### PR TITLE
test(csrf): smoke env-bound requireSameOrigin export wiring (#1463)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -132,6 +132,14 @@ jobs:
     - name: Verify built hook bundles are up-to-date
       run: git diff --exit-code -- server/workspace/wiki-history/hook/snapshot.mjs server/build/dispatcher.mjs
     - run: yarn run test:coverage
+    # Subprocess-mode env-bound smoke for `requireSameOrigin` (#1463).
+    # The main `test:coverage` glob exercises the env-UNSET path; this
+    # step re-runs the same spec with `MULMOCLAUDE_TRUSTED_ORIGINS` set
+    # so the EXPORTED middleware is exercised against a listed LAN
+    # origin. Catches a typo like `requireSameOriginWith([])` at the
+    # export site that the in-process suite cannot see (Node's ESM
+    # resolver caches `env.ts` on first import).
+    - run: yarn run test:csrf-wiring
 
   # Single Yarn 4 cell — Yarn 1 stays the primary tool for the lint_test
   # matrix, but this guards against duplicate-workspace-name (Yarn 4 is

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "build:packages": "concurrently --kill-others-on-fail \"yarn workspace @mulmobridge/protocol run build\" \"yarn workspace @receptron/task-scheduler run build\" && concurrently --kill-others-on-fail \"yarn workspace @mulmobridge/client run build\" \"yarn workspace @mulmobridge/chat-service run build\" \"yarn workspace @mulmobridge/mock-server run build\" && node scripts/build-workspaces.mjs packages/bridges @mulmobridge && node scripts/build-workspaces.mjs packages/plugins @mulmoclaude --name-suffix=-plugin",
     "build": "yarn build:packages && yarn build:hooks && vite build",
     "test": "tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts && yarn workspaces run test",
+    "test:csrf-wiring": "cross-env MULMOCLAUDE_TRUSTED_ORIGINS=http://192.168.1.42:5173 tsx --test test/server/test_csrfGuard_env_wiring.ts",
     "ensure:playwright-browsers": "playwright install chromium webkit",
     "test:e2e": "yarn ensure:playwright-browsers && playwright test --config e2e/playwright.config.ts",
     "test:e2e:live": "yarn ensure:playwright-browsers && playwright test --config e2e-live/playwright.config.ts",

--- a/plans/test-csrf-env-wiring-1463.md
+++ b/plans/test-csrf-env-wiring-1463.md
@@ -1,0 +1,74 @@
+# test: env-bound `requireSameOrigin` wiring smoke (#1463)
+
+## 背景
+
+PR #1458 で CSRF guard に opt-in trusted-origin allowlist を追加。
+[`server/api/csrfGuard.ts`](../server/api/csrfGuard.ts) 末尾の以下の export 行が wiring:
+
+```ts
+export const requireSameOrigin = requireSameOriginWith(env.trustedOrigins);
+```
+
+既存テスト [`test/server/test_csrfGuard.ts`](../test/server/test_csrfGuard.ts) の "env-binding integration" describe は、`server/system/env.ts` を fresh import → `requireSameOriginWith(envMod.env.trustedOrigins)` を **手動 recompose** している。これでは `env-parser + factory` の合成は検証できるが、`csrfGuard.ts` の export 行で
+
+```ts
+export const requireSameOrigin = requireSameOriginWith([]);  // ← typo
+// or
+export const requireSameOrigin = requireSameOriginWith(env.sandboxMountConfigs);  // ← wrong field
+```
+
+のような typo が混入しても fail しない。CodeRabbit が PR #1458 で指摘した通り。
+
+## 方針
+
+Issue #1463 の **案 A**（別 spec ファイル + 専用 yarn script）を採用。
+
+ESM resolver は `import { env } from "../system/env.js"` を un-queried URL でキャッシュするため、同一プロセス内で `csrfGuard.ts` を fresh re-import しても初回 env snapshot に張り付く。subprocess で別プロセスから fresh load するのが唯一確実な方法。
+
+## 実装
+
+### 1. 新規 spec ファイル: `test/server/test_csrfGuard_env_wiring.ts`
+
+- `import { requireSameOrigin } from "../../server/api/csrfGuard.js"` だけ（factory は import しない）
+- `process.env.MULMOCLAUDE_TRUSTED_ORIGINS` の状態で test の登録を分岐:
+  - **set モード** (trusted origin が含まれる): listed LAN origin への POST が `next()` を呼ぶこと、非 listed LAN origin が 403 になることを検証
+  - **unset モード** (default): LAN origin への POST が 403 になる (localhost-only fallback) ことを検証
+- 共通: `http://localhost:5173` への POST は常に通る (sanity)
+
+### 2. `package.json` に dedicated script を追加
+
+```json
+"test:csrf-wiring": "cross-env MULMOCLAUDE_TRUSTED_ORIGINS=http://192.168.1.42:5173 tsx --test test/server/test_csrfGuard_env_wiring.ts"
+```
+
+`cross-env` 経由なので Windows でも動く (CI matrix に Windows あり)。
+
+### 3. CI 連携
+
+`.github/workflows/pull_request.yaml` の `lint_test` job に step を追加:
+
+```yaml
+- run: yarn run test:csrf-wiring
+```
+
+`yarn run test:coverage` の後に配置。env-unset の variant は既存の glob `./test/*/test_*.ts` が拾うので、新規 step は env-set variant を担当。
+
+## 何をテストして何をしないか
+
+- ✅ `csrfGuard.ts` の export 行が正しい env field (`env.trustedOrigins`) と factory を wiring していること
+- ✅ env unset 時の fallback (localhost-only) が壊れていないこと
+- ❌ env parser 自体の挙動 (CSV split, null 拒否) — `test_csrfGuard.ts` の既存 suite 担当
+- ❌ middleware の純粋ロジック (Origin parse, allowlist match) — `test_csrfGuard.ts` の既存 suite 担当
+- ❌ 他の env-bound module への横展開 — 必要になったら別 issue
+
+## 受け入れ条件 (Issue #1463)
+
+- [x] env を set した subprocess / spawned context で csrfGuard.ts を fresh import し、`requireSameOrigin` が当該 LAN Origin の POST を 200 で通すことを検証する test がある
+- [x] 同じ仕組みで env unset 時に LAN Origin は 403 になることも検証
+- [x] CI で実行され、export 文 typo (`requireSameOriginWith([])` 等) が必ず fail を出す
+
+## 影響範囲
+
+- 追加: `test/server/test_csrfGuard_env_wiring.ts`, `plans/test-csrf-env-wiring-1463.md`
+- 修正: `package.json` (`scripts.test:csrf-wiring` を追加), `.github/workflows/pull_request.yaml` (CI step を追加)
+- production code (`server/api/csrfGuard.ts`, `server/system/env.ts`) は触らない

--- a/plans/test-csrf-env-wiring-1463.md
+++ b/plans/test-csrf-env-wiring-1463.md
@@ -69,6 +69,12 @@ ESM resolver は `import { env } from "../system/env.js"` を un-queried URL で
 
 ## 影響範囲
 
-- 追加: `test/server/test_csrfGuard_env_wiring.ts`, `plans/test-csrf-env-wiring-1463.md`
-- 修正: `package.json` (`scripts.test:csrf-wiring` を追加), `.github/workflows/pull_request.yaml` (CI step を追加)
+- 追加:
+  - `test/server/test_csrfGuard_env_wiring.ts` — env-bound wiring smoke spec
+  - `test/server/helpers/fakeExpressMiddleware.ts` — shared fake Express helpers (`FakeReq` / `FakeRes` / `makeReq` / `makeReqWithRawOrigin` / `makeRes`)、既存 spec との duplicate を解消するため抽出
+  - `plans/test-csrf-env-wiring-1463.md`
+- 修正:
+  - `package.json` (`scripts.test:csrf-wiring` を追加)
+  - `.github/workflows/pull_request.yaml` (lint_test job に CI step を追加)
+  - `test/server/test_csrfGuard.ts` — 上記 helper module を import するように refactor。仕様変更なし、net -47 lines
 - production code (`server/api/csrfGuard.ts`, `server/system/env.ts`) は触らない

--- a/test/server/helpers/fakeExpressMiddleware.ts
+++ b/test/server/helpers/fakeExpressMiddleware.ts
@@ -1,0 +1,58 @@
+// Minimal fake Request / Response factories for unit-testing Express
+// middleware without pulling in supertest.
+//
+// The `headers` value type is intentionally widened to `unknown` so
+// tests can simulate header-smuggling-style malformed values (e.g. an
+// array Origin) even though Express's runtime type is
+// `string | string[]`. The middleware-under-test only touches
+// `method`, `headers`, `status`, `json`, so casting through `unknown`
+// at the call site is safe.
+//
+// Used by:
+//   - test/server/test_csrfGuard.ts (factory + env-binding suite)
+//   - test/server/test_csrfGuard_env_wiring.ts (export-site wiring smoke, #1463)
+
+export interface FakeReq {
+  method: string;
+  headers: Record<string, unknown>;
+}
+
+export interface FakeRes {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => FakeRes;
+  json: (payload: unknown) => FakeRes;
+}
+
+export function makeReq(method: string, origin?: string): FakeReq {
+  return {
+    method,
+    headers: origin === undefined ? {} : { origin },
+  };
+}
+
+// Raw-Origin variant: lets a test inject an Array / non-string Origin
+// value to exercise the header-smuggling rejection path. Required
+// because `makeReq`'s `origin` parameter is typed `string | undefined`.
+export function makeReqWithRawOrigin(method: string, rawOrigin: unknown): FakeReq {
+  return {
+    method,
+    headers: { origin: rawOrigin },
+  };
+}
+
+export function makeRes(): FakeRes {
+  const res: FakeRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+}

--- a/test/server/test_csrfGuard.ts
+++ b/test/server/test_csrfGuard.ts
@@ -10,6 +10,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { Request, Response, NextFunction } from "express";
 import { isAllowedOrigin, isLocalhostOrigin, isTrustedOrigin, requireSameOrigin, requireSameOriginWith } from "../../server/api/csrfGuard.js";
+import { type FakeReq, type FakeRes, makeReq, makeReqWithRawOrigin, makeRes } from "./helpers/fakeExpressMiddleware.js";
 
 // --- isLocalhostOrigin: the pure check --------------------------
 
@@ -120,46 +121,6 @@ describe("isLocalhostOrigin — rejects everything else", () => {
 });
 
 // --- requireSameOrigin: Express middleware behaviour ------------
-
-// Minimal fake Request/Response/NextFunction for middleware
-// testing — avoids pulling in supertest. The `headers` value type
-// is intentionally widened to `unknown` so tests can simulate
-// header-smuggling-style malformed values (e.g. an array Origin)
-// even though Express's runtime type is `string | string[]`.
-interface FakeReq {
-  method: string;
-  headers: Record<string, unknown>;
-}
-
-interface FakeRes {
-  statusCode: number;
-  body: unknown;
-  status: (code: number) => FakeRes;
-  json: (payload: unknown) => FakeRes;
-}
-
-function makeReq(method: string, origin?: string): FakeReq {
-  return {
-    method,
-    headers: origin === undefined ? {} : { origin },
-  };
-}
-
-function makeRes(): FakeRes {
-  const res: FakeRes = {
-    statusCode: 200,
-    body: undefined,
-    status(code) {
-      this.statusCode = code;
-      return this;
-    },
-    json(payload) {
-      this.body = payload;
-      return this;
-    },
-  };
-  return res;
-}
 
 // Baseline middleware fixture: a `requireSameOriginWith([])` instance
 // rather than the env-bound `requireSameOrigin` export. The baseline
@@ -465,13 +426,6 @@ describe("requireSameOriginWith — trusted-origins allowlist wiring", () => {
 // guard treats those as present-but-untrustworthy: the localhost-
 // binding trust argument only covers the genuine *missing*-Origin
 // path, not multi-valued / non-string values.
-
-function makeReqWithRawOrigin(method: string, rawOrigin: unknown): FakeReq {
-  return {
-    method,
-    headers: { origin: rawOrigin },
-  };
-}
 
 describe("requireSameOriginWith — malformed Origin (non-string / array)", () => {
   const trusted = ["http://192.168.1.42:5173"] as const;

--- a/test/server/test_csrfGuard_env_wiring.ts
+++ b/test/server/test_csrfGuard_env_wiring.ts
@@ -29,6 +29,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { Request, Response, NextFunction } from "express";
 import { requireSameOrigin } from "../../server/api/csrfGuard.js";
+import { makeReq, makeRes } from "./helpers/fakeExpressMiddleware.js";
 
 const TRUSTED_ORIGINS_ENV_KEY = "MULMOCLAUDE_TRUSTED_ORIGINS";
 const TRUSTED_ORIGIN = "http://192.168.1.42:5173";
@@ -44,29 +45,6 @@ function envHas(value: string): boolean {
     .includes(value);
 }
 
-interface FakeRes {
-  statusCode: number;
-  body: unknown;
-  status: (code: number) => FakeRes;
-  json: (payload: unknown) => FakeRes;
-}
-
-function makeRes(): FakeRes {
-  const res: FakeRes = {
-    statusCode: 200,
-    body: undefined,
-    status(code) {
-      this.statusCode = code;
-      return this;
-    },
-    json(payload) {
-      this.body = payload;
-      return this;
-    },
-  };
-  return res;
-}
-
 interface MiddlewareCallResult {
   nextCalled: boolean;
   statusCode: number;
@@ -78,8 +56,7 @@ function callMiddleware(method: string, origin: string): MiddlewareCallResult {
     nextCalled = true;
   };
   const res = makeRes();
-  const req = { method, headers: { origin } } as unknown as Request;
-  requireSameOrigin(req, res as unknown as Response, next);
+  requireSameOrigin(makeReq(method, origin) as unknown as Request, res as unknown as Response, next);
   return { nextCalled, statusCode: res.statusCode };
 }
 

--- a/test/server/test_csrfGuard_env_wiring.ts
+++ b/test/server/test_csrfGuard_env_wiring.ts
@@ -1,0 +1,126 @@
+// Env-bound wiring smoke for the exported `requireSameOrigin`.
+// Issue #1463 — companion to test/server/test_csrfGuard.ts.
+//
+// Why a separate file: the existing "env-binding integration" suite
+// in test_csrfGuard.ts dynamically re-imports server/system/env.ts and
+// **manually recomposes** the middleware via
+// `requireSameOriginWith(envMod.env.trustedOrigins)`. That proves the
+// env parser + factory still compose, but it cannot catch a typo at
+// the actual export site, e.g.
+//
+//     export const requireSameOrigin = requireSameOriginWith([]);
+//     export const requireSameOrigin = requireSameOriginWith(env.sandboxMountConfigs);
+//
+// Node's ESM resolver caches `import { env } from "../system/env.js"`
+// by un-queried URL, so re-importing csrfGuard.ts inside the same
+// process always captures the original env snapshot. The only
+// reliable way to verify the export wiring is to run a fresh process
+// with `MULMOCLAUDE_TRUSTED_ORIGINS` set and import the ACTUAL
+// exported `requireSameOrigin` — that's what the dedicated
+// `yarn test:csrf-wiring` script does.
+//
+// The same file is also picked up by the main `./test/*/test_*.ts`
+// glob during `yarn test` (env unset), where it asserts the
+// localhost-only fallback. CI runs both invocations.
+//
+// Full design: plans/test-csrf-env-wiring-1463.md
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Request, Response, NextFunction } from "express";
+import { requireSameOrigin } from "../../server/api/csrfGuard.js";
+
+const TRUSTED_ORIGINS_ENV_KEY = "MULMOCLAUDE_TRUSTED_ORIGINS";
+const TRUSTED_ORIGIN = "http://192.168.1.42:5173";
+const FORBIDDEN_ORIGIN = "http://192.168.1.99:5173";
+const LOCALHOST_ORIGIN = "http://localhost:5173";
+
+function envHas(value: string): boolean {
+  const raw = process.env[TRUSTED_ORIGINS_ENV_KEY] ?? "";
+  return raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .includes(value);
+}
+
+interface FakeRes {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => FakeRes;
+  json: (payload: unknown) => FakeRes;
+}
+
+function makeRes(): FakeRes {
+  const res: FakeRes = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+}
+
+interface MiddlewareCallResult {
+  nextCalled: boolean;
+  statusCode: number;
+}
+
+function callMiddleware(method: string, origin: string): MiddlewareCallResult {
+  let nextCalled = false;
+  const next: NextFunction = () => {
+    nextCalled = true;
+  };
+  const res = makeRes();
+  const req = { method, headers: { origin } } as unknown as Request;
+  requireSameOrigin(req, res as unknown as Response, next);
+  return { nextCalled, statusCode: res.statusCode };
+}
+
+describe("requireSameOrigin (env-bound export) — wiring smoke (#1463)", () => {
+  // Sanity: localhost always passes — guards against an export-site
+  // wiring that accidentally rejects every origin (e.g. swapping
+  // SAFE_METHODS or inverting the allow check).
+  it("admits a POST from http://localhost regardless of env", () => {
+    const { nextCalled, statusCode } = callMiddleware("POST", LOCALHOST_ORIGIN);
+    assert.equal(nextCalled, true, "localhost POST must pass the env-bound middleware");
+    assert.equal(statusCode, 200);
+  });
+
+  if (envHas(TRUSTED_ORIGIN)) {
+    // Env-set mode: `yarn test:csrf-wiring` runs this branch.
+    //
+    // The typo catcher. If `csrfGuard.ts` wires
+    // `requireSameOriginWith([])` (or the wrong env field), the
+    // LAN origin is NOT in the bound allowlist and the POST is
+    // 403'd here — assertion fails, CI red.
+    it(`admits a POST from the listed LAN origin (${TRUSTED_ORIGIN})`, () => {
+      const { nextCalled, statusCode } = callMiddleware("POST", TRUSTED_ORIGIN);
+      assert.equal(nextCalled, true, "env-bound requireSameOrigin must admit the configured LAN origin — export-site typo?");
+      assert.equal(statusCode, 200);
+    });
+
+    it("rejects a POST from a non-listed LAN origin", () => {
+      const { nextCalled, statusCode } = callMiddleware("POST", FORBIDDEN_ORIGIN);
+      assert.equal(nextCalled, false, "non-listed LAN origin must still be blocked");
+      assert.equal(statusCode, 403);
+    });
+  } else {
+    // Env-unset mode (default `yarn test` invocation via the glob).
+    //
+    // Pins the fallback: with no allowlist, the env-bound middleware
+    // is localhost-only. Catches a regression where someone defaults
+    // `env.trustedOrigins` to something permissive at the env layer.
+    it(`rejects a POST from a LAN origin when ${TRUSTED_ORIGINS_ENV_KEY} is unset`, () => {
+      const { nextCalled, statusCode } = callMiddleware("POST", TRUSTED_ORIGIN);
+      assert.equal(nextCalled, false, "LAN origin must be blocked when the allowlist is unset");
+      assert.equal(statusCode, 403);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Issue #1463 対応: 環境変数 `MULMOCLAUDE_TRUSTED_ORIGINS` から構築される CSRF 信頼 origin リストが、Express が実際に `app.use` する middleware の export まで正しく届いていることを、別プロセスで起動した test で検証する仕組みを追加した。
- 対象範囲: `server/api/csrfGuard.ts` の末尾で env から middleware を組み立てている wiring 行のみ。middleware 本体のロジック、env parser、その他の production code には変更を加えない。
- 起点: 同一プロセス内では Node の ESM resolver が env 読み込み済 module を cache してしまい、env を後から差し替えて middleware を再生成する経路では検証できない。env を set した状態で起動する別プロセスで test を走らせるルートのみが、export 行で env 値を取り違える typo を確実に検出できる。

## Items to Confirm / Review

- **設計判断 (案 A 採用)**: Issue #1463 にあった案 A / 案 B / 案 C のうち、別 spec + 専用 yarn script (案 A) を採用しました。subprocess を test 内で spawn する案 B より shape が単純、production code を分割する案 C は test 都合で prod が動くため不採用。異論あれば指摘ください。
- **同一 spec の dual-mode 設計**: `test/server/test_csrfGuard_env_wiring.ts` 内で `process.env.MULMOCLAUDE_TRUSTED_ORIGINS` を直接読んで `it()` 登録を分岐しています。これにより 1 spec で「env-set モード (`yarn test:csrf-wiring`)」と「env-unset モード (既存 glob 経由)」を両方カバー。仕様意図的なので、レビュアーは「`yarn test` で env-unset 分岐、`yarn test:csrf-wiring` で env-set 分岐が走る」前提で読んでください。
- **typo catcher の効果**: `requireSameOriginWith(env.trustedOrigins)` → `requireSameOriginWith([])` への書き換えで `yarn test:csrf-wiring` が想定通り fail することをローカル mutation test で確認済み (revert 済)。
- **CI 配置**: 別 job ではなく既存 `lint_test` job 内に step として追加しました。matrix の Linux/Windows/macOS × Node 22/24 で計 6 セル走り redundant ではありますが、別 job を立てる infra cost を避ける判断。別 job 化を希望される場合は指摘ください。
- **既存 spec の振る舞い不変**: refactor commit (`866ca1b8`) は import 元の入れ替えだけで、`test/server/test_csrfGuard.ts` の test 構造・assertion 内容は全件そのまま。net -47 lines。

## User Prompt

Issue #1463 (`test(csrf): exercise the env-bound requireSameOrigin export under non-empty MULMOCLAUDE_TRUSTED_ORIGINS via subprocess`) の対応依頼。worktree で実装し、commit 後に `/code-review-me`、続いて `/codex-cross-review` を実施するよう指示。`/code-review-me` で flag された helpers の duplicate について「抽出する」判断が出たため、共通 helper module を切り出す追加 commit を入れた。

## 背景

PR #1458 で CSRF guard に opt-in trusted-origin allowlist を追加。production wiring は `server/api/csrfGuard.ts` 末尾:

```ts
export const requireSameOrigin = requireSameOriginWith(env.trustedOrigins);
```

既存 `test/server/test_csrfGuard.ts` の "env-binding integration" describe は、`server/system/env.ts` を dynamic re-import して `requireSameOriginWith(envMod.env.trustedOrigins)` を **手動で再合成**してテストしている。これでは env parser + factory の合成は検証できるが、`csrfGuard.ts` の export 行で

```ts
export const requireSameOrigin = requireSameOriginWith([]);            // typo
export const requireSameOrigin = requireSameOriginWith(env.sandboxMountConfigs);  // wrong field
```

のような typo が混入しても fail しない (PR #1458 で CodeRabbit が指摘済)。Node ESM resolver は `import { env } from "../system/env.js"` を un-queried URL でキャッシュするため、同一プロセス内で `csrfGuard.ts` を fresh re-import しても初回 env snapshot に張り付き、env-bound export を後から差し替えられない。**subprocess で別プロセスから fresh load** するのが唯一確実な検証方法。

## 実装

### 1. 新規 spec — `test/server/test_csrfGuard_env_wiring.ts`

- `import { requireSameOrigin } from "../../server/api/csrfGuard.js"` のみ (factory は import しない、実 export だけを test 対象に)
- `process.env.MULMOCLAUDE_TRUSTED_ORIGINS` の状態で `it()` 登録を分岐
  - **env-set モード**: listed LAN origin への POST が `next()` を呼ぶこと + 非 listed LAN origin が 403 になることを検証 ← typo catcher
  - **env-unset モード**: LAN origin への POST が 403 になる (localhost-only fallback) ことを検証 ← regression pin
- 共通 sanity: `http://localhost:5173` への POST は常に `next()` を呼ぶ

### 2. yarn script — `test:csrf-wiring`

```json
"test:csrf-wiring": "cross-env MULMOCLAUDE_TRUSTED_ORIGINS=http://192.168.1.42:5173 tsx --test test/server/test_csrfGuard_env_wiring.ts"
```

`cross-env` 経由で Windows でも動く (CI matrix は ubuntu/windows/macos の 3 OS)。

### 3. CI 連携 — `.github/workflows/pull_request.yaml`

`lint_test` job に step を追加 (matrix 6 セルで走る):

```yaml
- run: yarn run test:csrf-wiring
```

env-unset variant は既存の glob `./test/*/test_*.ts` が拾うので、新規 step は env-set variant を担当。

### 4. helper module 抽出 (refactor commit)

`/code-review-me` の指摘: 新旧 spec の `FakeReq` / `FakeRes` / `makeReq` / `makeReqWithRawOrigin` / `makeRes` が duplicate (rule 1 / 4)。`test/server/helpers/fakeExpressMiddleware.ts` に集約し、両 spec から import。仕様変更なし、net -47 lines。

## 受け入れ条件 (Issue #1463)

- [x] env を set した subprocess で `csrfGuard.ts` を fresh import し、`requireSameOrigin` が当該 LAN Origin の POST を 200 で通すことを検証する test がある
- [x] 同じ仕組みで env unset 時に LAN Origin が 403 になることも検証
- [x] CI で実行され、export 文 typo (`requireSameOriginWith([])` 等) が必ず fail を出す

## 確認手順 (ローカル)

```bash
# env-set モード — typo catcher
yarn test:csrf-wiring
# → 3 件 pass (localhost / listed LAN / non-listed LAN reject)

# env-unset モード — fallback regression pin
yarn test  # 新規 spec も glob 経由で 2 件 pass

# mutation test (実際の検出能力確認、要 revert)
# server/api/csrfGuard.ts の最終行を一時的に
#   export const requireSameOrigin = requireSameOriginWith([]);
# に書き換え → yarn test:csrf-wiring が fail することを確認 → revert
```

## Cross-review

Codex (`@openai/codex` CLI) と Claude で dual review (2 iterations) で収束:

- **Iteration 1**: Codex が 2 nits → 1 件は false-positive (glob path コメントが正しいことをローカル `ls` で実証)、1 件は valid nit (plan の 影響範囲 セクションが refactor commit 後 stale) → `956689db` で修正
- **Iteration 2**: Codex LGTM (no findings)、Claude LGTM

## Out of Scope

- `csrfGuard.ts` 本体のロジック変更 — 触らない
- 他の env-bound module への横展開 — 必要になったら別 issue

---

Closes #1463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added environment variable validation testing for CSRF protection.
  * Created reusable test utilities for Express middleware testing.
  * Refactored existing tests to use shared test fixtures.

* **Chores**
  * Enhanced CI workflow with new CSRF wiring validation step.
  * Added documentation for environment-based testing approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
