### PR TITLE
feat(ui): backend-offline banner + retry (#1479)

### DIFF
--- a/e2e/tests/backend-offline-banner.spec.ts
+++ b/e2e/tests/backend-offline-banner.spec.ts
@@ -33,7 +33,10 @@ test.describe("backend offline banner (#1479)", () => {
   test("does not show when the backend is reachable", async ({ page }) => {
     await mockAllApis(page);
     await page.goto("/");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    // Wait for the app shell rather than a localized text — testids
+    // survive i18n changes and aren't ambiguous against other
+    // "MulmoClaude" occurrences in copy.
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(page.getByTestId("backend-offline-banner")).toHaveCount(0);
   });
 });

--- a/e2e/tests/backend-offline-banner.spec.ts
+++ b/e2e/tests/backend-offline-banner.spec.ts
@@ -1,0 +1,39 @@
+// Backend-offline banner + retry (#1479). The banner is surfaced by
+// `apiCall` setting `backendReachable = false` whenever `fetch` throws
+// — i.e. any HTTP probe to a stopped server triggers it. The first
+// such probe at mount time is `fetchHealth()` in App.vue's
+// `onMounted`, so aborting `/api/health` is the simplest reliable
+// trigger.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+test.describe("backend offline banner (#1479)", () => {
+  test("shows when the backend is unreachable and hides after a successful retry", async ({ page }) => {
+    await mockAllApis(page);
+
+    // Abort every /api/* call so `backendReachable` stays false (any
+    // successful apiCall flips it back to true; we need a sustained
+    // failure for the banner to remain visible while we observe it).
+    // Registered AFTER mockAllApis so this catch-all wins.
+    let offline = true;
+    await page.route("**/api/**", (route) => (offline ? route.abort("connectionrefused") : route.fallback()));
+
+    await page.goto("/");
+    // Banner appears as soon as the first apiCall throws.
+    await expect(page.getByTestId("backend-offline-banner")).toBeVisible();
+
+    // Switch the catch-all to pass-through; mockAllApis defaults now
+    // answer. Click Retry → `fetchHealth` succeeds → banner hides.
+    offline = false;
+    await page.getByTestId("backend-offline-retry").click();
+    await expect(page.getByTestId("backend-offline-banner")).toBeHidden();
+  });
+
+  test("does not show when the backend is reachable", async ({ page }) => {
+    await mockAllApis(page);
+    await page.goto("/");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("backend-offline-banner")).toHaveCount(0);
+  });
+});

