### PR TITLE
feat(collections): conditional field visibility via `when` predicate

### DIFF
--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -81,6 +81,16 @@ Relations and computed/behavioural constructs:
 - **`actions`** — per-record buttons. `kind: "chat"` starts a new chat in
   `role` seeded from `template`. An optional `when: { field, in: [...] }`
   predicate shows the button only for matching record states.
+- **field `when`** — any field may carry the same `when: { field, in: [...] }`
+  predicate to hide itself until a sibling field matches (e.g. a `rating`
+  field with `{ "field": "visited", "in": ["true"] }` stays hidden until
+  `visited` is `true`). The gate applies in the list (cell blanks), the edit
+  form (the input hides/shows live as the gating field changes), and the
+  detail view (the field is omitted). Purely presentational — a hidden
+  field's stored value is preserved, so re-matching the gate restores it.
+  `when.field` is validated to name a real top-level field. The shared
+  predicate (`actionVisible` / `fieldVisible` / `whenMatches`) is in
+  `src/utils/collections/actionVisible.ts`.
 
 The canonical example is the invoice schema
 (`server/workspace/skills-preset/mc-invoice/schema.json`): `id` (primary),
@@ -254,7 +264,7 @@ collections (the `mc-*` skills) ship under
 | REST + action dispatch | `server/api/routes/collections.ts` |
 | UI (table / form / detail / actions) | `src/components/CollectionView.vue` |
 | Derived-formula evaluator | `src/utils/collections/derivedFormula.ts` |
-| Action visibility predicate (UI + server) | `src/utils/collections/actionVisible.ts` |
+| Action + field visibility predicate (`when`, UI + server) | `src/utils/collections/actionVisible.ts` |
 | Canonical example schema | `server/workspace/skills-preset/mc-invoice/schema.json` |
 
 Field-type design history and deferred-work rationale live in the shipped

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -78,6 +78,16 @@ const currencyMessage = {
   path: ["currency"],
 };
 
+// Optional visibility predicate shared by actions and fields: the
+// target shows only when the open record's `field` (stringified) is
+// one of `in`. Domain-free — `field` is any non-empty key, `in` a
+// non-empty array of non-empty values; the host never interprets the
+// meaning.
+const WhenSchema = z.object({
+  field: z.string().trim().min(1),
+  in: z.array(z.string().trim().min(1)).min(1),
+});
+
 // Sub-fields inside a `table.of` map: the regular field types
 // minus `table` (no nested tables) and `derived` (no computed
 // columns inside a table — would need the evaluator to walk the
@@ -119,6 +129,12 @@ const FieldSpecSchema = z
      *  values are scalars, so rendering them via `table` or another
      *  `derived` would be meaningless. */
     display: z.enum(["string", "number", "money", "date"]).optional(),
+    // Optional visibility predicate: this field renders only when the
+    // record matches (e.g. hide `rating` until `visited` is `true`).
+    // The referenced `when.field` is validated to be a real top-level
+    // field by a schema-level refine below (a field can't see its
+    // siblings here).
+    when: WhenSchema.optional(),
   })
   .refine(refRefine, refMessage)
   .refine(enumRefine, enumMessage)
@@ -133,15 +149,6 @@ const FieldSpecSchema = z
     path: ["formula"],
   });
 
