### PR TITLE
fix(encore): timezone, directory hygiene, ticket rename, and ghost-ticket rescue

### DIFF
--- a/.github/workflows/mulmoclaude_smoke.yaml
+++ b/.github/workflows/mulmoclaude_smoke.yaml
@@ -103,9 +103,21 @@ jobs:
       # machine where `claude` has been run interactively. Without
       # this the launcher calls process.exit(1) during startup on
       # CI's pristine $HOME.
+      #
+      # PUPPETEER_SKIP_DOWNLOAD=1 skips puppeteer's postinstall
+      # chrome-headless-shell extraction during the tarball stage's
+      # `npm install`. `mulmocast-vision` bundles its own nested
+      # puppeteer in addition to the top-level one, so two parallel
+      # postinstalls race on `~/.cache/puppeteer/...` and reliably
+      # collide with `File exists` on the runner — main has been
+      # red on this since PR #1437. The smoke test only verifies
+      # that the launcher boots and serves "/" so chrome isn't
+      # exercised here anyway; skipping the download loses zero
+      # smoke coverage and unblocks the gate.
       - name: Run publish smoke
         env:
           DISABLE_SANDBOX: "1"
+          PUPPETEER_SKIP_DOWNLOAD: "1"
         run: node scripts/mulmoclaude/smoke.mjs
 
       # Preserve the smoke-verified tarball as a downloadable

