### PR TITLE
fix: generate images for Marp directive slides via a title prompt (markdown-plugin 0.1.4)

### DIFF
--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/markdown-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Full-fidelity markdown document plugin (presentDocument) — Marp slides, PDF export, AI image-fill — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
@@ -46,7 +46,9 @@ export const TOOL_DEFINITION: ToolDefinition = {
     "- ![bg fit](path)        — background scaled to fit, no crop\n" +
     "- ![fit](path)           — fit-to-content inline\n" +
     "- ![w:600 h:400](path)   — explicit pixel size\n" +
-    "The placeholder URL `__too_be_replaced_image_path__` still applies — the directive goes in the alt-text slot, the placeholder in the URL slot.\n\n" +
+    "For a GENERATED image WITH a directive you must use THREE slots: the directive in the alt-text slot, the placeholder `__too_be_replaced_image_path__` in the URL slot, AND the image prompt in a quoted markdown TITLE right after the URL:\n" +
+    '    ![bg right:45%](__too_be_replaced_image_path__ "A detailed description of the image to generate")\n' +
+    "The title is REQUIRED in this form — the alt slot is taken by the directive, so WITHOUT a title there is no prompt and no image is generated. (Plain non-directive images keep the prompt in the alt slot, as shown earlier.)\n\n" +
     "Aspect: `size: 16:9` (default 1280×720) or `size: 4:3` (960×720) — handled natively by Marp. For other shapes MulmoClaude bridges the directive so vertical / square / custom decks work too:\n" +
     "- `size: 9:16` → 1080×1920 portrait\n" +
     "- `size: 16:10` → 1280×800\n" +

--- a/packages/plugins/markdown-plugin/src/render/imageFill.ts
+++ b/packages/plugins/markdown-plugin/src/render/imageFill.ts
@@ -1,27 +1,34 @@
-// Shared image-placeholder fill (task #6 Phase 4). The LLM is told to
-// emit `![prompt](__too_be_replaced_image_path__)` for embedded images
-// (see definition.ts); this owns the regex + the substitution format so
-// every host stays in lockstep with that contract, while the actual
-// image GENERATION + STORAGE is injected (each host wires its own
-// Gemini + image store / data-URI strategy).
+// Shared image-placeholder fill (task #6 Phase 4). The LLM is told (see
+// definition.ts) to emit embedded images as one of:
+//   - plain:  ![prompt](__too_be_replaced_image_path__)
+//   - Marp:   ![bg right:45%](__too_be_replaced_image_path__ "prompt")
+// i.e. the GENERATION PROMPT is the alt text, UNLESS the alt is taken by a
+// Marp directive — then the prompt lives in the quoted markdown title. This
+// owns the regex + substitution so every host stays in lockstep, while image
+// GENERATION + STORAGE is injected (each host wires Gemini + URL/data-URI).
 
-// Alt text is bounded ({1,1000}) rather than `+` so the regex stays linear on
-// adversarial/uncontrolled markdown (CodeQL polynomial-ReDoS); image prompts are
-// never anywhere near 1000 chars.
-export const IMAGE_PLACEHOLDER = /!\[([^\]]{1,1000})\]\(\/?__too_be_replaced_image_path__\)/g;
+// Groups: 1 = alt text (prompt OR Marp directive), 2 = optional quoted title
+// (the prompt when the alt is a directive). Both bounded ({1,1000}) rather
+// than `+` so the regex stays linear on uncontrolled markdown (CodeQL
+// polynomial-ReDoS).
+export const IMAGE_PLACEHOLDER = /!\[([^\]]{1,1000})\]\(\/?__too_be_replaced_image_path__(?:\s+"([^"]{1,1000})")?\)/g;
 
