### PR TITLE
feat(notifier): add update op + action-style priority alerts for todos

### DIFF
--- a/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
+++ b/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
@@ -27,12 +27,12 @@
 //     here: the user resolved the obligation and the audit trail
 //     reads as "you completed this".
 //
-// Ghost-ticket recovery (host bell deleted out-of-band while ticket
-// survives) is NOT implemented: Encore uses `engine.get(id)` for
-// that, which a runtime plugin can't reach. If the user dismisses
-// via the bell UI, the next reconcile sees no drift and leaves the
-// (now phantom) ticket alone. To force a re-publish: toggle the
-// item's priority off and back on.
+// Ghost-ticket recovery: when the host bell is deleted out-of-band
+// while the ticket survives (user dismissed via bell UI, crash
+// truncated active.json), the reconciler calls `notifier.get` on
+// the recorded notificationId, finds nothing, drops the ticket,
+// and lets Phase 2 republish a fresh entry. Same pattern Encore
+// uses via `engine.get` (`server/encore/notifier.ts:bellExists`).
 
 import type { FileOps } from "gui-chat-protocol";
 import type { TodoItem, TodoPriority } from "../types";
@@ -74,6 +74,13 @@ export interface PriorityNotifierApi {
     },
   ): Promise<void>;
   clear(id: string): Promise<void>;
+  /** Returns a truthy entry when the bell still exists and belongs
+   *  to this plugin, otherwise undefined. Used for ghost-bell
+   *  detection: a ticket whose `notificationId` no longer resolves
+   *  here means the bell was wiped (user dismissed via UI, crash
+   *  truncated active.json) and reconcile should re-publish rather
+   *  than `update` (which would silently no-op). */
+  get(id: string): Promise<unknown | undefined>;
 }
 
 // ── Constants ─────────────────────────────────────────────────────
