### PR TITLE
feat(collections): embed field type + singleton collections

### DIFF
--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -16,6 +16,7 @@ import {
   deleteItem,
   listItems,
   loadCollection,
+  resolveCreateItemId,
   toDetail,
   toSummary,
   writeItem,
@@ -87,11 +88,14 @@ router.post(API_ROUTES.collections.items, async (req: Request<{ slug: string }>,
     badRequest(res, "request body must be a JSON object");
     return;
   }
-  // Honour the schema's primaryKey: if the record carries it, use that
-  // value as the item id; otherwise generate one. The body always wins
-  // over a generated id so Claude-derived semantic slugs stick.
-  const primaryRaw = record[collection.schema.primaryKey];
-  const itemId = typeof primaryRaw === "string" && primaryRaw.length > 0 ? primaryRaw : generateItemId();
+  // Resolve the item id: a singleton collection pins EVERY create to
+  // its fixed id (so the "at most one record" contract holds against
+  // direct API calls / scripts / concurrent clients — not just the UI,
+  // which merely hides Add; with the id pinned, a second create targets
+  // the same file and hits the refuseOverwrite conflict below). For a
+  // normal collection the body's primaryKey value wins, else a
+  // generated id (Codex P1 on #1510).
+  const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
   try {
     const result = await writeItem(collection.dataDir, itemId, recordWithId, { refuseOverwrite: true });
@@ -126,10 +130,17 @@ router.put(API_ROUTES.collections.item, async (req: Request<{ slug: string; item
     badRequest(res, "request body must be a JSON object");
     return;
   }
+  // Singleton enforcement: only the fixed id is writable, so a PUT to
+  // any other id can't smuggle in a second record (Codex P1 on #1510).
+  const { singleton, primaryKey } = collection.schema;
+  if (singleton && req.params.itemId !== singleton) {
+    badRequest(res, `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'`);
+    return;
+  }
   // PUT pins the primaryKey to the URL itemId — disregard any
   // mismatched primary-key value in the body so the file's id and its
   // record id never drift.
-  const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: req.params.itemId };
+  const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
   try {
     const result = await writeItem(collection.dataDir, req.params.itemId, recordWithId);
     if (result.kind === "invalid-id") {

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -120,11 +120,13 @@ const CollectionSchemaZ = z
     singleton: z.string().trim().min(1).optional(),
     fields: z.record(z.string(), FieldSpecSchema),
   })
-  // The singleton value becomes a filename (`<id>.json`), so reject
-  // path separators / dot-segments up front rather than relying solely
-  // on the write-path sanitiser.
-  .refine((schema) => schema.singleton === undefined || (!/[\\/]/.test(schema.singleton) && schema.singleton !== "." && schema.singleton !== ".."), {
-    message: "schema `singleton` must be a plain id with no path separators or dot-segments",
+  // The singleton value becomes a record id (and thus a `<id>.json`
+  // filename), so it must satisfy the SAME `safeSlugName` rule the
+  // write path enforces — otherwise the create form would lock the
+  // primary key to a value the POST route then rejects as an invalid
+  // item id, making the collection impossible to initialize (Codex P1).
+  .refine((schema) => schema.singleton === undefined || safeSlugName(schema.singleton) !== null, {
+    message: "schema `singleton` must be a valid item id (alphanumeric / hyphen / underscore, no path separators)",
     path: ["singleton"],
   });
 

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -35,6 +35,20 @@ const refMessage = {
   path: ["to"],
 };
 
+// `embed` pulls a fixed record from another collection into the
+// read-only detail view. It must declare a valid `to` slug (same
+// path-traversal guard as `ref`) AND a non-empty `id` naming the
+// fixed record's primary key (e.g. `me` for the singleton profile).
+const embedRefine = (spec: { type: string; to?: string; id?: string }): boolean => {
+  if (spec.type !== "embed") return true;
+  if (typeof spec.to !== "string" || safeSlugName(spec.to) === null) return false;
+  return typeof spec.id === "string" && spec.id.trim().length > 0;
+};
+const embedMessage = {
+  message: "fields with type 'embed' must declare a `to` (valid collection slug) and a non-empty `id` (the fixed record's primary key)",
+  path: ["id"],
+};
+
 const enumRefine = (spec: { type: string; values?: readonly string[] }): boolean =>
   spec.type !== "enum" || (Array.isArray(spec.values) && spec.values.length > 0 && spec.values.every((value) => typeof value === "string" && value.length > 0));
 const enumMessage = {
@@ -65,11 +79,12 @@ const SubFieldSpecSchema = z
 
 const FieldSpecSchema = z
   .object({
-    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived"]),
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived", "embed"]),
     label: z.string().min(1),
     primary: z.boolean().optional(),
     required: z.boolean().optional(),
     to: z.string().min(1).optional(),
+    id: z.string().trim().min(1).optional(),
     currency: z.string().trim().min(1).optional(),
     values: z.array(z.string().trim().min(1)).min(1).optional(),
     of: z.record(z.string(), SubFieldSpecSchema).optional(),
@@ -82,6 +97,7 @@ const FieldSpecSchema = z
   })
   .refine(refRefine, refMessage)
   .refine(enumRefine, enumMessage)
+  .refine(embedRefine, embedMessage)
   .refine((spec) => spec.type !== "table" || (spec.of !== undefined && Object.keys(spec.of).length > 0), {
     message: "fields with type 'table' must declare a non-empty `of` (sub-schema for each row)",
     path: ["of"],
@@ -91,13 +107,26 @@ const FieldSpecSchema = z
     path: ["formula"],
   });
 
-const CollectionSchemaZ = z.object({
-  title: z.string().min(1),
-  icon: z.string().min(1),
-  dataPath: z.string().min(1),
-  primaryKey: z.string().min(1),
-  fields: z.record(z.string(), FieldSpecSchema),
-});
+const CollectionSchemaZ = z
+  .object({
+    title: z.string().min(1),
+    icon: z.string().min(1),
+    dataPath: z.string().min(1),
+    primaryKey: z.string().min(1),
+    // When set, the collection holds at most one record whose primary
+    // key is this exact value (e.g. `me` for the business profile).
+    // The host fixes the create form's primary key to it and hides the
+    // Add button once the record exists.
+    singleton: z.string().trim().min(1).optional(),
+    fields: z.record(z.string(), FieldSpecSchema),
+  })
+  // The singleton value becomes a filename (`<id>.json`), so reject
+  // path separators / dot-segments up front rather than relying solely
+  // on the write-path sanitiser.
+  .refine((schema) => schema.singleton === undefined || (!/[\\/]/.test(schema.singleton) && schema.singleton !== "." && schema.singleton !== ".."), {
+    message: "schema `singleton` must be a plain id with no path separators or dot-segments",
+    path: ["singleton"],
+  });
 
 interface LoadedCollection {
   slug: string;

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -1,5 +1,5 @@
 export { discoverCollections, loadCollection, toSummary, toDetail, type LoadedCollection } from "./discovery.js";
-export { listItems, readItem, writeItem, deleteItem, generateItemId, type WriteItemResult, type DeleteItemResult } from "./io.js";
+export { listItems, readItem, writeItem, deleteItem, generateItemId, resolveCreateItemId, type WriteItemResult, type DeleteItemResult } from "./io.js";
 export type {
   CollectionSchema,
   CollectionFieldSpec,

--- a/server/workspace/collections/io.ts
+++ b/server/workspace/collections/io.ts
@@ -10,7 +10,7 @@ import { log } from "../../system/logger/index.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { workspacePath } from "../workspace.js";
 import { isContainedInRoot, itemFilePath, safeSlugName } from "./paths.js";
-import type { CollectionItem } from "./types.js";
+import type { CollectionItem, CollectionSchema } from "./types.js";
 
 export interface IoOptions {
   /** Override the workspace root for containment checks. Default:
@@ -213,4 +213,17 @@ export async function deleteItem(dataDir: string, itemId: string, opts: IoOption
  *  semantic id from the record's name). */
 export function generateItemId(): string {
   return randomBytes(4).toString("hex");
+}
+
+/** The item id a CREATE should use for `schema`, or null when the
+ *  caller should generate one. A singleton collection pins every
+ *  create to its fixed `schema.singleton` id, so the "at most one
+ *  record" contract is enforced server-side (a second create targets
+ *  the same file and hits `writeItem`'s refuseOverwrite conflict) —
+ *  not only in the UI. Otherwise the record's own primaryKey value
+ *  wins, falling back to a generated id (null = "generate"). */
+export function resolveCreateItemId(schema: CollectionSchema, record: CollectionItem): string | null {
+  if (schema.singleton) return schema.singleton;
+  const primaryRaw = record[schema.primaryKey];
+  return typeof primaryRaw === "string" && primaryRaw.length > 0 ? primaryRaw : null;
 }

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -11,7 +11,20 @@
 // plans/done/feat-skill-driven-apps-worklog.md — historical names predate
 // the rename).
 
-export type CollectionFieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived";
+export type CollectionFieldType =
+  | "string"
+  | "text"
+  | "email"
+  | "number"
+  | "date"
+  | "boolean"
+  | "markdown"
+  | "ref"
+  | "money"
+  | "enum"
+  | "table"
+  | "derived"
+  | "embed";
 
 export type CollectionSource = "user" | "project";
 
@@ -22,14 +35,21 @@ export interface CollectionFieldSpec {
    *  separate auto-id). Exactly one field per schema may set this. */
   primary?: boolean;
   required?: boolean;
-  /** When `type === "ref"`: the slug of the target collection the
-   *  field's value references (e.g. `clientId` in mc-worklog has
-   *  `to: "mc-clients"`). The record stores the target item's
-   *  primary-key slug as a plain string; the host uses `to` to
-   *  render a clickable link, populate a dropdown picker, and
-   *  (future) validate referential integrity. Required when type
-   *  is `ref`; ignored on every other type. */
+  /** When `type === "ref"` or `type === "embed"`: the slug of the
+   *  target collection. For `ref` the record stores the target
+   *  item's primary-key slug and the host renders a clickable link
+   *  + dropdown picker. For `embed` the host pulls a *fixed* record
+   *  (see `id`) from the target and renders its fields read-only in
+   *  the detail view. Required for both; ignored on every other
+   *  type. */
   to?: string;
+  /** When `type === "embed"`: the primary-key value of the fixed
+   *  record to pull from the `to` collection (e.g. `me` for the
+   *  singleton mc-profile). Nothing is stored on this record — the
+   *  embed is a display-only directive resolved at render time, so
+   *  it never appears in the list table or the edit form. Required
+   *  when type is `embed`; ignored on every other type. */
+  id?: string;
   /** When `type === "money"` (or `type === "derived"` with
    *  `display: "money"`): ISO 4217 currency code passed to
    *  `Intl.NumberFormat` for table display. Defaults to "USD"
@@ -69,6 +89,11 @@ export interface CollectionSchema {
   dataPath: string;
   /** Field name whose value doubles as the record's filename. */
   primaryKey: string;
+  /** When set, the collection is a singleton: at most one record,
+   *  whose primary key is fixed to this value (e.g. `me` for the
+   *  business profile). The host pre-fills + locks the create form's
+   *  primary key and hides Add once the record exists. */
+  singleton?: string;
   /** Ordered map: insertion order = column order in the table view. */
   fields: Record<string, CollectionFieldSpec>;
 }

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -27,6 +27,11 @@ The schema declares these fields (read `schema.json` for the authoritative
 types):
 
 - `id` — string, **primary key** (the filename, no extension)
+- `issuer` — **display-only**; the host embeds the user's own business
+  profile (the `me` record from `mc-clients`' sibling `mc-profile`) as the
+  "bill-from" block in the read-only invoice view. You do **not** write this
+  field — it carries no stored value. If the user hasn't set up their profile,
+  the invoice view shows a "set it up" prompt; point them at `mc-profile`.
 - `clientId` — ref → `mc-clients`, **required**
 - `issueDate` — ISO date `YYYY-MM-DD`, **required**
 - `dueDate` — ISO date (optional)

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -28,7 +28,7 @@ types):
 
 - `id` — string, **primary key** (the filename, no extension)
 - `issuer` — **display-only**; the host embeds the user's own business
-  profile (the `me` record from `mc-clients`' sibling `mc-profile`) as the
+  profile (the `me` record from the `mc-profile` collection) as the
   "bill-from" block in the read-only invoice view. You do **not** write this
   field — it carries no stored value. If the user hasn't set up their profile,
   the invoice view shows a "set it up" prompt; point them at `mc-profile`.

--- a/server/workspace/skills-preset/mc-invoice/schema.json
+++ b/server/workspace/skills-preset/mc-invoice/schema.json
@@ -10,6 +10,12 @@
       "primary": true,
       "required": true
     },
+    "issuer": {
+      "type": "embed",
+      "to": "mc-profile",
+      "id": "me",
+      "label": "From (issuer)"
+    },
     "clientId": {
       "type": "ref",
       "to": "mc-clients",

--- a/server/workspace/skills-preset/mc-profile/schema.json
+++ b/server/workspace/skills-preset/mc-profile/schema.json
@@ -3,6 +3,7 @@
   "icon": "badge",
   "dataPath": "data/profile/items",
   "primaryKey": "id",
+  "singleton": "me",
   "fields": {
     "id": {
       "type": "string",

--- a/src/components/CollectionEmbedView.vue
+++ b/src/components/CollectionEmbedView.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="rounded border border-gray-200 bg-gray-50 p-3 space-y-2" :data-testid="`collections-embed-${fieldKey}`">
+    <template v-if="view.found">
+      <div v-for="row in view.rows" :key="row.key" class="space-y-0.5">
+        <div class="text-xs font-medium text-gray-500">{{ row.label }}</div>
+        <div class="text-sm text-gray-800 break-words" :data-testid="`collections-embed-${fieldKey}-${row.key}`">
+          <template v-if="row.type === 'boolean'">
+            <span v-if="row.value === true" class="material-icons text-green-600 text-base align-middle">check</span>
+            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph, same treatment as the other read-only detail branches. -->
+            <span v-else class="text-gray-400">—</span>
+          </template>
+          <p v-else-if="row.type === 'markdown'" class="whitespace-pre-wrap">{{ row.display }}</p>
+          <span v-else>{{ row.display }}</span>
+        </div>
+      </div>
+    </template>
+    <p v-else class="text-sm text-red-700" :data-testid="`collections-embed-missing-${fieldKey}`">
+      {{ t("collectionsView.embedMissing", { collection: view.targetSlug, id: view.recordId }) }}
+      <router-link v-if="view.targetSlug" :to="{ path: `/collections/${view.targetSlug}` }" class="text-blue-600 hover:underline ml-1">{{
+        t("collectionsView.embedCreate")
+      }}</router-link>
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import type { EmbedView } from "./collectionEmbed";
+
+defineProps<{ view: EmbedView; fieldKey: string }>();
+
+const { t } = useI18n();
+</script>

--- a/src/components/CollectionEmbedView.vue
+++ b/src/components/CollectionEmbedView.vue
@@ -1,20 +1,27 @@
 <template>
-  <div class="rounded border border-gray-200 bg-gray-50 p-3 space-y-2" :data-testid="`collections-embed-${fieldKey}`">
-    <template v-if="view.found">
-      <div v-for="row in view.rows" :key="row.key" class="space-y-0.5">
-        <div class="text-xs font-medium text-gray-500">{{ row.label }}</div>
-        <div class="text-sm text-gray-800 break-words" :data-testid="`collections-embed-${fieldKey}-${row.key}`">
-          <template v-if="row.type === 'boolean'">
-            <span v-if="row.value === true" class="material-icons text-green-600 text-base align-middle">check</span>
-            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph, same treatment as the other read-only detail branches. -->
-            <span v-else class="text-gray-400">—</span>
-          </template>
-          <p v-else-if="row.type === 'markdown'" class="whitespace-pre-wrap">{{ row.display }}</p>
-          <span v-else>{{ row.display }}</span>
-        </div>
+  <!-- Found: the whole card links to the embedded record's detail view,
+       like a normal `ref` link (record → record hop). -->
+  <router-link
+    v-if="view.found"
+    :to="{ path: `/collections/${view.targetSlug}`, query: { selected: view.recordId } }"
+    class="block rounded border border-gray-200 bg-gray-50 p-3 space-y-2 hover:bg-gray-100 hover:border-gray-300 transition-colors"
+    :data-testid="`collections-embed-${fieldKey}`"
+  >
+    <div v-for="row in view.rows" :key="row.key" class="space-y-0.5">
+      <div class="text-xs font-medium text-gray-500">{{ row.label }}</div>
+      <div class="text-sm text-gray-800 break-words" :data-testid="`collections-embed-${fieldKey}-${row.key}`">
+        <template v-if="row.type === 'boolean'">
+          <span v-if="row.value === true" class="material-icons text-green-600 text-base align-middle">check</span>
+          <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph, same treatment as the other read-only detail branches. -->
+          <span v-else class="text-gray-400">—</span>
+        </template>
+        <p v-else-if="row.type === 'markdown'" class="whitespace-pre-wrap">{{ row.display }}</p>
+        <span v-else>{{ row.display }}</span>
       </div>
-    </template>
-    <p v-else class="text-sm text-red-700" :data-testid="`collections-embed-missing-${fieldKey}`">
+    </div>
+  </router-link>
+  <div v-else class="rounded border border-gray-200 bg-gray-50 p-3" :data-testid="`collections-embed-${fieldKey}`">
+    <p class="text-sm text-red-700" :data-testid="`collections-embed-missing-${fieldKey}`">
       {{ t("collectionsView.embedMissing", { collection: view.targetSlug, id: view.recordId }) }}
       <router-link v-if="view.targetSlug" :to="{ path: `/collections/${view.targetSlug}` }" class="text-blue-600 hover:underline ml-1">{{
         t("collectionsView.embedCreate")

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -16,7 +16,7 @@
         {{ collection?.title ?? t("collectionsView.title") }}
       </h1>
       <button
-        v-if="collection"
+        v-if="canCreate"
         type="button"
         class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm"
         data-testid="collections-add-item"
@@ -43,7 +43,7 @@
       <table v-else class="min-w-full text-sm">
         <thead class="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
           <tr>
-            <th v-for="(field, key) in collection.schema.fields" :key="key" class="px-4 py-2 font-medium">{{ field.label }}</th>
+            <th v-for="[key, field] in nonEmbedFields" :key="key" class="px-4 py-2 font-medium">{{ field.label }}</th>
             <th class="px-4 py-2 font-medium w-px"></th>
           </tr>
         </thead>
@@ -60,7 +60,7 @@
             @keydown.enter.self="openView(item)"
             @keydown.space.self.prevent="openView(item)"
           >
-            <td v-for="(field, key) in collection.schema.fields" :key="key" class="px-4 py-2 text-gray-800 align-top max-w-xs">
+            <td v-for="[key, field] in nonEmbedFields" :key="key" class="px-4 py-2 text-gray-800 align-top max-w-xs">
               <span v-if="field.type === 'boolean'" class="block">
                 <span v-if="item[key] === true" class="material-icons text-green-600 text-base align-middle">check</span>
                 <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" is a universal "empty value" glyph already used in `formatCell` and reused here for the boolean=false case; translating it would diverge the two visual states across locales. -->
@@ -142,6 +142,10 @@
               />
               <span>{{ editing.bool[key] ? t("common.yes") : t("common.no") }}</span>
             </label>
+            <!-- embed: read-only in the form too. Not a dropdown — the
+                 referenced record is a fixed singleton, so there's
+                 nothing to pick; it just shows who the embed points at. -->
+            <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
             <select
               v-else-if="field.type === 'ref' && field.to && refOptions(field.to).length > 0"
               :id="`collections-field-${key}`"
@@ -283,7 +287,7 @@
               v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
               :required="isFieldRequiredInUi(field)"
-              :disabled="field.primary === true && editing.mode === 'edit'"
+              :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
               class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
               :data-testid="`collections-input-${key}`"
             />
@@ -389,6 +393,9 @@
               </table>
               <span v-else-if="field.type === 'table'" class="text-gray-400">{{ formatCell(undefined, "string") }}</span>
               <p v-else-if="field.type === 'markdown'" class="whitespace-pre-wrap">{{ detailText(viewing[key]) }}</p>
+              <!-- embed: a fixed record from another collection (e.g. the
+                   issuer profile) rendered read-only inline. -->
+              <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
               <span v-else>{{ formatCell(viewing[key], field.type) }}</span>
             </div>
           </div>
@@ -408,19 +415,26 @@ import { apiDelete, apiGet, apiPost, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { PAGE_ROUTES } from "../router/pageRoutes";
 import ConfirmModal from "./ConfirmModal.vue";
+import CollectionEmbedView from "./CollectionEmbedView.vue";
+import type { EmbedRow, EmbedView } from "./collectionEmbed";
 import { useConfirm } from "../composables/useConfirm";
 import { evaluateDerived } from "../utils/collections/derivedFormula";
 
-type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived";
+type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived" | "embed";
 
 interface FieldSpec {
   type: FieldType;
   label: string;
   primary?: boolean;
   required?: boolean;
-  /** When type === "ref": slug of the target collection (see
-   *  plans/done/feat-collections-ref-field.md). */
+  /** When type === "ref" or "embed": slug of the target collection
+   *  (see plans/done/feat-collections-ref-field.md). */
   to?: string;
+  /** When type === "embed": primary-key value of the fixed record
+   *  pulled from `to` and rendered read-only in the detail view
+   *  (e.g. `me` for the singleton mc-profile). Display-only — never
+   *  stored, never shown in the list table or the edit form. */
+  id?: string;
   /** When type === "money": ISO 4217 currency for Intl display.
    *  Defaults to "USD" when omitted. */
   currency?: string;
@@ -440,17 +454,31 @@ interface FieldSpec {
 
 /** Per-target-collection cache: maps an item's primary-key slug to
  *  the value we'll show in the table and dropdown. Filled in by
- *  `loadRefTargets` after the main collection's items arrive — one
- *  fetch per unique target collection, regardless of how many ref
- *  fields point at it. */
+ *  `loadLinkedCollections` after the main collection's items arrive
+ *  — one fetch per unique target collection, regardless of how many
+ *  ref fields point at it. */
 type RefDisplayMap = Record<string, string>;
 type RefCache = Record<string, RefDisplayMap>;
+
+/** Per-target cache for `embed` fields: the target collection's
+ *  schema + items, kept in full (not reduced to display names like
+ *  RefCache) so the detail view can render the embedded record's
+ *  every field read-only. Keyed by target slug; the fixed record is
+ *  looked up by `field.id` at render time. */
+interface EmbedTargetData {
+  schema: CollectionSchema;
+  items: CollectionItem[];
+}
+type EmbedCache = Record<string, EmbedTargetData>;
 
 interface CollectionSchema {
   title: string;
   icon: string;
   dataPath: string;
   primaryKey: string;
+  /** When set, the collection is a singleton: at most one record whose
+   *  primary key is fixed to this value. */
+  singleton?: string;
   fields: Record<string, FieldSpec>;
 }
 
@@ -542,6 +570,7 @@ const viewing = ref<CollectionItem | null>(null);
 const saving = ref(false);
 const saveError = ref<string | null>(null);
 const refCache = ref<RefCache>({});
+const embedCache = ref<EmbedCache>({});
 
 function detailUrl(slug: string): string {
   return API_ROUTES.collections.detail.replace(":slug", encodeURIComponent(slug));
@@ -561,6 +590,7 @@ async function loadCollection(slug: string): Promise<void> {
   collection.value = null;
   items.value = [];
   refCache.value = {};
+  embedCache.value = {};
   viewing.value = null;
   const result = await apiGet<CollectionDetailResponse>(detailUrl(slug));
   loading.value = false;
@@ -577,7 +607,7 @@ async function loadCollection(slug: string): Promise<void> {
   // Pass the slug that triggered THIS load so the helper can drop
   // its result if a faster subsequent load has already switched us
   // to a different collection (Codex P1 review on PR #1495).
-  await loadRefTargets(result.data.collection.schema, slug);
+  await loadLinkedCollections(result.data.collection.schema, slug);
   // A `?selected=<id>` deep link opens that record in read-only
   // mode once its items are available. Guard against a stale load:
   // only act if we're still on the slug that triggered this fetch.
@@ -604,23 +634,44 @@ function uniqueRefTargets(schema: CollectionSchema): string[] {
   return [...targets];
 }
 
-async function loadRefTargets(schema: CollectionSchema, expectedSlug: string): Promise<void> {
-  const targets = uniqueRefTargets(schema);
-  if (targets.length === 0) return;
-  const results = await Promise.all(targets.map((target) => apiGet<CollectionDetailResponse>(detailUrl(target)).then((result) => ({ target, result }))));
+function uniqueEmbedTargets(schema: CollectionSchema): string[] {
+  const targets = new Set<string>();
+  // Embeds are top-level only — the schema rejects `embed` inside a
+  // table's `of` (SubFieldSpecSchema omits it), so no recursion.
+  for (const field of Object.values(schema.fields)) {
+    if (field.type === "embed" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
+  }
+  return [...targets];
+}
+
+/** Fetch every collection this schema links to — `ref` targets (for
+ *  display-name labels + dropdown options) and `embed` targets (for
+ *  the full record rendered in the detail view). Fetched as one
+ *  union so a slug used by both is only requested once; the result
+ *  fans out into `refCache` (display maps) and `embedCache` (full
+ *  schema + items). */
+async function loadLinkedCollections(schema: CollectionSchema, expectedSlug: string): Promise<void> {
+  const refTargets = new Set(uniqueRefTargets(schema));
+  const embedTargets = new Set(uniqueEmbedTargets(schema));
+  const allTargets = [...new Set([...refTargets, ...embedTargets])];
+  if (allTargets.length === 0) return;
+  const results = await Promise.all(allTargets.map((target) => apiGet<CollectionDetailResponse>(detailUrl(target)).then((result) => ({ target, result }))));
   // Stale-write guard: a quicker subsequent `loadCollection()`
   // (user navigated to a different collection mid-fetch) may have
-  // already replaced `collection.value`. Overwriting `refCache`
-  // here would surface the previous collection's ref data on the
+  // already replaced `collection.value`. Overwriting the caches
+  // here would surface the previous collection's linked data on the
   // current one's UI — broken labels until another reload. Drop
   // the write if we're no longer on the slug that triggered us.
   if (collection.value?.slug !== expectedSlug) return;
-  const next: RefCache = {};
+  const nextRef: RefCache = {};
+  const nextEmbed: EmbedCache = {};
   for (const { target, result } of results) {
     if (!result.ok) continue;
-    next[target] = buildRefDisplayMap(result.data);
+    if (refTargets.has(target)) nextRef[target] = buildRefDisplayMap(result.data);
+    if (embedTargets.has(target)) nextEmbed[target] = { schema: result.data.collection.schema, items: result.data.items };
   }
-  refCache.value = next;
+  refCache.value = nextRef;
+  embedCache.value = nextEmbed;
 }
 
 function buildRefDisplayMap(detail: CollectionDetailResponse): RefDisplayMap {
@@ -654,6 +705,70 @@ function refOptions(targetSlug: string): { slug: string; display: string }[] {
     .map(([slug, display]) => ({ slug, display }))
     .sort((left, right) => left.display.localeCompare(right.display));
 }
+
+/** Resolve the fixed record an `embed` field points at, from the
+ *  embedCache. Returns the target schema + the matching record, or
+ *  nulls when the target couldn't be loaded or has no record with
+ *  that id — the detail view renders the fields when `item` is set,
+ *  a "missing" message otherwise. */
+function resolveEmbed(field: FieldSpec): { schema: CollectionSchema | null; item: CollectionItem | null } {
+  if (field.type !== "embed" || !field.to || !field.id) return { schema: null, item: null };
+  const data = embedCache.value[field.to];
+  if (!data) return { schema: null, item: null };
+  const item = data.items.find((entry) => String(entry[data.schema.primaryKey] ?? "") === field.id) ?? null;
+  return { schema: data.schema, item };
+}
+
+/** Read-only string for one field of an embedded record. Booleans
+ *  and markdown are handled in the template (icon / pre-wrap); money
+ *  formats via Intl; everything else falls back to the full text
+ *  value (a ref inside an embedded record can't resolve a label
+ *  across the boundary, so it shows its raw slug). */
+function embedValue(field: FieldSpec, value: unknown): string {
+  if (field.type === "money") return formatMoney(value, field.currency, locale.value);
+  return detailText(value);
+}
+
+/** Render-ready model for each `embed` field of the current
+ *  collection, resolved against the embedCache and keyed by field
+ *  key. Pre-formatting the rows in script keeps the detail template
+ *  simple and type-safe. Independent of which record is open — an
+ *  embed shows a fixed record regardless. */
+const embedViews = computed<Record<string, EmbedView>>(() => {
+  const out: Record<string, EmbedView> = {};
+  if (!collection.value) return out;
+  for (const [key, field] of Object.entries(collection.value.schema.fields)) {
+    if (field.type !== "embed") continue;
+    const { schema, item } = resolveEmbed(field);
+    const rows: EmbedRow[] = [];
+    if (schema && item) {
+      for (const [subKey, subField] of Object.entries(schema.fields)) {
+        rows.push({ key: subKey, label: subField.label, type: subField.type, value: item[subKey], display: embedValue(subField, item[subKey]) });
+      }
+    }
+    out[key] = { found: Boolean(item), rows, targetSlug: field.to ?? "", recordId: field.id ?? "" };
+  }
+  return out;
+});
+
+/** Schema fields excluding display-only `embed` fields — used by the
+ *  list table only (a whole embedded record doesn't fit a table cell,
+ *  and it'd be identical in every row). The detail modal and the edit
+ *  form iterate the full `schema.fields` so embeds render there too. */
+const nonEmbedFields = computed<[string, FieldSpec][]>(() =>
+  collection.value ? Object.entries(collection.value.schema.fields).filter(([, field]) => field.type !== "embed") : [],
+);
+
+/** True when the current collection declares `schema.singleton` —
+ *  exactly one record, its primary key fixed to the declared value. */
+const isSingleton = computed<boolean>(() => Boolean(collection.value?.schema.singleton));
+
+/** Whether the Add button should show. Always for a normal collection;
+ *  for a singleton only until its one record exists. */
+const canCreate = computed<boolean>(() => {
+  if (!collection.value) return false;
+  return !(isSingleton.value && items.value.length > 0);
+});
 
 function inputTypeFor(type: FieldType): string {
   if (type === "email") return "email";
@@ -835,11 +950,16 @@ function openCreate(): void {
       boolTouched[key] = false;
     } else if (field.type === "table") {
       table[key] = [];
-    } else if (field.type !== "derived") {
+    } else if (field.type !== "derived" && field.type !== "embed") {
       text[key] = "";
     }
-    // derived fields are computed on the fly; nothing to seed.
+    // derived (computed) and embed (display-only, foreign record)
+    // fields have no draft slot.
   }
+  // Singleton collections fix the primary key to the schema-declared
+  // value (e.g. "me") so the first Add can't pick an arbitrary id.
+  const { singleton, primaryKey } = collection.value.schema;
+  if (singleton) text[primaryKey] = singleton;
   editing.value = { mode: "create", text, bool, boolOriginallyPresent, boolTouched, table, originalId: null };
   saveError.value = null;
 }
@@ -869,7 +989,7 @@ function openEdit(item: CollectionItem): void {
       table[key] = rows
         .filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row))
         .map((row) => rowFromItem(row, sub));
-    } else if (field.type !== "derived") {
+    } else if (field.type !== "derived" && field.type !== "embed") {
       text[key] = raw === undefined || raw === null ? "" : String(raw);
     }
   }
@@ -1065,7 +1185,8 @@ function validateOneField(key: string, field: FieldSpec, draft: EditState): stri
   }
   if (!field.required) return null;
   if (draft.mode === "create" && field.primary === true) return null;
-  if (field.type === "boolean" || field.type === "derived") return null;
+  // embed has no draft slot (foreign display-only); derived is computed.
+  if (field.type === "boolean" || field.type === "derived" || field.type === "embed") return null;
   return isMissingDraftValue(draft.text[key]) ? field.label : null;
 }
 
@@ -1080,7 +1201,7 @@ function firstMissingRequiredField(draft: EditState, schema: CollectionSchema): 
 function draftToRecord(state: EditState, schema: CollectionSchema): CollectionItem {
   const record: CollectionItem = {};
   for (const [key, field] of Object.entries(schema.fields)) {
-    if (field.type === "derived") continue; // never persisted; computed on demand
+    if (field.type === "derived" || field.type === "embed") continue; // never persisted (computed / foreign display-only)
     if (field.type === "boolean") {
       if (shouldEmitBoolean(state, key, field)) record[key] = state.bool[key] === true;
       continue;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -743,7 +743,13 @@ const embedViews = computed<Record<string, EmbedView>>(() => {
     const rows: EmbedRow[] = [];
     if (schema && item) {
       for (const [subKey, subField] of Object.entries(schema.fields)) {
-        rows.push({ key: subKey, label: subField.label, type: subField.type, value: item[subKey], display: embedValue(subField, item[subKey]) });
+        const value = item[subKey];
+        // Skip empty fields — the embed is a read-only summary of
+        // another record (e.g. a "From (issuer)" block), so unfilled
+        // optional fields would just be "—" noise rather than the
+        // editable blanks a form needs.
+        if (value === undefined || value === null || value === "") continue;
+        rows.push({ key: subKey, label: subField.label, type: subField.type, value, display: embedValue(subField, value) });
       }
     }
     out[key] = { found: Boolean(item), rows, targetSlug: field.to ?? "", recordId: field.id ?? "" };

--- a/src/components/collectionEmbed.ts
+++ b/src/components/collectionEmbed.ts
@@ -1,0 +1,29 @@
+// View model for an `embed` field — a fixed record from another
+// collection rendered read-only. Shared between CollectionView (which
+// resolves the model from the embedCache) and CollectionEmbedView
+// (which renders it), so both the detail modal and the edit form draw
+// the embed identically.
+
+export interface EmbedRow {
+  /** Sub-field key (used for `:key` + testids). */
+  key: string;
+  label: string;
+  /** Sub-field type — the renderer branches on "boolean" / "markdown". */
+  type: string;
+  /** Raw value, used only for the boolean check / em-dash. */
+  value: unknown;
+  /** Pre-formatted string for every non-boolean render path. */
+  display: string;
+}
+
+export interface EmbedView {
+  /** False when the target collection has no record with the embed's
+   *  `id` (or the target couldn't be loaded) — the renderer shows a
+   *  "missing" message + a link to create it. */
+  found: boolean;
+  rows: EmbedRow[];
+  /** Target collection slug, for the "create it" link + message. */
+  targetSlug: string;
+  /** The fixed record id the embed points at, for the message. */
+  recordId: string;
+}

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1354,6 +1354,8 @@ const deMessages = {
     removeRow: "Zeile entfernen",
     noRows: "Noch keine Zeilen",
     tableSummary: "{count} Einträge",
+    embedMissing: "Kein Datensatz {id} in {collection} gefunden.",
+    embedCreate: "Einrichten",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1335,6 +1335,8 @@ const enMessages = {
     removeRow: "Remove row",
     noRows: "No rows yet",
     tableSummary: "{count} items",
+    embedMissing: "No “{id}” record found in {collection}.",
+    embedCreate: "Set it up",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1349,6 +1349,8 @@ const esMessages = {
     removeRow: "Quitar fila",
     noRows: "Aún no hay filas",
     tableSummary: "{count} elementos",
+    embedMissing: "No se encontró el registro «{id}» en {collection}.",
+    embedCreate: "Configurarlo",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1343,6 +1343,8 @@ const frMessages = {
     removeRow: "Supprimer la ligne",
     noRows: "Aucune ligne pour l'instant",
     tableSummary: "{count} éléments",
+    embedMissing: "Aucun enregistrement « {id} » trouvé dans {collection}.",
+    embedCreate: "Le configurer",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1332,6 +1332,8 @@ const jaMessages = {
     removeRow: "行を削除",
     noRows: "行がありません",
     tableSummary: "{count}件",
+    embedMissing: "{collection} に「{id}」のレコードが見つかりません。",
+    embedCreate: "設定する",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1335,6 +1335,8 @@ const koMessages = {
     removeRow: "행 삭제",
     noRows: "행이 없습니다",
     tableSummary: "{count}개",
+    embedMissing: "{collection}에 '{id}' 레코드가 없습니다.",
+    embedCreate: "설정하기",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1338,6 +1338,8 @@ const ptBRMessages = {
     removeRow: "Remover linha",
     noRows: "Ainda não há linhas",
     tableSummary: "{count} itens",
+    embedMissing: "Nenhum registro '{id}' encontrado em {collection}.",
+    embedCreate: "Configurar",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1325,6 +1325,8 @@ const zhMessages = {
     removeRow: "删除行",
     noRows: "暂无行",
     tableSummary: "{count} 项",
+    embedMissing: "在 {collection} 中找不到「{id}」记录。",
+    embedCreate: "去设置",
     source: {
       user: "用户",
       project: "项目",

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -362,6 +362,71 @@ describe("discoverCollections — field-type support", () => {
     const collections = await listCollections();
     assert.equal(collections.length, 0);
   });
+
+  // ─── embed (feat-collections-embed PR) ───
+
+  it("accepts `embed` with a valid `to` and non-empty `id`", async () => {
+    writeSkill("test-embed", {
+      title: "Invoice-like",
+      icon: "receipt",
+      dataPath: "data/embed/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        issuer: { type: "embed", to: "mc-profile", id: "me", label: "From (issuer)" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.fields.issuer?.type, "embed");
+    assert.equal(collections[0]?.schema.fields.issuer?.to, "mc-profile");
+    assert.equal(collections[0]?.schema.fields.issuer?.id, "me");
+  });
+
+  it("rejects `embed` with no `to`", async () => {
+    writeSkill("test-embed-no-to", {
+      title: "Bad Embed",
+      icon: "warning",
+      dataPath: "data/embednoto/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        issuer: { type: "embed", id: "me", label: "Issuer" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0, "embed without `to` must be skipped");
+  });
+
+  it("rejects `embed` with no `id`", async () => {
+    writeSkill("test-embed-no-id", {
+      title: "Bad Embed",
+      icon: "warning",
+      dataPath: "data/embednoid/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        issuer: { type: "embed", to: "mc-profile", label: "Issuer" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0, "embed without `id` must be skipped");
+  });
+
+  it("rejects `embed` whose `to` contains path traversal", async () => {
+    writeSkill("test-embed-traversal", {
+      title: "Traversal Embed",
+      icon: "warning",
+      dataPath: "data/embedtrav/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        issuer: { type: "embed", to: "../escape", id: "me", label: "Issuer" },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
 });
 
 describe("discoverCollections — structural validation", () => {
@@ -417,6 +482,35 @@ describe("discoverCollections — structural validation", () => {
 
   it("ignores skills that ship no schema.json (they're regular skills)", async () => {
     writeSkill("test-no-schema", null);
+    const collections = await listCollections();
+    assert.equal(collections.length, 0);
+  });
+});
+
+describe("discoverCollections — singleton", () => {
+  it("accepts a schema declaring a `singleton` id", async () => {
+    writeSkill("test-singleton", {
+      title: "Profile-like",
+      icon: "badge",
+      dataPath: "data/singleton/items",
+      primaryKey: "id",
+      singleton: "me",
+      fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.singleton, "me");
+  });
+
+  it("rejects a `singleton` containing a path separator", async () => {
+    writeSkill("test-singleton-bad", {
+      title: "Bad Singleton",
+      icon: "warning",
+      dataPath: "data/singletonbad/items",
+      primaryKey: "id",
+      singleton: "../escape",
+      fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+    });
     const collections = await listCollections();
     assert.equal(collections.length, 0);
   });

--- a/test/workspace/collections/test_io.ts
+++ b/test/workspace/collections/test_io.ts
@@ -12,7 +12,8 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { listItems, readItem } from "../../../server/workspace/collections/io.js";
+import { listItems, readItem, resolveCreateItemId } from "../../../server/workspace/collections/io.js";
+import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
 
 let workdir: string;
 let dataDir: string;
@@ -75,5 +76,25 @@ describe("readItem file-disclosure defense", () => {
   it("returns null for an invalid slug", async () => {
     const item = await readItem(dataDir, "../escape", { workspaceRoot: workdir });
     assert.equal(item, null);
+  });
+});
+
+describe("resolveCreateItemId — singleton enforcement", () => {
+  const base = { title: "T", icon: "i", dataPath: "data/x/items", primaryKey: "id" };
+  const singleton: CollectionSchema = { ...base, singleton: "me", fields: { id: { type: "string", label: "ID", primary: true } } };
+  const normal: CollectionSchema = { ...base, fields: { id: { type: "string", label: "ID", primary: true } } };
+
+  it("pins a singleton create to the fixed id, ignoring the body's primary key", () => {
+    assert.equal(resolveCreateItemId(singleton, { id: "evil", name: "x" }), "me");
+    assert.equal(resolveCreateItemId(singleton, {}), "me");
+  });
+
+  it("uses the body's primary key for a normal collection", () => {
+    assert.equal(resolveCreateItemId(normal, { id: "acme-corp" }), "acme-corp");
+  });
+
+  it("returns null (caller generates) when a normal collection's body has no primary key", () => {
+    assert.equal(resolveCreateItemId(normal, { name: "x" }), null);
+    assert.equal(resolveCreateItemId(normal, { id: "" }), null);
   });
 });


### PR DESCRIPTION
## Summary

Two generic, schema-driven collection primitives — no collection/record names hardcoded in UI code.

- **`embed` field type** — a display-only field that pulls a *fixed* record from another collection (declared via `to` + `id`) and renders its fields read-only, in both the read-only detail modal **and** the edit/create form (never a dropdown — the referenced record is fixed). It's skipped in the list table, never persisted, never validated. Resolution reads `field.to` / `field.id` off the schema; if the target record is absent it shows a localized "set it up" prompt linking to the target collection.
- **`singleton` schema flag** — `"singleton": "<id>"` fixes a collection to at most one record with a fixed primary key. The create form pre-fills + locks the primary key to that id, and the Add button hides once the record exists.

## Wiring (data only)

- `mc-invoice/schema.json` gains `"issuer": { "type": "embed", "to": "mc-profile", "id": "me" }`, so opening/editing any invoice shows the issuer "From" block read-only.
- `mc-profile/schema.json` gains `"singleton": "me"`, so the first "Add" is forced to id `me` and a second profile can't be created.

## Implementation notes

- New `CollectionEmbedView.vue` (+ shared `collectionEmbed.ts` types) renders the embed block, reused by both the detail modal and the form — no duplicated template.
- Discovery (`discovery.ts`) validates: `embed` requires a valid `to` slug + non-empty `id`; `singleton` rejects path separators / dot-segments (it becomes a filename).
- `embedMissing` / `embedCreate` strings added across all 8 locales.

## Follow-up to

PR #1507 (added the `mc-profile` preset skill).

## Test plan

- [x] `yarn format` / `lint` / `typecheck` / `test` / `build` — green (incl. new discovery tests for embed + singleton)
- [ ] **Manual (no collections e2e harness):** with `mc-profile` + `mc-invoice` starred, create the `me` profile via the locked Add form; open/edit an invoice and confirm the issuer block renders read-only; with no profile, confirm the "set it up" prompt; confirm the Add button disappears on `mc-profile` after one record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only embedded fields: display a fixed record from another collection.
  * Singleton collections: support for collections limited to a single record with a fixed ID.

* **UI**
  * Embed card view in record detail/edit (read-only), list/table rendering skips embed columns, and create-button visibility respects singletons.

* **Behavior**
  * Create/update flows enforce/pin singleton IDs and resolve item IDs accordingly.

* **Documentation**
  * Invoice preset documents issuer as display-only (from profile).

* **Localization**
  * Added embed-related messages in multiple languages.

* **Tests**
  * New tests for embed validation and singleton behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->