### PR TITLE
fix(agent): block AskUserQuestion → "Answer questions?" leak (#1499)

### DIFF
--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -303,15 +303,6 @@ export function buildCliArgs(params: CliArgsParams): string[] {
     systemPrompt,
     "--allowedTools",
     allowedTools.join(","),
-    // Route every `behavior:"ask"` permission check through our MCP
-    // handler instead of letting the headless CLI fall back to
-    // echoing the permission message as the tool result — the
-    // built-in `AskUserQuestion` tool used to leak the literal
-    // `"Answer questions?"` to the model that way and made the LLM
-    // think the user had skipped the question. See #1499 and
-    // `server/agent/mcp-tools/handlePermission.ts`.
-    "--permission-prompt-tool",
-    "mcp__mulmoclaude__handlePermission",
     "-p",
   ];
 
@@ -331,6 +322,15 @@ export function buildCliArgs(params: CliArgsParams): string[] {
     // intends, since mulmoclaude itself is the broker for all the
     // GUI plugin tools.
     args.push("--strict-mcp-config");
+    // Permission hook for `behavior:"ask"` checks. Gated on
+    // `mcpConfigPath` because the handler tool (`handlePermission`)
+    // lives inside our MCP server — without `--mcp-config` the CLI
+    // can't resolve `mcp__mulmoclaude__handlePermission` and refuses
+    // to start (Codex review on PR #1560). In a no-MCP session the
+    // CLI's default ask handling stays in place; AskUserQuestion's
+    // leak (#1499) only manifests once tools are wired up, so the
+    // hook is correctly tied to the MCP-config presence.
+    args.push("--permission-prompt-tool", "mcp__mulmoclaude__handlePermission");
   }
 
   if (effortLevel) {

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -303,6 +303,15 @@ export function buildCliArgs(params: CliArgsParams): string[] {
     systemPrompt,
     "--allowedTools",
     allowedTools.join(","),
+    // Route every `behavior:"ask"` permission check through our MCP
+    // handler instead of letting the headless CLI fall back to
+    // echoing the permission message as the tool result — the
+    // built-in `AskUserQuestion` tool used to leak the literal
+    // `"Answer questions?"` to the model that way and made the LLM
+    // think the user had skipped the question. See #1499 and
+    // `server/agent/mcp-tools/handlePermission.ts`.
+    "--permission-prompt-tool",
+    "mcp__mulmoclaude__handlePermission",
     "-p",
   ];
 

--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -125,7 +125,18 @@ const ALL_TOOLS: Record<string, ToolDef> = {
   ...Object.fromEntries(PLUGIN_DEFS.map((def) => [def.name, fromPackage(def, TOOL_ENDPOINTS[def.name])])),
 };
 
-let activeNames: string[] = [...PLUGIN_NAMES];
+// Host-internal MCP tools the CLI invokes directly via flags
+// (currently: `--permission-prompt-tool mcp__mulmoclaude__handlePermission`,
+// see buildCliArgs + #1499). NOT gated by `role.availablePlugins`
+// — they're infrastructure, not LLM-facing surfaces. Filtered against
+// ALL_TOOLS before use so a typo here can't crash the server.
+const ALWAYS_ON_INTERNAL_TOOL_NAMES = ["handlePermission"] as const;
+
+function expandActiveNames(base: readonly string[]): string[] {
+  return [...base, ...ALWAYS_ON_INTERNAL_TOOL_NAMES];
+}
+
+let activeNames: string[] = expandActiveNames(PLUGIN_NAMES);
 let tools: ToolDef[] = activeNames.map((name) => ALL_TOOLS[name]).filter(Boolean);
 
 // Static collision floor — both the GUI plugin set (`MCP_PLUGIN_NAMES`)
@@ -170,7 +181,7 @@ const runtimeReady: Promise<void> = (async () => {
     // intersection is now: ALL_TOOLS includes both static + runtime
     // entries, but only the names PLUGIN_NAMES authorises become live
     // tools.
-    activeNames = [...PLUGIN_NAMES];
+    activeNames = expandActiveNames(PLUGIN_NAMES);
     tools = activeNames.map((name) => ALL_TOOLS[name]).filter(Boolean);
   } catch (err) {
     process.stderr.write(`[mcp-server] runtime plugin load failed; static tools only: ${String(err)}\n`);

--- a/server/agent/mcp-tools/handlePermission.ts
+++ b/server/agent/mcp-tools/handlePermission.ts
@@ -1,0 +1,107 @@
+// Permission-prompt-tool handler — wired via the Claude CLI's
+// `--permission-prompt-tool mcp__mulmoclaude__handlePermission`
+// flag in `buildCliArgs`. Whenever a built-in CLI tool's own
+// `checkPermissions()` returns `behavior: "ask"` (i.e. it wants
+// to gate on the user), the CLI calls this tool instead of
+// surfacing an interactive prompt — which is what we need
+// because MulmoClaude drives the CLI in headless stream-json
+// mode with no TTY for the user to answer on.
+//
+// The CLI expects a JSON-encoded permission decision wrapped in
+// a single MCP text block. We return the decision as a string;
+// the MCP bridge in `mcp-server.ts` already wraps tool-handler
+// strings as `{type:"text", text:<str>}`, which matches the
+// CLI's expected shape.
+//
+// Decision shape (per the Claude Code 2.1.x CLI):
+//   { behavior: "allow", updatedInput: <object> }
+//   { behavior: "deny",  message: <string> }
+//
+// Current policy:
+//   - `AskUserQuestion` is always denied with an instruction
+//     telling the LLM to use `presentForm` instead. The CLI's
+//     built-in AskUserQuestion has no UI surface in this
+//     environment — without this handler the CLI would echo
+//     the literal permission message `"Answer questions?"`
+//     back to the LLM as the tool result, which the model
+//     misreads as "the user skipped the question". See #1499.
+//   - Every other ask-requiring tool is allowed through with
+//     the input unchanged. We already pin the agent's effective
+//     tool set via `--allowedTools`, so a permission ask that
+//     reaches this handler means the tool is on the explicit
+//     allow list and the host has no further policy to apply.
+
+import type { McpTool, McpToolContext } from "./index.js";
+import { log } from "../../system/logger/index.js";
+
+const TOOL_NAME = "handlePermission";
+
+// Match the literal name the Claude Code CLI emits in `tool_name`
+// for the built-in clarifying-question tool. Exported so tests can
+// pin against the same constant rather than a duplicated string.
+export const ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
+
+const DENY_ASK_USER_QUESTION_MESSAGE =
+  "AskUserQuestion is not supported in MulmoClaude — use the `presentForm` tool to collect the user's answer. " +
+  "Build a small form with the same prompt and choices (radio for one-of, checkbox for many-of, text/textarea for free-form) and call presentForm with it. " +
+  "Do not re-call AskUserQuestion; it will be denied again.";
+
+interface PermissionInput {
+  tool_name?: unknown;
+  input?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function buildAllowResponse(input: unknown): string {
+  // CLI expects the permission decision as a JSON string. The
+  // `updatedInput` must be the exact arg shape the original tool
+  // will be called with — leave it untouched for the
+  // pass-through case.
+  return JSON.stringify({ behavior: "allow", updatedInput: isRecord(input) ? input : {} });
+}
+
+function buildDenyResponse(message: string): string {
+  return JSON.stringify({ behavior: "deny", message });
+}
+
+export const handlePermission: McpTool = {
+  definition: {
+    name: TOOL_NAME,
+    description:
+      "Internal: permission decision hook called by the Claude Code CLI for tools whose `checkPermissions()` returns `behavior:'ask'`. Not for LLM use — the host wires it via `--permission-prompt-tool` and the CLI invokes it on every ask-mode permission check.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tool_name: {
+          type: "string",
+          description: "Name of the tool the CLI is asking permission for (e.g. 'AskUserQuestion').",
+        },
+        input: {
+          type: "object",
+          description: "Original argument object the LLM passed to the tool.",
+        },
+      },
+      required: ["tool_name", "input"],
+    },
+  },
+
+  // Internal-only tool: don't surface it to the LLM via the
+  // role's allowedTools / system prompt. The CLI calls it
+  // directly through the `--permission-prompt-tool` flag.
+
+  async handler(args: Record<string, unknown>, __ctx?: McpToolContext): Promise<string> {
+    const raw = args as PermissionInput;
+    const toolName = typeof raw.tool_name === "string" ? raw.tool_name : "";
+
+    if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
+      log.info("mcp/handlePermission", "deny AskUserQuestion — instruct LLM to use presentForm");
+      return buildDenyResponse(DENY_ASK_USER_QUESTION_MESSAGE);
+    }
+
+    log.debug("mcp/handlePermission", "allow", { toolName });
+    return buildAllowResponse(raw.input);
+  },
+};

--- a/server/agent/mcp-tools/handlePermission.ts
+++ b/server/agent/mcp-tools/handlePermission.ts
@@ -18,18 +18,25 @@
 //   { behavior: "deny",  message: <string> }
 //
 // Current policy:
-//   - `AskUserQuestion` is always denied with an instruction
-//     telling the LLM to use `presentForm` instead. The CLI's
-//     built-in AskUserQuestion has no UI surface in this
-//     environment — without this handler the CLI would echo
+//   - `AskUserQuestion` is denied with a presentForm-redirect
+//     message. The CLI's built-in AskUserQuestion has no UI
+//     surface here — without this handler the CLI would echo
 //     the literal permission message `"Answer questions?"`
 //     back to the LLM as the tool result, which the model
 //     misreads as "the user skipped the question". See #1499.
-//   - Every other ask-requiring tool is allowed through with
-//     the input unchanged. We already pin the agent's effective
-//     tool set via `--allowedTools`, so a permission ask that
-//     reaches this handler means the tool is on the explicit
-//     allow list and the host has no further policy to apply.
+//   - **Every other ask-mode permission check is denied** with
+//     a "no headless consent path" message. Auto-allowing them
+//     would silently bypass the per-call consent the CLI tool
+//     intentionally requested (Codex security review on PR
+//     #1560: "removes per-call consent semantics for tools
+//     that intentionally escalate to behavior:'ask'"). The
+//     deny message tells the LLM the tool needs explicit user
+//     approval that isn't available in this surface, so the
+//     model picks a non-ask alternative (Read instead of a
+//     Bash needing approval, etc.) or asks the user to redo
+//     the request more concretely. The role's `--allowedTools`
+//     remains the authoritative allow gate; this handler is
+//     ONLY for ask-mode hooks.
 
 import type { McpTool, McpToolContext } from "./index.js";
 import { log } from "../../system/logger/index.js";
@@ -46,21 +53,18 @@ const DENY_ASK_USER_QUESTION_MESSAGE =
   "Build a small form with the same prompt and choices (radio for one-of, checkbox for many-of, text/textarea for free-form) and call presentForm with it. " +
   "Do not re-call AskUserQuestion; it will be denied again.";
 
+function buildDenyGenericMessage(toolName: string): string {
+  return (
+    `The CLI built-in tool '${toolName}' asked the host for per-call user permission, but MulmoClaude runs the CLI in headless mode and has no consent prompt for it. ` +
+    `Try a non-ask alternative for the same goal (e.g. read the file with Read instead of running a Bash command that needs approval), ` +
+    `or summarise the situation to the user in plain text and let them re-issue the request with a more concrete instruction. ` +
+    `Do not retry '${toolName}' with the same arguments; the host will deny it again.`
+  );
+}
+
 interface PermissionInput {
   tool_name?: unknown;
   input?: unknown;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function buildAllowResponse(input: unknown): string {
-  // CLI expects the permission decision as a JSON string. The
-  // `updatedInput` must be the exact arg shape the original tool
-  // will be called with — leave it untouched for the
-  // pass-through case.
-  return JSON.stringify({ behavior: "allow", updatedInput: isRecord(input) ? input : {} });
 }
 
 function buildDenyResponse(message: string): string {
@@ -101,7 +105,11 @@ export const handlePermission: McpTool = {
       return buildDenyResponse(DENY_ASK_USER_QUESTION_MESSAGE);
     }
 
-    log.debug("mcp/handlePermission", "allow", { toolName });
-    return buildAllowResponse(raw.input);
+    // Deny-by-default for every other ask-mode check. Auto-allow
+    // would silently bypass the per-call consent the tool itself
+    // requested — see the policy block at the top of the file.
+    const safeName = toolName.length > 0 ? toolName : "<unknown>";
+    log.info("mcp/handlePermission", "deny ask-mode tool — no headless consent surface", { toolName: safeName });
+    return buildDenyResponse(buildDenyGenericMessage(safeName));
   },
 };

--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { readXPost, searchX } from "./x.js";
 import { notify } from "./notify.js";
+import { handlePermission } from "./handlePermission.js";
 import { errorMessage } from "../../utils/errors.js";
 import { notFound, sendError, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -27,7 +28,7 @@ export interface McpTool {
   handler: (args: Record<string, unknown>, ctx?: McpToolContext) => Promise<string>;
 }
 
-export const mcpTools: McpTool[] = [readXPost, searchX, notify];
+export const mcpTools: McpTool[] = [readXPost, searchX, notify, handlePermission];
 
 const toolMap = new Map(mcpTools.map((tool) => [tool.definition.name, tool]));
 

--- a/server/prompts/system/system.md
+++ b/server/prompts/system/system.md
@@ -6,6 +6,12 @@ You are MulmoClaude, a versatile assistant app with rich visual output.
 - Be concise and helpful. Avoid unnecessary filler.
 - When you use a tool, briefly explain what you are doing and why.
 
+## Clarifying questions
+
+When you need an answer from the user before you can proceed, **always use the `presentForm` tool**. It renders proper interactive controls (radio / checkbox / dropdown / text / textarea / date / number) and the user's answers come back to you as a structured tool result.
+
+Do **NOT** use the built-in `AskUserQuestion` tool. It has no UI surface here — the host's permission gate denies it explicitly and returns an instruction telling you to switch to `presentForm`. Even for a single yes/no or short follow-up, a one-field `presentForm` is the right path; never ask in plain prose and wait for a chat reply when a form is appropriate.
+
 ## Workspace
 
 All data lives in the workspace directory as plain files:

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -153,6 +153,19 @@ describe("buildCliArgs", () => {
     assert.ok(!args.includes("--mcp-config"));
   });
 
+  it("includes --permission-prompt-tool only when MCP is wired (#1499 / #1560)", async () => {
+    // The handler tool lives inside our MCP server. With no
+    // --mcp-config the CLI can't resolve it and refuses to start;
+    // gate the flag together with --mcp-config.
+    const withMcp = buildCliArgs({ systemPrompt: "x", activePlugins: ["foo"], mcpConfigPath: "/tmp/mcp.json" });
+    const withMcpIdx = withMcp.indexOf("--permission-prompt-tool");
+    assert.ok(withMcpIdx >= 0, "must pass --permission-prompt-tool when MCP is configured");
+    assert.equal(withMcp[withMcpIdx + 1], "mcp__mulmoclaude__handlePermission");
+
+    const withoutMcp = buildCliArgs({ systemPrompt: "x", activePlugins: [] });
+    assert.ok(!withoutMcp.includes("--permission-prompt-tool"), "must NOT pass --permission-prompt-tool in no-MCP sessions");
+  });
+
   it("includes --effort when effortLevel is set", async () => {
     const args = buildCliArgs({
       systemPrompt: "test",

--- a/test/agent/test_handle_permission.ts
+++ b/test/agent/test_handle_permission.ts
@@ -8,7 +8,9 @@
 //
 //   1. AskUserQuestion is denied with an actionable message that
 //      redirects the LLM to presentForm.
-//   2. Every other ask-mode tool is allowed with input preserved.
+//   2. Every OTHER ask-mode tool is also denied (deny-by-default
+//      after Codex review on PR #1560 — auto-allow would silently
+//      bypass the per-call consent the tool itself requested).
 //   3. The return value is a JSON string matching the CLI's
 //      `{ behavior, ... }` shape (the MCP bridge wraps it as a
 //      single text block, which the CLI then parses).
@@ -47,22 +49,37 @@ describe("handlePermission MCP tool", () => {
     }
   });
 
-  it("allows every other ask-mode tool unchanged", async () => {
+  it("deny-by-default for every other ask-mode tool (no auto-allow)", async () => {
+    // Codex security review on #1560: auto-allowing ask-mode for
+    // arbitrary tools bypasses per-call user consent. Deny by
+    // default; tools that we want unconditionally allowed should
+    // be on `--allowedTools` instead so they never escalate here.
     const input = { command: "ls", description: "list workspace" };
     const result = await handlePermission.handler({ tool_name: "Bash", input });
     const decision = parse(result);
-    assert.equal(decision.behavior, "allow");
-    if (decision.behavior === "allow") {
-      assert.deepEqual(decision.updatedInput, input);
+    assert.equal(decision.behavior, "deny");
+    if (decision.behavior === "deny") {
+      assert.match(decision.message, /Bash/);
+      // Should suggest a non-ask alternative path, not silent fail.
+      assert.match(decision.message, /alternative|presentForm|user/i);
     }
   });
 
-  it("falls back to an empty updatedInput when `input` isn't an object", async () => {
-    const result = await handlePermission.handler({ tool_name: "Read", input: "not an object" });
+  it("includes the tool name in the deny message for arbitrary unknown tools", async () => {
+    const result = await handlePermission.handler({ tool_name: "WeirdNewTool", input: {} });
     const decision = parse(result);
-    assert.equal(decision.behavior, "allow");
-    if (decision.behavior === "allow") {
-      assert.deepEqual(decision.updatedInput, {});
+    assert.equal(decision.behavior, "deny");
+    if (decision.behavior === "deny") {
+      assert.match(decision.message, /WeirdNewTool/);
+    }
+  });
+
+  it("handles missing / non-string tool_name without crashing", async () => {
+    const result = await handlePermission.handler({ tool_name: undefined as unknown, input: {} });
+    const decision = parse(result);
+    assert.equal(decision.behavior, "deny");
+    if (decision.behavior === "deny") {
+      assert.match(decision.message, /<unknown>/);
     }
   });
 

--- a/test/agent/test_handle_permission.ts
+++ b/test/agent/test_handle_permission.ts
@@ -1,0 +1,81 @@
+// Regression test for #1499 — the permission-prompt-tool MCP
+// handler. The Claude Code CLI calls this whenever a built-in
+// tool's checkPermissions returns `behavior:"ask"`; without this
+// hook the CLI used to echo the literal `"Answer questions?"`
+// permission message back to the LLM as the AskUserQuestion tool
+// result, and the model treated it as "the user skipped the
+// question". This test pins:
+//
+//   1. AskUserQuestion is denied with an actionable message that
+//      redirects the LLM to presentForm.
+//   2. Every other ask-mode tool is allowed with input preserved.
+//   3. The return value is a JSON string matching the CLI's
+//      `{ behavior, ... }` shape (the MCP bridge wraps it as a
+//      single text block, which the CLI then parses).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { handlePermission, ASK_USER_QUESTION_TOOL_NAME } from "../../server/agent/mcp-tools/handlePermission.js";
+
+interface ParsedDeny {
+  behavior: "deny";
+  message: string;
+}
+interface ParsedAllow {
+  behavior: "allow";
+  updatedInput: Record<string, unknown>;
+}
+
+function parse(result: string): ParsedDeny | ParsedAllow {
+  const parsed = JSON.parse(result) as ParsedDeny | ParsedAllow;
+  return parsed;
+}
+
+describe("handlePermission MCP tool", () => {
+  it("denies AskUserQuestion with an instruction to use presentForm", async () => {
+    const result = await handlePermission.handler({
+      tool_name: ASK_USER_QUESTION_TOOL_NAME,
+      input: { questions: [{ question: "favourite colour?", options: ["red", "blue"] }] },
+    });
+    const decision = parse(result);
+    assert.equal(decision.behavior, "deny");
+    if (decision.behavior === "deny") {
+      // The LLM needs a clear path forward — not just "denied".
+      assert.match(decision.message, /presentForm/);
+      assert.match(decision.message, /AskUserQuestion is not supported/);
+    }
+  });
+
+  it("allows every other ask-mode tool unchanged", async () => {
+    const input = { command: "ls", description: "list workspace" };
+    const result = await handlePermission.handler({ tool_name: "Bash", input });
+    const decision = parse(result);
+    assert.equal(decision.behavior, "allow");
+    if (decision.behavior === "allow") {
+      assert.deepEqual(decision.updatedInput, input);
+    }
+  });
+
+  it("falls back to an empty updatedInput when `input` isn't an object", async () => {
+    const result = await handlePermission.handler({ tool_name: "Read", input: "not an object" });
+    const decision = parse(result);
+    assert.equal(decision.behavior, "allow");
+    if (decision.behavior === "allow") {
+      assert.deepEqual(decision.updatedInput, {});
+    }
+  });
+
+  it("returns a JSON-parseable string for every code path (the CLI parses it back)", async () => {
+    for (const toolName of [ASK_USER_QUESTION_TOOL_NAME, "Bash", "Read", "Edit", "Glob"]) {
+      const result = await handlePermission.handler({ tool_name: toolName, input: {} });
+      assert.doesNotThrow(() => JSON.parse(result), `result for ${toolName} must be JSON`);
+    }
+  });
+
+  it("declares the MCP tool name the CLI expects via --permission-prompt-tool", () => {
+    // The host wires `--permission-prompt-tool mcp__mulmoclaude__handlePermission`
+    // in `buildCliArgs`; this assertion catches a future rename.
+    assert.equal(handlePermission.definition.name, "handlePermission");
+  });
+});


### PR DESCRIPTION
## Summary

#1499 の根本原因: Claude Code 2.1 CLI の `AskUserQuestion` が `checkPermissions() => {behavior:"ask", message:"Answer questions?"}` で permission ask する設計。MulmoClaude は CLI を **headless stream-json サブプロセス**で動かしているので permission の TTY がなく、`--allowedTools` にも入っていないため、SDK が permission の `message` をそのまま tool_result として返してターン継続 → LLM が「ユーザーがスキップ」と誤解釈して「最も忠実な既定方針で進めます」と応答する流れになっていました。

ご報告 (Safari/Chrome 10/10 再現、エラー無し、Network 空、Tool Call History の result 欄に固定文字列) と完全一致します。

### 2 段階修正

**(B) System prompt** — `server/prompts/system/system.md` に「Clarifying questions」セクション追加: 「`AskUserQuestion` 禁止 / `presentForm` を使え」を全 role 共通で明記。そもそも呼び出される頻度を下げる予防策。

**(C) Permission-prompt-tool ブリッジ** — Claude CLI 2.1 の隠しフラグ `--permission-prompt-tool` を経由して、全 ask-mode の permission decision を新規 MCP tool `mcp__mulmoclaude__handlePermission` に委譲。
- `AskUserQuestion` は **明示的に deny** + 「presentForm に切り替えて」という actionable な message を返す → CLI の固定文字列 `"Answer questions?"` 経路を完全遮断
- それ以外の ask-mode tool は `{behavior:"allow", updatedInput:<input>}` で通す (allowlist が本来のゲートなので、ここまで来たツールは通すのが期待挙動)

修正後は LLM が deny 文の中身を読んで自動的に `presentForm` に切り替えるので、ユーザー体験上 AskUserQuestion 呼び出しは透過的に正しい UI 経路に乗ります。

## Items to Confirm / Review

- **scope のトレードオフ**: (C) は \"AskUserQuestion を deny して presentForm に誘導\" にとどめており、本格的な「AskUserQuestion の引数を presentForm に翻訳して UI で出し、ユーザー回答を AskUserQuestion の tool_result に注入し戻す」フル UI ブリッジは将来作業。`presentForm` 自体は別経路で動いている既存の UI なので、LLM が切り替えた瞬間に普通の UX に乗るので、現状この PR の範囲で実害は解消する判断
- **新規 MCP tool は LLM に露出させていない**: handlePermission は `--permission-prompt-tool` 経由でのみ呼ばれる host 内部用。`prompt` フィールドを持たないので system prompt にも入らない
- **`--permission-prompt-tool` 隠しフラグ**: \`claude --help\` には出ないが、CLI バイナリ内 strings で確認 (`Permission prompt tool returned an invalid result. Expected a single text block...`). Claude Code 2.1.x で安定挙動

## Implementation

| ファイル | 変更内容 |
|---|---|
| `server/agent/mcp-tools/handlePermission.ts` (新) | ask-mode permission decision を返す MCP tool。AskUserQuestion は deny + presentForm 誘導 message、他は allow pass-through |
| `server/agent/mcp-tools/index.ts` | `mcpTools[]` に handlePermission 追加 |
| `server/agent/config.ts` | `buildCliArgs` の args 配列に `--permission-prompt-tool mcp__mulmoclaude__handlePermission` 追加 |
| `server/prompts/system/system.md` | 「Clarifying questions」セクション追加 (presentForm 使え / AskUserQuestion 禁止) |
| `test/agent/test_handle_permission.ts` (新) | 5 ケース: deny / allow / 非 object 入力 / JSON shape / tool name pin |

## Test

- `yarn lint` clean
- `yarn typecheck:server` clean
- `yarn build` clean
- `npx tsx --test test/agent/test_handle_permission.ts test/agent/test_agent_config.ts` → **65/65 pass** (new 5 + existing 60)

Closes #1499.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1499 再現させたいけどどうすれば良い？原因わかる？
> B/C をまとめて実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permission prompts are routed through a built-in permission handler that is always exposed in the tool registry.

* **Bug Fixes**
  * CLI now includes the permission-prompt tool option when the MCP configuration is enabled.

* **Documentation**
  * System prompt updated to require using the form-based tool for collecting user input (avoid unsupported question tool).

* **Tests**
  * Added regression tests covering the permission handler behavior and CLI wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->