### PR TITLE
feat(collections): unify open/edit into one modal across all view modes

### DIFF
--- a/e2e/tests/collection-calendar.spec.ts
+++ b/e2e/tests/collection-calendar.spec.ts
@@ -250,6 +250,22 @@ test.describe("collection calendar view", () => {
     await expect(page.getByTestId("collections-input-on")).toHaveValue(empty);
   });
 
+  test("closing the day popup mid-create does not re-open the draft in the shared modal", async ({ page }) => {
+    await page.goto("/collections/events");
+    await page.getByTestId("collection-view-toggle-calendar").click();
+    const empty = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-20`;
+    await page.getByTestId(`collection-calendar-day-${empty}`).click();
+    await page.getByTestId("collection-day-view-create").click();
+    await expect(page.getByTestId("collections-create")).toBeVisible();
+
+    // Closing the whole day popup must discard the in-progress create — it must
+    // NOT fall through and re-appear in the centred record modal (Codex P2 #1656).
+    await page.getByTestId("collection-day-view-close").click();
+    await expect(page.getByTestId("collection-day-view")).toHaveCount(0);
+    await expect(page.getByTestId("collections-record-modal")).toHaveCount(0);
+    await expect(page.getByTestId("collections-create")).toHaveCount(0);
+  });
+
   test("calendar view hides the top Add button (create happens via the day view +)", async ({ page }) => {
     await page.goto("/collections/events");
     // Present in the table view…

--- a/e2e/tests/collection-calendar.spec.ts
+++ b/e2e/tests/collection-calendar.spec.ts
@@ -218,14 +218,14 @@ test.describe("collection calendar view", () => {
     await expect(page.getByTestId("collection-calendar-chip-someday")).toHaveCount(0);
   });
 
-  test("selecting an undated record shows the bottom panel, not the day popup", async ({ page }) => {
+  test("selecting an undated record shows the shared record modal, not the day popup", async ({ page }) => {
     await page.goto("/collections/events");
     await page.getByTestId("collection-view-toggle-calendar").click();
     // An undated record has no day to place on a timeline → its detail opens in
-    // the panel below the grid and no day popup appears.
+    // the shared record modal and no day popup appears.
     await page.getByTestId("collection-calendar-undated-someday").click();
     await expect(page.getByTestId("collection-day-view")).toHaveCount(0);
-    await expect(page.getByTestId("collections-calendar-panel")).toBeVisible();
+    await expect(page.getByTestId("collections-record-modal")).toBeVisible();
     await expect(page.getByTestId("collections-detail-title")).toHaveText("someday");
   });
 
@@ -246,7 +246,7 @@ test.describe("collection calendar view", () => {
     await expect(page.getByTestId("collection-day-view")).toBeVisible();
     await expect(page.getByTestId("collection-day-view-detail")).toBeVisible();
     await expect(page.getByTestId("collections-create")).toBeVisible();
-    await expect(page.getByTestId("collections-calendar-panel")).toHaveCount(0);
+    await expect(page.getByTestId("collections-record-modal")).toHaveCount(0);
     await expect(page.getByTestId("collections-input-on")).toHaveValue(empty);
   });
 

--- a/e2e/tests/collection-deep-link-scroll.spec.ts
+++ b/e2e/tests/collection-deep-link-scroll.spec.ts
@@ -1,17 +1,16 @@
 // E2E coverage for the `?selected=<id>` deep link (the path a
 // collection-item notification takes): opening a collection with a
-// selected id that loaded far down a long list must not only expand
-// that row's detail panel — it must SCROLL it into view. Before the
-// fix, `syncViewToSelected` opened the record but never called
-// `scrollOpenPanelIntoView`, so a notification for an off-screen item
-// left the user staring at the top of the table.
+// selected id that loaded far down a long list must open that record's
+// detail. It now opens in the shared, viewport-centred record modal, so
+// the record is on screen no matter where its row sits in the list — the
+// old inline-expansion era needed an explicit scroll-into-view; the modal
+// makes that moot.
 
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 
-// Enough rows that an id near the bottom renders well below the fold on
-// the default 720px-tall viewport — so "in viewport" is only true if we
-// actually scrolled to it.
+// Enough rows that the targeted id near the bottom renders well below the
+// fold on the default 720px-tall viewport.
 const ITEM_COUNT = 60;
 const TARGET_ID = "item-55";
 
@@ -42,18 +41,18 @@ async function mockCollection(page: Page): Promise<void> {
   );
 }
 
-test("a `?selected=` deep link scrolls the opened record into view", async ({ page }) => {
+test("a `?selected=` deep link opens the record in the centred modal", async ({ page }) => {
   await mockAllApis(page);
   await mockCollection(page);
 
   await page.goto(`/collections/long-list?selected=${TARGET_ID}`);
 
-  // The targeted record's detail panel expands inline under its row...
-  const panel = page.getByTestId(`collections-expansion-${TARGET_ID}`);
-  await expect(panel).toBeVisible({ timeout: 10_000 });
+  // The targeted record opens in the shared modal...
+  const modal = page.getByTestId("collections-record-modal");
+  await expect(modal).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("collections-detail-title")).toHaveText(TARGET_ID);
 
-  // ...and — the regression this guards — it is scrolled into view, not
-  // left below the fold. `toBeInViewport` auto-retries, so it waits out
-  // the smooth scroll.
-  await expect(panel).toBeInViewport();
+  // ...and the modal is on screen regardless of the row's position in the
+  // long list (it's viewport-centred, so this needs no scroll).
+  await expect(page.getByTestId("collections-detail")).toBeInViewport();
 });

--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -85,20 +85,16 @@ test("presentCollection card renders the collection without crashing", async ({ 
   await page.goto(SESSION_PATH);
 
   await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
-  // itemId "avatar" was passed → the read-only detail panel opens inline on mount.
+  // itemId "avatar" was passed → the read-only detail opens in the shared
+  // record modal on mount.
+  await expect(page.getByTestId("collections-record-modal")).toBeVisible();
   await expect(page.getByTestId("collections-detail")).toBeVisible();
   await expect(page.getByTestId("collections-detail-title")).toHaveText("avatar");
-
-  // The panel must fit the View width, never the (possibly wider) table
-  // width — otherwise a wide collection clips the right of the panel.
-  const cardBox = await page.getByTestId("present-collection").boundingBox();
-  const detailBox = await page.getByTestId("collections-detail").boundingBox();
-  expect(cardBox && detailBox && detailBox.width <= cardBox.width + 1).toBeTruthy();
 
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });
 
-test("Edit on an open record swaps the inline panel to the edit form in place", async ({ page }) => {
+test("Edit on an open record swaps the modal to the edit form in place", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
 
@@ -106,18 +102,18 @@ test("Edit on an open record swaps the inline panel to the edit form in place", 
   await page.goto(SESSION_PATH);
 
   await expect(page.getByTestId("collections-detail")).toBeVisible({ timeout: 10_000 });
-  // Edit flips the SAME inline expansion to the edit form (no modal).
+  // Edit flips the SAME modal to the edit form in place — the layout doesn't
+  // change, only the controls become editable.
   await page.getByTestId("collections-detail-edit").click();
+  await expect(page.getByTestId("collections-record-modal")).toBeVisible();
   await expect(page.getByTestId("collections-edit")).toBeVisible();
   await expect(page.getByTestId("collections-detail")).toBeHidden();
   await expect(page.getByTestId("collections-input-title")).toHaveValue("アバター");
-  // No fixed-overlay modal is used anymore.
-  await expect(page.locator(".fixed.inset-0.z-30")).toHaveCount(0);
 
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });
 
-test("Add opens the create form as a panel pinned at the top of the list", async ({ page }) => {
+test("Add opens the create form in the shared record modal", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
 
@@ -125,13 +121,15 @@ test("Add opens the create form as a panel pinned at the top of the list", async
   await page.goto(SESSION_PATH);
   await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
 
+  // The card mounts with itemId "avatar" → the detail modal is open. Close it
+  // first so the (overlay-covered) Add button is clickable.
+  await expect(page.getByTestId("collections-record-modal")).toBeVisible();
+  await page.getByTestId("collections-detail-close").click();
+  await expect(page.getByTestId("collections-record-modal")).toHaveCount(0);
+
   await page.getByTestId("collections-add-item").click();
-  const createForm = page.getByTestId("collections-create");
-  await expect(createForm).toBeVisible();
-  // The create panel sits above the first data row (synthetic top row).
-  const createBox = await createForm.boundingBox();
-  const firstRow = await page.getByTestId("collections-row-avatar").boundingBox();
-  expect(createBox && firstRow && createBox.y < firstRow.y).toBeTruthy();
+  await expect(page.getByTestId("collections-record-modal")).toBeVisible();
+  await expect(page.getByTestId("collections-create")).toBeVisible();
 
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });

--- a/src/components/CollectionRecordModal.vue
+++ b/src/components/CollectionRecordModal.vue
@@ -6,7 +6,11 @@
        (CollectionDayView), which embeds the same panel on its right. Teleported
        to <body> so an embedded card's transformed ancestor can't trap the
        fixed overlay. Backdrop click / Escape both emit `close`; the host
-       decides whether that cancels an edit or closes the detail. -->
+       decides whether that cancels an edit or closes the detail.
+
+       Focus is contained while open (Tab/Shift+Tab wrap inside the dialog)
+       and restored to the trigger on close, so keyboard users can't reach
+       the controls behind the overlay (WCAG focus containment). -->
   <Teleport to="body">
     <div class="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/40 p-4" data-testid="collections-record-modal" @click.self="emit('close')">
       <div
@@ -16,6 +20,7 @@
         aria-modal="true"
         tabindex="-1"
         @keydown.esc="emit('close')"
+        @keydown.tab="onTab"
       >
         <slot />
       </div>
@@ -24,16 +29,65 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, ref } from "vue";
+import { nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 
 const emit = defineEmits<{ close: [] }>();
 
 const dialogEl = ref<HTMLDivElement | null>(null);
 
+// The control that had focus before the modal opened (usually the row /
+// card the user activated). Restored when the modal unmounts.
+let previouslyFocused: HTMLElement | null = null;
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/** Visible, focusable controls inside the dialog, in DOM order. */
+function focusableItems(): HTMLElement[] {
+  if (!dialogEl.value) return [];
+  return Array.from(dialogEl.value.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((node) => node.offsetParent !== null);
+}
+
+/** Trap Tab / Shift+Tab inside the dialog so focus can't escape to the
+ *  page behind the overlay. Wraps at both ends; the dialog container
+ *  itself (tabindex -1) counts as "before the first item". */
+function onTab(event: KeyboardEvent): void {
+  const items = focusableItems();
+  if (items.length === 0) {
+    event.preventDefault();
+    dialogEl.value?.focus();
+    return;
+  }
+  const [first] = items;
+  const last = items[items.length - 1];
+  const active = document.activeElement;
+  if (event.shiftKey) {
+    if (active === first || active === dialogEl.value) {
+      event.preventDefault();
+      last.focus();
+    }
+  } else if (active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
 // Focus the dialog on open so Escape (bound on the dialog) fires even
 // before the user clicks into a field, and focus leaves the row behind it.
 onMounted(async () => {
+  previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   await nextTick();
   dialogEl.value?.focus();
+});
+
+// Restore focus to the trigger so keyboard users land back where they were.
+onBeforeUnmount(() => {
+  previouslyFocused?.focus?.();
 });
 </script>

--- a/src/components/CollectionRecordModal.vue
+++ b/src/components/CollectionRecordModal.vue
@@ -1,0 +1,39 @@
+<template>
+  <!-- Centered modal shell for a collection record's open/edit panel. Used
+       by every non-calendar view mode (table / kanban / dashboard) and the
+       calendar's undated tray, so opening an item is a consistent popup
+       everywhere. Calendar's dated records keep their own day-view modal
+       (CollectionDayView), which embeds the same panel on its right. Teleported
+       to <body> so an embedded card's transformed ancestor can't trap the
+       fixed overlay. Backdrop click / Escape both emit `close`; the host
+       decides whether that cancels an edit or closes the detail. -->
+  <Teleport to="body">
+    <div class="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/40 p-4" data-testid="collections-record-modal" @click.self="emit('close')">
+      <div
+        ref="dialogEl"
+        class="flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl focus:outline-none"
+        role="dialog"
+        aria-modal="true"
+        tabindex="-1"
+        @keydown.esc="emit('close')"
+      >
+        <slot />
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onMounted, ref } from "vue";
+
+const emit = defineEmits<{ close: [] }>();
+
+const dialogEl = ref<HTMLDivElement | null>(null);
+
+// Focus the dialog on open so Escape (bound on the dialog) fires even
+// before the user clicks into a field, and focus leaves the row behind it.
+onMounted(async () => {
+  await nextTick();
+  dialogEl.value?.focus();
+});
+</script>

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -1,258 +1,45 @@
 <template>
-  <!-- Edit / Create panel (in-place, detail-style grid layout). Shown
-       when an edit draft is active; otherwise the read-only detail. This
-       is the panel body only — the host (table row or calendar) supplies
-       the surrounding container. -->
-  <form
-    v-if="editing"
-    class="px-6 py-5 max-h-[60vh] overflow-y-auto"
-    :data-testid="editing.mode === 'create' ? 'collections-create' : 'collections-edit'"
-    @submit.prevent="emit('submit')"
-  >
+  <!-- One record panel for both open (read-only) and edit/create. The
+       layout is IDENTICAL across modes — same header skeleton, same field
+       grid, same per-field cell geometry — and only the inner control of
+       each cell swaps: a formatted value when viewing, an input when
+       editing. The root is a <form> while editing (so the Save button
+       submits) and a <div> when viewing. The host (modal / calendar day
+       view) supplies the surrounding container. -->
+  <component :is="editing ? 'form' : 'div'" class="px-6 py-5 max-h-[60vh] overflow-y-auto" :data-testid="rootTestid" @submit.prevent="emit('submit')">
+    <!-- Header: title block (left) is identical in both modes; only the
+         right-hand button cluster swaps (Cancel/Save ↔ actions/Edit/Delete/
+         Close). Same height + margin so nothing shifts on toggle. -->
     <div class="flex items-center gap-2 mb-4">
       <div class="flex-1 min-w-0">
         <span class="block text-[9px] font-bold text-slate-400 uppercase tracking-wider">{{ collection.title }}</span>
-        <h2 class="text-base font-bold text-slate-800 truncate" data-testid="collections-edit-title">
-          {{ editing.mode === "create" ? t("collectionsView.createTitle") : (editing.originalId ?? "") }}
+        <h2 class="text-base font-bold text-slate-800 truncate" :data-testid="editing ? 'collections-edit-title' : 'collections-detail-title'">
+          {{ headerTitle }}
         </h2>
       </div>
-      <button
-        type="button"
-        class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"
-        data-testid="collections-editor-cancel"
-        @click="emit('cancel')"
-      >
-        {{ t("common.cancel") }}
-      </button>
-      <button
-        type="submit"
-        class="h-8 px-2.5 rounded bg-indigo-600 text-white font-bold text-xs hover:bg-indigo-700 disabled:opacity-50 transition-all shadow-sm shadow-indigo-600/10"
-        :disabled="saving"
-        data-testid="collections-editor-save"
-      >
-        {{ saving ? t("common.saving") : t("common.save") }}
-      </button>
-    </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
-      <template v-for="(field, key) in collection.schema.fields" :key="key">
-        <!-- `toggle` is a projection of an enum field — that enum has its own
-             input here, so the toggle isn't a separate editable control. -->
-        <div
-          v-if="field.type !== 'toggle' && fieldVisible(field, liveRecord ?? {}) && (!field.primary || editing.mode === 'create')"
-          class="flex flex-col gap-1.5"
-          :class="['table', 'markdown', 'embed'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
+      <!-- Edit/create actions -->
+      <template v-if="editing">
+        <button
+          type="button"
+          class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"
+          data-testid="collections-editor-cancel"
+          @click="emit('cancel')"
         >
-          <label class="text-[10px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1" :for="`collections-field-${key}`">
-            {{ field.label }}
-            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
-            <span v-if="field.required" class="text-rose-500 font-bold">*</span>
-          </label>
-
-          <!-- Boolean checkbox -->
-          <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2.5 text-sm text-slate-700 cursor-pointer select-none">
-            <input
-              :id="`collections-field-${key}`"
-              v-model="editing.bool[key]"
-              type="checkbox"
-              class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
-              :data-testid="`collections-input-${key}`"
-              @change="markBoolTouched(String(key))"
-            />
-            <span class="text-xs font-semibold" :class="editing.bool[key] ? 'text-indigo-600' : 'text-slate-500'">
-              {{ editing.bool[key] ? t("common.yes") : t("common.no") }}
-            </span>
-          </label>
-
-          <!-- Embed card (read-only) -->
-          <CollectionEmbedView v-else-if="field.type === 'embed' && embedViews[key]" :view="embedViews[key]" :field-key="String(key)" />
-
-          <!-- Ref selector -->
-          <select
-            v-else-if="field.type === 'ref' && field.to && render.refOptions(field.to).length > 0"
-            :id="`collections-field-${key}`"
-            v-model="editing.text[key]"
-            :required="isFieldRequiredInUi(field)"
-            class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
-            :data-testid="`collections-input-${key}`"
-          >
-            <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-            <option v-for="opt in render.refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
-          </select>
-
-          <!-- Enum selector -->
-          <select
-            v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
-            :id="`collections-field-${key}`"
-            v-model="editing.text[key]"
-            :required="isFieldRequiredInUi(field)"
-            class="w-full rounded-xl border px-3 py-2 text-xs focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium"
-            :class="enumControlClass(String(key), editing.text[key])"
-            :data-testid="`collections-input-${key}`"
-          >
-            <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-            <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
-          </select>
-
-          <!-- Nested Table editor -->
-          <div
-            v-else-if="field.type === 'table' && field.of"
-            class="border border-slate-200 bg-slate-50/30 rounded-xl p-4 space-y-3"
-            :data-testid="`collections-table-${key}`"
-          >
-            <div v-if="editing.table[key] && editing.table[key].length > 0" class="overflow-hidden border border-slate-200 rounded-lg shadow-sm">
-              <table class="w-full text-xs text-slate-600 bg-white">
-                <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
-                  <tr>
-                    <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-3 py-2 font-bold">{{ subField.label }}</th>
-                    <th class="w-9"></th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-slate-100">
-                  <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx" class="hover:bg-slate-50/50">
-                    <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1.5 align-middle">
-                      <input
-                        v-if="subField.type === 'boolean'"
-                        v-model="row.bool[subKey]"
-                        type="checkbox"
-                        class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
-                        @change="markRowBoolTouched(row, String(subKey))"
-                      />
-                      <select
-                        v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
-                        v-model="row.text[subKey]"
-                        :required="subField.required"
-                        class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
-                      >
-                        <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                        <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
-                      </select>
-                      <select
-                        v-else-if="subField.type === 'ref' && subField.to && render.refOptions(subField.to).length > 0"
-                        v-model="row.text[subKey]"
-                        :required="subField.required"
-                        class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
-                      >
-                        <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                        <option v-for="opt in render.refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
-                      </select>
-                      <div v-else-if="subField.type === 'money'" class="relative flex items-center">
-                        <span class="absolute left-1.5 text-[10px] text-slate-400 font-bold pr-1 border-r border-slate-200">{{
-                          render.currencySymbol(render.resolveCurrency(subField, liveRecord))
-                        }}</span>
-                        <input
-                          v-model="row.text[subKey]"
-                          type="number"
-                          step="0.01"
-                          :required="subField.required"
-                          class="w-full rounded-lg border border-slate-200 pl-6 pr-1.5 py-1 text-xs focus:border-indigo-500 focus:outline-none font-semibold text-slate-800"
-                        />
-                      </div>
-                      <input
-                        v-else
-                        v-model="row.text[subKey]"
-                        :type="render.inputTypeFor(subField.type)"
-                        :required="subField.required"
-                        class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
-                      />
-                    </td>
-                    <td class="text-center px-1">
-                      <button
-                        type="button"
-                        class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
-                        :aria-label="t('collectionsView.removeRow')"
-                        :data-testid="`collections-table-${key}-remove-${rowIdx}`"
-                        @click="removeTableRow(String(key), rowIdx)"
-                      >
-                        <span class="material-icons text-base">close</span>
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <p v-else class="text-xs text-slate-400 italic">{{ t("collectionsView.noRows") }}</p>
-            <button
-              type="button"
-              class="inline-flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
-              :data-testid="`collections-table-${key}-add`"
-              @click="addTableRow(String(key), field.of)"
-            >
-              <span class="material-icons text-xs">add</span>
-              <span>{{ t("collectionsView.addRow") }}</span>
-            </button>
-          </div>
-
-          <!-- Derived formula field -->
-          <div v-else-if="field.type === 'derived'" class="relative flex items-center">
-            <span class="absolute left-3 text-indigo-500 font-bold text-[9px] uppercase select-none tracking-wider">{{
-              t("collectionsView.derivedLabel")
-            }}</span>
-            <input
-              :id="`collections-field-${key}`"
-              :value="render.derivedDisplay(field, liveDerived?.[key] ?? null, liveRecord)"
-              type="text"
-              disabled
-              class="w-full rounded-xl border border-indigo-100 bg-indigo-50/15 pl-16 pr-3 py-2 text-xs font-bold text-indigo-700 select-none cursor-not-allowed"
-              :data-testid="`collections-input-${key}`"
-            />
-          </div>
-
-          <!-- Money input field -->
-          <div v-else-if="field.type === 'money'" class="relative flex items-center">
-            <div class="absolute left-3 text-slate-400 font-bold text-xs select-none pr-1.5 border-r border-slate-200">
-              {{ render.currencySymbol(render.resolveCurrency(field, liveRecord)) }}
-            </div>
-            <input
-              :id="`collections-field-${key}`"
-              v-model="editing.text[key]"
-              type="number"
-              step="0.01"
-              :required="isFieldRequiredInUi(field)"
-              class="w-full rounded-xl border border-slate-200 pl-11 pr-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-semibold text-slate-800 transition-all"
-              :data-testid="`collections-input-${key}`"
-            />
-          </div>
-
-          <!-- Scalar inputs -->
-          <input
-            v-else-if="['string', 'email', 'number', 'date', 'datetime', 'ref', 'image'].includes(field.type)"
-            :id="`collections-field-${key}`"
-            v-model="editing.text[key]"
-            :type="render.inputTypeFor(field.type)"
-            :required="isFieldRequiredInUi(field)"
-            :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
-            class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
-            :data-testid="`collections-input-${key}`"
-          />
-
-          <!-- Markdown or long text -->
-          <textarea
-            v-else
-            :id="`collections-field-${key}`"
-            v-model="editing.text[key]"
-            :rows="field.type === 'markdown' ? 5 : 3"
-            :required="isFieldRequiredInUi(field)"
-            class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-medium text-slate-700 transition-all"
-            :data-testid="`collections-input-${key}`"
-          />
-        </div>
+          {{ t("common.cancel") }}
+        </button>
+        <button
+          type="submit"
+          class="h-8 px-2.5 rounded bg-indigo-600 text-white font-bold text-xs hover:bg-indigo-700 disabled:opacity-50 transition-all shadow-sm shadow-indigo-600/10"
+          :disabled="saving"
+          data-testid="collections-editor-save"
+        >
+          {{ saving ? t("common.saving") : t("common.save") }}
+        </button>
       </template>
-      <p v-if="saveError" class="col-span-full text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl">
-        {{ saveError }}
-      </p>
-    </div>
-  </form>
 
-  <!-- Read-only detail panel -->
-  <div v-else-if="viewing" data-testid="collections-detail" class="px-6 py-5 max-h-[60vh] overflow-y-auto">
-    <div class="flex items-center gap-2 mb-4">
-      <div class="flex-1 min-w-0">
-        <span class="block text-[9px] font-bold text-slate-400 uppercase tracking-wider">{{ collection.title }}</span>
-        <h2 class="text-base font-bold text-slate-800 truncate" data-testid="collections-detail-title">{{ viewTitle }}</h2>
-      </div>
-      <div class="flex items-center gap-2">
-        <!-- Dynamic Actions -->
+      <!-- Read-only actions -->
+      <div v-else class="flex items-center gap-2">
         <button
           v-for="action in visibleActions"
           :key="action.id"
@@ -299,27 +86,204 @@
     </div>
 
     <p
-      v-if="actionError"
+      v-if="!editing && actionError"
       class="mb-3 text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl shadow-sm"
       data-testid="collections-detail-action-error"
     >
       {{ actionError }}
     </p>
 
+    <!-- Field grid: same columns + per-field cell in both modes. Each cell
+         renders its edit control while editing (and the field is editable),
+         else its read-only display. -->
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 bg-white rounded-2xl border border-slate-200/60 p-6 shadow-sm">
       <template v-for="(field, key) in collection.schema.fields" :key="key">
-        <div
-          v-if="fieldVisible(field, viewing ?? {}) && !field.primary"
-          class="flex flex-col gap-1"
-          :class="['table', 'markdown', 'embed', 'image'].includes(field.type) ? 'col-span-full' : 'col-span-1'"
-        >
-          <div class="text-[10px] font-bold text-slate-400 uppercase tracking-wider select-none">{{ field.label }}</div>
+        <div v-if="cellVisible(field)" class="flex flex-col gap-1.5" :class="colSpanClass(field)">
+          <label class="text-[10px] font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1" :for="`collections-field-${key}`">
+            {{ field.label }}
+            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "*" is a universal required-field glyph; treating it as i18n copy would force eight translations of the same symbol. -->
+            <span v-if="editing && field.required" class="text-rose-500 font-bold">*</span>
+          </label>
 
-          <div class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
+          <!-- ===== EDIT CONTROLS (editable field types only) ===== -->
+          <template v-if="editing && isEditableType(field.type)">
+            <!-- Boolean checkbox -->
+            <label v-if="field.type === 'boolean'" class="inline-flex items-center gap-2.5 text-sm text-slate-700 cursor-pointer select-none">
+              <input
+                :id="`collections-field-${key}`"
+                v-model="editing.bool[key]"
+                type="checkbox"
+                class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                :data-testid="`collections-input-${key}`"
+                @change="markBoolTouched(String(key))"
+              />
+              <span class="text-xs font-semibold" :class="editing.bool[key] ? 'text-indigo-600' : 'text-slate-500'">
+                {{ editing.bool[key] ? t("common.yes") : t("common.no") }}
+              </span>
+            </label>
+
+            <!-- Ref selector -->
+            <select
+              v-else-if="field.type === 'ref' && field.to && render.refOptions(field.to).length > 0"
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :required="isFieldRequiredInUi(field)"
+              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs bg-slate-50 hover:bg-slate-50/50 focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium text-slate-700"
+              :data-testid="`collections-input-${key}`"
+            >
+              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+              <option v-for="opt in render.refOptions(field.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+            </select>
+
+            <!-- Enum selector -->
+            <select
+              v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :required="isFieldRequiredInUi(field)"
+              class="w-full rounded-xl border px-3 py-2 text-xs focus:bg-white focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none transition-all cursor-pointer font-medium"
+              :class="enumControlClass(String(key), editing.text[key])"
+              :data-testid="`collections-input-${key}`"
+            >
+              <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+              <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+            </select>
+
+            <!-- Nested Table editor -->
+            <div
+              v-else-if="field.type === 'table' && field.of"
+              class="border border-slate-200 bg-slate-50/30 rounded-xl p-4 space-y-3"
+              :data-testid="`collections-table-${key}`"
+            >
+              <div v-if="editing.table[key] && editing.table[key].length > 0" class="overflow-hidden border border-slate-200 rounded-lg shadow-sm">
+                <table class="w-full text-xs text-slate-600 bg-white">
+                  <thead class="bg-slate-50 border-b border-slate-200 text-slate-500 font-bold uppercase tracking-wider">
+                    <tr>
+                      <th v-for="(subField, subKey) in field.of" :key="subKey" class="text-left px-3 py-2 font-bold">{{ subField.label }}</th>
+                      <th class="w-9"></th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-slate-100">
+                    <tr v-for="(row, rowIdx) in editing.table[key]" :key="rowIdx" class="hover:bg-slate-50/50">
+                      <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-2 py-1.5 align-middle">
+                        <input
+                          v-if="subField.type === 'boolean'"
+                          v-model="row.bool[subKey]"
+                          type="checkbox"
+                          class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                          @change="markRowBoolTouched(row, String(subKey))"
+                        />
+                        <select
+                          v-else-if="subField.type === 'enum' && Array.isArray(subField.values) && subField.values.length > 0"
+                          v-model="row.text[subKey]"
+                          :required="subField.required"
+                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                        >
+                          <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                          <option v-for="value in subField.values" :key="value" :value="value">{{ value }}</option>
+                        </select>
+                        <select
+                          v-else-if="subField.type === 'ref' && subField.to && render.refOptions(subField.to).length > 0"
+                          v-model="row.text[subKey]"
+                          :required="subField.required"
+                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none cursor-pointer bg-slate-50 font-medium"
+                        >
+                          <option value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+                          <option v-for="opt in render.refOptions(subField.to)" :key="opt.slug" :value="opt.slug">{{ opt.display }}</option>
+                        </select>
+                        <div v-else-if="subField.type === 'money'" class="relative flex items-center">
+                          <span class="absolute left-1.5 text-[10px] text-slate-400 font-bold pr-1 border-r border-slate-200">{{
+                            render.currencySymbol(render.resolveCurrency(subField, liveRecord))
+                          }}</span>
+                          <input
+                            v-model="row.text[subKey]"
+                            type="number"
+                            step="0.01"
+                            :required="subField.required"
+                            class="w-full rounded-lg border border-slate-200 pl-6 pr-1.5 py-1 text-xs focus:border-indigo-500 focus:outline-none font-semibold text-slate-800"
+                          />
+                        </div>
+                        <input
+                          v-else
+                          v-model="row.text[subKey]"
+                          :type="render.inputTypeFor(subField.type)"
+                          :required="subField.required"
+                          class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
+                        />
+                      </td>
+                      <td class="text-center px-1">
+                        <button
+                          type="button"
+                          class="h-7 w-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
+                          :aria-label="t('collectionsView.removeRow')"
+                          :data-testid="`collections-table-${key}-remove-${rowIdx}`"
+                          @click="removeTableRow(String(key), rowIdx)"
+                        >
+                          <span class="material-icons text-base">close</span>
+                        </button>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <p v-else class="text-xs text-slate-400 italic">{{ t("collectionsView.noRows") }}</p>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 text-xs text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
+                :data-testid="`collections-table-${key}-add`"
+                @click="addTableRow(String(key), field.of)"
+              >
+                <span class="material-icons text-xs">add</span>
+                <span>{{ t("collectionsView.addRow") }}</span>
+              </button>
+            </div>
+
+            <!-- Money input field -->
+            <div v-else-if="field.type === 'money'" class="relative flex items-center">
+              <div class="absolute left-3 text-slate-400 font-bold text-xs select-none pr-1.5 border-r border-slate-200">
+                {{ render.currencySymbol(render.resolveCurrency(field, liveRecord)) }}
+              </div>
+              <input
+                :id="`collections-field-${key}`"
+                v-model="editing.text[key]"
+                type="number"
+                step="0.01"
+                :required="isFieldRequiredInUi(field)"
+                class="w-full rounded-xl border border-slate-200 pl-11 pr-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-semibold text-slate-800 transition-all"
+                :data-testid="`collections-input-${key}`"
+              />
+            </div>
+
+            <!-- Scalar inputs -->
+            <input
+              v-else-if="['string', 'email', 'number', 'date', 'datetime', 'ref', 'image'].includes(field.type)"
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :type="render.inputTypeFor(field.type)"
+              :required="isFieldRequiredInUi(field)"
+              :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
+              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
+              :data-testid="`collections-input-${key}`"
+            />
+
+            <!-- Markdown or long text -->
+            <textarea
+              v-else
+              :id="`collections-field-${key}`"
+              v-model="editing.text[key]"
+              :rows="field.type === 'markdown' ? 5 : 3"
+              :required="isFieldRequiredInUi(field)"
+              class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none font-medium text-slate-700 transition-all"
+              :data-testid="`collections-input-${key}`"
+            />
+          </template>
+
+          <!-- ===== READ-ONLY DISPLAY (viewing, or non-editable types) ===== -->
+          <div v-else class="text-xs font-medium text-slate-700 break-words" :data-testid="`collections-detail-value-${key}`">
             <!-- Toggle state (read-only reflection of the projected enum). -->
             <template v-if="field.type === 'toggle'">
               <span
-                v-if="field.field !== undefined && String(viewing[field.field] ?? '') === field.onValue"
+                v-if="field.field !== undefined && String(detailRecord[field.field] ?? '') === field.onValue"
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
               >
                 <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
@@ -336,14 +300,14 @@
             <!-- Boolean state -->
             <template v-else-if="field.type === 'boolean'">
               <span
-                v-if="viewing[key] === true"
+                v-if="detailRecord[key] === true"
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-emerald-50 text-emerald-700 border border-emerald-200/40"
               >
                 <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
                 {{ t("common.yes") }}
               </span>
               <span
-                v-else-if="viewing[key] === false"
+                v-else-if="detailRecord[key] === false"
                 class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-slate-50 text-slate-400 border border-slate-200/20"
               >
                 {{ t("common.no") }}
@@ -354,28 +318,28 @@
 
             <!-- Ref details link -->
             <router-link
-              v-else-if="field.type === 'ref' && field.to && typeof viewing[key] === 'string' && viewing[key]"
-              :to="{ path: `/collections/${field.to}`, query: { selected: String(viewing[key]) } }"
+              v-else-if="field.type === 'ref' && field.to && typeof detailRecord[key] === 'string' && detailRecord[key]"
+              :to="{ path: `/collections/${field.to}`, query: { selected: String(detailRecord[key]) } }"
               class="text-indigo-600 hover:text-indigo-800 font-bold hover:underline"
               :data-testid="`collections-detail-ref-${key}`"
-              >{{ render.refDisplay(field.to, String(viewing[key])) }}</router-link
+              >{{ render.refDisplay(field.to, String(detailRecord[key])) }}</router-link
             >
 
             <!-- Money format -->
             <span v-else-if="field.type === 'money'" class="font-semibold text-slate-900 tabular-nums text-sm">{{
-              render.formatMoney(viewing[key], render.resolveCurrency(field, viewing), locale)
+              render.formatMoney(detailRecord[key], render.resolveCurrency(field, detailRecord), locale)
             }}</span>
 
             <!-- Derived formula badge -->
             <span
               v-else-if="field.type === 'derived'"
               class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-2 py-0.5 rounded border border-indigo-100/50"
-              >{{ render.derivedDisplay(field, render.evaluateDerivedAgainstItem(field, String(key), viewing), viewing) }}</span
+              >{{ render.derivedDisplay(field, render.evaluateDerivedAgainstItem(field, String(key), detailRecord), detailRecord) }}</span
             >
 
             <!-- Sub table -->
             <div
-              v-else-if="field.type === 'table' && field.of && render.hasTableRows(viewing[key])"
+              v-else-if="field.type === 'table' && field.of && render.hasTableRows(detailRecord[key])"
               class="border border-slate-200/80 rounded-xl overflow-hidden shadow-sm mt-1"
             >
               <table class="w-full text-[11px] text-slate-600 bg-white">
@@ -385,7 +349,7 @@
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-slate-100">
-                  <tr v-for="(row, rowIdx) in render.tableRows(viewing[key])" :key="rowIdx" class="hover:bg-slate-50/50">
+                  <tr v-for="(row, rowIdx) in render.tableRows(detailRecord[key])" :key="rowIdx" class="hover:bg-slate-50/50">
                     <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-4 py-2 align-middle font-medium">
                       <template v-if="subField.type === 'boolean'">
                         <span v-if="row[subKey] === true" class="material-icons text-emerald-600 text-base">check_circle</span>
@@ -393,7 +357,7 @@
                         <span v-else class="text-slate-300">—</span>
                       </template>
                       <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
-                        render.formatSubCell(subField, row[subKey], viewing)
+                        render.formatSubCell(subField, row[subKey], detailRecord)
                       }}</span>
                     </td>
                   </tr>
@@ -408,7 +372,7 @@
               v-else-if="field.type === 'markdown'"
               class="bg-slate-50 rounded-xl p-4 border border-slate-200/60 text-slate-600 text-xs whitespace-pre-wrap leading-relaxed max-h-[30vh] overflow-y-auto"
             >
-              {{ render.detailText(viewing[key]) }}
+              {{ render.detailText(detailRecord[key]) }}
             </div>
 
             <!-- Embed view -->
@@ -416,8 +380,8 @@
 
             <!-- Image (workspace-relative path → <img> via auth-exempt /api/files/raw) -->
             <img
-              v-else-if="field.type === 'image' && typeof viewing[key] === 'string' && viewing[key]"
-              :src="resolveImageSrc(String(viewing[key]))"
+              v-else-if="field.type === 'image' && typeof detailRecord[key] === 'string' && detailRecord[key]"
+              :src="resolveImageSrc(String(detailRecord[key]))"
               :alt="field.label"
               class="max-h-64 max-w-full object-contain rounded-lg border border-slate-200 bg-slate-50"
               :data-testid="`collections-detail-image-${key}`"
@@ -425,22 +389,26 @@
 
             <!-- URL string → external link (new tab). -->
             <a
-              v-else-if="render.isExternalUrl(viewing[key])"
-              :href="String(viewing[key])"
+              v-else-if="render.isExternalUrl(detailRecord[key])"
+              :href="String(detailRecord[key])"
               target="_blank"
               rel="noopener noreferrer"
               class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
               :data-testid="`collections-detail-url-${key}`"
-              >{{ String(viewing[key]) }}</a
+              >{{ String(detailRecord[key]) }}</a
             >
 
             <!-- Fallback text styling -->
-            <span v-else class="text-slate-800 font-semibold">{{ render.formatCell(viewing[key], field.type) }}</span>
+            <span v-else class="text-slate-800 font-semibold">{{ render.formatCell(detailRecord[key], field.type) }}</span>
           </div>
         </div>
       </template>
+
+      <p v-if="editing && saveError" class="col-span-full text-xs font-semibold text-red-600 bg-red-50 border border-red-100 p-2.5 rounded-xl">
+        {{ saveError }}
+      </p>
     </div>
-  </div>
+  </component>
 </template>
 
 <script setup lang="ts">
@@ -494,6 +462,48 @@ const { t } = useI18n();
 // `embedViews` is a ComputedRef nested in the `render` object, so it isn't
 // auto-unwrapped in the template — re-expose it as a top-level computed.
 const embedViews = computed(() => props.render.embedViews.value);
+
+/** The record the read-only displays render from: the live draft while
+ *  editing (so non-editable cells like derived/embed preview the in-flight
+ *  values), else the open record. Always an object so `[key]` lookups are
+ *  safe in the template. */
+const detailRecord = computed<CollectionItem>(() => (editing.value ? (props.liveDerived ?? props.liveRecord ?? {}) : (props.viewing ?? {})));
+
+/** Title for the header: the create label, the edited record's id, or the
+ *  open record's title — same h2 slot in every mode. */
+const headerTitle = computed<string>(() => {
+  if (editing.value) return editing.value.mode === "create" ? t("collectionsView.createTitle") : (editing.value.originalId ?? "");
+  return props.viewTitle;
+});
+
+const rootTestid = computed<string>(() => {
+  if (!editing.value) return "collections-detail";
+  return editing.value.mode === "create" ? "collections-create" : "collections-edit";
+});
+
+/** Whether a field gets an editable control in edit mode. Toggle (a
+ *  projection of an enum that has its own input), derived (computed), and
+ *  embed (a foreign record) stay read-only in both modes, so the cell
+ *  geometry never changes on the view↔edit toggle. */
+function isEditableType(type: FieldSpec["type"]): boolean {
+  return type !== "toggle" && type !== "derived" && type !== "embed";
+}
+
+/** Wide field types span the full grid width in BOTH modes — keeping
+ *  `image` full-width here (not just when viewing) is what stops a field
+ *  from jumping columns when editing starts. */
+function colSpanClass(field: FieldSpec): "col-span-full" | "col-span-1" {
+  return ["table", "markdown", "embed", "image"].includes(field.type) ? "col-span-full" : "col-span-1";
+}
+
+/** Whether to render a field's cell. Identical rule in both modes so no
+ *  cell appears or disappears on toggle: respect the `when` predicate
+ *  (against the active record) and hide the primary key except while
+ *  creating. */
+function cellVisible(field: FieldSpec): boolean {
+  if (field.primary && editing.value?.mode !== "create") return false;
+  return fieldVisible(field, detailRecord.value);
+}
 
 /** Mirror of the create-mode primary-key carve-out: drop the HTML5
  *  `required` flag on the primary field while creating so the browser

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1612,9 +1612,14 @@ function onOpenDay(day: Ymd): void {
   openDay.value = day;
 }
 
-/** Close the day popup: drop the open day and the selection together. */
+/** Close the day popup: drop the open day, the selection, AND any in-progress
+ *  draft together. Clearing `editing` matters because the shared record modal
+ *  shows whenever `editing` is set and no day is open — so without this, an
+ *  edit/create started inside the day popup would re-appear in the centred
+ *  modal the instant the popup closed (Codex P2 on #1656). */
 function onDayClose(): void {
   openDay.value = null;
+  if (editing.value) closeEditor();
   closeView();
 }
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -280,37 +280,9 @@
           </template>
         </CollectionDayView>
 
-        <!-- Fallback panel for records with no resolvable day (the "no date"
-             tray): they can't appear on a timeline, so their detail still
-             opens below the grid. -->
-        <div
-          v-if="(viewing || editing) && !openDay"
-          class="mt-4 rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden"
-          data-testid="collections-calendar-panel"
-        >
-          <CollectionRecordPanel
-            v-model:editing="editing"
-            :collection="collection"
-            :viewing="viewing"
-            :saving="saving"
-            :save-error="saveError"
-            :action-error="actionError"
-            :action-pending="actionPending"
-            :visible-actions="visibleActions"
-            :live-record="liveRecord"
-            :live-derived="liveDerived"
-            :view-title="viewTitle"
-            :is-singleton="isSingleton"
-            :render="render"
-            :locale="locale"
-            @submit="saveEditor"
-            @cancel="cancelEditor"
-            @edit="editFromView"
-            @close="closeView"
-            @delete="viewing && confirmDelete(viewing)"
-            @run-action="runAction"
-          />
-        </div>
+        <!-- Undated records (the "no date" tray) have no timeline slot, so
+             they open in the shared record modal (rendered once at the View
+             root) instead of the day view. -->
       </div>
 
       <!-- Kanban body: an alternative to the table for enum-bearing
@@ -346,34 +318,6 @@
             @move="onKanbanMove"
           />
         </div>
-        <div
-          v-if="viewing || editing"
-          class="m-3 mt-0 rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden shrink-0"
-          data-testid="collections-kanban-panel"
-        >
-          <CollectionRecordPanel
-            v-model:editing="editing"
-            :collection="collection"
-            :viewing="viewing"
-            :saving="saving"
-            :save-error="saveError"
-            :action-error="actionError"
-            :action-pending="actionPending"
-            :visible-actions="visibleActions"
-            :live-record="liveRecord"
-            :live-derived="liveDerived"
-            :view-title="viewTitle"
-            :is-singleton="isSingleton"
-            :render="render"
-            :locale="locale"
-            @submit="saveEditor"
-            @cancel="cancelEditor"
-            @edit="editFromView"
-            @close="closeView"
-            @delete="viewing && confirmDelete(viewing)"
-            @run-action="runAction"
-          />
-        </div>
       </div>
 
       <!-- Dashboard body: a read-only snapshot for enum-bearing collections —
@@ -387,30 +331,6 @@
           :selected="viewing ? String(viewing[collection.schema.primaryKey] ?? '') : undefined"
           @select="onCalendarSelect"
         />
-        <div v-if="viewing || editing" class="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden" data-testid="collections-dashboard-panel">
-          <CollectionRecordPanel
-            v-model:editing="editing"
-            :collection="collection"
-            :viewing="viewing"
-            :saving="saving"
-            :save-error="saveError"
-            :action-error="actionError"
-            :action-pending="actionPending"
-            :visible-actions="visibleActions"
-            :live-record="liveRecord"
-            :live-derived="liveDerived"
-            :view-title="viewTitle"
-            :is-singleton="isSingleton"
-            :render="render"
-            :locale="locale"
-            @submit="saveEditor"
-            @cancel="cancelEditor"
-            @edit="editFromView"
-            @close="closeView"
-            @delete="viewing && confirmDelete(viewing)"
-            @run-action="runAction"
-          />
-        </div>
       </div>
 
       <div v-else-if="items.length === 0 && editing?.mode !== 'create'" class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2">
@@ -458,9 +378,8 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-100 bg-white">
-            <template v-for="item in displayItems" :key="String(item[collection.schema.primaryKey] ?? '')">
+            <template v-for="item in filteredItems" :key="String(item[collection.schema.primaryKey] ?? '')">
               <tr
-                v-if="!isCreateRow(item)"
                 class="hover:bg-slate-50/70 cursor-pointer transition-colors focus:outline-none focus:bg-indigo-50/30"
                 :class="isRowOpen(item) || isEditingRow(item) ? 'bg-indigo-50/40' : ''"
                 role="button"
@@ -572,50 +491,40 @@
                   </template>
                 </td>
               </tr>
-
-              <!-- Inline detail / edit panel: expands directly under the open
-                 row (replaces the old fixed modal). One row open at a time.
-                 The create form rides the synthetic top row (isCreateRow). -->
-              <tr v-if="shouldExpand(item)" :data-testid="`collections-expansion-${item[collection.schema.primaryKey]}`">
-                <td :colspan="listColumnFields.length" class="p-0 border-l-2 border-indigo-300 bg-slate-50/60">
-                  <!-- Pin the panel to the View's visible width, not the
-                       (possibly much wider) table width: sticky to the left
-                       edge of the horizontal scroller and capped at the
-                       scroller's content width via container-query units, so
-                       a wide collection never pushes the panel off-screen.
-                       `min(100%, 100cqw)` keeps it at table width when the
-                       table is narrower than the View. -->
-                  <div class="sticky left-0 w-[min(100%,100cqw)]">
-                    <CollectionRecordPanel
-                      v-model:editing="editing"
-                      :collection="collection"
-                      :viewing="viewing"
-                      :saving="saving"
-                      :save-error="saveError"
-                      :action-error="actionError"
-                      :action-pending="actionPending"
-                      :visible-actions="visibleActions"
-                      :live-record="liveRecord"
-                      :live-derived="liveDerived"
-                      :view-title="viewTitle"
-                      :is-singleton="isSingleton"
-                      :render="render"
-                      :locale="locale"
-                      @submit="saveEditor"
-                      @cancel="cancelEditor"
-                      @edit="editFromView"
-                      @close="closeView"
-                      @delete="viewing && confirmDelete(viewing)"
-                      @run-action="runAction"
-                    />
-                  </div>
-                </td>
-              </tr>
             </template>
           </tbody>
         </table>
       </div>
     </div>
+
+    <!-- Shared record modal — the single open/edit surface for every view
+         mode (table / kanban / dashboard) and the calendar's undated tray.
+         Calendar's DATED records keep their day-view modal (which embeds the
+         same panel on its right), so this is suppressed while that's open. -->
+    <CollectionRecordModal v-if="collection && (viewing || editing) && !(calendarActive && openDay)" @close="closeRecordModal">
+      <CollectionRecordPanel
+        v-model:editing="editing"
+        :collection="collection"
+        :viewing="viewing"
+        :saving="saving"
+        :save-error="saveError"
+        :action-error="actionError"
+        :action-pending="actionPending"
+        :visible-actions="visibleActions"
+        :live-record="liveRecord"
+        :live-derived="liveDerived"
+        :view-title="viewTitle"
+        :is-singleton="isSingleton"
+        :render="render"
+        :locale="locale"
+        @submit="saveEditor"
+        @cancel="cancelEditor"
+        @edit="editFromView"
+        @close="closeView"
+        @delete="viewing && confirmDelete(viewing)"
+        @run-action="runAction"
+      />
+    </CollectionRecordModal>
 
     <!-- Chat modal — collect a message and start a new general-role chat
          seeded with the collection's skill command (`/<slug> <message>`). -->
@@ -699,6 +608,7 @@ import { BUILTIN_ROLE_IDS } from "../config/roles";
 import ConfirmModal from "./ConfirmModal.vue";
 import PinToggle from "./PinToggle.vue";
 import CollectionRecordPanel from "./CollectionRecordPanel.vue";
+import CollectionRecordModal from "./CollectionRecordModal.vue";
 import CollectionCalendarView from "./CollectionCalendarView.vue";
 import CollectionDashboardView from "./CollectionDashboardView.vue";
 import CollectionDayView from "./CollectionDayView.vue";
@@ -854,28 +764,17 @@ const filteredItems = computed<CollectionItem[]>(() => {
 });
 
 // ────────────────────────────────────────────────────────────────
-// Inline row expansion (#detail / #edit / #create panels)
+// Open / edit record panel (shared modal + calendar day view)
 // ────────────────────────────────────────────────────────────────
-// Detail + edit render as a panel directly under the open row; create
-// rides a synthetic row pinned at the top of the list. One panel open
-// at a time (`viewing` / `editing` are single refs). The synthetic
-// create row keeps the edit form in a SINGLE template location (no
-// duplication, no separate component, no prop-mutation) — its data row
-// is hidden (`v-if="!isCreateRow"`) so only its expansion (the form)
-// shows.
-
-/** Sentinel primary-key for the synthetic create row. Chosen to never
- *  collide with a real record id. */
-const CREATE_ROW_ID = "__mc_create__";
+// Detail, edit, and create all render `CollectionRecordPanel` inside the
+// shared `CollectionRecordModal` (or the calendar day view for dated
+// records). One panel open at a time (`viewing` / `editing` are single
+// refs). The list table only highlights the open/edited row.
 
 /** Stringified primary-key value for a row (the row's stable identity). */
 function rowId(item: CollectionItem): string {
   const primaryKey = collection.value?.schema.primaryKey;
   return primaryKey ? String(item[primaryKey] ?? "") : "";
-}
-
-function isCreateRow(item: CollectionItem): boolean {
-  return rowId(item) === CREATE_ROW_ID;
 }
 
 /** Stable key for one cell in the `enumOriginallyEmpty` snapshot. */
@@ -916,33 +815,17 @@ function enumControlClass(fieldKey: string, value: unknown): string {
   return `${cls.badge} ${cls.border}`;
 }
 
-/** Rows rendered by the table: the filtered records, plus a synthetic
- *  create row at the top while a create is in progress. */
-const displayItems = computed<CollectionItem[]>(() => {
-  if (editing.value?.mode === "create" && collection.value) {
-    const sentinel = { [collection.value.schema.primaryKey]: CREATE_ROW_ID } as CollectionItem;
-    return [sentinel, ...filteredItems.value];
-  }
-  return filteredItems.value;
-});
-
 /** This row is the one open in read-only detail. */
 function isRowOpen(item: CollectionItem): boolean {
   return viewing.value !== null && rowId(viewing.value) === rowId(item);
 }
 
-/** This row is the one being edited (a real row in edit mode, or the
- *  synthetic create row in create mode). */
+/** This row is the one being edited (highlights it in the list while the
+ *  edit modal is open). Create mode has no backing row, so nothing matches. */
 function isEditingRow(item: CollectionItem): boolean {
   const draft = editing.value;
-  if (!draft) return false;
-  if (draft.mode === "create") return isCreateRow(item);
+  if (!draft || draft.mode === "create") return false;
   return draft.originalId === rowId(item);
-}
-
-/** Whether to render this row's expansion panel (detail or edit). */
-function shouldExpand(item: CollectionItem): boolean {
-  return isRowOpen(item) || isEditingRow(item);
 }
 
 function detailUrl(slug: string): string {
@@ -1378,18 +1261,6 @@ function cancelEditor(): void {
   }
 }
 
-/** Scroll the open expansion panel into view after it opens (e.g. a newly
- *  created record that landed off-screen). Only one panel is open at a
- *  time, so a fixed prefix selector finds it — no record id is
- *  interpolated into the selector (avoids CSS injection / `SyntaxError`
- *  from ids containing selector-special chars). Best-effort. */
-function scrollOpenPanelIntoView(): void {
-  void nextTick(() => {
-    const row = document.querySelector('[data-testid^="collections-expansion-"]');
-    if (row) row.scrollIntoView({ behavior: "smooth", block: "nearest" });
-  });
-}
-
 /** Open mode (read-only detail). Toggles: clicking the already-open row
  *  collapses it. Opening a row cancels any in-progress edit (one panel
  *  open at a time). In embedded mode, report the open id so the host
@@ -1433,6 +1304,18 @@ function closeView(): void {
   }
 }
 
+/** Backdrop click / Escape on the shared record modal. While editing this
+ *  cancels the draft (reopening the detail, matching the in-panel Cancel
+ *  button — so a stray click never silently discards edits); while viewing
+ *  it closes the detail. */
+function closeRecordModal(): void {
+  if (editing.value) {
+    cancelEditor();
+    return;
+  }
+  closeView();
+}
+
 /** Hand off from open mode to the editor for the same record. */
 function editFromView(): void {
   const item = viewing.value;
@@ -1462,10 +1345,9 @@ function syncViewToSelected(): void {
   }
   const match = findItemById(selected) ?? null;
   viewing.value = match;
-  // A deep link / notification can target a row that loaded off-screen
-  // (long collection). Bring the now-open record into view — the save
-  // path already does this; the `?selected=` path must too.
-  if (match) scrollOpenPanelIntoView();
+  // A deep link / notification opens the record in the shared modal, which
+  // is centred regardless of where the row sits in a long list — no scroll
+  // needed (the inline-expansion era required one).
 }
 
 /** Title for the open-mode header: the record's primary-key value
@@ -1534,12 +1416,9 @@ async function saveEditor(): Promise<void> {
   closeEditor();
   await loadCollection(slug);
   // Return to the saved record's read-only detail (for create, this is the
-  // newly added row), scrolling it into view if it's off-screen.
+  // newly added row) in the shared modal.
   const saved = findItemById(savedId);
-  if (saved) {
-    showDetail(saved);
-    scrollOpenPanelIntoView();
-  }
+  if (saved) showDetail(saved);
 }
 
 /** Write a single cell's value directly onto the live `items` entry.


### PR DESCRIPTION
## What

Two changes to the collection item **open/edit** experience, requested together:

### 1. Modal popup in every view mode
Opening or editing a record now uses **one shared, viewport-centred modal** (`CollectionRecordModal`) across **table / kanban / dashboard** and the calendar's **undated** tray — replacing the old per-mode surfaces:

| Before | After |
|---|---|
| Table: inline `<tr>` expansion under the row (+ synthetic create row) | Shared modal |
| Kanban / Dashboard: panel docked below | Shared modal |
| Calendar (undated): panel below the grid | Shared modal |
| Calendar (dated): day-view modal — timeline left, panel right | **Unchanged** |

The calendar's **day view stays calendar-only** (the day timeline on the left is not shown in other modes, by design). The modal is teleported to `<body>` so an embedded card's transformed ancestor can't trap the fixed overlay.

Removes the now-dead table machinery: the synthetic create row (`CREATE_ROW_ID` / `displayItems` / `isCreateRow` / `shouldExpand`) and `scrollOpenPanelIntoView` (the modal is always on screen, so deep links need no scroll-into-view).

### 2. Identical layout, view vs edit
`CollectionRecordPanel`'s two separate read/edit template blocks are merged into **one**: same header skeleton, same field grid, same per-field cell geometry. Only each cell's **inner control** swaps — a formatted value when viewing, an input when editing. Reconciled the three drifts that used to shift the layout on toggle:
- **Image** fields are full-width in both modes (no column jump)
- **Toggle** fields render the read-only badge in both (edited via their enum field)
- **Header** keeps the same height; only the right-hand button cluster swaps (`Edit/Delete/Close` ↔ `Cancel/Save`)

## Testing
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — all clean
- `yarn test` — 45 + 26 unit tests pass
- `yarn test:e2e` — collection specs (calendar, deep-link, image, url, inline-edit, chat-button, present-collection) all pass; specs updated to the `collections-record-modal` testid and the embedded card's open-on-mount behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Records now open in a shared, centered modal across table, kanban, dashboard and calendar views; modal traps focus and supports Escape/backdrop to dismiss.

* **Improvements**
  * Deep links open records in the centered modal (no scroll-into-view).
  * After save, records reopen read-only in the modal.

* **Bug Fixes**
  * Day-popup edits/creates no longer reopen as drafts in the shared modal when the popup is closed.
  * Undated record selection opens the shared modal as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->