### PR TITLE
feat(mcp): runtime failure monitor — warn + bell when an MCP server fails repeatedly (#1353)

### DIFF
--- a/plans/feat-mcp-failure-monitor-1353.md
+++ b/plans/feat-mcp-failure-monitor-1353.md
@@ -1,0 +1,120 @@
+# MCP Runtime Failure Monitor (#1353)
+
+## Problem
+
+Even after #1352 (boot-time preflight + skip) lands, an MCP server
+that passed preflight can still fail at runtime:
+
+- API key was valid yesterday but rotated today → repeated 401s.
+- Upstream service is down → ECONNREFUSED.
+- Wrong workspace / scope set in OAuth → repeated permission errors.
+
+Today MulmoClaude has no per-server runtime failure signal. The
+existing `mcpTracker` (`server/agent/backend/claude-code.ts:61`) only
+notices the binary case "ToolSearch happened but no MCP tool was
+ever called" — useful but coarse. An MCP that calls *succeeded* and
+*also failed* slips through.
+
+## Approach — parse `is_error` from `tool_result`
+
+Anthropic's `tool_result` block carries `is_error?: boolean`. When an
+MCP tool call ends in an error (server-reported, transport-reported,
+or auth), Claude Code surfaces it in the stream-json with
+`is_error: true`. That's our hook.
+
+### Pipeline
+
+1. **`server/agent/stream.ts`** — extend the `toolCallResult` event
+   to carry `isError?: boolean`. Currently the parser strips this
+   flag. Mirror the field on `SseToolCallResult` so it survives to
+   the frontend (useful for #1354).
+2. **`server/agent/mcpFailureMonitor.ts`** (new) — module-level
+   monitor that tracks per-server consecutive failure count, with
+   threshold-based reporting. The monitor:
+   - Keeps a `Map<toolUseId, toolName>` from `toolCall` events to
+     correlate tool-name with each `toolCallResult`.
+   - For `mcp__<server>__<tool>` results, increments a per-server
+     consecutive-failure counter on `is_error: true`, resets on
+     success.
+   - When a server crosses the threshold (default 3 consecutive
+     failures), emits one `log.warn` + one `publishNotification`
+     for that server. Idempotent per server until success resets
+     the counter.
+3. **`server/agent/backend/claude-code.ts`** — instantiate the
+   monitor next to `mcpTracker`, feed each `agentEvent` through
+   `monitor.track(event)`.
+4. **Defensive wrapping** (#1353 acceptance "server resilience"):
+   - Wrap `getActiveToolDescriptors` calls in defensive try/catch
+     where they currently throw — none today since `activeTools.ts`
+     is pure data, but the *consumers* (`buildSystemPrompt`,
+     `buildCliArgs`) read from it. Audit and add a guard layer at
+     `getActivePlugins` so a malformed role doesn't crash the
+     agent.
+
+### Bell notification shape
+
+Mirror the existing `announcePluginMetaDiagnostics` pattern:
+
+```ts
+publishNotification({
+  id: `mcp-failure-${serverId}`,
+  kind: "system",
+  title: "MCP server failing",
+  body: `${serverId} returned errors on ${count} consecutive tool calls. Check the API key / network.`,
+  action: { type: NOTIFICATION_ACTION_TYPES.none },
+  priority: NOTIFICATION_PRIORITIES.high,
+});
+```
+
+The `legacyId` dedup in the notification engine ensures a server
+that's consistently failing across multiple agent runs only shows
+one bell entry until the user dismisses it OR a success resets
+the counter (which fires `dismissNotification(id)` on next success).
+
+### Threshold rationale
+
+A single `is_error: true` is *not* a sign of MCP brokenness — the
+user might have asked the MCP something it can't answer ("create
+page in database that doesn't exist"). Two consecutive could still
+be a sequence of bad inputs.
+
+Three+ consecutive errors with no successes in between is a strong
+"this server is broken" signal: a healthy server returns success
+*sometimes*, even if the user is asking weird things.
+
+The threshold is exported as a constant so a future config or test
+can override it. Default `MCP_FAILURE_THRESHOLD = 3`.
+
+## What this does NOT do
+
+- **Doesn't restart the MCP server.** That's the operator's call.
+- **Doesn't capture stderr from the MCP subprocess.** Claude Agent
+  SDK holds those handles, not MulmoClaude. Out of scope.
+- **Doesn't gate tool registration.** A flagged server still appears
+  in the tool list — #1354 will return a structured error from the
+  flagged tools so the LLM can recover.
+
+## Acceptance
+
+- 3 consecutive `is_error: true` results on `mcp__notion__*` →
+  warn log + bell notification with `id: "mcp-failure-notion"`.
+- 1 success on `mcp__notion__*` after the flag → counter resets,
+  next 3 failures re-flag (no zombie suppression).
+- Mix of MCP servers failing → each gets its own counter + bell
+  entry; one server's success doesn't reset another's count.
+- Server boot completes even when `getActivePlugins` would otherwise
+  throw on a malformed role (defensive guard).
+
+## Test plan
+
+`test/agent/test_mcpFailureMonitor.ts` — drives `monitor.track()`
+with synthetic `AgentEvent`s. Cases:
+
+1. **Threshold reached** — 3 errors → 1 notification + warn.
+2. **Below threshold** — 2 errors → nothing.
+3. **Reset on success** — 2 errors + 1 success + 2 errors → nothing.
+4. **Per-server isolation** — notion failing 3× + github succeeding
+   → only notion gets the notification.
+5. **Non-MCP tool result** — `Bash` / `Read` errors are ignored.
+6. **toolUseId not seen first** — orphan toolCallResult (no prior
+   toolCall) is ignored without crashing.

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -15,6 +15,7 @@ import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine } from "../con
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
+import { createMcpFailureMonitor } from "../mcpFailureMonitor.js";
 import { log } from "../../system/logger/index.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
@@ -100,6 +101,11 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
   const parser = createStreamParser();
 
   const mcpTracker = createMcpTracker();
+  // Runtime failure monitor (#1353). Lives next to mcpTracker
+  // because they share the same event stream — the tracker spots
+  // the "MCP never invoked" pattern, the monitor spots the
+  // "MCP invoked but consistently failing" pattern.
+  const mcpFailureMonitor = createMcpFailureMonitor();
 
   let buffer = "";
   for await (const chunk of proc.stdout) {
@@ -117,6 +123,7 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
       }
       for (const agentEvent of parser.parse(event)) {
         mcpTracker.track(agentEvent);
+        mcpFailureMonitor.track(agentEvent);
         yield agentEvent;
       }
     }

--- a/server/agent/mcpFailureMonitor.ts
+++ b/server/agent/mcpFailureMonitor.ts
@@ -28,13 +28,20 @@ import { log } from "../system/logger/index.js";
 
 export const MCP_FAILURE_THRESHOLD = 3;
 
-// Server-id contract — must match `isMcpServerId` in
-// `server/system/config.ts`. Both ends agreeing on this shape is
+// Server-id contract — mirrors `isMcpServerId` in
+// `server/system/config.ts`. Single `_` is allowed; consecutive
+// `__` is forbidden because it would collide with the
+// `mcp__<server>__<tool>` delimiter and make the parser ambiguous
+// (Codex iter-2 on #1356). Both ends agreeing on this shape is
 // what lets the monitor attribute failures back to the right
-// server entry in `mcp.json` (Codex review on #1356).
+// server entry in `mcp.json`.
 const MCP_SERVER_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
 const MCP_PREFIX = "mcp__";
 const MCP_DELIM = "__";
+
+function isValidServerId(value: string): boolean {
+  return MCP_SERVER_ID_PATTERN.test(value) && !value.includes("__");
+}
 
 /** Minimal AgentEvent surface the monitor needs. Defined locally to
  *  avoid a circular import; structurally matches the relevant fields
@@ -85,7 +92,7 @@ export function mcpServerFromToolName(toolName: string): string | null {
   // `__` of its own (some MCP authors use `__` in tool names) — we
   // only care that something is there.
   if (rest.length <= delim + MCP_DELIM.length) return null;
-  return MCP_SERVER_ID_PATTERN.test(serverId) ? serverId : null;
+  return isValidServerId(serverId) ? serverId : null;
 }
 
 /** Build a session-scoped monitor. Returns the same shape as

--- a/server/agent/mcpFailureMonitor.ts
+++ b/server/agent/mcpFailureMonitor.ts
@@ -1,0 +1,141 @@
+// Runtime failure monitor for external MCP servers (#1353).
+//
+// `mcpPreflight.ts` (#1352) handles the static case: servers that
+// can't even start because of missing required config. This module
+// handles the dynamic case: servers that start OK but fail to answer
+// tool calls (API key rotated, upstream down, OAuth scope wrong …).
+//
+// Signal source is `tool_result.is_error: true` from Claude Code's
+// stream-json. `stream.ts` now forwards that flag as
+// `AgentEvent.toolCallResult.isError`; this monitor consumes those
+// events, attributes errors to the originating MCP server (parsed
+// from `mcp__<server>__<tool>` names cached at toolCall time), and
+// fires a single warn + bell notification per server once a
+// consecutive-failure threshold is crossed.
+//
+// What the monitor intentionally does NOT do:
+//   - Restart the MCP server (operator's call).
+//   - Capture MCP subprocess stderr (Claude Agent SDK holds that —
+//     out of scope for #1353).
+//   - Auto-dismiss the bell entry when calls recover. The notification
+//     engine has no dismissal API exposed yet; future work can wire
+//     it once that lands. For now: bell stays until user dismisses.
+
+import { EVENT_TYPES } from "../../src/types/events.js";
+import { NOTIFICATION_ACTION_TYPES, NOTIFICATION_PRIORITIES } from "../../src/types/notification.js";
+import { publishNotification } from "../events/notifications.js";
+import { log } from "../system/logger/index.js";
+
+export const MCP_FAILURE_THRESHOLD = 3;
+
+// `[A-Za-z0-9-]+` keeps the server segment bounded to typical id
+// characters (no `_` so the trailing `__<tool>` is unambiguous).
+// Avoids the `(a+)+` style backtracking that the security linter
+// flagged in the earlier `([^_]+(?:_[^_]+)*)__` form.
+const MCP_TOOL_NAME_PATTERN = /^mcp__([A-Za-z0-9-]+)__/;
+
+/** Minimal AgentEvent surface the monitor needs. Defined locally to
+ *  avoid a circular import; structurally matches the relevant fields
+ *  on the real `AgentEvent` union. */
+interface TrackableEvent {
+  type: string;
+  toolUseId?: string;
+  toolName?: string;
+  content?: string;
+  isError?: boolean;
+}
+
+interface ServerStats {
+  consecutiveFailures: number;
+  totalFailures: number;
+  totalCalls: number;
+}
+
+interface NotificationSink {
+  publish: typeof publishNotification;
+  warn: (event: string, message: string, data?: Record<string, unknown>) => void;
+}
+
+const defaultSink: NotificationSink = {
+  publish: publishNotification,
+  warn: (event, message, data) => log.warn(event, message, data),
+};
+
+/** Pure helper: returns the server id encoded in an MCP tool name,
+ *  or `null` for non-MCP tools. `mcp__notion__page_create` →
+ *  `"notion"`. */
+export function mcpServerFromToolName(toolName: string): string | null {
+  const match = MCP_TOOL_NAME_PATTERN.exec(toolName);
+  return match ? match[1] : null;
+}
+
+/** Build a session-scoped monitor. Returns the same shape as
+ *  `createMcpTracker` so the backend wires both in the same loop.
+ *
+ *  `sink` is injectable for tests so we don't need to mock the
+ *  notification engine / logger globally. */
+export function createMcpFailureMonitor(opts: { sink?: NotificationSink; threshold?: number } = {}): {
+  track: (event: TrackableEvent) => void;
+} {
+  const sink = opts.sink ?? defaultSink;
+  const threshold = opts.threshold ?? MCP_FAILURE_THRESHOLD;
+  const toolUseIdToServer = new Map<string, string>();
+  const stats = new Map<string, ServerStats>();
+  const notified = new Set<string>();
+
+  function recordCall(toolUseId: string, toolName: string): void {
+    const server = mcpServerFromToolName(toolName);
+    if (server === null) return;
+    toolUseIdToServer.set(toolUseId, server);
+  }
+
+  function recordResult(toolUseId: string, isError: boolean): void {
+    const server = toolUseIdToServer.get(toolUseId);
+    if (server === undefined) return; // not an MCP call (or orphan result)
+    toolUseIdToServer.delete(toolUseId);
+    const entry = stats.get(server) ?? { consecutiveFailures: 0, totalFailures: 0, totalCalls: 0 };
+    entry.totalCalls += 1;
+    if (isError) {
+      entry.consecutiveFailures += 1;
+      entry.totalFailures += 1;
+      if (entry.consecutiveFailures >= threshold && !notified.has(server)) {
+        notified.add(server);
+        emitFailureNotice(server, entry, sink);
+      }
+    } else {
+      entry.consecutiveFailures = 0;
+    }
+    stats.set(server, entry);
+  }
+
+  return {
+    track(event: TrackableEvent): void {
+      if (event.type === EVENT_TYPES.toolCall && typeof event.toolUseId === "string" && typeof event.toolName === "string") {
+        recordCall(event.toolUseId, event.toolName);
+      } else if (event.type === EVENT_TYPES.toolCallResult && typeof event.toolUseId === "string") {
+        recordResult(event.toolUseId, event.isError === true);
+      }
+    },
+  };
+}
+
+function emitFailureNotice(server: string, entry: ServerStats, sink: NotificationSink): void {
+  const message = `MCP server ${server} returned errors on ${String(entry.consecutiveFailures)} consecutive tool calls; check API key, network, or upstream service health.`;
+  sink.warn("mcp", "subprocess appears broken — consecutive tool errors crossed threshold", {
+    server,
+    consecutiveFailures: entry.consecutiveFailures,
+    totalFailures: entry.totalFailures,
+    totalCalls: entry.totalCalls,
+  });
+  sink.publish({
+    // Deterministic id so the notification engine's legacyId dedup
+    // matches across restarts — bell entries from previous boots
+    // for the same broken server don't pile up.
+    id: `mcp-failure-${server}`,
+    kind: "system",
+    title: "MCP server failing",
+    body: message,
+    action: { type: NOTIFICATION_ACTION_TYPES.none },
+    priority: NOTIFICATION_PRIORITIES.high,
+  });
+}

--- a/server/agent/mcpFailureMonitor.ts
+++ b/server/agent/mcpFailureMonitor.ts
@@ -28,11 +28,13 @@ import { log } from "../system/logger/index.js";
 
 export const MCP_FAILURE_THRESHOLD = 3;
 
-// `[A-Za-z0-9-]+` keeps the server segment bounded to typical id
-// characters (no `_` so the trailing `__<tool>` is unambiguous).
-// Avoids the `(a+)+` style backtracking that the security linter
-// flagged in the earlier `([^_]+(?:_[^_]+)*)__` form.
-const MCP_TOOL_NAME_PATTERN = /^mcp__([A-Za-z0-9-]+)__/;
+// Server-id contract — must match `isMcpServerId` in
+// `server/system/config.ts`. Both ends agreeing on this shape is
+// what lets the monitor attribute failures back to the right
+// server entry in `mcp.json` (Codex review on #1356).
+const MCP_SERVER_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+const MCP_PREFIX = "mcp__";
+const MCP_DELIM = "__";
 
 /** Minimal AgentEvent surface the monitor needs. Defined locally to
  *  avoid a circular import; structurally matches the relevant fields
@@ -62,11 +64,28 @@ const defaultSink: NotificationSink = {
 };
 
 /** Pure helper: returns the server id encoded in an MCP tool name,
- *  or `null` for non-MCP tools. `mcp__notion__page_create` →
- *  `"notion"`. */
+ *  or `null` for non-MCP tools.
+ *
+ *  Parses by string-split rather than a single regex so:
+ *    - server ids containing `_` (allowed by `isMcpServerId`, e.g.
+ *      `a1_b2`) attribute correctly. The first `__` after the
+ *      `mcp__` prefix is treated as the server↔tool delimiter, so
+ *      `mcp__a1_b2__do_thing` resolves to server `"a1_b2"`,
+ *      tool-part `"do_thing"`.
+ *    - no regex backtracking surface (Codex flagged ReDoS on the
+ *      previous `[^_]+(?:_[^_]+)*` form; this fix uses split + a
+ *      simple per-character validator instead). */
 export function mcpServerFromToolName(toolName: string): string | null {
-  const match = MCP_TOOL_NAME_PATTERN.exec(toolName);
-  return match ? match[1] : null;
+  if (!toolName.startsWith(MCP_PREFIX)) return null;
+  const rest = toolName.slice(MCP_PREFIX.length);
+  const delim = rest.indexOf(MCP_DELIM);
+  if (delim <= 0) return null;
+  const serverId = rest.slice(0, delim);
+  // The tool-part is everything after the delimiter; it can carry
+  // `__` of its own (some MCP authors use `__` in tool names) — we
+  // only care that something is there.
+  if (rest.length <= delim + MCP_DELIM.length) return null;
+  return MCP_SERVER_ID_PATTERN.test(serverId) ? serverId : null;
 }
 
 /** Build a session-scoped monitor. Returns the same shape as

--- a/server/agent/stream.ts
+++ b/server/agent/stream.ts
@@ -15,6 +15,11 @@ export type AgentEvent =
       type: typeof EVENT_TYPES.toolCallResult;
       toolUseId: string;
       content: string;
+      /** Anthropic's `tool_result` block carries `is_error: true` when
+       *  the MCP server (or other tool) reported an error. Surfaced
+       *  here so the failure monitor (#1353) can attribute repeated
+       *  errors to a specific MCP server and warn / notify. */
+      isError?: boolean;
     }
   | { type: typeof EVENT_TYPES.claudeSessionId; id: string };
 