@@ -240,20 +247,23 @@ async function safeUpdate(
   try {
     await notifier.update(notificationId, patch);
     // `notifier.update` is silent on three engine-level no-ops:
-    //   1. unknown id (ghost bell — user dismissed via UI),
-    //   2. cross-plugin id (structurally impossible here — every id
-    //      we hold came from our own `notifier.publish`),
-    //   3. merged-shape validation failure (engine's
-    //      `validatePublishInput` rejects it).
-    // (1) is the documented ghost-bell limitation: we can't detect
-    // it without `engine.get` and we don't ship that on the
-    // runtime API. (2) can't happen by construction. (3) cannot
-    // happen either: title is clamped to TITLE_MAX, body to
-    // BODY_MAX, severity is always urgent/nudge, navigateTarget
-    // is the constant "/todos", and lifecycle is action — every
-    // field is constructed to pass validation. So a non-throwing
-    // call means the bell was updated (or it was a ghost-bell
-    // no-op which we accept).
+    //   1. unknown id (ghost bell),
+    //   2. cross-plugin id,
+    //   3. merged-shape validation failure.
+    // Each is either caught upstream or structurally impossible by
+    // the time we reach this call:
+    //   - (1) is filtered by the `notifier.get` ghost-check in
+    //     `reconcilePriorityNotifications` BEFORE this function is
+    //     invoked, so the entry was alive at check-time. A TOCTOU
+    //     race could in theory dismiss it between check and update;
+    //     the worst case is the next reconcile catches it and
+    //     drops the now-ghost ticket for Phase-2 republish.
+    //   - (2) can't happen by construction: every id we hold came
+    //     from our own `notifier.publish`.
+    //   - (3) can't happen either: title is clamped to TITLE_MAX,
+    //     body to BODY_MAX, severity is always urgent/nudge,
+    //     navigateTarget is "/todos", and lifecycle is action.
+    // So a non-throwing call means the bell really did update.
     return true;
   } catch (err) {
     // Caller MUST consult the return value — committing a ticket
@@ -313,6 +323,22 @@ export async function reconcilePriorityNotifications(items: TodoItem[], notifier
         delete ticketsFile.tickets[todoId];
         dirty = true;
       }
+      continue;
+    }
+
+    // Ghost-bell check: if the host no longer has this entry (user
+    // dismissed via the bell UI, or a crash wiped active.json),
+    // `notifier.update` would silently no-op and our ticket would
+    // converge to a fake "in-sync" state — the bell would never
+    // come back. Drop the ticket here so Phase 2's "publish for
+    // unticketed notifiable item" branch re-fires fresh, same
+    // shape Encore uses (`server/encore/reconcile.ts`'s
+    // `refreshGhostTicket`). Codex CHANGES REQUESTED, PR #1451.
+    const bellAlive = (await notifier.get(ticket.notificationId)) !== undefined;
+    if (!bellAlive) {
+      log?.warn("priority reconcile: ghost ticket dropped; Phase 2 will re-publish", { notificationId: ticket.notificationId, todoId });
+      delete ticketsFile.tickets[todoId];
+      dirty = true;
       continue;
     }
 

--- a/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
+++ b/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
@@ -81,6 +81,14 @@ export interface PriorityNotifierApi {
 const PLUGIN_DATA_KIND = "todo-priority" as const;
 const NAVIGATE_TARGET = "/todos";
 const TITLE_MAX = 60;
+// Matches the host notifier engine's `bodyMax` cap. Clamping in the
+// plugin (rather than letting publish/update reject) means
+// `safeUpdate` / `safePublish` can't be tricked into committing a
+// ticket-as-synced for a patch the engine silently no-op'd — the
+// only remaining engine no-op case is unknown id (ghost bell), and
+// that's the accepted limitation documented in the file header.
+// Codex CHANGES REQUESTED on PR #1451.
+const BODY_MAX = 4000;
 const TICKETS_FILE = "urgent-tickets.json";
 
 // ── Ticket store (the plugin's own source of truth) ───────────────
@@ -185,11 +193,16 @@ function buildTitle(item: TodoItem): string {
 // to push. Empty body renders identically to no body in the bell
 // UI's v-if templates, so this is a presentation-equivalent
 // representation we can compare and persist without ambiguity.
+//
+// Output is clamped to `BODY_MAX` so the engine's publish/update
+// validation can never reject for body length — see the BODY_MAX
+// rationale above.
 function buildBody(item: TodoItem): string {
   const note = item.note?.trim();
-  if (note) return note;
-  if (item.dueDate) return `Due ${item.dueDate}`;
-  return "";
+  let body = "";
+  if (note) body = note;
+  else if (item.dueDate) body = `Due ${item.dueDate}`;
+  return body.length <= BODY_MAX ? body : `${body.slice(0, BODY_MAX - 1)}…`;
 }
 
 // ── Reconcile (the IO-bound entry point) ──────────────────────────
@@ -226,6 +239,21 @@ async function safeUpdate(
 ): Promise<boolean> {
   try {
     await notifier.update(notificationId, patch);
+    // `notifier.update` is silent on three engine-level no-ops:
+    //   1. unknown id (ghost bell — user dismissed via UI),
+    //   2. cross-plugin id (structurally impossible here — every id
+    //      we hold came from our own `notifier.publish`),
+    //   3. merged-shape validation failure (engine's
+    //      `validatePublishInput` rejects it).
+    // (1) is the documented ghost-bell limitation: we can't detect
+    // it without `engine.get` and we don't ship that on the
+    // runtime API. (2) can't happen by construction. (3) cannot
+    // happen either: title is clamped to TITLE_MAX, body to
+    // BODY_MAX, severity is always urgent/nudge, navigateTarget
+    // is the constant "/todos", and lifecycle is action — every
+    // field is constructed to pass validation. So a non-throwing
+    // call means the bell was updated (or it was a ghost-bell
+    // no-op which we accept).
     return true;
   } catch (err) {
     // Caller MUST consult the return value — committing a ticket

--- a/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
+++ b/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
@@ -1,0 +1,318 @@
+// Reconcile active "urgent / high unchecked" notifications against
+// the current todo list. Single source of truth on the plugin side
+// is `urgent-tickets.json`: a JSON map `todoId → { notificationId,
+// priority, title, body }` written alongside `todos.json` in the
+// plugin's data dir. After every mutating dispatch (LLM action or
+// UI kind) the plugin runs `reconcilePriorityNotifications(...)` so
+// the host notifier's active set converges with the desired set.
+//
+// Design lifted from `server/encore/reconcile.ts` (post-update-API
+// migration):
+//
+//   - Tickets-on-disk are the source of truth for "what bells we
+//     own". The host's `engine.listFor` exists but is not exposed
+//     on the plugin-facing `NotifierRuntimeApi`; we don't need it
+//     once we keep our own ticket file.
+//   - **Drift detection on the trim path.** For every ticket whose
+//     item is still notifiable, we recompute the desired title /
+//     body / severity from current item state. If anything has
+//     drifted, we call `notifier.update(id, patch)` — same
+//     notificationId, no `cleared` history record, no flicker. The
+//     todo's rename/priority-shift bug ("two notifications for one
+//     item") collapses to a single in-place edit on the existing
+//     entry.
+//   - "No longer applicable" path: item gone / completed / priority
+//     dropped below the notifiable threshold — clear the bell, drop
+//     the ticket. The clear DOES write to history, which is fine
+//     here: the user resolved the obligation and the audit trail
+//     reads as "you completed this".
+//
+// Ghost-ticket recovery (host bell deleted out-of-band while ticket
+// survives) is NOT implemented: Encore uses `engine.get(id)` for
+// that, which a runtime plugin can't reach. If the user dismisses
+// via the bell UI, the next reconcile sees no drift and leaves the
+// (now phantom) ticket alone. To force a re-publish: toggle the
+// item's priority off and back on.
+
+import type { FileOps } from "gui-chat-protocol";
+import type { TodoItem, TodoPriority } from "../types";
+
+// ── Notifier surface this module needs ────────────────────────────
+//
+// Mirrors the relevant slice of the host's `NotifierRuntimeApi` —
+// duplicated here so the plugin doesn't import server-internal
+// types. The cast point is in `index.ts`.
+
+export type NotifiablePriority = "urgent" | "high";
+
+export interface PriorityAlertPluginData {
+  kind: "todo-priority";
+  todoId: string;
+  /** Snapshot of the item's priority at the last publish / update.
+   *  Duplicated on the notifier entry so a future debugger reading
+   *  active.json can see which severity bucket the entry came from
+   *  without cross-referencing the plugin's ticket store. */
+  priority: NotifiablePriority;
+}
+
+export interface PriorityNotifierApi {
+  publish(input: {
+    severity: "urgent" | "nudge";
+    lifecycle: "action";
+    title: string;
+    body?: string;
+    navigateTarget: string;
+    pluginData: PriorityAlertPluginData;
+  }): Promise<{ id: string }>;
+  update(
+    id: string,
+    patch: {
+      severity?: "urgent" | "nudge";
+      title?: string;
+      body?: string;
+      pluginData?: PriorityAlertPluginData;
+    },
+  ): Promise<void>;
+  clear(id: string): Promise<void>;
+}
+
+// ── Constants ─────────────────────────────────────────────────────
+
+const PLUGIN_DATA_KIND = "todo-priority" as const;
+const NAVIGATE_TARGET = "/todos";
+const TITLE_MAX = 60;
+const TICKETS_FILE = "urgent-tickets.json";
+
+// ── Ticket store (the plugin's own source of truth) ───────────────
+
+interface Ticket {
+  todoId: string;
+  notificationId: string;
+  priority: NotifiablePriority;
+  /** Title and body as last rendered to the bell — the drift
+   *  baseline. The reconciler's trim path compares these against
+   *  `buildTitle` / `buildBody` recomputed from current item state;
+   *  if either has drifted (most commonly via an item rename or a
+   *  note edit), the path calls `notifier.update` in place. Optional
+   *  on the wire so pre-update-API tickets load cleanly — they read
+   *  as "always drifted" on first sight, which triggers an
+   *  idempotent update + ticket rewrite that backfills the fields. */
+  title?: string;
+  body?: string;
+}
+
+interface TicketsFile {
+  tickets: Record<string, Ticket>;
+}
+
+function isTicket(value: unknown): value is Ticket {
+  if (!value || typeof value !== "object") return false;
+  const t = value as Record<string, unknown>;
+  if (typeof t["todoId"] !== "string") return false;
+  if (typeof t["notificationId"] !== "string") return false;
+  if (t["priority"] !== "urgent" && t["priority"] !== "high") return false;
+  // title / body are optional on the wire (legacy tickets) but if
+  // present must be strings — otherwise we drop them on read.
+  if (t["title"] !== undefined && typeof t["title"] !== "string") return false;
+  if (t["body"] !== undefined && typeof t["body"] !== "string") return false;
+  return true;
+}
+
+async function loadTickets(files: FileOps): Promise<TicketsFile> {
+  if (!(await files.exists(TICKETS_FILE))) return { tickets: {} };
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await files.read(TICKETS_FILE));
+  } catch {
+    return { tickets: {} };
+  }
+  if (!raw || typeof raw !== "object") return { tickets: {} };
+  const rawTickets = (raw as { tickets?: unknown }).tickets;
+  if (!rawTickets || typeof rawTickets !== "object") return { tickets: {} };
+  const out: Record<string, Ticket> = {};
+  for (const [key, value] of Object.entries(rawTickets as Record<string, unknown>)) {
+    if (!isTicket(value)) continue;
+    if (value.todoId !== key) continue;
+    out[key] = value;
+  }
+  return { tickets: out };
+}
+
+async function saveTickets(files: FileOps, file: TicketsFile): Promise<void> {
+  await files.write(TICKETS_FILE, JSON.stringify(file, null, 2));
+}
+
+// ── Priority → notification mapping ───────────────────────────────
+
+function isNotifiablePriority(priority: TodoPriority | undefined): priority is NotifiablePriority {
+  return priority === "urgent" || priority === "high";
+}
+
+function severityFor(priority: NotifiablePriority): "urgent" | "nudge" {
+  return priority === "urgent" ? "urgent" : "nudge";
+}
+
+// ── Title / body formatting ───────────────────────────────────────
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+// Title is the todo text verbatim (truncated). Severity is already
+// signalled by the bell's color badge and on-disk `pluginData.priority`,
+// so adding "Urgent: " / "High priority: " to the title is redundant.
+function buildTitle(item: TodoItem): string {
+  return truncate(item.text, TITLE_MAX);
+}
+
+function buildBody(item: TodoItem): string | undefined {
+  const note = item.note?.trim();
+  if (note) return note;
+  if (item.dueDate) return `Due ${item.dueDate}`;
+  return undefined;
+}
+
+// ── Reconcile (the IO-bound entry point) ──────────────────────────
+
+interface ReconcileLog {
+  warn: (msg: string, data?: object) => void;
+}
+
+async function safeClear(notifier: PriorityNotifierApi, notificationId: string, todoId: string, log?: ReconcileLog): Promise<void> {
+  try {
+    await notifier.clear(notificationId);
+  } catch (err) {
+    log?.warn("priority reconcile: clear failed", { notificationId, todoId, error: String(err) });
+  }
+}
+
+async function safeUpdate(
+  notifier: PriorityNotifierApi,
+  notificationId: string,
+  patch: {
+    severity?: "urgent" | "nudge";
+    title?: string;
+    body?: string;
+    pluginData?: PriorityAlertPluginData;
+  },
+  todoId: string,
+  log?: ReconcileLog,
+): Promise<void> {
+  try {
+    await notifier.update(notificationId, patch);
+  } catch (err) {
+    log?.warn("priority reconcile: update failed", { notificationId, todoId, error: String(err) });
+  }
+}
+
+async function safePublish(notifier: PriorityNotifierApi, item: TodoItem, priority: NotifiablePriority, log?: ReconcileLog): Promise<string | null> {
+  const body = buildBody(item);
+  try {
+    const { id } = await notifier.publish({
+      severity: severityFor(priority),
+      lifecycle: "action",
+      title: buildTitle(item),
+      ...(body !== undefined ? { body } : {}),
+      navigateTarget: NAVIGATE_TARGET,
+      pluginData: { kind: PLUGIN_DATA_KIND, todoId: item.id, priority },
+    });
+    return id;
+  } catch (err) {
+    log?.warn("priority reconcile: publish failed", { todoId: item.id, error: String(err) });
+    return null;
+  }
+}
+
+/** Reconcile the plugin's tickets and the host's bell entries with
+ *  the current item list. After this resolves:
+ *
+ *    - every notifiable item has a ticket and a live bell, with the
+ *      bell's severity / title / body matching the item's current
+ *      state;
+ *    - no ticket references a non-notifiable item.
+ *
+ *  Idempotent and tolerant of partial state. Drift is detected per-
+ *  ticket against the title / body / priority stored at last publish
+ *  or update; an item rename flows through `notifier.update` rather
+ *  than clear-then-publish, preserving the notificationId. */
+export async function reconcilePriorityNotifications(items: TodoItem[], notifier: PriorityNotifierApi, files: FileOps, log?: ReconcileLog): Promise<void> {
+  const ticketsFile = await loadTickets(files);
+  const itemsById = new Map(items.map((item) => [item.id, item]));
+  let dirty = false;
+
+  // Phase 1: walk existing tickets — clear stale, update in place
+  // on drift, leave alone on exact match.
+  for (const [todoId, ticket] of Object.entries(ticketsFile.tickets)) {
+    const item = itemsById.get(todoId);
+    const stillNotifiable = item !== undefined && !item.completed && isNotifiablePriority(item.priority);
+
+    if (!stillNotifiable) {
+      await safeClear(notifier, ticket.notificationId, todoId, log);
+      delete ticketsFile.tickets[todoId];
+      dirty = true;
+      continue;
+    }
+
+    const currentPriority: NotifiablePriority = item.priority as NotifiablePriority;
+    const desiredTitle = buildTitle(item);
+    const desiredBody = buildBody(item);
+
+    const priorityDrift = currentPriority !== ticket.priority;
+    const titleDrift = ticket.title !== desiredTitle;
+    const bodyDrift = ticket.body !== desiredBody;
+
+    if (priorityDrift || titleDrift || bodyDrift) {
+      // In-place update: same notificationId, no flicker, no
+      // history record. The bell's content is rewritten to match
+      // the item's current state.
+      await safeUpdate(
+        notifier,
+        ticket.notificationId,
+        {
+          ...(priorityDrift ? { severity: severityFor(currentPriority) } : {}),
+          ...(titleDrift ? { title: desiredTitle } : {}),
+          // body drift includes "became undefined" — the engine's
+          // update API doesn't honour explicit-undefined-clears
+          // today, so when the desired body is absent we just
+          // leave the old body on the bell rather than try to
+          // un-set it. The on-disk ticket tracks the latest desired
+          // body so re-runs don't re-fire this branch.
+          ...(bodyDrift && desiredBody !== undefined ? { body: desiredBody } : {}),
+          ...(priorityDrift ? { pluginData: { kind: PLUGIN_DATA_KIND, todoId, priority: currentPriority } } : {}),
+        },
+        todoId,
+        log,
+      );
+      ticketsFile.tickets[todoId] = { todoId, notificationId: ticket.notificationId, priority: currentPriority, title: desiredTitle, body: desiredBody };
+      dirty = true;
+      continue;
+    }
+
+    // Exact match: no work to do.
+  }
+
+  // Phase 2: publish bells for notifiable items that don't have a
+  // ticket yet.
+  for (const item of items) {
+    if (item.completed || !isNotifiablePriority(item.priority)) continue;
+    if (ticketsFile.tickets[item.id]) continue;
+    const newId = await safePublish(notifier, item, item.priority, log);
+    if (newId === null) continue;
+    ticketsFile.tickets[item.id] = {
+      todoId: item.id,
+      notificationId: newId,
+      priority: item.priority,
+      title: buildTitle(item),
+      body: buildBody(item),
+    };
+    dirty = true;
+  }
+
+  if (dirty) {
+    try {
+      await saveTickets(files, ticketsFile);
+    } catch (err) {
+      log?.warn("priority reconcile: tickets save failed", { error: String(err) });
+    }
+  }
+}

--- a/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
+++ b/packages/plugins/todo-plugin/src/handlers/priority-notifier.ts
@@ -118,19 +118,32 @@ function isTicket(value: unknown): value is Ticket {
   return true;
 }
 
-async function loadTickets(files: FileOps): Promise<TicketsFile> {
+async function loadTickets(files: FileOps, log?: ReconcileLog): Promise<TicketsFile> {
   if (!(await files.exists(TICKETS_FILE))) return { tickets: {} };
   let raw: unknown;
   try {
     raw = JSON.parse(await files.read(TICKETS_FILE));
-  } catch {
+  } catch (err) {
+    // Treat malformed JSON as "no tickets" rather than crashing the
+    // reconcile, but log a warning so this is diagnosable from logs
+    // if it ever happens (e.g. partial write from a crash, manual
+    // hand-edit that broke the syntax).
+    log?.warn("priority reconcile: tickets file unparseable; treating as empty", { file: TICKETS_FILE, error: String(err) });
     return { tickets: {} };
   }
-  if (!raw || typeof raw !== "object") return { tickets: {} };
-  const rawTickets = (raw as { tickets?: unknown }).tickets;
-  if (!rawTickets || typeof rawTickets !== "object") return { tickets: {} };
+  if (
+    !raw ||
+    typeof raw !== "object" ||
+    !("tickets" in raw) ||
+    typeof (raw as { tickets?: unknown }).tickets !== "object" ||
+    (raw as { tickets?: unknown }).tickets === null
+  ) {
+    log?.warn("priority reconcile: tickets file has unexpected shape; treating as empty", { file: TICKETS_FILE });
+    return { tickets: {} };
+  }
+  const rawTickets = (raw as { tickets: Record<string, unknown> }).tickets;
   const out: Record<string, Ticket> = {};
-  for (const [key, value] of Object.entries(rawTickets as Record<string, unknown>)) {
+  for (const [key, value] of Object.entries(rawTickets)) {
     if (!isTicket(value)) continue;
     if (value.todoId !== key) continue;
     out[key] = value;
@@ -165,11 +178,18 @@ function buildTitle(item: TodoItem): string {
   return truncate(item.text, TITLE_MAX);
 }
 
-function buildBody(item: TodoItem): string | undefined {
+// Returns the empty string (NOT undefined) when there is no note /
+// dueDate. The empty-string contract is what lets "removed body"
+// flow through the notifier's patch API: the engine treats an
+// absent patch field as "leave alone", so we need a concrete value
+// to push. Empty body renders identically to no body in the bell
+// UI's v-if templates, so this is a presentation-equivalent
+// representation we can compare and persist without ambiguity.
+function buildBody(item: TodoItem): string {
   const note = item.note?.trim();
   if (note) return note;
   if (item.dueDate) return `Due ${item.dueDate}`;
-  return undefined;
+  return "";
 }
 
 // ── Reconcile (the IO-bound entry point) ──────────────────────────
@@ -178,11 +198,17 @@ interface ReconcileLog {
   warn: (msg: string, data?: object) => void;
 }
 
-async function safeClear(notifier: PriorityNotifierApi, notificationId: string, todoId: string, log?: ReconcileLog): Promise<void> {
+async function safeClear(notifier: PriorityNotifierApi, notificationId: string, todoId: string, log?: ReconcileLog): Promise<boolean> {
   try {
     await notifier.clear(notificationId);
+    return true;
   } catch (err) {
+    // Caller MUST consult the return value before destructive ticket
+    // cleanup — swallowing a clear failure and dropping the ticket
+    // would orphan the bell forever (no ticket means the next
+    // reconcile has nothing to retry).
     log?.warn("priority reconcile: clear failed", { notificationId, todoId, error: String(err) });
+    return false;
   }
 }
 
@@ -197,22 +223,27 @@ async function safeUpdate(
   },
   todoId: string,
   log?: ReconcileLog,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await notifier.update(notificationId, patch);
+    return true;
   } catch (err) {
+    // Caller MUST consult the return value — committing a ticket
+    // rewrite after a failed update would erase the drift signal,
+    // so the next reconcile would think the bell is in sync while
+    // it's actually still stale.
     log?.warn("priority reconcile: update failed", { notificationId, todoId, error: String(err) });
+    return false;
   }
 }
 
 async function safePublish(notifier: PriorityNotifierApi, item: TodoItem, priority: NotifiablePriority, log?: ReconcileLog): Promise<string | null> {
-  const body = buildBody(item);
   try {
     const { id } = await notifier.publish({
       severity: severityFor(priority),
       lifecycle: "action",
       title: buildTitle(item),
-      ...(body !== undefined ? { body } : {}),
+      body: buildBody(item),
       navigateTarget: NAVIGATE_TARGET,
       pluginData: { kind: PLUGIN_DATA_KIND, todoId: item.id, priority },
     });
@@ -236,20 +267,24 @@ async function safePublish(notifier: PriorityNotifierApi, item: TodoItem, priori
  *  or update; an item rename flows through `notifier.update` rather
  *  than clear-then-publish, preserving the notificationId. */
 export async function reconcilePriorityNotifications(items: TodoItem[], notifier: PriorityNotifierApi, files: FileOps, log?: ReconcileLog): Promise<void> {
-  const ticketsFile = await loadTickets(files);
+  const ticketsFile = await loadTickets(files, log);
   const itemsById = new Map(items.map((item) => [item.id, item]));
   let dirty = false;
 
   // Phase 1: walk existing tickets — clear stale, update in place
-  // on drift, leave alone on exact match.
+  // on drift, leave alone on exact match. Each notifier op is gated
+  // on success: a failed clear/update keeps the ticket as-is so the
+  // next reconcile retries from the same drift signal.
   for (const [todoId, ticket] of Object.entries(ticketsFile.tickets)) {
     const item = itemsById.get(todoId);
     const stillNotifiable = item !== undefined && !item.completed && isNotifiablePriority(item.priority);
 
     if (!stillNotifiable) {
-      await safeClear(notifier, ticket.notificationId, todoId, log);
-      delete ticketsFile.tickets[todoId];
-      dirty = true;
+      const cleared = await safeClear(notifier, ticket.notificationId, todoId, log);
+      if (cleared) {
+        delete ticketsFile.tickets[todoId];
+        dirty = true;
+      }
       continue;
     }
 
@@ -261,34 +296,29 @@ export async function reconcilePriorityNotifications(items: TodoItem[], notifier
     const titleDrift = ticket.title !== desiredTitle;
     const bodyDrift = ticket.body !== desiredBody;
 
-    if (priorityDrift || titleDrift || bodyDrift) {
-      // In-place update: same notificationId, no flicker, no
-      // history record. The bell's content is rewritten to match
-      // the item's current state.
-      await safeUpdate(
-        notifier,
-        ticket.notificationId,
-        {
-          ...(priorityDrift ? { severity: severityFor(currentPriority) } : {}),
-          ...(titleDrift ? { title: desiredTitle } : {}),
-          // body drift includes "became undefined" — the engine's
-          // update API doesn't honour explicit-undefined-clears
-          // today, so when the desired body is absent we just
-          // leave the old body on the bell rather than try to
-          // un-set it. The on-disk ticket tracks the latest desired
-          // body so re-runs don't re-fire this branch.
-          ...(bodyDrift && desiredBody !== undefined ? { body: desiredBody } : {}),
-          ...(priorityDrift ? { pluginData: { kind: PLUGIN_DATA_KIND, todoId, priority: currentPriority } } : {}),
-        },
-        todoId,
-        log,
-      );
+    if (!priorityDrift && !titleDrift && !bodyDrift) continue;
+
+    // In-place update: same notificationId, no flicker, no history
+    // record. Body is sent on every drift (including the "note
+    // removed" case): `buildBody` returns "" rather than undefined
+    // so this branch can always push a concrete value through the
+    // notifier's patch API.
+    const updated = await safeUpdate(
+      notifier,
+      ticket.notificationId,
+      {
+        ...(priorityDrift ? { severity: severityFor(currentPriority) } : {}),
+        ...(titleDrift ? { title: desiredTitle } : {}),
+        ...(bodyDrift ? { body: desiredBody } : {}),
+        ...(priorityDrift ? { pluginData: { kind: PLUGIN_DATA_KIND, todoId, priority: currentPriority } } : {}),
+      },
+      todoId,
+      log,
+    );
+    if (updated) {
       ticketsFile.tickets[todoId] = { todoId, notificationId: ticket.notificationId, priority: currentPriority, title: desiredTitle, body: desiredBody };
       dirty = true;
-      continue;
     }
-
-    // Exact match: no work to do.
   }
 
   // Phase 2: publish bells for notifiable items that don't have a

--- a/packages/plugins/todo-plugin/src/index.ts
+++ b/packages/plugins/todo-plugin/src/index.ts
@@ -21,12 +21,13 @@
 // `columns.json` under `runtime.files.data`). All mutating actions
 // publish a `changed` pubsub event so multi-tab views auto-refresh.
 
-import { definePlugin } from "gui-chat-protocol";
+import { definePlugin, type PluginRuntime } from "gui-chat-protocol";
 import { TOOL_DEFINITION } from "./definition";
 import { loadTodos, saveTodos, loadColumns, saveColumns } from "./io";
 import { dispatchTodos, type TodosActionInput } from "./handlers/llm";
 import { handleAddColumn, handleDeleteColumn, handlePatchColumn, handleReorderColumns } from "./handlers/columns";
 import { handleCreate, handleDeleteItem, handleMove, handlePatch, type CreateInput, type MoveInput, type PatchInput } from "./handlers/items";
+import { reconcilePriorityNotifications, type PriorityNotifierApi } from "./handlers/priority-notifier";
 
 export { TOOL_DEFINITION };
 export type { TodoItem, TodoPriority, StatusColumn, TodoData } from "./types";
@@ -59,9 +60,48 @@ function isUiArgs(value: unknown): value is UiArgs {
   return typeof value === "object" && value !== null && "kind" in value && typeof (value as { kind: unknown }).kind === "string";
 }
 
-export default definePlugin(({ pubsub, files, log }) => {
+// Host extension: MulmoClaude attaches a per-plugin `notifier` to the
+// PluginRuntime (publish / clear). Type-only — the runtime object
+// the host hands us at boot already has the field; this cast just
+// teaches TypeScript about it without importing server-internal
+// types. Same pattern as debug-plugin.
+type MulmoclaudeRuntime = PluginRuntime & {
+  notifier: PriorityNotifierApi;
+};
+
+export default definePlugin((runtime) => {
+  const { pubsub, files, log } = runtime;
+  const { notifier } = runtime as MulmoclaudeRuntime;
+
+  // Single source of truth for the desired notification set. Called
+  // after every save so the notifier converges on
+  // `priority ∈ {urgent, high} && !completed`. Idempotent — extra
+  // calls are cheap (load tickets + diff) and never produce
+  // duplicates. The plugin's own `urgent-tickets.json` is the
+  // canonical "what bells we own" record; we never query the host
+  // notifier's active set.
+  async function reconcileNotifications(items: Awaited<ReturnType<typeof loadTodos>>): Promise<void> {
+    await reconcilePriorityNotifications(items, notifier, files.data, log);
+  }
+
+  // Boot reconcile: catches the post-crash case where active.json
+  // outlived a mutation that should have cleared its entry, or where
+  // todos.json was hand-edited while the host was down. Kicked off
+  // here (not awaited at init — plugin init must stay non-blocking),
+  // but each handler awaits the promise before its own reconcile so
+  // there's no race between the boot pass and the first dispatch.
+  const bootReconcile: Promise<void> = (async () => {
+    try {
+      const items = await loadTodos(files.data);
+      await reconcileNotifications(items);
+    } catch (err) {
+      log.warn("boot reconcile failed", { error: String(err) });
+    }
+  })();
+
   // ── LLM action path ───────────────────────────────────────────
   async function handleLlm(args: LlmArgs) {
+    await bootReconcile;
     const { action, ...input } = args;
     log.info("dispatch llm", { action });
     const items = await loadTodos(files.data);
@@ -72,6 +112,7 @@ export default definePlugin(({ pubsub, files, log }) => {
     }
     if (!READ_ONLY_ACTIONS.has(action)) {
       await saveTodos(files.data, result.items);
+      await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "llm-action", action });
     }
     return {
@@ -88,6 +129,7 @@ export default definePlugin(({ pubsub, files, log }) => {
   // just spread one big case statement across helper files for no
   // readability win.
   async function handleUi(args: UiArgs) {
+    await bootReconcile;
     log.info("dispatch ui", { kind: args.kind });
     if (args.kind === "listAll") {
       const [items, columns] = await Promise.all([loadTodos(files.data), loadColumns(files.data)]);
@@ -98,6 +140,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       const result = handleCreate(items, columns, args);
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveTodos(files.data, result.items);
+      await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "item-create" });
       return { data: { items: result.items, columns }, ...(result.item && { item: result.item }) };
     }
@@ -105,6 +148,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       const result = handlePatch(items, columns, args.id, args);
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveTodos(files.data, result.items);
+      await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "item-patch", id: args.id });
       return { data: { items: result.items, columns }, ...(result.item && { item: result.item }) };
     }
@@ -112,6 +156,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       const result = handleMove(items, columns, args.id, args);
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveTodos(files.data, result.items);
+      await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "item-move", id: args.id });
       return { data: { items: result.items, columns }, ...(result.item && { item: result.item }) };
     }
@@ -119,6 +164,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       const result = handleDeleteItem(items, args.id);
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveTodos(files.data, result.items);
+      await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "item-delete", id: args.id });
       return { data: { items: result.items, columns } };
     }
@@ -127,6 +173,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveColumns(files.data, result.columns);
       if (result.items) await saveTodos(files.data, result.items);
+      if (result.items) await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "column-add" });
       return { data: { items: result.items ?? items, columns: result.columns } };
     }
@@ -135,6 +182,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveColumns(files.data, result.columns);
       if (result.items) await saveTodos(files.data, result.items);
+      if (result.items) await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "column-patch", id: args.id });
       return { data: { items: result.items ?? items, columns: result.columns } };
     }
@@ -143,6 +191,7 @@ export default definePlugin(({ pubsub, files, log }) => {
       if (result.kind === "error") return { error: result.error, status: result.status };
       await saveColumns(files.data, result.columns);
       if (result.items) await saveTodos(files.data, result.items);
+      if (result.items) await reconcileNotifications(result.items);
       pubsub.publish("changed", { reason: "column-delete", id: args.id });
       return { data: { items: result.items ?? items, columns: result.columns } };
     }

--- a/server/encore/handlers/amend.ts
+++ b/server/encore/handlers/amend.ts
@@ -79,12 +79,15 @@ export async function handleAmend(args: z.infer<typeof AmendArgs>): Promise<Enco
 
   await writeText(indexPath, serializeIndexFile(validated, body));
 
-  // Force-refresh every active bell entry for this obligation. A
-  // title-only amend doesn't close anything, so trim-by-state alone
-  // wouldn't republish — but the on-screen text is stale. The
-  // `invalidateAllBells` flag tells the reconciler to clear all
-  // tickets+bells for the cycle first, then republish with fresh DSL.
-  await reconcileCycleNotifications({ obligationId: args.obligationId, now: new Date(), invalidateAllBells: true, log });
+  // Re-run the reconciler so any DSL-driven content drift (the most
+  // common amend is a `displayName` edit) flushes to the bells. The
+  // trim path detects title/body drift per ticket and calls
+  // `notifier.update` in place — same notificationId, no history
+  // record, no flicker. Prior to that engine op, this call required
+  // an `invalidateAllBells: true` flag that nuked every bell for the
+  // cycle and republished them; the flag and its supporting
+  // `clearAllForCycle` helper are gone.
+  await reconcileCycleNotifications({ obligationId: args.obligationId, now: new Date(), log });
   log.info("encore", "amendDefinition: obligation updated", { obligationId: args.obligationId });
 
   return {

--- a/server/encore/notifier.ts
+++ b/server/encore/notifier.ts
@@ -70,6 +70,38 @@ export async function publish(args: PublishArgs): Promise<{ id: string }> {
   });
 }
 
+/** In-place update of an Encore notification's presentation —
+ *  same id, same `pluginPkg`, same `lifecycle`, same `createdAt`,
+ *  new severity / title / body. The reconciler's trim path uses
+ *  this to flush DSL-driven content drift (an `amendDefinition`
+ *  edited a `displayName`, the bundle shrunk so the body's member
+ *  count changed, the cadence pushed us into a higher-severity
+ *  phase) without flickering the bell entry through a clear +
+ *  publish — which would litter history with `cleared` records
+ *  and assign a fresh id every time. Mirrors the DSL → host
+ *  vocabulary mapping in `publish` so a phase escalation from
+ *  `info` to `urgent` ends up at host `nudge` → `urgent` rather
+ *  than confusing the validator.
+ *
+ *  No-op on unknown / cross-plugin ids, and on patches that would
+ *  invalidate the entry (e.g. info severity on the action
+ *  lifecycle we always use). Caller treats the failure modes
+ *  uniformly — same isolation property as `clear`. */
+export async function update(
+  entryId: string,
+  patch: {
+    severity?: Severity;
+    title?: string;
+    body?: string;
+  },
+): Promise<void> {
+  await engine.updateForPlugin(ENCORE_PLUGIN_PKG, entryId, {
+    ...(patch.severity !== undefined ? { severity: toHostSeverity(patch.severity) } : {}),
+    ...(patch.title !== undefined ? { title: patch.title } : {}),
+    ...(patch.body !== undefined ? { body: patch.body } : {}),
+  });
+}
+
 /** Clear an Encore notification. No-ops on unknown / cross-plugin
  *  ids — matches host `clearForPlugin` semantics, plugin can't
  *  dismiss another plugin's entries. */

--- a/server/encore/reconcile.ts
+++ b/server/encore/reconcile.ts
@@ -36,11 +36,6 @@ export interface ReconcileDeps {
    *  the latest cycle on disk. */
   cycleId?: string;
   now: Date;
-  /** Force-clear every ticket+bell for the primary cycle before
-   *  publishing fresh ones. Used by `amendDefinition`: a title-only
-   *  amend doesn't close anything, so trim-by-state wouldn't
-   *  republish — but the on-screen text is now stale. */
-  invalidateAllBells?: boolean;
   log?: typeof defaultLog;
 }
 
@@ -63,10 +58,13 @@ export async function reconcileCycleNotifications(deps: ReconcileDeps): Promise<
   const primary = await loadPrimaryCycle(deps.obligationId, deps.cycleId);
   if (!primary) return;
 
-  if (deps.invalidateAllBells) {
-    await clearAllForCycle(deps.obligationId, primary.state.cycleId, "invalidateAllBells", log);
-  }
-
+  // `amendDefinition` used to set `invalidateAllBells: true` here to
+  // force every ticket+bell to be cleared and republished — the trim
+  // path couldn't republish a title-only edit because state hadn't
+  // moved. With the notifier engine's `update` op, the trim path now
+  // detects title/body drift directly and patches each bell in place
+  // (same notificationId, no history record). The flag and the
+  // `clearAllForCycle` helper it owned have been removed.
   await reconcileOneCycle(dsl, primary.state, todayIso, nowIso, log);
 
   // Cycle-close transition. If the primary cycle is now closed
@@ -203,8 +201,11 @@ async function trimOrEscalateTicket(
   }
 
   const phase = currentPhaseFor(stepDef, state, todayIso);
-  const severityChanged = phase !== null && phase.severity !== ticket.severity;
-  const targetsChanged = liveTargets.length !== ticket.targets.length;
+  const newSeverity = phase?.severity ?? ticket.severity;
+  const members = liveTargets.map((targetId) => ({ targetId }));
+  const desiredTitle = bundleTitle(dsl, stepDef, members);
+  const desiredBody = bundleBody(dsl, stepDef, members);
+
   // Ghost-ticket detection. The reconciler historically treated
   // ticket-existence as proof of bell-existence, so a bell dismissed
   // out-of-band by the host UI (or wiped by a crashed active.json)
@@ -216,20 +217,42 @@ async function trimOrEscalateTicket(
   // tick" gesture rather than an accidental silencer. `snooze` is
   // still the explicit verb for time-bound silence.
   const bellAlive = await encoreNotifier.bellExists(ticket.notificationId);
+  if (!bellAlive) {
+    await refreshGhostTicket({ dsl, state, ticket, stepDef, liveTargets, newSeverity, desiredTitle, desiredBody, log });
+    return { targets: liveTargets };
+  }
 
-  if (severityChanged || !bellAlive) {
-    const reason = !bellAlive ? "ghost-ticket republish" : "severity escalation";
-    const newSeverity = phase?.severity ?? ticket.severity;
-    await clearAndRepublish({ dsl, state, ticket, stepDef, liveTargets, newSeverity, reason, bellAlive, log });
+  // Drift detection. Title / body drift surfaces every kind of
+  // content-only DSL edit (`amendDefinition` rewriting a
+  // `displayName`, a target rename, a bundle shrinking to a count
+  // that changes the rendered text). Severity drift surfaces phase
+  // escalation. Either way the response is an in-place update —
+  // same notificationId, no history pollution, no flicker.
+  //
+  // Tickets written before this build don't carry `title` / `body`,
+  // so the !== checks read both as "always different on first
+  // sight". The first reconcile pass after the upgrade therefore
+  // calls `update` once per ticket (idempotent on the bell — host
+  // active.json is rewritten with the same values; only the ticket
+  // file gains the missing fields) and subsequent passes short-
+  // circuit.
+  const severityDrift = newSeverity !== ticket.severity;
+  const titleDrift = ticket.title !== desiredTitle;
+  const bodyDrift = ticket.body !== desiredBody;
+  const targetsChanged = liveTargets.length !== ticket.targets.length;
+
+  if (severityDrift || titleDrift || bodyDrift) {
+    await updateBellInPlace({ dsl, state, ticket, stepDef, liveTargets, newSeverity, desiredTitle, desiredBody, log });
     return { targets: liveTargets };
   }
 
   if (targetsChanged) {
-    // Bundle shrunk without escalation. Rewrite the ticket; the
-    // host bell entry keeps the same id (the on-screen badge count
-    // doesn't change for one notification, only its body).
-    await writeTicket({ ...ticket, targets: liveTargets });
-    log.info("encore", "reconcile: trimmed bundle", {
+    // Rare branch — target list shrunk but the formatters render
+    // the same title/body. Persist the trimmed target list so the
+    // ticket stays consistent with cycle state. No bell update
+    // needed since presentation didn't change.
+    await writeTicket({ ...ticket, targets: liveTargets, title: desiredTitle, body: desiredBody });
+    log.info("encore", "reconcile: trimmed bundle (no content drift)", {
       pendingId: ticket.pendingId,
       notificationId: ticket.notificationId,
       remaining: liveTargets,
@@ -240,62 +263,65 @@ async function trimOrEscalateTicket(
   return { targets: liveTargets };
 }
 
-/** Clear (if alive) and republish a ticket's bell with a fresh
- *  notificationId. Used by both the severity-escalation path (bell
- *  alive, new phase reached) and the ghost-ticket path (bell was
- *  manually dismissed or wiped). Preserves the ticket's pendingId,
- *  seedPrompt, createdAt, and chatSessionId — those are the chat-
- *  continuity binding the user expects to survive.
- *
- *  Returns true on success, false if the alive-bell clear failed
- *  (in which case the ticket is left as-is so a later reconcile
- *  retries). A ghost clear can't fail meaningfully (the bell is
- *  already gone) so we always proceed to publish in that case. */
-interface RepublishArgs {
+interface ReconcileRefreshArgs {
   dsl: EncoreDsl;
   state: CycleState;
   ticket: Ticket;
   stepDef: StepDef;
   liveTargets: string[];
   newSeverity: Severity;
-  reason: string;
-  bellAlive: boolean;
+  desiredTitle: string;
+  desiredBody: string;
   log: typeof defaultLog;
 }
 
-async function clearAndRepublish(args: RepublishArgs): Promise<boolean> {
-  const { dsl, state, ticket, stepDef, liveTargets, newSeverity, reason, bellAlive, log } = args;
-  if (bellAlive && !(await safeClearBell(ticket.notificationId, reason, log))) {
-    log.warn("encore", "reconcile: skipping republish; clear failed", {
-      pendingId: ticket.pendingId,
-      notificationId: ticket.notificationId,
-      reason,
-    });
-    return false;
-  }
-  const members = liveTargets.map((targetId) => ({ targetId }));
-  const title = bundleTitle(dsl, stepDef, members);
-  const body = bundleBody(dsl, stepDef, members);
-  const navigateTarget = encoreUrlFor(ticket.pendingId);
-  const { id: newId } = await encoreNotifier.publish({ severity: newSeverity, title, body, navigateTarget });
-  // Roll back the just-published bell entry if the ticket write
-  // fails — otherwise the bell would have no matching ticket and
-  // the next reconcile would see "un-fired" → publish a duplicate.
-  try {
-    await writeTicket({ ...ticket, notificationId: newId, severity: newSeverity, targets: liveTargets });
-  } catch (err) {
-    await safeClearBell(newId, `rollback: ticket write failed after ${reason}`, log);
-    throw err;
-  }
-  log.info("encore", `reconcile: ${reason}`, {
+/** Update a still-live bell entry in place — same notificationId,
+ *  fresh severity / title / body. No clear, no republish, no
+ *  history record. Used for the common case where an obligation's
+ *  DSL changed (most often via `amendDefinition`) or a phase
+ *  escalation pushed severity up.
+ *
+ *  The on-disk ticket is rewritten to reflect the new state so the
+ *  next reconcile's drift check short-circuits. */
+async function updateBellInPlace(args: ReconcileRefreshArgs): Promise<void> {
+  const { dsl, state, ticket, stepDef, liveTargets, newSeverity, desiredTitle, desiredBody, log } = args;
+  await encoreNotifier.update(ticket.notificationId, { severity: newSeverity, title: desiredTitle, body: desiredBody });
+  await writeTicket({ ...ticket, severity: newSeverity, title: desiredTitle, body: desiredBody, targets: liveTargets });
+  log.info("encore", "reconcile: bell updated in place", {
     obligationId: dsl.id,
     cycleId: state.cycleId,
     stepId: stepDef.id,
-    from: ticket.severity,
-    to: newSeverity,
-    notificationId: newId,
+    notificationId: ticket.notificationId,
+    fromSeverity: ticket.severity,
+    toSeverity: newSeverity,
   });
-  return true;
+}
+
+/** Bring back a bell that was dismissed out-of-band. The bell is
+ *  gone, so we publish a fresh entry at a new notificationId; the
+ *  ticket's pendingId / seedPrompt / chatSessionId / createdAt
+ *  carry over so the user lands in the same chat conversation on
+ *  click. With `update`, this is the ONLY reason the trim path
+ *  still allocates a new notificationId — every other refresh
+ *  (severity escalation, title amend, body drift) goes through
+ *  `updateBellInPlace` and keeps the original id stable. */
+async function refreshGhostTicket(args: ReconcileRefreshArgs): Promise<void> {
+  const { dsl, state, ticket, stepDef, liveTargets, newSeverity, desiredTitle, desiredBody, log } = args;
+  const navigateTarget = encoreUrlFor(ticket.pendingId);
+  const { id: newId } = await encoreNotifier.publish({ severity: newSeverity, title: desiredTitle, body: desiredBody, navigateTarget });
+  try {
+    await writeTicket({ ...ticket, notificationId: newId, severity: newSeverity, title: desiredTitle, body: desiredBody, targets: liveTargets });
+  } catch (err) {
+    await safeClearBell(newId, "rollback: ticket write failed after ghost-ticket republish", log);
+    throw err;
+  }
+  log.info("encore", "reconcile: ghost-ticket republish", {
+    obligationId: dsl.id,
+    cycleId: state.cycleId,
+    stepId: stepDef.id,
+    fromNotificationId: ticket.notificationId,
+    toNotificationId: newId,
+  });
 }
 
 function dedupeTickets(tickets: Ticket[]): Ticket[] {
@@ -377,6 +403,8 @@ async function fireGroup(dsl: EncoreDsl, state: CycleState, group: BundleGroup, 
     stepId: group.stepId,
     targets: group.members.map((member) => member.targetId),
     severity: group.severity,
+    title,
+    body,
     seedPrompt: buildSeedPrompt(dsl, group, pendingId, state.cycleId),
     createdAt: new Date().toISOString(),
   };
@@ -475,18 +503,6 @@ async function clearAllForObligation(obligationId: string, reason: string, log: 
     }
   }
   if (cleared > 0) log.info("encore", "reconcile: cleared all for obligation", { obligationId, reason, cleared });
-}
-
-async function clearAllForCycle(obligationId: string, cycleId: string, reason: string, log: typeof defaultLog): Promise<void> {
-  const tickets = await ticketsForCycle(obligationId, cycleId);
-  let cleared = 0;
-  for (const ticket of tickets) {
-    if (await safeClearBell(ticket.notificationId, reason, log)) {
-      await unlink(ticketPath(ticket.pendingId));
-      cleared += 1;
-    }
-  }
-  if (cleared > 0) log.info("encore", "reconcile: cleared all for cycle", { obligationId, cycleId, reason, cleared });
 }
 
 // ── phase eval ────────────────────────────────────────────────────

--- a/server/encore/tick.ts
+++ b/server/encore/tick.ts
@@ -58,6 +58,18 @@ export interface Ticket {
    *  `lastPublishedSeverity`; that moved here when status flags
    *  were removed. */
   severity: Severity;
+  /** Title and body as last rendered to the bell — the drift
+   *  baseline. Trim path compares these against `bundleTitle` /
+   *  `bundleBody` recomputed from the current DSL; if either has
+   *  drifted (most commonly via `amendDefinition` editing a
+   *  `displayName`), the path calls `notifier.update` in place
+   *  instead of clear-then-publish. Optional on the wire so
+   *  tickets written by pre-update-API builds load cleanly — they
+   *  are treated as "always drifted" on first sight, which causes
+   *  an idempotent in-place update to the bell and a ticket
+   *  rewrite that backfills the fields. */
+  title?: string;
+  body?: string;
   seedPrompt: string;
   createdAt: string;
   /** Filled by resolveNotification on first bell click. Subsequent

--- a/server/notifier/engine.ts
+++ b/server/notifier/engine.ts
@@ -459,6 +459,25 @@ export async function updateForPlugin<TPluginData = unknown>(
   });
 }
 
+/** Plugin-scoped point lookup. Returns the entry by id, but only if
+ *  it belongs to the caller's plugin; otherwise undefined. Used by
+ *  runtime plugins to detect ghost-bell ids (entry was dismissed
+ *  out-of-band via the bell UI or wiped by a crash) so the
+ *  reconciler can fall back to a fresh publish instead of
+ *  rewriting a ticket as if a silent-no-op update succeeded.
+ *
+ *  Cross-plugin reads return undefined for isolation — same
+ *  property as `clearForPlugin` / `updateForPlugin`. The plugin
+ *  can't distinguish "id never existed" from "belongs to another
+ *  plugin" from the caller side, which is the intended behaviour. */
+export async function getForPlugin(pluginPkg: string, entryId: string): Promise<NotifierEntry | undefined> {
+  const state = await loadActive(activeFilePath);
+  const entry = state.entries[entryId];
+  if (!entry) return undefined;
+  if (entry.pluginPkg !== pluginPkg) return undefined;
+  return entry;
+}
+
 /** Plugin-scoped clear. Same as `clear` but no-ops if the entry's
  *  `pluginPkg` doesn't match the caller's. Used by the per-plugin
  *  `runtime.notifier.clear` so a plugin can't dismiss another

--- a/server/notifier/engine.ts
+++ b/server/notifier/engine.ts
@@ -20,7 +20,15 @@ import { PUBSUB_CHANNELS } from "../../src/config/pubsubChannels.js";
 import { log } from "../system/logger/index.js";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
 import { loadActive, loadHistory, saveActive, saveHistory } from "./store.js";
-import { HISTORY_CAP, type NotifierEntry, type NotifierEvent, type NotifierFile, type NotifierHistoryEntry, type PublishInput } from "./types.js";
+import {
+  HISTORY_CAP,
+  type NotifierEntry,
+  type NotifierEvent,
+  type NotifierFile,
+  type NotifierHistoryEntry,
+  type NotifierSeverity,
+  type PublishInput,
+} from "./types.js";
 
 // ── Dependency injection (matches server/events/notifications.ts) ──
 
@@ -374,6 +382,80 @@ export async function cancel(entryId: string): Promise<void> {
       event: { type: "cancelled", id: entryId },
       historyEntry: buildHistoryEntry(entry, "cancelled"),
     };
+  });
+}
+
+/** In-place update for an active entry. Only the fields present on
+ *  `patch` are rewritten; `id`, `pluginPkg`, `lifecycle`, and
+ *  `createdAt` stay fixed. Emits a single `"updated"` event with
+ *  the post-mutation entry — no history record is written because
+ *  the entry is still active, just with refreshed content.
+ *
+ *  This is the missing primitive for "state-of-the-world"
+ *  notifications: action-lifecycle entries that mirror an
+ *  ongoing obligation whose presentation drifts (e.g. a renamed
+ *  todo, an Encore obligation's `displayName` amended). Callers
+ *  used to clear-then-publish to refresh, which polluted history
+ *  with `cleared` records and assigned new ids — both wrong for a
+ *  same-obligation refresh.
+ *
+ *  No-ops (no throw) when:
+ *    - the id is unknown,
+ *    - the entry belongs to a different plugin,
+ *    - the merged shape would violate `validatePublishInput` (e.g.
+ *      action + info severity, empty title, oversized body). The
+ *      silent skip matches `clearForPlugin`'s isolation semantics —
+ *      the plugin can't distinguish "id never existed" from "id
+ *      belongs to another plugin" from "patch would invalidate", so
+ *      we never throw across that line. Validation failures are
+ *      logged for diagnosis.
+ *
+ *  Passing only fields you want to change is the contract — omit a
+ *  field to leave it alone. There is no "clear this field" affordance
+ *  (e.g. removing a body once set); a future caller that needs it
+ *  can add an explicit sentinel. */
+export async function updateForPlugin<TPluginData = unknown>(
+  pluginPkg: string,
+  entryId: string,
+  patch: {
+    severity?: NotifierSeverity;
+    title?: string;
+    body?: string;
+    navigateTarget?: string;
+    pluginData?: TPluginData;
+  },
+): Promise<void> {
+  await enqueue((state) => {
+    const entry = state.entries[entryId];
+    if (!entry) return null;
+    if (entry.pluginPkg !== pluginPkg) return null;
+    const next: NotifierEntry = {
+      ...entry,
+      ...(patch.severity !== undefined ? { severity: patch.severity } : {}),
+      ...(patch.title !== undefined ? { title: patch.title } : {}),
+      ...(patch.body !== undefined ? { body: patch.body } : {}),
+      ...(patch.navigateTarget !== undefined ? { navigateTarget: patch.navigateTarget } : {}),
+      ...(patch.pluginData !== undefined ? { pluginData: patch.pluginData } : {}),
+    };
+    // Re-validate the merged shape so an update can't degrade the
+    // entry below publish-time invariants. Mirrors the
+    // `validatePublishInput` call in `publish` — same audit, just
+    // applied post-merge.
+    const validationError = validatePublishInput({
+      pluginPkg: next.pluginPkg,
+      severity: next.severity,
+      title: next.title,
+      body: next.body,
+      lifecycle: next.lifecycle,
+      navigateTarget: next.navigateTarget,
+      pluginData: next.pluginData,
+    });
+    if (validationError) {
+      log.warn("notifier", "update rejected by validation", { entryId, pluginPkg, error: validationError });
+      return null;
+    }
+    state.entries[entryId] = next;
+    return { event: { type: "updated", entry: next } };
   });
 }
 

--- a/server/notifier/runtime-api.ts
+++ b/server/notifier/runtime-api.ts
@@ -17,7 +17,7 @@
 // into gui-chat-protocol so the cast goes away.
 
 import type { PluginRuntime } from "gui-chat-protocol";
-import type { NotifierLifecycle, NotifierSeverity } from "./types.js";
+import type { NotifierEntry, NotifierLifecycle, NotifierSeverity } from "./types.js";
 import type { TasksRuntimeApi } from "../plugins/runtime-tasks-api.js";
 import type { ChatRuntimeApi } from "../plugins/runtime-chat-api.js";
 
@@ -88,6 +88,19 @@ export interface NotifierRuntimeApi {
    *  plugin's id (e.g. via a future leak) silently can't dismiss it.
    *  Internally backed by `engine.clearForPlugin(pluginPkg, id)`. */
   clear: (id: string) => Promise<void>;
+  /** Point lookup for an active entry the caller owns. Returns the
+   *  entry, or `undefined` when the id is unknown OR belongs to
+   *  another plugin (same isolation contract as `clear`).
+   *
+   *  Use this to detect ghost-bell ids — entries the plugin
+   *  published whose bell was dismissed via the bell UI or wiped
+   *  by a crash. A reconciler that calls `update` on a ghost id
+   *  gets a silent no-op back (the bell is gone, the patch has
+   *  nothing to land on), so without this check the plugin's
+   *  ticket store would falsely converge to "in sync" and the bell
+   *  would never come back. Encore's reconciler relies on the
+   *  engine equivalent (`engine.get`) for the same purpose. */
+  get: (id: string) => Promise<NotifierEntry | undefined>;
 }
 
 /** The runtime shape MulmoClaude actually provides — the

--- a/server/notifier/runtime-api.ts
+++ b/server/notifier/runtime-api.ts
@@ -53,6 +53,33 @@ export interface NotifierRuntimeApi {
    *  `action` requires a non-empty `navigateTarget` and cannot pair
    *  with `info` severity. */
   publish: <TPluginData = unknown>(input: PluginPublishInput<TPluginData>) => Promise<{ id: string }>;
+  /** In-place update of an existing entry's presentation. Only the
+   *  fields present on `patch` are rewritten; `id`, `pluginPkg`,
+   *  `lifecycle`, and `createdAt` stay fixed. Emits an `updated`
+   *  event — no history record is written.
+   *
+   *  Use this rather than clear-then-publish when the underlying
+   *  obligation is the same and only its presentation has shifted
+   *  (e.g. todo text renamed, Encore obligation `displayName`
+   *  amended, severity escalated). Preserves the entry's id, keeps
+   *  the bell history free of supersede noise, and avoids the
+   *  disappear/reappear that subscribers would otherwise see.
+   *
+   *  No-op (no throw) on unknown id, cross-plugin id, or a merged
+   *  shape that would violate publish-time invariants (action + info
+   *  severity, empty title, etc.). The silent skip matches `clear`'s
+   *  isolation semantics — plugin authors can't tell the failure
+   *  reasons apart, and we don't leak them by throwing differently. */
+  update: <TPluginData = unknown>(
+    id: string,
+    patch: {
+      severity?: NotifierSeverity;
+      title?: string;
+      body?: string;
+      navigateTarget?: string;
+      pluginData?: TPluginData;
+    },
+  ) => Promise<void>;
   /** Clear an entry by id. No-op (no throw) when:
    *   - the id is unknown, OR
    *   - the entry exists but belongs to a different plugin.

--- a/server/notifier/types.ts
+++ b/server/notifier/types.ts
@@ -117,5 +117,18 @@ export const HISTORY_CAP = 50;
 
 /** Pub-sub event published on `PUBSUB_CHANNELS.notifier` after every
  *  successful state change. Discriminated union — subscribers switch
- *  on `type` to keep TypeScript narrowing the rest of the payload. */
-export type NotifierEvent = { type: "published"; entry: NotifierEntry } | { type: "cleared"; id: string } | { type: "cancelled"; id: string };
+ *  on `type` to keep TypeScript narrowing the rest of the payload.
+ *
+ *  `updated` carries the post-mutation entry — the receiver swaps
+ *  the matching `id` in their local active set. Reserved for in-
+ *  place edits via `updateForPlugin`; no history record is written
+ *  because the entry is still active, just with refreshed content.
+ *  The right primitive for "state-of-the-world" notifications whose
+ *  presentation drifts while the underlying obligation persists
+ *  (e.g. Encore's amend-time title refresh, Todo's rename / priority
+ *  shift). */
+export type NotifierEvent =
+  | { type: "published"; entry: NotifierEntry }
+  | { type: "cleared"; id: string }
+  | { type: "cancelled"; id: string }
+  | { type: "updated"; entry: NotifierEntry };

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -255,7 +255,7 @@ function makeScopedPubSub(pkgName: string, hostPubSub: IPubSub): PluginRuntime["
 // ─────────────────────────────────────────────────────────────────────
 
 function makeScopedNotifier(pkgName: string): NotifierRuntimeApi {
-  // All three methods are plugin-scoped:
+  // Every method is plugin-scoped:
   //   - publish forces `pluginPkg` to the caller's pkg name (the
   //     plugin literally cannot publish under another's namespace).
   //   - update routes through `updateForPlugin` so a plugin can't
@@ -264,10 +264,14 @@ function makeScopedNotifier(pkgName: string): NotifierRuntimeApi {
   //   - clear routes through `clearForPlugin` so a plugin holding
   //     another plugin's id (e.g. via a future leak) silently no-ops
   //     instead of dismissing it. CodeRabbit review on PR #1198.
+  //   - get returns the entry only if it belongs to this plugin;
+  //     cross-plugin reads come back as `undefined`. Used for
+  //     ghost-bell detection in `action`-lifecycle reconcilers.
   return {
     publish: (input) => notifierEngine.publish({ ...input, pluginPkg: pkgName }),
     update: (entryId, patch) => notifierEngine.updateForPlugin(pkgName, entryId, patch),
     clear: (entryId) => notifierEngine.clearForPlugin(pkgName, entryId),
+    get: (entryId) => notifierEngine.getForPlugin(pkgName, entryId),
   };
 }
 

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -255,14 +255,18 @@ function makeScopedPubSub(pkgName: string, hostPubSub: IPubSub): PluginRuntime["
 // ─────────────────────────────────────────────────────────────────────
 
 function makeScopedNotifier(pkgName: string): NotifierRuntimeApi {
-  // Both `publish` and `clear` are plugin-scoped:
+  // All three methods are plugin-scoped:
   //   - publish forces `pluginPkg` to the caller's pkg name (the
   //     plugin literally cannot publish under another's namespace).
+  //   - update routes through `updateForPlugin` so a plugin can't
+  //     mutate another plugin's entries. Silent no-op on cross-
+  //     plugin id or validation failure.
   //   - clear routes through `clearForPlugin` so a plugin holding
   //     another plugin's id (e.g. via a future leak) silently no-ops
   //     instead of dismissing it. CodeRabbit review on PR #1198.
   return {
     publish: (input) => notifierEngine.publish({ ...input, pluginPkg: pkgName }),
+    update: (entryId, patch) => notifierEngine.updateForPlugin(pkgName, entryId, patch),
     clear: (entryId) => notifierEngine.clearForPlugin(pkgName, entryId),
   };
 }

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -39,7 +39,11 @@ export interface NotifierHistoryEntry extends NotifierEntry {
   terminalAt: string;
 }
 
-type NotifierEvent = { type: "published"; entry: NotifierEntry } | { type: "cleared"; id: string } | { type: "cancelled"; id: string };
+type NotifierEvent =
+  | { type: "published"; entry: NotifierEntry }
+  | { type: "cleared"; id: string }
+  | { type: "cancelled"; id: string }
+  | { type: "updated"; entry: NotifierEntry };
 
 const HISTORY_CAP = 50;
 
@@ -74,6 +78,22 @@ function applyEvent(event: NotifierEvent): void {
         entries.value = [...entries.value, event.entry];
       }
       return;
+    case "updated": {
+      // In-place replacement: same id, fresh title/body/severity.
+      // No history record — the entry is still active. If the id
+      // isn't in our local set (subscribed mid-flight, or the
+      // entry was optimistically cleared elsewhere), fall back to
+      // append so the bell at least surfaces live state.
+      const index = entries.value.findIndex((entry) => entry.id === event.entry.id);
+      if (index >= 0) {
+        const next = entries.value.slice();
+        next[index] = event.entry;
+        entries.value = next;
+      } else {
+        entries.value = [...entries.value, event.entry];
+      }
+      return;
+    }
     case "cleared":
     case "cancelled": {
       const removed = entries.value.find((entry) => entry.id === event.id);

--- a/test/plugins/test_encore_dispatch.ts
+++ b/test/plugins/test_encore_dispatch.ts
@@ -155,26 +155,35 @@ describe("Encore dispatch — component tests", () => {
     assert.equal(obligations[0].dsl.status, "paused");
   });
 
-  it("amendDefinition refreshes the bell with the new title", async () => {
+  it("amendDefinition refreshes the bell with the new title (in-place update — same id)", async () => {
+    // Pre-update-API behaviour: `amendDefinition` set
+    // `invalidateAllBells: true`, which cleared every bell for the
+    // cycle and republished, dumping `cleared` records into history
+    // and allocating a fresh notificationId per bell. With the
+    // engine's `update` op, the reconciler's trim path now detects
+    // title drift and patches each bell in place — same id, no
+    // history record. This test asserts the new contract.
     const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
     const before = await listFor("encore");
     assert.equal(before.length, 1, "setup should publish one bell entry");
-    const oldId = before[0].id;
+    const originalId = before[0].id;
     assert.match(before[0].title, /Hisayo/);
 
-    // Rename the obligation.
     await dispatch({
       kind: "amendDefinition",
       obligationId: setup.obligationId,
       definition: { displayName: "Daily payment — Renamed Person" },
     });
 
-    // The original bell entry must be gone; a fresh one with the
-    // new title must take its place.
     const after = await listFor("encore");
     assert.equal(after.length, 1, `expected exactly one bell entry after amend, got ${after.length}`);
-    assert.notEqual(after[0].id, oldId, "expected a fresh notification id (clear + republish)");
+    assert.equal(after[0].id, originalId, "in-place update must preserve the notificationId");
     assert.match(after[0].title, /Renamed Person/, `expected new title to contain "Renamed Person", got: ${after[0].title}`);
+
+    // Verify the no-history-pollution side of the new contract.
+    const { listHistory } = await import("../../server/notifier/engine.js");
+    const history = (await listHistory()).filter((entry) => entry.pluginPkg === "encore");
+    assert.equal(history.length, 0, "title-only amend must not write to notifier history");
   });
 
   it("amendDefinition recovers from a stale activeNotificationId (bell empty, cycle file holds an id)", async () => {

--- a/test/plugins/test_encore_reconcile.ts
+++ b/test/plugins/test_encore_reconcile.ts
@@ -356,19 +356,65 @@ describe("Encore reconciler — unit tests", () => {
     assert.equal(after.length, 1, `expected bell to re-fire once snoozes expired; got ${after.length}`);
   });
 
-  it("invalidateAllBells: clears every ticket for the cycle and republishes", async () => {
+  it("amendDefinition (displayName edit): updates bell title in place — same id, no history", async () => {
+    // Regression test for the migration off `invalidateAllBells`:
+    // a title-only amend used to clear every bell for the cycle and
+    // republish, dumping `cleared` records into history and giving
+    // each bell a fresh notificationId. With the engine's `update`
+    // op, the trim path now detects title drift and patches each
+    // bell in place. Same id, no flicker, no audit noise.
+    const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
+    const { obligationId } = setup;
+    if (!obligationId) throw new Error("setup should return obligationId");
+    const before = await listFor("encore");
+    assert.equal(before.length, 1);
+    const originalId = before[0].id;
+    const originalTitle = before[0].title;
+    assert.ok(originalTitle.includes("Daily payments — bundled"), `seed title must include the original displayName; got ${JSON.stringify(originalTitle)}`);
+
+    await dispatch({
+      kind: "amendDefinition",
+      obligationId,
+      definition: { displayName: "Daily payments — RENAMED" },
+    });
+
+    const after = await listFor("encore");
+    assert.equal(after.length, 1, "bell count must be unchanged");
+    assert.equal(after[0].id, originalId, "notificationId must stay stable across a title-only amend");
+    assert.ok(after[0].title.includes("RENAMED"), `bell title must reflect the new displayName; got ${JSON.stringify(after[0].title)}`);
+    assert.ok(!after[0].title.includes("bundled"), "old title fragment must not leak through");
+
+    const { listHistory } = await import("../../server/notifier/engine.js");
+    const history = (await listHistory()).filter((entry) => entry.pluginPkg === "encore");
+    assert.equal(history.length, 0, "title-amend must NOT pollute notifier history (regression from invalidateAllBells)");
+  });
+
+  it("amendDefinition is idempotent — re-running reconcile doesn't re-update unchanged bells", async () => {
+    // The trim path's drift check compares ticket.title/body against
+    // the recomputed bundle. After the first reconcile rewrites the
+    // ticket with fresh title/body, subsequent reconciles see no
+    // drift and short-circuit — no engine update calls, no log
+    // noise. Catches a regression where the comparison is wrong
+    // (e.g. always-update or always-skip).
     const setup = (await dispatch({ kind: "setup", definition: twoTargetDef })) as SetupResult;
     const { obligationId, cycleId } = setup;
     if (!obligationId || !cycleId) throw new Error("setup should return ids");
-    const before = await listFor("encore");
-    assert.equal(before.length, 1);
-    const oldId = before[0].id;
 
-    await reconcileCycleNotifications({ obligationId, cycleId, now: new Date(), invalidateAllBells: true });
+    await dispatch({
+      kind: "amendDefinition",
+      obligationId,
+      definition: { displayName: "Round 1 rename" },
+    });
+    const firstPass = await listFor("encore");
+    const firstId = firstPass[0].id;
+    const firstTitle = firstPass[0].title;
 
-    const after = await listFor("encore");
-    assert.equal(after.length, 1, "bell count should match (cleared then republished)");
-    assert.notEqual(after[0].id, oldId, "notification id must change (clear + republish)");
+    // Second reconcile with no DSL change between passes. The trim
+    // path should see "ticket.title === desiredTitle" and skip.
+    await reconcileCycleNotifications({ obligationId, cycleId, now: new Date() });
+    const secondPass = await listFor("encore");
+    assert.equal(secondPass[0].id, firstId, "idempotent reconcile must not churn the id");
+    assert.equal(secondPass[0].title, firstTitle, "idempotent reconcile must not rewrite the title");
   });
 
   it("notifier boundary: only reconcile.ts + ticket-orphan sweep paths invoke encoreNotifier.{publish,clear}", async () => {

--- a/test/plugins/test_todo_plugin_integration.ts
+++ b/test/plugins/test_todo_plugin_integration.ts
@@ -638,6 +638,44 @@ describe("Todo plugin — priority-alert notifications", () => {
     assert.equal(after[0].title, beforeEntry.title, "idempotent reconcile must not rewrite the title");
   });
 
+  it("ghost-bell recovery: out-of-band clear → next mutation re-publishes a fresh entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    // Regression for the Codex CHANGES REQUESTED ghost-id finding.
+    // Simulates the user dismissing the bell via the bell UI: we
+    // call `engine.clear` directly to wipe the active entry while
+    // leaving the plugin's ticket file untouched. The next
+    // reconcile (triggered by any mutation) must detect the ghost
+    // via `notifier.get`, drop the stale ticket, and re-publish a
+    // fresh entry from Phase 2. Without the get-based check, the
+    // bell would stay gone forever — `notifier.update` would
+    // silently no-op on the dead id and the ticket would lie about
+    // being in sync.
+    const plugin = await load();
+    await plugin.execute({}, { kind: "itemCreate", text: "Ghost recovery", priority: "urgent" });
+    const [seed] = await notifierEngine.listFor(PKG_NAME);
+    assert.ok(seed);
+    const seedId = seed.id;
+
+    // Dismiss the bell out-of-band, matching what the bell UI's
+    // "clear" button does (engine-level clear, not plugin-routed).
+    const { clear: hostClear } = await import("../../server/notifier/engine.js");
+    await hostClear(seedId);
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 0, "bell must be gone after out-of-band clear");
+
+    // Any subsequent reconcile pass should rebuild. Trigger one
+    // via a no-op-ish mutation (label change) that flows through
+    // handleUi → reconcileNotifications.
+    await plugin.execute({}, { kind: "itemPatch", id: seed.pluginData && (seed.pluginData as { todoId?: string }).todoId, labels: ["alive"] });
+
+    const after = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(after.length, 1, "ghost-recovery must re-publish exactly one fresh bell");
+    assert.notEqual(after[0].id, seedId, "the new entry must have a fresh notificationId");
+    assert.equal(after[0].title, "Ghost recovery");
+  });
+
   it("oversize note is clamped to the engine's body cap (no silent validation rejection)", async (ctx) => {
     if (!existsSync(PLUGIN_DIST_INDEX)) {
       ctx.skip("dist not built");

--- a/test/plugins/test_todo_plugin_integration.ts
+++ b/test/plugins/test_todo_plugin_integration.ts
@@ -16,6 +16,7 @@ import { makePluginRuntime } from "../../server/plugins/runtime.js";
 import { createTaskManager } from "../../server/events/task-manager/index.js";
 import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
 import type { IPubSub } from "../../server/events/pub-sub/index.js";
+import * as notifierEngine from "../../server/notifier/engine.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -443,5 +444,270 @@ describe("Todo plugin — end-to-end through the loader", () => {
     const res = (await plugin.execute({}, { foo: "bar" } as never)) as TodoResult;
     assert.ok(res.error);
     assert.equal(res.status, 400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Priority-alert notifications
+//
+// The plugin maintains an `action`-lifecycle notification for every
+// item with `priority ∈ {"urgent", "high"} && !completed`. Reconcile
+// runs after every mutation, with `pluginData.priority` carrying the
+// snapshot so a priority transition (high → urgent or vice versa)
+// clears the old entry and republishes with the right severity.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("Todo plugin — priority-alert notifications", () => {
+  // The integration test loads the built dist via `loadPluginFromCacheDir`
+  // and the real `makePluginRuntime`, which attaches a real notifier
+  // backed by `notifierEngine`. We redirect the engine's file paths
+  // to a tmp dir so reads/writes don't touch the user's workspace.
+  let notifierTmpDir: string;
+  let savedDataDescriptor: PropertyDescriptor | undefined;
+  let savedConfigDescriptor: PropertyDescriptor | undefined;
+  let dataRoot: string;
+  let configRoot: string;
+
+  beforeEach(() => {
+    notifierTmpDir = mkdtempSync(path.join(tmpdir(), "todo-int-notifier-"));
+    notifierEngine._setFilePathsForTesting({
+      active: path.join(notifierTmpDir, "active.json"),
+      history: path.join(notifierTmpDir, "history.json"),
+    });
+    savedDataDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsData");
+    savedConfigDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "pluginsConfig");
+    dataRoot = mkdtempSync(path.join(tmpdir(), "todo-int-data-"));
+    configRoot = mkdtempSync(path.join(tmpdir(), "todo-int-config-"));
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", { ...savedDataDescriptor, value: dataRoot });
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", { ...savedConfigDescriptor, value: configRoot });
+  });
+
+  afterEach(() => {
+    if (savedDataDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsData", savedDataDescriptor);
+    if (savedConfigDescriptor) Object.defineProperty(WORKSPACE_PATHS, "pluginsConfig", savedConfigDescriptor);
+    rmSync(dataRoot, { recursive: true, force: true });
+    rmSync(configRoot, { recursive: true, force: true });
+    rmSync(notifierTmpDir, { recursive: true, force: true });
+  });
+
+  async function load(): Promise<{ execute: NonNullable<NonNullable<Awaited<ReturnType<typeof loadPluginFromCacheDir>>>["execute"]> }> {
+    const { pubsub } = makeRecordingPubSub();
+    const plugin = await loadPluginFromCacheDir(PKG_NAME, VERSION, PLUGIN_DIR, {
+      runtimeFactory: (pkgName) => makePluginRuntime({ pkgName, pubsub, locale: "en", taskManager: createTaskManager() }),
+    });
+    assert.ok(plugin?.execute);
+    return { execute: plugin.execute };
+  }
+
+  it("itemCreate with priority=urgent publishes a single 'urgent' entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    await plugin.execute({}, { kind: "itemCreate", text: "Pay tax", priority: "urgent" });
+    const entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 1, "should publish exactly one entry");
+    assert.equal(entries[0].severity, "urgent");
+    assert.equal(entries[0].lifecycle, "action");
+    assert.equal(entries[0].navigateTarget, "/todos");
+    // Title is the todo text verbatim — severity is signalled by the
+    // bell's color badge (and on-disk `pluginData.priority`), not by
+    // a prefix in the title.
+    assert.equal(entries[0].title, "Pay tax");
+  });
+
+  it("itemCreate with priority=high publishes a single 'nudge' entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    await plugin.execute({}, { kind: "itemCreate", text: "Review PR", priority: "high" });
+    const entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].severity, "nudge");
+    assert.equal(entries[0].title, "Review PR");
+  });
+
+  it("itemCreate without notifiable priority publishes nothing", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    await plugin.execute({}, { kind: "itemCreate", text: "Buy milk", priority: "low" });
+    await plugin.execute({}, { kind: "itemCreate", text: "Email Sue", priority: "medium" });
+    await plugin.execute({}, { kind: "itemCreate", text: "Read book" });
+    const entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 0);
+  });
+
+  it("itemPatch to add priority publishes; remove priority clears", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Maybe urgent" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 0);
+
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, priority: "urgent" });
+    let entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].severity, "urgent");
+
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, priority: "medium" });
+    entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 0, "downgrading out of urgent/high must clear the entry");
+  });
+
+  it("priority transition urgent → high updates the bell in place (same id, new severity)", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Shift severity", priority: "urgent" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    const firstId = (await notifierEngine.listFor(PKG_NAME))[0]?.id;
+    assert.ok(firstId);
+
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, priority: "high" });
+    const entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 1, "still exactly one entry");
+    assert.equal(entries[0].severity, "nudge", "severity must follow the new priority");
+    assert.equal(entries[0].id, firstId, "in-place update must preserve the notification id");
+    // Title is the todo text verbatim — priority is signalled by the
+    // bell's color badge, not by a textual prefix.
+    assert.equal(entries[0].title, "Shift severity", "title must remain the todo text after a priority shift");
+
+    // The whole point of the migration to notifier.update: a priority
+    // shift on a still-active todo no longer pollutes history. The
+    // bell entry is the same one, just with new severity / title.
+    const history = await notifierEngine.listHistory();
+    assert.equal(history.filter((entry) => entry.pluginPkg === PKG_NAME).length, 0, "priority transition must NOT write to history");
+  });
+
+  it("rename updates the bell title in place (same id, no churn)", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Original name", priority: "urgent" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    const [firstEntry] = await notifierEngine.listFor(PKG_NAME);
+    assert.ok(firstEntry);
+    assert.match(firstEntry.title, /Original name/, "seed bell must include the original todo text");
+
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, text: "Renamed" });
+    const entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 1, "rename must not duplicate the bell entry");
+    assert.equal(entries[0].id, firstEntry.id, "rename must reuse the same notification id");
+    assert.match(entries[0].title, /Renamed/, "rename must update the bell title in place");
+    assert.ok(!entries[0].title.includes("Original name"), "old title fragment must not leak through");
+
+    const history = await notifierEngine.listHistory();
+    assert.equal(history.filter((entry) => entry.pluginPkg === PKG_NAME).length, 0, "rename must NOT write to history");
+  });
+
+  it("reconcile is idempotent — repeat dispatches with no content drift don't churn the bell", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Steady", priority: "high" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    const [beforeEntry] = await notifierEngine.listFor(PKG_NAME);
+    assert.ok(beforeEntry);
+    const beforeId = beforeEntry.id;
+
+    // A second patch that doesn't change anything notification-
+    // relevant (e.g. labels) must not trigger an update.
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, labels: ["new-label"] });
+    const after = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(after.length, 1);
+    assert.equal(after[0].id, beforeId, "idempotent reconcile must not churn the id");
+    assert.equal(after[0].title, beforeEntry.title, "idempotent reconcile must not rewrite the title");
+  });
+
+  it("checking (completed=true via itemPatch) clears the entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Tick me", priority: "urgent" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 1);
+
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, completed: true });
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 0);
+  });
+
+  it("itemMove into the done column flips completed and clears the entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Drag to done", priority: "high" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 1);
+
+    await plugin.execute({}, { kind: "itemMove", id: itemId, status: "done", position: 0 });
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 0);
+  });
+
+  it("itemDelete clears the entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Delete me", priority: "urgent" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 1);
+
+    await plugin.execute({}, { kind: "itemDelete", id: itemId });
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 0);
+  });
+
+  it("LLM check action on an urgent item clears the entry", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    await plugin.execute({}, { kind: "itemCreate", text: "LLM-check me", priority: "urgent" });
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 1);
+
+    // The LLM `check` action matches by partial text and flips
+    // completed=true on a hit. Reconcile then clears the entry.
+    await plugin.execute({}, { action: "check", text: "LLM-check" });
+    assert.equal((await notifierEngine.listFor(PKG_NAME)).length, 0);
+  });
+
+  it("isolates entries across plugin scopes (listFor returns only ours)", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    const plugin = await load();
+    await plugin.execute({}, { kind: "itemCreate", text: "Scoped", priority: "urgent" });
+    const ours = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(ours.length, 1);
+    const others = await notifierEngine.listFor("@mulmoclaude/some-other-plugin");
+    assert.equal(others.length, 0, "another plugin's listFor must not see todo entries");
   });
 });

