### PR TITLE
docs: add plans for Solopreneur OS plugins

### DIFF
--- a/plans/feat-solopreneur-client.md
+++ b/plans/feat-solopreneur-client.md
@@ -1,0 +1,123 @@
+# Plan: Client Plugin
+
+Part of the [Solopreneur OS umbrella](feat-solopreneur-os.md). Reviewable and shippable independently — no dependency on Worklog or Invoice.
+
+## Standalone value
+
+An AI-native client and project record. Earns its keep before Worklog or Invoice exist:
+
+- "What do I know about Acme?" → returns notes, contacts, recent project list, last interaction
+- "Who am I meeting next week?" → cross-references calendar plugin if installed
+- "Draft an intro email to Globex's new product lead." → uses stored context to compose
+- "List my active clients." / "Show me clients I haven't touched in 60 days."
+
+Compares to: Cardhop, Notion CRM databases, Airtable client trackers, the "Contacts" tab in HoneyBook. Differentiator: chat-driven, file-backed, AI-summarizable without ETL or schema editor.
+
+## Data model
+
+One markdown file per client, mirroring the existing `~/mulmoclaude/data/contacts/` convention. Projects nest under their client:
+
+```text
+~/mulmoclaude/data/clients/
+  acme.md
+  globex.md
+  acme/
+    projects/
+      site-redesign.md
+      mobile-app.md
+```
+
+```markdown
+---
+id: acme
+name: Acme Corp
+status: active                   # active | paused | archived
+contacts:
+  - { name: Jane Doe, email: jane@acme.com, role: PM }
+rate: { amount: 200, currency: USD, unit: hour }
+paymentTerms: net-30
+tags: [retainer, enterprise]
+firstEngagement: 2024-09-01
+---
+
+# Acme Corp
+
+Free-form notes — context, deal history, gotchas, relationship dynamics. The LLM reads this when asked "what do I know about Acme?"
+```
+
+Project files use the same shape with `clientId: acme` plus project-specific fields (`scope`, `feeModel`, `startDate`, `expectedDeliverables`, `status`).
+
+**Why nested directories** (`acme/projects/...`) rather than flat `data/projects/<id>.md` with `clientId`: a client with no projects is still a valid record; a project without a client is not. Directory structure encodes the constraint.
+
+## Tool surface
+
+```ts
+manageClient({
+  action: "create" | "update" | "list" | "show" | "createProject" | "showProject" | "listProjects",
+  id?: string,
+  patch?: Partial<Client>,
+  projectId?: string,
+  projectPatch?: Partial<Project>,
+})
+```
+
+- `create` and `createProject` write candidate files for user approval (AI-on-a-leash).
+- `update`, `show`, `list*` operate on user-approved records directly.
+- No `delete`. Soft-delete via `update({status: "archived"})` preserves backrefs from worklogs/invoices.
+
+The tool description tells Claude to call `show` (not `list`) when the user names a specific client — `list` is for "show me all my clients" and renders a table; `show` is for "tell me about Acme" and renders a card.
+
+## GUI surfaces
+
+Two views, standard runtime-plugin Vue components:
+
+1. **Client card** (`show`): name, key fields, contacts table, project list with status, free-form notes rendered as markdown. The card is the answer to "tell me about X".
+2. **Client list** (`list`): table of all clients with status filter, sortable by `firstEngagement` / `name` / `status`. Click-through opens the card.
+
+Reuse existing markdown rendering for the notes section. The list view is ~80 lines of thin table Vue; reuse `src/plugins/spreadsheet/`'s table component if it generalizes, otherwise inline.
+
+No preview view in MVP; clients are pulled by name, not browsed in a sidebar.
+
+## Phases
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Tool handlers + frontmatter schema + file I/O (read / write / list) | 3 days |
+| 2 | Client card and list views | 2 days |
+| 3 | Project sub-records (nested directory + project handlers + project list view) | 2 days |
+| 4 | i18n for all 8 locales + tests | 1 day |
+
+Total: ~8 working days for a polished v1.
+
+## Cross-plugin reads (informational)
+
+Other plugins read from `data/clients/` but never write:
+
+- Worklog reads `data/clients/*.md` to populate a dropdown of valid `clientId` values for inferred entries.
+- Invoice reads `rate`, `paymentTerms`, and primary `contacts` to fill invoice metadata.
+
+This plugin does not need to know about those readers. The contract is the on-disk schema.
+
+## Success criteria
+
+The plugin ships when the user can do this against their real client list:
+
+1. "Add a new client: Globex, hourly rate $180, primary contact Jane Doe at jane@globex.com." → candidate appears, user approves, file written.
+2. "What do I know about Acme?" → card appears with notes, projects, contacts.
+3. "List my active clients." → table.
+4. "Archive the Hooli engagement; it's been dormant for 6 months." → status flip, no data loss.
+
+Not in scope for v1:
+
+- Contact deduplication across clients
+- Auto-import from email signatures, vcards, LinkedIn
+- Relationship timeline visualization
+- Cross-client "people I work with" rollup
+- Per-client document attachments (the markdown body is enough)
+
+## Open questions
+
+1. **Project file naming.** `acme/projects/site-redesign.md` vs. `clients/acme/site-redesign.md` (drop the `projects/` segment). The former groups by record type; the latter is less typing in chat references. Pick before phase 3.
+2. **Where do contacts live?** Inline in the client's frontmatter (current proposal) or in a separate `data/contacts/` namespace with backrefs? Inline is simpler but duplicates a contact who works for two clients. Default: inline; revisit if duplication bites.
+3. **Tags.** Free-form strings or a controlled vocabulary? Free-form for MVP. Add a `manageClient(action: "listTags")` later if grouping becomes important.
+4. **Contact-plugin overlap.** MulmoClaude already has a `contacts` plugin for personal contacts. Should a client's contacts link out to that plugin's records, or stay self-contained? Self-contained for v1; introducing a join breaks the "useful alone" principle.

