### PR TITLE
feat(collections): send into current chat when CollectionView is embedded

### DIFF
--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -922,10 +922,16 @@ interface EditState {
  *  `presentCollection` chat card mounts this component and drives both
  *  from the tool result). In standalone route mode (the
  *  `/collections/:slug` page) both are undefined and the component reads
- *  `route.params.slug` / `route.query.selected` as before. */
+ *  `route.params.slug` / `route.query.selected` as before.
+ *
+ *  `sendTextMessage` is forwarded ONLY by the chat card — its presence
+ *  is our "rendered inside a chat" signal. When set, chat-triggering
+ *  actions send into the current session instead of spawning a new
+ *  chat (see `runAction` / `submitChat`). */
 const props = defineProps<{
   slug?: string;
   selected?: string;
+  sendTextMessage?: (text?: string) => void;
 }>();
 
 const emit = defineEmits<{
@@ -1116,6 +1122,14 @@ async function runAction(action: CollectionAction): Promise<void> {
     actionError.value = result.error;
     return;
   }
+  // In a chat card we have a channel into the current session — send
+  // the seed prompt there rather than spawning a new chat. Standalone
+  // route mode has no such channel, so start a fresh chat in the
+  // action's role (which carries the tools the action needs).
+  if (props.sendTextMessage) {
+    props.sendTextMessage(result.data.prompt);
+    return;
+  }
   appApi.startNewChat(result.data.prompt, result.data.role);
 }
 
@@ -1138,7 +1152,13 @@ function submitChat(): void {
   const message = chatMessage.value.trim();
   if (!message) return;
   closeChat();
-  appApi.startNewChat(`/${collection.value.slug} ${message}`, BUILTIN_ROLE_IDS.general);
+  const text = `/${collection.value.slug} ${message}`;
+  // Chat card → send into the current session; standalone → new chat.
+  if (props.sendTextMessage) {
+    props.sendTextMessage(text);
+    return;
+  }
+  appApi.startNewChat(text, BUILTIN_ROLE_IDS.general);
 }
 
 async function loadCollection(slug: string): Promise<void> {

--- a/src/plugins/presentCollection/View.vue
+++ b/src/plugins/presentCollection/View.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full h-full" data-testid="present-collection">
-    <CollectionView v-if="slug" :slug="slug" :selected="selected" @select="onSelect" />
+    <CollectionView v-if="slug" :slug="slug" :selected="selected" :send-text-message="sendTextMessage" @select="onSelect" />
   </div>
 </template>
 
@@ -20,6 +20,10 @@ interface PresentCollectionViewState {
 
 const props = defineProps<{
   selectedResult: ToolResult | null;
+  /** Host-provided channel into the current chat session. Forwarded to
+   *  CollectionView so its chat actions send a message here instead of
+   *  spawning a new chat (the card is always rendered inside a chat). */
+  sendTextMessage?: (text?: string) => void;
 }>();
 
 const emit = defineEmits<{


### PR DESCRIPTION
## What

When `CollectionView` is rendered **inside a chat** (the `presentCollection` tool-result card), its chat-triggering actions now **send a message into the current session** instead of spawning a new chat. The standalone `/collections/:slug` page is unchanged — it still starts a fresh chat.

## Why

A collection card embedded in a chat that spawns a *brand-new* session on every action button / chat send is surprising — the user is already in a conversation about that collection. Sending into the current session keeps the thread coherent. This mirrors the existing wiki / presentForm behaviour.

## How

`CollectionView` is mounted in exactly two places:

- standalone `/collections/:slug` route (`App.vue`) — no `sendTextMessage`
- `presentCollection` chat card — forwards `sendTextMessage`

So the **presence of the `sendTextMessage` prop is the "rendered inside a chat" signal**, the same discriminator wiki / presentForm use.

- `presentCollection/View.vue`: accept `sendTextMessage?` and forward it to `<CollectionView>`
- `CollectionView.vue`: accept `sendTextMessage?`; in `runAction` and `submitChat`, when the prop is present send via `sendTextMessage(...)`, otherwise fall back to `appApi.startNewChat(...)`

## Note / trade-off

In standalone mode, `runAction` starts the new chat in the **action's designated role** (`result.data.role`), which carries the tools the action needs. When embedded, the message goes into the current session, so that role designation is not applied — the current session's role handles it. This matches the requested behaviour ("don't create a new session, just send the message").

## Checks

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat actions within collection views now support integration with your active chat session, routing messages to the current conversation instead of opening a new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->