-/** Build the markdown that replaces one placeholder. `ref` is the
- *  host-resolved image reference (a workspace-rooted URL, a data URI, …)
- *  or null when generation was unavailable/failed — in which case the
- *  alt text is kept as an italic marker so the operator can see what
- *  *would* have been generated. */
-export function buildImagePlaceholderReplacement(prompt: string, ref: string | null): string {
-  if (ref) return `![${prompt}](${ref})`;
-  return `*🖼️ Image: ${prompt}*`;
+/** Build the markdown that replaces one placeholder. `altText` is kept as the
+ *  rendered alt (the prompt for plain images, or the Marp directive for
+ *  directive images). `ref` is the host-resolved image reference (URL / data
+ *  URI) or null when generation was unavailable/failed — in which case an
+ *  italic marker shows `fallbackLabel` (defaults to `altText`; callers pass
+ *  the generation prompt so a Marp directive isn't shown as the label). */
+export function buildImagePlaceholderReplacement(altText: string, ref: string | null, fallbackLabel: string = altText): string {
+  if (ref) return `![${altText}](${ref})`;
+  return `*🖼️ Image: ${fallbackLabel}*`;
 }
 
 export interface ImagePlaceholderResult {
   full: string;
+  /** The rendered alt text (prompt for plain images, directive for Marp). */
+  alt: string;
+  /** The text used to GENERATE the image (the title when present, else alt). */
   prompt: string;
   ref: string | null;
 }
@@ -64,11 +71,13 @@ export async function fillImagePlaceholders(
   if (matches.length === 0) return { markdown, results: [] };
 
   const total = matches.length;
-  const results = await mapWithConcurrency(matches, deps.concurrency ?? 4, async (match, index) => ({
-    full: match[0],
-    prompt: match[1],
-    ref: await deps.resolveImage(match[1], index, total),
-  }));
+  const results = await mapWithConcurrency(matches, deps.concurrency ?? 4, async (match, index) => {
+    const alt = match[1];
+    // Marp directive form puts the prompt in the title (group 2); plain form
+    // uses the alt itself as the prompt.
+    const prompt = match[2] ?? alt;
+    return { full: match[0], alt, prompt, ref: await deps.resolveImage(prompt, index, total) };
+  });
 
   // One ordered pass over the same matches: `String.replace` with the
   // global regex invokes the replacer per match in document order, and
@@ -79,7 +88,9 @@ export async function fillImagePlaceholders(
   let cursor = 0;
   const filled = markdown.replace(IMAGE_PLACEHOLDER, () => {
     const result = results[cursor++];
-    return buildImagePlaceholderReplacement(result.prompt, result.ref);
+    // Keep the alt (prompt for plain, directive for Marp) in the output; the
+    // null-fallback marker shows the generation prompt, not the directive.
+    return buildImagePlaceholderReplacement(result.alt, result.ref, result.prompt);
   });
   return { markdown: filled, results };
 }

--- a/packages/plugins/markdown-plugin/src/render/imageFill.ts
+++ b/packages/plugins/markdown-plugin/src/render/imageFill.ts
@@ -8,10 +8,41 @@
 // GENERATION + STORAGE is injected (each host wires Gemini + URL/data-URI).
 
 // Groups: 1 = alt text (prompt OR Marp directive), 2 = optional quoted title
-// (the prompt when the alt is a directive). Both bounded ({1,1000}) rather
-// than `+` so the regex stays linear on uncontrolled markdown (CodeQL
-// polynomial-ReDoS).
-export const IMAGE_PLACEHOLDER = /!\[([^\]]{1,1000})\]\(\/?__too_be_replaced_image_path__(?:\s+"([^"]{1,1000})")?\)/g;
+// (the prompt when the alt is a directive). The title allows escaped chars
+// (`\"`, `\\`) so a prompt containing quotes still matches. Both groups are
+// bounded ({1,1000}) with disjoint alternatives so the regex stays linear on
+// uncontrolled markdown (CodeQL polynomial-ReDoS).
+export const IMAGE_PLACEHOLDER = /!\[([^\]]{1,1000})\]\(\/?__too_be_replaced_image_path__(?:\s+"((?:[^"\\]|\\.){1,1000})")?\)/g;
+
+// Marp image-directive keywords (the alt slot for a directive image). Used to
+// decide whether a title-less placeholder's alt is a prompt (generate) or a
+// layout directive (skip — a directive image needs its prompt in the title).
+const MARP_DIRECTIVE_KEYWORDS = new Set([
+  "bg", "fit", "cover", "auto", "left", "right", "vertical", "center", "top", "bottom",
+  "blur", "brightness", "contrast", "grayscale", "invert", "opacity", "saturate", "sepia", "drop-shadow", "hue-rotate",
+]);
+
+function isMarpDirectiveToken(token: string): boolean {
+  const lower = token.toLowerCase();
+  if (MARP_DIRECTIVE_KEYWORDS.has(lower)) return true;
+  const colon = lower.indexOf(":");
+  if (colon > 0 && (lower.slice(0, colon) === "w" || lower.slice(0, colon) === "h" || MARP_DIRECTIVE_KEYWORDS.has(lower.slice(0, colon)))) return true;
+  return /^#?[0-9a-f]+$|^\d+(\.\d+)?(%|px)?$/.test(lower); // bare size / colour value
+}
+
+/** True when every whitespace-separated token of `alt` is a Marp image
+ *  directive — i.e. the alt is layout, not a prompt. A real prompt always has
+ *  at least one natural-language token, so this won't swallow prompts. */
+function altIsOnlyDirectives(alt: string): boolean {
+  const tokens = alt.trim().split(/\s+/);
+  return tokens.length > 0 && tokens.every(isMarpDirectiveToken);
+}
+
+// Undo markdown title escaping (`\"` → `"`, `\\` → `\`, …) before using the
+// title as a generation prompt.
+function unescapeTitle(title: string): string {
+  return title.replace(/\\(.)/g, "$1");
+}
 
 /** Build the markdown that replaces one placeholder. `altText` is kept as the
  *  rendered alt (the prompt for plain images, or the Marp directive for
@@ -73,10 +104,14 @@ export async function fillImagePlaceholders(
   const total = matches.length;
   const results = await mapWithConcurrency(matches, deps.concurrency ?? 4, async (match, index) => {
     const alt = match[1];
-    // Marp directive form puts the prompt in the title (group 2); plain form
-    // uses the alt itself as the prompt.
-    const prompt = match[2] ?? alt;
-    return { full: match[0], alt, prompt, ref: await deps.resolveImage(prompt, index, total) };
+    const title = match[2] !== undefined ? unescapeTitle(match[2]) : undefined;
+    // Plain image: the alt IS the prompt. Directive image: the prompt is the
+    // title. A directive alt WITHOUT a title carries no prompt → skip
+    // generation (the contract requires the title for directive images), rather
+    // than generating a garbage image from "bg right:45%".
+    const prompt = title ?? (altIsOnlyDirectives(alt) ? undefined : alt);
+    const ref = prompt !== undefined ? await deps.resolveImage(prompt, index, total) : null;
+    return { full: match[0], alt, prompt: prompt ?? alt, ref };
   });
 
   // One ordered pass over the same matches: `String.replace` with the

--- a/test/utils/files/test_markdownImageFill.ts
+++ b/test/utils/files/test_markdownImageFill.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildImagePlaceholderReplacement } from "@mulmoclaude/markdown-plugin";
+import { buildImagePlaceholderReplacement, fillImagePlaceholders } from "@mulmoclaude/markdown-plugin";
 import { IMAGE_PLACEHOLDER } from "../../../server/utils/files/markdown-image-fill.js";
 
 describe("buildImagePlaceholderReplacement", () => {
@@ -93,5 +93,45 @@ describe("IMAGE_PLACEHOLDER regex", () => {
 
   it("does not match if the alt text is missing (empty `[]` not captured)", () => {
     assert.deepEqual(findAll("![](__too_be_replaced_image_path__)"), []);
+  });
+});
+
+describe("fillImagePlaceholders — plain vs Marp directive (title) forms", () => {
+  it("plain: generates from the alt and keeps it as the alt", async () => {
+    const prompts: string[] = [];
+    const { markdown } = await fillImagePlaceholders("![A sunset over Kyoto](__too_be_replaced_image_path__)", {
+      resolveImage: async (prompt) => {
+        prompts.push(prompt);
+        return "https://img/0.png";
+      },
+    });
+    assert.deepEqual(prompts, ["A sunset over Kyoto"]);
+    assert.equal(markdown, "![A sunset over Kyoto](https://img/0.png)");
+  });
+
+  it("Marp: generates from the TITLE and preserves the directive in the alt", async () => {
+    const prompts: string[] = [];
+    const { markdown } = await fillImagePlaceholders('![bg right:45%](__too_be_replaced_image_path__ "A Tokyo skyline at golden hour")', {
+      resolveImage: async (prompt) => {
+        prompts.push(prompt);
+        return "data:image/png;base64,AAA";
+      },
+    });
+    assert.deepEqual(prompts, ["A Tokyo skyline at golden hour"]);
+    assert.equal(markdown, "![bg right:45%](data:image/png;base64,AAA)");
+  });
+
+  it("Marp null fallback shows the prompt (title), not the directive", async () => {
+    const { markdown } = await fillImagePlaceholders('![bg left:45%](__too_be_replaced_image_path__ "A temple in Asakusa")', {
+      resolveImage: async () => null,
+    });
+    assert.equal(markdown, "*🖼️ Image: A temple in Asakusa*");
+  });
+
+  it("handles a mix of plain + Marp placeholders in document order", async () => {
+    const source = ["![plain prompt](__too_be_replaced_image_path__)", '![bg right:45%](__too_be_replaced_image_path__ "marp prompt")'].join("\n\n");
+    let i = 0;
+    const { markdown } = await fillImagePlaceholders(source, { resolveImage: async () => `https://img/${i++}.png` });
+    assert.equal(markdown, ["![plain prompt](https://img/0.png)", "![bg right:45%](https://img/1.png)"].join("\n\n"));
   });
 });

--- a/test/utils/files/test_markdownImageFill.ts
+++ b/test/utils/files/test_markdownImageFill.ts
@@ -128,6 +128,31 @@ describe("fillImagePlaceholders — plain vs Marp directive (title) forms", () =
     assert.equal(markdown, "*🖼️ Image: A temple in Asakusa*");
   });
 
+  it("Marp directive WITHOUT a title generates no image (contract: title required)", async () => {
+    let called = 0;
+    const { markdown } = await fillImagePlaceholders("![bg right:45%](__too_be_replaced_image_path__)", {
+      resolveImage: async () => {
+        called++;
+        return "https://img/should-not-happen.png";
+      },
+    });
+    assert.equal(called, 0, "resolveImage must not run for a directive alt without a title");
+    assert.equal(markdown, "*🖼️ Image: bg right:45%*");
+  });
+
+  it("accepts escaped quotes inside the title prompt", async () => {
+    const prompts: string[] = [];
+    const { markdown } = await fillImagePlaceholders('![bg](__too_be_replaced_image_path__ "A sign reading \\"AI\\"")', {
+      resolveImage: async (prompt) => {
+        prompts.push(prompt);
+        return "https://img/0.png";
+      },
+    });
+    // The regex must match (no silent skip), and the prompt is unescaped.
+    assert.deepEqual(prompts, ['A sign reading "AI"']);
+    assert.equal(markdown, "![bg](https://img/0.png)");
+  });
+
   it("handles a mix of plain + Marp placeholders in document order", async () => {
     const source = ["![plain prompt](__too_be_replaced_image_path__)", '![bg right:45%](__too_be_replaced_image_path__ "marp prompt")'].join("\n\n");
     let i = 0;


### PR DESCRIPTION
## Problem
A Marp deck whose images use a layout directive — `![bg right:45%](…)`, `![fit](…)`, etc. — silently produced **no generated images**, while plain image-bearing documents worked fine.

**Root cause (in the shared package, so it affected both apps):** for a directive image, the alt slot is taken by the directive, leaving no slot for the prompt under the `![prompt](__too_be_replaced_image_path__)` contract. The LLM resolved that by putting the prompt in the **URL slot** (where the placeholder belongs), so `fillImagePlaceholders` matched nothing and generated nothing.

## Fix — a third slot (the markdown title)
```
![bg right:45%](__too_be_replaced_image_path__ "A detailed image prompt")
```
- **`definition.ts`** — instruct the title-slot form for directive images (required; the alt is the directive).
- **`render/imageFill.ts`** — `IMAGE_PLACEHOLDER` now captures an optional quoted title (bounded for ReDoS); **generation prompt = title ?? alt**; the substitution preserves the alt (the directive) so Marp still applies it, and the null-fallback marker shows the prompt rather than the directive. Plain images (alt = prompt, no title) are unchanged. `buildImagePlaceholderReplacement` gains an optional `fallbackLabel` (2-arg calls stay backward-compatible).

## Verification
Package `vue-tsc` + `vite` + eslint; host `typecheck:server`/`typecheck:test`, eslint, and new end-to-end fill tests for the plain vs Marp-title forms — **17/17**.

## Rollout
`0.1.4`. MulmoClaude picks it up via the workspace on merge; **MulmoTerminal needs `0.1.4` published**, then a dep bump (PR #15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle AI image generation prompts for Marp directive images via the markdown title slot and document the required syntax.

New Features:
- Support image generation for Marp directive images by reading the prompt from the markdown title when present.

Bug Fixes:
- Fix image placeholder handling so Marp directive images correctly trigger image generation instead of being skipped.

Enhancements:
- Preserve Marp directives as alt text while using the prompt as a separate fallback label for null image-generation cases.
- Extend the image placeholder regex and result metadata to distinguish rendered alt text from the generation prompt and support both plain and directive image forms.

Build:
- Bump @mulmoclaude/markdown-plugin package version to 0.1.4.

Documentation:
- Update markdown plugin tooling docs to describe the three-slot syntax for generated Marp directive images and the requirement for a title-based prompt.

Tests:
- Add end-to-end tests covering plain images, Marp directive images with title-based prompts, null-fallback behavior, and mixed placeholder scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Marp directive syntax in markdown image placeholders, including correct handling of quoted titles and directive layouts.
  * Improved image generation so prompts derive from the quoted title (when present) while preserving the original alt/directive text in the output.
* **Bug Fixes**
  * Updated placeholder replacement behavior for Marp directives without titles and for generation fallbacks.
* **Tests**
  * Expanded test coverage for plain vs Marp directive placeholder forms and mixed replacements.
* **Chores**
  * Released plugin version **0.1.4**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->