### PR TITLE
feat(collections): add money + enum field types

### DIFF
--- a/plans/feat-collections-money-enum.md
+++ b/plans/feat-collections-money-enum.md
@@ -1,0 +1,100 @@
+# Plan: `money` + `enum` Field Types for Collections
+
+Second of three follow-up PRs aimed at making the schema-driven
+collection primitive expressive enough for invoice migration.
+Follow-up to [plans/feat-collections-ref-field.md](feat-collections-ref-field.md)
+(merged); next is PR-C (`table` + `derived` for line items) then
+PR-D (mc-invoice + actions + PDF template renderer).
+
+## Scope
+
+Two new field types added together because each is small and they
+share the same shape pattern PR-A established:
+
+1. **`money`** — number stored as a decimal, displayed via
+   `Intl.NumberFormat` (`$15.50`, `¥1,500`) in the table and as a
+   number input in the form. Optional `currency: "USD" | "JPY" | …`
+   on the schema (defaults to `"USD"`).
+
+2. **`enum`** — string constrained to a fixed list of allowed
+   values. Form input is a `<select>` populated from the schema's
+   declared `values: string[]`. Table cell shows the raw value;
+   per-value badge styling (color chips like the invoice plugin's
+   `paid` / `void`) is deferred to a follow-up.
+
+Both unlock mc-invoice's most common fields (line-item `rate`
+amounts, invoice `status`) without yet committing to the bigger
+`table` / `derived` / `actions` work that comes next.
+
+## Schema language additions
+
+```jsonc
+"rate": {
+  "type": "money",
+  "currency": "USD",          // optional, defaults to "USD"
+  "label": "Rate"
+},
+"status": {
+  "type": "enum",
+  "values": ["draft", "sent", "paid", "void"],
+  "label": "Status",
+  "required": true
+}
+```
+
+## Host changes
+
+### Server (`server/workspace/collections/`)
+
+- `types.ts`: add `"money"` and `"enum"` to `CollectionFieldType`;
+  `CollectionFieldSpec` gains optional `currency?: string` and
+  `values?: string[]`.
+- `discovery.ts`: extend the Zod refine to require:
+  - `enum` fields must declare a non-empty `values` array of strings
+  - `money` fields' `currency` (if present) must be a non-empty string
+  - bare `type: "enum"` (no `values`) is rejected at discovery, same
+    way `ref` without `to` is rejected.
+
+### Frontend (`src/components/CollectionView.vue`)
+
+- Type updates mirroring the server schema.
+- **Money in the table**: `Intl.NumberFormat(locale, { style: "currency", currency })` for display. Falls back to the raw number on format failure (e.g. unknown currency code).
+- **Money in the form**: `<input type="number" step="0.01">` bucketed into `editing.text` (same as the existing `number` type); `draftToRecord` converts to a number on save.
+- **Enum in the form**: `<select>` populated from `field.values`. No fallback needed (the schema declares all valid options).
+- **Enum in the table**: raw value (per-value badge styling deferred).
+
+### i18n
+
+The existing `collectionsView.refPlaceholder` ("Select…") is now shared
+by both `ref` and `enum` dropdowns. **Rename to
+`collectionsView.selectPlaceholder`** for accuracy across all 8
+locales — small mechanical change to keep the key name truthful
+before another field type adds a third use.
+
+### Skill updates
+
+None in this PR. `money` and `enum` aren't used by any current
+mc-* preset; they're put in place ready for mc-invoice in PR-C/D.
+
+## Deferred
+
+- **Per-value badge styling** for enum cells (draft = gray pill, paid = green pill, etc.). Cosmetic; defer until invoice ships and we know what palette feels right.
+- **Currency conversion** between locales. v0 displays whatever currency the schema declares; locale only affects digit grouping / decimal separator via `Intl.NumberFormat`.
+- **Server-side enum validation**: client can't submit an invalid value (the `<select>` restricts to declared options), but Claude could write whatever string into the JSON. Defer enforcement until orphan handling is more broadly designed.
+- **Subtotal / total aggregations** — that's `derived` (PR-C).
+
+## Test plan
+
+After `yarn dev`:
+
+- [ ] Existing `mc-clients` / `mc-worklog` collections still load (no regression from the type-enum extension)
+- [ ] A test fixture schema declaring `money` and `enum` validates and renders
+- [ ] Discovery rejects `enum` without `values`, with empty `values`, with non-string `values`
+- [ ] Discovery rejects `money` with `currency: ""` (must be non-empty if present)
+- [ ] All existing tests + 437 e2e still pass
+
+## What success looks like
+
+- Two new field types cost ~80 LoC total (similar order of magnitude as ref)
+- Schema language extension pattern (PR-A established, PR-B confirms it scales) is now reusable as a true template
+- PR-C (table + derived) can start without any further server scaffolding

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -16,7 +16,7 @@ import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSu
 
 const FieldSpecSchema = z
   .object({
-    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref"]),
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum"]),
     label: z.string().min(1),
     primary: z.boolean().optional(),
     required: z.boolean().optional(),
@@ -25,6 +25,11 @@ const FieldSpecSchema = z
      *  first-class discriminated union for this shape; refine is
      *  the standard escape hatch). */
     to: z.string().min(1).optional(),
+    /** ISO 4217 currency code, optional iff type === "money".
+     *  Defaults to "USD" client-side when omitted. */
+    currency: z.string().min(1).optional(),
+    /** Closed list of allowed strings, required iff type === "enum". */
+    values: z.array(z.string().min(1)).min(1).optional(),
   })
   .refine(
     (spec) => {
@@ -44,7 +49,11 @@ const FieldSpecSchema = z
       message: "fields with type 'ref' must declare a `to` that is a valid collection slug (alphanumeric / hyphen / underscore, no path separators)",
       path: ["to"],
     },
-  );
+  )
+  .refine((spec) => spec.type !== "enum" || (Array.isArray(spec.values) && spec.values.length > 0), {
+    message: "fields with type 'enum' must declare a non-empty `values` array of allowed strings",
+    path: ["values"],
+  });
 
 const CollectionSchemaZ = z.object({
   title: z.string().min(1),

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -11,7 +11,7 @@
 // plans/done/feat-skill-driven-apps-worklog.md — historical names predate
 // the rename).
 
-export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref";
+export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum";
 
 export type CollectionSource = "user" | "project";
 
@@ -30,6 +30,17 @@ export interface CollectionFieldSpec {
    *  (future) validate referential integrity. Required when type
    *  is `ref`; ignored on every other type. */
   to?: string;
+  /** When `type === "money"`: ISO 4217 currency code passed to
+   *  `Intl.NumberFormat` for table display (e.g. "USD", "JPY",
+   *  "EUR"). Defaults to "USD" when omitted. The stored value is
+   *  always a plain decimal number — currency is presentation only.
+   *  Ignored on non-money types. */
+  currency?: string;
+  /** When `type === "enum"`: the closed set of allowed string
+   *  values. The form renders a `<select>` populated from this
+   *  list; storage is a plain string. Required when type is
+   *  `enum`; ignored on every other type. */
+  values?: readonly string[];
 }
 
 export interface CollectionSchema {

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -63,6 +63,7 @@
                   >{{ refDisplay(field.to, String(item[key])) }}</router-link
                 >
               </span>
+              <span v-else-if="field.type === 'money'" class="block truncate tabular-nums">{{ formatMoney(item[key], field.currency, locale) }}</span>
               <span v-else class="block truncate">{{ formatCell(item[key], field.type) }}</span>
             </td>
             <td class="px-4 py-2 text-right whitespace-nowrap">
@@ -133,14 +134,26 @@
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
               :data-testid="`collections-input-${key}`"
             >
-              <option value="">{{ t("collectionsView.refPlaceholder") }}</option>
+              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
               <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
             </select>
+            <select
+              v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :required="isFieldRequiredInUi(field)"
+              class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+              :data-testid="`collections-input-${key}`"
+            >
+              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+              <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+            </select>
             <input
-              v-else-if="['string', 'email', 'number', 'date', 'ref'].includes(field.type)"
+              v-else-if="['string', 'email', 'number', 'date', 'ref', 'money'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
+              :step="field.type === 'money' ? '0.01' : undefined"
               :required="isFieldRequiredInUi(field)"
               :disabled="field.primary === true && editing.mode === 'edit'"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
@@ -190,7 +203,7 @@ import { PAGE_ROUTES } from "../router/pageRoutes";
 import ConfirmModal from "./ConfirmModal.vue";
 import { useConfirm } from "../composables/useConfirm";
 
-type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref";
+type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum";
 
 interface FieldSpec {
   type: FieldType;
@@ -198,8 +211,14 @@ interface FieldSpec {
   primary?: boolean;
   required?: boolean;
   /** When type === "ref": slug of the target collection (see
-   *  plans/feat-collections-ref-field.md). */
+   *  plans/done/feat-collections-ref-field.md). */
   to?: string;
+  /** When type === "money": ISO 4217 currency for Intl display.
+   *  Defaults to "USD" when omitted. */
+  currency?: string;
+  /** When type === "enum": closed list of allowed string values
+   *  for the form `<select>`. */
+  values?: readonly string[];
 }
 
 /** Per-target-collection cache: maps an item's primary-key slug to
@@ -269,7 +288,7 @@ interface EditState {
   originalId: string | null;
 }
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const route = useRoute();
 const router = useRouter();
 const { openConfirm } = useConfirm();
@@ -383,6 +402,7 @@ function refOptions(targetSlug: string): { slug: string; display: string }[] {
 function inputTypeFor(type: FieldType): string {
   if (type === "email") return "email";
   if (type === "number") return "number";
+  if (type === "money") return "number";
   if (type === "date") return "date";
   return "text";
 }
@@ -405,6 +425,27 @@ function formatCell(value: unknown, type: FieldType): string {
   }
   if (typeof value === "string" || typeof value === "number") return String(value);
   return JSON.stringify(value);
+}
+
+/** Format a money value via `Intl.NumberFormat`. Falls back to the
+ *  raw number on any failure (unknown currency code, non-finite
+ *  amount, etc.) so a malformed record still renders something
+ *  rather than blowing up the row. Locale comes from the active
+ *  i18n locale so digit grouping / decimal separator follow the
+ *  user's settings even though the currency is declared by the
+ *  schema. `money` is the table-cell branch; the form uses a
+ *  plain `<input type="number" step="0.01">` so the editor stays
+ *  language-agnostic for input. */
+function formatMoney(value: unknown, currency: string | undefined, displayLocale: string): string {
+  if (value === undefined || value === null || value === "") return "—";
+  const amount = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(amount)) return String(value);
+  const currencyCode = currency && currency.length > 0 ? currency : "USD";
+  try {
+    return new Intl.NumberFormat(displayLocale, { style: "currency", currency: currencyCode }).format(amount);
+  } catch {
+    return String(amount);
+  }
 }
 
 function openCreate(): void {
@@ -490,7 +531,7 @@ function draftToRecord(state: EditState, schema: CollectionSchema): CollectionIt
     }
     const raw = state.text[key];
     if (raw === undefined || raw === "") continue;
-    if (field.type === "number") {
+    if (field.type === "number" || field.type === "money") {
       const num = Number(raw);
       record[key] = Number.isFinite(num) ? num : raw;
     } else {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1342,7 +1342,7 @@ const deMessages = {
     notFound: "Sammlung nicht gefunden",
     loadFailed: "Laden fehlgeschlagen",
     requiredField: "Dieses Feld ist erforderlich",
-    refPlaceholder: "Auswählen…",
+    selectPlaceholder: "Auswählen…",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1324,7 +1324,7 @@ const enMessages = {
     notFound: "Collection not found",
     loadFailed: "Failed to load",
     requiredField: "This field is required",
-    refPlaceholder: "Select…",
+    selectPlaceholder: "Select…",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1337,7 +1337,7 @@ const esMessages = {
     notFound: "Colección no encontrada",
     loadFailed: "Error al cargar",
     requiredField: "Este campo es obligatorio",
-    refPlaceholder: "Seleccionar…",
+    selectPlaceholder: "Seleccionar…",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1331,7 +1331,7 @@ const frMessages = {
     notFound: "Collection introuvable",
     loadFailed: "Échec du chargement",
     requiredField: "Ce champ est obligatoire",
-    refPlaceholder: "Sélectionner…",
+    selectPlaceholder: "Sélectionner…",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1321,7 +1321,7 @@ const jaMessages = {
     notFound: "コレクションが見つかりません",
     loadFailed: "読み込みに失敗しました",
     requiredField: "この項目は必須です",
-    refPlaceholder: "選択…",
+    selectPlaceholder: "選択…",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1324,7 +1324,7 @@ const koMessages = {
     notFound: "컬렉션을 찾을 수 없습니다",
     loadFailed: "불러오기에 실패했습니다",
     requiredField: "이 필드는 필수입니다",
-    refPlaceholder: "선택…",
+    selectPlaceholder: "선택…",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1326,7 +1326,7 @@ const ptBRMessages = {
     notFound: "Coleção não encontrada",
     loadFailed: "Falha ao carregar",
     requiredField: "Este campo é obrigatório",
-    refPlaceholder: "Selecionar…",
+    selectPlaceholder: "Selecionar…",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1314,7 +1314,7 @@ const zhMessages = {
     notFound: "未找到集合",
     loadFailed: "加载失败",
     requiredField: "此字段为必填项",
-    refPlaceholder: "请选择…",
+    selectPlaceholder: "请选择…",
     source: {
       user: "用户",
       project: "项目",

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -167,6 +167,88 @@ describe("discoverCollections — field-type support", () => {
     const collections = await listCollections();
     assert.equal(collections.length, 0);
   });
+
+  // PR-B: money + enum field types.
+
+  it("accepts a schema using `money` with and without an explicit currency", async () => {
+    writeSkill("test-money", {
+      title: "Money",
+      icon: "payments",
+      dataPath: "data/money/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        rateUsd: { type: "money", currency: "USD", label: "Rate (USD)" },
+        rateDefault: { type: "money", label: "Rate (default currency)" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.fields.rateUsd?.type, "money");
+    assert.equal(collections[0]?.schema.fields.rateUsd?.currency, "USD");
+    assert.equal(collections[0]?.schema.fields.rateDefault?.currency, undefined);
+  });
+
+  it("rejects a schema with `money` whose `currency` is empty", async () => {
+    writeSkill("test-money-empty-currency", {
+      title: "Money",
+      icon: "payments",
+      dataPath: "data/moneybad/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        rate: { type: "money", currency: "", label: "Rate" }, // empty string fails min(1)
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("accepts a schema using `enum` with a non-empty `values` array", async () => {
+    writeSkill("test-enum-ok", {
+      title: "Invoice-like",
+      icon: "list",
+      dataPath: "data/enumok/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        status: { type: "enum", values: ["draft", "sent", "paid", "void"], label: "Status", required: true },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.deepEqual(collections[0]?.schema.fields.status?.values, ["draft", "sent", "paid", "void"]);
+  });
+
+  it("rejects a schema with `enum` but no `values`", async () => {
+    writeSkill("test-enum-no-values", {
+      title: "Bad Enum",
+      icon: "warning",
+      dataPath: "data/enumbad/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        status: { type: "enum", label: "Status" }, // missing `values`
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("rejects a schema with `enum` whose `values` is an empty array", async () => {
+    writeSkill("test-enum-empty", {
+      title: "Bad Enum",
+      icon: "warning",
+      dataPath: "data/enumempty/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        status: { type: "enum", values: [], label: "Status" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
 });
 
 describe("discoverCollections — structural validation", () => {


### PR DESCRIPTION
## Summary

PR-B of three follow-ups aimed at making the schema-driven collection primitive expressive enough for invoice migration. Follow-up to [PR #1495](../pull/1495) (\`ref\`); next is PR-C (\`table\` + \`derived\` for line items) then PR-D (\`mc-invoice\` + actions + PDF template). See [plans/feat-collections-money-enum.md](../blob/feat-collections-money-enum/plans/feat-collections-money-enum.md).

## What it does

Two new field types added together because each is small and they share the schema-extension pattern PR-A established:

### \`money\`

```jsonc
"rate": {
  "type": "money",
  "currency": "USD",     // optional, defaults to "USD"
  "label": "Rate"
}
```

- **Table cell**: displayed via \`Intl.NumberFormat(displayLocale, { style: \"currency\", currency })\` — \`$15.50\`, \`¥1,500\`, \`€12,34\`. Locale comes from the user's active i18n locale so digit grouping / decimal separator follow their settings even though the currency is declared by the schema.
- **Form input**: \`<input type=\"number\" step=\"0.01\">\` bucketed into \`editing.text\` (same as \`number\`); \`draftToRecord\` converts to a number on save.
- **Graceful fallback** on unknown currency code / non-finite amount — renders the raw number rather than blowing up the row.

### \`enum\`

```jsonc
"status": {
  "type": "enum",
  "values": [\"draft\", \"sent\", \"paid\", \"void\"],
  "label": "Status",
  "required": true
}
```

- **Form input**: \`<select>\` populated from \`field.values\`. The closed list means client-side input is naturally constrained.
- **Table cell**: raw value (per-value badge styling deferred — see plan).
- Discovery rejects \`enum\` without \`values\` or with an empty \`values\` array (mirrors how \`ref\` rejects missing \`to\`).

Both unlock mc-invoice's most common fields (line-item \`rate\` amounts, invoice \`status\`) without yet committing to the bigger \`table\` / \`derived\` / \`actions\` work in PR-C/D.

## Schema language changes

- \`server/workspace/collections/types.ts\`: \`\"money\"\` and \`\"enum\"\` added to \`CollectionFieldType\`; \`currency?: string\` and \`values?: readonly string[]\` added to \`CollectionFieldSpec\`.
- \`server/workspace/collections/discovery.ts\`: Zod FieldSpec schema gains optional \`currency\` (\`z.string().min(1)\`) and \`values\` (array of non-empty strings, length ≥ 1). New refine enforces \"enum requires non-empty values\" — same pattern the existing \`ref→to\` refine uses.

## i18n

\`collectionsView.refPlaceholder\` was already used by both \`ref\` and (now) \`enum\` dropdowns. **Renamed to \`selectPlaceholder\`** for accuracy across all 8 locales — small mechanical change to keep the key truthful before another field type adds a third use.

## Skill updates

None in this PR. \`money\` and \`enum\` aren't used by any current \`mc-*\` preset; they're put in place ready for \`mc-invoice\` in PR-C/D.

## Test plan

- [x] **5114 unit tests pass** (+5):
  - money accept with explicit currency
  - money accept without currency (defaults to USD client-side)
  - money reject empty currency
  - enum accept with non-empty values
  - enum reject missing values
  - enum reject empty values array
- [x] **437 e2e tests pass** — no regression on the existing ref / boolean / wiki flows
- [x] \`yarn format / lint / typecheck / build\` all green

Manual checks (once a schema declaring \`money\` or \`enum\` is starred):

- [ ] A money value renders as \`$15.50\` / \`¥1,500\` per the schema's \`currency\` and the active i18n locale
- [ ] Editing a money field shows a number input with \`step=0.01\`; saving stores a decimal number
- [ ] An enum value renders as the raw string in the table
- [ ] Editing an enum field shows a \`<select>\` with all declared values; saving stores the chosen value

## Deferred

- **Per-value badge styling** for enum cells (draft = gray pill, paid = green pill, etc.). Cosmetic; defer until invoice ships and we know what palette feels right.
- **Server-side enum validation** (Claude could write any string). Defer; client-side \`<select>\` is the v0 safeguard.
- **Currency conversion** across locales. v0 displays the schema-declared currency; locale only affects digit grouping / decimal separator.
- **Subtotal / total aggregations** — that's \`derived\` (PR-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)