### PR TITLE
feat(collections): invoice → bookkeeping journal actions

### DIFF
--- a/plans/feat-invoice-bookkeeping.md
+++ b/plans/feat-invoice-bookkeeping.md
@@ -1,0 +1,196 @@
+# Plan: invoice → bookkeeping actions (sale / payment / void)
+
+Builds on the schema-declared `actions` mechanism shipped in
+`plans/feat-collections-actions.md` (#1511). Adds the bookkeeping side
+of the invoice lifecycle: when an invoice you **issue** is sent, paid,
+or voided, post the matching **double-entry journal** into the
+accounting book — by handing the `accounting` role a templated
+instruction, exactly as the new `actions` primitive already does for
+"Generate PDF".
+
+## Hard constraint (unchanged): generic host, domain data in the skill
+
+No invoice/accounting literals in `server/` or `src/`. Each bookkeeping
+action is a row in `mc-invoice/schema.json` (`kind: "chat"`,
+`role: "accounting"`, a template name); the journal logic lives in
+skill templates under `mc-invoice/templates/`. The host only renders
+buttons, assembles the seed (record JSON + template), and starts the
+chat — it already does all of this.
+
+## Background: how the legacy plugin did it
+
+`packages/plugins/invoice-plugin/` never wrote journals itself. It built
+a plain-English instruction and seeded an `accounting`-role chat
+(`chat.start({ initialMessage, role: "accounting" })`, `index.ts:487`).
+Two triggers in `View.vue`:
+
+- **Approve** (`:746`): "record the double-entry bookkeeping journal
+  entries for approved Invoice {id}" + total/subtotal/tax/date/client +
+  Book ID — and trusted the accounting role to derive the debits/credits.
+- **Mark paid** (`:835`): "record the cash receipt journal entries
+  (debit Checking/Cash, credit Accounts Receivable)" + total + payment
+  reference + Book ID.
+
+It carried a `bookId`/`bookName` in issuer settings to name the ledger.
+
+## Scope: the receivable lifecycle (3 actions)
+
+An invoice you issue is an **account receivable**. The three actions
+mirror its lifecycle:
+
+| Action id | Button | Shows when status… | Journal it asks the accounting role to post |
+|---|---|---|---|
+| `journal-sale` | Record sale | `sent` or `paid` | Dr **Accounts Receivable** (total) / Cr **Revenue** (subtotal) / Cr **output-tax** `24xx` (tax) |
+| `journal-payment` | Record payment | `paid` | Dr **Cash/Checking** (total) / Cr **Accounts Receivable** (total) |
+| `journal-void` | Record void | `void` | **Void** the original sale (and payment, if any) entries for this invoice — or post their reversal |
+
+(**Out of scope:** accounts *payable* — recording vendor bills you owe —
+is the mirror flow and a separate feature.)
+
+## The actions (data — `mc-invoice/schema.json`)
+
+Appended to the existing `actions` array (alongside `pdf`):
+
+```jsonc
+{ "id": "journal-sale",    "label": "Record sale",    "icon": "request_quote",   "kind": "chat", "role": "accounting", "template": "templates/journal-sale.md",    "when": { "field": "status", "in": ["sent", "paid"] } },
+{ "id": "journal-payment", "label": "Record payment", "icon": "payments",        "kind": "chat", "role": "accounting", "template": "templates/journal-payment.md", "when": { "field": "status", "in": ["paid"] } },
+{ "id": "journal-void",    "label": "Record void",    "icon": "block",           "kind": "chat", "role": "accounting", "template": "templates/journal-void.md",    "when": { "field": "status", "in": ["void"] } }
+```
+
+## One host change: an optional `when` visibility predicate
+
+The three actions are status-driven, so showing all of them (plus
+"Generate PDF") on every invoice is noise. Add a small, generic `when`
+clause to the action schema:
+
+```jsonc
+"when": { "field": "<top-level field key>", "in": ["<value>", …] }
+```
+
+- **types/discovery**: `CollectionAction.when?: { field: string; in: string[] }`;
+  validate `field` non-empty and `in` a non-empty string array.
+- **CollectionView**: an action button renders only when
+  `when` is absent OR `String(viewing[when.field])` ∈ `when.in`. Pure,
+  generic, evaluated against the open record — no invoice knowledge.
+
+This is the only host code in the feature. **DECIDED: include it** —
+without it the detail header shows four always-on buttons.
+
+## The templates (data — `mc-invoice/templates/`)
+
+Each template gets the invoice record in the `<record_data_json>` block
+(host-injected) and instructs the `accounting` role, which owns
+`manageAccounting` (`addEntries`, `voidEntry`, `getReport`,
+`getAccounts`, `getBooks`). Common preamble for all three:
+
+1. **Resolve the book.** First read `defaultBookId` from the profile
+   (`data/profile/items/me.json`); if set, use it. Otherwise call
+   `getBooks`; if exactly one, use it; if several, pick the one matching
+   the invoice's currency/country, else `presentForm` to ask.
+2. **Tag every entry** with the invoice id in the memo (e.g.
+   `INV-2026-0001`) so payment/void can find it later.
+3. **Idempotency.** Before posting, query the ledger (`getReport`) for an
+   existing entry whose memo contains this invoice id + this transaction
+   type; if found, tell the user it's already recorded and stop — don't
+   double-post.
+
+Per-template specifics:
+
+- **`journal-sale.md`** — compute subtotal/tax/total from `lineItems` +
+  `taxRate`; post one balanced entry: Dr A/R, Cr Revenue, Cr output-tax
+  (omit the tax line when `taxRate` is 0/absent). Use `getAccounts` for
+  the real codes; never invent one.
+- **`journal-payment.md`** — find the open receivable for this invoice;
+  post Dr Cash/Checking, Cr A/R for the total. Payment is always direct
+  deposit to the issuer's bank account (from the profile's `bankDetails`),
+  so the debit is the Checking/Bank account in the book — match it via
+  `getAccounts`. If the invoice's `note` field carries a payment
+  reference, include it in the memo, otherwise post without one (do not
+  prompt).
+- **`journal-void.md`** — find the sale entry (and payment entry, if
+  posted) tagged with this invoice id via `getReport`; `voidEntry` each
+  by its `entryId` (confirm via `presentForm` first, per the accounting
+  role's voidEntry guidance); if no entry exists, say so.
+
+All three end by confirming in one sentence what was posted and linking
+to the book (`openBook`) so the user can review.
+
+## Profile additions (data — `mc-profile` / `data/profile/items/me.json`)
+
+Two new fields on the business profile schema, both optional:
+
+- **`defaultBookId`** (string) — the accounting book the journal
+  templates post into (decision #2). Templates read it first; fall back
+  to `getBooks` resolution when unset.
+- **`bankDetails`** (multi-line string, free-form) — the issuer's
+  remit-to bank info, typed however the issuer's country/bank expects
+  (US routing + account #, JP 銀行/支店/口座種別/口座番号, EU IBAN/BIC, …).
+  `invoice.md` renders it verbatim as a "payment instructions" block so
+  the client knows where to direct-deposit; `journal-payment.md` treats
+  its presence as confirmation that payment lands in the Checking/Bank
+  account.
+
+No host code — these are skill-schema fields the `mc-profile` collection
+and the invoice/journal templates consume.
+
+## Entry-linking convention (the load-bearing decision)
+
+Payment and void must reference the original sale entry. The mechanism
+has no shared id store, so the **memo is the join key**: every journal
+entry the sale template posts carries the invoice id in its memo, and
+the payment/void templates locate entries by searching memos for that
+id. Documented in all three templates + a one-line note in
+`mc-invoice/SKILL.md`.
+
+## Decisions (all confirmed)
+
+1. **`when` predicate** — DECIDED: include it (the only host code).
+2. **Book resolution** — DECIDED: add a `defaultBookId` field to
+   `mc-profile` (`data/profile/items/me.json`) that the templates read
+   first; fall back to `getBooks` resolution when unset.
+3. **Void mechanism** — DECIDED: `voidEntry` the original entries (the
+   accounting plugin's native reversal); locate them by invoice-id memo
+   and confirm via `presentForm` before voiding.
+4. **Payment reference** — DECIDED: no payment-ref field added to the
+   `mc-invoice` schema. Payment is always direct deposit to the issuer's
+   bank account (profile `bankDetails`), so the method is fixed; the
+   payment template reads the optional `note` field for a reference if
+   the user put one there, otherwise it posts without one and does not
+   prompt.
+5. **Bank account on profile** — DECIDED: add a single free-form
+   `bankDetails` text field to `mc-profile` (not structured fields).
+   `invoice.md` renders it as a payment-instructions block; the issuer
+   types it however their country/bank expects.
+
+## Test plan
+
+- discovery tests: accept actions with a valid `when`; reject `when`
+  missing `field` or with an empty/!array `in`.
+- A pure visibility helper (`actionVisible(action, record)`) unit-tested:
+  no `when` → always; `in` match / non-match; missing field → hidden.
+- Manual (no collections e2e harness): set an invoice to `sent` → only
+  "Record sale" (+ PDF) shows → click → accounting chat posts Dr A/R /
+  Cr Revenue / Cr tax tagged with the invoice id; set to `paid` → "Record
+  payment" posts the cash receipt; set to `void` → "Record void" voids
+  the tagged entries. Re-clicking detects the existing entry and refuses
+  to double-post.
+- `yarn format` / `lint` / `typecheck` / `test` / `build` green.
+
+## Deferred / out of scope
+
+- **Accounts payable** (vendor bills you owe) — separate flow.
+- **`kind: "mutate"`** auto-posting on a status change (no chat) — these
+  stay user-clicked `kind: "chat"` actions for now.
+- **Auto-firing** an action when the user flips `status` in the edit
+  form — out of scope; the buttons are explicit.
+- Richer `when` operators (`notIn`, numeric comparisons) — add when a
+  real schema needs them.
+
+## What success looks like
+
+- The full issue → pay → void bookkeeping loop is driven from the
+  invoice detail view, each step posting a correct, invoice-tagged,
+  idempotent journal into the accounting book.
+- The only host code is the generic `when` predicate (~15 LoC across
+  types + discovery + CollectionView); everything invoice/accounting
+  specific is three schema rows + three skill templates.

--- a/plans/feat-invoice-bookkeeping.md
+++ b/plans/feat-invoice-bookkeeping.md
@@ -85,14 +85,26 @@ Each template gets the invoice record in the `<record_data_json>` block
 
 1. **Resolve the book.** First read `defaultBookId` from the profile
    (`data/profile/items/me.json`); if set, use it. Otherwise call
-   `getBooks`; if exactly one, use it; if several, pick the one matching
-   the invoice's currency/country, else `presentForm` to ask.
+   `getBooks`; if exactly one, use it; if several, narrow by the
+   invoice's currency/country, then by the book name matching the
+   issuer's `companyName`, and only if still ambiguous `presentForm` to
+   ask. (Setting `defaultBookId` skips all of this — strongly preferred
+   once books multiply.)
 2. **Tag every entry** with the invoice id in the memo (e.g.
    `INV-2026-0001`) so payment/void can find it later.
-3. **Idempotency.** Before posting, query the ledger (`getReport`) for an
-   existing entry whose memo contains this invoice id + this transaction
-   type; if found, tell the user it's already recorded and stop — don't
-   double-post.
+3. **Idempotency / entry lookup.** Locate prior entries with a compact,
+   bounded query: `getReport` `kind: "ledger"`, `accountCode: <A/R>`,
+   `period: { kind: "range", from: <issueDate>, to: <today> }`. This
+   returns small rows (`entryId`, `date`, `memo`) for just the A/R
+   account in a narrow window; the `memo` concatenates entry+line memos,
+   so the invoice id is searchable, and the `entryId` is what `voidEntry`
+   needs. If a row's memo matches this invoice id + transaction type,
+   it's already recorded — stop, don't double-post. **Do NOT use
+   `getJournalEntries`**: its `accountCode` filter keeps the *whole*
+   entry whenever *any* line touches A/R (≈ every entry in a receivables
+   book), and full entries (~2KB each, no pagination cap) blow the
+   tool-result size limit — observed twice in testing (~110 KB even when
+   filtered). The ledger report is ~10× smaller per row.
 
 Per-template specifics:
 
@@ -102,9 +114,9 @@ Per-template specifics:
   the real codes; never invent one.
 - **`journal-payment.md`** — find the open receivable for this invoice;
   post Dr Cash/Checking, Cr A/R for the total. Payment is always direct
-  deposit to the issuer's bank account (from the profile's `bankDetails`),
+  deposit to the issuer's bank account (from the profile's `paymentDetails`),
   so the debit is the Checking/Bank account in the book — match it via
-  `getAccounts`. If the invoice's `note` field carries a payment
+  `getAccounts`. If the invoice's `notes` field carries a payment
   reference, include it in the memo, otherwise post without one (do not
   prompt).
 - **`journal-void.md`** — find the sale entry (and payment entry, if
@@ -117,21 +129,21 @@ to the book (`openBook`) so the user can review.
 
 ## Profile additions (data — `mc-profile` / `data/profile/items/me.json`)
 
-Two new fields on the business profile schema, both optional:
+The business profile already carries the bank/remit-to info: the
+existing **`paymentDetails`** markdown field ("Payment details (bank /
+wire / PayPal)") is free-form and is already rendered in the invoice's
+PAYMENT block by `invoice.md`. We reuse it rather than add a duplicate
+`bankDetails` field. `journal-payment.md` treats its presence as
+confirmation that payment lands in the Checking/Bank account.
+
+One genuinely new field, optional:
 
 - **`defaultBookId`** (string) — the accounting book the journal
   templates post into (decision #2). Templates read it first; fall back
   to `getBooks` resolution when unset.
-- **`bankDetails`** (multi-line string, free-form) — the issuer's
-  remit-to bank info, typed however the issuer's country/bank expects
-  (US routing + account #, JP 銀行/支店/口座種別/口座番号, EU IBAN/BIC, …).
-  `invoice.md` renders it verbatim as a "payment instructions" block so
-  the client knows where to direct-deposit; `journal-payment.md` treats
-  its presence as confirmation that payment lands in the Checking/Bank
-  account.
 
-No host code — these are skill-schema fields the `mc-profile` collection
-and the invoice/journal templates consume.
+No host code — this is a skill-schema field the `mc-profile` collection
+and the journal templates consume.
 
 ## Entry-linking convention (the load-bearing decision)
 
@@ -153,14 +165,14 @@ id. Documented in all three templates + a one-line note in
    and confirm via `presentForm` before voiding.
 4. **Payment reference** — DECIDED: no payment-ref field added to the
    `mc-invoice` schema. Payment is always direct deposit to the issuer's
-   bank account (profile `bankDetails`), so the method is fixed; the
-   payment template reads the optional `note` field for a reference if
+   bank account (profile `paymentDetails`), so the method is fixed; the
+   payment template reads the optional `notes` field for a reference if
    the user put one there, otherwise it posts without one and does not
    prompt.
-5. **Bank account on profile** — DECIDED: add a single free-form
-   `bankDetails` text field to `mc-profile` (not structured fields).
-   `invoice.md` renders it as a payment-instructions block; the issuer
-   types it however their country/bank expects.
+5. **Bank account on profile** — DECIDED: reuse the existing free-form
+   `paymentDetails` markdown field on `mc-profile` (already rendered in
+   `invoice.md`); do NOT add a duplicate `bankDetails` field. The issuer
+   types their direct-deposit details however their country/bank expects.
 
 ## Test plan
 

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -10,6 +10,7 @@
 
 import { Router, Request, Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { actionVisible } from "../../../src/utils/collections/actionVisible.js";
 import {
   discoverCollections,
   generateItemId,
@@ -222,6 +223,14 @@ router.post(API_ROUTES.collections.itemAction, async (req: Request<{ slug: strin
     const record = await readItem(collection.dataDir, req.params.itemId);
     if (!record) {
       notFound(res, `item '${req.params.itemId}' not found`);
+      return;
+    }
+    // Enforce the action's `when` predicate server-side: the client
+    // hides out-of-state buttons, but a stale or crafted request could
+    // still target one (e.g. seed a payment journal for a non-paid
+    // invoice). The visibility rule is the authorization rule.
+    if (!actionVisible(action, record)) {
+      conflict(res, `action '${action.id}' is not available for item '${req.params.itemId}' in its current state`);
       return;
     }
     const template = await readSkillTemplate(collection.skillDir, action.template);

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -116,6 +116,15 @@ function isSafeTemplatePath(value: string): boolean {
   return value.split("/").every((seg) => seg.length > 0 && seg !== "." && seg !== ".." && /^[A-Za-z0-9._-]+$/.test(seg));
 }
 
+// Optional visibility predicate: the action button shows only when the
+// open record's `field` (stringified) is one of `in`. Domain-free —
+// `field` is any non-empty key, `in` a non-empty array of non-empty
+// values; the host never interprets the meaning.
+const ActionWhenSchema = z.object({
+  field: z.string().trim().min(1),
+  in: z.array(z.string().trim().min(1)).min(1),
+});
+
 // A schema-declared record action. Domain-free: the host validates the
 // shape; the meaning (which role, which template) is data.
 const ActionSpecSchema = z.object({
@@ -125,6 +134,7 @@ const ActionSpecSchema = z.object({
   kind: z.enum(["chat"]),
   role: z.string().trim().min(1),
   template: z.string().trim().min(1).refine(isSafeTemplatePath, "must be a safe skill-relative path (no `..`, no leading `/`, no backslash)"),
+  when: ActionWhenSchema.optional(),
 });
 
 const CollectionSchemaZ = z

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -34,6 +34,18 @@ export type CollectionSource = "user" | "project";
  *  another schema-shape change. */
 export type CollectionActionKind = "chat";
 
+/** Optional visibility predicate for an action: the button renders
+ *  only when the open record's `field` (stringified) is one of `in`.
+ *  Generic and domain-free — the host evaluates it against the record
+ *  with no knowledge of what the field means. Absent ⇒ always shown. */
+export interface CollectionActionWhen {
+  /** Top-level record field key whose value gates the button. */
+  field: string;
+  /** Allowed values; the button shows when `String(record[field])` is
+   *  one of these. Non-empty. */
+  in: string[];
+}
+
 /** A schema-declared, per-record action rendered as a button in the
  *  read-only detail view. Pure UI/behaviour directive — never stored,
  *  never validated against record data. All domain specifics (label,
@@ -53,6 +65,10 @@ export interface CollectionAction {
   /** `kind: "chat"`: skill-relative path to the template file whose
    *  text becomes the seed prompt body (e.g. `templates/invoice.md`). */
   template: string;
+  /** Optional visibility predicate; the button renders only when the
+   *  open record matches (see CollectionActionWhen). Absent ⇒ always
+   *  shown. */
+  when?: CollectionActionWhen;
 }
 
 export interface CollectionFieldSpec {

--- a/server/workspace/skills-preset/mc-invoice/SKILL.md
+++ b/server/workspace/skills-preset/mc-invoice/SKILL.md
@@ -125,14 +125,28 @@ Always include the `?selected=<id>` query: it opens that invoice directly in
 the read-only detail view. Omit it (link to plain `/collections/mc-invoice`)
 only for a general, non-specific reference to the whole list.
 
-## Generate PDF (host action)
+## Host actions (detail-view buttons)
 
-The invoice detail view shows a **Generate PDF** button (a schema-declared
-action). When the user clicks it, the host opens a *new* chat in the Accounting
-role seeded with a layout template (`templates/invoice.md`) + the invoice data,
-and that chat renders the printable document to `artifacts/invoices/<id>.md`.
-You don't trigger this yourself — just point the user at the button if they ask
-how to print/export an invoice.
+The invoice detail view shows schema-declared action buttons. Each opens a
+*new* chat in the `accounting` role seeded with a template + the invoice data —
+you don't trigger them yourself; point the user at the button if they ask.
+
+- **Generate PDF** (always shown) — `templates/invoice.md` renders the printable
+  document to the canvas via `presentDocument`.
+- **Record sale** (status `sent` / `paid`) — `templates/journal-sale.md` posts
+  the receivable journal (Dr A/R, Cr Revenue, Cr output-tax).
+- **Record payment** (status `paid`) — `templates/journal-payment.md` posts the
+  cash receipt (Dr Cash/Checking, Cr A/R).
+- **Record void** (status `void`) — `templates/journal-void.md` voids the
+  entries posted for this invoice.
+
+### Bookkeeping: the memo is the join key
+
+The journal actions have no shared id store, so every entry they post carries
+the invoice `id` in its memo (e.g. `INV-2026-0001 sale`). The payment and void
+templates locate prior entries by searching memos for that id. The book they
+post into is the issuer's `defaultBookId` (from `mc-profile`), or resolved at
+posting time when that is unset.
 
 ## When to ask vs. when to act
 

--- a/server/workspace/skills-preset/mc-invoice/schema.json
+++ b/server/workspace/skills-preset/mc-invoice/schema.json
@@ -84,6 +84,33 @@
       "kind": "chat",
       "role": "accounting",
       "template": "templates/invoice.md"
+    },
+    {
+      "id": "journal-sale",
+      "label": "Record sale",
+      "icon": "request_quote",
+      "kind": "chat",
+      "role": "accounting",
+      "template": "templates/journal-sale.md",
+      "when": { "field": "status", "in": ["sent", "paid"] }
+    },
+    {
+      "id": "journal-payment",
+      "label": "Record payment",
+      "icon": "payments",
+      "kind": "chat",
+      "role": "accounting",
+      "template": "templates/journal-payment.md",
+      "when": { "field": "status", "in": ["paid"] }
+    },
+    {
+      "id": "journal-void",
+      "label": "Record void",
+      "icon": "block",
+      "kind": "chat",
+      "role": "accounting",
+      "template": "templates/journal-void.md",
+      "when": { "field": "status", "in": ["void"] }
     }
   ]
 }

--- a/server/workspace/skills-preset/mc-invoice/templates/journal-payment.md
+++ b/server/workspace/skills-preset/mc-invoice/templates/journal-payment.md
@@ -1,0 +1,72 @@
+## Task: record the payment (cash-receipt) journal for this invoice
+
+The invoice record is in the `<record_data_json>` block above (fields:
+`id`, `clientId`, `issueDate`, `dueDate`, `status`, `lineItems[]`
+(`description`, `quantity`, `rate`), `taxRate`, `notes`). You are the
+`accounting` role and own `manageAccounting`. The invoice has been paid;
+post the cash-receipt journal that clears the receivable.
+
+Payment is always **direct deposit to the issuer's bank account** (the
+issuer's `paymentDetails` on `data/profile/items/me.json`), so the debit
+is the book's Cash / Checking / Bank account — there is no other payment
+method to consider.
+
+### 1. Resolve the book
+
+1. Read `data/profile/items/me.json`. If it has a non-empty
+   `defaultBookId`, use it as `bookId`. Otherwise call `getBooks` and
+   pick the book as in the sale flow (one → use it; several → narrow by
+   currency/country, then by the book name matching the issuer's
+   `companyName`, then `presentForm`).
+2. If no book exists, tell the user to set one up and stop.
+
+### 2. Resolve real account codes
+
+Call `getAccounts` and pick the actual codes — never invent one:
+
+- **Cash / Checking / Bank** (asset) — the debit (the bank account the
+  deposit landed in). If several bank accounts exist, match the one in
+  the issuer's `paymentDetails`; ask only if genuinely ambiguous.
+- **Accounts Receivable** (asset) — the credit, the same account the sale
+  entry debited. Note its code — step 3 needs it.
+
+### 3. Find the open receivable + guard against double-posting
+
+The **memo is the join key**. Look up the A/R activity with a **compact,
+bounded ledger query** — NOT `getJournalEntries`, whose full-entry output
+can exceed the tool-result size limit even when filtered. Call `getReport`
+with:
+
+- `kind: "ledger"`,
+- `accountCode: "<A/R code>"` (the Accounts Receivable code from step 2),
+- `period: { "kind": "range", "from": "<invoice issueDate>", "to": "<today>" }`.
+
+This returns small rows (`entryId`, `date`, `memo`, debit/credit); the
+`memo` concatenates entry- and line-level memos, so the invoice id is
+searchable. Among the rows:
+
+- Find the **sale** row whose memo contains this invoice `id` (and
+  `sale`). If none exists, tell the user the sale hasn't been recorded
+  yet — they should click **Record sale** first — and stop.
+- If a row's memo contains this invoice `id` and the word `payment`, the
+  payment is already recorded — **tell the user (`openBook`) and stop**;
+  do not double-post.
+
+### 4. Post one balanced entry
+
+Call `addEntries` with a single entry dated the payment date (use today
+if the record gives no payment date) for the invoice `total`
+(= subtotal + tax, recomputed from `lineItems` + `taxRate`):
+
+- **Dr** Cash / Checking — `total`
+- **Cr** Accounts Receivable — `total`
+
+Set the entry `memo` to include the invoice id and the word `payment`,
+e.g. `INV-2026-0001 payment`. If the invoice `notes` field carries a
+payment reference (a transfer id / deposit slip number), append it to the
+memo; otherwise post without one — **do not prompt for a reference**.
+
+### 5. Confirm
+
+In one sentence, confirm the cash receipt was posted and link the book
+with `openBook`.

--- a/server/workspace/skills-preset/mc-invoice/templates/journal-sale.md
+++ b/server/workspace/skills-preset/mc-invoice/templates/journal-sale.md
@@ -1,0 +1,78 @@
+## Task: record the sale (account-receivable) journal for this invoice
+
+The invoice record is in the `<record_data_json>` block above (fields:
+`id`, `clientId`, `issueDate`, `dueDate`, `status`, `lineItems[]`
+(`description`, `quantity`, `rate`), `taxRate`, `notes`). You are the
+`accounting` role and own `manageAccounting`. Post the double-entry sale
+journal for this invoice into the user's accounting book.
+
+### 1. Resolve the book
+
+1. Read `data/profile/items/me.json`. If it has a non-empty
+   `defaultBookId`, use that as `bookId` and skip the rest of this step.
+2. Otherwise call `manageAccounting` `getBooks`. If exactly one book
+   exists, use it. If several:
+   - keep only books whose currency/country fit the invoice;
+   - if that leaves exactly one, use it;
+   - if it leaves several, prefer the book whose name matches the
+     issuer's `companyName` from the profile (e.g. company
+     "Pervasive Co Ltd." → book "Pervasive");
+   - only if still ambiguous, `presentForm` to ask which book.
+3. If no book exists at all, tell the user to set one up first (the
+   `accounting` role can `createBook`) and stop.
+
+### 2. Resolve real account codes
+
+Call `getAccounts` for this book and pick the actual codes — never invent
+one:
+
+- **Accounts Receivable** (asset) — the debit.
+- **Revenue / Sales** (income) — the credit for the subtotal.
+- **Output tax / VAT / consumption-tax payable** (liability, e.g.
+  "Sales Tax Payable", typically `24xx`) — the credit for the tax. If a
+  suitable account doesn't exist and tax is non-zero, `upsertAccount` one
+  (or ask the user) before posting.
+
+Note the **Accounts Receivable** code — step 3 needs it.
+
+### 3. Guard against double-posting (idempotency)
+
+The **memo is the join key** — there is no shared id store. Every entry
+this invoice's journals post carries the invoice `id` in the memo. Before
+posting, look it up with a **compact, bounded ledger query** — NOT
+`getJournalEntries`, whose full-entry output can exceed the tool-result
+size limit even when filtered. Call `getReport` with:
+
+- `kind: "ledger"`,
+- `accountCode: "<A/R code>"` (the Accounts Receivable code from step 2),
+- `period: { "kind": "range", "from": "<invoice issueDate>", "to": "<today>" }`.
+
+This returns small rows (`entryId`, `date`, `memo`, debit/credit) for just
+the A/R account in a narrow date window; the `memo` concatenates the
+entry- and line-level memos, so the invoice id is searchable. If any row's
+memo contains this invoice `id` and the word `sale`, **tell the user the
+sale is already recorded (link the book with `openBook`) and stop — do not
+post a duplicate.**
+
+### 4. Compute the amounts
+
+From `lineItems`: `subtotal` = Σ(`quantity` × `rate`). `tax` = `subtotal`
+× `taxRate` (treat a missing/zero `taxRate` as 0). `total` = `subtotal` +
+`tax`. (Do not trust any `subtotal`/`tax`/`total` in the record — those
+are host-computed display fields and may be absent here.)
+
+### 5. Post one balanced entry
+
+Call `addEntries` with a single entry dated the invoice `issueDate`:
+
+- **Dr** Accounts Receivable — `total`
+- **Cr** Revenue — `subtotal`
+- **Cr** Output tax — `tax` *(omit this line entirely when tax is 0)*
+
+Set the entry `memo` to include the invoice id and the word `sale`, e.g.
+`INV-2026-0001 sale`. Σ debit must equal Σ credit.
+
+### 6. Confirm
+
+In one sentence, confirm what was posted (the accounts + total) and link
+the book with `openBook` so the user can review.

--- a/server/workspace/skills-preset/mc-invoice/templates/journal-void.md
+++ b/server/workspace/skills-preset/mc-invoice/templates/journal-void.md
@@ -1,0 +1,56 @@
+## Task: void the bookkeeping journals for this invoice
+
+The invoice record is in the `<record_data_json>` block above (fields:
+`id`, `clientId`, `issueDate`, `dueDate`, `status`, `lineItems[]`,
+`taxRate`, `notes`). You are the `accounting` role and own
+`manageAccounting`. The invoice has been voided; reverse the journals
+that were posted for it so the book no longer reflects the sale.
+
+### 1. Resolve the book
+
+Read `data/profile/items/me.json` for a non-empty `defaultBookId` and use
+it as `bookId`; otherwise resolve via `getBooks` (one → use it; several →
+narrow by currency/country, then by the book name matching the issuer's
+`companyName`, then `presentForm`). If no book exists, there is nothing
+to void — say so and stop.
+
+### 2. Resolve the Accounts Receivable code
+
+Call `getAccounts` and note the **Accounts Receivable** code — step 3
+uses it to bound the entry search.
+
+### 3. Find the entries to void (memo is the join key)
+
+Look up the A/R activity with a **compact, bounded ledger query** — NOT
+`getJournalEntries`, whose full-entry output can exceed the tool-result
+size limit even when filtered. Call `getReport` with:
+
+- `kind: "ledger"`,
+- `accountCode: "<A/R code>"` (the Accounts Receivable code from step 2),
+- `period: { "kind": "range", "from": "<invoice issueDate>", "to": "<today>" }`.
+
+Every sale and payment entry for the invoice touches A/R, so its rows
+appear here. Each row carries the `entryId` you pass to `voidEntry`.
+Collect every row whose memo contains this invoice `id`:
+
+- the **sale** entry (memo has `sale`), and
+- the **payment** entry (memo has `payment`), if one was posted.
+
+Ignore rows already part of a void/reversal (don't re-void a reversal).
+**If no live row references this invoice, tell the user there is nothing
+to void and stop** — do not post anything.
+
+### 4. Confirm, then void
+
+Voiding is irreversible bookkeeping. Per the `accounting` role's
+`voidEntry` guidance, **confirm with the user via `presentForm` first** —
+list the entries you found (date, accounts, amount, `entryId`) and ask
+them to confirm the void. On confirmation, call `voidEntry` once per
+entry, passing its `entryId` and a `reason` that names the invoice (e.g.
+`Void INV-2026-0001`). `voidEntry` appends a reversing pair — the journal
+stays append-only.
+
+### 5. Confirm
+
+In one sentence, confirm which entries were voided (or that there were
+none) and link the book with `openBook`.

--- a/server/workspace/skills-preset/mc-invoice/templates/journal-void.md
+++ b/server/workspace/skills-preset/mc-invoice/templates/journal-void.md
@@ -31,14 +31,21 @@ size limit even when filtered. Call `getReport` with:
 
 Every sale and payment entry for the invoice touches A/R, so its rows
 appear here. Each row carries the `entryId` you pass to `voidEntry`.
-Collect every row whose memo contains this invoice `id`:
+Select the entries to void with these explicit, deterministic rules — do
+NOT void anything that fails them:
 
-- the **sale** entry (memo has `sale`), and
-- the **payment** entry (memo has `payment`), if one was posted.
+1. **Keep only original sale/payment rows.** A row qualifies only if its
+   memo contains this invoice `id` **and** the word `sale` or `payment`.
+   This excludes the reversing entries a prior void posted, whose memo is
+   the void reason (`Void INV-…`) and contains neither word.
+2. **Deduplicate by `entryId`** (an entry spans several A/R rows only if
+   it has multiple A/R lines, but treat each `entryId` once).
+3. **Skip anything already voided.** If a qualifying entry already has a
+   matching opposite-sign reversal in the ledger for this invoice (same
+   amount, memo `Void INV-…`), it was voided before — drop it.
 
-Ignore rows already part of a void/reversal (don't re-void a reversal).
-**If no live row references this invoice, tell the user there is nothing
-to void and stop** — do not post anything.
+**If no entry survives these rules, tell the user there is nothing to
+void and stop** — do not post anything.
 
 ### 4. Confirm, then void
 

--- a/server/workspace/skills-preset/mc-profile/SKILL.md
+++ b/server/workspace/skills-preset/mc-profile/SKILL.md
@@ -44,6 +44,9 @@ types):
 - `address` — multi-line text
 - `paymentDetails` — markdown (free-form bank / wire / PayPal instructions, so
   it isn't tied to any one country's bank-account structure)
+- `defaultBookId` — string (the accounting book the invoice bookkeeping actions
+  post journals into; the `accounting` role reads it to skip book selection.
+  Leave unset and the role resolves the book at posting time)
 - `notes` — markdown
 
 Leave optional fields the user hasn't given you out of the JSON entirely — don't

--- a/server/workspace/skills-preset/mc-profile/schema.json
+++ b/server/workspace/skills-preset/mc-profile/schema.json
@@ -36,6 +36,10 @@
       "type": "markdown",
       "label": "Payment details (bank / wire / PayPal)"
     },
+    "defaultBookId": {
+      "type": "string",
+      "label": "Default accounting book ID"
+    },
     "notes": {
       "type": "markdown",
       "label": "Notes"

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -328,12 +328,12 @@
       data-testid="collections-detail"
       @click.self="closeView"
     >
-      <div class="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[80vh] flex flex-col">
+      <div class="bg-white rounded-lg shadow-xl w-4/5 max-h-[80vh] flex flex-col">
         <header class="px-5 py-3 border-b border-gray-200 flex items-center gap-3">
           <span class="material-icons text-blue-600 text-base">{{ collection.icon }}</span>
           <h2 class="text-base font-medium text-gray-900 flex-1 min-w-0 truncate">{{ viewTitle }}</h2>
           <button
-            v-for="action in collection.schema.actions ?? []"
+            v-for="action in visibleActions"
             :key="action.id"
             type="button"
             class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 bg-white hover:bg-gray-50 text-sm text-gray-700 disabled:opacity-50"
@@ -433,6 +433,7 @@ import type { EmbedRow, EmbedView } from "./collectionEmbed";
 import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { evaluateDerived } from "../utils/collections/derivedFormula";
+import { actionVisible } from "../utils/collections/actionVisible";
 
 type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived" | "embed";
 
@@ -496,6 +497,9 @@ interface CollectionAction {
   kind: "chat";
   role: string;
   template: string;
+  /** Optional visibility predicate: the button renders only when
+   *  `String(record[when.field])` is one of `when.in`. */
+  when?: { field: string; in: string[] };
 }
 
 interface CollectionSchema {
@@ -621,6 +625,15 @@ function actionUrl(slug: string, itemId: string, actionId: string): string {
     .replace(":itemId", encodeURIComponent(itemId))
     .replace(":actionId", encodeURIComponent(actionId));
 }
+
+/** Actions whose optional `when` predicate matches the open record.
+ *  Status-driven buttons (e.g. invoice "Record payment") stay hidden
+ *  until the record reaches the matching state. */
+const visibleActions = computed<CollectionAction[]>(() => {
+  const record = viewing.value;
+  if (!record) return [];
+  return (collection.value?.schema.actions ?? []).filter((action) => actionVisible(action, record));
+});
 
 /** Run a schema-declared action on the open record: ask the server to
  *  assemble the seed prompt, then start a new chat in the action's

--- a/src/utils/collections/actionVisible.ts
+++ b/src/utils/collections/actionVisible.ts
@@ -1,0 +1,25 @@
+// Pure visibility predicate for schema-declared collection actions.
+// Kept as its own module (no Vue) so CollectionView can stay thin and
+// the match semantics are pinned by unit tests. Domain-free: the host
+// compares the stringified record value against the allowed set with no
+// knowledge of what the field means.
+
+/** Minimal shape this helper needs from an action — just its optional
+ *  `when` predicate. Accepts the full CollectionAction too. */
+export interface ActionWithWhen {
+  when?: { field: string; in: string[] };
+}
+
+/** True when the action's button should render against `record`:
+ *  - no `when` ⇒ always visible;
+ *  - otherwise visible only when `record[when.field]` is present and its
+ *    stringified value is one of `when.in`.
+ *  A missing/undefined field is treated as "not a match" (hidden), so a
+ *  status-gated action never shows on a record that lacks the status. */
+export function actionVisible(action: ActionWithWhen, record: Record<string, unknown>): boolean {
+  const { when } = action;
+  if (!when) return true;
+  const value = record[when.field];
+  if (value === undefined || value === null) return false;
+  return when.in.includes(String(value));
+}

--- a/test/utils/collections/test_actionVisible.ts
+++ b/test/utils/collections/test_actionVisible.ts
@@ -1,0 +1,40 @@
+// Unit tests for the pure action-visibility predicate
+// (src/utils/collections/actionVisible.ts).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { actionVisible } from "../../../src/utils/collections/actionVisible.js";
+
+describe("actionVisible", () => {
+  it("is always visible when no `when` predicate is set", () => {
+    assert.equal(actionVisible({}, {}), true);
+    assert.equal(actionVisible({}, { status: "anything" }), true);
+  });
+
+  it("shows when the field value is in the allowed set", () => {
+    const action = { when: { field: "status", in: ["sent", "paid"] } };
+    assert.equal(actionVisible(action, { status: "sent" }), true);
+    assert.equal(actionVisible(action, { status: "paid" }), true);
+  });
+
+  it("hides when the field value is not in the allowed set", () => {
+    const action = { when: { field: "status", in: ["paid"] } };
+    assert.equal(actionVisible(action, { status: "sent" }), false);
+    assert.equal(actionVisible(action, { status: "draft" }), false);
+  });
+
+  it("hides when the gating field is missing or null", () => {
+    const action = { when: { field: "status", in: ["sent"] } };
+    assert.equal(actionVisible(action, {}), false);
+    assert.equal(actionVisible(action, { status: undefined }), false);
+    assert.equal(actionVisible(action, { status: null }), false);
+  });
+
+  it("compares against the stringified value (non-string fields)", () => {
+    const action = { when: { field: "level", in: ["1", "2"] } };
+    assert.equal(actionVisible(action, { level: 1 }), true);
+    assert.equal(actionVisible(action, { level: 3 }), false);
+    assert.equal(actionVisible({ when: { field: "active", in: ["true"] } }, { active: true }), true);
+  });
+});

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -585,6 +585,56 @@ describe("discoverCollections — actions", () => {
     });
     assert.equal((await listCollections()).length, 0);
   });
+
+  it("accepts an action with a valid `when` predicate", async () => {
+    writeSkill("test-actions-when", {
+      title: "X",
+      icon: "receipt",
+      dataPath: "data/actwhen/items",
+      primaryKey: "id",
+      fields,
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { field: "status", in: ["sent", "paid"] } }],
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.deepEqual(collections[0]?.schema.actions?.[0]?.when, { field: "status", in: ["sent", "paid"] });
+  });
+
+  it("rejects a `when` missing `field`", async () => {
+    writeSkill("test-actions-when-nofield", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/actwhennf/items",
+      primaryKey: "id",
+      fields,
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { in: ["sent"] } }],
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a `when` whose `in` is empty", async () => {
+    writeSkill("test-actions-when-emptyin", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/actwhenei/items",
+      primaryKey: "id",
+      fields,
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { field: "status", in: [] } }],
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a `when` whose `in` is not an array", async () => {
+    writeSkill("test-actions-when-notarray", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/actwhenna/items",
+      primaryKey: "id",
+      fields,
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { field: "status", in: "sent" } }],
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
 });
 
 describe("discoverCollections — workspaceRoot propagation", () => {


### PR DESCRIPTION
## Summary

Adds the bookkeeping side of the invoice lifecycle on top of the schema-declared `actions` mechanism (#1511). When an invoice you **issue** is sent, paid, or voided, a detail-view button hands the `accounting` role a templated instruction to post the matching double-entry journal — sale, payment, or void.

Per the hard constraint, **no invoice/accounting literals land in `server/` or `src/`**: each bookkeeping action is a row in `mc-invoice/schema.json` and the journal logic lives in skill templates. The only host code is one generic, reusable `when` visibility predicate on collection actions.

## What's in it

**Host (generic, ~reusable):**
- `CollectionActionWhen` type + Zod validation in collections discovery (`field` non-empty, `in` non-empty string array)
- pure `actionVisible(action, record)` helper (`src/utils/collections/`) wired into `CollectionView` so status-gated buttons render only on matching records
- widen the read-only detail modal from `max-w-lg` to `w-4/5` so the action buttons fit

**Data (invoice/accounting specifics, all in the skill folder):**
- 3 journal actions on `mc-invoice/schema.json`: `journal-sale` (status `sent`/`paid`), `journal-payment` (`paid`), `journal-void` (`void`)
- `defaultBookId` field on `mc-profile` (bank/remit-to info reuses the existing `paymentDetails` field — no duplicate)
- 3 templates under `mc-invoice/templates/`

**Template design decisions:**
- **Book resolution:** read `defaultBookId` from the profile; else `getBooks` and narrow by currency/country → book name vs. issuer `companyName` → `presentForm`.
- **Entry linking:** no shared id store, so the **invoice id in each entry memo is the join key**; payment/void locate prior entries by memo.
- **Lookup:** uses the compact, date-bounded `getReport(kind: "ledger", accountCode, period: {range})` rather than `getJournalEntries` — the latter returns full entries (~2KB each, no cap) and overflows the tool-result limit on a busy A/R account (observed in live testing).

## Decisions (confirmed with reviewer)

1. include the `when` predicate · 2. `defaultBookId` on `mc-profile` · 3. native `voidEntry` · 4. no payment-ref field (optional `notes`) · 5. reuse `paymentDetails` for bank info

## Test plan

- [x] discovery tests: accept valid `when`; reject missing `field` / empty / non-array `in`
- [x] `actionVisible` unit tests: no `when` → always; in/out match; missing field → hidden; stringified compare
- [x] `yarn format` / `lint` / `typecheck` / `test` / `build` green
- [x] manual live run: **Record sale** posts Dr A/R / Cr Revenue / Cr tax tagged with the invoice id; **Record payment** posts Dr Bank / Cr A/R clearing the receivable
- [ ] manual: **Record void** end-to-end; re-click idempotency (refuses to double-post) — pending
- [ ] eyeball the widened modal on a large screen

## Notes / possible follow-up

`manageAccounting` has no memo-search and no result cap on `getJournalEntries`; a generic `limit` or memo filter would make any large-book lookup safe. Out of scope here (accounting-plugin concern). Accounts *payable* (vendor bills) is the mirror flow and also deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional invoice bookkeeping actions: Record Sale (sent/paid), Record Payment (paid), Record Void (void); shown only when the invoice status matches.
  * Collection action buttons now respect visibility rules and are enforced when invoking actions.
  * New optional "Default Accounting Book ID" in business profile to streamline posting.

* **Documentation**
  * Updated invoice and profile docs with bookkeeping workflow and posting guidance.

* **Tests**
  * Added tests for action visibility and schema validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->