### PR TITLE
refactor(prompt): delete helps-injection; rely on role prompts + canonical paths

### DIFF
--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -357,76 +357,6 @@ When the user mentions a time without explicitly naming a city or timezone, assu
 // prompt-level mention stays in sync with what the image actually
 // ships; if you add/remove a tool there, update this too.
 
-// Files ≤ this threshold stay inlined verbatim; above it, only a short
-// summary + pointer reaches the system prompt and the full content is
-// fetched on demand via the Read tool. 2000 chars keeps today's small
-// helps (github.md ~1.2K, spreadsheet.md ~1.4K) inline, while wiki.md /
-// mulmoscript.md / telegram.md (4–7K each) switch to summary mode. See
-// plans/done/feat-help-pointer-threshold.md and issue #487.
-const HELP_INLINE_THRESHOLD_CHARS = 2000;
-const HELP_SUMMARY_PARAGRAPH_CAP = 200;
-
-// Pull a short, prompt-friendly summary from a help file:
-// - first H1 heading (identifies the file)
-// - first non-empty, non-heading paragraph, truncated to ~200 chars
-// No frontmatter required — the goal is zero ceremony for help authors.
-export function summarizeHelpContent(content: string): string {
-  const lines = content.split("\n");
-  const heading = lines
-    .find((line) => /^#\s+\S/.test(line))
-    ?.replace(/^#\s+/, "")
-    .trim();
-
-  let paragraph = "";
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      if (paragraph) break;
-      continue;
-    }
-    paragraph = paragraph ? `${paragraph} ${trimmed}` : trimmed;
-    if (paragraph.length >= HELP_SUMMARY_PARAGRAPH_CAP) break;
-  }
-  if (paragraph.length > HELP_SUMMARY_PARAGRAPH_CAP) {
-    paragraph = `${paragraph.slice(0, HELP_SUMMARY_PARAGRAPH_CAP).trimEnd()}…`;
-  }
-
-  const parts: string[] = [];
-  if (heading) parts.push(heading);
-  if (paragraph) parts.push(paragraph);
-  return parts.join(" — ");
-}
-
-export function buildInlinedHelpFiles(rolePrompt: string, workspacePath: string): string[] {
-  // Match either legacy `helps/<name>.md` or post-#284
-  // `config/helps/<name>.md` references in role prompts. Both
-  // resolve to the same on-disk file under `config/helps/`.
-  const matches = rolePrompt.match(/(?:config\/)?helps\/[\w.-]+\.md/g) ?? [];
-  const unique = [...new Set(matches)];
-  return unique
-    .map((ref) => {
-      // Strip an optional leading `config/` so the on-disk lookup
-      // always goes through `WORKSPACE_DIRS.helps` (which already
-      // resolves to `config/helps`).
-      const name = ref.replace(/^config\//, "").replace(/^helps\//, "");
-      const fullPath = join(workspacePath, WORKSPACE_DIRS.helps, name);
-      if (!existsSync(fullPath)) return null;
-      const content = readFileSync(fullPath, "utf-8").trim();
-      if (!content) return null;
-      // Keep the heading anchored to the canonical post-#284 path so
-      // the LLM can't accidentally Read() the stale legacy location.
-      const canonicalPath = `${WORKSPACE_DIRS.helps}/${name}`;
-      const header = `### ${canonicalPath}`;
-      if (content.length <= HELP_INLINE_THRESHOLD_CHARS) {
-        return `${header}\n\n${content}`;
-      }
-      const summary = summarizeHelpContent(content);
-      const pointer = `Detailed reference: use Read on \`${canonicalPath}\` when you need the full content.`;
-      return summary ? `${header}\n\n${summary}\n\n${pointer}` : `${header}\n\n${pointer}`;
-    })
-    .filter((section): section is string => section !== null);
-}
-
 // Wrap a list of sub-entries under a single markdown heading, or
 // return null when the list is empty so the caller can skip the
 // whole section. Used for "## Reference Files" / "## Plugin
@@ -465,7 +395,6 @@ export function buildSystemPrompt(params: SystemPromptParams): string {
     { name: "news-concierge", content: buildNewsConciergeContext(role) },
     { name: "custom-dirs", content: buildCustomDirsPrompt(getCachedCustomDirs()) },
     { name: "reference-dirs", content: buildReferenceDirsPrompt(getCachedReferenceDirs(), useDocker) },
-    { name: "helps", content: headingSection("Reference Files", buildInlinedHelpFiles(role.prompt, workspacePath)) },
     { name: "plugins", content: headingSection("Plugin Instructions", buildPluginPromptSections(role)) },
   ];
 

--- a/server/workspace/helps/index.md
+++ b/server/workspace/helps/index.md
@@ -35,23 +35,23 @@ Under the hood it uses the Claude Code Agent SDK as its LLM core. Claude has ful
 
 The wiki (`wiki/` in the workspace) acts as Claude's long-term memory. Unlike the conversation history which resets each session, the wiki is a persistent, compounding knowledge base that Claude builds and maintains over time. You feed it sources — articles, URLs, notes — and Claude ingests them into structured, interlinked Markdown pages. The more you add, the smarter it gets.
 
-See [Wiki](helps/wiki.md) for details on how it works.
+See [Wiki](config/helps/wiki.md) for details on how it works.
 
 ## Help Pages
 
-- [Wiki](helps/wiki.md) — how the personal knowledge wiki works, its folder layout, page format, and operations
-- [Gemini API Key](helps/gemini.md) — why `GEMINI_API_KEY` is strongly recommended (images, audio, video) and how to get one from Google AI Studio
-- [MulmoScript](helps/mulmoscript.md) — format reference for authoring multimedia stories: beats, image types, speech, audio, and a minimal example
-- [Business Presentation Template](helps/business.md) — MulmoScript template and rules for business presentations in the Office role
-- [Storyteller Template](helps/storyteller.md) — MulmoScript template and rules for character-driven narrated stories in the Storyteller role
-- [Guide & Planner Templates](helps/guide.md) — document structures and form-field hints per guide type for the Guide & Planner role
-- [Spreadsheet](helps/spreadsheet.md) — cell format, formulas, date handling, and format codes for the presentSpreadsheet plugin
-- [presentHtml](helps/presenthtml.md) — self-contained HTML rules and the three-`../` relative-path convention used by the presentHtml plugin to keep generated files portable under `file://`
-- [Sandbox](helps/sandbox.md) — how the Docker sandbox isolates the agent, what it can access, and how to disable it
-- [Telegram Bridge](helps/telegram.md) — how to talk to MulmoClaude from the Telegram app: creating a bot, starting the bridge, allowlisting chat IDs, commands, and troubleshooting
-- [Information Sources](helps/sources.md) — registering RSS feeds / GitHub repos / arXiv queries, the daily-brief pipeline, and where its files live on disk
-- [Encore — recurring obligations DSL](helps/encore-dsl.md) — YAML DSL for recurring obligations (payments, services, check-ins), firing plans, multi-target bundles, and the bell-click resume loop
-- [GitHub repositories in the workspace](helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
+- [Wiki](config/helps/wiki.md) — how the personal knowledge wiki works, its folder layout, page format, and operations
+- [Gemini API Key](config/helps/gemini.md) — why `GEMINI_API_KEY` is strongly recommended (images, audio, video) and how to get one from Google AI Studio
+- [MulmoScript](config/helps/mulmoscript.md) — format reference for authoring multimedia stories: beats, image types, speech, audio, and a minimal example
+- [Business Presentation Template](config/helps/business.md) — MulmoScript template and rules for business presentations in the Office role
+- [Storyteller Template](config/helps/storyteller.md) — MulmoScript template and rules for character-driven narrated stories in the Storyteller role
+- [Guide & Planner Templates](config/helps/guide.md) — document structures and form-field hints per guide type for the Guide & Planner role
+- [Spreadsheet](config/helps/spreadsheet.md) — cell format, formulas, date handling, and format codes for the presentSpreadsheet plugin
+- [presentHtml](config/helps/presenthtml.md) — self-contained HTML rules and the three-`../` relative-path convention used by the presentHtml plugin to keep generated files portable under `file://`
+- [Sandbox](config/helps/sandbox.md) — how the Docker sandbox isolates the agent, what it can access, and how to disable it
+- [Telegram Bridge](config/helps/telegram.md) — how to talk to MulmoClaude from the Telegram app: creating a bot, starting the bridge, allowlisting chat IDs, commands, and troubleshooting
+- [Information Sources](config/helps/sources.md) — registering RSS feeds / GitHub repos / arXiv queries, the daily-brief pipeline, and where its files live on disk
+- [Encore — recurring obligations DSL](config/helps/encore-dsl.md) — YAML DSL for recurring obligations (payments, services, check-ins), firing plans, multi-target bundles, and the bell-click resume loop
+- [GitHub repositories in the workspace](config/helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
 
 ## Workspace Layout
 
@@ -62,6 +62,6 @@ See [Wiki](helps/wiki.md) for details on how it works.
   calendar/      ← calendar events
   contacts/      ← address book
   wiki/          ← personal knowledge wiki (long-term memory)
-  helps/         ← help pages (synced from app on every start)
+  config/helps/  ← help pages (synced from app on every start)
   memory.md      ← distilled facts loaded into every session
 ```

--- a/server/workspace/helps/index.md
+++ b/server/workspace/helps/index.md
@@ -50,6 +50,8 @@ See [Wiki](helps/wiki.md) for details on how it works.
 - [Sandbox](helps/sandbox.md) — how the Docker sandbox isolates the agent, what it can access, and how to disable it
 - [Telegram Bridge](helps/telegram.md) — how to talk to MulmoClaude from the Telegram app: creating a bot, starting the bridge, allowlisting chat IDs, commands, and troubleshooting
 - [Information Sources](helps/sources.md) — registering RSS feeds / GitHub repos / arXiv queries, the daily-brief pipeline, and where its files live on disk
+- [Encore — recurring obligations DSL](helps/encore-dsl.md) — YAML DSL for recurring obligations (payments, services, check-ins), firing plans, multi-target bundles, and the bell-click resume loop
+- [GitHub repositories in the workspace](helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
 
 ## Workspace Layout
 

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -98,7 +98,7 @@ export const ROLES: Role[] = [
     icon: "business_center",
     prompt:
       "You are a professional office assistant. Create and edit documents, spreadsheets, and presentations. Read existing files in the workspace for context.\n\n" +
-      "For multi-slide presentations, use presentMulmoScript. Follow the template and rules in config/helps/business.md exactly.\n\n" +
+      "For multi-slide presentations, use presentMulmoScript — first Read `config/helps/business.md` for the template and rules, then follow them exactly.\n\n" +
       "Use presentHtml for rich interactive output such as dashboards, reports with live controls, or data visualizations. Recommended libraries (load via CDN):\n" +
       "- **UI / layout**: Tailwind CSS — https://cdn.tailwindcss.com\n" +
       "- **Data visualization**: D3.js — https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js",
@@ -132,7 +132,7 @@ export const ROLES: Role[] = [
     prompt:
       "You are a knowledgeable guide and planner. You help users with any request that benefits from collecting their specific needs and producing a rich, illustrated step-by-step guide or detailed plan.\n\n" +
       "Supported guide types: recipe, travel itinerary, fitness program, event plan, study guide, DIY / home project — or any other scenario where a structured, illustrated document adds value.\n\n" +
-      "Follow the templates and rules in config/helps/guide.md exactly.\n\n" +
+      "Read `config/helps/guide.md` first; follow the templates and rules there exactly.\n\n" +
       "## Workflow\n\n" +
       "1. UNDERSTAND THE REQUEST: Identify which guide type fits the user's ask (or invent a fitting structure for novel requests).\n\n" +
       "2. COLLECT REQUIREMENTS: Call presentForm immediately to gather the details needed. Tailor the form fields to the specific request — see guide.md for per-type field suggestions. Pre-fill fields with `defaultValue` for anything the user has already provided.\n\n" +
@@ -202,7 +202,7 @@ export const ROLES: Role[] = [
     icon: "auto_stories",
     prompt:
       "You are a creative storyteller who crafts vivid, imaginative stories with consistent, named characters across every beat.\n\n" +
-      "For multi-beat narrated stories, use presentMulmoScript. Follow the template and rules in config/helps/storyteller.md exactly.\n\n" +
+      "For multi-beat narrated stories, use presentMulmoScript — first Read `config/helps/storyteller.md` for the template and rules, then follow them exactly.\n\n" +
       "When asked to create a story:\n" +
       "1. Decide on 2–5 main characters. For each, write a detailed visual description that will be used to generate a reference portrait.\n" +
       "2. Define every character in `imageParams.images` as a named entry with `type: 'imagePrompt'` and a rich prompt describing their appearance.\n" +

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -10,8 +10,6 @@ import {
   buildTimeSection,
   headingSection,
   prependJournalPointer,
-  buildInlinedHelpFiles,
-  summarizeHelpContent,
   buildPluginPromptSections,
   formatPluginSection,
 } from "../../server/agent/prompt.js";
@@ -114,8 +112,8 @@ describe("headingSection", () => {
   });
 
   it("keeps a single item verbatim under the heading", () => {
-    const out = headingSection("Reference Files", ["### helps/index.md\n\ncontent"]);
-    assert.equal(out, "## Reference Files\n\n### helps/index.md\n\ncontent");
+    const out = headingSection("Plugin Instructions", ["### name\n\ncontent"]);
+    assert.equal(out, "## Plugin Instructions\n\n### name\n\ncontent");
   });
 
   it("preserves embedded blank lines inside items", () => {
@@ -444,92 +442,6 @@ describe("prependJournalPointer", () => {
     writeJournalIndex();
     const result = prependJournalPointer("hi", workspace);
     assert.ok(result.toLowerCase().includes("skip"), "pointer should tell the model it can skip when not needed");
-  });
-});
-
-describe("summarizeHelpContent", () => {
-  it("extracts H1 and first paragraph joined by em-dash", () => {
-    const content = "# Wiki Help\n\nWrite wiki pages under data/wiki/pages/.\n\nMore details here.";
-    const result = summarizeHelpContent(content);
-    assert.equal(result, "Wiki Help — Write wiki pages under data/wiki/pages/.");
-  });
-
-  it("handles file with no H1", () => {
-    const content = "Quick tip: prefix branches with feat/.";
-    assert.equal(summarizeHelpContent(content), "Quick tip: prefix branches with feat/.");
-  });
-
-  it("handles file with only a heading", () => {
-    const content = "# Sandbox";
-    assert.equal(summarizeHelpContent("# Sandbox"), "Sandbox");
-    assert.equal(summarizeHelpContent(content), "Sandbox");
-  });
-
-  it("truncates long first paragraphs to 200 chars with ellipsis", () => {
-    const long = "x".repeat(500);
-    const content = `# Header\n\n${long}`;
-    const result = summarizeHelpContent(content);
-    assert.ok(result.startsWith("Header — "));
-    assert.ok(result.endsWith("…"));
-    // 200 for the paragraph cap + "Header — " prefix + trailing ellipsis
-    assert.ok(result.length <= "Header — ".length + 201);
-  });
-
-  it("skips headings between paragraphs when looking for a first paragraph", () => {
-    const content = "# Top\n\n## Sub\n\nFirst real paragraph after sub-heading.";
-    assert.equal(summarizeHelpContent(content), "Top — First real paragraph after sub-heading.");
-  });
-
-  it("returns empty string for content with nothing quotable", () => {
-    assert.equal(summarizeHelpContent(""), "");
-    assert.equal(summarizeHelpContent("\n\n\n"), "");
-  });
-});
-
-describe("buildInlinedHelpFiles", () => {
-  // Reuses the outer-scope `workspace` set by the top-level
-  // beforeEach/afterEach at the top of this file.
-  function writeHelp(name: string, content: string): void {
-    writeFileAt(workspace, `config/helps/${name}`, content);
-  }
-
-  it("inlines small help files verbatim", () => {
-    writeHelp("small.md", "# Small\n\nOne short line.");
-    const result = buildInlinedHelpFiles("Read helps/small.md for details.", workspace);
-    assert.equal(result.length, 1);
-    assert.ok(result[0].includes("### config/helps/small.md"));
-    assert.ok(result[0].includes("# Small\n\nOne short line."));
-    assert.ok(!result[0].includes("Detailed reference"));
-  });
-
-  it("summarizes + points to large help files", () => {
-    const bigBody = `\n\n${"filler paragraph. ".repeat(200)}`;
-    writeHelp("big.md", `# Big Help\n\nFirst real content paragraph explaining the feature.${bigBody}`);
-    const result = buildInlinedHelpFiles("See config/helps/big.md", workspace);
-    assert.equal(result.length, 1);
-    const [section] = result;
-    assert.ok(section.includes("### config/helps/big.md"));
-    assert.ok(section.includes("Big Help"));
-    assert.ok(section.includes("First real content paragraph"));
-    assert.ok(section.includes("Detailed reference: use Read on `config/helps/big.md`"));
-    assert.ok(!section.includes("filler paragraph. filler paragraph."));
-  });
-
-  it("deduplicates when the exact same ref appears twice", () => {
-    writeHelp("dup.md", "# Dup\n\nShort.");
-    const result = buildInlinedHelpFiles("Read helps/dup.md first, then helps/dup.md again.", workspace);
-    assert.equal(result.length, 1);
-  });
-
-  it("skips missing files without throwing", () => {
-    const result = buildInlinedHelpFiles("Read helps/ghost.md", workspace);
-    assert.deepEqual(result, []);
-  });
-
-  it("skips empty-content files", () => {
-    writeHelp("empty.md", "   \n\n   ");
-    const result = buildInlinedHelpFiles("Read helps/empty.md", workspace);
-    assert.deepEqual(result, []);
   });
 });
 

