### PR TITLE
feat(skills): catalog UI + Star action — PR-B of #1335

### DIFF
--- a/plans/feat-skill-catalog-star-ui-1335.md
+++ b/plans/feat-skill-catalog-star-ui-1335.md
@@ -1,0 +1,61 @@
+# Skill catalog UI + Star action — PR-B of #1335
+
+## Goal
+
+After PR-A moved preset skills out of `<workspace>/.claude/skills/` into `<workspace>/data/skills/catalog/preset/`, the catalog dir was populated but invisible to users — there was no UI to browse it and no way to ★ Star an entry back into the active layer without manual `cp -r`. PR-B closes both gaps.
+
+## Approach
+
+### Backend
+
+1. **`server/workspace/skills/catalog.ts`** (new) — exports:
+   - `CatalogSource = "preset"` (string union, extensible in PR-C to `"anthropic" | "community"`).
+   - `CATALOG_SOURCES` const tuple + `isCatalogSource(value): value is CatalogSource` type guard for the route's request validation.
+   - `CatalogEntry` shape: `{ slug, name, description, source, alreadyActive }`. `alreadyActive` is set by checking `<workspace>/.claude/skills/<slug>/` so the UI renders "★ Starred" vs "☆ Star".
+   - `listCatalogEntries(opts?)` — walks every catalog source, parses SKILL.md frontmatter, returns the entries sorted by slug.
+   - `starCatalogEntry(source, slug, opts?)` — validates slug against a path-traversal whitelist, copies the catalog slug-dir tree (incl. nested `scripts/` etc.) into `.claude/skills/`, returns a discriminated `StarResult` for the route's status-code mapping (`starred` / `already-active` / `not-found` / `invalid-slug`).
+   - Both functions accept `{ workspaceRoot? }` so tests can run against `mkdtempSync` trees. Default is the live `workspacePath` import.
+   - Internally uses `WORKSPACE_DIRS` (relative segments), NOT `WORKSPACE_PATHS` (absolute, rooted at the live `workspacePath`) — joining the latter with a caller-supplied `workspaceRoot` would silently discard the override.
+
+2. **`server/api/routes/skills.ts`** — two new endpoints:
+   - `GET /api/skills/catalog` → `{ entries: CatalogEntry[] }`.
+   - `POST /api/skills/catalog/star` body `{ source, slug }` → `{ starred: true, slug }` on 200; 409 already-active; 404 not-found; 400 invalid-slug.
+
+3. **`src/plugins/manageSkills/meta.ts`** — declare `catalogList` + `catalogStar` routes; the META aggregator auto-merges them into `API_ROUTES.skills.*` and the `SkillsEndpoints` typed map.
+
+### UI
+
+4. **`src/plugins/manageSkills/View.vue`** — add a catalog section to the left column below the active skills list:
+   - Header "Preset catalog" (i18n: `pluginManageSkills.catalogPresetHeading`).
+   - One row per catalog entry: name + description (truncated) + button.
+   - Button: `☆ Star` (clickable) or `★ Starred` (disabled) depending on `alreadyActive`.
+   - On Star: POST to `endpoints.catalogStar.url`, then refresh both lists (so the row flips to Starred and the active list shows the new entry).
+   - `starringSlug` tracks the in-flight slug to disable the button mid-request.
+   - Errors surface in a small red message below the list.
+
+5. **i18n** — 5 new keys × 8 locales:
+   - `catalogPresetHeading`, `catalogStar`, `catalogStarred`, `errCatalogListFailed`, `errCatalogStarFailed`.
+   - `☆` / `★` chars are baked into the i18n strings (not raw text in the template) to satisfy the `@intlify/vue-i18n/no-raw-text` lint rule. Each locale translates the action word but keeps the star icon.
+
+### Tests
+
+6. **`test/workspace/skills/test_catalog.ts`** — 16 cases covering:
+   - `isCatalogSource` accept/reject.
+   - `listCatalogEntries`: empty catalog, valid entries, malformed SKILL.md skip, hidden entries skip, `alreadyActive` true / false.
+   - `starCatalogEntry`: happy path, recursive subdir copy (scripts/), already-active conflict, not-found, path-traversal rejection, path separator rejection, empty / dot-prefixed slug rejection.
+
+## What this does NOT do
+
+- **Run once** (▶ button to inject the SKILL.md body into the current chat as a one-off): deferred to PR-B2.
+- **Preview** (📖 modal showing description + body without starring): deferred to PR-B2.
+- **Hierarchical sub-sections** (Anthropic / Community as siblings of Preset): the layout is a single flat group today; sub-sections land with PR-C when there are actually anthropic + community entries to show.
+- **Slug collision handling** when starring would clobber an existing `.claude/skills/<slug>/`: the backend returns `already-active` (409), the UI doesn't try to disambiguate yet. The "namespace prefix" idea from the issue (`anthropic-pdf-extractor`) is deferred — `preset` slugs are already `mc-*` prefixed so collisions are unlikely until PR-C.
+- **`stars.json` registry**: still not introduced. "Presence in `.claude/skills/`" remains the implicit star state. PR-C may introduce one for SHA pinning, but it's not needed for PR-B.
+
+## Acceptance
+
+- Settings → Skills shows a "Preset catalog" section below the active skills.
+- Each catalog entry has a working ★ Star button. After clicking, the row flips to "★ Starred" and the entry appears in the active list immediately (no reload needed).
+- Catalog tests pass against tmpdirs.
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
+- No i18n raw-text lint warnings.

--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -15,6 +15,7 @@
 import { Router, Request, Response } from "express";
 import { deleteProjectSkill, discoverSkills, saveProjectSkill, updateProjectSkill } from "../../workspace/skills/index.js";
 import type { Skill, SkillSummary } from "../../workspace/skills/index.js";
+import { isCatalogSource, listCatalogEntries, starCatalogEntry, type CatalogEntry } from "../../workspace/skills/catalog.js";
 import { workspacePath } from "../../workspace/workspace.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { bindRoute } from "../../utils/router.js";
