### PR TITLE
feat: role-aware empty state with clickable starter queries

### DIFF
--- a/e2e/tests/chatinput-attach.spec.ts
+++ b/e2e/tests/chatinput-attach.spec.ts
@@ -1,33 +1,23 @@
 // E2E coverage for ChatInput attachment discoverability (#499, PR #598).
 //
-// Three behaviours we care about:
-//  1. The placeholder advertises file attachment (drop / paste / attach).
-//  2. The paperclip button is present + wired to a hidden <input type="file">
+// Two behaviours we care about:
+//  1. The paperclip button is present + wired to a hidden <input type="file">
 //     with the right `accept` filter derived from ACCEPTED_MIME_*.
-//  3. Dropping an unsupported file type surfaces a visible error banner,
+//  2. Dropping an unsupported file type surfaces a visible error banner,
 //     instead of the pre-PR silent-drop.
+//
+// The placeholder used to spell out "drop / paste / attach", but was
+// shortened to "Message Claude…" — discoverability now rides on the
+// paperclip button (title) and the drop-overlay (`dropHint`), both
+// covered below.
 
 import { test, expect } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
-import { chatInput } from "../fixtures/chat";
 
 test.describe("ChatInput attach discoverability", () => {
   test.beforeEach(async ({ page }) => {
     await mockAllApis(page);
     await page.goto("/");
-  });
-
-  test("placeholder hints at file attachment", async ({ page }) => {
-    const placeholder = await chatInput(page).getAttribute("placeholder");
-    expect(placeholder).toBeTruthy();
-    if (placeholder === null) throw new Error("placeholder must be set");
-    // Either language: the three affordances we want the user to
-    // discover must all be named. Matches both EN ("drop / paste /
-    // attach") and JA ("ドロップ・ペースト・添付").
-    const lower = placeholder.toLowerCase();
-    const hasAllEn = lower.includes("drop") && lower.includes("paste") && lower.includes("attach");
-    const hasAllJa = placeholder.includes("ドロップ") && placeholder.includes("ペースト") && placeholder.includes("添付");
-    expect(hasAllEn || hasAllJa, `placeholder "${placeholder}" should mention drop/paste/attach`).toBeTruthy();
   });
 
   test("paperclip attach button is present with a title", async ({ page }) => {

--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -89,7 +89,7 @@ test.describe("session navigation via URL", () => {
   test("direct URL to an existing session loads it", async ({ page }) => {
     await page.goto(`/chat/${SESSION_A.id}`);
     await page.waitForURL(new RegExp(SESSION_A.id));
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
   });
 
   test("direct URL to a non-existent session falls back to new session", async ({ page }) => {
@@ -98,7 +98,7 @@ test.describe("session navigation via URL", () => {
     await expect(async () => {
       expect(page.url()).not.toContain("nonexistent-session-xyz");
     }).toPass({ timeout: 10 * ONE_SECOND_MS });
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
   });
 
   test("page reload preserves the session URL", async ({ page }) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -158,8 +158,20 @@
             <div v-else-if="selectedResult" class="h-full overflow-auto p-6">
               <pre class="text-sm text-gray-700 whitespace-pre-wrap">{{ JSON.stringify(selectedResult, null, 2) }}</pre>
             </div>
-            <div v-else class="flex items-center justify-center h-full text-gray-600">
-              <p>{{ t("app.startConversation") }}</p>
+            <div v-else class="flex flex-col items-center justify-center h-full px-6 text-center">
+              <span class="material-icons text-5xl text-gray-400 mb-2" aria-hidden="true">{{ sessionRoleIcon }}</span>
+              <p class="text-lg font-medium text-gray-700 mb-4">{{ sessionRoleName }}</p>
+              <div v-if="sessionRoleQueries.length > 0" class="flex flex-wrap gap-2 justify-center max-w-xl">
+                <button
+                  v-for="query in sessionRoleQueries"
+                  :key="query"
+                  class="text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full px-4 py-2 border border-gray-300 transition-colors"
+                  @click="sendMessage(query)"
+                >
+                  {{ query }}
+                </button>
+              </div>
+              <p v-else class="text-sm text-gray-500">{{ t("app.startConversation") }}</p>
             </div>
           </template>
           <StackView

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -28,7 +28,7 @@ const deMessages = {
     },
   },
   chatInput: {
-    placeholder: "Aufgabe eingeben oder Datei ziehen / einfügen / anhängen…",
+    placeholder: "Nachricht an Claude…",
     send: "Senden",
     attachFile: "Datei anhängen",
     fileTooLarge: "Datei zu groß ({sizeMB} MB). Das Maximum beträgt 30 MB.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -50,7 +50,7 @@ const enMessages = {
     },
   },
   chatInput: {
-    placeholder: "Type a task, or drop / paste / attach a file…",
+    placeholder: "Message Claude…",
     send: "Send",
     attachFile: "Attach file",
     fileTooLarge: "File too large ({sizeMB} MB). Maximum is 30 MB.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -33,7 +33,7 @@ const esMessages = {
     },
   },
   chatInput: {
-    placeholder: "Escribe una tarea, o arrastra / pega / adjunta un archivo…",
+    placeholder: "Mensaje para Claude…",
     send: "Enviar",
     attachFile: "Adjuntar archivo",
     fileTooLarge: "El archivo es demasiado grande ({sizeMB} MB). El máximo es 30 MB.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -28,7 +28,7 @@ const frMessages = {
     },
   },
   chatInput: {
-    placeholder: "Saisissez une tâche, ou glissez / collez / joignez un fichier…",
+    placeholder: "Message à Claude…",
     send: "Envoyer",
     attachFile: "Joindre un fichier",
     fileTooLarge: "Fichier trop volumineux ({sizeMB} Mo). La limite est de 30 Mo.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -35,7 +35,7 @@ const jaMessages = {
     },
   },
   chatInput: {
-    placeholder: "タスクを入力、またはファイルをドロップ・ペースト・添付…",
+    placeholder: "Claude にメッセージ…",
     send: "送信",
     attachFile: "ファイルを添付",
     fileTooLarge: "ファイルが大きすぎます（{sizeMB} MB）。上限は 30 MB です。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -35,7 +35,7 @@ const koMessages = {
     },
   },
   chatInput: {
-    placeholder: "작업을 입력하거나 파일을 드래그 / 붙여넣기 / 첨부하세요…",
+    placeholder: "Claude에게 메시지…",
     send: "전송",
     attachFile: "파일 첨부",
     fileTooLarge: "파일이 너무 큽니다 ({sizeMB} MB). 최대 30 MB 까지 가능합니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -28,7 +28,7 @@ const ptBRMessages = {
     },
   },
   chatInput: {
-    placeholder: "Digite uma tarefa ou arraste / cole / anexe um arquivo…",
+    placeholder: "Mensagem para Claude…",
     send: "Enviar",
     attachFile: "Anexar arquivo",
     fileTooLarge: "Arquivo muito grande ({sizeMB} MB). O limite é 30 MB.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -33,7 +33,7 @@ const zhMessages = {
     },
   },
   chatInput: {
-    placeholder: "输入任务,或拖放 / 粘贴 / 附加文件…",
+    placeholder: "向 Claude 发送消息…",
     send: "发送",
     attachFile: "附加文件",
     fileTooLarge: "文件过大（{sizeMB} MB）。上限为 30 MB。",


### PR DESCRIPTION
## Summary

- Replace the generic "Start a conversation" empty state in the canvas panel with the active role's **icon + name** on top and **clickable query bubbles** below — clicking a bubble sends it as a message via the existing `sendMessage(query)` path. Falls back to the old string when the role has no `queries`.
- Shorten the chat input placeholder from `"Type a task, or drop / paste / attach a file…"` to `"Message Claude…"` across all 8 locales. The file-drop affordance is already covered by the existing `dropHint` overlay (visible during drag) and the attach button.

All data (`sessionRoleIcon`, `sessionRoleName`, `sessionRoleQueries`, `sendMessage`) was already in scope at the touched call site in `App.vue`; the `queries` arrays already exist per-role in `src/config/roles.ts` and are i18n-aware via `useTranslatedQueries`.

## Test plan

- [ ] Open `/chat`, pick a fresh session — canvas shows the role icon, role name, and clickable query bubbles
- [ ] Click a bubble → message is sent and a result appears (replacing the empty state)
- [ ] Switch to a custom role with no `queries` defined → falls back to the existing "Start a conversation" string
- [ ] Confirm the new placeholder reads "Message Claude…" in each locale (en, ja, zh, ko, es, pt-BR, fr, de)
- [ ] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat empty state: shows the active session role's icon and name plus suggested starter queries to guide new conversations.

* **Style**
  * Updated chat input placeholder text across supported languages (EN, DE, ES, FR, JA, KO, PT‑BR, ZH) to reference Claude.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1379)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->