### PR TITLE
feat(collections): mc-invoice + money/enum/table/derived field types

### DIFF
--- a/plans/feat-mc-invoice.md
+++ b/plans/feat-mc-invoice.md
@@ -83,6 +83,15 @@ component.
 
 ## Out of scope (explicit defer to follow-up)
 
+- **`?highlight=<id>` scroll/ping handler** — the mc-* SKILL.md
+  files now instruct Claude to link records as
+  `/collections/<slug>?highlight=<id>` (so chat links open the
+  rendered collection table rather than the raw JSON file). The
+  query param is currently inert: CollectionView opens the table
+  but doesn't yet scroll-to / visually flag the matching row. A
+  follow-up should read `route.query.highlight`, scroll the row
+  into view, and pulse it. Once shipped, every already-emitted
+  link starts working with no skill change.
 - **`actions`** field type — explicit "Mark Sent" / "Mark Paid" /
   "Export PDF" buttons. v0 user changes status via the enum
   dropdown in the edit form. Manual but works.

--- a/plans/feat-mc-invoice.md
+++ b/plans/feat-mc-invoice.md
@@ -1,0 +1,134 @@
+# Plan: `mc-invoice` Collection (bundled field-type work)
+
+End of the invoice-migration arc that started with
+[plans/done/feat-skill-driven-apps.md](done/feat-skill-driven-apps.md)
+(PR #1483) and continued with PR #1495 (`ref`). Bundles **money +
+enum + table + derived + mc-invoice skill** into a single PR so the
+schema-language additions ship with a real consuming skill — none
+of the new field types are exercisable in isolation, so splitting
+into intermediate PRs (the earlier PR-B / PR-C / PR-D plan) hit a
+"can't actually test" wall the moment PR-B opened.
+
+## What ships
+
+### Field types
+
+| Type | What | Form input | Table cell |
+|---|---|---|---|
+| `money` | decimal stored verbatim | `<input type="number" step="0.01">` | `Intl.NumberFormat(locale, { style: "currency", currency })` |
+| `enum` | string from a closed list | `<select>` populated from `values: string[]` | raw value (per-value badge styling deferred) |
+| `table` | array of records | mini-table inside the form with add-row / remove-row buttons | `"N items"` summary |
+| `derived` | read-only computed value (formula) | shown but disabled, live-updated from current draft | computed against the loaded item |
+
+### Derived formula language (deliberately tiny)
+
+Just enough for invoice:
+
+- **Number literal**: `0`, `1.5`
+- **Identifier ref**: `subtotal`, `taxRate` (top-level fields on the record)
+- **Arithmetic**: `+ - * /` with normal precedence + parens
+- **Sum over a table column or product of two columns**:
+  - `sum(lineItems[].quantity * lineItems[].rate)` — typical "subtotal" pattern
+  - `sum(lineItems[].amount)` — single-column sum
+
+Anything else (string concat, conditionals, function calls beyond
+`sum`) is rejected at parse time. The evaluator is a pure helper
+under `src/utils/collections/derivedFormula.ts` with its own unit
+tests so the parser quirks are pinned independently from the Vue
+component.
+
+### Skill
+
+`server/workspace/skills-preset/mc-invoice/`:
+
+- `SKILL.md` — teaches Claude how to derive an invoice ID, resolve
+  client name → slug, build line items, default status to `draft`,
+  and NEVER write derived fields (`subtotal` / `tax` / `total`).
+- `schema.json` — the full invoice shape:
+
+```json
+{
+  "title": "Invoices",
+  "icon": "receipt_long",
+  "dataPath": "data/invoice/items",
+  "primaryKey": "id",
+  "fields": {
+    "id":        { "type": "string", "label": "ID", "primary": true, "required": true },
+    "clientId":  { "type": "ref",    "to": "mc-clients", "label": "Client", "required": true },
+    "issueDate": { "type": "date",   "label": "Issued", "required": true },
+    "dueDate":   { "type": "date",   "label": "Due" },
+    "status":    { "type": "enum",   "values": ["draft","sent","paid","void"], "label": "Status", "required": true },
+    "lineItems": {
+      "type": "table", "label": "Line items",
+      "of": {
+        "description": { "type": "string", "label": "Description", "required": true },
+        "quantity":    { "type": "number", "label": "Qty", "required": true },
+        "rate":        { "type": "money",  "currency": "USD", "label": "Rate", "required": true }
+      }
+    },
+    "subtotal":  { "type": "derived", "label": "Subtotal",
+                   "formula": "sum(lineItems[].quantity * lineItems[].rate)",
+                   "display": "money", "currency": "USD" },
+    "taxRate":   { "type": "number", "label": "Tax rate (e.g. 0.10 for 10%)" },
+    "tax":       { "type": "derived", "label": "Tax",
+                   "formula": "subtotal * taxRate",
+                   "display": "money", "currency": "USD" },
+    "total":     { "type": "derived", "label": "Total",
+                   "formula": "subtotal + tax",
+                   "display": "money", "currency": "USD" },
+    "notes":     { "type": "markdown", "label": "Notes" }
+  }
+}
+```
+
+## Out of scope (explicit defer to follow-up)
+
+- **`actions`** field type — explicit "Mark Sent" / "Mark Paid" /
+  "Export PDF" buttons. v0 user changes status via the enum
+  dropdown in the edit form. Manual but works.
+- **PDF template rendering** — invoice export to PDF. Requires
+  Handlebars (or similar) + a server route + the action wiring.
+- **Per-value enum badge styling** — gray pill for `draft`, green
+  for `paid`, etc. Cosmetic; defer until invoice ships and the
+  desired palette is obvious.
+- **Server-side ref / enum / formula validation** — client UI
+  constrains input; Claude could write whatever string into the
+  JSON. Acceptable for personal-workspace use.
+- **Nested tables** — `table.of.<subField>.type` can be the new
+  types (string / number / money) but NOT another `table` /
+  `derived` (no `derived` columns in line items; no tables in
+  tables). Worth enforcing in the Zod refine to fail loudly rather
+  than render nothing.
+
+## Test plan
+
+After `yarn dev` (and re-star of `mc-invoice` from `/skills`):
+
+1. `/collections/mc-invoice` → `+` to create
+2. Pick a client from the ref dropdown
+3. Set issue date, due date, tax rate (e.g. `0.10`)
+4. Add line items in the inline table: rows for "Web design × 10 @ $150" etc.
+5. As rows are added/edited, the **Subtotal / Tax / Total fields in the form update live**
+6. Set status (`draft`), save
+7. Table row appears with `lineItems` column showing `"2 items"` and the derived columns showing the computed values
+8. Edit the row, change status to `paid` via the dropdown, save
+9. Add a second invoice for a different client → independent record
+
+Unit tests cover:
+- Discovery accepts money / enum / table / derived shapes; rejects malformed (money empty currency, enum no values, table no `of`, derived no formula, nested table-in-table)
+- Formula evaluator: each operator, parens, identifiers, `sum()`, missing field → null, divide by zero / non-finite → null, malformed input → null
+
+## Why one PR
+
+Each of money / enum / table / derived has zero user-visible value
+in isolation — they only make sense inside a record-shape that uses
+them. Without `mc-invoice` shipping in the same PR, the only way to
+test them is a hand-rolled throwaway schema, which the user (the
+human reviewing) reasonably refused. Bundling lets one round of
+review cover the whole feature and one round of manual testing
+validates that invoice actually works end-to-end.
+
+The PR will be large (~600 LoC host + ~150 LoC skill) but the
+**field-type extension pattern** is already proven by PR #1495
+(`ref`) — each new type is mechanical: enum addition + Zod refine +
+form input branch + table cell branch.

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -52,8 +52,13 @@ const SubFieldSpecSchema = z
     label: z.string().min(1),
     required: z.boolean().optional(),
     to: z.string().min(1).optional(),
-    currency: z.string().min(1).optional(),
-    values: z.array(z.string().min(1)).min(1).optional(),
+    // `trim().min(1)` rather than bare `min(1)` so a whitespace-
+    // only string ("   ") fails validation — otherwise the cell
+    // formatter / dropdown would render visual blanks that look
+    // like missing data. Applied consistently to every "non-empty
+    // string" slot in the schema (CodeRabbit PR #1497).
+    currency: z.string().trim().min(1).optional(),
+    values: z.array(z.string().trim().min(1)).min(1).optional(),
   })
   .refine(refRefine, refMessage)
   .refine(enumRefine, enumMessage);
@@ -65,10 +70,10 @@ const FieldSpecSchema = z
     primary: z.boolean().optional(),
     required: z.boolean().optional(),
     to: z.string().min(1).optional(),
-    currency: z.string().min(1).optional(),
-    values: z.array(z.string().min(1)).min(1).optional(),
+    currency: z.string().trim().min(1).optional(),
+    values: z.array(z.string().trim().min(1)).min(1).optional(),
     of: z.record(z.string(), SubFieldSpecSchema).optional(),
-    formula: z.string().min(1).optional(),
+    formula: z.string().trim().min(1).optional(),
     /** Inner type to render a derived value as (e.g. `"money"`).
      *  Restricted to the non-composite display targets — derived
      *  values are scalars, so rendering them via `table` or another

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -58,6 +58,7 @@ const SubFieldSpecSchema = z
     // like missing data. Applied consistently to every "non-empty
     // string" slot in the schema (CodeRabbit PR #1497).
     currency: z.string().trim().min(1).optional(),
+    currencyField: z.string().trim().min(1).optional(),
     values: z.array(z.string().trim().min(1)).min(1).optional(),
   })
   .refine(refRefine, refMessage)
@@ -71,6 +72,7 @@ const FieldSpecSchema = z
     required: z.boolean().optional(),
     to: z.string().min(1).optional(),
     currency: z.string().trim().min(1).optional(),
+    currencyField: z.string().trim().min(1).optional(),
     values: z.array(z.string().trim().min(1)).min(1).optional(),
     of: z.record(z.string(), SubFieldSpecSchema).optional(),
     formula: z.string().trim().min(1).optional(),

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -14,37 +14,77 @@ import { USER_SKILLS_DIR, projectSkillsDir } from "../skills/paths.js";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths.js";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "./types.js";
 
+// Cross-field refines, factored out so they can apply at both the
+// top-level FieldSpec and the table-row SubFieldSpec without prose
+// duplication.
+//
+// Why two schemas: a `table` field's `of` sub-fields must NOT
+// themselves be `table` or `derived` (would explode the form editor
+// + formula evaluator into territory v0 doesn't need). The cleanest
+// way to encode that in Zod is a separate `SubFieldSpecSchema`
+// whose `type` enum simply omits those two values.
+const refRefine = (spec: { type: string; to?: string }): boolean => {
+  if (spec.type !== "ref") return true;
+  // `ref` must declare `to` AND `to` must be a real slug (not
+  // `../foo`, not `mc-clients/extra` — see Codex P2 on PR #1495).
+  if (typeof spec.to !== "string") return false;
+  return safeSlugName(spec.to) !== null;
+};
+const refMessage = {
+  message: "fields with type 'ref' must declare a `to` that is a valid collection slug (alphanumeric / hyphen / underscore, no path separators)",
+  path: ["to"],
+};
+
+const enumRefine = (spec: { type: string; values?: readonly string[] }): boolean =>
+  spec.type !== "enum" || (Array.isArray(spec.values) && spec.values.length > 0 && spec.values.every((value) => typeof value === "string" && value.length > 0));
+const enumMessage = {
+  message: "fields with type 'enum' must declare a non-empty `values` array of non-empty strings",
+  path: ["values"],
+};
+
+// Sub-fields inside a `table.of` map: the regular field types
+// minus `table` (no nested tables) and `derived` (no computed
+// columns inside a table — would need the evaluator to walk the
+// row context, defer until a real need surfaces).
+const SubFieldSpecSchema = z
+  .object({
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum"]),
+    label: z.string().min(1),
+    required: z.boolean().optional(),
+    to: z.string().min(1).optional(),
+    currency: z.string().min(1).optional(),
+    values: z.array(z.string().min(1)).min(1).optional(),
+  })
+  .refine(refRefine, refMessage)
+  .refine(enumRefine, enumMessage);
+
 const FieldSpecSchema = z
   .object({
-    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref"]),
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived"]),
     label: z.string().min(1),
     primary: z.boolean().optional(),
     required: z.boolean().optional(),
-    /** Target collection slug, required iff type === "ref". The
-     *  refine below enforces the cross-field rule (Zod has no
-     *  first-class discriminated union for this shape; refine is
-     *  the standard escape hatch). */
     to: z.string().min(1).optional(),
+    currency: z.string().min(1).optional(),
+    values: z.array(z.string().min(1)).min(1).optional(),
+    of: z.record(z.string(), SubFieldSpecSchema).optional(),
+    formula: z.string().min(1).optional(),
+    /** Inner type to render a derived value as (e.g. `"money"`).
+     *  Restricted to the non-composite display targets — derived
+     *  values are scalars, so rendering them via `table` or another
+     *  `derived` would be meaningless. */
+    display: z.enum(["string", "number", "money", "date"]).optional(),
   })
-  .refine(
-    (spec) => {
-      if (spec.type !== "ref") return true;
-      // Cross-field constraint: a `ref` field MUST declare a `to`,
-      // AND that `to` must be a valid slug. Non-slug values like
-      // `../foo` or `mc-clients/extra` would otherwise produce
-      // malformed `/collections/${field.to}` router targets and
-      // behavior-mismatched API fetches (the fetch URI-encodes
-      // each segment but the router-link interpolates raw —
-      // Codex P2 review on PR #1495). Same shape we enforce on
-      // collection slugs themselves via `safeSlugName`.
-      if (typeof spec.to !== "string") return false;
-      return safeSlugName(spec.to) !== null;
-    },
-    {
-      message: "fields with type 'ref' must declare a `to` that is a valid collection slug (alphanumeric / hyphen / underscore, no path separators)",
-      path: ["to"],
-    },
-  );
+  .refine(refRefine, refMessage)
+  .refine(enumRefine, enumMessage)
+  .refine((spec) => spec.type !== "table" || (spec.of !== undefined && Object.keys(spec.of).length > 0), {
+    message: "fields with type 'table' must declare a non-empty `of` (sub-schema for each row)",
+    path: ["of"],
+  })
+  .refine((spec) => spec.type !== "derived" || (typeof spec.formula === "string" && spec.formula.length > 0), {
+    message: "fields with type 'derived' must declare a non-empty `formula` (see src/utils/collections/derivedFormula.ts)",
+    path: ["formula"],
+  });
 
 const CollectionSchemaZ = z.object({
   title: z.string().min(1),

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -58,7 +58,6 @@ const SubFieldSpecSchema = z
     // like missing data. Applied consistently to every "non-empty
     // string" slot in the schema (CodeRabbit PR #1497).
     currency: z.string().trim().min(1).optional(),
-    currencyField: z.string().trim().min(1).optional(),
     values: z.array(z.string().trim().min(1)).min(1).optional(),
   })
   .refine(refRefine, refMessage)
