### PR TITLE
fix(scheduler): confirm before deleting calendar items

### DIFF
--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -108,6 +108,7 @@ This catalog only covers **cross-cutting** helpers — formatters, error helpers
 |---|---|---|
 | `src/composables/useContentDisplay.ts` | `useContentDisplay()` | Shared "show one of: loading / error / empty / data" state machine for plugin Views. |
 | `src/utils/dom/iframeHeightClamp.ts` | `iframeHeightClamp(...)` | iframe height autosize logic (used by html / spreadsheet preview surfaces). |
+| `src/utils/confirmDelete.ts` | `confirmItemDelete(message)` | "Are you sure?" gate before deleting a single item (todo card, calendar event, …). Single seam over `window.confirm` so the UI/wording can be swapped to a styled modal in one place. |
 
 ---
 

--- a/e2e/tests/calendar-delete-confirm.spec.ts
+++ b/e2e/tests/calendar-delete-confirm.spec.ts
@@ -20,34 +20,33 @@ const SAMPLE_ITEM: Item = {
   props: {},
 };
 
-async function mountCalendarWithItem(page: Page, item: Item, deleteHandler: (route: Route) => void): Promise<void> {
+async function stubSchedulerEndpoint(page: Page, item: Item, deleteHandler: (route: Route) => void): Promise<void> {
   await mockAllApis(page);
-
   let currentItems = [item];
-
   await page.route("**/api/scheduler", async (route) => {
     const request = route.request();
-    if (request.method() === "GET") {
-      await route.fulfill({ json: { data: { items: currentItems } } });
-      return;
-    }
     if (request.method() === "POST") {
       const body = JSON.parse(request.postData() ?? "{}") as { action?: string; id?: string };
       if (body.action === "delete") {
         deleteHandler(route);
         currentItems = currentItems.filter((each) => each.id !== body.id);
-        await route.fulfill({ json: { data: { items: currentItems } } });
-        return;
       }
     }
     await route.fulfill({ json: { data: { items: currentItems } } });
   });
+}
 
+async function openCalendarListView(page: Page, item: Item): Promise<void> {
   await page.goto("/calendar");
   await expect(page.getByTestId("scheduler-view-root")).toBeVisible();
   // Switch to list view via testid — the ✕ delete button only renders there.
   await page.getByTestId("scheduler-view-mode-list").click();
   await expect(page.getByTestId(`scheduler-item-delete-${item.id}`)).toBeVisible();
+}
+
+async function mountCalendarWithItem(page: Page, item: Item, deleteHandler: (route: Route) => void): Promise<void> {
+  await stubSchedulerEndpoint(page, item, deleteHandler);
+  await openCalendarListView(page, item);
 }
 
 test.describe("Calendar — delete confirmation", () => {

--- a/e2e/tests/calendar-delete-confirm.spec.ts
+++ b/e2e/tests/calendar-delete-confirm.spec.ts
@@ -3,20 +3,27 @@
 // `window.confirm` gate so a stray click on the ✕ button cannot
 // silently drop an event. See TodoExplorer.confirmAndDelete.
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 
-const SAMPLE_ITEM = {
+interface Item {
+  id: string;
+  title: string;
+  createdAt: number;
+  props: Record<string, unknown>;
+}
+
+const SAMPLE_ITEM: Item = {
   id: "evt_1",
   title: "Daily standup",
   createdAt: Date.now(),
   props: {},
 };
 
-async function mountCalendarWithItem(page: import("@playwright/test").Page, deleteHandler: (route: import("@playwright/test").Route) => void): Promise<void> {
+async function mountCalendarWithItem(page: Page, item: Item, deleteHandler: (route: Route) => void): Promise<void> {
   await mockAllApis(page);
 
-  let currentItems = [SAMPLE_ITEM];
+  let currentItems = [item];
 
   await page.route("**/api/scheduler", async (route) => {
     const request = route.request();
@@ -28,7 +35,7 @@ async function mountCalendarWithItem(page: import("@playwright/test").Page, dele
       const body = JSON.parse(request.postData() ?? "{}") as { action?: string; id?: string };
       if (body.action === "delete") {
         deleteHandler(route);
-        currentItems = currentItems.filter((item) => item.id !== body.id);
+        currentItems = currentItems.filter((each) => each.id !== body.id);
         await route.fulfill({ json: { data: { items: currentItems } } });
         return;
       }
@@ -38,15 +45,15 @@ async function mountCalendarWithItem(page: import("@playwright/test").Page, dele
 
   await page.goto("/calendar");
   await expect(page.getByTestId("scheduler-view-root")).toBeVisible();
-  // Switch to list view — that's where the ✕ button lives.
-  await page.locator('button[title="List"]').click();
-  await expect(page.getByTestId(`scheduler-item-delete-${SAMPLE_ITEM.id}`)).toBeVisible();
+  // Switch to list view via testid — the ✕ delete button only renders there.
+  await page.getByTestId("scheduler-view-mode-list").click();
+  await expect(page.getByTestId(`scheduler-item-delete-${item.id}`)).toBeVisible();
 }
 
 test.describe("Calendar — delete confirmation", () => {
   test("dismissing the confirm dialog keeps the item and fires no DELETE", async ({ page }) => {
     let deleteCalls = 0;
-    await mountCalendarWithItem(page, () => {
+    await mountCalendarWithItem(page, SAMPLE_ITEM, () => {
       deleteCalls += 1;
     });
 
@@ -66,7 +73,7 @@ test.describe("Calendar — delete confirmation", () => {
 
   test("accepting the confirm dialog fires the DELETE and removes the item", async ({ page }) => {
     let deleteCalls = 0;
-    await mountCalendarWithItem(page, () => {
+    await mountCalendarWithItem(page, SAMPLE_ITEM, () => {
       deleteCalls += 1;
     });
 
@@ -79,5 +86,28 @@ test.describe("Calendar — delete confirmation", () => {
 
     await expect(page.getByText(SAMPLE_ITEM.title)).toHaveCount(0);
     expect(deleteCalls).toBe(1);
+  });
+
+  test("title with quotes and special characters round-trips into the confirm message", async ({ page }) => {
+    // Guards against accidental HTML-escaping or interpolation breakage in
+    // vue-i18n's `{title}` placeholder — confirm() takes a plain string, so
+    // the message must contain the raw title verbatim.
+    const quotedItem: Item = {
+      id: "evt_quoted",
+      title: 'Sync "Q3 review" & plan — 100%',
+      createdAt: Date.now(),
+      props: {},
+    };
+
+    await mountCalendarWithItem(page, quotedItem, () => {});
+
+    let observedMessage = "";
+    page.once("dialog", (dialog) => {
+      observedMessage = dialog.message();
+      dialog.dismiss().catch(() => {});
+    });
+
+    await page.getByTestId(`scheduler-item-delete-${quotedItem.id}`).click();
+    expect(observedMessage).toContain(quotedItem.title);
   });
 });

--- a/e2e/tests/calendar-delete-confirm.spec.ts
+++ b/e2e/tests/calendar-delete-confirm.spec.ts
@@ -1,0 +1,83 @@
+// Calendar (scheduler plugin) delete confirmation — mirrors the
+// todo explorer pattern: every delete path routes through a
+// `window.confirm` gate so a stray click on the ✕ button cannot
+// silently drop an event. See TodoExplorer.confirmAndDelete.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const SAMPLE_ITEM = {
+  id: "evt_1",
+  title: "Daily standup",
+  createdAt: Date.now(),
+  props: {},
+};
+
+async function mountCalendarWithItem(page: import("@playwright/test").Page, deleteHandler: (route: import("@playwright/test").Route) => void): Promise<void> {
+  await mockAllApis(page);
+
+  let currentItems = [SAMPLE_ITEM];
+
+  await page.route("**/api/scheduler", async (route) => {
+    const request = route.request();
+    if (request.method() === "GET") {
+      await route.fulfill({ json: { data: { items: currentItems } } });
+      return;
+    }
+    if (request.method() === "POST") {
+      const body = JSON.parse(request.postData() ?? "{}") as { action?: string; id?: string };
+      if (body.action === "delete") {
+        deleteHandler(route);
+        currentItems = currentItems.filter((item) => item.id !== body.id);
+        await route.fulfill({ json: { data: { items: currentItems } } });
+        return;
+      }
+    }
+    await route.fulfill({ json: { data: { items: currentItems } } });
+  });
+
+  await page.goto("/calendar");
+  await expect(page.getByTestId("scheduler-view-root")).toBeVisible();
+  // Switch to list view — that's where the ✕ button lives.
+  await page.locator('button[title="List"]').click();
+  await expect(page.getByTestId(`scheduler-item-delete-${SAMPLE_ITEM.id}`)).toBeVisible();
+}
+
+test.describe("Calendar — delete confirmation", () => {
+  test("dismissing the confirm dialog keeps the item and fires no DELETE", async ({ page }) => {
+    let deleteCalls = 0;
+    await mountCalendarWithItem(page, () => {
+      deleteCalls += 1;
+    });
+
+    page.once("dialog", (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      expect(dialog.message()).toContain(SAMPLE_ITEM.title);
+      dialog.dismiss().catch(() => {});
+    });
+
+    await page.getByTestId(`scheduler-item-delete-${SAMPLE_ITEM.id}`).click();
+
+    // The item should remain in the list and the dispatch endpoint
+    // should never have been called with action=delete.
+    await expect(page.getByText(SAMPLE_ITEM.title)).toBeVisible();
+    expect(deleteCalls).toBe(0);
+  });
+
+  test("accepting the confirm dialog fires the DELETE and removes the item", async ({ page }) => {
+    let deleteCalls = 0;
+    await mountCalendarWithItem(page, () => {
+      deleteCalls += 1;
+    });
+
+    page.once("dialog", (dialog) => {
+      expect(dialog.type()).toBe("confirm");
+      dialog.accept().catch(() => {});
+    });
+
+    await page.getByTestId(`scheduler-item-delete-${SAMPLE_ITEM.id}`).click();
+
+    await expect(page.getByText(SAMPLE_ITEM.title)).toHaveCount(0);
+    expect(deleteCalls).toBe(1);
+  });
+});

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -161,6 +161,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import { scrollIntoViewByTestId } from "../utils/dom/scrollIntoViewByTestId";
+import { confirmItemDelete } from "../utils/confirmDelete";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TodoData, TodoItem, CreateItemInput, PatchItemInput, TodoViewMode as ViewMode } from "@mulmoclaude/todo-plugin/shared";
 import { TODO_VIEW, TODO_VIEW_MODES as VIEW_MODES, colorForLabel, filterByLabels, listLabelsWithCount } from "@mulmoclaude/todo-plugin/shared";
@@ -338,8 +339,7 @@ function onPatchItem(itemId: string, input: PatchItemInput): void {
 function confirmAndDelete(itemId: string): boolean {
   const item = items.value.find((i) => i.id === itemId);
   if (!item) return false;
-  const confirmed = window.confirm(`Delete "${item.text}"?`);
-  if (!confirmed) return false;
+  if (!confirmItemDelete(`Delete "${item.text}"?`)) return false;
   void deleteItem(itemId);
   return true;
 }

--- a/src/components/TodoExplorer.vue
+++ b/src/components/TodoExplorer.vue
@@ -339,7 +339,7 @@ function onPatchItem(itemId: string, input: PatchItemInput): void {
 function confirmAndDelete(itemId: string): boolean {
   const item = items.value.find((i) => i.id === itemId);
   if (!item) return false;
-  if (!confirmItemDelete(`Delete "${item.text}"?`)) return false;
+  if (!confirmItemDelete(t("todoExplorer.deleteConfirm", { text: item.text }))) return false;
   void deleteItem(itemId);
   return true;
 }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -910,6 +910,7 @@ const deMessages = {
   },
   todoExplorer: {
     heading: "To-do",
+    deleteConfirm: "„{text}“ löschen?",
     doneRatio: "{done}/{total} erledigt",
     addButton: "+ Hinzufügen",
     addColumnButton: "+ Spalte",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -632,6 +632,7 @@ const deMessages = {
     goToday: "Zu Heute",
     next: "Weiter",
     deleteItem: "Eintrag löschen",
+    deleteConfirm: "„{title}“ löschen?",
     closeEditor: "Editor schließen",
     apiError: "⚠ Scheduler-Aktualisierung fehlgeschlagen: {error}",
     tabCalendar: "Kalender",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -892,6 +892,7 @@ const enMessages = {
   },
   todoExplorer: {
     heading: "Todo",
+    deleteConfirm: 'Delete "{text}"?',
     doneRatio: "{done}/{total} done",
     addButton: "+ Add",
     addColumnButton: "+ Column",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -643,6 +643,7 @@ const enMessages = {
     goToday: "Go to today",
     next: "Next",
     deleteItem: "Delete item",
+    deleteConfirm: 'Delete "{title}"?',
     closeEditor: "Close editor",
     apiError: "⚠ Failed to update scheduler: {error}",
     tabCalendar: "Calendar",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -905,6 +905,7 @@ const esMessages = {
   },
   todoExplorer: {
     heading: "Tareas",
+    deleteConfirm: '¿Eliminar "{text}"?',
     doneRatio: "{done}/{total} hechas",
     addButton: "+ Añadir",
     addColumnButton: "+ Columna",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -629,6 +629,7 @@ const esMessages = {
     goToday: "Ir a hoy",
     next: "Siguiente",
     deleteItem: "Eliminar elemento",
+    deleteConfirm: '¿Eliminar "{title}"?',
     closeEditor: "Cerrar editor",
     apiError: "⚠ Error al actualizar el programador: {error}",
     tabCalendar: "Calendario",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -901,6 +901,7 @@ const frMessages = {
   },
   todoExplorer: {
     heading: "Tâches",
+    deleteConfirm: "Supprimer « {text} » ?",
     doneRatio: "{done}/{total} faites",
     addButton: "+ Ajouter",
     addColumnButton: "+ Colonne",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -623,6 +623,7 @@ const frMessages = {
     goToday: "Aller à aujourd'hui",
     next: "Suivant",
     deleteItem: "Supprimer l'élément",
+    deleteConfirm: "Supprimer « {title} » ?",
     closeEditor: "Fermer l'éditeur",
     apiError: "⚠ Échec de la mise à jour du planificateur : {error}",
     tabCalendar: "Calendrier",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -892,6 +892,7 @@ const jaMessages = {
   },
   todoExplorer: {
     heading: "Todo",
+    deleteConfirm: "「{text}」を削除しますか？",
     doneRatio: "{done}/{total} 完了",
     addButton: "+ 追加",
     addColumnButton: "+ 列",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -617,6 +617,7 @@ const jaMessages = {
     goToday: "今日へ移動",
     next: "次へ",
     deleteItem: "項目を削除",
+    deleteConfirm: "「{title}」を削除しますか？",
     closeEditor: "エディタを閉じる",
     apiError: "⚠ スケジューラの更新に失敗: {error}",
     tabCalendar: "カレンダー",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -893,6 +893,7 @@ const koMessages = {
   },
   todoExplorer: {
     heading: "할 일",
+    deleteConfirm: '"{text}"을(를) 삭제하시겠습니까?',
     doneRatio: "{done}/{total} 완료",
     addButton: "+ 추가",
     addColumnButton: "+ 칼럼",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -619,6 +619,7 @@ const koMessages = {
     goToday: "오늘로 이동",
     next: "다음",
     deleteItem: "항목 삭제",
+    deleteConfirm: '"{title}"을(를) 삭제하시겠습니까?',
     closeEditor: "에디터 닫기",
     apiError: "⚠ 스케줄러 업데이트 실패: {error}",
     tabCalendar: "달력",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -897,6 +897,7 @@ const ptBRMessages = {
   },
   todoExplorer: {
     heading: "Tarefas",
+    deleteConfirm: 'Excluir "{text}"?',
     doneRatio: "{done}/{total} feitas",
     addButton: "+ Adicionar",
     addColumnButton: "+ Coluna",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -622,6 +622,7 @@ const ptBRMessages = {
     goToday: "Ir para hoje",
     next: "Próximo",
     deleteItem: "Excluir item",
+    deleteConfirm: 'Excluir "{title}"?',
     closeEditor: "Fechar editor",
     apiError: "⚠ Falha ao atualizar o agendador: {error}",
     tabCalendar: "Calendário",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -883,6 +883,7 @@ const zhMessages = {
   },
   todoExplorer: {
     heading: "待办",
+    deleteConfirm: "删除「{text}」？",
     doneRatio: "{done}/{total} 完成",
     addButton: "+ 添加",
     addColumnButton: "+ 列",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -610,6 +610,7 @@ const zhMessages = {
     goToday: "跳到今天",
     next: "下一个",
     deleteItem: "删除项目",
+    deleteConfirm: "删除「{title}」？",
     closeEditor: "关闭编辑器",
     apiError: "⚠ 更新调度器失败: {error}",
     tabCalendar: "日历",

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -66,6 +66,7 @@
               class="h-8 w-8 flex items-center justify-center"
               :class="viewMode === mode.key ? 'bg-blue-500 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'"
               :title="mode.label"
+              :data-testid="`scheduler-view-mode-${mode.key}`"
               @click="viewMode = mode.key"
             >
               <span class="material-icons text-sm">{{ mode.icon }}</span>

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -258,6 +258,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SchedulerData, ScheduledItem } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { apiPost } from "../../utils/api";
+import { confirmItemDelete } from "../../utils/confirmDelete";
 import { pluginEndpoints } from "../api";
 import type { SchedulerEndpoints } from "./automationsDefinition";
 import TasksTab from "./TasksTab.vue";
@@ -591,8 +592,7 @@ async function callApi(body: Record<string, unknown>): Promise<boolean> {
 }
 
 async function remove(item: ScheduledItem): Promise<void> {
-  const confirmed = window.confirm(t("pluginScheduler.deleteConfirm", { title: item.title }));
-  if (!confirmed) return;
+  if (!confirmItemDelete(t("pluginScheduler.deleteConfirm", { title: item.title }))) return;
   if (selectedId.value === item.id) selectedId.value = null;
   await callApi({ action: "delete", id: item.id });
 }

--- a/src/plugins/scheduler/View.vue
+++ b/src/plugins/scheduler/View.vue
@@ -103,6 +103,7 @@
             <button
               class="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 text-xs px-1 mt-0.5 shrink-0"
               :title="t('pluginScheduler.deleteItem')"
+              :data-testid="`scheduler-item-delete-${item.id}`"
               @click.stop="remove(item)"
             >
               ✕
@@ -589,6 +590,8 @@ async function callApi(body: Record<string, unknown>): Promise<boolean> {
 }
 
 async function remove(item: ScheduledItem): Promise<void> {
+  const confirmed = window.confirm(t("pluginScheduler.deleteConfirm", { title: item.title }));
+  if (!confirmed) return;
   if (selectedId.value === item.id) selectedId.value = null;
   await callApi({ action: "delete", id: item.id });
 }

--- a/src/utils/confirmDelete.ts
+++ b/src/utils/confirmDelete.ts
@@ -1,0 +1,13 @@
+// Centralized gate for "are you sure?" prompts before a destructive
+// item action (deleting a todo card, calendar event, etc.). A thin
+// wrapper around `window.confirm` so the wording / UI can be swapped
+// to a styled modal in one place without touching every call site,
+// and so tests have a single seam to stub instead of monkey-patching
+// `window.confirm` per spec.
+//
+// Callers own the message and its localization — this helper is just
+// the gate that returns true iff the user accepted.
+
+export function confirmItemDelete(message: string): boolean {
+  return window.confirm(message);
+}

--- a/test/utils/test_confirmDelete.ts
+++ b/test/utils/test_confirmDelete.ts
@@ -1,0 +1,58 @@
+// Unit tests for the shared `confirmItemDelete` gate. Asserts that
+// the helper is a pure pass-through to `window.confirm` so callers
+// can rely on it as the single seam for destructive item prompts.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { confirmItemDelete } from "../../src/utils/confirmDelete";
+
+interface MinimalWindow {
+  confirm: (message?: string) => boolean;
+}
+
+let originalWindow: MinimalWindow | undefined;
+let lastMessage: string | undefined;
+let nextResult = true;
+
+describe("confirmItemDelete", () => {
+  before(() => {
+    originalWindow = (globalThis as { window?: MinimalWindow }).window;
+    (globalThis as { window?: MinimalWindow }).window = {
+      confirm: (message?: string) => {
+        lastMessage = message;
+        return nextResult;
+      },
+    };
+  });
+
+  after(() => {
+    (globalThis as { window?: MinimalWindow }).window = originalWindow;
+  });
+
+  beforeEach(() => {
+    lastMessage = undefined;
+    nextResult = true;
+  });
+
+  it("returns true when the user accepts", () => {
+    nextResult = true;
+    assert.equal(confirmItemDelete("Delete?"), true);
+  });
+
+  it("returns false when the user dismisses", () => {
+    nextResult = false;
+    assert.equal(confirmItemDelete("Delete?"), false);
+  });
+
+  it("forwards the message string verbatim", () => {
+    const msg = 'Delete "Q3 review" — 100%?';
+    confirmItemDelete(msg);
+    assert.equal(lastMessage, msg);
+  });
+
+  it("handles empty message", () => {
+    confirmItemDelete("");
+    assert.equal(lastMessage, "");
+  });
+});


### PR DESCRIPTION
## Summary

カレンダー (scheduler プラグイン) の予定削除に `window.confirm` の確認ダイアログを追加した。todo 側の `TodoExplorer.confirmAndDelete` と同じパターンで、✕ ボタンの誤クリックでイベントが無言で消えるのを防ぐ。

- 対象: `/calendar` のリストビューに表示される ✕ 削除ボタン (Scheduler View)
- 起点: ユーザー報告 — 「カレンダーの予定削除に confirm が出ない、todo と同じように出したい」

<img width="526" height="187" alt="image" src="https://github.com/user-attachments/assets/73c2025f-c276-439b-b1a3-506907924521" />


## Items to Confirm / Review

- `pluginScheduler.deleteConfirm` の翻訳が 8 ロケール全てで自然か (特に de.ts の typographic quote `„{title}"` のバイト列、fr.ts の `« {title} »`)
- `data-testid="scheduler-view-mode-<key>"` / `data-testid="scheduler-item-delete-<id>"` の命名規約が既存 testid 群 (`scheduler-view-root`, `scheduler-tab-calendar` 等) と揃っているか
- e2e の引用符テスト (`Sync "Q3 review" & plan — 100%`) で網羅しているエッジケース範囲が妥当か (HTML エスケープや改行入りタイトルは未カバー)

## User Prompt

> カレンダーの予定を削除するときに confirm が出ない。これの挙動を変えたい。todo と同じように confirm を出したい。worktree で対応し、commit → codex-cross-review まで実施。test 追加も忘れずに。

## 実装内容

### 変更点

- [src/plugins/scheduler/View.vue](src/plugins/scheduler/View.vue) — `remove(item)` の先頭で `window.confirm(t("pluginScheduler.deleteConfirm", { title: item.title }))` を呼び、false なら早期 return。✕ ボタンと viewMode 切替ボタンに `data-testid` を追加 (e2e の安定化用)。
- [src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts](src/lang/) — `pluginScheduler.deleteConfirm` を 8 ロケール lockstep で追加。
- [e2e/tests/calendar-delete-confirm.spec.ts](e2e/tests/calendar-delete-confirm.spec.ts) — 新規 spec。dismiss で削除されないこと / accept で DELETE が発火すること / 引用符を含むタイトルが confirm メッセージに正しく interpolation されることをカバー (3 ケース)。

### 設計判断

- todo 側に倣い、host レベルの ConfirmModal コンポーネントではなく `window.confirm` を採用 (todo の `TodoExplorer.confirmAndDelete` と同じ実装)。新コンポーネントを増やさず、削除パスを 1 箇所に集約する pattern を踏襲した。
- ✕ ボタンは現状 list view にしか描画されないため (View.vue の `viewMode === SCHEDULER_VIEW.list` ブランチのみ)、confirm ガードも `remove()` 関数 1 箇所で足りる。

### Cross-review

- Codex (`/codex-cross-review` self pre-PR mode) で 2 ラウンド回し convergence。iter1 で locale-coupled な `button[title="List"]` セレクタを testid 化、引用符タイトルケースを追加。iter2 で LGTM。

### 品質チェック

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` / 新 e2e 3 ケース、すべて green。

---

## Summary by Sourcery

Add a user-facing confirmation dialog before deleting scheduler calendar items and cover the behavior with end-to-end tests.

Bug Fixes:
- Prevent calendar events from being deleted without an explicit confirmation step.

Enhancements:
- Add data-testid attributes to scheduler view mode buttons and item delete buttons to support stable UI automation.

Tests:
- Introduce Playwright end-to-end tests to verify calendar delete confirmation behavior, including cancel, confirm, and special-character titles.

## Summary by Sourcery

Add a confirmation step before deleting scheduler calendar items and cover the behavior with end-to-end tests.

Bug Fixes:
- Prevent scheduler calendar events from being deleted immediately on delete button click by requiring user confirmation.

Enhancements:
- Add data-testid attributes to scheduler view mode and item delete buttons to support stable UI-based automation.

Tests:
- Introduce Playwright end-to-end tests verifying calendar delete confirmation behavior, including cancel, confirm, and quoted-title message interpolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deletion now requires an explicit confirmation for scheduler and todo items; testing hooks added to improve UI testability.

* **Tests**
  * Added end-to-end and unit tests covering confirm/dismiss flows and preservation of quoted/special-character titles.

* **Localization**
  * Added delete-confirmation messages for EN, DE, ES, FR, JA, KO, PT-BR, and ZH.

* **Documentation**
  * Documented the shared confirmation helper for destructive actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->