### PR TITLE
feat(map): merge same-groupId map operations onto one stack card (#1227)

### DIFF
--- a/e2e/fixtures/pubsub.ts
+++ b/e2e/fixtures/pubsub.ts
@@ -1,0 +1,114 @@
+// Shared harness for driving the app's real pub/sub WebSocket from
+// Playwright: mock `/api/agent`, accept the Socket.IO handshake, and
+// relay a scripted sequence of `data` events on whichever
+// `session.<id>` channel the client subscribes to. Used by the
+// streaming auto-scroll regression and the stack map-grouping scroll
+// regression — both exercise StackView's real watcher/DOM wiring.
+
+import type { Page, Route } from "@playwright/test";
+
+export function urlEndsWith(suffix: string): (url: URL) => boolean {
+  return (url) => url.pathname === suffix;
+}
+
+interface MockSocket {
+  send: (data: string) => void;
+}
+
+// Relay a sequence of pub/sub events to the mocked WebSocket with a
+// small gap between each send so Vue re-renders between events.
+const RENDER_GAP_MS = 20;
+
+interface StreamOptions {
+  // Delay before the first event is sent, after the client subscribes.
+  // Use when the events must land AFTER an async transcript fetch has
+  // populated the session, so they append rather than race the load.
+  startDelayMs?: number;
+}
+
+async function streamEventsToSocket(webSocket: MockSocket, channel: string, events: readonly unknown[], opts: StreamOptions): Promise<void> {
+  if (opts.startDelayMs) await new Promise((resolve) => setTimeout(resolve, opts.startDelayMs));
+  for (const event of events) {
+    webSocket.send(`42${JSON.stringify(["data", { channel, data: event }])}`);
+    await new Promise((resolve) => setTimeout(resolve, RENDER_GAP_MS));
+  }
+  webSocket.send(`42${JSON.stringify(["data", { channel, data: { type: "session_finished" } }])}`);
+}
+
+function handleSocketFrame(text: string, webSocket: MockSocket, events: readonly unknown[], opts: StreamOptions): void {
+  if (text === "2") {
+    webSocket.send("3");
+    return;
+  }
+  if (text === "40") {
+    webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
+    return;
+  }
+  if (!text.startsWith("42")) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.slice(2));
+  } catch {
+    return;
+  }
+  if (!Array.isArray(parsed)) return;
+  const [name, arg] = parsed as [string, unknown];
+  if (name !== "subscribe" || typeof arg !== "string" || !arg.startsWith("session.")) return;
+  void streamEventsToSocket(webSocket, arg, events, opts);
+}
+
+export async function mockAgentWithPubSub(page: Page, events: readonly unknown[], opts: StreamOptions = {}): Promise<void> {
+  await page.routeWebSocket(
+    (url) => url.pathname.startsWith("/ws/pubsub"),
+    (webSocket) => {
+      webSocket.send(
+        `0${JSON.stringify({
+          sid: "mock-sid",
+          upgrades: [],
+          pingInterval: 25000,
+          pingTimeout: 20000,
+          maxPayload: 1_000_000,
+        })}`,
+      );
+      webSocket.onMessage((msg) => handleSocketFrame(String(msg), webSocket, events, opts));
+    },
+  );
+
+  await page.route(urlEndsWith("/api/agent"), (route: Route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    return route.fulfill({
+      status: 202,
+      json: { chatSessionId: "mock-session" },
+    });
+  });
+}
+
+/** Wait until scrollHeight stops growing for two consecutive samples,
+ *  meaning streaming has finished and the DOM has settled. */
+export async function waitForScrollHeightStable(page: Page, testId: string, opts: { sampleGapMs?: number; maxWaitMs?: number } = {}): Promise<void> {
+  const gap = opts.sampleGapMs ?? 300;
+  const maxWait = opts.maxWaitMs ?? 10_000;
+  const deadline = Date.now() + maxWait;
+  let last = -1;
+  let stable = 0;
+  while (Date.now() < deadline) {
+    const current = await page.getByTestId(testId).evaluate((elem) => elem.scrollHeight);
+    if (current === last && current > 0) {
+      stable++;
+      if (stable >= 2) return;
+    } else {
+      stable = 0;
+      last = current;
+    }
+    await page.waitForTimeout(gap);
+  }
+}
+
+/** Read scrollTop + scrollHeight + clientHeight from a scroll container. */
+export async function scrollMetrics(page: Page, testId: string): Promise<{ scrollTop: number; scrollHeight: number; clientHeight: number }> {
+  return page.getByTestId(testId).evaluate((elem) => ({
+    scrollTop: elem.scrollTop,
+    scrollHeight: elem.scrollHeight,
+    clientHeight: elem.clientHeight,
+  }));
+}

--- a/e2e/fixtures/pubsub.ts
+++ b/e2e/fixtures/pubsub.ts
@@ -57,34 +57,37 @@ function handleSocketFrame(text: string, webSocket: MockSocket, events: readonly
   void streamEventsToSocket(webSocket, arg, events, opts);
 }
 
-export async function mockAgentWithPubSub(page: Page, events: readonly unknown[], opts: StreamOptions = {}): Promise<void> {
+// Accept the Socket.IO handshake and relay the scripted events on the
+// session channel the client subscribes to.
+async function mockPubSubSocket(page: Page, events: readonly unknown[], opts: StreamOptions): Promise<void> {
   await page.routeWebSocket(
     (url) => url.pathname.startsWith("/ws/pubsub"),
     (webSocket) => {
-      webSocket.send(
-        `0${JSON.stringify({
-          sid: "mock-sid",
-          upgrades: [],
-          pingInterval: 25000,
-          pingTimeout: 20000,
-          maxPayload: 1_000_000,
-        })}`,
-      );
+      const handshake = { sid: "mock-sid", upgrades: [], pingInterval: 25000, pingTimeout: 20000, maxPayload: 1_000_000 };
+      webSocket.send(`0${JSON.stringify(handshake)}`);
       webSocket.onMessage((msg) => handleSocketFrame(String(msg), webSocket, events, opts));
     },
   );
+}
 
+// Stub POST /api/agent so the client believes a run started.
+async function mockAgentEndpoint(page: Page): Promise<void> {
   await page.route(urlEndsWith("/api/agent"), (route: Route) => {
     if (route.request().method() !== "POST") return route.fallback();
-    return route.fulfill({
-      status: 202,
-      json: { chatSessionId: "mock-session" },
-    });
+    return route.fulfill({ status: 202, json: { chatSessionId: "mock-session" } });
   });
 }
 
+export async function mockAgentWithPubSub(page: Page, events: readonly unknown[], opts: StreamOptions = {}): Promise<void> {
+  await mockPubSubSocket(page, events, opts);
+  await mockAgentEndpoint(page);
+}
+
 /** Wait until scrollHeight stops growing for two consecutive samples,
- *  meaning streaming has finished and the DOM has settled. */
+ *  meaning streaming has finished and the DOM has settled. Throws on
+ *  timeout so a never-settling stream surfaces as a clear failure
+ *  rather than silently letting downstream assertions run on a moving
+ *  target. */
 export async function waitForScrollHeightStable(page: Page, testId: string, opts: { sampleGapMs?: number; maxWaitMs?: number } = {}): Promise<void> {
   const gap = opts.sampleGapMs ?? 300;
   const maxWait = opts.maxWaitMs ?? 10_000;
@@ -102,6 +105,7 @@ export async function waitForScrollHeightStable(page: Page, testId: string, opts
     }
     await page.waitForTimeout(gap);
   }
+  throw new Error(`waitForScrollHeightStable: "${testId}" scrollHeight never stabilised within ${maxWait}ms`);
 }
 
 /** Read scrollTop + scrollHeight + clientHeight from a scroll container. */

