### PR TITLE
feat: support multiple file attachments in chat (up to 10)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -981,6 +981,17 @@ function unsubscribeSession(chatSessionId: string): void {
   }
 }
 
+type AttachmentResult = { paths: string[] } | { error: string } | null;
+
+async function resolveAttachmentPaths(files: PastedFile[]): Promise<AttachmentResult> {
+  if (files.length === 0) return null;
+  const results = await Promise.all(files.map((file) => resolvePastedAttachment(file)));
+  const firstFailure = results.find((res) => !res.ok);
+  if (firstFailure && !firstFailure.ok) return { error: firstFailure.error };
+  const paths = results.filter((res): res is { ok: true; value: string } => res.ok).map((res) => res.value);
+  return paths.length > 0 ? { paths } : null;
+}
+
 async function sendMessage(text?: string) {
   const message = typeof text === "string" ? text : userInput.value.trim();
   if (!message || activeSessionRunning.value) return;
@@ -988,26 +999,20 @@ async function sendMessage(text?: string) {
   const filesSnapshot = [...pastedFiles.value];
   pastedFiles.value = [];
 
-  let attachmentPaths: string[] | undefined;
-  if (filesSnapshot.length > 0) {
-    const results = await Promise.all(filesSnapshot.map((file) => resolvePastedAttachment(file)));
-    const firstFailure = results.find((res) => !res.ok);
-    if (firstFailure && !firstFailure.ok) {
-      userInput.value = message;
-      pastedFiles.value = filesSnapshot;
-      const recoverySession = sessionMap.get(currentSessionId.value);
-      if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: firstFailure.error }));
-      return;
-    }
-    attachmentPaths = results.filter((res): res is { ok: true; value: string } => res.ok).map((res) => res.value);
-    if (attachmentPaths.length === 0) attachmentPaths = undefined;
+  const resolved = await resolveAttachmentPaths(filesSnapshot);
+  if (resolved !== null && "error" in resolved) {
+    userInput.value = message;
+    pastedFiles.value = filesSnapshot;
+    const recoverySession = sessionMap.get(currentSessionId.value);
+    if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
+    return;
   }
+  const attachmentPaths = resolved?.paths;
 
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
 
   beginUserTurn(session, message, attachmentPaths);
-
   ensureSessionSubscription(session);
 
   const result = await postAgentRun(

--- a/src/App.vue
+++ b/src/App.vue
@@ -137,7 +137,7 @@
         <ChatInput
           ref="chatInputRef"
           v-model="userInput"
-          v-model:pasted-file="pastedFile"
+          v-model:pasted-files="pastedFiles"
           :is-running="activeSessionRunning"
           :queries="sessionRoleQueries"
           @send="sendMessage()"
@@ -260,7 +260,7 @@
           <ChatInput
             ref="chatInputRef"
             v-model="userInput"
-            v-model:pasted-file="pastedFile"
+            v-model:pasted-files="pastedFiles"
             :is-running="activeSessionRunning"
             :queries="sessionRoleQueries"
             @send="sendMessage()"
@@ -451,7 +451,7 @@ const { currentRoleId } = useCurrentRole(roles);
 const { shortcuts } = useShortcuts();
 
 const userInput = ref("");
-const pastedFile = ref<PastedFile | null>(null);
+const pastedFiles = ref<PastedFile[]>([]);
 const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, historyError, fetchSessions, setBookmark, deleteSession: deleteSessionFromHistory } = useSessionHistory();
@@ -537,7 +537,7 @@ useGlobalImageErrorRepair();
 
 const sessionSidebarRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);
