### PR TITLE
feat(collections): completion-field bell + URL links

### DIFF
--- a/e2e/tests/collection-url-link.spec.ts
+++ b/e2e/tests/collection-url-link.spec.ts
@@ -1,0 +1,102 @@
+// E2E coverage for the value-based external-URL rendering in
+// CollectionView (feat/collection-completion-bell). Any string field
+// whose value starts with `http://` or `https://` renders as a
+// `target="_blank"` anchor in both the list table and the detail
+// view; non-URL string values fall through to the plain-text renderer.
+//
+// The list-row anchor uses `@click.stop` so clicking the link only
+// opens the new tab — it must NOT also bubble into the row click that
+// opens the detail panel. This file pins that boundary so a future
+// refactor can't quietly regress it.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const READING_LIST = {
+  collection: {
+    slug: "reading-list",
+    title: "Reading List",
+    icon: "bookmark",
+    source: "user",
+    schema: {
+      title: "Reading List",
+      icon: "bookmark",
+      dataPath: "data/reading-list/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        url: { type: "string", label: "URL", required: true },
+        notes: { type: "string", label: "Notes" },
+        read: { type: "boolean", label: "Read", required: true },
+      },
+      completionField: "read",
+      completionDoneValues: ["true"],
+    },
+  },
+  items: [
+    { id: "anthropic-blog", url: "https://www.anthropic.com/news", notes: "Skim the latest post", read: false },
+    { id: "non-url-row", url: "not actually a url", notes: "just text", read: false },
+  ],
+};
+
+async function mockCollection(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/reading-list",
+    (route) => route.fulfill({ json: READING_LIST }),
+  );
+}
+
+test.describe("collection URL links", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockCollection(page);
+  });
+
+  test("list row renders an http(s) URL value as a new-tab link", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+    const link = page.getByTestId("collections-url-link-url-anthropic-blog");
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "https://www.anthropic.com/news");
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  test("list row falls back to plain text for non-URL string values", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+    // The non-URL row is in the table…
+    await expect(page.getByTestId("collections-row-non-url-row")).toBeVisible();
+    // …but it has no anchor element for the `url` column — the fallback
+    // span renders the raw string instead.
+    await expect(page.getByTestId("collections-url-link-url-non-url-row")).toHaveCount(0);
+  });
+
+  test("detail view renders an http(s) URL value as a new-tab link", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+    // Click the ID cell rather than the row's geometric center — the
+    // center may land on the URL link cell, whose `@click.stop` would
+    // (correctly) block the row's openView handler. This test is about
+    // the detail-side rendering; the click-boundary itself is pinned
+    // by the next test below.
+    await page.getByTestId("collections-row-anthropic-blog").getByText("anthropic-blog").click();
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    const link = page.getByTestId("collections-detail-url-url");
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "https://www.anthropic.com/news");
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  test("clicking a URL link in the list does NOT open the row's detail panel", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+    // Prevent the new tab from actually opening — we only want to
+    // verify the click doesn't bubble into the row handler.
+    await page.addInitScript(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).open = () => null;
+    });
+    await page.getByTestId("collections-url-link-url-anthropic-blog").click();
+    // Detail panel is the modal-style overlay opened by the row click.
+    // If `@click.stop` is missing, this would be visible.
+    await expect(page.getByTestId("collections-detail")).toHaveCount(0);
+  });
+});

--- a/e2e/tests/collection-url-link.spec.ts
+++ b/e2e/tests/collection-url-link.spec.ts
@@ -87,13 +87,15 @@ test.describe("collection URL links", () => {
   });
 
   test("clicking a URL link in the list does NOT open the row's detail panel", async ({ page }) => {
-    await page.goto("/collections/reading-list");
-    // Prevent the new tab from actually opening — we only want to
+    // Stub `window.open` BEFORE navigating — `addInitScript` only runs
+    // on subsequent navigations, so the order matters. The override
+    // prevents the new tab from actually opening; we only need to
     // verify the click doesn't bubble into the row handler.
     await page.addInitScript(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).open = () => null;
     });
+    await page.goto("/collections/reading-list");
     await page.getByTestId("collections-url-link-url-anthropic-blog").click();
     // Detail panel is the modal-style overlay opened by the row click.
     // If `@click.stop` is missing, this would be visible.

--- a/server/events/notifications.ts
+++ b/server/events/notifications.ts
@@ -204,6 +204,18 @@ function buildNavigateTarget(target: NavigateTarget): string | undefined {
       return buildFilesTarget(target);
     case NOTIFICATION_VIEWS.wiki:
       return buildWikiTarget(target);
+    case NOTIFICATION_VIEWS.collections: {
+      // /collections/:slug?selected=<itemId> — the `?selected=` query
+      // param is the documented convention for deep-linking to a
+      // specific record (see `helps/collection-skills.md`). Dot-segment
+      // slug would normalize out of /collections, so fall back to the
+      // index; itemId is a query param so it doesn't participate in
+      // path normalization and doesn't need the same guard.
+      if (!isSafePathComponent(target.slug)) return `/${PAGE_ROUTES.collections}`;
+      const base = `/${PAGE_ROUTES.collections}/${encodeURIComponent(target.slug)}`;
+      if (!target.itemId) return base;
+      return `${base}?selected=${encodeURIComponent(target.itemId)}`;
+    }
     default:
       return undefined;
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,6 +30,7 @@ import configRefreshRoutes from "./api/routes/config-refresh.js";
 import hookLogRoutes from "./api/routes/hookLog.js";
 import skillsRoutes from "./api/routes/skills.js";
 import collectionsRoutes from "./api/routes/collections.js";
+import { startCollectionWatchers } from "./workspace/collections/watcher.js";
 import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 import { loadRuntimePlugins } from "./plugins/runtime-loader.js";
 import { evaluateDevPluginGate, loadDevPlugins, parseDevPluginsEnv } from "./plugins/dev-loader.js";
@@ -905,6 +906,18 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
   // missing one so a feature degrading is visible instead of a
   // later opaque crash. Never throws.
   await announceOptionalDeps();
+
+  // --- Collection completion watchers ---
+  // Mount `fs.watch` over every discovered collection's dataDir so
+  // schemas with `completionField` fire / clear bell notifications
+  // regardless of whether the record was written via REST or directly
+  // through the agent's Write tool. Runs a boot reconcile + sweep
+  // first to catch up changes that landed while the server was down.
+  // Errors are logged inside; fire-and-forget so a slow scan doesn't
+  // hold up the rest of boot.
+  startCollectionWatchers().catch((err: unknown) => {
+    log.warn("collections", "watcher boot failed", { error: String(err) });
+  });
 
   // --- Chat socket transport (Phase A of #268) ---
   chatService.attachSocket(httpServer);

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -199,6 +199,13 @@ const CollectionSchemaZ = z
     singleton: z.string().trim().min(1).optional(),
     fields: z.record(z.string(), FieldSpecSchema),
     actions: z.array(ActionSpecSchema).optional(),
+    // Completion-tracking pair: when both are set, item-create fires a
+    // notification that clears once `completionField` transitions into
+    // `completionDoneValues`. The two are bound together — declaring
+    // one without the other is a misconfiguration the cross-field
+    // refine below rejects.
+    completionField: z.string().trim().min(1).optional(),
+    completionDoneValues: z.array(z.string().trim().min(1)).min(1).optional(),
   })
   // The singleton value becomes a record id (and thus a `<id>.json`
   // filename), so it must satisfy the SAME `safeSlugName` rule the
