### PR TITLE
feat(email-plugin): scaffold + self-healing config + stub handlers (#1542 PR 1)

### DIFF
--- a/packages/plugins/email-plugin/eslint.config.mjs
+++ b/packages/plugins/email-plugin/eslint.config.mjs
@@ -1,0 +1,18 @@
+// Plugin-author ESLint config — extends the gui-chat-protocol preset
+// to ban node:fs / node:path / console / direct fetch so any
+// platform bypass shows up at lint time. Tests under test/ are
+// allowed to use node:assert / node:test directly.
+
+import tseslint from "typescript-eslint";
+import pluginPreset from "gui-chat-protocol/eslint-preset";
+
+export default [
+  {
+    files: ["src/**/*.ts", "test/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+    },
+  },
+  ...pluginPreset.map((entry) => ({ ...entry, files: ["src/**/*.ts"] })),
+];

--- a/packages/plugins/email-plugin/package.json
+++ b/packages/plugins/email-plugin/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@mulmoclaude/email-plugin",
+  "version": "0.1.0",
+  "description": "Generic IMAP/SMTP email runtime plugin for MulmoClaude. Gmail-default provider presets; works with any IMAP/SMTP server (Fastmail / iCloud / Outlook / …). Uses App Password auth (no OAuth in v1).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test test/test_*.ts"
+  },
+  "peerDependencies": {
+    "gui-chat-protocol": "^0.3.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "tsx": "^4.22.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.13",
+    "vite-plugin-dts": "^5.0.0",
+    "zod": "^4.4.3"
+  },
+  "license": "MIT"
+}

--- a/packages/plugins/email-plugin/package.json
+++ b/packages/plugins/email-plugin/package.json
@@ -25,12 +25,19 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/mailparser": "^3.4.6",
     "@types/node": "^25.9.0",
+    "@types/nodemailer": "^8.0.0",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
     "vite-plugin-dts": "^5.0.0",
     "zod": "^4.4.3"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "imapflow": "^1.3.3",
+    "mailparser": "^3.9.8",
+    "nodemailer": "^8.0.9"
+  }
 }

--- a/packages/plugins/email-plugin/src/args.ts
+++ b/packages/plugins/email-plugin/src/args.ts
@@ -1,0 +1,52 @@
+// Zod input schema for the `manageEmail` tool. Discriminated union
+// keyed on `kind` so the dispatch in `index.ts` gets a narrowed
+// type per branch. Lives in its own module so unit tests can
+// import without spinning up the runtime.
+
+import { z } from "zod";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const ListArgs = z.object({
+  kind: z.literal("list"),
+  mailbox: z.string().min(1).default("INBOX"),
+  limit: z.number().int().min(1).max(200).default(20),
+});
+
+const ReadArgs = z.object({
+  kind: z.literal("read"),
+  mailbox: z.string().min(1).default("INBOX"),
+  uid: z.number().int().min(1),
+});
+
+const SearchArgs = z.object({
+  kind: z.literal("search"),
+  mailbox: z.string().min(1).default("INBOX"),
+  limit: z.number().int().min(1).max(200).default(20),
+  from: z.string().min(1).optional(),
+  subject_contains: z.string().min(1).optional(),
+  since: z.string().regex(ISO_DATE_RE).optional(),
+  before: z.string().regex(ISO_DATE_RE).optional(),
+  unread: z.boolean().optional(),
+});
+
+// `to` accepts a single RFC-5321-shaped address. v1 keeps it
+// single-recipient; multi-to / cc / bcc land in v2.
+const EMAIL_LOCAL = "[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*";
+const EMAIL_DOMAIN = "[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+";
+const EMAIL_RE = new RegExp(`^${EMAIL_LOCAL}@${EMAIL_DOMAIN}$`);
+
+const SendArgs = z.object({
+  kind: z.literal("send"),
+  to: z.string().regex(EMAIL_RE, "must be a valid email address"),
+  subject: z.string().min(1),
+  body: z.string(),
+  html: z.string().optional(),
+  // confirmed === true means the user has approved the
+  // confirmation form. The dispatch refuses to actually send
+  // without it (see send-gate doc in definition.ts).
+  confirmed: z.boolean().optional(),
+});
+
+export const Args = z.discriminatedUnion("kind", [ListArgs, ReadArgs, SearchArgs, SendArgs]);
+export type EmailArgs = z.infer<typeof Args>;

