### PR TITLE
docs(make-e2e-live): point to e2e-live-testing.md for fake-echo rules

### DIFF
--- a/.claude/skills/make-e2e-live/SKILL.md
+++ b/.claude/skills/make-e2e-live/SKILL.md
@@ -136,7 +136,8 @@ git checkout -b feat/e2e-live-<topic>
   - 命名: `data-testid="<plugin>-<role>"` の kebab-case
   - **同 PR で `docs/ui-cheatsheet.md` の該当 ASCII ブロックを更新**（CLAUDE.md ルール）
   - 翻訳テキストや `iframe[sandbox]` 構造属性に依存しない（脆い）
-- 新規テスト追加時は `docs/e2e-live-testing.md` の skip 規約（`test.skip(process.env.E2E_LIVE_NO_LLM === "1", ...)`）と matrix 登録ルール（`.github/workflows/e2e_live_no_llm.yaml` の `matrix.spec:`）に従う
+- 新規テスト追加時は `docs/e2e-live-testing.md` の skip 規約に従う — Claude 必須テストには per-test で `test.skip(process.env.E2E_LIVE_NO_LLM === "1", ...)` を付ける
+- 新規 spec ファイル追加時は `.github/workflows/e2e_live_no_llm.yaml` の `matrix.spec:` への登録も併せて確認する（1 本でも fake-friendly なテストがあれば追加）
 
 ### コーディングルール（CLAUDE.md より）
 

--- a/.claude/skills/make-e2e-live/SKILL.md
+++ b/.claude/skills/make-e2e-live/SKILL.md
@@ -136,6 +136,7 @@ git checkout -b feat/e2e-live-<topic>
   - 命名: `data-testid="<plugin>-<role>"` の kebab-case
   - **同 PR で `docs/ui-cheatsheet.md` の該当 ASCII ブロックを更新**（CLAUDE.md ルール）
   - 翻訳テキストや `iframe[sandbox]` 構造属性に依存しない（脆い）
+- 新規テスト追加時は `docs/e2e-live-testing.md` の skip 規約（`test.skip(process.env.E2E_LIVE_NO_LLM === "1", ...)`）と matrix 登録ルール（`.github/workflows/e2e_live_no_llm.yaml` の `matrix.spec:`）に従う
 
 ### コーディングルール（CLAUDE.md より）
 
@@ -227,4 +228,5 @@ yarn test:e2e:live:<category>   # 該当カテゴリだけ
 - `e2e-live/fixtures/live-chat.ts` — 既存 helper 一覧
 - `e2e-live/tests/media.spec.ts` — L-01 / L-02 の参考実装
 - `docs/ui-cheatsheet.md` — testid 追加時に併せて更新
+- `docs/e2e-live-testing.md` — e2e-live オーサリング規約（2 backend / fake-echo 対応表 / skip 作法、必読）
 - `CLAUDE.md` — コーディングルール / git 運用 / PR フォーマット


### PR DESCRIPTION
## Summary

- `make-e2e-live` skill は #1364 以前に書かれており、 fake-echo backend / `E2E_LIVE_NO_LLM` / `e2e_live_no_llm.yaml` matrix への言及がゼロだった。 これから書く新規 e2e-live テストが新ルール（per-test skip 注釈 / matrix への登録）を満たさず、 CI で見せかけ緑を生むリスクがあった。
- 内容の決定版は `docs/e2e-live-testing.md` に既にあるので、 skill 側には参照を計 2 行だけ追加（共通ルールに 2 bullet + 参照節に 1 行）。 重複は作らない。

## Items to Confirm / Review

- 文言は「per-test skip 規約」と「per-spec matrix 登録」を別 bullet で分離してある（codex 指摘を反映）。 粒度の混在が解消されているかを見てほしい。
- 参照節に追加した `docs/e2e-live-testing.md` の説明文（「2 backend / fake-echo 対応表 / skip 作法、 必読」）が doc の中身と乖離していないか。
- 「重複させない、 参照だけ」 という方針自体が妥当か（skill にも作法を直接書き込むべき、 という反対意見が無いか）。

## User Prompt

> PR #1364 の変更を踏まえて make-e2e-live skill も更新した方が良いか？ 更新するならどう書くか提案してほしい。 ブランチを切って編集 → commit → codex-cross-review にかけて欲しい。

## 実装内容

- `.claude/skills/make-e2e-live/SKILL.md` Phase 4 共通ルール末尾に 2 bullet 追加:
  - 新規テスト追加時は `docs/e2e-live-testing.md` の skip 規約に従う — Claude 必須テストには per-test で `test.skip(process.env.E2E_LIVE_NO_LLM === "1", ...)` を付ける
  - 新規 spec ファイル追加時は `.github/workflows/e2e_live_no_llm.yaml` の `matrix.spec:` への登録も併せて確認する（1 本でも fake-friendly なテストがあれば追加）
- 参照節に 1 行追加: `docs/e2e-live-testing.md` — e2e-live オーサリング規約（2 backend / fake-echo 対応表 / skip 作法、 必読）

## レビュー履歴

`/codex-cross-review` で 2 iteration 回した:

- iter 1: codex から nit 1 件（per-test と per-spec が 1 行に同居していて粒度が混ざる）→ 2 bullet に分割して対応
- iter 2: codex LGTM、 findings 無し

## Test plan

- [ ] reviewer が `docs/e2e-live-testing.md` と照合して、 skill 側の文言が doc の実記載とズレていないか確認
- [ ] 「参照のみで充分／skill に直接作法も書くべき」 の方針判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated e2e testing guidelines to establish new compliance requirements for AI-powered tests, including standardized conventions and procedures for test implementation and registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1376)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->