### PR TITLE
test(agent): fake-echo failure-shaped scenario coverage

### DIFF
--- a/.github/workflows/e2e_live_no_llm.yaml
+++ b/.github/workflows/e2e_live_no_llm.yaml
@@ -53,6 +53,7 @@ jobs:
           - skills                   # L-21 (presentChart) / L-22 (slash-command)
           - mulmo-script-edit        # L-EDIT via plugin-dispatch
           - media                    # L-01 only (L-02..L-05 need real LLM / external tools)
+          - error-banner             # L-ERR: forced error event → [Error] card
 
     steps:
       - uses: actions/checkout@v6

--- a/e2e-live/tests/error-banner.spec.ts
+++ b/e2e-live/tests/error-banner.spec.ts
@@ -34,9 +34,15 @@ test.describe("agent error banner (fake-echo forced error)", () => {
       await expect(assistantBody, "the forced backend error must render as an assistant [Error] card").toContainText("[Error]", {
         timeout: ONE_MINUTE_MS,
       });
-      await expect(assistantBody, "the error card must carry the fake-echo error message").toContainText("__FAKE_ERROR__ marker", {
-        timeout: ONE_MINUTE_MS,
-      });
+      // Assert on a markdown-safe substring of fake-echo's error
+      // string (the `__FAKE_ERROR__` trigger itself would be eaten
+      // by marked() as bold emphasis, so don't assert on it).
+      await expect(assistantBody, "the error card must carry the fake-echo error message").toContainText(
+        "fake-echo forced error for the e2e-live error-banner canary",
+        {
+          timeout: ONE_MINUTE_MS,
+        },
+      );
 
       // The turn must still complete — endRun fires in the
       // consumer's finally even on the error path, so the thinking

--- a/e2e-live/tests/error-banner.spec.ts
+++ b/e2e-live/tests/error-banner.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+import { ONE_MINUTE_MS } from "../../server/utils/time.ts";
+import { deleteSession, getCurrentSessionId, sendChatMessage, startNewSession, waitForAssistantResponseComplete } from "../fixtures/live-chat.ts";
+
+const L_ERR_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
+
+// Batch 3: the agent-error → chat-banner UI path. When the backend
+// yields an `error` AgentEvent, the SSE consumer maps it through
+// `pushErrorMessage` (src/utils/agent/eventDispatch.ts → session
+// helpers) into a `text-response` card prefixed with `[Error] `.
+// Before the fake-echo seam this needed a crashed Claude
+// subprocess to reproduce; now the spec opts in with the
+// `__FAKE_ERROR__` marker, which fake-echo's defaultResponse turns
+// into a forced error event (prod never reaches fake-echo).
+test.describe("agent error banner (fake-echo forced error)", () => {
+  test("L-ERR: backend error event renders as an [Error] text card and the turn ends", async ({ page }) => {
+    test.setTimeout(L_ERR_TIMEOUT_MS);
+    let sessionIdForCleanup: string | null = null;
+    try {
+      await startNewSession(page);
+      await page.waitForURL(/\/chat\/[0-9a-f-]+/);
+      sessionIdForCleanup = getCurrentSessionId(page);
+
+      // The marker drives fake-echo's forced-error branch. We embed
+      // it in an otherwise normal sentence so the detector's
+      // substring check (not a strict-equality match) is exercised.
+      await sendChatMessage(page, "please trigger __FAKE_ERROR__ now");
+
+      // pushErrorMessage builds a `text-response` ToolResult with
+      // title "Error" and body `[Error] <message>`, and selects it,
+      // so the assistant body surface must show the prefix.
+      const assistantBody = page.getByTestId("text-response-assistant-body").last();
+      await expect(assistantBody, "the forced backend error must render as an assistant [Error] card").toContainText("[Error]", {
+        timeout: ONE_MINUTE_MS,
+      });
+      await expect(assistantBody, "the error card must carry the fake-echo error message").toContainText("__FAKE_ERROR__ marker", {
+        timeout: ONE_MINUTE_MS,
+      });
+
+      // The turn must still complete — endRun fires in the
+      // consumer's finally even on the error path, so the thinking
+      // indicator clears (no perpetual spinner).
+      await waitForAssistantResponseComplete(page, L_ERR_TIMEOUT_MS);
+    } finally {
+      if (sessionIdForCleanup !== null) await deleteSession(page, sessionIdForCleanup);
+    }
+  });
+});

--- a/server/agent/backend/fake-echo.ts
+++ b/server/agent/backend/fake-echo.ts
@@ -55,6 +55,15 @@ export interface FakeResponse {
   toolCalls?: readonly FakeToolCall[];
   /** Assistant text. Omit to skip the text event entirely. */
   text?: string;
+  /** When set, emit a single `error` AgentEvent with this message
+   *  and stop — mirrors what the claude-code backend does when the
+   *  CLI exits non-zero (`readAgentEvents`). Tool calls / text that
+   *  would otherwise follow are suppressed. */
+  error?: string;
+  /** Emit the `tool_call` for each `toolCalls` entry but NOT the
+   *  paired `tool_call_result` — simulates a truncated / partial
+   *  stream where the model died mid tool round-trip. */
+  omitToolResult?: boolean;
 }
 
 export type FakeResponseFn = (input: AgentInput) => FakeResponse | Promise<FakeResponse>;
@@ -287,12 +296,29 @@ export function resetFakeResponse(): void {
   sessionTurns.clear();
 }
 
+// Abort is checked between every yield. Real claude-code kills the
+// subprocess on abort; the echo stub has no subprocess, so the
+// faithful equivalent is "stop emitting immediately".
+function aborted(input: AgentInput): boolean {
+  return input.abortSignal?.aborted === true;
+}
+
 async function* runFakeEchoAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
+  if (aborted(input)) return;
   yield { type: EVENT_TYPES.claudeSessionId, id: randomUUID() };
 
   const response = await responseFn(input);
 
+  // Error short-circuit: surface the error and stop, exactly like
+  // the claude-code backend on a non-zero CLI exit.
+  if (response.error !== undefined) {
+    if (aborted(input)) return;
+    yield { type: EVENT_TYPES.error, message: response.error };
+    return;
+  }
+
   for (const call of response.toolCalls ?? []) {
+    if (aborted(input)) return;
     const toolUseId = `fake-${randomUUID()}`;
     yield {
       type: EVENT_TYPES.toolCall,
@@ -300,10 +326,13 @@ async function* runFakeEchoAgent(input: AgentInput): AsyncGenerator<AgentEvent> 
       toolName: call.toolName,
       args: call.args,
     };
+    // Partial-stream simulation: skip the result half.
+    if (response.omitToolResult) continue;
     // Run the actual plugin handler AND push the envelope to
     // /api/internal/tool-result so the canvas mounts the View — same
     // two-step the MCP bridge does for real Claude.
     const content = await dispatchToPlugin(call, input.port, input.sessionId);
+    if (aborted(input)) return;
     yield {
       type: EVENT_TYPES.toolCallResult,
       toolUseId,
@@ -311,7 +340,7 @@ async function* runFakeEchoAgent(input: AgentInput): AsyncGenerator<AgentEvent> 
     };
   }
 
-  if (response.text !== undefined) {
+  if (response.text !== undefined && !aborted(input)) {
     yield { type: EVENT_TYPES.text, message: response.text };
   }
 }

--- a/server/agent/backend/fake-echo.ts
+++ b/server/agent/backend/fake-echo.ts
@@ -86,7 +86,11 @@ async function defaultResponse(input: AgentInput): Promise<FakeResponse> {
   // by sending a message containing this exact marker. Prod never
   // reaches fake-echo (real Claude backend) so this is inert there.
   if (input.message.includes("__FAKE_ERROR__")) {
-    return { error: "fake-echo forced error (__FAKE_ERROR__ marker)" };
+    // Message text is rendered through marked() in the chat card,
+    // so keep it free of markdown-significant characters (no `__`,
+    // `*`, backticks) — the e2e-live canary asserts on a literal
+    // substring of this string.
+    return { error: "fake-echo forced error for the e2e-live error-banner canary" };
   }
 
   const slashMatch = input.message.trim().match(/^\/([a-z0-9][a-z0-9-]*)$/i);

--- a/server/agent/backend/fake-echo.ts
+++ b/server/agent/backend/fake-echo.ts
@@ -80,6 +80,15 @@ async function defaultResponse(input: AgentInput): Promise<FakeResponse> {
   // short-circuit to read the seeded body and apply the
   // "respond with this exact line" heuristic the e2e-live canaries
   // rely on. Falls through to default echo on no match.
+  // Prompt-driven error trigger for e2e-live. The in-process
+  // `setFakeResponse()` knob is unreachable from a browser-driven
+  // spec (separate process), so the error-banner UI canary opts in
+  // by sending a message containing this exact marker. Prod never
+  // reaches fake-echo (real Claude backend) so this is inert there.
+  if (input.message.includes("__FAKE_ERROR__")) {
+    return { error: "fake-echo forced error (__FAKE_ERROR__ marker)" };
+  }
+
   const slashMatch = input.message.trim().match(/^\/([a-z0-9][a-z0-9-]*)$/i);
   if (slashMatch) {
     const skillReply = await replyFromSeededSkill(input.workspacePath, slashMatch[1]);

--- a/test/agent/test_agent_lifecycle_resilience.ts
+++ b/test/agent/test_agent_lifecycle_resilience.ts
@@ -1,0 +1,200 @@
+// Batch 2: drive the fake-echo backend through the SAME consumer
+// lifecycle that server/api/routes/agent.ts#runAgentInBackground
+// uses (beginRun → for-await(events) → handleEvent → finally
+// endRun) and assert the load-bearing invariant:
+//
+//   no matter how the turn fails, the session never gets stuck
+//   `isRunning` — `endRun` in the consumer's `finally` always runs.
+//
+// A stuck `isRunning` is a real, user-visible failure: the UI spins
+// forever and the 409 guard in `beginRun` rejects every subsequent
+// turn on that session. Before the fake-echo seam this path needed
+// a mocked Claude subprocess, so it had zero coverage.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import {
+  __resetForTests,
+  getSession,
+  getOrCreateSession,
+  beginRun,
+  endRun,
+  cancelRun,
+  initSessionStore,
+  pushSessionEvent,
+} from "../../server/events/session-store/index.ts";
+import { fakeEchoBackend, setFakeResponse, resetFakeResponse } from "../../server/agent/backend/fake-echo.ts";
+import type { AgentInput } from "../../server/agent/backend/types.ts";
+import { ROLES, type Role } from "../../src/config/roles.ts";
+import { EVENT_TYPES } from "../../src/types/events.ts";
+
+function requireRole(roleId: string): Role {
+  const role = ROLES.find((candidate) => candidate.id === roleId);
+  if (!role) throw new Error(`test setup: role '${roleId}' not found`);
+  return role;
+}
+const GENERAL_ROLE = requireRole("general");
+
+function stubPubSub() {
+  const published: { channel: string; data: Record<string, unknown> }[] = [];
+  return {
+    published,
+    publish(channel: string, data: Record<string, unknown>) {
+      published.push({ channel, data });
+    },
+    subscribe() {
+      return () => {};
+    },
+  };
+}
+
+let pubsub: ReturnType<typeof stubPubSub>;
+
+beforeEach(() => {
+  __resetForTests();
+  pubsub = stubPubSub();
+  // initSessionStore expects an IPubSub; the stub covers the
+  // publish/subscribe surface the store actually calls.
+  initSessionStore(pubsub as unknown as Parameters<typeof initSessionStore>[0]);
+});
+
+afterEach(() => {
+  resetFakeResponse();
+  __resetForTests();
+});
+
+function makeInput(sessionId: string, overrides: Partial<AgentInput> = {}): AgentInput {
+  return {
+    systemPrompt: "test",
+    message: "hello",
+    role: GENERAL_ROLE,
+    workspacePath: "/tmp/does-not-matter",
+    sessionId,
+    port: 0,
+    activePlugins: [],
+    extraAllowedTools: [],
+    useDocker: false,
+    ...overrides,
+  };
+}
+
+// Mirrors the runAgentInBackground consumer loop closely enough to
+// exercise the lifecycle invariant: beginRun, stream events into the
+// session, convert a thrown error into an error event, always
+// endRun in finally.
+async function consumeTurn(sessionId: string, input: AgentInput): Promise<void> {
+  try {
+    for await (const event of fakeEchoBackend.runAgent(input)) {
+      pushSessionEvent(sessionId, event as unknown as Record<string, unknown>);
+    }
+  } catch (err) {
+    pushSessionEvent(sessionId, { type: EVENT_TYPES.error, message: String(err) });
+  } finally {
+    endRun(sessionId);
+  }
+}
+
+function seedRunningSession(): string {
+  const sessionId = `lc-${randomUUID()}`;
+  getOrCreateSession(sessionId, {
+    roleId: "general",
+    resultsFilePath: "/tmp/fake.jsonl",
+    startedAt: "2026-05-15T00:00:00.000Z",
+    updatedAt: "2026-05-15T00:00:00.000Z",
+  });
+  const begun = beginRun(sessionId, () => {});
+  assert.equal(begun, true, "beginRun should succeed on a fresh session");
+  assert.equal(getSession(sessionId)?.isRunning, true);
+  return sessionId;
+}
+
+describe("agent lifecycle resilience (fake-echo driven)", () => {
+  it("error event: session ends not-running, error reached the channel", async () => {
+    setFakeResponse(() => ({ error: "claude exited with code 1" }));
+    const sessionId = seedRunningSession();
+
+    await consumeTurn(sessionId, makeInput(sessionId));
+
+    assert.equal(getSession(sessionId)?.isRunning, false, "endRun must clear isRunning after an error turn");
+    const sawError = pubsub.published.some((entry) => entry.data?.type === EVENT_TYPES.error);
+    assert.ok(sawError, "the error event must be published to the session channel");
+  });
+
+  it("throwing generator: error is caught, session still ends not-running", async () => {
+    setFakeResponse(() => {
+      throw new Error("boom in response generator");
+    });
+    const sessionId = seedRunningSession();
+
+    await consumeTurn(sessionId, makeInput(sessionId));
+
+    assert.equal(getSession(sessionId)?.isRunning, false, "a thrown generator must not leave the session stuck running");
+    const errored = pubsub.published.find((entry) => entry.data?.type === EVENT_TYPES.error);
+    assert.ok(errored, "the caught error must be surfaced as an error event");
+    assert.match(String(errored?.data?.message), /boom in response generator/);
+  });
+
+  it("abort mid-turn: cancelRun fires the abort cb and the turn ends clean", async () => {
+    const sessionId = `lc-${randomUUID()}`;
+    getOrCreateSession(sessionId, {
+      roleId: "general",
+      resultsFilePath: "/tmp/fake.jsonl",
+      startedAt: "2026-05-15T00:00:00.000Z",
+      updatedAt: "2026-05-15T00:00:00.000Z",
+    });
+    const controller = new AbortController();
+    let abortCbFired = false;
+    beginRun(sessionId, () => {
+      abortCbFired = true;
+      controller.abort();
+    });
+
+    // The user hits cancel while the turn is in flight.
+    const cancelled = cancelRun(sessionId);
+    assert.equal(cancelled, true, "cancelRun returns true while running");
+    assert.equal(abortCbFired, true, "cancelRun must invoke the registered abort cb");
+
+    setFakeResponse(() => ({ text: "should be cut off by abort" }));
+    await consumeTurn(sessionId, makeInput(sessionId, { abortSignal: controller.signal }));
+
+    assert.equal(getSession(sessionId)?.isRunning, false, "endRun must run even when the turn was aborted");
+    const sawText = pubsub.published.some((entry) => entry.data?.type === EVENT_TYPES.text);
+    assert.ok(!sawText, "no assistant text should reach the channel after an abort");
+  });
+
+  it("partial stream (tool_call, no result): session still ends not-running", async () => {
+    setFakeResponse(() => ({
+      toolCalls: [{ toolName: "presentForm", args: { fields: [] } }],
+      omitToolResult: true,
+    }));
+    const sessionId = seedRunningSession();
+
+    await consumeTurn(sessionId, makeInput(sessionId));
+
+    assert.equal(getSession(sessionId)?.isRunning, false, "a truncated tool round-trip must not hang the session");
+  });
+
+  it("empty stream: session ends not-running with no error", async () => {
+    setFakeResponse(() => ({}));
+    const sessionId = seedRunningSession();
+
+    await consumeTurn(sessionId, makeInput(sessionId));
+
+    assert.equal(getSession(sessionId)?.isRunning, false);
+    const sawError = pubsub.published.some((entry) => entry.data?.type === EVENT_TYPES.error);
+    assert.ok(!sawError, "an empty (but valid) stream is not an error");
+  });
+
+  it("next turn is accepted after a failed turn (409 guard not stuck)", async () => {
+    setFakeResponse(() => ({ error: "first turn failed" }));
+    const sessionId = seedRunningSession();
+    await consumeTurn(sessionId, makeInput(sessionId));
+
+    // The whole point of the invariant: a fresh beginRun must
+    // succeed, proving the 409 guard isn't wedged by the failure.
+    const secondBegin = beginRun(sessionId, () => {});
+    assert.equal(secondBegin, true, "beginRun must succeed again after a failed turn");
+  });
+});

--- a/test/agent/test_fake_backend_scenarios.ts
+++ b/test/agent/test_fake_backend_scenarios.ts
@@ -1,0 +1,131 @@
+// Scenario coverage for the fake-echo backend test seam. These
+// exercise the failure-shaped paths that were previously
+// unreachable without mocking the real Claude subprocess:
+//
+//   1. the backend yields an `error` event (CLI exited non-zero)
+//   2. the response generator throws (programming error mid-turn)
+//   3. the turn is aborted mid-stream (user cancel / timeout)
+//   4. a partial stream — tool_call with no tool_call_result
+//   5. an empty stream — only the session id, no text/tool
+//
+// They assert the *contract the consumer relies on* (the
+// for-await loop in server/api/routes/agent.ts#runAgentInBackground
+// + the begin/endRun lifecycle): every shape terminates the
+// generator cleanly so `endRun` in the consumer's `finally` always
+// runs and the session never gets stuck `isRunning`.
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import { fakeEchoBackend, setFakeResponse, resetFakeResponse } from "../../server/agent/backend/fake-echo.js";
+import type { AgentInput } from "../../server/agent/backend/types.js";
+import { ROLES, type Role } from "../../src/config/roles.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
+
+function requireRole(roleId: string): Role {
+  const role = ROLES.find((candidate) => candidate.id === roleId);
+  if (!role) throw new Error(`test setup: role '${roleId}' not found`);
+  return role;
+}
+
+const GENERAL_ROLE = requireRole("general");
+
+function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
+  return {
+    systemPrompt: "test",
+    message: "hello",
+    role: GENERAL_ROLE,
+    workspacePath: "/tmp/does-not-matter",
+    sessionId: `test-${randomUUID()}`,
+    port: 0,
+    activePlugins: [],
+    extraAllowedTools: [],
+    useDocker: false,
+    ...overrides,
+  };
+}
+
+async function drain(input: AgentInput) {
+  const events = [];
+  for await (const event of fakeEchoBackend.runAgent(input)) {
+    events.push(event);
+  }
+  return events;
+}
+
+afterEach(() => {
+  resetFakeResponse();
+});
+
+describe("fake-echo backend — failure-shaped scenarios", () => {
+  it("1. error event: surfaces an error AgentEvent and stops", async () => {
+    setFakeResponse(() => ({ error: "claude exited with code 1", text: "should not appear" }));
+
+    const events = await drain(makeInput());
+
+    // claudeSessionId then the error — text is suppressed.
+    assert.equal(events.at(-1)?.type, EVENT_TYPES.error);
+    const errorEvent = events.find((event) => event.type === EVENT_TYPES.error);
+    assert.equal(errorEvent?.message, "claude exited with code 1");
+    assert.ok(!events.some((event) => event.type === EVENT_TYPES.text), "text must not be emitted once an error short-circuits the turn");
+  });
+
+  it("2. throwing generator: rejects so the consumer's try/catch runs", async () => {
+    setFakeResponse(() => {
+      throw new Error("boom in response generator");
+    });
+
+    // The consumer wraps the for-await in try/catch → pushes an
+    // error event + endRun in finally. The contract here is just
+    // "the generator rejects rather than hanging".
+    await assert.rejects(() => drain(makeInput()), /boom in response generator/);
+  });
+
+  it("3. abort before consumption: yields nothing", async () => {
+    setFakeResponse(() => ({ text: "unreachable" }));
+    const controller = new AbortController();
+    controller.abort();
+
+    const events = await drain(makeInput({ abortSignal: controller.signal }));
+
+    assert.deepEqual(events, [], "an already-aborted turn must emit no events");
+  });
+
+  it("3b. abort mid-stream: stops before the text event", async () => {
+    const controller = new AbortController();
+    // Abort while the response generator is resolving, before the
+    // text event would be yielded.
+    setFakeResponse(async () => {
+      controller.abort();
+      return { text: "should be cut off" };
+    });
+
+    const events = await drain(makeInput({ abortSignal: controller.signal }));
+
+    assert.ok(!events.some((event) => event.type === EVENT_TYPES.text), "no text after an abort fired mid-turn");
+  });
+
+  it("4. partial stream: tool_call with no tool_call_result", async () => {
+    setFakeResponse(() => ({
+      toolCalls: [{ toolName: "presentForm", args: { fields: [] } }],
+      omitToolResult: true,
+    }));
+
+    const events = await drain(makeInput());
+
+    const calls = events.filter((event) => event.type === EVENT_TYPES.toolCall);
+    const results = events.filter((event) => event.type === EVENT_TYPES.toolCallResult);
+    assert.equal(calls.length, 1, "the tool_call half is emitted");
+    assert.equal(results.length, 0, "the tool_call_result half is intentionally dropped");
+  });
+
+  it("5. empty stream: only the session id, no text/tool", async () => {
+    setFakeResponse(() => ({}));
+
+    const events = await drain(makeInput());
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, EVENT_TYPES.claudeSessionId);
+  });
+});


### PR DESCRIPTION
## Summary

First batch of server-side failure-path tests enabled by the fake-echo seam (#1371). These shapes were unreachable before without mocking the real Claude subprocess.

## What changed

`server/agent/backend/fake-echo.ts` gains two test-only scripting knobs (same `setFakeResponse` / `MULMOCLAUDE_FAKE_AGENT` gating, no production path change):

- `error?: string` — emit a single `error` AgentEvent then stop (mirrors claude-code's non-zero-exit behavior)
- `omitToolResult?: boolean` — emit `tool_call` without its paired `tool_call_result` (truncated stream)

It now also honors `input.abortSignal` (checked between every yield), matching the real backend's proc.kill-on-abort contract — previously the stub ignored abort entirely.

`test/agent/test_fake_backend_scenarios.ts` covers the shapes the consumer (`runAgentInBackground`'s for-await + begin/endRun lifecycle) must survive:

1. error event surfaces + suppresses trailing text
2. throwing response generator rejects (consumer try/catch path)
3. pre-aborted turn emits nothing
3b. abort fired mid-turn stops before the text event
4. partial stream — tool_call with no result
5. empty stream — only the session id

## Items to Confirm / Review

- The abort knob is a behavior change to fake-echo (now stops on `abortSignal.aborted`). It's strictly more faithful to the real backend; no existing test depended on the old ignore-abort behavior (full suite green locally).
- These assert the **backend event-stream contract**, not the full HTTP/SSE path. Driving them through the real session-store `begin/endRun` lifecycle is the next batch (kept separate so each batch stays reviewable, per the "one at a time" plan).

## User Prompt

> fake実装したけど、これを使ってserver周りで今までなかったケースにテストって増やすことできる？とくにllm(claude code)のエラーのケースも増やせんじゃないかと。
> １つ１つわかりやすく。。。
> はい、エラーを返す、アボートする、データの一部だけ送らる、、など想定できるパターンで作ってください。

## Test plan

- [x] `yarn typecheck` / `yarn lint` green
- [x] `npx tsx --test test/agent/test_fake_backend_scenarios.ts` — 6/6 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit and integration tests for agent failure scenarios, lifecycle resilience, cancellation, partial tool streams, and a new end-to-end spec that verifies the agent error banner UI.

* **Improvements**
  * Agent execution now consistently respects cancellation throughout runs and terminates cleanly on backend errors.
  * Backend error paths emit clear error events and stop further output.
  * Tool call handling can suppress emitting tool results while still invoking tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1389)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->