### PR TITLE
feat(skills): external-repo Update button (C3-scoped, #1383)

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -396,7 +396,7 @@ already-starred skills in Active (star = fork).
 │ │ ▼ CATALOG            4  │                                       │ │
 │ │   Presets               │  (catalog row → preset/external detail│ │
 │ │ ├ [skill-catalog-…] ★   │   with ★ Star / ▶ Run once)           │ │
-│ │ ▼ owner/repo  (n) [🗑]   │                                       │ │
+│ │ ▼ owner/repo (n) [⟳][🗑] │                                       │ │
 │ │ ├ [skill-catalog-…] ☁   │                                       │ │
 │ │ [+ Add skill repository]│                                       │ │
 │ └─────────────────────────┴───────────────────────────────────────┘ │
@@ -411,6 +411,7 @@ Testids: `skill-section-{key}` / `skill-section-toggle-{key}` /
 derived slug);
 `skill-catalog-empty` when the catalog has no presets;
 `skill-catalog-repo-{repoId}` / `skill-catalog-repo-toggle-{repoId}` /
+`skill-catalog-repo-update-{repoId}` (re-fetch upstream) /
 `skill-catalog-repo-uninstall-{repoId}` per external-repo subgroup;
 `skill-catalog-add-repo` + `skill-add-repo-modal` /
 `skill-add-repo-url` / `skill-add-repo-subpath` /

--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -549,4 +549,16 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     await page.getByTestId("skill-catalog-repo-uninstall-anthropics-skills").click();
     await expect.poll(() => calls.deleted).toContain("anthropics-skills");
   });
+
+  test("Update button re-installs with the repo's recorded url/subpath", async ({ page }) => {
+    const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
+    await setupExternalCatalog(page, calls);
+    await page.goto("/chat/skills-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+
+    await page.getByTestId("skill-catalog-repo-update-anthropics-skills").click();
+    await expect.poll(() => calls.install.length).toBe(1);
+    expect(calls.install[0]).toMatchObject({ url: "https://github.com/anthropics/skills", subpath: "skills" });
+  });
 });

