### PR TITLE
fix(smoke): poll plugin list to outrun fire-and-forget loader

### DIFF
--- a/plans/fix-smoke-plugin-probe-race.md
+++ b/plans/fix-smoke-plugin-probe-race.md
@@ -1,0 +1,84 @@
+# Fix: `mulmoclaude_smoke` runtime-plugin probe race
+
+## Symptom
+
+`mulmoclaude_smoke` workflow intermittently fails at the tarball stage:
+
+```
+✗ tarball  runtime plugin probe failed: dev plugin "@smoke/dev-fixture@dev" not in list — saw:
+```
+
+The list comes back empty (`saw:` trailing nothing). Triggers on PRs that
+touch unrelated paths in the workflow's `paths:` filter (`package.json`,
+`server/**`, `src/**`, …) — including PR #1411 (Playwright dep tweak).
+
+## Root cause
+
+Plugin loading runs inside a fire-and-forget IIFE at
+`server/index.ts:940`:
+
+```js
+void (async () => {
+  const [presets, userInstalled, devLoad] = await Promise.all([
+    loadPresetPlugins(...),
+    loadRuntimePlugins(...),
+    loadDevPlugins(...),
+  ]);
+  ...
+  registerRuntimePlugins(staticToolNames, [...presets, ...userInstalled, ...devLoad.plugins]);
+})();
+```
+
+The IIFE fires AFTER `app.listen()` returns, so the `/` route can answer
+200 before `registerRuntimePlugins` runs. `runTarballSmoke` polls `/`
+until 200, then immediately probes `/api/plugins/runtime/list` — on a
+fast boot (warm cache, light load) the probe wins the race against the
+IIFE and the list is `[]`.
+
+Downloaded launcher.log from run 25985390538 confirms it:
+
+```
+2026-05-17T08:07:35.476Z INFO  [server] listening port=34447
+2026-05-17T08:07:35.742Z INFO  [server] shutting down signal=SIGTERM
+```
+
+266 ms between listening and the smoke killing the server. No log lines
+about plugin loading in between — the IIFE hadn't logged anything yet.
+
+Last successful main run (#1424 merge, 25981541291) booted slowly:
+"HTTP 200 on port 35103 after 10 attempt(s) (4515ms)" — 4.5 s of poll
+attempts gave the IIFE time to finish. The race has been latent forever;
+fast boots just make it visible.
+
+## Fix
+
+Make `probeRuntimePlugins` poll when `expectedDevPlugin` is set —
+single-shot is wrong when the thing we're asserting on is loaded
+asynchronously. Same poll-until-condition pattern as `pollHttp`.
+
+- Add `pollTimeoutMs` (default 10 s) and `pollIntervalMs` (default
+  250 ms) options.
+- Extract the single-attempt logic into a private helper
+  (`runRuntimePluginsProbeOnce`) so the poll loop doesn't duplicate
+  response-shape checks.
+- When `expectedDevPlugin` is null, keep one-shot behaviour: an empty
+  list is a legitimate state (fresh install) and polling would just
+  burn the budget.
+- Inject `now` / `sleep` so unit tests stay deterministic.
+
+Why not "wait for plugins to load before listening" in the launcher?
+That would slow real users' boot and is a bigger surface change. The
+smoke is the one consumer that needs the strong ordering; bake the wait
+into the smoke.
+
+## Test plan
+
+- Unit tests added to `test/scripts/mulmoclaude/test_tarball.ts`:
+  - polls until `expectedDevPlugin` appears (3 attempts, 2 sleeps)
+  - gives up after `pollTimeoutMs` and preserves the last error
+  - does NOT poll when `expectedDevPlugin` is absent (one-shot)
+  - existing "expected plugin absent" tests pin `pollTimeoutMs: 0` so
+    they assert on the single-attempt error shape, not the
+    poll-and-give-up path.
+- `yarn lint` / `yarn typecheck` clean.
+- Whole tarball suite runs in 260 ms (no real-time sleeps).

--- a/scripts/mulmoclaude/tarball.d.mts
+++ b/scripts/mulmoclaude/tarball.d.mts
@@ -72,6 +72,18 @@ export interface ProbeRuntimePluginsOptions {
    *  this name appears in the list with version `"dev"`. Used by the
    *  smoke variant that boots with `--dev-plugin <fixture>`. */
   expectedDevPlugin?: string | null;
+  /** Upper bound on how long to keep polling the list endpoint while
+   *  waiting for `expectedDevPlugin` to appear. Plugin loading is a
+   *  fire-and-forget IIFE that resolves after `app.listen()`, so a
+   *  single-shot probe can race the loader and see an empty array.
+   *  Ignored when `expectedDevPlugin` is absent. */
+  pollTimeoutMs?: number;
+  /** Delay between poll attempts when waiting for `expectedDevPlugin`. */
+  pollIntervalMs?: number;
+  /** Injectable clock for tests — defaults to `Date.now`. */
+  now?: () => number;
+  /** Injectable sleep for tests — defaults to a real `setTimeout`. */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export function probeRuntimePlugins(options: ProbeRuntimePluginsOptions): Promise<RuntimePluginProbeResult>;

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -226,11 +226,14 @@ export async function readTokenFromLauncherLog({ logFile, readFileImpl = readFil
 // Plugin loading runs in a fire-and-forget IIFE that resolves AFTER
 // `app.listen()`, so the very first request can see an empty list
 // even when everything is wired correctly. When `expectedDevPlugin`
-// is set we poll until the plugin appears or the budget expires —
-// the assertion is "this plugin loads", not "it loaded by the time
-// the / route went 200". For the plain probe (no expectation), the
-// list may legitimately be empty at any moment after boot, so a
-// single shot is sufficient.
+// is set we poll the **transient** failure modes (fetch error while
+// the server is still binding, or 200 with the dev plugin not yet in
+// the list) until the plugin appears or the budget expires.
+// Permanent failures — non-200 status, body shape regression, JSON
+// parse error — fail immediately so a real auth / route regression
+// surfaces in the CI log without 10s of dead poll attempts. For the
+// plain probe (no expectation), the list may legitimately be empty
+// at any moment after boot, so a single shot is sufficient.
 export async function probeRuntimePlugins({
   port,
   token,
@@ -247,20 +250,29 @@ export async function probeRuntimePlugins({
   // Without an expected plugin we have no signal to wait for; one
   // attempt is the right behaviour (preserves the original semantics).
   if (!expectedDevPlugin) {
-    return runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin });
+    return stripRetryable(await runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin }));
   }
   const startedAt = now();
   let lastResult = await runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin });
-  while (!lastResult.ok && now() - startedAt < pollTimeoutMs) {
+  while (!lastResult.ok && lastResult.retryable && now() - startedAt < pollTimeoutMs) {
     await sleep(pollIntervalMs);
     lastResult = await runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin });
   }
-  return lastResult;
+  return stripRetryable(lastResult);
 }
 
