### PR TITLE
refactor(marp): extract MarpSplitEditor shared component

### DIFF
--- a/plans/refactor-marp-split-editor.md
+++ b/plans/refactor-marp-split-editor.md
@@ -1,0 +1,55 @@
+# refactor(marp): extract MarpSplitEditor (shared split-pane layout)
+
+## 背景
+
+PR #1658 (markdown plugin `View.vue` split mode) と PR #1663 (FileContentRenderer Marp editor) で **同じ 50/50 split layout** が独立して 2 箇所にコピーされている:
+
+- `style="height: min(80vh, 720px); display: flex; overflow: hidden"`
+- 左 column: textarea + toolbar
+- 右 column: `<MarpView :markdown="draft">` (live preview)
+- inline-style 戦術で `.stack-natural` overrides を回避
+
+CSS / template の双方で **数十行のコピペ**。1 箇所変えたら 2 箇所修正の負担、片方だけ regression が出る危険もある。
+
+## 目的
+
+`src/plugins/markdown/MarpSplitEditor.vue` (新規) に **layout だけ** を切り出し、Action ボタン / Apply・Cancel・Save の振る舞いは slot で受ける形にする。MarpView は内側に直接 mount。
+
+## API 設計
+
+```ts
+defineProps<{
+  modelValue: string;        // draft buffer (textarea v-model)
+  pdfFilename: string;
+  baseDir?: string;
+  editorLabel: string;       // i18n キーは呼び出し側で解決
+}>();
+
+defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+```
+
+Slots:
+- `actions` — 右上のボタン群 (apply/cancel/save 等、呼び出し側のスタイルそのまま)
+- `error` — toolbar と textarea の間に挟むエラー表示 (optional)
+- `preview-toolbar` — 右 pane の MarpView 内ツールバー (preview-only / close-split など)
+
+## 触るファイル
+
+- `src/plugins/markdown/MarpSplitEditor.vue` (新規)
+- `src/plugins/markdown/View.vue` — split mode 分岐を `<MarpSplitEditor>` で書き換え、内部の textarea CSS を削除
+- `src/components/FileContentRenderer.vue` — marp 編集分岐を `<MarpSplitEditor>` で書き換え
+- `src/lang/*` — i18n キー無改変 (呼び出し側で `t(...)` を解決して渡す)
+
+## 受け入れ基準
+
+- [ ] split mode の挙動 (live preview / apply / cancel / aria-label / `.stack-natural` 配下での高さ) に regression なし
+- [ ] FileContentRenderer の marp 編集 (start / save / cancel / content watcher) に regression なし
+- [ ] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass
+- [ ] dev で 2 surface (chat plugin View / File Explorer) を実機確認
+
+## 非ゴール
+
+- 機能追加 (resizer / CodeMirror / debounce) は別 issue
+- Apply / Save の状態管理ロジック (`editableMarkdown` / `marpDraft` / `applyMarkdown` / `saveMarpEdit`) は呼び出し側に残す — 共通化すると差異吸収で複雑化するので留保

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -17,44 +17,35 @@
              because marp-core consumes its own directives (theme,
              paginate, size, …) from the YAML header. -->
         <template v-if="isMarkdown && !mdRawMode && marpMode">
