### PR TITLE
feat(collections): add `ref` field type + migrate mc-worklog.clientId

### DIFF
--- a/plans/feat-collections-ref-field.md
+++ b/plans/feat-collections-ref-field.md
@@ -1,0 +1,140 @@
+# Plan: `ref` Field Type for Collections
+
+Follow-up to [plans/done/feat-skill-driven-apps.md](done/feat-skill-driven-apps.md)
+(PR #1483) and [plans/done/feat-skill-driven-apps-worklog.md](done/feat-skill-driven-apps-worklog.md)
+(PR #1489). First of three follow-up PRs aimed at making the
+schema-driven collection primitive expressive enough for invoice
+migration. This PR adds **only** the `ref` field type — `money`,
+`table`, `derived`, and `actions` are deferred to subsequent PRs.
+
+## Why this PR alone
+
+`mc-worklog` declares `clientId` as a plain `string` today. Its
+SKILL.md tells Claude to manually resolve client names to slugs by
+listing `data/clients/items/` first — a "soft" cross-collection
+reference that's the LLM's responsibility to honor. The host
+validates nothing and the UI shows just the raw slug.
+
+`ref` turns that informal convention into a first-class schema
+construct: the field declares which collection it points at, the
+host renders a clickable link (Acme Corp → `/collections/mc-clients`),
+and the form provides a dropdown picker. Pulling this out as its own
+PR also tests the **pattern** for adding a new schema feature — a
+template that PR-B (`money` + `table` + `derived`) and PR-C
+(`actions` + template renderer + invoice skill) can both follow.
+
+## Architecture
+
+### Schema language addition
+
+```jsonc
+"clientId": {
+  "type": "ref",
+  "to": "mc-clients",      // collection slug the value references
+  "label": "Client",
+  "required": true
+}
+```
+
+The record stores the **slug** of the target item — no shape change
+(`{"clientId": "acme-corp"}` looks identical before and after).
+The schema just gives the host enough metadata to:
+
+- render a clickable link instead of plain text,
+- present a dropdown picker instead of a free-text input,
+- (later) validate the slug exists in the target collection.
+
+### Host changes
+
+**Server** (`server/workspace/collections/`):
+
+- `types.ts`: add `"ref"` to `CollectionFieldType`; `CollectionFieldSpec`
+  gains an optional `to?: string`.
+- `discovery.ts`: extend `FieldSpecSchema` so `type: "ref"` requires
+  a non-empty `to`; bare `type: "ref"` (no `to`) rejects the schema.
+
+No runtime validation (the slug being a real client) — deferred. The
+SKILL.md still tells Claude to use real client slugs; the schema
+declaration plus dropdown UI is the safety net for human input.
+
+**Frontend** (`src/components/CollectionView.vue`):
+
+- New `refCache: Record<targetSlug, Record<itemSlug, displayName>>`
+  loaded after the current collection's items arrive. One fetch per
+  unique target collection, regardless of how many ref fields point
+  there.
+- **Table cell**: `<router-link>` to `/collections/<to>` (with
+  `?highlight=<slug>` query). Displays the heuristic name (prefers
+  `name` field, falls back to `title`, then primaryKey value).
+- **Form input**: `<select>` populated from the cached items;
+  falls back to plain text input if the target collection has no
+  items or hasn't loaded.
+- `draftToRecord` / `openCreate` / `openEdit` / required-check:
+  ref values bucket with text (same string-typed slot, no boolean-
+  style preservation needed).
+
+Highlight rendering (scroll-into-view + visual ping on the matching
+row) is deferred — query param is set, scroll handler is a small
+follow-up.
+
+### Skill update
+
+`server/workspace/skills-preset/mc-worklog/schema.json`: change
+`clientId` from `type: "string"` to:
+
+```json
+{ "type": "ref", "to": "mc-clients", "label": "Client", "required": true }
+```
+
+`SKILL.md`: drop the "## clientId resolution (until `ref` exists)"
+section that walked Claude through the manual lookup. Replace with
+a brief note that the host UI provides a picker and that Claude
+should still pick a real existing slug rather than inventing one
+(the picker is for the human; Claude writes the raw slug).
+
+## Test plan
+
+After `yarn dev` reboot, the auto-update sync will pick up the new
+mc-worklog SKILL.md + schema.json (no manual re-star needed).
+
+- [ ] `/collections/mc-worklog` table shows the `Client` column as
+      clickable links displaying the client's `name` (e.g. "Acme
+      Corp"), not the raw slug
+- [ ] Clicking a client link lands on `/collections/mc-clients?highlight=acme-corp`
+- [ ] `+` on mc-worklog renders the Client field as a `<select>`
+      populated with all clients; selecting one saves the slug
+- [ ] Editing an existing entry shows the current client pre-selected
+- [ ] If the dropdown is empty (e.g. user deleted all clients), the
+      field falls back to a text input so the form still works
+- [ ] A schema declaring `type: "ref"` without `to` is rejected on
+      discovery (warn-and-skip; covered by new test)
+- [ ] All existing apps tests + 437 e2e tests still pass
+
+## Deferred (the gap from a full ref implementation)
+
+- **Runtime referential integrity**: writing a worklog with
+  `clientId: "nonexistent-slug"` is currently accepted. Server-side
+  validation is straightforward (the host already loads target
+  collections for the dropdown) but adds the question of what to
+  do with orphaned refs when a target gets deleted (cascade /
+  reject / soft-orphan). Defer until the question forces itself.
+- **Display field declaration**: target collections currently
+  surface a heuristic name (`name` / `title` / primaryKey). Adding
+  `displayField` to the schema gives the author explicit control
+  but adds a knob; defer until a real schema wants something other
+  than the heuristic.
+- **Highlight on landing**: the link sets `?highlight=<slug>` but
+  CollectionView doesn't yet scroll-into-view + visual ping. Small,
+  cosmetic; defer.
+- **Reverse navigation** (`/collections/mc-clients` showing "used by
+  N worklog entries"): would require an index across collections.
+  Out of scope for ref alone.
+
+## What success looks like
+
+- One new field type costs ~50 LoC across types + discovery + UI
+  (matches the boolean cost from PR #1489)
+- `mc-worklog` SKILL.md shrinks (drops the manual-resolution section)
+- Clicking a client in the worklog table lands on the client view
+- The pattern (schema enum extension + UI branch + cache + skill
+  migration) is reusable for the remaining field types in PR-B/C

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -14,12 +14,22 @@ import { USER_SKILLS_DIR, projectSkillsDir } from "../skills/paths.js";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths.js";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "./types.js";
 
-const FieldSpecSchema = z.object({
-  type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown"]),
-  label: z.string().min(1),
-  primary: z.boolean().optional(),
-  required: z.boolean().optional(),
-});
+const FieldSpecSchema = z
+  .object({
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref"]),
+    label: z.string().min(1),
+    primary: z.boolean().optional(),
+    required: z.boolean().optional(),
+    /** Target collection slug, required iff type === "ref". The
+     *  refine below enforces the cross-field rule (Zod has no
+     *  first-class discriminated union for this shape; refine is
+     *  the standard escape hatch). */
+    to: z.string().min(1).optional(),
+  })
+  .refine((spec) => spec.type !== "ref" || (typeof spec.to === "string" && spec.to.length > 0), {
+    message: "fields with type 'ref' must declare a non-empty `to` (target collection slug)",
+    path: ["to"],
+  });
 
 const CollectionSchemaZ = z.object({
   title: z.string().min(1),

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -26,10 +26,25 @@ const FieldSpecSchema = z
      *  the standard escape hatch). */
     to: z.string().min(1).optional(),
   })
-  .refine((spec) => spec.type !== "ref" || (typeof spec.to === "string" && spec.to.length > 0), {
-    message: "fields with type 'ref' must declare a non-empty `to` (target collection slug)",
-    path: ["to"],
-  });
+  .refine(
+    (spec) => {
+      if (spec.type !== "ref") return true;
+      // Cross-field constraint: a `ref` field MUST declare a `to`,
+      // AND that `to` must be a valid slug. Non-slug values like
+      // `../foo` or `mc-clients/extra` would otherwise produce
+      // malformed `/collections/${field.to}` router targets and
+      // behavior-mismatched API fetches (the fetch URI-encodes
+      // each segment but the router-link interpolates raw —
+      // Codex P2 review on PR #1495). Same shape we enforce on
+      // collection slugs themselves via `safeSlugName`.
+      if (typeof spec.to !== "string") return false;
+      return safeSlugName(spec.to) !== null;
+    },
+    {
+      message: "fields with type 'ref' must declare a `to` that is a valid collection slug (alphanumeric / hyphen / underscore, no path separators)",
+      path: ["to"],
+    },
+  );
 
 const CollectionSchemaZ = z.object({
   title: z.string().min(1),

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -11,7 +11,7 @@
 // plans/done/feat-skill-driven-apps-worklog.md — historical names predate
 // the rename).
 
-export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown";
+export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref";
 
 export type CollectionSource = "user" | "project";
 
@@ -22,6 +22,14 @@ export interface CollectionFieldSpec {
    *  separate auto-id). Exactly one field per schema may set this. */
   primary?: boolean;
   required?: boolean;
+  /** When `type === "ref"`: the slug of the target collection the
+   *  field's value references (e.g. `clientId` in mc-worklog has
+   *  `to: "mc-clients"`). The record stores the target item's
+   *  primary-key slug as a plain string; the host uses `to` to
+   *  render a clickable link, populate a dropdown picker, and
+   *  (future) validate referential integrity. Required when type
+   *  is `ref`; ignored on every other type. */
+  to?: string;
 }
 
 export interface CollectionSchema {

--- a/server/workspace/skills-preset/mc-worklog/SKILL.md
+++ b/server/workspace/skills-preset/mc-worklog/SKILL.md
@@ -29,7 +29,7 @@ types):
 
 - `id` — string, **primary key** (the filename, no extension)
 - `date` — ISO date `YYYY-MM-DD`, **required**
-- `clientId` — string, **required** (slug from `data/clients/items/`)
+- `clientId` — ref → `mc-clients`, **required** (slug from `data/clients/items/`)
 - `hours` — decimal number, **required** (1.5 = 90 minutes; not seconds)
 - `billable` — boolean (defaults to `true` if the user doesn't say otherwise)
 - `notes` — markdown (what was worked on)
@@ -39,21 +39,20 @@ types):
 sessions in the same day for the same client. Generate the suffix randomly
 and check that the resulting file doesn't already exist.
 
-## clientId resolution (until `ref` exists)
+## clientId resolution
 
-The schema language doesn't yet have a `ref` field type, so `clientId` is a
-free string and the host doesn't validate that it points at a real client.
+`clientId` is a `ref` field pointing at the `mc-clients` collection.
+The host renders it as a dropdown picker in the UI and a clickable link
+in the table, but you write the raw slug into the JSON.
 
-That validation is your job:
+When the user says "log 2 hours for Acme":
 
-- When the user says "log 2 hours for Acme", list `data/clients/items/` first,
-  find the slug whose `name` matches "Acme" (case-insensitive substring is
-  fine for a first pass), and use that slug as `clientId`.
-- If no match: ask the user whether to (a) create the client first (via the
-  `mc-clients` skill) or (b) use a literal slug they provide.
-- Never silently invent a clientId that doesn't exist in `data/clients/items/`
-  — that breaks the table the user sees at `/collections/mc-worklog` and any
-  downstream reporting.
+- List `data/clients/items/` and find the slug whose `name` matches
+  "Acme" (case-insensitive substring is fine for a first pass).
+- If no match: ask the user whether to (a) create the client first
+  (via the `mc-clients` skill) or (b) use a literal slug they provide.
+- Never invent a clientId that doesn't exist in `data/clients/items/` —
+  it'll show up as a broken link in the worklog table.
 
 ## What to do
 

--- a/server/workspace/skills-preset/mc-worklog/schema.json
+++ b/server/workspace/skills-preset/mc-worklog/schema.json
@@ -16,7 +16,8 @@
       "required": true
     },
     "clientId": {
-      "type": "string",
+      "type": "ref",
+      "to": "mc-clients",
       "label": "Client",
       "required": true
     },

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -55,6 +55,14 @@
                 <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" is a universal "empty value" glyph already used in `formatCell` and reused here for the boolean=false case; translating it would diverge the two visual states across locales. -->
                 <span v-else class="text-gray-400">—</span>
               </span>
+              <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
+                <router-link
+                  :to="{ path: `/collections/${field.to}`, query: { highlight: String(item[key]) } }"
+                  class="text-blue-600 hover:underline"
+                  :data-testid="`collections-ref-link-${key}-${item[key]}`"
+                  >{{ refDisplay(field.to, String(item[key])) }}</router-link
+                >
+              </span>
               <span v-else class="block truncate">{{ formatCell(item[key], field.type) }}</span>
             </td>
             <td class="px-4 py-2 text-right whitespace-nowrap">
@@ -117,8 +125,19 @@
               />
               <span>{{ editing.bool[key] ? t("common.yes") : t("common.no") }}</span>
             </label>
+            <select
+              v-else-if="field.type === 'ref' && field.to && refOptions(field.to).length > 0"
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :required="isFieldRequiredInUi(field)"
+              class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+              :data-testid="`collections-input-${key}`"
+            >
+              <option value="">{{ t("collectionsView.refPlaceholder") }}</option>
+              <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+            </select>
             <input
-              v-else-if="['string', 'email', 'number', 'date'].includes(field.type)"
+              v-else-if="['string', 'email', 'number', 'date', 'ref'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
@@ -171,14 +190,25 @@ import { PAGE_ROUTES } from "../router/pageRoutes";
 import ConfirmModal from "./ConfirmModal.vue";
 import { useConfirm } from "../composables/useConfirm";
 
-type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown";
+type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref";
 
 interface FieldSpec {
   type: FieldType;
   label: string;
   primary?: boolean;
   required?: boolean;
+  /** When type === "ref": slug of the target collection (see
+   *  plans/feat-collections-ref-field.md). */
+  to?: string;
 }
+
+/** Per-target-collection cache: maps an item's primary-key slug to
+ *  the value we'll show in the table and dropdown. Filled in by
+ *  `loadRefTargets` after the main collection's items arrive — one
+ *  fetch per unique target collection, regardless of how many ref
+ *  fields point at it. */
+type RefDisplayMap = Record<string, string>;
+type RefCache = Record<string, RefDisplayMap>;
 
 interface CollectionSchema {
   title: string;
@@ -251,6 +281,7 @@ const loadError = ref<string | null>(null);
 const editing = ref<EditState | null>(null);
 const saving = ref(false);
 const saveError = ref<string | null>(null);
+const refCache = ref<RefCache>({});
 
 function detailUrl(slug: string): string {
   return API_ROUTES.collections.detail.replace(":slug", encodeURIComponent(slug));
@@ -269,6 +300,7 @@ async function loadCollection(slug: string): Promise<void> {
   loadError.value = null;
   collection.value = null;
   items.value = [];
+  refCache.value = {};
   const result = await apiGet<CollectionDetailResponse>(detailUrl(slug));
   loading.value = false;
   if (!result.ok) {
@@ -277,6 +309,65 @@ async function loadCollection(slug: string): Promise<void> {
   }
   collection.value = result.data.collection;
   items.value = result.data.items;
+  // Fan out to fetch each unique target collection so the table can
+  // render ref values as display names (not slugs) and the form
+  // dropdown has options. Failures fall back gracefully — the table
+  // cell shows the raw slug and the form falls back to text input.
+  await loadRefTargets(result.data.collection.schema);
+}
+
+function uniqueRefTargets(schema: CollectionSchema): string[] {
+  const targets = new Set<string>();
+  for (const field of Object.values(schema.fields)) {
+    if (field.type === "ref" && typeof field.to === "string" && field.to.length > 0) {
+      targets.add(field.to);
+    }
+  }
+  return [...targets];
+}
+
+async function loadRefTargets(schema: CollectionSchema): Promise<void> {
+  const targets = uniqueRefTargets(schema);
+  if (targets.length === 0) return;
+  const results = await Promise.all(targets.map((target) => apiGet<CollectionDetailResponse>(detailUrl(target)).then((result) => ({ target, result }))));
+  const next: RefCache = {};
+  for (const { target, result } of results) {
+    if (!result.ok) continue;
+    next[target] = buildRefDisplayMap(result.data);
+  }
+  refCache.value = next;
+}
+
+function buildRefDisplayMap(detail: CollectionDetailResponse): RefDisplayMap {
+  // Heuristic for what to display in the table cell + dropdown:
+  // prefer a field called `name`, fall back to `title`, then to the
+  // primary key value (= the slug itself, which we'd show anyway).
+  // Future-proof escape hatch (`displayField` in the schema) is
+  // explicitly deferred — see plans/feat-collections-ref-field.md.
+  const { fields, primaryKey } = detail.collection.schema;
+  const displayField = "name" in fields ? "name" : "title" in fields ? "title" : primaryKey;
+  const map: RefDisplayMap = {};
+  for (const item of detail.items) {
+    const slugRaw = item[primaryKey];
+    if (typeof slugRaw !== "string" || slugRaw.length === 0) continue;
+    const displayRaw = item[displayField];
+    const display = typeof displayRaw === "string" && displayRaw.length > 0 ? displayRaw : slugRaw;
+    map[slugRaw] = display;
+  }
+  return map;
+}
+
+function refDisplay(targetSlug: string, itemSlug: string): string {
+  const map = refCache.value[targetSlug];
+  return (map && map[itemSlug]) || itemSlug;
+}
+
+function refOptions(targetSlug: string): { slug: string; display: string }[] {
+  const map = refCache.value[targetSlug];
+  if (!map) return [];
+  return Object.entries(map)
+    .map(([slug, display]) => ({ slug, display }))
+    .sort((left, right) => left.display.localeCompare(right.display));
 }
 
 function inputTypeFor(type: FieldType): string {

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -313,7 +313,10 @@ async function loadCollection(slug: string): Promise<void> {
   // render ref values as display names (not slugs) and the form
   // dropdown has options. Failures fall back gracefully — the table
   // cell shows the raw slug and the form falls back to text input.
-  await loadRefTargets(result.data.collection.schema);
+  // Pass the slug that triggered THIS load so the helper can drop
+  // its result if a faster subsequent load has already switched us
+  // to a different collection (Codex P1 review on PR #1495).
+  await loadRefTargets(result.data.collection.schema, slug);
 }
 
 function uniqueRefTargets(schema: CollectionSchema): string[] {
@@ -326,10 +329,17 @@ function uniqueRefTargets(schema: CollectionSchema): string[] {
   return [...targets];
 }
 
-async function loadRefTargets(schema: CollectionSchema): Promise<void> {
+async function loadRefTargets(schema: CollectionSchema, expectedSlug: string): Promise<void> {
   const targets = uniqueRefTargets(schema);
   if (targets.length === 0) return;
   const results = await Promise.all(targets.map((target) => apiGet<CollectionDetailResponse>(detailUrl(target)).then((result) => ({ target, result }))));
+  // Stale-write guard: a quicker subsequent `loadCollection()`
+  // (user navigated to a different collection mid-fetch) may have
+  // already replaced `collection.value`. Overwriting `refCache`
+  // here would surface the previous collection's ref data on the
+  // current one's UI — broken labels until another reload. Drop
+  // the write if we're no longer on the slug that triggered us.
+  if (collection.value?.slug !== expectedSlug) return;
   const next: RefCache = {};
   for (const { target, result } of results) {
     if (!result.ok) continue;

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1342,6 +1342,7 @@ const deMessages = {
     notFound: "Sammlung nicht gefunden",
     loadFailed: "Laden fehlgeschlagen",
     requiredField: "Dieses Feld ist erforderlich",
+    refPlaceholder: "Auswählen…",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1324,6 +1324,7 @@ const enMessages = {
     notFound: "Collection not found",
     loadFailed: "Failed to load",
     requiredField: "This field is required",
+    refPlaceholder: "Select…",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1337,6 +1337,7 @@ const esMessages = {
     notFound: "Colección no encontrada",
     loadFailed: "Error al cargar",
     requiredField: "Este campo es obligatorio",
+    refPlaceholder: "Seleccionar…",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1331,6 +1331,7 @@ const frMessages = {
     notFound: "Collection introuvable",
     loadFailed: "Échec du chargement",
     requiredField: "Ce champ est obligatoire",
+    refPlaceholder: "Sélectionner…",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1321,6 +1321,7 @@ const jaMessages = {
     notFound: "コレクションが見つかりません",
     loadFailed: "読み込みに失敗しました",
     requiredField: "この項目は必須です",
+    refPlaceholder: "選択…",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1324,6 +1324,7 @@ const koMessages = {
     notFound: "컬렉션을 찾을 수 없습니다",
     loadFailed: "불러오기에 실패했습니다",
     requiredField: "이 필드는 필수입니다",
+    refPlaceholder: "선택…",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1326,6 +1326,7 @@ const ptBRMessages = {
     notFound: "Coleção não encontrada",
     loadFailed: "Falha ao carregar",
     requiredField: "Este campo é obrigatório",
+    refPlaceholder: "Selecionar…",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1314,6 +1314,7 @@ const zhMessages = {
     notFound: "未找到集合",
     loadFailed: "加载失败",
     requiredField: "此字段为必填项",
+    refPlaceholder: "请选择…",
     source: {
       user: "用户",
       project: "项目",

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -70,19 +70,51 @@ describe("discoverCollections — field-type support", () => {
     assert.equal(collections[0]?.schema.fields.active?.type, "boolean");
   });
 
-  it("rejects a schema with an unknown field type (still v0)", async () => {
-    writeSkill("test-ref-not-yet", {
-      title: "Ref",
+  it("accepts a schema using `ref` with a non-empty `to` (added in feat-collections-ref-field)", async () => {
+    writeSkill("test-ref-ok", {
+      title: "Worklog-like",
       icon: "link",
-      dataPath: "data/ref/items",
+      dataPath: "data/refok/items",
       primaryKey: "id",
       fields: {
         id: { type: "string", label: "ID", primary: true, required: true },
-        clientId: { type: "ref", label: "Client" }, // ref is deferred
+        clientId: { type: "ref", to: "mc-clients", label: "Client", required: true },
       },
     });
     const collections = await listCollections();
-    assert.equal(collections.length, 0, "schema with unsupported field type must be skipped");
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.fields.clientId?.type, "ref");
+    assert.equal(collections[0]?.schema.fields.clientId?.to, "mc-clients");
+  });
+
+  it("rejects a schema with `ref` but no `to`", async () => {
+    writeSkill("test-ref-bad", {
+      title: "Broken Ref",
+      icon: "link",
+      dataPath: "data/refbad/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        clientId: { type: "ref", label: "Client" }, // missing `to`
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0, "schema with type:ref but no `to` must be skipped");
+  });
+
+  it("rejects a schema with an unknown field type", async () => {
+    writeSkill("test-unknown-type", {
+      title: "Unknown",
+      icon: "warning",
+      dataPath: "data/unknown/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        weird: { type: "geocoord", label: "Geo" }, // not in v0 enum
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
   });
 });
 

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -102,6 +102,57 @@ describe("discoverCollections — field-type support", () => {
     assert.equal(collections.length, 0, "schema with type:ref but no `to` must be skipped");
   });
 
+  // Codex P2 review on PR #1495: `to` must be a real slug, not
+  // any non-empty string. Without this guard, values like
+  // `"../escape"` or `"mc-clients/extra"` produced malformed
+  // `/collections/${field.to}` router targets and behavior
+  // mismatches versus the URI-encoded API fetch path.
+
+  it("rejects a schema whose `ref.to` contains path traversal", async () => {
+    writeSkill("test-ref-traversal", {
+      title: "Traversal Ref",
+      icon: "warning",
+      dataPath: "data/reftrav/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        clientId: { type: "ref", to: "../escape", label: "Client" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("rejects a schema whose `ref.to` contains a path separator", async () => {
+    writeSkill("test-ref-slash", {
+      title: "Slash Ref",
+      icon: "warning",
+      dataPath: "data/refslash/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        clientId: { type: "ref", to: "mc-clients/extra", label: "Client" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("rejects a schema whose `ref.to` is whitespace", async () => {
+    writeSkill("test-ref-ws", {
+      title: "Whitespace Ref",
+      icon: "warning",
+      dataPath: "data/refws/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        clientId: { type: "ref", to: "  ", label: "Client" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
   it("rejects a schema with an unknown field type", async () => {
     writeSkill("test-unknown-type", {
       title: "Unknown",


### PR DESCRIPTION
## Summary

First of three follow-up PRs aimed at making the schema-driven collection primitive expressive enough for invoice migration. See [plans/feat-collections-ref-field.md](../blob/feat-collections-ref-field/plans/feat-collections-ref-field.md) for the full scope; \`money\`, \`table\`, \`derived\`, and \`actions\` are deferred to subsequent PRs.

## What `ref` does

Declares a cross-collection foreign key in the schema:

```jsonc
"clientId": {
  "type": "ref",
  "to": "mc-clients",        // collection slug the value references
  "label": "Client",
  "required": true
}
```

The record still stores the target item's primary-key slug as a plain string — **no shape change to existing JSON** (\`{"clientId": "acme-corp"}\` looks identical before and after). The schema just gives the host enough metadata to:

1. **Table cell**: clickable \`<router-link>\` to \`/collections/<to>?highlight=<slug>\`, displaying the target's \`name\` / \`title\` / primaryKey (heuristic) instead of the raw slug
2. **Form input**: a \`<select>\` populated from the target collection's items, instead of free-text. Falls back to text input if the target is empty / unreachable
3. (Future) validate referential integrity at write time

One per-target-collection fetch happens after the current collection's items load, cached in \`refCache\` so multiple ref fields pointing at the same target share one round-trip.

## mc-worklog migration

\`server/workspace/skills-preset/mc-worklog/schema.json\`: \`clientId\` changes from plain \`string\` to \`ref\` with \`to: mc-clients\`.

The auto-update sync added in PR #1490 picks up the change on next \`yarn dev\` — no manual re-star needed.

\`SKILL.md\`: the long "## clientId resolution (until \`ref\` exists)" section shrinks to a short note. Claude still resolves names → slugs by reading \`data/clients/items/\` before writing (no server-side referential validation yet — deferred), but the host now provides the dropdown UI and clickable link.

## Schema language changes

- \`server/workspace/collections/types.ts\`: \`"ref"\` added to \`CollectionFieldType\`; optional \`to?: string\` added to \`CollectionFieldSpec\`
- \`server/workspace/collections/discovery.ts\`: Zod \`FieldSpecSchema\` refines on \`type === "ref"\` to require a non-empty \`to\`. Bare \`type: "ref"\` (no \`to\`) is rejected at discovery (warn-and-skip) — pinned by a new test

## Test plan

After \`yarn dev\` reboot:

- [ ] \`/collections/mc-worklog\` table renders the \`Client\` column as clickable links displaying client \`name\` (e.g. "Acme Corp"), not the raw slug
- [ ] Clicking a client link lands on \`/collections/mc-clients?highlight=acme-corp\`
- [ ] \`+\` on mc-worklog renders the Client field as a \`<select>\` populated with all clients; selecting one saves the slug
- [ ] Editing an existing entry shows the current client pre-selected
- [ ] If the dropdown is empty (e.g. user deleted all clients), the field falls back to text input so the form still works
- [x] **5106 unit tests pass** (+2: ref accept + ref-missing-\`to\` reject in \`test_discovery.ts\`)
- [x] **437 e2e tests pass**
- [x] \`yarn format / lint / typecheck / build\` all green

## Deferred (the gap from a full ref implementation)

- **Runtime referential integrity check** on write — orphan-handling policy (cascade / reject / soft) is the open design question
- **\`displayField\` schema knob** — heuristic (\`name\` → \`title\` → primaryKey) suffices today
- **Highlight-on-landing** — \`?highlight=<slug>\` query param is set, scroll-into-view + visual ping is the small follow-up
- **Reverse navigation** (\`/collections/mc-clients\` showing "used by N worklog entries") — would require a cross-collection index, out of scope

## Success criteria (from the plan)

- [x] One new field type costs ~50 LoC across types + discovery + UI (actual: ~120, mostly UI — table cell + select + cache logic + helpers)
- [x] \`mc-worklog\` SKILL.md shrinks (manual-resolution section dropped)
- [ ] Clicking a client in the worklog table lands on the client view (manual test above)
- [x] The pattern (schema enum extension + UI branch + cache + skill migration) is reusable for the remaining field types in PR-B/C

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collection "ref" field type to link items across collections.
  * Ref fields render as clickable links in tables and as dropdowns in forms (falls back to text input when no options).

* **Documentation**
  * Updated schema and usage docs and a worklog example to use the new ref field.

* **Internationalization**
  * Added ref placeholder text in eight languages.

* **Tests**
  * Added validation tests for ref field discovery and rejection cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->