### PR TITLE
fix(wiki): score-based fuzzy resolve to stop iteration-order miss-matches (#1194)

### DIFF
--- a/e2e-live/tests/wiki-nav.spec.ts
+++ b/e2e-live/tests/wiki-nav.spec.ts
@@ -81,20 +81,19 @@ test.describe("wiki navigation (real workspace)", () => {
     //     and the fuzzy fallback is what makes the file findable
     //     without depending on a seeded data/wiki/index.md row)
     //
-    // Slug shape — the trailing ASCII tail must (1) survive
-    // wikiSlugify so the fuzzy step has *something* to substring-
-    // match against, and (2) NOT appear inside the sibling source
-    // page's filename, otherwise the fuzzy `key.includes(slug)`
-    // loop happily returns whichever matching key it iterates first
-    // (readdir order). The first run of this spec hit exactly that:
-    // both `日本語タイトル-${project}-${nonce}` and `e2e-live-l15-source-${project}-${nonce}`
-    // collapse under wikiSlugify to a string ending in
-    // `-${project}-${nonce}`, the source key contains that
-    // substring too, and the target navigation rendered the source
-    // page instead of the target. Using a target-unique
-    // `nonascii-target-${nonce}` token keeps the fuzzy match
-    // pointed at the right file. The shared `nonce` still drives
-    // cleanup correlation across both pages.
+    // Slug shape — the trailing ASCII tail must survive wikiSlugify
+    // so the fuzzy step has *something* to substring-match against.
+    // The original first run of this spec also hit a server-side bug
+    // (#1194): when the slug + a sibling page filename shared a
+    // suffix, the resolver's fuzzy `key.includes(slug)` loop returned
+    // whichever matching key it iterated first (readdir order) — i.e.
+    // the source page got rendered instead of the target. That bug
+    // is fixed (`pickFuzzyMatch` now scores by length-ratio and
+    // returns null on a tie), so the `nonascii-target` token is no
+    // longer load-bearing for correctness. It stays as a redundancy
+    // belt: the target slug is still uniquely identifiable and the
+    // spec doesn't depend on the implementation's tie-breaker. The
+    // shared `nonce` drives cleanup correlation across both pages.
     const projectSlug = testInfo.project.name;
     const nonce = `${Date.now()}-${randomUUID().slice(0, 6)}`;
     const targetSlug = `日本語タイトル-nonascii-target-${projectSlug}-${nonce}`;

--- a/plans/fix-wiki-resolve-fuzzy-1194.md
+++ b/plans/fix-wiki-resolve-fuzzy-1194.md
@@ -1,0 +1,121 @@
+# fix(wiki): resolvePagePath fuzzy 分岐の誤マッチを塞ぐ (#1194)
+
+## 問題
+
+`server/api/routes/wiki.ts:228 resolvePagePath()` の fuzzy fallback は、
+`slug.includes(key) || key.includes(slug)` で当たった **最初の候補** を
+iteration 順 (=実質的に readdir 順) で返す。 これにより:
+
+- 非 ASCII slug を `wikiSlugify()` で空に近い文字列に削ぎ落とした結果、
+  別ページのファイル名と部分一致する → 全く違うページが silent に返る
+- ファイル一覧の並びが変わるだけで挙動が変わる reproducible でない
+  インシデント源
+
+PR #1179 の L-15 spec は spec 側で「ユニークトークンを入れて衝突回避」
+という回避コメントを残しているが、 これは server 側のバグを spec で
+かわしているだけで根本対応ではない。
+
+## 採用方針: (d) + (c) + (b) のハイブリッド
+
+issue 本文の 4 案のうち単一を取らず、 三層の防衛で締める:
+
+1. **(d) min-length gate** — `slug.length` が閾値未満なら fuzzy 自体を
+   skip。 CJK が全部剥がれた残骸 (`-chromium-{nonce}` のような) は
+   "意味ある一致" にならないので scoring すら走らせない。
+
+2. **(c) score-based pick** — `includes` で当たった全候補を `min/max`
+   ratio (= 0..1, 1 に近いほど長さが近い ≒ 強い一致) で score 付け、
+   最高 score を 1 件選ぶ。 iteration 順依存を排除。
+
+3. **(b) tie → ambiguous → null** — 最高 score が複数候補で並んだら
+   silent に「先勝ち」せず、 `null` を返して `index.md` の title-match
+   fallback に委ねる (あるいは 404)。
+
+## 実装スケッチ
+
+```ts
+const MIN_FUZZY_SLUG_LEN = 6;  // 経験則: CJK 剥離後の残骸の典型サイズ
+
+async function resolvePagePath(pageName: string): Promise<string | null> {
+  // ... existing exact match path (unchanged) ...
+
+  if (slug.length >= MIN_FUZZY_SLUG_LEN) {
+    type Candidate = { file: string; score: number };
+    const matches: Candidate[] = [];
+    for (const [key, file] of slugs) {
+      if (slug.includes(key) || key.includes(slug)) {
+        const shorter = Math.min(slug.length, key.length);
+        const longer = Math.max(slug.length, key.length);
+        matches.push({ file, score: shorter / longer });
+      }
+    }
+    if (matches.length > 0) {
+      matches.sort((left, right) => right.score - left.score);
+      const [top, runner] = matches;
+      if (matches.length === 1 || top.score > (runner?.score ?? 0)) {
+        return path.join(dir, top.file);
+      }
+      // ties → fall through to index.md title-match (ambiguous)
+    }
+  }
+
+  // existing index.md title-match fallback (unchanged)
+}
+```
+
+`MIN_FUZZY_SLUG_LEN = 6` の根拠: 短すぎる slug (空 / 1–5 文字) は
+意味ある page name の slugify 結果には足りない (実例で出ている
+`-chromium-{nonce}` の "純 noise" 部は数文字)。 5 文字以下で意味ある
+英数 slug を持つ wiki ページは稀。 必要なら後で実測で調整。
+
+## テスト
+
+新規 `test/api/routes/wiki/test_resolvePagePath.ts` を追加し以下を pin:
+
+1. **正常 fuzzy** — slug `bar` が key `foobar` に含まれる → 唯一の
+   候補なら return
+2. **短すぎ slug は skip** — slug が 5 文字以下なら fuzzy 全 skip
+   (title-match だけ動く)
+3. **tie → null** — 2 候補が同 score (= 同 length 関係) で並ぶ
+   → null (caller の title-match に委譲)
+4. **異なる length は決定的** — 短い key を持つ候補が勝つ
+   (`bar` slug → key `bars` (3/4) > key `barfoo-extra` (3/12))
+5. **exact match 優先** — fuzzy より先に handled、 score 経路を
+   通らない (回帰防止)
+
+既存の `e2e-live/tests/wiki-nav.spec.ts` の L-15 の「ユニークトークン
+入れて回避」コメントから、 server 側で塞いだ旨に書き換える
+(コードは変更不要、 コメントのみ更新)。
+
+## 影響範囲
+
+- 短い英数 slug を fuzzy で誤って当てていた既存 navigation が
+  500 → null (= 404) に変わる可能性。 ただしそういう短 slug は
+  実例で意味ある wiki page ではない (空 / 数文字 noise) ので
+  実害は無い見込み。
+- スコア最良が単独でない (tie) ケースは silent ヒット → 404 化。
+  少なくとも誤ページを開くよりは正しい挙動。
+
+## 影響なし
+
+- 既存の exact match 経路 (line 235-237) は touch せず、
+  fuzzy 分岐内のみ書き換え。
+- `index.md` title-match fallback (line 248-257) も touch せず。
+- 非 ASCII slug の通常解決経路 (= title-match で当てる) は変化なし。
+
+## 採用しなかった他案 (issue 本文より)
+
+- **(a) fuzzy 撤廃**: 既存の英数 slug 誤字許容 ("foo-bra" → "foo-bar"
+  みたいなライト fuzzy) を失う。 採用案は (c) で score の高い一致を
+  優先するので、 「ほぼ完全一致」 は引き続きヒットする。
+- **(c) 単独**: 短い slug の noise マッチを許してしまう。 (d) と
+  併用して 2 重防衛にすべき。
+- **(b) 単独**: 短い slug ですべて 「ambiguous → 404」 になりかねない。
+  (d) でガードを先に立てる方が UX 良。
+
+## 完了基準
+
+- [ ] `resolvePagePath` 内の fuzzy 分岐が新ロジックに置換
+- [ ] `test_resolvePagePath.ts` の 5 ケース pass
+- [ ] L-15 spec のコメント整理 (ユニークトークン部はそのまま残しても OK、 「server 側で塞いだので不要だがフレーキー対策で残す」 と意味付け)
+- [ ] typecheck / lint / build / `yarn test` clean

--- a/plans/fix-wiki-resolve-fuzzy-1194.md
+++ b/plans/fix-wiki-resolve-fuzzy-1194.md
@@ -74,7 +74,7 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
 
 1. **正常 fuzzy** — slug `bar` が key `foobar` に含まれる → 唯一の
    候補なら return
-2. **短すぎ slug は skip** — slug が 5 文字以下なら fuzzy 全 skip
+2. **短すぎる slug は skip** — slug が 5 文字以下なら fuzzy 全 skip
    (title-match だけ動く)
 3. **tie → null** — 2 候補が同 score (= 同 length 関係) で並ぶ
    → null (caller の title-match に委譲)
@@ -83,7 +83,7 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
 5. **exact match 優先** — fuzzy より先に handled、 score 経路を
    通らない (回帰防止)
 
-既存の `e2e-live/tests/wiki-nav.spec.ts` の L-15 の「ユニークトークン
+既存の `e2e-live/tests/wiki-nav.spec.ts` の L-15 の「ユニークトークンを
 入れて回避」コメントから、 server 側で塞いだ旨に書き換える
 (コードは変更不要、 コメントのみ更新)。
 

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -52,6 +52,15 @@ export { findBrokenLinksInPage, findMissingFiles, findOrphanPages, findTagDrift,
 // renderer fix). `parseWikiLink` strips the display half so the
 // lookup uses just the target — same parser the renderer + lint
 // agree on, which is the whole point of the #1297 refactor.
+// Below this length the fuzzy `includes` step skips altogether.
+// CJK / emoji-only / very-short page names get slugified down to a
+// short noise tail (e.g. "日本語タイトル-chromium-{nonce}" →
+// "-chromium-{nonce}"), and that noise will partial-match almost
+// any page that happens to share the suffix. Skipping fuzzy for
+// these slugs avoids silent miss-resolves; the index.md title-match
+// fallback below still handles the legitimate non-ASCII case (#1194).
+const MIN_FUZZY_SLUG_LEN = 6;
+
 async function resolvePagePath(pageName: string): Promise<string | null> {
   const dir = pagesDir();
   const { slugs } = await getPageIndex(dir);
@@ -64,13 +73,8 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
     const exact = slugs.get(slug);
     if (exact) return path.join(dir, exact);
 
-    // Fuzzy: same `includes` semantics as the old sync path — iterate
-    // the index's keys, no filesystem access.
-    for (const [key, file] of slugs) {
-      if (slug.includes(key) || key.includes(slug)) {
-        return path.join(dir, file);
-      }
-    }
+    const fuzzy = pickFuzzyMatch(slug, slugs);
+    if (fuzzy) return path.join(dir, fuzzy);
   }
 
   // Non-ASCII page names (e.g. Japanese [[wiki links]]) produce empty
@@ -85,6 +89,39 @@ async function resolvePagePath(pageName: string): Promise<string | null> {
   }
 
   return null;
+}
+
+// Walk every indexed slug looking for an `includes`-style match.
+// Returns the single best candidate, or null when the slug is too
+// short to be meaningful OR multiple candidates tie at the top score
+// (ambiguous — leave the resolution to the caller's title-match
+// fallback rather than silently picking iteration-order-first).
+//
+// Score = min(slug.length, key.length) / max(slug.length, key.length).
+// A perfect match where both strings are identical scores 1.0 (but
+// that path is taken by the exact `slugs.get` above, never reaches
+// here). Otherwise the highest-scoring partial match wins, and the
+// score is decoupled from Map iteration order (= filesystem readdir
+// order) so the resolver is deterministic across hosts.
+export function pickFuzzyMatch(slug: string, slugs: ReadonlyMap<string, string>): string | null {
+  if (slug.length < MIN_FUZZY_SLUG_LEN) return null;
+  let bestFile: string | null = null;
+  let bestScore = 0;
+  let bestIsTied = false;
+  for (const [key, file] of slugs) {
+    if (!slug.includes(key) && !key.includes(slug)) continue;
+    const shorter = Math.min(slug.length, key.length);
+    const longer = Math.max(slug.length, key.length);
+    const score = shorter / longer;
+    if (score > bestScore) {
+      bestScore = score;
+      bestFile = file;
+      bestIsTied = false;
+    } else if (score === bestScore) {
+      bestIsTied = true;
+    }
+  }
+  return bestIsTied ? null : bestFile;
 }
 
 router.get(API_ROUTES.wiki.base, async (req: Request, res: Response<WikiResponse | ErrorResponse>) => {

--- a/test/routes/test_wikiResolveFuzzy.ts
+++ b/test/routes/test_wikiResolveFuzzy.ts
@@ -1,0 +1,94 @@
+// Unit tests for the score-based fuzzy match used by
+// `resolvePagePath` in `server/api/routes/wiki.ts` (#1194).
+//
+// Pins three properties of the new resolver:
+//
+//   1. Slugs shorter than `MIN_FUZZY_SLUG_LEN` (6 chars) skip fuzzy
+//      altogether — protects against the CJK-stripped noise tail
+//      that originally motivated the issue.
+//   2. The candidate whose key is closest in length (= highest
+//      `min/max` score) wins. Iteration order does not.
+//   3. Ties at the top score return null — the caller falls back to
+//      its index.md title-match path rather than silently picking
+//      whichever Map entry came first.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { pickFuzzyMatch } from "../../server/api/routes/wiki.js";
+
+describe("pickFuzzyMatch — wiki resolvePagePath fuzzy fallback (#1194)", () => {
+  it("returns the unique candidate when only one slug fuzzy-matches", () => {
+    const slugs = new Map([
+      ["foobar", "foobar.md"],
+      ["unrelated", "unrelated.md"],
+    ]);
+    // `bar` length 3 — under MIN_FUZZY_SLUG_LEN, so even a real
+    // match would skip. Use a longer slug that still triggers fuzzy.
+    assert.equal(pickFuzzyMatch("foobar-page", slugs), "foobar.md");
+  });
+
+  it("returns null when the slug is shorter than MIN_FUZZY_SLUG_LEN", () => {
+    const slugs = new Map([
+      ["foobar", "foobar.md"],
+      ["barbaz", "barbaz.md"],
+    ]);
+    // 3-char slug `bar` is `includes`-contained in both keys but
+    // semantically meaningless — skip fuzzy entirely.
+    assert.equal(pickFuzzyMatch("bar", slugs), null);
+    // Same for `bars` (4) and `barfo` (5) — all below the gate.
+    assert.equal(pickFuzzyMatch("bars", slugs), null);
+    assert.equal(pickFuzzyMatch("barfo", slugs), null);
+    // 6 chars passes the gate — `barbaz` is an exact hit which the
+    // resolver normally handles before fuzzy, but here we're driving
+    // the picker directly, so the score path returns it.
+    assert.equal(pickFuzzyMatch("barbaz", slugs), "barbaz.md");
+  });
+
+  it("picks the candidate whose key is closest in length to the slug", () => {
+    // slug = `chromium-test` (13 chars).
+    //  - key `chromium-test-page` (18) → score 13/18 ≈ 0.72
+    //  - key `chromium-test-extra-suffix-noise` (32) → score 13/32 ≈ 0.41
+    // The closer-length candidate must win regardless of map order.
+    const slugs = new Map([
+      ["chromium-test-extra-suffix-noise", "noisy.md"],
+      ["chromium-test-page", "close.md"],
+    ]);
+    assert.equal(pickFuzzyMatch("chromium-test", slugs), "close.md");
+  });
+
+  it("is order-independent (regression: original bug was iteration-first)", () => {
+    // Same inputs as above but the Map is constructed in the opposite
+    // order. The pre-fix code returned the FIRST inserted key that
+    // partial-matched; the fixed code picks the higher score either way.
+    const slugs = new Map([
+      ["chromium-test-page", "close.md"],
+      ["chromium-test-extra-suffix-noise", "noisy.md"],
+    ]);
+    assert.equal(pickFuzzyMatch("chromium-test", slugs), "close.md");
+  });
+
+  it("returns null on a tie at the top score (caller falls back to title-match)", () => {
+    // slug `target-page` length 11.
+    //  - key `target-page-foo` (15) → 11/15 ≈ 0.733
+    //  - key `bar-target-page` (15) → 11/15 ≈ 0.733
+    // Same score → ambiguous → null (better than silent wrong page).
+    const slugs = new Map([
+      ["target-page-foo", "left.md"],
+      ["bar-target-page", "right.md"],
+    ]);
+    assert.equal(pickFuzzyMatch("target-page", slugs), null);
+  });
+
+  it("returns null when no key fuzzy-matches", () => {
+    const slugs = new Map([
+      ["alpha", "alpha.md"],
+      ["beta", "beta.md"],
+    ]);
+    assert.equal(pickFuzzyMatch("gamma-delta", slugs), null);
+  });
+
+  it("handles an empty slugs index", () => {
+    assert.equal(pickFuzzyMatch("anything-long", new Map()), null);
+  });
+});


### PR DESCRIPTION
## Summary

- `server/api/routes/wiki.ts:resolvePagePath()` had a fuzzy `key.includes(slug) || slug.includes(key)` fallback that returned the FIRST matching Map entry (= readdir order). When a CJK-stripped slug like `-chromium-{nonce}` partial-matched a sibling page's filename, the resolver silently rendered the wrong page. Issue #1194 walks through the exact L-15 reproduction.
- New `pickFuzzyMatch()` helper applies three layered defences in one pass: **min-length gate (≥ 6)**, **length-ratio scoring**, **tie → null**. Iteration-order dependence is gone.
- 7 new unit tests in `test/routes/test_wikiResolveFuzzy.ts` pin every branch (gate / order-independence / closest-length / tie / no-match / empty index).
- The L-15 spec's `nonascii-target` token + accompanying comment are downgraded from "load-bearing workaround" to "redundancy belt" — the server-side bug it worked around is fixed.

## Items to Confirm / Review

- **`MIN_FUZZY_SLUG_LEN = 6` heuristic**: derived from the example noise tails (`-chromium-{nonce}` etc.) where the meaningful semantic content is gone after slugify. If a user has wiki pages whose slug is genuinely 3–5 chars (very rare in practice) those navigations would now miss → fall through to the title-match path. Flag if any real workspace would be affected.
- **Tie behaviour**: returns `null` and lets the caller's `index.md` title-match handle ambiguity. The alternative was 404. The chosen behaviour is gentler (gives the title-match a chance) but does mean a tied ambiguous slug shows the index-resolved page if one happens to match. Either way, no silent miss-resolve.
- **Score metric**: `min(slug, key) / max(slug, key)`. Simple, deterministic, doesn't need a tokenizer or unicode-aware comparator. Substring-position is ignored intentionally — `bar-foo` and `foo-bar` should score the same vs slug `foo`.
- **No e2e-live spec change for correctness** — only the explanatory comment is rewritten. The spec still constructs the same target/source slugs so it doubles as an integration test of the new resolver under real seeded data.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1194 これってどうなる？いろいろ更新したけど。
> dベースでcを取り入れたよいほうほうない？

## Implementation approach

Per the design discussion: the three options from the issue body (b / c / d) compose naturally — (d) is a cheap pre-gate, (c) does the actual deciding, (b) is the safety net. Helper extracted (`pickFuzzyMatch`) so the score logic is testable without spinning up a real wiki dir. See `plans/fix-wiki-resolve-fuzzy-1194.md` for the design rationale.

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn build` clean
- [x] `yarn test` — 7/7 new tests pass in `test_wikiResolveFuzzy.ts`
- [ ] CI green on the matrix
- [ ] Manual: open a wiki page with a CJK title and confirm the page still resolves via the index.md title-match fallback (= the legitimate non-ASCII case is not broken).
- [ ] L-15 e2e-live still passes in chromium (it'll now exercise the new resolver path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve wiki page resolution fuzzy matching to avoid iteration-order-dependent mis-resolves and make behaviour deterministic and safer for short or ambiguous slugs.

Bug Fixes:
- Prevent wiki fuzzy slug resolution from silently selecting the wrong page based on Map iteration / filesystem order when multiple filenames partially match a slug.

Enhancements:
- Introduce a score-based fuzzy matching helper with a minimum slug-length gate and tie-as-ambiguous behaviour to make wiki slug resolution deterministic and robust.
- Document the design and rationale for the updated wiki fuzzy resolution logic in a dedicated plan file.
- Clarify the L-15 wiki navigation e2e comment to reflect the server-side fix and the nonascii token’s role as a non-essential safeguard.

Tests:
- Add unit tests covering the new wiki fuzzy resolution helper, including short-slug gating, deterministic scoring, tie handling, and empty index cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wiki page resolution to use deterministic score-based matching instead of order-dependent selection, eliminating unpredictable behavior when multiple pages could match.
  * Pages with very short slugs now skip fuzzy matching to prevent incorrect resolution.
  * Tied fuzzy matches now safely defer to title-based matching instead of silently misrouting.

* **Tests**
  * Added test coverage for fuzzy page resolution logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1319)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->