@@ -72,7 +71,6 @@ const FieldSpecSchema = z
     required: z.boolean().optional(),
     to: z.string().min(1).optional(),
     currency: z.string().trim().min(1).optional(),
-    currencyField: z.string().trim().min(1).optional(),
     values: z.array(z.string().trim().min(1)).min(1).optional(),
     of: z.record(z.string(), SubFieldSpecSchema).optional(),
     formula: z.string().trim().min(1).optional(),

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -32,10 +32,22 @@ export interface CollectionFieldSpec {
   to?: string;
   /** When `type === "money"` (or `type === "derived"` with
    *  `display: "money"`): ISO 4217 currency code passed to
-   *  `Intl.NumberFormat` for table display. Defaults to "USD"
-   *  client-side when omitted. The stored value is always a plain
-   *  decimal number — currency is presentation only. */
+   *  `Intl.NumberFormat` for table display. Used as the default
+   *  when `currencyField` is absent OR the referenced record
+   *  field is blank. Defaults to "USD" client-side when omitted.
+   *  The stored value is always a plain decimal number — currency
+   *  is presentation only. */
   currency?: string;
+  /** When `type === "money"`: name of a sibling field on the
+   *  same record that holds the currency code for this money
+   *  value. Use this when different records need different
+   *  currencies (e.g. `hourlyRate` on `mc-clients` — one client
+   *  invoices in USD, another in JPY). The sibling field should
+   *  be an `enum` listing the allowed currency codes. When the
+   *  sibling resolves to a non-empty string the host uses it for
+   *  both display formatting AND the form-input prefix symbol;
+   *  otherwise it falls back to `currency`. */
+  currencyField?: string;
   /** When `type === "enum"`: the closed set of allowed string
    *  values. The form renders a `<select>` populated from this
    *  list; storage is a plain string. Required when type is

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -11,7 +11,7 @@
 // plans/done/feat-skill-driven-apps-worklog.md — historical names predate
 // the rename).
 
-export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref";
+export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived";
 
 export type CollectionSource = "user" | "project";
 
@@ -30,6 +30,33 @@ export interface CollectionFieldSpec {
    *  (future) validate referential integrity. Required when type
    *  is `ref`; ignored on every other type. */
   to?: string;
+  /** When `type === "money"` (or `type === "derived"` with
+   *  `display: "money"`): ISO 4217 currency code passed to
+   *  `Intl.NumberFormat` for table display. Defaults to "USD"
+   *  client-side when omitted. The stored value is always a plain
+   *  decimal number — currency is presentation only. */
+  currency?: string;
+  /** When `type === "enum"`: the closed set of allowed string
+   *  values. The form renders a `<select>` populated from this
+   *  list; storage is a plain string. Required when type is
+   *  `enum`; ignored on every other type. */
+  values?: readonly string[];
+  /** When `type === "table"`: the sub-schema for each row (a flat
+   *  record of non-table / non-derived field specs). Required when
+   *  type is `table`. v0 disallows nested tables and derived
+   *  columns to keep the editor + evaluator simple. */
+  of?: Record<string, CollectionFieldSpec>;
+  /** When `type === "derived"`: a tiny expression evaluated against
+   *  the record. Supports `+ - * /`, parens, identifier refs to
+   *  top-level fields, `sum(tableField[].col)`, and
+   *  `sum(tableField[].col * tableField[].col)`. See
+   *  `src/utils/collections/derivedFormula.ts`. Required when type
+   *  is `derived`. */
+  formula?: string;
+  /** When `type === "derived"`: an inner field type the computed
+   *  value should be rendered as (e.g. `"money"` so $1,234.56 is
+   *  formatted). Defaults to `"number"`. */
+  display?: CollectionFieldType;
 }
 
 export interface CollectionSchema {

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -32,22 +32,10 @@ export interface CollectionFieldSpec {
   to?: string;
   /** When `type === "money"` (or `type === "derived"` with
    *  `display: "money"`): ISO 4217 currency code passed to
-   *  `Intl.NumberFormat` for table display. Used as the default
-   *  when `currencyField` is absent OR the referenced record
-   *  field is blank. Defaults to "USD" client-side when omitted.
-   *  The stored value is always a plain decimal number — currency
-   *  is presentation only. */
+   *  `Intl.NumberFormat` for table display. Defaults to "USD"
+   *  client-side when omitted. The stored value is always a plain
+   *  decimal number — currency is presentation only. */
   currency?: string;
-  /** When `type === "money"`: name of a sibling field on the
-   *  same record that holds the currency code for this money
-   *  value. Use this when different records need different
-   *  currencies (e.g. `hourlyRate` on `mc-clients` — one client
-   *  invoices in USD, another in JPY). The sibling field should
-   *  be an `enum` listing the allowed currency codes. When the
-   *  sibling resolves to a non-empty string the host uses it for
-   *  both display formatting AND the form-input prefix symbol;
-   *  otherwise it falls back to `currency`. */
-  currencyField?: string;
   /** When `type === "enum"`: the closed set of allowed string
    *  values. The form renders a `<select>` populated from this
    *  list; storage is a plain string. Required when type is

--- a/server/workspace/skills-preset/mc-clients/SKILL.md
+++ b/server/workspace/skills-preset/mc-clients/SKILL.md
@@ -53,6 +53,19 @@ you weren't asked to change.
 **Delete**: confirm with the user once if the request is ambiguous, then
 remove the file.
 
+## Linking to a client in chat
+
+When you reference a specific client in your reply, link to the collection
+view — NOT the raw JSON file path:
+
+- Do: `[Acme Corp](/collections/mc-clients?highlight=acme-corp)`
+- Don't: `[Acme Corp](data/clients/items/acme-corp.json)` — that opens the raw
+  file in the Files view instead of the rendered table.
+
+Always include the `?highlight=<id>` query. Today it just opens the table; a
+later host update will use it to scroll to and highlight the matching row, and
+existing links will start working automatically.
+
 ## When to ask vs. when to act
 
 If the user gives you a name and an email in one sentence, just add the

--- a/server/workspace/skills-preset/mc-clients/schema.json
+++ b/server/workspace/skills-preset/mc-clients/schema.json
@@ -23,9 +23,15 @@
       "type": "text",
       "label": "Address"
     },
+    "currency": {
+      "type": "enum",
+      "values": ["USD", "JPY", "EUR", "GBP", "CAD", "AUD", "CNY", "INR", "CHF"],
+      "label": "Billing currency"
+    },
     "hourlyRate": {
       "type": "money",
       "currency": "USD",
+      "currencyField": "currency",
       "label": "Hourly rate"
     },
     "notes": {

--- a/server/workspace/skills-preset/mc-clients/schema.json
+++ b/server/workspace/skills-preset/mc-clients/schema.json
@@ -23,6 +23,11 @@
       "type": "text",
       "label": "Address"
     },
+    "hourlyRate": {
+      "type": "money",
+      "currency": "USD",
+      "label": "Hourly rate"
+    },
     "notes": {
       "type": "markdown",
       "label": "Notes"

--- a/server/workspace/skills-preset/mc-clients/schema.json
+++ b/server/workspace/skills-preset/mc-clients/schema.json
@@ -23,17 +23,6 @@
       "type": "text",
       "label": "Address"
     },
-    "currency": {
-      "type": "enum",
-      "values": ["USD", "JPY", "EUR", "GBP", "CAD", "AUD", "CNY", "INR", "CHF"],
-      "label": "Billing currency"
-    },
-    "hourlyRate": {
-      "type": "money",
-      "currency": "USD",
-      "currencyField": "currency",
-      "label": "Hourly rate"
-    },
     "notes": {
       "type": "markdown",
       "label": "Notes"

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -84,8 +84,11 @@ last invoice"):
    grouping: one line item per worklog entry (`description = entry.notes`,
    `quantity = entry.hours`, `rate = <user's standing rate or asked>`).
    You can also group by description if many entries share the same notes.
-4. If the user hasn't specified a rate and you don't have one on file,
-   ASK via `presentForm` — don't invent one.
+4. For the line-item rate, check the **client record's `hourlyRate`** field
+   first (`data/clients/items/<clientId>.json`). If it's set, use that. If
+   it's absent AND the user didn't specify a rate, ASK via `presentForm` —
+   don't invent one. (Future invoices for this client will skip the form
+   once the `hourlyRate` is recorded on the client.)
 5. Write the invoice. The host will display Subtotal / Tax / Total
    automatically once the file is saved.
 

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -107,6 +107,21 @@ fields you weren't asked to change.
 **Delete**: confirm with the user once if the request is ambiguous, then
 remove the file.
 
+## Linking to an invoice in chat
+
+When you reference a specific invoice in your reply, link to the collection
+view — NOT the raw JSON file path:
+
+- Do: `[INV-2026-0002](/collections/mc-invoice?highlight=INV-2026-0002)`
+- Don't: `[INV-2026-0002](data/invoice/items/INV-2026-0002.json)` — that opens
+  the raw file in the Files view instead of the rendered table.
+
+Always include the `?highlight=<id>` query. Today it just opens the table; a
+later host update will use it to scroll to and highlight the matching row, and
+existing links will start working automatically. The "see the list at
+/collections/mc-invoice" pointer is also fine for a general (non-specific)
+reference.
+
 ## When to ask vs. when to act
 
 If the user gives you clear info ("invoice Acme $5000 for May consulting"),

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -73,6 +73,27 @@ to `data/invoice/items/<id>.json` via the `Write` tool. Defaults:
 `status: "draft"`, `issueDate: <today>`. Don't write `subtotal` / `tax` /
 `total` (computed).
 
+**Create from worklog hours** — common case. When the user says
+"invoice Acme for the work I did this month" (or "for May", or "since the
+last invoice"):
+
+1. Resolve "Acme" → a real client slug by reading `data/clients/items/`.
+2. List `data/worklog/items/` and filter to entries where `clientId`
+   matches AND `date` falls in the requested period.
+3. Group the matching worklog entries into invoice line items. The simplest
+   grouping: one line item per worklog entry (`description = entry.notes`,
+   `quantity = entry.hours`, `rate = <user's standing rate or asked>`).
+   You can also group by description if many entries share the same notes.
+4. If the user hasn't specified a rate and you don't have one on file,
+   ASK via `presentForm` — don't invent one.
+5. Write the invoice. The host will display Subtotal / Tax / Total
+   automatically once the file is saved.
+
+Do NOT skip step 2 and just ask the user "what should the invoice say?" —
+the whole reason mc-worklog exists is so you can pull that data without
+re-asking. If the worklog has no matching entries, tell the user and ask
+whether to create one-off line items instead.
+
 **List / summarize**: read `data/invoice/items/` and answer from those files.
 Don't recite the whole table in chat — the user can see it at
 `/collections/mc-invoice`. For aggregates ("how much have I billed Acme this

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: mc-invoice
+description: A simple invoice ledger — create, list, edit, and remove invoices as JSON files. Skill at `.claude/skills/mc-invoice/` (SKILL.md + schema.json); records at `data/invoice/items/<id>.json`. Each invoice references a client (`clientId` is a `ref` to `mc-clients`) and carries an array of line items. Subtotal / tax / total are computed by the host from the line items + tax rate — you don't write them. The user views records at `/collections/mc-invoice`.
+---
+
+# Invoice (schema-driven collection)
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+## Files
+
+| Purpose | Path |
+|---|---|
+| This skill's instructions (you are reading it) | `.claude/skills/mc-invoice/SKILL.md` |
+| Field schema (source of truth for the host UI) | `.claude/skills/mc-invoice/schema.json` |
+| Records — one JSON per invoice | `data/invoice/items/<id>.json` |
+| Client database (referenced by `clientId`) | `data/clients/items/` (managed by `mc-clients` skill) |
+| User-visible collection surface | `/collections/mc-invoice` (in the host UI) |
+
+You write JSON; the host's `<CollectionView>` reads the same files and renders
+a table + form. There is no separate database — the workspace IS the database.
+
+## Record shape
+
+The schema declares these fields (read `schema.json` for the authoritative
+types):
+
+- `id` — string, **primary key** (the filename, no extension)
+- `clientId` — ref → `mc-clients`, **required**
+- `issueDate` — ISO date `YYYY-MM-DD`, **required**
+- `dueDate` — ISO date (optional)
+- `status` — enum `draft | sent | paid | void`, **required** (default to `draft` when creating)
+- `lineItems` — array of `{ description, quantity, rate }` rows
+- `taxRate` — decimal (e.g. `0.10` for 10%)
+- `notes` — markdown
+- `subtotal`, `tax`, `total` — **computed by the host**; never write these
+
+### id format
+
+`INV-YYYY-NNNN`, year-then-zero-padded counter. Examples: `INV-2026-0001`,
+`INV-2026-0042`. List `data/invoice/items/` first to find the highest existing
+number for the year, then increment. If the file already exists (concurrent
+draft, edited copy), pick the next free number rather than overwriting.
+
+### Computed fields — do NOT write these
+
+`subtotal`, `tax`, and `total` are **derived** fields. The host re-computes
+them from `lineItems` + `taxRate` whenever the record is rendered, and
+`<CollectionView>` will refuse to persist them through the form. If you ever
+see a value for these in an existing JSON file (e.g. from a hand-edit or
+import), leave it alone — the host's computed value wins for display.
+
+## clientId resolution
+
+`clientId` is a `ref` field pointing at the `mc-clients` collection. The host
+renders it as a dropdown picker in the form and a clickable link in the table;
+you write the raw slug.
+
+When the user says "invoice Acme for May consulting":
+
+- List `data/clients/items/` and find the slug whose `name` matches "Acme"
+  (case-insensitive substring is fine for a first pass).
+- If no match: ask the user whether to (a) create the client first via the
+  `mc-clients` skill or (b) supply a literal slug.
+- Never invent a clientId that doesn't exist — it'll render as a broken link
+  in the invoice table.
+
+## What to do
+
+**Create**: derive an `id`, build the record with the fields you have, write
+to `data/invoice/items/<id>.json` via the `Write` tool. Defaults:
+`status: "draft"`, `issueDate: <today>`. Don't write `subtotal` / `tax` /
+`total` (computed).
+
+**List / summarize**: read `data/invoice/items/` and answer from those files.
+Don't recite the whole table in chat — the user can see it at
+`/collections/mc-invoice`. For aggregates ("how much have I billed Acme this
+quarter?") group by clientId + date range and answer in one line.
+
+**Mark sent / paid / void**: read the record, change `status`, write back.
+
+**Edit line items**: read, mutate the `lineItems` array, write back. Preserve
+fields you weren't asked to change.
+
+**Delete**: confirm with the user once if the request is ambiguous, then
+remove the file.
+
+## When to ask vs. when to act
+
+If the user gives you clear info ("invoice Acme $5000 for May consulting"),
+just write the record: one line item `{ description: "May consulting",
+quantity: 1, rate: 5000 }`, status `draft`, today's `issueDate`, `dueDate`
+empty (or 30 days out if a default is set elsewhere).
+
+Use `presentForm` only when something is ambiguous: multiple clients match
+the name they typed, line-item rate vs total isn't clear, etc.

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -84,11 +84,8 @@ last invoice"):
    grouping: one line item per worklog entry (`description = entry.notes`,
    `quantity = entry.hours`, `rate = <user's standing rate or asked>`).
    You can also group by description if many entries share the same notes.
-4. For the line-item rate, check the **client record's `hourlyRate`** field
-   first (`data/clients/items/<clientId>.json`). If it's set, use that. If
-   it's absent AND the user didn't specify a rate, ASK via `presentForm` —
-   don't invent one. (Future invoices for this client will skip the form
-   once the `hourlyRate` is recorded on the client.)
+4. If the user hasn't specified a line-item rate and you don't have one on
+   file, ASK via `presentForm` — don't invent one.
 5. Write the invoice. The host will display Subtotal / Tax / Total
    automatically once the file is saved.
 

--- a/server/workspace/skills-preset/mc-invoice/schema.json
+++ b/server/workspace/skills-preset/mc-invoice/schema.json
@@ -1,0 +1,73 @@
+{
+  "title": "Invoices",
+  "icon": "receipt_long",
+  "dataPath": "data/invoice/items",
+  "primaryKey": "id",
+  "fields": {
+    "id": {
+      "type": "string",
+      "label": "ID",
+      "primary": true,
+      "required": true
+    },
+    "clientId": {
+      "type": "ref",
+      "to": "mc-clients",
+      "label": "Client",
+      "required": true
+    },
+    "issueDate": {
+      "type": "date",
+      "label": "Issued",
+      "required": true
+    },
+    "dueDate": {
+      "type": "date",
+      "label": "Due"
+    },
+    "status": {
+      "type": "enum",
+      "values": ["draft", "sent", "paid", "void"],
+      "label": "Status",
+      "required": true
+    },
+    "lineItems": {
+      "type": "table",
+      "label": "Line items",
+      "of": {
+        "description": { "type": "string", "label": "Description", "required": true },
+        "quantity": { "type": "number", "label": "Qty", "required": true },
+        "rate": { "type": "money", "label": "Rate", "currency": "USD", "required": true }
+      }
+    },
+    "subtotal": {
+      "type": "derived",
+      "label": "Subtotal",
+      "formula": "sum(lineItems[].quantity * lineItems[].rate)",
+      "display": "money",
+      "currency": "USD"
+    },
+    "taxRate": {
+      "type": "number",
+      "label": "Tax rate (e.g. 0.10 for 10%)"
+    },
+    "tax": {
+      "type": "derived",
+      "label": "Tax",
+      "formula": "subtotal * taxRate",
+      "display": "money",
+      "currency": "USD"
+    },
+    "total": {
+      "type": "derived",
+      "label": "Total",
+      "formula": "subtotal + tax",
+      "display": "money",
+      "currency": "USD"
+    },
+    "notes": {
+      "type": "markdown",
+      "label": "Notes"
+    }
+  }
+}

--- a/server/workspace/skills-preset/mc-worklog/SKILL.md
+++ b/server/workspace/skills-preset/mc-worklog/SKILL.md
@@ -69,6 +69,19 @@ month?") group by clientId + date range and answer in one line.
 **Edit / delete**: same conventions as `mc-clients` — read, merge, write,
 or unlink. Preserve fields you weren't asked to change.
 
+## Linking to an entry in chat
+
+When you reference a specific worklog entry in your reply, link to the
+collection view — NOT the raw JSON file path:
+
+- Do: `[2026-05-24 Acme](/collections/mc-worklog?highlight=2026-05-24-acme-corp-a1b2)`
+- Don't: `[…](data/worklog/items/2026-05-24-acme-corp-a1b2.json)` — that opens
+  the raw file in the Files view instead of the rendered table.
+
+Always include the `?highlight=<id>` query. Today it just opens the table; a
+later host update will use it to scroll to and highlight the matching row, and
+existing links will start working automatically.
+
 ## When to ask vs. when to act
 
 If the user gives you a clear "log N hours for X today" sentence with all

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -172,6 +172,7 @@
                         v-model="row.bool[subKey]"
                         type="checkbox"
                         class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-400"
+                        @change="markRowBoolTouched(row, String(subKey))"
                       />
                       <select
                         v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
@@ -385,10 +386,15 @@ interface ItemMutationResponse {
 /** One row of a `table`-typed field, in draft form. Same shape as
  *  a top-level EditState's `text`/`bool` slots but flat — v0
  *  disallows nested tables and derived columns, so a row never
- *  needs its own table/derived sub-buckets. */
+ *  needs its own table/derived sub-buckets. The boolean
+ *  presence/touched maps mirror the top-level boolean omission
+ *  semantics per row, so a row's explicit `false` round-trips
+ *  through a no-op edit instead of being dropped. */
 interface TableRowDraft {
   text: Record<string, string>;
   bool: Record<string, boolean>;
+  boolOriginallyPresent: Record<string, boolean>;
+  boolTouched: Record<string, boolean>;
 }
 
 interface EditState {
@@ -605,25 +611,43 @@ function formatMoney(value: unknown, currency: string | undefined, displayLocale
 function emptyRow(subFields: Record<string, FieldSpec>): TableRowDraft {
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
+  const boolOriginallyPresent: Record<string, boolean> = {};
+  const boolTouched: Record<string, boolean> = {};
   for (const [subKey, subField] of Object.entries(subFields)) {
-    if (subField.type === "boolean") bool[subKey] = false;
-    else text[subKey] = "";
+    if (subField.type === "boolean") {
+      bool[subKey] = false;
+      boolOriginallyPresent[subKey] = false; // brand-new row
+      boolTouched[subKey] = false;
+    } else {
+      text[subKey] = "";
+    }
   }
-  return { text, bool };
+  return { text, bool, boolOriginallyPresent, boolTouched };
 }
 
 function rowFromItem(item: Record<string, unknown>, subFields: Record<string, FieldSpec>): TableRowDraft {
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
+  const boolOriginallyPresent: Record<string, boolean> = {};
+  const boolTouched: Record<string, boolean> = {};
   for (const [subKey, subField] of Object.entries(subFields)) {
     const raw = item[subKey];
     if (subField.type === "boolean") {
       bool[subKey] = raw === true;
+      // `typeof raw === "boolean"` (not `raw === true`) so an
+      // existing explicit `false` is recorded as present and
+      // round-trips on a no-op save.
+      boolOriginallyPresent[subKey] = typeof raw === "boolean";
+      boolTouched[subKey] = false;
     } else {
       text[subKey] = raw === undefined || raw === null ? "" : String(raw);
     }
   }
-  return { text, bool };
+  return { text, bool, boolOriginallyPresent, boolTouched };
+}
+
+function markRowBoolTouched(row: TableRowDraft, subKey: string): void {
+  row.boolTouched[subKey] = true;
 }
 
 function addTableRow(key: string, subFields: Record<string, FieldSpec>): void {
@@ -777,14 +801,17 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
   const row: Record<string, unknown> = {};
   for (const [subKey, subField] of Object.entries(subFields)) {
     if (subField.type === "boolean") {
-      // Mirror the top-level boolean omission rule (lighter-weight
-      // — no per-row touched tracking): emit only when `true` or
-      // when the sub-field is required. An absent optional boolean
-      // stays absent through a no-op edit, so consumers that
-      // distinguish absence from `false` aren't clobbered.
-      // (github-actions review PR #1497.)
+      // Full mirror of the top-level boolean omission rule: emit if
+      // it was originally present (preserve an existing explicit
+      // `false`), OR the user actively toggled it this session, OR
+      // it's required, OR it's now `true`. Otherwise omit so a
+      // brand-new untouched optional boolean stays absent (default
+      // applies) — round-tripping both "absent" and explicit
+      // "false" losslessly. (Codex PR #1497, two rounds.)
       const value = rowDraft.bool[subKey] === true;
-      if (value || subField.required) row[subKey] = value;
+      if (rowDraft.boolOriginallyPresent[subKey] || rowDraft.boolTouched[subKey] || value || subField.required) {
+        row[subKey] = value;
+      }
       continue;
     }
     const value = scalarDraftToValue(rowDraft.text[subKey], subField.type);

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -191,11 +191,24 @@
                         <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
                         <option v-for="opt in refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
                       </select>
+                      <!-- money sub-field: same currency-prefix
+                           treatment as the top-level money input. -->
+                      <div v-else-if="subField.type === 'money'" class="relative">
+                        <span class="absolute inset-y-0 left-0 flex items-center pl-1 text-xs text-gray-500 pointer-events-none">{{
+                          currencySymbol(subField.currency)
+                        }}</span>
+                        <input
+                          v-model="row.text[subKey]"
+                          type="number"
+                          step="0.01"
+                          :required="subField.required"
+                          class="w-full rounded border border-gray-300 pl-6 pr-1 py-0.5 text-sm focus:border-blue-400 focus:outline-none"
+                        />
+                      </div>
                       <input
                         v-else
                         v-model="row.text[subKey]"
                         :type="inputTypeFor(subField.type)"
-                        :step="subField.type === 'money' ? '0.01' : undefined"
                         :required="subField.required"
                         class="w-full rounded border border-gray-300 px-1 py-0.5 text-sm focus:border-blue-400 focus:outline-none"
                       />
@@ -234,12 +247,28 @@
               class="w-full rounded border border-gray-200 bg-gray-50 px-2 py-1 text-sm text-gray-700"
               :data-testid="`collections-input-${key}`"
             />
+            <!-- money input: currency symbol as a left-pinned prefix
+                 so the user can see which currency they're typing
+                 into (the bare number input gave no visual hint). -->
+            <div v-else-if="field.type === 'money'" class="relative">
+              <span class="absolute inset-y-0 left-0 flex items-center pl-2 text-xs text-gray-500 pointer-events-none">{{
+                currencySymbol(field.currency)
+              }}</span>
+              <input
+                :id="`collections-field-${key}`"
+                v-model="editing.text[key]"
+                type="number"
+                step="0.01"
+                :required="isFieldRequiredInUi(field)"
+                class="w-full rounded border border-gray-300 pl-7 pr-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+                :data-testid="`collections-input-${key}`"
+              />
+            </div>
             <input
-              v-else-if="['string', 'email', 'number', 'date', 'ref', 'money'].includes(field.type)"
+              v-else-if="['string', 'email', 'number', 'date', 'ref'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
-              :step="field.type === 'money' ? '0.01' : undefined"
               :required="isFieldRequiredInUi(field)"
               :disabled="field.primary === true && editing.mode === 'edit'"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
@@ -526,6 +555,23 @@ function inputTypeFor(type: FieldType): string {
   return "text";
 }
 
+/** Extract the localized currency symbol for a given ISO code
+ *  (`USD` → `$`, `JPY` → `¥`, `EUR` → `€`). Used in the form's
+ *  money input so the user can see which currency they're typing
+ *  into — the schema declares the code per-field, but a bare
+ *  number input gave no visual hint of currency. Falls back to
+ *  the raw code on any Intl failure. */
+function currencySymbol(currency: string | undefined): string {
+  const code = currency && currency.length > 0 ? currency : "USD";
+  try {
+    const parts = new Intl.NumberFormat(locale.value, { style: "currency", currency: code }).formatToParts(0);
+    const part = parts.find((entry) => entry.type === "currency");
+    return part?.value ?? code;
+  } catch {
+    return code;
+  }
+}
+
 /** Format a money value via `Intl.NumberFormat`. Falls back to the
  *  raw number on any failure (unknown currency code, non-finite
  *  amount, etc.) so a malformed record still renders something
@@ -534,7 +580,13 @@ function inputTypeFor(type: FieldType): string {
  *  user's settings even though the currency is declared by the
  *  schema. */
 function formatMoney(value: unknown, currency: string | undefined, displayLocale: string): string {
-  if (value === undefined || value === null || value === "") return "—";
+  // `null` is intentionally NOT in this guard — `derivedDisplay`
+  // short-circuits on null before calling here, and the table
+  // cell branch passes `item[key]` from JSON where missing keys
+  // arrive as `undefined`, not `null` (we never persist explicit
+  // null). CodeQL flagged the original `value === null` as
+  // unreachable; removed per github-code-quality on PR #1497.
+  if (value === undefined || value === "") return "—";
   const amount = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(amount)) return String(value);
   const currencyCode = currency && currency.length > 0 ? currency : "USD";
@@ -724,6 +776,31 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
   return row;
 }
 
+/** Walk every row of a `table` field's draft, returning the label
+ *  of the first required sub-field that's empty in any row.
+ *  Returns null when every required cell is filled (or when no
+ *  rows / no required sub-fields exist).
+ *
+ *  Why this needs to exist: save is triggered via a `type="button"`
+ *  click that calls `saveEditor` directly, which skips native HTML5
+ *  form submission. The `:required` attributes on row inputs are
+ *  therefore never enforced by the browser — we have to enforce
+ *  them here. (Codex P1 review on PR #1497.) */
+function firstMissingTableSubField(field: FieldSpec, rows: TableRowDraft[] | undefined): string | null {
+  if (!field.of || !rows) return null;
+  for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+    const row = rows[rowIdx];
+    for (const [subKey, subField] of Object.entries(field.of)) {
+      if (!subField.required) continue;
+      // Boolean required is a no-op (same reasoning as the
+      // top-level skip below).
+      if (subField.type === "boolean") continue;
+      if (!row.text[subKey]) return `${field.label} #${rowIdx + 1}: ${subField.label}`;
+    }
+  }
+  return null;
+}
+
 /** Client-side required-field check. Returns the human-readable
  *  label of the first missing required field, or null if everything
  *  required is filled. Extracted from `saveEditor` to keep that
@@ -735,18 +812,29 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
  *    "blank → server-generated id" flow even for schemas that mark
  *    the primary field required)
  *  - booleans (`false` is a valid answer; required is a no-op)
- *  - derived (computed, not user-entered) */
+ *  - derived (computed, not user-entered)
+ *
+ *  Table fields are special: their `required` flag means "at least
+ *  one row", AND each row's sub-fields validate per their own
+ *  `required` flags — even if the table itself is optional. The
+ *  table block therefore runs OUTSIDE the `if (!field.required)`
+ *  short-circuit. */
+function validateOneField(key: string, field: FieldSpec, draft: EditState): string | null {
+  if (field.type === "table" && field.of) {
+    const rows = draft.table[key];
+    if (field.required && (!rows || rows.length === 0)) return field.label;
+    return firstMissingTableSubField(field, rows);
+  }
+  if (!field.required) return null;
+  if (draft.mode === "create" && field.primary === true) return null;
+  if (field.type === "boolean" || field.type === "derived") return null;
+  return draft.text[key] ? null : field.label;
+}
+
 function firstMissingRequiredField(draft: EditState, schema: CollectionSchema): string | null {
   for (const [key, field] of Object.entries(schema.fields)) {
-    if (!field.required) continue;
-    if (draft.mode === "create" && field.primary === true) continue;
-    if (field.type === "boolean" || field.type === "derived") continue;
-    if (field.type === "table") {
-      const rows = draft.table[key];
-      if (!rows || rows.length === 0) return field.label;
-      continue;
-    }
-    if (!draft.text[key]) return field.label;
+    const missing = validateOneField(key, field, draft);
+    if (missing) return missing;
   }
   return null;
 }
@@ -778,17 +866,20 @@ const liveRecord = computed<CollectionItem | null>(() => {
   return draftToRecord(editing.value, collection.value.schema);
 });
 
-/** Evaluate a derived field's formula against the live draft,
- *  then evaluate any top-level fields that have downstream derived
- *  fields (subtotal → tax → total). Two-pass eval: first pass
- *  fills `subtotal` from the live record; second pass evaluates
- *  fields that reference subtotal (tax, total).
+/** Evaluate every derived field against `base`, iterating until
+ *  the values stop changing (or until we've used at most one pass
+ *  per derived field — the natural upper bound on chain length,
+ *  reached when the fields appear in worst-case dependency order
+ *  and each pass settles only one slot).
  *
- *  Three passes is enough for invoice's depth (subtotal → tax →
- *  total). If a future schema needs deeper chains, raise the cap. */
+ *  Per CodeRabbit on PR #1497: the previous hard-coded 3-pass
+ *  ceiling silently capped longer chains. The new bound is exact
+ *  for any DAG over derived fields and an early `break` on
+ *  fixed-point keeps the common-case cost the same. */
 function deriveAll(schema: CollectionSchema, base: CollectionItem): CollectionItem {
   const enriched: CollectionItem = { ...base };
-  for (let pass = 0; pass < 3; pass++) {
+  const maxPasses = Object.values(schema.fields).filter((field) => field.type === "derived").length;
+  for (let pass = 0; pass < maxPasses; pass++) {
     let mutated = false;
     for (const [key, field] of Object.entries(schema.fields)) {
       if (field.type !== "derived" || !field.formula) continue;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -63,7 +63,9 @@
                   >{{ refDisplay(field.to, String(item[key])) }}</router-link
                 >
               </span>
-              <span v-else-if="field.type === 'money'" class="block truncate tabular-nums">{{ formatMoney(item[key], field.currency, locale) }}</span>
+              <span v-else-if="field.type === 'money'" class="block truncate tabular-nums">{{
+                formatMoney(item[key], resolveCurrency(field, item), locale)
+              }}</span>
               <span v-else-if="field.type === 'table'" class="block text-gray-500">{{ tableSummary(item[key]) }}</span>
               <span v-else-if="field.type === 'derived'" class="block truncate tabular-nums">{{
                 derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item))
@@ -195,7 +197,7 @@
                            treatment as the top-level money input. -->
                       <div v-else-if="subField.type === 'money'" class="relative">
                         <span class="absolute inset-y-0 left-0 flex items-center pl-1 text-xs text-gray-500 pointer-events-none">{{
-                          currencySymbol(subField.currency)
+                          currencySymbol(resolveCurrency(subField, rowDraftToRecord(row, field.of)))
                         }}</span>
                         <input
                           v-model="row.text[subKey]"
@@ -252,7 +254,7 @@
                  into (the bare number input gave no visual hint). -->
             <div v-else-if="field.type === 'money'" class="relative">
               <span class="absolute inset-y-0 left-0 flex items-center pl-2 text-xs text-gray-500 pointer-events-none">{{
-                currencySymbol(field.currency)
+                currencySymbol(resolveCurrency(field, liveRecord))
               }}</span>
               <input
                 :id="`collections-field-${key}`"
@@ -330,8 +332,14 @@ interface FieldSpec {
    *  plans/done/feat-collections-ref-field.md). */
   to?: string;
   /** When type === "money": ISO 4217 currency for Intl display.
-   *  Defaults to "USD" when omitted. */
+   *  Default when `currencyField` is absent or resolves blank. */
   currency?: string;
+  /** When type === "money": name of a sibling field whose value
+   *  holds the currency code. Lets different records of the same
+   *  collection use different currencies (e.g. each client's
+   *  hourlyRate billed in their own currency). See
+   *  `resolveCurrency`. */
+  currencyField?: string;
   /** When type === "enum": closed list of allowed string values
    *  for the form `<select>`. */
   values?: readonly string[];
@@ -553,6 +561,18 @@ function inputTypeFor(type: FieldType): string {
   if (type === "money") return "number";
   if (type === "date") return "date";
   return "text";
+}
+
+/** Pick the currency code to use for a money field at render
+ *  time. When the schema declares `currencyField`, look up that
+ *  sibling on the current record (form draft or persisted item);
+ *  fall back to the field's static `currency`, then to `USD`. */
+function resolveCurrency(field: FieldSpec, record: CollectionItem | null | undefined): string | undefined {
+  if (field.currencyField && record) {
+    const fromRecord = record[field.currencyField];
+    if (typeof fromRecord === "string" && fromRecord.length > 0) return fromRecord;
+  }
+  return field.currency;
 }
 
 /** Extract the localized currency symbol for a given ISO code

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -63,6 +63,11 @@
                   >{{ refDisplay(field.to, String(item[key])) }}</router-link
                 >
               </span>
+              <span v-else-if="field.type === 'money'" class="block truncate tabular-nums">{{ formatMoney(item[key], field.currency, locale) }}</span>
+              <span v-else-if="field.type === 'table'" class="block text-gray-500">{{ tableSummary(item[key]) }}</span>
+              <span v-else-if="field.type === 'derived'" class="block truncate tabular-nums">{{
+                derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item))
+              }}</span>
               <span v-else class="block truncate">{{ formatCell(item[key], field.type) }}</span>
             </td>
             <td class="px-4 py-2 text-right whitespace-nowrap">
@@ -133,14 +138,108 @@
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
               :data-testid="`collections-input-${key}`"
             >
-              <option value="">{{ t("collectionsView.refPlaceholder") }}</option>
+              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
               <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
             </select>
+            <select
+              v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :required="isFieldRequiredInUi(field)"
+              class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none"
+              :data-testid="`collections-input-${key}`"
+            >
+              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+              <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+            </select>
+            <!-- table editor: inline mini-table with add/remove row.
+                 Sub-fields use the same input branches as top-level
+                 fields (minus nested table / derived — rejected by
+                 the SubFieldSpecSchema in discovery). -->
+            <div v-else-if="field.type === 'table' && field.of" class="border border-gray-200 rounded p-2 space-y-2" :data-testid="`collections-table-${key}`">
+              <table v-if="editing.table[key] && editing.table[key].length > 0" class="w-full text-sm">
+                <thead>
+                  <tr class="text-xs text-gray-500">
+                    <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-1 py-1 font-medium">{{ subField.label }}</th>
+                    <th class="w-px"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx">
+                    <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-1 py-1 align-top">
+                      <input
+                        v-if="subField.type === 'boolean'"
+                        v-model="row.bool[subKey]"
+                        type="checkbox"
+                        class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-400"
+                      />
+                      <select
+                        v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
+                        v-model="row.text[subKey]"
+                        :required="subField.required"
+                        class="w-full rounded border border-gray-300 px-1 py-0.5 text-sm focus:border-blue-400 focus:outline-none"
+                      >
+                        <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                        <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
+                      </select>
+                      <select
+                        v-else-if="subField.type === 'ref' && subField.to && refOptions(subField.to).length > 0"
+                        v-model="row.text[subKey]"
+                        :required="subField.required"
+                        class="w-full rounded border border-gray-300 px-1 py-0.5 text-sm focus:border-blue-400 focus:outline-none"
+                      >
+                        <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                        <option v-for="opt in refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+                      </select>
+                      <input
+                        v-else
+                        v-model="row.text[subKey]"
+                        :type="inputTypeFor(subField.type)"
+                        :step="subField.type === 'money' ? '0.01' : undefined"
+                        :required="subField.required"
+                        class="w-full rounded border border-gray-300 px-1 py-0.5 text-sm focus:border-blue-400 focus:outline-none"
+                      />
+                    </td>
+                    <td class="text-right px-1">
+                      <button
+                        type="button"
+                        class="h-6 w-6 flex items-center justify-center rounded text-red-500 hover:bg-red-50"
+                        :aria-label="t('collectionsView.removeRow')"
+                        :data-testid="`collections-table-${key}-remove-${rowIdx}`"
+                        @click="removeTableRow(key, rowIdx)"
+                      >
+                        <span class="material-icons text-base">close</span>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <p v-else class="text-xs text-gray-500 italic">{{ t("collectionsView.noRows") }}</p>
+              <button
+                type="button"
+                class="text-xs text-blue-600 hover:underline"
+                :data-testid="`collections-table-${key}-add`"
+                @click="addTableRow(key, field.of)"
+              >
+                + {{ t("collectionsView.addRow") }}
+              </button>
+            </div>
+            <!-- derived: read-only display, computed live from the draft. -->
             <input
-              v-else-if="['string', 'email', 'number', 'date', 'ref'].includes(field.type)"
+              v-else-if="field.type === 'derived'"
+              :id="`collections-field-${key}`"
+              :value="derivedDisplay(field, liveDerived?.[key] ?? null)"
+              type="text"
+              disabled
+              class="w-full rounded border border-gray-200 bg-gray-50 px-2 py-1 text-sm text-gray-700"
+              :data-testid="`collections-input-${key}`"
+            />
+            <input
+              v-else-if="['string', 'email', 'number', 'date', 'ref', 'money'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
+              :step="field.type === 'money' ? '0.01' : undefined"
               :required="isFieldRequiredInUi(field)"
               :disabled="field.primary === true && editing.mode === 'edit'"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
@@ -181,7 +280,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { apiDelete, apiGet, apiPost, apiPut } from "../utils/api";
@@ -189,8 +288,9 @@ import { API_ROUTES } from "../config/apiRoutes";
 import { PAGE_ROUTES } from "../router/pageRoutes";
 import ConfirmModal from "./ConfirmModal.vue";
 import { useConfirm } from "../composables/useConfirm";
+import { evaluateDerived } from "../utils/collections/derivedFormula";
 
-type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref";
+type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived";
 
 interface FieldSpec {
   type: FieldType;
@@ -198,8 +298,23 @@ interface FieldSpec {
   primary?: boolean;
   required?: boolean;
   /** When type === "ref": slug of the target collection (see
-   *  plans/feat-collections-ref-field.md). */
+   *  plans/done/feat-collections-ref-field.md). */
   to?: string;
+  /** When type === "money": ISO 4217 currency for Intl display.
+   *  Defaults to "USD" when omitted. */
+  currency?: string;
+  /** When type === "enum": closed list of allowed string values
+   *  for the form `<select>`. */
+  values?: readonly string[];
+  /** When type === "table": sub-schema for each row (a flat map
+   *  of non-table / non-derived sub-fields). */
+  of?: Record<string, FieldSpec>;
+  /** When type === "derived": formula evaluated against the
+   *  record. See src/utils/collections/derivedFormula.ts. */
+  formula?: string;
+  /** When type === "derived": render the computed value as this
+   *  field type (e.g. "money"). Defaults to "number". */
+  display?: FieldType;
 }
 
 /** Per-target-collection cache: maps an item's primary-key slug to
@@ -238,6 +353,15 @@ interface ItemMutationResponse {
   item: CollectionItem;
 }
 
+/** One row of a `table`-typed field, in draft form. Same shape as
+ *  a top-level EditState's `text`/`bool` slots but flat — v0
+ *  disallows nested tables and derived columns, so a row never
+ *  needs its own table/derived sub-buckets. */
+interface TableRowDraft {
+  text: Record<string, string>;
+  bool: Record<string, boolean>;
+}
+
 interface EditState {
   mode: "create" | "edit";
   /** Form drafts for text-like inputs. v-model on `<input type="text">`
@@ -265,11 +389,15 @@ interface EditState {
    *  unchecked box looks the same as untouched), which blocks
    *  things like a non-billable mc-worklog entry from the UI. */
   boolTouched: Record<string, boolean>;
+  /** Per-table-field row drafts. Vue tracks deep mutations on
+   *  these arrays so derived formulas re-evaluate live as the
+   *  user edits cells. */
+  table: Record<string, TableRowDraft[]>;
   /** For edit mode: the original item id pinned to the URL. */
   originalId: string | null;
 }
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const route = useRoute();
 const router = useRouter();
 const { openConfirm } = useConfirm();
@@ -321,11 +449,21 @@ async function loadCollection(slug: string): Promise<void> {
 
 function uniqueRefTargets(schema: CollectionSchema): string[] {
   const targets = new Set<string>();
-  for (const field of Object.values(schema.fields)) {
-    if (field.type === "ref" && typeof field.to === "string" && field.to.length > 0) {
-      targets.add(field.to);
+  const walk = (fields: Record<string, FieldSpec>): void => {
+    for (const field of Object.values(fields)) {
+      if (field.type === "ref" && typeof field.to === "string" && field.to.length > 0) {
+        targets.add(field.to);
+      }
+      if (field.type === "table" && field.of) {
+        // Sub-fields of a table can also be refs (e.g. lineItem
+        // referencing a product catalog). Walk one level deep —
+        // nested tables are rejected by the schema, so a single
+        // recursion is enough.
+        walk(field.of);
+      }
     }
-  }
+  };
+  walk(schema.fields);
   return [...targets];
 }
 
@@ -383,8 +521,71 @@ function refOptions(targetSlug: string): { slug: string; display: string }[] {
 function inputTypeFor(type: FieldType): string {
   if (type === "email") return "email";
   if (type === "number") return "number";
+  if (type === "money") return "number";
   if (type === "date") return "date";
   return "text";
+}
+
+/** Format a money value via `Intl.NumberFormat`. Falls back to the
+ *  raw number on any failure (unknown currency code, non-finite
+ *  amount, etc.) so a malformed record still renders something
+ *  rather than blowing up the row. Locale comes from the active
+ *  i18n locale so digit grouping / decimal separator follow the
+ *  user's settings even though the currency is declared by the
+ *  schema. */
+function formatMoney(value: unknown, currency: string | undefined, displayLocale: string): string {
+  if (value === undefined || value === null || value === "") return "—";
+  const amount = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(amount)) return String(value);
+  const currencyCode = currency && currency.length > 0 ? currency : "USD";
+  try {
+    return new Intl.NumberFormat(displayLocale, { style: "currency", currency: currencyCode }).format(amount);
+  } catch {
+    return String(amount);
+  }
+}
+
+/** Live computed record from the current draft, used by `derived`
+ *  fields in the form so subtotal/tax/total update as the user
+ *  edits line items. For derived cells in the main table, we
+ *  evaluate against the loaded item instead — see the table cell
+ *  branch. */
+function emptyRow(subFields: Record<string, FieldSpec>): TableRowDraft {
+  const text: Record<string, string> = {};
+  const bool: Record<string, boolean> = {};
+  for (const [subKey, subField] of Object.entries(subFields)) {
+    if (subField.type === "boolean") bool[subKey] = false;
+    else text[subKey] = "";
+  }
+  return { text, bool };
+}
+
+function rowFromItem(item: Record<string, unknown>, subFields: Record<string, FieldSpec>): TableRowDraft {
+  const text: Record<string, string> = {};
+  const bool: Record<string, boolean> = {};
+  for (const [subKey, subField] of Object.entries(subFields)) {
+    const raw = item[subKey];
+    if (subField.type === "boolean") {
+      bool[subKey] = raw === true;
+    } else {
+      text[subKey] = raw === undefined || raw === null ? "" : String(raw);
+    }
+  }
+  return { text, bool };
+}
+
+function addTableRow(key: string, subFields: Record<string, FieldSpec>): void {
+  if (!editing.value) return;
+  const rows = editing.value.table[key] ?? [];
+  rows.push(emptyRow(subFields));
+  editing.value.table[key] = rows;
+}
+
+function removeTableRow(key: string, index: number): void {
+  if (!editing.value) return;
+  const rows = editing.value.table[key];
+  if (!rows) return;
+  rows.splice(index, 1);
 }
 
 /** Mirror of the create-mode primary-key carve-out in `saveEditor`:
@@ -413,17 +614,21 @@ function openCreate(): void {
   const bool: Record<string, boolean> = {};
   const boolOriginallyPresent: Record<string, boolean> = {};
   const boolTouched: Record<string, boolean> = {};
+  const table: Record<string, TableRowDraft[]> = {};
   for (const [key, field] of Object.entries(collection.value.schema.fields)) {
     if (field.type === "boolean") {
       bool[key] = false;
       // New record — no boolean was originally present.
       boolOriginallyPresent[key] = false;
       boolTouched[key] = false;
-    } else {
+    } else if (field.type === "table") {
+      table[key] = [];
+    } else if (field.type !== "derived") {
       text[key] = "";
     }
+    // derived fields are computed on the fly; nothing to seed.
   }
-  editing.value = { mode: "create", text, bool, boolOriginallyPresent, boolTouched, originalId: null };
+  editing.value = { mode: "create", text, bool, boolOriginallyPresent, boolTouched, table, originalId: null };
   saveError.value = null;
 }
 
@@ -433,6 +638,7 @@ function openEdit(item: CollectionItem): void {
   const bool: Record<string, boolean> = {};
   const boolOriginallyPresent: Record<string, boolean> = {};
   const boolTouched: Record<string, boolean> = {};
+  const table: Record<string, TableRowDraft[]> = {};
   for (const [key, field] of Object.entries(collection.value.schema.fields)) {
     const raw = item[key];
     if (field.type === "boolean") {
@@ -445,13 +651,19 @@ function openEdit(item: CollectionItem): void {
       // existing boolean state.
       boolOriginallyPresent[key] = typeof raw === "boolean";
       boolTouched[key] = false;
-    } else {
+    } else if (field.type === "table" && field.of) {
+      const sub = field.of;
+      const rows = Array.isArray(raw) ? raw : [];
+      table[key] = rows
+        .filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row))
+        .map((row) => rowFromItem(row, sub));
+    } else if (field.type !== "derived") {
       text[key] = raw === undefined || raw === null ? "" : String(raw);
     }
   }
   const primaryRaw = item[collection.value.schema.primaryKey];
   const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
-  editing.value = { mode: "edit", text, bool, boolOriginallyPresent, boolTouched, originalId };
+  editing.value = { mode: "edit", text, bool, boolOriginallyPresent, boolTouched, table, originalId };
   saveError.value = null;
 }
 
@@ -465,39 +677,165 @@ function closeEditor(): void {
   saveError.value = null;
 }
 
+/** Decide whether and how to emit a boolean field's draft value.
+ *  Extracted from `draftToRecord` to keep that function's
+ *  cognitive complexity under the lint cap. */
+function shouldEmitBoolean(state: EditState, key: string, field: FieldSpec): boolean {
+  // Emit when any of:
+  //  - originally present (preserve prior choice + any in-session
+  //    toggle, including explicit false)
+  //  - user has actively interacted with the checkbox (required so
+  //    explicit `false` is round-trippable from create mode, where
+  //    every untouched checkbox would otherwise look like "omit")
+  //  - the schema marks the field required (downstream consumers
+  //    may depend on the key always being present)
+  // Otherwise omit so a brand-new record that didn't touch an
+  // optional boolean doesn't materialize `false`, letting the
+  // consumer's default apply (e.g. mc-worklog's "absent billable
+  // means true").
+  return Boolean(state.boolOriginallyPresent[key] || state.boolTouched[key] || field.required);
+}
+
+/** Convert a scalar draft slot (text bucket) to its persisted form
+ *  per the field's type. Returns `undefined` to signal "omit". */
+function scalarDraftToValue(raw: string | undefined, fieldType: FieldType): unknown {
+  if (raw === undefined || raw === "") return undefined;
+  if (fieldType === "number" || fieldType === "money") {
+    const num = Number(raw);
+    return Number.isFinite(num) ? num : raw;
+  }
+  return raw;
+}
+
+/** Convert one row of a `table` field's draft to its persisted
+ *  row record. Sub-fields are restricted to non-table / non-derived
+ *  types by the SubFieldSpecSchema, so we only need to handle the
+ *  scalar + boolean branches. */
+function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, FieldSpec>): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  for (const [subKey, subField] of Object.entries(subFields)) {
+    if (subField.type === "boolean") {
+      row[subKey] = rowDraft.bool[subKey] === true;
+      continue;
+    }
+    const value = scalarDraftToValue(rowDraft.text[subKey], subField.type);
+    if (value !== undefined) row[subKey] = value;
+  }
+  return row;
+}
+
+/** Client-side required-field check. Returns the human-readable
+ *  label of the first missing required field, or null if everything
+ *  required is filled. Extracted from `saveEditor` to keep that
+ *  function's cognitive complexity under the lint cap.
+ *
+ *  Skip rules:
+ *  - primary key in create mode (server auto-generates an id when
+ *    blank, so blocking here would deny the documented
+ *    "blank → server-generated id" flow even for schemas that mark
+ *    the primary field required)
+ *  - booleans (`false` is a valid answer; required is a no-op)
+ *  - derived (computed, not user-entered) */
+function firstMissingRequiredField(draft: EditState, schema: CollectionSchema): string | null {
+  for (const [key, field] of Object.entries(schema.fields)) {
+    if (!field.required) continue;
+    if (draft.mode === "create" && field.primary === true) continue;
+    if (field.type === "boolean" || field.type === "derived") continue;
+    if (field.type === "table") {
+      const rows = draft.table[key];
+      if (!rows || rows.length === 0) return field.label;
+      continue;
+    }
+    if (!draft.text[key]) return field.label;
+  }
+  return null;
+}
+
 function draftToRecord(state: EditState, schema: CollectionSchema): CollectionItem {
   const record: CollectionItem = {};
   for (const [key, field] of Object.entries(schema.fields)) {
+    if (field.type === "derived") continue; // never persisted; computed on demand
     if (field.type === "boolean") {
-      // Emit the boolean if any of:
-      //   - it was originally present (preserve prior choice + any
-      //     in-session toggle, including explicit false)
-      //   - the user has actively interacted with the checkbox in
-      //     this session (boolTouched — required to make explicit
-      //     `false` round-trippable from create mode, where every
-      //     untouched checkbox would otherwise look like "omit")
-      //   - the schema marks the field required (downstream
-      //     consumers may depend on the key always being present)
-      // Otherwise omit so a brand-new record that didn't touch
-      // an optional boolean doesn't materialize `false` for it,
-      // letting the consumer's default (e.g. mc-worklog's
-      // "absent billable means true") apply.
-      const value = state.bool[key] === true;
-      if (state.boolOriginallyPresent[key] || state.boolTouched[key] || field.required) {
-        record[key] = value;
-      }
+      if (shouldEmitBoolean(state, key, field)) record[key] = state.bool[key] === true;
       continue;
     }
-    const raw = state.text[key];
-    if (raw === undefined || raw === "") continue;
-    if (field.type === "number") {
-      const num = Number(raw);
-      record[key] = Number.isFinite(num) ? num : raw;
-    } else {
-      record[key] = raw;
+    if (field.type === "table" && field.of) {
+      const subFields = field.of;
+      record[key] = (state.table[key] ?? []).map((rowDraft) => rowDraftToRecord(rowDraft, subFields));
+      continue;
     }
+    const value = scalarDraftToValue(state.text[key], field.type);
+    if (value !== undefined) record[key] = value;
   }
   return record;
+}
+
+/** Live computed record from the current draft. Drives derived
+ *  field displays in the form so subtotal/tax/total update as
+ *  the user edits line items. */
+const liveRecord = computed<CollectionItem | null>(() => {
+  if (!collection.value || !editing.value) return null;
+  return draftToRecord(editing.value, collection.value.schema);
+});
+
+/** Evaluate a derived field's formula against the live draft,
+ *  then evaluate any top-level fields that have downstream derived
+ *  fields (subtotal → tax → total). Two-pass eval: first pass
+ *  fills `subtotal` from the live record; second pass evaluates
+ *  fields that reference subtotal (tax, total).
+ *
+ *  Three passes is enough for invoice's depth (subtotal → tax →
+ *  total). If a future schema needs deeper chains, raise the cap. */
+function deriveAll(schema: CollectionSchema, base: CollectionItem): CollectionItem {
+  const enriched: CollectionItem = { ...base };
+  for (let pass = 0; pass < 3; pass++) {
+    let mutated = false;
+    for (const [key, field] of Object.entries(schema.fields)) {
+      if (field.type !== "derived" || !field.formula) continue;
+      const next = evaluateDerived(field.formula, { record: enriched });
+      if (next !== null && enriched[key] !== next) {
+        enriched[key] = next;
+        mutated = true;
+      }
+    }
+    if (!mutated) break;
+  }
+  return enriched;
+}
+
+const liveDerived = computed<CollectionItem | null>(() => {
+  if (!collection.value || !liveRecord.value) return null;
+  return deriveAll(collection.value.schema, liveRecord.value);
+});
+
+function derivedDisplay(field: FieldSpec, computedValue: unknown): string {
+  if (computedValue === null || computedValue === undefined) return "—";
+  if (field.display === "money") {
+    return formatMoney(computedValue, field.currency, locale.value);
+  }
+  return formatCell(computedValue, field.display ?? "number");
+}
+
+/** Evaluate a derived field against a persisted item (for the
+ *  main collection table). The form uses `liveDerived` instead so
+ *  it can reflect uncommitted draft edits. */
+function evaluateDerivedAgainstItem(field: FieldSpec, fieldKey: string, item: CollectionItem): number | null {
+  if (!field.formula || !collection.value) return null;
+  // Walk derived chain: subtotal → tax → total. Same 3-pass cap as
+  // `deriveAll`; if a field's value is already on disk (Claude
+  // wrote it), prefer the disk value over re-computing.
+  const enriched = deriveAll(collection.value.schema, item);
+  const result = enriched[fieldKey];
+  return typeof result === "number" && Number.isFinite(result) ? result : null;
+}
+
+/** Short summary for a `table`-typed cell in the main collection
+ *  table. Counts rows; nothing fancier yet (per-row preview is
+ *  hard to fit in a single cell). */
+function tableSummary(value: unknown): string {
+  if (!Array.isArray(value)) return "—";
+  if (value.length === 0) return "—";
+  return t("collectionsView.tableSummary", { count: value.length });
 }
 
 async function saveEditor(): Promise<void> {
@@ -509,23 +847,10 @@ async function saveEditor(): Promise<void> {
   const draft = editing.value;
   saveError.value = null;
 
-  // Client-side required-field check — server doesn't enforce. Skip
-  // the primary key in create mode: the server auto-generates an id
-  // when the field is blank, so blocking here would deny the
-  // documented "blank → server-generated id" flow even for schemas
-  // (like mc-clients) that mark the primary field `required: true`
-  // for the edit-form-displays-it-as-a-real-field reason.
-  for (const [key, field] of Object.entries(schema.fields)) {
-    if (!field.required) continue;
-    if (draft.mode === "create" && field.primary === true) continue;
-    // Booleans always have a value (`false` is a valid answer), so
-    // `required: true` on a boolean field is a no-op rather than a
-    // gate. Skip the empty check for them.
-    if (field.type === "boolean") continue;
-    if (!draft.text[key]) {
-      saveError.value = `${field.label}: ${t("collectionsView.requiredField")}`;
-      return;
-    }
+  const missing = firstMissingRequiredField(draft, schema);
+  if (missing) {
+    saveError.value = `${missing}: ${t("collectionsView.requiredField")}`;
+    return;
   }
 
   saving.value = true;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -759,6 +759,16 @@ function scalarDraftToValue(raw: string | undefined, fieldType: FieldType): unkn
   return raw;
 }
 
+/** True when a draft slot should count as "empty" for required-
+ *  field validation. NOT a truthiness check: Vue coerces
+ *  `<input type="number">` to a numeric `0`, and a required field
+ *  whose value is `0` (a quantity of 0, a rate of 0) is a filled
+ *  value, not a missing one. Only `undefined` / `null` / empty
+ *  string count as missing. (CodeRabbit PR #1497.) */
+function isMissingDraftValue(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
 /** Convert one row of a `table` field's draft to its persisted
  *  row record. Sub-fields are restricted to non-table / non-derived
  *  types by the SubFieldSpecSchema, so we only need to handle the
@@ -767,7 +777,14 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
   const row: Record<string, unknown> = {};
   for (const [subKey, subField] of Object.entries(subFields)) {
     if (subField.type === "boolean") {
-      row[subKey] = rowDraft.bool[subKey] === true;
+      // Mirror the top-level boolean omission rule (lighter-weight
+      // — no per-row touched tracking): emit only when `true` or
+      // when the sub-field is required. An absent optional boolean
+      // stays absent through a no-op edit, so consumers that
+      // distinguish absence from `false` aren't clobbered.
+      // (github-actions review PR #1497.)
+      const value = rowDraft.bool[subKey] === true;
+      if (value || subField.required) row[subKey] = value;
       continue;
     }
     const value = scalarDraftToValue(rowDraft.text[subKey], subField.type);
@@ -795,7 +812,7 @@ function firstMissingTableSubField(field: FieldSpec, rows: TableRowDraft[] | und
       // Boolean required is a no-op (same reasoning as the
       // top-level skip below).
       if (subField.type === "boolean") continue;
-      if (!row.text[subKey]) return `${field.label} #${rowIdx + 1}: ${subField.label}`;
+      if (isMissingDraftValue(row.text[subKey])) return `${field.label} #${rowIdx + 1}: ${subField.label}`;
     }
   }
   return null;
@@ -828,7 +845,7 @@ function validateOneField(key: string, field: FieldSpec, draft: EditState): stri
   if (!field.required) return null;
   if (draft.mode === "create" && field.primary === true) return null;
   if (field.type === "boolean" || field.type === "derived") return null;
-  return draft.text[key] ? null : field.label;
+  return isMissingDraftValue(draft.text[key]) ? field.label : null;
 }
 
 function firstMissingRequiredField(draft: EditState, schema: CollectionSchema): string | null {

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -63,9 +63,7 @@
                   >{{ refDisplay(field.to, String(item[key])) }}</router-link
                 >
               </span>
-              <span v-else-if="field.type === 'money'" class="block truncate tabular-nums">{{
-                formatMoney(item[key], resolveCurrency(field, item), locale)
-              }}</span>
+              <span v-else-if="field.type === 'money'" class="block truncate tabular-nums">{{ formatMoney(item[key], field.currency, locale) }}</span>
               <span v-else-if="field.type === 'table'" class="block text-gray-500">{{ tableSummary(item[key]) }}</span>
               <span v-else-if="field.type === 'derived'" class="block truncate tabular-nums">{{
                 derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item))
@@ -197,7 +195,7 @@
                            treatment as the top-level money input. -->
                       <div v-else-if="subField.type === 'money'" class="relative">
                         <span class="absolute inset-y-0 left-0 flex items-center pl-1 text-xs text-gray-500 pointer-events-none">{{
-                          currencySymbol(resolveCurrency(subField, rowDraftToRecord(row, field.of)))
+                          currencySymbol(subField.currency)
                         }}</span>
                         <input
                           v-model="row.text[subKey]"
@@ -254,7 +252,7 @@
                  into (the bare number input gave no visual hint). -->
             <div v-else-if="field.type === 'money'" class="relative">
               <span class="absolute inset-y-0 left-0 flex items-center pl-2 text-xs text-gray-500 pointer-events-none">{{
-                currencySymbol(resolveCurrency(field, liveRecord))
+                currencySymbol(field.currency)
               }}</span>
               <input
                 :id="`collections-field-${key}`"
@@ -332,14 +330,8 @@ interface FieldSpec {
    *  plans/done/feat-collections-ref-field.md). */
   to?: string;
   /** When type === "money": ISO 4217 currency for Intl display.
-   *  Default when `currencyField` is absent or resolves blank. */
+   *  Defaults to "USD" when omitted. */
   currency?: string;
-  /** When type === "money": name of a sibling field whose value
-   *  holds the currency code. Lets different records of the same
-   *  collection use different currencies (e.g. each client's
-   *  hourlyRate billed in their own currency). See
-   *  `resolveCurrency`. */
-  currencyField?: string;
   /** When type === "enum": closed list of allowed string values
    *  for the form `<select>`. */
   values?: readonly string[];
@@ -561,18 +553,6 @@ function inputTypeFor(type: FieldType): string {
   if (type === "money") return "number";
   if (type === "date") return "date";
   return "text";
-}
-
-/** Pick the currency code to use for a money field at render
- *  time. When the schema declares `currencyField`, look up that
- *  sibling on the current record (form draft or persisted item);
- *  fall back to the field's static `currency`, then to `USD`. */
-function resolveCurrency(field: FieldSpec, record: CollectionItem | null | undefined): string | undefined {
-  if (field.currencyField && record) {
-    const fromRecord = record[field.currencyField];
-    if (typeof fromRecord === "string" && fromRecord.length > 0) return fromRecord;
-  }
-  return field.currency;
 }
 
 /** Extract the localized currency symbol for a given ISO code

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -363,44 +363,15 @@ export const ROLES: Role[] = [
   // migration helper moves any pre-skill recipes from the plugin's
   // `files.data` scope to the new path.
 
-  // Account beta — PoC for the schema-driven collection architecture
-  // (see plans/done/feat-skill-driven-apps.md — historical name predates
-  // the apps→collections rename). The `mc-clients` and `mc-worklog`
-  // preset skills ship a `schema.json` alongside their `SKILL.md`;
-  // once starred, the host renders their records via <CollectionView>
-  // at /collections/<slug>. This role's job is to demonstrate that
-  // flow: Claude does file I/O via the Agent SDK's native
-  // Read/Write/Edit; no MCP plugins per domain. `presentForm` stays
-  // available as the sanctioned way to collect structured input
-  // when needed.
-  {
-    id: "account-beta",
-    name: "Account beta",
-    icon: "science",
-    prompt:
-      "You are a beta accounting assistant testing the schema-driven collection architecture.\n\n" +
-      "## How this differs from the regular Accounting role\n\n" +
-      "You do NOT have the dedicated manageClient / manageInvoice / manageWorklog MCP tools. Instead, the user has starred preset skills that define each domain via a `schema.json` file. The file layouts under `data/<collection>/items/` are the database; the host renders each at `/collections/<slug>`.\n\n" +
-      "Available skill-driven collections (read each skill's `SKILL.md` for the per-collection conventions — id format, where files live, when to ask vs. when to act):\n\n" +
-      "- **mc-clients** — `data/clients/items/<id>.json`, viewed at `/collections/mc-clients`. Tracks client records (name, email, address, notes).\n" +
-      "- **mc-worklog** — `data/worklog/items/<id>.json`, viewed at `/collections/mc-worklog`. Tracks billable / non-billable hours per client per day. `clientId` references slugs in `data/clients/items/`; resolve client names to slugs by reading that directory first (no `ref` field-type validation yet — that's your responsibility).\n\n" +
-      "Use Read / Write / Edit directly for CRUD — these are always available via the Agent SDK; no MCP plugin needed.\n\n" +
-      "## Hard rules\n\n" +
-      "- Always derive a kebab-case `id` per each skill's documented format (mc-clients: from name; mc-worklog: `{date}-{clientId}-{4hex}`). Read the directory first; never silently overwrite an existing file.\n" +
-      "- Don't recite the full record list in chat after a mutation. A one-line confirmation is enough — the user can see the table at the collection's `/collections/<slug>` route.\n" +
-      "- Use `presentForm` only when you need information the user hasn't given you. Don't use it to re-confirm values they already typed.\n" +
-      "- When logging worklog hours for a client name, resolve the name to a real `clientId` slug by reading `data/clients/items/` first. Never invent a clientId that doesn't exist there — that breaks the worklog table.\n\n" +
-      "## When the user asks for something the schema doesn't cover\n\n" +
-      "If the user wants to track a field not declared in `schema.json` (e.g. a phone number on a client, start/end times on a worklog entry), tell them the field isn't part of the current schema and offer two paths: (a) put it in the `notes` markdown field, or (b) extend the schema (which requires the launcher's owner to update the bundled preset). Don't silently add an unknown key to the record.",
-    availablePlugins: [TOOL_NAMES.presentForm],
-    queries: [
-      "Add a client: Acme Corp, billing@acme.example, San Francisco",
-      "List my clients",
-      "Log 2 hours for Acme today on the migration work",
-      "How many hours did I bill Acme this week?",
-      "Log 30 minutes of non-billable internal review for Globex yesterday",
-    ],
-  },
+  // Schema-driven `mc-*` collection skills (mc-clients, mc-worklog,
+  // mc-invoice) are NOT gated by a special role. Once starred via
+  // `/skills`, Claude Code's skill discovery surfaces them in every
+  // role's system prompt and each SKILL.md is self-contained
+  // (conventions, "don't write derived fields", file paths). In
+  // roles that ALSO have the legacy manageInvoice / manageClient /
+  // manageWorklog MCP tools (Accounting), Claude may still pick the
+  // dedicated tool over the skill; that's expected during the
+  // transition period while both paths coexist.
   {
     id: "debug",
     name: "Debug",
@@ -479,7 +450,6 @@ export const BUILTIN_ROLE_IDS = {
   // single-skill `mc-settings` originally introduced in #1283 was
   // split into three in #1295 for stronger discovery).
   accounting: "accounting",
-  "account-beta": "account-beta",
   investor: "investor",
   // cookingCoach: removed (#1286) — replaced by `mc-cooking-coach` preset skill.
   debug: "debug",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1342,7 +1342,11 @@ const deMessages = {
     notFound: "Sammlung nicht gefunden",
     loadFailed: "Laden fehlgeschlagen",
     requiredField: "Dieses Feld ist erforderlich",
-    refPlaceholder: "Auswählen…",
+    selectPlaceholder: "Auswählen…",
+    addRow: "Zeile hinzufügen",
+    removeRow: "Zeile entfernen",
+    noRows: "Noch keine Zeilen",
+    tableSummary: "{count} Einträge",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1324,7 +1324,11 @@ const enMessages = {
     notFound: "Collection not found",
     loadFailed: "Failed to load",
     requiredField: "This field is required",
-    refPlaceholder: "Select…",
+    selectPlaceholder: "Select…",
+    addRow: "Add row",
+    removeRow: "Remove row",
+    noRows: "No rows yet",
+    tableSummary: "{count} items",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1337,7 +1337,11 @@ const esMessages = {
     notFound: "Colección no encontrada",
     loadFailed: "Error al cargar",
     requiredField: "Este campo es obligatorio",
-    refPlaceholder: "Seleccionar…",
+    selectPlaceholder: "Seleccionar…",
+    addRow: "Añadir fila",
+    removeRow: "Quitar fila",
+    noRows: "Aún no hay filas",
+    tableSummary: "{count} elementos",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1331,7 +1331,11 @@ const frMessages = {
     notFound: "Collection introuvable",
     loadFailed: "Échec du chargement",
     requiredField: "Ce champ est obligatoire",
-    refPlaceholder: "Sélectionner…",
+    selectPlaceholder: "Sélectionner…",
+    addRow: "Ajouter une ligne",
+    removeRow: "Supprimer la ligne",
+    noRows: "Aucune ligne pour l'instant",
+    tableSummary: "{count} éléments",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1321,7 +1321,11 @@ const jaMessages = {
     notFound: "コレクションが見つかりません",
     loadFailed: "読み込みに失敗しました",
     requiredField: "この項目は必須です",
-    refPlaceholder: "選択…",
+    selectPlaceholder: "選択…",
+    addRow: "行を追加",
+    removeRow: "行を削除",
+    noRows: "行がありません",
+    tableSummary: "{count}件",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1324,7 +1324,11 @@ const koMessages = {
     notFound: "컬렉션을 찾을 수 없습니다",
     loadFailed: "불러오기에 실패했습니다",
     requiredField: "이 필드는 필수입니다",
-    refPlaceholder: "선택…",
+    selectPlaceholder: "선택…",
+    addRow: "행 추가",
+    removeRow: "행 삭제",
+    noRows: "행이 없습니다",
+    tableSummary: "{count}개",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1326,7 +1326,11 @@ const ptBRMessages = {
     notFound: "Coleção não encontrada",
     loadFailed: "Falha ao carregar",
     requiredField: "Este campo é obrigatório",
-    refPlaceholder: "Selecionar…",
+    selectPlaceholder: "Selecionar…",
+    addRow: "Adicionar linha",
+    removeRow: "Remover linha",
+    noRows: "Ainda não há linhas",
+    tableSummary: "{count} itens",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1314,7 +1314,11 @@ const zhMessages = {
     notFound: "未找到集合",
     loadFailed: "加载失败",
     requiredField: "此字段为必填项",
-    refPlaceholder: "请选择…",
+    selectPlaceholder: "请选择…",
+    addRow: "添加行",
+    removeRow: "删除行",
+    noRows: "暂无行",
+    tableSummary: "{count} 项",
     source: {
       user: "用户",
       project: "项目",

--- a/src/utils/collections/derivedFormula.ts
+++ b/src/utils/collections/derivedFormula.ts
@@ -1,0 +1,329 @@
+// Tiny expression evaluator for the `derived` field type on
+// schema-driven collections (see plans/feat-mc-invoice.md).
+//
+// Grammar (recursive-descent, no precedence climbing — five
+// non-terminals total):
+//
+//   expr   := term (('+' | '-') term)*
+//   term   := factor (('*' | '/') factor)*
+//   factor := number | sumCall | identifier | '(' expr ')'
+//   sumCall:= 'sum' '(' sumArg ')'
+//   sumArg := tableCol (('*' | '/') tableCol)*      // e.g. lineItems[].quantity * lineItems[].rate
+//   tableCol := identifier '[]' '.' identifier
+//
+// `identifier` accepts top-level field names (single segment).
+// Inside `sumArg`, identifiers are the `<table>[].col` form.
+//
+// What's deliberately NOT supported (and would parse-error rather
+// than silently misbehave):
+//   - String literals, boolean operators, comparisons, conditionals
+//   - Nested function calls beyond `sum(...)`
+//   - Anything in the record that isn't a number / table-of-objects
+//
+// All evaluation is pure — no eval(), no Function constructor.
+// Returns `null` on any failure (parse error, unbound identifier,
+// non-finite arithmetic). The caller renders `null` as em-dash in
+// the table cell + form display.
+
+export interface FormulaContext {
+  /** The record being evaluated. For derived fields in the form,
+   *  this is the live draft (text + table both converted via the
+   *  same `draftToRecord` pipeline). For the main table cell,
+   *  this is the persisted item. */
+  record: Record<string, unknown>;
+}
+
+export function evaluateDerived(formula: string, ctx: FormulaContext): number | null {
+  let tokens: Token[];
+  try {
+    tokens = tokenize(formula);
+  } catch {
+    return null;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- Parser class is defined later in the file (grouped with its AST + evaluator); evaluateDerived runs after module init so the TDZ concern doesn't apply.
+  const parser = new Parser(tokens);
+  let ast: Node;
+  try {
+    ast = parser.parseExpr();
+    if (!parser.atEnd()) return null; // trailing junk
+  } catch {
+    return null;
+  }
+  const value = evaluate(ast, ctx);
+  return Number.isFinite(value) ? value : null;
+}
+
+// ─── Tokens ────────────────────────────────────────────────
+
+type TokenKind = "number" | "ident" | "(" | ")" | "+" | "-" | "*" | "/" | "[]" | ".";
+
+interface Token {
+  kind: TokenKind;
+  value?: string | number;
+}
+
+const SINGLE_CHAR_PUNCT = new Set<TokenKind>(["(", ")", "+", "-", "*", "/", "."]);
+
+interface Cursor {
+  input: string;
+  index: number;
+}
+
+function consumeWhitespace(cur: Cursor): boolean {
+  const char = cur.input[cur.index];
+  if (char === " " || char === "\t" || char === "\n") {
+    cur.index++;
+    return true;
+  }
+  return false;
+}
+
+function consumeNumber(cur: Cursor): Token | null {
+  const char = cur.input[cur.index] ?? "";
+  const next = cur.input[cur.index + 1] ?? "";
+  if (!isDigit(char) && !(char === "." && isDigit(next))) return null;
+  let raw = "";
+  while (cur.index < cur.input.length) {
+    const here = cur.input[cur.index] ?? "";
+    if (!isDigit(here) && here !== ".") break;
+    raw += here;
+    cur.index++;
+  }
+  const num = Number(raw);
+  if (!Number.isFinite(num)) throw new Error("bad number");
+  return { kind: "number", value: num };
+}
+
+function consumeIdent(cur: Cursor): Token | null {
+  const char = cur.input[cur.index] ?? "";
+  if (!isIdentStart(char)) return null;
+  let raw = "";
+  while (cur.index < cur.input.length && isIdentChar(cur.input[cur.index] ?? "")) {
+    raw += cur.input[cur.index];
+    cur.index++;
+  }
+  return { kind: "ident", value: raw };
+}
+
+function consumePunct(cur: Cursor): Token | null {
+  const char = cur.input[cur.index] ?? "";
+  if (char === "[" && cur.input[cur.index + 1] === "]") {
+    cur.index += 2;
+    return { kind: "[]" };
+  }
+  if (SINGLE_CHAR_PUNCT.has(char as TokenKind)) {
+    cur.index++;
+    return { kind: char as TokenKind };
+  }
+  return null;
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  const cur: Cursor = { input, index: 0 };
+  while (cur.index < input.length) {
+    if (consumeWhitespace(cur)) continue;
+    // Number FIRST so a leading-dot literal (`.25`) isn't split by
+    // the `.` punctuation branch.
+    const numTok = consumeNumber(cur);
+    if (numTok) {
+      tokens.push(numTok);
+      continue;
+    }
+    const punctTok = consumePunct(cur);
+    if (punctTok) {
+      tokens.push(punctTok);
+      continue;
+    }
+    const identTok = consumeIdent(cur);
+    if (identTok) {
+      tokens.push(identTok);
+      continue;
+    }
+    throw new Error(`unexpected char ${input[cur.index]}`);
+  }
+  return tokens;
+}
+
+function isDigit(char: string): boolean {
+  return char >= "0" && char <= "9";
+}
+function isIdentStart(char: string): boolean {
+  return (char >= "a" && char <= "z") || (char >= "A" && char <= "Z") || char === "_";
+}
+function isIdentChar(char: string): boolean {
+  return isIdentStart(char) || isDigit(char);
+}
+
+// ─── AST + Parser ───────────────────────────────────────────
+
+type Node =
+  | { kind: "num"; value: number }
+  | { kind: "ident"; name: string }
+  | { kind: "binop"; operator: "+" | "-" | "*" | "/"; left: Node; right: Node }
+  | { kind: "sum"; arg: SumArg };
+
+interface SumArg {
+  // factors multiplied/divided together; each is a (tableName, colName) ref into a row.
+  factors: { table: string; col: string }[];
+  /** Operators between factors: length = factors.length - 1; each
+   *  is "*" or "/". For a single-factor sum (`sum(lineItems[].amount)`)
+   *  this is empty. */
+  operators: ("*" | "/")[];
+}
+
+class Parser {
+  private cursor = 0;
+  constructor(private readonly tokens: Token[]) {}
+
+  atEnd(): boolean {
+    return this.cursor >= this.tokens.length;
+  }
+  private peek(): Token | undefined {
+    return this.tokens[this.cursor];
+  }
+  private consume(): Token {
+    const tok = this.tokens[this.cursor++];
+    if (!tok) throw new Error("unexpected end of input");
+    return tok;
+  }
+  private expect(kind: TokenKind): Token {
+    const tok = this.consume();
+    if (tok.kind !== kind) throw new Error(`expected ${kind}, got ${tok.kind}`);
+    return tok;
+  }
+
+  parseExpr(): Node {
+    let left = this.parseTerm();
+    while (this.peek()?.kind === "+" || this.peek()?.kind === "-") {
+      const operator = this.consume().kind as "+" | "-";
+      const right = this.parseTerm();
+      left = { kind: "binop", operator, left, right };
+    }
+    return left;
+  }
+
+  private parseTerm(): Node {
+    let left = this.parseFactor();
+    while (this.peek()?.kind === "*" || this.peek()?.kind === "/") {
+      const operator = this.consume().kind as "*" | "/";
+      const right = this.parseFactor();
+      left = { kind: "binop", operator, left, right };
+    }
+    return left;
+  }
+
+  private parseFactor(): Node {
+    const tok = this.peek();
+    if (!tok) throw new Error("unexpected end in factor");
+    if (tok.kind === "number") {
+      this.consume();
+      return { kind: "num", value: tok.value as number };
+    }
+    if (tok.kind === "(") {
+      this.consume();
+      const inner = this.parseExpr();
+      this.expect(")");
+      return inner;
+    }
+    if (tok.kind === "ident") {
+      const name = (tok.value as string) ?? "";
+      // sum(...) — only function call we support
+      if (name === "sum" && this.tokens[this.cursor + 1]?.kind === "(") {
+        this.consume(); // ident
+        this.expect("(");
+        const arg = this.parseSumArg();
+        this.expect(")");
+        return { kind: "sum", arg };
+      }
+      this.consume();
+      return { kind: "ident", name };
+    }
+    throw new Error(`unexpected token ${tok.kind} in factor`);
+  }
+
+  private parseSumArg(): SumArg {
+    const factors: { table: string; col: string }[] = [];
+    const operators: ("*" | "/")[] = [];
+    factors.push(this.parseTableCol());
+    while (this.peek()?.kind === "*" || this.peek()?.kind === "/") {
+      const operator = this.consume().kind as "*" | "/";
+      operators.push(operator);
+      factors.push(this.parseTableCol());
+    }
+    return { factors, operators };
+  }
+
+  private parseTableCol(): { table: string; col: string } {
+    const tableTok = this.expect("ident");
+    this.expect("[]");
+    this.expect(".");
+    const colTok = this.expect("ident");
+    return { table: tableTok.value as string, col: colTok.value as string };
+  }
+}
+
+// ─── Evaluator ──────────────────────────────────────────────
+
+function evaluate(node: Node, ctx: FormulaContext): number {
+  if (node.kind === "num") return node.value;
+  if (node.kind === "ident") {
+    const raw = ctx.record[node.name];
+    return toFiniteNumber(raw);
+  }
+  if (node.kind === "binop") {
+    const left = evaluate(node.left, ctx);
+    const right = evaluate(node.right, ctx);
+    return applyBinop(node.operator, left, right);
+  }
+  if (node.kind === "sum") {
+    return evaluateSum(node.arg, ctx);
+  }
+  // Exhaustive — TS narrows above branches but throw keeps runtime honest.
+  throw new Error(`unknown node`);
+}
+
+function applyBinop(operator: "+" | "-" | "*" | "/", left: number, right: number): number {
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return Number.NaN;
+  if (operator === "+") return left + right;
+  if (operator === "-") return left - right;
+  if (operator === "*") return left * right;
+  // operator === "/"
+  if (right === 0) return Number.NaN;
+  return left / right;
+}
+
+function evaluateSum(arg: SumArg, ctx: FormulaContext): number {
+  if (arg.factors.length === 0) return 0;
+  const tableName = arg.factors[0].table;
+  // All factors must reference the SAME table (you can't multiply
+  // a row from lineItems against a row from another table — the
+  // semantics would be ambiguous). Reject mismatch.
+  for (const factor of arg.factors) {
+    if (factor.table !== tableName) return Number.NaN;
+  }
+  const rows = ctx.record[tableName];
+  if (!Array.isArray(rows)) return 0;
+  let total = 0;
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    let product = toFiniteNumber((row as Record<string, unknown>)[arg.factors[0].col]);
+    if (!Number.isFinite(product)) return Number.NaN;
+    for (let i = 1; i < arg.factors.length; i++) {
+      const value = toFiniteNumber((row as Record<string, unknown>)[arg.factors[i].col]);
+      if (!Number.isFinite(value)) return Number.NaN;
+      product = applyBinop(arg.operators[i - 1], product, value);
+    }
+    total += product;
+  }
+  return total;
+}
+
+function toFiniteNumber(value: unknown): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : Number.NaN;
+  if (typeof value === "string" && value.length > 0) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : Number.NaN;
+  }
+  return Number.NaN;
+}

--- a/test/utils/collections/test_derivedFormula.ts
+++ b/test/utils/collections/test_derivedFormula.ts
@@ -1,0 +1,130 @@
+// Unit tests for the tiny derived-formula evaluator
+// (src/utils/collections/derivedFormula.ts). The evaluator is a
+// pure module specifically so the parser/eval quirks are pinned
+// here, independently from any Vue rendering layer.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { evaluateDerived } from "../../../src/utils/collections/derivedFormula.js";
+
+describe("evaluateDerived — literals + arithmetic", () => {
+  it("returns a bare number literal", () => {
+    assert.equal(evaluateDerived("42", { record: {} }), 42);
+    assert.equal(evaluateDerived("0", { record: {} }), 0);
+    assert.equal(evaluateDerived("1.5", { record: {} }), 1.5);
+    assert.equal(evaluateDerived(".25", { record: {} }), 0.25);
+  });
+
+  it("respects standard arithmetic precedence", () => {
+    assert.equal(evaluateDerived("1 + 2 * 3", { record: {} }), 7);
+    assert.equal(evaluateDerived("(1 + 2) * 3", { record: {} }), 9);
+    assert.equal(evaluateDerived("10 - 4 - 2", { record: {} }), 4); // left-associative
+    assert.equal(evaluateDerived("100 / 4 / 5", { record: {} }), 5);
+    assert.equal(evaluateDerived("2 + 3 * 4 - 1", { record: {} }), 13);
+  });
+
+  it("handles parens nested deeply", () => {
+    assert.equal(evaluateDerived("((1 + 2) * (3 + 4))", { record: {} }), 21);
+  });
+});
+
+describe("evaluateDerived — identifiers", () => {
+  it("resolves a top-level field by name", () => {
+    assert.equal(evaluateDerived("subtotal", { record: { subtotal: 100 } }), 100);
+    assert.equal(evaluateDerived("subtotal + tax", { record: { subtotal: 100, tax: 10 } }), 110);
+  });
+
+  it("coerces numeric strings to numbers", () => {
+    assert.equal(evaluateDerived("rate", { record: { rate: "12.5" } }), 12.5);
+  });
+
+  it("returns null when a referenced field is missing", () => {
+    assert.equal(evaluateDerived("subtotal", { record: {} }), null);
+  });
+
+  it("returns null when a referenced field is non-numeric", () => {
+    assert.equal(evaluateDerived("subtotal", { record: { subtotal: "abc" } }), null);
+    assert.equal(evaluateDerived("subtotal", { record: { subtotal: true } }), null);
+  });
+});
+
+describe("evaluateDerived — sum()", () => {
+  const lineItems = [
+    { quantity: 10, rate: 100 },
+    { quantity: 2, rate: 250 },
+    { quantity: 5, rate: 50 },
+  ];
+
+  it("sums a single column", () => {
+    const record = { lineItems: [{ amount: 100 }, { amount: 250 }, { amount: 50 }] };
+    assert.equal(evaluateDerived("sum(lineItems[].amount)", { record }), 400);
+  });
+
+  it("sums the product of two columns", () => {
+    // 10*100 + 2*250 + 5*50 = 1000 + 500 + 250 = 1750
+    assert.equal(evaluateDerived("sum(lineItems[].quantity * lineItems[].rate)", { record: { lineItems } }), 1750);
+  });
+
+  it("returns 0 when the table is missing or empty", () => {
+    assert.equal(evaluateDerived("sum(lineItems[].amount)", { record: {} }), 0);
+    assert.equal(evaluateDerived("sum(lineItems[].amount)", { record: { lineItems: [] } }), 0);
+  });
+
+  it("integrates with surrounding arithmetic (subtotal-tax-total pattern)", () => {
+    const record = { lineItems, taxRate: 0.1 };
+    // subtotal = 1750
+    assert.equal(evaluateDerived("sum(lineItems[].quantity * lineItems[].rate)", { record }), 1750);
+    // tax = subtotal * taxRate, computed against the post-subtotal context
+    assert.equal(evaluateDerived("subtotal * taxRate", { record: { subtotal: 1750, taxRate: 0.1 } }), 175);
+    // total = subtotal + tax
+    assert.equal(evaluateDerived("subtotal + tax", { record: { subtotal: 1750, tax: 175 } }), 1925);
+  });
+
+  it("returns null when a column value is non-numeric inside sum", () => {
+    const record = { lineItems: [{ quantity: 10, rate: "bad" }] };
+    assert.equal(evaluateDerived("sum(lineItems[].quantity * lineItems[].rate)", { record }), null);
+  });
+
+  it("rejects mismatched tables inside one sum (would be ambiguous)", () => {
+    const record = { foo: [{ x: 1 }], bar: [{ y: 1 }] };
+    assert.equal(evaluateDerived("sum(foo[].x * bar[].y)", { record }), null);
+  });
+});
+
+describe("evaluateDerived — error handling", () => {
+  it("returns null on parse error (unexpected char)", () => {
+    assert.equal(evaluateDerived("1 + @ + 2", { record: {} }), null);
+  });
+
+  it("returns null on parse error (trailing junk)", () => {
+    assert.equal(evaluateDerived("1 + 2 garbage", { record: {} }), null);
+  });
+
+  it("returns null on parse error (mismatched parens)", () => {
+    assert.equal(evaluateDerived("(1 + 2", { record: {} }), null);
+    assert.equal(evaluateDerived("1 + 2)", { record: {} }), null);
+  });
+
+  it("returns null on divide by zero", () => {
+    assert.equal(evaluateDerived("10 / 0", { record: {} }), null);
+  });
+
+  it("returns null on division by missing field", () => {
+    assert.equal(evaluateDerived("10 / divisor", { record: { divisor: 0 } }), null);
+  });
+
+  it("returns null when sum() argument shape is wrong", () => {
+    assert.equal(evaluateDerived("sum(lineItems)", { record: { lineItems: [] } }), null);
+    assert.equal(evaluateDerived("sum()", { record: {} }), null);
+  });
+
+  it("rejects unsupported function calls", () => {
+    assert.equal(evaluateDerived("avg(lineItems[].amount)", { record: {} }), null);
+  });
+
+  it("rejects string concatenation / boolean operators / comparisons", () => {
+    assert.equal(evaluateDerived("1 == 1", { record: {} }), null);
+    assert.equal(evaluateDerived("a && b", { record: { a: 1, b: 2 } }), null);
+  });
+});

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -167,6 +167,201 @@ describe("discoverCollections — field-type support", () => {
     const collections = await listCollections();
     assert.equal(collections.length, 0);
   });
+
+  // ─── money / enum / table / derived (feat-mc-invoice PR) ───
+
+  it("accepts a schema using `money` with and without an explicit currency", async () => {
+    writeSkill("test-money", {
+      title: "Money",
+      icon: "payments",
+      dataPath: "data/money/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        rateUsd: { type: "money", currency: "USD", label: "Rate USD" },
+        rateDefault: { type: "money", label: "Rate default" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.fields.rateUsd?.currency, "USD");
+    assert.equal(collections[0]?.schema.fields.rateDefault?.currency, undefined);
+  });
+
+  it("rejects `money` with an empty `currency` string", async () => {
+    writeSkill("test-money-bad", {
+      title: "Money",
+      icon: "payments",
+      dataPath: "data/moneybad/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        rate: { type: "money", currency: "", label: "Rate" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("accepts `enum` with a non-empty values array", async () => {
+    writeSkill("test-enum", {
+      title: "Enum",
+      icon: "list",
+      dataPath: "data/enum/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        status: { type: "enum", values: ["draft", "sent", "paid", "void"], label: "Status", required: true },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.deepEqual(collections[0]?.schema.fields.status?.values, ["draft", "sent", "paid", "void"]);
+  });
+
+  it("rejects `enum` with no values", async () => {
+    writeSkill("test-enum-empty", {
+      title: "Enum",
+      icon: "warning",
+      dataPath: "data/enumempty/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        status: { type: "enum", label: "Status" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("rejects `enum` with an empty values array", async () => {
+    writeSkill("test-enum-empty-arr", {
+      title: "Enum",
+      icon: "warning",
+      dataPath: "data/enumarr/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        status: { type: "enum", values: [], label: "Status" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("accepts `table` with a non-empty `of` sub-schema", async () => {
+    writeSkill("test-table", {
+      title: "Invoice-like",
+      icon: "receipt",
+      dataPath: "data/table/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        lineItems: {
+          type: "table",
+          label: "Line items",
+          of: {
+            description: { type: "string", label: "Description", required: true },
+            quantity: { type: "number", label: "Qty", required: true },
+            rate: { type: "money", currency: "USD", label: "Rate", required: true },
+          },
+        },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.fields.lineItems?.type, "table");
+    assert.equal(collections[0]?.schema.fields.lineItems?.of?.quantity?.type, "number");
+  });
+
+  it("rejects `table` with no `of`", async () => {
+    writeSkill("test-table-no-of", {
+      title: "Bad Table",
+      icon: "warning",
+      dataPath: "data/tabnoof/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        rows: { type: "table", label: "Rows" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("rejects nested tables (v0 disallows table inside a table)", async () => {
+    writeSkill("test-table-nested", {
+      title: "Nested Table",
+      icon: "warning",
+      dataPath: "data/tabnested/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        outer: {
+          type: "table",
+          label: "Outer",
+          of: {
+            inner: { type: "table", label: "Inner", of: { x: { type: "string", label: "X" } } },
+          },
+        },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0, "nested table must be rejected at the sub-schema level");
+  });
+
+  it("rejects `derived` columns inside a table (v0 disallows)", async () => {
+    writeSkill("test-table-derived-col", {
+      title: "Derived in Table",
+      icon: "warning",
+      dataPath: "data/tabderivedcol/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        rows: {
+          type: "table",
+          label: "Rows",
+          of: {
+            amount: { type: "derived", label: "Amount", formula: "1" },
+          },
+        },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+
+  it("accepts `derived` with a non-empty formula", async () => {
+    writeSkill("test-derived", {
+      title: "Derived",
+      icon: "calculate",
+      dataPath: "data/derived/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        subtotal: { type: "derived", label: "Subtotal", formula: "sum(lineItems[].quantity * lineItems[].rate)", display: "money", currency: "USD" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.fields.subtotal?.formula, "sum(lineItems[].quantity * lineItems[].rate)");
+    assert.equal(collections[0]?.schema.fields.subtotal?.display, "money");
+  });
+
+  it("rejects `derived` with no formula", async () => {
+    writeSkill("test-derived-no-formula", {
+      title: "Bad Derived",
+      icon: "warning",
+      dataPath: "data/derivednoform/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        total: { type: "derived", label: "Total" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
 });
 
 describe("discoverCollections — structural validation", () => {


### PR DESCRIPTION
## Summary

End of the invoice-migration arc that started with [#1483](../pull/1483) (schema-driven apps PoC) and continued with [#1495](../pull/1495) (\`ref\`). **One bundled PR** because none of the new field types are testable in isolation — \`money\`/\`enum\`/\`table\`/\`derived\` only make sense inside a record-shape that uses them, and the closed PR-B/C/D split hit a "can't actually test it" wall the moment PR-B opened. See [plans/feat-mc-invoice.md](../blob/feat-mc-invoice/plans/feat-mc-invoice.md).

## What ships

### Four new field types

| Type      | Form input                                       | Table cell                                    |
|---|---|---|
| \`money\`   | \`<input type=\"number\" step=\"0.01\">\`            | \`Intl.NumberFormat\` ($1,234.56, ¥1,500)       |
| \`enum\`    | \`<select>\` from \`values: string[]\`               | raw value (per-value badge styling deferred)  |
| \`table\`   | nested inline editor + add-row / remove-row      | \"N items\" summary                             |
| \`derived\` | read-only, live-updated from current draft       | computed against the loaded item              |

Storage:
- \`money\` values are decimals (numbers); the schema's \`currency\` is presentation only.
- \`enum\` values are strings.
- \`table\` values are arrays of plain records; sub-fields are restricted to non-composite types (no nested table, no derived columns) — enforced by \`SubFieldSpecSchema\` at discovery.
- \`derived\` values are **never persisted** — recomputed every render from the live draft (form) or the loaded item (table cell).

### Derived formula language

\`src/utils/collections/derivedFormula.ts\` — recursive-descent parser + evaluator, deliberately tiny:

- number literals (\`0\`, \`1.5\`, \`.25\`)
- identifier refs (\`subtotal\`, \`taxRate\`)
- \`+ - * /\` with normal precedence + parens
- \`sum(table[].col)\` and \`sum(table[].colA * table[].colB)\`

Anything else (string concat, conditionals, function calls beyond \`sum\`) parse-errors → returns \`null\`. No \`eval()\`, no \`Function\`. Caller renders \`null\` as em-dash.

### mc-invoice skill

\`server/workspace/skills-preset/mc-invoice/\`:

- \`SKILL.md\` — teaches Claude id format (\`INV-YYYY-NNNN\`), client-name → slug resolution, line items, status defaulting, and the hard rule \"never write \`subtotal\` / \`tax\` / \`total\` — those are computed\"
- \`schema.json\` — all the above field types in concert: \`ref clientId\`, date \`issueDate\`/\`dueDate\`, \`enum status\` (\`draft\`/\`sent\`/\`paid\`/\`void\`), \`table lineItems\` (\`description\`/\`quantity\`/\`rate\`), \`derived\` \`subtotal\` / \`tax\` / \`total\`

## i18n

Renamed \`collectionsView.refPlaceholder\` → \`selectPlaceholder\` (shared by ref + enum) across all 8 locales. New keys for table-editor chrome: \`addRow\`, \`removeRow\`, \`noRows\`, \`tableSummary\`.

## Out of scope (explicit defer)

- \`actions\` field type (\"Mark Sent\" / \"Mark Paid\" / \"Export PDF\" as one-click buttons). User changes status via the enum dropdown in v0. Follow-up.
- PDF template rendering. Follow-up.
- Per-value enum badge styling. Cosmetic; defer.
- Server-side ref / enum / formula validation. Client UI constrains; Claude could write anything. Acceptable for personal workspace.
- Nested tables / derived columns inside tables — both rejected at the \`SubFieldSpecSchema\` level at discovery time.

## Test plan

- [x] **5141 unit tests pass** (+27):
  - \`test_derivedFormula.ts\`: 21 tests — literals, arithmetic precedence, identifiers, \`sum()\`, error handling, unsupported syntax
  - \`test_discovery.ts\`: +11 — each new type's accept-with-shape + reject-without-required-field, plus nested-table / derived-column-in-table rejection
- [x] **437 e2e tests pass**
- [x] \`yarn format / lint / typecheck / build\` all green

Manual checks once shipped + \`mc-invoice\` re-starred:

- [ ] \`/collections/mc-invoice\` → \`+\`: form shows ref dropdown for Client, enum dropdown for Status, inline table editor for Line items, and read-only Subtotal/Tax/Total cells
- [ ] Adding line items live-updates the Subtotal/Tax/Total displays as you type
- [ ] Save → row appears in the table; lineItems column shows \"N items\", derived columns show formatted money values
- [ ] Edit existing invoice → all field states round-trip (enum pre-selected, table rows pre-filled, ref pre-selected)
- [ ] Flip status to \"paid\" → save → status updates in the table
- [ ] Create a second invoice for a different client → derived calcs are per-record

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice collection with line items, client links, dates and status
  * Table field with inline row add/remove and per-row editing
  * Derived fields with live formula-based subtotal/tax/total computation
  * Money and enum field types with localized currency formatting
  * UI strings added for table operations across languages

* **Documentation**
  * Added invoice skill documentation and JSON schema

* **Tests**
  * Added formula evaluator and field-type discovery tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->