### PR TITLE
fix(wiki): add interaction + visited states for external links in wiki body

### DIFF
--- a/src/plugins/wiki/components/WikiPageBody.vue
+++ b/src/plugins/wiki/components/WikiPageBody.vue
@@ -66,17 +66,20 @@ function onClick(event: MouseEvent) {
   text-decoration: underline;
 }
 /* Interaction + visited states for external / markdown-rendered
-   anchors. `.wiki-link` (internal cross-refs) has its own hover
-   rule above; this covers all other anchors inside the wiki body
-   so keyboard focus and visit history are visible to the user.
-   (Sourcery follow-up on #1453.) */
-.wiki-content :deep(a:hover) {
-  color: #1d4ed8;
-}
-.wiki-content :deep(a:visited) {
+   anchors. Scope with `:not(.wiki-link)` so the rules don't override
+   the dotted-underline / solid-on-hover styling that internal
+   cross-refs already carry above (Codex follow-up on #1466).
+   Order follows LVHA: visited before hover so a visited+hovered
+   link shows the hover color, not the visited one (Sourcery
+   follow-up on #1466). focus-visible is appended; it can stack
+   with any state to give keyboard users a visible outline. */
+.wiki-content :deep(a:not(.wiki-link):visited) {
   color: #6d28d9;
 }
-.wiki-content :deep(a:focus-visible) {
+.wiki-content :deep(a:not(.wiki-link):hover) {
+  color: #1d4ed8;
+}
+.wiki-content :deep(a:not(.wiki-link):focus-visible) {
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }

--- a/src/plugins/wiki/components/WikiPageBody.vue
+++ b/src/plugins/wiki/components/WikiPageBody.vue
@@ -65,6 +65,21 @@ function onClick(event: MouseEvent) {
   color: #2563eb;
   text-decoration: underline;
 }
+/* Interaction + visited states for external / markdown-rendered
+   anchors. `.wiki-link` (internal cross-refs) has its own hover
+   rule above; this covers all other anchors inside the wiki body
+   so keyboard focus and visit history are visible to the user.
+   (Sourcery follow-up on #1453.) */
+.wiki-content :deep(a:hover) {
+  color: #1d4ed8;
+}
+.wiki-content :deep(a:visited) {
+  color: #6d28d9;
+}
+.wiki-content :deep(a:focus-visible) {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
 .wiki-content :deep(h1) {
   font-size: 1.5rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary

Sourcery follow-up on #1453. `.wiki-content :deep(a)` had only the default state (blue + underline) — no `:hover`, `:visited`, or keyboard `:focus-visible` styles. Adds three rules so non-internal anchors in the wiki markdown body have proper accessibility / affordance behaviour, matching the discipline `.wiki-link` already follows for internal cross-refs.

## Change

```diff
 .wiki-content :deep(a) {
   color: #2563eb;
   text-decoration: underline;
 }
+.wiki-content :deep(a:hover) {
+  color: #1d4ed8;
+}
+.wiki-content :deep(a:visited) {
+  color: #6d28d9;
+}
+.wiki-content :deep(a:focus-visible) {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
```

Scope kept identical (`:deep(a)` inside `.wiki-content`) — Sourcery also suggested narrowing the scope, but every anchor inside the markdown body is intentionally a link; no non-link anchors today.

## Test plan

- [x] `yarn lint` / `typecheck` clean
- Manual eyeball check on a wiki page recommended after merge to confirm hover/visited colours pass contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add hover, visited, and keyboard focus-visible styles for external/markdown-rendered anchors in wiki page content to better align with existing internal link behaviour and accessibility expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced link styling across wiki pages: distinct hover and visited colors plus a clear focus indicator to improve accessibility and interaction feedback, while preserving existing special link underline behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->