### PR TITLE
windows: spawn the real claude.exe instead of claude.cmd

### DIFF
--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -12,6 +12,7 @@
 import { spawn, type ChildProcessByStdio } from "child_process";
 import type { Readable, Writable } from "stream";
 import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine } from "../config.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
@@ -29,7 +30,12 @@ function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[
     // PostToolUse hook needs to publish a `page-edit` toolResult back to
     // the right session (#963). Claude CLI's own hook payload carries
     // its internal session_id, which doesn't match our session store.
-    return spawn("claude", cliArgs, {
+    //
+    // Windows: see `server/utils/claudeBin.ts` — the npm `.cmd`
+    // wrapper trips Node's CVE-2024-27980 guard, and `shell: true`
+    // would hit cmd.exe's 8191-char limit. Path the real `.exe`
+    // directly (helper handles platform branching).
+    return spawn(claudeBinPath(), cliArgs, {
       cwd: workspacePath,
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, MULMOCLAUDE_CHAT_SESSION_ID: chatSessionId },

--- a/server/services/translation/llm.ts
+++ b/server/services/translation/llm.ts
@@ -12,6 +12,7 @@ import { errorMessage } from "../../utils/errors.js";
 import { formatSpawnFailure } from "../../utils/spawn.js";
 import { isRecord } from "../../utils/types.js";
 import { ClaudeCliNotFoundError } from "../../workspace/journal/archivist-cli.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 import type { TranslateBatchFn } from "./types.js";
 
 const SYSTEM_PROMPT =
@@ -119,7 +120,7 @@ function spawnClaudeTranslate(promptInput: string, timeoutMs: number): Promise<s
   return new Promise<string>((resolve, reject) => {
     // Run from tmpdir so claude does not load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", buildArgs(promptInput), { cwd: tmpdir(), stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn(claudeBinPath(), buildArgs(promptInput), { cwd: tmpdir(), stdio: ["ignore", "pipe", "pipe"] });
     const state: SpawnState = { stdout: "", stderr: "", settled: false };
     const timer = setTimeout(() => onTimeout(state, proc, reject, timeoutMs), timeoutMs);
     proc.stdout.on("data", (chunk: Buffer) => {

--- a/server/utils/claudeBin.ts
+++ b/server/utils/claudeBin.ts
@@ -1,0 +1,35 @@
+// Cross-platform resolver for the Claude Code CLI executable.
+//
+// Background (Windows-specific): the npm global install of
+// `@anthropic-ai/claude-code` ships:
+//   - `claude.cmd` on PATH (Windows batch wrapper)
+//   - `claude.exe` at `<npm-root>/node_modules/@anthropic-ai/claude-code/bin/`
+//     (the real native binary)
+//
+// Node's `child_process.spawn` on Windows:
+//   - cannot resolve `.cmd` since CVE-2024-27980 unless `shell: true`
+//   - `shell: true` wraps via cmd.exe, which has an 8191-char command
+//     line limit — MulmoClaude's MCP-config + system-prompt args
+//     exceed it
+//
+// The cleanest fix is to point spawn directly at the bundled .exe.
+// On non-Windows platforms, bare "claude" resolves through PATH as
+// usual.
+//
+// Local patch 2026-05-30 / 2026-06-01 (extended to all spawn sites).
+// Suitable as the base of an upstream PR to receptron/mulmoclaude.
+
+import path from "node:path";
+
+export function claudeBinPath(): string {
+  if (process.platform !== "win32") return "claude";
+  return path.join(
+    process.env.APPDATA ?? "",
+    "npm",
+    "node_modules",
+    "@anthropic-ai",
+    "claude-code",
+    "bin",
+    "claude.exe",
+  );
+}

--- a/server/utils/claudeBin.ts
+++ b/server/utils/claudeBin.ts
@@ -3,33 +3,99 @@
 // Background (Windows-specific): the npm global install of
 // `@anthropic-ai/claude-code` ships:
 //   - `claude.cmd` on PATH (Windows batch wrapper)
-//   - `claude.exe` at `<npm-root>/node_modules/@anthropic-ai/claude-code/bin/`
-//     (the real native binary)
+//   - `claude.exe` under the global `node_modules` tree (real native
+//     binary the .cmd wrapper delegates to)
 //
 // Node's `child_process.spawn` on Windows:
 //   - cannot resolve `.cmd` since CVE-2024-27980 unless `shell: true`
 //   - `shell: true` wraps via cmd.exe, which has an 8191-char command
-//     line limit — MulmoClaude's MCP-config + system-prompt args
-//     exceed it
+//     line limit that MulmoClaude's MCP-config + system-prompt args
+//     comfortably exceed in normal operation
 //
-// The cleanest fix is to point spawn directly at the bundled .exe.
+// The cleanest fix is to point spawn directly at the bundled `.exe`.
+// We probe a small set of candidate npm-global prefixes and verify
+// the file exists before returning. If no candidate matches we
+// fall back to bare "claude" — spawn() will then attempt PATH
+// resolution and surface the original failure honestly rather than
+// masking it behind a constructed-but-nonexistent path.
+//
 // On non-Windows platforms, bare "claude" resolves through PATH as
 // usual.
 //
-// Local patch 2026-05-30 / 2026-06-01 (extended to all spawn sites).
-// Suitable as the base of an upstream PR to receptron/mulmoclaude.
+// The result is memoised so the existsSync probe (and the
+// `npm prefix -g` shell-out below) runs at most once per process.
 
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
+const CLAUDE_EXE_REL = path.join(
+  "node_modules",
+  "@anthropic-ai",
+  "claude-code",
+  "bin",
+  "claude.exe",
+);
+
+let memoised: string | null = null;
+
 export function claudeBinPath(): string {
+  if (memoised !== null) return memoised;
+  memoised = resolveClaudeBinPath();
+  return memoised;
+}
+
+function resolveClaudeBinPath(): string {
   if (process.platform !== "win32") return "claude";
-  return path.join(
-    process.env.APPDATA ?? "",
-    "npm",
-    "node_modules",
-    "@anthropic-ai",
-    "claude-code",
-    "bin",
-    "claude.exe",
-  );
+
+  const candidates: string[] = [];
+
+  // 1. Default npm prefix on Windows: %APPDATA%\npm.
+  if (process.env.APPDATA) {
+    candidates.push(path.join(process.env.APPDATA, "npm", CLAUDE_EXE_REL));
+  }
+
+  // 2. Same shape under %LOCALAPPDATA% — some installers default here.
+  if (process.env.LOCALAPPDATA) {
+    candidates.push(path.join(process.env.LOCALAPPDATA, "npm", CLAUDE_EXE_REL));
+  }
+
+  // 3. Whatever `npm prefix -g` reports. Covers nvm-windows and
+  //    similar setups that move the prefix outside the AppData dirs.
+  const npmPrefix = readNpmGlobalPrefix();
+  if (npmPrefix) {
+    candidates.push(path.join(npmPrefix, CLAUDE_EXE_REL));
+  }
+
+  for (const candidate of candidates) {
+    if (path.isAbsolute(candidate) && existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // No prebuilt `.exe` found. Fall back to bare "claude" — spawn()
+  // will then attempt PATH resolution. On a typical Windows install
+  // this surfaces as ENOENT (Node looks for an extensionless binary)
+  // or EINVAL (PATH-resolution lands on `claude.cmd`), which is the
+  // original failure mode — honestly surfaced rather than masked
+  // behind a constructed-but-nonexistent absolute path.
+  return "claude";
+}
+
+function readNpmGlobalPrefix(): string | null {
+  try {
+    // Sync subprocess: runs at most once per process due to the
+    // memoisation in claudeBinPath().
+    const out = execSync("npm prefix -g", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    });
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    // npm not on PATH, or timed out, or non-zero exit. The other
+    // candidate paths still cover the default install layout.
+    return null;
+  }
 }

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -18,6 +18,7 @@ import { readFile } from "node:fs/promises";
 import { formatSpawnFailure } from "../../utils/spawn.js";
 import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 import { errorMessage } from "../../utils/errors.js";
 import type { SummaryResult } from "./types.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";
@@ -195,7 +196,7 @@ function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string>
     ];
     // Run from tmpdir so claude does not load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", args, {
+    const proc = spawn(claudeBinPath(), args, {
       cwd: tmpdir(),
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -2,6 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 
 export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
 
@@ -29,7 +30,7 @@ export class ClaudeCliFailedError extends Error {
 // Pipe the combined prompt via stdin to dodge shell-argv limits for large day excerpts.
 export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) =>
   new Promise((resolve, reject) => {
-    const child = spawn("claude", ["-p", "--output-format", "text"], {
+    const child = spawn(claudeBinPath(), ["-p", "--output-format", "text"], {
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/server/workspace/sources/classifier.ts
+++ b/server/workspace/sources/classifier.ts
@@ -20,6 +20,7 @@
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 import { formatSpawnFailure } from "../../utils/spawn.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";
 import { CATEGORY_SLUGS, normalizeCategories, type CategorySlug } from "./taxonomy.js";
@@ -204,7 +205,7 @@ function spawnClaudeClassify(userPrompt: string, timeoutMs: number): Promise<str
     ];
     // Run from tmpdir so claude doesn't load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", args, {
+    const proc = spawn(claudeBinPath(), args, {
       cwd: tmpdir(),
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/server/workspace/sources/pipeline/summarize.ts
+++ b/server/workspace/sources/pipeline/summarize.ts
@@ -13,6 +13,7 @@
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { ClaudeCliNotFoundError } from "../../journal/archivist-cli.js";
+import { claudeBinPath } from "../../../utils/claudeBin.js";
 import { formatSpawnFailure } from "../../../utils/spawn.js";
 import { errorMessage } from "../../../utils/errors.js";
 import type { SourceItem } from "../types.js";
@@ -131,7 +132,7 @@ function spawnClaudeSummarize(userPrompt: string, timeoutMs: number): Promise<st
       "-p",
       userPrompt,
     ];
-    const proc = spawn("claude", args, {
+    const proc = spawn(claudeBinPath(), args, {
       cwd: tmpdir(),
       stdio: ["ignore", "pipe", "pipe"],
     });


### PR DESCRIPTION
## Problem

On Windows, the npm global install of \`@anthropic-ai/claude-code\` ships:

- \`claude.cmd\` on PATH (Windows batch wrapper)
- \`claude.exe\` at \`<npm-root>/node_modules/@anthropic-ai/claude-code/bin/claude.exe\` (real native binary)

Node's \`child_process.spawn\` on Windows:

- cannot resolve \`.cmd\` since CVE-2024-27980 unless \`shell: true\`
- \`shell: true\` wraps via cmd.exe, which has an 8191-char command
  line limit that MulmoClaude's MCP-config + system-prompt args
  comfortably exceed in normal operation

Result: \`spawn(\"claude\", ...)\` on Windows fails one of three ways depending on what you try:

| Approach | Failure |
|---|---|
| \`spawn(\"claude\", args)\` (status quo) | \`ENOENT\` — Node looks for an extensionless executable |
| \`spawn(\"claude.cmd\", args)\` | \`EINVAL\` — CVE-2024-27980 hardening rejects \`.cmd\` |
| \`spawn(\"claude\", args, { shell: true })\` | \`コマンド ラインが長すぎます\` / \`The command line is too long\` once MCP args are realistic |

I hit all three in sequence trying to get a fresh Windows install of MulmoClaude working. Chat, journal (\`[journal] running daily pass\` followed by \`claude CLI is not available on PATH\`), summarizer, classifier, and source-pipeline summarize are all affected today.

## Fix

Introduce a small cross-platform resolver, \`claudeBinPath()\` in \`server/utils/claudeBin.ts\`, that returns the bundled \`claude.exe\` path on Windows (\`%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe\`) and bare \`\"claude\"\` everywhere else. Replace the literal string at all six spawn sites:

- \`server/agent/backend/claude-code.ts\` (the chat backend)
- \`server/services/translation/llm.ts\`
- \`server/workspace/chat-index/summarizer.ts\`
- \`server/workspace/journal/archivist-cli.ts\`
- \`server/workspace/sources/classifier.ts\`
- \`server/workspace/sources/pipeline/summarize.ts\`

\`pty.spawn(\"claude\", …)\` in \`server/system/credentials.ts\` is left alone — that goes through node-pty and the failure mode is different; happy to extend the helper to that site too if the maintainers prefer.

## Test plan

- [ ] Linux / macOS: \`claudeBinPath()\` returns \`\"claude\"\`, all six call sites behave identically to main.
- [ ] Windows with \`@anthropic-ai/claude-code\` installed globally via npm:
  - [ ] Browser chat at \`/chat\` returns a response (was returning \`spawn EINVAL\` or similar).
  - [ ] \`[journal] daily pass done\` instead of \`[journal] claude CLI is not available on PATH\`.
  - [ ] \`/sources\` summarizer / classifier work on a real feed.

## Notes

- I kept the helper's path lookup deliberately simple (anchored on \`%APPDATA%\npm\`) since that's where npm installs global packages on default Windows setups. If maintainers want a more robust lookup (e.g. \`npm root -g\` shelling out), happy to extend.
- This is the second of a small two-PR series. See also #1570 (the dev-side bearer-token plugin needs a similar honor-the-env-var fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude CLI executable resolution for enhanced cross-platform compatibility and reliability, ensuring the CLI can be properly located on Windows and other systems when installed via npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->