### PR TITLE
feat(files): inline JSON config editor — #833 Phase 1

### DIFF
--- a/e2e/tests/files-json-edit.spec.ts
+++ b/e2e/tests/files-json-edit.spec.ts
@@ -1,0 +1,151 @@
+// #833 Phase 1 — inline JSON editor in the Files Explorer.
+//
+// Pins the observable contract:
+//   - policy-editable JSON (config/settings.json → user-editable)
+//     shows an Edit button; edit → Save round-trips through
+//     PUT /api/files/content
+//   - a server 400 (invalid JSON) surfaces in the inline error banner
+//     and the editor stays open
+//   - agent-managed JSON (config/scheduler/tasks.json) shows NO Edit
+//     button (gated by editPolicy in systemFileDescriptors)
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { API_ROUTES } from "../../src/config/apiRoutes";
+import { ONE_SECOND_MS } from "../../server/utils/time.ts";
+
+const EDITABLE = "config/settings.json";
+const AGENT_MANAGED = "config/scheduler/tasks.json";
+const EDITABLE_BODY = '{\n  "theme": "dark"\n}';
+const AGENT_BODY = '{\n  "tasks": []\n}';
+
+async function mockJsonFiles(page: Page) {
+  await page.route(
+    (url) => url.pathname === API_ROUTES.files.dir,
+    (route) => {
+      const path = new URL(route.request().url()).searchParams.get("path") ?? "";
+      if (path === "") {
+        return route.fulfill({
+          json: { name: "", path: "", type: "dir", children: [{ name: "config", path: "config", type: "dir" }] },
+        });
+      }
+      if (path === "config") {
+        return route.fulfill({
+          json: {
+            name: "config",
+            path: "config",
+            type: "dir",
+            children: [
+              { name: "settings.json", path: EDITABLE, type: "file", size: EDITABLE_BODY.length },
+              { name: "scheduler", path: "config/scheduler", type: "dir" },
+            ],
+          },
+        });
+      }
+      if (path === "config/scheduler") {
+        return route.fulfill({
+          json: {
+            name: "scheduler",
+            path: "config/scheduler",
+            type: "dir",
+            children: [{ name: "tasks.json", path: AGENT_MANAGED, type: "file", size: AGENT_BODY.length }],
+          },
+        });
+      }
+      return route.fulfill({ json: { name: path, path, type: "dir", children: [] } });
+    },
+  );
+
+  await page.route(
+    (url) => url.pathname === API_ROUTES.files.content && url.searchParams.get("path") === EDITABLE,
+    (route) => route.fulfill({ json: { kind: "text", path: EDITABLE, content: EDITABLE_BODY, size: EDITABLE_BODY.length, modifiedMs: Date.now() } }),
+  );
+  await page.route(
+    (url) => url.pathname === API_ROUTES.files.content && url.searchParams.get("path") === AGENT_MANAGED,
+    (route) => route.fulfill({ json: { kind: "text", path: AGENT_MANAGED, content: AGENT_BODY, size: AGENT_BODY.length, modifiedMs: Date.now() } }),
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+  await mockJsonFiles(page);
+});
+
+test.describe("Files Explorer — JSON inline editor (#833)", () => {
+  test("editable JSON: edit → save round-trips through PUT, server-validated", async ({ page }) => {
+    const puts: { path: string; content: string }[] = [];
+    await page.route(
+      (url) => url.pathname === API_ROUTES.files.content,
+      async (route, req) => {
+        if (req.method() === "PUT") {
+          const body = req.postDataJSON() as { path: string; content: string };
+          // Mirror the server: invalid JSON → 400.
+          try {
+            JSON.parse(body.content);
+          } catch (err) {
+            await route.fulfill({ status: 400, json: { error: `Invalid JSON: ${(err as Error).message}` } });
+            return;
+          }
+          puts.push(body);
+          await route.fulfill({ json: { path: body.path, size: body.content.length, modifiedMs: Date.now() } });
+          return;
+        }
+        await route.fallback();
+      },
+    );
+
+    await page.goto(`/files/${EDITABLE}`);
+
+    const editBtn = page.getByTestId("files-json-edit-btn");
+    await expect(editBtn).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
+    await editBtn.click();
+
+    const editor = page.getByTestId("files-json-editor");
+    await expect(editor).toHaveValue(EDITABLE_BODY);
+    await editor.fill('{\n  "theme": "light"\n}');
+    await page.getByTestId("files-json-save-btn").click();
+
+    await expect(() => {
+      expect(puts).toHaveLength(1);
+      expect(puts[0].path).toBe(EDITABLE);
+      expect(puts[0].content).toBe('{\n  "theme": "light"\n}');
+    }).toPass({ timeout: 5 * ONE_SECOND_MS });
+
+    // Successful save exits edit mode (read-only pre returns).
+    await expect(page.getByTestId("files-json-editor")).toBeHidden();
+    await expect(page.getByTestId("files-json-edit-btn")).toBeVisible();
+  });
+
+  test("invalid JSON: server 400 surfaces in the inline error banner, editor stays open", async ({ page }) => {
+    await page.route(
+      (url) => url.pathname === API_ROUTES.files.content,
+      async (route, req) => {
+        if (req.method() === "PUT") {
+          await route.fulfill({ status: 400, json: { error: "Invalid JSON: Unexpected end of JSON input" } });
+          return;
+        }
+        await route.fallback();
+      },
+    );
+
+    await page.goto(`/files/${EDITABLE}`);
+    await page.getByTestId("files-json-edit-btn").click();
+    const editor = page.getByTestId("files-json-editor");
+    await editor.fill("{ broken");
+    await page.getByTestId("files-json-save-btn").click();
+
+    const banner = page.getByTestId("files-json-save-error");
+    await expect(banner).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
+    await expect(banner).toContainText("Invalid JSON");
+    // Still in edit mode so the user can fix the value.
+    await expect(editor).toBeVisible();
+  });
+
+  test("agent-managed JSON shows no Edit button", async ({ page }) => {
+    await page.goto(`/files/${AGENT_MANAGED}`);
+    // Wait for the JSON pretty-print to render, then assert the Edit
+    // button is absent (editPolicy = agent-managed).
+    await expect(page.getByText('"tasks"')).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
+    await expect(page.getByTestId("files-json-edit-btn")).toHaveCount(0);
+  });
+});