--- a/packages/plugins/email-plugin/src/config.ts
+++ b/packages/plugins/email-plugin/src/config.ts
@@ -1,0 +1,138 @@
+// Self-healing config: email + App Password, optional IMAP/SMTP
+// host+port overrides. Same pattern as edgar-plugin — the LLM
+// reads the `instructions` payload, asks the user, writes the
+// JSON file via its built-in Write tool, then retries.
+//
+// We resolve IMAP/SMTP server settings in this order:
+//   1. explicit `imap` / `smtp` block in the user's config.json
+//   2. provider preset table keyed on the email's domain
+//   3. otherwise → missing-config response that asks for the
+//      block to be added
+//
+// Storing credentials in plain JSON inside the workspace matches
+// existing plugin conventions (bookmarks / spotify / edgar). OS
+// keyring integration is a v2+ concern.
+
+import { homedir } from "node:os";
+import { z } from "zod";
+import type { PluginRuntime } from "gui-chat-protocol";
+
+import { providerPresetForEmail, type HostPort, type ProviderPreset } from "./providers";
+
+export const PKG_NAME = "@mulmoclaude/email-plugin";
+
+const CONFIG_FILE = "config.json";
+
+const HostPortSchema = z.object({
+  host: z.string().min(1),
+  port: z.number().int().min(1).max(65535),
+  secure: z.boolean(),
+});
+
+const ConfigFileSchema = z.object({
+  email: z.email(),
+  // App Password (Gmail = 16-char alphanumeric, others vary). Not
+  // tightly constrained — provider-specific shape varies and
+  // mistypes surface via the IMAP/SMTP server's AUTH response.
+  password: z.string().min(1),
+  imap: HostPortSchema.optional(),
+  smtp: HostPortSchema.optional(),
+});
+
+export type EmailConfigFile = z.infer<typeof ConfigFileSchema>;
+
+/** Fully-resolved config used by the IMAP / SMTP clients. */
+export interface ResolvedEmailConfig {
+  email: string;
+  password: string;
+  imap: HostPort;
+  smtp: HostPort;
+}
+
+/** Absolute path the plugin reads from / Claude must write to.
+ *  Forward slashes throughout for Windows compatibility — see
+ *  edgar-plugin/config.ts for the rationale. */
+export function configAbsolutePath(): string {
+  const seg = encodeURIComponent(PKG_NAME);
+  const home = homedir().replace(/\\/g, "/");
+  return `${home}/mulmoclaude/config/plugins/${seg}/${CONFIG_FILE}`;
+}
+
+/** Best-effort read of the raw config file. Returns null on any
+ *  parse / shape mismatch so the dispatch returns self-healing
+ *  instructions instead of throwing. */
+export async function readConfigFile(files: PluginRuntime["files"]): Promise<EmailConfigFile | null> {
+  try {
+    if (!(await files.config.exists(CONFIG_FILE))) return null;
+    const raw = await files.config.read(CONFIG_FILE);
+    const parsed = ConfigFileSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export type ConfigResolution = { kind: "ok"; config: ResolvedEmailConfig } | { kind: "missing" } | { kind: "server_unknown"; email: string };
+
+/** Promote the raw config to a fully-resolved one by filling in
+ *  IMAP/SMTP defaults from the provider preset table. */
+export function resolveConfig(raw: EmailConfigFile): ConfigResolution {
+  const preset: ProviderPreset | null = providerPresetForEmail(raw.email);
+  const imap = raw.imap ?? preset?.imap;
+  const smtp = raw.smtp ?? preset?.smtp;
+  if (!imap || !smtp) {
+    return { kind: "server_unknown", email: raw.email };
+  }
+  return {
+    kind: "ok",
+    config: { email: raw.email, password: raw.password, imap, smtp },
+  };
+}
+
+/** Combined read + resolve. */
+export async function loadConfig(files: PluginRuntime["files"]): Promise<ConfigResolution> {
+  const raw = await readConfigFile(files);
+  if (!raw) return { kind: "missing" };
+  return resolveConfig(raw);
+}
+
+/** Self-healing payload when config.json is absent or invalid. */
+export function missingConfigResponse(): { instructions: string } {
+  const path = configAbsolutePath();
+  const schema = {
+    email: "<user's email address>",
+    password: "<App Password (NOT the main account password)>",
+    "// imap (optional)": "Only needed if the provider isn't auto-detected; preset table covers gmail / fastmail / icloud / outlook.",
+    imap: { host: "imap.example.com", port: 993, secure: true },
+    smtp: { host: "smtp.example.com", port: 465, secure: true },
+  };
+  const prose =
+    "This plugin needs the user's email address and an APP PASSWORD (not the main account password). " +
+    "For Gmail: ask the user to enable 2FA and generate an App Password at https://myaccount.google.com/apppasswords. " +
+    "Other providers have a similar setting under security/account. " +
+    "Write the JSON file at the absolute path below, then retry the original tool call. " +
+    "The `imap` and `smtp` blocks are optional — leave them out if the user is on gmail.com / fastmail.com / icloud.com / outlook.com (auto-detected). " +
+    "**Never invent credentials.** Always ask the user.";
+  return {
+    instructions: `${prose}\n\nDetails (JSON):\n${JSON.stringify({ path, schema }, null, 2)}`,
+  };
+}
+
+/** Self-healing payload when the user's domain isn't in the
+ *  preset table and they haven't supplied explicit imap/smtp. */
+export function serverUnknownResponse(email: string): { instructions: string } {
+  const path = configAbsolutePath();
+  const example = {
+    email,
+    password: "<existing App Password>",
+    imap: { host: "imap.example.com", port: 993, secure: true },
+    smtp: { host: "smtp.example.com", port: 465, secure: true },
+  };
+  const prose =
+    `The domain in "${email}" isn't in the auto-detected preset list (gmail / fastmail / icloud / outlook). ` +
+    "Ask the user for their IMAP and SMTP server settings (host + port + whether TLS is on-connect or STARTTLS), " +
+    "then add an `imap` and `smtp` block to the existing config.json at the absolute path below, and retry.";
+  return {
+    instructions: `${prose}\n\nDetails (JSON):\n${JSON.stringify({ path, example }, null, 2)}`,
+  };
+}

--- a/packages/plugins/email-plugin/src/definition.ts
+++ b/packages/plugins/email-plugin/src/definition.ts
@@ -1,0 +1,58 @@
+// Tool schema for `manageEmail`. One tool, kind-discriminated.
+// The LLM picks `list` / `read` / `search` / `send`; dispatch in
+// `index.ts` validates args with Zod and routes.
+//
+// v1 surface only — label / archive / trash / draft / attachment
+// upload are deferred. See #1542 for the full roadmap.
+
+export const TOOL_DEFINITION = {
+  type: "function" as const,
+  name: "manageEmail" as const,
+  prompt:
+    "Configuration: this plugin needs the user's email address and an **App Password** (NOT their main account password). " +
+    "For Gmail, the user must enable 2FA, then generate an App Password at https://myaccount.google.com/apppasswords. " +
+    "For other providers (Fastmail, iCloud, Outlook) the App Password setting is in their security/account page. " +
+    "The plugin reads `~/mulmoclaude/config/plugins/%40mulmoclaude%2Femail-plugin/config.json` with shape " +
+    '`{"email":"<address>","password":"<app-password>","imap":{"host":..,"port":..,"secure":..}?,"smtp":{"host":..,"port":..,"secure":..}?}`. ' +
+    "If the file is missing the tool returns an `instructions` payload; ask the user, write the JSON file, then retry. " +
+    "**Never invent credentials**, never store the user's main account password. " +
+    "**Send is gated**: calling `kind:'send'` first returns a payload that asks the host to render a confirmation form — the actual SMTP send only happens after the user explicitly approves on a second `kind:'send'` call with `confirmed:true`.",
+  description:
+    "Read / search / send email via IMAP + SMTP. Generic — works with Gmail (default), Fastmail, iCloud, Outlook, or any IMAP/SMTP server. Supported kinds:\n" +
+    " - `list`: list recent messages from the inbox (subject, from, date, unread flag). Use `limit` to cap; default 20.\n" +
+    " - `read`: fetch the full body + headers + attachment metadata for one message by its IMAP UID.\n" +
+    " - `search`: IMAP SEARCH — filter by `from`, `subject_contains`, `since`, `before`, `unread`. Combine criteria.\n" +
+    " - `send`: SMTP send. ALWAYS requires a two-step confirm: first call returns a form for the user; second call (with the user-confirmed args + `confirmed:true`) actually sends.",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      kind: {
+        type: "string",
+        enum: ["list", "read", "search", "send"],
+        description: "Which email operation to perform.",
+      },
+      // list
+      mailbox: { type: "string", description: "For `list`/`search`: IMAP mailbox (default 'INBOX')." },
+      limit: { type: "integer", minimum: 1, maximum: 200, description: "For `list`/`search`: max messages (default 20)." },
+      // read
+      uid: { type: "integer", minimum: 1, description: "For `read`: IMAP UID of the message (from a prior `list` or `search` result)." },
+      // search
+      from: { type: "string", description: "For `search`: filter by sender address or display name (substring match)." },
+      subject_contains: { type: "string", description: "For `search`: filter by subject substring." },
+      since: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$", description: "For `search`: only messages on or after this ISO date." },
+      before: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$", description: "For `search`: only messages strictly before this ISO date." },
+      unread: { type: "boolean", description: "For `search`: only unread messages when true." },
+      // send
+      to: { type: "string", description: "For `send`: recipient address (single, v1)." },
+      subject: { type: "string", description: "For `send`: subject line." },
+      body: { type: "string", description: "For `send`: plain-text body." },
+      html: { type: "string", description: "For `send`: optional HTML body (used in addition to `body` as multipart/alternative)." },
+      confirmed: {
+        type: "boolean",
+        description:
+          "For `send`: MUST be `true` on the second call (after the user approves the confirmation form). Omit/false on first call to surface the form.",
+      },
+    },
+    required: ["kind"],
+  },
+};

