### PR TITLE
feat: add claude.ai connector config link to settings

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -127,7 +127,13 @@
                   </li>
                 </ul>
                 <div v-else class="text-xs text-gray-400">{{ t("settingsToolsTab.connectorsEmpty") }}</div>
-                <p class="text-xs text-gray-500">{{ t("settingsToolsTab.connectorsGuide") }}</p>
+                <i18n-t keypath="settingsToolsTab.connectorsGuide" tag="p" class="text-xs text-gray-500">
+                  <template #configLink>
+                    <a href="https://claude.ai/customize/connectors" target="_blank" rel="noopener noreferrer" class="text-blue-500 underline">{{
+                      t("settingsToolsTab.connectorsConfigLinkText")
+                    }}</a>
+                  </template>
+                </i18n-t>
               </div>
             </div>
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1169,7 +1169,8 @@ const deMessages = {
     connectorConnected: "Verbunden",
     connectorDisconnected: "Nicht verbunden",
     connectorsGuide:
-      "Konnektoren wie Slack und Gmail erlauben Claude den Zugriff auf Ihre Konten. Konnektoren werden in Claude Desktop hinzugefügt oder entfernt.",
+      "Konnektoren wie Slack und Gmail erlauben Claude den Zugriff auf Ihre Konten. Konnektoren können in Claude Desktop oder {configLink} hinzugefügt oder entfernt werden. (Öffnet claude.ai)",
+    connectorsConfigLinkText: "hier",
   },
   collectionsView: {
     addCollectionLabel: "Sammlung",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1152,7 +1152,9 @@ const enMessages = {
     connectorsEmpty: "No connectors found.",
     connectorConnected: "Connected",
     connectorDisconnected: "Not connected",
-    connectorsGuide: "Connectors like Slack and Gmail let Claude access your accounts. Add or remove connectors from Claude Desktop.",
+    connectorsGuide:
+      "Connectors like Slack and Gmail let Claude access your accounts. Add or remove connectors from Claude Desktop, or configure them {configLink}. (Opens claude.ai)",
+    connectorsConfigLinkText: "here",
   },
   collectionsView: {
     addCollectionLabel: "Collection",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1165,7 +1165,9 @@ const esMessages = {
     connectorsEmpty: "No se encontraron conectores.",
     connectorConnected: "Conectado",
     connectorDisconnected: "No conectado",
-    connectorsGuide: "Los conectores como Slack y Gmail permiten a Claude acceder a tus cuentas. Agrega o elimina conectores desde Claude Desktop.",
+    connectorsGuide:
+      "Los conectores como Slack y Gmail permiten a Claude acceder a tus cuentas. Agrega o elimina conectores desde Claude Desktop o configúralos {configLink}. (Abre claude.ai)",
+    connectorsConfigLinkText: "aquí",
   },
   collectionsView: {
     addCollectionLabel: "Colección",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1158,7 +1158,8 @@ const frMessages = {
     connectorConnected: "Connecté",
     connectorDisconnected: "Non connecté",
     connectorsGuide:
-      "Les connecteurs comme Slack et Gmail permettent à Claude d'accéder à vos comptes. Ajoutez ou supprimez des connecteurs depuis Claude Desktop.",
+      "Les connecteurs comme Slack et Gmail permettent à Claude d'accéder à vos comptes. Ajoutez ou supprimez des connecteurs depuis Claude Desktop ou configurez-les {configLink}. (Ouvre claude.ai)",
+    connectorsConfigLinkText: "ici",
   },
   collectionsView: {
     addCollectionLabel: "Collection",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1148,7 +1148,9 @@ const jaMessages = {
     connectorsEmpty: "コネクタが見つかりません。",
     connectorConnected: "接続済み",
     connectorDisconnected: "未接続",
-    connectorsGuide: "Slack や Gmail 等のコネクタで Claude がアカウントにアクセスできるようになります。追加・削除は Claude Desktop から行えます。",
+    connectorsGuide:
+      "Slack や Gmail 等のコネクタで Claude がアカウントにアクセスできるようになります。追加・削除は Claude Desktop から、または、{configLink}からも設定できます。（Web 版 claude.ai に移動します）",
+    connectorsConfigLinkText: "こちら",
   },
   collectionsView: {
     addCollectionLabel: "コレクション",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1152,7 +1152,9 @@ const koMessages = {
     connectorsEmpty: "커넥터를 찾을 수 없습니다.",
     connectorConnected: "연결됨",
     connectorDisconnected: "연결 안 됨",
-    connectorsGuide: "Slack, Gmail 등의 커넥터로 Claude가 계정에 접근할 수 있습니다. 커넥터 추가 및 제거는 Claude Desktop에서 할 수 있습니다.",
+    connectorsGuide:
+      "Slack, Gmail 등의 커넥터로 Claude가 계정에 접근할 수 있습니다. 커넥터 추가 및 제거는 Claude Desktop 또는 {configLink}에서 할 수 있습니다. (claude.ai로 이동합니다)",
+    connectorsConfigLinkText: "여기",
   },
   collectionsView: {
     addCollectionLabel: "컬렉션",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1154,7 +1154,9 @@ const ptBRMessages = {
     connectorsEmpty: "Nenhum conector encontrado.",
     connectorConnected: "Conectado",
     connectorDisconnected: "Não conectado",
-    connectorsGuide: "Conectores como Slack e Gmail permitem que o Claude acesse suas contas. Adicione ou remova conectores pelo Claude Desktop.",
+    connectorsGuide:
+      "Conectores como Slack e Gmail permitem que o Claude acesse suas contas. Adicione ou remova conectores pelo Claude Desktop ou configure-os {configLink}. (Abre claude.ai)",
+    connectorsConfigLinkText: "aqui",
   },
   collectionsView: {
     addCollectionLabel: "Coleção",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1141,7 +1141,9 @@ const zhMessages = {
     connectorsEmpty: "未找到连接器。",
     connectorConnected: "已连接",
     connectorDisconnected: "未连接",
-    connectorsGuide: "Slack、Gmail 等连接器让 Claude 可以访问您的账户。请在 Claude Desktop 中添加或移除连接器。",
+    connectorsGuide:
+      "Slack、Gmail 等连接器让 Claude 可以访问您的账户。请在 Claude Desktop 中添加或移除连接器，也可以在{configLink}进行配置。（将打开 claude.ai）",
+    connectorsConfigLinkText: "此处",
   },
   collectionsView: {
     addCollectionLabel: "集合",


### PR DESCRIPTION
## Summary

#1659 のフォローアップ: コネクタのガイドテキストに https://claude.ai/customize/connectors へのリンクを追加。ユーザーが Claude Desktop 以外からもコネクタを設定できることを案内する。

- `connectorsGuide` テキストにリンクを統合（「…Claude Desktop から、または、こちらからも設定できます。」）
- リンク先が外部サイトであることを明示する注記を追加（「Web 版 claude.ai に移動します」）
- `<i18n-t>` + スロットでリンク部分をレンダリング
- 全 8 言語（en / ja / zh / ko / es / pt-BR / fr / de）を更新

<img width="1366" height="530" alt="CleanShot 2026-06-09 at 16 40 31@2x" src="https://github.com/user-attachments/assets/3a638465-bbb8-4d16-a0c3-fdd9cd5528fd" />

## Items to Confirm / Review

- リンクテキストの各言語翻訳が自然かどうか

## User Prompt

- #1659 で追加したコネクタの説明に、https://claude.ai/customize/connectors で設定できる旨を追加したい
- 「追加・削除は Claude Desktop から、または、こちらからも設定できます。（Web 版 claude.ai に移動します）」の形式

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the connectors guide in Settings to include a direct link to Claude's connector configuration page.
  * Enhanced multilingual support with localized link text across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->