### PR TITLE
feat(encore): unify bell state in one reconciler + add unsnooze

### DIFF
--- a/plans/feat-encore-reconciler.md
+++ b/plans/feat-encore-reconciler.md
@@ -1,0 +1,108 @@
+# Encore: unified reconciler + `unsnooze` action
+
+## Problem
+
+Encore's dispatch handlers and the periodic tick each carry their own copy of "what bell state should exist for this obligation right now?" logic. The two paths drift, with `snooze` as the worst offender:
+
+- **`handleSnooze`** writes `snoozedSteps[stepId]` on the cycle file, then **manually** calls `dropTargetFromMatchingTickets` + `safeClearBell` to remove the matching bell entry — and **deliberately skips** `tickUnlocked`, because if it kicked the tick, the tick wouldn't trim the now-snoozed target from the bundle. (`maybeEscalate` only trims when `isStepClosed(...)` is true; it doesn't consider snooze.)
+- **`handleMarkStepDone` / `handleMarkTargetSkipped`** persist the cycle state and then call `clearPendingNotification(pendingId, …)` — a handler-side bell trimmer that walks the matching ticket by `pendingId`, filters out closed targets, and clears the bell when the bundle empties. This duplicates what the tick's `maybeEscalate` already knows how to compute from cycle state.
+- **`handleAmendDefinition`** calls `resetActiveNotificationsForObligation` to nuke every ticket for the current cycle, then kicks the tick to republish with the amended display name. A third bell-manipulation path with its own contract.
+
+Three concrete problems fall out:
+
+1. **No `unsnooze`.** Once a user has clicked "Snooze 24h" on a bell, there's no API to unsnooze before the timestamp expires. The only escape hatches today are `markStepDone` (falsely closes the step), `markTargetSkipped` (falsely closes the target), or hand-editing the cycle file.
+2. **Snooze's "no tick" is load-bearing.** The comment in `handleSnooze` admits the workaround: "DO NOT kick the tick — the bell is cleared and the snooze marker is in place; running runTick now would just check the marker and skip, so it's wasted work." That's the symptom of the tick not understanding snooze on the trim/clear side.
+3. **`amendDefinition` needs special-case bell wiping.** Trimming-by-state isn't enough when the DSL text changed (display name renamed, step label rewritten); the existing tickets need to be republished even though no `(target, step)` pair closed.
+
+## Approach
+
+One reconciler. One place that decides whether each obligation/cycle should have bell entries, what their severity should be, and what targets they should list. Every state-mutating handler funnels through it.
+
+### `server/encore/reconcile.ts` (new)
+
+`reconcileCycleNotifications({ obligationId, cycleId?, now, invalidateAllBells?, log })` is **the only code path** allowed to call `encoreNotifier.publish` / `encoreNotifier.clear` or write/unlink pending-clear tickets. It re-derives the desired bell state from disk:
+
+1. Load DSL. If `status !== "active"`, clear every bell+ticket for the obligation and stop.
+2. Load the primary cycle (the hinted one, or the obligation's current cycle).
+3. Reconcile that cycle's bells (Phase 1: trim/escalate existing tickets; Phase 2: publish for un-fired pairs).
+4. If the primary cycle is now closed, provision (or reuse) its successor and reconcile that too — the same path handles both "handler closed the last step" and "tick saw a cycle close naturally" cycle transitions.
+
+Key invariant — the "in-bundle" predicate is unified across phases:
+
+```ts
+function isPairInBundle(record, step, nowIso) {
+  if (isStepClosed(record, step)) return false;
+  if (isStepSnoozed(record, step.id, nowIso)) return false;
+  return true;
+}
+```
+
+That's the symmetry the current code lacks: **snoozed and closed are both out-of-bundle**, so a snoozed target trims out of its ticket the same way a closed one does. When all targets in a bundle are closed-or-snoozed, the bell clears.
+
+### `server/encore/tick.ts` (rewritten as thin shell)
+
+`runTick` becomes: walk every obligation directory, call `reconcileCycleNotifications(obligationId, …)`, then prune orphan tickets older than 30 days. No bell logic of its own. The tick is just the time-driven invoker; the reconciler is the brain.
+
+### `server/encore/dispatch.ts` (handlers refactored)
+
+Every state-mutating handler follows one shape — mutate cycle state, then call `persistAndReconcile`:
+
+```ts
+async function persistAndReconcile(rel, state, body, obligationId, cycleId) {
+  await writeText(rel, serializeCycleFile(state, body));
+  await reconcileCycleNotifications({ obligationId, cycleId, now: new Date(), log });
+}
+```
+
+Per-handler simplifications:
+
+- **`handleMarkStepDone` / `handleMarkTargetSkipped`** — drop `clearPendingNotification`; the reconciler trims the ticket from state.
+- **`handleSnooze`** — drop `dropTargetFromMatchingTickets` + `safeClearBell`. Write `snoozedSteps[stepId]`, reconcile, done. The "no tick" workaround disappears with it.
+- **`handleAmendDefinition`** — drop `resetActiveNotificationsForObligation`. Pass `invalidateAllBells: true` to the reconciler; it clears every ticket for the cycle and republishes with fresh DSL text.
+- **`handleSetup`** — keep cycle provisioning, but kick the reconciler instead of `tickUnlocked` so the first firingPlan phase surfaces in the same SSE turn.
+- **`handleRecordValues`** — now also calls `persistAndReconcile` for uniformity even though values changes never affect bells (reconciler is a no-op for that mutation). No special-case handler.
+
+### New `unsnooze` dispatch kind
+
+```ts
+const UnsnoozeArgs = z.object({
+  kind: z.literal("unsnooze"),
+  obligationId: z.string(),
+  cycleId: z.string(),
+  targetId: z.string(),
+  stepId: z.string(),
+});
+```
+
+Inverse of `snooze`: delete `snoozedSteps[stepId]` from the target's record (via a new `recordStepUnsnooze` pure mutator in `cycle.ts`), call reconcile. The reconciler sees the pair is once again eligible to fire (assuming it's not also closed) and the un-fired pass publishes a fresh bell — **in the same dispatch turn**, no tick wait. Add to `LLM_ENCORE_KINDS` so the LLM can invoke it.
+
+### Helpers added to `cycle.ts`
+
+- `recordStepUnsnooze(state, targetId, stepId)` — idempotent. No-op if the entry was already absent.
+- `isStepSnoozed(record, stepId, nowIso)` — shared predicate; reconciler uses it both for "should this bundle target trim?" and "is this un-fired pair eligible to fire?"
+
+### Cycle-close transition
+
+The reconciler needs to handle one subtle case the original tick handled implicitly: when a handler closes the last open step of a cycle, the just-closed cycle's tickets must be trimmed AND the successor cycle must be provisioned. `loadPrimaryCycle` always returns the named cycle (whether open or closed); after reconciling it, if `isCycleClosed(state, dsl)` is now true, `provisionSuccessor` provisions (or reuses) the next cycle file and the successor is reconciled too. This is what the pre-refactor handler chain (`persistAndKickTick` → `clearPendingNotification`-by-`pendingId`) did across two paths; the unified reconciler does it in one.
+
+## Out of scope
+
+- **The 24-hour snooze default** stays hardcoded. A separate change can let the LLM (or a future Snooze-UI affordance) request 1h / 1d / 1wk.
+- **Browser-side "Snooze 24h" button** on the bell that bypasses the LLM. Currently the LLM has to invoke `snooze` from inside a bell-seeded chat; a direct dispatch would close the loop faster but is a frontend change orthogonal to this server work.
+- **`/api/encore` per-kind JSON Schema** in the MCP tool definition (currently the `parameters` only declares `kind`, with `additionalProperties: true`). Tightening it so the LLM gets per-kind hints — especially `cycleId: { type: "string" }` for the annual-cycle "2026" gotcha — is its own follow-up. See discussion in #1431 thread.
+- **`PendingClearTicket` schema changes** (e.g. storing rendered title/body to detect DSL drift autonomously, instead of relying on `invalidateAllBells`). Out of scope for this PR; the flag is sufficient.
+
+## Acceptance
+
+- Every existing component test in `test/plugins/test_encore_dispatch.ts` keeps passing — including the two-target bundle invariant and the cycle-close-provisions-successor invariant.
+- New tests cover:
+  - `unsnooze` republishes the bell in the same dispatch turn (no tick wait).
+  - `unsnooze` on a step that wasn't snoozed is a no-op that doesn't flicker the existing bell.
+- `dispatch.ts` no longer contains `dropTargetFromMatchingTickets`, `safeClearBell` calls from non-orphan paths, `resetActiveNotificationsForObligation`, or `clearPendingNotification` — these helpers are deleted, not just unused.
+- Single grep guarantee: `grep -rn "encoreNotifier\.\(publish\|clear\)" server/encore/` returns only `server/encore/reconcile.ts` (production) and `server/encore/dispatch.ts` orphan-cleanup in `handleOrphanResolve` (recovery path for ticket-less bells; documented exception).
+- `LLM_ENCORE_KINDS` in `src/plugins/encore/definition.ts` includes `unsnooze`; the bell-seed prompt in `reconcile.ts` mentions it alongside `snooze` so the LLM knows it's available.
+- All checks pass: `yarn format`, `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build`.
+
+## Dependencies
+
+- PR #1430 (`feat/personal-role`) — introduces `ENCORE_SEED_ROLE_ID` and the Personal role that owns `manageEncore`. The reconciler PR builds on top; either merge order works as long as both land before any chat tries to call `unsnooze` from a non-Personal role.

--- a/plans/feat-encore-reconciler.md
+++ b/plans/feat-encore-reconciler.md
@@ -95,11 +95,23 @@ The reconciler needs to handle one subtle case the original tick handled implici
 ## Acceptance
 
 - Every existing component test in `test/plugins/test_encore_dispatch.ts` keeps passing — including the two-target bundle invariant and the cycle-close-provisions-successor invariant.
-- New tests cover:
-  - `unsnooze` republishes the bell in the same dispatch turn (no tick wait).
-  - `unsnooze` on a step that wasn't snoozed is a no-op that doesn't flicker the existing bell.
+- **New reconciler-level tests** in `test/plugins/test_encore_reconcile.ts` (state in, state out, no SSE):
+  1. **Trim symmetry** — bundle with two targets, one closed + one snoozed → both trim, bell clears. This is the load-bearing invariant the refactor rests on.
+  2. **Idempotency** — `reconcile` → `reconcile` with no state change between → second call makes zero notifier calls. Guards against bell-flicker regressions.
+  3. **Cycle-close transition** — closing the last open step in a handler-driven reconcile → just-closed cycle's tickets clear AND successor is provisioned AND reconciled in the same call.
+  4. **Snooze expiry** — `snoozedSteps[stepId]` with a past timestamp → treated as not-snoozed, pair fires.
+  5. **`invalidateAllBells: true`** — existing tickets cleared and republished with fresh DSL text (covers the `amendDefinition` path).
+  6. **Inactive status** — DSL `status !== "active"` → every bell + ticket for the obligation cleared, no republish.
+- **New dispatch-level tests** extending `test/plugins/test_encore_dispatch.ts`:
+  7. `unsnooze` republishes the bell in the same dispatch turn (no tick wait).
+  8. `unsnooze` on a step that wasn't snoozed is a no-op that doesn't flicker the existing bell.
+  9. `snooze` → `unsnooze` round-trip in one chat — bell present, gone, present.
+  10. Static guard test — assert no production code under `server/encore/` outside `reconcile.ts` and `handleOrphanResolve` imports/calls `encoreNotifier`. Programmatic enforcement of the grep guarantee below.
 - `dispatch.ts` no longer contains `dropTargetFromMatchingTickets`, `safeClearBell` calls from non-orphan paths, `resetActiveNotificationsForObligation`, or `clearPendingNotification` — these helpers are deleted, not just unused.
-- Single grep guarantee: `grep -rn "encoreNotifier\.\(publish\|clear\)" server/encore/` returns only `server/encore/reconcile.ts` (production) and `server/encore/dispatch.ts` orphan-cleanup in `handleOrphanResolve` (recovery path for ticket-less bells; documented exception).
+- Grep guarantee: `grep -rn "encoreNotifier\.\(publish\|clear\)" server/encore/` returns only:
+  - `server/encore/reconcile.ts` (production state-driven path), plus
+  - `server/encore/notifier.ts` (the wrapper that owns the host calls), plus
+  - two documented "ticket about to disappear, sweep the bell" exceptions: `handleOrphanResolve` in `dispatch.ts` (click landed after ticket was swept) and `pruneOneTicket` in `tick.ts` (30-day age-based orphan sweep). Both clear the host bell before unlinking the stale ticket so the next reconcile doesn't see "un-fired" and publish a duplicate.
 - `LLM_ENCORE_KINDS` in `src/plugins/encore/definition.ts` includes `unsnooze`; the bell-seed prompt in `reconcile.ts` mentions it alongside `snooze` so the LLM knows it's available.
 - All checks pass: `yarn format`, `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build`.
 

--- a/server/encore/cycle.ts
+++ b/server/encore/cycle.ts
@@ -110,6 +110,38 @@ export function recordStepSnooze(state: CycleState, targetId: string, stepId: st
   return next;
 }
 
+/** Inverse of `recordStepSnooze`. Idempotent — no-op if the entry
+ *  was already absent. Used by the `unsnooze` dispatch kind so the
+ *  bell can republish in the same turn (the reconciler sees the
+ *  pair eligible to fire again). */
+export function recordStepUnsnooze(state: CycleState, targetId: string, stepId: string): CycleState {
+  const next = cloneState(state);
+  const record = next.records[targetId];
+  if (record?.snoozedSteps && stepId in record.snoozedSteps) {
+    const rest: Record<string, string> = {};
+    for (const [key, value] of Object.entries(record.snoozedSteps)) {
+      if (key !== stepId) rest[key] = value;
+    }
+    record.snoozedSteps = Object.keys(rest).length > 0 ? rest : undefined;
+  }
+  return next;
+}
+
+/** True iff the target's `snoozedSteps[stepId]` is present AND its
+ *  ISO timestamp hasn't passed yet. Used by the reconciler both for
+ *  "should this bundle target trim?" and "is this un-fired pair
+ *  eligible to fire?" — the symmetry the pre-reconciler code lacked.
+ *
+ *  Use a full ISO timestamp for `nowIso` (not date-only `YYYY-MM-DD`).
+ *  `snoozedUntil` is written by `recordStepSnooze` via
+ *  `toISOString()`; comparing it lexically against a date-only
+ *  string would over-block by ~24h for any snooze that doesn't land
+ *  on midnight. */
+export function isStepSnoozed(record: TargetRecord | undefined, stepId: string, nowIso: string): boolean {
+  const until = record?.snoozedSteps?.[stepId];
+  return Boolean(until && until > nowIso);
+}
+
 /** Merge new field values onto a target without marking any step
  *  done. This is `recordValues` semantics — partial info, no
  *  closure. */

--- a/server/encore/dispatch.ts
+++ b/server/encore/dispatch.ts
@@ -1,22 +1,24 @@
 // Encore plugin — server-side handler module.
 //
 // Data-only on-disk model (PR #1416 follow-up): cycle files hold
-// only what the user recorded (values / skipped / completedSteps).
-// Closure is derived. Bell-entry tracking lives in pending-clear
-// tickets, not in the cycle file.
+// only what the user recorded (values / skipped / completedSteps /
+// snoozedSteps). Closure is derived. Bell-entry tracking lives in
+// pending-clear tickets, not in the cycle file.
 //
 // `dispatch(body)` is the single entry point; the Express adapter in
 // `server/api/routes/encore.ts` calls it. The dispatch wrapper
 // acquires the per-plugin mutex before each handler runs so two
 // concurrent mutations can't race on writeFileAtomic, and so a
-// kick-the-tick from a handler can't double-publish with the hourly
-// heartbeat. State-mutating handlers kick the tick after persisting
-// — the tick re-evaluates the obligation, derives closure, and
-// surfaces newly-due notifications within the same SSE turn.
+// reconcile from a handler can't double-publish with the hourly
+// heartbeat.
 //
-// Next-cycle provisioning happens INSIDE the tick when it detects
-// the latest cycle is closed (via closure.ts) — no separate
-// provisionNextCycle path from dispatch.
+// State-mutating handlers funnel through `persistAndReconcile`:
+// write the cycle file, then run the reconciler under the same lock.
+// The reconciler is the sole owner of bell state (see reconcile.ts)
+// — handlers don't touch notifier publish/clear or pending-clear
+// tickets directly. The one documented exception is
+// `handleOrphanResolve`, which clears a bell entry whose ticket was
+// already swept (the click landed too late).
 
 import { z } from "zod";
 
@@ -27,20 +29,22 @@ import {
   parseCycleFile,
   recordStepDone,
   recordStepSnooze,
+  recordStepUnsnooze,
   recordTargetSkip,
   serializeCycleFile,
   type CycleState,
 } from "./cycle.js";
 import { ONE_HOUR_MS } from "../utils/time.js";
-import { isCycleClosed, isStepClosed } from "./closure.js";
+import { isCycleClosed } from "./closure.js";
 import { parseIndexFile, serializeIndexFile } from "./obligation.js";
 import { currentCycleSlot } from "./dsl/cadence.js";
 import path from "node:path";
