### PR TITLE
feat(collections): add `file` field type with clickable path links

### DIFF
--- a/server/workspace/collections/discovery.ts
+++ b/server/workspace/collections/discovery.ts
@@ -139,6 +139,7 @@ const FieldSpecSchema = z
       "derived",
       "embed",
       "image",
+      "file",
       "toggle",
     ]),
     label: z.string().min(1),

--- a/server/workspace/collections/types.ts
+++ b/server/workspace/collections/types.ts
@@ -33,6 +33,12 @@ export type CollectionFieldType =
   // a per-row fetch is too expensive at scale). Stored and edited as a
   // plain string.
   | "image"
+  // Holds a workspace-relative file path as a plain string (e.g. an
+  // `artifacts/html/<name>.html` app). Rendered as a clickable link in
+  // both the list table and the detail view: HTML / SVG artifacts open
+  // their rendered form in a new tab; any other path opens in the File
+  // Explorer. Stored and edited as a plain string, like `image`.
+  | "file"
   // A checkbox that is a pure PROJECTION of an `enum` field — it stores
   // nothing of its own. Checked when the enum equals `onValue`; toggling
   // writes `onValue` / `offValue` back to that enum field. Lets a "done"

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -119,7 +119,7 @@ skipped, never crashes the host):
 
 `string` · `text` (multi-line) · `email` · `number` · `date` (`YYYY-MM-DD`) ·
 `datetime` (`YYYY-MM-DDTHH:MM`) · `boolean` · `markdown` · `money` · `enum` ·
-`ref` · `embed` · `table` · `derived` · `image` · `toggle`
+`ref` · `embed` · `table` · `derived` · `image` · `file` · `toggle`
 
 Every field spec needs a `type` and a `label`. Extra keys by type:
 
@@ -158,6 +158,15 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
   collection). No extra keys. Great for photos like a business card: read the
   details off the attached image and write its path into the image field.
   Write the bare workspace-relative path — never an `/api/files/raw?...` URL.
+- **`file`** — stores a **workspace-relative file path** as a plain string (e.g.
+  `artifacts/html/the-solar-system-1777158558023.html`). Rendered as a
+  **clickable link** in both the list table and the detail view (unlike `image`,
+  which is detail-only — a link is cheap per-row). Clicking an HTML or SVG
+  artifact opens its **rendered** form in a new browser tab (the live app /
+  drawing); any other path opens in the **File Explorer**. No extra keys. Ideal
+  for a "my apps" collection where each record points at a generated HTML app —
+  the user launches it straight from the row. Write the bare workspace-relative
+  path — never an `/artifacts/...` or `/api/files/raw?...` URL.
 - **`toggle`** — `field: "<enum-field>"`, `onValue`, `offValue`. A checkbox that
   is a pure **projection** of an `enum` field — it **stores nothing** of its own
   (like `derived`/`embed`). Checked when the projected enum equals `onValue`;

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -256,7 +256,7 @@
 
             <!-- Scalar inputs -->
             <input
-              v-else-if="['string', 'email', 'number', 'date', 'datetime', 'ref', 'image'].includes(field.type)"
+              v-else-if="['string', 'email', 'number', 'date', 'datetime', 'ref', 'image', 'file'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="render.inputTypeFor(field.type)"
@@ -396,6 +396,26 @@
               class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
               :data-testid="`collections-detail-url-${key}`"
               >{{ String(detailRecord[key]) }}</a
+            >
+
+            <!-- File: served HTML/SVG artifact → open the rendered app in a new tab. -->
+            <a
+              v-else-if="field.type === 'file' && render.artifactUrl(detailRecord[key])"
+              :href="render.artifactUrl(detailRecord[key]) ?? undefined"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
+              :data-testid="`collections-detail-file-${key}`"
+              >{{ String(detailRecord[key]) }}</a
+            >
+
+            <!-- File: any other workspace path → open in File Explorer. -->
+            <router-link
+              v-else-if="field.type === 'file' && render.fileRoutePath(detailRecord[key])"
+              :to="render.fileRoutePath(detailRecord[key]) ?? ''"
+              class="text-blue-600 hover:text-blue-800 font-semibold hover:underline break-all"
+              :data-testid="`collections-detail-file-${key}`"
+              >{{ String(detailRecord[key]) }}</router-link
             >
 
             <!-- Fallback text styling -->

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -389,7 +389,7 @@
 
             <!-- URL string → external link (new tab). -->
             <a
-              v-else-if="render.isExternalUrl(detailRecord[key])"
+              v-else-if="field.type !== 'file' && render.isExternalUrl(detailRecord[key])"
               :href="String(detailRecord[key])"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -478,7 +478,7 @@
                     <!-- URL string → external link (new tab). `@click.stop` so
                      clicking the link doesn't also open the row's detail. -->
                     <a
