### PR TITLE
docs: rename umbrella plan + reflect #1385 v1 progress

### DIFF
--- a/plans/umbrella-deps-ux-1049.md
+++ b/plans/umbrella-deps-ux-1049.md
@@ -23,7 +23,7 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 > 1. その PR 用の plan ファイルを `plans/<branch-name>.md` (例: `plans/feat-pr-4a-docker-auto-fallback.md`) に新規作成する
 > 2. **下表の該当行の「状態」列に plan ファイルへの相対リンクを追記する** (例: `⏳ [plan](feat-pr-4a-docker-auto-fallback.md)`)
 > 3. PR が立ったら同じセルに PR 番号も追記 (例: `🚧 [plan](feat-pr-4a-docker-auto-fallback.md) / #1380`)
-> 4. PR がマージされたら `✅ #1380` に書き換え、対応する plan を `plans/done/` に移動 (`/archive-shipped-plans` skill で自動化)
+> 4. PR がマージされたら状態を `✅` にして PR 番号を併記する (例: `✅ [plan](done/feat-pr-4a-docker-auto-fallback.md) / #1380`)。同時に plan を `plans/done/` に移動し、リンク先も `done/` プレフィックスに更新する (`/archive-shipped-plans` skill で自動化)。完了スライスでも plan リンクを保持することで、後から「なぜそう実装したか」を辿れるようにする
 >
 > 表の更新を怠ると umbrella 全体の進捗が見えなくなる。新規 plan を作成したら、対応する行を必ず更新すること。
 
@@ -43,7 +43,7 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 
 ### PR-1b ノート (新 skill `/check-prereqs`)
 