@@ -216,6 +217,63 @@ bindRoute(router, API_ROUTES.skills.remove, async (req: Request<{ name: string }
     log.warn("skills", "delete: not found", { name: result.name });
     notFound(res, `skill not found: ${result.name}`);
   }
+});
+
+// Catalog endpoints (#1335 PR-B). Reads from
+// `<workspace>/data/skills/catalog/<source>/<slug>/` (populated by
+// `syncPresetSkills`); the star endpoint copies catalog entries
+// into `.claude/skills/<slug>/` so Claude Code's discovery picks
+// them up. Catalog entries themselves are NOT in `.claude/skills/`
+// by design — that's the prompt-bloat fix from #1335.
+
+interface CatalogListResponse {
+  entries: CatalogEntry[];
+}
+
+interface StarBody {
+  source?: unknown;
+  slug?: unknown;
+}
+
+interface StarResponse {
+  starred: true;
+  slug: string;
+}
+
+bindRoute(router, API_ROUTES.skills.catalogList, async (_req: Request, res: Response<CatalogListResponse>) => {
+  const entries = await listCatalogEntries();
+  log.info("skills", "catalog list: ok", { count: entries.length });
+  res.json({ entries });
+});
+
+bindRoute(router, API_ROUTES.skills.catalogStar, async (req: Request<object, unknown, StarBody>, res: Response<StarResponse | ErrorResponse>) => {
+  const { source, slug } = req.body;
+  if (typeof slug !== "string" || slug.length === 0) {
+    badRequest(res, "slug is required");
+    return;
+  }
+  if (!isCatalogSource(source)) {
+    badRequest(res, "source must be a known catalog source");
+    return;
+  }
+  const result = await starCatalogEntry(source, slug);
+  if (result.kind === "starred") {
+    log.info("skills", "catalog star: ok", { source, slug });
+    res.json({ starred: true, slug: result.slug });
+    return;
+  }
+  if (result.kind === "already-active") {
+    log.info("skills", "catalog star: already-active", { source, slug });
+    conflict(res, `skill "${result.slug}" is already active`);
+    return;
+  }
+  if (result.kind === "not-found") {
+    log.warn("skills", "catalog star: not found", { source, slug });
+    notFound(res, `catalog entry not found: ${result.source}/${result.slug}`);
+    return;
+  }
+  log.warn("skills", "catalog star: invalid slug", { slug });
+  badRequest(res, `invalid slug: ${result.slug}`);
 });
 
 export default router;