--- a/plans/feat-solopreneur-invoice.md
+++ b/plans/feat-solopreneur-invoice.md
@@ -1,0 +1,165 @@
+# Plan: Invoice / Report Plugin
+
+Part of the [Solopreneur OS umbrella](feat-solopreneur-os.md). Reviewable and shippable independently — no dependency on Client or Worklog.
+
+## Standalone value
+
+An AI-native invoice and report generator. Earns its keep before Client or Worklog exist:
+
+- "Generate an invoice for Acme: $5000 for May consulting." → produces a polished markdown invoice with a line item.
+- "Draft a weekly status report for Globex covering the migration work." → produces a markdown report; user supplies the bullets in chat.
+- "Make an invoice for last month's retainer to Hooli: $3000 retainer + 6 hours overage at $200." → multiple line items, computed total.
+- "List my unpaid invoices." → table with totals per client.
+
+In manual mode the plugin is a **formatter and file manager** for invoices — taking informal chat input and producing a sendable artifact with consistent layout, sequential numbering, status tracking, and a paper trail.
+
+When Client and Worklog plugins are present, the same tool surface auto-populates: client metadata from `data/clients/`, line items from `data/worklogs/`. The user does not learn a new flow — they say "generate an Acme invoice for May" and the plugin uses whatever sources are available.
+
+Compares to: FreshBooks invoice generator, Wave, Bonsai. Differentiator: chat input, markdown-native artifacts, no template editor, no SaaS lock-in.
+
+## Data model
+
+Each invoice is a markdown file with rich frontmatter:
+
+```text
+~/mulmoclaude/artifacts/invoices/
+  2026-05-31-acme-INV-0042.md
+  2026-04-30-acme-INV-0041.md
+  2026-05-15-globex-INV-0043.md
+```
+
+```markdown
+---
+id: INV-0042
+clientId: acme                     # free string if Client plugin absent
+issueDate: 2026-05-31
+dueDate: 2026-06-30
+status: draft                      # draft | sent | paid | void
+currency: USD
+lineItems:
+  - { description: May consulting hours, quantity: 24, unit: hour, rate: 200, amount: 4800 }
+  - { description: April overage carry-forward, quantity: 1, unit: flat, rate: 200, amount: 200 }
+subtotal: 5000
+tax: 0
+total: 5000
+paidDate: null
+paymentReference: null
+---
+
+# Invoice INV-0042
+
+**To:** Acme Corp
+**From:** Satoshi Nakajima
+**Issue date:** 2026-05-31
+**Due:** 2026-06-30
+
+| Description | Qty | Rate | Amount |
+|---|---|---|---|
+| May consulting hours | 24 | $200 | $4,800 |
+| April overage carry-forward | 1 | — | $200 |
+
+**Total: $5,000**
+
+Payment terms: Net 30. Bank transfer details on file.
+```
+
+The markdown body is the human-readable invoice; the frontmatter is the machine-queryable state. Same pattern as the rest of the workspace.
+
+Reports use the same shape under `~/mulmoclaude/artifacts/reports/` with simpler frontmatter (no `total`, no `lineItems`, just `period` and `clientId`).
+
+## Tool surface
+
+```ts
+manageInvoice({
+  action:
+    | "generate"        // create new invoice from inline or fetched data
+    | "list"            // query invoices by client / status / range
+    | "show"            // open one invoice in canvas
+    | "markPaid"        // status flip + paidDate stamp + paymentReference
+    | "void"            // status flip; record reason in notes; ID is NOT reused
+    | "generateReport", // same flow for a non-billing report
+  clientId?: string,
+  range?: { from: string; to: string },
+  lineItems?: LineItem[],          // explicit override; skips worklog fetch
+  invoiceId?: string,
+  reportKind?: "weekly" | "monthly" | "custom",
+})
+```
+
+### `generate` data sourcing — cascading fallbacks
+
+1. If `lineItems` provided in the call → use them verbatim. (Manual mode.)
+2. Else if Worklog plugin present and `range` provided → read worklogs for that client in range, group by project, multiply hours × rate. (Auto mode.)
+3. Else prompt the user via chat for line items. (Interactive mode.)
+
+### Client metadata sourcing
+
+1. If `clientId` matches a `data/clients/<id>.md` → use frontmatter (`rate`, `currency`, `paymentTerms`, primary contact).
+2. Else use the bare string as the recipient name; prompt for any missing required fields.
+
+### Invoice numbering
+
+Scan existing invoice IDs at generation time, increment, pad to 4 digits. Configurable prefix in `~/mulmoclaude/config/invoice.json`. Voided IDs are not reused — gaps in the sequence are intentional for audit.
+
+## GUI surfaces
+
+1. **Invoice preview** (default for `generate` and `show`): renders the invoice markdown with a print-styled wrapper. Browser print-to-PDF produces a sendable PDF without a generation pipeline.
+2. **Invoice list** (`list`): table grouped by status, filterable by client / range. Sums per status at the bottom.
+3. **Report view**: same as invoice preview but without the totals row.
+
+No standalone `/invoices` route in MVP.
+
+## Phases
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Schema + markdown writer + `generate` (manual mode) + `show` view | 4 days |
+| 2 | `list` + `markPaid` + `void` + invoice numbering | 2 days |
+| 3 | Client-plugin integration (auto-fill from `data/clients/`) | 1 day |
+| 4 | Worklog-plugin integration (auto-fill `lineItems` from `data/worklogs/`) | 2 days |
+| 5 | `generateReport` + report view + templates per `reportKind` | 3 days |
+| 6 | i18n + tests + polish | 2 days |
+
+Total: ~14 working days.
+
+**Ship phases 1–2 as v1 (manual-only, standalone).** Phases 3–4 ship as v1.1 once Client and Worklog plugins exist. Phase 5 is independent and can land any time after v1.
+
+## Cross-plugin reads (informational)
+
+- Reads `data/clients/<id>.md` to fill recipient metadata and rate.
+- Reads `data/worklogs/committed/*.jsonl` to auto-populate line items.
+
+Both reads are **best-effort**: missing data prompts the user rather than failing. This is the key to standalone shippability — the plugin works in a workspace with no other solopreneur plugins installed.
+
+## Success criteria
+
+**v1 (manual, standalone):**
+
+1. "Generate an invoice for Acme, $5000 for May consulting." → invoice opens in canvas with one line item, status: draft.
+2. "List my unpaid invoices." → table with totals.
+3. "Acme paid INV-0042 on June 15." → status flips to paid, list re-renders.
+4. "Void INV-0043; client cancelled the engagement." → status flips, ID is not reused on next generate.
+
+**v1.1 (composed with Client + Worklog):**
+
+5. With Client + Worklog installed: "Generate May invoice for Acme." → line items derived from worklog totals × rate from client file. User reviews, approves.
+6. "Weekly status report for Globex." → report markdown with bullet summary of the past week's activity.
+
+Not in scope:
+
+- PDF generation pipeline (browser print is sufficient)
+- Email delivery
+- Payment-link generation (Stripe / PayPal)
+- Recurring invoice schedules
+- Sales tax computation per jurisdiction
+- Currency conversion / multi-currency invoices
+- Invoice templates (the markdown body is the template; one shape for now)
+
+Each is its own follow-up plugin once v1 ships and a real client demands it.
+
+## Open questions
+
+1. **Invoice numbering scope.** Per-client (`ACME-0001`) or global (`INV-0042`)? Global is simpler and easier for accounting; per-client is what some users expect. Default to global, make prefix configurable.
+2. **Tax handling.** A `tax` field exists in the schema but is always 0 in MVP. When does the user actually need it? Defer until asked; the schema accommodates future addition.
+3. **Report templates.** `reportKind: "weekly" | "monthly"` implies fixed structure. Should custom templates live as user-editable markdown in `~/mulmoclaude/config/invoice/templates/`? Yes, but post-MVP.
+4. **Sender details.** Where does the user's own name / address / payment instructions live? Proposal: a single `~/mulmoclaude/config/invoice.json` with `sender: {...}`. Read once at generation, embedded in the markdown body. Keeps the invoice self-contained (sender details survive even if config is later edited).

