### PR TITLE
feat(roles): split General into General + Personal; pin Encore seed role to Personal

### DIFF
--- a/server/encore/dispatch.ts
+++ b/server/encore/dispatch.ts
@@ -46,6 +46,7 @@ import { ENCORE_PLUGIN_PKG } from "./notifier.js";
 import type { PendingClearTicket } from "./tick.js";
 import { startChat } from "../api/routes/agent.js";
 import { PLUGIN_SESSION_ORIGIN_PREFIX } from "../../src/types/session.js";
+import { ENCORE_SEED_ROLE_ID } from "../../src/config/roles.js";
 import { randomUUID } from "node:crypto";
 
 function makeUuid(): string {
@@ -755,7 +756,7 @@ async function seedChatForTicket(ticket: PendingClearTicket, ticketRel: string, 
   const chatSessionId = makeUuid();
   const result = await startChat({
     message: ticket.seedPrompt,
-    roleId: "general",
+    roleId: ENCORE_SEED_ROLE_ID,
     chatSessionId,
     origin: `${PLUGIN_SESSION_ORIGIN_PREFIX}${ENCORE_PLUGIN_PKG}`,
   });

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -30,6 +30,7 @@ import type { TasksRuntimeApi } from "./runtime-tasks-api.js";
 import type { ChatRuntimeApi } from "./runtime-chat-api.js";
 import { startChat } from "../api/routes/agent.js";
 import { PLUGIN_SESSION_ORIGIN_PREFIX } from "../../src/types/session.js";
+import { BUILTIN_ROLE_IDS } from "../../src/config/roles.js";
 
 const DEFAULT_FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
 
@@ -304,7 +305,7 @@ function makeScopedTasks(pkgName: string, taskManager: ITaskManager): TasksRunti
 // Scoped chat (host extension — Phase 1 of Encore plan)
 // ─────────────────────────────────────────────────────────────────────
 
-const DEFAULT_PLUGIN_CHAT_ROLE = "general";
+const DEFAULT_PLUGIN_CHAT_ROLE = BUILTIN_ROLE_IDS.general;
 
 function makeScopedChat(pkgName: string): ChatRuntimeApi {
   return {

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -58,27 +58,13 @@ export const ROLES: Role[] = [
       "- **Browse / lint**: direct the user to the `/wiki` UI — catalog at `/wiki`, a specific page at `/wiki/pages/<slug>`, activity log at `/wiki/log`, or the Lint button on `/wiki` for a health check.\n\n" +
       "Page format: YAML frontmatter (title, created, updated, tags) + markdown body + `[[wiki links]]` for cross-references. Slugs are lowercase hyphen-separated. Always keep `data/wiki/index.md` current and append to `data/wiki/log.md` after any change. The page-list section of `index.md` is a flat, recency-ordered log: prepend new pages at the top, and when a page is updated (content, description, tags, or rename) move its entry to the top — don't group by category. The Tags section (if present) still needs its per-tag page lists updated on add / rename / delete, but the tag order itself is not reordered by recency. Read `config/helps/wiki.md` for full details.",
     availablePlugins: [
-      TOOL_NAMES.manageCalendar,
-      TOOL_NAMES.manageEncore,
       TOOL_NAMES.presentDocument,
       TOOL_NAMES.presentForm,
       TOOL_NAMES.presentMulmoScript,
       TOOL_NAMES.generateImage,
       TOOL_NAMES.presentHtml,
-      TOOL_NAMES.mapControl,
-      TOOL_NAMES.managePhotoLocations,
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
-      TOOL_NAMES.notify,
-      // Preset runtime plugins (server/plugins/preset-list.ts).
-      // Runtime plugins are gated by `availablePlugins` like the
-      // static-GUI / static-MCP entries above; listed here so the
-      // out-of-the-box "general" role keeps exposing them. User-
-      // installed runtime plugins (`~/mulmoclaude/plugins/*`) are
-      // added to roles via Settings → Roles.
-      TOOL_NAMES.manageBookmarks,
-      TOOL_NAMES.manageTodoList,
-      TOOL_NAMES.manageSpotify,
     ],
     queries: [
       "Tell me about this app, MulmoClaude.",
@@ -88,8 +74,43 @@ export const ROLES: Role[] = [
       "How do I use the Telegram bridge to talk to MulmoClaude from my phone?",
       "Show my wiki index",
       "Lint my wiki",
-      "Show my todo list",
+    ],
+  },
+  {
+    id: "personal",
+    name: "Personal",
+    icon: "person",
+    prompt:
+      "You are a personal assistant focused on the user's daily life — calendar, todos, recurring obligations (Encore), bookmarks, music, places, and notifications. Help the user organize, track, and recall personal information.\n\n" +
+      "## Asking the user to choose\n\n" +
+      "When the user must pick from a small set of options, toggle features, or answer yes/no, call presentForm with the appropriate fields (radio for one-of, checkbox for many-of, text/textarea for free-form). Group related questions into one form. Prefer this strongly over phrasing the choice in plain prose — the form gives the user clickable controls and sends the answers back as a markdown bullet list.\n\n" +
+      "Mark every field the user must answer as `required: true`. The form blocks submission until required fields are filled, which prevents the LLM from receiving partial responses.",
+    availablePlugins: [
+      TOOL_NAMES.manageCalendar,
+      TOOL_NAMES.manageEncore,
+      TOOL_NAMES.managePhotoLocations,
+      TOOL_NAMES.mapControl,
+      TOOL_NAMES.notify,
+      TOOL_NAMES.presentDocument,
+      TOOL_NAMES.presentForm,
+      // Preset runtime plugins (server/plugins/preset-list.ts).
+      // Runtime plugins are gated by `availablePlugins` like the
+      // static-GUI / static-MCP entries above; listed here so the
+      // out-of-the-box "personal" role keeps exposing them. User-
+      // installed runtime plugins (`~/mulmoclaude/plugins/*`) are
+      // added to roles via Settings → Roles.
+      TOOL_NAMES.manageBookmarks,
+      TOOL_NAMES.manageTodoList,
+      TOOL_NAMES.manageSpotify,
+    ],
+    queries: [
       "Show me my calendar",
+      "Show my todo list",
+      "What recurring obligations do I have?",
+      "Add a bookmark for this URL",
+      "Where are the photos I took last weekend?",
+      "Play some focus music on Spotify",
+      "Remind me to call mom this evening",
     ],
   },
   {
@@ -398,6 +419,7 @@ export const BUILTIN_ROLES = ROLES;
 // updating this map fails the test.
 export const BUILTIN_ROLE_IDS = {
   general: "general",
+  personal: "personal",
   office: "office",
   guide: "guide",
   artist: "artist",
@@ -416,6 +438,15 @@ export const BUILTIN_ROLE_IDS = {
 export type BuiltInRoleId = (typeof BUILTIN_ROLE_IDS)[keyof typeof BUILTIN_ROLE_IDS];
 
 export const DEFAULT_ROLE_ID: BuiltInRoleId = BUILTIN_ROLE_IDS.general;
+
+// Role id that Encore's `resolveNotification` flow seeds new chats
+// with. Pinned to `personal` because that role owns `manageEncore` —
+// seeding into a role without the tool leaves the agent unable to
+// drive the obligation it was just woken up for. Guarded by
+// `test/roles/test_encore_seed_role.ts` so renaming the role or
+// dropping `manageEncore` from its `availablePlugins` fails CI
+// rather than silently breaking the seeded chat.
+export const ENCORE_SEED_ROLE_ID: BuiltInRoleId = BUILTIN_ROLE_IDS.personal;
 
 export function getRole(roleId: string): Role {
   return ROLES.find((role) => role.id === roleId) ?? ROLES[0];

--- a/test/roles/test_encore_seed_role.ts
+++ b/test/roles/test_encore_seed_role.ts
@@ -1,0 +1,28 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ROLES, ENCORE_SEED_ROLE_ID } from "../../src/config/roles.ts";
+import { TOOL_NAMES } from "../../src/config/toolNames.ts";
+
+// Encore's `resolveNotification` flow seeds a new chat under
+// `ENCORE_SEED_ROLE_ID`. The seeded role MUST exist and MUST expose
+// `manageEncore`, otherwise the agent wakes up with no way to drive
+// the obligation it was just resumed for. These tests catch:
+//   - renaming the role id without updating ENCORE_SEED_ROLE_ID
+//   - dropping `manageEncore` from the seed role's availablePlugins
+//   - removing the role entry from ROLES outright
+
+describe("ENCORE_SEED_ROLE_ID", () => {
+  it("resolves to a role that exists in ROLES", () => {
+    const role = ROLES.find((entry) => entry.id === ENCORE_SEED_ROLE_ID);
+    assert.ok(role, `no role found for ENCORE_SEED_ROLE_ID "${ENCORE_SEED_ROLE_ID}"`);
+  });
+
+  it("resolves to a role whose availablePlugins includes manageEncore", () => {
+    const role = ROLES.find((entry) => entry.id === ENCORE_SEED_ROLE_ID);
+    assert.ok(role, `no role found for ENCORE_SEED_ROLE_ID "${ENCORE_SEED_ROLE_ID}"`);
+    assert.ok(
+      role.availablePlugins.includes(TOOL_NAMES.manageEncore),
+      `Encore seed role "${ENCORE_SEED_ROLE_ID}" must include TOOL_NAMES.manageEncore in availablePlugins`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Split the General role into General + a new **Personal** role. General's plugin list had grown to 15 plugins (~8k chars of role+plugin instructions in the system prompt). Personal now owns the daily-life plugins (calendar, encore, todos, bookmarks, photo locations, map, spotify, notify) plus presentDocument/presentForm; General keeps the broader content/research surface (presentMulmoScript, presentHtml, generateImage, readXPost, searchX, presentDocument, presentForm).
- Pin Encore's `resolveNotification` chat-seed flow to the Personal role via a new `ENCORE_SEED_ROLE_ID` export, so the agent that wakes up to handle a bell click actually has `manageEncore` available. Backed by `test/roles/test_encore_seed_role.ts` which fails CI if the pinned role disappears or stops listing `manageEncore`.
- Hardened the runtime-plugin `chat.start` fallback in `server/plugins/runtime.ts` to use `BUILTIN_ROLE_IDS.general` instead of the bare `"general"` string literal, so a future rename of the role id fails at compile time rather than silently breaking runtime-plugin-initiated chats.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `npx tsx --test test/roles/test_encore_seed_role.ts test/roles/test_builtin_role_ids.ts` — 7/7 pass
- [ ] Manual: open the role picker, confirm Personal appears with `person` icon and the listed starter queries.
- [ ] Manual: click an Encore bell entry, confirm the resumed chat lands in the Personal role (not General) and can call `manageEncore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new "personal" role with specialized tool access and configuration settings.

* **Chores**
  * Updated role-based permissions and tool availability across the system for improved consistency and organization.
  * Refactored internal role references to use configuration constants.

* **Tests**
  * Added validation tests for the new Encore seed role configuration to ensure proper tool permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->