### PR TITLE
feat(NotificationBell): collapse history beyond 5 rows behind toggle

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -71,21 +71,27 @@ In **Stack layout** this sidebar isn't rendered; the same data flows through `<S
 
 ```
 🔔[notification-bell]──┐
-   🔴[notification-badge: "N"] (red dot, only when unread > 0)
-   │  ┌─[notification-panel] (opens on click)──────────────────┐
-   │  │ Notifications              [notification-mark-all-read]│
-   │  ├─────────────────────────────────────────────────────────┤
-   │  │ 🔵 Title (bold)                                       ✕ │  ← unread
-   │  │ ◯  body line                                            │  data-unread="true"
-   │  │ ◯  N min ago                                            │
-   │  ├─────────────────────────────────────────────────────────┤
-   │  │ ⚪ Title (regular)                                    ✕ │  ← read
-   │  │     body line                                            │  data-unread="false"
-   │  └─────────────────────────────────────────────────────────┘
-   └─ each row: [notification-item-<id>]; click → router.push(target)
+   🔴[notification-badge: "N"] (worst-severity color; shown when active > 0)
+   │  ┌─[notification-panel] (opens on click) ─────────────────┐
+   │  │ Notifications                                          │
+   │  ├─ Active (N) ──────────────── [notification-clear-all]  │ (fyi rows only)
+   │  │ 🔔 Active row title                  ✕ (action only)   │
+   │  │     N min ago · pluginPkg                              │
+   │  │ … [notification-item-<id>]                             │
+   │  ├─ History (N) ─────────────────────────────────────────┤
+   │  │ ✓ / ✗  History row title                              │
+   │  │        N min ago · cleared|cancelled · pluginPkg      │
+   │  │ … initial 5 rows; rest hidden behind toggle           │
+   │  ├──────────────────────────────────────────────────────┤
+   │  │ [notification-history-toggle]                          │
+   │  │   "Show more (N)" / "Show less" (only when > 5 items) │
+   │  └──────────────────────────────────────────────────────┘
+   └─ active rows: [notification-item-<id>]
+      history rows: [notification-history-<id>]
 ```
 
-Click on a row → `useNotifications.markRead(id)` → badge decrements. The 🔵/⚪ leading dot disappears once read; bold title fades to gray.
+- **Active** rows: fyi (body click clears + navigates) vs action (× cancels; body click navigates only).
+- **History** rows: read-only; navigate on click when `navigateTarget` is present. Capped at `HISTORY_CAP` (50) FIFO server-side; bell collapses to the first 5 with a toggle so repetitive entries (e.g. recurring "docker not running") don't bury the rest. Toggle state resets each time the popup closes.
 
 ## /chat — the chat page
 

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -339,4 +339,20 @@ test.describe("notification bell — history more / less toggle", () => {
     await expect(page.getByTestId(`notification-history-${history[0].id}`)).toBeVisible();
     await expect(page.getByTestId("notification-history-toggle")).toHaveCount(0);
   });
+
+  test("toggle appears with hidden count 1 at the > 5 boundary", async ({ page }) => {
+    // Triangulates the threshold (`> HISTORY_INITIAL_VISIBLE`): combined
+    // with the 5-entry "toggle absent" case above and the 8-entry
+    // expand/collapse case, this pins the boundary at exactly 5.
+    const history = Array.from({ length: HISTORY_INITIAL_VISIBLE + 1 }, (_, index) => buildHistoryEntry(index));
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+    const toggle = page.getByTestId("notification-history-toggle");
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveText(/\b1\b/);
+    await expect(page.getByTestId(`notification-history-${history[HISTORY_INITIAL_VISIBLE].id}`)).toHaveCount(0);
+  });
 });

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -28,6 +28,7 @@
 
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
+import { ONE_SECOND_MS } from "../../server/utils/time.ts";
 
 interface NotifierEntryFixture {
   id: string;
@@ -253,9 +254,20 @@ interface NotifierHistoryFixture extends NotifierEntryFixture {
   terminalAt: string;
 }
 
+// Aligned with buildEntry's `createdAt` of 2026-04-25T06:00 — history
+// rows are stamped one hour later. Computing via Date arithmetic
+// instead of `0${index}` template concat keeps the helper safe past
+// index 9 (HISTORY_CAP is 50, so we need to handle two-digit indices).
+const HISTORY_BASE_MS = Date.parse("2026-04-25T07:00:00.000Z");
+
 function buildHistoryEntry(index: number): NotifierHistoryFixture {
   const base = buildEntry(`notif-hist-${index}`, `History entry ${index}`, "");
-  return { ...base, navigateTarget: undefined, terminalType: "cleared", terminalAt: `2026-04-25T07:00:0${index}.000Z` };
+  return {
+    ...base,
+    navigateTarget: undefined,
+    terminalType: "cleared",
+    terminalAt: new Date(HISTORY_BASE_MS + index * ONE_SECOND_MS).toISOString(),
+  };
 }
 
 async function primeNotifierHistory(page: Page, history: readonly NotifierHistoryFixture[]): Promise<void> {

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -247,3 +247,96 @@ test.describe("notification bell — dismiss", () => {
     await expect(page.getByTestId("notification-badge")).toHaveCount(0);
   });
 });
