### PR TITLE
feat: shared renderMarp + image-fill render core (markdown-plugin 0.1.2)

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -34,7 +34,7 @@
     "@mulmochat-plugin/quiz": "0.4.3",
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/form-plugin": "^0.1.0",
-    "@mulmoclaude/markdown-plugin": "^0.1.0",
+    "@mulmoclaude/markdown-plugin": "^0.1.2",
     "@mulmoclaude/spotify-plugin": "^0.1.0",
     "@receptron/task-scheduler": "^0.1.0",
     "cors": "^2.8.6",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/markdown-plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Full-fidelity markdown document plugin (presentDocument) — Marp slides, PDF export, AI image-fill — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/markdown-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Full-fidelity markdown document plugin (presentDocument) — Marp slides, PDF export, AI image-fill — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/markdown-plugin/src/core/index.ts
+++ b/packages/plugins/markdown-plugin/src/core/index.ts
@@ -7,3 +7,9 @@ export type { MarkdownExecuteContext } from "../plugins/markdown/core";
 export type { MarkdownHostApp, MarkdownDispatchArgs, MarkdownDispatchResult, ExportPdfOptions, MarpThemeEntry } from "../plugins/markdown/contract";
 // Hosts whose workspace file server is not `/api/files/raw` call this.
 export { setFilesRawUrl } from "../utils/image/resolve";
+// Shared Marp render core — both hosts' PDF export + the MarpView preview.
+export { renderMarpDeck, DEFAULT_SLIDE_WIDTH, DEFAULT_SLIDE_HEIGHT } from "../render/marp";
+export type { RenderMarpOptions, RenderMarpResult } from "../render/marp";
+// Shared image-placeholder fill — host injects image generation + storage.
+export { fillImagePlaceholders, buildImagePlaceholderReplacement, IMAGE_PLACEHOLDER } from "../render/imageFill";
+export type { FillImagePlaceholdersDeps, ImagePlaceholderResult } from "../render/imageFill";

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/MarpView.vue
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/MarpView.vue
@@ -45,8 +45,7 @@ import { usePdfExport } from "./usePdfExport";
 import type { MarpThemeEntry } from "./contract";
 import { errorMessage } from "../../utils/errors";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
-import { applyCustomMarpSize } from "../../utils/markdown/marpCustomSize";
-import { MARP_HTML_ALLOWLIST } from "../../utils/markdown/marpTheme";
+import { renderMarpDeck, type RenderMarpResult } from "../../render/marp";
 import { useT } from "../../lang";
 
 const t = useT();
@@ -60,8 +59,6 @@ const props = defineProps<{
 
 const DEFAULT_SLIDE_WIDTH = 1280;
 const DEFAULT_SLIDE_HEIGHT = 720;
-const MIN_SLIDE_DIM = 200;
-const MAX_SLIDE_DIM = 3840;
 const SLIDE_GAP_PX = 16;
 const BODY_PADDING_PX = 16;
 const WRAPPER_PADDING_PX = 12;
@@ -141,24 +138,6 @@ function countSlides(html: string): number {
   return sectionMatches ? sectionMatches.length : 0;
 }
 
-const SECTION_SIZE_RE = /div\.marpit\s*>\s*section\s*\{[^}]*?width:\s*(\d+)px[^}]*?height:\s*(\d+)px/;
-
-function clampDim(value: number, fallback: number): number {
-  if (!Number.isFinite(value) || value < MIN_SLIDE_DIM) return fallback;
-  return Math.min(value, MAX_SLIDE_DIM);
-}
-
-function extractSlideDimensions(css: string): { width: number; height: number } {
-  const match = css.match(SECTION_SIZE_RE);
-  if (match) {
-    return {
-      width: clampDim(Number(match[1]), DEFAULT_SLIDE_WIDTH),
-      height: clampDim(Number(match[2]), DEFAULT_SLIDE_HEIGHT),
-    };
-  }
-  return { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT };
-}
-
 function resetRenderState(): void {
   srcDoc.value = "";
   slideCount.value = 0;
@@ -189,24 +168,17 @@ async function loadMarpThemes(): Promise<readonly MarpThemeEntry[]> {
   }
 }
 
