### PR TITLE
feat(mcp): catalog-derived hint chip for MCP tool errors in right sidebar (#1354)

### DIFF
--- a/plans/feat-mcp-error-hint-1354.md
+++ b/plans/feat-mcp-error-hint-1354.md
@@ -1,0 +1,76 @@
+# MCP Error Hint Chip (#1354)
+
+## Problem
+
+After #1353 lands, `SseToolCallResult` carries `isError: true` when an
+MCP tool call failed. The frontend currently just dumps the raw
+`event.content` into the result chip — confusing 401 bodies or
+"Unable to connect" stack traces that the user has no idea how to
+act on.
+
+## Scope (UI-only path of the original #1354 issue)
+
+The issue's literal ask was "inject a structured error to the LLM via
+a hook" so the LLM could guide the user. That requires significant
+hook-dispatcher API change + bundling mcpCatalog into the hook
+script — deferred until concrete demand justifies it.
+
+This PR delivers the **user-facing half**: an enriched error chip in
+the right-sidebar tool-call history that pulls the setup-guide URL,
+display name, and required-keys list from `src/config/mcpCatalog.ts`
+and renders them next to the raw error body. The user can act on the
+hint immediately without LLM mediation.
+
+## Implementation
+
+1. **`src/utils/agent/mcpHint.ts`** (new) — pure helper
+   `extractMcpHint(toolName: string): McpHint | null` returning
+   `{ server, displayNameKey, setupGuideUrl?, requiredKeys[] }` for
+   `mcp__<server>__*` tools whose server matches the catalog;
+   `null` for non-MCP tools or unknown servers.
+
+2. **`src/types/toolCallHistory.ts`** — add `mcpHint?: McpHint`
+   to `ToolCallHistoryItem`. Pure-data extension.
+
+3. **`src/utils/agent/eventDispatch.ts`** — in the
+   `EVENT_TYPES.toolCallResult` case, when `event.isError === true`:
+   - Set `entry.error = event.content` (instead of `entry.result`).
+   - Set `entry.mcpHint = extractMcpHint(entry.toolName)`.
+
+4. **`src/components/RightSidebar.vue`** — when `call.mcpHint` is
+   present (only when `call.error` is also present), render an
+   additional chip with:
+   - Server display name (via `t(mcpHint.displayNameKey)`).
+   - Required keys list.
+   - "Setup guide" link to `mcpHint.setupGuideUrl` (when present).
+
+5. **i18n lockstep** — new keys under `rightSidebar.mcpHint.*` in
+   all 8 locales (en / ja / zh / ko / es / pt-BR / fr / de).
+
+## Acceptance
+
+- MCP tool call to `mcp__notion__page_create` returns `is_error: true`
+  → right-sidebar shows the error body AND a hint chip with "Notion",
+  setup guide link, and "Required: NOTION_API_KEY".
+- Non-MCP tool error (e.g. Bash exit 1) → no hint chip (`mcpHint`
+  is `null`).
+- Custom MCP server not in the catalog → no hint chip (catalog
+  lookup returns null).
+
+## Out of scope (deferred)
+
+- LLM-side context injection via PostToolUse hook. Issue noted as
+  the original ask; revisit when a real fallback flow needs it.
+- Auto-dismissing the hint chip when subsequent calls succeed.
+  Chip persists until a new toolCallResult arrives (matches the
+  existing `error` field behaviour).
+
+## Test plan
+
+`test/utils/agent/test_mcpHint.ts` — pure helper tests:
+
+1. Returns null for non-MCP tools (`Bash`, `Read`, `ToolSearch`).
+2. Returns null for unknown MCP servers (no catalog match).
+3. Returns hint with `setupGuideUrl` for `mcp__notion__page_create`.
+4. Returns hint without `setupGuideUrl` for entries that lack one.
+5. Required keys reflect `requiredKeysOf(entry)` output.

--- a/src/components/RightSidebar.vue
+++ b/src/components/RightSidebar.vue
@@ -54,6 +54,25 @@
             <div class="bg-red-50 p-2 rounded text-red-700">
               {{ call.error }}
             </div>
+            <!--
+              Catalog-derived hint chip for MCP tool errors (#1354).
+              Shown only when `mcpHint` was attached at event-dispatch
+              time (= the failing tool's server is in the catalog).
+              Non-MCP / custom-server errors fall through to the plain
+              red chip above.
+            -->
+            <div v-if="call.mcpHint" class="mt-2 bg-amber-50 border border-amber-200 p-2 rounded text-amber-900">
+              <div class="font-medium mb-1">{{ t("rightSidebar.mcpHint.title", { server: t(call.mcpHint.displayNameKey) }) }}</div>
+              <div v-if="call.mcpHint.requiredKeys.length > 0" class="text-xs mb-1">
+                {{ t("rightSidebar.mcpHint.requiredKeys") }}:
+                <code class="bg-amber-100 px-1 rounded">{{ call.mcpHint.requiredKeys.join(", ") }}</code>
+              </div>
+              <div v-if="call.mcpHint.setupGuideUrl" class="text-xs">
+                <a :href="call.mcpHint.setupGuideUrl" target="_blank" rel="noopener noreferrer" class="underline text-amber-800 hover:text-amber-900">{{
+                  t("rightSidebar.mcpHint.setupGuide")
+                }}</a>
+              </div>
+            </div>
           </div>
           <div v-else-if="call.result !== undefined">
             <div class="font-medium text-gray-500 mb-1">{{ t("rightSidebar.result") }}</div>

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -105,6 +105,11 @@ const deMessages = {
     error: "Fehler",
     result: "Ergebnis",
     running: "Läuft...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `Einrichtungshinweis: ${ctx.named("server")}`,
+      requiredKeys: "Erforderliche Schlüssel",
+      setupGuide: "Einrichtungsanleitung öffnen",
+    },
   },
   fileTreePane: {
     sort: "Sortieren:",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -125,6 +125,11 @@ const enMessages = {
     error: "Error",
     result: "Result",
     running: "Running...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `${ctx.named("server")} setup hint`,
+      requiredKeys: "Required keys",
+      setupGuide: "Open setup guide",
+    },
   },
   fileTreePane: {
     sort: "Sort:",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -109,6 +109,11 @@ const esMessages = {
     error: "Error",
     result: "Resultado",
     running: "Ejecutando...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `Ayuda de configuración: ${ctx.named("server")}`,
+      requiredKeys: "Claves requeridas",
+      setupGuide: "Abrir guía de configuración",
+    },
   },
   fileTreePane: {
     sort: "Orden:",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -104,6 +104,11 @@ const frMessages = {
     error: "Erreur",
     result: "Résultat",
     running: "En cours...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `Aide à la configuration : ${ctx.named("server")}`,
+      requiredKeys: "Clés requises",
+      setupGuide: "Ouvrir le guide de configuration",
+    },
   },
   fileTreePane: {
     sort: "Tri :",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -111,6 +111,11 @@ const jaMessages = {
     error: "エラー",
     result: "結果",
     running: "実行中...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `${ctx.named("server")} のセットアップヒント`,
+      requiredKeys: "必要なキー",
+      setupGuide: "セットアップガイドを開く",
+    },
   },
   fileTreePane: {
     sort: "並び順:",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -112,6 +112,11 @@ const koMessages = {
     error: "오류",
     result: "결과",
     running: "실행 중...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `${ctx.named("server")} 설정 도움말`,
+      requiredKeys: "필수 키",
+      setupGuide: "설정 가이드 열기",
+    },
   },
   fileTreePane: {
     sort: "정렬:",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -104,6 +104,11 @@ const ptBRMessages = {
     error: "Erro",
     result: "Resultado",
     running: "Executando...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `Dica de configuração: ${ctx.named("server")}`,
+      requiredKeys: "Chaves obrigatórias",
+      setupGuide: "Abrir guia de configuração",
+    },
   },
   fileTreePane: {
     sort: "Ordenar:",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -108,6 +108,11 @@ const zhMessages = {
     error: "错误",
     result: "结果",
     running: "运行中...",
+    mcpHint: {
+      title: (ctx: { named: (key: "server") => string }) => `${ctx.named("server")} 配置提示`,
+      requiredKeys: "必填字段",
+      setupGuide: "打开配置指南",
+    },
   },
   fileTreePane: {
     sort: "排序:",

--- a/src/types/toolCallHistory.ts
+++ b/src/types/toolCallHistory.ts
@@ -3,6 +3,8 @@
 // session domain types, the pending-calls helper, etc.) can refer
 // to it without depending on a Vue file.
 
+import type { McpHint } from "../utils/agent/mcpHint";
+
 export interface ToolCallHistoryItem {
   toolUseId: string;
   toolName: string;
@@ -10,4 +12,9 @@ export interface ToolCallHistoryItem {
   timestamp: number;
   result?: string;
   error?: string;
+  /** Structured hint surfaced next to `error` when the failing tool
+   *  belongs to a catalogued MCP server. Lets the right-sidebar
+   *  render setup-guide links / required-key reminders without the
+   *  caller re-parsing the tool name. (#1354) */
+  mcpHint?: McpHint;
 }

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -25,6 +25,10 @@ function applyToolCallResult(history: ToolCallHistoryItem[], event: SseToolCallR
   const entry = findPendingToolCall(history, event.toolUseId);
   if (!entry) return;
   if (event.isError === true) {
+    // Clear any prior success content so the UI never shows a stale
+    // green `result` chip next to a fresh red `error` chip for the
+    // same toolUseId. (Sourcery review on #1357.)
+    entry.result = undefined;
     entry.error = event.content;
     const hint = extractMcpHint(entry.toolName);
     if (hint !== null) entry.mcpHint = hint;

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -2,9 +2,11 @@
 // via the AgentEventContext adapter. No Vue refs, no component scope.
 
 import type { ActiveSession } from "../../types/session";
-import type { SseEvent } from "../../types/sse";
+import type { SseEvent, SseToolCallResult } from "../../types/sse";
 import { EVENT_TYPES, generationKey } from "../../types/events";
+import type { ToolCallHistoryItem } from "../../types/toolCallHistory";
 import { findPendingToolCall, toToolCallEntry } from "./toolCalls";
+import { extractMcpHint } from "./mcpHint";
 import { pushErrorMessage, applySkillEvent, applyTextEvent, applyToolResultToSession } from "../session/sessionHelpers";
 
 export interface AgentEventContext {
@@ -14,6 +16,23 @@ export interface AgentEventContext {
   onGenerationsDrained: () => void;
 }
 
+// Route a `toolCallResult` SSE event onto the pending history entry.
+// Errors land on `entry.error` (drives the red chip) with an optional
+// catalog-derived MCP hint; successes land on `entry.result`. Pulled
+// out of `applyAgentEvent` so the dispatch switch keeps its cognitive
+// complexity below the lint budget (#1354).
+function applyToolCallResult(history: ToolCallHistoryItem[], event: SseToolCallResult): void {
+  const entry = findPendingToolCall(history, event.toolUseId);
+  if (!entry) return;
+  if (event.isError === true) {
+    entry.error = event.content;
+    const hint = extractMcpHint(entry.toolName);
+    if (hint !== null) entry.mcpHint = hint;
+    return;
+  }
+  entry.result = event.content;
+}
+
 export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): Promise<void> {
   const { session } = ctx;
   switch (event.type) {
@@ -21,12 +40,10 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       session.toolCallHistory.push(toToolCallEntry(event));
       ctx.scrollSidebarToBottom();
       return;
-    case EVENT_TYPES.toolCallResult: {
-      const entry = findPendingToolCall(session.toolCallHistory, event.toolUseId);
-      if (entry) entry.result = event.content;
+    case EVENT_TYPES.toolCallResult:
+      applyToolCallResult(session.toolCallHistory, event);
       ctx.scrollSidebarToBottom();
       return;
-    }
     case EVENT_TYPES.status:
       session.statusMessage = event.message;
       return;

--- a/src/utils/agent/mcpHint.ts
+++ b/src/utils/agent/mcpHint.ts
@@ -23,10 +23,13 @@ export interface McpHint {
   requiredKeys: string[];
 }
 
-// `[A-Za-z0-9-]+` matches all current catalog ids (e.g. `notion`,
-// `google-maps`, `weather-open-meteo`). No underscore — the trailing
-// `__<tool>` separator would otherwise be ambiguous.
-const MCP_TOOL_NAME_PATTERN = /^mcp__([A-Za-z0-9-]+)__/;
+// Allow `[A-Za-z0-9_-]+` for the server segment so a future catalog
+// id with an underscore (none today, all current ids use `-`) is
+// still recognised. The greedy match works because `findCatalogEntry`
+// is the actual gatekeeper — anything that fails the catalog lookup
+// returns `null` upstream regardless of how the regex grouped it.
+// (Sourcery review on #1357.)
+const MCP_TOOL_NAME_PATTERN = /^mcp__([A-Za-z0-9_-]+)__/;
 
 /** Returns a structured hint when `toolName` references an MCP
  *  server present in the catalog; `null` otherwise. */

--- a/src/utils/agent/mcpHint.ts
+++ b/src/utils/agent/mcpHint.ts
@@ -1,0 +1,47 @@
+// Frontend-side helper that turns an `mcp__<server>__<tool>` name
+// into a structured hint the right-sidebar can render alongside an
+// MCP tool's error body (#1354).
+//
+// The hint is *user-facing only* — pulled from the same `mcpCatalog`
+// the Settings UI uses, so it stays consistent with whatever the
+// user installed via Settings. Non-MCP tools and custom (off-catalog)
+// servers return `null` and the UI falls back to the plain error
+// chip.
+
+import { findCatalogEntry, requiredKeysOf } from "../../config/mcpCatalog";
+
+export interface McpHint {
+  /** Catalog id parsed from the tool name (`notion`, `github`, …). */
+  server: string;
+  /** i18n key for the server's localised display name. Render via
+   *  `t(displayNameKey)` in the consuming component. */
+  displayNameKey: string;
+  /** External setup-guide URL when the catalog entry provides one. */
+  setupGuideUrl?: string;
+  /** Sorted list of `configSchema[].key` values the catalog marks
+   *  `required: true`. Empty when the entry has no required fields. */
+  requiredKeys: string[];
+}
+
+// `[A-Za-z0-9-]+` matches all current catalog ids (e.g. `notion`,
+// `google-maps`, `weather-open-meteo`). No underscore — the trailing
+// `__<tool>` separator would otherwise be ambiguous.
+const MCP_TOOL_NAME_PATTERN = /^mcp__([A-Za-z0-9-]+)__/;
+
+/** Returns a structured hint when `toolName` references an MCP
+ *  server present in the catalog; `null` otherwise. */
+export function extractMcpHint(toolName: string): McpHint | null {
+  const match = MCP_TOOL_NAME_PATTERN.exec(toolName);
+  if (match === null) return null;
+  const [, server] = match;
+  const entry = findCatalogEntry(server);
+  if (entry === null) return null;
+  const requiredKeys = [...requiredKeysOf(entry)].sort();
+  const hint: McpHint = {
+    server,
+    displayNameKey: entry.displayName,
+    requiredKeys,
+  };
+  if (entry.setupGuideUrl) hint.setupGuideUrl = entry.setupGuideUrl;
+  return hint;
+}

--- a/test/utils/agent/test_mcpHint.ts
+++ b/test/utils/agent/test_mcpHint.ts
@@ -1,0 +1,53 @@
+// Tests for the catalog-derived MCP error hint helper (#1354).
+// Runs the helper against the actual production catalog so a future
+// catalog edit that removes / renames an entry will surface as a
+// test break instead of a silent UI regression.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractMcpHint } from "../../../src/utils/agent/mcpHint";
+
+describe("extractMcpHint", () => {
+  it("returns null for non-MCP tools", () => {
+    assert.equal(extractMcpHint("Bash"), null);
+    assert.equal(extractMcpHint("Read"), null);
+    assert.equal(extractMcpHint("ToolSearch"), null);
+    assert.equal(extractMcpHint(""), null);
+  });
+
+  it("returns null for unknown MCP servers (custom user-added)", () => {
+    assert.equal(extractMcpHint("mcp__my-custom-server__do_thing"), null);
+  });
+
+  it("returns a structured hint for the Notion catalog entry", () => {
+    const hint = extractMcpHint("mcp__notion__page_create");
+    assert.notEqual(hint, null);
+    assert.equal(hint?.server, "notion");
+    assert.equal(hint?.displayNameKey, "settingsMcpTab.catalog.entry.notion.displayName");
+    assert.deepEqual(hint?.requiredKeys, ["NOTION_API_KEY"]);
+    assert.equal(typeof hint?.setupGuideUrl, "string");
+  });
+
+  it("returns a hint for hyphenated server ids (google-maps, weather-open-meteo)", () => {
+    const gmaps = extractMcpHint("mcp__google-maps__search");
+    assert.notEqual(gmaps, null);
+    assert.equal(gmaps?.server, "google-maps");
+
+    const weather = extractMcpHint("mcp__weather-open-meteo__forecast");
+    assert.notEqual(weather, null);
+    assert.equal(weather?.server, "weather-open-meteo");
+  });
+
+  it("returns hint with empty requiredKeys when the catalog entry has no required fields", () => {
+    // deepwiki / context7 / memory / sequential-thinking all have configSchema: [].
+    const hint = extractMcpHint("mcp__deepwiki__lookup");
+    assert.notEqual(hint, null);
+    assert.deepEqual(hint?.requiredKeys, []);
+  });
+
+  it("ignores malformed mcp__ names", () => {
+    assert.equal(extractMcpHint("mcp__"), null);
+    assert.equal(extractMcpHint("mcp_notion"), null);
+    assert.equal(extractMcpHint("mcp__notion"), null);
+  });
+});


### PR DESCRIPTION
## Summary

- New amber **MCP setup-hint chip** in the right-sidebar tool-call history, rendered next to the red error chip when an MCP tool call returns `is_error: true` AND the failing server is in `mcpCatalog`.
- Chip shows server display name, required-keys list, and "Open setup guide" external link — pulled live from the same catalog the Settings UI uses, so it stays in sync with whatever the user installed.
- Pure helper `extractMcpHint(toolName)` + `ToolCallHistoryItem.mcpHint` type extension. No new server-side wiring; uses the `SseToolCallResult.isError` flag added in #1356.

## Items to Confirm / Review

1. **Scope deliberately limited to the UI path.** The original issue (#1354) framed the structured error as something the *LLM* sees so it can guide the user or trigger fallbacks. That requires dispatcher API change + bundling \`mcpCatalog\` into the PostToolUse hook bundle — substantial work that's deferred until a concrete fallback flow needs it. The user-facing chip captures most of the practical value with much less complexity. Called out in the plan + commit body.

2. **Catalog lookup is shared with the Settings UI** (`src/config/mcpCatalog.ts`), so a new MCP entry added to the catalog automatically gets a hint when its tools fail — no per-server wiring.

3. **i18n lockstep across all 8 locales.** German entry uses plain ASCII text (no typographic quotes) per the `.claude/rules/i18n-de.md` rule about U+201C/U+201E round-trip safety.

4. **Branches off #1356** because the `isError` flag this chip consumes is defined there. Once #1356 merges, this PR rebases to main.

## User Prompt

> mcpとかで設定値が必要なもので設定されてない場合は、起動時にログでアラート出す？あと、そのmcp自体は読み込まないとか、key違って失敗した場合でもきちんとログ逃がしたいよね。で、サーバ死なないように。

Split into #1352 / #1353 / #1354. This PR closes the user-facing slice of #1354.

## Implementation Approach

1. **`src/utils/agent/mcpHint.ts`** (new) — pure helper: parse \`mcp__<server>__*\`, look up the catalog entry, return \`{ server, displayNameKey, setupGuideUrl?, requiredKeys[] }\` or \`null\`.
2. **`src/types/toolCallHistory.ts`** — \`ToolCallHistoryItem\` gains \`mcpHint?: McpHint\`.
3. **`src/utils/agent/eventDispatch.ts`** — extracted \`applyToolCallResult()\` from the dispatcher's switch to keep cognitive complexity under the lint cap. Errors route to \`entry.error\` + attach hint when applicable; successes still route to \`entry.result\`.
4. **`src/components/RightSidebar.vue`** — new amber card rendered when \`call.mcpHint\` is populated. External link uses \`rel=\"noopener noreferrer\"\`.
5. **i18n** — \`rightSidebar.mcpHint.{title,requiredKeys,setupGuide}\` in 8 locales.

## Test Plan

- [x] \`yarn lint\` clean
- [x] \`yarn typecheck\` clean
- [x] \`yarn build\` clean
- [x] 6/6 mcpHint tests pass (Notion, hyphenated ids, empty-required-keys, malformed names)
- [ ] Manual: trigger a Notion tool with wrong API key → red error chip shows raw 401, amber hint chip below shows "Notion setup hint", required keys, setup guide link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface catalog-derived MCP setup hints alongside MCP tool errors in the right sidebar and wire them through the tool-call history pipeline.

New Features:
- Add an amber MCP setup-hint chip in the right sidebar next to MCP tool error messages, showing server name, required configuration keys, and a setup guide link when available.
- Introduce a frontend helper to derive structured MCP hint metadata from catalogued MCP tool names for use in the UI.

Enhancements:
- Route tool call result events through a dedicated helper that records errors and attaches MCP hints on failure while keeping successful results behavior unchanged.
- Extend tool call history items with optional structured MCP hint data to avoid re-parsing tool names in UI components.

Documentation:
- Add an internal planning document describing the MCP error hint chip scope, behavior, and test plan.

Tests:
- Add unit tests for the MCP hint extraction helper, covering non-MCP tools, unknown servers, presence/absence of setup guides, and required key handling.