### PR TITLE
ci: skip codex-review on Dependabot PRs

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -70,6 +70,14 @@ concurrency:
 
 jobs:
   codex-review:
+    # Skip on Dependabot PRs. GitHub strips repo secrets from PRs
+    # opened by Dependabot for security; `secrets.AZURE_OPENAI_API_KEY`
+    # resolves to "" and `codex exec` exits "Missing environment
+    # variable: OPENAI_API_KEY" within seconds, failing the check.
+    # Dependabot version bumps don't benefit from an LLM review
+    # anyway — let the rest of the matrix (CodeRabbit / Socket /
+    # lint_test / smoke) gate them.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Fixes the spurious `codex-review` CI failure on every Dependabot PR — most recently #1611 ([failed run](https://github.com/receptron/mulmoclaude/actions/runs/26980340770/job/79629726315)).

## Root cause

GitHub strips repository secrets from Actions runs triggered by Dependabot PRs (security policy). `secrets.AZURE_OPENAI_API_KEY` therefore resolves to an empty string, and `codex exec` exits within ~11s with:

```
ERROR: Missing environment variable: `OPENAI_API_KEY`.
```

The check then fails red. Every Dependabot version-bump PR has hit this.

## Fix

Add a single job-level gate to `.github/workflows/codex_review.yaml`:

```yaml
if: github.actor != 'dependabot[bot]'
```

The job now appears as a gray **Skipped** on Dependabot PRs instead of a red ✗. CodeRabbit / Socket / lint_test / smoke / e2e still run and gate the PR — losing the LLM pass on a version bump is a non-issue.

## Items to Confirm / Review

- Standard well-known Dependabot-skip pattern. No behaviour change for human or workflow_dispatch invocations.
- An alternative (Dependabot-scoped secrets) is an operator action outside this PR's reach and would also require trusting bumps with an LLM API key, which doesn't seem worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add a conditional to the codex-review workflow so the job is skipped when run on Dependabot PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to skip redundant review processes for automated dependency updates, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->