--- a/test/workspace/test_helps_registry.ts
+++ b/test/workspace/test_helps_registry.ts
@@ -13,7 +13,14 @@ import { fileURLToPath } from "node:url";
 // other reference material exists if it Reads index.md.
 //
 // Required shape, per line:
-//   `- [Title](helps/<name>.md) — <one-sentence summary>`
+//   `- [Title](config/helps/<name>.md) — <one-sentence summary>`
+//
+// The `config/helps/` prefix is the workspace-relative canonical
+// path (matching `WORKSPACE_PATHS.helps` in
+// `server/workspace/paths.ts`), and is the same form role prompts
+// use when telling the LLM to Read a help file — so an LLM that
+// browses index.md sees identical paths to those it sees in the
+// system prompt.
 //
 // Test fails when:
 //   (a) a new help file is added without adding an index entry
@@ -32,7 +39,7 @@ const __dirname = path.dirname(__filename);
 const HELPS_DIR = path.resolve(__dirname, "../../server/workspace/helps");
 const INDEX_FILENAME = "index.md";
 const HELP_PAGES_HEADING_RE = /^##\s+Help Pages\s*$/;
-const HELP_LIST_LINK_PREFIX = "helps/";
+const HELP_LIST_LINK_PREFIX = "config/helps/";
 const HELP_LIST_LINK_SUFFIX = ".md";
 const SUMMARY_MAX_CHARS = 200;
 
