### PR TITLE
feat(agent): spawnBackgroundChat — generic parallel/detached chat primitive

### DIFF
--- a/plans/feat-spawn-background-chat.md
+++ b/plans/feat-spawn-background-chat.md
@@ -1,0 +1,188 @@
+# feat: `spawnBackgroundChat` — a generic detached-session primitive
+
+## Motivation
+
+When a learner opens **Lesson 1** of a lessons-collection course, they wait
+**minutes** before any text appears: lessons are authored just-in-time, and
+`presentHtml` only renders *after* the whole HTML page has generated. There is no
+background thread to hide that behind — the runtime agent (`claude` CLI subprocess)
+runs only inside its conversational turns, and Claude Code's `Task` subagent is
+**blocking** (the parent turn doesn't advance until the subagent returns), so it
+buys context isolation, not latency hiding.
+
+The real lever is that **each MulmoClaude chat session is its own `claude`
+subprocess**, so a *second* session runs genuinely in parallel. The host already has
+the primitive: `startChat()` (`server/api/routes/agent.ts:137`) launches a run
+fire-and-forget — it calls `runAgentInBackground(...)` (not awaited) and returns
+`{ kind: "started", chatSessionId }` immediately. It's already used headless by the
+scheduler and by runtime plugins (`ChatRuntimeApi.start()`).
+
+What's missing is a way for the **agent itself** (any role/skill, not just runtime
+plugins) to launch such a detached session, and a way to keep those sessions out of
+the user's sidebar when they're pure plumbing.
+
+This plan adds a generic, agent-callable MCP tool:
+
+```ts
+spawnBackgroundChat({ message: string, role: string, hidden: boolean }) → { chatId: string }
+```
+
+- **Generic** — not lessons-specific. Any skill/collection that wants lazy
+  background work uses it. (First consumer: lessons-collection prefetch — Phase 5.)
+- **Available to every role**, like a built-in (Bash/Read/Write) — no
+  `role.availablePlugins` opt-in.
+- **`hidden`** controls user visibility (see below).
+
+## Design
+
+### `hidden` → session origin mapping
+
+Every session carries an `origin` tag (`src/types/session.ts:10`), persisted in meta
+and used by the history sidebar (`src/config/historyFilters.ts`). Today the `all`
+filter lists **every** session regardless of origin — there is no "hidden".
+
+- **`hidden: true`** → tag the worker `SESSION_ORIGINS.system` (new). The
+  session-list path **excludes** this origin entirely — it shows under *no* sidebar
+  filter. Lessons calls it this way.
+- **`hidden: false`** → tag `SESSION_ORIGINS.skill` (it *is* an agent/skill-spawned
+  chat): a normal, visible session reachable under the **Skill** filter, for callers
+  that *want* the user to see/jump into the spawned chat.
+
+`system` is deliberately **not** added to `historyFilters.ts` — it has no pill; it's
+internal-only.
+
+### Fire-and-forget
+
+`spawnBackgroundChat`'s handler runs in the Express process (pure MCP tool handlers
+do — `mcp-tools/index.ts`), so it imports `startChat` directly, calls it with a fresh
+`randomUUID()` chatSessionId, and returns `{ chatId }` without awaiting the run.
+`startChat` is already non-blocking, so no new wrapper is needed.
+
+### Lifecycle of a `system` session
+
+`runAgentInBackground`'s `finally` block (`agent.ts:958-1021`) currently fires, for
+**every** completed run: the chat-indexer (summary/title — an LLM cost), wiki
+backlinks, and the journal. For a `system` worker these are waste + pollution. So:
+
+- **Skip** chat-index, wiki-backlinks, and journal for `origin === system`.
+- **Auto-delete on success, retain on error**: track whether the run errored; in the
+  `finally`, if `origin === system` and no error → `deleteSessionFiles(chatSessionId)`;
+  on error → keep the files so the failure is inspectable.
+
+(Completion notifications are already commented out at `agent.ts:960-991`, so there's
+nothing to suppress there.)
+
+### Runaway guard
+
+`spawnBackgroundChat` must not let the agent spawn a fleet:
+
+1. **No nesting** — refuse if the *calling* session is itself `origin === system`
+   (read the caller's origin via `ctx.sessionId`). A background worker cannot spawn
+   more background workers.
+2. **Concurrency cap** — a module-level counter of in-flight `system` sessions
+   (incremented on spawn, decremented when the run's `finally` deletes/finishes);
+   reject with a tool-result error (which the LLM can read and degrade gracefully)
+   when over the cap (start: `MAX_BACKGROUND_SESSIONS = 4`).
+
+## Per-file edits
+
+### Phase 1 — the `system` origin (host, data model)
+
+- **`src/types/session.ts`**
+  - Add `system: "system"` to `SESSION_ORIGINS` (`:10`). The `SessionOrigin` union
+    and `isSessionOrigin` pick it up automatically (both derive from
+    `SESSION_ORIGINS`).
+- **`src/config/historyFilters.ts`** — **no change** (intentionally: `system` gets no
+  filter pill). Add a one-line comment noting `system` is excluded by design.
+
+### Phase 2 — exclude `system` from listings (host, API)
+
+- **`server/api/routes/sessions.ts`** — in `loadSessionRow` (`:177`), after
+  `readSessionMeta`, `if (meta.origin === SESSION_ORIGINS.system) return null;`. This
+  is the single choke point feeding both the list route and the cursor diff
+  (`loadAllSessions`). Import `SESSION_ORIGINS` (currently only the type is imported).
+- **`server/workspace/chat-index/indexer.ts`** (verify) — ensure the indexer doesn't
+  separately surface `system` sessions; primary suppression is the Phase-4 skip, but
+  confirm no other enumerator lists them.
+
+### Phase 3 — the `spawnBackgroundChat` MCP tool (host)
+
+- **`server/agent/mcp-tools/spawnBackgroundChat.ts`** (new) — `McpTool` with:
+  - `definition.inputSchema`: `message` (string, required), `role` (string,
+    required), `hidden` (boolean, required).
+  - `prompt`: explains it launches a parallel detached chat; `hidden: true` for
+    invisible workers (artifact pre-generation), `hidden: false` for a visible chat
+    the user can open; returns `{ chatId }`; fire-and-forget (does not wait for the
+    work to finish).
+  - `handler(args, ctx)`: validate args; enforce runaway guard (no nesting via
+    `ctx.sessionId` origin lookup + concurrency cap); `origin = hidden ?
+    SESSION_ORIGINS.system : SESSION_ORIGINS.skill`; `const chatId = randomUUID();`
+    `await startChat({ message, roleId: role, chatSessionId: chatId, origin });`
+    return `JSON.stringify({ chatId })`.
+  - `alwaysActive: true` (see Phase 4).
+- **`server/agent/mcp-tools/index.ts`**
+  - Add `alwaysActive?: boolean` to the `McpTool` interface.
+  - Add `spawnBackgroundChat` to the `mcpTools` array.
+- **`src/config/toolNames.ts`** — add `spawnBackgroundChat: "spawnBackgroundChat"`
+  alongside `readXPost`/`searchX`/`notify` (`:61-63`).
+
+### Phase 4 — "always active" gating + lifecycle (host)
+
+- **`server/agent/activeTools.ts`** — in the static-MCP loop, treat `alwaysActive`
+  tools as allowed regardless of `role.availablePlugins`:
+  `const isAllowed = tool.alwaysActive === true || allowed.has(toolName);`
+  This makes the tool appear in every role's published MCP list **and** its system
+  prompt section (both derive from `getActiveToolDescriptors`). `--allowedTools`
+  already passes the `mcp__mulmoclaude` wildcard (`config.ts:309`), so permission is
+  covered.
+- **`server/api/routes/agent.ts`** — in `runAgentInBackground`:
+  - Track a `didError` flag (set in the `catch` at `:948`).
+  - In the `finally` (`:958-1021`): when `params.origin === SESSION_ORIGINS.system`,
+    skip the chat-index enqueue (`:997`), wiki-backlinks (`:1005`), and journal
+    (`:993`); and after `endRun`, `if (!didError) await deleteSessionFiles(chatSessionId)`.
+  - Decrement the background-session counter here (shared with Phase 3's guard) —
+    keep the counter in a small dedicated module (e.g.
+    `server/agent/backgroundSessions.ts`) imported by both the tool handler and this
+    finally, so the data model has one owner.
+
+### Phase 5 — consumer: lessons-collection recipe (docs only; independently shippable after 1–4)
+
+`server/workspace/helps/lessons-collection.md`:
+
+- **Pre-author Lesson 1 at course creation** — in "Plan the course", after
+  `presentCollection`, `Write` Lesson 1's HTML to disk and set its `lesson` path so
+  the very first **Learn** click presents-by-path instantly (no background trick can
+  cover a cold start with nothing on screen).
+- **Prefetch the next lesson** — in the `learn`/`continue` templates and the teaching
+  loop: when finishing lesson N, call `spawnBackgroundChat({ role: "tutor", hidden:
+  true, message: "<author lesson N+1 from its objective, Write the HTML to
+  artifacts/html/lessons-<topic>/<id>.html, set the record's lesson field, do NOT
+  presentHtml, then stop>" })`. By the time the learner reaches N+1 the file exists →
+  present-by-path → instant. Graceful fallback: if `lesson` is still empty (worker not
+  done / failed), author inline as today.
+- Add a short rationale paragraph (the worker uses `Write`, never `presentHtml`,
+  because no one is viewing its canvas).
+
+> Phase 5 is a separate concern from the host primitive. Ship Phases 1–4 first
+> (generic, testable on their own); lessons-collection is the first consumer.
+
+## Testing
+
+- **Unit (`test/agent/`)**:
+  - `spawnBackgroundChat` handler: arg validation; `hidden` → origin mapping; nesting
+    refusal when caller is `system`; concurrency cap rejection.
+  - `activeTools`: `alwaysActive` tool present for a role with empty
+    `availablePlugins`.
+  - `sessions` listing: a `system`-origin session is excluded from `loadAllSessions`.
+- **e2e-live** (optional follow-up): a course Learn click renders within a tight
+  bound on the second lesson (prefetch warmed); first lesson instant (pre-authored).
+- Manual: confirm `system` sessions never appear in the sidebar under any filter, and
+  that files are deleted on success / retained on error.
+
+## Out of scope / follow-ups
+
+- A declarative "on-action → fire background action for the next record" Collections
+  feature (host-driven prefetch) — bigger no-code-platform surface; revisit later.
+- Surfacing in-flight `system` workers anywhere in the UI (a debug-only view).
+- `selectedImageData`/attachments passthrough for spawned chats (not needed for
+  artifact authoring).

--- a/server/agent/activeTools.ts
+++ b/server/agent/activeTools.ts
@@ -97,7 +97,11 @@ export function getActiveToolDescriptors(role: Role): ActiveToolDescriptor[] {
 
   for (const tool of mcpTools) {
     const toolName = tool.definition.name;
-    if (!allowed.has(toolName) || seen.has(toolName) || !isMcpToolEnabled(tool)) continue;
+    // `alwaysActive` tools (generic host infra like spawnBackgroundChat)
+    // bypass the per-role gate — they're offered to every role, like a
+    // built-in. All other MCP tools stay gated by `availablePlugins`.
+    const isAllowed = tool.alwaysActive === true || allowed.has(toolName);
+    if (!isAllowed || seen.has(toolName) || !isMcpToolEnabled(tool)) continue;
     out.push({
       name: toolName,
       fullName: fullNameFor(toolName),

--- a/server/agent/backgroundSessions.ts
+++ b/server/agent/backgroundSessions.ts
@@ -14,14 +14,23 @@ const MAX_BACKGROUND_SESSIONS = 4;
 
 const inFlight = new Set<string>();
 
-/** True when there's room to launch another hidden worker session. */
-export function canSpawnBackgroundSession(): boolean {
-  return inFlight.size < MAX_BACKGROUND_SESSIONS;
+/** Atomically reserve a slot for a hidden worker session: returns
+ *  `false` (without reserving) when the cap is already reached,
+ *  otherwise reserves and returns `true`. The check and the insert
+ *  happen together with no `await` in between, so concurrent handler
+ *  calls can't all pass a separate "is there room?" check and then
+ *  each launch — which would briefly exceed the cap. The caller MUST
+ *  pair a `true` result with `releaseBackgroundSession` (on the
+ *  worker's completion, and as rollback if the launch itself fails). */
+export function tryReserveBackgroundSession(chatSessionId: string): boolean {
+  if (inFlight.size >= MAX_BACKGROUND_SESSIONS) return false;
+  inFlight.add(chatSessionId);
+  return true;
 }
 
-/** Mark a hidden worker session as in-flight. Call only once the
- *  underlying `startChat` has actually launched (so a failed launch
- *  doesn't leak a slot). */
+/** Unconditionally mark a session as in-flight (bypasses the cap).
+ *  Production code uses `tryReserveBackgroundSession`; this exists for
+ *  tests that need to fill the cap deterministically. */
 export function reserveBackgroundSession(chatSessionId: string): void {
   inFlight.add(chatSessionId);
 }

--- a/server/agent/backgroundSessions.ts
+++ b/server/agent/backgroundSessions.ts
@@ -1,0 +1,36 @@
+// In-flight bookkeeping for detached worker sessions launched via the
+// `spawnBackgroundChat` MCP tool with `hidden: true` (origin
+// `system`). Both the tool handler (which reserves a slot before
+// `startChat`) and `runAgentInBackground`'s `finally` (which releases
+// it when the worker finishes) run in the same Express process, so
+// this module-level Set is the single shared owner of the count.
+//
+// Purpose: a runaway guard. Without a cap, a misbehaving agent could
+// fan out an unbounded number of parallel `claude` subprocesses. The
+// cap is small on purpose — the intended use is "stay one or two
+// lessons ahead", not a job queue.
+
+const MAX_BACKGROUND_SESSIONS = 4;
+
+const inFlight = new Set<string>();
+
+/** True when there's room to launch another hidden worker session. */
+export function canSpawnBackgroundSession(): boolean {
+  return inFlight.size < MAX_BACKGROUND_SESSIONS;
+}
+
+/** Mark a hidden worker session as in-flight. Call only once the
+ *  underlying `startChat` has actually launched (so a failed launch
+ *  doesn't leak a slot). */
+export function reserveBackgroundSession(chatSessionId: string): void {
+  inFlight.add(chatSessionId);
+}
+
+/** Release a hidden worker session's slot. Idempotent / safe to call
+ *  for non-background sessions (no-op when the id was never reserved),
+ *  so the agent run's `finally` can call it without branching. */
+export function releaseBackgroundSession(chatSessionId: string): void {
+  inFlight.delete(chatSessionId);
+}
+
+export { MAX_BACKGROUND_SESSIONS };

--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { readXPost, searchX } from "./x.js";
 import { notify } from "./notify.js";
 import { handlePermission } from "./handlePermission.js";
+import { spawnBackgroundChat } from "./spawnBackgroundChat.js";
 import { errorMessage } from "../../utils/errors.js";
 import { notFound, sendError, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -25,10 +26,16 @@ export interface McpTool {
   };
   requiredEnv?: string[];
   prompt?: string;
+  /** When true, the tool is offered to EVERY role regardless of
+   *  `role.availablePlugins` — like a built-in (Bash/Read/Write).
+   *  `getActiveToolDescriptors` (server/agent/activeTools.ts) skips
+   *  the per-role gate for these. Use only for generic host
+   *  infrastructure that benefits every role. */
+  alwaysActive?: boolean;
   handler: (args: Record<string, unknown>, ctx?: McpToolContext) => Promise<string>;
 }
 
-export const mcpTools: McpTool[] = [readXPost, searchX, notify, handlePermission];
+export const mcpTools: McpTool[] = [readXPost, searchX, notify, handlePermission, spawnBackgroundChat];
 
 const toolMap = new Map(mcpTools.map((tool) => [tool.definition.name, tool]));
 

--- a/server/agent/mcp-tools/spawnBackgroundChat.ts
+++ b/server/agent/mcp-tools/spawnBackgroundChat.ts
@@ -33,7 +33,7 @@ import { readSessionMeta } from "../../utils/files/session-io.js";
 // builds its `mcpTools` array. `startChat` is loaded lazily via dynamic
 // import in the production singleton instead.
 import type { StartChatParams, StartChatResult } from "../../api/routes/agent.js";
-import { canSpawnBackgroundSession, reserveBackgroundSession, MAX_BACKGROUND_SESSIONS } from "../backgroundSessions.js";
+import { tryReserveBackgroundSession, releaseBackgroundSession, MAX_BACKGROUND_SESSIONS } from "../backgroundSessions.js";
 import type { McpToolContext } from "./index.js";
 
 export type StartChatFn = (params: StartChatParams) => Promise<StartChatResult>;
@@ -100,20 +100,24 @@ export function makeSpawnBackgroundChatTool(deps: SpawnBackgroundChatDeps) {
         }
       }
 
-      // Runaway guard: cap concurrent hidden workers.
-      if (hidden && !canSpawnBackgroundSession()) {
+      const origin: SessionOrigin = hidden ? SESSION_ORIGINS.system : SESSION_ORIGINS.skill;
+      const chatId = randomUUID();
+
+      // Runaway guard: cap concurrent hidden workers. Reserve the slot
+      // ATOMICALLY and BEFORE launching — a check-then-reserve split
+      // around the `await startChat` below would let concurrent calls
+      // all pass the check and over-spawn. Released in
+      // `runAgentInBackground`'s finally, or rolled back here if the
+      // launch fails.
+      if (hidden && !tryReserveBackgroundSession(chatId)) {
         return `spawnBackgroundChat: refused — too many background sessions already in flight (max ${MAX_BACKGROUND_SESSIONS}). Do the work inline instead.`;
       }
 
-      const origin: SessionOrigin = hidden ? SESSION_ORIGINS.system : SESSION_ORIGINS.skill;
-      const chatId = randomUUID();
       const result = await deps.startChat({ message, roleId: role, chatSessionId: chatId, origin });
       if (result.kind === "error") {
+        if (hidden) releaseBackgroundSession(chatId); // roll back the reservation
         return `spawnBackgroundChat: failed to start chat: ${result.error}`;
       }
-      // Reserve only after a successful launch so a failed start can't
-      // leak a slot. Released in `runAgentInBackground`'s finally.
-      if (hidden) reserveBackgroundSession(chatId);
       return JSON.stringify({ chatId, hidden });
     },
   };

--- a/server/agent/mcp-tools/spawnBackgroundChat.ts
+++ b/server/agent/mcp-tools/spawnBackgroundChat.ts
@@ -1,0 +1,131 @@
+// `spawnBackgroundChat` launches a SECOND, parallel chat session via
+// the host's `startChat` (each session is its own `claude`
+// subprocess, so the worker runs genuinely concurrently with the
+// caller's conversation — unlike Claude Code's blocking `Task`
+// subagent). It's a generic primitive: any role/skill can use it to
+// do work off the critical path (the first consumer is the
+// lessons-collection recipe, which pre-authors the next lesson's HTML
+// while the learner reads the current one).
+//
+// `startChat` is already fire-and-forget — it kicks off
+// `runAgentInBackground` (not awaited) and returns once the run is
+// launched — so this handler returns the new `chatId` immediately
+// without waiting for the worker to finish.
+//
+// `hidden` controls whether the user ever sees the spawned session:
+//   - true  → origin `system`; excluded from every session listing
+//             (no sidebar entry under any filter). For invisible
+//             plumbing like artifact pre-generation.
+//   - false → origin `skill`; a normal visible chat, reachable under
+//             the "Skill" history filter. For when the user should be
+//             able to open the spawned chat.
+//
+// Deps are injected so the unit test can assert the origin mapping,
+// the no-nesting refusal, and the concurrency cap without spawning
+// real subprocesses.
+
+import { randomUUID } from "node:crypto";
+import { SESSION_ORIGINS, type SessionOrigin } from "../../../src/types/session.js";
+import { readSessionMeta } from "../../utils/files/session-io.js";
+// `agent.ts` is imported TYPE-ONLY: a value import would form a runtime
+// module cycle (agent.ts → agent/index → config → activeTools →
+// mcp-tools/index → here) that triggers a TDZ error while index.ts
+// builds its `mcpTools` array. `startChat` is loaded lazily via dynamic
+// import in the production singleton instead.
+import type { StartChatParams, StartChatResult } from "../../api/routes/agent.js";
+import { canSpawnBackgroundSession, reserveBackgroundSession, MAX_BACKGROUND_SESSIONS } from "../backgroundSessions.js";
+import type { McpToolContext } from "./index.js";
+
+export type StartChatFn = (params: StartChatParams) => Promise<StartChatResult>;
+export type ReadSessionOriginFn = (sessionId: string) => Promise<SessionOrigin | undefined>;
+
+export interface SpawnBackgroundChatDeps {
+  startChat: StartChatFn;
+  /** Look up the calling session's origin so a hidden worker can be
+   *  refused permission to spawn further hidden workers (no nesting). */
+  readSessionOrigin: ReadSessionOriginFn;
+}
+
+export function makeSpawnBackgroundChatTool(deps: SpawnBackgroundChatDeps) {
+  return {
+    definition: {
+      name: "spawnBackgroundChat",
+      description:
+        "Launch a separate, parallel chat session that runs its own agent turn concurrently with this conversation, then returns immediately (fire-and-forget). Use it to do work off the critical path — e.g. pre-generate an artifact the user will need soon — without blocking the current turn. Returns the new session's chatId.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: {
+            type: "string",
+            description:
+              "The first user turn for the spawned session — a complete, self-contained instruction, since the worker shares none of this conversation's context. State exactly what to produce and where to write it, and tell it to finish silently (do not present anything) when done.",
+          },
+          role: {
+            type: "string",
+            description: "Role id the spawned session runs in (e.g. the same role that owns the task). Determines which tools the worker has.",
+          },
+          hidden: {
+            type: "boolean",
+            description:
+              "true → invisible worker the user never sees (use for background plumbing like artifact pre-generation). false → a normal visible chat the user can open from history.",
+          },
+        },
+        required: ["message", "role", "hidden"],
+      },
+    },
+
+    // Generic host infrastructure — available to every role, not gated
+    // by `role.availablePlugins`. See `McpTool.alwaysActive`.
+    alwaysActive: true,
+
+    prompt:
+      "Use `spawnBackgroundChat` to run work in parallel with the current conversation instead of making the user wait for it inline. The classic case: while the user is reading or working through the current item, spawn a hidden worker to pre-generate the NEXT artifact they'll need, so it's ready instantly when they reach it. " +
+      "Set `hidden: true` for invisible background work (the session never appears in the user's history); `hidden: false` only when the user should be able to open the spawned chat themselves. " +
+      "The `message` must be fully self-contained — the worker shares NONE of this chat's context — and should instruct the worker to write its output to disk and stop without presenting anything (no one is viewing its canvas). It returns right away with a `chatId`; it does NOT wait for the worker to finish, so always keep a graceful fallback (do the work inline) in case the worker hasn't finished by the time its output is needed.",
+
+    async handler(args: Record<string, unknown>, ctx?: McpToolContext): Promise<string> {
+      const message = typeof args.message === "string" ? args.message.trim() : "";
+      if (!message) return "spawnBackgroundChat: `message` is required (non-empty string).";
+      const role = typeof args.role === "string" ? args.role.trim() : "";
+      if (!role) return "spawnBackgroundChat: `role` is required (non-empty string — the role id the worker runs in).";
+      const { hidden } = args;
+      if (typeof hidden !== "boolean") return "spawnBackgroundChat: `hidden` is required (boolean).";
+
+      // No nesting: a hidden worker session must not fan out further
+      // hidden workers. Only enforced when we know the caller's session.
+      if (ctx?.sessionId) {
+        const parentOrigin = await deps.readSessionOrigin(ctx.sessionId);
+        if (parentOrigin === SESSION_ORIGINS.system) {
+          return "spawnBackgroundChat: refused — a background worker session cannot spawn further background sessions. Do the work inline instead.";
+        }
+      }
+
+      // Runaway guard: cap concurrent hidden workers.
+      if (hidden && !canSpawnBackgroundSession()) {
+        return `spawnBackgroundChat: refused — too many background sessions already in flight (max ${MAX_BACKGROUND_SESSIONS}). Do the work inline instead.`;
+      }
+
+      const origin: SessionOrigin = hidden ? SESSION_ORIGINS.system : SESSION_ORIGINS.skill;
+      const chatId = randomUUID();
+      const result = await deps.startChat({ message, roleId: role, chatSessionId: chatId, origin });
+      if (result.kind === "error") {
+        return `spawnBackgroundChat: failed to start chat: ${result.error}`;
+      }
+      // Reserve only after a successful launch so a failed start can't
+      // leak a slot. Released in `runAgentInBackground`'s finally.
+      if (hidden) reserveBackgroundSession(chatId);
+      return JSON.stringify({ chatId, hidden });
+    },
+  };
+}
+
+export const spawnBackgroundChat = makeSpawnBackgroundChatTool({
+  // Dynamic import (call-time) breaks the module cycle with agent.ts —
+  // see the type-only import note above. The module is cached after the
+  // first call, so this costs nothing on the hot path.
+  startChat: async (params) => {
+    const { startChat } = await import("../../api/routes/agent.js");
+    return startChat(params);
+  },
+  readSessionOrigin: async (sessionId) => (await readSessionMeta(sessionId))?.origin,
+});

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -12,6 +12,7 @@ import {
   readSessionJsonl,
   sessionJsonlAbsPath,
   ensureChatDir,
+  deleteSessionFiles,
 } from "../../utils/files/session-io.js";
 import { getRole } from "../../workspace/roles.js";
 import { runAgent } from "../../agent/index.js";
@@ -31,16 +32,14 @@ import { errorMessage } from "../../utils/errors.js";
 import { createArgsCache, recordToolEvent } from "../../workspace/tool-trace/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
-import { isSessionOrigin, type SessionOrigin } from "../../../src/types/session.js";
+import { isSessionOrigin, SESSION_ORIGINS, type SessionOrigin } from "../../../src/types/session.js";
+import { releaseBackgroundSession } from "../../agent/backgroundSessions.js";
 // Imports kept commented (instead of deleted) alongside the
-// publishNotification call below — see the duplicate-notification
-// comment near `endRun()` in `runAgentInBackground` for context.
-// `SESSION_ORIGINS` is dragged into this same commented block
-// because every remaining live reference to it lived inside the
-// commented helper / call site; once those went, leaving the value
-// import un-commented would trip the unused-import lint rule.
+// publishNotification call in `runPostTurnSideEffects` — see the
+// duplicate-notification comment there for context. (`SESSION_ORIGINS`
+// is now imported live above — the hidden-worker branch in
+// `runAgentInBackground` references it.)
 // (by snakajima)
-// import { SESSION_ORIGINS } from "../../../src/types/session.js";
 // import { NOTIFICATION_KINDS } from "../../../src/types/notification.js";
 // import { publishNotification } from "../../events/notifications.js";
 import { env } from "../../system/env.js";
@@ -890,6 +889,10 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
   let failoverAttemptsRemaining = claudeSessionId ? 1 : 0;
   let currentMessage = decoratedMessage;
   let currentClaudeSessionId = claudeSessionId;
+  // Tracks whether this run threw, so the finally can decide whether a
+  // hidden worker session's files are safe to delete (success) or
+  // should be kept for inspection (error).
+  let didError = false;
 
   try {
     while (true) {
@@ -946,6 +949,7 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
       durationMs: Date.now() - requestStartedAt,
     });
   } catch (err) {
+    didError = true;
     await flushTextAccumulator(eventCtx);
     log.error("agent", "request failed", {
       chatSessionId,
@@ -956,54 +960,83 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
       message: String(err),
     });
   } finally {
-    endRun(chatSessionId);
-    // Commented out: this would create a duplicate notification.
-    //
-    // `endRun(chatSessionId)` above flips `session.hasUnread = true`
-    // for every chat-session turn completion regardless of origin,
-    // which already lights up the red unread-count badge on the
-    // Session History Panel toggle button (driven by `hasUnread` →
-    // `useSessionDerived.unreadCount` →
-    // `SessionHistoryToggleButton.vue`). Firing
-    // `publishNotification` here adds a *second* red badge — on the
-    // notification bell — for the exact same event, in the same
-    // chrome row. Two indicators, one event = noise.
-    //
-    // The duplicate occurs whenever a chat session receives a new
-    // message, which is exactly what every code path through this
-    // `finally` represents. The initiator of the turn (human, bridge
-    // user, scheduled job, skill chain, another agent) does not
-    // change this — both badges flip together.
-    //
-    // Other `publishNotification` call sites (news pipeline, `notify`
-    // MCP tool, scheduled-test endpoint) do not post a chat-session
-    // message at the same time, so they are not duplicates and
-    // remain enabled.
-    //
-    // (by snakajima)
-    //
-    // if (params.origin && params.origin !== SESSION_ORIGINS.human) {
-    //   publishNotification({
-    //     kind: NOTIFICATION_KINDS.agent,
-    //     title: completionNotificationTitle(params.role.name, params.origin),
-    //     sessionId: chatSessionId,
-    //   });
-    // }
-    // Fire-and-forget: journal + chat-index post-processing
-    maybeRunJournal({ activeSessionIds: getActiveSessionIds() }).catch(logBackgroundError("journal"));
-    maybeIndexSession({
-      sessionId: chatSessionId,
-      activeSessionIds: getActiveSessionIds(),
-    }).catch(logBackgroundError("chat-index"));
-    // Walks wiki/pages/ for files modified during this turn and
-    // appends a backlink to the originating chat session so the
-    // user can jump back from a wiki page to the conversation
-    // that created it. See #109.
-    maybeAppendWikiBacklinks({
-      chatSessionId,
-      turnStartedAt: requestStartedAt,
-    }).catch(logBackgroundError("wiki-backlinks"));
+    await finalizeRun(chatSessionId, params.origin, didError, requestStartedAt);
   }
+}
+
+// Run the per-turn teardown: mark the run finished, then either clean up
+// a hidden worker session or fire the normal post-turn side effects.
+// Split out of `runAgentInBackground` to keep that function under the
+// cognitive-complexity threshold.
+async function finalizeRun(chatSessionId: string, origin: SessionOrigin | undefined, didError: boolean, requestStartedAt: number): Promise<void> {
+  endRun(chatSessionId);
+
+  if (origin === SESSION_ORIGINS.system) {
+    // Hidden worker session (spawnBackgroundChat `hidden: true`) —
+    // plumbing, not a conversation. Release its runaway-guard slot,
+    // skip the post-turn side effects (they'd burn tokens summarising
+    // plumbing and pollute wiki backlinks), and clean up its files on
+    // success — keep them on error so a failed worker stays inspectable.
+    releaseBackgroundSession(chatSessionId);
+    if (!didError) {
+      await deleteSessionFiles(chatSessionId).catch(logBackgroundError("background-session-cleanup"));
+    }
+    return;
+  }
+
+  runPostTurnSideEffects(chatSessionId, requestStartedAt);
+}
+
+// Fire-and-forget post-turn processing for a normal (user-facing) chat
+// session: journal, chat-index, and wiki-backlinks. Hidden worker
+// sessions skip this entirely (see `runAgentInBackground`'s finally).
+function runPostTurnSideEffects(chatSessionId: string, requestStartedAt: number): void {
+  // Commented out: this would create a duplicate notification.
+  //
+  // `endRun(chatSessionId)` (in the caller) flips `session.hasUnread =
+  // true` for every chat-session turn completion regardless of origin,
+  // which already lights up the red unread-count badge on the
+  // Session History Panel toggle button (driven by `hasUnread` →
+  // `useSessionDerived.unreadCount` →
+  // `SessionHistoryToggleButton.vue`). Firing
+  // `publishNotification` here adds a *second* red badge — on the
+  // notification bell — for the exact same event, in the same
+  // chrome row. Two indicators, one event = noise.
+  //
+  // The duplicate occurs whenever a chat session receives a new
+  // message, which is exactly what every code path through the
+  // `finally` represents. The initiator of the turn (human, bridge
+  // user, scheduled job, skill chain, another agent) does not
+  // change this — both badges flip together.
+  //
+  // Other `publishNotification` call sites (news pipeline, `notify`
+  // MCP tool, scheduled-test endpoint) do not post a chat-session
+  // message at the same time, so they are not duplicates and
+  // remain enabled.
+  //
+  // (by snakajima)
+  //
+  // if (params.origin && params.origin !== SESSION_ORIGINS.human) {
+  //   publishNotification({
+  //     kind: NOTIFICATION_KINDS.agent,
+  //     title: completionNotificationTitle(params.role.name, params.origin),
+  //     sessionId: chatSessionId,
+  //   });
+  // }
+  // Fire-and-forget: journal + chat-index post-processing
+  maybeRunJournal({ activeSessionIds: getActiveSessionIds() }).catch(logBackgroundError("journal"));
+  maybeIndexSession({
+    sessionId: chatSessionId,
+    activeSessionIds: getActiveSessionIds(),
+  }).catch(logBackgroundError("chat-index"));
+  // Walks wiki/pages/ for files modified during this turn and
+  // appends a backlink to the originating chat session so the
+  // user can jump back from a wiki page to the conversation
+  // that created it. See #109.
+  maybeAppendWikiBacklinks({
+    chatSessionId,
+    turnStartedAt: requestStartedAt,
+  }).catch(logBackgroundError("wiki-backlinks"));
 }
 
 // Read claudeSessionId from meta (primary) or jsonl (legacy fallback).

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -19,7 +19,7 @@ import { markRead, getSession, evictSession, publishSessionsChanged } from "../.
 import { notFound } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
-import type { SessionOrigin } from "../../../src/types/session.js";
+import { SESSION_ORIGINS, type SessionOrigin } from "../../../src/types/session.js";
 import { env } from "../../system/env.js";
 import { ONE_DAY_MS } from "../../utils/time.js";
 import { encodeCursor, parseCursor, sessionChangeMs } from "./sessionsCursor.js";
@@ -181,6 +181,12 @@ async function loadSessionRow(sessionId: string, ctx: SessionRowContext): Promis
 
     const meta = await readSessionMeta(ctx.chatDir, sessionId);
     if (!meta) return null;
+
+    // Hidden worker sessions (spawnBackgroundChat `hidden: true`) are
+    // internal plumbing, not conversations — exclude them from every
+    // listing. This is the single choke point feeding both the list
+    // route and the cursor diff (`loadAllSessions`).
+    if (meta.origin === SESSION_ORIGINS.system) return null;
 
     // The meta sidecar bumps its mtime on hasUnread / origin writes —
     // feed it into changeMs so cursor-based refetches pick up drains

--- a/server/workspace/helps/lessons-collection.md
+++ b/server/workspace/helps/lessons-collection.md
@@ -22,9 +22,10 @@ self-contained HTML lessons you author.
 > stores its **workspace-relative path**, and the row becomes a clickable link
 > that re-opens the rendered page. The collection never stores the lesson body —
 > it points at it. One concept per lesson, one HTML file per lesson, one record
-> per lesson. **How that file gets written matters — see "Authoring the lesson
-> HTML" below: `presentHtml` renders a single lesson to the learner; don't loop it
-> to batch-create files.**
+> per lesson. **How and *when* that file gets written matters — see "Authoring the
+> lesson HTML" and "Pre-generating lessons in the background" below: author ahead of
+> time in a hidden background session so the learner never waits; `presentHtml`
+> renders a single lesson to the learner but don't loop it to batch-create files.**
 
 ## Ground it in the learner's goal first
 
@@ -131,11 +132,21 @@ already authored — its `lesson` HTML path. Pick the mode from `status`, and ne
 jump straight to a quiz — the HTML page IS the lesson, so deliver it first.
 
 Deliver the page with `presentHtml`:
-- `lesson` empty (not authored yet — lessons are written just-in-time) → author the
+- `lesson` already set (often pre-authored in the background — see below) → present
+  it by passing its **path** to `presentHtml` (no duplicate save). Instant.
+- `lesson` empty (the prefetch worker hasn't finished, or never ran) → author the
   page **from the `objective` brief** and present it with `presentHtml` (passing the
   `html`), then write the returned `data.filePath` into the record's `lesson` field.
-- `lesson` already set → present it by passing its **path** to `presentHtml` (no
-  duplicate save).
+  This is the graceful fallback.
+
+**The moment the page is on screen — _before_ you teach or quiz — prefetch the next
+lesson** so its generation overlaps the whole time the learner spends here: call
+`spawnBackgroundChat` (`hidden: true`, `role: "tutor"`) to author the next-by-`order`
+lesson's HTML in the background (a self-contained message that reads that record and
+`Write`s the page to `artifacts/html/lessons-<topic>/<id>.html`, sets its `lesson`
+field, and presents nothing). Skip if it's already authored or this is the last
+lesson. **Do this now, not at the end** — the learner often advances the instant they
+finish, and a prefetch fired during the wrap-up is too late to hide the wait.
 
 Then branch on `status`:
 - `planned` / `learning` → teach the page, check understanding with a question or a
@@ -147,7 +158,8 @@ Then branch on `status`:
 
 Cite real sources in the page and in `resources`, and record anything to revisit in
 `notes`. Don't re-show the collection card after a single lesson — just keep the
-conversation going; the board reflects the new `status` next time it's opened.
+conversation going; the board reflects the new `status` next time it's opened. (The
+next lesson was already prefetched right after you showed this page — see above.)
 ```
 
 `data/skills/lessons-<topic>/templates/continue.md` (collection-level):
@@ -160,9 +172,11 @@ Continue the course. The summary above lists every lesson's `id`, `title`, and
 2. else the lowest-`order` `status: planned` lesson → start it
 3. else a `practiced` (not yet `mastered`) lesson → review it
 
-In cases 1–3, run that one lesson exactly like the per-lesson Learn button (author
-its page from `objective` if `lesson` is empty, else present by `path`; deliver it;
-check understanding; update `status` + `notes`). Don't re-show the collection card
+In cases 1–3, run that one lesson exactly like the per-lesson Learn button: present
+by `path` if `lesson` is set (else author from `objective`), and **immediately
+prefetch the next lesson** with a hidden `spawnBackgroundChat` worker — _before_ you
+teach or quiz, so it generates while the learner works. Then deliver the lesson, check
+understanding, and update `status` + `notes`. Don't re-show the collection card
 afterwards — just continue the conversation.
 
 4. only if **every** lesson is `mastered` → append the next batch as `planned`
@@ -211,6 +225,68 @@ of teaching, not an optional step before the quiz.
 Keep lesson pages **self-contained** (inline everything or an allowed CDN) so
 they render correctly regardless of the directory they were saved in.
 
+## Pre-generating lessons in the background — no wait
+
+Authoring a full HTML page takes the model tens of seconds, and `presentHtml` only
+renders **after** the page is fully generated. So a lesson authored at the moment
+the learner asks for it makes them **stare at a blank canvas** — worst of all on the
+very first lesson of a brand-new course. The fix: author **ahead of time, in a
+parallel background session**, so the page is already on disk (and the record's
+`lesson` field set) by the time the learner opens it. Then you just present it by
+`path`, instantly.
+
+The tool is **`spawnBackgroundChat({ message, role, hidden })`** — it launches a
+second, independent agent session that runs **concurrently** with this conversation
+and returns immediately. To pre-author one lesson:
+
+```
+spawnBackgroundChat({
+  role: "tutor",
+  hidden: true,
+  message: "<a fully self-contained instruction — see the rules below>"
+})
+```
+
+Rules for the worker:
+
+- **`hidden: true`, always.** These are plumbing, not conversations — a visible
+  worker would clutter the learner's chat history. (`hidden: false` exists for other
+  uses where the user *should* see the spawned chat; a lesson worker is never that.)
+- **The `message` must be fully self-contained** — the worker shares NONE of this
+  chat's context. Spell out: read the record at
+  `data/lessons-<topic>/items/<id>.json`; author a self-contained HTML page **from
+  its `objective`** (full `<!DOCTYPE html>`, inline CSS/JS or an allowed CDN — see
+  `config/helps/presenthtml.md`); **`Write`** it to
+  `artifacts/html/lessons-<topic>/<id>.html`; set that path as the record's `lesson`
+  field; do **NOT** call `presentHtml` and do **NOT** present anything — just write
+  the files and stop. (No one is viewing the worker's canvas, so presenting there is
+  wasted.)
+- **One lesson per call**, and don't spawn a fleet — the host caps concurrent hidden
+  workers and a worker can't spawn further workers.
+
+**When to pre-author:**
+
+1. **At course creation — pre-author lesson 1 (optionally 2).** Right after
+   `presentCollection` shows the roadmap, fire a worker for lesson 1 and tell the
+   learner it's being prepared (e.g. "コースができました!最初のレッスンを準備中です。
+   準備ができたら『始めて』と言ってください"). The learner reads the roadmap while the
+   page generates — the wait now **overlaps** with something useful instead of being
+   dead air. Do **not** also author lesson 1 inline in the same turn.
+2. **Prefetch the next lesson the moment you present the current one — not at the
+   end.** As soon as lesson N's page is on screen (*before* you teach or quiz it),
+   fire a worker for the next-by-`order` lesson, so its generation overlaps the
+   *whole* time the learner spends on N. Waiting until you update `status`/`notes` is
+   too late — the learner often advances the instant they finish, and the wait
+   reappears. By the time they reach N+1, it's already authored → instant.
+
+**Presenting, and the fallback.** When the learner opens a lesson, check its `lesson`
+field: **set** → `presentHtml` by `path` (instant); **still empty** (the worker
+hasn't finished, or never ran) → author it inline from `objective` as usual. The
+inline path is the graceful fallback — background pre-generation is a pure
+optimization, never a dependency. Because workers write to the **stable**
+`artifacts/html/lessons-<topic>/<id>.html` path, a rare double-author (learner races
+ahead of the worker) just overwrites in place — never a duplicate.
+
 ## SKILL.md
 
 `data/skills/lessons-<topic>/SKILL.md` tells the agent when and how to operate the
@@ -231,23 +307,33 @@ collection. Keep it short — the schema and templates do the heavy lifting. Cov
     what makes deferred authoring work: when you write the page later, the record's
     `objective` is the prompt you generate it from, so write it that way. Once the
     records are written, call `presentCollection` **once** to show the roadmap (this
-    also surfaces any malformed records right away).
-  - **Pre-author the initial set** (optional): you *may* **Write** a few lesson
-    HTML pages **directly to disk** at `artifacts/html/lessons-<topic>/<id>.html`
-    (see "Authoring the lesson HTML") and set their `lesson` paths up front — but
-    you don't have to. Leaving every lesson `planned` with an empty `lesson` and
-    authoring each one just-in-time (when it's taught) is the better default.
+    also surfaces any malformed records right away). **Then immediately fire a hidden
+    `spawnBackgroundChat` worker to pre-author lesson 1** and tell the learner it's
+    being prepared — do NOT author lesson 1 inline in the same turn (see
+    "Pre-generating lessons in the background"). The learner reads the roadmap while
+    it generates.
+  - **Pre-author lesson 1 in the background** (then the rest just-in-time): the
+    worker above writes lesson 1's HTML to disk and sets its `lesson` path, so the
+    first open never waits. You *may* fire a second worker for lesson 2 as well.
+    Leaving the rest `planned` with an empty `lesson` and prefetching each next
+    lesson as you open the current one is the default — never pre-generate the
+    whole course up front.
   - **Learn a lesson** (the per-lesson **Learn** button): always **deliver the page
-    with `presentHtml` first** — never jump straight to a quiz. Author it from
-    `objective` if `lesson` is empty (store the returned `data.filePath`), else
-    present by `path`. Then branch on `status`: `planned`/`learning` → teach + quiz
-    (→ `learning`/`practiced`); `practiced`/`mastered` → review quiz (→ `mastered`,
-    or back to `learning` if shaky). Record gaps in `notes`.
+    with `presentHtml` first** — never jump straight to a quiz. Present by `path` if
+    `lesson` is set (usually it was pre-authored in the background), else author from
+    `objective` inline (store the returned `data.filePath`) as the fallback. **The
+    moment the page is shown — before teaching or quizzing — prefetch the next lesson**
+    with a hidden `spawnBackgroundChat` worker, so its generation overlaps this whole
+    lesson rather than starting at the end. Then branch on `status`:
+    `planned`/`learning` → teach + quiz (→ `learning`/`practiced`);
+    `practiced`/`mastered` → review quiz (→ `mastered`, or back to `learning` if
+    shaky). Record gaps in `notes`.
   - **Continue the course** (the header **Learn** button, `continue` action): from
     the progress summary, resume a `learning` lesson, else start the lowest-`order`
-    `planned` one, else review a `practiced` lesson — and only once everything is
-    `mastered`, append the next batch of `planned` lessons (paragraph `objective`
-    each, HTML authored lazily later).
+    `planned` one, else review a `practiced` lesson; **prefetch the next lesson the
+    moment you present the current one** (not after running it) — and only once
+    everything is `mastered`, append the next batch of `planned` lessons (paragraph
+    `objective` each, HTML authored lazily later).
 - **Operations** — all I/O is plain Read / Write / Edit on
   `data/lessons-<topic>/items/<id>.json`, one record per file (Add / List /
   Update status / Edit / Delete). Rather than dumping the whole course into chat,

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -61,6 +61,9 @@ const HOST_TOOL_NAMES = {
   readXPost: "readXPost",
   searchX: "searchX",
   notify: "notify",
+  // Generic host primitive — always active for every role (not gated
+  // by `availablePlugins`). See `McpTool.alwaysActive`.
+  spawnBackgroundChat: "spawnBackgroundChat",
 
   // Preset runtime plugins (`server/plugins/preset-list.ts`).
   // Their `toolName` comes from the plugin package's

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -12,6 +12,13 @@ export const SESSION_ORIGINS = {
   scheduler: "scheduler",
   skill: "skill",
   bridge: "bridge",
+  // Detached worker sessions launched via `spawnBackgroundChat` with
+  // `hidden: true` (e.g. just-in-time artifact pre-generation). These
+  // are internal plumbing, not conversations — the session-list path
+  // (`loadSessionRow` in server/api/routes/sessions.ts) excludes this
+  // origin entirely, so it appears under NO history filter. Deliberately
+  // NOT added to `src/config/historyFilters.ts` (it has no pill).
+  system: "system",
 } as const;
 
 /** Prefix for plugin-seeded sessions. `runtime.chat.start()` (Phase 1

--- a/test/agent/test_activeTools.ts
+++ b/test/agent/test_activeTools.ts
@@ -127,6 +127,17 @@ describe("getActiveToolDescriptors — single source of truth", () => {
     assert.equal(matches[0].source, "static-gui", "static wins over runtime in the unified list");
   });
 
+  it("surfaces an `alwaysActive` MCP tool even when the role lists nothing", () => {
+    // `spawnBackgroundChat` is generic host infra flagged
+    // `alwaysActive: true`, so it must appear for EVERY role,
+    // bypassing the `availablePlugins` gate that all other tools obey.
+    const role = fakeRole([]);
+    const descriptors = getActiveToolDescriptors(role);
+    const entry = descriptors.find((descriptor) => descriptor.name === "spawnBackgroundChat");
+    assert.ok(entry, "alwaysActive tool must surface for a role with empty availablePlugins");
+    assert.equal(entry?.source, "static-mcp");
+  });
+
   it("does not include runtime plugins when the registry is empty", () => {
     const role = fakeRole(["presentMulmoScript"]);
     const descriptors = getActiveToolDescriptors(role);

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -376,7 +376,11 @@ describe("buildSystemPrompt", () => {
     assert.ok(!result.includes("## Sandbox Tools"));
   });
 
-  it("omits plugin section when no prompts", () => {
+  it("always includes the Plugin Instructions section for the always-active spawnBackgroundChat tool", () => {
+    // spawnBackgroundChat is generic host infra flagged `alwaysActive`,
+    // so EVERY role — even one with no `availablePlugins` — gets its
+    // section (an MCP tool must be described in the prompt; unlike a
+    // Claude Code built-in, the model doesn't know it inherently).
     const role = makeRole();
     const result = buildSystemPrompt({
       role,
@@ -384,7 +388,8 @@ describe("buildSystemPrompt", () => {
       useDocker: false,
       memorySnapshot: EMPTY_ATOMIC_SNAPSHOT,
     });
-    assert.ok(!result.includes("## Plugin Instructions"));
+    assert.ok(result.includes("## Plugin Instructions"));
+    assert.ok(result.includes("mcp__mulmoclaude__spawnBackgroundChat"));
   });
 });
 
@@ -454,12 +459,15 @@ describe("buildPluginPromptSections", () => {
     // mcp__<server>__<tool> shape for ToolSearch lookups.
     // Section headers print the fully-qualified id so the LLM uses
     // the exact tool name on tool_use.
+    // The list also always carries the always-active spawnBackgroundChat
+    // section, so assert on the openCanvas entry specifically rather than
+    // on a fixed length.
     const role = makeRole({ availablePlugins: ["openCanvas"] });
     const sections = buildPluginPromptSections(role);
-    assert.equal(sections.length, 2, "MCP-prefix hint + one plugin section");
     assert.ok(sections[0].includes("mcp__mulmoclaude__"), "first entry is the prefix hint");
-    assert.ok(sections[1].startsWith("- **mcp__mulmoclaude__openCanvas**: "));
-    assert.ok(!sections[1].includes("\n"));
+    const openCanvas = sections.find((section) => section.startsWith("- **mcp__mulmoclaude__openCanvas**: "));
+    assert.ok(openCanvas, "openCanvas renders as a compact bullet");
+    assert.ok(!openCanvas.includes("\n"));
   });
 
   it("returns heading form for a multi-paragraph plugin prompt", () => {
@@ -468,18 +476,24 @@ describe("buildPluginPromptSections", () => {
     // survives.
     const role = makeRole({ availablePlugins: ["presentDocument"] });
     const sections = buildPluginPromptSections(role);
-    assert.equal(sections.length, 2, "MCP-prefix hint + one plugin section");
     assert.ok(sections[0].includes("mcp__mulmoclaude__"), "first entry is the prefix hint");
-    assert.ok(sections[1].startsWith("### mcp__mulmoclaude__presentDocument\n\n"));
+    const doc = sections.find((section) => section.startsWith("### mcp__mulmoclaude__presentDocument\n\n"));
+    assert.ok(doc, "presentDocument renders in heading form");
     // Body retains its paragraph break
-    assert.ok(sections[1].includes("\n\n"));
+    assert.ok(doc.includes("\n\n"));
   });
 
-  it("returns empty array when the role has no matching plugins (no orphan hint)", () => {
-    // No plugins → no hint either. The prefix hint is meaningless on
-    // its own and clutters the prompt of a tool-less role.
+  it("still surfaces the always-active spawnBackgroundChat section for a role with no plugins", () => {
+    // Previously a plugin-less role got an empty list (no orphan hint).
+    // Now spawnBackgroundChat is always-active, so the hint is
+    // meaningful and the section is present.
     const role = makeRole({ availablePlugins: [] });
-    assert.deepEqual(buildPluginPromptSections(role), []);
+    const sections = buildPluginPromptSections(role);
+    assert.ok(sections[0].includes("mcp__mulmoclaude__"), "prefix hint present");
+    assert.ok(
+      sections.some((section) => section.includes("mcp__mulmoclaude__spawnBackgroundChat")),
+      "always-active spawnBackgroundChat section present even with no role plugins",
+    );
   });
 });
 

--- a/test/agent/test_spawnBackgroundChat.ts
+++ b/test/agent/test_spawnBackgroundChat.ts
@@ -1,0 +1,185 @@
+// Unit tests for the `spawnBackgroundChat` MCP tool. Deps (startChat,
+// readSessionOrigin) are injected so we exercise the origin mapping,
+// the no-nesting refusal, and the runaway cap WITHOUT launching real
+// `claude` subprocesses.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  makeSpawnBackgroundChatTool,
+  spawnBackgroundChat,
+  type StartChatFn,
+  type ReadSessionOriginFn,
+} from "../../server/agent/mcp-tools/spawnBackgroundChat.ts";
+import { mcpTools } from "../../server/agent/mcp-tools/index.ts";
+import { reserveBackgroundSession, releaseBackgroundSession, MAX_BACKGROUND_SESSIONS } from "../../server/agent/backgroundSessions.ts";
+import { SESSION_ORIGINS } from "../../src/types/session.ts";
+
+type StartChatCall = Parameters<StartChatFn>[0];
+
+function makeMockStartChat(result: Awaited<ReturnType<StartChatFn>> = { kind: "started", chatSessionId: "ignored" }): {
+  startChat: StartChatFn;
+  calls: StartChatCall[];
+} {
+  const calls: StartChatCall[] = [];
+  const startChat: StartChatFn = async (params) => {
+    calls.push(params);
+    return result;
+  };
+  return { startChat, calls };
+}
+
+const originNone: ReadSessionOriginFn = async () => undefined;
+
+// Parse the `{ chatId }` JSON a successful spawn returns, and release
+// the runaway-guard slot it reserved so tests don't leak into each
+// other's in-flight count.
+function chatIdFrom(result: string): string {
+  const parsed = JSON.parse(result) as { chatId?: string };
+  assert.ok(parsed.chatId, `expected a chatId in result: ${result}`);
+  return parsed.chatId;
+}
+
+describe("spawnBackgroundChat — input validation", () => {
+  it("rejects a missing / empty message", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    assert.match(await tool.handler({ role: "tutor", hidden: true }), /message.*required/i);
+    assert.match(await tool.handler({ message: "   ", role: "tutor", hidden: true }), /message.*required/i);
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects a missing / empty role", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    assert.match(await tool.handler({ message: "do x", hidden: true }), /role.*required/i);
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects a non-boolean hidden", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    assert.match(await tool.handler({ message: "do x", role: "tutor" }), /hidden.*required/i);
+    assert.match(await tool.handler({ message: "do x", role: "tutor", hidden: "yes" }), /hidden.*required/i);
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("spawnBackgroundChat — origin mapping", () => {
+  it("hidden:true → origin `system`, and returns the chatId", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    const result = await tool.handler({ message: "author lesson 2", role: "tutor", hidden: true });
+    const chatId = chatIdFrom(result);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].origin, SESSION_ORIGINS.system);
+    assert.equal(calls[0].roleId, "tutor");
+    assert.equal(calls[0].chatSessionId, chatId);
+    assert.equal(calls[0].message, "author lesson 2");
+    releaseBackgroundSession(chatId);
+  });
+
+  it("hidden:false → origin `skill` (visible)", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    const result = await tool.handler({ message: "open a chat", role: "general", hidden: false });
+    chatIdFrom(result);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].origin, SESSION_ORIGINS.skill);
+  });
+
+  it("trims message and role before passing them to startChat", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    const result = await tool.handler({ message: "  go  ", role: "  tutor  ", hidden: true });
+    releaseBackgroundSession(chatIdFrom(result));
+    assert.equal(calls[0].message, "go");
+    assert.equal(calls[0].roleId, "tutor");
+  });
+});
+
+describe("spawnBackgroundChat — no nesting", () => {
+  it("refuses when the calling session is itself a hidden worker (origin `system`)", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: async () => SESSION_ORIGINS.system });
+    const result = await tool.handler({ message: "spawn more", role: "tutor", hidden: true }, { sessionId: "worker-1" });
+    assert.match(result, /cannot spawn further background sessions/i);
+    assert.equal(calls.length, 0);
+  });
+
+  it("allows spawning when the calling session is a normal conversation", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: async () => SESSION_ORIGINS.human });
+    const result = await tool.handler({ message: "go", role: "tutor", hidden: true }, { sessionId: "human-1" });
+    releaseBackgroundSession(chatIdFrom(result));
+    assert.equal(calls.length, 1);
+  });
+});
+
+describe("spawnBackgroundChat — runaway guard", () => {
+  it("refuses a hidden spawn once the concurrency cap is reached", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    const fillIds = Array.from({ length: MAX_BACKGROUND_SESSIONS }, (_unused, i) => `cap-fill-${i}`);
+    fillIds.forEach(reserveBackgroundSession);
+    try {
+      const result = await tool.handler({ message: "go", role: "tutor", hidden: true });
+      assert.match(result, /too many background sessions/i);
+      assert.equal(calls.length, 0, "must not call startChat when over the cap");
+    } finally {
+      fillIds.forEach(releaseBackgroundSession);
+    }
+  });
+
+  it("does NOT apply the cap to visible (hidden:false) spawns", async () => {
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    const fillIds = Array.from({ length: MAX_BACKGROUND_SESSIONS }, (_unused, i) => `cap-fill2-${i}`);
+    fillIds.forEach(reserveBackgroundSession);
+    try {
+      const result = await tool.handler({ message: "go", role: "general", hidden: false });
+      chatIdFrom(result);
+      assert.equal(calls.length, 1, "visible spawns are not capped");
+    } finally {
+      fillIds.forEach(releaseBackgroundSession);
+    }
+  });
+});
+
+describe("spawnBackgroundChat — startChat failure", () => {
+  it("surfaces a startChat error and does not reserve a slot", async () => {
+    const { startChat, calls } = makeMockStartChat({ kind: "error", error: "boom" });
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    // Fill to one below the cap so a leaked reservation would tip it over.
+    const fillIds = Array.from({ length: MAX_BACKGROUND_SESSIONS - 1 }, (_unused, i) => `fail-fill-${i}`);
+    fillIds.forEach(reserveBackgroundSession);
+    try {
+      const result = await tool.handler({ message: "go", role: "tutor", hidden: true });
+      assert.match(result, /failed to start chat: boom/i);
+      assert.equal(calls.length, 1);
+      // A failed launch must leave room — the next hidden spawn still succeeds.
+      const { startChat: ok, calls: okCalls } = makeMockStartChat();
+      const okTool = makeSpawnBackgroundChatTool({ startChat: ok, readSessionOrigin: originNone });
+      const okResult = await okTool.handler({ message: "go2", role: "tutor", hidden: true });
+      assert.equal(okCalls.length, 1, "a failed launch must not have consumed the last slot");
+      releaseBackgroundSession(chatIdFrom(okResult));
+    } finally {
+      fillIds.forEach(releaseBackgroundSession);
+    }
+  });
+});
+
+describe("spawnBackgroundChat — registry integration", () => {
+  it("is registered in the production mcpTools array", () => {
+    assert.ok(mcpTools.includes(spawnBackgroundChat), "spawnBackgroundChat must be in the mcpTools registry");
+  });
+
+  it("is flagged alwaysActive so every role gets it", () => {
+    assert.equal(spawnBackgroundChat.alwaysActive, true);
+  });
+
+  it("declares message, role, and hidden as required", () => {
+    const schema = spawnBackgroundChat.definition.inputSchema as { required: readonly string[] };
+    assert.deepEqual([...schema.required].sort(), ["hidden", "message", "role"]);
+  });
+});

--- a/test/agent/test_spawnBackgroundChat.ts
+++ b/test/agent/test_spawnBackgroundChat.ts
@@ -69,14 +69,18 @@ describe("spawnBackgroundChat — origin mapping", () => {
   it("hidden:true → origin `system`, and returns the chatId", async () => {
     const { startChat, calls } = makeMockStartChat();
     const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
-    const result = await tool.handler({ message: "author lesson 2", role: "tutor", hidden: true });
-    const chatId = chatIdFrom(result);
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0].origin, SESSION_ORIGINS.system);
-    assert.equal(calls[0].roleId, "tutor");
-    assert.equal(calls[0].chatSessionId, chatId);
-    assert.equal(calls[0].message, "author lesson 2");
-    releaseBackgroundSession(chatId);
+    let chatId: string | undefined;
+    try {
+      const result = await tool.handler({ message: "author lesson 2", role: "tutor", hidden: true });
+      chatId = chatIdFrom(result);
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].origin, SESSION_ORIGINS.system);
+      assert.equal(calls[0].roleId, "tutor");
+      assert.equal(calls[0].chatSessionId, chatId);
+      assert.equal(calls[0].message, "author lesson 2");
+    } finally {
+      if (chatId) releaseBackgroundSession(chatId);
+    }
   });
 
   it("hidden:false → origin `skill` (visible)", async () => {
@@ -91,10 +95,15 @@ describe("spawnBackgroundChat — origin mapping", () => {
   it("trims message and role before passing them to startChat", async () => {
     const { startChat, calls } = makeMockStartChat();
     const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
-    const result = await tool.handler({ message: "  go  ", role: "  tutor  ", hidden: true });
-    releaseBackgroundSession(chatIdFrom(result));
-    assert.equal(calls[0].message, "go");
-    assert.equal(calls[0].roleId, "tutor");
+    let chatId: string | undefined;
+    try {
+      const result = await tool.handler({ message: "  go  ", role: "  tutor  ", hidden: true });
+      chatId = chatIdFrom(result);
+      assert.equal(calls[0].message, "go");
+      assert.equal(calls[0].roleId, "tutor");
+    } finally {
+      if (chatId) releaseBackgroundSession(chatId);
+    }
   });
 });
 
@@ -110,9 +119,14 @@ describe("spawnBackgroundChat — no nesting", () => {
   it("allows spawning when the calling session is a normal conversation", async () => {
     const { startChat, calls } = makeMockStartChat();
     const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: async () => SESSION_ORIGINS.human });
-    const result = await tool.handler({ message: "go", role: "tutor", hidden: true }, { sessionId: "human-1" });
-    releaseBackgroundSession(chatIdFrom(result));
-    assert.equal(calls.length, 1);
+    let chatId: string | undefined;
+    try {
+      const result = await tool.handler({ message: "go", role: "tutor", hidden: true }, { sessionId: "human-1" });
+      chatId = chatIdFrom(result);
+      assert.equal(calls.length, 1);
+    } finally {
+      if (chatId) releaseBackgroundSession(chatId);
+    }
   });
 });
 
@@ -128,6 +142,34 @@ describe("spawnBackgroundChat — runaway guard", () => {
       assert.equal(calls.length, 0, "must not call startChat when over the cap");
     } finally {
       fillIds.forEach(releaseBackgroundSession);
+    }
+  });
+
+  it("reserves atomically before launch — concurrent calls cannot exceed the cap", async () => {
+    // Leave exactly one free slot, then fire two hidden spawns concurrently.
+    // With `ctx` omitted there is no `await` before the reserve, so the first
+    // handler() synchronously claims the last slot before yielding at
+    // `await startChat`; the second must be refused. A check-then-reserve split
+    // around the await (the previous bug) would let BOTH launch.
+    const { startChat, calls } = makeMockStartChat();
+    const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
+    const fillIds = Array.from({ length: MAX_BACKGROUND_SESSIONS - 1 }, (_unused, i) => `race-fill-${i}`);
+    fillIds.forEach(reserveBackgroundSession);
+    const launched: string[] = [];
+    try {
+      const results = await Promise.all([
+        tool.handler({ message: "a", role: "tutor", hidden: true }),
+        tool.handler({ message: "b", role: "tutor", hidden: true }),
+      ]);
+      const isRefusal = (res: string): boolean => /too many background sessions/i.test(res);
+      const refused = results.filter(isRefusal);
+      assert.equal(refused.length, 1, "exactly one call must be refused");
+      assert.equal(results.length - refused.length, 1, "exactly one call must launch");
+      assert.equal(calls.length, 1, "startChat called only for the one that reserved a slot");
+      results.filter((res) => !isRefusal(res)).forEach((res) => launched.push(chatIdFrom(res)));
+    } finally {
+      fillIds.forEach(releaseBackgroundSession);
+      launched.forEach(releaseBackgroundSession);
     }
   });
 
@@ -147,7 +189,7 @@ describe("spawnBackgroundChat — runaway guard", () => {
 });
 
 describe("spawnBackgroundChat — startChat failure", () => {
-  it("surfaces a startChat error and does not reserve a slot", async () => {
+  it("surfaces a startChat error and rolls back the reserved slot", async () => {
     const { startChat, calls } = makeMockStartChat({ kind: "error", error: "boom" });
     const tool = makeSpawnBackgroundChatTool({ startChat, readSessionOrigin: originNone });
     // Fill to one below the cap so a leaked reservation would tip it over.


### PR DESCRIPTION
## Summary

Adds **`spawnBackgroundChat({ message, role, hidden })`** — an always-active MCP tool that launches a *second, independent* agent session (its own `claude` subprocess) running **concurrently** with the current conversation, via the existing fire-and-forget `startChat`. Unlike Claude Code's blocking `Task` subagent, this gives true parallelism: the worker runs while the user keeps chatting.

Motivating use case: a lessons-collection course made the learner wait minutes after pressing **Learn** on lesson 1 — `presentHtml` only renders *after* the whole HTML page is generated, and there was no way to author ahead of time. Now the recipe pre-authors lesson 1 at course creation and prefetches lesson N+1 the moment lesson N is shown, so authoring overlaps the time the learner spends reading — the wait disappears.

## How `hidden` works

- **`hidden: true`** → new `SESSION_ORIGINS.system` origin, **excluded from every history listing** (no sidebar entry under any filter). For invisible plumbing like artifact pre-generation.
- **`hidden: false`** → `SESSION_ORIGINS.skill`, a normal visible chat reachable under the **Skill** filter.

Hidden worker sessions: skip the post-turn indexer / journal / wiki-backlinks; **auto-delete on success**, retained on error for inspection; capped and non-nesting via a small runaway guard (`backgroundSessions.ts`).

"Always-active" (like a built-in): `McpTool.alwaysActive` makes `getActiveToolDescriptors` bypass the per-role `availablePlugins` gate, so every role gets the tool.

## Changes

**Host (generic infra):**
- `src/types/session.ts` — `SESSION_ORIGINS.system` (deliberately *not* a history filter)
- `server/api/routes/sessions.ts` — exclude `system` origin in `loadSessionRow` (single choke point for both list paths)
- `server/agent/mcp-tools/spawnBackgroundChat.ts` (new) + `server/agent/backgroundSessions.ts` (new runaway guard)
- `server/agent/mcp-tools/index.ts` — `McpTool.alwaysActive` flag + registration
- `server/agent/activeTools.ts` — honour `alwaysActive`
- `server/api/routes/agent.ts` — hidden-session finalize (skip side effects, release slot, delete-on-success), extracted to keep `runAgentInBackground` under the cognitive-complexity threshold
- `src/config/toolNames.ts` — `spawnBackgroundChat`

Note on the import cycle (`spawnBackgroundChat → agent.ts → activeTools → mcp-tools/index`): `agent.ts` is imported type-only and `startChat` is loaded via dynamic import at call time, so module-eval order is safe.

**Recipe + docs:**
- `server/workspace/helps/lessons-collection.md` — new "Pre-generating lessons in the background" section; templates + SKILL.md updated to pre-author lesson 1 and prefetch N+1 *the moment* the current lesson is presented (not at the end)
- `plans/feat-spawn-background-chat.md` — design doc

## Testing

- `test/agent/test_spawnBackgroundChat.ts` (new) — origin mapping, no-nesting refusal, concurrency cap, startChat-error slot release, registry wiring, schema
- `test/agent/test_activeTools.ts` — an `alwaysActive` tool surfaces for a role with empty `availablePlugins`
- `test/agent/test_agent_prompt.ts` — updated for the now-universal plugin section
- Full suite green (5011+ tests, 0 failures); `format` / `lint` / `typecheck` / `build` clean
- Verified end-to-end on a running instance: course creation spawns a hidden lesson-1 worker that authors the page; lesson 1 opens instantly by path; lesson 2 prefetch fires during lesson 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a generic spawnBackgroundChat MCP tool for launching parallel background chat sessions and wire it into the host with dedicated lifecycle handling and visibility controls.

New Features:
- Add always-active spawnBackgroundChat MCP tool to start detached chat sessions in parallel with the current conversation, with support for hidden and visible worker modes.
- Introduce a system session origin for hidden worker chats that are excluded from all history listings and treated as internal plumbing.
- Add a background session runaway guard with a small concurrency cap and non-nesting enforcement for hidden worker sessions.

Enhancements:
- Extend MCP tool infrastructure to support alwaysActive tools that bypass per-role plugin gating so essential host primitives are available to all roles.
- Factor agent run finalization into a dedicated finalizeRun helper that applies specialized teardown for hidden worker sessions and reuses shared post-turn side effects for user-facing chats.

Documentation:
- Document background pre-generation of lessons using spawnBackgroundChat in the lessons-collection help, including when and how to pre-author and prefetch lessons to eliminate learner wait time.
- Add a design plan detailing the motivation, design, and testing strategy for the spawnBackgroundChat detached-session primitive.

Tests:
- Add unit tests for spawnBackgroundChat covering origin mapping, non-nesting behavior, concurrency limits, error handling, and registry wiring.
- Extend active tools and agent prompt tests to ensure alwaysActive tools like spawnBackgroundChat are surfaced for all roles and always documented in plugin instruction sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add host tool to spawn hidden background chat sessions (fire-and-forget) and mark it always-active.
  * Lessons collection updated to pre-generate and prefetch lesson HTML via background workers.

* **Bug Fixes**
  * Hidden/system-origin sessions are excluded from session listings.
  * Enforce max 4 concurrent background sessions and prevent nested hidden spawns.
  * Successful system runs auto-delete artifacts; errored runs retain files for inspection.

* **Tests / Docs**
  * Unit tests and docs updated for background spawn behavior and lesson pre-generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->