### PR TITLE
test(e2e-live): L-15b — #1194 wiki fuzzy resolver collision repro

### DIFF
--- a/e2e-live/tests/wiki-nav.spec.ts
+++ b/e2e-live/tests/wiki-nav.spec.ts
@@ -178,7 +178,14 @@ test.describe("wiki navigation (real workspace)", () => {
     //       server to resolve the same colliding slug, so both must
     //       land on the target page.
     const projectSlug = testInfo.project.name;
-    const nonce = `${Date.now()}-${randomUUID().slice(0, 6)}`;
+    // `testInfo.title` を nonce に織り込む (Sourcery review #1347)。
+    // 失敗時に `data/wiki/pages/` に残った slug ファイルを見ただけ
+    // で「どのテストが書いた fixture か」が分かるため、parallel
+    // 実行中の triage と stale 検出が楽になる。`.split(":")[0]` で
+    // テスト名先頭の short id (例: "L-15b") だけ取り出して slug に
+    // 安全な ASCII プレフィックスに揃える。
+    const testLabel = testInfo.title.split(":")[0].trim();
+    const nonce = `${testLabel}-${Date.now()}-${randomUUID().slice(0, 6)}`;
     const targetSlug = `日本語タイトル-${projectSlug}-${nonce}`;
     const sourceSlug = `e2e-live-l15b-source-${projectSlug}-${nonce}`;
     const targetMarker = `L-15b target body marker ${nonce}`;
@@ -195,35 +202,47 @@ test.describe("wiki navigation (real workspace)", () => {
       await placeWikiPage(sourceSlug, [`# L-15b source`, ``, sourceMarker, ``, `[[${targetSlug}]]`, ``].join("\n"));
       await placeWikiPage(targetSlug, [`# 日本語タイトル`, ``, targetMarker, ``].join("\n"));
 
-      // (A) Direct URL navigation.
-      await navigateToWikiPage(page, targetSlug);
-      await expect(page.getByTestId("wiki-page-body"), "target page body must render (positive assertion)").toContainText(targetMarker);
-      // Negative assertion = #1194 regression sentinel. If the
-      // fuzzy resolver ever silently picks the source page again,
-      // this is the line that fails.
-      await expect(
-        page.getByTestId("wiki-page-body"),
-        "source marker must NOT appear — would indicate #1194 regression (fuzzy resolver returned colliding page)",
-      ).not.toContainText(sourceMarker);
-      await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
-      // Negative guard mirroring L-14 / L-15 — catch-all router
-      // must not swallow non-ASCII page slugs (B-24 shape).
-      await expect(page).not.toHaveURL(/\/chat/);
+      // Each route is wrapped in `test.step` so the Playwright
+      // trace viewer renders (A) and (B) as separate, named nodes
+      // and CI failures attribute to the correct route without
+      // hunting through a flat assertion log (Sourcery review
+      // #1347). The four assertions inside each step are
+      // intentionally duplicated rather than extracted into a
+      // helper — collision repro semantics differ subtly between
+      // routes (e.g. the "click into a colliding wikilink" shape
+      // is route-(B)-only), and a helper would obscure that.
+      await test.step("(A) direct URL navigation to target slug", async () => {
+        await navigateToWikiPage(page, targetSlug);
+        await expect(page.getByTestId("wiki-page-body"), "target page body must render (positive assertion)").toContainText(targetMarker);
+        // Negative assertion = #1194 regression sentinel. If the
+        // fuzzy resolver ever silently picks the source page again,
+        // this is the line that fails.
+        await expect(
+          page.getByTestId("wiki-page-body"),
+          "source marker must NOT appear — would indicate #1194 regression (fuzzy resolver returned colliding page)",
+        ).not.toContainText(sourceMarker);
+        await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
+        // Negative guard mirroring L-14 / L-15 — catch-all router
+        // must not swallow non-ASCII page slugs (B-24 shape).
+        await expect(page).not.toHaveURL(/\/chat/);
+      });
 
-      // (B) Wikilink click. The [[ ]] → router-push pipeline hands
-      // the raw non-ASCII slug to the same server resolver, so the
-      // collision condition applies here too. If the resolver ever
-      // returns the source page, the click bounces back to its own
-      // page and the target marker never appears.
-      await navigateToWikiPage(page, sourceSlug);
-      await page.locator(`.wiki-link[data-page="${targetSlug}"]`).first().click();
-      await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
-      await expect(page.getByTestId("wiki-page-body"), "target page body must render after wikilink click").toContainText(targetMarker);
-      await expect(
-        page.getByTestId("wiki-page-body"),
-        "source marker must NOT appear after wikilink click — would indicate #1194 regression",
-      ).not.toContainText(sourceMarker);
-      await expect(page).not.toHaveURL(/\/chat/);
+      await test.step("(B) wikilink click from source page → target", async () => {
+        // The [[ ]] → router-push pipeline hands the raw non-ASCII
+        // slug to the same server resolver, so the collision
+        // condition applies here too. If the resolver ever returns
+        // the source page, the click bounces back to its own page
+        // and the target marker never appears.
+        await navigateToWikiPage(page, sourceSlug);
+        await page.locator(`.wiki-link[data-page="${targetSlug}"]`).first().click();
+        await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
+        await expect(page.getByTestId("wiki-page-body"), "target page body must render after wikilink click").toContainText(targetMarker);
+        await expect(
+          page.getByTestId("wiki-page-body"),
+          "source marker must NOT appear after wikilink click — would indicate #1194 regression",
+        ).not.toContainText(sourceMarker);
+        await expect(page).not.toHaveURL(/\/chat/);
+      });
     } finally {
       await removeWikiPage(sourceSlug);
       await removeWikiPage(targetSlug);

--- a/e2e-live/tests/wiki-nav.spec.ts
+++ b/e2e-live/tests/wiki-nav.spec.ts
@@ -167,6 +167,16 @@ test.describe("wiki navigation (real workspace)", () => {
     // the load-bearing one: it fails loudly if the resolver ever
     // returns the source page again, which is the exact regression
     // shape we're protecting against.
+    //
+    // Two routes are exercised, mirroring L-15's shape:
+    //   (A) Direct URL navigation — hits resolvePagePath via the
+    //       /api/wiki request triggered by the wiki route guard.
+    //   (B) Wikilink click in the source page — `[[targetSlug]]`
+    //       renders into a `.wiki-link[data-page]` span; clicking
+    //       hands the raw slug to the SPA router, which makes the
+    //       same /api/wiki request. Both routes ultimately ask the
+    //       server to resolve the same colliding slug, so both must
+    //       land on the target page.
     const projectSlug = testInfo.project.name;
     const nonce = `${Date.now()}-${randomUUID().slice(0, 6)}`;
     const targetSlug = `日本語タイトル-${projectSlug}-${nonce}`;
@@ -179,9 +189,13 @@ test.describe("wiki navigation (real workspace)", () => {
       // source page being readdir-first when both keys partial-
       // matched. The new resolver is order-independent, so this
       // ordering is documentation, not a load-bearing setup step.
-      await placeWikiPage(sourceSlug, [`# L-15b source`, ``, sourceMarker, ``].join("\n"));
+      // Source body carries the unique sourceMarker (for the
+      // negative assertion) plus a `[[targetSlug]]` wikilink so
+      // route (B) below has something to click.
+      await placeWikiPage(sourceSlug, [`# L-15b source`, ``, sourceMarker, ``, `[[${targetSlug}]]`, ``].join("\n"));
       await placeWikiPage(targetSlug, [`# 日本語タイトル`, ``, targetMarker, ``].join("\n"));
 
+      // (A) Direct URL navigation.
       await navigateToWikiPage(page, targetSlug);
       await expect(page.getByTestId("wiki-page-body"), "target page body must render (positive assertion)").toContainText(targetMarker);
       // Negative assertion = #1194 regression sentinel. If the
@@ -194,6 +208,21 @@ test.describe("wiki navigation (real workspace)", () => {
       await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
       // Negative guard mirroring L-14 / L-15 — catch-all router
       // must not swallow non-ASCII page slugs (B-24 shape).
+      await expect(page).not.toHaveURL(/\/chat/);
+
+      // (B) Wikilink click. The [[ ]] → router-push pipeline hands
+      // the raw non-ASCII slug to the same server resolver, so the
+      // collision condition applies here too. If the resolver ever
+      // returns the source page, the click bounces back to its own
+      // page and the target marker never appears.
+      await navigateToWikiPage(page, sourceSlug);
+      await page.locator(`.wiki-link[data-page="${targetSlug}"]`).first().click();
+      await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
+      await expect(page.getByTestId("wiki-page-body"), "target page body must render after wikilink click").toContainText(targetMarker);
+      await expect(
+        page.getByTestId("wiki-page-body"),
+        "source marker must NOT appear after wikilink click — would indicate #1194 regression",
+      ).not.toContainText(sourceMarker);
       await expect(page).not.toHaveURL(/\/chat/);
     } finally {
       await removeWikiPage(sourceSlug);

--- a/e2e-live/tests/wiki-nav.spec.ts
+++ b/e2e-live/tests/wiki-nav.spec.ts
@@ -7,6 +7,7 @@ import { navigateToWikiIndex, navigateToWikiPage, placeWikiPage, removeWikiPage,
 
 const L14_TIMEOUT_MS = ONE_MINUTE_MS;
 const L15_TIMEOUT_MS = ONE_MINUTE_MS;
+const L15B_TIMEOUT_MS = ONE_MINUTE_MS;
 const L16_TIMEOUT_MS = ONE_MINUTE_MS;
 
 // L-14 / L-15 each seed their own pair of wiki pages and never
@@ -130,6 +131,68 @@ test.describe("wiki navigation (real workspace)", () => {
       await page.locator(`.wiki-link[data-page="${targetSlug}"]`).first().click();
       await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
       await expect(page.getByTestId("wiki-page-body")).toContainText(targetMarker);
+      await expect(page).not.toHaveURL(/\/chat/);
+    } finally {
+      await removeWikiPage(sourceSlug);
+      await removeWikiPage(targetSlug);
+    }
+  });
+
+  test("L-15b: 非 ASCII slug fuzzy resolve が衝突候補から正しい target を決定的に選ぶ (#1194)", async ({ page }, testInfo) => {
+    test.setTimeout(L15B_TIMEOUT_MS);
+    // End-to-end repro of the #1194 collision condition. L-15 keeps
+    // a `nonascii-target` token in the target slug as a redundancy
+    // belt; this spec strips that belt off and exercises the
+    // resolver under the exact shape the original bug needed:
+    //
+    //   target slug = `日本語タイトル-${projectSlug}-${nonce}`
+    //   source slug = `e2e-live-l15b-source-${projectSlug}-${nonce}`
+    //
+    // wikiSlugify(target) drops the Japanese chars → leaves a tail
+    // like `-${projectSlug}-${nonce}`. That tail is a substring of
+    // BOTH on-disk filenames, so the resolver's fuzzy fallback has
+    // two equally-includes-eligible candidates. Pre-#1319, the
+    // fuzzy loop returned whichever key Map iteration (= readdir
+    // order, = creation order) surfaced first — typically the
+    // source page, since we seed it first below — and the SPA
+    // silently rendered the wrong page. Post-#1319 `pickFuzzyMatch`
+    // scores `min/max` of slug-vs-key lengths; the target key (≈
+    // Japanese 7 chars + shared suffix) is closer in length to the
+    // slug than the source key (≈ "e2e-live-l15b-source-" 21 chars
+    // + shared suffix), so target wins deterministically regardless
+    // of seed order.
+    //
+    // The negative `not.toContainText(sourceMarker)` assertion is
+    // the load-bearing one: it fails loudly if the resolver ever
+    // returns the source page again, which is the exact regression
+    // shape we're protecting against.
+    const projectSlug = testInfo.project.name;
+    const nonce = `${Date.now()}-${randomUUID().slice(0, 6)}`;
+    const targetSlug = `日本語タイトル-${projectSlug}-${nonce}`;
+    const sourceSlug = `e2e-live-l15b-source-${projectSlug}-${nonce}`;
+    const targetMarker = `L-15b target body marker ${nonce}`;
+    const sourceMarker = `L-15b source body marker ${nonce}`;
+    const encodedTargetSlug = encodeURIComponent(targetSlug);
+    try {
+      // Seed source first — the original bug's repro relied on the
+      // source page being readdir-first when both keys partial-
+      // matched. The new resolver is order-independent, so this
+      // ordering is documentation, not a load-bearing setup step.
+      await placeWikiPage(sourceSlug, [`# L-15b source`, ``, sourceMarker, ``].join("\n"));
+      await placeWikiPage(targetSlug, [`# 日本語タイトル`, ``, targetMarker, ``].join("\n"));
+
+      await navigateToWikiPage(page, targetSlug);
+      await expect(page.getByTestId("wiki-page-body"), "target page body must render (positive assertion)").toContainText(targetMarker);
+      // Negative assertion = #1194 regression sentinel. If the
+      // fuzzy resolver ever silently picks the source page again,
+      // this is the line that fails.
+      await expect(
+        page.getByTestId("wiki-page-body"),
+        "source marker must NOT appear — would indicate #1194 regression (fuzzy resolver returned colliding page)",
+      ).not.toContainText(sourceMarker);
+      await expect(page).toHaveURL(new RegExp(`/wiki/pages/${encodedTargetSlug}$`));
+      // Negative guard mirroring L-14 / L-15 — catch-all router
+      // must not swallow non-ASCII page slugs (B-24 shape).
       await expect(page).not.toHaveURL(/\/chat/);
     } finally {
       await removeWikiPage(sourceSlug);

--- a/e2e-live/tests/wiki-nav.spec.ts
+++ b/e2e-live/tests/wiki-nav.spec.ts
@@ -7,7 +7,6 @@ import { navigateToWikiIndex, navigateToWikiPage, placeWikiPage, removeWikiPage,
 
 const L14_TIMEOUT_MS = ONE_MINUTE_MS;
 const L15_TIMEOUT_MS = ONE_MINUTE_MS;
-const L15B_TIMEOUT_MS = ONE_MINUTE_MS;
 const L16_TIMEOUT_MS = ONE_MINUTE_MS;
 
 // L-14 / L-15 each seed their own pair of wiki pages and never
@@ -139,7 +138,9 @@ test.describe("wiki navigation (real workspace)", () => {
   });
 
   test("L-15b: 非 ASCII slug fuzzy resolve が衝突候補から正しい target を決定的に選ぶ (#1194)", async ({ page }, testInfo) => {
-    test.setTimeout(L15B_TIMEOUT_MS);
+    // L-15 と同じ shape のテストなので timeout 定数も共用 (plan
+    // file の方針)。
+    test.setTimeout(L15_TIMEOUT_MS);
     // End-to-end repro of the #1194 collision condition. L-15 keeps
     // a `nonascii-target` token in the target slug as a redundancy
     // belt; this spec strips that belt off and exercises the

--- a/plans/survey-e2e-live-test-step-and-nonce.md
+++ b/plans/survey-e2e-live-test-step-and-nonce.md
@@ -1,0 +1,62 @@
+# e2e-live: `test.step` + `testInfo.title` nonce 横展開の要調査
+
+## 動機
+
+PR [#1347](https://github.com/receptron/mulmoclaude/pull/1347) (L-15b 追加) の Sourcery review で以下 2 点が指摘され、L-15b には適用済み:
+
+1. **`test.step` で route ごとにブロック化** — Playwright trace viewer / report に route 単位の独立ノードができ、CI 失敗時に「どのルート」で落ちたかの triage が容易になる
+2. **`testInfo.title` を nonce に織り込み** — `data/wiki/pages/` 等に取り残された fixture slug を見ただけで「どのテストが書いたファイルか」が分かる。parallel 実行中の stale 検出と correlation が楽になる
+
+これらは L-15b 固有の改善ではなく、**e2e-live スイート全般に効く改善**。他テストへの横展開を検討する。
+
+## 調査対象
+
+`e2e-live/tests/` 配下の全 spec:
+
+- `media.spec.ts`
+- `mulmo-script-edit.spec.ts`
+- `roles.spec.ts`
+- `session.spec.ts`
+- `skills.spec.ts`
+- `ui.spec.ts`
+- `wiki-nav.spec.ts` (L-15b は適用済み、L-14 / L-15 / L-16 が候補)
+- `wiki.spec.ts`
+- `workspace-link-routing.spec.ts`
+
+`e2e/tests/` (mock 系) も同様の構造を持つので追加調査の余地あり。ただし e2e-live の方が trace を実環境で読むケースが多いため優先度高。
+
+## 各 spec の見立て (要検証)
+
+| spec | route 数 | 重複量 | `test.step` 化の価値 | nonce 改善の価値 |
+|---|---|---|---|---|
+| `wiki-nav.spec.ts:L-14` | 1 | 小 | 低 | 中 (stale 識別) |
+| `wiki-nav.spec.ts:L-15` | 2 (A / B) | 中 | **高** (L-15b と同形) | 中 |
+| `wiki-nav.spec.ts:L-16` | 1 (index → click × 2) | 中 | 中 | 中 |
+| その他 spec | 要調査 | 要調査 | 要調査 | 要調査 |
+
+## 調査タスク
+
+1. 各 spec を読み、route / phase が複数ある test を列挙
+2. 「同じ assertion パターンが N 回繰り返されている」テストを洗い出す
+3. `test.step` 化したときの読みやすさ / trace 改善度合いを weigh
+4. nonce が `Date.now()` ベースのみのテストを列挙し、`testInfo.title` 化の cost を見積もる
+5. **`test.describe.serial` / `parallel` の境界を犯さないか確認** — `test.step` は同じテスト内で動くので問題なし。nonce 変更は slug 長を変えるので、fuzzy resolver 系テスト (wiki-nav.spec.ts) では collision math が変動しないか要確認 (L-15b では問題なしと確認済み)
+6. 1 PR にまとめるか per-spec で分割するか判断
+
+## 注意点
+
+- **L-15 を触る場合**: `nonascii-target` safety token は PR #1319 が「redundancy belt」として残す意図を明記しているため、`test.step` 化 + nonce 改善のみに留め、slug shape は変えない
+- **collision-sensitive な spec (L-15 / L-15b)**: nonce 長を変えると `pickFuzzyMatch` の length-ratio score が変動する。安全マージンは大きいが、 数字を plan / コメントに残しておく
+- **Skill-level な抽出は不採用方針**: `test.step` 内の assertion 列を helper にまとめる案も Sourcery が出していたが、L-15b では「route-(B) 固有の wikilink click は helper に乗らない」「assertion 列の意図を読者が追いやすい」理由で見送り。横展開でも同じ判断軸を維持する想定。helper 化するならテスト固有のドメインロジックを切り出さない汎用 wrapper (`expectWikiPageBody(target)` 等) に限る
+
+## 完了条件
+
+- 各 spec の見立て (test.step 化 / nonce 改善の要否) が一覧化されている
+- 横展開する PR の単位と順序が決まっている
+- L-15 (wiki-nav) の `test.step` 化は最優先候補として PR 化
+
+## 関連
+
+- PR #1347 (L-15b 追加 + Sourcery review)
+- Issue #1194 (元の wiki fuzzy resolver bug)
+- PR #1319 (fix)

--- a/plans/test-e2e-live-wiki-1194-collision.md
+++ b/plans/test-e2e-live-wiki-1194-collision.md
@@ -1,0 +1,67 @@
+# L-15b: #1194 衝突条件の end-to-end repro
+
+## 背景
+
+[#1194](https://github.com/receptron/mulmoclaude/issues/1194) は PR [#1319](https://github.com/receptron/mulmoclaude/pull/1319) で fix 済み (`server/api/routes/wiki.ts:pickFuzzyMatch`)。
+
+既存カバレッジ:
+
+- **Unit** — `test/routes/test_wikiResolveFuzzy.ts` (7 ケース、全ブランチ pin)。十分。
+- **e2e-live** — `e2e-live/tests/wiki-nav.spec.ts:72` の **L-15** が新 resolver 経路を通る。**ただし**、target slug に `nonascii-target` という unique token が入っているため、`-${projectSlug}-${nonce}` 共通 suffix を真に共有する状況にはなっていない。PR 本文も「load-bearing からは降りた redundancy belt」と明記している。
+
+## 不足
+
+「target slug と source slug が共通 suffix だけを共有し、wikiSlugify 後の slug が両 key に partial-match する」という #1194 オリジナルの衝突条件を end-to-end で再現する spec が無い。
+
+## 提案
+
+`e2e-live/tests/wiki-nav.spec.ts` に **L-15b** を追加。L-15 はそのまま残す (regression belt 兼 navigation 一般のカバー)。
+
+### 設計
+
+- target slug = `日本語タイトル-${projectSlug}-${nonce}` (unique token なし)
+- source slug = `e2e-live-l15b-source-${projectSlug}-${nonce}`
+- 共通 suffix: `-${projectSlug}-${nonce}` ← wikiSlugify(target) の出力そのもの
+- 両 key に対し `key.includes(slug)` が true になる
+
+### 期待される resolver 挙動 (`pickFuzzyMatch`)
+
+- `slug` (≈ `-chromium-...`) の長さ ≥ MIN_FUZZY_SLUG_LEN (6)
+- score(slug, target key) = `min/max` ≈ 0.8 (Japanese 7 字 + 共通 suffix)
+- score(slug, source key) = `min/max` ≈ 0.57 (`e2e-live-l15b-source-` 20 字 + 共通 suffix)
+- → target が高スコアで勝つ。決定的。
+
+### Seed 順
+
+source → target の順で seed (元 bug repro 時と同じ順)。readdir order に依存していた pre-#1319 挙動を再現する条件。
+
+### Assertion
+
+- `wiki-page-body` testid に **target marker** が含まれる (positive)
+- `wiki-page-body` に **source marker** が含まれない (negative — #1194 regression shape を直撃)
+- URL が `/wiki/pages/<encoded target>$` で終わる
+- URL が `/chat` 配下に流れていない (catch-all router B-24 系の負ガード、L-14/L-15 と shape を揃える)
+
+## 不採用案
+
+- **L-15 を改修 (`nonascii-target` 削除)** — PR #1319 が「safety belt として残す」と明言している意図を覆すため不採用。新規 spec で独立にカバーする方が clean。
+- **手動 QA のみ** — issue コメントが「QA を」だが、自動回帰がないと将来の readdir 挙動変更で silent 再発する。
+
+## 実装スコープ
+
+- 1 ファイル: `e2e-live/tests/wiki-nav.spec.ts` に test ブロック追加のみ
+- timeout: 既存 `L15_TIMEOUT_MS = ONE_MINUTE_MS` を流用 (L15B 用に別定数を切る必要なし、同じ shape のテスト)
+- import 追加なし (L-15 と同じヘルパで完結)
+
+## 注意点 / Items to Confirm
+
+- **Seed 順序依存ではない** — `pickFuzzyMatch` は length-ratio スコアで決定的なので、source/target どちらを先に seed しても結果は変わらない。「source 先 seed」は単に元バグの再現条件を踏襲しているだけ。
+- **`projectSlug` (`chromium` / `webkit` etc.) の長さ依存** — 共通 suffix が長くなりすぎると target key の長さに対する score 差が縮む可能性がある。現状の projectSlug + nonce 長 (約 28 字) と target key 長 (35 字) のバランスでは安全マージンあり。極端に短い projectSlug が将来追加されたら見直し対象。
+- **Japanese chars 部分の長さ** — `日本語タイトル` (7 字) は target key 長を意図的に slug 長に近づけるための値。短くしすぎると source 側にスコアが寄る。
+
+## Test plan
+
+- [ ] `yarn typecheck` clean
+- [ ] `yarn lint` clean
+- [ ] `yarn format` 適用済み
+- [ ] (Manual / CI) e2e-live live 環境で chromium + webkit の両 project で pass


### PR DESCRIPTION
## Summary

- `e2e-live/tests/wiki-nav.spec.ts` に **L-15b** spec を追加。Issue #1194 (PR #1319 で fix 済み) の「非 ASCII slug fuzzy resolver の collision」を end-to-end で踏み抜く回帰テスト。
- target = `日本語タイトル-${projectSlug}-${nonce}` / source = `e2e-live-l15b-source-${projectSlug}-${nonce}` で共通 suffix のみを共有 → `wikiSlugify(target)` が両ファイルに partial-match する #1194 オリジナルの衝突条件を再現。
- 既存 L-15 spec は target slug に `nonascii-target` という safety token を残しており衝突を回避してしまうため、本来の bug 形状を踏めない。L-15b はそれを外した「素の衝突条件」版。
- route (A) 直接 URL navigation + route (B) wikilink-click の両方をカバー (L-15 と shape を揃える)。
- 設計メモを `plans/test-e2e-live-wiki-1194-collision.md` に同梱。

## Items to Confirm / Review

- **Collision shape の妥当性** — `pickFuzzyMatch` の length-ratio スコアで target が source を上回るか。想定: slug ≒ 28 文字、target key ≒ 35 文字、source key ≒ 49 文字 → score(target) ≒ 0.8 / score(source) ≒ 0.57。projectSlug (`chromium` / `webkit` 等) が将来極端に短くなったらマージンが詰まる点はプラン file に注意書きあり。
- **Negative assertion (`not.toContainText(sourceMarker)`) が regression sentinel として load-bearing か** — fuzzy resolver が source を返す silent miss-resolve を直撃する想定。Codex 再レビューでも load-bearing と確認済み。
- **Route (B) のレンダラ前提** — `[[${targetSlug}]]` が `renderWikiLinks` で `<span class=\"wiki-link\" data-page=\"…\">` に変換され、`WikiPageBody` の click handler が `dataset.page` で `wikiLinkClick` を emit するパイプラインが engaged されるか (Codex iter 3 で確認済み)。
- **既存 L-15 は据置** — PR #1319 が `nonascii-target` safety token を「load-bearing から降りた redundancy belt」と明記しているため、L-15 は触らず L-15b として独立に追加。
- **動作確認 (live e2e)** は未実施。Reviewer 側または author 側で `yarn dev` を上げて以下で確認推奨:
  ```
  yarn test:e2e:live e2e-live/tests/wiki-nav.spec.ts -g \"L-15b\" --debug
  ```

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1194 これ解消したらしいのでテストしたい。e2e live にある？それとも、新規作成？

議論の結果、衝突条件を素のまま再現する L-15b spec を新規追加する方針 (既存 L-15 は据置)。worktree で作業。

## 実装アプローチ

### 背景

- Issue #1194: `server/api/routes/wiki.ts:resolvePagePath()` の fuzzy fallback が `key.includes(slug) || slug.includes(key)` で複数候補にヒットした際、Map iteration 順 (= readdir 順) で先に当たった key を返していた。非 ASCII slug を `wikiSlugify` で剥がした後の短い ASCII tail が別ページの filename に部分文字列として含まれると silent に誤 page が返る。
- PR #1319 が `pickFuzzyMatch` (MIN_FUZZY_SLUG_LEN ゲート + length-ratio スコアリング + tie → null) で fix 済み。unit test (`test/routes/test_wikiResolveFuzzy.ts`) で関数レベルはカバー済み。
- 既存 L-15 e2e spec は target slug に `nonascii-target` 安全弁を残しており本来の衝突条件を踏まない (PR #1319 本文も「redundancy belt に格下げ」と明記)。

### 設計

- target slug: `日本語タイトル-${projectSlug}-${nonce}` (unique token なし)
- source slug: `e2e-live-l15b-source-${projectSlug}-${nonce}`
- 共通 suffix = `-${projectSlug}-${nonce}` ← `wikiSlugify(target)` の出力そのもの
- route (A) 直接 URL navigation: target slug を URL 直叩き → server resolver → target body が render される
- route (B) wikilink-click: source ページに `[[targetSlug]]` を seed、click で SPA router → 同じ server resolver を踏む
- positive: target body marker が `wiki-page-body` testid に含まれる
- negative (load-bearing): source body marker が含まれない (= #1194 regression sentinel)
- secondary: URL が `/wiki/pages/<encoded target>$` で終わる / `/chat` 配下に流れていない (catch-all router B-24 系の負ガード)

### Codex cross-review (3 iterations)

1. iter 1: LGTM + 1 nit (`L15B_TIMEOUT_MS` 重複) → `L15_TIMEOUT_MS` に統一
2. iter 2: LGTM (no findings)
3. iter 3 (route (B) 追加後): LGTM (no findings)

### チェック

- ✅ `yarn format` / `yarn lint` / `yarn typecheck`
- ⏳ Live e2e 動作確認は別途 `yarn dev` + `yarn test:e2e:live -g \"L-15b\" --debug` で実施想定

### 不採用案

- **L-15 を改修して `nonascii-target` 削除**: PR #1319 が safety belt として残す意図を明示しているため不採用。
- **手動 QA のみ**: 自動回帰が無いと将来の readdir 挙動変更で silent 再発しうる。

## Summary by Sourcery

Add an end-to-end regression test and supporting plan to cover the original wiki fuzzy slug collision scenario from issue #1194 without altering existing specs.

Bug Fixes:
- Guard against regressions of the wiki fuzzy slug resolver collision by exercising the exact original collision shape end-to-end.

Documentation:
- Document the design and assumptions of the new wiki fuzzy collision e2e test in a dedicated plan file.

Tests:
- Introduce a new L-15b e2e-live wiki navigation spec that reproduces the non-ASCII slug fuzzy resolver collision and verifies correct page resolution via direct URL and wikilink navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new end-to-end test covering wiki slug fuzzy-match collision scenarios, verifying correct page resolution and navigation behavior across different routes.

* **Documentation**
  * Added planning documents for e2e-live test infrastructure improvements, including enhanced test organization and diagnostic tracing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1347)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->