### PR TITLE
feat(chat-input): multi-attach + queued send during a running run

### DIFF
--- a/e2e/tests/chatinput-attach.spec.ts
+++ b/e2e/tests/chatinput-attach.spec.ts
@@ -44,6 +44,11 @@ test.describe("ChatInput attach discoverability", () => {
     expect(accept).toContain("wordprocessingml"); // DOCX
     expect(accept).toContain("spreadsheetml"); // XLSX
     expect(accept).toContain("presentationml"); // PPTX
+    // Multi-attach (plans/feat-chat-input-multi-attach.md): the picker
+    // must allow several files in a single open. Without `multiple`,
+    // the browser caps the selection at 1 and the multi-screenshot
+    // workflow regresses.
+    await expect(input).toHaveAttribute("multiple", "");
   });
 
   test("clicking the attach button opens the picker (fires a click on the hidden input)", async ({ page }) => {
@@ -68,6 +73,27 @@ test.describe("ChatInput attach discoverability", () => {
     await expect(banner).toBeVisible();
     const text = (await banner.textContent())?.trim() ?? "";
     expect(text.length).toBeGreaterThan(0);
+  });
+
+  test("dropping multiple accepted files surfaces a preview chip per file", async ({ page }) => {
+    // Multi-attach (plans/feat-chat-input-multi-attach.md): all three
+    // entry points — picker, paste, drop — should accept several
+    // files in one go. Drop is the easiest to drive synthetically;
+    // verify that the preview list grows to match.
+    const dropTarget = page.locator("[data-testid=user-input]").locator("..").locator("..");
+    await dropTarget.evaluate((element) => {
+      const transfer = new DataTransfer();
+      // Tiny 1x1 PNG so the FileReader actually parses something.
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      transfer.items.add(new File([pngBytes], "first.png", { type: "image/png" }));
+      transfer.items.add(new File([pngBytes], "second.png", { type: "image/png" }));
+      element.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: transfer }));
+    });
+    const previews = page.getByTestId("chat-attachment-preview");
+    await expect(previews).toHaveCount(2);
+    // Clicking the remove × on the first chip should leave one behind.
+    await page.getByTestId("chat-attachment-remove").first().click();
+    await expect(previews).toHaveCount(1);
   });
 
   test("dropping an oversized accepted file still shows the too-large error (regression)", async ({ page }) => {

--- a/e2e/tests/chatinput-queue.spec.ts
+++ b/e2e/tests/chatinput-queue.spec.ts
@@ -1,0 +1,90 @@
+// E2E coverage for the queued-send feature
+// (plans/feat-chat-input-queued-send.md).
+//
+// When the active session is already running, the send button used to
+// be disabled. The new behaviour lets the user submit a follow-up
+// anyway; the message + any attachments are pushed onto a queue and
+// the watcher in App.vue flushes them once the run goes idle.
+//
+// Driving "an in-flight run" deterministically without a backend is
+// hard, so we stub /api/sessions with `isRunning: true` and verify
+// the send-button → queue-panel relationship at the UI level. The
+// flush-on-idle behaviour is exercised by the unit-level reactivity
+// of the watcher; no need to fake an SSE flip here.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const SESSION_ID = "queued-session";
+const SESSION_PATH = `/chat/${SESSION_ID}`;
+
+async function stubRunningSession(page: import("@playwright/test").Page) {
+  await mockAllApis(page, {
+    sessions: [
+      {
+        id: SESSION_ID,
+        title: "Queued Session",
+        roleId: "general",
+        startedAt: "2026-04-12T10:00:00Z",
+        updatedAt: "2026-04-12T10:05:00Z",
+        isRunning: true,
+      },
+    ],
+  });
+  // The session transcript matters only for the page not to error;
+  // an empty list is enough to make ChatInput render.
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [{ type: "session_meta", roleId: "general", sessionId: SESSION_ID }],
+      }),
+  );
+}
+
+test.describe("ChatInput queued send", () => {
+  test.beforeEach(async ({ page }) => {
+    await stubRunningSession(page);
+    await page.goto(SESSION_PATH);
+  });
+
+  test("send button stays enabled while a run is in flight", async ({ page }) => {
+    // Pre-PR the button carried `:disabled="isRunning"`. The queued-send
+    // refactor relaxed it so users can submit follow-ups during a run.
+    const sendBtn = page.getByTestId("send-btn");
+    await expect(sendBtn).toBeVisible();
+    await expect(sendBtn).toBeEnabled();
+  });
+
+  test("clicking send while running pushes the message onto the queue panel", async ({ page }) => {
+    // Queue is hidden until the user actually adds an entry.
+    await expect(page.getByTestId("queued-messages-panel")).toHaveCount(0);
+
+    await page.getByTestId("user-input").fill("follow-up while running");
+    await page.getByTestId("send-btn").click();
+
+    const panel = page.getByTestId("queued-messages-panel");
+    await expect(panel).toBeVisible();
+    const items = page.getByTestId("queued-message-item");
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText("follow-up while running");
+
+    // The input box clears once the message rides into the queue so a
+    // second submission is unambiguously a NEW queue entry, not a
+    // re-send of the visible text.
+    await expect(page.getByTestId("user-input")).toHaveValue("");
+  });
+
+  test("the × button removes a queued entry", async ({ page }) => {
+    await page.getByTestId("user-input").fill("first queued");
+    await page.getByTestId("send-btn").click();
+    await page.getByTestId("user-input").fill("second queued");
+    await page.getByTestId("send-btn").click();
+
+    await expect(page.getByTestId("queued-message-item")).toHaveCount(2);
+
+    await page.getByTestId("queued-message-remove").first().click();
+    await expect(page.getByTestId("queued-message-item")).toHaveCount(1);
+    await expect(page.getByTestId("queued-message-item").first()).toContainText("second queued");
+  });
+});