-// Single-shot probe — one HTTP call, one verdict. Pulled out so the
-// polling layer in `probeRuntimePlugins` can drive retries without
-// re-implementing the response-shape checks.
+// `retryable` is an internal contract between the poll loop and the
+// single-shot probe — callers see the result without it (keeps the
+// public shape stable for unit tests and the smoke driver).
+function stripRetryable(result) {
+  const { retryable: _retryable, ...rest } = result;
+  return rest;
+}
+
+// Single-shot probe — one HTTP call, one verdict. The `retryable`
+// flag tells the caller whether a !ok result should trigger a retry
+// (race against fire-and-forget plugin loader) or fail immediately
+// (real configuration / route regression).
 async function runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin }) {
   let response;
   try {
@@ -268,28 +280,40 @@ async function runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevP
       headers: { Authorization: `Bearer ${token}` },
     });
   } catch (err) {
-    return { ok: false, status: null, plugins: 0, lastError: `fetch failed: ${err instanceof Error ? err.message : String(err)}` };
+    // Transport-level failure — server is still binding, or the
+    // listener went away mid-boot. Retry: the boot probe already
+    // confirmed `/` answered 200, so this is transient by design.
+    return { ok: false, status: null, plugins: 0, lastError: `fetch failed: ${err instanceof Error ? err.message : String(err)}`, retryable: true };
   }
   if (response.status !== 200) {
-    return { ok: false, status: response.status, plugins: 0, lastError: `status ${response.status}` };
+    // 401 / 403 / 5xx are configuration or route regressions, not
+    // races. Fail fast so the CI log points at the actual problem
+    // instead of "we waited 10s and still got 401".
+    return { ok: false, status: response.status, plugins: 0, lastError: `status ${response.status}`, retryable: false };
   }
   let body;
   try {
     body = await response.json();
   } catch (err) {
-    return { ok: false, status: 200, plugins: 0, lastError: `json parse failed: ${err instanceof Error ? err.message : String(err)}` };
+    // 200 with a non-JSON body means the route is serving the wrong
+    // content (e.g. an error page proxied through). Permanent.
+    return { ok: false, status: 200, plugins: 0, lastError: `json parse failed: ${err instanceof Error ? err.message : String(err)}`, retryable: false };
   }
   if (!Array.isArray(body?.plugins)) {
-    return { ok: false, status: 200, plugins: 0, lastError: "response body is not { plugins: [...] }" };
+    // Response shape regression — the contract changed under us.
+    // Retrying can't heal a broken contract.
+    return { ok: false, status: 200, plugins: 0, lastError: "response body is not { plugins: [...] }", retryable: false };
   }
   if (expectedDevPlugin) {
     const match = body.plugins.find((entry) => entry.name === expectedDevPlugin && entry.version === "dev");
     if (!match) {
+      // The race we're actually fixing: route is wired, body shape
+      // is right, but the IIFE hasn't registered yet. Retry.
       const seen = body.plugins.map((entry) => `${entry.name}@${entry.version}`).join(", ");
-      return { ok: false, status: 200, plugins: body.plugins.length, lastError: `dev plugin "${expectedDevPlugin}@dev" not in list — saw: ${seen}` };
+      return { ok: false, status: 200, plugins: body.plugins.length, lastError: `dev plugin "${expectedDevPlugin}@dev" not in list — saw: ${seen}`, retryable: true };
     }
   }
