### PR TITLE
feat(skills): catalog vs active split — PR-A of #1335

### DIFF
--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -262,7 +262,7 @@ schedule: "interval 168h"
 
 **Preset skills (launcher 同梱)**:
 
-リポジトリには **launcher が同梱して出荷するプリセット skill** が `server/workspace/skills-preset/<name>/SKILL.md` に置かれている。命名規約は `mc-` プレフィックス (= "MulmoClaude managed") — workspace 側でこの prefix を持つ skill は launcher 起動時に上書き同期されるので、ユーザがその場で編集しても次回 boot で元に戻る。リポジトリ側を編集して PR を出すのが正規ルート。
+リポジトリには **launcher が同梱して出荷するプリセット skill** が `server/workspace/skills-preset/<name>/SKILL.md` に置かれている。命名規約は `mc-` プレフィックス (= "MulmoClaude managed")。リポジトリ側を編集して PR を出すのが正規ルート。
 
 現在の preset (`mc-` prefix 持ち):
 
@@ -272,7 +272,17 @@ schedule: "interval 168h"
 | `mc-library` | 読書記録 — 読みたい本 / 読了の登録、感想を本人の言葉で記録、後から想起できるジャーナル |
 | `mc-cooking-coach` | レシピの保存・更新・削除と `data/cooking/recipes/README.md` 索引維持 |
 
