### PR TITLE
feat(collections): manageCollection MCP tool — computed-aware reads, validated writes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,16 @@
     "allow": [
       "Bash(yarn test)",
       "Bash(yarn test *)",
-      "Bash(yarn test:*)"
+      "Bash(yarn test:*)",
+      "Bash(yarn lint)",
+      "Bash(yarn lint *)",
+      "Bash(yarn typecheck)",
+      "Bash(yarn typecheck *)",
+      "Bash(yarn format)",
+      "Bash(yarn format *)",
+      "Bash(sed -n *)",
+      "Bash(ls *)",
+      "mcp__mulmoclaude__readXPost"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,16 +3,7 @@
     "allow": [
       "Bash(yarn test)",
       "Bash(yarn test *)",
-      "Bash(yarn test:*)",
-      "Bash(yarn lint)",
-      "Bash(yarn lint *)",
-      "Bash(yarn typecheck)",
-      "Bash(yarn typecheck *)",
-      "Bash(yarn format)",
-      "Bash(yarn format *)",
-      "Bash(sed -n *)",
-      "Bash(ls *)",
-      "mcp__mulmoclaude__readXPost"
+      "Bash(yarn test:*)"
     ]
   },
   "hooks": {

--- a/docs/collections-architecture.md
+++ b/docs/collections-architecture.md
@@ -189,6 +189,8 @@ The schema defines the relationship.
 
 The host computes the result.
 
+Computed values are part of the runtime's view, not just the screen's: the `manageCollection` tool returns records with derived fields evaluated, so Claude acts on the same numbers the user sees.
+
 ---
 
 ## Business Logic as Language

--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -76,6 +76,12 @@ This catalog only covers **cross-cutting** helpers — formatters, error helpers
 | `server/utils/markdown.ts` | server-side helpers | Server-side markdown utilities (not for Vue). |
 | `src/utils/dom/externalLink.ts` | `handleExternalLinkClick(event)` | Single source of truth for v-html link delegation. Every `v-html` consumer routes external links through this so OS-vs-in-app navigation is consistent. |
 
+## Collections
+
+| Path | Helper | When to use |
+|---|---|---|
+| `src/utils/collections/deriveAll.ts` | `deriveAll(schema, record, refRecords)` / `resolveRowRefs(...)` | Evaluate every `derived` field on a collection record (saturating, cycle-safe, ref-deref via a preloaded target cache). The ONE derive implementation — used by the client rendering layer and the server's `manageCollection` enrichment; never reimplement the loop. |
+
 ## Plugin Infrastructure
 
 > The plugin META aggregator pattern is the canonical way to extend host barrels (api routes, tool names, workspace dirs, pub-sub channels). **Edit the plugin's `meta.ts`, not the host barrel.**

--- a/plans/feat-manage-collection-tool.md
+++ b/plans/feat-manage-collection-tool.md
@@ -94,7 +94,7 @@ call, then maps the shared `deriveAll` over the requested items.
 ### `putItems`
 
 ```ts
-{ action: "putItems", slug, items: object[], mode?: "upsert" | "create" }
+{ action: "putItems", slug, items: object[], mode?: "upsert" | "create" | "merge" }
 ```
 
 - Per-row validation **before** any write, reusing the existing per-record
@@ -107,7 +107,12 @@ call, then maps the shared `deriveAll` over the requested items.
   remove it"; toggle → "write enum field 'status' instead").
 - Writes go through `writeItem` (atomic, id-sanitized, containment-checked —
   no new I/O path). `mode: "create"` maps to `refuseOverwrite: true`;
-  default `upsert`.
+  default `upsert` replaces the record whole; `mode: "merge"` shallow-merges
+  the row over the existing record and validates the merged result — the
+  recommended mode for partial updates, since a partial upsert that carries
+  all required fields would silently erase the optional fields it omits.
+  Merge rejects unknown ids (a merged-over-nothing partial record is the
+  data shape the mode exists to prevent).
 - **Per-row results, not all-or-nothing**: valid rows are written, invalid
   rows are rejected individually —
   `{ written: string[], rejected: [{ id, problem }] }` — because the

--- a/server/agent/mcp-tools/index.ts
+++ b/server/agent/mcp-tools/index.ts
@@ -3,6 +3,7 @@ import { readXPost, searchX } from "./x.js";
 import { notify } from "./notify.js";
 import { handlePermission } from "./handlePermission.js";
 import { spawnBackgroundChat } from "./spawnBackgroundChat.js";
+import { manageCollection } from "./manageCollection.js";
 import { errorMessage } from "../../utils/errors.js";
 import { notFound, sendError, serverError } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
@@ -35,7 +36,7 @@ export interface McpTool {
   handler: (args: Record<string, unknown>, ctx?: McpToolContext) => Promise<string>;
 }
 
-export const mcpTools: McpTool[] = [readXPost, searchX, notify, handlePermission, spawnBackgroundChat];
+export const mcpTools: McpTool[] = [readXPost, searchX, notify, handlePermission, spawnBackgroundChat, manageCollection];
 
 const toolMap = new Map(mcpTools.map((tool) => [tool.definition.name, tool]));
 

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -49,10 +49,12 @@ interface GetItemsArgs {
   fields?: string[];
 }
 
+type PutMode = "upsert" | "create" | "merge";
+
 interface PutItemsArgs {
   slug: string;
   items: CollectionItem[];
-  mode: "upsert" | "create";
+  mode: PutMode;
 }
 
 function optionalStringArray(value: unknown, name: string): { ok: true; value?: string[] } | { ok: false; error: string } {
@@ -134,10 +136,29 @@ interface RejectedRow {
   problem: string;
 }
 
+/** `mode: "merge"` resolves the row against the EXISTING record —
+ *  a partial row updates just the fields it carries, instead of a
+ *  whole-record upsert silently erasing the optional fields it omits
+ *  (an upsert of `{id, status}` would pass validation yet drop
+ *  `notes`/`lesson`/…). Merge is a partial UPDATE by definition, so a
+ *  missing record is a reject, not an implicit create — a merged-over-
+ *  nothing partial record is exactly the data shape this mode exists
+ *  to prevent. */
+async function mergeWithExisting(
+  collection: LoadedCollection,
+  record: CollectionItem,
+  itemId: string,
+  deps: ManageCollectionDeps,
+): Promise<CollectionItem | string> {
+  const existing = await readItem(collection.dataDir, itemId, { workspaceRoot: deps.workspaceRoot });
+  if (!existing) return `'${itemId}' not found — mode "merge" updates an existing record; use "upsert" or "create" to add it`;
+  return { ...existing, ...record };
+}
+
 async function putOneItem(
   collection: LoadedCollection,
   record: CollectionItem,
-  mode: "upsert" | "create",
+  mode: PutMode,
   deps: ManageCollectionDeps,
 ): Promise<{ written?: string; rejected?: RejectedRow }> {
   const { schema } = collection;
@@ -148,9 +169,15 @@ async function putOneItem(
   if (itemId === null) return reject("(no id)", `record has no '${schema.primaryKey}' value — set it (it doubles as the filename)`);
   const computed = computedKeyProblem(record, schema);
   if (computed) return reject(itemId, computed);
-  const invalid = validateRecordObject(record, itemId, schema);
+  let toWrite = record;
+  if (mode === "merge") {
+    const merged = await mergeWithExisting(collection, record, itemId, deps);
+    if (typeof merged === "string") return reject(itemId, merged);
+    toWrite = merged;
+  }
+  const invalid = validateRecordObject(toWrite, itemId, schema);
   if (invalid) return reject(itemId, invalid);
-  const result = await writeItem(collection.dataDir, itemId, record, { refuseOverwrite: mode === "create", workspaceRoot: deps.workspaceRoot });
+  const result = await writeItem(collection.dataDir, itemId, toWrite, { refuseOverwrite: mode === "create", workspaceRoot: deps.workspaceRoot });
   if (result.kind === "ok") return { written: result.itemId };
   if (result.kind === "invalid-id") return reject(itemId, `'${itemId}' is not a valid record id (letters/digits with - or _ inside, no path characters)`);
   if (result.kind === "conflict") return reject(itemId, `'${itemId}' already exists — mode "create" refuses overwrite; use "upsert" to update it`);
@@ -172,8 +199,10 @@ function parsePutItems(args: Record<string, unknown>, slug: string): PutItemsArg
   const { items, mode } = args;
   const validItems = Array.isArray(items) && items.length > 0 && items.every((entry) => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry));
   if (!validItems) return "manageCollection: `items` is required for putItems — a non-empty array of record objects.";
-  if (mode !== undefined && mode !== "upsert" && mode !== "create") return 'manageCollection: `mode` must be "upsert" (default) or "create".';
-  return { slug, items: items as CollectionItem[], mode: (mode as "upsert" | "create" | undefined) ?? "upsert" };
+  if (mode !== undefined && mode !== "upsert" && mode !== "create" && mode !== "merge") {
+    return 'manageCollection: `mode` must be "upsert" (default), "create", or "merge".';
+  }
+  return { slug, items: items as CollectionItem[], mode: (mode as PutItemsArgs["mode"] | undefined) ?? "upsert" };
 }
 
 export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
@@ -204,8 +233,9 @@ export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
           },
           mode: {
             type: "string",
-            enum: ["upsert", "create"],
-            description: 'putItems: "upsert" (default) overwrites existing records; "create" rejects rows whose id already exists.',
+            enum: ["upsert", "create", "merge"],
+            description:
+              'putItems: "upsert" (default) replaces existing records WHOLE; "create" rejects rows whose id already exists; "merge" updates only the fields a row carries, keeping the rest of the existing record (rejects unknown ids). Use "merge" when changing a few fields.',
           },
         },
         required: ["action", "slug"],
@@ -220,7 +250,8 @@ export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
     prompt:
       "Use `manageCollection` instead of raw Read/Write/Edit when working with a collection's records (raw file I/O stays available as the escape hatch). " +
       "`getItems` is the only way to see computed values — `derived` fields (e.g. a portfolio's value), `toggle` projections, and `embed` records are host-computed and never present in the stored JSON files. On large collections pass `ids` and/or `fields` to keep the result small. " +
