### PR TITLE
feat: schema-driven apps PoC + "Account beta" role

### DIFF
--- a/plans/feat-skill-driven-apps.md
+++ b/plans/feat-skill-driven-apps.md
@@ -159,7 +159,7 @@ After `yarn build`:
 3. **Role**: select "Account beta" → prompt
    `"Add a client: Acme Corp, billing@acme.example"` → verify
    `data/clients/items/<id>.json` is created with the right shape
-4. **View**: navigate to `/apps/clients` — verify Acme appears in the table
+4. **View**: navigate to `/apps/mc-clients` — verify Acme appears in the table
 5. **Edit**: click the row → modify email → save → verify file updates
 6. **Delete**: click delete in modal → verify file removed
 7. **Add via UI** (not just via Claude): click "+" → fill form → verify file

--- a/plans/feat-skill-driven-apps.md
+++ b/plans/feat-skill-driven-apps.md
@@ -1,0 +1,209 @@
+# Plan: Skill-driven Apps (PoC)
+
+## Hypothesis
+
+Per-feature plugins (worklog / client / invoice — ~3,000 lines each, requires
+PR + build + plugin registration) can be replaced by:
+
+1. A **small set of generic host primitives** (schema-driven CollectionView,
+   later: template renderer, `$ref` resolver), and
+2. **Feature-specific skills** that declare a schema, a folder layout, and
+   workflow instructions for Claude.
+
+The skill system already exists in MulmoClaude (preset → catalog → star →
+`.claude/skills/`). This PoC adds the missing piece — a **schema-driven
+CollectionView primitive** — and validates the model with one app (clients).
+
+Out of scope for the PoC: migrating worklog or invoice. Those have richer
+UX needs (drag-to-reorder line items, PDF export, cross-collection links)
+that should only be tackled once the basic shape is proven.
+
+---
+
+## Architecture
+
+### Reused as-is
+
+| Piece | Path | Role |
+|---|---|---|
+| Skill discovery | `server/workspace/skills/discovery.ts` | Finds SKILL.md under `~/.claude/skills/` + `<workspace>/.claude/skills/` |
+| Preset bundle | `server/workspace/skills-preset/<slug>/` | Source-tree home for launcher-shipped skills |
+| Preset sync | `server/workspace/skills-preset.ts` | Boot-time copy preset → `data/skills/catalog/preset/` |
+| Catalog → active | `server/workspace/skills/catalog.ts#starCatalogEntry` | `copyDirTree` from catalog into `.claude/skills/` |
+| Files API | `server/api/routes/files.ts` | Generic file read/write — used by CollectionView for CRUD |
+
+### What this PoC adds
+
+1. **Generalize preset sync to copy entire skill directory.** Today
+   `copySourcesIntoDest` copies only `SKILL.md`. Schemas, templates, and any
+   other sibling files would silently get dropped on boot. Change it to walk
+   the source skill directory recursively. `copyDirTree` in
+   `catalog.ts` already does the right thing on the star side.
+
+2. **Schema convention.** A skill that ships a `schema.json` alongside
+   `SKILL.md` is *also* an "app" — the host renders its records via the
+   CollectionView primitive. A skill without `schema.json` stays a normal
+   instructional skill, unchanged.
+
+3. **App discovery endpoint** (`GET /api/apps`): scans
+   `~/.claude/skills/*/schema.json` + `<workspace>/.claude/skills/*/schema.json`
+   (active skills only — not catalog), returns `[{ slug, title, icon, dataPath }]`.
+   `GET /api/apps/:slug` returns `{ schema, items }`.
+
+4. **`<AppCollectionView>` Vue primitive.** Schema-driven table + edit modal.
+   Reads via `/api/apps/:slug`; writes via existing `/api/files/content` PUT
+   (already supported for JSON files in workspace).
+
+5. **Route `/apps/:slug`** in vue-router + App.vue switch case. Sidebar gets
+   one "Apps" launcher that lists discovered apps.
+
+6. **Sample app `mc-clients`** under `server/workspace/skills-preset/`.
+
+7. **"Account beta" role** in `src/config/roles.ts` whose prompt instructs
+   Claude to use the `mc-clients` skill and whose `availablePlugins` is
+   intentionally tiny (just `presentForm`). Native Read / Write / Edit from
+   the Agent SDK do the CRUD.
+
+### Schema format (v0)
+
+Minimal, JSON-Schema-ish but with UI hints inline. Lives at
+`<skillDir>/schema.json`.
+
+```json
+{
+  "title": "Clients",
+  "icon": "people",
+  "dataPath": "data/clients/items/",
+  "primaryKey": "id",
+  "fields": {
+    "id":      { "type": "string",   "label": "ID",      "primary": true },
+    "name":    { "type": "string",   "label": "Name",    "required": true },
+    "email":   { "type": "email",    "label": "Email" },
+    "address": { "type": "text",     "label": "Address" },
+    "notes":   { "type": "markdown", "label": "Notes" }
+  }
+}
+```
+
+Supported field types for v0: `string | text | email | number | date | markdown`.
+
+**Deferred** (will surface as needs emerge during migration of real apps):
+
+- `ref` (cross-collection links) — needed for invoice → client / worklog
+- `table` (nested array of objects) — needed for invoice line items
+- `money` (currency-aware number) — needed for invoice
+- `derived` (computed fields like `total`) — needed for invoice
+- `actions` (status changes, export-PDF) — needed for invoice send/mark-paid
+- Validation beyond `required`
+
+### Sample app: `mc-clients`
+
+- `server/workspace/skills-preset/mc-clients/SKILL.md` — Claude's instructions
+  for clients CRUD, referencing `data/clients/items/<id>.json`
+- `server/workspace/skills-preset/mc-clients/schema.json` — the schema above
+
+Boot flow:
+1. Preset sync copies `mc-clients/` (both files) → `data/skills/catalog/preset/mc-clients/`
+2. User opens `/skills`, sees Clients in the catalog, clicks ★ → copied to `.claude/skills/mc-clients/`
+3. Now both Claude (via skill discovery) and the host UI (via `/api/apps`) see it
+
+### "Account beta" role
+
+```ts
+{
+  id: "account-beta",
+  name: "Account beta",
+  icon: "science",  // beta flask
+  prompt:
+    "You are a beta accounting assistant testing the skill-driven app architecture.\n\n" +
+    "You have a `mc-clients` skill that defines a client database. Use it whenever the user " +
+    "asks to add, list, edit, or delete clients. Follow the conventions in that skill exactly — " +
+    "the file layout is the source of truth; the UI reads the same files.\n\n" +
+    "Use Read / Write / Edit directly for file I/O. Use presentForm when you need information " +
+    "from the user that isn't already provided.",
+  availablePlugins: [TOOL_NAMES.presentForm],
+  queries: [
+    "Add a client: Acme Corp, billing@acme.example, San Francisco",
+    "List my clients",
+    "What's Acme's email?",
+    "Update Acme's address to 'One Market Plaza, San Francisco'",
+  ],
+  isDebugRole: true,  // hides from the default role picker until proven
+}
+```
+
+---
+
+## Implementation tasks
+
+Tracked in the live TaskList:
+
+1. Write this plan
+2. Author `mc-clients` skill (SKILL.md + schema.json) under `skills-preset/`
+3. Generalize preset sync to copy entire skill tree
+4. Add `GET /api/apps` + `GET /api/apps/:slug` server endpoints
+5. Build `<AppCollectionView>` Vue component
+6. Wire `/apps/:slug` route + sidebar entry
+7. Add "Account beta" role
+8. Run yarn format / lint / typecheck / build
+
+---
+
+## Test plan
+
+After `yarn build`:
+
+1. **Boot**: `yarn dev` — verify log shows `mc-clients` in preset sync
+2. **Star**: navigate to `/skills`, find Clients in the catalog, click ★ — verify
+   `.claude/skills/mc-clients/{SKILL.md,schema.json}` exists in the workspace
+3. **Role**: select "Account beta" → prompt
+   `"Add a client: Acme Corp, billing@acme.example"` → verify
+   `data/clients/items/<id>.json` is created with the right shape
+4. **View**: navigate to `/apps/clients` — verify Acme appears in the table
+5. **Edit**: click the row → modify email → save → verify file updates
+6. **Delete**: click delete in modal → verify file removed
+7. **Add via UI** (not just via Claude): click "+" → fill form → verify file
+   created and Claude can list it on next turn
+8. **Refresh**: leave the app open while Claude adds another via chat → verify
+   the new row appears (poll or pubsub — acceptable to require manual refresh
+   for the PoC)
+
+---
+
+## Honest limits of the PoC
+
+- **No bespoke UX**: CollectionView is generic table + form. Anything richer
+  (drag-to-reorder, inline editing with keyboard nav, status badges with
+  workflow rules) is out of scope. The escape hatch — letting a skill ship
+  its own Vue component — is a separate design problem; the right time to
+  solve it is after the generic path has shipped enough apps to know what's
+  missing.
+- **No relationships**: clients is a single-collection app. Cross-collection
+  references (`invoice.clientId → client`) are deliberately deferred — they
+  introduce the hardest design question (ref resolution, dangling-ref UX,
+  cascade rules), and one of those is enough work for a separate iteration.
+- **No template renderer**: PDF/HTML export is the second-biggest piece of
+  the invoice plugin and is also deferred — it's an additive primitive, not
+  a blocker for proving the schema-driven shape works.
+- **Live updates**: if the user edits via UI while Claude is composing, or
+  vice versa, the other side won't see it without a manual refresh. The
+  existing file-change pubsub (`server/events/file-change.ts`) is the right
+  long-term plumbing; PoC accepts manual refresh.
+
+---
+
+## What success looks like
+
+After clients-as-a-skill is working end-to-end, the comparison vs.
+clients-as-a-plugin (`packages/plugins/client-plugin/`, ~1,500 lines):
+
+- **Skill side**: ~2 files (SKILL.md + schema.json), maybe ~100 lines total
+- **Host side**: shared CollectionView reused for every future app
+- **Adding a new app** (e.g. bookmarks, projects, contacts): drop a folder
+  under `skills-preset/`, no PR to host code
+
+If that comparison feels obviously better, migrate worklog next (simpler
+than invoice, shares the same primitive). If it feels meaningfully worse —
+e.g. the form UX is too generic, the schema language hits its limits too
+quickly, or skill-authoring is harder than expected — the PoC is cheap to
+abandon; the existing plugins keep working.

