### PR TITLE
feat(todo): polish done-column menu — check icon, scoped actions, click-outside dismiss

### DIFF
--- a/e2e/tests/todo-columns.spec.ts
+++ b/e2e/tests/todo-columns.spec.ts
@@ -215,9 +215,10 @@ test.describe("Todo column management", () => {
     await todoColumn.locator("text=more_horiz").click();
     await expect(page.getByRole("button", { name: "Rename" })).toBeVisible();
 
-    // Click on an empty corner of the body — the document-level
-    // listener should fire and close the menu.
-    await page.locator("body").click({ position: { x: 1, y: 1 } });
+    // Click a stable element outside the menu wrapper (the search box
+    // up in the explorer chrome). The document-level listener should
+    // fire and close the menu.
+    await page.getByTestId("todo-search").click();
     await expect(page.getByRole("button", { name: "Rename" })).toHaveCount(0);
   });
 

--- a/e2e/tests/todo-columns.spec.ts
+++ b/e2e/tests/todo-columns.spec.ts
@@ -35,6 +35,16 @@ async function setupTodoMocks(page: Page): Promise<void> {
       }
       return undefined;
     },
+    dispatchItem(method, path, _body, state) {
+      // Item deletion is wired up here so the "Remove all items" flow
+      // can actually shrink the state. The other item verbs aren't
+      // exercised in this file.
+      const [idSegment] = path.split("/");
+      if (method === "DELETE" && idSegment) {
+        return { items: state.items.filter((todoItem) => todoItem.id !== idSegment) };
+      }
+      return undefined;
+    },
   });
 }
 
@@ -103,7 +113,7 @@ test.describe("Todo column management", () => {
     await expect(page.getByText("Mark as done column")).toBeVisible();
   });
 