-async function prepareMarp(markdown: string): Promise<{ html: string; css: string }> {
-  const { Marp } = await import("@marp-team/marp-core");
-  // `html: MARP_HTML_ALLOWLIST` opens a small layout-tag subset
-  // (`<div class>`, `<span>`, `<img>`, …); default `html: false`
-  // escapes them all. Same allowlist applied server-side in
-  // `renderMarpPdf` so preview / export agree. Scripts, iframes,
-  // and form elements stay escaped.
-  const marp = new Marp({ inlineSVG: false, html: MARP_HTML_ALLOWLIST, emoji: { unicode: false, shortcode: false } });
+async function prepareMarp(markdown: string): Promise<RenderMarpResult> {
   // Register every workspace-defined theme (#1649). A deck opts in
   // via frontmatter `theme: <name>`; decks that don't keep Marp's
   // default look.
   const themes = await loadMarpThemes();
-  for (const theme of themes) {
-    marp.themeSet.add(theme.css);
-  }
+  // Rewrite workspace-relative `<img>` refs to host URLs BEFORE Marp so
+  // the preview iframe can load them (the PDF export inlines instead).
+  // `inlineSVG: false` (the renderMarpDeck default) → CSS-sized sections
+  // for the scrollable preview.
   const rewritten = rewriteMarkdownImageRefs(markdown, props.baseDir ?? "");
-  const sized = applyCustomMarpSize(marp, rewritten);
-  return marp.render(sized);
+  return renderMarpDeck(rewritten, { themes });
 }
 
 let renderToken = 0;
@@ -219,13 +191,12 @@ async function renderMarp(markdown: string): Promise<void> {
     return;
   }
   try {
-    const { html, css } = await prepareMarp(markdown);
+    const { html, css, slideWidth: width, slideHeight: height } = await prepareMarp(markdown);
     // regex note: monotonic render counter, not a secret
     if (token !== renderToken) return;
     slideCount.value = countSlides(html);
-    const dims = extractSlideDimensions(css);
-    slideWidth.value = dims.width;
-    slideHeight.value = dims.height;
+    slideWidth.value = width;
+    slideHeight.value = height;
     srcDoc.value = buildSrcDoc(html, css);
   } catch (err) {
     // regex note: monotonic render counter, not a secret

--- a/packages/plugins/markdown-plugin/src/render/imageFill.ts
+++ b/packages/plugins/markdown-plugin/src/render/imageFill.ts
@@ -5,7 +5,10 @@
 // image GENERATION + STORAGE is injected (each host wires its own
 // Gemini + image store / data-URI strategy).
 
-export const IMAGE_PLACEHOLDER = /!\[([^\]]+)\]\(\/?__too_be_replaced_image_path__\)/g;
+// Alt text is bounded ({1,1000}) rather than `+` so the regex stays linear on
+// adversarial/uncontrolled markdown (CodeQL polynomial-ReDoS); image prompts are
+// never anywhere near 1000 chars.
+export const IMAGE_PLACEHOLDER = /!\[([^\]]{1,1000})\]\(\/?__too_be_replaced_image_path__\)/g;
 
 /** Build the markdown that replaces one placeholder. `ref` is the
  *  host-resolved image reference (a workspace-rooted URL, a data URI, …)
@@ -28,11 +31,31 @@ export interface FillImagePlaceholdersDeps {
    *  generates + stores it, returning a URL or data URI), or null to
    *  fall back to a text marker. `index`/`total` are for progress logs. */
   resolveImage: (prompt: string, index: number, total: number) => Promise<string | null>;
