### PR TITLE
feat: widen file drop to chat panel + window default guard (#1289 Step 2)

### DIFF
--- a/e2e/tests/chatinput-attach.spec.ts
+++ b/e2e/tests/chatinput-attach.spec.ts
@@ -98,7 +98,7 @@ test.describe("ChatInput attach discoverability", () => {
   });
 });
 
-test.describe("ChatInput drop-target affordance (#1289 Step 1)", () => {
+test.describe("ChatInput drop-target affordance (#1289 Step 1 + Step 2)", () => {
   test.beforeEach(async ({ page }) => {
     await mockAllApis(page);
     await page.goto("/");
@@ -174,5 +174,35 @@ test.describe("ChatInput drop-target affordance (#1289 Step 1)", () => {
     // Overlay stays open — the counter was at 2 (wrapper + child)
     // and only one leave landed, so it stays positive.
     await expect(overlay).toBeVisible();
+  });
+
+  test("Step 2: dragging onto the chat-sidebar (panel-wide) shows the overlay and attaches on drop", async ({ page }) => {
+    // The panel-wide drop zone (#1289 Step 2) wires the handlers on
+    // the chat-sidebar div instead of the ChatInput wrapper.
+    // Dragging onto an element above the input (i.e. the sessions
+    // list region) should now reveal the overlay, and a drop there
+    // should still route the file through ChatInput.readFile().
+    const panel = page.getByTestId("chat-sidebar");
+    const overlay = page.getByTestId("chat-drop-overlay");
+
+    await expect(overlay).toHaveCount(0);
+
+    await panel.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.txt", { type: "text/plain" }));
+      element.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toBeVisible();
+
+    // Dropping an unsupported type at the panel level surfaces the
+    // SAME error banner the textarea-drop path surfaces — verifies
+    // App.vue actually routes the dropped file into ChatInput.readFile.
+    await panel.evaluate((element) => {
+      const transfer = new DataTransfer();
+      transfer.items.add(new File(["payload"], "thing.zip", { type: "application/zip" }));
+      element.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    await expect(overlay).toHaveCount(0);
+    await expect(page.getByTestId("file-error")).toBeVisible();
   });
 });

--- a/plans/feat-chatpanel-drop-widen-1289.md
+++ b/plans/feat-chatpanel-drop-widen-1289.md
@@ -1,0 +1,47 @@
+# Widen file drop to chat panel + window default guard (#1289 Step 2)
+
+## Goal
+
+Step 1 (#1327) showed a dashed overlay when a file enters the chat **input** wrapper. Step 2 widens that drop zone to the whole **chat panel** (messages + thinking indicator + input) and installs a window-level guard so a near-miss outside the panel doesn't navigate the browser to the dropped file. This closes the original UX problem in #1289 — losing the in-progress conversation because the drop zone was too small.
+
+## Approach
+
+1. **New composable `useFileDropZone`** owns the drag state + handlers + window guard:
+   - `isDragging` ref + counter pattern (already established in Step 1).
+   - `dataTransfer.types.includes("Files")` guard so text-selection drags inside the page never trigger.
+   - **Window-level guard** (lazy, install-once across all consumers): `window.addEventListener("dragover"/"drop", preventDefault)` for file drags only. Without this, missing the drop zone leaves the browser to navigate away and lose the conversation.
+   - Returns `{ isDragging, onDragenter, onDragover, onDragleave, onDrop }` for the consumer to wire onto the target element.
+2. **New component `FileDropOverlay.vue`** — the visual cue (dashed border + hint pill). Same i18n key `chatInput.dropHint` as Step 1; no new locale strings. `pointer-events-none` so it never absorbs the drop.
+3. **Strip the Step 1 drop machinery from `ChatInput.vue`**:
+   - Remove the wrapper-level dragenter/dragover/dragleave/drop handlers.
+   - Remove `isDragging` + counter + overlay markup.
+   - Expose `readFile(file)` (alias for the existing `readAttachmentFile`) so the parent can route a panel-level drop into ChatInput's validation + emit pipeline.
+4. **`App.vue`** wires the composable for both layouts using the same `chatInputRef`:
+   - **Single layout** — handlers on the `data-testid="chat-sidebar"` div (already `relative`); overlay rendered inside. Drop anywhere over sessions list + thinking + input attaches the file.
+   - **Stack layout** — handlers on the canvas column (where the stack chat lives). Conditional via `v-on="canvasDropHandlers"` so single-mode plugin pages (Files / Wiki / …) inside the canvas don't get hijacked. Overlay gated on `isPanelDragging && isStackLayout && isChatPage`.
+
+## Why a window-level guard
+
+`event.preventDefault()` on `dragover` AND `drop` is what blocks the browser's default "open the file" behaviour. Without listeners on `window`, a drop outside the chat panel navigates the browser to `file:///…`, killing the in-progress conversation. The guard is install-once (`windowGuardInstalled` flag) so multiple consumers don't double-bind. Only Files-type drags are suppressed — text-selection drags within the page keep their default behaviour.
+
+## What this does NOT do
+
+- Multi-file drops — still picks `files[0]` (`MAX_ATTACH_BYTES` and `pastedFile` are single-file by design).
+- Drag-and-drop on plugin pages (Files / Wiki / …) — those handle their own input on their own terms; widening the chat-panel drop to cover them would be surprising.
+
+## Test plan
+
+- [x] Existing Step 1 e2e tests still pass — they dispatch DragEvents on `[data-testid=user-input]`'s grandparent (the `p-2` div). Step 1 had the listener on the ChatInput wrapper one level up; Step 2 moves it further up to the chat-sidebar / canvas column. The dispatched DragEvents bubble (`bubbles: true`) so the move is transparent to the tests.
+- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
+- [ ] Manual single layout: drag a real file from Finder/Explorer over the sidebar — overlay appears anywhere within the panel (sessions / thinking / input). Drop attaches the file.
+- [ ] Manual stack layout: same flow in the canvas column.
+- [ ] Manual near-miss: drag over the panel, then RELEASE outside the panel — browser does NOT navigate to the file, conversation remains intact.
+
+## Acceptance
+
+- Drop anywhere inside the chat panel (single + stack) attaches the file via the existing `pastedFile` flow.
+- Drop OUTSIDE the panel does nothing (browser does not navigate).
+- Overlay covers the whole panel during a file drag and only during a file drag.
+- Text-selection drags do not show the overlay.
+- All 8 locales still carry the existing `chatInput.dropHint` (no new keys).
+- `#1289` can be closed.

--- a/src/App.vue
+++ b/src/App.vue
@@ -88,7 +88,12 @@
         v-if="!isStackLayout && !sidePanelExpanded"
         class="w-80 flex-shrink-0 border-r border-gray-200 flex flex-col bg-white text-gray-900 relative"
         data-testid="chat-sidebar"
+        @dragenter="onPanelDragenter"
+        @dragover="onPanelDragover"
+        @dragleave="onPanelDragleave"
+        @drop="onPanelDrop"
       >
+        <FileDropOverlay v-if="isPanelDragging" />
         <!-- Tool result previews + role header (#842) -->
         <SessionSidebar
           ref="sessionSidebarRef"
@@ -130,8 +135,14 @@
         />
       </div>
 
-      <!-- Canvas column -->
-      <div v-if="!sidePanelExpanded" class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden relative">
+      <!-- Canvas column. In stack-chat mode the canvas IS the chat
+           panel (messages on top, ChatInput at the bottom), so the
+           panel-wide drop zone (#1289 Step 2) applies here too. In
+           single mode the canvas hosts plugin pages (Files / Wiki /
+           …); we deliberately do NOT widen the drop zone onto those
+           because each page handles file input on its own terms. -->
+      <div v-if="!sidePanelExpanded" class="flex-1 flex flex-col bg-white text-gray-900 min-w-0 overflow-hidden relative" v-on="canvasDropHandlers">
+        <FileDropOverlay v-if="isPanelDragging && isStackLayout && isChatPage" />
         <div ref="canvasRef" class="flex-1 overflow-hidden outline-none min-h-0" tabindex="0" @mousedown="activePane = 'main'" @keydown="handleCanvasKeydown">
           <!-- Chat page: single or stack layout -->
           <template v-if="isChatPage && layoutMode === 'single'">
@@ -273,6 +284,7 @@ import SidebarHeader from "./components/SidebarHeader.vue";
 import SessionHeaderControls from "./components/SessionHeaderControls.vue";
 import SessionTabBar from "./components/SessionTabBar.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
+import FileDropOverlay from "./components/FileDropOverlay.vue";
 import SessionHistoryExpandButton from "./components/SessionHistoryExpandButton.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
 import SessionSidebar from "./components/SessionSidebar.vue";
@@ -307,6 +319,7 @@ import { useRunElapsed } from "./composables/useRunElapsed";
 import { useKeyNavigation } from "./composables/useKeyNavigation";
 import { useDebugBeat } from "./composables/useDebugBeat";
 import { useChatScroll } from "./composables/useChatScroll";
+import { useFileDropZone } from "./composables/useFileDropZone";
 import { useViewLayout } from "./composables/useViewLayout";
 import { useSessionSync } from "./composables/useSessionSync";
 import { useSessionDerived } from "./composables/useSessionDerived";
@@ -495,12 +508,31 @@ useGlobalImageErrorRepair();
 
 const sessionSidebarRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);
-const chatInputRef = ref<{ focus: () => void; collapseSuggestions: () => void } | null>(null);
+const chatInputRef = ref<{ focus: () => void; collapseSuggestions: () => void; readFile: (file: File) => void } | null>(null);
 const { focusChatInput } = useChatScroll({
   sessionSidebarRef,
   toolResults,
   isRunning: activeSessionRunning,
   chatInputRef,
+});
+
+// Panel-wide file drop (#1289 Step 2). The handlers are bound on
+// both the sidebar (single layout) and the stack-mode canvas column;
+// the same `chatInputRef` is reused across layouts because only one
+// ChatInput is mounted at a time (v-if'd). The composable also
+// installs a window-level guard so a drop OUTSIDE the panel still
+// `preventDefault`s — the browser would otherwise navigate to the
+// file and the user would lose their in-progress conversation.
+const {
+  isDragging: isPanelDragging,
+  onDragenter: onPanelDragenter,
+  onDragover: onPanelDragover,
+  onDragleave: onPanelDragleave,
+  onDrop: onPanelDrop,
+} = useFileDropZone({
+  onFile: (file) => {
+    chatInputRef.value?.readFile(file);
+  },
 });
 
 const { showRightSidebar, toggleRightSidebar } = useRightSidebar();
@@ -558,6 +590,22 @@ const { isStackLayout } = useViewLayout({
   isChatPage,
   activePane,
 });
+
+// Canvas-column drop handlers are conditional: only attach in
+// stack-chat mode. Single-mode canvas shows plugin pages (Files /
+// Wiki / …) whose own drop handling we don't want to shadow.
+// v-on with an empty object is a no-op in Vue 3, so the canvas
+// listens to nothing on single-mode chat / non-chat pages.
+const canvasDropHandlers = computed(() =>
+  isStackLayout.value && isChatPage.value
+    ? {
+        dragenter: onPanelDragenter,
+        dragover: onPanelDragover,
+        dragleave: onPanelDragleave,
+        drop: onPanelDrop,
+      }
+    : {},
+);
 
 // Clear currentSessionId when the user leaves /chat so downstream
 // consumers (history-panel border, mark-read, unread dot, session-

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -1,25 +1,10 @@
 <template>
-  <div
-    class="relative border-t border-gray-200"
-    :class="{ 'bg-blue-50/40': isDragging }"
-    @dragenter="onDragEnter"
-    @dragover.prevent
-    @dragleave="onDragLeave"
-    @drop="onDropFile"
-  >
-    <!-- Drop-target visual cue (#1289 Step 1). pointer-events-none so
-         it never absorbs the drop — the real handler is on the
-         wrapper. Files-only guard runs in the enter/leave handlers
-         so a stray text-selection drag won't trigger the overlay. -->
-    <div
-      v-if="isDragging"
-      class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded border-2 border-dashed border-blue-400"
-      data-testid="chat-drop-overlay"
-    >
-      <span class="rounded bg-white/85 px-3 py-1 text-sm font-medium text-blue-700 shadow-sm">
-        {{ t("chatInput.dropHint") }}
-      </span>
-    </div>
+  <!-- File drop is handled at the chat panel level (#1289 Step 2)
+       so the user can drop anywhere over the panel + messages, not
+       just over the input box. ChatInput still owns `readFile` for
+       the dropped file — App.vue calls it via the exposed method
+       once the panel-wide drop fires. -->
+  <div class="border-t border-gray-200">
     <SuggestionsPanel
       v-model:expanded="suggestionsExpanded"
       :queries="queries"
@@ -132,15 +117,6 @@ const fileInput = ref<HTMLInputElement | null>(null);
 const suggestionsExpanded = ref(false);
 const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
 
-// Drop-target affordance (#1289 Step 1). `dragEnterCount` is the
-// counter pattern — every time the dragged pointer crosses into a
-// child element (textarea, button, preview thumb) the browser
-// fires another `dragenter`; without the counter, an immediate
-// `dragleave` from the previous element would flicker the overlay
-// off and back on as the user moves across children.
-const isDragging = ref(false);
-let dragEnterCount = 0;
-
 const MAX_ATTACH_BYTES = 30 * 1024 * 1024;
 
 const ACCEPTED_MIME_PREFIXES = ["image/", "text/"];
@@ -207,40 +183,6 @@ function onPasteFile(event: ClipboardEvent): void {
   }
 }
 
-function onDropFile(event: DragEvent): void {
-  event.preventDefault();
-  dragEnterCount = 0;
-  isDragging.value = false;
-  const file = event.dataTransfer?.files[0];
-  if (file) readAttachmentFile(file);
-}
-
-function isFileDrag(event: DragEvent): boolean {
-  // `dataTransfer.types` is a DOMStringList in some browsers and a
-  // plain array in others — both expose `.includes` reliably in
-  // modern Chromium / WebKit / Firefox. Text-selection drags inside
-  // the page set "text/plain" / "text/html" but NOT "Files", so
-  // this guard keeps the overlay from flashing on local-page text
-  // drags. (#1289 Step 1)
-  return event.dataTransfer?.types.includes("Files") ?? false;
-}
-
-function onDragEnter(event: DragEvent): void {
-  if (!isFileDrag(event)) return;
-  event.preventDefault();
-  dragEnterCount += 1;
-  isDragging.value = true;
-}
-
-function onDragLeave(event: DragEvent): void {
-  if (!isFileDrag(event)) return;
-  dragEnterCount -= 1;
-  if (dragEnterCount <= 0) {
-    dragEnterCount = 0;
-    isDragging.value = false;
-  }
-}
-
 function openFilePicker(): void {
   fileInput.value?.click();
 }
@@ -272,5 +214,5 @@ function collapseSuggestions(): void {
   suggestionsExpanded.value = false;
 }
 
-defineExpose({ focus, collapseSuggestions });
+defineExpose({ focus, collapseSuggestions, readFile: readAttachmentFile });
 </script>

--- a/src/components/FileDropOverlay.vue
+++ b/src/components/FileDropOverlay.vue
@@ -1,0 +1,18 @@
+<template>
+  <!-- pointer-events-none so the overlay never absorbs the drop —
+       the real handler stays on the parent element. -->
+  <div
+    class="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded border-2 border-dashed border-blue-400 bg-blue-50/40"
+    data-testid="chat-drop-overlay"
+  >
+    <span class="rounded bg-white/90 px-4 py-2 text-sm font-medium text-blue-700 shadow-sm">
+      {{ t("chatInput.dropHint") }}
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+</script>

--- a/src/composables/useFileDropZone.ts
+++ b/src/composables/useFileDropZone.ts
@@ -38,23 +38,28 @@ export interface UseFileDropZoneOptions {
   onFile: (file: File) => void;
 }
 
-let windowGuardInstalled = false;
+// Module-scope so the install-once contract holds across multiple
+// `useFileDropZone` consumers. The handler reference is retained
+// so `_resetFileDropZoneForTests` can actually remove the listeners
+// (a naive reset that only flipped the flag would leak handlers
+// across test runs — Sourcery review on PR #1331).
+let windowGuardHandler: ((event: DragEvent) => void) | null = null;
 
 function isFileDrag(event: DragEvent): boolean {
   return event.dataTransfer?.types.includes("Files") ?? false;
 }
 
 function installWindowDefaultGuard(): void {
-  if (windowGuardInstalled) return;
+  if (windowGuardHandler !== null) return;
   if (typeof window === "undefined") return;
-  windowGuardInstalled = true;
-  const prevent = (event: DragEvent): void => {
+  const handler = (event: DragEvent): void => {
     if (isFileDrag(event)) event.preventDefault();
   };
   // Capture-phase isn't needed: `preventDefault` from a bubbling
   // handler still suppresses the default action.
-  window.addEventListener("dragover", prevent);
-  window.addEventListener("drop", prevent);
+  window.addEventListener("dragover", handler);
+  window.addEventListener("drop", handler);
+  windowGuardHandler = handler;
 }
 
 export function useFileDropZone(opts: UseFileDropZoneOptions): UseFileDropZoneResult {
@@ -87,6 +92,11 @@ export function useFileDropZone(opts: UseFileDropZoneOptions): UseFileDropZoneRe
   }
 
   function onDrop(event: DragEvent): void {
+    // Non-file drops (e.g. dropping selected text from elsewhere on
+    // the page into the textarea) need to keep their default
+    // behaviour. Suppressing the default for those would break a
+    // legitimate browser action. Sourcery review on PR #1331.
+    if (!isFileDrag(event)) return;
     event.preventDefault();
     dragEnterCount = 0;
     isDragging.value = false;
@@ -97,8 +107,13 @@ export function useFileDropZone(opts: UseFileDropZoneOptions): UseFileDropZoneRe
   return { isDragging, onDragenter, onDragover, onDragleave, onDrop };
 }
 
-/** Test-only reset. Lets unit tests verify the install-once contract
- *  without leaking listeners across cases. */
+/** Test-only reset. Removes the window listeners installed by
+ *  `installWindowDefaultGuard` so a test can verify the install-once
+ *  contract without leaking handlers across cases. */
 export function _resetFileDropZoneForTests(): void {
-  windowGuardInstalled = false;
+  if (windowGuardHandler !== null && typeof window !== "undefined") {
+    window.removeEventListener("dragover", windowGuardHandler);
+    window.removeEventListener("drop", windowGuardHandler);
+  }
+  windowGuardHandler = null;
 }

--- a/src/composables/useFileDropZone.ts
+++ b/src/composables/useFileDropZone.ts
@@ -1,0 +1,104 @@
+// File drag-and-drop zone helper (#1289 Step 2).
+//
+// Returns DOM-event handlers a caller binds onto the target element
+// plus an `isDragging` ref the caller uses to render visual feedback.
+// Also installs (once, lazily) a window-level guard that
+// `preventDefault`s `dragover` / `drop` on file drags so the browser
+// never navigates to a dropped file when the user misses the zone —
+// losing the in-progress conversation was the original UX bug.
+//
+// Why "Files"-only: text-selection drags inside the page set
+// `text/plain` on `dataTransfer.types` but never include `"Files"`.
+// Gating on Files keeps the overlay hidden for those, both at the
+// composable level and the window-guard level.
+//
+// Why a counter: real browsers fire `dragenter` / `dragleave` on
+// every child the pointer crosses inside the target. A naive boolean
+// toggles off as the pointer moves from the panel into the textarea,
+// then on again, flickering the overlay. The counter ratchets up on
+// each enter and only releases the overlay once it hits zero.
+
+import { ref, type Ref } from "vue";
+
+export interface FileDropHandlers {
+  onDragenter: (event: DragEvent) => void;
+  onDragover: (event: DragEvent) => void;
+  onDragleave: (event: DragEvent) => void;
+  onDrop: (event: DragEvent) => void;
+}
+
+export interface UseFileDropZoneResult extends FileDropHandlers {
+  isDragging: Readonly<Ref<boolean>>;
+}
+
+export interface UseFileDropZoneOptions {
+  /** Called when the user releases a file over the zone. The
+   *  composable picks `files[0]` (first file) and ignores the rest;
+   *  multi-file uploads are not a current product requirement. */
+  onFile: (file: File) => void;
+}
+
+let windowGuardInstalled = false;
+
+function isFileDrag(event: DragEvent): boolean {
+  return event.dataTransfer?.types.includes("Files") ?? false;
+}
+
+function installWindowDefaultGuard(): void {
+  if (windowGuardInstalled) return;
+  if (typeof window === "undefined") return;
+  windowGuardInstalled = true;
+  const prevent = (event: DragEvent): void => {
+    if (isFileDrag(event)) event.preventDefault();
+  };
+  // Capture-phase isn't needed: `preventDefault` from a bubbling
+  // handler still suppresses the default action.
+  window.addEventListener("dragover", prevent);
+  window.addEventListener("drop", prevent);
+}
+
+export function useFileDropZone(opts: UseFileDropZoneOptions): UseFileDropZoneResult {
+  installWindowDefaultGuard();
+
+  const isDragging = ref(false);
+  let dragEnterCount = 0;
+
+  function onDragenter(event: DragEvent): void {
+    if (!isFileDrag(event)) return;
+    event.preventDefault();
+    dragEnterCount += 1;
+    isDragging.value = true;
+  }
+
+  function onDragover(event: DragEvent): void {
+    // Some browsers (notably WebKit) suppress the subsequent `drop`
+    // if `dragover` doesn't preventDefault — even when the prior
+    // `dragenter` did. Re-prevent here.
+    if (isFileDrag(event)) event.preventDefault();
+  }
+
+  function onDragleave(event: DragEvent): void {
+    if (!isFileDrag(event)) return;
+    dragEnterCount -= 1;
+    if (dragEnterCount <= 0) {
+      dragEnterCount = 0;
+      isDragging.value = false;
+    }
+  }
+
+  function onDrop(event: DragEvent): void {
+    event.preventDefault();
+    dragEnterCount = 0;
+    isDragging.value = false;
+    const file = event.dataTransfer?.files[0];
+    if (file) opts.onFile(file);
+  }
+
+  return { isDragging, onDragenter, onDragover, onDragleave, onDrop };
+}
+
+/** Test-only reset. Lets unit tests verify the install-once contract
+ *  without leaking listeners across cases. */
+export function _resetFileDropZoneForTests(): void {
+  windowGuardInstalled = false;
+}


### PR DESCRIPTION
## Summary

Step 1 (#1327, merged) showed an overlay only over the ChatInput wrapper. **Step 2** widens the drop zone to the entire chat panel and installs a window-level guard so a near-miss outside the panel no longer navigates the browser to the dropped file.

Closes **#1289**.

```
SINGLE layout (drop anywhere over sessions / thinking / input):
┌─ chat-sidebar (drop zone) ─────────┐  ┌─ canvas (plugin views) ─┐
│  ╔═════ dashed blue overlay ══════╗ │  │                         │
│  ║                                ║ │  │                         │
│  ║       Drop file to attach      ║ │  │   (no drop zone here)   │
│  ║                                ║ │  │                         │
│  ╚════════════════════════════════╝ │  │                         │
│  [sessions list]                    │  │                         │
│  [thinking indicator]               │  │                         │
│  [ChatInput]                        │  │                         │
└─────────────────────────────────────┘  └─────────────────────────┘

STACK layout (drop anywhere over messages + input):
                                         ┌─ canvas (drop zone) ─────┐
                                         │  ╔══ dashed overlay ════╗ │
                                         │  ║   Drop file to ...   ║ │
                                         │  ╚══════════════════════╝ │
                                         │  [StackView messages]    │
                                         │  [ChatInput bottom bar]  │
                                         └──────────────────────────┘

Window outside the panel: dragover/drop → preventDefault.
                          No overlay, no read — just stops the
                          browser from navigating away.
```

## Items to Confirm / Review

- **Architecture: composable + exposed `readFile`.** `useFileDropZone` owns drag state + window guard. ChatInput exposes `readFile(file)` via `defineExpose` so App.vue can route the dropped file through ChatInput's existing validation + emit pipeline (same `pastedFile` flow paste/click already use). This keeps validation (`isAcceptedType`, `MAX_ATTACH_BYTES`, fileError banner) in one place.
- **Window guard is install-once.** A module-scope `windowGuardInstalled` flag prevents double-binding if `useFileDropZone` is called from multiple components. Files-only filter (`dataTransfer.types.includes("Files")`) so text-selection drags keep their default behaviour.
- **Stack layout drop zone is conditional.** `v-on="canvasDropHandlers"` returns `{}` on non-stack-chat pages so plugin views (Files / Wiki / …) inside the same canvas column aren't hijacked. Verified by inspection — please flag if any plugin page expects drag-and-drop on the canvas column itself.
- **Single layout: canvas plugin pages keep their own behaviour.** Drop on Files / Wiki / etc. is NOT routed to ChatInput (which lives in a separate sidebar). Each plugin handles its own input on its own terms.
- **Multi-file drops still pick `files[0]`.** Matches the existing single-file `pastedFile` contract.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1289 つぎはこれ。まず、ファイルをDRAG中は、UIに領域の部分に枠を出すなどしてD&Dできていることがわかるとよい。そのうえでひろげよう
>
> (Step 1 merged as #1327 — visual cue on the input wrapper.) 動作ok merge / つづけて

## Implementation approach

1. **`src/composables/useFileDropZone.ts`** (new):
   - `isDragging` ref + counter pattern.
   - Files-only guard at both composable level (skip non-file drags) and window level (skip default-prevention for non-file drags).
   - Module-scope `windowGuardInstalled` flag + `installWindowDefaultGuard()` so the window listeners bind once across all consumers.
   - Returns `{ isDragging, onDragenter, onDragover, onDragleave, onDrop }`.
   - Exposes `_resetFileDropZoneForTests` for cases that need to verify the install-once contract.
2. **`src/components/FileDropOverlay.vue`** (new):
   - Visual cue (dashed border + centred hint pill). `pointer-events-none`. `data-testid="chat-drop-overlay"` — same testid Step 1 used, so existing e2e tests don't need new selectors.
   - i18n: reuses the `chatInput.dropHint` key landed in Step 1 — no new locale strings.
3. **`src/components/ChatInput.vue`**:
   - Remove the Step 1 wrapper-level drag handlers, the `isDragging` ref + counter, and the inline overlay.
   - Keep `readAttachmentFile` (the validation + emit pipeline) and expose it via `defineExpose({ ..., readFile: readAttachmentFile })`.
4. **`src/App.vue`**:
   - Import the composable + overlay component.
   - One `useFileDropZone` call wires both layouts (single ChatInput is mounted at a time; `chatInputRef.value?.readFile(file)` no-ops cleanly between mounts).
   - Single layout: `@dragenter` / `@dragover` / `@dragleave` / `@drop` on `data-testid="chat-sidebar"` (already `relative`); `<FileDropOverlay v-if="isPanelDragging" />` inside.
   - Stack layout: `v-on="canvasDropHandlers"` on the canvas column. `canvasDropHandlers` is a computed returning the handler map only when `isStackLayout && isChatPage`, else `{}` (Vue 3 reads that as "no listeners").
5. **Plan**: `plans/feat-chatpanel-drop-widen-1289.md`.

## Test plan

- [x] Existing Step 1 e2e tests pass unchanged (they dispatch bubbling DragEvents that reach the new panel-level listeners).
- [x] New e2e test "Step 2: dragging onto the chat-sidebar" — dispatches on the panel directly (above the input area), confirms the overlay appears, then asserts an unsupported-type drop at the panel level surfaces the same `file-error` banner the textarea path uses (proves App.vue routes through ChatInput.readFile).
- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` no regressions
- [ ] Manual: drag a real file from Finder/Explorer over various parts of the chat sidebar (sessions list, thinking indicator, input) — overlay appears every time. Drop attaches the file.
- [ ] Manual: drag a real file, then RELEASE outside any panel — browser does NOT navigate to the file, conversation remains intact.
- [ ] Manual stack mode: same flow on the canvas column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Widen the file drag-and-drop zone from the chat input to the entire chat panel and add a window-level guard to prevent accidental browser navigation when drops miss the panel.

New Features:
- Introduce a reusable useFileDropZone composable that manages file drag state, panel-level drop handling, and a global window guard for file drags.
- Add a FileDropOverlay component to display a panel-wide visual cue during file drags in both single and stack chat layouts.

Enhancements:
- Route panel-level file drops through ChatInput's existing file validation and emit pipeline by exposing a readFile method and wiring it from App.vue.
- Adjust chat layout bindings so the sidebar and stack-mode canvas conditionally handle panel-wide drops without interfering with plugin-specific drag-and-drop behavior.

Documentation:
- Add a feature plan document describing the widened chat panel drop zone, window guard behavior, and acceptance criteria.

Tests:
- Extend e2e coverage to verify panel-wide drag-and-drop behavior and error handling while keeping existing Step 1 tests passing unchanged.