### PR TITLE
chore: bump actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/e2e_live_no_llm.yaml
+++ b/.github/workflows/e2e_live_no_llm.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ matrix.spec }}
           path: playwright-report-live/${{ matrix.spec }}/
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload dev server log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dev-server-log-${{ matrix.spec }}
           path: dev-server.log

--- a/.github/workflows/mulmoclaude_smoke.yaml
+++ b/.github/workflows/mulmoclaude_smoke.yaml
@@ -135,7 +135,7 @@ jobs:
       # lets you retry the install locally.
       - name: Upload smoke-verified tarball
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mulmoclaude-tarball
           path: packages/mulmoclaude/mulmoclaude-*.tgz
@@ -151,7 +151,7 @@ jobs:
       # keeps green runs quiet (the log exists but nobody needs it).
       - name: Upload launcher log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mulmoclaude-launcher-log
           # mktemp-generated path — match by glob because the suffix

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -234,7 +234,7 @@ jobs:
       run: yarn test:e2e --shard=${{ matrix.shard }}/2
     - name: Upload test results on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: playwright-results-shard-${{ matrix.shard }}
         path: test-results/


### PR DESCRIPTION
## Summary
Bumps `actions/upload-artifact` from `@v4` to `@v7` (current latest) in `.github/workflows/pull_request.yaml`.

## Items to Confirm / Review
- Mechanical version bump only. CI run on this PR validates the artifact upload step still works under v7.

## User Prompt
`actions/upload-artifact@v4` を最新（v7）にバージョンアップ。`~/ss/llm` 配下の重複しない自リポ + GUIChatPlugins 配下を対象に、main を最新化してから新ブランチで実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD infrastructure for improved artifact handling and reliability across automated testing and deployment workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->