+  /** Max image generations in flight at once. Bounded so a document with
+   *  many placeholders doesn't fan out into a burst of provider calls
+   *  (rate limits / resource spikes). Default 4. */
+  concurrency?: number;
+}
+
+/** Run `worker` over `items` with at most `limit` in flight, preserving
+ *  input order in the results. */
+async function mapWithConcurrency<T, R>(items: readonly T[], limit: number, worker: (item: T, index: number) => Promise<R>): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await worker(items[index], index);
+    }
+  });
+  await Promise.all(runners);
+  return results;
 }
 
 /** Replace every `__too_be_replaced_image_path__` placeholder. Returns
  *  the filled markdown plus the per-placeholder results so the host can
- *  emit its own batch observability. Generation runs concurrently. */
+ *  emit its own batch observability. Generation runs with bounded
+ *  concurrency (`deps.concurrency`, default 4). */
 export async function fillImagePlaceholders(
   markdown: string,
   deps: FillImagePlaceholdersDeps,
@@ -41,17 +64,22 @@ export async function fillImagePlaceholders(
   if (matches.length === 0) return { markdown, results: [] };
 
   const total = matches.length;
-  const results: ImagePlaceholderResult[] = await Promise.all(
-    matches.map(async (match, index) => ({
-      full: match[0],
-      prompt: match[1],
-      ref: await deps.resolveImage(match[1], index, total),
-    })),
-  );
+  const results = await mapWithConcurrency(matches, deps.concurrency ?? 4, async (match, index) => ({
+    full: match[0],
+    prompt: match[1],
+    ref: await deps.resolveImage(match[1], index, total),
+  }));
 
-  let filled = markdown;
-  for (const { full, prompt, ref } of results) {
-    filled = filled.replace(full, buildImagePlaceholderReplacement(prompt, ref));
-  }
+  // One ordered pass over the same matches: `String.replace` with the
+  // global regex invokes the replacer per match in document order, and
+  // `results` is in matchAll order — so each placeholder (including
+  // duplicate identical ones) gets its own result. Avoids the
+  // quadratic re-scan + first-occurrence collision of a per-item
+  // `filled.replace(full, …)` loop (Sourcery).
+  let cursor = 0;
+  const filled = markdown.replace(IMAGE_PLACEHOLDER, () => {
+    const result = results[cursor++];
+    return buildImagePlaceholderReplacement(result.prompt, result.ref);
+  });
   return { markdown: filled, results };
 }

--- a/packages/plugins/markdown-plugin/src/render/imageFill.ts
+++ b/packages/plugins/markdown-plugin/src/render/imageFill.ts
@@ -1,0 +1,57 @@
+// Shared image-placeholder fill (task #6 Phase 4). The LLM is told to
+// emit `![prompt](__too_be_replaced_image_path__)` for embedded images
+// (see definition.ts); this owns the regex + the substitution format so
+// every host stays in lockstep with that contract, while the actual
+// image GENERATION + STORAGE is injected (each host wires its own
+// Gemini + image store / data-URI strategy).
+
+export const IMAGE_PLACEHOLDER = /!\[([^\]]+)\]\(\/?__too_be_replaced_image_path__\)/g;
+
+/** Build the markdown that replaces one placeholder. `ref` is the
+ *  host-resolved image reference (a workspace-rooted URL, a data URI, …)
+ *  or null when generation was unavailable/failed — in which case the
+ *  alt text is kept as an italic marker so the operator can see what
+ *  *would* have been generated. */
+export function buildImagePlaceholderReplacement(prompt: string, ref: string | null): string {
+  if (ref) return `![${prompt}](${ref})`;
+  return `*🖼️ Image: ${prompt}*`;
+}
+
+export interface ImagePlaceholderResult {
+  full: string;
+  prompt: string;
+  ref: string | null;
+}
+
+export interface FillImagePlaceholdersDeps {
+  /** Resolve a displayable image reference for `prompt` (the host
+   *  generates + stores it, returning a URL or data URI), or null to
+   *  fall back to a text marker. `index`/`total` are for progress logs. */
+  resolveImage: (prompt: string, index: number, total: number) => Promise<string | null>;
+}
+
+/** Replace every `__too_be_replaced_image_path__` placeholder. Returns
+ *  the filled markdown plus the per-placeholder results so the host can
+ *  emit its own batch observability. Generation runs concurrently. */
+export async function fillImagePlaceholders(
+  markdown: string,
+  deps: FillImagePlaceholdersDeps,
+): Promise<{ markdown: string; results: ImagePlaceholderResult[] }> {
+  const matches = [...markdown.matchAll(IMAGE_PLACEHOLDER)];
+  if (matches.length === 0) return { markdown, results: [] };
+
+  const total = matches.length;
+  const results: ImagePlaceholderResult[] = await Promise.all(
+    matches.map(async (match, index) => ({
+      full: match[0],
+      prompt: match[1],
+      ref: await deps.resolveImage(match[1], index, total),
+    })),
+  );
+
+  let filled = markdown;
+  for (const { full, prompt, ref } of results) {
+    filled = filled.replace(full, buildImagePlaceholderReplacement(prompt, ref));
+  }
+  return { markdown: filled, results };
+}

