### PR TITLE
docs(papers): "Software for an Audience of One" essay + reflect custom views & feeds

### DIFF
--- a/docs/papers/collections-architecture.md
+++ b/docs/papers/collections-architecture.md
@@ -95,13 +95,15 @@ This is the key distinction between Collections and traditional application fram
 
 A single schema defines:
 
-| Concern        | Collection DSL |
-| -------------- | -------------- |
-| Data Model     | Fields         |
-| Relationships  | Ref / Embed    |
-| User Interface | Field Types    |
-| Computation    | Derived Fields |
-| Workflow       | Actions        |
+| Concern          | Collection DSL  |
+| ---------------- | --------------- |
+| Data Model       | Fields          |
+| Relationships    | Ref / Embed     |
+| User Interface   | Field Types     |
+| Custom UI        | Views (HTML)    |
+| Computation      | Derived Fields  |
+| Workflow         | Actions         |
+| Data Acquisition | Ingest (Feeds)  |
 
 Traditional application frameworks spread these concerns across multiple technologies and codebases.
 
@@ -234,6 +236,97 @@ are often easier to express in prose than in a specialized language.
 Collections embrace that reality.
 
 > Business logic becomes language.
+
+---
+
+## Custom Views
+
+The host renders every collection from its field types: a list, a detail form, and — where the schema declares them — calendar and Kanban layouts.
+
+Every collection therefore has a usable interface for free.
+
+But host-rendered field types describe data; they do not always present it well.
+
+A portfolio is clearer as an allocation chart.
+
+A set of restaurants is clearer as a map.
+
+A vocabulary list is clearer as flashcards.
+
+For these, a collection can carry custom views: HTML files the agent authors and the host serves.
+
+```json
+"views": [
+  { "id": "allocation", "label": "Allocation", "file": "views/allocation.html", "capabilities": ["read", "write"] }
+]
+```
+
+A view is an ordinary web page.
+
+It may pull a charting library such as Chart.js or Plotly from a curated CDN allow-list.
+
+It receives its collection's records through a capability-scoped token, not ambient access.
+
+The host serves it inside a sandboxed iframe under a strict Content-Security-Policy: an opaque origin, `default-src 'none'`, and network access only back to the host.
+
+A view's `capabilities` declare what its token permits: `read` to fetch records, `write` to update them.
+
+So a custom view is not a hole in the harness.
+
+It is the same bargain as the rest of Collections.
+
+The agent supplies the bespoke surface.
+
+The host supplies the deterministic, sandboxed boundary around it.
+
+The presentation layer, too, becomes data — an HTML file inside the collection, authored on request, versioned with everything else.
+
+---
+
+## Feeds — Acquisition as Data
+
+A collection holds records.
+
+Where do the records come from?
+
+Usually the agent writes them.
+
+But some collections track an external source: a podcast's episodes, a newspaper's headlines, a JSON API.
+
+For these, a collection declares an `ingest` block, and becomes a feed.
+
+```json
+"ingest": {
+  "kind": "rss",
+  "url": "https://lexfridman.com/feed/podcast/",
+  "schedule": "daily",
+  "idFrom": "guid",
+  "map": { "headline": "title", "url": "link", "published": "pubDate" },
+  "maxItems": 100
+}
+```
+
+The block is purely declarative.
+
+`kind` selects a retriever (`rss`, `atom`, or `http-json`).
+
+`map` projects source fields onto the collection's fields.
+
+`schedule` (`hourly` / `daily` / `weekly` / `on-demand`) tells the host when to fetch.
+
+`maxItems` caps how many records are kept.
+
+The host owns the deterministic half: fetching on schedule, parsing the response, mapping fields, de-duplicating by id, pruning to the cap, and tracking a cursor and failure count.
+
+No retrieval code is written.
+
+And because a feed is just a collection, everything else still applies.
+
+It can carry its own custom views.
+
+The user can layer their own fields on top of the ingested ones — a rating, a note, a resume position — turning a passive mirror into a read-write application over an external source.
+
+Acquisition becomes data, in the same way computation, UI, and workflow already did.
 
 ---
 

