### PR TITLE
feat: expand notification history body on click

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -91,7 +91,7 @@ In **Stack layout** this sidebar isn't rendered; the same data flows through `<S
 ```
 
 - **Active** rows: fyi (body click clears + navigates) vs action (× cancels; body click navigates only).
-- **History** rows: read-only; navigate on click when `navigateTarget` is present. Capped at `HISTORY_CAP` (50) FIFO server-side; bell collapses to the first 5 with a toggle so repetitive entries (e.g. recurring "docker not running") don't bury the rest. Toggle state resets each time the popup closes.
+- **History** rows: click to expand/collapse the notification body inline. When expanded and `navigateTarget` is present, a small `open_in_new` icon appears for navigation. Capped at `HISTORY_CAP` (50) FIFO server-side; bell collapses to the first 5 with a toggle so repetitive entries (e.g. recurring "docker not running") don't bury the rest. Toggle and expansion state reset each time the popup closes.
 
 ## /chat — the chat page
 

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -368,3 +368,89 @@ test.describe("notification bell — history more / less toggle", () => {
     await expect(page.getByTestId(`notification-history-${history[HISTORY_INITIAL_VISIBLE].id}`)).toHaveCount(0);
   });
 });
+
+function buildHistoryEntryWithBody(index: number, body: string, navigateTarget?: string): NotifierHistoryFixture {
+  const base = buildHistoryEntry(index);
+  return { ...base, body, navigateTarget };
+}
+
+test.describe("notification bell — history body expansion", () => {
+  test("clicking a history row with body expands and collapses the body", async ({ page }) => {
+    const history = [buildHistoryEntryWithBody(0, "Detailed body text for testing")];
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+
+    const row = page.getByTestId(`notification-history-${history[0].id}`);
+    await expect(row).toBeVisible();
+    await expect(page.getByTestId("notification-history-body")).toHaveCount(0);
+
+    await row.click();
+    await expect(page.getByTestId("notification-history-body")).toBeVisible();
+    await expect(page.getByTestId("notification-history-body")).toHaveText("Detailed body text for testing");
+
+    await row.click();
+    await expect(page.getByTestId("notification-history-body")).toHaveCount(0);
+  });
+
+  test("expanded body state resets when the panel closes", async ({ page }) => {
+    const history = [buildHistoryEntryWithBody(0, "Body resets on close")];
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+    await page.getByTestId(`notification-history-${history[0].id}`).click();
+    await expect(page.getByTestId("notification-history-body")).toBeVisible();
+
+    await page.mouse.click(10, 10);
+    await expect(page.getByTestId("notification-panel")).toHaveCount(0);
+
+    await page.getByTestId("notification-bell").click();
+    await expect(page.getByTestId("notification-panel")).toBeVisible();
+    await expect(page.getByTestId("notification-history-body")).toHaveCount(0);
+  });
+
+  test("navigate icon appears when expanded and navigateTarget is present", async ({ page }) => {
+    const history = [buildHistoryEntryWithBody(0, "Body with link", "/calendar")];
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+
+    const row = page.getByTestId(`notification-history-${history[0].id}`);
+    await expect(page.getByTestId("notification-history-navigate")).toHaveCount(0);
+
+    await row.click();
+    await expect(page.getByTestId("notification-history-navigate")).toBeVisible();
+  });
+
+  test("navigate icon is absent for entries without navigateTarget", async ({ page }) => {
+    const history = [buildHistoryEntryWithBody(0, "Body without link")];
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+    await page.getByTestId(`notification-history-${history[0].id}`).click();
+
+    await expect(page.getByTestId("notification-history-body")).toBeVisible();
+    await expect(page.getByTestId("notification-history-navigate")).toHaveCount(0);
+  });
+
+  test("history row without body or navigateTarget is not expandable", async ({ page }) => {
+    const history = [{ ...buildHistoryEntry(0), body: undefined }];
+    await mockAllApis(page, { sessions: [] });
+    await primeNotifierHistory(page, history);
+
+    await page.goto("/todos");
+    await page.getByTestId("notification-bell").click();
+
+    const row = page.getByTestId(`notification-history-${history[0].id}`);
+    await expect(row).toBeVisible();
+    await expect(row).not.toHaveAttribute("role", "button");
+  });
+});

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -441,7 +441,7 @@ test.describe("notification bell — history body expansion", () => {
     await expect(page.getByTestId("notification-history-navigate")).toHaveCount(0);
   });
 
-  test("history row without body or navigateTarget is not expandable", async ({ page }) => {
+  test("history row without body or navigateTarget has no expand button", async ({ page }) => {
     const history = [{ ...buildHistoryEntry(0), body: undefined }];
     await mockAllApis(page, { sessions: [] });
     await primeNotifierHistory(page, history);
@@ -451,6 +451,6 @@ test.describe("notification bell — history body expansion", () => {
 
     const row = page.getByTestId(`notification-history-${history[0].id}`);
     await expect(row).toBeVisible();
-    await expect(row).not.toHaveAttribute("role", "button");
+    await expect(row.getByTestId("notification-history-expand")).toHaveCount(0);
   });
 });

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -6,9 +6,10 @@
 // readable than a generic dot. History rows fall back to a faded
 // dot so the row reads as past-tense.
 //
-// Body is displayed only as a native hover tooltip (`:title=`) — the
-// row stays compact and the relative-time meta line is what the user
-// scans for "when was this?".
+// Active rows show body as a native hover tooltip (`:title=`).
+// History rows expand body inline on click — a chevron indicates
+// expandability, and a navigate icon appears when `navigateTarget`
+// is present.
 //
 // The dev-mode `NotifierDebugPopup` that ran in parallel during PR 3
 // is gone — the production bell now serves both audiences.

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -48,6 +48,7 @@ const badgeText = computed(() => (badgeCount.value > 99 ? "99+" : String(badgeCo
 // "docker not running" notifications burying active items).
 const HISTORY_INITIAL_VISIBLE = 5;
 const historyExpanded = ref(false);
+const expandedHistoryIds = ref(new Set<string>());
 const displayedHistory = computed(() => (historyExpanded.value ? visibleHistory.value : visibleHistory.value.slice(0, HISTORY_INITIAL_VISIBLE)));
 const hiddenHistoryCount = computed(() => Math.max(0, visibleHistory.value.length - HISTORY_INITIAL_VISIBLE));
 const canToggleHistory = computed(() => visibleHistory.value.length > HISTORY_INITIAL_VISIBLE);
@@ -90,7 +91,10 @@ watch(
 // starts from the collapsed 5-row view. Without this, an expanded
 // state persists across closes and the scroll position jumps.
 watch(open, (nowOpen: boolean) => {
-  if (!nowOpen) historyExpanded.value = false;
+  if (!nowOpen) {
+    historyExpanded.value = false;
+    expandedHistoryIds.value = new Set();
+  }
 });
 
 // ── Legacy pluginData typing ────────────────────────────────
@@ -239,7 +243,25 @@ async function handleDismiss(event: Event, entry: NotifierEntry): Promise<void> 
   else await cancel(entry.id);
 }
 
-async function handleHistoryClick(entry: NotifierHistoryEntry): Promise<void> {
+function isHistoryExpandable(entry: NotifierHistoryEntry): boolean {
+  return Boolean(localizeBody(entry) || entry.navigateTarget);
+}
+
+function isHistoryBodyExpanded(entryId: string): boolean {
+  return expandedHistoryIds.value.has(entryId);
+}
+
+function toggleHistoryBody(entryId: string): void {
+  const next = new Set(expandedHistoryIds.value);
+  if (next.has(entryId)) {
+    next.delete(entryId);
+  } else {
+    next.add(entryId);
+  }
+  expandedHistoryIds.value = next;
+}
+
+async function handleHistoryNavigate(entry: NotifierHistoryEntry): Promise<void> {
   if (!entry.navigateTarget) return;
   await navigateAndClose(entry.navigateTarget, entry.id);
 }
@@ -370,13 +392,14 @@ async function clearAllFyi(): Promise<void> {
             v-for="entry in displayedHistory"
             :key="`${entry.id}-${entry.terminalAt}`"
             :data-testid="`notification-history-${entry.id}`"
-            :role="entry.navigateTarget ? 'button' : undefined"
-            :tabindex="entry.navigateTarget ? 0 : undefined"
-            :aria-label="entry.navigateTarget ? localizeTitle(entry) : undefined"
-            :class="['px-3 py-2 focus:bg-gray-100 focus:outline-none', entry.navigateTarget ? 'cursor-pointer hover:bg-gray-50' : '']"
-            @click="entry.navigateTarget && handleHistoryClick(entry)"
-            @keydown.enter.prevent.self="(e) => entry.navigateTarget && !e.repeat && handleHistoryClick(entry)"
-            @keydown.space.prevent.self="(e) => entry.navigateTarget && !e.repeat && handleHistoryClick(entry)"
+            :role="isHistoryExpandable(entry) ? 'button' : undefined"
+            :tabindex="isHistoryExpandable(entry) ? 0 : undefined"
+            :aria-label="isHistoryExpandable(entry) ? localizeTitle(entry) : undefined"
+            :aria-expanded="isHistoryExpandable(entry) ? isHistoryBodyExpanded(entry.id) : undefined"
+            :class="['px-3 py-2 focus:bg-gray-100 focus:outline-none', isHistoryExpandable(entry) ? 'cursor-pointer hover:bg-gray-50' : '']"
+            @click="isHistoryExpandable(entry) && toggleHistoryBody(entry.id)"
+            @keydown.enter.prevent.self="(e) => isHistoryExpandable(entry) && !e.repeat && toggleHistoryBody(entry.id)"
+            @keydown.space.prevent.self="(e) => isHistoryExpandable(entry) && !e.repeat && toggleHistoryBody(entry.id)"
           >
             <div class="flex items-start gap-2">
               <!-- eslint-disable @intlify/vue-i18n/no-raw-text --
@@ -388,14 +411,34 @@ async function clearAllFyi(): Promise<void> {
               </span>
               <!-- eslint-enable @intlify/vue-i18n/no-raw-text -->
               <span :class="['mt-1 inline-block w-2 h-2 rounded-full shrink-0 opacity-30', severityDotClassForHistory(entry.severity)]" aria-hidden="true" />
-              <div :class="['flex-1 min-w-0', entry.navigateTarget ? 'hover:underline' : '']">
+              <div class="flex-1 min-w-0">
                 <div class="flex items-baseline gap-2">
-                  <span class="text-gray-700 truncate">{{ localizeTitle(entry) }}</span>
+                  <span :class="['text-gray-700', isHistoryBodyExpanded(entry.id) ? '' : 'truncate']">{{ localizeTitle(entry) }}</span>
                 </div>
-                <div class="text-gray-400 mt-0.5 font-mono text-[10px]">
-                  {{ formatTime(entry.terminalAt) }} · {{ entry.terminalType }} · {{ shortPkg(entry.pluginPkg) }}
+                <p
+                  v-if="isHistoryBodyExpanded(entry.id) && localizeBody(entry)"
+                  class="text-gray-600 mt-1 whitespace-pre-wrap break-words text-[11px]"
+                  data-testid="notification-history-body"
+                >
+                  {{ localizeBody(entry) }}
+                </p>
+                <div class="flex items-center gap-1 text-gray-400 mt-0.5 font-mono text-[10px]">
+                  <span>{{ formatTime(entry.terminalAt) }} · {{ entry.terminalType }} · {{ shortPkg(entry.pluginPkg) }}</span>
+                  <button
+                    v-if="isHistoryBodyExpanded(entry.id) && entry.navigateTarget"
+                    type="button"
+                    class="ml-1 text-blue-500 hover:text-blue-700"
+                    :aria-label="t('notificationBell.openTarget')"
+                    data-testid="notification-history-navigate"
+                    @click.stop="handleHistoryNavigate(entry)"
+                  >
+                    <span class="material-icons text-xs">open_in_new</span>
+                  </button>
                 </div>
               </div>
+              <span v-if="isHistoryExpandable(entry)" class="material-icons text-xs text-gray-300 shrink-0 mt-0.5" aria-hidden="true">
+                {{ isHistoryBodyExpanded(entry.id) ? "expand_less" : "expand_more" }}
+              </span>
             </div>
           </li>
         </ul>

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -393,14 +393,8 @@ async function clearAllFyi(): Promise<void> {
             v-for="entry in displayedHistory"
             :key="`${entry.id}-${entry.terminalAt}`"
             :data-testid="`notification-history-${entry.id}`"
-            :role="isHistoryExpandable(entry) ? 'button' : undefined"
-            :tabindex="isHistoryExpandable(entry) ? 0 : undefined"
-            :aria-label="isHistoryExpandable(entry) ? localizeTitle(entry) : undefined"
-            :aria-expanded="isHistoryExpandable(entry) ? isHistoryBodyExpanded(entry.id) : undefined"
-            :class="['px-3 py-2 focus:bg-gray-100 focus:outline-none', isHistoryExpandable(entry) ? 'cursor-pointer hover:bg-gray-50' : '']"
+            :class="['px-3 py-2', isHistoryExpandable(entry) ? 'cursor-pointer hover:bg-gray-50' : '']"
             @click="isHistoryExpandable(entry) && toggleHistoryBody(entry.id)"
-            @keydown.enter.prevent.self="(e) => isHistoryExpandable(entry) && !e.repeat && toggleHistoryBody(entry.id)"
-            @keydown.space.prevent.self="(e) => isHistoryExpandable(entry) && !e.repeat && toggleHistoryBody(entry.id)"
           >
             <div class="flex items-start gap-2">
               <!-- eslint-disable @intlify/vue-i18n/no-raw-text --
@@ -437,9 +431,19 @@ async function clearAllFyi(): Promise<void> {
                   </button>
                 </div>
               </div>
-              <span v-if="isHistoryExpandable(entry)" class="material-icons text-xs text-gray-300 shrink-0 mt-0.5" aria-hidden="true">
-                {{ isHistoryBodyExpanded(entry.id) ? "expand_less" : "expand_more" }}
-              </span>
+              <button
+                v-if="isHistoryExpandable(entry)"
+                type="button"
+                class="text-gray-300 hover:text-gray-500 shrink-0 mt-0.5"
+                :aria-label="localizeTitle(entry)"
+                :aria-expanded="isHistoryBodyExpanded(entry.id)"
+                data-testid="notification-history-expand"
+                @click.stop="toggleHistoryBody(entry.id)"
+              >
+                <span class="material-icons text-xs">
+                  {{ isHistoryBodyExpanded(entry.id) ? "expand_less" : "expand_more" }}
+                </span>
+              </button>
             </div>
           </li>
         </ul>

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -94,7 +94,7 @@ watch(
 watch(open, (nowOpen: boolean) => {
   if (!nowOpen) {
     historyExpanded.value = false;
-    expandedHistoryIds.value = new Set();
+    expandedHistoryIds.value = new Set<string>();
   }
 });
 
@@ -435,7 +435,7 @@ async function clearAllFyi(): Promise<void> {
                 v-if="isHistoryExpandable(entry)"
                 type="button"
                 class="text-gray-300 hover:text-gray-500 shrink-0 mt-0.5"
-                :aria-label="localizeTitle(entry)"
+                :aria-label="t('notificationBell.expandDetails')"
                 :aria-expanded="isHistoryBodyExpanded(entry.id)"
                 data-testid="notification-history-expand"
                 @click.stop="toggleHistoryBody(entry.id)"

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -74,6 +74,7 @@ const deMessages = {
     cancel: "Abbrechen",
     showMore: "Mehr anzeigen ({count})",
     showLess: "Weniger anzeigen",
+    openTarget: "Öffnen",
   },
   pluginDiagnostics: {
     title: "Plugin-Konfigurationsproblem",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -75,6 +75,7 @@ const deMessages = {
     showMore: "Mehr anzeigen ({count})",
     showLess: "Weniger anzeigen",
     openTarget: "Öffnen",
+    expandDetails: "Details anzeigen",
   },
   pluginDiagnostics: {
     title: "Plugin-Konfigurationsproblem",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -96,6 +96,7 @@ const enMessages = {
     cancel: "Cancel",
     showMore: "Show more ({count})",
     showLess: "Show less",
+    openTarget: "Open",
   },
   pluginDiagnostics: {
     title: "Plugin configuration issue",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -97,6 +97,7 @@ const enMessages = {
     showMore: "Show more ({count})",
     showLess: "Show less",
     openTarget: "Open",
+    expandDetails: "Expand details",
   },
   pluginDiagnostics: {
     title: "Plugin configuration issue",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -79,6 +79,7 @@ const esMessages = {
     cancel: "Cancelar",
     showMore: "Mostrar más ({count})",
     showLess: "Mostrar menos",
+    openTarget: "Abrir",
   },
   pluginDiagnostics: {
     title: "Problema de configuración del plugin",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -80,6 +80,7 @@ const esMessages = {
     showMore: "Mostrar más ({count})",
     showLess: "Mostrar menos",
     openTarget: "Abrir",
+    expandDetails: "Expandir detalles",
   },
   pluginDiagnostics: {
     title: "Problema de configuración del plugin",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -74,6 +74,7 @@ const frMessages = {
     cancel: "Annuler",
     showMore: "Voir plus ({count})",
     showLess: "Réduire",
+    openTarget: "Ouvrir",
   },
   pluginDiagnostics: {
     title: "Problème de configuration du plugin",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -75,6 +75,7 @@ const frMessages = {
     showMore: "Voir plus ({count})",
     showLess: "Réduire",
     openTarget: "Ouvrir",
+    expandDetails: "Afficher les détails",
   },
   pluginDiagnostics: {
     title: "Problème de configuration du plugin",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -81,6 +81,7 @@ const jaMessages = {
     cancel: "キャンセル",
     showMore: "もっと見る ({count})",
     showLess: "閉じる",
+    openTarget: "開く",
   },
   pluginDiagnostics: {
     title: "プラグイン設定の問題",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -82,6 +82,7 @@ const jaMessages = {
     showMore: "もっと見る ({count})",
     showLess: "閉じる",
     openTarget: "開く",
+    expandDetails: "詳細を展開",
   },
   pluginDiagnostics: {
     title: "プラグイン設定の問題",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -81,6 +81,7 @@ const koMessages = {
     cancel: "취소",
     showMore: "더 보기 ({count})",
     showLess: "접기",
+    openTarget: "열기",
   },
   pluginDiagnostics: {
     title: "플러그인 구성 문제",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -82,6 +82,7 @@ const koMessages = {
     showMore: "더 보기 ({count})",
     showLess: "접기",
     openTarget: "열기",
+    expandDetails: "상세 보기",
   },
   pluginDiagnostics: {
     title: "플러그인 구성 문제",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -74,6 +74,7 @@ const ptBRMessages = {
     cancel: "Cancelar",
     showMore: "Mostrar mais ({count})",
     showLess: "Mostrar menos",
+    openTarget: "Abrir",
   },
   pluginDiagnostics: {
     title: "Problema de configuração do plugin",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -75,6 +75,7 @@ const ptBRMessages = {
     showMore: "Mostrar mais ({count})",
     showLess: "Mostrar menos",
     openTarget: "Abrir",
+    expandDetails: "Expandir detalhes",
   },
   pluginDiagnostics: {
     title: "Problema de configuração do plugin",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -79,6 +79,7 @@ const zhMessages = {
     cancel: "取消",
     showMore: "显示更多 ({count})",
     showLess: "收起",
+    openTarget: "打开",
   },
   pluginDiagnostics: {
     title: "插件配置问题",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -80,6 +80,7 @@ const zhMessages = {
     showMore: "显示更多 ({count})",
     showLess: "收起",
     openTarget: "打开",
+    expandDetails: "展开详情",
   },
   pluginDiagnostics: {
     title: "插件配置问题",


### PR DESCRIPTION
## Summary

通知履歴アイテムをクリックして body（詳細内容）をインライン展開できるようにした。
- 履歴の行をクリック → body テキストが展開/折りたたみ（タイトルの truncate も解除）
- `navigateTarget` がある場合は展開時にリンクアイコン（`open_in_new`）表示
- 展開可能な行にはシェブロン（▾/▴）を `<button>` として表示（ARIA 準拠）
- パネルを閉じると展開状態はリセット

<img width="488" height="392" alt="image" src="https://github.com/user-attachments/assets/f3bec742-c8be-414d-adf2-7331eb4004ba" />


## Items to Confirm / Review

- chevron を `<button>` にして `<li>` から `role="button"` を外す構造変更（nested interactive 要素の ARIA 違反を解消）
- i18n `openTarget` キーを全 8 ロケールに追加

## User Prompt

通知履歴で確認済みの通知をクリックして内容を再確認できるようにしたい。

## Implementation

- `NotificationBell.vue`: `expandedHistoryIds` (reactive Set) で展開状態を管理。`isHistoryExpandable` / `isHistoryBodyExpanded` / `toggleHistoryBody` を追加。`<li>` はマウスクリック用の `@click` のみ保持し、キーボードアクセスは chevron `<button>` が担当
- `docs/ui-cheatsheet.md`: History rows の説明を更新
- `e2e/tests/notifications.spec.ts`: 展開/折りたたみ、パネル閉じでリセット、navigate アイコン表示/非表示、非展開行の 5 テスト追加
- 全 8 ロケール: `notificationBell.openTarget` キー追加

## Summary by Sourcery

Enable inline expansion of notification history entries in the bell panel and reset expansion state when the panel closes.

New Features:
- Allow notification history rows to expand and collapse their body inline on click, with title truncation lifted while expanded.
- Display a contextual navigate icon on expanded history entries that have a navigation target.

Enhancements:
- Track expanded history entries by ID and clear both history and expansion state whenever the notification panel closes.
- Improve accessibility of history rows by moving interaction to a dedicated chevron button instead of the list item role.
- Update the notification UI cheatsheet to describe the new history expansion and navigation behavior.
- Add localized labels for the notification history navigation control across all supported locales.

Tests:
- Extend end-to-end notification bell tests to cover history body expansion/collapse, state reset on panel close, navigate icon visibility, and non-expandable rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification history rows can be expanded inline to reveal full content.
  * Expanded entries with a navigation target show an "Open" action instead of making the whole row navigate.
  * Expansion state clears when the notification panel closes.

* **Localization**
  * Added "Open" and "Expand details" text for the notification bell in EN, DE, ES, FR, JA, KO, PT‑BR, ZH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->