-  return { ok: true, status: 200, plugins: body.plugins.length, lastError: null };
+  return { ok: true, status: 200, plugins: body.plugins.length, lastError: null, retryable: false };
 }
 
 // Lay out a minimal dev-plugin fixture: a directory with package.json

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -32,6 +32,16 @@ const DEFAULT_POLL_INTERVAL_MS = 500;
 const DEFAULT_PACK_TIMEOUT_MS = 60_000;
 const DEFAULT_INSTALL_TIMEOUT_MS = 180_000;
 const KILL_GRACE_MS = 2_000;
+// Plugin loading runs inside a fire-and-forget IIFE in `server/index.ts`
+// that fires AFTER `app.listen()` returns. The `/` route therefore goes
+// 200 before presets / user-installed / dev plugins finish resolving.
+// On slow boots (cold yarn install) the list is populated by probe
+// time; on fast boots the probe wins the race and sees `[]`. Poll the
+// list endpoint up to this budget so the assertion survives either
+// ordering. 10s comfortably covers preset + dev-fixture import on CI
+// hardware while still failing fast when the IIFE actually crashed.
+const DEFAULT_PLUGIN_PROBE_TIMEOUT_MS = 10_000;
+const DEFAULT_PLUGIN_PROBE_INTERVAL_MS = 250;
 
 // Ask the OS for a random free TCP port on 127.0.0.1. Binding to 0
 // returns whatever port the kernel assigns; we close immediately and