--- a/packages/plugins/markdown-plugin/src/render/marp.ts
+++ b/packages/plugins/markdown-plugin/src/render/marp.ts
@@ -1,0 +1,82 @@
+// Shared Marp render core (task #6 Phase 4). The one place both the
+// MarpView preview AND each host's server-side PDF export construct a
+// Marp instance, register workspace themes, apply custom-size bridging,
+// and render — so the preview and the exported PDF can't drift, and a
+// new host (MulmoTerminal) reuses it instead of re-deriving the config.
+//
+// Image handling stays with the CALLER: the browser preview rewrites
+// `<img>` refs to host URLs before calling this; a server PDF passes raw
+// markdown and inlines the resulting HTML's images to base64 after. This
+// function only does the Marp config + render + slide-dimension readout.
+//
+// marp-core is dynamically imported so it stays out of the eager browser
+// bundle (it's only needed once a Marp deck is actually rendered).
+
+import { MARP_HTML_ALLOWLIST } from "../utils/markdown/marpTheme";
+import { applyCustomMarpSize } from "../utils/markdown/marpCustomSize";
+import type { MarpThemeEntry } from "../plugins/markdown/contract";
+
+export const DEFAULT_SLIDE_WIDTH = 1280;
+export const DEFAULT_SLIDE_HEIGHT = 720;
+const MIN_SLIDE_DIM = 200;
+const MAX_SLIDE_DIM = 3840;
+
+function clampDim(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value < MIN_SLIDE_DIM) return fallback;
+  return Math.min(value, MAX_SLIDE_DIM);
+}
+
+// inlineSVG:false renders plain `div.marpit > section { width:Npx; height:Npx }`
+// (CSS-driven sizing — the scrollable preview).
+const SECTION_SIZE_RE = /div\.marpit\s*>\s*section\s*\{[^}]*?width:\s*(\d+)px[^}]*?height:\s*(\d+)px/;
+function dimsFromCss(css: string): { width: number; height: number } {
+  const match = css.match(SECTION_SIZE_RE);
+  if (match) {
+    return { width: clampDim(Number(match[1]), DEFAULT_SLIDE_WIDTH), height: clampDim(Number(match[2]), DEFAULT_SLIDE_HEIGHT) };
+  }
+  return { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT };
+}
+
+// inlineSVG:true wraps sections in an `<svg viewBox="0 0 W H">` (fixed
+// coordinate system — one PDF page per slide at native proportions).
+const VIEWBOX_RE = /viewBox="0 0 (\d+) (\d+)"/;
+function dimsFromViewBox(html: string): { width: number; height: number } {
+  const match = html.match(VIEWBOX_RE);
+  if (!match) return { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT };
+  return { width: clampDim(Number(match[1]), DEFAULT_SLIDE_WIDTH), height: clampDim(Number(match[2]), DEFAULT_SLIDE_HEIGHT) };
+}
+
+export interface RenderMarpOptions {
+  /** Workspace Marp themes to register (decks opt in via `theme:`). */
+  themes?: readonly MarpThemeEntry[];
+  /** false (default) → CSS-sized `div.marpit > section` (scrollable
+   *  preview); true → SVG `viewBox` sizing (fixed-page PDF export). The
+   *  slide-dimension readout follows the mode. */
+  inlineSVG?: boolean;
+}
+
+export interface RenderMarpResult {
+  html: string;
+  css: string;
+  slideWidth: number;
+  slideHeight: number;
+}
+
+/** Render a Marp deck. `markdown` must already have its images processed
+ *  by the caller (preview: rewritten to URLs; PDF: left raw, inlined
+ *  afterward). */
+export async function renderMarpDeck(markdown: string, opts: RenderMarpOptions = {}): Promise<RenderMarpResult> {
+  const inlineSVG = opts.inlineSVG ?? false;
+  const { Marp } = await import("@marp-team/marp-core");
+  // `html: MARP_HTML_ALLOWLIST` opens a small layout-tag subset; scripts,
+  // iframes, form elements stay escaped. Same allowlist both modes so
+  // preview / export agree on what raw HTML survives.
+  const marp = new Marp({ inlineSVG, html: MARP_HTML_ALLOWLIST, emoji: { unicode: false, shortcode: false } });
+  for (const theme of opts.themes ?? []) {
+    marp.themeSet.add(theme.css);
+  }
+  const sized = applyCustomMarpSize(marp, markdown);
+  const { html, css } = marp.render(sized);
+  const { width, height } = inlineSVG ? dimsFromViewBox(html) : dimsFromCss(css);
+  return { html, css, slideWidth: width, slideHeight: height };
+}

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -2,9 +2,8 @@ import { realpathSync } from "fs";
 import path from "path";
 import { Router, Request, Response } from "express";
 import { marked } from "marked";
-import { Marp } from "@marp-team/marp-core";
+import { renderMarpDeck } from "@mulmoclaude/markdown-plugin";
 import { listMarpThemes } from "../../workspace/marp-themes.js";
-import { MARP_HTML_ALLOWLIST } from "../../../src/utils/markdown/marpTheme.js";
 import puppeteer from "puppeteer";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
@@ -12,7 +11,6 @@ import { WORKSPACE_DIRS } from "../../workspace/paths.js";
 import { resolveWithinRoot, readBinarySafeSync } from "../../utils/files/safe.js";
 import { resolveWorkspacePath } from "../../utils/files/workspace-io.js";
 import { parseFrontmatter } from "../../utils/markdown/frontmatter.js";
-import { applyCustomMarpSize } from "../../../src/utils/markdown/marpCustomSize.js";
 import { log } from "../../system/logger/index.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { transformResolvableUrlsInHtml } from "../../../src/utils/image/htmlSrcAttrs.js";