-      "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write.",
+      "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write. " +
+      'To update a few fields of an existing record, use `mode: "merge"` with a partial row ({ id, <changed fields> }) — the default upsert replaces the WHOLE record, so a partial upsert would silently erase every optional field it omits.',
 
     async handler(args: Record<string, unknown>): Promise<string> {
       const action = typeof args.action === "string" ? args.action : "";

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -1,0 +1,246 @@
+// `manageCollection` is the agent's data plane for schema-driven
+// collections — the paved road over the same record files that raw
+// Read/Write/Edit reach (the workspace stays the database; this tool is
+// a convenience + gate, not a second store):
+//
+//   - getItems: records WITH the host-computed fields the stored JSON
+//     never contains — `derived` formulas evaluated (cross-collection
+//     derefs included), `toggle` projected, `embed` resolved — i.e. the
+//     same numbers the user sees rendered. One call instead of N file
+//     Reads plus a mental join.
+//   - putItems: rows validated against the schema BEFORE the write
+//     (primaryKey↔id, required fields, enum membership, no computed
+//     keys), written atomically, with per-row accept/reject results the
+//     model can fix and retry — instead of writing a broken file and
+//     meeting it later in the presentCollection repair loop.
+//
+// Like `spawnBackgroundChat`, the workspace lookups are injected so the
+// unit test can point everything at a tmpdir workspace; the production
+// singleton binds the live modules with default (real-workspace) opts.
+
+import {
+  COMPUTED_TYPES,
+  enrichItems,
+  listItems,
+  loadCollection,
+  readItem,
+  resolveCreateItemId,
+  validateCollectionRecords,
+  validateRecordObject,
+  writeItem,
+} from "../../workspace/collections/index.js";
+import type { CollectionItem, CollectionSchema, LoadedCollection } from "../../workspace/collections/index.js";
+import type { DiscoveryOptions } from "../../workspace/collections/discovery.js";
+import { defangForPrompt } from "../../../src/utils/promptSafety.js";
+
+/** Refuse an unselective getItems beyond this many records — a silent
+ *  truncation would read as "covered everything", and an unbounded dump
+ *  of a large collection is a token bomb. `ids` or `fields` lifts it. */
+export const MAX_UNSELECTIVE_ITEMS = 200;
+
+/** Workspace-targeting overrides, threaded to every collections call.
+ *  Production: `{}` (live workspace). Tests: a tmpdir + empty user
+ *  skills dir. */
+export type ManageCollectionDeps = DiscoveryOptions;
+
+interface GetItemsArgs {
+  slug: string;
+  ids?: string[];
+  fields?: string[];
+}
+
+interface PutItemsArgs {
+  slug: string;
+  items: CollectionItem[];
+  mode: "upsert" | "create";
+}
+
+function optionalStringArray(value: unknown, name: string): { ok: true; value?: string[] } | { ok: false; error: string } {
+  if (value === undefined) return { ok: true };
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string" && entry.length > 0)) {
+    return { ok: false, error: `manageCollection: \`${name}\` must be an array of non-empty strings when present.` };
+  }
+  return { ok: true, value: value as string[] };
+}
+
+/** Project a record down to the requested fields. The primary key is
+ *  always kept so every returned record stays addressable for a
+ *  follow-up getItems/putItems. */
+function projectFields(record: CollectionItem, fields: string[], primaryKey: string): CollectionItem {
+  const keys = fields.includes(primaryKey) ? fields : [primaryKey, ...fields];
+  return Object.fromEntries(keys.filter((key) => key in record).map((key) => [key, record[key]]));
+}
+
+/** The validation warning appended to a getItems result when stored
+ *  record files are malformed (they're silently skipped at read time,
+ *  so without this they'd just look missing). Issue strings quote
+ *  record-controlled text → defanged, mirroring the presentCollection
+ *  dispatch. The record VALUES in `items` ride verbatim, like a raw
+ *  file Read — only host-composed report strings are defanged. */
+async function recordIssuesWarning(collection: LoadedCollection, deps: ManageCollectionDeps): Promise<string | undefined> {
+  const issues = await validateCollectionRecords(collection, { workspaceRoot: deps.workspaceRoot });
+  if (issues.length === 0) return undefined;
+  const lines = issues.map((issue) => `- ${defangForPrompt(issue.file)}: ${defangForPrompt(issue.problem)}`).join("\n");
+  return `${issues.length} record file(s) have data problems and are missing from this result. Fix each (Read → correct → Write):\n${lines}`;
+}
+
+async function loadRequestedItems(
+  collection: LoadedCollection,
+  ids: string[] | undefined,
+  deps: ManageCollectionDeps,
+): Promise<{ items: CollectionItem[]; missing: string[] }> {
+  if (!ids) return { items: await listItems(collection.dataDir, { workspaceRoot: deps.workspaceRoot }), missing: [] };
+  const items: CollectionItem[] = [];
+  const missing: string[] = [];
+  for (const recordId of ids) {
+    const item = await readItem(collection.dataDir, recordId, { workspaceRoot: deps.workspaceRoot });
+    if (item) items.push(item);
+    else missing.push(recordId);
+  }
+  return { items, missing };
+}
+
+async function handleGetItems(collection: LoadedCollection, args: GetItemsArgs, deps: ManageCollectionDeps): Promise<string> {
+  const { items, missing } = await loadRequestedItems(collection, args.ids, deps);
+  if (!args.ids && !args.fields && items.length > MAX_UNSELECTIVE_ITEMS) {
+    return `manageCollection: refused — '${collection.slug}' has ${items.length} records, over the unselective limit of ${MAX_UNSELECTIVE_ITEMS}. Pass \`ids\` for specific records or \`fields\` to project only the columns you need.`;
+  }
+  const enriched = await enrichItems(collection, items, deps);
+  const projected = args.fields ? enriched.map((item) => projectFields(item, args.fields as string[], collection.schema.primaryKey)) : enriched;
+  const warning = await recordIssuesWarning(collection, deps);
+  return JSON.stringify({
+    collection: collection.slug,
+    count: projected.length,
+    items: projected,
+    ...(missing.length > 0 ? { missing: missing.map((recordId) => defangForPrompt(recordId)) } : {}),
+    ...(warning ? { warning } : {}),
+  });
+}
+
+/** Reject writes that set host-computed keys, with a pointer at the
+ *  writable source of truth (the toggle's enum) where one exists. */
+function computedKeyProblem(record: CollectionItem, schema: CollectionSchema): string | null {
+  for (const key of Object.keys(record)) {
+    const spec = schema.fields[key];
+    if (!spec || !COMPUTED_TYPES.has(spec.type)) continue;
+    if (spec.type === "toggle" && spec.field) return `'${key}' is a toggle projection — write the enum field '${spec.field}' instead`;
+    return `'${key}' is ${spec.type === "derived" ? "derived" : "an embed"} — computed by the host, remove it from the record`;
+  }
+  return null;
+}
+
+interface RejectedRow {
+  id: string;
+  problem: string;
+}
+
+async function putOneItem(
+  collection: LoadedCollection,
+  record: CollectionItem,
+  mode: "upsert" | "create",
+  deps: ManageCollectionDeps,
+): Promise<{ written?: string; rejected?: RejectedRow }> {
+  const { schema } = collection;
+  const itemId = resolveCreateItemId(schema, record);
+  const reject = (about: string, problem: string): { rejected: RejectedRow } => ({
+    rejected: { id: defangForPrompt(about), problem: defangForPrompt(problem) },
+  });
+  if (itemId === null) return reject("(no id)", `record has no '${schema.primaryKey}' value — set it (it doubles as the filename)`);
+  const computed = computedKeyProblem(record, schema);
+  if (computed) return reject(itemId, computed);
+  const invalid = validateRecordObject(record, itemId, schema);
+  if (invalid) return reject(itemId, invalid);
+  const result = await writeItem(collection.dataDir, itemId, record, { refuseOverwrite: mode === "create", workspaceRoot: deps.workspaceRoot });
+  if (result.kind === "ok") return { written: result.itemId };
+  if (result.kind === "invalid-id") return reject(itemId, `'${itemId}' is not a valid record id (letters/digits with - or _ inside, no path characters)`);
+  if (result.kind === "conflict") return reject(itemId, `'${itemId}' already exists — mode "create" refuses overwrite; use "upsert" to update it`);
+  return reject(itemId, "write refused: the collection's data dir escapes the workspace");
+}
+
+async function handlePutItems(collection: LoadedCollection, args: PutItemsArgs, deps: ManageCollectionDeps): Promise<string> {
+  const written: string[] = [];
+  const rejected: RejectedRow[] = [];
+  for (const record of args.items) {
+    const outcome = await putOneItem(collection, record, args.mode, deps);
+    if (outcome.written) written.push(outcome.written);
+    if (outcome.rejected) rejected.push(outcome.rejected);
+  }
+  return JSON.stringify({ collection: collection.slug, written, rejected });
+}
+
+function parsePutItems(args: Record<string, unknown>, slug: string): PutItemsArgs | string {
+  const { items, mode } = args;
+  const validItems = Array.isArray(items) && items.length > 0 && items.every((entry) => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry));
+  if (!validItems) return "manageCollection: `items` is required for putItems — a non-empty array of record objects.";
+  if (mode !== undefined && mode !== "upsert" && mode !== "create") return 'manageCollection: `mode` must be "upsert" (default) or "create".';
+  return { slug, items: items as CollectionItem[], mode: (mode as "upsert" | "create" | undefined) ?? "upsert" };
+}
+
+export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
+  return {
+    definition: {
+      name: "manageCollection",
+      description:
+        "Read and write records of a schema-driven collection through the host. getItems returns records WITH computed values (derived formulas, toggles, embeds) the stored JSON files don't contain; putItems validates each row against the collection's schema before writing and reports per-row rejects. Prefer it over raw file I/O on collection records.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          action: { type: "string", enum: ["getItems", "putItems"], description: "What to do." },
+          slug: { type: "string", description: "The collection's slug (its directory name, e.g. `stock-quotes`)." },
+          ids: {
+            type: "array",
+            items: { type: "string" },
+            description: "getItems: only these record ids (primary-key values). Omit for all records.",
+          },
+          fields: {
+            type: "array",
+            items: { type: "string" },
+            description: "getItems: only these fields per record (the primary key is always included). Omit for all fields. Use on large collections.",
+          },
+          items: {
+            type: "array",
+            items: { type: "object" },
+            description: "putItems: the record objects to store. Each must carry the schema's primaryKey value (it doubles as the filename).",
+          },
+          mode: {
+            type: "string",
+            enum: ["upsert", "create"],
+            description: 'putItems: "upsert" (default) overwrites existing records; "create" rejects rows whose id already exists.',
+          },
+        },
+        required: ["action", "slug"],
+      },
+    },
+
+    // Collections are workspace data every role can already reach via
+    // raw Read/Write/Edit — gating the SAFER path per-role would only
+    // push unlisted roles back onto unvalidated file I/O.
+    alwaysActive: true,
+
+    prompt:
+      "Use `manageCollection` instead of raw Read/Write/Edit when working with a collection's records (raw file I/O stays available as the escape hatch). " +
+      "`getItems` is the only way to see computed values — `derived` fields (e.g. a portfolio's value), `toggle` projections, and `embed` records are host-computed and never present in the stored JSON files. On large collections pass `ids` and/or `fields` to keep the result small. " +
+      "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write.",
+
+    async handler(args: Record<string, unknown>): Promise<string> {
+      const action = typeof args.action === "string" ? args.action : "";
+      const slug = typeof args.slug === "string" ? args.slug.trim() : "";
+      if (!slug) return "manageCollection: `slug` is required (the collection's slug).";
+      if (action !== "getItems" && action !== "putItems") return 'manageCollection: `action` must be "getItems" or "putItems".';
+      const collection = await loadCollection(slug, deps);
+      if (!collection) return `manageCollection: unknown collection '${defangForPrompt(slug)}' — its schema.json is missing or failed validation.`;
+      if (action === "getItems") {
+        const ids = optionalStringArray(args.ids, "ids");
+        if (!ids.ok) return ids.error;
+        const fields = optionalStringArray(args.fields, "fields");
+        if (!fields.ok) return fields.error;
+        return handleGetItems(collection, { slug, ids: ids.value, fields: fields.value }, deps);
+      }
+      const parsed = parsePutItems(args, slug);
+      if (typeof parsed === "string") return parsed;
+      return handlePutItems(collection, parsed, deps);
+    },
+  };
+}
+
+export const manageCollection = makeManageCollectionTool();

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -95,7 +95,11 @@ async function loadRequestedItems(
   const items: CollectionItem[] = [];
   const missing: string[] = [];
   for (const recordId of ids) {
-    const item = await readItem(collection.dataDir, recordId, { workspaceRoot: deps.workspaceRoot });
+    // readItem THROWS on a malformed record file (only ENOENT is null) —
+    // for the tool that's a `missing` entry, not a failed call: the
+    // warning scan that runs whenever something is missing then names
+    // the broken file and how to fix it.
+    const item = await readItem(collection.dataDir, recordId, { workspaceRoot: deps.workspaceRoot }).catch(() => null);
     if (item) items.push(item);
     else missing.push(recordId);
   }
@@ -109,7 +113,11 @@ async function handleGetItems(collection: LoadedCollection, args: GetItemsArgs, 
   }
   const enriched = await enrichItems(collection, items, deps);
   const projected = args.fields ? enriched.map((item) => projectFields(item, args.fields as string[], collection.schema.primaryKey)) : enriched;
-  const warning = await recordIssuesWarning(collection, deps);
+  // The warning scan reads every record file, so don't pay it on a
+  // selective read that found everything it asked for — only a full
+  // listing (where a malformed file silently looks absent) or a missing
+  // requested id (where the scan explains WHY it's missing) needs it.
+  const warning = !args.ids || missing.length > 0 ? await recordIssuesWarning(collection, deps) : undefined;
   return JSON.stringify({
     collection: collection.slug,
     count: projected.length,
@@ -143,7 +151,13 @@ interface RejectedRow {
  *  `notes`/`lesson`/…). Merge is a partial UPDATE by definition, so a
  *  missing record is a reject, not an implicit create — a merged-over-
  *  nothing partial record is exactly the data shape this mode exists
- *  to prevent. */
+ *  to prevent.
+ *
+ *  Computed keys found in the STORED record are stripped before the
+ *  merge: the caller's own row was already computed-key-rejected, but a
+ *  raw-written / legacy record can carry a stale `derived`/`embed`/
+ *  `toggle` value, and re-writing it would perpetuate a forged
+ *  host-computed value. A merge heals the record instead. */
 async function mergeWithExisting(
   collection: LoadedCollection,
   record: CollectionItem,
@@ -152,7 +166,8 @@ async function mergeWithExisting(
 ): Promise<CollectionItem | string> {
   const existing = await readItem(collection.dataDir, itemId, { workspaceRoot: deps.workspaceRoot });
   if (!existing) return `'${itemId}' not found — mode "merge" updates an existing record; use "upsert" or "create" to add it`;
-  return { ...existing, ...record };
+  const stored = Object.entries(existing).filter(([key]) => !COMPUTED_TYPES.has(collection.schema.fields[key]?.type ?? ""));
+  return { ...Object.fromEntries(stored), ...record };
 }
 
 async function putOneItem(

--- a/server/workspace/collections/derive.ts
+++ b/server/workspace/collections/derive.ts
@@ -1,0 +1,100 @@
+// Server-side computed-field enrichment for collection records: the
+// host evaluates `derived` formulas (via the SHARED saturation loop in
+// src/utils/collections/deriveAll.ts — never a server reimplementation),
+// projects `toggle` fields off their enum, and resolves `embed` fields
+// to their fixed target record. The client does the same at render
+// time; this module gives server consumers (manageCollection getItems)
+// the same numbers the user sees on screen.
+
+import { deriveAll, type DeriveRefRecords } from "../../../src/utils/collections/deriveAll.js";
+import { loadCollection, type DiscoveryOptions, type LoadedCollection } from "./discovery.js";
+import { listItems } from "./io.js";
+import type { CollectionFieldSpec, CollectionItem, CollectionSchema } from "./types.js";
+
+/** Slugs of every collection referenced by a `ref` field — top-level
+ *  and one level into `table` sub-fields (nested tables are
+ *  schema-rejected). Mirrors the client's `uniqueRefTargets`. */
+function uniqueRefTargets(schema: CollectionSchema): string[] {
+  const targets = new Set<string>();
+  const walk = (fields: Record<string, CollectionFieldSpec>): void => {
+    for (const field of Object.values(fields)) {
+      if (field.type === "ref" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
+      if (field.type === "table" && field.of) walk(field.of);
+    }
+  };
+  walk(schema.fields);
+  return [...targets];
+}
+
+/** Slugs of every collection referenced by an `embed` field (top-level
+ *  only, like the client). */
+function uniqueEmbedTargets(schema: CollectionSchema): string[] {
+  const targets = new Set<string>();
+  for (const field of Object.values(schema.fields)) {
+    if (field.type === "embed" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
+  }
+  return [...targets];
+}
+
+interface LinkedTarget {
+  schema: CollectionSchema;
+  /** primary-key slug → record (ref targets store the DERIVED record,
+   *  mirroring the client's `buildRefRecordMap`, so a formula deref
+   *  like `ticker.price` can read the target's own derived columns). */
+  byId: Record<string, CollectionItem>;
+}
+
+async function loadTarget(slug: string, opts: DiscoveryOptions): Promise<LinkedTarget | null> {
+  const target = await loadCollection(slug, opts);
+  if (!target) return null;
+  const items = await listItems(target.dataDir, { workspaceRoot: opts.workspaceRoot });
+  const byId: Record<string, CollectionItem> = {};
+  for (const item of items) {
+    const itemId = item[target.schema.primaryKey];
+    if (typeof itemId === "string" && itemId.length > 0) byId[itemId] = deriveAll(target.schema, item, {});
+  }
+  return { schema: target.schema, byId };
+}
+
+/** Load every ref/embed target collection once. Unknown / unloadable
+ *  targets are simply absent — downstream derefs resolve to null, the
+ *  same fail-soft the UI renders as an em-dash. */
+async function loadLinkedTargets(schema: CollectionSchema, opts: DiscoveryOptions): Promise<Record<string, LinkedTarget>> {
+  const slugs = [...new Set([...uniqueRefTargets(schema), ...uniqueEmbedTargets(schema)])];
+  const loaded: Record<string, LinkedTarget> = {};
+  for (const slug of slugs) {
+    const target = await loadTarget(slug, opts);
+    if (target) loaded[slug] = target;
+  }
+  return loaded;
+}
+
+function toRefRecords(linked: Record<string, LinkedTarget>): DeriveRefRecords {
+  return Object.fromEntries(Object.entries(linked).map(([slug, target]) => [slug, target.byId]));
+}
+
+/** Project the computed (never-stored) field kinds onto one derived
+ *  record: `toggle` → boolean off its enum, `embed` → the fixed target
+ *  record (or null when missing). */
+function projectComputed(schema: CollectionSchema, enriched: CollectionItem, linked: Record<string, LinkedTarget>): CollectionItem {
+  for (const [key, field] of Object.entries(schema.fields)) {
+    if (field.type === "toggle" && field.field) {
+      enriched[key] = String(enriched[field.field] ?? "") === field.onValue;
+    }
+    if (field.type === "embed" && field.to && field.id) {
+      enriched[key] = linked[field.to]?.byId[field.id] ?? null;
+    }
+  }
+  return enriched;
+}
+
+/** Enrich records with every host-computed field: derived formulas
+ *  evaluated (cross-collection derefs included), toggles projected,
+ *  embeds resolved. Loads each linked collection ONCE per call. Input
+ *  records are not mutated. */
+export async function enrichItems(collection: LoadedCollection, items: CollectionItem[], opts: DiscoveryOptions = {}): Promise<CollectionItem[]> {
+  const { schema } = collection;
+  const linked = await loadLinkedTargets(schema, opts);
+  const refRecords = toRefRecords(linked);
+  return items.map((item) => projectComputed(schema, deriveAll(schema, item, refRecords), linked));
+}

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -1,5 +1,6 @@
 export { discoverCollections, loadCollection, toSummary, toDetail, CollectionSchemaZ, type LoadedCollection } from "./discovery.js";
-export { validateCollectionRecords, type RecordIssue } from "./validate.js";
+export { validateCollectionRecords, validateRecordObject, COMPUTED_TYPES, type RecordIssue } from "./validate.js";
+export { enrichItems } from "./derive.js";
 export { deleteCollection, deleteCollectionRefusalMessage, type DeleteCollectionResult } from "./delete.js";
 export {
   listItems,

--- a/server/workspace/collections/validate.ts
+++ b/server/workspace/collections/validate.ts
@@ -25,7 +25,7 @@ export interface RecordIssue {
 const MAX_ISSUES = 25;
 // derived/embed/toggle are host-computed or projected — never written to
 // the record JSON, so required / value checks must not apply to them.
-const COMPUTED_TYPES = new Set(["derived", "embed", "toggle"]);
+export const COMPUTED_TYPES: ReadonlySet<string> = new Set(["derived", "embed", "toggle"]);
 
 /** Read every `<id>.json` under the collection's dataDir and report the
  *  ones that won't load or violate the schema. An empty list means every
@@ -90,28 +90,28 @@ async function inspectRecord(fullPath: string, name: string, schema: CollectionS
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     return { file: name, problem: "not a JSON object — skipped, won't appear" };
   }
-  return schemaViolation(parsed as CollectionItem, name, schema);
+  const problem = validateRecordObject(parsed as CollectionItem, name.replace(/\.json$/, ""), schema);
+  return problem ? { file: name, problem } : null;
 }
 
-/** First schema problem on a parseable record (id↔filename, missing
- *  required, bad enum value), or null. One issue per record keeps the
- *  report short and the fix obvious. */
-function schemaViolation(record: CollectionItem, name: string, schema: CollectionSchema): RecordIssue | null {
-  const stem = name.replace(/\.json$/, "");
+/** First schema problem on an in-memory record (primaryKey↔id mismatch,
+ *  missing required, bad enum value), or null when it's fine. One issue
+ *  per record keeps the report short and the fix obvious. Pure +
+ *  exported so write paths (manageCollection putItems) can gate on the
+ *  SAME rules the post-hoc file scan reports — `itemId` is the id the
+ *  record is (or would be) stored under. */
+export function validateRecordObject(record: CollectionItem, itemId: string, schema: CollectionSchema): string | null {
   const idValue = record[schema.primaryKey];
-  if (typeof idValue !== "string" || idValue !== stem) {
-    return {
-      file: name,
-      problem: `'${schema.primaryKey}' is '${String(idValue ?? "")}' but must equal the filename ('${stem}'), or the record can't be opened`,
-    };
+  if (typeof idValue !== "string" || idValue !== itemId) {
+    return `'${schema.primaryKey}' is '${String(idValue ?? "")}' but must equal the filename ('${itemId}'), or the record can't be opened`;
   }
   for (const [field, spec] of Object.entries(schema.fields)) {
     if (COMPUTED_TYPES.has(spec.type)) continue;
     const value = record[field];
     const empty = value === undefined || value === null || value === "";
-    if (spec.required && empty) return { file: name, problem: `missing required field '${field}'` };
+    if (spec.required && empty) return `missing required field '${field}'`;
     if (!empty && spec.type === "enum" && spec.values && !spec.values.includes(String(value))) {
-      return { file: name, problem: `'${field}' = '${String(value)}' is not one of [${spec.values.join(", ")}]` };
+      return `'${field}' = '${String(value)}' is not one of [${spec.values.join(", ")}]`;
     }
   }
   return null;

--- a/server/workspace/helps/billing-invoice.md
+++ b/server/workspace/helps/billing-invoice.md
@@ -93,7 +93,8 @@ name: profile
 description: The user's own business profile — the issuer ("bill-from") identity
   used on invoices. A singleton collection with exactly one record, id `me`. The
   record lives at `data/profile/items/me.json`; the user views and edits it at
-  `/collections/profile`. You do all I/O via Read / Write / Edit on the JSON file.
+  `/collections/profile`. Record I/O via the `manageCollection` tool (raw
+  Read / Write / Edit on the JSON file is the escape hatch).
 ---
 
 # Business Profile (schema-driven collection)

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -81,7 +81,9 @@ description: A personal recipe box. Use whenever the user asks to add, list,
 **Add / Update** — `manageCollection` putItems: each row is validated against
 the schema BEFORE the write; fix any `rejected` row from its `problem` text
 and retry just those. Use `mode: "create"` when adding so an id collision is
-rejected instead of silently overwritten.
+rejected instead of silently overwritten, and `mode: "merge"` with a partial
+row (`{ id, <changed fields> }`) when updating — the default upsert replaces
+the WHOLE record and would erase every optional field the row omits.
 **List / Read** — `manageCollection` getItems: the only way to see
 host-computed `derived` / `toggle` / `embed` values (the stored JSON never
 contains them); pass `ids` / `fields` on large collections.

--- a/server/workspace/helps/collection-skills.md
+++ b/server/workspace/helps/collection-skills.md
@@ -65,8 +65,9 @@ name: recipes
 description: A personal recipe box. Use whenever the user asks to add, list,
   edit, or remove a recipe. Records live at `data/recipes/items/<id>.json`
   (one JSON per recipe); the user views them at `/collections/recipes`,
-  rendered from `schema.json` by the host. You do all I/O via Read / Write /
-  Edit on the JSON files.
+  rendered from `schema.json` by the host. Record I/O via the
+  `manageCollection` tool (raw Read / Write / Edit on the JSON files is the
+  escape hatch).
 ---
 
 # Recipes (schema-driven collection)
@@ -77,8 +78,14 @@ description: A personal recipe box. Use whenever the user asks to add, list,
 - ... (one bullet per field; note which are host-computed and must NOT be written)
 
 ## What to do
-**Add / List / Update / Delete** — derive an id, Read/Write/Edit the JSON.
-List the directory first and pick a fresh slug rather than overwriting.
+**Add / Update** — `manageCollection` putItems: each row is validated against
+the schema BEFORE the write; fix any `rejected` row from its `problem` text
+and retry just those. Use `mode: "create"` when adding so an id collision is
+rejected instead of silently overwritten.
+**List / Read** — `manageCollection` getItems: the only way to see
+host-computed `derived` / `toggle` / `embed` values (the stored JSON never
+contains them); pass `ids` / `fields` on large collections.
+**Delete** — remove the record file.
 Don't recite the whole table in chat. After adding or updating a record,
 call `presentCollection` (with the collection slug and the record's id) to
 show it inline; for a plain "show/list" request, call `presentCollection`

--- a/server/workspace/helps/lessons-collection.md
+++ b/server/workspace/helps/lessons-collection.md
@@ -334,9 +334,10 @@ collection. Keep it short — the schema and templates do the heavy lifting. Cov
     moment you present the current one** (not after running it) — and only once
     everything is `mastered`, append the next batch of `planned` lessons (paragraph
     `objective` each, HTML authored lazily later).
-- **Operations** — all I/O is plain Read / Write / Edit on
-  `data/lessons-<topic>/items/<id>.json`, one record per file (Add / List /
-  Update status / Edit / Delete). Rather than dumping the whole course into chat,
+- **Operations** — record I/O via `manageCollection` (`getItems` to read,
+  `putItems` for schema-validated Add / Update; Delete removes the file at
+  `data/lessons-<topic>/items/<id>.json`; raw Read / Write / Edit is the
+  escape hatch). Rather than dumping the whole course into chat,
   point the user at `/collections/lessons-<topic>`.
 - **When to call `presentCollection`** — when the **course itself** changes: after
   creating the collection or adding/extending lessons (it also surfaces malformed

--- a/server/workspace/helps/lessons-collection.md
+++ b/server/workspace/helps/lessons-collection.md
@@ -258,9 +258,10 @@ Rules for the worker:
   its `objective`** (full `<!DOCTYPE html>`, inline CSS/JS or an allowed CDN — see
   `config/helps/presenthtml.md`); **`Write`** it to
   `artifacts/html/lessons-<topic>/<id>.html`; set that path as the record's `lesson`
-  field; do **NOT** call `presentHtml` and do **NOT** present anything — just write
-  the files and stop. (No one is viewing the worker's canvas, so presenting there is
-  wasted.)
+  field with `manageCollection` putItems `mode: "merge"` (`{ id, lesson }` — merge
+  keeps every other field); do **NOT** call `presentHtml` and do **NOT** present
+  anything — just write the files and stop. (No one is viewing the worker's canvas,
+  so presenting there is wasted.)
 - **One lesson per call**, and don't spawn a fleet — the host caps concurrent hidden
   workers and a worker can't spawn further workers.
 
@@ -334,8 +335,10 @@ collection. Keep it short — the schema and templates do the heavy lifting. Cov
     moment you present the current one** (not after running it) — and only once
     everything is `mastered`, append the next batch of `planned` lessons (paragraph
     `objective` each, HTML authored lazily later).
-- **Operations** — record I/O via `manageCollection` (`getItems` to read,
-  `putItems` for schema-validated Add / Update; Delete removes the file at
+- **Operations** — record I/O via `manageCollection` (`getItems` to read;
+  `putItems` for schema-validated writes — `mode: "create"` for new lessons,
+  `mode: "merge"` with a partial row for status/notes/lesson updates so the
+  fields you omit survive; Delete removes the file at
   `data/lessons-<topic>/items/<id>.json`; raw Read / Write / Edit is the
   escape hatch). Rather than dumping the whole course into chat,
   point the user at `/collections/lessons-<topic>`.

--- a/server/workspace/helps/portfolio-tracker.md
+++ b/server/workspace/helps/portfolio-tracker.md
@@ -79,7 +79,7 @@ row renders `price`/`value` as `—` (fail-soft) until the quote exists.
 ```markdown
 ---
 name: stock-quotes
-description: A simple stock-quote watchlist. Use whenever the user asks to add, list, update, or remove a stock quote, or to look up the latest price / PE ratio / dividend yield for a ticker. Records live at `data/stock-quotes/items/<ticker>.json` (one JSON per ticker, lowercase id); the user views them at `/collections/stock-quotes`, rendered from `schema.json` by the host. All I/O via Read / Write / Edit on the JSON files. Price data comes from Yahoo Finance (15-minute delayed).
+description: A simple stock-quote watchlist. Use whenever the user asks to add, list, update, or remove a stock quote, or to look up the latest price / PE ratio / dividend yield for a ticker. Records live at `data/stock-quotes/items/<ticker>.json` (one JSON per ticker, lowercase id); the user views them at `/collections/stock-quotes`, rendered from `schema.json` by the host. Record I/O via the `manageCollection` tool (getItems / putItems; raw Read / Write / Edit on the JSON files is the escape hatch). Price data comes from Yahoo Finance (15-minute delayed).
 ---
 
 # Stock Quotes (schema-driven collection)
@@ -102,13 +102,13 @@ Omit fields the user didn't supply or that Yahoo Finance didn't return — don't
 
 ## What to do
 
-**Add / refresh**: Fetch from Yahoo Finance (`https://query1.finance.yahoo.com/v7/finance/quote?symbols=<SYM>` or `quoteSummary` with `summaryDetail,price,defaultKeyStatistics`). Build the record, Write to `data/stock-quotes/items/<lowercased-ticker>.json`. Overwriting an existing file is the intended way to refresh a quote.
+**Add / refresh**: Fetch from Yahoo Finance (`https://query1.finance.yahoo.com/v7/finance/quote?symbols=<SYM>` or `quoteSummary` with `summaryDetail,price,defaultKeyStatistics`). Build the records and store them in one call — `manageCollection` `putItems` with `slug: "stock-quotes"` validates each row against the schema before writing; fix any `rejected` row using its `problem` text and retry just those. Upserting an existing id is the intended way to refresh a quote.
 
-**List**: Read `data/stock-quotes/items/` and answer from there. Don't dump every record into chat — link to `/collections/stock-quotes`.
+**List**: `manageCollection` `getItems` with `slug: "stock-quotes"` (use `fields` to keep it small). Don't dump every record into chat — link to `/collections/stock-quotes`.
 
-**Update**: Read, merge, Write. Preserve fields the user didn't ask to change. Always update `asOf`.
+**Update**: `getItems` with `ids: ["<id>"]`, merge, `putItems`. Preserve fields the user didn't ask to change. Always update `asOf`.
 
-**Delete**: Confirm once if ambiguous, then remove the file.
+**Delete**: Confirm once if ambiguous, then remove the file (`data/stock-quotes/items/<id>.json`).
 
 ## Linking from chat
 
@@ -153,7 +153,7 @@ Always tell the user when the price was fetched and that it's typically 15-minut
 ```markdown
 ---
 name: portfolio
-description: A personal stock portfolio. Use whenever the user asks to add, list, edit, or remove a holding, or to see the value of their portfolio. Each record is one holding (ticker + share count); the latest price is pulled live from the `stock-quotes` collection via a derived ref, so the holding's value updates whenever the quote is refreshed. Records live at `data/portfolio/items/<id>.json`; the user views them at `/collections/portfolio`, rendered from `schema.json` by the host. All I/O via Read / Write / Edit on the JSON files.
+description: A personal stock portfolio. Use whenever the user asks to add, list, edit, or remove a holding, or to see the value of their portfolio. Each record is one holding (ticker + share count); the latest price is pulled live from the `stock-quotes` collection via a derived ref, so the holding's value updates whenever the quote is refreshed. Records live at `data/portfolio/items/<id>.json`; the user views them at `/collections/portfolio`, rendered from `schema.json` by the host. Record I/O via the `manageCollection` tool — its getItems is the ONLY way to read the computed `price` / `value` columns (the stored JSON never contains them).
 ---
 
 # My Portfolio (schema-driven collection)
@@ -173,15 +173,15 @@ Omit fields the user didn't supply — don't write empty strings. Never write `p
 
 ## What to do
 
-**Add a holding**: confirm the ticker has a row in `/collections/stock-quotes`; if not, add it first via the `stock-quotes` skill (so `ticker.price` resolves). Then Write `data/portfolio/items/<lowercased-ticker>.json` with `id`, `ticker`, `shares` (and optional `notes`).
+**Add a holding**: confirm the ticker has a row in `/collections/stock-quotes`; if not, add it first via the `stock-quotes` skill (so `ticker.price` resolves). Then `manageCollection` `putItems` with `slug: "portfolio"` and a row carrying `id`, `ticker`, `shares` (and optional `notes`) — never `price` / `value`; putItems rejects computed keys.
 
-**List**: Read `data/portfolio/items/` and answer from there. Don't dump every record into chat — link to `/collections/portfolio`.
+**List / value the portfolio**: `manageCollection` `getItems` with `slug: "portfolio"` — the returned records INCLUDE the host-computed `price` and `value`, so total the `value` column from there (reading the raw JSON files would show neither). Don't dump every record into chat — link to `/collections/portfolio`.
 
-**Update shares**: Read, change `shares`, Write back. Preserve other fields.
+**Update shares**: `getItems` with `ids: ["<id>"]`, change `shares`, `putItems`. Preserve other fields.
 
 **Refresh prices**: don't touch the portfolio records — go refresh the matching row in `stock-quotes` instead. The portfolio's `price` and `value` columns update on the next render.
 
-**Delete**: Confirm once if ambiguous, then remove the file.
+**Delete**: Confirm once if ambiguous, then remove the file (`data/portfolio/items/<id>.json`).
 
 ## Linking from chat
 

--- a/server/workspace/helps/portfolio-tracker.md
+++ b/server/workspace/helps/portfolio-tracker.md
@@ -106,7 +106,7 @@ Omit fields the user didn't supply or that Yahoo Finance didn't return — don't
 
 **List**: `manageCollection` `getItems` with `slug: "stock-quotes"` (use `fields` to keep it small). Don't dump every record into chat — link to `/collections/stock-quotes`.
 
-**Update**: `getItems` with `ids: ["<id>"]`, merge, `putItems`. Preserve fields the user didn't ask to change. Always update `asOf`.
+**Update**: `putItems` with `mode: "merge"` and a partial row (`{ id, <changed fields> }`) — it keeps every field the row omits. Always update `asOf`.
 
 **Delete**: Confirm once if ambiguous, then remove the file (`data/stock-quotes/items/<id>.json`).
 
@@ -177,7 +177,7 @@ Omit fields the user didn't supply — don't write empty strings. Never write `p
 
 **List / value the portfolio**: `manageCollection` `getItems` with `slug: "portfolio"` — the returned records INCLUDE the host-computed `price` and `value`, so total the `value` column from there (reading the raw JSON files would show neither). Don't dump every record into chat — link to `/collections/portfolio`.
 
-**Update shares**: `getItems` with `ids: ["<id>"]`, change `shares`, `putItems`. Preserve other fields.
+**Update shares**: `putItems` with `mode: "merge"` and `{ "id": "<id>", "shares": <n> }` — merge keeps the fields the row omits.
 
 **Refresh prices**: don't touch the portfolio records — go refresh the matching row in `stock-quotes` instead. The portfolio's `price` and `value` columns update on the next render.
 

--- a/server/workspace/helps/vocabulary.md
+++ b/server/workspace/helps/vocabulary.md
@@ -76,9 +76,9 @@ collection. Keep it short — the schema does the heavy lifting. It should cover
   - **List** — getItems (it includes the host-computed `mastered` value);
     rather than dumping every word into chat, point the user at
     `/collections/vocabulary`.
-  - **Update proficiency** — getItems with `ids` → change `proficiency` →
-    putItems.
-  - **Edit** — same getItems → change → putItems (preserve the other fields).
+  - **Update proficiency** — putItems with `mode: "merge"` and
+    `{ id, proficiency }` (merge keeps the fields the row omits).
+  - **Edit** — same: putItems `mode: "merge"` with just the changed fields.
   - **Delete** — remove the JSON file.
 - After any change, call `presentCollection` with slug `vocabulary` (and the
   record id) to render the result inline.

--- a/server/workspace/helps/vocabulary.md
+++ b/server/workspace/helps/vocabulary.md
@@ -69,13 +69,16 @@ collection. Keep it short — the schema does the heavy lifting. It should cover
 - **Record shape** — point at the schema; note `id` is the filename
   (`word-<slug>` or `word-<unix-ms>`), `proficiency` starts at `"new"`, and
   `mastered` is host-computed (never write it directly).
-- **Operations** — all I/O is plain Read / Write / Edit on
-  `data/vocabulary/items/<id>.json`, one record per file:
-  - **Add** — generate an id, set `proficiency` to `"new"`, Write the JSON.
-  - **List** — read the items dir; rather than dumping every word into chat,
-    point the user at `/collections/vocabulary`.
-  - **Update proficiency** — Read → change `proficiency` → Write.
-  - **Edit** — Read → change → Write (preserve the other fields).
+- **Operations** — record I/O via `manageCollection` (raw Read / Write / Edit
+  on `data/vocabulary/items/<id>.json` is the escape hatch):
+  - **Add** — generate an id, set `proficiency` to `"new"`, putItems with
+    `mode: "create"`.
+  - **List** — getItems (it includes the host-computed `mastered` value);
+    rather than dumping every word into chat, point the user at
+    `/collections/vocabulary`.
+  - **Update proficiency** — getItems with `ids` → change `proficiency` →
+    putItems.
+  - **Edit** — same getItems → change → putItems (preserve the other fields).
   - **Delete** — remove the JSON file.
 - After any change, call `presentCollection` with slug `vocabulary` (and the
   record id) to render the result inline.

--- a/src/composables/collections/useCollectionRendering.ts
+++ b/src/composables/collections/useCollectionRendering.ts
@@ -12,7 +12,7 @@ import { apiGet } from "../../utils/api";
 import { API_ROUTES } from "../../config/apiRoutes";
 import { htmlPreviewUrlFor, svgPreviewUrlFor } from "../useContentDisplay";
 import { isValidFilePath } from "../useFileSelection";
-import { evaluateDerived, type FormulaContext } from "../../utils/collections/derivedFormula";
+import { deriveAll } from "../../utils/collections/deriveAll";
 import type { EmbedRow, EmbedView } from "../../components/collectionEmbed";
 import type {
   CollectionDetail,
@@ -280,34 +280,11 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return "text";
   }
 
-  function resolveRowRefs(schema: CollectionSchema, record: CollectionItem, refRecords: RefRecordCache): NonNullable<FormulaContext["refs"]> {
-    const refs: NonNullable<FormulaContext["refs"]> = {};
-    for (const [key, field] of Object.entries(schema.fields)) {
-      if (field.type !== "ref" || !field.to) continue;
-      const slug = record[key];
-      refs[key] = typeof slug === "string" ? (refRecords[field.to]?.[slug] ?? null) : null;
-    }
-    return refs;
-  }
-
-  function deriveAll(schema: CollectionSchema, base: CollectionItem, refRecords: RefRecordCache): CollectionItem {
-    const enriched: CollectionItem = { ...base };
-    const refs = resolveRowRefs(schema, base, refRecords);
-    const maxPasses = Object.values(schema.fields).filter((field) => field.type === "derived").length;
-    for (let pass = 0; pass < maxPasses; pass++) {
-      let mutated = false;
-      for (const [key, field] of Object.entries(schema.fields)) {
-        if (field.type !== "derived" || !field.formula) continue;
-        const next = evaluateDerived(field.formula, { record: enriched, refs });
-        if (next !== null && enriched[key] !== next) {
-          enriched[key] = next;
-          mutated = true;
-        }
-      }
-      if (!mutated) break;
-    }
-    return enriched;
-  }
+  // The derive loop itself lives in `utils/collections/deriveAll.ts`,
+  // shared with the server's manageCollection enrichment so both sides
+  // compute identical values. This composable re-exposes it (typed with
+  // the richer client types via structural assignability) plus the
+  // collection-bound convenience wrappers below.
 
   function evaluateDerivedAgainstItem(field: FieldSpec, fieldKey: string, item: CollectionItem): number | null {
     if (!field.formula || !collection.value) return null;

--- a/src/config/toolNames.ts
+++ b/src/config/toolNames.ts
@@ -61,9 +61,10 @@ const HOST_TOOL_NAMES = {
   readXPost: "readXPost",
   searchX: "searchX",
   notify: "notify",
-  // Generic host primitive — always active for every role (not gated
+  // Generic host primitives — always active for every role (not gated
   // by `availablePlugins`). See `McpTool.alwaysActive`.
   spawnBackgroundChat: "spawnBackgroundChat",
+  manageCollection: "manageCollection",
 
   // Preset runtime plugins (`server/plugins/preset-list.ts`).
   // Their `toolName` comes from the plugin package's

--- a/src/utils/collections/deriveAll.ts
+++ b/src/utils/collections/deriveAll.ts
@@ -53,10 +53,18 @@ export function resolveRowRefs(schema: DerivableSchema, record: DerivableRecord,
  *  pass (`subtotal → tax → total` converges in ≤ field-count passes).
  *  Cycles can't loop forever — passes are bounded by the number of
  *  derived fields and the loop breaks as soon as a pass changes
- *  nothing. Failed formulas stay absent/null (the UI renders them as
- *  em-dash). Returns a copy; `base` is never mutated. */
+ *  nothing. Failed formulas stay ABSENT (the UI renders them as
+ *  em-dash). Returns a copy; `base` is never mutated.
+ *
+ *  Derived keys already present in `base` are stripped before
+ *  evaluation: computed output is host-truth, never persisted-input
+ *  fallback. A record JSON can carry a stale (or forged) derived value
+ *  — raw Write/Edit, legacy data — and without the strip, a failing
+ *  formula would silently surface that value as if the host computed
+ *  it. */
 export function deriveAll(schema: DerivableSchema, base: DerivableRecord, refRecords: DeriveRefRecords): DerivableRecord {
-  const enriched: DerivableRecord = { ...base };
+  const derivedKeys = new Set(Object.keys(schema.fields).filter((key) => schema.fields[key]?.type === "derived"));
+  const enriched: DerivableRecord = Object.fromEntries(Object.entries(base).filter(([key]) => !derivedKeys.has(key)));
   const refs = resolveRowRefs(schema, base, refRecords);
   const maxPasses = Object.values(schema.fields).filter((field) => field.type === "derived").length;
   for (let pass = 0; pass < maxPasses; pass++) {

--- a/src/utils/collections/deriveAll.ts
+++ b/src/utils/collections/deriveAll.ts
@@ -1,0 +1,75 @@
+// The derived-field saturation loop for schema-driven collections,
+// extracted from `composables/collections/useCollectionRendering.ts` so
+// the server (manageCollection getItems enrichment) and the client
+// (table cells, form display) evaluate formulas through ONE
+// implementation — if the two ever diverged, the UI and the LLM would
+// disagree on a number. Pure module: no Vue, no I/O.
+//
+// Like `actionVisible.ts`, the input types are minimal structural
+// shapes so both the client `FieldSpec`/`CollectionSchema`
+// (src/components/collectionTypes.ts) and the server
+// `CollectionFieldSpec`/`CollectionSchema`
+// (server/workspace/collections/types.ts) satisfy them as-is.
+
+import { evaluateDerived, type FormulaContext } from "./derivedFormula";
+
+/** Minimal field shape the derive loop needs — accepts both the client
+ *  FieldSpec and the server CollectionFieldSpec. */
+export interface DerivableFieldSpec {
+  type: string;
+  /** When type === "ref": slug of the target collection. */
+  to?: string;
+  /** When type === "derived": formula evaluated against the record. */
+  formula?: string;
+}
+
+/** Minimal schema shape: just the ordered field map. */
+export interface DerivableSchema {
+  fields: Record<string, DerivableFieldSpec>;
+}
+
+export type DerivableRecord = Record<string, unknown>;
+
+/** Per-target-collection cache of loaded referenced records:
+ *  target collection slug → item slug → full record. Mirrors the
+ *  client's `RefRecordCache` / the server's enrichment loader. */
+export type DeriveRefRecords = Record<string, Record<string, DerivableRecord>>;
+
+/** Map each `ref` field's stored slug to its loaded target record (or
+ *  null when dangling / not loaded), keyed by the LOCAL field name —
+ *  the shape `evaluateDerived` reads for `<field>.<col>` derefs. */
+export function resolveRowRefs(schema: DerivableSchema, record: DerivableRecord, refRecords: DeriveRefRecords): NonNullable<FormulaContext["refs"]> {
+  const refs: NonNullable<FormulaContext["refs"]> = {};
+  for (const [key, field] of Object.entries(schema.fields)) {
+    if (field.type !== "ref" || !field.to) continue;
+    const slug = record[key];
+    refs[key] = typeof slug === "string" ? (refRecords[field.to]?.[slug] ?? null) : null;
+  }
+  return refs;
+}
+
+/** Evaluate every `derived` field against `base`, saturating so a
+ *  derived field can read another derived field computed in an earlier
+ *  pass (`subtotal → tax → total` converges in ≤ field-count passes).
+ *  Cycles can't loop forever — passes are bounded by the number of
+ *  derived fields and the loop breaks as soon as a pass changes
+ *  nothing. Failed formulas stay absent/null (the UI renders them as
+ *  em-dash). Returns a copy; `base` is never mutated. */
+export function deriveAll(schema: DerivableSchema, base: DerivableRecord, refRecords: DeriveRefRecords): DerivableRecord {
+  const enriched: DerivableRecord = { ...base };
+  const refs = resolveRowRefs(schema, base, refRecords);
+  const maxPasses = Object.values(schema.fields).filter((field) => field.type === "derived").length;
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let mutated = false;
+    for (const [key, field] of Object.entries(schema.fields)) {
+      if (field.type !== "derived" || !field.formula) continue;
+      const next = evaluateDerived(field.formula, { record: enriched, refs });
+      if (next !== null && enriched[key] !== next) {
+        enriched[key] = next;
+        mutated = true;
+      }
+    }
+    if (!mutated) break;
+  }
+  return enriched;
+}

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -1,0 +1,201 @@
+// `manageCollection` MCP tool: getItems returns computed-enriched
+// records with ids/fields selection and the unselective-size refusal;
+// putItems gates every row on schema validation (and computed-key
+// rejection) BEFORE writing, with per-row accept/reject results.
+// Exercised against a real tmpdir workspace via the factory's injected
+// DiscoveryOptions — no mocking of the collections layer, so the test
+// pins the same code paths production runs.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { makeManageCollectionTool, MAX_UNSELECTIVE_ITEMS } from "../../server/agent/mcp-tools/manageCollection.js";
+import { mcpTools } from "../../server/agent/mcp-tools/index.js";
+
+let workdir: string;
+let emptyUserDir: string;
+let tool: ReturnType<typeof makeManageCollectionTool>;
+
+const quotesSchema = {
+  title: "Stock Quotes",
+  icon: "trending_up",
+  dataPath: "data/stock-quotes/items",
+  primaryKey: "symbol",
+  fields: {
+    symbol: { type: "string", label: "Symbol", primary: true, required: true },
+    price: { type: "number", label: "Price" },
+  },
+};
+
+const portfolioSchema = {
+  title: "Portfolio",
+  icon: "work",
+  dataPath: "data/portfolio/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name", required: true },
+    ticker: { type: "ref", label: "Ticker", to: "stock-quotes" },
+    shares: { type: "number", label: "Shares" },
+    value: { type: "derived", label: "Value", formula: "shares * ticker.price" },
+    status: { type: "enum", label: "Status", values: ["open", "closed"] },
+    closed: { type: "toggle", label: "Closed", field: "status", onValue: "closed", offValue: "open" },
+  },
+};
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "manage-collection-"));
+  emptyUserDir = mkdtempSync(path.join(tmpdir(), "manage-collection-user-"));
+  tool = makeManageCollectionTool({ workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+  writeSkill("stock-quotes", quotesSchema);
+  writeSkill("portfolio", portfolioSchema);
+  writeRecord("data/stock-quotes/items", "aapl", { symbol: "aapl", price: 200 });
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(emptyUserDir, { recursive: true, force: true });
+});
+
+function writeSkill(slug: string, schema: object): void {
+  const dir = path.join(workdir, ".claude/skills", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${slug}\ndescription: test fixture\n---\nbody\n`);
+  writeFileSync(path.join(dir, "schema.json"), JSON.stringify(schema));
+}
+
+function writeRecord(dataPath: string, itemId: string, record: object): void {
+  const dir = path.join(workdir, dataPath);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, `${itemId}.json`), JSON.stringify(record));
+}
+
+const run = (args: Record<string, unknown>) => tool.handler(args);
+const runJson = async (args: Record<string, unknown>) => JSON.parse(await run(args)) as Record<string, unknown>;
+
+describe("manageCollection — argument validation", () => {
+  it("requires slug and a known action", async () => {
+    assert.match(await run({ action: "getItems" }), /`slug` is required/);
+    assert.match(await run({ action: "destroy", slug: "portfolio" }), /`action` must be/);
+  });
+
+  it("reports an unknown collection", async () => {
+    assert.match(await run({ action: "getItems", slug: "nope" }), /unknown collection 'nope'/);
+  });
+
+  it("rejects malformed ids / fields / items / mode", async () => {
+    assert.match(await run({ action: "getItems", slug: "portfolio", ids: [42] }), /`ids` must be an array/);
+    assert.match(await run({ action: "getItems", slug: "portfolio", fields: "name" }), /`fields` must be an array/);
+    assert.match(await run({ action: "putItems", slug: "portfolio" }), /`items` is required/);
+    assert.match(await run({ action: "putItems", slug: "portfolio", items: [[1]] }), /`items` is required/);
+    assert.match(await run({ action: "putItems", slug: "portfolio", items: [{ id: "a" }], mode: "merge" }), /`mode` must be/);
+  });
+
+  it("is registered as an alwaysActive MCP tool", () => {
+    const registered = mcpTools.find((entry) => entry.definition.name === "manageCollection");
+    assert.ok(registered, "manageCollection must be in the mcpTools array");
+    assert.equal(registered.alwaysActive, true);
+  });
+});
+
+describe("manageCollection — getItems", () => {
+  beforeEach(() => {
+    writeRecord("data/portfolio/items", "h1", { id: "h1", name: "Apple", ticker: "aapl", shares: 10, status: "open" });
+    writeRecord("data/portfolio/items", "h2", { id: "h2", name: "Cash", status: "closed" });
+  });
+
+  it("returns records enriched with derived + toggle values", async () => {
+    const result = await runJson({ action: "getItems", slug: "portfolio" });
+    assert.equal(result.count, 2);
+    const items = result.items as Record<string, unknown>[];
+    const apple = items.find((item) => item.id === "h1");
+    const cash = items.find((item) => item.id === "h2");
+    assert.equal(apple?.value, 2000); // 10 * 200, host-computed
+    assert.equal(apple?.closed, false);
+    assert.equal(cash?.closed, true);
+  });
+
+  it("selects by ids and reports missing ones", async () => {
+    const result = await runJson({ action: "getItems", slug: "portfolio", ids: ["h1", "ghost"] });
+    assert.equal(result.count, 1);
+    assert.deepEqual(result.missing, ["ghost"]);
+  });
+
+  it("projects fields, always keeping the primary key", async () => {
+    const result = await runJson({ action: "getItems", slug: "portfolio", ids: ["h1"], fields: ["value"] });
+    const [item] = result.items as Record<string, unknown>[];
+    assert.deepEqual(item, { id: "h1", value: 2000 });
+  });
+
+  it("appends a defanged warning for malformed record files", async () => {
+    writeFileSync(path.join(workdir, "data/portfolio/items/bad.json"), '{ "id": "bad", broken');
+    const result = await runJson({ action: "getItems", slug: "portfolio" });
+    assert.match(String(result.warning), /bad\.json/);
+    assert.match(String(result.warning), /1 record file/);
+  });
+
+  it("refuses an unselective read over the limit, lifted by fields", async () => {
+    for (let i = 0; i < MAX_UNSELECTIVE_ITEMS + 1; i++) {
+      writeRecord("data/portfolio/items", `r${i}`, { id: `r${i}`, name: `R${i}` });
+    }
+    assert.match(await run({ action: "getItems", slug: "portfolio" }), /over the unselective limit/);
+    const projected = await runJson({ action: "getItems", slug: "portfolio", fields: ["name"] });
+    assert.equal(projected.count, MAX_UNSELECTIVE_ITEMS + 3);
+  });
+});
+
+describe("manageCollection — putItems", () => {
+  const record = (itemId: string, extra: Record<string, unknown> = {}) => ({ id: itemId, name: `Name ${itemId}`, status: "open", ...extra });
+  const stored = (itemId: string) => JSON.parse(readFileSync(path.join(workdir, `data/portfolio/items/${itemId}.json`), "utf-8")) as Record<string, unknown>;
+
+  it("writes valid rows and rejects invalid rows independently", async () => {
+    const result = await runJson({
+      action: "putItems",
+      slug: "portfolio",
+      items: [record("good"), { id: "noname", status: "open" }, record("badenum", { status: "nope" })],
+    });
+    assert.deepEqual(result.written, ["good"]);
+    const rejected = result.rejected as { id: string; problem: string }[];
+    assert.equal(rejected.length, 2);
+    assert.match(rejected.find((row) => row.id === "noname")?.problem ?? "", /missing required field 'name'/);
+    assert.match(rejected.find((row) => row.id === "badenum")?.problem ?? "", /not one of/);
+    assert.deepEqual(stored("good"), record("good"));
+    assert.ok(!existsSync(path.join(workdir, "data/portfolio/items/noname.json")), "rejected row must not be written");
+  });
+
+  it("rejects a row with no primaryKey value", async () => {
+    const result = await runJson({ action: "putItems", slug: "portfolio", items: [{ name: "No Id", status: "open" }] });
+    const [rejectedRow] = result.rejected as { id: string; problem: string }[];
+    assert.match(rejectedRow?.problem ?? "", /has no 'id' value/);
+  });
+
+  it("rejects computed keys with an actionable pointer", async () => {
+    const result = await runJson({
+      action: "putItems",
+      slug: "portfolio",
+      items: [record("a", { value: 999 }), record("b", { closed: true })],
+    });
+    const rejected = result.rejected as { id: string; problem: string }[];
+    assert.match(rejected.find((row) => row.id === "a")?.problem ?? "", /'value' is derived/);
+    assert.match(rejected.find((row) => row.id === "b")?.problem ?? "", /write the enum field 'status' instead/);
+    assert.deepEqual(result.written, []);
+  });
+
+  it("rejects path-shaped ids before any write", async () => {
+    const result = await runJson({ action: "putItems", slug: "portfolio", items: [record("../evil")] });
+    const [rejectedRow] = result.rejected as { id: string; problem: string }[];
+    assert.match(rejectedRow?.problem ?? "", /not a valid record id/);
+  });
+
+  it('mode "create" refuses an existing id; default upsert overwrites', async () => {
+    writeRecord("data/portfolio/items", "h1", record("h1"));
+    const created = await runJson({ action: "putItems", slug: "portfolio", items: [record("h1")], mode: "create" });
+    assert.match((created.rejected as { problem: string }[])[0]?.problem ?? "", /already exists/);
+    const upserted = await runJson({ action: "putItems", slug: "portfolio", items: [record("h1", { shares: 5 })] });
+    assert.deepEqual(upserted.written, ["h1"]);
+    assert.equal(stored("h1").shares, 5);
+  });
+});

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -43,6 +43,19 @@ const portfolioSchema = {
     value: { type: "derived", label: "Value", formula: "shares * ticker.price" },
     status: { type: "enum", label: "Status", values: ["open", "closed"] },
     closed: { type: "toggle", label: "Closed", field: "status", onValue: "closed", offValue: "open" },
+    owner: { type: "embed", label: "Owner", to: "profile", id: "me" },
+  },
+};
+
+const profileSchema = {
+  title: "Profile",
+  icon: "person",
+  dataPath: "data/profile/items",
+  primaryKey: "id",
+  singleton: "me",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name" },
   },
 };
 
@@ -52,7 +65,9 @@ beforeEach(() => {
   tool = makeManageCollectionTool({ workspaceRoot: workdir, userSkillsDir: emptyUserDir });
   writeSkill("stock-quotes", quotesSchema);
   writeSkill("portfolio", portfolioSchema);
+  writeSkill("profile", profileSchema);
   writeRecord("data/stock-quotes/items", "aapl", { symbol: "aapl", price: 200 });
+  writeRecord("data/profile/items", "me", { id: "me", name: "Satoshi" });
 });
 
 afterEach(() => {
@@ -124,6 +139,23 @@ describe("manageCollection — getItems", () => {
     assert.deepEqual(result.missing, ["ghost"]);
   });
 
+  it("resolves embed fields to the target record, null when missing", async () => {
+    const withProfile = await runJson({ action: "getItems", slug: "portfolio", ids: ["h1"] });
+    const [item] = withProfile.items as Record<string, unknown>[];
+    assert.deepEqual(item?.owner, { id: "me", name: "Satoshi" });
+    rmSync(path.join(workdir, "data/profile/items/me.json"), { force: true });
+    const withoutProfile = await runJson({ action: "getItems", slug: "portfolio", ids: ["h1"] });
+    const [bare] = withoutProfile.items as Record<string, unknown>[];
+    assert.equal(bare?.owner, null);
+  });
+
+  it("a stale stored derived value never reaches the result", async () => {
+    writeRecord("data/portfolio/items", "h9", { id: "h9", name: "Forged", ticker: "ghost", shares: 10, value: 999, status: "open" });
+    const result = await runJson({ action: "getItems", slug: "portfolio", ids: ["h9"] });
+    const [item] = result.items as Record<string, unknown>[];
+    assert.equal(item?.value, undefined); // formula fails (dangling ref) → absent, not 999
+  });
+
   it("projects fields, always keeping the primary key", async () => {
     const result = await runJson({ action: "getItems", slug: "portfolio", ids: ["h1"], fields: ["value"] });
     const [item] = result.items as Record<string, unknown>[];
@@ -135,6 +167,16 @@ describe("manageCollection — getItems", () => {
     const result = await runJson({ action: "getItems", slug: "portfolio" });
     assert.match(String(result.warning), /bad\.json/);
     assert.match(String(result.warning), /1 record file/);
+  });
+
+  it("skips the warning scan on a selective read that found everything", async () => {
+    writeFileSync(path.join(workdir, "data/portfolio/items/bad.json"), '{ "id": "bad", broken');
+    const found = await runJson({ action: "getItems", slug: "portfolio", ids: ["h1"] });
+    assert.equal(found.warning, undefined); // all requested ids present → no full scan
+    // A requested id that comes back missing IS explained by the scan.
+    const missed = await runJson({ action: "getItems", slug: "portfolio", ids: ["bad"] });
+    assert.deepEqual(missed.missing, ["bad"]);
+    assert.match(String(missed.warning), /bad\.json/);
   });
 
   it("refuses an unselective read over the limit, lifted by fields", async () => {
@@ -182,6 +224,8 @@ describe("manageCollection — putItems", () => {
     assert.match(rejected.find((row) => row.id === "a")?.problem ?? "", /'value' is derived/);
     assert.match(rejected.find((row) => row.id === "b")?.problem ?? "", /write the enum field 'status' instead/);
     assert.deepEqual(result.written, []);
+    const embed = await runJson({ action: "putItems", slug: "portfolio", items: [record("c", { owner: { id: "me" } })] });
+    assert.match((embed.rejected as { problem: string }[])[0]?.problem ?? "", /'owner' is an embed/);
   });
 
   it("rejects path-shaped ids before any write", async () => {
@@ -223,6 +267,18 @@ describe("manageCollection — putItems", () => {
     const [rejectedRow] = result.rejected as { id: string; problem: string }[];
     assert.match(rejectedRow?.problem ?? "", /not found .* use "upsert" or "create"/);
     assert.ok(!existsSync(path.join(workdir, "data/portfolio/items/ghost.json")));
+  });
+
+  it('mode "merge" heals a stale computed key in the stored record', async () => {
+    // Raw-written/legacy record carrying a forged host-computed value:
+    // a merge must not re-write it.
+    writeRecord("data/portfolio/items", "h1", record("h1", { value: 999, notes: "keep me" }));
+    const merged = await runJson({ action: "putItems", slug: "portfolio", items: [{ id: "h1", status: "closed" }], mode: "merge" });
+    assert.deepEqual(merged.written, ["h1"]);
+    const healed = stored("h1");
+    assert.ok(!("value" in healed), "stale derived key must be stripped on merge");
+    assert.equal(healed.notes, "keep me");
+    assert.equal(healed.status, "closed");
   });
 
   it('mode "merge" still validates the merged result and rejects computed keys', async () => {

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -91,7 +91,7 @@ describe("manageCollection — argument validation", () => {
     assert.match(await run({ action: "getItems", slug: "portfolio", fields: "name" }), /`fields` must be an array/);
     assert.match(await run({ action: "putItems", slug: "portfolio" }), /`items` is required/);
     assert.match(await run({ action: "putItems", slug: "portfolio", items: [[1]] }), /`items` is required/);
-    assert.match(await run({ action: "putItems", slug: "portfolio", items: [{ id: "a" }], mode: "merge" }), /`mode` must be/);
+    assert.match(await run({ action: "putItems", slug: "portfolio", items: [{ id: "a" }], mode: "replace" }), /`mode` must be/);
   });
 
   it("is registered as an alwaysActive MCP tool", () => {
@@ -197,5 +197,40 @@ describe("manageCollection — putItems", () => {
     const upserted = await runJson({ action: "putItems", slug: "portfolio", items: [record("h1", { shares: 5 })] });
     assert.deepEqual(upserted.written, ["h1"]);
     assert.equal(stored("h1").shares, 5);
+  });
+
+  it('mode "merge" updates only the carried fields, keeping the rest', async () => {
+    writeRecord("data/portfolio/items", "h1", record("h1", { ticker: "aapl", shares: 10, notes: "keep me" }));
+    const merged = await runJson({ action: "putItems", slug: "portfolio", items: [{ id: "h1", status: "closed" }], mode: "merge" });
+    assert.deepEqual(merged.written, ["h1"]);
+    // The partial row changed status; everything it omitted survives.
+    assert.deepEqual(stored("h1"), record("h1", { ticker: "aapl", shares: 10, notes: "keep me", status: "closed" }));
+  });
+
+  it("the same partial row under default upsert documents the hazard merge prevents", async () => {
+    // A partial upsert passes validation only when every REQUIRED field
+    // is carried — here it isn't, so validation already rejects it. With
+    // name carried it would write and erase the optionals; merge is the
+    // safe path for partial updates either way.
+    writeRecord("data/portfolio/items", "h1", record("h1", { notes: "keep me" }));
+    const partial = await runJson({ action: "putItems", slug: "portfolio", items: [{ id: "h1", status: "closed" }] });
+    assert.match((partial.rejected as { problem: string }[])[0]?.problem ?? "", /missing required field 'name'/);
+    assert.equal(stored("h1").notes, "keep me");
+  });
+
+  it('mode "merge" rejects an unknown id instead of creating a partial record', async () => {
+    const result = await runJson({ action: "putItems", slug: "portfolio", items: [{ id: "ghost", status: "open" }], mode: "merge" });
+    const [rejectedRow] = result.rejected as { id: string; problem: string }[];
+    assert.match(rejectedRow?.problem ?? "", /not found .* use "upsert" or "create"/);
+    assert.ok(!existsSync(path.join(workdir, "data/portfolio/items/ghost.json")));
+  });
+
+  it('mode "merge" still validates the merged result and rejects computed keys', async () => {
+    writeRecord("data/portfolio/items", "h1", record("h1", { notes: "keep me" }));
+    const badEnum = await runJson({ action: "putItems", slug: "portfolio", items: [{ id: "h1", status: "nope" }], mode: "merge" });
+    assert.match((badEnum.rejected as { problem: string }[])[0]?.problem ?? "", /not one of/);
+    assert.equal(stored("h1").status, "open"); // untouched
+    const computed = await runJson({ action: "putItems", slug: "portfolio", items: [{ id: "h1", value: 1 }], mode: "merge" });
+    assert.match((computed.rejected as { problem: string }[])[0]?.problem ?? "", /'value' is derived/);
   });
 });

--- a/test/utils/collections/test_deriveAll.ts
+++ b/test/utils/collections/test_deriveAll.ts
@@ -1,0 +1,105 @@
+// Unit tests for the shared derived-field saturation loop
+// (src/utils/collections/deriveAll.ts) — the one implementation the
+// client rendering layer AND the server's manageCollection enrichment
+// both call, so its convergence/cycle/ref semantics are pinned here.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { deriveAll, resolveRowRefs, type DerivableSchema } from "../../../src/utils/collections/deriveAll.js";
+
+const field = (type: string, extra: Record<string, unknown> = {}) => ({ type, ...extra });
+
+describe("deriveAll — saturation across chained derived fields", () => {
+  // total reads tax reads subtotal: declaration order is reversed on
+  // purpose so convergence REQUIRES multiple passes.
+  const schema: DerivableSchema = {
+    fields: {
+      total: field("derived", { formula: "subtotal + tax" }),
+      tax: field("derived", { formula: "subtotal * taxRate" }),
+      subtotal: field("derived", { formula: "sum(lineItems[].quantity * lineItems[].rate)" }),
+      taxRate: field("number"),
+      lineItems: field("table"),
+    },
+  };
+
+  it("converges within field-count passes regardless of declaration order", () => {
+    const enriched = deriveAll(
+      schema,
+      {
+        taxRate: 0.1,
+        lineItems: [
+          { quantity: 10, rate: 100 },
+          { quantity: 2, rate: 250 },
+        ],
+      },
+      {},
+    );
+    assert.equal(enriched.subtotal, 1500);
+    assert.equal(enriched.tax, 150);
+    assert.equal(enriched.total, 1650);
+  });
+
+  it("does not mutate the base record", () => {
+    const base = { taxRate: 0.1, lineItems: [{ quantity: 1, rate: 100 }] };
+    deriveAll(schema, base, {});
+    assert.deepEqual(base, { taxRate: 0.1, lineItems: [{ quantity: 1, rate: 100 }] });
+  });
+
+  it("leaves a failed formula absent instead of poisoning siblings", () => {
+    // No taxRate: `tax` (and so `total`) can never evaluate, but
+    // `subtotal` still does — a failure stays local to its field.
+    const enriched = deriveAll(schema, { lineItems: [{ quantity: 1, rate: 100 }] }, {});
+    assert.equal(enriched.subtotal, 100);
+    assert.equal(enriched.tax, undefined);
+    assert.equal(enriched.total, undefined);
+  });
+});
+
+describe("deriveAll — cycles", () => {
+  it("saturates without looping on a 2-cycle", () => {
+    const schema: DerivableSchema = {
+      fields: {
+        a: field("derived", { formula: "b + 1" }),
+        b: field("derived", { formula: "a + 1" }),
+      },
+    };
+    // Bounded passes (= derived-field count); values climb once per pass
+    // then the loop exits. The exact values don't matter — termination
+    // and "no throw" do.
+    const enriched = deriveAll(schema, {}, {});
+    assert.ok(!("a" in enriched) || typeof enriched.a === "number");
+  });
+});
+
+describe("deriveAll + resolveRowRefs — cross-collection deref", () => {
+  const schema: DerivableSchema = {
+    fields: {
+      ticker: field("ref", { to: "stock-quotes" }),
+      shares: field("number"),
+      value: field("derived", { formula: "shares * ticker.price" }),
+    },
+  };
+  const refRecords = { "stock-quotes": { aapl: { symbol: "aapl", price: 200 } } };
+
+  it("evaluates shares * ticker.price through the ref cache", () => {
+    const enriched = deriveAll(schema, { ticker: "aapl", shares: 10 }, refRecords);
+    assert.equal(enriched.value, 2000);
+  });
+
+  it("dangling ref slug yields no derived value", () => {
+    const enriched = deriveAll(schema, { ticker: "msft", shares: 10 }, refRecords);
+    assert.equal(enriched.value, undefined);
+  });
+
+  it("missing target collection yields no derived value", () => {
+    const enriched = deriveAll(schema, { ticker: "aapl", shares: 10 }, {});
+    assert.equal(enriched.value, undefined);
+  });
+
+  it("resolveRowRefs keys by LOCAL field name and nulls non-string slugs", () => {
+    const refs = resolveRowRefs(schema, { ticker: "aapl", shares: 10 }, refRecords);
+    assert.deepEqual(refs, { ticker: { symbol: "aapl", price: 200 } });
+    assert.deepEqual(resolveRowRefs(schema, { ticker: 42 }, refRecords), { ticker: null });
+  });
+});

--- a/test/utils/collections/test_deriveAll.ts
+++ b/test/utils/collections/test_deriveAll.ts
@@ -56,6 +56,30 @@ describe("deriveAll — saturation across chained derived fields", () => {
   });
 });
 
+describe("deriveAll — persisted derived values are never trusted", () => {
+  const schema: DerivableSchema = {
+    fields: {
+      ticker: field("ref", { to: "stock-quotes" }),
+      shares: field("number"),
+      value: field("derived", { formula: "shares * ticker.price" }),
+    },
+  };
+
+  it("a stale stored value is stripped when the formula fails (dangling ref)", () => {
+    // The record carries value: 999 (raw Write / legacy data); the
+    // formula can't evaluate. The stale value must NOT survive as if
+    // host-computed.
+    const enriched = deriveAll(schema, { ticker: "ghost", shares: 10, value: 999 }, {});
+    assert.equal(enriched.value, undefined);
+  });
+
+  it("a stale stored value is replaced when the formula succeeds", () => {
+    const refRecords = { "stock-quotes": { aapl: { price: 200 } } };
+    const enriched = deriveAll(schema, { ticker: "aapl", shares: 10, value: 999 }, refRecords);
+    assert.equal(enriched.value, 2000);
+  });
+});
+
 describe("deriveAll — cycles", () => {
   it("saturates without looping on a 2-cycle", () => {
     const schema: DerivableSchema = {

--- a/test/workspace/collections/test_derive.ts
+++ b/test/workspace/collections/test_derive.ts
@@ -1,0 +1,170 @@
+// Server-side computed-field enrichment (collections/derive.ts):
+// derived formulas evaluated through the SHARED deriveAll loop with
+// ref targets loaded from disk, toggles projected off their enum, and
+// embeds resolved to the fixed target record. Exercised against real
+// on-disk collections (workspaceRoot + userSkillsDir overrides — same
+// isolation pattern as test_discovery.ts).
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { ref } from "vue";
+
+import { enrichItems } from "../../../server/workspace/collections/derive.js";
+import { loadCollection, toDetail } from "../../../server/workspace/collections/discovery.js";
+import { useCollectionRendering } from "../../../src/composables/collections/useCollectionRendering.js";
+import { deriveAll } from "../../../src/utils/collections/deriveAll.js";
+import type { CollectionDetail, FieldSpec } from "../../../src/components/collectionTypes.js";
+
+let workdir: string;
+let emptyUserDir: string;
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "collections-derive-"));
+  emptyUserDir = mkdtempSync(path.join(tmpdir(), "collections-derive-user-"));
+});
+
+afterEach(() => {
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(emptyUserDir, { recursive: true, force: true });
+});
+
+const opts = () => ({ workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+
+function writeSkill(slug: string, schema: object): void {
+  const dir = path.join(workdir, ".claude/skills", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${slug}\ndescription: test fixture\n---\nbody\n`);
+  writeFileSync(path.join(dir, "schema.json"), JSON.stringify(schema));
+}
+
+function writeRecord(dataPath: string, itemId: string, record: object): void {
+  const dir = path.join(workdir, dataPath);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, `${itemId}.json`), JSON.stringify(record));
+}
+
+const quotesSchema = {
+  title: "Stock Quotes",
+  icon: "trending_up",
+  dataPath: "data/stock-quotes/items",
+  primaryKey: "symbol",
+  fields: {
+    symbol: { type: "string", label: "Symbol", primary: true, required: true },
+    price: { type: "number", label: "Price" },
+    doubled: { type: "derived", label: "Doubled", formula: "price * 2" },
+  },
+};
+
+const portfolioSchema = {
+  title: "Portfolio",
+  icon: "work",
+  dataPath: "data/portfolio/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    ticker: { type: "ref", label: "Ticker", to: "stock-quotes" },
+    shares: { type: "number", label: "Shares" },
+    value: { type: "derived", label: "Value", formula: "shares * ticker.price" },
+    status: { type: "enum", label: "Status", values: ["open", "closed"] },
+    closed: { type: "toggle", label: "Closed", field: "status", onValue: "closed", offValue: "open" },
+    owner: { type: "embed", label: "Owner", to: "profile", id: "me" },
+  },
+};
+
+const profileSchema = {
+  title: "Profile",
+  icon: "person",
+  dataPath: "data/profile/items",
+  primaryKey: "id",
+  singleton: "me",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name" },
+  },
+};
+
+async function enrichPortfolio(items: Record<string, unknown>[]) {
+  const collection = await loadCollection("portfolio", opts());
+  assert.ok(collection, "portfolio collection must load");
+  return enrichItems(collection, items, opts());
+}
+
+describe("enrichItems — derived across refs", () => {
+  beforeEach(() => {
+    writeSkill("stock-quotes", quotesSchema);
+    writeSkill("portfolio", portfolioSchema);
+    writeSkill("profile", profileSchema);
+    writeRecord("data/stock-quotes/items", "aapl", { symbol: "aapl", price: 200 });
+    writeRecord("data/profile/items", "me", { id: "me", name: "Satoshi" });
+  });
+
+  it("evaluates shares * ticker.price from the on-disk target", async () => {
+    const [enriched] = await enrichPortfolio([{ id: "h1", ticker: "aapl", shares: 10, status: "open" }]);
+    assert.equal(enriched?.value, 2000);
+  });
+
+  it("ref targets are themselves derived first (mirrors the client's buildRefRecordMap)", async () => {
+    writeSkill("portfolio", {
+      ...portfolioSchema,
+      fields: { ...portfolioSchema.fields, value: { type: "derived", label: "Value", formula: "shares * ticker.doubled" } },
+    });
+    const [enriched] = await enrichPortfolio([{ id: "h1", ticker: "aapl", shares: 10 }]);
+    assert.equal(enriched?.value, 4000); // 10 * (200 * 2)
+  });
+
+  it("dangling ref slug leaves the derived field absent", async () => {
+    const [enriched] = await enrichPortfolio([{ id: "h1", ticker: "msft", shares: 10 }]);
+    assert.equal(enriched?.value, undefined);
+  });
+
+  it("missing target collection leaves the derived field absent", async () => {
+    rmSync(path.join(workdir, ".claude/skills/stock-quotes"), { recursive: true, force: true });
+    const [enriched] = await enrichPortfolio([{ id: "h1", ticker: "aapl", shares: 10 }]);
+    assert.equal(enriched?.value, undefined);
+  });
+
+  it("projects toggle fields off their enum", async () => {
+    const enriched = await enrichPortfolio([{ id: "h1", status: "closed" }, { id: "h2", status: "open" }, { id: "h3" }]);
+    assert.equal(enriched[0]?.closed, true);
+    assert.equal(enriched[1]?.closed, false);
+    assert.equal(enriched[2]?.closed, false);
+  });
+
+  it("resolves embed fields to the fixed target record, null when missing", async () => {
+    const [withProfile] = await enrichPortfolio([{ id: "h1" }]);
+    assert.deepEqual(withProfile?.owner, { id: "me", name: "Satoshi" });
+    rmSync(path.join(workdir, "data/profile/items/me.json"), { force: true });
+    const [withoutProfile] = await enrichPortfolio([{ id: "h1" }]);
+    assert.equal(withoutProfile?.owner, null);
+  });
+
+  it("does not mutate the input records", async () => {
+    const input = { id: "h1", ticker: "aapl", shares: 10 };
+    await enrichPortfolio([input]);
+    assert.deepEqual(input, { id: "h1", ticker: "aapl", shares: 10 });
+  });
+
+  it("matches the client rendering path exactly (determinism cross-check)", async () => {
+    const collection = await loadCollection("portfolio", opts());
+    assert.ok(collection);
+    const item = { id: "h1", ticker: "aapl", shares: 10 };
+    const [server] = await enrichItems(collection, [item], opts());
+
+    // Client path: the composable with its ref cache primed the way
+    // `loadLinkedCollections` would prime it from the detail endpoint.
+    const detail = toDetail(collection) as unknown as CollectionDetail;
+    const rendering = useCollectionRendering(ref<CollectionDetail | null>(detail), ref("en"));
+    rendering.refRecordCache.value = { "stock-quotes": { aapl: { symbol: "aapl", price: 200 } } };
+    const valueField = detail.schema.fields.value as FieldSpec;
+    const clientValue = rendering.evaluateDerivedAgainstItem(valueField, "value", item);
+
+    assert.equal(server?.value, 2000);
+    assert.equal(clientValue, server?.value);
+    // Stronger than value equality: both sides hold the SAME function.
+    assert.equal(rendering.deriveAll, deriveAll);
+  });
+});

--- a/test/workspace/collections/test_derive.ts
+++ b/test/workspace/collections/test_derive.ts
@@ -121,6 +121,14 @@ describe("enrichItems — derived across refs", () => {
     assert.equal(enriched?.value, undefined);
   });
 
+  it("a stale stored derived value never survives enrichment", async () => {
+    // Raw-written/legacy record carrying value: 999 with a formula that
+    // can't evaluate (dangling ticker): the stale value must come back
+    // absent, not echoed as host-computed truth.
+    const [enriched] = await enrichPortfolio([{ id: "h1", ticker: "ghost", shares: 10, value: 999 }]);
+    assert.equal(enriched?.value, undefined);
+  });
+
   it("missing target collection leaves the derived field absent", async () => {
     rmSync(path.join(workdir, ".claude/skills/stock-quotes"), { recursive: true, force: true });
     const [enriched] = await enrichPortfolio([{ id: "h1", ticker: "aapl", shares: 10 }]);

--- a/test/workspace/collections/test_validate.ts
+++ b/test/workspace/collections/test_validate.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { validateCollectionRecords } from "../../../server/workspace/collections/validate.js";
+import { validateCollectionRecords, validateRecordObject } from "../../../server/workspace/collections/validate.js";
 import type { LoadedCollection } from "../../../server/workspace/collections/index.js";
 import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
 
@@ -107,5 +107,33 @@ describe("validateCollectionRecords", () => {
     writeFileSync(path.join(outside, "secret.json"), "42");
     assert.deepEqual(await validate(outside), []);
     rmSync(outside, { recursive: true, force: true });
+  });
+});
+
+describe("validateRecordObject — the write-gate variant", () => {
+  const check = (record: Record<string, unknown>, itemId: string) => validateRecordObject(record, itemId, schema);
+
+  it("accepts a record matching the schema", () => {
+    assert.equal(check({ id: "a", title: "A", status: "planned" }, "a"), null);
+  });
+
+  it("reports the same problems the file scan reports (parity)", async () => {
+    write("m.json", JSON.stringify({ id: "m", status: "planned" }));
+    const [scanIssue] = await validate();
+    assert.equal(check({ id: "m", status: "planned" }, "m"), scanIssue?.problem);
+  });
+
+  it("flags primaryKey ≠ itemId, missing required, bad enum", () => {
+    assert.match(check({ id: "other", title: "T", status: "done" }, "a") ?? "", /must equal the filename/);
+    assert.match(check({ id: "a", status: "done" }, "a") ?? "", /missing required field 'title'/);
+    assert.match(check({ id: "a", title: "T", status: "nope" }, "a") ?? "", /not one of/);
+  });
+
+  it("skips computed field types entirely", () => {
+    const withDerived = {
+      ...schema,
+      fields: { ...schema.fields, total: { type: "derived", label: "Total", formula: "1 + 1", required: true } },
+    } as unknown as CollectionSchema;
+    assert.equal(validateRecordObject({ id: "a", title: "T", status: "done" }, "a", withDerived), null);
   });
 });

--- a/test/workspace/collections/test_validate.ts
+++ b/test/workspace/collections/test_validate.ts
@@ -129,11 +129,18 @@ describe("validateRecordObject — the write-gate variant", () => {
     assert.match(check({ id: "a", title: "T", status: "nope" }, "a") ?? "", /not one of/);
   });
 
-  it("skips computed field types entirely", () => {
-    const withDerived = {
+  it("skips computed field types entirely (derived, embed, toggle)", () => {
+    // All three COMPUTED_TYPES marked required: a record carrying none
+    // of them must still validate — they're host-computed, never stored.
+    const withComputed = {
       ...schema,
-      fields: { ...schema.fields, total: { type: "derived", label: "Total", formula: "1 + 1", required: true } },
+      fields: {
+        ...schema.fields,
+        total: { type: "derived", label: "Total", formula: "1 + 1", required: true },
+        owner: { type: "embed", label: "Owner", to: "profile", id: "me", required: true },
+        done: { type: "toggle", label: "Done", field: "status", onValue: "done", offValue: "planned", required: true },
+      },
     } as unknown as CollectionSchema;
-    assert.equal(validateRecordObject({ id: "a", title: "T", status: "done" }, "a", withDerived), null);
+    assert.equal(validateRecordObject({ id: "a", title: "T", status: "done" }, "a", withComputed), null);
   });
 });


### PR DESCRIPTION
## Summary

Implements `plans/feat-manage-collection-tool.md` (merged in #1680). `manageCollection` is the agent's data plane for schema-driven collections — the paved road over the same record files raw Read/Write/Edit reach. It closes the two gaps the architecture review found: the runtime never saw host-computed values (derived/toggle/embed exist only in the browser at render time), and record validation was post-hoc advisory rather than a write gate.

### The tool (`alwaysActive` — every role, no `roles.ts` opt-in)

- **`getItems`** — records enriched with everything the host computes: `derived` formulas evaluated (cross-collection derefs included; ref targets derived first, mirroring the client), `toggle` projected, `embed` resolved. `ids`/`fields` selection for context economy; unselective reads over 200 records are refused with a "pass ids or fields" message (no silent truncation); malformed record files surface as a defanged warning instead of silently vanishing.
- **`putItems`** — each row validated **before** `writeItem` (primaryKey↔id, required fields, enum membership, computed-key rejection with a pointer at the toggle's enum). Per-row `{ written, rejected }` results so the model fixes rejects and retries just those. Modes: `upsert` (default, whole-record), `create` (O_EXCL, rejects existing ids), and `merge` — shallow-merge a partial row over the existing record, validate the merged result, reject unknown ids. Merge exists because a partial upsert carrying all required fields would pass validation yet silently erase the optional fields it omits (spotted in a live lessons-course session).

### How it's built

- The derive saturation loop is **extracted verbatim** from `useCollectionRendering` into `src/utils/collections/deriveAll.ts` (minimal structural types, `actionVisible`-style); the composable delegates. A test asserts client and server hold the **same function object**, not just equal behavior.
- Server enrichment (`server/workspace/collections/derive.ts`) loads each ref/embed target once per call. The per-record validator is exported from `validate.ts` (`validateRecordObject`) so the write gate enforces the same rules the repair-loop scan reports.
- No new I/O path: writes go through the existing `writeItem` (atomic, id-sanitized, containment-checked).

### Docs

Five help recipes migrated from "all I/O via Read/Write/Edit" to manageCollection-first (raw file I/O stays the escape hatch), with `mode: "merge"` recommended for partial updates — including the lessons background-worker rules. `docs/collections-architecture.md` gains one sentence: computed values now reach the runtime. New shared util cataloged in `docs/shared-utils.md`.

## Test plan

- `test/utils/collections/test_deriveAll.ts` — saturation across chained derived fields, cycle termination, ref deref, no input mutation.
- `test/workspace/collections/test_derive.ts` — `enrichItems` against real on-disk tmpdir collections (derived-through-ref, derived ref targets, dangling/missing targets, toggle, embed), plus the client/server determinism cross-check.
- `test/agent/test_manageCollection.ts` — 18 cases over the real collections layer: arg validation, enrichment, ids/fields selection, unselective cap, skipped-record warning, per-row accept/reject, computed-key + path-shaped-id rejection, create/upsert/merge semantics incl. the partial-upsert hazard pinned as a contrast case.
- `validateRecordObject` parity tests against the file-scan results.
- Full gates: 5050 unit + 86 package tests, 434 Playwright E2E, lint/typecheck/build all clean.
- Field-validated in a live session: a 10-lesson Japanese-localized course created via `putItems mode: "create"` (zero rejects, localized enum values, long `「」`-quoted objectives — the unescaped-quote JSON breakage class is structurally gone on this path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce the always-active `manageCollection` MCP tool to provide schema-validated read/write access to collections with host-computed fields, and centralize the derived-field evaluation logic for consistent client/server behavior.

New Features:
- Add the `manageCollection` MCP tool with `getItems` and `putItems` actions for schema-driven collections, including support for an upsert/create/merge write mode model.
- Expose a shared `deriveAll` utility and server-side `enrichItems` helper so collections can be enriched with derived, toggle, and embed fields on the server.

Enhancements:
- Export collection validation helpers, including `validateRecordObject` and `COMPUTED_TYPES`, so write paths can enforce the same rules as offline validation scans.
- Update host tool registration so `manageCollection` is always active for all roles, aligning it with other core workspace tools.
- Refactor client collection rendering to delegate derived-field evaluation to the new shared utility without changing behavior.

Documentation:
- Update collection-related help docs and architecture documentation to recommend `manageCollection` as the primary I/O path for schema-driven collections and to explain that computed values are now visible to the runtime.
- Extend the shared utils catalog to document the new collections derive helper.

Tests:
- Add comprehensive tests for the shared derive loop, server-side enrichment, and the `manageCollection` tool’s read/write, validation, and merge semantics, including parity checks with existing validation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `manageCollection` tool for reading and writing collection records with support for `create`, `upsert`, and `merge` modes.
  * `merge` mode enables safe partial updates that preserve omitted fields.

* **Documentation**
  * Updated skill guidance across Portfolio, Vocabulary, Lessons, and Collections to recommend using `manageCollection` for record I/O.
  * Clarified that host-computed values (derived fields, toggles, embeds) are available through `getItems`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->