### PR TITLE
docs(make-e2e-live): add Step 0 for testid identification

### DIFF
--- a/.claude/skills/make-e2e-live/SKILL.md
+++ b/.claude/skills/make-e2e-live/SKILL.md
@@ -124,7 +124,7 @@ git checkout -b feat/e2e-live-<topic>
 
 **先に読むべき docs**:
 - [`docs/ui-cheatsheet.md`](../../../docs/ui-cheatsheet.md) — 既存 testid の ASCII リファレンス。 触る surface が既にカバーされているか先に確認
-- [`docs/e2e-live-testing.md`](../../../docs/e2e-live-testing.md) §2 — testid 命名規約（「Functional names, not positional / text-content」）
+- [`docs/e2e-live-testing.md`](../../../docs/e2e-live-testing.md#writing-a-new-e2e-live-spec) — 「Writing a new e2e-live spec」 §2 が testid 命名規約（「Functional names, not positional / text-content」）
 
 手順:
 

--- a/.claude/skills/make-e2e-live/SKILL.md
+++ b/.claude/skills/make-e2e-live/SKILL.md
@@ -118,6 +118,30 @@ git checkout -b feat/e2e-live-<topic>
 
 既存パターンを踏襲する。 `plans/feat-e2e-live.md` の 「実装の詳細」 セクションが詳細仕様。
 
+### Step 0: testid 洗い出し（spec を書き始める前に必ず）
+
+このステップを後回しにすると、 spec 内に `getByText('日本語ラベル')` / `locator('.tw-xxxx')` のような i18n / class 依存 selector が残り、 翻訳変更や Tailwind class rename で壊れる。 **最初の `page.locator(...)` / `page.click(...)` を書く前に** 必ず通る関門として扱う。
+
+**先に読むべき docs**:
+- [`docs/ui-cheatsheet.md`](../../../docs/ui-cheatsheet.md) — 既存 testid の ASCII リファレンス。 触る surface が既にカバーされているか先に確認
+- [`docs/e2e-live-testing.md`](../../../docs/e2e-live-testing.md) §2 — testid 命名規約（「Functional names, not positional / text-content」）
+
+手順:
+
+1. spec で触る予定の UI 要素を箇条書きで洗い出す（input / button / iframe / preview / thumbnail / 等）
+2. それぞれが既に `data-testid` を持っているかを確認（ui-cheatsheet → grep の順）:
+   ```bash
+   grep -rn "data-testid" src/ | grep -i "<keyword>"
+   ```
+3. 不足分は **spec を書き始める前に** 同 PR 内で先に追加:
+   - source に `data-testid="<plugin>-<role>"` を追加（kebab-case、 例: `audio-play-button` / `image-thumbnail`）
+   - **機能名**で付ける — 位置（`top-right-button`）、 文言（`save-button` の "Save" ラベル直訳）、 構造（`first-row-cell`）は NG
+   - `docs/ui-cheatsheet.md` の該当 ASCII ブロックを更新（CLAUDE.md ルール）
+   - 翻訳テキストや `iframe[sandbox]` 構造属性に依存しない（脆い）
+4. testid 追加は spec 実装と独立した commit に切る（review しやすくするため）
+
+「あとでまとめて付ける」 にしないこと — spec 実装中に「ここ testid 無いな」 と気づいた時点で **その場で Step 0 に戻る**。
+
 ### 共通ルール
 
 - helper の追加先:
@@ -132,10 +156,7 @@ git checkout -b feat/e2e-live-<topic>
   - **`frameLocator` API を使う** — `page.evaluate` + `iframe.contentDocument` は Vue の srcdoc 更新で古い document を返す罠
   - iframe `toBeVisible` だけでは早すぎる。 内側の特定要素を `frameLocator(...).locator(...)` で待つ
 - assertion 達成後に `waitForAssistantResponseComplete(page)` を呼ぶ — 呼ばないと trace / video が応答途中で切れる
-- testid 新設時:
-  - 命名: `data-testid="<plugin>-<role>"` の kebab-case
-  - **同 PR で `docs/ui-cheatsheet.md` の該当 ASCII ブロックを更新**（CLAUDE.md ルール）
-  - 翻訳テキストや `iframe[sandbox]` 構造属性に依存しない（脆い）
+- testid 新設時: **Step 0 を参照**（命名規約 / `docs/ui-cheatsheet.md` 更新 / 脆い selector 回避）
 - 新規テスト追加時は `docs/e2e-live-testing.md` の skip 規約に従う — Claude 必須テストには per-test で `test.skip(process.env.E2E_LIVE_NO_LLM === "1", ...)` を付ける
 - 新規 spec ファイル追加時は `.github/workflows/e2e_live_no_llm.yaml` の `matrix.spec:` への登録も併せて確認する（1 本でも fake-friendly なテストがあれば追加）
 


### PR DESCRIPTION
## Summary

`make-e2e-live` skill の Phase 4 冒頭に「Step 0: testid 洗い出し」 を新規セクションとして追加。 これまで `共通ルール` の bullet 1 行に埋もれていた testid 付与ルールを、 spec を書き始める前に必ず通る独立ステップへ昇格させて、 testid 付与忘れを防ぐ。

## Items to Confirm / Review

- 「最初の `page.locator(...)` / `page.click(...)` を書く前に必ず通る関門」 という強い表現が、 既存 Phase 4 の他セクションと矛盾していないか
- 「先に読むべき docs」 のリンク先（`docs/ui-cheatsheet.md`、 `docs/e2e-live-testing.md#writing-a-new-e2e-live-spec`）が意図したコンテンツを指しているか
- NG 例として挙げた testid 命名（`top-right-button` / `save-button` ラベル直訳 / `first-row-cell`）の選定が repo の慣習と齟齬がないか
- `共通ルール` 内の旧 「testid 新設時:」 3 項目を Step 0 への 1 行参照に圧縮した点（情報集約のための意図的変更）

## User Prompt

- `.claude/skills/make-e2e-live/SKILL.md` の改善をしたい。 testid 付与を実行しない時があるので、 step に明示的に testid を付与する旨を追加できないか
- testid に関する docs がどこかにあったはずなので、 そこも踏まえてほしい

## 変更内容

### Phase 4 冒頭に新規セクション「Step 0: testid 洗い出し」 を追加

- 「最初の `page.locator(...)` / `page.click(...)` を書く前に必ず通る関門」 と明示
- 4 ステップ手順化: 要素洗い出し → grep で既存確認 → 不足分を spec 前に追加 → 独立 commit
- 「先に読むべき docs」 として `docs/ui-cheatsheet.md`（testid の ASCII リファレンス）と `docs/e2e-live-testing.md` の 「Writing a new e2e-live spec」 §2（命名規約）を参照
- 「機能名で付ける」 ルールを明文化し、 NG 例（位置 / 文言 / 構造）を 3 つ列挙
- 「あとでまとめて付ける」 を禁じ、 spec 実装中に気付いたらその場で Step 0 へ戻る、 という戻り条件も追加

### 共通ルール内の重複を整理

旧 「testid 新設時:」 の 3 bullet を Step 0 への参照 1 行に圧縮し、 ルールの二重メンテを防止。

## クロスレビュー

`/codex-cross-review` skill で Codex と Claude の 2-reviewer ループを実施。 2 イテレーションで収束（Codex 最終判定: LGTM）。

- イテレーション 1: Codex が `docs/e2e-live-testing.md §2` の指し先が曖昧（文字通りの 2 番目セクションは "Two backends behind the agent" で、 testid 命名規約のセクションとは別）と must-fix を指摘。 アンカー付きリンク (`#writing-a-new-e2e-live-spec`) とセクション名併記で解消（commit `3cf00694`）。
- イテレーション 2: 追加指摘なし、 LGTM。