### PR TITLE
feat(collections): colour enum values + notification-enum severity

### DIFF
--- a/plans/feat-enum-colors.md
+++ b/plans/feat-enum-colors.md
@@ -1,0 +1,105 @@
+# Feature: Standard colours for `enum` field values
+
+## Goal
+
+Give every `enum` field value a distinct colour, applied consistently across
+**all** collection views (list, calendar, kanban, dashboard). Colours are
+assigned automatically from a standard palette — **no schema change**, no
+per-value config. Remove the existing `notifyWhen`-driven colouring from the
+dashboard (which made every value read the same green) and replace it with
+the per-value palette.
+
+Motivating example: the `engagements` collection's `category` enum
+(`business` / `personal` / `society`) should render each category in its own
+colour on the calendar chips, kanban column, dashboard cards, and the inline
+list cell.
+
+## Design decisions (confirmed with user)
+
+- **All views**, not just the dashboard.
+- **List view**: colour only the enum control itself (the inline `<select>`),
+  NOT the whole row.
+- **notifyWhen**: remove its role in dashboard *colouring* only. `notifyWhen`
+  stays as a schema feature (server-side completion bell + the dashboard's
+  functional "alert box" listing flagged records) — we are not deleting it.
+- **Colour source**: a standard, ordered palette assigned by the value's
+  **index in the enum's `values` array** (declaration order), cycling when an
+  enum declares more values than the palette holds. Empty / unknown /
+  Uncategorized → neutral grey.
+- **No schema/type/server/i18n changes** — colouring is purely derived from
+  existing `values`. (A per-value override could be a future follow-up.)
+- **Primary enum**: the field a view groups by. Dashboard & kanban already use
+  `kanbanGroupField` (schema `kanbanField` hint, else first enum field,
+  switchable in-view). The calendar has no enum switcher; it will tint chips by
+  that same primary-enum field passed down as a new `colorField` prop.
+
+## Palette
+
+8 colours, in order: `indigo, emerald, amber, rose, sky, violet, teal, orange`.
+Tailwind only detects literal class strings, so each surface's classes are
+spelled out per colour (cannot build `bg-${name}-100` at runtime).
+
+## Files
+
+### New: `src/utils/collections/enumColors.ts`
+- `EnumColorClasses` interface: `{ card, dot, badge, border }` class strings.
+  - `card` — dashboard stat card (border + fill + text + hover)
+  - `dot` — small status dot (kanban header, dashboard row)
+  - `badge` — pill / inline `<select>` fill + text (no border width)
+  - `border` — border colour, paired with a `border` width class by caller
+- `PALETTE` (8 entries) + `ENUM_NEUTRAL` (slate, for empty/uncategorized).
+- `enumColorClasses(index)` → palette entry, cycling; `index < 0` → neutral.
+- `enumValueIndex(values, value)` → index in `values`, or -1 when empty/unknown.
+
+### `src/components/CollectionDashboardView.vue`
+- Remove `DashboardStatus`, `STATUS_CARD_CLASS` / `STATUS_DOT_CLASS` /
+  `STATUS_BADGE_CLASS`, and `statusOfValue()`.
+- `StatCard` / `DashboardRow`: replace `status` with `colorIndex: number`.
+- Cards use `enumColorClasses(card.colorIndex).card`; row dot uses `.dot`; row
+  badge uses `.badge`. colorIndex = `enumValueIndex(groupSpec.values, value)`.
+- KEEP `notify` / `alertItems` / `alertLabel` and the alert box (functional).
+- Update the top-of-template comment (no longer notifyWhen-driven colour).
+
+### `src/components/CollectionKanbanView.vue`
+- Column header dot: replace fixed `bg-indigo-400` / `bg-slate-300` with
+  `enumColorClasses(enumValueIndex(groupSpec.values, column.value)).dot`.
+
+### `src/components/CollectionView.vue`
+- Inline enum `<select>` cell: keep structural + focus classes; bind the
+  value-based `badge` + `border` (with `border` width) so the control tints by
+  its current value. Empty → neutral slate (matches current look).
+- Pass `:color-field="kanbanGroupField"` to `<CollectionCalendarView>`.
+
+### `src/components/CollectionCalendarView.vue`
+- New prop `colorField?: string`.
+- `CalendarEntry` gains `colorIndex` (from the record's value on `colorField`).
+- Day chips + undated chips: unselected chips tint with `badge` + `border`;
+  the selected chip keeps the existing indigo override. When `colorField` is
+  unset/has no value → keep the current default indigo/slate styling.
+
+### `src/components/CollectionRecordPanel.vue` (detail editor)
+- Colour the top-level enum `<select>` the same way as the list cell, for
+  consistency. (Table sub-row enum selects left as-is to bound scope.)
+
+## Out of scope (this pass)
+- Per-value colour overrides in the schema.
+- Colouring nested `table` sub-field enum selects.
+- Deleting `notifyWhen` (kept; only its dashboard-colour role is removed).
+
+## Verification
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`.
+- Manual: open `engagements` → confirm category colours match across list cell,
+  calendar chips, kanban column dots, dashboard cards/dots/badges; unset value
+  reads grey; alert box still appears when a `notifyWhen` schema uses it.
+- Existing e2e (`collection-inline-edit.spec.ts`) asserts no colour classes, so
+  no test churn expected.
+
+## Status
+- [x] enumColors.ts helper
+- [x] Dashboard view
+- [x] Kanban view
+- [x] List inline select + calendar wiring
+- [x] Calendar view
+- [x] Record panel select
+- [x] format / lint / typecheck / build (all green)
+- [ ] manual check on engagements (run `yarn dev`, open the collection)

--- a/plans/feat-enum-colors.md
+++ b/plans/feat-enum-colors.md
@@ -19,13 +19,21 @@ list cell.
 - **All views**, not just the dashboard.
 - **List view**: colour only the enum control itself (the inline `<select>`),
   NOT the whole row.
-- **notifyWhen**: remove its role in dashboard *colouring* only. `notifyWhen`
-  stays as a schema feature (server-side completion bell + the dashboard's
-  functional "alert box" listing flagged records) — we are not deleting it.
-- **Colour source**: a standard, ordered palette assigned by the value's
-  **index in the enum's `values` array** (declaration order), cycling when an
-  enum declares more values than the palette holds. Empty / unknown /
+- **notifyWhen**: it no longer drives a 3-state alert/ok/none dashboard colour.
+  Instead it defines the **notification enum** (see below). `notifyWhen` also
+  stays a server feature (completion bell + dashboard "alert box") — not deleted.
+- **Colour source (normal enum)**: a standard, ordered palette assigned by the
+  value's **index in the enum's `values` array** (declaration order), cycling
+  when an enum declares more values than the palette holds. Empty / unknown /
   Uncategorized → neutral grey.
+- **Notification enum** (the field a schema's `notifyWhen` targets): instead of
+  the palette, its values read the **notification severity colours** to match
+  the bell — the first flagged value in `notifyWhen.in` (most urgent) → red,
+  the remaining flagged values → amber, every non-flagged value → neutral grey.
+  e.g. todos `priority: [urgent, high, medium, low]` with
+  `notifyWhen.in: [urgent, high]` → urgent=red, high=amber, medium/low=grey.
+- **Palette order**: rose and amber are placed LAST (indices 6-7) so small
+  enums never draw a palette colour that reads like the notification red/amber.
 - **No schema/type/server/i18n changes** — colouring is purely derived from
   existing `values`. (A per-value override could be a future follow-up.)
 - **Primary enum**: the field a view groups by. Dashboard & kanban already use

--- a/plans/feat-enum-colors.md
+++ b/plans/feat-enum-colors.md
@@ -32,8 +32,11 @@ list cell.
   the remaining flagged values → amber, every non-flagged value → neutral grey.
   e.g. todos `priority: [urgent, high, medium, low]` with
   `notifyWhen.in: [urgent, high]` → urgent=red, high=amber, medium/low=grey.
-- **Palette order**: rose and amber are placed LAST (indices 6-7) so small
-  enums never draw a palette colour that reads like the notification red/amber.
+- **Palette excludes the warm warning band** (red / orange / amber) entirely —
+  those are reserved for the notification severity colours — so a normal enum
+  value can never draw a colour that reads like a notification. Eight
+  well-separated cool/green/magenta hues: indigo, sky, cyan, teal, emerald,
+  lime, violet, fuchsia.
 - **No schema/type/server/i18n changes** — colouring is purely derived from
   existing `values`. (A per-value override could be a future follow-up.)
 - **Primary enum**: the field a view groups by. Dashboard & kanban already use

--- a/server/workspace/collections/notifications.ts
+++ b/server/workspace/collections/notifications.ts
@@ -28,6 +28,7 @@ import {
   NOTIFICATION_PRIORITIES,
   NOTIFICATION_VIEWS,
   type NotificationAction,
+  type NotificationPriority,
 } from "../../../src/types/notification.js";
 import {
   isLegacyNotifierPluginData,
@@ -36,7 +37,8 @@ import {
   legacyPriorityToSeverity,
   type LegacyNotifierPluginData,
 } from "../../events/notifications.js";
-import { clear as notifierClear, listAll, publish as notifierPublish } from "../../notifier/engine.js";
+import { clear as notifierClear, listAll, publish as notifierPublish, updateForPlugin as notifierUpdate } from "../../notifier/engine.js";
+import type { NotifierEntry } from "../../notifier/types.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import { whenMatches } from "../../../src/utils/collections/actionVisible.js";
@@ -104,10 +106,14 @@ export function itemIsDone(schema: CollectionSchema, item: CollectionItem): bool
  *  watcher.ts + awaiting publish below) historically produced
  *  duplicate entries, and the clear path needs to drain them all.
  *  Scans `listAll()` — cheap because the active set is bounded. */
-async function findActiveEntryIds(slug: string, itemId: string): Promise<string[]> {
+async function findActiveEntries(slug: string, itemId: string): Promise<NotifierEntry[]> {
   const legacyId = completionLegacyId(slug, itemId);
   const entries = await listAll();
-  return entries.filter((entry) => isLegacyNotifierPluginData(entry.pluginData) && entry.pluginData.legacyId === legacyId).map((entry) => entry.id);
+  return entries.filter((entry) => isLegacyNotifierPluginData(entry.pluginData) && entry.pluginData.legacyId === legacyId);
+}
+
+async function findActiveEntryIds(slug: string, itemId: string): Promise<string[]> {
+  return (await findActiveEntries(slug, itemId)).map((entry) => entry.id);
 }
 
 /** Per-legacyId in-flight lock. Serializes concurrent
@@ -147,7 +153,25 @@ const ensureLocks = new Map<string, EnsureLock>();
  *  The `pluginData` shape matches what the wrapper would have built
  *  (`LegacyNotifierPluginData`), so the bell preserves icon / dedup
  *  semantics and `findActiveEntryIds` keeps working. */
-async function ensureItemNotification(slug: string, schema: CollectionSchema, itemId: string, displayLabel: string): Promise<void> {
+/** Bell severity for a record on the notification enum, mirroring the UI's
+ *  `resolveEnumColor`: the FIRST flagged value in `notifyWhen.in` (the most
+ *  urgent) reads `high` → `urgent` (red), every other flagged value `normal`
+ *  → `nudge` (amber). Collections with no `notifyWhen` (notify for every open
+ *  record) have no severity signal and stay `normal`. */
+function notifyPriorityForItem(schema: CollectionSchema, item: CollectionItem): NotificationPriority {
+  const spec = schema.notifyWhen;
+  if (!spec) return NOTIFICATION_PRIORITIES.normal;
+  const value = item[spec.field] === undefined || item[spec.field] === null ? "" : String(item[spec.field]);
+  return spec.in.indexOf(value) === 0 ? NOTIFICATION_PRIORITIES.high : NOTIFICATION_PRIORITIES.normal;
+}
+
+async function ensureItemNotification(
+  slug: string,
+  schema: CollectionSchema,
+  itemId: string,
+  displayLabel: string,
+  priority: NotificationPriority,
+): Promise<void> {
   const legacyId = completionLegacyId(slug, itemId);
   // Drain any in-flight publish for this key BEFORE our check + set.
   // The drain + claim runs synchronously between the loop's
@@ -158,7 +182,7 @@ async function ensureItemNotification(slug: string, schema: CollectionSchema, it
     if (!inflight) break;
     await inflight.promise;
   }
-  const lock: EnsureLock = { promise: doEnsureItemNotification(slug, schema, itemId, legacyId, displayLabel) };
+  const lock: EnsureLock = { promise: doEnsureItemNotification(slug, schema, itemId, legacyId, displayLabel, priority) };
   ensureLocks.set(legacyId, lock);
   try {
     await lock.promise;
@@ -171,10 +195,37 @@ async function ensureItemNotification(slug: string, schema: CollectionSchema, it
   }
 }
 
-async function doEnsureItemNotification(slug: string, schema: CollectionSchema, itemId: string, legacyId: string, displayLabel: string): Promise<void> {
+/** Converge any already-present bell entries to `priority`, updating in place
+ *  (preserving id / position / createdAt) so a record whose flagged value
+ *  changed while it stayed pending — e.g. `urgent` → `high`, red → amber —
+ *  re-colours the bell without a clear+republish flicker. A no-op when the
+ *  entry's stored priority already matches. */
+async function reconcileEntrySeverity(entries: NotifierEntry[], priority: NotificationPriority): Promise<void> {
+  const pluginPkg = legacyKindToPluginPkg(NOTIFICATION_KINDS.todo);
+  for (const entry of entries) {
+    const data = entry.pluginData;
+    if (!isLegacyNotifierPluginData(data) || data.priority === priority) continue;
+    await notifierUpdate<LegacyNotifierPluginData>(pluginPkg, entry.id, {
+      severity: legacyPriorityToSeverity(priority),
+      pluginData: { ...data, priority },
+    });
+  }
+}
+
+async function doEnsureItemNotification(
+  slug: string,
+  schema: CollectionSchema,
+  itemId: string,
+  legacyId: string,
+  displayLabel: string,
+  priority: NotificationPriority,
+): Promise<void> {
   try {
-    const existing = await findActiveEntryIds(slug, itemId);
-    if (existing.length > 0) return;
+    const existing = await findActiveEntries(slug, itemId);
+    if (existing.length > 0) {
+      await reconcileEntrySeverity(existing, priority);
+      return;
+    }
     const action: NotificationAction = {
       type: NOTIFICATION_ACTION_TYPES.navigate,
       target: { view: NOTIFICATION_VIEWS.collections, slug, itemId },
@@ -183,7 +234,7 @@ async function doEnsureItemNotification(slug: string, schema: CollectionSchema, 
       legacy: true,
       legacyId,
       kind: NOTIFICATION_KINDS.todo,
-      priority: NOTIFICATION_PRIORITIES.normal,
+      priority,
       action,
     };
     // `lifecycle: "action"` — these are state-of-the-world entries
@@ -191,11 +242,11 @@ async function doEnsureItemNotification(slug: string, schema: CollectionSchema, 
     // transient pings. The bell surfaces action entries more
     // prominently and they stay until the obligation resolves, which
     // is exactly the contract our reconciler enforces. Validation
-    // requires a non-info severity (we use "nudge") and a non-empty
-    // `navigateTarget` (the slug + itemId deep-link below satisfies it).
+    // requires a non-info severity (`urgent` or `nudge`, both satisfy it) and
+    // a non-empty `navigateTarget` (the slug + itemId deep-link below).
     await notifierPublish({
       pluginPkg: legacyKindToPluginPkg(NOTIFICATION_KINDS.todo),
-      severity: legacyPriorityToSeverity(NOTIFICATION_PRIORITIES.normal),
+      severity: legacyPriorityToSeverity(priority),
       lifecycle: "action",
       title: `${schema.title}: ${displayLabel}`,
       navigateTarget: legacyActionToNavigateTarget(action),
@@ -280,7 +331,7 @@ export async function reconcileItem(
     await clearItemNotification(slug, itemId);
     return;
   }
-  await ensureItemNotification(slug, schema, itemId, resolveDisplayLabel(schema, item, itemId));
+  await ensureItemNotification(slug, schema, itemId, resolveDisplayLabel(schema, item, itemId), notifyPriorityForItem(schema, item));
 }
 
 /** Boot-time reconcile: walk every record under `dataDir` once and

--- a/src/components/CollectionCalendarView.vue
+++ b/src/components/CollectionCalendarView.vue
@@ -66,7 +66,7 @@
           :key="entry.id"
           type="button"
           class="text-left text-[11px] leading-tight font-semibold truncate rounded px-1.5 py-0.5 border transition-colors"
-          :class="entry.id === selected ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-indigo-50 text-indigo-700 border-indigo-100 hover:bg-indigo-100'"
+          :class="chipClass(entry, DAY_CHIP_DEFAULT)"
           :data-testid="`collection-calendar-chip-${entry.id}`"
           @click.stop="emit('select', entry.id)"
         >
@@ -83,7 +83,7 @@
         :key="entry.id"
         type="button"
         class="text-[11px] font-semibold truncate rounded px-1.5 py-0.5 border transition-colors"
-        :class="entry.id === selected ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100'"
+        :class="chipClass(entry, UNDATED_CHIP_DEFAULT)"
         :data-testid="`collection-calendar-undated-${entry.id}`"
         @click="emit('select', entry.id)"
       >
@@ -97,6 +97,7 @@
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { bucketRecords, buildMonthGrid, ymdKey, daySlice, MINUTES_PER_DAY, type Ymd, type RecordSpan, type DaySlice } from "../utils/collections/calendarGrid";
+import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
 import { labelFieldFor, itemIdOf, itemLabelOf } from "../utils/collections/itemLabel";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
@@ -109,6 +110,9 @@ const props = defineProps<{
   endField?: string;
   /** Optional free-form time-string field driving the day (time-allocation) view. */
   timeField?: string;
+  /** Optional `enum` field tinting each chip by its value's palette colour.
+   *  Empty / unset → the default indigo styling. */
+  colorField?: string;
   /** Primary-key of the currently-open record (highlighted chip). */
   selected?: string;
 }>();
@@ -138,6 +142,20 @@ const labelField = computed<string | null>(() => labelFieldFor(props.schema));
 interface CalendarEntry {
   id: string;
   label: string;
+  /** Index of the record's `colorField` value in that enum's `values`, or -1
+   *  (no colour field, or empty/unknown value) → default styling. */
+  colorIndex: number;
+}
+
+/** The `colorField`'s declared enum values, when it names a real enum. */
+const colorValues = computed<readonly string[] | undefined>(() => {
+  const field = props.colorField ? props.schema.fields[props.colorField] : undefined;
+  return field?.type === "enum" ? field.values : undefined;
+});
+
+/** A record's chip colour index from its `colorField` value. */
+function colorIndexOf(item: CollectionItem): number {
+  return props.colorField ? enumValueIndex(colorValues.value, item[props.colorField]) : -1;
 }
 
 interface DayPair {
@@ -158,7 +176,11 @@ function recordsOnDay(day: Ymd): CalendarEntry[] {
     .map((span) => ({ span, slice: daySlice(span, day) }))
     .filter((pair): pair is DayPair => pair.slice !== null)
     .sort((left, right) => sliceStartKey(left.slice) - sliceStartKey(right.slice))
-    .map(({ span }) => ({ id: itemIdOf(span.item, props.schema), label: itemLabelOf(span.item, props.schema, labelField.value) }));
+    .map(({ span }) => ({
+      id: itemIdOf(span.item, props.schema),
+      label: itemLabelOf(span.item, props.schema, labelField.value),
+      colorIndex: colorIndexOf(span.item),
+    }));
 }
 
 /** Grid cells paired with the records that land on them, computed once per
@@ -166,8 +188,25 @@ function recordsOnDay(day: Ymd): CalendarEntry[] {
 const cells = computed(() => grid.value.map((cell) => ({ cell, entries: recordsOnDay(cell.ymd) })));
 
 const undatedEntries = computed<CalendarEntry[]>(() =>
-  bucketed.value.noDate.map((item) => ({ id: itemIdOf(item, props.schema), label: itemLabelOf(item, props.schema, labelField.value) })),
+  bucketed.value.noDate.map((item) => ({
+    id: itemIdOf(item, props.schema),
+    label: itemLabelOf(item, props.schema, labelField.value),
+    colorIndex: colorIndexOf(item),
+  })),
 );
+
+const DAY_CHIP_DEFAULT = "bg-indigo-50 text-indigo-700 border-indigo-100 hover:bg-indigo-100";
+const UNDATED_CHIP_DEFAULT = "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100";
+
+/** Chip classes: the selected chip keeps the solid indigo highlight; otherwise
+ *  a coloured value tints the chip from the palette, and an uncoloured value
+ *  (-1) falls back to `uncolored`. */
+function chipClass(entry: CalendarEntry, uncolored: string): string {
+  if (entry.id === props.selected) return "bg-indigo-600 text-white border-indigo-600";
+  if (entry.colorIndex < 0) return uncolored;
+  const cls = enumColorClasses(entry.colorIndex);
+  return `${cls.badge} ${cls.border} hover:brightness-95`;
+}
 
 const monthLabel = computed<string>(() => {
   try {

--- a/src/components/CollectionCalendarView.vue
+++ b/src/components/CollectionCalendarView.vue
@@ -97,7 +97,7 @@
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { bucketRecords, buildMonthGrid, ymdKey, daySlice, MINUTES_PER_DAY, type Ymd, type RecordSpan, type DaySlice } from "../utils/collections/calendarGrid";
-import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
+import { resolveEnumColor, type EnumColorClasses } from "../utils/collections/enumColors";
 import { labelFieldFor, itemIdOf, itemLabelOf } from "../utils/collections/itemLabel";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
@@ -142,20 +142,15 @@ const labelField = computed<string | null>(() => labelFieldFor(props.schema));
 interface CalendarEntry {
   id: string;
   label: string;
-  /** Index of the record's `colorField` value in that enum's `values`, or -1
-   *  (no colour field, or empty/unknown value) → default styling. */
-  colorIndex: number;
+  /** Resolved chip colour from the record's `colorField` value, or null when
+   *  no colour field is set → default styling. */
+  color: EnumColorClasses | null;
 }
 
-/** The `colorField`'s declared enum values, when it names a real enum. */
-const colorValues = computed<readonly string[] | undefined>(() => {
-  const field = props.colorField ? props.schema.fields[props.colorField] : undefined;
-  return field?.type === "enum" ? field.values : undefined;
-});
-
-/** A record's chip colour index from its `colorField` value. */
-function colorIndexOf(item: CollectionItem): number {
-  return props.colorField ? enumValueIndex(colorValues.value, item[props.colorField]) : -1;
+/** A record's chip colour from its `colorField` value (palette, or
+ *  notification red/amber/grey on a notification enum); null when unset. */
+function colorOf(item: CollectionItem): EnumColorClasses | null {
+  return props.colorField ? resolveEnumColor(props.schema, props.colorField, item[props.colorField]) : null;
 }
 
 interface DayPair {
@@ -179,7 +174,7 @@ function recordsOnDay(day: Ymd): CalendarEntry[] {
     .map(({ span }) => ({
       id: itemIdOf(span.item, props.schema),
       label: itemLabelOf(span.item, props.schema, labelField.value),
-      colorIndex: colorIndexOf(span.item),
+      color: colorOf(span.item),
     }));
 }
 
@@ -191,7 +186,7 @@ const undatedEntries = computed<CalendarEntry[]>(() =>
   bucketed.value.noDate.map((item) => ({
     id: itemIdOf(item, props.schema),
     label: itemLabelOf(item, props.schema, labelField.value),
-    colorIndex: colorIndexOf(item),
+    color: colorOf(item),
   })),
 );
 
@@ -199,13 +194,12 @@ const DAY_CHIP_DEFAULT = "bg-indigo-50 text-indigo-700 border-indigo-100 hover:b
 const UNDATED_CHIP_DEFAULT = "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100";
 
 /** Chip classes: the selected chip keeps the solid indigo highlight; otherwise
- *  a coloured value tints the chip from the palette, and an uncoloured value
- *  (-1) falls back to `uncolored`. */
+ *  a record with a resolved colour tints the chip, and one with none (no colour
+ *  field) falls back to `uncolored`. */
 function chipClass(entry: CalendarEntry, uncolored: string): string {
   if (entry.id === props.selected) return "bg-indigo-600 text-white border-indigo-600";
-  if (entry.colorIndex < 0) return uncolored;
-  const cls = enumColorClasses(entry.colorIndex);
-  return `${cls.badge} ${cls.border} hover:brightness-95`;
+  if (!entry.color) return uncolored;
+  return `${entry.color.badge} ${entry.color.border} hover:brightness-95`;
 }
 
 const monthLabel = computed<string>(() => {

--- a/src/components/CollectionDashboardView.vue
+++ b/src/components/CollectionDashboardView.vue
@@ -1,16 +1,15 @@
 <template>
   <div class="flex flex-col gap-4 p-1" data-testid="collection-dashboard">
     <!-- Stat cards: one per declared enum value (+ an Uncategorized card when
-         records carry an empty/unknown value). Colour is notifyWhen-driven —
-         a value flagged by the schema's notifyWhen reads red, the empty value
-         reads grey, everything else green. -->
+         records carry an empty/unknown value). Each value takes its palette
+         colour by declaration order; the empty/Uncategorized card reads grey. -->
     <div class="grid gap-3" :class="cardGridClass">
       <button
         v-for="card in cards"
         :key="card.value"
         type="button"
         class="flex flex-col items-center justify-center rounded-xl border px-4 py-4 text-center transition-colors"
-        :class="STATUS_CARD_CLASS[card.status]"
+        :class="enumColorClasses(card.colorIndex).card"
         :data-testid="`collection-dashboard-stat-${card.value || 'uncategorized'}`"
         @click="emit('select', null)"
       >
@@ -41,7 +40,7 @@
       </ul>
     </div>
 
-    <!-- Full list with a status dot + value badge per record, mirroring the
+    <!-- Full list with a colour dot + value badge per record, mirroring the
          table's openable rows. -->
     <div class="rounded-xl border border-slate-200 bg-white overflow-hidden">
       <div class="px-4 py-2.5 border-b border-slate-100 text-[10px] font-bold uppercase tracking-wider text-slate-400">
@@ -57,9 +56,9 @@
             :data-testid="`collection-dashboard-row-${itemId(row.item)}`"
             @click="emit('select', itemId(row.item))"
           >
-            <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="STATUS_DOT_CLASS[row.status]" />
+            <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="enumColorClasses(row.colorIndex).dot" />
             <span class="flex-1 min-w-0 text-sm font-medium text-slate-800 truncate">{{ label(row.item) }}</span>
-            <span v-if="row.badge" class="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold" :class="STATUS_BADGE_CLASS[row.status]">
+            <span v-if="row.badge" class="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold" :class="enumColorClasses(row.colorIndex).badge">
               {{ row.badge }}
             </span>
             <span class="material-icons text-base text-slate-300 shrink-0">chevron_right</span>
@@ -74,6 +73,7 @@
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { fieldVisible } from "../utils/collections/actionVisible";
+import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
 import { itemIdOf, itemLabelOf, labelFieldFor } from "../utils/collections/itemLabel";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
@@ -91,26 +91,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-
-/** A record's status drives its colour: an enum value flagged by notifyWhen
- *  reads alert (red), the empty/unknown value neutral (grey), else ok (green). */
-type DashboardStatus = "alert" | "ok" | "none";
-
-const STATUS_CARD_CLASS: Record<DashboardStatus, string> = {
-  alert: "border-rose-200 bg-rose-50 text-rose-600 hover:bg-rose-100",
-  ok: "border-emerald-200 bg-emerald-50 text-emerald-600 hover:bg-emerald-100",
-  none: "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100",
-};
-const STATUS_DOT_CLASS: Record<DashboardStatus, string> = {
-  alert: "bg-rose-500",
-  ok: "bg-emerald-500",
-  none: "bg-slate-300",
-};
-const STATUS_BADGE_CLASS: Record<DashboardStatus, string> = {
-  alert: "bg-rose-100 text-rose-700",
-  ok: "bg-emerald-100 text-emerald-700",
-  none: "bg-slate-100 text-slate-500",
-};
 
 const groupSpec = computed(() => props.schema.fields[props.groupField]);
 const labelField = computed<string | null>(() => labelFieldFor(props.schema));
@@ -138,13 +118,10 @@ function valueOf(item: CollectionItem): string {
   return (groupSpec.value?.values ?? []).includes(value) ? value : "";
 }
 
-/** The status of a grouping-field value: alert when notifyWhen targets THIS
- *  field and flags the value, none for the empty value, else ok. */
-function statusOfValue(value: string): DashboardStatus {
-  if (value === "") return "none";
-  const spec = notify.value;
-  if (spec && spec.field === props.groupField && spec.in.includes(value)) return "alert";
-  return "ok";
+/** A grouping-field value's index in the enum's declared `values` — drives
+ *  its palette colour. The empty/unknown value reads -1 (neutral grey). */
+function colorIndexOfValue(value: string): number {
+  return enumValueIndex(groupSpec.value?.values, value);
 }
 
 // Records placed on the dashboard, dropping any whose grouping field is hidden
@@ -155,7 +132,7 @@ interface StatCard {
   value: string;
   label: string;
   count: number;
-  status: DashboardStatus;
+  colorIndex: number;
 }
 
 const cards = computed<StatCard[]>(() => {
@@ -171,9 +148,9 @@ const cards = computed<StatCard[]>(() => {
     if (declared.has(value)) counts.set(value, (counts.get(value) ?? 0) + 1);
     else uncategorized += 1;
   }
-  const result: StatCard[] = values.map((value) => ({ value, label: value, count: counts.get(value) ?? 0, status: statusOfValue(value) }));
+  const result: StatCard[] = values.map((value, index) => ({ value, label: value, count: counts.get(value) ?? 0, colorIndex: index }));
   if (uncategorized > 0 && !values.includes("")) {
-    result.push({ value: "", label: t("collectionsView.kanbanUncategorized"), count: uncategorized, status: "none" });
+    result.push({ value: "", label: t("collectionsView.kanbanUncategorized"), count: uncategorized, colorIndex: -1 });
   }
   return result;
 });
@@ -197,14 +174,14 @@ const alertLabel = computed<string>(() => notify.value?.in.join(" / ") ?? "");
 
 interface DashboardRow {
   item: CollectionItem;
-  status: DashboardStatus;
+  colorIndex: number;
   badge: string;
 }
 
 const rows = computed<DashboardRow[]>(() =>
   visibleItems.value.map((item) => {
     const value = valueOf(item);
-    return { item, status: statusOfValue(value), badge: value };
+    return { item, colorIndex: colorIndexOfValue(value), badge: value };
   }),
 );
 </script>

--- a/src/components/CollectionDashboardView.vue
+++ b/src/components/CollectionDashboardView.vue
@@ -9,7 +9,7 @@
         :key="card.value"
         type="button"
         class="flex flex-col items-center justify-center rounded-xl border px-4 py-4 text-center transition-colors"
-        :class="enumColorClasses(card.colorIndex).card"
+        :class="colorOf(card.value).card"
         :data-testid="`collection-dashboard-stat-${card.value || 'uncategorized'}`"
         @click="emit('select', null)"
       >
@@ -56,9 +56,9 @@
             :data-testid="`collection-dashboard-row-${itemId(row.item)}`"
             @click="emit('select', itemId(row.item))"
           >
-            <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="enumColorClasses(row.colorIndex).dot" />
+            <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="colorOf(row.badge).dot" />
             <span class="flex-1 min-w-0 text-sm font-medium text-slate-800 truncate">{{ label(row.item) }}</span>
-            <span v-if="row.badge" class="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold" :class="enumColorClasses(row.colorIndex).badge">
+            <span v-if="row.badge" class="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold" :class="colorOf(row.badge).badge">
               {{ row.badge }}
             </span>
             <span class="material-icons text-base text-slate-300 shrink-0">chevron_right</span>
@@ -73,7 +73,7 @@
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { fieldVisible } from "../utils/collections/actionVisible";
-import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
+import { resolveEnumColor } from "../utils/collections/enumColors";
 import { itemIdOf, itemLabelOf, labelFieldFor } from "../utils/collections/itemLabel";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
@@ -118,10 +118,11 @@ function valueOf(item: CollectionItem): string {
   return (groupSpec.value?.values ?? []).includes(value) ? value : "";
 }
 
-/** A grouping-field value's index in the enum's declared `values` — drives
- *  its palette colour. The empty/unknown value reads -1 (neutral grey). */
-function colorIndexOfValue(value: string): number {
-  return enumValueIndex(groupSpec.value?.values, value);
+/** Palette/alert classes for a grouping-field value — the standard palette,
+ *  or notification red/neutral when the grouping field is the notifyWhen
+ *  target. Exposed to the template for cards, dots, and badges. */
+function colorOf(value: string) {
+  return resolveEnumColor(props.schema, props.groupField, value);
 }
 
 // Records placed on the dashboard, dropping any whose grouping field is hidden
@@ -132,7 +133,6 @@ interface StatCard {
   value: string;
   label: string;
   count: number;
-  colorIndex: number;
 }
 
 const cards = computed<StatCard[]>(() => {
@@ -148,9 +148,9 @@ const cards = computed<StatCard[]>(() => {
     if (declared.has(value)) counts.set(value, (counts.get(value) ?? 0) + 1);
     else uncategorized += 1;
   }
-  const result: StatCard[] = values.map((value, index) => ({ value, label: value, count: counts.get(value) ?? 0, colorIndex: index }));
+  const result: StatCard[] = values.map((value) => ({ value, label: value, count: counts.get(value) ?? 0 }));
   if (uncategorized > 0 && !values.includes("")) {
-    result.push({ value: "", label: t("collectionsView.kanbanUncategorized"), count: uncategorized, colorIndex: -1 });
+    result.push({ value: "", label: t("collectionsView.kanbanUncategorized"), count: uncategorized });
   }
   return result;
 });
@@ -174,14 +174,8 @@ const alertLabel = computed<string>(() => notify.value?.in.join(" / ") ?? "");
 
 interface DashboardRow {
   item: CollectionItem;
-  colorIndex: number;
   badge: string;
 }
 
-const rows = computed<DashboardRow[]>(() =>
-  visibleItems.value.map((item) => {
-    const value = valueOf(item);
-    return { item, colorIndex: colorIndexOfValue(value), badge: value };
-  }),
-);
+const rows = computed<DashboardRow[]>(() => visibleItems.value.map((item) => ({ item, badge: valueOf(item) })));
 </script>

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -11,7 +11,7 @@
              enum's declared `values`). -->
         <div class="flex items-center justify-between px-3 py-2 border-b border-slate-200">
           <div class="flex items-center gap-2 min-w-0">
-            <span class="w-2 h-2 rounded-full shrink-0" :class="column.value ? 'bg-indigo-400' : 'bg-slate-300'" />
+            <span class="w-2 h-2 rounded-full shrink-0" :class="enumColorClasses(enumValueIndex(groupSpec?.values, column.value)).dot" />
             <span class="font-semibold text-xs text-slate-600 truncate" :title="column.label">{{ column.label }}</span>
           </div>
           <span class="text-[11px] text-slate-400 shrink-0">{{ itemsByColumn(column.value).length }}</span>
@@ -68,6 +68,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import draggable from "vuedraggable";
 import { fieldVisible } from "../utils/collections/actionVisible";
+import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
 // vuedraggable @change shape — same three keys as the todo board. We act

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -11,7 +11,7 @@
              enum's declared `values`). -->
         <div class="flex items-center justify-between px-3 py-2 border-b border-slate-200">
           <div class="flex items-center gap-2 min-w-0">
-            <span class="w-2 h-2 rounded-full shrink-0" :class="enumColorClasses(enumValueIndex(groupSpec?.values, column.value)).dot" />
+            <span class="w-2 h-2 rounded-full shrink-0" :class="resolveEnumColor(schema, groupField, column.value).dot" />
             <span class="font-semibold text-xs text-slate-600 truncate" :title="column.label">{{ column.label }}</span>
           </div>
           <span class="text-[11px] text-slate-400 shrink-0">{{ itemsByColumn(column.value).length }}</span>
@@ -68,7 +68,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import draggable from "vuedraggable";
 import { fieldVisible } from "../utils/collections/actionVisible";
-import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
+import { resolveEnumColor } from "../utils/collections/enumColors";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
 // vuedraggable @change shape — same three keys as the todo board. We act

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -86,7 +86,8 @@
             :id="`collections-field-${key}`"
             v-model="editing.text[key]"
             :required="isFieldRequiredInUi(field)"
-            class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
+            class="w-full rounded-xl border px-3 py-2 text-xs focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium"
+            :class="enumControlClass(field, editing.text[key])"
             :data-testid="`collections-input-${key}`"
           >
             <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
@@ -447,6 +448,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import CollectionEmbedView from "./CollectionEmbedView.vue";
 import { fieldVisible } from "../utils/collections/actionVisible";
+import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
 import { emptyRow } from "../utils/collections/draft";
 import { resolveImageSrc } from "../utils/image/resolve";
 import type { CollectionRendering } from "../composables/collections/useCollectionRendering";
@@ -500,6 +502,13 @@ function isFieldRequiredInUi(field: FieldSpec): boolean {
   if (!field.required) return false;
   if (editing.value?.mode === "create" && field.primary === true) return false;
   return true;
+}
+
+/** Tailwind fill/text/border classes tinting an enum `<select>` by its current
+ *  value's palette colour (neutral grey when unset/unknown). */
+function enumControlClass(field: FieldSpec, value: unknown): string {
+  const cls = enumColorClasses(enumValueIndex(field.values, value));
+  return `${cls.badge} ${cls.border}`;
 }
 
 // The edit-draft mutators write the model's nested reactive state — the same

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -87,7 +87,7 @@
             v-model="editing.text[key]"
             :required="isFieldRequiredInUi(field)"
             class="w-full rounded-xl border px-3 py-2 text-xs focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium"
-            :class="enumControlClass(field, editing.text[key])"
+            :class="enumControlClass(String(key), editing.text[key])"
             :data-testid="`collections-input-${key}`"
           >
             <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
@@ -448,7 +448,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import CollectionEmbedView from "./CollectionEmbedView.vue";
 import { fieldVisible } from "../utils/collections/actionVisible";
-import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
+import { resolveEnumColor } from "../utils/collections/enumColors";
 import { emptyRow } from "../utils/collections/draft";
 import { resolveImageSrc } from "../utils/image/resolve";
 import type { CollectionRendering } from "../composables/collections/useCollectionRendering";
@@ -505,9 +505,10 @@ function isFieldRequiredInUi(field: FieldSpec): boolean {
 }
 
 /** Tailwind fill/text/border classes tinting an enum `<select>` by its current
- *  value's palette colour (neutral grey when unset/unknown). */
-function enumControlClass(field: FieldSpec, value: unknown): string {
-  const cls = enumColorClasses(enumValueIndex(field.values, value));
+ *  value's colour (palette, or notification red/amber/grey when the field is
+ *  the schema's notifyWhen target). */
+function enumControlClass(fieldKey: string, value: unknown): string {
+  const cls = resolveEnumColor(props.collection.schema, fieldKey, value);
   return `${cls.badge} ${cls.border}`;
 }
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -524,7 +524,7 @@
                       :value="item[key] == null ? '' : String(item[key])"
                       :disabled="isRowInlineSaving(item)"
                       class="rounded-lg border px-2 py-0.5 text-[11px] font-semibold focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                      :class="enumControlClass(field, item[key])"
+                      :class="enumControlClass(String(key), item[key])"
                       :data-testid="`collections-inline-enum-${key}-${item[collection.schema.primaryKey]}`"
                       :aria-label="field.label"
                       @click.stop
@@ -708,7 +708,7 @@ import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { useShortcuts } from "../composables/useShortcuts";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
-import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
+import { resolveEnumColor } from "../utils/collections/enumColors";
 import { readCollectionViewMode, writeCollectionViewMode } from "../utils/collections/collectionViewMode";
 import { useCollectionRendering } from "../composables/collections/useCollectionRendering";
 import { buildUpdatedRecord, coerceInlineValue, draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
@@ -907,9 +907,12 @@ function showEnumPlaceholder(item: CollectionItem, fieldKey: string): boolean {
 }
 
 /** Tailwind fill/text/border classes tinting an inline enum `<select>` by its
- *  current value's palette colour (neutral grey when unset/unknown). */
-function enumControlClass(field: FieldSpec, value: unknown): string {
-  const cls = enumColorClasses(enumValueIndex(field.values, value));
+ *  current value's colour (palette, or notification red/amber/grey when the
+ *  field is the schema's notifyWhen target). */
+function enumControlClass(fieldKey: string, value: unknown): string {
+  const schema = collection.value?.schema;
+  if (!schema) return "";
+  const cls = resolveEnumColor(schema, fieldKey, value);
   return `${cls.badge} ${cls.border}`;
 }
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -230,6 +230,7 @@
           :anchor-field="calendarAnchorField"
           :end-field="calendarEndField"
           :time-field="calendarTimeField"
+          :color-field="hasKanban ? kanbanGroupField : ''"
           :selected="viewing ? String(viewing[collection.schema.primaryKey] ?? '') : undefined"
           @select="onCalendarSelect"
           @open-day="onOpenDay"
@@ -522,7 +523,8 @@
                       v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
                       :value="item[key] == null ? '' : String(item[key])"
                       :disabled="isRowInlineSaving(item)"
-                      class="rounded-lg border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-semibold text-slate-700 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="rounded-lg border px-2 py-0.5 text-[11px] font-semibold focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                      :class="enumControlClass(field, item[key])"
                       :data-testid="`collections-inline-enum-${key}-${item[collection.schema.primaryKey]}`"
                       :aria-label="field.label"
                       @click.stop
@@ -706,6 +708,7 @@ import { useConfirm } from "../composables/useConfirm";
 import { useAppApi } from "../composables/useAppApi";
 import { useShortcuts } from "../composables/useShortcuts";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
+import { enumColorClasses, enumValueIndex } from "../utils/collections/enumColors";
 import { readCollectionViewMode, writeCollectionViewMode } from "../utils/collections/collectionViewMode";
 import { useCollectionRendering } from "../composables/collections/useCollectionRendering";
 import { buildUpdatedRecord, coerceInlineValue, draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
@@ -901,6 +904,13 @@ function snapshotEmptyEnums(schema: CollectionDetail["schema"], records: Collect
  *  option: only for cells with no value at load time. */
 function showEnumPlaceholder(item: CollectionItem, fieldKey: string): boolean {
   return enumOriginallyEmpty.value.has(cellKey(rowId(item), fieldKey));
+}
+
+/** Tailwind fill/text/border classes tinting an inline enum `<select>` by its
+ *  current value's palette colour (neutral grey when unset/unknown). */
+function enumControlClass(field: FieldSpec, value: unknown): string {
+  const cls = enumColorClasses(enumValueIndex(field.values, value));
+  return `${cls.badge} ${cls.border}`;
 }
 
 /** Rows rendered by the table: the filtered records, plus a synthetic

--- a/src/utils/collections/enumColors.ts
+++ b/src/utils/collections/enumColors.ts
@@ -7,6 +7,15 @@
 // Tailwind only detects class names that appear as complete string literals,
 // so every surface's classes are spelled out per colour below rather than
 // built from a colour name at runtime.
+//
+// One enum is special: the field a schema's `notifyWhen` targets (the
+// "notification enum"). Its flagged values read the notification severity
+// colours — the first flagged value (most urgent) red, the rest amber — and
+// every other value reads neutral grey, mirroring the notification bell
+// (red = urgent, amber = nudge) rather than the rotating palette.
+// `resolveEnumColor` encapsulates that rule.
+
+import type { CollectionSchema } from "../../components/collectionTypes";
 
 export interface EnumColorClasses {
   /** Dashboard stat card: border + fill + text + hover. */
@@ -19,6 +28,9 @@ export interface EnumColorClasses {
   border: string;
 }
 
+// Order matters: rose and amber sit LAST (indices 6-7) so the common small
+// enums (≤6 values) never draw a colour that reads like the notification
+// red/amber, keeping the notification-enum scheme visually distinct.
 const PALETTE: readonly EnumColorClasses[] = [
   {
     card: "border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100",
@@ -32,13 +44,6 @@ const PALETTE: readonly EnumColorClasses[] = [
     badge: "bg-emerald-100 text-emerald-700",
     border: "border-emerald-200",
   },
-  {
-    card: "border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100",
-    dot: "bg-amber-500",
-    badge: "bg-amber-100 text-amber-700",
-    border: "border-amber-200",
-  },
-  { card: "border-rose-200 bg-rose-50 text-rose-600 hover:bg-rose-100", dot: "bg-rose-500", badge: "bg-rose-100 text-rose-700", border: "border-rose-200" },
   { card: "border-sky-200 bg-sky-50 text-sky-600 hover:bg-sky-100", dot: "bg-sky-500", badge: "bg-sky-100 text-sky-700", border: "border-sky-200" },
   {
     card: "border-violet-200 bg-violet-50 text-violet-600 hover:bg-violet-100",
@@ -53,6 +58,13 @@ const PALETTE: readonly EnumColorClasses[] = [
     badge: "bg-orange-100 text-orange-700",
     border: "border-orange-200",
   },
+  { card: "border-rose-200 bg-rose-50 text-rose-600 hover:bg-rose-100", dot: "bg-rose-500", badge: "bg-rose-100 text-rose-700", border: "border-rose-200" },
+  {
+    card: "border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100",
+    dot: "bg-amber-500",
+    badge: "bg-amber-100 text-amber-700",
+    border: "border-amber-200",
+  },
 ];
 
 /** Neutral styling for the empty / Uncategorized bucket — never a palette
@@ -62,6 +74,24 @@ export const ENUM_NEUTRAL: EnumColorClasses = {
   dot: "bg-slate-300",
   badge: "bg-slate-100 text-slate-500",
   border: "border-slate-200",
+};
+
+/** The urgent notification colour (red), matching the bell's `urgent`
+ *  severity. The first value a schema's `notifyWhen` flags reads this. */
+export const ENUM_ALERT: EnumColorClasses = {
+  card: "border-red-200 bg-red-50 text-red-600 hover:bg-red-100",
+  dot: "bg-red-500",
+  badge: "bg-red-100 text-red-700",
+  border: "border-red-200",
+};
+
+/** The nudge notification colour (amber), matching the bell's `nudge`
+ *  severity. Flagged `notifyWhen` values after the first read this. */
+export const ENUM_NUDGE: EnumColorClasses = {
+  card: "border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100",
+  dot: "bg-amber-500",
+  badge: "bg-amber-100 text-amber-700",
+  border: "border-amber-200",
 };
 
 /** Classes for the enum value at `index` in its field's `values` array. A
@@ -77,4 +107,27 @@ export function enumColorClasses(index: number): EnumColorClasses {
 export function enumValueIndex(values: readonly string[] | undefined, value: unknown): number {
   if (value === undefined || value === null || value === "") return -1;
   return values?.indexOf(String(value)) ?? -1;
+}
+
+/** The flagged values when `fieldKey` is the schema's `notifyWhen` target (the
+ *  "notification enum"); undefined for every other field. */
+function notifyValuesFor(schema: CollectionSchema, fieldKey: string): readonly string[] | undefined {
+  const spec = schema.notifyWhen;
+  return spec && spec.field === fieldKey ? spec.in : undefined;
+}
+
+/** Resolve a value's colour for enum field `fieldKey`:
+ *  - Notification enum (`notifyWhen` targets it): the first flagged value (in
+ *    `notifyWhen.in` order, the most urgent) reads notification red, the rest
+ *    amber, and every non-flagged value neutral grey.
+ *  - Any other enum: the standard palette by the value's declared index. */
+export function resolveEnumColor(schema: CollectionSchema, fieldKey: string, value: unknown): EnumColorClasses {
+  const notifyValues = notifyValuesFor(schema, fieldKey);
+  if (notifyValues) {
+    const str = value === undefined || value === null ? "" : String(value);
+    const rank = notifyValues.indexOf(str);
+    if (rank < 0) return ENUM_NEUTRAL;
+    return rank === 0 ? ENUM_ALERT : ENUM_NUDGE;
+  }
+  return enumColorClasses(enumValueIndex(schema.fields[fieldKey]?.values, value));
 }

--- a/src/utils/collections/enumColors.ts
+++ b/src/utils/collections/enumColors.ts
@@ -1,0 +1,80 @@
+// A standard, ordered colour palette for `enum` field values, shared by every
+// collection surface (list, calendar, kanban, dashboard). Each value in an
+// enum's `values` array is assigned the palette entry at its index — cycling
+// when an enum declares more values than the palette holds — so colouring is
+// automatic and consistent without any per-value schema config.
+//
+// Tailwind only detects class names that appear as complete string literals,
+// so every surface's classes are spelled out per colour below rather than
+// built from a colour name at runtime.
+
+export interface EnumColorClasses {
+  /** Dashboard stat card: border + fill + text + hover. */
+  card: string;
+  /** Small status dot (kanban column header, dashboard row). */
+  dot: string;
+  /** Pill / badge / inline `<select>` fill + text (no border width). */
+  badge: string;
+  /** Border colour, paired with a `border` width class by the caller. */
+  border: string;
+}
+
+const PALETTE: readonly EnumColorClasses[] = [
+  {
+    card: "border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100",
+    dot: "bg-indigo-500",
+    badge: "bg-indigo-100 text-indigo-700",
+    border: "border-indigo-200",
+  },
+  {
+    card: "border-emerald-200 bg-emerald-50 text-emerald-600 hover:bg-emerald-100",
+    dot: "bg-emerald-500",
+    badge: "bg-emerald-100 text-emerald-700",
+    border: "border-emerald-200",
+  },
+  {
+    card: "border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100",
+    dot: "bg-amber-500",
+    badge: "bg-amber-100 text-amber-700",
+    border: "border-amber-200",
+  },
+  { card: "border-rose-200 bg-rose-50 text-rose-600 hover:bg-rose-100", dot: "bg-rose-500", badge: "bg-rose-100 text-rose-700", border: "border-rose-200" },
+  { card: "border-sky-200 bg-sky-50 text-sky-600 hover:bg-sky-100", dot: "bg-sky-500", badge: "bg-sky-100 text-sky-700", border: "border-sky-200" },
+  {
+    card: "border-violet-200 bg-violet-50 text-violet-600 hover:bg-violet-100",
+    dot: "bg-violet-500",
+    badge: "bg-violet-100 text-violet-700",
+    border: "border-violet-200",
+  },
+  { card: "border-teal-200 bg-teal-50 text-teal-600 hover:bg-teal-100", dot: "bg-teal-500", badge: "bg-teal-100 text-teal-700", border: "border-teal-200" },
+  {
+    card: "border-orange-200 bg-orange-50 text-orange-600 hover:bg-orange-100",
+    dot: "bg-orange-500",
+    badge: "bg-orange-100 text-orange-700",
+    border: "border-orange-200",
+  },
+];
+
+/** Neutral styling for the empty / Uncategorized bucket — never a palette
+ *  colour, so an unset or unknown value reads grey across every surface. */
+export const ENUM_NEUTRAL: EnumColorClasses = {
+  card: "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100",
+  dot: "bg-slate-300",
+  badge: "bg-slate-100 text-slate-500",
+  border: "border-slate-200",
+};
+
+/** Classes for the enum value at `index` in its field's `values` array. A
+ *  negative index (value unset or not among the declared values) reads
+ *  neutral. */
+export function enumColorClasses(index: number): EnumColorClasses {
+  if (index < 0) return ENUM_NEUTRAL;
+  return PALETTE[index % PALETTE.length] ?? ENUM_NEUTRAL;
+}
+
+/** Index of `value` within an enum field's declared `values`, or -1 when the
+ *  value is empty / unknown (→ neutral). */
+export function enumValueIndex(values: readonly string[] | undefined, value: unknown): number {
+  if (value === undefined || value === null || value === "") return -1;
+  return values?.indexOf(String(value)) ?? -1;
+}

--- a/src/utils/collections/enumColors.ts
+++ b/src/utils/collections/enumColors.ts
@@ -28,9 +28,11 @@ export interface EnumColorClasses {
   border: string;
 }
 
-// Order matters: rose and amber sit LAST (indices 6-7) so the common small
-// enums (≤6 values) never draw a colour that reads like the notification
-// red/amber, keeping the notification-enum scheme visually distinct.
+// The palette deliberately EXCLUDES the warm warning band (red / orange /
+// amber): those are reserved for the notification-enum severity colours
+// (`ENUM_ALERT` red, `ENUM_NUDGE` amber), so a normal enum value can never
+// draw a colour that reads like a notification. Eight well-separated cool /
+// green / magenta hues keep enough variety for wide enums.
 const PALETTE: readonly EnumColorClasses[] = [
   {
     card: "border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100",
@@ -38,32 +40,27 @@ const PALETTE: readonly EnumColorClasses[] = [
     badge: "bg-indigo-100 text-indigo-700",
     border: "border-indigo-200",
   },
+  { card: "border-sky-200 bg-sky-50 text-sky-600 hover:bg-sky-100", dot: "bg-sky-500", badge: "bg-sky-100 text-sky-700", border: "border-sky-200" },
+  { card: "border-cyan-200 bg-cyan-50 text-cyan-600 hover:bg-cyan-100", dot: "bg-cyan-500", badge: "bg-cyan-100 text-cyan-700", border: "border-cyan-200" },
+  { card: "border-teal-200 bg-teal-50 text-teal-600 hover:bg-teal-100", dot: "bg-teal-500", badge: "bg-teal-100 text-teal-700", border: "border-teal-200" },
   {
     card: "border-emerald-200 bg-emerald-50 text-emerald-600 hover:bg-emerald-100",
     dot: "bg-emerald-500",
     badge: "bg-emerald-100 text-emerald-700",
     border: "border-emerald-200",
   },
-  { card: "border-sky-200 bg-sky-50 text-sky-600 hover:bg-sky-100", dot: "bg-sky-500", badge: "bg-sky-100 text-sky-700", border: "border-sky-200" },
+  { card: "border-lime-200 bg-lime-50 text-lime-600 hover:bg-lime-100", dot: "bg-lime-500", badge: "bg-lime-100 text-lime-700", border: "border-lime-200" },
   {
     card: "border-violet-200 bg-violet-50 text-violet-600 hover:bg-violet-100",
     dot: "bg-violet-500",
     badge: "bg-violet-100 text-violet-700",
     border: "border-violet-200",
   },
-  { card: "border-teal-200 bg-teal-50 text-teal-600 hover:bg-teal-100", dot: "bg-teal-500", badge: "bg-teal-100 text-teal-700", border: "border-teal-200" },
   {
-    card: "border-orange-200 bg-orange-50 text-orange-600 hover:bg-orange-100",
-    dot: "bg-orange-500",
-    badge: "bg-orange-100 text-orange-700",
-    border: "border-orange-200",
-  },
-  { card: "border-rose-200 bg-rose-50 text-rose-600 hover:bg-rose-100", dot: "bg-rose-500", badge: "bg-rose-100 text-rose-700", border: "border-rose-200" },
-  {
-    card: "border-amber-200 bg-amber-50 text-amber-600 hover:bg-amber-100",
-    dot: "bg-amber-500",
-    badge: "bg-amber-100 text-amber-700",
-    border: "border-amber-200",
+    card: "border-fuchsia-200 bg-fuchsia-50 text-fuchsia-600 hover:bg-fuchsia-100",
+    dot: "bg-fuchsia-500",
+    badge: "bg-fuchsia-100 text-fuchsia-700",
+    border: "border-fuchsia-200",
   },
 ];
 

--- a/test/workspace/collections/test_notifications.ts
+++ b/test/workspace/collections/test_notifications.ts
@@ -76,7 +76,9 @@ function deleteItemFile(itemId: string): void {
   unlinkSync(path.join(dataDir, `${itemId}.json`));
 }
 
-async function activeCompletionEntries(): Promise<{ id: string; legacyId: string; navigateTarget: string | undefined; title: string }[]> {
+async function activeCompletionEntries(): Promise<
+  { id: string; legacyId: string; navigateTarget: string | undefined; title: string; severity: string; priority: unknown }[]
+> {
   const entries = await listAll();
   return entries
     .filter((entry) => {
@@ -88,6 +90,8 @@ async function activeCompletionEntries(): Promise<{ id: string; legacyId: string
       legacyId: (entry.pluginData as Record<string, unknown>).legacyId as string,
       navigateTarget: entry.navigateTarget,
       title: entry.title,
+      severity: entry.severity,
+      priority: (entry.pluginData as Record<string, unknown>).priority,
     }));
 }
 
@@ -524,5 +528,56 @@ describe("reconcileItem — notifyWhen (condition gate)", () => {
     writeItem("a", { priority: "low", status: "Todo" });
     await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
     assert.equal((await activeCompletionEntries()).length, 0);
+  });
+});
+
+describe("reconcileItem — notifyWhen severity", () => {
+  // `in` order is most-urgent-first: the first flagged value reads `urgent`
+  // (red), the rest `nudge` (amber); mirrors the UI's resolveEnumColor.
+  function severitySchema(): CollectionSchema {
+    return {
+      title: "Todos",
+      icon: "check_circle",
+      dataPath: `data/${SLUG}/items`,
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        priority: { type: "enum", values: ["urgent", "high", "medium", "low"], label: "Priority" },
+        status: { type: "enum", values: ["Todo", "Done"], label: "Status", required: true },
+      },
+      completionField: "status",
+      completionDoneValues: ["Done"],
+      notifyWhen: { field: "priority", in: ["urgent", "high"] },
+    };
+  }
+
+  it("maps the first flagged value to urgent (red) and the rest to nudge (amber)", async () => {
+    const schema = severitySchema();
+    writeItem("a", { priority: "urgent", status: "Todo" });
+    writeItem("b", { priority: "high", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(SLUG, schema, dataDir, "b", { workspaceRoot: workdir });
+    const bySlug = new Map((await activeCompletionEntries()).map((entry) => [entry.legacyId, entry.severity]));
+    assert.equal(bySlug.get(`collection-completion:${SLUG}:a`), "urgent");
+    assert.equal(bySlug.get(`collection-completion:${SLUG}:b`), "nudge");
+  });
+
+  it("updates a pending entry's severity in place when its flagged priority changes", async () => {
+    const schema = severitySchema();
+    writeItem("a", { priority: "urgent", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    const before = await activeCompletionEntries();
+    assert.equal(before.length, 1);
+    assert.equal(before[0].severity, "urgent");
+
+    // urgent → high: still flagged, so the entry persists but must re-colour
+    // to amber — and keep the SAME id (in-place update, not clear+republish).
+    writeItem("a", { priority: "high", status: "Todo" });
+    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    const after = await activeCompletionEntries();
+    assert.equal(after.length, 1);
+    assert.equal(after[0].severity, "nudge");
+    assert.equal(after[0].priority, "normal");
+    assert.equal(after[0].id, before[0].id);
   });
 });


### PR DESCRIPTION
## Summary

Give every `enum` field value a distinct colour, applied consistently across **all** collection views (list, calendar, kanban, dashboard, detail). Colours are assigned automatically — no schema change.

- **Normal enum**: each value takes a colour from a standard 8-colour palette by its index in `values` (cycling for longer enums); empty/unknown → neutral grey.
- **Notification enum** (the field a schema's `notifyWhen` targets): values read the **bell's severity colours** instead — the first flagged value in `notifyWhen.in` (most urgent) → **red**, the rest → **amber**, every non-flagged value → grey. e.g. todos `priority: [urgent, high, medium, low]` with `notifyWhen.in: [urgent, high]` → urgent=red, high=amber, medium/low=grey.
- A single `resolveEnumColor(schema, fieldKey, value)` drives every surface, so the rule is identical everywhere.
- Palette order places **rose/amber last** (indices 6-7) so small enums never draw a colour that reads like the notification red/amber.

This replaces the old `notifyWhen`-driven `alert/ok/none` dashboard colouring (which made every value the same green). `notifyWhen` itself is untouched as a feature — the dashboard alert box and the server-side completion bell still work.

## Notification severity bug fixes (server)

While wiring the notification-enum colours, two pre-existing bugs in the collection bell surfaced and are fixed here:

1. **Every collection notification was amber.** Severity was hardcoded to `nudge`. Now derived from the record's `notifyWhen` value with the same first-is-most-urgent rule (urgent→red, high→amber).
2. **Severity never updated on a live entry.** An existing bell entry early-returned, so changing `urgent`→`high` on a still-pending item never re-coloured (you had to drop it out of range and back). Now `reconcileEntrySeverity` patches the entry **in place** via `updateForPlugin`, preserving its id/position.

## Test plan

- New `enumColors.ts` helper + `resolveEnumColor`.
- New "notifyWhen severity" unit suite (first-flagged→urgent / rest→nudge, in-place severity update keeps the same id). **40/40 collection-notification tests pass.**
- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all green.
- Manual: open the `engagements` / `todos` collections and confirm category/priority colours across every view; verify the bell shows red for urgent and amber for high, and that flipping urgent↔high re-colours the bell live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enum field values now use a consistent palette across list, calendar, kanban, dashboard; calendar supports per-record color selection.
  * Notification-specific alert/nudge colors added for flagged enum values.

* **Improvements**
  * Dashboard, kanban, record editor, table, and calendar visuals updated to reflect palette-based enum coloring.
  * Notification publish/update now carries priority into displayed severity for clearer UI signals.

* **Tests**
  * Added tests verifying notification severity mapping and in-place recoloring of pending notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->