-import { obligationDir, obligationIndexPath, cycleFilePath, pendingClearPath, slugify, OBLIGATIONS_DIRNAME, PENDING_CLEAR_DIRNAME } from "./paths.js";
-import { exists, readDir, readTextOrNull, writeText, unlink } from "../utils/files/encore-io.js";
+import { obligationDir, obligationIndexPath, cycleFilePath, pendingClearPath, slugify, OBLIGATIONS_DIRNAME } from "./paths.js";
+import { exists, readDir, readTextOrNull, writeText } from "../utils/files/encore-io.js";
 import { WORKSPACE_DIRS } from "../workspace/paths.js";
 import { log } from "../system/logger/index.js";
-import { tickUnlocked, withLock } from "./lock.js";
+import { withLock } from "./lock.js";
+import { reconcileCycleNotifications } from "./reconcile.js";
 import * as encoreNotifier from "./notifier.js";
 import { ENCORE_PLUGIN_PKG } from "./notifier.js";
 import type { PendingClearTicket } from "./tick.js";
@@ -87,7 +91,11 @@ const SetupArgs = z.object({
 const AmendArgs = z.object({
   kind: z.literal("amendDefinition"),
   obligationId: z.string(),
-  definition: z.record(z.string(), z.unknown()),
+  // `z.unknown()` instead of `z.record(...)` so the handler can also
+  // accept a JSON-encoded string and parse it via `coerceDefinitionToObject`
+  // — same tolerance as setup. The handler validates the resulting
+  // object shape before merging.
+  definition: z.unknown(),
 });
 
 const QueryArgs = z.object({
@@ -140,6 +148,14 @@ const SnoozeArgs = z.object({
   pendingId: z.string().optional(),
 });
 
+const UnsnoozeArgs = z.object({
+  kind: z.literal("unsnooze"),
+  obligationId: z.string(),
+  cycleId: z.string(),
+  targetId: z.string(),
+  stepId: z.string(),
+});
+
 const ResolveNotificationArgs = z.object({
   kind: z.literal("resolveNotification"),
   pendingId: z.string(),
@@ -164,9 +180,10 @@ async function generateUniqueObligationId(displayName: string): Promise<string> 
 // ── handlers ──────────────────────────────────────────────────────
 
 async function handleSetup(args: z.infer<typeof SetupArgs>): Promise<EncoreDispatchResult> {
+  const definitionObject = coerceDefinitionToObject(args.definition, "setup");
   let dsl: EncoreDsl;
   try {
-    dsl = EncoreDslInput.parse(args.definition);
+    dsl = EncoreDslInput.parse(definitionObject);
   } catch (err) {
     if (err instanceof z.ZodError) {
       throw new EncoreError(400, formatZodError(err), { issues: err.issues });
@@ -189,10 +206,10 @@ async function handleSetup(args: z.infer<typeof SetupArgs>): Promise<EncoreDispa
   await writeText(obligationIndexPath(obligationId), serializeIndexFile(fullDsl, ""));
   await writeText(cycleFilePath(obligationId, cycle.cycleId), serializeCycleFile(cycle, ""));
 
-  // Kick the tick so that if the firingPlan's first phase is
-  // already due (cycle-start with no offset, for example), the bell
-  // surfaces the notification within the same SSE turn.
-  await tickUnlocked({ now: new Date() }, `setup ${obligationId}`);
+  // Reconcile so that if the firingPlan's first phase is already due
+  // (cycle-start with no offset, for example), the bell surfaces the
+  // notification within the same SSE turn.
+  await reconcileCycleNotifications({ obligationId, cycleId: cycle.cycleId, now: new Date(), log });
 
   log.info("encore", "setup: obligation created", { obligationId, cycleId: cycle.cycleId });
 
@@ -213,7 +230,7 @@ async function handleAmend(args: z.infer<typeof AmendArgs>): Promise<EncoreDispa
     throw new EncoreError(404, `obligation ${JSON.stringify(args.obligationId)} not found`);
   }
   const { dsl: existing, body } = parseIndexFile(raw);
-  const patch = args.definition;
+  const patch = coerceDefinitionToObject(args.definition, "amendDefinition");
 
   // Immutable fields per Resolved #15 / #10: type, currency, and
   // cadence.type. Changing them would invalidate prior cycle records
@@ -255,17 +272,12 @@ async function handleAmend(args: z.infer<typeof AmendArgs>): Promise<EncoreDispa
 
   await writeText(indexPath, serializeIndexFile(validated, body));
 
-  // Force-refresh every active bell entry for this obligation:
-  // clear the current bell entries, null out the cycle file's
-  // activeNotificationId / lastPublishedSeverity, then kick the
-  // tick. The tick will see the un-fired entries and publish fresh
-  // notifications carrying the new displayName / step labels.
-  // Without this step, a title-only amend leaves the old bell in
-  // place (or worse — if the bell entry was already cleared but the
-  // cycle file still holds the id, no new notification fires at all
-  // because the tick thinks one is already active).
-  await resetActiveNotificationsForObligation(args.obligationId, `amendDefinition`);
-  await tickUnlocked({ now: new Date() }, `amendDefinition ${args.obligationId}`);
+  // Force-refresh every active bell entry for this obligation. A
+  // title-only amend doesn't close anything, so trim-by-state alone
+  // wouldn't republish — but the on-screen text is stale. The
+  // `invalidateAllBells` flag tells the reconciler to clear all
+  // tickets+bells for the cycle first, then republish with fresh DSL.
+  await reconcileCycleNotifications({ obligationId: args.obligationId, now: new Date(), invalidateAllBells: true, log });
   log.info("encore", "amendDefinition: obligation updated", { obligationId: args.obligationId });
 
   return {
@@ -425,81 +437,6 @@ function appendBody(existing: string, addition: string): string {
 
 // ── per-cycle mutating handlers ───────────────────────────────────
 
-/** Find every pending-clear ticket for this obligation+cycle, clear
- *  its host bell entry, and unlink the ticket. Used by
- *  amendDefinition so a title (or any other amend) produces a
- *  freshly-published notification carrying the updated text — and
- *  to recover from "ticket exists but the bell is empty" stuck
- *  states. */
-async function resetActiveNotificationsForObligation(obligationId: string, reason: string): Promise<void> {
-  const cycleId = await currentCycleIdFor(obligationId);
-  if (!cycleId) return;
-  const matchingTickets = await ticketsForObligationCycle(obligationId, cycleId);
-  let cleared = 0;
-  for (const { rel, ticket } of matchingTickets) {
-    await safeClearBell(ticket.notificationId, `${reason}:reset`);
-    await unlink(rel);
-    cleared += 1;
-  }
-  if (cleared > 0) log.info("encore", `${reason}: reset active notifications`, { obligationId, cleared });
-}
-
-interface LocatedTicket {
-  rel: string;
-  ticket: PendingClearTicket;
-}
-
-async function ticketsForObligationCycle(obligationId: string, cycleId: string): Promise<LocatedTicket[]> {
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
-  const out: LocatedTicket[] = [];
-  for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    const rel = path.join(PENDING_CLEAR_DIRNAME, entry);
-    const raw = await readTextOrNull(rel);
-    if (!raw) continue;
-    try {
-      const ticket = JSON.parse(raw) as PendingClearTicket;
-      if (ticket.obligationId === obligationId && ticket.cycleId === cycleId) {
-        out.push({ rel, ticket });
-      }
-    } catch {
-      // skip unparsable
-    }
-  }
-  return out;
-}
-
-async function currentCycleIdFor(obligationId: string): Promise<string | null> {
-  const entries = await readDir(obligationDir(obligationId));
-  const cycleFiles = entries.filter((name) => name !== "index.md" && name.endsWith(".md")).sort();
-  if (cycleFiles.length === 0) return null;
-  return cycleFiles[cycleFiles.length - 1].replace(/\.md$/, "");
-}
-
-// `removeTicketsForNotifications` was used by the old
-// reset-by-notificationId path; the new reset walks tickets by
-// obligation+cycle directly. Kept (with the lint-required `__`
-// prefix) in case a future caller needs it.
-async function __removeTicketsForNotifications(ids: Set<string>): Promise<void> {
-  if (ids.size === 0) return;
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
-  for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    const rel = path.join(PENDING_CLEAR_DIRNAME, entry);
-    const raw = await readTextOrNull(rel);
-    if (!raw) continue;
-    try {
-      const ticket = JSON.parse(raw) as { notificationId?: string };
-      if (ticket.notificationId && ids.has(ticket.notificationId)) {
-        await unlink(rel);
-      }
-    } catch {
-      // Unparsable ticket — leave it; the orphan sweep handles
-      // those by age.
-    }
-  }
-}
-
 async function loadDsl(obligationId: string): Promise<EncoreDsl | null> {
   const raw = await readTextOrNull(obligationIndexPath(obligationId));
   if (raw === null) return null;
@@ -520,134 +457,14 @@ async function loadCycle(obligationId: string, cycleId: string): Promise<{ rel: 
   return { rel, raw, state, body };
 }
 
-/** When a handler is the resolution of a notification-seeded chat,
- *  the pending-clear ticket carries the bell-entry id and the set
- *  of targets it covers (a bundle when length > 1).
- *
- *  Bundle-aware semantics: closing one target inside a multi-target
- *  bundle must NOT clear the shared bell entry — the other targets
- *  in the bundle still need a chat to resolve them. We drop the
- *  closed target(s) from `ticket.targets`; only when the set
- *  becomes empty do we clear the bell and unlink the ticket. This
- *  also covers the single-target case as a degenerate (one
- *  remaining target → close it → set empties → clear).
- *
- *  "Closed" here means the target's step (the one named in the
- *  ticket) is no longer `open` AND no longer references this
- *  notificationId — set to null by closeStep/skipTarget/snoozeStep
- *  via cycle.ts. */
-interface ExpectedTicketScope {
-  obligationId: string;
-  cycleId: string;
-}
-
-async function clearPendingNotification(
-  pendingId: string | undefined,
-  dsl: EncoreDsl | null,
-  expectedScope: ExpectedTicketScope | null,
-  mutatedState?: CycleState,
-): Promise<void> {
-  if (!pendingId) return;
-  const ticketRel = pendingClearPath(pendingId);
-  const ticket = await readTicketOrCleanup(ticketRel, pendingId);
-  if (!ticket) return;
-
-  // Verify the ticket belongs to the obligation+cycle that was
-  // just mutated. A mismatched pendingId (LLM passes the wrong
-  // one) would otherwise let us trim/clear an unrelated bundle.
-  if (expectedScope && (ticket.obligationId !== expectedScope.obligationId || ticket.cycleId !== expectedScope.cycleId)) {
-    log.warn("encore", "clearPendingNotification: pendingId scope mismatch; ignoring", {
-      pendingId,
-      ticketScope: { obligationId: ticket.obligationId, cycleId: ticket.cycleId },
-      expectedScope,
-    });
-    return;
-  }
-
-  const state = await loadStateForTicket(ticket, mutatedState);
-  if (!state) {
-    // Cycle file gone → orphan. Clear and unlink.
-    await safeClearBell(ticket.notificationId, pendingId);
-    await unlink(ticketRel);
-    return;
-  }
-  const stepDef = await resolveStepDef(ticket, dsl);
-  if (!stepDef) {
-    // Can't derive closure without the step definition; clear so
-    // the bundle doesn't get stuck.
-    await safeClearBell(ticket.notificationId, pendingId);
-    await unlink(ticketRel);
-    return;
-  }
-
-  const stillOpenTargets = ticket.targets.filter((targetId) => !isStepClosed(state.records[targetId], stepDef));
-
-  if (stillOpenTargets.length > 0) {
-    await writeText(ticketRel, JSON.stringify({ ...ticket, targets: stillOpenTargets }, null, 2));
-    log.info("encore", "pending-clear: partial resolution; bell kept", {
-      pendingId,
-      notificationId: ticket.notificationId,
-      remaining: stillOpenTargets,
-    });
-    return;
-  }
-
-  // No targets left open on this bundle — clear the bell and the ticket.
-  await safeClearBell(ticket.notificationId, pendingId);
-  await unlink(ticketRel);
-}
-
-async function readTicketOrCleanup(ticketRel: string, pendingId: string): Promise<PendingClearTicket | null> {
-  const raw = await readTextOrNull(ticketRel);
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as PendingClearTicket;
-  } catch (err) {
-    log.warn("encore", "pending-clear ticket unparseable; removing", { pendingId, error: err instanceof Error ? err.message : String(err) });
-    await unlink(ticketRel);
-    return null;
-  }
-}
-
-async function loadStateForTicket(ticket: PendingClearTicket, mutatedState?: CycleState): Promise<CycleState | null> {
-  if (mutatedState) return mutatedState;
-  const cycleRaw = await readTextOrNull(cycleFilePath(ticket.obligationId, ticket.cycleId));
-  if (cycleRaw === null) return null;
-  return parseCycleFile(cycleRaw).state;
-}
-
-async function resolveStepDef(ticket: PendingClearTicket, dsl: EncoreDsl | null): Promise<EncoreDsl["steps"][number] | undefined> {
-  const direct = dsl?.steps.find((step) => step.id === ticket.stepId);
-  if (direct) return direct;
-  const indexRaw = await readTextOrNull(obligationIndexPath(ticket.obligationId));
-  if (indexRaw === null) return undefined;
-  try {
-    return parseIndexFile(indexRaw).dsl.steps.find((step) => step.id === ticket.stepId);
-  } catch {
-    return undefined;
-  }
-}
-
-async function safeClearBell(notificationId: string, pendingId: string): Promise<void> {
-  try {
-    await encoreNotifier.clear(notificationId);
-  } catch (err) {
-    log.warn("encore", "notifier.clear failed", { pendingId, notificationId, error: err instanceof Error ? err.message : String(err) });
-  }
-}
-
-async function persistAndKickTick(rel: string, state: CycleState, body: string, reason: string): Promise<void> {
+/** The mutating-handler envelope. Write the cycle file, then run
+ *  the reconciler under the same per-plugin lock that wraps this
+ *  dispatch. The reconciler re-derives the desired bell state from
+ *  disk — it's both the trim path (closed/snoozed → out of bundle)
+ *  and the publish path (un-fired in-bundle pairs → publish). */
+async function persistAndReconcile(rel: string, state: CycleState, body: string, obligationId: string, cycleId: string): Promise<void> {
   await writeText(rel, serializeCycleFile(state, body));
-  // The tick itself derives closure via closure.ts and provisions
-  // the next cycle file when the current one is closed (see
-  // ensureOpenCycle in tick.ts). The handler doesn't need to
-  // detect close here.
-  //
-  // Run the tick inside the SAME lock that wraps the dispatch
-  // (we use `tickUnlocked`, not `kickTickLocked` — the latter
-  // would deadlock by trying to re-acquire the lock we already
-  // hold).
-  await tickUnlocked({ now: new Date() }, reason);
+  await reconcileCycleNotifications({ obligationId, cycleId, now: new Date(), log });
 }
 
 /** Reject calls referencing target/step ids that don't exist in
@@ -674,8 +491,7 @@ async function handleMarkStepDone(args: z.infer<typeof MarkStepDoneArgs>): Promi
   assertKnownTargetAndStep(dsl, args);
   const { rel, state, body } = await loadCycle(args.obligationId, args.cycleId);
   const nextState = recordStepDone(state, args.targetId, args.stepId, args.values);
-  await persistAndKickTick(rel, nextState, body, `markStepDone ${args.obligationId}/${args.cycleId}/${args.targetId}/${args.stepId}`);
-  await clearPendingNotification(args.pendingId, dsl, { obligationId: args.obligationId, cycleId: args.cycleId }, nextState);
+  await persistAndReconcile(rel, nextState, body, args.obligationId, args.cycleId);
   log.info("encore", "markStepDone: step recorded", { obligationId: args.obligationId, cycleId: args.cycleId, targetId: args.targetId, stepId: args.stepId });
   return {
     ok: true,
@@ -693,8 +509,7 @@ async function handleMarkTargetSkipped(args: z.infer<typeof MarkTargetSkippedArg
   assertKnownTargetAndStep(dsl, args);
   const { rel, state, body } = await loadCycle(args.obligationId, args.cycleId);
   const nextState = recordTargetSkip(state, args.targetId);
-  await persistAndKickTick(rel, nextState, body, `markTargetSkipped ${args.obligationId}/${args.cycleId}/${args.targetId}`);
-  await clearPendingNotification(args.pendingId, dsl, { obligationId: args.obligationId, cycleId: args.cycleId }, nextState);
+  await persistAndReconcile(rel, nextState, body, args.obligationId, args.cycleId);
   log.info("encore", "markTargetSkipped: target skipped", { obligationId: args.obligationId, cycleId: args.cycleId, targetId: args.targetId });
   return {
     ok: true,
@@ -711,9 +526,12 @@ async function handleRecordValues(args: z.infer<typeof RecordValuesArgs>): Promi
   assertKnownTargetAndStep(dsl, args);
   const { rel, state, body } = await loadCycle(args.obligationId, args.cycleId);
   const nextState = applyValues(state, args.targetId, args.values);
-  // No tick kick — recording partial values doesn't close anything
-  // and doesn't change firing eligibility.
-  await writeText(rel, serializeCycleFile(nextState, body));
+  // recordValues never closes anything, so the reconciler is a no-op
+  // for bells — but we still funnel through `persistAndReconcile`
+  // for uniformity (no special-case handler shape). The reconciler
+  // is cheap when nothing changed: Phase 1 sees the same live targets,
+  // Phase 2 sees the same covered keys, no notifier calls.
+  await persistAndReconcile(rel, nextState, body, args.obligationId, args.cycleId);
   log.info("encore", "recordValues: values recorded", {
     obligationId: args.obligationId,
     cycleId: args.cycleId,
@@ -734,6 +552,10 @@ async function handleOrphanResolve(args: z.infer<typeof ResolveNotificationArgs>
   // The ticket was already swept (e.g. the LLM resolved the
   // obligation in another chat before this click). Clear the bell
   // entry so it disappears.
+  //
+  // DOCUMENTED EXCEPTION to the reconciler-owns-the-bell rule:
+  // there's no ticket to reconcile against, so the reconciler can't
+  // know the bell entry exists. Direct clear is the only way out.
   if (args.notificationId) {
     try {
       await encoreNotifier.clear(args.notificationId);
@@ -803,57 +625,59 @@ async function handleResolveNotification(args: z.infer<typeof ResolveNotificatio
   };
 }
 
-async function dropTargetFromMatchingTickets(obligationId: string, cycleId: string, stepId: string, targetId: string): Promise<number> {
-  const matchingTickets = await ticketsForObligationCycle(obligationId, cycleId);
-  let dropped = 0;
-  for (const { rel, ticket } of matchingTickets) {
-    if (ticket.stepId !== stepId) continue;
-    if (!ticket.targets.includes(targetId)) continue;
-    const remaining = ticket.targets.filter((entry) => entry !== targetId);
-    if (remaining.length === 0) {
-      await safeClearBell(ticket.notificationId, "snooze");
-      await unlink(rel);
-    } else {
-      await writeText(rel, JSON.stringify({ ...ticket, targets: remaining }, null, 2));
-    }
-    dropped += 1;
-  }
-  return dropped;
-}
-
 async function handleSnooze(args: z.infer<typeof SnoozeArgs>): Promise<EncoreDispatchResult> {
   const dsl = await loadDsl(args.obligationId);
   assertKnownTargetAndStep(dsl, args);
-  // Snooze under the data-only model:
-  //   1. Clear the matching bell entry (the user clicked snooze;
-  //      the bell should go away now).
-  //   2. Write `snoozedSteps[stepId]` on the cycle file so the
-  //      tick skips this step until the snooze expires. Without
-  //      this marker the next tick would see "open step, no
-  //      ticket" → un-fired → republish the same bell entry
-  //      immediately. Default snooze = 24 hours; tunable later if
-  //      a real use case emerges.
-  //   3. DO NOT kick the tick — the bell is cleared and the
-  //      snooze marker is in place; running runTick now would
-  //      just check the marker and skip, so it's wasted work.
-  const droppedCount = await dropTargetFromMatchingTickets(args.obligationId, args.cycleId, args.stepId, args.targetId);
-
+  // Snooze under the unified-reconciler model: write
+  // `snoozedSteps[stepId]` on the cycle file and let the reconciler
+  // do the rest. Because `isPairInBundle` treats snoozed as
+  // out-of-bundle, Phase 1 trims this target out of any existing
+  // ticket (clearing the bell if the bundle empties); Phase 2 sees
+  // the pair as not eligible-to-fire (snooze active), so no
+  // republish. The pre-reconciler workaround ("skip the tick after
+  // snooze") is no longer needed.
   const snoozeUntilIso = new Date(Date.now() + 24 * ONE_HOUR_MS).toISOString();
   const { rel, state, body } = await loadCycle(args.obligationId, args.cycleId);
   const nextState = recordStepSnooze(state, args.targetId, args.stepId, snoozeUntilIso);
-  await writeText(rel, serializeCycleFile(nextState, body));
-
-  await clearPendingNotification(args.pendingId, null, { obligationId: args.obligationId, cycleId: args.cycleId });
+  await persistAndReconcile(rel, nextState, body, args.obligationId, args.cycleId);
   log.info("encore", "snooze: step snoozed", {
     obligationId: args.obligationId,
     cycleId: args.cycleId,
     targetId: args.targetId,
     stepId: args.stepId,
-    droppedCount,
+    snoozeUntilIso,
   });
   return {
     ok: true,
     message: `Encore: snoozed ${args.stepId} for ${args.targetId} in cycle ${args.cycleId} of ${args.obligationId}.`,
+    obligationId: args.obligationId,
+    cycleId: args.cycleId,
+    targetId: args.targetId,
+    stepId: args.stepId,
+  };
+}
+
+async function handleUnsnooze(args: z.infer<typeof UnsnoozeArgs>): Promise<EncoreDispatchResult> {
+  const dsl = await loadDsl(args.obligationId);
+  assertKnownTargetAndStep(dsl, args);
+  // Inverse of snooze: delete `snoozedSteps[stepId]`. The reconciler
+  // sees the pair eligible to fire again (assuming the step isn't
+  // also closed) and Phase 2 publishes a fresh bell — in the same
+  // dispatch turn, no tick wait. If the step was already not
+  // snoozed, `recordStepUnsnooze` is a no-op and the reconciler
+  // sees no state change → no flicker.
+  const { rel, state, body } = await loadCycle(args.obligationId, args.cycleId);
+  const nextState = recordStepUnsnooze(state, args.targetId, args.stepId);
+  await persistAndReconcile(rel, nextState, body, args.obligationId, args.cycleId);
+  log.info("encore", "unsnooze: step unsnoozed", {
+    obligationId: args.obligationId,
+    cycleId: args.cycleId,
+    targetId: args.targetId,
+    stepId: args.stepId,
+  });
+  return {
+    ok: true,
+    message: `Encore: unsnoozed ${args.stepId} for ${args.targetId} in cycle ${args.cycleId} of ${args.obligationId}.`,
     obligationId: args.obligationId,
     cycleId: args.cycleId,
     targetId: args.targetId,
@@ -870,6 +694,34 @@ function formatZodError(err: z.ZodError): string {
   const [first] = err.issues;
   const pathStr = first.path.length > 0 ? first.path.map((segment) => String(segment)).join(".") : "(root)";
   return `DSL validation failed at ${pathStr}: ${first.message}. Read config/helps/encore-dsl.md for the full grammar.`;
+}
+
+/** Accept `definition` as either an object literal OR a JSON-encoded
+ *  string of one. The LLM commonly JSON.stringify's tool-call
+ *  arguments (especially for nested objects), and rejecting that
+ *  shape with "expected object, received string" reads as a schema
+ *  problem rather than a wire-format problem — the LLM tends to
+ *  retry with the same shape. Silently coercing eliminates the
+ *  whole class of mistake. The trade-off: a non-JSON string or a
+ *  JSON string that decodes to a non-object surfaces with a clear
+ *  400 instead of being silently dropped. */
+function coerceDefinitionToObject(value: unknown, kind: string): Record<string, unknown> {
+  let coerced = value;
+  if (typeof coerced === "string") {
+    try {
+      coerced = JSON.parse(coerced);
+    } catch (err) {
+      throw new EncoreError(
+        400,
+        `${kind}: \`definition\` was provided as a string but is not valid JSON: ${err instanceof Error ? err.message : String(err)}. Pass an object literal, or a JSON-encoded string of one.`,
+      );
+    }
+  }
+  if (!coerced || typeof coerced !== "object" || Array.isArray(coerced)) {
+    const actual = Array.isArray(coerced) ? "array" : coerced === null ? "null" : typeof coerced;
+    throw new EncoreError(400, `${kind}: \`definition\` must be an object (or a JSON string of one), got ${actual}.`);
+  }
+  return coerced as Record<string, unknown>;
 }
 
 function workspaceRelativePath(rel: string): string {
@@ -905,6 +757,7 @@ async function dispatchInner(body: EncoreDispatchBody): Promise<EncoreDispatchRe
   if (kind === "markTargetSkipped") return handleMarkTargetSkipped(safeParse(MarkTargetSkippedArgs, body, kind));
   if (kind === "recordValues") return handleRecordValues(safeParse(RecordValuesArgs, body, kind));
   if (kind === "snooze") return handleSnooze(safeParse(SnoozeArgs, body, kind));
+  if (kind === "unsnooze") return handleUnsnooze(safeParse(UnsnoozeArgs, body, kind));
   if (kind === "resolveNotification") return handleResolveNotification(safeParse(ResolveNotificationArgs, body, kind));
   throw new EncoreError(400, `unknown kind ${JSON.stringify(kind)}`);
 }
@@ -917,7 +770,7 @@ export async function dispatch(body: EncoreDispatchBody): Promise<EncoreDispatch
     throw new EncoreError(400, "missing or non-string `kind`");
   }
   // Serialise every dispatch through the per-plugin mutex (Resolved
-  // #22). The mutex also covers handler-side `tickUnlocked` calls
-  // since we run them from inside this same critical section.
+  // #22). The mutex also covers handler-side reconcile calls since
+  // we run them from inside this same critical section.
   return withLock(() => dispatchInner(body));
 }

--- a/server/encore/reconcile.ts
+++ b/server/encore/reconcile.ts
@@ -184,17 +184,21 @@ async function trimOrEscalateTicket(
   const stepDef = dsl.steps.find((step) => step.id === ticket.stepId);
   if (!stepDef) {
     // Step no longer exists in the DSL (e.g., amend dropped it).
-    // Clear the bell and unlink the ticket so we don't leak.
-    await safeClearBell(ticket.notificationId, "step removed", log);
-    await unlink(pendingClearPath(ticket.pendingId));
+    // Clear the bell and unlink the ticket so we don't leak. If the
+    // clear failed, keep the ticket on disk so the next reconcile
+    // retries — unlinking an un-cleared bell would orphan it.
+    if (await safeClearBell(ticket.notificationId, "step removed", log)) {
+      await unlink(pendingClearPath(ticket.pendingId));
+    }
     return null;
   }
 
   const liveTargets = ticket.targets.filter((targetId) => isPairInBundle(state.records[targetId], stepDef, nowIso));
 
   if (liveTargets.length === 0) {
-    await safeClearBell(ticket.notificationId, "bundle drained", log);
-    await unlink(pendingClearPath(ticket.pendingId));
+    if (await safeClearBell(ticket.notificationId, "bundle drained", log)) {
+      await unlink(pendingClearPath(ticket.pendingId));
+    }
     return null;
   }
 
@@ -204,14 +208,30 @@ async function trimOrEscalateTicket(
 
   if (severityChanged) {
     // Escalation. Clear the old bell entry and republish at the new
-    // severity with the trimmed bundle.
-    await safeClearBell(ticket.notificationId, "severity escalation", log);
+    // severity with the trimmed bundle. If the clear failed, bail
+    // BEFORE publishing — otherwise the old bell would remain while
+    // we attach a fresh ticket to a new id, leaving a duplicate.
+    if (!(await safeClearBell(ticket.notificationId, "severity escalation", log))) {
+      log.warn("encore", "reconcile: skipping escalation; clear failed", {
+        pendingId: ticket.pendingId,
+        notificationId: ticket.notificationId,
+      });
+      return { targets: liveTargets };
+    }
     const members = liveTargets.map((targetId) => ({ targetId }));
     const title = bundleTitle(dsl, stepDef, members);
     const body = bundleBody(dsl, stepDef, members);
     const navigateTarget = encoreUrlFor(ticket.pendingId);
     const { id: newId } = await encoreNotifier.publish({ severity: phase.severity, title, body, navigateTarget });
-    await writeTicket({ ...ticket, notificationId: newId, severity: phase.severity, targets: liveTargets });
+    // Roll back the just-published bell entry if the ticket write
+    // fails — otherwise the bell would have no matching ticket and
+    // the next reconcile would see "un-fired" → publish a duplicate.
+    try {
+      await writeTicket({ ...ticket, notificationId: newId, severity: phase.severity, targets: liveTargets });
+    } catch (err) {
+      await safeClearBell(newId, "rollback: ticket write failed after escalation publish", log);
+      throw err;
+    }
     log.info("encore", "reconcile: escalated", {
       obligationId: dsl.id,
       cycleId: state.cycleId,
@@ -321,7 +341,15 @@ async function fireGroup(dsl: EncoreDsl, state: CycleState, group: BundleGroup, 
     seedPrompt: buildSeedPrompt(dsl, group, pendingId, state.cycleId),
     createdAt: new Date().toISOString(),
   };
-  await writeTicket(ticket);
+  // Roll back the just-published bell entry if the ticket write
+  // fails — without rollback the bell would be live with no ticket,
+  // and the next reconcile would re-publish a duplicate.
+  try {
+    await writeTicket(ticket);
+  } catch (err) {
+    await safeClearBell(notificationId, "rollback: ticket write failed after publish", log);
+    throw err;
+  }
   log.info("encore", "reconcile: published bundled notification", {
     obligationId: dsl.id,
     cycleId: state.cycleId,
@@ -399,9 +427,13 @@ async function clearAllForObligation(obligationId: string, reason: string, log: 
       continue;
     }
     if (ticket.obligationId !== obligationId) continue;
-    await safeClearBell(ticket.notificationId, reason, log);
-    await unlink(rel);
-    cleared += 1;
+    // Only unlink the ticket if the bell clear succeeded; otherwise
+    // a transient notifier failure would orphan the host bell entry.
+    // Leaving the ticket lets the next reconcile retry.
+    if (await safeClearBell(ticket.notificationId, reason, log)) {
+      await unlink(rel);
+      cleared += 1;
+    }
   }
   if (cleared > 0) log.info("encore", "reconcile: cleared all for obligation", { obligationId, reason, cleared });
 }
@@ -410,9 +442,10 @@ async function clearAllForCycle(obligationId: string, cycleId: string, reason: s
   const tickets = await ticketsForCycle(obligationId, cycleId);
   let cleared = 0;
   for (const ticket of tickets) {
-    await safeClearBell(ticket.notificationId, reason, log);
-    await unlink(pendingClearPath(ticket.pendingId));
-    cleared += 1;
+    if (await safeClearBell(ticket.notificationId, reason, log)) {
+      await unlink(pendingClearPath(ticket.pendingId));
+      cleared += 1;
+    }
   }
   if (cleared > 0) log.info("encore", "reconcile: cleared all for cycle", { obligationId, cycleId, reason, cleared });
 }
@@ -552,11 +585,19 @@ async function ticketsForCycle(obligationId: string, cycleId: string): Promise<P
   return out;
 }
 
-async function safeClearBell(notificationId: string, reason: string, log: typeof defaultLog): Promise<void> {
+/** Try to clear the bell entry. Returns `true` on success, `false`
+ *  on failure (logged). Callers MUST consult the return value before
+ *  destructive follow-ups (unlinking the ticket, republishing at a
+ *  new id, etc.); swallowing a clear failure and proceeding would
+ *  orphan the host bell entry — the pre-refactor escalation aborted
+ *  on clear failure for exactly this reason. */
+async function safeClearBell(notificationId: string, reason: string, log: typeof defaultLog): Promise<boolean> {
   try {
     await encoreNotifier.clear(notificationId);
+    return true;
   } catch (err) {
     log.warn("encore", "reconcile: notifier.clear failed", { reason, notificationId, error: err instanceof Error ? err.message : String(err) });
+    return false;
   }
 }
 

--- a/server/encore/reconcile.ts
+++ b/server/encore/reconcile.ts
@@ -1,0 +1,565 @@
+// Encore reconciler — the sole owner of bell state.
+//
+// Every state-mutating handler funnels through `reconcileCycleNotifications`,
+// and the time-driven tick walks all obligations through the same call. This
+// is the ONLY production code path that invokes `encoreNotifier.publish` /
+// `encoreNotifier.clear` and writes/unlinks pending-clear tickets — the one
+// documented exception is `handleOrphanResolve` in dispatch.ts (recovery
+// path for a click that lost its ticket).
+//
+// Re-deriving from disk on every call is intentional: each handler used to
+// patch bell state with its own copy of the trim/escalate logic, and the
+// copies drifted (snooze had to skip the tick to avoid double-publish; amend
+// needed a bespoke wipe path; markStepDone had a pendingId-walker). One
+// reconciler removes all three workarounds because the unifying predicate
+// `isPairInBundle` treats closed AND snoozed as out-of-bundle.
+
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import { log as defaultLog } from "../system/logger/index.js";
+import { compareIsoDates, formatCycleId, isoDate, nextSlot, type CycleSlot } from "./dsl/cadence.js";
+import { parseAtExpression } from "./dsl/at-expression.js";
+import { resolveAtExpression } from "./dsl/at-resolver.js";
+import type { EncoreDsl, Severity, StepDef } from "./dsl/schema.js";
+import { parseIndexFile } from "./obligation.js";
+import { buildCycleState, isStepSnoozed, parseCycleFile, serializeCycleFile, type CycleState, type TargetRecord } from "./cycle.js";
+import { isCycleClosed, isStepClosed } from "./closure.js";
+import { cycleFilePath, obligationDir, obligationIndexPath, pendingClearPath, PENDING_CLEAR_DIRNAME } from "./paths.js";
+import { exists, readDir, readTextOrNull, writeText, unlink } from "../utils/files/encore-io.js";
+import * as encoreNotifier from "./notifier.js";
+import type { PendingClearTicket } from "./tick.js";
+
+export interface ReconcileDeps {
+  obligationId: string;
+  /** Specific cycle the caller just mutated. Omitted (tick path) →
+   *  the latest cycle on disk. */
+  cycleId?: string;
+  now: Date;
+  /** Force-clear every ticket+bell for the primary cycle before
+   *  publishing fresh ones. Used by `amendDefinition`: a title-only
+   *  amend doesn't close anything, so trim-by-state wouldn't
+   *  republish — but the on-screen text is now stale. */
+  invalidateAllBells?: boolean;
+  log?: typeof defaultLog;
+}
+
+/** Single entry point. Re-derive desired bell state from disk and
+ *  reconcile to match. Safe to call concurrently only under the
+ *  per-plugin lock (see `lock.ts`). */
+export async function reconcileCycleNotifications(deps: ReconcileDeps): Promise<void> {
+  const log = deps.log ?? defaultLog;
+  const todayIso = isoDate(deps.now);
+  const nowIso = deps.now.toISOString();
+
+  const dsl = await loadDsl(deps.obligationId);
+  if (!dsl) return;
+
+  if (dsl.status !== "active") {
+    await clearAllForObligation(deps.obligationId, "obligation inactive", log);
+    return;
+  }
+
+  const primary = await loadPrimaryCycle(deps.obligationId, deps.cycleId);
+  if (!primary) return;
+
+  if (deps.invalidateAllBells) {
+    await clearAllForCycle(deps.obligationId, primary.state.cycleId, "invalidateAllBells", log);
+  }
+
+  await reconcileOneCycle(dsl, primary.state, todayIso, nowIso, log);
+
+  // Cycle-close transition. If the primary cycle is now closed
+  // (handler closed the last step, or the tick saw closure happen
+  // naturally), provision (or reuse) its successor and reconcile
+  // that too — same dispatch turn, same lock, no second tick wait.
+  if (isCycleClosed(primary.state, dsl)) {
+    const successor = await provisionSuccessor(dsl, primary.state, log);
+    if (successor) {
+      await reconcileOneCycle(dsl, successor.state, todayIso, nowIso, log);
+    }
+  }
+}
+
+// ── loaders ───────────────────────────────────────────────────────
+
+async function loadDsl(obligationId: string): Promise<EncoreDsl | null> {
+  const raw = await readTextOrNull(obligationIndexPath(obligationId));
+  if (raw === null) return null;
+  try {
+    return parseIndexFile(raw).dsl;
+  } catch {
+    return null;
+  }
+}
+
+interface PrimaryCycle {
+  rel: string;
+  state: CycleState;
+  body: string;
+}
+
+async function loadPrimaryCycle(obligationId: string, hint: string | undefined): Promise<PrimaryCycle | null> {
+  const cycleId = hint ?? (await pickLatestCycleId(obligationId));
+  if (!cycleId) return null;
+  const rel = cycleFilePath(obligationId, cycleId);
+  const raw = await readTextOrNull(rel);
+  if (raw === null) return null;
+  try {
+    const { state, body } = parseCycleFile(raw);
+    return { rel, state, body };
+  } catch {
+    return null;
+  }
+}
+
+async function pickLatestCycleId(obligationId: string): Promise<string | null> {
+  const entries = await readDir(obligationDir(obligationId));
+  const cycleFiles = entries.filter((name) => name !== "index.md" && name.endsWith(".md")).sort();
+  if (cycleFiles.length === 0) return null;
+  return cycleFiles[cycleFiles.length - 1].replace(/\.md$/, "");
+}
+
+// ── unified "is this (target, step) pair currently in any bundle?" ──
+
+/** The load-bearing predicate. A pair belongs in a bundle iff the
+ *  step is OPEN (not closed) AND not currently snoozed. Both the
+ *  trim phase (existing ticket → still-live targets) and the publish
+ *  phase (un-fired pairs → eligible to fire) consult this. The
+ *  pre-reconciler code had two parallel checks that diverged: snooze
+ *  was special-cased in the publish path (`isStepEligibleToFire`)
+ *  but ignored on the trim path (`maybeEscalate`), so a snooze had
+ *  to skip the tick entirely to avoid re-publishing the entry it
+ *  had just cleared. */
+function isPairInBundle(record: TargetRecord | undefined, step: StepDef, nowIso: string): boolean {
+  if (isStepClosed(record, step)) return false;
+  if (isStepSnoozed(record, step.id, nowIso)) return false;
+  return true;
+}
+
+// ── one-cycle reconcile (phase 1 + phase 2) ───────────────────────
+
+async function reconcileOneCycle(dsl: EncoreDsl, state: CycleState, todayIso: string, nowIso: string, log: typeof defaultLog): Promise<void> {
+  const tickets = await ticketsForCycle(dsl.id ?? "", state.cycleId);
+
+  // Phase 1: trim or escalate existing tickets. Anything covered by
+  // a still-live ticket is OFF the publish-eligibility list for
+  // Phase 2 (we don't want to publish a duplicate while the existing
+  // entry is still up).
+  const coveredKeys = new Set<string>();
+  for (const ticket of dedupeTickets(tickets)) {
+    const survivor = await trimOrEscalateTicket(dsl, state, ticket, todayIso, nowIso, log);
+    if (survivor) {
+      for (const targetId of survivor.targets) {
+        coveredKeys.add(`${ticket.stepId}:${targetId}`);
+      }
+    }
+  }
+
+  // Phase 2: publish for un-fired, in-bundle (target, step) pairs.
+  const unfired = collectUnfired(dsl, state, coveredKeys, todayIso, nowIso);
+  for (const group of groupForBundling(unfired)) {
+    await fireGroup(dsl, state, group, log);
+  }
+}
+
+// ── Phase 1: trim or escalate ─────────────────────────────────────
+
+interface TicketSurvivor {
+  targets: string[];
+}
+
+/** Recompute the still-live target set for this ticket; rewrite,
+ *  escalate, or clear as appropriate. Returns the survivor's target
+ *  set so Phase 2 can know which (step, target) pairs are already
+ *  covered. */
+async function trimOrEscalateTicket(
+  dsl: EncoreDsl,
+  state: CycleState,
+  ticket: PendingClearTicket,
+  todayIso: string,
+  nowIso: string,
+  log: typeof defaultLog,
+): Promise<TicketSurvivor | null> {
+  const stepDef = dsl.steps.find((step) => step.id === ticket.stepId);
+  if (!stepDef) {
+    // Step no longer exists in the DSL (e.g., amend dropped it).
+    // Clear the bell and unlink the ticket so we don't leak.
+    await safeClearBell(ticket.notificationId, "step removed", log);
+    await unlink(pendingClearPath(ticket.pendingId));
+    return null;
+  }
+
+  const liveTargets = ticket.targets.filter((targetId) => isPairInBundle(state.records[targetId], stepDef, nowIso));
+
+  if (liveTargets.length === 0) {
+    await safeClearBell(ticket.notificationId, "bundle drained", log);
+    await unlink(pendingClearPath(ticket.pendingId));
+    return null;
+  }
+
+  const phase = currentPhaseFor(stepDef, state, todayIso);
+  const severityChanged = phase !== null && phase.severity !== ticket.severity;
+  const targetsChanged = liveTargets.length !== ticket.targets.length;
+
+  if (severityChanged) {
+    // Escalation. Clear the old bell entry and republish at the new
+    // severity with the trimmed bundle.
+    await safeClearBell(ticket.notificationId, "severity escalation", log);
+    const members = liveTargets.map((targetId) => ({ targetId }));
+    const title = bundleTitle(dsl, stepDef, members);
+    const body = bundleBody(dsl, stepDef, members);
+    const navigateTarget = encoreUrlFor(ticket.pendingId);
+    const { id: newId } = await encoreNotifier.publish({ severity: phase.severity, title, body, navigateTarget });
+    await writeTicket({ ...ticket, notificationId: newId, severity: phase.severity, targets: liveTargets });
+    log.info("encore", "reconcile: escalated", {
+      obligationId: dsl.id,
+      cycleId: state.cycleId,
+      stepId: stepDef.id,
+      from: ticket.severity,
+      to: phase.severity,
+      notificationId: newId,
+    });
+    return { targets: liveTargets };
+  }
+
+  if (targetsChanged) {
+    // Bundle shrunk without escalation. Rewrite the ticket; the
+    // host bell entry keeps the same id (the on-screen badge count
+    // doesn't change for one notification, only its body).
+    await writeTicket({ ...ticket, targets: liveTargets });
+    log.info("encore", "reconcile: trimmed bundle", {
+      pendingId: ticket.pendingId,
+      notificationId: ticket.notificationId,
+      remaining: liveTargets,
+    });
+    return { targets: liveTargets };
+  }
+
+  return { targets: liveTargets };
+}
+
+function dedupeTickets(tickets: PendingClearTicket[]): PendingClearTicket[] {
+  const seen = new Set<string>();
+  const out: PendingClearTicket[] = [];
+  for (const ticket of tickets) {
+    if (seen.has(ticket.pendingId)) continue;
+    seen.add(ticket.pendingId);
+    out.push(ticket);
+  }
+  return out;
+}
+
+// ── Phase 2: un-fired collection + publish ────────────────────────
+
+interface UnfiredPair {
+  targetId: string;
+  stepId: string;
+  stepDef: StepDef;
+  severity: Severity;
+  fireDate: string;
+}
+
+function collectUnfired(dsl: EncoreDsl, state: CycleState, coveredKeys: Set<string>, todayIso: string, nowIso: string): UnfiredPair[] {
+  const out: UnfiredPair[] = [];
+  for (const target of dsl.targets) {
+    const record = state.records[target.id];
+    if (record?.skipped) continue;
+    for (const step of dsl.steps) {
+      if (coveredKeys.has(`${step.id}:${target.id}`)) continue;
+      if (!isPairInBundle(record, step, nowIso)) continue;
+      const phase = currentPhaseFor(step, state, todayIso);
+      if (!phase) continue;
+      out.push({ targetId: target.id, stepId: step.id, stepDef: step, severity: phase.severity, fireDate: phase.fireDate });
+    }
+  }
+  return out;
+}
+
+interface BundleGroup {
+  stepId: string;
+  stepDef: StepDef;
+  severity: Severity;
+  fireDate: string;
+  members: { targetId: string }[];
+}
+
+function groupForBundling(unfired: UnfiredPair[]): BundleGroup[] {
+  const byKey = new Map<string, BundleGroup>();
+  for (const pair of unfired) {
+    const key = `${pair.stepId} ${pair.severity} ${pair.fireDate}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.members.push({ targetId: pair.targetId });
+    } else {
+      byKey.set(key, {
+        stepId: pair.stepId,
+        stepDef: pair.stepDef,
+        severity: pair.severity,
+        fireDate: pair.fireDate,
+        members: [{ targetId: pair.targetId }],
+      });
+    }
+  }
+  return [...byKey.values()];
+}
+
+async function fireGroup(dsl: EncoreDsl, state: CycleState, group: BundleGroup, log: typeof defaultLog): Promise<void> {
+  const pendingId = randomUUID();
+  const navigateTarget = encoreUrlFor(pendingId);
+  const title = bundleTitle(dsl, group.stepDef, group.members);
+  const body = bundleBody(dsl, group.stepDef, group.members);
+  const { id: notificationId } = await encoreNotifier.publish({ severity: group.severity, title, body, navigateTarget });
+  const ticket: PendingClearTicket = {
+    pendingId,
+    obligationId: dsl.id ?? "",
+    cycleId: state.cycleId,
+    notificationId,
+    stepId: group.stepId,
+    targets: group.members.map((member) => member.targetId),
+    severity: group.severity,
+    seedPrompt: buildSeedPrompt(dsl, group, pendingId, state.cycleId),
+    createdAt: new Date().toISOString(),
+  };
+  await writeTicket(ticket);
+  log.info("encore", "reconcile: published bundled notification", {
+    obligationId: dsl.id,
+    cycleId: state.cycleId,
+    stepId: group.stepId,
+    severity: group.severity,
+    targets: group.members.map((member) => member.targetId),
+    notificationId,
+    pendingId,
+  });
+}
+
+// ── successor provisioning ────────────────────────────────────────
+
+async function provisionSuccessor(dsl: EncoreDsl, state: CycleState, log: typeof defaultLog): Promise<{ state: CycleState } | null> {
+  const slot = slotFromCycleId(dsl.cadence, state.cycleId);
+  if (!slot) {
+    log.warn("encore", "reconcile: could not parse cycleId for next slot", { obligationId: dsl.id, cycleId: state.cycleId });
+    return null;
+  }
+  const next = nextSlot(dsl.cadence, slot);
+  const nextRel = cycleFilePath(dsl.id ?? "", formatCycleId(next));
+  if (!(await exists(nextRel))) {
+    await writeText(nextRel, serializeCycleFile(buildCycleState(dsl, next), ""));
+    log.info("encore", "reconcile: provisioned next cycle", { obligationId: dsl.id, fromCycleId: state.cycleId, toCycleId: formatCycleId(next) });
+  }
+  const nextRaw = await readTextOrNull(nextRel);
+  if (nextRaw === null) return null;
+  try {
+    const parsed = parseCycleFile(nextRaw);
+    return { state: parsed.state };
+  } catch {
+    return null;
+  }
+}
+
+function slotFromCycleId(cadence: EncoreDsl["cadence"], cycleId: string): CycleSlot | null {
+  if (cadence.type === "annual") {
+    const year = Number.parseInt(cycleId, 10);
+    if (!Number.isFinite(year)) return null;
+    return { kind: "annual", year };
+  }
+  if (cadence.type === "biannual") {
+    const match = cycleId.match(/^(\d{4})-h([12])$/);
+    if (!match) return null;
+    return { kind: "biannual", year: Number.parseInt(match[1], 10), half: Number.parseInt(match[2], 10) as 1 | 2 };
+  }
+  if (cadence.type === "monthly") {
+    const match = cycleId.match(/^(\d{4})-(\d{2})$/);
+    if (!match) return null;
+    return { kind: "monthly", year: Number.parseInt(match[1], 10), month: Number.parseInt(match[2], 10) };
+  }
+  if (cadence.type === "weekly") {
+    const match = cycleId.match(/^(\d{4})-W(\d{2})$/);
+    if (!match) return null;
+    return { kind: "weekly", year: Number.parseInt(match[1], 10), week: Number.parseInt(match[2], 10) };
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(cycleId)) return null;
+  return { kind: "daily", iso: cycleId };
+}
+
+// ── clear-all helpers ─────────────────────────────────────────────
+
+async function clearAllForObligation(obligationId: string, reason: string, log: typeof defaultLog): Promise<void> {
+  const entries = await readDir(PENDING_CLEAR_DIRNAME);
+  let cleared = 0;
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const rel = path.join(PENDING_CLEAR_DIRNAME, entry);
+    const raw = await readTextOrNull(rel);
+    if (!raw) continue;
+    let ticket: PendingClearTicket;
+    try {
+      ticket = JSON.parse(raw) as PendingClearTicket;
+    } catch {
+      continue;
+    }
+    if (ticket.obligationId !== obligationId) continue;
+    await safeClearBell(ticket.notificationId, reason, log);
+    await unlink(rel);
+    cleared += 1;
+  }
+  if (cleared > 0) log.info("encore", "reconcile: cleared all for obligation", { obligationId, reason, cleared });
+}
+
+async function clearAllForCycle(obligationId: string, cycleId: string, reason: string, log: typeof defaultLog): Promise<void> {
+  const tickets = await ticketsForCycle(obligationId, cycleId);
+  let cleared = 0;
+  for (const ticket of tickets) {
+    await safeClearBell(ticket.notificationId, reason, log);
+    await unlink(pendingClearPath(ticket.pendingId));
+    cleared += 1;
+  }
+  if (cleared > 0) log.info("encore", "reconcile: cleared all for cycle", { obligationId, cycleId, reason, cleared });
+}
+
+// ── phase eval ────────────────────────────────────────────────────
+
+interface ResolvedPhase {
+  severity: Severity;
+  fireDate: string;
+}
+
+function currentPhaseFor(stepDef: StepDef, cycleState: CycleState, todayIso: string): ResolvedPhase | null {
+  let stepDeadline: string;
+  try {
+    stepDeadline = resolveAtExpression(parseAtExpression(stepDef.deadline, { allowStepDeadline: false }), {
+      cycleStart: cycleState.cycleStart,
+      cycleDeadline: cycleState.cycleDeadline,
+    });
+  } catch {
+    return null;
+  }
+  const anchors = { cycleStart: cycleState.cycleStart, cycleDeadline: cycleState.cycleDeadline, stepDeadline };
+  let latest: ResolvedPhase | null = null;
+  for (const phase of stepDef.firingPlan) {
+    let resolved: string;
+    try {
+      resolved = resolveAtExpression(parseAtExpression(phase.at, { allowStepDeadline: true }), anchors);
+    } catch {
+      continue;
+    }
+    if (compareIsoDates(resolved, todayIso) <= 0) {
+      latest = { severity: phase.severity, fireDate: resolved };
+    } else {
+      break;
+    }
+  }
+  return latest;
+}
+
+// ── titles + bodies + seed prompts ────────────────────────────────
+
+function bundleTitle(dsl: EncoreDsl, stepDef: StepDef, members: { targetId: string }[]): string {
+  if (members.length === 1) {
+    const [{ targetId }] = members;
+    const target = dsl.targets.find((entry) => entry.id === targetId);
+    return `${dsl.displayName} — ${stepDef.displayName} (${target?.displayName ?? targetId})`;
+  }
+  return `${dsl.displayName} — ${stepDef.displayName} (${members.length} targets)`;
+}
+
+function bundleBody(dsl: EncoreDsl, _stepDef: StepDef, members: { targetId: string }[]): string {
+  if (members.length === 1) return "";
+  return members
+    .map((member) => {
+      const target = dsl.targets.find((entry) => entry.id === member.targetId);
+      return target?.displayName ?? member.targetId;
+    })
+    .join(", ");
+}
+
+function buildSeedPrompt(dsl: EncoreDsl, group: BundleGroup, pendingId: string, cycleId: string): string {
+  const targetLines = group.members
+    .map((member) => {
+      const target = dsl.targets.find((entry) => entry.id === member.targetId);
+      return `- ${target?.displayName ?? member.targetId} (id: ${member.targetId})`;
+    })
+    .join("\n");
+  const fieldList = group.stepDef.fields.length === 0 ? "(no fields to record for this step)" : group.stepDef.fields.map((name) => `- ${name}`).join("\n");
+  const firstTargetId = group.members[0]?.targetId ?? "<targetId>";
+  const obligationId = dsl.id ?? "";
+  const exampleCall = JSON.stringify(
+    {
+      kind: "markStepDone",
+      pendingId,
+      obligationId,
+      cycleId,
+      targetId: firstTargetId,
+      stepId: group.stepId,
+      values: Object.fromEntries(group.stepDef.fields.map((name) => [name, "<value>"])),
+    },
+    null,
+    2,
+  );
+  return [
+    `An Encore reminder for the obligation "${dsl.displayName}" (id: ${obligationId}, cycle: ${cycleId}).`,
+    "",
+    `Step: ${group.stepDef.displayName} (id: ${group.stepId})`,
+    `Severity: ${group.severity}. Fire date: ${group.fireDate}.`,
+    "",
+    `Targets covered by this notification:`,
+    targetLines,
+    "",
+    `Fields to collect on each target's record:`,
+    fieldList,
+    "",
+    `Help the user record what happened, then call manageEncore — ONCE PER TARGET — with one of:`,
+    `- kind: "markStepDone" — step is complete (pass field values via \`values\`).`,
+    `- kind: "markTargetSkipped" — user is skipping this target for this cycle.`,
+    `- kind: "recordValues" — partial info only, no closing.`,
+    `- kind: "snooze" — defer the bell entry (default 24h).`,
+    `- kind: "unsnooze" — re-enable a previously snoozed step before its timer expires.`,
+    "",
+    `Call-shape rules (the parser will 400 on these common mistakes):`,
+    `- \`targetId\` is SINGULAR (a string), NOT \`targetIds\` (array). If the notification covers multiple targets, make one call per target.`,
+    `- \`values\` is a FLAT field-map: \`{ fieldName: value, ... }\`. NEVER nest it by target id (\`{ <targetId>: { ... } }\` is wrong).`,
+    `- Always pass \`pendingId\`, \`obligationId\`, and \`cycleId\` as shown below — they're what clears the bell entry when the cycle progresses.`,
+    "",
+    `Example for ${firstTargetId}:`,
+    "```json",
+    exampleCall,
+    "```",
+  ].join("\n");
+}
+
+// ── ticket I/O ────────────────────────────────────────────────────
+
+async function writeTicket(ticket: PendingClearTicket): Promise<void> {
+  await writeText(pendingClearPath(ticket.pendingId), JSON.stringify(ticket, null, 2));
+}
+
+async function ticketsForCycle(obligationId: string, cycleId: string): Promise<PendingClearTicket[]> {
+  const entries = await readDir(PENDING_CLEAR_DIRNAME);
+  const out: PendingClearTicket[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const raw = await readTextOrNull(path.join(PENDING_CLEAR_DIRNAME, entry));
+    if (!raw) continue;
+    try {
+      const ticket = JSON.parse(raw) as PendingClearTicket;
+      if (ticket.obligationId === obligationId && ticket.cycleId === cycleId) {
+        out.push(ticket);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+async function safeClearBell(notificationId: string, reason: string, log: typeof defaultLog): Promise<void> {
+  try {
+    await encoreNotifier.clear(notificationId);
+  } catch (err) {
+    log.warn("encore", "reconcile: notifier.clear failed", { reason, notificationId, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+function encoreUrlFor(pendingId: string): string {
+  return `/encore?pendingId=${encodeURIComponent(pendingId)}`;
+}

--- a/server/encore/tick.ts
+++ b/server/encore/tick.ts
@@ -15,14 +15,14 @@
 import path from "node:path";
 
 import { log as defaultLog } from "../system/logger/index.js";
-import { ONE_HOUR_MS } from "../utils/time.js";
+import { ONE_DAY_MS } from "../utils/time.js";
 import type { Severity } from "./dsl/schema.js";
 import { PENDING_CLEAR_DIRNAME, OBLIGATIONS_DIRNAME } from "./paths.js";
 import { readDir, readTextOrNull, unlink } from "../utils/files/encore-io.js";
 import * as encoreNotifier from "./notifier.js";
 import { reconcileCycleNotifications } from "./reconcile.js";
 
-const ORPHAN_TICKET_AGE_MS = 30 * 24 * ONE_HOUR_MS; // 30 days
+const ORPHAN_TICKET_AGE_MS = 30 * ONE_DAY_MS;
 
 export interface TickDeps {
   now: Date;

--- a/server/encore/tick.ts
+++ b/server/encore/tick.ts
@@ -4,8 +4,12 @@
 // That moved into `reconcile.ts` (the sole owner of bell state). The
 // tick is now a thin walker:
 //
-//   1. For every obligation directory, call reconcileCycleNotifications.
-//   2. Prune orphan pending-clear tickets older than 30 days.
+//   1. For every obligation directory, reconcile the latest cycle.
+//   2. Sweep stuck tickets — reconcile any (obligationId, cycleId)
+//      pair found in pending-clear/ that step 1 didn't cover. This
+//      retries clear failures on closed/non-latest cycles, which
+//      step 1 alone would skip (it only picks the latest cycle).
+//   3. Prune orphan pending-clear tickets older than 30 days.
 //
 // `PendingClearTicket` still lives here because dispatch.ts, reconcile.ts,
 // and the host UI all import the type — keeping it adjacent to the on-disk
@@ -64,7 +68,65 @@ export async function runTick(deps: TickDeps): Promise<void> {
       log.warn("encore", "tick: reconcile failed", { obligationId, error: err instanceof Error ? err.message : String(err) });
     }
   }
+  await sweepStuckTickets(new Set(obligationIds), deps.now, log);
   await pruneOrphanTickets(deps.now, log);
+}
+
+// ── stuck-ticket sweep (Phase 2) ──────────────────────────────────
+//
+// The per-obligation reconcile above only touches the obligation's
+// latest cycle (and its just-provisioned successor on cycle-close).
+// A ticket on a NON-latest cycle never gets revisited there — which
+// matters because `safeClearBell` failures are intentionally
+// non-destructive: when the clear fails, the reconciler keeps the
+// ticket so a later attempt can retry. Without this sweep, that
+// "later attempt" would never come for tickets on closed cycles
+// (until the 30-day age-based prune).
+//
+// This sweep collects every (obligationId, cycleId) pair present in
+// pending-clear/ and reconciles each. It overlaps Phase 1 for the
+// latest cycle, but reconcile is idempotent (proven by the
+// "idempotency" test in test_encore_reconcile.ts) so the redundancy
+// is cheap and the contract stays simple.
+
+async function sweepStuckTickets(knownObligationIds: Set<string>, now: Date, log: typeof defaultLog): Promise<void> {
+  const entries = await readDir(PENDING_CLEAR_DIRNAME);
+  const pairsToReconcile = await collectStuckCyclePairs(entries, knownObligationIds);
+  for (const pair of pairsToReconcile) {
+    try {
+      await reconcileCycleNotifications({ obligationId: pair.obligationId, cycleId: pair.cycleId, now, log });
+    } catch (err) {
+      log.warn("encore", "tick: stuck-ticket sweep failed", {
+        obligationId: pair.obligationId,
+        cycleId: pair.cycleId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+async function collectStuckCyclePairs(entries: string[], knownObligationIds: Set<string>): Promise<{ obligationId: string; cycleId: string }[]> {
+  const seen = new Set<string>();
+  const out: { obligationId: string; cycleId: string }[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const raw = await readTextOrNull(path.join(PENDING_CLEAR_DIRNAME, entry));
+    if (!raw) continue;
+    let ticket: PendingClearTicket;
+    try {
+      ticket = JSON.parse(raw) as PendingClearTicket;
+    } catch {
+      continue;
+    }
+    // Skip tickets pointing at obligations that no longer exist on
+    // disk — those get cleaned up by the age-based prune below.
+    if (!knownObligationIds.has(ticket.obligationId)) continue;
+    const key = `${ticket.obligationId}::${ticket.cycleId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ obligationId: ticket.obligationId, cycleId: ticket.cycleId });
+  }
+  return out;
 }
 
 // ── orphan ticket sweep (time-driven, lives here not in reconcile) ──

--- a/server/encore/tick.ts
+++ b/server/encore/tick.ts
@@ -1,47 +1,26 @@
-// Encore tick — the DSL interpreter over data-only cycle state.
+// Encore tick — time-driven invoker for the reconciler.
 //
-// Each tick, for every `active` obligation:
+// The tick used to carry its own copy of trim/escalate/publish logic.
+// That moved into `reconcile.ts` (the sole owner of bell state). The
+// tick is now a thin walker:
 //
-//   1. Read DSL (index.md). Pick the current cycle file (latest by
-//      name). If derivation says it's closed (closure.ts), provision
-//      the next cycle file and operate on that — no separate
-//      `state.status` flag is consulted.
-//   2. Read pending-clear/*.json filtered to this obligation+cycle.
-//      One ticket = one live bell entry; their `targets[]` and
-//      `stepId` tell us which (target, step) pairs are already
-//      published. (The cycle file no longer mentions notification
-//      ids.)
-//   3. For each existing ticket: compute the step's current phase;
-//      if its severity differs from the ticket's `severity`,
-//      escalate (clear+republish) and rewrite the ticket.
-//   4. For each (target, step) that is NOT closed (via closure.ts)
-//      AND not covered by any ticket: compute the current phase; if
-//      one fires, collect into a bundle group keyed by
-//      (stepId, severity, fireDate).
-//   5. Each bundle group becomes one published notification + one
-//      ticket. Multi-target → one ding.
-//   6. Prune orphan tickets older than 30 days.
+//   1. For every obligation directory, call reconcileCycleNotifications.
+//   2. Prune orphan pending-clear tickets older than 30 days.
 //
-// The tick NEVER calls chat.start — chat creation is deferred to the
-// user's bell click via the /encore page (View.vue dispatches
-// resolveNotification on mount). The tick also never writes a
-// `status` flag; the cycle file is purely user-recorded data.
+// `PendingClearTicket` still lives here because dispatch.ts, reconcile.ts,
+// and the host UI all import the type — keeping it adjacent to the on-disk
+// shape (the only consumer is `pending-clear/*.json`) makes the locus of
+// schema changes obvious.
 
-import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import { log as defaultLog } from "../system/logger/index.js";
 import { ONE_HOUR_MS } from "../utils/time.js";
-import { compareIsoDates, formatCycleId, isoDate, nextSlot, type CycleSlot } from "./dsl/cadence.js";
-import { parseAtExpression } from "./dsl/at-expression.js";
-import { resolveAtExpression } from "./dsl/at-resolver.js";
-import type { EncoreDsl, Severity, StepDef } from "./dsl/schema.js";
-import { parseIndexFile } from "./obligation.js";
-import { buildCycleState, parseCycleFile, serializeCycleFile, type CycleState, type TargetRecord } from "./cycle.js";
-import { isCycleClosed, isStepClosed } from "./closure.js";
-import { cycleFilePath, obligationDir, obligationIndexPath, pendingClearPath, PENDING_CLEAR_DIRNAME, OBLIGATIONS_DIRNAME } from "./paths.js";
-import { exists, readDir, readTextOrNull, writeText, unlink } from "../utils/files/encore-io.js";
+import type { Severity } from "./dsl/schema.js";
+import { PENDING_CLEAR_DIRNAME, OBLIGATIONS_DIRNAME } from "./paths.js";
+import { readDir, readTextOrNull, unlink } from "../utils/files/encore-io.js";
 import * as encoreNotifier from "./notifier.js";
+import { reconcileCycleNotifications } from "./reconcile.js";
 
 const ORPHAN_TICKET_AGE_MS = 30 * 24 * ONE_HOUR_MS; // 30 days
 
@@ -77,432 +56,25 @@ export interface PendingClearTicket {
 
 export async function runTick(deps: TickDeps): Promise<void> {
   const log = deps.log ?? defaultLog;
-  const todayIso = isoDate(deps.now);
-  // Full-precision timestamp for sub-day comparisons (snooze
-  // expiry). Date-only `todayIso` is still used for phase fire-date
-  // comparisons (those are date-only by DSL design).
-  const nowIso = deps.now.toISOString();
-
   const obligationIds = await readDir(OBLIGATIONS_DIRNAME);
   for (const obligationId of obligationIds) {
     try {
-      await tickOneObligation(obligationId, todayIso, nowIso, log);
+      await reconcileCycleNotifications({ obligationId, now: deps.now, log });
     } catch (err) {
-      log.warn("encore", "tick: obligation failed", { obligationId, error: err instanceof Error ? err.message : String(err) });
+      log.warn("encore", "tick: reconcile failed", { obligationId, error: err instanceof Error ? err.message : String(err) });
     }
   }
-
   await pruneOrphanTickets(deps.now, log);
 }
 
-async function tickOneObligation(obligationId: string, todayIso: string, nowIso: string, log: typeof defaultLog): Promise<void> {
-  const indexRaw = await readTextOrNull(obligationIndexPath(obligationId));
-  if (indexRaw === null) return;
-  const { dsl } = parseIndexFile(indexRaw);
-  if (dsl.status !== "active") return;
-
-  const opened = await ensureOpenCycle(obligationId, dsl, log);
-  if (!opened) return;
-  const { state } = opened;
-
-  // Pull every ticket that covers this obligation+cycle so we know
-  // which (target, step) pairs already have a live bell entry.
-  const tickets = await ticketsForCycle(obligationId, state.cycleId);
-  const activeByStepTarget = new Map<string, PendingClearTicket>();
-  for (const ticket of tickets) {
-    for (const targetId of ticket.targets) {
-      activeByStepTarget.set(`${ticket.stepId}:${targetId}`, ticket);
-    }
-  }
-
-  // Phase 1: escalate existing notifications when current phase
-  // severity differs from the ticket's recorded severity. The
-  // cycle file is untouched (it carries user-data only; bell
-  // state lives in the ticket).
-  for (const ticket of dedupeTickets(tickets)) {
-    await maybeEscalate(dsl, state, ticket, todayIso, log);
-  }
-
-  // Phase 2: publish for un-fired, not-closed (target, step) pairs.
-  const unfired = collectUnfired(dsl, state, activeByStepTarget, todayIso, nowIso);
-  for (const group of groupForBundling(unfired)) {
-    await fireGroup(dsl, state, group, log);
-  }
-}
-
-/** Pick the obligation's latest cycle file. If it's closed (per
- *  closure derivation), provision the next cycle and return that
- *  instead. Returns null if the obligation has no cycle files at
- *  all (shouldn't happen — setup writes the first). */
-async function ensureOpenCycle(
-  obligationId: string,
-  dsl: EncoreDsl,
-  log: typeof defaultLog,
-): Promise<{ cycleRel: string; state: CycleState; body: string } | null> {
-  const latest = await pickCurrentCycle(obligationId);
-  if (!latest) return null;
-  const raw = await readTextOrNull(latest);
-  if (raw === null) return null;
-  const { state, body } = parseCycleFile(raw);
-
-  if (!isCycleClosed(state, dsl)) {
-    return { cycleRel: latest, state, body };
-  }
-
-  // Closed → provision the next cycle (if not already on disk) and
-  // operate on it instead. This is where "stuck obligations"
-  // unstick: the closure is derived, so even cycles that closed
-  // under the old shape (or that never had status flags set
-  // explicitly) get a successor on the next tick.
-  const slot = slotFromCycleId(dsl.cadence, state.cycleId);
-  if (!slot) {
-    log.warn("encore", "tick: could not parse cycleId for next-slot", { obligationId, cycleId: state.cycleId });
-    return null;
-  }
-  const next = nextSlot(dsl.cadence, slot);
-  const nextRel = cycleFilePath(obligationId, formatCycleId(next));
-  if (!(await exists(nextRel))) {
-    await writeText(nextRel, serializeCycleFile(buildCycleState(dsl, next), ""));
-    log.info("encore", "tick: provisioned next cycle", { obligationId, fromCycleId: state.cycleId, toCycleId: formatCycleId(next) });
-  }
-  const nextRaw = await readTextOrNull(nextRel);
-  if (nextRaw === null) return null;
-  const nextParsed = parseCycleFile(nextRaw);
-  return { cycleRel: nextRel, state: nextParsed.state, body: nextParsed.body };
-}
-
-async function pickCurrentCycle(obligationId: string): Promise<string | null> {
-  const entries = await readDir(obligationDir(obligationId));
-  const cycleFiles = entries.filter((name) => name !== "index.md" && name.endsWith(".md")).sort();
-  if (cycleFiles.length === 0) return null;
-  return path.join(obligationDir(obligationId), cycleFiles[cycleFiles.length - 1]);
-}
-
-/** Cycle id → slot. Reverse of `formatCycleId`. */
-function slotFromCycleId(cadence: EncoreDsl["cadence"], cycleId: string): CycleSlot | null {
-  if (cadence.type === "annual") {
-    const year = Number.parseInt(cycleId, 10);
-    if (!Number.isFinite(year)) return null;
-    return { kind: "annual", year };
-  }
-  if (cadence.type === "biannual") {
-    const match = cycleId.match(/^(\d{4})-h([12])$/);
-    if (!match) return null;
-    return { kind: "biannual", year: Number.parseInt(match[1], 10), half: Number.parseInt(match[2], 10) as 1 | 2 };
-  }
-  if (cadence.type === "monthly") {
-    const match = cycleId.match(/^(\d{4})-(\d{2})$/);
-    if (!match) return null;
-    return { kind: "monthly", year: Number.parseInt(match[1], 10), month: Number.parseInt(match[2], 10) };
-  }
-  if (cadence.type === "weekly") {
-    const match = cycleId.match(/^(\d{4})-W(\d{2})$/);
-    if (!match) return null;
-    return { kind: "weekly", year: Number.parseInt(match[1], 10), week: Number.parseInt(match[2], 10) };
-  }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(cycleId)) return null;
-  return { kind: "daily", iso: cycleId };
-}
-
-// ── escalation ────────────────────────────────────────────────────
-
-function dedupeTickets(tickets: PendingClearTicket[]): PendingClearTicket[] {
-  const seen = new Set<string>();
-  const out: PendingClearTicket[] = [];
-  for (const ticket of tickets) {
-    if (seen.has(ticket.pendingId)) continue;
-    seen.add(ticket.pendingId);
-    out.push(ticket);
-  }
-  return out;
-}
-
-async function maybeEscalate(dsl: EncoreDsl, state: CycleState, ticket: PendingClearTicket, todayIso: string, log: typeof defaultLog): Promise<boolean> {
-  const stepDef = dsl.steps.find((step) => step.id === ticket.stepId);
-  if (!stepDef) return false;
-  // Use the first still-open target as the reference for anchoring
-  // step deadlines (they share the same step.deadline expression).
-  const liveTarget = ticket.targets.find((targetId) => !isStepClosed(state.records[targetId], stepDef));
-  if (!liveTarget) {
-    // Every target in the bundle has closed — the handler-side
-    // ticket trimming should have already run, but if a heartbeat
-    // races ahead of `clearPendingNotification`, clean up here.
-    await encoreNotifier.clear(ticket.notificationId);
-    await unlink(pendingClearPath(ticket.pendingId));
-    log.info("encore", "tick: cleared fully-resolved bundle", { pendingId: ticket.pendingId, notificationId: ticket.notificationId });
-    return true;
-  }
-  const phase = currentPhaseFor(stepDef, state, todayIso);
-  if (!phase || phase.severity === ticket.severity) return false;
-
-  // Severity transition → clear + republish, rewrite ticket.
-  await encoreNotifier.clear(ticket.notificationId);
-  const navigateTarget = encoreUrlFor(ticket.pendingId);
-  const liveMembers = ticket.targets.filter((targetId) => !isStepClosed(state.records[targetId], stepDef)).map((targetId) => ({ targetId }));
-  const title = bundleTitle(dsl, stepDef, liveMembers);
-  const body = bundleBody(dsl, stepDef, liveMembers);
-  const { id: newId } = await encoreNotifier.publish({ severity: phase.severity, title, body, navigateTarget });
-  await writeTicket({ ...ticket, notificationId: newId, severity: phase.severity, targets: liveMembers.map((entry) => entry.targetId) });
-  log.info("encore", "tick: escalated notification", {
-    obligationId: dsl.id,
-    cycleId: state.cycleId,
-    stepId: stepDef.id,
-    from: ticket.severity,
-    to: phase.severity,
-    notificationId: newId,
-  });
-  return true;
-}
-
-// ── un-fired collection + bundling ────────────────────────────────
-
-interface UnfiredPair {
-  targetId: string;
-  stepId: string;
-  stepDef: StepDef;
-  severity: Severity;
-  fireDate: string;
-}
-
-function isStepEligibleToFire(
-  record: TargetRecord | undefined,
-  step: StepDef,
-  nowIso: string,
-  activeByStepTarget: Map<string, PendingClearTicket>,
-  targetId: string,
-): boolean {
-  if (isStepClosed(record, step)) return false;
-  if (activeByStepTarget.has(`${step.id}:${targetId}`)) return false;
-  // A snoozed step is "open but defer firing" — skip until the
-  // snooze timestamp has passed. Use the FULL ISO timestamp (not
-  // date-only `YYYY-MM-DD`) because the stored snoozedUntil is a
-  // full timestamp from `toISOString()`; comparing it against a
-  // date-only string would over-block by a day for any snooze that
-  // doesn't land on midnight.
-  const snoozedUntil = record?.snoozedSteps?.[step.id];
-  if (snoozedUntil && snoozedUntil > nowIso) return false;
-  return true;
-}
-
-function collectUnfired(
-  dsl: EncoreDsl,
-  state: CycleState,
-  activeByStepTarget: Map<string, PendingClearTicket>,
-  todayIso: string,
-  nowIso: string,
-): UnfiredPair[] {
-  const out: UnfiredPair[] = [];
-  for (const target of dsl.targets) {
-    const record = state.records[target.id];
-    if (record?.skipped) continue;
-    for (const step of dsl.steps) {
-      if (!isStepEligibleToFire(record, step, nowIso, activeByStepTarget, target.id)) continue;
-      const phase = currentPhaseFor(step, state, todayIso);
-      if (!phase) continue;
-      out.push({ targetId: target.id, stepId: step.id, stepDef: step, severity: phase.severity, fireDate: phase.fireDate });
-    }
-  }
-  return out;
-}
-
-interface BundleGroup {
-  stepId: string;
-  stepDef: StepDef;
-  severity: Severity;
-  fireDate: string;
-  members: { targetId: string }[];
-}
-
-function groupForBundling(unfired: UnfiredPair[]): BundleGroup[] {
-  const byKey = new Map<string, BundleGroup>();
-  for (const pair of unfired) {
-    const key = `${pair.stepId} ${pair.severity} ${pair.fireDate}`;
-    const existing = byKey.get(key);
-    if (existing) {
-      existing.members.push({ targetId: pair.targetId });
-    } else {
-      byKey.set(key, {
-        stepId: pair.stepId,
-        stepDef: pair.stepDef,
-        severity: pair.severity,
-        fireDate: pair.fireDate,
-        members: [{ targetId: pair.targetId }],
-      });
-    }
-  }
-  return [...byKey.values()];
-}
-
-async function fireGroup(dsl: EncoreDsl, state: CycleState, group: BundleGroup, log: typeof defaultLog): Promise<void> {
-  const pendingId = randomUUID();
-  const navigateTarget = encoreUrlFor(pendingId);
-  const title = bundleTitle(dsl, group.stepDef, group.members);
-  const body = bundleBody(dsl, group.stepDef, group.members);
-
-  const { id: notificationId } = await encoreNotifier.publish({ severity: group.severity, title, body, navigateTarget });
-
-  const ticket: PendingClearTicket = {
-    pendingId,
-    obligationId: dsl.id ?? "",
-    cycleId: state.cycleId,
-    notificationId,
-    stepId: group.stepId,
-    targets: group.members.map((member) => member.targetId),
-    severity: group.severity,
-    seedPrompt: buildSeedPrompt(dsl, group, pendingId, state.cycleId),
-    createdAt: new Date().toISOString(),
-  };
-  await writeTicket(ticket);
-
-  log.info("encore", "tick: fired bundled notification", {
-    obligationId: dsl.id,
-    cycleId: state.cycleId,
-    stepId: group.stepId,
-    severity: group.severity,
-    targets: group.members.map((member) => member.targetId),
-    notificationId,
-    pendingId,
-  });
-}
-
-// ── phase eval ────────────────────────────────────────────────────
-
-interface ResolvedPhase {
-  severity: Severity;
-  fireDate: string;
-}
-
-function currentPhaseFor(stepDef: StepDef, cycleState: CycleState, todayIso: string): ResolvedPhase | null {
-  // Resolve the step's own deadline first (step.deadline can't use
-  // step-deadline anchor — only firingPlan phases can).
-  let stepDeadline: string;
-  try {
-    stepDeadline = resolveAtExpression(parseAtExpression(stepDef.deadline, { allowStepDeadline: false }), {
-      cycleStart: cycleState.cycleStart,
-      cycleDeadline: cycleState.cycleDeadline,
-    });
-  } catch {
-    return null;
-  }
-  const anchors = { cycleStart: cycleState.cycleStart, cycleDeadline: cycleState.cycleDeadline, stepDeadline };
-  let latest: ResolvedPhase | null = null;
-  for (const phase of stepDef.firingPlan) {
-    let resolved: string;
-    try {
-      resolved = resolveAtExpression(parseAtExpression(phase.at, { allowStepDeadline: true }), anchors);
-    } catch {
-      continue;
-    }
-    if (compareIsoDates(resolved, todayIso) <= 0) {
-      latest = { severity: phase.severity, fireDate: resolved };
-    } else {
-      break; // firingPlan is chronological; nothing later fires
-    }
-  }
-  return latest;
-}
-
-// ── titles + bodies + seed prompts ────────────────────────────────
-
-function bundleTitle(dsl: EncoreDsl, stepDef: StepDef, members: { targetId: string }[]): string {
-  if (members.length === 1) {
-    const [{ targetId }] = members;
-    const target = dsl.targets.find((entry) => entry.id === targetId);
-    return `${dsl.displayName} — ${stepDef.displayName} (${target?.displayName ?? targetId})`;
-  }
-  return `${dsl.displayName} — ${stepDef.displayName} (${members.length} targets)`;
-}
-
-function bundleBody(dsl: EncoreDsl, _stepDef: StepDef, members: { targetId: string }[]): string {
-  if (members.length === 1) return "";
-  return members
-    .map((member) => {
-      const target = dsl.targets.find((entry) => entry.id === member.targetId);
-      return target?.displayName ?? member.targetId;
-    })
-    .join(", ");
-}
-
-function buildSeedPrompt(dsl: EncoreDsl, group: BundleGroup, pendingId: string, cycleId: string): string {
-  const targetLines = group.members
-    .map((member) => {
-      const target = dsl.targets.find((entry) => entry.id === member.targetId);
-      return `- ${target?.displayName ?? member.targetId} (id: ${member.targetId})`;
-    })
-    .join("\n");
-  const fieldList = group.stepDef.fields.length === 0 ? "(no fields to record for this step)" : group.stepDef.fields.map((name) => `- ${name}`).join("\n");
-  const firstTargetId = group.members[0]?.targetId ?? "<targetId>";
-  const obligationId = dsl.id ?? "";
-  const exampleCall = JSON.stringify(
-    {
-      kind: "markStepDone",
-      pendingId,
-      obligationId,
-      cycleId,
-      targetId: firstTargetId,
-      stepId: group.stepId,
-      values: Object.fromEntries(group.stepDef.fields.map((name) => [name, "<value>"])),
-    },
-    null,
-    2,
-  );
-  return [
-    `An Encore reminder for the obligation "${dsl.displayName}" (id: ${obligationId}, cycle: ${cycleId}).`,
-    "",
-    `Step: ${group.stepDef.displayName} (id: ${group.stepId})`,
-    `Severity: ${group.severity}. Fire date: ${group.fireDate}.`,
-    "",
-    `Targets covered by this notification:`,
-    targetLines,
-    "",
-    `Fields to collect on each target's record:`,
-    fieldList,
-    "",
-    `Help the user record what happened, then call manageEncore — ONCE PER TARGET — with one of:`,
-    `- kind: "markStepDone" — step is complete (pass field values via \`values\`).`,
-    `- kind: "markTargetSkipped" — user is skipping this target for this cycle.`,
-    `- kind: "recordValues" — partial info only, no closing.`,
-    `- kind: "snooze" — defer the bell entry.`,
-    "",
-    `Call-shape rules (the parser will 400 on these common mistakes):`,
-    `- \`targetId\` is SINGULAR (a string), NOT \`targetIds\` (array). If the notification covers multiple targets, make one call per target.`,
-    `- \`values\` is a FLAT field-map: \`{ fieldName: value, ... }\`. NEVER nest it by target id (\`{ <targetId>: { ... } }\` is wrong).`,
-    `- Always pass \`pendingId\`, \`obligationId\`, and \`cycleId\` as shown below — they're what clears the bell entry when the cycle progresses.`,
-    "",
-    `Example for ${firstTargetId}:`,
-    "```json",
-    exampleCall,
-    "```",
-  ].join("\n");
-}
-
-// ── ticket I/O ────────────────────────────────────────────────────
-
-async function writeTicket(ticket: PendingClearTicket): Promise<void> {
-  await writeText(pendingClearPath(ticket.pendingId), JSON.stringify(ticket, null, 2));
-}
-
-/** Read all pending-clear tickets that match (obligationId,
- *  cycleId). Tolerates unparsable entries (skipped silently;
- *  pruneOrphanTickets cleans them up eventually). */
-async function ticketsForCycle(obligationId: string, cycleId: string): Promise<PendingClearTicket[]> {
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
-  const out: PendingClearTicket[] = [];
-  for (const entry of entries) {
-    if (!entry.endsWith(".json")) continue;
-    const raw = await readTextOrNull(path.join(PENDING_CLEAR_DIRNAME, entry));
-    if (!raw) continue;
-    try {
-      const ticket = JSON.parse(raw) as PendingClearTicket;
-      if (ticket.obligationId === obligationId && ticket.cycleId === cycleId) {
-        out.push(ticket);
-      }
-    } catch {
-      continue;
-    }
-  }
-  return out;
-}
+// ── orphan ticket sweep (time-driven, lives here not in reconcile) ──
+//
+// Orphan tickets are pending-clear records older than 30 days that
+// somehow weren't trimmed by reconcile (e.g. the cycle file was
+// deleted manually, or a host crash left a ticket without its bell
+// counterpart). The sweep is age-based, not state-based, so it
+// belongs with the time-driven tick rather than the state-driven
+// reconciler.
 
 async function pruneOneTicket(rel: string, raw: string, now: Date, log: typeof defaultLog): Promise<void> {
   let ticket: PendingClearTicket;
@@ -536,8 +108,4 @@ async function pruneOrphanTickets(now: Date, log: typeof defaultLog): Promise<vo
     if (!raw) continue;
     await pruneOneTicket(rel, raw, now, log);
   }
-}
-
-function encoreUrlFor(pendingId: string): string {
-  return `/encore?pendingId=${encodeURIComponent(pendingId)}`;
 }

--- a/server/workspace/helps/encore-dsl.md
+++ b/server/workspace/helps/encore-dsl.md
@@ -125,7 +125,34 @@ Every action takes a `kind` discriminator. The handler validates the rest with Z
 { "kind": "setup", "definition": { /* full DSL above */ } }
 ```
 
-`definition` is an **OBJECT** in the tool-call arguments, not a JSON-encoded string. Don't `JSON.stringify` it — pass the object literal. The 400 you get for the string form names the error explicitly ("expected object, received string"), so if you see that, drop the stringify.
+`definition` is normally an **OBJECT** in the tool-call arguments. The handler also accepts a JSON-encoded string (it calls `JSON.parse` on the string before validating) so a `JSON.stringify`'d definition won't error — but the object form is preferred (one less parse step on the server, and easier for you to debug field-level Zod errors).
+
+Minimal concrete example — copy this exact wire shape (`definition` as an object literal):
+
+```json
+{
+  "kind": "setup",
+  "definition": {
+    "version": 1,
+    "displayName": "Daily check-in",
+    "type": "service",
+    "cadence": { "type": "daily" },
+    "targets": [{ "id": "me", "displayName": "Me" }],
+    "steps": [
+      {
+        "id": "checkin",
+        "displayName": "Check in",
+        "deadline": "cycle-deadline",
+        "firingPlan": [{ "at": "cycle-start", "severity": "info" }],
+        "fields": []
+      }
+    ],
+    "formSchema": { "fields": [] }
+  }
+}
+```
+
+For richer obligations (payments with currency, escalation phases, bundled targets, multi-step) see the worked examples below; they're shown in YAML for readability but translate field-for-field to JSON.
 
 Returns `{ ok: true, obligationId, cycleId, cyclePath, indexPath }`. Encore writes `obligations/<id>/index.md` plus the first cycle file and kicks the tick (so a `cycle-start` phase fires immediately).
 
@@ -139,7 +166,7 @@ Returns `{ ok: true, obligationId, cycleId, cyclePath, indexPath }`. Encore writ
 }
 ```
 
-`definition` is an **OBJECT**, not a JSON-encoded string (same as setup). Shallow-merge at the top level — for arrays (`targets`, `steps`, `formSchema.fields`, `firingPlan`) send the **full** replacement value, not just the field you want to change. Cannot change `type` / `currency` / `cadence.type`. Encore clears active bell entries on amend and re-fires with the new title/text.
+`definition` is preferred as an **OBJECT** (a JSON-encoded string of one is also accepted, same as setup). Shallow-merge at the top level — for arrays (`targets`, `steps`, `formSchema.fields`, `firingPlan`) send the **full** replacement value, not just the field you want to change. Cannot change `type` / `currency` / `cadence.type`. Encore clears active bell entries on amend and re-fires with the new title/text.
 
 ### markStepDone — CLOSE ONE STEP ON ONE TARGET
 
@@ -182,7 +209,15 @@ Writes partial values without closing the step. Use when the user has reported p
 { "kind": "snooze", "pendingId": "...", "obligationId": "...", "cycleId": "...", "targetId": "...", "stepId": "..." }
 ```
 
-Clears the current bell entry and persists a `snoozedSteps[stepId]` marker (24h by default) on the cycle file. The tick skips this step until the snooze timestamp passes; after that, the next tick re-fires from the current phase.
+Clears the current bell entry and persists a `snoozedSteps[stepId]` marker (24h by default) on the cycle file. The reconciler skips this step until the snooze timestamp passes; after that, the next reconcile re-fires from the current phase.
+
+### unsnooze
+
+```json
+{ "kind": "unsnooze", "obligationId": "...", "cycleId": "...", "targetId": "...", "stepId": "..." }
+```
+
+Inverse of `snooze`. Deletes `snoozedSteps[stepId]` from the target's record. If the step is otherwise eligible to fire (not closed, current phase past), the bell republishes in the same turn — no need to wait for the 24h timer or run a tick manually. A no-op if the step wasn't snoozed.
 
 ### query
 

--- a/src/plugins/encore/definition.ts
+++ b/src/plugins/encore/definition.ts
@@ -36,7 +36,17 @@ export type EncoreEndpoints = { readonly [K in keyof typeof META.apiRoutes]: Res
  *  call it: if yes, add it here; if it's a browser-internal
  *  dispatch like resolveNotification, leave it out of this list
  *  and only handle it in dispatch.ts. */
-export const LLM_ENCORE_KINDS = ["setup", "amendDefinition", "markStepDone", "markTargetSkipped", "recordValues", "query", "appendNote", "snooze"] as const;
+export const LLM_ENCORE_KINDS = [
+  "setup",
+  "amendDefinition",
+  "markStepDone",
+  "markTargetSkipped",
+  "recordValues",
+  "query",
+  "appendNote",
+  "snooze",
+  "unsnooze",
+] as const;
 
 /** Every action kind the server-side dispatch handles, including
  *  browser-only ones. Re-exported for the dispatch.ts switch and

--- a/test/plugins/test_encore_dispatch.ts
+++ b/test/plugins/test_encore_dispatch.ts
@@ -292,6 +292,36 @@ describe("Encore dispatch — component tests", () => {
     );
   });
 
+  it("setup accepts `definition` as a JSON-encoded string (LLM tolerance)", async () => {
+    // The LLM commonly JSON.stringify's the `definition` argument.
+    // Rejecting that with "expected object, received string" reads
+    // as a schema problem and the LLM tends to retry with the same
+    // shape. The handler now coerces string → object via JSON.parse
+    // before validation so both wire forms work identically.
+    const result = (await dispatch({ kind: "setup", definition: JSON.stringify(hisayoDefinition) })) as SetupResult;
+    assert.equal(result.ok, true, `setup-from-string failed: ${result.message}`);
+    assert.ok(result.obligationId);
+    assert.ok(result.cycleId);
+  });
+
+  it("setup rejects `definition` strings that aren't valid JSON with a clear message", async () => {
+    await assert.rejects(dispatch({ kind: "setup", definition: "{not json" }), /not valid JSON/);
+  });
+
+  it("setup rejects `definition` strings that decode to a non-object", async () => {
+    await assert.rejects(dispatch({ kind: "setup", definition: "[1,2,3]" }), /must be an object[\s\S]*got array/);
+  });
+
+  it("amendDefinition accepts `definition` as a JSON-encoded string (LLM tolerance)", async () => {
+    const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
+    const result = await dispatch({
+      kind: "amendDefinition",
+      obligationId: setup.obligationId,
+      definition: JSON.stringify({ status: "paused" }),
+    });
+    assert.equal(result.ok, true, `amend-from-string failed: ${result.message}`);
+  });
+
   // Note: there is intentionally NO test that invokes
   // `dispatch({ kind: "resolveNotification" })`. That path calls
   // `startChat`, which (a) writes a real session file under
@@ -422,5 +452,96 @@ describe("Encore dispatch — component tests", () => {
     // Bell entry should be cleared.
     const remaining = await listFor("encore");
     assert.equal(remaining.length, 0, `expected bell to be empty after markStepDone, found ${remaining.length} entries`);
+  });
+
+  it("unsnooze republishes the bell in the same dispatch turn (no tick wait)", async () => {
+    // The pre-reconciler architecture had no way to undo a snooze
+    // before its 24h timer expired; the LLM had to call markStepDone
+    // (falsely) or markTargetSkipped (falsely) or hand-edit the file.
+    // Under the unified reconciler, unsnooze is the inverse of snooze
+    // and the bell republishes in the same turn — the publish
+    // happens inside the reconcile call that follows the unsnooze
+    // mutator, not via a tick.
+    const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
+    const { cycleId } = setup;
+    if (!cycleId) throw new Error("setup should return cycleId");
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    const initialEntries = await fsPromises.readdir(pendingDir);
+    const initialTicket = JSON.parse(await fsPromises.readFile(path.join(pendingDir, initialEntries[0]), "utf8")) as { pendingId: string };
+
+    await dispatch({
+      kind: "snooze",
+      obligationId: setup.obligationId,
+      cycleId,
+      targetId: "hisayo",
+      stepId: "pay",
+      pendingId: initialTicket.pendingId,
+    });
+    assert.equal((await listFor("encore")).length, 0, "bell must clear after snooze");
+
+    await dispatch({
+      kind: "unsnooze",
+      obligationId: setup.obligationId,
+      cycleId,
+      targetId: "hisayo",
+      stepId: "pay",
+    });
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, `bell must republish in the same turn as unsnooze; got ${after.length}`);
+  });
+
+  it("unsnooze on a step that wasn't snoozed is a no-op (no flicker)", async () => {
+    // Idempotency. If the LLM calls unsnooze on a step that's not
+    // currently snoozed, the existing bell must NOT flicker
+    // (clear+republish would change the notification id and re-ring
+    // the host bell). Verified by checking that the notification id
+    // stays the same across the no-op unsnooze.
+    const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
+    const { cycleId } = setup;
+    if (!cycleId) throw new Error("setup should return cycleId");
+    const before = await listFor("encore");
+    assert.equal(before.length, 1);
+    const originalId = before[0].id;
+
+    await dispatch({
+      kind: "unsnooze",
+      obligationId: setup.obligationId,
+      cycleId,
+      targetId: "hisayo",
+      stepId: "pay",
+    });
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, "bell count unchanged");
+    assert.equal(after[0].id, originalId, "notification id must not change (no clear+republish flicker)");
+  });
+
+  it("snooze → unsnooze round-trip: bell present → gone → present", async () => {
+    // End-to-end round-trip exercising both handlers through one
+    // chat. The post-unsnooze bell is a freshly-published one (new
+    // notification id), but it must be present.
+    const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
+    const { cycleId } = setup;
+    if (!cycleId) throw new Error("setup should return cycleId");
+    const present1 = await listFor("encore");
+    assert.equal(present1.length, 1, "stage 1: setup published bell");
+
+    await dispatch({
+      kind: "snooze",
+      obligationId: setup.obligationId,
+      cycleId,
+      targetId: "hisayo",
+      stepId: "pay",
+    });
+    assert.equal((await listFor("encore")).length, 0, "stage 2: snooze cleared bell");
+
+    await dispatch({
+      kind: "unsnooze",
+      obligationId: setup.obligationId,
+      cycleId,
+      targetId: "hisayo",
+      stepId: "pay",
+    });
+    const present2 = await listFor("encore");
+    assert.equal(present2.length, 1, "stage 3: unsnooze republished bell");
   });
 });

--- a/test/plugins/test_encore_reconcile.ts
+++ b/test/plugins/test_encore_reconcile.ts
@@ -23,6 +23,7 @@ import { _resetLockForTesting } from "../../server/encore/lock.js";
 import { dispatch, type EncoreDispatchResult } from "../../server/encore/dispatch.js";
 import { reconcileCycleNotifications } from "../../server/encore/reconcile.js";
 import { parseCycleFile, recordStepSnooze, serializeCycleFile } from "../../server/encore/cycle.js";
+import { runTick } from "../../server/encore/tick.js";
 
 let savedEncoreDescriptor: PropertyDescriptor | undefined;
 let workspaceRoot: string;
@@ -380,5 +381,68 @@ describe("Encore reconciler — unit tests", () => {
     assert.equal(after.length, 0, "inactive obligation must have no bell entries");
     const tickets = await pendingDirEntries();
     assert.equal(tickets.length, 0, "inactive obligation must have no pending-clear tickets");
+  });
+
+  it("runTick Phase 2: sweep revisits stuck tickets on non-latest cycles", async () => {
+    // Regression test for the interaction noted in PR review: with
+    // the new "keep ticket on clear failure" contract, a ticket
+    // stranded on cycle N can outlive the next tick if Phase 1 only
+    // visits the latest cycle (N+1). Phase 2's sweep walks every
+    // pending-clear ticket and reconciles its (obligationId, cycleId)
+    // so the strand is retried every tick instead of waiting 30 days
+    // for the age-based prune.
+    //
+    // Setup: create the obligation, then manually install a
+    // closed-cycle file + a leftover pending-clear ticket pointing at
+    // it. Phase 1 (latest cycle reconcile) won't touch the closed
+    // cycle's ticket; Phase 2 must.
+    const oneTargetDef = {
+      ...twoTargetDef,
+      targets: [{ id: "alice", displayName: "Alice" }],
+    };
+    const setup = (await dispatch({ kind: "setup", definition: oneTargetDef })) as SetupResult;
+    const { obligationId, cycleId: latestCycleId } = setup;
+    if (!obligationId || !latestCycleId) throw new Error("setup should return ids");
+
+    // Inject a closed predecessor cycle file (yesterday) directly on
+    // disk, plus a stranded pending-clear ticket pointing at it.
+    const stuckCycleId = "2026-05-16";
+    const stuckCycle = {
+      cycleId: stuckCycleId,
+      cycleStart: `${stuckCycleId}T00:00:00.000Z`,
+      cycleDeadline: `${stuckCycleId}T23:59:59.999Z`,
+      records: {
+        alice: { completedSteps: { pay: `${stuckCycleId}T12:00:00.000Z` } }, // closed
+      },
+    };
+    const stuckCyclePath = path.join(workspaceRoot, "data/plugins/encore/obligations", obligationId, `${stuckCycleId}.md`);
+    await fsPromises.writeFile(stuckCyclePath, serializeCycleFile(stuckCycle, ""));
+
+    const stuckTicket = {
+      pendingId: "stuck-pending-id",
+      obligationId,
+      cycleId: stuckCycleId,
+      notificationId: "stuck-notification-id", // no live bell entry — clear is a no-op
+      stepId: "pay",
+      targets: ["alice"],
+      severity: "info",
+      seedPrompt: "stuck",
+      createdAt: new Date().toISOString(),
+    };
+    const ticketPath = path.join(workspaceRoot, "data/plugins/encore/pending-clear", "stuck-pending-id.json");
+    await fsPromises.writeFile(ticketPath, JSON.stringify(stuckTicket, null, 2));
+
+    // Sanity: the stuck ticket is on disk and the latest is unrelated.
+    const beforeNames = await pendingDirEntries();
+    assert(beforeNames.includes("stuck-pending-id.json"), "test setup: stuck ticket must be on disk");
+    assert.notEqual(stuckCycleId, latestCycleId, "test setup: stuck cycle must differ from latest");
+
+    await runTick({ now: new Date() });
+
+    // Phase 2 reconciled (obligationId, stuckCycleId). All targets in
+    // the stuck cycle are closed → bundle drained → clear (no-op,
+    // succeeds) → ticket unlinked.
+    const afterNames = await pendingDirEntries();
+    assert(!afterNames.includes("stuck-pending-id.json"), `stuck ticket must be reaped by Phase 2 sweep; remaining: ${afterNames.join(", ")}`);
   });
 });

--- a/test/plugins/test_encore_reconcile.ts
+++ b/test/plugins/test_encore_reconcile.ts
@@ -118,23 +118,47 @@ function countBraces(line: string): { opens: number; closes: number } {
   return { opens, closes };
 }
 
+// Mutable scope tracker for the allowed-function brace scanner. Once
+// the scanner sees an allowed function declaration, it waits for the
+// first `{` (body entry — handles multi-line headers), then exits
+// when braceDepth returns to 0. The earlier "exit when braceDepth
+// === 0 && opens > 0" was a bug — on a closing-brace-only line
+// `opens === 0`, so the flag never reset and every line below the
+// allowed function was silently skipped (caught by review on PR #1433).
+interface AllowedScopeState {
+  inAllowedFn: boolean;
+  entered: boolean;
+  braceDepth: number;
+}
+
+function makeScopeState(): AllowedScopeState {
+  return { inAllowedFn: false, entered: false, braceDepth: 0 };
+}
+
+function advanceScope(state: AllowedScopeState, line: string): void {
+  if (NOTIFIER_BOUNDARY_ALLOWED_FUNCTIONS.test(line)) {
+    state.inAllowedFn = true;
+    state.entered = false;
+    state.braceDepth = 0;
+  }
+  if (!state.inAllowedFn) return;
+  const { opens, closes } = countBraces(line);
+  state.braceDepth += opens - closes;
+  if (!state.entered && state.braceDepth > 0) state.entered = true;
+  if (state.entered && state.braceDepth <= 0) {
+    state.inAllowedFn = false;
+    state.entered = false;
+  }
+}
+
 function collectFileViolations(file: string, raw: string): NotifierViolation[] {
   const out: NotifierViolation[] = [];
   const lines = raw.split("\n");
-  let inAllowedFn = false;
-  let braceDepth = 0;
+  const scope = makeScopeState();
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx];
-    if (NOTIFIER_BOUNDARY_ALLOWED_FUNCTIONS.test(line)) {
-      inAllowedFn = true;
-      braceDepth = 0;
-    }
-    if (inAllowedFn) {
-      const { opens, closes } = countBraces(line);
-      braceDepth += opens - closes;
-      if (braceDepth === 0 && opens > 0) inAllowedFn = false;
-    }
-    if (inAllowedFn) continue;
+    advanceScope(scope, line);
+    if (scope.inAllowedFn) continue;
     if (NOTIFIER_CALL.test(line)) {
       out.push({ file, lineNumber: lineIdx + 1, line: line.trim() });
     }
@@ -319,6 +343,24 @@ describe("Encore reconciler — unit tests", () => {
       violations.push(...collectFileViolations(file, raw));
     }
     assert.deepEqual(violations, [], formatViolationList(violations));
+  });
+
+  it("collectFileViolations: scope tracker exits the allowed function and catches violations placed below it", () => {
+    // Regression test for the brace-depth scope bug. With the old
+    // exit condition (`braceDepth === 0 && opens > 0`), the closing
+    // `}` of an allowed function never reset `inAllowedFn`, so a
+    // subsequent encoreNotifier.* call was silently skipped.
+    const fixture = [
+      `async function handleOrphanResolve() {`,
+      `  await encoreNotifier.clear("inside-allowed");`, // ALLOWED
+      `}`,
+      `async function someOtherHandler() {`,
+      `  await encoreNotifier.clear("smuggled");`, // MUST flag
+      `}`,
+    ].join("\n");
+    const violations = collectFileViolations("fixture.ts", fixture);
+    assert.equal(violations.length, 1, `expected exactly one violation (the smuggled call); got ${JSON.stringify(violations)}`);
+    assert.match(violations[0].line, /smuggled/);
   });
 
   it("inactive status: clears every bell + ticket for the obligation, no republish", async () => {

--- a/test/plugins/test_encore_reconcile.ts
+++ b/test/plugins/test_encore_reconcile.ts
@@ -1,0 +1,342 @@
+// Reconciler unit tests — state in, state out, no SSE.
+//
+// These tests exercise `reconcileCycleNotifications` directly. The
+// dispatch-level tests in test_encore_dispatch.ts cover handler →
+// reconciler wiring; here we pin down the reconciler's invariants
+// in isolation so a future refactor that breaks them surfaces at
+// the right place.
+//
+// Per-test isolation mirrors the dispatch test suite:
+//   - `WORKSPACE_PATHS.encore` redirected to a tmpdir per test
+//   - notifier engine pointed at tmpdir paths
+//   - per-plugin lock reset between tests
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, promises as fsPromises } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
+import { _setFilePathsForTesting, listFor } from "../../server/notifier/engine.js";
+import { _resetLockForTesting } from "../../server/encore/lock.js";
+import { dispatch, type EncoreDispatchResult } from "../../server/encore/dispatch.js";
+import { reconcileCycleNotifications } from "../../server/encore/reconcile.js";
+import { parseCycleFile, recordStepSnooze, serializeCycleFile } from "../../server/encore/cycle.js";
+
+let savedEncoreDescriptor: PropertyDescriptor | undefined;
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(path.join(tmpdir(), "encore-reconcile-"));
+  savedEncoreDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "encore");
+  Object.defineProperty(WORKSPACE_PATHS, "encore", {
+    ...savedEncoreDescriptor,
+    value: path.join(workspaceRoot, "data/plugins/encore"),
+  });
+  _setFilePathsForTesting({
+    active: path.join(workspaceRoot, "notifier-active.json"),
+    history: path.join(workspaceRoot, "notifier-history.json"),
+  });
+  _resetLockForTesting();
+});
+
+afterEach(() => {
+  if (savedEncoreDescriptor) Object.defineProperty(WORKSPACE_PATHS, "encore", savedEncoreDescriptor);
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+const twoTargetDef = {
+  version: 1,
+  displayName: "Daily payments — bundled",
+  type: "payment",
+  currency: "JPY",
+  cadence: { type: "daily" },
+  targets: [
+    { id: "alice", displayName: "Alice" },
+    { id: "bob", displayName: "Bob" },
+  ],
+  steps: [
+    {
+      id: "pay",
+      displayName: "Pay",
+      deadline: "cycle-deadline",
+      firingPlan: [{ at: "cycle-start", severity: "info" }],
+      fields: ["amount"],
+    },
+  ],
+  formSchema: {
+    fields: [{ name: "amount", type: "number", label: "Amount", required: true }],
+  },
+};
+
+interface SetupResult extends EncoreDispatchResult {
+  obligationId?: string;
+  cycleId?: string;
+}
+
+async function readCycleRaw(obligationId: string, cycleId: string): Promise<string> {
+  const cyclePath = path.join(workspaceRoot, "data/plugins/encore/obligations", obligationId, `${cycleId}.md`);
+  return fsPromises.readFile(cyclePath, "utf8");
+}
+
+async function writeCycleRaw(obligationId: string, cycleId: string, raw: string): Promise<void> {
+  const cyclePath = path.join(workspaceRoot, "data/plugins/encore/obligations", obligationId, `${cycleId}.md`);
+  await fsPromises.writeFile(cyclePath, raw);
+}
+
+async function pendingDirEntries(): Promise<string[]> {
+  const dir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+  return fsPromises.readdir(dir);
+}
+
+// ── notifier-boundary static-guard helpers ──────────────────────
+//
+// Walk each non-allowed source file under server/encore/, find lines
+// that call encoreNotifier.{publish,clear}, and filter out hits
+// inside the two documented allowed functions (handleOrphanResolve,
+// pruneOneTicket). We track a tiny brace-depth machine to know when
+// we've exited the allowed function body.
+
+interface NotifierViolation {
+  file: string;
+  lineNumber: number;
+  line: string;
+}
+
+const NOTIFIER_BOUNDARY_ALLOWED_FILES = new Set(["reconcile.ts", "notifier.ts"]);
+const NOTIFIER_BOUNDARY_ALLOWED_FUNCTIONS = /async function (handleOrphanResolve|pruneOneTicket)\b/;
+const NOTIFIER_CALL = /encoreNotifier\.(publish|clear)\b/;
+
+function countBraces(line: string): { opens: number; closes: number } {
+  let opens = 0;
+  let closes = 0;
+  for (const char of line) {
+    if (char === "{") opens += 1;
+    else if (char === "}") closes += 1;
+  }
+  return { opens, closes };
+}
+
+function collectFileViolations(file: string, raw: string): NotifierViolation[] {
+  const out: NotifierViolation[] = [];
+  const lines = raw.split("\n");
+  let inAllowedFn = false;
+  let braceDepth = 0;
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const line = lines[lineIdx];
+    if (NOTIFIER_BOUNDARY_ALLOWED_FUNCTIONS.test(line)) {
+      inAllowedFn = true;
+      braceDepth = 0;
+    }
+    if (inAllowedFn) {
+      const { opens, closes } = countBraces(line);
+      braceDepth += opens - closes;
+      if (braceDepth === 0 && opens > 0) inAllowedFn = false;
+    }
+    if (inAllowedFn) continue;
+    if (NOTIFIER_CALL.test(line)) {
+      out.push({ file, lineNumber: lineIdx + 1, line: line.trim() });
+    }
+  }
+  return out;
+}
+
+function formatViolationList(violations: NotifierViolation[]): string {
+  const detail = violations.map((entry) => `  ${entry.file}:${entry.lineNumber} ${entry.line}`).join("\n");
+  return `unexpected encoreNotifier.publish/clear outside reconcile.ts and documented orphan-sweep paths:\n${detail}`;
+}
+
+describe("Encore reconciler — unit tests", () => {
+  it("trim symmetry: closed + snoozed both trim the bundle, bell clears", async () => {
+    // The load-bearing invariant. `isPairInBundle` must treat closed
+    // and snoozed identically; otherwise the snooze handler's bell
+    // would re-fire on the same dispatch turn (the pre-reconciler
+    // bug that forced snooze to skip the tick).
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId, cycleId } = setup;
+    if (!obligationId || !cycleId) throw new Error("setup should return ids");
+
+    // Setup published one bundled bell entry covering both targets.
+    assert.equal((await listFor("encore")).length, 1, "setup should publish one bell entry");
+
+    // Close Alice via markStepDone (writes completedSteps + reconciles
+    // → ticket trims to [bob], bell stays).
+    await dispatch({
+      kind: "markStepDone",
+      obligationId,
+      cycleId,
+      targetId: "alice",
+      stepId: "pay",
+      values: { amount: 1000 },
+    });
+    assert.equal((await listFor("encore")).length, 1, "bell must persist after closing one of two");
+
+    // Snooze Bob via snooze handler (writes snoozedSteps + reconciles
+    // → ticket trims to [], bell clears). If snoozed were NOT treated
+    // as out-of-bundle, the bell would survive here.
+    await dispatch({
+      kind: "snooze",
+      obligationId,
+      cycleId,
+      targetId: "bob",
+      stepId: "pay",
+    });
+    assert.equal((await listFor("encore")).length, 0, "bell must clear when remaining target is snoozed");
+  });
+
+  it("idempotency: reconcile twice with no state change makes zero notifier calls the second time", async () => {
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId, cycleId } = setup;
+    if (!obligationId || !cycleId) throw new Error("setup should return ids");
+
+    const before = await listFor("encore");
+    assert.equal(before.length, 1);
+    const originalId = before[0].id;
+
+    // Second reconcile, no intervening state change.
+    await reconcileCycleNotifications({ obligationId, cycleId, now: new Date() });
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, "bell count should be unchanged");
+    assert.equal(after[0].id, originalId, "notification id must be unchanged (no clear+republish)");
+  });
+
+  it("cycle-close transition: closing last open step provisions successor + clears closed cycle's bell", async () => {
+    // Single-target single-step daily obligation. After markStepDone
+    // the cycle closes; the reconciler must (a) clear the closed
+    // cycle's bell+ticket, (b) provision the successor cycle file,
+    // and (c) reconcile the successor (no-op for `cycle-start` phase
+    // because tomorrow's start is still in the future, but the call
+    // must happen — verified by the successor-fire assertion below).
+    const oneTargetDef = {
+      ...twoTargetDef,
+      targets: [{ id: "alice", displayName: "Alice" }],
+    };
+    const setup = (await dispatch({ kind: "setup", definition: oneTargetDef })) as SetupResult;
+    const { obligationId, cycleId } = setup;
+    if (!obligationId || !cycleId) throw new Error("setup should return ids");
+
+    await dispatch({
+      kind: "markStepDone",
+      obligationId,
+      cycleId,
+      targetId: "alice",
+      stepId: "pay",
+      values: { amount: 5000 },
+    });
+
+    // (a) closed cycle's bell cleared.
+    const liveAfterClose = await listFor("encore");
+    assert.equal(liveAfterClose.length, 0, `closed cycle's bell must clear (today's phase is gone, tomorrow's hasn't started); got ${liveAfterClose.length}`);
+
+    // (b) successor file provisioned (cycleFiles count goes 1 → 2).
+    const obligDir = path.join(workspaceRoot, "data/plugins/encore/obligations", obligationId);
+    const cycleFiles = (await fsPromises.readdir(obligDir)).filter((name) => name !== "index.md").sort();
+    assert.equal(cycleFiles.length, 2, `expected closed + successor cycle, got ${cycleFiles.join(", ")}`);
+    assert(cycleFiles[1] > cycleFiles[0], `successor must sort after closed (got ${cycleFiles.join(", ")})`);
+
+    // No pending-clear tickets at all — closed cycle's was unlinked,
+    // successor hasn't fired anything yet.
+    assert.equal((await pendingDirEntries()).length, 0, "no tickets between cycles");
+
+    // (c) advance `now` past the successor's cycle-start and
+    // reconcile. The successor was already provisioned by the
+    // close-time reconcile, so this call should fire its phase-0
+    // notification.
+    const successorCycleId = cycleFiles[1].replace(/\.md$/, "");
+    const tomorrow = new Date(`${successorCycleId}T12:00:00Z`);
+    await reconcileCycleNotifications({ obligationId, cycleId: successorCycleId, now: tomorrow });
+    const liveTomorrow = await listFor("encore");
+    assert.equal(liveTomorrow.length, 1, `successor should fire once now is past its cycle-start; got ${liveTomorrow.length}`);
+  });
+
+  it("snooze expiry: snoozedSteps with past timestamp → reconciler republishes", async () => {
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId, cycleId } = setup;
+    if (!obligationId || !cycleId) throw new Error("setup should return ids");
+
+    // Snooze both targets so the bell clears.
+    await dispatch({ kind: "snooze", obligationId, cycleId, targetId: "alice", stepId: "pay" });
+    await dispatch({ kind: "snooze", obligationId, cycleId, targetId: "bob", stepId: "pay" });
+    assert.equal((await listFor("encore")).length, 0, "bell must clear after snoozing both targets");
+
+    // Back-date both snoozes by parsing/mutating/re-serializing the
+    // cycle file. Simulates time passing without monkeying with Date.
+    // We MUST set the timestamps strictly before our reconcile `now`
+    // so the reconciler treats them as expired.
+    const raw = await readCycleRaw(obligationId, cycleId);
+    const { state, body } = parseCycleFile(raw);
+    const PAST = "2000-01-01T00:00:00.000Z";
+    let backDated = state;
+    backDated = recordStepSnooze(backDated, "alice", "pay", PAST);
+    backDated = recordStepSnooze(backDated, "bob", "pay", PAST);
+    await writeCycleRaw(obligationId, cycleId, serializeCycleFile(backDated, body));
+
+    await reconcileCycleNotifications({ obligationId, cycleId, now: new Date() });
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, `expected bell to re-fire once snoozes expired; got ${after.length}`);
+  });
+
+  it("invalidateAllBells: clears every ticket for the cycle and republishes", async () => {
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId, cycleId } = setup;
+    if (!obligationId || !cycleId) throw new Error("setup should return ids");
+    const before = await listFor("encore");
+    assert.equal(before.length, 1);
+    const oldId = before[0].id;
+
+    await reconcileCycleNotifications({ obligationId, cycleId, now: new Date(), invalidateAllBells: true });
+
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, "bell count should match (cleared then republished)");
+    assert.notEqual(after[0].id, oldId, "notification id must change (clear + republish)");
+  });
+
+  it("notifier boundary: only reconcile.ts + ticket-orphan sweep paths invoke encoreNotifier.{publish,clear}", async () => {
+    // Programmatic enforcement of the acceptance criterion's grep
+    // guarantee. The reconciler is the sole owner of bell state in
+    // every state-driven code path. Two documented exceptions:
+    //   - dispatch.ts `handleOrphanResolve` — user clicked a bell
+    //     whose ticket was already swept; no reconcile target left.
+    //   - tick.ts `pruneOneTicket` — age-based sweep clears the
+    //     bell before unlinking the stale ticket so the next tick
+    //     doesn't see "un-fired" and publish a duplicate.
+    // Both fit the same pattern: "the ticket is about to disappear,
+    // clear its bell counterpart directly because reconcile can't
+    // reach a ticket-less bell."
+    //
+    // A regression where a normal handler calls encoreNotifier.clear
+    // (instead of writing state + reconciling) is exactly the drift
+    // this refactor exists to prevent — catching it here surfaces
+    // the violation at PR time, not in a stale-bell bug report a
+    // week later.
+    const encoreDir = path.join(import.meta.dirname, "..", "..", "server", "encore");
+    const files = (await fsPromises.readdir(encoreDir)).filter((name) => name.endsWith(".ts"));
+    const violations: NotifierViolation[] = [];
+    for (const file of files) {
+      if (NOTIFIER_BOUNDARY_ALLOWED_FILES.has(file)) continue;
+      const raw = await fsPromises.readFile(path.join(encoreDir, file), "utf8");
+      violations.push(...collectFileViolations(file, raw));
+    }
+    assert.deepEqual(violations, [], formatViolationList(violations));
+  });
+
+  it("inactive status: clears every bell + ticket for the obligation, no republish", async () => {
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId } = setup;
+    if (!obligationId) throw new Error("setup should return obligationId");
+    assert.equal((await listFor("encore")).length, 1);
+
+    // Flip status to paused via amend.
+    await dispatch({
+      kind: "amendDefinition",
+      obligationId,
+      definition: { status: "paused" },
+    });
+
+    const after = await listFor("encore");
+    assert.equal(after.length, 0, "inactive obligation must have no bell entries");
+    const tickets = await pendingDirEntries();
+    assert.equal(tickets.length, 0, "inactive obligation must have no pending-clear tickets");
+  });
+});


### PR DESCRIPTION
## Summary

- One reconciler (`server/encore/reconcile.ts`) becomes the sole owner of bell publish/clear. The unifying predicate `isPairInBundle` treats **closed and snoozed both as out-of-bundle**, so `snooze` no longer needs its "skip the tick" workaround and `amendDefinition` no longer needs a bespoke wipe path. Tick is now a thin walker; dispatch handlers funnel through `persistAndReconcile`.
- New `unsnooze` dispatch kind — inverse of `snooze`, republishes the bell in the same dispatch turn (no tick wait, no falsely-closing the step).
- Tolerate `definition` as a JSON-encoded string on `setup` and `amendDefinition`. The LLM often `JSON.stringify`'s nested object arguments; the handler now `JSON.parse`'s strings before validation. Non-JSON / non-object decodes surface as clear 400s.

Full plan: [`plans/feat-encore-reconciler.md`](plans/feat-encore-reconciler.md).

## What's NOT in this PR (follow-ups)

- Per-kind typed JSON Schema on the MCP tool (`dsl: { type: "object", ... }` derived from Zod via `z.toJSONSchema`) — discussed and deferred to a separate PR. The string-coercion in this PR is the bridging fix.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` clean
- [x] `yarn typecheck` clean
- [x] `yarn test` — 4924 host tests pass (3 reconciler-level invariants + dispatch-level unsnooze + string-form coercion are new)
- [x] `yarn build` clean
- [x] Notifier-boundary static guard test passes (programmatic enforcement that only `reconcile.ts`, `handleOrphanResolve`, and `pruneOneTicket` call `encoreNotifier.{publish,clear}`)

## Acceptance criteria from the plan

- [x] Every existing dispatch test keeps passing (two-target bundle invariant, cycle-close-provisions-successor invariant)
- [x] Trim symmetry: closed + snoozed both trim the bundle, bell clears
- [x] Idempotency: reconcile twice with no state change → no notifier calls the second time
- [x] Cycle-close transition: closing last open step provisions successor in same call
- [x] Snooze expiry: past timestamp → reconciler republishes
- [x] `invalidateAllBells`: clears every ticket for the cycle and republishes
- [x] Inactive status: clears every bell + ticket for the obligation, no republish
- [x] `unsnooze` republishes in same dispatch turn
- [x] `unsnooze` no-op doesn't flicker
- [x] `snooze` → `unsnooze` round-trip
- [x] `dispatch.ts` no longer contains `dropTargetFromMatchingTickets`, `clearPendingNotification`, `resetActiveNotificationsForObligation`, or non-orphan `safeClearBell` calls
- [x] Grep guarantee: `encoreNotifier.{publish,clear}` only in `reconcile.ts` + documented orphan-sweep paths (`handleOrphanResolve`, `pruneOneTicket`)
- [x] `LLM_ENCORE_KINDS` includes `unsnooze`; help file documents it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `unsnooze` action to remove step snoozes and re-trigger notifications within the same dispatch turn.
  * Enhanced definition input to accept both object literals and JSON-encoded strings for greater flexibility.

* **Documentation**
  * Clarified `snooze` and new `unsnooze` action behavior in notification lifecycle documentation.
  * Updated action descriptions with accepted input formats and behavior details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->