### PR TITLE
chore(roles): drop legacy worklog/client/invoice tools from built-in roles

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -103,8 +103,6 @@ export const ROLES: Role[] = [
       TOOL_NAMES.manageBookmarks,
       TOOL_NAMES.manageTodoList,
       TOOL_NAMES.manageSpotify,
-      TOOL_NAMES.manageWorklog,
-      TOOL_NAMES.manageClient,
     ],
     queries: [
       "Show me my calendar",
@@ -138,8 +136,6 @@ export const ROLES: Role[] = [
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
       TOOL_NAMES.notify,
-      TOOL_NAMES.manageWorklog,
-      TOOL_NAMES.manageClient,
     ],
     queries: [
       "Show me the discount cash flow analysis of monthly income of $10,000 for two years. Make it possible to change the discount rate and monthly income.",
@@ -290,9 +286,6 @@ export const ROLES: Role[] = [
       'When the user asks to compare a metric over time — "chart my quarterly revenue", "show net income month-over-month", "plot the cash balance by month" — call `getTimeSeries` with the right `metric` (revenue / expense / netIncome / accountBalance), `granularity` (month / quarter / year), and `from`/`to`. It returns a flat `points: [{ label, value }]` series in a single round-trip; pipe `points` straight into `presentChart` to render. NEVER fan out repeated `getReport` calls and stitch the buckets yourself — that\'s slow and the bucket math (especially fiscal quarters under non-Q4 books) is easy to get wrong. For `accountBalance` you must also pass `accountCode`; for the other three metrics, `accountCode` is forbidden.',
     availablePlugins: [
       TOOL_NAMES.manageAccounting,
-      TOOL_NAMES.manageWorklog,
-      TOOL_NAMES.manageClient,
-      TOOL_NAMES.manageInvoice,
       TOOL_NAMES.presentForm,
       TOOL_NAMES.presentDocument,
       TOOL_NAMES.presentSpreadsheet,
@@ -367,11 +360,15 @@ export const ROLES: Role[] = [
   // mc-invoice) are NOT gated by a special role. Once starred via
   // `/skills`, Claude Code's skill discovery surfaces them in every
   // role's system prompt and each SKILL.md is self-contained
-  // (conventions, "don't write derived fields", file paths). In
-  // roles that ALSO have the legacy manageInvoice / manageClient /
-  // manageWorklog MCP tools (Accounting), Claude may still pick the
-  // dedicated tool over the skill; that's expected during the
-  // transition period while both paths coexist.
+  // (conventions, "don't write derived fields", file paths).
+  //
+  // The legacy manageWorklog / manageClient / manageInvoice MCP
+  // tools have been removed from every built-in role's
+  // `availablePlugins` — the `mc-*` collection skills fully replace
+  // them. The worklog / client / invoice plugins still ship in
+  // `PRESET_PLUGINS` (so existing workspaces keep working and a user
+  // can re-add a tool via Settings → Roles), but no built-in role
+  // exposes them out of the box anymore.
   {
     id: "debug",
     name: "Debug",
@@ -405,8 +402,6 @@ export const ROLES: Role[] = [
       TOOL_NAMES.manageBookmarks,
       TOOL_NAMES.manageTodoList,
       TOOL_NAMES.manageSpotify,
-      TOOL_NAMES.manageWorklog,
-      TOOL_NAMES.manageClient,
       // manageRecipes removed (#1286) — recipe-book-plugin no longer
       // in PRESET_PLUGINS; recipes drive via the `mc-cooking-coach`
       // preset skill.

--- a/test/roles/test_role_schema.ts
+++ b/test/roles/test_role_schema.ts
@@ -220,6 +220,11 @@ describe("Accounting role", () => {
   // - presentDocument (longer narrative outputs like month-end notes)
   // - presentSpreadsheet / presentChart / presentHtml (rich report
   //   surfaces for B/S, P&L, ratio analysis, dashboards)
+  //
+  // The legacy manageWorklog / manageClient / manageInvoice MCP tools
+  // were removed from every built-in role — the schema-driven `mc-*`
+  // collection skills replace them (the plugins still ship in
+  // PRESET_PLUGINS but no role exposes them out of the box).
   const role = BUILTIN_ROLES.find((entry) => entry.id === "accounting");
 
   it("exists in BUILTIN_ROLES", () => {
@@ -230,9 +235,6 @@ describe("Accounting role", () => {
     assert.ok(role);
     assert.deepStrictEqual([...role.availablePlugins].sort(), [
       "manageAccounting",
-      "manageClient",
-      "manageInvoice",
-      "manageWorklog",
       "presentChart",
       "presentDocument",
       "presentForm",


### PR DESCRIPTION
## Summary

The schema-driven `mc-*` collection skills (mc-worklog, mc-clients, mc-invoice) now fully replace the legacy worklog/client/invoice MCP-tool plugins. This **de-gates** those tools from the built-in roles — they're no longer offered out of the box — without removing the plugins from the app yet.

Removed `manageWorklog` / `manageClient` / `manageInvoice` from `availablePlugins`:

| Role | Removed |
|---|---|
| General (`personal`) | manageWorklog, manageClient |
| Office | manageWorklog, manageClient |
| Accounting | manageWorklog, manageClient, manageInvoice |
| Debug | manageWorklog, manageClient |

## Not in scope (deliberately kept)

- `server/plugins/preset-list.ts` **still registers all three plugins**, so the MCP tool + Vue View stay mounted. Existing workspaces keep working, and a user can re-add a tool via **Settings → Roles**. "Removed from system roles, not from the app."
- The plugin packages under `packages/plugins/{worklog,client,invoice}-plugin/` are untouched, and their dispatch integration tests still pass.

## Changes

- `src/config/roles.ts` — removed the three tools from the four roles above; rewrote the `mc-*` coexistence comment to state the legacy tools are no longer in any built-in role.
- `test/roles/test_role_schema.ts` — updated the pinned Accounting plugin-set assertion (it hardcoded the three legacy tools).

## Test plan

- [x] `yarn format` / `lint` / `typecheck` / `build` — green
- [x] `yarn test` — 5145 pass / 0 fail
- [ ] Sanity-check in-app: General / Office / Accounting / Debug chats no longer expose the worklog/client/invoice MCP tools, and the `mc-*` collection skills (once starred) still drive those workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated built-in role configurations to reorganize tool management and role assignments
  * Adjusted roles to utilize an updated tool architecture approach

* **Tests**
  * Updated test expectations to reflect role configuration changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->