### PR TITLE
feat(collections): add "+ Chat" button to start a skill-seeded chat

### DIFF
--- a/e2e/tests/collection-chat-button.spec.ts
+++ b/e2e/tests/collection-chat-button.spec.ts
@@ -1,0 +1,91 @@
+// E2E coverage for the "+ Chat" button in CollectionView. The button
+// opens a modal text input and, on submit, starts a new general-role
+// chat seeded with the collection's skill command:
+//
+//   typing "make a new entry" on the `reading-list` collection POSTs
+//   `/reading-list make a new entry` to /api/agent with roleId "general".
+//
+// Pinned here: the seeded message shape (slug + trimmed text), the
+// empty/whitespace-disabled send button, and Escape/cancel dismissal.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const READING_LIST = {
+  collection: {
+    slug: "reading-list",
+    title: "Reading List",
+    icon: "bookmark",
+    source: "user",
+    schema: {
+      title: "Reading List",
+      icon: "bookmark",
+      dataPath: "data/reading-list/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        notes: { type: "string", label: "Notes" },
+      },
+    },
+  },
+  items: [{ id: "first", notes: "an existing row" }],
+};
+
+async function mockCollection(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/reading-list",
+    (route) => route.fulfill({ json: READING_LIST }),
+  );
+}
+
+test.describe("collection + Chat button", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockCollection(page);
+  });
+
+  test("opens the chat modal and gates submit on non-empty input", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+    await page.getByTestId("collections-chat").click();
+
+    const modal = page.getByTestId("collections-chat-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toHaveAttribute("role", "dialog");
+    await expect(modal).toHaveAttribute("aria-modal", "true");
+
+    // Empty → disabled; whitespace-only → still disabled; real text → enabled.
+    const send = page.getByTestId("collections-chat-send");
+    await expect(send).toBeDisabled();
+    await page.getByTestId("collections-chat-input").fill("   ");
+    await expect(send).toBeDisabled();
+    await page.getByTestId("collections-chat-input").fill("make a new entry");
+    await expect(send).toBeEnabled();
+  });
+
+  test("submitting seeds a general-role chat with `/<slug> <message>`", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+    await page.getByTestId("collections-chat").click();
+    await page.getByTestId("collections-chat-input").fill("  make a new entry  ");
+
+    const agentPost = page.waitForRequest((req) => req.url().endsWith("/api/agent") && req.method() === "POST");
+    await page.getByTestId("collections-chat-send").click();
+    const body = (await agentPost).postDataJSON();
+
+    expect(body.message).toBe("/reading-list make a new entry");
+    expect(body.roleId).toBe("general");
+  });
+
+  test("Escape and Cancel both dismiss the modal without starting a chat", async ({ page }) => {
+    await page.goto("/collections/reading-list");
+
+    await page.getByTestId("collections-chat").click();
+    await expect(page.getByTestId("collections-chat-modal")).toBeVisible();
+    await page.getByTestId("collections-chat-input").press("Escape");
+    await expect(page.getByTestId("collections-chat-modal")).toBeHidden();
+
+    await page.getByTestId("collections-chat").click();
+    await expect(page.getByTestId("collections-chat-modal")).toBeVisible();
+    await page.getByTestId("collections-chat-cancel").click();
+    await expect(page.getByTestId("collections-chat-modal")).toBeHidden();
+  });
+});

--- a/server/agent/backend/fake-echo.ts
+++ b/server/agent/backend/fake-echo.ts
@@ -94,7 +94,11 @@ async function defaultResponse(input: AgentInput): Promise<FakeResponse> {
     return { error: "fake-echo forced error for the e2e-live error-banner canary" };
   }
 
