### PR TITLE
chore(helps): align model names in business.md / mulmoscript.md with presentMulmoScript canonical structure (#1009)

### DIFF
--- a/server/workspace/helps/business.md
+++ b/server/workspace/helps/business.md
@@ -37,8 +37,8 @@ Reach for `presentMulmoScript` when the user asks for a presentation, slideshow,
       }
     }
   },
-  "imageParams": { "provider": "google", "model": "gemini-2.5-flash-image" },
-  "movieParams": { "provider": "google", "model": "veo-2.0-generate-001" },
+  "imageParams": { "provider": "google", "model": "gemini-3.1-flash-image-preview" },
+  "movieParams": { "provider": "google", "model": "veo-3.1-generate" },
   "textSlideParams": { "cssStyles": "body { background-color: white; }" },
   "beats": [
     {

--- a/server/workspace/helps/mulmoscript.md
+++ b/server/workspace/helps/mulmoscript.md
@@ -11,8 +11,8 @@ MulmoScript files are rendered in the canvas. The underlying engine is [mulmocas
 | Purpose | Provider | Example config |
 |---|---|---|
 | TTS (speech) | `gemini` | `"provider": "gemini", "voiceId": "Kore"` |
-| Image generation | `google` | `"provider": "google", "model": "gemini-2.5-flash-image"` |
-| Video generation | `google` | `"provider": "google", "model": "veo-2.0-generate-001"` |
+| Image generation | `google` | `"provider": "google", "model": "gemini-3.1-flash-image-preview"` |
+| Video generation | `google` | `"provider": "google", "model": "veo-3.1-generate"` |
 
 Do not use `openai`, `elevenlabs`, or other providers — they are not configured in this app.
 
@@ -225,7 +225,7 @@ Control BGM and volume mixing.
       "Presenter": { "provider": "gemini", "voiceId": "Kore", "displayName": { "en": "Presenter" } }
     }
   },
-  "imageParams": { "provider": "google", "model": "gemini-2.5-flash-image" },
+  "imageParams": { "provider": "google", "model": "gemini-3.1-flash-image-preview" },
   "beats": [
     {
       "speaker": "Presenter",


### PR DESCRIPTION
## Summary

Help files `business.md` and `mulmoscript.md` still named the stale `gemini-2.5-flash-image` / `veo-2.0-generate-001` models. Updated to match the canonical structure in `src/plugins/presentMulmoScript/definition.ts` (`gemini-3.1-flash-image-preview` / `veo-3.1-generate`).

## Items to Confirm

- 3 edits total: `business.md:40-41` (JSON template), `mulmoscript.md:14-15` (provider/model reference table), `mulmoscript.md:228` (embedded JSON example).
- `gemini.md:22` lists older Veo names as historical examples — left alone since it's documenting the model family, not prescribing one (matches the issue's "Optional / unchanged" note).

## User Prompt

> #1009 修正されてないか確認してなければ対応して、マージ後、このissueに書き込んで確認してもらおう

Confirmed not yet fixed; this PR closes the drift.

## Test Plan

- [x] `yarn lint` clean
- [x] Grep confirms all 3 sites updated and no `gemini-2.5-flash-image` / `veo-2.0-generate-001` remains in `business.md` / `mulmoscript.md`.

Closes #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)