-「主要な依存を集めて事前確認 → 不足を対話で 1 件ずつ案内」する独立 skill。Codex cross-review で分割推奨 (#1367 デザイン相談、`/tmp/codex-cross-review-local-docs-ffmpeg-prereq/design-skill-split.md`):
+「主要な依存を集めて事前確認 → 不足を対話で 1 件ずつ案内」する独立 skill。#1367 デザイン相談での Codex cross-review で分割推奨:
 
 - **発動経路 3 つ**: (1) ユーザーが直接呼ぶ pre-flight check、(2) `setup-mulmoclaude` の Step 3 から委譲、(3) PR-4 の bell 通知から「`/check-prereqs` 実行」誘導
 - **対話フロー**: 各依存に対して `probe → 結果表示 → (不足時) 入れる/後で/入れない 分岐 → install コマンド案内 (README から取得) → 再確認 → 次の依存へ`

--- a/plans/umbrella-deps-ux-1049.md
+++ b/plans/umbrella-deps-ux-1049.md
@@ -58,11 +58,12 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 
 レビューア提案を素直に展開した umbrella 行。当初は PR-4a / 4b / 4c を個別に出して共通点が見えてから 4d に切り出す想定だったが、実装してみると probe レジストリと plugin の `requires` 宣言が並行ではなく共依存だったため、**PR-4a + PR-4b + PR-4d を 1 本にまとめて v1 として #1390 でマージ済み**。PR-4c は依存先が「Gemini API key」という env 変数で、`which`-based probe とは仕組みが異なるため別 PR として残置。
 
-| 子 PR     | 内容                                                                 | 状態                                              |
-| --------- | -------------------------------------------------------------------- | ------------------------------------------------- |
-| **PR-4a** | Docker 不在 → 自動 `DISABLE_SANDBOX` + warn                          | ✅ #1390 (v1) — `isDockerLive()` を probe override |
-| **PR-4b** | ffmpeg 不在 → mulmocast 関連を runtime disable + warn                | 🟡 #1390 (v1, ルート層 503 ガード)                |
-| **PR-4c** | Gemini API key 不在 → 画像生成系 plugin を runtime disable + 案内    | ⏳ (env probe 別仕組みなので別 PR)                |
+#### v1 (出荷済み)
+
+| 子 PR     | 内容                                                                   | 状態                                              |
+| --------- | ---------------------------------------------------------------------- | ------------------------------------------------- |
+| **PR-4a** | Docker 不在 → 自動 `DISABLE_SANDBOX` + warn                            | ✅ #1390 (v1) — `isDockerLive()` を probe override |
+| **PR-4b** | ffmpeg 不在 → mulmocast 関連を runtime disable + warn                  | 🟡 #1390 (v1, ルート層 503 ガード)                |
 | **PR-4d** | 共通フレーム (`server/system/optionalDeps.ts` + `PluginMeta.requires`) | ✅ #1390 (v1)                                     |
 
 **v1 (#1390) が提供したもの**:
@@ -74,13 +75,23 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 - ffmpeg 欠如時、`generateMovie` / `renderBeat` が不透明な spawn エラーではなく **HTTP 503**
 - `test/system/test_optionalDeps*.ts` — CI 実行可能（API キー・実 ffmpeg 不要）な決定論的テスト
 
-**v2 (follow-up issue を切る想定)**:
+#### umbrella 内で並走 (v1 と独立)
 
-- MCP ツールリストの cross-process gating（ffmpeg 欠如時に LLM から `presentMulmoScript` ツール自体を隠す）— MCP が別 stdio 子プロセスで組まれるため。v1 はルート 503 ガードで「落ちない」を担保済み
-- `git` / `libreoffice` / `pandoc` / `poppler` のレジストリ追加
-- 警告文へのプラットフォーム別インストールヒント（`brew install ffmpeg` / `apt install` / `choco install`）
+| 子 PR     | 内容                                                              | 状態                                |
+| --------- | ----------------------------------------------------------------- | ----------------------------------- |
+| **PR-4c** | Gemini API key 不在 → 画像生成系 plugin を runtime disable + 案内 | ⏳ (env probe 別仕組みなので別 PR) |
 
-PR-4c は umbrella 内で独立して進められる。
+#### v2 (未着手 — follow-up issue を切ってから着手)
+
+PR-4b の 🟡 を ✅ に押し上げる + 残りの依存をレジストリに乗せる + UX 改善。
+
+| 子 PR     | 内容                                                                                                          | 状態 |
+| --------- | ------------------------------------------------------------------------------------------------------------- | ---- |
+| **PR-4e** | MCP ツールリストの cross-process gating — ffmpeg 欠如時に LLM から `presentMulmoScript` ツール自体を隠す      | ⏳   |
+| **PR-4f** | `git` / `libreoffice` / `pandoc` / `poppler` のレジストリ追加 (probe 定義 + プラグイン `requires` 宣言)       | ⏳   |
+| **PR-4g** | 警告文にプラットフォーム別インストールヒント (`brew install ffmpeg` / `apt install` / `choco install`)        | ⏳   |
+
+PR-4e がマージできると PR-4b を ✅ に確定できる。PR-4f は複数の依存を 1 PR でまとめても、依存ごとに分割しても良い (着手時に判断)。
 
 ## PR-A + PR-1e 一部 の詳細 (現状 #1367 でカバー)
 

--- a/plans/umbrella-deps-ux-1049.md
+++ b/plans/umbrella-deps-ux-1049.md
@@ -24,6 +24,8 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 > 2. **下表の該当行の「状態」列に plan ファイルへの相対リンクを追記する** (例: `⏳ [plan](feat-pr-4a-docker-auto-fallback.md)`)
 > 3. PR が立ったら同じセルに PR 番号も追記 (例: `🚧 [plan](feat-pr-4a-docker-auto-fallback.md) / #1380`)
 > 4. PR がマージされたら状態を `✅` にして PR 番号を併記する (例: `✅ [plan](done/feat-pr-4a-docker-auto-fallback.md) / #1380`)。同時に plan を `plans/done/` に移動し、リンク先も `done/` プレフィックスに更新する (`/archive-shipped-plans` skill で自動化)。完了スライスでも plan リンクを保持することで、後から「なぜそう実装したか」を辿れるようにする
+> 
+> **例外**: スライス専用の plan ファイルが無く、この umbrella 自身を plan として兼用したスライス (例: PR-A は #1367 で README と本ファイルを同時に編集した) は、リンク先がこのファイル自身 (`umbrella-deps-ux-1049.md`) となり `done/` 移動も発生しない。完了行に `done/` プレフィックスが無い行はこの例外と読む
 >
 > 表の更新を怠ると umbrella 全体の進捗が見えなくなる。新規 plan を作成したら、対応する行を必ず更新すること。
 

--- a/plans/umbrella-deps-ux-1049.md
+++ b/plans/umbrella-deps-ux-1049.md
@@ -1,6 +1,8 @@
-# docs: ffmpeg prerequisite + setup-mulmoclaude dependency check
+# umbrella: optional-dependency UX (#1049)
 
 Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存欠落 UX 整備 umbrella。
+
+> ファイル名履歴: 旧称 `plans/docs-ffmpeg-prereq.md`。初期スライス (PR-A) 起点で命名したが、umbrella 全体の進捗ハブとして機能している実態に合わせて `umbrella-deps-ux-1049.md` に改名 (2026-05-16)。
 
 ## Umbrella 全体像 (#1049)
 
@@ -14,7 +16,7 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 
 ### PR 一覧
 
-> **進捗管理ルール**: この `plans/docs-ffmpeg-prereq.md` を `#1049` umbrella の進捗ハブとして扱う。
+> **進捗管理ルール**: この `plans/umbrella-deps-ux-1049.md` を `#1049` umbrella の進捗ハブとして扱う。
 >
 > umbrella の各 PR に着手する際は、以下の手順で下表を更新する:
 >
@@ -29,15 +31,15 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 
 | ID        | 内容                                                                                                                                                                               | 状態                                                                                          |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **PR-A**  | README に Prerequisites を明記 (ffmpeg / Docker / claude CLI / Node)                                                                                                               | ✅ [plan](docs-ffmpeg-prereq.md) / #1367                                                      |
-| **PR-1a** | bundled system skill の配布機構 (`--plugin-dir` + `discoverSkills` 拡張)                                                                                                           | ⏳                                                                                            |
-| **PR-1b** | `/check-prereqs` skill — **対話的な依存チェック**。probe → 「入れる/後で/入れない」分岐 → install ガイド → 再確認。下記 PR-1b ノート参照                                           | ⏳ — PR-1a 依存                                                                               |
-| **PR-1c** | Settings タブの依存欠落表示 (Gemini タブ横展開)。**Gemini API key 等の「あったら便利系」も案内**                                                                                   | ⏳                                                                                            |
-| **PR-1d** | `npx` 利用者向けブラウザ onboarding                                                                                                                                                | ⏳                                                                                            |
-| **PR-1e** | `yarn dev` 開発者向け onboarding skill                                                                                                                                             | 🟡 [plan](docs-ffmpeg-prereq.md) / #1367 (`setup-mulmoclaude` の dependency check 拡張で先行) |
-| **PR-2**  | 各失敗経路 (動画 / PDF / 画像 / MCP / ブリッジ / scheduler) の Web UI 表面化 audit。**自動 disable と組み合わせて運用**                                                            | ⏳                                                                                            |
-| **PR-3**  | `UserFacingError` 型導入 (`message` / `cause` / `remediation` / `docsUrl`)。**Disabled feature の理由表示にも使用**                                                                | ⏳                                                                                            |
-| **PR-4**  | **依存欠落時の graceful degradation (capability gating)** — 起動時に `which` 等で依存を probe し、不足時は該当 feature を runtime disable + warn。落とさない。下記 PR-4 ノート参照 | ⏳                                                                                            |
+| **PR-A**  | README に Prerequisites を明記 (ffmpeg / Docker / claude CLI / Node)                                                                                                               | ✅ [plan](umbrella-deps-ux-1049.md) / #1367                                                                                                       |
+| **PR-1a** | bundled system skill の配布機構 (`--plugin-dir` + `discoverSkills` 拡張)                                                                                                           | ⏳                                                                                                                                                |
+| **PR-1b** | `/check-prereqs` skill — **対話的な依存チェック**。probe → 「入れる/後で/入れない」分岐 → install ガイド → 再確認。下記 PR-1b ノート参照                                           | ⏳ — PR-1a 依存                                                                                                                                   |
+| **PR-1c** | Settings タブの依存欠落表示 (Gemini タブ横展開)。**Gemini API key 等の「あったら便利系」も案内**                                                                                   | ⏳                                                                                                                                                |
+| **PR-1d** | `npx` 利用者向けブラウザ onboarding                                                                                                                                                | ⏳                                                                                                                                                |
+| **PR-1e** | `yarn dev` 開発者向け onboarding skill                                                                                                                                             | 🟡 [plan](umbrella-deps-ux-1049.md) / #1367 (`setup-mulmoclaude` の dependency check 拡張で先行)                                                  |
+| **PR-2**  | 各失敗経路 (動画 / PDF / 画像 / MCP / ブリッジ / scheduler) の Web UI 表面化 audit。**自動 disable と組み合わせて運用**                                                            | ⏳                                                                                                                                                |
+| **PR-3**  | `UserFacingError` 型導入 (`message` / `cause` / `remediation` / `docsUrl`)。**Disabled feature の理由表示にも使用**                                                                | ⏳                                                                                                                                                |
+| **PR-4**  | **依存欠落時の graceful degradation (capability gating)** — 起動時に `which` 等で依存を probe し、不足時は該当 feature を runtime disable + warn。落とさない。下記 PR-4 ノート参照 | 🟡 [plan](feat-optional-deps-1385.md) / #1390 ([#1385](https://github.com/receptron/mulmoclaude/issues/1385) v1 = PR-4a + PR-4b + PR-4d を一括) |
 
 ### PR-1b ノート (新 skill `/check-prereqs`)
 
@@ -50,16 +52,33 @@ Tracks: [#1049](https://github.com/receptron/mulmoclaude/issues/1049) — 依存
 - **mode 引数は不要**: skill 1 個 = 1 mode で十分。pre-flight 用途と setup フロー内呼び出しで挙動を変える必要は無い (どちらも同じ「対話的に依存を確認」が欲しい)
 - **配布**: 開発者向けは project-local `.claude/skills/check-prereqs/` で OK。npx 利用者にも届かせる場合は PR-1a (bundled system skill 機構) が前提
 
-### PR-4 ノート (新規)
+### PR-4 ノート (進捗: v1 shipped via #1390 / [#1385](https://github.com/receptron/mulmoclaude/issues/1385))
 
-レビューア提案を素直に展開した umbrella 行。以下を別 PR として個別に出すことを想定:
+レビューア提案を素直に展開した umbrella 行。当初は PR-4a / 4b / 4c を個別に出して共通点が見えてから 4d に切り出す想定だったが、実装してみると probe レジストリと plugin の `requires` 宣言が並行ではなく共依存だったため、**PR-4a + PR-4b + PR-4d を 1 本にまとめて v1 として #1390 でマージ済み**。PR-4c は依存先が「Gemini API key」という env 変数で、`which`-based probe とは仕組みが異なるため別 PR として残置。
 
-- **PR-4a — Docker 不在 → 自動 `DISABLE_SANDBOX` + warn**: 起動時に `which docker` / `docker info` を probe。不足なら sandbox 無し起動に fallback し、起動 banner / Settings で「Docker 無しで動作中」を案内
-- **PR-4b — ffmpeg 不在 → mulmocast 関連 plugin を runtime disable + warn**: 動画系 tool を tool list から除外、UI で「動画生成は無効 (ffmpeg 未インストール)」と案内
-- **PR-4c — Gemini API key 不在 → 画像生成系 plugin を runtime disable + 案内**: 既存の Settings → Gemini タブを「不足案内」モードで使う
-- **PR-4d — 共通フレーム**: 依存 probe + feature toggle の汎用化。PR-4a–c の重複を吸収
+| 子 PR     | 内容                                                                 | 状態                                              |
+| --------- | -------------------------------------------------------------------- | ------------------------------------------------- |
+| **PR-4a** | Docker 不在 → 自動 `DISABLE_SANDBOX` + warn                          | ✅ #1390 (v1) — `isDockerLive()` を probe override |
+| **PR-4b** | ffmpeg 不在 → mulmocast 関連を runtime disable + warn                | 🟡 #1390 (v1, ルート層 503 ガード)                |
+| **PR-4c** | Gemini API key 不在 → 画像生成系 plugin を runtime disable + 案内    | ⏳ (env probe 別仕組みなので別 PR)                |
+| **PR-4d** | 共通フレーム (`server/system/optionalDeps.ts` + `PluginMeta.requires`) | ✅ #1390 (v1)                                     |
 
-PR-4d を最初に作るとブロッキングになるので、PR-4a / 4b / 4c を個別に出して共通点が見えてから 4d に切り出すのが現実的。
+**v1 (#1390) が提供したもの**:
+
+- `which@^6` 直接依存（root + `packages/mulmoclaude` 両方）
+- `server/system/optionalDeps.ts` = 集中レジストリ + 並列・プロセス存続中キャッシュの存在チェック、`probe` override (docker daemon liveness)
+- 起動時 probe + reason-aware ベル通知 (`not-on-path` / `probe-failed` を出し分け)、i18n 全 8 ロケール lockstep
+- `PluginMeta.requires` 拡張、`presentMulmoScript` が `["ffmpeg"]` を宣言
+- ffmpeg 欠如時、`generateMovie` / `renderBeat` が不透明な spawn エラーではなく **HTTP 503**
+- `test/system/test_optionalDeps*.ts` — CI 実行可能（API キー・実 ffmpeg 不要）な決定論的テスト
+
+**v2 (follow-up issue を切る想定)**:
+
+- MCP ツールリストの cross-process gating（ffmpeg 欠如時に LLM から `presentMulmoScript` ツール自体を隠す）— MCP が別 stdio 子プロセスで組まれるため。v1 はルート 503 ガードで「落ちない」を担保済み
+- `git` / `libreoffice` / `pandoc` / `poppler` のレジストリ追加
+- 警告文へのプラットフォーム別インストールヒント（`brew install ffmpeg` / `apt install` / `choco install`）
+
+PR-4c は umbrella 内で独立して進められる。
 
 ## PR-A + PR-1e 一部 の詳細 (現状 #1367 でカバー)
 


### PR DESCRIPTION
## Summary

- umbrella plan `plans/docs-ffmpeg-prereq.md` を `plans/umbrella-deps-ux-1049.md` に改名。旧称は初期スライス (PR-A) 起点だったが、現状は umbrella #1049 全体の進捗ハブとして機能している実態に合わせた
- PR-4 行 (graceful degradation / capability gating) を ⏳ → 🟡 に更新。#1390 ([#1385](https://github.com/receptron/mulmoclaude/issues/1385) 対応) が v1 として **PR-4a (Docker auto-fallback) + PR-4b (ffmpeg → mulmocast disable) + PR-4d (共通フレーム)** を一括出荷したことを反映
- PR-4 ノートに子 PR 表 (4a/4b/4c/4d) と v1 提供物・v2 follow-up リストを追記
- 進捗管理ルール step 4 を実運用に合わせて改訂 (完了行も plan リンクを `done/` プレフィックス付きで保持 → 後から「なぜそう実装したか」を辿れる)。umbrella 自身を plan として兼用するスライス (PR-A 等) の例外も明記

## Items to Confirm / Review

- **改名先のファイル名**: `umbrella-deps-ux-1049.md` で OK か。代案として `feat-deps-ux-umbrella-1049.md` も検討したが、umbrella は単一機能の feat ではないため接頭辞 `umbrella-` を選定
- **PR-4b の状態 (🟡 / ✅)**: v1 はルート層で 503 ガードしただけで、MCP ツールリストの cross-process gating は v2 行きにした。「ffmpeg → mulmocast disable」の本来の意図は LLM からツール自体を隠すことなので、現状の v1 を 🟡 と表現した。✅ にしたい場合は文言と合わせて見直し
- **v2 行きの線引き**: MCP cross-process gating / git / libreoffice / pandoc / poppler / プラットフォーム別 install ヒントは「umbrella #1049 内の follow-up issue」想定。別 umbrella にしたい場合は指示ください
- **PR-4c (Gemini API key)**: `which`-based probe ではなく env 変数 probe なので別 PR とした。同じ PR-4 行に並べたまま運用するか、別行に切り出すかは要判断
- **進捗管理ルールの例外条項**: umbrella 自身を plan として兼用するスライスの例外を明記したが、将来「READMEs だけ触る docs-only スライス」が増えると条文の射程が広がる可能性。今のところは PR-A の 1 件のみ

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1385 と、それに付随する PR は plans/docs-ffmpeg-prereq.md のどこに当たる？ worktree で更新して。あと、このファイル名がよくないね。適切なものに変えて。

## Changes

- `plans/docs-ffmpeg-prereq.md` → `plans/umbrella-deps-ux-1049.md` (rename via `git mv`、内容も更新)
- 内訳:
  - タイトル: `# docs: ffmpeg prerequisite + setup-mulmoclaude dependency check` → `# umbrella: optional-dependency UX (#1049)`
  - 冒頭にファイル名履歴 note を追加
  - PR 一覧表の PR-4 行を ⏳ → 🟡 にし、#1390 と plan リンクを併記
  - PR-4 ノートを書き直し: 当初の 4a/4b/4c/4d 個別 PR 想定から「v1 で 4a + 4b + 4d を一括出荷」に整理、v1 提供物と v2 follow-up を箇条書きで列挙、4c は env probe で別仕組みなので別行
  - 進捗管理ルール step 4 を改訂、umbrella-self-plan 例外を明記
  - PR-A / PR-1e 行の自己参照リンクを新ファイル名に追従
  - 過去のレビュー時に使った `/tmp/...` の dead path 参照を削除

## Verification

- [x] Codex cross-review 3 イテレーションで LGTM 収束 (iter1: 2件 → 修正、iter2: low 1件 → 修正、iter3: LGTM)
- [x] ファイル内に旧名 `docs-ffmpeg-prereq` の参照が残っていないことを確認（ファイル名履歴 note 1 箇所のみ意図的に保持）
- [x] markdown 表のアライメント・リンクが Codex 側で再レンダリング検証済み
- [ ] (manual) GitHub 上でレンダリングを目視確認、子表が崩れていないか

ドキュメント専用変更のため `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal planning documentation and project tracking procedures.

---

**Note:** This release contains no user-facing features or bug fixes. Changes are limited to internal project documentation and planning file updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->