-// Optional visibility predicate: the action button shows only when the
-// open record's `field` (stringified) is one of `in`. Domain-free —
-// `field` is any non-empty key, `in` a non-empty array of non-empty
-// values; the host never interprets the meaning.
-const ActionWhenSchema = z.object({
-  field: z.string().trim().min(1),
-  in: z.array(z.string().trim().min(1)).min(1),
-});
-
 // A schema-declared record action. Domain-free: the host validates the
 // shape; the meaning (which role, which template) is data.
 const ActionSpecSchema = z.object({
@@ -155,7 +162,7 @@ const ActionSpecSchema = z.object({
     .trim()
     .min(1)
     .refine(isSafeActionTemplatePath, "must be a safe path under `templates/` (e.g. `templates/invoice.md`; no `..`, no leading `/`, no backslash)"),
-  when: ActionWhenSchema.optional(),
+  when: WhenSchema.optional(),
 });
 
 // Field types that can hold a currency code string. A `currencyField`
@@ -256,6 +263,14 @@ const CollectionSchemaZ = z
   .refine((schema) => schema.displayField === undefined || schema.fields[schema.displayField] !== undefined, {
     message: "schema `displayField` must name a top-level field declared in `fields`",
     path: ["displayField"],
+  })
+  // A field's `when.field` gates its visibility against a sibling's
+  // value, so it must name a real top-level field — a typo would
+  // silently keep the field hidden forever (the gate never matches).
+  // Checked at the schema level because a field can't see its siblings.
+  .refine((schema) => Object.values(schema.fields).every((field) => field.when === undefined || schema.fields[field.when.field] !== undefined), {
+    message: "a field's `when.field` must name a top-level field declared in `fields`",
+    path: ["fields"],
   });
 
 interface LoadedCollection {

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -39,17 +39,22 @@ export type CollectionSource = "user" | "project";
  *  another schema-shape change. */
 export type CollectionActionKind = "chat";
 
-/** Optional visibility predicate for an action: the button renders
- *  only when the open record's `field` (stringified) is one of `in`.
- *  Generic and domain-free — the host evaluates it against the record
- *  with no knowledge of what the field means. Absent ⇒ always shown. */
-export interface CollectionActionWhen {
-  /** Top-level record field key whose value gates the button. */
+/** Optional visibility predicate: the target (an action button or a
+ *  field) renders only when the open record's `field` (stringified) is
+ *  one of `in`. Generic and domain-free — the host evaluates it against
+ *  the record with no knowledge of what the field means. Absent ⇒
+ *  always shown. */
+export interface CollectionWhen {
+  /** Top-level record field key whose value gates visibility. */
   field: string;
-  /** Allowed values; the button shows when `String(record[field])` is
+  /** Allowed values; the target shows when `String(record[field])` is
    *  one of these. Non-empty. */
   in: string[];
 }
+
+/** @deprecated Name retained for back-compat; use {@link CollectionWhen}.
+ *  Both actions and fields share the same predicate shape. */
+export type CollectionActionWhen = CollectionWhen;
 
 /** A schema-declared, per-record action rendered as a button in the
  *  read-only detail view. Pure UI/behaviour directive — never stored,
@@ -71,9 +76,9 @@ export interface CollectionAction {
    *  text becomes the seed prompt body (e.g. `templates/invoice.md`). */
   template: string;
   /** Optional visibility predicate; the button renders only when the
-   *  open record matches (see CollectionActionWhen). Absent ⇒ always
+   *  open record matches (see CollectionWhen). Absent ⇒ always
    *  shown. */
-  when?: CollectionActionWhen;
+  when?: CollectionWhen;
 }
 
 export interface CollectionFieldSpec {
@@ -134,6 +139,15 @@ export interface CollectionFieldSpec {
    *  value should be rendered as (e.g. `"money"` so $1,234.56 is
    *  formatted). Defaults to `"number"`. */
   display?: CollectionFieldType;
+  /** Optional visibility predicate: this field renders only when the
+   *  record matches (e.g. hide a `rating` field until `visited` is
+   *  `true` via `{ field: "visited", in: ["true"] }`). Applies to the
+   *  list cell (blank when hidden), the edit form (hidden live as the
+   *  gating field changes), and the detail view. Purely presentational
+   *  — a hidden field's stored value is never cleared. `when.field`
+   *  must name another top-level field. Absent ⇒ always shown. Only
+   *  honoured on top-level fields, not inside a `table`'s `of`. */
+  when?: CollectionWhen;
 }
 
 export interface CollectionSchema {

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -139,6 +139,28 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
   details off the attached image and write its path into the image field.
   Write the bare workspace-relative path — never an `/api/files/raw?...` URL.
 
+### Conditional field visibility (`when`)
+
+Any field may carry an optional `when: { field, in: [...] }` predicate to hide
+itself until another field on the same record matches — the same shape used to
+gate `actions`. The field shows only when `String(record[when.field])` is one of
+`in`; absent ⇒ always shown. `when.field` MUST name another top-level field
+(validated on discovery).
+
+```json
+"visited":    { "type": "boolean", "label": "Visited" },
+"rating":     { "type": "number",  "label": "Rating", "when": { "field": "visited", "in": ["true"] } }
+```
+
+Here `rating` stays hidden until `visited` is checked (booleans stringify, so
+match `"true"` / `"false"`). The gate applies everywhere the field renders: the
+list cell goes **blank**, the edit-form input hides/shows **live** as the gating
+field changes, and the detail view omits it. It is **purely presentational** —
+a hidden field's stored value is never cleared, so re-matching the gate restores
+it. Use it for fields that only make sense in a given state (a rating before
+you've visited, a shipped-date before an order ships). Only honoured on
+top-level fields, not inside a `table`'s `of`.
+
 ### Derived-formula syntax
 
 A tiny expression evaluated against the record (pure evaluator, no `eval`;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1616,6 +1616,11 @@ function firstMissingTableSubField(field: FieldSpec, rows: TableRowDraft[] | und
  *  function's cognitive complexity under the lint cap.
  *
  *  Skip rules:
+ *  - fields hidden by a `when` gate (no visible input to fill, so a
+ *    required gated field must not block save — otherwise a schema
+ *    like `rating: { required, when: { field: "visited", in: ["true"] }}`
+ *    is unsavable while `visited` is false; Codex P2 on #1555). Checked
+ *    against the live draft `record` so it tracks the in-progress form.
  *  - primary key in create mode (server auto-generates an id when
  *    blank, so blocking here would deny the documented
  *    "blank → server-generated id" flow even for schemas that mark
@@ -1628,7 +1633,10 @@ function firstMissingTableSubField(field: FieldSpec, rows: TableRowDraft[] | und
  *  `required` flags — even if the table itself is optional. The
  *  table block therefore runs OUTSIDE the `if (!field.required)`
  *  short-circuit. */
-function validateOneField(key: string, field: FieldSpec, draft: EditState): string | null {
+function validateOneField(key: string, field: FieldSpec, draft: EditState, record: CollectionItem): string | null {
+  // A `when`-hidden field has no input the user can fill — never treat
+  // it as missing (covers the table branch below too, so it sits first).
+  if (!fieldVisible(field, record)) return null;
   if (field.type === "table" && field.of) {
     const rows = draft.table[key];
     if (field.required && (!rows || rows.length === 0)) return field.label;
@@ -1642,8 +1650,11 @@ function validateOneField(key: string, field: FieldSpec, draft: EditState): stri
 }
 
 function firstMissingRequiredField(draft: EditState, schema: CollectionSchema): string | null {
+  // Resolve `when` gates against the same draft record the form renders
+  // from, so visibility-skip matches exactly what the user sees.
+  const record = draftToRecord(draft, schema);
   for (const [key, field] of Object.entries(schema.fields)) {
-    const missing = validateOneField(key, field, draft);
+    const missing = validateOneField(key, field, draft, record);
     if (missing) return missing;
   }
   return null;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -117,80 +117,83 @@
               @keydown.space.self.prevent="openView(item)"
             >
               <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
-                <!-- Boolean state badge -->
-                <span v-if="field.type === 'boolean'" class="block">
-                  <span
-                    v-if="item[key] === true"
-                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
-                  >
-                    <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
-                    {{ t("common.yes") }}
+                <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
+                <template v-if="fieldVisible(field, item)">
+                  <!-- Boolean state badge -->
+                  <span v-if="field.type === 'boolean'" class="block">
+                    <span
+                      v-if="item[key] === true"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
+                    >
+                      <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
+                      {{ t("common.yes") }}
+                    </span>
+                    <span
+                      v-else-if="item[key] === false"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
+                    >
+                      {{ t("common.no") }}
+                    </span>
+                    <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false (the edit pipeline tracks presence via boolOriginallyPresent). -->
+                    <span v-else class="text-slate-300">—</span>
                   </span>
-                  <span
-                    v-else-if="item[key] === false"
-                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
-                  >
-                    {{ t("common.no") }}
+
+                  <!-- Ref router-link badge -->
+                  <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
+                    <router-link
+                      :to="{ path: `/collections/${field.to}`, query: { selected: String(item[key]) } }"
+                      class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
+                      :data-testid="`collections-ref-link-${key}-${item[key]}`"
+                      @click.stop
+                      >{{ refDisplay(field.to, String(item[key])) }}</router-link
+                    >
                   </span>
-                  <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false (the edit pipeline tracks presence via boolOriginallyPresent). -->
-                  <span v-else class="text-slate-300">—</span>
-                </span>
 
-                <!-- Ref router-link badge -->
-                <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
-                  <router-link
-                    :to="{ path: `/collections/${field.to}`, query: { selected: String(item[key]) } }"
-                    class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
-                    :data-testid="`collections-ref-link-${key}-${item[key]}`"
-                    @click.stop
-                    >{{ refDisplay(field.to, String(item[key])) }}</router-link
+                  <!-- Enum badges -->
+                  <span
+                    v-else-if="field.type === 'enum' && item[key]"
+                    class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border"
+                    :class="enumBadgeClass(item[key])"
                   >
-                </span>
+                    {{ item[key] }}
+                  </span>
 
-                <!-- Enum badges -->
-                <span
-                  v-else-if="field.type === 'enum' && item[key]"
-                  class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border"
-                  :class="enumBadgeClass(item[key])"
-                >
-                  {{ item[key] }}
-                </span>
+                  <!-- Money -->
+                  <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
+                    formatMoney(item[key], resolveCurrency(field, item), locale)
+                  }}</span>
 
-                <!-- Money -->
-                <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
-                  formatMoney(item[key], resolveCurrency(field, item), locale)
-                }}</span>
+                  <!-- Table summary counter -->
+                  <span
+                    v-else-if="field.type === 'table'"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-[10px] font-bold bg-slate-100 text-slate-600 border border-slate-200/40"
+                  >
+                    <span class="material-icons text-[11px]">list</span>
+                    <span>{{ tableSummary(item[key]) }}</span>
+                  </span>
 
-                <!-- Table summary counter -->
-                <span
-                  v-else-if="field.type === 'table'"
-                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-[10px] font-bold bg-slate-100 text-slate-600 border border-slate-200/40"
-                >
-                  <span class="material-icons text-[11px]">list</span>
-                  <span>{{ tableSummary(item[key]) }}</span>
-                </span>
+                  <!-- Derived formula fields -->
+                  <span
+                    v-else-if="field.type === 'derived'"
+                    class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
+                    >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
+                  >
 
-                <!-- Derived formula fields -->
-                <span
-                  v-else-if="field.type === 'derived'"
-                  class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
-                  >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
-                >
-
-                <!-- URL string → external link (new tab). `@click.stop` so
+                  <!-- URL string → external link (new tab). `@click.stop` so
                      clicking the link doesn't also open the row's detail. -->
-                <a
-                  v-else-if="isExternalUrl(item[key])"
-                  :href="String(item[key])"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
-                  :data-testid="`collections-url-link-${key}-${item[collection.schema.primaryKey]}`"
-                  @click.stop
-                  >{{ String(item[key]) }}</a
-                >
+                  <a
+                    v-else-if="isExternalUrl(item[key])"
+                    :href="String(item[key])"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+                    :data-testid="`collections-url-link-${key}-${item[collection.schema.primaryKey]}`"
+                    @click.stop
+                    >{{ String(item[key]) }}</a
+                  >
 
-                <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
+                  <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
+                </template>
               </td>
 
               <td class="px-5 py-2 text-right whitespace-nowrap align-middle">
@@ -254,201 +257,206 @@
         </header>
 
         <form class="flex-1 overflow-auto px-6 py-5 space-y-4" @submit.prevent="saveEditor">
-          <div v-for="(field, key) in collection.schema.fields" :key="key" class="space-y-1.5">
-            <label class="text-[10px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1" :for="`collections-field-${key}`">
-              {{ field.label }}
-              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
-              <span v-if="field.required" class="text-rose-500 font-bold">*</span>
-            </label>
+          <!-- `template v-for` + inner `v-if` so a `when`-gated field hides
+               live as its gating field changes (Vue 3: v-if can't share an
+               element with v-for). `liveRecord` reflects the in-progress draft. -->
+          <template v-for="(field, key) in collection.schema.fields" :key="key">
+            <div v-if="fieldVisible(field, liveRecord ?? {})" class="space-y-1.5">
+              <label class="text-[10px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1" :for="`collections-field-${key}`">
+                {{ field.label }}
+                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
+                <span v-if="field.required" class="text-rose-500 font-bold">*</span>
+              </label>
 
-            <!-- Boolean checkbox -->
-            <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2.5 text-sm text-slate-700 cursor-pointer select-none">
-              <input
-                :id="`collections-field-${key}`"
-                v-model="editing.bool[key]"
-                type="checkbox"
-                class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
-                :data-testid="`collections-input-${key}`"
-                @change="markBoolTouched(key)"
-              />
-              <span class="text-xs font-semibold" :class="editing.bool[key] ? 'text-indigo-600' : 'text-slate-500'">
-                {{ editing.bool[key] ? t("common.yes") : t("common.no") }}
-              </span>
-            </label>
+              <!-- Boolean checkbox -->
+              <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2.5 text-sm text-slate-700 cursor-pointer select-none">
+                <input
+                  :id="`collections-field-${key}`"
+                  v-model="editing.bool[key]"
+                  type="checkbox"
+                  class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                  :data-testid="`collections-input-${key}`"
+                  @change="markBoolTouched(key)"
+                />
+                <span class="text-xs font-semibold" :class="editing.bool[key] ? 'text-indigo-600' : 'text-slate-500'">
+                  {{ editing.bool[key] ? t("common.yes") : t("common.no") }}
+                </span>
+              </label>
 
-            <!-- Embed card (read-only) -->
-            <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
+              <!-- Embed card (read-only) -->
+              <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
 
-            <!-- Ref selector -->
-            <select
-              v-else-if="field.type === 'ref' && field.to && refOptions(field.to).length > 0"
-              :id="`collections-field-${key}`"
-              v-model="editing.text[key]"
-              :required="isFieldRequiredInUi(field)"
-              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
-              :data-testid="`collections-input-${key}`"
-            >
-              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-              <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
-            </select>
-
-            <!-- Enum selector -->
-            <select
-              v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
-              :id="`collections-field-${key}`"
-              v-model="editing.text[key]"
-              :required="isFieldRequiredInUi(field)"
-              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
-              :data-testid="`collections-input-${key}`"
-            >
-              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-              <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
-            </select>
-
-            <!-- Nested Table editor -->
-            <div
-              v-else-if="field.type === 'table' && field.of"
-              class="border border-slate-200 bg-slate-50/30 rounded-xl p-4 space-y-3"
-              :data-testid="`collections-table-${key}`"
-            >
-              <div v-if="editing.table[key] && editing.table[key].length > 0" class="overflow-hidden border border-slate-200 rounded-lg shadow-sm">
-                <table class="w-full text-xs text-slate-600 bg-white">
-                  <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
-                    <tr>
-                      <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-3 py-2 font-bold">{{ subField.label }}</th>
-                      <th class="w-9"></th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-slate-100">
-                    <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx" class="hover:bg-slate-50/50">
-                      <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1.5 align-middle">
-                        <input
-                          v-if="subField.type === 'boolean'"
-                          v-model="row.bool[subKey]"
-                          type="checkbox"
-                          class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
-                          @change="markRowBoolTouched(row, String(subKey))"
-                        />
-                        <select
-                          v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
-                          v-model="row.text[subKey]"
-                          :required="subField.required"
-                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
-                        >
-                          <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                          <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
-                        </select>
-                        <select
-                          v-else-if="subField.type === 'ref' && subField.to && refOptions(subField.to).length > 0"
-                          v-model="row.text[subKey]"
-                          :required="subField.required"
-                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
-                        >
-                          <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                          <option v-for="opt in refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
-                        </select>
-                        <!-- money subfield -->
-                        <div v-else-if="subField.type === 'money'" class="relative flex items-center">
-                          <span class="absolute left-1.5 text-[10px] text-slate-400 font-bold pr-1 border-r border-slate-200">{{
-                            currencySymbol(resolveCurrency(subField, liveRecord))
-                          }}</span>
-                          <input
-                            v-model="row.text[subKey]"
-                            type="number"
-                            step="0.01"
-                            :required="subField.required"
-                            class="w-full rounded-lg border border-slate-200 pl-6 pr-1.5 py-1 text-xs focus:border-indigo-500 focus:outline-none font-semibold text-slate-800"
-                          />
-                        </div>
-                        <input
-                          v-else
-                          v-model="row.text[subKey]"
-                          :type="inputTypeFor(subField.type)"
-                          :required="subField.required"
-                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
-                        />
-                      </td>
-                      <td class="text-center px-1">
-                        <button
-                          type="button"
-                          class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
-                          :aria-label="t('collectionsView.removeRow')"
-                          :data-testid="`collections-table-${key}-remove-${rowIdx}`"
-                          @click="removeTableRow(key, rowIdx)"
-                        >
-                          <span class="material-icons text-base">close</span>
-                        </button>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <p v-else class="text-xs text-slate-400 italic">{{ t("collectionsView.noRows") }}</p>
-              <button
-                type="button"
-                class="inline-flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
-                :data-testid="`collections-table-${key}-add`"
-                @click="addTableRow(key, field.of)"
-              >
-                <span class="material-icons text-xs">add</span>
-                <span>{{ t("collectionsView.addRow") }}</span>
-              </button>
-            </div>
-
-            <!-- Derived formula field -->
-            <div v-else-if="field.type === 'derived'" class="relative flex items-center">
-              <span class="absolute left-3 text-indigo-500 font-bold text-[9px] uppercase select-none tracking-wider">{{
-                t("collectionsView.derivedLabel")
-              }}</span>
-              <input
-                :id="`collections-field-${key}`"
-                :value="derivedDisplay(field, liveDerived?.[key] ?? null, liveRecord)"
-                type="text"
-                disabled
-                class="w-full rounded-xl border border-indigo-100 bg-indigo-50/15 pl-16 pr-3 py-2 text-xs font-bold text-indigo-700 select-none cursor-not-allowed"
-                :data-testid="`collections-input-${key}`"
-              />
-            </div>
-
-            <!-- Money input field -->
-            <div v-else-if="field.type === 'money'" class="relative flex items-center">
-              <div class="absolute left-3 text-slate-400 font-bold text-xs select-none pr-1.5 border-r border-slate-200">
-                {{ currencySymbol(resolveCurrency(field, liveRecord)) }}
-              </div>
-              <input
+              <!-- Ref selector -->
+              <select
+                v-else-if="field.type === 'ref' && field.to && refOptions(field.to).length > 0"
                 :id="`collections-field-${key}`"
                 v-model="editing.text[key]"
-                type="number"
-                step="0.01"
                 :required="isFieldRequiredInUi(field)"
-                class="w-full rounded-xl border border-slate-200 pl-11 pr-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-semibold text-slate-800 transition-all"
+                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
+                :data-testid="`collections-input-${key}`"
+              >
+                <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+              </select>
+
+              <!-- Enum selector -->
+              <select
+                v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+                :id="`collections-field-${key}`"
+                v-model="editing.text[key]"
+                :required="isFieldRequiredInUi(field)"
+                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
+                :data-testid="`collections-input-${key}`"
+              >
+                <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+              </select>
+
+              <!-- Nested Table editor -->
+              <div
+                v-else-if="field.type === 'table' && field.of"
+                class="border border-slate-200 bg-slate-50/30 rounded-xl p-4 space-y-3"
+                :data-testid="`collections-table-${key}`"
+              >
+                <div v-if="editing.table[key] && editing.table[key].length > 0" class="overflow-hidden border border-slate-200 rounded-lg shadow-sm">
+                  <table class="w-full text-xs text-slate-600 bg-white">
+                    <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
+                      <tr>
+                        <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-3 py-2 font-bold">{{ subField.label }}</th>
+                        <th class="w-9"></th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-100">
+                      <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx" class="hover:bg-slate-50/50">
+                        <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1.5 align-middle">
+                          <input
+                            v-if="subField.type === 'boolean'"
+                            v-model="row.bool[subKey]"
+                            type="checkbox"
+                            class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                            @change="markRowBoolTouched(row, String(subKey))"
+                          />
+                          <select
+                            v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
+                            v-model="row.text[subKey]"
+                            :required="subField.required"
+                            class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                          >
+                            <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                            <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
+                          </select>
+                          <select
+                            v-else-if="subField.type === 'ref' && subField.to && refOptions(subField.to).length > 0"
+                            v-model="row.text[subKey]"
+                            :required="subField.required"
+                            class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                          >
+                            <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                            <option v-for="opt in refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+                          </select>
+                          <!-- money subfield -->
+                          <div v-else-if="subField.type === 'money'" class="relative flex items-center">
+                            <span class="absolute left-1.5 text-[10px] text-slate-400 font-bold pr-1 border-r border-slate-200">{{
+                              currencySymbol(resolveCurrency(subField, liveRecord))
+                            }}</span>
+                            <input
+                              v-model="row.text[subKey]"
+                              type="number"
+                              step="0.01"
+                              :required="subField.required"
+                              class="w-full rounded-lg border border-slate-200 pl-6 pr-1.5 py-1 text-xs focus:border-indigo-500 focus:outline-none font-semibold text-slate-800"
+                            />
+                          </div>
+                          <input
+                            v-else
+                            v-model="row.text[subKey]"
+                            :type="inputTypeFor(subField.type)"
+                            :required="subField.required"
+                            class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
+                          />
+                        </td>
+                        <td class="text-center px-1">
+                          <button
+                            type="button"
+                            class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
+                            :aria-label="t('collectionsView.removeRow')"
+                            :data-testid="`collections-table-${key}-remove-${rowIdx}`"
+                            @click="removeTableRow(key, rowIdx)"
+                          >
+                            <span class="material-icons text-base">close</span>
+                          </button>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <p v-else class="text-xs text-slate-400 italic">{{ t("collectionsView.noRows") }}</p>
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
+                  :data-testid="`collections-table-${key}-add`"
+                  @click="addTableRow(key, field.of)"
+                >
+                  <span class="material-icons text-xs">add</span>
+                  <span>{{ t("collectionsView.addRow") }}</span>
+                </button>
+              </div>
+
+              <!-- Derived formula field -->
+              <div v-else-if="field.type === 'derived'" class="relative flex items-center">
+                <span class="absolute left-3 text-indigo-500 font-bold text-[9px] uppercase select-none tracking-wider">{{
+                  t("collectionsView.derivedLabel")
+                }}</span>
+                <input
+                  :id="`collections-field-${key}`"
+                  :value="derivedDisplay(field, liveDerived?.[key] ?? null, liveRecord)"
+                  type="text"
+                  disabled
+                  class="w-full rounded-xl border border-indigo-100 bg-indigo-50/15 pl-16 pr-3 py-2 text-xs font-bold text-indigo-700 select-none cursor-not-allowed"
+                  :data-testid="`collections-input-${key}`"
+                />
+              </div>
+
+              <!-- Money input field -->
+              <div v-else-if="field.type === 'money'" class="relative flex items-center">
+                <div class="absolute left-3 text-slate-400 font-bold text-xs select-none pr-1.5 border-r border-slate-200">
+                  {{ currencySymbol(resolveCurrency(field, liveRecord)) }}
+                </div>
+                <input
+                  :id="`collections-field-${key}`"
+                  v-model="editing.text[key]"
+                  type="number"
+                  step="0.01"
+                  :required="isFieldRequiredInUi(field)"
+                  class="w-full rounded-xl border border-slate-200 pl-11 pr-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-semibold text-slate-800 transition-all"
+                  :data-testid="`collections-input-${key}`"
+                />
+              </div>
+
+              <!-- Scalar inputs -->
+              <input
+                v-else-if="['string', 'email', 'number', 'date', 'ref', 'image'].includes(field.type)"
+                :id="`collections-field-${key}`"
+                v-model="editing.text[key]"
+                :type="inputTypeFor(field.type)"
+                :required="isFieldRequiredInUi(field)"
+                :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
+                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
+                :data-testid="`collections-input-${key}`"
+              />
+
+              <!-- Markdown or long text -->
+              <textarea
+                v-else
+                :id="`collections-field-${key}`"
+                v-model="editing.text[key]"
+                :rows="field.type === 'markdown' ? 5 : 3"
+                :required="isFieldRequiredInUi(field)"
+                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-medium text-slate-700 transition-all"
                 :data-testid="`collections-input-${key}`"
               />
             </div>
-
-            <!-- Scalar inputs -->
-            <input
-              v-else-if="['string', 'email', 'number', 'date', 'ref', 'image'].includes(field.type)"
-              :id="`collections-field-${key}`"
-              v-model="editing.text[key]"
-              :type="inputTypeFor(field.type)"
-              :required="isFieldRequiredInUi(field)"
-              :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
-              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
-              :data-testid="`collections-input-${key}`"
-            />
-
-            <!-- Markdown or long text -->
-            <textarea
-              v-else
-              :id="`collections-field-${key}`"
-              v-model="editing.text[key]"
-              :rows="field.type === 'markdown' ? 5 : 3"
-              :required="isFieldRequiredInUi(field)"
-              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-medium text-slate-700 transition-all"
-              :data-testid="`collections-input-${key}`"
-            />
-          </div>
+          </template>
           <p v-if="saveError" class="text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl">{{ saveError }}</p>
         </form>
 
@@ -542,122 +550,126 @@
           </p>
 
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
-            <div
-              v-for="(field, key) in collection.schema.fields"
-              :key="key"
-              class="flex flex-col gap-1"
-              :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
-            >
-              <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
+            <!-- `when`-gated fields are omitted entirely from the detail view
+                 (consistent with the list cell blanking) when the open record
+                 doesn't match. -->
+            <template v-for="(field, key) in collection.schema.fields" :key="key">
+              <div
+                v-if="fieldVisible(field, viewing ?? {})"
+                class="flex flex-col gap-1"
+                :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
+              >
+                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
 
-              <div class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
-                <!-- Boolean state -->
-                <template v-if="field.type === 'boolean'">
-                  <span
-                    v-if="viewing[key] === true"
-                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
+                <div class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
+                  <!-- Boolean state -->
+                  <template v-if="field.type === 'boolean'">
+                    <span
+                      v-if="viewing[key] === true"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
+                    >
+                      <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
+                      {{ t("common.yes") }}
+                    </span>
+                    <span
+                      v-else-if="viewing[key] === false"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
+                    >
+                      {{ t("common.no") }}
+                    </span>
+                    <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false. -->
+                    <span v-else class="text-slate-300">—</span>
+                  </template>
+
+                  <!-- Ref details link -->
+                  <router-link
+                    v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
+                    :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
+                    class="text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
+                    :data-testid="`collections-detail-ref-${key}`"
+                    >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
                   >
-                    <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
-                    {{ t("common.yes") }}
-                  </span>
+
+                  <!-- Money format -->
+                  <span v-else-if="field.type === 'money'" class="font-semibold text-slate-900 tabular-nums text-sm">{{
+                    formatMoney(viewing[key], resolveCurrency(field, viewing), locale)
+                  }}</span>
+
+                  <!-- Derived formula badge -->
                   <span
-                    v-else-if="viewing[key] === false"
-                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
+                    v-else-if="field.type === 'derived'"
+                    class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-2 py-0.5 rounded border border-indigo-100/50"
+                    >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), viewing), viewing) }}</span
                   >
-                    {{ t("common.no") }}
-                  </span>
-                  <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false. -->
-                  <span v-else class="text-slate-300">—</span>
-                </template>
 
-                <!-- Ref details link -->
-                <router-link
-                  v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
-                  :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
-                  class="text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
-                  :data-testid="`collections-detail-ref-${key}`"
-                  >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
-                >
+                  <!-- Sub table (e.g. Line Items in details) -->
+                  <div
+                    v-else-if="field.type === 'table' && field.of && hasTableRows(viewing[key])"
+                    class="border border-slate-200/80 rounded-xl overflow-hidden shadow-sm mt-1"
+                  >
+                    <table class="w-full text-[11px] text-slate-600 bg-white">
+                      <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
+                        <tr>
+                          <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-4 py-2 font-bold">{{ subField.label }}</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-slate-100">
+                        <tr v-for="(row, rowIdx) in tableRows(viewing[key])" :key="rowIdx" class="hover:bg-slate-50/50">
+                          <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-4 py-2 align-middle font-medium">
+                            <template v-if="subField.type === 'boolean'">
+                              <span v-if="row[subKey] === true" class="material-icons text-emerald-600 text-base">check_circle</span>
+                              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph (boolean=false), same as elsewhere. -->
+                              <span v-else class="text-slate-300">—</span>
+                            </template>
+                            <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
+                              formatSubCell(subField, row[subKey], viewing)
+                            }}</span>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
 
-                <!-- Money format -->
-                <span v-else-if="field.type === 'money'" class="font-semibold text-slate-900 tabular-nums text-sm">{{
-                  formatMoney(viewing[key], resolveCurrency(field, viewing), locale)
-                }}</span>
+                  <span v-else-if="field.type === 'table'" class="text-slate-400 italic">{{ t("collectionsView.noRows") }}</span>
 
-                <!-- Derived formula badge -->
-                <span
-                  v-else-if="field.type === 'derived'"
-                  class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-2 py-0.5 rounded border border-indigo-100/50"
-                  >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), viewing), viewing) }}</span
-                >
+                  <!-- Markdown blocks with scroll area -->
+                  <div
+                    v-else-if="field.type === 'markdown'"
+                    class="bg-slate-50 rounded-xl p-4 border border-slate-200/60 text-slate-600 text-xs whitespace-pre-wrap leading-relaxed max-h-[30vh] overflow-y-auto"
+                  >
+                    {{ detailText(viewing[key]) }}
+                  </div>
 