--- a/e2e/tests/stack-map-grouping-scroll.spec.ts
+++ b/e2e/tests/stack-map-grouping-scroll.spec.ts
@@ -1,0 +1,137 @@
+// E2E regression for session-wide map grouping in StackView (#1227 /
+// Codex review on #1504).
+//
+// Two `mapControl` results that share a `groupId` collapse into ONE
+// stack card (the View accumulates markers / routes). Grouping is
+// session-wide, not contiguous: a card belonging to a DIFFERENT group
+// can sit between the two same-group calls. That broke two assumptions
+// in StackView's scroll code, which had treated `toolResults` order as
+// 1:1 with the rendered cards:
+//
+//   * scroll-spy could flip the active card back to the merged group
+//     when a later member's uuid resolved to the group's earlier
+//     element;
+//   * the latest-result watcher always slammed scrollTop to the
+//     bottom, even when the newest result merged into an EARLIER card.
+//
+// The decision logic is unit-tested in test_stackGrouping.ts. This test
+// guards the real Vue watcher / DOM wiring (nextTick + scrollIntoView +
+// scroll-suppression) for the latest-result auto-scroll path.
+//
+// Setup: the session is PRELOADED (transcript fetch) with A(g1) and
+// B(g2) already present, so on open StackView renders two map cards.
+// Then a single live `mapControl` result C(g1) is streamed AFTER the
+// load settles (a `startDelayMs` avoids racing the transcript fetch,
+// which would otherwise overwrite live events). C's arrival fires the
+// `latestResultScrollKey` watcher with the newest result belonging to
+// the EARLIER g1 card — the exact non-contiguous shape that regressed.
+//
+// We assert C merges into the g1 card (still two cards, not three) and
+// that the watcher brings that earlier card into view rather than
+// slamming scrollTop to the bottom. All injected results are
+// `mapControl` because text-response tool results are folded into the
+// assistant text stream rather than rendered as their own card.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { mockAgentWithPubSub, waitForScrollHeightStable, scrollMetrics } from "../fixtures/pubsub";
+import { SESSION_A } from "../fixtures/sessions";
+
+import { ONE_SECOND_MS } from "../../server/utils/time.ts";
+
+// With no Google Maps API key configured (the default e2e mock), the
+// map View renders this placeholder — measurable height, no network.
+const MAP_PLACEHOLDER = "API key not configured";
+// A tall assistant turn between the g1 and g2 map cards forces the
+// stack to overflow AND separates the two cards by more than a
+// viewport — so "scrolled to the g1 card" (top) and "bottom-pinned"
+// (g2 in view, g1 off the top) are unambiguously different positions.
+const TALL_TEXT = "An assistant turn long enough to push the two map cards more than a viewport apart. ".repeat(80);
+
+function mapData(action: string, groupId: string) {
+  return { action, location: "Tokyo", groupId };
+}
+
+function mapEntry(uuid: string, action: string, groupId: string) {
+  return {
+    type: "tool_result",
+    source: "tool",
+    result: { toolName: "mapControl", uuid, message: `Map operation ${action}`, data: mapData(action, groupId) },
+  };
+}
+
+// Preloaded transcript: user text, A(g1), a tall assistant turn, then
+// B(g2). C(g1) arrives later as a live event and must merge into the
+// (now well above the fold) g1 card.
+const TRANSCRIPT_ENTRIES = [
+  { type: "session_meta", roleId: "general", sessionId: SESSION_A.id },
+  { type: "text", source: "user", message: "Plan my Tokyo trip on the map" },
+  mapEntry("map-a", "showLocation", "trip-g1"),
+  { type: "text", source: "assistant", message: TALL_TEXT },
+  mapEntry("map-b", "showLocation", "other-g2"),
+];
+
+// The live event: a new g1 marker that must merge into the (earlier)
+// g1 card, NOT create a third card or bottom-scroll.
+const LIVE_C_EVENT = {
+  type: "tool_result",
+  result: { toolName: "mapControl", uuid: "map-c", message: "Map operation addMarker", data: mapData("addMarker", "trip-g1") },
+};
+
+// The transcript fetch is a near-instant local mock; this delay only
+// has to outlast it so C appends to the loaded session rather than
+// racing the load.
+const STREAM_AFTER_LOAD_MS = 1200;
+
+async function openSessionInStackMode(page: Page): Promise<void> {
+  // Serve the custom transcript for this session; fall back to the
+  // default mock for any other session id.
+  await page.route(
+    (url) => url.pathname === `/api/sessions/${SESSION_A.id}`,
+    (route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      return route.fulfill({ json: TRANSCRIPT_ENTRIES });
+    },
+  );
+  // Stack layout is a localStorage preference; set it before navigating
+  // so the first render is already in stack mode. The default viewport
+  // gives the stack container a normal height; the tall transcript turn
+  // is what forces the overflow.
+  await page.addInitScript(() => localStorage.setItem("canvas_layout_mode", "stack"));
+  await page.goto(`/chat/${SESSION_A.id}`);
+}
+
+test.describe("StackView — session-wide map grouping (#1227)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    // Defensive: never hit the real Maps JS even if a key leaks in.
+    await page.route(/maps\.googleapis\.com/, (route) => route.abort());
+  });
+
+  test("a newly streamed same-groupId map result merges into its (earlier) card and scrolls there, not to the bottom", async ({ page }) => {
+    await mockAgentWithPubSub(page, [LIVE_C_EVENT], { startDelayMs: STREAM_AFTER_LOAD_MS });
+    await openSessionInStackMode(page);
+
+    // Preloaded state: two map cards (g1 = A, g2 = B).
+    await expect(page.getByText(MAP_PLACEHOLDER).first()).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
+    await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(2);
+
+    // C(g1) streams in after the load. It must merge into the existing
+    // g1 card — still exactly two map cards, never three.
+    await page.waitForTimeout(STREAM_AFTER_LOAD_MS);
+    await waitForScrollHeightStable(page, "stack-scroll");
+    await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(2);
+
+    // Latest-result wiring: C is the newest result but its card is the
+    // FIRST (g1) card, not the last. The fixed watcher brings that card
+    // into view; the regression slammed scrollTop to the bottom, which
+    // would push the g1 card off the top of the viewport.
+    await expect(page.getByText(MAP_PLACEHOLDER).first()).toBeInViewport();
+
+    const { scrollTop, scrollHeight, clientHeight } = await scrollMetrics(page, "stack-scroll");
+    expect(scrollHeight).toBeGreaterThan(clientHeight); // container actually overflows
+    const distanceFromBottomPx = scrollHeight - scrollTop - clientHeight;
+    const BOTTOM_TOLERANCE_PX = 50;
+    expect(distanceFromBottomPx).toBeGreaterThan(BOTTOM_TOLERANCE_PX); // NOT bottom-pinned
+  });
+});

--- a/e2e/tests/stack-map-grouping-scroll.spec.ts
+++ b/e2e/tests/stack-map-grouping-scroll.spec.ts
@@ -3,10 +3,10 @@
 //
 // Two `mapControl` results that share a `groupId` collapse into ONE
 // stack card (the View accumulates markers / routes). Grouping is
-// session-wide, not contiguous: a card belonging to a DIFFERENT group
-// can sit between the two same-group calls. That broke two assumptions
-// in StackView's scroll code, which had treated `toolResults` order as
-// 1:1 with the rendered cards:
+// session-wide, not contiguous: a card can sit between the two
+// same-group calls. That broke two assumptions in StackView's scroll
+// code, which had treated `toolResults` order as 1:1 with the rendered
+// cards:
 //
 //   * scroll-spy could flip the active card back to the merged group
 //     when a later member's uuid resolved to the group's earlier
@@ -14,25 +14,19 @@
 //   * the latest-result watcher always slammed scrollTop to the
 //     bottom, even when the newest result merged into an EARLIER card.
 //
-// The decision logic is unit-tested in test_stackGrouping.ts. This test
-// guards the real Vue watcher / DOM wiring (nextTick + scrollIntoView +
-// scroll-suppression) for the latest-result auto-scroll path.
+// The decision logic is unit-tested in test_stackGrouping.ts. These two
+// tests guard the real Vue watcher / DOM wiring (nextTick +
+// scrollIntoView + scroll-suppression + the passive scroll-spy
+// listener) for BOTH paths, over the non-contiguous `A(g1), B, C(g1)`
+// shape that regressed.
 //
-// Setup: the session is PRELOADED (transcript fetch) with A(g1) and
-// B(g2) already present, so on open StackView renders two map cards.
-// Then a single live `mapControl` result C(g1) is streamed AFTER the
-// load settles (a `startDelayMs` avoids racing the transcript fetch,
-// which would otherwise overwrite live events). C's arrival fires the
-// `latestResultScrollKey` watcher with the newest result belonging to
-// the EARLIER g1 card — the exact non-contiguous shape that regressed.
-//
-// We assert C merges into the g1 card (still two cards, not three) and
-// that the watcher brings that earlier card into view rather than
-// slamming scrollTop to the bottom. All injected results are
-// `mapControl` because text-response tool results are folded into the
-// assistant text stream rather than rendered as their own card.
+// Sessions are PRELOADED via the transcript fetch (deterministic; live
+// pub/sub events race the fetch and get overwritten). `mapControl`
+// stands in for the cards because text-response tool results are folded
+// into the assistant text stream rather than rendered as their own
+// card.
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 import { mockAgentWithPubSub, waitForScrollHeightStable, scrollMetrics } from "../fixtures/pubsub";
 import { SESSION_A } from "../fixtures/sessions";
