### PR TITLE
feat(collections): delete a collection with archive-on-delete + restore

### DIFF
--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -253,6 +253,121 @@ Star it from `/skills` and it appears at `/collections/<slug>`. Preset
 collections (the `mc-*` skills) ship under
 `server/workspace/skills-preset/` and are synced into the workspace on boot.
 
+## Deleting a collection
+
+Deletion is more involved than the opening layout diagram suggests, because
+that diagram shows a **preset** (`mc-invoice`). A collection that Claude
+authors at runtime is spread across **three** on-disk locations, not one, and
+removing the collection means removing all three.
+
+### The three locations of a user-authored collection
+
+Take a runtime-created collection with slug `restaurants`:
+
+| # | Path | Role | Written by |
+|---|---|---|---|
+| 1 | `data/skills/<slug>/` | **Staging / source of truth** — `SKILL.md` + `schema.json` + `templates/*.md` | Claude (via `mc-manage-skills`) |
+| 2 | `.claude/skills/<slug>/` | **Mirror** of #1 — the copy that discovery *and* Claude Code's slash-command resolver actually scan | the `skillBridge` hook, *not* Claude |
+| 3 | `data/<dataPath-parent>/` | **The records** — `data/<slug>/items/*.json` by convention | the REST API / Claude |
+
+Locations #1 and #2 are a **source → mirror pair**, wired by the skill-bridge
+PostToolUse hook (`server/workspace/hooks/handlers/skillBridge.ts`). The reason
+the split exists: `.claude/` is permission-gated (writes there are a
+self-modification risk, and the host GUI has no surface to answer the
+permission prompt), so Claude writes the editable copy to the ungated
+`data/skills/<slug>/` staging dir, and the hook — a plain subprocess, not a
+Claude tool call, so it is not subject to the gate — mirrors an **allowlist**
+(`SKILL.md`, `schema.json`, `templates/*` only) into `.claude/skills/<slug>/`
+(`mirrorWrite`, `skillBridge.ts:191`; `isAllowlisted`, `:138`). The collection
+appears in the UI because of #2, but #1 is the canonical copy.
+
+The same hook also mirrors **deletes**: it regex-matches a Bash
+`rm -rf data/skills/<slug>` command and runs the corresponding
+`rm -rf .claude/skills/<slug>` (`mirrorDelete`, `skillBridge.ts:205`;
+`slugFromRmCommand`, `:175`). So the canonical agent-driven delete is "remove
+staging #1, and #2 follows automatically." This is exactly what
+`mc-manage-skills`'s `SKILL.md` instructs Claude to do (`rm -rf data/skills/<slug>/`).
+
+### Why all three must go
+
+- **#1 is the source of truth — never delete only #2.** The mirror is
+  regenerated from staging on any write/edit trigger, and #1 is the copy a
+  re-activation would publish from. Leave #1 and the collection can come back;
+  remove #1 and #2 follows by the hook (or must be removed in lockstep when
+  deleting server-side, where the hook does *not* fire — it keys off agent tool
+  calls only).
+- **#3 is independent of the bridge.** The skill-bridge hook mirrors *only* the
+  skill dir (the allowlist) — it never touches records. So even the canonical
+  `rm -rf data/skills/<slug>` leaves `data/<slug>/items/*.json` orphaned on
+  disk. Removing the records is a separate, explicit step.
+
+### Backup before delete: `archive/<date>-<uuid>/`
+
+Deletion is destructive and there is no schema-versioned undo, so a
+collection-aware delete **archives a full copy before removing anything**. The
+backup goes to a fresh, collision-proof folder under the workspace root:
+
+```
+archive/<date>-<uuid>/
+  RESTORE.md     ← LLM-readable instructions: the slug, the original dataPath,
+                   and the step-by-step restore procedure
+  skill/         ← ONE copy of the skill dir: schema.json + SKILL.md + templates/*
+  records/       ← the collection's <id>.json record files
+```
+
+- **`<date>-<uuid>`** — `<date>` (e.g. `2026-05-31`) keeps the archive
+  human-sortable; `<uuid>` (`crypto.randomUUID()`) guarantees uniqueness so two
+  deletes of the same slug on the same day never collide. (`archive/` is a new
+  `WORKSPACE_PATHS` entry — it does not exist today.)
+- **Only one skill copy is stored.** Because `.claude/skills/<slug>/` is a
+  mirror of `data/skills/<slug>/`, archiving both would be redundant. Copy from
+  the **staging dir `data/skills/<slug>/`** — it is the canonical source (the
+  superset: any non-allowlisted extras the bridge never mirrors live only
+  there). The mirror is reconstructed on restore, not archived.
+- **`records/`** is the contents of the schema's `dataPath` directory (its
+  `<id>.json` files), captured before #3 is deleted.
+
+**`RESTORE.md`** is written *for an LLM to execute*, not just for a human to
+read. It records the slug and the original `dataPath`, then the procedure:
+
+1. Recreate `data/skills/<slug>/` from `skill/` — writing those files (via the
+   normal `mc-manage-skills` staging path) re-fires the skill-bridge hook, which
+   mirrors them back into `.claude/skills/<slug>/` and re-registers the
+   collection.
+2. Restore `records/` into the original `dataPath` (default `data/<slug>/items/`).
+3. Confirm the collection reappears at `/collections/<slug>`.
+
+Restoring through the staging path (not by hand-writing `.claude/skills/`)
+keeps the source → mirror invariant intact and avoids the `.claude/` permission
+gate — the same reason deletes route through `data/skills/` in the first place.
+
+### Two implementation cautions
+
+1. **The records path is schema-defined, not the slug.** Location #3 is the
+   parent of `schema.json`'s `dataPath`, *not* hardcoded `data/<slug>`. Runtime
+   collections follow the `data/<slug>/items` convention so `data/<slug>` holds
+   in practice — but the robust source of truth is to read `dataPath` from the
+   schema and delete its directory. Presets deliberately break the convention
+   (`mc-invoice` → `data/invoice`, not `data/mc-invoice`).
+2. **`deleteProjectSkill` is insufficient for collections.** The existing skill
+   writer (`server/workspace/skills/writer.ts:134`, behind `DELETE /api/skills/:name`)
+   only unlinks `.claude/skills/<slug>/SKILL.md` and `rmdir`s the dir *if empty*.
+   It ignores `schema.json` (so discovery still finds the collection), the
+   staging dir #1, and the records #3. A collection-aware delete cannot simply
+   reuse it. It also refuses user-scope (`~/.claude/skills/`) skills — only
+   project-scope is writable from MulmoClaude.
+
+### No boot-time resurrection (for non-preset collections)
+
+The startup sync (`syncPresetSkills` / `syncActivePresetSkills`,
+`server/workspace/skills-preset.ts`) only touches `mc-*` **preset** slugs from
+the preset source tree. It never syncs an arbitrary `data/skills/<slug>` into
+`.claude/skills/<slug>`, so removing all three dirs of a user-authored
+collection is durable across restarts. (Conversely, deleting a *preset*
+collection that is still active is futile — it re-seeds on next boot. Presets
+are factory-managed; the intended "remove" for them is to unstar from the
+catalog.)
+
 ## Source map
 
 | Concern | File |