@@ -212,10 +222,46 @@ export async function readTokenFromLauncherLog({ logFile, readFileImpl = readFil
 // list MUST contain a plugin matching that name with version `"dev"`.
 // This is what proves the `--dev-plugin` CLI flag → env-var → server
 // loader → registry → /list pipeline made it end-to-end (#1159 PR2).
-export async function probeRuntimePlugins({ port, token, fetchImpl = globalThis.fetch, expectedDevPlugin = null } = {}) {
+//
+// Plugin loading runs in a fire-and-forget IIFE that resolves AFTER
+// `app.listen()`, so the very first request can see an empty list
+// even when everything is wired correctly. When `expectedDevPlugin`
+// is set we poll until the plugin appears or the budget expires —
+// the assertion is "this plugin loads", not "it loaded by the time
+// the / route went 200". For the plain probe (no expectation), the
+// list may legitimately be empty at any moment after boot, so a
+// single shot is sufficient.
+export async function probeRuntimePlugins({
+  port,
+  token,
+  fetchImpl = globalThis.fetch,
+  expectedDevPlugin = null,
+  pollTimeoutMs = DEFAULT_PLUGIN_PROBE_TIMEOUT_MS,
+  pollIntervalMs = DEFAULT_PLUGIN_PROBE_INTERVAL_MS,
+  now = Date.now,
+  sleep = defaultSleep,
+} = {}) {
   if (!token) {
     return { ok: false, status: null, plugins: 0, lastError: "no bearer token (could not extract from launcher log)" };
   }
+  // Without an expected plugin we have no signal to wait for; one
+  // attempt is the right behaviour (preserves the original semantics).
+  if (!expectedDevPlugin) {
+    return runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin });
+  }
+  const startedAt = now();
+  let lastResult = await runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin });
+  while (!lastResult.ok && now() - startedAt < pollTimeoutMs) {
+    await sleep(pollIntervalMs);
+    lastResult = await runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin });
+  }
+  return lastResult;
+}
+
+// Single-shot probe — one HTTP call, one verdict. Pulled out so the
+// polling layer in `probeRuntimePlugins` can drive retries without
+// re-implementing the response-shape checks.
+async function runRuntimePluginsProbeOnce({ port, token, fetchImpl, expectedDevPlugin }) {
   let response;
   try {
     response = await fetchImpl(`http://127.0.0.1:${port}/api/plugins/runtime/list`, {

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -299,7 +299,9 @@ describe("probeRuntimePlugins", () => {
           headers: { "content-type": "application/json" },
         }),
     );
-    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl, expectedDevPlugin: "@smoke/dev-fixture" });
+    // pollTimeoutMs=0 skips retries — this test asserts on the
+    // single-attempt error shape, not the poll-and-give-up path.
+    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl, expectedDevPlugin: "@smoke/dev-fixture", pollTimeoutMs: 0 });
     assert.equal(result.ok, false);
     assert.match(result.lastError ?? "", /@smoke\/dev-fixture@dev/);
     assert.match(result.lastError ?? "", /@example\/installed@0\.1\.0/);
@@ -317,8 +319,76 @@ describe("probeRuntimePlugins", () => {
           headers: { "content-type": "application/json" },
         }),
     );
-    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl, expectedDevPlugin: "@smoke/dev-fixture" });
+    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl, expectedDevPlugin: "@smoke/dev-fixture", pollTimeoutMs: 0 });
     assert.equal(result.ok, false);