--- a/test/plugins/test_todo_plugin_integration.ts
+++ b/test/plugins/test_todo_plugin_integration.ts
@@ -638,6 +638,26 @@ describe("Todo plugin — priority-alert notifications", () => {
     assert.equal(after[0].title, beforeEntry.title, "idempotent reconcile must not rewrite the title");
   });
 
+  it("oversize note is clamped to the engine's body cap (no silent validation rejection)", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    // Regression for the Codex CHANGES REQUESTED finding: the engine
+    // rejects publish/update patches with body > 4000 chars by
+    // silently no-op'ing the update (no throw, no event). Without a
+    // plugin-side clamp, `safeUpdate` would falsely report success
+    // and the ticket would lie about being in sync. We clamp body
+    // to `BODY_MAX` in `buildBody` so this validation case can
+    // never fire — see priority-notifier.ts.
+    const plugin = await load();
+    const oversize = "x".repeat(5000);
+    await plugin.execute({}, { kind: "itemCreate", text: "Big note", note: oversize, priority: "urgent" });
+    const entries = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(entries.length, 1, "publish must succeed on an oversized note (clamped)");
+    assert.ok((entries[0].body ?? "").length <= 4000, `body must be at or under engine bodyMax; got ${(entries[0].body ?? "").length}`);
+  });
+
   it("removing the note from an alerting todo clears the bell's body", async (ctx) => {
     if (!existsSync(PLUGIN_DIST_INDEX)) {
       ctx.skip("dist not built");

--- a/test/plugins/test_todo_plugin_integration.ts
+++ b/test/plugins/test_todo_plugin_integration.ts
@@ -638,6 +638,34 @@ describe("Todo plugin — priority-alert notifications", () => {
     assert.equal(after[0].title, beforeEntry.title, "idempotent reconcile must not rewrite the title");
   });
 
+  it("removing the note from an alerting todo clears the bell's body", async (ctx) => {
+    if (!existsSync(PLUGIN_DIST_INDEX)) {
+      ctx.skip("dist not built");
+      return;
+    }
+    // Regression for the codex/sourcery/github-actions review findings:
+    // a previous build skipped the body field from `notifier.update`
+    // when desiredBody became undefined, but still wrote
+    // `body: undefined` to `urgent-tickets.json`. The bell kept the
+    // old note text forever while the ticket lied about being in
+    // sync. `buildBody` now returns "" rather than undefined so the
+    // patch always carries a concrete value through.
+    const plugin = await load();
+    const created = (await plugin.execute({}, { kind: "itemCreate", text: "Pay tax", note: "draft K-1 first", priority: "urgent" })) as TodoResult;
+    const itemId = created.data?.items?.[0]?.id;
+    assert.ok(itemId);
+    const [seed] = await notifierEngine.listFor(PKG_NAME);
+    assert.ok(seed);
+    assert.equal(seed.body, "draft K-1 first", "initial publish should carry the note as body");
+
+    // Remove the note. itemPatch treats `note: ""` / `null` as a
+    // clear (see applyNotePatch in handlers/items.ts).
+    await plugin.execute({}, { kind: "itemPatch", id: itemId, note: null });
+    const [after] = await notifierEngine.listFor(PKG_NAME);
+    assert.equal(after.id, seed.id, "in-place update — id is stable");
+    assert.equal(after.body, "", "bell's body must drop to empty, not stay as the old note");
+  });
+
   it("checking (completed=true via itemPatch) clears the entry", async (ctx) => {
     if (!existsSync(PLUGIN_DIST_INDEX)) {
       ctx.skip("dist not built");

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -9,6 +9,7 @@ import {
   cancel,
   clearForPlugin,
   updateForPlugin,
+  getForPlugin,
   get,
   listFor,
   listAll,
@@ -721,5 +722,38 @@ describe("updateForPlugin (in-place state refresh)", () => {
     const [terminal] = await listHistory();
     assert.equal(terminal.id, id);
     assert.equal(terminal.title, "t2", "history records the LAST seen title before clear");
+  });
+});
+
+describe("getForPlugin (scoped point lookup)", () => {
+  it("returns the entry when caller owns it", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "mine" });
+    const entry = await getForPlugin("@scope/owner", id);
+    assert.ok(entry);
+    assert.equal(entry.id, id);
+    assert.equal(entry.title, "mine");
+  });
+
+  it("returns undefined for an unknown id (ghost bell)", async () => {
+    const entry = await getForPlugin("@scope/owner", "00000000-0000-0000-0000-000000000000");
+    assert.equal(entry, undefined);
+  });
+
+  it("returns undefined when the entry belongs to another plugin (isolation)", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/a", severity: "info", title: "ours" });
+    // Probe from another plugin — must not be readable, same shape
+    // as clearForPlugin/updateForPlugin isolation.
+    const fromStranger = await getForPlugin("@scope/b", id);
+    assert.equal(fromStranger, undefined, "cross-plugin lookups must come back as undefined");
+    // Owner can still see it.
+    const fromOwner = await getForPlugin("@scope/a", id);
+    assert.ok(fromOwner, "owner read must succeed");
+  });
+
+  it("returns undefined for an entry that was just cleared (ghost detection works post-clear)", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "doomed" });
+    assert.ok(await getForPlugin("@scope/owner", id), "alive before clear");
+    await clearForPlugin("@scope/owner", id);
+    assert.equal(await getForPlugin("@scope/owner", id), undefined, "absent after clear");
   });
 });

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -8,6 +8,7 @@ import {
   clear,
   cancel,
   clearForPlugin,
+  updateForPlugin,
   get,
   listFor,
   listAll,
@@ -594,5 +595,131 @@ describe("clearForPlugin (per-plugin isolation)", () => {
     const { id: stranger } = await publish({ pluginPkg: "@scope/b", severity: "info", title: "theirs" });
     await clearForPlugin("@scope/a", stranger); // attempt
     assert.deepEqual(await listHistory(), []);
+  });
+});
+
+describe("updateForPlugin (in-place state refresh)", () => {
+  it("rewrites only the patched fields and keeps id, lifecycle, createdAt, pluginPkg fixed", async () => {
+    const { id } = await publish({
+      pluginPkg: "@scope/owner",
+      severity: "nudge",
+      lifecycle: "action",
+      title: "Pay tax",
+      body: "Due Friday",
+      navigateTarget: "/x",
+      pluginData: { todoId: "abc" },
+    });
+    const before = await get(id);
+    assert.ok(before);
+    const { createdAt } = before;
+
+    await updateForPlugin("@scope/owner", id, { title: "Pay state tax", severity: "urgent" });
+
+    const after = await get(id);
+    assert.ok(after);
+    assert.equal(after.id, id, "id must be stable");
+    assert.equal(after.pluginPkg, "@scope/owner");
+    assert.equal(after.lifecycle, "action", "lifecycle is not updatable");
+    assert.equal(after.createdAt, createdAt, "createdAt must be stable");
+    assert.equal(after.title, "Pay state tax", "title rewritten");
+    assert.equal(after.severity, "urgent", "severity rewritten");
+    assert.equal(after.body, "Due Friday", "body not in patch — must be preserved");
+    assert.equal(after.navigateTarget, "/x", "navigateTarget not in patch — must be preserved");
+    assert.deepEqual(after.pluginData, { todoId: "abc" }, "pluginData not in patch — must be preserved");
+  });
+
+  it("emits exactly one `updated` event after a successful update", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "t" });
+    emittedEvents.length = 0;
+    await updateForPlugin("@scope/owner", id, { title: "t2" });
+    assert.equal(emittedEvents.length, 1);
+    const [event] = emittedEvents;
+    assert.equal(event.type, "updated");
+    if (event.type === "updated") {
+      assert.equal(event.entry.id, id);
+      assert.equal(event.entry.title, "t2");
+    }
+  });
+
+  it("never writes to history (updated entries are still active)", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "t" });
+    await updateForPlugin("@scope/owner", id, { title: "t2" });
+    assert.deepEqual(await listHistory(), [], "update must not pollute history");
+  });
+
+  it("survives a JSON round-trip (active.json persists the new fields)", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "first" });
+    await updateForPlugin("@scope/owner", id, { title: "second", body: "now with body" });
+    // The file on disk is the source of truth — re-read it directly.
+    const fileContents = JSON.parse(readFileSync(activeFile, "utf-8"));
+    assert.equal(fileContents.entries[id].title, "second");
+    assert.equal(fileContents.entries[id].body, "now with body");
+  });
+
+  it("silently no-ops on unknown id", async () => {
+    emittedEvents.length = 0;
+    await updateForPlugin("@scope/anyone", "00000000-0000-0000-0000-000000000000", { title: "ghost" });
+    assert.equal(emittedEvents.length, 0);
+    assert.deepEqual(await listHistory(), []);
+  });
+
+  it("silently no-ops when the entry belongs to another plugin", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "theirs" });
+    emittedEvents.length = 0;
+    await updateForPlugin("@scope/intruder", id, { title: "hijacked" });
+    const after = await get(id);
+    assert.equal(after?.title, "theirs", "another plugin must not be able to mutate this entry");
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it("rejects a patch that would make action+info severity (validation re-runs)", async () => {
+    const { id } = await publish({
+      pluginPkg: "@scope/owner",
+      severity: "nudge",
+      lifecycle: "action",
+      title: "Live",
+      navigateTarget: "/x",
+    });
+    emittedEvents.length = 0;
+    await updateForPlugin("@scope/owner", id, { severity: "info" });
+    // Patch silently rejected — entry unchanged, no event emitted.
+    const after = await get(id);
+    assert.equal(after?.severity, "nudge", "severity must not have dropped to info on an action entry");
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it("rejects a patch that would empty the title", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "non-empty" });
+    emittedEvents.length = 0;
+    await updateForPlugin("@scope/owner", id, { title: "" });
+    const after = await get(id);
+    assert.equal(after?.title, "non-empty", "empty title rejected, original preserved");
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it("rejects a patch that would oversize the title", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "ok" });
+    emittedEvents.length = 0;
+    await updateForPlugin("@scope/owner", id, { title: "x".repeat(NOTIFIER_LIMITS.titleMax + 1) });
+    const after = await get(id);
+    assert.equal(after?.title, "ok");
+    assert.equal(emittedEvents.length, 0);
+  });
+
+  it("allows updating pluginData (opaque round-trip, like publish)", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "t", pluginData: { v: 1 } });
+    await updateForPlugin("@scope/owner", id, { pluginData: { v: 2, extra: "added" } });
+    const after = await get(id);
+    assert.deepEqual(after?.pluginData, { v: 2, extra: "added" });
+  });
+
+  it("does not interfere with a subsequent clear (same id, normal terminal path)", async () => {
+    const { id } = await publish({ pluginPkg: "@scope/owner", severity: "info", title: "t" });
+    await updateForPlugin("@scope/owner", id, { title: "t2" });
+    await clearForPlugin("@scope/owner", id);
+    assert.equal(await get(id), undefined, "entry removed by clear");
+    const [terminal] = await listHistory();
+    assert.equal(terminal.id, id);
+    assert.equal(terminal.title, "t2", "history records the LAST seen title before clear");
   });
 });


