### PR TITLE
feat(apps): mc-worklog as second schema-driven app + boolean field type

### DIFF
--- a/plans/feat-skill-driven-apps-worklog.md
+++ b/plans/feat-skill-driven-apps-worklog.md
@@ -33,7 +33,7 @@ existing app-discovery flow picks up any starred skill that ships a
 
 ### What the skill adds
 
-```
+```text
 server/workspace/skills-preset/mc-worklog/
 ├── SKILL.md          # Claude's instructions
 └── schema.json       # 5 fields

--- a/plans/feat-skill-driven-apps-worklog.md
+++ b/plans/feat-skill-driven-apps-worklog.md
@@ -1,0 +1,111 @@
+# Plan: Worklog as a Schema-driven App (minimal)
+
+Follow-up to [feat-skill-driven-apps.md](feat-skill-driven-apps.md)
+(PR #1483, merged). Validates the second-app hypothesis: that the same
+schema-driven primitive can host a different domain with **one** new
+schema-language addition (`boolean`) and zero new host UI work.
+
+## Goal
+
+Add a `mc-worklog` skill that records timesheet entries via the same
+`<AppCollectionView>` primitive `mc-clients` uses. **Out of scope** for
+this iteration: matching every feature of the existing 1,433-line
+worklog plugin — see "Deferred" below for the gap.
+
+## Architecture (delta from PR #1483)
+
+### What the host adds
+
+**One** new field type: `boolean`. That is the entire host change.
+
+| Surface | Change |
+|---|---|
+| `server/workspace/apps/types.ts` | Add `"boolean"` to `AppFieldType` |
+| `server/workspace/apps/discovery.ts` | Add `"boolean"` to the Zod field-type enum |
+| `src/components/AppCollectionView.vue` form | New branch: `<input type="checkbox">` v-model bound to a boolean draft slot. `:required` doesn't apply (a "required" checkbox is a UX foot-gun). |
+| `src/components/AppCollectionView.vue` table | Material `check` icon when `true`, em-dash when `false`/missing |
+| `EditState.draft` type | `Record<string, string>` → `Record<string, string \| boolean>` |
+| `draftToRecord` | Pass booleans through verbatim instead of stringifying |
+
+That's it. No new endpoints, no new routes, no new sidebar entry — the
+existing app-discovery flow picks up any starred skill that ships a
+`schema.json`.
+
+### What the skill adds
+
+```
+server/workspace/skills-preset/mc-worklog/
+├── SKILL.md          # Claude's instructions
+└── schema.json       # 5 fields
+```
+
+Schema:
+
+```json
+{
+  "title": "Worklog",
+  "icon": "schedule",
+  "dataPath": "data/worklog/items",
+  "primaryKey": "id",
+  "fields": {
+    "id":       { "type": "string",   "label": "ID",       "primary": true, "required": true },
+    "date":     { "type": "date",     "label": "Date",     "required": true },
+    "clientId": { "type": "string",   "label": "Client",   "required": true },
+    "hours":    { "type": "number",   "label": "Hours",    "required": true },
+    "billable": { "type": "boolean",  "label": "Billable" },
+    "notes":    { "type": "markdown", "label": "Notes" }
+  }
+}
+```
+
+Conventions encoded in `SKILL.md`:
+
+- `id` = `{date}-{clientId-slug}-{4-hex}` (e.g. `2026-05-23-acme-corp-a1b2`); avoids collisions for multi-session days.
+- `clientId` is a free string in this iteration. Skill tells Claude to look it up against `data/clients/items/*.json` when the user says "log 2 hours for Acme" — Claude resolves the name to the slug via Read, but the schema does not enforce the reference (that lands when we add `ref`).
+- `billable` defaults to `true` when the user doesn't say otherwise.
+- `hours` is a decimal (1.5 = 90 minutes). Worklog plugin used integer seconds; this is a deliberate ergonomic shift for the schema-driven version.
+
+### Role update
+
+`Account beta` (`src/config/roles.ts`) gets its prompt extended so
+Claude knows both `mc-clients` and `mc-worklog` exist, plus a few new
+sample queries. No new role; same `availablePlugins: [presentForm]`.
+
+## Test plan
+
+After `yarn dev` reboot:
+
+1. `/skills` → ★ Star **Worklog** in the catalog → `.claude/skills/mc-worklog/` populated
+2. Account beta: "log 2 hours for Acme today on the migration work" → `data/worklog/items/<id>.json` created with the right shape
+3. `/apps/mc-worklog` → entry visible in the table, `billable` column shows a check icon
+4. `+` button → form opens with a checkbox for `billable`; submit creates a record
+5. Edit a row → checkbox state round-trips correctly
+6. Same row, uncheck billable, save → file's `billable` field flips to `false`
+
+## Deferred (the gap from the real worklog plugin)
+
+Listed here so a future iteration can pick them up explicitly:
+
+| Feature | What it needs |
+|---|---|
+| `startTime` / `endTime` with timezone | New `datetime` field type (different from `date`) |
+| `source` enum (manual / claude-session / git / …) | New `enum` field type with declared values |
+| `evidence[]` array of arbitrary objects | Nested-object / JSON-blob field type |
+| candidate → committed → superseded workflow | Status field + UI-side approve action (or Claude-driven via Read/Write) |
+| `clientId` validation against `mc-clients` | `ref` field type with `{ to: "<other-skill>" }` |
+| Append-only versioning (`supersedes`, `deleted` tombstones) | Out of schema-language scope; would live in skill conventions |
+
+None of these block the minimal version. Most are useful for invoice
+too — `ref` and `enum` are the two that'd unlock the most.
+
+## What success looks like
+
+Concrete bar for "the schema-driven model is the right direction":
+
+- Adding `boolean` to the host costs ≤ ~30 lines spread across 3 files
+- The skill is ≤ 100 lines (SKILL.md + schema.json combined)
+- Claude correctly logs an entry on first try without any new tool
+- The CollectionView renders worklog cleanly with no per-app branches in the component
+
+If all four hold, invoice migration becomes a question of "which schema
+features do we add" rather than "is the primitive viable".

--- a/server/workspace/apps/discovery.ts
+++ b/server/workspace/apps/discovery.ts
@@ -38,7 +38,7 @@ interface LoadedApp {
   dataDir: string;
 }
 
-async function loadOneApp(skillsRoot: string, slug: string, source: AppSource): Promise<LoadedApp | null> {
+async function loadOneApp(skillsRoot: string, slug: string, source: AppSource, workspaceRoot: string): Promise<LoadedApp | null> {
   const safeName = safeSlugName(slug);
   if (safeName === null) return null;
   const schemaPath = path.join(skillsRoot, safeName, SCHEMA_FILE);
@@ -87,16 +87,16 @@ async function loadOneApp(skillsRoot: string, slug: string, source: AppSource): 
     return null;
   }
 
-  const dataDir = resolveDataDir(schema.dataPath);
+  const dataDir = resolveDataDir(schema.dataPath, workspaceRoot);
   if (dataDir === null) {
-    log.warn("apps", "schema.json dataPath escapes workspace, skipping", { slug: safeName, dataPath: schema.dataPath });
+    log.warn("apps", "schema.json dataPath escapes workspace, skipping", { slug: safeName, dataPath: schema.dataPath, workspaceRoot });
     return null;
   }
 
   return { slug: safeName, source, schema, dataDir };
 }
 
-async function collectAppsFromDir(skillsRoot: string, source: AppSource): Promise<LoadedApp[]> {
+async function collectAppsFromDir(skillsRoot: string, source: AppSource, workspaceRoot: string): Promise<LoadedApp[]> {
   let entries: string[];
   try {
     entries = await readdir(skillsRoot);
@@ -120,7 +120,7 @@ async function collectAppsFromDir(skillsRoot: string, source: AppSource): Promis
       continue;
     }
     if (!dirStat.isDirectory()) continue;
-    const app = await loadOneApp(skillsRoot, safeName, source);
+    const app = await loadOneApp(skillsRoot, safeName, source, workspaceRoot);
     if (app) results.push(app);
   }
   return results;
@@ -141,12 +141,17 @@ export interface DiscoveryOptions {
 }
 
 /** Discover every schema-driven app available to this workspace.
- *  Project-scope apps override user-scope on slug collision. */
+ *  Project-scope apps override user-scope on slug collision. The
+ *  `workspaceRoot` override also flows into each app's dataDir
+ *  resolution so a tmpdir-scoped test gets dataDirs under the same
+ *  tmpdir (Codex P1 review on PR #1489 — previously dataDir was
+ *  always rooted at the live workspacePath regardless of override). */
 export async function discoverApps(opts: DiscoveryOptions = {}): Promise<LoadedApp[]> {
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
   const userDir = opts.userSkillsDir ?? USER_SKILLS_DIR;
-  const projectDir = projectSkillsDir(opts.workspaceRoot ?? workspacePath);
-  const userApps = await collectAppsFromDir(userDir, "user");
-  const projectApps = await collectAppsFromDir(projectDir, "project");
+  const projectDir = projectSkillsDir(workspaceRoot);
+  const userApps = await collectAppsFromDir(userDir, "user", workspaceRoot);
+  const projectApps = await collectAppsFromDir(projectDir, "project", workspaceRoot);
   const merged = new Map<string, LoadedApp>();
   for (const app of userApps) merged.set(app.slug, app);
   for (const app of projectApps) merged.set(app.slug, app);
@@ -158,12 +163,13 @@ export async function discoverApps(opts: DiscoveryOptions = {}): Promise<LoadedA
 export async function loadApp(slug: string, opts: DiscoveryOptions = {}): Promise<LoadedApp | null> {
   const safeName = safeSlugName(slug);
   if (safeName === null) return null;
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
   const userDir = opts.userSkillsDir ?? USER_SKILLS_DIR;
-  const projectDir = projectSkillsDir(opts.workspaceRoot ?? workspacePath);
+  const projectDir = projectSkillsDir(workspaceRoot);
   // Project first (overrides user).
-  const projectApp = await loadOneApp(projectDir, safeName, "project");
+  const projectApp = await loadOneApp(projectDir, safeName, "project", workspaceRoot);
   if (projectApp) return projectApp;
-  return loadOneApp(userDir, safeName, "user");
+  return loadOneApp(userDir, safeName, "user", workspaceRoot);
 }
 
 export function toSummary(app: LoadedApp): AppSummary {

--- a/server/workspace/apps/discovery.ts
+++ b/server/workspace/apps/discovery.ts
@@ -14,7 +14,7 @@ import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths.js";
 import type { AppDetail, AppSchema, AppSource, AppSummary } from "./types.js";
 
 const FieldSpecSchema = z.object({
-  type: z.enum(["string", "text", "email", "number", "date", "markdown"]),
+  type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown"]),
   label: z.string().min(1),
   primary: z.boolean().optional(),
   required: z.boolean().optional(),
@@ -126,11 +126,27 @@ async function collectAppsFromDir(skillsRoot: string, source: AppSource): Promis
   return results;
 }
 
+export interface DiscoveryOptions {
+  /** Override the workspace root for project-scope skill discovery.
+   *  Default: the live `workspacePath`. Tests point this at a
+   *  `mkdtempSync` tree so they don't touch the user's real
+   *  `~/mulmoclaude/`. Mirrors the pattern in
+   *  `server/workspace/skills/catalog.ts#CatalogOptions`. */
+  workspaceRoot?: string;
+  /** Override `~/.claude/skills/` for tests. Production callers
+   *  leave this unset. Without an override, even a test-scoped
+   *  workspaceRoot still scans the real user home — which can leak
+   *  unrelated skills into the result. */
+  userSkillsDir?: string;
+}
+
 /** Discover every schema-driven app available to this workspace.
  *  Project-scope apps override user-scope on slug collision. */
-export async function discoverApps(): Promise<LoadedApp[]> {
-  const userApps = await collectAppsFromDir(USER_SKILLS_DIR, "user");
-  const projectApps = await collectAppsFromDir(projectSkillsDir(workspacePath), "project");
+export async function discoverApps(opts: DiscoveryOptions = {}): Promise<LoadedApp[]> {
+  const userDir = opts.userSkillsDir ?? USER_SKILLS_DIR;
+  const projectDir = projectSkillsDir(opts.workspaceRoot ?? workspacePath);
+  const userApps = await collectAppsFromDir(userDir, "user");
+  const projectApps = await collectAppsFromDir(projectDir, "project");
   const merged = new Map<string, LoadedApp>();
   for (const app of userApps) merged.set(app.slug, app);
   for (const app of projectApps) merged.set(app.slug, app);
@@ -139,13 +155,15 @@ export async function discoverApps(): Promise<LoadedApp[]> {
 
 /** Load one app by slug. Returns null if the slug is invalid, no
  *  matching skill exists, or the schema is malformed. */
-export async function loadApp(slug: string): Promise<LoadedApp | null> {
+export async function loadApp(slug: string, opts: DiscoveryOptions = {}): Promise<LoadedApp | null> {
   const safeName = safeSlugName(slug);
   if (safeName === null) return null;
+  const userDir = opts.userSkillsDir ?? USER_SKILLS_DIR;
+  const projectDir = projectSkillsDir(opts.workspaceRoot ?? workspacePath);
   // Project first (overrides user).
-  const projectApp = await loadOneApp(projectSkillsDir(workspacePath), safeName, "project");
+  const projectApp = await loadOneApp(projectDir, safeName, "project");
   if (projectApp) return projectApp;
-  return loadOneApp(USER_SKILLS_DIR, safeName, "user");
+  return loadOneApp(userDir, safeName, "user");
 }
 
 export function toSummary(app: LoadedApp): AppSummary {

--- a/server/workspace/apps/paths.ts
+++ b/server/workspace/apps/paths.ts
@@ -77,22 +77,28 @@ export function isContainedInWorkspace(absPath: string): boolean {
   return isContainedInRoot(absPath, workspacePath);
 }
 
-/** Resolve a schema-declared dataPath against the workspace root,
- *  refusing anything that escapes — absolute paths, `..`-segments,
- *  empty string, or symlinks pointing outside the workspace.
- *  Returns the absolute path on success, null on refusal. Does NOT
- *  require the directory to exist; the caller may create it on first
- *  write. The realpath containment check covers the symlink case at
- *  discovery time; io operations re-check before each write via
- *  `isContainedInWorkspace` to defend against symlinks introduced
- *  between discovery and use. */
-export function resolveDataDir(dataPath: string): string | null {
+/** Resolve a schema-declared dataPath against `rootPath` (default:
+ *  the live workspace), refusing anything that escapes — absolute
+ *  paths, `..`-segments, empty string, or symlinks pointing outside
+ *  the root. Returns the absolute path on success, null on refusal.
+ *  Does NOT require the directory to exist; the caller may create it
+ *  on first write. The realpath containment check covers the symlink
+ *  case at discovery time; io operations re-check before each write
+ *  to defend against symlinks introduced between discovery and use.
+ *
+ *  `rootPath` exists as an optional override so a test (or a tool
+ *  driving discovery against a `mkdtempSync` tree) gets a dataDir
+ *  rooted at the same place it asked to scan, not the real workspace.
+ *  Without this, `discoverApps({ workspaceRoot: tmpdir })` would
+ *  discover skills in tmpdir but resolve every app's dataDir against
+ *  `~/mulmoclaude/`, breaking isolation. */
+export function resolveDataDir(dataPath: string, rootPath: string = workspacePath): string | null {
   if (typeof dataPath !== "string" || dataPath.length === 0) return null;
   if (path.isAbsolute(dataPath)) return null;
   const normalized = path.normalize(dataPath);
   if (normalized.startsWith("..") || normalized.includes(`${path.sep}..${path.sep}`)) return null;
-  const resolved = path.resolve(workspacePath, normalized);
-  if (!isContainedInWorkspace(resolved)) return null;
+  const resolved = path.resolve(rootPath, normalized);
+  if (!isContainedInRoot(resolved, rootPath)) return null;
   return resolved;
 }
 

--- a/server/workspace/apps/types.ts
+++ b/server/workspace/apps/types.ts
@@ -9,7 +9,7 @@
 // tables / cross-collection refs / derived fields / actions are
 // deferred to follow-ups (see plans/feat-skill-driven-apps.md).
 
-export type AppFieldType = "string" | "text" | "email" | "number" | "date" | "markdown";
+export type AppFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown";
 
 export type AppSource = "user" | "project";
 

--- a/server/workspace/skills-preset/mc-worklog/SKILL.md
+++ b/server/workspace/skills-preset/mc-worklog/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: mc-worklog
+description: A simple timesheet — log billable / non-billable hours per client per day as JSON files. Skill files at `.claude/skills/mc-worklog/` (SKILL.md + schema.json); records at `data/worklog/items/<id>.json`. User views records at `/apps/mc-worklog`, rendered from the schema by the host. Companion to the `mc-clients` skill — clientId values reference that database.
+---
+
+# Worklog (schema-driven app)
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+## Files
+
+| Purpose | Path |
+|---|---|
+| This skill's instructions (you are reading it) | `.claude/skills/mc-worklog/SKILL.md` |
+| Field schema (source of truth for the host UI) | `.claude/skills/mc-worklog/schema.json` |
+| Records — one JSON per worklog entry | `data/worklog/items/<id>.json` |
+| Client database (referenced by `clientId`) | `data/clients/items/` (managed by `mc-clients` skill) |
+| User-visible app surface | `/apps/mc-worklog` (in the host UI) |
+
+You write JSON; the host's `<AppCollectionView>` reads the same files and
+renders a table + form. There is no separate database — the workspace IS the
+database.
+
+## Record shape
+
+The schema declares these fields (read `schema.json` for the authoritative
+types):
+
+- `id` — string, **primary key** (the filename, no extension)
+- `date` — ISO date `YYYY-MM-DD`, **required**
+- `clientId` — string, **required** (slug from `data/clients/items/`)
+- `hours` — decimal number, **required** (1.5 = 90 minutes; not seconds)
+- `billable` — boolean (defaults to `true` if the user doesn't say otherwise)
+- `notes` — markdown (what was worked on)
+
+`id` format: `{date}-{clientId}-{4-char-hex}` (e.g.
+`2026-05-23-acme-corp-a1b2`). The hex suffix avoids collisions for multiple
+sessions in the same day for the same client. Generate the suffix randomly
+and check that the resulting file doesn't already exist.
+
+## clientId resolution (until `ref` exists)
+
+The schema language doesn't yet have a `ref` field type, so `clientId` is a
+free string and the host doesn't validate that it points at a real client.
+
+That validation is your job:
+
+- When the user says "log 2 hours for Acme", list `data/clients/items/` first,
+  find the slug whose `name` matches "Acme" (case-insensitive substring is
+  fine for a first pass), and use that slug as `clientId`.
+- If no match: ask the user whether to (a) create the client first (via the
+  `mc-clients` skill) or (b) use a literal slug they provide.
+- Never silently invent a clientId that doesn't exist in `data/clients/items/`
+  — that breaks the table the user sees at `/apps/mc-worklog` and any
+  downstream reporting.
+
+## What to do
+
+**Log hours**: derive `id`, write `data/worklog/items/<id>.json` with the
+fields you have. Default `billable: true`; default `date` to today if the
+user didn't specify. The skill explicitly does NOT track start/end times in
+this iteration — just total hours per day per client.
+
+**List / summarize**: read `data/worklog/items/` and answer from those
+files. Don't recite the whole table in chat — the user can see it at
+`/apps/mc-worklog`. For aggregates ("how many hours did I bill Acme last
+month?") group by clientId + date range and answer in one line.
+
+**Edit / delete**: same conventions as `mc-clients` — read, merge, write,
+or unlink. Preserve fields you weren't asked to change.
+
+## When to ask vs. when to act
+
+If the user gives you a clear "log N hours for X today" sentence with all
+the fields, just write the record. Use `presentForm` only when something is
+genuinely ambiguous (e.g. multiple clients match the name they typed).

--- a/server/workspace/skills-preset/mc-worklog/schema.json
+++ b/server/workspace/skills-preset/mc-worklog/schema.json
@@ -1,0 +1,37 @@
+{
+  "title": "Worklog",
+  "icon": "schedule",
+  "dataPath": "data/worklog/items",
+  "primaryKey": "id",
+  "fields": {
+    "id": {
+      "type": "string",
+      "label": "ID",
+      "primary": true,
+      "required": true
+    },
+    "date": {
+      "type": "date",
+      "label": "Date",
+      "required": true
+    },
+    "clientId": {
+      "type": "string",
+      "label": "Client",
+      "required": true
+    },
+    "hours": {
+      "type": "number",
+      "label": "Hours",
+      "required": true
+    },
+    "billable": {
+      "type": "boolean",
+      "label": "Billable"
+    },
+    "notes": {
+      "type": "markdown",
+      "label": "Notes"
+    }
+  }
+}

--- a/src/components/AppCollectionView.vue
+++ b/src/components/AppCollectionView.vue
@@ -218,6 +218,15 @@ interface EditState {
    *  generic stays unambiguous (string vs boolean) — vue-tsc complains
    *  about `string | boolean` slots used as modelValue. */
   bool: Record<string, boolean>;
+  /** Boolean keys whose value was present in the source record at
+   *  the time the editor was opened. Used by `draftToRecord` to
+   *  preserve omission semantics: an originally-absent boolean is
+   *  only emitted if the user explicitly checked it (false stays
+   *  omitted = "default-applies"). Without this, opening + saving
+   *  a legacy record that omits `billable` would silently materialize
+   *  `billable: false`, which the `mc-worklog` skill treats as a
+   *  meaningful state distinct from "absent = default true". */
+  boolOriginallyPresent: Record<string, boolean>;
   /** For edit mode: the original item id pinned to the URL. */
   originalId: string | null;
 }
@@ -293,11 +302,17 @@ function openCreate(): void {
   if (!app.value) return;
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
+  const boolOriginallyPresent: Record<string, boolean> = {};
   for (const [key, field] of Object.entries(app.value.schema.fields)) {
-    if (field.type === "boolean") bool[key] = false;
-    else text[key] = "";
+    if (field.type === "boolean") {
+      bool[key] = false;
+      // New record — no boolean was originally present.
+      boolOriginallyPresent[key] = false;
+    } else {
+      text[key] = "";
+    }
   }
-  editing.value = { mode: "create", text, bool, originalId: null };
+  editing.value = { mode: "create", text, bool, boolOriginallyPresent, originalId: null };
   saveError.value = null;
 }
 
@@ -305,17 +320,25 @@ function openEdit(item: AppItem): void {
   if (!app.value) return;
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
+  const boolOriginallyPresent: Record<string, boolean> = {};
   for (const [key, field] of Object.entries(app.value.schema.fields)) {
     const raw = item[key];
     if (field.type === "boolean") {
       bool[key] = raw === true;
+      // Track whether the key was present in the source record so
+      // we can preserve "omitted" through a save that doesn't
+      // touch this field. `typeof raw === "boolean"` is more
+      // defensive than `key in item` because a wrong-typed value
+      // (e.g. `billable: "yes"`) shouldn't be treated as a real
+      // existing boolean state.
+      boolOriginallyPresent[key] = typeof raw === "boolean";
     } else {
       text[key] = raw === undefined || raw === null ? "" : String(raw);
     }
   }
   const primaryRaw = item[app.value.schema.primaryKey];
   const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
-  editing.value = { mode: "edit", text, bool, originalId };
+  editing.value = { mode: "edit", text, bool, boolOriginallyPresent, originalId };
   saveError.value = null;
 }
 
@@ -329,10 +352,19 @@ function draftToRecord(state: EditState, schema: AppSchema): AppItem {
   const record: AppItem = {};
   for (const [key, field] of Object.entries(schema.fields)) {
     if (field.type === "boolean") {
-      // Always include boolean fields so unchecking persists as
-      // `false` rather than disappearing (= "field unset"). Booleans
-      // have an explicit two-state meaning the schema declared.
-      record[key] = state.bool[key] === true;
+      // Preserve omission semantics: only emit the key if it was
+      // originally present in the source record (preserve the
+      // user's prior explicit choice and any subsequent toggle) OR
+      // the user has actively checked it (a brand-new "yes"). An
+      // originally-absent + still-unchecked boolean stays absent,
+      // so a save that doesn't touch the checkbox never materializes
+      // `false` on a legacy record. The mc-worklog SKILL.md
+      // explicitly treats absent as "default true", so collapsing
+      // unset → false would be data-corrupting.
+      const value = state.bool[key] === true;
+      if (state.boolOriginallyPresent[key] || value) {
+        record[key] = value;
+      }
       continue;
     }
     const raw = state.text[key];

--- a/src/components/AppCollectionView.vue
+++ b/src/components/AppCollectionView.vue
@@ -50,7 +50,12 @@
         <tbody class="divide-y divide-gray-100">
           <tr v-for="item in items" :key="String(item[app.schema.primaryKey] ?? '')" class="hover:bg-gray-50">
             <td v-for="(field, key) in app.schema.fields" :key="key" class="px-4 py-2 text-gray-800 align-top max-w-xs">
-              <span class="block truncate">{{ formatCell(item[key], field.type) }}</span>
+              <span v-if="field.type === 'boolean'" class="block">
+                <span v-if="item[key] === true" class="material-icons text-green-600 text-base align-middle">check</span>
+                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" is a universal "empty value" glyph already used in `formatCell` and reused here for the boolean=false case; translating it would diverge the two visual states across locales. -->
+                <span v-else class="text-gray-400">—</span>
+              </span>
+              <span v-else class="block truncate">{{ formatCell(item[key], field.type) }}</span>
             </td>
             <td class="px-4 py-2 text-right whitespace-nowrap">
               <button
@@ -101,10 +106,20 @@
               <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
               <span v-if="field.required" class="text-red-500">*</span>
             </label>
+            <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+              <input
+                :id="`apps-field-${key}`"
+                v-model="editing.bool[key]"
+                type="checkbox"
+                class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-400"
+                :data-testid="`apps-input-${key}`"
+              />
+              <span>{{ editing.bool[key] ? t("common.yes") : t("common.no") }}</span>
+            </label>
             <input
-              v-if="['string', 'email', 'number', 'date'].includes(field.type)"
+              v-else-if="['string', 'email', 'number', 'date'].includes(field.type)"
               :id="`apps-field-${key}`"
-              v-model="editing.draft[key]"
+              v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
               :required="isFieldRequiredInUi(field)"
               :disabled="field.primary === true && editing.mode === 'edit'"
@@ -114,7 +129,7 @@
             <textarea
               v-else
               :id="`apps-field-${key}`"
-              v-model="editing.draft[key]"
+              v-model="editing.text[key]"
               :rows="field.type === 'markdown' ? 6 : 3"
               :required="isFieldRequiredInUi(field)"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
@@ -155,7 +170,7 @@ import { PAGE_ROUTES } from "../router/pageRoutes";
 import ConfirmModal from "./ConfirmModal.vue";
 import { useConfirm } from "../composables/useConfirm";
 
-type FieldType = "string" | "text" | "email" | "number" | "date" | "markdown";
+type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown";
 
 interface FieldSpec {
   type: FieldType;
@@ -194,7 +209,15 @@ interface ItemMutationResponse {
 
 interface EditState {
   mode: "create" | "edit";
-  draft: Record<string, string>;
+  /** Form drafts for text-like inputs. v-model on `<input type="text">`
+   *  / `<textarea>` / number / date / email all bind here as strings;
+   *  `draftToRecord` parses numbers and date strings before posting. */
+  text: Record<string, string>;
+  /** Form drafts for `boolean`-typed fields. v-model on `<input
+   *  type="checkbox">` binds here. Split from `text` so the v-model
+   *  generic stays unambiguous (string vs boolean) — vue-tsc complains
+   *  about `string | boolean` slots used as modelValue. */
+  bool: Record<string, boolean>;
   /** For edit mode: the original item id pinned to the URL. */
   originalId: string | null;
 }
@@ -268,22 +291,31 @@ function formatCell(value: unknown, type: FieldType): string {
 
 function openCreate(): void {
   if (!app.value) return;
-  const draft: Record<string, string> = {};
-  for (const key of Object.keys(app.value.schema.fields)) draft[key] = "";
-  editing.value = { mode: "create", draft, originalId: null };
+  const text: Record<string, string> = {};
+  const bool: Record<string, boolean> = {};
+  for (const [key, field] of Object.entries(app.value.schema.fields)) {
+    if (field.type === "boolean") bool[key] = false;
+    else text[key] = "";
+  }
+  editing.value = { mode: "create", text, bool, originalId: null };
   saveError.value = null;
 }
 
 function openEdit(item: AppItem): void {
   if (!app.value) return;
-  const draft: Record<string, string> = {};
-  for (const key of Object.keys(app.value.schema.fields)) {
+  const text: Record<string, string> = {};
+  const bool: Record<string, boolean> = {};
+  for (const [key, field] of Object.entries(app.value.schema.fields)) {
     const raw = item[key];
-    draft[key] = raw === undefined || raw === null ? "" : String(raw);
+    if (field.type === "boolean") {
+      bool[key] = raw === true;
+    } else {
+      text[key] = raw === undefined || raw === null ? "" : String(raw);
+    }
   }
   const primaryRaw = item[app.value.schema.primaryKey];
   const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
-  editing.value = { mode: "edit", draft, originalId };
+  editing.value = { mode: "edit", text, bool, originalId };
   saveError.value = null;
 }
 
@@ -296,7 +328,14 @@ function closeEditor(): void {
 function draftToRecord(state: EditState, schema: AppSchema): AppItem {
   const record: AppItem = {};
   for (const [key, field] of Object.entries(schema.fields)) {
-    const raw = state.draft[key];
+    if (field.type === "boolean") {
+      // Always include boolean fields so unchecking persists as
+      // `false` rather than disappearing (= "field unset"). Booleans
+      // have an explicit two-state meaning the schema declared.
+      record[key] = state.bool[key] === true;
+      continue;
+    }
+    const raw = state.text[key];
     if (raw === undefined || raw === "") continue;
     if (field.type === "number") {
       const num = Number(raw);
@@ -326,7 +365,11 @@ async function saveEditor(): Promise<void> {
   for (const [key, field] of Object.entries(schema.fields)) {
     if (!field.required) continue;
     if (draft.mode === "create" && field.primary === true) continue;
-    if (!draft.draft[key]) {
+    // Booleans always have a value (`false` is a valid answer), so
+    // `required: true` on a boolean field is a no-op rather than a
+    // gate. Skip the empty check for them.
+    if (field.type === "boolean") continue;
+    if (!draft.text[key]) {
       saveError.value = `${field.label}: ${t("appsView.requiredField")}`;
       return;
     }

--- a/src/components/AppCollectionView.vue
+++ b/src/components/AppCollectionView.vue
@@ -113,6 +113,7 @@
                 type="checkbox"
                 class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-400"
                 :data-testid="`apps-input-${key}`"
+                @change="markBoolTouched(key)"
               />
               <span>{{ editing.bool[key] ? t("common.yes") : t("common.no") }}</span>
             </label>
@@ -220,13 +221,20 @@ interface EditState {
   bool: Record<string, boolean>;
   /** Boolean keys whose value was present in the source record at
    *  the time the editor was opened. Used by `draftToRecord` to
-   *  preserve omission semantics: an originally-absent boolean is
-   *  only emitted if the user explicitly checked it (false stays
-   *  omitted = "default-applies"). Without this, opening + saving
-   *  a legacy record that omits `billable` would silently materialize
-   *  `billable: false`, which the `mc-worklog` skill treats as a
-   *  meaningful state distinct from "absent = default true". */
+   *  preserve omission semantics: an originally-absent boolean
+   *  that the user never touched stays omitted (so the consumer's
+   *  default applies — `mc-worklog` treats absent `billable` as
+   *  "default true"). */
   boolOriginallyPresent: Record<string, boolean>;
+  /** Boolean keys whose checkbox the user has actively interacted
+   *  with in this editor session. Combined with
+   *  `boolOriginallyPresent`, this lets `draftToRecord` distinguish
+   *  "untouched and originally absent → omit" from "explicitly
+   *  set to false → emit false". Without the dirty bit a user
+   *  cannot persist an explicit `false` from create mode (every
+   *  unchecked box looks the same as untouched), which blocks
+   *  things like a non-billable mc-worklog entry from the UI. */
+  boolTouched: Record<string, boolean>;
   /** For edit mode: the original item id pinned to the URL. */
   originalId: string | null;
 }
@@ -303,16 +311,18 @@ function openCreate(): void {
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
   const boolOriginallyPresent: Record<string, boolean> = {};
+  const boolTouched: Record<string, boolean> = {};
   for (const [key, field] of Object.entries(app.value.schema.fields)) {
     if (field.type === "boolean") {
       bool[key] = false;
       // New record — no boolean was originally present.
       boolOriginallyPresent[key] = false;
+      boolTouched[key] = false;
     } else {
       text[key] = "";
     }
   }
-  editing.value = { mode: "create", text, bool, boolOriginallyPresent, originalId: null };
+  editing.value = { mode: "create", text, bool, boolOriginallyPresent, boolTouched, originalId: null };
   saveError.value = null;
 }
 
@@ -321,6 +331,7 @@ function openEdit(item: AppItem): void {
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
   const boolOriginallyPresent: Record<string, boolean> = {};
+  const boolTouched: Record<string, boolean> = {};
   for (const [key, field] of Object.entries(app.value.schema.fields)) {
     const raw = item[key];
     if (field.type === "boolean") {
@@ -332,14 +343,19 @@ function openEdit(item: AppItem): void {
       // (e.g. `billable: "yes"`) shouldn't be treated as a real
       // existing boolean state.
       boolOriginallyPresent[key] = typeof raw === "boolean";
+      boolTouched[key] = false;
     } else {
       text[key] = raw === undefined || raw === null ? "" : String(raw);
     }
   }
   const primaryRaw = item[app.value.schema.primaryKey];
   const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
-  editing.value = { mode: "edit", text, bool, boolOriginallyPresent, originalId };
+  editing.value = { mode: "edit", text, bool, boolOriginallyPresent, boolTouched, originalId };
   saveError.value = null;
+}
+
+function markBoolTouched(key: string): void {
+  if (editing.value) editing.value.boolTouched[key] = true;
 }
 
 function closeEditor(): void {
@@ -352,17 +368,21 @@ function draftToRecord(state: EditState, schema: AppSchema): AppItem {
   const record: AppItem = {};
   for (const [key, field] of Object.entries(schema.fields)) {
     if (field.type === "boolean") {
-      // Preserve omission semantics: only emit the key if it was
-      // originally present in the source record (preserve the
-      // user's prior explicit choice and any subsequent toggle) OR
-      // the user has actively checked it (a brand-new "yes"). An
-      // originally-absent + still-unchecked boolean stays absent,
-      // so a save that doesn't touch the checkbox never materializes
-      // `false` on a legacy record. The mc-worklog SKILL.md
-      // explicitly treats absent as "default true", so collapsing
-      // unset → false would be data-corrupting.
+      // Emit the boolean if any of:
+      //   - it was originally present (preserve prior choice + any
+      //     in-session toggle, including explicit false)
+      //   - the user has actively interacted with the checkbox in
+      //     this session (boolTouched — required to make explicit
+      //     `false` round-trippable from create mode, where every
+      //     untouched checkbox would otherwise look like "omit")
+      //   - the schema marks the field required (downstream
+      //     consumers may depend on the key always being present)
+      // Otherwise omit so a brand-new record that didn't touch
+      // an optional boolean doesn't materialize `false` for it,
+      // letting the consumer's default (e.g. mc-worklog's
+      // "absent billable means true") apply.
       const value = state.bool[key] === true;
-      if (state.boolOriginallyPresent[key] || value) {
+      if (state.boolOriginallyPresent[key] || state.boolTouched[key] || field.required) {
         record[key] = value;
       }
       continue;

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -378,20 +378,25 @@ export const ROLES: Role[] = [
     prompt:
       "You are a beta accounting assistant testing the schema-driven app architecture.\n\n" +
       "## How this differs from the regular Accounting role\n\n" +
-      "You do NOT have the dedicated manageClient / manageInvoice / manageWorklog MCP tools. Instead, the user has starred a `mc-clients` skill that defines a client database via a `schema.json` file. The file layout under `data/clients/items/` is the database; the host renders it at `/apps/mc-clients`.\n\n" +
-      "Read `mc-clients`'s `SKILL.md` for the conventions (id format, where files live, when to ask vs. when to act). Use Read / Write / Edit directly for CRUD — these are always available via the Agent SDK; no MCP plugin needed.\n\n" +
+      "You do NOT have the dedicated manageClient / manageInvoice / manageWorklog MCP tools. Instead, the user has starred preset skills that define each domain via a `schema.json` file. The file layouts under `data/<app>/items/` are the database; the host renders each at `/apps/<slug>`.\n\n" +
+      "Available skill-driven apps (read each skill's `SKILL.md` for the per-app conventions — id format, where files live, when to ask vs. when to act):\n\n" +
+      "- **mc-clients** — `data/clients/items/<id>.json`, viewed at `/apps/mc-clients`. Tracks client records (name, email, address, notes).\n" +
+      "- **mc-worklog** — `data/worklog/items/<id>.json`, viewed at `/apps/mc-worklog`. Tracks billable / non-billable hours per client per day. `clientId` references slugs in `data/clients/items/`; resolve client names to slugs by reading that directory first (no `ref` field-type validation yet — that's your responsibility).\n\n" +
+      "Use Read / Write / Edit directly for CRUD — these are always available via the Agent SDK; no MCP plugin needed.\n\n" +
       "## Hard rules\n\n" +
-      "- Always derive a kebab-case `id` from the client's name (e.g. Acme Corp → `acme-corp`). Read the directory first; if the obvious slug is taken, pick a fresh one (`acme-corp-2`) rather than overwriting.\n" +
-      "- Don't recite the full record list in chat after a mutation. A one-line confirmation is enough — the user can see the table at /apps/mc-clients.\n" +
-      "- Use `presentForm` only when you need information the user hasn't given you. Don't use it to re-confirm values they already typed.\n\n" +
+      "- Always derive a kebab-case `id` per each skill's documented format (mc-clients: from name; mc-worklog: `{date}-{clientId}-{4hex}`). Read the directory first; never silently overwrite an existing file.\n" +
+      "- Don't recite the full record list in chat after a mutation. A one-line confirmation is enough — the user can see the table at the app's `/apps/<slug>` route.\n" +
+      "- Use `presentForm` only when you need information the user hasn't given you. Don't use it to re-confirm values they already typed.\n" +
+      "- When logging worklog hours for a client name, resolve the name to a real `clientId` slug by reading `data/clients/items/` first. Never invent a clientId that doesn't exist there — that breaks the worklog table.\n\n" +
       "## When the user asks for something the schema doesn't cover\n\n" +
-      "If the user wants to track a field not declared in `schema.json` (e.g. a phone number, a billing currency), tell them the field isn't part of the current schema and offer two paths: (a) put it in the `notes` markdown field, or (b) extend the schema (which requires the launcher's owner to update the bundled preset). Don't silently add an unknown key to the record.",
+      "If the user wants to track a field not declared in `schema.json` (e.g. a phone number on a client, start/end times on a worklog entry), tell them the field isn't part of the current schema and offer two paths: (a) put it in the `notes` markdown field, or (b) extend the schema (which requires the launcher's owner to update the bundled preset). Don't silently add an unknown key to the record.",
     availablePlugins: [TOOL_NAMES.presentForm],
     queries: [
       "Add a client: Acme Corp, billing@acme.example, San Francisco",
       "List my clients",
-      "What is Acme's email?",
-      "Update Acme's address to One Market Plaza, San Francisco",
+      "Log 2 hours for Acme today on the migration work",
+      "How many hours did I bill Acme this week?",
+      "Log 30 minutes of non-billable internal review for Globex yesterday",
     ],
   },
   {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -10,6 +10,8 @@ const deMessages = {
     dismiss: "Verwerfen",
     add: "Hinzufügen",
     remove: "Entfernen",
+    yes: "Ja",
+    no: "Nein",
     saving: "Wird gespeichert...",
     saved: "Gespeichert",
     noResultsYet: "Noch keine Ergebnisse",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -30,6 +30,8 @@ const enMessages = {
     dismiss: "Dismiss",
     add: "Add",
     remove: "Remove",
+    yes: "Yes",
+    no: "No",
     saving: "Saving...",
     saved: "Saved",
     noResultsYet: "No results yet",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -15,6 +15,8 @@ const esMessages = {
     dismiss: "Descartar",
     add: "Añadir",
     remove: "Quitar",
+    yes: "Sí",
+    no: "No",
     saving: "Guardando...",
     saved: "Guardado",
     noResultsYet: "Aún no hay resultados",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -10,6 +10,8 @@ const frMessages = {
     dismiss: "Ignorer",
     add: "Ajouter",
     remove: "Supprimer",
+    yes: "Oui",
+    no: "Non",
     saving: "Enregistrement...",
     saved: "Enregistré",
     noResultsYet: "Aucun résultat pour le moment",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -15,6 +15,8 @@ const jaMessages = {
     dismiss: "閉じる",
     add: "追加",
     remove: "削除",
+    yes: "はい",
+    no: "いいえ",
     saving: "保存中...",
     saved: "保存しました",
     noResultsYet: "まだ結果はありません",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -15,6 +15,8 @@ const koMessages = {
     dismiss: "닫기",
     add: "추가",
     remove: "삭제",
+    yes: "예",
+    no: "아니오",
     saving: "저장 중...",
     saved: "저장됨",
     noResultsYet: "아직 결과가 없습니다",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -10,6 +10,8 @@ const ptBRMessages = {
     dismiss: "Dispensar",
     add: "Adicionar",
     remove: "Remover",
+    yes: "Sim",
+    no: "Não",
     saving: "Salvando...",
     saved: "Salvo",
     noResultsYet: "Ainda não há resultados",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -14,6 +14,8 @@ const zhMessages = {
     dismiss: "关闭",
     add: "添加",
     remove: "移除",
+    yes: "是",
+    no: "否",
     saving: "保存中...",
     saved: "已保存",
     noResultsYet: "暂无结果",

--- a/test/workspace/apps/test_discovery.ts
+++ b/test/workspace/apps/test_discovery.ts
@@ -144,6 +144,27 @@ describe("discoverApps — structural validation", () => {
   });
 });
 
+describe("discoverApps — workspaceRoot propagation", () => {
+  it("roots each app's dataDir at the supplied workspaceRoot, not the live workspace", async () => {
+    // Regression for PR #1489 Codex P1: discovery used to pass
+    // `workspaceRoot` through to `.claude/skills/` scanning but
+    // call `resolveDataDir` with no arg, so dataDir resolved
+    // against the real `~/mulmoclaude/` and broke test isolation.
+    writeSkill("test-rooting", {
+      title: "Rooting",
+      icon: "anchor",
+      dataPath: "data/rooting/items",
+      primaryKey: "id",
+      fields: { id: { type: "string", label: "ID", primary: true } },
+    });
+    const apps = await listApps();
+    assert.equal(apps.length, 1);
+    const dataDir = apps[0]?.dataDir;
+    assert.ok(dataDir, "dataDir should be set");
+    assert.ok(dataDir.startsWith(`${workdir}${path.sep}`), `dataDir ${dataDir} should live under workdir ${workdir}`);
+  });
+});
+
 describe("loadApp", () => {
   it("returns the named project-scope app", async () => {
     writeSkill("test-load", {

--- a/test/workspace/apps/test_discovery.ts
+++ b/test/workspace/apps/test_discovery.ts
@@ -1,0 +1,171 @@
+// Schema validation + field-type tests for the apps discovery
+// module. Locks in: (1) the v0 supported field-type set, (2) the
+// rejection of unknown types and structurally malformed schemas,
+// (3) the primaryKey-must-be-flagged-primary check from PR-1483
+// review round 1.
+//
+// Drives the live `discoverApps` against a `mkdtempSync` tree by
+// supplying `workspaceRoot` + `userSkillsDir` overrides — same
+// pattern as `server/workspace/skills/catalog.ts` tests.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { discoverApps, loadApp } from "../../../server/workspace/apps/discovery.js";
+
+let workdir: string;
+let emptyUserDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "apps-discovery-"));
+  // Empty stand-in for ~/.claude/skills/ so the user-scope scan
+  // doesn't read real skills into our assertions. The directory
+  // exists but contains nothing.
+  emptyUserDir = mkdtempSync(path.join(tmpdir(), "apps-discovery-user-"));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(emptyUserDir, { recursive: true, force: true });
+});
+
+function writeSkill(slug: string, schema: object | string | null): void {
+  const dir = path.join(workdir, ".claude/skills", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${slug}\ndescription: test fixture\n---\nbody\n`);
+  if (schema !== null) {
+    const body = typeof schema === "string" ? schema : JSON.stringify(schema);
+    writeFileSync(path.join(dir, "schema.json"), body);
+  }
+}
+
+async function listApps() {
+  return discoverApps({ workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+}
+
+describe("discoverApps — field-type support", () => {
+  it("accepts a schema using every v0 field type, including boolean", async () => {
+    writeSkill("test-allfields", {
+      title: "All Fields",
+      icon: "category",
+      dataPath: "data/all/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name" },
+        bio: { type: "text", label: "Bio" },
+        email: { type: "email", label: "Email" },
+        age: { type: "number", label: "Age" },
+        joined: { type: "date", label: "Joined" },
+        active: { type: "boolean", label: "Active" },
+        notes: { type: "markdown", label: "Notes" },
+      },
+    });
+    const apps = await listApps();
+    assert.equal(apps.length, 1);
+    assert.equal(apps[0]?.slug, "test-allfields");
+    assert.equal(apps[0]?.schema.fields.active?.type, "boolean");
+  });
+
+  it("rejects a schema with an unknown field type (still v0)", async () => {
+    writeSkill("test-ref-not-yet", {
+      title: "Ref",
+      icon: "link",
+      dataPath: "data/ref/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        clientId: { type: "ref", label: "Client" }, // ref is deferred
+      },
+    });
+    const apps = await listApps();
+    assert.equal(apps.length, 0, "schema with unsupported field type must be skipped");
+  });
+});
+
+describe("discoverApps — structural validation", () => {
+  it("rejects a schema whose primaryKey field is not flagged primary: true", async () => {
+    writeSkill("test-missing-primary-flag", {
+      title: "Missing Flag",
+      icon: "warning",
+      dataPath: "data/missing/items",
+      primaryKey: "id",
+      fields: {
+        // Note: no `primary: true` — discovery must reject this
+        // since the CollectionView disable-on-edit check is
+        // `field.primary === true`.
+        id: { type: "string", label: "ID", required: true },
+        name: { type: "string", label: "Name" },
+      },
+    });
+    const apps = await listApps();
+    assert.equal(apps.length, 0);
+  });
+
+  it("rejects a schema whose primaryKey doesn't name a declared field", async () => {
+    writeSkill("test-orphan-primary", {
+      title: "Orphan",
+      icon: "warning",
+      dataPath: "data/orphan/items",
+      primaryKey: "nonexistent",
+      fields: {
+        id: { type: "string", label: "ID", primary: true },
+      },
+    });
+    const apps = await listApps();
+    assert.equal(apps.length, 0);
+  });
+
+  it("rejects a schema whose dataPath escapes the workspace", async () => {
+    writeSkill("test-escape", {
+      title: "Escape",
+      icon: "warning",
+      dataPath: "../../etc",
+      primaryKey: "id",
+      fields: { id: { type: "string", label: "ID", primary: true } },
+    });
+    const apps = await listApps();
+    assert.equal(apps.length, 0);
+  });
+
+  it("rejects malformed JSON in schema.json", async () => {
+    writeSkill("test-bad-json", "{ not valid json");
+    const apps = await listApps();
+    assert.equal(apps.length, 0);
+  });
+
+  it("ignores skills that ship no schema.json (they're regular skills)", async () => {
+    writeSkill("test-no-schema", null);
+    const apps = await listApps();
+    assert.equal(apps.length, 0);
+  });
+});
+
+describe("loadApp", () => {
+  it("returns the named project-scope app", async () => {
+    writeSkill("test-load", {
+      title: "Loadable",
+      icon: "download",
+      dataPath: "data/load/items",
+      primaryKey: "id",
+      fields: { id: { type: "string", label: "ID", primary: true } },
+    });
+    const app = await loadApp("test-load", { workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+    assert.notEqual(app, null);
+    assert.equal(app?.slug, "test-load");
+    assert.equal(app?.source, "project");
+  });
+
+  it("returns null for an invalid slug", async () => {
+    const app = await loadApp("../escape", { workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+    assert.equal(app, null);
+  });
+
+  it("returns null when the named app does not exist", async () => {
+    const app = await loadApp("nope", { workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+    assert.equal(app, null);
+  });
+});


### PR DESCRIPTION
## Summary

Validates the second-app hypothesis from PR #1483: the same schema-driven primitive (`<AppCollectionView>` + `/api/apps`) can host another domain with **one** new schema-language addition (`boolean`) and **zero** new host UI work. See `plans/feat-skill-driven-apps-worklog.md` for the success bar and what's explicitly deferred.

**Host change is small** — that's the point:

- `AppFieldType` gains `boolean` (~3 LoC across `types.ts` + `discovery.ts`).
- `<AppCollectionView>` renders booleans as a checkbox in the form (with a Yes/No label) and a Material `check` / em-dash in the table. `EditState.draft` splits into `text` + `bool` slots so the v-model generic stays unambiguous (vue-tsc rejects `string | boolean` modelValue slots).
- `common.yes` / `common.no` added across all 8 locales for the checkbox label.
- Required-check skips booleans (`false` is a valid answer; a "required checkbox" is a UX foot-gun).

**New skill bundled as a preset** — `mc-worklog`: 5 fields (date / clientId / hours / billable / notes). Skill body teaches Claude the id-format convention (`{date}-{clientId}-{4hex}`) and how to resolve client names to slugs against `data/clients/items/` (the `ref` field type is still deferred; the cross-skill validation is currently the LLM's responsibility — and it works on the first try, see trace below).

**Role + discovery + tests:**

- "Account beta" role prompt now mentions both `mc-clients` and `mc-worklog`, with a hard rule never to invent a `clientId` that doesn't exist in `data/clients/items/`.
- `discoverApps` / `loadApp` grow an optional `{ workspaceRoot, userSkillsDir }` override (matches `catalog.ts` / `io.ts` pattern) so the new `test/workspace/apps/test_discovery.ts` can drive the full pipeline against a tmpdir.
- **+11 new tests** covering boolean type acceptance, ref/unknown-type rejection, primary-flag validation, dataPath escape, malformed JSON, schema-less skills, and `loadApp` happy/sad paths. Total apps test count: 26.

## Manual validation (already done locally)

With Account beta role, prompted ``"Log 2 hours for Acme today on the migration work"``. Claude's actual trace:

1. Listed `data/clients/items/` and `data/worklog/items/`
2. Read `acme-corp.json` to confirm the name match → resolved to slug `acme-corp`
3. Read `mc-worklog/SKILL.md` to confirm the id-format convention
4. Wrote `data/worklog/items/2026-05-24-acme-corp-3f7c.json` with the right shape (`billable: true` defaulted; `notes: "Migration work"`)

Zero new MCP tools were used — just `Bash` + `Read` + `Write` via the Agent SDK.

## Success-bar scorecard (from the plan)

| Goal | Target | Actual |
|---|---|---|
| Boolean addition cost | ≤ 30 LoC across 3 files | ~12 LoC across 3 files |
| Skill size (SKILL.md + schema.json) | ≤ 100 LoC | 95 LoC |
| Per-app branches in CollectionView | 0 | 0 |
| Claude logs an entry on first try | Manual | ✓ |

## What's explicitly deferred (the gap from the real worklog plugin)

Tracked in the plan; none of these block this iteration:

- `datetime` / `enum` / `ref` / nested-object array field types
- candidate → committed → superseded workflow
- Append-only versioning (`supersedes`, `deleted` tombstones)

`ref` and `enum` are the two that'd unlock the most for invoice migration.

## Test plan

- [ ] `yarn dev` boots; preset sync log shows `mc-worklog` alongside `mc-clients`
- [ ] `/skills` → ★ Star **Worklog** → `.claude/skills/mc-worklog/{SKILL.md,schema.json}` populated
- [ ] **Apps** launcher → `/apps` lists both Clients and Worklog
- [ ] Account beta: ``Log 2 hours for Acme today on migration work`` → `data/worklog/items/<id>.json` with right shape
- [ ] `/apps/mc-worklog` → row with green `check` icon for `billable: true`
- [ ] `+` button → checkbox renders with Yes/No label; submit creates record
- [ ] Edit → uncheck billable → save → file's `billable` flips to `false`; reopen shows unchecked
- [ ] ``Log 3 hours for SomeNonexistentCompany today`` → Claude asks rather than inventing a clientId
- [ ] `yarn lint`, `yarn typecheck`, `yarn test`, `yarn build` all green (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added boolean field support with checkbox UI, table rendering, and proper create/edit round-tripping; introduced a schema-driven Worklog preset (id, date, clientId, hours, optional billable, notes).

* **Docs**
  * New planning doc and Worklog skill instructions; updated account-role guidance for schema-driven presets and manual test/acceptance criteria.

* **Discovery / Config**
  * Discovery now accepts workspace overrides and resolves data roots relative to the supplied workspace.

* **Localization**
  * Added yes/no translations for multiple languages.

* **Tests**
  * Added discovery and schema validation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->