### PR TITLE
fix(wiki): style external/workspace markdown links

### DIFF
--- a/src/plugins/wiki/components/WikiPageBody.vue
+++ b/src/plugins/wiki/components/WikiPageBody.vue
@@ -61,6 +61,10 @@ function onClick(event: MouseEvent) {
 .wiki-content :deep(.wiki-link:hover) {
   text-decoration-style: solid;
 }
+.wiki-content :deep(a) {
+  color: #2563eb;
+  text-decoration: underline;
+}
 .wiki-content :deep(h1) {
   font-size: 1.5rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- External and workspace markdown links inside rendered wiki pages were invisible as links — they functioned (the `<a>` tag is real), but rendered as plain body text with no color or underline.
- Root cause: `WikiPageBody.vue`'s scoped `.wiki-content :deep(...)` rules cover `h1`/`p`/`code`/`table`/`.wiki-link` etc. but never `<a>`, and the `prose prose-sm` classes on the root are dead weight (Tailwind Typography isn't installed — confirmed by the comment at `src/index.css:17-22`). Tailwind v4 Preflight strips the browser default underline + blue, so anchors fell through to body styling.
- Fix: one scoped `:deep(a)` rule that mirrors the existing `.markdown-content a` baseline used by the text-response surface. Same blue (`#2563eb`) as the internal `[[bracket]]` `.wiki-link` so all three flavors (external URL, in-app workspace path, fragment) look like one family.

## Test plan
- [ ] Open a wiki page that contains a markdown link like `[Anthropic](https://anthropic.com)` — verify it renders blue + underlined and still opens externally on click.
- [ ] On the same page, verify `[[wiki page]]` brackets still render in blue with the dotted underline (unchanged).
- [ ] Click a workspace-relative link (e.g. `[note](../../artifacts/...)` or another wiki page link emitted as `<a>`) — verify the in-app routing via `workspaceLinkClick` still fires (no regression from the new style).
- [ ] Confirm the metadata bar, task checkboxes, code blocks, tables, headings still look the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure external and workspace-relative markdown links in rendered wiki pages are visibly styled as links with color and underline.