### PR TITLE
fix(runtime-plugin): bypass bearer auth for HEAD probes on plugin assets

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -210,7 +210,16 @@ app.use("/api", (req, res, next) => {
     next();
     return;
   }
-  if (req.method === "GET" && RUNTIME_PLUGIN_ASSET_PATH_RE.test(req.path)) {
+  if ((req.method === "GET" || req.method === "HEAD") && RUNTIME_PLUGIN_ASSET_PATH_RE.test(req.path)) {
+    // HEAD is bypassed for the same reason as GET: the frontend
+    // runtime-plugin loader HEAD-probes `dist/vue.js` to distinguish
+    // "no Vue bundle (404, server-only plugin)" from real load
+    // failures before `import()`-ing the asset (#1273 follow-up).
+    // That probe is a raw `fetch`, not the bearer-attaching `apiGet`,
+    // and the actual `import()` itself can't attach Authorization
+    // either — so the auth-bypass must cover both verbs or every
+    // runtime plugin's Vue View silently downgrades to a
+    // definition-only entry (401 → "unexpected status" → no view).
     next();
     return;
   }


### PR DESCRIPTION
## Summary

- The frontend runtime-plugin loader does a `HEAD` probe against `dist/vue.js` to distinguish *"no Vue bundle (404, server-only plugin)"* from real load failures (added in PR #1273 follow-up). The server's bearer-auth bypass for asset paths only matched `GET`, so every probe came back **401**, the loader logged "unexpected HEAD status" and bailed out, and every runtime plugin's Vue View silently downgraded to a definition-only entry (no `viewComponent`).
- Visible symptom: with `VITE_DEV_MODE=1`, clicking the **Debug** tab rendered the *"Debug plugin is not loaded"* fallback even though `@mulmoclaude/debug-plugin` was registered server-side and listed by `/api/plugins/runtime/list`. The same downgrade applied to every other runtime plugin's Vue View; debug is just the one surface that reads `getPlugin(toolName)?.viewComponent` directly.
- Fix: extend the bypass to allow `HEAD` alongside `GET` on the runtime-plugin asset path. `HEAD` is semantically `GET`-without-body, and the bypass rationale (`<script>` / `<link>` / `import()` can't attach `Authorization`) applies identically to the loader's `fetch(url, { method: "HEAD" })`.

## Reproduction (before fix)

```
$ curl -s -I 'http://127.0.0.1:3001/api/plugins/runtime/%40mulmoclaude%2Fdebug-plugin/0.2.0/dist/vue.js'
HTTP/1.1 401 Unauthorized

$ curl -s -o /dev/null -w '%{http_code}\n' 'http://127.0.0.1:3001/api/plugins/runtime/%40mulmoclaude%2Fdebug-plugin/0.2.0/dist/vue.js'
200
```

After the fix, both `HEAD` and `GET` return `200`, and the Debug page renders.

## When this broke

Commit `9a47ef3e` (2026-05-10) — *"fix(runtime-plugin): tighten loader catch — distinguish 404 from real bugs"* added the `HEAD` probe. The matching server-side auth bypass wasn't updated to accept `HEAD`.

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean
- [x] `yarn test` — 45 / 45 pass
- [x] `yarn build` — succeeds
- [x] Manual: with `VITE_DEV_MODE=1` and `yarn dev` running, click the Debug tab and confirm the plugin View renders instead of the "Debug plugin is not loaded" fallback.
- [x] Manual: `curl -I` against the asset path now returns 200 (was 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix runtime plugin Vue views failing to load by ensuring HEAD probes to dist/vue.js are not blocked by auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime plugin asset request handling by enabling proper request processing for additional HTTP methods alongside existing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->