### PR TITLE
feat(mcp): boot-time preflight — warn + skip external MCP servers with missing required config (#1352)

### DIFF
--- a/plans/feat-mcp-preflight-1352.md
+++ b/plans/feat-mcp-preflight-1352.md
@@ -1,0 +1,123 @@
+# MCP Preflight (#1352)
+
+## Problem
+
+`mcp.json` external MCP servers (Notion / GitHub / Linear / …) declare
+`required: true` fields in `src/config/mcpCatalog.ts`. When the user
+adds a catalog entry but doesn't fill those fields, today:
+
+- The spec's env value stays empty / unresolved.
+- Claude Code spawns the MCP subprocess anyway.
+- Every tool call into that server fails silently (401, "missing
+  credentials", etc.).
+- The operator sees nothing in MulmoClaude's own logs — they have to
+  dig into Claude Code's subprocess stderr.
+
+Built-in MCP-only tools (`notify`, `searchX` etc.) already have parity:
+`isMcpToolEnabled` + `logMcpStatus` log both available and
+unavailable-due-to-missing-env. External MCP servers need the same
+treatment.
+
+## Approach
+
+Add a preflight step that runs **before** MCP servers are handed to
+Claude Code. For each user MCP server, look up the catalog entry by
+id and check whether the required env fields are populated in the
+user's saved spec. Missing values → log warn + exclude the server.
+
+### Component layout
+
+- **`server/agent/mcpPreflight.ts`** (new) — pure helpers:
+  - `findMissingRequiredEnv(entry, spec): string[]` — map catalog
+    `configSchema.key` → spec env key via the template's `${KEY}`
+    placeholder, return the catalog keys whose bound env values are
+    empty or still contain `${...}`.
+  - `preflightUserServers(userServers): { ready, skipped }` — filter
+    a server map; servers with no catalog match pass through (custom).
+  - `logPreflightResult(result, source: "boot" | "agent-run")` —
+    structured logging with a module-level dedup cache so repeated
+    agent runs don't spam the same warn.
+
+- **`server/agent/config.ts`** — `prepareUserServers` calls
+  `preflightUserServers` first, before the Docker filter. Wire the
+  agent-run logging path.
+
+- **`server/index.ts`** — boot-time:
+  - Read `loadMcpConfig().mcpServers` once after `initWorkspace()`.
+  - Run preflight + log via `logPreflightResult(..., "boot")`.
+  - This is the human-facing "started=N, skipped=M" startup signal.
+
+### Why both boot AND agent-run preflight
+
+Boot-time gives the operator a clear startup signal. But Settings UI
+changes mid-session shouldn't require a server restart, and
+`prepareUserServers` already runs per agent invocation — adding the
+filter inside it means a freshly-saved Notion API key starts working
+on the very next chat turn without operator action.
+
+The dedup cache (`Set<string>` keyed by `serverId:keysSorted`)
+ensures the per-run path doesn't re-log identical state every turn.
+
+## Catalog mapping detail
+
+Catalog entry shape:
+
+```ts
+{
+  id: "notion",
+  spec: { type: "stdio", env: { NOTION_TOKEN: "${NOTION_API_KEY}" } },
+  configSchema: [{ key: "NOTION_API_KEY", required: true }],
+}
+```
+
+User's saved mcp.json (after filling the form):
+
+```json
+{ "type": "stdio", "env": { "NOTION_TOKEN": "secret_xyz" } }
+```
+
+The mapping `NOTION_API_KEY` → `NOTION_TOKEN` comes from the catalog
+template's env values: we parse each `${KEY}` and remember which env
+key holds the placeholder. Then we check the user's spec's matching
+env key for a non-empty, non-placeholder value.
+
+HTTP catalog entries don't currently have required fields (only
+deepwiki, which is `configSchema: []`). We scope preflight to stdio
+for now and leave HTTP as pass-through; an HTTP-side preflight can
+land later when a catalog entry uses required headers.
+
+## Acceptance
+
+- Workspace with Notion in mcp.json but `NOTION_TOKEN` empty/placeholder
+  → boot log: `mcp.preflight: skipping notion — missing required config { missing: ["NOTION_API_KEY"] }`
+  + boot summary `mcp.boot: started=N, skipped=1`
+  + Notion subprocess never spawned (tool list doesn't expose
+  `mcp__notion__*`).
+- Workspace with everything set → no behaviour change, no extra log.
+- Settings UI updates → next chat turn picks up the change silently
+  (no log spam from the dedup cache).
+
+## Out of scope
+
+- Runtime crash tolerance (#1353).
+- Structured error response on call into unavailable server (#1354).
+- Markdown-file fallback when integrations absent (deferred from the
+  withdrawn #1349).
+- HTTP-side preflight for required headers (no current catalog
+  entries need it; revisit when one shows up).
+
+## Test plan
+
+`test/agent/test_mcpPreflight.ts` — `node:test` driving the pure
+helpers without spinning up an Express server. Cases:
+
+1. **all fields set** — server in `ready`, `skipped` empty.
+2. **one field missing (empty value)** — server in `skipped` with the
+   right missing-key, NOT in `ready`.
+3. **field still has `${KEY}` placeholder** — treated the same as
+   empty.
+4. **multiple required fields, one missing** — `skipped.missing`
+   reports only the missing one.
+5. **custom server (no catalog match)** — passes through to `ready`,
+   `skipped` empty.
+6. **catalog entry with no required fields** — passes through.

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -10,6 +10,7 @@ import type { Attachment } from "@mulmobridge/protocol";
 import { isImageMime, isNativeAttachmentMime } from "@mulmobridge/client";
 import { convertAttachment } from "./attachmentConverter.js";
 import { log } from "../system/logger/index.js";
+import { preflightUserServers, logPreflightResult } from "./mcpPreflight.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 
@@ -73,8 +74,14 @@ function prepareUserStdioServer(spec: Extract<McpServerSpec, { type: "stdio" }>,
 }
 
 export function prepareUserServers(userServers: Record<string, McpServerSpec>, useDocker: boolean, hostWorkspacePath: string): Record<string, McpServerSpec> {
+  // Drop catalog-known entries that are missing required config (#1352).
+  // The dedup cache inside `logPreflightResult` keeps per-agent-run
+  // calls quiet so a Settings UI fix only logs once when it transitions
+  // missing → ok.
+  const preflight = preflightUserServers(userServers);
+  logPreflightResult(preflight, "agent-run");
   const out: Record<string, McpServerSpec> = {};
-  for (const [serverId, spec] of Object.entries(userServers)) {
+  for (const [serverId, spec] of Object.entries(preflight.ready)) {
     if (spec.enabled === false) continue;
     if (spec.type === "http") {
       out[serverId] = prepareUserHttpServer(spec, useDocker);

--- a/server/agent/mcpPreflight.ts
+++ b/server/agent/mcpPreflight.ts
@@ -134,32 +134,42 @@ export function preflightUserServers(userServers: Record<string, McpServerSpec> 
   return { ready, skipped };
 }
 
-// Dedup cache so per-agent-run logging doesn't repeat identical
-// state across chat turns. Boot-time logging bypasses the cache
-// (always logs once on startup).
-const loggedKeys = new Set<string>();
+// Snapshot of the previous run's skipped set so per-agent-run logging
+// only fires on state changes. Boot-time logging always fires (clean
+// startup signal) and seeds the snapshot for subsequent runs.
+//
+// The earlier shape — a monotonic Set that only ever grew — would
+// swallow a `missing → fixed → missing again` regression: the second
+// "missing" emitted no warning because the key had already been
+// logged on the first one (Codex review on #1355). Snapshot diffing
+// fixes that without losing the dedup property: identical state
+// across turns still logs at most once.
+let lastSkippedKeys = new Set<string>();
 
 function dedupKey(entry: { serverId: string; missing: string[] }): string {
   return `${entry.serverId}:${entry.missing.join(",")}`;
 }
 
 /** Emit structured logs for the preflight outcome.
- *  - `source: "boot"`  — runs once at startup; always logs.
- *  - `source: "agent-run"` — runs per agent invocation; dedups
- *    identical (server, missing-keys) tuples so a Settings UI
- *    change shows once and stale state stays quiet. */
+ *  - `source: "boot"`  — runs once at startup; always logs and
+ *    seeds the snapshot.
+ *  - `source: "agent-run"` — runs per agent invocation; logs only
+ *    entries that are new vs the previous run's snapshot. A server
+ *    that re-enters a broken state after being fixed will log again
+ *    because the key is absent from the snapshot. */
 export function logPreflightResult(result: McpPreflightResult, source: "boot" | "agent-run"): void {
   const isBoot = source === "boot";
+  const currentKeys = new Set(result.skipped.map(dedupKey));
   for (const entry of result.skipped) {
     const key = dedupKey(entry);
-    if (!isBoot && loggedKeys.has(key)) continue;
-    loggedKeys.add(key);
+    if (!isBoot && lastSkippedKeys.has(key)) continue;
     log.warn("mcp", "preflight: skipping server — missing required config", {
       source,
       serverId: entry.serverId,
       missing: entry.missing,
     });
   }
+  lastSkippedKeys = currentKeys;
   if (isBoot) {
     log.info("mcp", "preflight summary", {
       started: Object.keys(result.ready).length,
@@ -168,8 +178,8 @@ export function logPreflightResult(result: McpPreflightResult, source: "boot" | 
   }
 }
 
-/** Test seam — reset the dedup cache between tests so each case
- *  sees a fresh logging state. */
+/** Test seam — reset the snapshot between tests so each case sees a
+ *  fresh logging state. */
 export function _resetPreflightLogCache(): void {
-  loggedKeys.clear();
+  lastSkippedKeys = new Set();
 }

--- a/server/agent/mcpPreflight.ts
+++ b/server/agent/mcpPreflight.ts
@@ -78,7 +78,11 @@ function buildFieldToEnvKeyMap(templateEnv: Record<string, string>): Map<string,
 
 function isResolved(value: string | undefined): boolean {
   if (typeof value !== "string") return false;
-  if (value.length === 0) return false;
+  // Trim before the empty check — `"   "` (whitespace-only) is just
+  // as misconfigured as `""` and would otherwise let preflight
+  // greenlight a server that can't actually authenticate (Codex
+  // review on #1355).
+  if (value.trim().length === 0) return false;
   PLACEHOLDER_PATTERN.lastIndex = 0;
   return !PLACEHOLDER_PATTERN.test(value);
 }

--- a/server/agent/mcpPreflight.ts
+++ b/server/agent/mcpPreflight.ts
@@ -47,6 +47,12 @@ const SINGLE_PLACEHOLDER = /^\$\{([A-Z0-9_]+)\}$/;
  *  (deepwiki is empty) — they fall through with `[]`. When a
  *  required HTTP header lands in the catalog, extend this helper. */
 export function findMissingRequiredEnv(entry: McpCatalogEntry, spec: McpServerSpec): string[] {
+  // Transport mismatch (e.g. catalog stdio entry but user pointed
+  // the same id at an HTTP URL) means the catalog's env template
+  // doesn't apply to this user spec — see `preflightUserServers`'s
+  // header comment for the rationale. Guard here too so callers that
+  // skip the wrapper still get the correct answer.
+  if (entry.spec.type !== spec.type) return [];
   if (entry.spec.type !== "stdio" || !entry.spec.env) return [];
   const fieldToEnvKey = buildFieldToEnvKeyMap(entry.spec.env);
   const userEnv = spec.type === "stdio" ? spec.env : undefined;
@@ -80,13 +86,37 @@ function isResolved(value: string | undefined): boolean {
 /** Filter user MCP servers by checking the catalog's required
  *  fields. Servers without a catalog match (= user-added custom
  *  servers) pass through — we have no metadata to validate them
- *  against. */
-export function preflightUserServers(userServers: Record<string, McpServerSpec>): McpPreflightResult {
+ *  against.
+ *
+ *  Two other shapes also pass through unvalidated:
+ *
+ *  - `enabled: false` entries (CodeRabbit review on #1355). They're
+ *    intentionally disabled by the user; running them through
+ *    preflight produces spurious "missing required config" warnings
+ *    AND skews the boot summary's `started` count. The downstream
+ *    `prepareUserServers` already drops disabled entries before
+ *    spawning anything, so we just forward them.
+ *
+ *  - Type-mismatched catalog hits. If the user's mcp.json has
+ *    `gmail: { type: "http", url: ... }` but the catalog's `gmail`
+ *    entry is `type: "stdio"` with env templates, the catalog's
+ *    requirement list doesn't apply to the user's spec — they've
+ *    pointed `gmail` at a different transport, effectively making it
+ *    a custom server. Treat as custom (no preflight) rather than
+ *    false-flagging missing env. */
+export function preflightUserServers(userServers: Record<string, McpServerSpec> | undefined | null): McpPreflightResult {
   const ready: Record<string, McpServerSpec> = {};
   const skipped: McpPreflightResult["skipped"] = [];
-  for (const [serverId, spec] of Object.entries(userServers)) {
+  // Defensive default (Sourcery review on #1355): a malformed
+  // mcp.json — or a future refactor that nulls `mcpServers` — would
+  // otherwise throw `Object.entries(null)` at boot.
+  for (const [serverId, spec] of Object.entries(userServers ?? {})) {
+    if (spec.enabled === false) {
+      ready[serverId] = spec;
+      continue;
+    }
     const entry = findCatalogEntry(serverId);
-    if (entry === null) {
+    if (entry === null || entry.spec.type !== spec.type) {
       ready[serverId] = spec;
       continue;
     }

--- a/server/agent/mcpPreflight.ts
+++ b/server/agent/mcpPreflight.ts
@@ -1,0 +1,141 @@
+// Boot-time + per-agent-run preflight for external MCP servers
+// (#1352).
+//
+// Built-in MCP-only tools have always done this via
+// `isMcpToolEnabled` + `logMcpStatus` (server/index.ts:750) — when an
+// env var listed in `requiredEnv` is unset, the tool drops out of
+// the list and the operator sees an info log explaining why. External
+// MCP servers (the `mcp.json` ones — Notion / GitHub / Linear /…)
+// had no equivalent, so a half-configured catalog entry would still
+// spawn a subprocess and every tool call would fail silently with
+// 401. This module is the parity fix.
+//
+// The catalog (`src/config/mcpCatalog.ts`) declares which config
+// fields are `required: true`. The user's saved `mcp.json` holds
+// resolved values. Cross-referencing the two tells us which servers
+// are ready to boot and which should be excluded from the config
+// handed to Claude Code.
+
+import type { McpServerSpec } from "../system/config.js";
+import { findCatalogEntry, requiredKeysOf, type McpCatalogEntry } from "../../src/config/mcpCatalog.js";
+import { log } from "../system/logger/index.js";
+
+export interface McpPreflightResult {
+  /** Servers that passed preflight, keyed by the same id used in
+   *  the input. Safe to pass straight into `prepareUserServers` /
+   *  `buildMcpConfig`. */
+  ready: Record<string, McpServerSpec>;
+  /** Servers excluded by preflight, with the catalog field keys
+   *  whose values were unset / unresolved. */
+  skipped: { serverId: string; missing: string[] }[];
+}
+
+const PLACEHOLDER_PATTERN = /\$\{([A-Z0-9_]+)\}/g;
+const SINGLE_PLACEHOLDER = /^\$\{([A-Z0-9_]+)\}$/;
+
+/** Returns the catalog field keys whose values are unresolved in
+ *  the user's saved spec — `""`, missing, or still carrying a
+ *  `${KEY}` placeholder.
+ *
+ *  Mapping goes: catalog `configSchema[].key` → spec env key, via
+ *  the catalog template's env value. E.g. catalog template
+ *  `env: { NOTION_TOKEN: "${NOTION_API_KEY}" }` binds the field
+ *  `NOTION_API_KEY` to the env key `NOTION_TOKEN`. We then check
+ *  the user's saved spec's `env.NOTION_TOKEN`.
+ *
+ *  HTTP-type catalog entries currently have no required fields
+ *  (deepwiki is empty) — they fall through with `[]`. When a
+ *  required HTTP header lands in the catalog, extend this helper. */
+export function findMissingRequiredEnv(entry: McpCatalogEntry, spec: McpServerSpec): string[] {
+  if (entry.spec.type !== "stdio" || !entry.spec.env) return [];
+  const fieldToEnvKey = buildFieldToEnvKeyMap(entry.spec.env);
+  const userEnv = spec.type === "stdio" ? spec.env : undefined;
+  const required = requiredKeysOf(entry);
+  const missing: string[] = [];
+  for (const fieldKey of required) {
+    const envKey = fieldToEnvKey.get(fieldKey);
+    if (envKey === undefined) continue;
+    const value = userEnv?.[envKey];
+    if (!isResolved(value)) missing.push(fieldKey);
+  }
+  return missing;
+}
+
+function buildFieldToEnvKeyMap(templateEnv: Record<string, string>): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const [envKey, value] of Object.entries(templateEnv)) {
+    const match = SINGLE_PLACEHOLDER.exec(value);
+    if (match) out.set(match[1], envKey);
+  }
+  return out;
+}
+
+function isResolved(value: string | undefined): boolean {
+  if (typeof value !== "string") return false;
+  if (value.length === 0) return false;
+  PLACEHOLDER_PATTERN.lastIndex = 0;
+  return !PLACEHOLDER_PATTERN.test(value);
+}
+
+/** Filter user MCP servers by checking the catalog's required
+ *  fields. Servers without a catalog match (= user-added custom
+ *  servers) pass through — we have no metadata to validate them
+ *  against. */
+export function preflightUserServers(userServers: Record<string, McpServerSpec>): McpPreflightResult {
+  const ready: Record<string, McpServerSpec> = {};
+  const skipped: McpPreflightResult["skipped"] = [];
+  for (const [serverId, spec] of Object.entries(userServers)) {
+    const entry = findCatalogEntry(serverId);
+    if (entry === null) {
+      ready[serverId] = spec;
+      continue;
+    }
+    const missing = findMissingRequiredEnv(entry, spec);
+    if (missing.length > 0) {
+      skipped.push({ serverId, missing: missing.sort() });
+      continue;
+    }
+    ready[serverId] = spec;
+  }
+  return { ready, skipped };
+}
+
+// Dedup cache so per-agent-run logging doesn't repeat identical
+// state across chat turns. Boot-time logging bypasses the cache
+// (always logs once on startup).
+const loggedKeys = new Set<string>();
+
+function dedupKey(entry: { serverId: string; missing: string[] }): string {
+  return `${entry.serverId}:${entry.missing.join(",")}`;
+}
+
+/** Emit structured logs for the preflight outcome.
+ *  - `source: "boot"`  — runs once at startup; always logs.
+ *  - `source: "agent-run"` — runs per agent invocation; dedups
+ *    identical (server, missing-keys) tuples so a Settings UI
+ *    change shows once and stale state stays quiet. */
+export function logPreflightResult(result: McpPreflightResult, source: "boot" | "agent-run"): void {
+  const isBoot = source === "boot";
+  for (const entry of result.skipped) {
+    const key = dedupKey(entry);
+    if (!isBoot && loggedKeys.has(key)) continue;
+    loggedKeys.add(key);
+    log.warn("mcp", "preflight: skipping server — missing required config", {
+      source,
+      serverId: entry.serverId,
+      missing: entry.missing,
+    });
+  }
+  if (isBoot) {
+    log.info("mcp", "preflight summary", {
+      started: Object.keys(result.ready).length,
+      skipped: result.skipped.length,
+    });
+  }
+}
+
+/** Test seam — reset the dedup cache between tests so each case
+ *  sees a fresh logging state. */
+export function _resetPreflightLogCache(): void {
+  loggedKeys.clear();
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -56,6 +56,8 @@ import { WORKSPACE_PATHS } from "./workspace/paths.js";
 import { serverError } from "./utils/httpError.js";
 import { makeUuid } from "./utils/id.js";
 import { mcpToolsRouter, mcpTools, isMcpToolEnabled } from "./agent/mcp-tools/index.js";
+import { preflightUserServers, logPreflightResult } from "./agent/mcpPreflight.js";
+import { loadMcpConfig } from "./system/config.js";
 import { initWorkspace, workspacePath } from "./workspace/workspace.js";
 import { runMemoryMigrationOnce } from "./workspace/memory/run.js";
 import { runTopicMigrationOnce } from "./workspace/memory/topic-run.js";
@@ -767,6 +769,29 @@ function logMcpStatus(): void {
   if (disabledMcpTools.length > 0) {
     const names = disabledMcpTools.map((toolDef) => `${toolDef.definition.name} (${(toolDef.requiredEnv ?? []).join(", ")})`).join(", ");
     log.info("mcp", "Unavailable (missing env)", { tools: names });
+  }
+  logExternalMcpPreflight();
+}
+
+// External MCP servers (the `mcp.json` ones — Notion / GitHub /…)
+// get a separate preflight pass that mirrors the built-in
+// `Available / Unavailable` summary above. Servers with catalog
+// entries whose `required: true` fields are unset are excluded from
+// the config handed to Claude Code (filtered inside
+// `prepareUserServers`); this boot-time log gives the operator one
+// clear startup signal (#1352).
+function logExternalMcpPreflight(): void {
+  try {
+    const userMcpRaw = loadMcpConfig().mcpServers;
+    const preflight = preflightUserServers(userMcpRaw);
+    logPreflightResult(preflight, "boot");
+  } catch (err) {
+    // Best-effort: a broken mcp.json shouldn't take down boot. The
+    // per-agent-run path will still attempt the preflight and surface
+    // any genuine issue when the user actually starts a chat.
+    log.warn("mcp", "preflight at boot failed; will retry per-agent-run", {
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/test/agent/test_mcpPreflight.ts
+++ b/test/agent/test_mcpPreflight.ts
@@ -7,9 +7,16 @@
 
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { findMissingRequiredEnv, preflightUserServers, _resetPreflightLogCache } from "../../server/agent/mcpPreflight.js";
+import {
+  findMissingRequiredEnv,
+  preflightUserServers,
+  logPreflightResult,
+  _resetPreflightLogCache,
+  type McpPreflightResult,
+} from "../../server/agent/mcpPreflight.js";
 import { findCatalogEntry } from "../../src/config/mcpCatalog.js";
 import type { McpServerSpec } from "../../server/system/config.js";
+import { log } from "../../server/system/logger/index.js";
 
 beforeEach(() => {
   _resetPreflightLogCache();
@@ -146,5 +153,92 @@ describe("preflightUserServers", () => {
     assert.equal(result.skipped.length, 1);
     assert.equal(result.skipped[0].serverId, "slack");
     assert.deepEqual(result.skipped[0].missing.sort(), ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
+  });
+});
+
+describe("logPreflightResult — snapshot diffing (Codex review on #1355)", () => {
+  // Capture log.warn calls so we can assert on the dedup behavior
+  // without spinning up the real transport.
+  function captureWarn(): { calls: { serverId: string; missing: string[] }[]; restore: () => void } {
+    const originalWarn = log.warn;
+    const calls: { serverId: string; missing: string[] }[] = [];
+    log.warn = (_namespace, _message, data) => {
+      if (data && typeof data === "object" && "serverId" in data && "missing" in data) {
+        const { serverId, missing } = data as { serverId: unknown; missing: unknown };
+        if (typeof serverId === "string" && Array.isArray(missing)) {
+          calls.push({ serverId, missing: missing as string[] });
+        }
+      }
+    };
+    return {
+      calls,
+      restore: () => {
+        log.warn = originalWarn;
+      },
+    };
+  }
+
+  function emptyResult(): McpPreflightResult {
+    return { ready: {}, skipped: [] };
+  }
+
+  function skipResult(serverId: string, missing: string[]): McpPreflightResult {
+    return { ready: {}, skipped: [{ serverId, missing }] };
+  }
+
+  it("logs identical state only once across consecutive agent-run calls", () => {
+    const { calls, restore } = captureWarn();
+    try {
+      const notionSkipped = skipResult("notion", ["NOTION_API_KEY"]);
+      logPreflightResult(notionSkipped, "agent-run");
+      logPreflightResult(notionSkipped, "agent-run");
+      logPreflightResult(notionSkipped, "agent-run");
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].serverId, "notion");
+    } finally {
+      restore();
+    }
+  });
+
+  it("re-logs after a server goes missing → fixed → missing again", () => {
+    // Regression guard for the monotonic-Set bug Codex flagged: the
+    // earlier shape only ever added to the dedup set, so a fix-then-
+    // re-break sequence silently suppressed the second warning.
+    const { calls, restore } = captureWarn();
+    try {
+      logPreflightResult(skipResult("notion", ["NOTION_API_KEY"]), "agent-run"); // log #1
+      logPreflightResult(emptyResult(), "agent-run"); // user fixed it — nothing to log
+      logPreflightResult(skipResult("notion", ["NOTION_API_KEY"]), "agent-run"); // re-broken — must log #2
+      assert.equal(calls.length, 2);
+      assert.deepEqual(
+        calls.map((call) => call.serverId),
+        ["notion", "notion"],
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("logs again when the missing-key set changes for the same server", () => {
+    const { calls, restore } = captureWarn();
+    try {
+      logPreflightResult(skipResult("slack", ["SLACK_BOT_TOKEN"]), "agent-run");
+      logPreflightResult(skipResult("slack", ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]), "agent-run");
+      assert.equal(calls.length, 2);
+      assert.deepEqual(calls[1].missing, ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("boot mode always logs even when state hasn't changed since the last agent run", () => {
+    const { calls, restore } = captureWarn();
+    try {
+      logPreflightResult(skipResult("notion", ["NOTION_API_KEY"]), "agent-run");
+      logPreflightResult(skipResult("notion", ["NOTION_API_KEY"]), "boot");
+      assert.equal(calls.length, 2);
+    } finally {
+      restore();
+    }
   });
 });

--- a/test/agent/test_mcpPreflight.ts
+++ b/test/agent/test_mcpPreflight.ts
@@ -43,6 +43,19 @@ describe("findMissingRequiredEnv — Notion (single required field)", () => {
     assert.deepEqual(findMissingRequiredEnv(entry, spec), ["NOTION_API_KEY"]);
   });
 
+  it("flags the required field when the env value is whitespace only (Codex review on #1355)", () => {
+    // `"   "` has non-zero length but is just as misconfigured as
+    // `""` — a server with a whitespace-only token can't
+    // authenticate. Without trimming, preflight greenlit it.
+    const entry = getEntry("notion");
+    const spec: McpServerSpec = {
+      type: "stdio",
+      command: "npx",
+      env: { NOTION_TOKEN: "   " },
+    };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), ["NOTION_API_KEY"]);
+  });
+
   it("flags the required field when the env key is missing entirely", () => {
     const entry = getEntry("notion");
     const spec: McpServerSpec = {

--- a/test/agent/test_mcpPreflight.ts
+++ b/test/agent/test_mcpPreflight.ts
@@ -1,0 +1,137 @@
+// Tests for the MCP preflight helper (#1352).
+//
+// Drives the pure functions without spinning up Express. The catalog
+// is consumed read-only via `findCatalogEntry`, so the tests work
+// against the actual production catalog (matching `notion`,
+// `github`, etc. by id) rather than a fixture.
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { findMissingRequiredEnv, preflightUserServers, _resetPreflightLogCache } from "../../server/agent/mcpPreflight.js";
+import { findCatalogEntry } from "../../src/config/mcpCatalog.js";
+import type { McpServerSpec } from "../../server/system/config.js";
+
+beforeEach(() => {
+  _resetPreflightLogCache();
+});
+
+function getEntry(entryId: string) {
+  const entry = findCatalogEntry(entryId);
+  if (entry === null) throw new Error(`catalog entry ${entryId} missing — test fixture out of date`);
+  return entry;
+}
+
+describe("findMissingRequiredEnv — Notion (single required field)", () => {
+  it("returns [] when the bound env value is resolved", () => {
+    const entry = getEntry("notion");
+    const spec: McpServerSpec = {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@notionhq/notion-mcp-server"],
+      env: { NOTION_TOKEN: "secret_xyz" },
+    };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), []);
+  });
+
+  it("flags the required field when the env value is empty string", () => {
+    const entry = getEntry("notion");
+    const spec: McpServerSpec = {
+      type: "stdio",
+      command: "npx",
+      env: { NOTION_TOKEN: "" },
+    };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), ["NOTION_API_KEY"]);
+  });
+
+  it("flags the required field when the env key is missing entirely", () => {
+    const entry = getEntry("notion");
+    const spec: McpServerSpec = {
+      type: "stdio",
+      command: "npx",
+      env: {},
+    };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), ["NOTION_API_KEY"]);
+  });
+
+  it("flags the required field when the env value still holds the unresolved ${KEY} placeholder", () => {
+    // Settings UI is supposed to substitute placeholders before
+    // writing mcp.json, but a hand-edited file might leave them
+    // unresolved. Treat as missing so the operator gets the warn.
+    const entry = getEntry("notion");
+    const spec: McpServerSpec = {
+      type: "stdio",
+      command: "npx",
+      env: { NOTION_TOKEN: "${NOTION_API_KEY}" },
+    };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), ["NOTION_API_KEY"]);
+  });
+});
+
+describe("findMissingRequiredEnv — Slack (two required fields)", () => {
+  it("reports only the missing one when others are set", () => {
+    const entry = getEntry("slack");
+    const spec: McpServerSpec = {
+      type: "stdio",
+      command: "npx",
+      env: { SLACK_BOT_TOKEN: "xoxb-real", SLACK_TEAM_ID: "" },
+    };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), ["SLACK_TEAM_ID"]);
+  });
+
+  it("reports both when both are missing", () => {
+    const entry = getEntry("slack");
+    const spec: McpServerSpec = { type: "stdio", command: "npx", env: {} };
+    const missing = findMissingRequiredEnv(entry, spec);
+    assert.deepEqual(missing.sort(), ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
+  });
+});
+
+describe("findMissingRequiredEnv — HTTP entries fall through (no env to check)", () => {
+  it("returns [] for the HTTP-typed deepwiki entry", () => {
+    const entry = getEntry("deepwiki");
+    const spec: McpServerSpec = { type: "http", url: "https://mcp.deepwiki.com/sse" };
+    assert.deepEqual(findMissingRequiredEnv(entry, spec), []);
+  });
+});
+
+describe("preflightUserServers", () => {
+  it("passes through a custom server with no catalog match", () => {
+    const userServers: Record<string, McpServerSpec> = {
+      "my-custom-server": { type: "stdio", command: "node", args: ["./bin.js"] },
+    };
+    const result = preflightUserServers(userServers);
+    assert.deepEqual(Object.keys(result.ready), ["my-custom-server"]);
+    assert.deepEqual(result.skipped, []);
+  });
+
+  it("excludes a catalog server with missing required config", () => {
+    const userServers: Record<string, McpServerSpec> = {
+      notion: { type: "stdio", command: "npx", env: { NOTION_TOKEN: "" } },
+    };
+    const result = preflightUserServers(userServers);
+    assert.deepEqual(Object.keys(result.ready), []);
+    assert.deepEqual(result.skipped, [{ serverId: "notion", missing: ["NOTION_API_KEY"] }]);
+  });
+
+  it("passes catalog servers with all required env populated", () => {
+    const userServers: Record<string, McpServerSpec> = {
+      notion: { type: "stdio", command: "npx", env: { NOTION_TOKEN: "secret_xyz" } },
+    };
+    const result = preflightUserServers(userServers);
+    assert.deepEqual(Object.keys(result.ready), ["notion"]);
+    assert.deepEqual(result.skipped, []);
+  });
+
+  it("handles a mix: one ready, one skipped, one custom — all in one pass", () => {
+    const userServers: Record<string, McpServerSpec> = {
+      notion: { type: "stdio", command: "npx", env: { NOTION_TOKEN: "secret_ok" } },
+      slack: { type: "stdio", command: "npx", env: { SLACK_BOT_TOKEN: "", SLACK_TEAM_ID: "" } },
+      "my-custom": { type: "stdio", command: "node" },
+    };
+    const result = preflightUserServers(userServers);
+    assert.deepEqual(Object.keys(result.ready).sort(), ["my-custom", "notion"]);
+    assert.equal(result.skipped.length, 1);
+    assert.equal(result.skipped[0].serverId, "slack");
+    assert.deepEqual(result.skipped[0].missing.sort(), ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add preflight check for external MCP servers (`mcp.json` — Notion / GitHub / Linear / …) so half-configured catalog entries don't spawn doomed subprocesses.
- Mirrors the built-in `isMcpToolEnabled` / `logMcpStatus` parity for `mcpTools` (server/index.ts:759) — same idea, applied to the external server pipeline.
- Two log points: **boot** (always logs) + **per-agent-run** (dedups identical state so Settings UI changes show once).

## Items to Confirm / Review

1. **Catalog field → spec env key mapping** lives in `findMissingRequiredEnv` via parsing the catalog template's `${KEY}` placeholders. E.g. catalog `env: { NOTION_TOKEN: "${NOTION_API_KEY}" }` binds field `NOTION_API_KEY` to env key `NOTION_TOKEN`. The mapping is intentionally template-driven (not a hard-coded lookup) so a future catalog entry that uses a different env key name (e.g. `OPENAPI_MCP_HEADERS` form) works without touching this code.
2. **Custom servers (no catalog match) pass through.** No required-fields metadata to validate; `validateStdioPackages` still catches nonexistent packages there.
3. **HTTP catalog entries** currently have no required fields (only `deepwiki`, which is `configSchema: []`). Preflight scopes to `stdio` — when a required HTTP header lands in the catalog, extend `findMissingRequiredEnv`.
4. **Boot-time call is best-effort.** A broken mcp.json is caught and logged; boot continues. Per-agent-run path will surface any genuine issue when the user starts a chat.

## User Prompt

> mcpとかで設定値が必要なもので設定されてない場合は、起動時にログでアラート出す？あと、そのmcp自体は読み込まないとか、key違って失敗した場合でもきちんとログ逃がしたいよね。で、サーバ死なないように。

Split into three issues for clarity: #1352 (this PR — preflight + log + skip), #1353 (runtime crash tolerance), #1354 (structured error response). KazusaNakagawa's withdrawn #1349 (markdown fallback) is a separate idea, intentionally not bundled.

## Implementation Approach

1. **New `server/agent/mcpPreflight.ts`** — three pure helpers:
   - `findMissingRequiredEnv(entry, spec)` — catalog field → spec env key, with `${KEY}` placeholders and empty values both treated as missing.
   - `preflightUserServers(userServers)` — filter ready vs skipped, custom servers pass through.
   - `logPreflightResult(result, source)` — structured warn per skipped server + boot summary; dedup cache for agent-run source.

2. **`server/agent/config.ts`** — `prepareUserServers` calls `preflightUserServers` first, then proceeds with the existing Docker filtering. Skipped servers never reach `buildMcpConfig` so no subprocess spawn.

3. **`server/index.ts`** — boot-time wrapper (`logExternalMcpPreflight`) called from the existing `logMcpStatus` function so the built-in vs external MCP startup logs cluster together.

4. **`test/agent/test_mcpPreflight.ts`** — 11 cases pinned against the real catalog (Notion 1-required, Slack 2-required, deepwiki HTTP), covering placeholder / empty / missing-key / mixed-fleet / pass-through paths.

## Test Plan

- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] 11/11 preflight tests pass
- [ ] Manual: workspace with Notion entry but no token set → boot log shows `mcp.preflight: skipping notion`, summary `mcp.boot summary: { started: N, skipped: 1 }`, Notion tools absent from agent's tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a preflight validation step for external MCP servers that skips misconfigured catalog-based servers and logs their status at boot and per agent run.

Enhancements:
- Introduce shared preflight helper utilities for external MCP servers to determine readiness based on catalog-required configuration.
- Integrate MCP preflight into agent server preparation so only fully configured servers are started and surfaced to tools.
- Add structured, de-duplicated logging for MCP preflight results at boot and during agent runs for better operational visibility.

Documentation:
- Add a design/plan document describing the MCP preflight problem, approach, and acceptance criteria.

Tests:
- Add unit tests covering MCP preflight behavior against real catalog entries, including required-env handling and custom server passthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight validation for external MCP servers at boot and during agent runs, classifying servers as ready or skipped.
  * Boot logs emit a startup summary (started/skipped); agent-run logs deduplicate repeated warnings.

* **Bug Fixes / Behavior**
  * Custom or non-catalog servers pass through as ready; HTTP-only entries with no required fields are allowed.
  * Unresolved or empty env placeholders are detected and reported as missing.

* **Tests**
  * Added tests covering detection, classification, logging, deduplication, and state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1355)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->