### PR TITLE
refactor(e2e): testid sweep + helper extraction for MulmoScript spec

### DIFF
--- a/e2e/fixtures/present-mulmo-script.ts
+++ b/e2e/fixtures/present-mulmo-script.ts
@@ -1,0 +1,110 @@
+// Spec-local Playwright helpers for the presentMulmoScript plugin.
+//
+// The plugin's e2e suite (e2e/tests/present-mulmo-script.spec.ts) drives the
+// same boot → ready → sidebar-select → assert-canvas sequence over and over.
+// Centralizing those steps here keeps each test under the 20-line cognitive
+// budget and pins the testid contract in one place — when the plugin's DOM
+// shape changes, the helpers move, not every test.
+
+import { expect, type Locator, type Page } from "@playwright/test";
+
+import { ONE_SECOND_MS } from "../../server/utils/time.ts";
+
+const RENDER_BEAT_PATH = "/api/mulmoScript/render-beat";
+const GENERATE_MOVIE_PATH = "/api/mulmoScript/generate-movie";
+const IMAGE_RENDER_TIMEOUT_MS = 5 * ONE_SECOND_MS;
+// Generic "MovieGen failed" headline rendered by the chip regardless of locale
+// is set in en.ts; tests pass the locale-agnostic English copy.
+export const MOVIE_ERROR_HEADLINE = "Movie generation failed";
+
+/**
+ * Navigate to a session URL, wait for the app shell to be ready, and click
+ * the sidebar Preview entry for the given script title.
+ *
+ * The "ready" check pins on the app-title testid in SidebarHeader so it
+ * survives copy / locale tweaks. The Preview click goes through the
+ * preview-title testid so a stray match elsewhere in the DOM (e.g. the
+ * canvas heading rendering the same title) can't satisfy it.
+ */
+export async function openMulmoSessionAndSelectScript(page: Page, sessionPath: string): Promise<void> {
+  await page.goto(sessionPath);
+  await expect(page.getByTestId("app-title")).toBeVisible();
+  await page.getByTestId("mulmo-script-preview-title").first().click();
+}
+
+/** Assert the canvas View has mounted by checking its script-title heading. */
+export async function assertScriptHeader(page: Page, scriptTitle: string): Promise<void> {
+  const heading = page.getByTestId("mulmo-script-title");
+  await expect(heading).toBeVisible();
+  await expect(heading).toHaveText(scriptTitle);
+}
+
+/**
+ * Assert the inline movie-generation error chip is visible and contains the
+ * given detail message. Returns the chip locator so the caller can scope
+ * further interactions (e.g. clicking the retry button).
+ */
+export async function assertMovieErrorChip(page: Page, detail: string): Promise<Locator> {
+  const chip = page.getByTestId("mulmo-script-movie-error-chip");
+  await expect(chip).toBeVisible();
+  await expect(chip.getByText(MOVIE_ERROR_HEADLINE)).toBeVisible();
+  await expect(chip.getByText(detail)).toBeVisible();
+  return chip;
+}
+
+/**
+ * Mock /api/mulmoScript/render-beat with a 200 { image } payload. Returns a
+ * snapshot accessor over the post bodies the SPA actually sent — tests can
+ * assert against shape/count.
+ */
+export async function mockRenderBeatSuccess(page: Page, image: string): Promise<() => unknown[]> {
+  const calls: unknown[] = [];
+  await page.route(
+    (url) => url.pathname === RENDER_BEAT_PATH,
+    async (route) => {
+      calls.push(route.request().postDataJSON());
+      return route.fulfill({ json: { image } });
+    },
+  );
+  return () => calls;
+}
+
+/** Mock /api/mulmoScript/render-beat with a 500 { error } payload. */
+export async function mockRenderBeatError(page: Page, error: string): Promise<void> {
+  await page.route(
+    (url) => url.pathname === RENDER_BEAT_PATH,
+    (route) => route.fulfill({ status: 500, json: { error } }),
+  );
+}
+
+/**
+ * Wait until at least one <img> in the DOM has a data-URI src matching the
+ * given prefix. Used to confirm the mocked render-beat payload flowed
+ * through to the View's <img>.
+ */
+export async function waitForRenderedBeatImage(page: Page, dataUriPrefix: string): Promise<void> {
+  await page.waitForFunction((prefix) => Array.from(document.querySelectorAll("img")).some((img) => img.src.startsWith(prefix)), dataUriPrefix, {
+    timeout: IMAGE_RENDER_TIMEOUT_MS,
+  });
+}
+
+/**
+ * Mock /api/mulmoScript/generate-movie to return an SSE stream that
+ * immediately emits a single `error` event. Returns a counter accessor so
+ * tests can assert how many times the route was hit (e.g. initial + retry).
+ */
+export async function mockGenerateMovieSseError(page: Page, message: string): Promise<() => number> {
+  let calls = 0;
+  await page.route(
+    (url) => url.pathname === GENERATE_MOVIE_PATH,
+    (route) => {
+      calls++;
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+        body: `data: {"type":"error","message":"${message}"}\n\n`,
+      });
+    },
+  );
+  return () => calls;
+}

