### PR TITLE
fix(stack): taller card for presentMulmoScript so deck preview fits

### DIFF
--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -101,7 +101,7 @@
            h-full continue to render properly. Map groups pass the
            ordered `results` so the View replays the whole group onto
            one map; everything else uses the single `selected-result`. -->
-        <div v-else :style="{ height: PLUGIN_HEIGHT }">
+        <div v-else :style="{ height: pluginHeightFor(item.head.toolName) }">
           <component
             :is="getPlugin(item.head.toolName)?.viewComponent"
             v-if="getPlugin(item.head.toolName)?.viewComponent"
@@ -142,6 +142,20 @@ const { t } = useI18n();
 // height is required for them to render. text-response and the
 // "stack-natural" plugins below are special-cased.
 const PLUGIN_HEIGHT = "min(60vh, 560px)";
+
+// Per-tool height overrides. presentMulmoScript's deck-editor renders
+// a 16:9 slide preview inside an iframe; at the default 560px cap, the
+// chrome above (header + toolbar + script-source summary) leaves the
+// preview shorter than what a 16:9 slide needs to fit, and the bottom
+// of the rendered slide ends up clipped. A taller cap lets the slide
+// render in full without letterboxing.
+const PLUGIN_HEIGHT_OVERRIDES: Record<string, string> = {
+  [TOOL_NAMES.presentMulmoScript]: "min(85vh, 820px)",
+};
+
+function pluginHeightFor(toolName: string): string {
+  return PLUGIN_HEIGHT_OVERRIDES[toolName] ?? PLUGIN_HEIGHT;
+}
 
 // How long to ignore scroll-spy after a programmatic scroll (sidebar
 // click, auto-scroll on new result). Keeps the spy from emitting a

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -123,7 +123,7 @@
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { getPlugin } from "../tools";
-import { TOOL_NAMES } from "../config/toolNames";
+import { TOOL_NAMES, type ToolName } from "../config/toolNames";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { View as TextResponseOriginalView } from "../plugins/textResponse/index";
 import { handleExternalLinkClick } from "../utils/dom/externalLink";
@@ -141,7 +141,7 @@ const { t } = useI18n();
 // Most plugin viewComponents use h-full internally, so a defined parent
 // height is required for them to render. text-response and the
 // "stack-natural" plugins below are special-cased.
-const PLUGIN_HEIGHT = "min(60vh, 560px)";
+const DEFAULT_PLUGIN_HEIGHT = "min(60vh, 560px)";
 
 // Per-tool height overrides. presentMulmoScript's deck-editor renders
 // a 16:9 slide preview inside an iframe; at the default 560px cap, the
@@ -149,12 +149,18 @@ const PLUGIN_HEIGHT = "min(60vh, 560px)";
 // preview shorter than what a 16:9 slide needs to fit, and the bottom
 // of the rendered slide ends up clipped. A taller cap lets the slide
 // render in full without letterboxing.
-const PLUGIN_HEIGHT_OVERRIDES: Record<string, string> = {
+// `satisfies Partial<Record<ToolName, string>>` keys this off the
+// canonical `TOOL_NAMES` union so a typo'd or stale tool name fails at
+// compile time instead of silently falling through to the default.
+const PLUGIN_HEIGHT_OVERRIDES = {
   [TOOL_NAMES.presentMulmoScript]: "min(85vh, 820px)",
-};
+} satisfies Partial<Record<ToolName, string>>;
 
 function pluginHeightFor(toolName: string): string {
-  return PLUGIN_HEIGHT_OVERRIDES[toolName] ?? PLUGIN_HEIGHT;
+  // Indexed lookup is wide-string-keyed; the `satisfies` constraint
+  // above already ensures the literal's keys are valid `ToolName`s.
+  const overrides: Record<string, string | undefined> = PLUGIN_HEIGHT_OVERRIDES;
+  return overrides[toolName] ?? DEFAULT_PLUGIN_HEIGHT;
 }
 
 // How long to ignore scroll-spy after a programmatic scroll (sidebar


### PR DESCRIPTION
## Summary

`StackView` caps every plugin-View card at \`min(60vh, 560px)\`. presentMulmoScript's deck-editor mode renders a 16:9 slide preview inside that card; with the cap, the header + toolbar + script-source-summary chrome above the iframe leaves the preview shorter than what a 16:9 layout needs, and the bottom row of slide content gets clipped off the visible edge.

Per-tool height override map keyed off \`TOOL_NAMES.presentMulmoScript\` lifts the cap to \`min(85vh, 820px)\` for this plugin only. Other plugins keep \`min(60vh, 560px)\`.

## Items to Confirm / Review

- **Scope**: only \`presentMulmoScript\` changes; no other plugin is touched. The override is a plain map so future plugin-specific bumps are one-line additions.
- **Height value**: \`min(85vh, 820px)\` — 85% of viewport on small screens (laptops at 800px high → ~680px usable; full-screen 1080p → 820px cap kicks in). Compared to the prior 60vh / 560px, this is ~+50% taller. Tried 75vh first; still slightly clipping on the multi-column slide layouts the user tested.
- **Stack mode only**: \`single\` layout already uses full canvas height (no PLUGIN_HEIGHT path), so it's unaffected.
- **The presentMulmoScript fallback beat-list also gets the taller card.** Acceptable — more beats fit per scroll, matches user expectation for a long-running canvas.

## User prompt

> presentMulmoScriptでdeck表示時にlive previewがせまくてスライド全体が見えない。cardの高さ調整などをして全体をみえるようにして。

(Same chat also asked for PDF generation — that's a separate follow-up, larger surface area.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust plugin card height handling in StackView to support a taller layout for specific tools, notably presentMulmoScript's deck editor.

Enhancements:
- Introduce a per-tool height override mechanism for plugin cards in StackView.
- Increase the card height limit for presentMulmoScript to allow its 16:9 slide preview to render fully without clipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin card rendering to prevent content clipping by introducing per-tool height overrides so different plugin types display correctly (including a taller cap for a specific tool).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->