### PR TITLE
ci: auto-triage non-maintainer PRs against the plan-first policy

### DIFF
--- a/.github/workflows/pr_triage.yaml
+++ b/.github/workflows/pr_triage.yaml
@@ -32,7 +32,12 @@ on:
   #      pull_request.* }}` template substitution into the shell body,
   #      so zizmor's template-injection vector is closed.
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    # `edited` catches base-branch retargets: a contributor could open
+    # the PR against a non-main branch (bypassing `branches: [main]`)
+    # then edit it to point at main. That arrives as `edited`, not
+    # `opened` / `reopened`, so triage would otherwise never fire on
+    # the retargeted PR. CodeRabbit + Codex review on PR #1708.
+    types: [opened, reopened, synchronize, edited]
     branches: [main]
 
 permissions:

--- a/.github/workflows/pr_triage.yaml
+++ b/.github/workflows/pr_triage.yaml
@@ -1,0 +1,104 @@
+# Auto-triage incoming pull requests against the "open an issue and
+# agree on a plan first" contribution policy (docs/developer.md →
+# Contributing). PRs from listed maintainers / bots fall through with
+# no action. PRs from anyone else are allowed only when the diff is
+# small (additions + deletions ≤ LINE_LIMIT). Anything larger gets a
+# templated comment pointing at the policy and is closed.
+#
+# Why `pull_request_target` over `pull_request`:
+#   - Forked PRs running `pull_request` don't get write-scoped
+#     GITHUB_TOKEN, so we couldn't comment + close them.
+#   - `pull_request_target` runs from the base repo's workflow on the
+#     base branch, and we never check out the PR's code, so the usual
+#     `pull_request_target` security concerns (running attacker code
+#     with elevated permissions) don't apply here.
+#
+# Maintainer list — keep in sync with the Contributing section of
+# docs/developer.md. Adding a maintainer is a one-line edit in both
+# places.
+
+name: PR triage (non-maintainer guard)
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pr-triage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      # Newline-separated allowlist. Match is exact (full GitHub login
+      # including the `[bot]` suffix for App accounts).
+      MAINTAINERS: |
+        isamu
+        snakajima
+        ystknsh
+        yuki0627
+        dependabot[bot]
+        coderabbitai[bot]
+        sourcery-ai[bot]
+      # Combined cap on additions + deletions for non-maintainer PRs.
+      # The docs/developer.md "When you can skip the plan" section
+      # quotes the same number — bump both together if it changes.
+      LINE_LIMIT: 10
+      # Link target for the closing comment. Kept here so the URL
+      # interpolation happens at workflow-load time (not inside the
+      # bash heredoc) and stays grep-able alongside the policy.
+      DOC_LINK: https://github.com/${{ github.repository }}/blob/main/docs/developer.md#contributing--please-open-an-issue-with-a-plan-first
+    steps:
+      - name: Decide and act
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          ADDITIONS: ${{ github.event.pull_request.additions }}
+          DELETIONS: ${{ github.event.pull_request.deletions }}
+        run: |
+          set -euo pipefail
+          echo "PR=#${PR_NUMBER} author=${PR_AUTHOR} +${ADDITIONS} -${DELETIONS}"
+
+          # Exact-line match against the allowlist. `grep -Fxq` treats
+          # the pattern as a fixed string and requires whole-line
+          # equality, so the `[bot]` suffix isn't interpreted as a
+          # regex character class.
+          if echo "${MAINTAINERS}" | grep -Fxq "${PR_AUTHOR}"; then
+            echo "maintainer / allowlisted bot — pass through"
+            exit 0
+          fi
+
+          TOTAL=$((ADDITIONS + DELETIONS))
+          if [ "${TOTAL}" -le "${LINE_LIMIT}" ]; then
+            echo "small PR (${TOTAL} lines ≤ ${LINE_LIMIT}) — allowed"
+            exit 0
+          fi
+
+          # Large unsolicited PR — comment then close. Comment first
+          # so the closing event arrives with the explanation already
+          # attached (email notifications batch them together).
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$(cat <<EOF
+          ## This PR is being closed automatically — please open an issue first
+
+          Thanks for sending this! Our contribution policy is to **agree on a plan in a GitHub issue before opening a pull request**, except for very small fixes. This PR is **${TOTAL} lines of diff** (additions + deletions) and you're not on the maintainer allowlist, so it's being closed automatically.
+
+          ### What to do next
+
+          1. **Open an issue** describing the problem and your proposed plan. Keep the **first three lines a compact summary** so a maintainer can decide whether to engage at a glance. Save the longer rationale for the rest of the body.
+          2. **Wait for the plan to be agreed in the issue thread.** We may suggest scope adjustments, point out helpers you can reuse, or surface in-flight work that overlaps.
+          3. Once agreed, a maintainer drafts the pull request.
+
+          Direct pull requests are welcome for typos, copy fixes, doc tweaks, dependency bumps, and single-file bug fixes under **${LINE_LIMIT} lines of diff**. The full rationale lives in [docs/developer.md → Contributing](${DOC_LINK}).
+          EOF
+          )"
+          gh pr close "${PR_NUMBER}" --repo "${REPO}"