+  });
+
+  // Plugin loading runs in a fire-and-forget IIFE that resolves AFTER
+  // `app.listen()`, so `/` can return 200 while the list endpoint
+  // still reports `[]`. When `expectedDevPlugin` is set the probe
+  // must poll until the plugin appears — otherwise the smoke flakes
+  // on fast boots that win the race against plugin loading.
+  it("polls until expectedDevPlugin appears when initial responses show an empty list", async () => {
+    let call = 0;
+    const fetchImpl = fakeFetch(() => {
+      call += 1;
+      const plugins = call < 3 ? [] : [{ name: "@smoke/dev-fixture", version: "dev" }];
+      return new Response(JSON.stringify({ plugins }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const sleeps: number[] = [];
+    let now = 0;
+    const result = await tarball.probeRuntimePlugins({
+      port: 3099,
+      token: "tok",
+      fetchImpl,
+      expectedDevPlugin: "@smoke/dev-fixture",
+      pollTimeoutMs: 5_000,
+      pollIntervalMs: 100,
+      now: () => now,
+      sleep: async (delayMs: number) => {
+        sleeps.push(delayMs);
+        now += delayMs;
+      },
+    });
+    assert.equal(result.ok, true, "should succeed once the dev plugin appears");
+    assert.equal(call, 3, "should have probed three times");
+    assert.deepEqual(sleeps, [100, 100], "should have slept between probes");
+  });
+
+  // The polling has to terminate even when the plugin never shows up
+  // (e.g. the IIFE crashed). The last attempt's error message must
+  // surface intact so the CI log explains what was actually seen.
+  it("gives up after the poll timeout and returns the last error", async () => {
+    const fetchImpl = fakeFetch(() => new Response(JSON.stringify({ plugins: [] }), { status: 200, headers: { "content-type": "application/json" } }));
+    let now = 0;
+    const result = await tarball.probeRuntimePlugins({
+      port: 3099,
+      token: "tok",
+      fetchImpl,
+      expectedDevPlugin: "@smoke/dev-fixture",
+      pollTimeoutMs: 500,
+      pollIntervalMs: 100,
+      now: () => now,
+      sleep: async (delayMs: number) => {
+        now += delayMs;
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.lastError ?? "", /@smoke\/dev-fixture@dev/);
+  });
+
+  // Without `expectedDevPlugin`, the empty list is a legitimate state
+  // (fresh install) — don't burn the poll budget on something that's
+  // already true.
+  it("does NOT poll when expectedDevPlugin is absent (empty list is a valid state)", async () => {
+    let call = 0;
+    const fetchImpl = fakeFetch(() => {
+      call += 1;
+      return new Response(JSON.stringify({ plugins: [] }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl });
+    assert.equal(result.ok, true);
+    assert.equal(call, 1);
   });
 });
 

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -390,6 +390,80 @@ describe("probeRuntimePlugins", () => {
     assert.equal(result.ok, true);
     assert.equal(call, 1);
   });
+
+  // 401/403 (auth misconfigured), non-200 status, non-JSON body, and
+  // body-shape regressions are all permanent. The retry loop must
+  // bail out on the first attempt instead of masking the failure
+  // behind the poll budget — a 10s wait before surfacing "status
+  // 401" makes CI logs harder to read, not easier.
+  it("does NOT retry on non-200 status even when expectedDevPlugin is set (fail-fast on auth/route regression)", async () => {
+    let call = 0;
+    const fetchImpl = fakeFetch(() => {
+      call += 1;
+      return new Response("Unauthorized", { status: 401 });
+    });
+    const result = await tarball.probeRuntimePlugins({
+      port: 3099,
+      token: "tok",
+      fetchImpl,
+      expectedDevPlugin: "@smoke/dev-fixture",
+      pollTimeoutMs: 5_000,
+      pollIntervalMs: 100,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 401);
+    assert.equal(call, 1, "should fail fast on 401, not poll");
+  });
+
+  it("does NOT retry on body-shape regression even when expectedDevPlugin is set (fail-fast)", async () => {
+    let call = 0;
+    const fetchImpl = fakeFetch(() => {
+      call += 1;
+      return new Response(JSON.stringify({ unrelated: true }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const result = await tarball.probeRuntimePlugins({
+      port: 3099,
+      token: "tok",
+      fetchImpl,
+      expectedDevPlugin: "@smoke/dev-fixture",
+      pollTimeoutMs: 5_000,
+      pollIntervalMs: 100,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.lastError ?? "", /not \{ plugins/);
+    assert.equal(call, 1, "should fail fast on body-shape regression, not poll");
+  });
+
+  // Fetch failures ARE retryable: the boot poll already proved `/`
+  // answered 200, so an immediate ECONNREFUSED on the next request
+  // is a transient race against the server's shutdown / restart,
+  // not a permanent breakage.
+  it("DOES retry on fetch transport errors when expectedDevPlugin is set", async () => {
+    let call = 0;
+    let now = 0;
+    const fetchImpl = (async () => {
+      call += 1;
+      if (call < 3) throw new Error("ECONNREFUSED");
+      return new Response(JSON.stringify({ plugins: [{ name: "@smoke/dev-fixture", version: "dev" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    const result = await tarball.probeRuntimePlugins({
+      port: 3099,
+      token: "tok",
+      fetchImpl,
+      expectedDevPlugin: "@smoke/dev-fixture",
+      pollTimeoutMs: 5_000,
+      pollIntervalMs: 100,
+      now: () => now,
+      sleep: async (delayMs: number) => {
+        now += delayMs;
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(call, 3);
+  });
 });
 
 describe("makeDevPluginFixture", () => {

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -434,6 +434,25 @@ describe("probeRuntimePlugins", () => {
     assert.equal(call, 1, "should fail fast on body-shape regression, not poll");
   });
 
+  // The `retryable` flag is an internal contract between the poll
+  // loop and the single-shot probe. Callers (smoke driver, anyone
+  // who imports `tarball.mjs`) MUST NOT see it. Pin both branches
+  // so a future refactor that drops `stripRetryable` fails the
+  // suite instead of silently leaking internal state.
+  it("never leaks the internal `retryable` flag on the success path", async () => {
+    const fetchImpl = fakeFetch(
+      () => new Response(JSON.stringify({ plugins: [{ name: "@x/y", version: "1.0.0" }] }), { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl });
+    assert.equal(Object.prototype.hasOwnProperty.call(result, "retryable"), false, "public result must not expose `retryable`");
+  });
+
+  it("never leaks the internal `retryable` flag on the failure path", async () => {
+    const fetchImpl = fakeFetch(() => new Response("Unauthorized", { status: 401 }));
+    const result = await tarball.probeRuntimePlugins({ port: 3099, token: "tok", fetchImpl, expectedDevPlugin: "@smoke/dev-fixture", pollTimeoutMs: 0 });
+    assert.equal(Object.prototype.hasOwnProperty.call(result, "retryable"), false, "public result must not expose `retryable`");
+  });
+
   // Fetch failures ARE retryable: the boot poll already proved `/`
   // answered 200, so an immediate ECONNREFUSED on the next request
   // is a transient race against the server's shutdown / restart,


### PR DESCRIPTION
#1411 の `mulmoclaude_smoke` ワークフロー（未変更部分）でエラーが発生したため調査しました。

## Summary

- `mulmoclaude_smoke` ワークフローの tarball ステージが `runtime plugin probe failed: dev plugin \"@smoke/dev-fixture@dev\" not in list — saw:` で間欠的に落ちる flake を修正
- 原因は `server/index.ts` でプラグインを `app.listen()` 後に fire-and-forget な IIFE でロードしているため、`/` が 200 を返した直後の単発 probe が race を踏み empty list を見る
- `probeRuntimePlugins` に poll を追加。ただし retry は transient 失敗のみ（fetch エラー / expectedDevPlugin がまだ list にない）。401・503・JSON shape 異常など permanent 失敗は fail-fast

## Items to Confirm / Review

- **retry 判定の網羅性**: `runRuntimePluginsProbeOnce` の全 return パスで `retryable` 分類が妥当か（`scripts/mulmoclaude/tarball.mjs` 270–294 行付近）
- **内部フィールド漏洩**: `stripRetryable` が公開 API から `retryable` を確実に除去しているか（テスト 2 件で pin 済み、`test_tarball.ts:340` と `:348`）
- **poll 予算 (10s / 250ms)** が CI 環境で十分余裕があるか — 過去 main 成功時の boot は 4.5s 程度なので 10s で安全マージンは取れている認識
- launcher 側 (`server/index.ts:940` の IIFE) は触っていない — 「listen 前に await する」案も検討したが、real user の boot を遅らせる副作用が大きいので、smoke 側で待つ方針を採用

## User Prompt

> Run node scripts/mulmoclaude/smoke.mjs ... tarball runtime plugin probe failed: dev plugin \"@smoke/dev-fixture@dev\" not in list — saw: ...
> このerror 何？ pr 関係ないのに引っかかる。修正必要なら、worktree 配下で修正お願い。

## 根本原因

CI run 25985390538 の `launcher.log` で race を確認:

```
2026-05-17T08:07:35.476Z INFO  [server] listening port=34447
（266ms 後）
2026-05-17T08:07:35.742Z INFO  [server] shutting down signal=SIGTERM
```

`server/index.ts:940` のプラグインロード IIFE は `app.listen()` 後に fire-and-forget で走る。`/` の 200 → token 取得 → `/api/plugins/runtime/list` を smoke が一気に叩くと、boot が速い時は IIFE がまだ presets / userInstalled / devLoad の `Promise.all` を解決中で、list は `[]`。

直近 main 成功時 (#1424 マージ) は `HTTP 200 on port 35103 after 10 attempt(s) (4515ms)` と boot に 4.5s かかっていたので race が顕在化しなかっただけで、race 自体は前から潜在的に存在。PR #1411 は `paths:` の `package.json` で workflow が発動しただけで実体は無関係。

## 修正内容

`scripts/mulmoclaude/tarball.mjs`:

- `probeRuntimePlugins` に `pollTimeoutMs` (default 10s) / `pollIntervalMs` (default 250ms) / `now` / `sleep` オプション追加
- 単発 probe ロジックを `runRuntimePluginsProbeOnce` に分離。internal な `retryable` フラグを返す
- retry 判定:
  - `fetch failed` → retryable=true（server bind 中の transient）
  - `status ≠ 200` → retryable=false（auth/route regression、fail-fast）
  - `json parse failed` → retryable=false（contract violation）
  - `body shape regression` → retryable=false（contract violation）
  - `dev plugin not in list` → retryable=true（race that we're fixing）
- `stripRetryable` で公開 API から `retryable` を除去（type 不変）

`scripts/mulmoclaude/tarball.d.mts`: 新オプションの型追加

`test/scripts/mulmoclaude/test_tarball.ts`: 7 件追加
- poll で成功 / poll でタイムアウト / `expectedDevPlugin` なし時は one-shot
- 401・body-shape regression は fail-fast（retry しない）
- ECONNREFUSED は retry
- 公開 API contract: `retryable` が success / failure 両 path で漏洩しない

`plans/fix-smoke-plugin-probe-race.md`: 設計メモ

## レビュー履歴

`/codex-cross-review` で 3 iteration 回し、Codex + Claude 両者 LGTM で push:

- iter 1: retry が permanent 失敗を mask する指摘 → retryable 分類で fail-fast 化
- iter 2: 内部フィールド (`retryable`) 漏洩テスト無しの指摘 → contract test 2 件追加
- iter 3: LGTM

## Test plan

- [x] `node --import tsx --test test/scripts/mulmoclaude/test_tarball.ts` → 34 pass / 280ms
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `mulmoclaude_smoke` workflow が CI で green になることを確認（このコミット自体で flake 再現せず通れば 1 サンプルとして OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved runtime plugin detection reliability by implementing polling for plugin availability with configurable timeout and polling intervals, resolving intermittent detection failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->