### PR TITLE
test(date): harden formatDateTime/formatShortDate with fixed epoch (CR follow-up #1316)

### DIFF
--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -35,20 +35,41 @@ describe("formatDate", () => {
   });
 });
 
+// Fixed instant for the test suite below. Using `Date.now()` would
+// make assertions non-deterministic — the test would pass on any
+// string-looking output regardless of whether the formatter pulled a
+// digit out of the actual input. With a frozen epoch we can also
+// assert that the day-of-month survives, so a future bug that
+// returns "Invalid Date" but still includes some digit gets caught.
+// (Sourcery review on PR #1316.)
+//
+// Day 10 is the only locale-independent numeric substring we can
+// rely on: the year is omitted from formatDateTime / formatShortDate
+// (month + day + time only), and the month abbreviation varies by
+// locale. Picking day-of-month >= 13 would also disambiguate from
+// the hour, but day 10 is fine here because the hour formatting
+// uses 12-hour AM/PM (max "12") which can collide with day 12 but
+// not day 10.
+const FIXED_INSTANT = new Date(Date.UTC(2026, 3, 10, 12, 0, 0));
+const FIXED_EPOCH = FIXED_INSTANT.getTime();
+
 describe("formatDateTime", () => {
-  it("returns a non-empty string from epoch ms", () => {
-    const out = formatDateTime(Date.now());
+  it("returns a non-empty string carrying the input's day-of-month", () => {
+    const out = formatDateTime(FIXED_EPOCH);
     assert.equal(typeof out, "string");
     assert.ok(out.length > 0);
-    assert.match(out, /\d/);
+    assert.match(out, /\b10\b/);
   });
 });
 
 describe("formatTime", () => {
-  it("returns a non-empty string from epoch ms", () => {
-    const out = formatTime(Date.now());
+  it("renders the hour from a fixed epoch", () => {
+    const out = formatTime(FIXED_EPOCH);
     assert.equal(typeof out, "string");
-    assert.match(out, /\d/);
+    // UTC 12:00 becomes the user's local clock hour; assert that
+    // SOME two-digit hour appears (locale-independent) and a digit
+    // pair separator that looks like time.
+    assert.match(out, /\d{1,2}/);
   });
 });
 
@@ -67,20 +88,16 @@ describe("formatShortTime", () => {
 });
 
 describe("formatShortDate", () => {
-  it("returns a short date from epoch ms", () => {
-    const out = formatShortDate(Date.now());
+  it("renders a short date carrying the day-of-month from a fixed epoch", () => {
+    const out = formatShortDate(FIXED_EPOCH);
     assert.equal(typeof out, "string");
-    assert.match(out, /\d/);
+    assert.match(out, /\b10\b/);
   });
 });
 
 describe("formatMonthYear", () => {
-  // Fixed instant — using `Date.now()` would make the suite
-  // non-deterministic (Sourcery #1316). The exact picked instant
-  // doesn't matter, only that all three input shapes below address
-  // the same moment so the equivalence assertion is meaningful.
-  const FIXED_INSTANT = new Date(Date.UTC(2026, 3, 10, 12, 0, 0));
-  const FIXED_EPOCH = FIXED_INSTANT.getTime();
+  // `FIXED_INSTANT` / `FIXED_EPOCH` come from the top of this file;
+  // `FIXED_ISO` is only needed here so it stays local.
   const FIXED_ISO = FIXED_INSTANT.toISOString();
 
   it("returns a non-empty string from a Date", () => {

--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -46,26 +46,21 @@ describe("formatDate", () => {
 // assert that the day-of-month survives, so a future bug that
 // returns "Invalid Date" but still includes some digit gets caught.
 // (Sourcery review on PR #1316.)
-//
-// Day 10 is the only locale-independent numeric substring we can
-// rely on: the year is omitted from formatDateTime / formatShortDate
-// (month + day + time only), and the month abbreviation varies by
-// locale. Picking day-of-month >= 13 would also disambiguate from
-// the hour, but day 10 is fine here because the hour formatting
-// uses 12-hour AM/PM (max "12") which can collide with day 12 but
-// not day 10.
 const FIXED_INSTANT = new Date(Date.UTC(2026, 3, 10, 12, 0, 0));
 const FIXED_EPOCH = FIXED_INSTANT.getTime();
 
-// "10" rendered in whatever numerals the host's default locale uses.
-// `toLocaleString(undefined, ...)` inside the formatter pulls from
-// the same default, so `Intl.NumberFormat()` here produces the
-// matching glyphs — `"10"` on ASCII hosts, `"١٠"` on `ar-EG`,
-// `"१०"` on `hi-IN`, etc. The substring assertion below stays
-// correct under any default locale. `\b10\b` (the previous form)
-// was ASCII-only and would false-fail on non-Latin-numeral hosts
-// (Codex review on #1338).
-const TEN_IN_DEFAULT_LOCALE = new Intl.NumberFormat(undefined, { useGrouping: false }).format(10);
+// Day-of-month for `FIXED_INSTANT` as the formatter would render it
+// on THIS host. Both axes of variation collapse into one call:
+//   - **Numeral system** follows the host's default locale (`"10"`
+//     on ASCII hosts, `"١٠"` on `ar-EG`, `"१०"` on `hi-IN`, etc.).
+//   - **Timezone** is the host's default — important because
+//     `2026-04-10T12:00:00Z` is April 11 locally in UTC+13/+14 zones,
+//     so hard-coding `"10"` would fail in those zones even with
+//     correct formatter output (Codex review iter-2 on #1338).
+// `formatDateTime` / `formatShortDate` use the same `undefined`
+// locale + timezone defaults, so the substring assertion below
+// always finds a match when the formatter is healthy.
+const EXPECTED_DAY_OF_MONTH = new Intl.DateTimeFormat(undefined, { day: "numeric" }).format(FIXED_INSTANT);
 
 // Locale-independent time-shape pattern: 1-2 Unicode digits, a
 // common time separator (`:` typical, some locales use `.` or
@@ -78,7 +73,7 @@ describe("formatDateTime", () => {
     const out = formatDateTime(FIXED_EPOCH);
     assert.equal(typeof out, "string");
     assert.ok(out.length > 0);
-    assert.ok(out.includes(TEN_IN_DEFAULT_LOCALE), `expected "${TEN_IN_DEFAULT_LOCALE}" in ${out}`);
+    assert.ok(out.includes(EXPECTED_DAY_OF_MONTH), `expected "${EXPECTED_DAY_OF_MONTH}" in ${out}`);
   });
 });
 
@@ -114,7 +109,7 @@ describe("formatShortDate", () => {
   it("renders a short date carrying the day-of-month from a fixed epoch", () => {
     const out = formatShortDate(FIXED_EPOCH);
     assert.equal(typeof out, "string");
-    assert.ok(out.includes(TEN_IN_DEFAULT_LOCALE), `expected "${TEN_IN_DEFAULT_LOCALE}" in ${out}`);
+    assert.ok(out.includes(EXPECTED_DAY_OF_MONTH), `expected "${EXPECTED_DAY_OF_MONTH}" in ${out}`);
   });
 });
 

--- a/test/utils/format/test_date.ts
+++ b/test/utils/format/test_date.ts
@@ -11,7 +11,11 @@ describe("formatDate", () => {
 
   it("contains digits (some form of time/day)", () => {
     const out = formatDate("2026-04-10T07:21:39.125Z");
-    assert.match(out, /\d/);
+    // `\p{N}` matches any Unicode digit so this stays correct on
+    // hosts that emit non-ASCII numerals (Arabic-Indic `١`,
+    // Devanagari `१`, etc.). `\d` would be `[0-9]` only and
+    // false-fail there. (Codex review on #1338.)
+    assert.match(out, /\p{N}/u);
   });
 
   it("does not throw for an unparseable input", () => {
@@ -53,23 +57,42 @@ describe("formatDate", () => {
 const FIXED_INSTANT = new Date(Date.UTC(2026, 3, 10, 12, 0, 0));
 const FIXED_EPOCH = FIXED_INSTANT.getTime();
 
+// "10" rendered in whatever numerals the host's default locale uses.
+// `toLocaleString(undefined, ...)` inside the formatter pulls from
+// the same default, so `Intl.NumberFormat()` here produces the
+// matching glyphs — `"10"` on ASCII hosts, `"١٠"` on `ar-EG`,
+// `"१०"` on `hi-IN`, etc. The substring assertion below stays
+// correct under any default locale. `\b10\b` (the previous form)
+// was ASCII-only and would false-fail on non-Latin-numeral hosts
+// (Codex review on #1338).
+const TEN_IN_DEFAULT_LOCALE = new Intl.NumberFormat(undefined, { useGrouping: false }).format(10);
+
+// Locale-independent time-shape pattern: 1-2 Unicode digits, a
+// common time separator (`:` typical, some locales use `.` or
+// space), 2 more digits. `\p{N}` covers any numeric script so the
+// pattern matches `12:00`, `١٢:٠٠`, `१२.००`, etc.
+const TIME_PATTERN = /\p{N}{1,2}[:.\s]\p{N}{2}/u;
+
 describe("formatDateTime", () => {
   it("returns a non-empty string carrying the input's day-of-month", () => {
     const out = formatDateTime(FIXED_EPOCH);
     assert.equal(typeof out, "string");
     assert.ok(out.length > 0);
-    assert.match(out, /\b10\b/);
+    assert.ok(out.includes(TEN_IN_DEFAULT_LOCALE), `expected "${TEN_IN_DEFAULT_LOCALE}" in ${out}`);
   });
 });
 
 describe("formatTime", () => {
-  it("renders the hour from a fixed epoch", () => {
+  it("renders an hour:minute-shaped value from a fixed epoch", () => {
     const out = formatTime(FIXED_EPOCH);
     assert.equal(typeof out, "string");
-    // UTC 12:00 becomes the user's local clock hour; assert that
-    // SOME two-digit hour appears (locale-independent) and a digit
-    // pair separator that looks like time.
-    assert.match(out, /\d{1,2}/);
+    assert.ok(out.length > 0);
+    // Tightened from the original `/\d{1,2}/` which would pass for
+    // any string containing digits (e.g. a bare day number or just
+    // minutes). The locale-independent time-shape pattern asserts
+    // we got an actual HH:MM-style segment. (Codex + Sourcery
+    // reviews on #1338.)
+    assert.match(out, TIME_PATTERN);
   });
 });
 
@@ -77,7 +100,7 @@ describe("formatShortTime", () => {
   it("returns a short time from ISO string", () => {
     const out = formatShortTime("2026-04-10T07:21:39.125Z");
     assert.equal(typeof out, "string");
-    assert.match(out, /\d/);
+    assert.match(out, /\p{N}/u);
   });
 
   it("falls back to raw string on parse error", () => {
@@ -91,7 +114,7 @@ describe("formatShortDate", () => {
   it("renders a short date carrying the day-of-month from a fixed epoch", () => {
     const out = formatShortDate(FIXED_EPOCH);
     assert.equal(typeof out, "string");
-    assert.match(out, /\b10\b/);
+    assert.ok(out.includes(TEN_IN_DEFAULT_LOCALE), `expected "${TEN_IN_DEFAULT_LOCALE}" in ${out}`);
   });
 });
 


### PR DESCRIPTION
## Summary

Sourcery review on #1316 pointed out that the `formatDateTime` and `formatShortDate` tests were calling `Date.now()` and only asserting `typeof === "string"` + `.length > 0`. That passes for any string-shaped output regardless of whether the formatter actually pulled a digit out of the input — a regression that returned `"Invalid Date"` or an empty wrapper would still pass.

Replaced `Date.now()` with a fixed UTC instant (`2026-04-10T12:00:00Z`) and added a structural assertion on day-of-month.

## Items to Confirm / Review

- Day-of-month (`10`) is the only locale-independent numeric substring these two formatters retain. The year is **omitted** by design (`Apr 10, 09:00 PM` style), and the month abbreviation is locale-dependent. The earlier draft of this fix asserted `/2026/` and failed in CI for that reason — fix corrected before pushing.
- `formatTime` already uses `FIXED_EPOCH` and is fine; assertion is `/\d{1,2}/` (locale-independent hour digits).
- `formatMonthYear` block's local `FIXED_ISO` derives from the new top-level `FIXED_INSTANT`; no duplication.

## User Prompt

`/pr-quality-sweep 96時間みて。`, then `openのものはしなくてよい。それ以外のマージ済みで、planファイル以外は全て。` — directing the sweep to address all merged-PR follow-ups except plan files. This branch addresses the last remaining Sourcery finding from #1316.

## Test Plan

- [x] `yarn test` passes (formatDateTime + formatShortDate both green)
- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden date/time formatting tests by using a fixed UTC instant and asserting on stable, locale-independent output.

Tests:
- Introduce a shared fixed UTC instant/epoch for date/time formatter tests to avoid non-deterministic assertions.
- Strengthen formatDateTime and formatShortDate tests to verify the day-of-month survives formatting instead of only checking for non-empty strings.
- Update formatTime tests to use the fixed epoch and assert that an hour digit sequence is present.
- Reuse the shared fixed instant in formatMonthYear tests to avoid duplicate setup while keeping ISO-specific helpers local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made date/time tests deterministic by using shared fixed-time fixtures and removing duplicate setup.
  * Strengthened assertions so formatted dates include the expected day-of-month and time outputs match a locale-agnostic HH:MM pattern.
  * Broadened numeric checks to match Unicode digits for improved locale compatibility.
  * Reused top-level fixtures for month/year tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1338)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->