### PR TITLE
feat(markdown): render presentDocument as Marp slides when frontmatter has `marp: true` (#1621)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@gui-chat-plugin/google-map": "^0.5.0",
     "@gui-chat-plugin/mindmap": "^0.4.1",
     "@gui-chat-plugin/present3d": "^0.4.1",
+    "@marp-team/marp-core": "^4.3.0",
     "@mulmobridge/client": "^0.1.0",
     "@mulmocast/deck": "^1.0.0",
     "@mulmocast/deck-web": "^1.1.0",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -26,6 +26,7 @@
     "@gui-chat-plugin/google-map": "^0.5.0",
     "@gui-chat-plugin/mindmap": "^0.4.1",
     "@gui-chat-plugin/present3d": "^0.4.1",
+    "@marp-team/marp-core": "^4.3.0",
     "@mulmobridge/chat-service": "^0.1.2",
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",

--- a/plans/feat-marp-slides-1621.md
+++ b/plans/feat-marp-slides-1621.md
@@ -1,0 +1,71 @@
+# feat-marp-slides-1621
+
+Render `presentDocument` markdown as **Marp slides** when frontmatter has `marp: true`. PDF export via server-side `marp-cli`.
+
+Tracking issue: [#1621](https://github.com/receptron/mulmoclaude/issues/1621)
+
+## Why
+
+- Existing slide-shaped surfaces: `presentMulmoScript` (JSON storyboard), `pptx` skill (programmatic build). Neither covers "agent writes a `.md` and it becomes a slide deck."
+- Marp's authoring format is just markdown + `---` slide breaks + a `marp: true` frontmatter flag. The `presentDocument` plugin (= `src/plugins/markdown/`) already parses frontmatter and renders a body — Marp slots in as a render-mode branch.
+- Smallest viable wedge: render-only on client, PDF export only on server, no nav, no theme picker.
+
+## Choice recap
+
+User picked **B 案** (extend `presentDocument`, vertical stack layout) with **PDF export included**. PPTX / HTML / PNG / per-slide nav are out of scope for this PR.
+
+## Files
+
+| Path | Change | Lines (est.) |
+|---|---|---|
+| `package.json` | + `@marp-team/marp-core` (frontend dep) | +1 |
+| `package.json` | + `@marp-team/marp-cli` (runtime dep, spawned for export) | +1 |
+| `src/plugins/markdown/View.vue` | branch on `frontmatter.marp === true` → render `<MarpView>` instead of markdown body | ~15 |
+| `src/plugins/markdown/MarpView.vue` | **new** — instantiate `Marp` from `marp-core`, render stacked HTML + inject `Marp.themeSet` CSS, header with Export PDF button | ~120 |
+| `src/plugins/markdown/marpDetect.ts` | **new** — pure helper `isMarpDocument(frontmatter: object): boolean`; covers `marp: true`, `marp: yes`, string `"true"` | ~15 |
+| `src/config/apiRoutes.ts` | + `EXPORT_MARP_PDF: "/api/plugins/markdown/export-pdf"` | +1 |
+| `server/api/routes/markdown.ts` | **new** — `POST /api/plugins/markdown/export-pdf` body `{ documentId, markdown }` → spawn `marp-cli` → write `artifacts/documents/<id>.pdf` → return URL | ~80 |
+| `server/api/index.ts` | mount markdown route | +2 |
+| `server/utils/marpRuntime.ts` | **new** — `detectMarpCli()` / `runMarpExport(md, outPath)`; caches Chromium availability check at boot | ~60 |
+| `src/utils/api.ts` | (re-uses existing `apiPost`, no change) | 0 |
+| `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` | + `marp.slides_mode`, `marp.export_pdf`, `marp.exporting`, `marp.export_failed`, `marp.export_unavailable` (8 locales lockstep) | +5 × 8 |
+| `test/plugins/markdown/test_marpDetect.ts` | **new** — unit tests for the detection helper | ~40 |
+| `test/server/api/test_markdown_export_pdf.ts` | **new** — handler test (mocks `marp-cli` spawn) | ~50 |
+| `docs/shared-utils.md` | + entry for `marpDetect` and `marpRuntime` if cross-cutting (review at the end) | +2 |
+
+## Tasks
+
+1. **Deps**: `yarn add @marp-team/marp-core @marp-team/marp-cli`
+2. **Detect helper** + tests: `marpDetect.ts` + `test_marpDetect.ts`
+3. **Client render**: `MarpView.vue` (stacked, marp-core instance memoized per markdown body, themes via `marp.themeSet.default`)
+4. **View.vue branching**: when `isMarpDocument(frontmatter)` → `<MarpView :markdown :documentId>` instead of existing markdown body
+5. **Server route**: `markdown.ts` + `marpRuntime.ts` + register in `apiRoutes.ts` + mount in `server/api/index.ts`
+6. **Export button**: `MarpView.vue` header with disabled-state when `availability !== "ready"`. Bootstrap availability via `GET /api/plugins/markdown/export-pdf/health` (or piggyback on first POST? Simpler: probe once at MarpView mount.)
+7. **i18n 8 locales** in lockstep
+8. **Local checks**: `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
+9. **Push + PR** with User Prompt section
+
+## Trade-offs / known limits
+
+- **Chromium dep**: `marp-cli` PDF export requires Chromium. We don't bundle one — rely on `puppeteer`'s download or system Chrome. If missing, the Export button stays disabled and a tooltip says "Chromium not detected; install Chrome or set CHROME_PATH." NOT a launch blocker for the feature; the in-browser render still works.
+- **`marp-core` size**: ~120 KB minified gzipped. Loaded lazily in `MarpView.vue` via dynamic `import()` so the markdown view's bundle isn't bloated for non-Marp documents. (Acceptable exception to the "no dynamic import for always-needed packages" rule because Marp is conditional.)
+- **No slide nav**: deliberately deferred. If the stacked view feels too "wall of slides", add `◀/▶ + counter` in a follow-up.
+- **No PPTX export**: marp-cli supports it, but PDF covers 90% of the "send it" use case. Defer PPTX until asked.
+- **Theme**: marp-core default. `<!-- theme: gaia -->` directives work because marp-core ships gaia/uncover/default.
+
+## Acceptance
+
+- Agent writing a markdown doc with `marp: true` frontmatter → right pane shows the Marp-rendered slide stack (not the markdown body)
+- Removing `marp: true` → falls back to existing `<MarkdownView>` rendering (no regression)
+- Export PDF button → PDF lands in `artifacts/documents/`, accessible via Files pane
+- Chromium missing → Export PDF disabled + tooltip explanation
+- 8 locales lockstep pass `vue-tsc`
+- `yarn format` / `lint` / `typecheck` / `build` / `test` all green
+
+## Out of scope (future)
+
+- Slide pagination / keyboard nav
+- PPTX / HTML / PNG export
+- Per-slide thumbnails sidebar
+- Marp theme picker UI
+- "Convert presentMulmoScript ↔ Marp" round-trip

--- a/plans/feat-marp-slides-1621.md
+++ b/plans/feat-marp-slides-1621.md
@@ -16,41 +16,46 @@ User picked **B 案** (extend `presentDocument`, vertical stack layout) with **P
 
 ## Files
 
+> **Note**: this section was rewritten after implementation to match
+> what actually shipped. The original draft proposed `marp-cli` as a
+> separate spawned binary with a new `/api/plugins/markdown/export-pdf`
+> route — both were dropped during implementation in favour of
+> reusing the existing puppeteer-backed `/api/pdf/markdown` route with
+> a `marp: true` flag, saving a dependency + a route + ~140 lines.
+
 | Path | Change | Lines (est.) |
 |---|---|---|
-| `package.json` | + `@marp-team/marp-core` (frontend dep) | +1 |
-| `package.json` | + `@marp-team/marp-cli` (runtime dep, spawned for export) | +1 |
+| `package.json` + `packages/mulmoclaude/package.json` | + `@marp-team/marp-core` (single new dep, used both client- and server-side) | +1 / +1 |
 | `src/plugins/markdown/View.vue` | branch on `frontmatter.marp === true` → render `<MarpView>` instead of markdown body | ~15 |
-| `src/plugins/markdown/MarpView.vue` | **new** — instantiate `Marp` from `marp-core`, render stacked HTML + inject `Marp.themeSet` CSS, header with Export PDF button | ~120 |
-| `src/plugins/markdown/marpDetect.ts` | **new** — pure helper `isMarpDocument(frontmatter: object): boolean`; covers `marp: true`, `marp: yes`, string `"true"` | ~15 |
-| `src/config/apiRoutes.ts` | + `EXPORT_MARP_PDF: "/api/plugins/markdown/export-pdf"` | +1 |
-| `server/api/routes/markdown.ts` | **new** — `POST /api/plugins/markdown/export-pdf` body `{ documentId, markdown }` → spawn `marp-cli` → write `artifacts/documents/<id>.pdf` → return URL | ~80 |
-| `server/api/index.ts` | mount markdown route | +2 |
-| `server/utils/marpRuntime.ts` | **new** — `detectMarpCli()` / `runMarpExport(md, outPath)`; caches Chromium availability check at boot | ~60 |
-| `src/utils/api.ts` | (re-uses existing `apiPost`, no change) | 0 |
-| `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` | + `marp.slides_mode`, `marp.export_pdf`, `marp.exporting`, `marp.export_failed`, `marp.export_unavailable` (8 locales lockstep) | +5 × 8 |
-| `test/plugins/markdown/test_marpDetect.ts` | **new** — unit tests for the detection helper | ~40 |
-| `test/server/api/test_markdown_export_pdf.ts` | **new** — handler test (mocks `marp-cli` spawn) | ~50 |
-| `docs/shared-utils.md` | + entry for `marpDetect` and `marpRuntime` if cross-cutting (review at the end) | +2 |
+| `src/plugins/markdown/MarpView.vue` | **new** — instantiate `Marp` from `marp-core`, render stacked HTML in a sandboxed iframe srcdoc with a CSP, header with Export PDF button | ~150 |
+| `src/plugins/markdown/Preview.vue` | Marp-aware chat-stream tile (slide-count badge instead of stripped-text dump) | ~25 |
+| `src/components/FileContentRenderer.vue` | Files-pane branch: `marp: true` → `<MarpView>` (lazy-loaded) | ~30 |
+| `src/utils/markdown/marpDetect.ts` | **new** — pure helper `isMarpDocument(meta: Record<string, unknown>): boolean`; covers `marp: true`, `marp: yes` / `"true"` / `1` etc. | ~15 |
+| `src/composables/usePdfDownload.ts` | + `marp?: boolean` + `baseDir?: string` options forwarded to the server PDF route | +5 |
+| `server/api/routes/pdf.ts` | + `marp?: boolean` body field on the existing `/api/pdf/markdown` route → `renderMarpPdf()` (marp-core HTML → `inlineImages()` → puppeteer 1280×720 / margin 0) | ~30 |
+| `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` | + `marpSlidesMode`, `marpExportPdf`, `marpRenderFailed` (8 locales lockstep) | +3 × 8 |
+| `test/utils/markdown/test_marpDetect.ts` | **new** — unit tests for the detection helper (9 cases) | ~50 |
 
 ## Tasks
 
-1. **Deps**: `yarn add @marp-team/marp-core @marp-team/marp-cli`
-2. **Detect helper** + tests: `marpDetect.ts` + `test_marpDetect.ts`
-3. **Client render**: `MarpView.vue` (stacked, marp-core instance memoized per markdown body, themes via `marp.themeSet.default`)
-4. **View.vue branching**: when `isMarpDocument(frontmatter)` → `<MarpView :markdown :documentId>` instead of existing markdown body
-5. **Server route**: `markdown.ts` + `marpRuntime.ts` + register in `apiRoutes.ts` + mount in `server/api/index.ts`
-6. **Export button**: `MarpView.vue` header with disabled-state when `availability !== "ready"`. Bootstrap availability via `GET /api/plugins/markdown/export-pdf/health` (or piggyback on first POST? Simpler: probe once at MarpView mount.)
-7. **i18n 8 locales** in lockstep
-8. **Local checks**: `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
-9. **Push + PR** with User Prompt section
+1. **Dep**: `yarn add @marp-team/marp-core -W` (single dep, used both sides; mirror to `packages/mulmoclaude/package.json` so the published launcher resolves it).
+2. **Detect helper** + tests: `marpDetect.ts` + `test_marpDetect.ts`.
+3. **Client render**: `MarpView.vue` — dynamic `import("@marp-team/marp-core")`, `inlineSVG: true`, srcdoc-iframe with CSP + override Marp's `100vh/100vw` SVG sizing to use the viewBox-driven aspect.
+4. **View.vue branching**: when `isMarpDocument(frontmatter)` → `<MarpView :markdown :pdf-filename :base-dir>` instead of `<MarkdownView>`. Surface `refreshFailed` banner above MarpView too.
+5. **Preview.vue / FileContentRenderer**: surface Marp recognition to the chat-stream tile and the Files pane.
+6. **Server**: extend `/api/pdf/markdown` with a `marp?: boolean` flag; new `renderMarpPdf()` reuses the existing `inlineImages()` helper + puppeteer at 1280×720, margin 0.
+7. **i18n 8 locales** in lockstep (`de.ts` uses ASCII-safe strings per the German-quote rule).
+8. **Local checks**: `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`.
+9. **Push + PR** with User Prompt section.
 
 ## Trade-offs / known limits
 
-- **Chromium dep**: `marp-cli` PDF export requires Chromium. We don't bundle one — rely on `puppeteer`'s download or system Chrome. If missing, the Export button stays disabled and a tooltip says "Chromium not detected; install Chrome or set CHROME_PATH." NOT a launch blocker for the feature; the in-browser render still works.
-- **`marp-core` size**: ~120 KB minified gzipped. Loaded lazily in `MarpView.vue` via dynamic `import()` so the markdown view's bundle isn't bloated for non-Marp documents. (Acceptable exception to the "no dynamic import for always-needed packages" rule because Marp is conditional.)
+- **Puppeteer reuse over marp-cli**: the originally-planned `@marp-team/marp-cli` spawn was dropped because the markdown PDF route already runs puppeteer in-process. Sharing the engine cuts the dep, the new route, and the Chromium-detection / disable-button code paths.
+- **`marp-core` size**: ~120 KB min+gz — loaded lazily in `MarpView.vue` via `await import("@marp-team/marp-core")` inside `renderMarp()`. The `MarpView` shell itself stays a static import from both call sites (`markdown/View.vue` and `FileContentRenderer.vue`): the shell is ~150 lines / ~4 KB, and `defineAsyncComponent`-wrapping it would add a Suspense boundary + a flash of loading state every time a Marp document opens, for marginal payoff once the real weight is already on its own chunk via the inner dynamic import. (Acceptable exception to the "no dynamic import for always-needed packages" rule because Marp itself is conditional.)
+- **iframe CSP**: srcdoc carries `Content-Security-Policy: default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline' 'self'; font-src 'self' data:;` plus `referrer: no-referrer` so a malicious deck can't exfiltrate via subresource fetches even if the `sandbox=""` boundary leaks.
+- **Preview-side images**: srcdoc iframes have no base URL, so workspace-relative `<img src>` won't load in the in-browser preview. Server PDF inlines them via the existing helper so the exported deck is complete. A `<base href>` for the preview is deferred until requested.
 - **No slide nav**: deliberately deferred. If the stacked view feels too "wall of slides", add `◀/▶ + counter` in a follow-up.
-- **No PPTX export**: marp-cli supports it, but PDF covers 90% of the "send it" use case. Defer PPTX until asked.
+- **No PPTX export**: marp-cli supports it; we don't ship marp-cli, so PPTX is out. PDF covers 90% of the "send it" use case.
 - **Theme**: marp-core default. `<!-- theme: gaia -->` directives work because marp-core ships gaia/uncover/default.
 
 ## Acceptance

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -249,15 +249,18 @@ async function renderPdf(fullHtml: string, format: "Letter" | "A4" = "Letter"): 
 // feed puppeteer a page sized to that canvas with zero margin so each
 // `<section>` becomes exactly one PDF page at the slide's native
 // proportions. Skips the markdown CSS wrapper — Marp's own theme CSS
-// is the only style sheet the slides need.
-async function renderMarpPdf(markdown: string): Promise<Buffer> {
+// is the only style sheet the slides need. Images are inlined as
+// base64 data URIs (same path as the markdown route) because puppeteer
+// can't reach workspace-relative paths over the wire.
+async function renderMarpPdf(markdown: string, baseDir?: string): Promise<Buffer> {
   const marp = new Marp({ html: false });
   const { html, css } = marp.render(markdown);
+  const inlinedHtml = inlineImages(html, { sourceDir: baseDir });
   const fullHtml = `<!doctype html>
 <html><head><meta charset="utf-8"><style>
 html,body { margin:0; padding:0; background:white; }
 ${css}
-</style></head><body>${html}</body></html>`;
+</style></head><body>${inlinedHtml}</body></html>`;
   const browser = await puppeteer.launch({ headless: true });
   try {
     const page = await browser.newPage();
@@ -301,8 +304,10 @@ interface PdfMarkdownBody {
   stripFrontmatter?: boolean;
   /** When true, render via Marp (`@marp-team/marp-core`) instead of
    *  the default `marked` pipeline — one PDF page per `---`-separated
-   *  slide, 16:9, Marp's theme CSS. `baseDir` / `stripFrontmatter` /
-   *  `format` are ignored in this mode (Marp owns layout end-to-end). */
+   *  slide, 16:9, Marp's theme CSS. `baseDir` is still honoured for
+   *  resolving workspace-relative `<img src>` references; `format`
+   *  and `stripFrontmatter` are ignored (Marp owns paging + already
+   *  consumes its own frontmatter directives). */
   marp?: boolean;
 }
 
@@ -335,8 +340,8 @@ router.post(API_ROUTES.pdf.markdown, async (req: Request<object, unknown, PdfMar
 
   try {
     if (marpMode) {
-      log.info("pdf", "marp", { filename, length: markdown.length });
-      const buffer = await renderMarpPdf(markdown);
+      log.info("pdf", "marp", { filename, length: markdown.length, baseDir });
+      const buffer = await renderMarpPdf(markdown, baseDir);
       sendPdf(res, buffer, filename);
       return;
     }

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -2,6 +2,7 @@ import { realpathSync } from "fs";
 import path from "path";
 import { Router, Request, Response } from "express";
 import { marked } from "marked";
+import { Marp } from "@marp-team/marp-core";
 import puppeteer from "puppeteer";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
@@ -244,6 +245,36 @@ async function renderPdf(fullHtml: string, format: "Letter" | "A4" = "Letter"): 
   }
 }
 
+// Marp slides render at a fixed pixel canvas (default 1280×720). We
+// feed puppeteer a page sized to that canvas with zero margin so each
+// `<section>` becomes exactly one PDF page at the slide's native
+// proportions. Skips the markdown CSS wrapper — Marp's own theme CSS
+// is the only style sheet the slides need.
+async function renderMarpPdf(markdown: string): Promise<Buffer> {
+  const marp = new Marp({ html: false });
+  const { html, css } = marp.render(markdown);
+  const fullHtml = `<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body { margin:0; padding:0; background:white; }
+${css}
+</style></head><body>${html}</body></html>`;
+  const browser = await puppeteer.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 720 });
+    await page.setContent(fullHtml, { waitUntil: "load" });
+    const pdfBuffer = await page.pdf({
+      width: "1280px",
+      height: "720px",
+      margin: { top: "0", bottom: "0", left: "0", right: "0" },
+      printBackground: true,
+    });
+    return Buffer.from(pdfBuffer);
+  } finally {
+    await browser.close();
+  }
+}
+
 function sendPdf(res: Response, buffer: Buffer, filename: string): void {
   const safeFilename = filename.endsWith(".pdf") ? filename : `${filename}.pdf`;
   res.setHeader("Content-Type", "application/pdf");
@@ -268,6 +299,11 @@ interface PdfMarkdownBody {
    *  document that *literally* starts with `---\n…\n---\n` is
    *  preserved verbatim. */
   stripFrontmatter?: boolean;
+  /** When true, render via Marp (`@marp-team/marp-core`) instead of
+   *  the default `marked` pipeline — one PDF page per `---`-separated
+   *  slide, 16:9, Marp's theme CSS. `baseDir` / `stripFrontmatter` /
+   *  `format` are ignored in this mode (Marp owns layout end-to-end). */
+  marp?: boolean;
 }
 
 router.post(API_ROUTES.pdf.markdown, async (req: Request<object, unknown, PdfMarkdownBody>, res: Response) => {
@@ -290,6 +326,7 @@ router.post(API_ROUTES.pdf.markdown, async (req: Request<object, unknown, PdfMar
   const format: "Letter" | "A4" = body.format === "A4" ? "A4" : "Letter";
   const baseDir = typeof body.baseDir === "string" ? body.baseDir : undefined;
   const stripFrontmatter = body.stripFrontmatter === true;
+  const marpMode = body.marp === true;
 
   if (!markdown) {
     badRequest(res, "markdown is required");
@@ -297,6 +334,12 @@ router.post(API_ROUTES.pdf.markdown, async (req: Request<object, unknown, PdfMar
   }
 
   try {
+    if (marpMode) {
+      log.info("pdf", "marp", { filename, length: markdown.length });
+      const buffer = await renderMarpPdf(markdown);
+      sendPdf(res, buffer, filename);
+      return;
+    }
     log.info("pdf", "markdown", { filename, length: markdown.length, baseDir, stripFrontmatter });
     const source = stripFrontmatter ? parseFrontmatter(markdown).body : markdown;
     const html = inlineImages(await marked.parse(source), { sourceDir: baseDir });

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -252,7 +252,10 @@ const marpBaseDir = computed(() => {
   const path = props.selectedPath;
   if (!path) return undefined;
   const idx = path.lastIndexOf("/");
-  return idx > 0 ? path.slice(0, idx) : undefined;
+  // Root-level markdown (no "/") → "" so server-side inlineImages()
+  // resolves relative `<img>` refs against the workspace root instead
+  // of falling back to the legacy `markdowns/` sourceDir (codex review).
+  return idx < 0 ? "" : path.slice(0, idx);
 });
 
 const marpPdfFilename = computed(() => {

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -28,6 +28,14 @@
             <CalendarView :selected-result="schedulerResult" />
           </PluginScopedRoot>
         </div>
+        <!-- Marp slides: detected via `marp: true` frontmatter; replaces
+             the default markdown render with the slide-stack canvas
+             component. Frontmatter envelope is fed to Marp verbatim
+             because marp-core consumes its own directives (theme,
+             paginate, size, …) from the YAML header. -->
+        <div v-else-if="isMarkdown && !mdRawMode && marpMode" class="h-full flex flex-col overflow-auto">
+          <MarpView :markdown="content.content" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
+        </div>
         <!-- Markdown rendered: frontmatter panel + body -->
         <div v-else-if="isMarkdown && !mdRawMode" class="h-full flex flex-col overflow-auto">
           <div v-if="mdFrontmatter && mdFrontmatter.fields.length > 0" class="shrink-0 m-4 mb-0 rounded border border-gray-200 bg-gray-50 p-3 text-xs">
@@ -203,6 +211,9 @@ import { formatScalarField, type MarkdownDocView } from "../composables/useMarkd
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
 import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
+import { isMarpDocument } from "../utils/markdown/marpDetect";
+import { buildPdfFilename } from "../utils/files/filename";
+import MarpView from "../plugins/markdown/MarpView.vue";
 // Lazy: CodeMirror (~390 KB raw) is only fetched when a user actually
 // opens the inline JSON editor, keeping it out of the initial bundle.
 const JsonEditor = defineAsyncComponent(() => import("./JsonEditor.vue"));
@@ -234,6 +245,24 @@ const emit = defineEmits<{
 }>();
 
 const systemDescriptor = computed(() => (props.selectedPath ? descriptorForPath(props.selectedPath) : null));
+
+const marpMode = computed(() => Boolean(props.mdFrontmatter && isMarpDocument(props.mdFrontmatter.meta)));
+
+const marpBaseDir = computed(() => {
+  const path = props.selectedPath;
+  if (!path) return undefined;
+  const idx = path.lastIndexOf("/");
+  return idx > 0 ? path.slice(0, idx) : undefined;
+});
+
+const marpPdfFilename = computed(() => {
+  const path = props.selectedPath ?? "";
+  const lastSlash = path.lastIndexOf("/");
+  const base = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
+  const dot = base.lastIndexOf(".");
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  return buildPdfFilename({ name: stem, fallback: "slides" });
+});
 
 // Inline JSON editor (#833 Phase 1). Available only for policy-editable
 // JSON config files; the read-only pretty-print stays the default.

--- a/src/composables/usePdfDownload.ts
+++ b/src/composables/usePdfDownload.ts
@@ -25,6 +25,11 @@ export interface DownloadPdfOptions {
    *  Other callers leave it false so a chat-generated document that
    *  literally starts with `---` is preserved. */
   stripFrontmatter?: boolean;
+  /** When true, the server renders the markdown via Marp (slide deck,
+   *  one slide per page, 16:9) instead of the default paged markdown
+   *  layout. Caller sets this when the source has `marp: true` in its
+   *  frontmatter. */
+  marp?: boolean;
 }
 
 export interface UsePdfDownloadHandle {
@@ -47,7 +52,7 @@ export function usePdfDownload(): UsePdfDownloadHandle {
       const response = await apiFetchRaw(API_ROUTES.pdf.markdown, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ markdown, filename, baseDir: options.baseDir, stripFrontmatter: options.stripFrontmatter }),
+        body: JSON.stringify({ markdown, filename, baseDir: options.baseDir, stripFrontmatter: options.stripFrontmatter, marp: options.marp }),
       });
       if (!response.ok) {
         const errText = await response.text().catch(() => "");

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1231,6 +1231,9 @@ const deMessages = {
     copiedLabel: "Kopiert!",
     taskCountMismatch:
       "Die Anzahl der Aufgaben in der Markdown-Quelle und im gerenderten Ergebnis stimmt nicht überein. Das Umschalten wurde abgelehnt, um eine Beschädigung der Datei zu vermeiden.",
+    marpSlidesMode: "Marp-Folien · {count}",
+    marpExportPdf: "Als PDF exportieren",
+    marpRenderFailed: "⚠ Rendern der Marp-Folien fehlgeschlagen: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1213,6 +1213,9 @@ const enMessages = {
     copyLabel: "Copy",
     copiedLabel: "Copied!",
     taskCountMismatch: "Markdown source and rendered output disagree on the number of tasks. Refusing to toggle to avoid corruption.",
+    marpSlidesMode: "Marp slides · {count}",
+    marpExportPdf: "Export PDF",
+    marpRenderFailed: "⚠ Failed to render Marp slides: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1227,6 +1227,9 @@ const esMessages = {
     copyLabel: "Copiar",
     copiedLabel: "¡Copiado!",
     taskCountMismatch: "El número de tareas no coincide entre la fuente Markdown y la salida renderizada. Se rechazó el cambio para evitar dañar el archivo.",
+    marpSlidesMode: "Diapositivas Marp · {count}",
+    marpExportPdf: "Exportar PDF",
+    marpRenderFailed: "⚠ Error al renderizar las diapositivas Marp: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1220,6 +1220,9 @@ const frMessages = {
     copyLabel: "Copier",
     copiedLabel: "Copié !",
     taskCountMismatch: "Le nombre de tâches diffère entre la source Markdown et le rendu. La modification a été refusée pour éviter de corrompre le fichier.",
+    marpSlidesMode: "Diapositives Marp · {count}",
+    marpExportPdf: "Exporter en PDF",
+    marpRenderFailed: "⚠ Échec du rendu des diapositives Marp : {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1213,6 +1213,9 @@ const jaMessages = {
     copyLabel: "コピー",
     copiedLabel: "コピーしました！",
     taskCountMismatch: "Markdown ソースと描画結果でタスク数が一致しないため、ファイル破損を避けるためトグル操作を中止しました。",
+    marpSlidesMode: "Marp スライド · {count}",
+    marpExportPdf: "PDFを書き出し",
+    marpRenderFailed: "⚠ Marp スライドの描画に失敗しました: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1214,6 +1214,9 @@ const koMessages = {
     copyLabel: "복사",
     copiedLabel: "복사됨!",
     taskCountMismatch: "Markdown 원본과 렌더링 결과의 작업 수가 일치하지 않아, 파일 손상을 방지하기 위해 토글이 거부되었습니다.",
+    marpSlidesMode: "Marp 슬라이드 · {count}",
+    marpExportPdf: "PDF로 내보내기",
+    marpRenderFailed: "⚠ Marp 슬라이드 렌더링 실패: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1215,6 +1215,9 @@ const ptBRMessages = {
     copyLabel: "Copiar",
     copiedLabel: "Copiado!",
     taskCountMismatch: "O número de tarefas diverge entre a fonte Markdown e a saída renderizada. A alternância foi recusada para evitar corromper o arquivo.",
+    marpSlidesMode: "Slides Marp · {count}",
+    marpExportPdf: "Exportar PDF",
+    marpRenderFailed: "⚠ Falha ao renderizar os slides Marp: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1204,6 +1204,9 @@ const zhMessages = {
     copyLabel: "复制",
     copiedLabel: "已复制!",
     taskCountMismatch: "Markdown 源与渲染输出的任务数不一致，为避免文件损坏，已拒绝切换。",
+    marpSlidesMode: "Marp 幻灯片 · {count}",
+    marpExportPdf: "导出 PDF",
+    marpRenderFailed: "⚠ Marp 幻灯片渲染失败: {error}",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/plugins/markdown/MarpView.vue
+++ b/src/plugins/markdown/MarpView.vue
@@ -39,6 +39,7 @@ const { t } = useI18n();
 const props = defineProps<{
   markdown: string;
   pdfFilename: string;
+  baseDir?: string;
 }>();
 
 const SLIDE_ASPECT = 9 / 16;
@@ -61,12 +62,24 @@ const frameHeight = computed(() => {
 });
 
 function buildSrcDoc(html: string, css: string): string {
+  // Marp's default theme sets `svg[data-marpit-svg] { width:100vw;
+  // height:100vh }` so each slide tries to fill the entire viewport —
+  // right for the presenter app, wrong for a stacked-deck iframe view.
+  // Override AFTER Marp's CSS so our rule wins, and rely on the SVG's
+  // viewBox (1280×720) to keep the 16:9 aspect via `height: auto`.
   return `<!doctype html>
 <html><head><meta charset="utf-8"><style>
 html,body { margin:0; padding:16px; background:transparent; }
-section { box-shadow: 0 2px 8px rgba(0,0,0,0.12); border-radius: 6px; margin: 0 auto ${SLIDE_GAP_PX}px; max-width: 100%; }
-svg { width: 100%; height: auto; display: block; margin: 0 auto ${SLIDE_GAP_PX}px; box-shadow: 0 2px 8px rgba(0,0,0,0.12); border-radius: 6px; background: white; }
 ${css}
+div.marpit > svg[data-marpit-svg] {
+  width: 100% !important;
+  height: auto !important;
+  display: block !important;
+  margin: 0 auto ${SLIDE_GAP_PX}px !important;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  border-radius: 6px;
+  background: white;
+}
 </style></head><body>${html}</body></html>`;
 }
 
@@ -124,7 +137,7 @@ onBeforeUnmount(() => {
 
 async function onExportPdf(): Promise<void> {
   if (!props.markdown) return;
-  await downloadPdf(props.markdown, props.pdfFilename, { marp: true });
+  await downloadPdf(props.markdown, props.pdfFilename, { marp: true, baseDir: props.baseDir });
 }
 </script>
 

--- a/src/plugins/markdown/MarpView.vue
+++ b/src/plugins/markdown/MarpView.vue
@@ -1,0 +1,163 @@
+<template>
+  <div ref="containerEl" class="marp-container">
+    <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+      <span class="text-xs text-gray-500 mr-auto pl-2">{{ t("pluginMarkdown.marpSlidesMode", { count: slideCount }) }}</span>
+      <button
+        class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        :disabled="pdfDownloading"
+        @click="onExportPdf"
+      >
+        <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
+        {{ t("pluginMarkdown.marpExportPdf") }}
+      </button>
+      <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginMarkdown.pdfFailedShort") }}</span>
+    </div>
+    <div v-if="renderError" class="load-error-banner" role="alert">
+      {{ t("pluginMarkdown.marpRenderFailed", { error: renderError }) }}
+    </div>
+    <div class="marp-frame-wrapper">
+      <iframe
+        v-if="srcDoc"
+        :srcdoc="srcDoc"
+        :style="{ height: frameHeight + 'px' }"
+        sandbox=""
+        class="marp-frame"
+        :title="t('pluginMarkdown.marpSlidesMode', { count: slideCount })"
+      ></iframe>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { usePdfDownload } from "../../composables/usePdfDownload";
+import { errorMessage } from "../../utils/errors";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  markdown: string;
+  pdfFilename: string;
+}>();
+
+const SLIDE_ASPECT = 9 / 16;
+const SLIDE_GAP_PX = 16;
+const FRAME_PADDING_PX = 32;
+const FALLBACK_WIDTH_PX = 800;
+
+const containerEl = ref<HTMLElement | null>(null);
+const containerWidth = ref(FALLBACK_WIDTH_PX);
+const srcDoc = ref<string>("");
+const slideCount = ref(0);
+const renderError = ref<string | null>(null);
+
+const { pdfDownloading, pdfError, downloadPdf } = usePdfDownload();
+
+const frameHeight = computed(() => {
+  if (slideCount.value === 0) return FRAME_PADDING_PX;
+  const slideHeight = containerWidth.value * SLIDE_ASPECT;
+  return Math.ceil(slideCount.value * slideHeight + Math.max(0, slideCount.value - 1) * SLIDE_GAP_PX + FRAME_PADDING_PX);
+});
+
+function buildSrcDoc(html: string, css: string): string {
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><style>
+html,body { margin:0; padding:16px; background:transparent; }
+section { box-shadow: 0 2px 8px rgba(0,0,0,0.12); border-radius: 6px; margin: 0 auto ${SLIDE_GAP_PX}px; max-width: 100%; }
+svg { width: 100%; height: auto; display: block; margin: 0 auto ${SLIDE_GAP_PX}px; box-shadow: 0 2px 8px rgba(0,0,0,0.12); border-radius: 6px; background: white; }
+${css}
+</style></head><body>${html}</body></html>`;
+}
+
+function countSlides(html: string): number {
+  const svgMatches = html.match(/<svg[\s>]/g);
+  if (svgMatches) return svgMatches.length;
+  const sectionMatches = html.match(/<section[\s>]/g);
+  return sectionMatches ? sectionMatches.length : 0;
+}
+
+async function renderMarp(markdown: string): Promise<void> {
+  renderError.value = null;
+  if (!markdown) {
+    srcDoc.value = "";
+    slideCount.value = 0;
+    return;
+  }
+  try {
+    const { Marp } = await import("@marp-team/marp-core");
+    const marp = new Marp({ inlineSVG: true, html: false });
+    const { html, css } = marp.render(markdown);
+    slideCount.value = countSlides(html);
+    srcDoc.value = buildSrcDoc(html, css);
+  } catch (err) {
+    renderError.value = errorMessage(err);
+    srcDoc.value = "";
+    slideCount.value = 0;
+  }
+}
+
+watch(
+  () => props.markdown,
+  (source) => {
+    void renderMarp(source);
+  },
+  { immediate: true },
+);
+
+let resizeObserver: ResizeObserver | null = null;
+
+onMounted(() => {
+  if (!containerEl.value) return;
+  containerWidth.value = containerEl.value.clientWidth || FALLBACK_WIDTH_PX;
+  resizeObserver = new ResizeObserver((entries) => {
+    const [entry] = entries;
+    if (entry) containerWidth.value = entry.contentRect.width || FALLBACK_WIDTH_PX;
+  });
+  resizeObserver.observe(containerEl.value);
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+});
+
+async function onExportPdf(): Promise<void> {
+  if (!props.markdown) return;
+  await downloadPdf(props.markdown, props.pdfFilename, { marp: true });
+}
+</script>
+
+<style scoped>
+.marp-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #f8fafc;
+}
+
+.marp-frame-wrapper {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.marp-frame {
+  width: 100%;
+  border: none;
+  background: transparent;
+  display: block;
+}
+
+.load-error-banner {
+  margin: 0.75rem 1rem;
+  padding: 0.5rem 0.75rem;
+  background: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c2c7;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+</style>

--- a/src/plugins/markdown/MarpView.vue
+++ b/src/plugins/markdown/MarpView.vue
@@ -68,13 +68,24 @@ const frameHeight = computed(() => {
 // the slide could attempt — `connect-src 'none'` denies fetch /
 // XHR / WebSocket / EventSource, and `frame-ancestors 'none'`
 // prevents the iframe from being reframed by hostile content.
-// `img-src *` (with `referrer: no-referrer` set below) lets the
-// markdown's workspace-rooted image refs load — `<img>` is read-
-// only, so loosening the allowlist here doesn't open a script /
-// fetch / XHR vector but does fix the "preview shows broken
-// images" failure mode that surfaced for relative refs. Style
-// allows inline `<style>` blocks (Marp's theme CSS arrives inline).
-const SRCDOC_CSP = "default-src 'none'; img-src * data:; style-src 'unsafe-inline' 'self'; font-src 'self' data:; connect-src 'none'; frame-ancestors 'none';";
+//
+// `img-src` is pinned at runtime to the **parent app's origin** (plus
+// `data:`). We can't use `'self'` here: `sandbox=""` srcdoc iframes
+// have an opaque origin, and `'self'` resolves against that opaque
+// origin (= matches nothing), which would block every workspace
+// image including the legitimate `/artifacts/images/...` paths the
+// rewriter produces. Pinning to `window.location.origin` lets the
+// rewritten same-host URLs load while still denying every other host
+// — a malicious deck can't craft `<img src="http://10.0.0.1/...">`
+// SSRF probes or fetch external trackers. Style allows inline
+// `<style>` blocks (Marp ships theme CSS inline). The `referrer`
+// meta below keeps even the same-origin image fetches from leaking
+// a referrer URL to the workspace file server.
+function buildCsp(): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const imgSrc = origin ? `${origin} data:` : "data:";
+  return `default-src 'none'; img-src ${imgSrc}; style-src 'unsafe-inline' 'self'; font-src 'self' data:; connect-src 'none'; frame-ancestors 'none';`;
+}
 
 function buildSrcDoc(html: string, css: string): string {
   // Marp's default theme sets `svg[data-marpit-svg] { width:100vw;
@@ -84,7 +95,7 @@ function buildSrcDoc(html: string, css: string): string {
   // viewBox (1280×720) to keep the 16:9 aspect via `height: auto`.
   return `<!doctype html>
 <html><head><meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="${SRCDOC_CSP}">
+<meta http-equiv="Content-Security-Policy" content="${buildCsp()}">
 <meta name="referrer" content="no-referrer">
 <style>
 html,body { margin:0; padding:16px; background:transparent; }
@@ -135,10 +146,16 @@ async function renderMarp(markdown: string): Promise<void> {
   }
 }
 
+// Re-render whenever either the markdown OR the baseDir changes —
+// `rewriteMarkdownImageRefs` resolves `../images/foo.png` against
+// `baseDir`, so switching between two decks with the same body
+// text but different file paths would otherwise reuse stale URLs
+// (codex review). Pass `markdown` through verbatim; `renderMarp`
+// already reads `props.baseDir` directly.
 watch(
-  () => props.markdown,
-  (source) => {
-    void renderMarp(source);
+  () => [props.markdown, props.baseDir],
+  ([source]) => {
+    void renderMarp(source as string);
   },
   { immediate: true },
 );

--- a/src/plugins/markdown/MarpView.vue
+++ b/src/plugins/markdown/MarpView.vue
@@ -33,6 +33,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { errorMessage } from "../../utils/errors";
+import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 
 const { t } = useI18n();
 
@@ -67,12 +68,13 @@ const frameHeight = computed(() => {
 // the slide could attempt — `connect-src 'none'` denies fetch /
 // XHR / WebSocket / EventSource, and `frame-ancestors 'none'`
 // prevents the iframe from being reframed by hostile content.
-// `img-src 'self' data:` lets Marp's default-theme inline SVG and
-// inlined-as-data-URI assets render; `style-src 'unsafe-inline'
-// 'self'` is required because marp-core ships its theme CSS inline
-// via `<style>` blocks inside each rendered slide.
-const SRCDOC_CSP =
-  "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline' 'self'; font-src 'self' data:; connect-src 'none'; frame-ancestors 'none';";
+// `img-src *` (with `referrer: no-referrer` set below) lets the
+// markdown's workspace-rooted image refs load — `<img>` is read-
+// only, so loosening the allowlist here doesn't open a script /
+// fetch / XHR vector but does fix the "preview shows broken
+// images" failure mode that surfaced for relative refs. Style
+// allows inline `<style>` blocks (Marp's theme CSS arrives inline).
+const SRCDOC_CSP = "default-src 'none'; img-src * data:; style-src 'unsafe-inline' 'self'; font-src 'self' data:; connect-src 'none'; frame-ancestors 'none';";
 
 function buildSrcDoc(html: string, css: string): string {
   // Marp's default theme sets `svg[data-marpit-svg] { width:100vw;
@@ -116,7 +118,14 @@ async function renderMarp(markdown: string): Promise<void> {
   try {
     const { Marp } = await import("@marp-team/marp-core");
     const marp = new Marp({ inlineSVG: true, html: false });
-    const { html, css } = marp.render(markdown);
+    // Normalise `![alt](path)` refs BEFORE marp parses them — same
+    // pre-pass the regular markdown renderer uses (wiki/View.vue,
+    // FilesView.vue, markdown/View.vue). Without it, refs like
+    // `../images/foo.png` resolve against `about:srcdoc` and 404.
+    // Workspace-rooted refs route through `/artifacts/images` (static
+    // mount) or `/api/files/raw` (authenticated route).
+    const rewritten = rewriteMarkdownImageRefs(markdown, props.baseDir ?? "");
+    const { html, css } = marp.render(rewritten);
     slideCount.value = countSlides(html);
     srcDoc.value = buildSrcDoc(html, css);
   } catch (err) {

--- a/src/plugins/markdown/MarpView.vue
+++ b/src/plugins/markdown/MarpView.vue
@@ -61,6 +61,19 @@ const frameHeight = computed(() => {
   return Math.ceil(slideCount.value * slideHeight + Math.max(0, slideCount.value - 1) * SLIDE_GAP_PX + FRAME_PADDING_PX);
 });
 
+// Hard-locked CSP: defence-in-depth on top of `sandbox=""`. Even
+// if the iframe boundary ever leaks (e.g. someone removes the empty
+// sandbox attribute), the policy still blocks every network egress
+// the slide could attempt — `connect-src 'none'` denies fetch /
+// XHR / WebSocket / EventSource, and `frame-ancestors 'none'`
+// prevents the iframe from being reframed by hostile content.
+// `img-src 'self' data:` lets Marp's default-theme inline SVG and
+// inlined-as-data-URI assets render; `style-src 'unsafe-inline'
+// 'self'` is required because marp-core ships its theme CSS inline
+// via `<style>` blocks inside each rendered slide.
+const SRCDOC_CSP =
+  "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline' 'self'; font-src 'self' data:; connect-src 'none'; frame-ancestors 'none';";
+
 function buildSrcDoc(html: string, css: string): string {
   // Marp's default theme sets `svg[data-marpit-svg] { width:100vw;
   // height:100vh }` so each slide tries to fill the entire viewport —
@@ -68,7 +81,10 @@ function buildSrcDoc(html: string, css: string): string {
   // Override AFTER Marp's CSS so our rule wins, and rely on the SVG's
   // viewBox (1280×720) to keep the 16:9 aspect via `height: auto`.
   return `<!doctype html>
-<html><head><meta charset="utf-8"><style>
+<html><head><meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${SRCDOC_CSP}">
+<meta name="referrer" content="no-referrer">
+<style>
 html,body { margin:0; padding:16px; background:transparent; }
 ${css}
 div.marpit > svg[data-marpit-svg] {

--- a/src/plugins/markdown/Preview.vue
+++ b/src/plugins/markdown/Preview.vue
@@ -1,9 +1,13 @@
 <template>
   <div class="p-2 bg-purple-100 rounded overflow-hidden">
-    <div class="text-sm text-gray-800 font-medium truncate">
-      {{ displayTitle }}
+    <div class="text-sm text-gray-800 font-medium truncate flex items-center gap-1">
+      <span v-if="marpInfo" class="material-icons text-base text-purple-700" aria-hidden="true">slideshow</span>
+      <span class="truncate">{{ displayTitle }}</span>
     </div>
-    <div v-if="contentPreview" class="text-xs text-gray-500 mt-1 line-clamp-4 whitespace-pre-line">
+    <div v-if="marpInfo" class="text-xs text-purple-700 mt-1">
+      {{ t("pluginMarkdown.marpSlidesMode", { count: marpInfo.slideCount }) }}
+    </div>
+    <div v-else-if="contentPreview" class="text-xs text-gray-500 mt-1 line-clamp-4 whitespace-pre-line">
       {{ contentPreview }}
     </div>
   </div>
@@ -11,11 +15,16 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
 import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
 import { extractFirstH1 } from "../../utils/markdown/extractFirstH1";
+import { parseFrontmatter } from "../../utils/markdown/frontmatter";
+import { isMarpDocument } from "../../utils/markdown/marpDetect";
 import { apiGet } from "../../utils/api";
 import { pluginEndpoints } from "../api";
+
+const { t } = useI18n();
 
 const filesEndpoints = pluginEndpoints<{ content: string }>("files");
 
@@ -48,6 +57,20 @@ const resolvedMarkdown = computed(() => {
   const raw = props.result.data?.markdown;
   if (!raw) return "";
   return isFilePath(raw) ? fetchedContent.value : raw;
+});
+
+function countMarpSlides(body: string): number {
+  if (!body.trim()) return 0;
+  const separators = body.match(/^---\s*$/gm);
+  return (separators?.length ?? 0) + 1;
+}
+
+const marpInfo = computed(() => {
+  const markdown = resolvedMarkdown.value;
+  if (!markdown) return null;
+  const { meta, body } = parseFrontmatter(markdown);
+  if (!isMarpDocument(meta)) return null;
+  return { slideCount: countMarpSlides(body) };
 });
 
 const displayTitle = computed(() => {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -9,7 +9,7 @@
     <div v-else-if="!markdownContent" class="min-h-full p-8 flex items-center justify-center">
       <div class="text-gray-500">{{ t("pluginMarkdown.noContent") }}</div>
     </div>
-    <MarpView v-else-if="marpMode" :markdown="markdownContent" :pdf-filename="marpPdfFilename" />
+    <MarpView v-else-if="marpMode" :markdown="markdownContent" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
     <template v-else>
       <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
         <button
@@ -198,6 +198,13 @@ watch(fileVersion, (current, previous) => {
 const mdDoc = useMarkdownDoc(markdownContent);
 
 const marpMode = computed(() => isMarpDocument(mdDoc.value.meta));
+
+const marpBaseDir = computed(() => {
+  const raw = props.selectedResult.data?.markdown;
+  if (typeof raw !== "string" || !isFilePath(raw)) return undefined;
+  const idx = raw.lastIndexOf("/");
+  return idx > 0 ? raw.slice(0, idx) : undefined;
+});
 
 const marpPdfFilename = computed(() => {
   const prefix = props.selectedResult.data?.filenamePrefix;

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -9,6 +9,7 @@
     <div v-else-if="!markdownContent" class="min-h-full p-8 flex items-center justify-center">
       <div class="text-gray-500">{{ t("pluginMarkdown.noContent") }}</div>
     </div>
+    <MarpView v-else-if="marpMode" :markdown="markdownContent" :pdf-filename="marpPdfFilename" />
     <template v-else>
       <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
         <button
@@ -93,6 +94,8 @@ import { useClipboardCopy } from "../../composables/useClipboardCopy";
 import { buildPdfFilename } from "../../utils/files/filename";
 import { useAppApi } from "../../composables/useAppApi";
 import { useFileChange } from "../../composables/useFileChange";
+import { isMarpDocument } from "../../utils/markdown/marpDetect";
+import MarpView from "./MarpView.vue";
 
 const { t } = useI18n();
 
@@ -193,6 +196,19 @@ watch(fileVersion, (current, previous) => {
 // would render as a stray `<hr>` plus key:value plain text in
 // every file the LLM saved with frontmatter (#895 PR A).
 const mdDoc = useMarkdownDoc(markdownContent);
+
+const marpMode = computed(() => isMarpDocument(mdDoc.value.meta));
+
+const marpPdfFilename = computed(() => {
+  const prefix = props.selectedResult.data?.filenamePrefix;
+  const rawName = prefix || props.selectedResult.title || "";
+  const { uuid } = props.selectedResult;
+  return buildPdfFilename({
+    name: rawName,
+    fallback: "slides",
+    timestampMs: uuid ? appApi.getResultTimestamp(uuid) : undefined,
+  });
+});
 
 const renderedHtml = computed(() => {
   if (!markdownContent.value) return "";

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -210,7 +210,11 @@ const marpBaseDir = computed(() => {
   const raw = props.selectedResult.data?.markdown;
   if (typeof raw !== "string" || !isFilePath(raw)) return undefined;
   const idx = raw.lastIndexOf("/");
-  return idx > 0 ? raw.slice(0, idx) : undefined;
+  // Root-level files (no "/") resolve their relative `<img>` refs
+  // against the workspace root — return "" so the server's
+  // inlineImages() uses the workspace root instead of falling back
+  // to the legacy `markdowns/` sourceDir (codex review).
+  return idx < 0 ? "" : raw.slice(0, idx);
 });
 
 const marpPdfFilename = computed(() => {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -9,7 +9,14 @@
     <div v-else-if="!markdownContent" class="min-h-full p-8 flex items-center justify-center">
       <div class="text-gray-500">{{ t("pluginMarkdown.noContent") }}</div>
     </div>
-    <MarpView v-else-if="marpMode" :markdown="markdownContent" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
+    <template v-else-if="marpMode">
+      <div v-if="loadError" class="load-error-banner shrink-0" role="alert">
+        {{ t("pluginMarkdown.refreshFailed", { error: loadError }) }}
+      </div>
+      <div class="flex-1 min-h-0">
+        <MarpView :markdown="markdownContent" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
+      </div>
+    </template>
     <template v-else>
       <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
         <button

--- a/src/utils/markdown/marpDetect.ts
+++ b/src/utils/markdown/marpDetect.ts
@@ -1,0 +1,15 @@
+// Marp opt-in detection from parsed frontmatter. Marp's own convention
+// is the `marp: true` directive in the YAML header. We also accept the
+// string forms `"true"` / `"yes"` and the boolean-ish `1` so an LLM that
+// quoted the value still lands in slide mode.
+
+export function isMarpDocument(meta: Record<string, unknown>): boolean {
+  const value = meta.marp;
+  if (value === true) return true;
+  if (value === 1) return true;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "yes" || normalized === "1";
+  }
+  return false;
+}

--- a/test/utils/markdown/test_marpDetect.ts
+++ b/test/utils/markdown/test_marpDetect.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isMarpDocument } from "../../../src/utils/markdown/marpDetect.js";
+
+describe("isMarpDocument", () => {
+  it("returns true for boolean true", () => {
+    assert.equal(isMarpDocument({ marp: true }), true);
+  });
+
+  it("returns true for the numeric 1 (YAML truthiness corner)", () => {
+    assert.equal(isMarpDocument({ marp: 1 }), true);
+  });
+
+  it("accepts the string forms 'true' / 'yes' / '1', case-insensitive, with surrounding whitespace", () => {
+    assert.equal(isMarpDocument({ marp: "true" }), true);
+    assert.equal(isMarpDocument({ marp: "TRUE" }), true);
+    assert.equal(isMarpDocument({ marp: "yes" }), true);
+    assert.equal(isMarpDocument({ marp: "Yes" }), true);
+    assert.equal(isMarpDocument({ marp: "1" }), true);
+    assert.equal(isMarpDocument({ marp: "  true  " }), true);
+  });
+
+  it("returns false when the key is absent", () => {
+    assert.equal(isMarpDocument({}), false);
+    assert.equal(isMarpDocument({ title: "Hello" }), false);
+  });
+
+  it("returns false for boolean false", () => {
+    assert.equal(isMarpDocument({ marp: false }), false);
+  });
+
+  it("returns false for string 'false' / 'no' / '0' / empty", () => {
+    assert.equal(isMarpDocument({ marp: "false" }), false);
+    assert.equal(isMarpDocument({ marp: "no" }), false);
+    assert.equal(isMarpDocument({ marp: "0" }), false);
+    assert.equal(isMarpDocument({ marp: "" }), false);
+  });
+
+  it("returns false for null / undefined", () => {
+    assert.equal(isMarpDocument({ marp: null }), false);
+    assert.equal(isMarpDocument({ marp: undefined }), false);
+  });
+
+  it("returns false for non-boolean / non-string objects or arrays", () => {
+    assert.equal(isMarpDocument({ marp: { enabled: true } }), false);
+    assert.equal(isMarpDocument({ marp: ["true"] }), false);
+  });
+
+  it("does not collide with neighbouring keys", () => {
+    assert.equal(isMarpDocument({ marp: true, title: "x", tags: ["a"] }), true);
+    assert.equal(isMarpDocument({ marpy: true }), false);
+    assert.equal(isMarpDocument({ MARP: true }), false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,24 @@
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
+"@csstools/postcss-is-pseudo-class@^5.0.3":
+  version "5.0.3"
+  resolved "https://npm.flatt.tech/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz#d34e850bcad4013c2ed7abe948bfa0448aa8eb74"
+  integrity sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==
+  dependencies:
+    "@csstools/selector-specificity" "^5.0.0"
+    postcss-selector-parser "^7.0.0"
+
+"@csstools/selector-resolve-nested@^3.1.0":
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz#848c6f44cb65e3733e478319b9342b7aa436fac7"
+  integrity sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==
+
+"@csstools/selector-specificity@^5.0.0":
+  version "5.0.0"
+  resolved "https://npm.flatt.tech/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz#037817b574262134cabd68fc4ec1a454f168407b"
+  integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
+
 "@discordjs/builders@^1.14.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-1.14.1.tgz#c0ec04f3ae7a584296bfd1dccdda59bf580a0c89"
@@ -1391,6 +1409,38 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
   integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
+"@marp-team/marp-core@^4.3.0":
+  version "4.3.0"
+  resolved "https://npm.flatt.tech/@marp-team/marp-core/-/marp-core-4.3.0.tgz#e1286869ffc93872e3cfc4a87daef89a82b4547f"
+  integrity sha512-Qwd0wsHS+7bdCBmmnxCU2OKclCSdsVu4U474zSs44Y2SMXr6d9wBYAMD5IXI4dbmaB57Ez5fdPUxPZZsFo8Tmw==
+  dependencies:
+    "@marp-team/marpit" "^3.2.1"
+    "@marp-team/marpit-svg-polyfill" "^2.1.0"
+    highlight.js "^11.11.1"
+    katex "^0.16.33"
+    mathjax-full "^3.2.2"
+    postcss-selector-parser "^7.1.1"
+    xss "^1.0.15"
+
+"@marp-team/marpit-svg-polyfill@^2.1.0":
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-2.1.0.tgz#40e7ce3a2aa7496748541cc7053e6779d2f866ac"
+  integrity sha512-VqCoAKwv1HJdzZp36dDPxznz2JZgRjkVSSPHpCzk72G2N753F0HPKXjevdjxmzN6gir9bUGBgMD1SguWJIi11A==
+
+"@marp-team/marpit@^3.2.1":
+  version "3.2.1"
+  resolved "https://npm.flatt.tech/@marp-team/marpit/-/marpit-3.2.1.tgz#d0168bda5370d67df76d0647256b3d56288b9a6c"
+  integrity sha512-MflN1movsh8PXJbM9otjJOtlcB0vSrvw5PgXs2PDguVYVzKQmGpiy9QHHKq0rryrgaSp376TdJWBP7mXHHAG8w==
+  dependencies:
+    "@csstools/postcss-is-pseudo-class" "^5.0.3"
+    cssesc "^3.0.0"
+    js-yaml "^4.1.1"
+    lodash.kebabcase "^4.1.1"
+    markdown-it "^14.1.1"
+    markdown-it-front-matter "^0.2.4"
+    postcss "^8.5.6"
+    postcss-nesting "^13.0.2"
 
 "@matrix-org/matrix-sdk-crypto-wasm@^18.2.0":
   version "18.3.0"
@@ -2467,6 +2517,11 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.34.tgz#665f2b2fd600f6c180668423909a6fde64cbfccd"
   integrity sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==
 
+"@xmldom/xmldom@0.9.10":
+  version "0.9.10"
+  resolved "https://npm.flatt.tech/@xmldom/xmldom/-/xmldom-0.9.10.tgz#a0ad5a26fe8aa996310870726e1704977f769dee"
+  integrity sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==
+
 "@xmldom/xmldom@^0.8.6":
   version "0.8.13"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
@@ -3480,10 +3535,25 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@13.1.0:
+  version "13.1.0"
+  resolved "https://npm.flatt.tech/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
+
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://npm.flatt.tech/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://npm.flatt.tech/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 compare-versions@^6.1.1:
   version "6.1.1"
@@ -3639,6 +3709,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://npm.flatt.tech/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
 csstype@^3.2.3:
   version "3.2.3"
@@ -4362,6 +4437,11 @@ eslint@^10.4.1:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://npm.flatt.tech/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^10.0.1:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.4.0.tgz#d54f4949d4629005a1fa168d937c3ff1f7e2a837"
@@ -5063,6 +5143,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^11.11.1:
+  version "11.11.1"
+  resolved "https://npm.flatt.tech/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
+  integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
 hono@^4.11.4:
   version "4.12.23"
@@ -5789,6 +5874,13 @@ jwt-decode@^4.0.0:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
+katex@^0.16.33:
+  version "0.16.47"
+  resolved "https://npm.flatt.tech/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
+  integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
+  dependencies:
+    commander "^8.3.0"
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -5962,6 +6054,13 @@ linkify-it@5.0.0:
   dependencies:
     uc.micro "^2.0.0"
 
+linkify-it@^5.0.1:
+  version "5.0.1"
+  resolved "https://npm.flatt.tech/linkify-it/-/linkify-it-5.0.1.tgz#10c4cecbb5c6828eabf81d3c801adc4a542dfb55"
+  integrity sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==
+  dependencies:
+    uc.micro "^2.0.0"
+
 local-pkg@^1.1.1, local-pkg@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-1.1.2.tgz#c03d208787126445303f8161619dc701afa4abb5"
@@ -6012,6 +6111,11 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://npm.flatt.tech/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -6133,6 +6237,23 @@ mammoth@^1.12.0:
     underscore "^1.13.1"
     xmlbuilder "^10.0.0"
 
+markdown-it-front-matter@^0.2.4:
+  version "0.2.4"
+  resolved "https://npm.flatt.tech/markdown-it-front-matter/-/markdown-it-front-matter-0.2.4.tgz#cf29bc8222149b53575699357b1ece697bf39507"
+  integrity sha512-25GUs0yjS2hLl8zAemVndeEzThB1p42yxuDEKbd4JlL3jiz+jsm6e56Ya8B0VREOkNxLYB4TTwaoPJ3ElMmW+w==
+
+markdown-it@^14.1.1:
+  version "14.2.0"
+  resolved "https://npm.flatt.tech/markdown-it/-/markdown-it-14.2.0.tgz#06d48d9035e77d5b1c85adb315482fc8240289ef"
+  integrity sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.1"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
+
 marked@^18.0.4:
   version "18.0.4"
   resolved "https://npm.flatt.tech/marked/-/marked-18.0.4.tgz#7a54421f506c8729db32f852719972d2f939a77b"
@@ -6152,6 +6273,16 @@ math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+mathjax-full@^3.2.2:
+  version "3.2.2"
+  resolved "https://npm.flatt.tech/mathjax-full/-/mathjax-full-3.2.2.tgz#43f02e55219db393030985d2b6537ceae82f1fa7"
+  integrity sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==
+  dependencies:
+    esm "^3.2.25"
+    mhchemparser "^4.1.0"
+    mj-context-menu "^0.6.1"
+    speech-rule-engine "^4.0.6"
 
 matrix-events-sdk@0.0.1:
   version "0.0.1"
@@ -6190,6 +6321,11 @@ mdn-data@2.27.1:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.27.1.tgz#e37b9c50880b75366c4d40ac63d9bbcacdb61f0e"
   integrity sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==
 
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
+
 media-typer@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
@@ -6204,6 +6340,11 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+mhchemparser@^4.1.0:
+  version "4.2.1"
+  resolved "https://npm.flatt.tech/mhchemparser/-/mhchemparser-4.2.1.tgz#d73982e66bc06170a85b1985600ee9dabe157cb0"
+  integrity sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==
 
 middleware-handler@^0.2.0:
   version "0.2.0"
@@ -6306,6 +6447,11 @@ mitt@^3.0.1:
   resolved "https://npm.flatt.tech/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
+mj-context-menu@^0.6.1:
+  version "0.6.1"
+  resolved "https://npm.flatt.tech/mj-context-menu/-/mj-context-menu-0.6.1.tgz#a043c5282bf7e1cf3821de07b13525ca6f85aa69"
+  integrity sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==
+
 mlly@^1.7.4, mlly@^1.8.0:
   version "1.8.2"
   resolved "https://npm.flatt.tech/mlly/-/mlly-1.8.2.tgz#e7f7919a82d13b174405613117249a3f449d78bb"
@@ -6393,6 +6539,11 @@ nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+nanoid@^3.3.12:
+  version "3.3.12"
+  resolved "https://npm.flatt.tech/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6956,7 +7107,16 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
-postcss-selector-parser@^7.1.0:
+postcss-nesting@^13.0.2:
+  version "13.0.2"
+  resolved "https://npm.flatt.tech/postcss-nesting/-/postcss-nesting-13.0.2.tgz#fde0d4df772b76d03b52eccc84372e8d1ca1402e"
+  integrity sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==
+  dependencies:
+    "@csstools/selector-resolve-nested" "^3.1.0"
+    "@csstools/selector-specificity" "^5.0.0"
+    postcss-selector-parser "^7.0.0"
+
+postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.0, postcss-selector-parser@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
   integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
@@ -6970,6 +7130,15 @@ postcss@^8.5.14:
   integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
   dependencies:
     nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.5.6:
+  version "8.5.15"
+  resolved "https://npm.flatt.tech/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
+  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+  dependencies:
+    nanoid "^3.3.12"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -7055,7 +7224,7 @@ proxy-from-env@^2.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
-punycode.js@2.3.1:
+punycode.js@2.3.1, punycode.js@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
   integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
@@ -7722,6 +7891,15 @@ source-map-js@^1.0.2, source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+speech-rule-engine@^4.0.6:
+  version "4.1.4"
+  resolved "https://npm.flatt.tech/speech-rule-engine/-/speech-rule-engine-4.1.4.tgz#aabbd8342eb639f0cccb0d9e971084ec9c01bd73"
+  integrity sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==
+  dependencies:
+    "@xmldom/xmldom" "0.9.10"
+    commander "13.1.0"
+    wicked-good-xpath "1.3.0"
+
 split2@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
@@ -8262,7 +8440,7 @@ typescript@>=5, typescript@^6.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
-uc.micro@^2.0.0:
+uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
   integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
@@ -8692,6 +8870,11 @@ which@^6, which@^6.0.1:
   dependencies:
     isexe "^4.0.0"
 
+wicked-good-xpath@1.3.0:
+  version "1.3.0"
+  resolved "https://npm.flatt.tech/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz#81b0e95e8650e49c94b22298fff8686b5553cf6c"
+  integrity sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==
+
 word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
@@ -8834,6 +9017,14 @@ xmlhttprequest-ssl@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz#e9e8023b3f29ef34b97a859f584c5e6c61418e23"
   integrity sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==
+
+xss@^1.0.15:
+  version "1.0.15"
+  resolved "https://npm.flatt.tech/xss/-/xss-1.0.15.tgz#96a0e13886f0661063028b410ed1b18670f4e59a"
+  integrity sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Summary

Adds first-class **Marp** support to the existing `presentDocument` plugin. When the LLM writes a markdown file with `marp: true` in its frontmatter, the right pane switches to a slide-stack view (all slides shown vertically, each as a responsive SVG). The header gains an **Export PDF** button that produces a 16:9, one-slide-per-page PDF.

Implementation reuses the codebase's existing **puppeteer** dependency (already required for the regular `/api/pdf/markdown` route) — so **no new system-level deps** beyond `@marp-team/marp-core`.

Closes #1621.

## Items to Confirm / Review

- **`marp: true` detection** is YAML-truth-permissive (`true` / `1` / `"true"` / `"yes"`) — see `src/utils/markdown/marpDetect.ts` and its 9 unit-test cases. Anything else (false / null / "no" / `MARPY` typo) routes through the original `<MarkdownView>` so existing behaviour is preserved.
- **Slide rendering isolation**: `<MarpView>` mounts a sandboxed `<iframe sandbox="" srcdoc="...">` per document. Marp's theme CSS therefore cannot leak into the parent app, and the iframe has no script / same-origin / network capabilities. Iframe height is computed from slide count × container width × 9/16; a `ResizeObserver` keeps it responsive.
- **Server PDF path**: the existing `/api/pdf/markdown` route gains a `marp?: boolean` body field. When set, `renderMarpPdf` (new, ~22 lines) runs `marp-core` over the source and feeds the HTML+CSS into puppeteer with a 1280×720 viewport, zero margin. `baseDir` / `stripFrontmatter` / `format` are ignored in this mode (Marp owns layout end-to-end).
- **i18n 8 locales** updated in lockstep (`marpSlidesMode`, `marpExportPdf`, `marpRenderFailed`). `de.ts` uses ASCII-safe strings per the German-quote rule.
- **No regression on the original markdown path** — `mdDoc.fields` panel, `Edit Source` editor, task-list checkboxes, file-change pubsub, and the existing PDF button are all untouched for non-Marp documents.

## Out of scope (deferred follow-ups)

- Slide pagination / keyboard navigation
- PPTX / HTML / PNG export
- Marp theme picker UI
- Convert presentMulmoScript ↔ Marp

## User Prompt

> Marp っていう markdown ベースのスライドツールを扱いたいんだけど、どうすると自然で便利かな。
>
> → 簡単に B 案で。
>
> → 縦スタック（推奨・最小実装）、PDF だけ入れる

(Distilled across multiple turns: settled on extending `presentDocument`'s `markdown` plugin rather than building a new plugin, with vertical-stack rendering and PDF-only export at first.)

## Test plan

- [x] `yarn format` / `lint` / `typecheck` / `build` / `test` — all green
- [x] `isMarpDocument` unit-tested across true / yes / 1 / "1" / case / whitespace / false / null / undefined / nested-object / `marpy` typo
- [ ] Manual: agent writes a `marp: true` document → right pane shows slide stack
- [ ] Manual: same document → Export PDF → 16:9 PDF, one slide per page
- [ ] Manual: regular `presentDocument` (no `marp:` frontmatter) → unchanged behaviour
- [ ] Manual: 8 UI locales — toggle each, confirm new strings render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Render markdown as Marp-style slides in-app with slide-count display, slideshow preview, and a PDF export/download option (shows render errors and disables export if runtime is unavailable).

* **Documentation**
  * Added a feature specification and implementation plan for Marp slides.

* **i18n**
  * Added Marp-related translations across 8 locales.

* **Tests**
  * Added unit tests for Marp detection logic.

* **Chores**
  * Added Marp runtime dependency and enabled Marp-enabled server PDF export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->