### PR TITLE
chore: bump root version to 0.7.0 (sync with mulmoclaude@0.7.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",


### PR DESCRIPTION
## Summary
PR #1667 landed the launcher bump (`packages/mulmoclaude/package.json` → 0.7.0, `bin/mulmoclaude.js` version string, CHANGELOG entry) but the monorepo `package.json` at the repo root was missed. The `/release-app` skill reads the root version when it tags the GitHub release, so leaving it at 0.6.5 would mismatch the upcoming `v0.7.0` tag.

This PR brings the root in line. **One-line change, no other modifications.**

## Items to Confirm / Review
- The root `package.json` is the source-of-truth that `/release-app` step 4 expects (`jq -r .version package.json`).
- No other files need touching — `packages/mulmoclaude/package.json`, `bin/mulmoclaude.js`, and `docs/CHANGELOG.md` were all bumped in PR #1667.
- After this lands, the v0.7.0 git tag + GitHub release will match the repo state exactly.

## User Prompt
> `/release-app` を呼んだ流れで root の bump 漏れに気づいたので新規 PR で補修。

## Test Plan
- [ ] CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->