--- a/plans/feat-chat-input-multi-attach.md
+++ b/plans/feat-chat-input-multi-attach.md
@@ -1,0 +1,44 @@
+# feat: ChatInput を複数添付対応にする
+
+## 背景
+
+ユーザーが複数のスクショ（例: Airtable Automation 一覧 + その詳細）を 1 ターンで送りたいユースケースがある。現状は picker / paste / drop の 3 経路すべて 1 ファイル制限。バックエンド / モデルは `[Attached file: <path>]` 複数行を既に解釈できるので、UI 側 1 箇所の改修だけで複数対応できる。
+
+## 現状の制約（コード上の根拠）
+
+- `src/components/ChatInput.vue:90` — `<input type="file">` に `multiple` 属性なし
+- `src/components/ChatInput.vue:181-194` — `onPasteFile` は最初のファイルで `return`
+- `src/composables/useFileDropZone.ts:36, 108` — `event.dataTransfer?.files[0]` で 1 件だけ拾う
+- `src/components/ChatInput.vue` props の `pastedFile: PastedFile | null` が単数型
+- `src/App.vue:541, 561-566` — `chatInputRef.value?.readFile(file)` も単数前提
+
+## 想定スコープ
+
+1. `pastedFile: PastedFile | null` → `pastedFiles: PastedFile[]` へ配列化
+2. `<input type="file">` に `multiple` 属性追加（`ChatInput.vue:90`）
+3. `onFilePicked` — `input.files` を for-loop で全件 `readAttachmentFile()`
+4. `onPasteFile` — `return` を `continue` に変えて clipboard items 全件処理
+5. `useFileDropZone` の `onFile: (file)` → `onFiles: (files)` に変更、`dataTransfer.files` を全件渡す
+6. `ChatAttachmentPreview` をリスト表示に変更（既存はおそらく単発プレビュー）
+7. 個別添付の削除 UI（× ボタン）
+8. `MAX_ATTACH_BYTES` の扱い — 合計 30MB か、1 件 30MB × N か。前者推奨
+9. i18n: `chatInput.tooManyFiles` `chatInput.fileTooLarge` 等の文言を 8 言語
+
+## 完了条件
+
+- [ ] picker / paste / drop の 3 経路すべてで複数ファイルが取れる
+- [ ] 添付プレビューが横並びリストで表示され、個別に × 削除できる
+- [ ] サーバー送信時に `[Attached file: <path>]` 行が複数になる（既存サーバー側受信ロジックを壊さない）
+- [ ] 1 件 30MB 超 or 合計 N MB 超のときに分かりやすいエラー
+- [ ] E2E: 既存テスト `e2e/chat-attachment.spec.ts` 等が緑、複数添付のシナリオを 1 件追加
+- [ ] 8 言語 i18n 追加（en/ja/zh/ko/es/pt-BR/fr/de）
+
+## スコープ外
+
+- 添付ファイル間の並べ替え（drag reorder）
+- 添付ライブラリ的な永続保存
+- 個別ファイル毎の異なる処理（例: 画像は OCR、PDF はテキスト抽出 など）
+
+## 起票元
+
+2026-06-16 のチャットセッション。Airtable Automation 棚卸しで「スクショ 2 枚を 1 回で添付したい」というユーザー要望が発端。当面は 2 通連投で回避。