@@ -287,23 +285,16 @@ export function extractSlideDimensions(html: string): { width: number; height: n
 }
 
 async function renderMarpPdf(markdown: string, baseDir?: string): Promise<Buffer> {
-  // Disable twemoji conversion so the PDF stays self-contained — the
-  // default would emit `<img src="https://twemoji.maxcdn.com/...">`
-  // and puppeteer would need network access during the print to
-  // resolve them. OS-font emoji renders inline without a fetch and
-  // matches the MarpView preview's behaviour after the same change.
-  // Same allowlist as the MarpView preview so preview / export stay
-  // identical when authors lean on raw HTML tags for layout.
-  const marp = new Marp({ html: MARP_HTML_ALLOWLIST, emoji: { unicode: false, shortcode: false } });
-  // Register every workspace-defined theme (#1649). Slides that
-  // reference one via `theme: <name>` then render with the same
-  // CSS the previewer applied; slides that don't are unaffected.
-  for (const theme of listMarpThemes()) {
-    marp.themeSet.add(theme.css);
-  }
-  const sized = applyCustomMarpSize(marp, markdown);
-  const { html, css } = marp.render(sized);
-  const { width: slideWidth, height: slideHeight } = extractSlideDimensions(html);
+  // Shared render core (@mulmoclaude/markdown-plugin) — the MarpView
+  // preview and every host's PDF export use the same Marp config + theme
+  // registration + custom-size bridging, so they can't drift. Twemoji
+  // stays disabled (emoji unicode/shortcode false) so the PDF is self-
+  // contained (no network fetch for emoji during print). `inlineSVG:
+  // true` keeps this route's SVG `viewBox` page sizing.
+  const { html, css, slideWidth, slideHeight } = await renderMarpDeck(markdown, {
+    themes: listMarpThemes(),
+    inlineSVG: true,
+  });
   const inlinedHtml = inlineImages(html, { sourceDir: baseDir });
   const fullHtml = `<!doctype html>
 <html><head><meta charset="utf-8"><style>

--- a/server/utils/files/markdown-image-fill.ts
+++ b/server/utils/files/markdown-image-fill.ts
@@ -4,6 +4,7 @@
 // The placeholder regex + substitution format are shared with MulmoTerminal via @mulmoclaude/markdown-plugin
 // (fillImagePlaceholders); this file is MulmoClaude's host wiring — Gemini generation + workspace image store +
 // observability. Image generation/storage is injected as `resolveImage`.
+import path from "node:path";
 import { fillImagePlaceholders, IMAGE_PLACEHOLDER, type ImagePlaceholderResult } from "@mulmoclaude/markdown-plugin";
 import { generateGeminiImageFromPrompt, isGeminiAvailable } from "../gemini.js";
 import { errorMessage } from "../errors.js";
@@ -28,8 +29,9 @@ async function generateImageFile(prompt: string, index: number, total: number): 
       const url = await saveImage(imageData);
       log.info(LOG_PREFIX, "image gen ok", { index, total, elapsedMs, url });
       // Workspace-rooted "/…" so the ref resolves the same regardless of document depth (#764 sharded documents
-      // under artifacts/documents/YYYY/MM/; a relative path would be off by two directory levels).
-      return `/${url}`;
+      // under artifacts/documents/YYYY/MM/; a relative path would be off by two directory levels). path.posix.join
+      // normalises so a saveImage path that already starts with "/" can't produce a "//" ref.
+      return path.posix.join("/", url);
     }
     log.warn(LOG_PREFIX, "image gen returned no image data", { index, total, elapsedMs, prompt: meta });
   } catch (err) {

--- a/server/utils/files/markdown-image-fill.ts
+++ b/server/utils/files/markdown-image-fill.ts
@@ -1,100 +1,69 @@
 // Per the timeout-policy comment in server/agent/mcp-server.ts, generative-AI work MUST be observable — silent
 // partial failures hid the 10s bridge-timeout bug. Every image emits start/ok/failed/no-data + per-batch tally.
+//
+// The placeholder regex + substitution format are shared with MulmoTerminal via @mulmoclaude/markdown-plugin
+// (fillImagePlaceholders); this file is MulmoClaude's host wiring — Gemini generation + workspace image store +
+// observability. Image generation/storage is injected as `resolveImage`.
+import { fillImagePlaceholders, IMAGE_PLACEHOLDER, type ImagePlaceholderResult } from "@mulmoclaude/markdown-plugin";
 import { generateGeminiImageFromPrompt, isGeminiAvailable } from "../gemini.js";
 import { errorMessage } from "../errors.js";
 import { promptMeta } from "../promptMeta.js";
 import { log } from "../../system/logger/index.js";
 import { saveImage } from "./image-store.js";
 
-export const IMAGE_PLACEHOLDER = /!\[([^\]]+)\]\(\/?__too_be_replaced_image_path__\)/g;
 const LOG_PREFIX = "present-document";
 
+// Re-export so existing importers keep their single source for the placeholder contract.
+export { IMAGE_PLACEHOLDER };
+
 async function generateImageFile(prompt: string, index: number, total: number): Promise<string | null> {
-  if (!isGeminiAvailable()) return null;
   const startedAt = Date.now();
   // Prompt is user-controlled and may contain credentials/PII; promptMeta logs {length, sha256} instead of raw bytes.
   const meta = promptMeta(prompt);
-  log.info(LOG_PREFIX, "image gen start", {
-    index,
-    total,
-    prompt: meta,
-  });
+  log.info(LOG_PREFIX, "image gen start", { index, total, prompt: meta });
   try {
     const { imageData } = await generateGeminiImageFromPrompt(prompt);
     const elapsedMs = Date.now() - startedAt;
     if (imageData) {
       const url = await saveImage(imageData);
       log.info(LOG_PREFIX, "image gen ok", { index, total, elapsedMs, url });
-      return url;
+      // Workspace-rooted "/…" so the ref resolves the same regardless of document depth (#764 sharded documents
+      // under artifacts/documents/YYYY/MM/; a relative path would be off by two directory levels).
+      return `/${url}`;
     }
-    log.warn(LOG_PREFIX, "image gen returned no image data", {
-      index,
-      total,
-      elapsedMs,
-      prompt: meta,
-    });
+    log.warn(LOG_PREFIX, "image gen returned no image data", { index, total, elapsedMs, prompt: meta });
   } catch (err) {
-    log.warn(LOG_PREFIX, "image gen failed", {
-      index,
-      total,
-      elapsedMs: Date.now() - startedAt,
-      error: errorMessage(err),
-      prompt: meta,
-    });
+    log.warn(LOG_PREFIX, "image gen failed", { index, total, elapsedMs: Date.now() - startedAt, error: errorMessage(err), prompt: meta });
   }
   return null;
 }
 
-interface PlaceholderResult {
-  full: string;
-  prompt: string;
-  url: string | null;
-}
-
-function logBatchTally(results: PlaceholderResult[], total: number, batchStartedAt: number): void {
-  const failed = results.filter((result) => !result.url).length;
+function logBatchTally(results: ImagePlaceholderResult[], batchStartedAt: number): void {
+  const total = results.length;
+  const failed = results.filter((result) => !result.ref).length;
   const succeeded = total - failed;
   const elapsedMs = Date.now() - batchStartedAt;
   const level = failed > 0 ? "warn" : "info";
   log[level](LOG_PREFIX, "image batch done", { succeeded, failed, total, elapsedMs });
 }
 
-export function buildReplacement(prompt: string, url: string | null): string {
-  // Workspace-rooted "/…" so the ref resolves the same regardless of document depth (#764 sharded documents under
-  // artifacts/documents/YYYY/MM/; a relative path would be off by two directory levels).
-  if (url) return `![${prompt}](/${url})`;
-  // No image: leave the alt text as an italic marker so the operator can see what *would* have been generated.
-  return `*🖼️ Image: ${prompt}*`;
-}
-
 export async function fillMarkdownImagePlaceholders(markdown: string): Promise<string> {
-  const matches = [...markdown.matchAll(IMAGE_PLACEHOLDER)];
-  if (matches.length === 0) return markdown;
+  const placeholderCount = [...markdown.matchAll(IMAGE_PLACEHOLDER)].length;
+  if (placeholderCount === 0) return markdown;
 
   const geminiOk = isGeminiAvailable();
   if (!geminiOk) {
-    log.warn(LOG_PREFIX, "GEMINI_API_KEY not set — image placeholders will render as text markers", {
-      placeholderCount: matches.length,
-    });
+    log.warn(LOG_PREFIX, "GEMINI_API_KEY not set — image placeholders will render as text markers", { placeholderCount });
   }
 
-  const total = matches.length;
   const batchStartedAt = Date.now();
-  if (geminiOk) log.info(LOG_PREFIX, "image batch start", { total });
+  if (geminiOk) log.info(LOG_PREFIX, "image batch start", { total: placeholderCount });
 
-  const results: PlaceholderResult[] = await Promise.all(
-    matches.map(async (match, index) => ({
-      full: match[0],
-      prompt: match[1],
-      url: geminiOk ? await generateImageFile(match[1], index, total) : null,
-    })),
-  );
+  // Gemini available → generate + store each; otherwise resolve every placeholder to null (text markers).
+  const { markdown: filled, results } = await fillImagePlaceholders(markdown, {
+    resolveImage: geminiOk ? generateImageFile : () => Promise.resolve(null),
+  });
 
-  if (geminiOk) logBatchTally(results, total, batchStartedAt);
-
-  let filled = markdown;
-  for (const { full, prompt, url } of results) {
-    filled = filled.replace(full, buildReplacement(prompt, url));
-  }
+  if (geminiOk) logBatchTally(results, batchStartedAt);
   return filled;
 }

--- a/test/utils/files/test_markdownImageFill.ts
+++ b/test/utils/files/test_markdownImageFill.ts
@@ -1,56 +1,55 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildReplacement, IMAGE_PLACEHOLDER } from "../../../server/utils/files/markdown-image-fill.js";
+import { buildImagePlaceholderReplacement } from "@mulmoclaude/markdown-plugin";
+import { IMAGE_PLACEHOLDER } from "../../../server/utils/files/markdown-image-fill.js";
 
-describe("buildReplacement", () => {
-  describe("url present — workspace-rooted absolute ref", () => {
-    it("prefixes a leading `/` so the ref resolves from the workspace root", () => {
-      // `rewriteMarkdownImageRefs` on the client treats a leading
-      // `/` as "rooted at workspace", which is the only way a document
-      // shard under `artifacts/documents/YYYY/MM/` can still reach
-      // an image under `artifacts/images/YYYY/MM/` without depending
-      // on how deep the document is nested.
-      assert.equal(buildReplacement("sunset over kyoto", "artifacts/images/2026/04/x.png"), "![sunset over kyoto](/artifacts/images/2026/04/x.png)");
+describe("buildImagePlaceholderReplacement", () => {
+  describe("ref present — used verbatim as the image URL", () => {
+    it("emits the alt text + the host-resolved ref unchanged", () => {
+      // The host (generateImageFile) returns a workspace-rooted "/…" ref;
+      // a leading `/` lets a document shard under
+      // `artifacts/documents/YYYY/MM/` reach an image under
+      // `artifacts/images/YYYY/MM/` regardless of nesting depth.
+      assert.equal(
+        buildImagePlaceholderReplacement("sunset over kyoto", "/artifacts/images/2026/04/x.png"),
+        "![sunset over kyoto](/artifacts/images/2026/04/x.png)",
+      );
     });
 
     it("passes prompt text through as alt text unchanged (spaces / punctuation preserved)", () => {
       assert.equal(
-        buildReplacement("A dog, sitting on a rug (hyper-detailed)", "artifacts/images/2026/04/y.png"),
+        buildImagePlaceholderReplacement("A dog, sitting on a rug (hyper-detailed)", "/artifacts/images/2026/04/y.png"),
         "![A dog, sitting on a rug (hyper-detailed)](/artifacts/images/2026/04/y.png)",
       );
     });
 
     it("passes non-ASCII prompt text through unchanged", () => {
-      assert.equal(buildReplacement("夕焼けの京都", "artifacts/images/2026/04/z.png"), "![夕焼けの京都](/artifacts/images/2026/04/z.png)");
+      assert.equal(buildImagePlaceholderReplacement("夕焼けの京都", "/artifacts/images/2026/04/z.png"), "![夕焼けの京都](/artifacts/images/2026/04/z.png)");
     });
 
-    it("does NOT double-slash when the URL happens to already start with one (defensive)", () => {
-      // The caller's contract says `url` is workspace-relative without
-      // a leading slash (produced by saveImage). This test documents
-      // what happens if someone breaks that contract — currently
-      // produces `//artifacts/...`. If the helper is hardened to
-      // strip a leading slash, update this test; otherwise it stays
-      // as a regression guard on the contract.
-      assert.equal(buildReplacement("test", "/artifacts/images/foo.png"), "![test](//artifacts/images/foo.png)");
+    it("uses the ref verbatim (no slash munging) — supports data URIs for other hosts", () => {
+      // Host-agnostic: MulmoTerminal can pass a `data:` URI here and it
+      // must NOT be mangled with a leading slash.
+      assert.equal(buildImagePlaceholderReplacement("test", "data:image/png;base64,AAA"), "![test](data:image/png;base64,AAA)");
     });
   });
 