-  const slashMatch = input.message.trim().match(/^\/([a-z0-9][a-z0-9-]*)$/i);
+  // Match a leading `/<skill>` command, with or without trailing
+  // arguments (e.g. the collection Chat button seeds
+  // `/<slug> <message>`). Only the skill name drives the seeded
+  // reply — any args are for the real LLM and are ignored here.
+  const slashMatch = input.message.trim().match(/^\/([a-z0-9][a-z0-9-]*)(?:\s|$)/i);
   if (slashMatch) {
     const skillReply = await replyFromSeededSkill(input.workspacePath, slashMatch[1]);
     if (skillReply !== null) return { text: skillReply };

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -498,8 +498,12 @@
     <div
       v-if="chatOpen && collection"
       class="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/60 backdrop-blur-sm p-4 transition-all duration-300"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="collections-chat-title"
       data-testid="collections-chat-modal"
       @click.self="closeChat"
+      @keydown.esc="closeChat"
     >
       <div class="bg-white rounded-2xl shadow-2xl w-full max-w-xl flex flex-col border border-slate-200 overflow-hidden">
         <header class="px-6 py-4 border-b border-slate-100 flex items-center gap-3 bg-slate-50/50">
@@ -507,7 +511,7 @@
             <span class="material-icons text-lg">forum</span>
           </div>
           <div class="flex-1">
-            <h2 class="text-sm font-bold text-slate-800 uppercase tracking-wide">{{ t("collectionsView.chatTitle") }}</h2>
+            <h2 id="collections-chat-title" class="text-sm font-bold text-slate-800 uppercase tracking-wide">{{ t("collectionsView.chatTitle") }}</h2>
             <span class="text-xs text-slate-400 font-semibold">{{ collection.title }}</span>
           </div>
           <button

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -26,6 +26,17 @@
       </div>
 
       <button
+        v-if="collection"
+        type="button"
+        class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors"
+        data-testid="collections-chat"
+        @click="openChat"
+      >
+        <span class="material-icons text-sm">forum</span>
+        <span>{{ t("collectionsView.chat") }}</span>
+      </button>
+
+      <button
         v-if="canCreate"
         type="button"
         class="h-8 px-2.5 flex items-center gap-1 rounded bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs transition-colors shadow-sm"
@@ -482,6 +493,69 @@
       </div>
     </div>
 
+    <!-- Chat modal — collect a message and start a new general-role chat
+         seeded with the collection's skill command (`/<slug> <message>`). -->
+    <div
+      v-if="chatOpen && collection"
+      class="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/60 backdrop-blur-sm p-4 transition-all duration-300"
+      data-testid="collections-chat-modal"
+      @click.self="closeChat"
+    >
+      <div class="bg-white rounded-2xl shadow-2xl w-full max-w-xl flex flex-col border border-slate-200 overflow-hidden">
+        <header class="px-6 py-4 border-b border-slate-100 flex items-center gap-3 bg-slate-50/50">
+          <div class="h-9 w-9 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100/50">
+            <span class="material-icons text-lg">forum</span>
+          </div>
+          <div class="flex-1">
+            <h2 class="text-sm font-bold text-slate-800 uppercase tracking-wide">{{ t("collectionsView.chatTitle") }}</h2>
+            <span class="text-xs text-slate-400 font-semibold">{{ collection.title }}</span>
+          </div>
+          <button
+            type="button"
+            class="h-8 w-8 flex items-center justify-center rounded text-slate-400 hover:bg-slate-200/50 hover:text-slate-600 transition-colors"
+            :aria-label="t('common.close')"
+            data-testid="collections-chat-close"
+            @click="closeChat"
+          >
+            <span class="material-icons text-lg">close</span>
+          </button>
+        </header>
+
+        <div class="px-6 py-5">
+          <textarea
+            ref="chatInputEl"
+            v-model="chatMessage"
+            rows="4"
+            :placeholder="t('collectionsView.chatPlaceholder')"
+            class="w-full bg-slate-50 border border-slate-200/80 rounded-xl px-3 py-2.5 text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 focus:bg-white transition-all resize-none"
+            data-testid="collections-chat-input"
+            @keydown.meta.enter="submitChat"
+            @keydown.ctrl.enter="submitChat"
+          ></textarea>
+        </div>
+
+        <footer class="px-6 py-3.5 border-t border-slate-100 flex items-center justify-end gap-2 bg-slate-50/50">
+          <button
+            type="button"
+            class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"
+            data-testid="collections-chat-cancel"
+            @click="closeChat"
+          >
+            {{ t("common.cancel") }}
+          </button>
+          <button
+            type="button"
+            class="h-8 px-2.5 rounded bg-indigo-600 text-white font-bold text-xs hover:bg-indigo-700 disabled:opacity-50 transition-all shadow-sm shadow-indigo-600/10"
+            :disabled="!chatMessage.trim()"
+            data-testid="collections-chat-send"
+            @click="submitChat"
+          >
+            {{ t("collectionsView.chatStart") }}
+          </button>
+        </footer>
+      </div>
+    </div>
+
     <!-- Open / detail modal (read-only document-style card) -->
     <div
       v-if="viewing && collection"
@@ -680,12 +754,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { apiDelete, apiGet, apiPost, apiPut } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 import { PAGE_ROUTES } from "../router/pageRoutes";
+import { BUILTIN_ROLE_IDS } from "../config/roles";
 import ConfirmModal from "./ConfirmModal.vue";
 import CollectionEmbedView from "./CollectionEmbedView.vue";
 import type { EmbedRow, EmbedView } from "./collectionEmbed";
@@ -885,6 +960,9 @@ const saving = ref(false);
 const saveError = ref<string | null>(null);
 const actionPending = ref(false);
 const actionError = ref<string | null>(null);
+const chatOpen = ref(false);
+const chatMessage = ref("");
+const chatInputEl = ref<HTMLTextAreaElement | null>(null);
 const refCache = ref<RefCache>({});
 const refRecordCache = ref<RefRecordCache>({});
 const embedCache = ref<EmbedCache>({});
@@ -968,6 +1046,28 @@ async function runAction(action: CollectionAction): Promise<void> {
     return;
   }
   appApi.startNewChat(result.data.prompt, result.data.role);
+}
+
+/** Open the chat modal, blanking any prior draft and focusing the input. */
+function openChat(): void {
+  chatMessage.value = "";
+  chatOpen.value = true;
+  void nextTick(() => chatInputEl.value?.focus());
+}
+
+function closeChat(): void {
+  chatOpen.value = false;
+}
+
+/** Start a new general-role chat seeded with the collection's skill
+ *  command, so e.g. "I want to create an item" on `mc_worklog` becomes
+ *  `/mc_worklog I want to create an item`. */
+function submitChat(): void {
+  if (!collection.value) return;
+  const message = chatMessage.value.trim();
+  if (!message) return;
+  closeChat();
+  appApi.startNewChat(`/${collection.value.slug} ${message}`, BUILTIN_ROLE_IDS.general);
 }
 
 async function loadCollection(slug: string): Promise<void> {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1373,6 +1373,10 @@ const deMessages = {
     editTitle: "Datensatz bearbeiten",
     derivedLabel: "Abgeleitet",
     embedMissingTitle: "Eingebettete Referenz fehlt",
+    chat: "Chat",
+    chatTitle: "Chat starten",
+    chatPlaceholder: "Beschreibe, was du mit dieser Sammlung tun möchtest…",
+    chatStart: "Chat starten",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1354,6 +1354,10 @@ const enMessages = {
     editTitle: "Edit record",
     derivedLabel: "Derived",
     embedMissingTitle: "Embedded reference missing",
+    chat: "Chat",
+    chatTitle: "Start a chat",
+    chatPlaceholder: "Describe what you want to do with this collection…",
+    chatStart: "Start chat",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1368,6 +1368,10 @@ const esMessages = {
     editTitle: "Editar registro",
     derivedLabel: "Derivado",
     embedMissingTitle: "Falta la referencia incrustada",
+    chat: "Chat",
+    chatTitle: "Iniciar un chat",
+    chatPlaceholder: "Describe qué quieres hacer con esta colección…",
+    chatStart: "Iniciar chat",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1362,6 +1362,10 @@ const frMessages = {
     editTitle: "Modifier l'enregistrement",
     derivedLabel: "Calculé",
     embedMissingTitle: "Référence intégrée manquante",
+    chat: "Discussion",
+    chatTitle: "Démarrer une discussion",
+    chatPlaceholder: "Décrivez ce que vous voulez faire avec cette collection…",
+    chatStart: "Démarrer la discussion",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1351,6 +1351,10 @@ const jaMessages = {
     editTitle: "レコードを編集",
     derivedLabel: "計算値",
     embedMissingTitle: "埋め込み参照が見つかりません",
+    chat: "チャット",
+    chatTitle: "チャットを開始",
+    chatPlaceholder: "このコレクションで行いたいことを入力してください…",
+    chatStart: "チャットを開始",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1354,6 +1354,10 @@ const koMessages = {
     editTitle: "레코드 편집",
     derivedLabel: "파생",
     embedMissingTitle: "임베드된 참조 없음",
+    chat: "채팅",
+    chatTitle: "채팅 시작",
+    chatPlaceholder: "이 컬렉션으로 하고 싶은 작업을 설명하세요…",
+    chatStart: "채팅 시작",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1357,6 +1357,10 @@ const ptBRMessages = {
     editTitle: "Editar registro",
     derivedLabel: "Derivado",
     embedMissingTitle: "Referência incorporada ausente",
+    chat: "Chat",
+    chatTitle: "Iniciar um chat",
+    chatPlaceholder: "Descreva o que você quer fazer com esta coleção…",
+    chatStart: "Iniciar chat",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1344,6 +1344,10 @@ const zhMessages = {
     editTitle: "编辑记录",
     derivedLabel: "派生",
     embedMissingTitle: "缺少嵌入引用",
+    chat: "对话",
+    chatTitle: "开始对话",
+    chatPlaceholder: "描述你想对这个集合做什么…",
+    chatStart: "开始对话",
     source: {
       user: "用户",
       project: "项目",


### PR DESCRIPTION
## Summary

Adds a **"+ Chat"** button next to the existing **"+ Add"** button in the collection view (`CollectionView.vue`).

- The button shows in the header whenever a collection is loaded (left of "+ Add").
- Tapping it opens a modal with a text input for the user's message.
- On submit, it starts a **new chat in the `general` role** seeded with the collection's skill command: `/<slug> <message>`.
  - e.g. typing *"I want to create an item"* on the `mc_worklog` collection sends `/mc_worklog I want to create an item`.

## Implementation notes

- Reuses the existing `appApi.startNewChat(message, role)` pattern — the same path `runAction` already uses for schema-declared actions.
- Modal mirrors the existing edit-modal styling; supports Cmd/Ctrl+Enter to submit, autofocus on open, and overlay-click / close-button dismissal.
- Button uses the standard `h-8 px-2.5` chrome sizing and a `forum` Material Icon (no emoji).
- i18n keys (`chat`, `chatTitle`, `chatPlaceholder`, `chatStart`) added under `collectionsView` in **all 8 locales** in lockstep.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, and `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a collection-level entry point to start a new chat seeded with the collection’s skill command.

New Features:
- Add a "+ Chat" button in the collection header to initiate chats tied to the current collection.
- Introduce a chat modal from collections that captures a user prompt and opens a new general-role chat seeded with the collection’s skill command.

Enhancements:
- Wire collection-initiated chats to use the built-in general role and existing chat creation API.
- Improve collection UX with keyboard shortcuts, autofocus, and dismiss behaviors for the new chat modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-collection chat with a chat button on collection pages that opens a modal dialog
  * Message input supports keyboard shortcuts (meta+enter / ctrl+enter); send is disabled for empty/whitespace messages
  * Multilingual translations added for the chat UI across 8 languages

* **Tests**
  * End-to-end coverage added to verify chat open/close, input validation, submission, and dismissal behavior

* **Bug Fixes**
  * Improved slash-command handling so collection-prefixed chat messages are recognized reliably

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->