### PR TITLE
feat(collections): presentCollection tool + inline record panels

### DIFF
--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// Throwaway reproduction spec for the presentCollection render crash.
+// Captures the FIRST thrown exception (page.on("pageerror")) which the
+// browser console only showed as downstream null-component fallout.
+
+const SESSION_PATH = "/chat/watchlist-session";
+
+const WATCHLIST_DETAIL = {
+  collection: {
+    slug: "watchlist",
+    title: "Watchlist",
+    icon: "movie",
+    source: "user",
+    schema: {
+      title: "Watchlist",
+      icon: "movie",
+      dataPath: "data/watchlist/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true },
+        title: { type: "string", label: "Title", required: true },
+        type: { type: "string", label: "Type" },
+        mainActor: { type: "string", label: "Main Actor" },
+        genre: { type: "string", label: "Genre" },
+        platform: { type: "string", label: "Platform" },
+        synopsis: { type: "markdown", label: "Synopsis" },
+        watched: { type: "boolean", label: "Watched" },
+      },
+    },
+  },
+  items: [
+    { id: "avatar", title: "アバター", type: "映画", mainActor: "Sam Worthington", genre: "SF", platform: "Disney+", synopsis: "...", watched: false },
+    { id: "jack-ryan", title: "Jack Ryan", type: "TV", genre: "Thriller", platform: "Prime", watched: true },
+  ],
+};
+
+async function setup(page: Page) {
+  await mockAllApis(page, {
+    sessions: [{ id: "watchlist-session", title: "Watchlist", roleId: "general", startedAt: "2026-05-29T10:00:00Z", updatedAt: "2026-05-29T10:05:00Z" }],
+  });
+
+  await page.route(
+    (url) => url.pathname === "/api/collections/watchlist",
+    (route) => route.fulfill({ json: WATCHLIST_DETAIL }),
+  );
+
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [
+          { type: "session_meta", roleId: "general", sessionId: "watchlist-session" },
+          { type: "text", source: "user", message: "show me the watchlist" },
+          {
+            type: "tool_result",
+            source: "tool",
+            result: {
+              uuid: "pc-result-1",
+              toolName: "presentCollection",
+              title: "Watchlist",
+              message: "Presented collection watchlist / avatar",
+              data: { collectionSlug: "watchlist", itemId: "avatar" },
+            },
+          },
+        ],
+      }),
+  );
+}
+
+// Regression: the presentCollection card mounts the full CollectionView
+// via `wrapWithScope`, whose setup calls `pluginEndpoints("presentCollection")`.
+// That scope MUST be registered in the host endpoint registry
+// (`src/main.ts`); otherwise setup throws, the component subtree is left
+// null, and Vue's patch crashes with `emitsOptions`/`subTree` of null
+// during the next <App> update. This asserts the card renders cleanly,
+// the per-item detail modal opens (itemId in the tool result), and no
+// uncaught page error fires.
+test("presentCollection card renders the collection without crashing", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  await setup(page);
+  await page.goto(SESSION_PATH);
+
+  await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
+  // itemId "avatar" was passed → the read-only detail modal opens on mount.
+  await expect(page.getByTestId("collections-detail")).toBeVisible();
+  await expect(page.getByTestId("collections-detail-title")).toHaveText("avatar");
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});

--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -85,9 +85,53 @@ test("presentCollection card renders the collection without crashing", async ({ 
   await page.goto(SESSION_PATH);
 
   await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
-  // itemId "avatar" was passed → the read-only detail modal opens on mount.
+  // itemId "avatar" was passed → the read-only detail panel opens inline on mount.
   await expect(page.getByTestId("collections-detail")).toBeVisible();
   await expect(page.getByTestId("collections-detail-title")).toHaveText("avatar");
+
+  // The panel must fit the View width, never the (possibly wider) table
+  // width — otherwise a wide collection clips the right of the panel.
+  const cardBox = await page.getByTestId("present-collection").boundingBox();
+  const detailBox = await page.getByTestId("collections-detail").boundingBox();
+  expect(cardBox && detailBox && detailBox.width <= cardBox.width + 1).toBeTruthy();
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});
+
+test("Edit on an open record swaps the inline panel to the edit form in place", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  await setup(page);
+  await page.goto(SESSION_PATH);
+
+  await expect(page.getByTestId("collections-detail")).toBeVisible({ timeout: 10_000 });
+  // Edit flips the SAME inline expansion to the edit form (no modal).
+  await page.getByTestId("collections-detail-edit").click();
+  await expect(page.getByTestId("collections-edit")).toBeVisible();
+  await expect(page.getByTestId("collections-detail")).toBeHidden();
+  await expect(page.getByTestId("collections-input-title")).toHaveValue("アバター");
+  // No fixed-overlay modal is used anymore.
+  await expect(page.locator(".fixed.inset-0.z-30")).toHaveCount(0);
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});
+
+test("Add opens the create form as a panel pinned at the top of the list", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  await setup(page);
+  await page.goto(SESSION_PATH);
+  await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByTestId("collections-add-item").click();
+  const createForm = page.getByTestId("collections-create");
+  await expect(createForm).toBeVisible();
+  // The create panel sits above the first data row (synthetic top row).
+  const createBox = await createForm.boundingBox();
+  const firstRow = await page.getByTestId("collections-row-avatar").boundingBox();
+  expect(createBox && firstRow && createBox.y < firstRow.y).toBeTruthy();
 
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });

--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -135,3 +135,28 @@ test("Add opens the create form as a panel pinned at the top of the list", async
 
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });
+
+test("saving an edit returns to the record's detail (does not close) in the embedded card", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  await setup(page);
+  await page.route(
+    (url) => url.pathname === "/api/collections/watchlist/items/avatar",
+    (route) => (route.request().method() === "PUT" ? route.fulfill({ json: { itemId: "avatar", item: WATCHLIST_DETAIL.items[0] } }) : route.fallback()),
+  );
+  await page.goto(SESSION_PATH);
+
+  await expect(page.getByTestId("collections-detail")).toBeVisible({ timeout: 10_000 });
+  await page.getByTestId("collections-detail-edit").click();
+  await expect(page.getByTestId("collections-edit")).toBeVisible();
+  await page.getByTestId("collections-input-title").fill("アバター (改)");
+  await page.getByTestId("collections-editor-save").click();
+
+  // Back to the read-only detail of the same record — NOT closed.
+  await expect(page.getByTestId("collections-detail")).toBeVisible();
+  await expect(page.getByTestId("collections-detail-title")).toHaveText("avatar");
+  await expect(page.getByTestId("collections-edit")).toBeHidden();
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});

--- a/plans/feat-present-collection.md
+++ b/plans/feat-present-collection.md
@@ -152,6 +152,34 @@ registration crash above).
 shows the detail modal over the card; Edit writes back and the list
 refreshes.
 
+## Follow-up: inline panels instead of modals
+
+The item detail / edit / create surfaces were modals (`fixed inset-0`),
+which felt unnatural — and in the chat card a full-viewport overlay over
+a card is jarring. Replaced with **inline panels** (applies to both the
+standalone `/collections/:slug` page and the chat card — `CollectionView`
+itself):
+
+- **Detail & edit** expand as a panel **directly under the open row**
+  (`<tr>` + full-width `<td :colspan>`). Edit reuses the detail **2-col
+  grid layout** (label + input), so detail↔edit is visually continuous.
+- **Create** rides a **synthetic top row** (`CREATE_ROW_ID`) whose data
+  row is hidden — only its expansion (the form) shows, pinned above the
+  list. This keeps the edit form in a SINGLE template location (no
+  duplication, no child component, no `vue/no-mutating-props` fight).
+- **One panel open at a time** (`viewing` / `editing` single refs;
+  `openView`/`openEdit`/`openCreate` clear the others). Clicking the open
+  row toggles it closed. Panels cap at `max-h-[60vh]` with internal
+  scroll so the list isn't pushed far down.
+- Empty / no-match states are suppressed while creating so the create
+  panel still renders on an empty collection.
+- No `fixed`-overlay modal remains for records (the **chat** modal is
+  unchanged). e2e asserts `.fixed.inset-0.z-30` count is 0 after Edit.
+
+e2e (`present-collection.spec.ts`) covers: detail-on-mount, Edit→in-place
+edit form, and Add→top create panel. All 12 existing collection specs
+(standalone route) still pass.
+
 ## Out of scope (v1)
 
 - ref-link in-card navigation (see limitation above)

