### PR TITLE
Refine HN launch plan and PH listing after review

### DIFF
--- a/plans/launch-hn.md
+++ b/plans/launch-hn.md
@@ -10,7 +10,7 @@ Do these IN ORDER before clicking Submit.
 
 - [ ] **The PR is merged to `main`.** The HN link goes to `main`; if the PR is still open, HN readers see the old README.
 - [ ] **Visit https://github.com/receptron/mulmoclaude in a private/incognito browser tab.** Confirm the new platform-positioning hero ("MulmoClaude is an open-source, AI-native application platform...") and the MANIFEST.md blockquote are visible at the top.
-- [ ] **Check the time.** Submit only **Tuesday / Wednesday / Thursday, 8–11am Pacific Time**. Outside that window, hold the submission until tomorrow morning PT.
+- [ ] **Check the time.** Submit only **Tuesday / Wednesday / Thursday, 8–11am Pacific Time** (Tuesday best, Wednesday good, Thursday acceptable). Avoid Fridays and weekends entirely. Also avoid days with major AI announcements (Anthropic / OpenAI / Google keynotes, model launches) — your post will drown.
 - [ ] **First comment is in your clipboard** (the block below in this file). The maker comment must appear within ~60 seconds of submission.
 - [ ] **You have 6 hours free** to respond to comments after submitting. The first 6 hours determine ranking more than the title does.
 
@@ -23,12 +23,12 @@ Go to https://news.ycombinator.com/submit. Three fields:
 ### title (copy exactly)
 
 ```
-Show HN: MulmoClaude – AI-native app platform where chat summons GUIs
+Show HN: MulmoClaude – open-source platform where Claude composes tools and GUIs
 ```
 
 Notes:
 - The dash is `–` (en dash, `Option+-` on Mac, U+2013). HN accepts both `–` and `-`; `–` reads cleaner.
-- 69 chars — well under HN's 80 char limit.
+- 80 chars — at HN's 80 char limit; reads cleanly.
 
 ### url (copy exactly)
 
@@ -47,7 +47,17 @@ Do not fill in this field. The first comment goes as a manual comment after subm
 ```
 Maker here.
 
-MulmoClaude is an open-source application platform where Claude (via the Claude Agent SDK) acts as a universal controller across a plugin registry. Real applications running on it today: a full accounting system (with server-side bookkeeping logic), the Encore obligation engine, a personal wiki, a Financial Advisor (built on the Edgar SEC-filings plugin), and a Storyteller for interactive illustrated stories.
+MulmoClaude lets one chat session drive multiple apps and GUI surfaces.
+
+Examples running on it today:
+
+- **Accounting** — full bookkeeping with server-side business logic
+- **Personal wiki** — search, edit, and cross-link knowledge over time
+- **Financial Advisor** — analyzes SEC filings via the Edgar plugin
+- **Encore** — natural-language definition of recurring obligations, executed by a DSL engine
+- **Storyteller** — interactive illustrated stories with generated images
+
+Claude (via the Claude Agent SDK) acts as a universal controller over a plugin registry — composing across plugins via MCP tools.
 
 Three architectural commitments:
 
@@ -63,9 +73,9 @@ Install: see the [Quick Start in the README](https://github.com/receptron/mulmoc
 
 Three things I'd genuinely value HN feedback on:
 
-1. Does the **agent-as-universal-controller** framing hold up against your mental model of MCP?
+1. What other plugin patterns (beyond *API+UI+Agent* and *NL→DSL→engine*) should this architecture handle?
 2. Is `gui-chat-protocol` the right abstraction shape for "the agent and the GUI need to talk"?
-3. What other plugin patterns (beyond *API+UI+Agent* and *NL→DSL→engine*) should this architecture handle?
+3. Does the **agent-as-universal-controller** framing hold up against your mental model of MCP?
 ```
 
 ---
@@ -81,6 +91,30 @@ Three things I'd genuinely value HN feedback on:
 - **Don't argue with downvotes.** Just keep engaging substantively.
 
 Stop after ~6 hours. Diminishing returns past that, and threads drift.
