### PR TITLE
fix: use async-realpath workspace root for wiki classification on Windows

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -875,7 +875,9 @@ function jsonSyntaxError(relPath: string, content: string): string | null {
 //     reconstruct the final path under the resolved real ancestor.
 //     A symlinked workspace subtree pointing outside `workspaceReal`
 //     therefore can't route create writes outside the workspace.
-async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPath: string } | { ok: false; status: 400; message: string }> {
+async function resolveNewFilePath(
+  relPathRaw: string,
+): Promise<{ ok: true; absPath: string; workspaceRoot: string } | { ok: false; status: 400; message: string }> {
   const normalised = path.normalize(relPathRaw);
   if (path.isAbsolute(normalised)) return { ok: false, status: 400, message: "Path must be workspace-relative" };
   const candidate = path.resolve(workspaceReal, normalised);
@@ -921,7 +923,7 @@ async function resolveNewFilePath(relPathRaw: string): Promise<{ ok: true; absPa
   if (relFromReal === ".." || relFromReal.startsWith(`..${path.sep}`) || path.isAbsolute(relFromReal)) {
     return { ok: false, status: 400, message: "Path outside workspace" };
   }
-  return { ok: true, absPath: finalAbs };
+  return { ok: true, absPath: finalAbs, workspaceRoot: rootAsync };
 }
 
 // Create a new text file. Refuses to overwrite — that's PUT's job and
@@ -956,9 +958,14 @@ router.post(API_ROUTES.files.create, async (req: Request<object, unknown, WriteC
   // `writeWikiPage` with `exclusive: true` so the same exclusive
   // primitive applies after the frontmatter stamp.
   try {
-    const wikiClass = classifyAsWikiPage(resolved.absPath, { workspaceRoot: workspaceReal });
+    // `resolved.workspaceRoot` is the async-realpath form, matching
+    // `resolved.absPath`'s form. Passing the sync-form `workspaceReal`
+    // would make `classifyAsWikiPage` fail to match the prefix on
+    // Windows (8.3 short-name vs. long-name) — we'd fall into the
+    // plain-file branch and skip the wiki frontmatter stamp.
+    const wikiClass = classifyAsWikiPage(resolved.absPath, { workspaceRoot: resolved.workspaceRoot });
     if (wikiClass.wiki) {
-      await writeWikiPage(wikiClass.slug, content, { editor: "user" }, { workspaceRoot: workspaceReal, exclusive: true });
+      await writeWikiPage(wikiClass.slug, content, { editor: "user" }, { workspaceRoot: resolved.workspaceRoot, exclusive: true });
     } else {
       await mkdir(path.dirname(resolved.absPath), { recursive: true });
       await writeFile(resolved.absPath, content, { flag: "wx" });


### PR DESCRIPTION
## Summary

Follow-up to #1635. The first fix made `POST /api/files/create` return 200 on Windows by aligning the containment check on the async-realpath form. But the route still passed the **sync-form** `workspaceReal` to `classifyAsWikiPage` while `resolved.absPath` was now in the **async-form** — same `RUNNER~1` vs `runneradmin` prefix mismatch, so wiki page creation fell into the plain-file branch and skipped the frontmatter stamp.

Thread the async-form workspace root out of `resolveNewFilePath` and use it for both `classifyAsWikiPage` and `writeWikiPage`.

## Items to Confirm / Review

- The fix is local to the wiki branch in the create handler; PUT goes through `resolveExistingTextFile` (different function, unaffected).
- Validation: next Windows CI on `main` (post-merge) is the real signal — Windows CI run [27084926846](https://github.com/receptron/mulmoclaude/actions/runs/27084926846/job/79937400317) is the failure that surfaced this.
- The diagnostic message `expected wiki frontmatter to take up bytes, got 0` came from the wiki happy-path test, which is now exercising the right code path.

## User Prompt

(Continuation of #1633 / #1635 thread.) After merging #1635, the next Windows run still failed — but with a different symptom (\`size=0\` on the wiki page creation test), pointing at the same root cause (sync/async realpath form mismatch on Windows) in a different call site. User asked me to investigate and fix.

## Implementation

- `resolveNewFilePath` now returns `{ absPath, workspaceRoot }` where `workspaceRoot` is the cached async-realpath form.
- The create handler uses `resolved.workspaceRoot` for `classifyAsWikiPage` + `writeWikiPage` so both ends of the comparison share the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path resolution for wiki page creation, particularly on Windows systems where asynchronous and synchronous path operations may differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->