--- a/plans/feat-present-collection.md
+++ b/plans/feat-present-collection.md
@@ -1,0 +1,159 @@
+# feat: `presentCollection` — inline editable collection card in chat
+
+## Goal
+
+Let the LLM present a collection (or a specific item) inline in a chat
+session via a `presentCollection` MCP tool. The rendered card reuses the
+**full `CollectionView`** surface: the collection list/grid in the card
+body, and the existing detail / edit modal overlay popping **on top** when
+an item is opened. Edits write back to the workspace through the existing
+`/api/collections/...` REST routes — no new persistence layer.
+
+Decision (confirmed with user): **inline card, editable**, and **reuse
+`CollectionView` wholesale** rather than extracting field renderers.
+
+## Why this shape
+
+- The gui-chat-protocol render contract is already proven by the
+  `present*` family (`presentForm`, `presentSpreadsheet`, …): an MCP tool
+  returns a `ToolResult` whose `data` field is the host's
+  render-eligibility signal; the plugin's `viewComponent` then renders
+  with the `selectedResult` prop (`src/components/StackView.vue`).
+- Editable-in-card CRUD is also already precedented — `canvas/View.vue`,
+  `markdown/View.vue`, `presentSVG/View.vue` all `apiPut` real workspace
+  data from inside the card. `CollectionView` already does the same via
+  `apiPost`/`apiPut`/`apiDelete` against `API_ROUTES.collections.*`.
+- So **no protocol change** and **no new server CRUD route** is needed.
+  The card is a thin wrapper that mounts `CollectionView`; `CollectionView`
+  fetches and mutates live workspace state itself.
+
+## The one real refactor: decouple `CollectionView` from the router
+
+`CollectionView.vue` is currently **router-driven**, not prop-driven:
+
+| Concern | Today | Lines |
+|---|---|---|
+| which collection | `route.params.slug` | 1933, 1959 |
+| which item is open | `route.query.selected` | 1606, 1952 |
+| open/close item | `router.replace` (drop `?selected=`) | 1577–1581 |
+| back to index | `router.push` | 1929 |
+
+Mounted as-is in a chat card it would read the **chat** route (wrong
+slug) and navigate the app away from chat on interaction. Fix: give it a
+**prop-or-route** source and two modes.
+
+### Changes to `src/components/CollectionView.vue`
+
+1. Add optional props + emit (defaults keep standalone route mode intact):
+   ```ts
+   const props = defineProps<{ slug?: string; selected?: string }>();
+   const emit = defineEmits<{ (e: "select", id: string | null): void }>();
+   const embedded = computed(() => props.slug !== undefined);
+   const activeSlug = computed(() =>
+     props.slug !== undefined
+       ? props.slug
+       : (typeof route.params.slug === "string" && route.params.slug.length > 0 ? route.params.slug : undefined));
+   const activeSelected = computed(() =>
+     embedded.value
+       ? props.selected
+       : (typeof route.query.selected === "string" ? route.query.selected : undefined));
+   ```
+2. Replace `onMounted` + the `route.params.slug` watch with a single
+   `watch(activeSlug, …, { immediate: true })` (same load/clear logic).
+3. `syncViewToSelected()` reads `activeSelected.value` instead of
+   `route.query.selected`; the `route.query.selected` watch becomes
+   `watch(activeSelected, …)`.
+4. `openView(item)`: in embedded mode also `emit("select", id)`.
+5. `closeView()`: in embedded mode `emit("select", null)` and return
+   (skip `router.replace`); standalone path unchanged.
+6. Hide the header back button when `embedded` (`v-if="!embedded"`); a
+   chat card has no "collections index" to go back to.
+
+Everything else — the edit/create/detail modals, `EditState`,
+`draftToRecord`, the CRUD calls, ref/embed/derived rendering — is
+untouched. Standalone `/collections/:slug` behaviour is byte-for-byte
+identical when no `slug` prop is passed.
+
+**Known v1 limitation (follow-up):** `ref`-field `<router-link>`s in the
+table/detail still navigate the app route; clicking one in an embedded
+card leaves the chat. Acceptable for v1; document and revisit.
+
+## The plugin (`src/plugins/presentCollection/`)
+
+Built-in plugin; barrels (`metas.ts`, `index.ts`, `server.ts`) are
+**auto-generated** by `yarn plugins:codegen` (predev/prebuild) — just drop
+the directory.
+
+- `meta.ts` — `definePluginMeta({ toolName: "presentCollection",
+  apiNamespace: "presentCollection", apiRoutes: { dispatch: { method:
+  "POST", path: "" } }, mcpDispatch: "dispatch" })`. Namespace is distinct
+  from the host's `collections` REST routes, so no aggregator collision.
+- `types.ts` — `PresentCollectionData = { collectionSlug: string; itemId?: string }`,
+  `PresentCollectionArgs` (same shape).
+- `definition.ts` — `TOOL_DEFINITION` with params
+  `{ collectionSlug: string (required), itemId?: string }`; derive
+  `TOOL_NAME = META.toolName`.
+- `plugin.ts` — `executePresentCollection(_ctx, args)`: validate
+  `collectionSlug` is a non-empty string, return
+  `{ message, data: { collectionSlug, itemId }, jsonData, instructions }`.
+  Pure / isomorphic (no Vue, no Node-only imports — it's bundled to the
+  browser via `index.ts` and run server-side via `plugins.ts`). Existence
+  of the slug is validated client-side by `CollectionView`'s `loadError`
+  (`"not-found"`) path.
+- `index.ts` — `REGISTRATION` with
+  `viewComponent: wrapWithScope("presentCollection", View)` and
+  `previewComponent: wrapWithScope("presentCollection", Preview)`.
+- `View.vue` — thin wrapper: reads `selectedResult.data` →
+  `{ collectionSlug, itemId }`; `selected` = `viewState.selected` (if the
+  user navigated within the card) else `itemId`; mounts
+  `<CollectionView :slug :selected @select>`; on `select` emits
+  `updateResult` with `viewState: { selected }` so the open item survives
+  re-render (the `presentForm` viewState pattern).
+- `Preview.vue` — compact transcript card (collection title/slug + open
+  item id if any).
+
+## Host wiring
+
+1. **`server/api/routes/plugins.ts`** (NOT auto-generated): add
+   ```ts
+   bindRoute(router, API_ROUTES.presentCollection.dispatch,
+     wrapPluginExecute((req) => executePresentCollection(null as never, req.body)));
+   ```
+2. `yarn plugins:codegen` — regenerates `_generated/{metas,registrations,server-bindings}.ts`.
+3. **`src/main.ts`** — add `presentCollection: API_ROUTES.presentCollection`
+   to `pluginEndpointRegistry`. **Required**: `wrapWithScope` calls
+   `pluginEndpoints("presentCollection")` at View setup, which THROWS
+   `Unknown plugin endpoint scope` if the scope isn't registered here.
+   The throw aborts setup, leaves the component subtree null, and the
+   next `<App>` patch crashes with `emitsOptions` / `subTree` of null —
+   surfacing only as Vue-internal errors, not the real cause. (This was
+   the actual bug in the first cut.)
+4. **`src/config/roles.ts`** — add `TOOL_NAMES.presentCollection` to
+   `availablePlugins` of **General** and **Personal** (Office/accounting/
+   investor use specialised tools, not generic collections). The tool
+   description carries the when-to-use guidance, so no prompt edits.
+5. **i18n** — add `pluginPresentCollection.*` keys (Preview labels only;
+   the View inherits `CollectionView`'s existing `collectionsView.*`
+   strings) to **all 8** locales in lockstep.
+
+## Regression test
+
+`e2e/tests/present-collection.spec.ts` — injects a `presentCollection`
+tool result (with `itemId`) into a mocked session, mocks
+`/api/collections/watchlist`, and asserts the card renders, the detail
+modal opens, and **no uncaught page error fires** (guards the scope-
+registration crash above).
+
+## Validation
+
+`yarn format && yarn lint && yarn typecheck && yarn build`. Manual: in
+`yarn dev`, a chat in a role with the tool → LLM calls
+`presentCollection({ collectionSlug })` → list card renders; opening a row
+shows the detail modal over the card; Edit writes back and the list
+refreshes.
+
+## Out of scope (v1)
+
+- ref-link in-card navigation (see limitation above)
+- existence validation in the executor (handled client-side)
+- e2e fake-agent detector for the new tool

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -3,6 +3,7 @@ import { executeMindMap } from "@gui-chat-plugin/mindmap";
 import { executeSpreadsheet, type SpreadsheetArgs } from "../../../src/plugins/spreadsheet/definition.js";
 import { executeQuiz } from "@mulmochat-plugin/quiz";
 import { executeForm } from "../../../src/plugins/presentForm/plugin.js";
+import { executePresentCollection } from "../../../src/plugins/presentCollection/plugin.js";
 import { executeOpenCanvas } from "../../../src/plugins/canvas/definition.js";
 import { executePresent3D } from "@gui-chat-plugin/present3d";
 import { executeMapControl } from "@gui-chat-plugin/google-map";
@@ -243,6 +244,15 @@ bindRoute(
   router,
   API_ROUTES.form.dispatch,
   wrapPluginExecute((req) => executeForm(null as never, req.body)),
+);
+
+// presentCollection — render a collection (or one item) as an inline,
+// editable chat card. The View mounts CollectionView, which fetches +
+// mutates live workspace state via the existing /api/collections routes.
+bindRoute(
+  router,
+  API_ROUTES.presentCollection.dispatch,
+  wrapPluginExecute((req) => executePresentCollection(null as never, req.body)),
 );
 
 // 1×1 transparent PNG. Used as a placeholder so the canvas tool

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -2,6 +2,7 @@
   <div class="h-full flex flex-col bg-slate-50/30">
     <header class="flex items-center gap-3 px-6 py-4 border-b border-slate-200 bg-white">
       <button
+        v-if="!embedded"
         type="button"
         class="h-8 w-8 flex items-center justify-center rounded text-slate-500 hover:bg-slate-50 hover:text-slate-800 transition-colors"
         :title="t('collectionsView.backToIndex')"
@@ -758,7 +759,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { apiDelete, apiGet, apiPost, apiPut } from "../utils/api";
@@ -943,11 +944,49 @@ interface EditState {
   originalId: string | null;
 }
 
+/** `slug` / `selected` are supplied only in EMBEDDED mode (the
+ *  `presentCollection` chat card mounts this component and drives both
+ *  from the tool result). In standalone route mode (the
+ *  `/collections/:slug` page) both are undefined and the component reads
+ *  `route.params.slug` / `route.query.selected` as before. */
+const props = defineProps<{
+  slug?: string;
+  selected?: string;
+}>();
+
+const emit = defineEmits<{
+  /** Embedded mode only: the open record changed (id) or closed (null).
+   *  The card persists this in its tool-result `viewState` so the open
+   *  item survives a re-render. */
+  select: [id: string | null];
+}>();
+
 const { t, locale } = useI18n();
 const route = useRoute();
 const router = useRouter();
 const { openConfirm } = useConfirm();
 const appApi = useAppApi();
+
+/** Embedded when a `slug` prop is supplied; standalone (route-driven)
+ *  otherwise. Switches the slug/selected source and the open/close
+ *  navigation behaviour. */
+const embedded = computed<boolean>(() => props.slug !== undefined);
+
+/** Active collection slug: the prop in embedded mode, else the route
+ *  param. */
+const activeSlug = computed<string | undefined>(() => {
+  if (props.slug !== undefined) return props.slug;
+  const { slug } = route.params;
+  return typeof slug === "string" && slug.length > 0 ? slug : undefined;
+});
+
+/** Active open-record id: the prop in embedded mode (may be undefined),
+ *  else the `?selected=` query. */
+const activeSelected = computed<string | undefined>(() => {
+  if (embedded.value) return props.selected;
+  const { selected } = route.query;
+  return typeof selected === "string" ? selected : undefined;
+});
 
 const collection = ref<CollectionDetail | null>(null);
 const items = ref<CollectionItem[]>([]);
@@ -1562,18 +1601,27 @@ function closeEditor(): void {
   saveError.value = null;
 }
 
-/** Open mode (read-only detail). */
+/** Open mode (read-only detail). In embedded mode, report the open id
+ *  so the host card can persist it in `viewState`. */
 function openView(item: CollectionItem): void {
   viewing.value = item;
   actionError.value = null;
+  if (embedded.value && collection.value) {
+    emit("select", String(item[collection.value.schema.primaryKey] ?? ""));
+  }
 }
 
