### PR TITLE
fix(collections): render calendar month/weekday labels in UTC

### DIFF
--- a/src/components/CollectionCalendarView.vue
+++ b/src/components/CollectionCalendarView.vue
@@ -173,7 +173,9 @@ const undatedEntries = computed<CalendarEntry[]>(() => bucketed.value.noDate.map
 
 const monthLabel = computed<string>(() => {
   try {
-    return new Intl.DateTimeFormat(locale.value, { month: "long", year: "numeric" }).format(new Date(Date.UTC(viewYear.value, viewMonth.value - 1, 1)));
+    return new Intl.DateTimeFormat(locale.value, { month: "long", year: "numeric", timeZone: "UTC" }).format(
+      new Date(Date.UTC(viewYear.value, viewMonth.value - 1, 1)),
+    );
   } catch {
     return `${viewYear.value}-${String(viewMonth.value).padStart(2, "0")}`;
   }
@@ -182,7 +184,7 @@ const monthLabel = computed<string>(() => {
 /** Localized short weekday names, Sunday-first (matches the grid). */
 const weekdayLabels = computed<string[]>(() => {
   try {
-    const formatter = new Intl.DateTimeFormat(locale.value, { weekday: "short" });
+    const formatter = new Intl.DateTimeFormat(locale.value, { weekday: "short", timeZone: "UTC" });
     // 2024-01-07 is a Sunday — anchor the week there.
     return Array.from({ length: 7 }, (_, idx) => formatter.format(new Date(Date.UTC(2024, 0, 7 + idx))));
   } catch {


### PR DESCRIPTION
## Problem

In the Collections **calendar view**, items appeared shifted by one month. Reported on a machine in `America/Los_Angeles`.

## Root cause

The grid cells and item placement (`buildMonthGrid` / `parseIsoDate` / `spanCoversDay` in `src/utils/collections/calendarGrid.ts`) are all computed in UTC and are correct. But `CollectionCalendarView.vue` formatted **UTC-constructed `Date` objects** through `Intl.DateTimeFormat` *without* `timeZone: "UTC"` for:

- the month header (`monthLabel`)
- the weekday column labels (`weekdayLabels`)

In a negative-offset timezone, `Date.UTC(2026, 5, 1)` (June 1, 00:00 UTC) renders as May 31 locally, so the header read **"May 2026" over a June grid**. The June items sat on correct cells but under a one-month-early header — looking like every item was off by a month. It does not reproduce in JST (+9), which is why it stayed latent.

## Fix

Pin both `Intl.DateTimeFormat` calls to `timeZone: "UTC"` so the labels align with the UTC-based grid in every timezone. `todayKey` already compares civil-date strings against the grid keys, so it needed no change.

## Verification

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass. Confirmed via Node repro that the month label now reads "June 2026" in `America/Los_Angeles`, `America/New_York`, `Asia/Tokyo`, and `Europe/London`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure calendar view month and weekday labels are rendered consistently with the UTC-based calendar grid to avoid timezone-dependent shifts.

Bug Fixes:
- Fix calendar view month header displaying the wrong month in negative-offset timezones by formatting dates in UTC.
- Fix weekday column labels in the calendar view so they align with the UTC-based grid across timezones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar month and weekday labels to display consistently regardless of the user's local timezone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->