### PR TITLE
feat(wiki): mc-wiki-health-check preset — weekly read-only lint (RFC #1491 Phase D)

### DIFF
--- a/plans/feat-wiki-health-check-1521.md
+++ b/plans/feat-wiki-health-check-1521.md
@@ -1,0 +1,56 @@
+# feat(wiki): mc-wiki-health-check preset — weekly read-only lint (RFC #1491 Phase D)
+
+## 背景
+
+RFC #1491（Karpathy LLM-Wiki パターン取り込み）の Phase D。
+ユーザー要望: **副作用のないものから着手**。
+
+## 設計判断 — なぜ副作用なしか
+
+- **preset の追加のみ**（`server/workspace/skills-preset/mc-*` 配下に新規
+  ディレクトリ）。launcher は #1335 PR-A 以降 preset を
+  `data/skills/catalog/preset/` に sync するだけで、**★ star されない
+  限り自動でアクティブにならない**。既存ワークスペースの挙動はゼロ影響。
+- 起動後に呼ぶ操作は既存 `manageWiki.lint_report` のみ。これは現状
+  `src/lib/wiki-page/lint.ts` の `findBrokenLinksInPage` /
+  `findMissingFiles` / `findOrphanPages` / `findTagDrift` を回す
+  **完全 read-only** ルート。wiki への書き込みは一切しない。
+- 既定スケジュールは `interval 168h`（≈ weekly）。ユーザーは star 後に
+  `/automations` で頻度変更・停止可能。
+
+## 仕様
+
+- 新規ファイル: `server/workspace/skills-preset/mc-wiki-health-check/SKILL.md`
+- frontmatter: `name` / `description` / `schedule: interval 168h`
+- 本文:
+  - `manageWiki` を `{ action: "lint_report" }` で呼ぶ
+  - findings 0 件 → **1行で「Wiki is healthy (N pages checked)」のみ**
+    返して終了（healthy week の沈黙が運用価値）
+  - findings あり → カテゴリ別グループで簡潔に提示（broken links /
+    missing refs / orphan pages / tag drift）。既存 `formatLintReport`
+    の出力を貼るのを優先
+  - **自動修正しない**: 各 finding は判断要件（rename vs delete 等）。
+    ユーザーが個別に依頼してきた時のみ follow-up ターンで対応
+
+## 変更ファイル
+
+- `server/workspace/skills-preset/mc-wiki-health-check/SKILL.md`（新規・唯一）
+- `plans/feat-wiki-health-check-1521.md`（このファイル）
+
+ソースコード変更なし。新規ルート・新規ディスパッチなし。i18n 追加なし。
+
+## 検証
+
+- 既存 `test/workspace/test_skills_preset.ts` 26 ケース pass（preset
+  sync は glob ベースなので新規 dir は自動で検出される）
+- `yarn typecheck` green（.md のみ）
+- 手動: launcher 起動 → `/skills` の Catalog に `mc-wiki-health-check`
+  が現れる → ★ star → `/automations` に weekly エントリ → 実行で
+  findings の有無に応じた応答
+
+## スコープ外（RFC #1491 後続フェーズ）
+
+- **Phase A**: `mc-wiki-ingest` 系の **書き込みあり** ワークフロー
+- **Phase B**: LLM 駆動 lint（contradiction / stale claims /
+  missing-concepts）。read-only にできるが LLM コスト/精度の設計が要る
+- **Phase C**: Query→Page 昇格 UI（書き込みあり、UX 設計）

--- a/server/workspace/skills-preset/mc-wiki-health-check/SKILL.md
+++ b/server/workspace/skills-preset/mc-wiki-health-check/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: mc-wiki-health-check
+description: Periodically run the wiki lint and report findings — broken page links, missing image / file refs, orphan pages, tag drift. Read-only (never modifies the wiki). Use when the user asks to "check the wiki", "lint the wiki", or runs on the bundled weekly schedule below to surface drift before it accumulates. (#1491 Phase D, Karpathy "lint" operation.)
+schedule: interval 168h
+---
+
+# Wiki Health Check
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+This is the **lint** operation from the LLM-Wiki pattern: a periodic, fully
+**read-only** sweep that flags drift in `data/wiki/` (broken links, orphan
+pages, tag mismatches, missing image / file refs) so the user can fix it
+before it compounds. Findings only — this skill never writes to the wiki.
+
+## What to do
+
+1. Invoke `manageWiki` with `{ "action": "lint_report" }`. The server returns
+   the structured report (re-uses the same lint helpers that power the
+   on-demand "Wiki Lint" button).
+2. **Healthy wiki** (zero findings): reply with one line — "Wiki is healthy
+   (N pages checked)." — and stop. Do not page the user; the value of a
+   weekly run is the silence on healthy weeks.
+3. **Findings present**: render a short, grouped report:
+   - Broken `[[page]]` / `![](path)` links — list `source slug → target` with
+     the file path so the user can jump straight to the offending page.
+   - Missing image / file refs — same shape.
+   - Orphan pages (no incoming links) — list slugs; suggest either linking
+     from `index.md` / a hub page, or archiving if obsolete.
+   - Tag drift (tag in `index.md` ≠ tag in page frontmatter) — list the
+     mismatches.
+   Keep the prose minimal. The lint report's own `formatLintReport` output is
+   already terse and well-grouped; prefer pasting it over re-narrating.
+4. **Do not auto-fix.** Each finding is a decision the user must make
+   (rename vs delete, add a backlink vs archive, fix the tag in which
+   place). Offer to fix any specific one if the user picks it up, but never
+   write to the wiki as part of this scheduled run.
+
+## Rules
+
+- **Read-only**: this skill never calls `manageWiki` with `action` other than
+  `lint_report`. Any "fix" the user agrees to should be a follow-up turn so
+  the boundary stays clear.
+- **Quiet on success**: a healthy wiki run ends in one line. Don't expand the
+  report when there's nothing to report — the schedule's value is catching
+  drift, not generating weekly noise.
+- **Don't open files unless asked**: the lint output already names the
+  offending slugs and paths. The user reads and decides; they'll ask to open
+  a specific page if they want detail.
+- **Cadence**: bundled schedule is `interval 168h` (≈ weekly). The user can
+  star this preset to opt in, or change the cadence by editing the
+  re-registered task in `/automations` after activation.
+
+## Out of scope (RFC #1491 follow-ups)
+
+- LLM-driven lint extensions: contradiction detection across pages, stale
+  claims (date-aware), missing-concepts gap analysis. Tracked as Phase B of
+  the RFC; this preset deliberately covers only the structural lint that's
+  already in the codebase.
+- Auto-fix / promote-answer-to-page workflows: Phases A / C of the RFC.


### PR DESCRIPTION
## Summary

RFC #1491 (Karpathy LLM-Wiki pattern) Phase D, picked as the **side-effect-free** starter per user request. A bundled `mc-*` preset SKILL that calls the existing `manageWiki.lint_report` on a weekly cadence and reports drift only when present — stays silent on healthy weeks.

## Items to Confirm / Review

- **Why this is side-effect-free for existing workspaces:**
  - The change is a single new file under `server/workspace/skills-preset/mc-wiki-health-check/`. The launcher (#1335 PR-A) syncs presets into `data/skills/catalog/preset/` — they sit in the catalog. **They do not become active until the user ★ stars them**, so this PR cannot alter behavior for anyone who doesn't opt in.
  - When activated, the only operation the skill performs is `manageWiki.lint_report`, which is already read-only in the codebase (`findBrokenLinksInPage` / `findMissingFiles` / `findOrphanPages` / `findTagDrift`). No wiki writes, no auto-fix.
- **Cadence**: bundled `schedule: interval 168h` (≈ weekly). The user can change it in `/automations` after star.
- **Quiet on success**: a healthy run ends in one line ("Wiki is healthy (N pages checked)") — the value of the schedule is catching drift, not generating weekly noise.
- **Scope discipline**: out-of-scope are explicitly the writing or LLM-cost-bearing phases (A / B / C in RFC #1491) and are noted in the SKILL body so future maintainers don't expand this preset.

## User Prompt

> wiki 部分にこれを取り入れたい — https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
> RFC issue を立てる
> まずは副作用のないものを実装してほしい

(RFC #1491 captures the full pattern + 4 candidates A/B/C/D; Phase D was the only one with zero wiki writes and reuses existing infra, hence picked as the first deliverable.)

## Test plan

- [ ] `test/workspace/test_skills_preset.ts` 26/26 pass (done locally — preset sync is glob-based, picks up the new dir)
- [ ] `yarn typecheck` green (.md-only change)
- [ ] Manual: launcher boot → `/skills` Catalog shows `mc-wiki-health-check` → ★ star → `/automations` shows weekly entry → run → response shape matches the healthy / findings paths

Closes #1521
Refs #1491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Introduce the mc-wiki-health-check preset skill that schedules a weekly manageWiki.lint_report run to detect wiki drift while remaining read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added plan and skill documentation for a new wiki health check feature.

* **New Features (Planned)**
  * Scheduled weekly automated wiki lint checks to detect broken links, missing references, orphan pages, and tag inconsistencies.
  * Reports "Wiki is healthy" when no issues found; otherwise summarizes findings by category.
  * Read-only operation—no automatic fixes applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->