--- a/server/api/routes/apps.ts
+++ b/server/api/routes/apps.ts
@@ -12,7 +12,7 @@ import { Router, Request, Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { discoverApps, generateItemId, deleteItem, listItems, loadApp, toDetail, toSummary, writeItem } from "../../workspace/apps/index.js";
 import type { AppDetail, AppItem, AppSummary } from "../../workspace/apps/index.js";
-import { badRequest, notFound, conflict, serverError } from "../../utils/httpError.js";
+import { badRequest, notFound, conflict, forbidden, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
 
@@ -90,6 +90,10 @@ router.post(API_ROUTES.apps.items, async (req: Request<{ slug: string }>, res: R
       badRequest(res, `invalid item id: ${result.itemId}`);
       return;
     }
+    if (result.kind === "path-escape") {
+      forbidden(res, `data directory for app '${app.slug}' escapes the workspace`);
+      return;
+    }
     if (result.kind === "conflict") {
       conflict(res, `item '${result.itemId}' already exists`);
       return;
@@ -123,6 +127,10 @@ router.put(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: str
       badRequest(res, `invalid item id: ${result.itemId}`);
       return;
     }
+    if (result.kind === "path-escape") {
+      forbidden(res, `data directory for app '${app.slug}' escapes the workspace`);
+      return;
+    }
     if (result.kind === "conflict") {
       // refuseOverwrite was false — this branch is unreachable, but
       // typescript needs the exhaustive switch.
@@ -147,6 +155,10 @@ router.delete(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: 
     const result = await deleteItem(app.dataDir, req.params.itemId);
     if (result.kind === "invalid-id") {
       badRequest(res, `invalid item id: ${result.itemId}`);
+      return;
+    }
+    if (result.kind === "path-escape") {
+      forbidden(res, `data directory for app '${app.slug}' escapes the workspace`);
       return;
     }
     if (result.kind === "not-found") {

--- a/server/api/routes/apps.ts
+++ b/server/api/routes/apps.ts
@@ -1,0 +1,149 @@
+// REST surface for schema-driven apps. Each app is a skill that
+// ships a sibling `schema.json`; the host's <AppCollectionView>
+// component reads through these endpoints.
+//
+//   GET    /api/apps                       → { apps: AppSummary[] }
+//   GET    /api/apps/:slug                 → { app, items }
+//   POST   /api/apps/:slug/items           → { item, itemId }
+//   PUT    /api/apps/:slug/items/:itemId   → { item, itemId }
+//   DELETE /api/apps/:slug/items/:itemId   → { deleted: true }
+
+import { Router, Request, Response } from "express";
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { discoverApps, generateItemId, deleteItem, listItems, loadApp, toDetail, toSummary, writeItem } from "../../workspace/apps/index.js";
+import type { AppDetail, AppItem, AppSummary } from "../../workspace/apps/index.js";
+import { badRequest, notFound, conflict, serverError } from "../../utils/httpError.js";
+import { errorMessage } from "../../utils/errors.js";
+import { log } from "../../system/logger/index.js";
+
+const router = Router();
+
+interface AppsListResponse {
+  apps: AppSummary[];
+}
+
+interface AppDetailResponse {
+  app: AppDetail;
+  items: AppItem[];
+}
+
+interface ItemMutationResponse {
+  itemId: string;
+  item: AppItem;
+}
+
+interface DeleteResponse {
+  deleted: true;
+  itemId: string;
+}
+
+router.get(API_ROUTES.apps.list, async (_req: Request, res: Response<AppsListResponse>) => {
+  try {
+    const apps = await discoverApps();
+    res.json({ apps: apps.map(toSummary) });
+  } catch (err) {
+    log.warn("apps", "list failed", { error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+});
+
+router.get(API_ROUTES.apps.detail, async (req: Request<{ slug: string }>, res: Response<AppDetailResponse>) => {
+  const app = await loadApp(req.params.slug);
+  if (!app) {
+    notFound(res, `app '${req.params.slug}' not found`);
+    return;
+  }
+  try {
+    const items = await listItems(app.dataDir);
+    res.json({ app: toDetail(app), items });
+  } catch (err) {
+    log.warn("apps", "detail failed", { slug: app.slug, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+});
+
+function extractRecord(body: unknown): AppItem | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return body as AppItem;
+}
+
+router.post(API_ROUTES.apps.items, async (req: Request<{ slug: string }>, res: Response<ItemMutationResponse>) => {
+  const app = await loadApp(req.params.slug);
+  if (!app) {
+    notFound(res, `app '${req.params.slug}' not found`);
+    return;
+  }
+  const record = extractRecord(req.body);
+  if (!record) {
+    badRequest(res, "request body must be a JSON object");
+    return;
+  }
+  // Honour the schema's primaryKey: if the record carries it, use that
+  // value as the item id; otherwise generate one. The body always wins
+  // over a generated id so Claude-derived semantic slugs stick.
+  const primaryRaw = record[app.schema.primaryKey];
+  const itemId = typeof primaryRaw === "string" && primaryRaw.length > 0 ? primaryRaw : generateItemId();
+  const recordWithId: AppItem = { ...record, [app.schema.primaryKey]: itemId };
+  const result = await writeItem(app.dataDir, itemId, recordWithId, { refuseOverwrite: true });
+  if (result.kind === "invalid-id") {
+    badRequest(res, `invalid item id: ${result.itemId}`);
+    return;
+  }
+  if (result.kind === "conflict") {
+    conflict(res, `item '${result.itemId}' already exists`);
+    return;
+  }
+  log.info("apps", "item created", { slug: app.slug, itemId: result.itemId });
+  res.json({ itemId: result.itemId, item: result.item });
+});
+
+router.put(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: string }>, res: Response<ItemMutationResponse>) => {
+  const app = await loadApp(req.params.slug);
+  if (!app) {
+    notFound(res, `app '${req.params.slug}' not found`);
+    return;
+  }
+  const record = extractRecord(req.body);
+  if (!record) {
+    badRequest(res, "request body must be a JSON object");
+    return;
+  }
+  // PUT pins the primaryKey to the URL itemId — disregard any
+  // mismatched primary-key value in the body so the file's id and its
+  // record id never drift.
+  const recordWithId: AppItem = { ...record, [app.schema.primaryKey]: req.params.itemId };
+  const result = await writeItem(app.dataDir, req.params.itemId, recordWithId);
+  if (result.kind === "invalid-id") {
+    badRequest(res, `invalid item id: ${result.itemId}`);
+    return;
+  }
+  if (result.kind === "conflict") {
+    // refuseOverwrite was false — this branch is unreachable, but
+    // typescript needs the exhaustive switch.
+    serverError(res, "unexpected conflict on update");
+    return;
+  }
+  log.info("apps", "item updated", { slug: app.slug, itemId: result.itemId });
+  res.json({ itemId: result.itemId, item: result.item });
+});
+
+router.delete(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: string }>, res: Response<DeleteResponse>) => {
+  const app = await loadApp(req.params.slug);
+  if (!app) {
+    notFound(res, `app '${req.params.slug}' not found`);
+    return;
+  }
+  const result = await deleteItem(app.dataDir, req.params.itemId);
+  if (result.kind === "invalid-id") {
+    badRequest(res, `invalid item id: ${result.itemId}`);
+    return;
+  }
+  if (result.kind === "not-found") {
+    notFound(res, `item '${result.itemId}' not found`);
+    return;
+  }
+  log.info("apps", "item deleted", { slug: app.slug, itemId: result.itemId });
+  res.json({ deleted: true, itemId: result.itemId });
+});
+
+export default router;

--- a/server/api/routes/apps.ts
+++ b/server/api/routes/apps.ts
@@ -84,17 +84,22 @@ router.post(API_ROUTES.apps.items, async (req: Request<{ slug: string }>, res: R
   const primaryRaw = record[app.schema.primaryKey];
   const itemId = typeof primaryRaw === "string" && primaryRaw.length > 0 ? primaryRaw : generateItemId();
   const recordWithId: AppItem = { ...record, [app.schema.primaryKey]: itemId };
-  const result = await writeItem(app.dataDir, itemId, recordWithId, { refuseOverwrite: true });
-  if (result.kind === "invalid-id") {
-    badRequest(res, `invalid item id: ${result.itemId}`);
-    return;
+  try {
+    const result = await writeItem(app.dataDir, itemId, recordWithId, { refuseOverwrite: true });
+    if (result.kind === "invalid-id") {
+      badRequest(res, `invalid item id: ${result.itemId}`);
+      return;
+    }
+    if (result.kind === "conflict") {
+      conflict(res, `item '${result.itemId}' already exists`);
+      return;
+    }
+    log.info("apps", "item created", { slug: app.slug, itemId: result.itemId });
+    res.json({ itemId: result.itemId, item: result.item });
+  } catch (err) {
+    log.warn("apps", "item create failed", { slug: app.slug, itemId, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
   }
-  if (result.kind === "conflict") {
-    conflict(res, `item '${result.itemId}' already exists`);
-    return;
-  }
-  log.info("apps", "item created", { slug: app.slug, itemId: result.itemId });
-  res.json({ itemId: result.itemId, item: result.item });
 });
 
 router.put(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: string }>, res: Response<ItemMutationResponse>) => {
@@ -112,19 +117,24 @@ router.put(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: str
   // mismatched primary-key value in the body so the file's id and its
   // record id never drift.
   const recordWithId: AppItem = { ...record, [app.schema.primaryKey]: req.params.itemId };
-  const result = await writeItem(app.dataDir, req.params.itemId, recordWithId);
-  if (result.kind === "invalid-id") {
-    badRequest(res, `invalid item id: ${result.itemId}`);
-    return;
+  try {
+    const result = await writeItem(app.dataDir, req.params.itemId, recordWithId);
+    if (result.kind === "invalid-id") {
+      badRequest(res, `invalid item id: ${result.itemId}`);
+      return;
+    }
+    if (result.kind === "conflict") {
+      // refuseOverwrite was false — this branch is unreachable, but
+      // typescript needs the exhaustive switch.
+      serverError(res, "unexpected conflict on update");
+      return;
+    }
+    log.info("apps", "item updated", { slug: app.slug, itemId: result.itemId });
+    res.json({ itemId: result.itemId, item: result.item });
+  } catch (err) {
+    log.warn("apps", "item update failed", { slug: app.slug, itemId: req.params.itemId, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
   }
-  if (result.kind === "conflict") {
-    // refuseOverwrite was false — this branch is unreachable, but
-    // typescript needs the exhaustive switch.
-    serverError(res, "unexpected conflict on update");
-    return;
-  }
-  log.info("apps", "item updated", { slug: app.slug, itemId: result.itemId });
-  res.json({ itemId: result.itemId, item: result.item });
 });
 
 router.delete(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: string }>, res: Response<DeleteResponse>) => {
@@ -133,17 +143,22 @@ router.delete(API_ROUTES.apps.item, async (req: Request<{ slug: string; itemId: 
     notFound(res, `app '${req.params.slug}' not found`);
     return;
   }
-  const result = await deleteItem(app.dataDir, req.params.itemId);
-  if (result.kind === "invalid-id") {
-    badRequest(res, `invalid item id: ${result.itemId}`);
-    return;
+  try {
+    const result = await deleteItem(app.dataDir, req.params.itemId);
+    if (result.kind === "invalid-id") {
+      badRequest(res, `invalid item id: ${result.itemId}`);
+      return;
+    }
+    if (result.kind === "not-found") {
+      notFound(res, `item '${result.itemId}' not found`);
+      return;
+    }
+    log.info("apps", "item deleted", { slug: app.slug, itemId: result.itemId });
+    res.json({ deleted: true, itemId: result.itemId });
+  } catch (err) {
+    log.warn("apps", "item delete failed", { slug: app.slug, itemId: req.params.itemId, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
   }
-  if (result.kind === "not-found") {
-    notFound(res, `item '${result.itemId}' not found`);
-    return;
-  }
-  log.info("apps", "item deleted", { slug: app.slug, itemId: result.itemId });
-  res.json({ deleted: true, itemId: result.itemId });
 });
 
 export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import configRoutes from "./api/routes/config.js";
 import configRefreshRoutes from "./api/routes/config-refresh.js";
 import hookLogRoutes from "./api/routes/hookLog.js";
 import skillsRoutes from "./api/routes/skills.js";
+import appsRoutes from "./api/routes/apps.js";
 import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 import { loadRuntimePlugins } from "./plugins/runtime-loader.js";
 import { evaluateDevPluginGate, loadDevPlugins, parseDevPluginsEnv } from "./plugins/dev-loader.js";
@@ -637,6 +638,7 @@ app.use(configRoutes);
 app.use(configRefreshRoutes);
 app.use(hookLogRoutes);
 app.use(skillsRoutes);
+app.use(appsRoutes);
 app.use(runtimePluginRoutes);
 async function listSessionsForBridge(opts: { limit: number; offset: number }) {
   const rows = await loadAllSessions();

--- a/server/workspace/apps/discovery.ts
+++ b/server/workspace/apps/discovery.ts
@@ -1,0 +1,150 @@
+// Discover schema-driven apps. An "app" is a skill directory that
+// ships a `schema.json` alongside its `SKILL.md`. Scans both user
+// (`~/.claude/skills/`) and project (`<workspace>/.claude/skills/`)
+// scopes; project wins on slug collision (mirrors the rule in
+// `server/workspace/skills/discovery.ts`).
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { log } from "../../system/logger/index.js";
+import { workspacePath } from "../workspace.js";
+import { USER_SKILLS_DIR, projectSkillsDir } from "../skills/paths.js";
+import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths.js";
+import type { AppDetail, AppSchema, AppSource, AppSummary } from "./types.js";
+
+const FieldSpecSchema = z.object({
+  type: z.enum(["string", "text", "email", "number", "date", "markdown"]),
+  label: z.string().min(1),
+  primary: z.boolean().optional(),
+  required: z.boolean().optional(),
+});
+
+const AppSchemaZ = z.object({
+  title: z.string().min(1),
+  icon: z.string().min(1),
+  dataPath: z.string().min(1),
+  primaryKey: z.string().min(1),
+  fields: z.record(z.string(), FieldSpecSchema),
+});
+
+interface LoadedApp {
+  slug: string;
+  source: AppSource;
+  schema: AppSchema;
+  /** Absolute path to the resolved dataPath directory (inside the
+   *  workspace). May not exist yet — the data folder is created on
+   *  first write. */
+  dataDir: string;
+}
+
+async function loadOneApp(skillsRoot: string, slug: string, source: AppSource): Promise<LoadedApp | null> {
+  const safeName = safeSlugName(slug);
+  if (safeName === null) return null;
+  const schemaPath = path.join(skillsRoot, safeName, SCHEMA_FILE);
+  let raw: string;
+  try {
+    const fileStat = await stat(schemaPath);
+    if (!fileStat.isFile()) return null;
+    raw = await readFile(schemaPath, "utf-8");
+  } catch (err) {
+    const error = err as { code?: string };
+    if (error.code !== "ENOENT") {
+      log.warn("apps", "failed to read schema.json, skipping", { slug: safeName, path: schemaPath, error: String(err) });
+    }
+    return null;
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(raw);
+  } catch (err) {
+    log.warn("apps", "schema.json is not valid JSON, skipping", { slug: safeName, error: String(err) });
+    return null;
+  }
+
+  const parsed = AppSchemaZ.safeParse(parsedJson);
+  if (!parsed.success) {
+    log.warn("apps", "schema.json failed validation, skipping", { slug: safeName, issues: parsed.error.issues });
+    return null;
+  }
+
+  // Verify the primary key is one of the declared fields and is
+  // flagged `primary` (defensive — catches obvious skill-author typos).
+  const schema = parsed.data;
+  const primaryField = schema.fields[schema.primaryKey];
+  if (!primaryField) {
+    log.warn("apps", "schema.json primaryKey not found in fields, skipping", { slug: safeName, primaryKey: schema.primaryKey });
+    return null;
+  }
+
+  const dataDir = resolveDataDir(schema.dataPath);
+  if (dataDir === null) {
+    log.warn("apps", "schema.json dataPath escapes workspace, skipping", { slug: safeName, dataPath: schema.dataPath });
+    return null;
+  }
+
+  return { slug: safeName, source, schema, dataDir };
+}
+
+async function collectAppsFromDir(skillsRoot: string, source: AppSource): Promise<LoadedApp[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(skillsRoot);
+  } catch (err) {
+    const error = err as { code?: string };
+    if (error.code === "ENOENT") return [];
+    log.warn("apps", "failed to list skills dir, returning empty", { root: skillsRoot, error: String(err) });
+    return [];
+  }
+
+  const results: LoadedApp[] = [];
+  for (const name of entries) {
+    if (name.startsWith(".")) continue;
+    const safeName = safeSlugName(name);
+    if (safeName === null) continue;
+    const dirPath = path.join(skillsRoot, safeName);
+    let dirStat;
+    try {
+      dirStat = await stat(dirPath);
+    } catch {
+      continue;
+    }
+    if (!dirStat.isDirectory()) continue;
+    const app = await loadOneApp(skillsRoot, safeName, source);
+    if (app) results.push(app);
+  }
+  return results;
+}
+
+/** Discover every schema-driven app available to this workspace.
+ *  Project-scope apps override user-scope on slug collision. */
+export async function discoverApps(): Promise<LoadedApp[]> {
+  const userApps = await collectAppsFromDir(USER_SKILLS_DIR, "user");
+  const projectApps = await collectAppsFromDir(projectSkillsDir(workspacePath), "project");
+  const merged = new Map<string, LoadedApp>();
+  for (const app of userApps) merged.set(app.slug, app);
+  for (const app of projectApps) merged.set(app.slug, app);
+  return [...merged.values()].sort((left, right) => left.slug.localeCompare(right.slug));
+}
+
+/** Load one app by slug. Returns null if the slug is invalid, no
+ *  matching skill exists, or the schema is malformed. */
+export async function loadApp(slug: string): Promise<LoadedApp | null> {
+  const safeName = safeSlugName(slug);
+  if (safeName === null) return null;
+  // Project first (overrides user).
+  const projectApp = await loadOneApp(projectSkillsDir(workspacePath), safeName, "project");
+  if (projectApp) return projectApp;
+  return loadOneApp(USER_SKILLS_DIR, safeName, "user");
+}
+
+export function toSummary(app: LoadedApp): AppSummary {
+  return { slug: app.slug, title: app.schema.title, icon: app.schema.icon, source: app.source };
+}
+
+export function toDetail(app: LoadedApp): AppDetail {
+  return { ...toSummary(app), schema: app.schema };
+}
+
+export type { LoadedApp };

--- a/server/workspace/apps/discovery.ts
+++ b/server/workspace/apps/discovery.ts
@@ -69,12 +69,21 @@ async function loadOneApp(skillsRoot: string, slug: string, source: AppSource): 
     return null;
   }
 
-  // Verify the primary key is one of the declared fields and is
-  // flagged `primary` (defensive — catches obvious skill-author typos).
+  // Verify the primary key is one of the declared fields AND is
+  // flagged `primary: true`. Without the flag the CollectionView
+  // would render the field as editable (its disabled-on-edit check
+  // is `field.primary === true`), the user's rename would silently
+  // be pinned back to the URL itemId on save, and they'd never know
+  // the edit was dropped. Reject the schema up front rather than
+  // ship that UX.
   const schema = parsed.data;
   const primaryField = schema.fields[schema.primaryKey];
   if (!primaryField) {
     log.warn("apps", "schema.json primaryKey not found in fields, skipping", { slug: safeName, primaryKey: schema.primaryKey });
+    return null;
+  }
+  if (primaryField.primary !== true) {
+    log.warn("apps", "schema.json primaryKey field is not flagged primary: true, skipping", { slug: safeName, primaryKey: schema.primaryKey });
     return null;
   }
 

--- a/server/workspace/apps/index.ts
+++ b/server/workspace/apps/index.ts
@@ -1,0 +1,3 @@
+export { discoverApps, loadApp, toSummary, toDetail, type LoadedApp } from "./discovery.js";
+export { listItems, readItem, writeItem, deleteItem, generateItemId, type WriteItemResult, type DeleteItemResult } from "./io.js";
+export type { AppSchema, AppFieldSpec, AppFieldType, AppSummary, AppDetail, AppItem, AppSource } from "./types.js";

--- a/server/workspace/apps/io.ts
+++ b/server/workspace/apps/io.ts
@@ -3,17 +3,24 @@
 // atomic; deletes are idempotent enough to expose a clear 404 when
 // the file is missing.
 
-import { mkdir, readdir, readFile, stat, unlink } from "node:fs/promises";
+import { mkdir, open, readdir, readFile, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
+import path from "node:path";
 import { log } from "../../system/logger/index.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
-import { itemFilePath, safeSlugName } from "./paths.js";
+import { isContainedInWorkspace, itemFilePath, safeSlugName } from "./paths.js";
 import type { AppItem } from "./types.js";
 
 /** Read every record under `dataDir`. Returns [] if the dir doesn't
  *  exist yet (legitimate first-use state). Malformed JSON files are
- *  logged and skipped so one bad record can't take down the listing. */
+ *  logged and skipped so one bad record can't take down the listing.
+ *  Re-validates the realpath containment to defend against a symlink
+ *  appearing between discovery and use. */
 export async function listItems(dataDir: string): Promise<AppItem[]> {
+  if (!isContainedInWorkspace(dataDir)) {
+    log.warn("apps", "listItems refused: dataDir escapes workspace via symlink", { dataDir });
+    return [];
+  }
   let entries: string[];
   try {
     entries = await readdir(dataDir);
@@ -26,7 +33,7 @@ export async function listItems(dataDir: string): Promise<AppItem[]> {
   for (const name of entries) {
     if (!name.endsWith(".json")) continue;
     if (name.startsWith(".")) continue;
-    const filePath = `${dataDir}/${name}`;
+    const filePath = path.join(dataDir, name);
     try {
       const raw = await readFile(filePath, "utf-8");
       const parsed = JSON.parse(raw) as unknown;
@@ -40,10 +47,12 @@ export async function listItems(dataDir: string): Promise<AppItem[]> {
   return results;
 }
 
-/** Read one record by id. Returns null when the file is missing. */
+/** Read one record by id. Returns null when the file is missing or
+ *  when the resolved path escapes the workspace via a symlink. */
 export async function readItem(dataDir: string, itemId: string): Promise<AppItem | null> {
   const safeId = safeSlugName(itemId);
   if (safeId === null) return null;
+  if (!isContainedInWorkspace(dataDir)) return null;
   const filePath = itemFilePath(dataDir, safeId);
   try {
     const raw = await readFile(filePath, "utf-8");
@@ -65,38 +74,71 @@ export interface WriteItemOptions {
   refuseOverwrite?: boolean;
 }
 
-export type WriteItemResult = { kind: "ok"; itemId: string; item: AppItem } | { kind: "invalid-id"; itemId: string } | { kind: "conflict"; itemId: string };
+export type WriteItemResult =
+  | { kind: "ok"; itemId: string; item: AppItem }
+  | { kind: "invalid-id"; itemId: string }
+  | { kind: "conflict"; itemId: string }
+  | { kind: "path-escape"; itemId: string };
 
-/** Write a record. Ensures the directory exists, validates the id, and
- *  writes atomically. The caller is responsible for shaping `item` —
- *  v0 doesn't validate fields against the schema (the schema language
- *  has no type-enforced constraints yet beyond `required`, which the
- *  UI form enforces client-side). */
+/** Write a record. Ensures the directory exists, validates the id,
+ *  re-checks symlink containment after mkdir, and writes atomically.
+ *
+ *  Create path (`refuseOverwrite: true`) uses an O_EXCL `wx` open
+ *  rather than `stat` + `writeFileAtomic` to close a check-then-write
+ *  race: two concurrent POSTs would otherwise both pass the existence
+ *  check and one would silently overwrite the other. The trade-off
+ *  is that the create path is not crash-atomic (a partial file could
+ *  remain if the process dies mid-write); acceptable here because
+ *  records are small JSON blobs and the next read either parses or
+ *  is skipped via the "malformed JSON" branch in `listItems`.
+ *
+ *  Update path (`refuseOverwrite: false`) uses `writeFileAtomic` so
+ *  PUT remains crash-atomic. No race there — the URL pins the id. */
 export async function writeItem(dataDir: string, itemId: string, item: AppItem, opts: WriteItemOptions = {}): Promise<WriteItemResult> {
   const safeId = safeSlugName(itemId);
   if (safeId === null) return { kind: "invalid-id", itemId };
+  await mkdir(dataDir, { recursive: true });
+  if (!isContainedInWorkspace(dataDir)) {
+    log.warn("apps", "writeItem refused: dataDir escapes workspace via symlink", { dataDir, itemId: safeId });
+    return { kind: "path-escape", itemId: safeId };
+  }
   const filePath = itemFilePath(dataDir, safeId);
+  const payload = `${JSON.stringify(item, null, 2)}\n`;
 
   if (opts.refuseOverwrite) {
+    let handle;
     try {
-      await stat(filePath);
-      return { kind: "conflict", itemId: safeId };
+      handle = await open(filePath, "wx");
     } catch (err) {
       const error = err as { code?: string };
-      if (error.code !== "ENOENT") throw err;
+      if (error.code === "EEXIST") return { kind: "conflict", itemId: safeId };
+      throw err;
     }
+    try {
+      await handle.writeFile(payload);
+    } finally {
+      await handle.close();
+    }
+    return { kind: "ok", itemId: safeId, item };
   }
 
-  await mkdir(dataDir, { recursive: true });
-  await writeFileAtomic(filePath, `${JSON.stringify(item, null, 2)}\n`);
+  await writeFileAtomic(filePath, payload);
   return { kind: "ok", itemId: safeId, item };
 }
 
-export type DeleteItemResult = { kind: "ok"; itemId: string } | { kind: "invalid-id"; itemId: string } | { kind: "not-found"; itemId: string };
+export type DeleteItemResult =
+  | { kind: "ok"; itemId: string }
+  | { kind: "invalid-id"; itemId: string }
+  | { kind: "not-found"; itemId: string }
+  | { kind: "path-escape"; itemId: string };
 
 export async function deleteItem(dataDir: string, itemId: string): Promise<DeleteItemResult> {
   const safeId = safeSlugName(itemId);
   if (safeId === null) return { kind: "invalid-id", itemId };
+  if (!isContainedInWorkspace(dataDir)) {
+    log.warn("apps", "deleteItem refused: dataDir escapes workspace via symlink", { dataDir, itemId: safeId });
+    return { kind: "path-escape", itemId: safeId };
+  }
   const filePath = itemFilePath(dataDir, safeId);
   try {
     await unlink(filePath);

--- a/server/workspace/apps/io.ts
+++ b/server/workspace/apps/io.ts
@@ -1,0 +1,116 @@
+// Read / write item files for schema-driven apps. Records live at
+// `<dataDir>/<itemId>.json`, one JSON object per file. Writes are
+// atomic; deletes are idempotent enough to expose a clear 404 when
+// the file is missing.
+
+import { mkdir, readdir, readFile, stat, unlink } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+import { log } from "../../system/logger/index.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { itemFilePath, safeSlugName } from "./paths.js";
+import type { AppItem } from "./types.js";
+
+/** Read every record under `dataDir`. Returns [] if the dir doesn't
+ *  exist yet (legitimate first-use state). Malformed JSON files are
+ *  logged and skipped so one bad record can't take down the listing. */
+export async function listItems(dataDir: string): Promise<AppItem[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dataDir);
+  } catch (err) {
+    const error = err as { code?: string };
+    if (error.code === "ENOENT") return [];
+    throw err;
+  }
+  const results: AppItem[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    if (name.startsWith(".")) continue;
+    const filePath = `${dataDir}/${name}`;
+    try {
+      const raw = await readFile(filePath, "utf-8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        results.push(parsed as AppItem);
+      }
+    } catch (err) {
+      log.warn("apps", "failed to read item, skipping", { path: filePath, error: String(err) });
+    }
+  }
+  return results;
+}
+
+/** Read one record by id. Returns null when the file is missing. */
+export async function readItem(dataDir: string, itemId: string): Promise<AppItem | null> {
+  const safeId = safeSlugName(itemId);
+  if (safeId === null) return null;
+  const filePath = itemFilePath(dataDir, safeId);
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as AppItem;
+    }
+    return null;
+  } catch (err) {
+    const error = err as { code?: string };
+    if (error.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export interface WriteItemOptions {
+  /** When true (POST/create), refuse to overwrite an existing file
+   *  and return `kind: "conflict"`. Update flow (PUT) leaves it false. */
+  refuseOverwrite?: boolean;
+}
+
+export type WriteItemResult = { kind: "ok"; itemId: string; item: AppItem } | { kind: "invalid-id"; itemId: string } | { kind: "conflict"; itemId: string };
+
+/** Write a record. Ensures the directory exists, validates the id, and
+ *  writes atomically. The caller is responsible for shaping `item` —
+ *  v0 doesn't validate fields against the schema (the schema language
+ *  has no type-enforced constraints yet beyond `required`, which the
+ *  UI form enforces client-side). */
+export async function writeItem(dataDir: string, itemId: string, item: AppItem, opts: WriteItemOptions = {}): Promise<WriteItemResult> {
+  const safeId = safeSlugName(itemId);
+  if (safeId === null) return { kind: "invalid-id", itemId };
+  const filePath = itemFilePath(dataDir, safeId);
+
+  if (opts.refuseOverwrite) {
+    try {
+      await stat(filePath);
+      return { kind: "conflict", itemId: safeId };
+    } catch (err) {
+      const error = err as { code?: string };
+      if (error.code !== "ENOENT") throw err;
+    }
+  }
+
+  await mkdir(dataDir, { recursive: true });
+  await writeFileAtomic(filePath, `${JSON.stringify(item, null, 2)}\n`);
+  return { kind: "ok", itemId: safeId, item };
+}
+
+export type DeleteItemResult = { kind: "ok"; itemId: string } | { kind: "invalid-id"; itemId: string } | { kind: "not-found"; itemId: string };
+
+export async function deleteItem(dataDir: string, itemId: string): Promise<DeleteItemResult> {
+  const safeId = safeSlugName(itemId);
+  if (safeId === null) return { kind: "invalid-id", itemId };
+  const filePath = itemFilePath(dataDir, safeId);
+  try {
+    await unlink(filePath);
+    return { kind: "ok", itemId: safeId };
+  } catch (err) {
+    const error = err as { code?: string };
+    if (error.code === "ENOENT") return { kind: "not-found", itemId: safeId };
+    throw err;
+  }
+}
+
+/** Generate a short random hex id. Used by POST when the form doesn't
+ *  carry a primary-key value (UI shortcut — Claude normally derives a
+ *  semantic id from the record's name). */
+export function generateItemId(): string {
+  return randomBytes(4).toString("hex");
+}

--- a/server/workspace/apps/io.ts
+++ b/server/workspace/apps/io.ts
@@ -3,21 +3,67 @@
 // atomic; deletes are idempotent enough to expose a clear 404 when
 // the file is missing.
 
-import { mkdir, open, readdir, readFile, unlink } from "node:fs/promises";
+import { lstat, mkdir, open, readdir, readFile, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { log } from "../../system/logger/index.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
-import { isContainedInWorkspace, itemFilePath, safeSlugName } from "./paths.js";
+import { workspacePath } from "../workspace.js";
+import { isContainedInRoot, itemFilePath, safeSlugName } from "./paths.js";
 import type { AppItem } from "./types.js";
 
+export interface IoOptions {
+  /** Override the workspace root for containment checks. Default:
+   *  the live `workspacePath`. Tests point this at a `mkdtempSync`
+   *  tree so the realpath-based escape detection can be exercised
+   *  without touching `~/mulmoclaude/`. Same pattern as
+   *  `server/workspace/skills/catalog.ts#CatalogOptions`. */
+  workspaceRoot?: string;
+}
+
+/** True iff `filePath` exists and is a regular file (NOT a symlink).
+ *  Defends `listItems` / `readItem` against `*.json` symlinks placed
+ *  inside an otherwise-contained data dir — without this, a record
+ *  file could symlink to /etc/passwd and the detail endpoint would
+ *  happily serve it. Returns false on ENOENT and on any other lstat
+ *  failure so the caller's "missing" branch covers those cases too. */
+async function isRegularFile(filePath: string): Promise<boolean> {
+  try {
+    const info = await lstat(filePath);
+    return info.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Read one JSON record file. Returns null when the file is missing,
+ *  is a symlink (file-disclosure defense), parses to a non-object,
+ *  or has a read/parse error. Caller logs the per-entry skip — this
+ *  helper just classifies. Split out to keep `listItems` under the
+ *  `sonarjs/cognitive-complexity` threshold. */
+async function tryReadRecord(filePath: string): Promise<AppItem | null> {
+  if (!(await isRegularFile(filePath))) return null;
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as AppItem;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /** Read every record under `dataDir`. Returns [] if the dir doesn't
- *  exist yet (legitimate first-use state). Malformed JSON files are
- *  logged and skipped so one bad record can't take down the listing.
- *  Re-validates the realpath containment to defend against a symlink
- *  appearing between discovery and use. */
-export async function listItems(dataDir: string): Promise<AppItem[]> {
-  if (!isContainedInWorkspace(dataDir)) {
+ *  exist yet (legitimate first-use state). Malformed JSON files and
+ *  symlinked records are skipped (the latter is a file-disclosure
+ *  defense — see `isRegularFile`). Re-validates the realpath
+ *  containment to defend against a symlinked data dir appearing
+ *  between discovery and use. */
+export async function listItems(dataDir: string, opts: IoOptions = {}): Promise<AppItem[]> {
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  if (!isContainedInRoot(dataDir, workspaceRoot)) {
     log.warn("apps", "listItems refused: dataDir escapes workspace via symlink", { dataDir });
     return [];
   }
@@ -34,26 +80,27 @@ export async function listItems(dataDir: string): Promise<AppItem[]> {
     if (!name.endsWith(".json")) continue;
     if (name.startsWith(".")) continue;
     const filePath = path.join(dataDir, name);
-    try {
-      const raw = await readFile(filePath, "utf-8");
-      const parsed = JSON.parse(raw) as unknown;
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        results.push(parsed as AppItem);
-      }
-    } catch (err) {
-      log.warn("apps", "failed to read item, skipping", { path: filePath, error: String(err) });
+    const record = await tryReadRecord(filePath);
+    if (record === null) {
+      log.warn("apps", "skipping record (missing, symlink, or unreadable)", { path: filePath });
+      continue;
     }
+    results.push(record);
   }
   return results;
 }
 
-/** Read one record by id. Returns null when the file is missing or
- *  when the resolved path escapes the workspace via a symlink. */
-export async function readItem(dataDir: string, itemId: string): Promise<AppItem | null> {
+/** Read one record by id. Returns null when the file is missing,
+ *  when the resolved path escapes the workspace via a symlink, or
+ *  when the record file itself is a symlink (file-disclosure
+ *  defense — see `isRegularFile`). */
+export async function readItem(dataDir: string, itemId: string, opts: IoOptions = {}): Promise<AppItem | null> {
   const safeId = safeSlugName(itemId);
   if (safeId === null) return null;
-  if (!isContainedInWorkspace(dataDir)) return null;
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  if (!isContainedInRoot(dataDir, workspaceRoot)) return null;
   const filePath = itemFilePath(dataDir, safeId);
+  if (!(await isRegularFile(filePath))) return null;
   try {
     const raw = await readFile(filePath, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
@@ -68,7 +115,7 @@ export async function readItem(dataDir: string, itemId: string): Promise<AppItem
   }
 }
 
-export interface WriteItemOptions {
+export interface WriteItemOptions extends IoOptions {
   /** When true (POST/create), refuse to overwrite an existing file
    *  and return `kind: "conflict"`. Update flow (PUT) leaves it false. */
   refuseOverwrite?: boolean;
@@ -97,9 +144,19 @@ export type WriteItemResult =
 export async function writeItem(dataDir: string, itemId: string, item: AppItem, opts: WriteItemOptions = {}): Promise<WriteItemResult> {
   const safeId = safeSlugName(itemId);
   if (safeId === null) return { kind: "invalid-id", itemId };
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  // Containment check runs BEFORE mkdir so we never create
+  // directories outside the workspace even if a symlink ancestor
+  // was swapped after discovery. We re-check AFTER mkdir to catch
+  // a symlink racing in between the two — belt + suspenders, cheap
+  // and the only honest defense against TOCTOU on directory creation.
+  if (!isContainedInRoot(dataDir, workspaceRoot)) {
+    log.warn("apps", "writeItem refused: dataDir escapes workspace via symlink (pre-mkdir)", { dataDir, itemId: safeId });
+    return { kind: "path-escape", itemId: safeId };
+  }
   await mkdir(dataDir, { recursive: true });
-  if (!isContainedInWorkspace(dataDir)) {
-    log.warn("apps", "writeItem refused: dataDir escapes workspace via symlink", { dataDir, itemId: safeId });
+  if (!isContainedInRoot(dataDir, workspaceRoot)) {
+    log.warn("apps", "writeItem refused: dataDir escapes workspace via symlink (post-mkdir)", { dataDir, itemId: safeId });
     return { kind: "path-escape", itemId: safeId };
   }
   const filePath = itemFilePath(dataDir, safeId);
@@ -132,10 +189,11 @@ export type DeleteItemResult =
   | { kind: "not-found"; itemId: string }
   | { kind: "path-escape"; itemId: string };
 
-export async function deleteItem(dataDir: string, itemId: string): Promise<DeleteItemResult> {
+export async function deleteItem(dataDir: string, itemId: string, opts: IoOptions = {}): Promise<DeleteItemResult> {
   const safeId = safeSlugName(itemId);
   if (safeId === null) return { kind: "invalid-id", itemId };
-  if (!isContainedInWorkspace(dataDir)) {
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  if (!isContainedInRoot(dataDir, workspaceRoot)) {
     log.warn("apps", "deleteItem refused: dataDir escapes workspace via symlink", { dataDir, itemId: safeId });
     return { kind: "path-escape", itemId: safeId };
   }

--- a/server/workspace/apps/paths.ts
+++ b/server/workspace/apps/paths.ts
@@ -3,6 +3,7 @@
 // `js/path-injection` sanitiser recognises our taint-launder.
 
 import path from "node:path";
+import { realpathSync } from "node:fs";
 import { workspacePath } from "../workspace.js";
 
 export const SCHEMA_FILE = "schema.json";
@@ -26,18 +27,72 @@ export function safeSlugName(slug: string): string | null {
   return basename;
 }
 
+/** Realpath the closest existing ancestor of `absPath` and return it.
+ *  Returns null if no ancestor exists or if the realpath call fails
+ *  for a non-ENOENT reason (permissions, etc.). Used by
+ *  `containedPath` to defend against symlinks pointing outside the
+ *  workspace even when the leaf hasn't been created yet. */
+function realpathClosestAncestor(absPath: string): string | null {
+  let cursor = absPath;
+  while (cursor !== path.dirname(cursor)) {
+    try {
+      return realpathSync(cursor);
+    } catch (err) {
+      const error = err as { code?: string };
+      if (error.code === "ENOENT") {
+        cursor = path.dirname(cursor);
+        continue;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+/** True iff the realpath'd closest existing ancestor of `absPath`
+ *  resolves under `rootPath`'s realpath. Pure helper, takes both
+ *  paths explicitly so tests can drive it against a `mkdtempSync`
+ *  root without touching the user's workspace. Defends against the
+ *  data dir or any ancestor being a symlink to a directory outside
+ *  the workspace — lexical-only checks (`path.resolve` + prefix
+ *  match) would miss this case, which is the class of bug the rest
+ *  of this codebase uses realpath-based containment to avoid (see
+ *  `server/utils/files/safe.ts#resolveWithinRoot`). */
+export function isContainedInRoot(absPath: string, rootPath: string): boolean {
+  let rootReal: string;
+  try {
+    rootReal = realpathSync(rootPath);
+  } catch {
+    return false;
+  }
+  const ancestorReal = realpathClosestAncestor(absPath);
+  if (ancestorReal === null) return false;
+  if (ancestorReal === rootReal) return true;
+  return ancestorReal.startsWith(rootReal + path.sep);
+}
+
+/** Workspace-bound convenience over `isContainedInRoot`. Production
+ *  callers use this; the tests exercise the pure helper. */
+export function isContainedInWorkspace(absPath: string): boolean {
+  return isContainedInRoot(absPath, workspacePath);
+}
+
 /** Resolve a schema-declared dataPath against the workspace root,
- *  refusing anything that escapes (absolute paths, `..`-segments,
- *  empty string). Returns the absolute path on success, null on
- *  refusal. Does NOT require the directory to exist — the caller may
- *  create it on first write. */
+ *  refusing anything that escapes — absolute paths, `..`-segments,
+ *  empty string, or symlinks pointing outside the workspace.
+ *  Returns the absolute path on success, null on refusal. Does NOT
+ *  require the directory to exist; the caller may create it on first
+ *  write. The realpath containment check covers the symlink case at
+ *  discovery time; io operations re-check before each write via
+ *  `isContainedInWorkspace` to defend against symlinks introduced
+ *  between discovery and use. */
 export function resolveDataDir(dataPath: string): string | null {
   if (typeof dataPath !== "string" || dataPath.length === 0) return null;
   if (path.isAbsolute(dataPath)) return null;
   const normalized = path.normalize(dataPath);
   if (normalized.startsWith("..") || normalized.includes(`${path.sep}..${path.sep}`)) return null;
   const resolved = path.resolve(workspacePath, normalized);
-  if (resolved !== workspacePath && !resolved.startsWith(workspacePath + path.sep)) return null;
+  if (!isContainedInWorkspace(resolved)) return null;
   return resolved;
 }
 

--- a/server/workspace/apps/paths.ts
+++ b/server/workspace/apps/paths.ts
@@ -1,0 +1,49 @@
+// Path helpers + safe-slug guard for the apps module. Mirrors the
+// pattern used by `server/workspace/skills/catalog.ts` so CodeQL's
+// `js/path-injection` sanitiser recognises our taint-launder.
+
+import path from "node:path";
+import { workspacePath } from "../workspace.js";
+
+export const SCHEMA_FILE = "schema.json";
+
+// Same regex as `server/workspace/skills/catalog.ts#SAFE_SLUG_PATTERN`
+// — keep them in sync. Bounded character classes, no nested
+// quantifiers; ReDoS-safe.
+// eslint-disable-next-line security/detect-unsafe-regex -- non-overlapping character classes, no catastrophic backtracking
+const SAFE_SLUG_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?$/;
+
+/** Sanitise a user-supplied slug into a safe directory-name leaf.
+ *  Returns null for anything that fails the slug whitelist OR isn't a
+ *  basename (i.e. survives `path.basename` round-trip unchanged).
+ *  The basename round-trip is the pattern CodeQL recognises as a
+ *  `js/path-injection` sanitiser. */
+export function safeSlugName(slug: string): string | null {
+  if (typeof slug !== "string") return null;
+  if (!SAFE_SLUG_PATTERN.test(slug)) return null;
+  const basename = path.basename(slug);
+  if (basename !== slug) return null;
+  return basename;
+}
+
+/** Resolve a schema-declared dataPath against the workspace root,
+ *  refusing anything that escapes (absolute paths, `..`-segments,
+ *  empty string). Returns the absolute path on success, null on
+ *  refusal. Does NOT require the directory to exist — the caller may
+ *  create it on first write. */
+export function resolveDataDir(dataPath: string): string | null {
+  if (typeof dataPath !== "string" || dataPath.length === 0) return null;
+  if (path.isAbsolute(dataPath)) return null;
+  const normalized = path.normalize(dataPath);
+  if (normalized.startsWith("..") || normalized.includes(`${path.sep}..${path.sep}`)) return null;
+  const resolved = path.resolve(workspacePath, normalized);
+  if (resolved !== workspacePath && !resolved.startsWith(workspacePath + path.sep)) return null;
+  return resolved;
+}
+
+/** Compose the absolute path to a single record file. Both arguments
+ *  must have been passed through `safeSlugName` / `resolveDataDir`
+ *  before reaching here so the join can't escape. */
+export function itemFilePath(dataDir: string, itemId: string): string {
+  return path.join(dataDir, `${itemId}.json`);
+}

--- a/server/workspace/apps/types.ts
+++ b/server/workspace/apps/types.ts
@@ -1,0 +1,50 @@
+// Schema-driven app types. An "app" is a skill (under
+// .claude/skills/<slug>/) that also ships a sibling `schema.json`.
+// The host's CollectionView reads the schema + records and renders a
+// table/form; Claude reads SKILL.md and CRUDs the records as JSON
+// files.
+//
+// Field types for v0 — keep this list narrow and grow it only when a
+// real app needs the new type. v0 supports flat records only; nested
+// tables / cross-collection refs / derived fields / actions are
+// deferred to follow-ups (see plans/feat-skill-driven-apps.md).
+
+export type AppFieldType = "string" | "text" | "email" | "number" | "date" | "markdown";
+
+export type AppSource = "user" | "project";
+
+export interface AppFieldSpec {
+  type: AppFieldType;
+  label: string;
+  /** True for the field whose value is the record's filename (no
+   *  separate auto-id). Exactly one field per schema may set this. */
+  primary?: boolean;
+  required?: boolean;
+}
+
+export interface AppSchema {
+  /** Human-facing app name (sidebar, header). */
+  title: string;
+  /** Material-icon name shown next to the title. */
+  icon: string;
+  /** Workspace-relative folder holding one-JSON-per-record. Validated
+   *  to live under the workspace root at load time. */
+  dataPath: string;
+  /** Field name whose value doubles as the record's filename. */
+  primaryKey: string;
+  /** Ordered map: insertion order = column order in the table view. */
+  fields: Record<string, AppFieldSpec>;
+}
+
+export interface AppSummary {
+  slug: string;
+  title: string;
+  icon: string;
+  source: AppSource;
+}
+
+export interface AppDetail extends AppSummary {
+  schema: AppSchema;
+}
+
+export type AppItem = Record<string, unknown>;

--- a/server/workspace/skills-preset.ts
+++ b/server/workspace/skills-preset.ts
@@ -25,6 +25,26 @@ import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } fr
 import path from "node:path";
 import { errorMessage } from "../utils/errors.js";
 
+// Recursively mirror `srcDir` into `destDir`. Used by the preset
+// sync so a preset skill that ships sibling assets (e.g.
+// `schema.json` for schema-driven apps, `templates/*.html`) gets
+// copied alongside `SKILL.md` rather than silently dropped. Only
+// regular files and directories are followed — symlinks / FIFOs /
+// sockets are skipped because the preset tree is launcher-managed
+// and shouldn't contain them.
+function copyDirTreeSync(srcDir: string, destDir: string): void {
+  mkdirSync(destDir, { recursive: true });
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirTreeSync(srcPath, destPath);
+    } else if (entry.isFile()) {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
 const PRESET_SLUG_PREFIX = "mc-";
 const SKILL_FILENAME = "SKILL.md";
 
@@ -128,7 +148,14 @@ function copySourcesIntoDest(sourceDir: string, destDir: string, opts: SyncPrese
       opts.onWarn?.("preset entry skipped", { slug: entry, reason, destSlugDir });
       continue;
     }
-    copyFileSync(path.join(sourceDir, entry, SKILL_FILENAME), path.join(destSlugDir, SKILL_FILENAME));
+    // Wipe-and-replace so stale sibling assets (e.g. a schema.json
+    // dropped between releases) don't linger. The catalog preset
+    // slot is launcher-owned per the file header; user edits here
+    // are not preserved across boots. SKILL.md alone would survive
+    // the legacy single-file copy, but schema-driven apps and
+    // template-bearing skills need the full tree to be authoritative.
+    rmSync(destSlugDir, { recursive: true, force: true });
+    copyDirTreeSync(path.join(sourceDir, entry), destSlugDir);
     synced.add(entry);
     result.copied.push(entry);
   }

--- a/server/workspace/skills-preset/mc-clients/SKILL.md
+++ b/server/workspace/skills-preset/mc-clients/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: mc-clients
+description: A simple client database. Use whenever the user asks to add, list, update, or delete a client. Skill files live at `.claude/skills/mc-clients/` (SKILL.md + schema.json); records live at `data/clients/items/<id>.json` (one JSON file per client). The user views the records at `/apps/mc-clients`, rendered from the schema by the host — you do all I/O via Read / Write / Edit on the JSON files.
+---
+
+# Clients (schema-driven app)
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+## Files
+
+| Purpose | Path |
+|---|---|
+| This skill's instructions (you are reading it) | `.claude/skills/mc-clients/SKILL.md` |
+| Field schema (source of truth for the host UI) | `.claude/skills/mc-clients/schema.json` |
+| Records — one JSON per client | `data/clients/items/<id>.json` |
+| User-visible app surface | `/apps/mc-clients` (in the host UI) |
+
+You write JSON; the host's `<AppCollectionView>` reads the same files and
+renders a table + form. There is no separate database — the workspace IS the
+database.
+
+## Record shape
+
+The schema declares these fields (read `schema.json` for the authoritative
+types):
+
+- `id` — string, **primary key** (the filename, no extension)
+- `name` — string, **required**
+- `email` — email
+- `address` — multi-line text
+- `notes` — markdown
+
+`id` is a short kebab-case slug derived from the client name (e.g. `acme-corp`,
+`globex`). Lowercase letters, digits, hyphens; 1–48 chars. Pick a fresh suffix
+(`acme-corp-2`) if the obvious slug is already taken. Don't push for fields
+the user hasn't given you — leave optional fields out of the JSON entirely.
+
+## What to do
+
+**Add**: derive an `id`, build the record, write to
+`data/clients/items/<id>.json` via the `Write` tool. List the directory first
+and pick a fresh slug if the file already exists — don't silently overwrite.
+
+**List / look up**: read `data/clients/items/` and answer from those files.
+Don't recite the whole table in chat — the user can see it at
+`/apps/mc-clients`. A one-line confirmation ("Added Acme Corp.") is enough.
+
+**Update**: read the record, merge changes, write it back. Preserve fields
+you weren't asked to change.
+
+**Delete**: confirm with the user once if the request is ambiguous, then
+remove the file.
+
+## When to ask vs. when to act
+
+If the user gives you a name and an email in one sentence, just add the
+client. Use `presentForm` only when you genuinely need information they
+haven't provided — don't use it to re-confirm values they already typed.

--- a/server/workspace/skills-preset/mc-clients/schema.json
+++ b/server/workspace/skills-preset/mc-clients/schema.json
@@ -1,0 +1,31 @@
+{
+  "title": "Clients",
+  "icon": "people",
+  "dataPath": "data/clients/items",
+  "primaryKey": "id",
+  "fields": {
+    "id": {
+      "type": "string",
+      "label": "ID",
+      "primary": true,
+      "required": true
+    },
+    "name": {
+      "type": "string",
+      "label": "Name",
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "label": "Email"
+    },
+    "address": {
+      "type": "text",
+      "label": "Address"
+    },
+    "notes": {
+      "type": "markdown",
+      "label": "Notes"
+    }
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -221,6 +221,13 @@
           <RolesView v-else-if="currentPage === 'roles'" />
           <SourcesView v-else-if="currentPage === 'sources'" />
           <NewsView v-else-if="currentPage === 'news'" />
+          <!-- Schema-driven apps. The route is `/apps/:slug?`; with
+               a slug we mount the CollectionView, without one we
+               mount the index. Both are host components (no
+               PluginScopedRoot needed) — they call the host's
+               /api/apps endpoints directly. -->
+          <AppCollectionView v-else-if="currentPage === 'apps' && route.params.slug" :key="String(route.params.slug)" />
+          <AppsIndexView v-else-if="currentPage === 'apps'" />
           <!-- Debug page (encore plan PR 1 follow-up). The View ships
                inside the @mulmoclaude/debug-plugin runtime package; we
                look it up by tool name and render the registered
@@ -331,6 +338,8 @@ import SkillsView from "./plugins/manageSkills/View.vue";
 import RolesView from "./components/RolesView.vue";
 import SourcesView from "./components/SourcesView.vue";
 import NewsView from "./components/NewsView.vue";
+import AppsIndexView from "./components/AppsIndexView.vue";
+import AppCollectionView from "./components/AppCollectionView.vue";
 import PluginScopedRoot from "./components/PluginScopedRoot.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import { PAGE_ROUTES, type PageRouteName } from "./router";

--- a/src/components/AppCollectionView.vue
+++ b/src/components/AppCollectionView.vue
@@ -85,7 +85,7 @@
           </h2>
           <button
             type="button"
-            class="h-7 w-7 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100"
+            class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100"
             :aria-label="t('common.close')"
             data-testid="apps-editor-close"
             @click="closeEditor"
@@ -310,6 +310,11 @@ function draftToRecord(state: EditState, schema: AppSchema): AppItem {
 
 async function saveEditor(): Promise<void> {
   if (!app.value || !editing.value) return;
+  // Snapshot mutable refs before any await — route changes during
+  // the save (e.g. user navigates away) can null `app.value` and
+  // would throw on the post-await `loadApp(app.value.slug)`.
+  const { slug, schema } = app.value;
+  const draft = editing.value;
   saveError.value = null;
 
   // Client-side required-field check — server doesn't enforce. Skip
@@ -318,33 +323,37 @@ async function saveEditor(): Promise<void> {
   // documented "blank → server-generated id" flow even for schemas
   // (like mc-clients) that mark the primary field `required: true`
   // for the edit-form-displays-it-as-a-real-field reason.
-  for (const [key, field] of Object.entries(app.value.schema.fields)) {
+  for (const [key, field] of Object.entries(schema.fields)) {
     if (!field.required) continue;
-    if (editing.value.mode === "create" && field.primary === true) continue;
-    if (!editing.value.draft[key]) {
+    if (draft.mode === "create" && field.primary === true) continue;
+    if (!draft.draft[key]) {
       saveError.value = `${field.label}: ${t("appsView.requiredField")}`;
       return;
     }
   }
 
   saving.value = true;
-  const record = draftToRecord(editing.value, app.value.schema);
-  const isCreate = editing.value.mode === "create";
+  const record = draftToRecord(draft, schema);
+  const isCreate = draft.mode === "create";
   const result = isCreate
-    ? await apiPost<ItemMutationResponse>(itemsUrl(app.value.slug), record)
-    : await apiPut<ItemMutationResponse>(itemUrl(app.value.slug, editing.value.originalId ?? ""), record);
+    ? await apiPost<ItemMutationResponse>(itemsUrl(slug), record)
+    : await apiPut<ItemMutationResponse>(itemUrl(slug, draft.originalId ?? ""), record);
   saving.value = false;
   if (!result.ok) {
     saveError.value = result.error;
     return;
   }
   closeEditor();
-  await loadApp(app.value.slug);
+  await loadApp(slug);
 }
 
 async function confirmDelete(item: AppItem): Promise<void> {
   if (!app.value) return;
-  const idRaw = item[app.value.schema.primaryKey];
+  // Snapshot before any await (see saveEditor) — confirm dialog
+  // awaits user input, plenty of time for the route to change.
+  const { slug } = app.value;
+  const { primaryKey } = app.value.schema;
+  const idRaw = item[primaryKey];
   const itemId = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
   if (!itemId) return;
   const ok = await openConfirm({
@@ -354,12 +363,12 @@ async function confirmDelete(item: AppItem): Promise<void> {
     variant: "danger",
   });
   if (!ok) return;
-  const result = await apiDelete(itemUrl(app.value.slug, itemId));
+  const result = await apiDelete(itemUrl(slug, itemId));
   if (!result.ok) {
     loadError.value = result.error;
     return;
   }
-  await loadApp(app.value.slug);
+  await loadApp(slug);
 }
 
 function goBack(): void {

--- a/src/components/AppCollectionView.vue
+++ b/src/components/AppCollectionView.vue
@@ -1,0 +1,372 @@
+<template>
+  <div class="h-full flex flex-col">
+    <header class="flex items-center gap-3 px-6 py-4 border-b border-gray-200 bg-white">
+      <button
+        type="button"
+        class="h-8 w-8 flex items-center justify-center rounded text-gray-500 hover:bg-gray-100"
+        :title="t('appsView.backToIndex')"
+        :aria-label="t('appsView.backToIndex')"
+        data-testid="apps-back"
+        @click="goBack"
+      >
+        <span class="material-icons text-base">arrow_back</span>
+      </button>
+      <span v-if="app" class="material-icons text-blue-600">{{ app.icon }}</span>
+      <h1 class="text-lg font-medium text-gray-900 flex-1 min-w-0 truncate">
+        {{ app?.title ?? t("appsView.title") }}
+      </h1>
+      <button
+        v-if="app"
+        type="button"
+        class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm"
+        data-testid="apps-add-item"
+        @click="openCreate"
+      >
+        <span class="material-icons text-base">add</span>
+        <span>{{ t("common.add") }}</span>
+      </button>
+    </header>
+
+    <div class="flex-1 overflow-auto">
+      <div v-if="loading" class="p-6 text-sm text-gray-500">{{ t("common.loading") }}</div>
+
+      <div v-else-if="loadError" class="m-6 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+        {{ loadError === "not-found" ? t("appsView.appNotFound") : `${t("appsView.loadFailed")}: ${loadError}` }}
+      </div>
+
+      <div v-else-if="!app">
+        <!-- defensive: loading=false, error=null, app=null -->
+      </div>
+
+      <div v-else-if="items.length === 0" class="p-6 text-sm text-gray-500">{{ t("appsView.itemsEmpty") }}</div>
+
+      <table v-else class="min-w-full text-sm">
+        <thead class="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+          <tr>
+            <th v-for="(field, key) in app.schema.fields" :key="key" class="px-4 py-2 font-medium">{{ field.label }}</th>
+            <th class="px-4 py-2 font-medium w-px"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100">
+          <tr v-for="item in items" :key="String(item[app.schema.primaryKey] ?? '')" class="hover:bg-gray-50">
+            <td v-for="(field, key) in app.schema.fields" :key="key" class="px-4 py-2 text-gray-800 align-top max-w-xs">
+              <span class="block truncate">{{ formatCell(item[key], field.type) }}</span>
+            </td>
+            <td class="px-4 py-2 text-right whitespace-nowrap">
+              <button
+                type="button"
+                class="text-xs text-blue-600 hover:underline mr-3"
+                :data-testid="`apps-edit-item-${item[app.schema.primaryKey]}`"
+                @click="openEdit(item)"
+              >
+                {{ t("appsView.editItem") }}
+              </button>
+              <button
+                type="button"
+                class="text-xs text-red-600 hover:underline"
+                :data-testid="`apps-delete-item-${item[app.schema.primaryKey]}`"
+                @click="confirmDelete(item)"
+              >
+                {{ t("common.remove") }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Edit / Create modal -->
+    <div v-if="editing && app" class="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-4" @click.self="closeEditor">
+      <div class="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[80vh] flex flex-col">
+        <header class="px-5 py-3 border-b border-gray-200 flex items-center gap-3">
+          <span class="material-icons text-blue-600 text-base">{{ editing.mode === "create" ? "add" : "edit" }}</span>
+          <h2 class="text-base font-medium text-gray-900 flex-1">
+            {{ editing.mode === "create" ? `${t("common.add")} — ${app.title}` : `${t("appsView.editItem")} — ${app.title}` }}
+          </h2>
+          <button
+            type="button"
+            class="h-7 w-7 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100"
+            :aria-label="t('common.close')"
+            data-testid="apps-editor-close"
+            @click="closeEditor"
+          >
+            <span class="material-icons text-base">close</span>
+          </button>
+        </header>
+
+        <form class="flex-1 overflow-auto px-5 py-4 space-y-3" @submit.prevent="saveEditor">
+          <div v-for="(field, key) in app.schema.fields" :key="key" class="space-y-1">
+            <label class="text-xs font-medium text-gray-700 flex items-center gap-1" :for="`apps-field-${key}`">
+              {{ field.label }}
+              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
+              <span v-if="field.required" class="text-red-500">*</span>
+            </label>
+            <input
+              v-if="['string', 'email', 'number', 'date'].includes(field.type)"
+              :id="`apps-field-${key}`"
+              v-model="editing.draft[key]"
+              :type="inputTypeFor(field.type)"
+              :required="field.required"
+              :disabled="field.primary === true && editing.mode === 'edit'"
+              class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
+              :data-testid="`apps-input-${key}`"
+            />
+            <textarea
+              v-else
+              :id="`apps-field-${key}`"
+              v-model="editing.draft[key]"
+              :rows="field.type === 'markdown' ? 6 : 3"
+              :required="field.required"
+              class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+              :data-testid="`apps-input-${key}`"
+            />
+          </div>
+          <p v-if="saveError" class="text-sm text-red-700">{{ saveError }}</p>
+        </form>
+
+        <footer class="px-5 py-3 border-t border-gray-200 flex items-center justify-end gap-2">
+          <button type="button" class="h-8 px-3 rounded text-sm text-gray-700 hover:bg-gray-100" data-testid="apps-editor-cancel" @click="closeEditor">
+            {{ t("common.cancel") }}
+          </button>
+          <button
+            type="button"
+            class="h-8 px-3 rounded bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-50"
+            :disabled="saving"
+            data-testid="apps-editor-save"
+            @click="saveEditor"
+          >
+            {{ saving ? t("common.saving") : t("common.save") }}
+          </button>
+        </footer>
+      </div>
+    </div>
+
+    <ConfirmModal />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
+import { apiDelete, apiGet, apiPost, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+import { PAGE_ROUTES } from "../router/pageRoutes";
+import ConfirmModal from "./ConfirmModal.vue";
+import { useConfirm } from "../composables/useConfirm";
+
+type FieldType = "string" | "text" | "email" | "number" | "date" | "markdown";
+
+interface FieldSpec {
+  type: FieldType;
+  label: string;
+  primary?: boolean;
+  required?: boolean;
+}
+
+interface AppSchema {
+  title: string;
+  icon: string;
+  dataPath: string;
+  primaryKey: string;
+  fields: Record<string, FieldSpec>;
+}
+
+interface AppDetail {
+  slug: string;
+  title: string;
+  icon: string;
+  source: "user" | "project";
+  schema: AppSchema;
+}
+
+type AppItem = Record<string, unknown>;
+
+interface AppDetailResponse {
+  app: AppDetail;
+  items: AppItem[];
+}
+
+interface ItemMutationResponse {
+  itemId: string;
+  item: AppItem;
+}
+
+interface EditState {
+  mode: "create" | "edit";
+  draft: Record<string, string>;
+  /** For edit mode: the original item id pinned to the URL. */
+  originalId: string | null;
+}
+
+const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+const { openConfirm } = useConfirm();
+
+const app = ref<AppDetail | null>(null);
+const items = ref<AppItem[]>([]);
+const loading = ref(true);
+const loadError = ref<string | null>(null);
+const editing = ref<EditState | null>(null);
+const saving = ref(false);
+const saveError = ref<string | null>(null);
+
+function detailUrl(slug: string): string {
+  return API_ROUTES.apps.detail.replace(":slug", encodeURIComponent(slug));
+}
+
+function itemsUrl(slug: string): string {
+  return API_ROUTES.apps.items.replace(":slug", encodeURIComponent(slug));
+}
+
+function itemUrl(slug: string, itemId: string): string {
+  return API_ROUTES.apps.item.replace(":slug", encodeURIComponent(slug)).replace(":itemId", encodeURIComponent(itemId));
+}
+
+async function loadApp(slug: string): Promise<void> {
+  loading.value = true;
+  loadError.value = null;
+  app.value = null;
+  items.value = [];
+  const result = await apiGet<AppDetailResponse>(detailUrl(slug));
+  loading.value = false;
+  if (!result.ok) {
+    loadError.value = result.status === 404 ? "not-found" : result.error;
+    return;
+  }
+  app.value = result.data.app;
+  items.value = result.data.items;
+}
+
+function inputTypeFor(type: FieldType): string {
+  if (type === "email") return "email";
+  if (type === "number") return "number";
+  if (type === "date") return "date";
+  return "text";
+}
+
+function formatCell(value: unknown, type: FieldType): string {
+  if (value === undefined || value === null || value === "") return "—";
+  if (type === "markdown" && typeof value === "string") {
+    return value.length > 80 ? `${value.slice(0, 80)}…` : value;
+  }
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  return JSON.stringify(value);
+}
+
+function openCreate(): void {
+  if (!app.value) return;
+  const draft: Record<string, string> = {};
+  for (const key of Object.keys(app.value.schema.fields)) draft[key] = "";
+  editing.value = { mode: "create", draft, originalId: null };
+  saveError.value = null;
+}
+
+function openEdit(item: AppItem): void {
+  if (!app.value) return;
+  const draft: Record<string, string> = {};
+  for (const key of Object.keys(app.value.schema.fields)) {
+    const raw = item[key];
+    draft[key] = raw === undefined || raw === null ? "" : String(raw);
+  }
+  const primaryRaw = item[app.value.schema.primaryKey];
+  const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
+  editing.value = { mode: "edit", draft, originalId };
+  saveError.value = null;
+}
+
+function closeEditor(): void {
+  editing.value = null;
+  saving.value = false;
+  saveError.value = null;
+}
+
+function draftToRecord(state: EditState, schema: AppSchema): AppItem {
+  const record: AppItem = {};
+  for (const [key, field] of Object.entries(schema.fields)) {
+    const raw = state.draft[key];
+    if (raw === undefined || raw === "") continue;
+    if (field.type === "number") {
+      const num = Number(raw);
+      record[key] = Number.isFinite(num) ? num : raw;
+    } else {
+      record[key] = raw;
+    }
+  }
+  return record;
+}
+
+async function saveEditor(): Promise<void> {
+  if (!app.value || !editing.value) return;
+  saveError.value = null;
+
+  // client-side required-field check — server doesn't enforce.
+  for (const [key, field] of Object.entries(app.value.schema.fields)) {
+    if (field.required && !editing.value.draft[key]) {
+      saveError.value = `${field.label}: ${t("appsView.requiredField")}`;
+      return;
+    }
+  }
+
+  saving.value = true;
+  const record = draftToRecord(editing.value, app.value.schema);
+  const isCreate = editing.value.mode === "create";
+  const result = isCreate
+    ? await apiPost<ItemMutationResponse>(itemsUrl(app.value.slug), record)
+    : await apiPut<ItemMutationResponse>(itemUrl(app.value.slug, editing.value.originalId ?? ""), record);
+  saving.value = false;
+  if (!result.ok) {
+    saveError.value = result.error;
+    return;
+  }
+  closeEditor();
+  await loadApp(app.value.slug);
+}
+
+async function confirmDelete(item: AppItem): Promise<void> {
+  if (!app.value) return;
+  const idRaw = item[app.value.schema.primaryKey];
+  const itemId = typeof idRaw === "string" ? idRaw : String(idRaw ?? "");
+  if (!itemId) return;
+  const ok = await openConfirm({
+    message: t("appsView.confirmDelete"),
+    confirmText: t("common.remove"),
+    cancelText: t("common.cancel"),
+    variant: "danger",
+  });
+  if (!ok) return;
+  const result = await apiDelete(itemUrl(app.value.slug, itemId));
+  if (!result.ok) {
+    loadError.value = result.error;
+    return;
+  }
+  await loadApp(app.value.slug);
+}
+
+function goBack(): void {
+  router.push({ name: PAGE_ROUTES.apps, params: {} }).catch(() => {});
+}
+
+watch(
+  () => route.params.slug,
+  (slug) => {
+    if (typeof slug === "string" && slug.length > 0) {
+      loadApp(slug);
+    } else {
+      app.value = null;
+      items.value = [];
+      loading.value = false;
+    }
+  },
+);
+
+onMounted(() => {
+  const { slug } = route.params;
+  if (typeof slug === "string" && slug.length > 0) {
+    loadApp(slug);
+  } else {
+    loading.value = false;
+  }
+});
+</script>

--- a/src/components/AppCollectionView.vue
+++ b/src/components/AppCollectionView.vue
@@ -106,7 +106,7 @@
               :id="`apps-field-${key}`"
               v-model="editing.draft[key]"
               :type="inputTypeFor(field.type)"
-              :required="field.required"
+              :required="isFieldRequiredInUi(field)"
               :disabled="field.primary === true && editing.mode === 'edit'"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
               :data-testid="`apps-input-${key}`"
@@ -116,7 +116,7 @@
               :id="`apps-field-${key}`"
               v-model="editing.draft[key]"
               :rows="field.type === 'markdown' ? 6 : 3"
-              :required="field.required"
+              :required="isFieldRequiredInUi(field)"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
               :data-testid="`apps-input-${key}`"
             />
@@ -246,6 +246,17 @@ function inputTypeFor(type: FieldType): string {
   return "text";
 }
 
+/** Mirror of the create-mode primary-key carve-out in `saveEditor`:
+ *  drop the HTML5 `required` flag on the primary field while creating
+ *  so browser-level form validation doesn't pop a "Please fill out
+ *  this field" tooltip when the user is intentionally leaving the
+ *  primary blank for server-side ID generation. */
+function isFieldRequiredInUi(field: FieldSpec): boolean {
+  if (!field.required) return false;
+  if (editing.value?.mode === "create" && field.primary === true) return false;
+  return true;
+}
+
 function formatCell(value: unknown, type: FieldType): string {
   if (value === undefined || value === null || value === "") return "—";
   if (type === "markdown" && typeof value === "string") {
@@ -301,9 +312,16 @@ async function saveEditor(): Promise<void> {
   if (!app.value || !editing.value) return;
   saveError.value = null;
 
-  // client-side required-field check — server doesn't enforce.
+  // Client-side required-field check — server doesn't enforce. Skip
+  // the primary key in create mode: the server auto-generates an id
+  // when the field is blank, so blocking here would deny the
+  // documented "blank → server-generated id" flow even for schemas
+  // (like mc-clients) that mark the primary field `required: true`
+  // for the edit-form-displays-it-as-a-real-field reason.
   for (const [key, field] of Object.entries(app.value.schema.fields)) {
-    if (field.required && !editing.value.draft[key]) {
+    if (!field.required) continue;
+    if (editing.value.mode === "create" && field.primary === true) continue;
+    if (!editing.value.draft[key]) {
       saveError.value = `${field.label}: ${t("appsView.requiredField")}`;
       return;
     }

--- a/src/components/AppsIndexView.vue
+++ b/src/components/AppsIndexView.vue
@@ -23,7 +23,7 @@
             <span class="material-icons text-blue-600">{{ app.icon }}</span>
             <span class="flex-1 min-w-0">
               <span class="block font-medium text-gray-900 truncate">{{ app.title }}</span>
-              <span class="block text-[11px] uppercase tracking-wide text-gray-400">{{ app.source }} · {{ app.slug }}</span>
+              <span class="block text-[11px] uppercase tracking-wide text-gray-400">{{ t(`appsView.source.${app.source}`) }} · {{ app.slug }}</span>
             </span>
             <span class="material-icons text-gray-400 text-base">chevron_right</span>
           </button>

--- a/src/components/AppsIndexView.vue
+++ b/src/components/AppsIndexView.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="h-full overflow-y-auto p-6">
+    <div class="max-w-3xl mx-auto">
+      <h1 class="text-xl font-medium text-gray-900 mb-4">{{ t("appsView.title") }}</h1>
+
+      <div v-if="loading" class="text-sm text-gray-500">{{ t("common.loading") }}</div>
+
+      <div v-else-if="loadError" class="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+        {{ t("appsView.loadFailed") }}: {{ loadError }}
+      </div>
+
+      <div v-else-if="apps.length === 0" class="rounded border border-gray-200 bg-gray-50 px-4 py-6 text-sm text-gray-600">
+        {{ t("appsView.indexEmpty") }}
+      </div>
+
+      <ul v-else class="grid gap-2 sm:grid-cols-2">
+        <li v-for="app in apps" :key="app.slug">
+          <button
+            class="w-full text-left rounded border border-gray-200 bg-white hover:border-blue-300 hover:bg-blue-50 transition-colors px-4 py-3 flex items-center gap-3"
+            :data-testid="`apps-index-card-${app.slug}`"
+            @click="openApp(app.slug)"
+          >
+            <span class="material-icons text-blue-600">{{ app.icon }}</span>
+            <span class="flex-1 min-w-0">
+              <span class="block font-medium text-gray-900 truncate">{{ app.title }}</span>
+              <span class="block text-[11px] uppercase tracking-wide text-gray-400">{{ app.source }} · {{ app.slug }}</span>
+            </span>
+            <span class="material-icons text-gray-400 text-base">chevron_right</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+import { PAGE_ROUTES } from "../router/pageRoutes";
+
+interface AppSummary {
+  slug: string;
+  title: string;
+  icon: string;
+  source: "user" | "project";
+}
+
+interface AppsListResponse {
+  apps: AppSummary[];
+}
+
+const { t } = useI18n();
+const router = useRouter();
+
+const apps = ref<AppSummary[]>([]);
+const loading = ref(true);
+const loadError = ref<string | null>(null);
+
+async function loadApps(): Promise<void> {
+  loading.value = true;
+  loadError.value = null;
+  const result = await apiGet<AppsListResponse>(API_ROUTES.apps.list);
+  loading.value = false;
+  if (!result.ok) {
+    loadError.value = result.error;
+    return;
+  }
+  apps.value = result.data.apps;
+}
+
+function openApp(slug: string): void {
+  router.push({ name: PAGE_ROUTES.apps, params: { slug } }).catch(() => {});
+}
+
+onMounted(loadApps);
+</script>

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -53,7 +53,7 @@ import { useI18n } from "vue-i18n";
 import { useConfirm } from "../composables/useConfirm";
 
 const { confirmState, handleConfirm } = useConfirm();
-const { locale } = useI18n();
+const { t } = useI18n();
 
 const confirmBtn = ref<HTMLButtonElement | null>(null);
 const cancelBtn = ref<HTMLButtonElement | null>(null);
@@ -64,68 +64,15 @@ const iconName = computed(() => {
   return "info";
 });
 
-const defaultTitle = computed(() => {
-  switch (locale.value) {
-    case "ja":
-      return "確認";
-    case "ko":
-      return "확인";
-    case "zh":
-      return "确认";
-    case "es":
-      return "Confirmar";
-    case "de":
-      return "Bestätigen";
-    case "fr":
-      return "Confirmer";
-    case "pt-BR":
-      return "Confirmar";
-    default:
-      return "Confirm";
-  }
-});
-
-const defaultConfirmText = computed(() => {
-  switch (locale.value) {
-    case "ja":
-      return "実行";
-    case "ko":
-      return "확인";
-    case "zh":
-      return "确定";
-    case "es":
-      return "Aceptar";
-    case "de":
-      return "Bestätigen";
-    case "fr":
-      return "Confirmer";
-    case "pt-BR":
-      return "Confirmar";
-    default:
-      return "Confirm";
-  }
-});
-
-const defaultCancelText = computed(() => {
-  switch (locale.value) {
-    case "ja":
-      return "キャンセル";
-    case "ko":
-      return "취소";
-    case "zh":
-      return "取消";
-    case "es":
-      return "Cancelar";
-    case "de":
-      return "Abbrechen";
-    case "fr":
-      return "Annuler";
-    case "pt-BR":
-      return "Cancelar";
-    default:
-      return "Cancel";
-  }
-});
+// Defensive fallbacks for callers that omit title / confirmText /
+// cancelText. The host translates per-call via the i18n bundle
+// (`confirmModal.*` namespace in `src/lang/*.ts`) rather than the
+// locale-switch the plugin-side shared component still uses; once
+// the host/plugin runtime split is reconciled we can drop the dual
+// implementation entirely.
+const defaultTitle = computed(() => t("confirmModal.defaultTitle"));
+const defaultConfirmText = computed(() => t("confirmModal.defaultConfirm"));
+const defaultCancelText = computed(() => t("confirmModal.defaultCancel"));
 
 function onKeyDown(event: KeyboardEvent): void {
   if (!confirmState.value.isOpen) return;

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -1,0 +1,393 @@
+<!-- Host-side confirm dialog. Mirror of
+     `packages/plugins/shared/components/ConfirmModal.vue` with two
+     intentional deltas:
+       - Locale via vue-i18n's `useI18n` rather than the plugin
+         runtime's `useRuntime` (this component mounts in host code,
+         outside any PluginScopedRoot).
+       - Header iconography uses Material Icons (host convention,
+         see CLAUDE.md UI-controls rule) rather than emoji glyphs.
+     Composable + state interface stays identical so the two can be
+     unified the day the host/plugin runtime split is reconciled. -->
+<template>
+  <Transition name="confirm-modal">
+    <div
+      v-if="confirmState.isOpen"
+      class="confirm-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+      aria-describedby="confirm-message"
+      data-testid="host-confirm-modal"
+      @click="onOverlayClick"
+    >
+      <div class="confirm-card" @click.stop>
+        <div class="confirm-header">
+          <div class="confirm-icon-wrapper" :class="confirmState.variant">
+            <span class="material-icons icon" aria-hidden="true">{{ iconName }}</span>
+          </div>
+          <h3 id="confirm-title" class="confirm-title">
+            {{ confirmState.title || defaultTitle }}
+          </h3>
+        </div>
+
+        <div id="confirm-message" class="confirm-body">
+          {{ confirmState.message }}
+        </div>
+
+        <div class="confirm-footer">
+          <button ref="cancelBtn" type="button" class="btn-cancel" data-testid="host-confirm-cancel" @click="handleConfirm(false)">
+            {{ confirmState.cancelText || defaultCancelText }}
+          </button>
+          <button ref="confirmBtn" type="button" class="btn-confirm" :class="confirmState.variant" data-testid="host-confirm-ok" @click="handleConfirm(true)">
+            {{ confirmState.confirmText || defaultConfirmText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onUnmounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useConfirm } from "../composables/useConfirm";
+
+const { confirmState, handleConfirm } = useConfirm();
+const { locale } = useI18n();
+
+const confirmBtn = ref<HTMLButtonElement | null>(null);
+const cancelBtn = ref<HTMLButtonElement | null>(null);
+
+const iconName = computed(() => {
+  if (confirmState.value.variant === "danger") return "warning";
+  if (confirmState.value.variant === "success") return "check_circle";
+  return "info";
+});
+
+const defaultTitle = computed(() => {
+  switch (locale.value) {
+    case "ja":
+      return "確認";
+    case "ko":
+      return "확인";
+    case "zh":
+      return "确认";
+    case "es":
+      return "Confirmar";
+    case "de":
+      return "Bestätigen";
+    case "fr":
+      return "Confirmer";
+    case "pt-BR":
+      return "Confirmar";
+    default:
+      return "Confirm";
+  }
+});
+
+const defaultConfirmText = computed(() => {
+  switch (locale.value) {
+    case "ja":
+      return "実行";
+    case "ko":
+      return "확인";
+    case "zh":
+      return "确定";
+    case "es":
+      return "Aceptar";
+    case "de":
+      return "Bestätigen";
+    case "fr":
+      return "Confirmer";
+    case "pt-BR":
+      return "Confirmar";
+    default:
+      return "Confirm";
+  }
+});
+
+const defaultCancelText = computed(() => {
+  switch (locale.value) {
+    case "ja":
+      return "キャンセル";
+    case "ko":
+      return "취소";
+    case "zh":
+      return "取消";
+    case "es":
+      return "Cancelar";
+    case "de":
+      return "Abbrechen";
+    case "fr":
+      return "Annuler";
+    case "pt-BR":
+      return "Cancelar";
+    default:
+      return "Cancel";
+  }
+});
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (!confirmState.value.isOpen) return;
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    handleConfirm(false);
+    return;
+  }
+
+  if (event.key === "Enter") {
+    const active = document.activeElement;
+    if (active === cancelBtn.value) {
+      handleConfirm(false);
+    } else if (active !== confirmBtn.value) {
+      event.preventDefault();
+      handleConfirm(true);
+    }
+    return;
+  }
+
+  if (event.key === "Tab") {
+    const active = document.activeElement;
+    if (event.shiftKey && active !== confirmBtn.value) {
+      event.preventDefault();
+      confirmBtn.value?.focus();
+    } else if (!event.shiftKey && active !== cancelBtn.value) {
+      event.preventDefault();
+      cancelBtn.value?.focus();
+    }
+  }
+}
+
+watch(
+  () => confirmState.value.isOpen,
+  (open) => {
+    if (open) {
+      window.addEventListener("keydown", onKeyDown);
+      nextTick(() => {
+        confirmBtn.value?.focus();
+      });
+    } else {
+      window.removeEventListener("keydown", onKeyDown);
+    }
+  },
+);
+
+onUnmounted(() => {
+  window.removeEventListener("keydown", onKeyDown);
+});
+
+function onOverlayClick(): void {
+  handleConfirm(false);
+}
+</script>
+
+<style scoped>
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.confirm-card {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.05),
+    0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  border-radius: 1.25rem;
+  width: 100%;
+  max-width: 420px;
+  padding: 1.5rem;
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-sizing: border-box;
+}
+
+.confirm-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.confirm-icon-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.confirm-icon-wrapper .icon {
+  font-size: 1.25rem;
+}
+
+.confirm-icon-wrapper.primary {
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  color: #2563eb;
+}
+
+.confirm-icon-wrapper.success {
+  background: rgba(16, 185, 129, 0.15);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  color: #047857;
+}
+
+.confirm-icon-wrapper.danger {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  color: #b91c1c;
+}
+
+.confirm-title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.02em;
+}
+
+.confirm-body {
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: #475569;
+  margin: 0;
+  word-break: break-word;
+}
+
+.confirm-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn-cancel,
+.btn-confirm {
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  border: none;
+  outline: none;
+}
+
+.btn-cancel {
+  background: rgba(241, 245, 249, 0.8);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  color: #475569;
+}
+
+.btn-cancel:hover {
+  background: #e2e8f0;
+  color: #1e293b;
+  transform: translateY(-1px);
+}
+
+.btn-cancel:focus-visible {
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.5);
+}
+
+.btn-confirm {
+  color: #ffffff;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.btn-confirm.primary {
+  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+}
+
+.btn-confirm.primary:hover {
+  background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 8px -1px rgba(59, 130, 246, 0.3);
+}
+
+.btn-confirm.primary:focus-visible {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
+}
+
+.btn-confirm.success {
+  background: linear-gradient(135deg, #10b981 0%, #047857 100%);
+}
+
+.btn-confirm.success:hover {
+  background: linear-gradient(135deg, #059669 0%, #065f46 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 8px -1px rgba(16, 185, 129, 0.3);
+}
+
+.btn-confirm.success:focus-visible {
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.5);
+}
+
+.btn-confirm.danger {
+  background: linear-gradient(135deg, #ef4444 0%, #b91c1c 100%);
+}
+
+.btn-confirm.danger:hover {
+  background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 8px -1px rgba(239, 68, 68, 0.3);
+}
+
+.btn-confirm.danger:focus-visible {
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5);
+}
+
+.btn-cancel:active,
+.btn-confirm:active {
+  transform: translateY(0);
+}
+
+.confirm-modal-enter-active,
+.confirm-modal-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.confirm-modal-enter-from,
+.confirm-modal-leave-to {
+  opacity: 0;
+}
+
+.confirm-modal-enter-active .confirm-card {
+  transition:
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.25s ease;
+}
+
+.confirm-modal-leave-active .confirm-card {
+  transition:
+    transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.2s ease;
+}
+
+.confirm-modal-enter-from .confirm-card {
+  transform: scale(0.9) translateY(8px);
+  opacity: 0;
+}
+
+.confirm-modal-leave-to .confirm-card {
+  transform: scale(0.95) translateY(4px);
+  opacity: 0;
+}
+</style>

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -148,13 +148,17 @@ function onKeyDown(event: KeyboardEvent): void {
   }
 
   if (event.key === "Tab") {
-    const active = document.activeElement;
-    if (event.shiftKey && active !== confirmBtn.value) {
-      event.preventDefault();
-      confirmBtn.value?.focus();
-    } else if (!event.shiftKey && active !== cancelBtn.value) {
-      event.preventDefault();
+    // Trap focus inside the two-button dialog. The previous
+    // conditional-preventDefault leaked focus out of the modal when
+    // Tab was pressed from the cancel button (or Shift+Tab from the
+    // confirm button), breaking WCAG focus containment. Always
+    // preventDefault and toggle between the two buttons — Tab and
+    // Shift+Tab both cycle, which is the standard 2-control pattern.
+    event.preventDefault();
+    if (document.activeElement === confirmBtn.value) {
       cancelBtn.value?.focus();
+    } else {
+      confirmBtn.value?.focus();
     }
   }
 }

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -44,7 +44,7 @@ export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated vie
 // out of this file avoids duplication across the 8 locales.
 export interface PluginLauncherTarget {
   /** Stable key for testid + dispatch in App.vue. */
-  key: "todos" | "calendar" | "automations" | "encore" | "wiki" | "sources" | "news" | "skills" | "roles" | "files" | "debug";
+  key: "todos" | "calendar" | "automations" | "encore" | "wiki" | "apps" | "sources" | "news" | "skills" | "roles" | "files" | "debug";
   kind: PluginLauncherKind;
   /** Material-icons glyph. */
   icon: string;
@@ -75,6 +75,10 @@ const TARGETS: PluginLauncherTarget[] = [
   // the View branches on the query param.
   { key: "encore", kind: "view", icon: "event_repeat" },
   { key: "wiki", kind: "view", icon: "menu_book" },
+  // Schema-driven apps launcher — opens the apps index, from which
+  // the user picks one. The index lists every starred skill that
+  // ships a sibling `schema.json`. See plans/feat-skill-driven-apps.md.
+  { key: "apps", kind: "view", icon: "apps" },
   { key: "sources", kind: "view", icon: "rss_feed" },
   // News viewer (#761) — a reader UI for items aggregated by the
   // sources pipeline. Sits next to the source-registry button so the
@@ -95,9 +99,9 @@ const TARGETS: PluginLauncherTarget[] = [
 
 // Index AFTER which the visual separator is inserted (between data
 // plugins on the left and management on the right). Data plugins are
-// todos / calendar / automations / encore / wiki / sources / news
-// (indices 0-6), so the divider renders before index 7 (skills).
-const SEPARATOR_AFTER_INDEX = 7;
+// todos / calendar / automations / encore / wiki / apps / sources /
+// news (indices 0-7), so the divider renders before index 8 (skills).
+const SEPARATOR_AFTER_INDEX = 8;
 
 // Dev-mode flag — set `VITE_DEV_MODE=1` in `.env`. Anything else
 // (including unset) hides any target with `devOnly: true`.

--- a/src/composables/useConfirm.ts
+++ b/src/composables/useConfirm.ts
@@ -40,6 +40,12 @@ export function useConfirm() {
   function openConfirm(options: ConfirmOptions | string): Promise<boolean> {
     const opts = typeof options === "string" ? { message: options } : options;
     return new Promise<boolean>((resolve) => {
+      // If a previous confirm is still pending, settle it as
+      // "cancelled" before replacing the state. Without this the
+      // earlier `Promise<boolean>` would hang forever and any
+      // caller `await`ing it would deadlock.
+      const previous = confirmState.value.resolve;
+      if (previous) previous(false);
       confirmState.value = {
         isOpen: true,
         title: opts.title || "",

--- a/src/composables/useConfirm.ts
+++ b/src/composables/useConfirm.ts
@@ -1,0 +1,64 @@
+// Promise-based confirm dialog state, host-side mirror of
+// `packages/plugins/shared/components/confirm.ts`. The two have
+// identical interfaces but separate module-scoped state — they
+// can't be merged into one file today because the plugin-side
+// ConfirmModal pulls locale from `useRuntime` (only valid inside
+// PluginScopedRoot) while the host-side one uses vue-i18n. Unify
+// when the host/plugin runtime split is reconciled.
+
+import { ref } from "vue";
+
+export interface ConfirmOptions {
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: "primary" | "success" | "danger";
+}
+
+export interface ConfirmState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmText: string;
+  cancelText: string;
+  variant: "primary" | "success" | "danger";
+  resolve: ((value: boolean) => void) | null;
+}
+
+export const confirmState = ref<ConfirmState>({
+  isOpen: false,
+  title: "",
+  message: "",
+  confirmText: "",
+  cancelText: "",
+  variant: "primary",
+  resolve: null,
+});
+
+export function useConfirm() {
+  function openConfirm(options: ConfirmOptions | string): Promise<boolean> {
+    const opts = typeof options === "string" ? { message: options } : options;
+    return new Promise<boolean>((resolve) => {
+      confirmState.value = {
+        isOpen: true,
+        title: opts.title || "",
+        message: opts.message,
+        confirmText: opts.confirmText || "",
+        cancelText: opts.cancelText || "",
+        variant: opts.variant || "primary",
+        resolve,
+      };
+    });
+  }
+
+  function handleConfirm(value: boolean): void {
+    if (confirmState.value.resolve) {
+      confirmState.value.resolve(value);
+    }
+    confirmState.value.isOpen = false;
+    confirmState.value.resolve = null;
+  }
+
+  return { confirmState, openConfirm, handleConfirm };
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -217,6 +217,19 @@ const HOST_API_ROUTES = {
     manage: "/api/roles/manage",
   },
 
+  // Schema-driven apps (see plans/feat-skill-driven-apps.md). One
+  // "app" is a skill that ships a `schema.json` alongside its
+  // `SKILL.md`; the host renders its records via `<AppCollectionView>`.
+  apps: {
+    list: "/api/apps",
+    /** GET → { app, items } */
+    detail: "/api/apps/:slug",
+    /** POST → create one record (auto-id when primaryKey value omitted) */
+    items: "/api/apps/:slug/items",
+    /** PUT → upsert; DELETE → remove */
+    item: "/api/apps/:slug/items/:itemId",
+  },
+
   // `scheduler` group migrated to META — see `src/plugins/scheduler/calendarMeta.ts`.
   // Auto-merged via `apiNamespace: "scheduler"`.
 

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -362,6 +362,38 @@ export const ROLES: Role[] = [
   // with a `README.md` index the skill maintains. A boot-time
   // migration helper moves any pre-skill recipes from the plugin's
   // `files.data` scope to the new path.
+
+  // Account beta — PoC for the schema-driven app architecture (see
+  // plans/feat-skill-driven-apps.md). The `mc-clients` preset skill
+  // ships a `schema.json` alongside its `SKILL.md`; once starred,
+  // the host renders its records via <AppCollectionView> at
+  // /apps/mc-clients. This role's job is to demonstrate that flow:
+  // Claude does file I/O via the Agent SDK's native Read/Write/Edit;
+  // no MCP plugins per domain. `presentForm` stays available as the
+  // sanctioned way to collect structured input when needed.
+  {
+    id: "account-beta",
+    name: "Account beta",
+    icon: "science",
+    prompt:
+      "You are a beta accounting assistant testing the schema-driven app architecture.\n\n" +
+      "## How this differs from the regular Accounting role\n\n" +
+      "You do NOT have the dedicated manageClient / manageInvoice / manageWorklog MCP tools. Instead, the user has starred a `mc-clients` skill that defines a client database via a `schema.json` file. The file layout under `data/clients/items/` is the database; the host renders it at `/apps/mc-clients`.\n\n" +
+      "Read `mc-clients`'s `SKILL.md` for the conventions (id format, where files live, when to ask vs. when to act). Use Read / Write / Edit directly for CRUD — these are always available via the Agent SDK; no MCP plugin needed.\n\n" +
+      "## Hard rules\n\n" +
+      "- Always derive a kebab-case `id` from the client's name (e.g. Acme Corp → `acme-corp`). Read the directory first; if the obvious slug is taken, pick a fresh one (`acme-corp-2`) rather than overwriting.\n" +
+      "- Don't recite the full record list in chat after a mutation. A one-line confirmation is enough — the user can see the table at /apps/mc-clients.\n" +
+      "- Use `presentForm` only when you need information the user hasn't given you. Don't use it to re-confirm values they already typed.\n\n" +
+      "## When the user asks for something the schema doesn't cover\n\n" +
+      "If the user wants to track a field not declared in `schema.json` (e.g. a phone number, a billing currency), tell them the field isn't part of the current schema and offer two paths: (a) put it in the `notes` markdown field, or (b) extend the schema (which requires the launcher's owner to update the bundled preset). Don't silently add an unknown key to the record.",
+    availablePlugins: [TOOL_NAMES.presentForm],
+    queries: [
+      "Add a client: Acme Corp, billing@acme.example, San Francisco",
+      "List my clients",
+      "What is Acme's email?",
+      "Update Acme's address to One Market Plaza, San Francisco",
+    ],
+  },
   {
     id: "debug",
     name: "Debug",
@@ -440,6 +472,7 @@ export const BUILTIN_ROLE_IDS = {
   // single-skill `mc-settings` originally introduced in #1283 was
   // split into three in #1295 for stronger discovery).
   accounting: "accounting",
+  "account-beta": "account-beta",
   investor: "investor",
   // cookingCoach: removed (#1286) — replaced by `mc-cooking-coach` preset skill.
   debug: "debug",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1340,6 +1340,15 @@ const deMessages = {
     appNotFound: "App nicht gefunden",
     loadFailed: "Laden fehlgeschlagen",
     requiredField: "Dieses Feld ist erforderlich",
+    source: {
+      user: "Benutzer",
+      project: "Projekt",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "Bestätigen",
+    defaultConfirm: "Bestätigen",
+    defaultCancel: "Abbrechen",
   },
 };
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -286,6 +286,7 @@ const deMessages = {
     automations: { label: "Aktionen" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
+    apps: { label: "Apps" },
     sources: { label: "Quellen" },
     news: { label: "Nachrichten" },
     skills: { label: "Skills" },
@@ -1328,6 +1329,17 @@ const deMessages = {
     // behalten, während der Text übersetzbar ist.
     explanation:
       "Zusätzliche Tool-Namen, die Claude über {allowedTools} übergeben werden sollen. Einer pro Zeile. Nützlich für in Claude Code integrierte MCP-Server wie Gmail / Google Kalender, nachdem Sie sich über {claudeMcp} authentifiziert haben.",
+  },
+  appsView: {
+    title: "Apps",
+    backToIndex: "Zurück zu Apps",
+    indexEmpty: "Keine Apps installiert. Markiere auf der Skills-Seite eine Skill mit Schema, um sie hier zu sehen.",
+    editItem: "Bearbeiten",
+    confirmDelete: "Diesen Eintrag löschen? Das kann nicht rückgängig gemacht werden.",
+    itemsEmpty: "Noch keine Einträge. Klicke auf +, um einen hinzuzufügen.",
+    appNotFound: "App nicht gefunden",
+    loadFailed: "Laden fehlgeschlagen",
+    requiredField: "Dieses Feld ist erforderlich",
   },
 };
 

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1322,6 +1322,15 @@ const enMessages = {
     appNotFound: "App not found",
     loadFailed: "Failed to load",
     requiredField: "This field is required",
+    source: {
+      user: "User",
+      project: "Project",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "Confirm",
+    defaultConfirm: "Confirm",
+    defaultCancel: "Cancel",
   },
 };
 

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -302,6 +302,7 @@ const enMessages = {
     automations: { label: "Actions" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
+    apps: { label: "Apps" },
     sources: { label: "Sources" },
     news: { label: "News" },
     skills: { label: "Skills" },
@@ -1310,6 +1311,17 @@ const enMessages = {
     // is translatable.
     explanation:
       "Extra tool names to pass to Claude via {allowedTools}. One per line. Useful for built-in Claude Code MCP servers like Gmail / Google Calendar after you have authenticated via {claudeMcp}.",
+  },
+  appsView: {
+    title: "Apps",
+    backToIndex: "Back to apps",
+    indexEmpty: "No apps installed. Star a skill that ships a schema from the Skills page to see it here.",
+    editItem: "Edit",
+    confirmDelete: "Delete this item? This cannot be undone.",
+    itemsEmpty: "No items yet. Click + to add one.",
+    appNotFound: "App not found",
+    loadFailed: "Failed to load",
+    requiredField: "This field is required",
   },
 };
 

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1335,6 +1335,15 @@ const esMessages = {
     appNotFound: "App no encontrada",
     loadFailed: "Error al cargar",
     requiredField: "Este campo es obligatorio",
+    source: {
+      user: "Usuario",
+      project: "Proyecto",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "Confirmar",
+    defaultConfirm: "Aceptar",
+    defaultCancel: "Cancelar",
   },
 };
 

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -289,6 +289,7 @@ const esMessages = {
     automations: { label: "Acciones" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
+    apps: { label: "Apps" },
     sources: { label: "Fuentes" },
     news: { label: "Noticias" },
     skills: { label: "Skills" },
@@ -1323,6 +1324,17 @@ const esMessages = {
     // su estilo mientras el texto se traduce.
     explanation:
       "Nombres adicionales de herramientas que pasar a Claude mediante {allowedTools}. Uno por línea. Útil para servidores MCP integrados en Claude Code como Gmail / Google Calendar tras autenticarte mediante {claudeMcp}.",
+  },
+  appsView: {
+    title: "Apps",
+    backToIndex: "Volver a apps",
+    indexEmpty: "No hay apps instaladas. Marca con estrella una skill que incluya un schema desde la página Skills para verla aquí.",
+    editItem: "Editar",
+    confirmDelete: "¿Eliminar este elemento? Esta acción no se puede deshacer.",
+    itemsEmpty: "Aún no hay elementos. Pulsa + para añadir uno.",
+    appNotFound: "App no encontrada",
+    loadFailed: "Error al cargar",
+    requiredField: "Este campo es obligatorio",
   },
 };
 

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1329,6 +1329,15 @@ const frMessages = {
     appNotFound: "App introuvable",
     loadFailed: "Échec du chargement",
     requiredField: "Ce champ est obligatoire",
+    source: {
+      user: "Utilisateur",
+      project: "Projet",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "Confirmer",
+    defaultConfirm: "Confirmer",
+    defaultCancel: "Annuler",
   },
 };
 

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -283,6 +283,7 @@ const frMessages = {
     automations: { label: "Actions" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
+    apps: { label: "Apps" },
     sources: { label: "Sources" },
     news: { label: "Actualités" },
     skills: { label: "Skills" },
@@ -1317,6 +1318,17 @@ const frMessages = {
     // style tandis que le texte reste traduisible.
     explanation:
       "Noms d'outils supplémentaires à transmettre à Claude via {allowedTools}. Un par ligne. Utile pour les serveurs MCP intégrés à Claude Code comme Gmail / Google Agenda après authentification via {claudeMcp}.",
+  },
+  appsView: {
+    title: "Apps",
+    backToIndex: "Retour aux apps",
+    indexEmpty: "Aucune app installée. Mettez une étoile sur une compétence avec un schema depuis la page Skills pour la voir ici.",
+    editItem: "Modifier",
+    confirmDelete: "Supprimer cet élément ? Cette action est irréversible.",
+    itemsEmpty: "Aucun élément pour l'instant. Cliquez sur + pour en ajouter un.",
+    appNotFound: "App introuvable",
+    loadFailed: "Échec du chargement",
+    requiredField: "Ce champ est obligatoire",
   },
 };
 

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1319,6 +1319,15 @@ const jaMessages = {
     appNotFound: "アプリが見つかりません",
     loadFailed: "読み込みに失敗しました",
     requiredField: "この項目は必須です",
+    source: {
+      user: "ユーザー",
+      project: "プロジェクト",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "確認",
+    defaultConfirm: "実行",
+    defaultCancel: "キャンセル",
   },
 };
 

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -285,6 +285,7 @@ const jaMessages = {
     automations: { label: "自動化" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
+    apps: { label: "アプリ" },
     sources: { label: "ソース" },
     news: { label: "ニュース" },
     skills: { label: "スキル" },
@@ -1307,6 +1308,17 @@ const jaMessages = {
   settingsToolsTab: {
     explanation:
       "{allowedTools} を介して Claude に渡す追加ツール名。1行につき1つ。Gmail / Google Calendar などの Claude Code 組み込み MCP サーバを、{claudeMcp} で認証した後に利用する場合に便利です。",
+  },
+  appsView: {
+    title: "アプリ",
+    backToIndex: "アプリ一覧に戻る",
+    indexEmpty: "インストール済みのアプリがありません。スキーマを含むスキルを Skills ページからスター付けすると、ここに表示されます。",
+    editItem: "編集",
+    confirmDelete: "この項目を削除しますか？元に戻せません。",
+    itemsEmpty: "まだ項目がありません。+ を押して追加してください。",
+    appNotFound: "アプリが見つかりません",
+    loadFailed: "読み込みに失敗しました",
+    requiredField: "この項目は必須です",
   },
 };
 

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1322,6 +1322,15 @@ const koMessages = {
     appNotFound: "앱을 찾을 수 없습니다",
     loadFailed: "불러오기에 실패했습니다",
     requiredField: "이 필드는 필수입니다",
+    source: {
+      user: "사용자",
+      project: "프로젝트",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "확인",
+    defaultConfirm: "확인",
+    defaultCancel: "취소",
   },
 };
 

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -287,6 +287,7 @@ const koMessages = {
     automations: { label: "자동화" },
     encore: { label: "Encore" },
     wiki: { label: "위키" },
+    apps: { label: "앱" },
     sources: { label: "소스" },
     news: { label: "뉴스" },
     skills: { label: "스킬" },
@@ -1310,6 +1311,17 @@ const koMessages = {
     // `<code>` 태그는 스타일을 유지하면서 본문은 번역 가능합니다.
     explanation:
       "{allowedTools} 를 통해 Claude 에 전달할 추가 도구 이름. 한 줄에 하나씩. {claudeMcp} 로 인증을 완료한 후 Claude Code 내장 MCP 서버 (Gmail / Google 캘린더 등) 를 사용할 때 유용합니다.",
+  },
+  appsView: {
+    title: "앱",
+    backToIndex: "앱 목록으로 돌아가기",
+    indexEmpty: "설치된 앱이 없습니다. Skills 페이지에서 스키마를 포함한 스킬에 별표를 추가하면 여기에 표시됩니다.",
+    editItem: "편집",
+    confirmDelete: "이 항목을 삭제하시겠습니까? 되돌릴 수 없습니다.",
+    itemsEmpty: "아직 항목이 없습니다. + 를 눌러 추가하세요.",
+    appNotFound: "앱을 찾을 수 없습니다",
+    loadFailed: "불러오기에 실패했습니다",
+    requiredField: "이 필드는 필수입니다",
   },
 };
 

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -282,7 +282,7 @@ const ptBRMessages = {
     automations: { label: "Ações" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
-    apps: { label: "Apps" },
+    apps: { label: "Aplicativos" },
     sources: { label: "Fontes" },
     news: { label: "Notícias" },
     skills: { label: "Skills" },
@@ -1315,15 +1315,24 @@ const ptBRMessages = {
       "Nomes adicionais de ferramentas a serem passados ao Claude via {allowedTools}. Um por linha. Útil para servidores MCP integrados ao Claude Code como Gmail / Google Calendar após autenticar via {claudeMcp}.",
   },
   appsView: {
-    title: "Apps",
-    backToIndex: "Voltar para apps",
-    indexEmpty: "Nenhum app instalado. Marque com estrela uma skill que inclua um schema na página Skills para vê-la aqui.",
+    title: "Aplicativos",
+    backToIndex: "Voltar para aplicativos",
+    indexEmpty: "Nenhum aplicativo instalado. Marque com estrela uma skill que inclua um schema na página Skills para vê-la aqui.",
     editItem: "Editar",
     confirmDelete: "Excluir este item? Esta ação não pode ser desfeita.",
     itemsEmpty: "Ainda não há itens. Clique em + para adicionar um.",
-    appNotFound: "App não encontrado",
+    appNotFound: "Aplicativo não encontrado",
     loadFailed: "Falha ao carregar",
     requiredField: "Este campo é obrigatório",
+    source: {
+      user: "Usuário",
+      project: "Projeto",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "Confirmar",
+    defaultConfirm: "Confirmar",
+    defaultCancel: "Cancelar",
   },
 };
 

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -282,6 +282,7 @@ const ptBRMessages = {
     automations: { label: "Ações" },
     encore: { label: "Encore" },
     wiki: { label: "Wiki" },
+    apps: { label: "Apps" },
     sources: { label: "Fontes" },
     news: { label: "Notícias" },
     skills: { label: "Skills" },
@@ -1312,6 +1313,17 @@ const ptBRMessages = {
     // enquanto o texto é traduzível.
     explanation:
       "Nomes adicionais de ferramentas a serem passados ao Claude via {allowedTools}. Um por linha. Útil para servidores MCP integrados ao Claude Code como Gmail / Google Calendar após autenticar via {claudeMcp}.",
+  },
+  appsView: {
+    title: "Apps",
+    backToIndex: "Voltar para apps",
+    indexEmpty: "Nenhum app instalado. Marque com estrela uma skill que inclua um schema na página Skills para vê-la aqui.",
+    editItem: "Editar",
+    confirmDelete: "Excluir este item? Esta ação não pode ser desfeita.",
+    itemsEmpty: "Ainda não há itens. Clique em + para adicionar um.",
+    appNotFound: "App não encontrado",
+    loadFailed: "Falha ao carregar",
+    requiredField: "Este campo é obrigatório",
   },
 };
 

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1312,6 +1312,15 @@ const zhMessages = {
     appNotFound: "未找到应用",
     loadFailed: "加载失败",
     requiredField: "此字段为必填项",
+    source: {
+      user: "用户",
+      project: "项目",
+    },
+  },
+  confirmModal: {
+    defaultTitle: "确认",
+    defaultConfirm: "确定",
+    defaultCancel: "取消",
   },
 };
 

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -279,6 +279,7 @@ const zhMessages = {
     automations: { label: "自动化" },
     encore: { label: "Encore" },
     wiki: { label: "百科" },
+    apps: { label: "应用" },
     sources: { label: "信息源" },
     news: { label: "新闻" },
     skills: { label: "技能" },
@@ -1300,6 +1301,17 @@ const zhMessages = {
     // 以便保留 `<code>` 标签的样式,同时文本可本地化。
     explanation:
       "要通过 {allowedTools} 传递给 Claude 的额外工具名。每行一个。适用于在 {claudeMcp} 完成授权后,调用 Claude Code 内置的 MCP 服务器(如 Gmail / Google 日历)。",
+  },
+  appsView: {
+    title: "应用",
+    backToIndex: "返回应用列表",
+    indexEmpty: "尚未安装任何应用。在「技能」页面对带有 schema 的技能加星即可在此显示。",
+    editItem: "编辑",
+    confirmDelete: "删除此项？此操作无法撤销。",
+    itemsEmpty: "暂无项目。点击 + 添加一个。",
+    appNotFound: "未找到应用",
+    loadFailed: "加载失败",
+    requiredField: "此字段为必填项",
   },
 };
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -82,6 +82,10 @@ const routes: RouteRecordRaw[] = [
   //     active obligations + cycle history. Reached from the
   //     top-bar launcher. See plans/done/feat-encore-as-builtin.md.
   { path: "/encore", name: PAGE_ROUTES.encore, component: Stub },
+  // Schema-driven apps (see plans/feat-skill-driven-apps.md). `/apps`
+  // lists every discovered app; `/apps/:slug` opens that app's
+  // CollectionView.
+  { path: "/apps/:slug?", name: PAGE_ROUTES.apps, component: Stub },
   { path: "/:pathMatch(.*)*", redirect: "/chat" },
 ];
 

--- a/src/router/pageRoutes.ts
+++ b/src/router/pageRoutes.ts
@@ -20,6 +20,7 @@ export const PAGE_ROUTES = {
   news: "news",
   debug: "debug",
   encore: "encore",
+  apps: "apps",
 } as const;
 
 export type PageRouteName = (typeof PAGE_ROUTES)[keyof typeof PAGE_ROUTES];

--- a/test/workspace/apps/test_io.ts
+++ b/test/workspace/apps/test_io.ts
@@ -1,0 +1,79 @@
+// File-disclosure defense for the apps io module. The dataDir-level
+// realpath containment in test_paths.ts only proves the directory
+// anchor is inside the workspace — a `*.json` symlink dropped INSIDE
+// an otherwise-contained data dir could still point at any file on
+// disk, and a naive readFile would happily serve it. This file pins
+// the symlinked-record-file rejection from CodeRabbit's PR-1483
+// round-2 review.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { listItems, readItem } from "../../../server/workspace/apps/io.js";
+
+let workdir: string;
+let dataDir: string;
+let outsideFile: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "apps-io-"));
+  dataDir = path.join(workdir, "data", "clients", "items");
+  mkdirSync(dataDir, { recursive: true });
+  // A file outside the workspace that an attacker symlink would
+  // expose if file-disclosure defense were missing.
+  outsideFile = path.join(mkdtempSync(path.join(tmpdir(), "outside-")), "secret.json");
+  writeFileSync(outsideFile, JSON.stringify({ secret: "should-not-be-served" }));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(path.dirname(outsideFile), { recursive: true, force: true });
+});
+
+describe("listItems file-disclosure defense", () => {
+  it("returns regular records", async () => {
+    writeFileSync(path.join(dataDir, "acme.json"), JSON.stringify({ id: "acme", name: "Acme" }));
+    const items = await listItems(dataDir, { workspaceRoot: workdir });
+    assert.equal(items.length, 1);
+    assert.equal(items[0]?.id, "acme");
+  });
+
+  it("skips symlinked record files even when the dataDir is contained", async () => {
+    writeFileSync(path.join(dataDir, "real.json"), JSON.stringify({ id: "real", name: "Real" }));
+    // The symlink lives inside the contained dataDir but points at
+    // a file outside the workspace — exactly the file-disclosure
+    // shape CodeRabbit flagged.
+    symlinkSync(outsideFile, path.join(dataDir, "leaked.json"));
+    const items = await listItems(dataDir, { workspaceRoot: workdir });
+    assert.equal(items.length, 1, "symlinked record must not be included");
+    assert.equal(items[0]?.id, "real");
+  });
+
+  it("returns [] when the dataDir does not exist (first-use)", async () => {
+    const fresh = path.join(workdir, "data", "fresh", "items");
+    const items = await listItems(fresh, { workspaceRoot: workdir });
+    assert.deepEqual(items, []);
+  });
+});
+
+describe("readItem file-disclosure defense", () => {
+  it("reads a regular record", async () => {
+    writeFileSync(path.join(dataDir, "acme.json"), JSON.stringify({ id: "acme", name: "Acme" }));
+    const item = await readItem(dataDir, "acme", { workspaceRoot: workdir });
+    assert.equal(item?.id, "acme");
+  });
+
+  it("returns null for a symlinked record file", async () => {
+    symlinkSync(outsideFile, path.join(dataDir, "leaked.json"));
+    const item = await readItem(dataDir, "leaked", { workspaceRoot: workdir });
+    assert.equal(item, null);
+  });
+
+  it("returns null for an invalid slug", async () => {
+    const item = await readItem(dataDir, "../escape", { workspaceRoot: workdir });
+    assert.equal(item, null);
+  });
+});

--- a/test/workspace/apps/test_paths.ts
+++ b/test/workspace/apps/test_paths.ts
@@ -1,0 +1,110 @@
+// Realpath-based containment + slug-safety tests for the apps module.
+//
+// Locks in the symlink-traversal fix from the PR-1483 second review:
+// `resolveDataDir` used to do only lexical normalization, so a
+// schema could declare `dataPath: "data/clients/items"` while the
+// `clients` directory was actually a symlink to `/etc` or anywhere
+// outside the workspace. The fix (`isContainedInRoot` realpaths the
+// closest existing ancestor) is exercised here against three
+// scenarios CodeQL flagged: a symlinked dataPath, a symlinked
+// ancestor of dataPath, and a symlinked sibling that does NOT shadow
+// the dataPath but lives in the same tree.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { isContainedInRoot, safeSlugName } from "../../../server/workspace/apps/paths.js";
+
+let rootDir: string;
+let outsideDir: string;
+
+beforeEach(() => {
+  rootDir = mkdtempSync(path.join(tmpdir(), "apps-paths-root-"));
+  outsideDir = mkdtempSync(path.join(tmpdir(), "apps-paths-outside-"));
+});
+
+afterEach(() => {
+  rmSync(rootDir, { recursive: true, force: true });
+  rmSync(outsideDir, { recursive: true, force: true });
+});
+
+describe("isContainedInRoot", () => {
+  it("accepts a real subdirectory of the root", () => {
+    const sub = path.join(rootDir, "data", "clients", "items");
+    mkdirSync(sub, { recursive: true });
+    assert.equal(isContainedInRoot(sub, rootDir), true);
+  });
+
+  it("accepts a not-yet-existing subdirectory whose parent is inside the root", () => {
+    // Common first-write case: the data dir hasn't been created
+    // yet, but its parent (workspace root) is real and contained.
+    const sub = path.join(rootDir, "data", "clients", "items");
+    assert.equal(isContainedInRoot(sub, rootDir), true);
+  });
+
+  it("rejects a directory that IS a symlink pointing outside the root", () => {
+    // `<root>/escape` → `<outside>/`. Lexical check would pass
+    // because `path.resolve(root, "escape")` stays under root.
+    const linkPath = path.join(rootDir, "escape");
+    symlinkSync(outsideDir, linkPath);
+    assert.equal(isContainedInRoot(linkPath, rootDir), false);
+  });
+
+  it("rejects a path whose ancestor is a symlink pointing outside the root", () => {
+    // `<root>/data` → `<outside>/data`; then `<root>/data/clients`
+    // resolves to `<outside>/data/clients`. The escape happens at
+    // the ancestor, not the leaf — the lexical check missed this
+    // because it only normalised the textual path.
+    const outsideData = path.join(outsideDir, "data");
+    mkdirSync(outsideData);
+    symlinkSync(outsideData, path.join(rootDir, "data"));
+    const escapedLeaf = path.join(rootDir, "data", "clients", "items");
+    assert.equal(isContainedInRoot(escapedLeaf, rootDir), false);
+  });
+
+  it("rejects an absolute path that lives outside the root entirely", () => {
+    assert.equal(isContainedInRoot(outsideDir, rootDir), false);
+    assert.equal(isContainedInRoot(path.join(outsideDir, "items"), rootDir), false);
+  });
+
+  it("accepts a symlink whose target is itself inside the root", () => {
+    // Sibling symlinks within a workspace are common (the catalog
+    // sync writes them in some setups). Make sure we don't reject
+    // them — only the escape case should fail.
+    const insideTarget = path.join(rootDir, "real-data");
+    mkdirSync(insideTarget);
+    const link = path.join(rootDir, "link-data");
+    symlinkSync(insideTarget, link);
+    assert.equal(isContainedInRoot(link, rootDir), true);
+  });
+});
+
+describe("safeSlugName", () => {
+  it("accepts normal slugs", () => {
+    assert.equal(safeSlugName("acme-corp"), "acme-corp");
+    assert.equal(safeSlugName("client42"), "client42");
+    assert.equal(safeSlugName("a"), "a");
+  });
+
+  it("rejects path separators and traversal", () => {
+    assert.equal(safeSlugName("../etc"), null);
+    assert.equal(safeSlugName("a/b"), null);
+    assert.equal(safeSlugName("a\\b"), null);
+    assert.equal(safeSlugName(".."), null);
+  });
+
+  it("rejects leading/trailing hyphens and empty input", () => {
+    assert.equal(safeSlugName("-leading"), null);
+    assert.equal(safeSlugName("trailing-"), null);
+    assert.equal(safeSlugName(""), null);
+  });
+
+  it("rejects non-string input", () => {
+    assert.equal(safeSlugName(null as unknown as string), null);
+    assert.equal(safeSlugName(undefined as unknown as string), null);
+    assert.equal(safeSlugName(42 as unknown as string), null);
+  });
+});


### PR DESCRIPTION
## Summary

Tests the hypothesis that per-feature plugins (worklog/client/invoice — ~3,000 lines each) can be replaced by a **thin host primitive + per-domain skills that declare a schema**. See `plans/feat-skill-driven-apps.md` for the full hypothesis, what's deferred, and the migration path.

**Architecture** (one mechanical change to the existing skill plumbing, plus net-new host primitive):

- **Generalize preset sync**: `server/workspace/skills-preset.ts` now copies the entire skill directory tree (previously only `SKILL.md`). Lets a preset ship sibling assets like `schema.json` or PDF templates without silently dropping them on boot. Existing 26 preset-sync tests still pass; behavior change is documented in the file.
- **New `/api/apps`** (list / detail / item CRUD) in `server/api/routes/apps.ts` + `server/workspace/apps/`. Discovery scans `~/.claude/skills/*/schema.json` and `<workspace>/.claude/skills/*/schema.json`; project wins on collision (mirrors existing skill discovery). All paths go through `safeSlugName` + workspace-root checks (CodeQL's sanctioned anti-traversal pattern).
- **`<AppCollectionView>` + `<AppsIndexView>`** (host components, `src/components/`): schema-driven table + auto-generated edit/create modal. Field types for v0: `string | text | email | number | date | markdown`.
- **Route `/apps/:slug?`** wired through `PAGE_ROUTES`, vue-router, `App.vue`, and the top-bar `PluginLauncher` (new `apps` button between `wiki` and `sources`).
- **i18n in all 8 locales** (`pluginLauncher.apps` + new `appsView` namespace).
- **`<ConfirmModal>`** host-side mirror of the worklog one — same composable interface (`useConfirm.openConfirm`), `useI18n` instead of `useRuntime` for locale (host mounts outside `PluginScopedRoot`), Material Icons instead of emoji per CLAUDE.md. File header notes the two should be unified when the host/plugin runtime split is reconciled.

**Sample app** (`server/workspace/skills-preset/mc-clients/`): `SKILL.md` + `schema.json` declaring a 5-field client database. Records live at `data/clients/items/<id>.json`.

**New "Account beta" role** (`src/config/roles.ts`): deliberately tiny `availablePlugins: [presentForm]` — Claude does CRUD via the Agent SDK's native `Read` / `Write` / `Edit`, demonstrating that per-domain MCP tools aren't necessary when a skill declares the schema.

## What's intentionally deferred

The v0 schema language doesn't yet support: `ref` (cross-collection links), `table` (nested arrays), `money`, `derived` fields, `actions` (status changes, PDF export). All listed in the plan — they're the features invoice would need on the migration path. Adding them is the next iteration, gated on this primitive feeling right with one app first.

## Test plan

- [ ] `yarn dev` boots clean; preset sync log shows `mc-clients`
- [ ] `/skills` → ★ Star Clients → `~/mulmoclaude/.claude/skills/mc-clients/{SKILL.md,schema.json}` populated
- [ ] Select "Account beta" role → "Add a client: Acme Corp, billing@acme.example" → `data/clients/items/acme-corp.json` created with the right shape
- [ ] Navigate to `/apps/mc-clients` → Acme appears in the table with correct columns
- [ ] Click Edit → modify a field → Save → file on disk reflects the change
- [ ] Click Remove → ConfirmModal appears (Material warning icon, danger variant) → confirming deletes the file
- [ ] Click + → fill form → record created with auto-generated id (or honoring the primaryKey value if provided)
- [ ] `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build` all green (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps UI: discover, browse and manage schema-driven apps with index/detail pages, table-based CRUD, confirm modal, and launcher entry.
  * Server API and safe file-backed app storage with containment/symlink defenses and preset sync that mirrors full skill directories.
  * New confirm composable for promise-based confirmations and a sample "Clients" app.

* **Documentation**
  * Added PoC plan for skill-driven apps and sample app docs.

* **Localization**
  * Apps UI strings added in multiple languages.

* **Tests**
  * Path-safety and IO tests for workspace apps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->