--- a/plans/feat-backend-offline-banner-1479.md
+++ b/plans/feat-backend-offline-banner-1479.md
@@ -1,0 +1,55 @@
+# Backend-offline banner + retry (#1479)
+
+Frontend-only UX hardening so the user notices when the backend goes
+down (currently silent: only console errors).
+
+## Design
+
+- `src/utils/api.ts` already returns `{ ok:false, status:0 }` on
+  network errors (existing convention; used per-feature in several
+  callers). Centralise that signal:
+  - Export a module-level `backendReachable: Ref<boolean>` (default
+    `true`).
+  - `apiCall`: on `status:0` → `backendReachable.value = false`; on
+    any successful response → `true`. Eager: surfaces backend-down
+    immediately from whichever fetch the user triggered (no 15s
+    health-poll wait).
+- New `src/components/BackendOfflineBanner.vue`:
+  - Renders only when `!backendReachable`.
+  - Copy: title + "server may be down — check it is running" + the
+    last error message (small).
+  - **Retry** button: calls `fetchHealth()` from `useHealth`.
+    Success flips the signal back to true (already wired through
+    `apiCall`), and the banner hides automatically.
+- `src/App.vue`: mount the banner near the top of the root layout
+  (above the workspace content).
+
+## i18n (all 8 locales, lockstep)
+
+- `backendOffline.title` — "Can't reach the backend"
+- `backendOffline.body` — "The MulmoClaude server may not be running. Check the dev server, then retry."
+- `backendOffline.retry` — "Retry"
+
+## Tests
+
+- Unit: small test for the `backendReachable` flip semantics
+  (success → true, status:0 → false). Pure module-level state, so a
+  spy on `fetch` is enough.
+- e2e: route-mock `/api/health` (and a session fetch) to fail with
+  `route.abort('connectionrefused')` → assert
+  `data-testid="backend-offline-banner"` visible. Then re-mock health
+  to succeed and click Retry → banner disappears.
+
+## Out of scope
+
+- Granular reconnect UX (auto-poll on failure, exponential backoff).
+- WebSocket-specific banner (the WS layer has its own reconnect; the
+  banner only reflects HTTP reachability via `apiCall`).
+
+## Acceptance
+
+- Backend stopped → first user-triggered fetch (or the next 15s
+  health poll, whichever lands first) surfaces the banner.
+- Retry actually re-checks and hides the banner on success.
+- 8 locales updated; cheatsheet brief updated; format/lint/typecheck/
+  build/test/e2e clean.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="flex flex-col fixed inset-0 bg-gray-900 text-white">
+    <!-- Backend-offline banner (#1479) — pinned above the top bar so
+         it's the first thing the user sees when the server isn't
+         reachable. Self-hiding when fetchHealth succeeds. -->
+    <BackendOfflineBanner :on-retry="fetchHealth" />
     <!-- Global top bar — shown in every view mode -->
     <div class="shrink-0 bg-white text-gray-900">
       <!-- Row 1: title + plugin launcher -->
@@ -291,6 +295,7 @@ import { useI18n } from "vue-i18n";
 import { v4 as uuidv4 } from "uuid";
 import { getPlugin } from "./tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import BackendOfflineBanner from "./components/BackendOfflineBanner.vue";
 import RightSidebar from "./components/RightSidebar.vue";
 import SidebarHeader from "./components/SidebarHeader.vue";
 import SessionHeaderControls from "./components/SessionHeaderControls.vue";

--- a/src/components/BackendOfflineBanner.vue
+++ b/src/components/BackendOfflineBanner.vue
@@ -1,0 +1,56 @@
+<template>
+  <div
+    v-if="!backendReachable"
+    data-testid="backend-offline-banner"
+    role="alert"
+    class="flex items-center gap-2 px-3 py-2 bg-red-50 border-b border-red-200 text-red-700 text-sm"
+  >
+    <span class="material-icons text-base" aria-hidden="true">cloud_off</span>
+    <div class="flex-1 min-w-0">
+      <div class="font-medium">{{ t("backendOffline.title") }}</div>
+      <div class="text-xs text-red-600 truncate">
+        <span>{{ t("backendOffline.body") }}</span>
+        <span v-if="lastBackendError" class="opacity-70">{{ ` — ${lastBackendError}` }}</span>
+      </div>
+    </div>
+    <button
+      type="button"
+      data-testid="backend-offline-retry"
+      class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-red-300 text-red-700 hover:bg-red-100 disabled:opacity-40"
+      :disabled="retrying"
+      @click="retry"
+    >
+      <span class="material-icons text-sm" :class="retrying ? 'animate-spin' : ''" aria-hidden="true">refresh</span>
+      {{ t("backendOffline.retry") }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { backendReachable, lastBackendError } from "../utils/api";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  /** Health-check function injected by the parent (uses the shared
+   *  `useHealth` instance so we don't spin up a second poll loop). */
+  onRetry: () => Promise<void>;
+}>();
+
+const retrying = ref(false);
+
+async function retry(): Promise<void> {
+  if (retrying.value) return;
+  retrying.value = true;
+  try {
+    // `fetchHealth` hits `/api/health` through `apiCall`, which on
+    // success automatically flips `backendReachable` back to true.
+    // We don't need to manage that ourselves.
+    await props.onRetry();
+  } finally {
+    retrying.value = false;
+  }
+}
+</script>

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -82,6 +82,11 @@ const deMessages = {
     notResponding:
       "{command} ist installiert, antwortet aber nicht — zugehörige Funktionen wurden deaktiviert. Starten Sie es und starten Sie neu, um sie zu aktivieren.",
   },
+  backendOffline: {
+    title: "Backend nicht erreichbar",
+    body: "Der MulmoClaude-Server läuft möglicherweise nicht. Prüfe den Dev-Server und versuche es erneut.",
+    retry: "Erneut versuchen",
+  },
   pluginErrorBoundary: {
     title: "Plugin {pkg} ist abgestürzt",
     subtitle: "Das Plugin konnte nicht gerendert werden. Der Fehler wurde in der Konsole protokolliert.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -101,6 +101,11 @@ const enMessages = {
     notFound: "{command} not found — related features are disabled. Install it and restart to enable them.",
     notResponding: "{command} is installed but not responding — related features are disabled. Start it and restart to enable them.",
   },
+  backendOffline: {
+    title: "Can't reach the backend",
+    body: "The MulmoClaude server may not be running. Check the dev server, then retry.",
+    retry: "Retry",
+  },
   pluginErrorBoundary: {
     title: "Plugin {pkg} crashed",
     subtitle: "The plugin failed to render. The error has been logged to the console.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -85,6 +85,11 @@ const esMessages = {
     notFound: "No se encontró {command} — las funciones relacionadas se han desactivado. Instálalo y reinicia para habilitarlas.",
     notResponding: "{command} está instalado pero no responde — las funciones relacionadas se han desactivado. Inícialo y reinicia para habilitarlas.",
   },
+  backendOffline: {
+    title: "No se puede conectar con el backend",
+    body: "Es posible que el servidor de MulmoClaude no esté en ejecución. Comprueba el servidor de desarrollo y vuelve a intentarlo.",
+    retry: "Reintentar",
+  },
   pluginErrorBoundary: {
     title: "El plugin {pkg} se ha bloqueado",
     subtitle: "El plugin no se pudo renderizar. El error se ha registrado en la consola.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -80,6 +80,11 @@ const frMessages = {
     notFound: "{command} introuvable — les fonctionnalités associées ont été désactivées. Installez-le et redémarrez pour les activer.",
     notResponding: "{command} est installé mais ne répond pas — les fonctionnalités associées ont été désactivées. Démarrez-le et redémarrez pour les activer.",
   },
+  backendOffline: {
+    title: "Impossible de joindre le backend",
+    body: "Le serveur MulmoClaude n'est peut-être pas démarré. Vérifiez le serveur de développement, puis réessayez.",
+    retry: "Réessayer",
+  },
   pluginErrorBoundary: {
     title: "Le plugin {pkg} a planté",
     subtitle: "Le plugin n'a pas pu être affiché. L'erreur a été consignée dans la console.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -87,6 +87,11 @@ const jaMessages = {
     notFound: "{command} が見つかりません — 関連機能を無効化しました。インストールして再起動すると有効になります。",
     notResponding: "{command} はインストール済みですが応答しません — 関連機能を無効化しました。起動して再起動すると有効になります。",
   },
+  backendOffline: {
+    title: "バックエンドに接続できません",
+    body: "MulmoClaude サーバが起動していない可能性があります。dev サーバを確認してから再試行してください。",
+    retry: "再試行",
+  },
   pluginErrorBoundary: {
     title: "プラグイン {pkg} がクラッシュしました",
     subtitle: "プラグインのレンダリングに失敗しました。エラーはコンソールに記録されています。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -88,6 +88,11 @@ const koMessages = {
     notFound: "{command}을(를) 찾을 수 없습니다 — 관련 기능이 비활성화되었습니다. 설치 후 재시작하면 활성화됩니다.",
     notResponding: "{command}이(가) 설치되어 있지만 응답하지 않습니다 — 관련 기능이 비활성화되었습니다. 시작한 후 재시작하면 활성화됩니다.",
   },
+  backendOffline: {
+    title: "백엔드에 연결할 수 없습니다",
+    body: "MulmoClaude 서버가 실행 중이 아닐 수 있습니다. 개발 서버를 확인한 후 다시 시도하세요.",
+    retry: "다시 시도",
+  },
   pluginErrorBoundary: {
     title: "플러그인 {pkg}이(가) 충돌했습니다",
     subtitle: "플러그인 렌더링에 실패했습니다. 오류가 콘솔에 기록되었습니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -80,6 +80,11 @@ const ptBRMessages = {
     notFound: "{command} não encontrado — recursos relacionados foram desativados. Instale-o e reinicie para habilitá-los.",
     notResponding: "{command} está instalado mas não responde — recursos relacionados foram desativados. Inicie-o e reinicie para habilitá-los.",
   },
+  backendOffline: {
+    title: "Não foi possível conectar ao backend",
+    body: "O servidor do MulmoClaude pode não estar em execução. Verifique o servidor de desenvolvimento e tente novamente.",
+    retry: "Tentar novamente",
+  },
   pluginErrorBoundary: {
     title: "O plugin {pkg} travou",
     subtitle: "O plugin falhou ao renderizar. O erro foi registrado no console.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -84,6 +84,11 @@ const zhMessages = {
     notFound: "未找到 {command} — 相关功能已被禁用。安装后重启即可启用。",
     notResponding: "{command} 已安装但无响应 — 相关功能已被禁用。启动后重启即可启用。",
   },
+  backendOffline: {
+    title: "无法连接到后端",
+    body: "MulmoClaude 服务器可能未运行。请检查开发服务器后再重试。",
+    retry: "重试",
+  },
   pluginErrorBoundary: {
     title: "插件 {pkg} 已崩溃",
     subtitle: "插件渲染失败。错误已记录到控制台。",

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -51,6 +51,14 @@ export const backendReachable: Ref<boolean> = ref(true);
  *  flipped to false. Useful for the offline banner's small print. */
 export const lastBackendError: Ref<string | null> = ref(null);
 
+/** A `fetch` rejection that came from caller-driven `AbortController`
+ *  cancellation (the spec says it's a `DOMException` with `name ===
+ *  "AbortError"`). Normal flow — must NOT flip `backendReachable`. */
+function isAbortError(err: unknown): boolean {
+  if (typeof DOMException !== "undefined" && err instanceof DOMException && err.name === "AbortError") return true;
+  return typeof err === "object" && err !== null && "name" in err && (err as { name: unknown }).name === "AbortError";
+}
+
 // ── Auth token (populated by bootstrap; consumed by every call) ─────
 
 let authToken: string | null = null;
@@ -159,13 +167,17 @@ export async function apiCall<T = unknown>(path: string, opts: ApiOptions = {}):
   try {
     res = await fetch(url, init);
   } catch (err) {
-    // `fetch` itself threw — backend unreachable (server stopped,
-    // DNS, CORS preflight failure, etc.). Surface globally so the
-    // banner appears immediately rather than waiting for the 15s
-    // health poll.
     const message = errorMessage(err);
-    backendReachable.value = false;
-    lastBackendError.value = message;
+    // `fetch` throws on EITHER a true network failure (server
+    // stopped, DNS, CORS preflight) OR a caller-driven
+    // AbortController cancellation. The second case is a normal flow
+    // (file/plugin refresh races, navigation cancel) — flipping the
+    // global offline flag for those would surface a false banner.
+    // Only the first case warrants the signal.
+    if (!isAbortError(err)) {
+      backendReachable.value = false;
+      lastBackendError.value = message;
+    }
     return {
       ok: false,
       error: message,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -29,8 +29,27 @@
 //   - setAuthToken() populates a module-level token used by every call
 //   - interceptors could go here for logging, retry, metrics
 
+import { ref, type Ref } from "vue";
 import { errorMessage } from "./errors";
 import { hasStringProp } from "./types";
+
+// ── Backend reachability signal (#1479) ─────────────────────────────
+//
+// `apiCall` returns `{ ok:false, status:0 }` when `fetch` itself
+// throws — the classic "network error" / `ERR_CONNECTION_REFUSED`
+// shape. That used to be silently swallowed feature-by-feature; now
+// we flip a module-level ref so any consumer (App.vue's banner) can
+// react. Eager: surfaces backend-down at the FIRST failing user-
+// triggered fetch, no need to wait for the 15s health poll.
+
+/** True while the backend appears reachable. Flipped to false on a
+ *  `fetch` throw (network error, server stopped, DNS, etc.) and back
+ *  to true on any successful HTTP response. */
+export const backendReachable: Ref<boolean> = ref(true);
+
+/** Last network-error message observed when `backendReachable` was
+ *  flipped to false. Useful for the offline banner's small print. */
+export const lastBackendError: Ref<string | null> = ref(null);
 
 // ── Auth token (populated by bootstrap; consumed by every call) ─────
 
@@ -140,11 +159,26 @@ export async function apiCall<T = unknown>(path: string, opts: ApiOptions = {}):
   try {
     res = await fetch(url, init);
   } catch (err) {
+    // `fetch` itself threw — backend unreachable (server stopped,
+    // DNS, CORS preflight failure, etc.). Surface globally so the
+    // banner appears immediately rather than waiting for the 15s
+    // health poll.
+    const message = errorMessage(err);
+    backendReachable.value = false;
+    lastBackendError.value = message;
     return {
       ok: false,
-      error: errorMessage(err),
+      error: message,
       status: 0,
     };
+  }
+
+  // Any reply at all means the server is talking — re-arm the
+  // reachable flag. HTTP-level errors (4xx/5xx) leave it true; only
+  // network-error throws above flip it false.
+  if (!backendReachable.value) {
+    backendReachable.value = true;
+    lastBackendError.value = null;
   }
 
   if (!res.ok) {

--- a/test/utils/test_api.ts
+++ b/test/utils/test_api.ts
@@ -234,4 +234,16 @@ describe("apiCall — backendReachable signal", () => {
     // Server replied → backend is reachable, even though the request itself failed.
     assert.equal(backendReachable.value, true);
   });
+
+  it("does NOT flip on caller-driven AbortError (normal cancel flow)", async () => {
+    // Simulate `AbortController.abort()` mid-flight: fetch rejects
+    // with a DOMException-shaped AbortError. This is a normal
+    // navigation/race flow — must not surface as backend-offline.
+    const abortErr = Object.assign(new Error("aborted"), { name: "AbortError" });
+    globalThis.fetch = (() => Promise.reject(abortErr)) as typeof fetch;
+    const result = await apiCall("/api/anything");
+    assert.equal(result.ok, false);
+    assert.equal(backendReachable.value, true);
+    assert.equal(lastBackendError.value, null);
+  });
 });

--- a/test/utils/test_api.ts
+++ b/test/utils/test_api.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { apiCall, apiGet, apiPost, apiPut, apiDelete, setAuthToken } from "../../src/utils/api.ts";
+import { apiCall, apiGet, apiPost, apiPut, apiDelete, backendReachable, lastBackendError, setAuthToken } from "../../src/utils/api.ts";
 
 // fetch mocking. Capture the URL + init passed by the api module, and
 // reply with a pre-scripted response. Each test installs its own mock
@@ -186,5 +186,52 @@ describe("apiCall — query and headers", () => {
       headers: { "X-Custom": "1" },
     });
     assert.equal(getHeader(calls[0], "X-Custom"), "1");
+  });
+});
+
+// #1479 — backend-reachability signal. A `fetch` throw flips
+// `backendReachable` false (with the error message stored); any
+// subsequent HTTP reply (including 4xx/5xx) flips it back true.
+describe("apiCall — backendReachable signal", () => {
+  beforeEach(() => {
+    backendReachable.value = true;
+    lastBackendError.value = null;
+  });
+  afterEach(restoreMock);
+
+  it("flips to false on a fetch throw (network error / ERR_CONNECTION_REFUSED)", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("connection refused"))) as typeof fetch;
+    const result = await apiCall("/api/anything");
+    assert.equal(result.ok, false);
+    if (result.ok === false) {
+      assert.equal(result.status, 0);
+      assert.match(result.error, /connection refused/);
+    }
+    assert.equal(backendReachable.value, false);
+    assert.match(lastBackendError.value ?? "", /connection refused/);
+  });
+
+  it("flips back to true on the next successful HTTP reply", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("down"))) as typeof fetch;
+    await apiCall("/api/anything");
+    assert.equal(backendReachable.value, false);
+
+    installMock();
+    nextResponse = jsonResponse(200, { ok: true });
+    await apiCall("/api/anything");
+    assert.equal(backendReachable.value, true);
+    assert.equal(lastBackendError.value, null);
+  });
+
+  it("flips back to true even when the HTTP reply is a 4xx/5xx", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("down"))) as typeof fetch;
+    await apiCall("/api/anything");
+    assert.equal(backendReachable.value, false);
+
+    installMock();
+    nextResponse = jsonResponse(500, { error: "boom" });
+    await apiCall("/api/anything");
+    // Server replied → backend is reachable, even though the request itself failed.
+    assert.equal(backendReachable.value, true);
   });
 });