@@ -42,11 +36,8 @@ import { ONE_SECOND_MS } from "../../server/utils/time.ts";
 // With no Google Maps API key configured (the default e2e mock), the
 // map View renders this placeholder — measurable height, no network.
 const MAP_PLACEHOLDER = "API key not configured";
-// A tall assistant turn between the g1 and g2 map cards forces the
-// stack to overflow AND separates the two cards by more than a
-// viewport — so "scrolled to the g1 card" (top) and "bottom-pinned"
-// (g2 in view, g1 off the top) are unambiguously different positions.
-const TALL_TEXT = "An assistant turn long enough to push the two map cards more than a viewport apart. ".repeat(80);
+const SELECTED_CARD_CLASS = /border-blue-400/;
+const SCROLL_SPY_TARGET = "scroll-spy target card";
 
 function mapData(action: string, groupId: string) {
   return { action, location: "Tokyo", groupId };
@@ -60,45 +51,40 @@ function mapEntry(uuid: string, action: string, groupId: string) {
   };
 }
 
-// Preloaded transcript: user text, A(g1), a tall assistant turn, then
-// B(g2). C(g1) arrives later as a live event and must merge into the
-// (now well above the fold) g1 card.
-const TRANSCRIPT_ENTRIES = [
-  { type: "session_meta", roleId: "general", sessionId: SESSION_A.id },
-  { type: "text", source: "user", message: "Plan my Tokyo trip on the map" },
-  mapEntry("map-a", "showLocation", "trip-g1"),
-  { type: "text", source: "assistant", message: TALL_TEXT },
-  mapEntry("map-b", "showLocation", "other-g2"),
-];
+function textEntry(source: "user" | "assistant", message: string) {
+  return { type: "text", source, message };
+}
 
-// The live event: a new g1 marker that must merge into the (earlier)
-// g1 card, NOT create a third card or bottom-scroll.
-const LIVE_C_EVENT = {
-  type: "tool_result",
-  result: { toolName: "mapControl", uuid: "map-c", message: "Map operation addMarker", data: mapData("addMarker", "trip-g1") },
-};
+const META_ENTRY = { type: "session_meta", roleId: "general", sessionId: SESSION_A.id };
 
-// The transcript fetch is a near-instant local mock; this delay only
-// has to outlast it so C appends to the loaded session rather than
-// racing the load.
-const STREAM_AFTER_LOAD_MS = 1200;
-
-async function openSessionInStackMode(page: Page): Promise<void> {
-  // Serve the custom transcript for this session; fall back to the
-  // default mock for any other session id.
+// Serve a custom transcript for SESSION_A; fall back to the default
+// mock for any other session id.
+async function serveTranscript(page: Page, entries: readonly unknown[]): Promise<void> {
   await page.route(
     (url) => url.pathname === `/api/sessions/${SESSION_A.id}`,
-    (route) => {
-      if (route.request().method() !== "GET") return route.fallback();
-      return route.fulfill({ json: TRANSCRIPT_ENTRIES });
-    },
+    (route) => (route.request().method() === "GET" ? route.fulfill({ json: entries }) : route.fallback()),
   );
-  // Stack layout is a localStorage preference; set it before navigating
-  // so the first render is already in stack mode. The default viewport
-  // gives the stack container a normal height; the tall transcript turn
-  // is what forces the overflow.
+}
+
+// Stack layout is a localStorage preference; set it before navigating
+// so the first render is already in stack mode.
+async function openStackSession(page: Page): Promise<void> {
   await page.addInitScript(() => localStorage.setItem("canvas_layout_mode", "stack"));
   await page.goto(`/chat/${SESSION_A.id}`);
+  await expect(page.getByText(MAP_PLACEHOLDER).first()).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
+}
+
+// A stack card is a direct child of the scroll container; locate one by
+// the text it contains.
+function stackCard(page: Page, hasText: string | RegExp): Locator {
+  return page.getByTestId("stack-scroll").locator("> div").filter({ hasText });
+}
+
+async function expectNotBottomPinned(page: Page): Promise<void> {
+  const { scrollTop, scrollHeight, clientHeight } = await scrollMetrics(page, "stack-scroll");
+  expect(scrollHeight).toBeGreaterThan(clientHeight); // container actually overflows
+  const BOTTOM_TOLERANCE_PX = 50;
+  expect(scrollHeight - scrollTop - clientHeight).toBeGreaterThan(BOTTOM_TOLERANCE_PX);
 }
 
 test.describe("StackView — session-wide map grouping (#1227)", () => {
@@ -108,30 +94,69 @@ test.describe("StackView — session-wide map grouping (#1227)", () => {
     await page.route(/maps\.googleapis\.com/, (route) => route.abort());
   });
 
-  test("a newly streamed same-groupId map result merges into its (earlier) card and scrolls there, not to the bottom", async ({ page }) => {
-    await mockAgentWithPubSub(page, [LIVE_C_EVENT], { startDelayMs: STREAM_AFTER_LOAD_MS });
-    await openSessionInStackMode(page);
+  // ── latest-result auto-scroll path (`latestResultScrollKey` watcher) ──
+  //
+  // Preload A(g1) + B(g2); stream a live C(g1) AFTER the load settles (a
+  // startDelayMs avoids racing the transcript fetch). C's arrival fires
+  // the watcher with the newest result belonging to the EARLIER g1 card.
+  // A tall turn between the two map cards separates them by more than a
+  // viewport, so "scrolled to g1" and "bottom-pinned" are distinct.
+  test("a newly streamed same-groupId result merges into its earlier card and scrolls there, not to the bottom", async ({ page }) => {
+    const tallTurn = textEntry("assistant", "An assistant turn long enough to push the two map cards a viewport apart. ".repeat(80));
+    const transcript = [
+      META_ENTRY,
+      textEntry("user", "Plan my Tokyo trip"),
+      mapEntry("map-a", "showLocation", "trip-g1"),
+      tallTurn,
+      mapEntry("map-b", "showLocation", "other-g2"),
+    ];
+    const liveC = { type: "tool_result", result: { toolName: "mapControl", uuid: "map-c", message: "addMarker", data: mapData("addMarker", "trip-g1") } };
+    const streamAfterLoadMs = 1200;
 
-    // Preloaded state: two map cards (g1 = A, g2 = B).
-    await expect(page.getByText(MAP_PLACEHOLDER).first()).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
-    await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(2);
+    await serveTranscript(page, transcript);
+    await mockAgentWithPubSub(page, [liveC], { startDelayMs: streamAfterLoadMs });
+    await openStackSession(page);
+    await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(2); // g1 = A, g2 = B
 
-    // C(g1) streams in after the load. It must merge into the existing
-    // g1 card — still exactly two map cards, never three.
-    await page.waitForTimeout(STREAM_AFTER_LOAD_MS);
+    await page.waitForTimeout(streamAfterLoadMs);
     await waitForScrollHeightStable(page, "stack-scroll");
+
+    // C merged into the g1 card — still two cards, never three — and the
+    // watcher scrolled to that (first) card rather than the bottom.
     await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(2);
-
-    // Latest-result wiring: C is the newest result but its card is the
-    // FIRST (g1) card, not the last. The fixed watcher brings that card
-    // into view; the regression slammed scrollTop to the bottom, which
-    // would push the g1 card off the top of the viewport.
     await expect(page.getByText(MAP_PLACEHOLDER).first()).toBeInViewport();
+    await expectNotBottomPinned(page);
+  });
 
-    const { scrollTop, scrollHeight, clientHeight } = await scrollMetrics(page, "stack-scroll");
-    expect(scrollHeight).toBeGreaterThan(clientHeight); // container actually overflows
-    const distanceFromBottomPx = scrollHeight - scrollTop - clientHeight;
-    const BOTTOM_TOLERANCE_PX = 50;
-    expect(distanceFromBottomPx).toBeGreaterThan(BOTTOM_TOLERANCE_PX); // NOT bottom-pinned
+  // ── scroll-spy active-card path (`computeActiveUuidFromScroll`) ──
+  //
+  // Preload the full non-contiguous sequence A(g1), B(text), C(g1): the
+  // g1 group (A, C) renders first, the B text card last. Scrolling to B
+  // must select B — the regression resolved B's neighbour C back to the
+  // group element above and wrongly selected the group instead.
+  test("scrolling to the B card selects B, not the merged group whose member arrived after B", async ({ page }) => {
+    const tallTargetText = `${SCROLL_SPY_TARGET}. `.repeat(120);
+    const transcript = [
+      META_ENTRY,
+      textEntry("user", "Plan my Tokyo trip"),
+      mapEntry("map-a", "showLocation", "trip-g1"),
+      textEntry("assistant", tallTargetText),
+      mapEntry("map-c", "addMarker", "trip-g1"),
+    ];
+
+    await serveTranscript(page, transcript);
+    await openStackSession(page);
+    await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(1); // A + C merged into one g1 card
+
+    // Let the load's auto-scroll + its suppression window clear, then
+    // scroll to the bottom so the B card's top crosses the active line.
+    await page.waitForTimeout(500);
+    await page.getByTestId("stack-scroll").hover();
+    await page.mouse.wheel(0, 6000);
+
+    // Scroll-spy selected B (highlight ring), not the earlier g1 group
+    // whose later member (C) sits above B in the flat result list.
+    await expect(stackCard(page, SCROLL_SPY_TARGET)).toHaveClass(SELECTED_CARD_CLASS);
+    await expect(stackCard(page, MAP_PLACEHOLDER)).not.toHaveClass(SELECTED_CARD_CLASS);
   });
 });

--- a/e2e/tests/streaming-autoscroll.spec.ts
+++ b/e2e/tests/streaming-autoscroll.spec.ts
@@ -13,14 +13,11 @@
 // Stack mode) because a future refactor that introduces a new view
 // mode with its own scroll container must extend the same pattern.
 
-import { test, expect, type Page, type Route } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
+import { mockAgentWithPubSub, waitForScrollHeightStable, scrollMetrics } from "../fixtures/pubsub";
 
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
-
-function urlEndsWith(suffix: string): (url: URL) => boolean {
-  return (url) => url.pathname === suffix;
-}
 
 // Build a streaming transcript: the first text event creates the
 // assistant card (length 0 → 1), every subsequent event appends to
@@ -32,94 +29,6 @@ function buildStreamingEvents(chunkCount: number, chunkBody: string) {
     type: "text",
     source: "assistant",
     message: chunkBody,
-  }));
-}
-
-// Relay a sequence of pub/sub events to the mocked WebSocket with a
-// small gap between each send so Vue re-renders between chunks.
-async function streamEventsToSocket(webSocket: { send: (data: string) => void }, channel: string, events: readonly unknown[]): Promise<void> {
-  for (const event of events) {
-    webSocket.send(`42${JSON.stringify(["data", { channel, data: event }])}`);
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  webSocket.send(`42${JSON.stringify(["data", { channel, data: { type: "session_finished" } }])}`);
-}
-
-function handleSocketFrame(text: string, webSocket: { send: (data: string) => void }, events: readonly unknown[]): void {
-  if (text === "2") {
-    webSocket.send("3");
-    return;
-  }
-  if (text === "40") {
-    webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
-    return;
-  }
-  if (!text.startsWith("42")) return;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text.slice(2));
-  } catch {
-    return;
-  }
-  if (!Array.isArray(parsed)) return;
-  const [name, arg] = parsed as [string, unknown];
-  if (name !== "subscribe" || typeof arg !== "string" || !arg.startsWith("session.")) return;
-  void streamEventsToSocket(webSocket, arg, events);
-}
-
-async function mockAgentWithPubSub(page: Page, events: readonly unknown[]): Promise<void> {
-  await page.routeWebSocket(
-    (url) => url.pathname.startsWith("/ws/pubsub"),
-    (webSocket) => {
-      webSocket.send(
-        `0${JSON.stringify({
-          sid: "mock-sid",
-          upgrades: [],
-          pingInterval: 25000,
-          pingTimeout: 20000,
-          maxPayload: 1_000_000,
-        })}`,
-      );
-      webSocket.onMessage((msg) => handleSocketFrame(String(msg), webSocket, events));
-    },
-  );
-
-  await page.route(urlEndsWith("/api/agent"), (route: Route) => {
-    if (route.request().method() !== "POST") return route.fallback();
-    return route.fulfill({
-      status: 202,
-      json: { chatSessionId: "mock-session" },
-    });
-  });
-}
-
-/** Wait until scrollHeight stops growing for two consecutive samples,
- *  meaning the streaming has finished and the DOM has settled. */
-async function waitForScrollHeightStable(page: Page, testId: string, opts: { sampleGapMs?: number; maxWaitMs?: number } = {}): Promise<void> {
-  const gap = opts.sampleGapMs ?? 300;
-  const maxWait = opts.maxWaitMs ?? 10_000;
-  const deadline = Date.now() + maxWait;
-  let last = -1;
-  let stable = 0;
-  while (Date.now() < deadline) {
-    const current = await page.getByTestId(testId).evaluate((elem) => elem.scrollHeight);
-    if (current === last && current > 0) {
-      stable++;
-      if (stable >= 2) return;
-    } else {
-      stable = 0;
-      last = current;
-    }
-    await page.waitForTimeout(gap);
-  }
-}
-
-/** Read scrollTop + scrollHeight + clientHeight from a scroll container. */
-async function scrollMetrics(page: Page, testId: string): Promise<{ scrollTop: number; scrollHeight: number; clientHeight: number }> {
-  return page.getByTestId(testId).evaluate((elem) => ({
-    scrollTop: elem.scrollTop,
-    scrollHeight: elem.scrollHeight,
-    clientHeight: elem.clientHeight,
   }));
 }
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@google/genai": "^2.2.0",
     "@gui-chat-plugin/browse": "^0.4.0",
     "@gui-chat-plugin/camera": "^0.4.1",
