### PR TITLE
Collections follow-ups: + Collection button, UI density, ref-deref docs

### DIFF
--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -64,8 +64,19 @@ Relations and computed/behavioural constructs:
   derived columns are disallowed to keep the editor + evaluator simple.
 - **`derived`** — a read-only value from a tiny formula evaluated against the
   record (`subtotal * taxRate`, `sum(lineItems[].quantity * lineItems[].rate)`).
-  Pure recursive-descent evaluator, **no `eval`/`Function`**, returns `null` on
-  any failure (`src/utils/collections/derivedFormula.ts`).
+  A formula can also **dereference a `ref` field** to read a numeric column off
+  the record it points at — `shares * ticker.price`, where `ticker` is a `ref`
+  to a separate `stock-quotes` collection that owns `price`. This is a live
+  cross-collection lookup: the value is computed against data owned by *another*
+  collection without ever copying it, so refreshing a quote revalues every
+  holding on next render. The host enriches each referenced record with the
+  target collection's own (target-local) derived fields before the lookup, so a
+  deref can target a *computed* column too — one hop only; a target formula that
+  itself derefs a third collection stays unresolved. Pure recursive-descent
+  evaluator, **no `eval`/`Function`**, returns `null` on any failure
+  (`src/utils/collections/derivedFormula.ts`). This is the first construct where
+  a `ref` is more than a display link — it becomes a join the compute layer can
+  follow.
 - **`singleton`** — at most one record, pinned to a fixed id (e.g. `me`).
 - **`actions`** — per-record buttons. `kind: "chat"` starts a new chat in
   `role` seeded from `template`. An optional `when: { field, in: [...] }`
@@ -179,6 +190,44 @@ breaks: **runtime referential integrity** (orphaned refs on delete),
 **schema migration** of existing records when a schema changes, and
 **multi-user / concurrent writes** are all out of scope today and documented as
 such in the field-type plans under `plans/done/`.
+
+## Direction: toward a no-code app platform
+
+Each generic capability added to the host widens the class of apps a schema
+alone can express. The progression is visible in the shipped field types:
+flat records → relations (`ref`/`embed`) → composition (`table`) → in-record
+compute (`derived`) → **cross-collection compute** (ref-deref in formulas). With
+that last step a collection can value itself against data another collection
+owns, and "a `schema.json` + a folder of records" stops looking like a database
+table and starts looking like a small application — the motivating case being a
+portfolio whose holdings are valued live against a separate price list, authored
+entirely as a skill with zero host code.
+
+The honest **declarative ceiling** — where the schema currently stops and the
+LLM-as-runtime takes over — is the roadmap, each item a *DSL-vs.-agent* choice:
+
+- **Cross-row aggregation / rollups.** Per-row joins work (`shares * ticker.price`
+  on each holding); there is no cross-*row* sum over a joined column, so a
+  portfolio *total* isn't expressible declaratively. The same gap blocks
+  group-bys and pivots.
+- **Richer derived values.** The evaluator is numeric-only — no string
+  concatenation, date math, or conditional (`if`/`case`) derivation. Formatting
+  and "status from a date" logic still fall to the agent.
+- **Write-actions.** `actions` only have `kind: "chat"`; the `CollectionActionKind`
+  type reserves room for a future `"mutate"` kind — declarative state transitions,
+  a button that flips `status: draft → sent` without spinning up a chat — but it
+  is unbuilt. Today every write goes through the agent or the form.
+- **Declarative views.** Search exists; filter / sort / group, saved views, and
+  charts rendered from collection data do not.
+
+The governing constraint is the same one that keeps the host domain-free
+(*"add a generic capability, never a provider"*): **extend the DSL only when it
+beats handing the job to Claude on reliability or latency.** The LLM backstops
+every gap above already, so a new field type or action kind has to earn its
+place by being something a schema can express *more dependably* than a prose
+template can — not merely something that *could* be declarative. That tension —
+how much intelligence to freeze into the schema vs. leave to the runtime — is
+the live design question for every future extension here.
 
 ## Adding a collection
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -116,7 +116,7 @@
               @keydown.enter.self="openView(item)"
               @keydown.space.self.prevent="openView(item)"
             >
-              <td v-for="[key, field] in nonEmbedFields" :key="key" class="px-5 py-3.5 text-slate-700 align-middle max-w-xs font-medium">
+              <td v-for="[key, field] in nonEmbedFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
                 <!-- Boolean state badge -->
                 <span v-if="field.type === 'boolean'" class="block">
                   <span
@@ -182,7 +182,7 @@
                 <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
               </td>
 
