### PR TITLE
fix(StackView): scope flex-1 neutralisation to vertical flex (#1277)

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -483,7 +483,16 @@ onUnmounted(() => {
 .stack-natural :deep(.overflow-x-auto) {
   overflow: visible !important;
 }
-.stack-natural :deep(.flex-1) {
+/* Scope the flex-1 neutralisation to VERTICAL flex contexts only
+   (#1277). The intent was always "don't let a column child's
+   flex-1 collapse the natural content height in stack mode". The
+   old bare `:deep(.flex-1)` also hit `.flex-1` children of ROW
+   containers (e.g. a plugin `<summary>`'s description wrapper),
+   freezing them at `flex: 0 0 auto` so they stopped growing /
+   wrapping horizontally (PR #1276 had to work around this
+   plugin-side). Restricting to `.flex-col > .flex-1` keeps the
+   column fix and leaves row layouts alone. */
+.stack-natural :deep(.flex-col > .flex-1) {
   flex: 0 0 auto !important;
 }
 /* presentHtml's View.vue uses CSS-defined (not Tailwind class)


### PR DESCRIPTION
## Summary

`src/components/StackView.vue`'s `.stack-natural :deep(.flex-1)` rule matched **every** `.flex-1` descendant of a stack-natural plugin regardless of flex direction, freezing ROW-context children at `flex: 0 0 auto` so they stopped growing / wrapping horizontally.

PR #1276 had to work around this plugin-side (skill `<summary>` description wrapper rewritten to `grow shrink basis-0`). The root cause is the over-broad selector — a latent foot-gun for every future stack-natural plugin.

## Fix

Issue #1277 案1: restrict to `.flex-col > .flex-1`. The original intent (don't let a column child's flex-1 collapse natural content height in stack mode) is preserved; row layouts are left alone. One-line selector change + rationale comment.

## Items to Confirm / Review

- Pure CSS scope-narrowing, no behavior change for the column case it was designed for.
- The `:deep(.flex-col > .flex-1)` direct-child combinator: intentional — only neutralise a flex-1 whose immediate parent is the column container, which is exactly the document-plugin shape the rule targets.

## Test plan

- [x] `yarn typecheck` / `yarn lint` green
- [ ] Stack view: presentDocument / presentChart still flow at natural height (column case unchanged)
- [ ] A plugin using `.flex-1` in a row context (e.g. skill `<summary>`) now grows/wraps correctly in stack mode

Closes #1277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)