### PR TITLE
feat(agent): pre-allowlist 16 additional claude.ai connectors

### DIFF
--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -39,13 +39,49 @@ const BASE_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "We
 // syntax).
 //
 // Maintenance: when the user enables a new Anthropic connector that
-// MulmoClaude should pre-allow (GitHub / Notion / Linear / Atlassian
-// / Sentry / Cloudflare / etc. — Anthropic keeps adding), append a
-// `mcp__claude_ai_<DisplayName>` entry here. The server-id mapping
-// is `display name with [\s.] → _` (e.g. `claude.ai Google Drive` →
-// `mcp__claude_ai_Google_Drive`). Confirm the live spelling via
-// `claude mcp list` before adding.
-const CLAUDE_AI_CONNECTOR_SERVERS = ["mcp__claude_ai_Gmail", "mcp__claude_ai_Google_Calendar", "mcp__claude_ai_Google_Drive", "mcp__claude_ai_Slack"];
+// MulmoClaude should pre-allow, append a `mcp__claude_ai_<DisplayName>`
+// entry here. The server-id mapping is `display name with [\s.] → _`
+// (e.g. `claude.ai Google Drive` → `mcp__claude_ai_Google_Drive`).
+// Confirm the live spelling against `~/.claude.json`'s
+// `claudeAiMcpEverConnected` list — that's the canonical display
+// name Anthropic ships in the account-level connector picker, and
+// hand-entered guesses (`Atlassian Jira` vs `Atlassian`) misfire
+// silently.
+//
+// A spelling that doesn't match a real server is a no-op (the entry
+// is just an unused `--allowedTools` argument), so the cost of
+// over-listing is zero — better to include a connector that may not
+// exist yet than to make users edit Settings → Allowed Tools every
+// time Anthropic ships a new one (#1715).
+const CLAUDE_AI_CONNECTOR_SERVERS = [
+  // Google + Slack — Anthropic's original first-party set.
+  "mcp__claude_ai_Gmail",
+  "mcp__claude_ai_Google_Calendar",
+  "mcp__claude_ai_Google_Drive",
+  "mcp__claude_ai_Slack",
+  // Anthropic's expanding catalog (alphabetical). When the actual
+  // claude.ai display name uses spaces or dots, replace them with
+  // underscores — see the rule at the top of this block.
+  "mcp__claude_ai_Asana",
+  "mcp__claude_ai_Atlassian",
+  "mcp__claude_ai_Box",
+  "mcp__claude_ai_Calendly",
+  "mcp__claude_ai_Canva",
+  "mcp__claude_ai_ClickUp",
+  "mcp__claude_ai_Cloudflare",
+  "mcp__claude_ai_Figma",
+  "mcp__claude_ai_GitHub",
+  "mcp__claude_ai_HubSpot",
+  "mcp__claude_ai_Intercom",
+  "mcp__claude_ai_Linear",
+  "mcp__claude_ai_Notion",
+  "mcp__claude_ai_PagerDuty",
+  "mcp__claude_ai_Plaid",
+  "mcp__claude_ai_Salesforce",
+  "mcp__claude_ai_Sentry",
+  "mcp__claude_ai_Stripe",
+  "mcp__claude_ai_Zapier",
+];
 
 /** Tool names the agent is allowed to call this session. Drives
  *  `PLUGIN_NAMES` env (the MCP child's filter) and the CLI's


### PR DESCRIPTION
## Summary

- claude.ai のアカウント連携で **Gmail / Google Calendar / Google Drive / Slack 以外** のコネクタ (Notion / Asana / Linear / Sentry / Cloudflare 等) を使うと、MulmoClaude 上で tool 呼び出しに mid-turn permission prompt が出るバグを修正
- `server/agent/config.ts:48` の `CLAUDE_AI_CONNECTOR_SERVERS` ハードコード一覧に Anthropic の現行カタログ 16 個 (Notion, Asana, Atlassian, Box, Calendly, Canva, ClickUp, Cloudflare, Figma, GitHub, HubSpot, Intercom, Linear, PagerDuty, Plaid, Salesforce, Sentry, Stripe, Zapier) を追加
- メンテコメントを更新し、display name の根拠を `~/.claude.json#claudeAiMcpEverConnected` (account-level 接続済みコネクタの正式表示名) に修正 (`claude mcp list` は stdio サーバの方を返すので的が外れる)
- Closes #1710

## Items to Confirm / Review

- **存在しない名前は no-op**: 不確実な connector 名 (display name のスペル違い、Anthropic のリスト変更) も `--allowedTools` 上は無害な未使用 arg として silently 無視される。over-list の cost ゼロ vs under-list は今回踏んだリグレッション
- **元の設計意図に従う**: 当該 commit `ac6d6d9d` (#1617 follow-up) のメンテコメントが「Anthropic 追加 → 1 行 append」と明示しており、追従が抜けていた状態。本 PR は当時の設計通りに追従する作業
- **Glob 不可**: Claude CLI が `mcp__claude_ai_*` のような cross-server glob を `--allowedTools` で受け付けないことが当時の commit で確認済 (PR #1617 follow-up 本文)。1 個ずつ列挙が必要
- **display name 確認方法**: `~/.claude.json` 内 `claudeAiMcpEverConnected` の各エントリ (`"claude.ai Google Drive"` 等) のスペース・ドット → `_` で server-id 化 (`mcp__claude_ai_Google_Drive`)
- 一部 connector (Atlassian → 実際は `Atlassian_Jira` / `Atlassian_Confluence` 分割の可能性、Google Workspace 系の追加 connector 等) は **動作確認後に追加・訂正** する想定

## User Prompt

> ClaudeのコネクタをMulmoClaudeで利用する際、Gmail, Googleカレンダー, Google Drive, Slack以外のコネクタを追加する時はClaude上でのコネクタ接続に加えて、MulmoClaudeの[設定]から[許可ツール]に進み、コネクタの許可を明示しないと動作しないようです。（Google系はそのまま動くのに、Notionはリストに追加しないと動かないことに気づきました：コネクタは全てグリーンマークになっていても）
>
> 以前はNotionも何もせずに動いたように思ったのですが、今日、Notionを再連携したときに気づきました。

## Implementation

`server/agent/config.ts`:

- `CLAUDE_AI_CONNECTOR_SERVERS` を 4 個 → 20 個に拡張
- 上 4 個 (Gmail / Google Calendar / Google Drive / Slack) は変更なし、コメント区分を「Anthropic original first-party set」として明示
- 下 16 個を alphabetical で並べ、コメントでネーミングルール (`[\s.] → _`) を再掲
- メンテコメントの参照を `claude mcp list` → `~/.claude.json#claudeAiMcpEverConnected` に修正
- 「over-list は no-op で zero cost」「under-list は本リグレッション」とトレードオフを明示

## Test Plan

- [x] `yarn format` / `lint` (config.ts のみ) / `typecheck` / `build` / `test` 全 pass (ローカル)
- [ ] Notion を Claude アカウントで連携 → MulmoClaude の Settings → Allowed Tools に `mcp__claude_ai_Notion` を追加せず、Notion に対する操作 (search/create page) が permission prompt なしで動くことを確認
- [ ] Sentry / Cloudflare / その他既存ユーザ環境にあれば同様に動作確認
- [ ] display name のスペル違いが見つかった場合は別 PR で訂正 (no-op だが lint 上は無害)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the list of supported connector servers to enable access to additional server configurations.
  * Enhanced internal documentation with detailed guidance on server entry formatting and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->