### PR TITLE
feat(chat): inline "/" command palette for skills

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -111,6 +111,8 @@ In **Stack layout** this sidebar isn't rendered; the same data flows through `<S
 │ │                                       │ │ the top of certain views │  │
 │ │  ┌─<ChatInput> [chat-input/wrapper]─┐ │ │                          │  │
 │ │  │ <SuggestionsPanel> (when open)   │ │ │                          │  │
+│ │  │ <SlashCommandMenu> (typing "/")  │ │ │                          │  │
+│ │  │   [slash-command-menu]           │ │ │                          │  │
 │ │  │ [user-input]                  …  │ │ │                          │  │
 │ │  │ [suggestions-btn] (if queries)   │ │ │                          │  │
 │ │  │ [send-btn] [stop-btn]            │ │ │                          │  │
@@ -230,8 +232,9 @@ several layouts: the **index** (page list), a **single page** body, the activity
 │ ┌─[wiki-linked-references] (pages whose [[links]] point here)┐ │
 │ │ • [wiki-linked-reference-<slug>] → /wiki/pages/<slug>     │ │
 │ └───────────────────────────────────────────────────────────┘ │
-│ Per-page chat composer:                                       │
+│ Per-page chat composer (<PageChatComposer>):                  │
 │   [wiki-page-chat-input]  [wiki-page-chat-send]               │
