### PR TITLE
feat(skills): add-repo suggestions — fill form + repo link + expandable description (#1413)

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -416,7 +416,10 @@ derived slug);
 `skill-catalog-add-repo` + `skill-add-repo-modal` /
 `skill-add-repo-url` / `skill-add-repo-subpath` /
 `skill-add-repo-submit` / `skill-add-repo-error` /
-`skill-add-repo-suggestion-{url}` for the add-repo modal.
+`skill-add-repo-suggestion-{url}` (click = prefill the URL/subpath
+form + expand its description, NOT install) /
+`skill-add-repo-suggestion-link-{url}` (opens the repo on GitHub in a
+new tab) for the add-repo modal.
 
 ## /roles — role configuration
 

--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -542,7 +542,21 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
 
     await page.getByTestId("skill-catalog-add-repo").click();
     await expect(page.getByTestId("skill-add-repo-modal")).toBeVisible();
+
+    // The repo link opens GitHub in a new tab and must NOT install.
+    const link = page.getByTestId("skill-add-repo-suggestion-link-https://github.com/anthropics/skills");
+    await expect(link).toHaveAttribute("href", "https://github.com/anthropics/skills");
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("rel", /noopener/);
+
+    // Clicking a suggestion prefills the form — it must NOT install.
     await page.getByTestId("skill-add-repo-suggestion-https://github.com/anthropics/skills").click();
+    await expect(page.getByTestId("skill-add-repo-url")).toHaveValue("https://github.com/anthropics/skills");
+    await expect(page.getByTestId("skill-add-repo-subpath")).toHaveValue("skills");
+    expect(calls.install.length).toBe(0);
+
+    // Explicit Install is what actually installs.
+    await page.getByTestId("skill-add-repo-submit").click();
     await expect.poll(() => calls.install.length).toBe(1);
     expect(calls.install[0]).toMatchObject({ url: "https://github.com/anthropics/skills", subpath: "skills" });
 