--- a/server/encore/boot.ts
+++ b/server/encore/boot.ts
@@ -29,10 +29,10 @@ export function registerEncoreTick(taskManager: ITaskManager): void {
   // Fire-on-boot. Without this, a phase that came due during a
   // downtime window (e.g. a daily obligation whose cycle-start is
   // today, but the server was off all morning) wouldn't surface in
-  // the bell until the next UTC-hour-aligned heartbeat — up to ~60
-  // minutes of silence after reboot. Fire-and-forget so we don't
-  // block the rest of boot; errors are swallowed by tickUnlocked's
-  // inner try/catch and surfaced via log.warn.
+  // the bell until the next hourly heartbeat — up to ~60 minutes
+  // of silence after reboot. Fire-and-forget so we don't block the
+  // rest of boot; errors are swallowed by tickUnlocked's inner
+  // try/catch and surfaced via log.warn.
   kickTickLocked({ now: new Date() }, "encore-tick boot").catch((err) => {
     log.warn("encore", "boot tick: unhandled error", { error: err instanceof Error ? err.message : String(err) });
   });

--- a/server/encore/cycle.ts
+++ b/server/encore/cycle.ts
@@ -13,9 +13,9 @@
 //   - `completedSteps[stepId]` — timestamp set by markStepDone
 //
 // Notification-bell tracking (`activeNotificationId`,
-// `lastPublishedSeverity`) lives in pending-clear tickets, NOT in
-// this file. One ticket = one live bell entry; the tick scans
-// `pending-clear/*.json` to know what's active.
+// `lastPublishedSeverity`) lives in tickets, NOT in this file.
+// One ticket = one live bell entry; the tick scans
+// `tickets/*.json` to know what's active.
 
 import { parseEncoreFrontmatter as parseFrontmatter, serializeEncoreFrontmatter as serializeWithFrontmatter } from "./yaml-fm.js";
 import type { EncoreDsl } from "../../src/types/encore-dsl/schema.js";

--- a/server/encore/dispatch.ts
+++ b/server/encore/dispatch.ts
@@ -3,7 +3,7 @@
 // Data-only on-disk model (PR #1416 follow-up): cycle files hold
 // only what the user recorded (values / skipped / completedSteps /
 // snoozedSteps). Closure is derived. Bell-entry tracking lives in
-// pending-clear tickets, not in the cycle file.
+// tickets, not in the cycle file.
 //
 // `dispatch(body)` is the single entry point; the Express adapter in
 // `server/api/routes/encore.ts` calls it. The dispatch wrapper
@@ -15,8 +15,8 @@
 // State-mutating handlers funnel through `persistAndReconcile`:
 // write the cycle file, then run the reconciler under the same lock.
 // The reconciler is the sole owner of bell state (see reconcile.ts)
-// — handlers don't touch notifier publish/clear or pending-clear
-// tickets directly. The one documented exception is
+// — handlers don't touch notifier publish/clear or tickets
+// directly. The one documented exception is
 // `handleOrphanResolve`, which clears a bell entry whose ticket was
 // already swept (the click landed too late).
 
@@ -39,15 +39,15 @@ import { isCycleClosed } from "./closure.js";
 import { parseIndexFile, serializeIndexFile } from "./obligation.js";
 import { currentCycleSlot } from "../../src/types/encore-dsl/cadence.js";
 import path from "node:path";
-import { obligationDir, obligationIndexPath, cycleFilePath, pendingClearPath, slugify, OBLIGATIONS_DIRNAME } from "./paths.js";
-import { exists, readDir, readTextOrNull, writeText } from "../utils/files/encore-io.js";
+import { obligationDir, obligationIndexPath, cycleFilePath, ticketPath, slugify, OBLIGATIONS_DIRNAME } from "./paths.js";
+import { exists, readDir, readDirSubdirs, readTextOrNull, writeText } from "../utils/files/encore-io.js";
 import { WORKSPACE_DIRS } from "../workspace/paths.js";
 import { log } from "../system/logger/index.js";
 import { withLock } from "./lock.js";
 import { reconcileCycleNotifications } from "./reconcile.js";
 import * as encoreNotifier from "./notifier.js";
 import { ENCORE_PLUGIN_PKG } from "./notifier.js";
-import type { PendingClearTicket } from "./tick.js";
+import type { Ticket } from "./tick.js";
 import { startChat } from "../api/routes/agent.js";
 import { PLUGIN_SESSION_ORIGIN_PREFIX } from "../../src/types/session.js";
 import { ENCORE_SEED_ROLE_ID } from "../../src/config/roles.js";
@@ -165,7 +165,7 @@ const ResolveNotificationArgs = z.object({
   pendingId: z.string(),
   /** Bell entry id, spliced onto the navigateTarget at click time
    *  by the host's NotificationBell.vue. Lets us clear orphan bell
-   *  entries whose pending-clear ticket was already swept. */
+   *  entries whose ticket was already swept. */
   notificationId: z.string().optional(),
 });
 
@@ -341,7 +341,7 @@ async function handleQuery(args: z.infer<typeof QueryArgs>): Promise<EncoreDispa
   if (args.obligationId) {
     obligationIds = [args.obligationId];
   } else {
-    obligationIds = (await readDir(OBLIGATIONS_DIRNAME)).sort();
+    obligationIds = (await readDirSubdirs(OBLIGATIONS_DIRNAME)).sort();
   }
 
   const results: QueryObligationResult[] = [];
@@ -598,12 +598,12 @@ async function handleOrphanResolve(args: z.infer<typeof ResolveNotificationArgs>
   return {
     ok: false,
     orphan: true,
-    message: `Encore: this notification has already been resolved (the pending-clear ticket is gone). Bell entry cleared.`,
-    error: "pending-clear ticket not found",
+    message: `Encore: this notification has already been resolved (the ticket is gone). Bell entry cleared.`,
+    error: "ticket not found",
   };
 }
 
-async function seedChatForTicket(ticket: PendingClearTicket, ticketRel: string, pendingId: string): Promise<string> {
+async function seedChatForTicket(ticket: Ticket, ticketRel: string, pendingId: string): Promise<string> {
   const chatSessionId = makeUuid();
   const result = await startChat({
     message: ticket.seedPrompt,
@@ -625,15 +625,15 @@ async function seedChatForTicket(ticket: PendingClearTicket, ticketRel: string, 
 }
 
 async function handleResolveNotification(args: z.infer<typeof ResolveNotificationArgs>): Promise<EncoreDispatchResult> {
-  const ticketRel = pendingClearPath(args.pendingId);
+  const ticketRel = ticketPath(args.pendingId);
   const raw = await readTextOrNull(ticketRel);
   if (raw === null) return handleOrphanResolve(args);
 
-  let ticket: PendingClearTicket;
+  let ticket: Ticket;
   try {
-    ticket = JSON.parse(raw) as PendingClearTicket;
+    ticket = JSON.parse(raw) as Ticket;
   } catch (err) {
-    throw new EncoreError(500, `pending-clear ticket ${JSON.stringify(args.pendingId)} is unparseable`, {
+    throw new EncoreError(500, `ticket ${JSON.stringify(args.pendingId)} is unparseable`, {
       error: err instanceof Error ? err.message : String(err),
     });
   }

--- a/server/encore/notifier.ts
+++ b/server/encore/notifier.ts
@@ -76,3 +76,16 @@ export async function publish(args: PublishArgs): Promise<{ id: string }> {
 export async function clear(entryId: string): Promise<void> {
   await engine.clearForPlugin(ENCORE_PLUGIN_PKG, entryId);
 }
+
+/** True iff a live bell with this id still exists in the notifier
+ *  AND belongs to Encore. Used by the reconciler to detect "ghost
+ *  tickets" — a ticket whose bell was dismissed out-of-band by the
+ *  host UI (or wiped by a crashed active.json) so that the next
+ *  tick republishes instead of trusting ticket-existence as proof
+ *  of bell-existence. Cross-plugin entries (theoretically
+ *  impossible since the notifier ids are namespaced, but defense
+ *  in depth) read as not-ours. */
+export async function bellExists(entryId: string): Promise<boolean> {
+  const entry = await engine.get(entryId);
+  return entry !== undefined && entry.pluginPkg === ENCORE_PLUGIN_PKG;
+}

--- a/server/encore/paths.ts
+++ b/server/encore/paths.ts
@@ -6,7 +6,7 @@
 //
 //   obligations/<obligationId>/index.md      ← DSL + free-form body
 //   obligations/<obligationId>/<cycleId>.md  ← per-cycle state + body
-//   pending-clear/<pendingId>.json           ← chat-on-mount tickets
+//   tickets/<pendingId>.json                 ← live-bell tickets (chat-on-mount)
 //
 // `obligationId` and `cycleId` flow through the kebab-id validator
 // upstream (DSL schema) and the cadence id formatter — never raw
@@ -25,7 +25,7 @@ function assertSafeSegment(label: string, value: string): void {
 }
 
 export const OBLIGATIONS_DIRNAME = "obligations";
-export const PENDING_CLEAR_DIRNAME = "pending-clear";
+export const TICKETS_DIRNAME = "tickets";
 
 /** "obligations" — relative to the plugin root. */
 export function obligationsDir(): string {
@@ -49,10 +49,13 @@ export function cycleFilePath(obligationId: string, cycleId: string): string {
   return path.join(obligationDir(obligationId), `${cycleId}.md`);
 }
 
-/** "pending-clear/<pendingId>.json" — the chat-on-mount ticket. */
-export function pendingClearPath(pendingId: string): string {
+/** "tickets/<pendingId>.json" — the live-bell ticket (carries the
+ *  seed prompt for chat-on-mount, the severity baseline for
+ *  escalation diff, and the chatSessionId binding once the user
+ *  has clicked the bell at least once). */
+export function ticketPath(pendingId: string): string {
   assertSafeSegment("pendingId", pendingId);
-  return path.join(PENDING_CLEAR_DIRNAME, `${pendingId}.json`);
+  return path.join(TICKETS_DIRNAME, `${pendingId}.json`);
 }
 
 /** Slugify a display name into a kebab-case id. Deterministic,

--- a/server/encore/reconcile.ts
+++ b/server/encore/reconcile.ts
@@ -3,7 +3,7 @@
 // Every state-mutating handler funnels through `reconcileCycleNotifications`,
 // and the time-driven tick walks all obligations through the same call. This
 // is the ONLY production code path that invokes `encoreNotifier.publish` /
-// `encoreNotifier.clear` and writes/unlinks pending-clear tickets — the one
+// `encoreNotifier.clear` and writes/unlinks tickets — the one
 // documented exception is `handleOrphanResolve` in dispatch.ts (recovery
 // path for a click that lost its ticket).
 //
@@ -25,10 +25,10 @@ import type { EncoreDsl, Severity, StepDef } from "../../src/types/encore-dsl/sc
 import { parseIndexFile } from "./obligation.js";
 import { buildCycleState, isStepSnoozed, parseCycleFile, serializeCycleFile, type CycleState, type TargetRecord } from "./cycle.js";
 import { isCycleClosed, isStepClosed } from "./closure.js";
-import { cycleFilePath, obligationDir, obligationIndexPath, pendingClearPath, PENDING_CLEAR_DIRNAME } from "./paths.js";
+import { cycleFilePath, obligationDir, obligationIndexPath, ticketPath, TICKETS_DIRNAME } from "./paths.js";
 import { exists, readDir, readTextOrNull, writeText, unlink } from "../utils/files/encore-io.js";
 import * as encoreNotifier from "./notifier.js";
-import type { PendingClearTicket } from "./tick.js";
+import type { Ticket } from "./tick.js";
 
 export interface ReconcileDeps {
   obligationId: string;
@@ -176,7 +176,7 @@ interface TicketSurvivor {
 async function trimOrEscalateTicket(
   dsl: EncoreDsl,
   state: CycleState,
-  ticket: PendingClearTicket,
+  ticket: Ticket,
   todayIso: string,
   nowIso: string,
   log: typeof defaultLog,
@@ -188,7 +188,7 @@ async function trimOrEscalateTicket(
     // clear failed, keep the ticket on disk so the next reconcile
     // retries — unlinking an un-cleared bell would orphan it.
     if (await safeClearBell(ticket.notificationId, "step removed", log)) {
-      await unlink(pendingClearPath(ticket.pendingId));
+      await unlink(ticketPath(ticket.pendingId));
     }
     return null;
   }
@@ -197,7 +197,7 @@ async function trimOrEscalateTicket(
 
   if (liveTargets.length === 0) {
     if (await safeClearBell(ticket.notificationId, "bundle drained", log)) {
-      await unlink(pendingClearPath(ticket.pendingId));
+      await unlink(ticketPath(ticket.pendingId));
     }
     return null;
   }
@@ -205,41 +205,22 @@ async function trimOrEscalateTicket(
   const phase = currentPhaseFor(stepDef, state, todayIso);
   const severityChanged = phase !== null && phase.severity !== ticket.severity;
   const targetsChanged = liveTargets.length !== ticket.targets.length;
+  // Ghost-ticket detection. The reconciler historically treated
+  // ticket-existence as proof of bell-existence, so a bell dismissed
+  // out-of-band by the host UI (or wiped by a crashed active.json)
+  // stayed gone until severity escalation or the 30-day orphan
+  // prune. Cross-checking the notifier here lets the next tick
+  // republish using the ticket's existing pendingId / seedPrompt /
+  // chatSessionId — the user sees the bell again, the chat
+  // continuity survives, and manual dismiss becomes a "see it next
+  // tick" gesture rather than an accidental silencer. `snooze` is
+  // still the explicit verb for time-bound silence.
+  const bellAlive = await encoreNotifier.bellExists(ticket.notificationId);
 
-  if (severityChanged) {
-    // Escalation. Clear the old bell entry and republish at the new
-    // severity with the trimmed bundle. If the clear failed, bail
-    // BEFORE publishing — otherwise the old bell would remain while
-    // we attach a fresh ticket to a new id, leaving a duplicate.
-    if (!(await safeClearBell(ticket.notificationId, "severity escalation", log))) {
-      log.warn("encore", "reconcile: skipping escalation; clear failed", {
-        pendingId: ticket.pendingId,
-        notificationId: ticket.notificationId,
-      });
-      return { targets: liveTargets };
-    }
-    const members = liveTargets.map((targetId) => ({ targetId }));
-    const title = bundleTitle(dsl, stepDef, members);
-    const body = bundleBody(dsl, stepDef, members);
-    const navigateTarget = encoreUrlFor(ticket.pendingId);
-    const { id: newId } = await encoreNotifier.publish({ severity: phase.severity, title, body, navigateTarget });
-    // Roll back the just-published bell entry if the ticket write
-    // fails — otherwise the bell would have no matching ticket and
-    // the next reconcile would see "un-fired" → publish a duplicate.
-    try {
-      await writeTicket({ ...ticket, notificationId: newId, severity: phase.severity, targets: liveTargets });
-    } catch (err) {
-      await safeClearBell(newId, "rollback: ticket write failed after escalation publish", log);
-      throw err;
-    }
-    log.info("encore", "reconcile: escalated", {
-      obligationId: dsl.id,
-      cycleId: state.cycleId,
-      stepId: stepDef.id,
-      from: ticket.severity,
-      to: phase.severity,
-      notificationId: newId,
-    });
+  if (severityChanged || !bellAlive) {
+    const reason = !bellAlive ? "ghost-ticket republish" : "severity escalation";
+    const newSeverity = phase?.severity ?? ticket.severity;
+    await clearAndRepublish({ dsl, state, ticket, stepDef, liveTargets, newSeverity, reason, bellAlive, log });
     return { targets: liveTargets };
   }
 
@@ -259,9 +240,67 @@ async function trimOrEscalateTicket(
   return { targets: liveTargets };
 }
 
-function dedupeTickets(tickets: PendingClearTicket[]): PendingClearTicket[] {
+/** Clear (if alive) and republish a ticket's bell with a fresh
+ *  notificationId. Used by both the severity-escalation path (bell
+ *  alive, new phase reached) and the ghost-ticket path (bell was
+ *  manually dismissed or wiped). Preserves the ticket's pendingId,
+ *  seedPrompt, createdAt, and chatSessionId — those are the chat-
+ *  continuity binding the user expects to survive.
+ *
+ *  Returns true on success, false if the alive-bell clear failed
+ *  (in which case the ticket is left as-is so a later reconcile
+ *  retries). A ghost clear can't fail meaningfully (the bell is
+ *  already gone) so we always proceed to publish in that case. */
+interface RepublishArgs {
+  dsl: EncoreDsl;
+  state: CycleState;
+  ticket: Ticket;
+  stepDef: StepDef;
+  liveTargets: string[];
+  newSeverity: Severity;
+  reason: string;
+  bellAlive: boolean;
+  log: typeof defaultLog;
+}
+
+async function clearAndRepublish(args: RepublishArgs): Promise<boolean> {
+  const { dsl, state, ticket, stepDef, liveTargets, newSeverity, reason, bellAlive, log } = args;
+  if (bellAlive && !(await safeClearBell(ticket.notificationId, reason, log))) {
+    log.warn("encore", "reconcile: skipping republish; clear failed", {
+      pendingId: ticket.pendingId,
+      notificationId: ticket.notificationId,
+      reason,
+    });
+    return false;
+  }
+  const members = liveTargets.map((targetId) => ({ targetId }));
+  const title = bundleTitle(dsl, stepDef, members);
+  const body = bundleBody(dsl, stepDef, members);
+  const navigateTarget = encoreUrlFor(ticket.pendingId);
+  const { id: newId } = await encoreNotifier.publish({ severity: newSeverity, title, body, navigateTarget });
+  // Roll back the just-published bell entry if the ticket write
+  // fails — otherwise the bell would have no matching ticket and
+  // the next reconcile would see "un-fired" → publish a duplicate.
+  try {
+    await writeTicket({ ...ticket, notificationId: newId, severity: newSeverity, targets: liveTargets });
+  } catch (err) {
+    await safeClearBell(newId, `rollback: ticket write failed after ${reason}`, log);
+    throw err;
+  }
+  log.info("encore", `reconcile: ${reason}`, {
+    obligationId: dsl.id,
+    cycleId: state.cycleId,
+    stepId: stepDef.id,
+    from: ticket.severity,
+    to: newSeverity,
+    notificationId: newId,
+  });
+  return true;
+}
+
+function dedupeTickets(tickets: Ticket[]): Ticket[] {
   const seen = new Set<string>();
-  const out: PendingClearTicket[] = [];
+  const out: Ticket[] = [];
   for (const ticket of tickets) {
     if (seen.has(ticket.pendingId)) continue;
     seen.add(ticket.pendingId);
@@ -330,7 +369,7 @@ async function fireGroup(dsl: EncoreDsl, state: CycleState, group: BundleGroup, 
   const title = bundleTitle(dsl, group.stepDef, group.members);
   const body = bundleBody(dsl, group.stepDef, group.members);
   const { id: notificationId } = await encoreNotifier.publish({ severity: group.severity, title, body, navigateTarget });
-  const ticket: PendingClearTicket = {
+  const ticket: Ticket = {
     pendingId,
     obligationId: dsl.id ?? "",
     cycleId: state.cycleId,
@@ -413,16 +452,16 @@ function slotFromCycleId(cadence: EncoreDsl["cadence"], cycleId: string): CycleS
 // ── clear-all helpers ─────────────────────────────────────────────
 
 async function clearAllForObligation(obligationId: string, reason: string, log: typeof defaultLog): Promise<void> {
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
+  const entries = await readDir(TICKETS_DIRNAME);
   let cleared = 0;
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
-    const rel = path.join(PENDING_CLEAR_DIRNAME, entry);
+    const rel = path.join(TICKETS_DIRNAME, entry);
     const raw = await readTextOrNull(rel);
     if (!raw) continue;
-    let ticket: PendingClearTicket;
+    let ticket: Ticket;
     try {
-      ticket = JSON.parse(raw) as PendingClearTicket;
+      ticket = JSON.parse(raw) as Ticket;
     } catch {
       continue;
     }
@@ -443,7 +482,7 @@ async function clearAllForCycle(obligationId: string, cycleId: string, reason: s
   let cleared = 0;
   for (const ticket of tickets) {
     if (await safeClearBell(ticket.notificationId, reason, log)) {
-      await unlink(pendingClearPath(ticket.pendingId));
+      await unlink(ticketPath(ticket.pendingId));
       cleared += 1;
     }
   }
@@ -562,19 +601,19 @@ function buildSeedPrompt(dsl: EncoreDsl, group: BundleGroup, pendingId: string, 
 
 // ── ticket I/O ────────────────────────────────────────────────────
 
-async function writeTicket(ticket: PendingClearTicket): Promise<void> {
-  await writeText(pendingClearPath(ticket.pendingId), JSON.stringify(ticket, null, 2));
+async function writeTicket(ticket: Ticket): Promise<void> {
+  await writeText(ticketPath(ticket.pendingId), JSON.stringify(ticket, null, 2));
 }
 
-async function ticketsForCycle(obligationId: string, cycleId: string): Promise<PendingClearTicket[]> {
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
-  const out: PendingClearTicket[] = [];
+async function ticketsForCycle(obligationId: string, cycleId: string): Promise<Ticket[]> {
+  const entries = await readDir(TICKETS_DIRNAME);
+  const out: Ticket[] = [];
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
-    const raw = await readTextOrNull(path.join(PENDING_CLEAR_DIRNAME, entry));
+    const raw = await readTextOrNull(path.join(TICKETS_DIRNAME, entry));
     if (!raw) continue;
     try {
-      const ticket = JSON.parse(raw) as PendingClearTicket;
+      const ticket = JSON.parse(raw) as Ticket;
       if (ticket.obligationId === obligationId && ticket.cycleId === cycleId) {
         out.push(ticket);
       }

--- a/server/encore/tick.ts
+++ b/server/encore/tick.ts
@@ -6,14 +6,14 @@
 //
 //   1. For every obligation directory, reconcile the latest cycle.
 //   2. Sweep stuck tickets — reconcile any (obligationId, cycleId)
-//      pair found in pending-clear/ that step 1 didn't cover. This
+//      pair found in tickets/ that step 1 didn't cover. This
 //      retries clear failures on closed/non-latest cycles, which
 //      step 1 alone would skip (it only picks the latest cycle).
-//   3. Prune orphan pending-clear tickets older than 30 days.
+//   3. Prune orphan tickets older than 30 days.
 //
-// `PendingClearTicket` still lives here because dispatch.ts, reconcile.ts,
-// and the host UI all import the type — keeping it adjacent to the on-disk
-// shape (the only consumer is `pending-clear/*.json`) makes the locus of
+// `Ticket` still lives here because dispatch.ts, reconcile.ts, and
+// the host UI all import the type — keeping it adjacent to the on-disk
+// shape (the only consumer is `tickets/*.json`) makes the locus of
 // schema changes obvious.
 
 import path from "node:path";
@@ -21,8 +21,8 @@ import path from "node:path";
 import { log as defaultLog } from "../system/logger/index.js";
 import { ONE_DAY_MS } from "../utils/time.js";
 import type { Severity } from "../../src/types/encore-dsl/schema.js";
-import { PENDING_CLEAR_DIRNAME, OBLIGATIONS_DIRNAME } from "./paths.js";
-import { readDir, readTextOrNull, unlink } from "../utils/files/encore-io.js";
+import { TICKETS_DIRNAME, OBLIGATIONS_DIRNAME } from "./paths.js";
+import { readDir, readDirSubdirs, readTextOrNull, unlink } from "../utils/files/encore-io.js";
 import * as encoreNotifier from "./notifier.js";
 import { reconcileCycleNotifications } from "./reconcile.js";
 
@@ -33,12 +33,19 @@ export interface TickDeps {
   log?: typeof defaultLog;
 }
 
-/** Shape of a pending-clear ticket on disk. Authoritative record
- *  of every live Encore bell entry: which obligation+cycle+step it
- *  belongs to, which targets it covers, what severity it was
- *  published at (used for escalation diff), and the seed prompt
- *  resolveNotification will use to start the chat on user click. */
-export interface PendingClearTicket {
+/** Shape of a ticket on disk. Authoritative record of every live
+ *  Encore bell entry: which obligation+cycle+step it belongs to,
+ *  which targets it covers, what severity it was published at
+ *  (used for escalation diff), and the seed prompt
+ *  resolveNotification will use to start the chat on user click.
+ *
+ *  A ticket's existence asserts that a matching bell is alive and
+ *  awaiting a `clear` operation. Tickets are regeneratable cache
+ *  for everything except `chatSessionId` (the binding to a user's
+ *  open chat); a sweep of `tickets/*.json` plus the matching bell
+ *  entries leaves the system in a recoverable state — the
+ *  reconciler rebuilds from cycle files on the next tick. */
+export interface Ticket {
   pendingId: string;
   obligationId: string;
   cycleId: string;
@@ -60,7 +67,7 @@ export interface PendingClearTicket {
 
 export async function runTick(deps: TickDeps): Promise<void> {
   const log = deps.log ?? defaultLog;
-  const obligationIds = await readDir(OBLIGATIONS_DIRNAME);
+  const obligationIds = await readDirSubdirs(OBLIGATIONS_DIRNAME);
   for (const obligationId of obligationIds) {
     try {
       await reconcileCycleNotifications({ obligationId, now: deps.now, log });
@@ -84,13 +91,13 @@ export async function runTick(deps: TickDeps): Promise<void> {
 // (until the 30-day age-based prune).
 //
 // This sweep collects every (obligationId, cycleId) pair present in
-// pending-clear/ and reconciles each. It overlaps Phase 1 for the
+// tickets/ and reconciles each. It overlaps Phase 1 for the
 // latest cycle, but reconcile is idempotent (proven by the
 // "idempotency" test in test_encore_reconcile.ts) so the redundancy
 // is cheap and the contract stays simple.
 
 async function sweepStuckTickets(knownObligationIds: Set<string>, now: Date, log: typeof defaultLog): Promise<void> {
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
+  const entries = await readDir(TICKETS_DIRNAME);
   const pairsToReconcile = await collectStuckCyclePairs(entries, knownObligationIds);
   for (const pair of pairsToReconcile) {
     try {
@@ -110,11 +117,11 @@ async function collectStuckCyclePairs(entries: string[], knownObligationIds: Set
   const out: { obligationId: string; cycleId: string }[] = [];
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
-    const raw = await readTextOrNull(path.join(PENDING_CLEAR_DIRNAME, entry));
+    const raw = await readTextOrNull(path.join(TICKETS_DIRNAME, entry));
     if (!raw) continue;
-    let ticket: PendingClearTicket;
+    let ticket: Ticket;
     try {
-      ticket = JSON.parse(raw) as PendingClearTicket;
+      ticket = JSON.parse(raw) as Ticket;
     } catch {
       continue;
     }
@@ -131,17 +138,16 @@ async function collectStuckCyclePairs(entries: string[], knownObligationIds: Set
 
 // ── orphan ticket sweep (time-driven, lives here not in reconcile) ──
 //
-// Orphan tickets are pending-clear records older than 30 days that
-// somehow weren't trimmed by reconcile (e.g. the cycle file was
-// deleted manually, or a host crash left a ticket without its bell
-// counterpart). The sweep is age-based, not state-based, so it
-// belongs with the time-driven tick rather than the state-driven
-// reconciler.
+// Orphan tickets are records older than 30 days that somehow weren't
+// trimmed by reconcile (e.g. the cycle file was deleted manually,
+// or a host crash left a ticket without its bell counterpart). The
+// sweep is age-based, not state-based, so it belongs with the
+// time-driven tick rather than the state-driven reconciler.
 
 async function pruneOneTicket(rel: string, raw: string, now: Date, log: typeof defaultLog): Promise<void> {
-  let ticket: PendingClearTicket;
+  let ticket: Ticket;
   try {
-    ticket = JSON.parse(raw) as PendingClearTicket;
+    ticket = JSON.parse(raw) as Ticket;
   } catch {
     await unlink(rel);
     return;
@@ -162,10 +168,10 @@ async function pruneOneTicket(rel: string, raw: string, now: Date, log: typeof d
 }
 
 async function pruneOrphanTickets(now: Date, log: typeof defaultLog): Promise<void> {
-  const entries = await readDir(PENDING_CLEAR_DIRNAME);
+  const entries = await readDir(TICKETS_DIRNAME);
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
-    const rel = path.join(PENDING_CLEAR_DIRNAME, entry);
+    const rel = path.join(TICKETS_DIRNAME, entry);
     const raw = await readTextOrNull(rel);
     if (!raw) continue;
     await pruneOneTicket(rel, raw, now, log);

--- a/server/utils/files/encore-io.ts
+++ b/server/utils/files/encore-io.ts
@@ -85,6 +85,20 @@ export async function readDir(rel: string, workspaceRoot?: string): Promise<stri
   }
 }
 
+/** Like `readDir`, but returns only entries that are themselves
+ *  directories. Used to enumerate obligation IDs without tripping
+ *  over `.DS_Store` and other stray non-directory entries that
+ *  macOS and editors drop into the tree. */
+export async function readDirSubdirs(rel: string, workspaceRoot?: string): Promise<string[]> {
+  try {
+    const entries = await fsPromises.readdir(abs(rel, workspaceRoot), { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  } catch (err) {
+    if (isEnoent(err)) return [];
+    throw err;
+  }
+}
+
 /** Remove a file. No-op if it doesn't exist (matches the semantics
  *  callers want when sweeping orphan tickets). */
 export async function unlink(rel: string, workspaceRoot?: string): Promise<void> {

--- a/src/plugins/encore/View.vue
+++ b/src/plugins/encore/View.vue
@@ -18,7 +18,7 @@
 // Notification clearing is NOT done here — that's the LLM's job
 // once it's talking to the user in the resulting chat (the LLM
 // calls markStepDone / markTargetSkipped with the pendingId; the
-// MCP handler reads the pending-clear ticket and calls
+// MCP handler reads the ticket and calls
 // notifier.clear). The only clear-here case is an orphan ticket
 // (already swept) — the server clears the bell entry by
 // notificationId and returns { orphan: true }, and we render the
@@ -42,7 +42,7 @@ const pendingId = computed<string | null>(() => {
 // The host's NotificationBell.vue splices `notificationId=<entryId>`
 // onto every navigateTarget at click time (see appendNotificationId
 // in src/components/NotificationBell.vue). Reading it lets the
-// server clear orphan bell entries whose pending-clear ticket was
+// server clear orphan bell entries whose ticket was
 // already swept.
 const notificationId = computed<string | null>(() => {
   if (typeof window === "undefined") return null;

--- a/src/types/encore-dsl/cadence.ts
+++ b/src/types/encore-dsl/cadence.ts
@@ -17,25 +17,33 @@ import { z } from "zod";
 
 // ── ISO date helpers ────────────────────────────────────────────
 
-/** Format a Date as `YYYY-MM-DD` in UTC. The whole cadence math is
- *  date-only (no time-of-day), so UTC vs local mostly doesn't
- *  matter — but staying consistent in one zone makes "is today on
- *  or after deadline?" boundaries deterministic across servers. */
+/** Format a Date as `YYYY-MM-DD` in the server's LOCAL timezone.
+ *  Encore obligations are wall-clock obligations ("pay rent on the
+ *  1st" means the 1st in the user's calendar, not the 1st in UTC),
+ *  so cycle boundaries must follow the host's wall clock. Matches
+ *  the journal subsystem's `toLocalIsoDate` convention in
+ *  `server/utils/date.ts`. */
 export function isoDate(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
-function utcDate(year: number, monthZero: number, day: number): Date {
-  return new Date(Date.UTC(year, monthZero, day));
+function localDate(year: number, monthZero: number, day: number): Date {
+  return new Date(year, monthZero, day);
+}
+
+/** Parse a YYYY-MM-DD string to a local-midnight Date. */
+function parseLocalIsoDate(iso: string): Date {
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(year, month - 1, day);
 }
 
 /** Add N calendar days to an ISO date (returns ISO). */
 export function addDays(iso: string, days: number): string {
   const [year, month, day] = iso.split("-").map(Number);
-  return isoDate(utcDate(year, month - 1, day + days));
+  return isoDate(localDate(year, month - 1, day + days));
 }
 
 /** Lexicographic ISO compare. -1 / 0 / 1. */
@@ -54,27 +62,27 @@ const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
  *  cases where a date's calendar year and ISO-week year differ. */
 function isoWeekYearAndNumber(date: Date): { year: number; week: number } {
   // Copy to avoid mutating caller.
-  const thursdayOfWeek = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-  const dayNum = (thursdayOfWeek.getUTCDay() + 6) % 7; // Mon=0 … Sun=6
-  thursdayOfWeek.setUTCDate(thursdayOfWeek.getUTCDate() - dayNum + 3);
-  const firstThursday = new Date(Date.UTC(thursdayOfWeek.getUTCFullYear(), 0, 4));
-  const firstThursdayDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  const thursdayOfWeek = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const dayNum = (thursdayOfWeek.getDay() + 6) % 7; // Mon=0 … Sun=6
+  thursdayOfWeek.setDate(thursdayOfWeek.getDate() - dayNum + 3);
+  const firstThursday = new Date(thursdayOfWeek.getFullYear(), 0, 4);
+  const firstThursdayDayNum = (firstThursday.getDay() + 6) % 7;
   const firstThursdayWeekStart = new Date(firstThursday);
-  firstThursdayWeekStart.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNum);
+  firstThursdayWeekStart.setDate(firstThursday.getDate() - firstThursdayDayNum);
   const diffMs = thursdayOfWeek.getTime() - firstThursdayWeekStart.getTime();
   const week = 1 + Math.round(diffMs / MS_PER_WEEK);
-  return { year: thursdayOfWeek.getUTCFullYear(), week };
+  return { year: thursdayOfWeek.getFullYear(), week };
 }
 
 /** Monday of the given ISO week (returns ISO date). */
 function isoWeekMonday(year: number, week: number): string {
   // Jan 4 is always in week 1.
-  const jan4 = new Date(Date.UTC(year, 0, 4));
-  const jan4DayNum = (jan4.getUTCDay() + 6) % 7;
+  const jan4 = new Date(year, 0, 4);
+  const jan4DayNum = (jan4.getDay() + 6) % 7;
   const mondayOfWeek1 = new Date(jan4);
-  mondayOfWeek1.setUTCDate(jan4.getUTCDate() - jan4DayNum);
+  mondayOfWeek1.setDate(jan4.getDate() - jan4DayNum);
   const target = new Date(mondayOfWeek1);
-  target.setUTCDate(mondayOfWeek1.getUTCDate() + (week - 1) * 7);
+  target.setDate(mondayOfWeek1.getDate() + (week - 1) * 7);
   return isoDate(target);
 }
 
@@ -149,28 +157,28 @@ export function currentCycleSlot(cadence: Cadence, now: Date): CycleSlot {
   // would roll over one day early on the deadline day. ISO-string
   // lexical compare is calendar-correct for YYYY-MM-DD.
   const todayIso = isoDate(now);
-  const year = now.getUTCFullYear();
+  const year = now.getFullYear();
   if (cadence.type === "annual") {
     const [{ month, day }] = cadence.cycles;
-    const thisYearDeadlineIso = isoDate(utcDate(year, month - 1, day));
+    const thisYearDeadlineIso = isoDate(localDate(year, month - 1, day));
     return { kind: "annual", year: todayIso <= thisYearDeadlineIso ? year : year + 1 };
   }
   if (cadence.type === "biannual") {
     const [first, second] = cadence.cycles;
-    const firstDeadlineIso = isoDate(utcDate(year, first.month - 1, first.day));
-    const secondDeadlineIso = isoDate(utcDate(year, second.month - 1, second.day));
+    const firstDeadlineIso = isoDate(localDate(year, first.month - 1, first.day));
+    const secondDeadlineIso = isoDate(localDate(year, second.month - 1, second.day));
     if (todayIso <= firstDeadlineIso) return { kind: "biannual", year, half: 1 };
     if (todayIso <= secondDeadlineIso) return { kind: "biannual", year, half: 2 };
     return { kind: "biannual", year: year + 1, half: 1 };
   }
   if (cadence.type === "monthly") {
-    const monthZero = now.getUTCMonth();
-    const deadlineThisMonthIso = isoDate(utcDate(year, monthZero, cadence.day));
+    const monthZero = now.getMonth();
+    const deadlineThisMonthIso = isoDate(localDate(year, monthZero, cadence.day));
     if (todayIso <= deadlineThisMonthIso) {
       return { kind: "monthly", year, month: monthZero + 1 };
     }
-    const next = utcDate(year, monthZero + 1, 1);
-    return { kind: "monthly", year: next.getUTCFullYear(), month: next.getUTCMonth() + 1 };
+    const next = localDate(year, monthZero + 1, 1);
+    return { kind: "monthly", year: next.getFullYear(), month: next.getMonth() + 1 };
   }
   if (cadence.type === "weekly") {
     const targetIdx = DAY_OF_WEEK.indexOf(cadence.dayOfWeek);
@@ -181,8 +189,7 @@ export function currentCycleSlot(cadence: Cadence, now: Date): CycleSlot {
       return { kind: "weekly", year: isoYear, week };
     }
     const nextMondayIso = addDays(monday, 7);
-    const nextMondayDate = new Date(`${nextMondayIso}T00:00:00Z`);
-    const next = isoWeekYearAndNumber(nextMondayDate);
+    const next = isoWeekYearAndNumber(parseLocalIsoDate(nextMondayIso));
     return { kind: "weekly", year: next.year, week: next.week };
   }
   // daily
@@ -193,14 +200,14 @@ export function currentCycleSlot(cadence: Cadence, now: Date): CycleSlot {
 export function cycleDeadline(cadence: Cadence, slot: CycleSlot): string {
   if (cadence.type === "annual" && slot.kind === "annual") {
     const [{ month, day }] = cadence.cycles;
-    return isoDate(utcDate(slot.year, month - 1, day));
+    return isoDate(localDate(slot.year, month - 1, day));
   }
   if (cadence.type === "biannual" && slot.kind === "biannual") {
     const entry = cadence.cycles[slot.half - 1];
-    return isoDate(utcDate(slot.year, entry.month - 1, entry.day));
+    return isoDate(localDate(slot.year, entry.month - 1, entry.day));
   }
   if (cadence.type === "monthly" && slot.kind === "monthly") {
-    return isoDate(utcDate(slot.year, slot.month - 1, cadence.day));
+    return isoDate(localDate(slot.year, slot.month - 1, cadence.day));
   }
   if (cadence.type === "weekly" && slot.kind === "weekly") {
     const monday = isoWeekMonday(slot.year, slot.week);
@@ -220,21 +227,21 @@ export function cycleDeadline(cadence: Cadence, slot: CycleSlot): string {
 export function cycleStart(cadence: Cadence, slot: CycleSlot): string {
   if (cadence.type === "annual" && slot.kind === "annual") {
     const [{ month, day }] = cadence.cycles;
-    const prevDeadline = isoDate(utcDate(slot.year - 1, month - 1, day));
+    const prevDeadline = isoDate(localDate(slot.year - 1, month - 1, day));
     return addDays(prevDeadline, 1);
   }
   if (cadence.type === "biannual" && slot.kind === "biannual") {
     if (slot.half === 1) {
       const [, second] = cadence.cycles;
-      const prevDeadline = isoDate(utcDate(slot.year - 1, second.month - 1, second.day));
+      const prevDeadline = isoDate(localDate(slot.year - 1, second.month - 1, second.day));
       return addDays(prevDeadline, 1);
     }
     const [first] = cadence.cycles;
-    const prevDeadline = isoDate(utcDate(slot.year, first.month - 1, first.day));
+    const prevDeadline = isoDate(localDate(slot.year, first.month - 1, first.day));
     return addDays(prevDeadline, 1);
   }
   if (cadence.type === "monthly" && slot.kind === "monthly") {
-    return isoDate(utcDate(slot.year, slot.month - 1, 1));
+    return isoDate(localDate(slot.year, slot.month - 1, 1));
   }
   if (cadence.type === "weekly" && slot.kind === "weekly") {
     return isoWeekMonday(slot.year, slot.week);
@@ -266,13 +273,13 @@ export function nextSlot(cadence: Cadence, current: CycleSlot): CycleSlot {
     return { kind: "biannual", year: current.year + 1, half: 1 };
   }
   if (cadence.type === "monthly" && current.kind === "monthly") {
-    const next = utcDate(current.year, current.month, 1);
-    return { kind: "monthly", year: next.getUTCFullYear(), month: next.getUTCMonth() + 1 };
+    const next = localDate(current.year, current.month, 1);
+    return { kind: "monthly", year: next.getFullYear(), month: next.getMonth() + 1 };
   }
   if (cadence.type === "weekly" && current.kind === "weekly") {
     const monday = isoWeekMonday(current.year, current.week);
     const nextMondayIso = addDays(monday, 7);
-    const { year, week } = isoWeekYearAndNumber(new Date(`${nextMondayIso}T00:00:00Z`));
+    const { year, week } = isoWeekYearAndNumber(parseLocalIsoDate(nextMondayIso));
     return { kind: "weekly", year, week };
   }
   if (cadence.type === "daily" && current.kind === "daily") {

--- a/test/plugins/test_encore_dispatch.ts
+++ b/test/plugins/test_encore_dispatch.ts
@@ -8,7 +8,7 @@
 //
 // Per-test isolation:
 //   - `WORKSPACE_PATHS.encore` is redefined to a tmpdir so on-disk
-//     obligation/cycle/pending-clear files don't leak across cases.
+//     obligation/cycle/ticket files don't leak across cases.
 //   - The notifier engine is pointed at tmpdir paths via
 //     `_setFilePathsForTesting` so the bell writes go nowhere
 //     observable to the user.
@@ -219,7 +219,7 @@ describe("Encore dispatch — component tests", () => {
     const before = await listFor("encore");
     assert.equal(before.length, 1, "setup should publish one bell entry");
 
-    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/tickets");
     const entries = await fsPromises.readdir(pendingDir);
     const ticket = JSON.parse(await fsPromises.readFile(path.join(pendingDir, entries[0]), "utf8")) as { pendingId: string };
 
@@ -253,7 +253,7 @@ describe("Encore dispatch — component tests", () => {
     const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
     const { cycleId } = setup;
     if (!cycleId) throw new Error("setup should return cycleId");
-    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/tickets");
     const initialPending = await fsPromises.readdir(pendingDir);
     const initialTicket = JSON.parse(await fsPromises.readFile(path.join(pendingDir, initialPending[0]), "utf8")) as { pendingId: string };
 
@@ -435,7 +435,7 @@ describe("Encore dispatch — component tests", () => {
     assert.equal(before.length, 1, "two targets must bundle into one bell entry");
 
     // Read the ticket — should list both targets.
-    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/tickets");
     const entries = await fsPromises.readdir(pendingDir);
     const ticketRaw = await fsPromises.readFile(path.join(pendingDir, entries[0]), "utf8");
     const ticket = JSON.parse(ticketRaw) as { pendingId: string; targets: string[] };
@@ -484,7 +484,7 @@ describe("Encore dispatch — component tests", () => {
     const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
     const { cycleId } = setup;
     if (!cycleId) throw new Error("setup should return cycleId");
-    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/tickets");
     const entries = await fsPromises.readdir(pendingDir);
     const ticket = JSON.parse(await fsPromises.readFile(path.join(pendingDir, entries[0]), "utf8")) as { pendingId: string };
 
@@ -511,10 +511,10 @@ describe("Encore dispatch — component tests", () => {
 
   it("markStepDone closes the step and clears the bell", async () => {
     const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
-    // After setup, the tick fired and a pending-clear ticket exists.
-    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    // After setup, the tick fired and a ticket exists.
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/tickets");
     const entries = await fsPromises.readdir(pendingDir);
-    assert.equal(entries.length, 1, "expected one pending-clear ticket");
+    assert.equal(entries.length, 1, "expected one ticket");
     const ticketRaw = await fsPromises.readFile(path.join(pendingDir, entries[0]), "utf8");
     const ticket = JSON.parse(ticketRaw) as { pendingId: string; notificationId: string };
 
@@ -547,7 +547,7 @@ describe("Encore dispatch — component tests", () => {
     const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
     const { cycleId } = setup;
     if (!cycleId) throw new Error("setup should return cycleId");
-    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+    const pendingDir = path.join(workspaceRoot, "data/plugins/encore/tickets");
     const initialEntries = await fsPromises.readdir(pendingDir);
     const initialTicket = JSON.parse(await fsPromises.readFile(path.join(pendingDir, initialEntries[0]), "utf8")) as { pendingId: string };
 

--- a/test/plugins/test_encore_reconcile.ts
+++ b/test/plugins/test_encore_reconcile.ts
@@ -18,7 +18,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
-import { _setFilePathsForTesting, listFor } from "../../server/notifier/engine.js";
+import { _setFilePathsForTesting, clearForPlugin, listFor } from "../../server/notifier/engine.js";
 import { _resetLockForTesting } from "../../server/encore/lock.js";
 import { dispatch, type EncoreDispatchResult } from "../../server/encore/dispatch.js";
 import { reconcileCycleNotifications } from "../../server/encore/reconcile.js";
@@ -87,7 +87,7 @@ async function writeCycleRaw(obligationId: string, cycleId: string, raw: string)
 }
 
 async function pendingDirEntries(): Promise<string[]> {
-  const dir = path.join(workspaceRoot, "data/plugins/encore/pending-clear");
+  const dir = path.join(workspaceRoot, "data/plugins/encore/tickets");
   return fsPromises.readdir(dir);
 }
 
@@ -260,7 +260,7 @@ describe("Encore reconciler — unit tests", () => {
     assert.equal(cycleFiles.length, 2, `expected closed + successor cycle, got ${cycleFiles.join(", ")}`);
     assert(cycleFiles[1] > cycleFiles[0], `successor must sort after closed (got ${cycleFiles.join(", ")})`);
 
-    // No pending-clear tickets at all — closed cycle's was unlinked,
+    // No tickets at all — closed cycle's was unlinked,
     // successor hasn't fired anything yet.
     assert.equal((await pendingDirEntries()).length, 0, "no tickets between cycles");
 
@@ -273,6 +273,54 @@ describe("Encore reconciler — unit tests", () => {
     await reconcileCycleNotifications({ obligationId, cycleId: successorCycleId, now: tomorrow });
     const liveTomorrow = await listFor("encore");
     assert.equal(liveTomorrow.length, 1, `successor should fire once now is past its cycle-start; got ${liveTomorrow.length}`);
+  });
+
+  it("ghost ticket: bell dismissed out-of-band → reconciler republishes preserving pendingId", async () => {
+    // Simulates the host UI's manual-dismiss path (user clicks "X"
+    // on the notification menu). The notifier's active.json loses
+    // the bell, but the ticket on disk stays put — chat continuity
+    // and the pendingId binding must survive. Next reconcile should
+    // notice the bell is gone and republish using the ticket's
+    // existing pendingId, with a fresh notificationId.
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId, cycleId } = setup;
+    if (!obligationId || !cycleId) throw new Error("setup should return ids");
+
+    const before = await listFor("encore");
+    assert.equal(before.length, 1, "setup should publish exactly one bell");
+    const originalNotificationId = before[0].id;
+    const ticketsBefore = await pendingDirEntries();
+    assert.equal(ticketsBefore.length, 1, "setup should write exactly one ticket");
+    const [ticketFilename] = ticketsBefore;
+
+    // Snapshot the ticket so we can verify pendingId continuity after
+    // republish. Reading the file directly avoids depending on dispatch
+    // internals; the ticket file is the on-disk source of truth.
+    const ticketPath = path.join(workspaceRoot, "data/plugins/encore/tickets", ticketFilename);
+    const ticketRawBefore = await fsPromises.readFile(ticketPath, "utf8");
+    const ticketBefore = JSON.parse(ticketRawBefore) as { pendingId: string; notificationId: string };
+
+    // Simulate the host UI's manual dismiss: clear the bell directly
+    // via the engine, WITHOUT touching the ticket file.
+    await clearForPlugin("encore", originalNotificationId);
+    assert.equal((await listFor("encore")).length, 0, "manual dismiss must remove the bell");
+    assert.equal((await pendingDirEntries()).length, 1, "manual dismiss must NOT touch the ticket");
+
+    // Next reconcile (e.g. hourly tick or server restart). Should
+    // detect the ghost ticket and republish.
+    await reconcileCycleNotifications({ obligationId, cycleId, now: new Date() });
+
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, "reconcile must republish the bell after manual dismiss");
+    assert.notEqual(after[0].id, originalNotificationId, "republished bell must have a fresh notificationId");
+
+    const ticketsAfter = await pendingDirEntries();
+    assert.equal(ticketsAfter.length, 1, "still exactly one ticket after republish");
+    assert.equal(ticketsAfter[0], ticketFilename, "ticket filename (= pendingId) must be unchanged — that's the binding the chat depends on");
+    const ticketRawAfter = await fsPromises.readFile(ticketPath, "utf8");
+    const ticketAfter = JSON.parse(ticketRawAfter) as { pendingId: string; notificationId: string };
+    assert.equal(ticketAfter.pendingId, ticketBefore.pendingId, "pendingId must survive republish");
+    assert.equal(ticketAfter.notificationId, after[0].id, "ticket must point at the republished bell");
   });
 
   it("snooze expiry: snoozedSteps with past timestamp → reconciler republishes", async () => {
@@ -380,7 +428,7 @@ describe("Encore reconciler — unit tests", () => {
     const after = await listFor("encore");
     assert.equal(after.length, 0, "inactive obligation must have no bell entries");
     const tickets = await pendingDirEntries();
-    assert.equal(tickets.length, 0, "inactive obligation must have no pending-clear tickets");
+    assert.equal(tickets.length, 0, "inactive obligation must have no tickets");
   });
 
   it("runTick Phase 2: sweep revisits stuck tickets on non-latest cycles", async () => {
@@ -388,12 +436,12 @@ describe("Encore reconciler — unit tests", () => {
     // the new "keep ticket on clear failure" contract, a ticket
     // stranded on cycle N can outlive the next tick if Phase 1 only
     // visits the latest cycle (N+1). Phase 2's sweep walks every
-    // pending-clear ticket and reconciles its (obligationId, cycleId)
+    // ticket and reconciles its (obligationId, cycleId)
     // so the strand is retried every tick instead of waiting 30 days
     // for the age-based prune.
     //
     // Setup: create the obligation, then manually install a
-    // closed-cycle file + a leftover pending-clear ticket pointing at
+    // closed-cycle file + a leftover ticket pointing at
     // it. Phase 1 (latest cycle reconcile) won't touch the closed
     // cycle's ticket; Phase 2 must.
     const oneTargetDef = {
@@ -405,7 +453,7 @@ describe("Encore reconciler — unit tests", () => {
     if (!obligationId || !latestCycleId) throw new Error("setup should return ids");
 
     // Inject a closed predecessor cycle file (yesterday) directly on
-    // disk, plus a stranded pending-clear ticket pointing at it.
+    // disk, plus a stranded ticket pointing at it.
     const stuckCycleId = "2026-05-16";
     const stuckCycle = {
       cycleId: stuckCycleId,
@@ -429,7 +477,7 @@ describe("Encore reconciler — unit tests", () => {
       seedPrompt: "stuck",
       createdAt: new Date().toISOString(),
     };
-    const ticketPath = path.join(workspaceRoot, "data/plugins/encore/pending-clear", "stuck-pending-id.json");
+    const ticketPath = path.join(workspaceRoot, "data/plugins/encore/tickets", "stuck-pending-id.json");
     await fsPromises.writeFile(ticketPath, JSON.stringify(stuckTicket, null, 2));
 
     // Sanity: the stuck ticket is on disk and the latest is unrelated.


### PR DESCRIPTION
## Summary

Four related encore fixes, two commits:

### 1. Cadence math now uses server-local time (commit 1)
`cadence.ts` used `getUTCFullYear/Month/Date` throughout, so for users far from UTC the daily cycle rolled over at the wrong hour (e.g. 9 AM JST instead of midnight JST). Encore obligations are wall-clock commitments — *"pay rent on the 1st"* means the 1st in the user's calendar — so all accessors and Date constructors in `src/types/encore-dsl/cadence.ts` now use local time, matching the `toLocalIsoDate` convention used by the journal subsystem in `server/utils/date.ts`.

### 2. Skip non-directory entries when enumerating obligations
`manageEncore({ kind: "query" })` was returning HTTP 500 after deleting all obligations because macOS left a `.DS_Store` under `obligations/` and the handler treated it as an obligation id (`ENOTDIR` on reading its `index.md`). Same bug was firing silently on every hourly tick. Added `readDirSubdirs` helper to `encore-io.ts` and switched the top-level enumerations in `handleQuery` and `runTick` to use it.

### 3. Rename `pending-clear/` → `tickets/`
The code abstraction was already `Ticket` / `writeTicket` / `ticketsForCycle` everywhere — only the folder name and one path helper carried the long form. Renamed `PENDING_CLEAR_DIRNAME` → `TICKETS_DIRNAME`, `pendingClearPath` → `ticketPath`, `PendingClearTicket` → `Ticket`. No data migration: tickets are regeneratable from cycle files. Plan docs under `plans/` still reference the old name; left untouched as historical design records.

### 4. Ghost-ticket republish on next reconcile
When the user manually dismissed an Encore bell from the host UI, the bell disappeared but the ticket remained — fine for chat-session continuity, but the next reconcile *also* left the bell gone because the reconciler trusted ticket-existence as proof of bell-existence. Net effect: dismiss became an accidental silencer until severity escalation or the 30-day orphan prune.

Added `encoreNotifier.bellExists` (queries `engine.get` + verifies `pluginPkg`). Extended `trimOrEscalateTicket` to detect ghost tickets and republish at the current phase's severity, reusing the ticket's `pendingId` / `seedPrompt` / `chatSessionId` — chat continuity survives, but the user sees the bell again on the next tick. Factored the publish path into a `clearAndRepublish` helper shared with severity escalation. New test simulates the manual-dismiss path via `clearForPlugin` and asserts the bell is republished with a fresh `notificationId` but the same `pendingId`.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — clean
- [x] `yarn test` — all 7 suites, 0 failures (includes the new `ghost ticket: bell dismissed out-of-band` case)
- [x] `yarn test:e2e` — 421 Playwright tests pass
- [x] Manual: `manageEncore({ kind: "query" })` with a `.DS_Store` in `obligations/` now returns "no obligations found" instead of 500
- [x] Manual: daily obligation cycle file is named with local-zone date instead of UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification scheduling to use local time instead of UTC, ensuring reminders fire at the intended times.
  * Enhanced handling of notifications dismissed outside the app to prevent duplicate or orphaned reminder bells.

* **Documentation**
  * Updated internal comments to reflect notification storage improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->