### PR TITLE
feat(collections): `toggle` field + `notifyWhen` bell gate (Todo-as-collection)

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -418,6 +418,8 @@ The preview pane reuses plugin views — clicking a `config/scheduler/items.json
 
 The **Calendar** toggle (`[collection-view-toggle-calendar]`) appears only when the schema has a `date` field; the **Kanban** toggle (`[collection-view-toggle-kanban]`) only when it has an `enum` field. `<CollectionKanbanView>` groups records into columns by the chosen enum field (declared `values` order + a trailing **Uncategorized** column for empty/unknown values — omitted when the chosen enum is declared `required`), with a `[collection-kanban-field]` selector when >1 enum field exists. Dragging a card (`[collection-kanban-card-<id>]`) between columns writes the group field via the same inline-edit PUT (no column drag, no within-column ordering); a card whose group field is hidden by a `when` predicate is omitted from the board. Card click opens the same detail panel below the board.
 
+A `toggle` field is a checkbox that **projects** an `enum` field (stores nothing itself): checked when the enum equals its `onValue`, toggling writes `onValue`/`offValue` back to that enum. It renders inline in the table (`[collections-inline-toggle-<key>-<id>]`) and on the kanban card (`[collection-kanban-toggle-<id>]`, shown when it projects the board's group field — checking it also moves the card). This is how a todo-style "done" checkbox fronts a kanban `status` while keeping the enum as the single source of truth.
+
 ## /skills — workspace skills list
 
 Two-pane layout (`<ManageSkillsView>`): left sidebar = two collapsible

--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -113,7 +113,7 @@ const SubFieldSpecSchema = z
 
 const FieldSpecSchema = z
   .object({
-    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived", "embed", "image"]),
+    type: z.enum(["string", "text", "email", "number", "date", "boolean", "markdown", "ref", "money", "enum", "table", "derived", "embed", "image", "toggle"]),
     label: z.string().min(1),
     primary: z.boolean().optional(),
     required: z.boolean().optional(),
@@ -122,6 +122,12 @@ const FieldSpecSchema = z
     currency: z.string().trim().min(1).optional(),
     currencyField: z.string().trim().min(1).optional(),
     values: z.array(z.string().trim().min(1)).min(1).optional(),
+    // `toggle` projection: the enum field it fronts + the checked/unchecked
+    // values written to it. Validated against the target enum's `values` by
+    // a schema-level refine below.
+    field: z.string().trim().min(1).optional(),
+    onValue: z.string().trim().min(1).optional(),
+    offValue: z.string().trim().min(1).optional(),
     of: z.record(z.string(), SubFieldSpecSchema).optional(),
     formula: z.string().trim().min(1).optional(),
     /** Inner type to render a derived value as (e.g. `"money"`).
@@ -147,7 +153,16 @@ const FieldSpecSchema = z
   .refine((spec) => spec.type !== "derived" || (typeof spec.formula === "string" && spec.formula.length > 0), {
     message: "fields with type 'derived' must declare a non-empty `formula` (see src/utils/collections/derivedFormula.ts)",
     path: ["formula"],
-  });
+  })
+  .refine(
+    (spec) =>
+      spec.type !== "toggle" ||
+      (typeof spec.field === "string" && spec.field.length > 0 && typeof spec.onValue === "string" && typeof spec.offValue === "string"),
+    {
+      message: "fields with type 'toggle' must declare `field` (the enum field to project), `onValue`, and `offValue`",
+      path: ["field"],
+    },
+  );
 
 // A schema-declared record action. Domain-free: the host validates the
 // shape; the meaning (which role, which template) is data.
@@ -209,6 +224,23 @@ function collectCurrencyFieldRefs(fields: Record<string, FieldLike>): string[] {
     }
   }
   return refs;
+}
+
+// True iff every `toggle` field is a valid projection: its `field` names a
+// top-level `enum`, and both `onValue` and `offValue` are members of that
+// enum's closed `values` set.
+function everyToggleProjectsValidEnum(
+  fields: Record<string, { type: string; field?: string; onValue?: string; offValue?: string; values?: readonly string[] }>,
+): boolean {
+  for (const spec of Object.values(fields)) {
+    if (spec.type !== "toggle") continue;
+    const target = spec.field === undefined ? undefined : fields[spec.field];
+    if (!target || target.type !== "enum" || target.values === undefined) return false;
+    const allowed = new Set(target.values);
+    if (spec.onValue === undefined || !allowed.has(spec.onValue)) return false;
+    if (spec.offValue === undefined || !allowed.has(spec.offValue)) return false;
+  }
+  return true;
 }
 
 // True iff a `spawn`'s successor will NOT be born already matching its own
@@ -280,6 +312,10 @@ const CollectionSchemaZ = z
     // refine below. Optional — the toggle auto-derives from any `enum`
     // field when this is unset.
     kanbanField: z.string().trim().min(1).optional(),
+    // Completion-bell gate: only notify for records matching this predicate
+    // (e.g. high-priority todos). Reuses the `when` shape; requires
+    // `completionField`; field validated to exist by refines below.
+    notifyWhen: WhenSchema.optional(),
   })
   // The singleton value becomes a record id (and thus a `<id>.json`
   // filename), so it must satisfy the SAME `safeSlugName` rule the
@@ -406,6 +442,24 @@ const CollectionSchemaZ = z
   .refine((schema) => schema.kanbanField === undefined || schema.fields[schema.kanbanField]?.type === "enum", {
     message: "schema `kanbanField` must name a top-level `enum` field declared in `fields`",
     path: ["kanbanField"],
+  })
+  // A `toggle` field projects an `enum` field: its `field` must name a real
+  // top-level enum, and `onValue` / `offValue` must be members of that
+  // enum's `values` — otherwise toggling would write a value outside the
+  // closed set (and never appear "checked").
+  .refine((schema) => everyToggleProjectsValidEnum(schema.fields), {
+    message: "a `toggle` field's `field` must name a top-level `enum` field, and its `onValue`/`offValue` must be values of that enum",
+    path: ["fields"],
+  })
+  // `notifyWhen` narrows the completion bell, so it only means something with
+  // completion tracking, and its `field` must name a real top-level field.
+  .refine((schema) => schema.notifyWhen === undefined || schema.completionField !== undefined, {
+    message: "schema `notifyWhen` requires `completionField` (it narrows that bell)",
+    path: ["notifyWhen"],
+  })
+  .refine((schema) => schema.notifyWhen === undefined || schema.fields[schema.notifyWhen.field] !== undefined, {
+    message: "schema `notifyWhen.field` must name a top-level field declared in `fields`",
+    path: ["notifyWhen"],
   });
 
 interface LoadedCollection {

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -42,7 +42,7 @@ import { errorMessage } from "../../utils/errors.js";
 import { loadCollection, type DiscoveryOptions } from "./discovery.js";
 import { listItems, readItem, type IoOptions } from "./io.js";
 import { isTriggerDue, maybeSpawnSuccessor } from "./spawn.js";
-import type { CollectionItem, CollectionSchema } from "./types.js";
+import type { CollectionItem, CollectionSchema, CollectionWhen } from "./types.js";
 
 /** The legacy-id prefix every collection-completion bell entry carries.
  *  Used both to build new ids and to filter sweep candidates from the
@@ -67,6 +67,16 @@ function parseCompletionLegacyId(legacyId: string): { slug: string; itemId: stri
   const colon = body.indexOf(":");
   if (colon < 0) return null;
   return { slug: body.slice(0, colon), itemId: body.slice(colon + 1) };
+}
+
+/** Evaluate a `notifyWhen` predicate against a record — the server-side twin
+ *  of the frontend `whenMatches` (`src/utils/collections/actionVisible.ts`).
+ *  Absent predicate ⇒ always true; a missing/null field ⇒ no match. */
+function predicateMatches(when: CollectionWhen | undefined, item: CollectionItem): boolean {
+  if (!when) return true;
+  const raw = item[when.field];
+  if (raw === undefined || raw === null) return false;
+  return when.in.includes(String(raw));
 }
 
 /** The human-readable label shown in a completion notification's
@@ -268,6 +278,13 @@ export async function reconcileItem(
       return;
     }
   }
+  // Condition gate: when the schema declares `notifyWhen`, only bell records
+  // matching the predicate (e.g. high-priority todos). Convergent like the
+  // gates above — a record that stops matching has its bell cleared.
+  if (!predicateMatches(schema.notifyWhen, item)) {
+    await clearItemNotification(slug, itemId);
+    return;
+  }
   await ensureItemNotification(slug, schema, itemId, resolveDisplayLabel(schema, item, itemId));
 }
 
@@ -331,7 +348,7 @@ export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Prom
         continue;
       }
       const item = await readItem(collection.dataDir, itemId, opts);
-      if (item === null || itemIsDone(collection.schema, item)) {
+      if (item === null || itemIsDone(collection.schema, item) || !predicateMatches(collection.schema.notifyWhen, item)) {
         await notifierClear(entry.id);
       }
     } catch (err) {

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -39,10 +39,11 @@ import {
 import { clear as notifierClear, listAll, publish as notifierPublish } from "../../notifier/engine.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
+import { whenMatches } from "../../../src/utils/collections/actionVisible.js";
 import { loadCollection, type DiscoveryOptions } from "./discovery.js";
 import { listItems, readItem, type IoOptions } from "./io.js";
 import { isTriggerDue, maybeSpawnSuccessor } from "./spawn.js";
-import type { CollectionItem, CollectionSchema, CollectionWhen } from "./types.js";
+import type { CollectionItem, CollectionSchema } from "./types.js";
 
 /** The legacy-id prefix every collection-completion bell entry carries.
  *  Used both to build new ids and to filter sweep candidates from the
@@ -69,15 +70,9 @@ function parseCompletionLegacyId(legacyId: string): { slug: string; itemId: stri
   return { slug: body.slice(0, colon), itemId: body.slice(colon + 1) };
 }
 
-/** Evaluate a `notifyWhen` predicate against a record — the server-side twin
- *  of the frontend `whenMatches` (`src/utils/collections/actionVisible.ts`).
- *  Absent predicate ⇒ always true; a missing/null field ⇒ no match. */
-function predicateMatches(when: CollectionWhen | undefined, item: CollectionItem): boolean {
-  if (!when) return true;
-  const raw = item[when.field];
-  if (raw === undefined || raw === null) return false;
-  return when.in.includes(String(raw));
-}
+// `notifyWhen` is evaluated with the SAME `whenMatches` the frontend uses for
+// field/action visibility (`src/utils/collections/actionVisible.ts`) — one
+// predicate implementation, so client and server can't drift.
 
 /** The human-readable label shown in a completion notification's
  *  title. Uses the schema's `displayField` value when declared and
@@ -281,7 +276,7 @@ export async function reconcileItem(
   // Condition gate: when the schema declares `notifyWhen`, only bell records
   // matching the predicate (e.g. high-priority todos). Convergent like the
   // gates above — a record that stops matching has its bell cleared.
-  if (!predicateMatches(schema.notifyWhen, item)) {
+  if (!whenMatches(schema.notifyWhen, item)) {
     await clearItemNotification(slug, itemId);
     return;
   }
@@ -348,7 +343,7 @@ export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Prom
         continue;
       }
       const item = await readItem(collection.dataDir, itemId, opts);
-      if (item === null || itemIsDone(collection.schema, item) || !predicateMatches(collection.schema.notifyWhen, item)) {
+      if (item === null || itemIsDone(collection.schema, item) || !whenMatches(collection.schema.notifyWhen, item)) {
         await notifierClear(entry.id);
       }
     } catch (err) {

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -29,7 +29,13 @@ export type CollectionFieldType =
   // upload); rendered as an <img> in the detail view (not the list table —
   // a per-row fetch is too expensive at scale). Stored and edited as a
   // plain string.
-  | "image";
+  | "image"
+  // A checkbox that is a pure PROJECTION of an `enum` field — it stores
+  // nothing of its own. Checked when the enum equals `onValue`; toggling
+  // writes `onValue` / `offValue` back to that enum field. Lets a "done"
+  // checkbox front a kanban `status` field with the enum as the single
+  // source of truth (no separate stored boolean to keep in sync).
+  | "toggle";
 
 export type CollectionSource = "user" | "project";
 
@@ -192,6 +198,19 @@ export interface CollectionFieldSpec {
    *  must name another top-level field. Absent ⇒ always shown. Only
    *  honoured on top-level fields, not inside a `table`'s `of`. */
   when?: CollectionWhen;
+  /** When `type === "toggle"`: the name of the top-level `enum` field this
+   *  checkbox projects. The toggle stores nothing itself — it reads and
+   *  writes this field. Required when type is `toggle`; ignored otherwise.
+   *  Must name a real `enum` field. */
+  field?: string;
+  /** When `type === "toggle"`: the enum value that means "checked". The
+   *  box is checked when the projected `field` equals this; checking writes
+   *  it. Required when type is `toggle`; must be one of the enum's `values`. */
+  onValue?: string;
+  /** When `type === "toggle"`: the enum value written when the box is
+   *  unchecked. Required when type is `toggle`; must be one of the enum's
+   *  `values`. */
+  offValue?: string;
 }
 
 export interface CollectionSchema {
@@ -267,6 +286,15 @@ export interface CollectionSchema {
    *  default and is switchable in-view). Set this to pin a specific group
    *  field. Must name a real `enum` field. */
   kanbanField?: string;
+  /** Optional predicate that gates the completion bell: when set, the bell
+   *  fires only for records whose `String(record[notifyWhen.field])` is one
+   *  of `notifyWhen.in` (e.g. notify only `high`/`urgent` priority todos).
+   *  Reuses the `when` predicate shape. Requires `completionField` — it
+   *  narrows that bell rather than introducing a second one. The bell still
+   *  clears on done / delete / when the predicate stops matching. Absent ⇒
+   *  notify for every open record (the prior behaviour). `notifyWhen.field`
+   *  must name a real top-level field. */
+  notifyWhen?: CollectionWhen;
 }
 
 export interface CollectionSummary {

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -526,92 +526,19 @@ Notes:
 - Like the calendar, the board is purely a **rendering** of the records: it adds
   no storage. `completionField` / `completionDoneValues` (bells) are independent
   but pair naturally with the Done column.
-- For the full, copy-pasteable todo schema (status enum + done toggle + priority
-  + bells + calendar), see **"Worked example: a Todo list"** below.
+- **Building a todo / task list?** Read `config/helps/todo-collection.md` — the
+  complete, copy-pasteable recipe (status enum + `done` toggle + priority bells +
+  calendar) plus the legacy-`todo-plugin` migration steps.
 
 ### Worked example: a Todo list
 
-This is the canonical recipe — a single schema that gives you a kanban board, a
-table with an inline done checkbox, a due-date calendar, and completion bells,
-with the `status` enum as the **single source of truth** (no separate stored
-`done` boolean).
-
-`data/skills/todos/schema.json`:
-
-```json
-{
-  "title": "Todos",
-  "icon": "check_circle",
-  "dataPath": "data/todos/items",
-  "primaryKey": "id",
-  "fields": {
-    "id":       { "type": "string", "label": "ID", "primary": true, "required": true },
-    "done":     { "type": "toggle", "label": "Done", "field": "status", "onValue": "Done", "offValue": "Todo" },
-    "title":    { "type": "string", "label": "Title", "required": true },
-    "status":   { "type": "enum",   "label": "Status", "values": ["Backlog", "Todo", "In Progress", "Done"], "required": true },
-    "priority": { "type": "enum",   "label": "Priority", "values": ["low", "medium", "high", "urgent"] },
-    "dueDate":  { "type": "date",   "label": "Due" },
-    "note":     { "type": "markdown", "label": "Note" }
-  },
-  "displayField": "title",
-  "kanbanField": "status",
-  "calendarField": "dueDate",
-  "completionField": "status",
-  "completionDoneValues": ["Done"],
-  "notifyWhen": { "field": "priority", "in": ["high", "urgent"] }
-}
-```
-
-`data/skills/todos/SKILL.md` — front-matter `name: todos` + a one-line
-`description`, then the record-shape bullets (id is the filename; `status` is the
-column; leave `done` OUT of the JSON — it's a projection of `status`) and the
-CRUD conventions.
-
-A record (`data/todos/items/t-0042.json`) — note there is **no `done` key**:
-
-```json
-{ "id": "t-0042", "title": "Buy milk", "status": "Todo", "priority": "high", "dueDate": "2026-06-10" }
-```
-
-What you get from this one schema, with no host code:
-
-- **Table** — a `done` checkbox per row (checking it sets `status: "Done"`), plus
-  inline `status` / `priority` dropdowns.
-- **Kanban** — columns Backlog / Todo / In Progress / Done; drag a card to move
-  it (writes `status`); the per-card `done` checkbox does the same.
-- **Calendar** — todos placed on their `dueDate`.
-- **Completion bell** — fires on create, clears when `status` reaches `Done`.
-
-**Reminder timing (optional).** To make the bell fire on the due date instead of
-on create, add `"triggerField": "dueDate"` (and `"triggerLeadDays": 2` to fire it
-N days early). `triggerField` must name a real `date` field and reuses the
-completion pair above.
-
-**Priority-gated notifications (`notifyWhen`).** By default the completion bell
-fires for *every* open record. Add `notifyWhen` to fire it only for records
-matching a predicate — here, only `high`/`urgent` priority todos raise a bell
-(`low`/`medium` stay silent), reproducing the legacy Todo's priority behaviour.
-The bell still clears on done / delete, and also clears when the predicate stops
-matching (e.g. priority dropped to `low`). `notifyWhen` reuses the `when` shape
-and requires `completionField` (it narrows that bell rather than adding a second
-one). It does NOT vary the badge *color* by value — the bell uses the completion
-bell's standard severity; per-value severity (red vs amber) isn't modelled.
-
-**Migrating the legacy `todo-plugin`.** Old records live at
-`data/plugins/%40mulmoclaude%2Ftodo-plugin/todos.json` (an array) with columns in
-the sibling `columns.json`. Map them onto the schema above:
-
-- Use the legacy `columns.json` ids as the `status` enum `values` (keep the
-  user's own columns — e.g. `["todo", "mulmoclaude", "mag2", "done"]`), and set
-  `completionDoneValues` to the column whose `isDone` is true.
-- Fold the legacy `completed` boolean into `status` (a completed item → the
-  done column). Then **add the `done` toggle** projecting `status`
-  (`onValue` = the done column, `offValue` = your default open column, e.g.
-  `"todo"`). This is the row/card "done" checkbox — **without it the migrated
-  list has no checkbox**, which is the #1 migration mistake.
-- Preserve each item's `id` verbatim (one `<id>.json` per record), convert the
-  legacy millisecond `createdAt` to a `YYYY-MM-DD` `date`, and carry `priority`,
-  `dueDate`, `note` straight across.
+The full todo recipe — complete `schema.json`, `SKILL.md`, a sample record, and
+the legacy-`todo-plugin` migration steps — has its own file:
+**`config/helps/todo-collection.md`**. Read it whenever you create or migrate a
+todo / task list; it's the canonical template, so copy it rather than assembling
+one from the fragments above. The one rule to remember: the `status` enum is the
+single source of truth and the "done" checkbox is a `toggle` field projecting it
+— **omit the toggle and the list has no checkbox.**
 
 ## Records — one JSON object per file
 

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -102,18 +102,20 @@ skipped, never crashes the host):
 | `actions` | Optional array of per-record buttons (see below). |
 | `completionField` | Optional. Name of the field whose value marks an item as "done" — when set, item-create fires a bell notification that clears once the field reaches one of `completionDoneValues`. Must name a real field in `fields`. Paired with `completionDoneValues` (both set, or both omitted). |
 | `completionDoneValues` | Optional. Non-empty array of values that count as "done" for `completionField` (e.g. `["Done"]`, `["paid", "void"]`). Compared as strings. |
+| `notifyWhen` | Optional. A `when` predicate (`{ "field": "...", "in": [...] }`) that **gates** the completion bell: fire it only for records matching the predicate (e.g. `{ "field": "priority", "in": ["high", "urgent"] }`). Requires `completionField`; `field` must name a real field. Absent ⇒ notify for every open record. |
 | `displayField` | Optional. Name of a field whose value is shown as the human-readable label in the completion notification's title (e.g. `Contacts: Jane Doe` instead of the opaque primaryKey). Must name a real field in `fields`. Falls back to the primaryKey value when unset or when the record's value is empty. |
 | `triggerField` | Optional. Name of a `date` field that **delays** the completion bell until that date arrives (instead of firing on create). Requires `completionField` / `completionDoneValues` (the bell still clears via the done value). Must name a real `date` field. See "Time-gated bells" below. |
 | `triggerLeadDays` | Optional. Non-negative integer: fire the bell this many days **before** `triggerField` (e.g. `10` = "remind me 10 days early"). Requires `triggerField`. Default `0` (fire on the trigger date). |
 | `spawn` | Optional. Host-driven **recurrence**: when a record reaches a configured value (e.g. `status: paid`), the host auto-creates the next record with a forward-advanced `triggerField` date. Requires `triggerField`. See "Recurring obligations" below. |
 | `calendarField` | Optional. Name of a `date` field that anchors the **calendar view** (a month grid; each record lands on its date cell). When unset, the table↔calendar toggle still appears if the schema has any `date` field — the first one is used, switchable in-view. Set this to pin a specific anchor. Must name a real `date` field. See "Calendar view" below. |
 | `calendarEndField` | Optional. A second `date` field marking the END of a multi-day span on the calendar (the record renders across `calendarField` → this date). Requires `calendarField`. Must name a real `date` field. |
+| `kanbanField` | Optional. Name of an `enum` field that groups records into columns on the **Kanban board** (one column per declared value). When unset, the Kanban toggle still appears if the schema has any `enum` field — the first one is used, switchable in-view. Set this to pin a specific group field. Must name a real `enum` field. See "Kanban view" below. |
 
 ### Field types
 
 `string` · `text` (multi-line) · `email` · `number` · `date` (`YYYY-MM-DD`) ·
 `boolean` · `markdown` · `money` · `enum` · `ref` · `embed` · `table` ·
-`derived` · `image`
+`derived` · `image` · `toggle`
 
 Every field spec needs a `type` and a `label`. Extra keys by type:
 
@@ -146,6 +148,19 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
   collection). No extra keys. Great for photos like a business card: read the
   details off the attached image and write its path into the image field.
   Write the bare workspace-relative path — never an `/api/files/raw?...` URL.
+- **`toggle`** — `field: "<enum-field>"`, `onValue`, `offValue`. A checkbox that
+  is a pure **projection** of an `enum` field — it **stores nothing** of its own
+  (like `derived`/`embed`). Checked when the projected enum equals `onValue`;
+  toggling writes `onValue` / `offValue` back to that enum. `onValue`/`offValue`
+  must be members of the enum's `values`. Use it to front a kanban `status` with
+  a "done" checkbox while keeping the enum as the single source of truth — e.g.
+  `{ "type": "toggle", "label": "Done", "field": "status", "onValue": "Done", "offValue": "Todo" }`.
+  Renders an interactive checkbox in the list table and on the kanban card (when
+  it projects the board's group field); read-only in the detail view.
+  **A todo / task list should almost always include one** — it's the row/card
+  "done" checkbox. Without it, `status` only shows as a dropdown and a kanban
+  column, with no checkbox to tick. `offValue` is the status to return to on
+  uncheck (the default open column, e.g. `"Todo"`).
 
 ### Conditional field visibility (`when`)
 
@@ -308,6 +323,12 @@ Set `displayField` to make the bell title readable: with `displayField:
 It must name a real field; an empty value on a given record falls back to the
 primaryKey for that record.
 
