### PR TITLE
Collections UI improvements + persisted/shared table sort

### DIFF
--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -57,6 +57,7 @@ This catalog only covers **cross-cutting** helpers — formatters, error helpers
 | `server/utils/slug.ts` | slug helpers | URL-safe slugs from arbitrary text. |
 | `src/lib/wiki-page/slug.ts` | wiki page slug helpers | Wiki-specific slug shape (separate from the server one because the rules differ). |
 | `server/utils/id.ts` | id generation | Stable IDs (attachment, session). |
+| `src/utils/promptSafety.ts` | `defangForPrompt(value)` | Neutralize record-controlled text before interpolating it into an LLM-facing prompt: strips `<>`, defangs backticks / `${`, collapses whitespace (blocks newline-injected pseudo-instructions), clips to 200 chars. Used by BOTH the server (`presentCollection` validation → instructions) and the client (collection Repair button) so the two can't drift. |
 
 ## Regex
 

--- a/e2e/tests/collection-sort-persist.spec.ts
+++ b/e2e/tests/collection-sort-persist.spec.ts
@@ -1,0 +1,86 @@
+// E2E: the standalone /collections/:slug table persists the user's active
+// column sort across a page reload (localStorage, keyed by slug). Pins the
+// behaviour requested in the collections UI pass — a sorted Todo-style list
+// must reopen sorted instead of resetting to the file order.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const SCORES = {
+  collection: {
+    slug: "scores",
+    title: "Scores",
+    icon: "leaderboard",
+    source: "user",
+    schema: {
+      title: "Scores",
+      icon: "leaderboard",
+      dataPath: "data/scores/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name" },
+        points: { type: "number", label: "Points" },
+      },
+    },
+  },
+  // File order is a(30), b(10), c(20) — deliberately NOT sorted by points.
+  items: [
+    { id: "a", name: "Alpha", points: 30 },
+    { id: "b", name: "Bravo", points: 10 },
+    { id: "c", name: "Charlie", points: 20 },
+  ],
+};
+
+async function mockCollection(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/scores",
+    (route) => route.fulfill({ json: SCORES }),
+  );
+}
+
+/** Assert the table rows render top-to-bottom in `order` (by primary key). */
+async function expectRowOrder(page: Page, order: string[]): Promise<void> {
+  const rows = page.locator('[data-testid^="collections-row-"]');
+  await expect(rows).toHaveCount(order.length);
+  for (let index = 0; index < order.length; index++) {
+    await expect(rows.nth(index)).toHaveAttribute("data-testid", `collections-row-${order[index]}`);
+  }
+}
+
+test("standalone table sort persists across a reload", async ({ page }) => {
+  await mockAllApis(page);
+  await mockCollection(page);
+
+  await page.goto("/collections/scores");
+  await expectRowOrder(page, ["a", "b", "c"]); // file order, unsorted
+
+  // One click on the Points header → ascending: b(10), c(20), a(30).
+  await page.getByTestId("collections-sort-points").click();
+  await expectRowOrder(page, ["b", "c", "a"]);
+
+  // Reload: the ascending Points sort must survive (localStorage), so the
+  // table reopens in the same order — not the file order.
+  await page.reload();
+  await expectRowOrder(page, ["b", "c", "a"]);
+  const sortedHeader = page.locator('th[aria-sort="ascending"]');
+  await expect(sortedHeader).toHaveCount(1);
+  await expect(sortedHeader).toContainText("Points");
+});
+
+test("clearing the sort is also persisted", async ({ page }) => {
+  await mockAllApis(page);
+  await mockCollection(page);
+
+  await page.goto("/collections/scores");
+  // Cycle Points none → asc → desc → none, then reload: back to file order.
+  const sortButton = page.getByTestId("collections-sort-points");
+  await sortButton.click(); // asc
+  await sortButton.click(); // desc
+  await sortButton.click(); // none
+  await expectRowOrder(page, ["a", "b", "c"]);
+
+  await page.reload();
+  await expectRowOrder(page, ["a", "b", "c"]);
+  await expect(page.locator("th[aria-sort=ascending], th[aria-sort=descending]")).toHaveCount(0);
+});

--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -213,6 +213,109 @@ test("embedded card honours the shared localStorage view-mode store", async ({ p
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });
 
+test("embedded card honours the shared localStorage table sort", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  // The table sort is a single shared per-collection preference; seed it in the
+  // store (as the standalone page would) BEFORE the app boots, then assert a
+  // freshly-rendered card opens in that sort — proving the two surfaces share it.
+  await page.addInitScript(() => {
+    localStorage.setItem("collection_sorts", JSON.stringify({ watchlist: { field: "platform", direction: "desc" } }));
+  });
+
+  await mockAllApis(page, {
+    sessions: [{ id: "watchlist-session", title: "Watchlist", roleId: "general", startedAt: "2026-05-29T10:00:00Z", updatedAt: "2026-05-29T10:05:00Z" }],
+  });
+  await page.route(
+    (url) => url.pathname === "/api/collections/watchlist",
+    (route) => route.fulfill({ json: WATCHLIST_DETAIL }),
+  );
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [
+          { type: "session_meta", roleId: "general", sessionId: "watchlist-session" },
+          { type: "text", source: "user", message: "show me the watchlist" },
+          {
+            type: "tool_result",
+            source: "tool",
+            // No itemId → the table renders (not the detail modal).
+            result: {
+              uuid: "pc-result-3",
+              toolName: "presentCollection",
+              title: "Watchlist",
+              message: "Presented collection watchlist",
+              data: { collectionSlug: "watchlist" },
+            },
+          },
+        ],
+      }),
+  );
+
+  await page.goto(SESSION_PATH);
+  await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
+  // Fixture order is [avatar (Disney+), jack-ryan (Prime)]; the shared
+  // desc-by-platform sort flips it to [jack-ryan, avatar] on mount.
+  const rows = page.locator('[data-testid^="collections-row-"]');
+  await expect(rows).toHaveCount(2);
+  await expect(rows.nth(0)).toHaveAttribute("data-testid", "collections-row-jack-ryan");
+  await expect(rows.nth(1)).toHaveAttribute("data-testid", "collections-row-avatar");
+  // The header reflects the shared descending sort on the Platform column.
+  const sortedHeader = page.locator('th[aria-sort="descending"]');
+  await expect(sortedHeader).toHaveCount(1);
+  await expect(sortedHeader).toContainText("Platform");
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});
+
+test("sorting in an embedded card writes the shared store (so the standalone view shares it)", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
+
+  await mockAllApis(page, {
+    sessions: [{ id: "watchlist-session", title: "Watchlist", roleId: "general", startedAt: "2026-05-29T10:00:00Z", updatedAt: "2026-05-29T10:05:00Z" }],
+  });
+  await page.route(
+    (url) => url.pathname === "/api/collections/watchlist",
+    (route) => route.fulfill({ json: WATCHLIST_DETAIL }),
+  );
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [
+          { type: "session_meta", roleId: "general", sessionId: "watchlist-session" },
+          { type: "text", source: "user", message: "show me the watchlist" },
+          {
+            type: "tool_result",
+            source: "tool",
+            result: {
+              uuid: "pc-result-4",
+              toolName: "presentCollection",
+              title: "Watchlist",
+              message: "Presented collection watchlist",
+              data: { collectionSlug: "watchlist" },
+            },
+          },
+        ],
+      }),
+  );
+
+  await page.goto(SESSION_PATH);
+  await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
+  // Sort the Platform column inside the card → one click = ascending.
+  await page.getByTestId("collections-sort-platform").click();
+  await expect(page.locator('th[aria-sort="ascending"]')).toContainText("Platform");
+
+  // The card wrote the SHARED store — the standalone view would read the same.
+  const stored = await page.evaluate(() => localStorage.getItem("collection_sorts"));
+  expect(stored && JSON.parse(stored)).toEqual({ watchlist: { field: "platform", direction: "asc" } });
+
+  expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+});
+
 test("saving an edit returns to the record's detail (does not close) in the embedded card", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));

--- a/e2e/tests/present-collection.spec.ts
+++ b/e2e/tests/present-collection.spec.ts
@@ -162,11 +162,11 @@ const DATED_EVENTS_DETAIL = {
   items: [{ id: "launch", name: "Launch party", on: "" }],
 };
 