-同期の実装は `server/workspace/skills-preset.ts` (`syncPresetSkills`)。起動時に `server/workspace/workspace.ts:44` から呼ばれ、`<launcher>/server/workspace/skills-preset/` → `<workspace>/.claude/skills/` へコピーされる。ユーザ作成 skill (`mc-` でない名前) は同期対象外なので影響を受けない。
+同期の実装は `server/workspace/skills-preset.ts` (`syncPresetSkills`)。起動時に `server/workspace/workspace.ts` から呼ばれる。
+
+**Catalog vs Active 分離 (#1335 PR-A)**:
+
+- **Source**: `<launcher>/server/workspace/skills-preset/<name>/SKILL.md`
+- **Sync 先 (catalog)**: `<workspace>/data/skills/catalog/preset/<name>/SKILL.md` — 起動毎に上書き、launcher-owned
+- **Active レイヤー**: `<workspace>/.claude/skills/<name>/SKILL.md` — Claude Code が discover、prompt に description が乗る
+
+Catalog にあるだけでは prompt に乗らない (Claude Code の resolver は `.claude/skills/` しか見ない)。preset を有効化するには catalog → `.claude/skills/` にコピーする必要がある。コピー UI (★ star) は #1335 PR-B、上流 Anthropic skills の git sync は PR-C で予定。PR-A の時点で catalog はファイル上は populated されるが、UI 経由の active 化はまだない (手動 `cp` でアクティブ化可能)。
+
+設計の動機: preset を増やしても勝手に system prompt が肥大化しないようにする。ユーザは catalog を眺める / 試す → 気に入ったものだけ ★ で恒常 active 化する 2 段モデル。
 
 **ソース実装**:
 

--- a/plans/feat-skill-catalog-foundation-1335.md
+++ b/plans/feat-skill-catalog-foundation-1335.md
@@ -1,0 +1,49 @@
+# Skill catalog foundation — PR-A of #1335
+
+## Goal
+
+Stop auto-mirroring every preset skill into `<workspace>/.claude/skills/`. Move them into a separate **catalog** location (`<workspace>/data/skills/catalog/preset/`) that the launcher owns and rewrites on every boot. `.claude/skills/` becomes the **active** layer — only what's there enters Claude Code's discovery + the system prompt.
+
+PR-A is the foundation. PR-B will add UI to star catalog entries → mirror them into `.claude/skills/` (active). PR-C will add Anthropic catalog via git sparse checkout.
+
+## Approach
+
+1. **Add path constants** in `server/workspace/paths.ts`:
+   - `skillsCatalog: "data/skills/catalog"` — the catalog root (preset / anthropic / community will live under here)
+   - `skillsCatalogPreset: "data/skills/catalog/preset"` — launcher-managed preset slot
+2. **Flip the destination** in `server/workspace/skills-preset.ts` + `server/workspace/workspace.ts`:
+   - Source unchanged: `<launcher>/server/workspace/skills-preset/<slug>/`
+   - Destination: `<workspace>/data/skills/catalog/preset/<slug>/` (was `<workspace>/.claude/skills/<slug>/`)
+   - `mkdirSync(WORKSPACE_PATHS.skillsCatalogPreset, { recursive: true })` before the sync (catalog dir is several levels deep, not in `EAGER_WORKSPACE_DIRS`).
+3. **Sync behaviour unchanged** at the helper level: still copies every valid `mc-*` slug, still removes retired `mc-*` entries from the destination. The destination's "mc-* only" check stays as defence-in-depth even though `catalog/preset/` is fully launcher-owned.
+4. **Skill resolver behaviour unchanged**: Claude Code still scans `.claude/skills/` for slash-command discovery. Catalog entries are invisible to the resolver — that's the entire point.
+5. **No migration**: per user direction, existing `.claude/skills/mc-*` from prior installs is left untouched. Existing users will end up with duplicates (the same skill in both `catalog/preset/` and `.claude/skills/`) until they manually clean the active copies. Fresh installs see catalog only, no preset in `.claude/skills/` (until a UI lands in PR-B).
+
+## What this does NOT do
+
+- **No UI changes** (`src/plugins/manageSkills/View.vue` is untouched). PR-B introduces the catalog browser + ★ Star / ▶ Run once / 📖 Preview affordances.
+- **No star registry** (`stars.json` or similar). PR-B can introduce one if needed; PR-A leaves "presence in `.claude/skills/`" as the implicit active-state signal.
+- **No Anthropic skills catalog**. PR-C adds `data/skills/catalog/anthropic/` + git sparse checkout + scheduler sync.
+
+## Files touched
+
+- `server/workspace/paths.ts` — two new keys.
+- `server/workspace/skills-preset.ts` — doc-comment + interface comment refresh; logic untouched (the helper is destination-agnostic).
+- `server/workspace/workspace.ts` — destination switch + `mkdirSync` of the new path.
+- `test/workspace/test_skills_preset.ts` — doc-comment refresh; assertions tmpdir-based so they continue to pass without change.
+- `test/workspace/test_paths_shape.ts` — list the new path keys so the shape test reflects reality.
+- `docs/extension-mechanisms.md` — Preset Skills section now documents the catalog vs active split.
+
+## Acceptance
+
+- Fresh `~/mulmoclaude/` workspace: after boot, `data/skills/catalog/preset/mc-*/` contains every shipped preset. `.claude/skills/` is empty (no auto-mirror).
+- Existing workspace with `~/mulmoclaude/.claude/skills/mc-*/` from a prior install: those stay; the catalog dir is additionally populated. Existing skills keep working until PR-B's UI lets the user clean up.
+- `syncPresetSkills` tests pass unchanged (destination-agnostic).
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
+- `WORKSPACE_PATHS.skillsCatalogPreset` resolves correctly.
+- Comment block in `skills-preset.ts` + relevant section in `docs/extension-mechanisms.md` reflect the new model.
+
+## Follow-up issues
+
+- **PR-B** — UI: hierarchical menu (Active / Catalog / My Skills), Run once / ★ Star / 📖 Preview actions, slug-collision policy.
+- **PR-C** — Anthropic git sparse checkout, scheduler sync task, upstream-update notification badge.

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -153,6 +153,16 @@ const HOST_WORKSPACE_DIRS = {
   // so server code references it through `WORKSPACE_PATHS.claudeSkills`
   // instead of inlining the string.
   claudeSkills: ".claude/skills",
+  // Skill catalog root (#1335). Holds preset skills shipped with the
+  // launcher (`catalog/preset/`) and — in later PRs — git-synced
+  // Anthropic skills (`catalog/anthropic/`) and community URL-install
+  // entries (`catalog/community/`). Entries here are catalog-only:
+  // visible to UI / tooling but NOT discovered by Claude Code's
+  // slash-command resolver. An entry becomes active by being copied
+  // (or symlinked) into `.claude/skills/`. The catalog vs active
+  // split keeps unused skills out of the system prompt.
+  skillsCatalog: "data/skills/catalog",
+  skillsCatalogPreset: "data/skills/catalog/preset",
   // Nested subdirs inside a top-level grouping. Kept here (rather
   // than module-local constants) when multiple modules need to
   // reference the same nested path — e.g. wiki/pages/ is used by

--- a/server/workspace/skills-preset.ts
+++ b/server/workspace/skills-preset.ts
@@ -1,15 +1,21 @@
-// Preset skills bundled with mulmoclaude (#1210). Sibling to
-// `helps/`: this file owns the boot-time copy from
-// `server/workspace/skills-preset/<slug>/SKILL.md` (shipped with the
-// launcher tarball) into `<workspaceRoot>/.claude/skills/<slug>/SKILL.md`,
-// where Claude Code's slash-command resolver picks them up.
+// Preset skills bundled with mulmoclaude.
 //
-// The launcher overwrites preset entries unconditionally on every
-// boot — preset skills are "factory defaults", not user state. The
-// `mc-` slug prefix is the namespace boundary: anything under
-// `mc-*` belongs to the launcher and may be added / overwritten /
-// removed across releases. Anything WITHOUT the `mc-` prefix is
-// user-owned and never touched.
+// History: introduced in #1210 to ship launcher-managed "factory"
+// skills like `mc-library`. Originally synced straight into
+// `<workspaceRoot>/.claude/skills/<slug>/`, which made every preset
+// auto-active and inflated the Claude system prompt as new presets
+// landed.
+//
+// #1335 PR-A flipped the destination to the catalog
+// (`<workspaceRoot>/data/skills/catalog/preset/<slug>/`). Catalog
+// entries are visible to UI / tooling but NOT discovered by Claude
+// Code's slash-command resolver — they don't enter the system
+// prompt unless the user (or a later UI in PR-B) explicitly copies
+// one into `.claude/skills/`.
+//
+// The launcher overwrites catalog entries unconditionally on every
+// boot — they're factory defaults, not user state. Anything in
+// `.claude/skills/` (active layer) is left untouched.
 //
 // `syncPresetSkills(...)` is exported as a pure-ish helper (takes
 // paths + a logger sink, returns a summary) so tests can drive it
@@ -25,7 +31,10 @@ const SKILL_FILENAME = "SKILL.md";
 export interface SyncPresetSkillsOptions {
   /** Source directory: `<launcher>/server/workspace/skills-preset/`. */
   sourceDir: string;
-  /** Destination directory: `<workspaceRoot>/.claude/skills/`. */
+  /** Destination directory:
+   *  `<workspaceRoot>/data/skills/catalog/preset/`. The catalog
+   *  half of the catalog-vs-active split — entries here are visible
+   *  to UI but NOT to Claude Code's prompt-time skill resolver. */
   destDir: string;
   /** Logger callbacks — kept injectable so tests don't need to
    *  spin up the structured logger. The boot-side wrapper threads
@@ -142,11 +151,14 @@ function removeRetiredPresets(destDir: string, synced: ReadonlySet<string>, opts
   }
 }
 
-/** Copy every preset slug from `sourceDir` into `destDir`, then
- *  remove any `mc-*` entries in `destDir` that no longer have a
- *  source. Slugs without the `mc-` prefix are skipped (with a warn)
- *  on the source side and left untouched on the dest side — that's
- *  how user-authored skills coexist with launcher-managed presets. */
+/** Copy every preset slug from `sourceDir` into `destDir` (the
+ *  preset slot under the catalog root), then remove any `mc-*`
+ *  entries in `destDir` that no longer have a source. The catalog
+ *  preset subdir is fully launcher-owned, so the `mc-*` prefix
+ *  check at destination is defence-in-depth: a stray non-preset
+ *  slug landing in `catalog/preset/` is unexpected, and we'd
+ *  rather skip it than silently delete a directory we don't
+ *  recognise. */
 export function syncPresetSkills(opts: SyncPresetSkillsOptions): SyncPresetSkillsResult {
   const result: SyncPresetSkillsResult = { copied: [], removed: [], skipped: [] };
   if (!existsSync(opts.sourceDir)) {

--- a/server/workspace/workspace.ts
+++ b/server/workspace/workspace.ts
@@ -41,13 +41,18 @@ export function initWorkspace(): string {
     copyFileSync(path.join(TEMPLATES_DIR, file), path.join(WORKSPACE_PATHS.helps, file));
   }
 
-  // Sync preset skills (#1210) from server/workspace/skills-preset/
-  // into <workspaceRoot>/.claude/skills/. Only `mc-*` slugs are
-  // touched — user-authored skills coexist untouched. Retired
-  // presets (no longer in source) are removed from the workspace.
+  // Sync preset skills from `server/workspace/skills-preset/` into
+  // the catalog (#1335 PR-A). Catalog entries are visible to UI /
+  // tooling but NOT in `.claude/skills/`, so they don't enter
+  // Claude Code's system prompt by default. Activation (catalog →
+  // `.claude/skills/`) lands with the UI in #1335 PR-B; until then
+  // the catalog is reachable by file path only. The dest directory
+  // is created here because it's outside `EAGER_WORKSPACE_DIRS`
+  // (it lives several levels deep and is preset-specific).
+  mkdirSync(WORKSPACE_PATHS.skillsCatalogPreset, { recursive: true });
   syncPresetSkills({
     sourceDir: SKILLS_PRESET_SOURCE_DIR,
-    destDir: WORKSPACE_PATHS.claudeSkills,
+    destDir: WORKSPACE_PATHS.skillsCatalogPreset,
     onInfo: (message, data) => log.info("skills-preset", message, data),
     onWarn: (message, data) => log.warn("skills-preset", message, data),
   });

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -45,6 +45,8 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "roles",
     "scheduler",
     "searches",
+    "skillsCatalog",
+    "skillsCatalogPreset",
     "sources",
     "spreadsheets",
     "stories",

--- a/test/workspace/test_skills_preset.ts
+++ b/test/workspace/test_skills_preset.ts
@@ -1,4 +1,12 @@
-// Tests for the boot-time preset-skill sync (#1210 PR-A).
+// Tests for the boot-time preset-skill sync.
+//
+// #1210 PR-A: introduced. Source: `server/workspace/skills-preset/`.
+// Destination: originally `<workspaceRoot>/.claude/skills/`.
+// #1335 PR-A: destination flipped to
+// `<workspaceRoot>/data/skills/catalog/preset/` (catalog half of the
+// catalog-vs-active split). The sync helper itself doesn't care
+// about the literal path — it works against whatever `destDir` the
+// caller passes — so these tests stay tmpdir-based.
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
@@ -222,10 +230,12 @@ describe("syncPresetSkills — source resilience", () => {
 
 describe("syncPresetSkills — destination resilience", () => {
   it("aborts the sync cleanly when the root dest itself is a regular file (regression: corruption-tolerant boot)", () => {
-    // Codex review iter-2: prior fix only protected per-slug
-    // mkdirSync; the root mkdirSync would still EEXIST-crash if
-    // `<workspace>/.claude/skills` itself was somehow a regular
-    // file. Now it logs warn + skips the whole sync.
+    // Codex review iter-2 (on the original `.claude/skills/` dest;
+    // same defence applies to the catalog destination after #1335
+    // PR-A): prior fix only protected per-slug mkdirSync; the root
+    // mkdirSync would still EEXIST-crash if the destination root
+    // itself was somehow a regular file. Now it logs warn + skips
+    // the whole sync.
     writePresetSource("mc-foo");
     writeFileSync(destDir, "stray file blocking the root skills dir");
 


### PR DESCRIPTION
## Summary

Stop auto-mirroring preset skills into `<workspace>/.claude/skills/`. Move them to `<workspace>/data/skills/catalog/preset/` instead — a catalog directory the launcher owns and overwrites on every boot. `.claude/skills/` becomes the **active** layer: only what's there enters Claude Code's slash-command discovery and the system prompt.

This is **PR-A** — the foundation. PR-B will add UI (★ Star / ▶ Run once / 📖 Preview). PR-C will add Anthropic skills via git sparse-checkout.

```
Before this PR                After this PR
──────────────                ──────────────
server/workspace/             server/workspace/
  skills-preset/                skills-preset/
    mc-library/SKILL.md           mc-library/SKILL.md
    mc-cooking-coach/...          mc-cooking-coach/...
    ...                           ...
        │                             │
        ▼ boot sync                   ▼ boot sync
<workspace>/                  <workspace>/
  .claude/skills/               data/skills/catalog/preset/
    mc-library/...                mc-library/...
    mc-cooking-coach/...          mc-cooking-coach/...
    ...                           ...
        │                                 (NOT in .claude/skills/,
        ▼                                  so NOT in system prompt)
   Claude Code prompt                 .claude/skills/  ← empty
   gets all presets                   (until user / PR-B
   inlined every release.             stars something into it)
```

## Items to Confirm / Review

- **No migration** (per user direction). Existing `~/mulmoclaude/.claude/skills/mc-*` from prior installs stays in place. Existing users will see duplicates in catalog + active until they manually clean up via `rm -rf ~/mulmoclaude/.claude/skills/mc-*` (or wait for PR-B's UI).
- **No UI change** in this PR. `src/plugins/manageSkills/View.vue` is untouched — it still shows whatever's in `.claude/skills/`. Catalog is reachable by file path only. The catalog *exists* in the workspace and is `git status`-visible; UI to browse / star lands in PR-B.
- **No `stars.json` registry yet**. PR-B can introduce one if needed. PR-A leaves "presence in `.claude/skills/`" as the implicit active-state signal.
- **`mc-*` namespace check at destination stays** as defence in depth even though `catalog/preset/` is fully launcher-owned. A stray non-preset slug landing there is unexpected; we'd rather skip the cleanup than delete a dir we don't recognise.
- **`mkdirSync(skillsCatalogPreset)` lives in `workspace.ts`** rather than getting added to `EAGER_WORKSPACE_DIRS`. The catalog dir is several levels deep and preset-specific; it belongs with its sync caller, not the eager-create roll-call.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1335 これをすすめよう
>
> はい、順次進める。既存のユーザ、データは気にしないで、migrationなしですすめて。

## Implementation approach

1. `server/workspace/paths.ts` — add `skillsCatalog` (`"data/skills/catalog"`) and `skillsCatalogPreset` (`"data/skills/catalog/preset"`) to `WORKSPACE_DIRS`. They flow through to `WORKSPACE_PATHS` via the existing derivation.
2. `server/workspace/workspace.ts` — flip the `syncPresetSkills` `destDir` to the new catalog path; `mkdirSync` the new dir first because it's outside `EAGER_WORKSPACE_DIRS`.
3. `server/workspace/skills-preset.ts` — doc-comment refresh only. The helper is destination-agnostic (takes `destDir` as a parameter), so no logic change needed. Source comment now explains the catalog model + cross-references #1335.
4. `test/workspace/test_paths_shape.ts` — list the two new path keys so the shape lock matches reality.
5. `test/workspace/test_skills_preset.ts` — comment refresh; assertions stay tmpdir-based.
6. `docs/extension-mechanisms.md` — Preset Skills section now describes the catalog vs active split + cross-references #1335 PR-B / PR-C plans.
7. `plans/feat-skill-catalog-foundation-1335.md` — plan file.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — `syncPresetSkills` suite passes unchanged (tmpdir-based, destination-agnostic). `test_paths_shape` now lists the two new keys.
- [ ] Manual on a fresh workspace: delete `~/mulmoclaude/` (or use a tmp `MULMOCLAUDE_WORKSPACE`), launch, confirm `data/skills/catalog/preset/mc-*/` is populated and `.claude/skills/` is empty.
- [ ] Manual on an existing workspace: launch with current `~/mulmoclaude/.claude/skills/mc-*` present, confirm those stay AND the catalog dir is now populated. (Duplication is acceptable until PR-B; this is documented in the plan.)
- [ ] Slash-command sanity: a user-authored skill in `~/mulmoclaude/.claude/skills/my-helper/` should still be discovered by Claude Code (no regression — `.claude/skills/` is still scanned, the catalog just isn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)