### PR TITLE
fix: align workspace realpath form across sync/async on Windows

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -200,6 +200,28 @@ export function classify(filename: string): ContentKind {
 // already-realpath'd root.
 const workspaceReal = realpathSync(workspacePath);
 
+// Windows-only: cached **async-realpath** form of the workspace. On
+// Windows, `realpathSync` (sync) and `realpath` (async) can return
+// the same path in two different forms — 8.3 short-name (`RUNNER~1`)
+// vs. long-name (`runneradmin`) — depending on which syscall path
+// was used to open the dir entry. Comparing across forms via
+// `path.relative` then produces a false "outside workspace" verdict
+// (`..\..\runneradmin\...`). This cache mirrors `workspaceReal` but
+// is guaranteed to share the form the async `realpath` returns, so
+// `resolveNewFilePath`'s containment check has matching ends. On
+// non-Windows hosts both syscalls return the same string, so the
+// cache equals `workspaceReal` and the extra lookup is harmless.
+let workspaceRealAsyncCache: string | null = null;
+async function getWorkspaceRealAsync(): Promise<string> {
+  if (workspaceRealAsyncCache !== null) return workspaceRealAsyncCache;
+  try {
+    workspaceRealAsyncCache = await realpath(workspaceReal);
+  } catch {
+    workspaceRealAsyncCache = workspaceReal;
+  }
+  return workspaceRealAsyncCache;
+}
+
 // Wraps the shared resolveWithinRoot helper with the additional
 // hidden-dir traversal check (e.g. `.git/config`). `buildTreeAsync`
 // / `listDirShallow` hide these from the listing, but the URL
@@ -859,13 +881,13 @@ async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPa
   const candidate = path.resolve(workspaceReal, normalised);
   const relativeFromWorkspace = path.relative(workspaceReal, candidate);
   if (relativeFromWorkspace === ".." || relativeFromWorkspace.startsWith(`..${path.sep}`)) {
-    return { ok: false, status: 400, message: "Path outside workspace (syntactic)" };
+    return { ok: false, status: 400, message: "Path outside workspace" };
   }
   // Mirror `resolveSafe`: refuse `.git/` (or any HIDDEN_DIRS) segment.
   for (const seg of relativeFromWorkspace.split(path.sep)) {
-    if (HIDDEN_DIRS.has(seg)) return { ok: false, status: 400, message: `Path not allowed (hidden dir: ${seg})` };
+    if (HIDDEN_DIRS.has(seg)) return { ok: false, status: 400, message: "Path not allowed" };
   }
-  if (isSensitivePath(relativeFromWorkspace)) return { ok: false, status: 400, message: "Path not allowed (sensitive)" };
+  if (isSensitivePath(relativeFromWorkspace)) return { ok: false, status: 400, message: "Path not allowed" };
   if (classify(candidate) !== "text") return { ok: false, status: 400, message: "File type not editable" };
   // Walk up the candidate's ancestors until we find one that exists.
   // Realpath THAT ancestor — a symlinked in-workspace folder pointing
@@ -885,17 +907,19 @@ async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPa
   let realProbe: string;
   try {
     realProbe = await realpath(probe);
-  } catch (err) {
-    return { ok: false, status: 400, message: `Path not allowed (realpath: ${errorMessage(err)})` };
+  } catch {
+    return { ok: false, status: 400, message: "Path not allowed" };
   }
   const finalAbs = trailing.length === 0 ? realProbe : path.join(realProbe, ...trailing);
-  const relFromReal = path.relative(workspaceReal, finalAbs);
+  // Compare against the **async-realpath** form of the workspace, not
+  // the sync form cached as `workspaceReal`. On Windows the two can
+  // differ (8.3 short-name vs. long-name), and `path.relative` across
+  // the two yields a spurious `..\..\..\<long-name>\...` that fails
+  // the containment check. See `getWorkspaceRealAsync` for the why.
+  const rootAsync = await getWorkspaceRealAsync();
+  const relFromReal = path.relative(rootAsync, finalAbs);
   if (relFromReal === ".." || relFromReal.startsWith(`..${path.sep}`) || path.isAbsolute(relFromReal)) {
-    return {
-      ok: false,
-      status: 400,
-      message: `Path outside workspace (real) — root="${workspaceReal}" real="${finalAbs}" rel="${relFromReal}"`,
-    };
+    return { ok: false, status: 400, message: "Path outside workspace" };
   }
   return { ok: true, absPath: finalAbs };
 }


### PR DESCRIPTION
## Summary

- Windows `realpathSync` (sync, called at module load) returns the 8.3 short-name form (`C:\Users\RUNNER~1\...`) while async `realpath` (called per-request inside `resolveNewFilePath`) returns the long-name form (`C:\Users\runneradmin\...`). Comparing the two via `path.relative` produced a spurious `..\..\..\runneradmin\...` and every happy-path create returned 400 \"Path outside workspace\".
- Cache the **async-realpath** form of the workspace once, and use it for the containment comparison so both ends match.
- Drops the diagnostic detail strings added in #1633 now that the cause is identified.

## Items to Confirm / Review

- The fix is **local to `resolveNewFilePath`**; `resolveSafe` already realpaths both sides via the same sync API, so its containment check stays consistent. If you'd prefer a global switch (e.g. `realpathSync.native` for `workspaceReal`), happy to revisit — but that touches every caller of `workspaceReal`.
- On non-Windows hosts both syscalls return the same string, so the cache equals `workspaceReal` and the extra lookup is harmless.
- Validation: the next Windows CI run on `main` (post-merge) is the real test — local macOS run was green (`format`/`lint`/`typecheck`/`build`/`test`).

## User Prompt

(Continuation of the Windows CI fix thread that produced #1633.) After merging the diagnostic-only PR, the next Windows run surfaced:

\`\`\`
root=\"C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\...\\mulmoclaude\"
real=\"C:\\Users\\runneradmin\\AppData\\Local\\Temp\\...\\mulmoclaude\\conversations\\summaries\\2026-06.md\"
rel=\"..\\..\\..\\..\\..\\..\\runneradmin\\AppData\\Local\\Temp\\...\\mulmoclaude\\conversations\\summaries\\2026-06.md\"
\`\`\`

User confirmed proceeding with the follow-up fix PR.

## Implementation

- Add `workspaceRealAsyncCache` + `getWorkspaceRealAsync()` in `server/api/routes/files.ts`. First request lazily resolves the workspace via async `realpath` and caches the result.
- `resolveNewFilePath` calls `getWorkspaceRealAsync()` instead of using the sync-realpath'd `workspaceReal` directly for the containment check.
- All earlier diagnostic-rich `message:` strings revert to their original short forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a path validation issue in file operations that could incorrectly report files as outside the workspace boundary on certain systems.
  * Enhanced error messaging for file path restrictions, now providing standardized responses that clearly indicate when file operations are blocked due to security or policy restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->