-  describe("url null — text fallback", () => {
+  describe("ref null — text fallback", () => {
     it("renders an italic image marker when generation skipped or failed", () => {
       // When `GEMINI_API_KEY` is missing OR generation threw,
       // the placeholder falls through to a visible marker so the
       // document still renders without broken image refs. The
       // 🖼️ glyph makes the fallback obvious to operators reading
       // the rendered markdown.
-      assert.equal(buildReplacement("sunset over kyoto", null), "*🖼️ Image: sunset over kyoto*");
+      assert.equal(buildImagePlaceholderReplacement("sunset over kyoto", null), "*🖼️ Image: sunset over kyoto*");
     });
 
     it("preserves non-ASCII prompt text in the fallback", () => {
-      assert.equal(buildReplacement("夕焼けの京都", null), "*🖼️ Image: 夕焼けの京都*");
+      assert.equal(buildImagePlaceholderReplacement("夕焼けの京都", null), "*🖼️ Image: 夕焼けの京都*");
     });
 
     it("preserves empty prompt text (edge case — markdown still renders)", () => {
-      assert.equal(buildReplacement("", null), "*🖼️ Image: *");
+      assert.equal(buildImagePlaceholderReplacement("", null), "*🖼️ Image: *");
     });
   });
 });


### PR DESCRIPTION
Extracts the two heaviest, drift-prone pieces of `presentDocument` rendering into `@mulmoclaude/markdown-plugin` so **MulmoTerminal** can reuse them (Phase 4) instead of re-deriving the config — and the existing **MarpView ↔ pdf.ts** duplication collapses to one source of truth.