--- a/plans/feat-add-repo-suggestion-ux-1413.md
+++ b/plans/feat-add-repo-suggestion-ux-1413.md
@@ -1,0 +1,65 @@
+# Add-repo modal — suggestion UX polish (#1413)
+
+Follow-up to #1392 (C2). Frontend-only; no server change.
+
+## Current
+
+`skill-add-repo-suggestion-{url}` button → `installRepo(url, subpath)`
+immediately. Description is one-line `truncate`. No way to inspect the
+repo first.
+
+## Target behaviour
+
+A suggestion row becomes **select-only**:
+
+1. **Click fills the form** — `selectSuggestion(s)` sets
+   `addRepoUrl = s.url`, `addRepoSubpath = s.subpath ?? ""`,
+   `selectedSuggestionUrl = s.url`. Does NOT install. Install stays
+   driven solely by the existing Install button / Enter-in-URL.
+2. **Repo link** — an `<a :href="s.url" target="_blank"
+   rel="noopener noreferrer" @click.stop>` with an open-in-new icon
+   so the user can review the repo on GitHub before installing.
+   `@click.stop` so the link doesn't also trigger row-select.
+3. **Expandable description** — when `selectedSuggestionUrl === s.url`
+   the description renders full (no `truncate`, `whitespace-normal`);
+   otherwise truncated. Selecting also highlights the row
+   (`aria-pressed`).
+
+## Changes (`src/plugins/manageSkills/View.vue`)
+
+- State: `selectedSuggestionUrl = ref<string | null>(null)`; reset in
+  `openAddRepo()` and the `selectedResult` watcher.
+- `selectSuggestion(s: ExternalSuggestion)`: fill form + set selected.
+- Template: suggestion row stays a `<button type="button">` (action =
+  "fill form"), `:aria-pressed`, description class toggles
+  `truncate` ↔ `whitespace-normal break-words`; add the `<a>` repo
+  link with `@click.stop`, `data-testid="skill-add-repo-suggestion-link-{url}"`.
+  Drop the `@click="installRepo(...)"` + `:disabled="addRepoBusy"`.
+
+## i18n (all 8 locales, lockstep)
+
+`pluginManageSkills.catalogRepoOpenLink` — accessible name/title for
+the GitHub link (e.g. "Open repository on GitHub (new tab)").
+
+## Docs
+
+`docs/ui-cheatsheet.md`: tweak the add-repo modal note + add
+`skill-add-repo-suggestion-link-{url}` testid.
+
+## Tests
+
+`e2e/tests/skills.spec.ts` — update the existing
+"add-repo modal installs from a suggestion" test: clicking a
+suggestion now fills `skill-add-repo-url` (assert value), then
+clicking `skill-add-repo-submit` fires the install POST. Add an
+assertion that `skill-add-repo-suggestion-link-{url}` has the right
+`href` + `target="_blank"` + `rel` including `noopener`.
+
+## Acceptance
+
+- Clicking a suggestion never installs; it fills URL+subpath and
+  expands its description.
+- The repo link opens GitHub in a new tab and does not select/install.
+- Install only via the Install button / Enter in the URL field.
+- 8 locales + cheatsheet updated; e2e + full suite green;
+  format/lint/typecheck/build clean.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1128,6 +1128,7 @@ const deMessages = {
     catalogAddRepoSuggestions: "Vorgeschlagene Repositories",
     catalogUninstallRepo: "Repository deinstallieren",
     catalogUpdateRepo: "Repository aktualisieren (neueste Version erneut laden)",
+    catalogRepoOpenLink: "Repository auf GitHub öffnen (neuer Tab)",
     catalogUninstallConfirm: "Dieses Repository deinstallieren? Bereits mit Stern markierte Skills bleiben in deiner aktiven Liste.",
     catalogRepoInstalling: "Installiere…",
     catalogRepoEmpty: "In diesem Repository wurden keine Skills gefunden.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1112,6 +1112,7 @@ const enMessages = {
     catalogAddRepoSuggestions: "Suggested repositories",
     catalogUninstallRepo: "Uninstall repository",
     catalogUpdateRepo: "Update repository (re-fetch latest)",
+    catalogRepoOpenLink: "Open repository on GitHub (new tab)",
     catalogUninstallConfirm: "Uninstall this repository? Skills you already starred stay in your active list.",
     catalogRepoInstalling: "Installing…",
     catalogRepoEmpty: "No skills found in this repository.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1124,6 +1124,7 @@ const esMessages = {
     catalogAddRepoSuggestions: "Repositorios sugeridos",
     catalogUninstallRepo: "Desinstalar repositorio",
     catalogUpdateRepo: "Actualizar repositorio (volver a obtener lo último)",
+    catalogRepoOpenLink: "Abrir el repositorio en GitHub (nueva pestaña)",
     catalogUninstallConfirm: "¿Desinstalar este repositorio? Las skills que ya marcaste con estrella permanecen en tu lista activa.",
     catalogRepoInstalling: "Instalando…",
     catalogRepoEmpty: "No se encontraron skills en este repositorio.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1118,6 +1118,7 @@ const frMessages = {
     catalogAddRepoSuggestions: "Dépôts suggérés",
     catalogUninstallRepo: "Désinstaller le dépôt",
     catalogUpdateRepo: "Mettre à jour le dépôt (récupérer la dernière version)",
+    catalogRepoOpenLink: "Ouvrir le dépôt sur GitHub (nouvel onglet)",
     catalogUninstallConfirm: "Désinstaller ce dépôt ? Les skills déjà mises en favori restent dans votre liste active.",
     catalogRepoInstalling: "Installation…",
     catalogRepoEmpty: "Aucune skill trouvée dans ce dépôt.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1113,6 +1113,7 @@ const jaMessages = {
     catalogAddRepoSuggestions: "おすすめリポジトリ",
     catalogUninstallRepo: "リポジトリをアンインストール",
     catalogUpdateRepo: "リポジトリを更新（最新を再取得）",
+    catalogRepoOpenLink: "GitHub でリポジトリを開く（新しいタブ）",
     catalogUninstallConfirm: "このリポジトリをアンインストールしますか？ すでに★したスキルはアクティブ一覧に残ります。",
     catalogRepoInstalling: "インストール中…",
     catalogRepoEmpty: "このリポジトリにスキルが見つかりません。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1113,6 +1113,7 @@ const koMessages = {
     catalogAddRepoSuggestions: "추천 저장소",
     catalogUninstallRepo: "저장소 제거",
     catalogUpdateRepo: "저장소 업데이트(최신 다시 가져오기)",
+    catalogRepoOpenLink: "GitHub에서 저장소 열기(새 탭)",
     catalogUninstallConfirm: "이 저장소를 제거할까요? 이미 별표한 스킬은 활성 목록에 남습니다.",
     catalogRepoInstalling: "설치 중…",
     catalogRepoEmpty: "이 저장소에서 스킬을 찾을 수 없습니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1113,6 +1113,7 @@ const ptBRMessages = {
     catalogAddRepoSuggestions: "Repositórios sugeridos",
     catalogUninstallRepo: "Desinstalar repositório",
     catalogUpdateRepo: "Atualizar repositório (rebuscar o mais recente)",
+    catalogRepoOpenLink: "Abrir o repositório no GitHub (nova aba)",
     catalogUninstallConfirm: "Desinstalar este repositório? As skills que você já marcou com estrela permanecem na sua lista ativa.",
     catalogRepoInstalling: "Instalando…",
     catalogRepoEmpty: "Nenhuma skill encontrada neste repositório.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1105,6 +1105,7 @@ const zhMessages = {
     catalogAddRepoSuggestions: "推荐仓库",
     catalogUninstallRepo: "卸载仓库",
     catalogUpdateRepo: "更新仓库（重新获取最新）",
+    catalogRepoOpenLink: "在 GitHub 打开仓库（新标签页）",
     catalogUninstallConfirm: "卸载此仓库？已加星的技能仍保留在活动列表中。",
     catalogRepoInstalling: "安装中…",
     catalogRepoEmpty: "此仓库中未找到技能。",

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -451,18 +451,39 @@
         </div>
         <div v-if="suggestions.length > 0">
           <p class="text-xs font-medium text-gray-600 mb-2">{{ t("pluginManageSkills.catalogAddRepoSuggestions") }}</p>
-          <button
+          <div
             v-for="suggestion in suggestions"
             :key="suggestion.url"
-            type="button"
-            :data-testid="`skill-add-repo-suggestion-${suggestion.url}`"
-            class="w-full text-left px-3 py-2 mb-1 text-sm rounded border border-gray-200 hover:bg-gray-50 disabled:opacity-40"
-            :disabled="addRepoBusy"
-            @click="installRepo(suggestion.url, suggestion.subpath)"
+            class="mb-1 rounded border"
+            :class="selectedSuggestionUrl === suggestion.url ? 'border-blue-400 bg-blue-50' : 'border-gray-200'"
           >
-            <div class="font-medium text-gray-700">{{ suggestion.displayName }}</div>
-            <div class="text-xs text-gray-500 truncate">{{ suggestion.description }}</div>
-          </button>
+            <div class="flex items-start">
+              <button
+                type="button"
+                :data-testid="`skill-add-repo-suggestion-${suggestion.url}`"
+                class="flex-1 min-w-0 text-left px-3 py-2 text-sm"
+                :aria-pressed="selectedSuggestionUrl === suggestion.url"
+                @click="selectSuggestion(suggestion)"
+              >
+                <div class="font-medium text-gray-700">{{ suggestion.displayName }}</div>
+                <div class="text-xs text-gray-500" :class="selectedSuggestionUrl === suggestion.url ? 'whitespace-normal break-words' : 'truncate'">
+                  {{ suggestion.description }}
+                </div>
+              </button>
+              <a
+                :href="suggestion.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                :data-testid="`skill-add-repo-suggestion-link-${suggestion.url}`"
+                class="h-8 w-8 shrink-0 flex items-center justify-center rounded text-gray-400 hover:text-blue-600"
+                :title="t('pluginManageSkills.catalogRepoOpenLink')"
+                :aria-label="t('pluginManageSkills.catalogRepoOpenLink')"
+                @click.stop
+              >
+                <span class="material-icons text-sm" aria-hidden="true">open_in_new</span>
+              </a>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -620,6 +641,10 @@ const addRepoSubpath = ref("");
 const addRepoError = ref<string | null>(null);
 const addRepoBusy = ref(false);
 const suggestions = ref<ExternalSuggestion[]>([]);
+// Which suggestion the user picked: drives the form prefill + the
+// "expanded description" / highlight. Selecting never installs —
+// install stays explicit (Install button / Enter in the URL field).
+const selectedSuggestionUrl = ref<string | null>(null);
 const uninstallingRepoId = ref<string | null>(null);
 const updatingRepoId = ref<string | null>(null);
 // Single in-flight gate covers Star / Run once on the selected
@@ -754,6 +779,7 @@ watch(
     catalogError.value = null;
     addRepoOpen.value = false;
     addRepoError.value = null;
+    selectedSuggestionUrl.value = null;
     uninstallingRepoId.value = null;
     updatingRepoId.value = null;
   },
@@ -790,8 +816,19 @@ function openAddRepo(): void {
   addRepoUrl.value = "";
   addRepoSubpath.value = "";
   addRepoError.value = null;
+  selectedSuggestionUrl.value = null;
   addRepoOpen.value = true;
   if (suggestions.value.length === 0) void loadSuggestions();
+}
+
+// Pick a suggestion → prefill the form so the user can review and
+// then press Install. Deliberately does NOT install (avoids the
+// accidental one-click install footgun).
+function selectSuggestion(suggestion: ExternalSuggestion): void {
+  addRepoUrl.value = suggestion.url;
+  addRepoSubpath.value = suggestion.subpath ?? "";
+  addRepoError.value = null;
+  selectedSuggestionUrl.value = suggestion.url;
 }
 
 async function installRepo(url: string, subpath?: string): Promise<void> {


### PR DESCRIPTION
## Summary

UX polish to the C2 (#1392) add-skill-repository modal, per user feedback. Frontend-only, no server change.

Before: clicking a **suggested repository** installed it immediately — surprising, no way to review (one-line truncated description, no link to the repo).

After:
- **Click = prefill, not install.** Clicking a suggestion fills the URL + subpath form fields and highlights/expands that row. Install stays explicit (Install button / Enter in the URL field).
- **Repo link.** Each suggestion has an open-in-new-tab link to the GitHub repo (`target="_blank" rel="noopener noreferrer"`, `@click.stop` so it doesn't also select).
- **Expandable description.** The selected suggestion's description renders in full (`whitespace-normal break-words`) instead of `truncate`.

## Items to Confirm / Review

- Install can no longer be triggered by a single suggestion click — only the explicit Install button / Enter-in-URL. The existing add-repo install test was updated to reflect this (prefill → submit).
- `selectedSuggestionUrl` reset in `openAddRepo()` and the `selectedResult` watcher (modal reuse safety).
- Link uses `rel="noopener noreferrer"` + `@click.stop`; security/no-tabnabbing handled.

## User Prompt

スキルの追加部分、おすすめリポジトリのところ、クリックするといきなりインストールされる。form の GitHub URL に入力してユーザがインストール、のほうが自然。あと詳細がわからないのでリポジトリのリンクを貼って new tab で遷移するなどして事前にわかるとよい。説明文も一部しか見えないので、クリックすると少し広がって説明が見えてもよい。

## Test plan

- [x] `format`/`lint`/`typecheck`/`build` clean
- [x] e2e `skills.spec.ts` (13 pass) — suggestion click prefills URL+subpath and does NOT install; explicit submit installs; repo link has correct `href`/`target=_blank`/`rel~=noopener`
- [x] Full unit suite 4866 / 0 fail

Closes #1413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved "Add skill repository" modal suggestions: clicking a suggestion now pre-fills the form without installing, allowing review before confirming installation via the explicit install button.
  * Added external GitHub repository link to suggestion entries that opens in a new tab without triggering form pre-fill.

* **Documentation**
  * Updated UI cheatsheet and feature specifications for suggestion workflow changes.

* **Tests**
  * Enhanced E2E tests with assertions for suggestion interaction and form-filling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->