### PR TITLE
feat(right-sidebar): add copy button for Tool Call History

### DIFF
--- a/e2e/tests/right-sidebar-toggle.spec.ts
+++ b/e2e/tests/right-sidebar-toggle.spec.ts
@@ -21,7 +21,7 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
     });
     await expect(sidebarHeading).toBeHidden();
 
-    const toggleBtn = page.getByTitle("Tool call history");
+    const toggleBtn = page.getByTitle("Tool call history", { exact: true });
     await toggleBtn.click();
     await expect(sidebarHeading).toBeVisible();
 
@@ -33,14 +33,14 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    await page.getByTitle("Tool call history").click();
+    await page.getByTitle("Tool call history", { exact: true }).click();
     await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
 
     const stored = await page.evaluate(() => localStorage.getItem("right_sidebar_visible"));
     expect(stored).toBe("true");
 
     // Close → stored becomes "false".
-    await page.getByTitle("Tool call history").click();
+    await page.getByTitle("Tool call history", { exact: true }).click();
     const stored2 = await page.evaluate(() => localStorage.getItem("right_sidebar_visible"));
     expect(stored2).toBe("false");
   });
@@ -54,7 +54,7 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
     await expect(page.getByText("MulmoClaude")).toBeVisible();
     // Panel and toggle button both visible on chat.
     await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
-    await expect(page.getByTitle("Tool call history")).toBeVisible();
+    await expect(page.getByTitle("Tool call history", { exact: true })).toBeVisible();
 
     for (const route of ["/wiki", "/todos", "/calendar", "/automations", "/skills", "/roles", "/files"] as const) {
       await page.goto(route);
@@ -62,12 +62,12 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
       // Panel content gone.
       await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeHidden();
       // Toggle button gone (dead control suppression).
-      await expect(page.getByTitle("Tool call history")).toBeHidden();
+      await expect(page.getByTitle("Tool call history", { exact: true })).toBeHidden();
     }
 
     // Returning to chat restores the panel at the user's saved preference.
     await page.goto("/chat");
     await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
-    await expect(page.getByTitle("Tool call history")).toBeVisible();
+    await expect(page.getByTitle("Tool call history", { exact: true })).toBeVisible();
   });
 });

--- a/src/components/RightSidebar.vue
+++ b/src/components/RightSidebar.vue
@@ -34,8 +34,20 @@
         </div>
       </div>
 
-      <div class="p-4 border-b border-gray-200 bg-white">
+      <div class="p-4 border-b border-gray-200 bg-white flex items-center justify-between gap-2">
         <h2 class="text-lg font-semibold">{{ t("rightSidebar.toolCallHistory") }}</h2>
+        <button
+          type="button"
+          class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          :class="{ '!text-green-600': copied }"
+          data-testid="copy-tool-call-history"
+          :disabled="toolCallHistory.length === 0"
+          :title="copied ? t('rightSidebar.copiedHistory') : t('rightSidebar.copyHistory')"
+          :aria-label="copied ? t('rightSidebar.copiedHistory') : t('rightSidebar.copyHistory')"
+          @click="onCopyHistory"
+        >
+          <span class="material-icons text-lg" aria-hidden="true">{{ copied ? "check" : "content_copy" }}</span>
+        </button>
       </div>
 
       <div class="p-2 space-y-2 bg-gray-100">
@@ -92,15 +104,22 @@ import { ref, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolCallHistoryItem } from "../types/toolCallHistory";
 import { formatTime } from "../utils/format/date";
+import { useClipboardCopy } from "../composables/useClipboardCopy";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   toolCallHistory: ToolCallHistoryItem[];
   availableTools: string[];
   rolePrompt: string;
   toolDescriptions: Record<string, string>;
 }>();
