### PR TITLE
fix(bridges): force text/plain on hub.challenge echo (reflected-xss)

### DIFF
--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -15,6 +15,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { narrowChallenge } from "./verify.js";
 
 const TRANSPORT_ID = "messenger";
 const PORT = Number(process.env.MESSENGER_BRIDGE_PORT) || 3004;
@@ -97,21 +98,15 @@ app.use(express.text({ type: "application/json", limit: BODY_LIMIT }));
 
 // Webhook verification (GET).
 //
-// Meta sends `hub.mode=subscribe` + the shared `hub.verify_token`
-// + a one-time `hub.challenge` random ASCII nonce that we must
-// echo back verbatim. Three layered defences against
-// `js/reflected-xss` — see the WhatsApp bridge's comment for the
-// full rationale; same shape applies here because Meta's
-// Send/Receive verification protocol is shared across WhatsApp
-// Cloud API and Messenger Platform.
-const SAFE_CHALLENGE_RE = /^[A-Za-z0-9_-]{1,256}$/;
-
+// Meta's Send/Receive verification protocol is shared across
+// WhatsApp Cloud API and Messenger Platform — see
+// `./verify.ts` for the full rationale on the `narrowChallenge`
+// shape whitelist (CodeQL sanitiser + Meta compatibility notes).
 app.get("/webhook", (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
-  const rawChallenge = req.query["hub.challenge"];
-  const challenge = typeof rawChallenge === "string" && SAFE_CHALLENGE_RE.test(rawChallenge) ? rawChallenge : "";
-  if (mode === "subscribe" && token === verifyToken && challenge.length > 0) {
+  const challenge = narrowChallenge(req.query["hub.challenge"]);
+  if (mode === "subscribe" && token === verifyToken && challenge !== null) {
     console.log("[messenger] webhook verified");
     res.type("text/plain").status(200).send(challenge);
   } else {

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -97,20 +97,21 @@ app.use(express.text({ type: "application/json", limit: BODY_LIMIT }));
 
 // Webhook verification (GET).
 //
-// Meta's verification flow sends `hub.mode=subscribe` + the shared
-// `hub.verify_token` + a one-time `hub.challenge` random ASCII
-// nonce that we must echo back verbatim. The default `res.send`
-// path returns `Content-Type: text/html`, which would let a
-// crafted `hub.challenge=<script>...</script>` reflect executable
-// HTML into the response (CodeQL `js/reflected-xss`). Force
-// `text/plain` AND narrow the query value to a string so an
-// `hub.challenge[]=...` array form also bounces safely.
+// Meta sends `hub.mode=subscribe` + the shared `hub.verify_token`
+// + a one-time `hub.challenge` random ASCII nonce that we must
+// echo back verbatim. Three layered defences against
+// `js/reflected-xss` — see the WhatsApp bridge's comment for the
+// full rationale; same shape applies here because Meta's
+// Send/Receive verification protocol is shared across WhatsApp
+// Cloud API and Messenger Platform.
+const SAFE_CHALLENGE_RE = /^[A-Za-z0-9_-]{1,256}$/;
+
 app.get("/webhook", (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
   const rawChallenge = req.query["hub.challenge"];
-  const challenge = typeof rawChallenge === "string" ? rawChallenge : "";
-  if (mode === "subscribe" && token === verifyToken) {
+  const challenge = typeof rawChallenge === "string" && SAFE_CHALLENGE_RE.test(rawChallenge) ? rawChallenge : "";
+  if (mode === "subscribe" && token === verifyToken && challenge.length > 0) {
     console.log("[messenger] webhook verified");
     res.type("text/plain").status(200).send(challenge);
   } else {

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -95,16 +95,26 @@ const app = express();
 app.disable("x-powered-by");
 app.use(express.text({ type: "application/json", limit: BODY_LIMIT }));
 
-// Webhook verification (GET)
+// Webhook verification (GET).
+//
+// Meta's verification flow sends `hub.mode=subscribe` + the shared
+// `hub.verify_token` + a one-time `hub.challenge` random ASCII
+// nonce that we must echo back verbatim. The default `res.send`
+// path returns `Content-Type: text/html`, which would let a
+// crafted `hub.challenge=<script>...</script>` reflect executable
+// HTML into the response (CodeQL `js/reflected-xss`). Force
+// `text/plain` AND narrow the query value to a string so an
+// `hub.challenge[]=...` array form also bounces safely.
 app.get("/webhook", (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
-  const challenge = req.query["hub.challenge"];
+  const rawChallenge = req.query["hub.challenge"];
+  const challenge = typeof rawChallenge === "string" ? rawChallenge : "";
   if (mode === "subscribe" && token === verifyToken) {
     console.log("[messenger] webhook verified");
-    res.status(200).send(challenge);
+    res.type("text/plain").status(200).send(challenge);
   } else {
-    res.status(403).send("Forbidden");
+    res.status(403).type("text/plain").send("Forbidden");
   }
 });
 

--- a/packages/bridges/messenger/src/verify.ts
+++ b/packages/bridges/messenger/src/verify.ts
@@ -1,0 +1,36 @@
+// Webhook verification helpers for Meta's Send/Receive protocol.
+// Extracted into a pure module so the regex + narrowing logic can
+// be unit-tested without spinning up the Express server.
+//
+// **Why the regex exists** (Codex review on #1328): we tried the
+// `text/plain` content-type alone — CodeQL still flagged the
+// reflected data flow on heuristic grounds, so the
+// `js/reflected-xss` alert stayed open. The whitelist below IS the
+// CodeQL sanitiser: it narrows `hub.challenge` to a known-shape
+// before it ever reaches `res.send()`, which clears the alert and
+// gives us defence-in-depth against future regressions.
+//
+// **Compatibility expectations**: `[A-Za-z0-9_-]{1,256}` matches
+// every Meta nonce we've observed (the platform sends
+// base64url-shape random tokens, typically ~32 chars). If Meta
+// ever extends the format — adds padding, longer length, new
+// characters — widen the regex HERE, in one place, and the
+// regression test pins the new shape.
+//
+// The same helper lives in `packages/bridges/whatsapp/src/verify.ts`
+// because both bridges implement Meta's identical webhook handshake
+// but are separately-published npm packages without a shared utils
+// package. Keep them in sync when updating.
+
+export const SAFE_CHALLENGE_RE = /^[A-Za-z0-9_-]{1,256}$/;
+
+/** Returns the challenge string when `raw` matches the shape we'll
+ *  echo, or `null` to signal "drop into the verify-failure path".
+ *  Non-string types (`?hub.challenge[]=...` array forms etc.)
+ *  return `null` rather than coercing to "" so callers can't
+ *  accidentally compare `.length > 0` against a coerced empty. */
+export function narrowChallenge(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  if (!SAFE_CHALLENGE_RE.test(raw)) return null;
+  return raw;
+}

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -146,21 +146,34 @@ app.use(express.text({ type: "application/json" }));
 
 // Webhook verification (GET).
 //
-// Meta's verification flow sends `hub.mode=subscribe` + the shared
-// `hub.verify_token` + a one-time `hub.challenge` random ASCII
-// nonce that we must echo back verbatim. The default `res.send`
-// path returns `Content-Type: text/html`, which would let a
-// crafted `hub.challenge=<script>...</script>` reflect executable
-// HTML into the response (CodeQL `js/reflected-xss`). Force
-// `text/plain` AND narrow the query value to a string so an
-// `hub.challenge[]=...` array form also bounces safely.
+// Meta sends `hub.mode=subscribe` + the shared `hub.verify_token`
+// + a one-time `hub.challenge` random ASCII nonce that we must
+// echo back verbatim. Three layered defences against
+// `js/reflected-xss`:
+//
+//   1. Strict shape whitelist on `hub.challenge` — Meta's nonce is
+//      always alphanumeric + `_`/`-`, ≤256 chars. Anything else is
+//      a forgery / XSS probe and gets the same 403 the verify-token
+//      mismatch returns. CodeQL recognises this kind of
+//      "validate-then-reflect" sequence as a sanitiser, so the
+//      data-flow alert clears too. (The previous patch set only
+//      `text/plain` and CodeQL still flagged the data flow on
+//      heuristic grounds.)
+//   2. `text/plain` content-type — even if a future regression
+//      widened the whitelist, the browser wouldn't execute the
+//      body as HTML.
+//   3. Narrow the query value to a string up front so
+//      `?hub.challenge[]=…` array forms can't bypass the
+//      whitelist via toString().
+const SAFE_CHALLENGE_RE = /^[A-Za-z0-9_-]{1,256}$/;
+
 app.get("/webhook", (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
   const rawChallenge = req.query["hub.challenge"];
-  const challenge = typeof rawChallenge === "string" ? rawChallenge : "";
+  const challenge = typeof rawChallenge === "string" && SAFE_CHALLENGE_RE.test(rawChallenge) ? rawChallenge : "";
 
-  if (mode === "subscribe" && token === verifyToken) {
+  if (mode === "subscribe" && token === verifyToken && challenge.length > 0) {
     console.log("[whatsapp] webhook verified");
     res.type("text/plain").status(200).send(challenge);
   } else {

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -144,17 +144,27 @@ app.disable("x-powered-by");
 // Parse as raw text so we can verify the HMAC before JSON parsing
 app.use(express.text({ type: "application/json" }));
 
-// Webhook verification (GET)
+// Webhook verification (GET).
+//
+// Meta's verification flow sends `hub.mode=subscribe` + the shared
+// `hub.verify_token` + a one-time `hub.challenge` random ASCII
+// nonce that we must echo back verbatim. The default `res.send`
+// path returns `Content-Type: text/html`, which would let a
+// crafted `hub.challenge=<script>...</script>` reflect executable
+// HTML into the response (CodeQL `js/reflected-xss`). Force
+// `text/plain` AND narrow the query value to a string so an
+// `hub.challenge[]=...` array form also bounces safely.
 app.get("/webhook", (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
-  const challenge = req.query["hub.challenge"];
+  const rawChallenge = req.query["hub.challenge"];
+  const challenge = typeof rawChallenge === "string" ? rawChallenge : "";
 
   if (mode === "subscribe" && token === verifyToken) {
     console.log("[whatsapp] webhook verified");
-    res.status(200).send(challenge);
+    res.type("text/plain").status(200).send(challenge);
   } else {
-    res.status(403).send("Forbidden");
+    res.status(403).type("text/plain").send("Forbidden");
   }
 });
 

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -17,6 +17,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
+import { narrowChallenge } from "./verify.js";
 
 const TRANSPORT_ID = "whatsapp";
 const PORT = Number(process.env.WHATSAPP_BRIDGE_PORT) || 3003;
@@ -147,33 +148,25 @@ app.use(express.text({ type: "application/json" }));
 // Webhook verification (GET).
 //
 // Meta sends `hub.mode=subscribe` + the shared `hub.verify_token`
-// + a one-time `hub.challenge` random ASCII nonce that we must
-// echo back verbatim. Three layered defences against
-// `js/reflected-xss`:
+// + a one-time `hub.challenge` ASCII nonce that we must echo back.
+// Three layered defences against `js/reflected-xss` — full
+// rationale + compatibility notes live in `./verify.ts` next to
+// the unit-tested `narrowChallenge` helper.
 //
-//   1. Strict shape whitelist on `hub.challenge` — Meta's nonce is
-//      always alphanumeric + `_`/`-`, ≤256 chars. Anything else is
-//      a forgery / XSS probe and gets the same 403 the verify-token
-//      mismatch returns. CodeQL recognises this kind of
-//      "validate-then-reflect" sequence as a sanitiser, so the
-//      data-flow alert clears too. (The previous patch set only
-//      `text/plain` and CodeQL still flagged the data flow on
-//      heuristic grounds.)
-//   2. `text/plain` content-type — even if a future regression
-//      widened the whitelist, the browser wouldn't execute the
-//      body as HTML.
-//   3. Narrow the query value to a string up front so
-//      `?hub.challenge[]=…` array forms can't bypass the
-//      whitelist via toString().
-const SAFE_CHALLENGE_RE = /^[A-Za-z0-9_-]{1,256}$/;
-
+//   1. **Shape whitelist** on `hub.challenge` (`narrowChallenge`)
+//      — required to clear CodeQL's data-flow analyser (we tried
+//      `text/plain` alone and the alert stayed open).
+//   2. **`text/plain` content-type** — neutralises browser HTML
+//      execution even if a future regression widened the whitelist.
+//   3. **String-narrowing** — `narrowChallenge` rejects non-string
+//      query values so `?hub.challenge[]=…` array forms can't
+//      bypass the regex via toString().
 app.get("/webhook", (req: Request, res: Response) => {
   const mode = req.query["hub.mode"];
   const token = req.query["hub.verify_token"];
-  const rawChallenge = req.query["hub.challenge"];
-  const challenge = typeof rawChallenge === "string" && SAFE_CHALLENGE_RE.test(rawChallenge) ? rawChallenge : "";
+  const challenge = narrowChallenge(req.query["hub.challenge"]);
 
-  if (mode === "subscribe" && token === verifyToken && challenge.length > 0) {
+  if (mode === "subscribe" && token === verifyToken && challenge !== null) {
     console.log("[whatsapp] webhook verified");
     res.type("text/plain").status(200).send(challenge);
   } else {

--- a/packages/bridges/whatsapp/src/verify.ts
+++ b/packages/bridges/whatsapp/src/verify.ts
@@ -1,0 +1,38 @@
+// Webhook verification helpers for Meta's Send/Receive protocol.
+// Extracted into a pure module so the regex + narrowing logic can
+// be unit-tested without spinning up the Express server.
+//
+// **Why the regex exists** (Codex review on #1328): we tried the
+// `text/plain` content-type alone — CodeQL still flagged the
+// reflected data flow on heuristic grounds, so the
+// `js/reflected-xss` alert stayed open. The whitelist below IS the
+// CodeQL sanitiser: it narrows `hub.challenge` to a known-shape
+// before it ever reaches `res.send()`, which clears the alert and
+// gives us defence-in-depth against future regressions.
+//
+// **Compatibility expectations**: `[A-Za-z0-9_-]{1,256}` matches
+// every Meta nonce we've observed (the platform sends
+// base64url-shape random tokens, typically ~32 chars). If Meta
+// ever extends the format — adds padding, longer length, new
+// characters — widen the regex HERE, in one place, and the
+// regression test below pins the change so the new shape is the
+// EXACT shape we accept.
+//
+// **Why not just `typeof === "string"`**: that loses the CodeQL
+// sanitiser AND lets through HTML-metachar payloads from
+// hand-crafted phishing URLs. Even with `text/plain` neutralising
+// browser execution, having an input-validation gate is the
+// cleaner contract.
+
+export const SAFE_CHALLENGE_RE = /^[A-Za-z0-9_-]{1,256}$/;
+
+/** Returns the challenge string when `raw` matches the shape we'll
+ *  echo, or `null` to signal "drop into the verify-failure path".
+ *  Non-string types (`?hub.challenge[]=...` array forms etc.)
+ *  return `null` rather than coercing to "" so callers can't
+ *  accidentally compare `.length > 0` against a coerced empty. */
+export function narrowChallenge(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  if (!SAFE_CHALLENGE_RE.test(raw)) return null;
+  return raw;
+}

--- a/test/packages/bridges/messenger/test_verify.ts
+++ b/test/packages/bridges/messenger/test_verify.ts
@@ -1,0 +1,60 @@
+// Regression tests for the Messenger webhook verify-challenge
+// narrowing helper. Mirrors `test_verify.ts` in the WhatsApp
+// bridge because Meta's Send/Receive verification protocol is
+// shared — both bridges must accept and reject the same shapes.
+// (Codex review on #1328.)
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { narrowChallenge, SAFE_CHALLENGE_RE } from "../../../../packages/bridges/messenger/src/verify.js";
+
+describe("Messenger narrowChallenge — accepted forms", () => {
+  it("typical Meta nonce (alphanumeric)", () => {
+    assert.equal(narrowChallenge("ABC123xyz789"), "ABC123xyz789");
+  });
+
+  it("base64url shape", () => {
+    assert.equal(narrowChallenge("aB-cD_eF1"), "aB-cD_eF1");
+  });
+
+  it("256-char string (current upper bound)", () => {
+    const long = "a".repeat(256);
+    assert.equal(narrowChallenge(long), long);
+  });
+});
+
+describe("Messenger narrowChallenge — rejected forms", () => {
+  it("rejects empty string", () => {
+    assert.equal(narrowChallenge(""), null);
+  });
+
+  it("rejects beyond 256 chars", () => {
+    assert.equal(narrowChallenge("a".repeat(257)), null);
+  });
+
+  it("rejects non-string types", () => {
+    assert.equal(narrowChallenge(123), null);
+    assert.equal(narrowChallenge(undefined), null);
+    assert.equal(narrowChallenge(null), null);
+    assert.equal(narrowChallenge(["abc"]), null);
+  });
+
+  it("rejects HTML-meta / XSS probe payloads", () => {
+    assert.equal(narrowChallenge("<script>alert(1)</script>"), null);
+    // eslint-disable-next-line no-script-url -- payload fixture, asserting it is REJECTED
+    assert.equal(narrowChallenge("javascript:alert(1)"), null);
+  });
+
+  it("rejects characters outside the base64url alphabet", () => {
+    assert.equal(narrowChallenge("abc="), null);
+    assert.equal(narrowChallenge("a+b"), null);
+    assert.equal(narrowChallenge("with space"), null);
+  });
+});
+
+describe("Messenger SAFE_CHALLENGE_RE — anchor sanity", () => {
+  it("regex is fully anchored", () => {
+    assert.equal(SAFE_CHALLENGE_RE.source.startsWith("^"), true);
+    assert.equal(SAFE_CHALLENGE_RE.source.endsWith("$"), true);
+  });
+});

--- a/test/packages/bridges/whatsapp/test_verify.ts
+++ b/test/packages/bridges/whatsapp/test_verify.ts
@@ -1,0 +1,84 @@
+// Regression tests for the WhatsApp webhook verify-challenge
+// narrowing helper. Pins both directions per Codex's review on
+// #1328: accepted forms (Meta's known nonce shapes) must continue
+// to verify, rejected forms (anything outside the regex) must NOT
+// be echoed back so the `js/reflected-xss` sanitiser holds.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { narrowChallenge, SAFE_CHALLENGE_RE } from "../../../../packages/bridges/whatsapp/src/verify.js";
+
+describe("WhatsApp narrowChallenge — accepted forms", () => {
+  it("typical Meta nonce (alphanumeric, ~32 chars)", () => {
+    assert.equal(narrowChallenge("ABC123xyz789"), "ABC123xyz789");
+  });
+
+  it("base64url shape (alphanumeric + _ + -)", () => {
+    assert.equal(narrowChallenge("aB-cD_eF1"), "aB-cD_eF1");
+  });
+
+  it("single char (minimum length)", () => {
+    assert.equal(narrowChallenge("a"), "a");
+  });
+
+  it("256-char string (current upper bound)", () => {
+    const long = "a".repeat(256);
+    assert.equal(narrowChallenge(long), long);
+  });
+});
+
+describe("WhatsApp narrowChallenge — rejected forms", () => {
+  it("rejects empty string", () => {
+    assert.equal(narrowChallenge(""), null);
+  });
+
+  it("rejects beyond 256 chars (length cap)", () => {
+    assert.equal(narrowChallenge("a".repeat(257)), null);
+  });
+
+  it("rejects non-string types (number, undefined, null)", () => {
+    assert.equal(narrowChallenge(123), null);
+    assert.equal(narrowChallenge(undefined), null);
+    assert.equal(narrowChallenge(null), null);
+  });
+
+  it("rejects array (defeats `?hub.challenge[]=...` bypass)", () => {
+    // Express parses `?hub.challenge=a&hub.challenge=b` as an
+    // array. The narrowing must NOT toString-coerce that — the
+    // string check at the top of narrowChallenge catches it.
+    assert.equal(narrowChallenge(["abc"]), null);
+  });
+
+  it("rejects HTML-meta / XSS probe payloads", () => {
+    assert.equal(narrowChallenge("<script>alert(1)</script>"), null);
+    // eslint-disable-next-line no-script-url -- payload fixture, asserting it is REJECTED
+    assert.equal(narrowChallenge("javascript:alert(1)"), null);
+    assert.equal(narrowChallenge('" onload="evil"'), null);
+  });
+
+  it("rejects characters outside the base64url alphabet", () => {
+    // Padding `=`, traditional base64 `+`/`/`, whitespace, etc.
+    // are not in the regex by design. If Meta ever sends these,
+    // widen `SAFE_CHALLENGE_RE` and add a positive test above.
+    assert.equal(narrowChallenge("abc="), null);
+    assert.equal(narrowChallenge("a+b"), null);
+    assert.equal(narrowChallenge("a/b"), null);
+    assert.equal(narrowChallenge("with space"), null);
+    assert.equal(narrowChallenge("with\nnewline"), null);
+  });
+
+  it("rejects non-ASCII characters", () => {
+    assert.equal(narrowChallenge("café"), null);
+    assert.equal(narrowChallenge("日本語"), null);
+  });
+});
+
+describe("WhatsApp SAFE_CHALLENGE_RE — anchor sanity", () => {
+  it("regex is fully anchored (no partial match leakage)", () => {
+    // Without `^` / `$` anchors, a payload like
+    // `abc<script>` would substring-match `abc`. The anchored
+    // form below + the test above pins this contract.
+    assert.equal(SAFE_CHALLENGE_RE.source.startsWith("^"), true);
+    assert.equal(SAFE_CHALLENGE_RE.source.endsWith("$"), true);
+  });
+});


### PR DESCRIPTION
## Summary

CodeQL \`js/reflected-xss\` flagged the webhook verification endpoint on \`whatsapp\` and \`messenger\`. Part 2 of 3 bridge-security PRs.

## Items to Confirm / Review

1. **Same fix applied to both bridges** — Meta's Send/Receive verification protocol is shared between WhatsApp Cloud API and Messenger Platform, so the vulnerable code is essentially identical. The fix is identical too.
2. **Functional equivalence to Meta's expected behaviour** — Meta verifies the webhook by checking the echoed challenge matches what it sent. The challenge is a short random ASCII nonce; \`text/plain\` is what Meta's docs imply (they don't require any particular content-type beyond \"echo verbatim\"). Confirm by running Meta's webhook validator after deploy.
3. **No tests added** — the verification endpoint is straight HTTP without complex logic. Adding a test would need a stub Express app per bridge; if you'd like that as a follow-up PR, say so.

## User Prompt

> bridge系ってなにすればよいの？
> → 1, 2, 4 をそれぞれ別々の PR で進めよう

(1) = rate-limit (#1326); (2) = reflected-xss (this PR); (4) = double-escape (next).

## Implementation

Both bridges had:

\`\`\`ts
const challenge = req.query["hub.challenge"];
if (mode === "subscribe" && token === verifyToken) {
  res.status(200).send(challenge);
}
\`\`\`

The default \`res.send(string)\` path sets \`Content-Type: text/html; charset=utf-8\`. An attacker who knows the (not-secret-grade) \`verify_token\` could craft \`?hub.challenge=<script>...</script>\` and bounce executable HTML back.

Fix on both bridges:

\`\`\`ts
const rawChallenge = req.query["hub.challenge"];
const challenge = typeof rawChallenge === "string" ? rawChallenge : "";
if (mode === "subscribe" && token === verifyToken) {
  res.type("text/plain").status(200).send(challenge);
}
\`\`\`

Two changes:
- **`res.type("text/plain")`** — explicit content-type means a browser won't execute embedded markup even if a future change accidentally reintroduces unsafe content.
- **\`typeof rawChallenge === "string" ? rawChallenge : ""\`** — narrows the query value from \`unknown\` to \`string\`. Catches the array form (\`?hub.challenge[]=foo\`) that would otherwise bypass an implicit toString in send().

The 403 path also gets \`text/plain\` for consistency.

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\` clean
- [x] \`yarn test\` all green
- [ ] CodeQL re-scan should clear the 2 \`js/reflected-xss\` alerts
- [ ] Manual (optional): \`curl 'http://localhost:3003/webhook?hub.mode=subscribe&hub.verify_token=<token>&hub.challenge=hello' -i\` → expect \`Content-Type: text/plain; charset=utf-8\` in response headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the Messenger and WhatsApp webhook verification endpoints against reflected XSS in the Meta hub.challenge echo flow.

Bug Fixes:
- Ensure webhook verification responses for Messenger and WhatsApp return the hub.challenge value with a text/plain content type to prevent reflected script execution.
- Handle non-string hub.challenge query parameters safely by coercing them to an empty string before echoing in webhook verification responses.