--- a/plans/feat-skill-catalog-external-c3-update-1383.md
+++ b/plans/feat-skill-catalog-external-c3-update-1383.md
@@ -1,0 +1,61 @@
+# C3 (scoped) — external-repo Update button (#1383)
+
+Final slice of #1383 (PR-C). C1 (#1386 backend) + C2 (#1392 UI)
+merged. This delivers **only the per-repo Update button**; the rest of
+the original C3 (scheduler / SHA-pin / update notifications) is
+**de-scoped** — #1383 closes after this lands.
+
+## Why no backend change
+
+C1's `installExternalRepo({ url, subpath?, ref? })` already:
+fetches latest (`cloneOrUpdate` → `git fetch --depth=1 HEAD` +
+checkout), wipes + re-copies the catalog dir, rewrites `.source.json`
+with the new SHA. The repoId-collision guard passes for the same repo
+(same canonical URL). So **"update" == re-install with the repo's
+recorded url/subpath** — the frontend already has `repo.url` /
+`repo.subpath` from `GET /external/repos`. No new endpoint.
+
+Star = fork still holds: re-install only refreshes the catalog layer;
+already-starred copies in `.claude/skills/` are untouched (consistent
+with uninstall semantics).
+
+## Changes (frontend only)
+
+- `src/plugins/manageSkills/View.vue`
+  - `updatingRepoId` ref (spinner / disable gate, like
+    `uninstallingRepoId`).
+  - `updateRepo(repo: ExternalRepo)`: POST `externalReposInstall`
+    with `{ url: repo.url, subpath?: repo.subpath }`; on ok
+    `Promise.all([loadExternalRepos(), loadCatalog()])`; on error set
+    `catalogError`. No modal involved.
+  - Repo-header row: add a refresh icon-button between the count and
+    the uninstall button, `data-testid="skill-catalog-repo-update-{repoId}"`,
+    disabled while `updatingRepoId === repoId`.
+- i18n: one new key `pluginManageSkills.catalogUpdateRepo` across all
+  8 locales (lockstep).
+- `docs/ui-cheatsheet.md`: add the update button + testid to the
+  `/skills` block.
+
+## Tests
+
+`e2e/tests/skills.spec.ts` — extend the external-catalog describe:
+click `skill-catalog-repo-update-anthropics-skills`, assert a POST to
+`/api/skills/external/repos` fired with the repo's url/subpath and the
+list refreshed. (Reuses the existing `setupExternalCatalog` mocks; the
+install route already records POST bodies.)
+
+## Out of scope (closing #1383, not deferring)
+
+- Scheduler / periodic auto-update
+- SHA-pin / ref lock UI
+- "upstream has changes" bell notifications
+
+## Acceptance
+
+- Each installed repo shows an Update button; clicking it re-fetches
+  upstream and refreshes the catalog (new skills appear, removed ones
+  drop) without touching starred copies.
+- 8 locales updated; cheatsheet updated; e2e + full suite green;
+  `format`/`lint`/`typecheck`/`build`/`test` clean.
+- #1383 closed after merge with a note that scheduler/SHA-pin/
+  notifications were intentionally de-scoped.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1127,6 +1127,7 @@ const deMessages = {
     catalogAddRepoSubmit: "Installieren",
     catalogAddRepoSuggestions: "Vorgeschlagene Repositories",
     catalogUninstallRepo: "Repository deinstallieren",
+    catalogUpdateRepo: "Repository aktualisieren (neueste Version erneut laden)",
     catalogUninstallConfirm: "Dieses Repository deinstallieren? Bereits mit Stern markierte Skills bleiben in deiner aktiven Liste.",
     catalogRepoInstalling: "Installiere…",
     catalogRepoEmpty: "In diesem Repository wurden keine Skills gefunden.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1111,6 +1111,7 @@ const enMessages = {
     catalogAddRepoSubmit: "Install",
     catalogAddRepoSuggestions: "Suggested repositories",
     catalogUninstallRepo: "Uninstall repository",
+    catalogUpdateRepo: "Update repository (re-fetch latest)",
     catalogUninstallConfirm: "Uninstall this repository? Skills you already starred stay in your active list.",
     catalogRepoInstalling: "Installing…",
     catalogRepoEmpty: "No skills found in this repository.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1123,6 +1123,7 @@ const esMessages = {
     catalogAddRepoSubmit: "Instalar",
     catalogAddRepoSuggestions: "Repositorios sugeridos",
     catalogUninstallRepo: "Desinstalar repositorio",
+    catalogUpdateRepo: "Actualizar repositorio (volver a obtener lo último)",
     catalogUninstallConfirm: "¿Desinstalar este repositorio? Las skills que ya marcaste con estrella permanecen en tu lista activa.",
     catalogRepoInstalling: "Instalando…",
     catalogRepoEmpty: "No se encontraron skills en este repositorio.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1117,6 +1117,7 @@ const frMessages = {
     catalogAddRepoSubmit: "Installer",
     catalogAddRepoSuggestions: "Dépôts suggérés",
     catalogUninstallRepo: "Désinstaller le dépôt",
+    catalogUpdateRepo: "Mettre à jour le dépôt (récupérer la dernière version)",
     catalogUninstallConfirm: "Désinstaller ce dépôt ? Les skills déjà mises en favori restent dans votre liste active.",
     catalogRepoInstalling: "Installation…",
     catalogRepoEmpty: "Aucune skill trouvée dans ce dépôt.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1112,6 +1112,7 @@ const jaMessages = {
     catalogAddRepoSubmit: "インストール",
     catalogAddRepoSuggestions: "おすすめリポジトリ",
     catalogUninstallRepo: "リポジトリをアンインストール",
+    catalogUpdateRepo: "リポジトリを更新（最新を再取得）",
     catalogUninstallConfirm: "このリポジトリをアンインストールしますか？ すでに★したスキルはアクティブ一覧に残ります。",
     catalogRepoInstalling: "インストール中…",
     catalogRepoEmpty: "このリポジトリにスキルが見つかりません。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1112,6 +1112,7 @@ const koMessages = {
     catalogAddRepoSubmit: "설치",
     catalogAddRepoSuggestions: "추천 저장소",
     catalogUninstallRepo: "저장소 제거",
+    catalogUpdateRepo: "저장소 업데이트(최신 다시 가져오기)",
     catalogUninstallConfirm: "이 저장소를 제거할까요? 이미 별표한 스킬은 활성 목록에 남습니다.",
     catalogRepoInstalling: "설치 중…",
     catalogRepoEmpty: "이 저장소에서 스킬을 찾을 수 없습니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1112,6 +1112,7 @@ const ptBRMessages = {
     catalogAddRepoSubmit: "Instalar",
     catalogAddRepoSuggestions: "Repositórios sugeridos",
     catalogUninstallRepo: "Desinstalar repositório",
+    catalogUpdateRepo: "Atualizar repositório (rebuscar o mais recente)",
     catalogUninstallConfirm: "Desinstalar este repositório? As skills que você já marcou com estrela permanecem na sua lista ativa.",
     catalogRepoInstalling: "Instalando…",
     catalogRepoEmpty: "Nenhuma skill encontrada neste repositório.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1103,6 +1103,7 @@ const zhMessages = {
     catalogAddRepoSubmit: "安装",
     catalogAddRepoSuggestions: "推荐仓库",
     catalogUninstallRepo: "卸载仓库",
+    catalogUpdateRepo: "更新仓库（重新获取最新）",
     catalogUninstallConfirm: "卸载此仓库？已加星的技能仍保留在活动列表中。",
     catalogRepoInstalling: "安装中…",
     catalogRepoEmpty: "此仓库中未找到技能。",

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -158,6 +158,8 @@
                   :data-testid="`skill-catalog-repo-update-${group.repo.repoId}`"
                   :disabled="updatingRepoId === group.repo.repoId"
                   :title="t('pluginManageSkills.catalogUpdateRepo')"
+                  :aria-label="t('pluginManageSkills.catalogUpdateRepo')"
+                  :aria-busy="updatingRepoId === group.repo.repoId"
                   @click="updateRepo(group.repo)"
                 >
                   <span class="material-icons text-sm" :class="updatingRepoId === group.repo.repoId ? 'animate-spin' : ''" aria-hidden="true">refresh</span>
@@ -168,6 +170,8 @@
                   :data-testid="`skill-catalog-repo-uninstall-${group.repo.repoId}`"
                   :disabled="uninstallingRepoId === group.repo.repoId"
                   :title="t('pluginManageSkills.catalogUninstallRepo')"
+                  :aria-label="t('pluginManageSkills.catalogUninstallRepo')"
+                  :aria-busy="uninstallingRepoId === group.repo.repoId"
                   @click="uninstallRepo(group.repo.repoId)"
                 >
                   <span class="material-icons text-sm" aria-hidden="true">delete_outline</span>

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -154,6 +154,16 @@
                 </button>
                 <button
                   type="button"
+                  class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-blue-600 disabled:opacity-40"
+                  :data-testid="`skill-catalog-repo-update-${group.repo.repoId}`"
+                  :disabled="updatingRepoId === group.repo.repoId"
+                  :title="t('pluginManageSkills.catalogUpdateRepo')"
+                  @click="updateRepo(group.repo)"
+                >
+                  <span class="material-icons text-sm" :class="updatingRepoId === group.repo.repoId ? 'animate-spin' : ''" aria-hidden="true">refresh</span>
+                </button>
+                <button
+                  type="button"
                   class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-red-600 disabled:opacity-40"
                   :data-testid="`skill-catalog-repo-uninstall-${group.repo.repoId}`"
                   :disabled="uninstallingRepoId === group.repo.repoId"
@@ -597,6 +607,7 @@ const addRepoError = ref<string | null>(null);
 const addRepoBusy = ref(false);
 const suggestions = ref<ExternalSuggestion[]>([]);
 const uninstallingRepoId = ref<string | null>(null);
+const updatingRepoId = ref<string | null>(null);
 // Single in-flight gate covers Star / Run once on the selected
 // entry so a slow request doesn't let the user fire a second
 // action mid-flight.
@@ -730,6 +741,7 @@ watch(
     addRepoOpen.value = false;
     addRepoError.value = null;
     uninstallingRepoId.value = null;
+    updatingRepoId.value = null;
   },
 );
 