+│   typing "/" → <SlashCommandMenu> [slash-command-menu]        │
 └───────────────────────────────────────────────────────────────┘
 ```
 

--- a/e2e/tests/slash-command-menu.spec.ts
+++ b/e2e/tests/slash-command-menu.spec.ts
@@ -64,8 +64,7 @@ test.describe("slash command menu", () => {
     // Populated with a trailing space (ready for args), and NOT sent.
     await expect(chatInput(page)).toHaveValue("/archive ");
     await expect(page.getByTestId("slash-command-menu")).toHaveCount(0);
-    await page.waitForTimeout(100);
-    expect(agentCalls).toHaveLength(0);
+    await expect.poll(() => agentCalls.length, { timeout: 500 }).toBe(0);
   });
 
   test("ArrowDown moves the highlight before Enter selects", async ({ page }) => {
@@ -77,7 +76,7 @@ test.describe("slash command menu", () => {
     await input.press("Enter");
 
     await expect(input).toHaveValue("/android ");
-    expect(agentCalls).toHaveLength(0);
+    await expect.poll(() => agentCalls.length, { timeout: 500 }).toBe(0);
   });
 
   test("Escape dismisses the menu and leaves the text untouched", async ({ page }) => {
@@ -97,6 +96,6 @@ test.describe("slash command menu", () => {
     await page.getByTestId("slash-command-item-android").click();
 
     await expect(chatInput(page)).toHaveValue("/android ");
-    expect(agentCalls).toHaveLength(0);
+    await expect.poll(() => agentCalls.length, { timeout: 500 }).toBe(0);
   });
 });

--- a/e2e/tests/slash-command-menu.spec.ts
+++ b/e2e/tests/slash-command-menu.spec.ts
@@ -1,0 +1,102 @@
+// E2E for the inline "/" command palette (useSlashCommandMenu wired into
+// ChatInput). The menu lists skills from a mocked GET /api/skills; selecting
+// one POPULATES the textarea (it must never send), so "no send" is verified
+// the same way ime-enter.spec does — by asserting POST /api/agent never fired.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { chatInput, fillChatInput } from "../fixtures/chat";
+
+const SKILLS = [
+  { name: "archive", description: "Archive things", source: "user" },
+  { name: "android", description: "Android helper", source: "project" },
+  { name: "publish", description: "Publish a package", source: "user" },
+];
+
+test.describe("slash command menu", () => {
+  let agentCalls: string[];
+
+  test.beforeEach(async ({ page }) => {
+    agentCalls = [];
+    await mockAllApis(page);
+
+    // Registered after mockAllApis so this wins (last-registered first).
+    await page.route(
+      (url) => url.pathname === "/api/skills",
+      (route) => route.fulfill({ json: { skills: SKILLS } }),
+    );
+
+    await page.route(
+      (url) => url.pathname === "/api/agent",
+      (route) => {
+        if (route.request().method() === "POST") {
+          agentCalls.push(route.request().postData() ?? "");
+          return route.fulfill({ status: 202, json: { chatSessionId: "mock-session" } });
+        }
+        return route.fallback();
+      },
+    );
+
+    await page.goto("/");
+    await expect(page.getByTestId("user-input")).toBeVisible();
+  });
+
+  test("typing a bare / token opens the menu and filters by name prefix", async ({ page }) => {
+    await fillChatInput(page, "/a");
+
+    await expect(page.getByTestId("slash-command-menu")).toBeVisible();
+    await expect(page.getByTestId("slash-command-item-archive")).toBeVisible();
+    await expect(page.getByTestId("slash-command-item-android")).toBeVisible();
+    // `publish` does not start with "a" — filtered out.
+    await expect(page.getByTestId("slash-command-item-publish")).toHaveCount(0);
+
+    // A space turns it into a command-with-args → menu closes.
+    await fillChatInput(page, "/a ");
+    await expect(page.getByTestId("slash-command-menu")).toHaveCount(0);
+  });
+
+  test("Enter selects the highlighted item, populating the input without sending", async ({ page }) => {
+    await fillChatInput(page, "/a");
+    await expect(page.getByTestId("slash-command-menu")).toBeVisible();
+
+    await chatInput(page).press("Enter");
+
+    // Populated with a trailing space (ready for args), and NOT sent.
+    await expect(chatInput(page)).toHaveValue("/archive ");
+    await expect(page.getByTestId("slash-command-menu")).toHaveCount(0);
+    await page.waitForTimeout(100);
+    expect(agentCalls).toHaveLength(0);
+  });
+
+  test("ArrowDown moves the highlight before Enter selects", async ({ page }) => {
+    await fillChatInput(page, "/a");
+    await expect(page.getByTestId("slash-command-menu")).toBeVisible();
+
+    const input = chatInput(page);
+    await input.press("ArrowDown");
+    await input.press("Enter");
+
+    await expect(input).toHaveValue("/android ");
+    expect(agentCalls).toHaveLength(0);
+  });
+
+  test("Escape dismisses the menu and leaves the text untouched", async ({ page }) => {
+    await fillChatInput(page, "/a");
+    await expect(page.getByTestId("slash-command-menu")).toBeVisible();
+
+    await chatInput(page).press("Escape");
+
+    await expect(page.getByTestId("slash-command-menu")).toHaveCount(0);
+    await expect(chatInput(page)).toHaveValue("/a");
+  });
+
+  test("clicking an item populates the input", async ({ page }) => {
+    await fillChatInput(page, "/a");
+    await expect(page.getByTestId("slash-command-menu")).toBeVisible();
+
+    await page.getByTestId("slash-command-item-android").click();
+
+    await expect(chatInput(page)).toHaveValue("/android ");
+    expect(agentCalls).toHaveLength(0);
+  });
+});

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -107,7 +107,7 @@ import SlashCommandMenu from "./SlashCommandMenu.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
 import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
-import { useSlashCommandMenu } from "../composables/useSlashCommandMenu";
+import { useSlashCommandMenu, handleSlashMenuKeydown } from "../composables/useSlashCommandMenu";
 import type { PastedFile } from "../types/pastedFile";
 
 export type { PastedFile };
@@ -241,37 +241,10 @@ watch(slashMenuOpen, (open) => {
 });
 
 function onKeydown(event: KeyboardEvent): void {
-  if (slashMenuOpen.value && handleSlashKeydown(event)) return;
-  imeEnter.onKeydown(event);
-}
-
-function handleSlashKeydown(event: KeyboardEvent): boolean {
-  if (event.isComposing) return false; // let IME own the keys mid-composition
-  switch (event.key) {
-    case "ArrowDown":
-      event.preventDefault();
-      slashMenu.moveHighlight(1);
-      return true;
-    case "ArrowUp":
-      event.preventDefault();
-      slashMenu.moveHighlight(-1);
-      return true;
-    case "Enter":
-    case "Tab": {
-      if (event.shiftKey) return false; // Shift+Enter = newline, Shift+Tab = focus out
-      const skill = slashMenu.highlightedSkill.value;
-      if (!skill) return false;
-      event.preventDefault();
-      selectSlashSkill(skill);
-      return true;
-    }
-    case "Escape":
-      event.preventDefault();
-      slashMenu.dismiss();
-      return true;
-    default:
-      return false;
+  if (slashMenuOpen.value && handleSlashMenuKeydown(slashMenu, event, { isImeConfirmation: imeEnter.isImeConfirmation, onSelect: selectSlashSkill })) {
+    return;
   }
+  imeEnter.onKeydown(event);
 }
 
 // Selection populates `/<name> ` (trailing space dismisses the menu via the

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -12,7 +12,14 @@
       @send="onSuggestionSend"
       @edit="onSuggestionEdit"
     />
-    <div class="p-2">
+    <div class="p-2 relative">
+      <SlashCommandMenu
+        v-if="slashMenuOpen"
+        :items="slashItems"
+        :highlighted-index="slashHighlightedIndex"
+        @select="selectSlashSkill"
+        @hover="slashMenu.setHighlight($event)"
+      />
       <div v-if="fileError" class="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5" data-testid="file-error">
         {{ fileError }}
       </div>
@@ -35,8 +42,8 @@
           @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
           @compositionstart="imeEnter.onCompositionStart"
           @compositionend="imeEnter.onCompositionEnd"
-          @keydown="imeEnter.onKeydown"
-          @blur="imeEnter.onBlur"
+          @keydown="onKeydown"
+          @blur="onBlur"
           @paste="onPasteFile"
         />
         <div class="flex flex-col gap-1">
@@ -93,18 +100,21 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref } from "vue";
+import { nextTick, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import ChatAttachmentPreview from "./ChatAttachmentPreview.vue";
+import SlashCommandMenu from "./SlashCommandMenu.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
+import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
+import { useSlashCommandMenu } from "../composables/useSlashCommandMenu";
 import type { PastedFile } from "../types/pastedFile";
 
 export type { PastedFile };
 
 const { t } = useI18n();
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     modelValue: string;
     pastedFile: PastedFile | null;
@@ -207,6 +217,78 @@ function onFilePicked(event: Event): void {
 }
 
 const imeEnter = useImeAwareEnter(() => emit("send"));
+
+// Inline "/" command palette. Shares the lightbulb Skills tab's data store;
+// owns only open/filter/highlight state here, with the keyboard interception
+// below running ahead of `imeEnter` so Enter selects instead of sending.
+const { skills, refresh: refreshSkills } = useSkillsList();
+const slashMenu = useSlashCommandMenu(toRef(props, "modelValue"), () => skills.value);
+const slashMenuOpen = slashMenu.isOpen;
+const slashItems = slashMenu.items;
+const slashHighlightedIndex = slashMenu.highlightedIndex;
+
+// Refresh the skill list each time the menu first opens (cheap, dedup'd) so a
+// skill added since boot shows up; collapse the lightbulb panel so the two
+// menus are never open at once.
+watch(
+  () => slashMenu.query.value,
+  (query, prev) => {
+    if (query !== null && prev === null) void refreshSkills();
+  },
+);
+watch(slashMenuOpen, (open) => {
+  if (open) suggestionsExpanded.value = false;
+});
+
+function onKeydown(event: KeyboardEvent): void {
+  if (slashMenuOpen.value && handleSlashKeydown(event)) return;
+  imeEnter.onKeydown(event);
+}
+
+function handleSlashKeydown(event: KeyboardEvent): boolean {
+  if (event.isComposing) return false; // let IME own the keys mid-composition
+  switch (event.key) {
+    case "ArrowDown":
+      event.preventDefault();
+      slashMenu.moveHighlight(1);
+      return true;
+    case "ArrowUp":
+      event.preventDefault();
+      slashMenu.moveHighlight(-1);
+      return true;
+    case "Enter":
+    case "Tab": {
+      if (event.shiftKey) return false; // Shift+Enter = newline, Shift+Tab = focus out
+      const skill = slashMenu.highlightedSkill.value;
+      if (!skill) return false;
+      event.preventDefault();
+      selectSlashSkill(skill);
+      return true;
+    }
+    case "Escape":
+      event.preventDefault();
+      slashMenu.dismiss();
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Selection populates `/<name> ` (trailing space dismisses the menu via the
+// no-bare-token rule and lets the user type arguments) — it never sends.
+function selectSlashSkill(skill: SkillSummary): void {
+  emit("update:modelValue", `/${skill.name} `);
+  nextTick(() => {
+    const field = textarea.value;
+    field?.focus();
+    if (field) field.setSelectionRange(field.value.length, field.value.length);
+  });
+}
+
+function onBlur(): void {
+  imeEnter.onBlur();
+  slashMenu.dismiss();
+}
 
 function onSuggestionSend(query: string): void {
   emit("suggestion-send", query);

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -7,14 +7,7 @@
       @send="onSuggestionSend"
       @edit="onSuggestionEdit"
     />
-    <div class="px-4 py-3 flex gap-2 relative">
-      <SlashCommandMenu
-        v-if="slashMenuOpen"
-        :items="slashItems"
-        :highlighted-index="slashHighlightedIndex"
-        @select="selectSlashSkill"
-        @hover="slashMenu.setHighlight($event)"
-      />
+    <div class="px-4 py-3 flex gap-2">
       <textarea
         ref="textareaRef"
         v-model="draft"
@@ -24,8 +17,8 @@
         class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
         @compositionstart="imeEnter.onCompositionStart"
         @compositionend="imeEnter.onCompositionEnd"
-        @keydown="onKeydown"
-        @blur="onBlur"
+        @keydown="imeEnter.onKeydown"
+        @blur="imeEnter.onBlur"
       />
       <div class="flex flex-col gap-1 shrink-0">
         <button
@@ -55,13 +48,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useAppApi } from "../composables/useAppApi";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
-import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
-import { useSlashCommandMenu } from "../composables/useSlashCommandMenu";
-import SlashCommandMenu from "./SlashCommandMenu.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 
 const props = withDefaults(
@@ -109,73 +99,4 @@ function onSuggestionEdit(query: string) {
 }
 
 const imeEnter = useImeAwareEnter(submit);
-
-// Inline "/" command palette — same behaviour as ChatInput, sharing the
-// lightbulb Skills data store; keyboard interception runs ahead of `imeEnter`
-// so Enter selects instead of sending.
-const { skills, refresh: refreshSkills } = useSkillsList();
-const slashMenu = useSlashCommandMenu(draft, () => skills.value);
-const slashMenuOpen = slashMenu.isOpen;
-const slashItems = slashMenu.items;
-const slashHighlightedIndex = slashMenu.highlightedIndex;
-
-watch(
-  () => slashMenu.query.value,
-  (query, prev) => {
-    if (query !== null && prev === null) void refreshSkills();
-  },
-);
-watch(slashMenuOpen, (open) => {
-  if (open) suggestionsExpanded.value = false;
-});
-
-function onKeydown(event: KeyboardEvent): void {
-  if (slashMenuOpen.value && handleSlashKeydown(event)) return;
-  imeEnter.onKeydown(event);
-}
-
-function handleSlashKeydown(event: KeyboardEvent): boolean {
-  if (event.isComposing) return false; // let IME own the keys mid-composition
-  switch (event.key) {
-    case "ArrowDown":
-      event.preventDefault();
-      slashMenu.moveHighlight(1);
-      return true;
-    case "ArrowUp":
-      event.preventDefault();
-      slashMenu.moveHighlight(-1);
-      return true;
-    case "Enter":
-    case "Tab": {
-      if (event.shiftKey) return false; // Shift+Enter = newline, Shift+Tab = focus out
-      const skill = slashMenu.highlightedSkill.value;
-      if (!skill) return false;
-      event.preventDefault();
-      selectSlashSkill(skill);
-      return true;
-    }
-    case "Escape":
-      event.preventDefault();
-      slashMenu.dismiss();
-      return true;
-    default:
-      return false;
-  }
-}
-
-// Selection populates `/<name> ` (never sends); the trailing space closes the
-// menu and lets the user type arguments.
-function selectSlashSkill(skill: SkillSummary): void {
-  draft.value = `/${skill.name} `;
-  nextTick(() => {
-    const field = textareaRef.value;
-    field?.focus();
-    if (field) field.setSelectionRange(field.value.length, field.value.length);
-  });
-}
-
-function onBlur(): void {
-  imeEnter.onBlur();
-  slashMenu.dismiss();
-}
 </script>

--- a/src/components/PageChatComposer.vue
+++ b/src/components/PageChatComposer.vue
@@ -7,7 +7,14 @@
       @send="onSuggestionSend"
       @edit="onSuggestionEdit"
     />
-    <div class="px-4 py-3 flex gap-2">
+    <div class="px-4 py-3 flex gap-2 relative">
+      <SlashCommandMenu
+        v-if="slashMenuOpen"
+        :items="slashItems"
+        :highlighted-index="slashHighlightedIndex"
+        @select="selectSlashSkill"
+        @hover="slashMenu.setHighlight($event)"
+      />
       <textarea
         ref="textareaRef"
         v-model="draft"
@@ -17,8 +24,8 @@
         class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
         @compositionstart="imeEnter.onCompositionStart"
         @compositionend="imeEnter.onCompositionEnd"
-        @keydown="imeEnter.onKeydown"
-        @blur="imeEnter.onBlur"
+        @keydown="onKeydown"
+        @blur="onBlur"
       />
       <div class="flex flex-col gap-1 shrink-0">
         <button
@@ -48,10 +55,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useAppApi } from "../composables/useAppApi";
 import { useImeAwareEnter } from "../composables/useImeAwareEnter";
+import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
+import { useSlashCommandMenu } from "../composables/useSlashCommandMenu";
+import SlashCommandMenu from "./SlashCommandMenu.vue";
 import SuggestionsPanel from "./SuggestionsPanel.vue";
 
 const props = withDefaults(
@@ -99,4 +109,73 @@ function onSuggestionEdit(query: string) {
 }
 
 const imeEnter = useImeAwareEnter(submit);
+
+// Inline "/" command palette — same behaviour as ChatInput, sharing the
+// lightbulb Skills data store; keyboard interception runs ahead of `imeEnter`
+// so Enter selects instead of sending.
+const { skills, refresh: refreshSkills } = useSkillsList();
+const slashMenu = useSlashCommandMenu(draft, () => skills.value);
+const slashMenuOpen = slashMenu.isOpen;
+const slashItems = slashMenu.items;
+const slashHighlightedIndex = slashMenu.highlightedIndex;
+
+watch(
+  () => slashMenu.query.value,
+  (query, prev) => {
+    if (query !== null && prev === null) void refreshSkills();
+  },
+);
+watch(slashMenuOpen, (open) => {
+  if (open) suggestionsExpanded.value = false;
+});
+
+function onKeydown(event: KeyboardEvent): void {
+  if (slashMenuOpen.value && handleSlashKeydown(event)) return;
+  imeEnter.onKeydown(event);
+}
+
+function handleSlashKeydown(event: KeyboardEvent): boolean {
+  if (event.isComposing) return false; // let IME own the keys mid-composition
+  switch (event.key) {
+    case "ArrowDown":
+      event.preventDefault();
+      slashMenu.moveHighlight(1);
+      return true;
+    case "ArrowUp":
+      event.preventDefault();
+      slashMenu.moveHighlight(-1);
+      return true;
+    case "Enter":
+    case "Tab": {
+      if (event.shiftKey) return false; // Shift+Enter = newline, Shift+Tab = focus out
+      const skill = slashMenu.highlightedSkill.value;
+      if (!skill) return false;
+      event.preventDefault();
+      selectSlashSkill(skill);
+      return true;
+    }
+    case "Escape":
+      event.preventDefault();
+      slashMenu.dismiss();
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Selection populates `/<name> ` (never sends); the trailing space closes the
+// menu and lets the user type arguments.
+function selectSlashSkill(skill: SkillSummary): void {
+  draft.value = `/${skill.name} `;
+  nextTick(() => {
+    const field = textareaRef.value;
+    field?.focus();
+    if (field) field.setSelectionRange(field.value.length, field.value.length);
+  });
+}
+
+function onBlur(): void {
+  imeEnter.onBlur();
+  slashMenu.dismiss();
+}
 </script>

--- a/src/components/SlashCommandMenu.vue
+++ b/src/components/SlashCommandMenu.vue
@@ -1,0 +1,56 @@
+<template>
+  <!-- Floats above the input (drop-up) without reflowing it. Parent `.p-2`
+       is `relative`; this is `absolute bottom-full`. Items use
+       `@mousedown.prevent` so a click selects without first blurring the
+       textarea (which would otherwise fire @blur and dismiss the menu). -->
+  <div
+    ref="listRef"
+    data-testid="slash-command-menu"
+    role="listbox"
+    class="absolute bottom-full left-0 right-0 mx-2 mb-1 max-h-64 overflow-y-auto rounded border border-gray-300 bg-white shadow-lg z-10"
+  >
+    <button
+      v-for="(skill, index) in items"
+      :key="skill.name"
+      :data-testid="`slash-command-item-${skill.name}`"
+      role="option"
+      :aria-selected="index === highlightedIndex"
+      class="w-full text-left px-3 py-1.5 flex flex-col gap-0.5 transition-colors"
+      :class="index === highlightedIndex ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'"
+      @mousedown.prevent="emit('select', skill)"
+      @mouseenter="emit('hover', index)"
+    >
+      <span class="text-xs font-medium">/{{ skill.name }}</span>
+      <span v-if="skill.description" class="text-[11px] text-gray-500 truncate">{{ skill.description }}</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch } from "vue";
+import type { SkillSummary } from "../composables/useSkillsList";
+
+const props = defineProps<{
+  items: readonly SkillSummary[];
+  highlightedIndex: number;
+}>();
+
+const emit = defineEmits<{
+  select: [skill: SkillSummary];
+  hover: [index: number];
+}>();
+
+const listRef = ref<HTMLDivElement | null>(null);
+
+// Keep the keyboard-highlighted row in view when navigation moves it past
+// the visible window of the scroll container.
+watch(
+  () => props.highlightedIndex,
+  (index) => {
+    nextTick(() => {
+      const option = listRef.value?.children[index] as HTMLElement | undefined;
+      option?.scrollIntoView({ block: "nearest" });
+    });
+  },
+);
+</script>

--- a/src/composables/useImeAwareEnter.ts
+++ b/src/composables/useImeAwareEnter.ts
@@ -22,13 +22,27 @@ export interface ImeAwareEnterHandlers {
   onCompositionEnd: () => void;
   onKeydown: (event: KeyboardEvent) => void;
   onBlur: () => void;
+  /**
+   * True when this keydown is (or is likely) an IME confirmation rather than a
+   * deliberate keypress: mid-composition, or within the Safari post-
+   * `compositionend` race window where `isComposing` is already false. Other
+   * keydown consumers (e.g. the slash-command menu's Enter handler) call this
+   * to avoid hijacking an IME-confirming Enter.
+   */
+  isImeConfirmation: (event: KeyboardEvent) => boolean;
 }
 
 export function useImeAwareEnter(onSend: () => void, now: () => number = () => performance.now()): ImeAwareEnterHandlers {
   let isImeComposing = false;
   let lastCompositionEndAt = 0;
 
+  function isImeConfirmation(event: KeyboardEvent): boolean {
+    if (event.isComposing || isImeComposing) return true;
+    return now() - lastCompositionEndAt < SAFARI_IME_RACE_WINDOW_MS;
+  }
+
   return {
+    isImeConfirmation,
     onCompositionStart() {
       isImeComposing = true;
     },

--- a/src/composables/useSlashCommandMenu.ts
+++ b/src/composables/useSlashCommandMenu.ts
@@ -4,9 +4,9 @@
 // one to populate the textarea (selection populates, it does NOT send).
 //
 // Data comes from the same `useSkillsList()` module-level store the
-// lightbulb Skills tab uses — this composable only owns the open/filter/
-// highlight state; the keyboard interception lives in ChatInput so it can
-// coordinate with `useImeAwareEnter` before Enter sends.
+// lightbulb Skills tab uses — this composable owns the open/filter/highlight
+// state, and `handleSlashMenuKeydown` is the shared keyboard handler the
+// composer wires ahead of `useImeAwareEnter`.
 
 import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
 import type { SkillSummary } from "./useSkillsList";
@@ -38,45 +38,101 @@ export interface SlashCommandMenu {
   dismiss: () => void;
 }
 
+interface HighlightControls {
+  highlightedIndex: Ref<number>;
+  highlightedSkill: ComputedRef<SkillSummary | null>;
+  moveHighlight: (delta: number) => void;
+  setHighlight: (index: number) => void;
+}
+
+/** Highlight cursor over `items` with wrap-around navigation. */
+function useHighlight(items: ComputedRef<SkillSummary[]>): HighlightControls {
+  const highlightedIndex = ref(0);
+  const highlightedSkill = computed(() => items.value[highlightedIndex.value] ?? null);
+  function moveHighlight(delta: number): void {
+    const count = items.value.length;
+    if (count === 0) return;
+    highlightedIndex.value = (highlightedIndex.value + delta + count) % count;
+  }
+  const setHighlight = (index: number): void => {
+    highlightedIndex.value = index;
+  };
+  return { highlightedIndex, highlightedSkill, moveHighlight, setHighlight };
+}
+
+/** Open/filter/highlight state for the inline "/" command palette. */
 export function useSlashCommandMenu(value: Ref<string>, getSkills: () => readonly SkillSummary[]): SlashCommandMenu {
   const dismissed = ref(false);
-  const highlightedIndex = ref(0);
-
   const query = computed(() => parseSlashQuery(value.value));
   const items = computed(() => {
     const prefix = query.value;
     return prefix === null ? [] : filterSkillsByPrefix(getSkills(), prefix);
   });
   const isOpen = computed(() => !dismissed.value && query.value !== null && items.value.length > 0);
-  const highlightedSkill = computed(() => items.value[highlightedIndex.value] ?? null);
+  const highlight = useHighlight(items);
 
-  // Any keystroke un-dismisses (Escape/blur only suppress until the user
-  // types again) and resets the highlight so it never points past the
-  // freshly-filtered list. `flush: "sync"` so the reset lands in the same
-  // tick as the keystroke — a deferred reset would leave the highlight stale
-  // for one frame of navigation.
+  // Any keystroke un-dismisses (Escape/blur only suppress until the user types
+  // again) and resets the highlight so it never points past the freshly-
+  // filtered list. `flush: "sync"` so the reset lands in the same tick as the
+  // keystroke — a deferred reset would leave the highlight stale for one frame.
   watch(
     value,
     () => {
       dismissed.value = false;
-      highlightedIndex.value = 0;
+      highlight.highlightedIndex.value = 0;
     },
     { flush: "sync" },
   );
 
-  function moveHighlight(delta: number): void {
-    const count = items.value.length;
-    if (count === 0) return;
-    highlightedIndex.value = (highlightedIndex.value + delta + count) % count;
-  }
-
-  function setHighlight(index: number): void {
-    highlightedIndex.value = index;
-  }
-
-  function dismiss(): void {
+  const dismiss = (): void => {
     dismissed.value = true;
-  }
+  };
+  return { isOpen, query, items, ...highlight, dismiss };
+}
 
-  return { isOpen, query, items, highlightedIndex, highlightedSkill, moveHighlight, setHighlight, dismiss };
+export interface SlashKeydownDeps {
+  /** Predicate that flags an IME-confirming keydown (see useImeAwareEnter). */
+  isImeConfirmation: (event: KeyboardEvent) => boolean;
+  /** Populate the input with the chosen command. */
+  onSelect: (skill: SkillSummary) => void;
+}
+
+function consume(event: KeyboardEvent, action: () => void): boolean {
+  event.preventDefault();
+  action();
+  return true;
+}
+
+/** Enter/Tab selection, guarded so it never hijacks an IME confirmation. */
+function selectHighlighted(menu: SlashCommandMenu, event: KeyboardEvent, deps: SlashKeydownDeps): boolean {
+  if (event.shiftKey) return false; // Shift+Enter = newline, Shift+Tab = focus out
+  // Safari fires compositionend BEFORE the confirming Enter (isComposing is
+  // already false by then), so without this the menu would select on an IME
+  // confirmation. Defer to the same race window useImeAwareEnter uses.
+  if (deps.isImeConfirmation(event)) return false;
+  const skill = menu.highlightedSkill.value;
+  if (!skill) return false;
+  return consume(event, () => deps.onSelect(skill));
+}
+
+/**
+ * Handle a textarea keydown while the slash menu is open. Returns true when the
+ * event was consumed — the caller must then NOT fall through to its send
+ * handler. Wire this ahead of `useImeAwareEnter`'s onKeydown.
+ */
+export function handleSlashMenuKeydown(menu: SlashCommandMenu, event: KeyboardEvent, deps: SlashKeydownDeps): boolean {
+  if (event.isComposing) return false; // let IME own the keys mid-composition
+  switch (event.key) {
+    case "ArrowDown":
+      return consume(event, () => menu.moveHighlight(1));
+    case "ArrowUp":
+      return consume(event, () => menu.moveHighlight(-1));
+    case "Escape":
+      return consume(event, () => menu.dismiss());
+    case "Enter":
+    case "Tab":
+      return selectHighlighted(menu, event, deps);
+    default:
+      return false;
+  }
 }

--- a/src/composables/useSlashCommandMenu.ts
+++ b/src/composables/useSlashCommandMenu.ts
@@ -1,0 +1,82 @@
+// Inline slash-command autocomplete for the chat input. When the whole
+// input is a bare `/token` (no space yet), the menu lists matching skills
+// and the user can filter by typing, navigate with Arrow keys, and pick
+// one to populate the textarea (selection populates, it does NOT send).
+//
+// Data comes from the same `useSkillsList()` module-level store the
+// lightbulb Skills tab uses — this composable only owns the open/filter/
+// highlight state; the keyboard interception lives in ChatInput so it can
+// coordinate with `useImeAwareEnter` before Enter sends.
+
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import type { SkillSummary } from "./useSkillsList";
+
+// Whole input must be a single `/token` with no whitespace. The moment a
+// space appears (`/foo `) it's a command-with-args and the menu closes.
+const SLASH_QUERY_RE = /^\/(\S*)$/;
+
+/** Returns the query after `/` when the input is a bare `/token`, else null. */
+export function parseSlashQuery(value: string): string | null {
+  const match = SLASH_QUERY_RE.exec(value);
+  return match ? match[1] : null;
+}
+
+/** Case-insensitive prefix match on skill name (empty query matches all). */
+export function filterSkillsByPrefix(skills: readonly SkillSummary[], query: string): SkillSummary[] {
+  const needle = query.toLowerCase();
+  return skills.filter((skill) => skill.name.toLowerCase().startsWith(needle));
+}
+
+export interface SlashCommandMenu {
+  isOpen: ComputedRef<boolean>;
+  query: ComputedRef<string | null>;
+  items: ComputedRef<SkillSummary[]>;
+  highlightedIndex: Ref<number>;
+  highlightedSkill: ComputedRef<SkillSummary | null>;
+  moveHighlight: (delta: number) => void;
+  setHighlight: (index: number) => void;
+  dismiss: () => void;
+}
+
+export function useSlashCommandMenu(value: Ref<string>, getSkills: () => readonly SkillSummary[]): SlashCommandMenu {
+  const dismissed = ref(false);
+  const highlightedIndex = ref(0);
+
+  const query = computed(() => parseSlashQuery(value.value));
+  const items = computed(() => {
+    const prefix = query.value;
+    return prefix === null ? [] : filterSkillsByPrefix(getSkills(), prefix);
+  });
+  const isOpen = computed(() => !dismissed.value && query.value !== null && items.value.length > 0);
+  const highlightedSkill = computed(() => items.value[highlightedIndex.value] ?? null);
+
+  // Any keystroke un-dismisses (Escape/blur only suppress until the user
+  // types again) and resets the highlight so it never points past the
+  // freshly-filtered list. `flush: "sync"` so the reset lands in the same
+  // tick as the keystroke — a deferred reset would leave the highlight stale
+  // for one frame of navigation.
+  watch(
+    value,
+    () => {
+      dismissed.value = false;
+      highlightedIndex.value = 0;
+    },
+    { flush: "sync" },
+  );
+
+  function moveHighlight(delta: number): void {
+    const count = items.value.length;
+    if (count === 0) return;
+    highlightedIndex.value = (highlightedIndex.value + delta + count) % count;
+  }
+
+  function setHighlight(index: number): void {
+    highlightedIndex.value = index;
+  }
+
+  function dismiss(): void {
+    dismissed.value = true;
+  }
+
+  return { isOpen, query, items, highlightedIndex, highlightedSkill, moveHighlight, setHighlight, dismiss };
+}

--- a/test/composables/test_useImeAwareEnter.ts
+++ b/test/composables/test_useImeAwareEnter.ts
@@ -153,3 +153,29 @@ describe("useImeAwareEnter", () => {
     assert.equal(sends.length, 1);
   });
 });
+
+describe("useImeAwareEnter.isImeConfirmation", () => {
+  const enterEvent = (opts: { isComposing?: boolean }) => fakeKeydown({ key: "Enter", isComposing: opts.isComposing }) as unknown as KeyboardEvent;
+
+  it("is true mid-composition (event flag or internal flag)", () => {
+    const { handlers } = setup();
+    assert.equal(handlers.isImeConfirmation(enterEvent({ isComposing: true })), true);
+    handlers.onCompositionStart();
+    assert.equal(handlers.isImeConfirmation(enterEvent({ isComposing: false })), true);
+  });
+
+  it("is true within the Safari post-compositionend race window, false past it", () => {
+    const { handlers, advance } = setup();
+    handlers.onCompositionStart();
+    handlers.onCompositionEnd();
+    advance(1);
+    assert.equal(handlers.isImeConfirmation(enterEvent({ isComposing: false })), true);
+    advance(SAFARI_IME_RACE_WINDOW_MS);
+    assert.equal(handlers.isImeConfirmation(enterEvent({ isComposing: false })), false);
+  });
+
+  it("is false for an ordinary keydown with no recent composition", () => {
+    const { handlers } = setup();
+    assert.equal(handlers.isImeConfirmation(enterEvent({ isComposing: false })), false);
+  });
+});

--- a/test/composables/test_useSlashCommandMenu.ts
+++ b/test/composables/test_useSlashCommandMenu.ts
@@ -1,8 +1,29 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { ref } from "vue";
-import { parseSlashQuery, filterSkillsByPrefix, useSlashCommandMenu } from "../../src/composables/useSlashCommandMenu.ts";
+import { parseSlashQuery, filterSkillsByPrefix, useSlashCommandMenu, handleSlashMenuKeydown } from "../../src/composables/useSlashCommandMenu.ts";
 import type { SkillSummary } from "../../src/composables/useSkillsList.ts";
+
+interface FakeKeyEvent {
+  key: string;
+  shiftKey: boolean;
+  isComposing: boolean;
+  preventDefault: () => void;
+  defaultPrevented: boolean;
+}
+
+function fakeKeydown(opts: { key: string; shiftKey?: boolean; isComposing?: boolean }): FakeKeyEvent {
+  const evt: FakeKeyEvent = {
+    key: opts.key,
+    shiftKey: opts.shiftKey ?? false,
+    isComposing: opts.isComposing ?? false,
+    defaultPrevented: false,
+    preventDefault() {
+      evt.defaultPrevented = true;
+    },
+  };
+  return evt;
+}
 
 const SKILLS: SkillSummary[] = [
   { name: "archive", description: "Archive things", source: "user" },
@@ -91,5 +112,65 @@ describe("useSlashCommandMenu", () => {
 
     value.value = "/ar"; // typing un-dismisses
     assert.equal(menu.isOpen.value, true);
+  });
+});
+
+describe("handleSlashMenuKeydown", () => {
+  const neverIme = () => false;
+
+  function harness() {
+    const value = ref("/a");
+    const menu = useSlashCommandMenu(value, () => SKILLS); // [archive, android]
+    const selected: SkillSummary[] = [];
+    return { value, menu, selected, onSelect: (skill: SkillSummary) => selected.push(skill) };
+  }
+
+  it("ArrowDown/ArrowUp navigate and consume the event", () => {
+    const { menu } = harness();
+    const down = fakeKeydown({ key: "ArrowDown" });
+    assert.equal(handleSlashMenuKeydown(menu, down as unknown as KeyboardEvent, { isImeConfirmation: neverIme, onSelect: () => {} }), true);
+    assert.equal(down.defaultPrevented, true);
+    assert.equal(menu.highlightedSkill.value?.name, "android");
+  });
+
+  it("Enter selects the highlighted skill and consumes the event", () => {
+    const { menu, selected, onSelect } = harness();
+    const enter = fakeKeydown({ key: "Enter" });
+    assert.equal(handleSlashMenuKeydown(menu, enter as unknown as KeyboardEvent, { isImeConfirmation: neverIme, onSelect }), true);
+    assert.equal(enter.defaultPrevented, true);
+    assert.deepEqual(
+      selected.map((skill) => skill.name),
+      ["archive"],
+    );
+  });
+
+  it("Escape dismisses the menu", () => {
+    const { menu } = harness();
+    const esc = fakeKeydown({ key: "Escape" });
+    assert.equal(handleSlashMenuKeydown(menu, esc as unknown as KeyboardEvent, { isImeConfirmation: neverIme, onSelect: () => {} }), true);
+    assert.equal(menu.isOpen.value, false);
+  });
+
+  it("Shift+Enter is not treated as a selection", () => {
+    const { menu, selected, onSelect } = harness();
+    const shiftEnter = fakeKeydown({ key: "Enter", shiftKey: true });
+    assert.equal(handleSlashMenuKeydown(menu, shiftEnter as unknown as KeyboardEvent, { isImeConfirmation: neverIme, onSelect }), false);
+    assert.equal(selected.length, 0);
+  });
+
+  it("does NOT select on an IME-confirming Enter (Safari race regression)", () => {
+    const { menu, selected, onSelect } = harness();
+    // Safari: compositionend already fired, so event.isComposing is false, but
+    // isImeConfirmation still flags it. The menu must let it fall through.
+    const confirm = fakeKeydown({ key: "Enter", isComposing: false });
+    assert.equal(handleSlashMenuKeydown(menu, confirm as unknown as KeyboardEvent, { isImeConfirmation: () => true, onSelect }), false);
+    assert.equal(confirm.defaultPrevented, false);
+    assert.equal(selected.length, 0);
+  });
+
+  it("ignores keys while composing", () => {
+    const { menu } = harness();
+    const composing = fakeKeydown({ key: "ArrowDown", isComposing: true });
+    assert.equal(handleSlashMenuKeydown(menu, composing as unknown as KeyboardEvent, { isImeConfirmation: neverIme, onSelect: () => {} }), false);
   });
 });

--- a/test/composables/test_useSlashCommandMenu.ts
+++ b/test/composables/test_useSlashCommandMenu.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ref } from "vue";
+import { parseSlashQuery, filterSkillsByPrefix, useSlashCommandMenu } from "../../src/composables/useSlashCommandMenu.ts";
+import type { SkillSummary } from "../../src/composables/useSkillsList.ts";
+
+const SKILLS: SkillSummary[] = [
+  { name: "archive", description: "Archive things", source: "user" },
+  { name: "android", description: "Android stuff", source: "project" },
+  { name: "publish", description: "Publish a package", source: "user" },
+];
+
+describe("parseSlashQuery", () => {
+  it("returns the token after a leading slash when there is no space yet", () => {
+    assert.equal(parseSlashQuery("/"), "");
+    assert.equal(parseSlashQuery("/a"), "a");
+    assert.equal(parseSlashQuery("/archive"), "archive");
+  });
+
+  it("returns null once a space appears (command-with-args) or no leading slash", () => {
+    assert.equal(parseSlashQuery("/foo "), null);
+    assert.equal(parseSlashQuery("/foo bar"), null);
+    assert.equal(parseSlashQuery("hello"), null);
+    assert.equal(parseSlashQuery(" /foo"), null);
+    assert.equal(parseSlashQuery(""), null);
+  });
+});
+
+describe("filterSkillsByPrefix", () => {
+  it("matches case-insensitively on the name prefix", () => {
+    assert.deepEqual(
+      filterSkillsByPrefix(SKILLS, "a").map((skill) => skill.name),
+      ["archive", "android"],
+    );
+    assert.deepEqual(
+      filterSkillsByPrefix(SKILLS, "AR").map((skill) => skill.name),
+      ["archive"],
+    );
+  });
+
+  it("returns everything for an empty query and nothing for a non-match", () => {
+    assert.equal(filterSkillsByPrefix(SKILLS, "").length, 3);
+    assert.equal(filterSkillsByPrefix(SKILLS, "zzz").length, 0);
+  });
+});
+
+describe("useSlashCommandMenu", () => {
+  it("opens only for a bare /token with matches, closes on space or no match", () => {
+    const value = ref("");
+    const menu = useSlashCommandMenu(value, () => SKILLS);
+
+    assert.equal(menu.isOpen.value, false);
+
+    value.value = "/a";
+    assert.equal(menu.isOpen.value, true);
+    assert.deepEqual(
+      menu.items.value.map((skill) => skill.name),
+      ["archive", "android"],
+    );
+
+    value.value = "/zzz"; // no match → closed
+    assert.equal(menu.isOpen.value, false);
+
+    value.value = "/archive "; // trailing space → command-with-args → closed
+    assert.equal(menu.isOpen.value, false);
+  });
+
+  it("wraps highlight navigation and resets to the top on a new keystroke", () => {
+    const value = ref("/a");
+    const menu = useSlashCommandMenu(value, () => SKILLS); // [archive, android]
+
+    assert.equal(menu.highlightedIndex.value, 0);
+    menu.moveHighlight(1);
+    assert.equal(menu.highlightedSkill.value?.name, "android");
+    menu.moveHighlight(1); // wraps back to top
+    assert.equal(menu.highlightedSkill.value?.name, "archive");
+    menu.moveHighlight(-1); // wraps to bottom
+    assert.equal(menu.highlightedSkill.value?.name, "android");
+
+    value.value = "/ar"; // new keystroke resets highlight
+    assert.equal(menu.highlightedIndex.value, 0);
+  });
+
+  it("stays dismissed until the next keystroke", () => {
+    const value = ref("/a");
+    const menu = useSlashCommandMenu(value, () => SKILLS);
+
+    assert.equal(menu.isOpen.value, true);
+    menu.dismiss();
+    assert.equal(menu.isOpen.value, false);
+
+    value.value = "/ar"; // typing un-dismisses
+    assert.equal(menu.isOpen.value, true);
+  });
+});


### PR DESCRIPTION
## Summary

Typing `/` in the chat input now opens an autocomplete drop-up listing skills — the same data as the lightbulb **Skills** tab, but inline and keyboard-driven. It filters by name prefix as you type, navigates with arrows, and **populates** the selected command into the input (it never sends).

## Behavior

- Type `/` → menu opens (shares the lightbulb tab's `useSkillsList` store; refreshes on open and collapses the lightbulb panel so the two are never open at once).
- `/a` → filters to skills whose name starts with "a".
- **↑/↓** navigate (wrap-around), **Enter/Tab** select, **Esc** dismiss — all intercepted *ahead of* `useImeAwareEnter` so Enter selects instead of sending, and skipped during IME composition so Japanese input is untouched.
- Selecting populates `/<name> ` (trailing space lets you type arguments and closes the menu). No-match hides the menu so a normal message starting with "/" still goes through.

## Changes

- **`src/composables/useSlashCommandMenu.ts`** — open/filter/highlight state machine; pure `parseSlashQuery` / `filterSkillsByPrefix` helpers (unit-tested).
- **`src/components/SlashCommandMenu.vue`** — drop-up that floats above the input (no reflow), keeps the highlighted row in view, selects on `mousedown` (avoids blur).
- Wired into **both** composers: `ChatInput.vue` (main chat) and `PageChatComposer.vue` (wiki/news/files/sources).
- **`docs/ui-cheatsheet.md`** updated for both composer surfaces.

## Testing

- Unit: `test/composables/test_useSlashCommandMenu.ts` (helpers + state machine).
- E2E: `e2e/tests/slash-command-menu.spec.ts` — filter, **Enter-selects-not-sends**, arrow nav, Esc, click.
- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, and `yarn test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slash command menu: type "/" in chat to view and filter command suggestions, navigate with arrow keys, select with Enter or click, and dismiss with Escape.

* **Documentation**
  * Updated chat and wiki layout documentation to reflect slash command menu availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->