### PR TITLE
ci: add actionlint + zizmor workflow static checks (#1423)

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -124,7 +124,22 @@ jobs:
           mkdir -p "$HOME/.codex"
           # Strip trailing slash so concatenation never doubles up.
           BASE_URL="${AZURE_BASE_URL%/}"
-          cat > "$HOME/.codex/config.toml" <<TOML
+          # Quoted heredoc (<<'TOML') = pure literal: the TOML body
+          # (with its `=`, `{ }`, comments) is never parsed as shell,
+          # so no accidental command substitution. envsubst then fills
+          # ONLY the three whitelisted vars — anything else, including
+          # a literal `$x` in TOML, is left untouched.
+          # Codex CLI 0.125.0 only supports the "responses" wire (Chat
+          # Completions was removed); on Azure that needs
+          # api-version >= 2025-03-01-preview on a deployment exposing
+          # the Responses surface (recent gpt-4o / gpt-4.1 / gpt-5).
+          export AZURE_MODEL BASE_URL AZURE_API_VERSION
+          # envsubst's SHELL-FORMAT arg MUST stay single-quoted: it is
+          # the literal allowlist of names to replace, not a shell
+          # expansion. SC2016 is exactly backwards here.
+          # shellcheck disable=SC2016
+          envsubst '${AZURE_MODEL} ${BASE_URL} ${AZURE_API_VERSION}' \
+            > "$HOME/.codex/config.toml" <<'TOML'
           model_provider = "azure"
           model = "${AZURE_MODEL}"
 
@@ -132,11 +147,6 @@ jobs:
           name = "Azure OpenAI"
           base_url = "${BASE_URL}/openai/v1"
           env_key = "OPENAI_API_KEY"
-          # Codex CLI 0.125.0 only supports `responses` (Chat
-          # Completions wire was removed). On Azure this needs
-          # `api-version = 2025-03-01-preview` or newer + a
-          # deployment that exposes the Responses surface (recent
-          # gpt-4o / gpt-4.1 / gpt-5 family does).
           wire_api = "responses"
           query_params = { "api-version" = "${AZURE_API_VERSION}" }
           TOML

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -77,6 +77,9 @@ jobs:
         with:
           # Codex needs full history to inspect the PR diff via `gh`.
           fetch-depth: 0
+          # `gh` uses GH_TOKEN env, not git-persisted creds, so
+          # dropping them is safe (zizmor artipacked).
+          persist-credentials: false
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e_live_no_llm.yaml
+++ b/.github/workflows/e2e_live_no_llm.yaml
@@ -57,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false  # no git push; zizmor artipacked
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/mulmoclaude_smoke.yaml
+++ b/.github/workflows/mulmoclaude_smoke.yaml
@@ -54,6 +54,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false  # no git push; zizmor artipacked
 
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false  # no git push; zizmor artipacked
       - id: filter
         shell: bash
         run: |
@@ -61,6 +62,8 @@ jobs:
         os: [ubuntu-latest, windows-2022, macos-latest]
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false  # no git push; zizmor artipacked
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
@@ -136,6 +139,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false  # no git push; zizmor artipacked
       - uses: actions/setup-node@v6
         with:
           node-version: 24.x
@@ -189,6 +194,8 @@ jobs:
         shard: [1, 2]
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false  # no git push; zizmor artipacked
     - name: Use Node.js 22.x
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # full history scan needs every commit
+          persist-credentials: false  # read-only scan; don't persist the token
 
       # gitleaks-action@v2 は Organization 配下だとライセンスキー必須になったため、
       # MIT ライセンスの gitleaks CLI バイナリを直接実行する。

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -1,0 +1,87 @@
+name: workflow-lint
+
+# Static analysis for the GitHub Actions workflows themselves:
+#   - actionlint: YAML / ${{ }} expression syntax + embedded shellcheck
+#                 on `run:` blocks
+#   - zizmor:     workflow security (template injection, excessive
+#                 permissions, artifact poisoning); complements CodeQL
+#
+# Follows the repo's supply-chain posture (see secret-scan.yml): pull a
+# version-pinned CLI binary and SHA256-verify it rather than depending
+# on a third-party GitHub Action. Refresh VERSION + SHA256 together
+# when bumping (checksums: actionlint ships a checksums.txt; zizmor's
+# is computed from the linux x86_64 tarball).
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/**'
+
+permissions:
+  # Least privilege: both tools only read the checked-out workflows.
+  contents: read
+
+jobs:
+  workflow-lint:
+    name: workflow-lint (actionlint + zizmor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # No git pushes from this job; don't leave the token in
+          # .git/config (zizmor artipacked).
+          persist-credentials: false
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          # sha256 of actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz
+          # from the release's actionlint_<v>_checksums.txt.
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ARCHIVE}"
+          echo "${ACTIONLINT_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" actionlint
+          rm -f "$ARCHIVE"
+          actionlint --version
+
+      - name: Run actionlint
+        # Lints every workflow under .github/workflows. Embedded
+        # shellcheck (run: blocks) and pyflakes run automatically when
+        # those tools are on PATH — ubuntu-latest ships shellcheck.
+        run: actionlint -color
+
+      - name: Install zizmor
+        env:
+          ZIZMOR_VERSION: 1.25.2
+          # sha256 of zizmor-x86_64-unknown-linux-gnu.tar.gz computed
+          # from the release tarball (zizmor publishes no checksums
+          # file — recompute on every version bump).
+          ZIZMOR_SHA256: aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577
+        run: |
+          set -euo pipefail
+          ARCHIVE="zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/${ARCHIVE}"
+          echo "${ZIZMOR_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" zizmor
+          rm -f "$ARCHIVE"
+          zizmor --version
+
+      - name: Run zizmor
+        # Offline, default ("regular") persona — low false-positive.
+        # .github/zizmor.yml relaxes unpinned-uses for first-party
+        # actions/* (tag pins accepted) while still requiring a hash
+        # pin for any future third-party action. GITHUB_TOKEN lets the
+        # few online audits resolve refs; read-only per the job perms.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zizmor --persona=regular .github/workflows

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# zizmor configuration. See https://docs.zizmor.sh/configuration/
+#
+# unpinned-uses: this repo deliberately tag-pins the first-party
+# `actions/*` actions (checkout / setup-node / cache / upload-artifact)
+# rather than SHA-pinning them — official actions, low supply-chain
+# risk, and SHA pins force constant Dependabot churn. So allow a plain
+# ref (tag) pin for `actions/*`, but still require a full hash pin for
+# anything else, so a future third-party / community action can't slip
+# in tag-pinned unnoticed. Revisit if non-first-party actions are
+# introduced. (#1423)
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "*": hash-pin

--- a/plans/ci-workflow-lint-1423.md
+++ b/plans/ci-workflow-lint-1423.md
@@ -1,0 +1,50 @@
+# ci: actionlint + zizmor for GitHub Actions workflows (#1423)
+
+## 背景
+
+workflow YAML 専用の静的解析が無い。CodeQL `Analyze (actions)` は
+動くが `${{ }}` 構文ミスや `run:` の shellcheck、workflow 固有の
+セキュリティ smell は拾わない。記事
+（https://zenn.dev/kou_pg_0131/articles/gha-static-checker）の
+actionlint / ghalint / zizmor を現状 CI に照らして評価:
+
+- **actionlint** — 構文 + 式 + 埋め込み shellcheck。低ノイズ高価値 → 採用
+- **zizmor** — workflow セキュリティ（テンプレートインジェクション・
+  過剰権限・artifact poisoning）。CodeQL と相補 → 採用（regular persona）
+- **ghalint** — 主価値の `permissions:` 必須は5本全て既達。hash-pin
+  ルールが first-party `actions/*` に churn を強いる → **見送り**
+  （community action 導入時に再検討）
+
+## 実装
+
+- `.github/workflows/workflow-lint.yaml`（新規）。`.github/**` 変更の
+  PR/push でトリガ。リポジトリの supply-chain 方針（`secret-scan.yml`
+  と同じ）に従い **version+SHA256 pin したバイナリを DL+検証** して
+  実行（third-party action 不使用）。
+  - actionlint `v1.7.12`（SHA256 は release の checksums.txt 由来）
+  - zizmor `v1.25.2`（checksums 非公開のため tarball から算出）
+- `.github/zizmor.yml`: `unpinned-uses` を `actions/*` は `ref-pin`、
+  その他は `hash-pin`。first-party のタグ pin を許容しつつ将来の
+  third-party action はタグ pin だと検出される。ghalint 見送り判断と整合。
+- zizmor `artipacked`（checkout が token を .git/config に残す）9 件を
+  全 workflow の `actions/checkout` に `persist-credentials: false` を
+  付けて解消（いずれの job も git push しない。`gh` は GH_TOKEN env 認証
+  なので codex_review も安全）。
+
+## 検証（ローカル、mac バイナリ）
+
+- `actionlint` → exit 0（新 workflow 含む全 5+1 本クリーン）
+- `zizmor --persona=regular`（`.github/zizmor.yml` 適用）→ exit 0
+  "No findings"（unpinned-uses 23 件は config で suppress）
+
+## 完了条件（#1423）
+
+- [x] actionlint + zizmor が `.github/**` PR で実行・findings で fail
+- [x] 両ツール version+SHA256 pin（DL+検証）
+- [x] zizmor config が `actions/*` の SHA-pin churn を再導入しない
+- [x] 既存 5 workflow が両ツールを通過（artipacked 9 件修正）
+
+## スコープ外
+
+- ghalint 導入（別途、community action 追加時）
+- 既存 `actions/*` の SHA pin 化（方針として tag pin 維持）


### PR DESCRIPTION
## Summary

Adds dedicated static analysis for the GitHub Actions workflows, per the review of https://zenn.dev/kou_pg_0131/articles/gha-static-checker:

- **actionlint** — YAML / `${{ }}` expression syntax + embedded shellcheck on `run:` blocks.
- **zizmor** — workflow security (template injection, excessive permissions, artifact poisoning); complements the existing CodeQL `Analyze (actions)`.
- **ghalint — deliberately skipped**: its headline value (mandatory `permissions:`) is already satisfied by all 5 existing workflows, and its hash-pin rule would force SHA-pinning the first-party `actions/*` (constant Dependabot churn). Revisit if community actions are introduced.

## Items to Confirm / Review

- **Supply-chain pattern**: follows `secret-scan.yml` — version-pinned binary download + SHA256 verify, **not** a third-party action. actionlint `v1.7.12` (SHA from its `checksums.txt`), zizmor `v1.25.2` (SHA computed from the tarball — zizmor publishes none; recompute on bump).
- **`.github/zizmor.yml`**: `unpinned-uses` → `ref-pin` for `actions/*`, `hash-pin` for everything else. This keeps the repo's accepted tag-pin posture for official actions while still flagging any future third-party action — i.e. it does **not** reintroduce the churn that ghalint was skipped to avoid.
- **`artipacked` fixes (9)**: every `actions/checkout` now sets `persist-credentials: false`. No job pushes via git; `gh` authenticates via `GH_TOKEN` env (not git-persisted creds), so `codex_review` is safe. Please sanity-check no job actually relies on persisted git credentials.

## User Prompt

> https://zenn.dev/kou_pg_0131/articles/gha-static-checker この記事にあるツールで入れたほうが良いのある？
> ok 推奨で。

(Recommended set = actionlint + zizmor; ghalint excluded per the analysis, user approved.)

## Test plan

- [ ] `workflow-lint` job runs on this PR (it touches `.github/**`) and passes
- [ ] Local: `actionlint` exit 0, `zizmor --persona=regular` "No findings" across all 6 workflows (done)
- [ ] Existing CI (Node.js CI / smoke / e2e) unaffected by the `persist-credentials: false` additions

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)