+
+interface NotifierHistoryFixture extends NotifierEntryFixture {
+  terminalType: "cleared" | "cancelled";
+  terminalAt: string;
+}
+
+function buildHistoryEntry(index: number): NotifierHistoryFixture {
+  const base = buildEntry(`notif-hist-${index}`, `History entry ${index}`, "");
+  return { ...base, navigateTarget: undefined, terminalType: "cleared", terminalAt: `2026-04-25T07:00:0${index}.000Z` };
+}
+
+async function primeNotifierHistory(page: Page, history: readonly NotifierHistoryFixture[]): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/notifier",
+    (route) => {
+      const body = route.request().postData();
+      const action = parseAction(body);
+      if (action === "listHistory") return route.fulfill({ json: { history } });
+      if (action === "clear" || action === "cancel") return route.fulfill({ json: { ok: true } });
+      return route.fulfill({ json: { entries: [] } });
+    },
+  );
+}
+
+test.describe("notification bell — history more / less toggle", () => {
+  const HISTORY_INITIAL_VISIBLE = 5;
+
+  test("hides entries beyond the initial cap behind a toggle", async ({ page }) => {
+    const history = Array.from({ length: 8 }, (_, index) => buildHistoryEntry(index));
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+    await expect(page.getByTestId("notification-panel")).toBeVisible();
+
+    // First 5 entries render; the rest are hidden until expanded.
+    for (let index = 0; index < HISTORY_INITIAL_VISIBLE; index += 1) {
+      await expect(page.getByTestId(`notification-history-${history[index].id}`)).toBeVisible();
+    }
+    for (let index = HISTORY_INITIAL_VISIBLE; index < history.length; index += 1) {
+      await expect(page.getByTestId(`notification-history-${history[index].id}`)).toHaveCount(0);
+    }
+
+    const toggle = page.getByTestId("notification-history-toggle");
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveText(/3/);
+
+    await toggle.click();
+    for (const entry of history) {
+      await expect(page.getByTestId(`notification-history-${entry.id}`)).toBeVisible();
+    }
+    await expect(toggle).not.toHaveText(/3/);
+
+    await toggle.click();
+    for (let index = HISTORY_INITIAL_VISIBLE; index < history.length; index += 1) {
+      await expect(page.getByTestId(`notification-history-${history[index].id}`)).toHaveCount(0);
+    }
+  });
+
+  test("collapses again after closing and reopening the popup", async ({ page }) => {
+    const history = Array.from({ length: 8 }, (_, index) => buildHistoryEntry(index));
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+    await page.getByTestId("notification-history-toggle").click();
+    // Confirm we're expanded before the close-reopen cycle.
+    await expect(page.getByTestId(`notification-history-${history[7].id}`)).toBeVisible();
+
+    // Click outside the bell to close (App-level outside-click handler).
+    await page.mouse.click(10, 10);
+    await expect(page.getByTestId("notification-panel")).toHaveCount(0);
+
+    await page.getByTestId("notification-bell").click();
+    await expect(page.getByTestId("notification-panel")).toBeVisible();
+    // The hidden tail entry should be gone again — state reset on close.
+    await expect(page.getByTestId(`notification-history-${history[7].id}`)).toHaveCount(0);
+    await expect(page.getByTestId("notification-history-toggle")).toBeVisible();
+  });
+
+  test("toggle is absent when history is at or under the initial cap", async ({ page }) => {
+    const history = Array.from({ length: HISTORY_INITIAL_VISIBLE }, (_, index) => buildHistoryEntry(index));
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+    await expect(page.getByTestId(`notification-history-${history[0].id}`)).toBeVisible();
+    await expect(page.getByTestId("notification-history-toggle")).toHaveCount(0);
+  });
+});

