### PR TITLE
fix(chatinput): clear drop overlay on window-boundary dragleave (#1327 codex follow-up)

### DIFF
--- a/e2e/tests/chatinput-attach.spec.ts
+++ b/e2e/tests/chatinput-attach.spec.ts
@@ -145,6 +145,67 @@ test.describe("ChatInput drop-target affordance (#1289 Step 1)", () => {
     await expect(overlay).toHaveCount(0);
   });
 
+  test("window-leave dragleave (no Files type) clears the stuck overlay", async ({ page }) => {
+    // Regression for the Codex review on #1327: some browsers strip
+    // `Files` from `dataTransfer.types` when the dragleave event
+    // crosses a window boundary. The old handler bailed early on
+    // that case → counter stayed at 1 → overlay stuck `true` until
+    // the next drop.
+    const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
+    const overlay = page.getByTestId("chat-drop-overlay");
+
+    // Enter with a real file drag → overlay shows.
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toBeVisible();
+
+    // Leave the window — Firefox / WebKit sometimes deliver this
+    // dragleave with `relatedTarget === null` and an empty
+    // `dataTransfer.types`. Reproduce that shape.
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer(); // no items / no types
+      element.dispatchEvent(
+        new DragEvent("dragleave", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+          relatedTarget: null,
+        }),
+      );
+    });
+
+    // Overlay must clear — the leave handler decrements regardless
+    // of the missing `Files` type once the counter is positive.
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test("window-level drop outside the wrapper resets the overlay", async ({ page }) => {
+    // Belt-and-suspenders: if the user releases the file on a part
+    // of the page that ISN'T the chat input, the wrapper never sees
+    // a `drop`. The window-level `drop` listener catches it.
+    const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
+    const overlay = page.getByTestId("chat-drop-overlay");
+
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toBeVisible();
+
+    // Drop somewhere on document body (not inside the wrapper).
+    await page.evaluate(() => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      window.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+
+    await expect(overlay).toHaveCount(0);
+  });
+
   test("counter pattern absorbs child-element enter/leave pairs without flicker", async ({ page }) => {
     const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
     const child = page.getByTestId("user-input");

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -232,7 +232,7 @@ function onDragEnter(event: DragEvent): void {
   isDragging.value = true;
 }
 
-function onDragLeave(event: DragEvent): void {
+function onDragLeave(): void {
   // The `isFileDrag` guard is intentionally NOT applied here. Some
   // browsers strip `Files` from `dataTransfer.types` when the leave
   // event crosses a window boundary, which would leave the overlay
@@ -243,15 +243,6 @@ function onDragLeave(event: DragEvent): void {
   if (dragEnterCount === 0) return;
   dragEnterCount -= 1;
   if (dragEnterCount <= 0) {
-    dragEnterCount = 0;
-    isDragging.value = false;
-  }
-  // `event.relatedTarget === null` means the pointer left the
-  // document entirely (e.g. user dragged the file outside the
-  // browser window). Force a hard reset — counters can drift if
-  // some enter/leave pairs were unbalanced by intermediate
-  // re-renders.
-  if (event.relatedTarget === null) {
     dragEnterCount = 0;
     isDragging.value = false;
   }

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref } from "vue";
+import { nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import ChatAttachmentPreview from "./ChatAttachmentPreview.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
@@ -233,13 +233,51 @@ function onDragEnter(event: DragEvent): void {
 }
 
 function onDragLeave(event: DragEvent): void {
-  if (!isFileDrag(event)) return;
+  // The `isFileDrag` guard is intentionally NOT applied here. Some
+  // browsers strip `Files` from `dataTransfer.types` when the leave
+  // event crosses a window boundary, which would leave the overlay
+  // stuck (counter never decremented, `isDragging` stays `true` until
+  // the next drop). The enter handler already filters out non-file
+  // drags, so anything reaching this point with a positive counter
+  // is a file drag we entered earlier — Codex review on #1327.
+  if (dragEnterCount === 0) return;
   dragEnterCount -= 1;
   if (dragEnterCount <= 0) {
     dragEnterCount = 0;
     isDragging.value = false;
   }
+  // `event.relatedTarget === null` means the pointer left the
+  // document entirely (e.g. user dragged the file outside the
+  // browser window). Force a hard reset — counters can drift if
+  // some enter/leave pairs were unbalanced by intermediate
+  // re-renders.
+  if (event.relatedTarget === null) {
+    dragEnterCount = 0;
+    isDragging.value = false;
+  }
 }
+
+// Belt-and-suspenders escape hatch: `drop` outside our wrapper and
+// `dragend` (when applicable) both reset the overlay so a half-
+// observed drag sequence can't strand the UI in drag-state. Cross-
+// window file drags from the desktop never fire `dragend` inside
+// the page, but a user releasing the file on an inert part of the
+// page does fire `drop` at the window — that's the case we mainly
+// want to catch.
+function onWindowDragTerminal(): void {
+  dragEnterCount = 0;
+  isDragging.value = false;
+}
+
+onMounted(() => {
+  window.addEventListener("drop", onWindowDragTerminal);
+  window.addEventListener("dragend", onWindowDragTerminal);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("drop", onWindowDragTerminal);
+  window.removeEventListener("dragend", onWindowDragTerminal);
+});
 
 function openFilePicker(): void {
   fileInput.value?.click();


### PR DESCRIPTION
## Summary

Follow-up to merged #1327. Codex flagged a CHANGES REQUESTED right at merge time but the PR landed before the fix could be applied — addressing it here in a separate PR.

The bug: `onDragLeave` early-returned when `dataTransfer.types` didn't include `Files`. Some browsers strip `Files` from the types list when the dragleave event crosses a window boundary, so the counter never decremented, `isDragging` stayed `true`, and the overlay was stuck until the next drop.

Two layered fixes:

1. **Decrement-when-positive in `onDragLeave`**. Drop the `isFileDrag` guard once the counter is positive — the enter handler already filtered out non-file drags at entry, so anything reaching leave with a positive counter is a file drag we entered earlier. Additionally, when `event.relatedTarget === null` (pointer left the document entirely), force a hard reset.
2. **Window-level `drop` + `dragend` listeners**. Escape hatch for the case where the user releases the file on a non-drop-target part of the page — the wrapper never sees `drop`, but the window does. Mounted via `onMounted` / cleared via `onBeforeUnmount`.

## Items to Confirm / Review

- **Counter-positive condition vs flicker case**: the existing "child enter/leave pairs without flicker" test relies on the counter mechanism. The fix changes the guard from `isFileDrag(event)` to `dragEnterCount === 0` — same semantic during a real file drag (counter is positive while inside), no behaviour change during a non-file drag (counter is always 0 because enter never fired).
- **`event.relatedTarget === null` hard reset**: catches the case where the counter has drifted (e.g. unbalanced enter / leave pairs from intermediate re-renders) and the cursor has clearly left the document. Without this, a stuck counter could still wedge the overlay.
- **Window-level `drop` is safe to add**: a drop on a real drop target inside our wrapper already runs `onDropFile` first (which resets to 0); the bubbling window listener then runs harmlessly against the already-cleared state.
- **`dragend` doesn't fire for external file drags** (the dragged element is outside the browser), so it's mostly for in-page DOM drags. Kept for completeness; minimal cost.

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/1327 コメントをべつPRで対応

(PR #1327 had a Codex CHANGES REQUESTED that landed in parallel with the merge; the user asked to address it in a follow-up.)

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`yarn lint\` clean
- [x] \`yarn build\` clean
- [x] Two new e2e cases in \`e2e/tests/chatinput-attach.spec.ts\`:
   - window-boundary dragleave with no \`Files\` type + \`relatedTarget === null\` → overlay clears
   - window-level \`drop\` outside the wrapper → overlay clears
- [ ] CI green on the e2e matrix
- [ ] Manual repro: drag a file from desktop INTO the chat input, then drag back OUT of the browser window without releasing → overlay should fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix ChatInput drag-and-drop overlay getting stuck by making dragleave and global drag terminal handlers robust to window-boundary and out-of-wrapper drops.

Bug Fixes:
- Ensure dragleave events without `Files` types still decrement the drag counter and clear the overlay when appropriate.
- Reset drag state when the pointer leaves the document or when a window-level drop/dragend occurs outside the chat input wrapper.
- Add regression coverage for window-boundary dragleave and window-level drop scenarios to prevent stuck overlays.

Tests:
- Add e2e coverage for window-boundary dragleave without `Files` type and with `relatedTarget === null`.
- Add e2e coverage for window-level drop events outside the ChatInput wrapper resetting the overlay state.