### PR TITLE
fix(collections): allow audio/video in custom views (CSP media-src)

### DIFF
--- a/server/workspace/helps/custom-view.md
+++ b/server/workspace/helps/custom-view.md
@@ -115,6 +115,9 @@ The view runs in a `sandbox="allow-scripts"` iframe with a strict CSP:
   image URL stored in a record — a feed's article thumbnail, a poster, an
   avatar — renders directly. (Images are the one resource type not pinned to the
   CDN allowlist; everything else above still is.)
+- **`<audio>` / `<video>` may load from any `https:` host** (plus the origin and
+  `data:` / `blob:`), so a record's media URL — a podcast feed's `.mp3`, a
+  video enclosure — plays directly.
 - **`fetch` (and XHR / WebSocket / `sendBeacon`) is allowed ONLY to
   `window.__MC_VIEW.dataUrl`'s origin.** All other origins are blocked — no
   phone-home, no third-party analytics, no fetching weather / prices / etc.

--- a/src/utils/html/previewCsp.ts
+++ b/src/utils/html/previewCsp.ts
@@ -36,7 +36,7 @@ export const HTML_PREVIEW_CSP_ALLOWED_CDNS: readonly string[] = [
  * undefined for the `srcdoc` fallback (where `'self'` is meaningless
  * either way and there are no same-origin refs to resolve).
  */
-function buildCsp(connectSrc: string, imgSelf: string, cdns: readonly string[], extraImgSrc = ""): string {
+function buildCsp(connectSrc: string, imgSelf: string, cdns: readonly string[], extraImgSrc = "", mediaSrc = ""): string {
   const cdnList = cdns.join(" ");
   const imgExtra = extraImgSrc ? ` ${extraImgSrc}` : "";
   return [
@@ -56,6 +56,11 @@ function buildCsp(connectSrc: string, imgSelf: string, cdns: readonly string[], 
     // legitimately needs more hosts. `extraImgSrc` lets a specific caller
     // (custom views) opt into a broader source set — see buildCustomViewCsp.
     `img-src ${imgSelf} ${cdnList} data: blob:${imgExtra}`,
+    // Audio / video: omitted by default, so `<audio>`/`<video>` fall back to
+    // default-src 'none' (preview + print stay locked). Custom views opt in via
+    // `mediaSrc` so a record's media URL (e.g. a podcast feed's .mp3) plays;
+    // same one-way GET-exfil tradeoff as img-src, see buildCustomViewCsp.
+    ...(mediaSrc ? [`media-src ${mediaSrc}`] : []),
     `connect-src ${connectSrc}`,
   ].join("; ");
 }
@@ -97,13 +102,18 @@ export function buildHtmlPreviewCsp(origin?: string, cdns: readonly string[] = H
  *     XHR / WebSocket / beacon stay origin-locked, so bulk/bidirectional exfil
  *     is still blocked. If you need the strict guarantee back, proxy images
  *     through the origin instead of widening `img-src`.
+ *   - **`media-src` likewise allows the origin + any `https:` host** (+ `data:`/
+ *     `blob:`), so a record's audio/video URL — e.g. a podcast feed's `.mp3` —
+ *     plays in an `<audio>`/`<video>` element. Same one-way GET-exfil tradeoff
+ *     as `img-src`, accepted for the same reasons; the streamed bytes flow into
+ *     the element, not into readable script state.
  *
  * `origin` MUST be the explicit server origin: the sandboxed iframe has an
  * opaque origin, so `'self'` would never match (same reason the preview policy
  * substitutes the origin into `img-src`).
  */
 export function buildCustomViewCsp(origin: string, cdns: readonly string[] = HTML_PREVIEW_CSP_ALLOWED_CDNS): string {
-  return buildCsp(origin, origin, cdns, "https:");
+  return buildCsp(origin, origin, cdns, "https:", `${origin} https: data: blob:`);
 }
 
 /**

--- a/test/utils/html/test_previewCsp.ts
+++ b/test/utils/html/test_previewCsp.ts
@@ -51,6 +51,12 @@ describe("buildHtmlPreviewCsp", () => {
     assert.ok(!/img-src \*/.test(csp));
   });
 
+  it("sets no media-src, so audio/video falls back to default-src 'none'", () => {
+    // Media loosening is custom-view-only (buildCustomViewCsp). The Files
+    // preview keeps <audio>/<video> blocked via the default-src fallback.
+    assert.ok(!buildHtmlPreviewCsp().includes("media-src"));
+  });
+
   it("accepts a custom CDN list", () => {
     const csp = buildHtmlPreviewCsp(undefined, ["https://example.com"]);
     assert.ok(csp.includes("script-src 'unsafe-inline' https://example.com"));
@@ -85,6 +91,12 @@ describe("buildCustomViewCsp", () => {
   it("keeps the wildcard out of img-src (https: scheme, not *)", () => {
     const csp = buildCustomViewCsp("http://localhost:3001");
     assert.ok(!/img-src[^;]*\*/.test(csp));
+  });
+
+  it("adds a media-src allowing the origin + https (so a record's audio/video plays)", () => {
+    const csp = buildCustomViewCsp("http://localhost:3001");
+    assert.match(csp, /media-src http:\/\/localhost:3001 https: data: blob:/);
+    assert.ok(!/media-src[^;]*\*/.test(csp), "media-src must not be a wildcard");
   });
 });
 


### PR DESCRIPTION
## Summary

A custom view that plays a record's media (e.g. a podcast feed's `.mp3`) was blocked by CSP:

```
Loading media from 'https://media.blubrry.com/.../lex_ai_don_lincoln.mp3' violates
the following Content Security Policy directive: "default-src 'none'". Note that
'media-src' was not explicitly set, so 'default-src' is used as a fallback.
```

The custom-view CSP never set a `media-src`, so `<audio>`/`<video>` fell back to `default-src 'none'`. This adds a `media-src` to the **custom-view** CSP allowing the origin + any `https:` host (plus `data:` / `blob:`) — parallel to the earlier `img-src` loosening for feed thumbnails (#1687), with the same accepted, one-way GET-exfil tradeoff: media bytes stream into the element, not into readable script state, and `fetch` / XHR / WebSocket / beacon stay origin-locked so bulk exfil is still blocked.

The Files preview and print CSPs are **unchanged** — they set no `media-src`, so `<audio>`/`<video>` stays blocked there via the `default-src` fallback.

## Changes
- `previewCsp.ts`: optional `mediaSrc` directive in `buildCsp`; `buildCustomViewCsp` passes `<origin> https: data: blob:`; threat-model comment extended.
- `server/workspace/helps/custom-view.md`: document `<audio>`/`<video>` from https hosts so the authoring agent knows the capability exists.

## Test plan
- `yarn lint`, `yarn typecheck`, `yarn build` — green.
- `test/utils/html/test_previewCsp.ts`: pins the custom-view `media-src` (origin + https, no wildcard) and asserts the preview CSP has **no** `media-src` (media stays blocked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow custom views to load and play record media via CSP while keeping file previews and prints locked down.

New Features:
- Enable audio and video playback in custom views by adding a CSP media-src directive for origin, HTTPS, data, and blob sources.

Enhancements:
- Extend shared CSP builder to optionally include a media-src directive reused by custom view CSP.
- Clarify custom-view security documentation around allowed audio/video sources and existing CSP guarantees.

Documentation:
- Document that custom views may load <audio>/<video> from the origin, HTTPS hosts, data, and blob URLs.

Tests:
- Add tests verifying custom-view CSP includes a non-wildcard media-src while preview CSP omits media-src to keep media blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio and video content in custom views can now load from approved media sources, including the record’s origin, secure web hosts, and local data/blob URLs.

* **Bug Fixes**
  * Improved preview and custom view security policies so media playback works as expected without broadening access beyond allowed sources.

* **Tests**
  * Added coverage for media playback policy behavior in both preview and custom views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->