### PR TITLE
feat(sessions): expose narrow liveIsRunning predicate (#1195)

### DIFF
--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -578,23 +578,16 @@ function shouldKeepSessions(): boolean {
  * 409 silently from the UI's point of view, the test passes, and
  * the file stays on disk.
  *
- * Predicate-asymmetry note (codex iter-2): the summary `isRunning`
- * we read here is `live.isRunning || pendingGenerations.length>0`
- * (server/api/routes/sessions.ts:150), but `DELETE /api/sessions/:id`
- * only checks `getSession()?.isRunning` proper (line 401), without
- * pendingGenerations. We intentionally wait on the STRICTER summary
- * predicate because:
- *   * the summary is the only `isRunning`-shaped field exposed on
- *     the public API today — querying just `live.isRunning` would
- *     need a server-side endpoint addition
- *   * waiting too long is the safe direction (we never delete
- *     before the server is ready); waiting too SHORT is the
- *     regression we are explicitly closing
- *   * for every spec in this suite, the test already waits for
- *     the user-visible artifact to render (Download Movie button
- *     for L-04, etc.) before reaching cleanup — by then
- *     pendingGenerations is empty in practice, so the stricter
- *     predicate doesn't add measurable wall time
+ * Predicate-asymmetry resolution (#1195): we now poll the summary's
+ * `liveIsRunning` field, which the server sets byte-identical to the
+ * `DELETE /api/sessions/:id` 409 gate (`getSession()?.isRunning`,
+ * server/api/routes/sessions.ts). The old broad `isRunning`
+ * (`live.isRunning || pendingGenerations.length>0`) is still
+ * exposed for the sidebar busy indicator but is NOT what we wait on
+ * here — waiting on it could over-block through image/movie
+ * post-processing even though DELETE was already safe. `false ⇒
+ * DELETE accepted` is now an exact guarantee, not a conservative
+ * over-approximation.
  *
  * Runs the fetch inside `page.evaluate` so the browser's bearer
  * header (read from `<meta name="mulmoclaude-auth">`) is reused
@@ -642,7 +635,7 @@ async function probeSessionIdle(args: { sid: string; listUrl: string; perAttempt
       signal: AbortSignal.timeout(perAttemptTimeoutMs),
     });
     if (!res.ok) return { ok: false as const, reason: `GET ${listUrl} returned HTTP ${res.status} ${res.statusText}` };
-    const data = (await res.json()) as { sessions?: { id: string; isRunning?: boolean }[] };
+    const data = (await res.json()) as { sessions?: { id: string; liveIsRunning?: boolean }[] };
     // Fail closed on a malformed payload (codex iter-4: missing /
     // null / non-array `sessions` field would otherwise let
     // `?.find()` return undefined → stillRunning=false → cleanup
@@ -651,8 +644,13 @@ async function probeSessionIdle(args: { sid: string; listUrl: string; perAttempt
     if (!Array.isArray(data.sessions)) {
       return { ok: false as const, reason: `GET ${listUrl} returned an unexpected payload (no sessions array)` };
     }
+    // Poll the NARROW predicate (#1195). `liveIsRunning` mirrors
+    // the DELETE 409 gate exactly, so `false` proves DELETE will be
+    // accepted — no over-waiting on lingering pendingGenerations
+    // (the old broad `isRunning` could stay true through movie /
+    // image post-processing even though DELETE was already safe).
     const session = data.sessions.find((row) => row.id === sid);
-    return { ok: true as const, stillRunning: session?.isRunning === true };
+    return { ok: true as const, stillRunning: session?.liveIsRunning === true };
   } catch (err) {
     // Network drop / AbortSignal timeout / JSON parse throw — anything
     // that would otherwise surface as an opaque page.evaluate failure
@@ -709,10 +707,11 @@ export async function deleteSession(page: Page, sessionId: string): Promise<void
     }
     // Then wait for the SERVER side to agree the session is no
     // longer running — `thinking-indicator` going hidden is a UI
-    // signal, but `live.isRunning || pendingGenerations` lingers a
-    // little longer on the server. Skipping this wait is exactly
-    // the regression that surfaced as a silent 409 inside the
-    // route handler while the UI dance reported success.
+    // signal, but the server's live.isRunning lingers a little
+    // longer. waitForSessionIdle polls `liveIsRunning` (#1195),
+    // which matches the DELETE 409 gate exactly. Skipping this
+    // wait is the regression that surfaced as a silent 409 inside
+    // the route handler while the UI dance reported success.
     await waitForSessionIdle(page, sessionId);
     // The session-row kebab menu lives inside the session-history
     // side panel, which is collapsed by default. Open it via the

--- a/plans/feat-live-isrunning-1195.md
+++ b/plans/feat-live-isrunning-1195.md
@@ -1,0 +1,48 @@
+# feat: expose narrow `liveIsRunning` predicate (#1195)
+
+## Problem
+
+`GET /api/sessions` summary `isRunning` is the BROAD predicate
+(`live.isRunning || pendingGenerations.length > 0`) but
+`DELETE /api/sessions/:id`'s 409 gate is the NARROW one
+(`getSession()?.isRunning` only). No public field exposes the
+narrow predicate, so cleanup-style callers
+(`e2e-live waitForSessionIdle`) over-wait on lingering
+pendingGenerations even though DELETE is already safe — up to a
+30s timeout of wasted wall time per spec.
+
+## Fix (issue option A)
+
+Add an additive, optional `liveIsRunning` field to
+`SessionSummary` that is byte-identical to the DELETE gate. Leave
+the broad `isRunning` (and its sidebar-indicator semantics)
+untouched.
+
+### Changes
+
+1. `server/api/routes/sessions.ts`
+   - `SessionSummary.liveIsRunning?: boolean`
+   - `buildSessionSummary`: `summary.liveIsRunning = live.isRunning`
+2. `src/types/session.ts` — mirror the field (i18n/type lockstep)
+3. `e2e-live/fixtures/live-chat.ts`
+   - `probeSessionIdle` polls `liveIsRunning` not `isRunning`
+   - refresh the predicate-asymmetry block comment + the
+     `deleteSession` inline note
+
+## Non-goals
+
+- No change to existing callers' behavior (purely additive field;
+  `isRunning` semantics preserved for the sidebar busy indicator).
+- No unit test for `buildSessionSummary` — it's a non-exported
+  internal helper and the predicate is one line; the daily
+  e2e-live no-LLM matrix exercises `waitForSessionIdle` →
+  `liveIsRunning` on every spec's cleanup, which is the real
+  integration surface. Adding an export/mocked-store unit test
+  would be disproportionate (matches the existing repo pattern —
+  no `buildSessionSummary` unit test exists today).
+
+## Verification
+
+- `yarn typecheck` / `yarn lint` green
+- daily `e2e-live` matrix cleanup now polls the exact DELETE gate
+  → no over-wait on pendingGenerations

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -79,7 +79,18 @@ export interface SessionSummary {
   isBookmarked?: boolean;
   // Live state from the in-memory session store. Absent when the
   // session has no active entry in the store (i.e. idle / historical).
+  //
+  // `isRunning` is the BROAD predicate: agent turn live OR any
+  // background generation (image/audio/movie) still pending. Drives
+  // the sidebar "busy" indicator that must stay lit across nav.
+  //
+  // `liveIsRunning` is the NARROW predicate: exactly the
+  // `DELETE /api/sessions/:id` 409 gate (`getSession()?.isRunning`).
+  // Exposed for cleanup-style callers (e2e-live `waitForSessionIdle`)
+  // that need to poll "is DELETE accepted yet" without over-waiting
+  // on lingering pendingGenerations. See issue #1195.
   isRunning?: boolean;
+  liveIsRunning?: boolean;
   hasUnread?: boolean;
   statusMessage?: string;
 }
@@ -149,6 +160,10 @@ function buildSessionSummary(
     // "busy" even when the agent turn has ended, so the sidebar
     // indicator stays lit across view navigation.
     summary.isRunning = live.isRunning || Object.keys(live.pendingGenerations).length > 0;
+    // Narrow predicate — must stay byte-identical to the DELETE
+    // 409 gate (`getSession(sessionId)?.isRunning`) so a caller
+    // polling this can trust "false ⇒ DELETE will be accepted".
+    summary.liveIsRunning = live.isRunning;
     summary.statusMessage = live.statusMessage;
   }
   return summary;

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -63,7 +63,13 @@ export interface SessionSummary {
   isBookmarked?: boolean;
   // Live state from the server session store (present when the
   // session has an active in-memory entry on the server).
+  //
+  // `isRunning` — broad: agent turn live OR background generation
+  // pending. Drives the sidebar busy indicator.
+  // `liveIsRunning` — narrow: mirrors the DELETE 409 gate exactly
+  // (#1195). `false` ⇒ a DELETE on this session will be accepted.
   isRunning?: boolean;
+  liveIsRunning?: boolean;
   hasUnread?: boolean;
   statusMessage?: string;
 }


### PR DESCRIPTION
## Summary

Resolves the `isRunning` predicate asymmetry described in #1195.

- `GET /api/sessions` summary `isRunning` is **broad**: `live.isRunning || pendingGenerations.length > 0` (drives the sidebar busy indicator).
- `DELETE /api/sessions/:id`'s 409 gate is **narrow**: `getSession()?.isRunning` only.

No public field exposed the narrow predicate, so cleanup-style callers (`e2e-live waitForSessionIdle`) had to poll the broad one and could over-wait up to the 30s timeout on lingering image/movie post-processing even though DELETE was already safe.

## Changes (issue option A — additive only)

1. `server/api/routes/sessions.ts` — `SessionSummary.liveIsRunning?: boolean`, set byte-identical to the DELETE gate (`summary.liveIsRunning = live.isRunning`). Broad `isRunning` untouched.
2. `src/types/session.ts` — mirror the field (type lockstep).
3. `e2e-live/fixtures/live-chat.ts` — `probeSessionIdle` polls `liveIsRunning`; predicate-asymmetry block comment + `deleteSession` inline note refreshed.

## Items to Confirm / Review

- **Purely additive**: existing callers see no behavior change; `isRunning` keeps its broad sidebar semantics.
- **No `buildSessionSummary` unit test**: it's a non-exported one-line predicate, and the daily `e2e-live` no-LLM matrix exercises `waitForSessionIdle → liveIsRunning` on every spec cleanup (the real integration surface). Adding an export/mocked-store unit test would be disproportionate and there's no existing `buildSessionSummary` unit test to extend. Rationale in `plans/feat-live-isrunning-1195.md`.
- The narrow predicate must stay byte-identical to the DELETE gate — called out with a comment at both sites so a future change to one is caught against the other.

## Test plan

- [x] `yarn typecheck` / `yarn lint` green
- [ ] CI green
- [ ] Next daily `e2e-live` cron: cleanup no longer over-waits on pendingGenerations (wall-time drop on movie/image specs)

Closes #1195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)