-/** Close open mode and drop the `?selected=` query param so a
- *  refresh / back-button doesn't immediately reopen the record and
- *  the URL reflects the closed state. */
+/** Close open mode. Embedded mode reports the close via `select(null)`
+ *  (the card clears its `viewState`); standalone mode drops the
+ *  `?selected=` query param so a refresh / back-button doesn't reopen
+ *  the record and the URL reflects the closed state. */
 function closeView(): void {
   viewing.value = null;
   actionError.value = null;
+  if (embedded.value) {
+    emit("select", null);
+    return;
+  }
   if (route.query.selected !== undefined) {
     const query = { ...route.query };
     delete query.selected;
@@ -1603,7 +1651,7 @@ function findItemById(itemId: string): CollectionItem | undefined {
  *  back / forward and a removed param both close the modal instead
  *  of leaving stale UI on screen (Codex P2 + CodeRabbit on #1502). */
 function syncViewToSelected(): void {
-  const { selected } = route.query;
+  const selected = activeSelected.value;
   if (typeof selected !== "string" || selected.length === 0) {
     viewing.value = null;
     return;
@@ -1929,10 +1977,14 @@ function goBack(): void {
   router.push({ name: PAGE_ROUTES.collections, params: {} }).catch(() => {});
 }
 
+// Load on slug change, immediate so the initial value (route param or
+// prop) triggers the first fetch — replaces the old `onMounted` +
+// separate slug watch. Works identically for route mode (reads
+// `route.params.slug`) and embedded mode (reads the `slug` prop).
 watch(
-  () => route.params.slug,
+  activeSlug,
   (slug) => {
-    if (typeof slug === "string" && slug.length > 0) {
+    if (slug) {
       loadCollection(slug);
     } else {
       collection.value = null;
@@ -1941,26 +1993,15 @@ watch(
       loading.value = false;
     }
   },
+  { immediate: true },
 );
 
-// React to `?selected=` changing while already on this collection:
-// follow it to open the new record, OR close the modal when the
-// param is removed (browser back) or points at a missing id. The
-// initial / cross-collection case is handled by `loadCollection`;
+// React to the active selection changing while already on this
+// collection: follow it to open the new record, OR close the modal when
+// it's cleared (browser back / card close) or points at a missing id.
+// The initial / cross-collection case is handled by `loadCollection`;
 // here we only act once items are loaded.
-watch(
-  () => route.query.selected,
-  () => {
-    if (!loading.value && collection.value) syncViewToSelected();
-  },
-);
-
-onMounted(() => {
-  const { slug } = route.params;
-  if (typeof slug === "string" && slug.length > 0) {
-    loadCollection(slug);
-  } else {
-    loading.value = false;
-  }
+watch(activeSelected, () => {
+  if (!loading.value && collection.value) syncViewToSelected();
 });
 </script>

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -92,12 +92,15 @@
         <!-- defensive: loading=false, error=null, collection=null -->
       </div>
 
-      <div v-else-if="items.length === 0" class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2">
+      <div v-else-if="items.length === 0 && editing?.mode !== 'create'" class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2">
         <span class="material-icons text-4xl text-slate-300">folder_open</span>
         <p class="font-semibold text-slate-600">{{ t("collectionsView.itemsEmpty") }}</p>
       </div>
 
-      <div v-else-if="filteredItems.length === 0" class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2">
+      <div
+        v-else-if="filteredItems.length === 0 && editing?.mode !== 'create'"
+        class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2"
+      >
         <span class="material-icons text-4xl text-slate-300">search_off</span>
         <p class="font-semibold text-slate-600">{{ t("collectionsView.noMatchingItems") }}</p>
         <button type="button" class="text-xs text-indigo-600 font-semibold hover:underline" @click="searchQuery = ''">
@@ -105,7 +108,7 @@
         </button>
       </div>
 
-      <div v-else class="overflow-x-auto">
+      <div v-else class="overflow-x-auto [container-type:inline-size]">
         <table class="min-w-full text-xs">
           <thead>
             <tr class="bg-slate-50 border-b border-slate-200">
@@ -116,381 +119,561 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-100 bg-white">
-            <tr
-              v-for="item in filteredItems"
-              :key="String(item[collection.schema.primaryKey] ?? '')"
-              class="hover:bg-slate-50/70 cursor-pointer transition-colors focus:outline-none focus:bg-indigo-50/30"
-              role="button"
-              tabindex="0"
-              :aria-label="t('collectionsView.openItem', { id: String(item[collection.schema.primaryKey] ?? '') })"
-              :data-testid="`collections-row-${item[collection.schema.primaryKey]}`"
-              @click="openView(item)"
-              @keydown.enter.self="openView(item)"
-              @keydown.space.self.prevent="openView(item)"
-            >
-              <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
-                <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
-                <template v-if="fieldVisible(field, item)">
-                  <!-- Boolean state badge -->
-                  <span v-if="field.type === 'boolean'" class="block">
-                    <span
-                      v-if="item[key] === true"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
-                    >
-                      <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
-                      {{ t("common.yes") }}
+            <template v-for="item in displayItems" :key="String(item[collection.schema.primaryKey] ?? '')">
+              <tr
+                v-if="!isCreateRow(item)"
+                class="hover:bg-slate-50/70 cursor-pointer transition-colors focus:outline-none focus:bg-indigo-50/30"
+                :class="isRowOpen(item) || isEditingRow(item) ? 'bg-indigo-50/40' : ''"
+                role="button"
+                tabindex="0"
+                :aria-label="t('collectionsView.openItem', { id: String(item[collection.schema.primaryKey] ?? '') })"
+                :data-testid="`collections-row-${item[collection.schema.primaryKey]}`"
+                @click="openView(item)"
+                @keydown.enter.self="openView(item)"
+                @keydown.space.self.prevent="openView(item)"
+              >
+                <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
+                  <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
+                  <template v-if="fieldVisible(field, item)">
+                    <!-- Boolean state badge -->
+                    <span v-if="field.type === 'boolean'" class="block">
+                      <span
+                        v-if="item[key] === true"
+                        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
+                      >
+                        <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
+                        {{ t("common.yes") }}
+                      </span>
+                      <span
+                        v-else-if="item[key] === false"
+                        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
+                      >
+                        {{ t("common.no") }}
+                      </span>
+                      <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false (the edit pipeline tracks presence via boolOriginallyPresent). -->
+                      <span v-else class="text-slate-300">—</span>
                     </span>
-                    <span
-                      v-else-if="item[key] === false"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
-                    >
-                      {{ t("common.no") }}
+
+                    <!-- Ref router-link badge -->
+                    <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
+                      <router-link
+                        :to="{ path: `/collections/${field.to}`, query: { selected: String(item[key]) } }"
+                        class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
+                        :data-testid="`collections-ref-link-${key}-${item[key]}`"
+                        @click.stop
+                        >{{ refDisplay(field.to, String(item[key])) }}</router-link
+                      >
                     </span>
-                    <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false (the edit pipeline tracks presence via boolOriginallyPresent). -->
-                    <span v-else class="text-slate-300">—</span>
-                  </span>
 
-                  <!-- Ref router-link badge -->
-                  <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
-                    <router-link
-                      :to="{ path: `/collections/${field.to}`, query: { selected: String(item[key]) } }"
-                      class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
-                      :data-testid="`collections-ref-link-${key}-${item[key]}`"
-                      @click.stop
-                      >{{ refDisplay(field.to, String(item[key])) }}</router-link
+                    <!-- Enum badges -->
+                    <span
+                      v-else-if="field.type === 'enum' && item[key]"
+                      class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border"
+                      :class="enumBadgeClass(item[key])"
                     >
-                  </span>
+                      {{ item[key] }}
+                    </span>
 
-                  <!-- Enum badges -->
-                  <span
-                    v-else-if="field.type === 'enum' && item[key]"
-                    class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border"
-                    :class="enumBadgeClass(item[key])"
-                  >
-                    {{ item[key] }}
-                  </span>
+                    <!-- Money -->
+                    <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
+                      formatMoney(item[key], resolveCurrency(field, item), locale)
+                    }}</span>
 
-                  <!-- Money -->
-                  <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
-                    formatMoney(item[key], resolveCurrency(field, item), locale)
-                  }}</span>
+                    <!-- Table summary counter -->
+                    <span
+                      v-else-if="field.type === 'table'"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-[10px] font-bold bg-slate-100 text-slate-600 border border-slate-200/40"
+                    >
+                      <span class="material-icons text-[11px]">list</span>
+                      <span>{{ tableSummary(item[key]) }}</span>
+                    </span>
 
-                  <!-- Table summary counter -->
-                  <span
-                    v-else-if="field.type === 'table'"
-                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-[10px] font-bold bg-slate-100 text-slate-600 border border-slate-200/40"
-                  >
-                    <span class="material-icons text-[11px]">list</span>
-                    <span>{{ tableSummary(item[key]) }}</span>
-                  </span>
+                    <!-- Derived formula fields -->
+                    <span
+                      v-else-if="field.type === 'derived'"
+                      class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
+                      >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
+                    >
 
-                  <!-- Derived formula fields -->
-                  <span
-                    v-else-if="field.type === 'derived'"
-                    class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
-                    >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
-                  >
-
-                  <!-- URL string → external link (new tab). `@click.stop` so
+                    <!-- URL string → external link (new tab). `@click.stop` so
                      clicking the link doesn't also open the row's detail. -->
-                  <a
-                    v-else-if="isExternalUrl(item[key])"
-                    :href="String(item[key])"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
-                    :data-testid="`collections-url-link-${key}-${item[collection.schema.primaryKey]}`"
-                    @click.stop
-                    >{{ String(item[key]) }}</a
-                  >
+                    <a
+                      v-else-if="isExternalUrl(item[key])"
+                      :href="String(item[key])"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+                      :data-testid="`collections-url-link-${key}-${item[collection.schema.primaryKey]}`"
+                      @click.stop
+                      >{{ String(item[key]) }}</a
+                    >
 
-                  <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
-                </template>
-              </td>
+                    <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
+                  </template>
+                </td>
 
-              <td class="px-5 py-2 text-right whitespace-nowrap align-middle">
-                <div class="flex items-center justify-end gap-2">
-                  <button
-                    type="button"
-                    class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 border border-transparent hover:border-indigo-100 transition-all duration-200"
-                    :title="t('collectionsView.editItem')"
-                    :aria-label="t('collectionsView.editItem')"
-                    :data-testid="`collections-edit-item-${item[collection.schema.primaryKey]}`"
-                    @click.stop="openEdit(item)"
-                  >
-                    <span class="material-icons text-base">edit</span>
-                  </button>
-                  <button
-                    type="button"
-                    class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 border border-transparent hover:border-rose-100 transition-all duration-200"
-                    :title="t('common.remove')"
-                    :aria-label="t('common.remove')"
-                    :data-testid="`collections-delete-item-${item[collection.schema.primaryKey]}`"
-                    @click.stop="confirmDelete(item)"
-                  >
-                    <span class="material-icons text-base">delete</span>
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
+                <td class="px-5 py-2 text-right whitespace-nowrap align-middle">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 border border-transparent hover:border-indigo-100 transition-all duration-200"
+                      :title="t('collectionsView.editItem')"
+                      :aria-label="t('collectionsView.editItem')"
+                      :data-testid="`collections-edit-item-${item[collection.schema.primaryKey]}`"
+                      @click.stop="openEdit(item)"
+                    >
+                      <span class="material-icons text-base">edit</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 border border-transparent hover:border-rose-100 transition-all duration-200"
+                      :title="t('common.remove')"
+                      :aria-label="t('common.remove')"
+                      :data-testid="`collections-delete-item-${item[collection.schema.primaryKey]}`"
+                      @click.stop="confirmDelete(item)"
+                    >
+                      <span class="material-icons text-base">delete</span>
+                    </button>
+                  </div>
+                </td>
+              </tr>
 
-    <!-- Edit / Create modal -->
-    <div
-      v-if="editing && collection"
-      class="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/60 backdrop-blur-sm p-4 transition-all duration-300"
-      @click.self="closeEditor"
-    >
-      <div
-        class="bg-white rounded-2xl shadow-2xl w-full max-w-xl max-h-[85vh] flex flex-col border border-slate-200 overflow-hidden transform scale-100 transition-all"
-      >
-        <header class="px-6 py-4 border-b border-slate-100 flex items-center gap-3 bg-slate-50/50">
-          <div class="h-9 w-9 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100/50">
-            <span class="material-icons text-lg">{{ editing.mode === "create" ? "add_circle_outline" : "edit" }}</span>
-          </div>
-          <div class="flex-1">
-            <h2 class="text-sm font-bold text-slate-800 uppercase tracking-wide">
-              {{ editing.mode === "create" ? t("collectionsView.createTitle") : t("collectionsView.editTitle") }}
-            </h2>
-            <span class="text-xs text-slate-400 font-semibold">{{ collection.title }}</span>
-          </div>
-          <button
-            type="button"
-            class="h-8 w-8 flex items-center justify-center rounded text-slate-400 hover:bg-slate-200/50 hover:text-slate-600 transition-colors"
-            :aria-label="t('common.close')"
-            data-testid="collections-editor-close"
-            @click="closeEditor"
-          >
-            <span class="material-icons text-lg">close</span>
-          </button>
-        </header>
+              <!-- Inline detail / edit panel: expands directly under the open
+                 row (replaces the old fixed modal). One row open at a time.
+                 The create form rides the synthetic top row (isCreateRow). -->
+              <tr v-if="shouldExpand(item)" :data-testid="`collections-expansion-${item[collection.schema.primaryKey]}`">
+                <td :colspan="listColumnFields.length + 1" class="p-0 border-l-2 border-indigo-300 bg-slate-50/60">
+                  <!-- Pin the panel to the View's visible width, not the
+                       (possibly much wider) table width: sticky to the left
+                       edge of the horizontal scroller and capped at the
+                       scroller's content width via container-query units, so
+                       a wide collection never pushes the panel off-screen.
+                       `min(100%, 100cqw)` keeps it at table width when the
+                       table is narrower than the View. -->
+                  <div class="sticky left-0 w-[min(100%,100cqw)]">
+                    <!-- Edit / Create panel (in-place, detail-style grid layout).
+                     Shown for the row being edited, or for the synthetic
+                     create row pinned at the top of the list. -->
+                    <form
+                      v-if="isEditingRow(item)"
+                      class="px-6 py-5 max-h-[60vh] overflow-y-auto"
+                      :data-testid="isCreateRow(item) ? 'collections-create' : 'collections-edit'"
+                      @submit.prevent="saveEditor"
+                    >
+                      <div class="flex items-center gap-2 mb-4">
+                        <div class="flex-1 min-w-0">
+                          <span class="block text-[9px] font-bold text-slate-400 uppercase tracking-wider">{{ collection.title }}</span>
+                          <h2 class="text-base font-bold text-slate-800 truncate">
+                            {{ editing && editing.mode === "create" ? t("collectionsView.createTitle") : t("collectionsView.editTitle") }}
+                          </h2>
+                        </div>
+                        <button
+                          type="button"
+                          class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"
+                          data-testid="collections-editor-cancel"
+                          @click="closeEditor"
+                        >
+                          {{ t("common.cancel") }}
+                        </button>
+                        <button
+                          type="submit"
+                          class="h-8 px-2.5 rounded bg-indigo-600 text-white font-bold text-xs hover:bg-indigo-700 disabled:opacity-50 transition-all shadow-sm shadow-indigo-600/10"
+                          :disabled="saving"
+                          data-testid="collections-editor-save"
+                        >
+                          {{ saving ? t("common.saving") : t("common.save") }}
+                        </button>
+                      </div>
 
-        <form class="flex-1 overflow-auto px-6 py-5 space-y-4" @submit.prevent="saveEditor">
-          <!-- `template v-for` + inner `v-if` so a `when`-gated field hides
-               live as its gating field changes (Vue 3: v-if can't share an
-               element with v-for). `liveRecord` reflects the in-progress draft. -->
-          <template v-for="(field, key) in collection.schema.fields" :key="key">
-            <div v-if="fieldVisible(field, liveRecord ?? {})" class="space-y-1.5">
-              <label class="text-[10px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1" :for="`collections-field-${key}`">
-                {{ field.label }}
-                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
-                <span v-if="field.required" class="text-rose-500 font-bold">*</span>
-              </label>
-
-              <!-- Boolean checkbox -->
-              <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2.5 text-sm text-slate-700 cursor-pointer select-none">
-                <input
-                  :id="`collections-field-${key}`"
-                  v-model="editing.bool[key]"
-                  type="checkbox"
-                  class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
-                  :data-testid="`collections-input-${key}`"
-                  @change="markBoolTouched(key)"
-                />
-                <span class="text-xs font-semibold" :class="editing.bool[key] ? 'text-indigo-600' : 'text-slate-500'">
-                  {{ editing.bool[key] ? t("common.yes") : t("common.no") }}
-                </span>
-              </label>
-
-              <!-- Embed card (read-only) -->
-              <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
-
-              <!-- Ref selector -->
-              <select
-                v-else-if="field.type === 'ref' && field.to && refOptions(field.to).length > 0"
-                :id="`collections-field-${key}`"
-                v-model="editing.text[key]"
-                :required="isFieldRequiredInUi(field)"
-                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
-                :data-testid="`collections-input-${key}`"
-              >
-                <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
-              </select>
-
-              <!-- Enum selector -->
-              <select
-                v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
-                :id="`collections-field-${key}`"
-                v-model="editing.text[key]"
-                :required="isFieldRequiredInUi(field)"
-                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
-                :data-testid="`collections-input-${key}`"
-              >
-                <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
-              </select>
-
-              <!-- Nested Table editor -->
-              <div
-                v-else-if="field.type === 'table' && field.of"
-                class="border border-slate-200 bg-slate-50/30 rounded-xl p-4 space-y-3"
-                :data-testid="`collections-table-${key}`"
-              >
-                <div v-if="editing.table[key] && editing.table[key].length > 0" class="overflow-hidden border border-slate-200 rounded-lg shadow-sm">
-                  <table class="w-full text-xs text-slate-600 bg-white">
-                    <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
-                      <tr>
-                        <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-3 py-2 font-bold">{{ subField.label }}</th>
-                        <th class="w-9"></th>
-                      </tr>
-                    </thead>
-                    <tbody class="divide-y divide-slate-100">
-                      <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx" class="hover:bg-slate-50/50">
-                        <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1.5 align-middle">
-                          <input
-                            v-if="subField.type === 'boolean'"
-                            v-model="row.bool[subKey]"
-                            type="checkbox"
-                            class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
-                            @change="markRowBoolTouched(row, String(subKey))"
-                          />
-                          <select
-                            v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
-                            v-model="row.text[subKey]"
-                            :required="subField.required"
-                            class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                      <div v-if="editing" class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
+                        <template v-for="(field, key) in collection.schema.fields" :key="key">
+                          <div
+                            v-if="fieldVisible(field, liveRecord ?? {})"
+                            class="flex flex-col gap-1.5"
+                            :class="['table', 'markdown', 'embed'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
                           >
-                            <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                            <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
-                          </select>
-                          <select
-                            v-else-if="subField.type === 'ref' && subField.to && refOptions(subField.to).length > 0"
-                            v-model="row.text[subKey]"
-                            :required="subField.required"
-                            class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
-                          >
-                            <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                            <option v-for="opt in refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
-                          </select>
-                          <!-- money subfield -->
-                          <div v-else-if="subField.type === 'money'" class="relative flex items-center">
-                            <span class="absolute left-1.5 text-[10px] text-slate-400 font-bold pr-1 border-r border-slate-200">{{
-                              currencySymbol(resolveCurrency(subField, liveRecord))
-                            }}</span>
+                            <label
+                              class="text-[10px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1"
+                              :for="`collections-field-${key}`"
+                            >
+                              {{ field.label }}
+                              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
+                              <span v-if="field.required" class="text-rose-500 font-bold">*</span>
+                            </label>
+
+                            <!-- Boolean checkbox -->
+                            <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2.5 text-sm text-slate-700 cursor-pointer select-none">
+                              <input
+                                :id="`collections-field-${key}`"
+                                v-model="editing.bool[key]"
+                                type="checkbox"
+                                class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                                :data-testid="`collections-input-${key}`"
+                                @change="markBoolTouched(key)"
+                              />
+                              <span class="text-xs font-semibold" :class="editing.bool[key] ? 'text-indigo-600' : 'text-slate-500'">
+                                {{ editing.bool[key] ? t("common.yes") : t("common.no") }}
+                              </span>
+                            </label>
+
+                            <!-- Embed card (read-only) -->
+                            <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
+
+                            <!-- Ref selector -->
+                            <select
+                              v-else-if="field.type === 'ref' && field.to && refOptions(field.to).length > 0"
+                              :id="`collections-field-${key}`"
+                              v-model="editing.text[key]"
+                              :required="isFieldRequiredInUi(field)"
+                              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
+                              :data-testid="`collections-input-${key}`"
+                            >
+                              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                              <option v-for="opt in refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+                            </select>
+
+                            <!-- Enum selector -->
+                            <select
+                              v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+                              :id="`collections-field-${key}`"
+                              v-model="editing.text[key]"
+                              :required="isFieldRequiredInUi(field)"
+                              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
+                              :data-testid="`collections-input-${key}`"
+                            >
+                              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                              <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+                            </select>
+
+                            <!-- Nested Table editor -->
+                            <div
+                              v-else-if="field.type === 'table' && field.of"
+                              class="border border-slate-200 bg-slate-50/30 rounded-xl p-4 space-y-3"
+                              :data-testid="`collections-table-${key}`"
+                            >
+                              <div
+                                v-if="editing.table[key] && editing.table[key].length > 0"
+                                class="overflow-hidden border border-slate-200 rounded-lg shadow-sm"
+                              >
+                                <table class="w-full text-xs text-slate-600 bg-white">
+                                  <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
+                                    <tr>
+                                      <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-3 py-2 font-bold">{{ subField.label }}</th>
+                                      <th class="w-9"></th>
+                                    </tr>
+                                  </thead>
+                                  <tbody class="divide-y divide-slate-100">
+                                    <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx" class="hover:bg-slate-50/50">
+                                      <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1.5 align-middle">
+                                        <input
+                                          v-if="subField.type === 'boolean'"
+                                          v-model="row.bool[subKey]"
+                                          type="checkbox"
+                                          class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                                          @change="markRowBoolTouched(row, String(subKey))"
+                                        />
+                                        <select
+                                          v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
+                                          v-model="row.text[subKey]"
+                                          :required="subField.required"
+                                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                                        >
+                                          <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                                          <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
+                                        </select>
+                                        <select
+                                          v-else-if="subField.type === 'ref' && subField.to && refOptions(subField.to).length > 0"
+                                          v-model="row.text[subKey]"
+                                          :required="subField.required"
+                                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                                        >
+                                          <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                                          <option v-for="opt in refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+                                        </select>
+                                        <div v-else-if="subField.type === 'money'" class="relative flex items-center">
+                                          <span class="absolute left-1.5 text-[10px] text-slate-400 font-bold pr-1 border-r border-slate-200">{{
+                                            currencySymbol(resolveCurrency(subField, liveRecord))
+                                          }}</span>
+                                          <input
+                                            v-model="row.text[subKey]"
+                                            type="number"
+                                            step="0.01"
+                                            :required="subField.required"
+                                            class="w-full rounded-lg border border-slate-200 pl-6 pr-1.5 py-1 text-xs focus:border-indigo-500 focus:outline-none font-semibold text-slate-800"
+                                          />
+                                        </div>
+                                        <input
+                                          v-else
+                                          v-model="row.text[subKey]"
+                                          :type="inputTypeFor(subField.type)"
+                                          :required="subField.required"
+                                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
+                                        />
+                                      </td>
+                                      <td class="text-center px-1">
+                                        <button
+                                          type="button"
+                                          class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
+                                          :aria-label="t('collectionsView.removeRow')"
+                                          :data-testid="`collections-table-${key}-remove-${rowIdx}`"
+                                          @click="removeTableRow(key, rowIdx)"
+                                        >
+                                          <span class="material-icons text-base">close</span>
+                                        </button>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                              <p v-else class="text-xs text-slate-400 italic">{{ t("collectionsView.noRows") }}</p>
+                              <button
+                                type="button"
+                                class="inline-flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
+                                :data-testid="`collections-table-${key}-add`"
+                                @click="addTableRow(key, field.of)"
+                              >
+                                <span class="material-icons text-xs">add</span>
+                                <span>{{ t("collectionsView.addRow") }}</span>
+                              </button>
+                            </div>
+
+                            <!-- Derived formula field -->
+                            <div v-else-if="field.type === 'derived'" class="relative flex items-center">
+                              <span class="absolute left-3 text-indigo-500 font-bold text-[9px] uppercase select-none tracking-wider">{{
+                                t("collectionsView.derivedLabel")
+                              }}</span>
+                              <input
+                                :id="`collections-field-${key}`"
+                                :value="derivedDisplay(field, liveDerived?.[key] ?? null, liveRecord)"
+                                type="text"
+                                disabled
+                                class="w-full rounded-xl border border-indigo-100 bg-indigo-50/15 pl-16 pr-3 py-2 text-xs font-bold text-indigo-700 select-none cursor-not-allowed"
+                                :data-testid="`collections-input-${key}`"
+                              />
+                            </div>
+
+                            <!-- Money input field -->
+                            <div v-else-if="field.type === 'money'" class="relative flex items-center">
+                              <div class="absolute left-3 text-slate-400 font-bold text-xs select-none pr-1.5 border-r border-slate-200">
+                                {{ currencySymbol(resolveCurrency(field, liveRecord)) }}
+                              </div>
+                              <input
+                                :id="`collections-field-${key}`"
+                                v-model="editing.text[key]"
+                                type="number"
+                                step="0.01"
+                                :required="isFieldRequiredInUi(field)"
+                                class="w-full rounded-xl border border-slate-200 pl-11 pr-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-semibold text-slate-800 transition-all"
+                                :data-testid="`collections-input-${key}`"
+                              />
+                            </div>
+
+                            <!-- Scalar inputs -->
                             <input
-                              v-model="row.text[subKey]"
-                              type="number"
-                              step="0.01"
-                              :required="subField.required"
-                              class="w-full rounded-lg border border-slate-200 pl-6 pr-1.5 py-1 text-xs focus:border-indigo-500 focus:outline-none font-semibold text-slate-800"
+                              v-else-if="['string', 'email', 'number', 'date', 'ref', 'image'].includes(field.type)"
+                              :id="`collections-field-${key}`"
+                              v-model="editing.text[key]"
+                              :type="inputTypeFor(field.type)"
+                              :required="isFieldRequiredInUi(field)"
+                              :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
+                              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
+                              :data-testid="`collections-input-${key}`"
+                            />
+
+                            <!-- Markdown or long text -->
+                            <textarea
+                              v-else
+                              :id="`collections-field-${key}`"
+                              v-model="editing.text[key]"
+                              :rows="field.type === 'markdown' ? 5 : 3"
+                              :required="isFieldRequiredInUi(field)"
+                              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-medium text-slate-700 transition-all"
+                              :data-testid="`collections-input-${key}`"
                             />
                           </div>
-                          <input
-                            v-else
-                            v-model="row.text[subKey]"
-                            :type="inputTypeFor(subField.type)"
-                            :required="subField.required"
-                            class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
-                          />
-                        </td>
-                        <td class="text-center px-1">
+                        </template>
+                        <p v-if="saveError" class="col-span-full text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl">
+                          {{ saveError }}
+                        </p>
+                      </div>
+                    </form>
+
+                    <!-- Read-only detail panel -->
+                    <div v-else-if="viewing" data-testid="collections-detail" class="px-6 py-5 max-h-[60vh] overflow-y-auto">
+                      <div class="flex items-center gap-2 mb-4">
+                        <div class="flex-1 min-w-0">
+                          <span class="block text-[9px] font-bold text-slate-400 uppercase tracking-wider">{{ collection.title }}</span>
+                          <h2 class="text-base font-bold text-slate-800 truncate" data-testid="collections-detail-title">{{ viewTitle }}</h2>
+                        </div>
+                        <div class="flex items-center gap-2">
+                          <!-- Dynamic Actions -->
+                          <button
+                            v-for="action in visibleActions"
+                            :key="action.id"
+                            type="button"
+                            class="h-8 px-2.5 rounded border border-indigo-200 bg-indigo-50/50 text-indigo-600 hover:bg-indigo-600 hover:text-white hover:border-indigo-600 font-bold text-xs transition-all flex items-center gap-1 disabled:opacity-50"
+                            :disabled="actionPending"
+                            :data-testid="`collections-detail-action-${action.id}`"
+                            @click="runAction(action)"
+                          >
+                            <span v-if="action.icon" class="material-icons text-sm">{{ action.icon }}</span>
+                            <span>{{ action.label }}</span>
+                          </button>
+
                           <button
                             type="button"
-                            class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
-                            :aria-label="t('collectionsView.removeRow')"
-                            :data-testid="`collections-table-${key}-remove-${rowIdx}`"
-                            @click="removeTableRow(key, rowIdx)"
+                            class="h-8 px-2.5 rounded border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 font-bold text-xs transition-all flex items-center gap-1"
+                            data-testid="collections-detail-edit"
+                            @click="editFromView"
                           >
-                            <span class="material-icons text-base">close</span>
+                            <span class="material-icons text-sm">edit</span>
+                            <span>{{ t("collectionsView.editItem") }}</span>
                           </button>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-                <p v-else class="text-xs text-slate-400 italic">{{ t("collectionsView.noRows") }}</p>
-                <button
-                  type="button"
-                  class="inline-flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
-                  :data-testid="`collections-table-${key}-add`"
-                  @click="addTableRow(key, field.of)"
-                >
-                  <span class="material-icons text-xs">add</span>
-                  <span>{{ t("collectionsView.addRow") }}</span>
-                </button>
-              </div>
 
-              <!-- Derived formula field -->
-              <div v-else-if="field.type === 'derived'" class="relative flex items-center">
-                <span class="absolute left-3 text-indigo-500 font-bold text-[9px] uppercase select-none tracking-wider">{{
-                  t("collectionsView.derivedLabel")
-                }}</span>
-                <input
-                  :id="`collections-field-${key}`"
-                  :value="derivedDisplay(field, liveDerived?.[key] ?? null, liveRecord)"
-                  type="text"
-                  disabled
-                  class="w-full rounded-xl border border-indigo-100 bg-indigo-50/15 pl-16 pr-3 py-2 text-xs font-bold text-indigo-700 select-none cursor-not-allowed"
-                  :data-testid="`collections-input-${key}`"
-                />
-              </div>
+                          <button
+                            type="button"
+                            class="h-8 w-8 flex items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors"
+                            :aria-label="t('common.close')"
+                            data-testid="collections-detail-close"
+                            @click="closeView"
+                          >
+                            <span class="material-icons text-lg">close</span>
+                          </button>
+                        </div>
+                      </div>
 
-              <!-- Money input field -->
-              <div v-else-if="field.type === 'money'" class="relative flex items-center">
-                <div class="absolute left-3 text-slate-400 font-bold text-xs select-none pr-1.5 border-r border-slate-200">
-                  {{ currencySymbol(resolveCurrency(field, liveRecord)) }}
-                </div>
-                <input
-                  :id="`collections-field-${key}`"
-                  v-model="editing.text[key]"
-                  type="number"
-                  step="0.01"
-                  :required="isFieldRequiredInUi(field)"
-                  class="w-full rounded-xl border border-slate-200 pl-11 pr-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-semibold text-slate-800 transition-all"
-                  :data-testid="`collections-input-${key}`"
-                />
-              </div>
+                      <p
+                        v-if="actionError"
+                        class="mb-3 text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl shadow-sm"
+                        data-testid="collections-detail-action-error"
+                      >
+                        {{ actionError }}
+                      </p>
 
-              <!-- Scalar inputs -->
-              <input
-                v-else-if="['string', 'email', 'number', 'date', 'ref', 'image'].includes(field.type)"
-                :id="`collections-field-${key}`"
-                v-model="editing.text[key]"
-                :type="inputTypeFor(field.type)"
-                :required="isFieldRequiredInUi(field)"
-                :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
-                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
-                :data-testid="`collections-input-${key}`"
-              />
+                      <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
+                        <template v-for="(field, key) in collection.schema.fields" :key="key">
+                          <div
+                            v-if="fieldVisible(field, viewing ?? {})"
+                            class="flex flex-col gap-1"
+                            :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
+                          >
+                            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
 
-              <!-- Markdown or long text -->
-              <textarea
-                v-else
-                :id="`collections-field-${key}`"
-                v-model="editing.text[key]"
-                :rows="field.type === 'markdown' ? 5 : 3"
-                :required="isFieldRequiredInUi(field)"
-                class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-medium text-slate-700 transition-all"
-                :data-testid="`collections-input-${key}`"
-              />
-            </div>
-          </template>
-          <p v-if="saveError" class="text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl">{{ saveError }}</p>
-        </form>
+                            <div class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
+                              <!-- Boolean state -->
+                              <template v-if="field.type === 'boolean'">
+                                <span
+                                  v-if="viewing[key] === true"
+                                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
+                                >
+                                  <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
+                                  {{ t("common.yes") }}
+                                </span>
+                                <span
+                                  v-else-if="viewing[key] === false"
+                                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
+                                >
+                                  {{ t("common.no") }}
+                                </span>
+                                <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false. -->
+                                <span v-else class="text-slate-300">—</span>
+                              </template>
 
-        <footer class="px-6 py-3.5 border-t border-slate-100 flex items-center justify-end gap-2 bg-slate-50/50">
-          <button
-            type="button"
-            class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"
-            data-testid="collections-editor-cancel"
-            @click="closeEditor"
-          >
-            {{ t("common.cancel") }}
-          </button>
-          <button
-            type="button"
-            class="h-8 px-2.5 rounded bg-indigo-600 text-white font-bold text-xs hover:bg-indigo-700 disabled:opacity-50 transition-all shadow-sm shadow-indigo-600/10"
-            :disabled="saving"
-            data-testid="collections-editor-save"
-            @click="saveEditor"
-          >
-            {{ saving ? t("common.saving") : t("common.save") }}
-          </button>
-        </footer>
+                              <!-- Ref details link -->
+                              <router-link
+                                v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
+                                :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
+                                class="text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
+                                :data-testid="`collections-detail-ref-${key}`"
+                                >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
+                              >
+
+                              <!-- Money format -->
+                              <span v-else-if="field.type === 'money'" class="font-semibold text-slate-900 tabular-nums text-sm">{{
+                                formatMoney(viewing[key], resolveCurrency(field, viewing), locale)
+                              }}</span>
+
+                              <!-- Derived formula badge -->
+                              <span
+                                v-else-if="field.type === 'derived'"
+                                class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-2 py-0.5 rounded border border-indigo-100/50"
+                                >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), viewing), viewing) }}</span
+                              >
+
+                              <!-- Sub table (e.g. Line Items in details) -->
+                              <div
+                                v-else-if="field.type === 'table' && field.of && hasTableRows(viewing[key])"
+                                class="border border-slate-200/80 rounded-xl overflow-hidden shadow-sm mt-1"
+                              >
+                                <table class="w-full text-[11px] text-slate-600 bg-white">
+                                  <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
+                                    <tr>
+                                      <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-4 py-2 font-bold">{{ subField.label }}</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody class="divide-y divide-slate-100">
+                                    <tr v-for="(row, rowIdx) in tableRows(viewing[key])" :key="rowIdx" class="hover:bg-slate-50/50">
+                                      <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-4 py-2 align-middle font-medium">
+                                        <template v-if="subField.type === 'boolean'">
+                                          <span v-if="row[subKey] === true" class="material-icons text-emerald-600 text-base">check_circle</span>
+                                          <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph (boolean=false), same as elsewhere. -->
+                                          <span v-else class="text-slate-300">—</span>
+                                        </template>
+                                        <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
+                                          formatSubCell(subField, row[subKey], viewing)
+                                        }}</span>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+
+                              <span v-else-if="field.type === 'table'" class="text-slate-400 italic">{{ t("collectionsView.noRows") }}</span>
+
+                              <!-- Markdown blocks with scroll area -->
+                              <div
+                                v-else-if="field.type === 'markdown'"
+                                class="bg-slate-50 rounded-xl p-4 border border-slate-200/60 text-slate-600 text-xs whitespace-pre-wrap leading-relaxed max-h-[30vh] overflow-y-auto"
+                              >
+                                {{ detailText(viewing[key]) }}
+                              </div>
+
+                              <!-- Embed view -->
+                              <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
+
+                              <!-- Image (workspace-relative path → <img> via auth-exempt /api/files/raw) -->
+                              <img
+                                v-else-if="field.type === 'image' && typeof viewing[key] === 'string' && viewing[key]"
+                                :src="resolveImageSrc(String(viewing[key]))"
+                                :alt="field.label"
+                                class="max-h-64 max-w-full object-contain rounded-lg border border-slate-200 bg-slate-50"
+                                :data-testid="`collections-detail-image-${key}`"
+                              />
+
+                              <!-- URL string → external link (new tab). -->
+                              <a
+                                v-else-if="isExternalUrl(viewing[key])"
+                                :href="String(viewing[key])"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
+                                :data-testid="`collections-detail-url-${key}`"
+                                >{{ String(viewing[key]) }}</a
+                              >
+
+                              <!-- Fallback text styling -->
+                              <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>
+                            </div>
+                          </div>
+                        </template>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
       </div>
     </div>
 