--- a/packages/plugins/email-plugin/src/imap.ts
+++ b/packages/plugins/email-plugin/src/imap.ts
@@ -65,13 +65,22 @@ function makeClient(auth: ImapAuth): ImapFlow {
 // imapflow envelope addresses are `{name, address}`; render them
 // the way humans expect for the list view ("Alice <a@x.com>").
 function renderAddress(addrs: AddressObject | AddressObject[] | undefined): string {
-  if (!addrs) return "";
+  return addressList(addrs).join(", ");
+}
+
+// Structured per-address rendering. Returns one element per
+// address so a display name containing a comma (e.g.
+// `"Doe, John" <john@example.com>`) doesn't get sliced apart by
+// the caller — joining + splitting on `", "` is what the previous
+// version did and what Codex flagged. Build arrays from
+// `AddressObject.value[]` directly instead.
+export function addressList(addrs: AddressObject | AddressObject[] | undefined): string[] {
+  if (!addrs) return [];
   const arr = Array.isArray(addrs) ? addrs : [addrs];
   return arr
     .flatMap((a) => a.value)
     .map((v) => (v.name ? `${v.name} <${v.address ?? ""}>` : (v.address ?? "")))
-    .filter((s) => s.length > 0)
-    .join(", ");
+    .filter((s) => s.length > 0);
 }
 
 function renderEnvelopeAddress(arr: ReadonlyArray<{ name?: string | null; address?: string | null }> | null | undefined): string {
@@ -131,16 +140,8 @@ export async function readMessage(auth: ImapAuth, mailbox: string, uid: number):
         uid: Number(raw.uid),
         subject: parsed.subject ?? raw.envelope?.subject ?? "(no subject)",
         from: renderAddress(parsed.from),
-        to: parsed.to
-          ? renderAddress(parsed.to)
-              .split(", ")
-              .filter((s) => s.length > 0)
-          : [],
-        cc: parsed.cc
-          ? renderAddress(parsed.cc)
-              .split(", ")
-              .filter((s) => s.length > 0)
-          : [],
+        to: addressList(parsed.to),
+        cc: addressList(parsed.cc),
         date: parsed.date ? parsed.date.toISOString() : null,
         text: parsed.text ?? "",
         html: typeof parsed.html === "string" ? parsed.html : null,

--- a/packages/plugins/email-plugin/src/imap.ts
+++ b/packages/plugins/email-plugin/src/imap.ts
@@ -1,0 +1,198 @@
+// IMAP client wrapper. Uses imapflow for the protocol and
+// mailparser for MIME → structured body conversion.
+//
+// Connection lifecycle: each operation opens a fresh ImapFlow
+// connection, runs the command, then closes. For v1 this keeps
+// the implementation simple at the cost of a TLS handshake per
+// call. A pooled long-lived connection is a v2 optimisation —
+// Gmail's IMAP keepalive limits would matter once we add IDLE
+// for push notifications. See #1542.
+//
+// All public functions throw on network / auth errors; the
+// dispatcher in `index.ts` catches and converts to the
+// `instructions` payload shape so the LLM stays in the loop.
+
+import { ImapFlow, type FetchMessageObject } from "imapflow";
+import { simpleParser, type AddressObject, type ParsedMail } from "mailparser";
+
+import type { HostPort } from "./providers";
+
+export interface ImapAuth {
+  email: string;
+  password: string;
+  imap: HostPort;
+}
+
+export interface ListedMessage {
+  uid: number;
+  subject: string;
+  from: string;
+  date: string | null;
+  unread: boolean;
+  snippet: string;
+}
+
+export interface FullMessage {
+  uid: number;
+  subject: string;
+  from: string;
+  to: string[];
+  cc: string[];
+  date: string | null;
+  text: string;
+  html: string | null;
+  attachments: Array<{ filename: string; contentType: string; size: number }>;
+}
+
+export interface SearchCriteria {
+  from?: string;
+  subject_contains?: string;
+  since?: string; // ISO date
+  before?: string; // ISO date
+  unread?: boolean;
+}
+
+function makeClient(auth: ImapAuth): ImapFlow {
+  return new ImapFlow({
+    host: auth.imap.host,
+    port: auth.imap.port,
+    secure: auth.imap.secure,
+    auth: { user: auth.email, pass: auth.password },
+    logger: false,
+  });
+}
+
+// imapflow envelope addresses are `{name, address}`; render them
+// the way humans expect for the list view ("Alice <a@x.com>").
+function renderAddress(addrs: AddressObject | AddressObject[] | undefined): string {
+  if (!addrs) return "";
+  const arr = Array.isArray(addrs) ? addrs : [addrs];
+  return arr
+    .flatMap((a) => a.value)
+    .map((v) => (v.name ? `${v.name} <${v.address ?? ""}>` : (v.address ?? "")))
+    .filter((s) => s.length > 0)
+    .join(", ");
+}
+
+function renderEnvelopeAddress(arr: ReadonlyArray<{ name?: string | null; address?: string | null }> | null | undefined): string {
+  if (!arr || arr.length === 0) return "";
+  return arr
+    .map((v) => (v.name ? `${v.name} <${v.address ?? ""}>` : (v.address ?? "")))
+    .filter((s) => s.length > 0)
+    .join(", ");
+}
+
+function envelopeToSummary(msg: FetchMessageObject): ListedMessage {
+  return {
+    uid: Number(msg.uid),
+    subject: msg.envelope?.subject ?? "(no subject)",
+    from: renderEnvelopeAddress(msg.envelope?.from),
+    date: msg.envelope?.date ? msg.envelope.date.toISOString() : null,
+    unread: !msg.flags?.has("\\Seen"),
+    snippet: "",
+  };
+}
+
+/** List the N newest messages in a mailbox (newest first). */
+export async function listMessages(auth: ImapAuth, mailbox: string, limit: number): Promise<ListedMessage[]> {
+  const client = makeClient(auth);
+  await client.connect();
+  try {
+    const lock = await client.getMailboxLock(mailbox);
+    try {
+      const total = (client.mailbox && typeof client.mailbox !== "boolean" ? client.mailbox.exists : 0) ?? 0;
+      if (total === 0) return [];
+      const startSeq = Math.max(1, total - limit + 1);
+      const out: ListedMessage[] = [];
+      for await (const msg of client.fetch(`${startSeq}:*`, { uid: true, envelope: true, flags: true })) {
+        out.push(envelopeToSummary(msg));
+      }
+      // imapflow returns sequence-ascending; reverse so newest is first.
+      return out.reverse();
+    } finally {
+      lock.release();
+    }
+  } finally {
+    await client.logout();
+  }
+}
+
+/** Fetch the full body (text/html/attachments) for one message. */
+export async function readMessage(auth: ImapAuth, mailbox: string, uid: number): Promise<FullMessage> {
+  const client = makeClient(auth);
+  await client.connect();
+  try {
+    const lock = await client.getMailboxLock(mailbox);
+    try {
+      const raw = await client.fetchOne(String(uid), { uid: true, envelope: true, source: true }, { uid: true });
+      if (!raw || !raw.source) throw new Error(`uid ${uid} not found in ${mailbox}`);
+      const parsed: ParsedMail = await simpleParser(raw.source);
+      return {
+        uid: Number(raw.uid),
+        subject: parsed.subject ?? raw.envelope?.subject ?? "(no subject)",
+        from: renderAddress(parsed.from),
+        to: parsed.to
+          ? renderAddress(parsed.to)
+              .split(", ")
+              .filter((s) => s.length > 0)
+          : [],
+        cc: parsed.cc
+          ? renderAddress(parsed.cc)
+              .split(", ")
+              .filter((s) => s.length > 0)
+          : [],
+        date: parsed.date ? parsed.date.toISOString() : null,
+        text: parsed.text ?? "",
+        html: typeof parsed.html === "string" ? parsed.html : null,
+        attachments: (parsed.attachments ?? []).map((a) => ({
+          filename: a.filename ?? "(unnamed)",
+          contentType: a.contentType ?? "application/octet-stream",
+          size: a.size ?? 0,
+        })),
+      };
+    } finally {
+      lock.release();
+    }
+  } finally {
+    await client.logout();
+  }
+}
+
+/** Build an IMAP SEARCH query from our criteria. Each field is a
+ *  conjunction (AND); empty criteria → "ALL" (no filter). */
+function buildSearchQuery(criteria: SearchCriteria): Record<string, unknown> {
+  const query: Record<string, unknown> = {};
+  if (criteria.from) query.from = criteria.from;
+  if (criteria.subject_contains) query.subject = criteria.subject_contains;
+  if (criteria.since) query.since = new Date(criteria.since);
+  if (criteria.before) query.before = new Date(criteria.before);
+  if (criteria.unread === true) query.unseen = true;
+  if (criteria.unread === false) query.seen = true;
+  return query;
+}
+
+/** IMAP SEARCH + envelope FETCH. Returns newest first, capped by limit. */
+export async function searchMessages(auth: ImapAuth, mailbox: string, criteria: SearchCriteria, limit: number): Promise<ListedMessage[]> {
+  const client = makeClient(auth);
+  await client.connect();
+  try {
+    const lock = await client.getMailboxLock(mailbox);
+    try {
+      const query = buildSearchQuery(criteria);
+      const uids = (await client.search(query, { uid: true })) || [];
+      if (uids.length === 0) return [];
+      // Newest first — UIDs are monotonically assigned, so a
+      // descending sort matches arrival order well enough for v1.
+      const ordered = [...uids].sort((a, b) => Number(b) - Number(a)).slice(0, limit);
+      const out: ListedMessage[] = [];
+      for await (const msg of client.fetch(ordered.join(","), { uid: true, envelope: true, flags: true }, { uid: true })) {
+        out.push(envelopeToSummary(msg));
+      }
+      return out.sort((a, b) => b.uid - a.uid);
+    } finally {
+      lock.release();
+    }
+  } finally {
+    await client.logout();
+  }
+}

--- a/packages/plugins/email-plugin/src/index.ts
+++ b/packages/plugins/email-plugin/src/index.ts
@@ -1,0 +1,132 @@
+// Email plugin — server-side runtime plugin (v1 scaffold, #1542).
+//
+// One tool (`manageEmail`), four kinds (`list` / `read` / `search`
+// / `send`). v1 scaffold returns stub responses for the I/O kinds
+// so the configuration flow can be exercised end-to-end; real
+// IMAP/SMTP wiring lands in PR 2 (list/read/search) and PR 3
+// (send with the human-confirmation gate). See #1542.
+//
+// Send-gate contract: the first `kind:'send'` call (with no
+// `confirmed:true`) returns a structured payload that the host
+// renders as a presentForm confirmation. The LLM then re-calls
+// with `confirmed:true` only after the user has approved the
+// form. The dispatch refuses to send without `confirmed:true`.
+
+import { definePlugin } from "gui-chat-protocol";
+
+import { TOOL_DEFINITION } from "./definition";
+import { Args, type EmailArgs } from "./args";
+import { loadConfig, missingConfigResponse, serverUnknownResponse, type ResolvedEmailConfig } from "./config";
+
+export { TOOL_DEFINITION };
+
+// v1 scaffold — every I/O handler is a stub that proves the
+// dispatch reaches it. PR 2 / PR 3 swap these for real imapflow
+// + nodemailer calls. Each returns a JSON-serialisable shape so
+// the MCP bridge can stringify it into `message` for the LLM.
+
+interface StubResponse {
+  ok: true;
+  stub: string;
+  kind: string;
+  echoed_args: Record<string, unknown>;
+}
+
+function stub(kind: string, args: Record<string, unknown>): StubResponse {
+  return {
+    ok: true,
+    stub: "email-plugin v1 scaffold — IMAP/SMTP wiring lands in PR 2/3 (#1542). Args echoed for end-to-end testing.",
+    kind,
+    echoed_args: args,
+  };
+}
+
+function handleList(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "list" }>): StubResponse {
+  return stub("list", { mailbox: args.mailbox, limit: args.limit });
+}
+
+function handleRead(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "read" }>): StubResponse {
+  return stub("read", { mailbox: args.mailbox, uid: args.uid });
+}
+
+function handleSearch(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "search" }>): StubResponse {
+  return stub("search", {
+    mailbox: args.mailbox,
+    limit: args.limit,
+    from: args.from,
+    subject_contains: args.subject_contains,
+    since: args.since,
+    before: args.before,
+    unread: args.unread,
+  });
+}
+
+// Send is special: returns a confirmation envelope (NOT a stub
+// send result) when `confirmed !== true`. The host renders this
+// as a presentForm; the user approves; the LLM re-calls with
+// `confirmed:true`.
+interface SendConfirmRequest {
+  needs_confirmation: true;
+  message: string;
+  draft: { to: string; subject: string; body: string; html?: string };
+  retry_with: { kind: "send"; to: string; subject: string; body: string; html?: string; confirmed: true };
+}
+
+function buildSendConfirmation(args: Extract<EmailArgs, { kind: "send" }>): SendConfirmRequest {
+  return {
+    needs_confirmation: true,
+    message:
+      "About to send email. Show the user the draft below and ask them to confirm. " +
+      "Only call `manageEmail` again with `confirmed:true` after the user explicitly approves.",
+    draft: { to: args.to, subject: args.subject, body: args.body, ...(args.html ? { html: args.html } : {}) },
+    retry_with: { kind: "send", to: args.to, subject: args.subject, body: args.body, ...(args.html ? { html: args.html } : {}), confirmed: true },
+  };
+}
+
+function handleSend(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "send" }>): StubResponse | SendConfirmRequest {
+  if (args.confirmed !== true) return buildSendConfirmation(args);
+  return stub("send", { to: args.to, subject: args.subject });
+}
+
+type Handled = StubResponse | SendConfirmRequest;
+
+function dispatch(cfg: ResolvedEmailConfig, args: EmailArgs): Handled {
+  switch (args.kind) {
+    case "list":
+      return handleList(cfg, args);
+    case "read":
+      return handleRead(cfg, args);
+    case "search":
+      return handleSearch(cfg, args);
+    case "send":
+      return handleSend(cfg, args);
+    default: {
+      const exhaustive: never = args;
+      throw new Error(`unknown manageEmail kind: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+export default definePlugin(({ files }) => {
+  return {
+    TOOL_DEFINITION,
+
+    async manageEmail(rawArgs: unknown) {
+      const resolution = await loadConfig(files);
+      if (resolution.kind === "missing") return missingConfigResponse();
+      if (resolution.kind === "server_unknown") return serverUnknownResponse(resolution.email);
+
+      const parsed = Args.safeParse(rawArgs);
+      if (!parsed.success) {
+        return { instructions: `Invalid manageEmail arguments: ${parsed.error.issues.map((issue) => issue.message).join("; ")}` };
+      }
+
+      try {
+        const result = dispatch(resolution.config, parsed.data);
+        return { message: JSON.stringify(result) };
+      } catch (err) {
+        return { instructions: `manageEmail call failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    },
+  };
+});