@@ -27,6 +32,10 @@ export interface ClaudeContentBlock {
   content?: unknown;
   /** Text content — present in `text` type blocks. */
   text?: string;
+  /** Tool-result error flag from the Anthropic API. Present on
+   *  `tool_result` blocks when the tool itself reported failure
+   *  (MCP server returned an error, 401, ECONNREFUSED, …). */
+  is_error?: boolean;
 }
 
 export interface ClaudeMessage {
@@ -73,11 +82,13 @@ export function blockToEvent(block: ClaudeContentBlock): AgentEvent | null {
   if (block.type === "tool_result" && block.tool_use_id) {
     const raw = block.content;
     const content = typeof raw === "string" ? raw : raw === undefined ? "" : JSON.stringify(raw);
-    return {
+    const event: AgentEvent = {
       type: EVENT_TYPES.toolCallResult,
       toolUseId: block.tool_use_id,
       content,
     };
+    if (block.is_error === true) event.isError = true;
+    return event;
   }
   return null;
 }

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -292,10 +292,17 @@ export function isMcpServerSpec(value: unknown): value is McpServerSpec {
 
 // Workspace id must be slug-shaped so it survives being used as the
 // mcpServers map key and in the `mcp__<id>__<tool>` tool naming.
+//
+// Consecutive `__` is forbidden inside the id because `__` is the
+// delimiter in the tool-name encoding — a server id like `foo__bar`
+// produces `mcp__foo__bar__tool`, which is ambiguous between server
+// `foo` (tool `bar__tool`) and server `foo__bar` (tool `tool`).
+// Forbidding `__` in the id keeps the convention unambiguous
+// everywhere (Codex review on #1356).
 const MCP_ID_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 
 export function isMcpServerId(value: unknown): value is string {
-  return typeof value === "string" && MCP_ID_RE.test(value);
+  return typeof value === "string" && MCP_ID_RE.test(value) && !value.includes("__");
 }
 
 export function isMcpConfigFile(value: unknown): value is McpConfigFile {

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -17,6 +17,11 @@ export interface SseToolCallResult {
   type: typeof EVENT_TYPES.toolCallResult;
   toolUseId: string;
   content: string;
+  /** Set when the tool-result block carried `is_error: true` —
+   *  forwarded from `AgentEvent.toolCallResult.isError` so the
+   *  frontend can render the chip distinctly. Drives the MCP
+   *  failure monitor (#1353). */
+  isError?: boolean;
 }
 
 export interface SseStatus {

--- a/test/agent/test_mcpFailureMonitor.ts
+++ b/test/agent/test_mcpFailureMonitor.ts
@@ -1,0 +1,194 @@
+// Tests for the runtime MCP failure monitor (#1353).
+//
+// The monitor consumes `AgentEvent`s, tracks `is_error` ratio per
+// MCP server (parsed from `mcp__<server>__<tool>` toolName), and
+// fires one structured warn + one bell notification once a server
+// crosses a consecutive-failure threshold.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createMcpFailureMonitor, mcpServerFromToolName, MCP_FAILURE_THRESHOLD } from "../../server/agent/mcpFailureMonitor.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
+
+interface CapturedPublish {
+  id: string;
+  body: string;
+}
+interface CapturedWarn {
+  event: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function makeSink() {
+  const publishes: CapturedPublish[] = [];
+  const warns: CapturedWarn[] = [];
+  return {
+    publishes,
+    warns,
+    sink: {
+      // Loose `as never` casts because the real types pull a heavy
+      // notification union that's irrelevant for these assertions —
+      // we only need the `id` + `body` round-trip.
+      publish: ((params: { id: string; body: string }) => {
+        publishes.push({ id: params.id, body: params.body });
+      }) as never,
+      warn: (event: string, message: string, data?: Record<string, unknown>) => {
+        warns.push({ event, message, data });
+      },
+    },
+  };
+}
+
+function toolCall(toolUseId: string, toolName: string) {
+  return { type: EVENT_TYPES.toolCall, toolUseId, toolName };
+}
+
+function toolCallResult(toolUseId: string, isError: boolean) {
+  return { type: EVENT_TYPES.toolCallResult, toolUseId, content: "", isError };
+}
+
+describe("mcpServerFromToolName", () => {
+  it("extracts the server segment from a well-formed MCP tool name", () => {
+    assert.equal(mcpServerFromToolName("mcp__notion__page_create"), "notion");
+    assert.equal(mcpServerFromToolName("mcp__github__create_issue"), "github");
+  });
+
+  it("returns null for non-MCP tools", () => {
+    assert.equal(mcpServerFromToolName("Bash"), null);
+    assert.equal(mcpServerFromToolName("Read"), null);
+    assert.equal(mcpServerFromToolName("ToolSearch"), null);
+  });
+
+  it("returns null for malformed names", () => {
+    assert.equal(mcpServerFromToolName("mcp__"), null);
+    assert.equal(mcpServerFromToolName("mcp_notion"), null);
+  });
+});
+
+describe("createMcpFailureMonitor — threshold + notification", () => {
+  it("does NOT notify before the threshold", () => {
+    const { sink, publishes, warns } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    for (let callIndex = 0; callIndex < MCP_FAILURE_THRESHOLD - 1; callIndex += 1) {
+      monitor.track(toolCall(`id-${String(callIndex)}`, "mcp__notion__page_create"));
+      monitor.track(toolCallResult(`id-${String(callIndex)}`, true));
+    }
+    assert.equal(publishes.length, 0);
+    assert.equal(warns.length, 0);
+  });
+
+  it("notifies exactly once when the threshold is crossed", () => {
+    const { sink, publishes, warns } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    for (let callIndex = 0; callIndex < MCP_FAILURE_THRESHOLD + 2; callIndex += 1) {
+      monitor.track(toolCall(`id-${String(callIndex)}`, "mcp__notion__page_create"));
+      monitor.track(toolCallResult(`id-${String(callIndex)}`, true));
+    }
+    assert.equal(publishes.length, 1, "exactly one bell entry per server");
+    assert.equal(publishes[0].id, "mcp-failure-notion");
+    assert.match(publishes[0].body, /notion/);
+    assert.equal(warns.length, 1);
+  });
+
+  it("resets the consecutive counter on a success", () => {
+    const { sink, publishes } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    // 2 fails — below threshold.
+    monitor.track(toolCall("c1", "mcp__notion__page_create"));
+    monitor.track(toolCallResult("c1", true));
+    monitor.track(toolCall("c2", "mcp__notion__page_create"));
+    monitor.track(toolCallResult("c2", true));
+    // 1 success — resets streak.
+    monitor.track(toolCall("c3", "mcp__notion__page_create"));
+    monitor.track(toolCallResult("c3", false));
+    // 2 more fails — total 4 but only 2 consecutive, still below 3.
+    monitor.track(toolCall("c4", "mcp__notion__page_create"));
+    monitor.track(toolCallResult("c4", true));
+    monitor.track(toolCall("c5", "mcp__notion__page_create"));
+    monitor.track(toolCallResult("c5", true));
+    assert.equal(publishes.length, 0);
+  });
+});
+
+describe("createMcpFailureMonitor — per-server isolation", () => {
+  it("tracks each server independently", () => {
+    const { sink, publishes } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    // notion: 3 fails → notify
+    for (let i = 0; i < 3; i += 1) {
+      monitor.track(toolCall(`n-${String(i)}`, "mcp__notion__page_create"));
+      monitor.track(toolCallResult(`n-${String(i)}`, true));
+    }
+    // github: 3 successes → no notify
+    for (let i = 0; i < 3; i += 1) {
+      monitor.track(toolCall(`g-${String(i)}`, "mcp__github__create_issue"));
+      monitor.track(toolCallResult(`g-${String(i)}`, false));
+    }
+    assert.equal(publishes.length, 1);
+    assert.equal(publishes[0].id, "mcp-failure-notion");
+  });
+
+  it("interleaved failures across servers don't interfere", () => {
+    const { sink, publishes } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    // notion / github / notion / github / notion — 3 notion fails total, 2 github fails total
+    monitor.track(toolCall("n1", "mcp__notion__x"));
+    monitor.track(toolCall("g1", "mcp__github__y"));
+    monitor.track(toolCallResult("n1", true));
+    monitor.track(toolCallResult("g1", true));
+    monitor.track(toolCall("n2", "mcp__notion__x"));
+    monitor.track(toolCall("g2", "mcp__github__y"));
+    monitor.track(toolCallResult("n2", true));
+    monitor.track(toolCallResult("g2", true));
+    monitor.track(toolCall("n3", "mcp__notion__x"));
+    monitor.track(toolCallResult("n3", true));
+    // notion crossed threshold (3), github only at 2
+    assert.equal(publishes.length, 1);
+    assert.equal(publishes[0].id, "mcp-failure-notion");
+  });
+});
+
+describe("createMcpFailureMonitor — ignored / orphan events", () => {
+  it("ignores non-MCP tool errors", () => {
+    const { sink, publishes } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    for (let i = 0; i < 5; i += 1) {
+      monitor.track(toolCall(`id-${String(i)}`, "Bash"));
+      monitor.track(toolCallResult(`id-${String(i)}`, true));
+    }
+    assert.equal(publishes.length, 0);
+  });
+
+  it("ignores an orphan toolCallResult without a prior toolCall", () => {
+    const { sink, publishes } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    monitor.track(toolCallResult("orphan-1", true));
+    monitor.track(toolCallResult("orphan-2", true));
+    assert.equal(publishes.length, 0);
+  });
+});
+
+describe("createMcpFailureMonitor — does not double-notify", () => {
+  it("crossing threshold a second time after a success+failures bursts does NOT publish again", () => {
+    const { sink, publishes } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink });
+    // First burst → notify
+    for (let i = 0; i < 3; i += 1) {
+      monitor.track(toolCall(`a-${String(i)}`, "mcp__notion__x"));
+      monitor.track(toolCallResult(`a-${String(i)}`, true));
+    }
+    assert.equal(publishes.length, 1);
+    // Success resets counter
+    monitor.track(toolCall("ok", "mcp__notion__x"));
+    monitor.track(toolCallResult("ok", false));
+    // Second burst → no duplicate notification (bell entry persists
+    // until user dismisses; the engine's id-dedup matches our
+    // `notified` guard).
+    for (let i = 0; i < 3; i += 1) {
+      monitor.track(toolCall(`b-${String(i)}`, "mcp__notion__x"));
+      monitor.track(toolCallResult(`b-${String(i)}`, true));
+    }
+    assert.equal(publishes.length, 1);
+  });
+});

--- a/test/agent/test_mcpFailureMonitor.ts
+++ b/test/agent/test_mcpFailureMonitor.ts
@@ -90,6 +90,24 @@ describe("mcpServerFromToolName", () => {
     assert.equal(mcpServerFromToolName("mcp__1foo__tool"), null); // leading digit
     assert.equal(mcpServerFromToolName("mcp__foo!bar__tool"), null); // `!` forbidden
   });
+
+  // Codex iter-2 on #1356: `isMcpServerId` was tightened to forbid
+  // consecutive `__` because the `mcp__<server>__<tool>` encoding
+  // would otherwise be ambiguous. For input `mcp__foo__bar__tool`:
+  //   - First-`__` split → server `"foo"`, tool `"bar__tool"`  ✓ taken
+  //   - Hypothetical alt   → server `"foo__bar"`, tool `"tool"` — but
+  //     `foo__bar` is no longer a valid id, so the alt is dead.
+  // Pin both: parser returns the unambiguous first-segment server,
+  // AND the would-be-`__`-containing alt fails validation if anyone
+  // tried to construct it directly.
+  it("treats `__`-containing strings as the unambiguous first-segment server only", () => {
+    assert.equal(mcpServerFromToolName("mcp__foo__bar__tool"), "foo");
+    // A double-underscore name like `foo__bar` is not a legal server
+    // id (config-time isMcpServerId rejects it), so even if a tool
+    // name happens to be exactly `mcp__foo__bar` (server `foo`, tool
+    // `bar`), the parser resolves it unambiguously.
+    assert.equal(mcpServerFromToolName("mcp__foo__bar"), "foo");
+  });
 });
 
 describe("createMcpFailureMonitor — threshold + notification", () => {

--- a/test/agent/test_mcpFailureMonitor.ts
+++ b/test/agent/test_mcpFailureMonitor.ts
@@ -64,6 +64,32 @@ describe("mcpServerFromToolName", () => {
     assert.equal(mcpServerFromToolName("mcp__"), null);
     assert.equal(mcpServerFromToolName("mcp_notion"), null);
   });
+
+  // Regression for the Codex review on #1356: the old regex
+  // (`[A-Za-z0-9-]+`) excluded `_`, but `isMcpServerId` in
+  // `server/system/config.ts` explicitly allows underscores. Servers
+  // like `a1_b2` were silently un-attributed → their repeated
+  // failures never triggered the alert path. Pin the new shape so a
+  // future "let's tighten the regex" change can't silently regress.
+  it("attributes server ids that contain underscores (isMcpServerId contract)", () => {
+    assert.equal(mcpServerFromToolName("mcp__a1_b2__do_thing"), "a1_b2");
+    assert.equal(mcpServerFromToolName("mcp__my_server__tool"), "my_server");
+    assert.equal(mcpServerFromToolName("mcp__under_score_galore__x"), "under_score_galore");
+  });
+
+  it("uses the FIRST `__` after the `mcp__` prefix as the server↔tool delimiter", () => {
+    // Some MCP authors put `__` inside tool names too. The server
+    // half is always the first segment up to the first `__` after
+    // the prefix; what comes after is opaque tool-part.
+    assert.equal(mcpServerFromToolName("mcp__notion__page__create__subaction"), "notion");
+  });
+
+  it("rejects server ids that violate the isMcpServerId shape", () => {
+    // Uppercase / starts-with-digit / too-long / forbidden chars.
+    assert.equal(mcpServerFromToolName("mcp__Bad__tool"), null); // uppercase
+    assert.equal(mcpServerFromToolName("mcp__1foo__tool"), null); // leading digit
+    assert.equal(mcpServerFromToolName("mcp__foo!bar__tool"), null); // `!` forbidden
+  });
 });
 
 describe("createMcpFailureMonitor — threshold + notification", () => {
@@ -89,6 +115,30 @@ describe("createMcpFailureMonitor — threshold + notification", () => {
     assert.equal(publishes[0].id, "mcp-failure-notion");
     assert.match(publishes[0].body, /notion/);
     assert.equal(warns.length, 1);
+  });
+
+  // Sourcery review on #1356: `createMcpFailureMonitor` accepts a
+  // `threshold` override option, but the default-only tests above
+  // wouldn't catch a future refactor that ignores the override.
+  // Pin the wiring with an explicit per-call assertion.
+  it("honours the `threshold` override (single failure triggers when threshold=1)", () => {
+    const { sink, publishes, warns } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink, threshold: 1 });
+    monitor.track(toolCall("id-0", "mcp__notion__page_create"));
+    monitor.track(toolCallResult("id-0", true));
+    assert.equal(publishes.length, 1, "threshold=1 → one failure is enough");
+    assert.equal(warns.length, 1);
+  });
+
+  it("honours a high `threshold` override (5 failures don't trigger when threshold=10)", () => {
+    const { sink, publishes, warns } = makeSink();
+    const monitor = createMcpFailureMonitor({ sink, threshold: 10 });
+    for (let callIndex = 0; callIndex < 5; callIndex += 1) {
+      monitor.track(toolCall(`id-${String(callIndex)}`, "mcp__notion__page_create"));
+      monitor.track(toolCallResult(`id-${String(callIndex)}`, true));
+    }
+    assert.equal(publishes.length, 0, "threshold=10 stays silent below 10 failures");
+    assert.equal(warns.length, 0);
   });
 
   it("resets the consecutive counter on a success", () => {

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -243,6 +243,21 @@ describe("isMcpServerId", () => {
     assert.equal(mod.isMcpServerId("Foo"), false);
     assert.equal(mod.isMcpServerId("has space"), false);
   });
+
+  // Codex iter-2 on #1356: consecutive `__` is forbidden because the
+  // tool-naming encoding (`mcp__<server>__<tool>`) uses `__` as the
+  // delimiter — a server id like `foo__bar` produces a tool name
+  // ambiguous between server `foo` and server `foo__bar`. Single `_`
+  // is still allowed.
+  it("rejects ids containing consecutive `__` (delimiter collision)", () => {
+    assert.equal(mod.isMcpServerId("foo__bar"), false);
+    assert.equal(mod.isMcpServerId("a__b"), false);
+    assert.equal(mod.isMcpServerId("__leading"), false);
+    assert.equal(mod.isMcpServerId("trailing__"), false);
+    // Single `_` still accepted (regression guard).
+    assert.ok(mod.isMcpServerId("foo_bar"));
+    assert.ok(mod.isMcpServerId("a_b_c"));
+  });
 });
 
 describe("loadMcpConfig / saveMcpConfig", () => {


### PR DESCRIPTION
## Summary

- New `server/agent/mcpFailureMonitor.ts` consumes `tool_result.is_error` from Claude Code's stream-json, attributes errors to the originating MCP server (`mcp__<server>__<tool>`), and fires **one** structured warn log + **one** bell notification per server when consecutive failures cross `MCP_FAILURE_THRESHOLD = 3`.
- `stream.ts` now surfaces `is_error` on `AgentEvent.toolCallResult.isError` (it was being dropped). Mirrored on `SseToolCallResult` for frontend consumers (useful for #1354).
- Wired next to the existing `mcpTracker` in `backend/claude-code.ts` — same event loop, complementary signals (tracker spots "MCP never invoked", monitor spots "MCP invoked but consistently failing").

## Items to Confirm / Review

1. **Threshold = 3 consecutive failures.** Rationale in the plan + commit body: a single `is_error: true` is often "user asked the MCP something invalid"; three consecutive failures with no successes between them is the strong "this server is broken" signal. Constant is exported so a future config / test override fits without touching this PR.

2. **Bell notification id `mcp-failure-<server>`** is deterministic so the notification engine's `legacyId` dedup matches across restarts — the user doesn't get a fresh bell entry every time the server restarts.

3. **Auto-dismiss on recovery is deferred.** The notification engine doesn't expose a public dismissal API at the moment; once it does, recovery (consecutive successes after a flag) can auto-clear the bell. For now the entry stays until the user dismisses manually. This is called out in the commit body so future work picks it up.

4. **Defensive `getActivePlugins` wrapping** — the issue mentioned "wrap getActiveToolDescriptors in defensive try/catch". After auditing, all `getActiveToolDescriptors` consumers are pure-data reads against an in-memory list; nothing throws today. I left them as-is rather than adding speculative try/catch. If a malformed-role crash ever surfaces we add the guard then.

## User Prompt

> mcpとかで設定値が必要なもので設定されてない場合は、起動時にログでアラート出す？あと、そのmcp自体は読み込まないとか、key違って失敗した場合でもきちんとログ逃がしたいよね。で、サーバ死なないように。

Split into #1352 (boot-time preflight + skip — merged via #1355), this PR for #1353 (runtime crash signal), and #1354 (structured error to LLM on call into unavailable server). KazusaNakagawa's withdrawn #1349 (markdown fallback) is a separate idea.

## Implementation Approach

1. **`server/agent/stream.ts`** — surface `is_error` from the `tool_result` content block to `AgentEvent.toolCallResult.isError`.

2. **`server/agent/mcpFailureMonitor.ts`** (new) — session-scoped monitor:
   - Builds a `Map<toolUseId, serverId>` from `toolCall` events.
   - On `toolCallResult` with `isError: true`, increments consecutive-failure counter for the server; success resets it.
   - On threshold cross, calls a `NotificationSink` (injectable for tests) that wraps `publishNotification` + `log.warn`.
   - One-shot `notified: Set<string>` guard prevents double-publishing per server per process lifetime.

3. **`server/agent/backend/claude-code.ts`** — instantiates the monitor next to `mcpTracker` and feeds each parsed `AgentEvent` through `monitor.track(event)`.

4. **`test/agent/test_mcpFailureMonitor.ts`** — 11 cases:
   - Pure `mcpServerFromToolName` extraction (3 cases).
   - Threshold below / at / above (no-notify / no-notify / notify).
   - Success reset of counter (interleaved fails + success + fails).
   - Per-server isolation (notion fails 3× while github succeeds → only notion notified).
   - Interleaved across servers.
   - Non-MCP tool errors (Bash, Read) — ignored.
   - Orphan toolCallResult (no prior toolCall) — ignored, no crash.
   - No double-notify after success+second-burst.

## Test Plan

- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] 11/11 failure-monitor tests pass
- [ ] Manual: workspace with broken Notion API key → call into Notion 3 times → bell shows `MCP server failing`, log line `mcp: subprocess appears broken — consecutive tool errors crossed threshold`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a runtime monitor that tracks consecutive MCP server tool-call failures using the Anthropic `tool_result.is_error` flag and surfaces per-server alerts.

New Features:
- Surface `isError` from Anthropic `tool_result.is_error` into internal `AgentEvent.toolCallResult` and SSE tool call result events for downstream consumers.
- Add an MCP runtime failure monitor that tracks consecutive per-server tool failures and emits a single warning log and bell notification once a threshold is crossed.

Enhancements:
- Wire the MCP failure monitor into the Claude Code backend event loop alongside the existing MCP tracker to observe the shared agent event stream.

Documentation:
- Add a design plan document describing the MCP runtime failure monitoring approach, thresholds, behavior, and limitations.

Tests:
- Add unit tests covering MCP server name parsing, threshold behavior, per-server isolation, ignored/orphan events, and deduplication of notifications for the failure monitor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP runtime failure monitoring to detect and alert when MCP servers consistently fail after initialization
  * Frontend now displays error status for tool results

* **Tests**
  * Added comprehensive test suite for MCP failure monitoring behavior and thresholds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1356)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->