--- a/docs/papers/dsl-as-harness.md
+++ b/docs/papers/dsl-as-harness.md
@@ -106,9 +106,9 @@ executed" is, in MulmoScript, an actual boundary in the pipeline.
 MulmoClaude's collections feature is a DSL-as-harness whose authoring pen is
 handed to the end user. A collection is defined by a schema — a small DSL
 describing the shape of the data: its fields and types, the relationships between
-them, which value marks a record "done," when to raise a notification, and how a
-record recurs. That schema drives the skills the agent uses to read, write, and
-reason over the records. The schema is the spec; the generated skill files and
+them, which value marks a record "done," when to raise a notification, how a
+record recurs, and — for a feed — where to fetch its records from. That schema
+drives the skills the agent uses to read, write, and reason over the records. The schema is the spec; the generated skill files and
 the host's reconciler are the execution layer.
 
 Like any good harness, the schema enforces its own invariants. Whoever declares a
@@ -145,6 +145,11 @@ The well-designed DSLs all answer this the same way — with a deliberate exit t
 more expressive layer. A collection drops out of its declarative schema into a
 seeded chat — an agent with full tools — the moment a record needs the human
 judgment the form cannot capture; its action buttons start exactly such a chat.
+A collection's *presentation* has the same exit: when host-rendered field types
+cannot show the data well — a portfolio as a chart, restaurants as a map — the
+schema escapes to a **custom HTML view**, arbitrary code the agent writes and the
+host serves sandboxed, rather than contorting the field-type vocabulary into a
+layout it was never meant to express.
 MulmoScript can incorporate arbitrary external assets and media rather than
 insisting everything be expressed in its own primitives.
 The art of DSL-as-harness is not maximizing constraint; it is choosing *where*

