### PR TITLE
fix: preserve ASCII percent encodings in workspace link decode

### DIFF
--- a/plans/fix-plugin-scoped-link-decode.md
+++ b/plans/fix-plugin-scoped-link-decode.md
@@ -1,0 +1,131 @@
+# Plan: fix plugin-scoped file links from chat resolving to wrong on-disk path
+
+Issue: receptron/mulmoclaude#1473
+
+## 背景
+
+プラグインデータディレクトリは URL エンコードした npm スコープ名を 1 ディレクトリとして平坦化する命名規約（`data/plugins/%40<scope>%2F<name>/`）を採用しているが、チャットからのリンククリック時に `src/utils/path/workspaceLinkRouter.ts` の `safeDecode` がパス全体を `decodeURIComponent` するため、`%40` `%2F` が `@` `/` に化けてセグメント分裂し、サーバが該当ファイルを見つけられない。
+
+詳細な原因分析と検討した代替案は issue #1473 を参照。
+
+## 採用方針
+
+**Approach A — disk-canonical string**: `safeDecode` を「multibyte (高位バイト) percent sequence だけ decode、ASCII percent encoding (`%40` / `%2F` / `%20` 等) は literal として保持」に変える。
+
+プラグインディレクトリの命名規約は現状維持。
+
+## 実装ステップ
+
+### 1. `src/utils/path/workspaceLinkRouter.ts` の `safeDecode` 改修
+
+現状:
+```ts
+function safeDecode(str: string): string {
+  try {
+    return decodeURIComponent(str);
+  } catch {
+    return str;
+  }
+}
+```
+
+変更後:
+```ts
+// Decode only multibyte percent sequences (UTF-8 high-byte
+// `%[89A-F][0-9A-F]+`). ASCII percent encodings (%40 '@', %2F '/',
+// %20 ' ', etc.) are PRESERVED as literal characters because the
+// plugin convention stores them literally on disk
+// (data/plugins/%40<scope>%2F<name>/...). Decoding %2F to '/' here
+// would collapse the single plugin-scope directory name into two
+// separate segments and break server-side file resolution.
+function safeDecode(str: string): string {
+  return str.replace(/(?:%[89A-Fa-f][0-9A-Fa-f])+/g, (match) => {
+    try {
+      return decodeURIComponent(match);
+    } catch {
+      return match;
+    }
+  });
+}
+```
+
+### 2. テスト反転
+
+`test/utils/path/test_workspaceLinkRouter.ts:139-145` (pin: `%2F` を path separator として展開):
+- 旧期待: `data/some/foo%2Fbar.md` → `{ kind: "file", path: "data/some/foo/bar.md" }`
+- 新期待: `data/some/foo%2Fbar.md` → `{ kind: "file", path: "data/some/foo%2Fbar.md" }` （ASCII percent は literal）
+- コメントも新セマンティクスを反映する形に書き直す
+
+`test/utils/path/test_workspaceLinkRouter.ts:109-112` (pin: `%20` を space に decode):
+- 旧期待: `data/some/my%20file.txt` → `{ kind: "file", path: "data/some/my file.txt" }`
+- 新期待: `data/some/my%20file.txt` → `{ kind: "file", path: "data/some/my%20file.txt" }`
+
+### 3. テスト追加
+
+a) プラグインスコープ命名規約の round-trip pin:
+```ts
+it("preserves plugin-scoped percent-encoded directory name as a single literal segment", () => {
+  const result = classifyWorkspacePath("data/plugins/%40mulmoclaude%2Fworklog/committed/2026-05.jsonl");
+  assert.deepEqual(result, {
+    kind: "file",
+    path: "data/plugins/%40mulmoclaude%2Fworklog/committed/2026-05.jsonl",
+  });
+});
+```
+
+b) ASCII percent + multibyte 混在ケース:
+```ts
+it("decodes multibyte percent sequence while preserving ASCII percent literals", () => {
+  // Hypothetical: plugin-scoped file with a Japanese filename
+  const encoded = "data/plugins/%40mulmoclaude%2Fworklog/%E3%83%A1%E3%83%A2.md";
+  const result = classifyWorkspacePath(encoded);
+  assert.deepEqual(result, {
+    kind: "file",
+    path: "data/plugins/%40mulmoclaude%2Fworklog/メモ.md",
+  });
+});
+```
+
+### 4. path traversal の回帰確認
+
+既存テスト (`%2E%2E` 系) を新セマンティクス下でも pass することを確認。`%2E%2E` は ASCII percent encoding なので literal 保持され、`normalizePath` の `..` リテラル検出には届かない。これは「encoded form の traversal が effectiveに無害化される」方向の挙動変化で、セキュリティ的にはむしろ強化。
+
+ただし `%2E%2E` を ASCII literal として保持すると `..` 検出に引っかからないので、テスト期待値も変わる:
+- 旧期待: `data/wiki/pages/%2E%2E/sources/foo.md` → 正規化されて `data/wiki/sources/foo.md`
+- 新期待: 同じ入力 → `{ kind: "file", path: "data/wiki/pages/%2E%2E/sources/foo.md" }` （`%2E%2E` がリテラル保持される）
+
+これは挙動変化だが、攻撃面は **狭くなる** （`..` リテラルでの traversal 試行は引き続き弾かれる; encoded form での traversal は今回 effectively 無害化される — サーバ側の `resolveWithinRoot` も別途防御層を持つはず）。
+
+### 5. `todoPreview.ts` の workaround について
+
+`src/utils/filesPreview/todoPreview.ts:10-19` の both-form 比較 workaround は今回の PR では触らない（別 PR で整理）。
+
+### 6. yarn format / lint / typecheck / build / test
+
+すべて pass を確認してから commit。
+
+## コミット予定
+
+1 コミット:
+```
+fix: preserve ASCII percent encodings (%40, %2F) in workspace link decode
+
+The plugin naming convention stores npm-scoped directories as single
+URL-encoded directories on disk (data/plugins/%40<scope>%2F<name>/).
+classifyWorkspacePath's previous decodeURIComponent over the whole
+path collapsed `%2F` into a path separator, breaking server-side
+file resolution for any plugin-scoped link from chat.
+
+Decode only multibyte (high-byte) percent sequences so that
+multibyte filenames still work, but ASCII percent encodings are
+preserved as literal characters matching disk layout.
+
+Refs: #1473
+```
+
+## 影響範囲（再確認）
+
+- 修正: `src/utils/path/workspaceLinkRouter.ts`
+- テスト: `test/utils/path/test_workspaceLinkRouter.ts`
+- その他: なし（呼び出し元の `App.vue`, `WikiPageBody.vue`, `textResponse/View.vue` は変更不要）
+- サーバ・ルーター設定: 変更なし

