### PR TITLE
feat: add column sort to collection table view

### DIFF
--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -383,7 +383,7 @@
                   <span>{{ field.label }}</span>
                   <button
                     type="button"
-                    class="material-icons text-sm h-8 w-8 flex items-center justify-center rounded hover:text-indigo-400 transition-colors"
+                    class="material-icons h-8 w-8 flex items-center justify-center rounded hover:text-indigo-400 transition-colors"
                     :class="sortState?.field === String(key) ? 'text-indigo-600' : 'text-slate-300'"
                     :aria-label="sortAriaLabel(String(key), field.label)"
                     @click="cycleSort(String(key))"

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -381,26 +381,15 @@
               >
                 <span v-if="isSortableField(field)" class="inline-flex items-center gap-0.5" :data-testid="`collection-sort-${key}`">
                   <span>{{ field.label }}</span>
-                  <span class="inline-flex flex-col">
-                    <button
-                      type="button"
-                      class="material-icons text-[10px] leading-none min-w-6 min-h-6 flex items-center justify-center hover:text-indigo-400 transition-colors"
-                      :class="sortState?.direction === 'asc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
-                      :aria-label="t('collectionsView.sortAsc', { field: field.label })"
-                      @click="toggleSort(String(key), 'asc')"
-                    >
-                      expand_less
-                    </button>
-                    <button
-                      type="button"
-                      class="material-icons text-[10px] leading-none min-w-6 min-h-6 flex items-center justify-center hover:text-indigo-400 transition-colors"
-                      :class="sortState?.direction === 'desc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
-                      :aria-label="t('collectionsView.sortDesc', { field: field.label })"
-                      @click="toggleSort(String(key), 'desc')"
-                    >
-                      expand_more
-                    </button>
-                  </span>
+                  <button
+                    type="button"
+                    class="material-icons text-sm h-8 w-8 flex items-center justify-center rounded hover:text-indigo-400 transition-colors"
+                    :class="sortState?.field === String(key) ? 'text-indigo-600' : 'text-slate-300'"
+                    :aria-label="sortAriaLabel(String(key), field.label)"
+                    @click="cycleSort(String(key))"
+                  >
+                    {{ sortIcon(String(key)) }}
+                  </button>
                 </span>
                 <span v-else>{{ field.label }}</span>
               </th>
@@ -673,7 +662,7 @@ import { useShortcuts } from "../composables/useShortcuts";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
 import { resolveEnumColor } from "../utils/collections/enumColors";
 import { readCollectionViewMode, writeCollectionViewMode } from "../utils/collections/collectionViewMode";
