### PR TITLE
feat(collections): add image field type

### DIFF
--- a/e2e/tests/collection-image-field.spec.ts
+++ b/e2e/tests/collection-image-field.spec.ts
@@ -1,0 +1,88 @@
+// E2E coverage for the `image` collection field type
+// (feat/collection-image-field). A field typed `image` holds a
+// workspace-relative path; the host renders it as an <img> — a
+// thumbnail in the list row and a larger image in the detail / open
+// view — via resolveImageSrc → the auth-exempt /api/files/raw route. A
+// record without the field falls back to the em-dash placeholder.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// 1x1 transparent PNG so the mocked /api/files/raw returns real image
+// bytes — the <img> gets natural dimensions (toBeVisible passes) and
+// the catch-all 501 noise is avoided.
+const TINY_PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", "base64");
+
+const CARD_PATH = "data/attachments/2026/05/3c7bdd20ec494f8f.jpg";
+// resolveImageSrc(CARD_PATH) → `/api/files/raw?path=<encoded>`: the
+// path is neither a data: URI nor under artifacts/images/, so it routes
+// through the workspace file server. No cache-bust token (the
+// non-Fresh variant), so this is an exact match.
+const EXPECTED_SRC = `/api/files/raw?path=${encodeURIComponent(CARD_PATH)}`;
+
+const CONTACTS_DETAIL = {
+  collection: {
+    slug: "contacts",
+    title: "Contacts",
+    icon: "contact_page",
+    source: "user",
+    schema: {
+      title: "Contacts",
+      icon: "contact_page",
+      dataPath: "data/contacts/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+        company: { type: "string", label: "Company" },
+        businessCard: { type: "image", label: "Business Card" },
+      },
+    },
+  },
+  items: [
+    { id: "michel-zgarka", name: "Michel Zgarka", company: "Sonic Origin", businessCard: CARD_PATH },
+    { id: "jane-doe", name: "Jane Doe", company: "Acme" },
+  ],
+};
+
+async function mockContacts(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/files/raw",
+    (route) => route.fulfill({ contentType: "image/png", body: TINY_PNG }),
+  );
+  await page.route(
+    (url) => url.pathname === "/api/collections/contacts",
+    (route) => route.fulfill({ json: CONTACTS_DETAIL }),
+  );
+}
+
+test.describe("collection image field", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockContacts(page);
+  });
+
+  test("list row renders an image-field value as a thumbnail", async ({ page }) => {
+    await page.goto("/collections/contacts");
+    const thumb = page.getByTestId("collections-cell-image-businessCard");
+    await expect(thumb).toBeVisible();
+    await expect(thumb).toHaveAttribute("src", EXPECTED_SRC);
+  });
+
+  test("detail view renders the image-field value as a larger image", async ({ page }) => {
+    await page.goto("/collections/contacts");
+    await page.getByTestId("collections-row-michel-zgarka").click();
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    const img = page.getByTestId("collections-detail-image-businessCard");
+    await expect(img).toBeVisible();
+    await expect(img).toHaveAttribute("src", EXPECTED_SRC);
+  });
+
+  test("a record without the image falls back to the em-dash placeholder", async ({ page }) => {
+    await page.goto("/collections/contacts");
+    await page.getByTestId("collections-row-jane-doe").click();
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    await expect(page.getByTestId("collections-detail-image-businessCard")).toHaveCount(0);
+    await expect(page.getByTestId("collections-detail-value-businessCard")).toContainText("—");
+  });
+});

--- a/e2e/tests/collection-image-field.spec.ts
+++ b/e2e/tests/collection-image-field.spec.ts
@@ -62,11 +62,14 @@ test.describe("collection image field", () => {
     await mockContacts(page);
   });
 