--- a/.github/workflows/pr_triage.yaml
+++ b/.github/workflows/pr_triage.yaml
@@ -20,6 +20,17 @@
 name: PR triage (non-maintainer guard)
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # `pull_request_target` is needed so forked PRs get a write-scoped
+  # GITHUB_TOKEN (we must comment + close them). The two usual abuse
+  # paths for this trigger don't apply here:
+  #   1. We never `actions/checkout` the PR's code, so no attacker
+  #      script ever runs with elevated permissions.
+  #   2. PR-controlled fields (author login, additions count) reach
+  #      the shell only through `env:` bindings and are referenced as
+  #      `${VAR}` (quoted) inside bash. There is no `${{ github.event.
+  #      pull_request.* }}` template substitution into the shell body,
+  #      so zizmor's template-injection vector is closed.
   pull_request_target:
     types: [opened, reopened, synchronize]
     branches: [main]

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -33,10 +33,20 @@ A direct pull request is welcome for:
 
 - Typos, copy fixes, documentation tweaks
 - Dependency version bumps
-- Single-file bug fixes with an obvious root cause and a matching test, ideally under 20 lines of diff
+- Single-file bug fixes with an obvious root cause and a matching test, **under 10 lines of diff (additions + deletions)**
 - Anything a maintainer or a continuous integration bot explicitly asks for in a review comment
 
 Anything larger than that should start as an issue. If you are not sure, opening an issue first is always cheaper than writing a pull request that will not be accepted. Thanks for understanding.
+
+### Automated triage on pull requests
+
+The `.github/workflows/pr_triage.yaml` workflow runs on every PR and enforces the rule above mechanically:
+
+- PRs from maintainers and allowlisted bots fall through. The current allowlist is `isamu`, `snakajima`, `ystknsh`, `yuki0627`, `dependabot[bot]`, `coderabbitai[bot]`, `sourcery-ai[bot]`. To add a maintainer, edit the `MAINTAINERS` list in the workflow and the same list here.
+- PRs from anyone else are accepted automatically when the diff is ≤ 10 lines (additions + deletions).
+- Larger non-maintainer PRs receive a templated comment that links back to this section and asks for an issue first — **the issue body's first three lines should be a compact summary of the problem and the proposed plan** so a maintainer can decide whether to engage at a glance — and the PR is closed.
+
+The line cap and the documentation are intentionally kept in lock-step. If the cap moves, update both the workflow's `LINE_LIMIT` and the bullet above in the same commit.
 
 ---
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -33,7 +33,7 @@ A direct pull request is welcome for:
 
 - Typos, copy fixes, documentation tweaks
 - Dependency version bumps