-                <!-- Sub table (e.g. Line Items in details) -->
-                <div
-                  v-else-if="field.type === 'table' && field.of && hasTableRows(viewing[key])"
-                  class="border border-slate-200/80 rounded-xl overflow-hidden shadow-sm mt-1"
-                >
-                  <table class="w-full text-[11px] text-slate-600 bg-white">
-                    <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
-                      <tr>
-                        <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-4 py-2 font-bold">{{ subField.label }}</th>
-                      </tr>
-                    </thead>
-                    <tbody class="divide-y divide-slate-100">
-                      <tr v-for="(row, rowIdx) in tableRows(viewing[key])" :key="rowIdx" class="hover:bg-slate-50/50">
-                        <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-4 py-2 align-middle font-medium">
-                          <template v-if="subField.type === 'boolean'">
-                            <span v-if="row[subKey] === true" class="material-icons text-emerald-600 text-base">check_circle</span>
-                            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph (boolean=false), same as elsewhere. -->
-                            <span v-else class="text-slate-300">—</span>
-                          </template>
-                          <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
-                            formatSubCell(subField, row[subKey], viewing)
-                          }}</span>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+                  <!-- Embed view -->
+                  <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
 
-                <span v-else-if="field.type === 'table'" class="text-slate-400 italic">{{ t("collectionsView.noRows") }}</span>
+                  <!-- Image (workspace-relative path → <img> via auth-exempt /api/files/raw) -->
+                  <img
+                    v-else-if="field.type === 'image' && typeof viewing[key] === 'string' && viewing[key]"
+                    :src="resolveImageSrc(String(viewing[key]))"
+                    :alt="field.label"
+                    class="max-h-64 max-w-full object-contain rounded-lg border border-slate-200 bg-slate-50"
+                    :data-testid="`collections-detail-image-${key}`"
+                  />
 