+
+const { copied, copy } = useClipboardCopy();
+
+async function onCopyHistory(): Promise<void> {
+  await copy(formatJson(props.toolCallHistory));
+}
 
 const showSystemPrompt = ref(false);
 const expandedTools = ref(new Set<string>());

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -114,6 +114,8 @@ const deMessages = {
     availableTools: "Verfügbare Tools",
     toggleToolDescription: "Tool-Beschreibung umschalten",
     toolCallHistory: "Tool-Aufrufverlauf",
+    copyHistory: "Tool-Aufrufverlauf kopieren",
+    copiedHistory: "Kopiert!",
     noToolCalls: "Noch keine Tool-Aufrufe",
     arguments: "Argumente",
     error: "Fehler",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -132,6 +132,8 @@ const enMessages = {
     availableTools: "Available Tools",
     toggleToolDescription: "Toggle tool description",
     toolCallHistory: "Tool Call History",
+    copyHistory: "Copy tool call history",
+    copiedHistory: "Copied!",
     noToolCalls: "No tool calls yet",
     arguments: "Arguments",
     error: "Error",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -117,6 +117,8 @@ const esMessages = {
     availableTools: "Herramientas disponibles",
     toggleToolDescription: "Alternar descripción de la herramienta",
     toolCallHistory: "Historial de llamadas a herramientas",
+    copyHistory: "Copiar historial de llamadas a herramientas",
+    copiedHistory: "¡Copiado!",
     noToolCalls: "Aún no hay llamadas a herramientas",
     arguments: "Argumentos",
     error: "Error",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -112,6 +112,8 @@ const frMessages = {
     availableTools: "Outils disponibles",
     toggleToolDescription: "Basculer la description de l'outil",
     toolCallHistory: "Historique des appels d'outils",
+    copyHistory: "Copier l'historique des appels d'outils",
+    copiedHistory: "Copié !",
     noToolCalls: "Aucun appel d'outil pour le moment",
     arguments: "Arguments",
     error: "Erreur",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -117,6 +117,8 @@ const jaMessages = {
     availableTools: "利用可能ツール",
     toggleToolDescription: "ツール説明の表示切替",
     toolCallHistory: "ツール呼び出し履歴",
+    copyHistory: "ツール呼び出し履歴をコピー",
+    copiedHistory: "コピーしました!",
     noToolCalls: "ツール呼び出しはまだありません",
     arguments: "引数",
     error: "エラー",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -119,6 +119,8 @@ const koMessages = {
     availableTools: "사용 가능한 도구",
     toggleToolDescription: "도구 설명 토글",
     toolCallHistory: "도구 호출 기록",
+    copyHistory: "도구 호출 기록 복사",
+    copiedHistory: "복사됨!",
     noToolCalls: "아직 도구 호출이 없습니다",
     arguments: "인자",
     error: "오류",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -112,6 +112,8 @@ const ptBRMessages = {
     availableTools: "Ferramentas disponíveis",
     toggleToolDescription: "Alternar descrição da ferramenta",
     toolCallHistory: "Histórico de chamadas de ferramentas",
+    copyHistory: "Copiar histórico de chamadas de ferramentas",
+    copiedHistory: "Copiado!",
     noToolCalls: "Ainda não há chamadas de ferramentas",
     arguments: "Argumentos",
     error: "Erro",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -114,6 +114,8 @@ const zhMessages = {
     availableTools: "可用工具",
     toggleToolDescription: "切换工具说明",
     toolCallHistory: "工具调用历史",
+    copyHistory: "复制工具调用历史",
+    copiedHistory: "已复制!",
     noToolCalls: "还没有工具调用",
     arguments: "参数",
     error: "错误",


### PR DESCRIPTION
## Summary

- Adds a copy button next to the **Tool Call History** header in the right sidebar to aid debugging.
- Copies the full `ToolCallHistoryItem[]` as pretty-printed JSON — captures `toolUseId`, `toolName`, `args`, `timestamp`, `result`/`error`, and `mcpHint` (richer than what the panel renders).
- Icon-only chrome button (`h-8 w-8`, Material Icons `content_copy` → `check`) matching the sizing language in `CLAUDE.md`. Disabled when history is empty; swaps to a green check for ~2s via the existing `useClipboardCopy` composable.
- i18n keys `rightSidebar.copyHistory` / `rightSidebar.copiedHistory` added in lockstep across all 8 locales (`en`, `ja`, `zh`, `ko`, `es`, `pt-BR`, `fr`, `de`).
- `data-testid="copy-tool-call-history"` exposed for future E2E coverage.

## Test plan

- [ ] `yarn dev`, open the right sidebar, trigger a few tool calls, click the copy button, paste into a text editor — verify the JSON includes `toolUseId`, `args`, `result`/`error`, and `mcpHint` when present.
- [ ] Verify the button is disabled (40% opacity, no-pointer cursor) when no tool calls have occurred yet.
- [ ] Verify the icon swaps to a green check for ~2s after a successful copy, then reverts.
- [ ] Switch locale (e.g. `ja`, `de`) and confirm the tooltip and aria-label are translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a copy-to-clipboard control for tool call history in the right sidebar, including localization and accessibility wiring.

New Features:
- Add an icon-only button to copy the full tool call history from the right sidebar to the clipboard as formatted JSON.

Enhancements:
- Use the shared clipboard composable to provide copied state feedback on the tool call history header control.
- Expose a test ID on the new copy control and update all supported locales with tooltip and aria-label strings for the copy action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy-to-clipboard button for the tool call history with success feedback and disabled state when no entries exist.

* **Localization**
  * Added UI strings for the copy action and success state in English, German, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Simplified Chinese.

* **Tests**
  * Updated end-to-end tests to more reliably locate and assert the tool call history toggle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->