### PR TITLE
perf(prompt): topic memory context = index-only (#1432)

### DIFF
--- a/plans/perf-memory-index-only-1432.md
+++ b/plans/perf-memory-index-only-1432.md
@@ -1,0 +1,56 @@
+# perf(prompt): topic memory context = index-only (#1432)
+
+## 問題
+
+実行時 system prompt が実ワークスペースで ~46KB（~12K トークン）。
+うち **~78%（~36KB）が Memory ブロック**。`formatTopicFileForPrompt`
+（server/agent/prompt.ts）が **全 topic ファイルの body 全文**を毎ターン・
+全セッションでインライン（10数トピック、その大半は当該メッセージと無関係）。
+
+## なぜ冗長か
+
+同関数は既にトピックごとの**索引行**
+（`[type] <type>/<topic>.md — section1, section2`）を出力し、system
+prompt も「関連トピックは `Read` してから答えよ」と既に指示済み
+（proactive-recall）。＝ *索引 + 遅延 Read* 設計なのに body も全文同梱＝
+二重持ち。summaries は既に pointer 方式（`prependJournalPointer`）。
+
+## 変更（Option A）
+
+`formatTopicFileForPrompt` を**索引行のみ**返すよう変更（body 削除）。
+section ヒント（Read 判断の検索シグナル）は維持。Memory `<reference>`
+の topic 分岐先頭に「これは pointer であり中身はファイルにある。関連
+時は該当 `conversations/memory/<type>/<topic>.md` を Read せよ」の
+明示ヘッダを追加。
+
+**スコープ: topic 形式のみ。** atomic / legacy `memory.md` は #1029 の
+移行用 scaffolding（2026-07-01 撤去予定、実ワークスペースは未使用）の
+ため無改修。
+
+## 効果（ユーザ提供スナップショットで実測）
+
+| | before | after |
+|---|---|---|
+| Memory ブロック | ~36,110 B | ~1,571 B（索引29行）|
+| prompt 全体 | ~46,175 B | **~11,600 B（約75%減）** |
+
+代償: メモリが実際に関連するターンで `Read` 1往復が増える。大半の
+ターンでは10数トピックの大半が無関係なので純益大。
+
+## 変更ファイル
+
+- `server/agent/prompt.ts` — `formatTopicFileForPrompt` 索引のみ化 +
+  topic 分岐に pointer ヘッダ
+- `test/agent/test_topic_memory_context.ts` — 索引行 present / body
+  absent / pointer ヘッダ present にアサート更新
+
+## テスト
+
+- `test_topic_memory_context.ts` 更新、`test_memory_context.ts`
+  （atomic）/ `test_agent_prompt.ts` は無改修で pass（計 56 pass）
+- lint / typecheck green
+
+## スコープ外
+
+- atomic / legacy memory.md の pointer 化（移行 scaffolding、別途）
+- 静的 SYSTEM_PROMPT の helps 退避（別 issue 候補・小幅）

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -74,13 +74,20 @@ export function buildMemoryContext(snapshot: MemorySnapshot, workspacePath: stri
 
   if (snapshot.format === "topic") {
     // Post-swap (topic format active): each topic file lands in the
-    // prompt as a single block — header + section index + body.
-    // The atomic / legacy readers are intentionally skipped here:
-    // once the topic layout is in place the user has acknowledged
-    // the cluster and the atomic entries have been parked under
-    // `.atomic-backup/`.
+    // prompt as a single INDEX line — `[type] <type>/<topic>.md —
+    // sections` — not its body (#1432). The atomic / legacy readers
+    // are intentionally skipped here: once the topic layout is in
+    // place the user has acknowledged the cluster and the atomic
+    // entries have been parked under `.atomic-backup/`.
     const topic = formatTopicFiles(snapshot.files);
-    if (topic) parts.push(topic);
+    if (topic) {
+      parts.push(
+        "Topic memory index (pointers only — the bullets live in the files, not here). " +
+          "When a line's topic or section hints relate to the user's message, `Read` that " +
+          "`conversations/memory/<type>/<topic>.md` file before answering:",
+      );
+      parts.push(topic);
+    }
   } else {
     // Pre-swap: union of typed atomic entries (#1029) and the
     // legacy `memory.md` (#1029 PR-A). Same dual-mode behaviour
@@ -119,11 +126,17 @@ function formatTopicFiles(files: readonly TopicMemoryFile[]): string | null {
   return files.map(formatTopicFileForPrompt).join("\n\n---\n\n");
 }
 
+// Index-only (#1432): emit the pointer line — `[type] <type>/<topic>.md
+// — section1, section2` — NOT the body. Inlining every topic's full
+// body made the memory block ~78% of the system prompt while almost
+// every topic is irrelevant to any given message. The agent `Read`s
+// the topic file when the section hints indicate relevance (the
+// proactive-recall instructions already mandate this), so the body in
+// the prompt was pure redundancy. Section hints are kept — they are
+// the searchable signal that drives the Read decision.
 function formatTopicFileForPrompt(file: TopicMemoryFile): string {
   const link = `${file.type}/${file.topic}.md`;
-  const tagLine = file.sections.length > 0 ? `[${file.type}] ${link} — ${file.sections.join(", ")}` : `[${file.type}] ${link}`;
-  const body = file.body.trim();
-  return body ? `${tagLine}\n${body}` : tagLine;
+  return file.sections.length > 0 ? `[${file.type}] ${link} — ${file.sections.join(", ")}` : `[${file.type}] ${link}`;
 }
 
 function formatTypedMemoryEntries(entries: readonly MemoryEntry[]): string | null {

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -123,7 +123,11 @@ export function buildMemoryManagementSection(snapshot: MemorySnapshot): string {
 
 function formatTopicFiles(files: readonly TopicMemoryFile[]): string | null {
   if (files.length === 0) return null;
-  return files.map(formatTopicFileForPrompt).join("\n\n---\n\n");
+  // One pointer line per topic → join with a single newline. The
+  // old `\n\n---\n\n` rule separated multi-line bodies; with
+  // index-only (#1432) it was 4 newlines + a rule per one-liner —
+  // pure token/visual bloat. A flat list reads fine.
+  return files.map(formatTopicFileForPrompt).join("\n");
 }
 
 // Index-only (#1432): emit the pointer line — `[type] <type>/<topic>.md

--- a/server/prompts/system/system.md
+++ b/server/prompts/system/system.md
@@ -11,7 +11,7 @@ You are MulmoClaude, a versatile assistant app with rich visual output.
 All data lives in the workspace directory as plain files:
 
 - `conversations/chat/` — chat session history (one .jsonl per session)
-- `conversations/memory/` — distilled facts about the user, one entry per file (typed: preference / interest / fact / reference). `MEMORY.md` in the same directory is a system-owned index; entry bodies are loaded as context.
+- `conversations/memory/` — distilled facts about the user, one topic file per `<type>/<topic>.md` (typed: preference / interest / fact / reference). `MEMORY.md` is a system-owned index. The Memory section of this prompt lists each topic as a pointer line (`[type] <type>/<topic>.md — sections`) only — the bullet bodies are NOT inlined; `Read` the relevant topic file before relying on its contents.
 - `conversations/summaries/` — journal output (daily / topics / archive)
 - `data/plugins/%40mulmoclaude%2Ftodo-plugin/` — todo items (plugin-scoped after #1145; the encoded segment is `encodeURIComponent` of the npm package name)
 - `data/calendar/` — calendar events

--- a/test/agent/test_topic_memory_context.ts
+++ b/test/agent/test_topic_memory_context.ts
@@ -75,10 +75,15 @@ describe("memory/format-detect — topic workspace", () => {
     await rm(scoped, { recursive: true, force: true });
   });
 
-  it("buildMemoryContext renders the topic file with its sections", async () => {
+  it("buildMemoryContext renders the topic INDEX line + section hints, NOT the body (#1432)", async () => {
     const out = buildMemoryContext(await loadMemorySnapshot(scoped), scoped);
+    // Index pointer + searchable section hints survive.
     assert.match(out, /\[interest\] interest\/music\.md — Rock \/ Metal, Punk \/ Melodic/);
-    assert.match(out, /Pantera, Metallica/);
+    // Bodies are no longer inlined — the agent Reads the file instead.
+    assert.doesNotMatch(out, /Pantera, Metallica/);
+    assert.doesNotMatch(out, /NOFX, Hi-STANDARD/);
+    // The index header tells the agent these are pointers to Read.
+    assert.match(out, /pointers only/);
   });
 
   it("buildMemoryContext skips both atomic-format files AND a stray legacy memory.md once topic format is active", async () => {
@@ -101,8 +106,10 @@ describe("memory/format-detect — topic workspace", () => {
     const out = buildMemoryContext(await loadMemorySnapshot(scoped), scoped);
     assert.doesNotMatch(out, /should-not-leak-from-atomic/, "atomic file at memory root must not bleed into topic-mode prompt");
     assert.doesNotMatch(out, /should-not-leak-from-legacy/, "legacy memory.md must not bleed into topic-mode prompt");
-    // The topic file's content is still visible.
-    assert.match(out, /Pantera, Metallica/);
+    // The topic file's index line is still surfaced (body is not —
+    // index-only, #1432).
+    assert.match(out, /\[interest\] interest\/music\.md — Rock \/ Metal, Punk \/ Melodic/);
+    assert.doesNotMatch(out, /Pantera, Metallica/);
   });
 
   it("buildMemoryManagementSection emits the topic-format instructions", async () => {


### PR DESCRIPTION
## Summary

The runtime system prompt was **~46 KB (~12 K tokens)** for a real workspace; **~78 % (~36 KB) was the Memory block** because `formatTopicFileForPrompt` inlined every topic file's **full body** every turn / every session — while almost every topic is irrelevant to any given message.

The same function already emits a per-topic **index line** (`[type] <type>/<topic>.md — section1, section2`) and the prompt already instructs the agent to `Read` a topic file when relevant (proactive-recall). So the inlined bodies were pure redundancy — `summaries` already uses the pointer pattern (`prependJournalPointer`); memory was the outlier.

### Change (Option A)

- `formatTopicFileForPrompt` → **index line only** (drop `file.body`); section hints kept (they are the Read-decision signal).
- `buildMemoryContext` topic branch gains an explicit pointer header: the bullets live in the files, `Read` the relevant `conversations/memory/<type>/<topic>.md` before answering.

### Measured on a real prompt dump

| | before | after |
|---|---|---|
| Memory block | ~36,110 B | ~1,571 B (29 index lines) |
| Total prompt | ~46,175 B | **~11,600 B (~75 % smaller)** |

## Items to Confirm / Review

- **Scope = topic format only.** The atomic / legacy `memory.md` paths are #1029 pre-migration scaffolding (slated for removal 2026-07-01) and are not what real workspaces use — left unchanged on purpose.
- **Tradeoff**: on a turn where memory *is* relevant the agent now does one `Read` round-trip instead of having the body pre-inlined. The proactive-recall instructions already mandate that Read; this just makes it load-bearing. Net win because most turns touch none of the 10+ topics.
- Section hints (`— Rock / Metal, Punk / Melodic`) are preserved so the agent can still decide *which* file to Read without opening any.

## User Prompt

> system promptを実行中に確認したい… ~/…/server/system/logs/aaa にシステムpromptを書き出したんだけど、大きすぎるよね。ファイルのreferenceにするなど、削れる方法ある？ソースなどとも相談して、考えて
>
> A

(Analysis identified the memory block as ~78 % of the prompt; user chose Option A = index-only / file-reference.)

## Test plan

- [ ] `test/agent/test_topic_memory_context.ts` — index line + section hints present, bodies absent, pointer header present
- [ ] `test_memory_context.ts` (atomic) + `test_agent_prompt.ts` unaffected (56 tests pass locally)
- [ ] lint / typecheck / build green (CI)
- [ ] Manual: dump the prompt again (`--debug`, new session) and confirm memory section is index-only

Closes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified memory behavior: workspace memory now lists topics as pointer lines and instructs the agent to read referenced topic files when needed.

* **Tests**
  * Adjusted memory-context tests to expect index-only topic lines, section hints present, and no inlined topic bodies.

* **Chores**
  * Reduced prompt payload by ~75% by switching topic entries to pointer/index-only format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->