### PR DESCRIPTION
## Summary

- Adds a new **`updateForPlugin(pkg, id, patch)`** op to the notifier engine: in-place edit of severity/title/body/pluginData on a still-active entry. No history record, no flicker, same id. Matches the missing primitive for "state-of-the-world" notifications.
- **Encore migration**: drops the `invalidateAllBells` workaround. The reconciler's trim path now detects severity/title/body drift per ticket and patches each bell in place — a `displayName` amend no longer dumps every bell into history.
- **Todo plugin**: introduces action-lifecycle bell entries for unchecked todos with `priority ∈ {urgent, high}`. Rename, priority shift, and re-priority all flow through `notifier.update` — the user sees one bell entry whose content updates, not "old cleared, new published".

## Design

The engine had `publish` + `clear` but no `update`. That's the right shape for discrete events but wrong for entries that mirror live state — every content refresh had to clear-then-publish, polluting the bell's history and allocating a new id. Two existing callers had grown workarounds around the gap:

- Encore's `amendDefinition` set `invalidateAllBells: true` which nuked every bell for the cycle. The inline comment described it as "stale text" being patched with a sledgehammer.
- The new todo priority-alert feature kept hitting a "two notifications for one item" UX bug whenever the underlying item changed.

`updateForPlugin` collapses both to a single in-place patch:

- **Engine**: `next = { ...entry, ...patch }` then `validatePublishInput` on the merged shape (so an action entry can't be degraded to `info` severity, title can't be emptied, etc.). Emits `{ type: "updated", entry }`. No history write.
- **Runtime API**: `notifier.update(id, patch)` on `NotifierRuntimeApi`; same isolation as `clearForPlugin` (silent no-op on cross-plugin / unknown / invalid).
- **Bell composable**: `applyEvent` handles `updated` by find-id-and-swap. No history record on the client side either.

## Encore migration

- `Ticket` (`server/encore/tick.ts`) gains optional `title?` / `body?` as the drift baseline. Legacy tickets without these fields read as "always drifted" on first sight → one idempotent update + backfill, then steady state.
- `reconcile.ts:trimOrEscalateTicket` computes desired severity/title/body once, compares to the ticket snapshot, and routes:
  - **Ghost ticket** (bell wiped out-of-band) → fresh publish, new id, preserves `pendingId`/`seedPrompt`/`chatSessionId` for chat continuity.
  - **Content drift** → `notifier.update(id, patch)` + rewrite ticket. Same id, no history record. This is the new common path.
  - **Targets shrunk without content drift** (rare — bundleTitle/Body happen to render identically) → rewrite ticket only.
- `invalidateAllBells` field and `clearAllForCycle` helper are deleted.
- `amend.ts` drops the flag from its reconcile call.