-              <td class="px-5 py-3.5 text-right whitespace-nowrap align-middle">
+              <td class="px-5 py-2 text-right whitespace-nowrap align-middle">
                 <div class="flex items-center justify-end gap-2">
                   <button
                     type="button"

--- a/src/components/CollectionsIndexView.vue
+++ b/src/components/CollectionsIndexView.vue
@@ -1,19 +1,10 @@
 <template>
-  <div class="h-full overflow-y-auto bg-slate-50/50 px-6 py-8">
+  <div class="h-full overflow-y-auto bg-slate-50/50 px-6 py-6">
     <div class="max-w-4xl mx-auto">
-      <!-- Premium Hero Header -->
-      <div
-        class="relative overflow-hidden rounded-2xl bg-gradient-to-tr from-slate-900 via-indigo-950 to-slate-900 p-8 md:p-10 mb-8 shadow-xl shadow-slate-950/20 border border-slate-800/80"
-      >
-        <!-- Abstract decorative glows -->
-        <div class="absolute -right-10 -top-10 h-44 w-44 rounded-full bg-indigo-500/15 blur-3xl pointer-events-none"></div>
-        <div class="absolute -left-10 -bottom-10 h-44 w-44 rounded-full bg-violet-500/15 blur-3xl pointer-events-none"></div>
-
-        <div class="relative z-10">
-          <h1 class="text-2xl md:text-3xl font-bold text-white tracking-tight leading-tight">
-            {{ t("collectionsView.title") }}
-          </h1>
-        </div>
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-xl font-semibold text-slate-800">
+          {{ t("collectionsView.title") }}
+        </h1>
       </div>
 
       <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">

--- a/src/components/CollectionsIndexView.vue
+++ b/src/components/CollectionsIndexView.vue
@@ -5,6 +5,15 @@
         <h1 class="text-xl font-semibold text-slate-800">
           {{ t("collectionsView.title") }}
         </h1>
+        <button
+          type="button"
+          class="h-8 px-2.5 flex items-center gap-1 rounded bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs transition-colors shadow-sm"
+          data-testid="collections-add-collection"
+          @click="startCreateCollectionChat"
+        >
+          <span class="material-icons text-sm">add</span>
+          <span>{{ t("collectionsView.addCollectionLabel") }}</span>
+        </button>
       </div>
 
       <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">
