### PR TITLE
fix(encore): residual sweep findings — query trim parity + appendNote split

### DIFF
--- a/server/encore/handlers/appendNote.ts
+++ b/server/encore/handlers/appendNote.ts
@@ -30,38 +30,40 @@ export const AppendNoteArgs = z.object({
 });
 
 export async function handleAppendNote(args: z.infer<typeof AppendNoteArgs>): Promise<EncoreDispatchResult> {
-  if (args.cycleId) {
-    const rel = cycleFilePath(args.obligationId, args.cycleId);
-    const raw = await readTextOrNull(rel);
-    if (raw === null) {
-      throw new EncoreError(404, `cycle file ${args.obligationId}/${args.cycleId}.md not found`);
-    }
-    const { state, body } = parseCycleFile(raw);
-    const newBody = appendBody(body, args.body);
-    await writeText(rel, serializeCycleFile(state, newBody));
-    log.info("encore", "appendNote: cycle body updated", { obligationId: args.obligationId, cycleId: args.cycleId });
-    return {
-      ok: true,
-      message: `Note appended to cycle ${args.cycleId} of ${args.obligationId}.`,
-      obligationId: args.obligationId,
-      cycleId: args.cycleId,
-      path: workspaceRelativePath(rel),
-    };
-  }
+  return args.cycleId ? appendToCycle(args.obligationId, args.cycleId, args.body) : appendToObligation(args.obligationId, args.body);
+}
 
-  const indexRel = obligationIndexPath(args.obligationId);
-  const raw = await readTextOrNull(indexRel);
+async function appendToCycle(obligationId: string, cycleId: string, note: string): Promise<EncoreDispatchResult> {
+  const rel = cycleFilePath(obligationId, cycleId);
+  const raw = await readTextOrNull(rel);
   if (raw === null) {
-    throw new EncoreError(404, `obligation ${JSON.stringify(args.obligationId)} not found`);
+    throw new EncoreError(404, `cycle file ${obligationId}/${cycleId}.md not found`);
   }
-  const { dsl, body } = parseIndexFile(raw);
-  const newBody = appendBody(body, args.body);
-  await writeText(indexRel, serializeIndexFile(dsl, newBody));
-  log.info("encore", "appendNote: obligation body updated", { obligationId: args.obligationId });
+  const { state, body } = parseCycleFile(raw);
+  await writeText(rel, serializeCycleFile(state, appendBody(body, note)));
+  log.info("encore", "appendNote: cycle body updated", { obligationId, cycleId });
   return {
     ok: true,
-    message: `Note appended to obligation ${args.obligationId}.`,
-    obligationId: args.obligationId,
+    message: `Note appended to cycle ${cycleId} of ${obligationId}.`,
+    obligationId,
+    cycleId,
+    path: workspaceRelativePath(rel),
+  };
+}
+
+async function appendToObligation(obligationId: string, note: string): Promise<EncoreDispatchResult> {
+  const indexRel = obligationIndexPath(obligationId);
+  const raw = await readTextOrNull(indexRel);
+  if (raw === null) {
+    throw new EncoreError(404, `obligation ${JSON.stringify(obligationId)} not found`);
+  }
+  const { dsl, body } = parseIndexFile(raw);
+  await writeText(indexRel, serializeIndexFile(dsl, appendBody(body, note)));
+  log.info("encore", "appendNote: obligation body updated", { obligationId });
+  return {
+    ok: true,
+    message: `Note appended to obligation ${obligationId}.`,
+    obligationId,
     path: workspaceRelativePath(indexRel),
   };
 }