--- a/docs/papers/software-for-one.md
+++ b/docs/papers/software-for-one.md
@@ -1,0 +1,297 @@
+# Software for an Audience of One
+
+> Why the marginal cost of bespoke software has collapsed to near zero — turning
+> "build for the mass" into "build for this one person, this one time" — and what
+> that new phase of software development costs.
+
+**Status**: Essay. Written 2026-06-14. Author: Satoshi Nakajima.
+
+**Companion essays**: [`workspace-is-the-agent.md`](./workspace-is-the-agent.md)
+argues that the agent authors its own applications into its own substrate;
+[`collections-architecture.md`](./collections-architecture.md) develops the
+collection mechanism; [`dsl-as-harness.md`](./dsl-as-harness.md) argues why a
+limited language is a reliable harness. This essay narrows to one artifact those
+papers produce — the **custom view**, a piece of LLM-generated UI — and reads it
+as evidence of an economic inversion in how software comes to exist.
+
+---
+
+## The claim
+
+Look at what is actually in one MulmoClaude workspace today. Six collections have
+grown their own bespoke interfaces, each a self-contained HTML file the agent
+wrote on request:
+
+| Collection | Custom view | What it is |
+|---|---|---|
+| `restaurants` | `tokyo-map.html` | Tokyo restaurants laid out as a subway map |
+| `watchlist` | `gallery.html` | A movie-poster wall |
+| `vocabulary` | `flashcards.html` | An interactive flashcard drill |
+| `portfolio` | `allocation.html` | An asset-allocation chart |
+| `baseball-scout` | `radar.html` | Per-player rating radar charts |
+| `mag2-subscribers` | `trend.html` | A subscriber-count trend line |
+
+A feed has one too: the Lex Fridman podcast gallery is *read-write*, with the
+owner's own rating, notes, and resume-position fields layered on top of the
+ingested RSS.
+
+Every one of these is software that **no company would ever build.** The
+addressable market for "my restaurants, drawn as a Tokyo subway map, to my taste"
+is exactly one person. The market for the poster wall is one person. The market
+for the rating radar is one person. Under the economics that governed software
+for fifty years, that made each of them *impossible* — not hard, impossible,
+because the cost of building software was far larger than the value any single
+user could justify. The owner of this workspace never wrote, or even saw, a line
+of the HTML. He described what he wanted; the code appeared.
+
+The claim of this essay is simple: **the marginal cost of bespoke software has
+collapsed to near zero, and that single fact inverts the central economic
+constraint of the entire software industry.** What follows is what that inversion
+breaks, what it does *not* break, and the one cost it relocates rather than
+removes.
+
+---
+
+## 1. The economics that forced "software for the mass"
+
+Software was always built for the average of an audience, never for the
+individual — but this was a consequence, not a preference. The cause was a cost
+structure:
+
+```text
+cost to build software        = large, fixed, paid up front
+cost to serve one more user   ≈ zero
+∴ rational strategy           = spread the fixed cost over as many users
+                                as possible → build for the mass
+```
+
+Because development was expensive and replication was free, every product had to
+find the largest common denominator of need that would repay its build cost. That
+pressure shows up everywhere in how software feels: the settings panel that
+gestures at flexibility you will never fully use; the feature you wish existed but
+that "isn't worth building for your use case"; the workflow that is 80% right and
+permanently 20% wrong because the missing 20% differs for every user and no single
+version can satisfy all of them. None of this is a failure of taste. It is the
+arithmetic. A product priced to recoup a fixed build cost across millions of users
+*must* regress to their mean.
+
+The history of software is in large part a history of fighting this constraint
+from the user's side — of pushing some authoring power back down to the individual
+so they could close the last 20% themselves. The spreadsheet, the macro, the
+scripting layer, the no-code builder: each handed the user a constrained way to
+build a sliver of bespoke software without a development team. We return to those
+in §4, because they are the honest precedent. But each one bought
+individualization only by forcing the user to become, partly, a programmer.
+
+---
+
+## 2. The collapse
+
+The constraint had a single load-bearing term: *the cost to build software is
+large.* Remove it and the whole structure falls.
+
+An LLM that can generate working code on demand removes it. The Tokyo-subway
+restaurant map was not amortized across a market; it was produced, in one
+exchange, for one person, at a cost that rounds to nothing. The arithmetic of §1
+now reads:
+
+```text
+cost to build bespoke software  ≈ a sentence of intent  →  near zero
+∴ rational strategy             = build for exactly this person, this purpose
+```
+
+When building for one becomes as cheap as building for millions, the reason to
+build for millions — *cost amortization* — evaporates. Software no longer has to
+find the largest common denominator of need, because it no longer has a fixed
+cost to repay. It can fit a denominator of one.
+
+This is the new phase. Not "software is easier to build" — that undersells it.
+The category that was economically impossible for the entire history of the field,
+**software whose audience is a single person**, has become not just possible but
+the *default* for a large class of needs. The interesting unit of software is no
+longer the product shipped to a market. It is the artifact grown for an
+individual.
+
+---
+
+## 3. Code becomes an intermediate representation, not the deliverable
+
+The most important detail in the opening is the one easiest to skip past: **the
+owner never saw the HTML.** This is not a missing feature. It is the structural
+signature of the new phase.
+
+In traditional software, the source code *is* the asset. It is expensive to
+produce, so it is precious; it is precious, so it is version-controlled,
+reviewed, tested, refactored, and maintained for years. The whole discipline of
+software engineering is the care-and-feeding of an expensive, durable artifact.
+
+When code costs almost nothing to produce, it stops being the asset and becomes
+**an intermediate representation** — a compile target between intent and behavior,
+no more precious than the assembly a compiler emits. The durable things are the
+two ends:
+
+```text
+   INTENT                 CODE                    DATA
+   (natural language) →   (generated HTML/JS)  ←  (the collection's records)
+   durable                disposable               durable
+   "draw my restaurants                            restaurants/items/*.json
+    as a subway map"      regrown on demand
+```
+
+The view is downstream of both and owns neither. When the need changes you do not
+*maintain* the view — you *regrow* it. "Also color the stations by cuisine" does
+not open a code review; it reissues the request, and a new artifact replaces the
+old. The Lex Fridman feed adding personal rating fields, the restaurant guide
+gaining a "visited" flag — in the companion paper these are schema edits; at the
+view layer they are simply regenerations. Disposability is not a weakness of this
+software. It is the property that makes building-for-one affordable, and it is the
+cleanest break from everything that came before. We have spent decades making code
+*easier to maintain*. The new phase makes maintenance, in many cases, beside the
+point: it is cheaper to regenerate the artifact than to repair it.
+
+This is the view-layer instance of the broader thesis in
+[`workspace-is-the-agent.md`](./workspace-is-the-agent.md): the workspace's
+durable truth is data and intent; the code is the agent's transient output.
+Where that paper makes the point about *schemas the agent authors into itself*,
+here it is sharper still, because a view is even more disposable than a schema —
+nobody curates it, nobody reads it, it exists only to render once and be replaced.
+
+---
+
+## 4. The honest precedent: spreadsheets and no-code
+
+A claim that LLMs invented "software for an audience of one" would be false, and
+the falseness is instructive. The category already existed. Its name was the
+**spreadsheet.**
+
+VisiCalc, HyperCard, Excel — these were the first mass tools for building
+software with a market of one. A personal budget model in Excel is bespoke
+software: a data model, computations, a UI, used by exactly the person who built
+it and no one else. The no-code platforms that followed — Airtable, Notion,
+Retool — extended the same idea. So the individualizing impulse is old. What was
+missing was never the *desire* for personal software; it was the *cost.*
+
+Seeing the precedent clearly is what makes the genuinely new thing visible. Every
+prior tool for software-for-one bought individualization at the price of **two
+constraints**, and the LLM is the first to remove both at once:
+
+```text
+                          authoring surface        authoring burden
+                          (what you can express)   (who does the work)
+   spreadsheet / no-code  constrained DSL,          the USER assembles it
+                          a grid or block palette   (must become a programmer)
+
+   LLM codegen            arbitrary code            the AGENT writes it
+                          (full HTML/JS/charts)     (user only describes)
+```
+
+The spreadsheet removed the development *team* but kept the user inside a grid and
+made the user do the building. No-code widened the grid into a block palette but
+still cast the user as the composer. Both traded generality and effort for access.
+The LLM removes **both** constraints simultaneously: the authoring surface becomes
+arbitrary code — a subway-map layout is not a thing any spreadsheet or no-code
+builder offers — *and* the authoring burden moves off the user entirely. You do
+not assemble; you describe. That double removal is the actual novelty, and naming
+the precedent is what lets us locate it precisely. It is also why the right frame
+is the one the companion paper insists on: not a *no-code platform* (which still
+hands the user blocks to assemble) but an *agent that materializes the surface on
+request.*
+
+---
+
+## 5. The cost that relocates rather than disappears
+
+A new phase of software development is only credible if it is honest about what it
+gives up, and this one gives up something real.
+
+Mass software is bad at fitting the individual but extraordinarily good at one
+thing the individual cannot reproduce: **accumulating correctness.** A product
+used by millions over years is hardened by many eyes, surfaced edge cases,
+regression suites, and the slow accretion of fixes. That hardening was the *other*
+return on the fixed build cost — you paid once, and the whole user base debugged
+it for you. Software for an audience of one has no such audience. It is correct, or
+not, between exactly two parties: the user and the model. No one else will ever
+run it, so no one else will ever find its bugs.
+
+So the cost of correctness does not vanish in the new phase. It **relocates** —
+from the vendor's QA organization to the trust between one user and one LLM:
+
+```text
+   mass software:        correctness amortized across millions of users and years
+                         (many eyes find the bugs; you inherit the fixes)
+
+   software for one:     correctness is between you and the model, once
+                         (no other eyes; the bug ships to its only user — you)
+```
+
+The stakes are not uniform, and that is the whole design problem. A wrong
+movie-poster wall is harmless; you notice and shrug. But the same workspace holds
+a `portfolio` allocation view and, nearby, tax and recurring-bill collections —
+software whose arithmetic *matters*, generated by the same one-shot process, and
+audited by no one but the model that wrote it. This is not a new failure mode; it
+is the *oldest* one in end-user software, returning in a more powerful form. The
+spreadsheet era already taught the lesson the hard way: the danger was never the
+visible interface, it was the **invisible formula error** in a model no one else
+ever checked — the off-by-one in a cell reference that quietly corrupts a number
+a human then trusts. "The user never sees the code" is liberating for the subway
+map and quietly dangerous for the allocation chart, for exactly the same reason.
+
+The mitigations are the boring, correct ones, and they are the real frontier work
+of this phase — not the codegen, which is solved. Keep the durable data
+verifiable independent of the disposable view (the chart can be wrong; the
+numbers it reads must not be). Reserve human or deterministic review for the views
+whose output is consequential, and let the harmless ones run unaudited — the
+*reliability dial* of [`workspace-is-the-agent.md`](./workspace-is-the-agent.md)
+§5, applied to the view layer. And treat regenerability itself as a safety
+feature: a disposable artifact that is cheap to throw away and regrow is also
+cheap to *distrust and replace*, which is a real advantage over precious code that
+institutions defend long past its correctness.
+
+---
+
+## 6. The broader shift
+
+Two sentences capture the change.
+
+The old phase of software development assumed:
+
+```text
+Build software once, for the mass, because building is expensive.
+The individual gets the average; the code is the asset.
+```
+
+The new phase assumes:
+
+```text
+Build software for one, on demand, because building is nearly free.
+The individual gets exactly their need; the code is disposable; intent and data are the asset.
+```
+
+For fifty years the economics of software forced every product toward the mean of
+its audience, and the entire craft of programming grew up around protecting an
+expensive, durable artifact. The collapse of the marginal cost of bespoke software
+removes the force and demotes the artifact. The audience of software can now be a
+single person; the code can be thrown away and regrown; the durable things are
+what the person *meant* and what they *have.* A restaurant guide drawn as a subway
+map is not a toy at the edge of this shift — it is the shape of the whole thing:
+software no market would fund, built for one person who never saw the code, kept
+only as long as it is useful, and regenerated the moment it is not.
+
+The companion paper ends on *the workspace is the agent, and building software is
+how the agent grows.* This essay's addition is what that means for software
+itself: when building costs nothing, software stops being a product shipped to a
+market and becomes **an artifact grown for an individual** — and the discipline of
+the field shifts from maintaining precious code to verifying disposable code and
+curating the durable intent and data behind it.
+
+---
+
+## See also
+
+- [`workspace-is-the-agent.md`](./workspace-is-the-agent.md) — the agent authors
+  its own applications into its own substrate; the reliability dial (§5) this
+  essay applies to the view layer.
+- [`collections-architecture.md`](./collections-architecture.md) — Collections as
+  applications-as-data; where the views in *The claim* actually live.
+- [`dsl-as-harness.md`](./dsl-as-harness.md) — why a limited language is a
+  reliable harness; the "democratization of harness engineering."