--- a/plans/feat-solopreneur-os.md
+++ b/plans/feat-solopreneur-os.md
@@ -1,0 +1,126 @@
+# Plan: Solopreneur OS — Vision and Architecture
+
+## Vision
+
+An AI-native business operations layer for solopreneurs, built as three independent MulmoClaude plugins:
+
+- **Client** — relationship and project records
+- **Worklog** — time and activity records
+- **Invoice / Report** — billable artifacts
+
+Each plugin delivers value on its own. Composed together, they let one chat session turn the user's actual work into billable business records — without forms, without bookkeeping screens, without leaving the conversation.
+
+Target user: consultants, freelancers, developers, designers, creators, small agencies, independent researchers.
+
+## The chat-as-interface promise
+
+Existing SaaS for solopreneurs (HoneyBook, Toggl Track, FreshBooks, Bonsai) converge on the same shape: dashboards, forms, modals, table editors. Each captures one slice (CRM, time, invoices) and forces the user to maintain three parallel mental models.
+
+MulmoClaude inverts this. The user types intent; the agent composes the right plugins and surfaces the right views. The three plugins are not three apps glued together — they are three sources of truth that one agent can read, write, and reconcile in a single turn.
+
+The user should be able to say:
+
+> "Show me what I billed Acme this quarter, then draft a renewal proposal."
+
+…and have the agent walk worklogs → invoices → client notes → a generated proposal, with the right views appearing in the canvas as the work happens.
+
+## Why three plugins (not one app, not many micro-apps)
+
+**Not one app**, because the data models genuinely differ: clients are relational records, worklogs are append-only events, invoices are immutable artifacts. Forcing them into a single plugin couples evolution speed — Worklog will iterate fast as inference improves; Client schema should be stable. Two plugins changing nightly should not require a third unchanged plugin to ship a release.
+
+**Not many micro-apps**, because the three boundaries map cleanly onto the user's mental model: *who I work with*, *what I did*, *what I got paid for*. Splitting further (separating contacts from clients, or projects from clients) creates joins the user has to manage.
+
+Three is the count where each plugin earns its keep on its own.
+
+## Independence principle
+
+Each plugin must satisfy:
+
+1. **Useful alone.** Installable and demoable without the others. A user who only wants time-tracking should get a complete time-tracker.
+2. **Reads, never writes, the others.** The Invoice plugin reads from `~/mulmoclaude/data/worklogs/` and `~/mulmoclaude/data/clients/` if they exist, but never mutates them. If those directories are absent, Invoice falls back to inline chat values.
+3. **No shared event bus in MVP.** Cross-plugin coordination happens through filesystem reads. If a third consumer of worklog data ever appears, revisit. Until then, an event bus is over-engineering.
+4. **Shippable in any order.** No plugin's MVP blocks another's MVP.
+
+The **recommended** build order (by ROI to a developer-founder using MulmoClaude themselves, not by dependency):
+
+| Order | Plugin | Why this slot |
+|---|---|---|
+| 1 | **Worklog** | Most novel; only one whose value depends on Claude doing something hard; demos the platform's differentiation |
+| 2 | **Client** | Identity layer that Worklog labels reference and Invoice addresses; cheapest of the three to build |
+| 3 | **Invoice / Report** | The payoff plugin; trivial once Worklog and Client provide structured inputs |
+
+Any order works; the plans below should be reviewed and approved independently.
+
+## Architecture
+
+### Plugin-vs-host boundary
+
+All three live as runtime plugins under `packages/plugins/` per the CLAUDE.md plugin-vs-host rule. The host gets zero solopreneur-specific code. Each plugin owns:
+
+- Its `meta.ts` (tool name, workspace dirs, channels)
+- Its data directory under `~/mulmoclaude/data/<plugin>/` or `~/mulmoclaude/artifacts/<plugin>/`
+- Its tool definition and dispatch endpoint
+- Its Vue views (canvas + preview)
+
+The only host-side concern is whether the runtime-plugin scaffold can handle a plugin that reads another plugin's workspace directory — it can, since filesystem access is host-level, not plugin-scoped.
+
+### Shared conventions
+
+All three plugins follow the same patterns, copied from the existing todo/calendar/contacts plugins. This is convention, not framework code:
+
+- **Storage.** Markdown + YAML frontmatter for relational records (`data/clients/<slug>.md`); append-only JSONL for event streams (`data/worklogs/<YYYY-MM>.jsonl`); markdown for generated artifacts (`artifacts/invoices/<name>.md`).
+- **AI-on-a-leash.** The LLM never writes a committed record. It writes a candidate file (under `candidates/`) that the user promotes via the approval UI. Matches the existing todo plugin's pattern.
+- **Cross-references.** Foreign keys are file paths in frontmatter (`clientId: acme` → `data/clients/acme.md`), not joins.
+- **i18n.** Every user-facing string goes through `src/lang/*.ts` in all 8 locales (per CLAUDE.md).
+- **No new chrome buttons in MVP.** Plugins are invoked from chat; standalone routes (`/clients`, `/worklogs`, `/invoices`) appear only after the plugin has earned its keep.
+
+### Cross-plugin orchestration (when all three are installed)
+
+```
+User: Prepare May invoice for Acme.
+  → manageWorklog(action=list, clientId=acme, range=2026-05)
+  → manageClient(action=show, id=acme)              [for rate, terms]
+  → manageInvoice(action=generate, clientId=acme, range=2026-05)
+  → invoice.md opens in canvas
+```
+
+This composition is not hard-coded anywhere — Claude decides the chain from the tool descriptions and the user's intent. The plugins do not know about each other.
+
+## Shared workspace layout
+
+```text
+~/mulmoclaude/
+  data/
+    clients/<slug>.md
+    clients/<slug>/projects/<slug>.md
+    worklogs/committed/<YYYY-MM>.jsonl
+    worklogs/candidates/<ts>.json
+  artifacts/
+    invoices/<date>-<client>-<num>.md
+    reports/<period>-<client>.md
+  config/
+    worklog.json                  ← inference repo list, optional
+    invoice.json                  ← numbering prefix, sender details, optional
+```
+
+Each plugin owns its subtree exclusively. No plugin reads or writes outside its own subtree, with the documented exception that Invoice may read from `data/clients/` and `data/worklogs/`.
+
+## Out of scope for the umbrella
+
+| Cut | Why |
+|---|---|
+| Cross-plugin event bus | One consumer per data source; defer until a second appears |
+| PDF generation | Browser print-to-PDF suffices for v1 |
+| Email / Stripe / accounting integrations | Each is its own plugin once the core three prove out |
+| Multi-currency invoice math | Single-currency-per-client is enough |
+| Revenue forecasting | Requires a model; ship reports first |
+| Multi-user / team support | "Solopreneur" is in the name |
+| Marketplace distribution | Coordinate with `plans/feat-plugin-sdk-rollout.md` |
+
+## Plan documents
+
+Each plugin plan is reviewable and shippable independently. Each will move to `plans/done/` once its plugin ships.
+
+- [Client plugin](feat-solopreneur-client.md)
+- [Worklog plugin](feat-solopreneur-worklog.md)
+- [Invoice / Report plugin](feat-solopreneur-invoice.md)

