### PR TITLE
fix(collections): reduce CollectionView header height

### DIFF
--- a/src/components/CollectionView.vue
+++ b/src/components/CollectionView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="h-full flex flex-col bg-slate-50/30">
-    <header class="flex items-center gap-3 px-6 py-4 border-b border-slate-200 bg-white">
+    <header class="flex items-center gap-3 px-6 py-2 border-b border-slate-200 bg-white">
       <button
         v-if="!embedded"
         type="button"


### PR DESCRIPTION
## Summary

The Collection View title row (top header with the back arrow and title) had `py-4` (16px top/bottom) padding, making it unnecessarily tall.

Reduced to `py-2` (8px) so the header height is governed by the `h-9` icon badge (~52px), in line with the standard chrome-row spacing.

## Change

`src/components/CollectionView.vue` — header `py-4` → `py-2` (one line).

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` pass
- [ ] Visual: Collection View header is more compact, title and back arrow still vertically centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Adjust Collection View header padding to decrease overall header height without affecting layout structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized the collection view toolbar spacing for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->