### PR TITLE
feat(collections): inline checkbox/dropdown editing in the table view

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -395,6 +395,27 @@ Clicking a list row marks it read (badge decrements). The "Mark all read" button
 
 The preview pane reuses plugin views — clicking a `config/scheduler/items.json` mounts `<CalendarView>` via `toSchedulerResult`. System-managed files (`config/*.json`, `data/wiki/*.md`, `conversations/memory.md`, …) get a `[system-file-banner]` above the body explaining what the file is, who writes it, and whether hand-edits survive (descriptors live in `src/config/systemFileDescriptors.ts`; #832).
 
+## /collections — schema-driven record tables
+
+```
+┌─[<CollectionView> — /collections/:slug]────────────────────────────────┐
+│ Toolbar: [Table | Calendar] toggle · search · [+ add]                   │
+│                                                                         │
+│ [collections-inline-error] (banner, only after a failed inline write)   │
+│ ┌─Table──────────────────────────────────────────────────────────────┐ │
+│ │ ID        │ Yoga                  │ Status                          │ │
+│ │ [collections-row-<id>] (whole row click → detail panel)            │ │
+│ │  jun-03   │ ☑ [collections-      │ ▾ [collections-                 │ │
+│ │           │   inline-bool-       │   inline-enum-                  │ │
+│ │           │   <key>-<id>]        │   <key>-<id>]                   │ │
+│ └────────────────────────────────────────────────────────────────────┘ │
+│                                                                         │
+│ Row click expands [collections-detail] (read-only → Edit → Save).       │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`boolean` columns render an inline checkbox and `enum` columns an inline `<select>` directly in the table cell — changing one writes the value straight to the record (`PUT .../items/:id`, optimistic + rollback on failure) without opening the detail panel. The controls use `@click.stop` so the cell click never bubbles into the row's `openView`. All other field types (and the full edit form) still go through the row → `[collections-detail]` → Edit → Save flow.
+
 ## /skills — workspace skills list
 
 Two-pane layout (`<ManageSkillsView>`): left sidebar = two collapsible

--- a/e2e/tests/collection-inline-edit.spec.ts
+++ b/e2e/tests/collection-inline-edit.spec.ts
@@ -123,4 +123,35 @@ test.describe("collection inline cell editing", () => {
     await expect(page.getByTestId("collections-inline-error")).toBeVisible();
     await expect(checkbox).not.toBeChecked();
   });
+
+  test("a row's inline controls are gated while its save is in flight", async ({ page }) => {
+    // Hold the PUT response so the save stays in flight; this is the
+    // window where a second same-row edit could otherwise race.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route(
+      (url) => url.pathname.startsWith("/api/collections/daily-routine/items/"),
+      async (route) => {
+        if (route.request().method() !== "PUT") return route.fallback();
+        await gate;
+        const itemId = decodeURIComponent(route.request().url().split("/items/").pop() ?? "");
+        return route.fulfill({ json: { itemId, item: JSON.parse(route.request().postData() ?? "{}") } });
+      },
+    );
+    await page.goto("/collections/daily-routine");
+    const checkbox = page.getByTestId("collections-inline-bool-yoga-jun-03");
+    const select = page.getByTestId("collections-inline-enum-status-jun-03");
+    await checkbox.check();
+    // Both inline controls in the SAME row are disabled while the PUT is
+    // pending — no second full-record PUT can be issued to race the first.
+    await expect(checkbox).toBeDisabled();
+    await expect(select).toBeDisabled();
+    // A different row stays editable (the gate is per-row).
+    await expect(page.getByTestId("collections-inline-bool-yoga-jun-04")).toBeEnabled();
+    release();
+    await expect(checkbox).toBeEnabled();
+    await expect(select).toBeEnabled();
+  });
 });

--- a/e2e/tests/collection-inline-edit.spec.ts
+++ b/e2e/tests/collection-inline-edit.spec.ts
@@ -1,0 +1,126 @@
+// E2E coverage for inline table-cell editing in CollectionView: a
+// `boolean` column renders a checkbox and an `enum` column a dropdown,
+// both writing the changed value straight to the record via PUT (no
+// open→edit→save). Pins three things a refactor must not regress:
+//   1. toggling the cell fires the PUT with the merged record,
+//   2. the cell control uses `@click.stop` so it does NOT open the
+//      row's detail panel, and
+//   3. a failed PUT rolls the cell back and surfaces an error banner.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const ROUTINE = {
+  collection: {
+    slug: "daily-routine",
+    title: "Daily Routine",
+    icon: "self_improvement",
+    source: "user",
+    schema: {
+      title: "Daily Routine",
+      icon: "self_improvement",
+      dataPath: "data/daily-routine/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        yoga: { type: "boolean", label: "Yoga" },
+        status: { type: "enum", label: "Status", values: ["todo", "doing", "done"] },
+      },
+      completionField: "yoga",
+      completionDoneValues: ["true"],
+    },
+  },
+  items: [
+    { id: "jun-03", yoga: false, status: "todo" },
+    { id: "jun-04", yoga: true, status: "done" },
+    // `status` absent → this cell was empty at load, so its dropdown
+    // keeps the empty placeholder option (the others don't).
+    { id: "jun-05", yoga: false },
+  ],
+};
+
+async function mockCollection(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/daily-routine",
+    (route) => route.fulfill({ json: ROUTINE }),
+  );
+}
+
+/** Mock the item PUT endpoint. `ok` toggles success vs a 500 so the
+ *  rollback path can be exercised. Awaits route registration and returns
+ *  `{ body }`, where `body` resolves with the first PUT's parsed request
+ *  body — for assertion. */
+async function mockItemPut(page: Page, ok: boolean): Promise<{ body: Promise<Record<string, unknown>> }> {
+  let resolveBody: (body: Record<string, unknown>) => void;
+  const body = new Promise<Record<string, unknown>>((resolve) => {
+    resolveBody = resolve;
+  });
+  await page.route(
+    (url) => url.pathname.startsWith("/api/collections/daily-routine/items/"),
+    (route) => {
+      if (route.request().method() !== "PUT") return route.fallback();
+      const parsed = JSON.parse(route.request().postData() ?? "{}");
+      resolveBody(parsed);
+      const itemId = decodeURIComponent(route.request().url().split("/items/").pop() ?? "");
+      if (!ok) return route.fulfill({ status: 500, json: { error: "boom" } });
+      return route.fulfill({ json: { itemId, item: parsed } });
+    },
+  );
+  return { body };
+}
+
+test.describe("collection inline cell editing", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockCollection(page);
+  });
+
+  test("toggling the boolean checkbox PUTs the merged record", async ({ page }) => {
+    const { body } = await mockItemPut(page, true);
+    await page.goto("/collections/daily-routine");
+    const checkbox = page.getByTestId("collections-inline-bool-yoga-jun-03");
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.check();
+    const put = await body;
+    expect(put.yoga).toBe(true);
+    expect(put.id).toBe("jun-03");
+    await expect(checkbox).toBeChecked();
+  });
+
+  test("changing the enum dropdown PUTs the new value", async ({ page }) => {
+    const { body } = await mockItemPut(page, true);
+    await page.goto("/collections/daily-routine");
+    const select = page.getByTestId("collections-inline-enum-status-jun-03");
+    await select.selectOption("doing");
+    const put = await body;
+    expect(put.status).toBe("doing");
+  });
+
+  test("the empty placeholder option appears only for cells empty at load", async ({ page }) => {
+    await mockItemPut(page, true);
+    await page.goto("/collections/daily-routine");
+    // jun-03's `status` had a value → no empty option (can't blank inline).
+    const filled = page.getByTestId("collections-inline-enum-status-jun-03");
+    await expect(filled.locator('option[value=""]')).toHaveCount(0);
+    // jun-05's `status` was absent at load → keeps the empty placeholder.
+    const empty = page.getByTestId("collections-inline-enum-status-jun-05");
+    await expect(empty.locator('option[value=""]')).toHaveCount(1);
+  });
+
+  test("inline controls do NOT open the row's detail panel", async ({ page }) => {
+    await mockItemPut(page, true);
+    await page.goto("/collections/daily-routine");
+    await page.getByTestId("collections-inline-bool-yoga-jun-03").check();
+    // If `@click.stop` were missing, the row click would open the detail.
+    await expect(page.getByTestId("collections-detail")).toHaveCount(0);
+  });
+
+  test("a failed PUT rolls the cell back and shows the error banner", async ({ page }) => {
+    await mockItemPut(page, false);
+    await page.goto("/collections/daily-routine");
+    const checkbox = page.getByTestId("collections-inline-bool-yoga-jun-03");
+    await checkbox.check();
+    await expect(page.getByTestId("collections-inline-error")).toBeVisible();
+    await expect(checkbox).not.toBeChecked();
+  });
+});

--- a/e2e/tests/collection-inline-edit.spec.ts
+++ b/e2e/tests/collection-inline-edit.spec.ts
@@ -119,7 +119,10 @@ test.describe("collection inline cell editing", () => {
     await mockItemPut(page, false);
     await page.goto("/collections/daily-routine");
     const checkbox = page.getByTestId("collections-inline-bool-yoga-jun-03");
-    await checkbox.check();
+    // `.click()`, not `.check()`: the failed PUT rolls the cell back to
+    // unchecked, so `.check()` (which asserts a final checked state) would
+    // race the rollback. A single click + explicit assertions is stable.
+    await checkbox.click();
     await expect(page.getByTestId("collections-inline-error")).toBeVisible();
     await expect(checkbox).not.toBeChecked();
   });

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -258,7 +258,8 @@
                       v-if="field.type === 'boolean'"
                       type="checkbox"
                       :checked="item[key] === true"
-                      class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle"
+                      :disabled="isRowInlineSaving(item)"
+                      class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle disabled:opacity-50 disabled:cursor-not-allowed"
                       :data-testid="`collections-inline-bool-${key}-${item[collection.schema.primaryKey]}`"
                       :aria-label="field.label"
                       @click.stop
@@ -282,7 +283,8 @@
                     <select
                       v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
                       :value="item[key] == null ? '' : String(item[key])"
-                      class="rounded-lg border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-700 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer"
+                      :disabled="isRowInlineSaving(item)"
+                      class="rounded-lg border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-700 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                       :data-testid="`collections-inline-enum-${key}-${item[collection.schema.primaryKey]}`"
                       :aria-label="field.label"
                       @click.stop
@@ -552,6 +554,12 @@ const inlineError = ref<string | null>(null);
  *  placeholder option in their inline dropdown — a cell that already
  *  has a value can't be blanked inline (use the edit form for that). */
 const enumOriginallyEmpty = ref<Set<string>>(new Set());
+/** Rows with an inline cell save in flight (by `rowId`). While a row is
+ *  here its inline controls are disabled, so two quick edits to the same
+ *  row can't race two full-record PUTs — an older PUT landing last would
+ *  otherwise clobber the newer field on disk while the UI shows the
+ *  newer optimistic value (Codex PR #1599 P2). */
+const inlineSavingRows = ref<Set<string>>(new Set());
 const actionPending = ref(false);
 const actionError = ref<string | null>(null);
 const chatOpen = ref(false);
@@ -1109,19 +1117,28 @@ function applyInlineValue(item: CollectionItem, key: string, value: unknown): vo
   item[key] = value;
 }
 
+/** True while this row has an inline cell save in flight — its inline
+ *  controls render disabled to serialize edits (one PUT per row). */
+function isRowInlineSaving(item: CollectionItem): boolean {
+  return inlineSavingRows.value.has(rowId(item));
+}
+
 /** Inline table-cell edit (boolean checkbox / enum dropdown): optimistic
- *  update, then PUT the full record. On failure, roll the cell back and
- *  surface the error. Bypasses the detail/edit panel entirely. */
+ *  update, then PUT the full record. Gated per row so a second edit can't
+ *  race the in-flight one. On failure, roll the cell back and surface the
+ *  error. Bypasses the detail/edit panel entirely. */
 async function commitInlineEdit(item: CollectionItem, key: string, field: FieldSpec, raw: boolean | string): Promise<void> {
   if (!collection.value) return;
   const { slug } = collection.value;
   const itemId = rowId(item);
-  if (!itemId) return;
+  if (!itemId || inlineSavingRows.value.has(itemId)) return;
   const previous = item[key];
   const coerced = coerceInlineValue(field, raw);
   applyInlineValue(item, key, coerced);
   inlineError.value = null;
+  inlineSavingRows.value.add(itemId);
   const result = await apiPut<ItemMutationResponse>(itemUrl(slug, itemId), buildUpdatedRecord(item, key, coerced));
+  inlineSavingRows.value.delete(itemId);
   if (!result.ok) {
     applyInlineValue(item, key, previous);
     inlineError.value = result.error;
@@ -1224,6 +1241,7 @@ watch(
       collection.value = null;
       items.value = [];
       enumOriginallyEmpty.value = new Set();
+      inlineSavingRows.value = new Set();
       searchQuery.value = ""; // Reset search query
       loading.value = false;
     }

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -206,6 +206,25 @@
       </div>
 
       <div v-else class="overflow-x-auto [container-type:inline-size]">
+        <!-- Inline-edit failure banner: a cell write (checkbox/dropdown)
+             was rolled back; the detail panel's `saveError` isn't visible
+             here so inline edits surface their own. -->
+        <div
+          v-if="inlineError"
+          class="m-4 rounded-xl border border-red-200 bg-red-50/50 p-4 text-sm text-red-800 shadow-sm flex items-center gap-3"
+          data-testid="collections-inline-error"
+        >
+          <span class="material-icons text-red-600">error</span>
+          <span class="flex-1">{{ t("collectionsView.inlineSaveFailed", { error: inlineError }) }}</span>
+          <button
+            type="button"
+            class="h-8 w-8 flex items-center justify-center rounded text-red-600 hover:bg-red-100"
+            :aria-label="t('common.close')"
+            @click="inlineError = null"
+          >
+            <span class="material-icons text-base">close</span>
+          </button>
+        </div>
         <table class="min-w-full text-xs">
           <thead>
             <tr class="bg-slate-50 border-b border-slate-200">
@@ -231,24 +250,20 @@
                 <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
                   <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
                   <template v-if="fieldVisible(field, item)">
-                    <!-- Boolean state badge -->
-                    <span v-if="field.type === 'boolean'" class="block">
-                      <span
-                        v-if="item[key] === true"
-                        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
-                      >
-                        <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
-                        {{ t("common.yes") }}
-                      </span>
-                      <span
-                        v-else-if="item[key] === false"
-                        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
-                      >
-                        {{ t("common.no") }}
-                      </span>
-                      <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" for an omitted boolean: distinct from an explicit false (the edit pipeline tracks presence via boolOriginallyPresent). -->
-                      <span v-else class="text-slate-300">—</span>
-                    </span>
+                    <!-- Boolean → inline checkbox. Tap toggles + saves
+                         immediately; `@click.stop` so it doesn't open the
+                         row's detail panel. Unset (undefined) and explicit
+                         false both render unchecked. -->
+                    <input
+                      v-if="field.type === 'boolean'"
+                      type="checkbox"
+                      :checked="item[key] === true"
+                      class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle"
+                      :data-testid="`collections-inline-bool-${key}-${item[collection.schema.primaryKey]}`"
+                      :aria-label="field.label"
+                      @click.stop
+                      @change="commitInlineEdit(item, String(key), field, ($event.target as HTMLInputElement).checked)"
+                    />
 
                     <!-- Ref router-link badge -->
                     <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
@@ -261,14 +276,21 @@
                       >
                     </span>
 
-                    <!-- Enum badges -->
-                    <span
-                      v-else-if="field.type === 'enum' && item[key]"
-                      class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border"
-                      :class="enumBadgeClass(item[key])"
+                    <!-- Enum → inline dropdown. Selecting writes + saves
+                         immediately; the empty placeholder clears the field.
+                         `@click.stop` keeps the row's detail panel closed. -->
+                    <select
+                      v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+                      :value="item[key] == null ? '' : String(item[key])"
+                      class="rounded-lg border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-700 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer"
+                      :data-testid="`collections-inline-enum-${key}-${item[collection.schema.primaryKey]}`"
+                      :aria-label="field.label"
+                      @click.stop
+                      @change="commitInlineEdit(item, String(key), field, ($event.target as HTMLSelectElement).value)"
                     >
-                      {{ item[key] }}
-                    </span>
+                      <option v-if="showEnumPlaceholder(item, String(key))" value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                      <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+                    </select>
 
                     <!-- Money -->
                     <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
@@ -439,7 +461,7 @@ import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
 import { useCollectionRendering } from "../composables/collections/useCollectionRendering";
-import { draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
+import { buildUpdatedRecord, coerceInlineValue, draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
 import type {
   CollectionAction,
   CollectionDetail,
@@ -521,6 +543,15 @@ const editing = ref<EditState | null>(null);
 const viewing = ref<CollectionItem | null>(null);
 const saving = ref(false);
 const saveError = ref<string | null>(null);
+/** Error from an inline table-cell edit (checkbox/dropdown). Distinct
+ *  from `saveError` (rendered only inside the detail panel, which is
+ *  closed during inline editing) — shown as a banner above the table. */
+const inlineError = ref<string | null>(null);
+/** Per-load snapshot of enum cells that had NO value when fetched
+ *  (keyed `<rowId>:<fieldKey>`). Only these cells offer the empty
+ *  placeholder option in their inline dropdown — a cell that already
+ *  has a value can't be blanked inline (use the edit form for that). */
+const enumOriginallyEmpty = ref<Set<string>>(new Set());
 const actionPending = ref(false);
 const actionError = ref<string | null>(null);
 const chatOpen = ref(false);
@@ -578,6 +609,34 @@ function isCreateRow(item: CollectionItem): boolean {
   return rowId(item) === CREATE_ROW_ID;
 }
 
+/** Stable key for one cell in the `enumOriginallyEmpty` snapshot. */
+function cellKey(rowIdValue: string, fieldKey: string): string {
+  return `${rowIdValue}:${fieldKey}`;
+}
+
+/** Build the set of enum cells that were empty in the freshly-fetched
+ *  records — the only cells whose inline dropdown offers an empty option. */
+function snapshotEmptyEnums(schema: CollectionDetail["schema"], records: CollectionItem[]): Set<string> {
+  const empty = new Set<string>();
+  const enumKeys = Object.entries(schema.fields)
+    .filter(([, field]) => field.type === "enum")
+    .map(([fieldKey]) => fieldKey);
+  if (enumKeys.length === 0) return empty;
+  for (const record of records) {
+    const recordId = String(record[schema.primaryKey] ?? "");
+    for (const fieldKey of enumKeys) {
+      if (record[fieldKey] == null || record[fieldKey] === "") empty.add(cellKey(recordId, fieldKey));
+    }
+  }
+  return empty;
+}
+
+/** Whether an inline enum dropdown should render its empty placeholder
+ *  option: only for cells with no value at load time. */
+function showEnumPlaceholder(item: CollectionItem, fieldKey: string): boolean {
+  return enumOriginallyEmpty.value.has(cellKey(rowId(item), fieldKey));
+}
+
 /** Rows rendered by the table: the filtered records, plus a synthetic
  *  create row at the top while a create is in progress. */
 const displayItems = computed<CollectionItem[]>(() => {
@@ -605,23 +664,6 @@ function isEditingRow(item: CollectionItem): boolean {
 /** Whether to render this row's expansion panel (detail or edit). */
 function shouldExpand(item: CollectionItem): boolean {
   return isRowOpen(item) || isEditingRow(item);
-}
-
-// Best-effort status coloring for enum badges: maps common
-// status-like values to a semantic tint, falling back to neutral
-// slate for anything unrecognized. Value-matching only (no i18n).
-function enumBadgeClass(value: unknown): string {
-  const str = String(value).toLowerCase();
-  if (["paid", "completed", "success", "active", "approved", "yes", "true"].includes(str)) {
-    return "bg-emerald-50 text-emerald-700 border-emerald-200/30";
-  }
-  if (["pending", "processing", "draft", "warning"].includes(str)) {
-    return "bg-amber-50 text-amber-700 border-amber-200/30";
-  }
-  if (["void", "cancelled", "failed", "error", "no", "false"].includes(str)) {
-    return "bg-rose-50 text-rose-700 border-rose-200/30";
-  }
-  return "bg-slate-50 text-slate-600 border-slate-200/50";
 }
 
 function detailUrl(slug: string): string {
@@ -722,6 +764,7 @@ async function loadCollection(slug: string): Promise<void> {
   }
   collection.value = result.data.collection;
   items.value = result.data.items;
+  enumOriginallyEmpty.value = snapshotEmptyEnums(result.data.collection.schema, result.data.items);
   // Fan out to fetch each unique target collection so the table can
   // render ref values as display names (not slugs) and the form
   // dropdown has options. Failures fall back gracefully — the table
@@ -1058,6 +1101,33 @@ async function saveEditor(): Promise<void> {
   }
 }
 
+/** Write a single cell's value directly onto the live `items` entry.
+ *  Reactive in Vue 3 (proxy), so the bound checkbox/select re-renders.
+ *  `undefined` (enum cleared to the placeholder) renders as the empty
+ *  option; the PUT body omits the key via `buildUpdatedRecord`. */
+function applyInlineValue(item: CollectionItem, key: string, value: unknown): void {
+  item[key] = value;
+}
+
+/** Inline table-cell edit (boolean checkbox / enum dropdown): optimistic
+ *  update, then PUT the full record. On failure, roll the cell back and
+ *  surface the error. Bypasses the detail/edit panel entirely. */
+async function commitInlineEdit(item: CollectionItem, key: string, field: FieldSpec, raw: boolean | string): Promise<void> {
+  if (!collection.value) return;
+  const { slug } = collection.value;
+  const itemId = rowId(item);
+  if (!itemId) return;
+  const previous = item[key];
+  const coerced = coerceInlineValue(field, raw);
+  applyInlineValue(item, key, coerced);
+  inlineError.value = null;
+  const result = await apiPut<ItemMutationResponse>(itemUrl(slug, itemId), buildUpdatedRecord(item, key, coerced));
+  if (!result.ok) {
+    applyInlineValue(item, key, previous);
+    inlineError.value = result.error;
+  }
+}
+
 async function confirmDelete(item: CollectionItem): Promise<void> {
   if (!collection.value) return;
   // Snapshot before any await (see saveEditor) — confirm dialog
@@ -1153,6 +1223,7 @@ watch(
     } else {
       collection.value = null;
       items.value = [];
+      enumOriginallyEmpty.value = new Set();
       searchQuery.value = ""; // Reset search query
       loading.value = false;
     }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1340,6 +1340,7 @@ const deMessages = {
     loadFailed: "Laden fehlgeschlagen",
     requiredField: "Dieses Feld ist erforderlich",
     selectPlaceholder: "Auswählen…",
+    inlineSaveFailed: "Änderung konnte nicht gespeichert werden: {error}",
     addRow: "Zeile hinzufügen",
     removeRow: "Zeile entfernen",
     noRows: "Noch keine Zeilen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1321,6 +1321,7 @@ const enMessages = {
     loadFailed: "Failed to load",
     requiredField: "This field is required",
     selectPlaceholder: "Select…",
+    inlineSaveFailed: "Couldn't save change: {error}",
     addRow: "Add row",
     removeRow: "Remove row",
     noRows: "No rows yet",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1335,6 +1335,7 @@ const esMessages = {
     loadFailed: "Error al cargar",
     requiredField: "Este campo es obligatorio",
     selectPlaceholder: "Seleccionar…",
+    inlineSaveFailed: "No se pudo guardar el cambio: {error}",
     addRow: "Añadir fila",
     removeRow: "Quitar fila",
     noRows: "Aún no hay filas",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1330,6 +1330,7 @@ const frMessages = {
     loadFailed: "Échec du chargement",
     requiredField: "Ce champ est obligatoire",
     selectPlaceholder: "Sélectionner…",
+    inlineSaveFailed: "Impossible d'enregistrer la modification : {error}",
     addRow: "Ajouter une ligne",
     removeRow: "Supprimer la ligne",
     noRows: "Aucune ligne pour l'instant",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1318,6 +1318,7 @@ const jaMessages = {
     loadFailed: "読み込みに失敗しました",
     requiredField: "この項目は必須です",
     selectPlaceholder: "選択…",
+    inlineSaveFailed: "変更を保存できませんでした: {error}",
     addRow: "行を追加",
     removeRow: "行を削除",
     noRows: "行がありません",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1321,6 +1321,7 @@ const koMessages = {
     loadFailed: "불러오기에 실패했습니다",
     requiredField: "이 필드는 필수입니다",
     selectPlaceholder: "선택…",
+    inlineSaveFailed: "변경 사항을 저장하지 못했습니다: {error}",
     addRow: "행 추가",
     removeRow: "행 삭제",
     noRows: "행이 없습니다",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1324,6 +1324,7 @@ const ptBRMessages = {
     loadFailed: "Falha ao carregar",
     requiredField: "Este campo é obrigatório",
     selectPlaceholder: "Selecionar…",
+    inlineSaveFailed: "Não foi possível salvar a alteração: {error}",
     addRow: "Adicionar linha",
     removeRow: "Remover linha",
     noRows: "Ainda não há linhas",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1311,6 +1311,7 @@ const zhMessages = {
     loadFailed: "加载失败",
     requiredField: "此字段为必填项",
     selectPlaceholder: "请选择…",
+    inlineSaveFailed: "无法保存更改：{error}",
     addRow: "添加行",
     removeRow: "删除行",
     noRows: "暂无行",

--- a/src/utils/collections/draft.ts
+++ b/src/utils/collections/draft.ts
@@ -97,6 +97,25 @@ export function draftToRecord(state: EditState, schema: CollectionSchema): Colle
   return record;
 }
 
+/** Normalise a raw inline-edit input (table-cell checkbox/select) to its
+ *  persisted form. Mirrors `draftToRecord`'s boolean strictness; an empty
+ *  enum selection (the placeholder option) clears the field via `undefined`. */
+export function coerceInlineValue(field: FieldSpec, raw: boolean | string): unknown {
+  if (field.type === "boolean") return raw === true;
+  return raw === "" ? undefined : raw;
+}
+
+/** Build the full record to PUT for a single-cell inline edit, without
+ *  mutating `item`. A `undefined` value omits the key (enum cleared),
+ *  matching `draftToRecord`'s omission semantics. */
+export function buildUpdatedRecord(item: CollectionItem, key: string, value: unknown): CollectionItem {
+  if (value === undefined) {
+    const { [key]: __omit, ...rest } = item;
+    return rest;
+  }
+  return { ...item, [key]: value };
+}
+
 /** Empty for required-field validation — NOT a truthiness check (a
  *  numeric `0` is a filled value). */
 function isMissingDraftValue(value: unknown): boolean {

--- a/test/utils/collections/test_draft.ts
+++ b/test/utils/collections/test_draft.ts
@@ -1,0 +1,52 @@
+// Unit tests for the inline-edit pure helpers in
+// src/utils/collections/draft.ts (used by the collections table's
+// checkbox/dropdown cells). No Vue, no I/O.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildUpdatedRecord, coerceInlineValue } from "../../../src/utils/collections/draft.js";
+import type { FieldSpec } from "../../../src/components/collectionTypes.js";
+
+const boolField: FieldSpec = { type: "boolean", label: "Done" };
+const enumField: FieldSpec = { type: "enum", label: "Status", values: ["todo", "doing", "done"] };
+
+describe("coerceInlineValue", () => {
+  it("coerces a checkbox value to a strict boolean", () => {
+    assert.equal(coerceInlineValue(boolField, true), true);
+    assert.equal(coerceInlineValue(boolField, false), false);
+    // Anything other than a literal `true` is `false`, matching draftToRecord.
+    assert.equal(coerceInlineValue(boolField, "on"), false);
+  });
+
+  it("passes a non-empty enum selection through unchanged", () => {
+    assert.equal(coerceInlineValue(enumField, "doing"), "doing");
+  });
+
+  it("treats the empty enum placeholder as a clear (undefined)", () => {
+    assert.equal(coerceInlineValue(enumField, ""), undefined);
+  });
+});
+
+describe("buildUpdatedRecord", () => {
+  it("sets the key to the new value without mutating the input", () => {
+    const item = { id: "mon", done: false };
+    const next = buildUpdatedRecord(item, "done", true);
+    assert.deepEqual(next, { id: "mon", done: true });
+    assert.notStrictEqual(next, item);
+    assert.equal(item.done, false); // original untouched
+  });
+
+  it("omits the key when the value is undefined (cleared field)", () => {
+    const item = { id: "mon", status: "done" };
+    const next = buildUpdatedRecord(item, "status", undefined);
+    assert.deepEqual(next, { id: "mon" });
+    assert.equal("status" in next, false);
+  });
+
+  it("preserves all other keys", () => {
+    const item = { id: "mon", status: "todo", note: "yoga", count: 3 };
+    const next = buildUpdatedRecord(item, "status", "done");
+    assert.deepEqual(next, { id: "mon", status: "done", note: "yoga", count: 3 });
+  });
+});


### PR DESCRIPTION
## Why

A user moved their paper habit tracker into a collection (daily yoga/plank with notifications + completion records) and found marking something done too heavy: row click → Edit → dropdown → Save. They wanted the "tick it like a paper tracker" feel — one tap to record.

Collections already declare `completionField` / `completionDoneValues` in the schema, but the UI had no path to write a field value directly — every mutation went through the detail → edit → save form. This adds inline editing for the two field types where a single tap/select fully expresses the change.

## What

In the **table view only**, `boolean` columns render an inline checkbox and `enum` columns an inline `<select>`. Changing one writes straight to the record — optimistic update, then `PUT .../items/:id`, with rollback + an error banner on failure. Applies to **all** visible boolean/enum columns (not just `completionField`), so it generalizes across collections like a spreadsheet. Calendar view and the detail/edit form are unchanged; all other field types keep the existing flow.

- `@click.stop` on the controls so a cell interaction never opens the row's detail panel
- Enum empty placeholder is offered **only for cells that were empty at load** — a populated enum can't be blanked inline (use the edit form to clear it)
- Boolean: unset (`undefined`) and explicit `false` both render unchecked; a tap writes an explicit boolean

### Files
- `src/utils/collections/draft.ts` — `coerceInlineValue` / `buildUpdatedRecord` pure helpers
- `src/components/CollectionView.vue` — inline controls, `commitInlineEdit` / `applyInlineValue`, `inlineError` banner, load-time empty-enum snapshot
- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — `collectionsView.inlineSaveFailed` (8 locales in lockstep)
- `test/utils/collections/test_draft.ts` — unit tests for the helpers
- `e2e/tests/collection-inline-edit.spec.ts` — table interaction coverage
- `docs/ui-cheatsheet.md` — new `/collections` section

## Test plan
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — all pass
- `yarn test` — full unit suite green (incl. new `test_draft.ts`)
- `yarn test:e2e` — **471 passed**, incl. 5 new inline-edit specs (PUT fires with merged record, enum select, placeholder-only-when-empty, no detail panel on cell click, failed-PUT rollback + banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add inline boolean and enum editing to collection tables with optimistic saves and error handling.

New Features:
- Render boolean fields in collection tables as inline checkboxes that update the record directly on change.
- Render enum fields in collection tables as inline dropdowns that persist the selected value without opening the detail panel.

Enhancements:
- Track which enum cells were empty on initial load so only those offer a clearable placeholder option in the inline dropdowns.
- Introduce pure helpers to coerce inline field values and build updated records for PUT requests to keep persistence semantics consistent with the edit form.

Documentation:
- Document the /collections table view inline editing behavior and related test IDs in the UI cheatsheet.

Tests:
- Add unit tests for the inline-edit helpers used by collection tables.
- Add end-to-end tests covering inline boolean and enum editing, placeholder behavior, click suppression of the detail panel, and rollback plus error banner on failed saves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline table cell editing for boolean (checkbox) and enum (dropdown) fields in collections with optimistic updates and rollback on failure.
  * Per-row gating to prevent edit races and inline error banner when saves fail.

* **Documentation**
  * Added comprehensive collections view and inline-editing documentation.

* **Tests**
  * New end-to-end tests for inline edit flows and unit tests for value coercion/record updates.

* **Internationalization**
  * Added inline-save-failed translations in 8 languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmoclaude/pull/1599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->