+> **Building a todo / task list?** When your `completionField` is a status enum,
+> also add a `toggle` field (the row/card "done" checkbox) and `notifyWhen`
+> (fire the bell only for high-priority items, not every record). See the full
+> recipe in **"Worked example: a Todo list"** below — that's the canonical
+> template; don't reinvent it from these fragments.
+
 ### Time-gated bells (`triggerField`)
 
 By default the completion bell fires **on create**. Add `triggerField` — the
@@ -464,6 +485,134 @@ Notes:
 - This is a generic collection view — distinct from the scheduler's calendar
   (`manageCalendar`), which is a separate built-in.
 
+### Kanban view
+
+Any collection that has at least one `enum` field gains a **Kanban board** toggle
+in its header — **zero config**. The board renders one column per declared enum
+value (in `values` order), plus a trailing **Uncategorized** column for
+empty/unknown values (omitted when the group enum is `required`). Dragging a card
+between columns writes that enum field; clicking a card opens the same
+detail/edit panel.
+
+```json
+{
+  "title": "Tasks",
+  "icon": "checklist",
+  "dataPath": "data/tasks/items",
+  "primaryKey": "id",
+  "fields": {
+    "id":     { "type": "string", "label": "ID", "primary": true, "required": true },
+    "title":  { "type": "string", "label": "Title", "required": true },
+    "status": { "type": "enum",   "label": "Status", "values": ["Backlog", "Todo", "In Progress", "Done"] },
+    "done":   { "type": "toggle", "label": "Done", "field": "status", "onValue": "Done", "offValue": "Todo" }
+  },
+  "displayField": "title",
+  "kanbanField": "status"
+}
+```
+
+Notes:
+
+- **No schema change is needed to get the toggle** — it appears whenever an
+  `enum` field exists. `kanbanField` only *tunes* which enum groups the board
+  (otherwise the first `enum` field is used, switchable in-view).
+- **The enum is the single source of truth.** For a todo-style "done" checkbox,
+  use a `toggle` field projecting the status enum (above) — do NOT add a separate
+  stored boolean. Checking the box sets `status` to the done value (and moves the
+  card to that column); dragging the card to the Done column checks the box. They
+  are the same write.
+- Columns are not draggable (order comes from the enum's `values`) and there is
+  no manual ordering within a column — a drop only changes the enum value.
+- Like the calendar, the board is purely a **rendering** of the records: it adds
+  no storage. `completionField` / `completionDoneValues` (bells) are independent
+  but pair naturally with the Done column.
+- For the full, copy-pasteable todo schema (status enum + done toggle + priority
+  + bells + calendar), see **"Worked example: a Todo list"** below.
+
+### Worked example: a Todo list
+
+This is the canonical recipe — a single schema that gives you a kanban board, a
+table with an inline done checkbox, a due-date calendar, and completion bells,
+with the `status` enum as the **single source of truth** (no separate stored
+`done` boolean).
+
+`data/skills/todos/schema.json`:
+
+```json
+{
+  "title": "Todos",
+  "icon": "check_circle",
+  "dataPath": "data/todos/items",
+  "primaryKey": "id",
+  "fields": {
+    "id":       { "type": "string", "label": "ID", "primary": true, "required": true },
+    "done":     { "type": "toggle", "label": "Done", "field": "status", "onValue": "Done", "offValue": "Todo" },
+    "title":    { "type": "string", "label": "Title", "required": true },
+    "status":   { "type": "enum",   "label": "Status", "values": ["Backlog", "Todo", "In Progress", "Done"], "required": true },
+    "priority": { "type": "enum",   "label": "Priority", "values": ["low", "medium", "high", "urgent"] },
+    "dueDate":  { "type": "date",   "label": "Due" },
+    "note":     { "type": "markdown", "label": "Note" }
+  },
+  "displayField": "title",
+  "kanbanField": "status",
+  "calendarField": "dueDate",
+  "completionField": "status",
+  "completionDoneValues": ["Done"],
+  "notifyWhen": { "field": "priority", "in": ["high", "urgent"] }
+}
+```
+
+`data/skills/todos/SKILL.md` — front-matter `name: todos` + a one-line
+`description`, then the record-shape bullets (id is the filename; `status` is the
+column; leave `done` OUT of the JSON — it's a projection of `status`) and the
+CRUD conventions.
+
+A record (`data/todos/items/t-0042.json`) — note there is **no `done` key**:
+
+```json
+{ "id": "t-0042", "title": "Buy milk", "status": "Todo", "priority": "high", "dueDate": "2026-06-10" }
+```
+
+What you get from this one schema, with no host code:
+
+- **Table** — a `done` checkbox per row (checking it sets `status: "Done"`), plus
+  inline `status` / `priority` dropdowns.
+- **Kanban** — columns Backlog / Todo / In Progress / Done; drag a card to move
+  it (writes `status`); the per-card `done` checkbox does the same.
+- **Calendar** — todos placed on their `dueDate`.
+- **Completion bell** — fires on create, clears when `status` reaches `Done`.
+
+**Reminder timing (optional).** To make the bell fire on the due date instead of
+on create, add `"triggerField": "dueDate"` (and `"triggerLeadDays": 2` to fire it
+N days early). `triggerField` must name a real `date` field and reuses the
+completion pair above.
+
+**Priority-gated notifications (`notifyWhen`).** By default the completion bell
+fires for *every* open record. Add `notifyWhen` to fire it only for records
+matching a predicate — here, only `high`/`urgent` priority todos raise a bell
+(`low`/`medium` stay silent), reproducing the legacy Todo's priority behaviour.
+The bell still clears on done / delete, and also clears when the predicate stops
+matching (e.g. priority dropped to `low`). `notifyWhen` reuses the `when` shape
+and requires `completionField` (it narrows that bell rather than adding a second
+one). It does NOT vary the badge *color* by value — the bell uses the completion
+bell's standard severity; per-value severity (red vs amber) isn't modelled.
+
+**Migrating the legacy `todo-plugin`.** Old records live at
+`data/plugins/%40mulmoclaude%2Ftodo-plugin/todos.json` (an array) with columns in
+the sibling `columns.json`. Map them onto the schema above:
+
+- Use the legacy `columns.json` ids as the `status` enum `values` (keep the
+  user's own columns — e.g. `["todo", "mulmoclaude", "mag2", "done"]`), and set
+  `completionDoneValues` to the column whose `isDone` is true.
+- Fold the legacy `completed` boolean into `status` (a completed item → the
+  done column). Then **add the `done` toggle** projecting `status`
+  (`onValue` = the done column, `offValue` = your default open column, e.g.
+  `"todo"`). This is the row/card "done" checkbox — **without it the migrated
+  list has no checkbox**, which is the #1 migration mistake.
+- Preserve each item's `id` verbatim (one `<id>.json` per record), convert the
+  legacy millisecond `createdAt` to a `YYYY-MM-DD` `date`, and carry `priority`,
+  `dueDate`, `note` straight across.
+
 ## Records — one JSON object per file
 
 - Write each record to `<dataPath>/<id>.json` via the **Write** tool; the `id`
@@ -501,7 +650,10 @@ Notes:
    `dataPath` under the workspace, `triggerField` names a real `date` field and
    has the completion pair, `spawn` has `triggerField` and a valid `every`,
    `calendarField` / `calendarEndField` name real `date` fields (and
-   `calendarEndField` requires `calendarField`).
+   `calendarEndField` requires `calendarField`), `kanbanField` names a real
+   `enum` field, any `toggle` field names a real `enum` `field` with its
+   `onValue` / `offValue` among that enum's `values`, and `notifyWhen` (if set)
+   requires `completionField` and names a real field.
    (A schema that fails validation is logged server-side and silently skipped
    at discovery.)
 

--- a/server/workspace/helps/index.md
+++ b/server/workspace/helps/index.md
@@ -53,6 +53,7 @@ See [Wiki](config/helps/wiki.md) for details on how it works.
 - [Information Sources](config/helps/sources.md) — registering RSS feeds / GitHub repos / arXiv queries, the daily-brief pipeline, and where its files live on disk
 - [GitHub repositories in the workspace](config/helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
 - [Collection skills](config/helps/collection-skills.md) — build a data app (model + UI + relations + computed fields + action buttons) by authoring a `schema.json` collection skill: the DSL, field types, derived formulas, actions, records
+- [Todo list collection](config/helps/todo-collection.md) — the canonical recipe for building or migrating a todo / task list: full schema (status enum + `done` toggle + priority bells), `SKILL.md`, and legacy `todo-plugin` migration steps
 
 ## Workspace Layout
 

--- a/server/workspace/helps/todo-collection.md
+++ b/server/workspace/helps/todo-collection.md
@@ -1,0 +1,140 @@
+# Todo list — the canonical collection recipe
+
+Read this whenever you build (or migrate) a **todo / task list** as a collection.
+It is the authoritative template; copy it rather than reinventing one from the
+generic DSL fragments in `config/helps/collection-skills.md`. Read that file
+first for the general schema rules — this one is the todo-specific specialization.
+
+The design in one line: **the `status` enum is the single source of truth, and
+the "done" checkbox is a `toggle` field that projects it.** There is NO separate
+stored `done` boolean to keep in sync.
+
+> **The #1 mistake:** omitting the `done` toggle. Without it the list still works
+> — but there is **no checkbox**, only a status dropdown and a kanban column.
+> A todo list almost always wants the checkbox. Always include the toggle.
+
+## schema.json
+
+Author it at `data/skills/todos/schema.json` (the bridge mirrors it to
+`.claude/skills/todos/`; the user opens it at `/collections/todos`):
+
+```json
+{
+  "title": "Todos",
+  "icon": "checklist",
+  "dataPath": "data/todos/items",
+  "primaryKey": "id",
+  "fields": {
+    "id":       { "type": "string", "label": "ID", "primary": true, "required": true },
+    "done":     { "type": "toggle", "label": "Done", "field": "status", "onValue": "done", "offValue": "todo" },
+    "text":     { "type": "string", "label": "Task", "required": true },
+    "status":   { "type": "enum",   "label": "Status", "values": ["todo", "doing", "done"], "required": true },
+    "priority": { "type": "enum",   "label": "Priority", "values": ["urgent", "high", "medium", "low"] },
+    "dueDate":  { "type": "date",   "label": "Due" },
+    "note":     { "type": "markdown", "label": "Note" }
+  },
+  "displayField": "text",
+  "kanbanField": "status",
+  "calendarField": "dueDate",
+  "completionField": "status",
+  "completionDoneValues": ["done"],
+  "notifyWhen": { "field": "priority", "in": ["urgent", "high"] }
+}
+```
+
+Every key earns its place:
+
+| Key | What it gives the user |
+|---|---|
+| `done` (`toggle`) | The **checkbox** — in every table row and on every kanban card. Checking it sets `status` to `onValue`; the card jumps to the Done column. `offValue` is the status to return to on uncheck (your default open column). Both must be members of the `status` enum's `values`. |
+| `status` (`enum`) | The kanban columns and the single source of truth for "done". |
+| `kanbanField` | Pins the board to `status` (drag a card → writes `status`). |
+| `displayField` | Card / bell label (the task text, not the opaque id). |
+| `calendarField` | A due-date calendar view (only if you keep `dueDate`). |
+| `completionField` + `completionDoneValues` | The bell: fires while a todo is open, clears when `status` → `done`. |
+| `notifyWhen` | Fire the bell **only** for `urgent`/`high` priority (not every todo). Omit it to bell every open todo. |
+
+## SKILL.md
+
+`data/skills/todos/SKILL.md`:
+
+```markdown
+---
+name: todos
+description: The user's personal todo list. Use whenever they add, list, edit,
+  mark done, or remove a todo ("todo 追加", "やることリスト", "add a todo",
+  "what's on my list?", "mark X as done"). Records live at
+  `data/todos/items/<id>.json`; the user views them at `/collections/todos`.
+---
+
+# Todos (schema-driven collection)
+
+## Record shape
+- `id` — string, primary key (the filename). New items: `todo-<slug>` or
+  `todo-<YYYYMMDDHHmm>`.
+- `text` — the task line (required).
+- `status` — `todo` | `doing` | `done` (required). This IS the done state.
+- `priority` — `urgent` | `high` | `medium` | `low` (optional).
+- `dueDate` — `YYYY-MM-DD` (optional).
+- `note` — markdown (optional; URLs, context).
+- Do NOT write a `done` field — it's a projection of `status`.
+
+## What to do
+- **Add**: derive an id, default `status: "todo"`, Write the JSON.
+- **List**: read `data/todos/items/`, answer from the files; point the user at
+  `/collections/todos` rather than reciting the table.
+- **Mark done**: Read → set `status: "done"` → Write.
+- **Edit / Delete**: Read → mutate / remove the file (preserve untouched fields).
+- After a change, call `presentCollection` with slug `todos` (and the id) to show
+  it inline.
+```
+
+## A record on disk
+
+One JSON per item — note there is **no `done` key**:
+
+```json
+{ "id": "todo-buy-milk", "text": "Buy milk", "status": "todo", "priority": "high", "dueDate": "2026-06-10" }
+```
+
+## What the user gets, with zero host code
+
+- **Table** — a `done` checkbox per row (ticking it sets `status: "done"`), plus
+  inline `status` / `priority` dropdowns.
+- **Kanban** — columns from `status`; drag a card to move it, or tick its
+  per-card `done` checkbox (same write).
+- **Calendar** — todos on their `dueDate`.
+- **Bell** — fires for open `urgent`/`high` todos, clears on done / delete.
+
+## Options
+
+- **Reminder timing.** Add `"triggerField": "dueDate"` to hold the bell until the
+  due date instead of firing on create; add `"triggerLeadDays": 2` to fire it N
+  days early. `triggerField` must name a real `date` field.
+- **Notify on everything.** Drop `notifyWhen` to bell every open todo (not just
+  high priority).
+- **Severity color.** `notifyWhen` controls *whether* the bell fires, not its
+  color — the bell uses the standard severity; per-value red-vs-amber isn't
+  modelled.
+
+## Migrating the legacy `todo-plugin`
+
+Old records live at `data/plugins/%40mulmoclaude%2Ftodo-plugin/todos.json` (a
+single array) with the columns in the sibling `columns.json`. Convert them:
+
+1. **Columns → `status` values.** Use the `columns.json` ids as the `status`
+   enum `values` (keep the user's own columns — e.g.
+   `["todo", "mulmoclaude", "mag2", "done"]`). Set `completionDoneValues` to the
+   column whose `isDone` is `true`, and `kanbanField: "status"`.
+2. **Add the `done` toggle.** `onValue` = the done column, `offValue` = the
+   default open column (e.g. `"todo"`). **Do not skip this** — it's the checkbox
+   the legacy list had.
+3. **Fold `completed` into `status`.** A legacy `completed: true` item belongs in
+   the done column; don't carry a separate boolean.
+4. **One file per item.** Split the array into `data/todos/items/<id>.json`,
+   preserving each legacy `id` verbatim.
+5. **Convert `createdAt`.** The legacy value is Unix milliseconds — convert it to
+   a `YYYY-MM-DD` `date` field. Carry `priority`, `dueDate`, `note` straight
+   across.
+6. Leave the legacy plugin files in place (don't delete) unless the user asks.
+```

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -39,7 +39,22 @@
               @keydown.enter.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
               @keydown.space.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
             >
-              <div class="text-sm font-medium text-slate-800 truncate">{{ itemLabel(element) }}</div>
+              <div class="flex items-start gap-2">
+                <!-- Toggle checkbox (when the schema has a toggle projecting
+                     this board's group field). Checking it sets the group
+                     field, so the card also moves columns. -->
+                <input
+                  v-if="cardToggle"
+                  type="checkbox"
+                  :checked="cardChecked(element)"
+                  class="mt-0.5 h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer shrink-0"
+                  :aria-label="cardToggle.label"
+                  :data-testid="`collection-kanban-toggle-${itemId(element)}`"
+                  @click.stop
+                  @change="onCardToggle(element)"
+                />
+                <div class="text-sm font-medium text-slate-800 truncate">{{ itemLabel(element) }}</div>
+              </div>
             </div>
           </template>
         </draggable>
@@ -153,5 +168,28 @@ function itemsByColumn(value: string): CollectionItem[] {
 
 function onDragChange(columnValue: string, event: DragChangeEvent): void {
   if (event.added) emit("move", itemId(event.added.element), columnValue);
+}
+
+// A `toggle` field that projects THIS board's group field — rendered as a
+// per-card checkbox. Checking it writes the group field (so the card also
+// changes column), reusing the same `move` event as a drag.
+const cardToggle = computed(() => {
+  for (const spec of Object.values(props.schema.fields)) {
+    if (spec.type === "toggle" && spec.field === props.groupField) return spec;
+  }
+  return null;
+});
+
+function cardChecked(item: CollectionItem): boolean {
+  const toggle = cardToggle.value;
+  return toggle !== null && String(item[props.groupField] ?? "") === toggle.onValue;
+}
+
+function onCardToggle(item: CollectionItem): void {
+  const toggle = cardToggle.value;
+  if (!toggle) return;
+  const next = cardChecked(item) ? toggle.offValue : toggle.onValue;
+  if (next === undefined) return;
+  emit("move", itemId(item), next);
 }
 </script>

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -36,8 +36,10 @@
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
       <template v-for="(field, key) in collection.schema.fields" :key="key">
+        <!-- `toggle` is a projection of an enum field — that enum has its own
+             input here, so the toggle isn't a separate editable control. -->
         <div
-          v-if="fieldVisible(field, liveRecord ?? {}) && (!field.primary || editing.mode === 'create')"
+          v-if="field.type !== 'toggle' && fieldVisible(field, liveRecord ?? {}) && (!field.primary || editing.mode === 'create')"
           class="flex flex-col gap-1.5"
           :class="['table', 'markdown', 'embed'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
         >
@@ -313,8 +315,25 @@
           <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
 
           <div class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
+            <!-- Toggle state (read-only reflection of the projected enum). -->
+            <template v-if="field.type === 'toggle'">
+              <span
+                v-if="field.field !== undefined && String(viewing[field.field] ?? '') === field.onValue"
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
+              >
+                <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
+                {{ t("common.yes") }}
+              </span>
+              <span
+                v-else
+                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
+              >
+                {{ t("common.no") }}
+              </span>
+            </template>
+
             <!-- Boolean state -->
-            <template v-if="field.type === 'boolean'">
+            <template v-else-if="field.type === 'boolean'">
               <span
                 v-if="viewing[key] === true"
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -341,12 +341,27 @@
                 <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
                   <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
                   <template v-if="fieldVisible(field, item)">
+                    <!-- Toggle → inline checkbox projecting an enum field.
+                         Stores nothing itself; toggling writes onValue/
+                         offValue to the projected field via the same PUT. -->
+                    <input
+                      v-if="field.type === 'toggle'"
+                      type="checkbox"
+                      :checked="toggleChecked(item, field)"
+                      :disabled="isRowInlineSaving(item)"
+                      class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle disabled:opacity-50 disabled:cursor-not-allowed"
+                      :data-testid="`collections-inline-toggle-${key}-${item[collection.schema.primaryKey]}`"
+                      :aria-label="field.label"
+                      @click.stop
+                      @change="commitToggle(item, field)"
+                    />
+
                     <!-- Boolean → inline checkbox. Tap toggles + saves
                          immediately; `@click.stop` so it doesn't open the
                          row's detail panel. Unset (undefined) and explicit
                          false both render unchecked. -->
                     <input
-                      v-if="field.type === 'boolean'"
+                      v-else-if="field.type === 'boolean'"
                       type="checkbox"
                       :checked="item[key] === true"
                       :disabled="isRowInlineSaving(item)"
@@ -1011,11 +1026,11 @@ function openCreate(): void {
       boolTouched[key] = false;
     } else if (field.type === "table") {
       table[key] = [];
-    } else if (field.type !== "derived" && field.type !== "embed") {
+    } else if (field.type !== "derived" && field.type !== "embed" && field.type !== "toggle") {
       text[key] = "";
     }
-    // derived (computed) and embed (display-only, foreign record)
-    // fields have no draft slot.
+    // derived (computed), embed (display-only, foreign record), and toggle
+    // (projection of an enum field) have no draft slot.
   }
   // Singleton collections fix the primary key to the schema-declared
   // value (e.g. "me") so the first Add can't pick an arbitrary id.
@@ -1051,7 +1066,7 @@ function openEdit(item: CollectionItem): void {
       table[key] = rows
         .filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row))
         .map((row) => rowFromItem(row, sub));
-    } else if (field.type !== "derived" && field.type !== "embed") {
+    } else if (field.type !== "derived" && field.type !== "embed" && field.type !== "toggle") {
       text[key] = raw === undefined || raw === null ? "" : String(raw);
     }
   }
@@ -1273,6 +1288,25 @@ async function commitInlineEdit(item: CollectionItem, key: string, field: FieldS
     applyInlineValue(item, key, previous);
     inlineError.value = result.error;
   }
+}
+
+/** Whether a `toggle` field reads as checked: its projected enum field
+ *  currently equals `onValue`. The toggle stores nothing itself. */
+function toggleChecked(item: CollectionItem, field: FieldSpec): boolean {
+  return field.field !== undefined && String(item[field.field] ?? "") === field.onValue;
+}
+
+/** Flip a `toggle`: write the projected enum field to `offValue` when
+ *  currently checked, else `onValue`. Reuses the inline-edit PUT path
+ *  (optimistic + rollback) — the toggle has no value of its own. */
+function commitToggle(item: CollectionItem, field: FieldSpec): void {
+  const targetKey = field.field;
+  if (!targetKey || !collection.value) return;
+  const enumField = collection.value.schema.fields[targetKey];
+  if (!enumField) return;
+  const next = toggleChecked(item, field) ? field.offValue : field.onValue;
+  if (next === undefined) return;
+  void commitInlineEdit(item, targetKey, enumField, next);
 }
 
 async function confirmDelete(item: CollectionItem): Promise<void> {

--- a/src/components/collectionTypes.ts
+++ b/src/components/collectionTypes.ts
@@ -20,7 +20,8 @@ export type FieldType =
   | "table"
   | "derived"
   | "image"
-  | "embed";
+  | "embed"
+  | "toggle";
 
 export interface FieldSpec {
   type: FieldType;
@@ -49,6 +50,14 @@ export interface FieldSpec {
   /** Optional visibility predicate: render this field only when
    *  `String(record[when.field])` is one of `when.in`. */
   when?: { field: string; in: string[] };
+  /** When type === "toggle": the `enum` field this checkbox projects
+   *  (stores nothing itself — reads + writes that field). */
+  field?: string;
+  /** When type === "toggle": the enum value meaning "checked" (and written
+   *  on check). */
+  onValue?: string;
+  /** When type === "toggle": the enum value written on uncheck. */
+  offValue?: string;
 }
 
 /** A schema-declared, per-record action rendered as a button in the
@@ -87,6 +96,9 @@ export interface CollectionSchema {
    *  exists (the first one, in declaration order, is the default and is
    *  switchable in-view). */
   kanbanField?: string;
+  /** Optional predicate gating the completion bell (server-side); reuses
+   *  the `when` shape. */
+  notifyWhen?: { field: string; in: string[] };
 }
 
 export interface CollectionDetail {

--- a/src/utils/collections/draft.ts
+++ b/src/utils/collections/draft.ts
@@ -81,7 +81,7 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
 export function draftToRecord(state: EditState, schema: CollectionSchema): CollectionItem {
   const record: CollectionItem = {};
   for (const [key, field] of Object.entries(schema.fields)) {
-    if (field.type === "derived" || field.type === "embed") continue; // never persisted
+    if (field.type === "derived" || field.type === "embed" || field.type === "toggle") continue; // never persisted (toggle projects an enum field)
     if (field.type === "boolean") {
       if (shouldEmitBoolean(state, key, field)) record[key] = state.bool[key] === true;
       continue;
@@ -145,7 +145,7 @@ function validateOneField(key: string, field: FieldSpec, draft: EditState, recor
   }
   if (!field.required) return null;
   if (draft.mode === "create" && field.primary === true) return null; // server auto-generates id
-  if (field.type === "boolean" || field.type === "derived" || field.type === "embed") return null;
+  if (field.type === "boolean" || field.type === "derived" || field.type === "embed" || field.type === "toggle") return null;
   return isMissingDraftValue(draft.text[key]) ? field.label : null;
 }
 

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -1163,6 +1163,11 @@ describe("discoverCollections — toggle field validation", () => {
     writeSkill("test-toggle-bad-value", toggleSchema({ field: "status", onValue: "Finished", offValue: "Todo" }));
     assert.equal((await listCollections()).length, 0);
   });
+
+  it("rejects a toggle whose offValue is not one of the enum's values", async () => {
+    writeSkill("test-toggle-bad-off-value", toggleSchema({ field: "status", onValue: "Done", offValue: "Finished" }));
+    assert.equal((await listCollections()).length, 0);
+  });
 });
 
 describe("discoverCollections — notifyWhen validation", () => {

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -1118,6 +1118,91 @@ describe("discoverCollections — kanbanField validation", () => {
   });
 });
 
+describe("discoverCollections — toggle field validation", () => {
+  // A collection with an enum `status` field and a `done` toggle projecting
+  // it, cloned + mutated per case.
+  function toggleSchema(doneField: Record<string, unknown>): Record<string, unknown> {
+    return {
+      title: "Tasks",
+      icon: "checklist",
+      dataPath: "data/tasks/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+        status: { type: "enum", label: "Status", values: ["Todo", "Done"] },
+        done: { type: "toggle", label: "Done", ...doneField },
+      },
+    };
+  }
+
+  it("accepts a valid toggle and preserves it through parsing", async () => {
+    writeSkill("test-toggle-ok", toggleSchema({ field: "status", onValue: "Done", offValue: "Todo" }));
+    const collection = await loadCollection("test-toggle-ok", { workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+    assert.equal(collection?.schema.fields.done?.type, "toggle");
+    assert.equal(collection?.schema.fields.done?.field, "status");
+    assert.equal(collection?.schema.fields.done?.onValue, "Done");
+  });
+
+  it("rejects a toggle missing field/onValue/offValue", async () => {
+    writeSkill("test-toggle-incomplete", toggleSchema({ field: "status" }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a toggle whose field names a non-enum field", async () => {
+    writeSkill("test-toggle-non-enum", toggleSchema({ field: "name", onValue: "Done", offValue: "Todo" }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a toggle whose field names a missing field", async () => {
+    writeSkill("test-toggle-missing-field", toggleSchema({ field: "nope", onValue: "Done", offValue: "Todo" }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a toggle whose onValue is not one of the enum's values", async () => {
+    writeSkill("test-toggle-bad-value", toggleSchema({ field: "status", onValue: "Finished", offValue: "Todo" }));
+    assert.equal((await listCollections()).length, 0);
+  });
+});
+
+describe("discoverCollections — notifyWhen validation", () => {
+  function notifySchema(extra: Record<string, unknown>): Record<string, unknown> {
+    return {
+      title: "Todos",
+      icon: "check_circle",
+      dataPath: "data/todos/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        priority: { type: "enum", label: "Priority", values: ["low", "high"] },
+        status: { type: "enum", label: "Status", values: ["Todo", "Done"], required: true },
+      },
+      completionField: "status",
+      completionDoneValues: ["Done"],
+      ...extra,
+    };
+  }
+
+  it("accepts a valid notifyWhen and preserves it through parsing", async () => {
+    writeSkill("test-notify-ok", notifySchema({ notifyWhen: { field: "priority", in: ["high"] } }));
+    const collection = await loadCollection("test-notify-ok", { workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+    assert.deepEqual(collection?.schema.notifyWhen, { field: "priority", in: ["high"] });
+  });
+
+  it("rejects notifyWhen without completionField", async () => {
+    writeSkill(
+      "test-notify-no-completion",
+      notifySchema({ completionField: undefined, completionDoneValues: undefined, notifyWhen: { field: "priority", in: ["high"] } }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects notifyWhen naming a missing field", async () => {
+    writeSkill("test-notify-missing-field", notifySchema({ notifyWhen: { field: "nope", in: ["high"] } }));
+    assert.equal((await listCollections()).length, 0);
+  });
+});
+
 describe("loadCollection", () => {
   it("returns the named project-scope collection", async () => {
     writeSkill("test-load", {

--- a/test/workspace/collections/test_notifications.ts
+++ b/test/workspace/collections/test_notifications.ts
@@ -457,3 +457,72 @@ describe("reconcileItem — triggerField (time gate)", () => {
     assert.equal((await activeCompletionEntries()).length, 1);
   });
 });
+
+describe("reconcileItem — notifyWhen (condition gate)", () => {
+  // A todo whose completion bell is gated to high/urgent priority only.
+  function notifySchema(extra: Partial<CollectionSchema> = {}): CollectionSchema {
+    return {
+      title: "Todos",
+      icon: "check_circle",
+      dataPath: `data/${SLUG}/items`,
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        priority: { type: "enum", values: ["low", "medium", "high", "urgent"], label: "Priority" },
+        status: { type: "enum", values: ["Todo", "Done"], label: "Status", required: true },
+      },
+      completionField: "status",
+      completionDoneValues: ["Done"],
+      notifyWhen: { field: "priority", in: ["high", "urgent"] },
+      ...extra,
+    };
+  }
+
+  it("fires the bell only for records matching notifyWhen", async () => {
+    const schema = notifySchema();
+    writeItem("a", { priority: "high", status: "Todo" });
+    writeItem("b", { priority: "low", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(SLUG, schema, dataDir, "b", { workspaceRoot: workdir });
+    const ids = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.deepEqual(ids, [`collection-completion:${SLUG}:a`]);
+  });
+
+  it("does not fire when the gated field is missing", async () => {
+    const schema = notifySchema();
+    writeItem("a", { status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("clears the bell when the record stops matching (priority dropped)", async () => {
+    const schema = notifySchema();
+    writeItem("a", { priority: "urgent", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    writeItem("a", { priority: "low", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("still clears on done even while notifyWhen matches", async () => {
+    const schema = notifySchema();
+    writeItem("a", { priority: "high", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    writeItem("a", { priority: "high", status: "Done" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+
+  it("sweep clears entries that no longer match notifyWhen", async () => {
+    const schema = notifySchema();
+    writeSchemaJson(schema);
+    writeItem("a", { priority: "high", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    assert.equal((await activeCompletionEntries()).length, 1);
+    writeItem("a", { priority: "low", status: "Todo" });
+    await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});


### PR DESCRIPTION
## What

Two small, composable additions to the Collections schema that let the legacy **Todo list be reimplemented as a Collection** — with a "done" checkbox and priority-gated notifications — keeping the `status` enum as the single source of truth.

### 1. `toggle` field type
A checkbox that is a pure **projection** of an `enum` field — it stores nothing of its own (like `derived`/`embed`):
- Checked when the projected enum equals `onValue`; toggling writes `onValue`/`offValue` back to that enum via the existing inline-edit PUT (optimistic + rollback).
- Renders inline in the **list table** and on the **kanban card** (when it projects the board's group field — ticking it also moves the card); read-only reflection in the detail view; excluded from the edit form and from persistence/validation.
- Zod: per-field refine (`field`/`onValue`/`offValue` required) + schema-level refine (`field` names a real enum; `onValue`/`offValue` ∈ its `values`).

### 2. `notifyWhen` schema key
An optional `when` predicate that **gates the existing completion bell** (reuses the bell machinery — no parallel system):
- Fire the bell only for records matching the predicate (e.g. `{ "field": "priority", "in": ["high","urgent"] }`) instead of every open record.
- Convergent: a record that stops matching has its bell cleared, in both `reconcileItem` and the boot sweep. Done / delete still clear as before.
- Zod: requires `completionField`; `notifyWhen.field` must name a real field.

## Docs
- New **`config/helps/todo-collection.md`** — the canonical, copy-pasteable todo recipe (schema + `SKILL.md` + sample record + legacy `todo-plugin` migration steps), referenced from `collection-skills.md` and the helps `index.md`.
- `collection-skills.md`: `toggle`/`notifyWhen` entries, nudges in the field-type + completion + kanban sections, and the worked example reduced to a pointer (no duplication).
- `docs/ui-cheatsheet.md` updated.

## Validation in the wild
Driven by a real migration of the user's todo list: the agent read `todo-collection.md`, authored the `done` toggle + `notifyWhen`, and the migrated `/collections/todos` rendered the checkbox on every row/card with the priority bell — confirming the docs→schema→render chain.

## Tests / checks
- New: `toggle` + `notifyWhen` Zod validation (`test_discovery`); `notifyWhen` reconcile/sweep incl. done-clears-while-matching (`test_notifications`).
- `yarn format` / `lint` / `typecheck` / `build` clean; **5354 unit tests** + **472 Playwright e2e** pass.

No server route changes — both features reuse existing write/notify paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a toggle field type that projects enum fields and introduce a notifyWhen predicate to gate completion notifications for collections.

New Features:
- Introduce a toggle field type that projects an enum field to provide a non-persisted checkbox in list and kanban views.
- Add a notifyWhen schema predicate that conditionally gates completion bell notifications based on record field values.

Enhancements:
- Extend collection validation and schema typing to support toggle projections, kanban configuration, and notifyWhen constraints.
- Update collection list, detail, and kanban UIs to render toggle fields appropriately without persisting their own values.

Documentation:
- Document the new toggle field type and notifyWhen predicate in the collection skills help and UI cheatsheet.
- Add a dedicated todo-collection help file as the canonical recipe for building or migrating todo/task lists, and link it from the helps index and collection skills docs.

Tests:
- Add discovery-time validation tests for toggle fields and notifyWhen usage in collection schemas.
- Add notification reconciliation and sweep tests covering notifyWhen-gated completion bells.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `toggle` field type shown as a checkbox that projects to an underlying enum; supported in table view, Kanban cards, and record details
  * Toggle actions write the corresponding enum value and can move Kanban cards when tied to the board’s grouping
  * Completion notifications can be gated by a `notifyWhen` condition

* **Documentation**
  * Added a todo-collection template and updated schema docs for toggle and conditional notifications

* **Tests**
  * Added validation and behavior tests for toggles and notifyWhen gates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->