-test("embedded card ignores the standalone localStorage view-mode store", async ({ page }) => {
+test("embedded card honours the shared localStorage view-mode store", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (err) => pageErrors.push(`${err.message}\n${err.stack ?? ""}`));
 
-  // Seed the standalone store with "calendar" for this slug BEFORE the app boots.
+  // Seed the shared store with "calendar" for this slug BEFORE the app boots.
   await page.addInitScript(() => {
     localStorage.setItem("collection_view_modes", JSON.stringify({ "dated-events": "calendar" }));
   });
@@ -203,12 +203,12 @@ test("embedded card ignores the standalone localStorage view-mode store", async 
 
   await page.goto(SESSION_PATH);
   await expect(page.getByTestId("present-collection")).toBeVisible({ timeout: 10_000 });
-  // The date field means the calendar toggle IS offered — so the card COULD
-  // have honoured the stored "calendar". It must not: the table is shown and
-  // the calendar grid never mounts.
+  // The date field means the calendar toggle IS offered, and a fresh card
+  // (no own `viewState`) now seeds from the shared store: it opens on the
+  // stored "calendar" — the grid mounts and the table is not shown.
   await expect(page.getByTestId("collection-view-toggle-calendar")).toBeVisible();
-  await expect(page.getByTestId("collections-row-launch")).toBeVisible();
-  await expect(page.getByTestId("collection-calendar")).toHaveCount(0);
+  await expect(page.getByTestId("collection-calendar")).toBeVisible();
+  await expect(page.getByTestId("collections-row-launch")).toHaveCount(0);
 
   expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
 });

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -26,9 +26,17 @@ import {
   resolveCreateItemId,
   toDetail,
   toSummary,
+  validateCollectionRecords,
   writeItem,
 } from "../../workspace/collections/index.js";
-import type { CollectionAction, CollectionDetail, CollectionItem, CollectionSummary, LoadedCollection } from "../../workspace/collections/index.js";
+import type {
+  CollectionAction,
+  CollectionDetail,
+  CollectionItem,
+  CollectionSummary,
+  LoadedCollection,
+  RecordIssue,
+} from "../../workspace/collections/index.js";
 import { badRequest, notFound, conflict, forbidden, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
@@ -44,6 +52,10 @@ interface CollectionsListResponse {
 interface CollectionDetailResponse {
   collection: CollectionDetail;
   items: CollectionItem[];
+  /** Record files that failed validation (malformed JSON / schema
+   *  violation) and are silently skipped at read time. Drives the
+   *  in-view Repair prompt. Omitted/empty when every record is fine. */
+  issues?: RecordIssue[];
 }
 
 interface ItemMutationResponse {
@@ -89,7 +101,17 @@ router.get(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>,
   }
   try {
     const items = await listItems(collection.dataDir);
-    res.json({ collection: toDetail(collection), items });
+    // Best-effort validation: a malformed record is silently skipped at
+    // read time, so surface the problems here too (the same pass
+    // presentCollection runs) and let the view offer a Repair button.
+    // Never let validation failure turn a successful detail into a 500.
+    let issues: RecordIssue[] = [];
+    try {
+      issues = await validateCollectionRecords(collection);
+    } catch (err) {
+      log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
+    }
+    res.json({ collection: toDetail(collection), items, issues });
   } catch (err) {
     log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
     serverError(res, errorMessage(err));

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -111,7 +111,9 @@ router.get(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>,
     } catch (err) {
       log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
     }
-    res.json({ collection: toDetail(collection), items, issues });
+    // Omit `issues` entirely when everything is fine, matching the
+    // "absent when clean" contract on CollectionDetailResponse.
+    res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
   } catch (err) {
     log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
     serverError(res, errorMessage(err));

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -6,6 +6,7 @@ import { executeForm } from "../../../src/plugins/presentForm/plugin.js";
 import { executePresentCollection } from "../../../src/plugins/presentCollection/plugin.js";
 import type { PresentCollectionArgs } from "../../../src/plugins/presentCollection/types.js";
 import { loadCollection, validateCollectionRecords } from "../../workspace/collections/index.js";
+import { defangForPrompt } from "../../../src/utils/promptSafety.js";
 import { executeOpenCanvas } from "../../../src/plugins/canvas/definition.js";
 import { executePresent3D } from "@gui-chat-plugin/present3d";
 import { executeMapControl } from "@gui-chat-plugin/google-map";
@@ -257,13 +258,11 @@ bindRoute(
 // bad file just vanishes. We append any problems to `instructions` (which
 // the LLM reads) so the model — which is told to call presentCollection
 // after every write — fixes the file instead of losing the record.
-// Strip markup / escape sequences and clip, so record-controlled text in a
-// validation issue (a filename, id, or enum value) can't be read as
-// instructions once appended to the LLM-facing result.
-function defangForPrompt(value: string): string {
-  return value.replace(/[<>]/g, "").replace(/`/g, "'").replace(/\$\{/g, "$ {").replace(/\s+/g, " ").slice(0, 200);
-}
-
+// `defangForPrompt` (shared with the client Repair button via
+// `src/utils/promptSafety.ts`) strips markup / escape sequences, collapses
+// whitespace, and clips — so record-controlled text in a validation issue (a
+// filename, id, or enum value) can't be read as instructions once appended to
+// the LLM-facing result.
 async function dispatchPresentCollection(req: Request<object, unknown, PresentCollectionArgs>) {
   const result = await executePresentCollection(null as never, req.body);
   const slug = result.data?.collectionSlug;

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -34,10 +34,7 @@
               role="button"
               :aria-label="t('collectionsView.kanbanOpenCard', { label: itemLabel(element) })"
               class="bg-white border border-slate-200 rounded shadow-sm p-2 cursor-grab hover:shadow active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
-              :class="[
-                itemId(element) === selected ? 'ring-2 ring-indigo-500 border-indigo-300' : '',
-                isNotified(element) ? 'border-l-4 border-l-amber-400' : '',
-              ]"
+              :class="[itemId(element) === selected ? 'ring-2 ring-indigo-500 border-indigo-300' : '', notifyAccentClass(element)]"
               @click="emit('select', itemId(element))"
               @keydown.enter.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
               @keydown.space.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
@@ -72,6 +69,7 @@ import { useI18n } from "vue-i18n";
 import draggable from "vuedraggable";
 import { fieldVisible } from "../utils/collections/actionVisible";
 import { resolveEnumColor } from "../utils/collections/enumColors";
+import type { NotifierSeverity } from "../utils/collections/notifiedItems";
 import type { CollectionItem, CollectionSchema } from "./collectionTypes";
 
 // vuedraggable @change shape — same three keys as the todo board. We act
@@ -91,9 +89,9 @@ const props = defineProps<{
   items: CollectionItem[];
   /** Primary-key of the currently-open record (highlighted card). */
   selected?: string;
-  /** Primary-keys of records with an active bell notification — flagged
-   *  with an amber left accent so they stand out on the board. */
-  notifiedIds?: Set<string>;
+  /** Primary-key → active-notification severity. Cards with a notification get
+   *  a left accent in the matching bell colour (urgent red / nudge amber). */
+  notified?: Map<string, NotifierSeverity>;
 }>();
 
 const emit = defineEmits<{
@@ -135,9 +133,18 @@ function itemId(item: CollectionItem): string {
   return String(item[props.schema.primaryKey] ?? "");
 }
 
-/** True when this card's record has an active bell notification. */
-function isNotified(item: CollectionItem): boolean {
-  return props.notifiedIds?.has(itemId(item)) ?? false;
+// Left-accent class per notification severity — the same red/amber the bell
+// uses (see NotificationBell's severity colours), so a flagged card matches
+// the badge. Empty string when the record has no active notification.
+const NOTIFY_ACCENT: Record<NotifierSeverity, string> = {
+  urgent: "border-l-4 border-l-red-500",
+  nudge: "border-l-4 border-l-amber-500",
+  info: "border-l-4 border-l-slate-400",
+};
+
+function notifyAccentClass(item: CollectionItem): string {
+  const severity = props.notified?.get(itemId(item));
+  return severity ? NOTIFY_ACCENT[severity] : "";
 }
 
 /** Card label: the schema's `displayField` value, else the primary key. */

--- a/src/components/CollectionKanbanView.vue
+++ b/src/components/CollectionKanbanView.vue
@@ -34,7 +34,10 @@
               role="button"
               :aria-label="t('collectionsView.kanbanOpenCard', { label: itemLabel(element) })"
               class="bg-white border border-slate-200 rounded shadow-sm p-2 cursor-grab hover:shadow active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
-              :class="itemId(element) === selected ? 'ring-2 ring-indigo-500 border-indigo-300' : ''"
+              :class="[
+                itemId(element) === selected ? 'ring-2 ring-indigo-500 border-indigo-300' : '',
+                isNotified(element) ? 'border-l-4 border-l-amber-400' : '',
+              ]"
               @click="emit('select', itemId(element))"
               @keydown.enter.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
               @keydown.space.prevent.self="(e) => !e.repeat && emit('select', itemId(element))"
@@ -88,6 +91,9 @@ const props = defineProps<{
   items: CollectionItem[];
   /** Primary-key of the currently-open record (highlighted card). */
   selected?: string;
+  /** Primary-keys of records with an active bell notification — flagged
+   *  with an amber left accent so they stand out on the board. */
+  notifiedIds?: Set<string>;
 }>();
 
 const emit = defineEmits<{
@@ -127,6 +133,11 @@ const columns = computed<KanbanColumn[]>(() => {
 
 function itemId(item: CollectionItem): string {
   return String(item[props.schema.primaryKey] ?? "");
+}
+
+/** True when this card's record has an active bell notification. */
+function isNotified(item: CollectionItem): boolean {
+  return props.notifiedIds?.has(itemId(item)) ?? false;
 }
 
 /** Card label: the schema's `displayField` value, else the primary key. */

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -702,7 +702,7 @@ import { useAppApi } from "../composables/useAppApi";
 import { useShortcuts } from "../composables/useShortcuts";
 import { actionVisible, fieldVisible } from "../utils/collections/actionVisible";
 import { resolveEnumColor } from "../utils/collections/enumColors";
-import { readCollectionViewMode, writeCollectionViewMode } from "../utils/collections/collectionViewMode";
+import { readCollectionViewMode, writeCollectionViewMode, readCollectionSort, writeCollectionSort } from "../utils/collections/collectionViewMode";
 import {
   isSortableField,
   nextSortDirection,
@@ -748,7 +748,8 @@ const props = defineProps<{
   sendTextMessage?: (text?: string) => void;
   /** Embedded mode only: initial view / anchor / group restored from the
    *  card's persisted `viewState` so a switch to calendar or kanban
-   *  survives a remount. */
+   *  survives a remount. (The table sort is NOT a card prop — it's a shared
+   *  per-collection localStorage preference, read by both modes.) */
   initialView?: "table" | "calendar" | "kanban" | "dashboard";
   initialAnchorField?: string;
   initialGroupField?: string;
@@ -761,7 +762,7 @@ const emit = defineEmits<{
   select: [id: string | null];
   /** Embedded mode only: the view mode / calendar anchor / kanban group
    *  changed. The card persists these alongside `selected` so the calendar
-   *  and kanban stick. */
+   *  and kanban stick. (The table sort is shared via localStorage instead.) */
   viewStateChange: [state: { view: "table" | "calendar" | "kanban" | "dashboard"; anchorField: string; groupField: string }];
 }>();
 
@@ -888,8 +889,15 @@ const filteredItems = computed<CollectionItem[]>(() => {
 
 // ── List-table sort (single active column, header toggle) ─────────
 // Calendar / kanban keep their own ordering; only the table consumes
-// `sortedItems`. State resets to null whenever a new collection loads.
-const sortState = ref<SortState | null>(null);
+// `sortedItems`. The active sort is a single SHARED per-collection
+// preference in localStorage — both the standalone page and embedded chat
+// cards read AND write it, so a sort set anywhere is consistent the next
+// time the collection is viewed. Resets only when a DIFFERENT collection
+// loads (the slug watch), so the sort survives a refresh / edit / remount.
+function storedSortFor(slug: string | undefined): SortState | null {
+  return (slug && readCollectionSort(slug)) || null;
+}
+const sortState = ref<SortState | null>(storedSortFor(activeSlug.value));
 // The column whose sort button is currently hovered (at most one). Hover
 // previews the NEXT click's state, so descending visibly fades back to the
 // light-grey "off" look — signalling the next click clears the sort.
@@ -1223,7 +1231,9 @@ async function loadCollection(slug: string): Promise<void> {
   items.value = [];
   dataIssues.value = []; // never carry a previous collection's issues over
   searchQuery.value = ""; // Reset search query on collection load
-  sortState.value = null; // Drop any active column sort from the prior collection
+  // NOTE: the active column sort is NOT reset here — it's part of the view
+  // state, so it must survive a refresh / edit reload and an embedded card
+  // remount. The collection-SWITCH reset lives in the `activeSlug` watch.
   render.resetLinkedCaches();
   viewing.value = null;
   openDay.value = null; // never carry a previous collection's open day over
@@ -1944,6 +1954,9 @@ watch(
       view.value = (slug && readCollectionViewMode(slug)) || "table";
       anchorOverride.value = null;
       kanbanOverride.value = null;
+      // A sort belongs to a collection's own schema, so don't carry it across —
+      // restore the new collection's stored (shared) sort instead.
+      sortState.value = storedSortFor(slug);
     }
     if (slug) {
       loadCollection(slug);
@@ -1966,18 +1979,24 @@ watch(
 // loading: that's the point where a stored mode unsupported by this schema
 // (its date/enum field gone) has collapsed to "table" and must be normalized
 // back into storage — otherwise no other dependency changes and it lingers.
-watch([activeView, calendarAnchorField, kanbanGroupField, loading], () => {
+watch([activeView, calendarAnchorField, kanbanGroupField, sortState, loading], () => {
   // Persist the EFFECTIVE view (activeView), not the raw `view` ref — a
   // stale "calendar"/"kanban" that has fallen back to "table" (its enabling
   // field gone) must not be saved as an impossible mode.
   if (embedded.value) {
     emit("viewStateChange", { view: activeView.value, anchorField: calendarAnchorField.value, groupField: kanbanGroupField.value });
-    return;
   }
   // Don't write during the load window: until the collection resolves,
   // `hasCalendar`/`hasKanban` are false so `activeView` reads "table",
   // which would clobber a stored "calendar"/"kanban" before it can apply.
-  if (activeSlug.value && !loading.value && collection.value) writeCollectionViewMode(activeSlug.value, activeView.value);
+  if (activeSlug.value && !loading.value && collection.value) {
+    // View mode stays standalone-authored — embedded reads but never writes it,
+    // so a stale card can't clobber the shared mode. The table SORT, by
+    // contrast, IS shared both ways: a card always re-reads it on mount, so
+    // there's no per-card value to go stale and clobber the store.
+    if (!embedded.value) writeCollectionViewMode(activeSlug.value, activeView.value);
+    writeCollectionSort(activeSlug.value, sortState.value);
+  }
 });
 
 // React to the active selection changing while already on this

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -352,7 +352,7 @@
             :items="filteredItems"
             :group-field="kanbanGroupField"
             :selected="viewing ? String(viewing[collection.schema.primaryKey] ?? '') : undefined"
-            :notified-ids="notifiedItemIds"
+            :notified="notifiedSeverities"
             @select="onCalendarSelect"
             @move="onKanbanMove"
           />
@@ -729,8 +729,9 @@ import type {
   TableRowDraft,
 } from "./collectionTypes";
 import { shortHexId } from "../utils/id";
+import { defangForPrompt } from "../utils/promptSafety";
 import { useNotifications } from "../composables/useNotifications";
-import { collectionNotifiedItemIds } from "../utils/collections/notifiedItems";
+import { collectionNotifiedSeverities, type NotifierSeverity } from "../utils/collections/notifiedItems";
 
 /** `slug` / `selected` are supplied only in EMBEDDED mode (the
  *  `presentCollection` chat card mounts this component and drives both
@@ -804,11 +805,12 @@ const loadError = ref<string | null>(null);
 // button reports them back to the LLM. See `repairCollection`.
 const dataIssues = ref<CollectionRecordIssue[]>([]);
 
-// Primary-keys of this collection's records that currently have an active
-// bell notification — passed to the Kanban board to flag their cards.
-const notifiedItemIds = computed<Set<string>>(() => {
+// Primary-key → notification severity for this collection's records that
+// currently have an active bell notification — passed to the Kanban board so
+// it can flag those cards in the matching bell colour (urgent red / nudge amber).
+const notifiedSeverities = computed<Map<string, NotifierSeverity>>(() => {
   const slug = collection.value?.slug;
-  return slug ? collectionNotifiedItemIds(notifierEntries.value, slug) : new Set<string>();
+  return slug ? collectionNotifiedSeverities(notifierEntries.value, slug) : new Map<string, NotifierSeverity>();
 });
 /** True while a feed collection's manual refresh is in flight. */
 const refreshing = ref(false);
@@ -1125,11 +1127,11 @@ async function runCollectionAction(action: CollectionAction): Promise<void> {
 function repairCollection(): void {
   const current = collection.value;
   if (!current || dataIssues.value.length === 0) return;
-  // Issue text carries record-controlled values (ids, enum values), so
-  // defang structural injection vectors before it rides into the LLM
-  // prompt — mirrors `defangForPrompt` on the server's presentCollection path.
-  const defang = (value: string): string => value.replace(/[<>]/g, "").replace(/`/g, "'").replace(/\$\{/g, "$ {").slice(0, 200);
-  const lines = dataIssues.value.map((issue) => `- ${defang(issue.file)}: ${defang(issue.problem)}`).join("\n");
+  // Issue text carries record-controlled values (ids, enum values), so defang
+  // structural injection vectors before it rides into the LLM prompt. Shared
+  // with the server's presentCollection path via `defangForPrompt` so the two
+  // can't drift (it also collapses whitespace, closing a newline-injection gap).
+  const lines = dataIssues.value.map((issue) => `- ${defangForPrompt(issue.file)}: ${defangForPrompt(issue.problem)}`).join("\n");
   const prompt = t("collectionsView.repairPrompt", { title: current.title, count: dataIssues.value.length, issues: lines });
   if (props.sendTextMessage) {
     props.sendTextMessage(prompt);

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -220,6 +220,28 @@
       </div>
     </div>
 
+    <!-- Repair banner: the server flagged record files that won't load /
+         violate the schema and are silently skipped. The button reports
+         them back to the LLM (same path presentCollection uses) so it
+         fixes the files. View-independent, so it sits above the body. -->
+    <div
+      v-if="collection && dataIssues.length > 0"
+      class="mx-6 mt-4 rounded-xl border border-amber-200 bg-amber-50/60 p-4 text-sm text-amber-900 shadow-sm flex items-center gap-3"
+      data-testid="collections-data-issues"
+    >
+      <span class="material-icons text-amber-600">warning</span>
+      <span class="flex-1">{{ t("collectionsView.dataIssuesDetected", { count: dataIssues.length }) }}</span>
+      <button
+        type="button"
+        class="h-8 px-2.5 flex items-center gap-1 rounded border border-amber-300 bg-white hover:bg-amber-100 text-amber-700 font-bold text-xs transition-colors"
+        data-testid="collections-repair"
+        @click="repairCollection"
+      >
+        <span class="material-icons text-sm">build</span>
+        <span>{{ t("collectionsView.repair") }}</span>
+      </button>
+    </div>
+
     <div class="flex-1 overflow-auto">
       <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">
         <div class="h-8 w-8 border-2 border-indigo-600/20 border-t-indigo-600 rounded-full animate-spin"></div>
@@ -330,6 +352,7 @@
             :items="filteredItems"
             :group-field="kanbanGroupField"
             :selected="viewing ? String(viewing[collection.schema.primaryKey] ?? '') : undefined"
+            :notified-ids="notifiedItemIds"
             @select="onCalendarSelect"
             @move="onKanbanMove"
           />
@@ -392,10 +415,10 @@
                 v-for="[key, field] in listColumnFields"
                 :key="key"
                 :aria-sort="isSortableField(field) ? sortAriaValue(key) : undefined"
-                class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider"
+                class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider whitespace-nowrap"
               >
                 <div class="flex items-center gap-1">
-                  <span>{{ field.label }}</span>
+                  <span class="truncate max-w-[14rem]" :title="field.label">{{ field.label }}</span>
                   <button
                     v-if="isSortableField(field)"
                     type="button"
@@ -699,11 +722,15 @@ import type {
   CollectionDetail,
   CollectionDetailResponse,
   CollectionItem,
+  CollectionRecordIssue,
   EditState,
   FieldSpec,
   ItemMutationResponse,
   TableRowDraft,
 } from "./collectionTypes";
+import { shortHexId } from "../utils/id";
+import { useNotifications } from "../composables/useNotifications";
+import { collectionNotifiedItemIds } from "../utils/collections/notifiedItems";
 
 /** `slug` / `selected` are supplied only in EMBEDDED mode (the
  *  `presentCollection` chat card mounts this component and drives both
@@ -744,6 +771,7 @@ const router = useRouter();
 const { openConfirm } = useConfirm();
 const appApi = useAppApi();
 const { unpin } = useShortcuts();
+const { entries: notifierEntries } = useNotifications();
 
 /** Embedded when a `slug` prop is supplied; standalone (route-driven)
  *  otherwise. Switches the slug/selected source and the open/close
@@ -770,6 +798,17 @@ const collection = ref<CollectionDetail | null>(null);
 const items = ref<CollectionItem[]>([]);
 const loading = ref(true);
 const loadError = ref<string | null>(null);
+// Record files the server flagged as malformed/invalid (silently skipped
+// at read time). When non-empty the view shows a Repair banner whose
+// button reports them back to the LLM. See `repairCollection`.
+const dataIssues = ref<CollectionRecordIssue[]>([]);
+
+// Primary-keys of this collection's records that currently have an active
+// bell notification — passed to the Kanban board to flag their cards.
+const notifiedItemIds = computed<Set<string>>(() => {
+  const slug = collection.value?.slug;
+  return slug ? collectionNotifiedItemIds(notifierEntries.value, slug) : new Set<string>();
+});
 /** True while a feed collection's manual refresh is in flight. */
 const refreshing = ref(false);
 /** Slug already auto-refreshed on first open — prevents a reload loop
@@ -1070,6 +1109,27 @@ async function runCollectionAction(action: CollectionAction): Promise<void> {
   appApi.startNewChat(result.data.prompt, result.data.role);
 }
 
+/** Report the server-detected record data problems back to the LLM so it
+ *  fixes the offending files. Mirrors the `presentCollection` validation
+ *  path (`dispatchPresentCollection`), but user-initiated via the Repair
+ *  button instead of fired automatically after a write. Dispatches into
+ *  the current chat when embedded, else seeds a new General chat. */
+function repairCollection(): void {
+  const current = collection.value;
+  if (!current || dataIssues.value.length === 0) return;
+  // Issue text carries record-controlled values (ids, enum values), so
+  // defang structural injection vectors before it rides into the LLM
+  // prompt — mirrors `defangForPrompt` on the server's presentCollection path.
+  const defang = (value: string): string => value.replace(/[<>]/g, "").replace(/`/g, "'").replace(/\$\{/g, "$ {").slice(0, 200);
+  const lines = dataIssues.value.map((issue) => `- ${defang(issue.file)}: ${defang(issue.problem)}`).join("\n");
+  const prompt = t("collectionsView.repairPrompt", { title: current.title, count: dataIssues.value.length, issues: lines });
+  if (props.sendTextMessage) {
+    props.sendTextMessage(prompt);
+    return;
+  }
+  appApi.startNewChat(prompt, BUILTIN_ROLE_IDS.general);
+}
+
 /** Actions whose optional `when` predicate matches the open record.
  *  Status-driven buttons (e.g. invoice "Record payment") stay hidden
  *  until the record reaches the matching state. */
@@ -1161,6 +1221,7 @@ async function loadCollection(slug: string): Promise<void> {
   loadError.value = null;
   collection.value = null;
   items.value = [];
+  dataIssues.value = []; // never carry a previous collection's issues over
   searchQuery.value = ""; // Reset search query on collection load
   sortState.value = null; // Drop any active column sort from the prior collection
   render.resetLinkedCaches();
@@ -1182,6 +1243,7 @@ async function loadCollection(slug: string): Promise<void> {
   }
   collection.value = result.data.collection;
   items.value = result.data.items;
+  dataIssues.value = result.data.issues ?? [];
   enumOriginallyEmpty.value = snapshotEmptyEnums(result.data.collection.schema, result.data.items);
   // Fan out to fetch each unique target collection so the table can
   // render ref values as display names (not slugs) and the form
@@ -1379,6 +1441,19 @@ function setView(next: CollectionViewMode): void {
   view.value = next;
 }
 
+/** A short, slug-safe id not already used by a loaded record. Collisions
+ *  are astronomically unlikely (32 bits), but we still re-roll a few
+ *  times against the in-memory set before giving up and using the last
+ *  candidate (the server's overwrite guard is the final backstop). */
+function generateUniqueItemId(primaryKey: string): string {
+  const existing = new Set(items.value.map((item) => String(item[primaryKey] ?? "")));
+  let candidate = shortHexId();
+  for (let attempt = 0; attempt < 8 && existing.has(candidate); attempt++) {
+    candidate = shortHexId();
+  }
+  return candidate;
+}
+
 function openCreate(): void {
   if (!collection.value) return;
   const text: Record<string, string> = {};
@@ -1402,8 +1477,16 @@ function openCreate(): void {
   }
   // Singleton collections fix the primary key to the schema-declared
   // value (e.g. "me") so the first Add can't pick an arbitrary id.
+  // Otherwise pre-fill a unique, editable id so the user doesn't have to
+  // invent one — the primary-key input stays enabled in create mode, so
+  // they can still override it before saving. Matches the id shape the
+  // server would generate for a blank-id POST (`generateItemId`).
   const { singleton, primaryKey } = collection.value.schema;
-  if (singleton) text[primaryKey] = singleton;
+  if (singleton) {
+    text[primaryKey] = singleton;
+  } else if (primaryKey in text) {
+    text[primaryKey] = generateUniqueItemId(primaryKey);
+  }
   viewing.value = null; // one panel open at a time
   editing.value = { mode: "create", text, bool, boolOriginallyPresent, boolTouched, table, originalId: null };
   saveError.value = null;

--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1335,18 +1335,19 @@ const isFeedRoute = computed<boolean>(() => !embedded.value && route.name === PA
 //
 // Standalone route mode persists the last-used mode per collection in
 // localStorage so reopening `/collections/:slug` restores the prior view
-// instead of always starting on the table. Embedded mode ignores the store
-// and restores from the card's `initialView` prop instead.
+// instead of always starting on the table. Embedded chat cards restore from
+// the card's own `initialView` first; lacking that (a freshly-rendered
+// presentCollection card), they fall back to the same per-collection store
+// the standalone page uses, so a card also opens in the last-used view.
 type CollectionViewMode = "table" | "calendar" | "kanban" | "dashboard";
 
 /** The view to open with: the embedded card's restored `initialView` if
- *  present, else the standalone slug's stored mode, else "table". Embedded
- *  mode never reads the localStorage store — its state lives in the card's
- *  `viewState`, so a standalone preference must not leak into (and then be
- *  re-persisted by) an embedded card. */
+ *  present (its own persisted state wins), else the slug's stored
+ *  preference, else "table". Embedded cards READ the store but never WRITE
+ *  it (the persist watch only emits `viewStateChange` for them), so a stale
+ *  card re-rendering can't clobber the shared preference. */
 function initialViewMode(): CollectionViewMode {
   if (props.initialView) return props.initialView;
-  if (embedded.value) return "table";
   const slug = activeSlug.value;
   return (slug && readCollectionViewMode(slug)) || "table";
 }
@@ -1936,11 +1937,11 @@ watch(
   (slug, prevSlug) => {
     // Reset view state when switching BETWEEN collections — but not on the
     // initial run (prevSlug undefined), so an embedded card's restored
-    // `initialView` / `initialAnchorField` survive the first load. Standalone
-    // mode restores the new collection's stored mode (else "table"); the axis
+    // `initialView` / `initialAnchorField` survive the first load. Both modes
+    // restore the new collection's stored mode (else "table"); the axis
     // fields always reset to their schema defaults.
     if (prevSlug !== undefined && slug !== prevSlug) {
-      view.value = (slug && !embedded.value && readCollectionViewMode(slug)) || "table";
+      view.value = (slug && readCollectionViewMode(slug)) || "table";
       anchorOverride.value = null;
       kanbanOverride.value = null;
     }

--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -9,42 +9,50 @@
      Composable + state interface stays identical so the two can be
      unified the day the host/plugin runtime split is reconciled. -->
 <template>
-  <Transition name="confirm-modal">
-    <div
-      v-if="confirmState.isOpen"
-      class="confirm-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="confirm-title"
-      aria-describedby="confirm-message"
-      data-testid="host-confirm-modal"
-      @click="onOverlayClick"
-    >
-      <div class="confirm-card" @click.stop>
-        <div class="confirm-header">
-          <div class="confirm-icon-wrapper" :class="confirmState.variant">
-            <span class="material-icons icon" aria-hidden="true">{{ iconName }}</span>
+  <!-- Teleport to <body> so the overlay isn't trapped in the stacking
+       context of whatever mounts this dialog (e.g. CollectionView). The
+       record modal is itself teleported with z-40; keeping the confirm
+       dialog inside CollectionView's subtree left its z-9999 meaningless
+       against that body-level layer, so a delete confirm rendered behind
+       the open item view. -->
+  <Teleport to="body">
+    <Transition name="confirm-modal">
+      <div
+        v-if="confirmState.isOpen"
+        class="confirm-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-title"
+        aria-describedby="confirm-message"
+        data-testid="host-confirm-modal"
+        @click="onOverlayClick"
+      >
+        <div class="confirm-card" @click.stop>
+          <div class="confirm-header">
+            <div class="confirm-icon-wrapper" :class="confirmState.variant">
+              <span class="material-icons icon" aria-hidden="true">{{ iconName }}</span>
+            </div>
+            <h3 id="confirm-title" class="confirm-title">
+              {{ confirmState.title || defaultTitle }}
+            </h3>
           </div>
-          <h3 id="confirm-title" class="confirm-title">
-            {{ confirmState.title || defaultTitle }}
-          </h3>
-        </div>
 
-        <div id="confirm-message" class="confirm-body">
-          {{ confirmState.message }}
-        </div>
+          <div id="confirm-message" class="confirm-body">
+            {{ confirmState.message }}
+          </div>
 
-        <div class="confirm-footer">
-          <button ref="cancelBtn" type="button" class="btn-cancel" data-testid="host-confirm-cancel" @click="handleConfirm(false)">
-            {{ confirmState.cancelText || defaultCancelText }}
-          </button>
-          <button ref="confirmBtn" type="button" class="btn-confirm" :class="confirmState.variant" data-testid="host-confirm-ok" @click="handleConfirm(true)">
-            {{ confirmState.confirmText || defaultConfirmText }}
-          </button>
+          <div class="confirm-footer">
+            <button ref="cancelBtn" type="button" class="btn-cancel" data-testid="host-confirm-cancel" @click="handleConfirm(false)">
+              {{ confirmState.cancelText || defaultCancelText }}
+            </button>
+            <button ref="confirmBtn" type="button" class="btn-confirm" :class="confirmState.variant" data-testid="host-confirm-ok" @click="handleConfirm(true)">
+              {{ confirmState.confirmText || defaultConfirmText }}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  </Transition>
+    </Transition>
+  </Teleport>
 </template>
 
 <script setup lang="ts">

--- a/src/components/collectionTypes.ts
+++ b/src/components/collectionTypes.ts
@@ -127,9 +127,22 @@ export interface CollectionDetail {
 
 export type CollectionItem = Record<string, unknown>;
 
+/** A record file the server couldn't load or that violates the schema —
+ *  silently skipped at read time. Mirror of `RecordIssue` in
+ *  `server/workspace/collections/validate.ts`. */
+export interface CollectionRecordIssue {
+  /** Record filename, e.g. `lesson-003.json`. */
+  file: string;
+  /** Human-readable problem, written to be actionable by the LLM. */
+  problem: string;
+}
+
 export interface CollectionDetailResponse {
   collection: CollectionDetail;
   items: CollectionItem[];
+  /** Record files that failed validation; drives the in-view Repair
+   *  prompt. Absent or empty when every record is fine. */
+  issues?: CollectionRecordIssue[];
 }
 
 export interface ItemMutationResponse {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -1251,6 +1251,10 @@ const deMessages = {
     viewDashboard: "Dashboard",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Alle Einträge",
+    repair: "Reparieren",
+    dataIssuesDetected: "{count} Datensatzdatei(en) haben Datenprobleme und fehlen möglicherweise in dieser Ansicht.",
+    repairPrompt:
+      "Die Sammlung {title} hat {count} Datensatzdatei(en) mit Datenproblemen, die ihr Erscheinen verhindern. Korrigiere jede — die Datei mit Read lesen, korrigieren und mit Write zurückschreiben:\n{issues}\n\nRufe anschließend presentCollection auf, um zu bestätigen, dass die Datensätze geladen werden.",
     source: {
       user: "Benutzer",
       project: "Projekt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1235,6 +1235,10 @@ const enMessages = {
     viewDashboard: "Dashboard",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "All items",
+    repair: "Repair",
+    dataIssuesDetected: "{count} record file(s) have data problems and may be missing from this view.",
+    repairPrompt:
+      'The "{title}" collection has {count} record file(s) with data problems that keep them from appearing. Fix each one — Read the file, correct it, then Write it back:\n{issues}\n\nWhen you\'re done, call presentCollection to confirm the records load.',
     source: {
       user: "User",
       project: "Project",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -1248,6 +1248,10 @@ const esMessages = {
     viewDashboard: "Panel",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Todos los elementos",
+    repair: "Reparar",
+    dataIssuesDetected: "{count} archivo(s) de registro tienen problemas de datos y podrían no aparecer en esta vista.",
+    repairPrompt:
+      "La colección {title} tiene {count} archivo(s) de registro con problemas de datos que impiden que aparezcan. Corrige cada uno: lee el archivo con Read, corrígelo y vuelve a escribirlo con Write:\n{issues}\n\nCuando termines, llama a presentCollection para confirmar que los registros se cargan.",
     source: {
       user: "Usuario",
       project: "Proyecto",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1241,6 +1241,10 @@ const frMessages = {
     viewDashboard: "Tableau de bord",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Tous les éléments",
+    repair: "Réparer",
+    dataIssuesDetected: "{count} fichier(s) d'enregistrement présentent des problèmes de données et peuvent être absents de cette vue.",
+    repairPrompt:
+      "La collection « {title} » comporte {count} fichier(s) d'enregistrement présentant des problèmes de données qui les empêchent d'apparaître. Corrigez chacun : lisez le fichier avec Read, corrigez-le, puis réécrivez-le avec Write :\n{issues}\n\nUne fois terminé, appelez presentCollection pour confirmer que les enregistrements se chargent.",
     source: {
       user: "Utilisateur",
       project: "Projet",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1231,6 +1231,10 @@ const jaMessages = {
     viewDashboard: "ダッシュボード",
     dashboardAlertHeading: "{label} — {count}件",
     dashboardAllItems: "一覧",
+    repair: "修復",
+    dataIssuesDetected: "{count} 件のレコードファイルにデータの問題があり、この表示に出てこない可能性があります。",
+    repairPrompt:
+      "コレクション「{title}」に、表示されない原因となるデータの問題を持つレコードファイルが {count} 件あります。それぞれを修正してください — ファイルを Read し、修正してから Write し直します:\n{issues}\n\n完了したら presentCollection を呼び出して、レコードが読み込めることを確認してください。",
     source: {
       user: "ユーザー",
       project: "プロジェクト",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1235,6 +1235,10 @@ const koMessages = {
     viewDashboard: "대시보드",
     dashboardAlertHeading: "{label} — {count}건",
     dashboardAllItems: "전체 항목",
+    repair: "복구",
+    dataIssuesDetected: "{count}개의 레코드 파일에 데이터 문제가 있어 이 보기에 표시되지 않을 수 있습니다.",
+    repairPrompt:
+      "{title} 컬렉션에 표시되지 않는 원인이 되는 데이터 문제가 있는 레코드 파일이 {count}개 있습니다. 각 파일을 수정하세요 — Read로 파일을 읽고 수정한 뒤 Write로 다시 저장하세요:\n{issues}\n\n완료되면 presentCollection을 호출하여 레코드가 로드되는지 확인하세요.",
     source: {
       user: "사용자",
       project: "프로젝트",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -1237,6 +1237,10 @@ const ptBRMessages = {
     viewDashboard: "Painel",
     dashboardAlertHeading: "{label} — {count}",
     dashboardAllItems: "Todos os itens",
+    repair: "Reparar",
+    dataIssuesDetected: "{count} arquivo(s) de registro têm problemas de dados e podem não aparecer nesta visualização.",
+    repairPrompt:
+      "A coleção {title} tem {count} arquivo(s) de registro com problemas de dados que impedem que apareçam. Corrija cada um: leia o arquivo com Read, corrija-o e grave-o novamente com Write:\n{issues}\n\nQuando terminar, chame presentCollection para confirmar que os registros carregam.",
     source: {
       user: "Usuário",
       project: "Projeto",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -1224,6 +1224,10 @@ const zhMessages = {
     viewDashboard: "仪表板",
     dashboardAlertHeading: "{label} — {count} 项",
     dashboardAllItems: "全部条目",
+    repair: "修复",
+    dataIssuesDetected: "有 {count} 个记录文件存在数据问题，可能未显示在此视图中。",
+    repairPrompt:
+      "集合 {title} 有 {count} 个记录文件存在导致无法显示的数据问题。请逐一修复——用 Read 读取该文件，更正后再用 Write 写回：\n{issues}\n\n完成后，调用 presentCollection 确认记录可以正常加载。",
     source: {
       user: "用户",
       project: "项目",

--- a/src/plugins/presentCollection/View.vue
+++ b/src/plugins/presentCollection/View.vue
@@ -22,8 +22,11 @@ import type { PresentCollectionData } from "./types";
 
 /** Card-local UI state persisted in the tool result's `viewState` so it
  *  survives a re-render — same pattern as presentForm. `selected` is the
- *  open record (`null` once explicitly closed); `view` / `anchorField`
- *  keep the table↔calendar choice and calendar anchor sticky. */
+ *  open record (`null` once explicitly closed); `view` / `anchorField` /
+ *  `groupField` keep the table↔calendar↔kanban choice and its axes sticky.
+ *  NOTE: the table sort is deliberately NOT here — it's a single shared
+ *  per-collection preference in localStorage (read+written by both the
+ *  standalone page and chat cards), so it stays consistent everywhere. */
 interface PresentCollectionViewState {
   selected?: string | null;
   view?: "table" | "calendar" | "kanban" | "dashboard";

--- a/src/utils/collections/collectionViewMode.ts
+++ b/src/utils/collections/collectionViewMode.ts
@@ -1,12 +1,16 @@
-// Per-collection view-mode preference (table | calendar | kanban | dashboard)
-// persisted to localStorage, keyed by collection slug. Lets the standalone
-// `/collections/:slug` page reopen in the last-used view instead of always
-// defaulting to "table". Embedded chat-card mode persists its own `viewState`
-// in the tool result and does NOT use this.
+// Per-collection view preferences (the view mode, and the table's active
+// column sort) persisted to localStorage, keyed by collection slug. Lets the
+// standalone `/collections/:slug` page reopen in the last-used view and sort
+// instead of resetting. Embedded chat cards seed from these but persist their
+// own copy in the tool-result `viewState` (they read, never write — so a
+// stale card can't clobber the shared preference).
+
+import type { SortState } from "./sortItems";
 
 export type CollectionViewMode = "table" | "calendar" | "kanban" | "dashboard";
 
 const STORAGE_KEY = "collection_view_modes";
+const SORT_STORAGE_KEY = "collection_sorts";
 
 const VIEW_MODES: readonly CollectionViewMode[] = ["table", "calendar", "kanban", "dashboard"];
 
@@ -38,5 +42,51 @@ export function writeCollectionViewMode(slug: string, view: CollectionViewMode):
   } catch {
     // localStorage unavailable / quota exceeded — the preference is
     // best-effort, so silently skip rather than break the view.
+  }
+}
+
+// ── Active column sort (table view) ──────────────────────────────────
+
+type SortMap = Record<string, SortState>;
+
+function isSortState(value: unknown): value is SortState {
+  if (!value || typeof value !== "object") return false;
+  const rec = value as Record<string, unknown>;
+  return typeof rec.field === "string" && (rec.direction === "asc" || rec.direction === "desc");
+}
+
+function readAllSorts(): SortMap {
+  try {
+    const raw = localStorage.getItem(SORT_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    // Drop any entry whose stored shape no longer validates (e.g. a schema
+    // whose field was renamed away leaves a stale value) so callers only ever
+    // see a well-formed SortState.
+    const out: SortMap = {};
+    for (const [slug, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (isSortState(value)) out[slug] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function readCollectionSort(slug: string): SortState | null {
+  return readAllSorts()[slug] ?? null;
+}
+
+/** Persist (or, when `sort` is null, clear) the slug's active column sort. */
+export function writeCollectionSort(slug: string, sort: SortState | null): void {
+  try {
+    // Rebuild without the slug rather than `delete all[slug]` (dynamic-delete),
+    // then re-add it when a sort is set — clearing leaves no stale key behind.
+    const all = Object.fromEntries(Object.entries(readAllSorts()).filter(([key]) => key !== slug));
+    if (sort) all[slug] = sort;
+    localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // Best-effort, same as the view-mode store.
   }
 }

--- a/src/utils/collections/notifiedItems.ts
+++ b/src/utils/collections/notifiedItems.ts
@@ -10,11 +10,23 @@
 
 import { NOTIFICATION_VIEWS } from "../../types/notification";
 
+/** Bell severities, worst-last. Mirrors `NotifierEntry["severity"]`. The
+ *  Kanban accent colours by this so it matches the bell badge / icon
+ *  (urgent → red, nudge → amber). */
+export type NotifierSeverity = "info" | "nudge" | "urgent";
+
+const SEVERITY_RANK: Record<NotifierSeverity, number> = { info: 0, nudge: 1, urgent: 2 };
+
+function asSeverity(value: unknown): NotifierSeverity {
+  return value === "urgent" || value === "nudge" ? value : "info";
+}
+
 /** The minimum entry shape this module reads — a structural subset of
  *  `NotifierEntry` so callers can pass entries straight from
  *  `useNotifications()` without a cast. */
 export interface NotifiedEntryLike {
   pluginData?: unknown;
+  severity?: string;
 }
 
 interface CollectionTarget {
@@ -35,14 +47,19 @@ function collectionTargetOf(pluginData: unknown): CollectionTarget | null {
   return { slug, itemId: typeof itemId === "string" ? itemId : undefined };
 }
 
-/** Item ids in `slug` that currently have an active bell notification.
+/** Map of itemId → worst active-notification severity for records in `slug`.
  *  Only entries carrying a concrete `itemId` are included (a bare
- *  collection-level target can't highlight a specific card). */
-export function collectionNotifiedItemIds(entries: readonly NotifiedEntryLike[], slug: string): Set<string> {
-  const ids = new Set<string>();
+ *  collection-level target can't highlight a specific card); when an item has
+ *  several notifications the highest severity wins, so the accent matches the
+ *  most urgent one. */
+export function collectionNotifiedSeverities(entries: readonly NotifiedEntryLike[], slug: string): Map<string, NotifierSeverity> {
+  const out = new Map<string, NotifierSeverity>();
   for (const entry of entries) {
     const target = collectionTargetOf(entry.pluginData);
-    if (target && target.slug === slug && target.itemId) ids.add(target.itemId);
+    if (!target || target.slug !== slug || !target.itemId) continue;
+    const severity = asSeverity(entry.severity);
+    const existing = out.get(target.itemId);
+    if (!existing || SEVERITY_RANK[severity] > SEVERITY_RANK[existing]) out.set(target.itemId, severity);
   }
-  return ids;
+  return out;
 }

--- a/src/utils/collections/notifiedItems.ts
+++ b/src/utils/collections/notifiedItems.ts
@@ -1,0 +1,48 @@
+// Map active bell notifications back to the collection records they
+// point at, so views (the Kanban board) can flag a card that has a
+// pending notification.
+//
+// Collection-completion entries are published by
+// `server/workspace/collections/notifications.ts` with a typed
+// `pluginData.action.target = { view: "collections", slug, itemId }`
+// (see `LegacyNotifierPluginData`). `pluginData` arrives on the client
+// as `unknown`, so we narrow defensively rather than trusting its shape.
+
+import { NOTIFICATION_VIEWS } from "../../types/notification";
+
+/** The minimum entry shape this module reads — a structural subset of
+ *  `NotifierEntry` so callers can pass entries straight from
+ *  `useNotifications()` without a cast. */
+export interface NotifiedEntryLike {
+  pluginData?: unknown;
+}
+
+interface CollectionTarget {
+  slug: string;
+  itemId?: string;
+}
+
+/** Narrow an entry's opaque `pluginData` to its collection navigate
+ *  target, or null when it isn't a collection-targeting entry. */
+function collectionTargetOf(pluginData: unknown): CollectionTarget | null {
+  if (!pluginData || typeof pluginData !== "object") return null;
+  const { action } = pluginData as { action?: unknown };
+  if (!action || typeof action !== "object") return null;
+  const { target } = action as { target?: unknown };
+  if (!target || typeof target !== "object") return null;
+  const { view, slug, itemId } = target as { view?: unknown; slug?: unknown; itemId?: unknown };
+  if (view !== NOTIFICATION_VIEWS.collections || typeof slug !== "string") return null;
+  return { slug, itemId: typeof itemId === "string" ? itemId : undefined };
+}
+
+/** Item ids in `slug` that currently have an active bell notification.
+ *  Only entries carrying a concrete `itemId` are included (a bare
+ *  collection-level target can't highlight a specific card). */
+export function collectionNotifiedItemIds(entries: readonly NotifiedEntryLike[], slug: string): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    const target = collectionTargetOf(entry.pluginData);
+    if (target && target.slug === slug && target.itemId) ids.add(target.itemId);
+  }
+  return ids;
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,10 +1,10 @@
 // Client-side ID helpers. Mirrors `server/utils/id.ts` for the
 // frontend — see issue #723 for the full design rationale.
 //
-// The client only needs `makeUuid()` at the moment: all per-action
-// tool-call `uuid` fields emitted by `src/plugins/*/index.ts`. If a
-// client-side file-naming use case emerges, mirror `shortId()` from
-// the server helper.
+// `makeUuid()` backs the per-action tool-call `uuid` fields emitted by
+// `src/plugins/*/index.ts`. `shortHexId()` backs UI-side record naming:
+// pre-filling a new collection record's primary key with the same id
+// shape the server would have generated for a blank-id POST.
 
 /**
  * Full UUID v4 (36 chars, hyphenated).
@@ -15,4 +15,15 @@
  */
 export function makeUuid(): string {
   return crypto.randomUUID();
+}
+
+/**
+ * 8-char hex id — short, slug-safe (matches `SAFE_SLUG_PATTERN`), and
+ * editable. Mirrors the server's `generateItemId()`
+ * (`randomBytes(4).toString("hex")`) so a UI-created collection record
+ * gets the same id shape the server would have generated for a form
+ * submitted with a blank primary key.
+ */
+export function shortHexId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 8);
 }

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -19,10 +19,11 @@ export function makeUuid(): string {
 
 /**
  * 8-char hex id — short, slug-safe (matches `SAFE_SLUG_PATTERN`), and
- * editable. Mirrors the server's `generateItemId()`
- * (`randomBytes(4).toString("hex")`) so a UI-created collection record
- * gets the same id shape the server would have generated for a form
- * submitted with a blank primary key.
+ * editable. Produces the same id *shape* as the server's `generateItemId()`
+ * (8 hex chars) so a UI-created collection record looks like one the server
+ * would have generated for a form submitted with a blank primary key. The
+ * source of randomness differs (UUID-derived here vs `randomBytes` on the
+ * server); only the shape is intentionally shared, not the algorithm.
  */
 export function shortHexId(): string {
   return crypto.randomUUID().replace(/-/g, "").slice(0, 8);

--- a/src/utils/promptSafety.ts
+++ b/src/utils/promptSafety.ts
@@ -1,0 +1,14 @@
+// Neutralize structural prompt-injection vectors in a short, record-derived
+// string before it rides into an LLM-facing prompt: strip angle brackets,
+// defang backticks / `${` template openings, COLLAPSE WHITESPACE (so an
+// embedded newline can't fabricate a pseudo-instruction on its own line), and
+// clip to a small budget. Shared by the server (presentCollection validation →
+// instructions) and the client (collection Repair button) so the two defangs
+// can't drift (#1677).
+
+/** Max chars kept — the first batch of a validation issue is enough to act on. */
+const DEFANG_MAX_LEN = 200;
+
+export function defangForPrompt(value: string): string {
+  return value.replace(/[<>]/g, "").replace(/`/g, "'").replace(/\$\{/g, "$ {").replace(/\s+/g, " ").slice(0, DEFANG_MAX_LEN);
+}

--- a/test/utils/collections/test_notifiedItems.ts
+++ b/test/utils/collections/test_notifiedItems.ts
@@ -1,0 +1,47 @@
+// Unit tests for collectionNotifiedItemIds
+// (src/utils/collections/notifiedItems.ts) — maps active bell entries to
+// the (slug, itemId) records they deep-link, so the Kanban board can flag
+// cards that have a pending notification.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { collectionNotifiedItemIds, type NotifiedEntryLike } from "../../../src/utils/collections/notifiedItems.js";
+
+/** A bell entry shaped like the ones `notifications.ts` publishes:
+ *  `pluginData.action.target = { view: "collections", slug, itemId }`. */
+function collectionEntry(slug: string, itemId?: string): NotifiedEntryLike {
+  return { pluginData: { action: { type: "navigate", target: { view: "collections", slug, itemId } } } };
+}
+
+describe("collectionNotifiedItemIds", () => {
+  it("collects item ids for the matching slug", () => {
+    const entries = [collectionEntry("tasks", "t1"), collectionEntry("tasks", "t2"), collectionEntry("notes", "n1")];
+    assert.deepEqual(collectionNotifiedItemIds(entries, "tasks"), new Set(["t1", "t2"]));
+  });
+
+  it("ignores entries for other collections", () => {
+    assert.deepEqual(collectionNotifiedItemIds([collectionEntry("notes", "n1")], "tasks"), new Set());
+  });
+
+  it("skips collection-level entries that carry no itemId", () => {
+    assert.deepEqual(collectionNotifiedItemIds([collectionEntry("tasks")], "tasks"), new Set());
+  });
+
+  it("ignores entries whose target is a different view", () => {
+    const wiki: NotifiedEntryLike = { pluginData: { action: { target: { view: "wiki", slug: "tasks", itemId: "t1" } } } };
+    assert.deepEqual(collectionNotifiedItemIds([wiki], "tasks"), new Set());
+  });
+
+  it("tolerates entries with absent or malformed pluginData", () => {
+    const entries: NotifiedEntryLike[] = [
+      {},
+      { pluginData: null },
+      { pluginData: "nope" },
+      { pluginData: { action: {} } },
+      { pluginData: { action: { target: { view: "collections" } } } }, // missing slug
+      collectionEntry("tasks", "t1"),
+    ];
+    assert.deepEqual(collectionNotifiedItemIds(entries, "tasks"), new Set(["t1"]));
+  });
+});

--- a/test/utils/collections/test_notifiedItems.ts
+++ b/test/utils/collections/test_notifiedItems.ts
@@ -1,36 +1,52 @@
-// Unit tests for collectionNotifiedItemIds
-// (src/utils/collections/notifiedItems.ts) — maps active bell entries to
-// the (slug, itemId) records they deep-link, so the Kanban board can flag
-// cards that have a pending notification.
+// Unit tests for collectionNotifiedSeverities
+// (src/utils/collections/notifiedItems.ts) — maps active bell entries to the
+// (slug, itemId) records they deep-link plus the notification severity, so the
+// Kanban board can flag cards in the matching bell colour.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { collectionNotifiedItemIds, type NotifiedEntryLike } from "../../../src/utils/collections/notifiedItems.js";
+import { collectionNotifiedSeverities, type NotifiedEntryLike } from "../../../src/utils/collections/notifiedItems.js";
 
 /** A bell entry shaped like the ones `notifications.ts` publishes:
- *  `pluginData.action.target = { view: "collections", slug, itemId }`. */
-function collectionEntry(slug: string, itemId?: string): NotifiedEntryLike {
-  return { pluginData: { action: { type: "navigate", target: { view: "collections", slug, itemId } } } };
+ *  `pluginData.action.target = { view: "collections", slug, itemId }`, with a
+ *  top-level `severity`. */
+function collectionEntry(slug: string, itemId?: string, severity?: string): NotifiedEntryLike {
+  return { severity, pluginData: { action: { type: "navigate", target: { view: "collections", slug, itemId } } } };
 }
 
-describe("collectionNotifiedItemIds", () => {
-  it("collects item ids for the matching slug", () => {
-    const entries = [collectionEntry("tasks", "t1"), collectionEntry("tasks", "t2"), collectionEntry("notes", "n1")];
-    assert.deepEqual(collectionNotifiedItemIds(entries, "tasks"), new Set(["t1", "t2"]));
+describe("collectionNotifiedSeverities", () => {
+  it("maps item ids to their severity for the matching slug", () => {
+    const entries = [collectionEntry("tasks", "t1", "urgent"), collectionEntry("tasks", "t2", "nudge"), collectionEntry("notes", "n1", "urgent")];
+    assert.deepEqual(
+      collectionNotifiedSeverities(entries, "tasks"),
+      new Map([
+        ["t1", "urgent"],
+        ["t2", "nudge"],
+      ]),
+    );
+  });
+
+  it("defaults an unknown/absent severity to 'info'", () => {
+    assert.deepEqual(collectionNotifiedSeverities([collectionEntry("tasks", "t1")], "tasks"), new Map([["t1", "info"]]));
+  });
+
+  it("keeps the worst severity when an item has several notifications", () => {
+    const entries = [collectionEntry("tasks", "t1", "nudge"), collectionEntry("tasks", "t1", "urgent"), collectionEntry("tasks", "t1", "info")];
+    assert.deepEqual(collectionNotifiedSeverities(entries, "tasks"), new Map([["t1", "urgent"]]));
   });
 
   it("ignores entries for other collections", () => {
-    assert.deepEqual(collectionNotifiedItemIds([collectionEntry("notes", "n1")], "tasks"), new Set());
+    assert.deepEqual(collectionNotifiedSeverities([collectionEntry("notes", "n1", "urgent")], "tasks"), new Map());
   });
 
   it("skips collection-level entries that carry no itemId", () => {
-    assert.deepEqual(collectionNotifiedItemIds([collectionEntry("tasks")], "tasks"), new Set());
+    assert.deepEqual(collectionNotifiedSeverities([collectionEntry("tasks", undefined, "urgent")], "tasks"), new Map());
   });
 
   it("ignores entries whose target is a different view", () => {
-    const wiki: NotifiedEntryLike = { pluginData: { action: { target: { view: "wiki", slug: "tasks", itemId: "t1" } } } };
-    assert.deepEqual(collectionNotifiedItemIds([wiki], "tasks"), new Set());
+    const wiki: NotifiedEntryLike = { severity: "urgent", pluginData: { action: { target: { view: "wiki", slug: "tasks", itemId: "t1" } } } };
+    assert.deepEqual(collectionNotifiedSeverities([wiki], "tasks"), new Map());
   });
 
   it("tolerates entries with absent or malformed pluginData", () => {
@@ -40,8 +56,8 @@ describe("collectionNotifiedItemIds", () => {
       { pluginData: "nope" },
       { pluginData: { action: {} } },
       { pluginData: { action: { target: { view: "collections" } } } }, // missing slug
-      collectionEntry("tasks", "t1"),
+      collectionEntry("tasks", "t1", "nudge"),
     ];
-    assert.deepEqual(collectionNotifiedItemIds(entries, "tasks"), new Set(["t1"]));
+    assert.deepEqual(collectionNotifiedSeverities(entries, "tasks"), new Map([["t1", "nudge"]]));
   });
 });


### PR DESCRIPTION
A batch of Collections UI fixes plus view-mode/sort persistence work.

## Changes

### Five collection-view UI fixes (`9b10a8bb`)
1. **Add-item ID** — manual add pre-fills a unique, editable primary-key id (`shortHexId`, matching the server's blank-id fallback) so users don't have to invent one.
2. **Table header height** — long field names clamp to one line (`whitespace-nowrap` + `truncate` + `title` tooltip) so the header row keeps its standard height.
3. **Delete confirm z-order** — `ConfirmModal` is now `Teleport`ed to `<body>` so its `z-9999` wins over the body-teleported item modal (`z-40`) instead of rendering behind it.
4. **Kanban notification accent** — cards with an active bell notification get an amber left accent, mapped from notifier entries by a new pure helper (unit-tested).
5. **Repair button** — the collection detail route returns record-validation issues; the view shows a Repair button that reports them back to the LLM (same path as `presentCollection`), with client-side defang. New i18n keys in all 8 locales.

### View mode applied to presentCollection cards (`ab0a549c`)
A freshly-rendered chat card seeds its initial view from the same per-collection localStorage store the standalone page uses (cards read but never write it, so a stale card can't clobber the shared preference).

### Table sort — persisted + shared (`4991c3a6`)
The table's active column sort is remembered across reloads and shared between the standalone page and chat cards via a single `localStorage` store (`collection_sorts`). Sort is intentionally not kept per-card; a card always re-reads the shared store on mount, so the two surfaces stay consistent with no clobber.

## Testing
- `yarn format` / `lint` / `typecheck` / `build` — all clean
- Unit: 5508 pass (incl. new `notifiedItems` helper test)
- E2E (Playwright): new `collection-sort-persist` (standalone reload + clear) and updated `present-collection` (embedded honours + writes the shared sort store; view-mode seeding) — all pass

## Notes
- Reverses a previously-deliberate behavior ("embedded card ignores the standalone view-mode store") — the matching E2E test was updated.
- Behavioral consequence of shared sort: sorting in one chat card updates the collection's remembered sort, so the standalone view and other cards pick it up the next time they mount.

## Summary by Sourcery

Improve collections UI ergonomics and make table view preferences (mode and sort) persist and be shared between the standalone page and embedded chat cards.

New Features:
- Surface server-detected collection record issues in the collections view with a Repair banner that sends a guided fix prompt to the LLM.
- Pre-fill new collection records with a generated, editable primary-key id matching the server’s default id shape.
- Highlight kanban cards that have active bell notifications with an amber accent.
- Persist per-collection table sort in localStorage and share it between the standalone collections page and presentCollection chat cards.
- Seed presentCollection cards’ initial view mode from the shared per-collection store when no card-local state exists.

Enhancements:
- Clamp long table header labels to a single truncated line to keep header height consistent.
- Teleport the confirmation modal to the document body to ensure it reliably overlays other modals.
- Add server-side validation of collection records to return non-fatal record issues alongside collection details.
- Introduce utilities for shared collection sort storage, short hex id generation, and mapping notification entries to collection item ids.

Documentation:
- Localize new collection repair messaging across all supported languages.

Tests:
- Add E2E coverage for standalone table sort persistence and its clearing behaviour.
- Extend presentCollection E2E tests to cover shared view-mode and table-sort behaviour between embedded cards and the standalone view.
- Add unit tests for mapping notification entries to collection item ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-view data validation + “Repair” banner for collections; shared per-collection table sort persistence; kanban cards show notification accents; shorter auto-generated IDs for new records; safer text sanitization for repair prompts.

* **Bug Fixes**
  * Modal overlay layering improved (renders under document body).

* **Tests**
  * Added E2E tests for table sorting persistence and embedded cards; unit tests for notification severity mapping.

* **Documentation**
  * Added repair-flow docs and localized UI strings (8 languages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->