## What's shared now (package `0.1.2`)
- **`renderMarpDeck(markdown, { themes, inlineSVG })`** → `{ html, css, slideWidth, slideHeight }`. One place builds the Marp instance, registers workspace themes, applies custom-size bridging, and reads slide dimensions. `inlineSVG` is parametrized with the matching dim readout — `false` → CSS `div.marpit > section` sizing (scrollable preview); `true` → SVG `viewBox` sizing (fixed-page PDF) — so each caller keeps its exact behavior. marp-core stays a lazy `import()`.
- **`fillImagePlaceholders(markdown, { resolveImage })`** + `buildImagePlaceholderReplacement` + `IMAGE_PLACEHOLDER`. The `__too_be_replaced_image_path__` contract + substitution format live here; image generation + storage are injected. `buildReplacement` is now format-agnostic (host passes the final ref — a workspace URL *or* a data URI), and the fn returns per-item results so the host owns batch observability.

## Callers refactored
- **MarpView** → `renderMarpDeck` (drops its inline Marp config + dim extraction).
- **MulmoClaude `pdf.ts`** → `renderMarpDeck({ inlineSVG: true })`; output preserved (`extractSlideDimensions` test 9/9 unchanged).
- **MulmoClaude `markdown-image-fill.ts`** → `fillImagePlaceholders`; the `/` workspace-root prefix moved into `generateImageFile` (the injected `resolveImage`). Replacement test updated for the format-agnostic API (13/13).