--- a/plans/feat-files-json-edit-833.md
+++ b/plans/feat-files-json-edit-833.md
@@ -1,0 +1,58 @@
+# feat(files): JSON config inline editor — #833 Phase 1
+
+## 背景
+
+Files Explorer は markdown のみ Edit 可。`config/*.json` 等の構造化
+設定ファイルは raw 表示のみで、ブラウザから編集できない（ターミナル
+`vi`/`jq` か LLM 依頼の 2 択）。フォーマットを壊さず編集できる UI が
+欲しい。本 PR は #833 の **Phase 1（Text mode + JSON validate）**。
+
+## スコープ（Phase 1）
+
+- **サーバ**: `PUT /api/files/content` で対象が `.json` の場合
+  `JSON.parse` を実行、失敗なら 400 + 明示メッセージ。書き込み前に
+  実行するので壊れた JSON はディスクに到達しない。`.jsonl` は各行が
+  独立ドキュメントなので除外。整形（prettier）は Phase 1 では行わない
+  （差分予測性を優先）。
+- **クライアント**: FileContentRenderer の JSON プレビューに inline
+  エディタ（Edit → textarea → Save/Cancel）。Save は既存の
+  `updateSource`→`saveRawMarkdown`→`PUT files/content` 経路を再利用。
+  400 は既存の `rawSaveError` バナーに表示し編集モード継続。
+- **可視性ゲート**: `jsonEditableByPolicy(path)`（systemFileDescriptors,
+  #832 の editPolicy 利用）。descriptor なし or
+  `user-editable` / `agent-managed-but-hand-editable` のみ Edit 表示。
+  `agent-managed` / `fragile-format` / `ephemeral` は非表示
+  （agent/app 所有 state の破壊・脆弱フォーマットのリスク回避）。
+
+## 設計判断
+
+- 既存 `PUT /api/files/content`（text-only gate）に validate を 1 段
+  足すだけ。新エンドポイント不要。
+- エディタは markdown 編集と同じ generic save 経路を再利用（重複回避）。
+- editable 判定はユーザー合意:
+  user-editable + hand-editable + descriptor なし。
+
+## 変更ファイル
+
+- `server/api/routes/files.ts` — `jsonSyntaxError()` + PUT で 400
+- `src/config/systemFileDescriptors.ts` — `jsonEditableByPolicy()`
+- `src/components/FileContentRenderer.vue` — inline JSON editor
+- `src/lang/{8}.ts` — `fileContentRenderer.editJson`
+- `test/config/test_systemFileDescriptors.ts` — policy ゲート単体
+- `e2e/tests/files-json-edit.spec.ts` — 編集→保存→反映 / 400→バナー /
+  agent-managed→Edit 非表示
+
+## 完了条件（Phase 1, issue より）
+
+- [x] `.json` 選択時 Edit 表示（descriptor で suppress 可）
+- [x] save 時 server-side `JSON.parse` validate + 400 + UI エラー
+- [x] 保存成功で編集モード解除 + content 反映
+- [x] read-only（agent-managed/ephemeral/fragile）は Edit 非表示
+- [x] e2e: 編集→保存→反映 を pin
+
+## スコープ外（後続 Phase）
+
+- Phase 2: schema-aware form mode（#832 descriptor に JSON Schema）
+- Phase 3: 保存前 before/after diff
+- 保存時 prettier 正規化（オプトイン）
+- 新規ファイル作成

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -816,6 +816,22 @@ async function writeFileContent(absPath: string, content: string): Promise<void>
   }
 }
 
