### PR TITLE
fix(bridges): add express-rate-limit to webhook endpoints (6 bridges)

### DIFF
--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -24,7 +24,8 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -18,7 +18,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "google-chat";
@@ -194,12 +194,13 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  // Explicit keyGenerator — uses Express's `req.ip` which honours
-  // the `app.set("trust proxy", ...)` block elsewhere in this file.
-  // Made explicit so a reviewer doesn't have to dig through default
-  // values to confirm the limiter is per-client rather than global
-  // (Codex review on #1326).
-  keyGenerator: (req) => req.ip ?? "unknown",
+  // Explicit keyGenerator routed through `ipKeyGenerator(...)` so
+  // IPv6 clients get folded to their /56 subnet (a raw `req.ip` key
+  // would let IPv6 rotation within a prefix evade the per-client
+  // limit). `req.ip` itself is trust-proxy-aware via the
+  // `app.set("trust proxy", ...)` block elsewhere in this file.
+  // (Codex reviews iter-1 + iter-2 on #1326.)
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "", 56),
 });
 
 function redactId(resourceId: string): string {

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -18,6 +18,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "google-chat";
@@ -181,20 +182,19 @@ async function verifyGoogleChatToken(authHeader: string | undefined): Promise<bo
 // ── Webhook server ──────────────────────────────────────────────
 
 const BODY_LIMIT = "1mb";
-const RATE_WINDOW_MS = 60_000;
-const MAX_REQUESTS_PER_WINDOW = 120;
-const requestCounts = new Map<string, { count: number; resetAt: number }>();
 
-function rateLimitCheck(clientIp: string): boolean {
-  const now = Date.now();
-  const entry = requestCounts.get(clientIp);
-  if (!entry || now >= entry.resetAt) {
-    requestCounts.set(clientIp, { count: 1, resetAt: now + RATE_WINDOW_MS });
-    return true;
-  }
-  entry.count += 1;
-  return entry.count <= MAX_REQUESTS_PER_WINDOW;
-}
+// `express-rate-limit` is the well-tested per-IP throttle that
+// CodeQL's `js/missing-rate-limiting` rule recognises. Defaults
+// match the conservative 120 req/min/IP cap the bridge has shipped
+// since the original custom Map-based limiter was added — Google's
+// platform sends well under this rate during normal use, so the
+// cap exists to bound a flood / accidentally-stuck retry loop.
+const webhookRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
 
 function redactId(resourceId: string): string {
   return resourceId.length > 6 ? `${resourceId.slice(0, 3)}***${resourceId.slice(-3)}` : "***";
@@ -227,13 +227,10 @@ function extractMessage(body: unknown): ParsedMessage | null {
   return { spaceName: space.name, senderName, text: msg.text };
 }
 
-app.post("/", async (req: Request, res: Response) => {
-  const clientIp = req.ip ?? "unknown";
-  if (!rateLimitCheck(clientIp)) {
-    res.status(429).json({ error: "Too Many Requests" });
-    return;
-  }
-
+// Webhook events. Rate-limited per-IP via `webhookRateLimit`; the
+// middleware writes the 429 response itself when the cap is hit so
+// the handler body only sees admitted requests.
+app.post("/", webhookRateLimit, async (req: Request, res: Response) => {
   // Verify the request is from Google Chat
   const authHeader = typeof req.headers.authorization === "string" ? req.headers.authorization : undefined;
   const verified = await verifyGoogleChatToken(authHeader);

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -194,6 +194,12 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  // Explicit keyGenerator — uses Express's `req.ip` which honours
+  // the `app.set("trust proxy", ...)` block elsewhere in this file.
+  // Made explicit so a reviewer doesn't have to dig through default
+  // values to confirm the limiter is per-client rather than global
+  // (Codex review on #1326).
+  keyGenerator: (req) => req.ip ?? "unknown",
 });
 
 function redactId(resourceId: string): string {

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -202,6 +202,20 @@ function redactId(resourceId: string): string {
 
 const app = express();
 app.disable("x-powered-by");
+
+// Honour an explicit `trust proxy` setting so `req.ip` (the
+// rate-limit key below) reflects the real client IP rather than the
+// load balancer's. Default `false` for safety; operators behind a
+// known LB should set BRIDGE_TRUST_PROXY=1 (or a number of hops, or
+// an Express preset like "loopback"). Without this every webhook
+// looks like it comes from one IP and the limiter degrades into a
+// global throttle (Codex review on #1326).
+const trustProxyEnv = process.env.BRIDGE_TRUST_PROXY;
+if (trustProxyEnv) {
+  const numeric = Number(trustProxyEnv);
+  app.set("trust proxy", Number.isInteger(numeric) && numeric >= 0 ? numeric : trustProxyEnv);
+}
+
 app.use(express.json({ limit: BODY_LIMIT }));
 
 function extractEventType(body: unknown): string {

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -24,7 +24,8 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "express": "^5.0.0"
+    "express": "^5.0.0",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -26,7 +26,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import { readFileSync } from "fs";
 import express, { type Request, type Response as ExpressResponse } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "line-works";
@@ -243,12 +243,13 @@ const callbackRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  // Explicit keyGenerator — uses Express's `req.ip` which honours
-  // the `app.set("trust proxy", ...)` block elsewhere in this file.
-  // Made explicit so a reviewer doesn't have to dig through default
-  // values to confirm the limiter is per-client rather than global
-  // (Codex review on #1326).
-  keyGenerator: (req) => req.ip ?? "unknown",
+  // Explicit keyGenerator routed through `ipKeyGenerator(...)` so
+  // IPv6 clients get folded to their /56 subnet (a raw `req.ip` key
+  // would let IPv6 rotation within a prefix evade the per-client
+  // limit). `req.ip` itself is trust-proxy-aware via the
+  // `app.set("trust proxy", ...)` block elsewhere in this file.
+  // (Codex reviews iter-1 + iter-2 on #1326.)
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "", 56),
 });
 
 app.get("/health", (__req, res) => {

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -243,6 +243,12 @@ const callbackRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  // Explicit keyGenerator — uses Express's `req.ip` which honours
+  // the `app.set("trust proxy", ...)` block elsewhere in this file.
+  // Made explicit so a reviewer doesn't have to dig through default
+  // values to confirm the limiter is per-client rather than global
+  // (Codex review on #1326).
+  keyGenerator: (req) => req.ip ?? "unknown",
 });
 
 app.get("/health", (__req, res) => {

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -26,6 +26,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import { readFileSync } from "fs";
 import express, { type Request, type Response as ExpressResponse } from "express";
+import rateLimit from "express-rate-limit";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "line-works";
@@ -219,11 +220,22 @@ const app = express();
 app.disable("x-powered-by");
 app.use(express.text({ type: "application/json", limit: "1mb" }));
 
+// Per-IP throttle on the callback. CodeQL's
+// `js/missing-rate-limiting` rule recognises `express-rate-limit`
+// specifically. 120 req/min/IP is well above LINE WORKS' normal
+// delivery rate; the cap bounds a flood / stuck retry loop.
+const callbackRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+
 app.get("/health", (__req, res) => {
   res.json({ status: "ok", transport: TRANSPORT_ID });
 });
 
-app.post("/callback", async (req: Request, res: ExpressResponse) => {
+app.post("/callback", callbackRateLimit, async (req: Request, res: ExpressResponse) => {
   const signature = typeof req.headers["x-works-signature"] === "string" ? req.headers["x-works-signature"] : "";
   const rawBody = typeof req.body === "string" ? req.body : "";
   if (!signature || !verifySignature(rawBody, signature)) {

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -218,6 +218,20 @@ function parseEvent(body: unknown): IncomingLineWorks | null {
 
 const app = express();
 app.disable("x-powered-by");
+
+// Honour an explicit `trust proxy` setting so `req.ip` (the
+// rate-limit key below) reflects the real client IP rather than the
+// load balancer's. Default `false` for safety; operators behind a
+// known LB should set BRIDGE_TRUST_PROXY=1 (or a number of hops, or
+// an Express preset like "loopback"). Without this every webhook
+// looks like it comes from one IP and the limiter degrades into a
+// global throttle (Codex review on #1326).
+const trustProxyEnv = process.env.BRIDGE_TRUST_PROXY;
+if (trustProxyEnv) {
+  const numeric = Number(trustProxyEnv);
+  app.set("trust proxy", Number.isInteger(numeric) && numeric >= 0 ? numeric : trustProxyEnv);
+}
+
 app.use(express.text({ type: "application/json", limit: "1mb" }));
 
 // Per-IP throttle on the callback. CodeQL's

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -24,7 +24,8 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -16,7 +16,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
 import { extractIncomingLineMessage, parseLineWebhookBody } from "./parse.js";
 
@@ -137,12 +137,13 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  // Explicit keyGenerator — uses Express's `req.ip` which honours
-  // the `app.set("trust proxy", ...)` block elsewhere in this file.
-  // Made explicit so a reviewer doesn't have to dig through default
-  // values to confirm the limiter is per-client rather than global
-  // (Codex review on #1326).
-  keyGenerator: (req) => req.ip ?? "unknown",
+  // Explicit keyGenerator routed through `ipKeyGenerator(...)` so
+  // IPv6 clients get folded to their /56 subnet (a raw `req.ip` key
+  // would let IPv6 rotation within a prefix evade the per-client
+  // limit). `req.ip` itself is trust-proxy-aware via the
+  // `app.set("trust proxy", ...)` block elsewhere in this file.
+  // (Codex reviews iter-1 + iter-2 on #1326.)
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "", 56),
 });
 
 app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -112,6 +112,20 @@ function verifySignature(body: string, signature: string): boolean {
 
 const app = express();
 app.disable("x-powered-by");
+
+// Honour an explicit `trust proxy` setting so `req.ip` (the
+// rate-limit key below) reflects the real client IP rather than the
+// load balancer's. Default `false` for safety; operators behind a
+// known LB should set BRIDGE_TRUST_PROXY=1 (or a number of hops, or
+// an Express preset like "loopback"). Without this every webhook
+// looks like it comes from one IP and the limiter degrades into a
+// global throttle (Codex review on #1326).
+const trustProxyEnv = process.env.BRIDGE_TRUST_PROXY;
+if (trustProxyEnv) {
+  const numeric = Number(trustProxyEnv);
+  app.set("trust proxy", Number.isInteger(numeric) && numeric >= 0 ? numeric : trustProxyEnv);
+}
+
 app.use(express.text({ type: "application/json" }));
 
 // Per-IP throttle on the webhook endpoint. CodeQL's

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -137,6 +137,12 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  // Explicit keyGenerator — uses Express's `req.ip` which honours
+  // the `app.set("trust proxy", ...)` block elsewhere in this file.
+  // Made explicit so a reviewer doesn't have to dig through default
+  // values to confirm the limiter is per-client rather than global
+  // (Codex review on #1326).
+  keyGenerator: (req) => req.ip ?? "unknown",
 });
 
 app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -16,6 +16,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
 import { extractIncomingLineMessage, parseLineWebhookBody } from "./parse.js";
 
@@ -113,7 +114,18 @@ const app = express();
 app.disable("x-powered-by");
 app.use(express.text({ type: "application/json" }));
 
-app.post("/webhook", async (req: Request, res: Response) => {
+// Per-IP throttle on the webhook endpoint. CodeQL's
+// `js/missing-rate-limiting` rule recognises `express-rate-limit`
+// specifically, and LINE's platform sends well under 120 req/min/IP
+// during normal use — the cap bounds a flood / stuck retry loop.
+const webhookRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+
+app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
   const signature = req.headers["x-line-signature"] as string;
   const bodyStr = req.body as string;
 

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -24,7 +24,8 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -14,7 +14,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "messenger";
@@ -91,14 +91,13 @@ const webhookRateLimit = rateLimit({
   // headers so the upstream platform can self-throttle.
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  // Explicit keyGenerator — uses Express's `req.ip` which honours
-  // the `app.set("trust proxy", ...)` block below. Made explicit
-  // here so a reviewer doesn't have to dig through default values
-  // to confirm the limiter is per-client rather than global
-  // (Codex review on #1326). `"unknown"` fallback only fires when
-  // Express couldn't determine an IP at all (e.g. socket closed
-  // mid-request), keeping the limit from silently disappearing.
-  keyGenerator: (req) => req.ip ?? "unknown",
+  // Explicit keyGenerator routed through `ipKeyGenerator(...)` so
+  // IPv6 clients get folded to their /56 subnet (a raw `req.ip` key
+  // would let IPv6 rotation within a prefix evade the per-client
+  // limit). `req.ip` itself is trust-proxy-aware via the
+  // `app.set("trust proxy", ...)` block below. (Codex reviews
+  // iter-1 + iter-2 on #1326.)
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "", 56),
 });
 
 const app = express();

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -14,6 +14,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "messenger";
@@ -76,20 +77,21 @@ function verifySignature(rawBody: string, signature: string): boolean {
 // ── Webhook server ──────────────────────────────────────────────
 
 const BODY_LIMIT = "1mb";
-const RATE_WINDOW_MS = 60_000;
-const MAX_REQUESTS_PER_WINDOW = 120;
-const requestCounts = new Map<string, { count: number; resetAt: number }>();
 
-function rateLimitCheck(clientIp: string): boolean {
-  const now = Date.now();
-  const entry = requestCounts.get(clientIp);
-  if (!entry || now >= entry.resetAt) {
-    requestCounts.set(clientIp, { count: 1, resetAt: now + RATE_WINDOW_MS });
-    return true;
-  }
-  entry.count += 1;
-  return entry.count <= MAX_REQUESTS_PER_WINDOW;
-}
+// `express-rate-limit` is the well-tested per-IP throttle that
+// CodeQL's `js/missing-rate-limiting` rule recognises. Defaults
+// match the conservative 120 req/min/IP cap the bridge has shipped
+// since the original custom Map-based limiter was added — Meta's
+// platform sends well under this rate during normal use, so the
+// cap exists to bound a flood / accidentally-stuck retry loop.
+const webhookRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  // Send the limit + remaining count in standard `RateLimit-*`
+  // headers so the upstream platform can self-throttle.
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
 
 const app = express();
 app.disable("x-powered-by");
@@ -121,14 +123,10 @@ async function handleWebhookBody(rawBody: string): Promise<void> {
   }
 }
 
-// Webhook events (POST)
-app.post("/webhook", async (req: Request, res: Response) => {
-  const clientIp = req.ip ?? "unknown";
-  if (!rateLimitCheck(clientIp)) {
-    res.status(429).send("Too Many Requests");
-    return;
-  }
-
+// Webhook events (POST). Rate-limited per-IP via `webhookRateLimit`
+// above; the middleware writes the 429 response itself when the cap
+// is hit so the handler body only sees admitted requests.
+app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
   const signature = typeof req.headers["x-hub-signature-256"] === "string" ? req.headers["x-hub-signature-256"] : "";
   const rawBody = typeof req.body === "string" ? req.body : "";
 

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -95,6 +95,20 @@ const webhookRateLimit = rateLimit({
 
 const app = express();
 app.disable("x-powered-by");
+
+// Honour an explicit `trust proxy` setting so `req.ip` (the
+// rate-limit key below) reflects the real client IP rather than the
+// load balancer's. Default `false` for safety; operators behind a
+// known LB should set BRIDGE_TRUST_PROXY=1 (or a number of hops, or
+// an Express preset like "loopback"). Without this every webhook
+// looks like it comes from one IP and the limiter degrades into a
+// global throttle (Codex review on #1326).
+const trustProxyEnv = process.env.BRIDGE_TRUST_PROXY;
+if (trustProxyEnv) {
+  const numeric = Number(trustProxyEnv);
+  app.set("trust proxy", Number.isInteger(numeric) && numeric >= 0 ? numeric : trustProxyEnv);
+}
+
 app.use(express.text({ type: "application/json", limit: BODY_LIMIT }));
 
 // Webhook verification (GET)

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -91,6 +91,14 @@ const webhookRateLimit = rateLimit({
   // headers so the upstream platform can self-throttle.
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  // Explicit keyGenerator — uses Express's `req.ip` which honours
+  // the `app.set("trust proxy", ...)` block below. Made explicit
+  // here so a reviewer doesn't have to dig through default values
+  // to confirm the limiter is per-client rather than global
+  // (Codex review on #1326). `"unknown"` fallback only fires when
+  // Express couldn't determine an IP at all (e.g. socket closed
+  // mid-request), keeping the limit from silently disappearing.
+  keyGenerator: (req) => req.ip ?? "unknown",
 });
 
 const app = express();
@@ -111,8 +119,12 @@ if (trustProxyEnv) {
 
 app.use(express.text({ type: "application/json", limit: BODY_LIMIT }));
 
-// Webhook verification (GET)
-app.get("/webhook", (req: Request, res: Response) => {
+// Webhook verification (GET). Rate-limited so a flood of bogus
+// `hub.challenge` probes can't hammer the bridge before the
+// `hub.verify_token` check rejects them. Matches the WhatsApp
+// bridge's GET-side throttling — same shared Meta protocol, same
+// abuse surface (Codex review on #1326).
+app.get("/webhook", webhookRateLimit, (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
   const challenge = req.query["hub.challenge"];

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -24,7 +24,8 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "express": "^5.0.0"
+    "express": "^5.0.0",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -18,6 +18,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response as ExpressResponse } from "express";
+import rateLimit from "express-rate-limit";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "viber";
@@ -146,11 +147,22 @@ app.disable("x-powered-by");
 // Parse as raw text so HMAC runs on the exact bytes Viber signed.
 app.use(express.text({ type: "application/json", limit: "1mb" }));
 
+// Per-IP throttle on the webhook. CodeQL's
+// `js/missing-rate-limiting` rule recognises `express-rate-limit`
+// specifically. 120 req/min/IP is well above Viber's normal
+// delivery rate; the cap bounds a flood / stuck retry loop.
+const webhookRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+
 app.get("/health", (__req, res) => {
   res.json({ status: "ok", transport: TRANSPORT_ID });
 });
 
-app.post("/viber", async (req: Request, res: ExpressResponse) => {
+app.post("/viber", webhookRateLimit, async (req: Request, res: ExpressResponse) => {
   const signature = typeof req.headers["x-viber-content-signature"] === "string" ? req.headers["x-viber-content-signature"] : "";
   const rawBody = typeof req.body === "string" ? req.body : "";
 

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -18,7 +18,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response as ExpressResponse } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "viber";
@@ -170,12 +170,13 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  // Explicit keyGenerator — uses Express's `req.ip` which honours
-  // the `app.set("trust proxy", ...)` block elsewhere in this file.
-  // Made explicit so a reviewer doesn't have to dig through default
-  // values to confirm the limiter is per-client rather than global
-  // (Codex review on #1326).
-  keyGenerator: (req) => req.ip ?? "unknown",
+  // Explicit keyGenerator routed through `ipKeyGenerator(...)` so
+  // IPv6 clients get folded to their /56 subnet (a raw `req.ip` key
+  // would let IPv6 rotation within a prefix evade the per-client
+  // limit). `req.ip` itself is trust-proxy-aware via the
+  // `app.set("trust proxy", ...)` block elsewhere in this file.
+  // (Codex reviews iter-1 + iter-2 on #1326.)
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "", 56),
 });
 
 app.get("/health", (__req, res) => {

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -170,6 +170,12 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  // Explicit keyGenerator — uses Express's `req.ip` which honours
+  // the `app.set("trust proxy", ...)` block elsewhere in this file.
+  // Made explicit so a reviewer doesn't have to dig through default
+  // values to confirm the limiter is per-client rather than global
+  // (Codex review on #1326).
+  keyGenerator: (req) => req.ip ?? "unknown",
 });
 
 app.get("/health", (__req, res) => {

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -144,6 +144,20 @@ function parseMessageEvent(body: unknown): IncomingViber | null {
 
 const app = express();
 app.disable("x-powered-by");
+
+// Honour an explicit `trust proxy` setting so `req.ip` (the
+// rate-limit key below) reflects the real client IP rather than the
+// load balancer's. Default `false` for safety; operators behind a
+// known LB should set BRIDGE_TRUST_PROXY=1 (or a number of hops, or
+// an Express preset like "loopback"). Without this every webhook
+// looks like it comes from one IP and the limiter degrades into a
+// global throttle (Codex review on #1326).
+const trustProxyEnv = process.env.BRIDGE_TRUST_PROXY;
+if (trustProxyEnv) {
+  const numeric = Number(trustProxyEnv);
+  app.set("trust proxy", Number.isInteger(numeric) && numeric >= 0 ? numeric : trustProxyEnv);
+}
+
 // Parse as raw text so HMAC runs on the exact bytes Viber signed.
 app.use(express.text({ type: "application/json", limit: "1mb" }));
 

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -24,7 +24,8 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -16,7 +16,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "whatsapp";
@@ -171,14 +171,16 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
-  // Explicit keyGenerator — uses Express's `req.ip` which honours
-  // the `app.set("trust proxy", ...)` block above. Made explicit
-  // here so a reviewer doesn't have to dig through default values
-  // to confirm the limiter is per-client rather than global
-  // (Codex review on #1326). `"unknown"` fallback only fires when
-  // Express couldn't determine an IP at all (e.g. socket closed
-  // mid-request), keeping the limit from silently disappearing.
-  keyGenerator: (req) => req.ip ?? "unknown",
+  // Explicit keyGenerator routed through `ipKeyGenerator(...)`. The
+  // raw `req.ip` reading isn't safe on its own — IPv6 clients can
+  // rotate addresses within a /56 prefix and evade per-client limits.
+  // `express-rate-limit`'s `ipKeyGenerator` normalises both IPv4
+  // and IPv6 (folding IPv6 to its /56 subnet by default), which is
+  // what `req.ip` alone misses. The `app.set("trust proxy", ...)`
+  // block above is what makes `req.ip` reflect the real client
+  // rather than the LB. Together: explicit + IPv6-safe + proxy-
+  // aware (Codex reviews iter-1 + iter-2 on #1326).
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? "", 56),
 });
 
 // Webhook verification (GET)

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -142,6 +142,20 @@ function extractTextMessages(body: unknown): WhatsAppTextMessage[] {
 
 const app = express();
 app.disable("x-powered-by");
+
+// Honour an explicit `trust proxy` setting so `req.ip` (the
+// rate-limit key below) reflects the real client IP rather than the
+// load balancer's. Default `false` for safety; operators behind a
+// known LB should set BRIDGE_TRUST_PROXY=1 (or a number of hops, or
+// an Express preset like "loopback"). Without this every webhook
+// looks like it comes from one IP and the limiter degrades into a
+// global throttle (Codex review on #1326).
+const trustProxyEnv = process.env.BRIDGE_TRUST_PROXY;
+if (trustProxyEnv) {
+  const numeric = Number(trustProxyEnv);
+  app.set("trust proxy", Number.isInteger(numeric) && numeric >= 0 ? numeric : trustProxyEnv);
+}
+
 // Parse as raw text so we can verify the HMAC before JSON parsing
 app.use(express.text({ type: "application/json" }));
 

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -171,6 +171,14 @@ const webhookRateLimit = rateLimit({
   limit: 120,
   standardHeaders: "draft-7",
   legacyHeaders: false,
+  // Explicit keyGenerator — uses Express's `req.ip` which honours
+  // the `app.set("trust proxy", ...)` block above. Made explicit
+  // here so a reviewer doesn't have to dig through default values
+  // to confirm the limiter is per-client rather than global
+  // (Codex review on #1326). `"unknown"` fallback only fires when
+  // Express couldn't determine an IP at all (e.g. socket closed
+  // mid-request), keeping the limit from silently disappearing.
+  keyGenerator: (req) => req.ip ?? "unknown",
 });
 
 // Webhook verification (GET)

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -16,6 +16,7 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "whatsapp";
@@ -144,8 +145,22 @@ app.disable("x-powered-by");
 // Parse as raw text so we can verify the HMAC before JSON parsing
 app.use(express.text({ type: "application/json" }));
 
+// Per-IP throttle on the webhook endpoint. CodeQL's
+// `js/missing-rate-limiting` rule recognises `express-rate-limit`
+// specifically, and Meta's platform sends well under 120 req/min/IP
+// during normal use, so the cap exists to bound a flood / stuck
+// retry loop. The verification GET shares the limiter since a
+// flood of bogus `hub.challenge` probes would otherwise hammer
+// us just as effectively.
+const webhookRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+
 // Webhook verification (GET)
-app.get("/webhook", (req: Request, res: Response) => {
+app.get("/webhook", webhookRateLimit, (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
   const challenge = req.query["hub.challenge"];
@@ -158,8 +173,8 @@ app.get("/webhook", (req: Request, res: Response) => {
   }
 });
 
-// Webhook events (POST) — signature-verified
-app.post("/webhook", async (req: Request, res: Response) => {
+// Webhook events (POST) — signature-verified + rate-limited
+app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
   const signature = req.headers["x-hub-signature-256"] as string;
   const rawBody = req.body as string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,13 +1075,6 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
-
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -3100,11 +3093,6 @@ chokidar@^5.0.0:
   dependencies:
     readdirp "^5.0.0"
 
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
-
 chromium-bidi@14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-14.0.0.tgz#15a12ab083ae519a49a724e94994ca0a9ced9c8e"
@@ -4222,7 +4210,7 @@ exifr@^7.1.3:
   resolved "https://registry.yarnpkg.com/exifr/-/exifr-7.1.3.tgz#f6218012c36dbb7d843222011b27f065fddbab6f"
   integrity sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==
 
-express-rate-limit@^8.2.1:
+express-rate-limit@^8.2.1, express-rate-limit@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.1.tgz#ee62473d7b3bdf3b27b7be3d7f25c6d13308479a"
   integrity sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==
@@ -6093,17 +6081,10 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
-
-minizlib@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
-  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
-  dependencies:
-    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -7890,17 +7871,6 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.13:
-  version "7.5.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
-  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8726,11 +8696,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

CodeQL \`js/missing-rate-limiting\` flagged 6 bridge webhook endpoints as exposed without per-IP throttling. This PR is part 1 of 3 bridge-security PRs that close out the alerts left open from #1297's security pass.

Affected bridges: \`whatsapp\`, \`viber\`, \`messenger\`, \`line-works\`, \`line\`, \`google-chat\`.

## Items to Confirm / Review

1. **Limiter settings carried over** — \`google-chat\` and \`messenger\` already had a custom Map-based limiter at 120 req/min/IP. The new \`express-rate-limit\` middleware uses identical settings, so behaviour is unchanged for normal traffic. The other 4 bridges (\`whatsapp\`, \`viber\`, \`line-works\`, \`line\`) get the same cap — confirm 120/min is right for those platforms or suggest per-bridge tuning.
2. **GET endpoints share the limiter** — \`whatsapp\` / \`messenger\`'s \`GET /webhook\` (the platform verification probe with \`hub.challenge\`) is also rate-limited. A flood of bogus probes would otherwise hammer the server just as effectively as POSTs.
3. **No new tests** — the existing custom limiter had no tests either; \`express-rate-limit\` is a well-tested external dependency. Adding a smoke test per bridge would be a larger touch that should be tracked separately if desired.
4. **Bundle size** — \`express-rate-limit@^8.5.1\` is small (~20 KB published, no transitive deps beyond \`express\` peer). Each bridge ships independently so the impact is contained.

## User Prompt

> bridge系ってなにすればよいの？
> → 1, 2, 4 をそれぞれ別々の PR で進めよう

(1) = rate-limit (this PR); (2) = reflected-xss (next); (4) = double-escape (last).

## Implementation

\`packages/bridges/{whatsapp,viber,messenger,line-works,line,google-chat}\` each get:

\`\`\`ts
import rateLimit from "express-rate-limit";

const webhookRateLimit = rateLimit({
  windowMs: 60_000,
  limit: 120,
  standardHeaders: "draft-7",
  legacyHeaders: false,
});

app.post("/webhook", webhookRateLimit, handler);
\`\`\`

\`google-chat\` and \`messenger\` had a custom in-process \`Map<ip, {count, resetAt}>\` limiter; that block + its helper \`rateLimitCheck()\` are deleted. Settings carried over verbatim (120 req/min/IP).

\`standardHeaders: "draft-7"\` advertises the cap upstream so the platform can self-throttle on \`RateLimit-Remaining\` / \`RateLimit-Reset\`.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\` clean
- [x] \`yarn test\` all green (45/45)
- [ ] CodeQL re-scan should clear all 6 \`js/missing-rate-limiting\` alerts on these files
- [ ] Manual: optional — run one bridge locally with \`for i in {1..200}; do curl … ; done\` to confirm 429 kicks in around the 120-mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce standard per-IP rate limiting to bridge webhooks using express-rate-limit across six transports.

Bug Fixes:
- Add 120 req/min/IP rate limiting to webhook endpoints for WhatsApp, Viber, Messenger, LINE WORKS, LINE, and Google Chat bridges to address missing throttling alerts.

Enhancements:
- Replace custom Map-based rate limiter implementations in Messenger and Google Chat bridges with express-rate-limit middleware configured with equivalent limits.
- Apply shared rate limiting to WhatsApp and Messenger webhook verification GET endpoints to protect against probe floods.

Build:
- Add express-rate-limit dependency to all affected bridge packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to all messaging bridge webhook endpoints (120 requests per minute per client IP) to improve service stability and prevent abuse.
  * Added optional `BRIDGE_TRUST_PROXY` environment variable configuration for correct client IP detection behind load balancers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->