-    "@gui-chat-plugin/google-map": "^0.4.2",
+    "@gui-chat-plugin/google-map": "^0.5.0",
     "@gui-chat-plugin/mindmap": "^0.4.1",
     "@gui-chat-plugin/present3d": "^0.4.1",
     "@mulmobridge/client": "^0.1.0",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -23,7 +23,7 @@
     "@google/genai": "^2.2.0",
     "@gui-chat-plugin/browse": "^0.4.0",
     "@gui-chat-plugin/camera": "^0.4.1",
-    "@gui-chat-plugin/google-map": "^0.4.2",
+    "@gui-chat-plugin/google-map": "^0.5.0",
     "@gui-chat-plugin/mindmap": "^0.4.1",
     "@gui-chat-plugin/present3d": "^0.4.1",
     "@mulmobridge/chat-service": "^0.1.2",

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -40,7 +40,7 @@
         >
           <span class="material-icons text-sm text-gray-400">{{ iconFor(item.head.toolName) }}</span>
           <span class="text-sm font-medium text-gray-800 truncate">{{ item.head.title || item.head.toolName }}</span>
-          <span v-if="item.isMapGroup && item.members.length > 1" class="text-[10px] text-gray-400 shrink-0">{{ `${item.members.length}×` }}</span>
+          <span v-if="item.isGroup && item.members.length > 1" class="text-[10px] text-gray-400 shrink-0">{{ `${item.members.length}×` }}</span>
           <span v-if="resultTimestamps.get(item.head.uuid)" class="text-[10px] text-gray-400 shrink-0">{{
             formatSmartTime(resultTimestamps.get(item.head.uuid)!)
           }}</span>
@@ -90,7 +90,7 @@
             v-if="getPlugin(item.head.toolName)?.viewComponent"
             :key="`${item.key}-${googleMapKeyFor(item.head.toolName) ?? ''}`"
             :selected-result="item.head"
-            :results="item.isMapGroup ? item.members : undefined"
+            :results="item.isGroup ? item.members : undefined"
             :send-text-message="sendTextMessage"
             :google-map-key="googleMapKeyFor(item.head.toolName)"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
@@ -114,6 +114,7 @@ import { clampIframeHeight } from "../utils/dom/iframeHeightClamp";
 import type { TextResponseData } from "../plugins/textResponse/types";
 import { formatSmartTime } from "../utils/format/date";
 import { isRecord } from "../utils/types";
+import { buildStackDisplayItems } from "../utils/canvas/stackGrouping";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
 import CopyChatButton from "./CopyChatButton.vue";
 import type { LayoutMode } from "../utils/canvas/layoutMode";
@@ -206,20 +207,10 @@ function setNaturalWrapperRef(uuid: string, element: HTMLElement | null): void {
   }
 }
 
