### PR TITLE
fix(e2e): de-flake files-tree-scroll deep-link test

### DIFF
--- a/e2e/tests/files-tree-scroll.spec.ts
+++ b/e2e/tests/files-tree-scroll.spec.ts
@@ -81,9 +81,21 @@ async function mockTree(page: Page): Promise<void> {
   await page.route((url) => url.pathname === "/api/files/content", handleContentRoute);
 }
 
+// Wait for an expanded directory to be FULLY rendered (its first and
+// last file rows both in the DOM). Each lazy-load batch pushes the
+// selected row further down, so polling for the scroll position before
+// the tree height has settled would race the reveal watcher even when
+// the logic is correct.
+async function expectDirFullyRendered(page: Page, dir: "a" | "b"): Promise<void> {
+  await expect(page.locator(`[data-testid="file-tree-file-${dir}-00.md"]`)).toBeVisible();
+  await expect(page.locator(`[data-testid="file-tree-file-${dir}-39.md"]`)).toBeVisible();
+}
+
 async function expectSelectedRowInView(page: Page): Promise<void> {
-  // poll: the reveal effect re-fires on tree growth, so give it a beat
-  // to settle after the lazy-load of dir-a finishes.
+  // The reveal effect re-fires on tree growth via a coalesced rAF, so
+  // the final scroll only lands once the last lazy-load resolves and
+  // its DOM patch flushes. The 15s ceiling is for slow CI runners —
+  // logic is eventual-correct, this just gives the cascade headroom.
   await expect
     .poll(
       async () =>
@@ -95,7 +107,7 @@ async function expectSelectedRowInView(page: Page): Promise<void> {
           const containerRect = container.getBoundingClientRect();
           return selRect.top >= containerRect.top && selRect.bottom <= containerRect.bottom;
         }),
-      { timeout: 5000 },
+      { timeout: 15000 },
     )
     .toBe(true);
 }
@@ -108,7 +120,7 @@ test.beforeEach(async ({ page }) => {
 test.describe("file tree auto-scroll to selection", () => {
   test("deep link to a file below the fold scrolls the tree to reveal it", async ({ page }) => {
     await page.goto("/files/dir-b/b-39.md");
-    await expect(page.locator('[data-testid="file-tree-file-b-39.md"]')).toBeVisible();
+    await expectDirFullyRendered(page, "b");
     await expectSelectedRowInView(page);
   });
 
@@ -116,7 +128,7 @@ test.describe("file tree auto-scroll to selection", () => {
     // Land on a row at the top of dir-a (which auto-expands via the
     // deep-link path). dir-b is still collapsed at this point.
     await page.goto("/files/dir-a/a-00.md");
-    await expect(page.locator('[data-testid="file-tree-file-a-00.md"]')).toBeVisible();
+    await expectDirFullyRendered(page, "a");
 
     // Simulate a markdown link navigating to a file in the still-
     // collapsed dir-b — this is the in-app file→file case the fix
@@ -127,7 +139,7 @@ test.describe("file tree auto-scroll to selection", () => {
       window.dispatchEvent(new PopStateEvent("popstate"));
     });
 
-    await expect(page.locator('[data-testid="file-tree-file-b-39.md"]')).toBeVisible();
+    await expectDirFullyRendered(page, "b");
     await expectSelectedRowInView(page);
   });
 });


### PR DESCRIPTION
## Summary
- Bump `expectSelectedRowInView` poll timeout from **5s → 15s** to absorb slow-CI variance in the lazy-load → re-render → rAF-coalesced scroll cascade.
- Before polling for scroll position, wait deterministically for the expanded dir to be **fully rendered** (its first AND last rows in the DOM) so intermediate sibling renders can't push the target back below the fold.

## Items to Confirm / Review
- The 15s ceiling matches the spirit of "give it a beat" without masking a logic bug — `FilesView.vue#revealSelectedInTree` is eventual-correct (it re-fires on every `childrenByPath` update via a coalesced rAF). The window was just tight; the design is sound.
- The "fully-rendered" wait checks `b-00.md` AND `b-39.md` (first and last of the lazy-loaded dir). This is a stronger settled-tree signal than waiting on the target row alone — the target appearing only proves *its own* row is in DOM, not that the tree height has stopped growing.
- I considered whether a true logic bug was hiding behind the flake; the watcher chain looks sound, and 6× local repeat passes consistently after the fix.

## User Prompt
> `e2e/tests/files-tree-scroll.spec.ts` がたまに CI で flake する(`deep link to a file below the fold scrolls the tree to reveal it` が 5s polling で timeout)。タイムアウト変更で直る? → 推奨案で(timeout を 10–15s に上げる **and** dir-b の全行が DOM に揃ってから scroll を assert)。

## Implementation
- `expectSelectedRowInView`: `{ timeout: 5000 }` → `{ timeout: 15000 }`. Comment updated to call out that this is for slow-CI headroom on an eventual-correct cascade.
- New helper `expectDirFullyRendered(page, dir)` asserts both `${dir}-00.md` and `${dir}-39.md` are visible — proves dir's 40 children are mounted.
- Both tests now call `expectDirFullyRendered(page, "b")` (and "a" before the in-app navigation) instead of waiting only on the target row.

### Why this is the right shape, not just a longer timeout
The flake is caused by a real race: each lazy-load batch (`childrenByPath` update) re-fires the reveal watcher. Polling for the FINAL scroll position before every batch has settled can catch the row mid-cascade — the rAF will land it eventually, but the poll window has to outlast the slowest batch. Waiting for the dir's first AND last rows removes that race entirely. The 15s ceiling is then headroom for the genuinely slow path (lazy-load → 40 children render → layout → scroll), not a workaround.

## Validation
- Single run: 2/2 pass (~4s).
- `--repeat-each=6`: 12/12 pass (~6s).
- `yarn lint` / `typecheck` / `build`: clean.

## Test Plan
- [ ] CI green on the e2e job.
- [ ] No regression in any other `e2e/tests/` spec.