--- a/packages/plugins/email-plugin/src/index.ts
+++ b/packages/plugins/email-plugin/src/index.ts
@@ -1,70 +1,25 @@
-// Email plugin — server-side runtime plugin (v1 scaffold, #1542).
+// Email plugin — server-side runtime plugin (#1542).
 //
 // One tool (`manageEmail`), four kinds (`list` / `read` / `search`
-// / `send`). v1 scaffold returns stub responses for the I/O kinds
-// so the configuration flow can be exercised end-to-end; real
-// IMAP/SMTP wiring lands in PR 2 (list/read/search) and PR 3
-// (send with the human-confirmation gate). See #1542.
+// / `send`). v1 ships real IMAP via `imapflow` + `mailparser` and
+// SMTP via `nodemailer`. Auth is App Password (no OAuth in v1).
 //
 // Send-gate contract: the first `kind:'send'` call (with no
-// `confirmed:true`) returns a structured payload that the host
-// renders as a presentForm confirmation. The LLM then re-calls
-// with `confirmed:true` only after the user has approved the
-// form. The dispatch refuses to send without `confirmed:true`.
+// `confirmed:true`) returns a structured payload telling the LLM
+// to show the draft to the user via presentForm and only re-call
+// with `confirmed:true` after the user explicitly approves. The
+// dispatch refuses to actually call SMTP without `confirmed:true`.
 
 import { definePlugin } from "gui-chat-protocol";
 
 import { TOOL_DEFINITION } from "./definition";
 import { Args, type EmailArgs } from "./args";
 import { loadConfig, missingConfigResponse, serverUnknownResponse, type ResolvedEmailConfig } from "./config";
+import { listMessages, readMessage, searchMessages } from "./imap";
+import { sendMail } from "./smtp";
 
 export { TOOL_DEFINITION };
 
-// v1 scaffold — every I/O handler is a stub that proves the
-// dispatch reaches it. PR 2 / PR 3 swap these for real imapflow
-// + nodemailer calls. Each returns a JSON-serialisable shape so
-// the MCP bridge can stringify it into `message` for the LLM.
-
-interface StubResponse {
-  ok: true;
-  stub: string;
-  kind: string;
-  echoed_args: Record<string, unknown>;
-}
-
-function stub(kind: string, args: Record<string, unknown>): StubResponse {
-  return {
-    ok: true,
-    stub: "email-plugin v1 scaffold — IMAP/SMTP wiring lands in PR 2/3 (#1542). Args echoed for end-to-end testing.",
-    kind,
-    echoed_args: args,
-  };
-}
-
-function handleList(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "list" }>): StubResponse {
-  return stub("list", { mailbox: args.mailbox, limit: args.limit });
-}
-
-function handleRead(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "read" }>): StubResponse {
-  return stub("read", { mailbox: args.mailbox, uid: args.uid });
-}
-
-function handleSearch(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "search" }>): StubResponse {
-  return stub("search", {
-    mailbox: args.mailbox,
-    limit: args.limit,
-    from: args.from,
-    subject_contains: args.subject_contains,
-    since: args.since,
-    before: args.before,
-    unread: args.unread,
-  });
-}
-
-// Send is special: returns a confirmation envelope (NOT a stub
-// send result) when `confirmed !== true`. The host renders this
-// as a presentForm; the user approves; the LLM re-calls with
-// `confirmed:true`.
 interface SendConfirmRequest {
   needs_confirmation: true;
   message: string;
@@ -76,21 +31,36 @@ function buildSendConfirmation(args: Extract<EmailArgs, { kind: "send" }>): Send
   return {
     needs_confirmation: true,
     message:
-      "About to send email. Show the user the draft below and ask them to confirm. " +
-      "Only call `manageEmail` again with `confirmed:true` after the user explicitly approves.",
+      "About to send email. Call `presentForm` to show the user the draft (to / subject / body) and ask them to confirm. " +
+      "Only re-call `manageEmail` with `confirmed:true` after the user explicitly approves.",
     draft: { to: args.to, subject: args.subject, body: args.body, ...(args.html ? { html: args.html } : {}) },
     retry_with: { kind: "send", to: args.to, subject: args.subject, body: args.body, ...(args.html ? { html: args.html } : {}), confirmed: true },
   };
 }
 