@@ -558,199 +741,6 @@
             {{ t("collectionsView.chatStart") }}
           </button>
         </footer>
-      </div>
-    </div>
-
-    <!-- Open / detail modal (read-only document-style card) -->
-    <div
-      v-if="viewing && collection"
-      class="fixed inset-0 z-30 flex items-center justify-center bg-slate-900/60 backdrop-blur-sm p-4 transition-all duration-300"
-      data-testid="collections-detail"
-      @click.self="closeView"
-    >
-      <div
-        class="bg-slate-50/90 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[85vh] flex flex-col border border-slate-200/50 overflow-hidden transform scale-100 transition-all"
-      >
-        <header class="px-6 py-4 bg-white border-b border-slate-200 flex items-center gap-3">
-          <div class="h-10 w-10 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100">
-            <span class="material-icons text-xl">{{ collection.icon }}</span>
-          </div>
-          <div class="flex-1 min-w-0">
-            <span class="block text-[9px] font-bold text-slate-400 uppercase tracking-wider">{{ collection.title }}</span>
-            <h2 class="text-base font-bold text-slate-800 truncate" data-testid="collections-detail-title">{{ viewTitle }}</h2>
-          </div>
-
-          <div class="flex items-center gap-2">
-            <!-- Dynamic Actions -->
-            <button
-              v-for="action in visibleActions"
-              :key="action.id"
-              type="button"
-              class="h-8 px-2.5 rounded border border-indigo-200 bg-indigo-50/50 text-indigo-600 hover:bg-indigo-600 hover:text-white hover:border-indigo-600 font-bold text-xs transition-all flex items-center gap-1 disabled:opacity-50"
-              :disabled="actionPending"
-              :data-testid="`collections-detail-action-${action.id}`"
-              @click="runAction(action)"
-            >
-              <span v-if="action.icon" class="material-icons text-sm">{{ action.icon }}</span>
-              <span>{{ action.label }}</span>
-            </button>
-
-            <!-- Edit Button -->
-            <button
-              type="button"
-              class="h-8 px-2.5 rounded border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 font-bold text-xs transition-all flex items-center gap-1"
-              data-testid="collections-detail-edit"
-              @click="editFromView"
-            >
-              <span class="material-icons text-sm">edit</span>
-              <span>{{ t("collectionsView.editItem") }}</span>
-            </button>
-
-            <!-- Close Button -->
-            <button
-              type="button"
-              class="h-8 w-8 flex items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors"
-              :aria-label="t('common.close')"
-              data-testid="collections-detail-close"
-              @click="closeView"
-            >
-              <span class="material-icons text-lg">close</span>
-            </button>
-          </div>
-        </header>
-
-        <div class="flex-1 overflow-auto p-6 space-y-4">
-          <p
-            v-if="actionError"
-            class="text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl shadow-sm"
-            data-testid="collections-detail-action-error"
-          >
-            {{ actionError }}
-          </p>
-
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
-            <!-- `when`-gated fields are omitted entirely from the detail view
-                 (consistent with the list cell blanking) when the open record
-                 doesn't match. -->
-            <template v-for="(field, key) in collection.schema.fields" :key="key">
-              <div
-                v-if="fieldVisible(field, viewing ?? {})"
-                class="flex flex-col gap-1"
-                :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
-              >
-                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
-
-                <div class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
-                  <!-- Boolean state -->
-                  <template v-if="field.type === 'boolean'">
-                    <span
-                      v-if="viewing[key] === true"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
-                    >
-                      <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
-                      {{ t("common.yes") }}
-                    </span>
-                    <span
-                      v-else-if="viewing[key] === false"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
-                    >
-                      {{ t("common.no") }}
-                    </span>
-                    <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false. -->
-                    <span v-else class="text-slate-300">—</span>
-                  </template>
-
-                  <!-- Ref details link -->
-                  <router-link
-                    v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
-                    :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
-                    class="text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
-                    :data-testid="`collections-detail-ref-${key}`"
-                    >{{ refDisplay(field.to, String(viewing[key])) }}</router-link
-                  >
-
-                  <!-- Money format -->
-                  <span v-else-if="field.type === 'money'" class="font-semibold text-slate-900 tabular-nums text-sm">{{
-                    formatMoney(viewing[key], resolveCurrency(field, viewing), locale)
-                  }}</span>
-
-                  <!-- Derived formula badge -->
-                  <span
-                    v-else-if="field.type === 'derived'"
-                    class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-2 py-0.5 rounded border border-indigo-100/50"
-                    >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), viewing), viewing) }}</span
-                  >
-
-                  <!-- Sub table (e.g. Line Items in details) -->
-                  <div
-                    v-else-if="field.type === 'table' && field.of && hasTableRows(viewing[key])"
-                    class="border border-slate-200/80 rounded-xl overflow-hidden shadow-sm mt-1"
-                  >
-                    <table class="w-full text-[11px] text-slate-600 bg-white">
-                      <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
-                        <tr>
-                          <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-4 py-2 font-bold">{{ subField.label }}</th>
-                        </tr>
-                      </thead>
-                      <tbody class="divide-y divide-slate-100">
-                        <tr v-for="(row, rowIdx) in tableRows(viewing[key])" :key="rowIdx" class="hover:bg-slate-50/50">
-                          <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-4 py-2 align-middle font-medium">
-                            <template v-if="subField.type === 'boolean'">
-                              <span v-if="row[subKey] === true" class="material-icons text-emerald-600 text-base">check_circle</span>
-                              <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph (boolean=false), same as elsewhere. -->
-                              <span v-else class="text-slate-300">—</span>
-                            </template>
-                            <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
-                              formatSubCell(subField, row[subKey], viewing)
-                            }}</span>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
-
-                  <span v-else-if="field.type === 'table'" class="text-slate-400 italic">{{ t("collectionsView.noRows") }}</span>
-
-                  <!-- Markdown blocks with scroll area -->
-                  <div
-                    v-else-if="field.type === 'markdown'"
-                    class="bg-slate-50 rounded-xl p-4 border border-slate-200/60 text-slate-600 text-xs whitespace-pre-wrap leading-relaxed max-h-[30vh] overflow-y-auto"
-                  >
-                    {{ detailText(viewing[key]) }}
-                  </div>
-
-                  <!-- Embed view -->
-                  <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
-
-                  <!-- Image (workspace-relative path → <img> via auth-exempt /api/files/raw) -->
-                  <img
-                    v-else-if="field.type === 'image' && typeof viewing[key] === 'string' && viewing[key]"
-                    :src="resolveImageSrc(String(viewing[key]))"
-                    :alt="field.label"
-                    class="max-h-64 max-w-full object-contain rounded-lg border border-slate-200 bg-slate-50"
-                    :data-testid="`collections-detail-image-${key}`"
-                  />
-
-                  <!-- URL string → external link (new tab). Value-based, so any
-                     field whose value is a http(s) URL renders as a link,
-                     regardless of the declared `field.type`. -->
-                  <a
-                    v-else-if="isExternalUrl(viewing[key])"
-                    :href="String(viewing[key])"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
-                    :data-testid="`collections-detail-url-${key}`"
-                    >{{ String(viewing[key]) }}</a
-                  >
-
-                  <!-- Fallback text styling -->
-                  <span v-else class="text-slate-800 font-semibold">{{ formatCell(viewing[key], field.type) }}</span>
-                </div>
-              </div>
-            </template>
-          </div>
-        </div>
       </div>
     </div>
 