--- a/docs/papers/workspace-is-the-agent.md
+++ b/docs/papers/workspace-is-the-agent.md
@@ -60,7 +60,9 @@ Look at what is actually there:
 | `config/mcp.json` | tool-and-server wiring | **code** (capability DSL) |
 | `config/helps/` | help surfaces | code + data |
 | `data/collections/*/schema.json` | data model + UI + computation + workflow | **code** (application DSL) |
+| `data/collections/*/views/*.html` | bespoke, agent-authored UI for a collection | **code** (presentation) |
 | collection `SKILL.md` | procedural instructions the agent reads to operate a collection | **code** (procedural DSL) |
+| `feeds/*/schema.json` | external-source ingestion + data model | **code** (acquisition DSL) |
 | `data/scheduler/` | recurring automations | **code** (trigger DSL) |
 | `data/wiki/` | densely cross-linked knowledge | data + graph DSL |
 | `conversations/memory.md` | accreted facts | **data** |
@@ -126,16 +128,19 @@ The most important consequence of "code lives in the workspace" is this: **a
 collection skill is an application in the full, traditional sense — not merely
 structured memory.**
 
-A traditional application bundles four things. A collection skill bundles the
-same four, and the host supplies the runtime for all of them generically:
+A traditional application bundles a handful of concerns. A collection skill
+bundles the same ones, and the host supplies the runtime for all of them
+generically:
 
 | Concern | Traditional stack | Collection skill |
 |---|---|---|
 | Data model | database + ORM | `schema.json` fields |
 | Relationships | foreign keys, joins | `ref` / `embed` fields |
 | User interface | frontend framework | host-rendered field types — **free** |