@@ -265,6 +380,9 @@ collections (the `mc-*` skills) ship under
 | UI (table / form / detail / actions) | `src/components/CollectionView.vue` |
 | Derived-formula evaluator | `src/utils/collections/derivedFormula.ts` |
 | Action + field visibility predicate (`when`, UI + server) | `src/utils/collections/actionVisible.ts` |
+| Staging → `.claude/skills` mirror bridge (create + delete) | `server/workspace/hooks/handlers/skillBridge.ts` |
+| Project-skill writer / `deleteProjectSkill` | `server/workspace/skills/writer.ts` |
+| Preset boot-sync (`mc-*` only) | `server/workspace/skills-preset.ts` |
 | Canonical example schema | `server/workspace/skills-preset/mc-invoice/schema.json` |
 
 Field-type design history and deferred-work rationale live in the shipped

--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -308,7 +308,7 @@ Deletion is destructive and there is no schema-versioned undo, so a
 collection-aware delete **archives a full copy before removing anything**. The
 backup goes to a fresh, collision-proof folder under the workspace root:
 
-```
+```text
 archive/<date>-<uuid>/
   RESTORE.md     ← LLM-readable instructions: the slug, the original dataPath,
                    and the step-by-step restore procedure

--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -331,16 +331,22 @@ archive/<date>-<uuid>/
 **`RESTORE.md`** is written *for an LLM to execute*, not just for a human to
 read. It records the slug and the original `dataPath`, then the procedure:
 
-1. Recreate `data/skills/<slug>/` from `skill/` — writing those files (via the
-   normal `mc-manage-skills` staging path) re-fires the skill-bridge hook, which
-   mirrors them back into `.claude/skills/<slug>/` and re-registers the
-   collection.
-2. Restore `records/` into the original `dataPath` (default `data/<slug>/items/`).
+1. Recreate `data/skills/<slug>/` from `skill/` **using the Write tool** — the
+   skill-bridge hook only fires on Write/Edit, so it then mirrors those files
+   into `.claude/skills/<slug>/` and re-registers the collection. The doc
+   explicitly forbids `cp` / `mv` / shell redirects here: those land the files
+   in staging without ever triggering the mirror, leaving the collection
+   invisible (the failure mode that motivated this wording).
+2. Copy `records/` into the original `dataPath` (default `data/<slug>/items/`).
+   The records are plain data files, not bridged, so they must be `cp`-ed —
+   the Write-tool rule from step 1 is scoped to the skill files only, so the
+   (potentially many) records are copied, not Written one by one.
 3. Confirm the collection reappears at `/collections/<slug>`.
 
-Restoring through the staging path (not by hand-writing `.claude/skills/`)
-keeps the source → mirror invariant intact and avoids the `.claude/` permission
-gate — the same reason deletes route through `data/skills/` in the first place.
+Restoring the skill through the staging path with Write (not by hand-writing
+`.claude/skills/`) keeps the source → mirror invariant intact and avoids the
+`.claude/` permission gate — the same reason deletes route through
+`data/skills/` in the first place.
 
 ### Two implementation cautions
 

--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -124,7 +124,8 @@ Discover ──▶ Validate ──▶ Serve ──▶ Render ──▶ CRUD ─�
   declared field flagged `primary: true`. A bad schema is logged and skipped,
   never crashes the host (`discovery.ts:140`, `:222`).
 - **Serve** — REST surface (`server/api/routes/collections.ts`):
-  `GET /api/collections`, `GET /:slug`, `POST/PUT/DELETE /:slug/items[/:itemId]`,
+  `GET /api/collections`, `GET /:slug`, `DELETE /:slug` (delete the whole
+  collection — see below), `POST/PUT/DELETE /:slug/items[/:itemId]`,
   `POST /:slug/items/:itemId/actions/:actionId`.
 - **Render** — `/collections/:slug` mounts `<CollectionView>`
   (`src/router/index.ts:89`, `src/App.vue:230`); every field type maps to a
@@ -380,6 +381,7 @@ catalog.)
 | UI (table / form / detail / actions) | `src/components/CollectionView.vue` |
 | Derived-formula evaluator | `src/utils/collections/derivedFormula.ts` |
 | Action + field visibility predicate (`when`, UI + server) | `src/utils/collections/actionVisible.ts` |
