### PR TITLE
feat: enable inline toggle for boolean cells in table sub-rows

### DIFF
--- a/e2e/tests/collection-table-bool-toggle.spec.ts
+++ b/e2e/tests/collection-table-bool-toggle.spec.ts
@@ -1,0 +1,127 @@
+// E2E coverage for toggling a boolean cell inside a `table` sub-row
+// directly from the read-only detail panel (no edit-mode round-trip).
+// Pins: the checkbox fires a PUT with the toggled value, a failed PUT
+// rolls back, and checkboxes are disabled while a save is in flight.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const TASKS = {
+  collection: {
+    slug: "tasks",
+    title: "Tasks",
+    icon: "task_alt",
+    source: "user",
+    schema: {
+      title: "Tasks",
+      icon: "task_alt",
+      dataPath: "data/tasks/items",
+      primaryKey: "name",
+      fields: {
+        name: { type: "string", label: "Task", primary: true, required: true },
+        checklist: {
+          type: "table",
+          label: "Checklist",
+          of: {
+            item: { type: "string", label: "Item" },
+            done: { type: "boolean", label: "Done" },
+          },
+        },
+      },
+    },
+  },
+  items: [
+    {
+      name: "prep",
+      checklist: [
+        { item: "Step A", done: true },
+        { item: "Step B", done: false },
+      ],
+    },
+  ],
+};
+
+async function setupRoutes(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/tasks",
+    (route) => route.fulfill({ json: TASKS }),
+  );
+}
+
+async function mockItemPut(page: Page, ok: boolean): Promise<{ body: Promise<Record<string, unknown>> }> {
+  let resolveBody: (body: Record<string, unknown>) => void;
+  const body = new Promise<Record<string, unknown>>((resolve) => {
+    resolveBody = resolve;
+  });
+  await page.route(
+    (url) => url.pathname.startsWith("/api/collections/tasks/items/"),
+    (route) => {
+      if (route.request().method() !== "PUT") return route.fallback();
+      const parsed = JSON.parse(route.request().postData() ?? "{}");
+      resolveBody(parsed);
+      const itemId = decodeURIComponent(route.request().url().split("/items/").pop() ?? "");
+      if (!ok) return route.fulfill({ status: 500, json: { error: "boom" } });
+      return route.fulfill({ json: { itemId, item: parsed } });
+    },
+  );
+  return { body };
+}
+
+async function openDetail(page: Page): Promise<void> {
+  await page.goto("/collections/tasks");
+  await page.getByTestId("collections-row-prep").click();
+  await expect(page.getByTestId("collections-detail")).toBeVisible();
+}
+
+test.describe("table boolean toggle in detail panel", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await setupRoutes(page);
+  });
+
+  test("toggling a sub-row boolean checkbox PUTs the updated record", async ({ page }) => {
+    const { body } = await mockItemPut(page, true);
+    await openDetail(page);
+    const checkbox = page.getByTestId("collections-detail-table-bool-checklist-1-done");
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.check();
+    const put = await body;
+    expect(put.name).toBe("prep");
+    const checklist = put.checklist as { item: string; done: boolean }[];
+    expect(checklist[0].done).toBe(true);
+    expect(checklist[1].done).toBe(true);
+  });
+
+  test("a failed PUT rolls the checkbox back", async ({ page }) => {
+    await mockItemPut(page, false);
+    await openDetail(page);
+    const checkbox = page.getByTestId("collections-detail-table-bool-checklist-1-done");
+    await checkbox.click();
+    await expect(checkbox).not.toBeChecked();
+  });
+
+  test("checkboxes are disabled while save is in flight", async ({ page }) => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await page.route(
+      (url) => url.pathname.startsWith("/api/collections/tasks/items/"),
+      async (route) => {
+        if (route.request().method() !== "PUT") return route.fallback();
+        await gate;
+        const itemId = decodeURIComponent(route.request().url().split("/items/").pop() ?? "");
+        return route.fulfill({ json: { itemId, item: JSON.parse(route.request().postData() ?? "{}") } });
+      },
+    );
+    await openDetail(page);
+    const checkbox0 = page.getByTestId("collections-detail-table-bool-checklist-0-done");
+    const checkbox1 = page.getByTestId("collections-detail-table-bool-checklist-1-done");
+    await checkbox1.click();
+    await expect(checkbox0).toBeDisabled();
+    await expect(checkbox1).toBeDisabled();
+    release();
+    await expect(checkbox0).toBeEnabled();
+    await expect(checkbox1).toBeEnabled();
+  });
+});

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -352,9 +352,13 @@
                   <tr v-for="(row, rowIdx) in render.tableRows(detailRecord[key])" :key="rowIdx" class="hover:bg-slate-50/50">
                     <td v-for="(subField, subKey) in field.of" :key="subKey" class="px-4 py-2 align-middle font-medium">
                       <template v-if="subField.type === 'boolean'">