--- a/server/encore/handlers/query.ts
+++ b/server/encore/handlers/query.ts
@@ -17,9 +17,16 @@ import { EncoreError, workspaceRelativePath, type EncoreDispatchResult } from ".
 
 export const QueryArgs = z.object({
   kind: z.literal("query"),
-  obligationId: z.string().optional(),
+  // `.trim().min(1)` parity with every other Encore handler
+  // (amend / appendNote / markStepDone / recordValues /
+  // markTargetSkipped / defineEncore). Without it, the empty /
+  // whitespace-only id would silently flow into path math and
+  // surface as an opaque 500 from `assertSafeSegment`. Same
+  // hardening CodeRabbit asked for on #1441; query.ts was missed
+  // in that sweep.
+  obligationId: z.string().trim().min(1).optional(),
   range: z.union([z.literal("current"), z.literal("all"), z.number().int().positive()]).optional(),
-  targetId: z.string().optional(),
+  targetId: z.string().trim().min(1).optional(),
 });
 
 interface QueryCycleResult {

--- a/test/plugins/test_encore_dispatch.ts
+++ b/test/plugins/test_encore_dispatch.ts
@@ -141,6 +141,28 @@ describe("Encore dispatch — component tests", () => {
     assert.equal(obligations[0].obligationId, setup.obligationId);
   });
 
+  // Boundary tests for `QueryArgs`'s `.trim().min(1).optional()` on
+  // both id fields — parity with the `defineEncore` boundary tests
+  // below. Without the trim guard, the empty / whitespace id would
+  // route into path math and bubble as an opaque 500 from
+  // `assertSafeSegment` instead of a structured 4xx (Codex review
+  // on the PR that added the guard).
+  it('query with `obligationId: ""` rejects at parse time', async () => {
+    await assert.rejects(dispatch({ kind: "query", obligationId: "" }), /invalid args[\s\S]*obligationId/);
+  });
+
+  it("query with whitespace-only `obligationId` rejects at parse time", async () => {
+    await assert.rejects(dispatch({ kind: "query", obligationId: "   " }), /invalid args[\s\S]*obligationId/);
+  });
+
+  it('query with `targetId: ""` rejects at parse time', async () => {
+    await assert.rejects(dispatch({ kind: "query", targetId: "" }), /invalid args[\s\S]*targetId/);
+  });
+
+  it("query with whitespace-only `targetId` rejects at parse time", async () => {
+    await assert.rejects(dispatch({ kind: "query", targetId: "   " }), /invalid args[\s\S]*targetId/);
+  });
+
   it("amendDefinition pauses the obligation", async () => {
     const setup = (await dispatch({ kind: "setup", definition: hisayoDefinition })) as SetupResult;
     const result = await dispatch({


### PR DESCRIPTION
## Summary

Two residuals from the recent Encore PR series (#1427 / #1433 / #1437 / #1441 / #1443) that survived merge. Verified against current `main` that the rest of the 3-day sweep findings are already addressed.

## Items to Confirm / Review

Two unrelated concerns intentionally in one PR because both are post-merge follow-ups to the same Encore review series and touch one file each in the same module. One commit, easy to revert either change cleanly by reverting individual hunks if needed.

## Fixes (1-by-1 walkthrough)

### 1. `server/encore/handlers/query.ts` — schema trim parity (`#1441` follow-up)

The recent sweep added `.trim().min(1)` to every Encore handler's identifier fields. `query.ts` was missed:

```diff
 export const QueryArgs = z.object({
   kind: z.literal("query"),
-  obligationId: z.string().optional(),
+  obligationId: z.string().trim().min(1).optional(),
   range: z.union([z.literal("current"), z.literal("all"), z.number().int().positive()]).optional(),
-  targetId: z.string().optional(),
+  targetId: z.string().trim().min(1).optional(),
 });
```

Without it, an empty / whitespace-only id flowed into `obligationIndexPath` path math and surfaced as an opaque 500 from `assertSafeSegment` instead of a clean 400 at the schema boundary. All sibling handlers (`amend.ts`, `appendNote.ts`, `markStepDone.ts`, `recordValues.ts`, `markTargetSkipped.ts`, `defineEncore.ts`) already have this hardening — `query.ts` is brought into parity.

### 2. `server/encore/handlers/appendNote.ts` — split `handleAppendNote` (CLAUDE.md 20-line rule, `#1441` follow-up)

`handleAppendNote` was **36 lines**. Split along the existing branch (cycle vs obligation):

- `appendToCycle(obligationId, cycleId, note)` — the `cycleId` branch
- `appendToObligation(obligationId, note)` — the no-`cycleId` branch
- `handleAppendNote` itself becomes a one-line dispatch:
  ```ts
  return args.cycleId
    ? appendToCycle(args.obligationId, args.cycleId, args.body)
    : appendToObligation(args.obligationId, args.body);
  ```

Same on-disk effect; identical logging, error shape, return shape. The pre-existing `appendBody()` helper is untouched.

## Out of scope — deliberately NOT changed (verified false positive or already-fixed in main)

| CodeRabbit / Sourcery suggestion | Why skipped |
|---|---|
| `defineEncoreMeta.ts` use `TOOL_NAME` constant instead of literal `"defineEncore"` | This file IS the canonical source consumed by `definePluginMeta` → fed into the host's `TOOL_NAMES`. Every other plugin meta follows the same pattern (presentChart / editImages / manageAccounting / etc.). The constant CodeRabbit suggested using is derived FROM this literal. |
| `roles.ts` change `config/helps/*` → `server/workspace/helps/*` | `config/helps/` is the **workspace runtime location** (agent runs with cwd = `~/mulmoclaude`); `server/workspace/helps/` is the **repo seed template** that gets `cpSync`'d in by `workspace.ts`. Role prompts correctly reference the runtime path. |
| `AppendNote body .trim()` | Already in main (line 29). |
| identifier `.trim().min(1)` across other handlers | Already in main (verified across amend / appendNote / markStepDone / recordValues / markTargetSkipped / defineEncore). |
| `publish` → `writeTicket` rollback in reconcile | Already in main — `safeClearBell` rollback wired at the three call sites. |
| `ORPHAN_TICKET_AGE_MS` named time constants | Already in main: `30 * ONE_DAY_MS`. |
| `MS_PER_WEEK` in `cadence.ts` | Moot — `server/encore/dsl/cadence.ts` no longer exists (file removed in subsequent restructure). |
| `listTickets` shape validation | Already in main: `isWellFormed(parsed)` guard before `toSummary`. |
| `TOOL_NAME` in `defineEncoreDefinition.ts` | Already in main (line 38, 52). |

## User Prompt

> /pr-quality-sweep 3日文 … Nits も含め、できるだけ。encore に関しては、encore だけでまとめて PR 化して、1つ1つ説明し snakajima に assign して。… 事前に fix してないか確かめてから進めてね

## Test plan

- [x] `yarn lint` / `typecheck` clean
- [x] Encore unit tests: 38/38 (`test_encore_dispatch.ts` + `test_encore_reconcile.ts`)
- [x] `yarn test` — 4978 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Encore query argument validation with other handlers and refactor append-note handling for clearer separation of cycle vs obligation updates.

Bug Fixes:
- Harden Encore query handler arguments by trimming and enforcing non-empty obligation and target IDs to prevent invalid identifiers reaching path handling.

Enhancements:
- Refactor Encore append note handling into separate helpers for cycle and obligation updates to keep the main handler small and focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trim and enforce non-empty values for query parameters to prevent malformed inputs from causing errors.

* **Refactor**
  * Reorganized note-append logic into clearer, maintainable paths while preserving existing behavior and responses.

* **Tests**
  * Added tests to ensure empty or whitespace-only query arguments are rejected at validation time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->