### PR TITLE
ci: move Windows lint_test to a scheduled workflow (#1585)

### DIFF
--- a/.github/workflows/lint_test_windows.yaml
+++ b/.github/workflows/lint_test_windows.yaml
@@ -1,0 +1,101 @@
+name: lint_test (Windows)
+
+# The Windows half of the lint_test matrix, split out of pull_request.yaml
+# in #1585 so PR CI doesn't pay the Windows wall-clock cost (NTFS tar
+# extraction + Defender + slower tsc across the 25 packages/* workspaces)
+# on every push.
+#
+# Coverage cadence:
+#   - schedule: daily, so a Windows-only regression surfaces within a day
+#   - push to main: catches regressions immediately after merge
+#   - workflow_dispatch: manual rerun
+#
+# Steps mirror the lint_test job in pull_request.yaml (ubuntu/macos
+# variant). Keep them in sync when adding new gates.
+
+on:
+  schedule:
+    - cron: "0 18 * * *" # Daily 18:00 UTC = 03:00 JST (matches e2e_live_no_llm)
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'plans/**'
+      - '**/*.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-test-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint_test_windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false  # no git push; zizmor artipacked
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          # Skip setup-node's built-in yarn cache on Windows — tar
+          # extraction on NTFS is slower than a fresh install. We use
+          # actions/cache for node_modules instead (below).
+      # Disable Defender realtime monitoring to prevent EPERM on
+      # atomic rename during yarn install / build.
+      - name: Disable Windows Defender realtime monitoring
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: powershell
+      # Cache node_modules directly (faster than yarn cache because it
+      # skips the tar extract → yarn install file-write cycle).
+      # restore-keys lets a yarn.lock change land on a warm node_modules
+      # tree (yarn install fills in the diff) instead of a cold cache.
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            win-node-modules-${{ matrix.node-version }}-
+      - run: yarn install --frozen-lockfile --network-timeout 120000
+      # Cache the output of `yarn build:packages` keyed on the source
+      # files it consumes. The 25 @mulmobridge/* workspaces all run tsc
+      # serially / pairwise — the slowest non-install step on Windows.
+      # When no package source / tsconfig / package.json changed, skip
+      # the build step entirely. Cache key includes runner.os and node
+      # version because emitted JS can differ across them.
+      - name: Cache packages/dist
+        id: pkg-dist-cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            packages/*/dist
+            packages/bridges/*/dist
+            packages/plugins/*/dist
+          key: pkg-dist-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'packages/bridges/*/src/**', 'packages/bridges/*/tsconfig.json', 'packages/bridges/*/package.json', 'packages/plugins/*/src/**', 'packages/plugins/*/tsconfig.json', 'packages/plugins/*/package.json', 'config/tsconfig.packages.json') }}
+      - name: Build internal packages (required before typecheck)
+        if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
+        run: yarn build:packages
+      - run: yarn run typecheck
+      - run: yarn run lint
+      # Plugin barrel codegen must be in sync — fail the build if a
+      # developer added a plugin dir without re-running the codegen.
+      - run: yarn run plugins:codegen:check
+      - run: yarn run build
+      # Bundle integrity: `yarn build` regenerates committed esbuild
+      # artifacts. If a developer changed the TS source but forgot to
+      # commit the new bundle, this fails.
+      - name: Verify built hook bundles are up-to-date
+        run: git diff --exit-code -- server/workspace/wiki-history/hook/snapshot.mjs server/build/dispatcher.mjs
+      - run: yarn run test:coverage
+      # Subprocess-mode env-bound smoke for `requireSameOrigin` (#1463).
+      - run: yarn run test:csrf-wiring

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -52,6 +52,10 @@ jobs:
             echo "run_e2e=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # ubuntu + macos lint matrix. Windows runs in a separate scheduled
+  # workflow (`.github/workflows/lint_test_windows.yaml`, #1585) so PR
+  # CI doesn't pay the Windows wall-clock cost on every push — Windows
+  # is covered daily and on every main push instead.
   lint_test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -59,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x, 24.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v6
       with:
@@ -68,33 +72,12 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
-        # Skip setup-node's built-in yarn cache on Windows — tar
-        # extraction on NTFS is slower than a fresh install.
-        # We use actions/cache for node_modules instead.
-        cache: ${{ runner.os == 'Windows' && '' || 'yarn' }}
-    # Windows: disable Defender realtime monitoring to prevent
-    # EPERM on atomic rename (#CI)
-    - name: Disable Windows Defender realtime monitoring
-      if: runner.os == 'Windows'
-      run: Set-MpPreference -DisableRealtimeMonitoring $true
-      shell: powershell
-    # Windows: cache node_modules directly (faster than yarn cache
-    # because it skips the tar extract → yarn install file-write cycle).
-    # restore-keys lets a yarn.lock change land on a warm node_modules
-    # tree (yarn install fills in the diff) instead of a cold cache.
-    - name: Cache node_modules (Windows)
-      if: runner.os == 'Windows'
-      uses: actions/cache@v5
-      with:
-        path: node_modules
-        key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          win-node-modules-${{ matrix.node-version }}-
+        cache: yarn
     - run: yarn install --frozen-lockfile --network-timeout 120000
     # Cache the output of `yarn build:packages` keyed on the source
     # files it consumes. The 25 @mulmobridge/* workspaces all run tsc
-    # serially / pairwise — slowest non-install step on Windows. When
-    # no package source / tsconfig / package.json changed, skip the
+    # serially / pairwise — the slowest non-install step. When no
+    # package source / tsconfig / package.json changed, skip the
     # build step entirely. Cache key includes runner.os and node
     # version because emitted JS can differ across them.
     - name: Cache packages/dist

--- a/plans/ci-windows-lint-to-schedule-1585.md
+++ b/plans/ci-windows-lint-to-schedule-1585.md
@@ -1,0 +1,91 @@
+# Move Windows `lint_test` matrix to a scheduled workflow
+
+Closes #1585.
+
+## Why
+
+`lint_test` runs on every PR push as a 6-cell matrix —
+`[ubuntu-latest, windows-latest, macos-latest] × [node 22.x, 24.x]`.
+The Windows cells are consistently the slowest (~3-5× the ubuntu wall
+clock) because:
+
+- NTFS extraction of the yarn cache and `packages/*/dist` tarballs
+  is slow under tar-on-Windows.
+- Windows Defender realtime monitoring fights `yarn install`'s atomic
+  renames; we disable it per-job, but the disable itself takes time.
+- `tsc` across the 25 `@mulmobridge/*` workspaces serialises tighter
+  on Windows than on Linux/macOS.
+
+Windows-specific regressions are real but rare — usually path
+separators or case-sensitivity bugs. Daily + on-merge coverage is
+plenty; paying the cost on every PR push is not.
+
+## What changes
+
+1. **`.github/workflows/pull_request.yaml`** — drop `windows-latest`
+   from the `lint_test.strategy.matrix.os` list. The matrix becomes
+   `[ubuntu-latest, macos-latest] × [22.x, 24.x]` (4 cells, down
+   from 6). Remove the Windows-only step variants (Defender disable,
+   node_modules cache) that no longer have a Windows cell to gate.
+
+2. **`.github/workflows/lint_test_windows.yaml`** (new) — runs the
+   same step sequence on `windows-latest × [22.x, 24.x]` (2 cells),
+   triggered by:
+
+   - `schedule`: `0 18 * * *` (daily 18:00 UTC = 03:00 JST, matches
+     `e2e_live_no_llm.yaml`'s cadence).
+   - `push: branches: [main]`: catches regressions immediately
+     after a merge so the next PR doesn't inherit a broken main.
+   - `workflow_dispatch`: manual rerun for triage.
+
+   `paths-ignore: docs/**, plans/**, **/*.md` mirrors the PR
+   workflow so doc-only main pushes don't trigger a Windows run.
+
+## Step coverage parity
+
+Both workflows run, in order: install → cache packages/dist →
+build:packages (when cache miss) → typecheck → lint →
+plugins:codegen:check → build → verify bundle integrity →
+test:coverage → test:csrf-wiring.
+
+The Windows-only setup pre-steps (Defender disable, node_modules
+cache, no setup-node yarn cache) move with the matrix into the new
+workflow.
+
+## Trade-offs
+
+- **PR feedback**: saves ~3-5 minutes per push by retiring the
+  Windows cells. e2e (the other long pole) is unchanged.
+- **Regression detection lag**: a Windows-only break introduced
+  by a PR now lands on main and only surfaces on either (a) the
+  post-merge `push` trigger (within ~minutes) or (b) the next
+  scheduled run (within 24h). The post-merge trigger reverts the
+  "wait 24h to find out" worry — if main breaks, the very next
+  scheduled-workflow run on main reports it before the next PR
+  starts CI.
+- **Coverage gap**: PRs that ONLY change `.github/**` or top-level
+  files outside the `paths-ignore` list still trigger the schedule
+  workflow's push side after merge, so workflow-edit regressions
+  still get caught. PRs that ONLY touch docs are already excluded
+  from PR-CI via the existing `paths-ignore` block; they remain
+  excluded on the Windows side too.
+
+## Out of scope
+
+- Touching `e2e` (the other PR-CI pole). E2E is already sharded
+  across 2 runners and runs only on ubuntu — no Windows cell exists.
+- Adding macOS or Linux to the scheduled workflow. The PR-CI
+  matrix already covers them, and Windows is the only platform
+  with cost asymmetry justifying this split.
+- Caching `dist/client` (the Vite build output) — that step is
+  fast on Windows compared to `build:packages` and complicates the
+  cache key. Out of scope.
+
+## Validation
+
+- `actionlint .github/workflows/pull_request.yaml
+  .github/workflows/lint_test_windows.yaml` → clean.
+- `zizmor --persona=regular --config .github/zizmor.yml
+  .github/workflows/` → clean.
+- The new workflow's first run will be the post-merge `push: main`
+  trigger — that's the smoke test.


### PR DESCRIPTION
## Summary

- Drop `windows-latest` from the PR-time `lint_test` matrix (`pull_request.yaml`). Matrix becomes `[ubuntu-latest, macos-latest] × [22.x, 24.x]` (4 cells, down from 6).
- Add `.github/workflows/lint_test_windows.yaml` — same step sequence, `windows-latest × [22.x, 24.x]`, triggered by `schedule: 0 18 * * *` (daily 18:00 UTC = 03:00 JST), `push: branches: [main]`, and `workflow_dispatch`.
- Net effect: PRs feel ~3-5 min faster; Windows regressions are still caught on every main push (and once daily as a backstop).

## Items to Confirm / Review

- [ ] Schedule cadence: `0 18 * * *` matches `e2e_live_no_llm.yaml` — let me know if you want a different time (current pick puts the run during low-traffic JST hours, finishes well before working day).
- [ ] `paths-ignore` parity: same `docs/**`, `plans/**`, `**/*.md` exclusion as `pull_request.yaml`. Only applied to the `push: main` trigger; `schedule` always runs.
- [ ] Coverage gap: post-merge `push` trigger reports Windows-only breakage on main within ~minutes, so the worst case is "next PR's CI on top of a broken main, briefly." Plan file argues this is acceptable; flag if you'd rather keep one Windows cell on PR.
- [ ] Step parity: the new workflow runs the **same** steps as the old Windows path (Defender disable, node_modules cache, packages/dist cache + cache-miss-only `build:packages`, all gates). No coverage was dropped — only the trigger changed.
- [ ] `concurrency: cancel-in-progress: true` on the new workflow — a rapid sequence of main pushes will cancel earlier Windows runs in favor of the latest. Standard pattern but flagging in case you want post-merge runs to all complete.

## User Prompt

> ci時間がかかるので、windowsのlintはschedulesにいどうする

(Move the Windows `lint_test` matrix off PR CI to a scheduled workflow because PR CI is taking too long.)

## Why

`lint_test` ran 6 cells per PR push — `[ubuntu, windows, macos] × [22.x, 24.x]`. The Windows cells consistently dominated the wall clock because:

1. **NTFS tar extraction** for the yarn cache and `packages/*/dist` cache hit is much slower than ext4/APFS.
2. **Windows Defender realtime monitoring** fights `yarn install`'s atomic-rename pattern, so we have to disable it per-run (the disable itself is overhead).
3. **`tsc` across the 25 `@mulmobridge/*` workspaces** parallelises tighter on Linux/macOS than on Windows.

Windows-specific regressions in this repo are real but rare — almost all are path-separator / case-sensitivity / shell-quoting bugs. Daily + on-merge coverage is plenty; paying the cost on every PR push is not. (See `e2e_live_no_llm.yaml` for the same pattern applied to live-server e2e.)

## What changes

### `.github/workflows/pull_request.yaml`

- Matrix `os: [ubuntu-latest, windows-latest, macos-latest]` → `[ubuntu-latest, macos-latest]`.
- Remove the `runner.os == 'Windows'` guarded steps:
  - The conditional `cache: ${{ runner.os == 'Windows' && '' || 'yarn' }}` on `setup-node` collapses to plain `cache: yarn`.
  - The "Disable Windows Defender realtime monitoring" step is gone.
  - The "Cache node_modules (Windows)" step is gone.
- Add a comment block above `lint_test` explaining where Windows runs now.

### `.github/workflows/lint_test_windows.yaml` (new)

- `runs-on: windows-latest`, matrix `node-version: [22.x, 24.x]`, `fail-fast: false`, `timeout-minutes: 30`.
- Triggers:
  - `schedule: 0 18 * * *` (daily 18:00 UTC).
  - `push: branches: [main]` with the same `paths-ignore` as PR workflow.
  - `workflow_dispatch` for manual triage.
- `permissions: contents: read` (zizmor-clean, no token persistence).
- `concurrency: cancel-in-progress: true` keyed on `github.ref`.
- Same step sequence as the old Windows cell: `actions/checkout@v6` (with `persist-credentials: false`) → `setup-node@v6` (no built-in yarn cache) → Defender disable → cache node_modules → `yarn install` → cache packages/dist → `build:packages` (cache-miss only) → `typecheck` → `lint` → `plugins:codegen:check` → `build` → bundle-integrity `git diff --exit-code` → `test:coverage` → `test:csrf-wiring`.

### `plans/ci-windows-lint-to-schedule-1585.md` (new)

Documents the rationale, trade-offs, and explicit out-of-scope items (e2e, macOS scheduling, dist/client caching).

## Validation

- `actionlint .github/workflows/pull_request.yaml .github/workflows/lint_test_windows.yaml` — clean.
- `zizmor --persona=regular --config .github/zizmor.yml .github/workflows/` — `No findings to report` (24 suppressed, all pre-existing).
- The new workflow's first real-world signal will be the post-merge `push: main` trigger after this PR lands — that's the smoke test.

Closes #1585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI testing pipeline by moving Windows-specific tests to a separate daily scheduled workflow, reducing pull request feedback time while maintaining comprehensive cross-platform quality assurance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->