### PR DESCRIPTION
## Summary

When the backend server is down but the Vite dev/client is still up, clicking around the UI fails silently — the console fills with `ERR_CONNECTION_REFUSED` but the screen looks fine, leaving the user wondering why nothing works. This PR surfaces a clear red banner with a Retry button as soon as `apiCall` sees a `fetch` throw.

## Items to Confirm / Review

- **Centralised in `apiCall`**: every existing per-feature `status === 0` check already had this signal in front of it; we just lift it into one shared ref so a single banner can react. Eager — no need to wait 15s for the health poll.
- **Self-arming**: any HTTP reply (incl. 4xx/5xx) flips `backendReachable` back to `true` since "server replied" ≠ "server down". Network throws are the only thing that flips it false.
- **Retry**: uses the existing `useHealth.fetchHealth()` — same `apiCall` path, so success auto-hides the banner.
- **i18n**: `backendOffline.{title, body, retry}` × all 8 locales (lockstep). German written without typographic quotes per `.claude/rules/i18n-de.md`.

## User Prompt

> バックエンドを落としてVueだけ表示されているときにセッションなどをクリックすると … `ERR_CONNECTION_REFUSED` ばかりで UIではエラーにならない。UI でサーバ落ちているかもと教えてほしい。retry

## Test plan

- [x] `format`/`lint`/`typecheck`/`build` clean
- [x] Unit `test/utils/test_api.ts` (17 pass) — `backendReachable` flip semantics
- [x] e2e `backend-offline-banner.spec.ts` (2 pass) — banner appears when `/api/**` aborts, hides after a successful Retry; doesn't appear when reachable
- [x] Full unit suite 4885 / 0 fail
- [ ] Manual: stop backend, click a session in the sidebar → banner appears → restart backend → click Retry → banner hides

Closes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prominent backend-offline banner that alerts when the server is unreachable
  * Retry action (button) to re-check connectivity; shows loading state and prevents duplicate retries
  * Banner mounted near the app top and hides automatically after a successful retry
  * Localized messages added for 8 languages

* **Tests**
  * End-to-end and unit tests covering banner visibility, retry behavior, and offline/online transitions

* **Documentation**
  * Feature plan describing offline behavior, UX, and i18n expectations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->