### PR TITLE
feat(collections): dereference ref fields in derived formulas

### DIFF
--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -175,6 +175,11 @@ Rules and limits:
   column, a non-numeric value, or a **dangling ref** (the slug points at a row
   that doesn't exist) makes the whole formula fail soft to an em-dash (`—`),
   same as any other formula error.
+- The referenced column may itself be a **`derived`** field in the target
+  collection (the host computes the target's own derived fields before the
+  lookup) — *as long as* that target formula is target-local. A target derived
+  field that in turn derefs a **third** collection won't resolve (only one hop
+  is loaded) and reads as `—`.
 - The target collection is loaded **when the page opens**. If a value changes in
   the target while the viewing collection is already open (e.g. you refresh a
   price in `stock-quotes` in another tab), the derived value updates on the next

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -113,6 +113,9 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
 - **`ref`** — `to: "<target-slug>"`. Stores the target record's primary-key
   slug; host renders a clickable link + a dropdown picker populated from the
   target collection. Example: `{ "type": "ref", "to": "mc-clients", "label": "Client" }`.
+  A `derived` field on the same record can also **dereference** a `ref` to read
+  a numeric column off the record it points at — see the cross-collection
+  formula syntax below.
 - **`embed`** — `to: "<target-slug>"`, `id: "<record-id>"`. Pulls a *fixed*
   record from another collection into the read-only detail view (display-only,
   **nothing is stored** on this record). Example: an invoice embedding the
@@ -134,9 +137,52 @@ returns `null` on any failure). Supported:
 - identifier references to **top-level** fields (`subtotal * taxRate`)
 - `sum(tableField[].col)` — sum a column across table rows
 - `sum(tableField[].col * tableField[].col)` — sum a per-row product
+- `<refField>.<col>` — **dereference a `ref` field** and read a numeric column
+  off the record it points at (a live cross-collection lookup)
 
 Example: `subtotal` = `sum(lineItems[].quantity * lineItems[].rate)`,
 `tax` = `subtotal * taxRate`, `total` = `subtotal + tax`.
