### PR TITLE
chore(ci): run e2e-live no-LLM matrix daily at 03:00 JST

### DIFF
--- a/.github/workflows/e2e_live_no_llm.yaml
+++ b/.github/workflows/e2e_live_no_llm.yaml
@@ -13,7 +13,7 @@ name: E2E Live (no LLM)
 
 on:
   schedule:
-    - cron: "0 0 * * 1"  # Weekly Monday 00:00 UTC
+    - cron: "0 18 * * *"  # Daily 18:00 UTC = 03:00 JST
   workflow_dispatch:
   pull_request:
     paths:


### PR DESCRIPTION
## Summary

Bumps the cron from weekly Monday 09:00 JST to **daily 03:00 JST** (`0 18 * * *` UTC).

The fake-echo seam (landed in #1371) makes each run free of Claude credit, so daily cadence catches regressions in the plugin-dispatch chain (`presentForm` / `presentHtml` / `presentChart` / `presentMulmoScript` / Write) about a week earlier than weekly would.

## User Prompt

> mainから、このテストをscheduledにして！
> 毎日にしようか。jstの午前３時。

## Test plan

- [ ] PR check goes green (this PR change touches the workflow file, so the `pull_request.paths` filter fires the matrix once for confirmation)
- [ ] After merge, the daily 18:00 UTC cron starts firing — verify the next scheduled run in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)