+// JSON config files are editable from the Files Explorer (#833 Phase
+// 1), but a hand-edit that breaks JSON syntax would corrupt a file the
+// app (or the agent) parses on read. Reject a malformed save before it
+// hits disk so the editor can surface the parser error inline. `.jsonl`
+// is intentionally excluded — each line is its own document, not one
+// JSON value, so `JSON.parse` of the whole file would always fail.
+function jsonSyntaxError(relPath: string, content: string): string | null {
+  if (!relPath.toLowerCase().endsWith(".json")) return null;
+  try {
+    JSON.parse(content);
+    return null;
+  } catch (err) {
+    return `Invalid JSON: ${errorMessage(err)}`;
+  }
+}
+
 // Write the body of an existing text file. Only text-classified files
 // (per `classify`) are editable — binary, image, audio, etc. are
 // refused so the endpoint can't be used to ship arbitrary uploads.
@@ -834,6 +850,12 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
   if (!resolved.ok) {
     if (resolved.status === 404) notFound(res, resolved.message);
     else badRequest(res, resolved.message);
+    return;
+  }
+  const jsonError = jsonSyntaxError(relPath, content);
+  if (jsonError !== null) {
+    log.warn("files", "PUT content: invalid JSON", { pathPreview: previewSnippet(relPath) });
+    badRequest(res, jsonError);
     return;
   }
   try {

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -99,13 +99,59 @@
           sandbox="allow-scripts"
           :title="t('fileContentRenderer.htmlPreview')"
         />
-        <!-- JSON: pretty-printed with simple syntax coloring. Fall
-             back to raw content if the file is malformed. -->
-        <pre v-else-if="isJson" class="p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"><span
-          v-for="(tok, i) in jsonTokens"
-          :key="i"
-          :class="JSON_TOKEN_CLASS[tok.type]"
-        >{{ tok.value }}</span></pre>
+        <!-- JSON: read-only pretty-print, or an inline text editor for
+             policy-editable config files (#833 Phase 1). The server
+             JSON-validates on save and returns 400 → rawSaveError. -->
+        <div v-else-if="isJson" class="h-full flex flex-col overflow-auto">
+          <div class="shrink-0 flex items-center justify-end gap-2 px-4 pt-3">
+            <template v-if="jsonEditing">
+              <button
+                class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                data-testid="files-json-cancel-btn"
+                @click="cancelJsonEdit"
+              >
+                {{ t("common.cancel") }}
+              </button>
+              <button
+                class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-green-600 hover:bg-green-700 text-white"
+                data-testid="files-json-save-btn"
+                @click="saveJsonEdit"
+              >
+                <span class="material-icons text-sm">save</span>
+                {{ t("common.save") }}
+              </button>
+            </template>
+            <button
+              v-else-if="jsonEditable"
+              class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+              data-testid="files-json-edit-btn"
+              @click="startJsonEdit"
+            >
+              <span class="material-icons text-sm">edit</span>
+              {{ t("fileContentRenderer.editJson") }}
+            </button>
+          </div>
+          <textarea
+            v-if="jsonEditing"
+            v-model="jsonDraft"
+            data-testid="files-json-editor"
+            class="flex-1 min-h-0 m-4 px-3 py-2 text-xs font-mono border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 text-gray-800 resize-none"
+            spellcheck="false"
+          ></textarea>
+          <pre v-else class="flex-1 p-4 text-xs whitespace-pre-wrap font-mono text-gray-800"><span
+            v-for="(tok, i) in jsonTokens"
+            :key="i"
+            :class="JSON_TOKEN_CLASS[tok.type]"
+          >{{ tok.value }}</span></pre>
+          <div
+            v-if="rawSaveError"
+            class="shrink-0 m-4 mt-0 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-700"
+            role="alert"
+            data-testid="files-json-save-error"
+          >
+            ⚠ {{ rawSaveError }}
+          </div>
+        </div>
         <!-- JSONL / NDJSON: one pretty-printed + colored record per line -->
         <div v-else-if="isJsonl" class="p-4 space-y-2">
           <div v-for="(line, i) in jsonlLines" :key="i" class="rounded border bg-gray-50 p-3" :class="line.parseError ? 'border-red-300' : 'border-gray-200'">
@@ -148,7 +194,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import CalendarView from "../plugins/scheduler/CalendarView.vue";
@@ -165,7 +211,7 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import { formatScalarField, type MarkdownDocView } from "../composables/useMarkdownDoc";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
-import { descriptorForPath } from "../config/systemFileDescriptors";
+import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
 
 const { t } = useI18n();
 
@@ -195,6 +241,39 @@ const emit = defineEmits<{
 }>();
 
 const systemDescriptor = computed(() => (props.selectedPath ? descriptorForPath(props.selectedPath) : null));
+
+// Inline JSON editor (#833 Phase 1). Available only for policy-editable
+// JSON config files; the read-only pretty-print stays the default.
+const jsonEditing = ref(false);
+const jsonDraft = ref("");
+
+const jsonEditable = computed(() => props.isJson && props.selectedPath !== null && props.content?.kind === "text" && jsonEditableByPolicy(props.selectedPath));
+
+function startJsonEdit(): void {
+  if (props.content?.kind !== "text") return;
+  jsonDraft.value = props.content.content;
+  jsonEditing.value = true;
+}
+
+function cancelJsonEdit(): void {
+  jsonEditing.value = false;
+}
+
+function saveJsonEdit(): void {
+  emit("updateSource", jsonDraft.value);
+}
+
+// Leave edit mode whenever the underlying content changes — that's
+// either a successful save (parent swaps in the new content + clears
+// rawSaveError) or navigation to another file. A failed save leaves
+// content untouched and sets rawSaveError, so we stay in edit mode
+// with the error banner visible.
+watch(
+  () => props.content,
+  () => {
+    jsonEditing.value = false;
+  },
+);
 
 function rawUrl(filePath: string): string {
   return `${API_ROUTES.files.raw}?path=${encodeURIComponent(filePath)}`;

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -134,6 +134,7 @@
           <textarea
             v-if="jsonEditing"
             v-model="jsonDraft"
+            :aria-label="t('fileContentRenderer.jsonEditorLabel')"
             data-testid="files-json-editor"
             class="flex-1 min-h-0 m-4 px-3 py-2 text-xs font-mono border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 text-gray-800 resize-none"
             spellcheck="false"

--- a/src/config/systemFileDescriptors.ts
+++ b/src/config/systemFileDescriptors.ts
@@ -155,6 +155,18 @@ export function descriptorForPath(filePath: string): SystemFileDescriptor | null
   return null;
 }
 
+// editPolicy values for which the Files Explorer offers an inline
+// JSON editor (#833 Phase 1). A path with no descriptor is a plain
+// user-owned file → editable. `agent-managed` / `fragile-format` /
+// `ephemeral` are withheld: hand-edits there risk corrupting state the
+// agent or app owns, or a format too brittle for free-text editing.
+const JSON_EDITABLE_POLICIES: ReadonlySet<EditPolicy> = new Set<EditPolicy>(["user-editable", "agent-managed-but-hand-editable"]);
+
+export function jsonEditableByPolicy(filePath: string): boolean {
+  const descriptor = descriptorForPath(filePath);
+  return descriptor === null || JSON_EDITABLE_POLICIES.has(descriptor.editPolicy);
+}
+
 // Tailwind text colors used to tint a file-icon (or any single-color
 // glyph) according to the system file's edit policy. Same hue as the
 // banner's chip but text-only (no background) — the chip uses a

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -288,6 +288,7 @@ const deMessages = {
     htmlPreview: "HTML-Vorschau",
     pdfPreview: "PDF-Vorschau",
     parseError: "Parse-Fehler",
+    editJson: "JSON bearbeiten",
   },
   filesView: {
     chatPlaceholder: "Frage zu dieser Datei stellen…",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -289,6 +289,7 @@ const deMessages = {
     pdfPreview: "PDF-Vorschau",
     parseError: "Parse-Fehler",
     editJson: "JSON bearbeiten",
+    jsonEditorLabel: "JSON-Editor",
   },
   filesView: {
     chatPlaceholder: "Frage zu dieser Datei stellen…",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -305,6 +305,7 @@ const enMessages = {
     htmlPreview: "HTML preview",
     pdfPreview: "PDF preview",
     parseError: "parse error",
+    editJson: "Edit JSON",
   },
   filesView: {
     chatPlaceholder: "Ask about this file…",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -306,6 +306,7 @@ const enMessages = {
     pdfPreview: "PDF preview",
     parseError: "parse error",
     editJson: "Edit JSON",
+    jsonEditorLabel: "JSON editor",
   },
   filesView: {
     chatPlaceholder: "Ask about this file…",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -291,6 +291,7 @@ const esMessages = {
     htmlPreview: "Vista previa HTML",
     pdfPreview: "Vista previa PDF",
     parseError: "error al analizar",
+    editJson: "Editar JSON",
   },
   filesView: {
     chatPlaceholder: "Pregunta sobre este archivo…",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -292,6 +292,7 @@ const esMessages = {
     pdfPreview: "Vista previa PDF",
     parseError: "error al analizar",
     editJson: "Editar JSON",
+    jsonEditorLabel: "Editor JSON",
   },
   filesView: {
     chatPlaceholder: "Pregunta sobre este archivo…",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -285,6 +285,7 @@ const frMessages = {
     htmlPreview: "Aperçu HTML",
     pdfPreview: "Aperçu PDF",
     parseError: "erreur d'analyse",
+    editJson: "Modifier le JSON",
   },
   filesView: {
     chatPlaceholder: "Posez une question sur ce fichier…",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -286,6 +286,7 @@ const frMessages = {
     pdfPreview: "Aperçu PDF",
     parseError: "erreur d'analyse",
     editJson: "Modifier le JSON",
+    jsonEditorLabel: "Éditeur JSON",
   },
   filesView: {
     chatPlaceholder: "Posez une question sur ce fichier…",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -289,6 +289,7 @@ const jaMessages = {
     htmlPreview: "HTML プレビュー",
     pdfPreview: "PDF プレビュー",
     parseError: "パースエラー",
+    editJson: "JSON を編集",
   },
   filesView: {
     chatPlaceholder: "このファイルについて質問…",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -290,6 +290,7 @@ const jaMessages = {
     pdfPreview: "PDF プレビュー",
     parseError: "パースエラー",
     editJson: "JSON を編集",
+    jsonEditorLabel: "JSON エディタ",
   },
   filesView: {
     chatPlaceholder: "このファイルについて質問…",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -290,6 +290,7 @@ const koMessages = {
     htmlPreview: "HTML 미리보기",
     pdfPreview: "PDF 미리보기",
     parseError: "파싱 오류",
+    editJson: "JSON 편집",
   },
   filesView: {
     chatPlaceholder: "이 파일에 대해 질문하세요…",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -291,6 +291,7 @@ const koMessages = {
     pdfPreview: "PDF 미리보기",
     parseError: "파싱 오류",
     editJson: "JSON 편집",
+    jsonEditorLabel: "JSON 편집기",
   },
   filesView: {
     chatPlaceholder: "이 파일에 대해 질문하세요…",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -284,6 +284,7 @@ const ptBRMessages = {
     htmlPreview: "Pré-visualização HTML",
     pdfPreview: "Pré-visualização PDF",
     parseError: "erro de análise",
+    editJson: "Editar JSON",
   },
   filesView: {
     chatPlaceholder: "Pergunte sobre este arquivo…",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -285,6 +285,7 @@ const ptBRMessages = {
     pdfPreview: "Pré-visualização PDF",
     parseError: "erro de análise",
     editJson: "Editar JSON",
+    jsonEditorLabel: "Editor JSON",
   },
   filesView: {
     chatPlaceholder: "Pergunte sobre este arquivo…",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -283,6 +283,7 @@ const zhMessages = {
     htmlPreview: "HTML 预览",
     pdfPreview: "PDF 预览",
     parseError: "解析错误",
+    editJson: "编辑 JSON",
   },
   filesView: {
     chatPlaceholder: "询问关于此文件的问题…",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -284,6 +284,7 @@ const zhMessages = {
     pdfPreview: "PDF 预览",
     parseError: "解析错误",
     editJson: "编辑 JSON",
+    jsonEditorLabel: "JSON 编辑器",
   },
   filesView: {
     chatPlaceholder: "询问关于此文件的问题…",

--- a/test/config/test_systemFileDescriptors.ts
+++ b/test/config/test_systemFileDescriptors.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { descriptorForPath, SYSTEM_FILE_DESCRIPTORS } from "../../src/config/systemFileDescriptors.js";
+import { descriptorForPath, jsonEditableByPolicy, SYSTEM_FILE_DESCRIPTORS } from "../../src/config/systemFileDescriptors.js";
 
 describe("descriptorForPath — exact matches", () => {
   it("returns the interests descriptor for config/interests.json", () => {
@@ -99,5 +99,28 @@ describe("SYSTEM_FILE_DESCRIPTORS — invariants", () => {
         assert.ok(!entry.path.startsWith("/"), `${entry.path} must be workspace-relative`);
       }
     }
+  });
+});
+
+describe("jsonEditableByPolicy (#833)", () => {
+  it("allows a plain user file with no descriptor", () => {
+    assert.equal(jsonEditableByPolicy("notes/scratch.json"), true);
+  });
+
+  it("allows user-editable system files (settings/mcp)", () => {
+    assert.equal(jsonEditableByPolicy("config/settings.json"), true);
+    assert.equal(jsonEditableByPolicy("config/mcp.json"), true);
+  });
+
+  it("allows agent-managed-but-hand-editable (interests)", () => {
+    assert.equal(jsonEditableByPolicy("config/interests.json"), true);
+  });
+
+  it("withholds editing from agent-managed files (scheduler tasks)", () => {
+    assert.equal(jsonEditableByPolicy("config/scheduler/tasks.json"), false);
+  });
+
+  it("withholds editing from ephemeral state files", () => {
+    assert.equal(jsonEditableByPolicy("data/sources/_state/example.json"), false);
   });
 });

--- a/test/routes/test_filesPutRoute.ts
+++ b/test/routes/test_filesPutRoute.ts
@@ -238,3 +238,46 @@ describe("PUT /api/files/content — missing targets", () => {
     assert.match((state.body as ErrorBody).error, /not a file/i);
   });
 });
+
+describe("PUT /api/files/content — JSON validation (#833)", () => {
+  it("rejects a syntactically invalid .json save with 400 and does not write to disk", async () => {
+    const rel = "config.json";
+    const original = '{\n  "a": 1\n}';
+    await writeFile(path.join(workspaceDir, rel), original, "utf-8");
+
+    const { state, res } = mockRes();
+    await putHandler(req({ path: rel, content: "{ broken" }), res);
+
+    assert.equal(state.status, 400);
+    assert.match((state.body as ErrorBody).error, /invalid json/i);
+    // The malformed body must never reach disk — the original stays.
+    const onDisk = await promises.readFile(path.join(workspaceDir, rel), "utf-8");
+    assert.equal(onDisk, original);
+  });
+
+  it("accepts a valid .json save", async () => {
+    const rel = "config.json";
+    await writeFile(path.join(workspaceDir, rel), "{}", "utf-8");
+
+    const { state, res } = mockRes();
+    await putHandler(req({ path: rel, content: '{\n  "theme": "dark"\n}' }), res);
+
+    assert.equal(state.status, 200);
+    const onDisk = await promises.readFile(path.join(workspaceDir, rel), "utf-8");
+    assert.equal(onDisk, '{\n  "theme": "dark"\n}');
+  });
+
+  it("does not apply JSON validation to .jsonl (multi-document; whole-file parse would always fail)", async () => {
+    const rel = "log.jsonl";
+    await writeFile(path.join(workspaceDir, rel), '{"n":1}\n', "utf-8");
+
+    const { state, res } = mockRes();
+    // Two newline-delimited objects: not a single JSON value, so a
+    // .json gate would reject it. .jsonl must remain writable.
+    await putHandler(req({ path: rel, content: '{"n":1}\n{"n":2}\n' }), res);
+
+    assert.equal(state.status, 200);
+    const onDisk = await promises.readFile(path.join(workspaceDir, rel), "utf-8");
+    assert.equal(onDisk, '{"n":1}\n{"n":2}\n');
+  });
+});


### PR DESCRIPTION
## Summary

Files Explorer could only edit markdown. This adds a **Text-mode inline JSON editor** for policy-editable config files, with server-side parse validation (#833 Phase 1).

- **Server**: `PUT /api/files/content` runs `JSON.parse` on the body when the target is `.json` and returns **400 + the parser message** before writing — a syntax-broken hand-edit never reaches disk. `.jsonl` excluded (each line is its own document).
- **UI**: read-only JSON pretty-print gains an **Edit → textarea → Save/Cancel** flow, reusing the existing `updateSource → PUT files/content` path. A 400 surfaces in the existing `rawSaveError` banner and the editor stays open so the user can fix the value.
- **Gating**: `jsonEditableByPolicy(path)` via #832's `editPolicy` — editable when no descriptor (plain user file) or `user-editable` / `agent-managed-but-hand-editable`; **withheld** for `agent-managed`, `fragile-format`, `ephemeral`.

## Items to Confirm / Review

- **Edit-visibility policy** (chosen interactively): `user-editable` + `agent-managed-but-hand-editable` + no-descriptor plain JSON. `fragile-format` is intentionally **not** editable in Phase 1 (conservative; revisit with Phase 2 schema mode).
- **Validate-only, no reformat**: Phase 1 deliberately does not prettier-normalize on save (predictable diffs). Listed as out-of-scope.
- Reuses the markdown save path (`saveRawMarkdown` → `PUT files/content`) rather than a new endpoint — the only server change is one validation step in the existing handler.

## User Prompt

> next 833

(Issue #833 — placement/policy clarified interactively: Settings-style Edit gating by editPolicy, Phase 1 = Text mode + JSON validate.)

## Test plan

- [ ] Open a `config/settings.json` in /files → Edit → change value → Save → persists; reopen reflects
- [ ] Save broken JSON → red banner with parser message, editor stays open
- [ ] `config/scheduler/tasks.json` (agent-managed) → no Edit button
- [ ] `node --test test/config/test_systemFileDescriptors.ts` (22 pass)
- [ ] `e2e/tests/files-json-edit.spec.ts` (3 pass) + format/lint/typecheck/build CI

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)