### PR TITLE
feat(textResponse): render plugin-seeded first turn as a skill-style card

### DIFF
--- a/e2e/tests/encore-seeded.spec.ts
+++ b/e2e/tests/encore-seeded.spec.ts
@@ -1,0 +1,112 @@
+// E2E for the plugin-seeded first user turn. When `session_meta`
+// carries a `plugin:<pkg>` origin (e.g. Encore opens a chat via
+// `runtime.chat.start()`), the very first user message is rendered
+// through the skill-style collapsed card path instead of the regular
+// text-response bubble — both in the canvas View and in the
+// chat-history preview.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const SESSION_ID = "encore-seeded-session";
+const PLUGIN_PKG = "@mulmoclaude/encore-plugin";
+const SEEDED_BODY = "Seeded greeting from Encore plugin — please respond.";
+
+async function setupSeededSession(page: Page) {
+  await mockAllApis(page, {
+    sessions: [
+      {
+        id: SESSION_ID,
+        title: "Encore Seeded",
+        roleId: "general",
+        startedAt: "2026-04-15T10:00:00Z",
+        updatedAt: "2026-04-15T10:00:00Z",
+      },
+    ],
+  });
+
+  // Per-session entries override (Playwright matches last-registered
+  // first, so this beats the default in mockAllApis). The `session_meta`
+  // row's `origin` is what flips `parseSessionEntries` into seeding
+  // the first user turn with `data.seededByPlugin`.
+  await page.route(
+    (url) => url.pathname === `/api/sessions/${SESSION_ID}`,
+    (route) =>
+      route.fulfill({
+        json: [
+          {
+            type: "session_meta",
+            roleId: "general",
+            sessionId: SESSION_ID,
+            origin: `plugin:${PLUGIN_PKG}`,
+          },
+          { type: "text", source: "user", message: SEEDED_BODY },
+        ],
+      }),
+  );
+}
+
+test.describe("plugin-seeded first user turn", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupSeededSession(page);
+  });
+
+  test("renders the skill-style collapsed card in the canvas View", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_ID}`);
+    // App-ready signal: the home button renders once the shell mounts.
+    // (Plain `getByText("MulmoClaude")` is ambiguous here because the
+    // seeded fixture's pkg name `@mulmoclaude/encore-plugin` also
+    // matches.)
+    await expect(page.getByTestId("app-home-btn")).toBeVisible();
+
+    const card = page.getByTestId("text-response-seeded-card");
+    await expect(card).toBeVisible();
+
+    // The "from {pkg}" label uses the pluginTextResponse.seededByPlugin
+    // i18n key. Asserting on the visible text keeps the test resilient
+    // to template tweaks while still pinning down the chip content.
+    await expect(card).toContainText(PLUGIN_PKG);
+
+    // The default text-response bubble path must NOT be taken for the
+    // seeded turn — there's no speaker label ("You" / "Assistant")
+    // bubble rendered in the canvas.
+    await expect(page.getByTestId("text-response-assistant-body")).toHaveCount(0);
+  });
+
+  test("collapses body by default and reveals it on summary click", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_ID}`);
+    // App-ready signal: the home button renders once the shell mounts.
+    // (Plain `getByText("MulmoClaude")` is ambiguous here because the
+    // seeded fixture's pkg name `@mulmoclaude/encore-plugin` also
+    // matches.)
+    await expect(page.getByTestId("app-home-btn")).toBeVisible();
+
+    const summary = page.getByTestId("text-response-seeded-summary");
+    await expect(summary).toBeVisible();
+
+    // Body markdown lives inside the `<details>` element and is hidden
+    // until expanded. `<details>` content is `display: none` when the
+    // parent is closed, so toBeVisible() returns false.
+    const body = page.getByTestId("text-response-seeded-card").locator(".markdown-content");
+    await expect(body).toBeHidden();
+
+    await summary.click();
+    await expect(body).toBeVisible();
+    await expect(body).toContainText("Seeded greeting from Encore plugin");
+  });
+
+  test("sidebar preview renders the seeded one-liner, not the markdown excerpt", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_ID}`);
+    // App-ready signal: the home button renders once the shell mounts.
+    // (Plain `getByText("MulmoClaude")` is ambiguous here because the
+    // seeded fixture's pkg name `@mulmoclaude/encore-plugin` also
+    // matches.)
+    await expect(page.getByTestId("app-home-btn")).toBeVisible();
+
+    // The chat-history sidebar uses Preview.vue; the seeded variant
+    // renders only the extension icon + "from {pkg}" label.
+    const preview = page.getByTestId("text-response-preview-seeded");
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText(PLUGIN_PKG);
+  });
+});

--- a/src/plugins/textResponse/Preview.vue
+++ b/src/plugins/textResponse/Preview.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="p-2">
+  <!-- Plugin-seeded first user turn (e.g. Encore): render the same
+       one-line extension-icon + label preview the skill plugin uses,
+       so the chat-history sidebar reads it as "seeded by a plugin"
+       rather than a wall-of-text user message. -->
+  <div v-if="isSeededUserTurn" class="flex items-center gap-1.5 text-sm text-gray-700 p-2" data-testid="text-response-preview-seeded">
+    <span class="material-icons text-purple-500 text-sm shrink-0">extension</span>
+    <span class="truncate font-medium">{{ t("pluginTextResponse.seededByPlugin", { pkg: seededByPlugin }) }}</span>
+  </div>
+  <div v-else class="p-2">
     <div class="preview-text text-sm leading-snug" :class="textColorClass">{{ previewText }}</div>
     <div v-if="attachments.length > 0" class="flex flex-wrap gap-1 mt-1.5" data-testid="text-response-preview-attachments">
       <SentAttachmentChip v-for="path in attachments" :key="path" :path="path" variant="thumb" />
@@ -9,16 +17,21 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "./types";
 import SentAttachmentChip from "../../components/SentAttachmentChip.vue";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   result: ToolResultComplete<TextResponseData>;
 }>();
 
 const messageRole = computed(() => props.result.data?.role ?? "assistant");
+const seededByPlugin = computed<string>(() => props.result.data?.seededByPlugin ?? "");
+const isSeededUserTurn = computed(() => Boolean(seededByPlugin.value) && messageRole.value === "user");
 
 const textColorClass = computed(() => {
   switch (messageRole.value) {

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -1,5 +1,35 @@
 <template>
-  <div class="h-full flex flex-col">
+  <!-- Plugin-seeded first user turn (e.g. Encore): mirror the skill
+       plugin's collapsed-card layout. Skips the assistant chrome
+       (PDF / edit / copy) since the message wasn't authored by the
+       user and editing it post-hoc has no meaning. -->
+  <div v-if="isSeededUserTurn" class="h-full flex flex-col overflow-y-auto p-6" data-testid="text-response-seeded-card">
+    <div class="max-w-3xl mx-auto w-full">
+      <div class="rounded-lg border border-purple-200 bg-purple-50 shadow-sm">
+        <details class="group">
+          <summary class="cursor-pointer list-none p-4 flex items-start gap-3 hover:bg-purple-100/40 rounded-lg" data-testid="text-response-seeded-summary">
+            <span class="material-icons text-purple-600 text-base mt-0.5 shrink-0">extension</span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2 flex-wrap">
+                <span class="font-medium text-purple-900">{{ t("pluginTextResponse.seededByPlugin", { pkg: seededByPlugin }) }}</span>
+              </div>
+              <div class="text-sm text-gray-700 mt-1">{{ t("pluginTextResponse.seededByPluginTooltip", { pkg: seededByPlugin }) }}</div>
+            </div>
+            <span class="material-icons text-gray-400 text-base shrink-0 group-open:rotate-180 transition-transform">expand_more</span>
+          </summary>
+          <div class="border-t border-purple-200 p-4 bg-white rounded-b-lg">
+            <!-- eslint-disable vue/no-v-html -- marked.parse output of the plugin-seeded prompt; trusted in-process render matching the standard textResponse path. Multi-line element so disable/enable pair (CLAUDE.md UI rule). -->
+            <div class="markdown-content prose prose-slate max-w-none" @click="openLinksInNewTab" v-html="renderedHtml"></div>
+            <!-- eslint-enable vue/no-v-html -->
+            <div v-if="messageAttachments.length > 0" class="space-y-3 mt-3" data-testid="text-response-seeded-attachments">
+              <SentAttachmentChip v-for="path in messageAttachments" :key="path" :path="path" variant="block" />
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  </div>
+  <div v-else class="h-full flex flex-col">
     <div v-if="isAssistant" class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
       <button
         class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
@@ -17,23 +47,9 @@
         <div class="text-response-content-wrapper">
           <div class="p-6">
             <div class="max-w-3xl mx-auto space-y-4">
-              <div
-                class="rounded-lg border border-gray-300 bg-white shadow-sm p-5"
-                :class="roleTheme"
-                :data-testid="seededByPlugin ? 'text-response-plugin-seeded' : undefined"
-              >
+              <div class="rounded-lg border border-gray-300 bg-white shadow-sm p-5" :class="roleTheme">
                 <div class="flex justify-between items-start mb-2 text-sm text-gray-500">
-                  <span class="flex items-center gap-2">
-                    <span class="font-medium text-gray-700">{{ speakerLabel }}</span>
-                    <span
-                      v-if="seededByPlugin"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] uppercase font-medium bg-purple-100 text-purple-700 ring-1 ring-purple-200"
-                      :title="t('pluginTextResponse.seededByPluginTooltip', { pkg: seededByPlugin })"
-                      data-testid="text-response-seeded-by-plugin"
-                    >
-                      {{ t("pluginTextResponse.seededByPlugin", { pkg: seededByPlugin }) }}
-                    </span>
-                  </span>
+                  <span class="font-medium text-gray-700">{{ speakerLabel }}</span>
                   <span v-if="transportKind" class="italic">{{ transportKind }}</span>
                 </div>
                 <!-- eslint-disable vue/no-v-html -- marked.parse output of app-owned assistant response text; trusted in-process render. Multi-line element so disable/enable pair (CLAUDE.md UI rule) instead of -next-line. -->
@@ -126,6 +142,12 @@ const messageAttachments = computed<string[]>(() => props.selectedResult.data?.a
 // muted background variant so the user can tell the message came
 // from a plugin and not themselves.
 const seededByPlugin = computed<string>(() => props.selectedResult.data?.seededByPlugin ?? "");
+// First-user-turn-seeded-by-plugin signal (#1218-adjacent): render
+// the skill-style collapsed card path instead of the default user
+// bubble. `parseSessionEntries` only stamps `seededByPlugin` on the
+// very first user turn of a plugin-origin session, so this branch is
+// inherently scoped to the opening message.
+const isSeededUserTurn = computed(() => Boolean(seededByPlugin.value) && messageRole.value === "user");
 
 const renderedHtml = computed(() => {
   if (!messageText.value) return "";
@@ -164,13 +186,6 @@ const speakerLabel = computed(() => {
 });
 
 const roleTheme = computed(() => {
-  // Plugin-seeded user turns get a muted gray background instead of
-  // the standard "user" green so the row reads as "this came from a
-  // plugin, not you." The chip beside the speaker label carries the
-  // pkg name; the background change is the at-a-glance signal.
-  if (seededByPlugin.value && messageRole.value === "user") {
-    return "bg-gray-50 border-gray-200";
-  }
   switch (messageRole.value) {
     case "system":
       return "bg-blue-50 border-blue-200";


### PR DESCRIPTION
## Summary
- When a chat is opened via `runtime.chat.start()` (e.g. Encore), `parseSessionEntries` already stamps `data.seededByPlugin` on the very first user turn. The textResponse View and Preview now route that turn through a collapsed extension-icon card that mirrors `src/plugins/skill/View.vue` / `Preview.vue`, so the seeded prompt reads as "from a plugin" at a glance instead of impersonating a user-authored bubble.
- Skips the assistant chrome (PDF / edit / copy) for the seeded variant — the message wasn't authored by the user, so editing it post-hoc has no meaning.
- Cleans up the now-dead bubble-tinted variant: the `text-response-plugin-seeded` testid, the muted-gray `roleTheme` branch, and the inline chip beside the speaker label are all removed since the seeded turn no longer flows through that path.

Plumbing was already in place (`seededByPlugin` is set on the first user turn by `src/utils/session/sessionEntries.ts:69-73`); this PR is a pure View/Preview rewrite plus an e2e covering the new layout.

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`
- [x] `yarn test` — all unit suites green
- [x] `yarn test:e2e` — full suite (424 tests) green, including the new `e2e/tests/encore-seeded.spec.ts`:
  - canvas renders `text-response-seeded-card` instead of the default bubble
  - body collapsed by default; visible after summary click
  - sidebar Preview renders `text-response-preview-seeded` (one-liner) instead of the markdown excerpt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin-seeded chat sessions now render with distinct visual styling in the chat canvas and sidebar previews, including specialized card layouts and localized labels.

* **Tests**
  * Added end-to-end tests for plugin-seeded chat session functionality and UI rendering behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->