-function handleSend(_cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "send" }>): StubResponse | SendConfirmRequest {
-  if (args.confirmed !== true) return buildSendConfirmation(args);
-  return stub("send", { to: args.to, subject: args.subject });
+async function handleList(cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "list" }>): Promise<unknown> {
+  return await listMessages({ email: cfg.email, password: cfg.password, imap: cfg.imap }, args.mailbox, args.limit);
 }
 
-type Handled = StubResponse | SendConfirmRequest;
+async function handleRead(cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "read" }>): Promise<unknown> {
+  return await readMessage({ email: cfg.email, password: cfg.password, imap: cfg.imap }, args.mailbox, args.uid);
+}
 
-function dispatch(cfg: ResolvedEmailConfig, args: EmailArgs): Handled {
+async function handleSearch(cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "search" }>): Promise<unknown> {
+  return await searchMessages(
+    { email: cfg.email, password: cfg.password, imap: cfg.imap },
+    args.mailbox,
+    { from: args.from, subject_contains: args.subject_contains, since: args.since, before: args.before, unread: args.unread },
+    args.limit,
+  );
+}
+
+async function handleSend(cfg: ResolvedEmailConfig, args: Extract<EmailArgs, { kind: "send" }>): Promise<unknown> {
+  if (args.confirmed !== true) return buildSendConfirmation(args);
+  return await sendMail({ email: cfg.email, password: cfg.password, smtp: cfg.smtp }, args);
+}
+
+async function dispatch(cfg: ResolvedEmailConfig, args: EmailArgs): Promise<unknown> {
   switch (args.kind) {
     case "list":
       return handleList(cfg, args);
@@ -122,7 +92,7 @@ export default definePlugin(({ files }) => {
       }
 
       try {
-        const result = dispatch(resolution.config, parsed.data);
+        const result = await dispatch(resolution.config, parsed.data);
         return { message: JSON.stringify(result) };
       } catch (err) {
         return { instructions: `manageEmail call failed: ${err instanceof Error ? err.message : String(err)}` };

--- a/packages/plugins/email-plugin/src/providers.ts
+++ b/packages/plugins/email-plugin/src/providers.ts
@@ -1,0 +1,62 @@
+// Provider preset table — derive IMAP / SMTP host+port from the
+// user's email domain so they don't have to look up the server
+// settings for common providers. The user can override either
+// section in their config.json if their setup differs.
+
+export interface HostPort {
+  host: string;
+  port: number;
+  /** TLS-on-connect (993 IMAP / 465 SMTP) when true; STARTTLS upgrade (143 / 587) when false. */
+  secure: boolean;
+}
+
+export interface ProviderPreset {
+  imap: HostPort;
+  smtp: HostPort;
+}
+
+// Lowercased domain → preset. Keep entries to providers the
+// MulmoClaude users actually use; we'd rather return a
+// `config_required` for unknown domains than guess wrong and
+// silently send mail through the wrong server.
+const PRESETS: Record<string, ProviderPreset> = {
+  "gmail.com": {
+    imap: { host: "imap.gmail.com", port: 993, secure: true },
+    smtp: { host: "smtp.gmail.com", port: 465, secure: true },
+  },
+  "googlemail.com": {
+    imap: { host: "imap.gmail.com", port: 993, secure: true },
+    smtp: { host: "smtp.gmail.com", port: 465, secure: true },
+  },
+  "fastmail.com": {
+    imap: { host: "imap.fastmail.com", port: 993, secure: true },
+    smtp: { host: "smtp.fastmail.com", port: 465, secure: true },
+  },
+  "icloud.com": {
+    imap: { host: "imap.mail.me.com", port: 993, secure: true },
+    smtp: { host: "smtp.mail.me.com", port: 587, secure: false },
+  },
+  "me.com": {
+    imap: { host: "imap.mail.me.com", port: 993, secure: true },
+    smtp: { host: "smtp.mail.me.com", port: 587, secure: false },
+  },
+  "outlook.com": {
+    imap: { host: "outlook.office365.com", port: 993, secure: true },
+    smtp: { host: "smtp.office365.com", port: 587, secure: false },
+  },
+  "hotmail.com": {
+    imap: { host: "outlook.office365.com", port: 993, secure: true },
+    smtp: { host: "smtp.office365.com", port: 587, secure: false },
+  },
+};
+
+/** Lookup preset by the user's email domain. Returns null when
+ *  the domain isn't in the table — the caller should fall back to
+ *  reading the user-supplied `imap` / `smtp` blocks from config,
+ *  and emit `config_required` if those are also missing. */
+export function providerPresetForEmail(email: string): ProviderPreset | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return null;
+  const domain = email.slice(at + 1).toLowerCase();
+  return PRESETS[domain] ?? null;
+}

--- a/packages/plugins/email-plugin/src/smtp.ts
+++ b/packages/plugins/email-plugin/src/smtp.ts
@@ -1,0 +1,52 @@
+// SMTP send wrapper. nodemailer handles the transport (AUTH PLAIN
+// for App Password, STARTTLS or TLS-on-connect depending on the
+// resolved port). One transporter per call for v1 to match the
+// IMAP side; pooling is a v2 optimisation.
+
+import nodemailer from "nodemailer";
+
+import type { HostPort } from "./providers";
+
+export interface SmtpAuth {
+  email: string;
+  password: string;
+  smtp: HostPort;
+}
+
+export interface SendDraft {
+  to: string;
+  subject: string;
+  body: string;
+  html?: string;
+}
+
+export interface SendResult {
+  messageId: string;
+  accepted: string[];
+  rejected: string[];
+}
+
+export async function sendMail(auth: SmtpAuth, draft: SendDraft): Promise<SendResult> {
+  const transporter = nodemailer.createTransport({
+    host: auth.smtp.host,
+    port: auth.smtp.port,
+    secure: auth.smtp.secure,
+    auth: { user: auth.email, pass: auth.password },
+  });
+  try {
+    const info = await transporter.sendMail({
+      from: auth.email,
+      to: draft.to,
+      subject: draft.subject,
+      text: draft.body,
+      ...(draft.html ? { html: draft.html } : {}),
+    });
+    return {
+      messageId: info.messageId,
+      accepted: (info.accepted ?? []).map((a) => (typeof a === "string" ? a : (a.address ?? ""))).filter((s) => s.length > 0),
+      rejected: (info.rejected ?? []).map((a) => (typeof a === "string" ? a : (a.address ?? ""))).filter((s) => s.length > 0),
+    };
+  } finally {
+    transporter.close();
+  }
+}

--- a/packages/plugins/email-plugin/src/smtp.ts
+++ b/packages/plugins/email-plugin/src/smtp.ts
@@ -41,11 +41,19 @@ export async function sendMail(auth: SmtpAuth, draft: SendDraft): Promise<SendRe
       text: draft.body,
       ...(draft.html ? { html: draft.html } : {}),
     });
-    return {
-      messageId: info.messageId,
-      accepted: (info.accepted ?? []).map((a) => (typeof a === "string" ? a : (a.address ?? ""))).filter((s) => s.length > 0),
-      rejected: (info.rejected ?? []).map((a) => (typeof a === "string" ? a : (a.address ?? ""))).filter((s) => s.length > 0),
-    };
+    const accepted = (info.accepted ?? []).map((a) => (typeof a === "string" ? a : (a.address ?? ""))).filter((s) => s.length > 0);
+    const rejected = (info.rejected ?? []).map((a) => (typeof a === "string" ? a : (a.address ?? ""))).filter((s) => s.length > 0);
+    // nodemailer resolves successfully when the SMTP handshake +
+    // DATA upload succeed, even if the server rejected every
+    // recipient (RCPT TO 550). Treat zero-accepted as a hard
+    // failure so the dispatcher surfaces it to the LLM as an
+    // error instead of a false-positive "sent!". Codex review
+    // caught this.
+    if (accepted.length === 0) {
+      const detail = rejected.length > 0 ? `rejected recipients: ${rejected.join(", ")}` : "no recipients accepted";
+      throw new Error(`SMTP send rejected all recipients — ${detail}`);
+    }
+    return { messageId: info.messageId, accepted, rejected };
   } finally {
     transporter.close();
   }

