### PR TITLE
feat(chat): add Stop button to interrupt an in-flight agent run

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -135,6 +135,7 @@
           :is-running="activeSessionRunning"
           :queries="sessionRoleQueries"
           @send="sendMessage()"
+          @stop="stopCurrentRun()"
           @suggestion-send="(q) => sendMessage(q)"
         />
       </div>
@@ -267,6 +268,7 @@
             :is-running="activeSessionRunning"
             :queries="sessionRoleQueries"
             @send="sendMessage()"
+            @stop="stopCurrentRun()"
             @suggestion-send="(q) => sendMessage(q)"
           />
         </div>
@@ -372,7 +374,7 @@ import { useEventListeners } from "./composables/useEventListeners";
 import { provideAppApi } from "./composables/useAppApi";
 import { provideActiveSession } from "./composables/useActiveSession";
 import { useRoute, useRouter } from "vue-router";
-import { apiGet } from "./utils/api";
+import { apiGet, apiPost } from "./utils/api";
 import { API_ROUTES } from "./config/apiRoutes";
 import { TOOL_NAMES } from "./config/toolNames";
 import { classifyWorkspacePath } from "./utils/path/workspaceLinkRouter";
@@ -1024,6 +1026,21 @@ async function sendMessage(text?: string) {
   if (!result.ok) {
     pushErrorMessage(session, result.error);
     unsubscribeSession(session.id);
+  }
+}
+
+// Stop the in-flight agent run for the displayed session. The server's
+// /api/agent/cancel aborts the AbortController, kills the Claude
+// subprocess, and publishes `session_finished` — which flips
+// `isRunning` back to false through the normal pub/sub path. So we only
+// fire-and-report here; no local state reset is needed on success.
+async function stopCurrentRun(): Promise<void> {
+  const sessionId = currentSessionId.value;
+  if (!sessionId) return;
+  const result = await apiPost<{ ok: boolean }>(API_ROUTES.agent.cancel, { chatSessionId: sessionId });
+  if (!result.ok) {
+    const session = sessionMap.get(sessionId);
+    if (session) pushErrorMessage(session, t("chatInput.stopFailed", { error: result.error }));
   }
 }
 

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -52,11 +52,21 @@
             <span class="material-icons text-base leading-none">lightbulb</span>
           </button>
           <button
+            v-if="isRunning"
+            data-testid="stop-btn"
+            class="bg-red-600 hover:bg-red-700 text-white rounded w-8 h-8 flex items-center justify-center"
+            :title="t('chatInput.stop')"
+            :aria-label="t('chatInput.stop')"
+            @click="emit('stop')"
+          >
+            <span class="material-icons text-base leading-none">stop</span>
+          </button>
+          <button
+            v-else
             data-testid="send-btn"
             class="bg-blue-600 hover:bg-blue-700 text-white rounded w-8 h-8 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
             :title="t('chatInput.send')"
             :aria-label="t('chatInput.send')"
-            :disabled="isRunning"
             @click="emit('send')"
           >
             <span class="material-icons text-base leading-none">send</span>
@@ -108,6 +118,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: string];
   "update:pastedFile": [file: PastedFile | null];
   send: [];
