### PR TITLE
fix: address codex + sourcery review on Settings reorg (#1337 follow-up)

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="open" class="fixed inset-0 z-50 bg-black/40 flex items-start justify-center pt-16" data-testid="settings-modal-backdrop" @click="close">
     <div
-      class="bg-white rounded-lg shadow-xl w-[52rem] max-h-[85vh] flex flex-col"
+      class="bg-white rounded-lg shadow-xl w-[52rem] max-w-[95vw] max-h-[85vh] flex flex-col"
       role="dialog"
       aria-modal="true"
       aria-labelledby="settings-modal-title"
@@ -16,7 +16,7 @@
       </div>
 
       <div class="flex flex-1 min-h-0">
-        <nav class="w-44 border-r border-gray-200 bg-gray-50 py-3 overflow-y-auto" aria-label="Settings sections" data-testid="settings-nav">
+        <nav class="w-44 border-r border-gray-200 bg-gray-50 py-3 overflow-y-auto" :aria-label="t('settingsModal.navAriaLabel')" data-testid="settings-nav">
           <div v-for="group in visibleGroups" :key="group.key" class="mb-3">
             <div class="px-4 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
               {{ t(`settingsModal.groups.${group.key}`) }}
@@ -27,6 +27,7 @@
               class="w-full text-left px-4 py-1.5 text-sm border-l-2"
               :class="activeTab === tabId ? 'border-blue-500 bg-white text-blue-700 font-medium' : 'border-transparent text-gray-700 hover:bg-gray-100'"
               :data-testid="`settings-tab-${tabId}`"
+              :aria-current="activeTab === tabId ? 'page' : undefined"
               @click="activeTab = tabId"
             >
               {{ t(`settingsModal.tabs.${tabId}`) }}

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -157,6 +157,7 @@ const deMessages = {
       workspace: "Arbeitsbereich",
       plugins: "Plugins",
     },
+    navAriaLabel: "Einstellungsbereiche",
     mapTab: {
       description:
         "Legt den Google-Maps-API-Schlüssel fest, den das Karten-Plugin verwendet. Der Schlüssel wird lokal gespeichert und nur an Google Maps gesendet.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -177,6 +177,7 @@ const enMessages = {
       workspace: "Workspace",
       plugins: "Plugins",
     },
+    navAriaLabel: "Settings sections",
     mapTab: {
       description: "Set the Google Maps API key used by the map plugin. The key is stored locally and never transmitted anywhere except to Google Maps.",
       apiKeyLabel: "Google Maps API key",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -161,6 +161,7 @@ const esMessages = {
       workspace: "Espacio de trabajo",
       plugins: "Plugins",
     },
+    navAriaLabel: "Secciones de ajustes",
     mapTab: {
       description: "Configura la clave de la API de Google Maps que usa el plugin de mapas. La clave se guarda localmente y solo se envía a Google Maps.",
       apiKeyLabel: "Clave API de Google Maps",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -156,6 +156,7 @@ const frMessages = {
       workspace: "Espace de travail",
       plugins: "Plugins",
     },
+    navAriaLabel: "Sections des paramètres",
     mapTab: {
       description: "Définit la clé API Google Maps utilisée par le plugin de carte. La clé est stockée localement et n'est envoyée qu'à Google Maps.",
       apiKeyLabel: "Clé API Google Maps",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -161,6 +161,7 @@ const jaMessages = {
       workspace: "ワークスペース",
       plugins: "プラグイン",
     },
+    navAriaLabel: "設定セクション",
     mapTab: {
       description: "地図プラグインで使う Google Maps API キーを設定します。キーはローカルに保存され、Google Maps への通信以外で送信されることはありません。",
       apiKeyLabel: "Google Maps API キー",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -163,6 +163,7 @@ const koMessages = {
       workspace: "워크스페이스",
       plugins: "플러그인",
     },
+    navAriaLabel: "설정 섹션",
     mapTab: {
       description: "지도 플러그인에서 사용하는 Google Maps API 키를 설정합니다. 키는 로컬에 저장되며 Google Maps 외부로는 전송되지 않습니다.",
       apiKeyLabel: "Google Maps API 키",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -156,6 +156,7 @@ const ptBRMessages = {
       workspace: "Espaço de trabalho",
       plugins: "Plugins",
     },
+    navAriaLabel: "Seções de configurações",
     mapTab: {
       description: "Define a chave da API do Google Maps usada pelo plugin de mapa. A chave fica salva localmente e só é enviada para o Google Maps.",
       apiKeyLabel: "Chave API do Google Maps",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -159,6 +159,7 @@ const zhMessages = {
       workspace: "工作区",
       plugins: "插件",
     },
+    navAriaLabel: "设置分区",
     mapTab: {
       description: "设置地图插件使用的 Google Maps API 密钥。密钥仅存储在本地,除发送到 Google Maps 外不会传输到任何地方。",
       apiKeyLabel: "Google Maps API 密钥",


### PR DESCRIPTION
## Summary

Follow-up to merged #1337 — three bot-review items not addressed pre-merge.

- **a11y/i18n**: sidebar nav `aria-label` is now translated via `settingsModal.navAriaLabel` in all 8 locales (codex). Screen-reader users on non-English locales no longer hear mixed-language UI.
- **a11y**: active sidebar item now has `aria-current="page"` so assistive tech reflects selected state, not just visual styling (sourcery).
- **responsive**: modal grows up to `52rem` but caps at `95vw` so it doesn't overflow on smaller viewports (sourcery).

## Items to Confirm / Review

- All three are mechanical / additive. No behavior change for visual users; just adds proper a11y semantics and a viewport-relative max.
- `navAriaLabel` translations are best-effort. Please skim if a native speaker is available; the values are not surfaced visually so the bar for correctness is "screen reader friendly", not "marketing copy".

## Skipped from the same review

- `role="tablist"`/`role="tab"` on the sidebar: this is a navigation menu, not a strict tablist (groups + headings break the tab pattern). `aria-current` is the canonical fit for nav, and both bots actually converge on it inline.
- Tighten `GROUPS` key typing to a string-literal union: 4 values, low churn. Skipped as overengineering.

## User Prompt

> mergeしたけどコメント読んで必要ならべつPRで。

## Test plan

- [ ] `yarn typecheck` / `yarn lint` — clean
- [ ] Open Settings on a wide viewport — modal at 52rem, sidebar visible
- [ ] Resize browser to 800px wide — modal caps at ~760px, no horizontal scroll
- [ ] Inspect the active sidebar button — confirm `aria-current="page"` attribute
- [ ] Switch UI locale (e.g. to ja) — `<nav>`'s `aria-label` reads "設定セクション"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve accessibility and responsiveness of the Settings modal navigation.

New Features:
- Translate the Settings sidebar navigation aria-label across all supported locales via a new navAriaLabel string.
- Expose aria-current="page" on the active Settings sidebar tab to reflect selection state for assistive technologies.

Enhancements:
- Constrain the Settings modal width with a viewport-relative max to prevent overflow on smaller screens.