--- a/plans/feat-solopreneur-worklog.md
+++ b/plans/feat-solopreneur-worklog.md
@@ -1,0 +1,158 @@
+# Plan: Worklog Plugin
+
+Part of the [Solopreneur OS umbrella](feat-solopreneur-os.md). Reviewable and shippable independently — no dependency on Client or Invoice.
+
+## Standalone value
+
+An AI-native time tracker. Useful in two modes; both ship as part of v1.
+
+**Manual mode:**
+
+- "Log 2 hours on the auth refactor for Acme just now."
+- "I worked from 9 to noon today on Globex onboarding."
+- "What did I log this week?"
+- "Total my hours per client for May."
+
+This alone replaces Toggl Track for a chat-native user. No inference, no AI risk; a structured, queryable time log.
+
+**Inference mode:**
+
+- "What did I do for Acme yesterday?" → scans git commits, Claude sessions, and recent artifacts, proposes a worklog draft for approval.
+- "Propose worklog for last week." → same, across configured repos and the full workspace.
+
+Inference is an **enhancement layered on top** of the manual surface. If proposals are low quality, the user falls back to manual entry and the plugin is still useful. Partial fills are still less work than full entry. This is why there is no kill-gate on inference quality — a worse-than-hoped inference engine still augments the manual baseline.
+
+Compares to: Toggl Track, Harvest, Clockify. Differentiator: chat input, artifact-aware inference, no timer to forget to start.
+
+## Data model
+
+Two trees:
+
+```text
+~/mulmoclaude/data/worklogs/
+  committed/
+    2026-05.jsonl                 ← one file per month, append-only
+    2026-04.jsonl
+  candidates/
+    2026-05-20T10-00-00Z.json     ← one file per `propose` or `create` call
+```
+
+**Committed entry** (one JSONL record per line):
+
+```yaml
+id: wl-2026-05-20-001
+clientId: acme                    # foreign key into data/clients/<id>.md if Client plugin present; otherwise a free string
+projectId: acme/site-redesign     # optional, slash-separated
+startTime: 2026-05-20T09:15:00-07:00
+endTime: 2026-05-20T11:45:00-07:00
+duration: 9000                    # seconds, denormalized for grep
+billable: true
+source: manual                    # manual | claude-session | git | document | calendar
+evidence:                         # populated for inferred entries; empty for manual
+  - kind: git-commits
+    repo: ~/git/acme/site
+    shas: [a1b2c3d, e4f5g6h]
+notes: |
+  Free-form. Survives edits via supersedes.
+supersedes: null                  # id of previous version if this is an edit
+```
+
+Edits append a new line with `supersedes: <oldId>` rather than mutating. Listing resolves to the latest version per id. Trade-off: file grows monotonically; rotate annually if needed.
+
+**Candidates** are arrays of proposed entries with an extra `confidence: 0.0–1.0` field per entry, dropped on approval.
+
+Each monthly file starts with a `{"schema": "v1"}` header line so a future v2 reader has a hook.
+
+## Tool surface
+
+```ts
+manageWorklog({
+  action:
+    | "create"          // manual entry; writes a candidate, user approves
+    | "propose"         // inference; scans evidence, writes candidate
+    | "approve"         // promote candidate(s) to committed
+    | "edit"            // append supersedes-line
+    | "delete"          // append tombstone
+    | "list"            // query committed entries
+    | "summarize",      // weekly/monthly rollup with totals per client/project
+  range?: { from: string; to: string },
+  clientId?: string,
+  projectId?: string,
+  worklogId?: string,
+  entry?: Partial<Worklog>,
+})
+```
+
+`create` and `propose` both produce candidates — the difference is who fills the fields (user via chat for `create`, Claude via evidence scan for `propose`). Approval funnels through the same UI, keeping the AI-on-a-leash boundary uniform.
+
+## Inference engine (v1.1 of the plugin)
+
+Lives entirely in the plugin, not the host. The `propose` handler:
+
+1. Reads the configured repo list from `~/mulmoclaude/config/worklog.json`.
+2. Walks git logs in those repos for the date range (commits authored by `user.email`).
+3. Reads Claude Code session indices from `~/.claude/projects/*/` for sessions overlapping the range.
+4. Stats `~/mulmoclaude/artifacts/` and `data/` for files written in the range.
+5. Optionally reads `data/calendar/` for events in the range (if the calendar plugin is installed).
+6. Bundles the evidence into a structured prompt and calls Claude with a JSON-schema response.
+7. Writes the response as a candidate file; opens the approval view.
+
+The user can edit any field inline before approving. Approval moves the entries into the committed JSONL.
+
+Manual-mode `create` takes the same path with an empty evidence bundle; Claude is just structuring the user's chat description into the schema.
+
+## GUI surfaces
+
+1. **Approval view**: table of candidate rows with inline edit. Per row: time range, duration, client, project, billable toggle, confidence (if inferred), evidence chips (clickable to expand). Approve-selected button writes them to committed JSONL and deletes the candidate file.
+2. **Weekly summary view** (default for `list` and `summarize`): spreadsheet of committed entries for a date range, grouped by client / project / day. Reuse `src/plugins/spreadsheet/`. Totals row at the bottom.
+3. **Preview** (sidebar): for a `list` result, show a compact "this week vs. last week" bar.
+
+No standalone `/worklog` route in MVP.
+
+## Phases
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Schema + JSONL I/O + `create` / `approve` / `list` / `edit` / `delete` handlers | 4 days |
+| 2 | Approval view + weekly summary view + i18n | 3 days |
+| 3 | `propose` handler — evidence collection from git, sessions, artifacts | 5 days |
+| 4 | Inference prompt + dogfooding on user's real week + tuning | 3 days |
+| 5 | Polish: confidence display, evidence drill-down, supersedes resolver | 2 days |
+
+Total: ~17 working days.
+
+**Ship phases 1–2 as v1 (manual-only).** v1 is independently useful and demoable. Phases 3–5 ship as v1.1 once manual is stable.
+
+## Cross-plugin reads (informational)
+
+- Reads `data/clients/*.md` if present, to validate `clientId` and offer autocomplete. Falls back to free-string entry if Client plugin absent.
+- Reads `data/calendar/` if present, as inference evidence.
+
+Does not write outside its own subtree.
+
+## Success criteria
+
+**v1 (manual):**
+
+1. "Log 2 hours on the Acme migration starting at 9am." → candidate, approve, committed JSONL line written.
+2. "What did I log this week?" → spreadsheet view with totals per client.
+3. "Edit yesterday's Acme entry to end at 4pm instead of 3pm." → new supersedes-line appended; list reflects the updated time.
+
+**v1.1 (inference):**
+
+4. "Propose worklog for last week." → table of candidates with evidence chips; user accepts >50% without edit.
+5. The user prefers `propose` + edit over manual entry for a typical week. (Qualitative measure; if not true, ship v1, stop iterating on inference.)
+
+Not in scope:
+
+- Live timer UI ("start tracking now") — manual entry of completed blocks is enough; live timers are what this plugin is replacing.
+- Invoicing-aware billable rate (lives in the Client plugin; Invoice reads it).
+- Multi-user attribution.
+- Non-developer evidence sources (figma, vscode liveshare, etc.) — see open question 4.
+
+## Open questions
+
+1. **Claude session enumeration.** Confirm `~/.claude/projects/-*/` naming convention and session index layout before phase 3 starts.
+2. **Confidence in the approval UI.** Show numerically (`0.82`), as bands (`high/med/low`), or hide entirely? Anchoring bias risk if shown. Decide after first dogfooding.
+3. **Schema versioning.** v1 header line is the migration hook. The actual v2 migration is deferred until a schema change is actually proposed.
+4. **Inference for non-developer users.** All v1.1 evidence sources are developer-centric. A designer's "work" is figma history; a writer's is document mtimes. Out of scope for MVP; the evidence-collection layer is plug-replaceable per-source so adding figma later is additive, not a rewrite.