@@ -1027,6 +1017,60 @@ const filteredItems = computed<CollectionItem[]>(() => {
   if (!query) return items.value;
   return items.value.filter((item) => itemMatchesQuery(item, query));
 });
+
+// ────────────────────────────────────────────────────────────────
+// Inline row expansion (#detail / #edit / #create panels)
+// ────────────────────────────────────────────────────────────────
+// Detail + edit render as a panel directly under the open row; create
+// rides a synthetic row pinned at the top of the list. One panel open
+// at a time (`viewing` / `editing` are single refs). The synthetic
+// create row keeps the edit form in a SINGLE template location (no
+// duplication, no separate component, no prop-mutation) — its data row
+// is hidden (`v-if="!isCreateRow"`) so only its expansion (the form)
+// shows.
+
+/** Sentinel primary-key for the synthetic create row. Chosen to never
+ *  collide with a real record id. */
+const CREATE_ROW_ID = "__mc_create__";
+
+/** Stringified primary-key value for a row (the row's stable identity). */
+function rowId(item: CollectionItem): string {
+  const primaryKey = collection.value?.schema.primaryKey;
+  return primaryKey ? String(item[primaryKey] ?? "") : "";
+}
+
+function isCreateRow(item: CollectionItem): boolean {
+  return rowId(item) === CREATE_ROW_ID;
+}
+
+/** Rows rendered by the table: the filtered records, plus a synthetic
+ *  create row at the top while a create is in progress. */
+const displayItems = computed<CollectionItem[]>(() => {
+  if (editing.value?.mode === "create" && collection.value) {
+    const sentinel = { [collection.value.schema.primaryKey]: CREATE_ROW_ID } as CollectionItem;
+    return [sentinel, ...filteredItems.value];
+  }
+  return filteredItems.value;
+});
+
+/** This row is the one open in read-only detail. */
+function isRowOpen(item: CollectionItem): boolean {
+  return viewing.value !== null && rowId(viewing.value) === rowId(item);
+}
+
+/** This row is the one being edited (a real row in edit mode, or the
+ *  synthetic create row in create mode). */
+function isEditingRow(item: CollectionItem): boolean {
+  const draft = editing.value;
+  if (!draft) return false;
+  if (draft.mode === "create") return isCreateRow(item);
+  return draft.originalId === rowId(item);
+}
+
+/** Whether to render this row's expansion panel (detail or edit). */
+function shouldExpand(item: CollectionItem): boolean {
+  return isRowOpen(item) || isEditingRow(item);
+}
 
 // Best-effort status coloring for enum badges: maps common
 // status-like values to a semantic tint, falling back to neutral