+
+---
+
+## Common objections — pre-written replies
+
+Paste-ready answers for objections that commonly come up in Show HN threads. Pull from these when relevant; don't dump them all at once.
+
+### "Why not MCP?"
+
+> MCP solves agent ↔ tool access. MulmoClaude adds three things MCP doesn't cover:
+>
+> 1. **GUI rendering** — what happens when a tool result is a UI surface (chart, form, wiki, spreadsheet, 3D scene), not just data
+> 2. **Agent ↔ UI communication** — pub/sub channels, scoped REST dispatch, locale, error isolation
+> 3. **Cross-plugin composition** — agent orchestrating across multiple plugins in a single turn
+>
+> Think of MCP as transport. `gui-chat-protocol` is presentation + state, sitting on top of MCP, not next to it.
+
+### "Why not just use Claude Desktop?"
+
+> Claude Desktop gives you one agent with tools. MulmoClaude is a platform where applications themselves are composable plugins with GUI surfaces — accounting, wiki, Financial Advisor, Storyteller, etc. — and Claude composes across them in a single turn. Different layer of the stack.
+
+### "Why not just build this in React/Vue/Svelte?"
+
+> You still can — and we do (MulmoClaude's frontend is Vue). The interesting question isn't the rendering framework; it's *where the orchestration lives*. In a traditional web app, the frontend orchestrates which views/components to render. MulmoClaude moves orchestration into the agent layer: the agent decides which plugin to invoke, which GUI surface to render, and how to compose across plugins. The rendering still happens in your framework of choice; the orchestration logic doesn't.
 
 ---
 

--- a/plans/launch-hn.md
+++ b/plans/launch-hn.md
@@ -23,12 +23,12 @@ Go to https://news.ycombinator.com/submit. Three fields:
 ### title (copy exactly)
 
 ```
-Show HN: MulmoClaude – chat summons GUIs, applications are plugins
+Show HN: MulmoClaude – AI-native app platform where chat summons GUIs
 ```
 
 Notes:
 - The dash is `–` (en dash, `Option+-` on Mac, U+2013). HN accepts both `–` and `-`; `–` reads cleaner.
-- 64 chars — well under HN's 80 char limit.
+- 69 chars — well under HN's 80 char limit.
 
 ### url (copy exactly)
 
@@ -47,13 +47,15 @@ Do not fill in this field. The first comment goes as a manual comment after subm
 ```
 Maker here.
 
-MulmoClaude is an open-source application platform where Claude (via the Claude Agent SDK) acts as a universal controller across a plugin registry. Real applications running on it today: a full accounting system (with server-side bookkeeping logic), the Encore obligation engine, a personal wiki, and an Edgar SEC-filings reader.
+MulmoClaude is an open-source application platform where Claude (via the Claude Agent SDK) acts as a universal controller across a plugin registry. Real applications running on it today: a full accounting system (with server-side bookkeeping logic), the Encore obligation engine, a personal wiki, a Financial Advisor (built on the Edgar SEC-filings plugin), and a Storyteller for interactive illustrated stories.
 
-The two claims in the title:
+Three architectural commitments:
 
-**"Chat summons GUIs"** — the agent's reply isn't a string. It picks a format for the content: Markdown for prose, MCP tool invocations for GUI surfaces (chart, form, wiki, spreadsheet, 3D scene), MulmoScript for multimedia. The chat input is the address bar; what arrives is whatever the content demands.
+**Chat summons GUIs** — the agent's reply isn't a string. It picks a format for the content: Markdown for prose, MCP tool invocations for GUI surfaces (chart, form, wiki, spreadsheet, 3D scene), MulmoScript for multimedia. The chat input is the address bar; what arrives is whatever the content demands.
 
-**"Applications are plugins"** — each plugin contributes one or more MCP tools to the agent. The agent composes across them in one turn. "Summarize Q1 expenses as a chart" reads accounting, writes chart. No app-switching, no copy-paste between apps.
+**Cross-plugin composition** — each plugin contributes one or more MCP tools to the agent. The agent composes across them in one turn. "Summarize Q1 expenses as a chart" reads accounting, writes chart. No app-switching, no copy-paste between apps.
+
+**Open protocol (gui-chat-protocol extending MCP)** — the agent↔GUI contract is a versioned npm package, not an internal API. Plugins are distributed as npm packages; any future agent host that implements the protocol can run them. The protocol sits on top of MCP — it adds the visual layer that MCP doesn't cover.
 
 The architectural argument is in [MANIFEST.md](https://github.com/receptron/mulmoclaude/blob/main/MANIFEST.md) — three commitments (universal controller / chat summons GUIs / open protocol extending MCP) plus the patterns proven by the accounting and Encore plugins.
 

--- a/plans/launch-ph-listing.md
+++ b/plans/launch-ph-listing.md
@@ -4,18 +4,18 @@ Reflects the final manifesto (post-revision) and the HN launch positioning. PH c
 
 ## Tagline (≤60 chars)
 
-**Primary:** Chat summons GUIs, applications are plugins — *47 chars*
+**Primary:** AI-native app platform where chat summons GUIs — *46 chars*
 
 Alternates:
 - How AI-native applications should be built — *43 chars* (essay title; works as tagline)
-- Open-source platform where applications are plugins — *51 chars*
+- AI-native app platform; Claude as universal controller — *54 chars*
 - Claude as a universal controller across plugins — *47 chars*
 
 ## Description (≤260 chars)
 
 **Primary draft (245 chars):**
 
-> An open-source AI-native application platform. Real apps already run on it: a full accounting system, the Encore obligation engine, a personal wiki, an SEC-filings reader (Edgar). Claude composes plugins in one turn. MIT · `npx mulmoclaude`.
+> An open-source AI-native application platform. Real apps already run on it: a full accounting system, the Encore obligation engine, a personal wiki, a Financial Advisor (Edgar SEC filings). Claude composes plugins in one turn. MIT · `npx mulmoclaude`.
 
 **Alternate (251 chars), heavier on the architectural angle:**
 
@@ -32,7 +32,7 @@ Alternates:
 
 > Hey Product Hunt — Satoshi here.
 >
-> MulmoClaude is an open-source AI-native application platform. The unusual thing about it is structural: instead of being a single application, it's a registry of applications running as plugins, with Claude as a universal controller composing across them. Real applications running on it today include a full accounting system (with server-side bookkeeping logic), the Encore obligation engine, a personal wiki, and an SEC-filings reader (Edgar).
+> MulmoClaude is an open-source AI-native application platform. The unusual thing about it is structural: instead of being a single application, it's a registry of applications running as plugins, with Claude as a universal controller composing across them. Real applications running on it today include a full accounting system (with server-side bookkeeping logic), the Encore obligation engine, a personal wiki, a Financial Advisor (built on the Edgar SEC-filings plugin), and a Storyteller for interactive illustrated stories.
 >
 > Three architectural commitments:
 >
@@ -65,7 +65,7 @@ Alternates:
 
 ## Notes
 
-- **Tagline #1 ("Chat summons GUIs, applications are plugins")** matches the HN submission title verbatim. Cohesion across launches: HN visitors who land on PH 10 days later see the same line they upvoted; PH visitors who follow the link to MANIFEST.md find the same two phrases as section anchors.
+- **Tagline #1 ("AI-native app platform where chat summons GUIs")** matches the HN submission title verbatim (minus the "Show HN: MulmoClaude –" prefix). Cohesion across launches: HN visitors who land on PH 10 days later see the same line they upvoted; PH visitors who follow the link to MANIFEST.md find "Chat summons GUIs" as a section anchor.
 - **Description** leads with what it *is* (a platform) and what's *on it today* (named real apps). Avoids the "everyone says SaaS is dead" hook from the manifesto — that hook is essay register, not PH-listing register. The listing is a destination card; the essay is the argument.
 - **Maker comment** mirrors the essay's three commitments structure (universal controller → chat summons GUIs → open protocol extending MCP) plus the Pattern C insight at the end. Slightly warmer than the HN version (Hey/Hi opener; less defensive about "where does this break"; more invitational ending).
 - **HN reference is optional.** If HN goes well, the optional line in the maker comment becomes a social-proof asset for PH. If HN underperforms, omit silently — PH visitors don't know what HN reception looked like.

--- a/plans/launch-ph-listing.md
+++ b/plans/launch-ph-listing.md
@@ -4,11 +4,11 @@ Reflects the final manifesto (post-revision) and the HN launch positioning. PH c
 
 ## Tagline (≤60 chars)
 
-**Primary:** AI-native app platform where chat summons GUIs — *46 chars*
+**Primary:** open-source platform where Claude composes tools and GUIs — *57 chars*
 
 Alternates:
+- AI-native app platform where chat summons GUIs — *46 chars* (matches manifesto's section 2 title)
 - How AI-native applications should be built — *43 chars* (essay title; works as tagline)
-- AI-native app platform; Claude as universal controller — *54 chars*
 - Claude as a universal controller across plugins — *47 chars*
 
 ## Description (≤260 chars)
@@ -65,7 +65,7 @@ Alternates:
 
 ## Notes
 
-- **Tagline #1 ("AI-native app platform where chat summons GUIs")** matches the HN submission title verbatim (minus the "Show HN: MulmoClaude –" prefix). Cohesion across launches: HN visitors who land on PH 10 days later see the same line they upvoted; PH visitors who follow the link to MANIFEST.md find "Chat summons GUIs" as a section anchor.
+- **Tagline #1 ("open-source platform where Claude composes tools and GUIs")** matches the HN submission title verbatim (minus the "Show HN: MulmoClaude –" prefix). Cohesion across launches: HN visitors who land on PH 10 days later see the same line they upvoted. The catchy "Chat summons GUIs" phrase from the manifesto still appears in the maker comment callout for readers who go deeper.
 - **Description** leads with what it *is* (a platform) and what's *on it today* (named real apps). Avoids the "everyone says SaaS is dead" hook from the manifesto — that hook is essay register, not PH-listing register. The listing is a destination card; the essay is the argument.
 - **Maker comment** mirrors the essay's three commitments structure (universal controller → chat summons GUIs → open protocol extending MCP) plus the Pattern C insight at the end. Slightly warmer than the HN version (Hey/Hi opener; less defensive about "where does this break"; more invitational ending).
 - **HN reference is optional.** If HN goes well, the optional line in the maker comment becomes a social-proof asset for PH. If HN underperforms, omit silently — PH visitors don't know what HN reception looked like.


### PR DESCRIPTION
## Summary

Post-review refinements to the HN and PH launch planning documents.

**`plans/launch-hn.md`**
- Restructured the maker's first comment to lead with **visible behavior** (one-line hook + five example apps) before introducing architecture. Reader sees what it *does* before parsing what it *is*.
- Added a **"Common objections — pre-written replies"** section with paste-ready answers for the predictable Show HN attacks: *Why not MCP?*, *Why not Claude Desktop?*, *Why not React/Vue/Svelte?*
- Reordered the three feedback questions to lead with the **design-space** question instead of framing-validation.
- Tightened submission timing: Tuesday > Wednesday > Thursday; avoid Fridays/weekends and AI keynote days.
- Removed undocumented `npx mulmoclaude` install command (CodeRabbit feedback); replaced with a link to the README Quick Start.
- New title: **`Show HN: MulmoClaude – open-source platform where Claude composes tools and GUIs`** — concrete verb ("composes"), "open-source" front-loaded, "Claude" named as HN keyword.

**`plans/launch-ph-listing.md`**
- Primary tagline updated to match the new HN title verbatim: *open-source platform where Claude composes tools and GUIs* (57 chars; fits the 60-char PH limit).
- Reframed Edgar as a **capability** under a **Financial Advisor** application (not as an application itself). Edgar is one of the plugins behind the Financial Advisor role.
- Added **Storyteller** as a fifth example application alongside accounting / Encore / wiki / Financial Advisor — adds creative-domain breadth alongside the business/productivity/knowledge/finance items.

## Test plan

- [ ] Read through `plans/launch-hn.md` end-to-end — confirm the submission-day flow makes sense
- [ ] Confirm the maker comment reads naturally with examples → architecture order
- [ ] Confirm the new title makes sense as an HN submission
- [ ] Confirm the "Common objections" section has paste-ready replies you'd actually use
- [ ] Confirm `plans/launch-ph-listing.md` primary tagline matches the new HN title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine the Hacker News launch plan and Product Hunt listing copy to better foreground visible behavior, align positioning, and prepare for common launch objections.

Documentation:
- Update the HN launch checklist and maker comment to emphasize concrete example applications, clarify architectural commitments, and tighten submission timing guidance.
- Add a canned-replies section addressing common HN objections around MCP, Claude Desktop, and traditional frontend frameworks.
- Align the PH tagline and description with the new HN title, reposition Edgar under a Financial Advisor app, and introduce Storyteller as an additional example application.

Chores:
- Adjust character-count notes and phrasing to match platform limits and maintain consistency between HN and Product Hunt messaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal launch planning documentation with refined messaging and positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->