### PR TITLE
fix(todo): guard onRemoveAllItemsInColumn to done-column contract

### DIFF
--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -404,7 +404,11 @@ function onMarkDone(columnId: string): void {
 
 async function onRemoveAllItemsInColumn(columnId: string): Promise<void> {
   const col = columns.value.find((column) => column.id === columnId);
-  if (!col) return;
+  // Defense-in-depth: the menu entry is rendered only on done
+  // columns, but a programmatic caller could still hit this with any
+  // column id. Bulk delete is destructive, so refuse outside the
+  // done-column contract. (CodeRabbit follow-up on #1452.)
+  if (!col || !col.isDone) return;
   // Items without an explicit status render in the first column in
   // the kanban view, so apply the same fallback here.
   const fallbackColumnId = columns.value[0]?.id;


### PR DESCRIPTION
## Summary

`onRemoveAllItemsInColumn` (`src/components/TodoExplorer.vue:405`) accepts any column id and bulk-deletes its items. The kanban menu only exposes the entry on done columns, but the function itself has no `isDone` guard — a programmatic caller could trigger destructive deletion outside the done-column contract. Add a defensive `!col.isDone` early return.

## User Prompt

> /pr-quality-sweep 3日文 … Nits も含め、できるだけ。

CodeRabbit on #1452: "Guard bulk-delete to done columns only."

## Change

```diff
 async function onRemoveAllItemsInColumn(columnId: string): Promise<void> {
   const col = columns.value.find((column) => column.id === columnId);
-  if (!col) return;
+  if (!col || !col.isDone) return;
```

## Test plan

- [x] `yarn lint` / `typecheck` clean
- Menu entry still only renders on done columns (UI affordance unchanged); the new guard is defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent programmatic bulk deletion of items from non-done columns by guarding the remove-all-in-column handler with a done-column check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent bulk deletion of items from being invoked on non-done columns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->