### PR TITLE
chore(mulmoclaude): bump launcher to 0.6.3

### DIFF
--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -115,7 +115,7 @@ ${cliFlagHelpLines()}
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.6.2");
+  console.log("mulmoclaude 0.6.3");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Post-publish bookkeeping for `mulmoclaude@0.6.3` (already live on npm, matches app release [v0.6.3](https://github.com/receptron/mulmoclaude/releases/tag/v0.6.3)).

`/publish-mulmoclaude` flow results:
- §1 deps audit — clean (no missing deps)
- §2 workspace drift — clean (`chat-service` / `client` / `protocol` all `src == published`); **no `@mulmobridge/*` cascade needed**
- §3 build — OK
- §4 tarball boot smoke — HTTP 200, launcher boots from packed tarball
- §6 publish — `mulmoclaude@0.6.3` published; `npx mulmoclaude@0.6.3 --version` → `mulmoclaude 0.6.3`

## Changes

- `packages/mulmoclaude/package.json` 0.6.2 → 0.6.3
- `packages/mulmoclaude/bin/mulmoclaude.js` `--version` banner 0.6.2 → 0.6.3 (kept in lockstep per §5)

## Test plan

- [x] CI "MulmoClaude publish smoke" green on the release commit (`64eea2d0`)
- [x] Local deps audit + drift + tarball smoke green
- [x] `npm view mulmoclaude version` = 0.6.3 after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)