### PR TITLE
fix(collections): colour day-view chips by enum, including all-day items

### DIFF
--- a/e2e/tests/collection-calendar.spec.ts
+++ b/e2e/tests/collection-calendar.spec.ts
@@ -106,6 +106,35 @@ const DTEVENTS = {
   items: [{ id: "kickoff", name: "Kickoff", at: `${MID}T14:30` }],
 };
 
+// A date + enum collection: the enum is the colour field, so chips on every
+// calendar surface (month grid AND the day view, timed or all-day) tint by the
+// value's palette colour. No time field → every record sits in the day view's
+// all-day strip, which must carry the colour just like the timed chips.
+const COLORED = {
+  collection: {
+    slug: "colored-events",
+    title: "Colored",
+    icon: "event",
+    source: "user",
+    schema: {
+      title: "Colored",
+      icon: "event",
+      dataPath: "data/colored-events/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+        on: { type: "date", label: "Date" },
+        status: { type: "enum", label: "Status", values: ["todo", "doing", "done"] },
+      },
+      displayField: "name",
+      calendarField: "on",
+    },
+  },
+  // "doing" is enum index 1 → the sky palette entry (badge `bg-sky-100`).
+  items: [{ id: "review", name: "Review", on: MID, status: "doing" }],
+};
+
 // A collection with NO date field — must never show the calendar toggle.
 const CONTACTS = {
   collection: {
@@ -147,6 +176,10 @@ async function mockCollections(page: Page): Promise<void> {
   await page.route(
     (url) => url.pathname === "/api/collections/contacts",
     (route) => route.fulfill({ json: CONTACTS }),
+  );
+  await page.route(
+    (url) => url.pathname === "/api/collections/colored-events",
+    (route) => route.fulfill({ json: COLORED }),
   );
 }
 
@@ -317,6 +350,24 @@ test.describe("collection calendar view", () => {
     await expect(page.getByTestId("collection-day-view")).toBeVisible();
     await expect(page.getByTestId("collection-day-view-detail")).toBeVisible();
     await expect(page.getByTestId("collections-detail-title")).toHaveText("block");
+  });
+
+  test("day view all-day chips carry the enum colour, not the slate default", async ({ page }) => {
+    await page.goto("/collections/colored-events");
+    await page.getByTestId("collection-view-toggle-calendar").click();
+    // Open the day via keyboard so the click doesn't land on (and select) the
+    // record's chip — an unselected chip shows its palette colour.
+    const cell = page.getByTestId(`collection-calendar-day-${MID}`);
+    await cell.focus();
+    await cell.press("Enter");
+    await expect(page.getByTestId("collection-day-view")).toBeVisible();
+    // The record has no time field → it lands in the all-day strip. Its enum
+    // value "doing" (palette index 1 → sky) must tint the chip; before the fix
+    // the all-day strip was hardcoded slate, dropping the colour.
+    const chip = page.getByTestId("collection-day-view-allday-review");
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveClass(/bg-sky-100/);
+    await expect(chip).not.toHaveClass(/bg-slate-50/);
   });
 
   test("day-view create on a datetime-anchored collection prefills a valid datetime", async ({ page }) => {

--- a/src/components/CollectionDayView.vue
+++ b/src/components/CollectionDayView.vue
@@ -64,11 +64,7 @@
                 :key="entry.id"
                 type="button"
                 class="absolute overflow-hidden rounded border px-1.5 py-0.5 text-left transition-colors"
-                :class="
-                  entry.id === selected
-                    ? 'bg-indigo-600 text-white border-indigo-600 z-10'
-                    : 'bg-indigo-50 text-indigo-700 border-indigo-200 hover:bg-indigo-100'
-                "
+                :class="timedChipClass(entry)"
                 :style="entry.style"
                 :data-testid="`collection-day-view-chip-${entry.id}`"
                 @click="onSelect(entry.id)"
@@ -97,7 +93,7 @@
             :key="entry.id"
             type="button"
             class="truncate rounded border px-1.5 py-0.5 text-[11px] font-semibold transition-colors"
-            :class="entry.id === selected ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100'"
+            :class="allDayChipClass(entry)"
             :data-testid="`collection-day-view-allday-${entry.id}`"
             @click="onSelect(entry.id)"
           >
@@ -120,6 +116,7 @@
 import { computed, nextTick, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { bucketRecords, daySlice, assignLanes, ymdKey, MINUTES_PER_DAY, type Ymd, type DaySlice } from "../utils/collections/calendarGrid";
+import { resolveEnumColor, type EnumColorClasses } from "../utils/collections/enumColors";
 import { labelFieldFor, itemIdOf, itemLabelOf } from "../utils/collections/itemLabel";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
@@ -130,6 +127,9 @@ const props = defineProps<{
   anchorField: string;
   endField?: string;
   timeField?: string;
+  /** Optional `enum` field tinting each chip by its value's palette colour
+   *  (matching the month view). Empty / unset → default indigo/slate styling. */
+  colorField?: string;
   selected?: string;
   canCreate: boolean;
   /** When true, expand the modal to two columns and render the `#detail`
@@ -203,7 +203,16 @@ interface DayEntry {
   id: string;
   label: string;
   secondary: string[];
+  /** Resolved chip colour from the record's `colorField` value, or null when
+   *  no colour field is set → default styling. */
+  color: EnumColorClasses | null;
   slice: DaySlice;
+}
+
+/** A record's chip colour from its `colorField` value (palette, or
+ *  notification red/amber/grey on a notification enum); null when unset. */
+function colorOf(item: CollectionItem): EnumColorClasses | null {
+  return props.colorField ? resolveEnumColor(props.schema, props.colorField, item[props.colorField]) : null;
 }
 
 // Every record whose span covers this day, projected onto it.
@@ -217,6 +226,7 @@ const dayEntries = computed<DayEntry[]>(() => {
       id: itemIdOf(span.item, props.schema),
       label: itemLabelOf(span.item, props.schema, labelField.value),
       secondary: secondaryFieldsOf(span.item),
+      color: colorOf(span.item),
       slice,
     });
   }
@@ -249,6 +259,26 @@ const timedEntries = computed<TimedEntry[]>(() => {
     };
   });
 });
+
+// Chip styling. The selected chip keeps the solid indigo highlight; otherwise
+// a record with a resolved colour tints the chip (palette badge + border), and
+// one with none (no colour field) falls back to the kind's default — indigo on
+// the timeline, slate in the all-day strip. Mirrors the month view's
+// `chipClass` so the two surfaces colour records identically.
+const TIMED_DEFAULT = "bg-indigo-50 text-indigo-700 border-indigo-200 hover:bg-indigo-100";
+const ALL_DAY_DEFAULT = "bg-slate-50 text-slate-600 border-slate-200 hover:bg-slate-100";
+
+function timedChipClass(entry: DayEntry): string {
+  if (entry.id === props.selected) return "bg-indigo-600 text-white border-indigo-600 z-10";
+  if (!entry.color) return TIMED_DEFAULT;
+  return `${entry.color.badge} ${entry.color.border} hover:brightness-95`;
+}
+
+function allDayChipClass(entry: DayEntry): string {
+  if (entry.id === props.selected) return "bg-indigo-600 text-white border-indigo-600";
+  if (!entry.color) return ALL_DAY_DEFAULT;
+  return `${entry.color.badge} ${entry.color.border} hover:brightness-95`;
+}
 
 // Select a record: report it to the host (which shows it in the right pane).
 // Unlike before, the modal stays open so the timeline and detail sit

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -247,6 +247,7 @@
           :anchor-field="calendarAnchorField"
           :end-field="calendarEndField"
           :time-field="calendarTimeField"
+          :color-field="hasKanban ? kanbanGroupField : ''"
           :selected="viewing ? String(viewing[collection.schema.primaryKey] ?? '') : undefined"
           :can-create="canCreate"
           :show-detail="Boolean(viewing || editing)"


### PR DESCRIPTION
## Problem

In the calendar **day (time-allocation) view**, items **without a time field** — the all-day strip — rendered colourless/grey, while every other chip looked tinted.

Root cause: the month calendar tints each chip by the enum colour field (`resolveEnumColor`), but `CollectionDayView` was never wired for it. Its timeline chips were hardcoded indigo and its all-day strip hardcoded slate, so the day view ignored the palette entirely.

## Fix

- Pass `:color-field="hasKanban ? kanbanGroupField : ''"` into `<CollectionDayView>` (the same expression the month view already uses).
- In `CollectionDayView`, add the `colorField` prop + a `colorOf()` resolver, attach each entry's resolved palette colour, and apply it to **both** the timeline chips and the all-day strip via `timedChipClass` / `allDayChipClass`.
- Selected chips keep the solid-indigo highlight; collections with no enum field fall back to the prior indigo/slate defaults.

This mirrors the month view's `chipClass`, so both surfaces colour records identically.

## Testing

- `format` / `lint` / `typecheck` / `build` — clean
- Calendar e2e — **18 passed**, including a new test asserting an all-day chip carries its enum palette colour (`bg-sky-100`, not the slate default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calendar events now display with colors based on their status enum field. All-day events render with the appropriate color in the day view.

* **Tests**
  * Added end-to-end tests verifying colored event display in the calendar day view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->