-                        <span v-if="row[subKey] === true" class="material-icons text-emerald-600 text-base">check_circle</span>
-                        <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph (boolean=false), same as elsewhere. -->
-                        <span v-else class="text-slate-300">—</span>
+                        <input
+                          type="checkbox"
+                          :checked="row[subKey] === true"
+                          class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                          :data-testid="`collections-detail-table-bool-${key}-${rowIdx}-${subKey}`"
+                          @change="emit('toggleTableBool', String(key), rowIdx, String(subKey), !row[subKey])"
+                        />
                       </template>
                       <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
                         render.formatSubCell(subField, row[subKey], detailRecord)
@@ -475,6 +479,7 @@ const emit = defineEmits<{
   close: [];
   delete: [];
   runAction: [action: CollectionAction];
+  toggleTableBool: [fieldKey: string, rowIndex: number, subKey: string, newValue: boolean];
 }>();
 
 const { t } = useI18n();

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -355,9 +355,10 @@
                         <input
                           type="checkbox"
                           :checked="row[subKey] === true"
-                          class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer"
+                          :disabled="tableBoolSaving"
+                          class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                           :data-testid="`collections-detail-table-bool-${key}-${rowIdx}-${subKey}`"
-                          @change="emit('toggleTableBool', String(key), rowIdx, String(subKey), !row[subKey])"
+                          @change="emit('toggleTableBool', String(key), row, String(subKey), !row[subKey])"
                         />
                       </template>
                       <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{
@@ -464,6 +465,8 @@ const props = defineProps<{
   /** Shared rendering/derivation helpers + ref/embed caches. */
   render: CollectionRendering;
   locale: string;
+  /** True while a table-bool inline save is in flight — disables checkboxes. */
+  tableBoolSaving?: boolean;
 }>();
 
 // The edit/create draft is a two-way model: the form's v-model bindings and
@@ -479,7 +482,7 @@ const emit = defineEmits<{
   close: [];
   delete: [];
   runAction: [action: CollectionAction];
-  toggleTableBool: [fieldKey: string, rowIndex: number, subKey: string, newValue: boolean];
+  toggleTableBool: [fieldKey: string, row: Record<string, unknown>, subKey: string, newValue: boolean];
 }>();
 
 const { t } = useI18n();

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -356,7 +356,7 @@
                           type="checkbox"
                           :checked="row[subKey] === true"
                           :disabled="tableBoolSaving"
-                          :aria-label="`${subField.label}`"
+                          :aria-label="`${subField.label} #${rowIdx + 1}`"
                           class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                           :data-testid="`collections-detail-table-bool-${key}-${rowIdx}-${subKey}`"
                           @change="emit('toggleTableBool', String(key), row, String(subKey), ($event.target as HTMLInputElement).checked)"

--- a/src/components/CollectionRecordPanel.vue
+++ b/src/components/CollectionRecordPanel.vue
@@ -356,9 +356,10 @@
                           type="checkbox"
                           :checked="row[subKey] === true"
                           :disabled="tableBoolSaving"
+                          :aria-label="`${subField.label}`"
                           class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                           :data-testid="`collections-detail-table-bool-${key}-${rowIdx}-${subKey}`"
-                          @change="emit('toggleTableBool', String(key), row, String(subKey), !row[subKey])"
+                          @change="emit('toggleTableBool', String(key), row, String(subKey), ($event.target as HTMLInputElement).checked)"
                         />
                       </template>
                       <span v-else :class="[subField.type === 'money' ? 'font-bold text-slate-800 tabular-nums' : '']">{{

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -271,6 +271,7 @@
               :is-singleton="isSingleton"
               :render="render"
               :locale="locale"
+              :table-bool-saving="tableBoolSaving"
               @submit="saveEditor"
               @cancel="cancelEditor"
               @edit="editFromView"
@@ -543,6 +544,7 @@
         :is-singleton="isSingleton"
         :render="render"
         :locale="locale"
+        :table-bool-saving="tableBoolSaving"
         @submit="saveEditor"
         @cancel="cancelEditor"
         @edit="editFromView"
@@ -758,6 +760,10 @@ const enumOriginallyEmpty = ref<Set<string>>(new Set());
  *  otherwise clobber the newer field on disk while the UI shows the
  *  newer optimistic value (Codex PR #1599 P2). */
 const inlineSavingRows = ref<Set<string>>(new Set());
+const tableBoolSaving = computed(() => {
+  const item = viewing.value;
+  return item !== null && inlineSavingRows.value.has(rowId(item));
+});
 const actionPending = ref(false);
 const actionError = ref<string | null>(null);
 const chatOpen = ref(false);
@@ -1515,23 +1521,23 @@ function commitToggle(item: CollectionItem, field: FieldSpec): void {
 }
 
 /** Toggle a boolean cell inside a table sub-row of the detail panel.
- *  Optimistic update + PUT, same pattern as commitInlineEdit. */
-async function commitTableBoolToggle(fieldKey: string, rowIndex: number, subKey: string, newValue: boolean): Promise<void> {
+ *  Receives the row object reference from the filtered `tableRows()` list
+ *  and looks it up by identity in the raw array, avoiding index mismatch
+ *  when non-object entries are filtered out. */
+async function commitTableBoolToggle(fieldKey: string, row: Record<string, unknown>, subKey: string, newValue: boolean): Promise<void> {
   const item = viewing.value;
   if (!item || !collection.value) return;
   const { slug } = collection.value;
   const itemId = rowId(item);
   if (!itemId || inlineSavingRows.value.has(itemId)) return;
-  const rows = item[fieldKey];
-  if (!Array.isArray(rows) || rowIndex >= rows.length) return;
-  const previous = rows[rowIndex][subKey];
-  rows[rowIndex][subKey] = newValue;
+  const previous = row[subKey];
+  row[subKey] = newValue;
   inlineError.value = null;
   inlineSavingRows.value.add(itemId);
   const result = await apiPut<ItemMutationResponse>(itemUrl(slug, itemId), { ...item });
   inlineSavingRows.value.delete(itemId);
   if (!result.ok) {
-    rows[rowIndex][subKey] = previous;
+    row[subKey] = previous;
     inlineError.value = result.error;
   }
 }

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -277,6 +277,7 @@
               @close="onDayClose"
               @delete="viewing && confirmDelete(viewing)"
               @run-action="runAction"
+              @toggle-table-bool="commitTableBoolToggle"
             />
           </template>
         </CollectionDayView>
@@ -548,6 +549,7 @@
         @close="closeView"
         @delete="viewing && confirmDelete(viewing)"
         @run-action="runAction"
+        @toggle-table-bool="commitTableBoolToggle"
       />
     </CollectionRecordModal>
 
@@ -1510,6 +1512,28 @@ function commitToggle(item: CollectionItem, field: FieldSpec): void {
   const next = toggleChecked(item, field) ? field.offValue : field.onValue;
   if (next === undefined) return;
   void commitInlineEdit(item, targetKey, enumField, next);
+}
+
+/** Toggle a boolean cell inside a table sub-row of the detail panel.
+ *  Optimistic update + PUT, same pattern as commitInlineEdit. */
+async function commitTableBoolToggle(fieldKey: string, rowIndex: number, subKey: string, newValue: boolean): Promise<void> {
+  const item = viewing.value;
+  if (!item || !collection.value) return;
+  const { slug } = collection.value;
+  const itemId = rowId(item);
+  if (!itemId || inlineSavingRows.value.has(itemId)) return;
+  const rows = item[fieldKey];
+  if (!Array.isArray(rows) || rowIndex >= rows.length) return;
+  const previous = rows[rowIndex][subKey];
+  rows[rowIndex][subKey] = newValue;
+  inlineError.value = null;
+  inlineSavingRows.value.add(itemId);
+  const result = await apiPut<ItemMutationResponse>(itemUrl(slug, itemId), { ...item });
+  inlineSavingRows.value.delete(itemId);
+  if (!result.ok) {
+    rows[rowIndex][subKey] = previous;
+    inlineError.value = result.error;
+  }
 }
 
 async function confirmDelete(item: CollectionItem): Promise<void> {


### PR DESCRIPTION
## Summary

#1670 対応: コレクション詳細パネルの `table.of` 内 boolean フィールドをワンクリックでトグル可能にした。
- 読み取り専用モードのサブチェックリストが Material Icons 表示からネイティブ checkbox に変わり、クリック → optimistic PUT → 即反映（編集モード不要）
- メインリストの inline toggle と同じ UX パターン（optimistic update + rollback + saving 中 disabled）を採用
- Codex cross-review 3 iterations で収束（row index mismatch 修正、aria-label、E2E テスト追加）

<img width="619" height="434" alt="CleanShot 2026-06-10 at 15 34 51" src="https://github.com/user-attachments/assets/2973b3a1-51b8-408d-959c-cfb0ece0faa4" />

## Items to Confirm / Review

- `commitTableBoolToggle` で row object の参照を直接使って index mismatch を回避しているが、`tableRows()` フィルタが参照を保持する前提の妥当性
- `tableBoolSaving` prop が item 単位の粒度で全 checkbox を disable する設計（行単位ではなく item 単位）

## User Prompt

- コレクション詳細パネルのサブチェックリスト（`table.of` 内 `boolean`）が読み取り専用で、トグルするには編集モードに入る必要がある
- 少なくともサブチェックリストのチェックボックスだけはサクッと完了にしたい
- メインとサブでアイコン表示が異なる（メイン: ネイティブ checkbox、サブ: Material Icons `check_circle`）点も統一したい

## 変更内容

### `src/components/CollectionRecordPanel.vue`
- 読み取り専用テーブルの boolean セルを `check_circle` アイコン / `—` 表示からネイティブ `<input type="checkbox">` に変更
- `tableBoolSaving` prop で saving 中に checkbox を disabled 化
- `aria-label` に行番号を含めてアクセシビリティ対応
- `toggleTableBool` emit を追加（fieldKey, row object, subKey, newValue）

### `src/components/CollectionView.vue`
- `commitTableBoolToggle` 関数を追加 — row object 参照で直接変更 + PUT API
- `tableBoolSaving` computed を追加（`inlineSavingRows` ベース）
- 2 箇所の panel 使用箇所に prop + event handler を追加

### `e2e/tests/collection-table-bool-toggle.spec.ts` (新規)
- toggle PUT の正常系、失敗時 rollback、saving 中 disabled の 3 テスト

## Codex Cross-Review

| Iteration | Verdict | 主な指摘と対応 |
|---|---|---|
| 1 | CHANGES REQUESTED | `tableRows()` フィルタ後の index ずれ → row reference 渡しに変更 / saving 中 disabled 追加 |
| 2 | CHANGES REQUESTED | `!row[subKey]` → `event.target.checked` / aria-label 追加 / E2E テスト追加 |
| 3 | LGTM (1 nit) | aria-label に行番号追加 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean fields in collection detail table sub-rows are now interactive checkboxes instead of static displays.
  * Changes persist with inline saving and automatic rollback on save failures.
  * System prevents concurrent edits on the same row while a save is in progress.

* **Tests**
  * Added comprehensive end-to-end tests validating boolean field toggle behavior, save operations, error handling, and edit state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->