--- a/server/workspace/skills/catalog.ts
+++ b/server/workspace/skills/catalog.ts
@@ -86,6 +86,8 @@ async function isDirectory(absPath: string): Promise<boolean> {
 }
 
 async function readCatalogEntry(slugDir: string, slug: string, source: CatalogSource, workspaceRoot: string): Promise<CatalogEntry | null> {
+  // `slugDir` is already a `safeJoinSlug` result — joining a fixed
+  // `"SKILL.md"` keeps the path inside the catalog tree.
   const skillMdPath = path.join(slugDir, "SKILL.md");
   let raw: string;
   try {
@@ -95,7 +97,8 @@ async function readCatalogEntry(slugDir: string, slug: string, source: CatalogSo
   }
   const parsed = parseSkillFrontmatter(raw);
   if (!parsed) return null;
-  const alreadyActive = await isDirectory(path.join(activeDir(workspaceRoot), slug));
+  const activeSlugDir = safeJoinSlug(activeDir(workspaceRoot), slug);
+  const alreadyActive = activeSlugDir !== null && (await isDirectory(activeSlugDir));
   return { slug, name: slug, description: parsed.description, source, alreadyActive };
 }
 
@@ -113,7 +116,13 @@ async function scanCatalogSource(source: CatalogSource, workspaceRoot: string): 
   const results: CatalogEntry[] = [];
   for (const slug of entries) {
     if (slug.startsWith(".")) continue;
-    const slugDir = path.join(dir, slug);
+    // Slugs come from `readdir`, which CodeQL flags as tainted even
+    // though the directory is launcher-managed. `safeJoinSlug` is
+    // both the path-injection sanitiser (resolve + startsWith) and
+    // a slug-shape guard — a malformed catalog entry name is
+    // skipped rather than crashing the listing.
+    const slugDir = safeJoinSlug(dir, slug);
+    if (slugDir === null) continue;
     if (!(await isDirectory(slugDir))) continue;
     const entry = await readCatalogEntry(slugDir, slug, source, workspaceRoot);
     if (entry) results.push(entry);
@@ -145,6 +154,28 @@ export async function listCatalogEntries(opts: CatalogOptions = {}): Promise<Cat
 // eslint-disable-next-line security/detect-unsafe-regex -- non-overlapping character classes, no catastrophic backtracking
 const SAFE_SLUG_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$/;
 
+/** Resolve `<rootDir>/<slug>/` and verify the result stays inside
+ *  `rootDir`. Returns `null` if anything looks suspicious — a
+ *  separator-bearing slug, a `..` segment, an absolute slug, or a
+ *  result that escapes the root after `path.resolve` normalisation.
+ *
+ *  Belt-and-suspenders on top of `SAFE_SLUG_PATTERN`: the regex
+ *  already rejects every problematic shape, but mirroring the
+ *  resolve-then-startsWith check CodeQL recognises for
+ *  `js/path-injection` is cheap and lets downstream readers verify
+ *  the sanitisation at a glance without re-deriving why the regex
+ *  is sufficient. */
+function safeJoinSlug(rootDir: string, slug: string): string | null {
+  if (!SAFE_SLUG_PATTERN.test(slug)) return null;
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedSlug = path.resolve(resolvedRoot, slug);
+  // `path.sep` boundary check avoids the `/root` vs `/root-other` confusion.
+  if (resolvedSlug !== resolvedRoot && !resolvedSlug.startsWith(resolvedRoot + path.sep)) {
+    return null;
+  }
+  return resolvedSlug;
+}
+
 export type StarResult =
   | { kind: "starred"; slug: string }
   | { kind: "not-found"; source: CatalogSource; slug: string }
@@ -169,13 +200,15 @@ async function copyDirTree(srcDir: string, destDir: string): Promise<void> {
 
 /** Copy `data/skills/catalog/<source>/<slug>/` → `.claude/skills/<slug>/`.
  *  Returns a discriminated result so the route can map to clean
- *  HTTP status codes. */
+ *  HTTP status codes. Slug is sanitised via `safeJoinSlug` for both
+ *  the source and destination — a separator-bearing or escaping
+ *  slug yields `invalid-slug` and never reaches the filesystem. */
 export async function starCatalogEntry(source: CatalogSource, slug: string, opts: CatalogOptions = {}): Promise<StarResult> {
-  if (!SAFE_SLUG_PATTERN.test(slug)) return { kind: "invalid-slug", slug };
   const workspaceRoot = opts.workspaceRoot ?? workspacePath;
-  const catalogSlugDir = path.join(catalogDirForSource(source, workspaceRoot), slug);
+  const catalogSlugDir = safeJoinSlug(catalogDirForSource(source, workspaceRoot), slug);
+  const activeSlugDir = safeJoinSlug(activeDir(workspaceRoot), slug);
+  if (catalogSlugDir === null || activeSlugDir === null) return { kind: "invalid-slug", slug };
   if (!(await isDirectory(catalogSlugDir))) return { kind: "not-found", source, slug };
-  const activeSlugDir = path.join(activeDir(workspaceRoot), slug);
   if (await isDirectory(activeSlugDir)) return { kind: "already-active", slug };
   await copyDirTree(catalogSlugDir, activeSlugDir);
   log.info("skills", "starred catalog entry", { source, slug });

--- a/server/workspace/skills/catalog.ts
+++ b/server/workspace/skills/catalog.ts
@@ -85,9 +85,10 @@ async function isDirectory(absPath: string): Promise<boolean> {
   }
 }
 
-async function readCatalogEntry(slugDir: string, slug: string, source: CatalogSource, workspaceRoot: string): Promise<CatalogEntry | null> {
-  // `slugDir` is already a `safeJoinSlug` result — joining a fixed
-  // `"SKILL.md"` keeps the path inside the catalog tree.
+async function readCatalogEntry(slugDir: string, safeName: string, source: CatalogSource, workspaceRoot: string): Promise<CatalogEntry | null> {
+  // `slugDir` was built from a `safeSlugName`-laundered name, so
+  // joining a fixed `"SKILL.md"` keeps the path inside the catalog
+  // tree and stays clear of CodeQL's path-injection trace.
   const skillMdPath = path.join(slugDir, "SKILL.md");
   let raw: string;
   try {
@@ -97,9 +98,9 @@ async function readCatalogEntry(slugDir: string, slug: string, source: CatalogSo
   }
   const parsed = parseSkillFrontmatter(raw);
   if (!parsed) return null;
-  const activeSlugDir = safeJoinSlug(activeDir(workspaceRoot), slug);
-  const alreadyActive = activeSlugDir !== null && (await isDirectory(activeSlugDir));
-  return { slug, name: slug, description: parsed.description, source, alreadyActive };
+  const activeSlugDir = joinUnderRoot(activeDir(workspaceRoot), safeName);
+  const alreadyActive = await isDirectory(activeSlugDir);
+  return { slug: safeName, name: safeName, description: parsed.description, source, alreadyActive };
 }
 
 async function scanCatalogSource(source: CatalogSource, workspaceRoot: string): Promise<CatalogEntry[]> {
@@ -117,14 +118,16 @@ async function scanCatalogSource(source: CatalogSource, workspaceRoot: string): 
   for (const slug of entries) {
     if (slug.startsWith(".")) continue;
     // Slugs come from `readdir`, which CodeQL flags as tainted even
-    // though the directory is launcher-managed. `safeJoinSlug` is
-    // both the path-injection sanitiser (resolve + startsWith) and
-    // a slug-shape guard — a malformed catalog entry name is
-    // skipped rather than crashing the listing.
-    const slugDir = safeJoinSlug(dir, slug);
-    if (slugDir === null) continue;
+    // though the directory is launcher-managed. `safeSlugName`
+    // applies the slug whitelist + a `path.basename` round-trip —
+    // CodeQL's recognised path-injection sanitiser. A catalog entry
+    // with an unexpected name is skipped rather than crashing the
+    // listing.
+    const safeName = safeSlugName(slug);
+    if (safeName === null) continue;
+    const slugDir = joinUnderRoot(dir, safeName);
     if (!(await isDirectory(slugDir))) continue;
-    const entry = await readCatalogEntry(slugDir, slug, source, workspaceRoot);
+    const entry = await readCatalogEntry(slugDir, safeName, source, workspaceRoot);
     if (entry) results.push(entry);
   }
   results.sort((left, right) => left.slug.localeCompare(right.slug));
@@ -154,26 +157,35 @@ export async function listCatalogEntries(opts: CatalogOptions = {}): Promise<Cat
 // eslint-disable-next-line security/detect-unsafe-regex -- non-overlapping character classes, no catastrophic backtracking
 const SAFE_SLUG_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$/;
 
-/** Resolve `<rootDir>/<slug>/` and verify the result stays inside
- *  `rootDir`. Returns `null` if anything looks suspicious — a
- *  separator-bearing slug, a `..` segment, an absolute slug, or a
- *  result that escapes the root after `path.resolve` normalisation.
+/** Sanitise a user-supplied slug into a safe directory-name leaf.
+ *  Returns `null` for anything that fails the slug whitelist OR is
+ *  not a basename (i.e. survives `path.basename` round-trip
+ *  unchanged). Returning a `path.basename` result is the pattern
+ *  CodeQL recognises as a `js/path-injection` sanitiser — once a
+ *  slug has been passed through `path.basename`, downstream
+ *  `path.join` / `stat` / `readFile` calls are no longer flagged.
  *
  *  Belt-and-suspenders on top of `SAFE_SLUG_PATTERN`: the regex
- *  already rejects every problematic shape, but mirroring the
- *  resolve-then-startsWith check CodeQL recognises for
- *  `js/path-injection` is cheap and lets downstream readers verify
- *  the sanitisation at a glance without re-deriving why the regex
- *  is sufficient. */
-function safeJoinSlug(rootDir: string, slug: string): string | null {
+ *  already rejects every problematic shape, but the basename
+ *  round-trip catches edge cases the regex might miss on platforms
+ *  with different separators (Windows `\\`) and lets the type
+ *  system express "this value has been laundered". */
+function safeSlugName(slug: string): string | null {
   if (!SAFE_SLUG_PATTERN.test(slug)) return null;
-  const resolvedRoot = path.resolve(rootDir);
-  const resolvedSlug = path.resolve(resolvedRoot, slug);
-  // `path.sep` boundary check avoids the `/root` vs `/root-other` confusion.
-  if (resolvedSlug !== resolvedRoot && !resolvedSlug.startsWith(resolvedRoot + path.sep)) {
-    return null;
-  }
-  return resolvedSlug;
+  // `path.basename` strips anything that looks like a directory
+  // component and is CodeQL's recognised sanitiser for
+  // `js/path-injection`. On a slug that already passed the regex
+  // this is an identity transform.
+  const basename = path.basename(slug);
+  if (basename !== slug) return null;
+  return basename;
+}
+
+/** Compose a path inside `rootDir` using a `safeSlugName`-laundered
+ *  slug. The taint flow ends at `safeSlugName`, so the joined path
+ *  is no longer flagged. */
+function joinUnderRoot(rootDir: string, safeName: string): string {
+  return path.join(rootDir, safeName);
 }
 
 export type StarResult =
@@ -200,17 +212,20 @@ async function copyDirTree(srcDir: string, destDir: string): Promise<void> {
 
 /** Copy `data/skills/catalog/<source>/<slug>/` → `.claude/skills/<slug>/`.
  *  Returns a discriminated result so the route can map to clean
- *  HTTP status codes. Slug is sanitised via `safeJoinSlug` for both
- *  the source and destination — a separator-bearing or escaping
- *  slug yields `invalid-slug` and never reaches the filesystem. */
+ *  HTTP status codes. Slug is laundered via `safeSlugName` (regex
+ *  whitelist + `path.basename` round-trip) before any `path.join`,
+ *  which is CodeQL's recognised pattern for clearing
+ *  `js/path-injection` taint. A separator-bearing or escaping slug
+ *  yields `invalid-slug` and never reaches the filesystem. */
 export async function starCatalogEntry(source: CatalogSource, slug: string, opts: CatalogOptions = {}): Promise<StarResult> {
+  const safeName = safeSlugName(slug);
+  if (safeName === null) return { kind: "invalid-slug", slug };
   const workspaceRoot = opts.workspaceRoot ?? workspacePath;
-  const catalogSlugDir = safeJoinSlug(catalogDirForSource(source, workspaceRoot), slug);
-  const activeSlugDir = safeJoinSlug(activeDir(workspaceRoot), slug);
-  if (catalogSlugDir === null || activeSlugDir === null) return { kind: "invalid-slug", slug };
-  if (!(await isDirectory(catalogSlugDir))) return { kind: "not-found", source, slug };
-  if (await isDirectory(activeSlugDir)) return { kind: "already-active", slug };
+  const catalogSlugDir = joinUnderRoot(catalogDirForSource(source, workspaceRoot), safeName);
+  const activeSlugDir = joinUnderRoot(activeDir(workspaceRoot), safeName);
+  if (!(await isDirectory(catalogSlugDir))) return { kind: "not-found", source, slug: safeName };
+  if (await isDirectory(activeSlugDir)) return { kind: "already-active", slug: safeName };
   await copyDirTree(catalogSlugDir, activeSlugDir);
-  log.info("skills", "starred catalog entry", { source, slug });
-  return { kind: "starred", slug };
+  log.info("skills", "starred catalog entry", { source, slug: safeName });
+  return { kind: "starred", slug: safeName };
 }

--- a/server/workspace/skills/catalog.ts
+++ b/server/workspace/skills/catalog.ts
@@ -1,0 +1,183 @@
+// Skill catalog reader + star (copy-to-active) helper. The other
+// half of the catalog/active split established by #1335 PR-A — the
+// preset-sync writer in `server/workspace/skills-preset.ts`
+// populates `data/skills/catalog/preset/`, and this module is what
+// the UI reads from + writes through when the user ★ Stars an entry
+// to bring it into `.claude/skills/`.
+//
+// Why a separate module from `discovery.ts`: catalog entries are
+// not yet in Claude Code's discovery scope (that's the whole point
+// — they're not in `.claude/skills/`). Treating them as a different
+// shape (CatalogEntry vs Skill) keeps the type system honest about
+// which entries are prompt-active. The two converge once an entry
+// is starred: it gets copied into `.claude/skills/<slug>/`, after
+// which `discoverSkills()` picks it up as a normal project-scope
+// skill on the next listing.
+
+import { copyFile, mkdir, readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { workspacePath } from "../workspace.js";
+// WORKSPACE_DIRS — relative segments (e.g. "data/skills/catalog/preset").
+// We deliberately do NOT use WORKSPACE_PATHS here: those are absolute
+// paths rooted at the live `workspacePath`, so joining one with a
+// caller-supplied `workspaceRoot` would silently discard `workspaceRoot`
+// (Node `path.join` drops everything before an absolute argument).
+import { WORKSPACE_DIRS } from "../paths.js";
+import { parseSkillFrontmatter } from "./parser.js";
+import { log } from "../../system/logger/index.js";
+
+// Catalog sources. PR-B ships only `preset` (the `mc-*` skills
+// shipped with the launcher). PR-C will add `anthropic` (sparse
+// git checkout of anthropics/skills) and possibly `community`
+// (URL-installed third-party). The string-union keeps the API
+// surface ready for that extension.
+export type CatalogSource = "preset";
+
+export const CATALOG_SOURCES: readonly CatalogSource[] = ["preset"] as const;
+
+export function isCatalogSource(value: unknown): value is CatalogSource {
+  return typeof value === "string" && (CATALOG_SOURCES as readonly string[]).includes(value);
+}
+
+export interface CatalogEntry {
+  slug: string;
+  /** The slug doubles as the displayed name today — frontmatter has
+   *  no separate `name` field. */
+  name: string;
+  description: string;
+  source: CatalogSource;
+  /** `<workspace>/.claude/skills/<slug>/` exists. UI uses this to
+   *  render "★ Starred" instead of "★ Star" and to disable the
+   *  star button on already-active entries. */
+  alreadyActive: boolean;
+}
+
+// `preset` is the only catalog source today. PR-C will add
+// `anthropic` and possibly `community` — at that point this will
+// switch on the source string. For now an if-else keeps the lint
+// rule (sonarjs/no-small-switch) happy without losing the
+// exhaustiveness narrowing.
+function catalogDirForSource(source: CatalogSource, workspaceRoot: string): string {
+  if (source === "preset") {
+    return path.join(workspaceRoot, WORKSPACE_DIRS.skillsCatalogPreset);
+  }
+  const exhaustive: never = source;
+  throw new Error(`unknown catalog source: ${exhaustive as string}`);
+}
+
+function activeDir(workspaceRoot: string): string {
+  return path.join(workspaceRoot, WORKSPACE_DIRS.claudeSkills);
+}
+
+export interface CatalogOptions {
+  /** Override the workspace root. Default: live `workspacePath`
+   *  (`~/mulmoclaude`). Tests point this at a `mkdtempSync` tree so
+   *  they don't touch the user's real home dir. */
+  workspaceRoot?: string;
+}
+
+async function isDirectory(absPath: string): Promise<boolean> {
+  try {
+    const info = await stat(absPath);
+    return info.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function readCatalogEntry(slugDir: string, slug: string, source: CatalogSource, workspaceRoot: string): Promise<CatalogEntry | null> {
+  const skillMdPath = path.join(slugDir, "SKILL.md");
+  let raw: string;
+  try {
+    raw = await readFile(skillMdPath, "utf-8");
+  } catch {
+    return null;
+  }
+  const parsed = parseSkillFrontmatter(raw);
+  if (!parsed) return null;
+  const alreadyActive = await isDirectory(path.join(activeDir(workspaceRoot), slug));
+  return { slug, name: slug, description: parsed.description, source, alreadyActive };
+}
+
+async function scanCatalogSource(source: CatalogSource, workspaceRoot: string): Promise<CatalogEntry[]> {
+  const dir = catalogDirForSource(source, workspaceRoot);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    // ENOENT is normal — workspace may be freshly created and the
+    // catalog dir hasn't been populated yet (the preset sync runs
+    // first, but defensive). Return [].
+    return [];
+  }
+  const results: CatalogEntry[] = [];
+  for (const slug of entries) {
+    if (slug.startsWith(".")) continue;
+    const slugDir = path.join(dir, slug);
+    if (!(await isDirectory(slugDir))) continue;
+    const entry = await readCatalogEntry(slugDir, slug, source, workspaceRoot);
+    if (entry) results.push(entry);
+  }
+  results.sort((left, right) => left.slug.localeCompare(right.slug));
+  return results;
+}
+
+export async function listCatalogEntries(opts: CatalogOptions = {}): Promise<CatalogEntry[]> {
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  const out: CatalogEntry[] = [];
+  for (const source of CATALOG_SOURCES) {
+    const entries = await scanCatalogSource(source, workspaceRoot);
+    out.push(...entries);
+  }
+  return out;
+}
+
+// Slug whitelist matches the convention used by user-authored
+// skills + preset slugs. The slug becomes a directory name under
+// `.claude/skills/`, so we forbid anything that could escape (`..`,
+// path separators, leading dots) or be interpreted as a special
+// shell character. The two `[a-zA-Z0-9_-]` segments around a
+// required leading + trailing alphanumeric look like nested
+// quantifiers to the security/detect-unsafe-regex rule, but each
+// segment can only consume from a single bounded character class
+// (no overlap), so worst-case backtracking is linear — annotate
+// rather than rewrite for clarity.
+// eslint-disable-next-line security/detect-unsafe-regex -- non-overlapping character classes, no catastrophic backtracking
+const SAFE_SLUG_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$/;
+
+export type StarResult =
+  | { kind: "starred"; slug: string }
+  | { kind: "not-found"; source: CatalogSource; slug: string }
+  | { kind: "already-active"; slug: string }
+  | { kind: "invalid-slug"; slug: string };
+
+async function copyDirTree(srcDir: string, destDir: string): Promise<void> {
+  await mkdir(destDir, { recursive: true });
+  const entries = await readdir(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirTree(srcPath, destPath);
+    } else if (entry.isFile()) {
+      await copyFile(srcPath, destPath);
+    }
+    // Symlinks / sockets / FIFOs are intentionally skipped — the
+    // catalog is launcher-managed and shouldn't contain them.
+  }
+}
+
+/** Copy `data/skills/catalog/<source>/<slug>/` → `.claude/skills/<slug>/`.
+ *  Returns a discriminated result so the route can map to clean
+ *  HTTP status codes. */
+export async function starCatalogEntry(source: CatalogSource, slug: string, opts: CatalogOptions = {}): Promise<StarResult> {
+  if (!SAFE_SLUG_PATTERN.test(slug)) return { kind: "invalid-slug", slug };
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  const catalogSlugDir = path.join(catalogDirForSource(source, workspaceRoot), slug);
+  if (!(await isDirectory(catalogSlugDir))) return { kind: "not-found", source, slug };
+  const activeSlugDir = path.join(activeDir(workspaceRoot), slug);
+  if (await isDirectory(activeSlugDir)) return { kind: "already-active", slug };
+  await copyDirTree(catalogSlugDir, activeSlugDir);
+  log.info("skills", "starred catalog entry", { source, slug });
+  return { kind: "starred", slug };
+}

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1094,6 +1094,11 @@ const deMessages = {
     errSaveFailed: "Speichern fehlgeschlagen: {error}",
     errDeleteFailed: "Löschen fehlgeschlagen",
     confirmDelete: 'Skill "{name}" löschen? Dies entfernt ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
+    catalogPresetHeading: "Preset-Katalog",
+    catalogStar: "☆ Markieren",
+    catalogStarred: "★ Markiert",
+    errCatalogListFailed: "Katalog konnte nicht geladen werden: {error}",
+    errCatalogStarFailed: "Skill konnte nicht markiert werden: {error}",
   },
   pluginManageRoles: {
     heading: "Benutzerdefinierte Rollen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1079,6 +1079,11 @@ const enMessages = {
     errSaveFailed: "Save failed: {error}",
     errDeleteFailed: "Failed to delete",
     confirmDelete: 'Delete skill "{name}"? This removes ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
+    catalogPresetHeading: "Preset catalog",
+    catalogStar: "☆ Star",
+    catalogStarred: "★ Starred",
+    errCatalogListFailed: "Failed to load catalog: {error}",
+    errCatalogStarFailed: "Failed to star skill: {error}",
   },
   pluginManageRoles: {
     heading: "Custom Roles",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1091,6 +1091,11 @@ const esMessages = {
     errSaveFailed: "Error al guardar: {error}",
     errDeleteFailed: "Error al eliminar",
     confirmDelete: '¿Eliminar la skill "{name}"? Esto borrará ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
+    catalogPresetHeading: "Catálogo de preajustes",
+    catalogStar: "☆ Destacar",
+    catalogStarred: "★ Destacada",
+    errCatalogListFailed: "Error al cargar el catálogo: {error}",
+    errCatalogStarFailed: "Error al destacar la skill: {error}",
   },
   pluginManageRoles: {
     heading: "Roles personalizados",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1085,6 +1085,11 @@ const frMessages = {
     errSaveFailed: "Échec de l'enregistrement : {error}",
     errDeleteFailed: "Échec de la suppression",
     confirmDelete: 'Supprimer la skill "{name}" ? Cela retire ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
+    catalogPresetHeading: "Catalogue de préréglages",
+    catalogStar: "☆ Favori",
+    catalogStarred: "★ Favoris",
+    errCatalogListFailed: "Échec du chargement du catalogue : {error}",
+    errCatalogStarFailed: "Échec de l'ajout aux favoris : {error}",
   },
   pluginManageRoles: {
     heading: "Rôles personnalisés",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1080,6 +1080,11 @@ const jaMessages = {
     errSaveFailed: "保存失敗: {error}",
     errDeleteFailed: "削除に失敗しました",
     confirmDelete: "スキル「{name}」を削除しますか? ~/mulmoclaude/.claude/skills/{name}/SKILL.md が削除されます。",
+    catalogPresetHeading: "プリセットカタログ",
+    catalogStar: "☆ Star",
+    catalogStarred: "★ Starred",
+    errCatalogListFailed: "カタログの読み込みに失敗しました: {error}",
+    errCatalogStarFailed: "スキルの star に失敗しました: {error}",
   },
   pluginManageRoles: {
     heading: "カスタムロール",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1080,6 +1080,11 @@ const koMessages = {
     errSaveFailed: "저장 실패: {error}",
     errDeleteFailed: "삭제 실패",
     confirmDelete: '스킬 "{name}" 을(를) 삭제할까요? ~/mulmoclaude/.claude/skills/{name}/SKILL.md 가 제거됩니다.',
+    catalogPresetHeading: "프리셋 카탈로그",
+    catalogStar: "☆ 별 표시",
+    catalogStarred: "★ 별 표시됨",
+    errCatalogListFailed: "카탈로그를 불러오지 못했습니다: {error}",
+    errCatalogStarFailed: "스킬에 별 표시를 추가하지 못했습니다: {error}",
   },
   pluginManageRoles: {
     heading: "커스텀 역할",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1080,6 +1080,11 @@ const ptBRMessages = {
     errSaveFailed: "Falha ao salvar: {error}",
     errDeleteFailed: "Falha ao excluir",
     confirmDelete: 'Excluir a skill "{name}"? Isso remove ~/mulmoclaude/.claude/skills/{name}/SKILL.md.',
+    catalogPresetHeading: "Catálogo de presets",
+    catalogStar: "☆ Favoritar",
+    catalogStarred: "★ Favoritada",
+    errCatalogListFailed: "Falha ao carregar o catálogo: {error}",
+    errCatalogStarFailed: "Falha ao favoritar a skill: {error}",
   },
   pluginManageRoles: {
     heading: "Papéis personalizados",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1072,6 +1072,11 @@ const zhMessages = {
     errSaveFailed: "保存失败: {error}",
     errDeleteFailed: "删除失败",
     confirmDelete: '要删除技能 "{name}" 吗?将会移除 ~/mulmoclaude/.claude/skills/{name}/SKILL.md。',
+    catalogPresetHeading: "预设目录",
+    catalogStar: "☆ 收藏",
+    catalogStarred: "★ 已收藏",
+    errCatalogListFailed: "加载目录失败: {error}",
+    errCatalogStarFailed: "收藏技能失败: {error}",
   },
   pluginManageRoles: {
     heading: "自定义角色",

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -37,6 +37,49 @@
             <code class="text-[11px]">{{ t("pluginManageSkills.emptySkillPath") }}</code>
           </template>
         </i18n-t>
+
+        <!-- Catalog: launcher-managed presets that haven't been
+             starred into `.claude/skills/` yet. #1335 PR-B. Rendered
+             below the Active list as a flat group; PR-C will add
+             Anthropic + community subsections. Each row is read-only
+             (Run once + Preview land in PR-B2) with a single ★ Star
+             action that copies the entry into the Active layer. -->
+        <div v-if="catalogPresets.length > 0" class="border-t border-gray-200 mt-2">
+          <div class="px-4 py-2 text-[11px] uppercase tracking-wide text-gray-500 font-semibold" data-testid="skill-catalog-section-heading">
+            {{ t("pluginManageSkills.catalogPresetHeading") }}
+          </div>
+          <div
+            v-for="entry in catalogPresets"
+            :key="`catalog-preset-${entry.slug}`"
+            :data-testid="`skill-catalog-item-${entry.slug}`"
+            class="px-4 py-2 border-b border-gray-100 text-sm flex items-start gap-2"
+          >
+            <div class="flex-1 min-w-0">
+              <div class="font-medium text-gray-700 truncate">{{ entry.name }}</div>
+              <div class="text-xs text-gray-500 truncate mt-0.5">{{ entry.description }}</div>
+            </div>
+            <button
+              v-if="entry.alreadyActive"
+              class="shrink-0 h-7 px-2 text-[11px] rounded text-gray-400 cursor-not-allowed"
+              :title="t('pluginManageSkills.catalogStarred')"
+              :data-testid="`skill-catalog-starred-${entry.slug}`"
+              disabled
+            >
+              {{ t("pluginManageSkills.catalogStarred") }}
+            </button>
+            <button
+              v-else
+              class="shrink-0 h-7 px-2 text-[11px] rounded border border-blue-300 text-blue-600 hover:bg-blue-50 disabled:opacity-40"
+              :disabled="starringSlug === entry.slug"
+              :title="t('pluginManageSkills.catalogStar')"
+              :data-testid="`skill-catalog-star-btn-${entry.slug}`"
+              @click="starCatalogEntry(entry)"
+            >
+              {{ t("pluginManageSkills.catalogStar") }}
+            </button>
+          </div>
+          <div v-if="catalogError" class="px-4 py-2 text-xs text-red-600">{{ catalogError }}</div>
+        </div>
       </div>
 
       <!-- Right: detail pane -->
@@ -152,7 +195,7 @@ import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
 import { useAppApi } from "../../composables/useAppApi";
-import { apiGet, apiPut, apiDelete } from "../../utils/api";
+import { apiGet, apiPost, apiPut, apiDelete } from "../../utils/api";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { sanitizeMarkdownHtml } from "../../utils/markdown/sanitize";
 import { pluginEndpoints } from "../api";
@@ -209,9 +252,66 @@ const listError = ref<string | null>(null);
 
 const endpoints = pluginEndpoints<SkillsEndpoints>("skills");
 
+// Catalog state (#1335 PR-B). Loaded on mount + after a successful
+// star so the row updates from "★ Star" → "★ Starred". `starringSlug`
+// disables the button mid-request to prevent double-clicks.
+type CatalogSource = "preset";
+interface CatalogEntry {
+  slug: string;
+  name: string;
+  description: string;
+  source: CatalogSource;
+  alreadyActive: boolean;
+}
+const catalogPresets = ref<CatalogEntry[]>([]);
+const catalogError = ref<string | null>(null);
+const starringSlug = ref<string | null>(null);
+
+async function loadCatalog(): Promise<void> {
+  const response = await apiGet<{ entries: CatalogEntry[] }>(endpoints.catalogList.url);
+  if (!response.ok) {
+    catalogError.value = t("pluginManageSkills.errCatalogListFailed", { error: response.error });
+    return;
+  }
+  catalogError.value = null;
+  if (Array.isArray(response.data.entries)) {
+    catalogPresets.value = response.data.entries.filter((entry) => entry.source === "preset");
+  }
+}
+
+async function refreshActiveList(): Promise<void> {
+  // Mirrors the onMounted fetch so the left-column list reflects the
+  // newly-starred skill without waiting for the next manageSkills
+  // tool result. Errors here are non-fatal — the catalog state is
+  // the source of truth for the "Starred" badge.
+  const response = await apiGet<{ skills: SkillSummary[] }>(endpoints.list.url);
+  if (response.ok && Array.isArray(response.data.skills)) {
+    skills.value = response.data.skills;
+  }
+}
+
+async function starCatalogEntry(entry: CatalogEntry): Promise<void> {
+  if (entry.alreadyActive) return;
+  starringSlug.value = entry.slug;
+  const response = await apiPost<{ starred: true; slug: string }>(endpoints.catalogStar.url, { source: entry.source, slug: entry.slug });
+  starringSlug.value = null;
+  if (!response.ok) {
+    catalogError.value = t("pluginManageSkills.errCatalogStarFailed", { error: response.error });
+    return;
+  }
+  catalogError.value = null;
+  // Refresh both lists so the row flips to "Starred" and the new
+  // active entry shows up in the left column.
+  await Promise.all([loadCatalog(), refreshActiveList()]);
+}
+
 // Standalone mode: if no selectedResult was passed, fetch the skill
 // list from the API on mount so the view is populated.
 onMounted(async () => {
+  // Always load the catalog so the section appears even when the
+  // view was opened from a tool result (which only carries the
+  // active list).
+  await loadCatalog();
   if (props.selectedResult || skills.value.length > 0) return;
   const response = await apiGet<{ skills: SkillSummary[] }>(endpoints.list.url);
   if (!response.ok) {

--- a/src/plugins/manageSkills/meta.ts
+++ b/src/plugins/manageSkills/meta.ts
@@ -16,6 +16,15 @@ export const META = definePluginMeta({
     update: { method: "PUT", path: "/:name" },
     /** DELETE /api/skills/:name — delete a project-scope skill. */
     remove: { method: "DELETE", path: "/:name" },
+    /** GET /api/skills/catalog — list catalog entries (preset for
+     *  now; anthropic / community land in #1335 PR-C). Catalog
+     *  entries are NOT in `.claude/skills/` and don't enter the
+     *  Claude Code system prompt until the user ★ Stars them. */
+    catalogList: { method: "GET", path: "/catalog" },
+    /** POST /api/skills/catalog/star — body `{ source, slug }`.
+     *  Copies the catalog entry into `.claude/skills/<slug>/` so
+     *  Claude Code's slash-command resolver picks it up. */
+    catalogStar: { method: "POST", path: "/catalog/star" },
   },
   mcpDispatch: "create",
 });

--- a/test/workspace/skills/test_catalog.ts
+++ b/test/workspace/skills/test_catalog.ts
@@ -1,0 +1,158 @@
+// Catalog reader + star helper tests (#1335 PR-B).
+//
+// `catalog.ts` reads `<workspace>/data/skills/catalog/<source>/<slug>/`
+// and copies entries into `<workspace>/.claude/skills/<slug>/` on
+// star. Both functions accept an explicit `workspaceRoot` override so
+// tests can point at a `mkdtempSync` tree without touching
+// `~/mulmoclaude/`.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { isCatalogSource, listCatalogEntries, starCatalogEntry } from "../../../server/workspace/skills/catalog.js";
+
+let workdir: string;
+let catalogPresetDir: string;
+let activeDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "catalog-test-"));
+  catalogPresetDir = path.join(workdir, "data/skills/catalog/preset");
+  activeDir = path.join(workdir, ".claude/skills");
+  mkdirSync(catalogPresetDir, { recursive: true });
+  mkdirSync(activeDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+function writeCatalogEntry(slug: string, body: string): void {
+  const slugDir = path.join(catalogPresetDir, slug);
+  mkdirSync(slugDir, { recursive: true });
+  writeFileSync(path.join(slugDir, "SKILL.md"), body);
+}
+
+describe("isCatalogSource", () => {
+  it("accepts the supported source strings", () => {
+    assert.equal(isCatalogSource("preset"), true);
+  });
+
+  it("rejects unknown sources", () => {
+    assert.equal(isCatalogSource("anthropic"), false);
+    assert.equal(isCatalogSource("community"), false);
+    assert.equal(isCatalogSource(""), false);
+    assert.equal(isCatalogSource(123), false);
+    assert.equal(isCatalogSource(null), false);
+  });
+});
+
+describe("listCatalogEntries", () => {
+  it("returns [] on an empty catalog", async () => {
+    const entries = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.deepEqual(entries, []);
+  });
+
+  it("returns one entry per valid catalog slug", async () => {
+    writeCatalogEntry("mc-foo", "---\ndescription: foo desc\n---\nbody");
+    writeCatalogEntry("mc-bar", "---\ndescription: bar desc\n---\nbody");
+    const entries = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.equal(entries.length, 2);
+    assert.deepEqual(
+      entries.map((entry) => entry.slug),
+      ["mc-bar", "mc-foo"], // sorted
+    );
+    assert.equal(entries[0].source, "preset");
+    assert.equal(entries[0].description, "bar desc");
+  });
+
+  it("skips entries with missing or malformed SKILL.md", async () => {
+    writeCatalogEntry("mc-good", "---\ndescription: ok\n---\nbody");
+    // No SKILL.md at all
+    mkdirSync(path.join(catalogPresetDir, "mc-empty"));
+    // SKILL.md exists but has no frontmatter
+    const noFmDir = path.join(catalogPresetDir, "mc-no-fm");
+    mkdirSync(noFmDir);
+    writeFileSync(path.join(noFmDir, "SKILL.md"), "just text, no frontmatter");
+    const entries = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.deepEqual(
+      entries.map((entry) => entry.slug),
+      ["mc-good"],
+    );
+  });
+
+  it("skips hidden entries", async () => {
+    writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\n");
+    // .DS_Store, .gitkeep, etc.
+    writeFileSync(path.join(catalogPresetDir, ".DS_Store"), "");
+    mkdirSync(path.join(catalogPresetDir, ".hidden-dir"));
+    const entries = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.deepEqual(
+      entries.map((entry) => entry.slug),
+      ["mc-foo"],
+    );
+  });
+
+  it("flags alreadyActive when the slug exists under .claude/skills/", async () => {
+    writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\n");
+    mkdirSync(path.join(activeDir, "mc-foo"));
+    const entries = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.equal(entries[0].alreadyActive, true);
+  });
+
+  it("alreadyActive is false when only the catalog has the entry", async () => {
+    writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\n");
+    const entries = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.equal(entries[0].alreadyActive, false);
+  });
+});
+
+describe("starCatalogEntry", () => {
+  it("copies the catalog slug dir into .claude/skills/", async () => {
+    writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\nthe body");
+    const result = await starCatalogEntry("preset", "mc-foo", { workspaceRoot: workdir });
+    assert.deepEqual(result, { kind: "starred", slug: "mc-foo" });
+    const activeSkill = path.join(activeDir, "mc-foo/SKILL.md");
+    assert.equal(existsSync(activeSkill), true);
+    assert.match(readFileSync(activeSkill, "utf-8"), /the body/);
+  });
+
+  it("copies subdirectories too (scripts/ etc.)", async () => {
+    const slugDir = path.join(catalogPresetDir, "mc-with-scripts");
+    mkdirSync(path.join(slugDir, "scripts"), { recursive: true });
+    writeFileSync(path.join(slugDir, "SKILL.md"), "---\ndescription: ok\n---\n");
+    writeFileSync(path.join(slugDir, "scripts", "helper.py"), "print('hi')");
+    await starCatalogEntry("preset", "mc-with-scripts", { workspaceRoot: workdir });
+    assert.equal(existsSync(path.join(activeDir, "mc-with-scripts/scripts/helper.py")), true);
+  });
+
+  it("returns already-active when the slug is in .claude/skills/", async () => {
+    writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\n");
+    mkdirSync(path.join(activeDir, "mc-foo"));
+    const result = await starCatalogEntry("preset", "mc-foo", { workspaceRoot: workdir });
+    assert.deepEqual(result, { kind: "already-active", slug: "mc-foo" });
+  });
+
+  it("returns not-found when the catalog slug doesn't exist", async () => {
+    const result = await starCatalogEntry("preset", "mc-missing", { workspaceRoot: workdir });
+    assert.deepEqual(result, { kind: "not-found", source: "preset", slug: "mc-missing" });
+  });
+
+  it("rejects path-traversal slugs", async () => {
+    const result = await starCatalogEntry("preset", "../etc/passwd", { workspaceRoot: workdir });
+    assert.equal(result.kind, "invalid-slug");
+  });
+
+  it("rejects slugs with path separators", async () => {
+    assert.equal((await starCatalogEntry("preset", "foo/bar", { workspaceRoot: workdir })).kind, "invalid-slug");
+    assert.equal((await starCatalogEntry("preset", "foo\\bar", { workspaceRoot: workdir })).kind, "invalid-slug");
+  });
+
+  it("rejects empty + dot-prefixed slugs", async () => {
+    assert.equal((await starCatalogEntry("preset", "", { workspaceRoot: workdir })).kind, "invalid-slug");
+    assert.equal((await starCatalogEntry("preset", ".hidden", { workspaceRoot: workdir })).kind, "invalid-slug");
+  });
+});


### PR DESCRIPTION
## Summary

After PR-A (#1369) moved preset skills to `<workspace>/data/skills/catalog/preset/`, they were populated on disk but unreachable from the UI. **PR-B** adds the catalog reader, the ★ Star action that copies a catalog entry into `.claude/skills/`, and a minimum UI in the Skills settings tab.

Closes #1335 backend + minimum UI. Run once + Preview (deferred PR-B2) and Anthropic / Community catalog (PR-C) follow.

```
manageSkills (left column, after PR-B)
──────────────────────────────────────
┌─ Active ────────────────────────────┐
│  my-helper           (project)      │
│  mc-library          (project)*     │  ← already starred
└─────────────────────────────────────┘
┌─ Preset catalog ────────────────────┐
│  mc-cooking-coach    ★ Starred      │  ← disabled, mc-library equivalent
│  mc-library          ★ Starred      │
│  mc-manage-automations  ☆ Star  ← click to copy → .claude/skills/
│  mc-manage-skills    ☆ Star
│  mc-manage-sources   ☆ Star
└─────────────────────────────────────┘
```

## Items to Confirm / Review

- **`WORKSPACE_DIRS` vs `WORKSPACE_PATHS`**: catalog.ts joins on `WORKSPACE_DIRS.skillsCatalogPreset` (relative segment) and not `WORKSPACE_PATHS.skillsCatalogPreset` (absolute, rooted at the live `workspacePath`). The latter would silently drop the test's `workspaceRoot` override because Node `path.join` discards everything before an absolute argument. Hit + fixed during test-writing, documented inline.
- **No `stars.json` registry yet** — "presence in `.claude/skills/`" remains the implicit star signal. Star = copy, un-star = use the existing project-scope DELETE endpoint. Simpler; PR-C can introduce a registry if SHA pinning becomes necessary.
- **Slug whitelist**: the star endpoint rejects slugs that aren't `^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$`. Defence in depth on top of the `path.join` semantics so a request body with `../etc/passwd` can't escape.
- **i18n star icons in strings**: `☆ Star` / `★ Starred` baked into each locale rather than rendered as raw template text. Keeps the template free of `@intlify/vue-i18n/no-raw-text` warnings.
- **Subdir copy**: when a catalog entry has support files (e.g. `mc-cooking-coach/scripts/foo.py`), the star action copies the WHOLE slug dir, not just SKILL.md. Tested.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1335 これをすすめよう
>
> はい、順次進める。既存のユーザ、データは気にしないで、migrationなしですすめて。

## Implementation approach

1. **`server/workspace/skills/catalog.ts`** — new module. `CatalogEntry`, `listCatalogEntries(opts?)`, `starCatalogEntry(source, slug, opts?)`, `isCatalogSource` type guard. Both functions take `{ workspaceRoot? }` defaulting to the live `workspacePath`, so tests run against `mkdtempSync` trees.
2. **`server/api/routes/skills.ts`** — two new bound routes via the existing META auto-aggregator.
3. **`src/plugins/manageSkills/meta.ts`** — declare `catalogList` (`GET /catalog`) + `catalogStar` (`POST /catalog/star`) routes.
4. **`src/plugins/manageSkills/View.vue`** — catalog section in the left column. On star, both the catalog list and active list refresh so the row flips instantly.
5. **`src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`** — 5 keys × 8 locales.
6. **`test/workspace/skills/test_catalog.ts`** — 16 cases (lists, alreadyActive, malformed SKILL.md, hidden entries, star happy / already-active / not-found / invalid-slug / path-traversal).
7. **`plans/feat-skill-catalog-star-ui-1335.md`** — plan file.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean (fixed `id-length` on test `e` → `entry` arg names; resolved `sonarjs/no-small-switch` by inlining the single-case dispatch; annotated `security/detect-unsafe-regex` on the slug whitelist with a non-overlapping-classes rationale)
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — 16 new catalog cases pass; existing skills tests unaffected
- [ ] Manual: open Settings → Skills, scroll to "Preset catalog" section, click ☆ Star on `mc-library`, verify (a) the row flips to ★ Starred immediately, (b) `mc-library` appears in the active list above without a refresh, (c) `~/mulmoclaude/.claude/skills/mc-library/SKILL.md` now exists and matches `data/skills/catalog/preset/mc-library/SKILL.md`.
- [ ] Manual: click a second star while the first is in-flight — the second button should be disabled briefly (`starringSlug` guard).
- [ ] Manual: after starring, the `mc-library` slash-command should work in chat (Claude Code's discovery picks it up because it's now in `.claude/skills/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)