-const chatInputRef = ref<{ focus: () => void; collapseSuggestions: () => void; readFile: (file: File) => void } | null>(null);
+const chatInputRef = ref<{ focus: () => void; collapseSuggestions: () => void; addFiles: (files: File[]) => void } | null>(null);
 const { focusChatInput } = useChatScroll({
   sessionSidebarRef,
   toolResults,
@@ -559,8 +559,8 @@ const {
   onDragleave: onPanelDragleave,
   onDrop: onPanelDrop,
 } = useFileDropZone({
-  onFile: (file) => {
-    chatInputRef.value?.readFile(file);
+  onFiles: (files) => {
+    chatInputRef.value?.addFiles(files);
   },
 });
 
@@ -985,36 +985,26 @@ async function sendMessage(text?: string) {
   const message = typeof text === "string" ? text : userInput.value.trim();
   if (!message || activeSessionRunning.value) return;
   userInput.value = "";
-  const fileSnapshot = pastedFile.value;
-  pastedFile.value = null;
+  const filesSnapshot = [...pastedFiles.value];
+  pastedFiles.value = [];
 
-  // Pasted / dropped files are pre-uploaded to a workspace file so
-  // the server (and the LLM downstream) sees a relative path — never
-  // a data: URI. The path then rides on `attachments[]` as a path-only
-  // entry. On upload failure, restore both userInput and pastedFile so
-  // the user can retry without retyping.
-  let attachmentForRequest: string | undefined;
-  if (fileSnapshot) {
-    const resolved = await resolvePastedAttachment(fileSnapshot);
-    if (!resolved.ok) {
+  let attachmentPaths: string[] | undefined;
+  if (filesSnapshot.length > 0) {
+    const results = await Promise.all(filesSnapshot.map((file) => resolvePastedAttachment(file)));
+    const firstFailure = results.find((res) => !res.ok);
+    if (firstFailure && !firstFailure.ok) {
       userInput.value = message;
-      pastedFile.value = fileSnapshot;
+      pastedFiles.value = filesSnapshot;
       const recoverySession = sessionMap.get(currentSessionId.value);
-      if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
+      if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: firstFailure.error }));
       return;
     }
-    attachmentForRequest = resolved.value;
+    attachmentPaths = results.filter((res): res is { ok: true; value: string } => res.ok).map((res) => res.value);
+    if (attachmentPaths.length === 0) attachmentPaths = undefined;
   }
 
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
-
-  // Only files the user explicitly attached this turn (paste / drop /
-  // file-picker) ride on the message. Do NOT auto-attach whatever
-  // image happens to be selected in the sidebar — selection moves to
-  // the latest generated image automatically, which would silently
-  // glue the previous picture onto every follow-up comment.
-  const attachmentPaths = attachmentForRequest ? [attachmentForRequest] : undefined;
 
   beginUserTurn(session, message, attachmentPaths);
 

--- a/src/components/ChatAttachmentPreview.vue
+++ b/src/components/ChatAttachmentPreview.vue
@@ -3,7 +3,7 @@
     <img v-if="isImage" :src="dataUrl" alt="Attached image" class="max-h-20 max-w-40 object-contain" />
     <div v-else class="flex items-center gap-1.5 text-xs text-gray-700">
       <span class="material-icons text-base" :class="iconColor">{{ icon }}</span>
-      <span class="max-w-40 truncate">{{ filename || "attachment" }}</span>
+      <span class="max-w-40 truncate">{{ filename || t("chatInput.attachmentFallbackName") }}</span>
     </div>
     <button
       data-testid="chat-attachment-remove"

--- a/src/components/ChatAttachmentPreview.vue
+++ b/src/components/ChatAttachmentPreview.vue
@@ -8,6 +8,8 @@
     <button
       data-testid="chat-attachment-remove"
       class="absolute top-0 right-0 bg-black/60 text-white rounded-bl px-1 text-xs leading-tight hover:bg-black/80"
+      :aria-label="removeLabel"
+      :title="removeLabel"
       @click="emit('remove')"
     >
       ✕
@@ -17,6 +19,9 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   dataUrl: string;
@@ -24,6 +29,8 @@ const props = defineProps<{
   mime: string;
 }>();
 const emit = defineEmits<{ remove: [] }>();
+
+const removeLabel = computed(() => t("chatInput.removeAttachment", { name: props.filename || "attachment" }));
 
 const isImage = computed(() => props.mime.startsWith("image/"));
 

--- a/src/components/ChatAttachmentPreview.vue
+++ b/src/components/ChatAttachmentPreview.vue
@@ -30,7 +30,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ remove: [] }>();
 
-const removeLabel = computed(() => t("chatInput.removeAttachment", { name: props.filename || "attachment" }));
+const removeLabel = computed(() => t("chatInput.removeAttachment", { name: props.filename || t("chatInput.attachmentFallbackName") }));
 
 const isImage = computed(() => props.mime.startsWith("image/"));
 

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -185,18 +185,35 @@ function readFileAsDataUrl(file: File): Promise<string | null> {
   });
 }
 