--- a/plans/feat-chat-input-queued-send.md
+++ b/plans/feat-chat-input-queued-send.md
@@ -1,0 +1,69 @@
+# feat: ChatInput を「実行中の連投」対応にする
+
+## 背景
+
+現状、エージェントが実行中の間、ユーザーは textarea にタイプはできるが Send ボタンが disabled で送信できない（`ChatInput.vue:69` の `:disabled="isRunning"`）。
+
+ユーザー要望：考え中（実行中）でも追加の文脈や補足情報を送りたい。会話の流れが切れずにいったん投げておきたい。
+
+## 現状の制約（コード上の根拠）
+
+- `src/components/ChatInput.vue:38-51` — textarea は **enabled のまま**（IME 中断回避のため、#1289 で意図的）
+- `src/components/ChatInput.vue:69` — Send ボタンは `:disabled="isRunning"`
+- `src/App.vue` の `sendMessage()` — `activeSessionRunning` のとき bail する（二重 submit 防止）
+
+## 想定仕様
+
+3 案：
+
+### A. キューイング型（推奨）
+- 実行中もユーザーが送信ボタンを押せる
+- 押した瞬間に「次のターンに送るキュー」に積まれる（UI 上「⏳ 実行完了後に送信されます」と表示）
+- 現在の run が完了した瞬間、キューの内容を新規メッセージとして自動送信
+- メリット：実装シンプル、副作用なし、現在の会話が完了してから次の文脈を受ける
+- デメリット：本当の意味での「割り込み」はできない
+
+### B. 割り込み型（複雑）
+- ストリーミング中のレスポンスを止めて、ユーザーメッセージを差し込む
+- Anthropic SDK は native の割り込みサポートが薄いので、現在の run を `abort` → 中断点までの結果を保存 → 新規メッセージ追加 → 再開
+- メリット：本物の "途中で口を挟む" 体験
+- デメリット：実装複雑、ツール呼び出しの途中中断のセマンティクスが厄介
+
+### C. 並列セッション型
+- Send ボタンの隣に「New thread」ボタンを置いて、別セッションで送る
+- 既存実装の `sessionId` を変えるだけ
+- メリット：ほぼ実装ゼロ
+- デメリット：会話の文脈が切れる（ユーザーが望む挙動ではなさそう）
+
+→ **A 案推奨**。B はオーバーキル、C は要件未達。
+
+## A 案の実装スケッチ
+
+1. App.vue で `queuedMessages: PastedMessage[]` を新設
+2. `ChatInput.vue` の Send ボタンの `:disabled` を外す
+3. `sendMessage()` を分岐：
+   - `!activeSessionRunning` → 即時送信（現状）
+   - `activeSessionRunning` → `queuedMessages` に push、textarea クリア、トースト or インライン表示「実行完了後に送信されます」
+4. run 完了イベントをフックして、キューが空でなければ FIFO で 1 件ずつ自動 send
+5. キュー表示の UI：textarea の下に「Queued (N)」と並べて、× で取り消し可能
+6. i18n: `chatInput.queuedHint` `chatInput.queueLabel` 等を 8 言語
+
+## 完了条件
+
+- [ ] 実行中に Send ボタンが押せる
+- [ ] キューが UI に見える（件数 + 内容のプレビュー + 削除 × ボタン）
+- [ ] run 完了後、キューが自動で順次送信される
+- [ ] 既存の二重 submit 防止セマンティクスは維持（同じ瞬間に 2 回押しても 1 件しか入らない）
+- [ ] IME 中断回避（既存挙動）も維持
+- [ ] E2E: 「実行中に追加 prompt 送信 → 完了後に自動配送」のシナリオを 1 件追加
+- [ ] 8 言語 i18n 追加
+
+## スコープ外
+
+- B 案（割り込み型）
+- 添付ファイル付きメッセージのキューイング（feat-chat-input-multi-attach.md と合流したら検討）
+- キューの永続化（リロード生存）
+
+## 起票元
+
+2026-06-16 のチャットセッション。Airtable Automation 棚卸し中、ユーザーから「考え中の時にも Chat を続けて連投したいです。今後検討ください」と要望。

--- a/src/App.vue
+++ b/src/App.vue
@@ -127,11 +127,16 @@
           class="border-t border-gray-100"
         />
 
+        <!-- Queued follow-ups, listed above the input box so they're
+             visible without scrolling. Auto-flushes on
+             `activeSessionRunning` → false (watcher in script). -->
+        <QueuedMessagesPanel :messages="queuedMessages" @remove="removeQueuedMessage" />
+
         <!-- Text input -->
         <ChatInput
           ref="chatInputRef"
           v-model="userInput"
-          v-model:pasted-file="pastedFile"
+          v-model:pasted-files="pastedFiles"
           :is-running="activeSessionRunning"
           :queries="sessionRoleQueries"
           @send="sendMessage()"
@@ -260,10 +265,11 @@
             :pending-calls="pendingCalls"
             class="border-t border-gray-100"
           />
+          <QueuedMessagesPanel :messages="queuedMessages" @remove="removeQueuedMessage" />
           <ChatInput
             ref="chatInputRef"
             v-model="userInput"
-            v-model:pasted-file="pastedFile"
+            v-model:pasted-files="pastedFiles"
             :is-running="activeSessionRunning"
             :queries="sessionRoleQueries"
             @send="sendMessage()"
@@ -312,6 +318,7 @@ import SidebarHeader from "./components/SidebarHeader.vue";
 import SessionHeaderControls from "./components/SessionHeaderControls.vue";
 import SessionTabBar from "./components/SessionTabBar.vue";
 import ChatInput, { type PastedFile } from "./components/ChatInput.vue";
+import QueuedMessagesPanel from "./components/QueuedMessagesPanel.vue";
 import FileDropOverlay from "./components/FileDropOverlay.vue";
 import SessionHistoryExpandButton from "./components/SessionHistoryExpandButton.vue";
 import SessionHistoryPanel from "./components/SessionHistoryPanel.vue";
@@ -452,7 +459,11 @@ const { roles, refreshRoles } = useRoles();
 const { currentRoleId } = useCurrentRole(roles);
 
 const userInput = ref("");
-const pastedFile = ref<PastedFile | null>(null);
+const pastedFiles = ref<PastedFile[]>([]);
+// Messages the user submitted while a previous run was still in
+// flight. Flushed FIFO when `activeSessionRunning` flips back to
+// false. See plans/feat-chat-input-queued-send.md.
+const queuedMessages = ref<{ text: string; files: PastedFile[] }[]>([]);
 const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, historyError, fetchSessions, setBookmark, deleteSession: deleteSessionFromHistory } = useSessionHistory();