-// One rendered card per display item. A `mapControl` result carrying
-// a `groupId` collapses with every other result of the same groupId
-// into ONE card (positioned at the group's first occurrence), so the
-// markers / routes accumulate on one shared map instead of spawning a
-// card per call. `members` holds the group's results in order;
-// `head` is the latest one (drives the header + legacy View fields).
-// Non-grouped results stay as singletons (members = [head]).
-interface DisplayItem {
-  key: string;
-  head: ToolResultComplete;
-  members: ToolResultComplete[];
-  isMapGroup: boolean;
-}
-
+// `mapControl` results carrying a `groupId` collapse into one card
+// (the View accumulates markers / routes). Grouping is session-wide,
+// so `displayItems` is the rendered card order — scroll-spy below
+// iterates THIS, not the flat `toolResults`. See stackGrouping.ts.
 function groupIdOf(result: ToolResultComplete): string | null {
   if (result.toolName !== TOOL_NAMES.mapControl) return null;
   const { data } = result;
@@ -228,26 +219,7 @@ function groupIdOf(result: ToolResultComplete): string | null {
   return typeof groupId === "string" && groupId.length > 0 ? groupId : null;
 }
 
-const displayItems = computed<DisplayItem[]>(() => {
-  const items: DisplayItem[] = [];
-  const groupIndexById = new Map<string, number>();
-  for (const result of props.toolResults) {
-    const groupId = groupIdOf(result);
-    if (groupId !== null) {
-      const existingIndex = groupIndexById.get(groupId);
-      if (existingIndex !== undefined) {
-        items[existingIndex].members.push(result);
-        items[existingIndex].head = result; // latest call drives the header
-        continue;
-      }
-      groupIndexById.set(groupId, items.length);
-      items.push({ key: `mapgroup:${groupId}`, head: result, members: [result], isMapGroup: true });
-    } else {
-      items.push({ key: result.uuid, head: result, members: [result], isMapGroup: false });
-    }
-  }
-  return items;
-});
+const displayItems = computed(() => buildStackDisplayItems(props.toolResults, groupIdOf, (result) => result.uuid));
 
 // Register the group card element under EVERY member uuid so the
 // scroll-spy and scroll-to-selection logic (which key on individual
@@ -424,11 +396,17 @@ function computeActiveUuidFromScroll(): string | null {
   const container = containerRef.value;
   const paddedTop = container.getBoundingClientRect().top + readPaddingTop(container);
   let activeUuid: string | null = null;
-  for (const result of props.toolResults) {
-    const element = itemRefs.get(result.uuid);
+  // Iterate RENDERED card order (`displayItems`), not the flat
+  // `toolResults`. A merged map group shares one DOM element across
+  // multiple member uuids; walking `toolResults` would let a later
+  // member (positioned after a non-grouped card) resolve back to the
+  // group's earlier element and wrongly win the active slot. Each
+  // card resolves via its head uuid; the head uuid is what we emit.
+  for (const item of displayItems.value) {
+    const element = itemRefs.get(item.head.uuid);
     if (!element) continue;
     if (element.getBoundingClientRect().top <= paddedTop) {
-      activeUuid = result.uuid;
+      activeUuid = item.head.uuid;
     } else {
       break;
     }

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -27,23 +27,24 @@
     </div>
     <div v-else ref="containerRef" class="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3" data-testid="stack-scroll">
       <div
-        v-for="result in toolResults"
-        :key="result.uuid"
-        :ref="(element) => setItemRef(result.uuid, element as HTMLElement | null)"
+        v-for="item in displayItems"
+        :key="item.key"
+        :ref="(element) => setItemRefForMembers(item.members, element as HTMLElement | null)"
         class="bg-white rounded-lg border transition-colors"
-        :class="result.uuid === selectedResultUuid ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'"
+        :class="item.members.some((m) => m.uuid === selectedResultUuid) ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'"
       >
         <button
           class="w-full flex items-center gap-2 px-3 py-2 border-b border-gray-100 text-left hover:bg-gray-50"
-          :title="result.title || result.toolName"
-          @click="emit('select', result.uuid)"
+          :title="item.head.title || item.head.toolName"
+          @click="emit('select', item.head.uuid)"
         >
-          <span class="material-icons text-sm text-gray-400">{{ iconFor(result.toolName) }}</span>
-          <span class="text-sm font-medium text-gray-800 truncate">{{ result.title || result.toolName }}</span>
-          <span v-if="resultTimestamps.get(result.uuid)" class="text-[10px] text-gray-400 shrink-0">{{
-            formatSmartTime(resultTimestamps.get(result.uuid)!)
+          <span class="material-icons text-sm text-gray-400">{{ iconFor(item.head.toolName) }}</span>
+          <span class="text-sm font-medium text-gray-800 truncate">{{ item.head.title || item.head.toolName }}</span>
+          <span v-if="item.isMapGroup && item.members.length > 1" class="text-[10px] text-gray-400 shrink-0">{{ `${item.members.length}×` }}</span>
+          <span v-if="resultTimestamps.get(item.head.uuid)" class="text-[10px] text-gray-400 shrink-0">{{
+            formatSmartTime(resultTimestamps.get(item.head.uuid)!)
           }}</span>
-          <span class="font-mono text-xs text-gray-400 shrink-0">{{ result.toolName }}</span>
+          <span class="font-mono text-xs text-gray-400 shrink-0">{{ item.head.toolName }}</span>
         </button>
         <!-- text-response: render the message as Markdown via the
            underlying plugin View. The .stack-text-response class below
@@ -56,8 +57,8 @@
            "open external links in a new tab" click handler. Attach
            the same handler here via @click.capture so cross-origin
            links in assistant Markdown don't navigate the SPA away. -->
-        <div v-if="isTextResponse(result)" class="stack-text-response" @click.capture="handleExternalLinkClick">
-          <TextResponseOriginalView :selected-result="result" />
+        <div v-if="isTextResponse(item.head)" class="stack-text-response" @click.capture="handleExternalLinkClick">
+          <TextResponseOriginalView :selected-result="item.head" />
         </div>
         <!-- Document-like plugins: let the content flow at its natural
            height by overriding the plugin's internal h-full / overflow
@@ -65,33 +66,36 @@
            plugins that embed iframes (e.g. presentHtml) we also size
            each iframe to its content after load. -->
         <div
-          v-else-if="isStackNatural(result.toolName)"
-          :ref="(element) => setNaturalWrapperRef(result.uuid, element as HTMLElement | null)"
+          v-else-if="isStackNatural(item.head.toolName)"
+          :ref="(element) => setNaturalWrapperRef(item.head.uuid, element as HTMLElement | null)"
           class="stack-natural"
         >
           <component
-            :is="getPlugin(result.toolName)?.viewComponent"
-            v-if="getPlugin(result.toolName)?.viewComponent"
-            :key="`${result.uuid}-${googleMapKeyFor(result.toolName) ?? ''}`"
-            :selected-result="result"
+            :is="getPlugin(item.head.toolName)?.viewComponent"
+            v-if="getPlugin(item.head.toolName)?.viewComponent"
+            :key="`${item.key}-${googleMapKeyFor(item.head.toolName) ?? ''}`"
+            :selected-result="item.head"
             :send-text-message="sendTextMessage"
-            :google-map-key="googleMapKeyFor(result.toolName)"
+            :google-map-key="googleMapKeyFor(item.head.toolName)"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
           />
         </div>
         <!-- Other plugins: fixed height wrapper so plugins that rely on
-           h-full continue to render properly. -->
+           h-full continue to render properly. Map groups pass the
+           ordered `results` so the View replays the whole group onto
+           one map; everything else uses the single `selected-result`. -->
         <div v-else :style="{ height: PLUGIN_HEIGHT }">
           <component
-            :is="getPlugin(result.toolName)?.viewComponent"
-            v-if="getPlugin(result.toolName)?.viewComponent"
-            :key="`${result.uuid}-${googleMapKeyFor(result.toolName) ?? ''}`"
-            :selected-result="result"
+            :is="getPlugin(item.head.toolName)?.viewComponent"
+            v-if="getPlugin(item.head.toolName)?.viewComponent"
+            :key="`${item.key}-${googleMapKeyFor(item.head.toolName) ?? ''}`"
+            :selected-result="item.head"
+            :results="item.isMapGroup ? item.members : undefined"
             :send-text-message="sendTextMessage"
-            :google-map-key="googleMapKeyFor(result.toolName)"
+            :google-map-key="googleMapKeyFor(item.head.toolName)"
             @update-result="(r: ToolResultComplete) => emit('updateResult', r)"
           />
-          <pre v-else class="h-full overflow-auto p-4 text-xs text-gray-500 whitespace-pre-wrap">{{ JSON.stringify(result, null, 2) }}</pre>
+          <pre v-else class="h-full overflow-auto p-4 text-xs text-gray-500 whitespace-pre-wrap">{{ JSON.stringify(item.head, null, 2) }}</pre>
         </div>
       </div>
     </div>
@@ -200,6 +204,56 @@ function setNaturalWrapperRef(uuid: string, element: HTMLElement | null): void {
   } else {
     naturalWrapperRefs.delete(uuid);
   }
+}
+
+// One rendered card per display item. A `mapControl` result carrying
+// a `groupId` collapses with every other result of the same groupId
+// into ONE card (positioned at the group's first occurrence), so the
+// markers / routes accumulate on one shared map instead of spawning a
+// card per call. `members` holds the group's results in order;
+// `head` is the latest one (drives the header + legacy View fields).
+// Non-grouped results stay as singletons (members = [head]).
+interface DisplayItem {
+  key: string;
+  head: ToolResultComplete;
+  members: ToolResultComplete[];
+  isMapGroup: boolean;
+}
+
+function groupIdOf(result: ToolResultComplete): string | null {
+  if (result.toolName !== TOOL_NAMES.mapControl) return null;
+  const { data } = result;
+  if (!isRecord(data)) return null;
+  const { groupId } = data;
+  return typeof groupId === "string" && groupId.length > 0 ? groupId : null;
+}
+
+const displayItems = computed<DisplayItem[]>(() => {
+  const items: DisplayItem[] = [];
+  const groupIndexById = new Map<string, number>();
+  for (const result of props.toolResults) {
+    const groupId = groupIdOf(result);
+    if (groupId !== null) {
+      const existingIndex = groupIndexById.get(groupId);
+      if (existingIndex !== undefined) {
+        items[existingIndex].members.push(result);
+        items[existingIndex].head = result; // latest call drives the header
+        continue;
+      }
+      groupIndexById.set(groupId, items.length);
+      items.push({ key: `mapgroup:${groupId}`, head: result, members: [result], isMapGroup: true });
+    } else {
+      items.push({ key: result.uuid, head: result, members: [result], isMapGroup: false });
+    }
+  }
+  return items;
+});
+
+// Register the group card element under EVERY member uuid so the
+// scroll-spy and scroll-to-selection logic (which key on individual
+// result uuids) resolve any member to this one card.
+function setItemRefForMembers(members: ToolResultComplete[], element: HTMLElement | null): void {
+  for (const member of members) setItemRef(member.uuid, element);
 }
 
 // Sandboxed iframes inside stack-natural plugins (e.g. presentHtml)

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -114,7 +114,7 @@ import { clampIframeHeight } from "../utils/dom/iframeHeightClamp";
 import type { TextResponseData } from "../plugins/textResponse/types";
 import { formatSmartTime } from "../utils/format/date";
 import { isRecord } from "../utils/types";
-import { buildStackDisplayItems } from "../utils/canvas/stackGrouping";
+import { buildStackDisplayItems, pickActiveCardUuid, resolveLatestScrollTarget } from "../utils/canvas/stackGrouping";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
 import CopyChatButton from "./CopyChatButton.vue";
 import type { LayoutMode } from "../utils/canvas/layoutMode";
@@ -394,24 +394,12 @@ function readPaddingTop(element: HTMLElement): number {
 function computeActiveUuidFromScroll(): string | null {
   if (!containerRef.value) return null;
   const container = containerRef.value;
-  const paddedTop = container.getBoundingClientRect().top + readPaddingTop(container);
-  let activeUuid: string | null = null;
-  // Iterate RENDERED card order (`displayItems`), not the flat
-  // `toolResults`. A merged map group shares one DOM element across
-  // multiple member uuids; walking `toolResults` would let a later
-  // member (positioned after a non-grouped card) resolve back to the
-  // group's earlier element and wrongly win the active slot. Each
-  // card resolves via its head uuid; the head uuid is what we emit.
-  for (const item of displayItems.value) {
-    const element = itemRefs.get(item.head.uuid);
-    if (!element) continue;
-    if (element.getBoundingClientRect().top <= paddedTop) {
-      activeUuid = item.head.uuid;
-    } else {
-      break;
-    }
-  }
-  return activeUuid;
+  const paddedTopPx = container.getBoundingClientRect().top + readPaddingTop(container);
+  const topOfCardPx = (headUuid: string): number | null => {
+    const element = itemRefs.get(headUuid);
+    return element ? element.getBoundingClientRect().top : null;
+  };
+  return pickActiveCardUuid(displayItems.value, (result) => result.uuid, topOfCardPx, paddedTopPx);
 }
 
 function onContainerScroll(): void {
@@ -463,22 +451,12 @@ watch(latestResultScrollKey, () => {
   nextTick(() => {
     if (containerRef.value) {
       beginSuppressScrollSync();
-      // The newest result usually creates/extends the BOTTOM card →
-      // scroll to the bottom. But with session-wide map grouping it
-      // can merge into an EARLIER group card; jumping to the bottom
-      // would scroll away from where the update actually rendered.
-      // So: bottom-scroll only when the newest result is in the last
-      // card; otherwise bring its (earlier) card into view (Codex
-      // review on #1504).
-      const items = displayItems.value;
       const newest = props.toolResults[props.toolResults.length - 1];
-      const lastCard = items[items.length - 1];
-      const newestInLastCard = newest !== undefined && lastCard !== undefined && lastCard.members.some((member) => member.uuid === newest.uuid);
-      if (newestInLastCard) {
+      const target = resolveLatestScrollTarget(displayItems.value, newest, (result) => result.uuid);
+      if (target.kind === "bottom") {
         containerRef.value.scrollTop = containerRef.value.scrollHeight;
-      } else if (newest) {
-        const card = items.find((item) => item.members.some((member) => member.uuid === newest.uuid));
-        const element = card ? itemRefs.get(card.head.uuid) : null;
+      } else if (target.kind === "card") {
+        const element = itemRefs.get(target.headUuid);
         if (element) element.scrollIntoView({ block: "nearest", behavior: "auto" });
       }
     }

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -467,10 +467,22 @@ watch(latestResultScrollKey, () => {
   });
 });
 
+// The scroll container lives in the `v-else` branch (rendered only once
+// `toolResults` is non-empty). Sessions mount empty — the transcript /
+// stream populates them after mount — so binding the scroll-spy listener
+// in `onMounted` would attach it to a null ref and never fire. Watch the
+// ref instead so the listener (re)binds whenever the container appears
+// or is replaced.
+watch(
+  containerRef,
+  (element, previous) => {
+    previous?.removeEventListener("scroll", onContainerScroll);
+    element?.addEventListener("scroll", onContainerScroll, { passive: true });
+  },
+  { immediate: true },
+);
+
 onMounted(() => {
-  containerRef.value?.addEventListener("scroll", onContainerScroll, {
-    passive: true,
-  });
   window.addEventListener("message", handleIframeHeightMessage);
   // Align the initial scroll position with the externally selected
   // item so the sidebar and stack start in sync on mount.

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -463,7 +463,24 @@ watch(latestResultScrollKey, () => {
   nextTick(() => {
     if (containerRef.value) {
       beginSuppressScrollSync();
-      containerRef.value.scrollTop = containerRef.value.scrollHeight;
+      // The newest result usually creates/extends the BOTTOM card →
+      // scroll to the bottom. But with session-wide map grouping it
+      // can merge into an EARLIER group card; jumping to the bottom
+      // would scroll away from where the update actually rendered.
+      // So: bottom-scroll only when the newest result is in the last
+      // card; otherwise bring its (earlier) card into view (Codex
+      // review on #1504).
+      const items = displayItems.value;
+      const newest = props.toolResults[props.toolResults.length - 1];
+      const lastCard = items[items.length - 1];
+      const newestInLastCard = newest !== undefined && lastCard !== undefined && lastCard.members.some((member) => member.uuid === newest.uuid);
+      if (newestInLastCard) {
+        containerRef.value.scrollTop = containerRef.value.scrollHeight;
+      } else if (newest) {
+        const card = items.find((item) => item.members.some((member) => member.uuid === newest.uuid));
+        const element = card ? itemRefs.get(card.head.uuid) : null;
+        if (element) element.scrollIntoView({ block: "nearest", behavior: "auto" });
+      }
     }
     // New items may have brought in more iframes to size.
     for (const wrapper of naturalWrapperRefs.values()) {

--- a/src/utils/canvas/stackGrouping.ts
+++ b/src/utils/canvas/stackGrouping.ts
@@ -1,0 +1,52 @@
+// Collapse a flat tool-result list into the cards StackView renders.
+//
+// Most results are their own card. Results that share a non-null
+// group key (today: `mapControl` results with the same `groupId`)
+// collapse into ONE card, positioned at the group's FIRST occurrence,
+// with every later same-group result appended to `members` in order.
+// `head` is the latest member (drives the card header + the View's
+// legacy single-result fields).
+//
+// Grouping is session-wide, not contiguous: `A(g1), B, C(g1)` yields
+// two cards — the g1 group `[A, C]` at index 0 and `B` at index 1.
+// The card order returned here is the DOM order StackView renders, so
+// scroll-spy / active-item logic MUST iterate THIS, not the original
+// flat result list (a member that maps back to an earlier card would
+// otherwise corrupt the active-item computation — Codex review on
+// #1504).
+
+export interface StackDisplayItem<T> {
+  /** Stable v-for key: `group:<key>` for groups, the uuid otherwise. */
+  key: string;
+  /** Latest member — header + single-result View props derive from it. */
+  head: T;
+  /** All results in this card, in arrival order (1 for singletons). */
+  members: T[];
+  /** True when this card merges a multi-call group. */
+  isGroup: boolean;
+}
+
+export function buildStackDisplayItems<T>(
+  results: readonly T[],
+  groupKeyOf: (result: T) => string | null,
+  uuidOf: (result: T) => string,
+): StackDisplayItem<T>[] {
+  const items: StackDisplayItem<T>[] = [];
+  const indexByGroupKey = new Map<string, number>();
+  for (const result of results) {
+    const groupKey = groupKeyOf(result);
+    if (groupKey !== null) {
+      const existing = indexByGroupKey.get(groupKey);
+      if (existing !== undefined) {
+        items[existing].members.push(result);
+        items[existing].head = result; // latest call drives the header
+        continue;
+      }
+      indexByGroupKey.set(groupKey, items.length);
+      items.push({ key: `group:${groupKey}`, head: result, members: [result], isGroup: true });
+    } else {
+      items.push({ key: uuidOf(result), head: result, members: [result], isGroup: false });
+    }
+  }
+  return items;
+}

--- a/src/utils/canvas/stackGrouping.ts
+++ b/src/utils/canvas/stackGrouping.ts
@@ -50,3 +50,47 @@ export function buildStackDisplayItems<T>(
   }
   return items;
 }
+
+// Scroll-spy core: given the rendered cards (already in DOM order) and a
+// way to read each card's top coordinate, return the canonical uuid of
+// the LAST card whose top edge is at or above `paddedTopPx`. Iterating
+// `StackDisplayItem`s — not the flat result list — is the whole point:
+// a merged group shares one element across several member uuids, so a
+// flat walk would let a later member resolve back to the group's
+// earlier element and wrongly win the active slot (Codex review on
+// #1504). The early `break` relies on cards being top-sorted, which
+// the rendered order guarantees.
+export function pickActiveCardUuid<T>(
+  items: readonly StackDisplayItem<T>[],
+  uuidOf: (result: T) => string,
+  topOfCardPx: (headUuid: string) => number | null,
+  paddedTopPx: number,
+): string | null {
+  let activeUuid: string | null = null;
+  for (const item of items) {
+    const headUuid = uuidOf(item.head);
+    const topPx = topOfCardPx(headUuid);
+    if (topPx === null) continue;
+    if (topPx <= paddedTopPx) activeUuid = headUuid;
+    else break;
+  }
+  return activeUuid;
+}
+
+export type LatestScrollTarget = { kind: "bottom" } | { kind: "card"; headUuid: string } | { kind: "none" };
+
+// Where to scroll when a new result arrives. Usually the newest result
+// creates/extends the BOTTOM card → scroll to the bottom. But session-
+// wide grouping can merge a new result into an EARLIER card, so bottom-
+// scrolling would jump away from where it rendered. Returns `bottom`
+// only when the newest result lands in the last card; otherwise the
+// (earlier) card to bring into view (Codex review on #1504).
+export function resolveLatestScrollTarget<T>(items: readonly StackDisplayItem<T>[], newest: T | undefined, uuidOf: (result: T) => string): LatestScrollTarget {
+  if (newest === undefined) return { kind: "none" };
+  const newestUuid = uuidOf(newest);
+  const containsNewest = (item: StackDisplayItem<T>): boolean => item.members.some((member) => uuidOf(member) === newestUuid);
+  const lastCard = items[items.length - 1];
+  if (lastCard !== undefined && containsNewest(lastCard)) return { kind: "bottom" };
+  const card = items.find(containsNewest);
+  return card === undefined ? { kind: "none" } : { kind: "card", headUuid: uuidOf(card.head) };
+}

--- a/test/utils/canvas/test_stackGrouping.ts
+++ b/test/utils/canvas/test_stackGrouping.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildStackDisplayItems } from "../../../src/utils/canvas/stackGrouping.js";
+
+// Minimal result shape the grouper needs.
+interface Row {
+  uuid: string;
+  group: string | null;
+}
+const groupKeyOf = (row: Row): string | null => row.group;
+const uuidOf = (row: Row): string => row.uuid;
+const build = (rows: Row[]) => buildStackDisplayItems(rows, groupKeyOf, uuidOf);
+
+describe("buildStackDisplayItems", () => {
+  it("keeps ungrouped results as one card each, in order", () => {
+    const items = build([
+      { uuid: "a", group: null },
+      { uuid: "b", group: null },
+    ]);
+    assert.equal(items.length, 2);
+    assert.deepEqual(
+      items.map((item) => item.head.uuid),
+      ["a", "b"],
+    );
+    assert.equal(
+      items.every((i) => !i.isGroup),
+      true,
+    );
+    assert.equal(
+      items.every((item) => item.members.length === 1),
+      true,
+    );
+  });
+
+  it("collapses consecutive same-group results into one card with members in order", () => {
+    const items = build([
+      { uuid: "a", group: "g1" },
+      { uuid: "b", group: "g1" },
+      { uuid: "c", group: "g1" },
+    ]);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].isGroup, true);
+    assert.deepEqual(
+      items[0].members.map((member) => member.uuid),
+      ["a", "b", "c"],
+    );
+    assert.equal(items[0].head.uuid, "c", "head is the latest member");
+    assert.equal(items[0].key, "group:g1");
+  });
+
+  it("merges NON-contiguous same-group results at the first occurrence (Codex #1504)", () => {
+    // A(g1), B(text), C(g1) → two cards: the g1 group [A, C] at index 0
+    // (A's slot), and B at index 1. C must NOT create a third card, and
+    // the group must stay at A's position so rendered order is
+    // [g1, B] — what scroll-spy iterates.
+    const items = build([
+      { uuid: "a", group: "g1" },
+      { uuid: "b", group: null },
+      { uuid: "c", group: "g1" },
+    ]);
+    assert.equal(items.length, 2, "C merges into the existing g1 card, not a new one");
+    assert.equal(items[0].key, "group:g1");
+    assert.deepEqual(
+      items[0].members.map((member) => member.uuid),
+      ["a", "c"],
+    );
+    assert.equal(items[0].head.uuid, "c", "head follows the latest call");
+    assert.equal(items[1].head.uuid, "b");
+    assert.equal(items[1].isGroup, false);
+  });
+
+  it("keeps distinct groups as distinct cards in first-occurrence order", () => {
+    const items = build([
+      { uuid: "a", group: "g1" },
+      { uuid: "b", group: "g2" },
+      { uuid: "c", group: "g1" },
+      { uuid: "d", group: "g2" },
+    ]);
+    assert.equal(items.length, 2);
+    assert.deepEqual(
+      items.map((item) => item.key),
+      ["group:g1", "group:g2"],
+    );
+    assert.deepEqual(
+      items[0].members.map((member) => member.uuid),
+      ["a", "c"],
+    );
+    assert.deepEqual(
+      items[1].members.map((member) => member.uuid),
+      ["b", "d"],
+    );
+  });
+
+  it("treats a lone grouped result as a (single-member) group card", () => {
+    const items = build([{ uuid: "a", group: "g1" }]);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].isGroup, true);
+    assert.equal(items[0].members.length, 1);
+  });
+});

--- a/test/utils/canvas/test_stackGrouping.ts
+++ b/test/utils/canvas/test_stackGrouping.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildStackDisplayItems } from "../../../src/utils/canvas/stackGrouping.js";
+import { buildStackDisplayItems, pickActiveCardUuid, resolveLatestScrollTarget } from "../../../src/utils/canvas/stackGrouping.js";
 
 // Minimal result shape the grouper needs.
 interface Row {
@@ -96,5 +96,90 @@ describe("buildStackDisplayItems", () => {
     assert.equal(items.length, 1);
     assert.equal(items[0].isGroup, true);
     assert.equal(items[0].members.length, 1);
+  });
+});
+
+// Behaviour-level regression for the scroll-spy / latest-scroll logic
+// that previously assumed `toolResults` order == DOM order (Codex
+// #1504). Both helpers are exercised over the non-contiguous sequence
+// `A(g1), B, C(g1)` — the exact shape that broke — driven through the
+// real `buildStackDisplayItems` projection, not hand-built cards.
+describe("pickActiveCardUuid (scroll-spy over rendered card order)", () => {
+  // A(g1), B, C(g1) renders as two cards: [group g1 (head C), B]. The
+  // group card sits at A's slot (top), B below it.
+  const items = build([
+    { uuid: "a", group: "g1" },
+    { uuid: "b", group: null },
+    { uuid: "c", group: "g1" },
+  ]);
+  // Card → simulated top-edge px. The group card is keyed by its HEAD
+  // uuid ("c") — that is what `pickActiveCardUuid` resolves against.
+  const GROUP_CARD_TOP_PX = 0;
+  const B_CARD_TOP_PX = 100;
+  const topOfCardPx = (headUuid: string): number | null => {
+    if (headUuid === "c") return GROUP_CARD_TOP_PX;
+    if (headUuid === "b") return B_CARD_TOP_PX;
+    return null;
+  };
+
+  it("returns B (not the group's member C) when the viewport sits on B", () => {
+    // Padded line below both cards → last card at/above the line wins.
+    // The flat-walk regression returned C here because C's uuid mapped
+    // back to the group element above B.
+    const active = pickActiveCardUuid(items, (row) => row.uuid, topOfCardPx, B_CARD_TOP_PX + 10);
+    assert.equal(active, "b");
+  });
+
+  it("returns the group's canonical (head) uuid when only the group card is above the line", () => {
+    const active = pickActiveCardUuid(items, (row) => row.uuid, topOfCardPx, B_CARD_TOP_PX - 10);
+    assert.equal(active, "c", "the group card emits its head uuid, never an arbitrary member");
+  });
+
+  it("returns null when no card has been mounted yet", () => {
+    const active = pickActiveCardUuid(
+      items,
+      (row) => row.uuid,
+      () => null,
+      999,
+    );
+    assert.equal(active, null);
+  });
+});
+
+describe("resolveLatestScrollTarget (latest-result auto-scroll)", () => {
+  it("targets the EARLIER group card (not the bottom) when a new result merges into it", () => {
+    // A(g1), B, C(g1): C is newest but its card is the group at the
+    // TOP. Bottom-scrolling would jump away from where C rendered.
+    const rows: Row[] = [
+      { uuid: "a", group: "g1" },
+      { uuid: "b", group: null },
+      { uuid: "c", group: "g1" },
+    ];
+    const target = resolveLatestScrollTarget(build(rows), rows[rows.length - 1], uuidOf);
+    assert.deepEqual(target, { kind: "card", headUuid: "c" });
+  });
+
+  it("scrolls to the bottom when the newest result lands in the last card", () => {
+    const rows: Row[] = [
+      { uuid: "a", group: null },
+      { uuid: "b", group: null },
+    ];
+    const target = resolveLatestScrollTarget(build(rows), rows[rows.length - 1], uuidOf);
+    assert.deepEqual(target, { kind: "bottom" });
+  });
+
+  it("scrolls to the bottom when the newest result extends a trailing group card", () => {
+    const rows: Row[] = [
+      { uuid: "a", group: null },
+      { uuid: "b", group: "g1" },
+      { uuid: "c", group: "g1" },
+    ];
+    const target = resolveLatestScrollTarget(build(rows), rows[rows.length - 1], uuidOf);
+    assert.deepEqual(target, { kind: "bottom" });
+  });
+
+  it("returns none when there is no newest result", () => {
+    const target = resolveLatestScrollTarget(build([]), undefined, uuidOf);
+    assert.deepEqual(target, { kind: "none" });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,6 +966,13 @@
   dependencies:
     gui-chat-protocol "^0.3.3"
 
+"@gui-chat-plugin/google-map@^0.5.0":
+  version "0.5.0"
+  resolved "https://npm.flatt.tech/@gui-chat-plugin/google-map/-/google-map-0.5.0.tgz#e9cf36180b30d7fd70e07bc9ea7b5f2465165da6"
+  integrity sha512-bNFM57kP61Nn7whpCriED/TtWNuacfQIi6Tj8rbTrryfy5HxFZJci/lrfnBdbFLLLMGvRkoWNcG3d6jAbJSuXA==
+  dependencies:
+    gui-chat-protocol "^0.3.3"
+
 "@gui-chat-plugin/mindmap@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@gui-chat-plugin/mindmap/-/mindmap-0.4.1.tgz#547ed008e920d9b579f1f15bc8faeefbd0b9b5e4"
@@ -1313,6 +1320,13 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://npm.flatt.tech/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -3360,6 +3374,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@16.0.1:
   version "16.0.1"
@@ -6306,10 +6325,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://npm.flatt.tech/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://npm.flatt.tech/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -8046,6 +8072,17 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.13:
+  version "7.5.13"
+  resolved "https://npm.flatt.tech/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
+  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8870,6 +8907,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://npm.flatt.tech/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,13 +959,6 @@
   resolved "https://registry.yarnpkg.com/@gui-chat-plugin/camera/-/camera-0.4.1.tgz#f127547f19bd89d5135f32dcc179fadebe5562e4"
   integrity sha512-JgMeYubDfX2Ez49SoKGHpVgekNViDtUXUxDm9/F2fuzHD6KqxzmkLHYnmbgP4h8LJP8OB3sgELDItBpkRkeDHA==
 
-"@gui-chat-plugin/google-map@^0.4.2":
-  version "0.4.2"
-  resolved "https://npm.flatt.tech/@gui-chat-plugin/google-map/-/google-map-0.4.2.tgz#a83f06096d0d7e820c746bf2b5dc5db47347057a"
-  integrity sha512-3p0q9MkAarqDptE7ZyACrKmfqaQI4QlauC2Uv6PGSquE43VUmu2ShA6UcrYMtOsA0WpEgCjq0QuYKOtgemx6dg==
-  dependencies:
-    gui-chat-protocol "^0.3.3"
-
 "@gui-chat-plugin/google-map@^0.5.0":
   version "0.5.0"
   resolved "https://npm.flatt.tech/@gui-chat-plugin/google-map/-/google-map-0.5.0.tgz#e9cf36180b30d7fd70e07bc9ea7b5f2465165da6"


### PR DESCRIPTION
## Summary

When the agent makes several `mapControl` calls for one task (search places, drop markers, draw a route), they previously each rendered as a **separate map card**. This consumes `@gui-chat-plugin/google-map` **0.5.0**'s new `groupId` to merge them: results sharing a `groupId` collapse into ONE stack card and accumulate on a single map.

Depends on the just-published plugin release: [`@gui-chat-plugin/google-map@0.5.0`](https://www.npmjs.com/package/@gui-chat-plugin/google-map/v/0.5.0) (PR receptron/GUIChatPluginGoogleMap#19).

## Items to Confirm / Review

- **Grouping is session-wide, positioned at the group's first occurrence.** A later same-`groupId` update lands on the existing card (not a new one) — this matches the "更新まで考えると" requirement. The alternative (contiguous-only) was rejected because it wouldn't catch later updates.
- **Scroll-spy / selection compatibility.** A group card spans multiple result uuids. The card element is registered under **every** member uuid (`setItemRefForMembers`), so `computeActiveUuidFromScroll` and the scroll-to-selection watch (both keyed on individual uuids) resolve any member to the one card without changes to that machinery. Please sanity-check that interaction.
- **Scope: stack layout only.** The single-layout (`selectedResult`) path in `App.vue` still shows one result at a time. Tracked as a follow-up (see below).

## Changes

- `package.json`: `@gui-chat-plugin/google-map` `^0.4.0` → `^0.5.0` (+ `yarn.lock`).
- `src/components/StackView.vue`:
  - `displayItems` computed — walks `toolResults`, collapses `mapControl` results with the same non-empty `groupId` into one item (`members[]`, ordered; `head` = latest, drives the card header). Everything else stays a singleton.
  - Map-group cards mount one View with `:results="item.members"` (the View replays the group onto one map); all other cards keep `:selected-result` only.
  - `setItemRefForMembers` registers the group element under every member uuid; selection highlight fires if any member is selected; `N×` badge shows op count.

## Follow-up (separate issue)

Single-layout (`App.vue`) map grouping + any UX polish on group card headers. Will file per the earlier recommendation.

## Test plan

- [x] `yarn typecheck` / `yarn lint` / `yarn build` clean
- [x] component tests (incl. stackview googlemap wiring) green
- [x] Verified end-to-end locally against the linked plugin before publish (reporter confirmed merge behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Results with the same group ID collapse into single stacked cards showing the latest item as header; selecting any member highlights the card and emits the group's head.
  * Plugins receive group member data to render full-group views.

* **Bug Fixes**
  * Scroll and active-selection now operate on rendered cards, improving visibility and auto-scroll behavior for merged results.

* **Tests**
  * Unit tests for grouping, active-card detection, and scroll-target logic; new end-to-end tests and a pub/sub test fixture for streaming/scroll scenarios.

* **Chores**
  * Updated google-map plugin dependency to 0.5.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->