### PR TITLE
fix(x): read X Article and long-form Post bodies in readXPost

### DIFF
--- a/server/agent/mcp-tools/x.ts
+++ b/server/agent/mcp-tools/x.ts
@@ -12,7 +12,7 @@ const X_API_BASE = "https://api.twitter.com/2";
 // headroom for a slow but real response while still bailing long
 // before the MCP client's tool-call timeout fires.
 const X_API_TIMEOUT_MS = 20 * ONE_SECOND_MS;
-const TWEET_FIELDS = "tweet.fields=created_at,author_id,public_metrics,entities";
+const TWEET_FIELDS = "tweet.fields=created_at,author_id,public_metrics,entities,note_tweet,article";
 const EXPANSIONS = "expansions=author_id";
 const USER_FIELDS = "user.fields=name,username";
 
@@ -27,6 +27,11 @@ interface XTweet {
   text: string;
   author_id?: string;
   created_at?: string;
+  // Long-form Post (>280 chars): full body lives here, not in `text`.
+  note_tweet?: { text: string };
+  // X Article (rich long-form, up to 100k chars): `text` only holds the t.co
+  // link, so the body must be read from `article.plain_text`.
+  article?: { title?: string; plain_text?: string };
   public_metrics?: {
     like_count: number;
     retweet_count: number;
@@ -65,6 +70,17 @@ async function fetchX(path: string): Promise<XApiResponse> {
   return response.json() as Promise<XApiResponse>;
 }
 
+// `text` caps at 280 chars; long-form Posts and Articles carry their real body
+// in `note_tweet` / `article`. Prefer those so the LLM sees the full content.
+function tweetBody(tweet: XTweet): string {
+  if (tweet.note_tweet?.text) return tweet.note_tweet.text;
+  const { article } = tweet;
+  if (article?.plain_text) {
+    return [article.title, article.plain_text].filter(Boolean).join("\n\n");
+  }
+  return tweet.text;
+}
+
 function formatTweet(tweet: XTweet, author?: XUser, url?: string): string {
   const date = tweet.created_at ? toUtcIsoDate(new Date(tweet.created_at)) : "";
   const dateSuffix = date ? ` · ${date}` : "";
@@ -73,7 +89,7 @@ function formatTweet(tweet: XTweet, author?: XUser, url?: string): string {
     ? `Likes: ${tweet.public_metrics.like_count} | Retweets: ${tweet.public_metrics.retweet_count} | Replies: ${tweet.public_metrics.reply_count}`
     : "";
   const link = url ?? "";
-  return [byline, "", tweet.text, "", metrics, link]
+  return [byline, "", tweetBody(tweet), "", metrics, link]
     .filter((line) => line !== undefined)
     .join("\n")
     .trimEnd();


### PR DESCRIPTION
## Problem

`readXPost` returned almost-empty content for **X Article** posts (and long-form Posts). The X API v2 `text` field caps at 280 chars, and for Articles `text` only contains the `t.co` link — the actual body was never requested.

Root cause: the `/tweets/:id` call requested `tweet.fields=created_at,author_id,public_metrics,entities` and never asked for the body-bearing fields.

## Fix

Request `note_tweet,article` in `tweet.fields` and select the real body via a new `tweetBody()` helper, in priority order:

1. `note_tweet.text` — long-form Post (>280 chars)
2. `article.title` + `article.plain_text` — X Article (rich long-form, up to 100k chars)
3. `text` — normal post (fallback)

Verified against a real Article post: `article.plain_text` returns the full body (contrary to public docs/forums that claim it isn't fetchable). Works on the current bearer token — no Pro/Enterprise tier needed.

`searchX` is intentionally left unchanged — it does not request `article`, so search results keep using `text` and won't be flooded with full article bodies.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update X post fetching to retrieve and surface full bodies for long-form posts and Articles instead of truncated text.

New Features:
- Support reading long-form X Posts via the note_tweet field when available.
- Support reading X Article content by combining article titles and plain-text bodies into the displayed post text.

Enhancements:
- Centralize X post body selection in a tweetBody helper used by tweet formatting to ensure consistent content display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * X (Twitter) integration now displays full-length posts, including notes and articles in addition to standard tweets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->