-  test("list row renders an image-field value as a thumbnail", async ({ page }) => {
+  test("list table omits the image column (no per-row thumbnail)", async ({ page }) => {
     await page.goto("/collections/contacts");
-    const thumb = page.getByTestId("collections-cell-image-businessCard");
-    await expect(thumb).toBeVisible();
-    await expect(thumb).toHaveAttribute("src", EXPECTED_SRC);
+    // The collection still renders...
+    await expect(page.getByTestId("collections-row-michel-zgarka")).toBeVisible();
+    // ...but the image field is neither a column header nor a per-row cell
+    // (excluded from listColumnFields — a per-row fetch is too expensive).
+    await expect(page.locator("thead th", { hasText: "Business Card" })).toHaveCount(0);
+    await expect(page.getByTestId("collections-cell-image-businessCard")).toHaveCount(0);
   });
 
   test("detail view renders the image-field value as a larger image", async ({ page }) => {

--- a/plans/feat-collection-image-field.md
+++ b/plans/feat-collection-image-field.md
@@ -1,0 +1,86 @@
+# feat: `image` field type for collections
+
+## Goal
+
+Let a collection store a workspace-relative image path in a field and render
+it as an actual `<img>` in the list table and the detail (open) view. The
+motivating flow: the user attaches a photo of a business card to chat, Claude
+reads the details off it (vision) and creates a `contacts` entry whose
+`cardImage` field holds the attachment path.
+
+## What already works (no change needed)
+
+Two of the three things this feature seemed to need are already in place:
+
+1. **The LLM already sees the attachment path.** When a file is attached, the
+   server prepends `[Attached file: <path>]` to the user message
+   (`server/api/routes/agent.ts:257` → `withAttachedFileMarker`). So Claude
+   can copy `data/attachments/YYYY/MM/<id>.jpg` straight into a field — it is
+   not limited to the base64 vision block.
+2. **Serving the image to an `<img>` is already auth-safe.** `/api/files/raw`
+   is bearer-exempt precisely so `<img src>` works without a token
+   (`server/api/auth/bearerAuth.ts:15`, `server/index.ts:238`). The
+   `resolveImageSrc()` helper (`src/utils/image/resolve.ts`) already turns a
+   workspace-relative path into the right URL.
+
+So the design we discussed — store the **original attachment path**, no copy,
+no delete-time cleanup (attachments already persist forever in
+`data/attachments/`) — needs only one new capability: a field type that
+renders a stored path as an image.
+
+## The one change: an `image` field type
+
+`image` behaves like a `string` for storage and editing (it holds a
+workspace-relative path), and gets special render treatment: an `<img>` via
+`resolveImageSrc()`.
+
+### Server
+
+- `server/workspace/collections/types.ts` — add `"image"` to
+  `CollectionFieldType`.
+- `server/workspace/collections/discovery.ts` — add `"image"` to the
+  **top-level** field-type zod enum (line ~106). Not added to the table
+  sub-field enum — images inside table rows are out of scope.
+
+### Frontend (`src/components/CollectionView.vue`)
+
+- Add `"image"` to the local `FieldType` union.
+- `import { resolveImageSrc } from "../utils/image/resolve"`.
+- **Detail view**: render `<img :src="resolveImageSrc(String(viewing[key]))">`
+  when `field.type === 'image'` and the value is a non-empty string; empty
+  falls through to the `—` fallback. Add `image` to the `col-span-full` list
+  so the card spans the row.
+- **List table**: render a small thumbnail for `image` cells; empty falls
+  through to `formatCell` → `—`.
+- **Edit form**: add `image` to the scalar-`<input>` list so the path is an
+  editable single-line text field (`inputTypeFor` already returns `text`,
+  `scalarDraftToValue` already returns the raw string).
+
+### LLM-facing docs
+
+- `server/workspace/helps/collection-skills.md` — add `image` to the field
+  types list + a bullet: stores a workspace-relative path (e.g. a
+  `data/attachments/...` upload), rendered as an `<img>` in the table and
+  detail view. This is what tells Claude the type exists when it authors a
+  collection.
+
+### Personal role sample query
+
+- `src/config/roles.ts` — add one English sample query to the Personal role
+  prompting creation of a contacts collection with a business-card image
+  field and the attach-and-extract flow. (English only per request; the
+  `queries` array is not part of the i18n locale schema.)
+
+## Out of scope / deferred
+
+- No image inside table rows.
+- No copy of the attachment into the collection dir, no delete-time cleanup
+  (decided: store the original path; attachments persist anyway).
+- No upload widget in the collection edit form — the field is a path string;
+  population happens via chat (Claude) or manual path entry.
+
+## Verification
+
+- `yarn format && yarn lint && yarn typecheck && yarn build`, `yarn test`.
+- Manual: define a collection with an `image` field, point it at an existing
+  `data/attachments/...` file, confirm it renders in both list and detail.

--- a/plans/feat-collection-image-field.md
+++ b/plans/feat-collection-image-field.md
@@ -50,8 +50,10 @@ workspace-relative path), and gets special render treatment: an `<img>` via
   when `field.type === 'image'` and the value is a non-empty string; empty
   falls through to the `—` fallback. Add `image` to the `col-span-full` list
   so the card spans the row.
-- **List table**: render a small thumbnail for `image` cells; empty falls
-  through to `formatCell` → `—`.
+- **List table**: `image` fields are excluded from the columns (via
+  `listColumnFields`, alongside `embed`). A per-row image fetch is too
+  expensive for a collection with many records, and the image is shown in the
+  detail view anyway.
 - **Edit form**: add `image` to the scalar-`<input>` list so the path is an
   editable single-line text field (`inputTypeFor` already returns `text`,
   `scalarDraftToValue` already returns the raw string).

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -103,7 +103,7 @@ const SubFieldSpecSchema = z
 
 const FieldSpecSchema = z
   .object({
-    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived", "embed"]),
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived", "embed", "image"]),
     label: z.string().min(1),
     primary: z.boolean().optional(),
     required: z.boolean().optional(),

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -24,7 +24,11 @@ export type CollectionFieldType =
   | "enum"
   | "table"
   | "derived"
-  | "embed";
+  | "embed"
+  // Holds a workspace-relative image path (e.g. a `data/attachments/...`
+  // upload); rendered as an <img> in the table + detail view. Stored and
+  // edited as a plain string.
+  | "image";
 
 export type CollectionSource = "user" | "project";
 

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -26,8 +26,9 @@ export type CollectionFieldType =
   | "derived"
   | "embed"
   // Holds a workspace-relative image path (e.g. a `data/attachments/...`
-  // upload); rendered as an <img> in the table + detail view. Stored and
-  // edited as a plain string.
+  // upload); rendered as an <img> in the detail view (not the list table —
+  // a per-row fetch is too expensive at scale). Stored and edited as a
+  // plain string.
   | "image";
 
 export type CollectionSource = "user" | "project";

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -102,7 +102,7 @@ skipped, never crashes the host):
 
 `string` · `text` (multi-line) · `email` · `number` · `date` (`YYYY-MM-DD`) ·
 `boolean` · `markdown` · `money` · `enum` · `ref` · `embed` · `table` ·
-`derived`
+`derived` · `image`
 
 Every field spec needs a `type` and a `label`. Extra keys by type:
 
@@ -127,6 +127,13 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
   `money` / `string` / `date`) and `currency`. **Read-only, host-computed** —
   you NEVER write derived values into the JSON; the host recomputes them on
   every render and the form refuses to persist them.
+- **`image`** — stores a **workspace-relative image path** as a plain string
+  (e.g. `data/attachments/2026/05/<id>.jpg` — the exact path from an
+  `[Attached file: ...]` marker when the user attaches a photo). The host
+  renders it as an `<img>` (thumbnail in the table, larger in the detail
+  view). No extra keys. Great for photos like a business card: read the
+  details off the attached image and write its path into the image field.
+  Write the bare workspace-relative path — never an `/api/files/raw?...` URL.
 
 ### Derived-formula syntax
 

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -130,8 +130,9 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
 - **`image`** — stores a **workspace-relative image path** as a plain string
   (e.g. `data/attachments/2026/05/<id>.jpg` — the exact path from an
   `[Attached file: ...]` marker when the user attaches a photo). The host
-  renders it as an `<img>` (thumbnail in the table, larger in the detail
-  view). No extra keys. Great for photos like a business card: read the
+  renders it as an `<img>` in the **detail view** (it is intentionally not a
+  list-table column — a per-row image fetch is too expensive for a large
+  collection). No extra keys. Great for photos like a business card: read the
   details off the attached image and write its path into the image field.
   Write the bare workspace-relative path — never an `/api/files/raw?...` URL.
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -179,6 +179,14 @@
                   >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
                 >
 
+                <img
+                  v-else-if="field.type === 'image' && typeof item[key] === 'string' && item[key]"
+                  :src="resolveImageSrc(String(item[key]))"
+                  :alt="field.label"
+                  class="max-h-10 max-w-16 object-contain rounded border border-slate-200 bg-white"
+                  :data-testid="`collections-cell-image-${key}`"
+                />
+
                 <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
               </td>
 
@@ -417,7 +425,7 @@
 
             <!-- Scalar inputs -->
             <input
-              v-else-if="['string', 'email', 'number', 'date', 'ref'].includes(field.type)"
+              v-else-if="['string', 'email', 'number', 'date', 'ref', 'image'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="inputTypeFor(field.type)"
@@ -535,7 +543,7 @@
               v-for="(field, key) in collection.schema.fields"
               :key="key"
               class="flex flex-col gap-1"
-              :class="['table', 'markdown', 'embed'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
+              :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
             >
               <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
 
@@ -623,6 +631,15 @@
                 <!-- Embed view -->
                 <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
 
+                <!-- Image (workspace-relative path → <img> via auth-exempt /api/files/raw) -->
+                <img
+                  v-else-if="field.type === 'image' && typeof viewing[key] === 'string' && viewing[key]"
+                  :src="resolveImageSrc(String(viewing[key]))"
+                  :alt="field.label"
+                  class="max-h-64 max-w-full object-contain rounded-lg border border-slate-200 bg-slate-50"
+                  :data-testid="`collections-detail-image-${key}`"
+                />
+
                 <!-- Fallback text styling -->
                 <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>
               </div>
@@ -650,8 +667,9 @@ import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { evaluateDerived, type FormulaContext } from "../utils/collections/derivedFormula";
 import { actionVisible } from "../utils/collections/actionVisible";
+import { resolveImageSrc } from "../utils/image/resolve";
 
-type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived" | "embed";
+type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived" | "embed" | "image";
 
 interface FieldSpec {
   type: FieldType;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -97,7 +97,7 @@
         <table class="min-w-full text-xs">
           <thead>
             <tr class="bg-slate-50 border-b border-slate-200">
-              <th v-for="[key, field] in nonEmbedFields" :key="key" class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider">
+              <th v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider">
                 {{ field.label }}
               </th>
               <th class="px-5 py-3 font-medium w-24"></th>
@@ -116,7 +116,7 @@
               @keydown.enter.self="openView(item)"
               @keydown.space.self.prevent="openView(item)"
             >
-              <td v-for="[key, field] in nonEmbedFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
+              <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
                 <!-- Boolean state badge -->
                 <span v-if="field.type === 'boolean'" class="block">
                   <span
@@ -178,14 +178,6 @@
                   class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
                   >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
                 >
-
-                <img
-                  v-else-if="field.type === 'image' && typeof item[key] === 'string' && item[key]"
-                  :src="resolveImageSrc(String(item[key]))"
-                  :alt="field.label"
-                  class="max-h-10 max-w-16 object-contain rounded border border-slate-200 bg-white"
-                  :data-testid="`collections-cell-image-${key}`"
-                />
 
                 <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
               </td>
@@ -1142,8 +1134,12 @@ const embedViews = computed<Record<string, EmbedView>>(() => {
  *  list table only (a whole embedded record doesn't fit a table cell,
  *  and it'd be identical in every row). The detail modal and the edit
  *  form iterate the full `schema.fields` so embeds render there too. */
-const nonEmbedFields = computed<[string, FieldSpec][]>(() =>
-  collection.value ? Object.entries(collection.value.schema.fields).filter(([, field]) => field.type !== "embed") : [],
+// Fields shown as columns in the list table. Excludes `embed`
+// (display-only fixed record, no per-record value) and `image` — a
+// per-row <img> fetches one file each, too expensive for a collection
+// with many records, and the image is shown in the detail view anyway.
+const listColumnFields = computed<[string, FieldSpec][]>(() =>
+  collection.value ? Object.entries(collection.value.schema.fields).filter(([, field]) => field.type !== "embed" && field.type !== "image") : [],
 );
 
 /** True when the current collection declares `schema.singleton` —

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -110,6 +110,7 @@ export const ROLES: Role[] = [
       "Where are the photos I took last weekend?",
       "Play some focus music on Spotify",
       "Remind me to call mom this evening",
+      "Create a contacts collection with name, company, title, email, phone, notes, and a business-card image. When I attach a photo of a business card, read the details off it and add a new contact.",
     ],
   },
   {

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -62,12 +62,14 @@ describe("discoverCollections — field-type support", () => {
         joined: { type: "date", label: "Joined" },
         active: { type: "boolean", label: "Active" },
         notes: { type: "markdown", label: "Notes" },
+        photo: { type: "image", label: "Photo" },
       },
     });
     const collections = await listCollections();
     assert.equal(collections.length, 1);
     assert.equal(collections[0]?.slug, "test-allfields");
     assert.equal(collections[0]?.schema.fields.active?.type, "boolean");
+    assert.equal(collections[0]?.schema.fields.photo?.type, "image");
   });
 
   it("accepts a schema using `ref` with a non-empty `to` (added in feat-collections-ref-field)", async () => {


### PR DESCRIPTION
## Summary

Adds an `image` collection field type. A field typed `image` stores a **workspace-relative path** and the host renders it as an `<img>` — a thumbnail in the list table and a larger image in the detail/open view — via `resolveImageSrc()` through the bearer-exempt `/api/files/raw` route. It is stored and edited as a plain string.

**Motivating flow:** attach a business-card photo to chat → Claude reads the card (vision) → creates a contacts entry whose image field holds the attachment path → the card renders in the collection view.

The two pieces this *seemed* to need turned out to already exist, so the field type is the only new capability:
- The LLM already receives the attachment path via the `[Attached file: <path>]` marker (`server/api/routes/agent.ts`).
- `/api/files/raw` is already bearer-exempt for `<img src>` use (`server/api/auth/bearerAuth.ts`).

Decided against copying the attachment into the collection dir / cleaning up on delete — chat attachments persist in `data/attachments/` regardless, so storing the original path is simplest. See `plans/feat-collection-image-field.md`.

## Changes
- **server**: `image` added to `CollectionFieldType` and the discovery zod enum (top-level fields; not table sub-fields).
- **frontend** (`CollectionView.vue`): renders the image in the list row + detail view; keeps it an editable path string in the form.
- **docs**: documents the `image` type in `collection-skills.md` so the agent uses it when authoring a collection.
- **roles**: a contacts/business-card sample query on the Personal role.
- **tests**: unit (discovery accepts `image`) + new e2e spec (list thumbnail, detail image, empty fallback).

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`
- [x] `yarn test` — unit suite green
- [x] `yarn test:e2e` — full suite (446) green, including 3 new specs in `collection-image-field.spec.ts`
- [x] Manual: agent authored a `contacts` collection with an `image` field and created a record with the attachment path verbatim; file confirmed present in workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for an `image` collection field type that stores a workspace-relative image path and renders it as an image in collection views.

New Features:
- Render `image`-typed collection fields as thumbnails in the list view and larger images in the detail view using workspace-relative paths.
- Allow `image` as a valid collection field type in server-side schemas and discovery so collections can store image paths.
- Expose the new `image` field type to the LLM via updated collection-skills documentation and a new Personal role sample query describing a contacts/business-card workflow.

Documentation:
- Document the `image` field type and its expected workspace-relative path usage in collection-skills documentation.

Tests:
- Add unit coverage ensuring collection discovery accepts the `image` field type and preserves it in schemas.
- Add end-to-end tests validating list and detail image rendering and fallback behavior when the image field is empty.

Chores:
- Add an internal design plan document describing the `image` collection field type and its scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an image field type for collections that shows full images in record detail views and is excluded from list/table columns.

* **Tests**
  * Added E2E coverage verifying list views do not render image columns/thumbnails and detail views render images or an em‑dash placeholder when absent.

* **Documentation**
  * Updated field docs and example query to describe image field usage and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->