### PR TITLE
windows-latest

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
-        os: [ubuntu-latest, windows-2022, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust the GitHub Actions pull_request workflow matrix to target windows-latest rather than windows-2022.