### PR TITLE
feat: show app version in Settings modal (#1410)

### DIFF
--- a/plans/feat-ui-app-version-1410.md
+++ b/plans/feat-ui-app-version-1410.md
@@ -1,0 +1,50 @@
+# feat: show app version in the web UI Settings modal (#1410)
+
+## 背景
+
+実行中のアプリ版（root `package.json` の version）が web UI から
+一切見えず、特に `npx mulmoclaude` ユーザは古いキャッシュ版か判別
+できない。バグ報告時の version 特定もできない。
+
+## 仕様
+
+- **サーバ**: 既存の `/api/health` レスポンスに `version` を追加。
+  `server/system/appVersion.ts` が最寄りの `package.json` を
+  module-load 時に 1 回読む。`../../package.json` 相対で dev
+  （repo root）と tarball（`packages/mulmoclaude/`）の両方で正しく
+  解決（launcher が publish 時に両者を lockstep 維持）。読めない
+  場合は `"unknown"` にフォールバック + warn ログ。
+- **UI**: SettingsModal ヘッダのタイトル下に小さく
+  `MulmoClaude v{version}`（muted, `data-testid="settings-app-version"`）。
+  モーダル open 時に `/api/health` を 1 回 fetch しキャッシュ。
+- **i18n**: `settingsModal.version = "MulmoClaude v{version}"` を
+  全 8 ロケールに lockstep 追加（ブランド名 + placeholder のため
+  全ロケール同値）。
+
+## 設計判断
+
+- runtime（/api/health）採用。Vite build-time `__APP_VERSION__` は
+  tarball で publish 時に焼き込まれ runtime 実体とずれ得るため不可。
+- 配置は Settings モーダル（About 的定位置、ユーザー選択）。
+  sidebar ロゴ / lockStatusPopup は将来別途。
+- `errorMessage` / `log` の共有ユーティリティを使用（独自実装しない）。
+
+## 変更ファイル
+
+- `server/system/appVersion.ts`（新規）
+- `server/index.ts` — `/api/health` に `version: APP_VERSION`
+- `src/components/SettingsModal.vue` — fetch + 表示
+- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — `settingsModal.version`
+- `test/system/test_appVersion.ts`（新規）
+
+## テスト
+
+- `APP_VERSION` == repo `package.json` version（独立に再導出）
+- semver 形 / 非空 / 非 "unknown"
+- `yarn format` / `lint` / `typecheck` / `build` / `test`
+- 手動: Settings を開いて `MulmoClaude vX.Y.Z` 表示確認
+
+## スコープ外
+
+- sidebar ロゴ / lockStatusPopup への表示（将来）
+- build-time inject 方式

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,6 +47,7 @@ import { createJournalRouter } from "./api/routes/journal.js";
 import { createTranslationRouter } from "./api/routes/translation.js";
 import { announcePluginMetaDiagnostics } from "./plugins/diagnostics.js";
 import { announceOptionalDeps } from "./system/announceOptionalDeps.js";
+import { APP_VERSION } from "./system/appVersion.js";
 import { createChatService } from "@mulmobridge/chat-service";
 import { readSessionJsonl } from "./utils/files/session-io.js";
 import { onSessionEvent, initSessionStore } from "./events/session-store/index.js";
@@ -566,6 +567,7 @@ app.get(API_ROUTES.health, (_req: Request, res: Response) => {
   const cores = cpus().length;
   res.json({
     status: "OK",
+    version: APP_VERSION,
     geminiAvailable: isGeminiAvailable(),
     sandboxEnabled,
     cpu: { load1, cores },

--- a/server/system/appVersion.ts
+++ b/server/system/appVersion.ts
@@ -1,0 +1,34 @@
+// The running app's version, read once from the nearest package.json.
+//
+// Layout is the same shape in both modes, so `../../package.json`
+// relative to this file resolves correctly without a workspace walk:
+//   - dev (`yarn dev`):  <repo>/server/system/appVersion.ts        → <repo>/package.json
+//   - tarball (`npx`):   <pkgDir>/server/system/appVersion.ts      → <pkgDir>/package.json
+// The launcher keeps `packages/mulmoclaude/package.json` in lockstep
+// with the root version at publish time, so either resolution yields
+// the same user-facing app version.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { errorMessage } from "../utils/errors.js";
+import { log } from "./logger/index.js";
+
+function readAppVersion(): string {
+  const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(pkgPath, "utf8"));
+    if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
+      const { version } = parsed as { version: unknown };
+      if (typeof version === "string" && version.length > 0) return version;
+    }
+    log.warn("appVersion", "package.json has no usable version field", { pkgPath });
+  } catch (err) {
+    log.warn("appVersion", "failed to read package.json", { pkgPath, error: errorMessage(err) });
+  }
+  return "unknown";
+}
+
+/** Frozen at module load — package.json never changes mid-process. */
+export const APP_VERSION: string = readAppVersion();

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -11,7 +11,7 @@
       <div class="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
         <div>
           <h2 id="settings-modal-title" class="text-base font-semibold text-gray-900">{{ t("settingsModal.title") }}</h2>
-          <p v-if="appVersion" class="text-[11px] text-gray-400 mt-0.5" data-testid="settings-app-version">
+          <p v-if="appVersion" class="text-xs text-gray-600 mt-0.5" data-testid="settings-app-version">
             {{ t("settingsModal.version", { version: appVersion }) }}
           </p>
         </div>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -9,7 +9,12 @@
       @click.stop
     >
       <div class="px-5 py-4 border-b border-gray-200 flex items-center justify-between">
-        <h2 id="settings-modal-title" class="text-base font-semibold text-gray-900">{{ t("settingsModal.title") }}</h2>
+        <div>
+          <h2 id="settings-modal-title" class="text-base font-semibold text-gray-900">{{ t("settingsModal.title") }}</h2>
+          <p v-if="appVersion" class="text-[11px] text-gray-400 mt-0.5" data-testid="settings-app-version">
+            {{ t("settingsModal.version", { version: appVersion }) }}
+          </p>
+        </div>
         <button class="text-gray-400 hover:text-gray-700" :title="t('common.close')" data-testid="settings-close-btn" @click="close">
           <span class="material-icons">close</span>
         </button>
@@ -236,6 +241,9 @@ const toolsText = ref("");
 const toolsSavedText = ref("");
 const mcpServers = ref<McpServerEntry[]>([]);
 const loadError = ref("");
+// App version (root package.json), surfaced from /api/health. Fetched
+// once on first open and kept — it can't change mid-process.
+const appVersion = ref("");
 const statusMessage = ref("");
 const statusError = ref(false);
 const toolsSaving = ref(false);
@@ -266,6 +274,14 @@ const invalidToolNames = computed(() => parsedToolNames.value.filter((name) => !
 
 function isBuiltIn(name: string): boolean {
   return ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"].includes(name);
+}
+
+async function loadVersion(): Promise<void> {
+  if (appVersion.value) return;
+  const response = await apiGet<{ version?: string }>(API_ROUTES.health);
+  if (response.ok && typeof response.data.version === "string") {
+    appVersion.value = response.data.version;
+  }
 }
 
 async function loadConfig(): Promise<void> {
@@ -398,6 +414,7 @@ watch(
       mcpInflight = Promise.resolve();
       activeTab.value = props.geminiAvailable ? "tools" : "gemini";
       loadConfig();
+      loadVersion();
       mapReloadToken.value += 1;
       photosReloadToken.value += 1;
       modelReloadToken.value += 1;

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -278,10 +278,14 @@ function isBuiltIn(name: string): boolean {
 
 async function loadVersion(): Promise<void> {
   if (appVersion.value) return;
+  // apiGet absorbs network + HTTP errors into `{ ok: false }` (see
+  // ApiResult contract in utils/api.ts — it never throws), so a
+  // try/catch would be unreachable. Both failure modes (network and
+  // !ok) are handled the same way on purpose: the version line is
+  // best-effort chrome, so on any failure we just leave it hidden.
   const response = await apiGet<{ version?: string }>(API_ROUTES.health);
-  if (response.ok && typeof response.data.version === "string") {
-    appVersion.value = response.data.version;
-  }
+  if (!response.ok || typeof response.data.version !== "string") return;
+  appVersion.value = response.data.version;
 }
 
 async function loadConfig(): Promise<void> {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -152,6 +152,7 @@ const deMessages = {
   },
   settingsModal: {
     title: "Einstellungen",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Gemini-API-Schlüssel",
       tools: "Erlaubte Tools",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -171,6 +171,7 @@ const enMessages = {
   },
   settingsModal: {
     title: "Settings",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Gemini API Key",
       tools: "Allowed Tools",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -155,6 +155,7 @@ const esMessages = {
   },
   settingsModal: {
     title: "Ajustes",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Clave API de Gemini",
       tools: "Herramientas permitidas",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -150,6 +150,7 @@ const frMessages = {
   },
   settingsModal: {
     title: "Paramètres",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Clé API Gemini",
       tools: "Outils autorisés",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -155,6 +155,7 @@ const jaMessages = {
   },
   settingsModal: {
     title: "設定",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Gemini API キー",
       tools: "許可ツール",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -157,6 +157,7 @@ const koMessages = {
   },
   settingsModal: {
     title: "설정",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Gemini API 키",
       tools: "허용된 도구",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -150,6 +150,7 @@ const ptBRMessages = {
   },
   settingsModal: {
     title: "Configurações",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Chave API do Gemini",
       tools: "Ferramentas permitidas",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -153,6 +153,7 @@ const zhMessages = {
   },
   settingsModal: {
     title: "设置",
+    version: "MulmoClaude v{version}",
     tabs: {
       gemini: "Gemini API 密钥",
       tools: "允许的工具",

--- a/test/system/test_appVersion.ts
+++ b/test/system/test_appVersion.ts
@@ -1,0 +1,32 @@
+// Verifies APP_VERSION resolves to the repo's package.json version.
+// The helper reads `../../package.json` relative to its own file
+// (server/system/appVersion.ts → repo root in dev), which this test
+// re-derives independently so a version bump never needs a test edit.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { APP_VERSION } from "../../server/system/appVersion.js";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const pkg: unknown = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+const expectedVersion = typeof pkg === "object" && pkg !== null && "version" in pkg ? (pkg as { version: string }).version : "";
+
+describe("appVersion APP_VERSION", () => {
+  it("equals the repo package.json version", () => {
+    assert.equal(APP_VERSION, expectedVersion);
+  });
+
+  it("is a non-empty, non-'unknown' string in this layout", () => {
+    assert.equal(typeof APP_VERSION, "string");
+    assert.ok(APP_VERSION.length > 0);
+    assert.notEqual(APP_VERSION, "unknown", "package.json should resolve from the repo root in tests");
+  });
+
+  it("looks like a semver", () => {
+    assert.match(APP_VERSION, /^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the running app version (root `package.json`) in the web UI Settings modal — previously invisible anywhere in-app. Helps `npx mulmoclaude` users on a stale cached build and bug reporters identify their version.

## Items to Confirm / Review

- **Version source = runtime `/api/health`**, not a Vite build-time define. Rationale: the published tarball's client is built once at publish, so a baked `__APP_VERSION__` would drift from the actually-running launcher; a server read is always accurate. `server/system/appVersion.ts` resolves `../../package.json` which is the repo root in `yarn dev` and the package dir in the tarball (kept in lockstep at publish per the publish flow). Falls back to `"unknown"` + a warn log on read failure.
- **Placement**: Settings modal header, muted line under the title (user-chosen). Sidebar logo / lock-status popup deferred.
- **i18n**: `settingsModal.version = "MulmoClaude v{version}"` — brand + placeholder, identical across all 8 locales (no translation needed; matches the "brand names stay English" rule).

## User Prompt

> web ui上でpackage jsonにあるversionがみえるとよいね。

(Placement clarified interactively → Settings modal.)

## Test plan

- [ ] Open Settings → `MulmoClaude vX.Y.Z` shows under the title
- [ ] `GET /api/health` includes `version`
- [ ] `node --test test/system/test_appVersion.ts` green
- [ ] format / lint / typecheck / build / test green (CI)

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application version is now displayed in the Settings modal, showing the running app version in the format "MulmoClaude v{version}".
  * Version display is available across all supported languages (English, German, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Simplified Chinese).

* **Tests**
  * Added system tests to validate version information accuracy and format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->