### PR TITLE
fix(collection): remember last-used view mode per collection

### DIFF
--- a/e2e/tests/collection-calendar.spec.ts
+++ b/e2e/tests/collection-calendar.spec.ts
@@ -159,4 +159,18 @@ test.describe("collection calendar view", () => {
     await expect(page.getByTestId("collections-row-jane")).toBeVisible();
     await expect(page.getByTestId("collection-view-toggle-calendar")).toHaveCount(0);
   });
+
+  // The standalone route persists the last-used view mode per collection in
+  // localStorage, so reopening restores the prior view instead of the table.
+  test("restores the last-used view mode after a reload", async ({ page }) => {
+    await page.goto("/collections/events");
+    await page.getByTestId("collection-view-toggle-calendar").click();
+    await expect(page.getByTestId("collection-calendar")).toBeVisible();
+
+    await page.reload();
+
+    // Reopens on the calendar, not the default table.
+    await expect(page.getByTestId("collection-calendar")).toBeVisible();
+    await expect(page.getByTestId("collection-calendar-chip-launch")).toBeVisible();
+  });
 });

--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -136,6 +136,85 @@ test("Add opens the create form as a panel pinned at the top of the list", async
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });
 
+// Channel isolation: an embedded card's view lives in its tool-result
+// `viewState`, NEVER in the standalone-route localStorage store. A stored
+// standalone preference for the same slug must not leak into (and then get
+// re-persisted by) the embedded card. Here a date-bearing collection has a
+// stored "calendar" mode; the embedded card must still open on the table.
+const DATED_EVENTS_DETAIL = {
+  collection: {
+    slug: "dated-events",
+    title: "Events",
+    icon: "event",
+    source: "user",
+    schema: {
+      title: "Events",
+      icon: "event",
+      dataPath: "data/dated-events/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+        on: { type: "date", label: "Date" },
+      },
+      displayField: "name",
+      calendarField: "on",
+    },
+  },
+  items: [{ id: "launch", name: "Launch party", on: "" }],
+};
+
+test("embedded card ignores the standalone localStorage view-mode store", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  // Seed the standalone store with "calendar" for this slug BEFORE the app boots.
+  await page.addInitScript(() => {
+    localStorage.setItem("collection_view_modes", JSON.stringify({ "dated-events": "calendar" }));
+  });
+
+  await mockAllApis(page, {
+    sessions: [{ id: "watchlist-session", title: "Events", roleId: "general", startedAt: "2026-05-29T10:00:00Z", updatedAt: "2026-05-29T10:05:00Z" }],
+  });
+  await page.route(
+    (url) => url.pathname === "/api/collections/dated-events",
+    (route) => route.fulfill({ json: DATED_EVENTS_DETAIL }),
+  );
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [
+          { type: "session_meta", roleId: "general", sessionId: "watchlist-session" },
+          { type: "text", source: "user", message: "show me the events" },
+          {
+            type: "tool_result",
+            source: "tool",
+            // No `viewState` → embedded `initialView` is undefined.
+            result: {
+              uuid: "pc-result-2",
+              toolName: "presentCollection",
+              title: "Events",
+              message: "Presented collection dated-events",
+              data: { collectionSlug: "dated-events" },
+            },
+          },
+        ],
+      }),
+  );
+
+  await page.goto(SESSION_PATH);
+  await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
+  // The date field means the calendar toggle IS offered — so the card COULD
+  // have honoured the stored "calendar". It must not: the table is shown and
+  // the calendar grid never mounts.
+  await expect(page.getByTestId("collection-view-toggle-calendar")).toBeVisible();
+  await expect(page.getByTestId("collections-row-launch")).toBeVisible();
+  await expect(page.getByTestId("collection-calendar")).toHaveCount(0);
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});
+
 test("saving an edit returns to the record's detail (does not close) in the embedded card", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -951,9 +951,13 @@ const canDeleteCollection = computed<boolean>(() => {
 type CollectionViewMode = "table" | "calendar" | "kanban";
 
 /** The view to open with: the embedded card's restored `initialView` if
- *  present, else the standalone slug's stored mode, else "table". */
+ *  present, else the standalone slug's stored mode, else "table". Embedded
+ *  mode never reads the localStorage store — its state lives in the card's
+ *  `viewState`, so a standalone preference must not leak into (and then be
+ *  re-persisted by) an embedded card. */
 function initialViewMode(): CollectionViewMode {
   if (props.initialView) return props.initialView;
+  if (embedded.value) return "table";
   const slug = activeSlug.value;
   return (slug && readCollectionViewMode(slug)) || "table";
 }

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -569,6 +569,7 @@ import CollectionKanbanView from "./CollectionKanbanView.vue";
 import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
+import { readCollectionViewMode, writeCollectionViewMode } from "../utils/collections/collectionViewMode";
 import { useCollectionRendering } from "../composables/collections/useCollectionRendering";
 import { buildUpdatedRecord, coerceInlineValue, draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
 import type {
@@ -942,8 +943,21 @@ const canDeleteCollection = computed<boolean>(() => {
 // when the schema has a `date` field and the kanban only when it has an
 // `enum` field, so plain collections and the initial load are unchanged
 // (default "table").
+//
+// Standalone route mode persists the last-used mode per collection in
+// localStorage so reopening `/collections/:slug` restores the prior view
+// instead of always starting on the table. Embedded mode ignores the store
+// and restores from the card's `initialView` prop instead.
 type CollectionViewMode = "table" | "calendar" | "kanban";
-const view = ref<CollectionViewMode>(props.initialView ?? "table");
+
+/** The view to open with: the embedded card's restored `initialView` if
+ *  present, else the standalone slug's stored mode, else "table". */
+function initialViewMode(): CollectionViewMode {
+  if (props.initialView) return props.initialView;
+  const slug = activeSlug.value;
+  return (slug && readCollectionViewMode(slug)) || "table";
+}
+const view = ref<CollectionViewMode>(initialViewMode());
 
 /** `date` fields in declaration order — the calendar can anchor on any. */
 const dateFields = computed<string[]>(() =>
@@ -1416,9 +1430,11 @@ watch(
   (slug, prevSlug) => {
     // Reset view state when switching BETWEEN collections — but not on the
     // initial run (prevSlug undefined), so an embedded card's restored
-    // `initialView` / `initialAnchorField` survive the first load.
+    // `initialView` / `initialAnchorField` survive the first load. Standalone
+    // mode restores the new collection's stored mode (else "table"); the axis
+    // fields always reset to their schema defaults.
     if (prevSlug !== undefined && slug !== prevSlug) {
-      view.value = "table";
+      view.value = (slug && !embedded.value && readCollectionViewMode(slug)) || "table";
       anchorOverride.value = null;
       kanbanOverride.value = null;
     }
@@ -1437,12 +1453,20 @@ watch(
 );
 
 // Embedded mode: report view/anchor changes so the chat card persists them
-// in `viewState` (alongside `selected`). No-op in standalone route mode.
+// in `viewState` (alongside `selected`). Standalone mode: persist the view
+// mode per slug in localStorage so reopening restores it.
 watch([activeView, calendarAnchorField, kanbanGroupField], () => {
   // Persist the EFFECTIVE view (activeView), not the raw `view` ref — a
   // stale "calendar"/"kanban" that has fallen back to "table" (its enabling
   // field gone) must not be saved as an impossible mode.
-  if (embedded.value) emit("viewStateChange", { view: activeView.value, anchorField: calendarAnchorField.value, groupField: kanbanGroupField.value });
+  if (embedded.value) {
+    emit("viewStateChange", { view: activeView.value, anchorField: calendarAnchorField.value, groupField: kanbanGroupField.value });
+    return;
+  }
+  // Don't write during the load window: until the collection resolves,
+  // `hasCalendar`/`hasKanban` are false so `activeView` reads "table",
+  // which would clobber a stored "calendar"/"kanban" before it can apply.
+  if (activeSlug.value && !loading.value && collection.value) writeCollectionViewMode(activeSlug.value, activeView.value);
 });
 
 // React to the active selection changing while already on this

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1455,7 +1455,11 @@ watch(
 // Embedded mode: report view/anchor changes so the chat card persists them
 // in `viewState` (alongside `selected`). Standalone mode: persist the view
 // mode per slug in localStorage so reopening restores it.
-watch([activeView, calendarAnchorField, kanbanGroupField], () => {
+// `loading` is a dependency so the write re-runs when the collection finishes
+// loading: that's the point where a stored mode unsupported by this schema
+// (its date/enum field gone) has collapsed to "table" and must be normalized
+// back into storage — otherwise no other dependency changes and it lingers.
+watch([activeView, calendarAnchorField, kanbanGroupField, loading], () => {
   // Persist the EFFECTIVE view (activeView), not the raw `view` ref — a
   // stale "calendar"/"kanban" that has fallen back to "table" (its enabling
   // field gone) must not be saved as an impossible mode.

--- a/src/utils/collections/collectionViewMode.ts
+++ b/src/utils/collections/collectionViewMode.ts
@@ -17,7 +17,9 @@ function readAll(): ViewModeMap {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? (parsed as ViewModeMap) : {};
+    // Plain object only — an array would pass `typeof === "object"` and then
+    // let writeCollectionViewMode write string keys onto it.
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as ViewModeMap) : {};
   } catch {
     return {};
   }

--- a/src/utils/collections/collectionViewMode.ts
+++ b/src/utils/collections/collectionViewMode.ts
@@ -1,0 +1,40 @@
+// Per-collection view-mode preference (table | calendar | kanban) persisted
+// to localStorage, keyed by collection slug. Lets the standalone
+// `/collections/:slug` page reopen in the last-used view instead of always
+// defaulting to "table". Embedded chat-card mode persists its own `viewState`
+// in the tool result and does NOT use this.
+
+export type CollectionViewMode = "table" | "calendar" | "kanban";
+
+const STORAGE_KEY = "collection_view_modes";
+
+const VIEW_MODES: readonly CollectionViewMode[] = ["table", "calendar", "kanban"];
+
+type ViewModeMap = Record<string, CollectionViewMode>;
+
+function readAll(): ViewModeMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as ViewModeMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readCollectionViewMode(slug: string): CollectionViewMode | null {
+  const stored = readAll()[slug];
+  return stored && VIEW_MODES.includes(stored) ? stored : null;
+}
+
+export function writeCollectionViewMode(slug: string, view: CollectionViewMode): void {
+  try {
+    const all = readAll();
+    all[slug] = view;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // localStorage unavailable / quota exceeded — the preference is
+    // best-effort, so silently skip rather than break the view.
+  }
+}


### PR DESCRIPTION
## Background

Feedback after moving the calendar into Collections: the standalone `/collections/:slug` page **always opened in table view**, and reset to table on every collection switch. For a calendar-style collection that felt off — the previously selected view never carried over.

## Change

Persist the last-used view mode (`table` | `calendar` | `kanban`) **per collection slug** in `localStorage`, and restore it when the page opens or the user switches collections.

- New `src/utils/collections/collectionViewMode.ts` — `read/writeCollectionViewMode`, a `{ slug: view }` map under one `collection_view_modes` key (same try/catch + validation style as `useFileSortMode`).
- `CollectionView.vue`:
  1. **Init** — standalone mode seeds the view from the stored mode (embedded chat-card mode is unchanged: it still wins from the `initialView` prop and ignores the store).
  2. **Collection switch** — restores the new slug's stored mode instead of forcing `table`.
  3. **Persist watch** — writes `activeView` per slug, guarded against the load window where `activeView` transiently falls back to `table` (so a stored `calendar`/`kanban` isn't clobbered before it applies).

## Scope / behavior

- **Per collection**: a calendar collection remembers calendar, a kanban one remembers kanban — independently.
- **View mode only**: calendar date-axis / kanban group fields still reset to their schema defaults each open.
- Opening a collection whose enabling field is gone safely falls back to `table` and updates that slug's stored value.
- Embedded chat-card persistence (tool-result `viewState`) is untouched.

## Testing

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — all clean
- `yarn test:e2e` — 473 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Persist per-collection view mode preferences for standalone collection pages and restore them on load and collection switch.

New Features:
- Remember the last-used view mode (table, calendar, kanban) per collection slug using localStorage and restore it when reopening a standalone collection route.

Enhancements:
- Adjust collection view initialization, collection-switch handling, and view-change watchers so standalone pages respect stored view modes while embedded cards continue using their own view state persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-collection view persistence: table/calendar/kanban choices are saved and restored per collection.
  * Switching collections preserves the last selected view instead of resetting to table.
  * Embedded collection cards honor an explicit initial view and do not pick up standalone saved modes.

* **Tests**
  * End-to-end tests added to verify view persistence across reloads and that embedded cards ignore standalone stored modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->