## Todo plugin

- New `packages/plugins/todo-plugin/src/handlers/priority-notifier.ts`. Encore-style `urgent-tickets.json` (`todoId → { notificationId, priority, title, body }`) as the source of truth — no dependency on `notifier.list`.
- `priority: "urgent"` → severity `urgent` (red); `priority: "high"` → severity `nudge` (amber). `lifecycle: "action"`, `navigateTarget: "/todos"`.
- Title is the todo text verbatim — color badge signals severity; no redundant "Urgent: " / "High priority: " prefix.
- Wired into `index.ts` after every mutating dispatch (LLM + UI). Boot reconcile runs once on plugin init.

## Test plan

- [x] **Engine** (`test/server/notifier/test_engine.ts`) — 12 new tests for `updateForPlugin`: field preservation, event emission, no-history, JSON round-trip, cross-plugin isolation, validation rejection (action+info, empty title, oversized), pluginData round-trip, clear-after-update.
- [x] **Encore reconcile** (`test/plugins/test_encore_reconcile.ts`) — replaced obsolete `invalidateAllBells` test with two new ones: title-amend keeps the same id and writes nothing to history; second reconcile after amend is idempotent.
- [x] **Encore dispatch** (`test/plugins/test_encore_dispatch.ts`) — updated `amendDefinition refreshes the bell` test to assert in-place semantics + empty history.
- [x] **Todo integration** (`test/plugins/test_todo_plugin_integration.ts`) — new suite of 11 tests covering urgent/high create, transition, rename, check, move-to-done, delete, LLM check, scope isolation, idempotency.
- [x] `yarn typecheck` ✅
- [x] `yarn lint` ✅
- [x] `yarn build` ✅
- [x] `yarn test` ✅ all 16 suites pass, zero failures
- [x] `yarn test:e2e` ✅ 429/429 passed (1.9m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce in-place notification updates in the notifier engine and migrate Encore and the todo plugin to use it for stable, non-flickering alerts.

New Features:
- Add a notifier runtime/API update operation for in-place edits to active notifications without changing ids or writing history.
- Introduce priority-based action notifications for urgent and high-priority todos that track item state changes and lifecycle.

Bug Fixes:
- Eliminate duplicate or churned notifications for todo priority changes and Encore definition amendments by replacing clear-then-publish flows with in-place updates.

Enhancements:
- Update Encore’s reconciliation logic to detect severity/title/body drift per ticket, updating existing bells in place and persisting the drift baseline on tickets.
- Extend the client notifications composable and notifier event types to handle updated events for seamless UI refreshes.
- Scope the plugin runtime notifier to support the new update operation while maintaining per-plugin isolation.

Tests:
- Add comprehensive notifier engine tests for update semantics, validation, and history behavior, plus new and updated Encore and todo plugin integration tests covering reconcile idempotency and priority-alert flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Todo priority alerts: urgent/high tasks publish persistent notifications that stay synchronized with task state.

* **Bug Fixes**
  * Notifications are updated in place (no churn of IDs), preserving history and reducing noise.
  * Reconciliation now trims, refreshes, or republishes notifications reliably, handling deleted or ghosted entries gracefully.

* **Tests**
  * Expanded end-to-end and engine tests covering publish, update, clear, idempotency, and scope isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->