### PR TITLE
fix(marp): close 9+ whitespace bypass in theme sanitizer

### DIFF
--- a/src/utils/markdown/marpTheme.ts
+++ b/src/utils/markdown/marpTheme.ts
@@ -85,17 +85,24 @@ export interface SanitizeResult {
 // it, but the PDF route runs in puppeteer without that CSP, so
 // `@import url(//attacker/...)` would happily fetch (CodeRabbit +
 // Codex review on #1653).
-// Bounded whitespace (`\s{0,8}`) instead of `\s*` so the regex
-// engine can't enter pathological backtracking on adversarial input
-// (sonarjs/slow-regex). Two separate patterns instead of one
-// alternation so each is a straight-line match.
-const EXTERNAL_URL_FN_RE = /url\s{0,8}\(\s{0,8}["']?\s{0,8}(?:https?:|\/\/)/i;
-const EXTERNAL_IMPORT_STR_RE = /@import\s{1,8}["']\s{0,8}(?:https?:|\/\/)/i;
+// Strip every run of whitespace before matching so adversarial
+// padding (`url  (   "  http...`) can't pad the gap to evade
+// detection. Marp doesn't care about whitespace inside `url()` /
+// `@import` either, so a theme that hides intent under 1 000 spaces
+// renders the same as one without — we'd lose nothing by ignoring
+// the spaces. The patterns below run against the stripped string,
+// so they contain no `\s` quantifiers and can't backtrack on any
+// input (linear time, ReDoS-safe). Codex flagged the previous
+// bounded-`\s{0,8}` form as bypassable with 9+ spaces on PR #1653.
+const STRIPPED_URL_EXTERNAL_RE = /url\(["']?(?:https?:|\/\/)/i;
+const STRIPPED_IMPORT_EXTERNAL_RE = /@import["'](?:https?:|\/\/)/i;
+const WHITESPACE_RE = /\s+/g;
 
 /** Reject CSS that would pull external resources at render time.
  *  Allows `data:` URIs (inline fonts) and same-origin / relative refs. */
 export function sanitizeMarpThemeCss(css: string): SanitizeResult {
-  if (EXTERNAL_URL_FN_RE.test(css) || EXTERNAL_IMPORT_STR_RE.test(css)) {
+  const compact = css.replace(WHITESPACE_RE, "");
+  if (STRIPPED_URL_EXTERNAL_RE.test(compact) || STRIPPED_IMPORT_EXTERNAL_RE.test(compact)) {
     return { ok: false, reason: "external url() / @import is not allowed" };
   }
   return { ok: true };

--- a/test/utils/markdown/test_marpTheme.ts
+++ b/test/utils/markdown/test_marpTheme.ts
@@ -91,6 +91,18 @@ describe("sanitizeMarpThemeCss", () => {
     assert.equal(sanitizeMarpThemeCss(`section { background-image: url("//ev.example/track.png"); }`).ok, false);
   });
 
+  it("rejects external refs padded with 9+ whitespace chars (bounded-regex bypass guard)", () => {
+    // The first cut bounded `\s{0,8}` so 9 spaces would slip past.
+    // Now the sanitizer strips all whitespace before matching.
+    const tenSpaces = " ".repeat(10);
+    const fiftyTabs = "\t".repeat(50);
+    const manyNewlines = "\n".repeat(100);
+    assert.equal(sanitizeMarpThemeCss(`url${tenSpaces}("http://attacker.example/x.css")`).ok, false);
+    assert.equal(sanitizeMarpThemeCss(`url(${fiftyTabs}//attacker.example/x.css)`).ok, false);
+    assert.equal(sanitizeMarpThemeCss(`@import${manyNewlines}"http://attacker.example/x.css";`).ok, false);
+    assert.equal(sanitizeMarpThemeCss(`@import url${tenSpaces}(${manyNewlines}//attacker.example/x.css)`).ok, false);
+  });
+
   it("does not confuse `//` inside a CSS comment for a protocol", () => {
     // `// ...` is not CSS comment syntax (block comments use `/* */`),
     // but the test guards against an over-eager match. A real


### PR DESCRIPTION
## Summary

- #1653 で導入した bounded `\s{0,8}` 形式の sanitizer は、**9 個以上の whitespace で padding** された adversarial CSS で bypass される (Codex 指摘済)
- strip-then-match 方式に変更: 全 whitespace を圧縮してから単純な文字列パターンで検出
- post-strip パターンは `\s` 量化子を含まないので backtracking が起きない (linear time / ReDoS 安全) かつ padding 長によらず確実に reject
- Follow-up to merged #1653

## Items to Confirm / Review

- 真に塞ぐべきは「PDF 経路 (puppeteer, CSP なし) で外部 URL を fetch される」ケース。preview iframe は CSP で network egress 全 deny なので二重防御として残っている — そちらの fallback が効かない PDF を sanitizer で守る
- strip 後のマッチで `data:` URI と相対パスは引き続き accept される (`url(data:...)` / `url(./bg.png)` / `url("../assets/x.svg")` の regression guard あり)
- 既存 unit テスト (`test/utils/markdown/test_marpTheme.ts`) に boundary test 1 件追加 (10 spaces / 50 tabs / 100 newlines を含む 4 ケース)
- 全 23 tests pass

## User Prompt

> comments

(Codex review on #1653:)
> CODEX VERDICT: CHANGES REQUESTED
> - `sanitizeMarpThemeCss` can be bypassed with valid CSS that uses 9+ spaces/newlines around `url(...)` / `@import` tokens because the regex uses bounded whitespace (`\s{0,8}` / `\s{1,8}`). That allows external fetches to slip into the PDF renderer (no iframe CSP), reintroducing SSRF/tracking risk. Please remove the whitespace caps (or switch to tokenized parsing) and add boundary tests for 9+ spaces/newlines to lock this down.

→ 「strip-then-match で進める」とユーザ合意の上、本 PR で follow-up 対応。

## Implementation

`src/utils/markdown/marpTheme.ts`:

```ts
const STRIPPED_URL_EXTERNAL_RE = /url\(["']?(?:https?:|\/\/)/i;
const STRIPPED_IMPORT_EXTERNAL_RE = /@import["'](?:https?:|\/\/)/i;
const WHITESPACE_RE = /\s+/g;

export function sanitizeMarpThemeCss(css: string): SanitizeResult {
  const compact = css.replace(WHITESPACE_RE, "");
  if (STRIPPED_URL_EXTERNAL_RE.test(compact) || STRIPPED_IMPORT_EXTERNAL_RE.test(compact)) {
    return { ok: false, reason: "external url() / @import is not allowed" };
  }
  return { ok: true };
}
```

- `compact` 化することで `url    (   "  http://...` のような padding が `url("http://...` に潰れる
- 2 つの post-strip pattern は `\s` を含まず、alternation も先頭固定なので backtracking フリー
- Marp は `url() / @import` 内の whitespace を ignore するので、空白を潰しても CSS のセマンティクスは温存される (= サニタイザの判定が render との挙動と一致する)

`test/utils/markdown/test_marpTheme.ts`: boundary test 1 件追加
- `url${" ".repeat(10)}("http://attacker...")` — 10 spaces
- `url(${"\t".repeat(50)}//attacker...)` — 50 tabs
- `@import${"\n".repeat(100)}"http://..."` — 100 newlines
- 組み合わせケース

## Test Plan

- [ ] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass (ローカル: ✅)
- [ ] 9+ 任意の whitespace を含む adversarial CSS が reject される
- [ ] `data:` URI と相対パスは引き続き accept される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSS theme sanitization to more robustly block external resources and style imports, preventing bypass attempts that use whitespace padding and obfuscation techniques to evade security checks.

* **Tests**
  * Added comprehensive test coverage for CSS sanitization with various whitespace patterns and edge cases to ensure protection mechanisms remain effective against obfuscation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->