### PR TITLE
vite: honor MULMOCLAUDE_WORKSPACE_PATH in dev token plugin

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,26 @@ import path from 'node:path'
 
 // Token file path mirrors `WORKSPACE_PATHS.sessionToken` in
 // server/workspace-paths.ts. Duplicated here (rather than imported)
-// because Vite config runs outside the TS server tsconfig; keep in
-// sync when either side moves the workspace root.
-const TOKEN_FILE_PATH = path.join(os.homedir(), 'mulmoclaude', '.session-token')
+// because Vite config runs outside the TS server tsconfig.
+//
+// Honors MULMOCLAUDE_WORKSPACE_PATH (via process.env or directly
+// parsing .env file) so the dev token plugin reads the same workspace
+// the server is using. Local patch 2026-05-30 to fix the unauthorized
+// error when workspace is relocated.
+function resolveWorkspacePath(): string {
+  const fromProcess = process.env.MULMOCLAUDE_WORKSPACE_PATH
+  if (fromProcess && fromProcess.length > 0) return fromProcess
+  try {
+    const envPath = path.join(process.cwd(), '.env')
+    const content = fs.readFileSync(envPath, 'utf-8')
+    const match = content.match(/^MULMOCLAUDE_WORKSPACE_PATH=(.+)$/m)
+    if (match) return match[1].trim()
+  } catch {
+    /* .env not present, fall through to default */
+  }
+  return path.join(os.homedir(), 'mulmoclaude')
+}
+const TOKEN_FILE_PATH = path.join(resolveWorkspacePath(), '.session-token')
 const TOKEN_PLACEHOLDER = '__MULMOCLAUDE_AUTH_TOKEN__'
 
 // Dev-side half of the bearer-token injection (#272). The server


### PR DESCRIPTION
## Problem

`vite.config.ts` reads the dev-time bearer token from a hardcoded
`~/mulmoclaude/.session-token` path. The server side (`server/workspace/paths.ts:89`) already honors the
`MULMOCLAUDE_WORKSPACE_PATH` env var for the same file, but the Vite plugin
does not — so when a user relocates the workspace, every API call from
the client 401s because the bearer token meta tag stays empty.

I tripped over this trying to keep MulmoClaude's workspace inside my main
`~/workspace/` tree rather than at `~/mulmoclaude/`. Server logs were
clean (`[auth] bearer token written path=...`), but the browser kept
showing \`unauthorized\` everywhere.

## Fix

Add a tiny resolver, \`resolveWorkspacePath()\`, that mirrors the server's
lookup order:

1. \`process.env.MULMOCLAUDE_WORKSPACE_PATH\` (set in the shell)
2. Parse the same key out of the project-root \`.env\` — Vite loads
   \`.env\` per-mode, but only inside the \`defineConfig\` callback;
   \`TOKEN_FILE_PATH\` lives at module-top so we read \`.env\` manually.
3. Default to \`~/mulmoclaude\` — unchanged behaviour.

No change for users who don't override the workspace location. No
runtime cost beyond a one-time file read at server startup.

## Test plan

- [ ] With \`MULMOCLAUDE_WORKSPACE_PATH\` unset, dev server keeps working
      against \`~/mulmoclaude/.session-token\` (existing behaviour).
- [ ] With \`MULMOCLAUDE_WORKSPACE_PATH=/some/other/path\` set in shell,
      the meta tag now contains the token from
      \`/some/other/path/.session-token\`.
- [ ] With \`MULMOCLAUDE_WORKSPACE_PATH=/some/other/path\` only in \`.env\`
      (no shell export), same result.

## Related

- Server lookup: \`server/workspace/paths.ts:89\` already does this dance.
- Comment at the top of \`vite.config.ts\` notes this duplication
  ("Duplicated here … keep in sync when either side moves the workspace
  root") — this PR keeps the two halves in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration flexibility by dynamically resolving the workspace directory path. The system now supports environment variables and `.env` file configuration in addition to default settings, enabling better customization of the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->