### PR TITLE
fix(agent): permit the Skill tool so .claude/skills/ skills are invokable

### DIFF
--- a/plans/fix-skill-tool-allowlist.md
+++ b/plans/fix-skill-tool-allowlist.md
@@ -1,0 +1,86 @@
+# fix: permit the `Skill` tool so `.claude/skills/` skills are invokable
+
+## User prompt
+
+> skill の呼び出しが失敗して、`Skill {skill: "nazonazo"}` → `Execute skill: nazonazo` エラー → `Glob **/nazonazo/**` で探している。なんで？ … ではまず `--allowedTools` だけやろう。
+
+## Root cause (confirmed via claude-code-guide)
+
+`server/agent/config.ts` builds the `claude` CLI invocation with an
+**explicit `--allowedTools` allowlist**:
+
+```ts
+const BASE_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"];
+// …
+const allowedTools = [...BASE_ALLOWED_TOOLS, ...extraAllowedTools, "mcp__mulmoclaude", ...mcpToolNames];
+args = [ …, "--allowedTools", allowedTools.join(","), … ];
+```
+
+`Skill` is **not** in the list. Claude Code gates the `Skill` tool
+(the mechanism the model uses to execute a discovered
+`.claude/skills/<name>/SKILL.md`) through `--allowedTools` like any
+other tool. With a strict allowlist that omits `Skill`, every
+autonomous `Skill({skill:"…"})` call is permission-denied → the
+harness emits `Execute skill: <name>` → the model falls back to
+`Glob`+`Read` to run the SKILL.md as a plain doc.
+
+This is independent of frontmatter (`name:` is optional; the dir slug
+is used when omitted) and of skill placement (cwd = workspace, the
+bridge mirrors into `.claude/skills/` correctly). It affects **all**
+skills uniformly — which matches the observed symptom (`nazonazo`
+with valid `name:` AND `daily-plan` without it both fail identically).
+
+## Scope (this PR — step A only)
+
+Add `"Skill"` to `BASE_ALLOWED_TOOLS`. This permits the model to
+invoke any discovered skill.
+
+### Explicitly out of scope (separate follow-up)
+
+- **(B)** `--system-prompt` full-replace drops Claude Code's default
+  skill listing + skill-use guidance. Even with `Skill` permitted, the
+  model may not know *which* skills exist or *when* to invoke them
+  unless we inject a skill listing into the custom system prompt.
+  That's a design change (the repo deliberately replaces, not appends,
+  the system prompt) and needs its own plan + empirical verification.
+  Tracked as the next step; this PR only unblocks the tool itself.
+- Fixing individual malformed SKILL.md files (`daily-plan` /
+  `shiritori` / `library` missing `name:` / `description:`) — separate
+  workspace-content concern, not a repo code bug.
+
+## Change
+
+`server/agent/config.ts`:
+
+```diff
+-const BASE_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"];
++const BASE_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch", "Skill"];
+```
+
+`"Skill"` (bare, no parens) is the exact token Claude Code matches to
+permit skill execution for all skills (confirmed: the in-repo
+state-machine test already models `toolName: "Skill"`,
+`args: { skill: "<name>" }`).
+
+## Test
+
+Add an assertion in `test/agent/test_agent_config.ts` that the
+`--allowedTools` value contains `Skill`, so a future allowlist edit
+that drops it fails CI rather than silently re-breaking skill
+invocation.
+
+## Validation
+
+- `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
+- Empirical (manual, after merge): invoke `/nazonazo` and an
+  autonomous `Skill` call in a real chat; confirm no `Execute skill`
+  error / Glob fallback. If invocation still fails even with `Skill`
+  permitted, that confirms (B) is also required — proceed to the
+  follow-up plan.
+
+## Risk
+
+Minimal. Widens the tool allowlist by one entry (`Skill`), which is
+the intended capability. No behaviour change for any non-skill path.
+Existing `--allowedTools` tests use `.includes()` membership checks,
+so adding an entry doesn't break them.

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -14,7 +14,14 @@ import { preflightUserServers, logPreflightResult } from "./mcpPreflight.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 
-const BASE_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"];
+// `Skill` is the tool Claude Code uses to execute a discovered
+// `.claude/skills/<name>/SKILL.md`. Because `--allowedTools` is passed
+// as a strict allowlist, omitting it permission-denies every
+// `Skill({skill:"…"})` call — the harness errors with
+// `Execute skill: <name>` and the model falls back to Glob+Read.
+// Bare `Skill` (no parens) permits all skills. See
+// plans/fix-skill-tool-allowlist.md.
+const BASE_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch", "Skill"];
 
 /** Tool names the agent is allowed to call this session. Drives
  *  `PLUGIN_NAMES` env (the MCP child's filter) and the CLI's

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -101,6 +101,16 @@ describe("buildCliArgs", () => {
     assert.ok(allowedStr.includes("Bash"));
   });
 
+  it("permits the Skill tool so .claude/skills/ skills are invokable", async () => {
+    // Regression guard: a strict --allowedTools that omits `Skill`
+    // permission-denies every Skill({skill:"…"}) call (Execute skill
+    // error + Glob fallback). See plans/fix-skill-tool-allowlist.md.
+    const args = buildCliArgs({ systemPrompt: "test", activePlugins: [] });
+    const allowedStr = args[args.indexOf("--allowedTools") + 1];
+    const tools = allowedStr.split(",");
+    assert.ok(tools.includes("Skill"), `--allowedTools must list "Skill" (got: ${allowedStr})`);
+  });
+
   it("includes --resume when claudeSessionId provided", async () => {
     const args = buildCliArgs({
       systemPrompt: "test",


### PR DESCRIPTION
## Summary

`--allowedTools` is a strict allowlist; `Skill` (the tool Claude Code uses to execute a discovered `.claude/skills/<name>/SKILL.md`) was missing from `BASE_ALLOWED_TOOLS`, so every autonomous `Skill({skill:"…"})` call was permission-denied → `Execute skill: <name>` error → model fell back to Glob+Read. One-line allowlist addition + regression test. **Confirmed working empirically by the reporter.**

## Items to Confirm / Review

- This is **step (A) only**. Step (B) — `--system-prompt` full-replace drops Claude Code's default skill listing / use-guidance — is a separate design change (the repo intentionally replaces rather than appends the system prompt). Tracked in `plans/fix-skill-tool-allowlist.md`. The reporter confirmed (A) alone restores invocation, so (B) may not be urgent — but worth a follow-up so the model reliably *discovers* skills, not just *can* invoke them.
- `"Skill"` (bare, no parens) permits ALL discovered skills. Confirm that's the intended capability (it is — the GUI manageSkills Run button + autonomous use both need it).

## Root cause

`server/agent/config.ts`: `BASE_ALLOWED_TOOLS = ["Bash","Read","Write","Edit","Glob","Grep","WebFetch","WebSearch"]` — no `Skill`. Built into `--allowedTools` as a strict allowlist. Affected all skills uniformly regardless of SKILL.md frontmatter or placement, which matched the symptom (well-formed `nazonazo` and malformed `daily-plan` failed identically).

## User Prompt

> skill の呼び出しが失敗して `Skill {skill:"nazonazo"}` → `Execute skill: nazonazo` → `Glob **/nazonazo/**` で探している。なんで？ … skill ってディレクトリ由来では？ tools と skill は別では？ … ではまず `--allowedTools` だけやろう。… 動いた。PR〜マージ。

## Change

- `server/agent/config.ts` — add `"Skill"` to `BASE_ALLOWED_TOOLS` (+ rationale comment)
- `test/agent/test_agent_config.ts` — regression test asserting `--allowedTools` lists `Skill`
- `plans/fix-skill-tool-allowlist.md` — root cause + scope ((A) here, (B) deferred)

## Test plan

- [x] new test: `permits the Skill tool …` (green)
- [x] `yarn format` / `lint` / `typecheck` / `build` clean
- [x] `yarn test` — 4939 pass, 0 fail
- [x] empirical: reporter confirmed `/nazonazo` etc. now invoke without the Execute-skill / Glob fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved skill invocation failures when using strict Claude Code allowlists.

* **Tests**
  * Added regression test to ensure the Skill tool remains included in the allowlist, preventing future invocation failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->