### PR TITLE
fix(presentMulmoScript): inline error chip + retry on movie generation failure (#1197)

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1148,6 +1148,8 @@ const deMessages = {
     stop: "■ Stoppen",
     playPresentation: "Präsentation abspielen",
     regenerateMovie: "Video neu generieren",
+    movieGenerationFailed: "Videoerstellung fehlgeschlagen",
+    retry: "Erneut versuchen",
     errPrefix: "⚠ Fehler",
     noBeats: "Keine Beats im Skript gefunden",
     editSource: "Skript-Quelle bearbeiten",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1133,6 +1133,8 @@ const enMessages = {
     stop: "■ Stop",
     playPresentation: "Play presentation",
     regenerateMovie: "Regenerate movie",
+    movieGenerationFailed: "Movie generation failed",
+    retry: "Retry",
     errPrefix: "⚠ Error",
     noBeats: "No beats found in script",
     editSource: "Edit Script Source",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1145,6 +1145,8 @@ const esMessages = {
     stop: "■ Detener",
     playPresentation: "Reproducir presentación",
     regenerateMovie: "Regenerar vídeo",
+    movieGenerationFailed: "Error al generar el vídeo",
+    retry: "Reintentar",
     errPrefix: "⚠ Error",
     noBeats: "No se encontraron beats en el script",
     editSource: "Editar fuente del script",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1139,6 +1139,8 @@ const frMessages = {
     stop: "■ Arrêter",
     playPresentation: "Lire la présentation",
     regenerateMovie: "Régénérer la vidéo",
+    movieGenerationFailed: "Échec de la génération de la vidéo",
+    retry: "Réessayer",
     errPrefix: "⚠ Erreur",
     noBeats: "Aucun beat trouvé dans le script",
     editSource: "Modifier la source du script",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1134,6 +1134,8 @@ const jaMessages = {
     stop: "■ 停止",
     playPresentation: "プレゼンテーション再生",
     regenerateMovie: "動画を再生成",
+    movieGenerationFailed: "動画の生成に失敗しました",
+    retry: "再試行",
     errPrefix: "⚠ エラー",
     noBeats: "スクリプトにビートが見つかりません",
     editSource: "スクリプトソースを編集",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1134,6 +1134,8 @@ const koMessages = {
     stop: "■ 정지",
     playPresentation: "프레젠테이션 재생",
     regenerateMovie: "동영상 재생성",
+    movieGenerationFailed: "동영상 생성에 실패했습니다",
+    retry: "다시 시도",
     errPrefix: "⚠ 오류",
     noBeats: "스크립트에서 비트를 찾을 수 없습니다",
     editSource: "스크립트 원본 편집",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1134,6 +1134,8 @@ const ptBRMessages = {
     stop: "■ Parar",
     playPresentation: "Reproduzir apresentação",
     regenerateMovie: "Regenerar vídeo",
+    movieGenerationFailed: "Falha ao gerar o vídeo",
+    retry: "Tentar novamente",
     errPrefix: "⚠ Erro",
     noBeats: "Nenhum beat encontrado no script",
     editSource: "Editar fonte do script",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1126,6 +1126,8 @@ const zhMessages = {
     stop: "■ 停止",
     playPresentation: "播放演示",
     regenerateMovie: "重新生成视频",
+    movieGenerationFailed: "视频生成失败",
+    retry: "重试",
     errPrefix: "⚠ 错误",
     noBeats: "脚本中没有找到 beat",
     editSource: "编辑脚本源",

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -89,6 +89,29 @@
       </div>
     </div>
 
+    <!--
+      Inline error chip for movie-generation failures (#1197).
+      Previously the catch arm of `generateMovie` raised an `alert()` —
+      blocking, no retry path, and many users just dismissed the modal
+      and saw a stalled spinner with no explanation. The chip stays
+      visible until the next generate attempt clears it.
+    -->
+    <div v-if="movieError" class="bg-red-50 border border-red-200 text-red-800 text-xs px-3 py-2 mx-4 mt-3 mb-1 rounded flex items-start gap-2">
+      <span class="material-icons text-base shrink-0 mt-px">error_outline</span>
+      <div class="flex-1 min-w-0">
+        <div class="font-medium">{{ t("pluginMulmoScript.movieGenerationFailed") }}</div>
+        <div class="break-words whitespace-pre-wrap mt-0.5">{{ movieError }}</div>
+      </div>
+      <button
+        class="shrink-0 h-7 px-2 text-xs rounded border border-red-300 text-red-700 hover:bg-red-100 disabled:opacity-50"
+        :disabled="movieGenerating"
+        data-testid="mulmo-script-movie-retry-button"
+        @click="generateMovie"
+      >
+        {{ t("pluginMulmoScript.retry") }}
+      </button>
+    </div>
+
     <!-- Characters section -->
     <div v-if="characterKeys.length > 0" class="border-b border-gray-100 shrink-0 px-4 py-3">
       <div class="flex items-center justify-between mb-2">
@@ -510,6 +533,10 @@ const localOverrides = reactive<Record<number, Beat>>({});
 const movieGenerating = ref(false);
 const movieDownloading = ref(false);
 const moviePath = ref<string | null>(null);
+// Persists the most-recent movie-generation failure so the spinner
+// area can surface it inline with a retry button (#1197). Cleared
+// at the start of every generate / regenerate attempt.
+const movieError = ref<string | null>(null);
 const beatAudios = reactive<Record<number, string>>({});
 const audioState = reactive<Record<number, "generating" | "done" | "error">>({});
 const audioErrors = reactive<Record<number, string>>({});
@@ -1275,6 +1302,7 @@ async function refreshMoviePath(): Promise<void> {
 
 async function generateMovie() {
   movieGenerating.value = true;
+  movieError.value = null;
   try {
     const res = await apiFetchRaw(endpoints.generateMovie.url, {
       method: "POST",
@@ -1296,7 +1324,10 @@ async function generateMovie() {
       },
     });
   } catch (err) {
-    alert(extractErrorMessage(err));
+    // Surface inline (instead of `alert()` which blocks + has no
+    // retry affordance). The error chip with a retry button lives
+    // next to the generate button in the template (#1197).
+    movieError.value = extractErrorMessage(err);
   } finally {
     movieGenerating.value = false;
   }


### PR DESCRIPTION
## Summary

`generateMovie` was already surfacing SSE error events through the try/catch as exceptions (via `applyMovieEvent` throwing on `error` type), but the catch arm raised an `alert()`. That blocked the canvas, gave the user no retry path, and left the movie button visually identical to a healthy idle state once the alert was dismissed. Repeated reproductions of the e2e-live L-04 timeout (server-side `protocolTimeout`) made the issue visible.

Swapped to an inline error chip + retry button, no helper API change:

- New `movieError` ref, populated in the catch arm, cleared at the start of every generate / regenerate.
- Red chip rendered between the chrome row and the Characters section in the View.vue template. Generic "Movie generation failed" headline + the raw error text + a "Retry" button.
- `alert()` removed.

## Items to Confirm / Review

1. **No `streamMovieEvents` API change**. The issue suggested adding an `onError` callback to the helper, but `applyMovieEvent` already throws on `error` events and `streamMovieEvents` propagates that throw — adding another callback would just duplicate the existing path. Keeping the helper unchanged means existing call sites (none other today) don't need to learn a new event hook.

2. **i18n lockstep** — `pluginMulmoScript.movieGenerationFailed` + `pluginMulmoScript.retry` added to all 8 locales (en / ja / zh / ko / es / pt-BR / fr / de).

3. **Retry button calls `generateMovie()` directly**. Same path as the chrome button. Reset of `movieError` happens inside `generateMovie` so the chip disappears the instant a fresh attempt starts; if that attempt fails too, a new error replaces the old.

## User Prompt

> #1197 #1073 簡単なら直して。

#1197 was simple — UI-only change, no API surface change. #1073 (separate PR).

## Test Plan

- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [ ] Manual: trigger a movie generation that fails (e.g. block `/api/mulmo-script/generate-movie` with a 500 in DevTools or kill the server mid-stream). Confirm red chip appears with retry button + clicking retry hides the chip and starts a fresh run.

Closes #1197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)