### PR TITLE
release: mulmoclaude@0.7.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] - 2026-06-10
+
+Three large built-ins move out of the launcher in favour of the schema-driven collections model: **Calendar**, the **Todo plugin**, and the **Encore** recurring-obligation built-in are all removed; their use cases are now expressed as collections (`calendarField` for dated items, `config/helps/todo-collection.md` for todo lists, `triggerField` + `spawn` for recurring obligations). The bundled **invoicing suite** moves the same way — from preset skills to on-demand help-file recipes. No data is deleted; the records on disk are left in place.
+
 ### Changed
 - The **invoicing suite** (`clients`, `worklog`, `invoice`, `profile`) moved from bundled `mc-*` preset skills to on-demand **help-file recipes** (`config/helps/billing-clients-worklog.md` + `config/helps/billing-invoice.md`), discoverable via two Personal-role sample prompts ("Set up client and time tracking…", "Set up invoicing…"). New workspaces no longer carry the four presets in the skill catalog; the recipes scaffold bare-slug collections (`/collections/invoice`, etc.) over the same prefix-free `data/*/items` record folders. On launch, any lingering starred `mc-{clients,worklog,invoice,profile}` skill is **removed** from `.claude/skills/` (records under `data/*/items` are left untouched), and a one-time bell explains the change — re-running a recipe re-attaches to the same data, so existing records reappear. No data is ever deleted.
 

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -115,7 +115,7 @@ ${cliFlagHelpLines()}
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.6.4");
+  console.log("mulmoclaude 0.7.0");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump `mulmoclaude` 0.6.5 → **0.7.0** (minor — three breaking removals).
- Sync `bin/mulmoclaude.js` version string (was stale at `0.6.4`).
- Promote `[Unreleased]` → `[0.7.0] - 2026-06-10` in `docs/CHANGELOG.md` with a release summary paragraph.
- **Already published**: `npm view mulmoclaude version` → `0.7.0`; `npx --yes mulmoclaude@0.7.0 --version` boots cleanly (ready banner + HTTP 200).

## Items to Confirm / Review
- The version-string mismatch (`bin` showed `0.6.4` against `package.json` 0.6.5) was a pre-existing oversight from the 0.6.5 release — both are now `0.7.0`.
- 0.7.0 minor is justified by user-facing breaking removals (Calendar / Todo plugin / Encore). Records on disk are left in place; no data is migrated automatically — replacements (collections + recipes) re-attach to the same `data/*/items` folders.
- CHANGELOG summary paragraph at the top of `[0.7.0]` mirrors the language already in `[Unreleased]` (no scope creep beyond the three removals + the invoicing-suite recipe move).

## User Prompt
> `/publish-mulmoclaude` — invoked the skill to ship the next release.

## Implementation
1. **§0 preflight**: branched off `main` → `release/v0.7.0`; `npm whoami` = `isamu`; **latest `MulmoClaude publish smoke` on main is green** (6972f594).
2. **§1 deps audit** (`node scripts/mulmoclaude/deps.mjs`): clean — no missing dependencies.
3. **§2 workspace drift** (`node scripts/mulmoclaude/drift.mjs`): clean — all three `@mulmobridge/*` packages match their published exports. **No cascade bump needed.**
4. **§3 build**: `yarn install` + `yarn build` clean.
5. **§4 tarball test** (`yarn package` → `mulmoclaude-0.7.0.tgz`, 12.1 MB / 747 files): fresh install in `/tmp/mc-test`, launcher boots with `✓ MulmoClaude is ready` + `HTTP 200`. Preset loader: requested=4, succeeded=1 (Spotify); the 3 misses are devOnly packages logged at `debug` per the 0.6.5 fix.
6. **§6 publish**: `npm publish --access public` → `+ mulmoclaude@0.7.0`. Verified via `npm view` + `npx --yes`.

No `@mulmobridge/*` cascade, so **§7 (tag + GitHub release for bridges) is skipped**. App tag + GitHub release (`vX.Y.Z`) is the separate `/release-app` skill's job.

## Test Plan
- [x] `npm view mulmoclaude version` → `0.7.0`
- [x] `npx --yes mulmoclaude@0.7.0 --version` → `mulmoclaude 0.7.0`
- [x] Fresh tarball install boots launcher to HTTP 200 + ready banner
- [ ] CI on this PR: green
- [ ] `MulmoClaude publish smoke` on this PR: green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.7.0 released

* **Feature Changes**
  * Calendar view, Todo plugin, and recurring-obligation features have been migrated to schema-driven collections and help-file recipes
  * Invoicing suite features are now provided through on-demand help-file recipes
  * All existing data is fully preserved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->