@@ -808,6 +820,25 @@ async function uninstallRepo(repoId: string): Promise<void> {
   // Starred copies survive uninstall (backend-guaranteed, C1) — pull
   // the active list so any starred-from-this-repo rows stay visible.
   await Promise.all([loadExternalRepos(), loadCatalog(), refreshActiveList()]);
+}
+
+// "Update" == re-install with the repo's recorded url/subpath. C1's
+// install path re-fetches upstream HEAD, wipes + re-copies the
+// catalog dir, and rewrites `.source.json` with the new SHA. Starred
+// copies under `.claude/skills/` are untouched (catalog-layer only).
+async function updateRepo(repo: ExternalRepo): Promise<void> {
+  if (updatingRepoId.value !== null) return;
+  updatingRepoId.value = repo.repoId;
+  const body: Record<string, string> = { url: repo.url };
+  if (repo.subpath) body.subpath = repo.subpath;
+  const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
+  updatingRepoId.value = null;
+  if (!response.ok) {
+    catalogError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
+    return;
+  }
+  catalogError.value = null;
+  await Promise.all([loadExternalRepos(), loadCatalog()]);
 }
 
 async function refreshActiveList(): Promise<void> {

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -793,37 +793,43 @@ async function installRepo(url: string, subpath?: string): Promise<void> {
   }
   addRepoBusy.value = true;
   addRepoError.value = null;
-  const trimmedSubpath = subpath?.trim();
-  const body: Record<string, string> = { url: trimmedUrl };
-  if (trimmedSubpath) body.subpath = trimmedSubpath;
-  const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
-  addRepoBusy.value = false;
-  if (!response.ok) {
-    addRepoError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
-    return;
+  try {
+    const trimmedSubpath = subpath?.trim();
+    const body: Record<string, string> = { url: trimmedUrl };
+    if (trimmedSubpath) body.subpath = trimmedSubpath;
+    const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
+    if (!response.ok) {
+      addRepoError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
+      return;
+    }
+    addRepoOpen.value = false;
+    await Promise.all([loadExternalRepos(), loadCatalog()]);
+  } finally {
+    addRepoBusy.value = false;
   }
-  addRepoOpen.value = false;
-  await Promise.all([loadExternalRepos(), loadCatalog()]);
 }
 
 async function uninstallRepo(repoId: string): Promise<void> {
   if (uninstallingRepoId.value !== null) return;
   if (typeof window !== "undefined" && !window.confirm(t("pluginManageSkills.catalogUninstallConfirm"))) return;
   uninstallingRepoId.value = repoId;
-  const response = await apiDelete<{ uninstalled: true }>(buildRouteUrl(endpoints.externalReposRemove, { repoId }));
-  uninstallingRepoId.value = null;
-  if (!response.ok) {
-    catalogError.value = t("pluginManageSkills.errCatalogRepoUninstallFailed", { error: response.error });
-    return;
+  try {
+    const response = await apiDelete<{ uninstalled: true }>(buildRouteUrl(endpoints.externalReposRemove, { repoId }));
+    if (!response.ok) {
+      catalogError.value = t("pluginManageSkills.errCatalogRepoUninstallFailed", { error: response.error });
+      return;
+    }
+    catalogError.value = null;
+    if (selectedCatalog.value?.repoId === repoId) {
+      selectedCatalog.value = null;
+      catalogDetail.value = null;
+    }
+    // Starred copies survive uninstall (backend-guaranteed, C1) — pull
+    // the active list so any starred-from-this-repo rows stay visible.
+    await Promise.all([loadExternalRepos(), loadCatalog(), refreshActiveList()]);
+  } finally {
+    uninstallingRepoId.value = null;
   }
-  catalogError.value = null;
-  if (selectedCatalog.value?.repoId === repoId) {
-    selectedCatalog.value = null;
-    catalogDetail.value = null;
-  }
-  // Starred copies survive uninstall (backend-guaranteed, C1) — pull
-  // the active list so any starred-from-this-repo rows stay visible.
-  await Promise.all([loadExternalRepos(), loadCatalog(), refreshActiveList()]);
 }
 
 // "Update" == re-install with the repo's recorded url/subpath. C1's
@@ -833,16 +839,22 @@ async function uninstallRepo(repoId: string): Promise<void> {
 async function updateRepo(repo: ExternalRepo): Promise<void> {
   if (updatingRepoId.value !== null) return;
   updatingRepoId.value = repo.repoId;
-  const body: Record<string, string> = { url: repo.url };
-  if (repo.subpath) body.subpath = repo.subpath;
-  const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
-  updatingRepoId.value = null;
-  if (!response.ok) {
-    catalogError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
-    return;
+  // try/finally so the in-flight gate always clears even if the
+  // request throws — otherwise the button stays disabled forever
+  // (same hardening as runOnceCatalogEntry, Codex review #1374).
+  try {
+    const body: Record<string, string> = { url: repo.url };
+    if (repo.subpath) body.subpath = repo.subpath;
+    const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
+    if (!response.ok) {
+      catalogError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
+      return;
+    }
+    catalogError.value = null;
+    await Promise.all([loadExternalRepos(), loadCatalog()]);
+  } finally {
+    updatingRepoId.value = null;
   }
-  catalogError.value = null;
-  await Promise.all([loadExternalRepos(), loadCatalog()]);
 }
 
 async function refreshActiveList(): Promise<void> {


### PR DESCRIPTION
## Summary

Final slice of #1383 PR-C. Adds a per-repo **Update** button to the hierarchical external-skill catalog (C2): re-fetches upstream and refreshes the catalog layer. **No backend change** — C1's install path already re-fetches HEAD + wipes/re-copies + rewrites `.source.json` with the new SHA, so "update" == re-install with the repo's recorded url/subpath (the frontend already has both from `GET /external/repos`).

The rest of the original C3 — scheduler / SHA-pin / update notifications — is **intentionally de-scoped**. #1383 closes when this merges.

## Items to Confirm / Review

- **Frontend-only**, no `server/` changes. Reuses `POST /api/skills/external/repos` with the stored `{url, subpath?}`.
- **Star = fork preserved**: re-install only refreshes `data/skills/catalog/external/<repoId>/`; already-starred copies in `.claude/skills/` are untouched (same as uninstall).
- Button sits between the per-repo count and the uninstall button; spins while in flight; gated by `updatingRepoId`.

## User Prompt

"とりあえず更新ボタンだけ作ってcloseしよう" — implement just the C3 Update button, de-scope the rest, and close #1383.

## Implementation

- `View.vue`: `updatingRepoId` ref + `updateRepo(repo)` (POST install with `repo.url`/`repo.subpath`, then refresh `loadExternalRepos`+`loadCatalog`); refresh icon-button in the repo header, `data-testid="skill-catalog-repo-update-{repoId}"`.
- i18n: `pluginManageSkills.catalogUpdateRepo` across all 8 locales.
- `docs/ui-cheatsheet.md`: `/skills` block + testid.

## Test plan

- [x] `format`/`lint`/`typecheck`/`build` clean
- [x] e2e `skills.spec.ts` (13 pass) — incl. Update click re-installs with the recorded url/subpath
- [x] Full unit suite 4850 / 0 fail

Closes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-repository "Update" button to external skills catalog view, enabling users to re-fetch and reinstall the latest version of selected skill repositories.

* **Documentation**
  * Updated UI cheatsheet to reflect new repository refresh control.

* **Tests**
  * Added end-to-end test verifying the update functionality re-installs repositories correctly.

* **Localization**
  * Added "Update repository" label translations across 8 languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->