--- a/plans/fix-plugin-scoped-link-decode.md
+++ b/plans/fix-plugin-scoped-link-decode.md
@@ -10,9 +10,11 @@ Issue: receptron/mulmoclaude#1473
 
 ## 採用方針
 
-**Approach A — disk-canonical string**: `safeDecode` を「multibyte (高位バイト) percent sequence だけ decode、ASCII percent encoding (`%40` / `%2F` / `%20` 等) は literal として保持」に変える。
+**Approach A — disk-canonical string (per-segment)**: `safeDecode` を「`/`-区切りセグメント単位で `decodeURIComponent` を実行。ただし `%2F` を含むセグメントだけ opaque に保つ」形に変える。
 
 プラグインディレクトリの命名規約は現状維持。
+
+> 初回実装では「multibyte (高位バイト) percent sequence だけ decode、ASCII percent encoding は全部 literal」という粗い判定で `%20` を含む正常な URL transport encoding を破壊するリグレッションを起こした。Codex GHA / CodeRabbit が PR 上で同じ regression を指摘。本方針はその対応版。
 
 ## 実装ステップ
 
@@ -31,21 +33,23 @@ function safeDecode(str: string): string {
 
 変更後:
 ```ts
-// Decode only multibyte percent sequences (UTF-8 high-byte
-// `%[89A-F][0-9A-F]+`). ASCII percent encodings (%40 '@', %2F '/',
-// %20 ' ', etc.) are PRESERVED as literal characters because the
-// plugin convention stores them literally on disk
-// (data/plugins/%40<scope>%2F<name>/...). Decoding %2F to '/' here
-// would collapse the single plugin-scope directory name into two
-// separate segments and break server-side file resolution.
+// Per-segment decode. Segments containing `%2F` are kept opaque
+// because the plugin convention stores npm-scoped packages as a
+// single literal on-disk directory (data/plugins/%40<scope>%2F<name>/).
+// All other segments are decoded normally so multibyte filenames,
+// `%20` spaces, and encoded `%2E%2E` round-trip through the file
+// API correctly (the latter then caught by `normalizePath`).
 function safeDecode(str: string): string {
-  return str.replace(/(?:%[89A-Fa-f][0-9A-Fa-f])+/g, (match) => {
-    try {
-      return decodeURIComponent(match);
-    } catch {
-      return match;
-    }
-  });
+  return str.split("/").map(decodeSegment).join("/");
+}
+
+function decodeSegment(seg: string): string {
+  if (/%2[fF]/.test(seg)) return seg;
+  try {
+    return decodeURIComponent(seg);
+  } catch {
+    return seg;
+  }
 }
 ```
 

--- a/src/utils/path/workspaceLinkRouter.ts
+++ b/src/utils/path/workspaceLinkRouter.ts
@@ -33,8 +33,15 @@ export function classifyWorkspacePath(href: string): WorkspaceLinkTarget | null 
   if (cleaned.length === 0) return null;
 
   // marked.parse() percent-encodes multibyte chars in <a href> output.
-  // Decode once so the downstream router doesn't double-encode (turning
-  // `%E4%BD%9C` into `%25E4%25BD%259C`, breaking the file API lookup).
+  // Decode only the multibyte (high-byte) sequences so the downstream
+  // router doesn't double-encode (turning `%E4%BD%9C` into
+  // `%25E4%25BD%259C`, breaking the file API lookup). ASCII percent
+  // encodings (%40 '@', %2F '/', %20 ' ', etc.) are preserved as
+  // literal characters because the plugin convention stores them
+  // literally on disk (data/plugins/%40<scope>%2F<name>/...). Decoding
+  // %2F to '/' here would collapse a single plugin-scope directory
+  // name into two segments and break server-side file resolution
+  // (#1473).
   const decoded = safeDecode(cleaned);
 
   // Normalize path (collapse ./ and ../, reject root-escape)
@@ -78,15 +85,21 @@ export function resolveWikiHref(href: string, baseDir: string): string {
   return href;
 }
 
-// Decode a percent-encoded path once. Falls back to the raw input on
-// malformed sequences (truncated UTF-8, lone `%`) so a bad link still
-// routes — Files view will surface its own 404 if the path is unreachable.
+// Decode only multibyte (high-byte UTF-8) percent sequences. ASCII
+// percent encodings (%40 / %2F / %20 / %2E / etc.) are preserved as
+// literal characters so the plugin naming convention
+// (data/plugins/%40<scope>%2F<name>/...) survives the click → router →
+// file API round-trip. Malformed sequences (truncated UTF-8, lone
+// `%`) fall back to the raw bytes so a bad link still routes — Files
+// view surfaces its own 404 if the path is unreachable.
 function safeDecode(str: string): string {
-  try {
-    return decodeURIComponent(str);
-  } catch {
-    return str;
-  }
+  return str.replace(/(?:%[89A-Fa-f][0-9A-Fa-f])+/g, (match) => {
+    try {
+      return decodeURIComponent(match);
+    } catch {
+      return match;
+    }
+  });
 }
 
 function stripFragmentAndQuery(str: string): string {

--- a/src/utils/path/workspaceLinkRouter.ts
+++ b/src/utils/path/workspaceLinkRouter.ts
@@ -32,16 +32,15 @@ export function classifyWorkspacePath(href: string): WorkspaceLinkTarget | null 
   const cleaned = stripFragmentAndQuery(href);
   if (cleaned.length === 0) return null;
 
-  // marked.parse() percent-encodes multibyte chars in <a href> output.
-  // Decode only the multibyte (high-byte) sequences so the downstream
-  // router doesn't double-encode (turning `%E4%BD%9C` into
-  // `%25E4%25BD%259C`, breaking the file API lookup). ASCII percent
-  // encodings (%40 '@', %2F '/', %20 ' ', etc.) are preserved as
-  // literal characters because the plugin convention stores them
-  // literally on disk (data/plugins/%40<scope>%2F<name>/...). Decoding
-  // %2F to '/' here would collapse a single plugin-scope directory
-  // name into two segments and break server-side file resolution
-  // (#1473).
+  // marked.parse() percent-encodes multibyte chars and spaces in
+  // <a href> output. `safeDecode` decodes those per segment so the
+  // downstream router doesn't double-encode (turning `%E4%BD%9C` into
+  // `%25E4%25BD%259C`, breaking the file API lookup). Segments that
+  // contain `%2F` are preserved opaque because the plugin convention
+  // stores npm-scoped packages as one literal on-disk directory
+  // (data/plugins/%40<scope>%2F<name>/...) — decoding `%2F` to `/`
+  // there would split that one segment into two and break server
+  // file resolution (#1473).
   const decoded = safeDecode(cleaned);
 
   // Normalize path (collapse ./ and ../, reject root-escape)
@@ -85,21 +84,33 @@ export function resolveWikiHref(href: string, baseDir: string): string {
   return href;
 }
 
-// Decode only multibyte (high-byte UTF-8) percent sequences. ASCII
-// percent encodings (%40 / %2F / %20 / %2E / etc.) are preserved as
-// literal characters so the plugin naming convention
-// (data/plugins/%40<scope>%2F<name>/...) survives the click → router →
-// file API round-trip. Malformed sequences (truncated UTF-8, lone
+// Decode a percent-encoded path *per segment*. Each `/`-separated
+// segment is decoded independently — except segments that contain
+// `%2F`, which are kept opaque because the plugin naming convention
+// stores npm-scoped packages as a SINGLE on-disk directory whose
+// literal name carries `%40` and `%2F` characters
+// (data/plugins/%40<scope>%2F<name>/...). Decoding `%2F` to `/` there
+// would collapse one directory into two segments and break server
+// file resolution (#1473).
+//
+// Everything else round-trips via `decodeURIComponent`: multibyte
+// (UTF-8) sequences emitted by marked.parse, transport-encoded spaces
+// (`%20`), and encoded `..` (`%2E%2E`) — the last one decodes to the
+// literal `..` token that `normalizePath` then catches as a
+// workspace-root escape. Malformed sequences (truncated UTF-8, lone
 // `%`) fall back to the raw bytes so a bad link still routes — Files
 // view surfaces its own 404 if the path is unreachable.
 function safeDecode(str: string): string {
-  return str.replace(/(?:%[89A-Fa-f][0-9A-Fa-f])+/g, (match) => {
-    try {
-      return decodeURIComponent(match);
-    } catch {
-      return match;
-    }
-  });
+  return str.split("/").map(decodeSegment).join("/");
+}
+
+function decodeSegment(seg: string): string {
+  if (/%2[fF]/.test(seg)) return seg;
+  try {
+    return decodeURIComponent(seg);
+  } catch {
+    return seg;
+  }
 }
 
 function stripFragmentAndQuery(str: string): string {

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -178,13 +178,14 @@ describe("classifyWorkspacePath", () => {
     // structural tokens (`%2E%2E` → `..`) get reinterpreted as path
     // structure and the same `normalizePath` root-escape gate applies.
 
-    it("decoded %2F splits into path segments (non-plugin synthetic input)", () => {
+    it("preserves %2F in any segment (opacity rule applies universally)", () => {
       // Synthetic case: a hand-encoded `foo%2Fbar.md` happens to
-      // satisfy the plugin-scope opacity rule (segment contains
-      // `%2F`), so it now stays opaque rather than collapsing into
-      // two segments. marked.parse() never emits this shape for
-      // legitimate workspace links, so the behaviour is captured
-      // here only to make the contract explicit.
+      // satisfy the opacity rule (segment contains `%2F`), so it
+      // stays opaque rather than collapsing into two segments.
+      // marked.parse() never emits this shape for legitimate
+      // workspace links, so the behaviour is captured here only to
+      // make the contract explicit — opacity is segment-local and
+      // does not care whether the path is under `data/plugins/`.
       const result = classifyWorkspacePath("data/some/foo%2Fbar.md");
       assert.deepEqual(result, { kind: "file", path: "data/some/foo%2Fbar.md" });
     });

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -180,15 +180,43 @@ describe("classifyWorkspacePath", () => {
       });
     });
 
-    it("rejects literal `..` traversal that escapes workspace root", () => {
-      // Literal `..` (not %2E%2E) is still detected by normalizePath
-      // and rejected — the traversal protection that mattered (raw
-      // `..` segments) is unchanged.
+    it("treats encoded %2E%2E root-escape as an opaque file path (not a traversal)", () => {
+      // Encoded %2E%2E never reaches the `..` collapse, so an
+      // attacker-crafted "%2E%2E/%2E%2E/etc/passwd" classifies as a
+      // file path containing literal '%' '2' 'E' bytes rather than
+      // resolving up two levels. Literal `..` traversal is still
+      // rejected by normalizePath — that case is pinned in the
+      // "returns null for paths that escape the workspace root" test
+      // below. The server's resolveWithinRoot is the authoritative
+      // defense against any encoded form that does reach the file API.
       const result = classifyWorkspacePath("%2E%2E/%2E%2E/etc/passwd");
       assert.deepEqual(result, {
         kind: "file",
         path: "%2E%2E/%2E%2E/etc/passwd",
       });
+    });
+
+    it("preserves lowercase ASCII percent encodings as literal (%2f / %2e%2e)", () => {
+      // The regex used for decoding is case-insensitive over high-byte
+      // sequences only. Lowercase ASCII encodings must be preserved
+      // verbatim, just like their uppercase counterparts.
+      const result = classifyWorkspacePath("data/plugins/%40mulmoclaude%2fworklog/%2e%2e/file.md");
+      assert.deepEqual(result, {
+        kind: "file",
+        path: "data/plugins/%40mulmoclaude%2fworklog/%2e%2e/file.md",
+      });
+    });
+
+    it("classifies a wiki filename containing literal %2F as a (synthetic) wiki match", () => {
+      // ASCII %2F is preserved as a literal segment character, so the
+      // slug capture `([^/]+)` happily eats `foo%2Fbar`. This is a
+      // synthetic shape — marked.parse never emits this for real wiki
+      // links, and wiki page filenames don't carry '/' in practice —
+      // so we accept the match and let the wiki view 404 if the page
+      // does not exist on disk. Pinning the current behaviour so any
+      // future "reject %2F in slugs" tightening is an explicit decision.
+      const result = classifyWorkspacePath("data/wiki/pages/foo%2Fbar.md");
+      assert.deepEqual(result, { kind: "wiki", slug: "foo%2Fbar" });
     });
 
     it("decodes multibyte while preserving ASCII percent literals in the same path (#1473)", () => {

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -106,9 +106,15 @@ describe("classifyWorkspacePath", () => {
       assert.deepEqual(result, { kind: "wiki", slug: "サンプル" });
     });
 
-    it("decodes percent-encoded space in filename", () => {
+    it("preserves ASCII percent-encoded space as literal (%20 stays as %20)", () => {
+      // ASCII percent encodings are preserved as literal characters so
+      // that the plugin naming convention (data/plugins/%40<scope>%2F<name>/)
+      // survives the click → router → file API round-trip (#1473).
+      // marked.parse() does not emit %20 for hrefs containing literal
+      // spaces, so this hand-encoded form is treated as an opaque file
+      // name token.
       const result = classifyWorkspacePath("data/some/my%20file.txt");
-      assert.deepEqual(result, { kind: "file", path: "data/some/my file.txt" });
+      assert.deepEqual(result, { kind: "file", path: "data/some/my%20file.txt" });
     });
 
     it("falls back to raw href when decode throws on malformed percent sequence", () => {
@@ -126,37 +132,75 @@ describe("classifyWorkspacePath", () => {
       assert.deepEqual(result, { kind: "file", path: raw });
     });
 
-    // Decoding before normalization means encoded structural tokens
-    // (`%2F` for `/`, `%2E%2E` for `..`) get reinterpreted as path
-    // structure rather than treated as literal filename bytes. The
-    // tests below pin that behaviour so a future "stop decoding"
-    // regression — or the inverse, decoding twice — is caught
-    // immediately. The same decode also runs through the
-    // normalizePath root-escape gate, so traversal attempts via
-    // encoded `..` still return null instead of broadening reach
-    // past the workspace root.
+    // ASCII percent encodings (%2F, %2E, %40, %20, %25, …) are
+    // preserved as literal characters so the plugin naming convention
+    // — which stores npm-scoped packages as single URL-encoded disk
+    // directories (data/plugins/%40<scope>%2F<name>/) — survives the
+    // click → router → file API round-trip. The tests below pin that
+    // semantics. Decoding is restricted to multibyte (UTF-8 high-byte)
+    // sequences emitted by marked.parse for non-ASCII characters.
+    //
+    // Traversal protection is still provided by normalizePath, which
+    // matches the literal `..` token. Encoded `%2E%2E` is now kept as
+    // an opaque filename token and never reaches the `..` collapse
+    // path — that narrows the attack surface (no encoded-traversal
+    // path possible) rather than widening it. The server's
+    // resolveWithinRoot adds a separate defense layer regardless.
 
-    it("decoded %2F splits into path segments (not a literal filename byte)", () => {
-      // After decode the href becomes "data/some/foo/bar.md" — the
-      // wiki regex rejects it (multi-segment under wiki/pages would
-      // not match `[^/]+`), but a generic file path is still routed.
+    it("preserves ASCII %2F as a literal segment character (plugin-scoped naming)", () => {
+      // Plugin convention: data/plugins/%40<scope>%2F<name>/ is a
+      // SINGLE directory whose name literally contains '%' '4' '0'
+      // '%' '2' 'F' characters — not two nested directories.
+      const result = classifyWorkspacePath("data/plugins/%40mulmoclaude%2Fworklog/committed/2026-05.jsonl");
+      assert.deepEqual(result, {
+        kind: "file",
+        path: "data/plugins/%40mulmoclaude%2Fworklog/committed/2026-05.jsonl",
+      });
+    });
+
+    it("preserves ASCII %2F as literal even for non-plugin hand-encoded inputs", () => {
+      // Behaviour change from the previous decode-everything implementation:
+      // a hand-encoded `foo%2Fbar.md` is now treated as a single literal
+      // filename token. marked.parse() never emits %2F for legitimate
+      // workspace links, so this only matters for synthetic inputs.
       const result = classifyWorkspacePath("data/some/foo%2Fbar.md");
-      assert.deepEqual(result, { kind: "file", path: "data/some/foo/bar.md" });
+      assert.deepEqual(result, { kind: "file", path: "data/some/foo%2Fbar.md" });
     });
 
-    it("decoded %2E%2E (..) is normalized away within workspace", () => {
-      // "data/wiki/pages/%2E%2E/sources/foo.md" → "data/wiki/pages/../sources/foo.md"
-      //   → normalizePath collapses to "data/wiki/sources/foo.md".
+    it("preserves ASCII %2E%2E as literal segment (encoded-traversal is inert)", () => {
+      // Previously %2E%2E was decoded to `..` and then collapsed by
+      // normalizePath. Now %2E%2E stays opaque, so the traversal never
+      // happens at this layer. resolveWithinRoot on the server side
+      // remains the authoritative defense if anyone ever tries to
+      // exploit this surface.
       const result = classifyWorkspacePath("data/wiki/pages/%2E%2E/sources/foo.md");
-      assert.deepEqual(result, { kind: "file", path: "data/wiki/sources/foo.md" });
+      assert.deepEqual(result, {
+        kind: "file",
+        path: "data/wiki/pages/%2E%2E/sources/foo.md",
+      });
     });
 
-    it("decoded %2E%2E that escapes workspace root still returns null", () => {
-      // "%2E%2E/%2E%2E/etc/passwd" → "../../etc/passwd" → normalizePath
-      // pops past root → null. Decoding does not widen the traversal
-      // surface beyond what a literal `..` href could already reach.
+    it("rejects literal `..` traversal that escapes workspace root", () => {
+      // Literal `..` (not %2E%2E) is still detected by normalizePath
+      // and rejected — the traversal protection that mattered (raw
+      // `..` segments) is unchanged.
       const result = classifyWorkspacePath("%2E%2E/%2E%2E/etc/passwd");
-      assert.equal(result, null);
+      assert.deepEqual(result, {
+        kind: "file",
+        path: "%2E%2E/%2E%2E/etc/passwd",
+      });
+    });
+
+    it("decodes multibyte while preserving ASCII percent literals in the same path (#1473)", () => {
+      // Plugin scope dir name stays opaque, but a Japanese filename
+      // inside it gets decoded to its multibyte form so the file API
+      // (which receives disk-literal multibyte names) resolves.
+      const encoded = "data/plugins/%40mulmoclaude%2Fworklog/%E3%83%A1%E3%83%A2.md";
+      const result = classifyWorkspacePath(encoded);
+      assert.deepEqual(result, {
+        kind: "file",
+        path: "data/plugins/%40mulmoclaude%2Fworklog/メモ.md",
+      });
     });
   });
 

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -106,15 +106,15 @@ describe("classifyWorkspacePath", () => {
       assert.deepEqual(result, { kind: "wiki", slug: "サンプル" });
     });
 
-    it("preserves ASCII percent-encoded space as literal (%20 stays as %20)", () => {
-      // ASCII percent encodings are preserved as literal characters so
-      // that the plugin naming convention (data/plugins/%40<scope>%2F<name>/)
-      // survives the click → router → file API round-trip (#1473).
-      // marked.parse() does not emit %20 for hrefs containing literal
-      // spaces, so this hand-encoded form is treated as an opaque file
-      // name token.
+    it("decodes percent-encoded space in filename", () => {
+      // marked.parse() encodes literal spaces in href as `%20`, and
+      // the on-disk filename carries the literal space. This must
+      // round-trip via decodeURIComponent so the file API receives
+      // the disk-canonical form. Segments containing `%2F` are the
+      // sole exception (plugin-scope opaqueness) — `%20` outside such
+      // a segment is ordinary URL transport encoding.
       const result = classifyWorkspacePath("data/some/my%20file.txt");
-      assert.deepEqual(result, { kind: "file", path: "data/some/my%20file.txt" });
+      assert.deepEqual(result, { kind: "file", path: "data/some/my file.txt" });
     });
 
     it("falls back to raw href when decode throws on malformed percent sequence", () => {
@@ -132,25 +132,17 @@ describe("classifyWorkspacePath", () => {
       assert.deepEqual(result, { kind: "file", path: raw });
     });
 
-    // ASCII percent encodings (%2F, %2E, %40, %20, %25, …) are
-    // preserved as literal characters so the plugin naming convention
-    // — which stores npm-scoped packages as single URL-encoded disk
-    // directories (data/plugins/%40<scope>%2F<name>/) — survives the
-    // click → router → file API round-trip. The tests below pin that
-    // semantics. Decoding is restricted to multibyte (UTF-8 high-byte)
-    // sequences emitted by marked.parse for non-ASCII characters.
-    //
-    // Traversal protection is still provided by normalizePath, which
-    // matches the literal `..` token. Encoded `%2E%2E` is now kept as
-    // an opaque filename token and never reaches the `..` collapse
-    // path — that narrows the attack surface (no encoded-traversal
-    // path possible) rather than widening it. The server's
-    // resolveWithinRoot adds a separate defense layer regardless.
+    // safeDecode runs per `/`-separated segment. Segments containing
+    // `%2F` are kept opaque (plugin-scope disk convention); every
+    // other segment is decoded via decodeURIComponent. The tests
+    // below pin both halves of that contract.
 
-    it("preserves ASCII %2F as a literal segment character (plugin-scoped naming)", () => {
+    it("preserves plugin-scoped %40<scope>%2F<name> as a single literal segment (#1473)", () => {
       // Plugin convention: data/plugins/%40<scope>%2F<name>/ is a
       // SINGLE directory whose name literally contains '%' '4' '0'
-      // '%' '2' 'F' characters — not two nested directories.
+      // '%' '2' 'F' characters — not two nested directories. The
+      // `%2F` in that segment is what marks it as a plugin-scope
+      // token so `safeDecode` leaves it opaque.
       const result = classifyWorkspacePath("data/plugins/%40mulmoclaude%2Fworklog/committed/2026-05.jsonl");
       assert.deepEqual(result, {
         kind: "file",
@@ -158,68 +150,17 @@ describe("classifyWorkspacePath", () => {
       });
     });
 
-    it("preserves ASCII %2F as literal even for non-plugin hand-encoded inputs", () => {
-      // Behaviour change from the previous decode-everything implementation:
-      // a hand-encoded `foo%2Fbar.md` is now treated as a single literal
-      // filename token. marked.parse() never emits %2F for legitimate
-      // workspace links, so this only matters for synthetic inputs.
-      const result = classifyWorkspacePath("data/some/foo%2Fbar.md");
-      assert.deepEqual(result, { kind: "file", path: "data/some/foo%2Fbar.md" });
-    });
-
-    it("preserves ASCII %2E%2E as literal segment (encoded-traversal is inert)", () => {
-      // Previously %2E%2E was decoded to `..` and then collapsed by
-      // normalizePath. Now %2E%2E stays opaque, so the traversal never
-      // happens at this layer. resolveWithinRoot on the server side
-      // remains the authoritative defense if anyone ever tries to
-      // exploit this surface.
-      const result = classifyWorkspacePath("data/wiki/pages/%2E%2E/sources/foo.md");
+    it("preserves lowercase %2f in a plugin-scope segment (case-insensitive opacity)", () => {
+      // The opacity check accepts %2F and %2f interchangeably so both
+      // capitalisations round-trip to the disk-canonical name.
+      const result = classifyWorkspacePath("data/plugins/%40mulmoclaude%2fworklog/file.md");
       assert.deepEqual(result, {
         kind: "file",
-        path: "data/wiki/pages/%2E%2E/sources/foo.md",
+        path: "data/plugins/%40mulmoclaude%2fworklog/file.md",
       });
     });
 
-    it("treats encoded %2E%2E root-escape as an opaque file path (not a traversal)", () => {
-      // Encoded %2E%2E never reaches the `..` collapse, so an
-      // attacker-crafted "%2E%2E/%2E%2E/etc/passwd" classifies as a
-      // file path containing literal '%' '2' 'E' bytes rather than
-      // resolving up two levels. Literal `..` traversal is still
-      // rejected by normalizePath — that case is pinned in the
-      // "returns null for paths that escape the workspace root" test
-      // below. The server's resolveWithinRoot is the authoritative
-      // defense against any encoded form that does reach the file API.
-      const result = classifyWorkspacePath("%2E%2E/%2E%2E/etc/passwd");
-      assert.deepEqual(result, {
-        kind: "file",
-        path: "%2E%2E/%2E%2E/etc/passwd",
-      });
-    });
-
-    it("preserves lowercase ASCII percent encodings as literal (%2f / %2e%2e)", () => {
-      // The regex used for decoding is case-insensitive over high-byte
-      // sequences only. Lowercase ASCII encodings must be preserved
-      // verbatim, just like their uppercase counterparts.
-      const result = classifyWorkspacePath("data/plugins/%40mulmoclaude%2fworklog/%2e%2e/file.md");
-      assert.deepEqual(result, {
-        kind: "file",
-        path: "data/plugins/%40mulmoclaude%2fworklog/%2e%2e/file.md",
-      });
-    });
-
-    it("classifies a wiki filename containing literal %2F as a (synthetic) wiki match", () => {
-      // ASCII %2F is preserved as a literal segment character, so the
-      // slug capture `([^/]+)` happily eats `foo%2Fbar`. This is a
-      // synthetic shape — marked.parse never emits this for real wiki
-      // links, and wiki page filenames don't carry '/' in practice —
-      // so we accept the match and let the wiki view 404 if the page
-      // does not exist on disk. Pinning the current behaviour so any
-      // future "reject %2F in slugs" tightening is an explicit decision.
-      const result = classifyWorkspacePath("data/wiki/pages/foo%2Fbar.md");
-      assert.deepEqual(result, { kind: "wiki", slug: "foo%2Fbar" });
-    });
-
-    it("decodes multibyte while preserving ASCII percent literals in the same path (#1473)", () => {
+    it("decodes multibyte while preserving the plugin-scope segment opaque (#1473)", () => {
       // Plugin scope dir name stays opaque, but a Japanese filename
       // inside it gets decoded to its multibyte form so the file API
       // (which receives disk-literal multibyte names) resolves.
@@ -229,6 +170,40 @@ describe("classifyWorkspacePath", () => {
         kind: "file",
         path: "data/plugins/%40mulmoclaude%2Fworklog/メモ.md",
       });
+    });
+
+    // The tests below pin the original behaviour for non-plugin
+    // segments — `safeDecode` falls back to per-segment
+    // `decodeURIComponent` when no `%2F` is present, so encoded
+    // structural tokens (`%2E%2E` → `..`) get reinterpreted as path
+    // structure and the same `normalizePath` root-escape gate applies.
+
+    it("decoded %2F splits into path segments (non-plugin synthetic input)", () => {
+      // Synthetic case: a hand-encoded `foo%2Fbar.md` happens to
+      // satisfy the plugin-scope opacity rule (segment contains
+      // `%2F`), so it now stays opaque rather than collapsing into
+      // two segments. marked.parse() never emits this shape for
+      // legitimate workspace links, so the behaviour is captured
+      // here only to make the contract explicit.
+      const result = classifyWorkspacePath("data/some/foo%2Fbar.md");
+      assert.deepEqual(result, { kind: "file", path: "data/some/foo%2Fbar.md" });
+    });
+
+    it("decoded %2E%2E (..) is normalized away within workspace", () => {
+      // "data/wiki/pages/%2E%2E/sources/foo.md" → per-segment decode
+      // turns the %2E%2E segment into ".." → normalizePath collapses
+      // to "data/wiki/sources/foo.md".
+      const result = classifyWorkspacePath("data/wiki/pages/%2E%2E/sources/foo.md");
+      assert.deepEqual(result, { kind: "file", path: "data/wiki/sources/foo.md" });
+    });
+
+    it("decoded %2E%2E that escapes workspace root still returns null", () => {
+      // "%2E%2E/%2E%2E/etc/passwd" → per-segment decode → "../../etc/passwd"
+      //   → normalizePath pops past root → null. Encoded `..` does
+      // not widen the traversal surface beyond what a literal `..`
+      // href could already reach.
+      const result = classifyWorkspacePath("%2E%2E/%2E%2E/etc/passwd");
+      assert.equal(result, null);
     });
   });
 


### PR DESCRIPTION
## Summary

- AI が出力するチャットメッセージ内のファイルリンクのうち、プラグインスコープのディレクトリ (`data/plugins/%40<scope>%2F<name>/...`) を指すものをクリックすると Files ビューで `File not found` になる不具合を修正する
- `src/utils/path/workspaceLinkRouter.ts` の `safeDecode` がパス全体を `decodeURIComponent` していたため `%40` `%2F` が `@` `/` に化け、本来 1 セグメントだった disk 上の literal なディレクトリ名がパス区切りに分裂してサーバ解決が失敗していた
- multibyte (UTF-8 高位バイト) percent sequence のみ decode し、ASCII percent encoding (`%40` / `%2F` / `%20` / `%2E` 等) は literal として保持する形に変更

## Items to Confirm / Review

AI 生成の PR なので、特にレビュアーに確認していただきたい論点:

- **End-to-end pipeline 整合性**: classifyWorkspacePath が disk-canonical 形を返すように変えたことで、`src/composables/useFileSelection.ts:42` の `readPathMatch().join("/")` 経由でも segment 境界が保たれることを実コードで確認しています。実装方針検討時には設計レビューを行い、当初の「`pathSegments: string[]` を pipeline 全体に伝搬」案だと FilesView → API 段を直し漏れることが判明したため、本 PR の disk-canonical アプローチに切り替えています（issue #1473 のコメント参照）
- **Path traversal の防御境界**: literal `..` segment は引き続き `normalizePath` で root-escape をブロック。encoded `%2E%2E` は ASCII literal 化により本レイヤでは `..` 解釈に到達しなくなる（攻撃面は狭まる方向の挙動変化）。サーバ側 `resolveWithinRoot` が最終防御層として残ります
- **既存の workaround との関係**: `src/utils/filesPreview/todoPreview.ts:10-19` の「encoded 形と decoded 形の両方でマッチ」させる比較は同根の問題を回避するためのコードです。本 PR では touch せず、別途整理予定
- **Wiki 正規表現の挙動**: synthetic に `data/wiki/pages/foo%2Fbar.md` 形のリンクを与えると wiki match します（`%2F` が slug 中の literal 文字として扱われる）。実利用では marked がこの形を出さないので無害ですが、明示的に reject したい場合は別途決定が必要。本 PR では現挙動を test で pin
- **テストの挙動反転**: 旧来 `%2F` を path separator として展開する、`%20` を space に decode するという挙動を明示的に pin していた 2 つのテストを新セマンティクスに反転しています

## User Prompt

ユーザーから依頼を受けた一連の作業:

1. プラグインスコープ配下のファイル (`data/plugins/%40mulmoclaude%2Fworklog/committed/2026-05.jsonl`) へのチャット内リンクをクリックすると `File not found` になる現象の調査
2. 原因分析、影響範囲、修正アプローチの検討
3. 設計フェーズで `/codex-cross-review` を使った方針レビュー（初回案 `pathSegments: string[]` 化が pipeline 全体に波及するため、より局所的な disk-canonical 形アプローチに変更）
4. 「`@` を削除する」「`/` を別文字に置換する」「`/` をディレクトリ階層化する」など命名規約変更案も検討したが、organization 名と unscoped パッケージ名の衝突リスクから棄却。命名規約は現状維持
5. Approach A（`safeDecode` を multibyte のみ decode に変更）で実装
6. worktree で実装 → commit → `/codex-cross-review` で 2 iteration（CHANGES REQUESTED → LGTM 収束）

## 背景・原因分析

プラグインデータディレクトリは URL エンコードした npm スコープ名を **1 ディレクトリ**として平坦化する命名規約を採用している (`server/workspace/paths.ts:100` にコメントで明文化):

```
data/plugins/%40mulmoclaude%2F<plugin-name>/
```

`%40mulmoclaude%2Fworklog` は「`%` `4` `0` ... の文字を literal に持つ 1 ディレクトリ名」であり、`@mulmoclaude/worklog` という 2 階層構造ではない。

チャットリンクのクリックは以下のパイプラインを通る:

1. `src/plugins/textResponse/View.vue:242` — `<a href>` クリックを intercept
2. `src/utils/path/workspaceLinkRouter.ts:38` — `classifyWorkspacePath()` が `safeDecode(href)` でパス全体を `decodeURIComponent`
3. `src/App.vue:1044` — `target.path.split("/")` で segments 配列化して vue-router に push
4. `src/composables/useFileSelection.ts:42` — `readPathMatch()` が vue-router のセグメント配列を `.join("/")` で再連結
5. `src/components/FilesView.vue:184` — そのパス文字列を `apiGet(API_ROUTES.files.content, { path })` で `/api/files/content` に送信
6. サーバはクエリ `path` を literal disk path として解決

ステップ 2 で `%40` → `@`、`%2F` → `/` に decode された結果、本来 1 セグメントだった `%40mulmoclaude%2Fworklog` が 2 セグメントに分裂。ステップ 4 で `/` 再連結するため、サーバには disk 上に存在しないパスが届く。

`safeDecode` の `decodeURIComponent` 自体は、marked が href 出力時に multibyte 文字（日本語ファイル名など）を percent-encode することへの対処として導入された経緯がある (`plans/done/fix-workspace-link-double-encoding.md` 参照)。multibyte 対応の decode が、後発のプラグイン命名規約と衝突している格好。

詳細は issue #1473 を参照。

## 実装内容

### 1. `src/utils/path/workspaceLinkRouter.ts` の `safeDecode` 改修

```ts
function safeDecode(str: string): string {
  return str.replace(/(?:%[89A-Fa-f][0-9A-Fa-f])+/g, (match) => {
    try {
      return decodeURIComponent(match);
    } catch {
      return match;
    }
  });
}
```

- 正規表現 `%[89A-Fa-f][0-9A-Fa-f]` は UTF-8 lead byte (`%80`〜`%FF`) を起点とする percent sequence にのみマッチ
- `%40` (`@`) や `%2F` (`/`) や `%20` (space) や `%2E` (`.`) などの ASCII percent encoding は literal として保持
- 不正バイト列に対しては従来通り raw fallback

### 2. テスト更新

- 旧来の pin テスト 2 件 (`%2F` を path separator として展開 / `%20` を space に decode) を新セマンティクスに反転
- 新規 pin テストを追加:
  - プラグインスコープ命名規約の round-trip
  - lowercase ASCII percent (`%2f` / `%2e%2e`) の literal 保持
  - encoded `%2E%2E` traversal 試行が opaque file path として分類されることの明示
  - multibyte + ASCII literal 混在 (`data/plugins/%40<scope>%2F<name>/<multibyte>.md`)
  - synthetic な wiki slug 内 `%2F` の挙動 pin

### 3. plan ファイル追加

`plans/fix-plugin-scoped-link-decode.md`

## レビュー履歴 (codex-cross-review)

設計フェーズと実装後の 2 段階で `/codex-cross-review` を実施:

- **設計レビュー (commit 前)**: 初回案 (`WorkspaceLinkTarget.path: string` を `pathSegments: string[]` に変更し pipeline 全体を segments-aware にする) が、`useFileSelection.readPathMatch()` の `.join("/")` で segment 境界が失われる経路を直し漏れることを Codex が指摘。`todoPreview.ts:10-19` の both-form 比較 workaround の存在も含めて、より局所的な disk-canonical 形アプローチへ切り替え

- **実装後レビュー (commit 後)**: 2 iteration で収束
  - iteration 1: 3 件の指摘（テスト名と実挙動の食い違い、wiki 正規表現の synthetic match 挙動、lowercase ASCII percent のカバレッジ）→ commit 45165d82 で全件対応
  - iteration 2: **CODEX VERDICT: LGTM**

## 参照

- Issue: #1473
- Plan: `plans/fix-plugin-scoped-link-decode.md`
- 関連既存 workaround (本 PR では非変更): `src/utils/filesPreview/todoPreview.ts:10-19`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes workspace link routing so URL-encoded plugin-scoped paths and npm scope segments remain intact and don’t trigger unintended path traversal.

* **Behavior Changes**
  * Per-segment decoding now preserves ASCII percent-encodings (e.g., literal %2F segments) while still decoding multibyte UTF-8 sequences.

* **Tests**
  * Added and updated tests to verify round-trip preservation, mixed multibyte/ASCII cases, and traversal expectations.

* **Documentation**
  * Added a plan and verification checklist describing the decoding strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->