### PR TITLE
test(e2e): pin movie-generation error chip + retry button (#1197)

### DIFF
--- a/e2e/tests/present-mulmo-script.spec.ts
+++ b/e2e/tests/present-mulmo-script.spec.ts
@@ -191,6 +191,47 @@ test.describe("presentMulmoScript plugin", () => {
   // per-test mock even though it passed in isolation), so the check
   // lives in manual testing rather than gating CI.
 
+  // Regression for #1197. Movie generation used to surface SSE
+  // errors via `alert()` — blocking, no retry, and once dismissed the
+  // canvas looked identical to a healthy idle state. The fix swaps to
+  // an inline error chip + Retry button between the chrome row and
+  // the Characters section. This test pins both the chip surface and
+  // the retry round-trip.
+  test("generateMovie error: SSE error event surfaces inline chip + retry button re-fires the request", async ({ page }) => {
+    const SSE_ERROR_MESSAGE = "Page.captureScreenshot timed out.";
+    let generateMovieCalls = 0;
+    await page.route(
+      (url) => url.pathname === "/api/mulmoScript/generate-movie",
+      (route) => {
+        generateMovieCalls++;
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+          body: `data: {"type":"error","message":"${SSE_ERROR_MESSAGE}"}\n\n`,
+        });
+      },
+    );
+
+    await page.goto("/chat/mulmo-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText(SCRIPT_TITLE).first().click();
+    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
+
+    // First attempt: chip should appear with the SSE-supplied message.
+    await page.getByTestId("mulmo-script-generate-movie-button").click();
+    const retryButton = page.getByTestId("mulmo-script-movie-retry-button");
+    await expect(retryButton).toBeVisible();
+    await expect(page.getByText("Movie generation failed")).toBeVisible();
+    await expect(page.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
+    expect(generateMovieCalls).toBe(1);
+
+    // Retry: same endpoint is hit again, chip stays (same error replays).
+    await retryButton.click();
+    await expect(retryButton).toBeVisible();
+    await expect(page.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
+    expect(generateMovieCalls).toBe(2);
+  });
+
   // Regression for #839 + the in-PR follow-up. The slide view must
   // light up the shared ThinkingIndicator while the active session
   // has a chat turn in flight — same signal the chat sidebar uses,

--- a/e2e/tests/present-mulmo-script.spec.ts
+++ b/e2e/tests/present-mulmo-script.spec.ts
@@ -223,13 +223,18 @@ test.describe("presentMulmoScript plugin", () => {
     await expect(retryButton).toBeVisible();
     await expect(page.getByText("Movie generation failed")).toBeVisible();
     await expect(page.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
-    expect(generateMovieCalls).toBe(1);
+    // expect.poll instead of a plain toBe so the assertion tolerates
+    // the microtask gap between the route handler firing and the SPA's
+    // catch arm landing. Chip visibility above already implies the
+    // handler ran, but the poll keeps this future-proof against any
+    // scheduling tweak in Playwright or Vue.
+    await expect.poll(() => generateMovieCalls).toBe(1);
 
     // Retry: same endpoint is hit again, chip stays (same error replays).
     await retryButton.click();
     await expect(retryButton).toBeVisible();
     await expect(page.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
-    expect(generateMovieCalls).toBe(2);
+    await expect.poll(() => generateMovieCalls).toBe(2);
   });
 
   // Regression for #839 + the in-PR follow-up. The slide view must

--- a/e2e/tests/present-mulmo-script.spec.ts
+++ b/e2e/tests/present-mulmo-script.spec.ts
@@ -218,11 +218,15 @@ test.describe("presentMulmoScript plugin", () => {
     await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
 
     // First attempt: chip should appear with the SSE-supplied message.
+    // All chip-internal assertions scope through the chip's testid so
+    // they survive copy / locale tweaks and aren't satisfied by a
+    // stray "Movie generation failed" string rendered anywhere else.
     await page.getByTestId("mulmo-script-generate-movie-button").click();
-    const retryButton = page.getByTestId("mulmo-script-movie-retry-button");
-    await expect(retryButton).toBeVisible();
-    await expect(page.getByText("Movie generation failed")).toBeVisible();
-    await expect(page.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
+    const errorChip = page.getByTestId("mulmo-script-movie-error-chip");
+    const retryButton = errorChip.getByTestId("mulmo-script-movie-retry-button");
+    await expect(errorChip).toBeVisible();
+    await expect(errorChip.getByText("Movie generation failed")).toBeVisible();
+    await expect(errorChip.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
     // expect.poll instead of a plain toBe so the assertion tolerates
     // the microtask gap between the route handler firing and the SPA's
     // catch arm landing. Chip visibility above already implies the
@@ -232,8 +236,8 @@ test.describe("presentMulmoScript plugin", () => {
 
     // Retry: same endpoint is hit again, chip stays (same error replays).
     await retryButton.click();
-    await expect(retryButton).toBeVisible();
-    await expect(page.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
+    await expect(errorChip).toBeVisible();
+    await expect(errorChip.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
     await expect.poll(() => generateMovieCalls).toBe(2);
   });
 

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -96,7 +96,11 @@
       and saw a stalled spinner with no explanation. The chip stays
       visible until the next generate attempt clears it.
     -->
-    <div v-if="movieError" class="bg-red-50 border border-red-200 text-red-800 text-xs px-3 py-2 mx-4 mt-3 mb-1 rounded flex items-start gap-2">
+    <div
+      v-if="movieError"
+      data-testid="mulmo-script-movie-error-chip"
+      class="bg-red-50 border border-red-200 text-red-800 text-xs px-3 py-2 mx-4 mt-3 mb-1 rounded flex items-start gap-2"
+    >
       <span class="material-icons text-base shrink-0 mt-px">error_outline</span>
       <div class="flex-1 min-w-0">
         <div class="font-medium">{{ t("pluginMulmoScript.movieGenerationFailed") }}</div>


### PR DESCRIPTION
## Summary

- #1197 / #1363 で入った「動画生成失敗時の inline error chip + Retry ボタン」 UI の e2e regression test を `e2e/tests/present-mulmo-script.spec.ts` に 1 本追加するだけの PR。 +48 行 / 削除 0。
- 修正 PR #1363 は `data-testid=\"mulmo-script-movie-retry-button\"` を付けてくれていたが e2e は同梱されていなかったので、 後追いで回帰網を張る。
- `/api/mulmoScript/generate-movie` を SSE error event (`data: {\"type\":\"error\",\"message\":\"...\"}\\n\\n`) で mock し、 chip 表示 + Retry → endpoint 再叩き + chip 残存 を assert。

## Items to Confirm / Review

1. **mock-based e2e (`e2e/`) を選んだ判断**。 e2e-live ではなく `e2e/` にしたのは: (a) `generateMovie` は `docs/e2e-live-testing.md` の対応表で fake-echo backend では動かない枠 (ffmpeg shell out)、 (b) error path 自体が real backend でも安定再現不可 (server 側 protocolTimeout を意図的に誘発する手段がない)、 (c) SSE プロトコル契約 (`{ type: \"error\", message }`) を pin するだけなら mock の方が回帰検出として強い、 という 3 点。 PR #1376 の新ルール下でも結論は変わらないと判断した。
2. **i18n-fragile な英語 hardcode**。 chip headline assertion (`\"Movie generation failed\"`) は英語ハードコードだが、 e2e Playwright Chromium は `navigator.language` 由来で `en` 固定 (`src/lib/vue-i18n.ts` `detectLocale`)、 同 spec file 内の他 assertion (`\"2 beats\"` / `\"Image was not generated\"`) も同じ慣習。 同 test 内に testid lookup と動的 SSE error 文字列の 2 つの i18n-stable assertion が同居しているので weakest assertion 1 つを英語で書くのは許容範囲、 と判断。 Codex も `[accepted-defer]` で同意済み。
3. **request-count 検証は `expect.poll`**。 plain `expect(...).toBe(N)` だと async route handler の counter increment と race する理論リスクがあったので、 Codex 指摘を受けて `await expect.poll(() => generateMovieCalls).toBe(N)` に修正済み。 retry button visible の時点で response 完了が保証されているため実害はないが、 将来の scheduling tweak への defensive coverage として残してある。

## User Prompt

> issue #1197 fixed したみたいです。 QA 実施 と e2e live 追加できるならして。

経緯として:

- 最初 e2e-live 追加可否を相談 → 上記 1 の理由で mock-based `e2e/` を提案 → ユーザー承認
- 私が main で作業しかけたのを「worktree で作業した？」 と指摘してもらい、 `.claude/worktrees/test-movie-error-1197/` (branch `test/e2e-movie-error-1197`) に移送して作業し直し
- `/codex-cross-review` を self pre-PR モードで 2 iteration 回し、 Codex APPROVED で push

## 実装内容

`e2e/tests/present-mulmo-script.spec.ts` に 1 test を追加 (+41 行 → iter-1 fix で +48 行):

```ts
test(\"generateMovie error: SSE error event surfaces inline chip + retry button re-fires the request\", async ({ page }) => {
  // /api/mulmoScript/generate-movie を SSE error event で mock
  // → Generate Movie click
  // → chip (testid + \"Movie generation failed\" + SSE 由来 error 文字列) 表示を assert
  // → Retry click → endpoint 再叩き + chip 残存を assert
});
```

mock SSE body は `Content-Type: text/event-stream` + `data: {\"type\":\"error\",\"message\":\"...\"}\\n\\n` の最小形。 `streamMovieEvents` (helpers.ts) → `applyMovieEvent` が error event を throw → View.vue catch arm で `movieError.value` に set される、 という PR #1363 の経路をそのまま走らせる。

## CI 適用範囲

`.github/workflows/pull_request.yaml` の e2e job は `src/lang/**` 以外の変更があれば起動する設計 (translation-only PR のみ skip)。 今回は `e2e/tests/**` 変更なので **PR 時 + main push 時の両方で実行される**。 ubuntu-latest × 2 shard parallel に乗る。

## レビュー履歴

`/codex-cross-review` を self pre-PR モードで 2 iteration:

- **iter 1 (CHANGES REQUESTED)**: must-fix 1 件 (request-count race) + question 1 件 (locale hardcode)
  - must-fix: `await expect.poll(() => generateMovieCalls).toBe(N)` に修正
  - question: defer + 理由を `claude-reply-1.md` で Codex に伝達
- **iter 2 (APPROVED)**: iter-1 fix を verified、 defer も `[accepted-defer]` で同意

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck:e2e` clean
- [x] `yarn test:e2e --grep \"generateMovie error\"` pass
- [x] `yarn test:e2e e2e/tests/present-mulmo-script.spec.ts` 全 7 test pass (regression なし)
- [ ] CI の e2e shard 1/2 + 2/2 で同 spec が pass すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end regression test covering Movie generation SSE error handling, verifying inline error display and retry behavior.
* **Style**
  * Minor template formatting cleanup for the movie-generation error UI component (no behavior changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1377)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->