### PR TITLE
fix(agent): suppress error event on stop-button abort

### DIFF
--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -81,6 +81,24 @@ function createMcpTracker() {
   };
 }
 
+// Exit codes the claude CLI reports when it is terminated by one of the
+// signals our abort handler sends: 128 + signal number (SIGTERM=15 → 143,
+// SIGKILL=9 → 137). Node also reports a null code with `signal` set when a
+// signal kills the process directly without the CLI's own handler running.
+const ABORT_EXIT_CODES = new Set([143, 137]);
+const ABORT_SIGNALS = new Set<string>(["SIGTERM", "SIGKILL"]);
+
+// A non-zero exit caused by our own abort (stop button → proc.kill()) is
+// expected, not a failure — surfacing it as an error event makes a deliberate
+// stop look like a crash. Suppress it ONLY when we actually aborted AND the
+// exit is signal-shaped, so a genuine crash that happens to coincide with a
+// stop click still surfaces its real error.
+export function isAbortCausedExit(exitCode: number | null, signal: string | null, abortSignal?: AbortSignal): boolean {
+  if (!abortSignal?.aborted) return false;
+  if (signal !== null && ABORT_SIGNALS.has(signal)) return true;
+  return exitCode !== null && ABORT_EXIT_CODES.has(exitCode);
+}
+
 async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
@@ -129,16 +147,15 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
     }
   }
 
-  const exitCode = await new Promise<number>((resolve) => proc.on("close", resolve));
+  const { code: exitCode, signal } = await new Promise<{ code: number | null; signal: string | null }>((resolve) =>
+    proc.on("close", (code, sig) => resolve({ code, signal: sig })),
+  );
 
   if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
-  log.info("agent", "claude exited", { exitCode });
+  log.info("agent", "claude exited", { exitCode, signal });
   mcpTracker.logIfSuspicious();
 
-  // A non-zero exit caused by our own abort (stop button → proc.kill()
-  // → SIGTERM → exit 143) is expected, not a failure. Surfacing it as an
-  // error event makes a deliberate stop look like a crash, so suppress it.
-  if (exitCode !== 0 && !abortSignal?.aborted) {
+  if (exitCode !== 0 && !isAbortCausedExit(exitCode, signal, abortSignal)) {
     yield {
       type: EVENT_TYPES.error,
       message: stderrOutput || `claude exited with code ${exitCode}`,

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -99,6 +99,21 @@ export function isAbortCausedExit(exitCode: number | null, signal: string | null
   return exitCode !== null && ABORT_EXIT_CODES.has(exitCode);
 }
 
+// Build the error event for a finished claude process, or null when nothing
+// should surface (clean exit, or a deliberate abort). exitCode is null when a
+// signal — not a code — ended the process, so name the signal in that case
+// rather than emitting "claude exited with code null".
+export function buildExitErrorEvent(
+  exitCode: number | null,
+  signal: string | null,
+  abortSignal: AbortSignal | undefined,
+  stderrOutput: string,
+): { type: typeof EVENT_TYPES.error; message: string } | null {
+  if (exitCode === 0 || isAbortCausedExit(exitCode, signal, abortSignal)) return null;
+  const exitSummary = exitCode !== null ? `claude exited with code ${exitCode}` : `claude terminated by signal ${signal ?? "unknown"}`;
+  return { type: EVENT_TYPES.error, message: stderrOutput || exitSummary };
+}
+
 async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
@@ -125,6 +140,11 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
   // "MCP invoked but consistently failing" pattern.
   const mcpFailureMonitor = createMcpFailureMonitor();
 
+  // Attach the close listener BEFORE draining stdout. The `close` event
+  // can fire on the same tick stdout ends; registering it only after the
+  // read loop risks missing it and hanging on the await below.
+  const closed = new Promise<{ code: number | null; signal: string | null }>((resolve) => proc.on("close", (code, sig) => resolve({ code, signal: sig })));
+
   let buffer = "";
   for await (const chunk of proc.stdout) {
     buffer += (chunk as Buffer).toString();
@@ -147,20 +167,14 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
     }
   }
 
-  const { code: exitCode, signal } = await new Promise<{ code: number | null; signal: string | null }>((resolve) =>
-    proc.on("close", (code, sig) => resolve({ code, signal: sig })),
-  );
+  const { code: exitCode, signal } = await closed;
 
   if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
   log.info("agent", "claude exited", { exitCode, signal });
   mcpTracker.logIfSuspicious();
 
-  if (exitCode !== 0 && !isAbortCausedExit(exitCode, signal, abortSignal)) {
-    yield {
-      type: EVENT_TYPES.error,
-      message: stderrOutput || `claude exited with code ${exitCode}`,
-    };
-  }
+  const errorEvent = buildExitErrorEvent(exitCode, signal, abortSignal, stderrOutput);
+  if (errorEvent) yield errorEvent;
 }
 
 async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -81,7 +81,7 @@ function createMcpTracker() {
   };
 }
 
