### PR TITLE
fix: skip Content-Security-Policy on PDF responses (#1299)

### DIFF
--- a/plans/fix-files-pdf-csp-safari-1299.md
+++ b/plans/fix-files-pdf-csp-safari-1299.md
@@ -1,0 +1,47 @@
+# PDF preview fails in Safari/WebKit (#1299)
+
+## Problem (per issue)
+
+`/api/files/raw` applies `Content-Security-Policy: sandbox` to every response, including PDFs. WebKit's PDF renderer refuses to display sandbox-opaque PDFs and forces a download, so the Files preview iframe ends up blank on Safari. Chromium (PDFium) and Firefox (pdf.js) handle the same response fine, so the regression is Safari-only and was not caught when the sandbox CSP landed.
+
+The original comment claiming "PDFs still work because they don't rely on same-origin access to the parent" was Chromium-only reasoning.
+
+## Approach (issue's Option A)
+
+Drop `Content-Security-Policy: sandbox` for PDF responses only. Keep `X-Content-Type-Options: nosniff` so the response can't be re-interpreted as HTML.
+
+The PDF viewer's own sandbox provides script isolation for embedded AcroJS — the response-level CSP was never the layer enforcing PDF script safety. So removing it costs nothing on the threat model side, and fixes Safari.
+
+## Why not options B / C
+
+- **B (`sandbox allow-same-origin`)**: dilutes the sandbox semantics for SVG / HTML / future threat shapes if they ever land on the same response shape. Narrower carve-out is safer.
+- **C (PDF.js bundle)**: hundreds of KB of new client code and a new dependency to maintain.
+
+## Changes
+
+1. `server/api/routes/files.ts`:
+   - Add `RAW_SECURITY_HEADERS_PDF` constant (just `nosniff`, no CSP).
+   - Add `rawSecurityHeadersForMime(mime)` picker so the call site doesn't branch inline.
+   - Make `applyRawSecurityHeaders(res, mime)` MIME-aware.
+   - Update the threat-model comment block to reflect the carve-out and link to #1299.
+2. `test/routes/test_filesRoute.ts`:
+   - Existing `RAW_SECURITY_HEADERS` assertions stay (still pin the non-PDF case).
+   - New `describe` block for `RAW_SECURITY_HEADERS_PDF` (no CSP, has nosniff).
+   - New `describe` block for `rawSecurityHeadersForMime` covering PDF + SVG/HTML/image/text/video/audio + near-miss MIME hardening.
+
+## Out of scope
+
+- **E2E webkit PDF preview test.** The issue's test plan suggests adding one to the Playwright `webkit` project. The current webkit project only matches `ime-enter.spec.ts`; a meaningful preview test needs a PDF fixture, a not-mocked `/api/files/raw` route, and a way to assert "render, don't download". Worth doing but heavier than the fix. Punt to a follow-up if real-Safari verification surfaces residual issues.
+- **Manual verification on real Safari**. Requires user's machine; can't do from CI.
+
+## Test plan
+
+- [x] Unit tests pin `RAW_SECURITY_HEADERS_PDF` (no CSP, has nosniff) and `rawSecurityHeadersForMime` PDF / non-PDF dispatch.
+- [x] Existing `RAW_SECURITY_HEADERS` assertions still pass — the non-PDF path is unchanged.
+- [ ] Manual: open MulmoClaude in Safari → pick a PDF in Files → confirm the iframe renders inline instead of triggering a download.
+
+## Acceptance
+
+- `/api/files/raw?path=foo.pdf` returns `X-Content-Type-Options: nosniff` and **no** `Content-Security-Policy` header.
+- `/api/files/raw?path=foo.svg` (and every other MIME) still returns `Content-Security-Policy: sandbox` + `nosniff` — sandbox CSP defenses for SVG / HTML threats are unchanged.
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -305,9 +305,9 @@ export function parseRange(header: string, size: number): ByteRange | null {
   return { start, end };
 }
 
-// Security headers applied to every `/files/raw` response. Exported
-// so a regression test can pin the exact strings down — a silent
-// regression here reopens a real XSS surface (see plans/
+// Security headers applied to `/files/raw` responses. Exported so a
+// regression test can pin the exact strings down — a silent
+// regression here reopens a real XSS surface (see plans/done/
 // fix-files-raw-csp-sandbox.md for the full threat model).
 //
 // `sandbox` (no allow-flags) creates an opaque origin for the
@@ -315,8 +315,7 @@ export function parseRange(header: string, size: number): ByteRange | null {
 // gets loaded as a top-level document or inside an iframe, its
 // scripts can't access the localhost:3001 origin's cookies,
 // session storage, or hit the `/api/*` endpoints. Frames rendering
-// the response become sandboxed too — PDFs still work because
-// they don't rely on same-origin access to the parent.
+// the response become sandboxed too.
 //
 // `nosniff` stops Chrome / Firefox from re-guessing Content-Type
 // on files the server declared but the browser might want to
@@ -326,8 +325,27 @@ export const RAW_SECURITY_HEADERS: Readonly<Record<string, string>> = {
   "X-Content-Type-Options": "nosniff",
 };
 
-function applyRawSecurityHeaders(res: Response): void {
-  for (const [name, value] of Object.entries(RAW_SECURITY_HEADERS)) {
+// PDF responses skip `Content-Security-Policy: sandbox`. Issue
+// #1299: WebKit refuses to render `sandbox`-opaque PDFs and forces
+// a download, breaking the Files preview iframe on Safari. The
+// PDF viewer (PDFium on Chromium, the WebKit PDF renderer, pdf.js
+// on Firefox) runs embedded AcroJS inside its own sandbox; the
+// response-level CSP was never the layer enforcing PDF script
+// isolation. `nosniff` is kept so the response can't be
+// re-interpreted as HTML.
+export const RAW_SECURITY_HEADERS_PDF: Readonly<Record<string, string>> = {
+  "X-Content-Type-Options": "nosniff",
+};
+
+/** Pick the header set for a given MIME. PDF is the only special
+ *  case today — every other MIME (`image/*`, `text/*`,
+ *  `application/octet-stream`, …) keeps the sandbox CSP. */
+export function rawSecurityHeadersForMime(mime: string): Readonly<Record<string, string>> {
+  return mime === "application/pdf" ? RAW_SECURITY_HEADERS_PDF : RAW_SECURITY_HEADERS;
+}
+
+function applyRawSecurityHeaders(res: Response, mime: string): void {
+  for (const [name, value] of Object.entries(rawSecurityHeadersForMime(mime))) {
     res.setHeader(name, value);
   }
 }
@@ -863,11 +881,13 @@ router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQue
   const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
   res.setHeader("Accept-Ranges", "bytes");
   res.setHeader("Content-Type", mime);
-  // Sandbox the response so an `.svg` / `.html` / `.pdf` with
-  // embedded JavaScript can't escape into the localhost:3001
-  // origin via direct navigation or <iframe>. See
-  // plans/done/fix-files-raw-csp-sandbox.md for the threat model.
-  applyRawSecurityHeaders(res);
+  // Sandbox the response so an `.svg` / `.html` with embedded
+  // JavaScript can't escape into the localhost:3001 origin via
+  // direct navigation or <iframe>. PDFs get a narrower header set
+  // (no sandbox CSP) because Safari/WebKit refuses to render
+  // sandbox-opaque PDFs (#1299). See plans/done/
+  // fix-files-raw-csp-sandbox.md for the full threat model.
+  applyRawSecurityHeaders(res, mime);
 
   // Range support is required for `<video>` playback (Safari refuses
   // to play media without 206 responses) and for seek-past-buffered

--- a/test/routes/test_filesRoute.ts
+++ b/test/routes/test_filesRoute.ts
@@ -23,7 +23,14 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseRange, classify, isSensitivePath, RAW_SECURITY_HEADERS } from "../../server/api/routes/files.js";
+import {
+  parseRange,
+  classify,
+  isSensitivePath,
+  RAW_SECURITY_HEADERS,
+  RAW_SECURITY_HEADERS_PDF,
+  rawSecurityHeadersForMime,
+} from "../../server/api/routes/files.js";
 
 describe("parseRange — happy path", () => {
   it("parses a basic start-end range", () => {
@@ -247,6 +254,48 @@ describe("RAW_SECURITY_HEADERS", () => {
     // sandbox back up, this catches it early.
     assert.equal(RAW_SECURITY_HEADERS["Access-Control-Allow-Origin"], undefined);
     assert.equal(RAW_SECURITY_HEADERS["Cross-Origin-Resource-Policy"], undefined);
+  });
+});
+
+describe("RAW_SECURITY_HEADERS_PDF — Safari/WebKit carve-out (#1299)", () => {
+  // WebKit refuses to render `Content-Security-Policy: sandbox` PDFs
+  // and forces a download — the Files preview iframe ends up blank
+  // on Safari. The PDF viewer's own sandbox provides script
+  // isolation for AcroJS, so dropping the response CSP is safe.
+  // These tests pin the carve-out so a future "let's just apply the
+  // CSP to everything" refactor can't silently regress #1299.
+
+  it("does NOT set Content-Security-Policy on PDFs", () => {
+    assert.equal(RAW_SECURITY_HEADERS_PDF["Content-Security-Policy"], undefined);
+  });
+
+  it("still sets X-Content-Type-Options nosniff on PDFs", () => {
+    // Keeping `nosniff` prevents a PDF being re-interpreted as HTML
+    // even if a misbehaving server (or proxy) drops Content-Type.
+    assert.equal(RAW_SECURITY_HEADERS_PDF["X-Content-Type-Options"], "nosniff");
+  });
+});
+
+describe("rawSecurityHeadersForMime", () => {
+  it("returns the PDF-specific set for application/pdf", () => {
+    assert.equal(rawSecurityHeadersForMime("application/pdf"), RAW_SECURITY_HEADERS_PDF);
+  });
+
+  it("returns the default sandbox set for image/* / text/* / SVG / HTML", () => {
+    // SVG and HTML are the original threat shapes the sandbox CSP
+    // was added to defend (plans/done/fix-files-raw-csp-sandbox.md).
+    // Anything that isn't a PDF MUST stay on the default headers.
+    for (const mime of ["image/svg+xml", "text/html", "image/png", "text/plain", "application/octet-stream", "video/mp4", "audio/mpeg"]) {
+      assert.equal(rawSecurityHeadersForMime(mime), RAW_SECURITY_HEADERS, `expected sandbox CSP for ${mime}`);
+    }
+  });
+
+  it("does not match PDF on a near-miss MIME like application/x-pdf", () => {
+    // Strict `application/pdf` match — extension-implied / vendor-
+    // prefix MIMEs do NOT get the carve-out unless the canonical
+    // form is sent (the route's MIME_BY_EXT only emits the canonical
+    // form for `.pdf`, so this is mainly a hardening assertion).
+    assert.equal(rawSecurityHeadersForMime("application/x-pdf"), RAW_SECURITY_HEADERS);
   });
 });
 


### PR DESCRIPTION
## Summary

- Drop `Content-Security-Policy: sandbox` for `application/pdf` responses on `/api/files/raw`. Keep `X-Content-Type-Options: nosniff`.
- Every other MIME (SVG / HTML / image / text / video / audio / octet-stream) still gets the full sandbox CSP — those were the original threat shapes the header was added to defend.
- Unit tests pin both the carve-out (`RAW_SECURITY_HEADERS_PDF`) and the MIME dispatcher (`rawSecurityHeadersForMime`).

Closes #1299.

## Items to Confirm / Review

- **Threat-model intent is preserved.** SVG / HTML still get sandbox CSP — the response-level CSP carve-out applies only to PDFs. The PDF viewer (PDFium / WebKit / pdf.js) sandboxes embedded AcroJS itself, so the response-CSP layer was never enforcing PDF script isolation. Please flag if a different layer was actually relying on the PDF being sandboxed.
- **Near-miss MIME (`application/x-pdf`).** The match is strict — only canonical `application/pdf` gets the carve-out. The route's `MIME_BY_EXT` only emits the canonical form for `.pdf`, so this is mainly a hardening assertion. Pinned in a test.
- **No E2E webkit test in this PR.** The issue's test plan asks for a Playwright `webkit` PDF-preview test. Doing it properly needs a PDF fixture, the un-mocked `/api/files/raw` route, and a "render-not-download" assertion. Heavier than the fix itself. Happy to do a follow-up if real-Safari verification doesn't shake anything else loose.
- **Manual verification.** I can't drive Safari from CI — verify on the real machine after merge.

## User Prompt

> これの対策できる？ https://github.com/receptron/mulmoclaude/issues/1299

## Implementation approach

The issue body already had a thorough root-cause analysis and three fix options (A: PDF-only no-CSP / B: `sandbox allow-same-origin` / C: pdf.js bundle). Chose **Option A** per the issue's recommendation — narrowest carve-out, no new dependencies, no dilution of sandbox semantics for the SVG / HTML threat shapes.

1. `server/api/routes/files.ts`:
   - Add `RAW_SECURITY_HEADERS_PDF` (`{ "X-Content-Type-Options": "nosniff" }`).
   - Add `rawSecurityHeadersForMime(mime)` so the call site doesn't branch inline.
   - Make `applyRawSecurityHeaders(res, mime)` take a MIME argument.
   - Rewrite the threat-model comment to document the carve-out + link #1299.
2. `test/routes/test_filesRoute.ts`:
   - Existing `RAW_SECURITY_HEADERS` assertions stay — they pin the non-PDF case.
   - New `describe` block for `RAW_SECURITY_HEADERS_PDF`: no CSP, has nosniff.
   - New `describe` block for `rawSecurityHeadersForMime`: PDF dispatch, non-PDF dispatch (covers SVG / HTML / image / text / video / audio / octet-stream), near-miss MIME hardening (`application/x-pdf` stays on the default set).
3. `plans/fix-files-pdf-csp-safari-1299.md`: committed plan.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — new `RAW_SECURITY_HEADERS_PDF` (2 cases) + `rawSecurityHeadersForMime` (3 cases) suites pass; existing `RAW_SECURITY_HEADERS` (3 cases) pass unchanged
- [ ] Manual on Safari: open MulmoClaude, select a PDF in Files, confirm the iframe renders the PDF inline instead of triggering a download
- [ ] Manual on Chromium: same flow, confirm no regression (sandbox CSP for non-PDF responses unchanged → no impact on Chromium PDF rendering either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust file download security headers to exempt PDF responses from CSP sandboxing while preserving protections for other MIME types.

Bug Fixes:
- Resolve Safari/WebKit PDF preview failures by omitting the Content-Security-Policy sandbox header on application/pdf responses while retaining X-Content-Type-Options nosniff.
- Ensure non-PDF file responses continue to receive the sandbox CSP and nosniff headers to maintain existing XSS protections.

Documentation:
- Document the Safari-specific PDF CSP issue, chosen mitigation, and acceptance criteria in a new plan file.

Tests:
- Add unit coverage for the new PDF-specific security header set and MIME-based header selection logic, including strict matching and near-miss MIME hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF preview failures in Safari browsers by adjusting file response security settings.

* **Tests**
  * Added comprehensive test coverage for security headers when serving different file types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1324)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->