### PR TITLE
fix: map pt / pt-PT browser locales to pt-BR instead of English

### DIFF
--- a/plans/fix-pt-locale-fallback.md
+++ b/plans/fix-pt-locale-fallback.md
@@ -1,0 +1,22 @@
+# fix: Map pt / pt-PT browser locales to pt-BR (#1590)
+
+## Problem
+
+Browsers reporting `pt` or `pt-PT` fall through to English because
+`primarySubtagIfSupported` only checks exact locale match and bare
+primary subtag — but the only Portuguese variant we ship is `pt-BR`,
+not `pt`.
+
+## Solution
+
+Extract the locale-resolution function to `src/lang/index.ts` as
+`resolveLocale` (testable without browser runtime), and add a final
+fallback step: when the primary subtag itself is not a supported
+locale, search for a supported locale whose primary subtag matches
+(e.g. `pt` → `pt-BR`).
+
+## Changes
+
+- `src/lang/index.ts` — add exported `resolveLocale` with regional-variant fallback
+- `src/lib/vue-i18n.ts` — replace inline `primarySubtagIfSupported` with `resolveLocale` import
+- `test/lang/test_resolve_locale.ts` — unit tests covering all resolution paths

--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -38,3 +38,18 @@ export const messages: Record<Locale, LocaleMessages> = {
 export function isSupportedLocale(tag: string): tag is Locale {
   return (SUPPORTED_LOCALES as readonly string[]).includes(tag);
 }
+
+// Match the full tag first (so `pt-BR` resolves exactly), then collapse
+// `ja-JP`, `ja-Hira-JP`, etc. to their primary subtag. When neither matches
+// exactly, look for a regional variant that shares the primary subtag
+// (e.g. `pt` / `pt-PT` → `pt-BR`).
+export function resolveLocale(tag: string): Locale | null {
+  if (isSupportedLocale(tag)) return tag;
+  const lower = tag.toLowerCase();
+  for (const supported of SUPPORTED_LOCALES) {
+    if (supported.toLowerCase() === lower) return supported;
+  }
+  const [primary] = lower.split("-");
+  if (isSupportedLocale(primary)) return primary;
+  return SUPPORTED_LOCALES.find((locale) => locale.toLowerCase().startsWith(`${primary}-`)) ?? null;
+}

--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -20,7 +20,7 @@
 // the Options API `this.$t`. CLAUDE.md mandates Composition API.
 
 import { createI18n } from "vue-i18n";
-import { messages, isSupportedLocale, resolveLocale, type Locale, type LocaleMessages } from "../lang";
+import { messages, resolveLocale, type Locale, type LocaleMessages } from "../lang";
 
 // Schema generic on createI18n — this is what makes `t("common.save")`
 // calls across the whole app compile-time checked (the module
@@ -33,10 +33,12 @@ type MessageSchema = LocaleMessages;
 const DEFAULT_LOCALE: Locale = "en";
 
 function detectLocale(): Locale {
-  // 1. explicit env override
+  // 1. explicit env override (resolved through the same path as browser tags
+  //    so that VITE_LOCALE=pt maps to pt-BR, same as a browser reporting "pt")
   const envLocale = import.meta.env.VITE_LOCALE;
-  if (typeof envLocale === "string" && isSupportedLocale(envLocale)) {
-    return envLocale;
+  if (typeof envLocale === "string") {
+    const resolved = resolveLocale(envLocale);
+    if (resolved) return resolved;
   }
 
   // 2. browser / OS preference list

--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -10,15 +10,17 @@
 //   3. Hard default `"en"`
 //
 // Language tags like `"ja-JP"` are matched by primary subtag, so
-// `ja-JP`, `ja-Hira-JP`, etc. all collapse to `"ja"`. Unknown tags
-// (`"fr-FR"`) skip to the next candidate.
+// `ja-JP`, `ja-Hira-JP`, etc. all collapse to `"ja"`. When only a
+// regional variant is supported (`pt-BR`), tags sharing the primary
+// subtag (`pt`, `pt-PT`) resolve to that variant. Completely unknown
+// primary subtags (`"sw"`) skip to the next candidate.
 //
 // `legacy: false` switches vue-i18n to the Composition API mode, so
 // components call `const { t } = useI18n()` instead of relying on
 // the Options API `this.$t`. CLAUDE.md mandates Composition API.
 
 import { createI18n } from "vue-i18n";
-import { messages, SUPPORTED_LOCALES, isSupportedLocale, type Locale, type LocaleMessages } from "../lang";
+import { messages, isSupportedLocale, resolveLocale, type Locale, type LocaleMessages } from "../lang";
 
 // Schema generic on createI18n — this is what makes `t("common.save")`
 // calls across the whole app compile-time checked (the module
@@ -29,19 +31,6 @@ import { messages, SUPPORTED_LOCALES, isSupportedLocale, type Locale, type Local
 type MessageSchema = LocaleMessages;
 
 const DEFAULT_LOCALE: Locale = "en";
-
-// Match the full tag first (so `pt-BR` resolves exactly), then collapse
-// `ja-JP`, `ja-Hira-JP`, etc. to their primary subtag. Returns null when
-// neither the full tag nor the primary subtag is supported.
-function primarySubtagIfSupported(tag: string): Locale | null {
-  if (isSupportedLocale(tag)) return tag;
-  const lower = tag.toLowerCase();
-  for (const supported of SUPPORTED_LOCALES) {
-    if (supported.toLowerCase() === lower) return supported;
-  }
-  const [primary] = lower.split("-");
-  return isSupportedLocale(primary) ? primary : null;
-}
 
 function detectLocale(): Locale {
   // 1. explicit env override
@@ -55,7 +44,7 @@ function detectLocale(): Locale {
     const preferred = navigator.languages && navigator.languages.length > 0 ? navigator.languages : [navigator.language];
     for (const tag of preferred) {
       if (typeof tag !== "string") continue;
-      const match = primarySubtagIfSupported(tag);
+      const match = resolveLocale(tag);
       if (match) return match;
     }
   }

--- a/test/lang/test_resolve_locale.ts
+++ b/test/lang/test_resolve_locale.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveLocale } from "../../src/lang";
+import { resolveLocale } from "../../src/lang/index.js";
 
 describe("resolveLocale", () => {
   it("returns exact match for supported locale", () => {

--- a/test/lang/test_resolve_locale.ts
+++ b/test/lang/test_resolve_locale.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveLocale } from "../../src/lang";
+
+describe("resolveLocale", () => {
+  it("returns exact match for supported locale", () => {
+    assert.equal(resolveLocale("en"), "en");
+    assert.equal(resolveLocale("ja"), "ja");
+    assert.equal(resolveLocale("pt-BR"), "pt-BR");
+  });
+
+  it("matches case-insensitively", () => {
+    assert.equal(resolveLocale("PT-BR"), "pt-BR");
+    assert.equal(resolveLocale("pt-br"), "pt-BR");
+    assert.equal(resolveLocale("EN"), "en");
+  });
+
+  it("collapses regional tag to primary subtag when primary is supported", () => {
+    assert.equal(resolveLocale("ja-JP"), "ja");
+    assert.equal(resolveLocale("en-US"), "en");
+    assert.equal(resolveLocale("ko-KR"), "ko");
+    assert.equal(resolveLocale("es-MX"), "es");
+    assert.equal(resolveLocale("fr-FR"), "fr");
+    assert.equal(resolveLocale("de-AT"), "de");
+    assert.equal(resolveLocale("zh-TW"), "zh");
+  });
+
+  it("maps bare primary subtag to regional variant (pt → pt-BR)", () => {
+    assert.equal(resolveLocale("pt"), "pt-BR");
+  });
+
+  it("maps regional variant to supported regional variant (pt-PT → pt-BR)", () => {
+    assert.equal(resolveLocale("pt-PT"), "pt-BR");
+  });
+
+  it("returns null for completely unsupported locale", () => {
+    assert.equal(resolveLocale("sw"), null);
+    assert.equal(resolveLocale("ar-SA"), null);
+    assert.equal(resolveLocale("th"), null);
+  });
+});


### PR DESCRIPTION
## Summary

#1590 対応: ブラウザが `pt` や `pt-PT` を報告したとき、英語にフォールバックせず `pt-BR` に解決するようにした。

- `primarySubtagIfSupported` のロケール解決ロジックを `resolveLocale` として `src/lang/index.ts` に抽出し、主部分が一致するリージョン variant へのフォールバックを追加（`pt` → `pt-BR`）
- `VITE_LOCALE` env override も同じ `resolveLocale` を通すよう統一（Codex review で指摘）
- ユニットテスト 6 ケース追加

## Items to Confirm / Review

- `pt` / `pt-PT` ユーザーにブラジルポルトガル語を見せることの許容性（issue で検討事項として記載済み）
- `VITE_LOCALE` パスを `resolveLocale` に統一したことで、無効な値が黙って無視されずリージョン variant にマップされるようになった点

## User Prompt

- `pt` / `pt-PT` のブラウザロケールを `pt-BR` にマップする（#1590 の実装）

## 動作確認

- `VITE_LOCALE=pt yarn dev` でポルトガル語表示を確認済み（修正前は日本語にフォールバック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Codex cross-review: 2 iterations で LGTM 収束

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale detection and fallback so Portuguese variants (pt, pt-PT) correctly map to Portuguese instead of defaulting to English.

* **Refactor**
  * Centralized locale resolution to ensure consistent language selection across the app.

* **Tests**
  * Added tests covering exact, case-insensitive, primary-subtag, and regional-variant locale resolution.

* **Documentation**
  * Added a plan describing the locale-fallback fix and intended integration/testing steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->