### PR TITLE
feat(marp): side-by-side live editor + preview

### DIFF
--- a/plans/feat-marp-split-preview.md
+++ b/plans/feat-marp-split-preview.md
@@ -1,0 +1,76 @@
+# feat(marp): side-by-side ライブプレビュー
+
+Issue: receptron/mulmoclaude#1647
+
+## 背景
+
+#1646 で chat plugin View の Marp 分岐に source editor (textarea) を露出した。これは「編集 → Apply → preview 更新」の離散ステップで、編集中はプレビューが古いまま。
+
+`MarpView` は `props.markdown` を watch して即時再描画する作りなので、未保存バッファをそのまま `MarpView` に流せばライブプレビューが成立する。今回その配線を追加する。
+
+## 設計 (ユーザ合意済)
+
+- **トグル UI**: MarpView 上部のツールバー (PDF ボタンの隣) に split / preview-only トグルを 1 つ追加
+- **layout**: 左 = editor, 右 = preview (横並び)
+- **size**: 50/50 固定 (リサイザーは別 PR)
+- **debounce**: なし (即時更新)
+- **デフォルト state**: preview-only (現状互換)
+- **状態の永続化**: なし (タブ切替・リロードでリセット)
+
+## 流用するもの (変更不要)
+
+- `editableMarkdown` ref / `hasChanges` computed / `applyMarkdown` / `cancelEdit` / `onDetailsToggle`
+- `MarpView` の reactive 再描画
+
+## 触るファイル
+
+- `src/plugins/markdown/View.vue` — split state + template 分岐 + toggle ボタン配線
+- `src/plugins/markdown/MarpView.vue` — トグルボタンを slot or prop で受ける (toolbar に追加)
+- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — トグルラベル i18n キー追加
+
+## 重要な実装判断
+
+### トグル UI を MarpView 内に置くか View.vue 側に置くか
+
+MarpView 内のツールバーには PDF ボタン / slide count が既にある。一貫性のため split toggle もそこに置く。
+
+ただし split state を MarpView が持つと「preview だけ MarpView 内 → 編集すると View.vue 側の textarea が要る」のように責務が両方にまたがる。
+
+解決: state は View.vue 側で持ち、MarpView には `onToggleSplit` emit + `splitMode` prop を渡してボタンを描画させる。MarpView の責務は「preview を出す + toolbar に既存ボタン + slot で外部ボタン」というシンプルな形にする。
+
+### split mode 時の textarea 表示
+
+split mode に入ると、左に textarea / 右に MarpView を flex で並置する。
+
+- textarea には `editableMarkdown` を bind (現状の `<details>` 内のものと同じ ref)
+- preview には `editableMarkdown` を流す → 未保存バッファでライブ更新
+- Apply / Cancel button を textarea 上部に出す
+- 既存の bottom `<details>` panel は split mode 時には隠す (重複 UI 防止)
+
+### 編集中バッファをそのまま preview に流すか?
+
+split mode 中: preview は `editableMarkdown` (未保存)。preview-only mode 中: preview は `markdownContent` (保存済)。
+
+→ MarpView に流す markdown は computed で切り替え。
+
+### `useFileChange` でリモート書き込みを受けた時の挙動
+
+split mode 中にリモート書き込みが来たら、現状の `<details>` 同様、編集破棄してリロード。`fileVersion` watcher で `splitMode = false` にする (panel 閉じる相当)。
+
+## 受け入れ基準
+
+- [ ] Marp ファイル (`marp: true`) を開くと MarpView ツールバーに split toggle ボタンが出る
+- [ ] split mode に入ると左 textarea / 右 MarpView の 50/50 並置
+- [ ] textarea で打鍵すると preview が即時更新 (未保存)
+- [ ] Apply で disk 保存 / Cancel で破棄 / どちらでも mode はそのまま (継続編集できる)
+- [ ] preview-only mode に戻すと元の単一 preview レイアウト
+- [ ] リモート書き込みが来たら mode 自動解除 + リロード
+- [ ] 非 Marp Markdown 分岐に regression なし
+- [ ] 8 locale で i18n 追加
+- [ ] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass
+
+## 非ゴール (別 issue)
+
+- リサイザー / pane width の永続化
+- textarea を CodeMirror / Monaco に置換
+- WYSIWYG

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1110,6 +1110,9 @@ const deMessages = {
     marpSlidesMode: "Marp-Folien · {count}",
     marpExportPdf: "Als PDF exportieren",
     marpRenderFailed: "⚠ Rendern der Marp-Folien fehlgeschlagen: {error}",
+    marpSplitEnter: "Quelle neben der Vorschau bearbeiten",
+    marpSplitExit: "Quelleneditor schließen",
+    marpSplitEditorLabel: "Quelle",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1094,6 +1094,9 @@ const enMessages = {
     marpSlidesMode: "Marp slides · {count}",
     marpExportPdf: "Export PDF",
     marpRenderFailed: "⚠ Failed to render Marp slides: {error}",
+    marpSplitEnter: "Edit source side-by-side with preview",
+    marpSplitExit: "Hide source editor",
+    marpSplitEditorLabel: "Source",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1107,6 +1107,9 @@ const esMessages = {
     marpSlidesMode: "Diapositivas Marp · {count}",
     marpExportPdf: "Exportar PDF",
     marpRenderFailed: "⚠ Error al renderizar las diapositivas Marp: {error}",
+    marpSplitEnter: "Editar la fuente junto a la vista previa",
+    marpSplitExit: "Cerrar el editor de la fuente",
+    marpSplitEditorLabel: "Fuente",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1099,6 +1099,9 @@ const frMessages = {
     marpSlidesMode: "Diapositives Marp · {count}",
     marpExportPdf: "Exporter en PDF",
     marpRenderFailed: "⚠ Échec du rendu des diapositives Marp : {error}",
+    marpSplitEnter: "Modifier la source en parallèle de l'aperçu",
+    marpSplitExit: "Fermer l'éditeur de source",
+    marpSplitEditorLabel: "Source",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1093,6 +1093,9 @@ const jaMessages = {
     marpSlidesMode: "Marp スライド · {count}",
     marpExportPdf: "PDFを書き出し",
     marpRenderFailed: "⚠ Marp スライドの描画に失敗しました: {error}",
+    marpSplitEnter: "ソースを並べて編集",
+    marpSplitExit: "ソースエディタを閉じる",
+    marpSplitEditorLabel: "ソース",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1095,6 +1095,9 @@ const koMessages = {
     marpSlidesMode: "Marp 슬라이드 · {count}",
     marpExportPdf: "PDF로 내보내기",
     marpRenderFailed: "⚠ Marp 슬라이드 렌더링 실패: {error}",
+    marpSplitEnter: "소스를 나란히 편집",
+    marpSplitExit: "소스 편집기 닫기",
+    marpSplitEditorLabel: "소스",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1096,6 +1096,9 @@ const ptBRMessages = {
     marpSlidesMode: "Slides Marp · {count}",
     marpExportPdf: "Exportar PDF",
     marpRenderFailed: "⚠ Falha ao renderizar os slides Marp: {error}",
+    marpSplitEnter: "Editar o código fonte ao lado da visualização",
+    marpSplitExit: "Fechar o editor de código",
+    marpSplitEditorLabel: "Código",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1084,6 +1084,9 @@ const zhMessages = {
     marpSlidesMode: "Marp 幻灯片 · {count}",
     marpExportPdf: "导出 PDF",
     marpRenderFailed: "⚠ Marp 幻灯片渲染失败: {error}",
+    marpSplitEnter: "并排编辑源代码",
+    marpSplitExit: "关闭源代码编辑器",
+    marpSplitEditorLabel: "源代码",
   },
   pluginTextResponse: {
     pdf: "PDF",

--- a/src/plugins/markdown/MarpView.vue
+++ b/src/plugins/markdown/MarpView.vue
@@ -2,6 +2,10 @@
   <div ref="containerEl" class="marp-container">
     <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
       <span class="text-xs text-gray-500 mr-auto pl-2">{{ t("pluginMarkdown.marpSlidesMode", { count: slideCount }) }}</span>
+      <!-- Toolbar slot: View.vue mounts the split-mode toggle here so
+           the chrome stays unified with PDF / slide-count. Slot is a
+           no-op for non-toggle consumers (FileContentRenderer). -->
+      <slot name="toolbar" />
       <button
         class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
         :disabled="pdfDownloading"

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -13,28 +13,69 @@
       <div v-if="loadError" class="load-error-banner shrink-0" role="alert">
         {{ t("pluginMarkdown.refreshFailed", { error: loadError }) }}
       </div>
-      <div class="flex-1 min-h-0 overflow-y-auto flex flex-col">
-        <!-- `m-auto` centres a short MarpView vertically in the canvas
-             (free space distributed top + bottom). When the deck is
-             tall enough to overflow, margin:auto stops contributing
-             and the outer wrapper scrolls naturally. -->
-        <div class="m-auto w-full">
-          <MarpView :markdown="markdownContent" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
-        </div>
-      </div>
-      <div class="bottom-bar-wrapper">
-        <details ref="sourceDetails" class="markdown-source" @toggle="onDetailsToggle">
-          <summary>{{ t("pluginMarkdown.editSource") }}</summary>
-          <textarea v-model="editableMarkdown" class="markdown-editor" spellcheck="false"></textarea>
-          <div class="editor-actions">
+      <!-- Split mode: live editor on the left, MarpView on the right
+           driven by the unsaved buffer. Toggle lives in the MarpView
+           toolbar via slot. Apply/Cancel sit above the textarea so
+           the action surface is co-located with the input. -->
+      <div v-if="marpSplitMode" class="flex-1 min-h-0 flex">
+        <div class="flex flex-col" style="flex: 1 1 50%; min-width: 0; border-right: 1px solid #e0e0e0">
+          <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+            <span class="text-xs text-gray-500 mr-auto">{{ t("pluginMarkdown.marpSplitEditorLabel") }}</span>
             <button class="apply-btn" :disabled="!hasChanges || saving" @click="applyMarkdown">
               {{ saving ? t("pluginMarkdown.saving") : t("pluginMarkdown.applyChanges") }}
             </button>
-            <button class="cancel-btn" @click="cancelEdit">{{ t("pluginMarkdown.cancel") }}</button>
+            <button class="cancel-btn" @click="cancelMarpSplitEdit">{{ t("pluginMarkdown.cancel") }}</button>
           </div>
-          <p v-if="saveError" class="save-error" role="alert">{{ t("pluginMarkdown.saveError", { error: saveError }) }}</p>
-        </details>
+          <p v-if="saveError" class="save-error mx-2 mt-1" role="alert">{{ t("pluginMarkdown.saveError", { error: saveError }) }}</p>
+          <textarea v-model="editableMarkdown" class="marp-split-editor flex-1" spellcheck="false"></textarea>
+        </div>
+        <div class="flex flex-col overflow-y-auto" style="flex: 1 1 50%; min-width: 0">
+          <div class="m-auto w-full">
+            <MarpView :markdown="marpPreviewMarkdown" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir">
+              <template #toolbar>
+                <button
+                  class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
+                  :title="t('pluginMarkdown.marpSplitExit')"
+                  @click="marpSplitMode = false"
+                >
+                  <span class="material-icons text-base">close_fullscreen</span>
+                </button>
+              </template>
+            </MarpView>
+          </div>
+        </div>
       </div>
+      <!-- Preview-only mode (default): single MarpView + bottom <details>. -->
+      <template v-else>
+        <div class="flex-1 min-h-0 overflow-y-auto flex flex-col">
+          <div class="m-auto w-full">
+            <MarpView :markdown="markdownContent" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir">
+              <template #toolbar>
+                <button
+                  class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
+                  :title="t('pluginMarkdown.marpSplitEnter')"
+                  @click="enterMarpSplitMode"
+                >
+                  <span class="material-icons text-base">open_in_full</span>
+                </button>
+              </template>
+            </MarpView>
+          </div>
+        </div>
+        <div class="bottom-bar-wrapper">
+          <details ref="sourceDetails" class="markdown-source" @toggle="onDetailsToggle">
+            <summary>{{ t("pluginMarkdown.editSource") }}</summary>
+            <textarea v-model="editableMarkdown" class="markdown-editor" spellcheck="false"></textarea>
+            <div class="editor-actions">
+              <button class="apply-btn" :disabled="!hasChanges || saving" @click="applyMarkdown">
+                {{ saving ? t("pluginMarkdown.saving") : t("pluginMarkdown.applyChanges") }}
+              </button>
+              <button class="cancel-btn" @click="cancelEdit">{{ t("pluginMarkdown.cancel") }}</button>
+            </div>
+            <p v-if="saveError" class="save-error" role="alert">{{ t("pluginMarkdown.saveError", { error: saveError }) }}</p>
+          </details>
+        </div>
+      </template>
     </template>
     <template v-else>
       <div class="flex items-center justify-end gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
@@ -201,6 +242,15 @@ const { version: fileVersion } = useFileChange(watchedPath);
 // `<details>` element to close the editor when a remote write lands.
 const sourceDetails = ref<HTMLDetailsElement>();
 
+// Split-mode state (#1647). When true, the marp branch renders a
+// 50/50 layout: textarea on the left feeds `editableMarkdown` live
+// to the MarpView on the right, so the deck re-renders on every
+// keystroke without going through Apply. Default false to preserve
+// the preview-only landing experience from #1646. Declared up here
+// (rather than alongside the other marp-* helpers) so the
+// `fileVersion` watcher below can reset it on remote writes.
+const marpSplitMode = ref(false);
+
 // Remote write: refetch so the rendered view tracks disk. If the
 // editor is open we close it first — `fileVersion` only fires once
 // per remote write, so leaving the panel open and skipping the fetch
@@ -213,6 +263,11 @@ watch(fileVersion, (current, previous) => {
   if (sourceDetails.value?.open) {
     sourceDetails.value.open = false;
   }
+  // Drop split mode on remote write — same discard-and-reload policy
+  // as the bottom <details> editor (#1647).
+  if (marpSplitMode.value) {
+    marpSplitMode.value = false;
+  }
   void fetchMarkdownContent();
 });
 
@@ -224,6 +279,30 @@ watch(fileVersion, (current, previous) => {
 const mdDoc = useMarkdownDoc(markdownContent);
 
 const marpMode = computed(() => isMarpDocument(mdDoc.value.meta));
+
+// Markdown handed to the MarpView preview. While split mode is on,
+// the unsaved `editableMarkdown` buffer drives the preview so the
+// user sees their edits live; otherwise we show the persisted
+// `markdownContent` (= disk truth).
+const marpPreviewMarkdown = computed(() => (marpSplitMode.value ? editableMarkdown.value : markdownContent.value));
+
+function enterMarpSplitMode(): void {
+  // Sync the editor buffer with disk truth before entering, in case
+  // a remote write landed between mounts. `editableMarkdown` already
+  // tracks `markdownContent` via `fetchMarkdownContent`, but a stale
+  // unsaved diff from a prior split session would otherwise leak in.
+  editableMarkdown.value = markdownContent.value;
+  saveError.value = null;
+  marpSplitMode.value = true;
+}
+
+function cancelMarpSplitEdit(): void {
+  // Discard the unsaved buffer and return to preview-only. Same
+  // policy as `cancelEdit` for the bottom <details>.
+  editableMarkdown.value = markdownContent.value;
+  saveError.value = null;
+  marpSplitMode.value = false;
+}
 
 const marpBaseDir = computed(() => {
   const raw = props.selectedResult.data?.markdown;
@@ -617,6 +696,27 @@ watch(
   outline: none;
   border-color: #4caf50;
   box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.1);
+}
+
+/* Split-mode textarea: fills the left pane vertically instead of
+   the 40vh cap the bottom-bar editor uses. No rounded border /
+   margin — it sits inside a framed pane. */
+.marp-split-editor {
+  width: 100%;
+  padding: 1rem;
+  background: #ffffff;
+  border: none;
+  border-radius: 0;
+  color: #333;
+  font-family: "Courier New", monospace;
+  font-size: 0.9rem;
+  resize: none;
+  line-height: 1.5;
+  min-height: 0;
+}
+
+.marp-split-editor:focus {
+  outline: none;
 }
 
 .apply-btn {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -16,9 +16,20 @@
       <!-- Split mode: live editor on the left, MarpView on the right
            driven by the unsaved buffer. Toggle lives in the MarpView
            toolbar via slot. Apply/Cancel sit above the textarea so
-           the action surface is co-located with the input. -->
-      <div v-if="marpSplitMode" class="flex-1 min-h-0 flex">
-        <div class="flex flex-col" style="flex: 1 1 50%; min-width: 0; border-right: 1px solid #e0e0e0">
+           the action surface is co-located with the input.
+           IMPORTANT: layout-critical sizing uses inline styles instead
+           of Tailwind utility classes because this plugin renders
+           under `.stack-natural` (`presentDocument` is in
+           STACK_NATURAL_TOOLS — see `src/components/StackView.vue`).
+           That wrapper neutralises `.h-full`, `.overflow-hidden`,
+           and `.flex-col > .flex-1` via `:deep(...) { ... !important }`
+           so the deck flows at natural height in stack view. The
+           split editor needs a **bounded** height, so we set one
+           explicitly with `style="height: min(80vh, 720px)"` and use
+           inline `flex` shorthands that aren't matched by the class-
+           targeted override rules. -->
+      <div v-if="marpSplitMode" style="height: min(80vh, 720px); display: flex; overflow: hidden">
+        <div style="display: flex; flex-direction: column; flex: 1 1 50%; min-width: 0; min-height: 0; border-right: 1px solid #e0e0e0">
           <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
             <span class="text-xs text-gray-500 mr-auto">{{ t("pluginMarkdown.marpSplitEditorLabel") }}</span>
             <button class="apply-btn" :disabled="!hasChanges || saving" @click="applyMarkdown">
@@ -27,22 +38,23 @@
             <button class="cancel-btn" @click="cancelMarpSplitEdit">{{ t("pluginMarkdown.cancel") }}</button>
           </div>
           <p v-if="saveError" class="save-error mx-2 mt-1" role="alert">{{ t("pluginMarkdown.saveError", { error: saveError }) }}</p>
-          <textarea v-model="editableMarkdown" class="marp-split-editor flex-1" spellcheck="false"></textarea>
+          <textarea v-model="editableMarkdown" class="marp-split-editor" style="flex: 1 1 0; min-height: 0" spellcheck="false"></textarea>
         </div>
-        <div class="flex flex-col overflow-y-auto" style="flex: 1 1 50%; min-width: 0">
-          <div class="m-auto w-full">
-            <MarpView :markdown="marpPreviewMarkdown" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir">
-              <template #toolbar>
-                <button
-                  class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
-                  :title="t('pluginMarkdown.marpSplitExit')"
-                  @click="marpSplitMode = false"
-                >
-                  <span class="material-icons text-base">close_fullscreen</span>
-                </button>
-              </template>
-            </MarpView>
-          </div>
+        <!-- Right pane: scroll container for the deck. No vertical
+             centering — the editor view starts slides at the top so
+             the source / preview baselines line up. -->
+        <div style="flex: 1 1 50%; min-width: 0; min-height: 0; overflow-y: auto">
+          <MarpView :markdown="marpPreviewMarkdown" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir">
+            <template #toolbar>
+              <button
+                class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
+                :title="t('pluginMarkdown.marpSplitExit')"
+                @click="marpSplitMode = false"
+              >
+                <span class="material-icons text-base">close_fullscreen</span>
+              </button>
+            </template>
+          </MarpView>
         </div>
       </div>
       <!-- Preview-only mode (default): single MarpView + bottom <details>. -->

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -315,6 +315,15 @@ function enterMarpSplitMode(): void {
   // buffer on fresh loads, and the remote-write watcher closes split
   // mode + reloads when disk diverges. Explicit discard stays on the
   // Cancel button.
+  //
+  // Tear down the legacy bottom <details> state in case it was open:
+  // Vue's `v-else` unmounts that subtree without firing the
+  // `@toggle` listener, leaving `editing` stuck on `true` — which
+  // then reverts task-checkbox clicks (`onMarkdownClick`) and hides
+  // the copy button (`v-show="!editing"`) for the rest of the
+  // session (Codex review on PR #1658).
+  if (sourceDetails.value?.open) sourceDetails.value.open = false;
+  editing.value = false;
   saveError.value = null;
   marpSplitMode.value = true;
 }

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -258,6 +258,16 @@ const watchedPath = computed(() => {
 });
 const { version: fileVersion } = useFileChange(watchedPath);
 
+// Counter of in-flight / very-recent self-saves. Bumped before our
+// own PUT lands, decremented when the resulting fileChange event
+// arrives. The watcher below uses it to distinguish "the user just
+// clicked Apply (same tab)" from "another tab / agent / browser
+// rewrote the file". Without this, `useFileChange` would feed our
+// own save back through the watcher and tear down split mode (and
+// the bottom <details> editor) every time the user presses Apply
+// (Codex review on PR #1658).
+const pendingSelfSaves = ref(0);
+
 // Declared early so the `fileVersion` watcher below can reach into the
 // `<details>` element to close the editor when a remote write lands.
 const sourceDetails = ref<HTMLDetailsElement>();
@@ -286,6 +296,12 @@ const editing = ref(false);
 // see plans/done/feat-file-change-pubsub.md.
 watch(fileVersion, (current, previous) => {
   if (current === 0 || current === previous) return;
+  // Self-save: our own Apply / task-checkbox write feeds back here
+  // through pubsub. Don't tear down the editor for our own writes.
+  if (pendingSelfSaves.value > 0) {
+    pendingSelfSaves.value -= 1;
+    return;
+  }
   if (sourceDetails.value?.open) {
     sourceDetails.value.open = false;
   }
@@ -445,12 +461,17 @@ async function applyMarkdown() {
   // (e.g. the YYYY/MM partitions added in #764).
   if (isFilePath(raw)) {
     saving.value = true;
+    pendingSelfSaves.value += 1;
     const result = await apiPut<unknown>(endpoints.update.url, {
       relativePath: raw,
       markdown: editableMarkdown.value,
     });
     saving.value = false;
     if (!result.ok) {
+      // Roll back the self-save expectation — no pubsub event will
+      // arrive for a failed PUT, so the counter would otherwise stay
+      // high and silently absorb the next *remote* write.
+      pendingSelfSaves.value = Math.max(0, pendingSelfSaves.value - 1);
       // Store the raw error; the template formats it via t() so locale
       // switches re-render without double-translating.
       saveError.value = result.error;
@@ -497,6 +518,7 @@ async function persistTaskMarkdown(relativePath: string, markdown: string): Prom
   // on screen, and persisting it would clobber unrelated state.
   if (props.selectedResult.data?.markdown !== relativePath) return;
 
+  pendingSelfSaves.value += 1;
   const result = await apiPut<unknown>(endpoints.update.url, {
     relativePath,
     markdown,
@@ -511,6 +533,10 @@ async function persistTaskMarkdown(relativePath: string, markdown: string): Prom
   if (props.selectedResult.data?.markdown !== relativePath) return;
 
   if (!result.ok) {
+    // Failed write — no pubsub event will land for it, so roll the
+    // self-save counter back to keep the next genuine remote write
+    // visible to the fileVersion watcher.
+    pendingSelfSaves.value = Math.max(0, pendingSelfSaves.value - 1);
     saveError.value = result.error;
     // Refetch synchronously inside the chain so subsequent queued
     // clicks observe the canonical (server-side) markdown before

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -632,6 +632,13 @@ watch(
     // <details> is already closed by `fetchMarkdownContent` via
     // editableMarkdown resync (Codex review on PR #1658).
     marpSplitMode.value = false;
+    // Drop any in-flight self-save expectation: `useFileChange`
+    // rebinds to the new path and resets `version` to 0, so any
+    // pubsub event we were waiting on for the *old* file will never
+    // reach our watcher. Leaving the counter positive would let it
+    // absorb the next genuine remote write on the new doc (Codex
+    // review on PR #1658).
+    pendingSelfSaves.value = 0;
     fetchMarkdownContent();
   },
 );

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -271,6 +271,12 @@ const sourceDetails = ref<HTMLDetailsElement>();
 // `fileVersion` watcher below can reset it on remote writes.
 const marpSplitMode = ref(false);
 
+// `editing` tracks whether the legacy bottom <details> editor is
+// open. Hoisted above `enterMarpSplitMode` (which clears this on
+// entry) and the click-delegation handler below; the toggle setter
+// lives in `onDetailsToggle` further down.
+const editing = ref(false);
+
 // Remote write: refetch so the rendered view tracks disk. If the
 // editor is open we close it first — `fileVersion` only fires once
 // per remote write, so leaving the panel open and skipping the fetch
@@ -393,7 +399,6 @@ watch(
   },
 );
 
-const editing = ref(false);
 const { copied, copy } = useClipboardCopy();
 
 function onDetailsToggle(event: Event) {

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -580,6 +580,12 @@ function onMarkdownClick(event: MouseEvent): void {
 watch(
   () => props.selectedResult.data?.markdown,
   () => {
+    // Reset split mode so navigating from one Marp doc to another
+    // doesn't carry the editor pane across (split mode is a
+    // per-document opt-in; "状態の永続化: なし"). The bottom-bar
+    // <details> is already closed by `fetchMarkdownContent` via
+    // editableMarkdown resync (Codex review on PR #1658).
+    marpSplitMode.value = false;
     fetchMarkdownContent();
   },
 );

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -49,9 +49,10 @@
               <button
                 class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
                 :title="t('pluginMarkdown.marpSplitExit')"
+                :aria-label="t('pluginMarkdown.marpSplitExit')"
                 @click="marpSplitMode = false"
               >
-                <span class="material-icons text-base">close_fullscreen</span>
+                <span class="material-icons text-base" aria-hidden="true">close_fullscreen</span>
               </button>
             </template>
           </MarpView>
@@ -66,9 +67,10 @@
                 <button
                   class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
                   :title="t('pluginMarkdown.marpSplitEnter')"
+                  :aria-label="t('pluginMarkdown.marpSplitEnter')"
                   @click="enterMarpSplitMode"
                 >
-                  <span class="material-icons text-base">open_in_full</span>
+                  <span class="material-icons text-base" aria-hidden="true">open_in_full</span>
                 </button>
               </template>
             </MarpView>
@@ -299,11 +301,14 @@ const marpMode = computed(() => isMarpDocument(mdDoc.value.meta));
 const marpPreviewMarkdown = computed(() => (marpSplitMode.value ? editableMarkdown.value : markdownContent.value));
 
 function enterMarpSplitMode(): void {
-  // Sync the editor buffer with disk truth before entering, in case
-  // a remote write landed between mounts. `editableMarkdown` already
-  // tracks `markdownContent` via `fetchMarkdownContent`, but a stale
-  // unsaved diff from a prior split session would otherwise leak in.
-  editableMarkdown.value = markdownContent.value;
+  // Preserve any existing unsaved draft. The close (`close_fullscreen`)
+  // button is labelled as "hide editor", not "discard" — silently
+  // overwriting `editableMarkdown` with `markdownContent` on re-entry
+  // would drop the user's in-flight edits without warning (Codex
+  // review on PR #1658). `fetchMarkdownContent` already syncs the
+  // buffer on fresh loads, and the remote-write watcher closes split
+  // mode + reloads when disk diverges. Explicit discard stays on the
+  // Cancel button.
   saveError.value = null;
   marpSplitMode.value = true;
 }

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -38,7 +38,13 @@
             <button class="cancel-btn" @click="cancelMarpSplitEdit">{{ t("pluginMarkdown.cancel") }}</button>
           </div>
           <p v-if="saveError" class="save-error mx-2 mt-1" role="alert">{{ t("pluginMarkdown.saveError", { error: saveError }) }}</p>
-          <textarea v-model="editableMarkdown" class="marp-split-editor" style="flex: 1 1 0; min-height: 0" spellcheck="false"></textarea>
+          <textarea
+            v-model="editableMarkdown"
+            class="marp-split-editor"
+            style="flex: 1 1 0; min-height: 0"
+            spellcheck="false"
+            :aria-label="t('pluginMarkdown.marpSplitEditorLabel')"
+          ></textarea>
         </div>
         <!-- Right pane: scroll container for the deck. No vertical
              centering — the editor view starts slides at the top so


### PR DESCRIPTION
## Summary

- Marp スライドの chat plugin View に **左 = textarea / 右 = preview の split mode** を追加
- 未保存の `editableMarkdown` バッファをそのまま `MarpView` に流す → **タイプ即時に preview 反映** (debounce なし)
- MarpView のツールバーに toggle ボタン (split / preview-only) を追加
- デフォルトは preview-only (#1646 の体験を維持)
- Apply / Cancel は textarea 上部に配置
- リモート書き込み時は split mode を解除して reload
- 全 8 locale で i18n 追加 (en/ja/zh/ko/es/pt-BR/fr/de)
- Closes #1647

## Items to Confirm / Review

- **`.stack-natural` 互換のための inline style 戦略**: markdown plugin (`presentDocument`) は `STACK_NATURAL_TOOLS` に入っており、StackView の `.stack-natural` ラッパーが `:deep(.h-full) / :deep(.overflow-hidden) / :deep(.flex-col > .flex-1)` を `!important` で auto / visible / `0 0 auto` に潰す。flex で textarea を縦に張る通常戦術 (Tailwind の `flex-1` + `min-h-0`) が効かなかったため、split-mode container 内では **layout-critical な sizing を inline style** で書いている (override から逃げる)。`style="height: min(80vh, 720px); display: flex; overflow: hidden"` 等。コメントで明記
- **container 高さ**: `min(80vh, 720px)` — Marp スライド 1 枚 (16:9 ≈ 720x405) を含む適度なサイズ。リサイザーで動的調整は別 PR
- **リサイザー**: 50/50 固定 (要望に応じて follow-up PR)
- **debounce**: 即時更新 (Marp render は client-side で軽いので問題なし)
- **未保存編集中のリモート書き込み**: `fileVersion` watcher で split mode を OFF + リロード ( #1001 P1 と同じポリシー)
- **流用**: `editableMarkdown` / `hasChanges` / `saving` / `saveError` / `applyMarkdown` は既存 ref。Cancel 用に `cancelMarpSplitEdit` を新規追加 (`cancelEdit` の split 版)

## User Prompt

> previweを表示させながらmdを編集しリアルタイムに確認したい

(Issue 化フェーズで合意:)
> #1647 side-by-side ライブプレビュー
> - 左 = editor / 右 = preview (横並び)
> - 50/50 固定 (リサイザーは別 PR)
> - 即時更新

## Implementation

### `src/plugins/markdown/MarpView.vue`
- ツールバーに `<slot name="toolbar" />` を 1 つ追加。slot を持たない consumer (`FileContentRenderer`) は影響なし

### `src/plugins/markdown/View.vue`
- `marpSplitMode: ref(false)` を `sourceDetails` ref の隣に置く (fileVersion watcher から到達可能)
- `marpPreviewMarkdown` computed: split 中は `editableMarkdown`、それ以外は `markdownContent` を MarpView に渡す
- `enterMarpSplitMode()`: split 入り直前に `editableMarkdown = markdownContent` で同期
- `cancelMarpSplitEdit()`: 編集破棄 + split off
- `fileVersion` watcher: リモート write 時に split off + reload
- template: marp 分岐に `v-if="marpSplitMode"` / `<template v-else>` 二段。preview-only は #1646 の構造そのまま

### Layout (inline style 戦術)
\`\`\`html
<div v-if="marpSplitMode" style="height: min(80vh, 720px); display: flex; overflow: hidden">
  <div style="display: flex; flex-direction: column; flex: 1 1 50%; min-width: 0; min-height: 0; border-right: 1px solid #e0e0e0">
    <toolbar (ソース | Apply | Cancel) />
    <textarea class="marp-split-editor" style="flex: 1 1 0; min-height: 0" />
  </div>
  <div style="flex: 1 1 50%; min-width: 0; min-height: 0; overflow-y: auto">
    <MarpView :markdown="marpPreviewMarkdown">
      <template #toolbar><exit split button /></template>
    </MarpView>
  </div>
</div>
\`\`\`

### CSS 追加
- `.marp-split-editor` — 縦張り対応の textarea スタイル (border / radius なし、resize: none、padding 1rem)

### i18n keys (8 locale)
- `marpSplitEnter`: split mode 入りボタンの tooltip
- `marpSplitExit`: split mode 出るボタンの tooltip
- `marpSplitEditorLabel`: editor pane の見出し

Plan: `plans/feat-marp-split-preview.md`

## Test Plan

- [ ] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass (ローカル: ✅)
- [ ] Marp スライドを開く → preview-only mode で表示 (現状互換)
- [ ] 上部の `open_in_full` ボタンで split mode 入り → 左 textarea / 右 preview
- [ ] textarea に打鍵 → preview がリアルタイム更新
- [ ] Apply → disk 保存 (mode 維持)
- [ ] Cancel → 編集破棄 + preview-only 戻り
- [ ] split 中の `close_fullscreen` で preview-only mode に戻る
- [ ] リモートで file が書き換わったら mode 解除 + reload
- [ ] 非 Marp markdown に regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side-by-side split-view for the Marp editor with a toolbar toggle, 50/50 layout, preview-only default, Apply/Cancel controls, and live preview from unsaved edits

* **Bug Fixes**
  * Remote edits now cancel local edits and disable split mode; switching documents exits split mode to avoid stale state

* **Internationalization**
  * Added split-view UI translations in 8 languages

* **Documentation**
  * Added design/spec for split-preview behavior and acceptance criteria
<!-- end of auto-generated comment: release notes by coderabbit.ai -->