### PR TITLE
fix(i18n/ja): localize Encore brand to アンコール for JA UI clarity (#1553)

### DIFF
--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -285,7 +285,7 @@ const jaMessages = {
     todos: { label: "Todo" },
     calendar: { label: "カレンダー" },
     automations: { label: "自動化" },
-    encore: { label: "Encore" },
+    encore: { label: "アンコール" },
     wiki: { label: "Wiki" },
     collections: { label: "コレクション" },
     sources: { label: "ソース" },
@@ -295,8 +295,8 @@ const jaMessages = {
     files: { label: "ファイル" },
   },
   encoreDashboard: {
-    title: "Encore",
-    subtitle: "Encore が追跡している定期的な義務の一覧です。",
+    title: "アンコール",
+    subtitle: "繰り返し発生するタスクや義務（アンコール）の一覧です。次回の発生タイミングを追跡します。",
     loading: "義務を読み込み中…",
     errorPrefix: "義務を読み込めませんでした: ",
     empty: "まだ義務がありません。チャットから設定を依頼してください。",
@@ -307,7 +307,7 @@ const jaMessages = {
     chatButtonTitle: "この義務について新しいチャットで相談する",
     bellButtonTitle: "このサイクルについて相談する",
     addButtonLabel: "追加",
-    unexpectedResponse: "Encore から予期しない応答が返されました。",
+    unexpectedResponse: "アンコール から予期しない応答が返されました。",
     fieldsHeading: "サイクルごとに記録する項目",
     fieldRequired: "必須",
     status: {


### PR DESCRIPTION
## Summary

JA UI で `Encore` がブランド英語商標のまま冒頭に出ていて、機能を知らないユーザーに意味が伝わりにくい問題を解消する。subtitle は機能の説明先行に書き換え、ブランドは括弧で補足。title / launcher label / error は カタカナ「アンコール」に統一して JA UI 全体で表記を揃える。

Before:
```
encore:    { label: "Encore" }
title:     "Encore"
subtitle:  "Encore が追跡している定期的な義務の一覧です。"
unexpected: "Encore から予期しない応答が返されました。"
```

After:
```
encore:    { label: "アンコール" }
title:     "アンコール"
subtitle:  "繰り返し発生するタスクや義務（アンコール）の一覧です。次回の発生タイミングを追跡します。"
unexpected: "アンコール から予期しない応答が返されました。"
```

## Items to Confirm / Review

- **JA-only 変更**: 他 7 locales (en/zh/ko/es/pt-BR/fr/de) は商標を機能の中に自然に組み込んだ表現になっているため変更なし。i18n CLAUDE.md ルールに照らしても「キーの追加/削除/リネーム」ではなく既存キーの値再翻訳なので 8 ロケール一斉更新は不要。
- **コードシンボル**: `encoreDashboard` / `pluginLauncher.encore` / `roleId: 'encore'` などの**識別子は `encore` のまま**。grep / docs / PR との一致のため。
- **launcher label の変更影響**: トップバー / サイドバーのプラグインランチャーが「Encore」→「アンコール」に変わる。幅は同等程度。CSS 上の問題はないはず。

## Implementation

`src/lang/ja.ts` の 4 行のみ書き換え (label / title / subtitle / unexpectedResponse)。

## Test

- `yarn lint` clean
- `yarn typecheck:vue` clean
- i18n key shape は不変 (値のみ変更) なので vue-tsc / i18n schema check に影響無し

Closes #1553.

## User Prompt

> Encore が追跡している定期的な義務の一覧です。 ってぶぶん、encore が分かりづらいので、アンコールにするか、もしくはもっと分かりやすい表現で localize して
> title の Encore もかな。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Localize the Encore plugin branding and dashboard copy in the Japanese locale for clearer feature understanding.

Bug Fixes:
- Clarify the Encore feature naming in the Japanese UI by using the localized brand name アンコール consistently.

Enhancements:
- Improve the Japanese Encore dashboard subtitle to describe recurring tasks and obligations more explicitly while retaining the brand in parentheses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced Japanese language support with updated translations across the application, including dashboard interface titles, labels, and system messages for improved user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->