--- a/plans/feat-notification-history-more.md
+++ b/plans/feat-notification-history-more.md
@@ -63,11 +63,16 @@ zh / ko / es / pt-BR / fr / de も同様に追加。placeholder `{count}` は全
 
 ## 検証コマンド
 
+リポジトリルート (または対応する worktree) で実行:
+
 ```bash
-cd /Users/yasutaka/local-workspace/mulmo/mulmoclaude-code/.claude/worktrees/feat-notification-history-more
-yarn format
-yarn lint
-yarn typecheck
-yarn build
-yarn test:e2e --grep "history more"
+yarn format && yarn lint && yarn typecheck && yarn build
+yarn test:e2e --grep "history more / less toggle"
+```
+
+Playwright を視覚確認したい場合は (global rule に従い `--debug` 付き):
+
+```bash
+cd <repo-root>/.claude/worktrees/feat-notification-history-more
+yarn test:e2e --debug --grep "history more / less toggle"
 ```

--- a/plans/feat-notification-history-more.md
+++ b/plans/feat-notification-history-more.md
@@ -1,0 +1,73 @@
+# feat: 通知履歴セクションに「もっと見る」を追加
+
+Issue: receptron/mulmoclaude#1438
+
+## User Prompt
+
+> 通知履歴（NotificationBell の cleared 履歴セクション）は最大 50 件をパネル内スクロールでそのまま表示しているため、`docker が起動していません` のような繰り返し通知で埋まってしまう。履歴セクションだけ初期表示を制限して「もっと見る」で展開できるようにしたい。
+>
+> - 初期 5 件 / 閉じるボタンあり / 文言は「もっと見る (N)」で
+> - worktree で作業、完了したら commit → `/codex-cross-review`
+
+## 背景
+
+- `HISTORY_CAP = 50`（[server/notifier/types.ts:116](../server/notifier/types.ts#L116)）で履歴は最大 50 件まで保持
+- パネルは `max-h-[80vh]` で頭打ち + `overflow-y-auto` で**パネル内スクロール**になるため画面外にはみ出しはしない
+- しかし 50 件が一気に DOM レンダリングされるためアクティブ通知の視認性が落ちる
+- 同一 key の dedupe / 折りたたみは現状なし
+
+## 変更方針
+
+### 1. `src/components/NotificationBell.vue`
+
+- 定数 `HISTORY_INITIAL_VISIBLE = 5` を追加
+- `historyExpanded` ref を追加（初期 `false`）
+- `displayedHistory` computed: 折りたたみ時は `visibleHistory.slice(0, HISTORY_INITIAL_VISIBLE)`、展開時は `visibleHistory` 全件
+- `hiddenHistoryCount` computed: `visibleHistory.length - HISTORY_INITIAL_VISIBLE`（0 未満は 0 に clamp）
+- template の `v-for` を `displayedHistory` に差し替え
+- 履歴 `<ul>` の直後に切替ボタンを追加。`visibleHistory.length > HISTORY_INITIAL_VISIBLE` の時のみ表示
+  - 折りたたみ時: `もっと見る (N)`（N = 隠れている件数）
+  - 展開時: `閉じる`
+- `open` を watch して、ベルを閉じたら `historyExpanded.value = false` に戻す（次回開いた時のスクロール位置を一定にする）
+- 履歴セクションヘッダーの件数 `(N)` は**合計件数のまま**（隠れている件数を含む）
+
+### 2. i18n キー追加（全 8 ロケール）
+
+`notificationBell` 配下に以下を追加:
+
+| key | en | ja |
+|---|---|---|
+| `showMore` | `Show more ({count})` | `もっと見る ({count})` |
+| `showLess` | `Show less` | `閉じる` |
+
+zh / ko / es / pt-BR / fr / de も同様に追加。placeholder `{count}` は全ロケールで verbatim 維持。
+
+### 3. テスト
+
+`e2e/tests/notifications.spec.ts` に追加:
+
+- 6 件以上の cleared 履歴を `listHistory` mock で返す
+- ベルを開いて履歴は 5 件しか描画されないこと
+- 「もっと見る (N)」ボタンが見えること
+- クリックで全件表示に切り替わること
+- 「閉じる」ボタンに文言が切り替わること
+- 再クリックで 5 件表示に戻ること
+- ベル popup を閉じて再度開くと初期 5 件表示に戻ること
+
+## スコープ外
+
+- 同一 key 通知の dedupe / グルーピング
+- 履歴の手動削除 UI
+- 仮想スクロール
+- アクティブセクションの表示変更
+
+## 検証コマンド
+
+```bash
+cd /Users/yasutaka/local-workspace/mulmo/mulmoclaude-code/.claude/worktrees/feat-notification-history-more
+yarn format
+yarn lint
+yarn typecheck
+yarn build
+yarn test:e2e --grep "history more"
+```

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -365,7 +365,7 @@ async function clearAllFyi(): Promise<void> {
         <p v-if="visibleHistory.length === 0" class="px-3 py-3 text-gray-400 italic" data-testid="notification-empty-history">
           {{ t("notificationBell.noHistory") }}
         </p>
-        <ul v-else class="divide-y divide-gray-100">
+        <ul v-else id="notification-history-list" class="divide-y divide-gray-100">
           <li
             v-for="entry in displayedHistory"
             :key="`${entry.id}-${entry.terminalAt}`"
@@ -404,6 +404,8 @@ async function clearAllFyi(): Promise<void> {
           type="button"
           class="w-full px-3 py-1.5 text-gray-500 font-medium hover:text-gray-700 hover:bg-gray-50 border-t border-gray-100"
           data-testid="notification-history-toggle"
+          :aria-expanded="historyExpanded"
+          aria-controls="notification-history-list"
           @click="toggleHistoryExpanded"
         >
           {{ historyExpanded ? t("notificationBell.showLess") : t("notificationBell.showMore", { count: hiddenHistoryCount }) }}

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -42,6 +42,20 @@ const fyiCount = computed(() => entries.value.filter((entry) => (entry.lifecycle
 
 const badgeText = computed(() => (badgeCount.value > 99 ? "99+" : String(badgeCount.value)));
 
+// History collapses to N rows on open; everything beyond hides behind
+// the "Show more" toggle. Keeps the panel scannable when the 50-item
+// HISTORY_CAP fills with repetitive entries (e.g. recurring
+// "docker not running" notifications burying active items).
+const HISTORY_INITIAL_VISIBLE = 5;
+const historyExpanded = ref(false);
+const displayedHistory = computed(() => (historyExpanded.value ? visibleHistory.value : visibleHistory.value.slice(0, HISTORY_INITIAL_VISIBLE)));
+const hiddenHistoryCount = computed(() => Math.max(0, visibleHistory.value.length - HISTORY_INITIAL_VISIBLE));
+const canToggleHistory = computed(() => visibleHistory.value.length > HISTORY_INITIAL_VISIBLE);
+
+function toggleHistoryExpanded(): void {
+  historyExpanded.value = !historyExpanded.value;
+}
+
 // Hover state on the bulk-clear button — every fyi row's hover-check
 // icon renders while it's true, mirroring the debug popup's "this is
 // what's about to get swept" affordance.
@@ -71,6 +85,13 @@ watch(
     if (shouldClose && open.value) close();
   },
 );
+
+// Reset history expansion when the popup closes so the next open
+// starts from the collapsed 5-row view. Without this, an expanded
+// state persists across closes and the scroll position jumps.
+watch(open, (nowOpen: boolean) => {
+  if (!nowOpen) historyExpanded.value = false;
+});
 
 // ── Legacy pluginData typing ────────────────────────────────
 //
@@ -346,7 +367,7 @@ async function clearAllFyi(): Promise<void> {
         </p>
         <ul v-else class="divide-y divide-gray-100">
           <li
-            v-for="entry in visibleHistory"
+            v-for="entry in displayedHistory"
             :key="`${entry.id}-${entry.terminalAt}`"
             :data-testid="`notification-history-${entry.id}`"
             :role="entry.navigateTarget ? 'button' : undefined"
@@ -378,6 +399,15 @@ async function clearAllFyi(): Promise<void> {
             </div>
           </li>
         </ul>
+        <button
+          v-if="canToggleHistory"
+          type="button"
+          class="w-full px-3 py-1.5 text-gray-500 font-medium hover:text-gray-700 hover:bg-gray-50 border-t border-gray-100"
+          data-testid="notification-history-toggle"
+          @click="toggleHistoryExpanded"
+        >
+          {{ historyExpanded ? t("notificationBell.showLess") : t("notificationBell.showMore", { count: hiddenHistoryCount }) }}
+        </button>
       </div>
     </div>
   </div>

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -68,6 +68,8 @@ const deMessages = {
     clearAll: "Alle löschen",
     dismiss: "Verwerfen",
     cancel: "Abbrechen",
+    showMore: "Mehr anzeigen ({count})",
+    showLess: "Weniger anzeigen",
   },
   pluginDiagnostics: {
     title: "Plugin-Konfigurationsproblem",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -90,6 +90,8 @@ const enMessages = {
     clearAll: "Clear",
     dismiss: "Dismiss",
     cancel: "Cancel",
+    showMore: "Show more ({count})",
+    showLess: "Show less",
   },
   pluginDiagnostics: {
     title: "Plugin configuration issue",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -73,6 +73,8 @@ const esMessages = {
     clearAll: "Borrar",
     dismiss: "Descartar",
     cancel: "Cancelar",
+    showMore: "Mostrar más ({count})",
+    showLess: "Mostrar menos",
   },
   pluginDiagnostics: {
     title: "Problema de configuración del plugin",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -68,6 +68,8 @@ const frMessages = {
     clearAll: "Tout effacer",
     dismiss: "Ignorer",
     cancel: "Annuler",
+    showMore: "Voir plus ({count})",
+    showLess: "Réduire",
   },
   pluginDiagnostics: {
     title: "Problème de configuration du plugin",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -75,6 +75,8 @@ const jaMessages = {
     clearAll: "すべてクリア",
     dismiss: "閉じる",
     cancel: "キャンセル",
+    showMore: "もっと見る ({count})",
+    showLess: "閉じる",
   },
   pluginDiagnostics: {
     title: "プラグイン設定の問題",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -75,6 +75,8 @@ const koMessages = {
     clearAll: "모두 지우기",
     dismiss: "닫기",
     cancel: "취소",
+    showMore: "더 보기 ({count})",
+    showLess: "접기",
   },
   pluginDiagnostics: {
     title: "플러그인 구성 문제",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -68,6 +68,8 @@ const ptBRMessages = {
     clearAll: "Limpar",
     dismiss: "Dispensar",
     cancel: "Cancelar",
+    showMore: "Mostrar mais ({count})",
+    showLess: "Mostrar menos",
   },
   pluginDiagnostics: {
     title: "Problema de configuração do plugin",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -73,6 +73,8 @@ const zhMessages = {
     clearAll: "全部清除",
     dismiss: "关闭",
     cancel: "取消",
+    showMore: "显示更多 ({count})",
+    showLess: "收起",
   },
   pluginDiagnostics: {
     title: "插件配置问题",


### PR DESCRIPTION
## Summary

通知履歴セクションが `HISTORY_CAP = 50` を全部スクロール領域にレンダリングしていて、繰り返し通知（例: `docker が起動していません`）でアクティブ通知が埋もれていた問題を解決。履歴セクションだけ初期 5 件表示にし、超過分は「もっと見る (N)」/「閉じる」のトグルで折りたためるようにした。ベル popup を閉じたらトグル状態は collapsed にリセット。

<img width="480" height="461" alt="CleanShot 2026-05-18 at 16 08 22" src="https://github.com/user-attachments/assets/61660b83-9a71-496d-ba86-4358b26a3786" />

## Items to Confirm / Review

AI-generated コードのため、以下を重点的に確認してほしい:

- **a11y**: `aria-expanded` + `aria-controls="notification-history-list"` + `<ul id="notification-history-list">` の disclosure pattern が標準的か。スクリーンリーダーで操作した時の読み上げが意図どおりか
- **i18n**: 8 ロケール (en/ja/zh/ko/es/pt-BR/fr/de) に `showMore` / `showLess` を追加。`{count}` placeholder は全ロケールで verbatim 維持。翻訳の自然さ、特に zh の「显示更多 ({count})」、ko の「더 보기 ({count})」あたり
- **UX**: popup を閉じたら展開状態がリセットされる挙動で OK か（次回開いた時のスクロール位置を一定に保つため、というのが採用した理由）
- **スコープ判断**: 同一 key 通知の dedupe / 履歴の手動削除 / 仮想スクロールは本 PR では**やっていない**。必要なら follow-up issue で OK か

## User Prompt

> 通知履歴（NotificationBell の cleared 履歴セクション）は最大 50 件をパネル内スクロールでそのまま表示しているため、`docker が起動していません` のような繰り返し通知で埋まる。履歴セクションだけ初期表示を制限して「もっと見る」で展開できるようにしたい。
>
> - 初期 5 件 / 閉じるボタンあり / 文言は「もっと見る (N)」
> - worktree で作業、完了したら commit → /codex-cross-review
> - テスト fixture / plan に個人 PC のパスを入れない

## 背景

- `HISTORY_CAP = 50` (server/notifier/types.ts:116) で履歴は最大 50 件まで保持
- パネルは `max-h-[80vh]` + `overflow-y-auto` で**パネル内スクロール**のため画面外にはみ出しはしない
- しかし 50 件が一気に DOM レンダリングされるためアクティブ通知の視認性が落ちる
- 同一 key の dedupe / 折りたたみは現状なし

## 実装

### 1. `src/components/NotificationBell.vue`

- 定数 `HISTORY_INITIAL_VISIBLE = 5` を追加
- `historyExpanded` ref (初期 `false`)
- `displayedHistory` computed: 折りたたみ時は `visibleHistory.slice(0, 5)`、展開時は全件
- `hiddenHistoryCount` / `canToggleHistory` computed
- 履歴 `<ul>` 直後にトグルボタン (`v-if="canToggleHistory"`)
  - 文言: 折りたたみ時 `もっと見る (N)`、展開時 `閉じる`
  - `aria-expanded` + `aria-controls="notification-history-list"` で disclosure pattern
  - `<ul>` 側に `id="notification-history-list"` を付与
- `watch(open, ...)` でベルを閉じたら `historyExpanded.value = false` にリセット

### 2. i18n キー追加 (全 8 ロケール)

| key | en | ja |
|---|---|---|
| `showMore` | `Show more ({count})` | `もっと見る ({count})` |
| `showLess` | `Show less` | `閉じる` |

zh / ko / es / pt-BR / fr / de も同様に追加。`{count}` placeholder は全ロケールで verbatim。

### 3. テスト (`e2e/tests/notifications.spec.ts`)

`notification bell — history more / less toggle` describe 下に 4 テスト追加:

- `hides entries beyond the initial cap behind a toggle` — 8 件 → 5 件表示 +「もっと見る (3)」→ クリックで全件 →「閉じる」→ 再クリックで戻る
- `collapses again after closing and reopening the popup` — 展開状態で閉じて再度開くと折りたたみに戻る
- `toggle is absent when history is at or under the initial cap` — 5 件で toggle 非表示
- `toggle appears with hidden count 1 at the > 5 boundary` — 6 件で toggle 表示・残件数 1 (5/6/8 の三角測量で閾値を `> 5` に pin)

fixture の `buildHistoryEntry` は `Date.parse` + `ONE_SECOND_MS` の演算ベースで生成 (index >= 10 で壊れない、`HISTORY_CAP=50` まで安全)。

### 4. `docs/ui-cheatsheet.md`

NotificationBell の ASCII レイアウト図が既に削除済みの `notification-mark-all-read` / `data-unread` を参照する古い状態だったので、現状のテストid (`notification-clear-all` / `notification-history-<id>` / `notification-history-toggle` 等) に合わせて書き直し、新規 toggle 行も追加。

## レビュー

**Codex Cross-Review** で 3 iteration 回して収束:

| Iteration | 判定 | 内容 |
|---|---|---|
| 1 | CHANGES REQUESTED | a11y disclosure semantics 不足、境界テスト不足 |
| 2 | LGTM | a11y 修正 (`aria-expanded` / `aria-controls` / `id`) + `==6` 境界テスト |
| 3 | LGTM | e2e fixture の `buildHistoryEntry` を `0${index}` 連結 (index ≥ 10 で壊れる罠) から `Date.parse + ONE_SECOND_MS * index` に変更 + plan から個人 PC パス除去 |

## 検証

リポジトリルートで:

```bash
yarn format && yarn lint && yarn typecheck && yarn build
yarn test:e2e --grep "history more / less toggle"
```

全て green、e2e 14/14 passed (既存 10 + 新規 4)。

Closes #1438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification history can now be expanded and collapsed with a toggle button. Initially displays 5 most recent items, with a "Show more" button to reveal additional history.
  * Expansion state resets automatically when the notification bell is reopened.
  * Added show more/less button labels across 8 languages.

* **Documentation**
  * Updated notification UI specifications and feature documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->