### PR TITLE
ci: cache Playwright browsers in the e2e job

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -211,8 +211,32 @@ jobs:
     - name: Build internal packages
       if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
       run: yarn build:packages
+    # Cache the ~392 MB of Playwright browser binaries (chromium + webkit +
+    # headless shell + ffmpeg) so a normal run restores them in seconds instead
+    # of re-downloading from the CDN every time. A slow CDN day was stretching
+    # the download to ~13 min and tipping shard 1 over its job timeout (the e2e
+    # flakes seen on #1725). Keyed on the Playwright version, which determines
+    # the exact browser builds.
+    - name: Resolve Playwright version
+      id: pw-version
+      run: |
+        VERSION=$(node -p "require('@playwright/test/package.json').version")
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
     - name: Install Playwright browsers
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install chromium webkit --with-deps
+    # On a cache hit the binaries are restored, but the OS-level libraries that
+    # `--with-deps` installs live in system paths (not ~/.cache) and aren't
+    # cached — install just those so the restored browsers can launch.
+    - name: Install Playwright OS dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps chromium webkit
     - name: Run E2E tests (shard ${{ matrix.shard }}/2)
       run: yarn test:e2e --shard=${{ matrix.shard }}/2
     - name: Upload test results on failure


### PR DESCRIPTION
## Problem

The `e2e` job re-downloads **~392 MB** of Playwright browser binaries from the CDN on **every run** — chromium (175 MB) + headless shell (113 MB) + webkit (101 MB) + ffmpeg (2 MB) — because nothing caches `~/.cache/ms-playwright`.

On a slow-CDN day this stretched the "Install Playwright browsers" step to **~13 min**, which tipped **shard 1 over its ~15-min job timeout**: the run died with `The operation was canceled` *during browser install*, before a single test executed. That's the repeated red `e2e (1)` on #1725 — not a test or code failure, pure download time. (Shard 2, racing the same download, scraped in by seconds.)

## Fix

Add an `actions/cache@v5` for `~/.cache/ms-playwright`, keyed on the **Playwright version** (which determines the exact browser builds), mirroring the existing `packages/dist` cache pattern in the same job:

- **Cache hit** → binaries restore in ~5 s. Only the OS-level libraries (`--with-deps` installs system `.deb`s that live outside `~/.cache`) are reinstalled via `playwright install-deps chromium webkit`.
- **Cache miss** (first run, or a Playwright bump) → falls back to the full `playwright install chromium webkit --with-deps` and repopulates the cache.

Turns a 6–13 min, occasionally-fatal download into a near-instant restore, removing the timeout flake.

## Notes

- Surgical: touches only the `e2e` job in `.github/workflows/pull_request.yaml`. No code, no test changes.
- The first run on this PR will be a cache **miss** (still does the full install + warms the cache); subsequent runs across the repo hit it.
- `e2e-live` (`e2e_live_no_llm.yaml`) installs chromium-only and didn't exhibit the flake; it could get the same treatment as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cache Playwright browser binaries in the e2e workflow to speed up runs and reduce timeout flakes.

CI:
- Add an actions/cache step for Playwright browser binaries in the e2e job, keyed by Playwright version, to avoid repeated large downloads.
- Conditionally install full Playwright browsers only on cache misses and install OS-level dependencies on cache hits to ensure restored browsers can run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline performance by implementing browser caching to reduce build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->