### PR TITLE
fix(notifier): clarify optional-dep notification title and body

### DIFF
--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -32,16 +32,20 @@ export async function announceOptionalDeps(): Promise<void> {
       reason: status.reason,
       affectedPlugins,
     });
+    // Title carries `{command}` + the reason so the bell history view
+    // — which renders title only — is self-explanatory without
+    // hovering for the body tooltip.
     publishNotification({
       id: `optional-dep-missing:${dep.id}`,
       kind: "system",
       priority: NOTIFICATION_PRIORITIES.normal,
-      title: "Optional dependency unavailable",
+      title: notFound ? `${dep.command} not found` : `${dep.command} not responding`,
       body: notFound
         ? `${dep.command} not found — some features are disabled. Install it and restart.`
         : `${dep.command} is installed but not responding — some features are disabled. Start it and restart.`,
       i18n: {
-        titleKey: "optionalDeps.title",
+        titleKey: notFound ? "optionalDeps.titleNotFound" : "optionalDeps.titleNotResponding",
+        titleParams: { command: dep.command },
         bodyKey: notFound ? "optionalDeps.notFound" : "optionalDeps.notResponding",
         bodyParams: { command: dep.command },
       },

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -28,10 +28,10 @@ export function buildOptionalDepNotification(dep: OptionalDep, status: DepStatus
     id: `optional-dep-missing:${dep.id}`,
     kind: "system",
     priority: NOTIFICATION_PRIORITIES.normal,
-    title: notFound ? `${dep.command} not found` : `${dep.command} not responding`,
+    title: notFound ? `${dep.command} not installed` : `${dep.command} not running`,
     body: notFound
       ? `${dep.command} not found — some features are disabled. Install it and restart.`
-      : `${dep.command} is installed but not responding — some features are disabled. Start it and restart.`,
+      : `${dep.command} is installed but not running — some features are disabled. Start it and restart.`,
     i18n: {
       titleKey: notFound ? "optionalDeps.titleNotFound" : "optionalDeps.titleNotResponding",
       titleParams: { command: dep.command },

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -30,8 +30,8 @@ export function buildOptionalDepNotification(dep: OptionalDep, status: DepStatus
     priority: NOTIFICATION_PRIORITIES.normal,
     title: notFound ? `${dep.command} not installed` : `${dep.command} not running`,
     body: notFound
-      ? `${dep.command} not found — some features are disabled. Install it and restart.`
-      : `${dep.command} is installed but not running — some features are disabled. Start it and restart.`,
+      ? `${dep.command} not found — some features are disabled. Install ${dep.command} and restart MulmoClaude.`
+      : `${dep.command} is installed but not running — some features are disabled. Start ${dep.command} and restart MulmoClaude.`,
     i18n: {
       titleKey: notFound ? "optionalDeps.titleNotFound" : "optionalDeps.titleNotResponding",
       titleParams: { command: dep.command },

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -8,12 +8,37 @@ import { BUILT_IN_PLUGIN_METAS } from "../../src/plugins/metas.js";
 import type { PluginMeta } from "../../src/plugins/meta-types.js";
 import { NOTIFICATION_PRIORITIES } from "../../src/types/notification.js";
 import { log } from "./logger/index.js";
-import { publishNotification } from "../events/notifications.js";
-import { probeOptionalDeps, optionalDeps } from "./optionalDeps.js";
+import { publishNotification, type PublishNotificationOpts } from "../events/notifications.js";
+import { probeOptionalDeps, optionalDeps, type OptionalDep, type DepStatus } from "./optionalDeps.js";
 
 function pluginsRequiring(depId: string): string[] {
   const metas: readonly PluginMeta[] = Object.values(BUILT_IN_PLUGIN_METAS);
   return metas.filter((meta) => meta.requires?.includes(depId)).map((meta) => meta.toolName);
+}
+
+// Pure payload builder, exposed for unit tests. `not-on-path` →
+// install it; `probe-failed` → it's installed but not responding
+// (e.g. the docker daemon is down). The remediation differs, so
+// title + body are reason-aware. The title carries `{command}` so
+// the bell history view — which renders title only — is
+// self-explanatory without hovering for the body tooltip.
+export function buildOptionalDepNotification(dep: OptionalDep, status: DepStatus): PublishNotificationOpts {
+  const notFound = status.reason === "not-on-path";
+  return {
+    id: `optional-dep-missing:${dep.id}`,
+    kind: "system",
+    priority: NOTIFICATION_PRIORITIES.normal,
+    title: notFound ? `${dep.command} not found` : `${dep.command} not responding`,
+    body: notFound
+      ? `${dep.command} not found — some features are disabled. Install it and restart.`
+      : `${dep.command} is installed but not responding — some features are disabled. Start it and restart.`,
+    i18n: {
+      titleKey: notFound ? "optionalDeps.titleNotFound" : "optionalDeps.titleNotResponding",
+      titleParams: { command: dep.command },
+      bodyKey: notFound ? "optionalDeps.notFound" : "optionalDeps.notResponding",
+      bodyParams: { command: dep.command },
+    },
+  };
 }
 
 export async function announceOptionalDeps(): Promise<void> {
@@ -22,33 +47,11 @@ export async function announceOptionalDeps(): Promise<void> {
     const status = statuses[dep.id];
     if (!status || status.available) continue;
     const affectedPlugins = pluginsRequiring(dep.id);
-    // `not-on-path` → install it; `probe-failed` → it's installed
-    // but not responding (e.g. the docker daemon is down). The
-    // remediation differs, so the copy must be reason-aware rather
-    // than always saying "not found" (Codex review).
-    const notFound = status.reason === "not-on-path";
     log.warn("deps", `optional dependency '${dep.command}' unavailable — ${dep.enables} degraded`, {
       depId: dep.id,
       reason: status.reason,
       affectedPlugins,
     });
-    // Title carries `{command}` + the reason so the bell history view
-    // — which renders title only — is self-explanatory without
-    // hovering for the body tooltip.
-    publishNotification({
-      id: `optional-dep-missing:${dep.id}`,
-      kind: "system",
-      priority: NOTIFICATION_PRIORITIES.normal,
-      title: notFound ? `${dep.command} not found` : `${dep.command} not responding`,
-      body: notFound
-        ? `${dep.command} not found — some features are disabled. Install it and restart.`
-        : `${dep.command} is installed but not responding — some features are disabled. Start it and restart.`,
-      i18n: {
-        titleKey: notFound ? "optionalDeps.titleNotFound" : "optionalDeps.titleNotResponding",
-        titleParams: { command: dep.command },
-        bodyKey: notFound ? "optionalDeps.notFound" : "optionalDeps.notResponding",
-        bodyParams: { command: dep.command },
-      },
-    });
+    publishNotification(buildOptionalDepNotification(dep, status));
   }
 }

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -6,7 +6,7 @@
 
 import { BUILT_IN_PLUGIN_METAS } from "../../src/plugins/metas.js";
 import type { PluginMeta } from "../../src/plugins/meta-types.js";
-import { NOTIFICATION_PRIORITIES } from "../../src/types/notification.js";
+import { NOTIFICATION_KINDS, NOTIFICATION_PRIORITIES } from "../../src/types/notification.js";
 import { log } from "./logger/index.js";
 import { publishNotification, type PublishNotificationOpts } from "../events/notifications.js";
 import { probeOptionalDeps, optionalDeps, type OptionalDep, type DepStatus } from "./optionalDeps.js";
@@ -26,7 +26,7 @@ export function buildOptionalDepNotification(dep: OptionalDep, status: DepStatus
   const notFound = status.reason === "not-on-path";
   return {
     id: `optional-dep-missing:${dep.id}`,
-    kind: "system",
+    kind: NOTIFICATION_KINDS.system,
     priority: NOTIFICATION_PRIORITIES.normal,
     title: notFound ? `${dep.command} not installed` : `${dep.command} not running`,
     body: notFound

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -101,7 +101,7 @@ function asLegacy(entry: { pluginData?: unknown }): LegacyPluginDataShape | null
 
 function localizeTitle(entry: NotifierEntry | NotifierHistoryEntry): string {
   const legacy = asLegacy(entry);
-  if (legacy?.i18n) return t(legacy.i18n.titleKey);
+  if (legacy?.i18n) return t(legacy.i18n.titleKey, legacy.i18n.titleParams ?? {});
   return entry.title;
 }
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -81,11 +81,11 @@ const deMessages = {
     // History-Einträge vor der Aufteilung nach Grund; neue Pfade
     // verwenden `titleNotFound` / `titleNotResponding`.
     title: "Optionale Abhängigkeit nicht verfügbar",
-    titleNotFound: "{command} nicht gefunden — Funktionen deaktiviert",
-    titleNotResponding: "{command} antwortet nicht — Funktionen deaktiviert",
+    titleNotFound: "{command} ist nicht installiert",
+    titleNotResponding: "{command} läuft nicht",
     notFound: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",
     notResponding:
-      "{command} ist installiert, antwortet aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie es und starten Sie neu, um sie zu aktivieren.",
+      "{command} ist installiert, läuft aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie es und starten Sie neu, um sie zu aktivieren.",
   },
   pluginErrorBoundary: {
     title: "Plugin {pkg} ist abgestürzt",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -77,7 +77,8 @@ const deMessages = {
       "Die Plugins „{first}“ und „{second}“ registrieren beide {dimension} „{key}“. „{first}“ hat ihn zuerst beansprucht, daher wird die Registrierung von „{second}“ ignoriert.",
   },
   optionalDeps: {
-    title: "Optionale Abhängigkeit nicht verfügbar",
+    titleNotFound: "{command} nicht gefunden — Funktionen deaktiviert",
+    titleNotResponding: "{command} antwortet nicht — Funktionen deaktiviert",
     notFound: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",
     notResponding:
       "{command} ist installiert, antwortet aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie es und starten Sie neu, um sie zu aktivieren.",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -83,9 +83,10 @@ const deMessages = {
     title: "Optionale Abhängigkeit nicht verfügbar",
     titleNotFound: "{command} ist nicht installiert",
     titleNotResponding: "{command} läuft nicht",
-    notFound: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",
+    notFound:
+      "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie {command} und starten Sie MulmoClaude neu, um sie zu aktivieren.",
     notResponding:
-      "{command} ist installiert, läuft aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie es und starten Sie neu, um sie zu aktivieren.",
+      "{command} ist installiert, läuft aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie {command} und starten Sie MulmoClaude neu, um sie zu aktivieren.",
   },
   pluginErrorBoundary: {
     title: "Plugin {pkg} ist abgestürzt",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -77,6 +77,10 @@ const deMessages = {
       "Die Plugins „{first}“ und „{second}“ registrieren beide {dimension} „{key}“. „{first}“ hat ihn zuerst beansprucht, daher wird die Registrierung von „{second}“ ignoriert.",
   },
   optionalDeps: {
+    // Generischer `title` aus Abwärtskompatibilität für persistierte
+    // History-Einträge vor der Aufteilung nach Grund; neue Pfade
+    // verwenden `titleNotFound` / `titleNotResponding`.
+    title: "Optionale Abhängigkeit nicht verfügbar",
     titleNotFound: "{command} nicht gefunden — Funktionen deaktiviert",
     titleNotResponding: "{command} antwortet nicht — Funktionen deaktiviert",
     notFound: "{command} nicht gefunden — zugehörige Funktionen wurden deaktiviert. Installieren Sie es und starten Sie neu, um sie zu aktivieren.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -101,10 +101,10 @@ const enMessages = {
     // history entries published before the reason-aware split below;
     // new code paths use `titleNotFound` / `titleNotResponding`.
     title: "Optional dependency unavailable",
-    titleNotFound: "{command} not found — features disabled",
-    titleNotResponding: "{command} not responding — features disabled",
+    titleNotFound: "{command} not installed",
+    titleNotResponding: "{command} not running",
     notFound: "{command} not found — related features are disabled. Install it and restart to enable them.",
-    notResponding: "{command} is installed but not responding — related features are disabled. Start it and restart to enable them.",
+    notResponding: "{command} is installed but not running — related features are disabled. Start it and restart to enable them.",
   },
   pluginErrorBoundary: {
     title: "Plugin {pkg} crashed",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -97,7 +97,8 @@ const enMessages = {
     intraBody: 'Plugins "{first}" and "{second}" both register {dimension} "{key}". "{first}" claimed it first, so "{second}"\'s registration is ignored.',
   },
   optionalDeps: {
-    title: "Optional dependency unavailable",
+    titleNotFound: "{command} not found — features disabled",
+    titleNotResponding: "{command} not responding — features disabled",
     notFound: "{command} not found — related features are disabled. Install it and restart to enable them.",
     notResponding: "{command} is installed but not responding — related features are disabled. Start it and restart to enable them.",
   },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -97,6 +97,10 @@ const enMessages = {
     intraBody: 'Plugins "{first}" and "{second}" both register {dimension} "{key}". "{first}" claimed it first, so "{second}"\'s registration is ignored.',
   },
   optionalDeps: {
+    // Generic `title` kept for backward compatibility with persisted
+    // history entries published before the reason-aware split below;
+    // new code paths use `titleNotFound` / `titleNotResponding`.
+    title: "Optional dependency unavailable",
     titleNotFound: "{command} not found — features disabled",
     titleNotResponding: "{command} not responding — features disabled",
     notFound: "{command} not found — related features are disabled. Install it and restart to enable them.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -103,8 +103,8 @@ const enMessages = {
     title: "Optional dependency unavailable",
     titleNotFound: "{command} not installed",
     titleNotResponding: "{command} not running",
-    notFound: "{command} not found — related features are disabled. Install it and restart to enable them.",
-    notResponding: "{command} is installed but not running — related features are disabled. Start it and restart to enable them.",
+    notFound: "{command} not found — related features are disabled. Install {command} and restart MulmoClaude to enable them.",
+    notResponding: "{command} is installed but not running — related features are disabled. Start {command} and restart MulmoClaude to enable them.",
   },
   pluginErrorBoundary: {
     title: "Plugin {pkg} crashed",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -85,10 +85,11 @@ const esMessages = {
     // historial persistidas antes de la división por motivo; las
     // nuevas usan `titleNotFound` / `titleNotResponding`.
     title: "Dependencia opcional no disponible",
-    titleNotFound: "{command} no encontrado — funciones desactivadas",
-    titleNotResponding: "{command} no responde — funciones desactivadas",
+    titleNotFound: "{command} no está instalado",
+    titleNotResponding: "{command} no está en ejecución",
     notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
-    notResponding: "{command} está instalado pero no responde — las funciones relacionadas se han desactivado. Inícialo y reinicia para habilitarlas.",
+    notResponding:
+      "{command} está instalado pero no se está ejecutando — las funciones relacionadas se han desactivado. Inícialo y reinicia para habilitarlas.",
   },
   pluginErrorBoundary: {
     title: "El plugin {pkg} se ha bloqueado",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -81,7 +81,8 @@ const esMessages = {
       'Los plugins "{first}" y "{second}" registran ambos el {dimension} "{key}". "{first}" lo reclamó primero, por lo que el registro de "{second}" se ignora.',
   },
   optionalDeps: {
-    title: "Dependencia opcional no disponible",
+    titleNotFound: "{command} no encontrado — funciones desactivadas",
+    titleNotResponding: "{command} no responde — funciones desactivadas",
     notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
     notResponding: "{command} está instalado pero no responde — las funciones relacionadas se han desactivado. Inícialo y reinicia para habilitarlas.",
   },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -81,6 +81,10 @@ const esMessages = {
       'Los plugins "{first}" y "{second}" registran ambos el {dimension} "{key}". "{first}" lo reclamó primero, por lo que el registro de "{second}" se ignora.',
   },
   optionalDeps: {
+    // `title` genérico conservado por compatibilidad con entradas de
+    // historial persistidas antes de la división por motivo; las
+    // nuevas usan `titleNotFound` / `titleNotResponding`.
+    title: "Dependencia opcional no disponible",
     titleNotFound: "{command} no encontrado — funciones desactivadas",
     titleNotResponding: "{command} no responde — funciones desactivadas",
     notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -87,9 +87,9 @@ const esMessages = {
     title: "Dependencia opcional no disponible",
     titleNotFound: "{command} no está instalado",
     titleNotResponding: "{command} no está en ejecución",
-    notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
+    notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instala {command} y reinicia MulmoClaude para habilitarlas.",
     notResponding:
-      "{command} está instalado pero no se está ejecutando — las funciones relacionadas se han desactivado. Inícialo y reinicia para habilitarlas.",
+      "{command} está instalado pero no se está ejecutando — las funciones relacionadas se han desactivado. Inicia {command} y reinicia MulmoClaude para habilitarlas.",
   },
   pluginErrorBoundary: {
     title: "El plugin {pkg} se ha bloqueado",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -76,7 +76,8 @@ const frMessages = {
       "Les plugins « {first} » et « {second} » enregistrent tous deux le {dimension} « {key} ». « {first} » l'a réclamé en premier, donc l'enregistrement de « {second} » est ignoré.",
   },
   optionalDeps: {
-    title: "Dépendance optionnelle indisponible",
+    titleNotFound: "{command} introuvable — fonctionnalités désactivées",
+    titleNotResponding: "{command} ne répond pas — fonctionnalités désactivées",
     notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
     notResponding: "{command} est installé mais ne répond pas — les fonctionnalités associées ont été désactivées. Démarrez-le et redémarrez pour les activer.",
   },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -80,10 +80,11 @@ const frMessages = {
     // entrées d'historique persistées avant la séparation par motif ;
     // les nouvelles utilisent `titleNotFound` / `titleNotResponding`.
     title: "Dépendance optionnelle indisponible",
-    titleNotFound: "{command} introuvable — fonctionnalités désactivées",
-    titleNotResponding: "{command} ne répond pas — fonctionnalités désactivées",
+    titleNotFound: "{command} n'est pas installé",
+    titleNotResponding: "{command} n'est pas en cours d'exécution",
     notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
-    notResponding: "{command} est installé mais ne répond pas — les fonctionnalités associées ont été désactivées. Démarrez-le et redémarrez pour les activer.",
+    notResponding:
+      "{command} est installé mais n'est pas en cours d'exécution — les fonctionnalités associées ont été désactivées. Démarrez-le et redémarrez pour les activer.",
   },
   pluginErrorBoundary: {
     title: "Le plugin {pkg} a planté",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -82,9 +82,9 @@ const frMessages = {
     title: "Dépendance optionnelle indisponible",
     titleNotFound: "{command} n'est pas installé",
     titleNotResponding: "{command} n'est pas en cours d'exécution",
-    notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
+    notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez {command} et redémarrez MulmoClaude pour les activer.",
     notResponding:
-      "{command} est installé mais n'est pas en cours d'exécution — les fonctionnalités associées ont été désactivées. Démarrez-le et redémarrez pour les activer.",
+      "{command} est installé mais n'est pas en cours d'exécution — les fonctionnalités associées ont été désactivées. Démarrez {command} et redémarrez MulmoClaude pour les activer.",
   },
   pluginErrorBoundary: {
     title: "Le plugin {pkg} a planté",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -76,6 +76,10 @@ const frMessages = {
       "Les plugins « {first} » et « {second} » enregistrent tous deux le {dimension} « {key} ». « {first} » l'a réclamé en premier, donc l'enregistrement de « {second} » est ignoré.",
   },
   optionalDeps: {
+    // `title` générique conservé pour la compatibilité avec les
+    // entrées d'historique persistées avant la séparation par motif ;
+    // les nouvelles utilisent `titleNotFound` / `titleNotResponding`.
+    title: "Dépendance optionnelle indisponible",
     titleNotFound: "{command} introuvable — fonctionnalités désactivées",
     titleNotResponding: "{command} ne répond pas — fonctionnalités désactivées",
     notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -86,10 +86,10 @@ const jaMessages = {
     // 旧来の `title` キーは、永続化済み履歴エントリの後方互換のため残す。
     // 新規発火は `titleNotFound` / `titleNotResponding` を使用。
     title: "任意の依存コマンドを利用できません",
-    titleNotFound: "{command} が見つかりません — 一部機能を無効化",
-    titleNotResponding: "{command} が応答しません — 一部機能を無効化",
-    notFound: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",
-    notResponding: "{command} はインストール済みですが応答しません — 関連機能を無効化しました。起動して再起動すると有効になります。",
+    titleNotFound: "{command} がインストールされていません",
+    titleNotResponding: "{command} が起動していません",
+    notFound: "{command} がインストールされていないため、関連機能を停止しています。インストールしてから再起動してください。",
+    notResponding: "{command} が起動していないため、関連機能を停止しています。{command} を起動してから再起動してください。",
   },
   pluginErrorBoundary: {
     title: "プラグイン {pkg} がクラッシュしました",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -83,7 +83,8 @@ const jaMessages = {
       "プラグイン「{first}」と「{second}」が同じ {dimension}「{key}」を登録しています。「{first}」が先に確保したため、「{second}」の登録は無視されます。",
   },
   optionalDeps: {
-    title: "任意の依存コマンドを利用できません",
+    titleNotFound: "{command} が見つかりません — 一部機能を無効化",
+    titleNotResponding: "{command} が応答しません — 一部機能を無効化",
     notFound: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",
     notResponding: "{command} はインストール済みですが応答しません — 関連機能を無効化しました。起動して再起動すると有効になります。",
   },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -83,6 +83,9 @@ const jaMessages = {
       "プラグイン「{first}」と「{second}」が同じ {dimension}「{key}」を登録しています。「{first}」が先に確保したため、「{second}」の登録は無視されます。",
   },
   optionalDeps: {
+    // 旧来の `title` キーは、永続化済み履歴エントリの後方互換のため残す。
+    // 新規発火は `titleNotFound` / `titleNotResponding` を使用。
+    title: "任意の依存コマンドを利用できません",
     titleNotFound: "{command} が見つかりません — 一部機能を無効化",
     titleNotResponding: "{command} が応答しません — 一部機能を無効化",
     notFound: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -88,8 +88,8 @@ const jaMessages = {
     title: "任意の依存コマンドを利用できません",
     titleNotFound: "{command} がインストールされていません",
     titleNotResponding: "{command} が起動していません",
-    notFound: "{command} がインストールされていないため、関連機能を停止しています。インストールしてから再起動してください。",
-    notResponding: "{command} が起動していないため、関連機能を停止しています。{command} を起動してから再起動してください。",
+    notFound: "{command} がインストールされていないため、関連機能を停止しています。{command} をインストールしてから MulmoClaude を再起動してください。",
+    notResponding: "{command} が起動していないため、関連機能を停止しています。{command} を起動してから MulmoClaude を再起動してください。",
   },
   pluginErrorBoundary: {
     title: "プラグイン {pkg} がクラッシュしました",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -84,7 +84,8 @@ const koMessages = {
       '플러그인 "{first}"과(와) "{second}"이(가) 동일한 {dimension} "{key}"을(를) 등록합니다. "{first}"이(가) 먼저 등록했으므로 "{second}"의 등록은 무시됩니다.',
   },
   optionalDeps: {
-    title: "선택적 의존성을 사용할 수 없습니다",
+    titleNotFound: "{command}을(를) 찾을 수 없음 — 일부 기능 비활성화",
+    titleNotResponding: "{command} 응답 없음 — 일부 기능 비활성화",
     notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
     notResponding: "{command}이(가) 설치되어 있지만 응답하지 않습니다 — 관련 기능이 비활성화되었습니다. 시작한 후 재시작하면 활성화됩니다.",
   },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -87,10 +87,10 @@ const koMessages = {
     // 영구 저장된 기존 히스토리 항목과의 호환을 위해 일반적인 `title` 키는
     // 그대로 둔다. 새 발화는 `titleNotFound` / `titleNotResponding` 사용.
     title: "선택적 의존성을 사용할 수 없습니다",
-    titleNotFound: "{command}을(를) 찾을 수 없음 — 일부 기능 비활성화",
-    titleNotResponding: "{command} 응답 없음 — 일부 기능 비활성화",
+    titleNotFound: "{command}이(가) 설치되어 있지 않습니다",
+    titleNotResponding: "{command}이(가) 실행 중이 아닙니다",
     notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
-    notResponding: "{command}이(가) 설치되어 있지만 응답하지 않습니다 — 관련 기능이 비활성화되었습니다. 시작한 후 재시작하면 활성화됩니다.",
+    notResponding: "{command}은(는) 설치되어 있지만 실행 중이 아닙니다 — 관련 기능이 비활성화되었습니다. 시작한 후 재시작하면 활성화됩니다.",
   },
   pluginErrorBoundary: {
     title: "플러그인 {pkg}이(가) 충돌했습니다",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -84,6 +84,9 @@ const koMessages = {
       '플러그인 "{first}"과(와) "{second}"이(가) 동일한 {dimension} "{key}"을(를) 등록합니다. "{first}"이(가) 먼저 등록했으므로 "{second}"의 등록은 무시됩니다.',
   },
   optionalDeps: {
+    // 영구 저장된 기존 히스토리 항목과의 호환을 위해 일반적인 `title` 키는
+    // 그대로 둔다. 새 발화는 `titleNotFound` / `titleNotResponding` 사용.
+    title: "선택적 의존성을 사용할 수 없습니다",
     titleNotFound: "{command}을(를) 찾을 수 없음 — 일부 기능 비활성화",
     titleNotResponding: "{command} 응답 없음 — 일부 기능 비활성화",
     notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -89,8 +89,9 @@ const koMessages = {
     title: "선택적 의존성을 사용할 수 없습니다",
     titleNotFound: "{command}이(가) 설치되어 있지 않습니다",
     titleNotResponding: "{command}이(가) 실행 중이 아닙니다",
-    notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
-    notResponding: "{command}은(는) 설치되어 있지만 실행 중이 아닙니다 — 관련 기능이 비활성화되었습니다. 시작한 후 재시작하면 활성화됩니다.",
+    notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. {command}을(를) 설치한 후 MulmoClaude를 재시작하면 활성화됩니다.",
+    notResponding:
+      "{command}은(는) 설치되어 있지만 실행 중이 아닙니다 — 관련 기능이 비활성화되었습니다. {command}을(를) 시작한 후 MulmoClaude를 재시작하면 활성화됩니다.",
   },
   pluginErrorBoundary: {
     title: "플러그인 {pkg}이(가) 충돌했습니다",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -76,7 +76,8 @@ const ptBRMessages = {
       'Os plugins "{first}" e "{second}" registram o mesmo {dimension} "{key}". "{first}" o reivindicou primeiro, portanto o registro de "{second}" é ignorado.',
   },
   optionalDeps: {
-    title: "Dependência opcional indisponível",
+    titleNotFound: "{command} não encontrado — recursos desativados",
+    titleNotResponding: "{command} não responde — recursos desativados",
     notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
     notResponding: "{command} está instalado mas não responde — recursos relacionados foram desativados. Inicie-o e reinicie para habilitá-los.",
   },

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -80,10 +80,10 @@ const ptBRMessages = {
     // histórico persistidas antes da divisão por motivo; as novas
     // usam `titleNotFound` / `titleNotResponding`.
     title: "Dependência opcional indisponível",
-    titleNotFound: "{command} não encontrado — recursos desativados",
-    titleNotResponding: "{command} não responde — recursos desativados",
+    titleNotFound: "{command} não está instalado",
+    titleNotResponding: "{command} não está em execução",
     notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
-    notResponding: "{command} está instalado mas não responde — recursos relacionados foram desativados. Inicie-o e reinicie para habilitá-los.",
+    notResponding: "{command} está instalado mas não está em execução — recursos relacionados foram desativados. Inicie-o e reinicie para habilitá-los.",
   },
   pluginErrorBoundary: {
     title: "O plugin {pkg} travou",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -82,8 +82,9 @@ const ptBRMessages = {
     title: "Dependência opcional indisponível",
     titleNotFound: "{command} não está instalado",
     titleNotResponding: "{command} não está em execução",
-    notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
-    notResponding: "{command} está instalado mas não está em execução — recursos relacionados foram desativados. Inicie-o e reinicie para habilitá-los.",
+    notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale {command} e reinicie o MulmoClaude para habilitá-los.",
+    notResponding:
+      "{command} está instalado mas não está em execução — recursos relacionados foram desativados. Inicie {command} e reinicie o MulmoClaude para habilitá-los.",
   },
   pluginErrorBoundary: {
     title: "O plugin {pkg} travou",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -76,6 +76,10 @@ const ptBRMessages = {
       'Os plugins "{first}" e "{second}" registram o mesmo {dimension} "{key}". "{first}" o reivindicou primeiro, portanto o registro de "{second}" é ignorado.',
   },
   optionalDeps: {
+    // `title` genérico mantido para compatibilidade com entradas do
+    // histórico persistidas antes da divisão por motivo; as novas
+    // usam `titleNotFound` / `titleNotResponding`.
+    title: "Dependência opcional indisponível",
     titleNotFound: "{command} não encontrado — recursos desativados",
     titleNotResponding: "{command} não responde — recursos desativados",
     notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -83,10 +83,10 @@ const zhMessages = {
     // 通用 `title` 键保留以便兼容已持久化的历史条目;新发布的通知改用
     // `titleNotFound` / `titleNotResponding`。
     title: "可选依赖不可用",
-    titleNotFound: "未找到 {command} — 部分功能已禁用",
-    titleNotResponding: "{command} 无响应 — 部分功能已禁用",
+    titleNotFound: "未安装 {command}",
+    titleNotResponding: "{command} 未运行",
     notFound: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
-    notResponding: "{command} 已安装但无响应 — 相关功能已被禁用。启动后重启即可启用。",
+    notResponding: "{command} 已安装但未运行 — 相关功能已被禁用。启动后重启即可启用。",
   },
   pluginErrorBoundary: {
     title: "插件 {pkg} 已崩溃",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -80,7 +80,8 @@ const zhMessages = {
     intraBody: '插件 "{first}" 和 "{second}" 都注册了 {dimension} "{key}"。"{first}" 先注册,因此 "{second}" 的注册被忽略。',
   },
   optionalDeps: {
-    title: "可选依赖不可用",
+    titleNotFound: "未找到 {command} — 部分功能已禁用",
+    titleNotResponding: "{command} 无响应 — 部分功能已禁用",
     notFound: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
     notResponding: "{command} 已安装但无响应 — 相关功能已被禁用。启动后重启即可启用。",
   },

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -85,8 +85,8 @@ const zhMessages = {
     title: "可选依赖不可用",
     titleNotFound: "未安装 {command}",
     titleNotResponding: "{command} 未运行",
-    notFound: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
-    notResponding: "{command} 已安装但未运行 — 相关功能已被禁用。启动后重启即可启用。",
+    notFound: "未找到 {command} — 相关功能已被禁用。请安装 {command} 后重启 MulmoClaude 以启用。",
+    notResponding: "{command} 已安装但未运行 — 相关功能已被禁用。请启动 {command} 后重启 MulmoClaude 以启用。",
   },
   pluginErrorBoundary: {
     title: "插件 {pkg} 已崩溃",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -80,6 +80,9 @@ const zhMessages = {
     intraBody: '插件 "{first}" 和 "{second}" 都注册了 {dimension} "{key}"。"{first}" 先注册,因此 "{second}" 的注册被忽略。',
   },
   optionalDeps: {
+    // 通用 `title` 键保留以便兼容已持久化的历史条目;新发布的通知改用
+    // `titleNotFound` / `titleNotResponding`。
+    title: "可选依赖不可用",
     titleNotFound: "未找到 {command} — 部分功能已禁用",
     titleNotResponding: "{command} 无响应 — 部分功能已禁用",
     notFound: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -96,6 +96,7 @@ export type NotificationAction =
  *  client is on. Other notification kinds may opt in later. */
 export interface NotificationI18n {
   titleKey: string;
+  titleParams?: Readonly<Record<string, string | number | readonly string[]>>;
   bodyKey?: string;
   bodyParams?: Readonly<Record<string, string | number | readonly string[]>>;
 }

--- a/test/system/test_optionalDeps_degradation.ts
+++ b/test/system/test_optionalDeps_degradation.ts
@@ -172,7 +172,7 @@ describe("optional-deps: notification payload", () => {
     assert.deepEqual(payload.i18n?.titleParams, { command: "docker" });
     assert.equal(payload.i18n?.bodyKey, "optionalDeps.notFound");
     assert.deepEqual(payload.i18n?.bodyParams, { command: "docker" });
-    assert.match(String(payload.title), /not found/);
+    assert.match(String(payload.title), /not installed/);
   });
 
   it("emits the not-responding title/body keys when the probe fails", () => {
@@ -183,7 +183,7 @@ describe("optional-deps: notification payload", () => {
     assert.deepEqual(payload.i18n?.titleParams, { command: "docker" });
     assert.equal(payload.i18n?.bodyKey, "optionalDeps.notResponding");
     assert.deepEqual(payload.i18n?.bodyParams, { command: "docker" });
-    assert.match(String(payload.title), /not responding/);
+    assert.match(String(payload.title), /not running/);
   });
 
   it("substitutes the command name from the dep (ffmpeg, not docker)", () => {

--- a/test/system/test_optionalDeps_degradation.ts
+++ b/test/system/test_optionalDeps_degradation.ts
@@ -21,8 +21,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Request, Response, Router } from "express";
 import mulmoScriptRouter from "../../server/api/routes/mulmo-script.js";
-import { announceOptionalDeps } from "../../server/system/announceOptionalDeps.js";
-import { _resetOptionalDepsCacheForTest, _setOptionalDepsCacheForTest, type DepStatus } from "../../server/system/optionalDeps.js";
+import { announceOptionalDeps, buildOptionalDepNotification } from "../../server/system/announceOptionalDeps.js";
+import { _resetOptionalDepsCacheForTest, _setOptionalDepsCacheForTest, type DepStatus, type OptionalDep } from "../../server/system/optionalDeps.js";
 import { initNotifier, _setFilePathsForTesting } from "../../server/notifier/engine.js";
 import { log } from "../../server/system/logger/index.js";
 import { API_ROUTES } from "../../src/config/apiRoutes.js";
@@ -157,5 +157,40 @@ describe("optional-deps: boot announcement", () => {
       undefined,
       "no 'deps' warn when the dependency is available",
     );
+  });
+});
+
+describe("optional-deps: notification payload", () => {
+  const dockerDep: OptionalDep = { id: "docker", command: "docker", enables: "dockerSandbox" };
+  const ffmpegDep: OptionalDep = { id: "ffmpeg", command: "ffmpeg", enables: "mulmocast" };
+
+  it("emits the not-found title/body keys when the binary is missing from PATH", () => {
+    const status: DepStatus = { id: "docker", available: false, reason: "not-on-path" };
+    const payload = buildOptionalDepNotification(dockerDep, status);
+    assert.equal(payload.id, "optional-dep-missing:docker");
+    assert.equal(payload.i18n?.titleKey, "optionalDeps.titleNotFound");
+    assert.deepEqual(payload.i18n?.titleParams, { command: "docker" });
+    assert.equal(payload.i18n?.bodyKey, "optionalDeps.notFound");
+    assert.deepEqual(payload.i18n?.bodyParams, { command: "docker" });
+    assert.match(String(payload.title), /not found/);
+  });
+
+  it("emits the not-responding title/body keys when the probe fails", () => {
+    const status: DepStatus = { id: "docker", available: false, reason: "probe-failed" };
+    const payload = buildOptionalDepNotification(dockerDep, status);
+    assert.equal(payload.id, "optional-dep-missing:docker");
+    assert.equal(payload.i18n?.titleKey, "optionalDeps.titleNotResponding");
+    assert.deepEqual(payload.i18n?.titleParams, { command: "docker" });
+    assert.equal(payload.i18n?.bodyKey, "optionalDeps.notResponding");
+    assert.deepEqual(payload.i18n?.bodyParams, { command: "docker" });
+    assert.match(String(payload.title), /not responding/);
+  });
+
+  it("substitutes the command name from the dep (ffmpeg, not docker)", () => {
+    const status: DepStatus = { id: "ffmpeg", available: false, reason: "not-on-path" };
+    const payload = buildOptionalDepNotification(ffmpegDep, status);
+    assert.equal(payload.id, "optional-dep-missing:ffmpeg");
+    assert.deepEqual(payload.i18n?.titleParams, { command: "ffmpeg" });
+    assert.deepEqual(payload.i18n?.bodyParams, { command: "ffmpeg" });
   });
 });


### PR DESCRIPTION
## Summary

- optional-dependency (`docker` / `ffmpeg`) が利用不可のときに bell から発火する通知の文言を整理。
- 旧: 履歴ビューに `任意の依存コマンドを利用できません` が並び、どの依存が・なぜダメなのか title から判別不能だった。
- 新: title に `{command}` と原因 (`installed not / not running`) を載せ、body は「何が止まっているか」+「対処手順 (`{command}` を入れて MulmoClaude を再起動)」を明示。

<img width="642" height="254" alt="CleanShot 2026-05-18 at 10 11 35" src="https://github.com/user-attachments/assets/5872c1b2-5ee6-4443-afa3-8a748543ea0f" />

## Items to Confirm / Review

- **後方互換**: `optionalDeps.title` キー (汎用文言) を 8 言語に残しています。理由は notifier 履歴 (`history.json`) に永続化された旧エントリが `titleKey: "optionalDeps.title"` を持っており、削除するとリテラルキー名が UI に表示されてしまうため。dead-code 扱いに見えるが意図的。
- **`NotificationI18n` に `titleParams` を追加**: 既存呼び出し側に影響なし(全てオプショナル)。他の通知タイプにも波及する可能性があるので型変更として確認お願いします。
- **多言語文言**: en/ja はこちらでネイティブ確認済み。zh/ko/es/pt-BR/fr/de は機械翻訳ベースのため、各言語のネイティブによる軽い目視を希望します。
- **scope 外として残した点**: 「機能名 (Sandbox / mulmocast 等) を title/body に出す」改善は別 issue/PR を想定。`OptionalDep.enables` フィールド (`dockerSandbox` / `mulmocast`) は既に i18n key fragment 設計で残置済み。

## User Prompt

bell の履歴に同じアラートが複数件 (`任意の依存コマンドを利用できません`) 並んでいて、何の問題なのか分からない。Docker 未起動が原因の可能性が高いが、他の組み合わせもありえるので、見ただけで判別できるようにしたい。あとから日本語の文言 (`一部機能を無効化`、対象不明な「再起動」) も不自然なので直す。

## Implementation

### Server side
- `server/system/announceOptionalDeps.ts`: payload 構築を `buildOptionalDepNotification(dep, status)` という pure 関数に抽出し、reason (`not-on-path` / `probe-failed`) によって title key を切替。
- `src/types/notification.ts`: `NotificationI18n` に `titleParams` フィールド追加 (`bodyParams` と同じシェイプ)。

### Client side
- `src/components/NotificationBell.vue`: `localizeTitle` が `titleParams` を `t()` に渡すように。legacy 経路 (`titleParams` 無し) は空オブジェクトをデフォルトに。

### i18n (全 8 ロケール)
- `titleNotFound` / `titleNotResponding` を新設。title は `{command}` を含むだけのシンプルな状態文に統一 (例: `docker がインストールされていません` / `docker が起動していません`)。
- 旧 `title` キー (`Optional dependency unavailable` / `任意の依存コマンドを利用できません` …) は永続化済み history との後方互換のため保持。
- body の「再起動」の曖昧さを解消し `MulmoClaude を再起動` と明示。`it` 系の代名詞も `{command}` に置換して何を install/start するか明示。
- ja の `— 一部機能を無効化` のような不自然な動詞ノミナル化を整理し、自然な文章スタイルへ書き換え。

### Tests
- `test/system/test_optionalDeps_degradation.ts` に `buildOptionalDepNotification` の単体テスト 3 ケース追加:
  - `not-on-path` 分岐 → `titleNotFound` + `notFound`
  - `probe-failed` 分岐 → `titleNotResponding` + `notResponding`
  - `{command}` 置換 (`ffmpeg` vs `docker`) の正しさ
- 既存 `announceOptionalDeps` の log.warn 検証テストはそのまま動作 (回帰なし)。

### Cross-review
本 PR の差分は Codex (`/codex-cross-review` skill) で 1 round 通過済み。
- iteration 1: must-fix 2 件 (legacy `title` key 復元、payload 単体テスト追加) → 適用済み (`44df4d99`)
- iteration 2: LGTM

## Commits

1. `0430676a` fix: include command name and reason in optional-dep notification title
2. `44df4d99` fix: address codex review iteration-1 (legacy key restore + helper extraction + tests)
3. `58ac1c09` fix: rewrite optional-dep notification wording for naturalness
4. `3fe87168` fix: clarify "restart" target in optional-dep notification body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notifications for unavailable optional dependencies with reason-specific titles and messages
  * Clearer distinction in messaging between missing (not installed) and unresponsive (not running) dependencies
  * Improved multilingual support with personalized guidance instructions

* **Refactor**
  * Streamlined notification payload construction for better maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->