--- a/e2e/tests/present-mulmo-script.spec.ts
+++ b/e2e/tests/present-mulmo-script.spec.ts
@@ -1,10 +1,25 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
+import {
+  assertMovieErrorChip,
+  assertScriptHeader,
+  mockGenerateMovieSseError,
+  mockRenderBeatError,
+  mockRenderBeatSuccess,
+  openMulmoSessionAndSelectScript,
+  waitForRenderedBeatImage,
+} from "../fixtures/present-mulmo-script";
 
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
 
 const SCRIPT_TITLE = "Test Mulmo Script";
 const SCRIPT_DESCRIPTION = "A short test script used by the smoke test.";
+const SESSION_PATH = "/chat/mulmo-session";
+
+// 1×1 transparent PNG. Used by the render-beat success mock.
+const PNG_1X1 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=";
+// Prefix the View's <img src> ends up with after the success mock fires.
+const PNG_DATA_URI_PREFIX = "data:image/png;base64,iVBOR";
 
 const SAMPLE_SCRIPT = {
   $mulmocast: { version: "1.1" },
@@ -82,30 +97,51 @@ async function setupScriptSession(page: Page) {
   );
 }
 
+/**
+ * Override the session-list endpoint so mulmo-session reports
+ * isRunning=true. setupScriptSession (in beforeEach) already mocks
+ * everything else; calling mockAllApis again would clobber the script
+ * transcript route. Playwright routes are LIFO, so this added handler
+ * takes precedence.
+ */
+async function stubRunningSession(page: Page) {
+  await page.route(
+    (url) => url.pathname === "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: {
+          sessions: [
+            {
+              id: "mulmo-session",
+              title: "Mulmo Session",
+              roleId: "general",
+              startedAt: "2026-04-12T10:00:00Z",
+              updatedAt: "2026-04-12T10:05:00Z",
+              isRunning: true,
+            },
+          ],
+          cursor: "v1:0",
+          deletedIds: [],
+        },
+      }),
+  );
+}
+
 test.describe("presentMulmoScript plugin", () => {
   test.beforeEach(async ({ page }) => {
     await setupScriptSession(page);
   });
 
   test("Preview shows the script title in the sidebar", async ({ page }) => {
-    await page.goto("/chat/mulmo-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
-    // The Preview component in the sidebar renders the script title.
-    await expect(page.getByText(SCRIPT_TITLE).first()).toBeVisible();
+    await page.goto(SESSION_PATH);
+    await expect(page.getByTestId("app-title")).toBeVisible();
+    await expect(page.getByTestId("mulmo-script-preview-title").first()).toHaveText(SCRIPT_TITLE);
   });
 
   test("View renders script title, description and beat count when selected", async ({ page }) => {
-    await page.goto("/chat/mulmo-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
-
-    // Click the sidebar preview to select the tool result → View
-    // mounts in the canvas (single view mode is the default).
-    await page.getByText(SCRIPT_TITLE).first().click();
-
-    // View header: title, description (as a <p>, not the sidebar's
-    // <div>), and "N beats" live text.
-    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
-    await expect(page.getByRole("paragraph").filter({ hasText: SCRIPT_DESCRIPTION })).toBeVisible();
+    await openMulmoSessionAndSelectScript(page, SESSION_PATH);
+    await assertScriptHeader(page, SCRIPT_TITLE);
+    await expect(page.getByTestId("mulmo-script-description")).toHaveText(SCRIPT_DESCRIPTION);
     await expect(page.getByText("2 beats")).toBeVisible();
   });
 
@@ -113,14 +149,10 @@ test.describe("presentMulmoScript plugin", () => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto("/chat/mulmo-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await page.getByText(SCRIPT_TITLE).first().click();
-
+    await openMulmoSessionAndSelectScript(page, SESSION_PATH);
     // Give the View a beat to mount and kick off its fetches.
     await page.waitForTimeout(ONE_SECOND_MS / 2);
-    // Title should be rendered; no uncaught exceptions should fire.
-    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
+    await assertScriptHeader(page, SCRIPT_TITLE);
     expect(errors).toEqual([]);
   });
 
@@ -130,58 +162,30 @@ test.describe("presentMulmoScript plugin", () => {
   // wiring is the regression net for the refactor.
 
   test("render-beat success: mocked image surfaces in the View", async ({ page }) => {
-    // 1×1 transparent PNG.
-    const PNG_1X1 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=";
-
-    const renderBeatCalls: unknown[] = [];
-    await page.route(
-      (url) => url.pathname === "/api/mulmoScript/render-beat",
-      async (route) => {
-        renderBeatCalls.push(route.request().postDataJSON());
-        return route.fulfill({ json: { image: PNG_1X1 } });
-      },
-    );
-
-    await page.goto("/chat/mulmo-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await page.getByText(SCRIPT_TITLE).first().click();
-    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
-
     // Beat 0 is a textSlide → auto-rendered on mount via renderBeat,
-    // which hits /api/mulmoScript/render-beat. Wait for the mocked
-    // image to surface in the DOM — proves the server→frontend
-    // contract (`{ image: <data-uri> }` on 200) still holds through
-    // the withStoryContext refactor.
-    await page.waitForFunction(() => Array.from(document.querySelectorAll("img")).some((img) => img.src.startsWith("data:image/png;base64,iVBOR")), undefined, {
-      timeout: 5 * ONE_SECOND_MS,
-    });
+    // which hits /api/mulmoScript/render-beat. Waiting for the mocked
+    // image to surface proves the server→frontend contract
+    // (`{ image: <data-uri> }` on 200) still holds through the
+    // withStoryContext refactor.
+    const getRenderBeatCalls = await mockRenderBeatSuccess(page, PNG_1X1);
+    await openMulmoSessionAndSelectScript(page, SESSION_PATH);
+    await assertScriptHeader(page, SCRIPT_TITLE);
+    await waitForRenderedBeatImage(page, PNG_DATA_URI_PREFIX);
 
-    expect(renderBeatCalls.length).toBeGreaterThan(0);
-    for (const call of renderBeatCalls) {
-      expect(call).toMatchObject({
-        filePath: expect.any(String),
-        beatIndex: expect.any(Number),
-      });
+    const calls = getRenderBeatCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call).toMatchObject({ filePath: expect.any(String), beatIndex: expect.any(Number) });
     }
   });
 
   test("render-beat error: mocked { error } surfaces to the UI", async ({ page }) => {
-    await page.route(
-      (url) => url.pathname === "/api/mulmoScript/render-beat",
-      (route) =>
-        route.fulfill({
-          status: 500,
-          json: { error: "Image was not generated" },
-        }),
-    );
-
-    await page.goto("/chat/mulmo-session");
-    await page.getByText(SCRIPT_TITLE).first().click();
-    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
-
     // Auto-render on mount hits render-beat for textSlide beats,
     // which now returns 500 { error }. The View renders the error
     // string in the placeholder slot.
+    await mockRenderBeatError(page, "Image was not generated");
+    await openMulmoSessionAndSelectScript(page, SESSION_PATH);
+    await assertScriptHeader(page, SCRIPT_TITLE);
     await expect(page.getByText("Image was not generated")).toBeVisible();
   });
 
@@ -199,46 +203,23 @@ test.describe("presentMulmoScript plugin", () => {
   // the retry round-trip.
   test("generateMovie error: SSE error event surfaces inline chip + retry button re-fires the request", async ({ page }) => {
     const SSE_ERROR_MESSAGE = "Page.captureScreenshot timed out.";
-    let generateMovieCalls = 0;
-    await page.route(
-      (url) => url.pathname === "/api/mulmoScript/generate-movie",
-      (route) => {
-        generateMovieCalls++;
-        return route.fulfill({
-          status: 200,
-          headers: { "Content-Type": "text/event-stream" },
-          body: `data: {"type":"error","message":"${SSE_ERROR_MESSAGE}"}\n\n`,
-        });
-      },
-    );
+    const getGenerateMovieCalls = await mockGenerateMovieSseError(page, SSE_ERROR_MESSAGE);
 
-    await page.goto("/chat/mulmo-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await page.getByText(SCRIPT_TITLE).first().click();
-    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
+    await openMulmoSessionAndSelectScript(page, SESSION_PATH);
+    await assertScriptHeader(page, SCRIPT_TITLE);
 
     // First attempt: chip should appear with the SSE-supplied message.
-    // All chip-internal assertions scope through the chip's testid so
-    // they survive copy / locale tweaks and aren't satisfied by a
-    // stray "Movie generation failed" string rendered anywhere else.
+    // expect.poll instead of plain equality tolerates the microtask
+    // gap between the route handler firing and the SPA's catch arm
+    // landing.
     await page.getByTestId("mulmo-script-generate-movie-button").click();
-    const errorChip = page.getByTestId("mulmo-script-movie-error-chip");
-    const retryButton = errorChip.getByTestId("mulmo-script-movie-retry-button");
-    await expect(errorChip).toBeVisible();
-    await expect(errorChip.getByText("Movie generation failed")).toBeVisible();
-    await expect(errorChip.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
-    // expect.poll instead of a plain toBe so the assertion tolerates
-    // the microtask gap between the route handler firing and the SPA's
-    // catch arm landing. Chip visibility above already implies the
-    // handler ran, but the poll keeps this future-proof against any
-    // scheduling tweak in Playwright or Vue.
-    await expect.poll(() => generateMovieCalls).toBe(1);
+    const errorChip = await assertMovieErrorChip(page, SSE_ERROR_MESSAGE);
+    await expect.poll(getGenerateMovieCalls).toBe(1);
 
     // Retry: same endpoint is hit again, chip stays (same error replays).
-    await retryButton.click();
-    await expect(errorChip).toBeVisible();
-    await expect(errorChip.getByText(SSE_ERROR_MESSAGE)).toBeVisible();
-    await expect.poll(() => generateMovieCalls).toBe(2);
+    await errorChip.getByTestId("mulmo-script-movie-retry-button").click();
+    await assertMovieErrorChip(page, SSE_ERROR_MESSAGE);
+    await expect.poll(getGenerateMovieCalls).toBe(2);
   });
 
   // Regression for #839 + the in-PR follow-up. The slide view must
@@ -246,46 +227,17 @@ test.describe("presentMulmoScript plugin", () => {
   // has a chat turn in flight — same signal the chat sidebar uses,
   // not just the slide-local generation flags.
   test("ThinkingIndicator lights up when the active session is running", async ({ page }) => {
-    // Override only the session-list endpoint so mulmo-session
-    // reports isRunning=true. setupScriptSession (in beforeEach)
-    // already mocks everything else; calling mockAllApis again
-    // would clobber the script transcript route. Playwright routes
-    // are LIFO, so this added handler takes precedence.
-    await page.route(
-      (url) => url.pathname === "/api/sessions",
-      (route) =>
-        route.fulfill({
-          json: {
-            sessions: [
-              {
-                id: "mulmo-session",
-                title: "Mulmo Session",
-                roleId: "general",
-                startedAt: "2026-04-12T10:00:00Z",
-                updatedAt: "2026-04-12T10:05:00Z",
-                isRunning: true,
-              },
-            ],
-            cursor: "v1:0",
-            deletedIds: [],
-          },
-        }),
-    );
+    await stubRunningSession(page);
+    await openMulmoSessionAndSelectScript(page, SESSION_PATH);
+    await assertScriptHeader(page, SCRIPT_TITLE);
 
-    await page.goto("/chat/mulmo-session");
-    await page.getByText(SCRIPT_TITLE).first().click();
-    await expect(page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })).toBeVisible();
-
-    // The indicator lives in the chat sidebar (above ChatInput),
-    // not inside the slide view itself — App.vue is now the
-    // canonical mount slot.
-    //
-    // Two complementary assertions:
+    // The indicator lives in the chat sidebar (above ChatInput), not
+    // inside the slide view itself — App.vue is now the canonical
+    // mount slot. Two complementary assertions:
     //   1. Page-wide count == 1 catches duplicate role=status
-    //      regions reappearing anywhere in the DOM (Codex iter-1).
-    //   2. The sidebar-scoped lookup pins the canonical mount slot
-    //      so a stray copy outside the sidebar would still fail
-    //      the count check above (Codex iter-2/3).
+    //      regions reappearing anywhere in the DOM.
+    //   2. The sidebar-scoped lookup pins the canonical mount slot so
+    //      a stray copy outside the sidebar would still fail count.
     await expect(page.getByTestId("thinking-indicator")).toHaveCount(1);
     const sidebarIndicator = page.getByTestId("chat-sidebar").getByTestId("thinking-indicator");
     await expect(sidebarIndicator).toBeVisible();

--- a/src/plugins/presentMulmoScript/Preview.vue
+++ b/src/plugins/presentMulmoScript/Preview.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="p-2 text-sm">
-    <div class="font-medium text-gray-700 truncate mb-1">
+  <div class="p-2 text-sm" data-testid="mulmo-script-preview">
+    <div class="font-medium text-gray-700 truncate mb-1" data-testid="mulmo-script-preview-title">
       {{ title }}
     </div>
-    <div v-if="description" class="text-xs text-gray-500 leading-relaxed">
+    <div v-if="description" class="text-xs text-gray-500 leading-relaxed" data-testid="mulmo-script-preview-description">
       {{ description }}
     </div>
   </div>

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -3,10 +3,10 @@
     <!-- Header -->
     <div class="flex items-start justify-between px-6 py-4 border-b border-gray-100 shrink-0">
       <div class="min-w-0 flex-1">
-        <h2 class="text-lg font-semibold text-gray-800 truncate">
+        <h2 class="text-lg font-semibold text-gray-800 truncate" data-testid="mulmo-script-title">
           {{ script.title || "Untitled Script" }}
         </h2>
-        <p v-if="script.description" class="text-sm text-gray-500 mt-0.5 truncate">
+        <p v-if="script.description" class="text-sm text-gray-500 mt-0.5 truncate" data-testid="mulmo-script-description">
           {{ script.description }}
         </p>
         <div class="flex items-center gap-3 mt-1 text-xs text-gray-400">


### PR DESCRIPTION
## Summary

- `e2e/tests/present-mulmo-script.spec.ts` の text/role ベース selector を testid に置換
- 共通の "boot → ready → sidebar-select → assert-canvas" フローを `e2e/fixtures/present-mulmo-script.ts` に抽出し、各テスト本体を 20 行未満に
- `Preview.vue` / `View.vue` に対応する `data-testid` を追加

## Items to Confirm / Review

- testid 命名は既存の `mulmo-script-<role>` kebab-case パターンに揃えました (`mulmo-script-preview` / `mulmo-script-preview-title` / `mulmo-script-preview-description` / `mulmo-script-title` / `mulmo-script-description`)。違和感あれば指摘ください
- helper の置き場は新規ファイル `e2e/fixtures/present-mulmo-script.ts` にしました。`chat.ts` への append (issue 案 a) は chat 全般用途のため避け、plugin 専用 helper (案 b) を採用
- Codex (codex-cross-review) で nit 2 件 (helper 内の `document.querySelectorAll("img")` 広域マッチ / `"Movie generation failed"` 英語ハードコード) が出ましたが、いずれも本 PR で導入した回帰ではなく既存挙動なので defer 判断

## User Prompt

> #1380 の対応をお願い。作業は worktree で。実施後は commit して、/codex-cross-review まで完了したら教えて。

## 背景

#1377 の CodeRabbit nit から派生したフォローアップ (#1380)。CLAUDE.md L235 (`Use data-testid for element selection`) と「テスト関数 20 行未満」ルールに揃えるための差分。

## 変更内容

### testid 追加

- `src/plugins/presentMulmoScript/Preview.vue`
  - ルート `<div>` に `mulmo-script-preview`
  - title `<div>` に `mulmo-script-preview-title`
  - description `<div>` に `mulmo-script-preview-description`
- `src/plugins/presentMulmoScript/View.vue`
  - `<h2>` (script title) に `mulmo-script-title`
  - `<p>` (description) に `mulmo-script-description`

### helper 抽出 (`e2e/fixtures/present-mulmo-script.ts` 新設)

- `openMulmoSessionAndSelectScript(page, sessionPath)` — `/chat/<id>` へ goto → app-title testid で ready 確認 → sidebar preview click
- `assertScriptHeader(page, scriptTitle)` — canvas heading 表示確認
- `assertMovieErrorChip(page, detail)` — error chip + headline + detail 確認
- `mockRenderBeatSuccess(page, image)` / `mockRenderBeatError(page, error)`
- `mockGenerateMovieSseError(page, message)`
- `waitForRenderedBeatImage(page, dataUriPrefix)`

### spec 書き換え

`e2e/tests/present-mulmo-script.spec.ts` の全 7 テストを上記 helper + testid で書き換え。以下の selector はゼロに:

- `page.getByText("MulmoClaude")` → `page.getByTestId("app-title")`
- `page.getByText(SCRIPT_TITLE).first().click()` → helper 内 `page.getByTestId("mulmo-script-preview-title").first().click()`
- `page.getByRole("heading", { name: SCRIPT_TITLE, level: 2 })` → `page.getByTestId("mulmo-script-title")`

## 受け入れ基準

- [x] `yarn test:e2e e2e/tests/present-mulmo-script.spec.ts` 全 7 テスト pass (8.4s)
- [x] 各 test 関数本体が 20 行未満
- [x] spec 内に banned selector の残存無し (grep で 0 件確認)
- [x] testid 命名は既存の `mulmo-script-<role>` kebab-case に準拠
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` すべて pass

## レビュー状況

Codex (codex-cross-review pre-PR mode) で 1 イテレーション LGTM。nit 2 件は本 PR の回帰ではないため defer。

## 関連

- Closes #1380
- #1377 (回帰網 PR、本 PR の派生元)