### PR TITLE
feat(collections): add Kanban board view grouped by an enum field

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -399,7 +399,7 @@ The preview pane reuses plugin views — clicking a `config/scheduler/items.json
 
 ```
 ┌─[<CollectionView> — /collections/:slug]────────────────────────────────┐
-│ Toolbar: [Table | Calendar | Kanban] toggle · search · [+ add]          │
+│ Toolbar: [collection-view-toggle-table | -calendar | -kanban] · search  │
 │                                                                         │
 │ [collections-inline-error] (banner, only after a failed inline write)   │
 │ ┌─Table──────────────────────────────────────────────────────────────┐ │
@@ -416,7 +416,7 @@ The preview pane reuses plugin views — clicking a `config/scheduler/items.json
 
 `boolean` columns render an inline checkbox and `enum` columns an inline `<select>` directly in the table cell — changing one writes the value straight to the record (`PUT .../items/:id`, optimistic + rollback on failure) without opening the detail panel. The controls use `@click.stop` so the cell click never bubbles into the row's `openView`. All other field types (and the full edit form) still go through the row → `[collections-detail]` → Edit → Save flow.
 
-The **Calendar** toggle (`[collection-view-toggle-calendar]`) appears only when the schema has a `date` field; the **Kanban** toggle (`[collection-view-toggle-kanban]`) only when it has an `enum` field. `<CollectionKanbanView>` groups records into columns by the chosen enum field (declared `values` order + a trailing **Uncategorized** column for empty/unknown values), with a `[collection-kanban-field]` selector when >1 enum field exists. Dragging a card (`[collection-kanban-card-<id>]`) between columns writes the group field via the same inline-edit PUT (no column drag, no within-column ordering); a card whose group field is hidden by a `when` predicate is omitted from the board. Card click opens the same detail panel below the board.
+The **Calendar** toggle (`[collection-view-toggle-calendar]`) appears only when the schema has a `date` field; the **Kanban** toggle (`[collection-view-toggle-kanban]`) only when it has an `enum` field. `<CollectionKanbanView>` groups records into columns by the chosen enum field (declared `values` order + a trailing **Uncategorized** column for empty/unknown values — omitted when the chosen enum is declared `required`), with a `[collection-kanban-field]` selector when >1 enum field exists. Dragging a card (`[collection-kanban-card-<id>]`) between columns writes the group field via the same inline-edit PUT (no column drag, no within-column ordering); a card whose group field is hidden by a `when` predicate is omitted from the board. Card click opens the same detail panel below the board.
 
 ## /skills — workspace skills list
 

--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -399,7 +399,7 @@ The preview pane reuses plugin views — clicking a `config/scheduler/items.json
 
 ```
 ┌─[<CollectionView> — /collections/:slug]────────────────────────────────┐
-│ Toolbar: [Table | Calendar] toggle · search · [+ add]                   │
+│ Toolbar: [Table | Calendar | Kanban] toggle · search · [+ add]          │
 │                                                                         │
 │ [collections-inline-error] (banner, only after a failed inline write)   │
 │ ┌─Table──────────────────────────────────────────────────────────────┐ │
@@ -415,6 +415,8 @@ The preview pane reuses plugin views — clicking a `config/scheduler/items.json
 ```
 
 `boolean` columns render an inline checkbox and `enum` columns an inline `<select>` directly in the table cell — changing one writes the value straight to the record (`PUT .../items/:id`, optimistic + rollback on failure) without opening the detail panel. The controls use `@click.stop` so the cell click never bubbles into the row's `openView`. All other field types (and the full edit form) still go through the row → `[collections-detail]` → Edit → Save flow.
+
+The **Calendar** toggle (`[collection-view-toggle-calendar]`) appears only when the schema has a `date` field; the **Kanban** toggle (`[collection-view-toggle-kanban]`) only when it has an `enum` field. `<CollectionKanbanView>` groups records into columns by the chosen enum field (declared `values` order + a trailing **Uncategorized** column for empty/unknown values), with a `[collection-kanban-field]` selector when >1 enum field exists. Dragging a card (`[collection-kanban-card-<id>]`) between columns writes the group field via the same inline-edit PUT (no column drag, no within-column ordering); a card whose group field is hidden by a `when` predicate is omitted from the board. Card click opens the same detail panel below the board.
 
 ## /skills — workspace skills list
 

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -275,6 +275,11 @@ const CollectionSchemaZ = z
     // Multi-day span end: a second `date` field the calendar record spans
     // to. Requires `calendarField`; validated to name a real `date` field.
     calendarEndField: z.string().trim().min(1).optional(),
+    // Kanban board group: names an `enum` field whose value buckets each
+    // record into a column. Validated to name a real `enum` field by a
+    // refine below. Optional — the toggle auto-derives from any `enum`
+    // field when this is unset.
+    kanbanField: z.string().trim().min(1).optional(),
   })
   // The singleton value becomes a record id (and thus a `<id>.json`
   // filename), so it must satisfy the SAME `safeSlugName` rule the
@@ -394,6 +399,13 @@ const CollectionSchemaZ = z
   .refine((schema) => schema.calendarEndField === undefined || schema.fields[schema.calendarEndField]?.type === "date", {
     message: "schema `calendarEndField` must name a top-level `date` field declared in `fields`",
     path: ["calendarEndField"],
+  })
+  // `kanbanField` must name a real `enum` field — the board groups records
+  // into one column per declared enum value; any other type has no closed
+  // set of columns to group by.
+  .refine((schema) => schema.kanbanField === undefined || schema.fields[schema.kanbanField]?.type === "enum", {
+    message: "schema `kanbanField` must name a top-level `enum` field declared in `fields`",
+    path: ["kanbanField"],
   });
 
 interface LoadedCollection {

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -259,6 +259,14 @@ export interface CollectionSchema {
    *  date inclusive. Requires `calendarField`. Must name a real `date`
    *  field. Absent ⇒ single-day placement. */
   calendarEndField?: string;
+  /** Name of an `enum` field that groups records into columns on the
+   *  optional Kanban board: each record lands in the column matching its
+   *  value, with empty/unknown values collected in an "Uncategorized"
+   *  column. When unset, the Kanban toggle still appears if the schema has
+   *  any `enum` field (the first one, in declaration order, is used by
+   *  default and is switchable in-view). Set this to pin a specific group
+   *  field. Must name a real `enum` field. */
+  kanbanField?: string;
 }
 
 export interface CollectionSummary {

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -101,7 +101,11 @@ const groupSpec = computed(() => props.schema.fields[props.groupField]);
 const columns = computed<KanbanColumn[]>(() => {
   const values = groupSpec.value?.values ?? [];
   const declared = values.map((value) => ({ value, label: value }));
-  if (groupSpec.value?.required) return declared;
+  // Skip the trailing Uncategorized column when the group field is
+  // `required` (no valid "no value" state), or when the enum already
+  // declares an empty-string value (it would collide with the
+  // Uncategorized sentinel's `value`/`:key`).
+  if (groupSpec.value?.required || values.includes(UNCATEGORIZED)) return declared;
   return [...declared, { value: UNCATEGORIZED, label: t("collectionsView.kanbanUncategorized") }];
 });
 

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -1,0 +1,153 @@
+<template>
+  <div class="h-full overflow-x-auto overflow-y-hidden" data-testid="collection-kanban">
+    <div class="flex gap-3 h-full p-1 min-w-max">
+      <div
+        v-for="column in columns"
+        :key="column.value"
+        :data-testid="`collection-kanban-column-${column.value || 'uncategorized'}`"
+        class="w-72 shrink-0 flex flex-col bg-slate-100 rounded-lg"
+      >
+        <!-- Column header (columns are NOT draggable: order is fixed by the
+             enum's declared `values`). -->
+        <div class="flex items-center justify-between px-3 py-2 border-b border-slate-200">
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="column.value ? 'bg-indigo-400' : 'bg-slate-300'" />
+            <span class="font-semibold text-xs text-slate-600 truncate" :title="column.label">{{ column.label }}</span>
+          </div>
+          <span class="text-[11px] text-slate-400 shrink-0">{{ itemsByColumn(column.value).length }}</span>
+        </div>
+
+        <!-- Cards. Dragging a card to another column writes the group field
+             (no manual ordering within a column). -->
+        <draggable
+          :model-value="itemsByColumn(column.value)"
+          :item-key="schema.primaryKey"
+          group="collection-kanban-cards"
+          class="flex-1 overflow-y-auto p-2 space-y-2 min-h-[2rem]"
+          :animation="150"
+          @change="(e: DragChangeEvent) => onDragChange(column.value, e)"
+        >
+          <template #item="{ element }: { element: CollectionItem }">
+            <div
+              :data-testid="`collection-kanban-card-${itemId(element)}`"
+              tabindex="0"
+              role="button"
+              :aria-label="t('collectionsView.kanbanOpenCard', { label: itemLabel(element) })"
+              class="bg-white border border-slate-200 rounded shadow-sm p-2 cursor-grab hover:shadow active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+              :class="itemId(element) === selected ? 'ring-2 ring-indigo-500 border-indigo-300' : ''"
+              @click="emit('select', itemId(element))"
+              @keydown.enter.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
+              @keydown.space.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
+            >
+              <div class="text-sm font-medium text-slate-800 truncate">{{ itemLabel(element) }}</div>
+            </div>
+          </template>
+        </draggable>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import draggable from "vuedraggable";
+import { fieldVisible } from "../utils/collections/actionVisible";
+import type { CollectionItem, CollectionSchema } from "./collectionTypes";
+
+// vuedraggable @change shape — same three keys as the todo board. We act
+// only on "added" (the destination column): a cross-column move emits a
+// paired "removed" on the source, and "moved" is a within-column reorder
+// we deliberately ignore (no manual ordering).
+interface DragChangeEvent {
+  added?: { newIndex: number; element: CollectionItem };
+  moved?: { newIndex: number; oldIndex: number; element: CollectionItem };
+  removed?: { oldIndex: number; element: CollectionItem };
+}
+
+const props = defineProps<{
+  schema: CollectionSchema;
+  /** The `enum` field whose value groups records into columns. */
+  groupField: string;
+  items: CollectionItem[];
+  /** Primary-key of the currently-open record (highlighted card). */
+  selected?: string;
+}>();
+
+const emit = defineEmits<{
+  select: [id: string | null];
+  /** Card dropped in a column: set the group field to `value` (the empty
+   *  string means the Uncategorized column → clear the field). */
+  move: [id: string, value: string];
+}>();
+
+const { t } = useI18n();
+
+/** The Uncategorized column uses the empty string as its sentinel value. */
+const UNCATEGORIZED = "";
+
+interface KanbanColumn {
+  value: string;
+  label: string;
+}
+
+const groupSpec = computed(() => props.schema.fields[props.groupField]);
+
+/** Declared enum values become columns in order, with a trailing
+ *  Uncategorized column for empty/unknown values (also a drop target that
+ *  clears the field). The Uncategorized column is omitted when the group
+ *  field is `required` — there's no valid "no value" state to drop into,
+ *  and clearing via it would only produce a rejected PUT. */
+const columns = computed<KanbanColumn[]>(() => {
+  const values = groupSpec.value?.values ?? [];
+  const declared = values.map((value) => ({ value, label: value }));
+  if (groupSpec.value?.required) return declared;
+  return [...declared, { value: UNCATEGORIZED, label: t("collectionsView.kanbanUncategorized") }];
+});
+
+function itemId(item: CollectionItem): string {
+  return String(item[props.schema.primaryKey] ?? "");
+}
+
+/** Card label: the schema's `displayField` value, else the primary key. */
+function itemLabel(item: CollectionItem): string {
+  const field = props.schema.displayField;
+  if (field) {
+    const value = item[field];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return itemId(item);
+}
+
+/** Which column a record belongs to: its group value when that value is
+ *  one of the declared enum values, else Uncategorized. */
+function columnOf(item: CollectionItem): string {
+  const raw = item[props.groupField];
+  if (raw === undefined || raw === null || raw === "") return UNCATEGORIZED;
+  const value = String(raw);
+  return (groupSpec.value?.values ?? []).includes(value) ? value : UNCATEGORIZED;
+}
+
+// Records to place on the board. A record whose group field is hidden by a
+// `when` predicate is dropped entirely (its column membership is undefined
+// while hidden), per the Kanban spec.
+const visibleItems = computed<CollectionItem[]>(() => (groupSpec.value ? props.items.filter((item) => fieldVisible(groupSpec.value, item)) : []));
+
+const itemsByColumnMap = computed<Map<string, CollectionItem[]>>(() => {
+  const map = new Map<string, CollectionItem[]>();
+  for (const column of columns.value) map.set(column.value, []);
+  for (const item of visibleItems.value) {
+    const value = columnOf(item);
+    (map.get(value) ?? map.get(UNCATEGORIZED))?.push(item);
+  }
+  return map;
+});
+
+function itemsByColumn(value: string): CollectionItem[] {
+  return itemsByColumnMap.value.get(value) ?? [];
+}
+
+function onDragChange(columnValue: string, event: DragChangeEvent): void {
+  if (event.added) emit("move", itemId(event.added.element), columnValue);
+}
+</script>

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -221,6 +221,25 @@
            collections. The board groups records into columns by the chosen
            enum field; dragging a card between columns writes that field. -->
       <div v-else-if="kanbanActive" class="h-full flex flex-col">
+        <!-- Inline-edit failure banner: a card drop (group-field write) was
+             rolled back. The detail panel's `saveError` isn't shown during a
+             drag, so inline edits surface their own — same as the table. -->
+        <div
+          v-if="inlineError"
+          class="m-3 mb-0 rounded-xl border border-red-200 bg-red-50/50 p-4 text-sm text-red-800 shadow-sm flex items-center gap-3"
+          data-testid="collections-inline-error"
+        >
+          <span class="material-icons text-red-600">error</span>
+          <span class="flex-1">{{ t("collectionsView.inlineSaveFailed", { error: inlineError }) }}</span>
+          <button
+            type="button"
+            class="h-8 w-8 flex items-center justify-center rounded text-red-600 hover:bg-red-100"
+            :aria-label="t('common.close')"
+            @click="inlineError = null"
+          >
+            <span class="material-icons text-base">close</span>
+          </button>
+        </div>
         <div class="flex-1 min-h-0 px-3 py-2">
           <CollectionKanbanView
             :schema="collection.schema"
@@ -1374,8 +1393,11 @@ watch(
 
 // Embedded mode: report view/anchor changes so the chat card persists them
 // in `viewState` (alongside `selected`). No-op in standalone route mode.
-watch([view, calendarAnchorField, kanbanGroupField], () => {
-  if (embedded.value) emit("viewStateChange", { view: view.value, anchorField: calendarAnchorField.value, groupField: kanbanGroupField.value });
+watch([activeView, calendarAnchorField, kanbanGroupField], () => {
+  // Persist the EFFECTIVE view (activeView), not the raw `view` ref — a
+  // stale "calendar"/"kanban" that has fallen back to "table" (its enabling
+  // field gone) must not be saved as an impossible mode.
+  if (embedded.value) emit("viewStateChange", { view: activeView.value, anchorField: calendarAnchorField.value, groupField: kanbanGroupField.value });
 });
 
 // React to the active selection changing while already on this

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -64,7 +64,10 @@
     <!-- Search Toolbar. Shown when there are items to search OR when the
          calendar toggle is available — the toggle must reach an empty
          date-bearing collection so its empty-day create affordance works. -->
-    <div v-if="collection && (items.length > 0 || hasCalendar)" class="px-6 py-3 bg-white border-b border-slate-100 flex items-center justify-between gap-4">
+    <div
+      v-if="collection && (items.length > 0 || hasCalendar || hasKanban)"
+      class="px-6 py-3 bg-white border-b border-slate-100 flex items-center justify-between gap-4"
+    >
       <div v-if="items.length > 0" class="relative flex-1 max-w-md">
         <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400 pointer-events-none">
           <span class="material-icons text-lg">search</span>
@@ -87,14 +90,15 @@
         </button>
       </div>
       <div class="flex items-center gap-2">
-        <!-- View toggle: table ↔ calendar. Shown only when the schema has a
-             `date` field; local UI state, never persisted. -->
-        <div v-if="hasCalendar" class="flex gap-0.5" role="group" :aria-label="t('collectionsView.viewToggle')">
+        <!-- View toggle: table ↔ calendar ↔ kanban. Calendar shows only when
+             the schema has a `date` field, kanban only with an `enum` field;
+             local UI state, never persisted. -->
+        <div v-if="hasCalendar || hasKanban" class="flex gap-0.5" role="group" :aria-label="t('collectionsView.viewToggle')">
           <button
             type="button"
             class="h-8 px-2.5 flex items-center gap-1 rounded text-xs font-bold transition-colors"
-            :class="!calendarActive ? 'bg-indigo-600 text-white' : 'bg-white text-slate-500 border border-slate-200 hover:bg-slate-50'"
-            :aria-pressed="!calendarActive"
+            :class="activeView === 'table' ? 'bg-indigo-600 text-white' : 'bg-white text-slate-500 border border-slate-200 hover:bg-slate-50'"
+            :aria-pressed="activeView === 'table'"
             data-testid="collection-view-toggle-table"
             @click="setView('table')"
           >
@@ -102,15 +106,28 @@
             <span>{{ t("collectionsView.viewTable") }}</span>
           </button>
           <button
+            v-if="hasCalendar"
             type="button"
             class="h-8 px-2.5 flex items-center gap-1 rounded text-xs font-bold transition-colors"
-            :class="calendarActive ? 'bg-indigo-600 text-white' : 'bg-white text-slate-500 border border-slate-200 hover:bg-slate-50'"
-            :aria-pressed="calendarActive"
+            :class="activeView === 'calendar' ? 'bg-indigo-600 text-white' : 'bg-white text-slate-500 border border-slate-200 hover:bg-slate-50'"
+            :aria-pressed="activeView === 'calendar'"
             data-testid="collection-view-toggle-calendar"
             @click="setView('calendar')"
           >
             <span class="material-icons text-sm">calendar_month</span>
             <span>{{ t("collectionsView.viewCalendar") }}</span>
+          </button>
+          <button
+            v-if="hasKanban"
+            type="button"
+            class="h-8 px-2.5 flex items-center gap-1 rounded text-xs font-bold transition-colors"
+            :class="activeView === 'kanban' ? 'bg-indigo-600 text-white' : 'bg-white text-slate-500 border border-slate-200 hover:bg-slate-50'"
+            :aria-pressed="activeView === 'kanban'"
+            data-testid="collection-view-toggle-kanban"
+            @click="setView('kanban')"
+          >
+            <span class="material-icons text-sm">view_kanban</span>
+            <span>{{ t("collectionsView.viewKanban") }}</span>
           </button>
         </div>
         <!-- Which date field anchors the grid (only when >1 date field). -->
@@ -123,6 +140,17 @@
           @change="anchorOverride = ($event.target as HTMLSelectElement).value"
         >
           <option v-for="key in dateFields" :key="key" :value="key">{{ collection?.schema.fields[key]?.label ?? key }}</option>
+        </select>
+        <!-- Which enum field groups the board (only when >1 enum field). -->
+        <select
+          v-if="kanbanActive && enumFields.length > 1"
+          :value="kanbanGroupField"
+          class="h-8 px-2 rounded border border-slate-200 bg-white text-xs font-semibold text-slate-600 focus:outline-none focus:border-indigo-500 cursor-pointer"
+          :aria-label="t('collectionsView.kanbanFieldLabel')"
+          data-testid="collection-kanban-field"
+          @change="kanbanOverride = ($event.target as HTMLSelectElement).value"
+        >
+          <option v-for="key in enumFields" :key="key" :value="key">{{ collection?.schema.fields[key]?.label ?? key }}</option>
         </select>
         <div v-if="items.length > 0" class="text-[10px] text-slate-400 font-bold uppercase tracking-wider select-none">
           {{ t("collectionsView.searchSummary", { shown: filteredItems.length, total: items.length }) }}
@@ -163,6 +191,50 @@
           v-if="viewing || editing"
           class="mt-4 rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden"
           data-testid="collections-calendar-panel"
+        >
+          <CollectionRecordPanel
+            v-model:editing="editing"
+            :collection="collection"
+            :viewing="viewing"
+            :saving="saving"
+            :save-error="saveError"
+            :action-error="actionError"
+            :action-pending="actionPending"
+            :visible-actions="visibleActions"
+            :live-record="liveRecord"
+            :live-derived="liveDerived"
+            :view-title="viewTitle"
+            :is-singleton="isSingleton"
+            :render="render"
+            :locale="locale"
+            @submit="saveEditor"
+            @cancel="cancelEditor"
+            @edit="editFromView"
+            @close="closeView"
+            @delete="viewing && confirmDelete(viewing)"
+            @run-action="runAction"
+          />
+        </div>
+      </div>
+
+      <!-- Kanban body: an alternative to the table for enum-bearing
+           collections. The board groups records into columns by the chosen
+           enum field; dragging a card between columns writes that field. -->
+      <div v-else-if="kanbanActive" class="h-full flex flex-col">
+        <div class="flex-1 min-h-0 px-3 py-2">
+          <CollectionKanbanView
+            :schema="collection.schema"
+            :items="filteredItems"
+            :group-field="kanbanGroupField"
+            :selected="viewing ? String(viewing[collection.schema.primaryKey] ?? '') : undefined"
+            @select="onCalendarSelect"
+            @move="onKanbanMove"
+          />
+        </div>
+        <div
+          v-if="viewing || editing"
+          class="m-3 mt-0 rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden shrink-0"
+          data-testid="collections-kanban-panel"
         >
           <CollectionRecordPanel
             v-model:editing="editing"
@@ -459,6 +531,7 @@ import { BUILTIN_ROLE_IDS } from "../config/roles";
 import ConfirmModal from "./ConfirmModal.vue";
 import CollectionRecordPanel from "./CollectionRecordPanel.vue";
 import CollectionCalendarView from "./CollectionCalendarView.vue";
+import CollectionKanbanView from "./CollectionKanbanView.vue";
 import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
@@ -489,10 +562,12 @@ const props = defineProps<{
   slug?: string;
   selected?: string;
   sendTextMessage?: (text?: string) => void;
-  /** Embedded mode only: initial view / anchor restored from the card's
-   *  persisted `viewState` so a switch to calendar survives a remount. */
-  initialView?: "table" | "calendar";
+  /** Embedded mode only: initial view / anchor / group restored from the
+   *  card's persisted `viewState` so a switch to calendar or kanban
+   *  survives a remount. */
+  initialView?: "table" | "calendar" | "kanban";
   initialAnchorField?: string;
+  initialGroupField?: string;
 }>();
 
 const emit = defineEmits<{
@@ -500,9 +575,10 @@ const emit = defineEmits<{
    *  The card persists this in its tool-result `viewState` so the open
    *  item survives a re-render. */
   select: [id: string | null];
-  /** Embedded mode only: the view mode / calendar anchor changed. The
-   *  card persists these alongside `selected` so the calendar sticks. */
-  viewStateChange: [state: { view: "table" | "calendar"; anchorField: string }];
+  /** Embedded mode only: the view mode / calendar anchor / kanban group
+   *  changed. The card persists these alongside `selected` so the calendar
+   *  and kanban stick. */
+  viewStateChange: [state: { view: "table" | "calendar" | "kanban"; anchorField: string; groupField: string }];
 }>();
 
 const { t, locale } = useI18n();
@@ -820,12 +896,13 @@ const canDeleteCollection = computed<boolean>(() => {
   return current.source === "project" && !current.slug.startsWith("mc-");
 });
 
-// ── View mode (table | calendar) ──────────────────────────────────
+// ── View mode (table | calendar | kanban) ─────────────────────────
 // Local UI state only — NEVER persisted to schema. The user toggles it;
 // the host never flips it programmatically. The calendar is offered only
-// when the schema has a `date` field, so date-less collections and the
-// initial load are unchanged (default "table").
-type CollectionViewMode = "table" | "calendar";
+// when the schema has a `date` field and the kanban only when it has an
+// `enum` field, so plain collections and the initial load are unchanged
+// (default "table").
+type CollectionViewMode = "table" | "calendar" | "kanban";
 const view = ref<CollectionViewMode>(props.initialView ?? "table");
 
 /** `date` fields in declaration order — the calendar can anchor on any. */
@@ -840,9 +917,43 @@ const dateFields = computed<string[]>(() =>
 /** Whether the table ↔ calendar toggle is offered. */
 const hasCalendar = computed<boolean>(() => dateFields.value.length > 0);
 
-/** True when the calendar is the active body (guards against a stale
- *  `view = "calendar"` lingering after switching to a date-less one). */
-const calendarActive = computed<boolean>(() => view.value === "calendar" && hasCalendar.value);
+/** `enum` fields in declaration order — the kanban can group on any. */
+const enumFields = computed<string[]>(() =>
+  collection.value
+    ? Object.entries(collection.value.schema.fields)
+        .filter(([, field]) => field.type === "enum")
+        .map(([key]) => key)
+    : [],
+);
+
+/** Whether the kanban toggle is offered (needs an `enum` field to group on). */
+const hasKanban = computed<boolean>(() => enumFields.value.length > 0);
+
+/** The effective view, collapsing any stale mode whose enabling field
+ *  vanished (e.g. `view = "kanban"` after switching to an enum-less
+ *  collection) back to "table". Single source of truth for the toggle and
+ *  the body branches. */
+const activeView = computed<CollectionViewMode>(() => {
+  if (view.value === "calendar" && hasCalendar.value) return "calendar";
+  if (view.value === "kanban" && hasKanban.value) return "kanban";
+  return "table";
+});
+
+/** True when the calendar is the active body. */
+const calendarActive = computed<boolean>(() => activeView.value === "calendar");
+
+/** True when the kanban is the active body. */
+const kanbanActive = computed<boolean>(() => activeView.value === "kanban");
+
+// In-view override for which enum field groups the board; null ⇒ the schema
+// hint, else the first enum field.
+const kanbanOverride = ref<string | null>(props.initialGroupField ?? null);
+const kanbanGroupField = computed<string>(() => {
+  if (kanbanOverride.value && enumFields.value.includes(kanbanOverride.value)) return kanbanOverride.value;
+  const hint = collection.value?.schema.kanbanField;
+  if (hint && enumFields.value.includes(hint)) return hint;
+  return enumFields.value[0] ?? "";
+});
 
 // In-view override for which date field anchors the grid; null ⇒ the
 // schema hint, else the first date field.
@@ -1211,9 +1322,9 @@ function createOnDate(iso: string): void {
   if (editing.value && anchor) editing.value.text[anchor] = iso;
 }
 
-/** Calendar chip click → open that record's detail below the grid (or
- *  close when the calendar reports a deselect). Unlike `openView`, this
- *  never toggles — a second click on the same chip keeps it open. */
+/** Calendar chip / kanban card click → open that record's detail below the
+ *  grid (or close when a deselect is reported). Unlike `openView`, this
+ *  never toggles — a second click on the same record keeps it open. */
 function onCalendarSelect(itemId: string | null): void {
   if (!itemId) {
     closeView();
@@ -1225,6 +1336,17 @@ function onCalendarSelect(itemId: string | null): void {
   showDetail(item);
 }
 
+/** Kanban card dropped in a column → set the record's group field to the
+ *  column value (the empty string clears it for the Uncategorized column).
+ *  Reuses the inline-edit path (optimistic write + PUT + rollback). */
+function onKanbanMove(itemId: string, value: string): void {
+  const item = findItemById(itemId);
+  const key = kanbanGroupField.value;
+  const field = collection.value?.schema.fields[key];
+  if (!item || !field) return;
+  void commitInlineEdit(item, key, field, value);
+}
+
 watch(
   activeSlug,
   (slug, prevSlug) => {
@@ -1234,6 +1356,7 @@ watch(
     if (prevSlug !== undefined && slug !== prevSlug) {
       view.value = "table";
       anchorOverride.value = null;
+      kanbanOverride.value = null;
     }
     if (slug) {
       loadCollection(slug);
@@ -1251,8 +1374,8 @@ watch(
 
 // Embedded mode: report view/anchor changes so the chat card persists them
 // in `viewState` (alongside `selected`). No-op in standalone route mode.
-watch([view, calendarAnchorField], () => {
-  if (embedded.value) emit("viewStateChange", { view: view.value, anchorField: calendarAnchorField.value });
+watch([view, calendarAnchorField, kanbanGroupField], () => {
+  if (embedded.value) emit("viewStateChange", { view: view.value, anchorField: calendarAnchorField.value, groupField: kanbanGroupField.value });
 });
 
 // React to the active selection changing while already on this

--- a/src/components/collectionTypes.ts
+++ b/src/components/collectionTypes.ts
@@ -82,6 +82,11 @@ export interface CollectionSchema {
   /** Name of a second `date` field marking the END of a multi-day span
    *  on the calendar. Requires `calendarField`. */
   calendarEndField?: string;
+  /** Name of an `enum` field grouping records into columns on the optional
+   *  Kanban board. When unset, the toggle still appears if any `enum` field
+   *  exists (the first one, in declaration order, is the default and is
+   *  switchable in-view). */
+  kanbanField?: string;
 }
 
 export interface CollectionDetail {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1368,6 +1368,10 @@ const deMessages = {
     calendarToday: "Heute",
     calendarNoDate: "Kein Datum",
     calendarCreateOn: "Am {date} erstellen",
+    viewKanban: "Kanban",
+    kanbanFieldLabel: "Kanban-Gruppierungsfeld",
+    kanbanUncategorized: "Nicht kategorisiert",
+    kanbanOpenCard: "{label} öffnen",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1349,6 +1349,10 @@ const enMessages = {
     calendarToday: "Today",
     calendarNoDate: "No date",
     calendarCreateOn: "Create on {date}",
+    viewKanban: "Kanban",
+    kanbanFieldLabel: "Kanban group field",
+    kanbanUncategorized: "Uncategorized",
+    kanbanOpenCard: "Open {label}",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1363,6 +1363,10 @@ const esMessages = {
     calendarToday: "Hoy",
     calendarNoDate: "Sin fecha",
     calendarCreateOn: "Crear el {date}",
+    viewKanban: "Kanban",
+    kanbanFieldLabel: "Campo de agrupación Kanban",
+    kanbanUncategorized: "Sin categoría",
+    kanbanOpenCard: "Abrir {label}",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1358,6 +1358,10 @@ const frMessages = {
     calendarToday: "Aujourd'hui",
     calendarNoDate: "Sans date",
     calendarCreateOn: "Créer le {date}",
+    viewKanban: "Kanban",
+    kanbanFieldLabel: "Champ de regroupement Kanban",
+    kanbanUncategorized: "Non classé",
+    kanbanOpenCard: "Ouvrir {label}",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1346,6 +1346,10 @@ const jaMessages = {
     calendarToday: "今日",
     calendarNoDate: "日付なし",
     calendarCreateOn: "{date} に作成",
+    viewKanban: "カンバン",
+    kanbanFieldLabel: "カンバンのグループフィールド",
+    kanbanUncategorized: "未分類",
+    kanbanOpenCard: "{label} を開く",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1349,6 +1349,10 @@ const koMessages = {
     calendarToday: "오늘",
     calendarNoDate: "날짜 없음",
     calendarCreateOn: "{date}에 생성",
+    viewKanban: "칸반",
+    kanbanFieldLabel: "칸반 그룹 필드",
+    kanbanUncategorized: "미분류",
+    kanbanOpenCard: "{label} 열기",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1352,6 +1352,10 @@ const ptBRMessages = {
     calendarToday: "Hoje",
     calendarNoDate: "Sem data",
     calendarCreateOn: "Criar em {date}",
+    viewKanban: "Kanban",
+    kanbanFieldLabel: "Campo de agrupamento do Kanban",
+    kanbanUncategorized: "Sem categoria",
+    kanbanOpenCard: "Abrir {label}",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1339,6 +1339,10 @@ const zhMessages = {
     calendarToday: "今天",
     calendarNoDate: "无日期",
     calendarCreateOn: "在 {date} 创建",
+    viewKanban: "看板",
+    kanbanFieldLabel: "看板分组字段",
+    kanbanUncategorized: "未分类",
+    kanbanOpenCard: "打开 {label}",
     source: {
       user: "用户",
       project: "项目",

--- a/src/plugins/presentCollection/View.vue
+++ b/src/plugins/presentCollection/View.vue
@@ -6,6 +6,7 @@
       :selected="selected"
       :initial-view="viewState?.view"
       :initial-anchor-field="viewState?.anchorField"
+      :initial-group-field="viewState?.groupField"
       :send-text-message="sendTextMessage"
       @select="onSelect"
       @view-state-change="onViewStateChange"
@@ -25,8 +26,9 @@ import type { PresentCollectionData } from "./types";
  *  keep the table↔calendar choice and calendar anchor sticky. */
 interface PresentCollectionViewState {
   selected?: string | null;
-  view?: "table" | "calendar";
+  view?: "table" | "calendar" | "kanban";
   anchorField?: string;
+  groupField?: string;
 }
 
 const props = defineProps<{
@@ -63,11 +65,14 @@ function onSelect(itemId: string | null): void {
   emit("updateResult", { ...props.selectedResult, viewState: { ...viewState.value, selected: itemId } });
 }
 
-function onViewStateChange(state: { view: "table" | "calendar"; anchorField: string }): void {
+function onViewStateChange(state: { view: "table" | "calendar" | "kanban"; anchorField: string; groupField: string }): void {
   if (!props.selectedResult) return;
-  // Skip redundant writes (the anchor settling on load fires this once).
+  // Skip redundant writes (the anchor/group settling on load fires this once).
   const current = viewState.value;
-  if (current?.view === state.view && current?.anchorField === state.anchorField) return;
-  emit("updateResult", { ...props.selectedResult, viewState: { ...current, view: state.view, anchorField: state.anchorField } });
+  if (current?.view === state.view && current?.anchorField === state.anchorField && current?.groupField === state.groupField) return;
+  emit("updateResult", {
+    ...props.selectedResult,
+    viewState: { ...current, view: state.view, anchorField: state.anchorField, groupField: state.groupField },
+  });
 }
 </script>

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -1079,6 +1079,45 @@ describe("discoverCollections — calendarField + calendarEndField validation", 
   });
 });
 
+describe("discoverCollections — kanbanField validation", () => {
+  // A collection with an enum field, cloned + mutated per case.
+  function kanbanSchema(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      title: "Tasks",
+      icon: "checklist",
+      dataPath: "data/tasks/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+        status: { type: "enum", label: "Status", values: ["Todo", "Done"] },
+      },
+      ...extra,
+    };
+  }
+
+  it("accepts a schema with no kanbanField (toggle auto-derives from the enum field)", async () => {
+    writeSkill("test-kanban-none", kanbanSchema());
+    assert.equal((await listCollections()).length, 1);
+  });
+
+  it("accepts a valid kanbanField and preserves it through parsing", async () => {
+    writeSkill("test-kanban-ok", kanbanSchema({ kanbanField: "status" }));
+    const collection = await loadCollection("test-kanban-ok", { workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+    assert.equal(collection?.schema.kanbanField, "status");
+  });
+
+  it("rejects kanbanField naming a non-enum field", async () => {
+    writeSkill("test-kanban-non-enum", kanbanSchema({ kanbanField: "name" }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects kanbanField naming a missing field", async () => {
+    writeSkill("test-kanban-missing", kanbanSchema({ kanbanField: "nope" }));
+    assert.equal((await listCollections()).length, 0);
+  });
+});
+
 describe("loadCollection", () => {
   it("returns the named project-scope collection", async () => {
     writeSkill("test-load", {


### PR DESCRIPTION
## What

Adds a **Kanban** view to Collections, alongside the existing table and calendar views. The toggle (`[collection-view-toggle-kanban]`) appears whenever a collection schema has any `enum` field — the same pattern as the calendar toggle being gated on `date` fields.

The board groups records into columns by an enum field; dragging a card to another column writes that field.

## Design decisions (as agreed)

1. **Schema hint** — new `kanbanField?: string` on `CollectionSchema` (server + frontend types) picks the grouping enum. When unset, the first enum field is used, switchable in-view via a `[collection-kanban-field]` selector when >1 enum field exists.
2. **Uncategorized column** — a trailing column collects records with empty/unknown values (and is a drop target that clears the field). It is **hidden when the group enum is `required`** (no valid "no value" state; clearing would only produce a rejected PUT). Records whose group field is hidden by a `when` predicate are omitted from the board entirely.
3. **No column dragging** — column order is fixed by the enum's declared `values`.
4. **No within-column ordering** — only cross-column moves (which change the enum value) are persisted; `moved`/`removed` drag events are ignored.

## How it works

- `<CollectionKanbanView>` is presentational (drag via `vuedraggable`, controlled `:model-value`), modeled on `<CollectionCalendarView>`.
- Card drops route through the existing `commitInlineEdit` path — optimistic write + `PUT .../items/:id` + rollback on failure. **No server changes.**
- Card click opens the same `CollectionRecordPanel` below the board (identical to calendar).
- Embedded chat card (`presentCollection`) persists `view: "kanban"` and the chosen group field across remounts.

## Files

- `src/components/CollectionKanbanView.vue` (new)
- `src/components/CollectionView.vue` — view-mode union, toggle, body branch, `onKanbanMove`
- `server/workspace/collections/types.ts` + `src/components/collectionTypes.ts` — `kanbanField` hint
- `src/plugins/presentCollection/View.vue` — viewState persistence
- `src/lang/*.ts` — `viewKanban` / `kanbanFieldLabel` / `kanbanUncategorized` / `kanbanOpenCard` (all 8 locales)
- `docs/ui-cheatsheet.md` — `/collections` block updated

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass. Manually verified in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Kanban board view for collections that groups records by enum fields alongside the existing table and calendar views.

New Features:
- Introduce a Kanban view in CollectionView that groups records into columns by a chosen enum field and supports drag-and-drop card moves to update that field.
- Allow users to choose which enum field groups the Kanban board when multiple enum fields exist via an in-view selector.
- Persist the selected view mode (table, calendar, or kanban) and associated anchor/group fields for embedded collection presentations.

Enhancements:
- Extend collection schema types on both server and frontend with an optional kanbanField hint to control the default grouping field for the Kanban view.
- Unify view-mode handling in CollectionView via a generalized activeView state that safely falls back when calendar or Kanban prerequisites are missing.

Documentation:
- Update the UI cheatsheet to document the new Kanban toggle, board behavior, and interaction model in the collections view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kanban view toggle in the collection toolbar with per-collection grouping by enum fields, an "Uncategorized" column, card click opening the detail panel, and drag-and-drop between columns that updates a card’s group (optimistic update with rollback).
  * Option to pin/select which enum field is used for Kanban; embedded state now persists Kanban view and group choice.

* **Documentation**
  * Updated UI cheatsheet with Kanban behavior and when Calendar vs Kanban appear.

* **Internationalization**
  * Added Kanban UI strings in EN, DE, ES, FR, JA, KO, PT-BR, ZH.

* **Tests**
  * Added validation tests for Kanban field configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->