### PR TITLE
feat(canvas): show role sample queries in StackView empty state (#1538)

### DIFF
--- a/plans/feat-stack-empty-queries-1538.md
+++ b/plans/feat-stack-empty-queries-1538.md
@@ -1,0 +1,35 @@
+# Plan: stack-view empty state shows role sample queries (#1538)
+
+## Problem
+
+In `single` layout the empty-chat surface (`<PageChatComposer>`) renders the
+role's sample queries as always-visible buttons. In `stack` layout the canvas
+shows only `t("common.noResultsYet")` and the queries are hidden behind the
+collapsed `<SuggestionsPanel>` toggle in ChatInput — users starting a new
+chat in stack mode have no on-screen hint of what to ask.
+
+## Approach (option A)
+
+1. `<StackView>` gains an optional `queries?: readonly string[]` prop.
+2. The empty-state branch (`v-if="toolResults.length === 0"`) renders, when
+   `queries` is non-empty, a vertical button list (same visual language as
+   `<SuggestionsPanel>`'s suggestion buttons) inside a centered column. Each
+   button calls `props.sendTextMessage(query)` (the prop already exists).
+3. Empty `queries` (or missing `sendTextMessage`) → keep the existing
+   "No results yet" message untouched.
+4. `App.vue` passes `:queries="sessionRoleQueries"` to `<StackView>`.
+   `sessionRoleQueries` is already computed and threaded into `<ChatInput>`
+   for the stack-mode bottom bar — same source of truth.
+5. No new i18n keys: rely on existing `common.noResultsYet` for the fallback.
+
+## Out of scope
+
+- SuggestionsPanel auto-expand (option B).
+- Persistent suggestions strip in ChatInput (option C).
+- Skill suggestions in the empty state — queries are role-only.
+
+## Test
+
+- Stack mode + role with queries + zero results → buttons render, click sends.
+- Stack mode + role with empty queries → "No results yet" fallback unchanged.
+- Single mode → unaffected.

--- a/src/App.vue
+++ b/src/App.vue
@@ -184,6 +184,7 @@
             :selected-result-uuid="selectedResultUuid"
             :result-timestamps="activeSession?.resultTimestamps ?? new Map()"
             :send-text-message="sendMessage"
+            :queries="sessionRoleQueries"
             :session-role-name="sessionRoleName"
             :session-role-icon="sessionRoleIcon"
             :layout-mode="layoutMode"

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -23,7 +23,21 @@
          the container's `pb-4` padding can't combine into a stray
          scrollbar. A sibling `flex-1` slot centers cleanly. -->
     <div v-if="toolResults.length === 0" class="flex-1 flex items-center justify-center text-gray-400 text-sm" data-testid="stack-empty">
-      {{ t("common.noResultsYet") }}
+      <!-- Mirror PageChatComposer's empty-state UX in single layout:
+           role.queries become clickable suggestions so a fresh stack
+           chat isn't a blank "no results yet" wall. -->
+      <div v-if="queries && queries.length > 0 && sendTextMessage" class="w-full max-w-2xl px-4 flex flex-col gap-1.5">
+        <button
+          v-for="query in queries"
+          :key="query"
+          class="text-left text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded px-3 py-1.5 border border-gray-300 transition-colors"
+          data-testid="stack-empty-query"
+          @click="sendTextMessage(query)"
+        >
+          {{ query }}
+        </button>
+      </div>
+      <template v-else>{{ t("common.noResultsYet") }}</template>
     </div>
     <div v-else ref="containerRef" class="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3" data-testid="stack-scroll">
       <div
@@ -161,6 +175,10 @@ const props = defineProps<{
   selectedResultUuid: string | null;
   resultTimestamps: Map<string, number>;
   sendTextMessage?: (text: string) => void;
+  /** Role's sample queries (already translated). Rendered as
+   *  click-to-send suggestions in the empty state so a fresh stack
+   *  chat matches the single-layout PageChatComposer experience. */
+  queries?: readonly string[];
   sessionRoleName?: string;
   sessionRoleIcon?: string;
   layoutMode: LayoutMode;

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -32,6 +32,7 @@
         <button
           v-for="(query, queryIdx) in queries"
           :key="`${queryIdx}-${query}`"
+          type="button"
           class="text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full px-4 py-2 border border-gray-300 transition-colors"
           data-testid="stack-empty-query"
           @click="sendTextMessage(query)"

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -22,22 +22,24 @@
     <!-- Empty state pulled out of the scroll container so `h-full` +
          the container's `pb-4` padding can't combine into a stray
          scrollbar. A sibling `flex-1` slot centers cleanly. -->
-    <div v-if="toolResults.length === 0" class="flex-1 flex items-center justify-center text-gray-400 text-sm" data-testid="stack-empty">
-      <!-- Mirror PageChatComposer's empty-state UX in single layout:
-           role.queries become clickable suggestions so a fresh stack
-           chat isn't a blank "no results yet" wall. -->
-      <div v-if="queries && queries.length > 0 && sendTextMessage" class="w-full max-w-2xl px-4 flex flex-col gap-1.5">
+    <!-- Mirror App.vue's single-layout empty state (role icon + name +
+         pill-shaped query suggestions) so switching canvas modes
+         doesn't change what a fresh chat looks like. -->
+    <div v-if="toolResults.length === 0" class="flex-1 flex flex-col items-center justify-center h-full px-6 text-center" data-testid="stack-empty">
+      <span v-if="sessionRoleIcon" class="material-icons text-5xl text-gray-400 mb-2" aria-hidden="true">{{ sessionRoleIcon }}</span>
+      <p v-if="sessionRoleName" class="text-lg font-medium text-gray-700 mb-4">{{ sessionRoleName }}</p>
+      <div v-if="queries && queries.length > 0 && sendTextMessage" class="flex flex-wrap gap-2 justify-center max-w-xl">
         <button
-          v-for="query in queries"
-          :key="query"
-          class="text-left text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded px-3 py-1.5 border border-gray-300 transition-colors"
+          v-for="(query, queryIdx) in queries"
+          :key="`${queryIdx}-${query}`"
+          class="text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full px-4 py-2 border border-gray-300 transition-colors"
           data-testid="stack-empty-query"
           @click="sendTextMessage(query)"
         >
           {{ query }}
         </button>
       </div>
-      <template v-else>{{ t("common.noResultsYet") }}</template>
+      <p v-else class="text-sm text-gray-500">{{ t("app.startConversation") }}</p>
     </div>
     <div v-else ref="containerRef" class="flex-1 min-h-0 overflow-y-auto px-4 pb-4 space-y-3" data-testid="stack-scroll">
       <div

--- a/test/components/test_stackview_empty_queries.ts
+++ b/test/components/test_stackview_empty_queries.ts
@@ -1,0 +1,62 @@
+// Regression check for #1538 — StackView's empty state must render
+// the role's sample queries as click-to-send pill buttons (mirroring
+// App.vue's single-layout empty state) and fall back to the
+// `app.startConversation` message when the role declares none.
+//
+// The repo doesn't have a Vue component unit-test runtime today; the
+// sibling googlemap-wiring test uses the same source-text assertion
+// pattern. A future refactor that drops any of the three branches
+// below will trip the assertion at unit-test time, ahead of the e2e
+// run that would otherwise catch it later.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function readSource(rel: string): string {
+  return readFileSync(path.join(REPO_ROOT, rel), "utf-8");
+}
+
+test("StackView declares `queries?: readonly string[]` prop", () => {
+  const src = readSource("src/components/StackView.vue");
+  assert.match(src, /queries\?:\s*readonly\s+string\[\]/, "StackView's defineProps must declare `queries?: readonly string[]`");
+});
+
+test("StackView empty state renders queries as click-to-send buttons (happy path)", () => {
+  const src = readSource("src/components/StackView.vue");
+  // Gate: queries non-empty AND a sender is wired.
+  assert.match(
+    src,
+    /queries\s*&&\s*queries\.length\s*>\s*0\s*&&\s*sendTextMessage/,
+    "Empty-state render must be gated on queries presence + sendTextMessage prop",
+  );
+  // Click handler dispatches to the prop directly so App.vue's
+  // sendMessage flows through the same path as ChatInput.
+  assert.match(src, /@click="sendTextMessage\(query\)"/, 'Each query button must @click="sendTextMessage(query)"');
+  // Defensive `type=\"button\"` so a future surrounding form can't
+  // accidentally turn these into submit triggers (Sourcery review).
+  assert.match(
+    src,
+    /data-testid="stack-empty-query"[\s\S]*?type="button"|type="button"[\s\S]*?data-testid="stack-empty-query"/,
+    'Query buttons must declare type="button"',
+  );
+});
+
+test("StackView empty state falls back to app.startConversation when queries are absent", () => {
+  const src = readSource("src/components/StackView.vue");
+  assert.match(src, /t\("app\.startConversation"\)/, "Empty-state fallback must reuse the existing `app.startConversation` i18n key");
+});
+
+test("App.vue threads sessionRoleQueries into StackView", () => {
+  const src = readSource("src/App.vue");
+  assert.match(
+    src,
+    /<StackView[\s\S]*?:queries="sessionRoleQueries"[\s\S]*?\/>/,
+    'App.vue\'s <StackView> mount must pass :queries="sessionRoleQueries" so the empty-state suggestions actually appear',
+  );
+});


### PR DESCRIPTION
## Summary

Stack layout の新規チャット画面で role の sample queries が表示されておらず（SuggestionsPanel に隠れていた）、「何を聞けばいいか分からない」状態になっていた。`<StackView>` の空状態を拡張して、queries が渡されていれば PageChatComposer (single layout) と同じ click-to-send ボタンで並べる。

## Items to Confirm / Review

- **UI トーン**: ボタンの見た目は `SuggestionsPanel` の suggestion ボタン (text-xs / bg-gray-100 / border-gray-300) と同一に揃えた。フォントサイズや密度がもっと中央寄せに堂々と見せたければ調整可。
- **Fallback**: queries が空 / `sendTextMessage` が未渡し の時は従来の "No results yet" メッセージが出る（後方互換）。
- **i18n**: 新規キー無し（queries は既に翻訳済み配列、fallback は既存 `common.noResultsYet`）。

## Implementation

1. `<StackView>` に `queries?: readonly string[]` prop 追加 (`src/components/StackView.vue`)。
2. 空状態の template に分岐追加: `queries && queries.length > 0 && sendTextMessage` で按ねボタン縦並び、click で `sendTextMessage(query)`。それ以外は既存メッセージ。
3. `App.vue` の `<StackView>` mount に `:queries=\"sessionRoleQueries\"` を追加。`sessionRoleQueries` は既に ChatInput 用に存在する computed なので追加コード無し。
4. Plan file: `plans/feat-stack-empty-queries-1538.md`。

## Test

- `yarn lint` clean
- `yarn typecheck:vue` clean
- `yarn build` clean
- `test/components/test_stackview_googlemap_wiring.ts` 3/3 pass (回帰なし)

新規 testid `stack-empty-query` を仕込んだので e2e 追加もしやすい。

Closes #1538.

## User Prompt

> sample query (=role.queries), canvas の stack view だと表示されないね
> A（StackView の空状態に queries を inline 表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Show role sample queries as clickable suggestions in the StackView empty state to align stack layout UX with the single-layout chat experience.

New Features:
- Display role sample queries as click-to-send buttons in the StackView empty state when queries are available.

Enhancements:
- Preserve the existing "No results yet" message as a fallback when no queries are provided or message sending is unavailable.

Chores:
- Add a planning document describing the StackView empty-state behavior change and its rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stack view empty state now displays clickable role-based sample query suggestions to quickly start or explore conversations when no results are present.
  * Suggestions are sourced from the active session role queries and trigger sending the selected query; when none are available, the view falls back to the standard "start conversation" message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->