+| Custom UI | bespoke frontend code | `views/*.html` the agent authors — sandboxed, capability-scoped |
 | Computation | service code | `derived` fields (spreadsheet-like, cross-collection) |
 | Workflow | workflow engine | `actions` + `SKILL.md` procedures |
+| Data acquisition | ETL / cron jobs | `ingest` block (RSS / Atom / JSON, scheduled) |
 | Persistence | DB server | `records/*.json` on disk |
 
 A personal restaurant guide built this way *is* an app: it has persistent
@@ -158,7 +163,9 @@ a note, and it is threefold:
    skill is a stable contract; a prompt-of-the-moment is not. CRUD on a
    collection is a real, repeatable file operation, not a re-derived guess.
 3. **A UI for free.** The host renders the collection as a navigable surface with
-   pickers, links, and computed columns. A note renders as text.
+   pickers, links, and computed columns — and where field types are not enough,
+   the agent authors a bespoke view (`views/*.html`: a chart, a map, a flashcard
+   deck) that the host serves sandboxed. A note renders as text.
 
 There is a natural ladder of memory maturity, and a collection skill is the top
 rung:


### PR DESCRIPTION
## Summary

Adds a new essay to `docs/papers/` and brings the three existing collection/agent papers up to date with features shipped since they were written.