@@ -82,6 +91,8 @@ import { useRouter } from "vue-router";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { PAGE_ROUTES } from "../router/pageRoutes";
+import { useAppApi } from "../composables/useAppApi";
+import { BUILTIN_ROLE_IDS } from "../config/roles";
 
 interface CollectionSummary {
   slug: string;
@@ -96,6 +107,7 @@ interface CollectionsListResponse {
 
 const { t } = useI18n();
 const router = useRouter();
+const appApi = useAppApi();
 
 const collections = ref<CollectionSummary[]>([]);
 const loading = ref(true);
@@ -115,6 +127,10 @@ async function loadCollections(): Promise<void> {
 
 function openCollection(slug: string): void {
   router.push({ name: PAGE_ROUTES.collections, params: { slug } }).catch(() => {});
+}
+
+function startCreateCollectionChat(): void {
+  appApi.startNewChat(t("collectionsView.addCollectionPrompt"), BUILTIN_ROLE_IDS.general);
 }
 
 onMounted(loadCollections);

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1344,6 +1344,9 @@ const deMessages = {
       "Zusätzliche Tool-Namen, die Claude über {allowedTools} übergeben werden sollen. Einer pro Zeile. Nützlich für in Claude Code integrierte MCP-Server wie Gmail / Google Kalender, nachdem Sie sich über {claudeMcp} authentifiziert haben.",
   },
   collectionsView: {
+    addCollectionLabel: "Sammlung",
+    addCollectionPrompt:
+      "Hilf mir, eine neue Sammlung zu erstellen. Lies zuerst `config/helps/collection-skills.md` für die Konventionen schemabasierter Sammlungen. Verwende dann das Tool `presentForm` (nutze nicht AskUserQuestion), um mich zu fragen, welche Art von Daten ich verfolgen möchte, und erstelle die schema.json und SKILL.md aus meinen Antworten.",
     title: "Sammlungen",
     backToIndex: "Zurück zu Sammlungen",
     indexEmpty: "Keine Sammlungen installiert. Markiere auf der Skills-Seite eine Skill mit Schema, um sie hier zu sehen.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1325,6 +1325,9 @@ const enMessages = {
       "Extra tool names to pass to Claude via {allowedTools}. One per line. Useful for built-in Claude Code MCP servers like Gmail / Google Calendar after you have authenticated via {claudeMcp}.",
   },
   collectionsView: {
+    addCollectionLabel: "Collection",
+    addCollectionPrompt:
+      "Help me create a new collection. First read `config/helps/collection-skills.md` for the schema-driven collection conventions. Then use the `presentForm` tool (do not use AskUserQuestion) to ask me what kind of data I want to track, and author the schema.json and SKILL.md from my answers.",
     title: "Collections",
     backToIndex: "Back to collections",
     indexEmpty: "No collections installed. Star a skill that ships a schema from the Skills page to see it here.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1339,6 +1339,9 @@ const esMessages = {
       "Nombres adicionales de herramientas que pasar a Claude mediante {allowedTools}. Uno por línea. Útil para servidores MCP integrados en Claude Code como Gmail / Google Calendar tras autenticarte mediante {claudeMcp}.",
   },
   collectionsView: {
+    addCollectionLabel: "Colección",
+    addCollectionPrompt:
+      "Ayúdame a crear una nueva colección. Primero lee `config/helps/collection-skills.md` para conocer las convenciones de las colecciones basadas en esquemas. Luego usa la herramienta `presentForm` (no uses AskUserQuestion) para preguntarme qué tipo de datos quiero registrar, y crea el schema.json y el SKILL.md a partir de mis respuestas.",
     title: "Colecciones",
     backToIndex: "Volver a colecciones",
     indexEmpty: "No hay colecciones instaladas. Marca con estrella una skill que incluya un schema desde la página Skills para verla aquí.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1333,6 +1333,9 @@ const frMessages = {
       "Noms d'outils supplémentaires à transmettre à Claude via {allowedTools}. Un par ligne. Utile pour les serveurs MCP intégrés à Claude Code comme Gmail / Google Agenda après authentification via {claudeMcp}.",
   },
   collectionsView: {
+    addCollectionLabel: "Collection",
+    addCollectionPrompt:
+      "Aide-moi à créer une nouvelle collection. Lis d'abord `config/helps/collection-skills.md` pour les conventions des collections basées sur un schéma. Utilise ensuite l'outil `presentForm` (n'utilise pas AskUserQuestion) pour me demander quel type de données je veux suivre, et crée le schema.json et le SKILL.md à partir de mes réponses.",
     title: "Collections",
     backToIndex: "Retour aux collections",
     indexEmpty: "Aucune collection installée. Mettez une étoile sur une compétence avec un schema depuis la page Skills pour la voir ici.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1322,6 +1322,9 @@ const jaMessages = {
       "{allowedTools} を介して Claude に渡す追加ツール名。1行につき1つ。Gmail / Google Calendar などの Claude Code 組み込み MCP サーバを、{claudeMcp} で認証した後に利用する場合に便利です。",
   },
   collectionsView: {
+    addCollectionLabel: "コレクション",
+    addCollectionPrompt:
+      "新しいコレクションを作成したいです。まず `config/helps/collection-skills.md` を読んでスキーマ駆動コレクションの規約を確認してください。次に `presentForm` ツールを使って（AskUserQuestion は使わないで）どんなデータを管理したいか質問し、その回答をもとに schema.json と SKILL.md を作成してください。",
     title: "コレクション",
     backToIndex: "コレクション一覧に戻る",
     indexEmpty: "インストール済みのコレクションがありません。スキーマを含むスキルを Skills ページからスター付けすると、ここに表示されます。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1325,6 +1325,9 @@ const koMessages = {
       "{allowedTools} 를 통해 Claude 에 전달할 추가 도구 이름. 한 줄에 하나씩. {claudeMcp} 로 인증을 완료한 후 Claude Code 내장 MCP 서버 (Gmail / Google 캘린더 등) 를 사용할 때 유용합니다.",
   },
   collectionsView: {
+    addCollectionLabel: "컬렉션",
+    addCollectionPrompt:
+      "새 컬렉션을 만들고 싶어요. 먼저 `config/helps/collection-skills.md`를 읽고 스키마 기반 컬렉션 규칙을 확인하세요. 그런 다음 `presentForm` 도구를 사용해(AskUserQuestion은 사용하지 말고) 어떤 데이터를 관리하고 싶은지 물어보고, 제 답변을 바탕으로 schema.json과 SKILL.md를 작성해 주세요.",
     title: "컬렉션",
     backToIndex: "컬렉션 목록으로 돌아가기",
     indexEmpty: "설치된 컬렉션이 없습니다. Skills 페이지에서 스키마를 포함한 스킬에 별표를 추가하면 여기에 표시됩니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1328,6 +1328,9 @@ const ptBRMessages = {
       "Nomes adicionais de ferramentas a serem passados ao Claude via {allowedTools}. Um por linha. Útil para servidores MCP integrados ao Claude Code como Gmail / Google Calendar após autenticar via {claudeMcp}.",
   },
   collectionsView: {
+    addCollectionLabel: "Coleção",
+    addCollectionPrompt:
+      "Ajude-me a criar uma nova coleção. Primeiro leia `config/helps/collection-skills.md` para conhecer as convenções de coleções baseadas em esquema. Depois use a ferramenta `presentForm` (não use AskUserQuestion) para perguntar que tipo de dados quero acompanhar, e crie o schema.json e o SKILL.md a partir das minhas respostas.",
     title: "Coleções",
     backToIndex: "Voltar para coleções",
     indexEmpty: "Nenhuma coleção instalada. Marque com estrela uma skill que inclua um schema na página Skills para vê-la aqui.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1315,6 +1315,9 @@ const zhMessages = {
       "要通过 {allowedTools} 传递给 Claude 的额外工具名。每行一个。适用于在 {claudeMcp} 完成授权后,调用 Claude Code 内置的 MCP 服务器(如 Gmail / Google 日历)。",
   },
   collectionsView: {
+    addCollectionLabel: "集合",
+    addCollectionPrompt:
+      "帮我创建一个新的集合。请先阅读 `config/helps/collection-skills.md` 了解基于 schema 的集合约定。然后使用 `presentForm` 工具（不要使用 AskUserQuestion）询问我想跟踪哪种数据，并根据我的回答编写 schema.json 和 SKILL.md。",
     title: "集合",
     backToIndex: "返回集合列表",
     indexEmpty: "尚未安装任何集合。在「技能」页面对带有 schema 的技能加星即可在此显示。",


### PR DESCRIPTION
## Summary

Three follow-ups to the cross-collection ref-deref work (merged in #1533), bundled since they all touch the collections surfaces:

- **`+ Collection` button on the dashboard.** The collections index (`/collections`) now has an Encore-style Add button that starts a new chat in the **general** role, seeded with a prompt pointing the agent at `config/helps/collection-skills.md` and instructing it to gather requirements via the `presentForm` tool (explicitly **not** `AskUserQuestion`, which isn't available in MulmoClaude) before authoring the `schema.json` + `SKILL.md`. Reuses the existing client `appApi.startNewChat` — no server endpoint. Labelled `+ Collection` to distinguish it from the per-collection `Add` button that creates a record. New i18n keys (`addCollectionLabel`, `addCollectionPrompt`) across all 8 locales.
- **UI density.** Table-body row padding `py-3.5` → `py-2` in `CollectionView`, and the oversized gradient hero header in `CollectionsIndexView` replaced with a compact title (matching the other dashboards). Reclaims vertical space.
- **Docs.** `docs/collections-architecture.md` updated for the merged ref-deref feature (the `derived` construct can dereference a `ref` to read a numeric column off the referenced record) plus a new "Direction: toward a no-code app platform" section laying out the declarative ceiling and the DSL-vs.-agent design tension.

## Verified

- Live end-to-end test: the `+ Collection` button opened a general-role chat; the agent read the help doc, used `presentForm` (not AskUserQuestion), and authored a working `contacts` collection (schema + SKILL.md + a PDF address-label action template).
- `general` role exposes both `presentForm` and `presentDocument` (`src/config/roles.ts:58-66`), so the generated action works when clicked.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` clean
- [x] i18n lockstep satisfied (all 8 locales; de.ts typographic quotes intact)
- [ ] Manual: `/collections` shows `+ Collection`; clicking opens a general-role chat with the seeded prompt; the row density + title look right; a generated action button renders its document

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a streamlined collections dashboard with inline collection creation and refreshed documentation for cross-collection computed fields.

New Features:
- Add a + Collection button on the collections index that opens a pre-seeded general-role chat to guide users through creating a new collection skill.

Enhancements:
- Tighten row padding in the collections table view and replace the gradient hero header with a compact header layout to increase information density.

Documentation:
- Expand collections architecture docs to document ref-deref support in derived formulas and outline the longer-term direction toward a no-code app platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Add Collection" button with a guided workflow to help create collections via a schema-driven prompt.

* **Documentation**
  * Expanded the collections architecture guide: clarified derived-field dereferencing and evaluator behavior; added a "no-code app platform" direction and roadmap gaps.

* **Style**
  * Tightened table row spacing in collection lists for denser, cleaner rows.

* **Localization**
  * Added collection-related UI strings across multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->