### PR TITLE
feat(collections): read-only "open" mode + ?highlight= deep-link handler

### DIFF
--- a/plans/feat-collections-open-mode.md
+++ b/plans/feat-collections-open-mode.md
@@ -1,0 +1,67 @@
+# feat: collections "open" (read-only detail) mode + `?highlight=` handler
+
+## Motivation
+
+Record links emitted by skills (e.g. mc-invoice's "Linking to an invoice in
+chat" section) point at `/collections/<slug>?highlight=<id>`. The query param
+was being produced but not consumed — landing on the collection just showed the
+list. This adds the back half: `?highlight=<id>` **opens** the referenced
+record in a read-only detail view, distinct from the existing edit form.
+
+## What shipped
+
+Two files — no schema, server, or i18n changes.
+
+### Link classifier: preserve the query string (`workspaceLinkRouter.ts`)
+
+The first cut of open mode looked correct but the `?highlight=` never
+arrived: `classifyWorkspacePath` (which routes agent-markdown links into SPA
+navigation) called `stripFragmentAndQuery` for **all** targets, so
+`/collections/mc-invoice?highlight=INV-2026-0001` became a bare
+`/collections/mc-invoice`. Fix: a new `extractQuery` helper re-attaches the
+query to `spa-route` targets only (`router.push(string)` parses it into
+`route.query`). Wiki / file / session targets still strip — they route by
+their own identifiers and take no query. Fragments stay dropped.
+
+### CollectionView.vue
+
+### Open mode (read-only detail modal)
+
+- New `viewing = ref<CollectionItem | null>`, mutually exclusive with `editing`.
+- A detail modal renders every field formatted for display (no inputs):
+  - `boolean` → check icon / em-dash
+  - `ref` → `<router-link>` to the target collection (`?highlight=` chained, so
+    you can hop record→record)
+  - `money` → `formatMoney`
+  - `derived` → `derivedDisplay` (evaluated against the item)
+  - `table` → read-only sub-table of all rows/columns
+  - `markdown` → full text, `whitespace-pre-wrap` (not the 80-char table clip)
+  - scalar → `formatCell`
+- Header shows the record's primary-key value (`viewTitle`) + an **Edit** button
+  (`editFromView` hands off to the existing editor) + close.
+
+### Entry points
+
+- **Deep link**: `loadCollection` calls `maybeOpenHighlighted` once items are
+  loaded; a `watch` on `route.query.highlight` covers same-collection link
+  hops. Unknown id → no-op (stale/deleted links just show the list).
+- **Row click**: table rows are clickable → open mode. Ref-links and the
+  Edit/Remove action buttons use `@click.stop` so they keep their own behavior.
+- `closeView` drops the `?highlight=` query param so refresh / back doesn't
+  reopen and the URL reflects the closed state.
+
+## Testing
+
+- `yarn format` / `lint` / `typecheck` / `build` / `test` (5141 unit) — green.
+- No automated UI test: collections has **no** e2e harness yet (edit/create
+  aren't covered either), so this was verified manually in the running app.
+  Building a collections e2e mock layer is out of scope for this change.
+
+## Out of scope / deferred
+
+- Scroll-into-view + row pulse on the list itself (the original "highlight"
+  literal reading) — superseded by "open the record", which is what the user
+  asked for.
+- `actions` field type (Mark Sent / Mark Paid) + PDF export — the remaining
+  mc-invoice follow-up.
+- A collections e2e mock harness.

--- a/plans/feat-collections-open-mode.md
+++ b/plans/feat-collections-open-mode.md
@@ -1,23 +1,28 @@
-# feat: collections "open" (read-only detail) mode + `?highlight=` handler
+# feat: collections "open" (read-only detail) mode + `?selected=` handler
 
 ## Motivation
 
 Record links emitted by skills (e.g. mc-invoice's "Linking to an invoice in
-chat" section) point at `/collections/<slug>?highlight=<id>`. The query param
+chat" section) point at `/collections/<slug>?selected=<id>`. The query param
 was being produced but not consumed — landing on the collection just showed the
-list. This adds the back half: `?highlight=<id>` **opens** the referenced
+list. This adds the back half: `?selected=<id>` **opens** the referenced
 record in a read-only detail view, distinct from the existing edit form.
+
+## Naming
+
+The query param is `?selected=<id>` (not `?highlight=`). "Highlight" implied
+flagging a row in the list; the behavior is "open this record in detail mode",
+so "selected" reads truer. Renamed across the classifier, CollectionView, the
+link tests, and the three `mc-*` skill files.
 
 ## What shipped
 
-Two files — no schema, server, or i18n changes.
-
 ### Link classifier: preserve the query string (`workspaceLinkRouter.ts`)
 
-The first cut of open mode looked correct but the `?highlight=` never
+The first cut of open mode looked correct but the `?selected=` never
 arrived: `classifyWorkspacePath` (which routes agent-markdown links into SPA
 navigation) called `stripFragmentAndQuery` for **all** targets, so
-`/collections/mc-invoice?highlight=INV-2026-0001` became a bare
+`/collections/mc-invoice?selected=INV-2026-0001` became a bare
 `/collections/mc-invoice`. Fix: a new `extractQuery` helper re-attaches the
 query to `spa-route` targets only (`router.push(string)` parses it into
 `route.query`). Wiki / file / session targets still strip — they route by
@@ -30,7 +35,7 @@ their own identifiers and take no query. Fragments stay dropped.
 - New `viewing = ref<CollectionItem | null>`, mutually exclusive with `editing`.
 - A detail modal renders every field formatted for display (no inputs):
   - `boolean` → check icon / em-dash
-  - `ref` → `<router-link>` to the target collection (`?highlight=` chained, so
+  - `ref` → `<router-link>` to the target collection (`?selected=` chained, so
     you can hop record→record)
   - `money` → `formatMoney`
   - `derived` → `derivedDisplay` (evaluated against the item)
@@ -42,13 +47,26 @@ their own identifiers and take no query. Fragments stay dropped.
 
 ### Entry points
 
-- **Deep link**: `loadCollection` calls `maybeOpenHighlighted` once items are
-  loaded; a `watch` on `route.query.highlight` covers same-collection link
-  hops. Unknown id → no-op (stale/deleted links just show the list).
-- **Row click**: table rows are clickable → open mode. Ref-links and the
-  Edit/Remove action buttons use `@click.stop` so they keep their own behavior.
-- `closeView` drops the `?highlight=` query param so refresh / back doesn't
+- **Deep link**: `loadCollection` calls `syncViewToSelected` once items are
+  loaded; a `watch` on `route.query.selected` covers same-collection link
+  hops. `?selected=` is the single source of truth — `syncViewToSelected`
+  opens the matching record, or **closes** the modal when the param is absent /
+  empty / points at a missing id (so browser-back and stale/deleted links both
+  land on the list, never leaving stale UI on screen).
+- **Row click**: table rows are clickable → open mode. Rows are keyboard
+  operable too (`role="button"`, `tabindex="0"`, Enter / Space, an
+  `openItem` aria-label). Ref-links and the Edit/Remove action buttons use
+  `@click.stop` so they keep their own behavior.
+- `closeView` drops the `?selected=` query param so refresh / back doesn't
   reopen and the URL reflects the closed state.
+
+## Review round (PR #1502)
+
+- Modal now closes when `?selected=` is removed (browser back) or points at a
+  missing id — `syncViewToSelected` replaced the open-only helper (Codex P2 +
+  CodeRabbit).
+- Row is keyboard/AT-accessible (`role`/`tabindex`/Enter+Space + aria-label).
+- `viewTitle` stringifies a non-string primary key instead of dropping it.
 
 ## Testing
 

--- a/server/workspace/skills-preset/mc-clients/SKILL.md
+++ b/server/workspace/skills-preset/mc-clients/SKILL.md
@@ -58,13 +58,13 @@ remove the file.
 When you reference a specific client in your reply, link to the collection
 view — NOT the raw JSON file path:
 
-- Do: `[Acme Corp](/collections/mc-clients?highlight=acme-corp)`
+- Do: `[Acme Corp](/collections/mc-clients?selected=acme-corp)`
 - Don't: `[Acme Corp](data/clients/items/acme-corp.json)` — that opens the raw
   file in the Files view instead of the rendered table.
 
-Always include the `?highlight=<id>` query. Today it just opens the table; a
-later host update will use it to scroll to and highlight the matching row, and
-existing links will start working automatically.
+Always include the `?selected=<id>` query: it opens that client directly in
+the read-only detail view. Omit it (link to plain `/collections/mc-clients`)
+only for a general, non-specific reference to the whole list.
 
 ## When to ask vs. when to act
 

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -112,15 +112,13 @@ remove the file.
 When you reference a specific invoice in your reply, link to the collection
 view — NOT the raw JSON file path:
 
-- Do: `[INV-2026-0002](/collections/mc-invoice?highlight=INV-2026-0002)`
+- Do: `[INV-2026-0002](/collections/mc-invoice?selected=INV-2026-0002)`
 - Don't: `[INV-2026-0002](data/invoice/items/INV-2026-0002.json)` — that opens
   the raw file in the Files view instead of the rendered table.
 
-Always include the `?highlight=<id>` query. Today it just opens the table; a
-later host update will use it to scroll to and highlight the matching row, and
-existing links will start working automatically. The "see the list at
-/collections/mc-invoice" pointer is also fine for a general (non-specific)
-reference.
+Always include the `?selected=<id>` query: it opens that invoice directly in
+the read-only detail view. Omit it (link to plain `/collections/mc-invoice`)
+only for a general, non-specific reference to the whole list.
 
 ## When to ask vs. when to act
 

--- a/server/workspace/skills-preset/mc-worklog/SKILL.md
+++ b/server/workspace/skills-preset/mc-worklog/SKILL.md
@@ -74,13 +74,13 @@ or unlink. Preserve fields you weren't asked to change.
 When you reference a specific worklog entry in your reply, link to the
 collection view — NOT the raw JSON file path:
 
-- Do: `[2026-05-24 Acme](/collections/mc-worklog?highlight=2026-05-24-acme-corp-a1b2)`
+- Do: `[2026-05-24 Acme](/collections/mc-worklog?selected=2026-05-24-acme-corp-a1b2)`
 - Don't: `[…](data/worklog/items/2026-05-24-acme-corp-a1b2.json)` — that opens
   the raw file in the Files view instead of the rendered table.
 
-Always include the `?highlight=<id>` query. Today it just opens the table; a
-later host update will use it to scroll to and highlight the matching row, and
-existing links will start working automatically.
+Always include the `?selected=<id>` query: it opens that entry directly in the
+read-only detail view. Omit it (link to plain `/collections/mc-worklog`) only
+for a general, non-specific reference to the whole list.
 
 ## When to ask vs. when to act
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -48,7 +48,13 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
-          <tr v-for="item in items" :key="String(item[collection.schema.primaryKey] ?? '')" class="hover:bg-gray-50">
+          <tr
+            v-for="item in items"
+            :key="String(item[collection.schema.primaryKey] ?? '')"
+            class="hover:bg-gray-50 cursor-pointer"
+            :data-testid="`collections-row-${item[collection.schema.primaryKey]}`"
+            @click="openView(item)"
+          >
             <td v-for="(field, key) in collection.schema.fields" :key="key" class="px-4 py-2 text-gray-800 align-top max-w-xs">
               <span v-if="field.type === 'boolean'" class="block">
                 <span v-if="item[key] === true" class="material-icons text-green-600 text-base align-middle">check</span>
@@ -60,6 +66,7 @@
                   :to="{ path: `/collections/${field.to}`, query: { highlight: String(item[key]) } }"
                   class="text-blue-600 hover:underline"
                   :data-testid="`collections-ref-link-${key}-${item[key]}`"
+                  @click.stop
                   >{{ refDisplay(field.to, String(item[key])) }}</router-link
                 >
               </span>
@@ -75,7 +82,7 @@
                 type="button"
                 class="text-xs text-blue-600 hover:underline mr-3"
                 :data-testid="`collections-edit-item-${item[collection.schema.primaryKey]}`"
-                @click="openEdit(item)"
+                @click.stop="openEdit(item)"
               >
                 {{ t("collectionsView.editItem") }}
               </button>
@@ -83,7 +90,7 @@
                 type="button"
                 class="text-xs text-red-600 hover:underline"
                 :data-testid="`collections-delete-item-${item[collection.schema.primaryKey]}`"
-                @click="confirmDelete(item)"
+                @click.stop="confirmDelete(item)"
               >
                 {{ t("common.remove") }}
               </button>
@@ -305,6 +312,85 @@
       </div>
     </div>
 
+    <!-- Open / detail modal (read-only) -->
+    <div
+      v-if="viewing && collection"
+      class="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-4"
+      data-testid="collections-detail"
+      @click.self="closeView"
+    >
+      <div class="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[80vh] flex flex-col">
+        <header class="px-5 py-3 border-b border-gray-200 flex items-center gap-3">
+          <span class="material-icons text-blue-600 text-base">{{ collection.icon }}</span>
+          <h2 class="text-base font-medium text-gray-900 flex-1 min-w-0 truncate">{{ viewTitle }}</h2>
+          <button
+            type="button"
+            class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm text-gray-700"
+            data-testid="collections-detail-edit"
+            @click="editFromView"
+          >
+            <span class="material-icons text-base">edit</span>
+            <span>{{ t("collectionsView.editItem") }}</span>
+          </button>
+          <button
+            type="button"
+            class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-100"
+            :aria-label="t('common.close')"
+            data-testid="collections-detail-close"
+            @click="closeView"
+          >
+            <span class="material-icons text-base">close</span>
+          </button>
+        </header>
+
+        <div class="flex-1 overflow-auto px-5 py-4 space-y-3">
+          <div v-for="(field, key) in collection.schema.fields" :key="key" class="space-y-1">
+            <div class="text-xs font-medium text-gray-500">{{ field.label }}</div>
+            <div class="text-sm text-gray-800 break-words" :data-testid="`collections-detail-value-${key}`">
+              <template v-if="field.type === 'boolean'">
+                <span v-if="viewing[key] === true" class="material-icons text-green-600 text-base align-middle">check</span>
+                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph, same treatment as the table cell + formatCell. -->
+                <span v-else class="text-gray-400">—</span>
+              </template>
+              <router-link
+                v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
+                :to="{ path: `/collections/${field.to}`, query: { highlight: String(viewing[key]) } }"
+                class="text-blue-600 hover:underline"
+                :data-testid="`collections-detail-ref-${key}`"
+                >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
+              >
+              <span v-else-if="field.type === 'money'" class="tabular-nums">{{ formatMoney(viewing[key], field.currency, locale) }}</span>
+              <span v-else-if="field.type === 'derived'" class="tabular-nums">{{
+                derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), viewing))
+              }}</span>
+              <table v-else-if="field.type === 'table' && field.of && hasTableRows(viewing[key])" class="w-full text-sm border border-gray-200 rounded">
+                <thead class="bg-gray-50 text-xs text-gray-500">
+                  <tr>
+                    <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-2 py-1 font-medium">{{ subField.label }}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(row, rowIdx) in tableRows(viewing[key])" :key="rowIdx" class="border-t border-gray-100">
+                    <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1 align-top">
+                      <template v-if="subField.type === 'boolean'">
+                        <span v-if="row[subKey] === true" class="material-icons text-green-600 text-base align-middle">check</span>
+                        <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph (boolean=false), same as elsewhere. -->
+                        <span v-else class="text-gray-400">—</span>
+                      </template>
+                      <span v-else :class="subField.type === 'money' ? 'tabular-nums' : ''">{{ formatSubCell(subField, row[subKey]) }}</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <span v-else-if="field.type === 'table'" class="text-gray-400">{{ formatCell(undefined, "string") }}</span>
+              <p v-else-if="field.type === 'markdown'" class="whitespace-pre-wrap">{{ detailText(viewing[key]) }}</p>
+              <span v-else>{{ formatCell(viewing[key], field.type) }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <ConfirmModal />
   </div>
 </template>
@@ -442,6 +528,12 @@ const items = ref<CollectionItem[]>([]);
 const loading = ref(true);
 const loadError = ref<string | null>(null);
 const editing = ref<EditState | null>(null);
+/** The record currently shown in read-only "open" mode. Distinct
+ *  from `editing`: open mode renders formatted values (no inputs)
+ *  and is what a `/collections/<slug>?highlight=<id>` deep link
+ *  lands on. Mutually exclusive with `editing` in practice —
+ *  `editFromView` hands off from one to the other. */
+const viewing = ref<CollectionItem | null>(null);
 const saving = ref(false);
 const saveError = ref<string | null>(null);
 const refCache = ref<RefCache>({});
@@ -464,6 +556,7 @@ async function loadCollection(slug: string): Promise<void> {
   collection.value = null;
   items.value = [];
   refCache.value = {};
+  viewing.value = null;
   const result = await apiGet<CollectionDetailResponse>(detailUrl(slug));
   loading.value = false;
   if (!result.ok) {
@@ -480,6 +573,10 @@ async function loadCollection(slug: string): Promise<void> {
   // its result if a faster subsequent load has already switched us
   // to a different collection (Codex P1 review on PR #1495).
   await loadRefTargets(result.data.collection.schema, slug);
+  // A `?highlight=<id>` deep link opens that record in read-only
+  // mode once its items are available. Guard against a stale load:
+  // only act if we're still on the slug that triggered this fetch.
+  if (collection.value?.slug === slug) maybeOpenHighlighted();
 }
 
 function uniqueRefTargets(schema: CollectionSchema): string[] {
@@ -684,6 +781,40 @@ function formatCell(value: unknown, type: FieldType): string {
   return JSON.stringify(value);
 }
 
+/** Full (untruncated) text rendering for open mode. `formatCell`
+ *  clips markdown to 80 chars for the dense table; the detail view
+ *  has room to show the whole value. */
+function detailText(value: unknown): string {
+  if (value === undefined || value === null || value === "") return "—";
+  return String(value);
+}
+
+/** Coerce a persisted `table` cell into a typed row array for
+ *  read-only rendering (open mode). Mirrors the filtering in
+ *  `openEdit` so a malformed non-object row never reaches the
+ *  template. */
+function tableRows(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row));
+}
+
+function hasTableRows(value: unknown): boolean {
+  return tableRows(value).length > 0;
+}
+
+/** Format one cell of a `table` sub-field for open mode. Booleans
+ *  are handled in the template (check / em-dash icon); everything
+ *  else routes through the same formatters the top-level fields
+ *  use. Sub-fields can't be `table`/`derived` (schema-rejected),
+ *  so only money / ref / scalar need handling here. */
+function formatSubCell(subField: FieldSpec, value: unknown): string {
+  if (subField.type === "money") return formatMoney(value, subField.currency, locale.value);
+  if (subField.type === "ref" && subField.to && typeof value === "string" && value.length > 0) {
+    return refDisplay(subField.to, value);
+  }
+  return formatCell(value, subField.type);
+}
+
 function openCreate(): void {
   if (!collection.value) return;
   const text: Record<string, string> = {};
@@ -752,6 +883,56 @@ function closeEditor(): void {
   saving.value = false;
   saveError.value = null;
 }
+
+/** Open mode (read-only detail). */
+function openView(item: CollectionItem): void {
+  viewing.value = item;
+}
+
+/** Close open mode and drop the `?highlight=` query param so a
+ *  refresh / back-button doesn't immediately reopen the record and
+ *  the URL reflects the closed state. */
+function closeView(): void {
+  viewing.value = null;
+  if (route.query.highlight !== undefined) {
+    const query = { ...route.query };
+    delete query.highlight;
+    router.replace({ query }).catch(() => {});
+  }
+}
+
+/** Hand off from open mode to the editor for the same record. */
+function editFromView(): void {
+  const item = viewing.value;
+  if (!item) return;
+  viewing.value = null;
+  openEdit(item);
+}
+
+function findItemById(itemId: string): CollectionItem | undefined {
+  if (!collection.value) return undefined;
+  const { primaryKey } = collection.value.schema;
+  return items.value.find((item) => String(item[primaryKey] ?? "") === itemId);
+}
+
+/** If the route carries `?highlight=<id>` and that id is present in
+ *  the loaded items, open it in read-only mode. No-op when the id
+ *  is absent (deleted record, stale link) so a bad link just shows
+ *  the list rather than erroring. */
+function maybeOpenHighlighted(): void {
+  const { highlight } = route.query;
+  if (typeof highlight !== "string" || highlight.length === 0) return;
+  const match = findItemById(highlight);
+  if (match) viewing.value = match;
+}
+
+/** Title for the open-mode header: the record's primary-key value
+ *  (e.g. `INV-2026-0001`), falling back to the collection title. */
+const viewTitle = computed<string>(() => {
+  if (!viewing.value || !collection.value) return "";
+  const pkValue = viewing.value[collection.value.schema.primaryKey];
+  return typeof pkValue === "string" && pkValue.length > 0 ? pkValue : (collection.value.title ?? "");
+});
 
 /** Decide whether and how to emit a boolean field's draft value.
  *  Extracted from `draftToRecord` to keep that function's
@@ -1041,6 +1222,17 @@ watch(
       items.value = [];
       loading.value = false;
     }
+  },
+);
+
+// React to `?highlight=` changing while already on this collection
+// (e.g. following two record links to the same collection in a
+// row). The initial / cross-collection case is handled by
+// `loadCollection`; here we only act once items are loaded.
+watch(
+  () => route.query.highlight,
+  () => {
+    if (!loading.value && collection.value) maybeOpenHighlighted();
   },
 );
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -51,9 +51,14 @@
           <tr
             v-for="item in items"
             :key="String(item[collection.schema.primaryKey] ?? '')"
-            class="hover:bg-gray-50 cursor-pointer"
+            class="hover:bg-gray-50 cursor-pointer focus:outline-none focus:bg-blue-50"
+            role="button"
+            tabindex="0"
+            :aria-label="t('collectionsView.openItem', { id: String(item[collection.schema.primaryKey] ?? '') })"
             :data-testid="`collections-row-${item[collection.schema.primaryKey]}`"
             @click="openView(item)"
+            @keydown.enter.self="openView(item)"
+            @keydown.space.self.prevent="openView(item)"
           >
             <td v-for="(field, key) in collection.schema.fields" :key="key" class="px-4 py-2 text-gray-800 align-top max-w-xs">
               <span v-if="field.type === 'boolean'" class="block">
@@ -63,7 +68,7 @@
               </span>
               <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
                 <router-link
-                  :to="{ path: `/collections/${field.to}`, query: { highlight: String(item[key]) } }"
+                  :to="{ path: `/collections/${field.to}`, query: { selected: String(item[key]) } }"
                   class="text-blue-600 hover:underline"
                   :data-testid="`collections-ref-link-${key}-${item[key]}`"
                   @click.stop
@@ -354,7 +359,7 @@
               </template>
               <router-link
                 v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
-                :to="{ path: `/collections/${field.to}`, query: { highlight: String(viewing[key]) } }"
+                :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
                 class="text-blue-600 hover:underline"
                 :data-testid="`collections-detail-ref-${key}`"
                 >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
@@ -530,7 +535,7 @@ const loadError = ref<string | null>(null);
 const editing = ref<EditState | null>(null);
 /** The record currently shown in read-only "open" mode. Distinct
  *  from `editing`: open mode renders formatted values (no inputs)
- *  and is what a `/collections/<slug>?highlight=<id>` deep link
+ *  and is what a `/collections/<slug>?selected=<id>` deep link
  *  lands on. Mutually exclusive with `editing` in practice —
  *  `editFromView` hands off from one to the other. */
 const viewing = ref<CollectionItem | null>(null);
@@ -573,10 +578,10 @@ async function loadCollection(slug: string): Promise<void> {
   // its result if a faster subsequent load has already switched us
   // to a different collection (Codex P1 review on PR #1495).
   await loadRefTargets(result.data.collection.schema, slug);
-  // A `?highlight=<id>` deep link opens that record in read-only
+  // A `?selected=<id>` deep link opens that record in read-only
   // mode once its items are available. Guard against a stale load:
   // only act if we're still on the slug that triggered this fetch.
-  if (collection.value?.slug === slug) maybeOpenHighlighted();
+  if (collection.value?.slug === slug) syncViewToSelected();
 }
 
 function uniqueRefTargets(schema: CollectionSchema): string[] {
@@ -889,14 +894,14 @@ function openView(item: CollectionItem): void {
   viewing.value = item;
 }
 
-/** Close open mode and drop the `?highlight=` query param so a
+/** Close open mode and drop the `?selected=` query param so a
  *  refresh / back-button doesn't immediately reopen the record and
  *  the URL reflects the closed state. */
 function closeView(): void {
   viewing.value = null;
-  if (route.query.highlight !== undefined) {
+  if (route.query.selected !== undefined) {
     const query = { ...route.query };
-    delete query.highlight;
+    delete query.selected;
     router.replace({ query }).catch(() => {});
   }
 }
@@ -915,23 +920,31 @@ function findItemById(itemId: string): CollectionItem | undefined {
   return items.value.find((item) => String(item[primaryKey] ?? "") === itemId);
 }
 
-/** If the route carries `?highlight=<id>` and that id is present in
- *  the loaded items, open it in read-only mode. No-op when the id
- *  is absent (deleted record, stale link) so a bad link just shows
- *  the list rather than erroring. */
-function maybeOpenHighlighted(): void {
-  const { highlight } = route.query;
-  if (typeof highlight !== "string" || highlight.length === 0) return;
-  const match = findItemById(highlight);
-  if (match) viewing.value = match;
+/** Reconcile the open-mode view with the `?selected=<id>` query —
+ *  the single source of truth for which record is open. Opens the
+ *  matching record, or closes the modal when the param is absent /
+ *  empty / points at an id that isn't loaded (deleted record, stale
+ *  link). Keeping `viewing` in lockstep with the URL means browser
+ *  back / forward and a removed param both close the modal instead
+ *  of leaving stale UI on screen (Codex P2 + CodeRabbit on #1502). */
+function syncViewToSelected(): void {
+  const { selected } = route.query;
+  if (typeof selected !== "string" || selected.length === 0) {
+    viewing.value = null;
+    return;
+  }
+  viewing.value = findItemById(selected) ?? null;
 }
 
 /** Title for the open-mode header: the record's primary-key value
- *  (e.g. `INV-2026-0001`), falling back to the collection title. */
+ *  (e.g. `INV-2026-0001`), falling back to the collection title.
+ *  Non-string primary keys (numeric ids) are stringified rather
+ *  than discarded (CodeRabbit on #1502). */
 const viewTitle = computed<string>(() => {
   if (!viewing.value || !collection.value) return "";
   const pkValue = viewing.value[collection.value.schema.primaryKey];
-  return typeof pkValue === "string" && pkValue.length > 0 ? pkValue : (collection.value.title ?? "");
+  if (pkValue === undefined || pkValue === null || pkValue === "") return collection.value.title ?? "";
+  return String(pkValue);
 });
 
 /** Decide whether and how to emit a boolean field's draft value.
@@ -1225,14 +1238,15 @@ watch(
   },
 );
 
-// React to `?highlight=` changing while already on this collection
-// (e.g. following two record links to the same collection in a
-// row). The initial / cross-collection case is handled by
-// `loadCollection`; here we only act once items are loaded.
+// React to `?selected=` changing while already on this collection:
+// follow it to open the new record, OR close the modal when the
+// param is removed (browser back) or points at a missing id. The
+// initial / cross-collection case is handled by `loadCollection`;
+// here we only act once items are loaded.
 watch(
-  () => route.query.highlight,
+  () => route.query.selected,
   () => {
-    if (!loading.value && collection.value) maybeOpenHighlighted();
+    if (!loading.value && collection.value) syncViewToSelected();
   },
 );
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1337,6 +1337,7 @@ const deMessages = {
     backToIndex: "Zurück zu Sammlungen",
     indexEmpty: "Keine Sammlungen installiert. Markiere auf der Skills-Seite eine Skill mit Schema, um sie hier zu sehen.",
     editItem: "Bearbeiten",
+    openItem: "{id} öffnen",
     confirmDelete: "Diesen Eintrag löschen? Das kann nicht rückgängig gemacht werden.",
     itemsEmpty: "Noch keine Einträge. Klicke auf +, um einen hinzuzufügen.",
     notFound: "Sammlung nicht gefunden",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1319,6 +1319,7 @@ const enMessages = {
     backToIndex: "Back to collections",
     indexEmpty: "No collections installed. Star a skill that ships a schema from the Skills page to see it here.",
     editItem: "Edit",
+    openItem: "Open {id}",
     confirmDelete: "Delete this item? This cannot be undone.",
     itemsEmpty: "No items yet. Click + to add one.",
     notFound: "Collection not found",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1332,6 +1332,7 @@ const esMessages = {
     backToIndex: "Volver a colecciones",
     indexEmpty: "No hay colecciones instaladas. Marca con estrella una skill que incluya un schema desde la página Skills para verla aquí.",
     editItem: "Editar",
+    openItem: "Abrir {id}",
     confirmDelete: "¿Eliminar este elemento? Esta acción no se puede deshacer.",
     itemsEmpty: "Aún no hay elementos. Pulsa + para añadir uno.",
     notFound: "Colección no encontrada",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1326,6 +1326,7 @@ const frMessages = {
     backToIndex: "Retour aux collections",
     indexEmpty: "Aucune collection installée. Mettez une étoile sur une compétence avec un schema depuis la page Skills pour la voir ici.",
     editItem: "Modifier",
+    openItem: "Ouvrir {id}",
     confirmDelete: "Supprimer cet élément ? Cette action est irréversible.",
     itemsEmpty: "Aucun élément pour l'instant. Cliquez sur + pour en ajouter un.",
     notFound: "Collection introuvable",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1316,6 +1316,7 @@ const jaMessages = {
     backToIndex: "コレクション一覧に戻る",
     indexEmpty: "インストール済みのコレクションがありません。スキーマを含むスキルを Skills ページからスター付けすると、ここに表示されます。",
     editItem: "編集",
+    openItem: "{id} を開く",
     confirmDelete: "この項目を削除しますか？元に戻せません。",
     itemsEmpty: "まだ項目がありません。+ を押して追加してください。",
     notFound: "コレクションが見つかりません",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1319,6 +1319,7 @@ const koMessages = {
     backToIndex: "컬렉션 목록으로 돌아가기",
     indexEmpty: "설치된 컬렉션이 없습니다. Skills 페이지에서 스키마를 포함한 스킬에 별표를 추가하면 여기에 표시됩니다.",
     editItem: "편집",
+    openItem: "{id} 열기",
     confirmDelete: "이 항목을 삭제하시겠습니까? 되돌릴 수 없습니다.",
     itemsEmpty: "아직 항목이 없습니다. + 를 눌러 추가하세요.",
     notFound: "컬렉션을 찾을 수 없습니다",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1321,6 +1321,7 @@ const ptBRMessages = {
     backToIndex: "Voltar para coleções",
     indexEmpty: "Nenhuma coleção instalada. Marque com estrela uma skill que inclua um schema na página Skills para vê-la aqui.",
     editItem: "Editar",
+    openItem: "Abrir {id}",
     confirmDelete: "Excluir este item? Esta ação não pode ser desfeita.",
     itemsEmpty: "Ainda não há itens. Clique em + para adicionar um.",
     notFound: "Coleção não encontrada",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1309,6 +1309,7 @@ const zhMessages = {
     backToIndex: "返回集合列表",
     indexEmpty: "尚未安装任何集合。在「技能」页面对带有 schema 的技能加星即可在此显示。",
     editItem: "编辑",
+    openItem: "打开 {id}",
     confirmDelete: "删除此项？此操作无法撤销。",
     itemsEmpty: "暂无项目。点击 + 添加一个。",
     notFound: "未找到集合",

--- a/src/utils/path/workspaceLinkRouter.ts
+++ b/src/utils/path/workspaceLinkRouter.ts
@@ -105,8 +105,8 @@ export function classifyWorkspacePath(href: string): WorkspaceLinkTarget | null 
   // carry dots; file extensions almost always do.
   const [firstSegment, ...restSegments] = normalized.split("/");
   if (SPA_ROUTE_NAMES.has(firstSegment) && !restSegments.some(looksLikeFileSegment)) {
-    // Preserve the query string (e.g. `?highlight=<id>`) so deep
-    // links like `/collections/mc-invoice?highlight=INV-2026-0001`
+    // Preserve the query string (e.g. `?selected=<id>`) so deep
+    // links like `/collections/mc-invoice?selected=INV-2026-0001`
     // reach the target view's query handler — `router.push(string)`
     // parses it into `route.query`. Kept for spa-route ONLY; wiki /
     // file / session targets route by their own identifiers and

--- a/src/utils/path/workspaceLinkRouter.ts
+++ b/src/utils/path/workspaceLinkRouter.ts
@@ -105,7 +105,16 @@ export function classifyWorkspacePath(href: string): WorkspaceLinkTarget | null 
   // carry dots; file extensions almost always do.
   const [firstSegment, ...restSegments] = normalized.split("/");
   if (SPA_ROUTE_NAMES.has(firstSegment) && !restSegments.some(looksLikeFileSegment)) {
-    return { kind: "spa-route", path: `/${normalized}` };
+    // Preserve the query string (e.g. `?highlight=<id>`) so deep
+    // links like `/collections/mc-invoice?highlight=INV-2026-0001`
+    // reach the target view's query handler — `router.push(string)`
+    // parses it into `route.query`. Kept for spa-route ONLY; wiki /
+    // file / session targets route by their own identifiers and
+    // take no query. Fragments stay dropped (no SPA route reads one
+    // today). The query is sliced from the raw href, so any
+    // percent-encoding marked emitted survives for vue-router to
+    // decode.
+    return { kind: "spa-route", path: `/${normalized}${extractQuery(href)}` };
   }
 
   // Everything else: open in Files view
@@ -172,6 +181,20 @@ function decodeSegment(seg: string): string {
 // `notes.txt`) directly.
 function looksLikeFileSegment(segment: string): boolean {
   return /\.[a-zA-Z0-9]{1,8}$/.test(segment);
+}
+
+// Extract the raw query string (including the leading "?") from an
+// href, or "" when there's none. Only a "?" that precedes any "#"
+// counts as a query delimiter — a "?" sitting inside the fragment
+// is part of the fragment, not a query. Sliced from the raw href so
+// percent-encoding is preserved for vue-router to decode.
+function extractQuery(href: string): string {
+  const queryIdx = href.indexOf("?");
+  if (queryIdx === -1) return "";
+  const hashIdx = href.indexOf("#");
+  if (hashIdx !== -1 && hashIdx < queryIdx) return "";
+  const end = hashIdx !== -1 ? hashIdx : href.length;
+  return href.slice(queryIdx, end);
 }
 
 function stripFragmentAndQuery(str: string): string {

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -414,6 +414,26 @@ describe("classifyWorkspacePath", () => {
       const result = classifyWorkspacePath("data/wiki/pages/foo.md?bar=1#baz");
       assert.deepEqual(result, { kind: "wiki", slug: "foo" });
     });
+
+    it("preserves ?highlight= query on a spa-route (collections deep link)", () => {
+      const result = classifyWorkspacePath("/collections/mc-invoice?highlight=INV-2026-0001");
+      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-invoice?highlight=INV-2026-0001" });
+    });
+
+    it("preserves the query but drops the fragment on a spa-route", () => {
+      const result = classifyWorkspacePath("/collections/mc-clients?highlight=acme#row");
+      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-clients?highlight=acme" });
+    });
+
+    it("a spa-route with no query stays query-free", () => {
+      const result = classifyWorkspacePath("/collections/mc-invoice");
+      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-invoice" });
+    });
+
+    it("ignores a '?' that lives inside the fragment on a spa-route", () => {
+      const result = classifyWorkspacePath("/collections/mc-invoice#frag?notquery");
+      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-invoice" });
+    });
   });
 });
 

--- a/test/utils/path/test_workspaceLinkRouter.ts
+++ b/test/utils/path/test_workspaceLinkRouter.ts
@@ -415,14 +415,14 @@ describe("classifyWorkspacePath", () => {
       assert.deepEqual(result, { kind: "wiki", slug: "foo" });
     });
 
-    it("preserves ?highlight= query on a spa-route (collections deep link)", () => {
-      const result = classifyWorkspacePath("/collections/mc-invoice?highlight=INV-2026-0001");
-      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-invoice?highlight=INV-2026-0001" });
+    it("preserves ?selected= query on a spa-route (collections deep link)", () => {
+      const result = classifyWorkspacePath("/collections/mc-invoice?selected=INV-2026-0001");
+      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-invoice?selected=INV-2026-0001" });
     });
 
     it("preserves the query but drops the fragment on a spa-route", () => {
-      const result = classifyWorkspacePath("/collections/mc-clients?highlight=acme#row");
-      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-clients?highlight=acme" });
+      const result = classifyWorkspacePath("/collections/mc-clients?selected=acme#row");
+      assert.deepEqual(result, { kind: "spa-route", path: "/collections/mc-clients?selected=acme" });
     });
 
     it("a spa-route with no query stays query-free", () => {


### PR DESCRIPTION
## Summary

Record links emitted by skills (e.g. mc-invoice's "Linking to an invoice in chat" section) point at `/collections/<slug>?highlight=<id>`. The query was being produced but not consumed. This adds the back half: **`?highlight=<id>` opens the referenced record in a read-only "open" mode**, distinct from the edit form.

While wiring it up, found the query was being dropped *before* it ever reached the view — fixed in the link classifier.

## What changed

**`src/components/CollectionView.vue` — open mode**
- New `viewing` state + a read-only detail modal rendering every field formatted: boolean→check/dash, ref→clickable link (chains its own `?highlight=`), money→`formatMoney`, derived→computed value, table→read-only sub-table, markdown→full pre-wrapped text, scalar→`formatCell`.
- Header shows the record's primary-key value + an **Edit** button (`editFromView` hands off to the existing editor) + close.
- Entry points: the `?highlight=` deep link (`loadCollection` + a `watch` on `route.query.highlight` for same-collection hops) and **row click**. Ref-links and the Edit/Remove action buttons use `@click.stop`. `closeView` drops the `?highlight=` query param so refresh/back doesn't reopen.
- Unknown id → no-op (stale/deleted links just show the list).

**`src/utils/path/workspaceLinkRouter.ts` — preserve the query (root-cause fix)**
- `classifyWorkspacePath` was calling `stripFragmentAndQuery` for **all** targets, so `/collections/mc-invoice?highlight=INV-2026-0001` became a bare `/collections/mc-invoice`.
- New `extractQuery` helper re-attaches the query to `spa-route` targets **only** (`router.push(string)` parses it into `route.query`). Wiki/file/session still strip — they route by their own identifiers and take no query. Fragments stay dropped.

## Test plan

- [x] `yarn format` / `lint` / `typecheck` / `build` — green
- [x] `yarn test` (5141 unit) — green; +4 new classifier tests (query preserved on spa-route; fragment dropped; no-query stays clean; `?` inside a fragment ignored)
- [x] Manual: clicking the chat link `[INV-2026-0001](/collections/mc-invoice?highlight=INV-2026-0001)` lands on the invoice's read-only detail view; the client `ref` inside links onward with its own `?highlight=`. Row-click opens; Edit hands off to the form; close clears the URL.
- Note: collections has **no** e2e harness yet (edit/create aren't covered either), so the UI is manually verified — building a collections e2e mock layer is out of scope here.

## Out of scope / deferred

- `actions` field type (Mark Sent / Mark Paid) + PDF export — the remaining mc-invoice follow-up.
- A collections e2e mock harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only detail modal: click a row to open a formatted record view with close and Edit handoff.
  * Deep links: use ?selected=<id> to open/close a record via URL.

* **Bug Fixes**
  * URL handling refined so app-route queries are preserved while fragments are dropped.

* **Localization**
  * Added “Open {id}” translations for multiple locales.

* **Tests / Docs**
  * Unit tests extended; planning and usage guidance updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->