-import { compareItems, readCollectionSort, writeCollectionSort, type SortDirection, type SortState } from "../utils/collections/collectionSort";
+import { compareItems, readCollectionSort, writeCollectionSort, type SortState } from "../utils/collections/collectionSort";
 import { useCollectionRendering } from "../composables/collections/useCollectionRendering";
 import { buildUpdatedRecord, coerceInlineValue, draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
 import type {
@@ -821,23 +810,32 @@ function isSortableField(field: FieldSpec): boolean {
   return SORTABLE_TYPES.has(field.type);
 }
 
-function toggleSort(fieldKey: string, direction: SortDirection): void {
+function cycleSort(fieldKey: string): void {
   const current = sortState.value;
-  if (current?.field === fieldKey && current.direction === direction) {
-    sortState.value = null;
+  if (current?.field !== fieldKey) {
+    sortState.value = { field: fieldKey, direction: "asc" };
+  } else if (current.direction === "asc") {
+    sortState.value = { field: fieldKey, direction: "desc" };
   } else {
-    sortState.value = { field: fieldKey, direction };
+    sortState.value = null;
   }
   persistSort();
 }
 
-function isSortedField(fieldKey: string): boolean {
-  return sortState.value?.field === fieldKey;
+function sortIcon(fieldKey: string): string {
+  if (sortState.value?.field !== fieldKey) return "swap_vert";
+  return sortState.value.direction === "asc" ? "arrow_upward_alt" : "arrow_downward_alt";
+}
+
+function sortAriaLabel(fieldKey: string, fieldLabel: string): string {
+  if (sortState.value?.field !== fieldKey) return t("collectionsView.sortAsc", { field: fieldLabel });
+  if (sortState.value.direction === "asc") return t("collectionsView.sortDesc", { field: fieldLabel });
+  return t("collectionsView.sortClear", { field: fieldLabel });
 }
 
 function ariaSortValue(fieldKey: string): "ascending" | "descending" | "none" | undefined {
-  if (!isSortedField(fieldKey)) return undefined;
-  return sortState.value?.direction === "asc" ? "ascending" : "descending";
+  if (sortState.value?.field !== fieldKey) return undefined;
+  return sortState.value.direction === "asc" ? "ascending" : "descending";
 }
 
 function persistSort(): void {

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -381,10 +381,10 @@
               >
                 <span v-if="isSortableField(field)" class="inline-flex items-center gap-0.5" :data-testid="`collection-sort-${key}`">
                   <span>{{ field.label }}</span>
-                  <span class="inline-flex flex-col -space-y-[5px]">
+                  <span class="inline-flex flex-col -space-y-0.5">
                     <button
                       type="button"
-                      class="material-icons text-[8px] leading-none p-0.5 hover:text-indigo-400 transition-colors"
+                      class="material-icons text-[10px] leading-none min-w-6 min-h-3 flex items-center justify-center hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'asc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
                       :aria-label="t('collectionsView.sortAsc', { field: field.label })"
                       @click="toggleSort(String(key), 'asc')"
@@ -393,7 +393,7 @@
                     </button>
                     <button
                       type="button"
-                      class="material-icons text-[8px] leading-none p-0.5 hover:text-indigo-400 transition-colors"
+                      class="material-icons text-[10px] leading-none min-w-6 min-h-3 flex items-center justify-center hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'desc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
                       :aria-label="t('collectionsView.sortDesc', { field: field.label })"
                       @click="toggleSort(String(key), 'desc')"
@@ -821,28 +821,18 @@ function isSortableField(field: FieldSpec): boolean {
   return SORTABLE_TYPES.has(field.type);
 }
 
-/** Resolve the actual data key for sorting: toggle fields project an
- *  enum field and store no value themselves, so sort by the projected key. */
-function resolveSortKey(fieldKey: string): string {
-  const field = collection.value?.schema.fields[fieldKey];
-  if (field?.type === "toggle" && field.field) return field.field;
-  return fieldKey;
-}
-
 function toggleSort(fieldKey: string, direction: SortDirection): void {
-  const sortKey = resolveSortKey(fieldKey);
   const current = sortState.value;
-  if (current?.field === sortKey && current.direction === direction) {
+  if (current?.field === fieldKey && current.direction === direction) {
     sortState.value = null;
   } else {
-    sortState.value = { field: sortKey, direction };
+    sortState.value = { field: fieldKey, direction };
   }
   persistSort();
 }
 
 function isSortedField(fieldKey: string): boolean {
-  const sortKey = resolveSortKey(fieldKey);
-  return sortState.value?.field === sortKey;
+  return sortState.value?.field === fieldKey;
 }
 
 function ariaSortValue(fieldKey: string): "ascending" | "descending" | "none" | undefined {

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1091,7 +1091,7 @@ async function loadCollection(slug: string): Promise<void> {
   collection.value = null;
   items.value = [];
   searchQuery.value = "";
-  restoreSort(slug);
+  sortState.value = null;
   render.resetLinkedCaches();
   viewing.value = null;
   openDay.value = null; // never carry a previous collection's open day over
@@ -1110,6 +1110,7 @@ async function loadCollection(slug: string): Promise<void> {
     return;
   }
   collection.value = result.data.collection;
+  restoreSort(slug);
   items.value = result.data.items;
   enumOriginallyEmpty.value = snapshotEmptyEnums(result.data.collection.schema, result.data.items);
   // Fan out to fetch each unique target collection so the table can

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -374,7 +374,26 @@
           <thead>
             <tr class="bg-slate-50 border-b border-slate-200">
               <th v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider">
-                {{ field.label }}
+                <span v-if="isSortableField(field)" class="inline-flex items-center gap-0.5" :data-testid="`collection-sort-${key}`">
+                  <span>{{ field.label }}</span>
+                  <span class="inline-flex flex-col -space-y-[5px]">
+                    <button
+                      type="button"
+                      class="material-icons text-[8px] leading-none hover:text-indigo-400 transition-colors"
+                      :class="sortState?.direction === 'asc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
+                      :aria-label="t('collectionsView.sortedAsc', { field: field.label })"
+                      @click="toggleSort(String(key), 'asc')"
+                    >expand_less</button>
+                    <button
+                      type="button"
+                      class="material-icons text-[8px] leading-none hover:text-indigo-400 transition-colors"
+                      :class="sortState?.direction === 'desc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
+                      :aria-label="t('collectionsView.sortedDesc', { field: field.label })"
+                      @click="toggleSort(String(key), 'desc')"
+                    >expand_more</button>
+                  </span>
+                </span>
+                <span v-else>{{ field.label }}</span>
               </th>
             </tr>
           </thead>
@@ -645,6 +664,7 @@ import { useShortcuts } from "../composables/useShortcuts";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
 import { resolveEnumColor } from "../utils/collections/enumColors";
 import { readCollectionViewMode, writeCollectionViewMode } from "../utils/collections/collectionViewMode";
+import { compareItems, readCollectionSort, writeCollectionSort, type SortDirection, type SortState } from "../utils/collections/collectionSort";
 import { useCollectionRendering } from "../composables/collections/useCollectionRendering";
 import { buildUpdatedRecord, coerceInlineValue, draftToRecord, firstMissingRequiredField, rowFromItem } from "../utils/collections/draft";
 import type {
@@ -783,6 +803,53 @@ const {
 
 const searchQuery = ref("");
 
+// ── Sort state ──────────────────────────────────────────────────────
+const sortState = ref<SortState | null>(null);
+
+const SORTABLE_TYPES = new Set(["string", "text", "email", "number", "date", "datetime", "boolean", "enum", "money", "toggle"]);
+
+function isSortableField(field: FieldSpec): boolean {
+  return SORTABLE_TYPES.has(field.type);
+}
+
+/** Resolve the actual data key for sorting: toggle fields project an
+ *  enum field and store no value themselves, so sort by the projected key. */
+function resolveSortKey(fieldKey: string): string {
+  const field = collection.value?.schema.fields[fieldKey];
+  if (field?.type === "toggle" && field.field) return field.field;
+  return fieldKey;
+}
+
+function toggleSort(fieldKey: string, direction: SortDirection): void {
+  const sortKey = resolveSortKey(fieldKey);
+  const current = sortState.value;
+  if (current?.field === sortKey && current.direction === direction) {
+    sortState.value = null;
+  } else {
+    sortState.value = { field: sortKey, direction };
+  }
+  persistSort();
+}
+
+function isSortedField(fieldKey: string): boolean {
+  const sortKey = resolveSortKey(fieldKey);
+  return sortState.value?.field === sortKey;
+}
+
+function persistSort(): void {
+  const slug = activeSlug.value;
+  if (!slug || embedded.value) return;
+  writeCollectionSort(slug, sortState.value);
+}
+
+function restoreSort(slug: string): void {
+  if (embedded.value) {
+    sortState.value = null;
+    return;
+  }
+  sortState.value = readCollectionSort(slug);
+}
+
 /** Case-insensitive substring match across an item's scalar fields.
  *  Object-valued fields (table rows, nested records) are skipped —
  *  they don't render as searchable text in the list table. */
@@ -795,8 +862,12 @@ function itemMatchesQuery(item: CollectionItem, query: string): boolean {
 
 const filteredItems = computed<CollectionItem[]>(() => {
   const query = searchQuery.value.trim().toLowerCase();
-  if (!query) return items.value;
-  return items.value.filter((item) => itemMatchesQuery(item, query));
+  const filtered = query ? items.value.filter((item) => itemMatchesQuery(item, query)) : [...items.value];
+  const sort = sortState.value;
+  if (!sort || !collection.value) return filtered;
+  const fieldSpec = collection.value.schema.fields[sort.field];
+  if (!fieldSpec) return filtered;
+  return filtered.sort((itemA, itemB) => compareItems(itemA, itemB, sort.field, fieldSpec, sort.direction));
 });
 
 // ────────────────────────────────────────────────────────────────
@@ -996,7 +1067,8 @@ async function loadCollection(slug: string): Promise<void> {
   loadError.value = null;
   collection.value = null;
   items.value = [];
-  searchQuery.value = ""; // Reset search query on collection load
+  searchQuery.value = "";
+  restoreSort(slug);
   render.resetLinkedCaches();
   viewing.value = null;
   openDay.value = null; // never carry a previous collection's open day over
@@ -1702,7 +1774,8 @@ watch(
       items.value = [];
       enumOriginallyEmpty.value = new Set();
       inlineSavingRows.value = new Set();
-      searchQuery.value = ""; // Reset search query
+      searchQuery.value = "";
+      sortState.value = null;
       loading.value = false;
     }
   },

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -383,14 +383,18 @@
                       :class="sortState?.direction === 'asc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
                       :aria-label="t('collectionsView.sortedAsc', { field: field.label })"
                       @click="toggleSort(String(key), 'asc')"
-                    >expand_less</button>
+                    >
+                      expand_less
+                    </button>
                     <button
                       type="button"
                       class="material-icons text-[8px] leading-none hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'desc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
                       :aria-label="t('collectionsView.sortedDesc', { field: field.label })"
                       @click="toggleSort(String(key), 'desc')"
-                    >expand_more</button>
+                    >
+                      expand_more
+                    </button>
                   </span>
                 </span>
                 <span v-else>{{ field.label }}</span>
@@ -860,13 +864,19 @@ function itemMatchesQuery(item: CollectionItem, query: string): boolean {
   });
 }
 
+function defaultSort(result: CollectionItem[]): CollectionItem[] {
+  const primaryKey = collection.value?.schema.primaryKey;
+  if (!primaryKey) return result;
+  return result.sort((itemA, itemB) => String(itemA[primaryKey] ?? "").localeCompare(String(itemB[primaryKey] ?? "")));
+}
+
 const filteredItems = computed<CollectionItem[]>(() => {
   const query = searchQuery.value.trim().toLowerCase();
   const filtered = query ? items.value.filter((item) => itemMatchesQuery(item, query)) : [...items.value];
   const sort = sortState.value;
-  if (!sort || !collection.value) return filtered;
+  if (!sort || !collection.value) return defaultSort(filtered);
   const fieldSpec = collection.value.schema.fields[sort.field];
-  if (!fieldSpec) return filtered;
+  if (!fieldSpec) return defaultSort(filtered);
   return filtered.sort((itemA, itemB) => compareItems(itemA, itemB, sort.field, fieldSpec, sort.direction));
 });
 

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -381,10 +381,10 @@
               >
                 <span v-if="isSortableField(field)" class="inline-flex items-center gap-0.5" :data-testid="`collection-sort-${key}`">
                   <span>{{ field.label }}</span>
-                  <span class="inline-flex flex-col -space-y-0.5">
+                  <span class="inline-flex flex-col">
                     <button
                       type="button"
-                      class="material-icons text-[10px] leading-none min-w-6 min-h-3 flex items-center justify-center hover:text-indigo-400 transition-colors"
+                      class="material-icons text-[10px] leading-none min-w-6 min-h-6 flex items-center justify-center hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'asc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
                       :aria-label="t('collectionsView.sortAsc', { field: field.label })"
                       @click="toggleSort(String(key), 'asc')"
@@ -393,7 +393,7 @@
                     </button>
                     <button
                       type="button"
-                      class="material-icons text-[10px] leading-none min-w-6 min-h-3 flex items-center justify-center hover:text-indigo-400 transition-colors"
+                      class="material-icons text-[10px] leading-none min-w-6 min-h-6 flex items-center justify-center hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'desc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
                       :aria-label="t('collectionsView.sortDesc', { field: field.label })"
                       @click="toggleSort(String(key), 'desc')"
@@ -846,12 +846,25 @@ function persistSort(): void {
   writeCollectionSort(slug, sortState.value);
 }
 
+function isSortableColumn(fieldKey: string): boolean {
+  const schema = collection.value?.schema;
+  if (!schema) return false;
+  const fieldSpec = schema.fields[fieldKey];
+  return fieldSpec != null && isSortableField(fieldSpec);
+}
+
 function restoreSort(slug: string): void {
   if (embedded.value) {
     sortState.value = null;
     return;
   }
-  sortState.value = readCollectionSort(slug);
+  const stored = readCollectionSort(slug);
+  if (stored && !isSortableColumn(stored.field)) {
+    writeCollectionSort(slug, null);
+    sortState.value = null;
+    return;
+  }
+  sortState.value = stored;
 }
 
 /** Case-insensitive substring match across an item's scalar fields.

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -373,24 +373,29 @@
         <table class="min-w-full text-xs">
           <thead>
             <tr class="bg-slate-50 border-b border-slate-200">
-              <th v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider">
+              <th
+                v-for="[key, field] in listColumnFields"
+                :key="key"
+                class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider"
+                :aria-sort="ariaSortValue(String(key))"
+              >
                 <span v-if="isSortableField(field)" class="inline-flex items-center gap-0.5" :data-testid="`collection-sort-${key}`">
                   <span>{{ field.label }}</span>
                   <span class="inline-flex flex-col -space-y-[5px]">
                     <button
                       type="button"
-                      class="material-icons text-[8px] leading-none hover:text-indigo-400 transition-colors"
+                      class="material-icons text-[8px] leading-none p-0.5 hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'asc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
-                      :aria-label="t('collectionsView.sortedAsc', { field: field.label })"
+                      :aria-label="t('collectionsView.sortAsc', { field: field.label })"
                       @click="toggleSort(String(key), 'asc')"
                     >
                       expand_less
                     </button>
                     <button
                       type="button"
-                      class="material-icons text-[8px] leading-none hover:text-indigo-400 transition-colors"
+                      class="material-icons text-[8px] leading-none p-0.5 hover:text-indigo-400 transition-colors"
                       :class="sortState?.direction === 'desc' && isSortedField(String(key)) ? 'text-indigo-600' : 'text-slate-300'"
-                      :aria-label="t('collectionsView.sortedDesc', { field: field.label })"
+                      :aria-label="t('collectionsView.sortDesc', { field: field.label })"
                       @click="toggleSort(String(key), 'desc')"
                     >
                       expand_more
@@ -838,6 +843,11 @@ function toggleSort(fieldKey: string, direction: SortDirection): void {
 function isSortedField(fieldKey: string): boolean {
   const sortKey = resolveSortKey(fieldKey);
   return sortState.value?.field === sortKey;
+}
+
+function ariaSortValue(fieldKey: string): "ascending" | "descending" | "none" | undefined {
+  if (!isSortedField(fieldKey)) return undefined;
+  return sortState.value?.direction === "asc" ? "ascending" : "descending";
 }
 
 function persistSort(): void {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1250,6 +1250,7 @@ const deMessages = {
     dashboardAllItems: "Alle Einträge",
     sortAsc: "Nach {field} aufsteigend sortieren",
     sortDesc: "Nach {field} absteigend sortieren",
+    sortClear: "Sortierung von {field} aufheben",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1248,8 +1248,8 @@ const deMessages = {
     viewDashboard: "Dashboard",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Alle Einträge",
-    sortedAsc: "Nach {field} aufsteigend sortiert",
-    sortedDesc: "Nach {field} absteigend sortiert",
+    sortAsc: "Nach {field} aufsteigend sortieren",
+    sortDesc: "Nach {field} absteigend sortieren",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1248,6 +1248,8 @@ const deMessages = {
     viewDashboard: "Dashboard",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Alle Einträge",
+    sortedAsc: "Nach {field} aufsteigend sortiert",
+    sortedDesc: "Nach {field} absteigend sortiert",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1232,8 +1232,8 @@ const enMessages = {
     viewDashboard: "Dashboard",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "All items",
-    sortedAsc: "Sorted by {field} ascending",
-    sortedDesc: "Sorted by {field} descending",
+    sortAsc: "Sort by {field} ascending",
+    sortDesc: "Sort by {field} descending",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1232,6 +1232,8 @@ const enMessages = {
     viewDashboard: "Dashboard",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "All items",
+    sortedAsc: "Sorted by {field} ascending",
+    sortedDesc: "Sorted by {field} descending",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1234,6 +1234,7 @@ const enMessages = {
     dashboardAllItems: "All items",
     sortAsc: "Sort by {field} ascending",
     sortDesc: "Sort by {field} descending",
+    sortClear: "Clear sort for {field}",
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1247,6 +1247,7 @@ const esMessages = {
     dashboardAllItems: "Todos los elementos",
     sortAsc: "Ordenar por {field} ascendente",
     sortDesc: "Ordenar por {field} descendente",
+    sortClear: "Quitar orden de {field}",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1245,6 +1245,8 @@ const esMessages = {
     viewDashboard: "Panel",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Todos los elementos",
+    sortedAsc: "Ordenado por {field} ascendente",
+    sortedDesc: "Ordenado por {field} descendente",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1245,8 +1245,8 @@ const esMessages = {
     viewDashboard: "Panel",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Todos los elementos",
-    sortedAsc: "Ordenado por {field} ascendente",
-    sortedDesc: "Ordenado por {field} descendente",
+    sortAsc: "Ordenar por {field} ascendente",
+    sortDesc: "Ordenar por {field} descendente",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1238,8 +1238,8 @@ const frMessages = {
     viewDashboard: "Tableau de bord",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Tous les éléments",
-    sortedAsc: "Trié par {field} croissant",
-    sortedDesc: "Trié par {field} décroissant",
+    sortAsc: "Trier par {field} croissant",
+    sortDesc: "Trier par {field} décroissant",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1240,6 +1240,7 @@ const frMessages = {
     dashboardAllItems: "Tous les éléments",
     sortAsc: "Trier par {field} croissant",
     sortDesc: "Trier par {field} décroissant",
+    sortClear: "Annuler le tri de {field}",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1238,6 +1238,8 @@ const frMessages = {
     viewDashboard: "Tableau de bord",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Tous les éléments",
+    sortedAsc: "Trié par {field} croissant",
+    sortedDesc: "Trié par {field} décroissant",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1228,6 +1228,8 @@ const jaMessages = {
     viewDashboard: "ダッシュボード",
     dashboardAlertHeading: "{label} — {count}件",
     dashboardAllItems: "一覧",
+    sortedAsc: "{field}の昇順で並べ替え中",
+    sortedDesc: "{field}の降順で並べ替え中",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1228,8 +1228,8 @@ const jaMessages = {
     viewDashboard: "ダッシュボード",
     dashboardAlertHeading: "{label} — {count}件",
     dashboardAllItems: "一覧",
-    sortedAsc: "{field}の昇順で並べ替え中",
-    sortedDesc: "{field}の降順で並べ替え中",
+    sortAsc: "{field}を昇順で並べ替え",
+    sortDesc: "{field}を降順で並べ替え",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1230,6 +1230,7 @@ const jaMessages = {
     dashboardAllItems: "一覧",
     sortAsc: "{field}を昇順で並べ替え",
     sortDesc: "{field}を降順で並べ替え",
+    sortClear: "{field}の並べ替えを解除",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1234,6 +1234,7 @@ const koMessages = {
     dashboardAllItems: "전체 항목",
     sortAsc: "{field} 오름차순 정렬",
     sortDesc: "{field} 내림차순 정렬",
+    sortClear: "{field} 정렬 해제",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1232,6 +1232,8 @@ const koMessages = {
     viewDashboard: "대시보드",
     dashboardAlertHeading: "{label} — {count}건",
     dashboardAllItems: "전체 항목",
+    sortedAsc: "{field} 오름차순 정렬 중",
+    sortedDesc: "{field} 내림차순 정렬 중",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1232,8 +1232,8 @@ const koMessages = {
     viewDashboard: "대시보드",
     dashboardAlertHeading: "{label} — {count}건",
     dashboardAllItems: "전체 항목",
-    sortedAsc: "{field} 오름차순 정렬 중",
-    sortedDesc: "{field} 내림차순 정렬 중",
+    sortAsc: "{field} 오름차순 정렬",
+    sortDesc: "{field} 내림차순 정렬",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1234,6 +1234,8 @@ const ptBRMessages = {
     viewDashboard: "Painel",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Todos os itens",
+    sortedAsc: "Ordenado por {field} crescente",
+    sortedDesc: "Ordenado por {field} decrescente",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1234,8 +1234,8 @@ const ptBRMessages = {
     viewDashboard: "Painel",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Todos os itens",
-    sortedAsc: "Ordenado por {field} crescente",
-    sortedDesc: "Ordenado por {field} decrescente",
+    sortAsc: "Ordenar por {field} crescente",
+    sortDesc: "Ordenar por {field} decrescente",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1236,6 +1236,7 @@ const ptBRMessages = {
     dashboardAllItems: "Todos os itens",
     sortAsc: "Ordenar por {field} crescente",
     sortDesc: "Ordenar por {field} decrescente",
+    sortClear: "Limpar ordenação de {field}",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1223,6 +1223,7 @@ const zhMessages = {
     dashboardAllItems: "全部条目",
     sortAsc: "按{field}升序排列",
     sortDesc: "按{field}降序排列",
+    sortClear: "清除{field}的排序",
     source: {
       user: "用户",
       project: "项目",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1221,6 +1221,8 @@ const zhMessages = {
     viewDashboard: "仪表板",
     dashboardAlertHeading: "{label} — {count} 项",
     dashboardAllItems: "全部条目",
+    sortedAsc: "按{field}升序排列",
+    sortedDesc: "按{field}降序排列",
     source: {
       user: "用户",
       project: "项目",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1221,8 +1221,8 @@ const zhMessages = {
     viewDashboard: "仪表板",
     dashboardAlertHeading: "{label} — {count} 项",
     dashboardAllItems: "全部条目",
-    sortedAsc: "按{field}升序排列",
-    sortedDesc: "按{field}降序排列",
+    sortAsc: "按{field}升序排列",
+    sortDesc: "按{field}降序排列",
     source: {
       user: "用户",
       project: "项目",

--- a/src/utils/collections/collectionSort.ts
+++ b/src/utils/collections/collectionSort.ts
@@ -1,0 +1,110 @@
+// Per-collection sort preference persisted to localStorage, keyed by
+// collection slug. Lets the standalone `/collections/:slug` page reopen
+// with the last-used sort instead of the default order. Embedded
+// chat-card mode persists its own `viewState` and does NOT use this.
+
+import type { CollectionItem, FieldSpec } from "../../components/collectionTypes";
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortState {
+  field: string;
+  direction: SortDirection;
+}
+
+const STORAGE_KEY = "collection_sort_states";
+
+type SortStateMap = Record<string, SortState>;
+
+function readAll(): SortStateMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as SortStateMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+function isValidSortState(value: unknown): value is SortState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.field === "string" && (obj.direction === "asc" || obj.direction === "desc");
+}
+
+export function readCollectionSort(slug: string): SortState | null {
+  const stored = readAll()[slug];
+  return isValidSortState(stored) ? stored : null;
+}
+
+export function writeCollectionSort(slug: string, sort: SortState | null): void {
+  try {
+    const all = readAll();
+    if (sort) {
+      all[slug] = sort;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- clearing a specific key from a string-keyed map
+      delete all[slug];
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+function toNumber(val: unknown): number {
+  const num = Number(val);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function toBoolean(val: unknown): boolean {
+  return val === true;
+}
+
+function compareNumeric(valLeft: unknown, valRight: unknown): number {
+  return toNumber(valLeft) - toNumber(valRight);
+}
+
+function compareBooleans(valLeft: unknown, valRight: unknown): number {
+  if (toBoolean(valLeft) === toBoolean(valRight)) return 0;
+  return toBoolean(valLeft) ? 1 : -1;
+}
+
+function compareEnumValues(valLeft: unknown, valRight: unknown, values: readonly string[]): number {
+  const idxLeft = values.indexOf(String(valLeft));
+  const idxRight = values.indexOf(String(valRight));
+  const posLeft = idxLeft === -1 ? values.length : idxLeft;
+  const posRight = idxRight === -1 ? values.length : idxRight;
+  return posLeft - posRight;
+}
+
+function compareByType(valLeft: unknown, valRight: unknown, fieldSpec: FieldSpec): number {
+  switch (fieldSpec.type) {
+    case "number":
+    case "money":
+      return compareNumeric(valLeft, valRight);
+    case "boolean":
+    case "toggle":
+      return compareBooleans(valLeft, valRight);
+    case "enum":
+      if (fieldSpec.values) return compareEnumValues(valLeft, valRight, fieldSpec.values);
+      return String(valLeft).localeCompare(String(valRight));
+    default:
+      return String(valLeft).localeCompare(String(valRight));
+  }
+}
+
+/** Compare two items for sorting by a given field. Null/undefined values
+ *  always sort to the end regardless of direction. */
+export function compareItems(itemLeft: CollectionItem, itemRight: CollectionItem, field: string, fieldSpec: FieldSpec, direction: SortDirection): number {
+  const valLeft = itemLeft[field];
+  const valRight = itemRight[field];
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  if (valLeft == null && valRight == null) return 0;
+  if (valLeft == null) return 1;
+  if (valRight == null) return -1;
+
+  return multiplier * compareByType(valLeft, valRight, fieldSpec);
+}

--- a/src/utils/collections/collectionSort.ts
+++ b/src/utils/collections/collectionSort.ts
@@ -95,11 +95,18 @@ function compareByType(valLeft: unknown, valRight: unknown, fieldSpec: FieldSpec
   }
 }
 
+function resolveToggleValues(itemLeft: CollectionItem, itemRight: CollectionItem, fieldSpec: FieldSpec): [unknown, unknown] {
+  const projectedKey = fieldSpec.field ?? "";
+  return [itemLeft[projectedKey] === fieldSpec.onValue, itemRight[projectedKey] === fieldSpec.onValue];
+}
+
 /** Compare two items for sorting by a given field. Null/undefined values
- *  always sort to the end regardless of direction. */
+ *  always sort to the end regardless of direction.
+ *  Toggle fields read the projected enum value and compare as binary
+ *  (matches onValue → true, otherwise false). */
 export function compareItems(itemLeft: CollectionItem, itemRight: CollectionItem, field: string, fieldSpec: FieldSpec, direction: SortDirection): number {
-  const valLeft = itemLeft[field];
-  const valRight = itemRight[field];
+  const [valLeft, valRight] =
+    fieldSpec.type === "toggle" && fieldSpec.field ? resolveToggleValues(itemLeft, itemRight, fieldSpec) : [itemLeft[field], itemRight[field]];
   const multiplier = direction === "asc" ? 1 : -1;
 
   if (valLeft == null && valRight == null) return 0;

--- a/test/components/test_collection_sort.ts
+++ b/test/components/test_collection_sort.ts
@@ -1,0 +1,118 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { compareItems, type SortDirection } from "../../src/utils/collections/collectionSort.js";
+import type { CollectionItem, FieldSpec } from "../../src/components/collectionTypes.js";
+
+function field(type: string, values?: readonly string[]): FieldSpec {
+  return { type: type as FieldSpec["type"], label: type, values } as FieldSpec;
+}
+
+function compare(left: unknown, right: unknown, spec: FieldSpec, dir: SortDirection = "asc"): number {
+  const itemLeft: CollectionItem = { val: left };
+  const itemRight: CollectionItem = { val: right };
+  return compareItems(itemLeft, itemRight, "val", spec, dir);
+}
+
+describe("compareItems", () => {
+  describe("string fields", () => {
+    const spec = field("string");
+    test("sorts alphabetically ascending", () => {
+      assert.ok(compare("apple", "banana", spec) < 0);
+    });
+    test("sorts alphabetically descending", () => {
+      assert.ok(compare("apple", "banana", spec, "desc") > 0);
+    });
+    test("equal strings return 0", () => {
+      assert.equal(compare("same", "same", spec), 0);
+    });
+  });
+
+  describe("number fields", () => {
+    const spec = field("number");
+    test("sorts numerically ascending", () => {
+      assert.ok(compare(1, 10, spec) < 0);
+    });
+    test("sorts numerically descending", () => {
+      assert.ok(compare(1, 10, spec, "desc") > 0);
+    });
+    test("equal numbers return 0", () => {
+      assert.equal(compare(5, 5, spec), 0);
+    });
+    test("non-finite values treated as 0", () => {
+      assert.equal(compare("not-a-number", "also-not", spec), 0);
+    });
+  });
+
+  describe("money fields", () => {
+    const spec = field("money");
+    test("sorts like numbers", () => {
+      assert.ok(compare(100, 200, spec) < 0);
+    });
+  });
+
+  describe("boolean fields", () => {
+    const spec = field("boolean");
+    test("false before true ascending", () => {
+      assert.ok(compare(false, true, spec) < 0);
+    });
+    test("true before false descending", () => {
+      assert.ok(compare(false, true, spec, "desc") > 0);
+    });
+    test("equal booleans return 0", () => {
+      assert.equal(compare(true, true, spec), 0);
+    });
+  });
+
+  describe("date fields", () => {
+    const spec = field("date");
+    test("sorts ISO date strings ascending", () => {
+      assert.ok(compare("2024-01-01", "2024-12-31", spec) < 0);
+    });
+    test("sorts descending", () => {
+      assert.ok(compare("2024-01-01", "2024-12-31", spec, "desc") > 0);
+    });
+  });
+
+  describe("enum fields", () => {
+    const spec = field("enum", ["todo", "in-progress", "done"]);
+    test("sorts by declaration order ascending", () => {
+      assert.ok(compare("todo", "done", spec) < 0);
+      assert.ok(compare("in-progress", "done", spec) < 0);
+    });
+    test("unknown values sort after known values", () => {
+      assert.ok(compare("done", "unknown-val", spec) < 0);
+    });
+    test("sorts descending", () => {
+      assert.ok(compare("todo", "done", spec, "desc") > 0);
+    });
+    test("enum without values falls back to string compare", () => {
+      const noValues = field("enum");
+      assert.ok(compare("alpha", "beta", noValues) < 0);
+    });
+  });
+
+  describe("null/undefined handling", () => {
+    const spec = field("string");
+    test("null sorts to the end regardless of direction", () => {
+      assert.ok(compare(null, "value", spec) > 0);
+      assert.ok(compare(null, "value", spec, "desc") > 0);
+    });
+    test("undefined sorts to the end", () => {
+      assert.ok(compare(undefined, "value", spec) > 0);
+    });
+    test("both null returns 0", () => {
+      assert.equal(compare(null, null, spec), 0);
+    });
+    test("null on right sorts to end", () => {
+      assert.ok(compare("value", null, spec) < 0);
+    });
+  });
+
+  describe("toggle fields", () => {
+    const spec = field("toggle");
+    test("sorts like boolean", () => {
+      assert.ok(compare(false, true, spec) < 0);
+    });
+  });
+});

--- a/test/components/test_collection_sort.ts
+++ b/test/components/test_collection_sort.ts
@@ -109,10 +109,32 @@ describe("compareItems", () => {
     });
   });
 
-  describe("toggle fields", () => {
-    const spec = field("toggle");
-    test("sorts like boolean", () => {
-      assert.ok(compare(false, true, spec) < 0);
+  describe("toggle fields (projected enum)", () => {
+    const toggleSpec: FieldSpec = { type: "toggle", label: "Done", field: "status", onValue: "Done", offValue: "Todo" };
+
+    function compareToggle(leftStatus: unknown, rightStatus: unknown, dir: SortDirection = "asc"): number {
+      const itemLeft: CollectionItem = { status: leftStatus };
+      const itemRight: CollectionItem = { status: rightStatus };
+      return compareItems(itemLeft, itemRight, "done", toggleSpec, dir);
+    }
+
+    test("onValue items sort after non-onValue ascending (true > false)", () => {
+      assert.ok(compareToggle("Done", "Todo") > 0);
+    });
+    test("non-onValue items sort before onValue ascending", () => {
+      assert.ok(compareToggle("Todo", "Done") < 0);
+    });
+    test("both onValue returns 0", () => {
+      assert.equal(compareToggle("Done", "Done"), 0);
+    });
+    test("both non-onValue returns 0", () => {
+      assert.equal(compareToggle("Todo", "In Progress"), 0);
+    });
+    test("descending reverses order", () => {
+      assert.ok(compareToggle("Done", "Todo", "desc") < 0);
+    });
+    test("null projected value treated as unchecked", () => {
+      assert.equal(compareToggle(null, "Todo"), 0);
     });
   });
 });


### PR DESCRIPTION
## Summary

コレクションのテーブル表示（リストビュー）にカラムソート機能を追加。
期日等でソートする機能追加です。
<img width="661" height="695" alt="CleanShot 2026-06-10 at 14 56 03" src="https://github.com/user-attachments/assets/796351bb-0014-4db5-b018-d52bc81b4da1" />


<img width="1006" height="692" alt="CleanShot 2026-06-10 at 14 57 15" src="https://github.com/user-attachments/assets/fea30954-43de-477b-86e2-9838e36201fe" />


- 対象: string / text / email / number / date / datetime / boolean / enum / money / toggle の各フィールド型
- ソート状態は localStorage にコレクション slug ごとに永続化（embedded モードでは無効）
- 明示的ソートがない場合は primary key のアルファベット順でデフォルトソート
- toggle フィールドは projected enum の値を二値（onValue 一致 or not）で比較



## Items to Confirm / Review

- ソートボタンのサイズ感（各 24×24px、2つ縦並びで 48px）がヘッダー行の見た目として許容範囲か
- toggle と enum が同じカラムを指す場合、クリックした列のみがハイライトされる挙動の確認
- stale な sort state（スキーマ変更後に存在しなくなったフィールド）が自動クリアされる挙動

## User Prompt

- コレクションのリスト表示にフィルタ・ソートを入れたい（todo の未実施を上に / due date でソート / 未完了だけ表示）
- まずソートだけ先に実装
- done フィールド（toggle 型）のソートに対応してほしい
- 矢印アイコンは常に上下が見えて、有効な方だけ強調される形式
- 上押したらソート、もう一度上押したらソート解除（下も同様、サイクリックではない）
- デフォルトの並び順は primary key のアルファベット順

## Codex Cross-Review

Codex + Claude の 5 iteration cross-review 済み。主な修正:
- aria-sort / aria-label 追加（アクセシビリティ）
- toggle ソートの二値セマンティクス修正（enum declaration order → binary）
- ソートボタンの WCAG 2.2 ターゲットサイズ対応（24×24px）
- 永続化 sort state のスキーマ validation + timing 修正

---

## Summary by Sourcery

Add sortable collection table columns with persisted per-collection sort preferences and default primary-key ordering.

New Features:
- Enable column-level ascending/descending sorting for supported collection fields in the list view, including accessible sort controls and ARIA attributes.
- Persist per-collection sort state in localStorage so standalone collection views reopen with the last-used sort instead of the default order.

Enhancements:
- Apply a stable default sort by primary key when no explicit sort is active to provide deterministic item ordering.
- Validate and restore stored sort state only for currently sortable fields, clearing invalid persisted preferences when schemas change.

Tests:
- Introduce unit tests for collection sorting logic across field types, including strings, numbers, money, booleans, dates, enums, toggles, and null handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table view columns are now user-sortable (cycle none → asc → desc) with accessible labels and visuals.
* **Behavior Changes**
  * Sort and search reset when switching collections; persisted sort is stored/restored in standalone mode only.
  * When no active sort, items fall back to default collection ordering.
* **Internationalization**
  * Added sorting UI labels for DE, EN, ES, FR, JA, KO, PT‑BR and ZH.
* **Tests**
  * Added tests covering sorting behavior across field types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->