### PR TITLE
diag: surface resolveNewFilePath rejection on Windows CI (#1608 follow-up)

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -859,13 +859,13 @@ async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPa
   const candidate = path.resolve(workspaceReal, normalised);
   const relativeFromWorkspace = path.relative(workspaceReal, candidate);
   if (relativeFromWorkspace === ".." || relativeFromWorkspace.startsWith(`..${path.sep}`)) {
-    return { ok: false, status: 400, message: "Path outside workspace" };
+    return { ok: false, status: 400, message: "Path outside workspace (syntactic)" };
   }
   // Mirror `resolveSafe`: refuse `.git/` (or any HIDDEN_DIRS) segment.
   for (const seg of relativeFromWorkspace.split(path.sep)) {
-    if (HIDDEN_DIRS.has(seg)) return { ok: false, status: 400, message: "Path not allowed" };
+    if (HIDDEN_DIRS.has(seg)) return { ok: false, status: 400, message: `Path not allowed (hidden dir: ${seg})` };
   }
-  if (isSensitivePath(relativeFromWorkspace)) return { ok: false, status: 400, message: "Path not allowed" };
+  if (isSensitivePath(relativeFromWorkspace)) return { ok: false, status: 400, message: "Path not allowed (sensitive)" };
   if (classify(candidate) !== "text") return { ok: false, status: 400, message: "File type not editable" };
   // Walk up the candidate's ancestors until we find one that exists.
   // Realpath THAT ancestor — a symlinked in-workspace folder pointing
@@ -877,7 +877,7 @@ async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPa
   let probeStat = await statSafeAsync(probe);
   while (!probeStat) {
     const parent = path.dirname(probe);
-    if (parent === probe) return { ok: false, status: 400, message: "Path outside workspace" };
+    if (parent === probe) return { ok: false, status: 400, message: `Path outside workspace (root reached at ${probe})` };
     trailing.unshift(path.basename(probe));
     probe = parent;
     probeStat = await statSafeAsync(probe);
@@ -885,13 +885,17 @@ async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPa
   let realProbe: string;
   try {
     realProbe = await realpath(probe);
-  } catch {
-    return { ok: false, status: 400, message: "Path not allowed" };
+  } catch (err) {
+    return { ok: false, status: 400, message: `Path not allowed (realpath: ${errorMessage(err)})` };
   }
   const finalAbs = trailing.length === 0 ? realProbe : path.join(realProbe, ...trailing);
   const relFromReal = path.relative(workspaceReal, finalAbs);
   if (relFromReal === ".." || relFromReal.startsWith(`..${path.sep}`) || path.isAbsolute(relFromReal)) {
-    return { ok: false, status: 400, message: "Path outside workspace" };
+    return {
+      ok: false,
+      status: 400,
+      message: `Path outside workspace (real) — root="${workspaceReal}" real="${finalAbs}" rel="${relFromReal}"`,
+    };
   }
   return { ok: true, absPath: finalAbs };
 }

--- a/test/routes/test_filesCreateRoute.ts
+++ b/test/routes/test_filesCreateRoute.ts
@@ -112,7 +112,7 @@ describe("POST /api/files/create — happy path", () => {
     mkdirSync(path.join(workspaceDir, "conversations", "summaries"), { recursive: true });
     const { state, res } = mockRes();
     await createHandler(req({ path: "conversations/summaries/2026-06.md", content: "" }), res);
-    assert.equal(state.status, 200);
+    assert.equal(state.status, 200, `expected 200, got ${state.status} with body=${JSON.stringify(state.body)}`);
     const body = state.body as WriteBody;
     assert.equal(body.path, "conversations/summaries/2026-06.md");
     assert.equal(body.size, 0);


### PR DESCRIPTION
## Summary

The Windows CI run on main is failing in `test_filesCreateRoute.ts` with `POST /api/files/create` returning **400 instead of 200**. Five tests fail (all happy-path + two conflict cases on Windows); the same tests pass on macOS / Ubuntu locally and in CI.

The route's `resolveNewFilePath` has multiple 400 branches — symlink containment, realpath failure, HIDDEN_DIRS, sensitive-path, etc. — and the response body just says `Path not allowed` or similar without indicating which one fired. So I can't tell from the Windows CI log which branch is rejecting.

This is a **diagnostic-only** PR: each 400 branch now identifies itself (`syntactic`, `hidden dir: <seg>`, `sensitive`, `root reached at <probe>`, `realpath: <err>`, or `real — root=... real=... rel=...`), and the failing test's assert prints the response body. Push, see what Windows says, ship a real fix.

## Items to Confirm / Review

- **No behavior change** — every code path still returns the same status; only the human-readable message changed. Tests still pass locally (14/14).
- I'll convert this into a real fix as soon as the Windows CI run on this branch surfaces which branch fires (most likely the realpath containment check, which I suspect is sensitive to Windows case / short-name resolution).

## User Prompt

> CI失敗 — https://github.com/receptron/mulmoclaude/actions/runs/27074146051

## Test plan

- [x] `yarn tsx --test test/routes/test_filesCreateRoute.ts` → 14/14 still pass locally
- [ ] Push, watch Windows CI, identify which 400 branch fires
- [ ] Convert into a Windows-tolerant fix, drop the diagnostic strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for file creation validation, offering more detailed information when operations fail due to path restrictions or system constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->