### PR TITLE
feat: add obra/superpowers to recommended external-skill presets (#1401)

### DIFF
--- a/server/workspace/skills/external/presets.ts
+++ b/server/workspace/skills/external/presets.ts
@@ -34,4 +34,17 @@ export const EXTERNAL_PRESETS: readonly ExternalPresetSuggestion[] = [
     description: "Anthropic's official skill collection — PDF / Excel / DOCX builders, MCP server scaffolder, and more.",
     license: "MIT",
   },
+  {
+    // Engineering-workflow skills that also pay off inside
+    // MulmoClaude's task agent: brainstorming, writing/executing
+    // plans, systematic-debugging, code review. Layout is one-level
+    // (`skills/<name>/SKILL.md`), so the existing one-level
+    // discovery handles it without a scanner change. Verified
+    // 2026-05: MIT, actively maintained, high-quality skills.
+    url: "https://github.com/obra/superpowers",
+    subpath: "skills",
+    displayName: "Superpowers",
+    description: "Battle-tested workflow skills — brainstorming, planning, systematic debugging, TDD, and code review.",
+    license: "MIT",
+  },
 ] as const;

--- a/test/workspace/skills/external/test_presets.ts
+++ b/test/workspace/skills/external/test_presets.ts
@@ -1,0 +1,42 @@
+// Invariant guard for the hand-curated external-skill preset list.
+// Adding an entry is an editorial act (see presets.ts header) — these
+// assertions keep every entry well-formed so a typo can't ship a
+// dead "+ Add skill repository" suggestion.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EXTERNAL_PRESETS } from "../../../../server/workspace/skills/external/presets.js";
+
+describe("EXTERNAL_PRESETS", () => {
+  it("has at least the Anthropic + Superpowers entries", () => {
+    const urls = EXTERNAL_PRESETS.map((preset) => preset.url);
+    assert.ok(urls.includes("https://github.com/anthropics/skills"));
+    assert.ok(urls.includes("https://github.com/obra/superpowers"));
+  });
+
+  it("every entry is a well-formed public GitHub https repo URL", () => {
+    for (const preset of EXTERNAL_PRESETS) {
+      assert.match(preset.url, /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+$/, `bad url: ${preset.url}`);
+    }
+  });
+
+  it("every entry has a non-empty displayName and description", () => {
+    for (const preset of EXTERNAL_PRESETS) {
+      assert.ok(preset.displayName.trim().length > 0, `empty displayName for ${preset.url}`);
+      assert.ok(preset.description.trim().length > 0, `empty description for ${preset.url}`);
+    }
+  });
+
+  it("subpath, when present, is a clean relative path (no leading/trailing slash, no traversal)", () => {
+    for (const preset of EXTERNAL_PRESETS) {
+      if (preset.subpath === undefined) continue;
+      assert.doesNotMatch(preset.subpath, /^\/|\/$|\.\.|\\|\0/, `unsafe subpath: ${preset.subpath}`);
+      assert.ok(preset.subpath.length > 0, "subpath, if set, must be non-empty");
+    }
+  });
+
+  it("URLs are unique (no duplicate suggestions)", () => {
+    const urls = EXTERNAL_PRESETS.map((preset) => preset.url);
+    assert.equal(new Set(urls).size, urls.length, "duplicate preset URL");
+  });
+});

--- a/test/workspace/skills/external/test_presets.ts
+++ b/test/workspace/skills/external/test_presets.ts
@@ -9,9 +9,13 @@ import { EXTERNAL_PRESETS } from "../../../../server/workspace/skills/external/p
 
 describe("EXTERNAL_PRESETS", () => {
   it("has at least the Anthropic + Superpowers entries", () => {
-    const urls = EXTERNAL_PRESETS.map((preset) => preset.url);
-    assert.ok(urls.includes("https://github.com/anthropics/skills"));
-    assert.ok(urls.includes("https://github.com/obra/superpowers"));
+    // Exact-equality membership (Set.has, not String/Array substring
+    // matching) so CodeQL's js/incomplete-url-substring-sanitization
+    // heuristic doesn't misread an asserted-equal URL literal as an
+    // origin check on untrusted input.
+    const urls = new Set(EXTERNAL_PRESETS.map((preset) => preset.url));
+    assert.ok(urls.has("https://github.com/anthropics/skills"));
+    assert.ok(urls.has("https://github.com/obra/superpowers"));
   });
 
   it("every entry is a well-formed public GitHub https repo URL", () => {


### PR DESCRIPTION
## Summary

- `EXTERNAL_PRESETS`（`GET /api/skills/external/suggestions` が返す「+ Add skill repository」推奨リスト）に **`obra/superpowers`** を追加（MIT, ~193k★, active）。
- スキャナ改修なし。`obra/superpowers` は `skills/<name>/SKILL.md` の1階層構造で既存 discovery がそのまま対応。

## Items to Confirm / Review

- **編集方針の判断**: 「skill は MulmoClaude で動かして役に立つ前提」という制約で実 skill 内容を精査。`wshobson/agents`（154 skills だが backend/cicd/cloud-infra/blockchain 等ほぼ開発インフラ）は MulmoClaude の文書/業務用途に不一致のため**意図的に不採用**。`obra/superpowers`（brainstorming / writing-plans / systematic-debugging / TDD / code-review）は MulmoClaude のタスク agent でも実利ありと判断し採用。この線引きで良いか確認ください。
- **ネスト scan は見送り**（#1401 の "nested SKILL.md support" 部分）。superpowers が1階層のため不要、YAGNI。将来 MulmoClaude 向けの良い多階層 repo が出たら別 issue で。
- awesome-list 系（ComposioHQ / VoltAgent 等）は `SKILL.md` を持たないリンク集で install 不可のため対象外。

## User Prompt

> スキルリポジトリを追加のおすすめレポジトリをふやしたい。検索して、テック系、通常の業務系、文書作成系などでメジャーでおすすめなのを探して。
> （2階層をサポートしてもよいよ。よいskillなら。 / skillはmulmoclaudeで動かして役に立つ前提だからね → Option 2: superpowers のみ追加）

## Implementation

- `server/workspace/skills/external/presets.ts` — 1 エントリ追加（rationale をコメントで明記）
- `test/workspace/skills/external/test_presets.ts`（新規）— preset リストの不変条件（GitHub https URL 妥当・表示文言非空・subpath traversal-safe・URL 一意）を保証

## Test plan

- [x] `yarn format / lint / typecheck / build / test` 全グリーン（4855 件 fail 0）
- [x] 新規 `test_presets.ts` 5 ケース
- [ ] 手動: 「+ Add skill repository」モーダルに Superpowers が出る → install で `skills/*/SKILL.md` が catalog に並ぶ

🤖 Generated with [Claude Code](https://claude.com/claude-code)