@@ -223,6 +230,21 @@ const CollectionSchemaZ = z
   .refine((schema) => collectCurrencyFieldRefs(schema.fields).every((name) => CODE_FIELD_TYPES.has(schema.fields[name]?.type ?? "")), {
     message: "a money field's `currencyField` must name a top-level `string`, `text`, or `enum` field that holds the currency code",
     path: ["fields"],
+  })
+  // Completion-tracking pair must be declared together: declaring
+  // `completionField` without `completionDoneValues` (or vice-versa)
+  // is meaningless — the host would either never fire (no done values
+  // to compare against) or never clear (no field to read). Bound
+  // together so the misconfiguration fails loudly at load time.
+  .refine((schema) => (schema.completionField === undefined) === (schema.completionDoneValues === undefined), {
+    message: "schema `completionField` and `completionDoneValues` must be declared together (both set, or both omitted)",
+    path: ["completionField"],
+  })
+  // `completionField` must name a real top-level field — a typo would
+  // silently disable the notification mechanism otherwise.
+  .refine((schema) => schema.completionField === undefined || schema.fields[schema.completionField] !== undefined, {
+    message: "schema `completionField` must name a top-level field declared in `fields`",
+    path: ["completionField"],
   });
 
 interface LoadedCollection {

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -39,8 +39,8 @@ import {
 import { clear as notifierClear, listAll, publish as notifierPublish } from "../../notifier/engine.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
-import { loadCollection } from "./discovery.js";
-import { listItems, readItem } from "./io.js";
+import { loadCollection, type DiscoveryOptions } from "./discovery.js";
+import { listItems, readItem, type IoOptions } from "./io.js";
 import type { CollectionItem, CollectionSchema } from "./types.js";
 
 /** The legacy-id prefix every collection-completion bell entry carries.
@@ -160,15 +160,21 @@ export async function clearItemNotification(slug: string, itemId: string): Promi
 /** Reconcile one item to the desired bell state. Re-reads the record
  *  from disk so the decision is grounded in current truth, not in the
  *  event payload. Safe to call when the file is missing (delete path)
- *  — `readItem` returns null and we clear. */
-export async function reconcileItem(slug: string, schema: CollectionSchema, dataDir: string, itemId: string): Promise<void> {
+ *  — `readItem` returns null and we clear.
+ *
+ *  `ioOpts` flows into `readItem`'s workspace-containment check —
+ *  production callers (the watcher) pass nothing and rely on the live
+ *  `workspacePath`; tests pass `{ workspaceRoot: <tmpdir> }` so the
+ *  containment check accepts a fixture dataDir outside the real
+ *  workspace. */
+export async function reconcileItem(slug: string, schema: CollectionSchema, dataDir: string, itemId: string, ioOpts: IoOptions = {}): Promise<void> {
   if (!schema.completionField) {
     // Schema doesn't track completion — make sure no stale entry sticks
     // around from a previous schema state.
     await clearItemNotification(slug, itemId);
     return;
   }
-  const item = await readItem(dataDir, itemId);
+  const item = await readItem(dataDir, itemId, ioOpts);
   if (item === null) {
     await clearItemNotification(slug, itemId);
     return;
@@ -184,12 +190,14 @@ export async function reconcileItem(slug: string, schema: CollectionSchema, data
  *  reconcile it. Catches up changes that happened while the server was
  *  down — items added (need to publish), items marked done (need to
  *  clear), items deleted (covered by `sweepStaleActiveEntries` below,
- *  not this function — this only sees files that exist). */
-export async function reconcileAllItems(slug: string, schema: CollectionSchema, dataDir: string): Promise<void> {
+ *  not this function — this only sees files that exist).
+ *
+ *  See `reconcileItem` for the `ioOpts` test-seam rationale. */
+export async function reconcileAllItems(slug: string, schema: CollectionSchema, dataDir: string, ioOpts: IoOptions = {}): Promise<void> {
   if (!schema.completionField) return;
   let items: CollectionItem[];
   try {
-    items = await listItems(dataDir);
+    items = await listItems(dataDir, ioOpts);
   } catch (err) {
     log.warn("collections", "reconcile list failed", { slug, dataDir, error: errorMessage(err) });
     return;
@@ -198,7 +206,7 @@ export async function reconcileAllItems(slug: string, schema: CollectionSchema, 
   for (const item of items) {
     const raw = item[primaryKey];
     if (typeof raw !== "string" || raw.length === 0) continue;
-    await reconcileItem(slug, schema, dataDir, raw);
+    await reconcileItem(slug, schema, dataDir, raw, ioOpts);
   }
 }
 
@@ -207,8 +215,12 @@ export async function reconcileAllItems(slug: string, schema: CollectionSchema, 
  *  no longer tracks completion, or whose item is now done. Required to
  *  reverse-cover the cases `reconcileAllItems` misses (it only walks
  *  files that exist on disk; a bell entry whose file vanished would be
- *  invisible to it). */
-export async function sweepStaleActiveEntries(): Promise<void> {
+ *  invisible to it).
+ *
+ *  Accepts `DiscoveryOptions` so tests can point at a tmpdir workspace
+ *  without touching `~/mulmoclaude/`. Production callers pass nothing
+ *  and get the live workspace defaults. */
+export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Promise<void> {
   let entries;
   try {
     entries = await listAll();
@@ -222,12 +234,12 @@ export async function sweepStaleActiveEntries(): Promise<void> {
     if (!parsed) continue;
     const { slug, itemId } = parsed;
     try {
-      const collection = await loadCollection(slug);
+      const collection = await loadCollection(slug, opts);
       if (!collection || !collection.schema.completionField) {
         await notifierClear(entry.id);
         continue;
       }
-      const item = await readItem(collection.dataDir, itemId);
+      const item = await readItem(collection.dataDir, itemId, opts);
       if (item === null || itemIsDone(collection.schema, item)) {
         await notifierClear(entry.id);
       }

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -103,8 +103,16 @@ async function findActiveEntryIds(slug: string, itemId: string): Promise<string[
  *  fs.watch event, so a reconcileAllItems pass can race a watcher
  *  event for the SAME item. Without this lock, both code paths read
  *  `listAll` (which bypasses the engine's write queue), miss each
- *  other's in-flight publish, and produce duplicate entries. */
-const ensureLocks = new Map<string, Promise<void>>();
+ *  other's in-flight publish, and produce duplicate entries.
+ *
+ *  The map's value is a tiny wrapper rather than a bare Promise so
+ *  that the "is this still my lock?" check below is an object-
+ *  identity comparison, not a promise-identity comparison — clearer
+ *  for both humans and static analyzers reading the cleanup path. */
+interface EnsureLock {
+  promise: Promise<void>;
+}
+const ensureLocks = new Map<string, EnsureLock>();
 
 /** Idempotently ensure a bell entry exists for a still-pending item.
  *  No-op if an entry with this (slug, itemId)'s legacy id is already
@@ -129,14 +137,16 @@ async function ensureItemNotification(slug: string, schema: CollectionSchema, it
   while (true) {
     const inflight = ensureLocks.get(legacyId);
     if (!inflight) break;
-    await inflight;
+    await inflight.promise;
   }
-  const work = doEnsureItemNotification(slug, schema, itemId, legacyId);
-  ensureLocks.set(legacyId, work);
+  const lock: EnsureLock = { promise: doEnsureItemNotification(slug, schema, itemId, legacyId) };
+  ensureLocks.set(legacyId, lock);
   try {
-    await work;
+    await lock.promise;
   } finally {
-    if (ensureLocks.get(legacyId) === work) {
+    // Only clear the slot if it still points at OUR lock — a
+    // sufficiently-delayed cleanup must not stomp a later claim.
+    if (ensureLocks.get(legacyId) === lock) {
       ensureLocks.delete(legacyId);
     }
   }

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -1,0 +1,238 @@
+// Bell-notification side-channel for collections whose schema declares
+// `completionField`. Driven by `watcher.ts`, which calls into the
+// reconciler functions below on file-system events and on boot.
+//
+// The model is **convergent**: a watcher event re-reads the record from
+// disk and the reconciler enforces the invariant
+//
+//   bell entry exists for (slug, itemId)  ↔
+//     schema has completionField  ∧
+//     file exists  ∧
+//     `String(item[completionField])` ∉ completionDoneValues
+//
+// Each reconcile is idempotent (`ensure*` / `clear*` no-op when state
+// already matches). This is why event-type quirks of `fs.watch`
+// (`rename` vs `change`, missed events, atomic-write coalescence)
+// don't matter — every event re-derives the desired state from the
+// file, not from the event.
+//
+// Lookup uses the legacy publisher's caller-supplied `id` stashed on
+// `pluginData.legacyId`: every notification this module fires uses
+// a deterministic id derived from `<slug>:<itemId>`, so the clear path
+// and the dedup check can both find the entry without a side state
+// file.
+
+import {
+  NOTIFICATION_ACTION_TYPES,
+  NOTIFICATION_KINDS,
+  NOTIFICATION_PRIORITIES,
+  NOTIFICATION_VIEWS,
+  type NotificationAction,
+} from "../../../src/types/notification.js";
+import {
+  isLegacyNotifierPluginData,
+  legacyActionToNavigateTarget,
+  legacyKindToPluginPkg,
+  legacyPriorityToSeverity,
+  type LegacyNotifierPluginData,
+} from "../../events/notifications.js";
+import { clear as notifierClear, listAll, publish as notifierPublish } from "../../notifier/engine.js";
+import { log } from "../../system/logger/index.js";
+import { errorMessage } from "../../utils/errors.js";
+import { loadCollection } from "./discovery.js";
+import { listItems, readItem } from "./io.js";
+import type { CollectionItem, CollectionSchema } from "./types.js";
+
+/** The legacy-id prefix every collection-completion bell entry carries.
+ *  Used both to build new ids and to filter sweep candidates from the
+ *  active bell. Kept private so external callers can't depend on the
+ *  exact format. */
+const LEGACY_ID_PREFIX = "collection-completion:";
+
+/** Stable id encoding slug + item. Stashed on the bell entry's
+ *  `pluginData.legacyId` so we can find it later without a side state
+ *  file. Slug + itemId are upstream-validated via `safeSlugName`, which
+ *  forbids the colon separator, so the two-segment parse below is
+ *  unambiguous. */
+function completionLegacyId(slug: string, itemId: string): string {
+  return `${LEGACY_ID_PREFIX}${slug}:${itemId}`;
+}
+
+/** Decode a legacy id back into its (slug, itemId) pair, or null if the
+ *  string didn't originate from this module. Used by the sweep step. */
+function parseCompletionLegacyId(legacyId: string): { slug: string; itemId: string } | null {
+  if (!legacyId.startsWith(LEGACY_ID_PREFIX)) return null;
+  const body = legacyId.slice(LEGACY_ID_PREFIX.length);
+  const colon = body.indexOf(":");
+  if (colon < 0) return null;
+  return { slug: body.slice(0, colon), itemId: body.slice(colon + 1) };
+}
+
+/** True iff the schema declares completion tracking AND the item's
+ *  `completionField` value (stringified) is in `completionDoneValues`.
+ *  Returns false when tracking is disabled. */
+export function itemIsDone(schema: CollectionSchema, item: CollectionItem): boolean {
+  const { completionField, completionDoneValues } = schema;
+  if (!completionField || !completionDoneValues) return false;
+  const raw = item[completionField];
+  if (raw === undefined || raw === null) return false;
+  return completionDoneValues.includes(String(raw));
+}
+
+/** Every active bell entry whose legacy id matches this (slug, itemId).
+ *  Returns multiple ids when defensive cleanup is needed — a race in
+ *  rapid-fire fs.watch events (now closed by single-flighting in
+ *  watcher.ts + awaiting publish below) historically produced
+ *  duplicate entries, and the clear path needs to drain them all.
+ *  Scans `listAll()` — cheap because the active set is bounded. */
+async function findActiveEntryIds(slug: string, itemId: string): Promise<string[]> {
+  const legacyId = completionLegacyId(slug, itemId);
+  const entries = await listAll();
+  return entries.filter((entry) => isLegacyNotifierPluginData(entry.pluginData) && entry.pluginData.legacyId === legacyId).map((entry) => entry.id);
+}
+
+/** Idempotently ensure a bell entry exists for a still-pending item.
+ *  No-op if an entry with this (slug, itemId)'s legacy id is already
+ *  active.
+ *
+ *  Awaits the engine's `publish` directly (rather than going through
+ *  the fire-and-forget `publishNotification` wrapper) so the next
+ *  `findActiveEntryIds` call on the same key sees the committed
+ *  entry. The wrapper enqueues and returns immediately, which let
+ *  a concurrent reconcile read stale state and publish a duplicate
+ *  — see the rapid-fire fs.watch race that motivated this rewrite.
+ *
+ *  The `pluginData` shape matches what the wrapper would have built
+ *  (`LegacyNotifierPluginData`), so the bell preserves icon / dedup
+ *  semantics and `findActiveEntryIds` keeps working. */
+async function ensureItemNotification(slug: string, schema: CollectionSchema, itemId: string): Promise<void> {
+  try {
+    const existing = await findActiveEntryIds(slug, itemId);
+    if (existing.length > 0) return;
+    const legacyId = completionLegacyId(slug, itemId);
+    const action: NotificationAction = {
+      type: NOTIFICATION_ACTION_TYPES.navigate,
+      target: { view: NOTIFICATION_VIEWS.collections, slug, itemId },
+    };
+    const pluginData: LegacyNotifierPluginData = {
+      legacy: true,
+      legacyId,
+      kind: NOTIFICATION_KINDS.todo,
+      priority: NOTIFICATION_PRIORITIES.normal,
+      action,
+    };
+    // `lifecycle: "action"` — these are state-of-the-world entries
+    // mirroring an outstanding obligation (the item is pending), not
+    // transient pings. The bell surfaces action entries more
+    // prominently and they stay until the obligation resolves, which
+    // is exactly the contract our reconciler enforces. Validation
+    // requires a non-info severity (we use "nudge") and a non-empty
+    // `navigateTarget` (the slug + itemId deep-link below satisfies it).
+    await notifierPublish({
+      pluginPkg: legacyKindToPluginPkg(NOTIFICATION_KINDS.todo),
+      severity: legacyPriorityToSeverity(NOTIFICATION_PRIORITIES.normal),
+      lifecycle: "action",
+      title: `${schema.title}: ${itemId}`,
+      navigateTarget: legacyActionToNavigateTarget(action),
+      pluginData,
+    });
+  } catch (err) {
+    log.warn("collections", "notify ensure failed", { slug, itemId, error: errorMessage(err) });
+  }
+}
+
+/** Idempotently clear EVERY bell entry that matches this
+ *  (slug, itemId). Silent no-op when nothing matches. The "every" is
+ *  defensive: with the single-flighting + awaited publish in place,
+ *  duplicates shouldn't appear, but if one ever slips through this
+ *  call drains the lot rather than leaving a stuck entry. */
+export async function clearItemNotification(slug: string, itemId: string): Promise<void> {
+  try {
+    const ids = await findActiveEntryIds(slug, itemId);
+    for (const entryId of ids) {
+      await notifierClear(entryId);
+    }
+  } catch (err) {
+    log.warn("collections", "notify clear failed", { slug, itemId, error: errorMessage(err) });
+  }
+}
+
+/** Reconcile one item to the desired bell state. Re-reads the record
+ *  from disk so the decision is grounded in current truth, not in the
+ *  event payload. Safe to call when the file is missing (delete path)
+ *  — `readItem` returns null and we clear. */
+export async function reconcileItem(slug: string, schema: CollectionSchema, dataDir: string, itemId: string): Promise<void> {
+  if (!schema.completionField) {
+    // Schema doesn't track completion — make sure no stale entry sticks
+    // around from a previous schema state.
+    await clearItemNotification(slug, itemId);
+    return;
+  }
+  const item = await readItem(dataDir, itemId);
+  if (item === null) {
+    await clearItemNotification(slug, itemId);
+    return;
+  }
+  if (itemIsDone(schema, item)) {
+    await clearItemNotification(slug, itemId);
+    return;
+  }
+  await ensureItemNotification(slug, schema, itemId);
+}
+
+/** Boot-time reconcile: walk every record under `dataDir` once and
+ *  reconcile it. Catches up changes that happened while the server was
+ *  down — items added (need to publish), items marked done (need to
+ *  clear), items deleted (covered by `sweepStaleActiveEntries` below,
+ *  not this function — this only sees files that exist). */
+export async function reconcileAllItems(slug: string, schema: CollectionSchema, dataDir: string): Promise<void> {
+  if (!schema.completionField) return;
+  let items: CollectionItem[];
+  try {
+    items = await listItems(dataDir);
+  } catch (err) {
+    log.warn("collections", "reconcile list failed", { slug, dataDir, error: errorMessage(err) });
+    return;
+  }
+  const { primaryKey } = schema;
+  for (const item of items) {
+    const raw = item[primaryKey];
+    if (typeof raw !== "string" || raw.length === 0) continue;
+    await reconcileItem(slug, schema, dataDir, raw);
+  }
+}
+
+/** Boot-time sweep over the active bell: drop any entries whose
+ *  underlying file is gone, whose collection was deleted, whose schema
+ *  no longer tracks completion, or whose item is now done. Required to
+ *  reverse-cover the cases `reconcileAllItems` misses (it only walks
+ *  files that exist on disk; a bell entry whose file vanished would be
+ *  invisible to it). */
+export async function sweepStaleActiveEntries(): Promise<void> {
+  let entries;
+  try {
+    entries = await listAll();
+  } catch (err) {
+    log.warn("collections", "sweep list failed", { error: errorMessage(err) });
+    return;
+  }
+  for (const entry of entries) {
+    if (!isLegacyNotifierPluginData(entry.pluginData)) continue;
+    const parsed = parseCompletionLegacyId(entry.pluginData.legacyId);
+    if (!parsed) continue;
+    const { slug, itemId } = parsed;
+    try {
+      const collection = await loadCollection(slug);
+      if (!collection || !collection.schema.completionField) {
+        await notifierClear(entry.id);
+        continue;
+      }
+      const item = await readItem(collection.dataDir, itemId);
+      if (item === null || itemIsDone(collection.schema, item)) {
+        await notifierClear(entry.id);
+      }
+    } catch (err) {
+      log.warn("collections", "sweep entry failed", { slug, itemId, error: errorMessage(err) });
+    }
+  }
+}

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -91,6 +91,21 @@ async function findActiveEntryIds(slug: string, itemId: string): Promise<string[
   return entries.filter((entry) => isLegacyNotifierPluginData(entry.pluginData) && entry.pluginData.legacyId === legacyId).map((entry) => entry.id);
 }
 
+/** Per-legacyId in-flight lock. Serializes concurrent
+ *  `ensureItemNotification` calls for the same (slug, itemId) so the
+ *  `findActiveEntryIds → publish` check stays atomic across callers
+ *  — not just across watcher events.
+ *
+ *  Why this matters: the watcher's `scheduleItemReconcile` single-
+ *  flights events from `fs.watch`, but reconciles can ALSO reach
+ *  `ensureItemNotification` from `reconcileAllItems` (boot + schema-
+ *  change). On macOS, `readdir` on a watched dir can itself fire an
+ *  fs.watch event, so a reconcileAllItems pass can race a watcher
+ *  event for the SAME item. Without this lock, both code paths read
+ *  `listAll` (which bypasses the engine's write queue), miss each
+ *  other's in-flight publish, and produce duplicate entries. */
+const ensureLocks = new Map<string, Promise<void>>();
+
 /** Idempotently ensure a bell entry exists for a still-pending item.
  *  No-op if an entry with this (slug, itemId)'s legacy id is already
  *  active.
@@ -106,10 +121,31 @@ async function findActiveEntryIds(slug: string, itemId: string): Promise<string[
  *  (`LegacyNotifierPluginData`), so the bell preserves icon / dedup
  *  semantics and `findActiveEntryIds` keeps working. */
 async function ensureItemNotification(slug: string, schema: CollectionSchema, itemId: string): Promise<void> {
+  const legacyId = completionLegacyId(slug, itemId);
+  // Drain any in-flight publish for this key BEFORE our check + set.
+  // The drain + claim runs synchronously between the loop's
+  // `ensureLocks.get` and `ensureLocks.set` calls below, so two
+  // callers can't both observe an empty slot and both claim it.
+  while (true) {
+    const inflight = ensureLocks.get(legacyId);
+    if (!inflight) break;
+    await inflight;
+  }
+  const work = doEnsureItemNotification(slug, schema, itemId, legacyId);
+  ensureLocks.set(legacyId, work);
+  try {
+    await work;
+  } finally {
+    if (ensureLocks.get(legacyId) === work) {
+      ensureLocks.delete(legacyId);
+    }
+  }
+}
+
+async function doEnsureItemNotification(slug: string, schema: CollectionSchema, itemId: string, legacyId: string): Promise<void> {
   try {
     const existing = await findActiveEntryIds(slug, itemId);
     if (existing.length > 0) return;
-    const legacyId = completionLegacyId(slug, itemId);
     const action: NotificationAction = {
       type: NOTIFICATION_ACTION_TYPES.navigate,
       target: { view: NOTIFICATION_VIEWS.collections, slug, itemId },

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -156,6 +156,15 @@ export interface CollectionSchema {
   /** Optional per-record actions rendered as buttons in the detail
    *  view (e.g. "Generate PDF"). Order = button order. */
   actions?: CollectionAction[];
+  /** Name of the field whose value marks an item as "done". When set,
+   *  a notification fires on item create (unless the item is born done)
+   *  and clears when the field's value transitions into
+   *  `completionDoneValues`. Must name a real field in `fields`. */
+  completionField?: string;
+  /** The set of values for `completionField` that count as "done"
+   *  (e.g. `["Done"]` for a todo status field, `["paid"]` for an
+   *  invoice). Non-empty. Compared as strings. */
+  completionDoneValues?: readonly string[];
 }
 
 export interface CollectionSummary {

--- a/server/workspace/collections/watcher.ts
+++ b/server/workspace/collections/watcher.ts
@@ -83,26 +83,37 @@ export interface CollectionWatcherOptions {
  *  re-init paths can call it freely. */
 export async function startCollectionWatchers(opts: CollectionWatcherOptions = {}): Promise<void> {
   if (started) return;
-  started = true;
+  // `started` only flips on AFTER boot finishes. If sweep or
+  // syncWatchers throws mid-boot, an earlier latch-then-await pattern
+  // would leave the flag stuck at `true`, permanently disabling
+  // subsequent boot attempts until process restart. Reset state on
+  // failure so a supervisor / test harness can retry.
   discoveryOpts = opts.discoveryOpts ?? {};
-  // Boot reconcile is split in two: sweep first (drop bell entries
-  // whose files / collections / schemas vanished while the server was
-  // down), then `syncWatchers` runs the per-collection forward fill
-  // (publish for items added during downtime). Order matters only
-  // weakly — sweep's clears can race the forward fill's publishes,
-  // but both paths are idempotent and converge on the same end state.
-  await sweepStaleActiveEntries(discoveryOpts);
-  await syncWatchers();
-  const intervalMs = opts.rediscoveryIntervalMs === undefined ? REDISCOVERY_INTERVAL_MS : opts.rediscoveryIntervalMs;
-  if (intervalMs !== null) {
-    rediscoveryTimer = setInterval(() => {
-      syncWatchers().catch((err: unknown) => {
-        log.warn("collections", "watcher rediscovery failed", { error: errorMessage(err) });
-      });
-    }, intervalMs);
-    // `unref` on the timer so a clean process exit isn't blocked
-    // waiting for the next tick.
-    rediscoveryTimer.unref();
+  try {
+    // Boot reconcile is split in two: sweep first (drop bell entries
+    // whose files / collections / schemas vanished while the server
+    // was down), then `syncWatchers` runs the per-collection forward
+    // fill (publish for items added during downtime). Order matters
+    // only weakly — sweep's clears can race the forward fill's
+    // publishes, but both paths are idempotent and converge on the
+    // same end state.
+    await sweepStaleActiveEntries(discoveryOpts);
+    await syncWatchers();
+    const intervalMs = opts.rediscoveryIntervalMs === undefined ? REDISCOVERY_INTERVAL_MS : opts.rediscoveryIntervalMs;
+    if (intervalMs !== null) {
+      rediscoveryTimer = setInterval(() => {
+        syncWatchers().catch((err: unknown) => {
+          log.warn("collections", "watcher rediscovery failed", { error: errorMessage(err) });
+        });
+      }, intervalMs);
+      // `unref` on the timer so a clean process exit isn't blocked
+      // waiting for the next tick.
+      rediscoveryTimer.unref();
+    }
+    started = true;
+  } catch (err) {
+    discoveryOpts = {};
+    throw err;
   }
 }
 
@@ -308,7 +319,15 @@ async function onEvent(slug: string, filename: string | Buffer | null): Promise<
   const collection = await loadCollection(slug, discoveryOpts);
   if (!collection) return;
   if (filename === null) {
+    // Some platforms (older Linux kernels, certain network mounts)
+    // omit the filename on a watch event — we don't know which record
+    // changed. `reconcileAllItems` covers items whose file still
+    // exists; pair it with a sweep so any record deleted inside the
+    // same opaque event has its stale bell entry cleared too. Without
+    // the sweep, a delete that fires with filename === null would
+    // persist as a phantom entry until the next rediscovery tick.
     await reconcileAllItems(slug, collection.schema, collection.dataDir, discoveryOpts);
+    await sweepStaleActiveEntries(discoveryOpts);
     return;
   }
   const name = typeof filename === "string" ? filename : filename.toString("utf-8");

--- a/server/workspace/collections/watcher.ts
+++ b/server/workspace/collections/watcher.ts
@@ -24,7 +24,7 @@ import { mkdir } from "node:fs/promises";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import { ONE_SECOND_MS } from "../../utils/time.js";
-import { discoverCollections, loadCollection, type LoadedCollection } from "./discovery.js";
+import { discoverCollections, loadCollection, type DiscoveryOptions, type LoadedCollection } from "./discovery.js";
 import { reconcileAllItems, reconcileItem, sweepStaleActiveEntries } from "./notifications.js";
 
 // Collections don't get added / removed rapidly; 30 s is a comfortable
@@ -49,30 +49,61 @@ interface CollectionWatcher {
 const watchers = new Map<string, CollectionWatcher>();
 let rediscoveryTimer: ReturnType<typeof setInterval> | null = null;
 let started = false;
+/** Discovery options threaded into every `discoverCollections` /
+ *  `loadCollection` / `sweepStaleActiveEntries` call this module
+ *  makes. Production: empty (live workspace). Tests:
+ *  `{ workspaceRoot, userSkillsDir }` pointing at a `mkdtempSync`
+ *  tree. Stored at module level so per-event handlers can read it
+ *  without threading through every signature. */
+let discoveryOpts: DiscoveryOptions = {};
+
+/** Per-key single-flight slot. Declared here (before
+ *  `stopCollectionWatchers`, which needs to clear it during teardown)
+ *  rather than next to `scheduleItemReconcile` below; the consumer is
+ *  documented at that call site. */
+interface ReconcileSlot {
+  running: Promise<void>;
+  pending: boolean;
+}
+const itemSlots = new Map<string, ReconcileSlot>();
+
+/** Test-only configuration knobs. Production callers pass nothing and
+ *  get the live workspace defaults; tests pass a tmpdir-rooted
+ *  `discoveryOpts` so the watcher reads schemas from the test fixture,
+ *  and override `rediscoveryIntervalMs` (or set it to `null` to
+ *  disable the auto-tick entirely so the test drives sync manually). */
+export interface CollectionWatcherOptions {
+  discoveryOpts?: DiscoveryOptions;
+  rediscoveryIntervalMs?: number | null;
+}
 
 /** Boot entry point: sweep stale active entries, then mount watchers
  *  for every discovered collection and arm the periodic re-discovery
  *  poll. Idempotent — a second call is a no-op so test harnesses and
  *  re-init paths can call it freely. */
-export async function startCollectionWatchers(): Promise<void> {
+export async function startCollectionWatchers(opts: CollectionWatcherOptions = {}): Promise<void> {
   if (started) return;
   started = true;
+  discoveryOpts = opts.discoveryOpts ?? {};
   // Boot reconcile is split in two: sweep first (drop bell entries
   // whose files / collections / schemas vanished while the server was
   // down), then `syncWatchers` runs the per-collection forward fill
   // (publish for items added during downtime). Order matters only
   // weakly — sweep's clears can race the forward fill's publishes,
   // but both paths are idempotent and converge on the same end state.
-  await sweepStaleActiveEntries();
+  await sweepStaleActiveEntries(discoveryOpts);
   await syncWatchers();
-  rediscoveryTimer = setInterval(() => {
-    syncWatchers().catch((err: unknown) => {
-      log.warn("collections", "watcher rediscovery failed", { error: errorMessage(err) });
-    });
-  }, REDISCOVERY_INTERVAL_MS);
-  // `unref` on the timer so a clean process exit isn't blocked
-  // waiting for the next tick.
-  rediscoveryTimer.unref();
+  const intervalMs = opts.rediscoveryIntervalMs === undefined ? REDISCOVERY_INTERVAL_MS : opts.rediscoveryIntervalMs;
+  if (intervalMs !== null) {
+    rediscoveryTimer = setInterval(() => {
+      syncWatchers().catch((err: unknown) => {
+        log.warn("collections", "watcher rediscovery failed", { error: errorMessage(err) });
+      });
+    }, intervalMs);
+    // `unref` on the timer so a clean process exit isn't blocked
+    // waiting for the next tick.
+    rediscoveryTimer.unref();
+  }
 }
 
 /** Tear down every watcher and stop the rediscovery interval. Used by
@@ -91,7 +122,17 @@ export async function stopCollectionWatchers(): Promise<void> {
     }
   }
   watchers.clear();
+  itemSlots.clear();
+  discoveryOpts = {};
   started = false;
+}
+
+/** Test-only: manually trigger one rediscovery + reconcile pass. Lets
+ *  tests drive the syncWatchers flow synchronously instead of waiting
+ *  for the auto-tick (which they disable via
+ *  `rediscoveryIntervalMs: null` in `startCollectionWatchers`). */
+export async function _syncWatchersForTesting(): Promise<void> {
+  await syncWatchers();
 }
 
 /** Reconcile the watcher set against the currently-discovered
@@ -111,7 +152,7 @@ export async function stopCollectionWatchers(): Promise<void> {
 async function syncWatchers(): Promise<void> {
   let collections;
   try {
-    collections = await discoverCollections();
+    collections = await discoverCollections(discoveryOpts);
   } catch (err) {
     log.warn("collections", "watcher discover failed", { error: errorMessage(err) });
     return;
@@ -129,7 +170,7 @@ async function syncWatchers(): Promise<void> {
   // entries). Bounded by the active set size; only runs when this
   // tick actually changed something.
   if (vanishedMutated || schemaMutated || addedMutated) {
-    await sweepStaleActiveEntries();
+    await sweepStaleActiveEntries(discoveryOpts);
   }
 }
 
@@ -165,7 +206,7 @@ async function reconcileChangedSchemas(collections: readonly LoadedCollection[])
     if (existing.schemaJson === nextJson) continue;
     existing.schemaJson = nextJson;
     log.info("collections", "watcher schema changed, re-reconciling", { slug: collection.slug });
-    await reconcileAllItems(collection.slug, collection.schema, collection.dataDir);
+    await reconcileAllItems(collection.slug, collection.schema, collection.dataDir, discoveryOpts);
     mutated = true;
   }
   return mutated;
@@ -190,7 +231,7 @@ async function startWatcherFor(slug: string, schema: import("./types.js").Collec
     // Boot reconcile this collection's existing items BEFORE mounting
     // the watcher: a pending item the user added during downtime
     // needs to get its bell entry even if no event fires today.
-    await reconcileAllItems(slug, schema, dataDir);
+    await reconcileAllItems(slug, schema, dataDir, discoveryOpts);
     const watcher = watch(dataDir, { persistent: false }, (_eventType, filename) => {
       // Errors from inside the callback would propagate as unhandled
       // rejections — wrap so a single bad event can't unwind the
@@ -209,7 +250,12 @@ async function startWatcherFor(slug: string, schema: import("./types.js").Collec
   }
 }
 
-/** Per-key single-flight slot. While a reconcile is in flight for a
+/** Test-only: the per-key single-flight scheduler. Exported via the
+ *  `_` prefix so test code can drive rapid-fire calls directly and
+ *  observe the trailing coalesce — `fs.watch` event timing is too
+ *  flaky to assert against.
+ *
+ *  Single-flight semantics: while a reconcile is in flight for a
  *  given (slug, itemId), additional events on the same key set
  *  `pending = true` and return — the running reconcile re-runs once
  *  after it completes, capturing any state change that happened during
@@ -218,11 +264,9 @@ async function startWatcherFor(slug: string, schema: import("./types.js").Collec
  *  single reconcile + one trailing re-run, preventing concurrent
  *  reads of `active.json` from racing the engine's write queue and
  *  producing duplicate publishes. */
-interface ReconcileSlot {
-  running: Promise<void>;
-  pending: boolean;
+export function _scheduleItemReconcileForTesting(slug: string, schema: import("./types.js").CollectionSchema, dataDir: string, itemId: string): Promise<void> {
+  return scheduleItemReconcile(slug, schema, dataDir, itemId);
 }
-const itemSlots = new Map<string, ReconcileSlot>();
 
 function scheduleItemReconcile(slug: string, schema: import("./types.js").CollectionSchema, dataDir: string, itemId: string): Promise<void> {
   const key = `${slug}\x00${itemId}`;
@@ -244,7 +288,7 @@ function scheduleItemReconcile(slug: string, schema: import("./types.js").Collec
       let keepGoing = true;
       while (keepGoing) {
         slot.pending = false;
-        await reconcileItem(slug, schema, dataDir, itemId);
+        await reconcileItem(slug, schema, dataDir, itemId, discoveryOpts);
         keepGoing = slot.pending;
       }
     } finally {
@@ -261,10 +305,10 @@ function scheduleItemReconcile(slug: string, schema: import("./types.js").Collec
  *  (rare, platform-specific) triggers a full directory rescan to be
  *  safe. */
 async function onEvent(slug: string, filename: string | Buffer | null): Promise<void> {
-  const collection = await loadCollection(slug);
+  const collection = await loadCollection(slug, discoveryOpts);
   if (!collection) return;
   if (filename === null) {
-    await reconcileAllItems(slug, collection.schema, collection.dataDir);
+    await reconcileAllItems(slug, collection.schema, collection.dataDir, discoveryOpts);
     return;
   }
   const name = typeof filename === "string" ? filename : filename.toString("utf-8");

--- a/server/workspace/collections/watcher.ts
+++ b/server/workspace/collections/watcher.ts
@@ -1,0 +1,221 @@
+// Filesystem watchers that drive collection-completion bell
+// notifications. One `fs.watch` per discovered collection's `dataDir`,
+// fanned out from a single boot call + a 30-second re-discovery
+// interval that catches newly-created / deleted collections (there is
+// no in-process "collections changed" event broadcast).
+//
+// Why a watcher, not just route hooks: the canonical pattern for
+// collection-skills (see `helps/collection-skills.md`) has the agent
+// Write records directly with the Write tool — that path never hits
+// the REST API, so a route-level hook would miss most of the traffic
+// the user actually generates. The watcher catches every mutation
+// regardless of who wrote the file.
+//
+// All decisions live in `notifications.ts`; this module is pure
+// plumbing: discover, mkdir, fs.watch, debounce-not-yet, forward
+// events into the reconciler. Every reconcile call is idempotent so
+// fs.watch's well-known quirks (`rename` vs `change`, atomic-write
+// coalescence, filename === null on some platforms) don't need
+// special handling — re-deriving state from the file on every event
+// is the contract.
+
+import { watch, type FSWatcher } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { log } from "../../system/logger/index.js";
+import { errorMessage } from "../../utils/errors.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
+import { discoverCollections, loadCollection } from "./discovery.js";
+import { reconcileAllItems, reconcileItem, sweepStaleActiveEntries } from "./notifications.js";
+
+// Collections don't get added / removed rapidly; 30 s is a comfortable
+// upper bound on how long a new schema can sit before its watcher is
+// up. Cheap to run — `discoverCollections` reads a handful of
+// `schema.json` files per scope.
+const REDISCOVERY_INTERVAL_MS = 30 * ONE_SECOND_MS;
+
+interface CollectionWatcher {
+  slug: string;
+  dataDir: string;
+  watcher: FSWatcher;
+}
+
+const watchers = new Map<string, CollectionWatcher>();
+let rediscoveryTimer: ReturnType<typeof setInterval> | null = null;
+let started = false;
+
+/** Boot entry point: sweep stale active entries, then mount watchers
+ *  for every discovered collection and arm the periodic re-discovery
+ *  poll. Idempotent — a second call is a no-op so test harnesses and
+ *  re-init paths can call it freely. */
+export async function startCollectionWatchers(): Promise<void> {
+  if (started) return;
+  started = true;
+  // Boot reconcile is split in two: sweep first (drop bell entries
+  // whose files / collections / schemas vanished while the server was
+  // down), then `syncWatchers` runs the per-collection forward fill
+  // (publish for items added during downtime). Order matters only
+  // weakly — sweep's clears can race the forward fill's publishes,
+  // but both paths are idempotent and converge on the same end state.
+  await sweepStaleActiveEntries();
+  await syncWatchers();
+  rediscoveryTimer = setInterval(() => {
+    syncWatchers().catch((err: unknown) => {
+      log.warn("collections", "watcher rediscovery failed", { error: errorMessage(err) });
+    });
+  }, REDISCOVERY_INTERVAL_MS);
+  // `unref` on the timer so a clean process exit isn't blocked
+  // waiting for the next tick.
+  rediscoveryTimer.unref();
+}
+
+/** Tear down every watcher and stop the rediscovery interval. Used by
+ *  tests; production never calls this (process exit reclaims the fds).
+ *  Resets `started` so a subsequent `startCollectionWatchers` re-mounts. */
+export async function stopCollectionWatchers(): Promise<void> {
+  if (rediscoveryTimer) {
+    clearInterval(rediscoveryTimer);
+    rediscoveryTimer = null;
+  }
+  for (const watcher of watchers.values()) {
+    try {
+      watcher.watcher.close();
+    } catch {
+      /* fs.watch close is best-effort */
+    }
+  }
+  watchers.clear();
+  started = false;
+}
+
+/** Reconcile the watcher set against the currently-discovered
+ *  collections. Adds watchers for newly-appeared slugs (including a
+ *  boot reconcile of their existing items), drops watchers for slugs
+ *  that no longer exist. Called once on start + every
+ *  `REDISCOVERY_INTERVAL_MS`. */
+async function syncWatchers(): Promise<void> {
+  let collections;
+  try {
+    collections = await discoverCollections();
+  } catch (err) {
+    log.warn("collections", "watcher discover failed", { error: errorMessage(err) });
+    return;
+  }
+  const liveSlugs = new Set(collections.map((collection) => collection.slug));
+  // Stop watchers for vanished collections — their bell entries get
+  // dropped on the next sweep, but the immediate concern here is to
+  // free the fd and stop forwarding events for a dead slug.
+  for (const slug of [...watchers.keys()]) {
+    if (liveSlugs.has(slug)) continue;
+    const watcher = watchers.get(slug);
+    if (watcher) {
+      try {
+        watcher.watcher.close();
+      } catch {
+        /* best-effort */
+      }
+    }
+    watchers.delete(slug);
+    log.info("collections", "watcher stopped", { slug });
+  }
+  // Start watchers for newly-appeared collections.
+  for (const collection of collections) {
+    if (watchers.has(collection.slug)) continue;
+    await startWatcherFor(collection.slug, collection.schema, collection.dataDir);
+  }
+}
+
+async function startWatcherFor(slug: string, schema: import("./types.js").CollectionSchema, dataDir: string): Promise<void> {
+  try {
+    // `fs.watch` throws on a missing dir, so ensure it exists. New
+    // collections legitimately start with no records — mkdir is the
+    // canonical first-use bootstrap.
+    await mkdir(dataDir, { recursive: true });
+    // Boot reconcile this collection's existing items BEFORE mounting
+    // the watcher: a pending item the user added during downtime
+    // needs to get its bell entry even if no event fires today.
+    await reconcileAllItems(slug, schema, dataDir);
+    const watcher = watch(dataDir, { persistent: false }, (_eventType, filename) => {
+      // Errors from inside the callback would propagate as unhandled
+      // rejections — wrap so a single bad event can't unwind the
+      // watcher.
+      onEvent(slug, filename).catch((err: unknown) => {
+        log.warn("collections", "watcher event failed", { slug, filename, error: errorMessage(err) });
+      });
+    });
+    watcher.on("error", (err) => {
+      log.warn("collections", "watcher error", { slug, error: errorMessage(err) });
+    });
+    watchers.set(slug, { slug, dataDir, watcher });
+    log.info("collections", "watcher started", { slug, dataDir });
+  } catch (err) {
+    log.warn("collections", "watcher start failed", { slug, error: errorMessage(err) });
+  }
+}
+
+/** Per-key single-flight slot. While a reconcile is in flight for a
+ *  given (slug, itemId), additional events on the same key set
+ *  `pending = true` and return — the running reconcile re-runs once
+ *  after it completes, capturing any state change that happened during
+ *  execution. This collapses fs.watch's well-known rapid-fire bursts
+ *  (atomic rename surfaces as 2-3 events on most platforms) into a
+ *  single reconcile + one trailing re-run, preventing concurrent
+ *  reads of `active.json` from racing the engine's write queue and
+ *  producing duplicate publishes. */
+interface ReconcileSlot {
+  running: Promise<void>;
+  pending: boolean;
+}
+const itemSlots = new Map<string, ReconcileSlot>();
+
+function scheduleItemReconcile(slug: string, schema: import("./types.js").CollectionSchema, dataDir: string, itemId: string): Promise<void> {
+  const key = `${slug}\x00${itemId}`;
+  const existing = itemSlots.get(key);
+  if (existing) {
+    existing.pending = true;
+    return existing.running;
+  }
+  const slot: ReconcileSlot = { running: Promise.resolve(), pending: false };
+  slot.running = (async () => {
+    try {
+      // Re-run while events keep arriving — the trailing re-run
+      // captures any state change that landed during a prior pass.
+      // After each pass we read `pending` and zero it before the next
+      // iteration, so an event that fires *during* the last
+      // reconcile's await still triggers one more pass before the
+      // slot is freed. Loop guarded by the `if (!slot.pending) break`
+      // check so the lint rule's `while(true)` ban doesn't trip.
+      let keepGoing = true;
+      while (keepGoing) {
+        slot.pending = false;
+        await reconcileItem(slug, schema, dataDir, itemId);
+        keepGoing = slot.pending;
+      }
+    } finally {
+      itemSlots.delete(key);
+    }
+  })();
+  itemSlots.set(key, slot);
+  return slot.running;
+}
+
+/** Handle a single fs.watch event. Re-loads the collection (schema may
+ *  have changed since startup), filters out non-record files, and
+ *  forwards to the single-flighted reconciler. `filename === null`
+ *  (rare, platform-specific) triggers a full directory rescan to be
+ *  safe. */
+async function onEvent(slug: string, filename: string | Buffer | null): Promise<void> {
+  const collection = await loadCollection(slug);
+  if (!collection) return;
+  if (filename === null) {
+    await reconcileAllItems(slug, collection.schema, collection.dataDir);
+    return;
+  }
+  const name = typeof filename === "string" ? filename : filename.toString("utf-8");
+  // Filter: only record files (`*.json`), skip dot-prefixed (atomic
+  // writes / OS metadata / editor swap files). The reconciler is
+  // idempotent so a stray non-record event would be harmless, but
+  // skipping early avoids needless I/O.
+  if (!name.endsWith(".json") || name.startsWith(".")) return;
+  const itemId = name.slice(0, -".json".length);
+  await scheduleItemReconcile(slug, collection.schema, collection.dataDir, itemId);
+}

--- a/server/workspace/collections/watcher.ts
+++ b/server/workspace/collections/watcher.ts
@@ -24,7 +24,7 @@ import { mkdir } from "node:fs/promises";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import { ONE_SECOND_MS } from "../../utils/time.js";
-import { discoverCollections, loadCollection } from "./discovery.js";
+import { discoverCollections, loadCollection, type LoadedCollection } from "./discovery.js";
 import { reconcileAllItems, reconcileItem, sweepStaleActiveEntries } from "./notifications.js";
 
 // Collections don't get added / removed rapidly; 30 s is a comfortable
@@ -37,6 +37,13 @@ interface CollectionWatcher {
   slug: string;
   dataDir: string;
   watcher: FSWatcher;
+  /** Last-seen serialized schema for change detection. When a
+   *  rediscovery tick observes a different value, the watcher's items
+   *  are reconciled and the cache is refreshed — this catches
+   *  schema-only edits (e.g. flipping `completionField` on or off)
+   *  that don't touch any record file and would otherwise leave bell
+   *  state stale indefinitely. */
+  schemaJson: string;
 }
 
 const watchers = new Map<string, CollectionWatcher>();
@@ -90,8 +97,17 @@ export async function stopCollectionWatchers(): Promise<void> {
 /** Reconcile the watcher set against the currently-discovered
  *  collections. Adds watchers for newly-appeared slugs (including a
  *  boot reconcile of their existing items), drops watchers for slugs
- *  that no longer exist. Called once on start + every
- *  `REDISCOVERY_INTERVAL_MS`. */
+ *  that no longer exist, and re-reconciles items for collections
+ *  whose schema changed since the last tick. Called once on start +
+ *  every `REDISCOVERY_INTERVAL_MS`.
+ *
+ *  When the watcher set or any schema changed in this tick, runs
+ *  `sweepStaleActiveEntries()` at the end to drop bell entries that
+ *  no longer have a backing collection / schema / file. Without this
+ *  sweep, a collection deleted at runtime would leak its entries
+ *  until process restart, and a schema with `completionField` flipped
+ *  off would keep its old entries indefinitely — both cases the boot
+ *  sweep alone wouldn't catch. */
 async function syncWatchers(): Promise<void> {
   let collections;
   try {
@@ -101,9 +117,24 @@ async function syncWatchers(): Promise<void> {
     return;
   }
   const liveSlugs = new Set(collections.map((collection) => collection.slug));
-  // Stop watchers for vanished collections — their bell entries get
-  // dropped on the next sweep, but the immediate concern here is to
-  // free the fd and stop forwarding events for a dead slug.
+  // The three passes below are split into helpers so this function
+  // stays under the `sonarjs/cognitive-complexity` threshold; each
+  // returns a boolean for whether it mutated state, OR-ed into a
+  // single `mutated` flag that gates the end-of-tick sweep.
+  const vanishedMutated = stopVanishedWatchers(liveSlugs);
+  const schemaMutated = await reconcileChangedSchemas(collections);
+  const addedMutated = await startNewWatchers(collections);
+  // Final sweep — catches anything the per-watcher paths above
+  // couldn't reach (vanished slugs' entries, removed-completionField
+  // entries). Bounded by the active set size; only runs when this
+  // tick actually changed something.
+  if (vanishedMutated || schemaMutated || addedMutated) {
+    await sweepStaleActiveEntries();
+  }
+}
+
+function stopVanishedWatchers(liveSlugs: Set<string>): boolean {
+  let mutated = false;
   for (const slug of [...watchers.keys()]) {
     if (liveSlugs.has(slug)) continue;
     const watcher = watchers.get(slug);
@@ -115,13 +146,39 @@ async function syncWatchers(): Promise<void> {
       }
     }
     watchers.delete(slug);
+    mutated = true;
     log.info("collections", "watcher stopped", { slug });
   }
-  // Start watchers for newly-appeared collections.
+  return mutated;
+}
+
+/** Re-reconcile already-watched collections whose schema changed
+ *  since the last tick. New collections fall through to
+ *  `startNewWatchers` (whose start path calls `reconcileAllItems`
+ *  internally), so this pass only handles already-watched slugs. */
+async function reconcileChangedSchemas(collections: readonly LoadedCollection[]): Promise<boolean> {
+  let mutated = false;
+  for (const collection of collections) {
+    const existing = watchers.get(collection.slug);
+    if (!existing) continue;
+    const nextJson = JSON.stringify(collection.schema);
+    if (existing.schemaJson === nextJson) continue;
+    existing.schemaJson = nextJson;
+    log.info("collections", "watcher schema changed, re-reconciling", { slug: collection.slug });
+    await reconcileAllItems(collection.slug, collection.schema, collection.dataDir);
+    mutated = true;
+  }
+  return mutated;
+}
+
+async function startNewWatchers(collections: readonly LoadedCollection[]): Promise<boolean> {
+  let mutated = false;
   for (const collection of collections) {
     if (watchers.has(collection.slug)) continue;
     await startWatcherFor(collection.slug, collection.schema, collection.dataDir);
+    mutated = true;
   }
+  return mutated;
 }
 
 async function startWatcherFor(slug: string, schema: import("./types.js").CollectionSchema, dataDir: string): Promise<void> {
@@ -145,7 +202,7 @@ async function startWatcherFor(slug: string, schema: import("./types.js").Collec
     watcher.on("error", (err) => {
       log.warn("collections", "watcher error", { slug, error: errorMessage(err) });
     });
-    watchers.set(slug, { slug, dataDir, watcher });
+    watchers.set(slug, { slug, dataDir, watcher, schemaJson: JSON.stringify(schema) });
     log.info("collections", "watcher started", { slug, dataDir });
   } catch (err) {
     log.warn("collections", "watcher start failed", { slug, error: errorMessage(err) });

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -97,6 +97,8 @@ skipped, never crashes the host):
 | `singleton` | Optional. When set, at most one record exists, pinned to this exact id (e.g. `me`). Host pre-fills + locks the create form and hides Add once it exists. |
 | `fields` | Ordered map of field-name → field spec. **Insertion order = column order** in the table. Required. |
 | `actions` | Optional array of per-record buttons (see below). |
+| `completionField` | Optional. Name of the field whose value marks an item as "done" — when set, item-create fires a bell notification that clears once the field reaches one of `completionDoneValues`. Must name a real field in `fields`. Paired with `completionDoneValues` (both set, or both omitted). |
+| `completionDoneValues` | Optional. Non-empty array of values that count as "done" for `completionField` (e.g. `["Done"]`, `["paid", "void"]`). Compared as strings. |
 
 ### Field types
 
@@ -224,6 +226,48 @@ journals, drafting an email) gets delegated to natural language.
   re-checks it server-side, so a button gated on `status: paid` can't be invoked
   for a draft. Omit `when` ⇒ always shown.
 - You do **not** trigger actions yourself; point the user at the button.
+
+### Completion tracking (bell notifications)
+
+Declare `completionField` + `completionDoneValues` at the top level of the
+schema to wire a record's lifecycle into the bell:
+
+```json
+{
+  "title": "Todos",
+  "icon": "check_circle",
+  "dataPath": "data/todos/items",
+  "primaryKey": "id",
+  "fields": {
+    "id":     { "type": "string", "label": "ID", "primary": true, "required": true },
+    "title":  { "type": "string", "label": "Title", "required": true },
+    "status": { "type": "enum", "values": ["Todo", "Doing", "Done"], "label": "Status", "required": true }
+  },
+  "completionField": "status",
+  "completionDoneValues": ["Done"]
+}
+```
+
+Behaviour:
+
+- **On create** the host fires a bell notification (titled `<schema.title>: <id>`,
+  click-navigates to `/collections/<slug>?selected=<id>` so the item's detail
+  opens) — unless the new record is **born done** (its `completionField` value
+  is already in `completionDoneValues`), in which case nothing fires. The entry
+  is published with `lifecycle: "action"` so it persists prominently in the
+  bell until the obligation resolves.
+- **On update** the host clears the notification when `completionField`
+  transitions **into** a done value. Un-completing (Done → Todo) does NOT
+  re-fire; firing is bound to create, by design.
+- **On delete** the host clears any matching notification so a removed record
+  can't leak a stale entry.
+
+The pair is bundled — declaring one without the other fails schema validation.
+`completionField` must name a real field; a typo is rejected at load. Works
+with any field type whose stringified value is comparable (`enum`, `string`,
+`boolean`, …) — e.g. `completionField: "status"` + `completionDoneValues:
+["paid", "void"]` on an invoice, or `completionField: "shipped"` +
+`completionDoneValues: ["true"]` on an order.
 
 ## Records — one JSON object per file
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -177,6 +177,19 @@
                   >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
                 >
 
+                <!-- URL string → external link (new tab). `@click.stop` so
+                     clicking the link doesn't also open the row's detail. -->
+                <a
+                  v-else-if="isExternalUrl(item[key])"
+                  :href="String(item[key])"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+                  :data-testid="`collections-url-link-${key}-${item[collection.schema.primaryKey]}`"
+                  @click.stop
+                  >{{ String(item[key]) }}</a
+                >
+
                 <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
               </td>
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -640,12 +640,10 @@
                   :href="String(viewing[key])"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-0.5 text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
+                  class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
                   :data-testid="`collections-detail-url-${key}`"
+                  >{{ String(viewing[key]) }}</a
                 >
-                  <span>{{ String(viewing[key]) }}</span>
-                  <span class="material-icons text-xs">launch</span>
-                </a>
 
                 <!-- Fallback text styling -->
                 <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -140,13 +140,11 @@
                 <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
                   <router-link
                     :to="{ path: `/collections/${field.to}`, query: { selected: String(item[key]) } }"
-                    class="inline-flex items-center gap-0.5 text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
+                    class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
                     :data-testid="`collections-ref-link-${key}-${item[key]}`"
                     @click.stop
+                    >{{ refDisplay(field.to, String(item[key])) }}</router-link
                   >
-                    <span>{{ refDisplay(field.to, String(item[key])) }}</span>
-                    <span class="material-icons text-[10px]">launch</span>
-                  </router-link>
                 </span>
 
                 <!-- Enum badges -->
@@ -563,12 +561,10 @@
                 <router-link
                   v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
                   :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
-                  class="inline-flex items-center gap-0.5 text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
+                  class="text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
                   :data-testid="`collections-detail-ref-${key}`"
+                  >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
                 >
-                  <span>{{ refDisplay(field.to, String(viewing[key])) }}</span>
-                  <span class="material-icons text-xs">launch</span>
-                </router-link>
 
                 <!-- Money format -->
                 <span v-else-if="field.type === 'money'" class="font-semibold text-slate-900 tabular-nums text-sm">{{

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -632,6 +632,21 @@
                   :data-testid="`collections-detail-image-${key}`"
                 />
 
+                <!-- URL string → external link (new tab). Value-based, so any
+                     field whose value is a http(s) URL renders as a link,
+                     regardless of the declared `field.type`. -->
+                <a
+                  v-else-if="isExternalUrl(viewing[key])"
+                  :href="String(viewing[key])"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-0.5 text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
+                  :data-testid="`collections-detail-url-${key}`"
+                >
+                  <span>{{ String(viewing[key]) }}</span>
+                  <span class="material-icons text-xs">launch</span>
+                </a>
+
                 <!-- Fallback text styling -->
                 <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>
               </div>
@@ -1298,6 +1313,17 @@ function formatCell(value: unknown, type: FieldType): string {
   }
   if (typeof value === "string" || typeof value === "number") return String(value);
   return JSON.stringify(value);
+}
+
+/** True iff `value` is a string starting with `http://` or `https://`
+ *  — used by the detail view to auto-render URLs as external links
+ *  (new tab). Schema-agnostic on purpose: any field whose value looks
+ *  like a URL gets the link affordance, not just fields the schema
+ *  flagged as URL-bearing. Restricted to the http(s) schemes so
+ *  `javascript:` / `data:` / `mailto:` strings can't become clickable
+ *  through this path. */
+function isExternalUrl(value: unknown): boolean {
+  return typeof value === "string" && /^https?:\/\//i.test(value);
 }
 
 /** Full (untruncated) text rendering for open mode. `formatCell`

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -111,6 +111,7 @@ export const ROLES: Role[] = [
       "Play some focus music on Spotify",
       "Remind me to call mom this evening",
       "Create a contacts collection with name, company, title, email, phone, notes, and a business-card image. When I attach a photo of a business card, read the details off it and add a new contact.",
+      "Create a reading-list collection with a URL field and a Read checkbox. While Read is unchecked, keep each item in the bell notifications.",
     ],
   },
   {

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -53,6 +53,7 @@ export const NOTIFICATION_VIEWS = {
   sources: "sources",
   files: "files",
   wiki: "wiki",
+  collections: "collections",
 } as const;
 
 export type NotificationView = (typeof NOTIFICATION_VIEWS)[keyof typeof NOTIFICATION_VIEWS];
@@ -75,7 +76,8 @@ export type NotificationTarget =
   | { view: typeof NOTIFICATION_VIEWS.automations; taskId?: string }
   | { view: typeof NOTIFICATION_VIEWS.sources; slug?: string }
   | { view: typeof NOTIFICATION_VIEWS.files; path?: string }
-  | { view: typeof NOTIFICATION_VIEWS.wiki; slug?: string; anchor?: string };
+  | { view: typeof NOTIFICATION_VIEWS.wiki; slug?: string; anchor?: string }
+  | { view: typeof NOTIFICATION_VIEWS.collections; slug: string; itemId?: string };
 
 export type NotificationAction =
   | {

--- a/test/workspace/collections/test_notifications.ts
+++ b/test/workspace/collections/test_notifications.ts
@@ -1,0 +1,324 @@
+// Reconciler tests for collection-completion bell notifications.
+// Drives the reconciler functions against a tmpdir workspace + tmpdir
+// notifier active.json so the assertions are deterministic and never
+// touch `~/mulmoclaude/`.
+//
+// Covers the scenarios called out in the PR review:
+//   - publish on pending create (`reconcileItem` with non-done item)
+//   - clear on done transition (`reconcileItem` with done item)
+//   - clear on delete (`reconcileItem` when the file is gone)
+//   - schema flip on/off (sweep + reconcile when completionField vanishes)
+//   - runtime collection removal (sweep when the schema is deleted)
+//   - defensive multi-drain in `clearItemNotification`
+//
+// The watcher's plumbing (fs.watch + single-flight + boot reconcile)
+// is exercised in test_watcher.ts.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { _setFilePathsForTesting, initNotifier, listAll, publish as notifierPublish } from "../../../server/notifier/engine.js";
+import {
+  clearItemNotification,
+  itemIsDone,
+  reconcileAllItems,
+  reconcileItem,
+  sweepStaleActiveEntries,
+} from "../../../server/workspace/collections/notifications.js";
+import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
+
+let workdir: string;
+let userDir: string;
+let notifierDir: string;
+let dataDir: string;
+
+const SLUG = "test-completion";
+
+function buildSchema(extra: Partial<CollectionSchema> = {}): CollectionSchema {
+  return {
+    title: "Test Completion",
+    icon: "check_circle",
+    dataPath: `data/${SLUG}/items`,
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      read: { type: "boolean", label: "Read", required: true },
+    },
+    completionField: "read",
+    completionDoneValues: ["true"],
+    ...extra,
+  };
+}
+
+function writeSchemaJson(schema: CollectionSchema | null): void {
+  const skillDir = path.join(workdir, ".claude/skills", SLUG);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(path.join(skillDir, "SKILL.md"), `---\nname: ${SLUG}\ndescription: test\n---\nbody\n`);
+  if (schema !== null) {
+    writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(schema));
+  }
+}
+
+function deleteSchemaDir(): void {
+  rmSync(path.join(workdir, ".claude/skills", SLUG), { recursive: true, force: true });
+}
+
+function writeItem(itemId: string, body: Record<string, unknown>): void {
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(path.join(dataDir, `${itemId}.json`), JSON.stringify({ id: itemId, ...body }));
+}
+
+function deleteItemFile(itemId: string): void {
+  unlinkSync(path.join(dataDir, `${itemId}.json`));
+}
+
+async function activeCompletionEntries(): Promise<{ id: string; legacyId: string; navigateTarget: string | undefined; title: string }[]> {
+  const entries = await listAll();
+  return entries
+    .filter((entry) => {
+      const data = entry.pluginData as Record<string, unknown> | undefined;
+      return data?.legacy === true && typeof data.legacyId === "string" && (data.legacyId as string).startsWith("collection-completion:");
+    })
+    .map((entry) => ({
+      id: entry.id,
+      legacyId: (entry.pluginData as Record<string, unknown>).legacyId as string,
+      navigateTarget: entry.navigateTarget,
+      title: entry.title,
+    }));
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "test-completion-notifications-"));
+  userDir = mkdtempSync(path.join(tmpdir(), "test-completion-notifications-user-"));
+  notifierDir = mkdtempSync(path.join(tmpdir(), "test-completion-notifications-notifier-"));
+  dataDir = path.join(workdir, "data", SLUG, "items");
+  _setFilePathsForTesting({
+    active: path.join(notifierDir, "active.json"),
+    history: path.join(notifierDir, "history.json"),
+  });
+  initNotifier({ publish: () => {} });
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(userDir, { recursive: true, force: true });
+  rmSync(notifierDir, { recursive: true, force: true });
+});
+
+describe("itemIsDone", () => {
+  it("returns true when the stringified field value is in completionDoneValues", () => {
+    const schema = buildSchema();
+    assert.equal(itemIsDone(schema, { id: "x", read: true }), true);
+    assert.equal(itemIsDone(schema, { id: "x", read: "true" }), true);
+  });
+
+  it("returns false when the value is not in completionDoneValues", () => {
+    const schema = buildSchema();
+    assert.equal(itemIsDone(schema, { id: "x", read: false }), false);
+    assert.equal(itemIsDone(schema, { id: "x", read: "false" }), false);
+  });
+
+  it("returns false when the value is missing entirely", () => {
+    const schema = buildSchema();
+    assert.equal(itemIsDone(schema, { id: "x" }), false);
+    assert.equal(itemIsDone(schema, { id: "x", read: undefined }), false);
+    assert.equal(itemIsDone(schema, { id: "x", read: null }), false);
+  });
+
+  it("returns false when the schema doesn't declare completion tracking", () => {
+    const schema = buildSchema({ completionField: undefined, completionDoneValues: undefined });
+    assert.equal(itemIsDone(schema, { id: "x", read: true }), false);
+  });
+
+  it("supports enum-style completion (e.g. invoice status)", () => {
+    const schema = buildSchema({ completionField: "status", completionDoneValues: ["paid", "void"] });
+    assert.equal(itemIsDone(schema, { id: "x", status: "paid" }), true);
+    assert.equal(itemIsDone(schema, { id: "x", status: "void" }), true);
+    assert.equal(itemIsDone(schema, { id: "x", status: "draft" }), false);
+  });
+});
+
+describe("reconcileItem", () => {
+  it("publishes a bell entry for a pending item with no existing entry", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    const entries = await activeCompletionEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.legacyId, `collection-completion:${SLUG}:a`);
+    assert.equal(entries[0]?.title, `${schema.title}: a`);
+    // Deep-link target includes the itemId so the bell click opens the detail.
+    assert.equal(entries[0]?.navigateTarget, `/collections/${SLUG}?selected=a`);
+  });
+
+  it("is idempotent — a second reconcile on the same pending item doesn't dup", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    const entries = await activeCompletionEntries();
+    assert.equal(entries.length, 1);
+  });
+
+  it("clears the bell entry when the item transitions to a done value", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    // Flip the item to done by rewriting the file.
+    writeItem("a", { read: true });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("clears the bell entry when the item file is deleted", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    deleteItemFile("a");
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("clears the entry when the schema no longer declares completionField", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    // Simulate a runtime schema edit that drops completion tracking.
+    const flipped = buildSchema({ completionField: undefined, completionDoneValues: undefined });
+    await reconcileItem(SLUG, flipped, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("does NOT publish for an item born done", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: true });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});
+
+describe("reconcileAllItems", () => {
+  it("walks every record and reconciles each", async () => {
+    const schema = buildSchema();
+    writeItem("a", { read: false });
+    writeItem("b", { read: true });
+    writeItem("c", { read: false });
+    await reconcileAllItems(SLUG, schema, dataDir, { workspaceRoot: workdir });
+    const entries = await activeCompletionEntries();
+    const legacyIds = entries.map((entry) => entry.legacyId).sort();
+    assert.deepEqual(legacyIds, [`collection-completion:${SLUG}:a`, `collection-completion:${SLUG}:c`]);
+  });
+
+  it("is a no-op when the schema has no completionField", async () => {
+    const schema = buildSchema({ completionField: undefined, completionDoneValues: undefined });
+    writeItem("a", { read: false });
+    await reconcileAllItems(SLUG, schema, dataDir, { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});
+
+describe("clearItemNotification", () => {
+  it("drains every matching entry, not just the first (defense against dupes)", async () => {
+    // Manually publish two entries with the same legacyId to simulate a
+    // historical race producing duplicates — the clear path must take
+    // them both out, not leave a stuck one behind.
+    const legacyId = `collection-completion:${SLUG}:a`;
+    const pluginData = {
+      legacy: true,
+      legacyId,
+      kind: "todo",
+      priority: "normal",
+      action: { type: "navigate", target: { view: "collections", slug: SLUG, itemId: "a" } },
+    };
+    await notifierPublish({
+      pluginPkg: "todo",
+      severity: "nudge",
+      lifecycle: "action",
+      title: "dup 1",
+      navigateTarget: `/collections/${SLUG}?selected=a`,
+      pluginData,
+    });
+    await notifierPublish({
+      pluginPkg: "todo",
+      severity: "nudge",
+      lifecycle: "action",
+      title: "dup 2",
+      navigateTarget: `/collections/${SLUG}?selected=a`,
+      pluginData,
+    });
+    assert.equal((await activeCompletionEntries()).length, 2);
+    await clearItemNotification(SLUG, "a");
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("is a silent no-op when no matching entry exists", async () => {
+    await clearItemNotification(SLUG, "ghost");
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});
+
+describe("sweepStaleActiveEntries", () => {
+  it("clears entries whose collection no longer exists", async () => {
+    const schema = buildSchema();
+    writeSchemaJson(schema);
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    // Delete the schema dir to simulate a collection deletion.
+    deleteSchemaDir();
+    await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("clears entries when the schema dropped its completionField", async () => {
+    const schema = buildSchema();
+    writeSchemaJson(schema);
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    // Rewrite the schema without completionField.
+    writeSchemaJson(buildSchema({ completionField: undefined, completionDoneValues: undefined }));
+    await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("clears entries whose underlying item file is gone", async () => {
+    const schema = buildSchema();
+    writeSchemaJson(schema);
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    deleteItemFile("a");
+    await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("clears entries when the item is now done", async () => {
+    const schema = buildSchema();
+    writeSchemaJson(schema);
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    // Flip the file to done without going through reconcileItem — sweep
+    // is the safety net for changes made while the watcher was down.
+    writeItem("a", { read: true });
+    await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("leaves still-pending entries alone", async () => {
+    const schema = buildSchema();
+    writeSchemaJson(schema);
+    writeItem("a", { read: false });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+  });
+});

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -1,0 +1,226 @@
+// Watcher-layer tests for the collection-completion bell. Exercises:
+//
+//  - Boot reconcile (a pending item already on disk gets a bell entry
+//    when `startCollectionWatchers` runs).
+//  - Runtime collection removal (the schema dir is deleted; a manual
+//    `_syncWatchersForTesting` call clears the now-orphaned entry).
+//  - Schema flip from no-tracking to tracking (existing items get
+//    entries on the next sync — the case Codex flagged).
+//  - The per-key single-flight scheduler (`scheduleItemReconcile`):
+//    rapid-fire calls coalesce into one publish plus one trailing
+//    pass, so concurrent reconciles can't race the engine's write
+//    queue into duplicate entries.
+//
+// `fs.watch` event timing is too flaky to assert against directly —
+// the watcher boots fine in production but a Node test that writes a
+// file and immediately checks the bell can land before the OS has
+// dispatched the event. We exercise the watcher's logic through
+// `_syncWatchersForTesting` (sync the watcher set on demand) and
+// `_scheduleItemReconcileForTesting` (drive the single-flight slot
+// directly).
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { _setFilePathsForTesting, initNotifier, listAll } from "../../../server/notifier/engine.js";
+import {
+  _scheduleItemReconcileForTesting,
+  _syncWatchersForTesting,
+  startCollectionWatchers,
+  stopCollectionWatchers,
+} from "../../../server/workspace/collections/watcher.js";
+import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
+
+let workdir: string;
+let userDir: string;
+let notifierDir: string;
+
+const SLUG = "test-watcher";
+
+function buildSchema(extra: Partial<CollectionSchema> = {}): CollectionSchema {
+  return {
+    title: "Test Watcher",
+    icon: "check_circle",
+    dataPath: `data/${SLUG}/items`,
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      read: { type: "boolean", label: "Read", required: true },
+    },
+    completionField: "read",
+    completionDoneValues: ["true"],
+    ...extra,
+  };
+}
+
+function writeSchema(schema: CollectionSchema): void {
+  const skillDir = path.join(workdir, ".claude/skills", SLUG);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(path.join(skillDir, "SKILL.md"), `---\nname: ${SLUG}\ndescription: test\n---\nbody\n`);
+  writeFileSync(path.join(skillDir, "schema.json"), JSON.stringify(schema));
+}
+
+function deleteSchemaDir(): void {
+  rmSync(path.join(workdir, ".claude/skills", SLUG), { recursive: true, force: true });
+}
+
+function writeItem(itemId: string, body: Record<string, unknown>): void {
+  const dataDir = path.join(workdir, "data", SLUG, "items");
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(path.join(dataDir, `${itemId}.json`), JSON.stringify({ id: itemId, ...body }));
+}
+
+async function activeCompletionEntries(): Promise<{ id: string; legacyId: string }[]> {
+  const entries = await listAll();
+  return entries
+    .filter((entry) => {
+      const data = entry.pluginData as Record<string, unknown> | undefined;
+      return data?.legacy === true && typeof data.legacyId === "string" && (data.legacyId as string).startsWith("collection-completion:");
+    })
+    .map((entry) => ({
+      id: entry.id,
+      legacyId: (entry.pluginData as Record<string, unknown>).legacyId as string,
+    }));
+}
+
+beforeEach(async () => {
+  workdir = mkdtempSync(path.join(tmpdir(), "test-watcher-"));
+  userDir = mkdtempSync(path.join(tmpdir(), "test-watcher-user-"));
+  notifierDir = mkdtempSync(path.join(tmpdir(), "test-watcher-notifier-"));
+  _setFilePathsForTesting({
+    active: path.join(notifierDir, "active.json"),
+    history: path.join(notifierDir, "history.json"),
+  });
+  initNotifier({ publish: () => {} });
+  // Make sure a previous test's watcher state didn't leak.
+  await stopCollectionWatchers();
+});
+
+afterEach(async () => {
+  await stopCollectionWatchers();
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(userDir, { recursive: true, force: true });
+  rmSync(notifierDir, { recursive: true, force: true });
+});
+
+describe("startCollectionWatchers boot reconcile", () => {
+  it("publishes bell entries for pending items already on disk at boot", async () => {
+    writeSchema(buildSchema());
+    writeItem("a", { read: false });
+    writeItem("b", { read: true });
+    writeItem("c", { read: false });
+
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+    });
+
+    const entries = await activeCompletionEntries();
+    const legacyIds = entries.map((entry) => entry.legacyId).sort();
+    assert.deepEqual(legacyIds, [`collection-completion:${SLUG}:a`, `collection-completion:${SLUG}:c`]);
+  });
+
+  it("ignores collections that don't declare completionField", async () => {
+    writeSchema(buildSchema({ completionField: undefined, completionDoneValues: undefined }));
+    writeItem("a", { read: false });
+
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+    });
+
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});
+
+describe("syncWatchers runtime drift", () => {
+  it("clears the entry when the collection is deleted at runtime", async () => {
+    writeSchema(buildSchema());
+    writeItem("a", { read: false });
+
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+    });
+    assert.equal((await activeCompletionEntries()).length, 1);
+
+    deleteSchemaDir();
+    await _syncWatchersForTesting();
+
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("publishes for a still-pending item when completionField is added later", async () => {
+    // Schema without completion tracking + one item.
+    writeSchema(buildSchema({ completionField: undefined, completionDoneValues: undefined }));
+    writeItem("a", { read: false });
+
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+    });
+    assert.equal((await activeCompletionEntries()).length, 0);
+
+    // Flip the schema to start tracking — re-sync should fill in the entry.
+    writeSchema(buildSchema());
+    await _syncWatchersForTesting();
+
+    const entries = await activeCompletionEntries();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.legacyId, `collection-completion:${SLUG}:a`);
+  });
+
+  it("clears entries when completionField is removed from the schema", async () => {
+    writeSchema(buildSchema());
+    writeItem("a", { read: false });
+
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+    });
+    assert.equal((await activeCompletionEntries()).length, 1);
+
+    writeSchema(buildSchema({ completionField: undefined, completionDoneValues: undefined }));
+    await _syncWatchersForTesting();
+
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});
+
+describe("scheduleItemReconcile single-flight", () => {
+  it("produces exactly one bell entry from a rapid-fire burst on the same key", async () => {
+    writeSchema(buildSchema());
+    writeItem("a", { read: false });
+
+    // Discover so the watcher module has discoveryOpts (the
+    // single-flight path doesn't need a started watcher, but the
+    // reconciler's readItem still needs the right workspaceRoot
+    // threaded through).
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+    });
+    // Boot reconcile may have already published an entry for the
+    // pending item; record that baseline and assert the burst added
+    // at most one more (in practice: zero — `ensure*` is idempotent).
+    const baseline = (await activeCompletionEntries()).length;
+
+    // Fire ten concurrent reconciles. With the single-flight slot, all
+    // ten collapse into one in-flight reconcile + one trailing re-run.
+    // Without it, each would `listAll → publish` while the others'
+    // writes are still queued, producing duplicate entries.
+    const schema = buildSchema();
+    const dataDir = path.join(workdir, "data", SLUG, "items");
+    const promises = Array.from({ length: 10 }, () => _scheduleItemReconcileForTesting(SLUG, schema, dataDir, "a"));
+    await Promise.all(promises);
+
+    const after = (await activeCompletionEntries()).length;
+    // Either there was already a boot entry (baseline=1, after=1) or
+    // there wasn't (baseline=0, after=1). Either way, the burst added
+    // at most one entry — never two.
+    assert.equal(after, Math.max(baseline, 1), "rapid-fire reconciles must not produce duplicate entries");
+  });
+});


### PR DESCRIPTION
## Summary
- **Completion tracking**: schemas may declare `completionField` + `completionDoneValues`. Creating a record fires an `action`-lifecycle bell entry; the entry clears when the field transitions into a done value. Click-navigates to `/collections/<slug>?selected=<itemId>` so the item's detail opens.
- **Filesystem-driven dispatch**: a per-collection `fs.watch` over the dataDir feeds a convergent reconciler, so direct Write-tool edits (the canonical SKILL.md pattern) get the same bell state as REST mutations. Single-flighted per `(slug, itemId)` with awaited publish so rapid-fire `fs.watch` events on a single atomic-rename can't race the engine's write queue into duplicates. Boot-time sweep + per-collection reconcile catch up any changes that landed during downtime.
- **Clickable URLs in CollectionView**: any `http(s)://` string value renders as a `target="_blank"` link in both the list and detail views (value-based, schema-agnostic). The pre-existing `launch` icon on ref-field links and the new URL links is removed — the colored, hover-underlined link text carries the affordance on its own.

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`
- [x] `yarn test` — unit suites pass
- [x] `yarn test:e2e` — 446 / 446 Playwright tests pass
- [ ] Manual: create a `data/skills/reading-list/schema.json` with `completionField: "read"` + `completionDoneValues: ["true"]`. Add a record with `read: false` via either REST or direct Write. Verify the bell entry appears with the item's title, clicking it opens `/collections/reading-list?selected=<id>`. Toggle `read: true` — entry clears. Toggle back — re-fires. Long URLs render as new-tab links in both the list table and the detail view; clicking a URL in the list table does NOT bubble into the row click.
- [ ] Manual: previously-published `fyi`-lifecycle entries from earlier dev iterations do NOT auto-migrate. Clear them by hand from the bell, or check-then-uncheck the item once to force a re-publish under the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add completion-based bell notifications for collection items and make URL values in collections clickable, with filesystem-backed reconciliation to keep notifications in sync with record state.

New Features:
- Allow collection schemas to declare a completion field and done values that drive bell notifications for item lifecycle state.
- Render string values that look like external HTTP(S) URLs as clickable links in both collection list and detail views, independent of schema field type.

Enhancements:
- Introduce filesystem watchers and a convergent reconciliation flow to keep collection completion notifications consistent for records changed via REST or direct file writes.
- Extend notification targets with a collections view deep-link that opens a specific collection item from a bell entry.
- Update collection schema types and validation to support the new completion tracking configuration.

Documentation:
- Document collection completion tracking, including schema configuration and bell notification behavior, in the collection skills help page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collections can opt into completion tracking that auto-fires/clears bell notifications when items become done.
  * Background filesystem watchers start at boot to keep collection notifications reconciled and updated in near real-time; watcher failures log as warnings and do not block startup.
  * Notifications can now target collections (optionally pointing to a specific item).
  * Ref fields render as plain text or external links that open in a new tab.

* **Documentation**
  * Docs updated with completion-tracking configuration and behavior.

* **Tests**
  * Added unit and watcher tests plus an end-to-end spec validating URL links and watcher behavior.

* **Chores**
  * Added a built-in personal role query for a reading-list collection with a URL field and Read checkbox.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->