### PR TITLE
refactor(worklog): remove "approve" from LLM action enum — UI-only

### DIFF
--- a/packages/plugins/worklog-plugin/src/definition.ts
+++ b/packages/plugins/worklog-plugin/src/definition.ts
@@ -5,13 +5,14 @@ export const TOOL_DEFINITION = {
   type: "function" as const,
   name: "manageWorklog" as const,
   prompt: "When users mention tracking their time, logging work, or viewing their work summaries, use manageWorklog.",
-  description: "Manage worklog entries — log hours manually (create candidate), approve candidates, list committed logs, edit logs, or delete logs.",
+  description:
+    "Manage worklog entries — log hours manually (create candidate), list committed logs, edit logs, or delete logs. Candidates are approved via the Review Board UI, not by this tool.",
   parameters: {
     type: "object" as const,
     properties: {
       action: {
         type: "string",
-        enum: ["create", "approve", "list", "edit", "delete", "present"],
+        enum: ["create", "list", "edit", "delete", "present"],
         description: "The action to perform on the worklog database.",
       },
       clientId: {
@@ -37,10 +38,6 @@ export const TOOL_DEFINITION = {
       billable: {
         type: "boolean",
         description: "Whether the logged hours are billable. Default is true.",
-      },
-      candidateId: {
-        type: "string",
-        description: "For 'approve': The unique candidate file ID or entry ID to approve.",
       },
       worklogId: {
         type: "string",

--- a/packages/plugins/worklog-plugin/src/index.ts
+++ b/packages/plugins/worklog-plugin/src/index.ts
@@ -35,7 +35,17 @@ export default definePlugin((runtime) => {
   const { pubsub, files, log } = runtime;
   const writeMutex = new WriteMutex();
 
-  // LLM / MCP action path
+  // LLM / MCP action path.
+  //
+  // `approve` is intentionally NOT in this switch. Promoting a
+  // candidate to a committed entry must be a deliberate click in the
+  // Review Board UI, not the LLM's read of "looks good" in chat —
+  // verbal approval is too easy to misinterpret as a commit signal,
+  // and the candidate flow exists specifically to guard that boundary.
+  // `handleApprove` is still imported for the UI dispatch path below
+  // (`candidateApprove` kind). `edit` / `delete` ARE exposed because
+  // they operate on already-approved entries, where the human-in-the-
+  // loop gate has already been crossed.
   async function handleLlm(args: LlmArgs) {
     const { action, ...input } = args;
     log.info("dispatch llm worklog", { action });
@@ -51,19 +61,6 @@ export default definePlugin((runtime) => {
             message: res.message,
             jsonData: res.jsonData,
             instructions: "Show the new worklog candidate in the Review Board.",
-          };
-        });
-      }
-      case "approve": {
-        return writeMutex.run(async () => {
-          const res = await handleApprove(files.data, input);
-          if (res.kind === "error") return { error: res.error, status: res.status };
-          pubsub.publish("changed", { reason: "llm-approve" });
-          return {
-            data: res.data,
-            message: res.message,
-            jsonData: res.jsonData,
-            instructions: "Show the approved entry in the worklog list.",
           };
         });
       }

--- a/test/plugins/test_worklog_integration.ts
+++ b/test/plugins/test_worklog_integration.ts
@@ -146,13 +146,22 @@ describe("Worklog plugin — end-to-end integration through the loader", () => {
     assert.equal(uiRes.data.candidates[0].id, candidateId);
     assert.equal(uiRes.data.candidates[0].clientId, "Acme Corp");
 
-    // 4. Approve the candidate (action: "approve").
-    res = (await plugin.execute({}, { action: "approve", candidateId })) as WorklogActionResult;
-    assert.ok(!res.error, `Approve failed: ${res.error}`);
-    assert.ok(res.jsonData?.worklogId);
-    const { worklogId } = res.jsonData;
+    // 4a. LLM cannot directly approve — the candidate-flow gate
+    // requires a UI click in the Review Board. The action enum in
+    // definition.ts does not list "approve", so the switch falls
+    // through to the default branch.
+    const llmApproveAttempt = (await plugin.execute({}, { action: "approve", candidateId })) as WorklogActionResult;
+    assert.ok(llmApproveAttempt.error, "LLM-direct approve must be rejected");
+    assert.equal(llmApproveAttempt.status, 400);
+    assert.equal(published.length, 1, "Rejected approve must not publish a change event");
 
-    assert.equal(published.length, 2, "Should publish again on approve");
+    // 4b. Approve via the UI dispatch path (kind: "candidateApprove").
+    const approveRes = (await plugin.execute({}, { kind: "candidateApprove", id: candidateId })) as unknown as ListAllResult;
+    assert.equal(approveRes.data.candidates.length, 0, "candidate should be consumed on approve");
+    assert.equal(approveRes.data.committed.length, 1, "approve should commit one entry");
+    const worklogId = approveRes.data.committed[0].id;
+
+    assert.equal(published.length, 2, "UI approve should publish exactly one change event");
     assert.equal(published[1].channel, `plugin:${PKG_NAME}:changed`);
 
     // 5. UI listAll shows no candidates, and 1 committed entry.


### PR DESCRIPTION
## Summary

Tightens the AI-on-a-leash boundary in the Worklog plugin so that promoting a candidate to a committed entry is **always** a deliberate Review Board click, never the LLM's read of "looks good" in chat.

Before this PR, the `manageWorklog` tool schema listed `"approve"` alongside `create / list / edit / delete / present`. A single conversational turn like *"create a worklog for 9-noon and approve it"* would commit straight to JSONL with no human touch — the candidate flow existed but the same actor it was designed to gate could bypass it.

## What's changed

- **`definition.ts`** — drop `"approve"` from the `action` enum; drop the `candidateId` parameter (no remaining LLM action uses it); update the tool description: *"Candidates are approved via the Review Board UI, not by this tool."*
- **`index.ts`** — remove the `case "approve":` block from `handleLlm`. Add a block comment above the switch explaining the design decision and why `edit` / `delete` are still exposed (they operate on already-approved entries, where the human-in-the-loop gate has already been crossed). `handleApprove` is still imported and used by the UI `candidateApprove` dispatch.
- **`test_worklog_integration.ts`** — split step 4 to assert the gate explicitly:
  - **4a:** `plugin.execute({ action: "approve", candidateId })` returns `{ error, status: 400 }` and publishes no `changed` event.
  - **4b:** `plugin.execute({ kind: "candidateApprove", id })` (UI path) consumes the candidate and commits the entry.

## What's preserved

- The UI "Approve" button in the Review Board (`candidateApprove` kind) works exactly as before.
- `create` / `edit` / `delete` / `list` / `present` remain LLM-callable.
- `handleApprove` stays in the source — only its LLM entrypoint is removed.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — clean
- [x] `yarn test` — 5029/5029 pass (worklog integration test #452 now verifies both the rejection of LLM-direct approve and the success of the UI dispatch path)
- [x] `yarn test:e2e` — 435/435 pass

## Follow-ups not addressed here

Three items from the earlier review (#1468) are still open and worth their own PRs:
- `confirm()` in `View.vue:752` (no other plugin uses native browser confirm)
- `View.vue` length / cognitive complexity (split into `useWorklogData` + `useWeekNavigation` composables)
- Unsaved candidate edits silently lost when `pubsub("changed")` fires (`View.vue:318`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten the Worklog plugin’s AI boundaries so only the UI can approve candidates and LLMs are limited to non-approval actions.

Bug Fixes:
- Reject direct LLM attempts to approve worklog candidates with a 400 response and no change events.

Enhancements:
- Remove the LLM-accessible `approve` action and its candidateId parameter from the manageWorklog tool definition, clarifying that approvals occur only via the Review Board UI.
- Document the rationale for excluding `approve` while keeping `edit` and `delete` available to the LLM path in the Worklog plugin dispatcher.

Tests:
- Extend the Worklog integration test to verify that LLM-based approve is rejected while UI-based candidateApprove still commits entries and publishes a single change event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Modified the worklog tool to remove approval functionality from the API. Candidate approvals are now exclusively handled through the Review Board UI, streamlining the approval workflow and ensuring consistency across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->