+
+#### Cross-collection lookups (`<refField>.<col>`)
+
+When a field is a `ref` to another collection, a `derived` formula can reach
+into the referenced record and pull a numeric column out of it. This lets one
+collection compute against data **owned by another** without copying that data.
+
+Canonical use — a portfolio that values holdings against a separate price list:
+
+```jsonc
+// my-portfolio/schema.json  (one record per holding)
+"fields": {
+  "ticker": { "type": "ref", "to": "stock-quotes", "label": "Stock" },  // stores e.g. "AAPL"
+  "shares": { "type": "number", "label": "Shares" },
+  "value":  { "type": "derived", "formula": "shares * ticker.price",     // ← reads price from the quotes row
+              "display": "money", "currency": "USD", "label": "Value" }
+}
+```
+
+Here `ticker.price` resolves the `ticker` ref to its `stock-quotes` record and
+reads that record's `price`. `price` lives **only** in `stock-quotes`; the
+portfolio never stores a copy, so a quote refresh in `stock-quotes` is the
+single source of truth for every holding's value.
+
+Rules and limits:
+
+- The left side must be a `ref` field **on this same record**; the right side is
+  a single column name. Only the `<field>.<col>` shape — no `a.b.c` chains, no
+  dereferencing inside `sum(...)`.
+- The referenced column must hold a number (or a numeric string). A missing
+  column, a non-numeric value, or a **dangling ref** (the slug points at a row
+  that doesn't exist) makes the whole formula fail soft to an em-dash (`—`),
+  same as any other formula error.
+- The target collection is loaded **when the page opens**. If a value changes in
+  the target while the viewing collection is already open (e.g. you refresh a
+  price in `stock-quotes` in another tab), the derived value updates on the next
+  reload — not instantly across tabs.
+- It's still per-record: each holding computes `shares * ticker.price` from its
+  own `ticker`/`shares`. To total the portfolio, add a one-record summary
+  collection or read the values off the list view — there is no cross-row sum
+  over a joined column.
 
 ### Actions (per-record buttons)
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1039,13 +1039,19 @@ function buildRefDisplayMap(detail: CollectionDetailResponse): RefDisplayMap {
 
 /** Index a target collection's items by primary-key slug, keeping the
  *  whole record (unlike buildRefDisplayMap, which reduces each to a
- *  label). Powers ref-dereferencing in derived formulas. */
+ *  label). Powers ref-dereferencing in derived formulas. Each record
+ *  is enriched with the target's OWN derived fields first, because
+ *  derived values are never persisted on disk — so a formula can
+ *  deref a *computed* target column (e.g. `ticker.marketCap`). The
+ *  empty refs (`{}`) resolve target-local derived fields (arithmetic /
+ *  sum / top-level); a target derived field that itself derefs a
+ *  *third* collection stays unresolved — only one hop is loaded. */
 function buildRefRecordMap(detail: CollectionDetailResponse): RefRecordMap {
-  const { primaryKey } = detail.collection.schema;
+  const { schema } = detail.collection;
   const map: RefRecordMap = {};
   for (const item of detail.items) {
-    const slugRaw = item[primaryKey];
-    if (typeof slugRaw === "string" && slugRaw.length > 0) map[slugRaw] = item;
+    const slugRaw = item[schema.primaryKey];
+    if (typeof slugRaw === "string" && slugRaw.length > 0) map[slugRaw] = deriveAll(schema, item, {});
   }
   return map;
 }

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -648,7 +648,7 @@ import CollectionEmbedView from "./CollectionEmbedView.vue";
 import type { EmbedRow, EmbedView } from "./collectionEmbed";
 import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
-import { evaluateDerived } from "../utils/collections/derivedFormula";
+import { evaluateDerived, type FormulaContext } from "../utils/collections/derivedFormula";
 import { actionVisible } from "../utils/collections/actionVisible";
 
 type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived" | "embed";
@@ -697,6 +697,15 @@ interface FieldSpec {
  *  ref fields point at it. */
 type RefDisplayMap = Record<string, string>;
 type RefCache = Record<string, RefDisplayMap>;
+
+/** Per-target-collection cache of the *full* referenced records,
+ *  keyed by target slug then by the target item's primary-key slug.
+ *  RefCache keeps only a display label per item; this keeps the whole
+ *  record so a `derived` formula can dereference a `ref` field and
+ *  read any numeric column off it (e.g. `shares * ticker.price`).
+ *  Built in the same fetch as RefCache (no extra request). */
+type RefRecordMap = Record<string, CollectionItem>;
+type RefRecordCache = Record<string, RefRecordMap>;
 
 /** Per-target cache for `embed` fields: the target collection's
  *  schema + items, kept in full (not reduced to display names like
@@ -828,6 +837,7 @@ const saveError = ref<string | null>(null);
 const actionPending = ref(false);
 const actionError = ref<string | null>(null);
 const refCache = ref<RefCache>({});
+const refRecordCache = ref<RefRecordCache>({});
 const embedCache = ref<EmbedCache>({});
 
 const searchQuery = ref("");
@@ -918,6 +928,7 @@ async function loadCollection(slug: string): Promise<void> {
   items.value = [];
   searchQuery.value = ""; // Reset search query on collection load
   refCache.value = {};
+  refRecordCache.value = {};
   embedCache.value = {};
   viewing.value = null;
   const result = await apiGet<CollectionDetailResponse>(detailUrl(slug));
@@ -992,13 +1003,18 @@ async function loadLinkedCollections(schema: CollectionSchema, expectedSlug: str
   // the write if we're no longer on the slug that triggered us.
   if (collection.value?.slug !== expectedSlug) return;
   const nextRef: RefCache = {};
+  const nextRefRecords: RefRecordCache = {};
   const nextEmbed: EmbedCache = {};
   for (const { target, result } of results) {
     if (!result.ok) continue;
-    if (refTargets.has(target)) nextRef[target] = buildRefDisplayMap(result.data);
+    if (refTargets.has(target)) {
+      nextRef[target] = buildRefDisplayMap(result.data);
+      nextRefRecords[target] = buildRefRecordMap(result.data);
+    }
     if (embedTargets.has(target)) nextEmbed[target] = { schema: result.data.collection.schema, items: result.data.items };
   }
   refCache.value = nextRef;
+  refRecordCache.value = nextRefRecords;
   embedCache.value = nextEmbed;
 }
 
@@ -1017,6 +1033,19 @@ function buildRefDisplayMap(detail: CollectionDetailResponse): RefDisplayMap {
     const displayRaw = item[displayField];
     const display = typeof displayRaw === "string" && displayRaw.length > 0 ? displayRaw : slugRaw;
     map[slugRaw] = display;
+  }
+  return map;
+}
+
+/** Index a target collection's items by primary-key slug, keeping the
+ *  whole record (unlike buildRefDisplayMap, which reduces each to a
+ *  label). Powers ref-dereferencing in derived formulas. */
+function buildRefRecordMap(detail: CollectionDetailResponse): RefRecordMap {
+  const { primaryKey } = detail.collection.schema;
+  const map: RefRecordMap = {};
+  for (const item of detail.items) {
+    const slugRaw = item[primaryKey];
+    if (typeof slugRaw === "string" && slugRaw.length > 0) map[slugRaw] = item;
   }
   return map;
 }
@@ -1587,14 +1616,31 @@ const liveRecord = computed<CollectionItem | null>(() => {
  *  ceiling silently capped longer chains. The new bound is exact
  *  for any DAG over derived fields and an early `break` on
  *  fixed-point keeps the common-case cost the same. */
-function deriveAll(schema: CollectionSchema, base: CollectionItem): CollectionItem {
+/** Resolve every `ref` field on a record to its full target record,
+ *  keyed by the local field name, for `<field>.<col>` derefs in
+ *  formulas. The stored value is the target's slug; we look it up in
+ *  the pre-fetched cache. Unknown slug ⇒ null ⇒ deref fails soft. */
+function resolveRowRefs(schema: CollectionSchema, record: CollectionItem, refRecords: RefRecordCache): NonNullable<FormulaContext["refs"]> {
+  const refs: NonNullable<FormulaContext["refs"]> = {};
+  for (const [key, field] of Object.entries(schema.fields)) {
+    if (field.type !== "ref" || !field.to) continue;
+    const slug = record[key];
+    refs[key] = typeof slug === "string" ? (refRecords[field.to]?.[slug] ?? null) : null;
+  }
+  return refs;
+}
+
+function deriveAll(schema: CollectionSchema, base: CollectionItem, refRecords: RefRecordCache): CollectionItem {
   const enriched: CollectionItem = { ...base };
+  // Ref slugs aren't themselves derived, so the resolved targets are
+  // stable across passes — resolve once up front.
+  const refs = resolveRowRefs(schema, base, refRecords);
   const maxPasses = Object.values(schema.fields).filter((field) => field.type === "derived").length;
   for (let pass = 0; pass < maxPasses; pass++) {
     let mutated = false;
     for (const [key, field] of Object.entries(schema.fields)) {
       if (field.type !== "derived" || !field.formula) continue;
-      const next = evaluateDerived(field.formula, { record: enriched });
+      const next = evaluateDerived(field.formula, { record: enriched, refs });
       if (next !== null && enriched[key] !== next) {
         enriched[key] = next;
         mutated = true;
@@ -1607,7 +1653,7 @@ function deriveAll(schema: CollectionSchema, base: CollectionItem): CollectionIt
 
 const liveDerived = computed<CollectionItem | null>(() => {
   if (!collection.value || !liveRecord.value) return null;
-  return deriveAll(collection.value.schema, liveRecord.value);
+  return deriveAll(collection.value.schema, liveRecord.value, refRecordCache.value);
 });
 
 function derivedDisplay(field: FieldSpec, computedValue: unknown, record: CollectionItem | null): string {
@@ -1626,7 +1672,7 @@ function evaluateDerivedAgainstItem(field: FieldSpec, fieldKey: string, item: Co
   // Walk derived chain: subtotal → tax → total. Same 3-pass cap as
   // `deriveAll`; if a field's value is already on disk (Claude
   // wrote it), prefer the disk value over re-computing.
-  const enriched = deriveAll(collection.value.schema, item);
+  const enriched = deriveAll(collection.value.schema, item, refRecordCache.value);
   const result = enriched[fieldKey];
   return typeof result === "number" && Number.isFinite(result) ? result : null;
 }

--- a/src/utils/collections/derivedFormula.ts
+++ b/src/utils/collections/derivedFormula.ts
@@ -1,18 +1,25 @@
 // Tiny expression evaluator for the `derived` field type on
 // schema-driven collections (see plans/done/feat-mc-invoice.md).
 //
-// Grammar (recursive-descent, no precedence climbing — five
+// Grammar (recursive-descent, no precedence climbing — six
 // non-terminals total):
 //
 //   expr   := term (('+' | '-') term)*
 //   term   := factor (('*' | '/') factor)*
-//   factor := number | sumCall | identifier | '(' expr ')'
+//   factor := number | sumCall | refAccess | identifier | '(' expr ')'
 //   sumCall:= 'sum' '(' sumArg ')'
 //   sumArg := tableCol (('*' | '/') tableCol)*      // e.g. lineItems[].quantity * lineItems[].rate
 //   tableCol := identifier '[]' '.' identifier
+//   refAccess := identifier '.' identifier          // e.g. ticker.price — deref a ref field into its target record
 //
 // `identifier` accepts top-level field names (single segment).
 // Inside `sumArg`, identifiers are the `<table>[].col` form.
+// A two-segment `<field>.<col>` at factor level is a *ref deref*:
+// `<field>` must be a `ref`-typed field on this record (its stored
+// value is the target item's slug), and `<col>` is a numeric column
+// read from that target record. The caller resolves the target into
+// `ctx.refs` (it owns the schema + the loaded target collection);
+// the evaluator stays pure and never does I/O.
 //
 // What's deliberately NOT supported (and would parse-error rather
 // than silently misbehave):
@@ -31,6 +38,16 @@ export interface FormulaContext {
    *  same `draftToRecord` pipeline). For the main table cell,
    *  this is the persisted item. */
   record: Record<string, unknown>;
+  /** Resolved ref-target records for THIS row, keyed by the local
+   *  `ref` field name. The caller (which has the schema + the linked
+   *  collection's items loaded) maps each ref field's stored slug to
+   *  the full target record and passes it here, so a `<field>.<col>`
+   *  formula can read a numeric column off the referenced record
+   *  (e.g. `shares * ticker.price`). A missing key or `null` value
+   *  (unknown field / dangling slug) makes that deref evaluate to
+   *  NaN → the whole formula returns `null` → em-dash, consistent
+   *  with every other failure mode. Absent ⇒ no refs available. */
+  refs?: Record<string, Record<string, unknown> | null>;
 }
 
 export function evaluateDerived(formula: string, ctx: FormulaContext): number | null {
@@ -160,6 +177,7 @@ function isIdentChar(char: string): boolean {
 type Node =
   | { kind: "num"; value: number }
   | { kind: "ident"; name: string }
+  | { kind: "ref"; field: string; col: string }
   | { kind: "binop"; operator: "+" | "-" | "*" | "/"; left: Node; right: Node }
   | { kind: "sum"; arg: SumArg };
 
@@ -236,7 +254,16 @@ class Parser {
         this.expect(")");
         return { kind: "sum", arg };
       }
-      this.consume();
+      this.consume(); // ident
+      // ref deref: `<field>.<col>` (e.g. ticker.price). The table-row
+      // form `<table>[].col` only appears inside sum(), so a `.`
+      // immediately after a top-level ident is unambiguously a ref
+      // dereference here.
+      if (this.peek()?.kind === ".") {
+        this.consume(); // '.'
+        const col = this.expect("ident");
+        return { kind: "ref", field: name, col: col.value as string };
+      }
       return { kind: "ident", name };
     }
     throw new Error(`unexpected token ${tok.kind} in factor`);
@@ -270,6 +297,14 @@ function evaluate(node: Node, ctx: FormulaContext): number {
   if (node.kind === "ident") {
     const raw = ctx.record[node.name];
     return toFiniteNumber(raw);
+  }
+  if (node.kind === "ref") {
+    // `<field>.<col>`: read `col` off the resolved target record the
+    // caller put in ctx.refs. Unknown field / dangling slug → null →
+    // NaN, so the whole formula fails soft to an em-dash.
+    const target = ctx.refs?.[node.field] ?? null;
+    if (!target) return Number.NaN;
+    return toFiniteNumber(target[node.col]);
   }
   if (node.kind === "binop") {
     const left = evaluate(node.left, ctx);

--- a/test/utils/collections/test_derivedFormula.ts
+++ b/test/utils/collections/test_derivedFormula.ts
@@ -92,6 +92,50 @@ describe("evaluateDerived — sum()", () => {
   });
 });
 
+describe("evaluateDerived — ref dereference (<field>.<col>)", () => {
+  // A my-portfolio row: `ticker` is a ref field whose stored value is
+  // the slug "AAPL"; the caller resolves it into ctx.refs.
+  const refs = { ticker: { price: 200, shares: 50 } };
+
+  it("reads a numeric column off the resolved target record", () => {
+    assert.equal(evaluateDerived("ticker.price", { record: { ticker: "AAPL" }, refs }), 200);
+  });
+
+  it("multiplies a local field by a referenced column (value = shares * ticker.price)", () => {
+    assert.equal(evaluateDerived("shares * ticker.price", { record: { ticker: "AAPL", shares: 10 }, refs }), 2000);
+  });
+
+  it("works inside larger arithmetic and parens", () => {
+    assert.equal(evaluateDerived("(ticker.price + 50) * 2", { record: { ticker: "AAPL" }, refs }), 500);
+  });
+
+  it("coerces a numeric-string column", () => {
+    assert.equal(evaluateDerived("ticker.price", { record: { ticker: "AAPL" }, refs: { ticker: { price: "12.5" } } }), 12.5);
+  });
+
+  it("returns null when the ref is unresolved (dangling slug → null)", () => {
+    assert.equal(evaluateDerived("ticker.price", { record: { ticker: "ZZZZ" }, refs: { ticker: null } }), null);
+  });
+
+  it("returns null when refs is absent entirely", () => {
+    assert.equal(evaluateDerived("ticker.price", { record: { ticker: "AAPL" } }), null);
+  });
+
+  it("returns null when the referenced column is missing or non-numeric", () => {
+    assert.equal(evaluateDerived("ticker.peRatio", { record: { ticker: "AAPL" }, refs }), null);
+    assert.equal(evaluateDerived("ticker.price", { record: { ticker: "AAPL" }, refs: { ticker: { price: "n/a" } } }), null);
+  });
+
+  it("does not mistake a top-level field for a ref deref", () => {
+    // No `.` ⇒ plain identifier path, unchanged.
+    assert.equal(evaluateDerived("shares", { record: { shares: 7 }, refs }), 7);
+  });
+
+  it("returns null on a malformed deref (trailing dot / missing column)", () => {
+    assert.equal(evaluateDerived("ticker.", { record: { ticker: "AAPL" }, refs }), null);
+  });
+});
+
 describe("evaluateDerived — error handling", () => {
   it("returns null on parse error (unexpected char)", () => {
     assert.equal(evaluateDerived("1 + @ + 2", { record: {} }), null);


### PR DESCRIPTION
## Summary

Lets a `derived` collection formula reach into the record a `ref` field points at and read a numeric column off it (`shares * ticker.price`). One collection can now compute live against data **owned by another** without copying it — the motivating case is a `my-portfolio` collection valued against a separate `stock-quotes` price list, authored entirely as a skill with **no host code**.

The price lives only in `stock-quotes`; refreshing a quote revalues every holding on next render.

## What changed

- **Evaluator (`src/utils/collections/derivedFormula.ts`)** — new `<refField>.<col>` factor in the grammar/parser, a `ref` AST node, and an optional `refs` map on `FormulaContext`. The evaluator stays pure and synchronous: the caller pre-resolves ref targets, and an unknown field / dangling slug / non-numeric column fails soft to `null` (→ em-dash), consistent with every other formula error. The bare-deref form (`ticker.price`, no surrounding arithmetic) works too.
- **`src/components/CollectionView.vue`** — keep each ref target's *full* records in a new cache (reusing the same fetch that already powers ref labels + the dropdown picker — no extra request), and thread them through `deriveAll` → `evaluateDerived`. Works for both persisted table cells and the live edit form (picking a ticker / editing shares recomputes instantly).
- **Tests** — 9 new unit tests (success, mixed arithmetic, bare deref, dangling ref, absent refs, missing/non-numeric column, plain-identifier non-regression, malformed deref).
- **Docs** — new "Cross-collection lookups" section in `server/workspace/helps/collection-skills.md` with the canonical portfolio example plus rules and limits.

## Limits (documented)

- Only the `<field>.<col>` shape — no `a.b.c` chains, no deref inside `sum(...)`.
- The target collection is snapshotted at page load; a change in the target shows on the next reload, not instantly across tabs.
- Still per-record — no cross-row sum over a joined column.

## Verified end-to-end

A running instance read the help doc, authored the `my-portfolio` schema (a `ticker` ref to `stock-quotes`, `shares`, and derived `price` + `value`), and the host computed `100 AAPL × $308.33 = $30,833`, `200 TSLA × $433.59 = $86,718` with no copied prices.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
- [x] Full unit suite green (5225 passing; +9 new in `test_derivedFormula.ts`)
- [ ] Manual: open a collection with a ref-deref derived field, confirm the value renders and updates live in the edit form; confirm a dangling ref renders `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Derived formulas now support cross-collection lookups, allowing formulas to read numeric columns from referenced records.

* **Documentation**
  * Expanded docs with syntax guidance, a portfolio/stock-quotes example, and explicit rules/limits (same-record ref requirement, single-column target, numeric-only expectation, failure behavior, update timing).

* **Tests**
  * Added tests covering dereference syntax, numeric coercion, arithmetic use, and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->