### PR TITLE
docs(plans): collections architecture review follow-ups

### DIFF
--- a/plans/fable_collection_feedback.md
+++ b/plans/fable_collection_feedback.md
@@ -1,0 +1,126 @@
+Here's the review — the verdict up front: the doc is 
+  honest about the architecture's shape and the implementation backs most of it up, 
+  often more rigorously than the doc claims. But it overclaims in three places (live 
+  recomputation, "the host computes," and validation-as-guarantee), undersells in 
+  others, and as a document it has a positioning problem in the comparison table.
+
+  What the implementation genuinely delivers                               
+
+  - Files as source of truth, no DB — literally true. Every read is a fresh filesystem
+  operation; the only cache is the schema JSON inside the time-trigger watcher
+  (server/workspace/collections/watcher.ts:56), never record data. Writes go through
+  writeFileAtomic or O_EXCL create.
+  - Path safety — stronger than the doc bothers to claim: slug whitelist +
+  path.basename round-trip, realpathSync containment with symlink defense, and a
+  pre/post-mkdir double containment check against TOCTOU races
+  (server/workspace/collections/io.ts:144-158).
+  - Schema validity — a real Zod schema-of-schemas with ~18 cross-field refinements
+  (discovery.ts:313-549), including subtle ones like "spawn successors must not be born
+  already matching their own predicate."
+  - Zero domain-specific host code — verified by grep. Domain words (invoice,
+  portfolio, ticker…) appear only in comments and in user-copyable help recipes under
+  server/workspace/helps/. No seeded collection ships with the host.
+  - Refs and embeds — both match the documented JSON shapes exactly, with
+  auto-generated pickers, <router-link> navigation, and the embed card including a
+  graceful missing-record state.
+  - Actions — the four-step flow (load record → validate visibility → assemble prompt →
+  Claude executes) exists as described, and crucially the when predicate is
+  re-enforced server-side (409 on mismatch, server/api/routes/collections.ts:323), so
+  visibility is an authorization rule, not just UI hiding.
+
+  Where the doc overclaims
+
+  1. "A portfolio can automatically revalue itself when a quote changes elsewhere" —
+  this is the biggest gap. Derived fields are evaluated on-read, in the browser
+  (src/utils/collections/derivedFormula.ts, called from
+  useCollectionRendering.ts:293-310). There are no watchers, no push, no server-side
+  evaluation at all. "Automatically" is true only in the weak sense that values are
+  never stale at render time. Worse, because derived values are computed client-side
+  and never persisted:
+
+  - Claude never sees them. The action seed prompt embeds the raw stored record
+  (readItem → buildActionSeedPrompt), so when Claude executes "Record Payment" on an
+  invoice, the prompt contains line items and tax rate but not the computed
+  subtotal/tax/total. For a doc whose thesis is "Claude is the runtime," the runtime
+  being blind to the computation layer is a real architectural seam, not a nitpick.
+  - Server-side features (notification predicates, time triggers, spawn) can't
+  reference derived fields either.
+
+  The doc's own Design Boundaries section lists "deterministic computation" as a host
+  guarantee — defensible only if "host" means "host platform including the client
+  bundle." A reader will assume server.
+
+  2. "A derived field behaves similarly to a spreadsheet formula" — the language is far
+  narrower than that sentence implies. The actual grammar: numbers, + - * /, parens,
+  exactly one function (sum() over table columns), and single-level ref deref. No
+  strings, no comparisons, no conditionals, no date math, no chaining
+  (ticker.sector.growth is impossible). Even the doc's own example subtotal =
+  sum(lineItems) doesn't parse — the real syntax is sum(lineItems[].amount). The
+  narrowness is arguably correct per the doc's own "extend the declarative layer only
+  when it outperforms the agent" principle, but the doc should state the boundary
+  instead of gesturing at Excel. Cycles, by the way, are handled by bounded saturation
+  (max passes = field count) and silently resolve to null — fine, but undocumented.
+
+  3. "It validates what Claude creates" — validation is advisory, not a gate. Record
+  validation (validate.ts) runs post-hoc, reports max 25 issues for the LLM to repair,
+  and bad records are silently skipped at read time. Nothing prevents writing a record
+  that violates the schema. Likewise an invalid schema.json is logged at warn and the
+  collection just silently doesn't load — for a system whose pitch is non-programmers
+  authoring schemas, "your app vanished, check the server log" is the wrong failure
+  mode. The repair-loop design is reasonable; calling it a host guarantee is not.
+
+  4. "Prompt isolation" deserves a footnote about what it actually is. The
+  implementation is real and thoughtful — recursive sanitization of keys and values,
+  iterative tag-stripping, a SECURITY BOUNDARY framing block (io.ts:245-287). Two
+  honest caveats: the boundary is ultimately an instruction to the model, not a
+  mechanism; and the sanitization is lossy — a markdown field containing legitimate
+  backticks or angle brackets reaches Claude mutated, which can silently corrupt the
+  very data Claude is supposed to act on (a code snippet in a record, a <10ms
+  requirement, etc.).
+
+  5. "Who designs the environment? Users." Two quibbles. First, the comparison table is
+  rhetorically vulnerable: Airtable's entire market position is non-engineers building
+  bases, so "Airtable → Engineers" will read as a strawman to anyone who's used it;
+  the actual differentiator (the agent is the runtime, business logic stays in prose)
+  is stronger than the one the table claims. Second, in practice there is no schema
+  editor UI — schemas are hand-written JSON or (realistically) authored by Claude in
+  chat. "Users design the harness, with Claude as the authoring interface" is the true
+  story and arguably a better one, but it's not what the doc says. Also, actions bind
+  to a role that must exist in host config (src/config/roles.ts) — roles are
+  engineer-defined, so the environment isn't 100% user-authored.
+
+  Where the doc undersells the implementation
+
+  The doc covers maybe 60% of what's built. Missing entirely: the four schema-driven
+  view modes (table, kanban via kanbanField, calendar via calendarField, dashboard);
+  time triggers, lead days, and recurrence/spawn with carry-forward fields;
+  notification predicates wired to the bell; the toggle-as-enum-projection field type;
+  money with per-record currencyField; feeds/ingest; and the whole
+  validation-and-repair loop, which is one of the more distinctive "Claude is the
+  runtime" mechanics in the system. The "Workflow = Actions" row in the concerns table
+  is the doc's weakest claim about itself — the workflow layer is much richer than
+  buttons.
+
+  One factual drift: the doc shows schema.json + records/*.json as the layout, but the
+  real layout couples collections to the skills system — data/skills/<slug>/schema.json
+  (mirrored to .claude/skills/) with records at a schema-declared dataPath. That
+  coupling (a collection is a skill, templates live in the skill dir, SKILL.md provides
+  agent context) is a core design decision the doc never mentions.
+
+  As a document
+
+  The one-sentence-per-line manifesto cadence works for the first third and gets
+  repetitive after ("This boundary is intentional" / "This constraint is deliberate" /
+  "This is intentional" appear in near-identical form three times). The ideas are
+  strong enough that the doc would land better with one rhetorical section up front and
+  concrete material after — the actual formula grammar, the actual action JSON, the
+  actual failure modes. Right now every code sample in it is illustrative
+  pseudo-syntax, and as shown above one of them doesn't parse against the real engine.
+
+  Suggested fixes, in priority order: (1) reword the portfolio claim to "values are
+  recomputed at render time" and decide whether derived values should be included in
+  action prompts — that's the one finding I'd act on rather than just document; (2) add
+  a "Formula language" section with the real grammar; (3) soften "validates" to
+  describe the validate-and-repair loop; (4) replace the Airtable table row with the
+  runtime-vs-tool framing; (5) either add the workflow/views/feeds material or mark the
+  doc as covering the core model only.

--- a/plans/feat-collections-agent-ingest.md
+++ b/plans/feat-collections-agent-ingest.md
@@ -1,0 +1,289 @@
+# feat: `ingest.kind: "agent"` — scheduled agent refresh for collections
+
+## Motivation
+
+A stock-quotes collection should be able to update its records daily without the
+user doing anything: a hidden chat fetches the quotes and edits the record files.
+Today that's expressible only as a `manageAutomations` task whose free-form prompt
+happens to mention the collection — the schedule lives in
+`config/scheduler/tasks.json`, detached from the schema. It doesn't travel when
+the skill directory is copied, it drifts when the schema changes, and it
+contradicts the Collections thesis (`docs/collections-architecture.md`): *the
+schema is the application definition*.
+
+The host already has both halves of the mechanism; they just don't meet:
+
+- **Feeds own the scheduling half.** The ingest engine
+  (`server/workspace/feeds/engine.ts`) has cadence (`hourly`/`daily`/`weekly`/
+  `on-demand`), per-collection state (`lastFetchedAt`, `consecutiveFailures`),
+  an hourly due-loop (`system:feed-refresh`, `server/index.ts:1077`), a manual
+  refresh route (`server/api/routes/collections.ts:278` — already commented
+  "generic over kind"), and a first-open auto-refresh. The `ingest` block is
+  already accepted by `CollectionSchemaZ` on every source — it's just never
+  executed for non-feeds. And `ingestTypes.ts:7-9` explicitly reserves an
+  LLM-performed retriever kind "without reshaping the engine".
+- **`spawnBackgroundChat` owns the hidden-execution half**
+  (`plans/feat-spawn-background-chat.md`): `origin: system` sessions are
+  invisible, capped at 4 via an atomic reserve
+  (`server/agent/backgroundSessions.ts`), auto-deleted on success, retained on
+  error.
+
+The declarative retrievers (`rss`/`atom`/`http-json`) can't do stock quotes
+anyway — no auth headers, static URL, no judgment about which symbols to fetch.
+That's exactly the "business logic becomes language" case: the *what/how* belongs
+in a prose template, the *when* in the schema.
+
+This plan joins the halves at the seam the engine left open:
+
+```json
+"ingest": {
+  "kind": "agent",
+  "schedule": "daily",
+  "role": "general",
+  "template": "templates/refresh.md"
+}
+```
+
+on an ordinary (skill-backed) collection. When due, the host assembles the same
+seed a collection-level action gets (template + all-records summary) and
+dispatches it as a hidden background chat in the declared role. The host stays
+domain-free; everything stock-specific lives in the collection's template.
+
+## Design
+
+### Schema shape
+
+`ingest` becomes a discriminated union on `kind`:
+
+- **Declarative** (`rss` | `atom` | `http-json`) — unchanged: `url`, `map`,
+  `schedule`, `itemsAt?`, `idFrom?`, `maxItems?`.
+- **Agent** (`agent`) — `schedule` (same `FEED_SCHEDULES` vocabulary), `role`
+  (non-empty string), `template` (skill-relative path validated by
+  `isSafeActionTemplatePath`, like action templates). No `url`/`map`/`maxItems`
+  — the agent owns retrieval and record shape; record writes are still
+  schema-validated by the existing validate-and-repair loop.
+
+`kind: "agent"` is meaningful on any source. The template resolves against
+`collection.skillDir` (`discovery.ts:644` sets it for feeds too —
+`feeds/<slug>/templates/…` works), but the primary consumer is skill-backed
+collections; feeds keep their declarative kinds.
+
+### Dispatch flow (`refreshOne`, agent branch)
+
+1. Build the seed with the **same assembly as collection-level actions**
+   (`buildCollectionActionSeed`, `server/api/routes/collections.ts:349`):
+   template text + compact summary of every record, with the existing
+   `sanitizeDeep` / SECURITY-BOUNDARY framing. Extract that helper from the
+   route file into the collections workspace layer so both the route and the
+   engine call it (it's pure assembly; the route keeps only HTTP concerns).
+2. Reserve a background slot (`tryReserveBackgroundSession`) and `startChat`
+   with `origin: SESSION_ORIGINS.system` — identical semantics to
+   `spawnBackgroundChat({hidden: true})`. Roll back the reservation if
+   `startChat` throws.
+3. **`lastFetchedAt` records dispatch time, not completion.** This is what
+   gates the due-loop, so a slow worker can't cause double-dispatch.
+4. **Cap miss ⇒ retry next tick.** If the reserve fails (4 hidden workers in
+   flight), do *not* touch `lastFetchedAt`; the hourly tick redials. Return it
+   in `errors` so a manual refresh surfaces "busy" honestly.
+
+### Completion feedback (don't let it die silently)
+
+Fire-and-forget is fine for lesson prefetch; a daily refresher that fails for a
+week unnoticed is the worst failure mode. `finalizeRun`
+(`server/api/routes/agent.ts:971`) already branches on `origin === system` to
+release the slot — add a generic completion-hook registry there:
+`backgroundSessions.ts` gains `registerCompletionHook(chatId, cb)` /
+`takeCompletionHook(chatId)`, and `finalizeRun` invokes the hook with
+`{ didError }`. This is generic host infra (any spawner of hidden workers can
+use it), not ingest-specific.
+
+The ingest dispatcher registers a hook per run:
+
+- **success** → reset `consecutiveFailures`, clear any failure bell entry.
+- **error** → increment `consecutiveFailures`, publish a bell entry
+  ("Collection refresh failed: `<slug>`", navigate-to-collection action,
+  stable id `collection-ingest:<slug>` for dedup/clear — same pattern as
+  `server/workspace/collections/notifications.ts`). The errored session's
+  files are already retained for inspection.
+
+### State location
+
+Feed state lives at `feeds/<slug>/_state.json`. Skill collections must NOT
+write there (a `feeds/<slug>/` dir without `schema.json` confuses feed
+discovery, and `_state.json` must never live in `dataDir`, where `listItems`
+would read it as a record). Generalize the state path: feeds keep their
+current location; non-feed collections store at `data/ingest-state/<slug>.json`
+(new `WORKSPACE_DIRS` entry, per the constants rule).
+
+### Scheduling
+
+`refreshDue` (`engine.ts:126`) currently iterates `listFeeds()`. Widen it to
+every discovered collection whose schema carries `ingest` (feeds and
+skill-backed alike); `isFeedDue` is already source-agnostic. The hourly system
+task keeps its id (`system:feed-refresh` — renaming would orphan its
+scheduler-state row); update its comment. Cadence stays elapsed-based
+(`daily` = "≥24 h since last dispatch, checked hourly"); time-of-day anchoring
+("daily at 09:00") is out of scope.
+
+### What this does NOT add
+
+No new top-level mechanism, no new storage format, no `manageAutomations`
+coupling, no per-record fan-out (one run = one collection-scoped worker that
+edits whatever records it judges necessary). Host purity holds: "scheduled
+agent refresh" is generic; the stock-quotes logic is prose in the template.
+
+## Per-file edits
+
+### Phase 1 — schema + types
+
+- **`server/workspace/feeds/ingestTypes.ts`** — split `IngestSpec` into
+  `DeclarativeIngestSpec` (current shape, kinds `rss`/`atom`/`http-json`) and
+  `AgentIngestSpec` (`kind: "agent"`, `schedule`, `role`, `template`);
+  `IngestSpec` becomes the union. Update the header comment (the reserved
+  "prompt" kind ships as `agent`).
+- **`server/workspace/collections/discovery.ts`** — replace `IngestSchemaZ`
+  (`:300`) with `z.discriminatedUnion("kind", [DeclarativeIngestZ,
+  AgentIngestZ])`; `AgentIngestZ` validates `role` non-empty and `template`
+  via `isSafeActionTemplatePath` (same rule as `ActionSpecSchema`).
+- **`test/workspace/collections/test_discovery.ts`** — accept/reject cases:
+  agent ingest with valid shape; missing role; unsafe template path
+  (`../x`, absolute); declarative kinds unaffected.
+
+### Phase 2 — seed assembly extraction
+
+- **`server/workspace/collections/io.ts`** (or a sibling `seeds.ts` if io.ts
+  grows past taste) — move `buildCollectionActionSeed`'s assembly
+  (template read + records summary + `buildActionSeedPrompt` framing) out of
+  `server/api/routes/collections.ts:349` into an exported
+  `buildCollectionSeed(collection, { role, template })`. Route delegates to it;
+  behavior unchanged.
+- **`server/api/routes/collections.ts`** — collection-action route calls the
+  extracted helper.
+
+### Phase 3 — engine dispatch + DI
+
+- **`server/workspace/feeds/state.ts`** — state path branches on collection
+  source: feeds → `feeds/<slug>/_state.json` (unchanged); otherwise →
+  `data/ingest-state/<slug>.json`. Read/write signatures gain the source (or
+  take the `LoadedCollection`).
+- **`server/workspace/paths.ts`** — add `ingestState: "data/ingest-state"` to
+  `WORKSPACE_DIRS`.
+- **`server/workspace/feeds/agentIngest.ts`** (new) —
+  - `setAgentWorkerRunner(runner)` DI seam; `runner({ message, roleId }) →
+    Promise<{ ok: true; chatId } | { ok: false; error }>` (wired in Phase 4;
+    avoids `workspace/ → api/routes/` imports).
+  - `refreshViaAgent(workspaceRoot, collection)`: build seed via
+    `buildCollectionSeed`, reserve slot, dispatch, set `lastFetchedAt` to now,
+    register the completion hook (Phase 5). Returns a `RefreshResult`
+    (`written: 0`, new `dispatched?: true` flag; cap-miss / template-missing →
+    `errors`, state untouched).
+- **`server/workspace/feeds/engine.ts`** —
+  - `refreshOne` branches: `ingest.kind === "agent"` → `refreshViaAgent`;
+    declarative kinds unchanged.
+  - `refreshDue` iterates all discovered collections with `schema.ingest`
+    instead of `listFeeds()`.
+- **`server/index.ts`** — comment touch-up on `system:feed-refresh` (`:1077`):
+  it now drives all scheduled ingest, not just feeds.
+
+### Phase 4 — hidden-worker spawn extraction (host)
+
+- **`server/api/routes/agent.ts`** — extract the reserve→`startChat`→rollback
+  sequence (currently inside the `spawnBackgroundChat` handler) into an
+  exported `spawnSystemWorker({ message, roleId })` living next to `startChat`.
+- **`server/agent/mcp-tools/spawnBackgroundChat.ts`** — `hidden: true` path
+  delegates to `spawnSystemWorker`; behavior identical.
+- **`server/index.ts`** — `setAgentWorkerRunner(spawnSystemWorker)` at boot,
+  next to the existing `registerUserTasks({ taskManager, startChat })` wiring.
+
+### Phase 5 — completion hooks + failure bell
+
+- **`server/agent/backgroundSessions.ts`** — add
+  `registerCompletionHook(chatSessionId, cb)` / `takeCompletionHook` (Map,
+  one-shot). Hooks are best-effort: a server restart mid-run drops them; the
+  next due-tick re-dispatches anyway.
+- **`server/api/routes/agent.ts`** — in `finalizeRun`'s `origin === system`
+  branch, invoke the hook with `{ didError }` (after slot release, before
+  file deletion).
+- **`server/workspace/feeds/agentIngest.ts`** — the registered hook updates
+  `consecutiveFailures` and publishes/clears the failure bell entry via
+  `server/notifier/engine.ts` (stable id `collection-ingest:<slug>`,
+  navigate-to-collection action, warning severity — mirror the entry shape
+  used by `server/workspace/collections/notifications.ts`).
+- **`test/agent/`** — hook registry: one-shot semantics; invoked with
+  `didError`; unknown chatId is a no-op.
+
+### Phase 6 — UI + i18n
+
+- **`src/components/CollectionView.vue`** — refresh button already renders for
+  any `schema.ingest`. Handle the `dispatched` response: show a transient
+  "refresh started in the background" note instead of a written-count; keep
+  the in-flight hourglass while the POST is pending only (the worker is
+  detached). Button label/tooltip: generic "Refresh", not "Refresh feed".
+- **`src/lang/en.ts` + all 7 other locales** — new key(s) for the dispatched
+  toast and label change, all 8 in lockstep, properly translated.
+- **`src/components/` feeds card grid** — no change (agent ingest on feeds is
+  possible but not promoted; cards already render kind/schedule generically).
+
+### Phase 7 — docs + recipe (independently shippable)
+
+- **`server/workspace/helps/portfolio-tracker.md`** — the existing
+  stock-quotes + portfolio recipe is the canonical consumer; upgrade it
+  rather than inventing a parallel example:
+  - the `stock-quotes` `schema.json` gains
+    `ingest: { kind: "agent", schedule: "daily", role: "investor",
+    template: "templates/refresh-quotes.md" }`;
+  - add `data/skills/stock-quotes/templates/refresh-quotes.md` to the recipe,
+    showing the prose contract: fetch the latest Yahoo Finance quote for
+    every record's ticker (the investor role prompt already documents the
+    endpoints + the 15-minute-delay caveat), `Edit` each record's
+    `price`/`pe`/`yield`, fix any validation issues, stop — no `present*`
+    calls, no one is watching the canvas;
+  - note the knock-on effect the recipe already sets up: the portfolio's
+    derived `price`/`value` revalue from the refreshed quotes with no copying.
+- **`src/config/roles.ts:349`** — update the investor role's portfolio-tracker
+  sample query to sell the new behavior, e.g. "Set up a stock portfolio
+  tracker — a stock-quotes watchlist that refreshes itself daily, plus a
+  portfolio that values my holdings against it. First read
+  `config/helps/portfolio-tracker.md` and follow it exactly to author both
+  collections — do not redesign the schemas or ask me design questions."
+  (`queries` are plain English strings in `roles.ts`, not i18n keys — no
+  locale work.)
+- **`server/workspace/helps/feeds.md` / `collection-skills.md`** — one short
+  section each pointing at `ingest.kind: "agent"` for collections whose
+  refresh needs judgment (auth, per-record requests) instead of a declarative
+  `map`.
+- **`docs/collections-architecture.md`** — the portfolio example
+  (`shares * ticker.price`) can now claim its daily revaluation honestly: add
+  a short "Scheduled ingest" paragraph under the workflow section.
+
+## Testing
+
+- **Unit (`test/workspace/`)**:
+  - Zod: agent-ingest accept/reject matrix (Phase 1).
+  - `agentIngest`: fake runner injected — dispatch updates `lastFetchedAt`;
+    cap-miss leaves state untouched and reports the error; template-missing
+    reports without dispatch; completion hook success/failure paths update
+    `consecutiveFailures` and publish/clear the bell entry (fake notifier).
+  - `state`: non-feed collections read/write `data/ingest-state/<slug>.json`;
+    feeds stay at `feeds/<slug>/_state.json`.
+  - `refreshDue`: a skill collection with agent ingest is picked up when due;
+    `on-demand` never auto-dispatches.
+- **Unit (`test/agent/`)**: `spawnSystemWorker` extraction keeps the
+  spawnBackgroundChat handler tests green (reserve, rollback, cap race).
+- **Manual** (`docs/manual-testing.md` entry): create the stock-quotes recipe
+  collection, click Refresh, confirm a hidden worker updates records and the
+  sidebar shows nothing; kill the network and confirm a failed run lands a
+  bell entry that clears on the next success.
+
+## Out of scope / follow-ups
+
+- Time-of-day anchoring (`"daily at 09:00"`) — `FEED_SCHEDULES` stays
+  elapsed-based; revisit if quote freshness needs market-hours alignment.
+- Per-record scheduled actions (fan-out of one worker per record) — cap
+  pressure and prompt design need their own plan.
+- A `code` ingest kind (LLM-generated deterministic transform, the other
+  reserved slot in `ingestTypes.ts`).
+- Surfacing in-flight hidden workers in the UI (debug view) — carried over
+  from `plans/feat-spawn-background-chat.md`.
+- Raising `MAX_BACKGROUND_SESSIONS` — revisit if several agent-ingest
+  collections plus lesson prefetch contend in practice.

--- a/plans/feat-manage-collection-tool.md
+++ b/plans/feat-manage-collection-tool.md
@@ -1,0 +1,244 @@
+# feat: `manageCollection` — computed-aware reads, validated writes for the LLM
+
+## Motivation
+
+The LLM's data plane for collections is raw `Read`/`Write`/`Edit` on record
+JSON files. That has two structural gaps:
+
+1. **The runtime is blind to the computation layer.** Derived fields are
+   evaluated only in the browser at render time
+   (`src/composables/collections/useCollectionRendering.ts:293` `deriveAll`,
+   over the pure evaluator in `src/utils/collections/derivedFormula.ts`).
+   Stored records never contain them, so the agent reading
+   `data/portfolio/items/*.json` never sees `price`/`value`, and an action
+   worker recording a payment never sees the invoice's computed total. For an
+   architecture whose thesis is "Claude is the runtime"
+   (`docs/collections-architecture.md`), the runtime can't read the one thing
+   the host computes.
+2. **Validation is advisory, not a gate.** `validateCollectionRecords`
+   (`server/workspace/collections/validate.ts`) runs *after* writes — the
+   `presentCollection` dispatch appends issues to the tool result
+   (`server/api/routes/plugins.ts:266-285`) and the model repairs files it
+   already broke. Nothing prevents writing a malformed record; a bad file is
+   silently skipped at read time until the repair loop catches it.
+
+Also a turn-economy cost: reading a 30-record collection with refs is ~30+
+file Reads plus a mental join; storing 20 quote rows is 20 `Write` calls.
+
+This plan adds one MCP tool:
+
+```ts
+manageCollection({ action: "getItems" | "putItems", slug, ... })
+```
+
+- **`getItems`** — fetch records with computed fields resolved (derived
+  evaluated server-side, toggle projected, embed targets attached), with
+  `ids`/`fields` selection for context economy.
+- **`putItems`** — store rows through host validation: each row validated
+  against the schema *before* `writeItem`; per-row accept/reject results the
+  model can act on.
+
+The `action` discriminator follows the house `manage*` pattern
+(`manageAutomations`, `manageSkills`) and leaves room for future actions
+(`deleteItems`, `validate`, `query`) without new tools.
+
+## Design
+
+### The paved road, not an enforcement boundary
+
+Raw file I/O cannot and should not go away — "the workspace is the database"
+means users, scripts, and external tools edit these files too. So
+`manageCollection` is the *recommended* path (validated, atomic,
+computed-aware, one call instead of N), raw `Read`/`Write`/`Edit` stays the
+escape hatch, and the existing post-hoc validation loop remains the backstop
+for off-road writes. Recipes that currently instruct "All I/O via
+Read / Write / Edit" migrate to "use `manageCollection`; raw file I/O is the
+escape hatch" (Phase 5).
+
+### Server-side derivation must share the client's code, not mirror it
+
+If the server reimplements derivation, UI and LLM eventually disagree on a
+number. The evaluator (`derivedFormula.ts`) is already a pure shared util;
+the saturation loop (`deriveAll` + `resolveRowRefs`,
+`useCollectionRendering.ts:283-310`) is also pure but trapped inside the
+composable. Extract both functions verbatim into
+`src/utils/collections/deriveAll.ts`; the composable delegates. The server
+already imports from `src/utils/collections/` (`actionVisible` in
+`server/workspace/collections/notifications.ts`), so no new boundary is
+crossed.
+
+On the server, the missing piece is the `RefRecordCache` the client builds by
+fetching linked collections: a new `server/workspace/collections/derive.ts`
+loads each unique ref/embed target via `loadCollection` + `listItems` once per
+call, then maps the shared `deriveAll` over the requested items.
+
+### `getItems`
+
+```ts
+{ action: "getItems", slug, ids?: string[], fields?: string[] }
+```
+
+- Omitted `ids` ⇒ all records; omitted `fields` ⇒ all fields. The selectors
+  are the token-economy lever — the tool prompt tells the model to use them
+  on large collections rather than dumping everything.
+- Enrichment per record: derived fields evaluated (failures stay `null`,
+  matching the UI's em-dash semantics), `toggle` projected from its enum,
+  `embed` fields resolved to the target record object (or `null` when
+  missing, matching `CollectionEmbedView`'s missing state).
+- Read semantics match the UI: malformed files are skipped by `listItems`.
+  Like the `presentCollection` dispatch, the result appends a
+  `validateCollectionRecords` warning (issue strings passed through
+  `defangForPrompt`, `src/utils/promptSafety.ts`) so skipped records are
+  visible, not vanished.
+
+### `putItems`
+
+```ts
+{ action: "putItems", slug, items: object[], mode?: "upsert" | "create" }
+```
+
+- Per-row validation **before** any write, reusing the existing per-record
+  validator: export `schemaViolation` from `validate.ts` (today
+  module-private at `:99`) as `validateRecordObject(record, id, schema)` —
+  it already checks primaryKey↔id, required fields, enum membership, and
+  skips `COMPUTED_TYPES`.
+- Additional putItems-only rule: reject rows that set computed keys, with an
+  actionable problem string ("'value' is derived — computed by the host,
+  remove it"; toggle → "write enum field 'status' instead").
+- Writes go through `writeItem` (atomic, id-sanitized, containment-checked —
+  no new I/O path). `mode: "create"` maps to `refuseOverwrite: true`;
+  default `upsert`.
+- **Per-row results, not all-or-nothing**: valid rows are written, invalid
+  rows are rejected individually —
+  `{ written: string[], rejected: [{ id, problem }] }` — because the
+  `RecordIssue` problem strings are already written to be LLM-actionable; the
+  model fixes the rejects and retries just those. Problem strings that quote
+  record-controlled values are defanged as above.
+
+### Tool home: pure server MCP tool, available to every role
+
+Not a built-in plugin — there is no Vue surface. The right pattern is
+`server/agent/mcp-tools/` (like `readXPost`/`searchX`/`notify`): a pure
+server-side handler running in the Express process with direct access to the
+collections workspace layer, named in `TOOL_NAMES`. It is **`alwaysActive:
+true`** (the gating mechanism `spawnBackgroundChat` introduced in
+`server/agent/activeTools.ts`): available to every role without being listed
+in any role's `availablePlugins`. Collections are workspace data, like files
+— every role can already reach them via Read/Write/Edit, so gating the
+*safer* path per-role would only push unlisted roles back onto raw file I/O.
+No `src/config/roles.ts` changes.
+
+### What v1 deliberately omits
+
+No filters, sorts, or aggregations — `ids`/`fields` selection only. Computing
+derived values is mechanical (the host's side of the boundary); filtering and
+aggregating are cheap in-context judgment. "Extend the declarative layer only
+when it outperforms the agent" cuts both ways. Future actions extend the
+`action` enum, not the query surface.
+
+## Per-file edits
+
+### Phase 1 — extract the shared derive loop
+
+- **`src/utils/collections/deriveAll.ts`** (new) — move `resolveRowRefs` and
+  `deriveAll` verbatim from `useCollectionRendering.ts:283-310`; the
+  `RefRecordCache` type moves (or is re-exported) with them. Pure module: no
+  Vue imports.
+- **`src/composables/collections/useCollectionRendering.ts`** — delete the
+  local copies, import from the new util. No behavior change.
+- **`docs/shared-utils.md`** — 1-line catalog entry for the new shared util
+  (same PR, per the catalog rule).
+- **`test/utils/collections/test_deriveAll.ts`** (new) — saturation across
+  chained derived fields (`subtotal → tax → total` converges in ≤ field-count
+  passes), cycle saturates to no-change, ref resolution via the cache.
+
+### Phase 2 — server-side enrichment
+
+- **`server/workspace/collections/derive.ts`** (new) —
+  `enrichItems(collection, items, opts)`: collect unique `ref`/`embed`
+  targets from the schema, `loadCollection` + `listItems` each once, build
+  the `RefRecordCache`, map the shared `deriveAll`, project `toggle`, attach
+  resolved `embed` records.
+- **`server/workspace/collections/validate.ts`** — export the per-record
+  validator as `validateRecordObject(record, id, schema)` (extracted from
+  `schemaViolation`, `:99`); `inspectRecord` delegates. No behavior change to
+  the file-scanning path.
+- **`test/workspace/collections/`** — `enrichItems`: derived across a ref
+  (`shares * ticker.price`), dangling ref ⇒ `null`, embed missing ⇒ `null`;
+  `validateRecordObject` parity with the existing scan results.
+
+### Phase 3 — the MCP tool
+
+- **`server/agent/mcp-tools/manageCollection.ts`** (new) —
+  - `definition.inputSchema`: `action` (enum `["getItems", "putItems"]`),
+    `slug` (required), `ids?`/`fields?` (getItems), `items?`/`mode?`
+    (putItems).
+  - `prompt`: when to prefer it over raw file I/O; computed fields are
+    read-only and present in getItems results; putItems validates and
+    returns per-row rejects to fix-and-retry; use `ids`/`fields` on large
+    collections.
+  - `handler`: `loadCollection(slug)` (404-style error result on unknown
+    slug), dispatch on `action`; getItems → `listItems`/`readItem` +
+    `enrichItems` + validation warning; putItems → per-row
+    `validateRecordObject` + computed-key rejection + `writeItem`.
+  - `alwaysActive: true` — exposed to every role regardless of
+    `availablePlugins` (no `roles.ts` edit).
+  - Keep the handler thin; the logic lives in the workspace layer
+    (Phase 2) so the function-size and complexity limits hold.
+- **`server/agent/mcp-tools/index.ts`** — add to the `mcpTools` array.
+- **`src/config/toolNames.ts`** — `manageCollection: "manageCollection"`
+  alongside the other host-fixed mcp-tool names (`:61-66`).
+- **`test/agent/test_manageCollection.ts`** (new) — getItems: enrichment +
+  ids/fields selection + skipped-record warning; putItems: valid rows
+  written, invalid rejected per-row with actionable problems, computed-key
+  rejection, `create` mode refuses overwrite; unknown slug/action error
+  results; tool present for a role with empty `availablePlugins`
+  (`alwaysActive` path).
+
+### Phase 4 — getItems/putItems hardening pass
+
+- Defang every record-controlled string that reaches the tool result
+  (problem strings, warning lines) via `defangForPrompt` — mirror
+  `server/api/routes/plugins.ts:278`.
+- Cap getItems response size defensively (e.g. refuse `ids`-less getItems
+  over N records with a "pass ids or fields" error rather than truncating
+  silently — no silent caps).
+
+### Phase 5 — recipes + docs (independently shippable)
+
+- **`server/workspace/helps/portfolio-tracker.md`**, **`collection-skills.md`**,
+  **`todo-collection.md`**, **`lessons-collection.md`** — migrate the
+  "All I/O via Read / Write / Edit" guidance in SKILL.md templates to
+  "prefer `manageCollection` (validated writes, computed values in reads);
+  raw file I/O is the escape hatch". The portfolio recipe's read examples
+  switch to getItems so `price`/`value` are real values, not "—".
+- **`docs/collections-architecture.md`** — the "host computes the result"
+  claim becomes server-side true; one sentence noting computed values are
+  readable by the runtime via `manageCollection`.
+
+## Testing
+
+Covered per-phase above; plus:
+
+- **Determinism cross-check**: one test feeds the same schema + records to
+  the client path (`evaluateDerivedAgainstItem`) and the server path
+  (`enrichItems`) and asserts identical numbers — the regression that matters
+  most after the extraction.
+- **Manual** (`docs/manual-testing.md`): in an investor chat, ask for
+  portfolio values — confirm the model calls
+  `manageCollection getItems` and reports the derived `value` without
+  reading record files; ask it to add a malformed holding — confirm the
+  reject round-trip fixes and retries instead of writing a broken file.
+
+## Out of scope / follow-ups
+
+- **Action seeds with computed values** — `buildActionSeedPrompt` /
+  `buildCollectionActionSeed` calling `enrichItems` so action workers see
+  derived totals. Cheap once Phase 2 lands; separate PR.
+- **`notifyWhen`/`spawn` predicates over derived fields** — possible once the
+  watcher can call `enrichItems`; own plan.
+- Future actions: `deleteItems`, `validate` (on-demand repair report),
+  `getSchema` (the agent can Read `schema.json`; add only if prompting shows
+  it's needed), `query` (resist until in-context filtering demonstrably fails).
+- Serving the UI from server-side enrichment (single evaluation site) —
+  client-side eval stays for reactivity; revisit only if drift ever appears.


### PR DESCRIPTION
## Summary

Plans-only PR — no source changes. Three documents from a critical review of `docs/collections-architecture.md`:

- **`plans/fable_collection_feedback.md`** — the review itself: claim-by-claim check of the architecture doc against the implementation. Headline findings: derived fields are evaluated client-side only (so the runtime never sees computed values, e.g. in action seed prompts), record validation is advisory rather than write-gated, and the "automatically revalue" portfolio claim is recompute-on-read, not live.
- **`plans/feat-collections-agent-ingest.md`** — `ingest.kind: "agent"`: scheduled hidden-chat refresh for collections (e.g. a stock-quotes watchlist that updates daily). Joins the feeds due-loop (`server/workspace/feeds/engine.ts`) with `spawnBackgroundChat` semantics (#1678), with completion hooks + failure bell so a dead refresher can't fail silently. Includes the `portfolio-tracker.md` recipe upgrade and the investor-role sample-query update.
- **`plans/feat-manage-collection-tool.md`** — `manageCollection` MCP tool (`alwaysActive`, every role): `getItems` returns records with server-evaluated derived/toggle/embed values via a shared `deriveAll` extraction; `putItems` validates each row against the schema before `writeItem` and returns per-row rejects the model can fix and retry. Paved road over the same files — raw Read/Write/Edit stays the escape hatch.

The two feature plans are independent and individually shippable; `manageCollection` is the more foundational of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add planning documents for scheduled agent-based collection ingest and a computed-aware, validated collections management tool, plus a critical review of the existing collections architecture documentation.

Documentation:
- Document the design for an `ingest.kind: "agent"` scheduled agent refresh mechanism for collections, including schema, engine integration, completion hooks, and UI implications.
- Document the design for a `manageCollection` MCP tool that provides computed-field-aware reads and schema-validated writes for collections, along with shared derivation logic between client and server.
- Capture a detailed review of the collections architecture documentation, highlighting mismatches with the implementation, gaps, and recommended documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled agent-based collection refresh with automatic failure detection and notifications
  * Collection management tool enabling server-side validation and computation of derived fields

* **Documentation**
  * Architecture documentation review and corrections for collection and ingest systems
  * Feature planning documents for upcoming collection and agent capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->