### PR TITLE
feat(collections): prompt the LLM to call presentCollection after collection changes

### DIFF
--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -76,7 +76,10 @@ description: A personal recipe box. Use whenever the user asks to add, list,
 ## What to do
 **Add / List / Update / Delete** — derive an id, Read/Write/Edit the JSON.
 List the directory first and pick a fresh slug rather than overwriting.
-Don't recite the whole table in chat — point the user at the collection view.
+Don't recite the whole table in chat. After adding or updating a record,
+call `presentCollection` (with the collection slug and the record's id) to
+show it inline; for a plain "show/list" request, call `presentCollection`
+with just the slug.
 ```
 
 Write the `description` so it tells *you* (in a future session) exactly when to

--- a/src/plugins/presentCollection/definition.ts
+++ b/src/plugins/presentCollection/definition.ts
@@ -9,7 +9,7 @@ export const TOOL_DEFINITION: ToolDefinition = {
   type: "function",
   name: META.toolName,
   description:
-    "Display a schema-driven collection inline in the chat as an interactive, editable card. Shows the collection's list of records; the user can open a record for a detailed view and edit / create / delete records, with changes saved to the workspace. Pass `itemId` to open one specific record on mount. Use this when the user wants to see or work with a collection (e.g. clients, invoices, contacts) directly in the conversation rather than navigating away to the collections page.",
+    "Display a schema-driven collection inline in the chat as an interactive, editable card. Shows the collection's list of records. Pass `itemId` to open one specific record on mount.",
   parameters: {
     type: "object",
     properties: {
@@ -24,6 +24,7 @@ export const TOOL_DEFINITION: ToolDefinition = {
     },
     required: ["collectionSlug"],
   },
+  prompt: `After making changes to schema-driven collections, use ${META.toolName} to present either the collection or the item`,
 };
 
 export default TOOL_DEFINITION;


### PR DESCRIPTION
## Summary

Make the LLM actually surface the inline collection card after working with a collection. Today, after adding/updating a record the model just posts a `/collections/...` link and never calls `presentCollection`, because the skill guidance points at the link. This nudges it via the **tool's own definition** (role-agnostic — no role-prompt changes).

## Changes (collection-specific files only)

- **`src/plugins/presentCollection/definition.ts`** — add a `prompt` to the `ToolDefinition`: _"After making changes to schema-driven collections, use presentCollection to present either the collection or the item."_ The MCP bridge folds `prompt` into the description Claude sees, so the cue travels with the tool. (Description also trimmed.)
- **`server/workspace/helps/collection-skills.md`** — the SKILL.md template's "What to do" now tells freshly-created collection skills to call `presentCollection` after add/update (and for show/list requests) instead of only linking to the collection view.

Role prompts are intentionally **not** touched.

## Note
Existing collection skills already in a user's workspace (authored before this change) keep their own SKILL.md, so they pick up the behavior mainly via the new tool `prompt`; the template change applies to newly created collections.

## Testing
- `yarn lint` / `yarn typecheck` — green. (Docs + one tool-definition string; no runtime logic changed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prompt the LLM to surface inline collection cards via the presentCollection tool after modifying or viewing collections.

New Features:
- Add a tool-level prompt to presentCollection instructing the model to present collections or items after schema-driven collection changes.

Enhancements:
- Simplify the presentCollection tool description to focus on inline display and item selection behavior.

Documentation:
- Update the collection skill template guidance to call presentCollection after add/update operations and for show/list requests instead of only linking to the collection view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for presenting collection results after adding or updating records, now instructing to show results inline using the collection tool with the slug and optional record ID.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->