### PR TITLE
fix(collections): scroll deep-linked record into view; hide id column

### DIFF
--- a/e2e/tests/collection-deep-link-scroll.spec.ts
+++ b/e2e/tests/collection-deep-link-scroll.spec.ts
@@ -1,0 +1,59 @@
+// E2E coverage for the `?selected=<id>` deep link (the path a
+// collection-item notification takes): opening a collection with a
+// selected id that loaded far down a long list must not only expand
+// that row's detail panel — it must SCROLL it into view. Before the
+// fix, `syncViewToSelected` opened the record but never called
+// `scrollOpenPanelIntoView`, so a notification for an off-screen item
+// left the user staring at the top of the table.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// Enough rows that an id near the bottom renders well below the fold on
+// the default 720px-tall viewport — so "in viewport" is only true if we
+// actually scrolled to it.
+const ITEM_COUNT = 60;
+const TARGET_ID = "item-55";
+
+const LONG_LIST = {
+  collection: {
+    slug: "long-list",
+    title: "Long List",
+    icon: "list",
+    source: "user",
+    schema: {
+      title: "Long List",
+      icon: "list",
+      dataPath: "data/long-list/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name" },
+      },
+    },
+  },
+  items: Array.from({ length: ITEM_COUNT }, (_, i) => ({ id: `item-${i}`, name: `Row ${i}` })),
+};
+
+async function mockCollection(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/long-list",
+    (route) => route.fulfill({ json: LONG_LIST }),
+  );
+}
+
+test("a `?selected=` deep link scrolls the opened record into view", async ({ page }) => {
+  await mockAllApis(page);
+  await mockCollection(page);
+
+  await page.goto(`/collections/long-list?selected=${TARGET_ID}`);
+
+  // The targeted record's detail panel expands inline under its row...
+  const panel = page.getByTestId(`collections-expansion-${TARGET_ID}`);
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+
+  // ...and — the regression this guards — it is scrolled into view, not
+  // left below the fold. `toBeInViewport` auto-retries, so it waits out
+  // the smooth scroll.
+  await expect(panel).toBeInViewport();
+});

--- a/e2e/tests/collection-url-link.spec.ts
+++ b/e2e/tests/collection-url-link.spec.ts
@@ -72,12 +72,13 @@ test.describe("collection URL links", () => {
 
   test("detail view renders an http(s) URL value as a new-tab link", async ({ page }) => {
     await page.goto("/collections/reading-list");
-    // Click the ID cell rather than the row's geometric center — the
-    // center may land on the URL link cell, whose `@click.stop` would
-    // (correctly) block the row's openView handler. This test is about
-    // the detail-side rendering; the click-boundary itself is pinned
-    // by the next test below.
-    await page.getByTestId("collections-row-anthropic-blog").getByText("anthropic-blog").click();
+    // Click the plain-text `notes` cell rather than the row's geometric
+    // center — the center may land on the URL link cell, whose
+    // `@click.stop` would (correctly) block the row's openView handler.
+    // (The id column is hidden, so we can't click that.) This test is
+    // about the detail-side rendering; the click-boundary itself is
+    // pinned by the next test below.
+    await page.getByTestId("collections-row-anthropic-blog").getByText("Skim the latest post").click();
     await expect(page.getByTestId("collections-detail")).toBeVisible();
     const link = page.getByTestId("collections-detail-url-url");
     await expect(link).toBeVisible();

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -902,11 +902,17 @@ async function loadCollection(slug: string): Promise<void> {
  *  and it'd be identical in every row). The detail modal and the edit
  *  form iterate the full `schema.fields` so embeds render there too. */
 // Fields shown as columns in the list table. Excludes `embed`
-// (display-only fixed record, no per-record value) and `image` — a
+// (display-only fixed record, no per-record value), `image` — a
 // per-row <img> fetches one file each, too expensive for a collection
-// with many records, and the image is shown in the detail view anyway.
+// with many records, and the image is shown in the detail view anyway —
+// and the primary key (an id is plumbing, not data: it identifies the
+// row via data-testid / ref links but doesn't earn a column).
 const listColumnFields = computed<[string, FieldSpec][]>(() =>
-  collection.value ? Object.entries(collection.value.schema.fields).filter(([, field]) => field.type !== "embed" && field.type !== "image") : [],
+  collection.value
+    ? Object.entries(collection.value.schema.fields).filter(
+        ([key, field]) => field.type !== "embed" && field.type !== "image" && key !== collection.value?.schema.primaryKey,
+      )
+    : [],
 );
 
 /** True when the current collection declares `schema.singleton` —
@@ -1177,7 +1183,12 @@ function syncViewToSelected(): void {
     viewing.value = null;
     return;
   }
-  viewing.value = findItemById(selected) ?? null;
+  const match = findItemById(selected) ?? null;
+  viewing.value = match;
+  // A deep link / notification can target a row that loaded off-screen
+  // (long collection). Bring the now-open record into view — the save
+  // path already does this; the `?selected=` path must too.
+  if (match) scrollOpenPanelIntoView();
 }
 
 /** Title for the open-mode header: the record's primary-key value


### PR DESCRIPTION
## Summary

Two small table-view fixes for collections, both surfaced while iterating on `CollectionView`:

1. **Scroll a deep-linked record into view.** Clicking a notification for a collection item opens the collection and selects the item (`?selected=<id>`), but if that item loaded below the fold the view stayed scrolled at the top. `syncViewToSelected` now calls the existing `scrollOpenPanelIntoView` helper when it opens a record — the exact scroll the save path already performs. No new scroll machinery; the `?selected=` path just reuses it.

2. **Hide the primary-key (id) column.** An id is plumbing, not data. It still identifies the row (`data-testid`, `ref` links) and shows in the detail panel when a row is opened — it just no longer takes a column in the list table. Implemented by excluding `schema.primaryKey` in `listColumnFields`, alongside the existing `embed`/`image` exclusions.

## Testing

- New e2e `collection-deep-link-scroll.spec.ts`: a `?selected=` deep link into a 60-row collection scrolls the opened panel into the viewport. **Verified it fails without the fix** (panel below the fold) and passes with it.
- Updated `collection-url-link.spec.ts` to click a plain-text cell instead of the now-removed id cell.
- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all green.
- Full collection + accounting + clickable-row e2e specs (64 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure deep-linked collection records open scrolled into view and hide primary-key columns from collection list tables.

Bug Fixes:
- Fix deep-linked collection items opened via the `?selected=` URL parameter not being scrolled into view when their rows render below the fold.

Enhancements:
- Hide the primary-key (id) field from collection list table columns while retaining it for identification and detail views.

Tests:
- Add an e2e test covering that `?selected=` deep links to long collections scroll the opened record’s expansion panel into the viewport.
- Update the collection URL link e2e test to click a non-id text cell now that the id column is hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection deep links with `?selected=<id>` parameter now automatically expand the item's detail panel and scroll it into view.

* **Changes**
  * Removed primary key column from collection table display.

* **Tests**
  * Added regression test for deep link scroll behavior.
  * Updated collection detail view click behavior test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->