### PR TITLE
feat(skills): bridge schema.json + templates so collection skills can be authored at runtime

### DIFF
--- a/plans/feat-collection-skill-authoring.md
+++ b/plans/feat-collection-skill-authoring.md
@@ -1,0 +1,211 @@
+# Plan: let the agent author collection skills (carry `schema.json` across the `.claude/` gate)
+
+## Problem
+
+A **collection skill** is a skill dir that ships `schema.json` (+ optional
+`templates/*.md`) next to `SKILL.md`. Discovery scans only
+`~/.claude/skills/` and `<workspace>/.claude/skills/`
+(`server/workspace/collections/discovery.ts:357-358`) — the `schema.json`
+**must** land in `.claude/skills/<slug>/` for a collection to register.
+
+The agent cannot put it there:
+
+- **Direct `Write` to `.claude/skills/…` is gated.** Claude Code applies a
+  self-modification permission prompt to `.claude/` that fires even with an
+  explicit `Write(.claude/**)` allow rule; MulmoClaude's headless transport
+  has no surface to answer it, so the write fails with "you haven't granted
+  it yet." (Documented at `server/workspace/hooks/handlers/skillBridge.ts:7-15`.)
+- **The skill-bridge only carries `SKILL.md`.** The sanctioned crossing
+  (write to `data/skills/<slug>/SKILL.md`, hook mirrors it into
+  `.claude/skills/<slug>/`) drops every sibling: `slugFromDataPath` returns
+  `null` for any basename other than `SKILL.md`
+  (`skillBridge.ts:104-115`, comment at `:99-103`). `schema.json` never crosses.
+- **The `manageSkills` MCP tool writes host-side (gate-free) but only emits
+  `SKILL.md`.** `saveProjectSkill` writes a single file via
+  `writeFileAtomic(projectSkillPath(...))` (`server/workspace/skills/writer.ts:61-69`);
+  its only content params are `name` / `description` / `body`
+  (`src/plugins/manageSkills/definition.ts:34-46`). No `schema.json`, no
+  templates, no multi-file write path.
+
+So today a collection skill can only be created by the server's boot-time
+preset sync (`syncPresetSkills`) — i.e. the bundled `mc-*` collections — never
+by the agent at runtime.
+
+### Role-availability constraint (affects the approach choice)
+
+The `manageSkills` MCP tool is exposed to **only the `tutor` role**
+(`src/config/roles.ts:211`). Per #1295 (`roles.ts:244-256`) the management
+tools were de-bundled in favor of the `mc-manage-skills` *skill* (file-editing,
+discoverable by every role). So:
+
+- The **MCP-tool** path is gate-free but reaches one role.
+- The **skill / bridge** path reaches every role but can't carry `schema.json`.
+
+## Two candidate designs
+
+### Design A — extend the `manageSkills` MCP tool (host-side writer)
+
+Add a `schema` (and optional `templates`) parameter; the server writes
+`schema.json` + `templates/*` alongside `SKILL.md` into
+`.claude/skills/<slug>/`. Host-side fs ⇒ no permission gate.
+
+- **Pros:** one transactional host call; can **validate the schema at write
+  time** with `CollectionSchemaZ` and return a real error instead of the
+  discovery-time silent skip; clear success/failure result.
+- **Cons:** only `tutor` has the tool — needs `availablePlugins` wiring for
+  every role that should author collections; runs against the #1295 direction
+  (which moved away from bundled management MCP tools).
+
+### Design B — extend the skill-bridge to mirror the whole skill dir
+
+Teach the bridge to mirror `data/skills/<slug>/schema.json` and
+`data/skills/<slug>/templates/*.md` (not just `SKILL.md`) into
+`.claude/skills/<slug>/`. The agent writes the files to `data/skills/`
+(gate-free — it's not `.claude/`) via its normal `Write` tool; the hook copies
+them over.
+
+- **Pros:** no role changes (every role already has `Write` to `data/`);
+  aligned with the current "skills edit files directly" architecture; the
+  `mc-manage-skills` skill already instructs the `data/skills/` + bridge flow.
+- **Cons:** mirror is best-effort / silent-fail by design
+  (`skillBridge.ts:179-188`) — a failed mirror leaves the staging copy with no
+  in-chat error; no validate-on-write (bad schema is logged + skipped at
+  discovery); multi-file mirror needs careful path/slug safety (templates
+  subdir, deletes).
+
+**Recommendation:** start with **Design B**. It reaches all roles with zero
+role wiring, fits the post-#1295 file-editing model, and the existing
+`mc-manage-skills` instructions already point at `data/skills/`. Layer
+Design A's validate-on-write later only if silent discovery-skips prove
+confusing in practice. (Decision is the first open question below — confirm
+before I implement.)
+
+---
+
+## Why the bridge mirrors `SKILL.md` only today — and how to widen it safely
+
+The "drop siblings" behaviour is deliberate, per the original commits
+(PR #1298 `11fdf900`, fix `7aa7e6eb`). Three reasons, so the widening
+respects them rather than steamrolls them:
+
+1. **A skill was modelled as one file.** Siblings (`README.md`, `assets/`)
+   were treated as the author's *scratch* material — "skill authors can keep
+   extra material there until they decide what belongs in the shipped bundle"
+   (`7aa7e6eb`). The bridge is a **publish boundary**: only the canonical file
+   is promoted; drafts stay staging-side.
+2. **The bridge is a deliberate hole in the `.claude/` self-modification
+   gate.** `.claude/` is gated *because* it holds the agent's own
+   skills/hooks/settings. The narrower the bypass, the safer — hence one known
+   filename, two segments deep, strict `SLUG_RE`, no subtrees, and (on delete)
+   no wildcards/bulk `rm`.
+3. **It was a targeted fix and `schema.json` didn't exist as agent output
+   yet.** Runtime collection authoring wasn't a use case; the `mc-*`
+   collections are boot-synced server-side, never bridged.
+
+The load-bearing assumption is #1 — and it's exactly what breaks for
+collections: `schema.json` is **not scratch**, it's the required, defining
+artifact (no schema → no collection). So the correct widening is **not**
+"mirror the whole dir" (that would blow reason #2's narrow hole wide open —
+the agent could auto-publish a `settings.json`, an executable, arbitrary
+nested trees into its own config dir). Instead: **mirror a fixed allowlist of
+filenames that are canonical for a collection**, keeping every existing guard.
+
+**Allowlist to cross the gate (and nothing else):**
+
+- `SKILL.md` — unchanged.
+- `schema.json` — the collection definition.
+- `templates/*.md` — only because schema `actions` reference them by path
+  (`discovery.ts` action `template`); a single `templates/` segment, no deeper.
+
+Any other basename / path shape stays staging-side, exactly as today.
+
+---
+
+## Design B — change surface
+
+1. **`server/workspace/hooks/handlers/skillBridge.ts`**
+   - Widen `slugFromDataPath` (`:104-115`) from "basename must be `SKILL.md`"
+     to "basename/relpath is on the **allowlist**" — `SKILL.md`, `schema.json`,
+     or `templates/<name>.md`. Return both the slug **and the relative
+     destination path** so the mirror knows where to write (today it only
+     returns the slug and hard-codes `SKILL.md`). Reject everything else, same
+     as now.
+   - Keep the strict `SLUG_RE` guard. For the `templates/` case, allow exactly
+     one `templates/` segment + a safe `*.md` basename (reuse the safe-name
+     rule from action `template` validation, `discovery.ts:114-117`); no `..`,
+     no deeper nesting, no non-`.md`.
+   - `mirrorWrite` (`:138-146`) already does atomic tmp+rename into the slug
+     dir — parameterize it by the relative destination filename so it can write
+     `schema.json` / `templates/x.md` as well as `SKILL.md`. `mkdirSync(destDir,
+     {recursive:true})` already covers the `templates/` subdir.
+   - **Delete is NOT a no-op anymore.** `rm -rf data/skills/<slug>` → mirror
+     `rm -rf .claude/skills/<slug>` (`:148-150`) is still correct (whole-dir
+     delete sweeps the new files too). But the `mc-manage-skills` *plain-skill*
+     delete still works file-by-file in some flows — confirm the canonical
+     delete is the whole-`<slug>/`-dir form so an orphaned `schema.json` can't
+     survive a SKILL.md-only delete. (See item 2.)
+   - Refresh ordering invariant (`:159-161`, `:170-173`) unchanged: mirror,
+     then `POST /api/config/refresh` so discovery re-scans. Note `configRefresh`
+     has its own `data/skills/*.md` matcher — verify it also fires for a
+     `schema.json`-only write (a collection edit that doesn't touch SKILL.md
+     must still trigger a re-scan), else widen it too.
+
+2. **`server/workspace/skills-preset/mc-manage-skills/SKILL.md`**
+   - Document the collection flow: to create a collection, write
+     `data/skills/<slug>/SKILL.md` **and** `data/skills/<slug>/schema.json`
+     (+ `templates/*.md` if it declares actions); the bridge mirrors all of
+     them; the collection appears at `/collections/<slug>`.
+
+3. **`server/workspace/helps/collection-skills.md`** (the doc that caused the
+   original failure)
+   - Replace every "write to `<workspace>/.claude/skills/<slug>/…`"
+     instruction with "write to `data/skills/<slug>/…`; the host mirrors it
+     into `.claude/skills/`." Fix the Anatomy diagram, the SKILL.md path, the
+     schema.json path, and the End-to-end checklist.
+
+4. **Tests** (`test/` mirrors source)
+   - Unit: bridge matcher accepts `schema.json` + `templates/x.md`, rejects
+     traversal (`../`, nested dirs, bad slug), still rejects unrelated
+     basenames. Mirror copies content faithfully; delete removes the dir.
+   - Integration (if a harness exists for the hook + discovery): write a full
+     collection under `data/skills/` and assert it shows up via
+     `discoverCollections()`.
+
+## Design A — change surface (only if we pick A, or layer it on later)
+
+1. `src/plugins/manageSkills/definition.ts` — add optional `schema`
+   (string or object) and `templates` (`[{ path, content }]`) params.
+2. `server/api/routes/skills.ts` — accept + validate on create/update; run
+   `schema` through `CollectionSchemaZ` and 400 on failure.
+3. `server/workspace/skills/writer.ts` — `saveProjectSkill` /
+   `updateProjectSkill` write `schema.json` (+ templates) into the slug dir;
+   `deleteProjectSkill` must remove siblings (today it `unlink`s SKILL.md then
+   `rmdir`, which **fails** when siblings exist — `:159-163` — orphaning the
+   dir).
+4. `src/config/roles.ts` — add `TOOL_NAMES.manageSkills` to the
+   `availablePlugins` of every role meant to author collections (decide which;
+   `general` / `personal` at minimum). Note the CI guard at `roles.ts:460`.
+5. Docs — same updates as B items 2-3, pointing at the tool instead of files.
+
+## Out of scope
+
+- Editing existing records (that's already Read/Write on `data/<name>/items/`).
+- User-scope (`~/.claude/skills/`) collection authoring — project scope only,
+  same boundary the writer already enforces.
+- Schema migration of existing records when a schema changes (documented
+  deferred item in `docs/collections-architecture.md`).
+- **Removing the `manageSkills` plugin.** Its MCP write tool is now redundant
+  (the agent authors via `data/skills/` + bridge), but the `/api/skills` route
+  + Skills catalog UI on the same plugin are still live. Excision is deferred
+  to its own PR — NOT part of this branch. Bridge work stands without it.
+
+## Open questions
+
+1. ~~**Design A vs B?**~~ **RESOLVED → Design B** (widen the bridge to a fixed
+   allowlist; no role wiring, fits #1295).
+2. If B: do we also want validate-on-write later, or is the discovery-time
+   log-and-skip acceptable? (A bad schema currently fails silently from the
+   user's view — only a server log.)
+3. If A: which roles get `manageSkills`? (`general`, `personal`, … ?)
+4. Should `mc-manage-skills` actively *teach* collection authoring, or just
+   reference `collection-skills.md`? (Keeps one source of truth.)

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -142,13 +142,21 @@ function errorMessage(err, fallback) {
   return String(err);
 }
 
+// server/workspace/collections/templatePath.ts
+var TEMPLATES_PREFIX = "templates/";
+function isSafeTemplatePath(value) {
+  if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
+  return value.split("/").every((seg) => seg.length > 0 && seg !== "." && seg !== ".." && /^[A-Za-z0-9._-]+$/.test(seg));
+}
+function isSafeActionTemplatePath(value) {
+  return value.startsWith(TEMPLATES_PREFIX) && isSafeTemplatePath(value);
+}
+
 // server/workspace/hooks/handlers/skillBridge.ts
 var DATA_SKILLS_DIR = path3.join("data", "skills");
 var CLAUDE_SKILLS_DIR = path3.join(".claude", "skills");
 var SKILL_FILENAME = "SKILL.md";
 var SCHEMA_FILENAME = "schema.json";
-var TEMPLATES_DIR = "templates";
-var SAFE_TEMPLATE_RE = /^[A-Za-z0-9_-][A-Za-z0-9._-]*\.md$/;
 var SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 var RM_RE = /^\s*rm\s+((?:-[a-zA-Z]+\s+)+)['"]?data\/skills\/([a-z0-9-]+)\/?['"]?\s*$/;
 var RECURSIVE_FLAG_RE = /[rR]/;
@@ -162,10 +170,7 @@ function isAllowlisted(relSegments) {
   if (relSegments.length === 1) {
     return relSegments[0] === SKILL_FILENAME || relSegments[0] === SCHEMA_FILENAME;
   }
-  if (relSegments.length === 2 && relSegments[0] === TEMPLATES_DIR) {
-    return SAFE_TEMPLATE_RE.test(relSegments[1]);
-  }
-  return false;
+  return isSafeActionTemplatePath(relSegments.join("/"));
 }
 function bridgeTargetFromDataPath(filePath) {
   const root = workspaceRoot();

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -146,31 +146,38 @@ function errorMessage(err, fallback) {
 var DATA_SKILLS_DIR = path3.join("data", "skills");
 var CLAUDE_SKILLS_DIR = path3.join(".claude", "skills");
 var SKILL_FILENAME = "SKILL.md";
+var SCHEMA_FILENAME = "schema.json";
+var TEMPLATES_DIR = "templates";
+var SAFE_TEMPLATE_RE = /^[A-Za-z0-9_-][A-Za-z0-9._-]*\.md$/;
 var SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 var RM_RE = /^\s*rm\s+((?:-[a-zA-Z]+\s+)+)['"]?data\/skills\/([a-z0-9-]+)\/?['"]?\s*$/;
 var RECURSIVE_FLAG_RE = /[rR]/;
 function dataSkillDir(slug) {
   return path3.join(workspaceRoot(), DATA_SKILLS_DIR, slug);
 }
-function dataSkillFilePath(slug) {
-  return path3.join(dataSkillDir(slug), SKILL_FILENAME);
-}
 function claudeSkillDir(slug) {
   return path3.join(workspaceRoot(), CLAUDE_SKILLS_DIR, slug);
 }
-function claudeSkillFilePath(slug) {
-  return path3.join(claudeSkillDir(slug), SKILL_FILENAME);
+function isAllowlisted(relSegments) {
+  if (relSegments.length === 1) {
+    return relSegments[0] === SKILL_FILENAME || relSegments[0] === SCHEMA_FILENAME;
+  }
+  if (relSegments.length === 2 && relSegments[0] === TEMPLATES_DIR) {
+    return SAFE_TEMPLATE_RE.test(relSegments[1]);
+  }
+  return false;
 }
-function slugFromDataPath(filePath) {
+function bridgeTargetFromDataPath(filePath) {
   const root = workspaceRoot();
   const staging = path3.join(root, DATA_SKILLS_DIR);
   const rel = path3.relative(staging, filePath);
-  if (!rel || rel.startsWith("..")) return null;
+  if (!rel || rel.startsWith("..") || path3.isAbsolute(rel)) return null;
   const segments = rel.split(path3.sep);
-  if (segments.length !== 2) return null;
-  const [slug, basename] = segments;
-  if (basename !== SKILL_FILENAME) return null;
-  return SLUG_RE.test(slug) ? slug : null;
+  if (segments.length < 2) return null;
+  const [slug, ...relSegments] = segments;
+  if (!SLUG_RE.test(slug)) return null;
+  if (!isAllowlisted(relSegments)) return null;
+  return { slug, relSegments };
 }
 function slugFromRmCommand(command) {
   const match = RM_RE.exec(command);
@@ -179,12 +186,14 @@ function slugFromRmCommand(command) {
   if (!RECURSIVE_FLAG_RE.test(flags)) return null;
   return SLUG_RE.test(slug) ? slug : null;
 }
-function mirrorWrite(slug) {
-  const content = readFileSync2(dataSkillFilePath(slug), "utf-8");
-  const destDir = claudeSkillDir(slug);
+function mirrorWrite(target) {
+  const { slug, relSegments } = target;
+  const src = path3.join(dataSkillDir(slug), ...relSegments);
+  const content = readFileSync2(src, "utf-8");
+  const dest = path3.join(claudeSkillDir(slug), ...relSegments);
+  const destDir = path3.dirname(dest);
   mkdirSync(destDir, { recursive: true });
-  const dest = claudeSkillFilePath(slug);
-  const tmp = path3.join(destDir, `.SKILL.md.${process.pid}.tmp`);
+  const tmp = path3.join(destDir, `.${path3.basename(dest)}.${process.pid}.tmp`);
   writeFileSync(tmp, content, "utf-8");
   renameSync(tmp, dest);
 }
@@ -197,16 +206,20 @@ async function refreshConfig() {
 async function handleWriteOrEdit(payload) {
   const filePath = extractFilePath(payload);
   if (!filePath) return;
-  const slug = slugFromDataPath(filePath);
-  if (slug === null) return;
+  const target = bridgeTargetFromDataPath(filePath);
+  if (target === null) return;
+  const { slug, relSegments } = target;
+  const relPath = relSegments.join("/");
   try {
-    mirrorWrite(slug);
+    mirrorWrite(target);
     await refreshConfig();
-    await serverLog("skill-bridge", `mirrored ${dataSkillFilePath(slug)} \u2192 ${claudeSkillFilePath(slug)}`, { data: { slug, op: "write" } });
+    const srcPath = path3.join(dataSkillDir(slug), ...relSegments);
+    const destPath = path3.join(claudeSkillDir(slug), ...relSegments);
+    await serverLog("skill-bridge", `mirrored ${srcPath} \u2192 ${destPath}`, { data: { slug, relPath, op: "write" } });
   } catch (err) {
-    await serverLog("skill-bridge", `mirror write failed for slug=${slug}`, {
+    await serverLog("skill-bridge", `mirror write failed for slug=${slug} (${relPath})`, {
       level: "error",
-      data: { slug, error: errorMessage(err) }
+      data: { slug, relPath, error: errorMessage(err) }
     });
   }
 }

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -12,6 +12,7 @@ import { log } from "../../system/logger/index.js";
 import { workspacePath } from "../workspace.js";
 import { USER_SKILLS_DIR, projectSkillsDir } from "../skills/paths.js";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths.js";
+import { isSafeActionTemplatePath } from "./templatePath.js";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "./types.js";
 
 // Cross-field refines, factored out so they can apply at both the
@@ -132,15 +133,6 @@ const FieldSpecSchema = z
     path: ["formula"],
   });
 
-// An action's `template` becomes a file read under the skill dir, so
-// reject traversal up front: each `/`-separated segment must be a plain
-// safe name, no `..`, no backslash, not absolute. The reader's realpath
-// containment is the hard guarantee; this fails a bad schema fast.
-function isSafeTemplatePath(value: string): boolean {
-  if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
-  return value.split("/").every((seg) => seg.length > 0 && seg !== "." && seg !== ".." && /^[A-Za-z0-9._-]+$/.test(seg));
-}
-
 // Optional visibility predicate: the action button shows only when the
 // open record's `field` (stringified) is one of `in`. Domain-free —
 // `field` is any non-empty key, `in` a non-empty array of non-empty
@@ -158,7 +150,11 @@ const ActionSpecSchema = z.object({
   icon: z.string().trim().min(1).optional(),
   kind: z.enum(["chat"]),
   role: z.string().trim().min(1),
-  template: z.string().trim().min(1).refine(isSafeTemplatePath, "must be a safe skill-relative path (no `..`, no leading `/`, no backslash)"),
+  template: z
+    .string()
+    .trim()
+    .min(1)
+    .refine(isSafeActionTemplatePath, "must be a safe path under `templates/` (e.g. `templates/invoice.md`; no `..`, no leading `/`, no backslash)"),
   when: ActionWhenSchema.optional(),
 });
 

--- a/server/workspace/collections/templatePath.ts
+++ b/server/workspace/collections/templatePath.ts
@@ -1,0 +1,36 @@
+// Shared template-path safety, used by BOTH the collection schema
+// validator (`discovery.ts` `ActionSpecSchema`) and the skill-bridge
+// hook (`hooks/handlers/skillBridge.ts`). Centralised so the set of
+// action `template` paths a schema may declare is *exactly* the set
+// the bridge mirrors into `.claude/skills/<slug>/` — if the two
+// diverge, a schema can validate yet reference a template the bridge
+// silently drops (runtime "template could not be read").
+//
+// Keep this module dependency-free: the bridge is bundled into a lean
+// esbuild dispatcher, so it must not drag in workspace/path machinery.
+
+/** `templates/` — the subdir an action template must live under. */
+const TEMPLATES_PREFIX = "templates/";
+
+/**
+ * A safe skill-relative path: non-empty, no backslash, not absolute,
+ * and every `/`-separated segment is a plain `[A-Za-z0-9._-]+` token
+ * that isn't `.` / `..` (no traversal). Multi-segment (nested) paths
+ * are allowed. The reader's realpath containment is the hard
+ * guarantee; this fails a bad path fast.
+ */
+export function isSafeTemplatePath(value: string): boolean {
+  if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
+  return value.split("/").every((seg) => seg.length > 0 && seg !== "." && seg !== ".." && /^[A-Za-z0-9._-]+$/.test(seg));
+}
+
+/**
+ * An action `template` value: a safe path that lives under the skill's
+ * `templates/` subdir. This is the canonical contract — the schema
+ * validator rejects anything else up front, and the bridge mirrors
+ * exactly these. Nested paths (`templates/mail/welcome.md`) and any
+ * extension are allowed as long as the path is otherwise safe.
+ */
+export function isSafeActionTemplatePath(value: string): boolean {
+  return value.startsWith(TEMPLATES_PREFIX) && isSafeTemplatePath(value);
+}

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -1,0 +1,218 @@
+# Collection skills — build a data app from a schema
+
+A **collection skill** is a skill directory that ships a `schema.json` next to
+its `SKILL.md`. The schema declares an entire data-driven app — its data model,
+cross-record relations, rendered UI, computed fields, and per-record action
+buttons — in one small JSON file. You author the schema, you write the records
+(one JSON file each), and you are the runtime for any behaviour the schema
+can't express declaratively. The host contains **zero** knowledge of any
+specific collection: it just reads the DSL and renders a table / form / detail
+view, and serves a REST surface. No database, no migration tool, no ORM — a
+`schema.json` plus a folder of `<id>.json` records **is** the app.
+
+This is the project philosophy made concrete: *the workspace is the database;
+files are the source of truth; you are the intelligent interface.*
+
+## Anatomy of a collection skill
+
+You **author** the skill under `data/skills/<slug>/` (a plain, writable data
+dir). A host-side hook then **mirrors** the files into `.claude/skills/<slug>/`,
+which is where the host actually discovers and renders the collection from:
+
+```
+data/skills/<slug>/            ← YOU write here (Write / Edit)
+  SKILL.md          ← instructions you read later (how to CRUD the records)
+  schema.json       ← the DSL: data model + relations + UI + actions
+  templates/*.md    ← natural-language bodies for actions (only if it has actions)
+        │
+        │  host's skill-bridge hook mirrors these three file kinds
+        ▼
+.claude/skills/<slug>/         ← host reads here (do NOT write here directly)
+  SKILL.md  ·  schema.json  ·  templates/*.md
+
+data/<name>/items/             ← the records (separate from the skill dir)
+  <id>.json         ← one record per file (you write; host reads + renders)
+```
+
+- **Author under `data/skills/<slug>/`, NEVER `.claude/skills/<slug>/`
+  directly.** Claude Code gates writes into `.claude/` (it's the agent's own
+  config surface) and the host GUI can't answer that prompt, so a direct write
+  hangs/fails. Writing under `data/skills/` has no such gate; the bridge hook
+  copies `SKILL.md`, `schema.json`, and `templates/*.md` across for you and
+  triggers a re-scan, so the collection appears at `/collections/<slug>`
+  without a restart. (Other files you drop in `data/skills/<slug>/` — a README,
+  scratch notes — stay put and are NOT mirrored.)
+- **Do NOT use the `mc-` prefix** for skills you create. `mc-*` is reserved for
+  the bundled presets (`mc-clients`, `mc-worklog`, `mc-invoice`, `mc-profile`);
+  the server overwrites those on every boot, so your edits would be lost.
+- **`<slug>` rules**: lowercase letters, digits, hyphens; no leading / trailing
+  hyphen; 1–64 chars (e.g. `recipes`, `book-club`, `gym-log`). It doubles as the
+  URL (`/collections/<slug>`) and the directory name.
+- The user opens the collection at **`/collections/<slug>`**. Link a specific
+  record with `?selected=<id>` (e.g. `/collections/recipes?selected=carbonara`).
+
+## SKILL.md
+
+Standard skill front-matter plus prose teaching *future-you* how to maintain the
+records. Keep it short and operational:
+
+```markdown
+---
+name: recipes
+description: A personal recipe box. Use whenever the user asks to add, list,
+  edit, or remove a recipe. Records live at `data/recipes/items/<id>.json`
+  (one JSON per recipe); the user views them at `/collections/recipes`,
+  rendered from `schema.json` by the host. You do all I/O via Read / Write /
+  Edit on the JSON files.
+---
+
+# Recipes (schema-driven collection)
+
+## Record shape
+- `id` — kebab-case slug, primary key (the filename, no extension)
+- `title` — string, required
+- ... (one bullet per field; note which are host-computed and must NOT be written)
+
+## What to do
+**Add / List / Update / Delete** — derive an id, Read/Write/Edit the JSON.
+List the directory first and pick a fresh slug rather than overwriting.
+Don't recite the whole table in chat — point the user at the collection view.
+```
+
+Write the `description` so it tells *you* (in a future session) exactly when to
+reach for this skill and where the records live — that text is what gets matched
+when the user makes a request.
+
+## schema.json — the DSL
+
+Top-level shape (validated on discovery; a malformed schema is logged and
+skipped, never crashes the host):
+
+| Key | Meaning |
+|---|---|
+| `title` | Human name shown in the sidebar / header. Required. |
+| `icon` | A **Material Icons** name (`receipt_long`, `people`, `schedule`, `menu_book`). Required. |
+| `dataPath` | Workspace-relative records folder, e.g. `data/recipes/items`. Must stay under the workspace. Required. |
+| `primaryKey` | The field name whose value is the filename. That field MUST set `primary: true`. Required. |
+| `singleton` | Optional. When set, at most one record exists, pinned to this exact id (e.g. `me`). Host pre-fills + locks the create form and hides Add once it exists. |
+| `fields` | Ordered map of field-name → field spec. **Insertion order = column order** in the table. Required. |
+| `actions` | Optional array of per-record buttons (see below). |
+
+### Field types
+
+`string` · `text` (multi-line) · `email` · `number` · `date` (`YYYY-MM-DD`) ·
+`boolean` · `markdown` · `money` · `enum` · `ref` · `embed` · `table` ·
+`derived`
+
+Every field spec needs a `type` and a `label`. Extra keys by type:
+
+- **`enum`** — `values: ["draft", "sent", "paid"]` (non-empty strings). Renders
+  a `<select>`; stored as a plain string.
+- **`money`** — `currency: "USD"` (ISO 4217, defaults to USD). Stored as a plain
+  decimal; currency is display-only.
+- **`ref`** — `to: "<target-slug>"`. Stores the target record's primary-key
+  slug; host renders a clickable link + a dropdown picker populated from the
+  target collection. Example: `{ "type": "ref", "to": "mc-clients", "label": "Client" }`.
+- **`embed`** — `to: "<target-slug>"`, `id: "<record-id>"`. Pulls a *fixed*
+  record from another collection into the read-only detail view (display-only,
+  **nothing is stored** on this record). Example: an invoice embedding the
+  user's own profile: `{ "type": "embed", "to": "mc-profile", "id": "me" }`.
+- **`table`** — `of: { <col>: <sub-field-spec>, ... }`. An array of rows. Each
+  sub-field is a flat spec; sub-fields **cannot** be `table` or `derived`
+  (no nested tables, no computed columns).
+- **`derived`** — `formula: "<expr>"`, optional `display` (`number` default, or
+  `money` / `string` / `date`) and `currency`. **Read-only, host-computed** —
+  you NEVER write derived values into the JSON; the host recomputes them on
+  every render and the form refuses to persist them.
+
+### Derived-formula syntax
+
+A tiny expression evaluated against the record (pure evaluator, no `eval`;
+returns `null` on any failure). Supported:
+
+- arithmetic `+ - * /` and parentheses
+- identifier references to **top-level** fields (`subtotal * taxRate`)
+- `sum(tableField[].col)` — sum a column across table rows
+- `sum(tableField[].col * tableField[].col)` — sum a per-row product
+
+Example: `subtotal` = `sum(lineItems[].quantity * lineItems[].rate)`,
+`tax` = `subtotal * taxRate`, `total` = `subtotal + tax`.
+
+### Actions (per-record buttons)
+
+Each entry in `actions` renders a button in the read-only detail view. The only
+`kind` today is `"chat"`: clicking it starts a **new chat in a role**, seeded
+with a template + the record data — the role then does the work with its tools.
+This is how hard logic the schema can't express (PDF generation, bookkeeping
+journals, drafting an email) gets delegated to natural language.
+
+```json
+{
+  "id": "pdf",                      // unique within the schema
+  "label": "Generate PDF",          // button text (English)
+  "icon": "picture_as_pdf",         // Material Icons name
+  "kind": "chat",
+  "role": "accounting",             // which role the new chat runs in
+  "template": "templates/invoice.md", // skill-relative; no `..`, no leading `/`
+  "when": { "field": "status", "in": ["paid"] }  // optional: show only when record.status ∈ {paid}
+}
+```
+
+- `template` is a path **inside the skill dir** (host reads it path-safely).
+  Write the action's instructions there in plain English; the host prepends the
+  record JSON as sanitized, passive data and hands the whole thing to the role.
+- `when` is both the visibility rule **and** the authorization rule — the host
+  re-checks it server-side, so a button gated on `status: paid` can't be invoked
+  for a draft. Omit `when` ⇒ always shown.
+- You do **not** trigger actions yourself; point the user at the button.
+
+## Records — one JSON object per file
+
+- Write each record to `<dataPath>/<id>.json` via the **Write** tool; the `id`
+  field's value is the filename (no extension).
+- **List the directory first** and pick a fresh id rather than silently
+  overwriting. Update = Read, merge, Write back (preserve fields you weren't
+  asked to change). Delete = remove the file.
+- **Never write `derived` fields**, and never write an `embed` field — both are
+  display-only / host-computed.
+- Leave optional fields out of the JSON entirely rather than writing empty
+  strings.
+- For a `ref` field, write the raw target slug, and make sure that record
+  actually exists in the target collection — an invalid slug renders as a broken
+  link. The host enforces structure and safety; **you own semantic correctness**
+  (valid refs, sane values).
+
+## End-to-end: creating a new collection skill
+
+1. Pick a `<slug>` (lowercase-hyphen, no `mc-` prefix) and a `dataPath`
+   (`data/<name>/items`).
+2. Write `data/skills/<slug>/schema.json` — `title`, `icon`, `dataPath`,
+   `primaryKey` (with the matching field flagged `primary: true`), and the
+   `fields` map in the order you want columns. Add `actions` +
+   `data/skills/<slug>/templates/*.md` only if the collection needs delegated
+   behaviour. (The bridge mirrors these into `.claude/skills/<slug>/`.)
+3. Write `data/skills/<slug>/SKILL.md` — front-matter `name` + `description`,
+   then the record-shape bullets and CRUD conventions.
+4. Tell the user it's ready at `/collections/<slug>`. The bridge mirrors the
+   files and triggers a re-scan, so the host discovers it without a restart and
+   with no host code. If it doesn't appear: first confirm you wrote under
+   `data/skills/<slug>/` (NOT `.claude/skills/…`, which is gated and won't
+   mirror); then check your `schema.json` passed validation — primary key
+   flagged `primary: true`, `ref`/`embed` have a valid `to`, `enum` has
+   `values`, `table` has `of`, `derived` has `formula`, action ids unique,
+   `dataPath` under the workspace. (A schema that fails validation is logged
+   server-side and silently skipped at discovery.)
+
+## Worked reference: the billing suite
+
+The bundled presets are the canonical examples — read their `schema.json` when
+in doubt:
+
+- **`mc-clients`** — flat table (`string` / `email` / `text` / `markdown`). The
+  simplest possible collection; everything else `ref`s into it.
+- **`mc-worklog`** — adds a `ref` (`clientId → mc-clients`), a `date`, a
+  `number`, a `boolean`. A companion data source.
+- **`mc-invoice`** — the full toolkit in one schema: an `embed` issuer, a `ref`
+  client, a `table` of line items, three `derived` money fields, an `enum`
+  status, and four `actions` (PDF always-on; sale / payment / void gated by
+  `status` via `when`).

--- a/server/workspace/helps/index.md
+++ b/server/workspace/helps/index.md
@@ -52,6 +52,7 @@ See [Wiki](config/helps/wiki.md) for details on how it works.
 - [Information Sources](config/helps/sources.md) — registering RSS feeds / GitHub repos / arXiv queries, the daily-brief pipeline, and where its files live on disk
 - [Encore — recurring obligations DSL](config/helps/encore-dsl.md) — YAML DSL for recurring obligations (payments, services, check-ins), firing plans, multi-target bundles, and the bell-click resume loop
 - [GitHub repositories in the workspace](config/helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
+- [Collection skills](config/helps/collection-skills.md) — build a data app (model + UI + relations + computed fields + action buttons) by authoring a `schema.json` collection skill: the DSL, field types, derived formulas, actions, records
 
 ## Workspace Layout
 

--- a/server/workspace/hooks/handlers/skillBridge.ts
+++ b/server/workspace/hooks/handlers/skillBridge.ts
@@ -23,12 +23,17 @@
 //
 // What crosses the gate — a FIXED ALLOWLIST, not the whole dir:
 //
-//   SKILL.md         the skill body Claude CLI reads
-//   schema.json      the collection definition (a "collection skill"
-//                    is a skill dir that ships a schema.json; without
-//                    it the collection never registers)
-//   templates/<x>.md action templates a schema's `actions` reference
-//                    by path (one `templates/` segment, `.md` only)
+//   SKILL.md          the skill body Claude CLI reads
+//   schema.json       the collection definition (a "collection skill"
+//                     is a skill dir that ships a schema.json; without
+//                     it the collection never registers)
+//   templates/<path>  action templates a schema's `actions` reference
+//                     by path. The accepted set is exactly what the
+//                     schema validator allows (`isSafeActionTemplatePath`
+//                     in collections/templatePath.ts) — a safe path
+//                     under `templates/`, nesting allowed — so a valid
+//                     schema can never reference a template the bridge
+//                     drops.
 //
 // Everything else (README.md, assets/, arbitrary nesting) stays
 // staging-side — same publish-boundary intent as the original
@@ -58,20 +63,12 @@ import type { HookPayload } from "../shared/stdin.js";
 import { extractCommand, extractFilePath, extractToolName } from "../shared/stdin.js";
 import { workspaceRoot } from "../shared/workspace.js";
 import { errorMessage } from "../../../utils/errors.js";
+import { isSafeActionTemplatePath } from "../../collections/templatePath.js";
 
 const DATA_SKILLS_DIR = path.join("data", "skills");
 const CLAUDE_SKILLS_DIR = path.join(".claude", "skills");
 const SKILL_FILENAME = "SKILL.md";
 const SCHEMA_FILENAME = "schema.json";
-const TEMPLATES_DIR = "templates";
-
-// A `templates/` entry must be a plain `*.md` basename: starts with
-// an alphanumeric / `_` / `-` (so hidden files and `..md` are out),
-// no path separators (the `<slug>/templates/<name>` shape already
-// guarantees a single segment), `.md` extension. Mirrors the
-// safe-name discipline `discovery.ts#isSafeTemplatePath` applies to
-// the schema's action `template` paths.
-const SAFE_TEMPLATE_RE = /^[A-Za-z0-9_-][A-Za-z0-9._-]*\.md$/;
 
 // Slugs follow Claude Code's skill-name convention: lowercase ASCII
 // letters / digits with single-hyphen separators. Matching is
@@ -130,19 +127,19 @@ export interface BridgeTarget {
 }
 
 // Decide whether a path below the slug dir is on the allowlist.
-//   <slug>/SKILL.md        → yes
-//   <slug>/schema.json     → yes
-//   <slug>/templates/<x>.md → yes (safe basename only)
-// everything else (README.md, assets/, deeper nesting, non-.md
-// templates) → no.
+//   <slug>/SKILL.md           → yes
+//   <slug>/schema.json        → yes
+//   <slug>/templates/<path>   → yes iff it's a safe action-template
+//                               path (same predicate the schema
+//                               validator uses, so what a schema can
+//                               declare is exactly what crosses)
+// everything else (README.md, assets/, any non-`templates/` sibling)
+// → no.
 function isAllowlisted(relSegments: string[]): boolean {
   if (relSegments.length === 1) {
     return relSegments[0] === SKILL_FILENAME || relSegments[0] === SCHEMA_FILENAME;
   }
-  if (relSegments.length === 2 && relSegments[0] === TEMPLATES_DIR) {
-    return SAFE_TEMPLATE_RE.test(relSegments[1]);
-  }
-  return false;
+  return isSafeActionTemplatePath(relSegments.join("/"));
 }
 
 // Resolve a Write/Edit path to the staging file it mirrors, or null

--- a/server/workspace/hooks/handlers/skillBridge.ts
+++ b/server/workspace/hooks/handlers/skillBridge.ts
@@ -1,8 +1,8 @@
-// Skill-bridge handler — agent writes skill drafts to
-// `data/skills/<slug>/SKILL.md` (a plain data dir, no permission
-// special case) and this hook mirrors them into
-// `.claude/skills/<slug>/SKILL.md` so Claude CLI's skill discovery
-// picks them up.
+// Skill-bridge handler — agent writes skill drafts under
+// `data/skills/<slug>/` (a plain data dir, no permission special
+// case) and this hook mirrors the allowlisted files into
+// `.claude/skills/<slug>/` so Claude CLI's skill discovery picks
+// them up.
 //
 // Why a bridge: Claude Code's permission system gives `.claude/`
 // stricter scrutiny than ordinary cwd subdirs (the dir holds the
@@ -21,17 +21,35 @@
 // mirror silently never fired. Mirroring 1:1 keeps the path math
 // trivial for both sides.
 //
+// What crosses the gate — a FIXED ALLOWLIST, not the whole dir:
+//
+//   SKILL.md         the skill body Claude CLI reads
+//   schema.json      the collection definition (a "collection skill"
+//                    is a skill dir that ships a schema.json; without
+//                    it the collection never registers)
+//   templates/<x>.md action templates a schema's `actions` reference
+//                    by path (one `templates/` segment, `.md` only)
+//
+// Everything else (README.md, assets/, arbitrary nesting) stays
+// staging-side — same publish-boundary intent as the original
+// SKILL.md-only design, but widened by exactly the two file kinds a
+// collection skill needs. Keeping it an allowlist (vs. mirroring the
+// whole dir) keeps the `.claude/` gate bypass narrow and auditable:
+// the agent can't auto-publish a settings.json, an executable, or a
+// deep subtree into its own config dir.
+//
 // Mirror operations:
 //
-//   Write/Edit data/skills/<slug>/SKILL.md
-//     → copy content to .claude/skills/<slug>/SKILL.md
-//       (creates the parent dir on first install)
+//   Write/Edit data/skills/<slug>/{SKILL.md,schema.json,templates/*.md}
+//     → copy content to the same relative path under
+//       .claude/skills/<slug>/ (creates parent dirs on first install)
 //
 //   Bash "rm -rf data/skills/<slug>/" or "rm -rf data/skills/<slug>"
 //     → rm -rf .claude/skills/<slug>/
-//       (regex-matched so the agent's intent is unambiguous;
-//        a bulk `rm -rf data/skills/` or wildcards are intentionally
-//        NOT mirrored to avoid mass deletion surprises)
+//       (regex-matched so the agent's intent is unambiguous; a bulk
+//        `rm -rf data/skills/` or wildcards are intentionally NOT
+//        mirrored to avoid mass deletion surprises. Whole-dir delete
+//        sweeps schema.json + templates too — no orphans)
 
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -44,6 +62,16 @@ import { errorMessage } from "../../../utils/errors.js";
 const DATA_SKILLS_DIR = path.join("data", "skills");
 const CLAUDE_SKILLS_DIR = path.join(".claude", "skills");
 const SKILL_FILENAME = "SKILL.md";
+const SCHEMA_FILENAME = "schema.json";
+const TEMPLATES_DIR = "templates";
+
+// A `templates/` entry must be a plain `*.md` basename: starts with
+// an alphanumeric / `_` / `-` (so hidden files and `..md` are out),
+// no path separators (the `<slug>/templates/<name>` shape already
+// guarantees a single segment), `.md` extension. Mirrors the
+// safe-name discipline `discovery.ts#isSafeTemplatePath` applies to
+// the schema's action `template` paths.
+const SAFE_TEMPLATE_RE = /^[A-Za-z0-9_-][A-Za-z0-9._-]*\.md$/;
 
 // Slugs follow Claude Code's skill-name convention: lowercase ASCII
 // letters / digits with single-hyphen separators. Matching is
@@ -90,28 +118,56 @@ export function claudeSkillFilePath(slug: string): string {
   return path.join(claudeSkillDir(slug), SKILL_FILENAME);
 }
 
-// Extract the slug from a Write/Edit on a
-// `data/skills/<slug>/SKILL.md` path. Returns null when:
-//   - the path doesn't sit directly under data/skills/<slug>/
-//   - the filename isn't SKILL.md
+/** A staging file that's cleared to cross the `.claude/` gate. */
+export interface BridgeTarget {
+  /** The skill slug (the dir directly under data/skills/). */
+  slug: string;
+  /** Path segments BELOW the slug dir, e.g. `["SKILL.md"]`,
+   *  `["schema.json"]`, `["templates", "invoice.md"]`. Used verbatim
+   *  to build both the source and destination paths so the mirror is
+   *  1:1. */
+  relSegments: string[];
+}
+
+// Decide whether a path below the slug dir is on the allowlist.
+//   <slug>/SKILL.md        → yes
+//   <slug>/schema.json     → yes
+//   <slug>/templates/<x>.md → yes (safe basename only)
+// everything else (README.md, assets/, deeper nesting, non-.md
+// templates) → no.
+function isAllowlisted(relSegments: string[]): boolean {
+  if (relSegments.length === 1) {
+    return relSegments[0] === SKILL_FILENAME || relSegments[0] === SCHEMA_FILENAME;
+  }
+  if (relSegments.length === 2 && relSegments[0] === TEMPLATES_DIR) {
+    return SAFE_TEMPLATE_RE.test(relSegments[1]);
+  }
+  return false;
+}
+
+// Resolve a Write/Edit path to the staging file it mirrors, or null
+// when it's not a bridged file. Returns null when:
+//   - the path doesn't sit under data/skills/<slug>/
 //   - the slug isn't a valid kebab-case identifier
+//   - the relative path isn't on the allowlist (see isAllowlisted)
 //
-// Sibling files in the same dir (e.g. data/skills/<slug>/README.md
-// or data/skills/<slug>/assets/foo.png) are intentionally NOT
-// bridged — only the canonical SKILL.md crosses over. Skill authors
-// can keep extra material staging-side until they decide what
-// belongs in the bundle.
-export function slugFromDataPath(filePath: string): string | null {
+// Non-allowlisted siblings (e.g. data/skills/<slug>/README.md or
+// data/skills/<slug>/assets/foo.png) are intentionally NOT bridged —
+// skill authors can keep extra material staging-side until they
+// decide what belongs in the bundle. The allowlist keeps the
+// `.claude/` gate bypass narrow.
+export function bridgeTargetFromDataPath(filePath: string): BridgeTarget | null {
   const root = workspaceRoot();
   const staging = path.join(root, DATA_SKILLS_DIR);
   const rel = path.relative(staging, filePath);
-  if (!rel || rel.startsWith("..")) return null;
-  // Expect exactly `<slug>/SKILL.md` — two segments deep.
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
   const segments = rel.split(path.sep);
-  if (segments.length !== 2) return null;
-  const [slug, basename] = segments;
-  if (basename !== SKILL_FILENAME) return null;
-  return SLUG_RE.test(slug) ? slug : null;
+  // Need at least `<slug>/<file>`.
+  if (segments.length < 2) return null;
+  const [slug, ...relSegments] = segments;
+  if (!SLUG_RE.test(slug)) return null;
+  if (!isAllowlisted(relSegments)) return null;
+  return { slug, relSegments };
 }
 
 // Extract the slug from a Bash `rm -rf data/skills/<slug>/` command.
@@ -135,12 +191,16 @@ export function slugFromRmCommand(command: string): string | null {
 // never read) and SKILL.md still has its previous contents — Claude
 // CLI's skill discovery never sees a torn file. CodeRabbit review
 // on PR #1298.
-function mirrorWrite(slug: string): void {
-  const content = readFileSync(dataSkillFilePath(slug), "utf-8");
-  const destDir = claudeSkillDir(slug);
+function mirrorWrite(target: BridgeTarget): void {
+  const { slug, relSegments } = target;
+  const src = path.join(dataSkillDir(slug), ...relSegments);
+  const content = readFileSync(src, "utf-8");
+  const dest = path.join(claudeSkillDir(slug), ...relSegments);
+  // `mkdirSync(recursive)` covers the `templates/` subdir on first
+  // install as well as the `<slug>/` dir itself.
+  const destDir = path.dirname(dest);
   mkdirSync(destDir, { recursive: true });
-  const dest = claudeSkillFilePath(slug);
-  const tmp = path.join(destDir, `.SKILL.md.${process.pid}.tmp`);
+  const tmp = path.join(destDir, `.${path.basename(dest)}.${process.pid}.tmp`);
   writeFileSync(tmp, content, "utf-8");
   renameSync(tmp, dest);
 }
@@ -163,27 +223,31 @@ async function refreshConfig(): Promise<void> {
 async function handleWriteOrEdit(payload: HookPayload): Promise<void> {
   const filePath = extractFilePath(payload);
   if (!filePath) return;
-  const slug = slugFromDataPath(filePath);
-  if (slug === null) return;
+  const target = bridgeTargetFromDataPath(filePath);
+  if (target === null) return;
+  const { slug, relSegments } = target;
+  const relPath = relSegments.join("/");
   try {
-    mirrorWrite(slug);
+    mirrorWrite(target);
     // Order matters: mirror must complete before refresh so the
-    // server's skill scan sees the new SKILL.md. See refreshConfig
-    // comment for the race history.
+    // server's skill / collection scan sees the new file. See
+    // refreshConfig comment for the race history.
     await refreshConfig();
     // Server-side log line so the user can see from
     // `server-<date>.log` that the hook fired and what it did.
     // Without this the mirror is invisible — a successful copy
     // and "the hook never ran" look identical from the chat UI.
-    await serverLog("skill-bridge", `mirrored ${dataSkillFilePath(slug)} → ${claudeSkillFilePath(slug)}`, { data: { slug, op: "write" } });
+    const srcPath = path.join(dataSkillDir(slug), ...relSegments);
+    const destPath = path.join(claudeSkillDir(slug), ...relSegments);
+    await serverLog("skill-bridge", `mirrored ${srcPath} → ${destPath}`, { data: { slug, relPath, op: "write" } });
   } catch (err) {
     // The Write itself succeeded; a failed mirror would leave the
     // staging copy in place. Surface the failure to server logs
     // (so the user has a chance to react) but never throw — the
     // user's tool turn must stay clean.
-    await serverLog("skill-bridge", `mirror write failed for slug=${slug}`, {
+    await serverLog("skill-bridge", `mirror write failed for slug=${slug} (${relPath})`, {
       level: "error",
-      data: { slug, error: errorMessage(err) },
+      data: { slug, relPath, error: errorMessage(err) },
     });
   }
 }

--- a/server/workspace/skills-preset/mc-manage-skills/SKILL.md
+++ b/server/workspace/skills-preset/mc-manage-skills/SKILL.md
@@ -26,6 +26,19 @@ outside MulmoClaude — don't touch those.
 End with a one-line confirmation ("Saved as foo-skill." / "Removed foo-skill.")
 so the user can verify without scrolling.
 
+## Collections (a skill + a `schema.json`)
+
+If the user wants a small **data app** — a list/table they can view and edit
+(a swimming log, a recipe box, a client database) — that's a **collection
+skill**: a skill dir that also ships a `schema.json` (and optional
+`templates/*.md`). Author all of them under the same staging dir
+(`data/skills/<slug>/SKILL.md` + `data/skills/<slug>/schema.json` +
+`data/skills/<slug>/templates/*.md`); the same bridge hook mirrors those three
+file kinds into `.claude/skills/<slug>/` and the collection appears at
+`/collections/<slug>`. **Read `config/helps/collection-skills.md` first** — it
+is the authority on the schema DSL (field types, relations, derived fields,
+actions). Don't hand-roll a schema from memory.
+
 ## Workflow 1: save a new skill
 
 **Triggers**: "skill 化して", "save this as a skill", "make this reusable",

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -730,6 +730,36 @@ describe("discoverCollections — actions", () => {
     assert.equal((await listCollections()).length, 0);
   });
 
+  it("rejects an action template not under templates/", async () => {
+    // The template path must live under `templates/` — this is the
+    // exact contract the skill-bridge hook mirrors, so a bare or
+    // sibling-dir path can't validate here yet fail to cross the gate
+    // (Codex review on PR #1518).
+    writeSkill("test-actions-bare-template", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/actbare/items",
+      primaryKey: "id",
+      fields,
+      actions: [{ id: "pdf", label: "PDF", kind: "chat", role: "accounting", template: "invoice.md" }],
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("accepts an action template nested under templates/", async () => {
+    writeSkill("test-actions-nested-template", {
+      title: "X",
+      icon: "receipt",
+      dataPath: "data/actnest/items",
+      primaryKey: "id",
+      fields,
+      actions: [{ id: "mail", label: "Send mail", kind: "chat", role: "accounting", template: "templates/mail/welcome.md" }],
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.actions?.[0]?.template, "templates/mail/welcome.md");
+  });
+
   it("rejects duplicate action ids", async () => {
     writeSkill("test-actions-dup", {
       title: "X",
@@ -738,8 +768,8 @@ describe("discoverCollections — actions", () => {
       primaryKey: "id",
       fields,
       actions: [
-        { id: "pdf", label: "A", kind: "chat", role: "accounting", template: "a.md" },
-        { id: "pdf", label: "B", kind: "chat", role: "accounting", template: "b.md" },
+        { id: "pdf", label: "A", kind: "chat", role: "accounting", template: "templates/a.md" },
+        { id: "pdf", label: "B", kind: "chat", role: "accounting", template: "templates/b.md" },
       ],
     });
     assert.equal((await listCollections()).length, 0);
@@ -752,7 +782,9 @@ describe("discoverCollections — actions", () => {
       dataPath: "data/actwhen/items",
       primaryKey: "id",
       fields,
-      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { field: "status", in: ["sent", "paid"] } }],
+      actions: [
+        { id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "templates/s.md", when: { field: "status", in: ["sent", "paid"] } },
+      ],
     });
     const collections = await listCollections();
     assert.equal(collections.length, 1);
@@ -766,7 +798,7 @@ describe("discoverCollections — actions", () => {
       dataPath: "data/actwhennf/items",
       primaryKey: "id",
       fields,
-      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { in: ["sent"] } }],
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "templates/s.md", when: { in: ["sent"] } }],
     });
     assert.equal((await listCollections()).length, 0);
   });
@@ -778,7 +810,7 @@ describe("discoverCollections — actions", () => {
       dataPath: "data/actwhenei/items",
       primaryKey: "id",
       fields,
-      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { field: "status", in: [] } }],
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "templates/s.md", when: { field: "status", in: [] } }],
     });
     assert.equal((await listCollections()).length, 0);
   });
@@ -790,7 +822,7 @@ describe("discoverCollections — actions", () => {
       dataPath: "data/actwhenna/items",
       primaryKey: "id",
       fields,
-      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "s.md", when: { field: "status", in: "sent" } }],
+      actions: [{ id: "sale", label: "Record sale", kind: "chat", role: "accounting", template: "templates/s.md", when: { field: "status", in: "sent" } }],
     });
     assert.equal((await listCollections()).length, 0);
   });

--- a/test/workspace/hooks/handlers/test_skillBridge.ts
+++ b/test/workspace/hooks/handlers/test_skillBridge.ts
@@ -41,14 +41,33 @@ describe("bridgeTargetFromDataPath", () => {
     assert.deepEqual(bridgeTargetFromDataPath("/ws/data/skills/swimming/schema.json"), { slug: "swimming", relSegments: ["schema.json"] });
   });
 
-  it("matches data/skills/<slug>/templates/<name>.md", () => {
-    // Action templates referenced by a schema's `actions` must
-    // cross too — a single `templates/` segment, `.md` only.
+  it("matches any safe action-template path under templates/ (matches the schema validator)", () => {
+    // Action templates referenced by a schema's `actions` must cross.
+    // The accepted set is exactly what `isSafeActionTemplatePath`
+    // allows (the same predicate discovery validates against): a safe
+    // path under `templates/`, nesting + any extension permitted — so
+    // a valid schema can never reference a template the bridge drops.
     setWorkspace("/ws");
     assert.deepEqual(bridgeTargetFromDataPath("/ws/data/skills/invoice/templates/journal-sale.md"), {
       slug: "invoice",
       relSegments: ["templates", "journal-sale.md"],
     });
+    assert.deepEqual(
+      bridgeTargetFromDataPath("/ws/data/skills/invoice/templates/mail/welcome.md"),
+      {
+        slug: "invoice",
+        relSegments: ["templates", "mail", "welcome.md"],
+      },
+      "nested template path",
+    );
+    assert.deepEqual(
+      bridgeTargetFromDataPath("/ws/data/skills/foo/templates/report.txt"),
+      {
+        slug: "foo",
+        relSegments: ["templates", "report.txt"],
+      },
+      "non-.md extension allowed",
+    );
   });
 
   it("rejects non-staging paths", () => {
@@ -69,12 +88,11 @@ describe("bridgeTargetFromDataPath", () => {
     assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/assets/img.png"), null);
   });
 
-  it("rejects templates that aren't a single safe *.md basename", () => {
+  it("rejects template-like paths that aren't under templates/ or that traverse", () => {
     setWorkspace("/ws");
-    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/x.txt"), null, "non-.md rejected");
-    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/.hidden.md"), null, "hidden file rejected");
-    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/sub/x.md"), null, "nested deeper rejected");
     assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/assets/x.md"), null, "non-templates subdir rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/prompts/x.md"), null, "must be under templates/, not a sibling dir");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/../escape.md"), null, "traversal rejected");
   });
 
   it("rejects flat <slug>.md (the old layout)", () => {

--- a/test/workspace/hooks/handlers/test_skillBridge.ts
+++ b/test/workspace/hooks/handlers/test_skillBridge.ts
@@ -1,7 +1,8 @@
 // Unit tests for the skill-bridge handler. The handler mirrors
-// edits + deletes from `data/skills/<slug>/SKILL.md` into
-// `.claude/skills/<slug>/SKILL.md`. We verify the path math and
-// the regex gating directly, plus a smoke test of the mirror
+// edits + deletes from `data/skills/<slug>/` into
+// `.claude/skills/<slug>/` — but only for an allowlist of files
+// (SKILL.md, schema.json, templates/*.md). We verify the path math
+// and the regex gating directly, plus a smoke test of the mirror
 // copy / delete against a real tmp workspace.
 
 import { describe, it } from "node:test";
@@ -11,11 +12,12 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  bridgeTargetFromDataPath,
+  claudeSkillDir,
   claudeSkillFilePath,
   dataSkillDir,
   dataSkillFilePath,
   handleSkillBridge,
-  slugFromDataPath,
   slugFromRmCommand,
 } from "../../../../server/workspace/hooks/handlers/skillBridge.js";
 
@@ -25,27 +27,54 @@ function setWorkspace(root: string): void {
   process.env.CLAUDE_PROJECT_DIR = root;
 }
 
-describe("slugFromDataPath", () => {
-  it("matches data/skills/<slug>/SKILL.md and returns the slug", () => {
+describe("bridgeTargetFromDataPath", () => {
+  it("matches data/skills/<slug>/SKILL.md", () => {
     setWorkspace("/ws");
-    assert.equal(slugFromDataPath("/ws/data/skills/nazonazo/SKILL.md"), "nazonazo");
-    assert.equal(slugFromDataPath("/ws/data/skills/my-skill/SKILL.md"), "my-skill");
+    assert.deepEqual(bridgeTargetFromDataPath("/ws/data/skills/nazonazo/SKILL.md"), { slug: "nazonazo", relSegments: ["SKILL.md"] });
+    assert.deepEqual(bridgeTargetFromDataPath("/ws/data/skills/my-skill/SKILL.md"), { slug: "my-skill", relSegments: ["SKILL.md"] });
+  });
+
+  it("matches data/skills/<slug>/schema.json (collection definition)", () => {
+    // A collection skill ships a schema.json next to SKILL.md;
+    // without it crossing the gate the collection never registers.
+    setWorkspace("/ws");
+    assert.deepEqual(bridgeTargetFromDataPath("/ws/data/skills/swimming/schema.json"), { slug: "swimming", relSegments: ["schema.json"] });
+  });
+
+  it("matches data/skills/<slug>/templates/<name>.md", () => {
+    // Action templates referenced by a schema's `actions` must
+    // cross too — a single `templates/` segment, `.md` only.
+    setWorkspace("/ws");
+    assert.deepEqual(bridgeTargetFromDataPath("/ws/data/skills/invoice/templates/journal-sale.md"), {
+      slug: "invoice",
+      relSegments: ["templates", "journal-sale.md"],
+    });
   });
 
   it("rejects non-staging paths", () => {
     setWorkspace("/ws");
-    assert.equal(slugFromDataPath("/ws/data/wiki/foo.md"), null);
-    assert.equal(slugFromDataPath("/ws/.claude/skills/foo/SKILL.md"), null);
-    assert.equal(slugFromDataPath("/elsewhere/data/skills/foo/SKILL.md"), null);
+    assert.equal(bridgeTargetFromDataPath("/ws/data/wiki/foo.md"), null);
+    assert.equal(bridgeTargetFromDataPath("/ws/.claude/skills/foo/SKILL.md"), null);
+    assert.equal(bridgeTargetFromDataPath("/elsewhere/data/skills/foo/SKILL.md"), null);
   });
 
-  it("rejects sibling files in the staging skill dir", () => {
-    // Only SKILL.md crosses over — assets and notes stay
-    // staging-side. The agent writing `data/skills/foo/README.md`
-    // by mistake should be a no-op, not a mis-mirror.
+  it("rejects non-allowlisted sibling files in the staging skill dir", () => {
+    // Only SKILL.md / schema.json / templates/*.md cross over —
+    // READMEs, assets, and arbitrary files stay staging-side. The
+    // agent writing `data/skills/foo/README.md` by mistake should
+    // be a no-op, not a mis-mirror.
     setWorkspace("/ws");
-    assert.equal(slugFromDataPath("/ws/data/skills/foo/README.md"), null);
-    assert.equal(slugFromDataPath("/ws/data/skills/foo/assets/img.png"), null);
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/README.md"), null);
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/notes.json"), null);
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/assets/img.png"), null);
+  });
+
+  it("rejects templates that aren't a single safe *.md basename", () => {
+    setWorkspace("/ws");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/x.txt"), null, "non-.md rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/.hidden.md"), null, "hidden file rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/templates/sub/x.md"), null, "nested deeper rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo/assets/x.md"), null, "non-templates subdir rejected");
   });
 
   it("rejects flat <slug>.md (the old layout)", () => {
@@ -54,15 +83,15 @@ describe("slugFromDataPath", () => {
     // form is no longer recognised. Document the change here so
     // a partial revert can't silently re-introduce it.
     setWorkspace("/ws");
-    assert.equal(slugFromDataPath("/ws/data/skills/foo.md"), null);
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo.md"), null);
   });
 
   it("rejects invalid slugs", () => {
     setWorkspace("/ws");
-    assert.equal(slugFromDataPath("/ws/data/skills/Foo/SKILL.md"), null, "uppercase rejected");
-    assert.equal(slugFromDataPath("/ws/data/skills/foo_bar/SKILL.md"), null, "underscore rejected");
-    assert.equal(slugFromDataPath("/ws/data/skills/-foo/SKILL.md"), null, "leading hyphen rejected");
-    assert.equal(slugFromDataPath("/ws/data/skills/foo--bar/SKILL.md"), null, "double hyphen rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/Foo/SKILL.md"), null, "uppercase rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo_bar/SKILL.md"), null, "underscore rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/-foo/SKILL.md"), null, "leading hyphen rejected");
+    assert.equal(bridgeTargetFromDataPath("/ws/data/skills/foo--bar/SKILL.md"), null, "double hyphen rejected");
   });
 });
 
@@ -122,11 +151,71 @@ describe("handleSkillBridge — mirror copy", () => {
     await rm(root, { recursive: true, force: true });
   });
 
+  it("copies schema.json to .claude/skills/<slug>/schema.json on Write", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skill-bridge-schema-"));
+    setWorkspace(root);
+    await mkdir(dataSkillDir("swimming"), { recursive: true });
+    const schemaPath = path.join(dataSkillDir("swimming"), "schema.json");
+    const content = '{\n  "title": "Swimming Log",\n  "primaryKey": "id",\n  "fields": {}\n}\n';
+    await writeFile(schemaPath, content, "utf-8");
+
+    await handleSkillBridge({
+      tool_name: "Write",
+      tool_input: { file_path: schemaPath },
+    });
+
+    const mirrored = await readFile(path.join(claudeSkillDir("swimming"), "schema.json"), "utf-8");
+    assert.equal(mirrored, content);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("copies templates/<name>.md into .claude/skills/<slug>/templates/ (creates the subdir)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skill-bridge-template-"));
+    setWorkspace(root);
+    await mkdir(path.join(dataSkillDir("invoice"), "templates"), { recursive: true });
+    const tplPath = path.join(dataSkillDir("invoice"), "templates", "journal-sale.md");
+    const content = "# Record sale\n\nPost the receivable journal.\n";
+    await writeFile(tplPath, content, "utf-8");
+
+    await handleSkillBridge({
+      tool_name: "Write",
+      tool_input: { file_path: tplPath },
+    });
+
+    const mirrored = await readFile(path.join(claudeSkillDir("invoice"), "templates", "journal-sale.md"), "utf-8");
+    assert.equal(mirrored, content);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("does NOT mirror a non-allowlisted sibling (README.md)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "skill-bridge-sibling-"));
+    setWorkspace(root);
+    await mkdir(dataSkillDir("foo"), { recursive: true });
+    const readmePath = path.join(dataSkillDir("foo"), "README.md");
+    await writeFile(readmePath, "scratch notes", "utf-8");
+
+    await handleSkillBridge({
+      tool_name: "Write",
+      tool_input: { file_path: readmePath },
+    });
+
+    // Nothing crossed — the canonical skill dir was never created.
+    assert.equal(existsSync(claudeSkillDir("foo")), false);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
   it("removes .claude/skills/<slug>/ on a matching Bash rm -rf", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "skill-bridge-delete-"));
     setWorkspace(root);
-    await mkdir(path.dirname(claudeSkillFilePath("doomed")), { recursive: true });
+    await mkdir(path.join(claudeSkillDir("doomed"), "templates"), { recursive: true });
     await writeFile(claudeSkillFilePath("doomed"), "---\nname: doomed\n---", "utf-8");
+    // A collection skill: prove the whole-dir delete sweeps the
+    // schema + templates too, leaving no orphans behind.
+    await writeFile(path.join(claudeSkillDir("doomed"), "schema.json"), "{}", "utf-8");
+    await writeFile(path.join(claudeSkillDir("doomed"), "templates", "x.md"), "# x", "utf-8");
 
     await handleSkillBridge({
       tool_name: "Bash",
@@ -134,9 +223,9 @@ describe("handleSkillBridge — mirror copy", () => {
     });
 
     // Whole `.claude/skills/doomed/` is gone — not just the SKILL.md
-    // file. Skills can have sibling assets and we don't want
-    // orphans dangling.
-    assert.equal(existsSync(path.dirname(claudeSkillFilePath("doomed"))), false);
+    // file. Collections carry schema.json + templates/ and we don't
+    // want orphans dangling.
+    assert.equal(existsSync(claudeSkillDir("doomed")), false);
 
     await rm(root, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

A **collection skill** (a skill dir that ships a `schema.json` alongside `SKILL.md`) could not be created by the agent at runtime. Writes into `.claude/skills/` are gated by Claude Code's self-modification permission prompt, which MulmoClaude's headless SSE transport can't answer — so a direct write hangs/fails. The existing **skill-bridge** hook (author under `data/skills/<slug>/`, hook mirrors into `.claude/skills/<slug>/`) crossed that gate for `SKILL.md` **only**, so a collection's defining `schema.json` never reached where discovery looks (`discovery.ts` scans only `.claude/skills/`).

This widens the bridge to a **fixed allowlist** — `SKILL.md`, `schema.json`, `templates/*.md` — and **nothing else**, keeping the `.claude/` bypass narrow and auditable (the agent can't auto-publish arbitrary files into its own config dir). The agent authors under `data/skills/<slug>/` (gate-free); the hook mirrors the three canonical file kinds across and triggers a config refresh.

## Changes

- **`server/workspace/hooks/handlers/skillBridge.ts`** — `slugFromDataPath` → `bridgeTargetFromDataPath`, returning `{ slug, relSegments }` for an allowlisted staging file. `mirrorWrite` is parameterized by the relative destination path so it writes `schema.json` / `templates/*.md` (creating the `templates/` subdir) as well as `SKILL.md`. Whole-dir `rm -rf` delete already sweeps the new files — no orphans.
- **Docs** — new help page `server/workspace/helps/collection-skills.md` (the schema DSL authority); `mc-manage-skills/SKILL.md` gains a Collections section. Both now instruct authoring under `data/skills/<slug>/` instead of `.claude/skills/` (the path that fails). Registered in `helps/index.md`.
- **`plans/feat-collection-skill-authoring.md`** — design + decision record (Design B: widen the bridge; manageSkills-plugin removal explicitly deferred to a separate PR).
- **`server/build/dispatcher.mjs`** — rebuilt esbuild bundle (the hook the server actually runs).
- **Tests** — `schema.json` + template mirror cases, allowlist rejections (README/assets/non-`.md`/nested/hidden), and a delete-sweep regression.

## Test plan

- [x] `yarn test` — unit suite green (incl. skillBridge + helps-registry)
- [x] `yarn test:e2e` — 439 passed
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — all green
- [x] **Manual, in-app**: "Create a swimming log collection skill" → agent followed mc-manage-skills → collection-skills.md, wrote `data/skills/swim-log/{SKILL.md,schema.json}`, and **both mirrored into `.claude/skills/swim-log/`** (schema.json crossed the gate — the previously-impossible step).

## Out of scope

Removing the `manageSkills` plugin (its MCP write tool is now redundant, but the `/api/skills` route + Skills catalog UI on the same plugin are still live) — tracked as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow runtime authoring of collection skills by extending the skill-bridge to mirror additional collection-related files from the staging directory into the Claude skills directory.

New Features:
- Support mirroring collection skill definitions (`schema.json`) and action templates (`templates/*.md`) from `data/skills/<slug>/` into `.claude/skills/<slug>/` so newly authored collections are discovered at runtime.
- Add user-facing documentation describing how to build and manage collection skills, including schema structure, field types, actions, and record storage layout.

Enhancements:
- Generalize the skill-bridge path resolution to an allowlisted set of files per skill and improve logging metadata for mirrored writes and failures.
- Document and record the design decisions and trade-offs for enabling collection skill authoring at runtime.

Tests:
- Extend hook tests to cover mirroring of `schema.json` and templates, rejection of non-allowlisted files and unsafe template paths, and verification that deletions remove all associated collection files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection skills now mirror schema and template files (in addition to skill docs) so runtime-authoring and discovery show full data-driven apps.

* **Documentation**
  * Added a comprehensive collection skills guide covering schema DSL, field types, actions, file layout, routing, and end-to-end workflow.

* **Tests**
  * Expanded validation and integration tests for template-path rules, mirroring behavior, slug validation, and delete semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->