+| Collection delete + archive (all three locations + RESTORE.md) | `server/workspace/collections/delete.ts` |
 | Staging → `.claude/skills` mirror bridge (create + delete) | `server/workspace/hooks/handlers/skillBridge.ts` |
 | Project-skill writer / `deleteProjectSkill` | `server/workspace/skills/writer.ts` |
 | Preset boot-sync (`mc-*` only) | `server/workspace/skills-preset.ts` |

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -15,6 +15,7 @@ import {
   discoverCollections,
   generateItemId,
   deleteCollection,
+  deleteCollectionRefusalMessage,
   deleteItem,
   listItems,
   loadCollection,
@@ -104,16 +105,8 @@ router.delete(API_ROUTES.collections.detail, async (req: Request<{ slug: string 
   }
   try {
     const result = await deleteCollection(collection);
-    if (result.kind === "user-scope") {
-      forbidden(res, `collection '${result.slug}' is user-scope (~/.claude/skills/) and is read-only from MulmoClaude`);
-      return;
-    }
-    if (result.kind === "preset") {
-      forbidden(res, `collection '${result.slug}' is a preset (mc-*) and re-seeds on restart; unstar it from the catalog instead`);
-      return;
-    }
-    if (result.kind === "path-escape") {
-      forbidden(res, `a directory for collection '${result.slug}' escapes the workspace`);
+    if (result.kind !== "ok") {
+      forbidden(res, deleteCollectionRefusalMessage(result));
       return;
     }
     log.info("collections", "collection deleted", { slug: result.slug, archivePath: result.archivePath });

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -14,6 +14,7 @@ import { actionVisible } from "../../../src/utils/collections/actionVisible.js";
 import {
   discoverCollections,
   generateItemId,
+  deleteCollection,
   deleteItem,
   listItems,
   loadCollection,
@@ -51,6 +52,14 @@ interface DeleteResponse {
   itemId: string;
 }
 
+interface DeleteCollectionResponse {
+  deleted: true;
+  slug: string;
+  /** Workspace-relative path to the backup written before removal
+   *  (e.g. `archive/2026-05-31-<uuid>`). */
+  archivePath: string;
+}
+
 interface ActionSeedResponse {
   /** Assembled seed prompt the client feeds to a new chat. */
   prompt: string;
@@ -79,6 +88,38 @@ router.get(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>,
     res.json({ collection: toDetail(collection), items });
   } catch (err) {
     log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+});
+
+// Delete an entire collection — the skill (staging + active mirror) AND
+// its records — after archiving a restorable copy. Only project-scope,
+// non-preset collections are deletable; see deleteCollection for the
+// scope rules and the archive layout.
+router.delete(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>, res: Response<DeleteCollectionResponse>) => {
+  const collection = await loadCollection(req.params.slug);
+  if (!collection) {
+    notFound(res, `collection '${req.params.slug}' not found`);
+    return;
+  }
+  try {
+    const result = await deleteCollection(collection);
+    if (result.kind === "user-scope") {
+      forbidden(res, `collection '${result.slug}' is user-scope (~/.claude/skills/) and is read-only from MulmoClaude`);
+      return;
+    }
+    if (result.kind === "preset") {
+      forbidden(res, `collection '${result.slug}' is a preset (mc-*) and re-seeds on restart; unstar it from the catalog instead`);
+      return;
+    }
+    if (result.kind === "path-escape") {
+      forbidden(res, `a directory for collection '${result.slug}' escapes the workspace`);
+      return;
+    }
+    log.info("collections", "collection deleted", { slug: result.slug, archivePath: result.archivePath });
+    res.json({ deleted: true, slug: result.slug, archivePath: result.archivePath });
+  } catch (err) {
+    log.warn("collections", "collection delete failed", { slug: req.params.slug, error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });

--- a/server/workspace/collections/delete.ts
+++ b/server/workspace/collections/delete.ts
@@ -87,17 +87,22 @@ function deleteTargets(collection: LoadedCollection, workspaceRoot: string): str
   return [stagingSkillDir(workspaceRoot, collection.slug), collection.skillDir, collection.dataDir];
 }
 
-/** A deletable collection's records must live in its OWN `data/<slug>/`
- *  subtree. `resolveDataDir` only proves the path stays inside the
- *  workspace, so a malformed or hostile schema could point `dataPath`
- *  at a shared root (`data`, `data/skills`, another collection) and
- *  turn the recursive records removal into a workspace-wide wipe whose
- *  archive only captures this one collection. Refuse unless the path is
- *  the per-collection root or a descendant of it. */
-function isDataPathSafe(dataPath: string, slug: string): boolean {
-  const normalized = path.normalize(dataPath);
-  const root = path.join("data", slug);
-  return normalized === root || normalized.startsWith(root + path.sep);
+/** The records directory the delete recursively archives + removes
+ *  (`collection.dataDir`) must live in this collection's OWN
+ *  `data/<slug>/` subtree. `dataDir` is normally derived from
+ *  `schema.dataPath`, but `deleteCollection` accepts a `LoadedCollection`
+ *  whose fields could be inconsistent — so we validate the RESOLVED
+ *  target the destructive ops actually touch, not the schema string.
+ *  `resolveDataDir` only proves containment in the workspace; a shared
+ *  root like `data` or `data/skills` would otherwise turn the recursive
+ *  removal into a workspace-wide wipe whose archive captures only this
+ *  collection. `path.resolve` collapses any `..` before the prefix test
+ *  (symlink escapes are caught separately by the realpath containment
+ *  check in `deleteTargets`). */
+function isDataDirSafe(dataDir: string, slug: string, workspaceRoot: string): boolean {
+  const expectedRoot = path.resolve(workspaceRoot, "data", slug);
+  const resolved = path.resolve(dataDir);
+  return resolved === expectedRoot || resolved.startsWith(expectedRoot + path.sep);
 }
 
 function buildRestoreDoc(collection: LoadedCollection): string {
@@ -163,8 +168,8 @@ export async function deleteCollection(collection: LoadedCollection, opts: Delet
   const workspaceRoot = opts.workspaceRoot ?? workspacePath;
   if (collection.source === "user") return { kind: "user-scope", slug };
   if (isPresetSlug(slug)) return { kind: "preset", slug };
-  if (!isDataPathSafe(collection.schema.dataPath, slug)) {
-    log.warn("collections", "deleteCollection refused: dataPath is not under the per-collection root", { slug, dataPath: collection.schema.dataPath });
+  if (!isDataDirSafe(collection.dataDir, slug, workspaceRoot)) {
+    log.warn("collections", "deleteCollection refused: dataDir is not under the per-collection root", { slug, dataDir: collection.dataDir });
     return { kind: "unsafe-data-path", slug };
   }
   if (deleteTargets(collection, workspaceRoot).some((target) => !isContainedInRoot(target, workspaceRoot))) {

--- a/server/workspace/collections/delete.ts
+++ b/server/workspace/collections/delete.ts
@@ -31,7 +31,25 @@ export type DeleteCollectionResult =
   | { kind: "ok"; slug: string; archivePath: string }
   | { kind: "user-scope"; slug: string }
   | { kind: "preset"; slug: string }
+  | { kind: "unsafe-data-path"; slug: string }
   | { kind: "path-escape"; slug: string };
+
+type DeleteRefusal = Exclude<DeleteCollectionResult, { kind: "ok" }>;
+
+/** Human-readable reason for a non-`ok` delete result. Exported so the
+ *  route maps `kind` → message without inlining the switch (keeps the
+ *  handler short and the mapping unit-testable). The `Record` is
+ *  exhaustive — a new refusal kind won't compile until it's added. */
+export function deleteCollectionRefusalMessage(result: DeleteRefusal): string {
+  const { slug } = result;
+  const messages: Record<DeleteRefusal["kind"], string> = {
+    "user-scope": `collection '${slug}' is user-scope (~/.claude/skills/) and is read-only from MulmoClaude`,
+    preset: `collection '${slug}' is a preset (mc-*) and re-seeds on restart; unstar it from the catalog instead`,
+    "unsafe-data-path": `collection '${slug}' declares a dataPath outside its own data/${slug}/ subtree; refusing to delete`,
+    "path-escape": `a directory for collection '${slug}' escapes the workspace`,
+  };
+  return messages[result.kind];
+}
 
 export interface DeleteCollectionOptions {
   /** Override the workspace root for containment checks + archive
@@ -67,6 +85,19 @@ function todayStamp(): string {
  *  workspace root — guards against a symlinked ancestor escaping it. */
 function deleteTargets(collection: LoadedCollection, workspaceRoot: string): string[] {
   return [stagingSkillDir(workspaceRoot, collection.slug), collection.skillDir, collection.dataDir];
+}
+
+/** A deletable collection's records must live in its OWN `data/<slug>/`
+ *  subtree. `resolveDataDir` only proves the path stays inside the
+ *  workspace, so a malformed or hostile schema could point `dataPath`
+ *  at a shared root (`data`, `data/skills`, another collection) and
+ *  turn the recursive records removal into a workspace-wide wipe whose
+ *  archive only captures this one collection. Refuse unless the path is
+ *  the per-collection root or a descendant of it. */
+function isDataPathSafe(dataPath: string, slug: string): boolean {
+  const normalized = path.normalize(dataPath);
+  const root = path.join("data", slug);
+  return normalized === root || normalized.startsWith(root + path.sep);
 }
 
 function buildRestoreDoc(collection: LoadedCollection): string {
@@ -132,6 +163,10 @@ export async function deleteCollection(collection: LoadedCollection, opts: Delet
   const workspaceRoot = opts.workspaceRoot ?? workspacePath;
   if (collection.source === "user") return { kind: "user-scope", slug };
   if (isPresetSlug(slug)) return { kind: "preset", slug };
+  if (!isDataPathSafe(collection.schema.dataPath, slug)) {
+    log.warn("collections", "deleteCollection refused: dataPath is not under the per-collection root", { slug, dataPath: collection.schema.dataPath });
+    return { kind: "unsafe-data-path", slug };
+  }
   if (deleteTargets(collection, workspaceRoot).some((target) => !isContainedInRoot(target, workspaceRoot))) {
     log.warn("collections", "deleteCollection refused: a target escapes the workspace", { slug });
     return { kind: "path-escape", slug };

--- a/server/workspace/collections/delete.ts
+++ b/server/workspace/collections/delete.ts
@@ -74,15 +74,28 @@ function buildRestoreDoc(collection: LoadedCollection): string {
   return `# Restore "${schema.title}" (collection \`${slug}\`)
 
 This folder is an automatic backup made when the collection was deleted.
-To restore it, follow these steps (the staging path matters — writing the
-skill into \`data/skills/\` lets the skill-bridge hook rebuild the
-\`.claude/skills/\` mirror and re-register the collection; writing
-\`.claude/skills/\` directly would hit the permission gate):
+Follow these steps to restore it.
 
-1. Recreate the skill from \`skill/\` into \`data/skills/${slug}/\`
-   (copy \`SKILL.md\`, \`schema.json\`, and any \`templates/\`). The hook
-   mirrors those files into \`.claude/skills/${slug}/\` automatically.
-2. Restore the records from \`records/\` into \`${schema.dataPath}/\`.
+1. Recreate the skill files in \`data/skills/${slug}/\` using the **Write
+   tool**: read each file under \`skill/\` and Write it to the matching
+   path — \`SKILL.md\`, \`schema.json\`, and any \`templates/*\`.
+
+   IMPORTANT — use the Write tool, NOT \`cp\` / \`mv\` / a shell redirect.
+   The skill-bridge hook mirrors \`data/skills/${slug}/\` into
+   \`.claude/skills/${slug}/\`, and that mirror is what actually registers
+   the collection. The hook only fires on Write/Edit tool calls, so a
+   \`cp\` would leave the files in staging with no \`.claude/skills/\`
+   mirror — the collection would stay invisible. (Writing
+   \`.claude/skills/\` directly is not an option either: that path is
+   permission-gated.)
+
+2. Copy the item data: \`cp\` every file under \`records/\` into
+   \`${schema.dataPath}/\`. The records are part of the collection and
+   must be restored. They are plain data files (NOT bridged), so use
+   \`cp\` — the Write-tool rule in step 1 applies ONLY to the skill
+   files, not to these records (there may be many; copy them, do not
+   Write them one by one).
+
 3. Confirm the collection reappears at \`/collections/${slug}\`.
 
 - slug: \`${slug}\`

--- a/server/workspace/collections/delete.ts
+++ b/server/workspace/collections/delete.ts
@@ -1,0 +1,133 @@
+// Delete a user-authored collection, archiving a full restorable copy
+// first. A collection spans three on-disk locations (see
+// docs/collections-architecture.md "Deleting a collection"):
+//
+//   1. data/skills/<slug>/    staging — the canonical skill source
+//   2. .claude/skills/<slug>/ active mirror — what discovery scans
+//   3. <schema.dataPath>/     the records (one <id>.json per record)
+//
+// Locations 1 and 2 are a source→mirror pair maintained by the
+// skill-bridge hook, but that hook only fires on the agent's own tool
+// calls — a server-side delete must remove BOTH explicitly. Before
+// anything is removed we write a single skill copy (from the canonical
+// staging dir), the records, and an LLM-runnable RESTORE.md to
+// `archive/<date>-<uuid>/`.
+//
+// Only project-scope, non-preset collections are deletable: user-scope
+// skills (`~/.claude/skills/`) are read-only from MulmoClaude, and a
+// preset (`mc-*`) re-seeds on next boot so deleting it is futile.
+
+import { cp, mkdir, rm, rmdir, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { log } from "../../system/logger/index.js";
+import { WORKSPACE_DIRS } from "../paths.js";
+import { workspacePath } from "../workspace.js";
+import { isPresetSlug } from "../skills-preset.js";
+import { isContainedInRoot } from "./paths.js";
+import type { LoadedCollection } from "./discovery.js";
+
+export type DeleteCollectionResult =
+  | { kind: "ok"; slug: string; archivePath: string }
+  | { kind: "user-scope"; slug: string }
+  | { kind: "preset"; slug: string }
+  | { kind: "path-escape"; slug: string };
+
+export interface DeleteCollectionOptions {
+  /** Override the workspace root for containment checks + archive
+   *  placement. Default: the live `workspacePath`. Tests point this at
+   *  a `mkdtempSync` tree (same pattern as the IO helpers). */
+  workspaceRoot?: string;
+  /** Override the `<date>` half of the archive folder name. Tests pass
+   *  a fixed stamp so the asserted path is deterministic; production
+   *  leaves it unset and the current UTC date (YYYY-MM-DD) is used. */
+  dateStamp?: string;
+}
+
+/** The canonical staging dir for a slug: `data/skills/<slug>`. */
+function stagingSkillDir(workspaceRoot: string, slug: string): string {
+  return path.join(workspaceRoot, WORKSPACE_DIRS.skillsStaging, slug);
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** UTC `YYYY-MM-DD` — keeps the archive folder human-sortable. */
+function todayStamp(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Every directory the delete will touch must resolve under the
+ *  workspace root — guards against a symlinked ancestor escaping it. */
+function deleteTargets(collection: LoadedCollection, workspaceRoot: string): string[] {
+  return [stagingSkillDir(workspaceRoot, collection.slug), collection.skillDir, collection.dataDir];
+}
+
+function buildRestoreDoc(collection: LoadedCollection): string {
+  const { slug, schema } = collection;
+  return `# Restore "${schema.title}" (collection \`${slug}\`)
+
+This folder is an automatic backup made when the collection was deleted.
+To restore it, follow these steps (the staging path matters — writing the
+skill into \`data/skills/\` lets the skill-bridge hook rebuild the
+\`.claude/skills/\` mirror and re-register the collection; writing
+\`.claude/skills/\` directly would hit the permission gate):
+
+1. Recreate the skill from \`skill/\` into \`data/skills/${slug}/\`
+   (copy \`SKILL.md\`, \`schema.json\`, and any \`templates/\`). The hook
+   mirrors those files into \`.claude/skills/${slug}/\` automatically.
+2. Restore the records from \`records/\` into \`${schema.dataPath}/\`.
+3. Confirm the collection reappears at \`/collections/${slug}\`.
+
+- slug: \`${slug}\`
+- title: ${schema.title}
+- dataPath: \`${schema.dataPath}\`
+`;
+}
+
+/** Copy one skill copy + the records + RESTORE.md into `archiveDir`. */
+async function writeArchive(collection: LoadedCollection, archiveDir: string, workspaceRoot: string): Promise<void> {
+  // Prefer the canonical staging dir; fall back to the active mirror
+  // for a project collection that was created without the bridge.
+  const staging = stagingSkillDir(workspaceRoot, collection.slug);
+  const skillSrc = (await pathExists(staging)) ? staging : collection.skillDir;
+  await cp(skillSrc, path.join(archiveDir, "skill"), { recursive: true });
+  if (await pathExists(collection.dataDir)) {
+    await cp(collection.dataDir, path.join(archiveDir, "records"), { recursive: true });
+  }
+  await writeFile(path.join(archiveDir, "RESTORE.md"), buildRestoreDoc(collection), "utf-8");
+}
+
+/** Remove all three locations. `rm -rf`-style (force) so a missing dir
+ *  is a no-op; the now-empty data parent (`data/<slug>/` after its
+ *  `items/` is gone) is swept too, but only when empty. */
+async function removeLocations(collection: LoadedCollection, workspaceRoot: string): Promise<void> {
+  await rm(stagingSkillDir(workspaceRoot, collection.slug), { recursive: true, force: true });
+  await rm(collection.skillDir, { recursive: true, force: true });
+  await rm(collection.dataDir, { recursive: true, force: true });
+  await rmdir(path.dirname(collection.dataDir)).catch(() => undefined);
+}
+
+export async function deleteCollection(collection: LoadedCollection, opts: DeleteCollectionOptions = {}): Promise<DeleteCollectionResult> {
+  const { slug } = collection;
+  const workspaceRoot = opts.workspaceRoot ?? workspacePath;
+  if (collection.source === "user") return { kind: "user-scope", slug };
+  if (isPresetSlug(slug)) return { kind: "preset", slug };
+  if (deleteTargets(collection, workspaceRoot).some((target) => !isContainedInRoot(target, workspaceRoot))) {
+    log.warn("collections", "deleteCollection refused: a target escapes the workspace", { slug });
+    return { kind: "path-escape", slug };
+  }
+  const archiveRel = path.join(WORKSPACE_DIRS.archive, `${opts.dateStamp ?? todayStamp()}-${randomUUID()}`);
+  const archiveDir = path.join(workspaceRoot, archiveRel);
+  await mkdir(archiveDir, { recursive: true });
+  await writeArchive(collection, archiveDir, workspaceRoot);
+  await removeLocations(collection, workspaceRoot);
+  log.info("collections", "collection deleted + archived", { slug, archive: archiveRel });
+  return { kind: "ok", slug, archivePath: archiveRel };
+}

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -1,5 +1,5 @@
 export { discoverCollections, loadCollection, toSummary, toDetail, type LoadedCollection } from "./discovery.js";
-export { deleteCollection, type DeleteCollectionResult } from "./delete.js";
+export { deleteCollection, deleteCollectionRefusalMessage, type DeleteCollectionResult } from "./delete.js";
 export {
   listItems,
   readItem,

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -1,4 +1,5 @@
 export { discoverCollections, loadCollection, toSummary, toDetail, type LoadedCollection } from "./discovery.js";
+export { deleteCollection, type DeleteCollectionResult } from "./delete.js";
 export {
   listItems,
   readItem,

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -180,6 +180,18 @@ const HOST_WORKSPACE_DIRS = {
   // split keeps unused skills out of the system prompt.
   skillsCatalog: "data/skills/catalog",
   skillsCatalogPreset: "data/skills/catalog/preset",
+  // Staging root for runtime-authored skills / collections. Claude
+  // writes `data/skills/<slug>/{SKILL.md,schema.json,templates/*}` here
+  // (an ungated data dir) and the skill-bridge hook mirrors the
+  // allowlisted files into `claudeSkills`. This is the *canonical*
+  // copy — the `.claude/skills/` entry is a mirror — so a
+  // collection-delete archives from here and removes it last.
+  skillsStaging: "data/skills",
+  // Restorable backups written before a destructive delete. A
+  // collection-delete drops `archive/<date>-<uuid>/` holding one skill
+  // copy + the records + an LLM-readable RESTORE.md (see
+  // docs/collections-architecture.md "Deleting a collection").
+  archive: "archive",
   // Nested subdirs inside a top-level grouping. Kept here (rather
   // than module-local constants) when multiple modules need to
   // reference the same nested path — e.g. wiki/pages/ is used by

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -47,6 +47,18 @@
         <span class="material-icons text-sm">add</span>
         <span>{{ t("common.add") }}</span>
       </button>
+
+      <button
+        v-if="canDeleteCollection && !embedded"
+        type="button"
+        class="h-8 w-8 flex items-center justify-center rounded border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 transition-colors"
+        :title="t('collectionsView.deleteCollection')"
+        :aria-label="t('collectionsView.deleteCollection')"
+        data-testid="collections-delete"
+        @click="confirmCollectionDelete"
+      >
+        <span class="material-icons text-sm">delete_forever</span>
+      </button>
     </header>
 
     <!-- Search Toolbar -->
@@ -1383,6 +1395,16 @@ const canCreate = computed<boolean>(() => {
   return !(isSingleton.value && items.value.length > 0);
 });
 
+// A collection is deletable only when it's project-scope AND not a
+// preset (`mc-*`) — mirrors the server-side rule in
+// `deleteCollection`. User-scope skills are read-only from MulmoClaude;
+// presets re-seed on restart so deleting them is futile.
+const canDeleteCollection = computed<boolean>(() => {
+  const current = collection.value;
+  if (!current) return false;
+  return current.source === "project" && !current.slug.startsWith("mc-");
+});
+
 function inputTypeFor(type: FieldType): string {
   if (type === "email") return "email";
   if (type === "number") return "number";
@@ -2068,6 +2090,30 @@ async function confirmDelete(item: CollectionItem): Promise<void> {
     return;
   }
   await loadCollection(slug);
+}
+
+// Delete the whole collection (skill + records), not just one item.
+// The server archives a restorable copy first; on success we leave the
+// now-gone collection's route for the index.
+async function confirmCollectionDelete(): Promise<void> {
+  const current = collection.value;
+  if (!current) return;
+  // Snapshot before the await — the confirm dialog yields control and
+  // the route could change underneath us (see confirmDelete).
+  const { slug, title } = current;
+  const ok = await openConfirm({
+    message: t("collectionsView.confirmDeleteCollection", { title }),
+    confirmText: t("common.remove"),
+    cancelText: t("common.cancel"),
+    variant: "danger",
+  });
+  if (!ok) return;
+  const result = await apiDelete(detailUrl(slug));
+  if (!result.ok) {
+    loadError.value = result.error;
+    return;
+  }
+  router.push({ name: PAGE_ROUTES.collections, params: {} }).catch(() => {});
 }
 
 function goBack(): void {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1363,6 +1363,8 @@ const deMessages = {
     editItem: "Bearbeiten",
     openItem: "{id} öffnen",
     confirmDelete: "Diesen Eintrag löschen? Das kann nicht rückgängig gemacht werden.",
+    deleteCollection: "Sammlung löschen",
+    confirmDeleteCollection: "Die gesamte Sammlung „{title}“ einschließlich aller Datensätze löschen? Zuvor wird eine wiederherstellbare Sicherung archiviert.",
     itemsEmpty: "Noch keine Einträge. Klicke auf +, um einen hinzuzufügen.",
     notFound: "Sammlung nicht gefunden",
     loadFailed: "Laden fehlgeschlagen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1344,6 +1344,8 @@ const enMessages = {
     editItem: "Edit",
     openItem: "Open {id}",
     confirmDelete: "Delete this item? This cannot be undone.",
+    deleteCollection: "Delete collection",
+    confirmDeleteCollection: 'Delete the entire "{title}" collection, including all its records? A restorable backup is archived first.',
     itemsEmpty: "No items yet. Click + to add one.",
     notFound: "Collection not found",
     loadFailed: "Failed to load",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1358,6 +1358,8 @@ const esMessages = {
     editItem: "Editar",
     openItem: "Abrir {id}",
     confirmDelete: "¿Eliminar este elemento? Esta acción no se puede deshacer.",
+    deleteCollection: "Eliminar colección",
+    confirmDeleteCollection: '¿Eliminar toda la colección "{title}", incluidos todos sus registros? Antes se archiva una copia de seguridad restaurable.',
     itemsEmpty: "Aún no hay elementos. Pulsa + para añadir uno.",
     notFound: "Colección no encontrada",
     loadFailed: "Error al cargar",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1352,6 +1352,9 @@ const frMessages = {
     editItem: "Modifier",
     openItem: "Ouvrir {id}",
     confirmDelete: "Supprimer cet élément ? Cette action est irréversible.",
+    deleteCollection: "Supprimer la collection",
+    confirmDeleteCollection:
+      "Supprimer toute la collection « {title} », y compris tous ses enregistrements ? Une sauvegarde restaurable est archivée au préalable.",
     itemsEmpty: "Aucun élément pour l'instant. Cliquez sur + pour en ajouter un.",
     notFound: "Collection introuvable",
     loadFailed: "Échec du chargement",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1341,6 +1341,8 @@ const jaMessages = {
     editItem: "編集",
     openItem: "{id} を開く",
     confirmDelete: "この項目を削除しますか？元に戻せません。",
+    deleteCollection: "コレクションを削除",
+    confirmDeleteCollection: "コレクション「{title}」とそのすべてのレコードを削除しますか？削除前に復元可能なバックアップが保存されます。",
     itemsEmpty: "まだ項目がありません。+ を押して追加してください。",
     notFound: "コレクションが見つかりません",
     loadFailed: "読み込みに失敗しました",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1344,6 +1344,8 @@ const koMessages = {
     editItem: "편집",
     openItem: "{id} 열기",
     confirmDelete: "이 항목을 삭제하시겠습니까? 되돌릴 수 없습니다.",
+    deleteCollection: "컬렉션 삭제",
+    confirmDeleteCollection: '"{title}" 컬렉션과 모든 레코드를 삭제하시겠습니까? 삭제 전에 복원 가능한 백업이 보관됩니다.',
     itemsEmpty: "아직 항목이 없습니다. + 를 눌러 추가하세요.",
     notFound: "컬렉션을 찾을 수 없습니다",
     loadFailed: "불러오기에 실패했습니다",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1347,6 +1347,8 @@ const ptBRMessages = {
     editItem: "Editar",
     openItem: "Abrir {id}",
     confirmDelete: "Excluir este item? Esta ação não pode ser desfeita.",
+    deleteCollection: "Excluir coleção",
+    confirmDeleteCollection: 'Excluir toda a coleção "{title}", incluindo todos os seus registros? Um backup restaurável é arquivado antes.',
     itemsEmpty: "Ainda não há itens. Clique em + para adicionar um.",
     notFound: "Coleção não encontrada",
     loadFailed: "Falha ao carregar",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1334,6 +1334,8 @@ const zhMessages = {
     editItem: "编辑",
     openItem: "打开 {id}",
     confirmDelete: "删除此项？此操作无法撤销。",
+    deleteCollection: "删除集合",
+    confirmDeleteCollection: "删除整个“{title}”集合及其所有记录？删除前会先归档一份可恢复的备份。",
     itemsEmpty: "暂无项目。点击 + 添加一个。",
     notFound: "未找到集合",
     loadFailed: "加载失败",

--- a/test/workspace/collections/test_delete.ts
+++ b/test/workspace/collections/test_delete.ts
@@ -88,12 +88,18 @@ describe("deleteCollection", () => {
     assert.equal(existsSync(path.join(workdir, ".claude", "skills", "mc-invoice")), true, "mirror must survive a refused delete");
   });
 
-  it("refuses a dataPath outside the per-collection subtree and deletes nothing", async () => {
+  it("refuses a dataDir outside the per-collection subtree and deletes nothing", async () => {
     // A hostile/malformed schema points dataPath at the shared `data`
-    // root; a recursive delete there would wipe every collection. The
-    // guard must refuse BEFORE any archive/removal runs.
+    // root, so loadCollection would resolve dataDir to <workdir>/data; a
+    // recursive delete there would wipe every collection. The guard
+    // validates the RESOLVED dataDir (not the schema string) and must
+    // refuse BEFORE any archive/removal runs.
     const collection = seedCollection("restaurants", "project");
-    const hostile: LoadedCollection = { ...collection, schema: { ...collection.schema, dataPath: "data" } };
+    const hostile: LoadedCollection = {
+      ...collection,
+      schema: { ...collection.schema, dataPath: "data" },
+      dataDir: path.join(workdir, "data"),
+    };
     const result = await deleteCollection(hostile, { workspaceRoot: workdir });
     assert.equal(result.kind, "unsafe-data-path");
     assert.equal(existsSync(path.join(workdir, "data", "skills", "restaurants")), true, "staging must survive");

--- a/test/workspace/collections/test_delete.ts
+++ b/test/workspace/collections/test_delete.ts
@@ -87,4 +87,18 @@ describe("deleteCollection", () => {
     assert.equal(result.kind, "preset");
     assert.equal(existsSync(path.join(workdir, ".claude", "skills", "mc-invoice")), true, "mirror must survive a refused delete");
   });
+
+  it("refuses a dataPath outside the per-collection subtree and deletes nothing", async () => {
+    // A hostile/malformed schema points dataPath at the shared `data`
+    // root; a recursive delete there would wipe every collection. The
+    // guard must refuse BEFORE any archive/removal runs.
+    const collection = seedCollection("restaurants", "project");
+    const hostile: LoadedCollection = { ...collection, schema: { ...collection.schema, dataPath: "data" } };
+    const result = await deleteCollection(hostile, { workspaceRoot: workdir });
+    assert.equal(result.kind, "unsafe-data-path");
+    assert.equal(existsSync(path.join(workdir, "data", "skills", "restaurants")), true, "staging must survive");
+    assert.equal(existsSync(path.join(workdir, ".claude", "skills", "restaurants")), true, "mirror must survive");
+    assert.equal(existsSync(path.join(workdir, "data", "restaurants", "items")), true, "records must survive");
+    assert.equal(existsSync(path.join(workdir, "archive")), false, "no archive should be written on refusal");
+  });
 });

--- a/test/workspace/collections/test_delete.ts
+++ b/test/workspace/collections/test_delete.ts
@@ -1,0 +1,90 @@
+// deleteCollection — archives a restorable copy, then removes all three
+// on-disk locations (staging skill, active mirror, records). Also pins
+// the scope guards: user-scope and preset (`mc-*`) collections refuse.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { deleteCollection } from "../../../server/workspace/collections/delete.js";
+import type { LoadedCollection } from "../../../server/workspace/collections/discovery.js";
+import type { CollectionSchema, CollectionSource } from "../../../server/workspace/collections/types.js";
+
+let workdir: string;
+
+function schemaFor(slug: string): CollectionSchema {
+  return {
+    title: "Restaurants",
+    icon: "restaurant",
+    dataPath: `data/${slug}/items`,
+    primaryKey: "id",
+    fields: { id: { type: "string", label: "ID", primary: true } },
+  };
+}
+
+/** Lay down the three on-disk locations for `slug` and return the
+ *  LoadedCollection a discovery pass would have produced. */
+function seedCollection(slug: string, source: CollectionSource): LoadedCollection {
+  const schema = schemaFor(slug);
+  const stagingDir = path.join(workdir, "data", "skills", slug);
+  const skillDir = path.join(workdir, ".claude", "skills", slug);
+  const dataDir = path.join(workdir, "data", slug, "items");
+  for (const dir of [stagingDir, skillDir, dataDir]) mkdirSync(dir, { recursive: true });
+  for (const dir of [stagingDir, skillDir]) {
+    writeFileSync(path.join(dir, "schema.json"), JSON.stringify(schema));
+    writeFileSync(path.join(dir, "SKILL.md"), `# ${slug}`);
+  }
+  writeFileSync(path.join(dataDir, "acme.json"), JSON.stringify({ id: "acme" }));
+  writeFileSync(path.join(dataDir, "globex.json"), JSON.stringify({ id: "globex" }));
+  return { slug, source, schema, dataDir, skillDir };
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "collections-delete-"));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+});
+
+describe("deleteCollection", () => {
+  it("archives a copy and removes all three locations", async () => {
+    const collection = seedCollection("restaurants", "project");
+    const result = await deleteCollection(collection, { workspaceRoot: workdir, dateStamp: "2026-05-31" });
+
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.ok(result.archivePath.startsWith(path.join("archive", "2026-05-31-")), `unexpected archivePath: ${result.archivePath}`);
+
+    // All three sources are gone.
+    assert.equal(existsSync(path.join(workdir, "data", "skills", "restaurants")), false, "staging skill remains");
+    assert.equal(existsSync(path.join(workdir, ".claude", "skills", "restaurants")), false, "active mirror remains");
+    assert.equal(existsSync(path.join(workdir, "data", "restaurants")), false, "records (and empty parent) remain");
+
+    // The backup holds one skill copy, the records, and RESTORE.md.
+    const archiveDir = path.join(workdir, result.archivePath);
+    assert.ok(existsSync(path.join(archiveDir, "skill", "schema.json")), "archived schema.json missing");
+    assert.ok(existsSync(path.join(archiveDir, "skill", "SKILL.md")), "archived SKILL.md missing");
+    assert.ok(existsSync(path.join(archiveDir, "records", "acme.json")), "archived record missing");
+    assert.ok(existsSync(path.join(archiveDir, "records", "globex.json")), "archived record missing");
+    const restore = readFileSync(path.join(archiveDir, "RESTORE.md"), "utf-8");
+    assert.match(restore, /restaurants/);
+    assert.match(restore, /data\/restaurants\/items/);
+  });
+
+  it("refuses a user-scope collection (read-only) and leaves it intact", async () => {
+    const collection = seedCollection("restaurants", "user");
+    const result = await deleteCollection(collection, { workspaceRoot: workdir });
+    assert.equal(result.kind, "user-scope");
+    assert.equal(existsSync(path.join(workdir, "data", "skills", "restaurants")), true, "staging must survive a refused delete");
+  });
+
+  it("refuses a preset (mc-*) collection and leaves it intact", async () => {
+    const collection = seedCollection("mc-invoice", "project");
+    const result = await deleteCollection(collection, { workspaceRoot: workdir });
+    assert.equal(result.kind, "preset");
+    assert.equal(existsSync(path.join(workdir, ".claude", "skills", "mc-invoice")), true, "mirror must survive a refused delete");
+  });
+});

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -36,6 +36,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
   const expectedKeys = [
     "accounting",
     "accountingBooks",
+    "archive",
     "attachments",
     "calendar",
     "charts",
@@ -66,6 +67,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "searches",
     "skillsCatalog",
     "skillsCatalogPreset",
+    "skillsStaging",
     "sources",
     "spreadsheets",
     "stories",


### PR DESCRIPTION
## What

Adds the ability to **delete a user-authored collection** — something that wasn't possible before — with a restorable backup written first.

A collection is a skill directory that ships a `schema.json`, so a user-authored one spans **three** on-disk locations, not one:

1. `data/skills/<slug>/` — staging (the canonical skill source)
2. `.claude/skills/<slug>/` — active mirror (what discovery scans), maintained by the skill-bridge hook
3. `<schema.dataPath>/` — the records

Deleting the collection removes all three. Because the skill-bridge hook only mirrors on the agent's own tool calls, a server-side delete removes both the staging dir and the active mirror explicitly.

## Archive on delete

Before anything is removed, a full restorable copy is written to `archive/<date>-<uuid>/`:

```
archive/<date>-<uuid>/
  RESTORE.md   ← LLM-runnable restore instructions (slug, dataPath, steps)
  skill/       ← one skill copy (schema.json + SKILL.md + templates/*)
  records/     ← the collection's <id>.json records
```

Only **one** skill copy is stored (the `.claude/skills/` entry is just a mirror of staging). `RESTORE.md` tells the LLM to recreate the skill files with the **Write tool** (which re-fires the bridge → rebuilds the `.claude/skills/` mirror → re-registers the collection) and to **`cp`** the records — the Write rule is scoped to the skill files only. This split was validated end-to-end on a real restore.

## Scope guards

- **User-scope** collections (`~/.claude/skills/`) refuse — read-only from MulmoClaude.
- **Preset** (`mc-*`) collections refuse — they re-seed on boot, so deleting is futile.
- Realpath containment guard on every delete target before touching disk.

## Surface

- `DELETE /api/collections/:slug` (`server/api/routes/collections.ts`)
- `server/workspace/collections/delete.ts` — archive + remove-all-three
- `CollectionView.vue` — a rose delete-collection button (project-scope, non-preset, non-embedded) → danger confirm → navigate to index
- i18n `deleteCollection` + `confirmDeleteCollection` across **all 8 locales**

## Tests

- `test/workspace/collections/test_delete.ts` — archive-and-remove-all-three, user-scope refusal, preset refusal
- `test_paths_shape.ts` — registers the two new workspace dirs (`skillsStaging`, `archive`)
- Full suite green (5296 pass); `yarn format`/`lint`/`typecheck`/`build` clean.

## Docs

`docs/collections-architecture.md` gains a "Deleting a collection" section documenting the three locations, the source→mirror bridge, the archive layout, and the restore procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete whole-collection API and UI action that archives a restorable backup.

* **Safety / Behavior**
  * Stronger delete guards with clearer refusal reasons (preset, user-scope, unsafe-data-path).

* **Documentation**
  * Expanded docs describing deletion, archiving, and restore procedures.

* **Internationalization**
  * Added delete-related UI strings in 8 languages.

* **Tests**
  * Tests for successful deletes, refusals, archiving, and unsafe-data-path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->