### PR TITLE
feat(files): inline Marp source editor in File Explorer

### DIFF
--- a/plans/feat-file-explorer-marp-edit.md
+++ b/plans/feat-file-explorer-marp-edit.md
@@ -1,0 +1,56 @@
+# feat(files): File Explorer から Marp md を編集できるようにする
+
+Issue: receptron/mulmoclaude#1651
+
+## 背景 / スコープ
+
+- `/files/...` 経路は `FileContentRenderer.vue` で render される
+- **非 Marp md** は既に `TextResponseView` 経由で inline 編集できる (Apply で `updateSource` emit → `FilesView` の `saveRawMarkdown` で PUT)
+- **Marp md は read-only** — preview のみ。chat plugin 経路 (#1647) では split mode で編集可能だが、File Explorer 経路では編集手段なし
+- 本 PR では **FileContentRenderer の Marp 分岐に編集機能** を追加
+
+#1651 のもう一つの side (非 Marp md は File Explorer で編集可能か) は既存実装で OK なので、本 PR の作業は **Marp branch のみ**。
+
+## 設計
+
+JSON editor の既存パターン (`jsonEditing` / `jsonDraft` / `startJsonEdit` / `cancelJsonEdit` / `saveJsonEdit`) を踏襲:
+
+| 項目 | 値 |
+|---|---|
+| トグル UI | MarpView の toolbar slot に "Edit" ボタン |
+| layout (編集中) | 左 = textarea / 右 = MarpView (draft をライブ反映) |
+| 編集確定 | `updateSource` emit → `FilesView` が PUT |
+| Cancel | 編集破棄 + MarpView preview を `content.content` に戻す |
+| 編集中の navigation | content change watcher で `marpEditing = false` |
+| 失敗時 | `rawSaveError` を表示 (既存パターン) |
+
+レイアウトは #1647 の split mode と同じ inline-style 戦術:
+- `style="height: min(80vh, 720px); display: flex; overflow: hidden"`
+- 左 column: `flex: 1 1 50%; min-height: 0; min-width: 0`
+- 右 column: 同 + `overflow-y: auto`
+- textarea: `flex: 1 1 0; min-height: 0`
+
+FileContentRenderer は StackView 配下にないので `.stack-natural` の override は当たらないが、念の為 inline style で統一しておくと挙動が読みやすい。
+
+## 触るファイル
+
+- `src/components/FileContentRenderer.vue` — Marp 分岐に編集 UI 追加
+- `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts` — i18n keys 追加 (`editMarp`, `marpEditorLabel`)
+
+## 受け入れ基準
+
+- [ ] File Explorer で Marp `.md` を開くと "Edit slide source" ボタンが MarpView toolbar に出る
+- [ ] クリックで split mode (左 textarea / 右 preview) に入る
+- [ ] textarea 編集で preview がリアルタイム反映
+- [ ] Save で disk 反映 + preview-only に戻る
+- [ ] Cancel で破棄 + preview-only
+- [ ] 編集中の別 file 切替で edit mode 解除
+- [ ] 非 Marp md / JSON edit / HTML / その他 file type に regression なし
+- [ ] 8 locale i18n 追加
+- [ ] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass
+
+## 非ゴール (別 issue)
+
+- `markdown plugin View.vue` の split mode との共通コンポーネント化 — 動作確認できたら follow-up で抽出
+- CodeMirror / Monaco syntax highlight
+- WYSIWYG — #1650

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -16,13 +16,75 @@
              component. Frontmatter envelope is fed to Marp verbatim
              because marp-core consumes its own directives (theme,
              paginate, size, …) from the YAML header. -->
-        <div v-if="isMarkdown && !mdRawMode && marpMode" class="h-full flex flex-col overflow-y-auto">
-          <!-- `m-auto` centres a short MarpView vertically in the file-
-               pane canvas (same pattern as View.vue's marp branch). -->
-          <div class="m-auto w-full">
-            <MarpView :markdown="content.content" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
+        <template v-if="isMarkdown && !mdRawMode && marpMode">
+          <!-- Edit mode: split view — left textarea / right MarpView,
+               with the draft buffer feeding both. Inline styles mirror
+               the markdown plugin's split mode (#1647) so the textarea
+               can actually fill the column even when the plugin renders
+               inside a layout wrapper that quietly neutralises Tailwind
+               sizing utilities. -->
+          <div v-if="marpEditing" style="height: min(80vh, 720px); display: flex; overflow: hidden">
+            <div style="display: flex; flex-direction: column; flex: 1 1 50%; min-width: 0; min-height: 0; border-right: 1px solid #e0e0e0">
+              <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+                <span class="text-xs text-gray-500 mr-auto">{{ t("fileContentRenderer.marpEditorLabel") }}</span>
+                <button
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                  data-testid="files-marp-cancel-btn"
+                  @click="cancelMarpEdit"
+                >
+                  {{ t("common.cancel") }}
+                </button>
+                <button
+                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-green-600 hover:bg-green-700 text-white"
+                  data-testid="files-marp-save-btn"
+                  @click="saveMarpEdit"
+                >
+                  <span class="material-icons text-sm" aria-hidden="true">save</span>
+                  {{ t("common.save") }}
+                </button>
+              </div>
+              <textarea
+                v-model="marpDraft"
+                class="w-full p-4 font-mono text-sm bg-white border-0 resize-none focus:outline-none"
+                style="flex: 1 1 0; min-height: 0"
+                spellcheck="false"
+                :aria-label="t('fileContentRenderer.marpEditorLabel')"
+              ></textarea>
+            </div>
+            <div style="flex: 1 1 50%; min-width: 0; min-height: 0; overflow-y: auto">
+              <MarpView :markdown="marpDraft" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
+            </div>
           </div>
-        </div>
+          <!-- Preview-only mode (default). `m-auto` centres a short
+               MarpView vertically in the file-pane canvas (same pattern
+               as View.vue's marp branch). -->
+          <div v-else class="h-full flex flex-col overflow-y-auto">
+            <div class="m-auto w-full">
+              <MarpView :markdown="content.content" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir">
+                <template #toolbar>
+                  <button
+                    class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 text-sm"
+                    :title="t('fileContentRenderer.editMarp')"
+                    :aria-label="t('fileContentRenderer.editMarp')"
+                    data-testid="files-marp-edit-btn"
+                    @click="startMarpEdit"
+                  >
+                    <span class="material-icons text-sm" aria-hidden="true">edit</span>
+                    {{ t("fileContentRenderer.editMarp") }}
+                  </button>
+                </template>
+              </MarpView>
+            </div>
+          </div>
+          <div
+            v-if="rawSaveError"
+            class="shrink-0 m-4 mt-0 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-700"
+            role="alert"
+            data-testid="files-marp-save-error"
+          >
+            ⚠ {{ rawSaveError }}
+          </div>
+        </template>
         <!-- Markdown rendered: frontmatter panel + body -->
         <div v-else-if="isMarkdown && !mdRawMode" class="h-full flex flex-col overflow-auto">
           <div v-if="mdFrontmatter && mdFrontmatter.fields.length > 0" class="shrink-0 m-4 mb-0 rounded border border-gray-200 bg-gray-50 p-3 text-xs">
@@ -283,6 +345,29 @@ function saveJsonEdit(): void {
   emit("updateSource", jsonDraft.value);
 }
 
+// Inline Marp source editor (#1651). Mirrors the JSON edit flow:
+// `marpEditing` flips the marp branch into split mode, `marpDraft`
+// holds the unsaved buffer that drives the live preview, Save emits
+// `updateSource`. Leaving edit mode on content change handles both
+// the success path (parent swaps content + clears rawSaveError) and
+// navigation to another file.
+const marpEditing = ref(false);
+const marpDraft = ref("");
+
+function startMarpEdit(): void {
+  if (props.content?.kind !== "text") return;
+  marpDraft.value = props.content.content;
+  marpEditing.value = true;
+}
+
+function cancelMarpEdit(): void {
+  marpEditing.value = false;
+}
+
+function saveMarpEdit(): void {
+  emit("updateSource", marpDraft.value);
+}
+
 // Leave edit mode whenever the underlying content changes — that's
 // either a successful save (parent swaps in the new content + clears
 // rawSaveError) or navigation to another file. A failed save leaves
@@ -292,6 +377,7 @@ watch(
   () => props.content,
   () => {
     jsonEditing.value = false;
+    marpEditing.value = false;
   },
 );
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -338,6 +338,8 @@ const deMessages = {
     invalidJson: "Ungültiges JSON",
     undo: "Rückgängig",
     redo: "Wiederholen",
+    editMarp: "Folienquelle bearbeiten",
+    marpEditorLabel: "Marp-Folienquelle",
   },
   filesView: {
     chatPlaceholder: "Frage zu dieser Datei stellen…",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -354,6 +354,8 @@ const enMessages = {
     invalidJson: "Invalid JSON",
     undo: "Undo",
     redo: "Redo",
+    editMarp: "Edit slide source",
+    marpEditorLabel: "Marp slide source",
   },
   filesView: {
     chatPlaceholder: "Ask about this file…",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -341,6 +341,8 @@ const esMessages = {
     invalidJson: "JSON no válido",
     undo: "Deshacer",
     redo: "Rehacer",
+    editMarp: "Editar fuente de la diapositiva",
+    marpEditorLabel: "Fuente de diapositivas Marp",
   },
   filesView: {
     chatPlaceholder: "Pregunta sobre este archivo…",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -335,6 +335,8 @@ const frMessages = {
     invalidJson: "JSON invalide",
     undo: "Annuler",
     redo: "Rétablir",
+    editMarp: "Modifier la source de la diapositive",
+    marpEditorLabel: "Source des diapositives Marp",
   },
   filesView: {
     chatPlaceholder: "Posez une question sur ce fichier…",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -337,6 +337,8 @@ const jaMessages = {
     invalidJson: "不正な JSON",
     undo: "元に戻す",
     redo: "やり直し",
+    editMarp: "スライドソースを編集",
+    marpEditorLabel: "Marp スライドソース",
   },
   filesView: {
     chatPlaceholder: "このファイルについて質問…",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -339,6 +339,8 @@ const koMessages = {
     invalidJson: "잘못된 JSON",
     undo: "실행 취소",
     redo: "다시 실행",
+    editMarp: "슬라이드 소스 편집",
+    marpEditorLabel: "Marp 슬라이드 소스",
   },
   filesView: {
     chatPlaceholder: "이 파일에 대해 질문하세요…",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -334,6 +334,8 @@ const ptBRMessages = {
     invalidJson: "JSON inválido",
     undo: "Desfazer",
     redo: "Refazer",
+    editMarp: "Editar código do slide",
+    marpEditorLabel: "Código do slide Marp",
   },
   filesView: {
     chatPlaceholder: "Pergunte sobre este arquivo…",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -331,6 +331,8 @@ const zhMessages = {
     invalidJson: "无效的 JSON",
     undo: "撤销",
     redo: "重做",
+    editMarp: "编辑幻灯片源代码",
+    marpEditorLabel: "Marp 幻灯片源代码",
   },
   filesView: {
     chatPlaceholder: "询问关于此文件的问题…",


### PR DESCRIPTION
## Summary

- File Explorer (`/files/...`) で開いた **Marp .md** に **inline 編集機能** を追加
- 既存の JSON editor パターン (`jsonEditing` / `jsonDraft` / `start...` / `cancel...` / `save...`) を踏襲
- MarpView ツールバー slot に `Edit slide source` ボタン → クリックで **50/50 split** (左 textarea / 右 live preview)
- Save で `updateSource` emit → `FilesView.saveRawMarkdown` が `PUT /api/files/content`
- Cancel で破棄
- content 変化 (保存成功 / ファイル切替) で自動で編集モード解除
- 全 8 locale で i18n 追加
- Closes #1651

## Items to Confirm / Review

- **既存非 Marp md パスは無改変**: `TextResponseView` 経由の inline 編集はそのまま (#1651 の半分は既に実装済だったため、本 PR は **Marp branch のみ**)
- **JSON edit パターン踏襲**: 既存の `jsonEditing` の構造をコピーしている (`marpEditing` / `marpDraft` / `startMarpEdit` / `cancelMarpEdit` / `saveMarpEdit`)。content watcher にも `marpEditing.value = false` を追加し、保存成功 / navigation で edit mode を抜ける挙動を JSON と合わせている
- **inline-style layout**: `style="height: min(80vh, 720px); display: flex; overflow: hidden"` で固定高さ。markdown plugin View.vue の split mode (#1658) と同じ戦術。FileContentRenderer は `.stack-natural` 配下ではないが、挙動を読みやすくするために統一
- **コンポーネント共通化は未対応**: View.vue (#1658) と本 PR で似た layout が 2 箇所に。動作確認後にフォローアップで extract する想定 (Plan に記載)
- **Save error**: 既存の `rawSaveError` prop / banner を流用 (parent の `FilesView.saveRawMarkdown` 側のロジックは無改変)

## User Prompt

> File Explorer (/files/...) で md 編集

(Issue #1651 化フェーズで合意:)
> #1651 — `/files/...` 経由 (FileContentRenderer) に md editor を統合。JSON の JsonEditor と同じパターンで md 編集ボタン + textarea を追加。Marp プラグイン View と FileContentRenderer 両方に編集 affordance が乗る。

## Implementation

### `src/components/FileContentRenderer.vue`
- Marp branch を `<template v-if="isMarkdown && !mdRawMode && marpMode">` に変更し、内部で `marpEditing` で 2 分岐
- preview-only: 既存 `<MarpView>` + slot で `Edit slide source` ボタン
- edit: 50/50 split layout
- `<script setup>`:
  - `marpEditing = ref(false)` / `marpDraft = ref("")`
  - `startMarpEdit()` — `content.kind === 'text'` ガード後に `marpDraft = content.content; marpEditing = true`
  - `cancelMarpEdit()` — `marpEditing = false`
  - `saveMarpEdit()` — `emit("updateSource", marpDraft.value)`
  - 既存 content watcher に `marpEditing.value = false` 追加

### `src/lang/{en,ja,zh,ko,es,pt-BR,fr,de}.ts`
- `fileContentRenderer.editMarp` — 編集ボタンラベル
- `fileContentRenderer.marpEditorLabel` — textarea aria-label + pane 見出し

### a11y
- Edit ボタンに `aria-label`
- save / edit アイコン `<span>` に `aria-hidden="true"`
- textarea に `aria-label="...marpEditorLabel"`

Plan: `plans/feat-file-explorer-marp-edit.md`

## Test Plan

- [ ] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass (ローカル: ✅)
- [ ] File Explorer で Marp `.md` 開く → ツールバーに `Edit slide source` ボタン
- [ ] クリック → 50/50 split (左 textarea / 右 preview)
- [ ] textarea 編集 → preview リアルタイム反映
- [ ] Save → disk 反映 + preview-only に戻る
- [ ] Cancel → 破棄 + preview-only
- [ ] 編集中に別 file 切替 → edit mode 解除
- [ ] 非 Marp md (TextResponseView 経由) / JSON edit / HTML / 他 file type に regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing capability for Marp presentation files with a split-view editor and live preview pane.
  * Includes save and cancel controls for managing edits with error feedback.
  * Editor automatically exits edit mode when navigating to a different file.

* **Documentation**
  * Added feature specification and design documentation for Marp file editing workflow and acceptance criteria.

* **Chores**
  * Extended multi-language support across German, Spanish, French, Japanese, Korean, Portuguese, and Simplified Chinese for new editing UI labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->