@@ -96,7 +103,10 @@ describe("server/workspace/helps registry (index.md)", () => {
   const helpFiles = listHelpFiles();
 
   it("has a parseable `## Help Pages` section with at least one entry", () => {
-    assert.ok(registry.size > 0, `${INDEX_FILENAME} should contain at least one entry under "## Help Pages" shaped: "- [Title](helps/<name>.md) — <summary>"`);
+    assert.ok(
+      registry.size > 0,
+      `${INDEX_FILENAME} should contain at least one entry under "## Help Pages" shaped: "- [Title](config/helps/<name>.md) — <summary>"`,
+    );
   });
 
   it("has an entry for every *.md under helps/ (except index.md itself)", () => {
@@ -104,7 +114,7 @@ describe("server/workspace/helps registry (index.md)", () => {
     const detail =
       missing.length === 0
         ? ""
-        : `Missing index.md entries for: ${missing.join(", ")}. Add a line under '## Help Pages' shaped: '- [Title](helps/<name>.md) — <summary>'.`;
+        : `Missing index.md entries for: ${missing.join(", ")}. Add a line under '## Help Pages' shaped: '- [Title](config/helps/<name>.md) — <summary>'.`;
     assert.deepEqual(missing, [], detail);
   });
 

--- a/test/workspace/test_helps_registry.ts
+++ b/test/workspace/test_helps_registry.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Guards the curated `## Help Pages` list in
+// `server/workspace/helps/index.md`. The list is the canonical
+// human-readable index of every help file shipped with the app —
+// roles point users (and Claude) at specific helps via canonical
+// `config/helps/<name>.md` paths in their role prompts, and the
+// index.md table is the directory that lets the LLM see what
+// other reference material exists if it Reads index.md.
+//
+// Required shape, per line:
+//   `- [Title](helps/<name>.md) — <one-sentence summary>`
+//
+// Test fails when:
+//   (a) a new help file is added without adding an index entry
+//       (LLM browsing index.md wouldn't discover it);
+//   (b) an index entry points at a missing file (stale link);
+//   (c) a summary line exceeds the length cap (one sentence, please).
+//
+// The parsing here is intentionally self-contained — production code
+// no longer reads index.md programmatically (the helps-injection
+// apparatus was removed in favour of role prompts referencing the
+// canonical path directly). This test exists purely as a
+// documentation-completeness guard.
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HELPS_DIR = path.resolve(__dirname, "../../server/workspace/helps");
+const INDEX_FILENAME = "index.md";
+const HELP_PAGES_HEADING_RE = /^##\s+Help Pages\s*$/;
+const HELP_LIST_LINK_PREFIX = "helps/";
+const HELP_LIST_LINK_SUFFIX = ".md";
+const SUMMARY_MAX_CHARS = 200;
+
+interface RegistryEntry {
+  title: string;
+  summary: string;
+}
+
+function parseListItem(line: string): { filename: string; entry: RegistryEntry } | null {
+  const trimmed = line.trimStart();
+  if (!(trimmed.startsWith("- ") || trimmed.startsWith("* "))) return null;
+  const afterBullet = trimmed.slice(2).trimStart();
+  if (!afterBullet.startsWith("[")) return null;
+  const titleEnd = afterBullet.indexOf("]");
+  if (titleEnd <= 1) return null;
+  const title = afterBullet.slice(1, titleEnd).trim();
+  const afterTitle = afterBullet.slice(titleEnd + 1);
+  if (!afterTitle.startsWith("(")) return null;
+  const linkEnd = afterTitle.indexOf(")");
+  if (linkEnd <= 1) return null;
+  const href = afterTitle.slice(1, linkEnd);
+  if (!href.startsWith(HELP_LIST_LINK_PREFIX) || !href.endsWith(HELP_LIST_LINK_SUFFIX)) return null;
+  const filename = href.slice(HELP_LIST_LINK_PREFIX.length);
+  const tail = afterTitle.slice(linkEnd + 1);
+  const sepIdx = tail.indexOf("—");
+  if (sepIdx === -1) return null;
+  const summary = tail.slice(sepIdx + 1).trim();
+  if (!summary) return null;
+  return { filename, entry: { title, summary } };
+}
+
+function parseRegistry(content: string): Map<string, RegistryEntry> {
+  const entries = new Map<string, RegistryEntry>();
+  const lines = content.split("\n");
+  let inSection = false;
+  for (const line of lines) {
+    if (HELP_PAGES_HEADING_RE.test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    if (/^#{1,2}\s+\S/.test(line)) break;
+    const parsed = parseListItem(line);
+    if (!parsed) continue;
+    entries.set(parsed.filename, parsed.entry);
+  }
+  return entries;
+}
+
+function listHelpFiles(): string[] {
+  return readdirSync(HELPS_DIR)
+    .filter((name) => name.endsWith(".md"))
+    .filter((name) => name !== INDEX_FILENAME)
+    .sort();
+}
+
+describe("server/workspace/helps registry (index.md)", () => {
+  const indexPath = path.join(HELPS_DIR, INDEX_FILENAME);
+  const indexContent = readFileSync(indexPath, "utf-8");
+  const registry = parseRegistry(indexContent);
+  const helpFiles = listHelpFiles();
+
+  it("has a parseable `## Help Pages` section with at least one entry", () => {
+    assert.ok(registry.size > 0, `${INDEX_FILENAME} should contain at least one entry under "## Help Pages" shaped: "- [Title](helps/<name>.md) — <summary>"`);
+  });
+
+  it("has an entry for every *.md under helps/ (except index.md itself)", () => {
+    const missing = helpFiles.filter((name) => !registry.has(name));
+    const detail =
+      missing.length === 0
+        ? ""
+        : `Missing index.md entries for: ${missing.join(", ")}. Add a line under '## Help Pages' shaped: '- [Title](helps/<name>.md) — <summary>'.`;
+    assert.deepEqual(missing, [], detail);
+  });
+
+  it("does not list entries for files that don't exist on disk", () => {
+    const orphaned = [...registry.keys()].filter((name) => !helpFiles.includes(name));
+    assert.deepEqual(orphaned, [], `index.md lists entries for missing files: ${orphaned.join(", ")}`);
+  });
+
+  it("keeps every summary within the length cap", () => {
+    const offenders: string[] = [];
+    for (const [filename, entry] of registry) {
+      if (entry.summary.length > SUMMARY_MAX_CHARS) {
+        offenders.push(`${filename}: ${entry.summary.length} chars`);
+      }
+    }
+    assert.deepEqual(offenders, [], `Summaries longer than ${SUMMARY_MAX_CHARS} chars: ${offenders.join("; ")}`);
+  });
+});


### PR DESCRIPTION
## Summary

- **Delete `buildInlinedHelpFiles` and its surrounding machinery** (auto-summarizer, inline/pointer threshold, `## Reference Files` section in the system prompt). Every role that wants a help file already names the canonical `config/helps/<name>.md` path in its own prompt and tells the LLM when to consult it — the injection just added a pointer with an auto-summary that paraphrased the role prompt's own instruction. Once we stopped inlining file contents (post-#487), the apparatus stopped earning its complexity.
- **Tighten three role prompts** (Office / Guide & Planner / Storyteller) to explicitly say "Read \`config/helps/<name>.md\`..." rather than "Follow the rules in `<path>`" — the latter was implicit about needing a `Read` call.
- **Backfill `helps/index.md`** with entries for `encore-dsl.md` and `github.md` (previously missing). The `## Help Pages` list now fully catalogs the directory; an LLM that `Read`s `index.md` can discover every reference document.
- **Add `test/workspace/test_helps_registry.ts`** guarding the catalog: every `helps/*.md` (except `index.md` itself) must have an entry, no entry may point at a missing file, and summaries stay under 200 chars. Production code no longer parses `index.md`, so the parser is duplicated locally in the test — a documentation-completeness guard, not a runtime dependency.

## Why

The original injection (pre-#487) inlined the full content of every referenced help file into every system prompt — that earned its place because the LLM got the content for free. After #487, it switched to a summary + pointer when a file exceeded 2K chars, and the summary was an auto-extracted `H1 + first paragraph capped at 200 chars`. Reviewing what's there now: role prompts like General already say `Read \`config/helps/wiki.md\` for full details`, which discovers the file, explains when to read it, and routes the LLM to the `Read` tool — all in one sentence. The injected `## Reference Files` block was duplicating that signal with auto-generated text. Deleting it shrinks every system prompt by the size of those blocks per referenced help, removes one code path, and keeps the LLM behavior unchanged for any role that uses help files (the role prompt's own instruction does the job).

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `yarn test` — full suite passes, including the new `test/workspace/test_helps_registry.ts` (4 cases) and the updated `test/agent/test_agent_prompt.ts`
- [ ] Manual: switch to the Office role, ask for a business presentation, confirm the LLM `Read`s `config/helps/business.md` and follows the template.
- [ ] Manual: switch to the Storyteller role, ask for a story, confirm the same for `config/helps/storyteller.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added help pages for "Encore — recurring obligations DSL" and "GitHub repositories in the workspace"

* **Updates**
  * Role instructions updated for office, guide, and storyteller
  * Help index paths moved to the config/helps location
  * System prompt no longer includes an inlined "Reference Files"/help-pages section

* **Tests**
  * Added validation tests to enforce help index completeness and summaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->