--- a/packages/plugins/email-plugin/test/test_args_validation.ts
+++ b/packages/plugins/email-plugin/test/test_args_validation.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Args } from "../src/args";
+
+describe("manageEmail Args", () => {
+  it("accepts a minimal list call with defaults", () => {
+    const parsed = Args.safeParse({ kind: "list" });
+    assert.equal(parsed.success, true);
+    if (parsed.success && parsed.data.kind === "list") {
+      assert.equal(parsed.data.mailbox, "INBOX");
+      assert.equal(parsed.data.limit, 20);
+    }
+  });
+
+  it("rejects out-of-range list limits", () => {
+    assert.equal(Args.safeParse({ kind: "list", limit: 0 }).success, false);
+    assert.equal(Args.safeParse({ kind: "list", limit: 201 }).success, false);
+  });
+
+  it("read requires a numeric UID", () => {
+    assert.equal(Args.safeParse({ kind: "read" }).success, false);
+    assert.equal(Args.safeParse({ kind: "read", uid: 42 }).success, true);
+  });
+
+  it("search rejects malformed ISO dates", () => {
+    assert.equal(Args.safeParse({ kind: "search", since: "2026/01/02" }).success, false);
+    assert.equal(Args.safeParse({ kind: "search", since: "2026-01-02" }).success, true);
+  });
+
+  it("send requires a recipient that looks like an email address", () => {
+    const bad = Args.safeParse({ kind: "send", to: "not-an-email", subject: "hi", body: "x" });
+    assert.equal(bad.success, false);
+    const good = Args.safeParse({ kind: "send", to: "alice@example.com", subject: "hi", body: "x" });
+    assert.equal(good.success, true);
+  });
+
+  it("send rejects empty subject", () => {
+    assert.equal(Args.safeParse({ kind: "send", to: "a@b.com", subject: "", body: "x" }).success, false);
+  });
+
+  it("unknown kind is rejected (closed discriminated union)", () => {
+    assert.equal(Args.safeParse({ kind: "delete" }).success, false);
+  });
+});

--- a/packages/plugins/email-plugin/test/test_config.ts
+++ b/packages/plugins/email-plugin/test/test_config.ts
@@ -1,0 +1,69 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { configAbsolutePath, missingConfigResponse, resolveConfig, serverUnknownResponse } from "../src/config";
+
+describe("configAbsolutePath", () => {
+  it("encodes the package scope so it sits under config/plugins/", () => {
+    const path = configAbsolutePath();
+    assert.ok(path.endsWith("/mulmoclaude/config/plugins/%40mulmoclaude%2Femail-plugin/config.json"), path);
+    assert.ok(!path.includes("\\"), "must use forward slashes for Windows compatibility");
+  });
+});
+
+describe("resolveConfig", () => {
+  it("ok branch fills both imap+smtp from the Gmail preset when not user-overridden", () => {
+    const res = resolveConfig({ email: "a@gmail.com", password: "abcd-efgh-ijkl-mnop" });
+    assert.equal(res.kind, "ok");
+    if (res.kind === "ok") {
+      assert.equal(res.config.imap.host, "imap.gmail.com");
+      assert.equal(res.config.smtp.host, "smtp.gmail.com");
+    }
+  });
+
+  it("user-supplied imap overrides the preset", () => {
+    const res = resolveConfig({
+      email: "a@gmail.com",
+      password: "x",
+      imap: { host: "imap.custom.example", port: 1993, secure: true },
+    });
+    assert.equal(res.kind, "ok");
+    if (res.kind === "ok") {
+      assert.equal(res.config.imap.host, "imap.custom.example");
+      assert.equal(res.config.imap.port, 1993);
+      // smtp still comes from the gmail preset
+      assert.equal(res.config.smtp.host, "smtp.gmail.com");
+    }
+  });
+
+  it("unknown domain without explicit imap/smtp returns server_unknown", () => {
+    const res = resolveConfig({ email: "a@self-hosted.local", password: "x" });
+    assert.equal(res.kind, "server_unknown");
+    if (res.kind === "server_unknown") assert.equal(res.email, "a@self-hosted.local");
+  });
+
+  it("unknown domain WITH explicit imap+smtp succeeds", () => {
+    const res = resolveConfig({
+      email: "a@self-hosted.local",
+      password: "x",
+      imap: { host: "mail.self-hosted.local", port: 993, secure: true },
+      smtp: { host: "mail.self-hosted.local", port: 465, secure: true },
+    });
+    assert.equal(res.kind, "ok");
+  });
+});
+
+describe("self-healing response shapes", () => {
+  it("missingConfigResponse embeds path + JSON schema in instructions", () => {
+    const res = missingConfigResponse();
+    assert.ok(res.instructions.includes("config.json"));
+    assert.ok(res.instructions.includes("password"));
+    assert.ok(res.instructions.includes("App Password"));
+  });
+
+  it("serverUnknownResponse quotes the offending email in instructions", () => {
+    const res = serverUnknownResponse("a@self-hosted.local");
+    assert.ok(res.instructions.includes("a@self-hosted.local"));
+    assert.ok(res.instructions.includes("imap"));
+    assert.ok(res.instructions.includes("smtp"));
+  });
+});

--- a/packages/plugins/email-plugin/test/test_imap_helpers.ts
+++ b/packages/plugins/email-plugin/test/test_imap_helpers.ts
@@ -1,0 +1,49 @@
+// Regression tests for the per-address rendering helper. Codex
+// review flagged that the previous version joined `to`/`cc` into
+// a comma-separated string and then split it back — display names
+// containing commas like `"Doe, John" <john@example.com>` would
+// be sliced apart. `addressList` now builds arrays straight from
+// the structured `AddressObject.value[]` so a comma in the name
+// stays inside its own entry.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { AddressObject } from "mailparser";
+import { addressList } from "../src/imap";
+
+function ao(value: Array<{ name?: string; address?: string }>): AddressObject {
+  // mailparser's AddressObject also carries `text` + `html` but
+  // only `.value` is read by `addressList`.
+  return { value, text: "", html: "" } as unknown as AddressObject;
+}
+
+describe("addressList", () => {
+  it("returns empty array for undefined input", () => {
+    assert.deepEqual(addressList(undefined), []);
+  });
+
+  it("preserves display names with commas as a single entry", () => {
+    const list = addressList(ao([{ name: "Doe, John", address: "john@example.com" }, { address: "alice@example.com" }]));
+    assert.deepEqual(list, ["Doe, John <john@example.com>", "alice@example.com"]);
+  });
+
+  it("formats name + address as `Name <addr>`", () => {
+    const list = addressList(ao([{ name: "Alice Smith", address: "a@x.com" }]));
+    assert.deepEqual(list, ["Alice Smith <a@x.com>"]);
+  });
+
+  it("falls back to bare address when no display name", () => {
+    const list = addressList(ao([{ address: "noreply@example.com" }]));
+    assert.deepEqual(list, ["noreply@example.com"]);
+  });
+
+  it("flattens AddressObject[] input (multi-block To)", () => {
+    const list = addressList([ao([{ address: "a@x.com" }]), ao([{ address: "b@x.com" }])]);
+    assert.deepEqual(list, ["a@x.com", "b@x.com"]);
+  });
+
+  it("drops entries with neither name nor address", () => {
+    const list = addressList(ao([{ address: "a@x.com" }, {}, { name: "Bob" }]));
+    assert.deepEqual(list, ["a@x.com", "Bob <>"]);
+  });
+});