-                <!-- Markdown blocks with scroll area -->
-                <div
-                  v-else-if="field.type === 'markdown'"
-                  class="bg-slate-50 rounded-xl p-4 border border-slate-200/60 text-slate-600 text-xs whitespace-pre-wrap leading-relaxed max-h-[30vh] overflow-y-auto"
-                >
-                  {{ detailText(viewing[key]) }}
-                </div>
-
-                <!-- Embed view -->
-                <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
-
-                <!-- Image (workspace-relative path → <img> via auth-exempt /api/files/raw) -->
-                <img
-                  v-else-if="field.type === 'image' && typeof viewing[key] === 'string' && viewing[key]"
-                  :src="resolveImageSrc(String(viewing[key]))"
-                  :alt="field.label"
-                  class="max-h-64 max-w-full object-contain rounded-lg border border-slate-200 bg-slate-50"
-                  :data-testid="`collections-detail-image-${key}`"
-                />
-
-                <!-- URL string → external link (new tab). Value-based, so any
+                  <!-- URL string → external link (new tab). Value-based, so any
                      field whose value is a http(s) URL renders as a link,
                      regardless of the declared `field.type`. -->
-                <a
-                  v-else-if="isExternalUrl(viewing[key])"
-                  :href="String(viewing[key])"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
-                  :data-testid="`collections-detail-url-${key}`"
-                  >{{ String(viewing[key]) }}</a
-                >
+                  <a
+                    v-else-if="isExternalUrl(viewing[key])"
+                    :href="String(viewing[key])"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
+                    :data-testid="`collections-detail-url-${key}`"
+                    >{{ String(viewing[key]) }}</a
+                  >
 
