### PR TITLE
refactor(skill): restore flex-1 now that StackView selector is scoped (#1277)

### DIFF
--- a/src/plugins/skill/View.vue
+++ b/src/plugins/skill/View.vue
@@ -13,11 +13,7 @@
         <details class="group">
           <summary class="cursor-pointer list-none p-4 flex items-start gap-3 hover:bg-purple-100/40 rounded-lg" :data-testid="'skill-summary-' + skillName">
             <span class="material-icons text-purple-600 text-base mt-0.5 shrink-0">extension</span>
-            <!-- `grow shrink basis-0` instead of `flex-1` is intentional: StackView's
-                 `.stack-natural :deep(.flex-1) { flex: 0 0 auto !important }` rule (intended
-                 for vertical-flex content height) would otherwise pin this horizontal flex
-                 child to its content width, breaking long-description wrapping in stack mode. -->
-            <div class="grow shrink basis-0 min-w-0">
+            <div class="flex-1 min-w-0">
               <div class="flex items-baseline gap-2 flex-wrap">
                 <span class="font-medium text-purple-900">{{ skillName }}</span>
                 <span v-if="skillScope !== 'unknown'" class="text-[10px] uppercase tracking-wide text-purple-500 px-1.5 py-0.5 rounded-full bg-purple-100">


### PR DESCRIPTION
## Summary

PR #1276 で skill plugin の `<summary>` 内 description ラッパーに入れた局所回避（`flex-1 min-w-0` → `grow shrink basis-0 min-w-0` + 解説コメント）を、PR #1400 で StackView の根本原因が直ったので revert します。実質 1 行のクラス戻し + 4 行の stale コメント削除のみ。

## Items to Confirm / Review

- **挙動の等価性**: `grow shrink basis-0` = `flex: 1 1 0%` = `flex-1` なので、PR #1400 後の `.stack-natural :deep(.flex-col > .flex-1)` セレクタ（横 flex の子にはマッチしない）を踏まえると、stack view での description 折り返しは PR #1276 と同じ挙動になります。
- **取り残しチェック**: `grep -rn "grow shrink basis-0" src/ packages/` を worktree で実行 → 今回の revert 後に 0 件。同種の workaround は他に残っていません。
- **手動確認**: stack view で skill カードの長い description が右端で折り返すこと（横にはみ出さないこと）を目視確認済み。

## Background

issue #1277 / PR #1400 のフォローアップ:

1. **#1276**: skill `<summary>` の description が stack view で折り返さない不具合を、skill 側で `flex-1` → `grow shrink basis-0` に置き換える局所回避で対応（StackView の `.stack-natural :deep(.flex-1)` セレクタが横 flex 子要素も巻き込んでいたため）。
2. **#1400 / #1277**: StackView のセレクタを `.flex-col > .flex-1` に絞り込み、横 flex コンテキストを除外。skill 側の workaround は不要に。
3. **本 PR**: workaround を撤去。`flex-1 min-w-0` に戻し、PR #1276 と #1400 の経緯を辿らないと読めない歴史的コメントも削除。

## Cross-review

`/codex-cross-review`（pre-PR モード）を 1 イテレーション実施。Codex 判定 `LGTM` / 指摘ゼロ。私自身の評価でも `grow shrink basis-0` の残存 0 件、ローカル format / lint / typecheck / build すべて green。

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/1400 これが適用されました。https://github.com/receptron/mulmoclaude/issues/1277 元々言及されていた箇所は修正済み？

> では、worktree で修正して、commit してください。完了後は /codex-cross-review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout behavior of collapsed skill headers to improve content sizing and text wrapping consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->