### PR TITLE
test(csrf): make baseline middleware fixture env-independent

### DIFF
--- a/test/server/test_csrfGuard.ts
+++ b/test/server/test_csrfGuard.ts
@@ -161,6 +161,16 @@ function makeRes(): FakeRes {
   return res;
 }
 
+// Baseline middleware fixture: a `requireSameOriginWith([])` instance
+// rather than the env-bound `requireSameOrigin` export. The baseline
+// tests below assert "default localhost-only" behaviour, so they
+// must NOT inherit the test process's `MULMOCLAUDE_TRUSTED_ORIGINS`
+// (which is normally unset, but a future test or CI matrix entry
+// could set it and silently corrupt these assertions). The dedicated
+// env-bound smoke test further down still exercises the exported
+// `requireSameOrigin`.
+const baselineMiddleware = requireSameOriginWith([]);
+
 function run(req: FakeReq, res: FakeRes): { nextCalled: boolean; statusCode: number; body: unknown } {
   let nextCalled = false;
   const next: NextFunction = () => {
@@ -169,7 +179,7 @@ function run(req: FakeReq, res: FakeRes): { nextCalled: boolean; statusCode: num
   // The types differ slightly from real Express — cast through
   // `unknown` since the middleware only touches `method`,
   // `headers`, `status`, `json`.
-  requireSameOrigin(req as unknown as Request, res as unknown as Response, next);
+  baselineMiddleware(req as unknown as Request, res as unknown as Response, next);
   return {
     nextCalled,
     statusCode: res.statusCode,


### PR DESCRIPTION
## Summary

[`test/server/test_csrfGuard.ts`](test/server/test_csrfGuard.ts) の baseline `run()` ヘルパを env-bound `requireSameOrigin` から `requireSameOriginWith([])` に切り替え、baseline ケースが test プロセスの `MULMOCLAUDE_TRUSTED_ORIGINS` 設定に依存しない決定論的なテストになるよう改善。

PR #1458 で導入したテストの follow-up。production code は変更なし、test code 1 ファイルのみ。

## Items to Confirm / Review

- 既存の env-bound smoke describe（`requireSameOrigin (env-bound export) — smoke test`）は残置。export された `requireSameOrigin` の wire-up は引き続きそこで検証している
- baseline テストの「localhost only」挙動は不変（`requireSameOriginWith([])` = 空 allowlist は env unset 相当）

## User Prompt

> PR #1458 のレビュー指摘に対する追加の test 改善を follow-up PR として上げてほしい。

## 背景

PR #1458 のレビューで CodeRabbit から指摘あり:

> `run()` currently goes through the env-bound `requireSameOrigin`, so these "default behavior" cases inherit whatever `MULMOCLAUDE_TRUSTED_ORIGINS` the test process started with. That turns the localhost-only baseline into an ambient-env test instead of a deterministic unit.

（[CodeRabbit review on PR #1458](https://github.com/receptron/mulmoclaude/pull/1458) より）

この指摘への対応を follow-up として本 PR で取り込む。

## 変更内容

[`test/server/test_csrfGuard.ts`](test/server/test_csrfGuard.ts):

- `run()` ヘルパが呼ぶ middleware を env-bound `requireSameOrigin` から `requireSameOriginWith([])` に変更
- 変更理由を冒頭コメントで明示

`server/api/csrfGuard.ts` 本体は変更なし。

## テスト

ローカル全 pass:

```
yarn format    ✓
yarn lint      ✓
yarn typecheck ✓
yarn build     ✓
yarn test      ✓ 5029 + 86 = 5115 tests pass
```

## 関連

- PR #1458（CSRF trusted-origin allowlist 追加。本 PR の元改修）
- Issue #1463（同じレビューで Major / Heavy lift として別 PR 対応となったもの。本 PR とは独立）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Adjust CSRF guard baseline test helper to use a `requireSameOriginWith([])` middleware fixture so assertions do not depend on `MULMOCLAUDE_TRUSTED_ORIGINS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for CSRF middleware to ensure default behavior assertions are not affected by environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->