-                <!-- Fallback text styling -->
-                <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>
+                  <!-- Fallback text styling -->
+                  <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>
+                </div>
               </div>
-            </div>
+            </template>
           </div>
         </div>
       </div>
@@ -680,7 +692,7 @@ import type { EmbedRow, EmbedView } from "./collectionEmbed";
 import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { evaluateDerived, type FormulaContext } from "../utils/collections/derivedFormula";
-import { actionVisible } from "../utils/collections/actionVisible";
+import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
 import { resolveImageSrc } from "../utils/image/resolve";
 
 type FieldType = "string" | "text" | "email" | "number" | "date" | "boolean" | "markdown" | "ref" | "money" | "enum" | "table" | "derived" | "embed" | "image";
@@ -720,6 +732,11 @@ interface FieldSpec {
   /** When type === "derived": render the computed value as this
    *  field type (e.g. "money"). Defaults to "number". */
   display?: FieldType;
+  /** Optional visibility predicate: render this field only when
+   *  `String(record[when.field])` is one of `when.in` (e.g. hide a
+   *  rating until `visited` is `true`). Presentational only — a
+   *  hidden field's stored value is preserved. See `fieldVisible`. */
+  when?: { field: string; in: string[] };
 }
 
 /** Per-target-collection cache: maps an item's primary-key slug to

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -112,6 +112,7 @@ export const ROLES: Role[] = [
       "Remind me to call mom this evening",
       "Create a contacts collection with name, company, title, email, phone, notes, and a business-card image. When I attach a photo of a business card, read the details off it and add a new contact.",
       "Create a reading-list collection with a title, a URL field, and a Read checkbox. While Read is unchecked, keep each item in the bell notifications, labeled with its title.",
+      "Create a restaurants collection with name, cuisine, neighborhood, a website URL, a phone number, a Visited checkbox, a 1-to-5 rating, and notes. Hide the rating until I've marked a place as visited — there's nothing to rate before I've been.",
     ],
   },
   {

--- a/src/utils/collections/actionVisible.ts
+++ b/src/utils/collections/actionVisible.ts
@@ -1,25 +1,55 @@
-// Pure visibility predicate for schema-declared collection actions.
-// Kept as its own module (no Vue) so CollectionView can stay thin and
-// the match semantics are pinned by unit tests. Domain-free: the host
-// compares the stringified record value against the allowed set with no
-// knowledge of what the field means.
+// Pure `when`-predicate visibility helpers for schema-driven
+// collections — used both for action buttons and for conditionally
+// shown fields. Kept as their own module (no Vue) so CollectionView
+// can stay thin and the match semantics are pinned by unit tests.
+// Domain-free: the host compares the stringified record value against
+// the allowed set with no knowledge of what the field means.
 
-/** Minimal shape this helper needs from an action — just its optional
- *  `when` predicate. Accepts the full CollectionAction too. */
-export interface ActionWithWhen {
-  when?: { field: string; in: string[] };
+/** A `when` predicate: render only when the open record's `field`
+ *  (stringified) is one of `in`. Shared shape for action buttons and
+ *  conditionally visible fields. */
+export interface WhenPredicate {
+  field: string;
+  in: string[];
 }
 
-/** True when the action's button should render against `record`:
- *  - no `when` ⇒ always visible;
- *  - otherwise visible only when `record[when.field]` is present and its
+/** Core matcher:
+ *  - no `when` ⇒ always true (visible);
+ *  - otherwise true only when `record[when.field]` is present and its
  *    stringified value is one of `when.in`.
- *  A missing/undefined field is treated as "not a match" (hidden), so a
- *  status-gated action never shows on a record that lacks the status. */
-export function actionVisible(action: ActionWithWhen, record: Record<string, unknown>): boolean {
-  const { when } = action;
+ *  A missing/undefined/null field is treated as "not a match"
+ *  (hidden), so a status-gated target never shows on a record that
+ *  lacks the status. */
+export function whenMatches(when: WhenPredicate | undefined, record: Record<string, unknown>): boolean {
   if (!when) return true;
   const value = record[when.field];
   if (value === undefined || value === null) return false;
   return when.in.includes(String(value));
+}
+
+/** Minimal shape this helper needs from an action — just its optional
+ *  `when` predicate. Accepts the full CollectionAction too. */
+export interface ActionWithWhen {
+  when?: WhenPredicate;
+}
+
+/** True when the action's button should render against `record`
+ *  (see whenMatches). */
+export function actionVisible(action: ActionWithWhen, record: Record<string, unknown>): boolean {
+  return whenMatches(action.when, record);
+}
+
+/** Minimal shape this helper needs from a field spec — just its
+ *  optional `when` predicate. Accepts the full FieldSpec too. */
+export interface FieldWithWhen {
+  when?: WhenPredicate;
+}
+
+/** True when the field should render against `record`. A field with
+ *  no `when` is always shown; otherwise it's shown only when the
+ *  record matches (e.g. hide a rating field until `visited` is true).
+ *  Purely presentational — a hidden field's stored value is never
+ *  altered, so toggling the gate back on restores it. */
+export function fieldVisible(field: FieldWithWhen, record: Record<string, unknown>): boolean {
+  return whenMatches(field.when, record);
 }

--- a/test/utils/collections/test_actionVisible.ts
+++ b/test/utils/collections/test_actionVisible.ts
@@ -1,10 +1,10 @@
-// Unit tests for the pure action-visibility predicate
+// Unit tests for the pure `when`-predicate visibility helpers
 // (src/utils/collections/actionVisible.ts).
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { actionVisible } from "../../../src/utils/collections/actionVisible.js";
+import { actionVisible, fieldVisible } from "../../../src/utils/collections/actionVisible.js";
 
 describe("actionVisible", () => {
   it("is always visible when no `when` predicate is set", () => {
@@ -36,5 +36,29 @@ describe("actionVisible", () => {
     assert.equal(actionVisible(action, { level: 1 }), true);
     assert.equal(actionVisible(action, { level: 3 }), false);
     assert.equal(actionVisible({ when: { field: "active", in: ["true"] } }, { active: true }), true);
+  });
+});
+
+describe("fieldVisible", () => {
+  it("is always visible when the field has no `when` predicate", () => {
+    assert.equal(fieldVisible({}, {}), true);
+    assert.equal(fieldVisible({}, { visited: false }), true);
+  });
+
+  it("shows a gated field only when the gating value matches (restaurant rating case)", () => {
+    const rating = { when: { field: "visited", in: ["true"] } };
+    // `visited` true → rating shown.
+    assert.equal(fieldVisible(rating, { visited: true }), true);
+    // `visited` false → rating hidden.
+    assert.equal(fieldVisible(rating, { visited: false }), false);
+    // `visited` omitted (boolean omission semantics) → rating hidden.
+    assert.equal(fieldVisible(rating, {}), false);
+  });
+
+  it("gates on an enum value just as well as a boolean", () => {
+    const field = { when: { field: "status", in: ["active", "trial"] } };
+    assert.equal(fieldVisible(field, { status: "active" }), true);
+    assert.equal(fieldVisible(field, { status: "trial" }), true);
+    assert.equal(fieldVisible(field, { status: "cancelled" }), false);
   });
 });

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -860,6 +860,54 @@ describe("discoverCollections — actions", () => {
   });
 });
 
+describe("discoverCollections — field visibility (`when`)", () => {
+  it("accepts a field with a valid `when` predicate naming a sibling field", async () => {
+    writeSkill("test-field-when", {
+      title: "Restaurants",
+      icon: "restaurant",
+      dataPath: "data/restaurants/items",
+      primaryKey: "name",
+      fields: {
+        name: { type: "string", label: "Name", primary: true, required: true },
+        visited: { type: "boolean", label: "Visited" },
+        rating: { type: "number", label: "Rating", when: { field: "visited", in: ["true"] } },
+      },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.deepEqual(collections[0]?.schema.fields.rating?.when, { field: "visited", in: ["true"] });
+  });
+
+  it("rejects a field whose `when.field` names a non-existent field", async () => {
+    writeSkill("test-field-when-missing", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/fieldwhenmiss/items",
+      primaryKey: "name",
+      fields: {
+        name: { type: "string", label: "Name", primary: true, required: true },
+        rating: { type: "number", label: "Rating", when: { field: "visted", in: ["true"] } }, // typo: no `visted` field
+      },
+    });
+    assert.equal((await listCollections()).length, 0, "a field whose when.field points at a missing field must be skipped");
+  });
+
+  it("rejects a field `when` whose `in` is empty", async () => {
+    writeSkill("test-field-when-emptyin", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/fieldwhenei/items",
+      primaryKey: "name",
+      fields: {
+        name: { type: "string", label: "Name", primary: true, required: true },
+        visited: { type: "boolean", label: "Visited" },
+        rating: { type: "number", label: "Rating", when: { field: "visited", in: [] } },
+      },
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+});
+
 describe("discoverCollections — workspaceRoot propagation", () => {
   it("roots each app's dataDir at the supplied workspaceRoot, not the live workspace", async () => {
     // Regression for PR #1489 Codex P1: discovery used to pass


### PR DESCRIPTION
## Summary

Adds **conditional field visibility** to schema-driven collections. Any field may now carry an optional `when: { field, in: [...] }` predicate to hide itself until a sibling field matches — reusing the exact shape that already gates `actions`.

Motivating example: a restaurants list where the **1-to-5 rating stays hidden until the `visited` checkbox is true** — nothing to rate before you've been.

```json
"visited": { "type": "boolean", "label": "Visited" },
"rating":  { "type": "number",  "label": "Rating", "when": { "field": "visited", "in": ["true"] } }
```

## Behavior across the three render surfaces

- **List** — the cell goes **blank** for non-matching rows (the column header stays, since columns are shared).
- **Edit form** — the input **hides/shows live** as the gating field changes (gated on the reactive draft, `liveRecord`).
- **Detail view** — the field is **omitted entirely** when it doesn't match.

Purely **presentational** — a hidden field's stored value is never cleared, so re-matching the gate restores it (same semantics as the existing action `when`).

## Implementation

- Extracted a shared `whenMatches` core in `actionVisible.ts`; added `fieldVisible` alongside `actionVisible` (both delegate to it).
- `when?` on `CollectionFieldSpec`; generalized `CollectionActionWhen` → `CollectionWhen` (old name kept as a deprecated alias).
- Zod accepts field `when`; a schema-level refine rejects a `when.field` naming a non-existent field (typo guard, mirrors `displayField`/`currencyField`).
- `CollectionView.vue` wraps the three render surfaces (`template v-for` + inner `v-if` per Vue 3).
- Honoured on **top-level fields only**, not inside a `table`'s `of`.

## Docs + agent guidance

- **`server/workspace/helps/collection-skills.md`** (the agent-facing authoring guide) gains a "Conditional field visibility (`when`)" subsection — without it the agent wouldn't know the capability exists, so the sample prompt below wouldn't produce a hidden field.
- `docs/collections-architecture.md` DSL section + source map updated.
- New **Personal-role starter query** exercising the feature: a restaurants list with name, cuisine, neighborhood, website URL, phone number, Visited checkbox, 1-to-5 rating, and notes — rating hidden until visited. (Role queries are translated at runtime via `/api/translation`, so no static i18n changes.)

## Limitation worth knowing

The predicate compares the **stringified** value, so a "show when X is false" gate (`"in": ["false"]`) matches only an *explicitly stored* `false` — an omitted boolean won't match. The "show when true" case (this PR's example) is unaffected.

## Tests

- `fieldVisible` unit tests (no-`when` always-visible, restaurant rating case, enum gating).
- Discovery validation tests: accept valid field `when`, reject a `when.field` that names a missing field, reject empty `in`.
- Full suite + `format` / `lint` / `typecheck` / `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fields can conditionally show/hide based on other field values in list, edit, and detail views.
  * Form validation ignores currently hidden required fields so records remain saveable.

* **Documentation**
  * Expanded docs describing the conditional-visibility predicate, evaluation rules, and scope.

* **Tests**
  * Added tests covering field visibility behavior and schema validation for visibility predicates.

* **Bug Fixes**
  * Schemas with invalid visibility predicates are now rejected to avoid permanently hidden fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->