### PR TITLE
feat(mcp): transport-aware catalog — Docker note + GitHub→HTTP (#1421 A1)

### DIFF
--- a/src/components/SettingsMcpTab.vue
+++ b/src/components/SettingsMcpTab.vue
@@ -62,6 +62,24 @@
               ></a>
             </div>
 
+            <!-- Sandbox-incompatible note (#1421 A1). A catalog entry
+                 whose template spec is stdio is dropped server-side
+                 in Docker mode (server/agent/config.ts) — the sandbox
+                 image can't host npx/python runtimes. Surface the
+                 same warning the installed-server list already shows
+                 for custom stdio servers (#1334) so the catalog
+                 toggle isn't a silent no-op under Docker. -->
+            <div
+              v-if="dockerMode && entry.spec.type === 'stdio'"
+              class="flex items-baseline gap-2 text-amber-700 text-[11px] ml-6"
+              :data-testid="`mcp-catalog-docker-warning-${entry.id}`"
+            >
+              <span>{{ t("settingsMcpTab.dockerStdioUnsupported") }}</span>
+              <a :href="MCP_SANDBOX_DOC_URL" target="_blank" rel="noopener noreferrer" class="underline whitespace-nowrap">
+                {{ t("settingsMcpTab.learnMore") }}
+              </a>
+            </div>
+
             <!-- Per-server config form (Phase 2). Only the entry being
                  actively configured renders the form; toggling a different
                  entry on closes this one. -->

--- a/src/config/mcpCatalog.ts
+++ b/src/config/mcpCatalog.ts
@@ -406,14 +406,19 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     displayName: "settingsMcpTab.catalog.entry.github.displayName",
     description: "settingsMcpTab.catalog.entry.github.description",
     audience: "general",
-    upstreamUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/github",
-    setupGuideUrl: "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+    upstreamUrl: "https://github.com/github/github-mcp-server",
+    setupGuideUrl: "https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp/set-up-the-github-mcp-server",
+    // Switched stdio (@modelcontextprotocol/server-github) → the
+    // provider-hosted remote MCP (#1421 A1). HTTP transport works
+    // under the Docker sandbox, where the stdio reference server is
+    // dropped (server/agent/config.ts — no npx in the minimal
+    // image). PAT auth keeps it OAuth-free; the configSchema key
+    // and its i18n are unchanged so installs/migrations stay valid.
     spec: {
-      type: "stdio",
-      command: "npx",
-      args: ["-y", "@modelcontextprotocol/server-github"],
-      env: {
-        GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PERSONAL_ACCESS_TOKEN}",
+      type: "http",
+      url: "https://api.githubcopilot.com/mcp/",
+      headers: {
+        Authorization: "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}",
       },
     },
     configSchema: [


### PR DESCRIPTION
## Summary

Phase A1 of #1421 (transport-aware catalog, no OAuth). Two coherent changes:

### A1.1 — Docker-incompat note on stdio catalog entries
Catalog entries whose template spec is stdio are dropped server-side in Docker mode (`server/agent/config.ts`), but the catalog toggle gave no hint — enabling Memory / Notion / Slack / Google Maps under Docker was a silent no-op. Adds the same amber "unsupported under Docker sandbox" note + learn-more link the installed-server list already shows for custom stdio servers (#1334). Gated on `dockerMode && entry.spec.type === 'stdio'`, reuses existing i18n keys (no new strings).

### A1.2 — GitHub catalog entry stdio → hosted-HTTP
GitHub now runs an official provider-hosted remote MCP (`https://api.githubcopilot.com/mcp/`) with PAT auth. Swapped the entry's spec from stdio (`@modelcontextprotocol/server-github`, dropped under Docker) to HTTP with `Authorization: Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}`. configSchema key + i18n unchanged → existing installs/migrations and the config form keep working. Works inside the sandbox, no OAuth.

## Sequence (#1421, one PR at a time)

- **A1.1 + A1.2 (this PR)** ✅
- Follow-up: GitLab entry (also hosted-HTTP `gitlab.com/api/v4/mcp`, token auth — additive entry + 8-locale i18n)
- Phase B: opt-in stdio→HTTP shim for the 4 genuine stdio-only servers (Memory / Sequential Thinking / Google Maps / Weather), explicit "escapes sandbox" acknowledgment
- Phase A2: MCP OAuth foundation (loopback+PKCE, separate prerequisite issue) → OAuth hosted-HTTP entries (Notion/Slack/Linear/Sentry/Cloudflare/Todoist)

## Items to Confirm / Review

- A1.2 is a behavior change for existing GitHub catalog users: the server now reaches `api.githubcopilot.com/mcp/` over HTTP instead of spawning `npx`. Same PAT, same scopes. Net positive (also fixes Docker), but worth a deliberate ack.
- Pure additive UI for A1.1, mirrors the audited #1334 pattern.

## Test plan

- [x] `yarn typecheck` / `yarn lint` green
- [ ] Docker mode: stdio catalog entries show the amber note; HTTP entries (DeepWiki, now GitHub) do not
- [ ] GitHub entry: enter a PAT → installs as an HTTP server → works under Docker
- [ ] Non-Docker: unchanged

Refs #1421, #1334, #823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)