-                      v-else-if="isExternalUrl(item[key])"
+                      v-else-if="field.type !== 'file' && isExternalUrl(item[key])"
                       :href="String(item[key])"
                       target="_blank"
                       rel="noopener noreferrer"

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -488,6 +488,30 @@
                       >{{ String(item[key]) }}</a
                     >
 
+                    <!-- File: served HTML/SVG artifact → open the rendered
+                         app in a new tab. `@click.stop` keeps the row's
+                         detail panel from also opening. -->
+                    <a
+                      v-else-if="field.type === 'file' && artifactUrl(item[key])"
+                      :href="artifactUrl(item[key]) ?? undefined"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+                      :data-testid="`collections-file-link-${key}-${item[collection.schema.primaryKey]}`"
+                      @click.stop
+                      >{{ String(item[key]) }}</a
+                    >
+
+                    <!-- File: any other workspace path → open in File Explorer. -->
+                    <router-link
+                      v-else-if="field.type === 'file' && fileRoutePath(item[key])"
+                      :to="fileRoutePath(item[key]) ?? ''"
+                      class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+                      :data-testid="`collections-file-link-${key}-${item[collection.schema.primaryKey]}`"
+                      @click.stop
+                      >{{ String(item[key]) }}</router-link
+                    >
+
                     <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
                   </template>
                 </td>
@@ -744,7 +768,18 @@ const chatInputEl = ref<HTMLTextAreaElement | null>(null);
 // helpers the list table renders with; pass the whole object to the
 // panel as its `render` prop.
 const render = useCollectionRendering(collection, locale);
-const { refRecordCache, refDisplay, formatMoney, resolveCurrency, derivedDisplay, evaluateDerivedAgainstItem, formatCell, isExternalUrl } = render;
+const {
+  refRecordCache,
+  refDisplay,
+  formatMoney,
+  resolveCurrency,
+  derivedDisplay,
+  evaluateDerivedAgainstItem,
+  formatCell,
+  isExternalUrl,
+  artifactUrl,
+  fileRoutePath,
+} = render;
 
 const searchQuery = ref("");
 

--- a/src/components/collectionTypes.ts
+++ b/src/components/collectionTypes.ts
@@ -21,6 +21,7 @@ export type FieldType =
   | "table"
   | "derived"
   | "image"
+  | "file"
   | "embed"
   | "toggle";
 

--- a/src/composables/collections/useCollectionRendering.ts
+++ b/src/composables/collections/useCollectionRendering.ts
@@ -10,6 +10,7 @@
 import { computed, ref, type ComputedRef, type Ref } from "vue";
 import { apiGet } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