-function addFiles(files: File[]): void {
-  fileError.value = null;
-  const currentCount = props.pastedFiles.length;
-  const remainingSlots = MAX_ATTACHMENTS - currentCount;
-
+function clampToSlots(files: File[]): File[] {
+  const remainingSlots = MAX_ATTACHMENTS - props.pastedFiles.length;
   if (files.length > remainingSlots) {
     fileError.value = t("chatInput.tooManyFiles", { max: MAX_ATTACHMENTS });
-    if (remainingSlots <= 0) return;
   }
-  const accepted = files.slice(0, remainingSlots);
+  return remainingSlots <= 0 ? [] : files.slice(0, remainingSlots);
+}
 
-  const firstError = accepted.reduce<string | null>((err, file) => err ?? validateFile(file), null);
+function findFirstValidationError(files: File[]): string | null {
+  return files.reduce<string | null>((err, file) => err ?? validateFile(file), null);
+}
+
+function emitClampedFiles(valid: PastedFile[]): void {
+  const slotsNow = MAX_ATTACHMENTS - props.pastedFiles.length;
+  const clamped = slotsNow < valid.length ? valid.slice(0, Math.max(0, slotsNow)) : valid;
+  if (clamped.length > 0) {
+    emit("update:pastedFiles", [...props.pastedFiles, ...clamped]);
+  }
+  if (clamped.length < valid.length) {
+    fileError.value = t("chatInput.tooManyFiles", { max: MAX_ATTACHMENTS });
+  }
+}
+
+function addFiles(files: File[]): void {
+  fileError.value = null;
+  const accepted = clampToSlots(files);
+  if (accepted.length === 0) return;
+
+  const firstError = findFirstValidationError(accepted);
   if (firstError) {
     fileError.value = firstError;
     return;
@@ -211,15 +228,7 @@ function addFiles(files: File[]): void {
   Promise.all(pending)
     .then((results) => {
       const valid = results.filter((result): result is PastedFile => result !== null);
-      if (valid.length === 0) return;
-      const slotsNow = MAX_ATTACHMENTS - props.pastedFiles.length;
-      const clamped = slotsNow < valid.length ? valid.slice(0, Math.max(0, slotsNow)) : valid;
-      if (clamped.length > 0) {
-        emit("update:pastedFiles", [...props.pastedFiles, ...clamped]);
-      }
-      if (clamped.length < valid.length) {
-        fileError.value = t("chatInput.tooManyFiles", { max: MAX_ATTACHMENTS });
-      }
+      if (valid.length > 0) emitClampedFiles(valid);
     })
     .catch(() => {
       fileError.value = t("chatInput.unsupportedFileType");

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -23,14 +23,17 @@
       <div v-if="fileError" class="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5" data-testid="file-error">
         {{ fileError }}
       </div>
-      <ChatAttachmentPreview
-        v-if="pastedFile"
-        :data-url="pastedFile.dataUrl"
-        :filename="pastedFile.name"
-        :mime="pastedFile.mime"
-        @remove="emit('update:pastedFile', null)"
-      />
-      <div class="flex gap-2" :class="{ 'mt-2': pastedFile }">
+      <div v-if="pastedFiles.length > 0" class="flex flex-wrap gap-1.5 mb-1" data-testid="chat-attachment-list">
+        <ChatAttachmentPreview
+          v-for="(file, index) in pastedFiles"
+          :key="file.name + index"
+          :data-url="file.dataUrl"
+          :filename="file.name"
+          :mime="file.mime"
+          @remove="removeFileAt(index)"
+        />
+      </div>
+      <div class="flex gap-2" :class="{ 'mt-2': pastedFiles.length > 0 }">
         <textarea
           ref="textarea"
           :value="modelValue"
@@ -94,7 +97,7 @@
            filter matches ACCEPTED_MIME_PREFIXES/_EXACT below; the change
            handler routes through the same readAttachmentFile() used by
            drop + paste, so all three paths behave identically. -->
-      <input ref="fileInput" type="file" class="hidden" :accept="fileInputAccept" data-testid="file-input" @change="onFilePicked" />
+      <input ref="fileInput" type="file" multiple class="hidden" :accept="fileInputAccept" data-testid="file-input" @change="onFilePicked" />
     </div>
   </div>
 </template>
@@ -117,7 +120,7 @@ const { t } = useI18n();
 const props = withDefaults(
   defineProps<{
     modelValue: string;
-    pastedFile: PastedFile | null;
+    pastedFiles: PastedFile[];
     isRunning: boolean;
     queries?: string[];
   }>(),
@@ -126,7 +129,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
-  "update:pastedFile": [file: PastedFile | null];
+  "update:pastedFiles": [files: PastedFile[]];
   send: [];
   stop: [];
   "suggestion-send": [query: string];
@@ -139,6 +142,7 @@ const suggestionsExpanded = ref(false);
 const suggestionsBtnRef = ref<HTMLButtonElement | null>(null);
 
 const MAX_ATTACH_BYTES = 30 * 1024 * 1024;
+const MAX_ATTACHMENTS = 10;
 
 const ACCEPTED_MIME_PREFIXES = ["image/", "text/"];
 const ACCEPTED_MIME_EXACT = new Set([
@@ -163,44 +167,77 @@ function isAcceptedType(mime: string): boolean {
   return ACCEPTED_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix)) || ACCEPTED_MIME_EXACT.has(mime);
 }
 
-function readAttachmentFile(file: File): void {
-  fileError.value = null;
-  if (!isAcceptedType(file.type)) {
-    // Previously returned silently. That left the user wondering whether
-    // the drop/paste registered at all — #499.
-    fileError.value = t("chatInput.unsupportedFileType");
-    return;
-  }
+function validateFile(file: File): string | null {
+  if (!isAcceptedType(file.type)) return t("chatInput.unsupportedFileType");
   if (file.size > MAX_ATTACH_BYTES) {
     const sizeMB = (file.size / 1024 / 1024).toFixed(1);
-    fileError.value = t("chatInput.fileTooLarge", { sizeMB });
+    return t("chatInput.fileTooLarge", { sizeMB });
+  }
+  return null;
+}
+
+function readFileAsDataUrl(file: File): Promise<string | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : null);
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
+}
+
+function addFiles(files: File[]): void {
+  fileError.value = null;
+  const currentCount = props.pastedFiles.length;
+  const remainingSlots = MAX_ATTACHMENTS - currentCount;
+
+  if (files.length > remainingSlots) {
+    fileError.value = t("chatInput.tooManyFiles", { max: MAX_ATTACHMENTS });
+    if (remainingSlots <= 0) return;
+  }
+  const accepted = files.slice(0, remainingSlots);
+
+  const firstError = accepted.reduce<string | null>((err, file) => err ?? validateFile(file), null);
+  if (firstError) {
+    fileError.value = firstError;
     return;
   }
-  const reader = new FileReader();
-  reader.onload = () => {
-    if (typeof reader.result === "string") {
-      emit("update:pastedFile", {
-        dataUrl: reader.result,
-        name: file.name,
-        mime: file.type,
-      });
-    }
-  };
-  reader.readAsDataURL(file);
+
+  const pending = accepted.map(async (file) => {
+    const dataUrl = await readFileAsDataUrl(file);
+    if (!dataUrl) return null;
+    return { dataUrl, name: file.name, mime: file.type } satisfies PastedFile;
+  });
+
+  Promise.all(pending)
+    .then((results) => {
+      const valid = results.filter((result): result is PastedFile => result !== null);
+      if (valid.length > 0) {
+        emit("update:pastedFiles", [...props.pastedFiles, ...valid]);
+      }
+    })
+    .catch(() => {
+      fileError.value = t("chatInput.unsupportedFileType");
+    });
+}
+
+function removeFileAt(index: number): void {
+  const updated = props.pastedFiles.filter((_, i) => i !== index);
+  emit("update:pastedFiles", updated);
 }
 
 function onPasteFile(event: ClipboardEvent): void {
   const items = event.clipboardData?.items;
   if (!items) return;
+  const files: File[] = [];
   for (const item of items) {
     if (isAcceptedType(item.type)) {
       const file = item.getAsFile();
-      if (file) {
-        event.preventDefault();
-        readAttachmentFile(file);
-        return;
-      }
+      if (file) files.push(file);
     }
+  }
+  if (files.length > 0) {
+    event.preventDefault();
+    addFiles(files);
   }
 }
 
@@ -210,9 +247,8 @@ function openFilePicker(): void {
 
 function onFilePicked(event: Event): void {
   const input = event.target as HTMLInputElement;
-  const file = input.files?.[0];
-  if (file) readAttachmentFile(file);
-  // Reset so selecting the same file twice in a row still fires @change.
+  const files = input.files ? Array.from(input.files) : [];
+  if (files.length > 0) addFiles(files);
   input.value = "";
 }
 
@@ -280,5 +316,5 @@ function collapseSuggestions(): void {
   suggestionsExpanded.value = false;
 }
 
-defineExpose({ focus, collapseSuggestions, readFile: readAttachmentFile });
+defineExpose({ focus, collapseSuggestions, addFiles });
 </script>

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -258,6 +258,13 @@ function onFilePicked(event: Event): void {
   input.value = "";
 }
 
+watch(
+  () => props.pastedFiles.length,
+  (len) => {
+    if (len === 0) fileError.value = null;
+  },
+);
+
 const imeEnter = useImeAwareEnter(() => emit("send"));
 
 // Inline "/" command palette. Shares the lightbulb Skills tab's data store;

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -211,8 +211,14 @@ function addFiles(files: File[]): void {
   Promise.all(pending)
     .then((results) => {
       const valid = results.filter((result): result is PastedFile => result !== null);
-      if (valid.length > 0) {
-        emit("update:pastedFiles", [...props.pastedFiles, ...valid]);
+      if (valid.length === 0) return;
+      const slotsNow = MAX_ATTACHMENTS - props.pastedFiles.length;
+      const clamped = slotsNow < valid.length ? valid.slice(0, Math.max(0, slotsNow)) : valid;
+      if (clamped.length > 0) {
+        emit("update:pastedFiles", [...props.pastedFiles, ...clamped]);
+      }
+      if (clamped.length < valid.length) {
+        fileError.value = t("chatInput.tooManyFiles", { max: MAX_ATTACHMENTS });
       }
     })
     .catch(() => {

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -208,7 +208,9 @@ function emitClampedFiles(valid: PastedFile[]): void {
   }
 }
 
-function addFiles(files: File[]): void {
+let fileQueue = Promise.resolve();
+
+async function processFiles(files: File[]): Promise<void> {
   fileError.value = null;
   const accepted = clampToSlots(files);
   if (accepted.length === 0) return;
@@ -225,14 +227,19 @@ function addFiles(files: File[]): void {
     return { dataUrl, name: file.name, mime: file.type } satisfies PastedFile;
   });
 
-  Promise.all(pending)
-    .then((results) => {
-      const valid = results.filter((result): result is PastedFile => result !== null);
-      if (valid.length > 0) emitClampedFiles(valid);
-    })
-    .catch(() => {
-      fileError.value = t("chatInput.unsupportedFileType");
-    });
+  try {
+    const results = await Promise.all(pending);
+    const valid = results.filter((result): result is PastedFile => result !== null);
+    if (valid.length > 0) emitClampedFiles(valid);
+  } catch {
+    fileError.value = t("chatInput.unsupportedFileType");
+  }
+
+  await nextTick();
+}
+
+function addFiles(files: File[]): void {
+  fileQueue = fileQueue.then(() => processFiles(files));
 }
 
 function removeFileAt(index: number): void {

--- a/src/composables/useFileDropZone.ts
+++ b/src/composables/useFileDropZone.ts
@@ -32,10 +32,7 @@ export interface UseFileDropZoneResult extends FileDropHandlers {
 }
 
 export interface UseFileDropZoneOptions {
-  /** Called when the user releases a file over the zone. The
-   *  composable picks `files[0]` (first file) and ignores the rest;
-   *  multi-file uploads are not a current product requirement. */
-  onFile: (file: File) => void;
+  onFiles: (files: File[]) => void;
 }
 
 // Module-scope so the install-once contract holds across multiple
@@ -105,8 +102,8 @@ export function useFileDropZone(opts: UseFileDropZoneOptions): UseFileDropZoneRe
     if (!isFileDrag(event)) return;
     event.preventDefault();
     resetTerminal();
-    const file = event.dataTransfer?.files[0];
-    if (file) opts.onFile(file);
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) opts.onFiles(Array.from(files));
   }
 
   function resetTerminal(): void {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -39,6 +39,7 @@ const deMessages = {
     attachImageFailed: "Anhängen des Bildes fehlgeschlagen: {error}",
     stopFailed: "Stoppen der Ausführung fehlgeschlagen: {error}",
     dropHint: "Datei zum Anhängen ablegen",
+    tooManyFiles: "Sie können maximal {max} Dateien gleichzeitig anhängen.",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -40,6 +40,7 @@ const deMessages = {
     stopFailed: "Stoppen der Ausführung fehlgeschlagen: {error}",
     dropHint: "Datei zum Anhängen ablegen",
     tooManyFiles: "Sie können maximal {max} Dateien gleichzeitig anhängen.",
+    removeAttachment: "{name} entfernen",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -41,6 +41,7 @@ const deMessages = {
     dropHint: "Datei zum Anhängen ablegen",
     tooManyFiles: "Sie können maximal {max} Dateien gleichzeitig anhängen.",
     removeAttachment: "{name} entfernen",
+    attachmentFallbackName: "Anhang",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -61,6 +61,7 @@ const enMessages = {
     attachImageFailed: "Failed to attach image: {error}",
     stopFailed: "Failed to stop the run: {error}",
     dropHint: "Drop file to attach",
+    tooManyFiles: "You can attach up to {max} files at once.",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -62,6 +62,7 @@ const enMessages = {
     stopFailed: "Failed to stop the run: {error}",
     dropHint: "Drop file to attach",
     tooManyFiles: "You can attach up to {max} files at once.",
+    removeAttachment: "Remove {name}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -63,6 +63,7 @@ const enMessages = {
     dropHint: "Drop file to attach",
     tooManyFiles: "You can attach up to {max} files at once.",
     removeAttachment: "Remove {name}",
+    attachmentFallbackName: "attachment",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -44,6 +44,7 @@ const esMessages = {
     attachImageFailed: "No se pudo adjuntar la imagen: {error}",
     stopFailed: "No se pudo detener la ejecución: {error}",
     dropHint: "Suelta el archivo para adjuntar",
+    tooManyFiles: "Puedes adjuntar hasta {max} archivos a la vez.",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -45,6 +45,7 @@ const esMessages = {
     stopFailed: "No se pudo detener la ejecución: {error}",
     dropHint: "Suelta el archivo para adjuntar",
     tooManyFiles: "Puedes adjuntar hasta {max} archivos a la vez.",
+    removeAttachment: "Quitar {name}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -46,6 +46,7 @@ const esMessages = {
     dropHint: "Suelta el archivo para adjuntar",
     tooManyFiles: "Puedes adjuntar hasta {max} archivos a la vez.",
     removeAttachment: "Quitar {name}",
+    attachmentFallbackName: "archivo adjunto",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -39,6 +39,7 @@ const frMessages = {
     attachImageFailed: "Échec de l'attache de l'image : {error}",
     stopFailed: "Échec de l'arrêt du traitement : {error}",
     dropHint: "Déposez le fichier pour joindre",
+    tooManyFiles: "Vous pouvez joindre jusqu'à {max} fichiers à la fois.",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -40,6 +40,7 @@ const frMessages = {
     stopFailed: "Échec de l'arrêt du traitement : {error}",
     dropHint: "Déposez le fichier pour joindre",
     tooManyFiles: "Vous pouvez joindre jusqu'à {max} fichiers à la fois.",
+    removeAttachment: "Retirer {name}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -41,6 +41,7 @@ const frMessages = {
     dropHint: "Déposez le fichier pour joindre",
     tooManyFiles: "Vous pouvez joindre jusqu'à {max} fichiers à la fois.",
     removeAttachment: "Retirer {name}",
+    attachmentFallbackName: "pièce jointe",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -46,6 +46,7 @@ const jaMessages = {
     attachImageFailed: "画像の添付に失敗しました: {error}",
     stopFailed: "処理の停止に失敗しました: {error}",
     dropHint: "ファイルをドロップして添付",
+    tooManyFiles: "一度に添付できるのは {max} 件までです。",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -48,6 +48,7 @@ const jaMessages = {
     dropHint: "ファイルをドロップして添付",
     tooManyFiles: "一度に添付できるのは {max} 件までです。",
     removeAttachment: "{name} を削除",
+    attachmentFallbackName: "添付ファイル",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -47,6 +47,7 @@ const jaMessages = {
     stopFailed: "処理の停止に失敗しました: {error}",
     dropHint: "ファイルをドロップして添付",
     tooManyFiles: "一度に添付できるのは {max} 件までです。",
+    removeAttachment: "{name} を削除",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -46,6 +46,7 @@ const koMessages = {
     attachImageFailed: "이미지를 첨부하지 못했습니다: {error}",
     stopFailed: "처리를 중지하지 못했습니다: {error}",
     dropHint: "파일을 놓아서 첨부",
+    tooManyFiles: "한 번에 최대 {max}개까지 첨부할 수 있습니다.",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -48,6 +48,7 @@ const koMessages = {
     dropHint: "파일을 놓아서 첨부",
     tooManyFiles: "한 번에 최대 {max}개까지 첨부할 수 있습니다.",
     removeAttachment: "{name} 제거",
+    attachmentFallbackName: "첨부파일",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -47,6 +47,7 @@ const koMessages = {
     stopFailed: "처리를 중지하지 못했습니다: {error}",
     dropHint: "파일을 놓아서 첨부",
     tooManyFiles: "한 번에 최대 {max}개까지 첨부할 수 있습니다.",
+    removeAttachment: "{name} 제거",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -39,6 +39,7 @@ const ptBRMessages = {
     attachImageFailed: "Falha ao anexar a imagem: {error}",
     stopFailed: "Falha ao parar a execução: {error}",
     dropHint: "Solte o arquivo para anexar",
+    tooManyFiles: "Você pode anexar no máximo {max} arquivos por vez.",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -41,6 +41,7 @@ const ptBRMessages = {
     dropHint: "Solte o arquivo para anexar",
     tooManyFiles: "Você pode anexar no máximo {max} arquivos por vez.",
     removeAttachment: "Remover {name}",
+    attachmentFallbackName: "anexo",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -40,6 +40,7 @@ const ptBRMessages = {
     stopFailed: "Falha ao parar a execução: {error}",
     dropHint: "Solte o arquivo para anexar",
     tooManyFiles: "Você pode anexar no máximo {max} arquivos por vez.",
+    removeAttachment: "Remover {name}",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -44,6 +44,7 @@ const zhMessages = {
     attachImageFailed: "附加图片失败：{error}",
     stopFailed: "停止处理失败：{error}",
     dropHint: "拖放文件以附加",
+    tooManyFiles: "一次最多可附加 {max} 个文件。",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -46,6 +46,7 @@ const zhMessages = {
     dropHint: "拖放文件以附加",
     tooManyFiles: "一次最多可附加 {max} 个文件。",
     removeAttachment: "移除 {name}",
+    attachmentFallbackName: "附件",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -45,6 +45,7 @@ const zhMessages = {
     stopFailed: "停止处理失败：{error}",
     dropHint: "拖放文件以附加",
     tooManyFiles: "一次最多可附加 {max} 个文件。",
+    removeAttachment: "移除 {name}",
   },
   sessionHistoryPanel: {
     filters: {


### PR DESCRIPTION
## Summary

チャット入力の添付ファイルを1件から最大10件に拡張（フロントエンドのみの変更）。

- サーバー側（`POST /api/attachments` によるアップロード、`POST /api/agent` の `attachments[]` 配列）は**既に複数ファイルに対応済み**だったため、バックエンドの変更はなし
- 今回の変更はフロントエンド UI 層のみ: 単一ファイル前提だった state・props・イベントハンドラを配列ベースに拡張
- ファイルピッカー・ペースト・ドラッグ＆ドロップの3経路すべてで複数ファイルに対応し、送信時は並列アップロード
- 11件以上の添付を試みると警告バナーを表示（超過分はカットして残りを追加）
- 連続ドロップによる race condition 対策として、非同期読み込み完了時にも上限を再チェック

<img width="337" height="211" alt="image" src="https://github.com/user-attachments/assets/e659596c-2cf5-47bb-b13f-9055828a10ab" />


<img width="536" height="476" alt="CleanShot 2026-06-09 at 15 32 12" src="https://github.com/user-attachments/assets/dcdb4be5-e447-4514-bd0d-e57f517c569e" />


## Items to Confirm / Review

- 10件 × 30MB の同時添付によるブラウザメモリ負荷は既存の単一ファイル設計と同じ per-request サイズだが、実用上問題があれば aggregate cap を follow-up で追加
- ChatInput のユニットテスト基盤が未整備のため、テストは別 PR で対応予定

## User Prompt

チャット欄の添付ファイルを1つから複数に拡張したい。用途は複数画像の一括読み取り。上限は10件、11件以上は警告を出す。

## 変更内容

### `ChatInput.vue`
- `pastedFile: PastedFile | null` → `pastedFiles: PastedFile[]`
- `<input type="file">` に `multiple` 属性追加
- `addFiles()`: 複数ファイルの検証・FileReader 読み込み・上限チェックを一括処理
- `removeFileAt(index)`: 個別削除
- Promise.all 完了時に `MAX_ATTACHMENTS` で再クランプ（race condition 対策）
- `pastedFiles` が空になったら `fileError` を自動クリア

### `ChatAttachmentPreview.vue`
- ✕ ボタンに `aria-label` / `title` を追加（ファイル名付き、空名時はローカライズ済み fallback）

### `useFileDropZone.ts`
- `onFile(file: File)` → `onFiles(files: File[])` でドロップ時に全ファイルを渡す

### `App.vue`
- `pastedFile` → `pastedFiles` 配列に変更
- 送信時に `Promise.all` で全ファイルを並列アップロード、1件でも失敗したら全復元

### i18n（8言語）
- `tooManyFiles`: 上限超過時の警告メッセージ
- `removeAttachment`: ✕ ボタンの aria-label
- `attachmentFallbackName`: 空ファイル名時の fallback

## Codex Cross-Review

3 iteration で収束。
- Iteration 1: race condition 修正、aria-label 追加
- Iteration 2: fallback name ローカライズ
- Iteration 3: LGTM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple file attachments per message (up to 10) with paste, pick (multi-select), and drag‑drop support; attachment previews list and add/remove controls.

* **Bug Fixes / Reliability**
  * Send flow validates and resolves all attachments as a batch; on failure input and attachments are restored and clear errors are shown.

* **Localization**
  * New i18n strings for attachment limits, removal labels, and fallback names; attachment UI uses localized labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->