--- a/packages/plugins/email-plugin/test/test_providers.ts
+++ b/packages/plugins/email-plugin/test/test_providers.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { providerPresetForEmail } from "../src/providers";
+
+describe("providerPresetForEmail", () => {
+  it("returns Gmail preset for @gmail.com (TLS 993 / 465)", () => {
+    const preset = providerPresetForEmail("alice@gmail.com");
+    assert.ok(preset);
+    assert.equal(preset?.imap.host, "imap.gmail.com");
+    assert.equal(preset?.imap.port, 993);
+    assert.equal(preset?.imap.secure, true);
+    assert.equal(preset?.smtp.host, "smtp.gmail.com");
+    assert.equal(preset?.smtp.port, 465);
+    assert.equal(preset?.smtp.secure, true);
+  });
+
+  it("aliases googlemail.com to the Gmail preset", () => {
+    const preset = providerPresetForEmail("a@googlemail.com");
+    assert.equal(preset?.imap.host, "imap.gmail.com");
+  });
+
+  it("returns iCloud STARTTLS-on-587 SMTP for @icloud.com", () => {
+    const preset = providerPresetForEmail("user@icloud.com");
+    assert.equal(preset?.smtp.host, "smtp.mail.me.com");
+    assert.equal(preset?.smtp.port, 587);
+    assert.equal(preset?.smtp.secure, false);
+  });
+
+  it("is case-insensitive on the domain part", () => {
+    const lower = providerPresetForEmail("a@gmail.com");
+    const upper = providerPresetForEmail("a@GMAIL.COM");
+    assert.deepEqual(lower, upper);
+  });
+
+  it("returns null for unknown domains so callers fall back to user-supplied config", () => {
+    assert.equal(providerPresetForEmail("a@example.com"), null);
+    assert.equal(providerPresetForEmail("a@self-hosted.local"), null);
+  });
+
+  it("returns null for malformed addresses without @", () => {
+    assert.equal(providerPresetForEmail("not-an-email"), null);
+  });
+});

--- a/packages/plugins/email-plugin/tsconfig.json
+++ b/packages/plugins/email-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/plugins/email-plugin/vite.config.ts
+++ b/packages/plugins/email-plugin/vite.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+// Server-only plugin (v1): one entry, no Vue View yet. Mirrors
+// the externals strategy from edgar-plugin / bookmarks-plugin —
+// `gui-chat-protocol` and `zod` are bundled inline so the runtime
+// loader can extract the published tarball into a cache dir
+// without needing the user to `npm install` peer deps.
+export default defineConfig({
+  plugins: [
+    dts({
+      include: ["src/**/*.ts"],
+      outDir: "dist",
+      compilerOptions: { rootDir: "src" },
+    }),
+  ],
+  build: {
+    lib: {
+      entry: { index: "src/index.ts" },
+      formats: ["es"],
+      fileName: (_format, entryName) => `${entryName}.js`,
+    },
+    rollupOptions: {
+      external: ["node:os", "node:url"],
+    },
+    minify: false,
+    sourcemap: true,
+  },
+});