-          <!-- Edit mode: split view — left textarea / right MarpView,
-               with the draft buffer feeding both. Inline styles mirror
-               the markdown plugin's split mode (#1647) so the textarea
-               can actually fill the column even when the plugin renders
-               inside a layout wrapper that quietly neutralises Tailwind
-               sizing utilities. -->
-          <div v-if="marpEditing" style="height: min(80vh, 720px); display: flex; overflow: hidden">
-            <div style="display: flex; flex-direction: column; flex: 1 1 50%; min-width: 0; min-height: 0; border-right: 1px solid #e0e0e0">
-              <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
-                <span class="text-xs text-gray-500 mr-auto">{{ t("fileContentRenderer.marpEditorLabel") }}</span>
-                <button
-                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
-                  data-testid="files-marp-cancel-btn"
-                  @click="cancelMarpEdit"
-                >
-                  {{ t("common.cancel") }}
-                </button>
-                <button
-                  class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-green-600 hover:bg-green-700 text-white"
-                  data-testid="files-marp-save-btn"
-                  @click="saveMarpEdit"
-                >
-                  <span class="material-icons text-sm" aria-hidden="true">save</span>
-                  {{ t("common.save") }}
-                </button>
-              </div>
-              <textarea
-                v-model="marpDraft"
-                class="w-full p-4 font-mono text-sm bg-white border-0 resize-none focus:outline-none"
-                style="flex: 1 1 0; min-height: 0"
-                spellcheck="false"
-                :aria-label="t('fileContentRenderer.marpEditorLabel')"
-              ></textarea>
-            </div>
-            <div style="flex: 1 1 50%; min-width: 0; min-height: 0; overflow-y: auto">
-              <MarpView :markdown="marpDraft" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir" />
-            </div>
-          </div>
+          <!-- Edit mode: shared MarpSplitEditor — textarea on the
+               left feeds a live MarpView preview on the right via
+               v-model. Layout / inline-style rationale lives in
+               the component. -->
+          <MarpSplitEditor
+            v-if="marpEditing"
+            v-model="marpDraft"
+            :pdf-filename="marpPdfFilename"
+            :base-dir="marpBaseDir"
+            :editor-label="t('fileContentRenderer.marpEditorLabel')"
+          >
+            <template #actions>
+              <button
+                class="h-8 px-2.5 flex items-center gap-1 text-sm rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                data-testid="files-marp-cancel-btn"
+                @click="cancelMarpEdit"
+              >
+                {{ t("common.cancel") }}
+              </button>
+              <button
+                class="h-8 px-2.5 flex items-center gap-1 text-sm rounded bg-green-600 hover:bg-green-700 text-white"
+                data-testid="files-marp-save-btn"
+                @click="saveMarpEdit"
+              >
+                <span class="material-icons text-sm" aria-hidden="true">save</span>
+                {{ t("common.save") }}
+              </button>
+            </template>
+          </MarpSplitEditor>
           <!-- Preview-only mode (default). `m-auto` centres a short
                MarpView vertically in the file-pane canvas (same pattern
                as View.vue's marp branch). -->
@@ -260,6 +251,7 @@ import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDes
 import { isMarpDocument } from "../utils/markdown/marpDetect";
 import { buildPdfFilename } from "../utils/files/filename";
 import MarpView from "../plugins/markdown/MarpView.vue";
+import MarpSplitEditor from "../plugins/markdown/MarpSplitEditor.vue";
 // Lazy: CodeMirror (~390 KB raw) is only fetched when a user actually
 // opens the inline JSON editor, keeping it out of the initial bundle.
 const JsonEditor = defineAsyncComponent(() => import("./JsonEditor.vue"));

--- a/src/plugins/markdown/MarpSplitEditor.vue
+++ b/src/plugins/markdown/MarpSplitEditor.vue
@@ -1,0 +1,73 @@
+<template>
+  <!-- Shared 50/50 split layout for the Marp source editor + live
+       preview. Used both by the markdown plugin's chat view
+       (`src/plugins/markdown/View.vue`, #1658) and by the File
+       Explorer (`src/components/FileContentRenderer.vue`, #1663).
+       The layout-critical sizing is set inline because the markdown
+       plugin renders under `.stack-natural` (StackView), which
+       neutralises `.h-full`, `.overflow-hidden`, and
+       `.flex-col > .flex-1` via `:deep(...) { ... !important }`. Inline
+       styles aren't matched by those class-targeted rules. -->
+  <div style="height: min(80vh, 720px); display: flex; overflow: hidden">
+    <div style="display: flex; flex-direction: column; flex: 1 1 50%; min-width: 0; min-height: 0; border-right: 1px solid #e0e0e0">
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+        <span class="text-xs text-gray-500 mr-auto">{{ editorLabel }}</span>
+        <slot name="actions" />
+      </div>
+      <slot name="error" />
+      <textarea
+        :value="modelValue"
+        :aria-label="editorLabel"
+        class="marp-split-textarea"
+        style="flex: 1 1 0; min-height: 0"
+        spellcheck="false"
+        @input="onInput"
+      ></textarea>
+    </div>
+    <div style="flex: 1 1 50%; min-width: 0; min-height: 0; overflow-y: auto">
+      <MarpView :markdown="modelValue" :pdf-filename="pdfFilename" :base-dir="baseDir">
+        <template #toolbar>
+          <slot name="preview-toolbar" />
+        </template>
+      </MarpView>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import MarpView from "./MarpView.vue";
+
+defineProps<{
+  modelValue: string;
+  pdfFilename: string;
+  baseDir?: string;
+  editorLabel: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+function onInput(event: Event): void {
+  emit("update:modelValue", (event.target as HTMLTextAreaElement).value);
+}
+</script>
+
+<style scoped>
+.marp-split-textarea {
+  width: 100%;
+  padding: 1rem;
+  background: #ffffff;
+  border: none;
+  border-radius: 0;
+  color: #333;
+  font-family: "Courier New", monospace;
+  font-size: 0.9rem;
+  resize: none;
+  line-height: 1.5;
+}
+
+.marp-split-textarea:focus {
+  outline: none;
+}
+</style>

--- a/src/plugins/markdown/View.vue
+++ b/src/plugins/markdown/View.vue
@@ -14,56 +14,37 @@
         {{ t("pluginMarkdown.refreshFailed", { error: loadError }) }}
       </div>
       <!-- Split mode: live editor on the left, MarpView on the right
-           driven by the unsaved buffer. Toggle lives in the MarpView
-           toolbar via slot. Apply/Cancel sit above the textarea so
-           the action surface is co-located with the input.
-           IMPORTANT: layout-critical sizing uses inline styles instead
-           of Tailwind utility classes because this plugin renders
-           under `.stack-natural` (`presentDocument` is in
-           STACK_NATURAL_TOOLS — see `src/components/StackView.vue`).
-           That wrapper neutralises `.h-full`, `.overflow-hidden`,
-           and `.flex-col > .flex-1` via `:deep(...) { ... !important }`
-           so the deck flows at natural height in stack view. The
-           split editor needs a **bounded** height, so we set one
-           explicitly with `style="height: min(80vh, 720px)"` and use
-           inline `flex` shorthands that aren't matched by the class-
-           targeted override rules. -->
-      <div v-if="marpSplitMode" style="height: min(80vh, 720px); display: flex; overflow: hidden">
-        <div style="display: flex; flex-direction: column; flex: 1 1 50%; min-width: 0; min-height: 0; border-right: 1px solid #e0e0e0">
-          <div class="flex items-center gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
-            <span class="text-xs text-gray-500 mr-auto">{{ t("pluginMarkdown.marpSplitEditorLabel") }}</span>
-            <button class="apply-btn" :disabled="!hasChanges || saving" @click="applyMarkdown">
-              {{ saving ? t("pluginMarkdown.saving") : t("pluginMarkdown.applyChanges") }}
-            </button>
-            <button class="cancel-btn" @click="cancelMarpSplitEdit">{{ t("pluginMarkdown.cancel") }}</button>
-          </div>
+           driven by the unsaved buffer. Layout / inline-style
+           rationale lives in `MarpSplitEditor.vue` (the shared
+           50/50 split component). Toggles, Apply / Cancel, error
+           banner are supplied here via slots. -->
+      <MarpSplitEditor
+        v-if="marpSplitMode"
+        v-model="editableMarkdown"
+        :pdf-filename="marpPdfFilename"
+        :base-dir="marpBaseDir"
+        :editor-label="t('pluginMarkdown.marpSplitEditorLabel')"
+      >
+        <template #actions>
+          <button class="apply-btn" :disabled="!hasChanges || saving" @click="applyMarkdown">
+            {{ saving ? t("pluginMarkdown.saving") : t("pluginMarkdown.applyChanges") }}
+          </button>
+          <button class="cancel-btn" @click="cancelMarpSplitEdit">{{ t("pluginMarkdown.cancel") }}</button>
+        </template>
+        <template #error>
           <p v-if="saveError" class="save-error mx-2 mt-1" role="alert">{{ t("pluginMarkdown.saveError", { error: saveError }) }}</p>
-          <textarea
-            v-model="editableMarkdown"
-            class="marp-split-editor"
-            style="flex: 1 1 0; min-height: 0"
-            spellcheck="false"
-            :aria-label="t('pluginMarkdown.marpSplitEditorLabel')"
-          ></textarea>
-        </div>
-        <!-- Right pane: scroll container for the deck. No vertical
-             centering — the editor view starts slides at the top so
-             the source / preview baselines line up. -->
-        <div style="flex: 1 1 50%; min-width: 0; min-height: 0; overflow-y: auto">
-          <MarpView :markdown="marpPreviewMarkdown" :pdf-filename="marpPdfFilename" :base-dir="marpBaseDir">
-            <template #toolbar>
-              <button
-                class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
-                :title="t('pluginMarkdown.marpSplitExit')"
-                :aria-label="t('pluginMarkdown.marpSplitExit')"
-                @click="marpSplitMode = false"
-              >
-                <span class="material-icons text-base" aria-hidden="true">close_fullscreen</span>
-              </button>
-            </template>
-          </MarpView>
-        </div>
-      </div>
+        </template>
+        <template #preview-toolbar>
+          <button
+            class="h-8 px-2.5 flex items-center gap-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm"
+            :title="t('pluginMarkdown.marpSplitExit')"
+            :aria-label="t('pluginMarkdown.marpSplitExit')"
+            @click="marpSplitMode = false"
+          >
+            <span class="material-icons text-base" aria-hidden="true">close_fullscreen</span>
+          </button>
+        </template>
+      </MarpSplitEditor>
       <!-- Preview-only mode (default): single MarpView + bottom <details>. -->
       <template v-else>
         <div class="flex-1 min-h-0 overflow-y-auto flex flex-col">
@@ -183,6 +164,7 @@ import { useAppApi } from "../../composables/useAppApi";
 import { useFileChange } from "../../composables/useFileChange";
 import { isMarpDocument } from "../../utils/markdown/marpDetect";
 import MarpView from "./MarpView.vue";
+import MarpSplitEditor from "./MarpSplitEditor.vue";
 
 const { t } = useI18n();
 
@@ -321,12 +303,6 @@ watch(fileVersion, (current, previous) => {
 const mdDoc = useMarkdownDoc(markdownContent);
 
 const marpMode = computed(() => isMarpDocument(mdDoc.value.meta));
-
-// Markdown handed to the MarpView preview. While split mode is on,
-// the unsaved `editableMarkdown` buffer drives the preview so the
-// user sees their edits live; otherwise we show the persisted
-// `markdownContent` (= disk truth).
-const marpPreviewMarkdown = computed(() => (marpSplitMode.value ? editableMarkdown.value : markdownContent.value));
 
 function enterMarpSplitMode(): void {
   // Preserve any existing unsaved draft. The close (`close_fullscreen`)
@@ -772,27 +748,6 @@ watch(
   outline: none;
   border-color: #4caf50;
   box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.1);
-}
-
-/* Split-mode textarea: fills the left pane vertically instead of
-   the 40vh cap the bottom-bar editor uses. No rounded border /
-   margin — it sits inside a framed pane. */
-.marp-split-editor {
-  width: 100%;
-  padding: 1rem;
-  background: #ffffff;
-  border: none;
-  border-radius: 0;
-  color: #333;
-  font-family: "Courier New", monospace;
-  font-size: 0.9rem;
-  resize: none;
-  line-height: 1.5;
-  min-height: 0;
-}
-
-.marp-split-editor:focus {
-  outline: none;
 }
 
 .apply-btn {


### PR DESCRIPTION
## Summary

- PR #1658 (chat plugin View split mode) と PR #1663 (FileContentRenderer Marp editor) で **同じ 50/50 split layout** を独立してコピーしていたので **共通コンポーネント** `src/plugins/markdown/MarpSplitEditor.vue` を抽出
- 両 call site が同コンポーネントを mount し、アクションボタン (Apply/Cancel/Save/Exit) は **slot で受ける** 形に
- 視覚的レイアウトのみ共通化し、ロジック (`editableMarkdown` / `marpDraft` / `applyMarkdown` / `saveMarpEdit` / fileVersion watcher / pendingSelfSaves) は呼び出し側に残す — 保存フローや navigation のリセット仕様が片方ごとに異なるため
- 機能変更なし (UI / 挙動 regression なし)

## Items to Confirm / Review

- **API 設計**: `modelValue` (v-model) で textarea ↔ preview の双方向 sync。`pdfFilename` / `baseDir` / `editorLabel` を props で受け、Action ボタンは slot で外注。最小限の表面積で 2 ユースケースを賄えている
- **ロジック共通化はしない**: View.vue の Apply 流れ (PUT via `endpoints.update.url` → `markdownContent` 更新 → `editableMarkdown` sync → `pendingSelfSaves` 管理) と FileContentRenderer の Save 流れ (`updateSource` emit → 親 `FilesView.saveRawMarkdown` → `content` 更新 watcher で edit mode 解除) が大きく異なるので、無理にひとつにまとめると差異吸収のための props / events が肥大化する。視覚的レイアウトのみ統一する判断
- **inline-style 戦術**: `style="height: min(80vh, 720px); display: flex; overflow: hidden"` 等のレイアウトは `MarpSplitEditor.vue` 内のコメントで `.stack-natural` overrides を回避する目的を一元化
- **View.vue は `marpPreviewMarkdown` computed を削除** — v-model 経由で `editableMarkdown` を直接 component に渡すため不要に
- **規模**: +189 / -114 (差し引き +75 行)。同じレイアウト二重管理の負担はゼロに

## User Prompt

> Marp 関連 (split mode / theme / File Explorer edit) の共通コンポーネント抽出 — PR #1658 と #1663 で似た layout コードが 2 箱所にコピーされている。\`MarpSplitEditor.vue\` のような共用コンポーネントに refactor。

## Implementation

### `src/plugins/markdown/MarpSplitEditor.vue` (新規)
\`\`\`ts
defineProps<{
  modelValue: string;
  pdfFilename: string;
  baseDir?: string;
  editorLabel: string;
}>();
defineEmits<{ "update:modelValue": [value: string] }>();
\`\`\`

Slots: \`actions\` (toolbar buttons), \`error\` (toolbar と textarea の間), \`preview-toolbar\` (MarpView 内ボタン)

Layout は **inline style** で sizing 固定。理由 (`.stack-natural` の \`:deep(...) !important\` overrides を回避) はコンポーネント先頭のコメントに一元化。

### `src/plugins/markdown/View.vue`
- Split mode 分岐を `<MarpSplitEditor v-model="editableMarkdown" ...>` に置き換え
- 不要になった `marpPreviewMarkdown` computed を削除
- `<style>` から \`.marp-split-editor\` テキストエリア CSS を削除 (コンポーネント側に移動)

### `src/components/FileContentRenderer.vue`
- Marp 編集分岐を `<MarpSplitEditor v-model="marpDraft" ...>` に置き換え
- inline-styled scaffold とハンドコピー textarea を削除

Plan: `plans/refactor-marp-split-editor.md`

## Test Plan

- [x] `yarn format` / `lint` / `typecheck` / `build` / `test` 全 pass (ローカル)
- [ ] chat plugin View で Marp split mode: live preview / Apply / Cancel / aria-label / `.stack-natural` 配下での高さ / リモート write による解除 — regression なし
- [ ] File Explorer で Marp 編集: edit → split → live preview / Save / Cancel / content navigation での解除 / 非 Marp と JSON の regression なし
- [ ] dev server で 2 surface 実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized the Marp split-pane editor layout into a shared component for improved code structure and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->