### PR TITLE
feat: file-drop visual affordance on chat input (#1289 Step 1)

### DIFF
--- a/e2e/tests/chatinput-attach.spec.ts
+++ b/e2e/tests/chatinput-attach.spec.ts
@@ -97,3 +97,82 @@ test.describe("ChatInput attach discoverability", () => {
     expect(text).toContain("30");
   });
 });
+
+test.describe("ChatInput drop-target affordance (#1289 Step 1)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto("/");
+  });
+
+  test("file dragenter reveals the overlay, drop clears it", async ({ page }) => {
+    const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
+    const overlay = page.getByTestId("chat-drop-overlay");
+
+    // Pre-condition: overlay is not present before the drag starts.
+    await expect(overlay).toHaveCount(0);
+
+    // Fire a synthetic dragenter carrying a File. The handler should
+    // flip `isDragging` true and render the overlay.
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toBeVisible();
+
+    // A drop must clear the overlay — the counter is forced to zero
+    // even if the synthetic events skipped a paired dragleave.
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test("a text-selection drag (no 'Files' type) does NOT trigger the overlay", async ({ page }) => {
+    const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
+    const overlay = page.getByTestId("chat-drop-overlay");
+
+    // Dragging selected text inside the page populates dataTransfer
+    // with `text/plain` only. The Files-only guard must keep the
+    // overlay hidden for these.
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.setData("text/plain", "some selected words");
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test("counter pattern absorbs child-element enter/leave pairs without flicker", async ({ page }) => {
+    const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
+    const child = page.getByTestId("user-input");
+    const overlay = page.getByTestId("chat-drop-overlay");
+
+    // Real browsers fire `dragenter` on the wrapper, then again on
+    // each child the pointer crosses (textarea, buttons). A naive
+    // toggle would flicker the overlay off when the pointer leaves
+    // the wrapper to "enter" the textarea. The counter must keep it
+    // open across that transition.
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toBeVisible();
+
+    // Simulate the pointer crossing into the textarea (browser fires
+    // dragenter on the new target, then dragleave on the previous
+    // one — both bubble up to the wrapper handler).
+    await child.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+      element.dispatchEvent(new DragEvent("dragleave", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    // Overlay stays open — the counter was at 2 (wrapper + child)
+    // and only one leave landed, so it stays positive.
+    await expect(overlay).toBeVisible();
+  });
+});

--- a/plans/feat-chatinput-drop-overlay-1289.md
+++ b/plans/feat-chatinput-drop-overlay-1289.md
@@ -1,0 +1,42 @@
+# File-drop visual affordance (#1289 Step 1)
+
+## Goal
+
+Show the user that drag-and-drop is recognised by the chat input. Before this PR, the textarea wrapper silently accepted drops but nothing on screen confirmed the target was a drop zone — a near miss often ended with the browser navigating to the file. Per the user's direction, this PR delivers **only the visual cue on the existing drop zone**; widening the drop zone to the full chat panel + window-wide default suppression (the rest of #1289) is the next step.
+
+## Approach
+
+1. Add `isDragging` state in `ChatInput.vue`, driven by a counter pattern.
+2. Wire `@dragenter` / `@dragleave` on the existing wrapper, guarded so only file drags (`dataTransfer.types.includes("Files")`) flip the state — text-selection drags inside the page must NOT show the overlay.
+3. When `isDragging`, render an absolute-inset overlay with a dashed border, soft background tint, and a centred hint pill. `pointer-events-none` so it never absorbs the drop — the real handler stays on the wrapper.
+4. Force `dragEnterCount` back to zero in `onDropFile` so a drop never leaves a stuck overlay.
+5. Add `chatInput.dropHint` to all 8 locales (en / ja / zh / ko / es / pt-BR / fr / de) — kept short ("Drop file to attach" / "ファイルをドロップして添付" / …).
+
+## Why the counter pattern
+
+`dragenter` and `dragleave` fire on the bubbling target, not just the wrapper. Moving the pointer between the textarea, send button, and attach button inside the wrapper fires a flurry of pairs (enter on the new child + leave from the old). A naive boolean toggle flickers the overlay. The standard fix is a counter — every enter increments, every leave decrements; the overlay stays visible while the count is positive.
+
+## What this does NOT do (Step 2, deferred)
+
+- Widen the drop zone to the entire chat panel (messages + input).
+- Add a `window` `dragover`/`drop` listener with `preventDefault` to stop the browser from opening the file when the user misses the panel.
+- Move the overlay above the messages region.
+
+Per user direction, those changes ride a follow-up after we confirm the visual cue lands well. Issue #1289 stays open for Step 2.
+
+## Test plan
+
+- [x] e2e: dragenter with a File shows the overlay; drop clears it (`chat-drop-overlay` testid).
+- [x] e2e: a text-selection drag (`text/plain` only, no `Files` type) does NOT show the overlay.
+- [x] e2e: child-element enter/leave pairs don't flicker the overlay (counter pattern verified by sending an enter on the wrapper, then an enter+leave pair on the textarea, then asserting the overlay is still visible).
+- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
+- [ ] Manual: open the chat, drag a file from Finder/Explorer/Files — overlay should appear when the pointer enters the input panel and disappear after drop or when the file leaves the panel.
+
+## Acceptance
+
+- Overlay appears the instant a file enters the chat input wrapper.
+- Overlay disappears on drop (success or failure paths).
+- Overlay stays open while the pointer moves between child elements inside the wrapper.
+- Text-selection drags do not trigger the overlay.
+- All 8 locales carry the hint string.
+- Issue #1289 remains open with Step 2 (panel-wide drop zone + window-level default suppression) as the remaining scope.

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -1,5 +1,25 @@
 <template>
-  <div class="border-t border-gray-200" @dragover.prevent @drop="onDropFile">
+  <div
+    class="relative border-t border-gray-200"
+    :class="{ 'bg-blue-50/40': isDragging }"
+    @dragenter="onDragEnter"
+    @dragover.prevent
+    @dragleave="onDragLeave"
+    @drop="onDropFile"
+  >
+    <!-- Drop-target visual cue (#1289 Step 1). pointer-events-none so
+         it never absorbs the drop — the real handler is on the
+         wrapper. Files-only guard runs in the enter/leave handlers
+         so a stray text-selection drag won't trigger the overlay. -->
+    <div
+      v-if="isDragging"
+      class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded border-2 border-dashed border-blue-400"
+      data-testid="chat-drop-overlay"
+    >
+      <span class="rounded bg-white/85 px-3 py-1 text-sm font-medium text-blue-700 shadow-sm">
+        {{ t("chatInput.dropHint") }}
+      </span>
+    </div>
     <SuggestionsPanel
       v-model:expanded="suggestionsExpanded"
       :queries="queries"
@@ -112,6 +132,15 @@ const fileInput = ref<HTMLInputElement | null>(null);
 const suggestionsExpanded = ref(false);
 const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
 
+// Drop-target affordance (#1289 Step 1). `dragEnterCount` is the
+// counter pattern — every time the dragged pointer crosses into a
+// child element (textarea, button, preview thumb) the browser
+// fires another `dragenter`; without the counter, an immediate
+// `dragleave` from the previous element would flicker the overlay
+// off and back on as the user moves across children.
+const isDragging = ref(false);
+let dragEnterCount = 0;
+
 const MAX_ATTACH_BYTES = 30 * 1024 * 1024;
 
 const ACCEPTED_MIME_PREFIXES = ["image/", "text/"];
@@ -180,8 +209,36 @@ function onPasteFile(event: ClipboardEvent): void {
 
 function onDropFile(event: DragEvent): void {
   event.preventDefault();
+  dragEnterCount = 0;
+  isDragging.value = false;
   const file = event.dataTransfer?.files[0];
   if (file) readAttachmentFile(file);
+}
+
+function isFileDrag(event: DragEvent): boolean {
+  // `dataTransfer.types` is a DOMStringList in some browsers and a
+  // plain array in others — both expose `.includes` reliably in
+  // modern Chromium / WebKit / Firefox. Text-selection drags inside
+  // the page set "text/plain" / "text/html" but NOT "Files", so
+  // this guard keeps the overlay from flashing on local-page text
+  // drags. (#1289 Step 1)
+  return event.dataTransfer?.types.includes("Files") ?? false;
+}
+
+function onDragEnter(event: DragEvent): void {
+  if (!isFileDrag(event)) return;
+  event.preventDefault();
+  dragEnterCount += 1;
+  isDragging.value = true;
+}
+
+function onDragLeave(event: DragEvent): void {
+  if (!isFileDrag(event)) return;
+  dragEnterCount -= 1;
+  if (dragEnterCount <= 0) {
+    dragEnterCount = 0;
+    isDragging.value = false;
+  }
 }
 
 function openFilePicker(): void {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -34,6 +34,7 @@ const deMessages = {
     fileTooLarge: "Datei zu groß ({sizeMB} MB). Das Maximum beträgt 30 MB.",
     unsupportedFileType: "Dateityp nicht unterstützt. Akzeptiert: Bilder, PDF, DOCX, XLSX, PPTX, Textdateien.",
     attachImageFailed: "Anhängen des Bildes fehlgeschlagen: {error}",
+    dropHint: "Datei zum Anhängen ablegen",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -56,6 +56,7 @@ const enMessages = {
     fileTooLarge: "File too large ({sizeMB} MB). Maximum is 30 MB.",
     unsupportedFileType: "File type not supported. Accepted: images, PDF, DOCX, XLSX, PPTX, text files.",
     attachImageFailed: "Failed to attach image: {error}",
+    dropHint: "Drop file to attach",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -39,6 +39,7 @@ const esMessages = {
     fileTooLarge: "El archivo es demasiado grande ({sizeMB} MB). El máximo es 30 MB.",
     unsupportedFileType: "Tipo de archivo no admitido. Se aceptan: imágenes, PDF, DOCX, XLSX, PPTX y archivos de texto.",
     attachImageFailed: "No se pudo adjuntar la imagen: {error}",
+    dropHint: "Suelta el archivo para adjuntar",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -34,6 +34,7 @@ const frMessages = {
     fileTooLarge: "Fichier trop volumineux ({sizeMB} Mo). La limite est de 30 Mo.",
     unsupportedFileType: "Type de fichier non pris en charge. Acceptés : images, PDF, DOCX, XLSX, PPTX, fichiers texte.",
     attachImageFailed: "Échec de l'attache de l'image : {error}",
+    dropHint: "Déposez le fichier pour joindre",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -41,6 +41,7 @@ const jaMessages = {
     fileTooLarge: "ファイルが大きすぎます（{sizeMB} MB）。上限は 30 MB です。",
     unsupportedFileType: "対応していないファイル形式です。画像・PDF・DOCX・XLSX・PPTX・テキストファイルを使用してください。",
     attachImageFailed: "画像の添付に失敗しました: {error}",
+    dropHint: "ファイルをドロップして添付",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -41,6 +41,7 @@ const koMessages = {
     fileTooLarge: "파일이 너무 큽니다 ({sizeMB} MB). 최대 30 MB 까지 가능합니다.",
     unsupportedFileType: "지원되지 않는 파일 형식입니다. 이미지, PDF, DOCX, XLSX, PPTX, 텍스트 파일만 지원됩니다.",
     attachImageFailed: "이미지를 첨부하지 못했습니다: {error}",
+    dropHint: "파일을 놓아서 첨부",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -34,6 +34,7 @@ const ptBRMessages = {
     fileTooLarge: "Arquivo muito grande ({sizeMB} MB). O limite é 30 MB.",
     unsupportedFileType: "Tipo de arquivo não suportado. Aceitos: imagens, PDF, DOCX, XLSX, PPTX e arquivos de texto.",
     attachImageFailed: "Falha ao anexar a imagem: {error}",
+    dropHint: "Solte o arquivo para anexar",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -39,6 +39,7 @@ const zhMessages = {
     fileTooLarge: "文件过大（{sizeMB} MB）。上限为 30 MB。",
     unsupportedFileType: "不支持的文件类型。支持:图像、PDF、DOCX、XLSX、PPTX、文本文件。",
     attachImageFailed: "附加图片失败：{error}",
+    dropHint: "拖放文件以附加",
   },
   sessionHistoryPanel: {
     filters: {


### PR DESCRIPTION
## Summary

Show a dashed-border + centred hint overlay when a file is dragged over the chat input wrapper. Before this change the wrapper silently accepted drops but nothing on screen confirmed it was a drop target — a near miss let the browser open the file instead.

This is **Step 1 of #1289** per the user's direction: visual cue first, widen-the-drop-zone second.

```
┌─ chat input wrapper ─────────────────────────────────────────┐
│  ╔═══════════════ dashed blue border on drag ══════════════╗ │
│  ║                                                         ║ │
│  ║              [ Drop file to attach ]                    ║ │
│  ║                                                         ║ │
│  ╚═════════════════════════════════════════════════════════╝ │
│  [textarea: existing drop+paste path unchanged] [send/attach]│
└──────────────────────────────────────────────────────────────┘
```

## Items to Confirm / Review

- **Scope discipline.** Issue #1289 asks for two things: visual cue + widening the drop zone to the whole chat panel (messages + input) + window-level default suppression. User said:
  > ファイルをDRAG中は、UIに領域の部分に枠を出すなどしてD&Dできていることがわかるとよい。そのうえでひろげよう

  → land Step 1 (visual cue on the current target), validate it lands well, then Step 2 (widen + window guard) as a follow-up. **Issue #1289 stays open** for Step 2.
- **Counter pattern.** `dragenter` / `dragleave` fire on every child the pointer crosses inside the wrapper. A naive boolean flickers; the counter pattern (`dragEnterCount++` / `--`) keeps the overlay open across child transitions. Verified by an e2e test.
- **Files-only guard.** `event.dataTransfer?.types.includes("Files")` keeps the overlay hidden for text-selection drags inside the page (which set `text/plain` but never `Files`). Verified by an e2e test.
- **`pointer-events-none` on overlay.** Drop is still handled by the wrapper — the overlay is purely visual. Without this, the overlay would absorb the drop and we'd need to re-fire it.
- **i18n string choice.** Short and action-oriented (`"Drop file to attach"`). All 8 locales translated, not just copied from English.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1289 つぎはこれ。まず、ファイルをDRAG中は、UIに領域の部分に枠を出すなどしてD&Dできていることがわかるとよい。そのうえでひろげよう

## Implementation approach

1. `ChatInput.vue`:
   - `isDragging` ref + `dragEnterCount` counter.
   - `@dragenter` / `@dragleave` on the existing wrapper, both gated by `isFileDrag(event)` (Files-only).
   - `onDropFile` force-resets the counter so a drop never leaves a stuck overlay.
   - Overlay: `absolute inset-0 z-10 pointer-events-none border-2 border-dashed border-blue-400` with a small `bg-white/85` pill carrying the hint text.
2. i18n: `chatInput.dropHint` in en/ja/zh/ko/es/pt-BR/fr/de. Translated per locale (not copy-pasted English).
3. E2E tests at `e2e/tests/chatinput-attach.spec.ts`:
   - **Overlay appears on file dragenter, clears on drop** — synthesizes a `DragEvent` with a File and asserts the `chat-drop-overlay` testid is visible, then hidden after a `drop`.
   - **Text-selection drag does NOT show overlay** — synthesizes a `DragEvent` carrying only `text/plain`, asserts overlay stays absent.
   - **Counter pattern absorbs child transitions** — fires enter on the wrapper, then a child enter+leave pair, asserts overlay stays visible.
4. Plan committed at `plans/feat-chatinput-drop-overlay-1289.md`.

## What's NOT in this PR (Step 2, deferred)

- Widening the drop zone to include the message-list area.
- Adding a `window` `dragover` / `drop` `preventDefault` listener so missing the panel doesn't navigate the browser to the file.
- Moving the overlay above the messages region.

#1289 stays open with the above scope.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` no regressions
- [x] E2E added (will run in CI's `lint_test` job)
- [ ] Manual: open the chat, drag a real file from Finder/Explorer over the input panel — overlay should fade in. Drop and verify it disappears. Test text selection drag (highlight text in the textarea then drag) — overlay should NOT appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a visual drag-and-drop affordance to the chat input while keeping scope limited to the existing drop zone.

New Features:
- Show a dashed-border overlay with a localized hint when a file is dragged over the chat input drop target.

Enhancements:
- Guard drag events to only show the overlay for file drags and use a counter-based state to avoid flicker when moving across child elements.
- Add localized drop-hint strings for the chat input across all supported languages.

Tests:
- Add end-to-end coverage for the file-drop overlay behavior, including file drags, non-file drags, and child-element dragenter/dragleave transitions.

Chores:
- Document the plan for the file-drop visual affordance and its staged rollout in a dedicated markdown plan file.