+  stop: [];
   "suggestion-send": [query: string];
 }>();
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -32,10 +32,12 @@ const deMessages = {
   chatInput: {
     placeholder: "Nachricht an Claude…",
     send: "Senden",
+    stop: "Stoppen",
     attachFile: "Datei anhängen",
     fileTooLarge: "Datei zu groß ({sizeMB} MB). Das Maximum beträgt 30 MB.",
     unsupportedFileType: "Dateityp nicht unterstützt. Akzeptiert: Bilder, PDF, DOCX, XLSX, PPTX, Textdateien.",
     attachImageFailed: "Anhängen des Bildes fehlgeschlagen: {error}",
+    stopFailed: "Stoppen der Ausführung fehlgeschlagen: {error}",
     dropHint: "Datei zum Anhängen ablegen",
   },
   sessionHistoryPanel: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -54,10 +54,12 @@ const enMessages = {
   chatInput: {
     placeholder: "Message Claude…",
     send: "Send",
+    stop: "Stop",
     attachFile: "Attach file",
     fileTooLarge: "File too large ({sizeMB} MB). Maximum is 30 MB.",
     unsupportedFileType: "File type not supported. Accepted: images, PDF, DOCX, XLSX, PPTX, text files.",
     attachImageFailed: "Failed to attach image: {error}",
+    stopFailed: "Failed to stop the run: {error}",
     dropHint: "Drop file to attach",
   },
   sessionHistoryPanel: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -37,10 +37,12 @@ const esMessages = {
   chatInput: {
     placeholder: "Mensaje para Claude…",
     send: "Enviar",
+    stop: "Detener",
     attachFile: "Adjuntar archivo",
     fileTooLarge: "El archivo es demasiado grande ({sizeMB} MB). El máximo es 30 MB.",
     unsupportedFileType: "Tipo de archivo no admitido. Se aceptan: imágenes, PDF, DOCX, XLSX, PPTX y archivos de texto.",
     attachImageFailed: "No se pudo adjuntar la imagen: {error}",
+    stopFailed: "No se pudo detener la ejecución: {error}",
     dropHint: "Suelta el archivo para adjuntar",
   },
   sessionHistoryPanel: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -32,10 +32,12 @@ const frMessages = {
   chatInput: {
     placeholder: "Message à Claude…",
     send: "Envoyer",
+    stop: "Arrêter",
     attachFile: "Joindre un fichier",
     fileTooLarge: "Fichier trop volumineux ({sizeMB} Mo). La limite est de 30 Mo.",
     unsupportedFileType: "Type de fichier non pris en charge. Acceptés : images, PDF, DOCX, XLSX, PPTX, fichiers texte.",
     attachImageFailed: "Échec de l'attache de l'image : {error}",
+    stopFailed: "Échec de l'arrêt du traitement : {error}",
     dropHint: "Déposez le fichier pour joindre",
   },
   sessionHistoryPanel: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -39,10 +39,12 @@ const jaMessages = {
   chatInput: {
     placeholder: "Claude にメッセージ…",
     send: "送信",
+    stop: "停止",
     attachFile: "ファイルを添付",
     fileTooLarge: "ファイルが大きすぎます（{sizeMB} MB）。上限は 30 MB です。",
     unsupportedFileType: "対応していないファイル形式です。画像・PDF・DOCX・XLSX・PPTX・テキストファイルを使用してください。",
     attachImageFailed: "画像の添付に失敗しました: {error}",
+    stopFailed: "処理の停止に失敗しました: {error}",
     dropHint: "ファイルをドロップして添付",
   },
   sessionHistoryPanel: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -39,10 +39,12 @@ const koMessages = {
   chatInput: {
     placeholder: "Claude에게 메시지…",
     send: "전송",
+    stop: "중지",
     attachFile: "파일 첨부",
     fileTooLarge: "파일이 너무 큽니다 ({sizeMB} MB). 최대 30 MB 까지 가능합니다.",
     unsupportedFileType: "지원되지 않는 파일 형식입니다. 이미지, PDF, DOCX, XLSX, PPTX, 텍스트 파일만 지원됩니다.",
     attachImageFailed: "이미지를 첨부하지 못했습니다: {error}",
+    stopFailed: "처리를 중지하지 못했습니다: {error}",
     dropHint: "파일을 놓아서 첨부",
   },
   sessionHistoryPanel: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -32,10 +32,12 @@ const ptBRMessages = {
   chatInput: {
     placeholder: "Mensagem para Claude…",
     send: "Enviar",
+    stop: "Parar",
     attachFile: "Anexar arquivo",
     fileTooLarge: "Arquivo muito grande ({sizeMB} MB). O limite é 30 MB.",
     unsupportedFileType: "Tipo de arquivo não suportado. Aceitos: imagens, PDF, DOCX, XLSX, PPTX e arquivos de texto.",
     attachImageFailed: "Falha ao anexar a imagem: {error}",
+    stopFailed: "Falha ao parar a execução: {error}",
     dropHint: "Solte o arquivo para anexar",
   },
   sessionHistoryPanel: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -37,10 +37,12 @@ const zhMessages = {
   chatInput: {
     placeholder: "向 Claude 发送消息…",
     send: "发送",
+    stop: "停止",
     attachFile: "附加文件",
     fileTooLarge: "文件过大（{sizeMB} MB）。上限为 30 MB。",
     unsupportedFileType: "不支持的文件类型。支持:图像、PDF、DOCX、XLSX、PPTX、文本文件。",
     attachImageFailed: "附加图片失败：{error}",
+    stopFailed: "停止处理失败：{error}",
     dropHint: "拖放文件以附加",
   },
   sessionHistoryPanel: {


### PR DESCRIPTION
## What

Adds a **Stop button** to the chat input. While the agent is running, the send button turns into a red Stop button; clicking it interrupts the in-flight run.

This addresses user feedback: when Claude starts heading in an unintended direction, or hangs without emitting a completion event, there was previously no way to interrupt it — the only options were to wait or reload the browser (which is how users have been clearing a stuck "考え中…" indicator).

## How

The server-side cancel wiring **already existed** and is unchanged:

- `POST /api/agent/cancel` → `cancelRun(chatSessionId)` → `abortController.abort()`
- The abort signal kills the spawned Claude CLI subprocess (`server/agent/backend/claude-code.ts`)
- `endRun()` publishes `session_finished`, which flips `isRunning` back to `false` via the normal pub/sub path

This PR only adds the missing UI affordance:

| File | Change |
|---|---|
| `src/components/ChatInput.vue` | When `isRunning`, render a red Stop button (`stop` icon) in place of the send button; emit `stop` |
| `src/App.vue` | Add `stopCurrentRun()` (`apiPost(API_ROUTES.agent.cancel, …)`); wire `@stop` on both single- and stack-layout `<ChatInput>` instances |
| `src/lang/*.ts` (8 locales) | Add `chatInput.stop` and `chatInput.stopFailed` |

## Behavior

- **Unintended direction**: Stop → subprocess killed → input re-enables → user retypes and resends.
- **Hung run**: Stop clears the perpetual "考え中…" state without a browser reload.

## Out of scope

- **Direct mid-run resubmit** (typing a new message while running): the input is `:disabled="isRunning"` by design, so the flow here is Stop → resend.
- **Automatic hang detection** (server-side overall-run timeout): not included; Stop provides manual recovery.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a UI control to stop an in-flight chat agent run from the chat input.

New Features:
- Show a red Stop button in the chat input while the agent is running, replacing the Send button and emitting a stop event.
- Expose a stopCurrentRun handler in the app shell to cancel the active chat session via the existing /api/agent/cancel endpoint.

Enhancements:
- Provide localized stop label and stop failure error message across all supported languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now cancel in-progress chat responses using a dedicated stop button that appears while a message is generating
  * Stop action failures display localized error messages across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->