### PR TITLE
fix(bridges/mastodon): single-pass entity decoder — drop double-unescape

### DIFF
--- a/packages/bridges/mastodon/src/parse.ts
+++ b/packages/bridges/mastodon/src/parse.ts
@@ -27,14 +27,30 @@ function stripTags(input: string): string {
   return out.join("");
 }
 
+// Single-pass entity decoder. Doing this as a chain of independent
+// `.replace()` calls produces a double-unescape bug when the source
+// contains a literal escaped entity like `&amp;lt;`:
+//
+//   chain order  &amp; → &   then  &lt; → <
+//   result       `&amp;lt;` ends up as `<`, but the author meant
+//                the literal string `&lt;`
+//
+// Walking the input once with a single regex + lookup table makes
+// `&amp;lt;` decode to `&lt;` (only the `&amp;` is unescaped, the
+// following `&lt;` is then left as plain text). CodeQL flags the
+// chained form as `js/double-escaping`.
+const ENTITY_REPLACEMENTS: Readonly<Record<string, string>> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};
+const ENTITY_RE = /&(?:nbsp|amp|lt|gt|quot|#39);/g;
+
 function decodeEntities(input: string): string {
-  return input
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
+  return input.replace(ENTITY_RE, (match) => ENTITY_REPLACEMENTS[match] ?? match);
 }
 
 export function htmlToText(html: string): string {

--- a/packages/bridges/mastodon/test/test_parse.ts
+++ b/packages/bridges/mastodon/test/test_parse.ts
@@ -35,6 +35,17 @@ describe("htmlToText", () => {
     assert.equal(htmlToText("a &amp; b &lt;x&gt; &quot;y&quot; &#39;z&#39; &nbsp;w"), "a & b <x> \"y\" 'z'  w");
   });
 
+  it("does NOT double-unescape `&amp;lt;` to `<`", () => {
+    // CodeQL js/double-escaping: a chained decoder that runs
+    // `&amp; → &` first would turn `&amp;lt;` into `&lt;` and then
+    // (in the next pass) into `<`. The single-pass decoder keeps
+    // the author's intent: `&amp;lt;` means "the literal text
+    // &lt;", not "the < character".
+    assert.equal(htmlToText("a &amp;lt; b"), "a &lt; b");
+    assert.equal(htmlToText("&amp;amp;"), "&amp;");
+    assert.equal(htmlToText("&amp;quot;"), "&quot;");
+  });
+
   it("returns empty string for empty / whitespace-only input", () => {
     assert.equal(htmlToText(""), "");
     assert.equal(htmlToText("   "), "");


### PR DESCRIPTION
## Summary

CodeQL \`js/double-escaping\` flagged a chained \`.replace()\` decoder in \`packages/bridges/mastodon/src/parse.ts\` that double-unescapes literal-escaped entities. Part 3 of 3 bridge-security PRs (closes the last alert from the post-#1297 sweep).

## Items to Confirm / Review

1. **Behaviour preserved for the common case** — single-layer entity input still decodes the same way (\`&amp;\` → \`&\`, \`&lt;\` → \`<\`, etc.). The existing "decodes HTML entities" test is unchanged.
2. **Behaviour changed for double-escaped input** — \`&amp;lt;\` now decodes to \`&lt;\` (the literal four-character string), not to \`<\`. This matches author intent: when a toot contained \`&amp;lt;\`, the author meant the visible text \`&lt;\`, not the symbol \`<\`. Three new regression tests pin this down.
3. **No new dependency** — pure regex + lookup table, same runtime cost (one pass instead of six).

## User Prompt

> bridge系ってなにすればよいの？
> → 1, 2, 4 をそれぞれ別々の PR で進めよう

(1) = rate-limit (#1326); (2) = reflected-xss (#1328); (4) = double-escape (this PR).

## Implementation

Before:

\`\`\`ts
function decodeEntities(input: string): string {
  return input
    .replace(/&nbsp;/g, " ")
    .replace(/&amp;/g, "&")     // unescapes first
    .replace(/&lt;/g, "<")      // then turns &lt; → <
    .replace(/&gt;/g, ">")
    .replace(/&quot;/g, '"')
    .replace(/&#39;/g, "'");
}
\`\`\`

The chain is order-dependent. Input \`&amp;lt;\` flows:
1. \`&amp;\` → \`&\`  ⇒  \`&lt;\`
2. \`&lt;\`  → \`<\`  ⇒  \`<\`

After:

\`\`\`ts
const ENTITY_REPLACEMENTS = { "&nbsp;": " ", "&amp;": "&", … } as const;
const ENTITY_RE = /&(?:nbsp|amp|lt|gt|quot|#39);/g;

function decodeEntities(input: string): string {
  return input.replace(ENTITY_RE, (m) => ENTITY_REPLACEMENTS[m] ?? m);
}
\`\`\`

Single pass; output is not re-scanned. Same input now decodes to \`&lt;\` (only the leading \`&amp;\` is unescaped).

## Test plan

- [x] \`yarn format && yarn lint && yarn typecheck && yarn build\` clean
- [x] \`yarn test\` all green — including 3 new regression cases (\`&amp;lt;\` / \`&amp;amp;\` / \`&amp;quot;\`)
- [ ] CodeQL re-scan should clear the \`js/double-escaping\` alert

## Bridge-security sweep status (post-#1297)

| PR | Alerts | Status |
|---|---|---|
| #1326 | 6 × \`js/missing-rate-limiting\` | Open |
| #1328 | 2 × \`js/reflected-xss\` | Open |
| This PR | 1 × \`js/double-escaping\` | This PR |
| (separate) | 1 × \`js/request-forgery\` (mastodon SSRF, critical) | Not yet — needs allowlist design |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch Mastodon bridge HTML entity decoding to a single-pass regex-based implementation to avoid double-unescaping while preserving normal entity handling.

Bug Fixes:
- Prevent double-unescaping of literal-escaped entities like `&amp;lt;` so they render as `&lt;` instead of `<`.

Tests:
- Add regression tests to verify double-escaped entities such as `&amp;lt;`, `&amp;amp;`, and `&amp;quot;` are decoded without double-unescaping.