### PR TITLE
fix(chat): select trailing summary in single-pane after tool calls

### DIFF
--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -170,6 +170,17 @@ export interface ActiveSession {
   // session (not on the subscription closure) so updates on turn N+1
   // are visible to the reused subscription callback.
   runStartIndex: number;
+  // Set true when a tool call lands while an assistant text card is the
+  // tail of `toolResults`, so the next streamed assistant delta opens a
+  // FRESH card instead of merging onto the pre-tool prose. Native
+  // Bash/Read/Write calls route to `toolCallHistory` (never
+  // `toolResults`), so without this flag `appendToLastAssistantText`
+  // would glue every post-tool text block onto the first one — a single
+  // merged card whose selection anchors at its first line. Reload splits
+  // them per persisted text entry and selects the last; this flag makes
+  // the live stream match that, so a trailing summary becomes its own
+  // auto-selected card in single-pane mode.
+  assistantTextInterrupted: boolean;
   /**
    * In-flight background generations triggered by a plugin view (e.g.
    * MulmoScript image/audio/movie renders). Keyed by

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -42,6 +42,10 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
   switch (event.type) {
     case EVENT_TYPES.toolCall:
       session.toolCallHistory.push(toToolCallEntry(event));
+      // A tool call closes the current assistant text block: the next
+      // streamed delta must open a fresh card, not merge onto the
+      // pre-tool prose. See `ActiveSession.assistantTextInterrupted`.
+      session.assistantTextInterrupted = true;
       ctx.scrollSidebarToBottom();
       return;
     case EVENT_TYPES.toolCallResult:

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -148,6 +148,7 @@ export function buildLoadedSession(opts: {
     startedAt,
     updatedAt,
     runStartIndex: toolResults.length,
+    assistantTextInterrupted: false,
     pendingGenerations: {},
   };
 }

--- a/src/utils/session/sessionFactory.ts
+++ b/src/utils/session/sessionFactory.ts
@@ -17,6 +17,7 @@ export function createEmptySession(sessionId: string, roleId: string): ActiveSes
     startedAt: now,
     updatedAt: now,
     runStartIndex: 0,
+    assistantTextInterrupted: false,
     pendingGenerations: {},
   };
 }

--- a/src/utils/session/sessionHelpers.ts
+++ b/src/utils/session/sessionHelpers.ts
@@ -73,7 +73,12 @@ export function applyTextEvent(session: ActiveSession, message: string, source: 
     }
     return;
   }
-  if (appendToLastAssistantText(session, message)) return;
+  // A tool call since the last delta closes the prior text block, so
+  // skip the append and open a fresh card (matches the per-block split
+  // a reloaded session produces). Otherwise stream deltas of the same
+  // block onto the tail card.
+  if (!session.assistantTextInterrupted && appendToLastAssistantText(session, message)) return;
+  session.assistantTextInterrupted = false;
   const textResult = makeTextResult(message, "assistant");
   pushResult(session, textResult);
   if (shouldSelectAssistantText(session.toolResults, session.runStartIndex)) {

--- a/test/agent/test_skillTagging.ts
+++ b/test/agent/test_skillTagging.ts
@@ -30,6 +30,7 @@ function makeSession(): ActiveSession {
     startedAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     runStartIndex: 0,
+    assistantTextInterrupted: false,
     pendingGenerations: {},
   };
 }

--- a/test/utils/session/test_assistantTextInterrupt.ts
+++ b/test/utils/session/test_assistantTextInterrupt.ts
@@ -1,0 +1,77 @@
+// Regression for the single-pane "last message not selected" bug.
+//
+// Assistant text streams as deltas; native Bash/Read/Write tool calls
+// route to `toolCallHistory`, never `toolResults`. Before the fix,
+// `appendToLastAssistantText` glued every post-tool text block onto the
+// first assistant card — one merged card whose selection anchored at its
+// first line, so a trailing summary never became the selected canvas
+// result in single-pane mode. The fix breaks the card at each tool-call
+// boundary (via `ActiveSession.assistantTextInterrupted`) so the live
+// stream matches the per-block split a reloaded session produces.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyTextEvent } from "../../../src/utils/session/sessionHelpers.js";
+import { createEmptySession } from "../../../src/utils/session/sessionFactory.js";
+import type { ActiveSession } from "../../../src/types/session.js";
+
+// Mirror the dispatcher's toolCall side effect without importing the
+// whole SSE machinery: a tool call closes the open text block.
+function toolCall(session: ActiveSession): void {
+  session.assistantTextInterrupted = true;
+}
+
+function beginTurn(session: ActiveSession, message: string): void {
+  applyTextEvent(session, message, "user");
+  session.runStartIndex = session.toolResults.length;
+}
+
+function assistantTexts(session: ActiveSession): string[] {
+  return session.toolResults
+    .filter((result) => result.toolName === "text-response" && (result.data as { role?: string }).role === "assistant")
+    .map((result) => (result.data as { text?: string }).text ?? "");
+}
+
+describe("applyTextEvent — tool calls split assistant text into separate cards", () => {
+  it("merges consecutive deltas of the same block but splits across a tool call", () => {
+    const session = createEmptySession("s1", "investor");
+    beginTurn(session, "Build my portfolio");
+
+    // Block 1 streams as two deltas, then a tool call, then block 2.
+    applyTextEvent(session, "I'll create ", "assistant");
+    applyTextEvent(session, "the collection.", "assistant");
+    toolCall(session);
+    applyTextEvent(session, "Now the holdings.", "assistant");
+
+    const texts = assistantTexts(session);
+    assert.deepEqual(texts, ["I'll create the collection.", "Now the holdings."]);
+  });
+
+  it("selects the final post-tool text card (the trailing summary)", () => {
+    const session = createEmptySession("s2", "investor");
+    beginTurn(session, "Build my portfolio");
+
+    applyTextEvent(session, "I'll create the collection.", "assistant");
+    toolCall(session);
+    applyTextEvent(session, "Now the holdings.", "assistant");
+    toolCall(session);
+    applyTextEvent(session, "Your portfolio is live: total $119,157.", "assistant");
+
+    const last = session.toolResults[session.toolResults.length - 1];
+    assert.equal((last.data as { text?: string }).text, "Your portfolio is live: total $119,157.");
+    // Single-pane canvas follows `selectedResultUuid` — it must land on
+    // the summary, not the first "I'll create…" card.
+    assert.equal(session.selectedResultUuid, last.uuid);
+  });
+
+  it("still streams uninterrupted deltas into one card", () => {
+    const session = createEmptySession("s3", "investor");
+    beginTurn(session, "Hi");
+
+    applyTextEvent(session, "Hello ", "assistant");
+    applyTextEvent(session, "there ", "assistant");
+    applyTextEvent(session, "friend.", "assistant");
+
+    assert.deepEqual(assistantTexts(session), ["Hello there friend."]);
+  });
+});

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -28,6 +28,7 @@ function makeActive(overrides: Partial<ActiveSession> = {}): ActiveSession {
     startedAt: "2026-04-10T10:00:00.000Z",
     updatedAt: "2026-04-10T10:05:00.000Z",
     runStartIndex: 0,
+    assistantTextInterrupted: false,
     pendingGenerations: {},
     ...overrides,
   };


### PR DESCRIPTION
## Summary
In single-pane (non-stack) mode, the **last** assistant message was not selected after a turn that involved tool calls — the canvas stayed anchored to the first part of the response (e.g. the *"I'll create the my-portfolio collection…"* preamble) while the final summary table was never surfaced.

**Root cause.** Assistant text streams as deltas (`server/agent/stream.ts`), and native `Bash`/`Read`/`Write` tool calls route to `toolCallHistory`, never `toolResults`. So `appendToLastAssistantText` kept seeing an assistant text card as the tail of `toolResults` and merged *every* post-tool text block onto it — collapsing a `text → Write → text → Write → summary` turn into a **single** card whose selection anchors at its first line. A reloaded session splits the same stream per persisted text entry and selects the last one (`parseSessionEntries` + `resolveSelectedUuid`), which is why it looked correct only after a refresh.

**Fix.** Track `assistantTextInterrupted` on the session: set it when a tool call lands while an assistant text card is the tail, and consume it in `applyTextEvent` so the next streamed delta opens a fresh card instead of merging. Live now matches reload — each assistant text block is its own card, and the trailing summary becomes the auto-selected canvas result.

## Changes
- `src/types/session.ts` — new `assistantTextInterrupted` flag on `ActiveSession` (documented).
- `src/utils/agent/eventDispatch.ts` — set the flag on `toolCall` events.
- `src/utils/session/sessionHelpers.ts` — skip the append (open a fresh card) when interrupted; clear the flag.
- `src/utils/session/sessionFactory.ts` / `sessionEntries.ts` — initialize the flag.
- Tests: new `test/utils/session/test_assistantTextInterrupt.ts`; fixture updates in `test_skillTagging.ts` / `test_mergeSessions.ts`.

## Test plan
- [x] `yarn test` (new regression test replays the bug's `text → tool → text → tool → summary` sequence and asserts separate cards + summary selected)
- [x] `yarn lint` / `yarn typecheck` / `yarn build`
- [ ] Manual: in single-pane mode, run the Investor *"Create a my-portfolio collection…"* query and confirm the canvas lands on the final summary, not the preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure assistant text following tool calls is split into separate cards so the final summary message is auto-selected in single-pane mode.

Bug Fixes:
- Fix single-pane chats where post-tool assistant text was merged into a single card, preventing the trailing summary from being selected.

Enhancements:
- Track assistant-text interruption state on sessions so streaming behavior matches reloaded sessions in how assistant messages are segmented.

Tests:
- Add regression tests covering assistant text streaming across tool-call boundaries and update existing session-related tests for the new session flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat message display when tool calls interrupt assistant text streaming; subsequent text now appears in a separate message instead of merging with the previous text.
  * Ensured live-stream chat behavior matches saved session reload behavior for consistent message splitting at tool call boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->