@@ -538,7 +549,7 @@ useGlobalImageErrorRepair();
 
 const sessionSidebarRef = ref<{ root: HTMLDivElement | null } | null>(null);
 const canvasRef = ref<HTMLDivElement | null>(null);
-const chatInputRef = ref<{ focus: () => void; collapseSuggestions: () => void; readFile: (file: File) => void } | null>(null);
+const chatInputRef = ref<{ focus: () => void; collapseSuggestions: () => void; readFiles: (files: File[]) => Promise<void> } | null>(null);
 const { focusChatInput } = useChatScroll({
   sessionSidebarRef,
   toolResults,
@@ -560,8 +571,8 @@ const {
   onDragleave: onPanelDragleave,
   onDrop: onPanelDrop,
 } = useFileDropZone({
-  onFile: (file) => {
-    chatInputRef.value?.readFile(file);
+  onFiles: (files) => {
+    chatInputRef.value?.readFiles(files).catch(() => undefined);
   },
 });
 
@@ -974,45 +985,29 @@ function unsubscribeSession(chatSessionId: string): void {
   }
 }
 
-async function sendMessage(text?: string) {
-  const message = typeof text === "string" ? text : userInput.value.trim();
-  if (!message || activeSessionRunning.value) return;
-  userInput.value = "";
-  const fileSnapshot = pastedFile.value;
-  pastedFile.value = null;
+// Upload the attachments and return the resolved workspace paths.
+// Returns `{ failure }` on the first upload error so the caller can
+// surface it (and decide whether to restore the input draft).
+async function uploadAttachments(filesSnapshot: PastedFile[]): Promise<{ paths: string[] } | { failure: string }> {
+  if (filesSnapshot.length === 0) return { paths: [] };
+  const results = await Promise.all(filesSnapshot.map((file) => resolvePastedAttachment(file)));
+  const firstFailure = results.find((entry) => !entry.ok);
+  if (firstFailure && !firstFailure.ok) return { failure: firstFailure.error };
+  return { paths: results.flatMap((entry) => (entry.ok ? [entry.value] : [])) };
+}
 
-  // Pasted / dropped files are pre-uploaded to a workspace file so
-  // the server (and the LLM downstream) sees a relative path — never
-  // a data: URI. The path then rides on `attachments[]` as a path-only
-  // entry. On upload failure, restore both userInput and pastedFile so
-  // the user can retry without retyping.
-  let attachmentForRequest: string | undefined;
-  if (fileSnapshot) {
-    const resolved = await resolvePastedAttachment(fileSnapshot);
-    if (!resolved.ok) {
-      userInput.value = message;
-      pastedFile.value = fileSnapshot;
-      const recoverySession = sessionMap.get(currentSessionId.value);
-      if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
-      return;
-    }
-    attachmentForRequest = resolved.value;
-  }
-
+// Start the agent run for an already-resolved message + attachment
+// path set. Pure pipeline-driver: no UI ref reads / writes.
+async function postUserTurn(message: string, attachmentPaths: string[] | undefined): Promise<void> {
   const session = sessionMap.get(currentSessionId.value);
   if (!session) return;
-
   // Only files the user explicitly attached this turn (paste / drop /
   // file-picker) ride on the message. Do NOT auto-attach whatever
   // image happens to be selected in the sidebar — selection moves to
   // the latest generated image automatically, which would silently
   // glue the previous picture onto every follow-up comment.
-  const attachmentPaths = attachmentForRequest ? [attachmentForRequest] : undefined;
-
   beginUserTurn(session, message, attachmentPaths);
-
   ensureSessionSubscription(session);
-
   const result = await postAgentRun(
     buildAgentRequestBody({
       message,
@@ -1025,6 +1020,67 @@ async function sendMessage(text?: string) {
     pushErrorMessage(session, result.error);
     unsubscribeSession(session.id);
   }
+}
+
+async function sendMessage(text?: string) {
+  const message = typeof text === "string" ? text : userInput.value.trim();
+  if (!message) return;
+
+  // Queue the message while a previous run is still in flight. The
+  // watcher on `activeSessionRunning` (just below) flushes the queue
+  // FIFO once the run completes. plans/feat-chat-input-queued-send.md
+  // for the design rationale.
+  if (activeSessionRunning.value) {
+    queuedMessages.value.push({ text: message, files: [...pastedFiles.value] });
+    userInput.value = "";
+    pastedFiles.value = [];
+    return;
+  }
+
+  userInput.value = "";
+  const filesSnapshot = [...pastedFiles.value];
+  pastedFiles.value = [];
+
+  // Pasted / dropped files are pre-uploaded so the server sees a
+  // relative path. If ANY upload fails we restore text + files
+  // together so a retry doesn't lose the partial set the user
+  // assembled. plans/feat-chat-input-multi-attach.md
+  const upload = await uploadAttachments(filesSnapshot);
+  if ("failure" in upload) {
+    userInput.value = message;
+    pastedFiles.value = filesSnapshot;
+    const recoverySession = sessionMap.get(currentSessionId.value);
+    if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: upload.failure }));
+    return;
+  }
+  await postUserTurn(message, upload.paths.length > 0 ? upload.paths : undefined);
+}
+
+// Flush queued messages once the current run goes idle. Shifts one at
+// a time so the next dequeue waits for the freshly-started run to
+// finish — otherwise back-to-back posts would race the SSE-driven
+// `activeSessionRunning` flip and overlap.
+//
+// The queued path intentionally does NOT restore on upload failure:
+// those messages already left the input box, and resurrecting them
+// would clobber whatever the user has typed since. We surface the
+// error inline in chat and drop the queue entry instead.
+watch(activeSessionRunning, async (running, wasRunning) => {
+  if (!wasRunning || running) return;
+  if (queuedMessages.value.length === 0) return;
+  const next = queuedMessages.value.shift();
+  if (!next) return;
+  const upload = await uploadAttachments(next.files);
+  if ("failure" in upload) {
+    const recoverySession = sessionMap.get(currentSessionId.value);
+    if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: upload.failure }));
+    return;
+  }
+  await postUserTurn(next.text, upload.paths.length > 0 ? upload.paths : undefined);
+});
+
+function removeQueuedMessage(index: number): void {
+  queuedMessages.value.splice(index, 1);
 }
 
 // Route workspace-internal links (wiki pages, files, sessions) to the

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -1,9 +1,11 @@
 <template>
   <!-- File drop is handled at the chat panel level (#1289 Step 2)
        so the user can drop anywhere over the panel + messages, not
-       just over the input box. ChatInput still owns `readFile` for
-       the dropped file — App.vue calls it via the exposed method
-       once the panel-wide drop fires. -->
+       just over the input box. ChatInput still owns `readFiles` for
+       the dropped files — App.vue calls it via the exposed method
+       once the panel-wide drop fires. Multi-attach was added in
+       plans/feat-chat-input-multi-attach.md so a single turn can
+       carry several screenshots / PDFs. -->
   <div class="border-t border-gray-200">
     <SuggestionsPanel
       v-model:expanded="suggestionsExpanded"
@@ -16,22 +18,34 @@
       <div v-if="fileError" class="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5" data-testid="file-error">
         {{ fileError }}
       </div>
-      <ChatAttachmentPreview
-        v-if="pastedFile"
-        :data-url="pastedFile.dataUrl"
-        :filename="pastedFile.name"
-        :mime="pastedFile.mime"
-        @remove="emit('update:pastedFile', null)"
-      />
-      <div class="flex gap-2" :class="{ 'mt-2': pastedFile }">
+      <div v-if="pastedFiles.length > 0" data-testid="chat-attachment-list" class="flex flex-wrap gap-1.5 mb-2">
+        <ChatAttachmentPreview
+          v-for="(file, index) in pastedFiles"
+          :key="`${file.name}-${index}`"
+          :data-url="file.dataUrl"
+          :filename="file.name"
+          :mime="file.mime"
+          @remove="removeAttachment(index)"
+        />
+      </div>
+      <div class="flex gap-2">
+        <!-- The textarea stays enabled even while a run is in flight so
+             the user can compose the NEXT message ("multitask"). The
+             send button used to be gated on `isRunning` to prevent a
+             double-submit; that was relaxed in
+             plans/feat-chat-input-queued-send.md so users can queue
+             a follow-up while the current run is still streaming.
+             App.vue's sendMessage() pushes onto a queue when running,
+             and flushes once `activeSessionRunning` flips back to
+             false. The textarea was always enabled (originally for
+             IME-in-progress safety, #1289 follow-up). -->
         <textarea
           ref="textarea"
           :value="modelValue"
           data-testid="user-input"
           :placeholder="t('chatInput.placeholder')"
           rows="2"
-          class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
-          :disabled="isRunning"
+          class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
           @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
           @compositionstart="imeEnter.onCompositionStart"
           @compositionend="imeEnter.onCompositionEnd"
@@ -54,12 +68,11 @@
           <button
             data-testid="send-btn"
             class="bg-blue-600 hover:bg-blue-700 text-white rounded w-8 h-8 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-            :title="t('chatInput.send')"
-            :aria-label="t('chatInput.send')"
-            :disabled="isRunning"
+            :title="isRunning ? t('chatInput.queueWhileRunning') : t('chatInput.send')"
+            :aria-label="isRunning ? t('chatInput.queueWhileRunning') : t('chatInput.send')"
             @click="emit('send')"
           >
-            <span class="material-icons text-base leading-none">send</span>
+            <span class="material-icons text-base leading-none">{{ isRunning ? "schedule_send" : "send" }}</span>
           </button>
           <button
             data-testid="attach-file-btn"
@@ -74,10 +87,11 @@
       </div>
 
       <!-- Hidden file input driven by the attach button. The `accept`
-           filter matches ACCEPTED_MIME_PREFIXES/_EXACT below; the change
-           handler routes through the same readAttachmentFile() used by
-           drop + paste, so all three paths behave identically. -->
-      <input ref="fileInput" type="file" class="hidden" :accept="fileInputAccept" data-testid="file-input" @change="onFilePicked" />
+           filter matches ACCEPTED_MIME_PREFIXES/_EXACT below; `multiple`
+           was added so the picker can return several files in one go.
+           The change handler routes through the same readAttachmentFiles()
+           used by drop + paste, so all three paths behave identically. -->
+      <input ref="fileInput" type="file" multiple class="hidden" :accept="fileInputAccept" data-testid="file-input" @change="onFilePicked" />
     </div>
   </div>
 </template>
@@ -94,10 +108,10 @@ export type { PastedFile };
 
 const { t } = useI18n();
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     modelValue: string;
-    pastedFile: PastedFile | null;
+    pastedFiles: PastedFile[];
     isRunning: boolean;
     queries?: string[];
   }>(),
@@ -106,7 +120,7 @@ withDefaults(
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
-  "update:pastedFile": [file: PastedFile | null];
+  "update:pastedFiles": [files: PastedFile[]];
   send: [];
   "suggestion-send": [query: string];
 }>();
@@ -142,45 +156,67 @@ function isAcceptedType(mime: string): boolean {
   return ACCEPTED_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix)) || ACCEPTED_MIME_EXACT.has(mime);
 }
 