--- a/packages/plugins/email-plugin/vite.config.ts
+++ b/packages/plugins/email-plugin/vite.config.ts
@@ -21,7 +21,17 @@ export default defineConfig({
       fileName: (_format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
-      external: ["node:os", "node:url"],
+      // While this plugin is devOnly (#1542), the preset loader
+      // resolves it via the yarn-workspace symlink and the imap /
+      // smtp / mime-parsing libs are hoisted into the repo's
+      // node_modules — leave them external so we don't pay the
+      // ESM-bundling-CJS interop cost (mailparser → libmime →
+      // iconv has CJS class-extends chains that explode when
+      // inlined). When we publish via npm, the libs will need to
+      // travel with the tarball — either as real `dependencies`
+      // (npm install hoists them at the consumer) or as a future
+      // bundled build once the CJS interop is properly solved.
+      external: [/^node:/, "imapflow", "nodemailer", "mailparser"],
     },
     minify: false,
     sourcemap: true,

--- a/plans/feat-email-plugin-scaffold-1542.md
+++ b/plans/feat-email-plugin-scaffold-1542.md
@@ -1,0 +1,31 @@
+# Plan: `@mulmoclaude/email-plugin` PR 1 scaffold (#1542)
+
+## Scope (this PR only)
+
+Stand the runtime plugin up with everything except real IMAP/SMTP I/O:
+
+- Package skeleton (`package.json`, `tsconfig`, `vite.config`, `eslint.config`)
+- `TOOL_DEFINITION` for `manageEmail` (`kind: list | read | search | send`)
+- Zod-discriminated `Args` with strict validation (email regex, ISO-date regex, range checks)
+- Self-healing config flow (`config.json` at `~/mulmoclaude/config/plugins/%40mulmoclaude%2Femail-plugin/`)
+  - `missing` → asks LLM to collect email + App Password from user
+  - `server_unknown` (domain not in preset table, no explicit imap/smtp block) → asks for host/port
+- Provider preset table (gmail / googlemail / fastmail / icloud / me / outlook / hotmail)
+- Stub handlers for `list` / `read` / `search` returning the dispatched args (proves the call path)
+- Send-gate envelope: first `kind:'send'` returns `needs_confirmation: true` + a `retry_with` block carrying the args + `confirmed: true`; only the second call (with `confirmed:true`) reaches the (stub) send
+- `preset-list.ts` entry with `devOnly: true` (matches the publish-boundary contract from #1513)
+- Unit tests: args, providers, config (20 tests total)
+
+## Out of scope (later PRs)
+
+- PR 2: real IMAP `list` / `read` / `search` via `imapflow` + `mailparser`
+- PR 3: real SMTP `send` via `nodemailer`, plus a host-side hook so the send-gate envelope renders as `presentForm`
+- PR 4: optional Vue View / Preview
+- PR 5: 8-locale i18n, Personal role wiring, e2e
+- PR 6: npm publish + `mulmoclaude` deps
+
+## Notes
+
+- No `node:fs` / `node:path` in plugin source (banned by the plugin eslint preset). `homedir()` is allowed (used by edgar-plugin too) and only needed for the absolute-path string returned in the self-healing payload.
+- `peerDependencies: { gui-chat-protocol, zod }` mirrors edgar-plugin so the runtime loader resolves the same singletons.
+- Tarball will publish at `0.1.0` later via the same `publish` skill flow used for todo/spotify.

--- a/server/plugins/preset-list.ts
+++ b/server/plugins/preset-list.ts
@@ -67,4 +67,11 @@ export const PRESET_PLUGINS: readonly PresetPlugin[] = [
   // and retry. Opt-in per role like every other runtime plugin.
   // Not published yet — kept dev-only until distribution is decided.
   { packageName: "@mulmoclaude/edgar-plugin", devOnly: true },
+  // Generic IMAP/SMTP email runtime plugin (#1542). Gmail-default
+  // provider presets; App Password auth (no OAuth in v1). v1
+  // scaffold returns stubs for list/read/search/send so the
+  // config + send-confirmation flow can be exercised end-to-end;
+  // real IMAP/SMTP wiring lands in follow-up PRs. devOnly until
+  // the surface stabilises + we decide on npm publish.
+  { packageName: "@mulmoclaude/email-plugin", devOnly: true },
 ];

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -135,6 +135,9 @@ export const ROLES: Role[] = [
       TOOL_NAMES.readXPost,
       TOOL_NAMES.searchX,
       TOOL_NAMES.notify,
+      // #1542 — `@mulmoclaude/email-plugin` (devOnly preset, IMAP/SMTP).
+      // v1 dispatch returns stubs; real I/O lands in follow-up PRs.
+      TOOL_NAMES.manageEmail,
     ],
     queries: [
       "Show me the discount cash flow analysis of monthly income of $10,000 for two years. Make it possible to change the discount rate and monthly income.",

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -86,6 +86,7 @@ const HOST_TOOL_NAMES = {
   // preset skill which drives files directly via Read/Write/Edit.
   manageDebug: "manageDebug",
   edgar: "edgar",
+  manageEmail: "manageEmail",
 } as const;
 
 // Plugin-owned tool names auto-merged from each plugin's META.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,13 +1314,6 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://npm.flatt.tech/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
-
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -2078,6 +2071,14 @@
     "@types/node" "*"
     iconv-lite "^0.6.3"
 
+"@types/mailparser@^3.4.6":
+  version "3.4.6"
+  resolved "https://npm.flatt.tech/@types/mailparser/-/mailparser-3.4.6.tgz#fcca99fe9f919f3da691a0bf5e3022c6283c3068"
+  integrity sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==
+  dependencies:
+    "@types/node" "*"
+    iconv-lite "^0.6.3"
+
 "@types/matrix-js-sdk@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@types/matrix-js-sdk/-/matrix-js-sdk-11.1.0.tgz#0383e7b64d4dd661651e50a1562d472953a6ce1b"
@@ -2110,6 +2111,13 @@
 "@types/nodemailer@^8":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-8.0.0.tgz#ea189a9c151c04cc65c8a2a4c668c65d952a24e2"
+  integrity sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/nodemailer@^8.0.0":
+  version "8.0.0"
+  resolved "https://npm.flatt.tech/@types/nodemailer/-/nodemailer-8.0.0.tgz#ea189a9c151c04cc65c8a2a4c668c65d952a24e2"
   integrity sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==
   dependencies:
     "@types/node" "*"
@@ -3367,11 +3375,6 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
-
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://npm.flatt.tech/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@16.0.1:
   version "16.0.1"
@@ -5217,7 +5220,7 @@ ignore@^7.0.0, ignore@^7.0.5:
 
 imapflow@^1.3.3:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/imapflow/-/imapflow-1.3.3.tgz#2f5b2d6b422735b255e3e688647b44bfc1ce3a9b"
+  resolved "https://npm.flatt.tech/imapflow/-/imapflow-1.3.3.tgz#2f5b2d6b422735b255e3e688647b44bfc1ce3a9b"
   integrity sha512-lx7nWcUDfNgITEKYYfunUDqJ3LT6ImuiA1ReqJepVEA2nqBQNUqa3ppF7Yz5CNjuDYG95pmzsCcNqRjMrwh/Vg==
   dependencies:
     "@zone-eu/mailsplit" "5.4.9"
@@ -6130,7 +6133,7 @@ magic-string@^0.30.17, magic-string@^0.30.19, magic-string@^0.30.21:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-mailparser@^3.7.2:
+mailparser@^3.7.2, mailparser@^3.9.8:
   version "3.9.8"
   resolved "https://registry.yarnpkg.com/mailparser/-/mailparser-3.9.8.tgz#882ebde0f8b2d535dc6f8954b040f011e2a774a4"
   integrity sha512-7jSlFGXiianVnhnb6wdutJFloD34488nrHY7r6FNqwXAhZ7YiJDYrKKTxZJ0oSrXcAPHm8YoYnh97xyGtrBQ3w==
@@ -6318,17 +6321,10 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://npm.flatt.tech/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.3"
   resolved "https://npm.flatt.tech/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
-
-minizlib@^3.1.0:
-  version "3.1.0"
-  resolved "https://npm.flatt.tech/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
-  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
-  dependencies:
-    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -6474,6 +6470,11 @@ nodemailer@8.0.7, nodemailer@^8.0.7:
   version "8.0.7"
   resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.7.tgz#538729a79444e538331bca8a6fc3e5c034eaebc6"
   integrity sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==
+
+nodemailer@^8.0.9:
+  version "8.0.9"
+  resolved "https://npm.flatt.tech/nodemailer/-/nodemailer-8.0.9.tgz#9ea0bdb84b04b1ee65d83b15aa7d62761e9b5677"
+  integrity sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -8065,17 +8066,6 @@ tar-stream@^3.0.0, tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.13:
-  version "7.5.13"
-  resolved "https://npm.flatt.tech/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
-  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8900,11 +8890,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://npm.flatt.tech/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

#1542 の PR 1: `@mulmoclaude/email-plugin` の **scaffold + config フロー + stub handlers**。実 IMAP/SMTP 通信は PR 2 / PR 3 に分けて、まず形・設定・送信ゲートを通せるようにする。

- `manageEmail` ツール (`kind: list | read | search | send`)
- App Password 認証 + Gmail/Fastmail/iCloud/Outlook の自動 host 推定
- 未設定なら edgar-plugin と同じ self-healing payload を返し、LLM が `presentForm` でユーザーから集めて `~/mulmoclaude/config/plugins/%40mulmoclaude%2Femail-plugin/config.json` に書き込む
- `send` は **二段確認**: 1 回目は `needs_confirmation:true` + `retry_with` ブロックを返し、2 回目 (`confirmed:true`) で送信実行 (今は stub)
- `preset-list.ts` に `devOnly:true` で追加 → 公開 tarball には乗らないが dev (`yarn dev`) では動く

## Items to Confirm / Review

- **package 名 / scope**: `@mulmoclaude/email-plugin` (汎用 IMAP/SMTP、Gmail はデフォルト preset)。`@mulmoclaude/gmail-plugin` にしたい場合は今のうちに rename 可。
- **send-gate envelope の形**: `{ needs_confirmation:true, message, draft, retry_with }`。host 側で `presentForm` にマッピングする hook は PR 3 で実装。LLM がこの形を「素直に form として人間に出してから retry」する挙動かどうかは PR 2/3 完了後に live で要検証。
- **provider preset の選択**: gmail / googlemail / fastmail / icloud / me / outlook / hotmail を入れた。他に v1 でカバーしたい主要プロバイダがあれば追加。
- **送信制約**: v1 は **単一宛先 `to` のみ**。cc / bcc / 複数 to は v2+。
- **credentials 保管**: workspace 内 plain JSON (既存 plugin と同様)。OS keyring 統合は v2+ の検討項目。

## Implementation

- `packages/plugins/email-plugin/` 配下に edgar-plugin 同型の scaffold (package.json / tsconfig / vite / eslint)
- `src/definition.ts`: `manageEmail` の TOOL_DEFINITION
- `src/args.ts`: Zod discriminated union + ISO-date / email regex
- `src/providers.ts`: domain → `{imap, smtp}` 推定テーブル
- `src/config.ts`: self-healing + 2 種の `instructions` payload (`missing` / `server_unknown`)
- `src/index.ts`: `definePlugin` entry + dispatch + stub handlers + 送信ゲート envelope
- `server/plugins/preset-list.ts`: `{ packageName: "@mulmoclaude/email-plugin", devOnly: true }` を追加
- `plans/feat-email-plugin-scaffold-1542.md`: PR 分割計画

## Test

- `yarn workspace @mulmoclaude/email-plugin run test` → **20/20 pass** (args 7 + providers 6 + config 7)
- `yarn workspace @mulmoclaude/email-plugin run typecheck` clean
- `yarn workspace @mulmoclaude/email-plugin run build` clean
- 上流 `yarn lint` / `yarn typecheck` / `yarn build` clean
- `npx tsx --test test/plugins/test_preset_loader.ts` → 4/4 pass (publish boundary 制約は変わらず: 非 devOnly は todo+spotify のみ)

Refs #1542 (PR 1 of 6)。

## User Prompt

> smtp/imap で動作する google gmail の plugin がほしい
> (clarifying Q&A の結果、App Password / list+read+send+search / presentForm 送信ゲート / 汎用 IMAP・Gmail default で確定)
> ちゃくしゅ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new dev-only generic IMAP/SMTP email runtime plugin scaffold with self-healing configuration and a confirmation-gated send flow, wired into the preset plugin list.

New Features:
- Add the @mulmoclaude/email-plugin runtime package providing a generic manageEmail tool supporting list, read, search, and send operations over IMAP/SMTP.
- Implement self-healing configuration for the email plugin that guides the LLM to collect App Password credentials and optional server settings and write them to a per-plugin config.json.
- Add provider presets to auto-derive IMAP/SMTP host and port settings for common providers like Gmail, Fastmail, iCloud, and Outlook.
- Introduce a two-step, form-based confirmation gate for email sending, returning a structured confirmation envelope on first send and only executing on confirmed retries.

Enhancements:
- Wire the new email plugin into the server preset list as a devOnly plugin so it is available in development without affecting published presets.
- Provide a documented multi-PR plan outlining how this scaffold will be extended with real IMAP/SMTP I/O, UI, i18n, and publishing steps in follow-up work.

Build:
- Add Vite, TypeScript, and ESLint configuration for the email plugin package to build and lint the server-only runtime artifact.

Tests:
- Add unit tests for email plugin argument validation, configuration resolution, and provider presets to verify the scaffolded behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an email management plugin: IMAP-backed listing/reading/searching, SMTP send with two-step confirmation, provider presets and self-healing config prompts.

* **Tests**
  * Unit tests for argument validation, provider presets, config resolution, IMAP helper formatting, and send/read/search flows.

* **Documentation**
  * PR scaffold and usage/instruction notes for the new plugin.

* **Chores**
  * Packaging, build, TypeScript, and linting configuration for the plugin; dev-only preset registered and tool name enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->