### PR TITLE
fix: feed chat button seeds schema+data prompt instead of a non-existent skill

### DIFF
--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -968,15 +968,29 @@ function closeChat(): void {
   chatOpen.value = false;
 }
 
-/** Start a new general-role chat seeded with the collection's skill
- *  command, so e.g. "I want to create an item" on `mc_worklog` becomes
- *  `/mc_worklog I want to create an item`. */
+/** Build the chat seed text for the current view.
+ *
+ *  A collection IS a skill, so its slug doubles as a slash command:
+ *  "I want to create an item" on `mc_worklog` becomes
+ *  `/mc_worklog I want to create an item`.
+ *
+ *  A feed is data-only — it has NO skill, so `/<slug>` would resolve to
+ *  nothing. Instead, point the agent at the feed's schema + records
+ *  (`feeds/<slug>/schema.json` and `<dataPath>/`) and let it act on the
+ *  request directly. */
+function buildChatSeed(slug: string, message: string): string {
+  if (!isFeed.value) return `/${slug} ${message}`;
+  const dataPath = collection.value?.schema.dataPath ?? `data/feeds/${slug}`;
+  return t("collectionsView.feedChatSeed", { slug, dataPath, message });
+}
+
+/** Start a new general-role chat seeded from the current view. */
 function submitChat(): void {
   if (!collection.value) return;
   const message = chatMessage.value.trim();
   if (!message) return;
   closeChat();
-  const text = `/${collection.value.slug} ${message}`;
+  const text = buildChatSeed(collection.value.slug, message);
   // Chat card → send into the current session; standalone → new chat.
   if (props.sendTextMessage) {
     props.sendTextMessage(text);

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -979,8 +979,12 @@ function closeChat(): void {
  *  (`feeds/<slug>/schema.json` and `<dataPath>/`) and let it act on the
  *  request directly. */
 function buildChatSeed(slug: string, message: string): string {
-  if (!isFeed.value) return `/${slug} ${message}`;
-  const dataPath = collection.value?.schema.dataPath ?? `data/feeds/${slug}`;
+  const schema = collection.value?.schema;
+  // A feed carries an `ingest` block; a plain collection does not. Checked
+  // here (rather than via the `isFeed` computed, defined further down) to
+  // keep this helper self-contained and avoid a use-before-define.
+  if (!schema?.ingest) return `/${slug} ${message}`;
+  const dataPath = schema.dataPath ?? `data/feeds/${slug}`;
   return t("collectionsView.feedChatSeed", { slug, dataPath, message });
 }
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1206,6 +1206,8 @@ const deMessages = {
     chat: "Chat",
     refreshFeed: "Aktualisieren",
     refreshFailed: "Aktualisierung fehlgeschlagen: {error}",
+    feedChatSeed:
+      "Der Feed {slug} ist durch das Schema `feeds/{slug}/schema.json` definiert und seine Datensätze liegen in `{dataPath}/` (eine `<id>.json`-Datei pro Datensatz). Nutze dieses Schema und diese Daten, um auf die folgende Anfrage zu antworten: {message}",
     feedsTitle: "Datenquellen-Feeds",
     feedsEmpty: "Noch keine Feeds registriert.",
     chatTitle: "Chat starten",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1190,6 +1190,8 @@ const enMessages = {
     chat: "Chat",
     refreshFeed: "Refresh",
     refreshFailed: "Refresh failed: {error}",
+    feedChatSeed:
+      'The "{slug}" feed is defined by the schema at `feeds/{slug}/schema.json` and its records live in `{dataPath}/` (one `<id>.json` per record). Using that schema and data, respond to this request: {message}',
     feedsTitle: "Data-source feeds",
     feedsEmpty: "No feeds registered yet.",
     chatTitle: "Start a chat",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1203,6 +1203,8 @@ const esMessages = {
     chat: "Chat",
     refreshFeed: "Actualizar",
     refreshFailed: "Error al actualizar: {error}",
+    feedChatSeed:
+      "El feed «{slug}» está definido por el esquema `feeds/{slug}/schema.json` y sus registros se guardan en `{dataPath}/` (un archivo `<id>.json` por registro). Usa ese esquema y esos datos para responder a esta solicitud: {message}",
     feedsTitle: "Fuentes de datos",
     feedsEmpty: "Aún no hay fuentes registradas.",
     chatTitle: "Iniciar un chat",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1196,6 +1196,8 @@ const frMessages = {
     chat: "Discussion",
     refreshFeed: "Actualiser",
     refreshFailed: "Échec de l'actualisation : {error}",
+    feedChatSeed:
+      "Le flux « {slug} » est défini par le schéma `feeds/{slug}/schema.json` et ses enregistrements se trouvent dans `{dataPath}/` (un fichier `<id>.json` par enregistrement). Utilise ce schéma et ces données pour répondre à cette demande : {message}",
     feedsTitle: "Flux de données",
     feedsEmpty: "Aucun flux enregistré pour le moment.",
     chatTitle: "Démarrer une discussion",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1186,6 +1186,8 @@ const jaMessages = {
     chat: "チャット",
     refreshFeed: "更新",
     refreshFailed: "更新に失敗しました: {error}",
+    feedChatSeed:
+      "フィード「{slug}」はスキーマ `feeds/{slug}/schema.json` で定義され、レコードは `{dataPath}/`（1 レコードにつき `<id>.json` 1 ファイル）に保存されています。このスキーマとデータを使って、次のリクエストに応えてください: {message}",
     feedsTitle: "データソースフィード",
     feedsEmpty: "登録されたフィードはありません。",
     chatTitle: "チャットを開始",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1190,6 +1190,8 @@ const koMessages = {
     chat: "채팅",
     refreshFeed: "새로고침",
     refreshFailed: "새로고침 실패: {error}",
+    feedChatSeed:
+      "“{slug}” 피드는 스키마 `feeds/{slug}/schema.json`로 정의되며, 레코드는 `{dataPath}/`(레코드당 `<id>.json` 파일 하나)에 저장됩니다. 이 스키마와 데이터를 사용하여 다음 요청에 응답하세요: {message}",
     feedsTitle: "데이터 소스 피드",
     feedsEmpty: "등록된 피드가 없습니다.",
     chatTitle: "채팅 시작",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1192,6 +1192,8 @@ const ptBRMessages = {
     chat: "Chat",
     refreshFeed: "Atualizar",
     refreshFailed: "Falha ao atualizar: {error}",
+    feedChatSeed:
+      'O feed "{slug}" é definido pelo esquema `feeds/{slug}/schema.json` e seus registros ficam em `{dataPath}/` (um arquivo `<id>.json` por registro). Use esse esquema e esses dados para responder a esta solicitação: {message}',
     feedsTitle: "Feeds de dados",
     feedsEmpty: "Nenhum feed registrado ainda.",
     chatTitle: "Iniciar um chat",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1179,6 +1179,8 @@ const zhMessages = {
     chat: "对话",
     refreshFeed: "刷新",
     refreshFailed: "刷新失败：{error}",
+    feedChatSeed:
+      "订阅源“{slug}”由 schema `feeds/{slug}/schema.json` 定义，其记录保存在 `{dataPath}/`（每条记录一个 `<id>.json` 文件）。请使用该 schema 和数据来响应以下请求：{message}",
     feedsTitle: "数据源订阅",
     feedsEmpty: "尚未注册任何订阅源。",
     chatTitle: "开始对话",


### PR DESCRIPTION
## Problem

The chat button in the shared `CollectionView` always built `/<slug> <message>`. That works for **collections** (each one *is* a skill, so the slug doubles as a slash command), but **feeds** are data-only — registered as `feeds/<slug>/schema.json` with no `SKILL.md` and no skill registration. So clicking chat on a feed sent `/<feed_id> …`, which resolves to a non-existent skill.

The component already knew the mode (`isFeed`) but `submitChat()` ignored it.

## Fix

`src/components/CollectionView.vue` — extract `buildChatSeed(slug, message)`:

- **Collection** → unchanged: `/<slug> <message>`.
- **Feed** → seed the chat with a localized prompt that points the agent at the feed's **schema** (`feeds/<slug>/schema.json`) and **records** (`<dataPath>/` = `data/feeds/<slug>/`, one `<id>.json` per record) and asks it to act on the user's request using them.

`dataPath` comes from `collection.value.schema.dataPath`, falling back to the forced feed namespace `data/feeds/<slug>`.

## i18n

Adds `collectionsView.feedChatSeed` to all 8 locales in lockstep (en/ja/zh/ko/es/pt-BR/fr/de), with `{slug}` / `{dataPath}` / `{message}` placeholders; code paths kept verbatim. The German entry avoids typographic quotes per the `de.ts` quote rule.

## Checks

`yarn format`, `lint`, `typecheck`, `build`, `test` all pass (pre-commit hook).

## Follow-up (not in this PR)

`e2e/tests/collection-chat-button.spec.ts` covers the collection case but there's no feed-mode equivalent. Worth adding a test asserting the feed seed is the schema/data prompt rather than `/<slug>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat in collection views now seeds responses with contextual data for feed collections (uses the collection’s schema/data path); non-feed collections continue to use the existing slash-command style.

* **Localization**
  * Added localized feed-chat prompt text across German, English, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->