### PR DESCRIPTION
This PR adds the vision and design documents for the upcoming Solopreneur OS plugins (Client, Worklog, and Invoice/Report) under the plans folder.

## Summary by Sourcery

Add planning and architecture documents for the Solopreneur OS suite of plugins (Client, Worklog, Invoice/Report) outlining their vision, data models, tool surfaces, UI surfaces, phases, and cross-plugin interactions.

Documentation:
- Document the overall Solopreneur OS vision and plugin architecture, including boundaries, shared conventions, and workspace layout.
- Add a detailed plan for the Client plugin covering standalone value, file-based data model for clients and projects, tool API, UI views, rollout phases, and success criteria.
- Add a detailed plan for the Worklog plugin describing manual and inference modes, append-only JSONL data model, tool API, UI flows, phased delivery, and success criteria.
- Add a detailed plan for the Invoice/Report plugin specifying markdown-based invoice/report artifacts, tool API, GUI views, phased rollout, and integration points with Client and Worklog plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published comprehensive feature plans for Solopreneur OS, an upcoming AI-native business operations platform
  * Includes detailed specifications for client management, invoice and report generation, and worklog time tracking
  * Covers data models, tool interfaces, GUI surfaces, phased rollout schedules, and success criteria
  * Establishes architecture principles and shared conventions for plugin independence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->