### PR TITLE
fix: use material-symbols-outlined for user-defined feed/collection icons

### DIFF
--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -97,7 +97,7 @@ skipped, never crashes the host):
 | Key | Meaning |
 |---|---|
 | `title` | Human name shown in the sidebar / header. Required. |
-| `icon` | A **Material Icons** name (`receipt_long`, `people`, `schedule`, `menu_book`). Required. |
+| `icon` | A **Material Symbols** name (`receipt_long`, `people`, `schedule`, `menu_book`). Required. |
 | `dataPath` | Workspace-relative records folder, e.g. `data/recipes/items`. Must stay under the workspace. Required. |
 | `primaryKey` | The field name whose value is the filename. That field MUST set `primary: true`. Required. |
 | `singleton` | Optional. When set, at most one record exists, pinned to this exact id (e.g. `me`). Host pre-fills + locks the create form and hides Add once it exists. |
@@ -260,7 +260,7 @@ journals, drafting an email) gets delegated to natural language.
 {
   "id": "pdf",                      // unique within the schema
   "label": "Generate PDF",          // button text (English)
-  "icon": "picture_as_pdf",         // Material Icons name
+  "icon": "picture_as_pdf",         // Material Symbols name
   "kind": "chat",
   "role": "accounting",             // which role the new chat runs in
   "template": "templates/invoice.md", // skill-relative; no `..`, no leading `/`

--- a/server/workspace/helps/feeds.md
+++ b/server/workspace/helps/feeds.md
@@ -61,7 +61,7 @@ lists all registered feeds, and its delete button does the same.
 }
 ```
 
-- `title` (required), `icon` (required — a Material Icons name; `dynamic_feed` is
+- `title` (required), `icon` (required — a Material Symbols name; `dynamic_feed` is
   a good default). `dataPath` is set by the host to `data/feeds/<slug>` — include
   it (must equal that) or omit it; any other value is ignored. A feed can only
   ever store records under its own `data/feeds/<slug>` folder.

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -14,7 +14,7 @@
       </button>
 
       <div v-if="collection" class="h-9 w-9 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100">
-        <span class="material-icons text-xl">{{ collection.icon }}</span>
+        <span class="material-symbols-outlined text-xl">{{ collection.icon }}</span>
       </div>
 
       <div class="flex-1 min-w-0">

--- a/src/components/CollectionsIndexView.vue
+++ b/src/components/CollectionsIndexView.vue
@@ -59,7 +59,7 @@
                 : 'bg-violet-50 text-violet-600 group-hover:bg-violet-100/80 border border-violet-100/50'
             "
           >
-            <span class="material-icons text-2xl">{{ collection.icon }}</span>
+            <span class="material-symbols-outlined text-2xl">{{ collection.icon }}</span>
           </div>
 
           <div class="flex-1 min-w-0">

--- a/src/components/FeedsView.vue
+++ b/src/components/FeedsView.vue
@@ -51,7 +51,7 @@
           @keydown.space.self.prevent="open(feed.slug)"
         >
           <div class="h-12 w-12 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100/50">
-            <span class="material-icons text-2xl">{{ feed.icon || "dynamic_feed" }}</span>
+            <span class="material-symbols-outlined text-2xl">{{ feed.icon || "dynamic_feed" }}</span>
           </div>
 
           <div class="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

フィード・コレクションのユーザー定義アイコンを Material Icons → Material Symbols Outlined に切り替え、Material Symbols にしか存在しないアイコン（`neurology` 等）が正しく描画されるようにした。

- 対象: `FeedsView` / `CollectionView` / `CollectionsIndexView` の動的アイコン表示（3箇所）
- ヘルプドキュメント (`collection-skills.md`, `feeds.md`) のフォント名記述も同期して更新
- 既存アイコン（`smart_toy`, `flight` 等）は Material Symbols にも含まれるため影響なし

変更前その１
<img width="958" height="194" alt="image" src="https://github.com/user-attachments/assets/a53405ba-c2f3-4db0-91d9-f676f6c23776" />

変更前その２（戻るボタン 押せない）
<img width="408" height="171" alt="image" src="https://github.com/user-attachments/assets/4beb2dfa-9fdc-4f0f-99a5-ec6f46805970" />


変更後
<img width="825" height="190" alt="image" src="https://github.com/user-attachments/assets/7d0e5dce-4863-45fe-ac8b-38fb5a5a6d4f" />

変更後その２（戻るボタン 押せるようになった）
<img width="432" height="158" alt="image" src="https://github.com/user-attachments/assets/73e50481-92dd-4bb6-8c20-7687bc361629" />



## Items to Confirm / Review

- Material Symbols Outlined は Material Icons とアウトラインの太さが微妙に異なる（やや細い線）。既存フィード・コレクションカードの見た目が若干変わる点を許容するか
- ハードコードされたアイコン（`add`, `refresh`, `error` 等）は `material-icons` のまま残している。統一すべきかは別 issue で検討

## User Prompt

フィード一覧画面で「Google Alerts — Deep Learning」カードのアイコンだけがズレて表示される問題の修正依頼。スキーマの `icon: "neurology"` が Material Icons フォントに存在しないためフォールバック文字が描画されていた。

## 背景

[Google Fonts FAQ](https://developers.google.com/fonts/faq) より:

> Material Icons は Material Symbols に置き換えられ、更新は行われなくなります。今後の開発や追加はすべて Material Symbols に反映されます。

- [Material Symbols guide](https://developers.google.com/fonts/docs/material_symbols)
- [Material Icons Guide](https://developers.google.com/fonts/docs/material_icons)

## Cross-review

Codex + Claude の cross-review 済み（2 iteration で収束）。Codex が `CollectionsIndexView.vue` の見落としとヘルプドキュメントの不整合を検出し、修正済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated collection and feed schema documentation to clarify that icon field values must use Material Symbols naming convention.

* **Style**
  * Updated icon rendering in collection views and feed cards to use Material Symbols font for consistent visual display across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->