### PR TITLE
feat: graceful degradation for optional host dependencies (#1385)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "vue-i18n": "^11.4.2",
     "vue-router": "^5.0.7",
     "vuedraggable": "^4.1.0",
+    "which": "^6",
     "ws": "^8.20.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.4.3"
@@ -120,6 +121,7 @@
     "@types/jsdom": "^28.0.3",
     "@types/node": "^25.8.0",
     "@types/uuid": "^11.0.0",
+    "@types/which": "^3.0.4",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-vue": "^6.0.7",
     "concurrently": "^9.2.1",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -49,6 +49,7 @@
     "socket.io-client": "^4.8.3",
     "tsx": "^4.22.0",
     "uuid": "^14.0.0",
+    "which": "^6",
     "ws": "^8.20.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.4.3"

--- a/plans/feat-optional-deps-1385.md
+++ b/plans/feat-optional-deps-1385.md
@@ -1,0 +1,68 @@
+# feat: optional-dependency graceful degradation (#1385)
+
+## Goal
+
+A missing optional host binary must never crash the app. The
+feature disables itself, the user is warned once (bell + log),
+everything else keeps working.
+
+## Scope (v1) — refined after reading the code
+
+The issue assumed `presentMulmoScript` was a runtime plugin gated
+in a registration loop. It is actually a **built-in** plugin and
+the MCP tool list is assembled in a **separate stdio child
+process** (`server/agent/mcp-server.ts`), so cross-process tool
+gating is delicate. ffmpeg is invoked deep inside the `mulmocast`
+lib from the `generateMovie` / `renderBeat` HTTP routes, not via a
+direct `spawn` in our code.
+
+So v1 delivers the reusable framework plus the user's two concrete
+asks, guarding ffmpeg at the **route** layer (where it actually
+crashes) rather than the MCP tool-list layer:
+
+1. `which@^6` direct dep — root `package.json` + `packages/mulmoclaude/package.json`
+   (launcher does not inherit transitive deps — publish-mulmoclaude trap #1).
+2. `server/system/optionalDeps.ts`:
+   - `OptionalDep` / `DepStatus` types
+   - `probeOptionalDeps()` — parallel, process-lifetime cached
+   - `depStatus(id)` — sync read after probe
+   - default probe = `which(cmd, {nothrow:true}) !== null`
+   - per-entry `probe?` override (docker daemon liveness)
+   - registry: `docker` (override = existing liveness), `ffmpeg` (default)
+3. `docker.ts` — register existing `isDockerAvailable` liveness body
+   as the docker entry's `probe`. Keep `isDockerAvailable` exported
+   and behaviour-identical so callers are untouched.
+4. Boot wiring `server/index.ts` after L885 `announcePluginMetaDiagnostics()`:
+   `await probeOptionalDeps()`, then per missing dep →
+   `publishNotification()` + one `log.warn("deps", …)`.
+5. ffmpeg route guard — `generateMovie` (L688) and `renderBeat`
+   (L587) in `server/api/routes/mulmo-script.ts`: when
+   `depStatus("ffmpeg")` is unavailable, respond with a clean
+   JSON error (`ffmpegMissing` message) instead of letting
+   `mulmocast` throw an opaque spawn error.
+6. `PluginMeta.requires?: readonly string[]` (`src/plugins/meta-types.ts`).
+   `presentMulmoScript/meta.ts` → `requires: ["ffmpeg"]`. Boot uses
+   it to name the affected plugin in the warn/notification.
+7. i18n `optionalDeps.*` (8 locales) + `lockStatusPopup` docker
+   disabled-reason copy.
+8. Tests:
+   - `probeOptionalDeps` parallel + cache (which called once) + `probe` override + `reason` mapping (stub `which`)
+   - ffmpeg route guard returns clean error when stubbed unavailable
+
+## Out of scope (→ follow-up)
+
+- MCP tool-list cross-process gating (hide the `presentMulmoScript`
+  tool entirely from the LLM when ffmpeg missing). Route guard is
+  enough to satisfy "doesn't crash" for v1.
+- `git` / `libreoffice` / `pandoc` / `poppler` (issue v2).
+- Per-platform install hints in the warn copy (issue v2).
+- Runtime re-probe (process-lifetime cache acceptable).
+
+## Acceptance
+
+- No ffmpeg installed → server boots, bell shows
+  "ffmpeg not found — presentMulmoScript (movie/render) disabled",
+  calling generateMovie returns a clean error, no crash/stacktrace.
+- No docker + sandbox-on → existing disable-sandbox fallback,
+  plus a bell warn + lock popup explains the reason.
+- `yarn format && yarn lint && yarn typecheck && yarn build && yarn test` green.

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -27,7 +27,8 @@ import { mulmoScriptSchema, type MulmoBeat, type MulmoImagePromptMedia } from "@
 import { slugify } from "../../utils/slug.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
 import { errorMessage } from "../../utils/errors.js";
-import { badRequest, notFound, serverError } from "../../utils/httpError.js";
+import { badRequest, notFound, sendError, serverError } from "../../utils/httpError.js";
+import { depStatus } from "../../system/optionalDeps.js";
 import { getOptionalStringQuery, getSessionQuery } from "../../utils/request.js";
 import { log } from "../../system/logger/index.js";
 import { validateUpdateBeatBody, validateUpdateScriptBody } from "./mulmoScriptValidate.js";
@@ -37,6 +38,20 @@ import { publishGeneration } from "../../events/session-store/index.js";
 import { GENERATION_KINDS } from "../../../src/types/events.js";
 
 const router = Router();
+
+// mulmocast shells out to ffmpeg for movie / beat rendering. When
+// ffmpeg is absent the optional-deps probe (#1385) marks it
+// unavailable; intercept here with a clear 503 instead of letting
+// the library throw an opaque spawn ENOENT mid-stream. `undefined`
+// means the boot probe hasn't completed — assume available so a
+// brief startup window never blocks a render.
+function ffmpegUnavailable(res: Response): boolean {
+  if (depStatus("ffmpeg")?.available === false) {
+    sendError(res, 503, "ffmpeg is not installed — movie and beat rendering are unavailable. Install ffmpeg and restart the server.");
+    return true;
+  }
+  return false;
+}
 const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
 
 // The downloadMovie handler expects "stories/<rel>" (historical
@@ -591,6 +606,7 @@ bindRoute(router, API_ROUTES.mulmoScript.renderBeat, async (req: Request<object,
     badRequest(res, "filePath and beatIndex are required");
     return;
   }
+  if (ffmpegUnavailable(res)) return;
 
   const key = String(beatIndex);
   publishGeneration(chatSessionId, GENERATION_KINDS.beatImage, filePath, key, false);
@@ -692,6 +708,8 @@ bindRoute(router, API_ROUTES.mulmoScript.generateMovie, async (req: Request<obje
     badRequest(res, "filePath is required");
     return;
   }
+
+  if (ffmpegUnavailable(res)) return;
 
   const absoluteFilePath = resolveStoryPath(filePath, res);
   if (!absoluteFilePath) return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,6 +46,7 @@ import { capturePhotoLocation } from "./workspace/photo-locations/index.js";
 import { createJournalRouter } from "./api/routes/journal.js";
 import { createTranslationRouter } from "./api/routes/translation.js";
 import { announcePluginMetaDiagnostics } from "./plugins/diagnostics.js";
+import { announceOptionalDeps } from "./system/announceOptionalDeps.js";
 import { createChatService } from "@mulmobridge/chat-service";
 import { readSessionJsonl } from "./utils/files/session-io.js";
 import { onSessionEvent, initSessionStore } from "./events/session-store/index.js";
@@ -883,6 +884,12 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
   // collision detected at module load via log.warn + a system
   // notification.
   await announcePluginMetaDiagnostics();
+
+  // --- Optional host-dependency probe (#1385) ---
+  // Probes docker / ffmpeg / … once, warns (log + bell) for any
+  // missing one so a feature degrading is visible instead of a
+  // later opaque crash. Never throws.
+  await announceOptionalDeps();
 
   // --- Chat socket transport (Phase A of #268) ---
   chatService.attachSocket(httpServer);

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -22,6 +22,11 @@ export async function announceOptionalDeps(): Promise<void> {
     const status = statuses[dep.id];
     if (!status || status.available) continue;
     const affectedPlugins = pluginsRequiring(dep.id);
+    // `not-on-path` → install it; `probe-failed` → it's installed
+    // but not responding (e.g. the docker daemon is down). The
+    // remediation differs, so the copy must be reason-aware rather
+    // than always saying "not found" (Codex review).
+    const notFound = status.reason === "not-on-path";
     log.warn("deps", `optional dependency '${dep.command}' unavailable — ${dep.enables} degraded`, {
       depId: dep.id,
       reason: status.reason,
@@ -31,11 +36,13 @@ export async function announceOptionalDeps(): Promise<void> {
       id: `optional-dep-missing:${dep.id}`,
       kind: "system",
       priority: NOTIFICATION_PRIORITIES.normal,
-      title: "Optional dependency missing",
-      body: `${dep.command} not found — some features are disabled`,
+      title: "Optional dependency unavailable",
+      body: notFound
+        ? `${dep.command} not found — some features are disabled. Install it and restart.`
+        : `${dep.command} is installed but not responding — some features are disabled. Start it and restart.`,
       i18n: {
-        titleKey: "optionalDeps.missingTitle",
-        bodyKey: "optionalDeps.missingBody",
+        titleKey: "optionalDeps.title",
+        bodyKey: notFound ? "optionalDeps.notFound" : "optionalDeps.notResponding",
         bodyParams: { command: dep.command },
       },
     });

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -1,0 +1,43 @@
+// Boot-time graceful-degradation announcement for missing optional
+// host binaries (#1385). Probes the registry, then for each missing
+// dependency emits one structured log.warn plus a deduped bell
+// notification naming the affected feature/plugins. Never throws —
+// degradation is the whole point.
+
+import { BUILT_IN_PLUGIN_METAS } from "../../src/plugins/metas.js";
+import type { PluginMeta } from "../../src/plugins/meta-types.js";
+import { NOTIFICATION_PRIORITIES } from "../../src/types/notification.js";
+import { log } from "./logger/index.js";
+import { publishNotification } from "../events/notifications.js";
+import { probeOptionalDeps, optionalDeps } from "./optionalDeps.js";
+
+function pluginsRequiring(depId: string): string[] {
+  const metas: readonly PluginMeta[] = Object.values(BUILT_IN_PLUGIN_METAS);
+  return metas.filter((meta) => meta.requires?.includes(depId)).map((meta) => meta.toolName);
+}
+
+export async function announceOptionalDeps(): Promise<void> {
+  const statuses = await probeOptionalDeps();
+  for (const dep of optionalDeps()) {
+    const status = statuses[dep.id];
+    if (!status || status.available) continue;
+    const affectedPlugins = pluginsRequiring(dep.id);
+    log.warn("deps", `optional dependency '${dep.command}' unavailable — ${dep.enables} degraded`, {
+      depId: dep.id,
+      reason: status.reason,
+      affectedPlugins,
+    });
+    publishNotification({
+      id: `optional-dep-missing:${dep.id}`,
+      kind: "system",
+      priority: NOTIFICATION_PRIORITIES.normal,
+      title: "Optional dependency missing",
+      body: `${dep.command} not found — some features are disabled`,
+      i18n: {
+        titleKey: "optionalDeps.missingTitle",
+        bodyKey: "optionalDeps.missingBody",
+        bodyParams: { command: dep.command },
+      },
+    });
+  }
+}

--- a/server/system/docker.ts
+++ b/server/system/docker.ts
@@ -41,18 +41,26 @@ function assertClaudeFiles(): void {
   }
 }
 
-export async function isDockerAvailable(): Promise<boolean> {
-  if (env.disableSandbox) return false;
-  if (_dockerEnabled !== null) return _dockerEnabled;
-  assertClaudeFiles();
+/** Pure daemon-liveness probe: `docker ps -q` succeeds only when the
+ *  client is installed AND the daemon is reachable. No config or
+ *  caching concerns — the optional-deps registry owns the PATH check
+ *  and caching; this is just the liveness half. */
+export async function isDockerLive(): Promise<boolean> {
   try {
     await execFileAsync("docker", ["ps", "-q"], {
       timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
     });
-    _dockerEnabled = true;
+    return true;
   } catch {
-    _dockerEnabled = false;
+    return false;
   }
+}
+
+export async function isDockerAvailable(): Promise<boolean> {
+  if (env.disableSandbox) return false;
+  if (_dockerEnabled !== null) return _dockerEnabled;
+  assertClaudeFiles();
+  _dockerEnabled = await isDockerLive();
   return _dockerEnabled;
 }
 

--- a/server/system/optionalDeps.ts
+++ b/server/system/optionalDeps.ts
@@ -116,3 +116,14 @@ export function _resetOptionalDepsCacheForTest(): void {
   cache = null;
   inFlight = null;
 }
+
+/** Test-only: seed the probe cache directly so route guards and
+ *  `announceOptionalDeps` behave deterministically without invoking
+ *  the real `which` / daemon probe (CI has no control over whether
+ *  ffmpeg/docker are installed on the runner). `probeOptionalDeps()`
+ *  returns this seeded cache untouched (its first line is
+ *  `if (cache) return cache;`). */
+export function _setOptionalDepsCacheForTest(seed: Record<string, DepStatus>): void {
+  cache = seed;
+  inFlight = null;
+}

--- a/server/system/optionalDeps.ts
+++ b/server/system/optionalDeps.ts
@@ -1,0 +1,94 @@
+// Optional host-binary registry + graceful-degradation probe (#1385).
+//
+// A missing optional binary must never crash the app: the feature
+// that needs it disables itself, the user is warned once, and the
+// rest keeps working. This module centralises the "is <binary>
+// available?" question so we don't re-implement the lazy-cached
+// probe per dependency (docker's ad-hoc check was the only one
+// before this).
+
+import which from "which";
+import { isDockerLive } from "./docker.js";
+
+/** A single optional host dependency the app can run without. */
+export interface OptionalDep {
+  /** Stable id used by `depStatus()` lookups and notification ids. */
+  readonly id: string;
+  /** Binary name passed to `which` for the default presence probe. */
+  readonly command: string;
+  /** i18n key fragment naming what stops working when absent. */
+  readonly enables: string;
+  /** Override when "on PATH" is insufficient (e.g. docker client
+   *  exists but the daemon is down). Returning false means the
+   *  dependency is treated as unavailable even if `which` found it. */
+  readonly probe?: () => Promise<boolean>;
+}
+
+export type DepReason = "ok" | "not-on-path" | "probe-failed";
+
+export interface DepStatus {
+  readonly id: string;
+  readonly available: boolean;
+  readonly reason: DepReason;
+}
+
+const REGISTRY: readonly OptionalDep[] = [
+  { id: "docker", command: "docker", enables: "dockerSandbox", probe: isDockerLive },
+  { id: "ffmpeg", command: "ffmpeg", enables: "mulmocast" },
+];
+
+async function onPath(command: string): Promise<boolean> {
+  const resolved = await which(command, { nothrow: true });
+  return resolved !== null;
+}
+
+// `pathCheck` is injectable so unit tests exercise the reason
+// mapping + override precedence without depending on the host's
+// real PATH.
+export async function probeOne(dep: OptionalDep, pathCheck: (command: string) => Promise<boolean> = onPath): Promise<DepStatus> {
+  if (!(await pathCheck(dep.command))) {
+    return { id: dep.id, available: false, reason: "not-on-path" };
+  }
+  if (dep.probe && !(await dep.probe())) {
+    return { id: dep.id, available: false, reason: "probe-failed" };
+  }
+  return { id: dep.id, available: true, reason: "ok" };
+}
+
+let cache: Record<string, DepStatus> | null = null;
+let inFlight: Promise<Record<string, DepStatus>> | null = null;
+
+/** Probe every registered dependency in parallel. Cached for the
+ *  process lifetime; concurrent callers share one in-flight run so
+ *  `which` / the daemon probe fire once each. */
+export async function probeOptionalDeps(): Promise<Record<string, DepStatus>> {
+  if (cache) return cache;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    const statuses = await Promise.all(REGISTRY.map((dep) => probeOne(dep)));
+    cache = Object.fromEntries(statuses.map((status) => [status.id, status]));
+    inFlight = null;
+    return cache;
+  })();
+  return inFlight;
+}
+
+/** Synchronous read of a previously-probed dependency. Returns
+ *  undefined if `probeOptionalDeps()` has not completed yet — callers
+ *  on the request path should treat that as "assume available" so a
+ *  not-yet-probed boot window never blocks a feature. */
+export function depStatus(depId: string): DepStatus | undefined {
+  return cache?.[depId];
+}
+
+/** The registry, for callers that need the human-facing `enables`
+ *  label (boot warning composition). */
+export function optionalDeps(): readonly OptionalDep[] {
+  return REGISTRY;
+}
+
+/** Test-only: drop the cache so a fresh probe runs next call. */
+export function _resetOptionalDepsCacheForTest(): void {
+  cache = null;
+  inFlight = null;
+}

--- a/server/system/optionalDeps.ts
+++ b/server/system/optionalDeps.ts
@@ -38,21 +38,34 @@ const REGISTRY: readonly OptionalDep[] = [
 ];
 
 async function onPath(command: string): Promise<boolean> {
-  const resolved = await which(command, { nothrow: true });
-  return resolved !== null;
+  try {
+    const resolved = await which(command, { nothrow: true });
+    return resolved !== null;
+  } catch {
+    // `which` shouldn't throw with nothrow, but a corrupt PATH or
+    // an fs error must degrade to "absent", never bubble up.
+    return false;
+  }
 }
 
+// Never throws — a missing optional dep degrades, it does not crash
+// startup. A throwing PATH check or liveness `probe` is treated as
+// "unavailable" rather than propagating into the boot sequence.
 // `pathCheck` is injectable so unit tests exercise the reason
 // mapping + override precedence without depending on the host's
 // real PATH.
 export async function probeOne(dep: OptionalDep, pathCheck: (command: string) => Promise<boolean> = onPath): Promise<DepStatus> {
-  if (!(await pathCheck(dep.command))) {
-    return { id: dep.id, available: false, reason: "not-on-path" };
-  }
-  if (dep.probe && !(await dep.probe())) {
+  try {
+    if (!(await pathCheck(dep.command))) {
+      return { id: dep.id, available: false, reason: "not-on-path" };
+    }
+    if (dep.probe && !(await dep.probe())) {
+      return { id: dep.id, available: false, reason: "probe-failed" };
+    }
+    return { id: dep.id, available: true, reason: "ok" };
+  } catch {
     return { id: dep.id, available: false, reason: "probe-failed" };
   }
-  return { id: dep.id, available: true, reason: "ok" };
 }
 
 let cache: Record<string, DepStatus> | null = null;
@@ -65,10 +78,21 @@ export async function probeOptionalDeps(): Promise<Record<string, DepStatus>> {
   if (cache) return cache;
   if (inFlight) return inFlight;
   inFlight = (async () => {
-    const statuses = await Promise.all(REGISTRY.map((dep) => probeOne(dep)));
-    cache = Object.fromEntries(statuses.map((status) => [status.id, status]));
-    inFlight = null;
-    return cache;
+    try {
+      const statuses = await Promise.all(REGISTRY.map((dep) => probeOne(dep)));
+      cache = Object.fromEntries(statuses.map((status) => [status.id, status]));
+      return cache;
+    } catch {
+      // probeOne never rejects, so this is unreachable in practice —
+      // but if it ever did, returning an empty map keeps boot alive
+      // (callers treat "no status" as "assume available"). Do NOT
+      // poison `cache` so a later call can retry.
+      return {};
+    } finally {
+      // Always clear so a rejected/failed run can't permanently
+      // poison the cache (Codex review).
+      inFlight = null;
+    }
   })();
   return inFlight;
 }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -76,6 +76,10 @@ const deMessages = {
     intraBody:
       "Die Plugins „{first}“ und „{second}“ registrieren beide {dimension} „{key}“. „{first}“ hat ihn zuerst beansprucht, daher wird die Registrierung von „{second}“ ignoriert.",
   },
+  optionalDeps: {
+    missingTitle: "Optionale Abhängigkeit fehlt",
+    missingBody: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",
+  },
   pluginErrorBoundary: {
     title: "Plugin {pkg} ist abgestürzt",
     subtitle: "Das Plugin konnte nicht gerendert werden. Der Fehler wurde in der Konsole protokolliert.",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -77,8 +77,10 @@ const deMessages = {
       "Die Plugins „{first}“ und „{second}“ registrieren beide {dimension} „{key}“. „{first}“ hat ihn zuerst beansprucht, daher wird die Registrierung von „{second}“ ignoriert.",
   },
   optionalDeps: {
-    missingTitle: "Optionale Abhängigkeit fehlt",
-    missingBody: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",
+    title: "Optionale Abhängigkeit nicht verfügbar",
+    notFound: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",
+    notResponding:
+      "{command} ist installiert, antwortet aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie es und starten Sie neu, um sie zu aktivieren.",
   },
   pluginErrorBoundary: {
     title: "Plugin {pkg} ist abgestürzt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -96,6 +96,10 @@ const enMessages = {
     hostBody: 'Plugin "{plugin}" tried to register the {label} key "{key}" but it is reserved by the host. The plugin\'s entry has been dropped.',
     intraBody: 'Plugins "{first}" and "{second}" both register {dimension} "{key}". "{first}" claimed it first, so "{second}"\'s registration is ignored.',
   },
+  optionalDeps: {
+    missingTitle: "Optional dependency missing",
+    missingBody: "{command} not found — related features have been disabled. Install it and restart to enable them.",
+  },
   pluginErrorBoundary: {
     title: "Plugin {pkg} crashed",
     subtitle: "The plugin failed to render. The error has been logged to the console.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -97,8 +97,9 @@ const enMessages = {
     intraBody: 'Plugins "{first}" and "{second}" both register {dimension} "{key}". "{first}" claimed it first, so "{second}"\'s registration is ignored.',
   },
   optionalDeps: {
-    missingTitle: "Optional dependency missing",
-    missingBody: "{command} not found — related features have been disabled. Install it and restart to enable them.",
+    title: "Optional dependency unavailable",
+    notFound: "{command} not found — related features are disabled. Install it and restart to enable them.",
+    notResponding: "{command} is installed but not responding — related features are disabled. Start it and restart to enable them.",
   },
   pluginErrorBoundary: {
     title: "Plugin {pkg} crashed",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -80,6 +80,10 @@ const esMessages = {
     intraBody:
       'Los plugins "{first}" y "{second}" registran ambos el {dimension} "{key}". "{first}" lo reclamó primero, por lo que el registro de "{second}" se ignora.',
   },
+  optionalDeps: {
+    missingTitle: "Falta una dependencia opcional",
+    missingBody: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
+  },
   pluginErrorBoundary: {
     title: "El plugin {pkg} se ha bloqueado",
     subtitle: "El plugin no se pudo renderizar. El error se ha registrado en la consola.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -81,8 +81,9 @@ const esMessages = {
       'Los plugins "{first}" y "{second}" registran ambos el {dimension} "{key}". "{first}" lo reclamó primero, por lo que el registro de "{second}" se ignora.',
   },
   optionalDeps: {
-    missingTitle: "Falta una dependencia opcional",
-    missingBody: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
+    title: "Dependencia opcional no disponible",
+    notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
+    notResponding: "{command} está instalado pero no responde — las funciones relacionadas se han desactivado. Inícialo y reinicia para habilitarlas.",
   },
   pluginErrorBoundary: {
     title: "El plugin {pkg} se ha bloqueado",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -76,8 +76,9 @@ const frMessages = {
       "Les plugins « {first} » et « {second} » enregistrent tous deux le {dimension} « {key} ». « {first} » l'a réclamé en premier, donc l'enregistrement de « {second} » est ignoré.",
   },
   optionalDeps: {
-    missingTitle: "Dépendance optionnelle manquante",
-    missingBody: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
+    title: "Dépendance optionnelle indisponible",
+    notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
+    notResponding: "{command} est installé mais ne répond pas — les fonctionnalités associées ont été désactivées. Démarrez-le et redémarrez pour les activer.",
   },
   pluginErrorBoundary: {
     title: "Le plugin {pkg} a planté",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -75,6 +75,10 @@ const frMessages = {
     intraBody:
       "Les plugins « {first} » et « {second} » enregistrent tous deux le {dimension} « {key} ». « {first} » l'a réclamé en premier, donc l'enregistrement de « {second} » est ignoré.",
   },
+  optionalDeps: {
+    missingTitle: "Dépendance optionnelle manquante",
+    missingBody: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
+  },
   pluginErrorBoundary: {
     title: "Le plugin {pkg} a planté",
     subtitle: "Le plugin n'a pas pu être affiché. L'erreur a été consignée dans la console.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -82,6 +82,10 @@ const jaMessages = {
     intraBody:
       "プラグイン「{first}」と「{second}」が同じ {dimension}「{key}」を登録しています。「{first}」が先に確保したため、「{second}」の登録は無視されます。",
   },
+  optionalDeps: {
+    missingTitle: "任意の依存コマンドが見つかりません",
+    missingBody: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",
+  },
   pluginErrorBoundary: {
     title: "プラグイン {pkg} がクラッシュしました",
     subtitle: "プラグインのレンダリングに失敗しました。エラーはコンソールに記録されています。",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -83,8 +83,9 @@ const jaMessages = {
       "プラグイン「{first}」と「{second}」が同じ {dimension}「{key}」を登録しています。「{first}」が先に確保したため、「{second}」の登録は無視されます。",
   },
   optionalDeps: {
-    missingTitle: "任意の依存コマンドが見つかりません",
-    missingBody: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",
+    title: "任意の依存コマンドを利用できません",
+    notFound: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",
+    notResponding: "{command} はインストール済みですが応答しません — 関連機能を無効化しました。起動して再起動すると有効になります。",
   },
   pluginErrorBoundary: {
     title: "プラグイン {pkg} がクラッシュしました",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -84,8 +84,9 @@ const koMessages = {
       '플러그인 "{first}"과(와) "{second}"이(가) 동일한 {dimension} "{key}"을(를) 등록합니다. "{first}"이(가) 먼저 등록했으므로 "{second}"의 등록은 무시됩니다.',
   },
   optionalDeps: {
-    missingTitle: "선택적 의존성을 찾을 수 없습니다",
-    missingBody: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
+    title: "선택적 의존성을 사용할 수 없습니다",
+    notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
+    notResponding: "{command}이(가) 설치되어 있지만 응답하지 않습니다 — 관련 기능이 비활성화되었습니다. 시작한 후 재시작하면 활성화됩니다.",
   },
   pluginErrorBoundary: {
     title: "플러그인 {pkg}이(가) 충돌했습니다",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -83,6 +83,10 @@ const koMessages = {
     intraBody:
       '플러그인 "{first}"과(와) "{second}"이(가) 동일한 {dimension} "{key}"을(를) 등록합니다. "{first}"이(가) 먼저 등록했으므로 "{second}"의 등록은 무시됩니다.',
   },
+  optionalDeps: {
+    missingTitle: "선택적 의존성을 찾을 수 없습니다",
+    missingBody: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
+  },
   pluginErrorBoundary: {
     title: "플러그인 {pkg}이(가) 충돌했습니다",
     subtitle: "플러그인 렌더링에 실패했습니다. 오류가 콘솔에 기록되었습니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -76,8 +76,9 @@ const ptBRMessages = {
       'Os plugins "{first}" e "{second}" registram o mesmo {dimension} "{key}". "{first}" o reivindicou primeiro, portanto o registro de "{second}" é ignorado.',
   },
   optionalDeps: {
-    missingTitle: "Dependência opcional ausente",
-    missingBody: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
+    title: "Dependência opcional indisponível",
+    notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
+    notResponding: "{command} está instalado mas não responde — recursos relacionados foram desativados. Inicie-o e reinicie para habilitá-los.",
   },
   pluginErrorBoundary: {
     title: "O plugin {pkg} travou",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -75,6 +75,10 @@ const ptBRMessages = {
     intraBody:
       'Os plugins "{first}" e "{second}" registram o mesmo {dimension} "{key}". "{first}" o reivindicou primeiro, portanto o registro de "{second}" é ignorado.',
   },
+  optionalDeps: {
+    missingTitle: "Dependência opcional ausente",
+    missingBody: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
+  },
   pluginErrorBoundary: {
     title: "O plugin {pkg} travou",
     subtitle: "O plugin falhou ao renderizar. O erro foi registrado no console.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -80,8 +80,9 @@ const zhMessages = {
     intraBody: '插件 "{first}" 和 "{second}" 都注册了 {dimension} "{key}"。"{first}" 先注册,因此 "{second}" 的注册被忽略。',
   },
   optionalDeps: {
-    missingTitle: "缺少可选依赖",
-    missingBody: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
+    title: "可选依赖不可用",
+    notFound: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
+    notResponding: "{command} 已安装但无响应 — 相关功能已被禁用。启动后重启即可启用。",
   },
   pluginErrorBoundary: {
     title: "插件 {pkg} 已崩溃",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -79,6 +79,10 @@ const zhMessages = {
     hostBody: '插件 "{plugin}" 尝试注册 {label} 键 "{key}",但该键由宿主保留。该插件条目已被丢弃。',
     intraBody: '插件 "{first}" 和 "{second}" 都注册了 {dimension} "{key}"。"{first}" 先注册,因此 "{second}" 的注册被忽略。',
   },
+  optionalDeps: {
+    missingTitle: "缺少可选依赖",
+    missingBody: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
+  },
   pluginErrorBoundary: {
     title: "插件 {pkg} 已崩溃",
     subtitle: "插件渲染失败。错误已记录到控制台。",

--- a/src/plugins/meta-types.ts
+++ b/src/plugins/meta-types.ts
@@ -80,6 +80,11 @@ export interface PluginMeta {
    *  live as separate named exports in the plugin's `meta.ts`
    *  because their signatures are plugin-specific. */
   readonly staticChannels?: Readonly<Record<string, string>>;
+  /** Optional host binaries this plugin's features need (ids from
+   *  the optional-deps registry, e.g. `["ffmpeg"]`). When any is
+   *  missing the host warns the user once and the plugin's
+   *  dependency-bound features degrade gracefully — see #1385. */
+  readonly requires?: readonly string[];
 }
 
 /** Substitute `:param` placeholders in a route URL with caller-

--- a/src/plugins/presentMulmoScript/meta.ts
+++ b/src/plugins/presentMulmoScript/meta.ts
@@ -49,4 +49,8 @@ export const META = definePluginMeta({
     downloadMovie: { method: "GET", path: "/download-movie" },
   },
   mcpDispatch: "save",
+  // mulmocast shells out to ffmpeg for movie/beat rendering. Without
+  // it the editor still works but render/generate-movie degrades —
+  // the host warns once at boot (#1385).
+  requires: ["ffmpeg"],
 });

--- a/test/system/test_optionalDeps.ts
+++ b/test/system/test_optionalDeps.ts
@@ -1,0 +1,77 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { probeOne, probeOptionalDeps, depStatus, optionalDeps, _resetOptionalDepsCacheForTest, type OptionalDep } from "../../server/system/optionalDeps.js";
+
+const present = async () => true;
+const absent = async () => false;
+
+describe("probeOne — reason mapping + override precedence", () => {
+  it("reports not-on-path when the binary is absent (probe never consulted)", async () => {
+    let probeCalled = false;
+    const dep: OptionalDep = {
+      id: "x",
+      command: "x",
+      enables: "x",
+      probe: async () => {
+        probeCalled = true;
+        return true;
+      },
+    };
+    const status = await probeOne(dep, absent);
+    assert.deepEqual(status, { id: "x", available: false, reason: "not-on-path" });
+    assert.equal(probeCalled, false, "liveness probe must not run when the binary is not on PATH");
+  });
+
+  it("reports probe-failed when on PATH but the liveness override returns false", async () => {
+    const dep: OptionalDep = { id: "docker", command: "docker", enables: "dockerSandbox", probe: absent };
+    const status = await probeOne(dep, present);
+    assert.deepEqual(status, { id: "docker", available: false, reason: "probe-failed" });
+  });
+
+  it("reports ok when on PATH and the override passes", async () => {
+    const dep: OptionalDep = { id: "docker", command: "docker", enables: "dockerSandbox", probe: present };
+    assert.deepEqual(await probeOne(dep, present), { id: "docker", available: true, reason: "ok" });
+  });
+
+  it("reports ok when on PATH and there is no override", async () => {
+    const dep: OptionalDep = { id: "ffmpeg", command: "ffmpeg", enables: "mulmocast" };
+    assert.deepEqual(await probeOne(dep, present), { id: "ffmpeg", available: true, reason: "ok" });
+  });
+});
+
+describe("registry", () => {
+  it("declares docker (with liveness override) and ffmpeg (plain PATH)", () => {
+    const byId = Object.fromEntries(optionalDeps().map((dep) => [dep.id, dep]));
+    assert.ok(byId.docker, "docker entry present");
+    assert.equal(typeof byId.docker?.probe, "function", "docker has a liveness override");
+    assert.ok(byId.ffmpeg, "ffmpeg entry present");
+    assert.equal(byId.ffmpeg?.probe, undefined, "ffmpeg uses the default PATH check");
+  });
+});
+
+describe("probeOptionalDeps — caching", () => {
+  afterEach(() => _resetOptionalDepsCacheForTest());
+
+  it("returns the same cached object across calls and exposes it via depStatus()", async () => {
+    const first = await probeOptionalDeps();
+    const second = await probeOptionalDeps();
+    assert.equal(first, second, "second call returns the cached reference, no re-probe");
+    for (const dep of optionalDeps()) {
+      assert.equal(depStatus(dep.id)?.id, dep.id, `depStatus('${dep.id}') is readable after probe`);
+    }
+  });
+
+  it("depStatus() is undefined before the first probe completes", async () => {
+    _resetOptionalDepsCacheForTest();
+    assert.equal(depStatus("ffmpeg"), undefined, "no status until probeOptionalDeps() resolves");
+    await probeOptionalDeps();
+    assert.notEqual(depStatus("ffmpeg"), undefined, "status populated after probe");
+  });
+
+  it("concurrent callers share one in-flight probe", async () => {
+    _resetOptionalDepsCacheForTest();
+    const [run1, run2, run3] = await Promise.all([probeOptionalDeps(), probeOptionalDeps(), probeOptionalDeps()]);
+    assert.equal(run1, run2);
+    assert.equal(run2, run3);
+  });
+});

--- a/test/system/test_optionalDeps.ts
+++ b/test/system/test_optionalDeps.ts
@@ -37,6 +37,28 @@ describe("probeOne — reason mapping + override precedence", () => {
     const dep: OptionalDep = { id: "ffmpeg", command: "ffmpeg", enables: "mulmocast" };
     assert.deepEqual(await probeOne(dep, present), { id: "ffmpeg", available: true, reason: "ok" });
   });
+
+  it("never throws when the PATH check itself throws (degrades, not crashes)", async () => {
+    const dep: OptionalDep = { id: "x", command: "x", enables: "x" };
+    const throwing = async () => {
+      throw new Error("corrupt PATH");
+    };
+    const status = await probeOne(dep, throwing);
+    assert.deepEqual(status, { id: "x", available: false, reason: "probe-failed" });
+  });
+
+  it("never throws when the liveness override throws", async () => {
+    const dep: OptionalDep = {
+      id: "docker",
+      command: "docker",
+      enables: "dockerSandbox",
+      probe: async () => {
+        throw new Error("daemon socket error");
+      },
+    };
+    const status = await probeOne(dep, present);
+    assert.deepEqual(status, { id: "docker", available: false, reason: "probe-failed" });
+  });
 });
 
 describe("registry", () => {

--- a/test/system/test_optionalDeps_degradation.ts
+++ b/test/system/test_optionalDeps_degradation.ts
@@ -1,0 +1,161 @@
+// E2E-style integration test for the optional-dependency graceful
+// degradation feature (#1385, PR #1390). Deterministic and
+// CI-runnable under `yarn test` (no Playwright, no Claude API, no
+// real ffmpeg/docker needed — the probe cache is seeded directly).
+//
+// Proves:
+//  1. ffmpeg absent  → generateMovie / renderBeat return a clean
+//     HTTP 503 instead of letting mulmocast crash mid-stream.
+//  2. ffmpeg absent  → boot announce emits a `deps` warn that
+//     attributes the affected plugin (presentMulmoScript).
+//  3. ffmpeg present → no false "missing" warning.
+//
+// Route handlers are pulled straight off the Express Router stack
+// and invoked with mock req/res (same idiom as test_hookLog.ts) so
+// no live server / supertest is needed.
+
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Request, Response, Router } from "express";
+import mulmoScriptRouter from "../../server/api/routes/mulmo-script.js";
+import { announceOptionalDeps } from "../../server/system/announceOptionalDeps.js";
+import { _resetOptionalDepsCacheForTest, _setOptionalDepsCacheForTest, type DepStatus } from "../../server/system/optionalDeps.js";
+import { initNotifier, _setFilePathsForTesting } from "../../server/notifier/engine.js";
+import { log } from "../../server/system/logger/index.js";
+import { API_ROUTES } from "../../src/config/apiRoutes.js";
+
+interface RouterInternals {
+  stack: { route?: { path: string; stack: { handle: (req: Request, res: Response) => unknown }[] } }[];
+}
+
+function getHandler(router: Router, url: string): (req: Request, res: Response) => unknown {
+  const internals = router as unknown as RouterInternals;
+  for (const layer of internals.stack) {
+    if (layer.route && layer.route.path === url) return layer.route.stack[0].handle;
+  }
+  throw new Error(`handler for ${url} not found in router stack`);
+}
+
+interface MockResponse {
+  statusCode: number;
+  body: unknown;
+  headersSent: boolean;
+  status: (code: number) => MockResponse;
+  json: (payload: unknown) => MockResponse;
+  setHeader: () => MockResponse;
+  write: () => boolean;
+  end: () => MockResponse;
+}
+
+function mockResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    headersSent: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.headersSent = true;
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {
+      this.headersSent = true;
+      return this;
+    },
+  };
+}
+
+const FFMPEG_ABSENT: Record<string, DepStatus> = {
+  ffmpeg: { id: "ffmpeg", available: false, reason: "not-on-path" },
+};
+const FFMPEG_PRESENT: Record<string, DepStatus> = {
+  ffmpeg: { id: "ffmpeg", available: true, reason: "ok" },
+};
+
+async function callRoute(url: string, body: unknown): Promise<MockResponse> {
+  const handler = getHandler(mulmoScriptRouter, url);
+  const res = mockResponse();
+  await Promise.resolve(handler({ body } as unknown as Request, res as unknown as Response));
+  return res;
+}
+
+describe("optional-deps: ffmpeg route guard", () => {
+  afterEach(() => _resetOptionalDepsCacheForTest());
+
+  it("renderBeat returns 503 with a clear message when ffmpeg is unavailable", async () => {
+    _setOptionalDepsCacheForTest(FFMPEG_ABSENT);
+    const res = await callRoute(API_ROUTES.mulmoScript.renderBeat.url, { filePath: "stories/x.json", beatIndex: 0 });
+    assert.equal(res.statusCode, 503);
+    assert.match(String((res.body as { error?: string }).error), /ffmpeg is not installed/);
+  });
+
+  it("generateMovie returns 503 with a clear message when ffmpeg is unavailable", async () => {
+    _setOptionalDepsCacheForTest(FFMPEG_ABSENT);
+    const res = await callRoute(API_ROUTES.mulmoScript.generateMovie.url, { filePath: "stories/x.json" });
+    assert.equal(res.statusCode, 503);
+    assert.match(String((res.body as { error?: string }).error), /ffmpeg is not installed/);
+  });
+
+  it("does NOT short-circuit with the ffmpeg 503 when ffmpeg is present", async () => {
+    _setOptionalDepsCacheForTest(FFMPEG_PRESENT);
+    // Missing filePath trips the route's own 400 validation, which
+    // sits before the ffmpeg guard — proving the guard stayed out
+    // of the way when the dependency is available.
+    const res = await callRoute(API_ROUTES.mulmoScript.generateMovie.url, {});
+    assert.notEqual(res.statusCode, 503);
+  });
+});
+
+describe("optional-deps: boot announcement", () => {
+  let tmpDir = "";
+  const captured: { namespace: string; message: string; data?: object }[] = [];
+  const originalWarn = log.warn;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-optdeps-test-"));
+    _setFilePathsForTesting({ active: path.join(tmpDir, "active.json"), history: path.join(tmpDir, "history.json") });
+    initNotifier({ publish: () => {} });
+    captured.length = 0;
+    log.warn = (namespace, message, data) => {
+      captured.push({ namespace, message, data });
+    };
+  });
+
+  afterEach(() => {
+    log.warn = originalWarn;
+    _resetOptionalDepsCacheForTest();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("warns under the 'deps' namespace and attributes presentMulmoScript when ffmpeg is absent", async () => {
+    _setOptionalDepsCacheForTest(FFMPEG_ABSENT);
+    await announceOptionalDeps();
+    const depWarn = captured.find((entry) => entry.namespace === "deps");
+    assert.ok(depWarn, "a 'deps' warn must be emitted for the missing dependency");
+    const data = depWarn.data as { depId?: string; affectedPlugins?: string[] };
+    assert.equal(data.depId, "ffmpeg");
+    assert.ok(data.affectedPlugins?.includes("presentMulmoScript"), "the warn must name the plugin that requires ffmpeg");
+  });
+
+  it("does not warn for ffmpeg when it is present", async () => {
+    _setOptionalDepsCacheForTest(FFMPEG_PRESENT);
+    await announceOptionalDeps();
+    assert.equal(
+      captured.find((entry) => entry.namespace === "deps"),
+      undefined,
+      "no 'deps' warn when the dependency is available",
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://npm.flatt.tech/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -1278,7 +1285,7 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
-"@matrix-org/matrix-sdk-crypto-wasm@^18.1.0", "@matrix-org/matrix-sdk-crypto-wasm@^18.2.0":
+"@matrix-org/matrix-sdk-crypto-wasm@^18.2.0":
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-18.2.0.tgz#b81c8ac73115e6bef8b42020b1026829017fbdff"
   integrity sha512-puyZefvq6sHfqlmkri8umhA44724H2JL0YtX8wlvhGuNl8awX/Q1tZyW2Iekm9ZJP7BtuOqlNdg9oQd6iaGbNw==
@@ -2045,6 +2052,11 @@
   integrity sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==
   dependencies:
     uuid "*"
+
+"@types/which@^3.0.4":
+  version "3.0.4"
+  resolved "https://npm.flatt.tech/@types/which/-/which-3.0.4.tgz#2c3a89be70c56a84a6957a7264639f39ae4340a1"
+  integrity sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==
 
 "@types/ws@^6.0.3":
   version "6.0.4"
@@ -2875,7 +2887,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.15.0, axios@^1.16.0, axios@^1.7.7, axios@^1.8.2:
+axios@^1.16.0, axios@^1.7.7, axios@^1.8.2:
   version "1.16.1"
   resolved "https://npm.flatt.tech/axios/-/axios-1.16.1.tgz#517e29291d19d6e8cf919ff264f4fe157261ba12"
   integrity sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==
@@ -3256,6 +3268,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@14.0.0:
   version "14.0.0"
@@ -4634,7 +4651,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-follow-redirects@^1.15.11, follow-redirects@^1.16.0:
+follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -6258,10 +6275,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -8043,6 +8067,17 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.13:
+  version "7.5.13"
+  resolved "https://npm.flatt.tech/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
+  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8325,11 +8360,6 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-undici-types@~7.21.0:
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.21.0.tgz#433f7dd1b5daa9ab4dacb721a5e11a8de51eadda"
-  integrity sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==
-
 undici@6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
@@ -8470,11 +8500,6 @@ uuid@*, uuid@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
-
-uuid@13:
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.2.tgz#41bc9c07b12f665089c205f6507976adbdf84ff8"
-  integrity sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==
 
 uuid@^10.0.0:
   version "10.0.0"
@@ -8718,7 +8743,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^6.0.1:
+which@^6, which@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/which/-/which-6.0.1.tgz#021642443a198fb93b784a5606721cb18cfcbfce"
   integrity sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==
@@ -8872,6 +8897,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://npm.flatt.tech/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

- 任意の外部コマンド（docker / ffmpeg）が無くてもアプリが落ちない。機能が自分を無効化し、ユーザーに一度だけ通知し、それ以外は通常どおり動く。
- `which@^6` を直接依存に追加（root + `packages/mulmoclaude` — ランチャーは間接依存を引き継がないため両方）。クロスプラットフォーム解決（Windows PATHEXT 含む）なので自前 PATH 走査は不要。
- `server/system/optionalDeps.ts` = 集中レジストリ + 並列・プロセス存続中キャッシュの存在チェック。デフォルトは `which`、エントリごとの `probe` 上書きで「入っているが動かない」（docker デーモン停止）に対応。
- 起動時に一度チェックし、欠落ごとに `log.warn` + ベル通知（既存の `publishNotification` を再利用）。
- ffmpeg 欠落時、`generateMovie` / `renderBeat` は mulmocast の不透明な spawn エラーではなく明確な 503 を返す。
- `PluginMeta.requires` を追加、`presentMulmoScript` が `["ffmpeg"]` を宣言。i18n は全 8 ロケール同時追加。

## Items to Confirm / Review

- **ffmpeg ゲートの位置**: MCP ツールリストは別の stdio 子プロセスで組まれるため、LLM からツール自体を隠す cross-process gating は v1 では見送り、ルート層で 503 ガード。これで「落ちない」は満たす。LLM にツールを出さない方が良ければ follow-up issue を切ります。
- **`isDockerAvailable()` の挙動非変更**: `isDockerLive()` を抽出してレジストリの override にしたが、`isDockerAvailable()` は `env.disableSandbox` 短絡・キャッシュ・`assertClaudeFiles()` を含め従来どおり。既存呼び出し側は無変更。要確認ポイント。
- **lockStatusPopup**: 既存文言（"No sandbox (Docker not found)" + install 案内）が既に理由を説明しているため追加変更なし、と判断。別途強化したい場合は指示ください。
- **silent-drop ではなく warn + degrade** という方針（ユーザーの「なくても動くほうが良い」に対応）。

## User Prompt

> 初心者向けのsetupでの気づき
>
> dockerがないのにdocker modeのとき、whichなどで毎回dockerを調べておいて、dockerがないならdisable sandboxで起動してwarnをだせばよい
>
> ffmpegも、whichで確認して、ないならないとwarnをだして、mulmocastはdisabledにすればよい
>
> 他も依存があるものはdisableにできるような仕組みがあれば良い。なければ落ちるとかエラーになるのはよくない。ないことがわかって、なくても動くほうが良い

## Implementation

詳細は `plans/feat-optional-deps-1385.md` と issue #1385 を参照。

## Out of scope (→ follow-up)

- MCP ツールリストの cross-process gating（ffmpeg 欠落時に LLM から `presentMulmoScript` ツール自体を隠す）
- `git` / `libreoffice` / `pandoc` / `poppler` のレジストリ追加、プラットフォーム別インストールヒント（issue v2）

## Test plan

- [x] `yarn format / lint / typecheck / build / test` 全グリーン（4727 + 各 workspace、fail 0）
- [x] `test/system/test_optionalDeps.ts` 8 ケース（reason マッピング、override 優先順位、レジストリ形状、キャッシュ／共有 in-flight／`depStatus` ライフサイクル）
- [ ] 手動: ffmpeg を PATH から外して起動 → ベルに警告、generate-movie が 503、クラッシュなし（`/pr-ui-test` 推奨）
- [ ] 手動: docker 無し + sandbox-on → 既存の disable-sandbox フォールバック + ベル警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Graceful handling when optional dependencies (ffmpeg, docker) are unavailable with clear error responses instead of crashes
  - Boot-time warnings and system notifications alerting users about missing optional dependencies that impact available features

* **Localization**
  - Added multilingual missing-dependency notifications (8 languages: English, German, Spanish, French, Japanese, Korean, Portuguese, Chinese)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->