-function readAttachmentFile(file: File): void {
+function readSingleFile(file: File): Promise<PastedFile | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve({ dataUrl: reader.result, name: file.name, mime: file.type });
+      } else {
+        resolve(null);
+      }
+    };
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
+}
+
+async function readAttachmentFiles(files: File[]): Promise<void> {
   fileError.value = null;
-  if (!isAcceptedType(file.type)) {
-    // Previously returned silently. That left the user wondering whether
-    // the drop/paste registered at all — #499.
-    fileError.value = t("chatInput.unsupportedFileType");
-    return;
-  }
-  if (file.size > MAX_ATTACH_BYTES) {
-    const sizeMB = (file.size / 1024 / 1024).toFixed(1);
-    fileError.value = t("chatInput.fileTooLarge", { sizeMB });
-    return;
-  }
-  const reader = new FileReader();
-  reader.onload = () => {
-    if (typeof reader.result === "string") {
-      emit("update:pastedFile", {
-        dataUrl: reader.result,
-        name: file.name,
-        mime: file.type,
-      });
+  const accepted: File[] = [];
+  for (const file of files) {
+    if (!isAcceptedType(file.type)) {
+      // Previously returned silently. That left the user wondering whether
+      // the drop/paste registered at all — #499.
+      fileError.value = t("chatInput.unsupportedFileType");
+      continue;
     }
-  };
-  reader.readAsDataURL(file);
+    if (file.size > MAX_ATTACH_BYTES) {
+      const sizeMB = (file.size / 1024 / 1024).toFixed(1);
+      fileError.value = t("chatInput.fileTooLarge", { sizeMB });
+      continue;
+    }
+    accepted.push(file);
+  }
+  if (accepted.length === 0) return;
+  const results = await Promise.all(accepted.map(readSingleFile));
+  const ok = results.filter((entry): entry is PastedFile => entry !== null);
+  if (ok.length === 0) return;
+  emit("update:pastedFiles", [...props.pastedFiles, ...ok]);
+}
+
+function removeAttachment(index: number): void {
+  emit(
+    "update:pastedFiles",
+    props.pastedFiles.filter((_, i) => i !== index),
+  );
 }
 
 function onPasteFile(event: ClipboardEvent): void {
   const items = event.clipboardData?.items;
   if (!items) return;
+  const files: File[] = [];
   for (const item of items) {
     if (isAcceptedType(item.type)) {
       const file = item.getAsFile();
-      if (file) {
-        event.preventDefault();
-        readAttachmentFile(file);
-        return;
-      }
+      if (file) files.push(file);
     }
   }
+  if (files.length === 0) return;
+  // Stop the default paste only when we're actually capturing the
+  // clipboard. Otherwise text-paste into the textarea would be eaten.
+  event.preventDefault();
+  void readAttachmentFiles(files);
 }
 
 function openFilePicker(): void {
@@ -189,8 +225,8 @@ function openFilePicker(): void {
 
 function onFilePicked(event: Event): void {
   const input = event.target as HTMLInputElement;
-  const file = input.files?.[0];
-  if (file) readAttachmentFile(file);
+  const files = Array.from(input.files ?? []);
+  if (files.length > 0) void readAttachmentFiles(files);
   // Reset so selecting the same file twice in a row still fires @change.
   input.value = "";
 }
@@ -214,5 +250,5 @@ function collapseSuggestions(): void {
   suggestionsExpanded.value = false;
 }
 
-defineExpose({ focus, collapseSuggestions, readFile: readAttachmentFile });
+defineExpose({ focus, collapseSuggestions, readFiles: readAttachmentFiles });
 </script>

--- a/src/components/QueuedMessagesPanel.vue
+++ b/src/components/QueuedMessagesPanel.vue
@@ -1,0 +1,49 @@
+<template>
+  <!-- Inline panel that lists messages the user submitted while a
+       previous run was still streaming. The submit-time snapshot is
+       stored in App.vue's `queuedMessages` ref; once
+       `activeSessionRunning` flips false the watcher shifts them off
+       FIFO into sendMessage(). plans/feat-chat-input-queued-send.md
+       for the rationale. -->
+  <div v-if="messages.length > 0" data-testid="queued-messages-panel" class="border-t border-gray-100 bg-amber-50/60 px-3 py-2">
+    <div class="text-[11px] font-medium text-amber-800 mb-1">
+      {{ t("chatInput.queuedHeading", { count: messages.length }) }}
+    </div>
+    <ul class="flex flex-col gap-1">
+      <li
+        v-for="(entry, index) in messages"
+        :key="index"
+        data-testid="queued-message-item"
+        class="flex items-start gap-2 text-xs text-gray-800 bg-white border border-amber-200 rounded px-2 py-1"
+      >
+        <span class="text-amber-700 leading-snug shrink-0 tabular-nums">{{ `#${index + 1}` }}</span>
+        <span class="flex-1 whitespace-pre-wrap break-words leading-snug">{{ entry.text }}</span>
+        <span v-if="entry.files.length > 0" class="shrink-0 text-[10px] text-amber-700">
+          {{ t("chatInput.queuedAttachmentBadge", { count: entry.files.length }) }}
+        </span>
+        <button
+          data-testid="queued-message-remove"
+          class="shrink-0 text-gray-400 hover:text-gray-600 text-sm leading-none"
+          :title="t('chatInput.queuedRemove')"
+          :aria-label="t('chatInput.queuedRemove')"
+          @click="emit('remove', index)"
+        >
+          ✕
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import type { PastedFile } from "../types/pastedFile";
+
+const { t } = useI18n();
+
+defineProps<{
+  messages: { text: string; files: PastedFile[] }[];
+}>();
+
+const emit = defineEmits<{ remove: [index: number] }>();
+</script>

--- a/src/composables/useFileDropZone.ts
+++ b/src/composables/useFileDropZone.ts
@@ -32,10 +32,10 @@ export interface UseFileDropZoneResult extends FileDropHandlers {
 }
 
 export interface UseFileDropZoneOptions {
-  /** Called when the user releases a file over the zone. The
-   *  composable picks `files[0]` (first file) and ignores the rest;
-   *  multi-file uploads are not a current product requirement. */
-  onFile: (file: File) => void;
+  /** Called when the user releases one or more files over the zone.
+   *  All files in `dataTransfer.files` are passed through; the caller
+   *  is responsible for accepting / rejecting individual entries. */
+  onFiles: (files: File[]) => void;
 }
 
 // Module-scope so the install-once contract holds across multiple
@@ -105,8 +105,8 @@ export function useFileDropZone(opts: UseFileDropZoneOptions): UseFileDropZoneRe
     if (!isFileDrag(event)) return;
     event.preventDefault();
     resetTerminal();
-    const file = event.dataTransfer?.files[0];
-    if (file) opts.onFile(file);
+    const files = Array.from(event.dataTransfer?.files ?? []);
+    if (files.length > 0) opts.onFiles(files);
   }
 
   function resetTerminal(): void {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -37,6 +37,10 @@ const deMessages = {
     unsupportedFileType: "Dateityp nicht unterstützt. Akzeptiert: Bilder, PDF, DOCX, XLSX, PPTX, Textdateien.",
     attachImageFailed: "Anhängen des Bildes fehlgeschlagen: {error}",
     dropHint: "Datei zum Anhängen ablegen",
+    queueWhileRunning: "Nach aktuellem Lauf in Warteschlange",
+    queuedHeading: "In Warteschlange: {count}",
+    queuedAttachmentBadge: "+{count} Dateien",
+    queuedRemove: "Aus Warteschlange entfernen",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -59,6 +59,10 @@ const enMessages = {
     unsupportedFileType: "File type not supported. Accepted: images, PDF, DOCX, XLSX, PPTX, text files.",
     attachImageFailed: "Failed to attach image: {error}",
     dropHint: "Drop file to attach",
+    queueWhileRunning: "Queue for after the current run",
+    queuedHeading: "Queued: {count}",
+    queuedAttachmentBadge: "+{count} files",
+    queuedRemove: "Remove from queue",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -42,6 +42,10 @@ const esMessages = {
     unsupportedFileType: "Tipo de archivo no admitido. Se aceptan: imágenes, PDF, DOCX, XLSX, PPTX y archivos de texto.",
     attachImageFailed: "No se pudo adjuntar la imagen: {error}",
     dropHint: "Suelta el archivo para adjuntar",
+    queueWhileRunning: "Encolar para después de la ejecución actual",
+    queuedHeading: "En cola: {count}",
+    queuedAttachmentBadge: "+{count} archivos",
+    queuedRemove: "Quitar de la cola",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -37,6 +37,10 @@ const frMessages = {
     unsupportedFileType: "Type de fichier non pris en charge. Acceptés : images, PDF, DOCX, XLSX, PPTX, fichiers texte.",
     attachImageFailed: "Échec de l'attache de l'image : {error}",
     dropHint: "Déposez le fichier pour joindre",
+    queueWhileRunning: "Mettre en file pour après l'exécution en cours",
+    queuedHeading: "En attente : {count}",
+    queuedAttachmentBadge: "+{count} fichiers",
+    queuedRemove: "Retirer de la file",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -44,6 +44,10 @@ const jaMessages = {
     unsupportedFileType: "対応していないファイル形式です。画像・PDF・DOCX・XLSX・PPTX・テキストファイルを使用してください。",
     attachImageFailed: "画像の添付に失敗しました: {error}",
     dropHint: "ファイルをドロップして添付",
+    queueWhileRunning: "実行完了後に送信",
+    queuedHeading: "送信待ち: {count}",
+    queuedAttachmentBadge: "+{count} 添付",
+    queuedRemove: "キューから削除",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -44,6 +44,10 @@ const koMessages = {
     unsupportedFileType: "지원되지 않는 파일 형식입니다. 이미지, PDF, DOCX, XLSX, PPTX, 텍스트 파일만 지원됩니다.",
     attachImageFailed: "이미지를 첨부하지 못했습니다: {error}",
     dropHint: "파일을 놓아서 첨부",
+    queueWhileRunning: "현재 실행 후 전송",
+    queuedHeading: "대기 중: {count}",
+    queuedAttachmentBadge: "+{count}개 첨부",
+    queuedRemove: "대기열에서 제거",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -37,6 +37,10 @@ const ptBRMessages = {
     unsupportedFileType: "Tipo de arquivo não suportado. Aceitos: imagens, PDF, DOCX, XLSX, PPTX e arquivos de texto.",
     attachImageFailed: "Falha ao anexar a imagem: {error}",
     dropHint: "Solte o arquivo para anexar",
+    queueWhileRunning: "Enfileirar para depois da execução atual",
+    queuedHeading: "Na fila: {count}",
+    queuedAttachmentBadge: "+{count} arquivos",
+    queuedRemove: "Remover da fila",
   },
   sessionHistoryPanel: {
     filters: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -42,6 +42,10 @@ const zhMessages = {
     unsupportedFileType: "不支持的文件类型。支持:图像、PDF、DOCX、XLSX、PPTX、文本文件。",
     attachImageFailed: "附加图片失败：{error}",
     dropHint: "拖放文件以附加",
+    queueWhileRunning: "等运行结束后再发送",
+    queuedHeading: "排队中: {count}",
+    queuedAttachmentBadge: "+{count} 个文件",
+    queuedRemove: "从队列中移除",
   },
   sessionHistoryPanel: {
     filters: {


### PR DESCRIPTION
## Summary

Two related ChatInput improvements that compound for screenshot-heavy workflows.

### Multi-attach
The picker, paste, and drop paths all accept several files in one go. The hidden `<input>` gains `multiple`, the paste handler stops returning after the first item, and `useFileDropZone` now hands the caller every file in `dataTransfer.files`. The component prop is `pastedFiles: PastedFile[]`; preview chips render in a flex-wrap row, each with its own × remove button. Uploads run in parallel via `Promise.all`; a single failure restores the whole draft for retry.

### Queued send
The send button stays enabled while a run is in flight. Submissions during that window land in `queuedMessages` (text + attachment snapshot) and a new `QueuedMessagesPanel` renders the backlog directly above the input. A `watch(activeSessionRunning)` flushes the queue FIFO once the run flips back to idle — one entry per transition so each new run gets its own clean SSE lifecycle.

### Race-free attachment plumbing
`sendMessage` is decomposed into `uploadAttachments` (pure upload) and `postUserTurn` (pure run-start). The immediate path restores draft on upload failure; the queued path surfaces the failure inline (it can't restore safely once the user has typed something new).

## Plans

- [plans/feat-chat-input-multi-attach.md](plans/feat-chat-input-multi-attach.md)
- [plans/feat-chat-input-queued-send.md](plans/feat-chat-input-queued-send.md)

## i18n

4 new keys added in lockstep across all 8 supported locales:
- `queueWhileRunning` — Send button tooltip during a run
- `queuedHeading` — "Queued: {count}" panel header
- `queuedAttachmentBadge` — "+{count} files" per queue entry
- `queuedRemove` — × button label

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` 0 errors (existing rules: `sonarjs/void-use`, `@intlify/vue-i18n/no-raw-text` both green)
- [x] `yarn typecheck` clean
- [x] `yarn build` succeeds
- [x] `yarn test` — 26 unit tests pass
- [x] `yarn test:e2e e2e/tests/chatinput-attach.spec.ts` — 12 pass (11 existing + 1 new "multiple drops surface a preview chip per file")
- [x] `yarn test:e2e e2e/tests/chatinput-queue.spec.ts` — 3 new tests pass (send-enabled-during-run, queue-on-submit, × removal)
- [ ] Manual: paste 2 screenshots into the chat — both preview, send works
- [ ] Manual: pick 2 PDFs via the paperclip dialog (Cmd+click) — both preview
- [ ] Manual: send a message, while it's "Thinking…" type another and click Send — yellow "Queued: 1" panel appears, then auto-sends when the first run completes

## Out of scope

- Drag-reorder of queued messages
- Persistence of queued messages across page reload
- Interrupt-style send (true mid-stream interjection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-file attachments: upload multiple files per message
  * Queued sending: submit messages while an agent is running; messages queue and auto-execute in order
  * New queued messages panel displays pending submissions with attachment counts

* **Tests**
  * Added E2E tests for multi-file attachments and queued send scenarios

* **Localization**
  * Added translations for new queue features across 8 languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->