### PR TITLE
feat(collections): add mc-profile preset skill (issuer/business profile)

### DIFF
--- a/server/workspace/skills-preset/mc-profile/SKILL.md
+++ b/server/workspace/skills-preset/mc-profile/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: mc-profile
+description: The user's own business profile — the issuer ("bill-from") identity used on invoices. A singleton collection with exactly one record, id `me`. Skill files live at `.claude/skills/mc-profile/` (SKILL.md + schema.json); the record lives at `data/profile/items/me.json`. The user views and edits it at `/collections/mc-profile`, rendered from the schema by the host — you do all I/O via Read / Write / Edit on the JSON file.
+---
+
+# Business Profile (schema-driven collection)
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+This collection holds the user's **own** business identity — the "bill-from"
+side of an invoice (company name, tax ID, address, payment details). It is the
+counterpart to `mc-clients`, which holds the "bill-to" parties.
+
+## Singleton — exactly one record, id `me`
+
+Unlike `mc-clients` (many clients) this collection has **one** record. Its
+primary key is always the literal string `me`, stored at
+`data/profile/items/me.json`. Never create a second record and never invent
+another id — read, create, and update `me.json` only.
+
+## Files
+
+| Purpose | Path |
+|---|---|
+| This skill's instructions (you are reading it) | `.claude/skills/mc-profile/SKILL.md` |
+| Field schema (source of truth for the host UI) | `.claude/skills/mc-profile/schema.json` |
+| The record — the one and only profile | `data/profile/items/me.json` |
+| User-visible collection surface | `/collections/mc-profile` (in the host UI) |
+
+You write JSON; the host's `<CollectionView>` reads the same file and renders a
+form. There is no separate database — the workspace IS the database.
+
+## Record shape
+
+The schema declares these fields (read `schema.json` for the authoritative
+types):
+
+- `id` — string, **primary key**, always `me`
+- `companyName` — string, **required** (the legal/company name shown on invoices)
+- `taxRegistrationId` — string (VAT / EIN / JP T-number — region-dependent)
+- `email` — email
+- `phone` — string
+- `address` — multi-line text
+- `paymentDetails` — markdown (free-form bank / wire / PayPal instructions, so
+  it isn't tied to any one country's bank-account structure)
+- `notes` — markdown
+
+Leave optional fields the user hasn't given you out of the JSON entirely — don't
+push for every field.
+
+## What to do
+
+**Set up / update**: read `data/profile/items/me.json` (it may not exist yet),
+merge the changes, write it back. Preserve fields you weren't asked to change.
+If the file doesn't exist and the user wants to set their profile, create it
+with `id: "me"` plus whatever fields they provided.
+
+**Look up**: read `data/profile/items/me.json` and answer from it. If it's
+missing, tell the user their business profile isn't set up yet and offer to
+collect it (use `presentForm` only if several fields are needed at once).
+
+**Never delete** the profile unless the user explicitly asks to reset it.
+
+## Linking to the profile in chat
+
+When you reference the profile in your reply, link to the collection view — NOT
+the raw JSON file path:
+
+- Do: `[your business profile](/collections/mc-profile?selected=me)`
+- Don't: `[profile](data/profile/items/me.json)` — that opens the raw file in
+  the Files view instead of the rendered form.
+
+## When to ask vs. when to act
+
+If the user gives you the details in a sentence, just write them. Use
+`presentForm` only when you genuinely need several fields they haven't
+provided — don't use it to re-confirm values they already typed.

--- a/server/workspace/skills-preset/mc-profile/schema.json
+++ b/server/workspace/skills-preset/mc-profile/schema.json
@@ -1,0 +1,43 @@
+{
+  "title": "Business Profile",
+  "icon": "badge",
+  "dataPath": "data/profile/items",
+  "primaryKey": "id",
+  "fields": {
+    "id": {
+      "type": "string",
+      "label": "ID",
+      "primary": true,
+      "required": true
+    },
+    "companyName": {
+      "type": "string",
+      "label": "Company / legal name",
+      "required": true
+    },
+    "taxRegistrationId": {
+      "type": "string",
+      "label": "Tax registration ID (VAT / EIN / T-number)"
+    },
+    "email": {
+      "type": "email",
+      "label": "Email"
+    },
+    "phone": {
+      "type": "string",
+      "label": "Phone"
+    },
+    "address": {
+      "type": "text",
+      "label": "Address"
+    },
+    "paymentDetails": {
+      "type": "markdown",
+      "label": "Payment details (bank / wire / PayPal)"
+    },
+    "notes": {
+      "type": "markdown",
+      "label": "Notes"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new `mc-profile` preset skill: a **singleton** schema-driven collection holding the user's own business identity — the bill-**from** issuer side of an invoice (company/legal name, tax registration ID, email, phone, address, payment details, notes).
- Counterpart to `mc-clients` (the bill-**to** parties). One record, primary key always `me`, at `data/profile/items/me.json`.
- **Zero host code** — auto-discovers as `/collections/mc-profile` once the skill is starred, like the other `mc-*` collections. `schema.json` validates against the existing discovery rules.

## Why

`mc-invoice` records reference a client (`clientId`) but had nowhere to store the issuer's own details, so a generated invoice couldn't actually be sent. `mc-profile` is where that identity now lives.

## Follow-up (not in this PR)

A generic `embed` field type so an invoice's read-only detail view can display the issuer record inline (and error if `me` is missing) — declared purely in `mc-invoice/schema.json`, no invoice/profile-specific code.

## Test plan

- [ ] `yarn dev` boot syncs `mc-profile` into the catalog
- [ ] Star `mc-profile`; `/collections/mc-profile` renders the form
- [ ] Create the `me` record; values round-trip via the form
- [ ] Agent can read/write `data/profile/items/me.json` via the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a business profile feature for managing company details including name, tax registration, contact information, payment methods, and notes.

* **Documentation**
  * Added documentation and schema definition for the business profile skill with operational guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->