### PR TITLE
chore: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -87,7 +87,7 @@ jobs:
           node-version: 22.x
 
       - name: Cache global npm tarballs
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: codex-cli-${{ env.CODEX_VERSION }}-node22

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -84,7 +84,7 @@ jobs:
     # tree (yarn install fills in the diff) instead of a cold cache.
     - name: Cache node_modules (Windows)
       if: runner.os == 'Windows'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
@@ -99,7 +99,7 @@ jobs:
     # version because emitted JS can differ across them.
     - name: Cache packages/dist
       id: pkg-dist-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           packages/*/dist
@@ -210,7 +210,7 @@ jobs:
     # finishes building first warms the cache for the other.
     - name: Cache packages/dist
       id: pkg-dist-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           packages/*/dist


### PR DESCRIPTION
## Summary
- **actions/cache v4 → v5**: Node.js 20 deprecation warning の解消

## Test plan
- [ ] CI で Node.js 20 deprecation warning が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)