### PR TITLE
fix(scheduler): use uniqueTmp to prevent state persistence race

### DIFF
--- a/server/events/scheduler-adapter.ts
+++ b/server/events/scheduler-adapter.ts
@@ -53,7 +53,7 @@ function logsDir(root = workspacePath): string {
 
 const stateDeps: StateDeps = {
   readFile: (filePath: string) => readFile(filePath, "utf-8"),
-  writeFileAtomic: (filePath: string, content: string) => writeFileAtomic(filePath, content),
+  writeFileAtomic: (filePath: string, content: string) => writeFileAtomic(filePath, content, { uniqueTmp: true }),
   exists: existsSync,
 };
 


### PR DESCRIPTION
## Summary

- Concurrent `saveState` calls shared the same `state.json.tmp` file, causing intermittent ENOENT errors on rename
- Pass `{ uniqueTmp: true }` so each atomic write uses a unique tmp file name

## Root cause

When multiple scheduler tasks complete near-simultaneously, their `saveState` calls race on the shared tmp path:

1. Task A writes `state.json.tmp`
2. Task B overwrites `state.json.tmp`
3. Task A renames `state.json.tmp` → `state.json` (succeeds, but saves B's data)
4. Task B tries to rename `state.json.tmp` → **ENOENT** (already moved by A)

## Test plan

- [ ] Confirm `yarn typecheck` passes
- [ ] Start dev server, trigger multiple scheduled tasks, verify no more `state persistence failed` warnings in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of scheduler state persistence by using safer atomic write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->