### PR TITLE
chore(mulmoclaude): bump to 0.6.4 (published)

### DIFF
--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -115,7 +115,7 @@ ${cliFlagHelpLines()}
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.6.3");
+  console.log("mulmoclaude 0.6.4");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- `mulmoclaude` launcher を 0.6.3 → **0.6.4** に bump。
- npm 公開済: https://www.npmjs.com/package/mulmoclaude/v/0.6.4
- 検証: `npx mulmoclaude@0.6.4 --version` → `mulmoclaude 0.6.4`
- skill `/publish-mulmoclaude` の §1（deps audit）/ §2（workspace drift）/ §4（tarball boot smoke）すべてローカルでも main の CI でも green
- `@mulmobridge/*` のカスケード bump なし → §7 GitHub release タグ付け不要

## 0.6.3 → 0.6.4 で含まれる主な変更

- **srcset rewriter** (#1407, closes #1275): `<img>`/`<source>` の `srcset` を wiki/PDF 両面で書き換え。WHATWG 準拠スキャナで `data:` URI 安全
- **おすすめスキル preset 追加** (#1403, closes #1401): `obra/superpowers` を `EXTERNAL_PRESETS` に追加
- **任意依存の graceful degradation** (#1390, closes #1385): docker / ffmpeg 等が無くてもクラッシュせず、ベル通知 + ルートガード
- **複数日カレンダーイベント** (#1370, closes #1368): `endDate` の範囲表示・17色パレット・壊れた範囲の警告 UI

## Test plan

- [x] `node scripts/mulmoclaude/smoke.mjs` 全 3 stage pass（deps / drift / tarball）
- [x] `npm view mulmoclaude version` → `0.6.4`
- [x] `npx mulmoclaude@0.6.4 --version` → `mulmoclaude 0.6.4`
- [ ] CI の `mulmoclaude_smoke.yaml` でも再検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the mulmoclaude package to version 0.6.4 and update the CLI version output accordingly.

Chores:
- Update mulmoclaude package.json version field to 0.6.4.
- Align the mulmoclaude CLI --version output with the new 0.6.4 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.4

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->