### PR TITLE
chore: bump @mulmocast/deck-web to ^1.1.1 (fixes editor / PDF theme mismatch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@marp-team/marp-core": "^4.3.0",
     "@mulmobridge/client": "^0.1.0",
     "@mulmocast/deck": "^1.0.0",
-    "@mulmocast/deck-web": "^1.1.0",
+    "@mulmocast/deck-web": "^1.1.1",
     "@mulmocast/types": "^2.6.18",
     "@mulmochat-plugin/quiz": "0.4.3",
     "@mulmochat-plugin/ui-image": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,10 +1482,10 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/deck-web@^1.1.0":
-  version "1.1.0"
-  resolved "https://npm.flatt.tech/@mulmocast/deck-web/-/deck-web-1.1.0.tgz#d5c694377ef34486771d918594cc6385db7b2c68"
-  integrity sha512-Repp+ALLrG7yzAEaob2qcGFSrMJOm34Xtal9cCrsPuH170FZDaiL1v1ikrXcONA0z7tJueVVaedYBDa9d1pAkA==
+"@mulmocast/deck-web@^1.1.1":
+  version "1.1.1"
+  resolved "https://npm.flatt.tech/@mulmocast/deck-web/-/deck-web-1.1.1.tgz#40d835c9a3e745348106923aabb7f4597a865262"
+  integrity sha512-YLyIDTIdhxbnDAmXuLv+6r+jX5qdcyMNJ+9UF7CXfb4iN/YUnZrAPlNVe5mCwyRzAg8fhwv85efxzzJeGKx2UQ==
 
 "@mulmocast/deck@^0.7.0":
   version "0.7.1"


### PR DESCRIPTION
## Summary

Pulls in [`@mulmocast/deck-web@1.1.1`](https://www.npmjs.com/package/@mulmocast/deck-web/v/1.1.1) ([upstream PR receptron/mulmocast-deck-web#14](https://github.com/receptron/mulmocast-deck-web/pull/14)) so `MulmoScriptDeckEditor`'s `effectiveTheme` priority consults `beat.image.theme` before the deck-level slots — matching what mulmocast's slide renderer (`utils/image_plugins/slide.ts:resolveTheme`) reads first.

## Items to Confirm / Review

- **No code change in this repo** — just `package.json` + `yarn.lock`. The fix is entirely in the upstream package.
- **The earlier WIP `deckThemeOverride` workaround in `View.vue`** was reverted before commit; this branch starts from `main` and only carries the bump.
- **Bundle impact**: deck-web 1.1.1's only change vs. 1.1.0 is the four-line priority tweak (no new dependency added on its side). No measurable size change.

## Why

#1622 follow-up: scripts whose theme lives on individual beats (Storyteller / generated decks, e.g. the bootcamp samples shipped with this repo) used to render correctly in PDF / movie via the mulmocast pipeline but fell back to deck-web's cream `defaultTheme` in the editor. Users saw a cream Aurora deck on screen and a navy themed PDF for the **same script**. With this bump, both surfaces resolve through the same priority and produce the same colour.

## User Prompt

> presentMulmoCast で pdf のサポートするのわすれてた。動画ボタンのように pdf ボタンを追加して pdf 化したい
>
> (the PDF button itself is on a separate PR #1622; this one is the matching theme-resolution fix discovered while testing PDF output)

## Test plan

- [x] `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` clean
- [ ] Manual: open a script with per-beat `image.theme` set (no top-level `slideParams.theme`) in the canvas → editor preview colours now match the rendered PDF / movie output (previously cream, now matches)
- [ ] Manual: scripts with `slideParams.theme` only (no per-beat) render unchanged
- [ ] Manual: scripts with no theme at all still fall back to deck-web's `defaultTheme` (no regression in the existing fallback path)

## Related

- Upstream PR (merged + published as 1.1.1): [receptron/mulmocast-deck-web#14](https://github.com/receptron/mulmocast-deck-web/pull/14)
- Related cli helper (kept available for any future consumers but no longer imported here): [receptron/mulmocast-cli#1402](https://github.com/receptron/mulmocast-cli/pull/1402)
- Downstream report: #1622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update @mulmocast/deck-web from 1.1.0 to 1.1.1 in package.json and yarn.lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to the latest patch version for stability and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->