### PR TITLE
refactor: consolidate accounting amount formatting (#1308)

### DIFF
--- a/plans/refactor-accounting-amount-format-1308.md
+++ b/plans/refactor-accounting-amount-format-1308.md
@@ -1,0 +1,43 @@
+# Accounting Amount Formatting (#1308)
+
+## Problem and scope reduction
+
+The original issue called out:
+1. `accounting/Preview.vue` re-implementing 2-decimal `toLocaleString` despite `accounting/currencies.ts` already exporting a `formatAmount`.
+2. `spreadsheet/engine/formatter.ts` having multiple `toFixed` sites that don't share dispatch with `currencies.ts`.
+
+After audit:
+
+### Preview.vue: real duplication, narrow fix
+
+`Preview.vue` has its own `formatAmount(value)` (currency-agnostic, hardcoded 2 decimals) because the JSON envelopes it renders (`profitLoss.netIncome`, `balanceSheet.sections[i].total`) don't carry currency codes on the data path. The shared `currencies.ts.formatAmount(value, currency, locale?)` requires currency, so it can't be a drop-in.
+
+**Fix**: add `formatAmountNumeric(value, decimals = 2)` to `currencies.ts` — a currency-agnostic numeric formatter for exactly this case. Preview migrates to it. Reduces the name collision (two `formatAmount`s) and centralises the format spec.
+
+### The JPY-shows-decimals concern is bigger than this PR
+
+The original issue flagged that Preview shows `100.00` even for JPY (where 0 decimals is correct). That fix needs the currency code to reach Preview's data path — a JSON envelope shape change, possibly threading book context through the dispatch. That's structural, not formatting; out of scope here. Tracked separately if/when prioritised.
+
+### Spreadsheet formatter: already centralised
+
+`spreadsheet/engine/formatter.ts` has 4 `toFixed` calls inside a switch over format kinds (`number` / `percent` / `accounting`). They're already in one file under one dispatcher. Extracting an intermediate `formatNumeric({ kind, value, decimals, locale })` would be cosmetic — same code, same control flow, one extra indirection. Skipped. Reopen if a third format kind shows up.
+
+### Out of scope
+
+- Currency-aware Preview rendering (data-path threading).
+- Spreadsheet formatter intermediate dispatcher.
+- Spotify plugin date/number formatting in `packages/` (separate package scope).
+
+## Approach
+
+1. Add `formatAmountNumeric(value, decimals = 2)` to `src/plugins/accounting/currencies.ts`. One line. Comment documents when to prefer this vs. the currency-aware `formatAmount`.
+2. Migrate `Preview.vue` — import + replace both call sites + drop the local function.
+3. Tests at `test/plugins/accounting/test_currencies.ts` — covers `formatAmountNumeric` (default 2 decimals, custom 0, negative, zero) and asserts the existing `formatAmount` honours `fractionDigitsFor(JPY) === 0`.
+4. Catalog NOT updated — `accounting/currencies.ts` is plugin-local, the catalog's scope is cross-cutting helpers only.
+
+## Acceptance
+
+- `formatAmountNumeric` exported from `currencies.ts` with tests.
+- `Preview.vue` uses it, no local `formatAmount` function.
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
+- Preview rendering unchanged for the same input (the new helper has identical behaviour to the old inline form).

--- a/src/plugins/accounting/Preview.vue
+++ b/src/plugins/accounting/Preview.vue
@@ -12,6 +12,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { formatAmountNumeric } from "./currencies";
 
 const { t } = useI18n();
 
@@ -32,10 +33,6 @@ interface EntriesLike {
 }
 interface BookLike {
   book?: { id?: string; name?: string };
-}
-
-function formatAmount(value: number): string {
-  return value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 // Each summarise* helper returns null when its branch doesn't apply,
@@ -65,7 +62,7 @@ function summarisePl(json: Record<string, unknown>): string | null {
   return t("pluginAccounting.preview.pl", {
     from: profitLoss.from ?? "?",
     to: profitLoss.to ?? "?",
-    net: formatAmount(profitLoss.netIncome),
+    net: formatAmountNumeric(profitLoss.netIncome),
   });
 }
 
@@ -75,7 +72,7 @@ function summariseBs(json: Record<string, unknown>): string | null {
   const assets = balanceSheet.sections.find((section) => section.type === "asset");
   return t("pluginAccounting.preview.bs", {
     date: balanceSheet.asOf,
-    assets: assets ? formatAmount(assets.total ?? 0) : "?",
+    assets: assets ? formatAmountNumeric(assets.total ?? 0) : "?",
   });
 }
 

--- a/src/plugins/accounting/currencies.ts
+++ b/src/plugins/accounting/currencies.ts
@@ -67,7 +67,11 @@ export function formatAmount(value: number, currency: string, locale?: string): 
  *  don't carry the currency code on the data path (compact preview
  *  envelopes etc.). Use `formatAmount(value, currency)` whenever the
  *  currency IS available — the currency-aware path picks the right
- *  fraction-digit count automatically (JPY = 0, USD = 2). */
-export function formatAmountNumeric(value: number, decimals = 2): string {
-  return value.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+ *  fraction-digit count automatically (JPY = 0, USD = 2).
+ *
+ *  `locale` mirrors `formatAmount`'s signature: pass an explicit BCP-47
+ *  locale (`"en-US"`, `"ja-JP"`, …) when the caller knows the desired
+ *  grouping / digit-shape; omit to fall back to the runtime default. */
+export function formatAmountNumeric(value: number, decimals = 2, locale?: string): string {
+  return value.toLocaleString(locale, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
 }

--- a/src/plugins/accounting/currencies.ts
+++ b/src/plugins/accounting/currencies.ts
@@ -62,3 +62,12 @@ export function formatAmount(value: number, currency: string, locale?: string): 
     return value.toFixed(fractionDigitsFor(currency));
   }
 }
+
+/** Currency-agnostic amount formatter — "1,130.00" — for places that
+ *  don't carry the currency code on the data path (compact preview
+ *  envelopes etc.). Use `formatAmount(value, currency)` whenever the
+ *  currency IS available — the currency-aware path picks the right
+ *  fraction-digit count automatically (JPY = 0, USD = 2). */
+export function formatAmountNumeric(value: number, decimals = 2): string {
+  return value.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+}

--- a/test/plugins/accounting/test_currencies.ts
+++ b/test/plugins/accounting/test_currencies.ts
@@ -2,36 +2,40 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { formatAmountNumeric, formatAmount, fractionDigitsFor } from "../../../src/plugins/accounting/currencies.js";
 
+// Pin locale on every assertion so host-default locale variations
+// (CI vs. dev machine, de-DE vs. en-US) cannot turn into flakes.
+// `.toLocaleString` honours the locale arg even when the host default
+// is something else — that's exactly the contract this suite verifies.
+
 describe("formatAmountNumeric", () => {
   it("renders 2 decimals by default", () => {
-    const out = formatAmountNumeric(1234.5);
-    assert.match(out, /[.,]50/);
+    assert.equal(formatAmountNumeric(1234.5, 2, "en-US"), "1,234.50");
   });
 
   it("accepts 0 decimals for integer-only currencies", () => {
-    const out = formatAmountNumeric(1234, 0);
-    // Locale-dependent grouping (`1,234` / `1.234` / `1234`); just
-    // assert the fractional part is absent.
-    assert.equal(out.endsWith(".00"), false);
-    assert.equal(/\.\d/.test(out), false);
+    // de-DE uses `.` as thousands separator — a regex like `/\.\d/`
+    // would false-match here even though there is no fractional part.
+    // Pin both locales and compare exact output instead. (Codex review
+    // on #1318.)
+    assert.equal(formatAmountNumeric(1234, 0, "en-US"), "1,234");
+    assert.equal(formatAmountNumeric(1234, 0, "de-DE"), "1.234");
   });
 
-  it("handles negative amounts", () => {
-    const out = formatAmountNumeric(-99.99);
-    assert.match(out, /99/);
+  it("preserves the minus sign on negative amounts", () => {
+    // Asserting `/99/` alone would silently pass if the sign were
+    // dropped (Codex review on #1318) — pin a locale + check the
+    // full string so a sign regression fails the test.
+    assert.equal(formatAmountNumeric(-99.99, 2, "en-US"), "-99.99");
   });
 
   it("handles zero", () => {
-    const out = formatAmountNumeric(0);
-    assert.match(out, /0/);
-    assert.match(out, /00/);
+    assert.equal(formatAmountNumeric(0, 2, "en-US"), "0.00");
   });
 
   it("respects an explicit locale when provided", () => {
     // en-US uses comma as the thousands separator + period as the
-    // decimal mark, regardless of the host's default locale, so we
-    // can pin the expected output. (de-DE swaps them — different
-    // host defaults must NOT bleed into a caller-pinned locale.)
+    // decimal mark; de-DE swaps them. The host's default locale must
+    // NOT bleed into a caller-pinned locale.
     assert.equal(formatAmountNumeric(1234.5, 2, "en-US"), "1,234.50");
     assert.equal(formatAmountNumeric(1234.5, 2, "de-DE"), "1.234,50");
   });
@@ -39,17 +43,20 @@ describe("formatAmountNumeric", () => {
 
 describe("formatAmount currency awareness", () => {
   it("returns a non-empty string for valid currency", () => {
-    const out = formatAmount(1130, "USD");
+    const out = formatAmount(1130, "USD", "en-US");
     assert.equal(typeof out, "string");
     assert.ok(out.length > 0);
   });
 
-  it("respects fractionDigitsFor on the fallback path", () => {
-    // JPY → 0 decimals. Even on the fallback path (e.g. unknown
-    // currency code), the helper should return whole numbers for JPY.
-    const jpy = formatAmount(1130, "JPY");
-    assert.match(jpy, /1[,.]?130|1130/);
-    assert.equal(jpy.includes(".00"), false);
+  it("renders JPY with 0 decimals on the happy path", () => {
+    // The previous version of this test claimed it exercised the
+    // `catch` fallback inside formatAmount, but JPY is a valid Intl
+    // currency code so the try path always succeeds (Codex review
+    // on #1318). Renamed + pinned to en-US so the assertion is
+    // robust regardless of host locale. Fallback-path coverage is
+    // intentionally out of scope: the catch arm is defensive code
+    // for partial-Intl runtimes that this codebase never targets.
+    assert.equal(formatAmount(1130, "JPY", "en-US"), "¥1,130");
   });
 
   it("fractionDigitsFor returns 0 for JPY, 2 for USD", () => {

--- a/test/plugins/accounting/test_currencies.ts
+++ b/test/plugins/accounting/test_currencies.ts
@@ -26,6 +26,15 @@ describe("formatAmountNumeric", () => {
     assert.match(out, /0/);
     assert.match(out, /00/);
   });
+
+  it("respects an explicit locale when provided", () => {
+    // en-US uses comma as the thousands separator + period as the
+    // decimal mark, regardless of the host's default locale, so we
+    // can pin the expected output. (de-DE swaps them — different
+    // host defaults must NOT bleed into a caller-pinned locale.)
+    assert.equal(formatAmountNumeric(1234.5, 2, "en-US"), "1,234.50");
+    assert.equal(formatAmountNumeric(1234.5, 2, "de-DE"), "1.234,50");
+  });
 });
 
 describe("formatAmount currency awareness", () => {

--- a/test/plugins/accounting/test_currencies.ts
+++ b/test/plugins/accounting/test_currencies.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatAmountNumeric, formatAmount, fractionDigitsFor } from "../../../src/plugins/accounting/currencies.js";
+
+describe("formatAmountNumeric", () => {
+  it("renders 2 decimals by default", () => {
+    const out = formatAmountNumeric(1234.5);
+    assert.match(out, /[.,]50/);
+  });
+
+  it("accepts 0 decimals for integer-only currencies", () => {
+    const out = formatAmountNumeric(1234, 0);
+    // Locale-dependent grouping (`1,234` / `1.234` / `1234`); just
+    // assert the fractional part is absent.
+    assert.equal(out.endsWith(".00"), false);
+    assert.equal(/\.\d/.test(out), false);
+  });
+
+  it("handles negative amounts", () => {
+    const out = formatAmountNumeric(-99.99);
+    assert.match(out, /99/);
+  });
+
+  it("handles zero", () => {
+    const out = formatAmountNumeric(0);
+    assert.match(out, /0/);
+    assert.match(out, /00/);
+  });
+});
+
+describe("formatAmount currency awareness", () => {
+  it("returns a non-empty string for valid currency", () => {
+    const out = formatAmount(1130, "USD");
+    assert.equal(typeof out, "string");
+    assert.ok(out.length > 0);
+  });
+
+  it("respects fractionDigitsFor on the fallback path", () => {
+    // JPY → 0 decimals. Even on the fallback path (e.g. unknown
+    // currency code), the helper should return whole numbers for JPY.
+    const jpy = formatAmount(1130, "JPY");
+    assert.match(jpy, /1[,.]?130|1130/);
+    assert.equal(jpy.includes(".00"), false);
+  });
+
+  it("fractionDigitsFor returns 0 for JPY, 2 for USD", () => {
+    assert.equal(fractionDigitsFor("JPY"), 0);
+    assert.equal(fractionDigitsFor("USD"), 2);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `formatAmountNumeric(value, decimals = 2)` to `src/plugins/accounting/currencies.ts` — a currency-agnostic numeric formatter sibling to the existing currency-aware `formatAmount`.
- Migrate `accounting/Preview.vue` to use it; drop the local copy.
- Tests at `test/plugins/accounting/test_currencies.ts`.
- Catalog NOT updated — `currencies.ts` is plugin-local; the catalog only covers cross-cutting helpers.

Closes #1308. Fifth follow-up to #1304.

## Items to Confirm / Review

- **Scope reduction.** The issue called out two refactors:
  1. **Preview.vue → currencies.ts** — done here, narrow fix.
  2. **Spreadsheet formatter intermediate dispatcher** — **skipped.** The 4 `toFixed` calls in `spreadsheet/engine/formatter.ts` live inside one switch under one dispatcher already. Extracting an intermediate `formatNumeric({ kind, value, decimals })` would be cosmetic. Please flag if you'd like the dispatcher extraction anyway.
- **JPY-shows-decimals concern.** The original issue mentioned that Preview shows `100.00` even for JPY (where 0 decimals is correct). Fixing that needs the currency code to reach Preview's data path — a JSON envelope shape change, possibly threading book context through the dispatch. That's structural, not a formatter swap. Out of scope here; happy to open a follow-up if it matters.
- **Two `formatAmount`s before this PR**. The shared one (`currencies.ts`, currency-aware) and the local one (`Preview.vue`, currency-agnostic) had the same name with different signatures. The new helper is named differently to make the intent explicit.

## User Prompt

> issueにして１つ１つ進めたい / 別でwikiを進めるからそれと重複しない部分をすすめて / mergeして、どんどんすすめて

## Implementation approach

1. `currencies.ts` — add a 1-line `formatAmountNumeric(value, decimals = 2)` with a doc-comment that points callers at the currency-aware path when currency IS available.
2. `Preview.vue` — `import { formatAmountNumeric } from "./currencies"`, drop the local `formatAmount` function, rename both call sites (2 hits).
3. Tests cover: default 2 decimals, custom 0 decimals, negative, zero. Plus a couple of assertions on the existing `formatAmount` to lock in the JPY-no-decimals fallback behaviour while we're in the file.
4. Plan committed at `plans/refactor-accounting-amount-format-1308.md`.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (fixed one `no-constant-binary-expression` in a test assertion)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — new `formatAmountNumeric` + `formatAmount currency awareness` suites pass; existing accounting tests unaffected
- [ ] Visual: trigger a `getReport` action with a `profitLoss` envelope; verify the compact preview shows the net income with 2 decimals exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate accounting amount formatting by introducing a shared numeric formatter and migrating the accounting preview to use it.

New Features:
- Add a currency-agnostic numeric amount formatter helper to the accounting currencies plugin.

Enhancements:
- Refactor the accounting preview component to use the shared numeric formatter instead of a local implementation.
- Document the refactor plan for accounting amount formatting in a dedicated plan file.

Tests:
- Add unit tests for the new numeric formatter and for existing currency-aware amount formatting behavior.