### PR TITLE
feat(skills): inline category icons in /skills legend

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1104,7 +1104,7 @@ const deMessages = {
     sectionActive: "Aktiv",
     sectionCatalog: "Katalog",
     sectionLegend:
-      "Aktiv: in den Prompt geladen (System = mc- mitgeliefert · Projekt = bearbeitbar · Benutzer = ~/.claude/skills/). Katalog: durchsuchen, ★markieren oder ▶einmal ausführen, ohne den Prompt aufzublähen.",
+      "Aktiv: in den Prompt geladen ({system} System = mc- mitgeliefert · {project} Projekt = bearbeitbar · {user} Benutzer = ~/.claude/skills/). Katalog: durchsuchen, ★markieren oder ▶einmal ausführen, ohne den Prompt aufzublähen.",
     catalogEmpty: "Keine Preset-Skills verfügbar.",
     catalogPresetHeading: "Presets",
     catalogStar: "Markieren",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1088,7 +1088,7 @@ const enMessages = {
     sectionActive: "Active",
     sectionCatalog: "Catalog",
     sectionLegend:
-      "Active: loaded into the prompt (System = mc- bundled · Project = editable · User = ~/.claude/skills/). Catalog: browse, ★ star or ▶ run once without bloating the prompt.",
+      "Active: loaded into the prompt ({system} System = mc- bundled · {project} Project = editable · {user} User = ~/.claude/skills/). Catalog: browse, ★ star or ▶ run once without bloating the prompt.",
     catalogEmpty: "No preset skills available.",
     catalogPresetHeading: "Presets",
     catalogStar: "Star",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1100,7 +1100,7 @@ const esMessages = {
     sectionActive: "Activas",
     sectionCatalog: "Catálogo",
     sectionLegend:
-      "Activas: cargadas en el prompt (Sistema = incluidas mc- · Proyecto = editables · Usuario = ~/.claude/skills/). Catálogo: explora, ★destaca o ▶ejecuta una vez sin inflar el prompt.",
+      "Activas: cargadas en el prompt ({system} Sistema = incluidas mc- · {project} Proyecto = editables · {user} Usuario = ~/.claude/skills/). Catálogo: explora, ★destaca o ▶ejecuta una vez sin inflar el prompt.",
     catalogEmpty: "No hay skills de preajuste disponibles.",
     catalogPresetHeading: "Preajustes",
     catalogStar: "Destacar",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1094,7 +1094,7 @@ const frMessages = {
     sectionActive: "Actives",
     sectionCatalog: "Catalogue",
     sectionLegend:
-      "Actives : chargées dans le prompt (Système = incluses mc- · Projet = modifiables · Utilisateur = ~/.claude/skills/). Catalogue : parcourez, ★ajoutez aux favoris ou ▶exécutez une fois sans alourdir le prompt.",
+      "Actives : chargées dans le prompt ({system} Système = incluses mc- · {project} Projet = modifiables · {user} Utilisateur = ~/.claude/skills/). Catalogue : parcourez, ★ajoutez aux favoris ou ▶exécutez une fois sans alourdir le prompt.",
     catalogEmpty: "Aucune skill de préréglage disponible.",
     catalogPresetHeading: "Préréglages",
     catalogStar: "Favori",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1089,7 +1089,7 @@ const jaMessages = {
     sectionActive: "アクティブ",
     sectionCatalog: "カタログ",
     sectionLegend:
-      "アクティブ: プロンプトに読み込まれる (システム = mc- 同梱 · プロジェクト = 編集可 · ユーザー = ~/.claude/skills/)。カタログ: プロンプトを肥大化させずに閲覧・★スター・▶今だけ実行ができる。",
+      "アクティブ: プロンプトに読み込まれる ({system} システム = mc- 同梱 · {project} プロジェクト = 編集可 · {user} ユーザー = ~/.claude/skills/)。カタログ: プロンプトを肥大化させずに閲覧・★スター・▶今だけ実行ができる。",
     catalogEmpty: "利用できるプリセットスキルがありません。",
     catalogPresetHeading: "プリセット",
     catalogStar: "スター",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1089,7 +1089,7 @@ const koMessages = {
     sectionActive: "활성",
     sectionCatalog: "카탈로그",
     sectionLegend:
-      "활성: 프롬프트에 로드됨 (시스템 = mc- 동봉 · 프로젝트 = 편집 가능 · 사용자 = ~/.claude/skills/). 카탈로그: 프롬프트를 키우지 않고 살펴보거나 ★별 표시 또는 ▶한 번만 실행할 수 있습니다.",
+      "활성: 프롬프트에 로드됨 ({system} 시스템 = mc- 동봉 · {project} 프로젝트 = 편집 가능 · {user} 사용자 = ~/.claude/skills/). 카탈로그: 프롬프트를 키우지 않고 살펴보거나 ★별 표시 또는 ▶한 번만 실행할 수 있습니다.",
     catalogEmpty: "사용 가능한 프리셋 스킬이 없습니다.",
     catalogPresetHeading: "프리셋",
     catalogStar: "별 표시",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1089,7 +1089,7 @@ const ptBRMessages = {
     sectionActive: "Ativas",
     sectionCatalog: "Catálogo",
     sectionLegend:
-      "Ativas: carregadas no prompt (Sistema = inclusas mc- · Projeto = editáveis · Usuário = ~/.claude/skills/). Catálogo: explore, ★favorite ou ▶execute uma vez sem inflar o prompt.",
+      "Ativas: carregadas no prompt ({system} Sistema = inclusas mc- · {project} Projeto = editáveis · {user} Usuário = ~/.claude/skills/). Catálogo: explore, ★favorite ou ▶execute uma vez sem inflar o prompt.",
     catalogEmpty: "Nenhuma skill de preset disponível.",
     catalogPresetHeading: "Presets",
     catalogStar: "Favoritar",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1080,7 +1080,8 @@ const zhMessages = {
     confirmDelete: '要删除技能 "{name}" 吗?将会移除 ~/mulmoclaude/.claude/skills/{name}/SKILL.md。',
     sectionActive: "活动",
     sectionCatalog: "目录",
-    sectionLegend: "活动: 已载入提示词 (系统 = mc- 随附 · 项目 = 可编辑 · 用户 = ~/.claude/skills/)。目录: 浏览、★收藏或▶运行一次而不会撑大提示词。",
+    sectionLegend:
+      "活动: 已载入提示词 ({system} 系统 = mc- 随附 · {project} 项目 = 可编辑 · {user} 用户 = ~/.claude/skills/)。目录: 浏览、★收藏或▶运行一次而不会撑大提示词。",
     catalogEmpty: "没有可用的预设技能。",
     catalogPresetHeading: "预设",
     catalogStar: "收藏",

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -7,13 +7,13 @@
         <p class="text-xs text-gray-400 mt-0.5">{{ t("pluginManageSkills.subheading", { count: skills.length }) }}</p>
         <i18n-t keypath="pluginManageSkills.sectionLegend" tag="p" class="text-xs text-gray-400 mt-0.5">
           <template #system>
-            <span class="material-icons text-xs align-middle text-gray-500" aria-hidden="true">lock</span>
+            <span class="material-icons !text-sm align-middle leading-none text-gray-500" aria-hidden="true">lock</span>
           </template>
           <template #project>
-            <span class="material-icons text-xs align-middle text-green-600" aria-hidden="true">folder</span>
+            <span class="material-icons !text-sm align-middle leading-none text-green-600" aria-hidden="true">folder</span>
           </template>
           <template #user>
-            <span class="material-icons text-xs align-middle text-blue-500" aria-hidden="true">home</span>
+            <span class="material-icons !text-sm align-middle leading-none text-blue-500" aria-hidden="true">home</span>
           </template>
         </i18n-t>
       </div>

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -7,13 +7,13 @@
         <p class="text-xs text-gray-400 mt-0.5">{{ t("pluginManageSkills.subheading", { count: skills.length }) }}</p>
         <i18n-t keypath="pluginManageSkills.sectionLegend" tag="p" class="text-xs text-gray-400 mt-0.5">
           <template #system>
-            <span class="material-icons text-[14px] align-middle text-gray-500" aria-hidden="true">lock</span>
+            <span class="material-icons text-xs align-middle text-gray-500" aria-hidden="true">lock</span>
           </template>
           <template #project>
-            <span class="material-icons text-[14px] align-middle text-green-600" aria-hidden="true">folder</span>
+            <span class="material-icons text-xs align-middle text-green-600" aria-hidden="true">folder</span>
           </template>
           <template #user>
-            <span class="material-icons text-[14px] align-middle text-blue-500" aria-hidden="true">home</span>
+            <span class="material-icons text-xs align-middle text-blue-500" aria-hidden="true">home</span>
           </template>
         </i18n-t>
       </div>

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -5,7 +5,17 @@
       <div>
         <h2 class="text-lg font-semibold text-gray-800">{{ t("pluginManageSkills.heading") }}</h2>
         <p class="text-xs text-gray-400 mt-0.5">{{ t("pluginManageSkills.subheading", { count: skills.length }) }}</p>
-        <p class="text-xs text-gray-400 mt-0.5">{{ t("pluginManageSkills.sectionLegend") }}</p>
+        <i18n-t keypath="pluginManageSkills.sectionLegend" tag="p" class="text-xs text-gray-400 mt-0.5">
+          <template #system>
+            <span class="material-icons text-[14px] align-middle text-gray-500" aria-hidden="true">lock</span>
+          </template>
+          <template #project>
+            <span class="material-icons text-[14px] align-middle text-green-600" aria-hidden="true">folder</span>
+          </template>
+          <template #user>
+            <span class="material-icons text-[14px] align-middle text-blue-500" aria-hidden="true">home</span>
+          </template>
+        </i18n-t>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

`/skills` のサブヘッダーにある凡例 (sectionLegend) に、`System` / `Project` / `User` のラベル横にカテゴリアイコン (lock / folder / home) をインライン挿入。サイドバー各行末尾に表示されているソース判別アイコンと凡例が視覚的に一致するようになる。

- 凡例の `<p>` を `<i18n-t>` + named slots (`{system}` / `{project}` / `{user}`) に置き換え
- スロット内容は `skillBadge()` が各行で使っているのと同じ icon / 色マッピング (lock=gray-500 / folder=green-600 / home=blue-500)
- 全 8 ロケール (en/ja/zh/ko/es/pt-BR/fr/de) のプレースホルダーを lockstep で更新
- icon サイズは最終的に `!text-sm` (14px) + `leading-none`、サイドバー badge と同サイズに統一

<img width="996" height="115" alt="image" src="https://github.com/user-attachments/assets/3902ea4c-4049-409b-b740-ae7d1333b7e6" />

## Items to Confirm / Review

- **`!important` の必要性**: `material-icons` の base CSS が `font-size: 24px` を持つため、`text-xs` / `text-sm` だけでは override されず icon が 24px のままだった。Tailwind の `!` (important) を付けて初めて効いた (`SessionHistoryPanel.vue:65` の overflow menu icon と同パターン)。グローバルに material-icons の base を上書きする方が筋が良いか、call-site で `!` を付ける現方針で良いか。
- **icon サイズ 14px**: 12px (`!text-xs`) も試したが lock / folder / home の glyph が潰れて読みにくく、14px に落ち着けた。row badge とも揃う。
- **i18n placeholder 位置**: 全ロケールで「icon → ラベル」の順序 (`{system} System = ...`)。RTL / 縦書き想定は無いので問題ない想定。
- **`<i18n-t>` slot 機能の test カバレッジ**: Codex から「slot interpolation / 欠落時 fallback の e2e が無い」と nit 指摘あり。vue-i18n フレームワーク機能 + vue-tsc で 8 ロケールの型保証はされているため deferred。

## User Prompt

- `/skills` ページのサブヘッダー第二行に出ている凡例 (`システム = mc- 同梱 · プロジェクト = 編集可 · ユーザー = ~/.claude/skills/`) は現状ラベルだけで、サイドバー各行末尾のソース判別アイコンと視覚的に紐づかない。ここにアイコンを追加できないか。
- 当初 14px で実装したものを「アイコンを文字 (text-xs=12px) と同じサイズにできないか」と依頼 → 12px に下げたが material-icons の base が 24px のため実際は反映されず → スクリーンショットで「小さくなっていない」と指摘 → 「やはり 14px の方が良い」と最終判断、`!important` で 14px に強制。

## 実装アプローチ

1. **`<i18n-t>` 化** ([src/plugins/manageSkills/View.vue:8-19](src/plugins/manageSkills/View.vue#L8-L19)) — 既存の `t('pluginManageSkills.sectionLegend')` を `<i18n-t keypath=..>` に置換、3 つの named slot (`#system` / `#project` / `#user`) を定義しそれぞれ material-icons span を配置。
2. **i18n 文字列に placeholder 追加** — 全 8 ロケールで `システム` → `{system} システム` のように icon プレースホルダー + ラベルの順で挿入。原文の翻訳は変更せず placeholder 挿入のみ。
3. **icon サイズ確定** — 試行錯誤の末 `!text-sm align-middle leading-none text-<colour>` で固定。`!important` で `.material-icons { font-size: 24px }` を上書き、`leading-none` で `text-xs` 段落の line-height を膨らませない。

## 確認チェック

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` ✓
- Codex cross-review (pre-PR mode, iteration 1): **LGTM** (1 nit: e2e for legend = deferred)
- ローカルブラウザでの見え方確認済み (icon = ラベル文字とほぼ同等の高さ、14px)

## コミット履歴

このブランチには 3 commit が積まれている (試行錯誤の経緯がそのまま残っている):

1. `9a79abd9 feat(skills): inline category icons in /skills legend` — `<i18n-t>` 化 + 全 8 ロケール更新 (icon は `text-[14px]`、`!important` 無しなので実際は 24px 表示)
2. `0cb7fde8 fix(skills): match legend icon size to body text` — `text-xs` (12px) に変更。ただし `!important` 無しのため `.material-icons` の 24px が勝ち、視覚的に変化なし
3. `40fedbda fix(skills): force legend icon to 14px with !important + leading-none` — `!text-sm` + `leading-none` で 14px に強制、最終形

3 を直接 1 に squash する方が綺麗だが、`!important` が必要だった経緯 / なぜ 12px ではなく 14px なのか の理由が history に残る方が後から見て分かりやすいのでそのまま残してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)