### PR TITLE
feat(encore): show formSchema field definitions in dashboard

### DIFF
--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -309,6 +309,8 @@ const deMessages = {
     bellButtonTitle: "Diesen Zyklus besprechen",
     addButtonLabel: "Hinzufügen",
     unexpectedResponse: "Encore hat eine unerwartete Antwort zurückgegeben.",
+    fieldsHeading: "Pro Zyklus erfasste Felder",
+    fieldRequired: "erforderlich",
     status: {
       active: "Aktiv",
       paused: "Pausiert",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -325,6 +325,8 @@ const enMessages = {
     bellButtonTitle: "Discuss this cycle",
     addButtonLabel: "Add",
     unexpectedResponse: "Encore returned an unexpected response.",
+    fieldsHeading: "Fields collected each cycle",
+    fieldRequired: "required",
     status: {
       active: "Active",
       paused: "Paused",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -312,6 +312,8 @@ const esMessages = {
     bellButtonTitle: "Hablar sobre este ciclo",
     addButtonLabel: "Añadir",
     unexpectedResponse: "Encore devolvió una respuesta inesperada.",
+    fieldsHeading: "Campos recogidos en cada ciclo",
+    fieldRequired: "obligatorio",
     status: {
       active: "Activa",
       paused: "Pausada",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -306,6 +306,8 @@ const frMessages = {
     bellButtonTitle: "Discuter de ce cycle",
     addButtonLabel: "Ajouter",
     unexpectedResponse: "Encore a renvoyé une réponse inattendue.",
+    fieldsHeading: "Champs collectés à chaque cycle",
+    fieldRequired: "requis",
     status: {
       active: "Active",
       paused: "En pause",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -308,6 +308,8 @@ const jaMessages = {
     bellButtonTitle: "このサイクルについて相談する",
     addButtonLabel: "追加",
     unexpectedResponse: "Encore から予期しない応答が返されました。",
+    fieldsHeading: "サイクルごとに記録する項目",
+    fieldRequired: "必須",
     status: {
       active: "有効",
       paused: "一時停止",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -310,6 +310,8 @@ const koMessages = {
     bellButtonTitle: "이 주기 논의하기",
     addButtonLabel: "추가",
     unexpectedResponse: "Encore가 예기치 않은 응답을 반환했습니다.",
+    fieldsHeading: "주기마다 기록하는 항목",
+    fieldRequired: "필수",
     status: {
       active: "활성",
       paused: "일시 중지",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -305,6 +305,8 @@ const ptBRMessages = {
     bellButtonTitle: "Conversar sobre este ciclo",
     addButtonLabel: "Adicionar",
     unexpectedResponse: "O Encore retornou uma resposta inesperada.",
+    fieldsHeading: "Campos coletados a cada ciclo",
+    fieldRequired: "obrigatório",
     status: {
       active: "Ativa",
       paused: "Pausada",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -302,6 +302,8 @@ const zhMessages = {
     bellButtonTitle: "讨论此周期",
     addButtonLabel: "新增",
     unexpectedResponse: "Encore 返回了意外的响应。",
+    fieldsHeading: "每个周期收集的字段",
+    fieldRequired: "必填",
     status: {
       active: "进行中",
       paused: "暂停",

--- a/src/plugins/encore/EncoreDashboard.vue
+++ b/src/plugins/encore/EncoreDashboard.vue
@@ -440,9 +440,12 @@ function recordedValuesForTarget(state: CycleState, targetId: string): RecordedV
                 }}</span>
                 <span v-if="field.placeholder" class="text-[11px] text-gray-400 italic truncate max-w-[16rem]">{{ field.placeholder }}</span>
                 <span v-if="field.options && field.options.length > 0" class="flex flex-wrap gap-1">
-                  <span v-for="opt in field.options" :key="opt" class="inline-flex items-center px-1.5 py-0.5 rounded bg-blue-50 text-[11px] text-blue-600">{{
-                    opt
-                  }}</span>
+                  <span
+                    v-for="(opt, idx) in field.options"
+                    :key="`${field.name}-${idx}`"
+                    class="inline-flex items-center px-1.5 py-0.5 rounded bg-blue-50 text-[11px] text-blue-600"
+                    >{{ opt }}</span
+                  >
                 </span>
               </li>
             </ul>

--- a/src/plugins/encore/EncoreDashboard.vue
+++ b/src/plugins/encore/EncoreDashboard.vue
@@ -26,7 +26,7 @@ import { pluginEndpoints } from "../api";
 import { apiCall } from "../../utils/api";
 import { META } from "./manageEncoreMeta";
 import type { EncoreEndpoints } from "./manageEncoreDefinition";
-import type { EncoreDsl, StepDef } from "../../types/encore-dsl/schema";
+import type { EncoreDsl, StepDef, FormFieldDef } from "../../types/encore-dsl/schema";
 import type { Cadence } from "../../types/encore-dsl/cadence";
 
 // Wire shape mirrors `server/encore/handlers/query.ts`. The
@@ -334,6 +334,14 @@ interface RecordedValue {
   value: string;
 }
 
+// The obligation's formSchema field definitions (label / type /
+// required / placeholder / enum options). Shown read-only when a row
+// is expanded so the user can see what Encore collects each cycle —
+// the chat-driven verbs are what actually record values into them.
+function obligationFields(dsl: EncoreDsl): FormFieldDef[] {
+  return dsl.formSchema.fields;
+}
+
 function recordedValuesForTarget(state: CycleState, targetId: string): RecordedValue[] {
   const values = state.records[targetId]?.values;
   if (!values) return [];
@@ -415,6 +423,29 @@ function recordedValuesForTarget(state: CycleState, targetId: string): RecordedV
             >
               <span class="material-icons text-base">{{ chatStarting[item.obligationId] ? "hourglass_empty" : "chat_bubble_outline" }}</span>
             </button>
+          </div>
+
+          <!-- formSchema field definitions — obligation-level reference,
+               shown only when the row is expanded. These are the fields
+               Encore collects each cycle; values land in the per-cycle
+               chips below once the LLM records them. -->
+          <div v-if="expanded[item.obligationId]" class="border-t border-gray-100 px-4 py-3 bg-white" :data-testid="`encore-fields-${item.obligationId}`">
+            <p class="text-xs font-medium text-gray-500 mb-2">{{ t("encoreDashboard.fieldsHeading") }}</p>
+            <ul class="space-y-1.5">
+              <li v-for="field in obligationFields(item.dsl)" :key="field.name" class="flex flex-wrap items-center gap-2 text-xs">
+                <span class="font-medium text-gray-700">{{ field.label }}</span>
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded bg-gray-100 text-[11px] font-mono text-gray-500">{{ field.type }}</span>
+                <span v-if="field.required" class="inline-flex items-center px-1.5 py-0.5 rounded bg-red-50 text-[11px] text-red-600">{{
+                  t("encoreDashboard.fieldRequired")
+                }}</span>
+                <span v-if="field.placeholder" class="text-[11px] text-gray-400 italic truncate max-w-[16rem]">{{ field.placeholder }}</span>
+                <span v-if="field.options && field.options.length > 0" class="flex flex-wrap gap-1">
+                  <span v-for="opt in field.options" :key="opt" class="inline-flex items-center px-1.5 py-0.5 rounded bg-blue-50 text-[11px] text-blue-600">{{
+                    opt
+                  }}</span>
+                </span>
+              </li>
+            </ul>
           </div>
 
           <div v-if="visibleCycles(item).length > 0" class="border-t border-gray-100 px-4 py-3 bg-gray-50">


### PR DESCRIPTION
## Summary

The `/encore` dashboard previously rendered only **recorded cycle values** and step status — the obligation's `formSchema` (the fields Encore collects each cycle) was never surfaced anywhere in the UI. Users who defined rich field schemas couldn't see them in the app at all.

This adds a read-only **"Fields collected each cycle"** section to the expanded obligation row, listing each `formSchema` field with its:
- `label`
- type badge (`string` / `date` / `enum` / …)
- `required` badge
- `placeholder` hint
- enum `options` chips

The section renders only when a row is expanded (it's obligation-level reference, not pending-attention info), placed above the per-cycle history. No new server endpoint — it uses `item.dsl.formSchema` already returned by the existing `query` dispatch.

## Changes
- `src/plugins/encore/EncoreDashboard.vue` — `obligationFields()` helper + field-list template block
- `src/lang/*.ts` (all 8 locales) — `encoreDashboard.fieldsHeading` + `fieldRequired` keys

## Test plan
- [ ] `/encore` → expand an obligation row → "Fields collected each cycle" lists every formSchema field with label/type/required/placeholder/options
- [ ] Collapsed rows (and ticketed cycles shown while collapsed) do NOT show the field section
- [ ] Expanding an obligation with no cycles still shows the field list + "No cycles recorded yet."
- [ ] `yarn format && yarn lint && yarn typecheck && yarn build` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose Encore obligation form schema details in the dashboard when an obligation row is expanded.

New Features:
- Display a read-only list of formSchema fields for each Encore obligation in the expanded dashboard row, including labels, types, required flags, placeholders, and enum options.

Enhancements:
- Add localized strings for the Encore dashboard fields section heading and required-field badge across all supported languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fields section to the Encore Dashboard that displays field details (name, type, required status, placeholder, and options) when expanding a row.

* **Localization**
  * Extended multilingual support (German, English, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Simplified Chinese) with new field-related labels and headings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->