-  test("done column's menu shows Already done column", async ({ page }) => {
+  test("done column's menu hides Mark-as-done and disables Delete column", async ({ page }) => {
     await page.goto(TODOS_URL);
     await expect(page.getByText("Todo").first()).toBeVisible({
       timeout: 5 * ONE_SECOND_MS,
@@ -111,7 +121,104 @@ test.describe("Todo column management", () => {
 
     const doneColumn = page.locator('[data-testid="todo-column-done"]');
     await doneColumn.locator("text=more_horiz").click();
-    await expect(page.getByText("Already done column")).toBeVisible();
+
+    // The Mark-as-done entry is the previous menu item — gone now
+    // because the column is already the done column.
+    await expect(page.getByRole("button", { name: "Mark as done column" })).toHaveCount(0);
+    // Delete column is still rendered, but disabled.
+    await expect(page.getByRole("button", { name: "Delete column" })).toBeDisabled();
+  });
+
+  test("done column header shows a check icon, not a colored dot", async ({ page }) => {
+    await page.goto(TODOS_URL);
+    await expect(page.getByText("Todo").first()).toBeVisible({
+      timeout: 5 * ONE_SECOND_MS,
+    });
+
+    const doneHeader = page.locator('[data-testid="todo-column-done"]');
+    // The check icon is the only material-icon-rendered glyph inside the
+    // column header that reads as "check". The dot has no text content,
+    // so getByText would never have matched it.
+    await expect(doneHeader.getByText("check", { exact: true })).toBeVisible();
+
+    // Non-done columns must NOT render a check icon.
+    const todoHeader = page.locator('[data-testid="todo-column-todo"]');
+    await expect(todoHeader.getByText("check", { exact: true })).toHaveCount(0);
+  });
+
+  test("done column menu shows Remove all items", async ({ page }) => {
+    await page.goto(TODOS_URL);
+    await expect(page.getByText("Todo").first()).toBeVisible({
+      timeout: 5 * ONE_SECOND_MS,
+    });
+
+    const doneColumn = page.locator('[data-testid="todo-column-done"]');
+    await doneColumn.locator("text=more_horiz").click();
+    await expect(page.getByRole("button", { name: "Remove all items" })).toBeVisible();
+  });
+
+  test("non-done column menu does NOT show Remove all items", async ({ page }) => {
+    await page.goto(TODOS_URL);
+    await expect(page.getByText("Todo").first()).toBeVisible({
+      timeout: 5 * ONE_SECOND_MS,
+    });
+
+    const todoColumn = page.locator('[data-testid="todo-column-todo"]');
+    await todoColumn.locator("text=more_horiz").click();
+    // The menu is open (Rename is the canary).
+    await expect(page.getByRole("button", { name: "Rename" })).toBeVisible();
+    // But there's no Remove-all-items entry.
+    await expect(page.getByRole("button", { name: "Remove all items" })).toHaveCount(0);
+  });
+
+  test("Remove all items: confirm wipes the column's cards", async ({ page }) => {
+    page.on("dialog", (dialog) => dialog.accept());
+
+    await page.goto(TODOS_URL);
+    await expect(page.getByText("Todo").first()).toBeVisible({
+      timeout: 5 * ONE_SECOND_MS,
+    });
+    // Seeded fixture has one item in the done column.
+    await expect(page.getByText("Clean kitchen")).toBeVisible();
+
+    const doneColumn = page.locator('[data-testid="todo-column-done"]');
+    await doneColumn.locator("text=more_horiz").click();
+    await page.getByRole("button", { name: "Remove all items" }).click();
+
+    await expect(page.getByText("Clean kitchen")).toHaveCount(0);
+  });
+
+  test("Remove all items: dismissing the confirm keeps the cards", async ({ page }) => {
+    page.on("dialog", (dialog) => dialog.dismiss());
+
+    await page.goto(TODOS_URL);
+    await expect(page.getByText("Todo").first()).toBeVisible({
+      timeout: 5 * ONE_SECOND_MS,
+    });
+    await expect(page.getByText("Clean kitchen")).toBeVisible();
+
+    const doneColumn = page.locator('[data-testid="todo-column-done"]');
+    await doneColumn.locator("text=more_horiz").click();
+    await page.getByRole("button", { name: "Remove all items" }).click();
+
+    // Same card still around after the user cancels.
+    await expect(page.getByText("Clean kitchen")).toBeVisible();
+  });
+
+  test("clicking outside the column menu dismisses it", async ({ page }) => {
+    await page.goto(TODOS_URL);
+    await expect(page.getByText("Todo").first()).toBeVisible({
+      timeout: 5 * ONE_SECOND_MS,
+    });
+
+    const todoColumn = page.locator('[data-testid="todo-column-todo"]');
+    await todoColumn.locator("text=more_horiz").click();
+    await expect(page.getByRole("button", { name: "Rename" })).toBeVisible();
+
+    // Click on an empty corner of the body — the document-level
+    // listener should fire and close the menu.
+    await page.locator("body").click({ position: { x: 1, y: 1 } });
+    await expect(page.getByRole("button", { name: "Rename" })).toHaveCount(0);
   });
 
   test("adds a column with a Japanese label (#161)", async ({ page }) => {

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -95,6 +95,7 @@
           @rename-column="onRenameColumn"
           @delete-column="onDeleteColumn"
           @mark-done="onMarkDone"
+          @remove-all-items="onRemoveAllItemsInColumn"
           @reorder-columns="onReorderColumns"
         />
         <TodoTableView
@@ -399,6 +400,21 @@ function onDeleteColumn(columnId: string): void {
 
 function onMarkDone(columnId: string): void {
   void patchColumn(columnId, { isDone: true });
+}
+
+async function onRemoveAllItemsInColumn(columnId: string): Promise<void> {
+  const col = columns.value.find((column) => column.id === columnId);
+  if (!col) return;
+  // Items without an explicit status render in the first column in
+  // the kanban view, so apply the same fallback here.
+  const fallbackColumnId = columns.value[0]?.id;
+  const idsToDelete = items.value.filter((item) => (item.status ?? fallbackColumnId) === columnId).map((item) => item.id);
+  if (idsToDelete.length === 0) return;
+  const confirmed = window.confirm(t("todoKanban.removeAllItemsConfirm", { column: col.label, count: idsToDelete.length }));
+  if (!confirmed) return;
+  for (const itemId of idsToDelete) {
+    await deleteItem(itemId);
+  }
 }
 
 function onReorderColumns(ids: string[]): void {

--- a/src/components/todo/TodoKanbanView.vue
+++ b/src/components/todo/TodoKanbanView.vue
@@ -18,7 +18,8 @@
              starts a column drag. -->
           <div class="flex items-center justify-between px-3 py-2 border-b border-gray-200 col-handle cursor-grab active:cursor-grabbing">
             <div class="flex items-center gap-2 min-w-0">
-              <span class="w-2 h-2 rounded-full shrink-0" :class="col.isDone ? 'bg-green-500' : 'bg-gray-400'" />
+              <span v-if="col.isDone" class="material-icons text-base text-gray-700 shrink-0 leading-none" aria-hidden="true">check</span>
+              <span v-else class="w-2 h-2 rounded-full shrink-0 bg-gray-400" />
               <span v-if="renamingId !== col.id" class="font-semibold text-sm text-gray-700 truncate" :title="col.label">{{ col.label }}</span>
               <input
                 v-else
@@ -31,7 +32,7 @@
               />
               <span class="text-xs text-gray-500 shrink-0">{{ itemsByColumn(col.id).length }}</span>
             </div>
-            <div class="relative">
+            <div class="relative" data-todo-column-menu>
               <button class="text-gray-400 hover:text-gray-600 px-1" :title="t('todoKanban.columnActions')" @click="toggleMenu(col.id)">
                 <span class="material-icons text-base">more_horiz</span>
               </button>
@@ -41,10 +42,17 @@
                 @click.stop
               >
                 <button class="w-full text-left px-3 py-1.5 hover:bg-gray-50" @click="startRename(col)">{{ t("todoKanban.rename") }}</button>
-                <button class="w-full text-left px-3 py-1.5 hover:bg-gray-50" @click="markAsDone(col.id)">
-                  {{ col.isDone ? t("todoKanban.alreadyDoneColumn") : t("todoKanban.markAsDoneColumn") }}
+                <button v-if="!col.isDone" class="w-full text-left px-3 py-1.5 hover:bg-gray-50" @click="markAsDone(col.id)">
+                  {{ t("todoKanban.markAsDoneColumn") }}
                 </button>
-                <button class="w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50" @click="deleteColumn(col.id)">
+                <button v-if="col.isDone" class="w-full text-left px-3 py-1.5 hover:bg-gray-50" @click="removeAllItems(col.id)">
+                  {{ t("todoKanban.removeAllItems") }}
+                </button>
+                <button
+                  class="w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50 disabled:text-gray-300 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                  :disabled="col.isDone"
+                  @click="deleteColumn(col.id)"
+                >
                   {{ t("todoKanban.deleteColumn") }}
                 </button>
               </div>
@@ -119,7 +127,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import draggable from "vuedraggable";
 import type { StatusColumn, TodoItem } from "@mulmoclaude/todo-plugin/shared";
@@ -153,6 +161,7 @@ const emit = defineEmits<{
   renameColumn: [id: string, label: string];
   deleteColumn: [id: string];
   markDone: [id: string];
+  removeAllItems: [id: string];
   reorderColumns: [ids: string[]];
 }>();
 
@@ -259,4 +268,23 @@ function markAsDone(columnId: string): void {
   menuOpenId.value = null;
   emit("markDone", columnId);
 }
+
+function removeAllItems(columnId: string): void {
+  menuOpenId.value = null;
+  emit("removeAllItems", columnId);
+}
+
+// Close any open column menu when the user clicks outside of its
+// wrapper. We tag each menu wrapper (toggle button + popover) with
+// data-todo-column-menu, so a click on either the toggle or a menu
+// entry is treated as "inside" and won't dismiss; everything else does.
+function onDocumentClickOutsideMenu(event: MouseEvent): void {
+  if (menuOpenId.value === null) return;
+  const target = event.target as Element | null;
+  if (target?.closest("[data-todo-column-menu]")) return;
+  menuOpenId.value = null;
+}
+
+onMounted(() => document.addEventListener("click", onDocumentClickOutsideMenu));
+onUnmounted(() => document.removeEventListener("click", onDocumentClickOutsideMenu));
 </script>

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -925,9 +925,9 @@ const deMessages = {
   },
   todoKanban: {
     rename: "Umbenennen",
-    markAsDoneColumn: 'Als Spalte „Erledigt" markieren',
+    markAsDoneColumn: "Als Spalte „Erledigt“ markieren",
     removeAllItems: "Alle Elemente entfernen",
-    removeAllItemsConfirm: 'Alle {count} Elemente in „{column}" entfernen? Diese Aktion kann nicht rückgängig gemacht werden.',
+    removeAllItemsConfirm: "Alle {count} Elemente in „{column}“ entfernen? Diese Aktion kann nicht rückgängig gemacht werden.",
     deleteColumn: "Spalte löschen",
     columnActions: "Spaltenaktionen",
     addCard: "+ Karte hinzufügen",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -925,8 +925,9 @@ const deMessages = {
   },
   todoKanban: {
     rename: "Umbenennen",
-    alreadyDoneColumn: 'Bereits Spalte „Erledigt"',
     markAsDoneColumn: 'Als Spalte „Erledigt" markieren',
+    removeAllItems: "Alle Elemente entfernen",
+    removeAllItemsConfirm: 'Alle {count} Elemente in „{column}" entfernen? Diese Aktion kann nicht rückgängig gemacht werden.',
     deleteColumn: "Spalte löschen",
     columnActions: "Spaltenaktionen",
     addCard: "+ Karte hinzufügen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -907,8 +907,9 @@ const enMessages = {
   },
   todoKanban: {
     rename: "Rename",
-    alreadyDoneColumn: "Already done column",
     markAsDoneColumn: "Mark as done column",
+    removeAllItems: "Remove all items",
+    removeAllItemsConfirm: 'Remove all {count} item(s) in "{column}"? This cannot be undone.',
     deleteColumn: "Delete column",
     columnActions: "Column actions",
     addCard: "+ Add card",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -920,8 +920,9 @@ const esMessages = {
   },
   todoKanban: {
     rename: "Cambiar nombre",
-    alreadyDoneColumn: "Columna ya marcada como hecha",
     markAsDoneColumn: "Marcar como columna de hechas",
+    removeAllItems: "Eliminar todos los elementos",
+    removeAllItemsConfirm: '¿Eliminar los {count} elementos de "{column}"? Esta acción no se puede deshacer.',
     deleteColumn: "Eliminar columna",
     columnActions: "Acciones de columna",
     addCard: "+ Añadir tarjeta",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -916,8 +916,9 @@ const frMessages = {
   },
   todoKanban: {
     rename: "Renommer",
-    alreadyDoneColumn: "Déjà la colonne des terminées",
     markAsDoneColumn: "Définir comme colonne des terminées",
+    removeAllItems: "Supprimer tous les éléments",
+    removeAllItemsConfirm: "Supprimer les {count} éléments de « {column} » ? Cette action est irréversible.",
     deleteColumn: "Supprimer la colonne",
     columnActions: "Actions de colonne",
     addCard: "+ Ajouter une carte",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -907,8 +907,9 @@ const jaMessages = {
   },
   todoKanban: {
     rename: "名前を変更",
-    alreadyDoneColumn: "完了列",
     markAsDoneColumn: "完了列に指定",
+    removeAllItems: "すべての項目を削除",
+    removeAllItemsConfirm: "「{column}」のすべての項目（{count}件）を削除しますか？この操作は取り消せません。",
     deleteColumn: "列を削除",
     columnActions: "列のアクション",
     addCard: "+ カードを追加",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -908,8 +908,9 @@ const koMessages = {
   },
   todoKanban: {
     rename: "이름 바꾸기",
-    alreadyDoneColumn: "이미 완료 칼럼",
     markAsDoneColumn: "완료 칼럼으로 설정",
+    removeAllItems: "모든 항목 삭제",
+    removeAllItemsConfirm: '"{column}"의 모든 항목 {count}개를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.',
     deleteColumn: "칼럼 삭제",
     columnActions: "칼럼 작업",
     addCard: "+ 카드 추가",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -912,8 +912,9 @@ const ptBRMessages = {
   },
   todoKanban: {
     rename: "Renomear",
-    alreadyDoneColumn: "Já é a coluna de concluídas",
     markAsDoneColumn: "Definir como coluna de concluídas",
+    removeAllItems: "Remover todos os itens",
+    removeAllItemsConfirm: 'Remover todos os {count} itens em "{column}"? Esta ação não pode ser desfeita.',
     deleteColumn: "Excluir coluna",
     columnActions: "Ações da coluna",
     addCard: "+ Adicionar cartão",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -899,8 +899,9 @@ const zhMessages = {
   },
   todoKanban: {
     rename: "重命名",
-    alreadyDoneColumn: "已经是完成列",
     markAsDoneColumn: "设为完成列",
+    removeAllItems: "删除所有项目",
+    removeAllItemsConfirm: "确定要删除“{column}”中的所有 {count} 个项目吗？此操作无法撤销。",
     deleteColumn: "删除列",
     columnActions: "列操作",
     addCard: "+ 添加卡片",


### PR DESCRIPTION
## Summary
- Done-column header now shows a gray `check` icon instead of a green dot. Non-done columns keep the existing gray dot.
- Column action menu is state-aware: "Mark as done column" is hidden on the done column, "Delete column" is disabled there, and a new **Remove all items** action (with `window.confirm`) replaces the previously inert "Already done column" entry.
- Any open column menu now dismisses when clicking outside its wrapper (`data-todo-column-menu`).
- `todoKanban.alreadyDoneColumn` removed; `todoKanban.removeAllItems` and `todoKanban.removeAllItemsConfirm` added across all 8 locales in lockstep.

## Test plan
- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`
- [x] `yarn test:e2e` — 435 passed (full suite)
- [x] Updated `e2e/tests/todo-columns.spec.ts`: replaced the obsolete `alreadyDoneColumn` assertion and added coverage for the check icon, the disabled Delete entry, both `Remove all items` confirm/cancel branches, and outside-click dismissal.
- [ ] Manual smoke in browser — not done in this session; worth verifying check-icon alignment in the column header and the confirm wording in at least one non-English locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Remove all items" action for completed columns with confirmation dialog showing item count and column name.
  * Added visual check icon indicator for completed columns.

* **Improvements**
  * Enhanced column menu behavior: "Mark as done" now appears only for incomplete columns; delete option is disabled for completed columns.
  * Column menu now closes when clicking outside of it for better UX.

* **Localization**
  * Updated translations across all supported languages for new bulk removal feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->