-async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
+async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
   proc.stderr.on("data", (chunk: Buffer) => {
@@ -135,7 +135,10 @@ async function* readAgentEvents(proc: ClaudeProc): AsyncGenerator<AgentEvent> {
   log.info("agent", "claude exited", { exitCode });
   mcpTracker.logIfSuspicious();
 
-  if (exitCode !== 0) {
+  // A non-zero exit caused by our own abort (stop button → proc.kill()
+  // → SIGTERM → exit 143) is expected, not a failure. Surfacing it as an
+  // error event makes a deliberate stop look like a crash, so suppress it.
+  if (exitCode !== 0 && !abortSignal?.aborted) {
     yield {
       type: EVENT_TYPES.error,
       message: stderrOutput || `claude exited with code ${exitCode}`,
@@ -197,7 +200,7 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
   input.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
   try {
-    yield* readAgentEvents(proc);
+    yield* readAgentEvents(proc, input.abortSignal);
   } finally {
     input.abortSignal?.removeEventListener("abort", onAbort);
     if (!proc.killed) proc.kill();

--- a/test/agent/test_abort_caused_exit.ts
+++ b/test/agent/test_abort_caused_exit.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isAbortCausedExit } from "../../server/agent/backend/claude-code.js";
+import { isAbortCausedExit, buildExitErrorEvent } from "../../server/agent/backend/claude-code.js";
 
 // Regression coverage for the stop-button false-error fix (#1625).
 // readAgentEvents only suppresses the exit-error event when
@@ -34,4 +34,23 @@ test("aborted but exit is NOT signal-shaped: real error still surfaces", () => {
   assert.equal(isAbortCausedExit(1, null, aborted()), false);
   assert.equal(isAbortCausedExit(2, null, aborted()), false);
   assert.equal(isAbortCausedExit(null, "SIGSEGV", aborted()), false);
+});
+
+test("buildExitErrorEvent: clean exit and deliberate abort produce no event", () => {
+  assert.equal(buildExitErrorEvent(0, null, undefined, ""), null);
+  assert.equal(buildExitErrorEvent(143, null, aborted(), ""), null);
+});
+
+test("buildExitErrorEvent: real failure surfaces an error event", () => {
+  const fromCode = buildExitErrorEvent(1, null, undefined, "");
+  assert.equal(fromCode?.type, "error");
+  assert.equal(fromCode?.message, "claude exited with code 1");
+  // stderr, when present, takes precedence over the synthetic summary.
+  assert.equal(buildExitErrorEvent(1, null, undefined, "boom")?.message, "boom");
+});
+
+test("buildExitErrorEvent: signal-only exit names the signal, never 'code null'", () => {
+  const errEvent = buildExitErrorEvent(null, "SIGSEGV", undefined, "");
+  assert.equal(errEvent?.message, "claude terminated by signal SIGSEGV");
+  assert.equal(buildExitErrorEvent(null, null, undefined, "")?.message, "claude terminated by signal unknown");
 });

--- a/test/agent/test_abort_caused_exit.ts
+++ b/test/agent/test_abort_caused_exit.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isAbortCausedExit } from "../../server/agent/backend/claude-code.js";
+
+// Regression coverage for the stop-button false-error fix (#1625).
+// readAgentEvents only suppresses the exit-error event when
+// isAbortCausedExit() returns true, so locking this helper locks both
+// the "deliberate stop is silent" and "real crash still surfaces" paths.
+
+function aborted(): AbortSignal {
+  const controller = new AbortController();
+  controller.abort();
+  return controller.signal;
+}
+
+test("not aborted: non-zero exit is treated as a real failure", () => {
+  // Genuine crash, user did not stop → must surface the error event.
+  assert.equal(isAbortCausedExit(143, null, new AbortController().signal), false);
+  assert.equal(isAbortCausedExit(1, null, new AbortController().signal), false);
+  assert.equal(isAbortCausedExit(null, "SIGTERM", new AbortController().signal), false);
+  assert.equal(isAbortCausedExit(1, null, undefined), false);
+});
+
+test("aborted + signal-shaped exit: treated as a deliberate stop", () => {
+  assert.equal(isAbortCausedExit(143, null, aborted()), true); // SIGTERM → 128+15
+  assert.equal(isAbortCausedExit(137, null, aborted()), true); // SIGKILL → 128+9
+  assert.equal(isAbortCausedExit(null, "SIGTERM", aborted()), true); // killed by signal directly
+  assert.equal(isAbortCausedExit(null, "SIGKILL", aborted()), true);
+});
+
+test("aborted but exit is NOT signal-shaped: real error still surfaces", () => {
+  // A genuine non-zero exit (code 1) that merely coincides with a stop
+  // click must NOT be swallowed — only signal-caused exits are aborts.
+  assert.equal(isAbortCausedExit(1, null, aborted()), false);
+  assert.equal(isAbortCausedExit(2, null, aborted()), false);
+  assert.equal(isAbortCausedExit(null, "SIGSEGV", aborted()), false);
+});


### PR DESCRIPTION
## Problem

Hitting the stop button surfaces a misleading error banner: `[Error] claude exited with code 143`.

The stop button aborts the agent via an `AbortSignal` → `proc.kill()` (SIGTERM), which makes the `claude` CLI exit with code 143 (128 + 15). `readAgentEvents` then hit the `exitCode !== 0` branch and yielded an error event — so a *deliberate* stop rendered as a crash.

## Fix

Thread `input.abortSignal` into `readAgentEvents` and skip the error event when the non-zero exit was caused by our own abort (`abortSignal.aborted`). Genuine non-zero exits (real crashes, where we did not abort) still surface as before.

## Testing

`yarn format` / `yarn lint` / `yarn typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Avoid emitting an error event when the agent process exits with a non-zero code due to a deliberate abort triggered by the stop button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user-initiated agent stops so deliberate aborts no longer produce misleading error messages; real failures still surface.
* **Tests**
  * Added regression tests to verify aborted runs are suppressed as non-errors and that genuine non-zero or signal-based failures are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->