-- Single-file bug fixes with an obvious root cause and a matching test, **under 10 lines of diff (additions + deletions)**
+- Single-file bug fixes with an obvious root cause and a matching test, **10 lines of diff or fewer (additions + deletions, inclusive)**
 - Anything a maintainer or a continuous integration bot explicitly asks for in a review comment
 
 Anything larger than that should start as an issue. If you are not sure, opening an issue first is always cheaper than writing a pull request that will not be accepted. Thanks for understanding.


### PR DESCRIPTION
## Summary

PR triage workflow が「issue で plan を合意してから PR」という contribution policy を機械的に強制します:

- maintainer / allowlist 済み bot からの PR → そのまま通す
- それ以外のユーザの PR → `additions + deletions ≤ 10` なら通す
- それ以外 → developer.md の Contributing を案内するコメント投稿 + 自動 close

Allowlist (7): `isamu`, `snakajima`, `ystknsh`, `yuki0627`, `dependabot[bot]`, `coderabbitai[bot]`, `sourcery-ai[bot]`

## Items to Confirm / Review

- **trigger は `pull_request_target`**: fork PR でも `GITHUB_TOKEN` が write 権限になるため必要。PR の中身は checkout しない (metadata のみ参照) ので、`pull_request_target` の典型的なセキュリティ懸念は当てはまらない (workflow ヘッダに記述)
- **行カウント = additions + deletions**: typo fix (1+1=2) や small rename を通しやすい設計。質問の合意通り
- **closing コメントの文面**: 3 ステップ手順 (issue 立てる → plan 合意 → maintainer drafts) + 「issue 本文の先頭 3 行を要約に」と明記。developer.md にディープリンク
- **doc と workflow の同期**: `LINE_LIMIT=10` と allowlist は doc 側にも書いてあり、変更は両方同時の旨をコメントで明記
- **小さい逸脱への余裕**: maintainer が override ラベルや draft skip を入れる選択は今回見送り (質問で選ばれず)。必要なら follow-up
- **この PR 自身は maintainer (isamu) author なので triage 対象外** = 通常 review + merge できる

## User Prompt

> Contributing に関して、10 行以下の簡単な PR は外部から受け入れても良いけど、それ以外は機械的に issue を立てるようにコメントして close したい。そして、そのときにこの doc へのリンクを issue を立てて、そのissueは最初の 3 行で概要をコンパクトに纏めてほしいと書く。主な開発者 (現在の bot 含むコントリビューター 7) だけの PR は素通りにしたい。それを CI で自動化できる？

## Implementation

### `.github/workflows/pr_triage.yaml` (新規)

```yaml
on:
  pull_request_target:
    types: [opened, reopened, synchronize]
    branches: [main]
permissions:
  contents: read
  issues: write
  pull-requests: write
concurrency:
  group: pr-triage-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

ステップは 1 つ:
1. `MAINTAINERS` リストに `PR_AUTHOR` が exact match で含まれるなら exit 0
2. `additions + deletions ≤ LINE_LIMIT` なら exit 0
3. それ以外: `gh pr comment` で説明コメント → `gh pr close` で close

### `docs/developer.md` (更新)

- 「When you can skip the plan」の line cap を 20 → **10** に統一 (workflow と一致)
- 直後に「Automated triage on pull requests」見出しを追加し、workflow の挙動を解説 + maintainer 一覧を併記。「両方同時に更新」と明記

## Test Plan

- [ ] `actionlint` のローカルチェックは pass (workflow syntax OK)
- [ ] heredoc dry-run で comment 本文の interpolation が想定通り
- [ ] この PR は **maintainer 著者なので triage 対象外** = 通常 CI で問題なく merge できることを確認
- [ ] merge 後、テスト用ダミー non-maintainer PR (sock-puppet account / fork から) で動作確認するなら別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request triage for pull requests targeting the main branch, with policy comments and automatic closing when the diff size exceeds the allowed limit, except for approved maintainer/bot authors.

* **Documentation**
  * Updated contribution guidance to further narrow the “direct pull request without an issue plan” exception to only very small, root-cause bug-fix changes with matching tests, and added a section documenting the triage automation and the requirement to keep the published diff limit aligned with it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->