### PR TITLE
fix(files): auto-scroll file tree to reveal selected file

### DIFF
--- a/e2e/tests/files-tree-scroll.spec.ts
+++ b/e2e/tests/files-tree-scroll.spec.ts
@@ -25,53 +25,55 @@ function buildWideTree() {
   return { dirAFiles, dirBFiles };
 }
 
+type FileNode = { name: string; path: string; type: "file"; size: number };
+
+function rootDirResponse() {
+  return {
+    name: "",
+    path: "",
+    type: "dir" as const,
+    children: [
+      { name: "dir-a", path: "dir-a", type: "dir" as const },
+      { name: "dir-b", path: "dir-b", type: "dir" as const },
+    ],
+  };
+}
+
+function dirResponse(name: string, files: FileNode[]) {
+  return { name, path: name, type: "dir" as const, children: files };
+}
+
+function emptyDirResponse(path: string) {
+  return { name: path, path, type: "dir" as const, children: [] };
+}
+
+function handleDirRoute(route: Route, dirAFiles: FileNode[], dirBFiles: FileNode[]): Promise<void> {
+  const path = new URL(route.request().url()).searchParams.get("path") ?? "";
+  if (path === "") return route.fulfill({ json: rootDirResponse() });
+  if (path === "dir-a") return route.fulfill({ json: dirResponse("dir-a", dirAFiles) });
+  if (path === "dir-b") return route.fulfill({ json: dirResponse("dir-b", dirBFiles) });
+  return route.fulfill({ json: emptyDirResponse(path) });
+}
+
+function handleContentRoute(route: Route): Promise<void> {
+  return route.fulfill({
+    json: {
+      kind: "text",
+      path: new URL(route.request().url()).searchParams.get("path") ?? "",
+      content: "stub content",
+      size: 12,
+      modifiedMs: Date.now(),
+    },
+  });
+}
+
 async function mockTree(page: Page): Promise<void> {
   const { dirAFiles, dirBFiles } = buildWideTree();
   await page.route(
     (url) => url.pathname === "/api/files/dir",
-    (route: Route) => {
-      const path = new URL(route.request().url()).searchParams.get("path") ?? "";
-      if (path === "") {
-        return route.fulfill({
-          json: {
-            name: "",
-            path: "",
-            type: "dir",
-            children: [
-              { name: "dir-a", path: "dir-a", type: "dir" },
-              { name: "dir-b", path: "dir-b", type: "dir" },
-            ],
-          },
-        });
-      }
-      if (path === "dir-a") {
-        return route.fulfill({
-          json: { name: "dir-a", path: "dir-a", type: "dir", children: dirAFiles },
-        });
-      }
-      if (path === "dir-b") {
-        return route.fulfill({
-          json: { name: "dir-b", path: "dir-b", type: "dir", children: dirBFiles },
-        });
-      }
-      return route.fulfill({
-        json: { name: path, path, type: "dir", children: [] },
-      });
-    },
+    (route: Route) => handleDirRoute(route, dirAFiles, dirBFiles),
   );
-  await page.route(
-    (url) => url.pathname === "/api/files/content",
-    (route) =>
-      route.fulfill({
-        json: {
-          kind: "text",
-          path: new URL(route.request().url()).searchParams.get("path") ?? "",
-          content: "stub content",
-          size: 12,
-          modifiedMs: Date.now(),
-        },
-      }),
-  );
+  await page.route((url) => url.pathname === "/api/files/content", handleContentRoute);
 }
 
 async function expectSelectedRowInView(page: Page): Promise<void> {

--- a/e2e/tests/files-tree-scroll.spec.ts
+++ b/e2e/tests/files-tree-scroll.spec.ts
@@ -25,7 +25,12 @@ function buildWideTree() {
   return { dirAFiles, dirBFiles };
 }
 
-type FileNode = { name: string; path: string; type: "file"; size: number };
+interface FileNode {
+  name: string;
+  path: string;
+  type: "file";
+  size: number;
+}
 
 function rootDirResponse() {
   return {

--- a/e2e/tests/files-tree-scroll.spec.ts
+++ b/e2e/tests/files-tree-scroll.spec.ts
@@ -84,9 +84,9 @@ async function expectSelectedRowInView(page: Page): Promise<void> {
           const selected = document.querySelector<HTMLElement>('[data-testid="files-view-root"] button[data-selected="true"]');
           const container = document.querySelector<HTMLElement>('[data-testid="files-view-root"] .overflow-y-auto');
           if (!selected || !container) return false;
-          const s = selected.getBoundingClientRect();
-          const c = container.getBoundingClientRect();
-          return s.top >= c.top && s.bottom <= c.bottom;
+          const selRect = selected.getBoundingClientRect();
+          const containerRect = container.getBoundingClientRect();
+          return selRect.top >= containerRect.top && selRect.bottom <= containerRect.bottom;
         }),
       { timeout: 5000 },
     )

--- a/e2e/tests/files-tree-scroll.spec.ts
+++ b/e2e/tests/files-tree-scroll.spec.ts
@@ -1,0 +1,126 @@
+// Tree pane auto-scrolls so the selected file row is visible after
+// (a) deep-link mount and (b) in-app file→file navigation. Covers
+// the bug where the selected row lived in the DOM but sat below the
+// fold of the overflow-y-auto pane.
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// Build a tree wide enough that the target row sits well below the
+// pane's clientHeight. Two top-level dirs each with 40 files; the
+// second dir's target file is at the bottom.
+function buildWideTree() {
+  const dirAFiles = Array.from({ length: 40 }, (_, i) => ({
+    name: `a-${String(i).padStart(2, "0")}.md`,
+    path: `dir-a/a-${String(i).padStart(2, "0")}.md`,
+    type: "file" as const,
+    size: 10,
+  }));
+  const dirBFiles = Array.from({ length: 40 }, (_, i) => ({
+    name: `b-${String(i).padStart(2, "0")}.md`,
+    path: `dir-b/b-${String(i).padStart(2, "0")}.md`,
+    type: "file" as const,
+    size: 10,
+  }));
+  return { dirAFiles, dirBFiles };
+}
+
+async function mockTree(page: Page): Promise<void> {
+  const { dirAFiles, dirBFiles } = buildWideTree();
+  await page.route(
+    (url) => url.pathname === "/api/files/dir",
+    (route: Route) => {
+      const path = new URL(route.request().url()).searchParams.get("path") ?? "";
+      if (path === "") {
+        return route.fulfill({
+          json: {
+            name: "",
+            path: "",
+            type: "dir",
+            children: [
+              { name: "dir-a", path: "dir-a", type: "dir" },
+              { name: "dir-b", path: "dir-b", type: "dir" },
+            ],
+          },
+        });
+      }
+      if (path === "dir-a") {
+        return route.fulfill({
+          json: { name: "dir-a", path: "dir-a", type: "dir", children: dirAFiles },
+        });
+      }
+      if (path === "dir-b") {
+        return route.fulfill({
+          json: { name: "dir-b", path: "dir-b", type: "dir", children: dirBFiles },
+        });
+      }
+      return route.fulfill({
+        json: { name: path, path, type: "dir", children: [] },
+      });
+    },
+  );
+  await page.route(
+    (url) => url.pathname === "/api/files/content",
+    (route) =>
+      route.fulfill({
+        json: {
+          kind: "text",
+          path: new URL(route.request().url()).searchParams.get("path") ?? "",
+          content: "stub content",
+          size: 12,
+          modifiedMs: Date.now(),
+        },
+      }),
+  );
+}
+
+async function expectSelectedRowInView(page: Page): Promise<void> {
+  // poll: the reveal effect re-fires on tree growth, so give it a beat
+  // to settle after the lazy-load of dir-a finishes.
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const selected = document.querySelector<HTMLElement>('[data-testid="files-view-root"] button[data-selected="true"]');
+          const container = document.querySelector<HTMLElement>('[data-testid="files-view-root"] .overflow-y-auto');
+          if (!selected || !container) return false;
+          const s = selected.getBoundingClientRect();
+          const c = container.getBoundingClientRect();
+          return s.top >= c.top && s.bottom <= c.bottom;
+        }),
+      { timeout: 5000 },
+    )
+    .toBe(true);
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+  await mockTree(page);
+});
+
+test.describe("file tree auto-scroll to selection", () => {
+  test("deep link to a file below the fold scrolls the tree to reveal it", async ({ page }) => {
+    await page.goto("/files/dir-b/b-39.md");
+    await expect(page.locator('[data-testid="file-tree-file-b-39.md"]')).toBeVisible();
+    await expectSelectedRowInView(page);
+  });
+
+  test("in-app navigation expands ancestors and scrolls to the new selection", async ({ page }) => {
+    // Land on a row at the top of dir-a (which auto-expands via the
+    // deep-link path). dir-b is still collapsed at this point.
+    await page.goto("/files/dir-a/a-00.md");
+    await expect(page.locator('[data-testid="file-tree-file-a-00.md"]')).toBeVisible();
+
+    // Simulate a markdown link navigating to a file in the still-
+    // collapsed dir-b — this is the in-app file→file case the fix
+    // targets. selectFile() updates state and pushes the route; the
+    // ancestor expansion + scroll must follow without a remount.
+    await page.evaluate(() => {
+      window.history.pushState({}, "", "/files/dir-b/b-39.md");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    await expect(page.locator('[data-testid="file-tree-file-b-39.md"]')).toBeVisible();
+    await expectSelectedRowInView(page);
+  });
+});

--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -11,6 +11,7 @@
     </button>
     <button
       v-else
+      ref="fileButtonRef"
       class="w-full flex items-center gap-1 px-2 py-1 text-left text-sm rounded transition-colors"
       :class="selectedPath === node.path ? 'bg-blue-100 text-blue-700' : 'text-gray-700 hover:bg-gray-100'"
       :data-testid="`file-tree-file-${node.name}`"
@@ -42,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 import { sortChildren } from "../utils/files/sortChildren";
@@ -133,6 +134,22 @@ const fileIcon = computed(() => {
 });
 
 const isRecent = computed(() => props.recentPaths.has(props.node.path));
+
+// Reveal the selected file in the scrollable tree pane. Fires both on
+// mount (deep-link case: ancestors expand asynchronously, so this node
+// can mount already-selected) and when `selectedPath` flips to this
+// node (in-app navigation like wiki → files links). `block: "nearest"`
+// avoids unnecessary scrolling when the row is already visible.
+const fileButtonRef = ref<HTMLButtonElement | null>(null);
+watch(
+  () => props.selectedPath === props.node.path && props.node.type === "file",
+  async (isSelected) => {
+    if (!isSelected) return;
+    await nextTick();
+    fileButtonRef.value?.scrollIntoView({ block: "nearest" });
+  },
+  { immediate: true },
+);
 
 // System-managed files get tinted by edit policy so the user can
 // spot them in the tree before clicking. Folders and unrecognised

--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -11,10 +11,10 @@
     </button>
     <button
       v-else
-      ref="fileButtonRef"
       class="w-full flex items-center gap-1 px-2 py-1 text-left text-sm rounded transition-colors"
       :class="selectedPath === node.path ? 'bg-blue-100 text-blue-700' : 'text-gray-700 hover:bg-gray-100'"
       :data-testid="`file-tree-file-${node.name}`"
+      :data-selected="selectedPath === node.path ? 'true' : undefined"
       :title="node.path"
       @click="emit('select', node.path)"
     >
@@ -43,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 import { sortChildren } from "../utils/files/sortChildren";
@@ -134,22 +134,6 @@ const fileIcon = computed(() => {
 });
 
 const isRecent = computed(() => props.recentPaths.has(props.node.path));
-
-// Reveal the selected file in the scrollable tree pane. Fires both on
-// mount (deep-link case: ancestors expand asynchronously, so this node
-// can mount already-selected) and when `selectedPath` flips to this
-// node (in-app navigation like wiki → files links). `block: "nearest"`
-// avoids unnecessary scrolling when the row is already visible.
-const fileButtonRef = ref<HTMLButtonElement | null>(null);
-watch(
-  () => props.selectedPath === props.node.path && props.node.type === "file",
-  async (isSelected) => {
-    if (!isSelected) return;
-    await nextTick();
-    fileButtonRef.value?.scrollIntoView({ block: "nearest" });
-  },
-  { immediate: true },
-);
 
 // System-managed files get tinted by edit policy so the user can
 // spot them in the tree before clicking. Folders and unrecognised

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -182,7 +182,7 @@ const { handleMarkdownLinkClick } = useMarkdownLinkHandler(selectedPath, {
 // see plans/done/feat-files-path-url.md.
 watch(
   () => readPathMatch(route.params.pathMatch),
-  (newPath) => {
+  async (newPath) => {
     if (!isValidFilePath(newPath)) {
       if (selectedPath.value !== null) {
         selectedPath.value = null;
@@ -193,6 +193,11 @@ watch(
     if (newPath !== selectedPath.value) {
       selectedPath.value = newPath;
       loadContent(newPath);
+      // Mirror the onMounted deep-link path: in-app navigation between
+      // files (markdown link → another /files/<path>) doesn't remount
+      // FilesView, so without this the new file's ancestors may stay
+      // collapsed and the row never enters the DOM for scroll.
+      await ensureAncestorsLoaded(newPath);
     }
   },
 );

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -182,7 +182,7 @@ const { handleMarkdownLinkClick } = useMarkdownLinkHandler(selectedPath, {
 // see plans/done/feat-files-path-url.md.
 watch(
   () => readPathMatch(route.params.pathMatch),
-  async (newPath) => {
+  (newPath) => {
     if (!isValidFilePath(newPath)) {
       if (selectedPath.value !== null) {
         selectedPath.value = null;
@@ -193,14 +193,20 @@ watch(
     if (newPath !== selectedPath.value) {
       selectedPath.value = newPath;
       loadContent(newPath);
-      // Mirror the onMounted deep-link path: in-app navigation between
-      // files (markdown link → another /files/<path>) doesn't remount
-      // FilesView, so without this the new file's ancestors may stay
-      // collapsed and the row never enters the DOM for scroll.
-      await ensureAncestorsLoaded(newPath);
     }
   },
 );
+
+// Keep the tree expanded down to the active selection regardless of
+// how the selection changed (URL bar, back/forward, selectFile from a
+// markdown link). selectFile() updates selectedPath synchronously
+// before pushing the route, so a guard on the route watcher would
+// miss in-app file→file navigation — we watch the source of truth
+// directly. Idempotent: loadDirChildren and expand() both short-circuit
+// when the cache/expand-state already has the ancestor.
+watch(selectedPath, (newPath) => {
+  if (newPath) ensureAncestorsLoaded(newPath);
+});
 
 // Reveal the selected file row in the tree pane. The tree grows
 // incrementally on deep-link mount: ensureAncestorsLoaded fetches the

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
 import FileTreePane from "./FileTreePane.vue";
@@ -203,11 +203,14 @@ watch(
 // restored from localStorage lazy-load their children later via each
 // FileTree's own watcher. Each of those loads pushes the selected
 // row further down, so scrollIntoView must re-run whenever the tree
-// grows, not just once on selection change.
-async function revealSelectedInTree(): Promise<void> {
+// grows, not just once on selection change. A pending-rAF guard
+// coalesces a burst of childrenByPath updates into a single scroll.
+let pendingRevealRaf = 0;
+function revealSelectedInTree(): void {
   if (!selectedPath.value) return;
-  await nextTick();
-  requestAnimationFrame(() => {
+  if (pendingRevealRaf !== 0) return;
+  pendingRevealRaf = requestAnimationFrame(() => {
+    pendingRevealRaf = 0;
     const button = document.querySelector<HTMLElement>('[data-testid="files-view-root"] button[data-selected="true"]');
     button?.scrollIntoView({ block: "nearest" });
   });
@@ -240,5 +243,6 @@ onMounted(async () => {
 
 onUnmounted(() => {
   abortContent();
+  if (pendingRevealRaf !== 0) cancelAnimationFrame(pendingRevealRaf);
 });
 </script>

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
 import FileTreePane from "./FileTreePane.vue";
@@ -197,6 +197,24 @@ watch(
   },
 );
 
+// Reveal the selected file row in the tree pane. Runs after the tree
+// has had a chance to expand ancestors and render the deepest button,
+// then on every selectedPath change (wiki link → file, back/forward).
+// rAF after nextTick = wait for Vue to flush DOM updates, then for the
+// browser to lay out the (potentially very tall) tree before scrolling.
+async function revealSelectedInTree(): Promise<void> {
+  if (!selectedPath.value) return;
+  await nextTick();
+  requestAnimationFrame(() => {
+    const button = document.querySelector<HTMLElement>('[data-testid="files-view-root"] button[data-selected="true"]');
+    button?.scrollIntoView({ block: "nearest" });
+  });
+}
+
+watch(selectedPath, () => {
+  revealSelectedInTree();
+});
+
 watch(
   () => props.refreshToken,
   () => {
@@ -215,6 +233,7 @@ onMounted(async () => {
   if (selectedPath.value) {
     await ensureAncestorsLoaded(selectedPath.value);
     loadContent(selectedPath.value);
+    revealSelectedInTree();
   }
 });
 

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="h-full flex bg-white" data-testid="files-view-root">
     <FileTreePane
+      ref="treePaneRef"
       :root-node="rootNode"
       :ref-roots="refRoots"
       :children-by-path="childrenByPath"
@@ -202,11 +203,17 @@ watch(
 // markdown link). selectFile() updates selectedPath synchronously
 // before pushing the route, so a guard on the route watcher would
 // miss in-app file→file navigation — we watch the source of truth
-// directly. Idempotent: loadDirChildren and expand() both short-circuit
-// when the cache/expand-state already has the ancestor.
-watch(selectedPath, (newPath) => {
-  if (newPath) ensureAncestorsLoaded(newPath);
-});
+// directly. `immediate: true` covers the deep-link mount case, so
+// onMounted doesn't need its own ensureAncestorsLoaded call.
+// Idempotent: loadDirChildren and expand() both short-circuit when
+// the cache/expand-state already has the ancestor.
+watch(
+  selectedPath,
+  (newPath) => {
+    if (newPath) ensureAncestorsLoaded(newPath);
+  },
+  { immediate: true },
+);
 
 // Reveal the selected file row in the tree pane. The tree grows
 // incrementally on deep-link mount: ensureAncestorsLoaded fetches the
@@ -216,13 +223,18 @@ watch(selectedPath, (newPath) => {
 // row further down, so scrollIntoView must re-run whenever the tree
 // grows, not just once on selection change. A pending-rAF guard
 // coalesces a burst of childrenByPath updates into a single scroll.
+// Scope the query to the FileTreePane's root via a template ref so
+// it survives data-testid / DOM-structure changes elsewhere in
+// FilesView.
+const treePaneRef = ref<InstanceType<typeof FileTreePane> | null>(null);
 let pendingRevealRaf = 0;
 function revealSelectedInTree(): void {
   if (!selectedPath.value) return;
   if (pendingRevealRaf !== 0) return;
   pendingRevealRaf = requestAnimationFrame(() => {
     pendingRevealRaf = 0;
-    const button = document.querySelector<HTMLElement>('[data-testid="files-view-root"] button[data-selected="true"]');
+    const paneRoot = treePaneRef.value?.$el as HTMLElement | undefined;
+    const button = paneRoot?.querySelector<HTMLElement>('button[data-selected="true"]');
     button?.scrollIntoView({ block: "nearest" });
   });
 }
@@ -242,14 +254,10 @@ onMounted(async () => {
   await loadDirChildren("");
   await loadRefRoots();
 
-  // Deep-link: if the URL has a selected path, reveal its ancestors
-  // by fetching each dir in sequence so the tree auto-expands to
-  // the selection.
-  if (selectedPath.value) {
-    await ensureAncestorsLoaded(selectedPath.value);
-    loadContent(selectedPath.value);
-    revealSelectedInTree();
-  }
+  // Deep-link content load. The ancestor expansion + scroll reveal are
+  // handled by the selectedPath watchers above (the ensureAncestorsLoaded
+  // watcher runs with immediate: true).
+  if (selectedPath.value) loadContent(selectedPath.value);
 });
 
 onUnmounted(() => {

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -197,11 +197,13 @@ watch(
   },
 );
 
-// Reveal the selected file row in the tree pane. Runs after the tree
-// has had a chance to expand ancestors and render the deepest button,
-// then on every selectedPath change (wiki link → file, back/forward).
-// rAF after nextTick = wait for Vue to flush DOM updates, then for the
-// browser to lay out the (potentially very tall) tree before scrolling.
+// Reveal the selected file row in the tree pane. The tree grows
+// incrementally on deep-link mount: ensureAncestorsLoaded fetches the
+// direct ancestors, but sibling dirs whose `expanded` state was
+// restored from localStorage lazy-load their children later via each
+// FileTree's own watcher. Each of those loads pushes the selected
+// row further down, so scrollIntoView must re-run whenever the tree
+// grows, not just once on selection change.
 async function revealSelectedInTree(): Promise<void> {
   if (!selectedPath.value) return;
   await nextTick();
@@ -211,9 +213,8 @@ async function revealSelectedInTree(): Promise<void> {
   });
 }
 
-watch(selectedPath, () => {
-  revealSelectedInTree();
-});
+watch(selectedPath, revealSelectedInTree);
+watch(childrenByPath, revealSelectedInTree);
 
 watch(
   () => props.refreshToken,


### PR DESCRIPTION

<img width="3212" height="3016" alt="CleanShot 2026-05-29 at 09 53 18@2x" src="https://github.com/user-attachments/assets/716dc1b2-45ef-4b59-8a33-267b446648fc" />

## Summary

`/files/<path>` を deep-link やアプリ内 markdown リンクで開いたとき、ファイルツリーの選択行が画面外に隠れたままになる不具合を修正。FilesView に親レベルの scroll-reveal effect を追加し、`selectedPath` 変更時とツリー成長時に選択行を `scrollIntoView({ block: "nearest" })` で可視範囲に運ぶ。

- 選択 button に `data-selected="true"` を付与し、親側で querySelector で取得
- `requestAnimationFrame` を `pendingRevealRaf` で coalesce してバーストでも 1 回に
- アプリ内ファイル間遷移（`selectFile()` 経由）でも祖先展開が走るよう `selectedPath` 自体を watch
- e2e テスト 2 件追加（deep-link / in-app history-push）

## Items to Confirm / Review

- `watch(childrenByPath, revealSelectedInTree)` の発火回数 — localStorage 復元 + 遅延ロードで多数の dir が膨らむケースでも、coalesce 済みなので scrollIntoView は 1 フレーム 1 回に収束する想定
- `watch(selectedPath, ...)` で `ensureAncestorsLoaded` を呼ぶようにしたため、onMounted の同呼び出しと冗長になる可能性 — `loadDirChildren` と `expand()` は idempotent なので副作用なし
- in-app file→file 遷移時、`selectFile()` が router.push する前に selectedPath を同期更新する関係で route watcher のガード（`newPath !== selectedPath.value`）にひっかからない経路があった。route watcher は loadContent のみ担当に変更、ancestor 展開と scroll は `selectedPath` watcher に集約
- `block: "nearest"` を採用しているため、既に行が可視範囲内なら no-op（ブラウザ標準動作）

## User Prompt

> wiki の最後のこのリンクをタップすると
> - ページ遷移をするのは OK
> - そのファイルがハイライトされるのもOK
>
> しかし、ファイルツリーがスクロールされないので、スクロールするようにして欲しい。

その後の対話で以下の追加要件:

> wiki / chat からのリンクは修正されたってこと？ → はい
> 「既に /files/... を開いている状態から、別のファイルへ markdown 内リンクで遷移する」というレアケースも実装できないの？ → 対応
> テストは追加している？していないなら、テスト追加して → e2e 2 件追加

## Implementation Notes

### なぜ最初の実装（FileTree.vue 内の per-node watcher）では不十分だったか

再帰 FileTree の各 node で `selectedPath === node.path` を watch する素朴な実装では、`ensureAncestorsLoaded` 完了直後に scrollIntoView が走るものの、その後に localStorage 復元された他の展開済み dir が遅延ロードで子を差し込み、選択行が画面外まで押し下げられていた（Playwright で `scrollTop=724, button bbox.top=1119, container bottom=933` を観測）。

### 最終形

1. FileTree.vue: button に `data-selected="true"` を付与するだけ
2. FilesView.vue:
   - `revealSelectedInTree()` を rAF + pending guard で実装
   - `watch(selectedPath, ...)` で発火（URL bar / back-forward / selectFile すべてカバー）
   - `watch(childrenByPath, ...)` で発火（遅延ロードによるツリー成長後の再 scroll）
   - `watch(selectedPath, ...)` で `ensureAncestorsLoaded` も発火（in-app 遷移時に祖先が collapsed のままだと選択行が DOM に存在しないため）

### Codex cross-review

5 iterations で convergence。各 iteration:
1. LGTM（初期実装、後に不十分と判明）
2. LGTM with minor perf caveat → rAF coalesce で対応
3. APPROVED
4. REQUEST CHANGES（route watcher のガードで in-app 遷移時の `ensureAncestorsLoaded` がスキップされる指摘）→ `selectedPath` watch に切り替えて対応
5. PASS

## Test Plan

- [x] `yarn typecheck` / `yarn lint` / `yarn build` green
- [x] `yarn test:e2e --grep "file tree auto-scroll"` green (2 tests)
- [x] Playwright で実機検証: 選択行の bbox が scroll container bbox 内に収まることを確認
- [ ] 手動: wiki ページ末尾のソースリンクから `/files/data/wiki/sources/.../transcript.md` 開いて選択行が可視範囲に
- [ ] 手動: chat メッセージ中のファイルリンクから同様に確認
- [ ] 手動: `/files/foo.md` を開いた状態から markdown 内のリンクで `/files/bar/baz/qux.md` に遷移（祖先が collapsed の状態から）

## Summary by Sourcery

Ensure the files tree automatically scrolls to keep the selected file visible in the sidebar after navigation and tree growth events.

Bug Fixes:
- Fix the file tree not scrolling to reveal the selected file when opening a deep-linked file or navigating between files in-app.

Enhancements:
- Centralize ancestor expansion and scroll-to-selection behavior in the files view, keyed off the selected path and tree data changes.

Tests:
- Add Playwright end-to-end tests covering deep-link mounts and in-app file-to-file navigation to verify the selected row stays within the visible tree pane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File tree now auto-expands to the active file and auto-scrolls to keep the selected file visible during navigation and when opening deep-linked files.

* **Tests**
  * Added end-to-end test that verifies the file tree’s expand-and-reveal behavior across initial loads and in-app navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->