### New essay
- **`software-for-one.md` — "Software for an Audience of One"**: argues that the marginal cost of bespoke software has collapsed to near zero, inverting the "build for the mass" economics — software whose audience is a single person becomes the default for a class of needs. Develops code-as-disposable-intermediate-representation, the spreadsheet/no-code precedent (and what's genuinely new), and the correctness cost that relocates from vendor QA to the user↔model trust. Grounded in the actual custom views in the workspace (Tokyo-subway restaurant map, poster gallery, flashcards, allocation chart, scout radar, subscriber trend). Companion to the three existing papers.

### Updates to existing papers (reflect current Collections/Feeds features)
The papers predated **custom views** and **feeds**; neither appeared in any of them. Verified against the live Zod schema (`server/workspace/collections/discovery.ts`) and the view/feed code.

- **`collections-architecture.md`**: new **Custom Views** and **Feeds — Acquisition as Data** sections; Custom UI / Data Acquisition rows added to the application table.
- **`workspace-is-the-agent.md`**: views (presentation) + feeds (acquisition DSL) added to the workspace-contents and application tables; bespoke views noted in §2.1.
- **`dsl-as-harness.md`**: feed ingestion noted in the collection-schema description; custom HTML views added as a presentation escape hatch.

Deliberately left out of the conceptual papers: incremental schema additions (`toggle`/`image`/`file` field types, calendar/kanban layouts, `when`/`notifyWhen` predicates, collection-level actions) — real, but they don't change any paper's argument.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation describing custom views and feeds functionality
  * Added comprehensive essay on bespoke software economics and personalization
  * Enhanced workspace architecture documentation with clearer capability-scoping and data acquisition concepts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->