### PR TITLE
feat: display Claude Desktop connectors in allowed tools settings

### DIFF
--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -29,7 +29,7 @@ import { loadReferenceDirs, saveReferenceDirs, validateReferenceDirs, type Refer
 import { loadSchedulerOverrides, saveSchedulerOverrides, UTC_HH_MM_RE, type ScheduleOverrides } from "../../utils/files/scheduler-overrides-io.js";
 import { applyScheduleOverride } from "../../events/scheduler-adapter.js";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
-import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../../utils/time.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
 
 // Public surface of /api/config. GET returns the full config tree so
 // the client can render every section in one request. PUT surfaces are
@@ -309,6 +309,7 @@ export interface ConnectorEntry {
   connected: boolean;
 }
 
+const MCP_LIST_TIMEOUT_MS = 30 * ONE_SECOND_MS;
 const CLAUDE_AI_PREFIX = "claude.ai ";
 const CONNECTED_MARKER = "✓ Connected";
 
@@ -324,7 +325,7 @@ function parseConnectors(stdout: string): ConnectorEntry[] {
 
 function listClaudeMcpServers(): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile("claude", ["mcp", "list"], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS }, (err, stdout) => {
+    execFile("claude", ["mcp", "list"], { timeout: MCP_LIST_TIMEOUT_MS }, (err, stdout) => {
       if (err) return reject(err);
       return resolve(stdout);
     });

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -316,7 +316,7 @@ const CONNECTED_PATTERN = /[✓✔] Connected/;
 export function parseConnectors(stdout: string): ConnectorEntry[] {
   return stdout
     .split("\n")
-    .filter((line) => line.startsWith(CLAUDE_AI_PREFIX))
+    .filter((line) => line.startsWith(CLAUDE_AI_PREFIX) && line.includes(":"))
     .map((line) => ({
       name: line.slice(CLAUDE_AI_PREFIX.length, line.indexOf(":")),
       connected: CONNECTED_PATTERN.test(line),

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -309,11 +309,11 @@ export interface ConnectorEntry {
   connected: boolean;
 }
 
-const MCP_LIST_TIMEOUT_MS = 30 * ONE_SECOND_MS;
+const MCP_LIST_TIMEOUT_MS = 60 * ONE_SECOND_MS;
 const CLAUDE_AI_PREFIX = "claude.ai ";
 const CONNECTED_MARKER = "✓ Connected";
 
-function parseConnectors(stdout: string): ConnectorEntry[] {
+export function parseConnectors(stdout: string): ConnectorEntry[] {
   return stdout
     .split("\n")
     .filter((line) => line.startsWith(CLAUDE_AI_PREFIX))

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -311,7 +311,7 @@ export interface ConnectorEntry {
 
 const MCP_LIST_TIMEOUT_MS = 60 * ONE_SECOND_MS;
 const CLAUDE_AI_PREFIX = "claude.ai ";
-const CONNECTED_MARKER = "✓ Connected";
+const CONNECTED_PATTERN = /[✓✔] Connected/;
 
 export function parseConnectors(stdout: string): ConnectorEntry[] {
   return stdout
@@ -319,7 +319,7 @@ export function parseConnectors(stdout: string): ConnectorEntry[] {
     .filter((line) => line.startsWith(CLAUDE_AI_PREFIX))
     .map((line) => ({
       name: line.slice(CLAUDE_AI_PREFIX.length, line.indexOf(":")),
-      connected: line.includes(CONNECTED_MARKER),
+      connected: CONNECTED_PATTERN.test(line),
     }));
 }
 

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response } from "express";
+import { execFile } from "node:child_process";
 import {
   fromMcpEntries,
   isAppSettings,
@@ -28,6 +29,7 @@ import { loadReferenceDirs, saveReferenceDirs, validateReferenceDirs, type Refer
 import { loadSchedulerOverrides, saveSchedulerOverrides, UTC_HH_MM_RE, type ScheduleOverrides } from "../../utils/files/scheduler-overrides-io.js";
 import { applyScheduleOverride } from "../../events/scheduler-adapter.js";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
+import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../../utils/time.js";
 
 // Public surface of /api/config. GET returns the full config tree so
 // the client can render every section in one request. PUT surfaces are
@@ -298,6 +300,48 @@ router.put(
       res.json({ overrides: loadSchedulerOverrides() });
     },
   ),
+);
+
+// ── Connectors (read-only) ──────────────────────────────────────
+
+export interface ConnectorEntry {
+  name: string;
+  connected: boolean;
+}
+
+const CLAUDE_AI_PREFIX = "claude.ai ";
+const CONNECTED_MARKER = "✓ Connected";
+
+function parseConnectors(stdout: string): ConnectorEntry[] {
+  return stdout
+    .split("\n")
+    .filter((line) => line.startsWith(CLAUDE_AI_PREFIX))
+    .map((line) => ({
+      name: line.slice(CLAUDE_AI_PREFIX.length, line.indexOf(":")),
+      connected: line.includes(CONNECTED_MARKER),
+    }));
+}
+
+function listClaudeMcpServers(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("claude", ["mcp", "list"], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS }, (err, stdout) => {
+      if (err) return reject(err);
+      return resolve(stdout);
+    });
+  });
+}
+
+router.get(
+  API_ROUTES.config.connectors,
+  asyncHandler("config", "failed to list connectors", async (_req: Request, res: Response) => {
+    try {
+      const stdout = await listClaudeMcpServers();
+      res.json({ connectors: parseConnectors(stdout) });
+    } catch (err) {
+      log.warn("config", "claude mcp list failed — returning empty connectors", { error: errorMessage(err) });
+      res.json({ connectors: [] });
+    }
+  }),
 );
 
 export default router;

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -114,8 +114,13 @@
                 <span class="text-xs font-semibold text-gray-700">{{ t("settingsToolsTab.connectorsSectionTitle") }}</span>
                 <div v-if="connectorsLoading" class="text-xs text-gray-400">{{ t("common.loading") }}</div>
                 <ul v-else-if="connectors.length > 0" class="text-xs text-gray-700 space-y-0.5">
-                  <li v-for="c in connectors" :key="c.name" class="flex items-center gap-1.5">
-                    <span class="material-icons text-[14px]" :class="c.connected ? 'text-green-600' : 'text-gray-400'">
+                  <li
+                    v-for="c in connectors"
+                    :key="c.name"
+                    class="flex items-center gap-1.5"
+                    :aria-label="`${c.name} — ${c.connected ? t('settingsToolsTab.connectorConnected') : t('settingsToolsTab.connectorDisconnected')}`"
+                  >
+                    <span class="material-icons text-[14px]" :class="c.connected ? 'text-green-600' : 'text-gray-400'" aria-hidden="true">
                       {{ c.connected ? "check_circle" : "radio_button_unchecked" }}
                     </span>
                     {{ c.name }}

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -365,9 +365,14 @@ async function loadConfig(): Promise<void> {
   if (token === loadToken) loading.value = false;
 }
 
+let connectorLoadToken = 0;
+
 async function loadConnectors(): Promise<void> {
+  const token = ++connectorLoadToken;
   connectorsLoading.value = true;
   const response = await apiGet<{ connectors: { name: string; connected: boolean }[] }>(API_ROUTES.config.connectors);
+  // eslint-disable-next-line security/detect-possible-timing-attacks -- in-memory race-token guard, not an auth compare
+  if (token !== connectorLoadToken) return;
   if (response.ok) {
     connectors.value = response.data.connectors;
   }

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -109,6 +109,21 @@
                   {{ t("settingsModal.unsavedMarker") }}
                 </span>
               </div>
+
+              <div class="space-y-1.5 pt-2 border-t border-gray-200" data-testid="settings-connectors">
+                <span class="text-xs font-semibold text-gray-700">{{ t("settingsToolsTab.connectorsSectionTitle") }}</span>
+                <div v-if="connectorsLoading" class="text-xs text-gray-400">{{ t("common.loading") }}</div>
+                <ul v-else-if="connectors.length > 0" class="text-xs text-gray-700 space-y-0.5">
+                  <li v-for="c in connectors" :key="c.name" class="flex items-center gap-1.5">
+                    <span class="material-icons text-[14px]" :class="c.connected ? 'text-green-600' : 'text-gray-400'">
+                      {{ c.connected ? "check_circle" : "radio_button_unchecked" }}
+                    </span>
+                    {{ c.name }}
+                  </li>
+                </ul>
+                <div v-else class="text-xs text-gray-400">{{ t("settingsToolsTab.connectorsEmpty") }}</div>
+                <p class="text-xs text-gray-500">{{ t("settingsToolsTab.connectorsGuide") }}</p>
+              </div>
             </div>
 
             <div v-else-if="activeTab === 'mcp'" class="space-y-3">
@@ -271,6 +286,8 @@ const toolsText = ref("");
 // actually edited the list.
 const toolsSavedText = ref("");
 const mcpServers = ref<McpServerEntry[]>([]);
+const connectors = ref<{ name: string; connected: boolean }[]>([]);
+const connectorsLoading = ref(false);
 const loadError = ref("");
 // App version (root package.json), surfaced from /api/health. Fetched
 // once on first open and kept — it can't change mid-process.
@@ -341,6 +358,15 @@ async function loadConfig(): Promise<void> {
   }
   // eslint-disable-next-line security/detect-possible-timing-attacks -- same race-token guard as above
   if (token === loadToken) loading.value = false;
+}
+
+async function loadConnectors(): Promise<void> {
+  connectorsLoading.value = true;
+  const response = await apiGet<{ connectors: { name: string; connected: boolean }[] }>(API_ROUTES.config.connectors);
+  if (response.ok) {
+    connectors.value = response.data.connectors;
+  }
+  connectorsLoading.value = false;
 }
 
 // Tools tab — Save button hits the settings-only endpoint. MCP
@@ -450,6 +476,7 @@ watch(
       activeTab.value = props.geminiAvailable ? "tools" : "gemini";
       loadConfig();
       loadVersion();
+      loadConnectors();
       mapReloadToken.value += 1;
       photosReloadToken.value += 1;
       modelReloadToken.value += 1;

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -95,6 +95,7 @@ const HOST_API_ROUTES = {
     // `mc-manage-automations` preset skills (split out in #1295).
     // Safe to call ad-hoc — pure side effect, no body.
     refresh: "/api/config/refresh",
+    connectors: "/api/config/connectors",
   },
 
   files: {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1166,6 +1166,8 @@ const deMessages = {
       "Zusätzliche Tool-Namen, die Claude über {allowedTools} übergeben werden sollen. Einer pro Zeile. Nützlich für in Claude Code integrierte MCP-Server wie Gmail / Google Kalender, nachdem Sie sich über {claudeMcp} authentifiziert haben.",
     connectorsSectionTitle: "Verbundene Konnektoren",
     connectorsEmpty: "Keine Konnektoren gefunden.",
+    connectorConnected: "Verbunden",
+    connectorDisconnected: "Nicht verbunden",
     connectorsGuide:
       "Konnektoren wie Slack und Gmail erlauben Claude den Zugriff auf Ihre Konten. Konnektoren werden in Claude Desktop hinzugefügt oder entfernt.",
   },

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1164,6 +1164,10 @@ const deMessages = {
     // behalten, während der Text übersetzbar ist.
     explanation:
       "Zusätzliche Tool-Namen, die Claude über {allowedTools} übergeben werden sollen. Einer pro Zeile. Nützlich für in Claude Code integrierte MCP-Server wie Gmail / Google Kalender, nachdem Sie sich über {claudeMcp} authentifiziert haben.",
+    connectorsSectionTitle: "Verbundene Konnektoren",
+    connectorsEmpty: "Keine Konnektoren gefunden.",
+    connectorsGuide:
+      "Konnektoren wie Slack und Gmail erlauben Claude den Zugriff auf Ihre Konten. Konnektoren werden in Claude Desktop hinzugefügt oder entfernt.",
   },
   collectionsView: {
     addCollectionLabel: "Sammlung",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1150,6 +1150,8 @@ const enMessages = {
       "Extra tool names to pass to Claude via {allowedTools}. One per line. Useful for built-in Claude Code MCP servers like Gmail / Google Calendar after you have authenticated via {claudeMcp}.",
     connectorsSectionTitle: "Connected connectors",
     connectorsEmpty: "No connectors found.",
+    connectorConnected: "Connected",
+    connectorDisconnected: "Not connected",
     connectorsGuide: "Connectors like Slack and Gmail let Claude access your accounts. Add or remove connectors from Claude Desktop.",
   },
   collectionsView: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1148,6 +1148,9 @@ const enMessages = {
     // is translatable.
     explanation:
       "Extra tool names to pass to Claude via {allowedTools}. One per line. Useful for built-in Claude Code MCP servers like Gmail / Google Calendar after you have authenticated via {claudeMcp}.",
+    connectorsSectionTitle: "Connected connectors",
+    connectorsEmpty: "No connectors found.",
+    connectorsGuide: "Connectors like Slack and Gmail let Claude access your accounts. Add or remove connectors from Claude Desktop.",
   },
   collectionsView: {
     addCollectionLabel: "Collection",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1163,6 +1163,8 @@ const esMessages = {
       "Nombres adicionales de herramientas que pasar a Claude mediante {allowedTools}. Uno por línea. Útil para servidores MCP integrados en Claude Code como Gmail / Google Calendar tras autenticarte mediante {claudeMcp}.",
     connectorsSectionTitle: "Conectores conectados",
     connectorsEmpty: "No se encontraron conectores.",
+    connectorConnected: "Conectado",
+    connectorDisconnected: "No conectado",
     connectorsGuide: "Los conectores como Slack y Gmail permiten a Claude acceder a tus cuentas. Agrega o elimina conectores desde Claude Desktop.",
   },
   collectionsView: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1161,6 +1161,9 @@ const esMessages = {
     // su estilo mientras el texto se traduce.
     explanation:
       "Nombres adicionales de herramientas que pasar a Claude mediante {allowedTools}. Uno por línea. Útil para servidores MCP integrados en Claude Code como Gmail / Google Calendar tras autenticarte mediante {claudeMcp}.",
+    connectorsSectionTitle: "Conectores conectados",
+    connectorsEmpty: "No se encontraron conectores.",
+    connectorsGuide: "Los conectores como Slack y Gmail permiten a Claude acceder a tus cuentas. Agrega o elimina conectores desde Claude Desktop.",
   },
   collectionsView: {
     addCollectionLabel: "Colección",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1155,6 +1155,8 @@ const frMessages = {
       "Noms d'outils supplémentaires à transmettre à Claude via {allowedTools}. Un par ligne. Utile pour les serveurs MCP intégrés à Claude Code comme Gmail / Google Agenda après authentification via {claudeMcp}.",
     connectorsSectionTitle: "Connecteurs actifs",
     connectorsEmpty: "Aucun connecteur trouvé.",
+    connectorConnected: "Connecté",
+    connectorDisconnected: "Non connecté",
     connectorsGuide:
       "Les connecteurs comme Slack et Gmail permettent à Claude d'accéder à vos comptes. Ajoutez ou supprimez des connecteurs depuis Claude Desktop.",
   },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1153,6 +1153,10 @@ const frMessages = {
     // style tandis que le texte reste traduisible.
     explanation:
       "Noms d'outils supplémentaires à transmettre à Claude via {allowedTools}. Un par ligne. Utile pour les serveurs MCP intégrés à Claude Code comme Gmail / Google Agenda après authentification via {claudeMcp}.",
+    connectorsSectionTitle: "Connecteurs actifs",
+    connectorsEmpty: "Aucun connecteur trouvé.",
+    connectorsGuide:
+      "Les connecteurs comme Slack et Gmail permettent à Claude d'accéder à vos comptes. Ajoutez ou supprimez des connecteurs depuis Claude Desktop.",
   },
   collectionsView: {
     addCollectionLabel: "Collection",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1146,6 +1146,8 @@ const jaMessages = {
       "{allowedTools} を介して Claude に渡す追加ツール名。1行につき1つ。Gmail / Google Calendar などの Claude Code 組み込み MCP サーバを、{claudeMcp} で認証した後に利用する場合に便利です。",
     connectorsSectionTitle: "接続済みコネクタ",
     connectorsEmpty: "コネクタが見つかりません。",
+    connectorConnected: "接続済み",
+    connectorDisconnected: "未接続",
     connectorsGuide: "Slack や Gmail 等のコネクタで Claude がアカウントにアクセスできるようになります。追加・削除は Claude Desktop から行えます。",
   },
   collectionsView: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1144,6 +1144,9 @@ const jaMessages = {
   settingsToolsTab: {
     explanation:
       "{allowedTools} を介して Claude に渡す追加ツール名。1行につき1つ。Gmail / Google Calendar などの Claude Code 組み込み MCP サーバを、{claudeMcp} で認証した後に利用する場合に便利です。",
+    connectorsSectionTitle: "接続済みコネクタ",
+    connectorsEmpty: "コネクタが見つかりません。",
+    connectorsGuide: "Slack や Gmail 等のコネクタで Claude がアカウントにアクセスできるようになります。追加・削除は Claude Desktop から行えます。",
   },
   collectionsView: {
     addCollectionLabel: "コレクション",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1150,6 +1150,8 @@ const koMessages = {
       "{allowedTools} 를 통해 Claude 에 전달할 추가 도구 이름. 한 줄에 하나씩. {claudeMcp} 로 인증을 완료한 후 Claude Code 내장 MCP 서버 (Gmail / Google 캘린더 등) 를 사용할 때 유용합니다.",
     connectorsSectionTitle: "연결된 커넥터",
     connectorsEmpty: "커넥터를 찾을 수 없습니다.",
+    connectorConnected: "연결됨",
+    connectorDisconnected: "연결 안 됨",
     connectorsGuide: "Slack, Gmail 등의 커넥터로 Claude가 계정에 접근할 수 있습니다. 커넥터 추가 및 제거는 Claude Desktop에서 할 수 있습니다.",
   },
   collectionsView: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1148,6 +1148,9 @@ const koMessages = {
     // `<code>` 태그는 스타일을 유지하면서 본문은 번역 가능합니다.
     explanation:
       "{allowedTools} 를 통해 Claude 에 전달할 추가 도구 이름. 한 줄에 하나씩. {claudeMcp} 로 인증을 완료한 후 Claude Code 내장 MCP 서버 (Gmail / Google 캘린더 등) 를 사용할 때 유용합니다.",
+    connectorsSectionTitle: "연결된 커넥터",
+    connectorsEmpty: "커넥터를 찾을 수 없습니다.",
+    connectorsGuide: "Slack, Gmail 등의 커넥터로 Claude가 계정에 접근할 수 있습니다. 커넥터 추가 및 제거는 Claude Desktop에서 할 수 있습니다.",
   },
   collectionsView: {
     addCollectionLabel: "컬렉션",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1152,6 +1152,8 @@ const ptBRMessages = {
       "Nomes adicionais de ferramentas a serem passados ao Claude via {allowedTools}. Um por linha. Útil para servidores MCP integrados ao Claude Code como Gmail / Google Calendar após autenticar via {claudeMcp}.",
     connectorsSectionTitle: "Conectores conectados",
     connectorsEmpty: "Nenhum conector encontrado.",
+    connectorConnected: "Conectado",
+    connectorDisconnected: "Não conectado",
     connectorsGuide: "Conectores como Slack e Gmail permitem que o Claude acesse suas contas. Adicione ou remova conectores pelo Claude Desktop.",
   },
   collectionsView: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1150,6 +1150,9 @@ const ptBRMessages = {
     // enquanto o texto é traduzível.
     explanation:
       "Nomes adicionais de ferramentas a serem passados ao Claude via {allowedTools}. Um por linha. Útil para servidores MCP integrados ao Claude Code como Gmail / Google Calendar após autenticar via {claudeMcp}.",
+    connectorsSectionTitle: "Conectores conectados",
+    connectorsEmpty: "Nenhum conector encontrado.",
+    connectorsGuide: "Conectores como Slack e Gmail permitem que o Claude acesse suas contas. Adicione ou remova conectores pelo Claude Desktop.",
   },
   collectionsView: {
     addCollectionLabel: "Coleção",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1139,6 +1139,8 @@ const zhMessages = {
       "要通过 {allowedTools} 传递给 Claude 的额外工具名。每行一个。适用于在 {claudeMcp} 完成授权后,调用 Claude Code 内置的 MCP 服务器(如 Gmail / Google 日历)。",
     connectorsSectionTitle: "已连接的连接器",
     connectorsEmpty: "未找到连接器。",
+    connectorConnected: "已连接",
+    connectorDisconnected: "未连接",
     connectorsGuide: "Slack、Gmail 等连接器让 Claude 可以访问您的账户。请在 Claude Desktop 中添加或移除连接器。",
   },
   collectionsView: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1137,6 +1137,9 @@ const zhMessages = {
     // 以便保留 `<code>` 标签的样式,同时文本可本地化。
     explanation:
       "要通过 {allowedTools} 传递给 Claude 的额外工具名。每行一个。适用于在 {claudeMcp} 完成授权后,调用 Claude Code 内置的 MCP 服务器(如 Gmail / Google 日历)。",
+    connectorsSectionTitle: "已连接的连接器",
+    connectorsEmpty: "未找到连接器。",
+    connectorsGuide: "Slack、Gmail 等连接器让 Claude 可以访问您的账户。请在 Claude Desktop 中添加或移除连接器。",
   },
   collectionsView: {
     addCollectionLabel: "集合",

--- a/test/api/routes/test_parseConnectors.ts
+++ b/test/api/routes/test_parseConnectors.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseConnectors } from "../../../server/api/routes/config.js";
+
+describe("parseConnectors", () => {
+  it("parses connected and disconnected connectors", () => {
+    const stdout = ["claude.ai Gmail: https://gmail.example.com - ✓ Connected", "claude.ai Slack: https://slack.example.com - ✗ Not connected"].join("\n");
+
+    const result = parseConnectors(stdout);
+    assert.deepEqual(result, [
+      { name: "Gmail", connected: true },
+      { name: "Slack", connected: false },
+    ]);
+  });
+
+  it("ignores non-claude.ai lines", () => {
+    const stdout = [
+      "my-custom-server: https://example.com - ✓ Connected",
+      "claude.ai Google Calendar: https://cal.example.com - ✓ Connected",
+      "another-server: https://other.com",
+    ].join("\n");
+
+    const result = parseConnectors(stdout);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "Google Calendar");
+    assert.equal(result[0].connected, true);
+  });
+
+  it("returns empty array for empty input", () => {
+    assert.deepEqual(parseConnectors(""), []);
+  });
+
+  it("returns empty array when no claude.ai lines exist", () => {
+    const stdout = "local-mcp: http://localhost:3000\nother-server: http://other.com";
+    assert.deepEqual(parseConnectors(stdout), []);
+  });
+
+  it("handles lines without the Connected marker as disconnected", () => {
+    const stdout = "claude.ai Google Drive: https://drive.example.com - Pending";
+    const result = parseConnectors(stdout);
+    assert.deepEqual(result, [{ name: "Google Drive", connected: false }]);
+  });
+
+  it("handles multiple connectors with mixed states", () => {
+    const stdout = [
+      "claude.ai Gmail: https://gmail.example.com - ✓ Connected",
+      "claude.ai Google Calendar: https://cal.example.com - ✓ Connected",
+      "claude.ai Google Drive: https://drive.example.com - ✗ Not connected",
+      "claude.ai Slack: https://slack.example.com - ✓ Connected",
+    ].join("\n");
+
+    const result = parseConnectors(stdout);
+    assert.equal(result.length, 4);
+    assert.equal(result.filter((entry) => entry.connected).length, 3);
+    assert.equal(result.filter((entry) => !entry.connected).length, 1);
+  });
+
+  it("handles trailing newlines", () => {
+    const stdout = "claude.ai Gmail: https://gmail.example.com - ✓ Connected\n\n";
+    const result = parseConnectors(stdout);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "Gmail");
+  });
+});

--- a/test/api/routes/test_parseConnectors.ts
+++ b/test/api/routes/test_parseConnectors.ts
@@ -61,6 +61,13 @@ describe("parseConnectors", () => {
     assert.deepEqual(result, [{ name: "Slack", connected: true }]);
   });
 
+  it("skips malformed claude.ai line without colon separator", () => {
+    const stdout = ["claude.ai MalformedEntry", "claude.ai Gmail: https://gmail.example.com - ✓ Connected"].join("\n");
+    const result = parseConnectors(stdout);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "Gmail");
+  });
+
   it("handles trailing newlines", () => {
     const stdout = "claude.ai Gmail: https://gmail.example.com - ✓ Connected\n\n";
     const result = parseConnectors(stdout);

--- a/test/api/routes/test_parseConnectors.ts
+++ b/test/api/routes/test_parseConnectors.ts
@@ -55,6 +55,12 @@ describe("parseConnectors", () => {
     assert.equal(result.filter((entry) => !entry.connected).length, 1);
   });
 
+  it("recognises heavy check mark (U+2714) as connected", () => {
+    const stdout = "claude.ai Slack: https://mcp.slack.com/mcp - ✔ Connected";
+    const result = parseConnectors(stdout);
+    assert.deepEqual(result, [{ name: "Slack", connected: true }]);
+  });
+
   it("handles trailing newlines", () => {
     const stdout = "claude.ai Gmail: https://gmail.example.com - ✓ Connected\n\n";
     const result = parseConnectors(stdout);


### PR DESCRIPTION
## Summary

設定 → 許可ツールタブに Claude Desktop で接続済みのコネクタ一覧（Gmail / Slack 等）を読み取り専用で表示する機能を追加。

- `claude mcp list` の stdout をパースし `claude.ai *` 行のみ抽出して接続状態を表示
- 追加・削除は Claude Desktop から行う旨のガイドテキストを表示
- ローディングインジケーター付き（`claude mcp list` はヘルスチェックで数秒〜数十秒かかる）

<img width="1648" height="1298" alt="CleanShot 2026-06-09 at 12 53 16@2x" src="https://github.com/user-attachments/assets/19a4f23c-2e04-4787-bc61-446e945091ec" />

### 読み込み中
<img width="658" height="137" alt="image" src="https://github.com/user-attachments/assets/a85ea2f9-301c-4668-9a01-d92491c4fbb0" />

### コネクタがない場合
<img width="646" height="131" alt="image" src="https://github.com/user-attachments/assets/8d3acf2e-c442-4b3f-a591-e16ab46872ce" />


## Items to Confirm / Review

- `claude mcp list` のタイムアウトを 60 秒に設定。極端に遅い環境ではタイムアウト → 空配列フォールバック（非致命的）
- チェックマーク文字の差異（U+2713 `✓` / U+2714 `✔`）を正規表現で両対応
- コネクタ情報はエンドポイントからの読み取り専用表示のみ（許可操作は不要 — `CLAUDE_AI_CONNECTOR_SERVERS` で既にプリ許可済み）

## User Prompt

- 許可ツールタブに Claude Desktop で設定しているコネクタも表示したい
- 追加は Claude Desktop からと案内したい
- 既存の保存ボタンの下に表示、リスト（改行）形式で
- ローディングインジケーターを入れる

## 実装詳細

### サーバー (`server/api/routes/config.ts`)

- `GET /api/config/connectors` エンドポイント追加
- `execFile("claude", ["mcp", "list"])` でコネクタ一覧を取得・パース
- `parseConnectors()` を export し、ユニットテストで検証

### フロントエンド (`src/components/SettingsModal.vue`)

- ツールタブの保存ボタン下にコネクタセクションを追加
- ローディング表示 → コネクタリスト or 空メッセージ → ガイドテキスト
- 接続状態アイコン（`check_circle` / `radio_button_unchecked`）+ `aria-label` によるアクセシビリティ対応

### i18n

- 8 言語すべて（en / ja / zh / ko / es / pt-BR / fr / de）に以下のキーを追加:
  - `connectorsSectionTitle`, `connectorsEmpty`, `connectorsGuide`
  - `connectorConnected`, `connectorDisconnected`（アクセシビリティ用）

### テスト (`test/api/routes/test_parseConnectors.ts`)

- happy path（接続 / 未接続の混在）
- 非 `claude.ai` 行のフィルタリング
- 空入力 / 末尾改行
- チェックマーク文字の差異（U+2714 回帰テスト）

## Codex Cross-Review

4 iterations で収束（iter-4 で LGTM）。主な修正:
- iter-1: タイムアウト 5s→30s、アクセシビリティ（aria-label / aria-hidden）
- iter-2: タイムアウト 30s→60s、`parseConnectors` のユニットテスト追加
- iter-3: チェックマーク文字の不一致修正（U+2713 → U+2713/U+2714 両対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only connectors endpoint added so the app can show connector statuses.
  * Settings → Tools gains a "Connectors" subsection that loads and displays connector status when opened.
  * Full localization for the connectors UI: English, German, Spanish, French, Japanese, Korean, Portuguese (BR), Simplified Chinese.

* **Tests**
  * Added unit tests for parsing connector status output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->