@@ -1552,6 +1596,7 @@ function openCreate(): void {
   // value (e.g. "me") so the first Add can't pick an arbitrary id.
   const { singleton, primaryKey } = collection.value.schema;
   if (singleton) text[primaryKey] = singleton;
+  viewing.value = null; // one panel open at a time
   editing.value = { mode: "create", text, bool, boolOriginallyPresent, boolTouched, table, originalId: null };
   saveError.value = null;
 }
@@ -1587,6 +1632,7 @@ function openEdit(item: CollectionItem): void {
   }
   const primaryRaw = item[collection.value.schema.primaryKey];
   const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
+  viewing.value = null; // one panel open at a time
   editing.value = { mode: "edit", text, bool, boolOriginallyPresent, boolTouched, table, originalId };
   saveError.value = null;
 }
@@ -1601,9 +1647,16 @@ function closeEditor(): void {
   saveError.value = null;
 }
 
-/** Open mode (read-only detail). In embedded mode, report the open id
- *  so the host card can persist it in `viewState`. */
+/** Open mode (read-only detail). Toggles: clicking the already-open row
+ *  collapses it. Opening a row cancels any in-progress edit (one panel
+ *  open at a time). In embedded mode, report the open id so the host
+ *  card can persist it in `viewState`. */
 function openView(item: CollectionItem): void {
+  if (isRowOpen(item) && !editing.value) {
+    closeView();
+    return;
+  }
+  if (editing.value) closeEditor();
   viewing.value = item;
   actionError.value = null;
   if (embedded.value && collection.value) {

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1643,12 +1643,14 @@ function cancelEditor(): void {
   }
 }
 
-/** Scroll a row's expansion panel into view after it opens (e.g. a newly
- *  created record that landed off-screen). Best-effort — no-op if the
- *  element isn't in the DOM yet. */
-function scrollRowIntoView(itemId: string): void {
+/** Scroll the open expansion panel into view after it opens (e.g. a newly
+ *  created record that landed off-screen). Only one panel is open at a
+ *  time, so a fixed prefix selector finds it — no record id is
+ *  interpolated into the selector (avoids CSS injection / `SyntaxError`
+ *  from ids containing selector-special chars). Best-effort. */
+function scrollOpenPanelIntoView(): void {
   void nextTick(() => {
-    const row = document.querySelector(`[data-testid="collections-expansion-${itemId}"]`);
+    const row = document.querySelector('[data-testid^="collections-expansion-"]');
     if (row) row.scrollIntoView({ behavior: "smooth", block: "nearest" });
   });
 }
@@ -2020,7 +2022,7 @@ async function saveEditor(): Promise<void> {
   const saved = findItemById(savedId);
   if (saved) {
     showDetail(saved);
-    scrollRowIntoView(savedId);
+    scrollOpenPanelIntoView();
   }
 }
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -115,7 +115,6 @@
               <th v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider">
                 {{ field.label }}
               </th>
-              <th class="px-5 py-3 font-medium w-24"></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-100 bg-white">
@@ -211,38 +210,13 @@
                     <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
                   </template>
                 </td>
-
-                <td class="px-5 py-2 text-right whitespace-nowrap align-middle">
-                  <div class="flex items-center justify-end gap-2">
-                    <button
-                      type="button"
-                      class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 border border-transparent hover:border-indigo-100 transition-all duration-200"
-                      :title="t('collectionsView.editItem')"
-                      :aria-label="t('collectionsView.editItem')"
-                      :data-testid="`collections-edit-item-${item[collection.schema.primaryKey]}`"
-                      @click.stop="openEdit(item)"
-                    >
-                      <span class="material-icons text-base">edit</span>
-                    </button>
-                    <button
-                      type="button"
-                      class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 border border-transparent hover:border-rose-100 transition-all duration-200"
-                      :title="t('common.remove')"
-                      :aria-label="t('common.remove')"
-                      :data-testid="`collections-delete-item-${item[collection.schema.primaryKey]}`"
-                      @click.stop="confirmDelete(item)"
-                    >
-                      <span class="material-icons text-base">delete</span>
-                    </button>
-                  </div>
-                </td>
               </tr>
 
               <!-- Inline detail / edit panel: expands directly under the open
                  row (replaces the old fixed modal). One row open at a time.
                  The create form rides the synthetic top row (isCreateRow). -->
               <tr v-if="shouldExpand(item)" :data-testid="`collections-expansion-${item[collection.schema.primaryKey]}`">
-                <td :colspan="listColumnFields.length + 1" class="p-0 border-l-2 border-indigo-300 bg-slate-50/60">
+                <td :colspan="listColumnFields.length" class="p-0 border-l-2 border-indigo-300 bg-slate-50/60">
                   <!-- Pin the panel to the View's visible width, not the
                        (possibly much wider) table width: sticky to the left
                        edge of the horizontal scroller and capped at the
@@ -263,15 +237,15 @@
                       <div class="flex items-center gap-2 mb-4">
                         <div class="flex-1 min-w-0">
                           <span class="block text-[9px] font-bold text-slate-400 uppercase tracking-wider">{{ collection.title }}</span>
-                          <h2 class="text-base font-bold text-slate-800 truncate">
-                            {{ editing && editing.mode === "create" ? t("collectionsView.createTitle") : t("collectionsView.editTitle") }}
+                          <h2 class="text-base font-bold text-slate-800 truncate" data-testid="collections-edit-title">
+                            {{ editing && editing.mode === "create" ? t("collectionsView.createTitle") : (editing?.originalId ?? "") }}
                           </h2>
                         </div>
                         <button
                           type="button"
                           class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"
                           data-testid="collections-editor-cancel"
-                          @click="closeEditor"
+                          @click="cancelEditor"
                         >
                           {{ t("common.cancel") }}
                         </button>
@@ -288,7 +262,7 @@
                       <div v-if="editing" class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
                         <template v-for="(field, key) in collection.schema.fields" :key="key">
                           <div
-                            v-if="fieldVisible(field, liveRecord ?? {})"
+                            v-if="fieldVisible(field, liveRecord ?? {}) && (!field.primary || editing?.mode === 'create')"
                             class="flex flex-col gap-1.5"
                             :class="['table', 'markdown', 'embed'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
                           >
@@ -532,6 +506,16 @@
 
                           <button
                             type="button"
+                            class="h-8 px-2.5 rounded border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 font-bold text-xs transition-all flex items-center gap-1"
+                            data-testid="collections-detail-remove"
+                            @click="viewing && confirmDelete(viewing)"
+                          >
+                            <span class="material-icons text-sm">delete</span>
+                            <span>{{ t("common.remove") }}</span>
+                          </button>
+
+                          <button
+                            type="button"
                             class="h-8 w-8 flex items-center justify-center rounded text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors"
                             :aria-label="t('common.close')"
                             data-testid="collections-detail-close"
@@ -553,7 +537,7 @@
                       <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
                         <template v-for="(field, key) in collection.schema.fields" :key="key">
                           <div
-                            v-if="fieldVisible(field, viewing ?? {})"
+                            v-if="fieldVisible(field, viewing ?? {}) && !field.primary"
                             class="flex flex-col gap-1"
                             :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
                           >
@@ -1647,6 +1631,28 @@ function closeEditor(): void {
   saveError.value = null;
 }
 
+/** Cancel the editor. Edit → reopen the record's read-only detail (don't
+ *  collapse the panel); create → just close (no prior detail to show). */
+function cancelEditor(): void {
+  const draft = editing.value;
+  const returnTo = draft && draft.mode === "edit" ? draft.originalId : null;
+  closeEditor();
+  if (returnTo) {
+    const item = findItemById(returnTo);
+    if (item) showDetail(item);
+  }
+}
+
+/** Scroll a row's expansion panel into view after it opens (e.g. a newly
+ *  created record that landed off-screen). Best-effort — no-op if the
+ *  element isn't in the DOM yet. */
+function scrollRowIntoView(itemId: string): void {
+  void nextTick(() => {
+    const row = document.querySelector(`[data-testid="collections-expansion-${itemId}"]`);
+    if (row) row.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  });
+}
+
 /** Open mode (read-only detail). Toggles: clicking the already-open row
  *  collapses it. Opening a row cancels any in-progress edit (one panel
  *  open at a time). In embedded mode, report the open id so the host
@@ -1657,6 +1663,14 @@ function openView(item: CollectionItem): void {
     return;
   }
   if (editing.value) closeEditor();
+  showDetail(item);
+}
+
+/** Open the read-only detail for a record WITHOUT the click-toggle. Used
+ *  when reopening detail programmatically (after save / cancel), where
+ *  `openView`'s "click the open row to collapse" guard would otherwise
+ *  immediately close a row the embedded `viewState` sync just reopened. */
+function showDetail(item: CollectionItem): void {
   viewing.value = item;
   actionError.value = null;
   if (embedded.value && collection.value) {
@@ -1998,8 +2012,16 @@ async function saveEditor(): Promise<void> {
     saveError.value = result.error;
     return;
   }
+  const savedId = result.data.itemId;
   closeEditor();
   await loadCollection(slug);
+  // Return to the saved record's read-only detail (for create, this is the
+  // newly added row), scrolling it into view if it's off-screen.
+  const saved = findItemById(savedId);
+  if (saved) {
+    showDetail(saved);
+    scrollRowIntoView(savedId);
+  }
 }
 
 async function confirmDelete(item: CollectionItem): Promise<void> {

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -58,6 +58,7 @@ export const ROLES: Role[] = [
     availablePlugins: [
       TOOL_NAMES.presentDocument,
       TOOL_NAMES.presentForm,
+      TOOL_NAMES.presentCollection,
       TOOL_NAMES.presentMulmoScript,
       TOOL_NAMES.generateImage,
       TOOL_NAMES.presentHtml,
@@ -92,6 +93,7 @@ export const ROLES: Role[] = [
       TOOL_NAMES.notify,
       TOOL_NAMES.presentDocument,
       TOOL_NAMES.presentForm,
+      TOOL_NAMES.presentCollection,
       // Preset runtime plugins (server/plugins/preset-list.ts).
       // Runtime plugins are gated by `availablePlugins` like the
       // static-GUI / static-MCP entries above; listed here so the

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1018,6 +1018,11 @@ const deMessages = {
     submit: "Senden",
     progress: "{filled} von {total} Pflichtfeldern ausgefüllt",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "Sammlung",
+    itemLabel: "Eintrag: {id}",
+    listLabel: "Alle Datensätze",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Als PDF speichern (öffnet Druckdialog)",
     pdf: "PDF",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1375,7 +1375,6 @@ const deMessages = {
     clearSearch: "Suche zurücksetzen",
     openCollection: "{title} öffnen",
     createTitle: "Neu hinzufügen",
-    editTitle: "Datensatz bearbeiten",
     derivedLabel: "Abgeleitet",
     embedMissingTitle: "Eingebettete Referenz fehlt",
     chat: "Chat",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -999,6 +999,11 @@ const enMessages = {
     submit: "Submit",
     progress: "{filled} of {total} required fields completed",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "Collection",
+    itemLabel: "Item: {id}",
+    listLabel: "All records",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Save as PDF (opens print dialog)",
     pdf: "PDF",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1356,7 +1356,6 @@ const enMessages = {
     clearSearch: "Clear search",
     openCollection: "Open {title}",
     createTitle: "Add new",
-    editTitle: "Edit record",
     derivedLabel: "Derived",
     embedMissingTitle: "Embedded reference missing",
     chat: "Chat",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1012,6 +1012,11 @@ const esMessages = {
     submit: "Enviar",
     progress: "{filled} de {total} campos obligatorios completados",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "Colección",
+    itemLabel: "Elemento: {id}",
+    listLabel: "Todos los registros",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Guardar como PDF (abre el diálogo de impresión)",
     pdf: "PDF",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1370,7 +1370,6 @@ const esMessages = {
     clearSearch: "Borrar búsqueda",
     openCollection: "Abrir {title}",
     createTitle: "Añadir nuevo",
-    editTitle: "Editar registro",
     derivedLabel: "Derivado",
     embedMissingTitle: "Falta la referencia incrustada",
     chat: "Chat",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1008,6 +1008,11 @@ const frMessages = {
     submit: "Envoyer",
     progress: "{filled} sur {total} champs obligatoires remplis",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "Collection",
+    itemLabel: "Élément : {id}",
+    listLabel: "Tous les enregistrements",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Enregistrer en PDF (ouvre la boîte de dialogue d'impression)",
     pdf: "PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1364,7 +1364,6 @@ const frMessages = {
     clearSearch: "Effacer la recherche",
     openCollection: "Ouvrir {title}",
     createTitle: "Ajouter",
-    editTitle: "Modifier l'enregistrement",
     derivedLabel: "Calculé",
     embedMissingTitle: "Référence intégrée manquante",
     chat: "Discussion",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -999,6 +999,11 @@ const jaMessages = {
     submit: "送信",
     progress: "必須項目 {total} 件中 {filled} 件入力済み",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "コレクション",
+    itemLabel: "項目: {id}",
+    listLabel: "すべてのレコード",
+  },
   pluginPresentHtml: {
     saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",
     pdf: "PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1353,7 +1353,6 @@ const jaMessages = {
     clearSearch: "検索をクリア",
     openCollection: "{title} を開く",
     createTitle: "新規追加",
-    editTitle: "レコードを編集",
     derivedLabel: "計算値",
     embedMissingTitle: "埋め込み参照が見つかりません",
     chat: "チャット",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1000,6 +1000,11 @@ const koMessages = {
     submit: "제출",
     progress: "필수 항목 {total}개 중 {filled}개 입력됨",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "컬렉션",
+    itemLabel: "항목: {id}",
+    listLabel: "모든 레코드",
+  },
   pluginPresentHtml: {
     saveAsPdf: "PDF 로 저장 (인쇄 대화 상자 열기)",
     pdf: "PDF",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1356,7 +1356,6 @@ const koMessages = {
     clearSearch: "검색 지우기",
     openCollection: "{title} 열기",
     createTitle: "새로 추가",
-    editTitle: "레코드 편집",
     derivedLabel: "파생",
     embedMissingTitle: "임베드된 참조 없음",
     chat: "채팅",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1004,6 +1004,11 @@ const ptBRMessages = {
     submit: "Enviar",
     progress: "{filled} de {total} campos obrigatórios preenchidos",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "Coleção",
+    itemLabel: "Item: {id}",
+    listLabel: "Todos os registros",
+  },
   pluginPresentHtml: {
     saveAsPdf: "Salvar como PDF (abre o diálogo de impressão)",
     pdf: "PDF",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1359,7 +1359,6 @@ const ptBRMessages = {
     clearSearch: "Limpar busca",
     openCollection: "Abrir {title}",
     createTitle: "Adicionar novo",
-    editTitle: "Editar registro",
     derivedLabel: "Derivado",
     embedMissingTitle: "Referência incorporada ausente",
     chat: "Chat",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -990,6 +990,11 @@ const zhMessages = {
     submit: "提交",
     progress: "已填写 {filled} / {total} 个必填字段",
   },
+  pluginPresentCollection: {
+    fallbackTitle: "集合",
+    itemLabel: "项目：{id}",
+    listLabel: "全部记录",
+  },
   pluginPresentHtml: {
     saveAsPdf: "另存为 PDF(打开打印对话框)",
     pdf: "PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1346,7 +1346,6 @@ const zhMessages = {
     clearSearch: "清除搜索",
     openCollection: "打开 {title}",
     createTitle: "新增",
-    editTitle: "编辑记录",
     derivedLabel: "派生",
     embedMissingTitle: "缺少嵌入引用",
     chat: "对话",

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ const pluginEndpointRegistry: EndpointRegistry = {
   encore: API_ROUTES.encore,
   canvas: API_ROUTES.canvas,
   form: API_ROUTES.form,
+  presentCollection: API_ROUTES.presentCollection,
   markdown: API_ROUTES.markdown,
   spreadsheet: API_ROUTES.spreadsheet,
   photoLocations: API_ROUTES.photoLocations,

--- a/src/plugins/_generated/metas.ts
+++ b/src/plugins/_generated/metas.ts
@@ -14,6 +14,7 @@ import { META as manageSkillsMeta } from "../manageSkills/meta";
 import { META as manageSourceMeta } from "../manageSource/meta";
 import { META as markdownMeta } from "../markdown/meta";
 import { META as photoLocationsMeta } from "../photoLocations/meta";
+import { META as presentCollectionMeta } from "../presentCollection/meta";
 import { META as presentFormMeta } from "../presentForm/meta";
 import { META as presentHtmlMeta } from "../presentHtml/meta";
 import { META as presentMulmoScriptMeta } from "../presentMulmoScript/meta";
@@ -37,6 +38,7 @@ export const GENERATED_PLUGIN_METAS = [
   manageSourceMeta,
   markdownMeta,
   photoLocationsMeta,
+  presentCollectionMeta,
   presentFormMeta,
   presentHtmlMeta,
   presentMulmoScriptMeta,

--- a/src/plugins/_generated/registrations.ts
+++ b/src/plugins/_generated/registrations.ts
@@ -13,6 +13,7 @@ import { REGISTRATION as manageSkillsRegistration } from "../manageSkills";
 import { REGISTRATION as manageSourceRegistration } from "../manageSource";
 import { REGISTRATION as markdownRegistration } from "../markdown";
 import { REGISTRATION as photoLocationsRegistration } from "../photoLocations";
+import { REGISTRATION as presentCollectionRegistration } from "../presentCollection";
 import { REGISTRATION as presentFormRegistration } from "../presentForm";
 import { REGISTRATION as presentHtmlRegistration } from "../presentHtml";
 import { REGISTRATION as presentMulmoScriptRegistration } from "../presentMulmoScript";
@@ -38,6 +39,7 @@ export const GENERATED_PLUGIN_REGISTRATIONS: readonly PluginRegistration[] = [
   manageSourceRegistration,
   markdownRegistration,
   photoLocationsRegistration,
+  presentCollectionRegistration,
   presentFormRegistration,
   presentHtmlRegistration,
   presentMulmoScriptRegistration,

--- a/src/plugins/_generated/server-bindings.ts
+++ b/src/plugins/_generated/server-bindings.ts
@@ -13,6 +13,7 @@ import manageSkillsDef from "../manageSkills/definition";
 import manageSourceDef from "../manageSource/definition";
 import markdownDef from "../markdown/definition";
 import photoLocationsDef from "../photoLocations/definition";
+import presentCollectionDef from "../presentCollection/definition";
 import presentFormDef from "../presentForm/definition";
 import presentHtmlDef from "../presentHtml/definition";
 import presentMulmoScriptDef from "../presentMulmoScript/definition";
@@ -28,6 +29,7 @@ import { META as manageSkillsMeta } from "../manageSkills/meta";
 import { META as manageSourceMeta } from "../manageSource/meta";
 import { META as markdownMeta } from "../markdown/meta";
 import { META as photoLocationsMeta } from "../photoLocations/meta";
+import { META as presentCollectionMeta } from "../presentCollection/meta";
 import { META as presentFormMeta } from "../presentForm/meta";
 import { META as presentHtmlMeta } from "../presentHtml/meta";
 import { META as presentMulmoScriptMeta } from "../presentMulmoScript/meta";
@@ -48,6 +50,7 @@ export const GENERATED_SERVER_BINDINGS: readonly ServerPluginBinding[] = [
   { def: manageSourceDef, endpoint: mcpEndpoint(manageSourceMeta) },
   { def: markdownDef, endpoint: mcpEndpoint(markdownMeta) },
   { def: photoLocationsDef, endpoint: mcpEndpoint(photoLocationsMeta) },
+  { def: presentCollectionDef, endpoint: mcpEndpoint(presentCollectionMeta) },
   { def: presentFormDef, endpoint: mcpEndpoint(presentFormMeta) },
   { def: presentHtmlDef, endpoint: mcpEndpoint(presentHtmlMeta) },
   { def: presentMulmoScriptDef, endpoint: mcpEndpoint(presentMulmoScriptMeta) },

--- a/src/plugins/presentCollection/Preview.vue
+++ b/src/plugins/presentCollection/Preview.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="w-full h-full flex flex-col items-center justify-center p-4 bg-gradient-to-br from-indigo-50 to-slate-50 rounded-lg border-2 border-gray-200">
+    <div class="text-center">
+      <span class="material-icons text-4xl text-indigo-600 mb-2">collections_bookmark</span>
+      <h3 class="text-gray-900 font-bold text-lg mb-1 line-clamp-2">
+        {{ collectionSlug || t("pluginPresentCollection.fallbackTitle") }}
+      </h3>
+      <p v-if="itemId" class="text-gray-600 text-sm">{{ t("pluginPresentCollection.itemLabel", { id: itemId }) }}</p>
+      <p v-else class="text-gray-500 text-sm">{{ t("pluginPresentCollection.listLabel") }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import type { ToolResult } from "gui-chat-protocol";
+import type { PresentCollectionData } from "./types";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  result: ToolResult;
+}>();
+
+const data = computed<PresentCollectionData | null>(() => (props.result?.data ?? props.result?.jsonData ?? null) as PresentCollectionData | null);
+
+const collectionSlug = computed<string>(() => data.value?.collectionSlug ?? "");
+const itemId = computed<string | undefined>(() => data.value?.itemId);
+</script>

--- a/src/plugins/presentCollection/View.vue
+++ b/src/plugins/presentCollection/View.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="w-full h-full" data-testid="present-collection">
+    <CollectionView v-if="slug" :slug="slug" :selected="selected" @select="onSelect" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { ToolResult } from "gui-chat-protocol";
+import CollectionView from "../../components/CollectionView.vue";
+import type { PresentCollectionData } from "./types";
+
+/** Card-local UI state: which record the user has opened within the
+ *  card. Persisted in the tool result's `viewState` so the open item
+ *  survives a re-render — same pattern as presentForm. `null` once the
+ *  user has explicitly closed the detail view. */
+interface PresentCollectionViewState {
+  selected?: string | null;
+}
+
+const props = defineProps<{
+  selectedResult: ToolResult | null;
+}>();
+
+const emit = defineEmits<{
+  updateResult: [result: ToolResult];
+}>();
+
+const data = computed<PresentCollectionData | null>(
+  () => (props.selectedResult?.data ?? props.selectedResult?.jsonData ?? null) as PresentCollectionData | null,
+);
+
+const slug = computed<string | undefined>(() => data.value?.collectionSlug);
+
+const viewState = computed<PresentCollectionViewState | null>(() => (props.selectedResult?.viewState as PresentCollectionViewState | undefined) ?? null);
+
+/** Open record: the card-local `viewState.selected` once the user has
+ *  navigated within the card (including an explicit close → null), else
+ *  the tool's initial `itemId`. */
+const selected = computed<string | undefined>(() => {
+  const state = viewState.value;
+  if (state && "selected" in state) return state.selected ?? undefined;
+  return data.value?.itemId;
+});
+
+function onSelect(itemId: string | null): void {
+  if (!props.selectedResult) return;
+  emit("updateResult", { ...props.selectedResult, viewState: { selected: itemId } });
+}
+</script>

--- a/src/plugins/presentCollection/definition.ts
+++ b/src/plugins/presentCollection/definition.ts
@@ -1,0 +1,29 @@
+import type { ToolDefinition } from "gui-chat-protocol";
+import { META } from "./meta";
+import type { ResolvedRoute } from "../meta-types";
+
+export const TOOL_NAME = META.toolName;
+export type PresentCollectionEndpoints = { readonly [K in keyof typeof META.apiRoutes]: ResolvedRoute };
+
+export const TOOL_DEFINITION: ToolDefinition = {
+  type: "function",
+  name: META.toolName,
+  description:
+    "Display a schema-driven collection inline in the chat as an interactive, editable card. Shows the collection's list of records; the user can open a record for a detailed view and edit / create / delete records, with changes saved to the workspace. Pass `itemId` to open one specific record on mount. Use this when the user wants to see or work with a collection (e.g. clients, invoices, contacts) directly in the conversation rather than navigating away to the collections page.",
+  parameters: {
+    type: "object",
+    properties: {
+      collectionSlug: {
+        type: "string",
+        description: "The slug of the collection to display (e.g. 'clients', 'invoices', 'contacts').",
+      },
+      itemId: {
+        type: "string",
+        description: "Optional primary-key value of a single record to open in detail view on mount. Omit to show the full list.",
+      },
+    },
+    required: ["collectionSlug"],
+  },
+};
+
+export default TOOL_DEFINITION;

--- a/src/plugins/presentCollection/index.ts
+++ b/src/plugins/presentCollection/index.ts
@@ -1,0 +1,25 @@
+import type { ToolPlugin } from "gui-chat-protocol/vue";
+import type { PluginRegistration } from "../../tools/types";
+import type { PresentCollectionData, PresentCollectionArgs } from "./types";
+import { TOOL_DEFINITION, TOOL_NAME } from "./definition";
+import { executePresentCollection } from "./plugin";
+import { wrapWithScope } from "../scope";
+import View from "./View.vue";
+import Preview from "./Preview.vue";
+
+const presentCollectionPlugin: ToolPlugin<PresentCollectionData, PresentCollectionData, PresentCollectionArgs> = {
+  toolDefinition: TOOL_DEFINITION,
+  execute: executePresentCollection,
+  generatingMessage: "Loading collection...",
+  isEnabled: () => true,
+  viewComponent: wrapWithScope("presentCollection", View),
+  previewComponent: wrapWithScope("presentCollection", Preview),
+};
+
+export default presentCollectionPlugin;
+export { TOOL_NAME };
+
+export const REGISTRATION: PluginRegistration = {
+  toolName: TOOL_NAME,
+  entry: presentCollectionPlugin,
+};

--- a/src/plugins/presentCollection/meta.ts
+++ b/src/plugins/presentCollection/meta.ts
@@ -1,0 +1,15 @@
+import { definePluginMeta } from "../meta-types";
+
+export const META = definePluginMeta({
+  toolName: "presentCollection",
+  // Distinct from the host-owned `collections` REST namespace
+  // (/api/collections/...) so the aggregator doesn't drop it as a
+  // collision — this is only the MCP dispatch endpoint.
+  apiNamespace: "presentCollection",
+  apiRoutes: {
+    /** POST /api/presentCollection — present a collection (or one
+     *  item) inline in the chat. */
+    dispatch: { method: "POST", path: "" },
+  },
+  mcpDispatch: "dispatch",
+});

--- a/src/plugins/presentCollection/plugin.ts
+++ b/src/plugins/presentCollection/plugin.ts
@@ -1,0 +1,39 @@
+// Server-side execute for presentCollection. Pure / isomorphic (no Vue,
+// no Node-only imports) — bundled to the browser via `index.ts` and run
+// server-side via `server/api/routes/plugins.ts`.
+//
+// The executor only validates + echoes the addressing. The live
+// collection schema + items are fetched client-side by `CollectionView`
+// (via /api/collections/...), so a bad slug surfaces as the View's
+// "not-found" state rather than a tool error.
+
+import type { ToolContext, ToolResult } from "gui-chat-protocol";
+import type { PresentCollectionArgs, PresentCollectionData } from "./types";
+
+export { TOOL_NAME, TOOL_DEFINITION } from "./definition";
+
+export const executePresentCollection = async (
+  _context: ToolContext,
+  args: PresentCollectionArgs,
+): Promise<ToolResult<PresentCollectionData, PresentCollectionData>> => {
+  const collectionSlug = typeof args?.collectionSlug === "string" ? args.collectionSlug.trim() : "";
+  if (!collectionSlug) {
+    return {
+      message: "presentCollection error: collectionSlug is required",
+      instructions: "Tell the user you couldn't display the collection because no collection was specified, and ask which collection they mean.",
+    };
+  }
+  const itemId = typeof args.itemId === "string" && args.itemId.trim().length > 0 ? args.itemId.trim() : undefined;
+  const data: PresentCollectionData = itemId ? { collectionSlug, itemId } : { collectionSlug };
+  const target = itemId ? `${collectionSlug} / ${itemId}` : collectionSlug;
+  return {
+    message: `Presented collection ${target}`,
+    // `data` is the view's source (also the host's render-eligibility
+    // signal); `jsonData` is what the LLM sees. Same payload, two
+    // audiences — keep both in sync.
+    data,
+    jsonData: data,
+    instructions:
+      "The collection has been presented to the user as an interactive card. They can browse, open, edit, create, and delete records directly. No further action is needed unless they ask.",
+  };
+};

--- a/src/plugins/presentCollection/types.ts
+++ b/src/plugins/presentCollection/types.ts
@@ -1,0 +1,13 @@
+/** Render payload carried in the tool result's `data` field. The View
+ *  mounts `<CollectionView>` keyed off these — the live collection
+ *  schema + items are fetched client-side via the existing
+ *  `/api/collections/...` routes, so only the addressing travels here. */
+export interface PresentCollectionData {
+  /** Slug of the collection to display (e.g. "clients", "invoices"). */
+  collectionSlug: string;
+  /** Optional primary-key value of a single item to open on mount. */
+  itemId?: string;
+}
+
+/** Tool arguments — same shape as the render payload. */
+export type PresentCollectionArgs = PresentCollectionData;


### PR DESCRIPTION
## Summary

Adds a **`presentCollection`** MCP tool so the LLM can render a collection (or a specific item) inline in a chat session as an interactive, editable card — and reworks the shared `CollectionView` so the record **detail / edit / create** surfaces are **inline panels** instead of modals (applies to both the chat card and the standalone `/collections/:slug` page).

## What's included

**`presentCollection` plugin** (`src/plugins/presentCollection/`)
- `presentCollection({ collectionSlug, itemId? })` → renders a card that mounts the full `CollectionView`; edits write back through the existing `/api/collections/...` routes (no new persistence).
- Built-in plugin wiring: server dispatch route, codegen barrels, host endpoint-scope registration in `main.ts` (required — `wrapWithScope` calls `pluginEndpoints` at setup), `pluginPresentCollection.*` i18n in all 8 locales, added to **General** + **Personal** roles.

**Inline panels (replaces record modals)**
- Detail & edit expand **directly under the open row**; edit reuses the detail 2-col grid layout so detail↔edit is visually continuous.
- Create rides a **synthetic top row**, keeping the edit form in a single template location (no duplication, no prop-mutation).
- One panel open at a time; panels cap at `max-h-[60vh]` with internal scroll.
- **Width-correct**: the panel is pinned to the View's visible width via container-query units + `sticky left-0`, so a wide collection no longer clips it.

**Review-feedback polish**
- Edit header shows the record **id** (not "Edit record"); create keeps the create title.
- The **id field is hidden** in detail/edit (it's in the title, not editable); shown only in create.
- Cancel/Save in edit **returns to the record's detail** (non-toggling `showDetail` so the embedded card doesn't re-close it); create-save adds the record, opens its detail, and scrolls into view.
- Details header gains a **Remove** button; per-row Edit/Remove action column dropped.

## Testing
- `yarn format / lint / typecheck / build` — green.
- Unit: 26 pass. e2e: **459 pass** (incl. new `present-collection.spec.ts`: render-without-crash + width, Edit→in-place form, Add→top create panel, save→return-to-detail in the embedded card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Present Collection: interactive, editable collection cards embedded in chat with inline record view, edit, and top-row creation (no modals).
  * Card preview shows collection title and optional item indicator.

* **Localization**
  * Added translations for DE/EN/ES/FR/JA/KO/PT-BR/ZH for the new collection UI.

* **Documentation**
  * Feature plan added for Present Collection.

* **Tests**
  * End-to-end regression tests for rendering and inline interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->