## Verification
Package: vue-tsc + vite + eslint. Host: `typecheck:vue/server/test`, eslint, `build:client`. Unit tests: pdf dimensions 9/9, image-fill 13/13.

## ⚠️ Requires publishing `0.1.2` before CI/merge
The launcher ships `server/` (incl. `pdf.ts`), which now imports `renderMarpDeck` from the package. The published npm version is still `0.1.0` (the `0.1.1` source from #1715 was never published), which lacks these exports — so the **publish-smoke `tarball` stage will fail to boot until `@mulmoclaude/markdown-plugin@0.1.2` is published**. The launcher's `^0.1.0` will then resolve `0.1.2` automatically (no dep bump needed). Publishing `0.1.2` also unblocks MulmoTerminal Phase 4, which consumes it from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize Marp deck rendering and markdown image placeholder handling in the shared markdown-plugin so both MulmoClaude and other hosts reuse a single render core and placeholder contract.

New Features:
- Expose a shared Marp render helper that returns HTML, CSS, and slide dimensions for both preview and PDF export use cases.
- Provide a shared image placeholder filling utility and regex contract that hosts can use by injecting their own image generation and storage logic.

Enhancements:
- Refactor MulmoClaude's markdown image fill path to delegate placeholder replacement to the shared plugin while keeping Gemini integration and observability in the host.
- Update MarpView and the server PDF route to use the shared Marp render helper, eliminating duplicated Marp configuration and dimension extraction logic.

Build:
- Bump @mulmoclaude/markdown-plugin package version to 0.1.2 to ship the new shared rendering and image fill APIs.

Tests:
- Adjust image-fill tests to align with the new format-agnostic replacement API and maintain coverage of PDF dimension extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the markdown plugin release version (0.1.1 → 0.1.3) and adjusted the main package dependency to use the newer plugin.

* **New Features**
  * Improved markdown rendering for image placeholders, including better performance and deterministic parallel image resolution.
  * Standardized slide sizing so preview and PDF export use consistent slide dimensions.

* **Bug Fixes**
  * More reliable handling of duplicate placeholders and placeholder replacement output.

* **Tests**
  * Updated unit tests to match the new placeholder replacement API and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->