+import { htmlPreviewUrlFor, svgPreviewUrlFor } from "../useContentDisplay";
 import { evaluateDerived, type FormulaContext } from "../../utils/collections/derivedFormula";
 import type { EmbedRow, EmbedView } from "../../components/collectionEmbed";
 import type {
@@ -42,6 +43,8 @@ export interface CollectionRendering {
   formatCell: (value: unknown, type: FieldType) => string;
   detailText: (value: unknown) => string;
   isExternalUrl: (value: unknown) => boolean;
+  artifactUrl: (value: unknown) => string | null;
+  fileRoutePath: (value: unknown) => string | null;
   tableRows: (value: unknown) => Record<string, unknown>[];
   hasTableRows: (value: unknown) => boolean;
   formatSubCell: (subField: FieldSpec, value: unknown, record: CollectionItem | null) => string;
@@ -227,6 +230,21 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return typeof value === "string" && /^https?:\/\//i.test(value);
   }
 
+  // A `file` field holds a workspace-relative path. When it points at an
+  // HTML/SVG artifact the server serves directly, return that served URL
+  // so the rendered app can open in a new tab; otherwise null.
+  function artifactUrl(value: unknown): string | null {
+    if (typeof value !== "string" || value.length === 0) return null;
+    return htmlPreviewUrlFor(value) ?? svgPreviewUrlFor(value);
+  }
+
+  // In-app File Explorer route for any non-empty workspace path — the
+  // fallback for `file` values that aren't a directly-served artifact.
+  function fileRoutePath(value: unknown): string | null {
+    if (typeof value !== "string" || value.length === 0) return null;
+    return `/files/${value.split("/").map(encodeURIComponent).join("/")}`;
+  }
+
   function detailText(value: unknown): string {
     if (value === undefined || value === null || value === "") return "—";
     return String(value);
@@ -313,6 +331,8 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     formatCell,
     detailText,
     isExternalUrl,
+    artifactUrl,
+    fileRoutePath,
     tableRows,
     hasTableRows,
     formatSubCell,

--- a/src/composables/collections/useCollectionRendering.ts
+++ b/src/composables/collections/useCollectionRendering.ts
@@ -11,6 +11,7 @@ import { computed, ref, type ComputedRef, type Ref } from "vue";
 import { apiGet } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { htmlPreviewUrlFor, svgPreviewUrlFor } from "../useContentDisplay";
+import { isValidFilePath } from "../useFileSelection";
 import { evaluateDerived, type FormulaContext } from "../../utils/collections/derivedFormula";
 import type { EmbedRow, EmbedView } from "../../components/collectionEmbed";
 import type {
@@ -238,10 +239,12 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return htmlPreviewUrlFor(value) ?? svgPreviewUrlFor(value);
   }
 
-  // In-app File Explorer route for any non-empty workspace path — the
-  // fallback for `file` values that aren't a directly-served artifact.
+  // In-app File Explorer route for a workspace path — the fallback for
+  // `file` values that aren't a directly-served artifact. Returns null
+  // for paths the Files view would reject (absolute or `..`-traversing),
+  // so we never emit a link that lands on an empty Files page.
   function fileRoutePath(value: unknown): string | null {
-    if (typeof value !== "string" || value.length === 0) return null;
+    if (!isValidFilePath(value)) return null;
     return `/files/${value.split("/").map(encodeURIComponent).join("/")}`;
   }
 

--- a/src/composables/collections/useCollectionRendering.ts
+++ b/src/composables/collections/useCollectionRendering.ts
@@ -233,9 +233,12 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
 
   // A `file` field holds a workspace-relative path. When it points at an
   // HTML/SVG artifact the server serves directly, return that served URL
-  // so the rendered app can open in a new tab; otherwise null.
+  // so the rendered app can open in a new tab; otherwise null. Reject
+  // absolute / `..`-traversing paths first (same guard as fileRoutePath)
+  // — the preview-URL builders don't, so a `..` would normalize out of
+  // the intended mount.
   function artifactUrl(value: unknown): string | null {
-    if (typeof value !== "string" || value.length === 0) return null;
+    if (!isValidFilePath(value)) return null;
     return htmlPreviewUrlFor(value) ?? svgPreviewUrlFor(value);
   }
 


### PR DESCRIPTION
## Summary

Adds a new **`file`** field type for schema-driven collections, modeled on the existing `image` type. It stores a workspace-relative path as a plain string and renders it as a **clickable link in both the list table and the detail view**:

- **HTML / SVG artifacts** → open their **rendered** form in a new tab (the live app), via the existing `htmlPreviewUrlFor` / `svgPreviewUrlFor` served mounts.
- **Any other workspace path** → opens in the **File Explorer**.
- Editable as a plain-text path in the create/edit form (like `image`).

### Motivation

An "apps" collection (a catalog of generated HTML apps) can now point each record's path field at its artifact, and the user launches the app straight from the row by clicking the path — instead of plain gray text.

This was a deliberate choice over auto-detecting paths in `string` values: a declared type matches the codebase's existing precedent (`image`, `ref`, `embed` are all typed, not string-sniffed), is greppable/intentional, and keeps server static-mount knowledge out of the render layer.

## Changes

| File | Change |
|---|---|
| `src/components/collectionTypes.ts` | `"file"` added to `FieldType` |
| `server/workspace/collections/types.ts` | `"file"` added to `CollectionFieldType` (+ doc comment) |
| `server/workspace/collections/discovery.ts` | `"file"` added to the top-level field zod enum (top-level only, mirroring `image`) |
| `src/composables/collections/useCollectionRendering.ts` | new shared `artifactUrl()` + `fileRoutePath()` helpers |
| `src/components/CollectionView.vue` | table-cell link branches |
| `src/components/CollectionRecordPanel.vue` | detail-view link branches + text input for editing |
| `server/workspace/helps/collection-skills.md` | document the `file` type |

## Notes

- No i18n keys needed — the link's visible text is the path itself.
- The create modal slots `CollectionRecordPanel`, so create/edit/detail are all covered by the panel changes.
- `file` is a plain string for persistence (no special coercion), so `draft.ts` / inline-edit need no changes.

## Test plan

- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass
- [ ] Manual: set a collection field to `type: "file"`, confirm an `artifacts/html/*.html` value renders as a link that opens the rendered app in a new tab, and a non-served path opens in the File Explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "file" field type for collections to store workspace-relative file paths. In edit mode it uses a standard input; in read mode it renders as a clickable link — served HTML/SVG artifacts open in a new tab, other paths open in the in-app file explorer.

* **Documentation**
  * Schema docs updated with the "file" field type, usage guidance, and display behavior in list and detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->