### PR TITLE
feat(collections): manage schema via manageCollection (schemaDocs/getSchema/putSchema)

### DIFF
--- a/packages/plugins/collection-plugin/src/server/discovery.ts
+++ b/packages/plugins/collection-plugin/src/server/discovery.ts
@@ -13,7 +13,7 @@ import { INGEST_KINDS, FEED_SCHEDULES } from "../core/schema";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths";
 import type { LoadedCollection } from "./discoveredCollection";
 import { isSafeActionTemplatePath, isSafeCustomViewPath } from "./templatePath";
-import type { CollectionDetail, CollectionSource, CollectionSummary } from "../core/schema";
+import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
 
 // Cross-field refines, factored out so they can apply at both the
 // top-level FieldSpec and the table-row SubFieldSpec without prose
@@ -597,6 +597,35 @@ function applyFeedSchemaDefaults(parsed: unknown, slug: string): unknown {
   return { ...obj, icon, dataPath: `data/feeds/${slug}` };
 }
 
+/** Result of the post-Zod acceptance gates: the resolved record dir on
+ *  success, or a one-line reason discovery would skip the schema. */
+export type SchemaAcceptance = { ok: true; dataDir: string } | { ok: false; reason: string };
+
+/** The acceptance gates discovery applies AFTER `CollectionSchemaZ` parses,
+ *  before a schema becomes a live collection:
+ *
+ *  - the `primaryKey` must be a declared field flagged `primary: true` —
+ *    without the flag CollectionView renders the field editable, and a
+ *    rename is silently pinned back to the URL itemId on save, so the user's
+ *    edit is dropped with no error;
+ *  - a `feed` schema must declare an `ingest` block (else it's a dead,
+ *    non-refreshable card);
+ *  - `dataPath` must resolve INSIDE the workspace.
+ *
+ *  Exported so `manageCollection`'s `putSchema` can run the SAME gates before
+ *  it reports success — a schema that passes `CollectionSchemaZ` but fails one
+ *  of these would otherwise write cleanly yet be skipped on the next discovery,
+ *  hiding the collection (the exact failure that tool exists to prevent). */
+export function acceptParsedSchema(schema: CollectionSchema, opts: { source: CollectionSource; workspaceRoot: string }): SchemaAcceptance {
+  const primaryField = schema.fields[schema.primaryKey];
+  if (!primaryField) return { ok: false, reason: `primaryKey '${schema.primaryKey}' is not one of the declared fields` };
+  if (primaryField.primary !== true) return { ok: false, reason: `the primaryKey field '${schema.primaryKey}' must be flagged \`primary: true\`` };
+  if (opts.source === "feed" && !schema.ingest) return { ok: false, reason: "a feed schema must declare an `ingest` block" };
+  const dataDir = resolveDataDir(schema.dataPath, opts.workspaceRoot);
+  if (dataDir === null) return { ok: false, reason: `dataPath '${schema.dataPath}' escapes the workspace` };
+  return { ok: true, dataDir };
+}
+
 async function loadOneCollection(skillsRoot: string, slug: string, source: CollectionSource, workspaceRoot: string): Promise<LoadedCollection | null> {
   const safeName = safeSlugName(slug);
   if (safeName === null) return null;
@@ -631,39 +660,17 @@ async function loadOneCollection(skillsRoot: string, slug: string, source: Colle
     return null;
   }
 
-  // Verify the primary key is one of the declared fields AND is
-  // flagged `primary: true`. Without the flag the CollectionView
-  // would render the field as editable (its disabled-on-edit check
-  // is `field.primary === true`), the user's rename would silently
-  // be pinned back to the URL itemId on save, and they'd never know
-  // the edit was dropped. Reject the schema up front rather than
-  // ship that UX.
+  // Post-Zod acceptance gates (primaryKey flagged primary, feed ingest,
+  // workspace-contained dataPath) — shared with manageCollection's putSchema
+  // so a validated write and discovery agree on what's a live collection.
   const schema = parsed.data;
-  const primaryField = schema.fields[schema.primaryKey];
-  if (!primaryField) {
-    log.warn("collections", "schema.json primaryKey not found in fields, skipping", { slug: safeName, primaryKey: schema.primaryKey });
-    return null;
-  }
-  if (primaryField.primary !== true) {
-    log.warn("collections", "schema.json primaryKey field is not flagged primary: true, skipping", { slug: safeName, primaryKey: schema.primaryKey });
+  const acceptance = acceptParsedSchema(schema, { source, workspaceRoot });
+  if (!acceptance.ok) {
+    log.warn("collections", "schema.json rejected after validation, skipping", { slug: safeName, reason: acceptance.reason });
     return null;
   }
 
-  // A feed-registry schema MUST declare an `ingest` block — without it the
-  // host can never fetch it, so it'd be a dead, non-refreshable card in
-  // /feeds. Skip it (the old register tool rejected this case explicitly).
-  if (source === "feed" && !schema.ingest) {
-    log.warn("collections", "feed schema.json has no `ingest` block, skipping", { slug: safeName });
-    return null;
-  }
-
-  const dataDir = resolveDataDir(schema.dataPath, workspaceRoot);
-  if (dataDir === null) {
-    log.warn("collections", "schema.json dataPath escapes workspace, skipping", { slug: safeName, dataPath: schema.dataPath, workspaceRoot });
-    return null;
-  }
-
-  return { slug: safeName, source, schema, dataDir, skillDir: path.join(skillsRoot, safeName) };
+  return { slug: safeName, source, schema, dataDir: acceptance.dataDir, skillDir: path.join(skillsRoot, safeName) };
 }
 
 async function collectFromDir(skillsRoot: string, source: CollectionSource, workspaceRoot: string): Promise<LoadedCollection[]> {

--- a/packages/plugins/collection-plugin/src/server/discovery.ts
+++ b/packages/plugins/collection-plugin/src/server/discovery.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 import { z } from "zod";
 import { log, getWorkspaceRoot, userSkillsDir, projectSkillsDir, feedsRoot } from "./host";
 import { INGEST_KINDS, FEED_SCHEDULES } from "../core/schema";
-import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths";
+import { SCHEMA_FILE, resolveDataDir, safeRecordId, safeSlugName } from "./paths";
 import type { LoadedCollection } from "./discoveredCollection";
 import { isSafeActionTemplatePath, isSafeCustomViewPath } from "./templatePath";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
@@ -396,12 +396,12 @@ export const CollectionSchemaZ = z
     ingest: IngestSchemaZ.optional(),
   })
   // The singleton value becomes a record id (and thus a `<id>.json`
-  // filename), so it must satisfy the SAME `safeSlugName` rule the
+  // filename), so it must satisfy the SAME `safeRecordId` rule the
   // write path enforces — otherwise the create form would lock the
   // primary key to a value the POST route then rejects as an invalid
   // item id, making the collection impossible to initialize (Codex P1).
-  .refine((schema) => schema.singleton === undefined || safeSlugName(schema.singleton) !== null, {
-    message: "schema `singleton` must be a valid item id (alphanumeric / hyphen / underscore, no path separators)",
+  .refine((schema) => schema.singleton === undefined || safeRecordId(schema.singleton) !== null, {
+    message: "schema `singleton` must be a valid item id (alphanumeric / hyphen / underscore / interior dot, no `..` or path separators)",
     path: ["singleton"],
   })
   // Action ids must be unique so the dispatch route resolves

--- a/packages/plugins/collection-plugin/src/server/io.ts
+++ b/packages/plugins/collection-plugin/src/server/io.ts
@@ -8,7 +8,7 @@ import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { getWorkspaceRoot, log, skillsStagingDir } from "./host";
 import { writeFileAtomic } from "./atomic";
-import { isContainedInRoot, itemFilePath, resolveTemplatePath, safeSlugName } from "./paths";
+import { isContainedInRoot, itemFilePath, resolveTemplatePath, safeRecordId, safeSlugName } from "./paths";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
 import type { LoadedCollection } from "./discoveredCollection";
 
@@ -95,7 +95,7 @@ export async function listItems(dataDir: string, opts: IoOptions = {}): Promise<
  *  when the record file itself is a symlink (file-disclosure
  *  defense — see `isRegularFile`). */
 export async function readItem(dataDir: string, itemId: string, opts: IoOptions = {}): Promise<CollectionItem | null> {
-  const safeId = safeSlugName(itemId);
+  const safeId = safeRecordId(itemId);
   if (safeId === null) return null;
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
   if (!isContainedInRoot(dataDir, workspaceRoot)) return null;
@@ -142,7 +142,7 @@ export type WriteItemResult =
  *  Update path (`refuseOverwrite: false`) uses `writeFileAtomic` so
  *  PUT remains crash-atomic. No race there — the URL pins the id. */
 export async function writeItem(dataDir: string, itemId: string, item: CollectionItem, opts: WriteItemOptions = {}): Promise<WriteItemResult> {
-  const safeId = safeSlugName(itemId);
+  const safeId = safeRecordId(itemId);
   if (safeId === null) return { kind: "invalid-id", itemId };
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
   // Containment check runs BEFORE mkdir so we never create
@@ -190,7 +190,7 @@ export type DeleteItemResult =
   | { kind: "path-escape"; itemId: string };
 
 export async function deleteItem(dataDir: string, itemId: string, opts: IoOptions = {}): Promise<DeleteItemResult> {
-  const safeId = safeSlugName(itemId);
+  const safeId = safeRecordId(itemId);
   if (safeId === null) return { kind: "invalid-id", itemId };
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
   if (!isContainedInRoot(dataDir, workspaceRoot)) {

--- a/packages/plugins/collection-plugin/src/server/paths.ts
+++ b/packages/plugins/collection-plugin/src/server/paths.ts
@@ -27,6 +27,31 @@ export function safeSlugName(slug: string): string | null {
   return basename;
 }
 
+// Record ids are a superset of slugs: they're only ever filename stems
+// (`<id>.json`), never directory names or URL segments, so they may carry
+// dots — natural keys like a Slack ts (`1718900000.123456`), a SemVer
+// (`1.2.3`), or a decimal timestamp. The interior class adds `.` to the slug
+// set; the explicit `..` reject below keeps a parent-dir-looking segment out
+// while still allowing repeated `-`/`_` (`a--b`, `a__b`). Start/end stay
+// alphanumeric so leading/trailing dots (hidden files, the special `.`/`..`
+// names) and `..`-only ids are all excluded.
+// eslint-disable-next-line security/detect-unsafe-regex -- non-overlapping character classes, no catastrophic backtracking
+const SAFE_RECORD_ID_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+
+/** Sanitise a user-supplied record id into a safe filename stem. Like
+ *  `safeSlugName` but tolerates interior dots (so natural keys work),
+ *  while still rejecting any `..` substring, path separators, and
+ *  leading/trailing dots. The `path.basename` round-trip is the same
+ *  `js/path-injection` sanitiser CodeQL recognises on `safeSlugName`. */
+export function safeRecordId(recordId: string): string | null {
+  if (typeof recordId !== "string") return null;
+  if (!SAFE_RECORD_ID_PATTERN.test(recordId)) return null;
+  if (recordId.includes("..")) return null;
+  const basename = path.basename(recordId);
+  if (basename !== recordId) return null;
+  return basename;
+}
+
 /** Realpath the closest existing ancestor of `absPath` and return it.
  *  Returns null if no ancestor exists or if the realpath call fails
  *  for a non-ENOENT reason (permissions, etc.). Used by

--- a/packages/services/collection-watchers/src/reconciler.ts
+++ b/packages/services/collection-watchers/src/reconciler.ts
@@ -250,10 +250,14 @@ export async function reconcileItem(
   }
   // Time gate: when the schema declares `triggerField`, suppress the bell
   // until the clock reaches that date (minus `triggerLeadDays`).
-  // Unparseable date ⇒ fail safe (no bell) + warn.
+  // Unparseable date ⇒ fail safe (no bell); warn ONLY when the field carries
+  // a non-empty value that won't parse — an empty optional trigger date is a
+  // normal state and must not spam a WARN every reconcile tick.
   if (schema.triggerField) {
-    const due = isTriggerDue(item[schema.triggerField], now, schema.triggerLeadDays);
-    if (due === null) {
+    const triggerRaw = item[schema.triggerField];
+    const due = isTriggerDue(triggerRaw, now, schema.triggerLeadDays);
+    const isEmpty = triggerRaw === undefined || triggerRaw === null || triggerRaw === "";
+    if (due === null && !isEmpty) {
       log().warn("trigger date unparseable, suppressing bell", { slug, itemId, triggerField: schema.triggerField });
     }
     if (due !== true) {

--- a/packages/services/workspace-setup/assets/helps/collection-skills.md
+++ b/packages/services/workspace-setup/assets/helps/collection-skills.md
@@ -127,7 +127,7 @@ skipped, never crashes the host):
 | `title`                | Human name shown in the sidebar / header. Required.                                                                                                                                                                                                                                                                                                                                                                           |
 | `icon`                 | A **Material Symbols** name (`receipt_long`, `people`, `schedule`, `menu_book`). Required.                                                                                                                                                                                                                                                                                                                                    |
 | `dataPath`             | Workspace-relative records folder, e.g. `data/recipes/items`. Must stay under the workspace. Required.                                                                                                                                                                                                                                                                                                                        |
-| `primaryKey`           | The field name whose value is the filename. That field MUST set `primary: true`. Required.                                                                                                                                                                                                                                                                                                                                    |
+| `primaryKey`           | The field name whose value is the filename. That field MUST set `primary: true`. The value must be a valid record id (see the **Records** section's id-charset rule). Required.                                                                                                                                                                                                                                                |
 | `singleton`            | Optional. When set, at most one record exists, pinned to this exact id (e.g. `me`). Host pre-fills + locks the create form and hides Add once it exists.                                                                                                                                                                                                                                                                      |
 | `fields`               | Ordered map of field-name → field spec. **Insertion order = column order** in the table. Required.                                                                                                                                                                                                                                                                                                                            |
 | `actions`              | Optional array of per-record buttons (see below).                                                                                                                                                                                                                                                                                                                                                                             |
@@ -677,6 +677,17 @@ single source of truth and the "done" checkbox is a `toggle` field projecting it
 
 - Write each record to `<dataPath>/<id>.json` via the **Write** tool; the `id`
   field's value is the filename (no extension).
+- **Id charset** (enforced by `safeRecordId` in
+  `packages/plugins/collection-plugin/src/server/paths.ts` — the single source of
+  truth; `manageCollection` rejects ids that fail it): start and end with a
+  letter or digit; inside, also `-`, `_`, and `.` are allowed (so natural keys
+  like a Slack ts `1718900000.123456` or a SemVer `1.2.3` work). **No** path
+  separators, **no** leading/trailing dot, and **no** `..` substring. If your
+  natural key contains anything else (a space, `/`, `:`, a leading dot), sanitise
+  it first — e.g. replace each illegal run with `_`. Note `manageCollection`
+  enforces this on every targeted read/write, so an id that only *looks* fine in
+  a full `getItems` listing but violates the rule can't be updated or deleted by
+  id — fix the id, don't work around it with raw file I/O.
 - **The file MUST be valid JSON.** A malformed record is **silently skipped** at
   read time (logged server-side, but invisible in the UI) — so one bad file out
   of fifteen looks like "fourteen records vanished." The #1 cause is an

--- a/packages/services/workspace-setup/assets/helps/collection-skills.md
+++ b/packages/services/workspace-setup/assets/helps/collection-skills.md
@@ -50,7 +50,7 @@ data/<name>/items/             ← the records (separate from the skill dir)
   silently fail validation and make the collection vanish from the UI. It writes
   the canonical `data/skills/<slug>/schema.json` and mirrors it for you — same
   destination as authoring, just validated. (Creating a *new* collection still
-  means Writing `SKILL.md` + `schema.json` under `data/skills/<slug>/`, since
+  means writing `SKILL.md` + `schema.json` under `data/skills/<slug>/`, since
   there's nothing to `getSchema` yet.)
 - **Do NOT use the `mc-` prefix** for skills you create. `mc-*` is reserved for
   the bundled presets (`mc-cooking-coach`, `mc-library`, `mc-wiki-*`,

--- a/packages/services/workspace-setup/assets/helps/collection-skills.md
+++ b/packages/services/workspace-setup/assets/helps/collection-skills.md
@@ -42,6 +42,16 @@ data/<name>/items/             ← the records (separate from the skill dir)
   triggers a re-scan, so the collection appears at `/collections/<slug>`
   without a restart. (Other files you drop in `data/skills/<slug>/` — a README,
   scratch notes — stay put and are NOT mirrored.)
+- **To CHANGE an existing collection's schema, use `manageCollection` — not raw
+  file edits.** Call `schemaDocs` for this very reference, `getSchema` to read
+  the current `schema.json` (you don't need to know its path), then `putSchema`
+  to write it back. `putSchema` validates the whole schema against the same rules
+  discovery enforces and reports the exact problem, where a hand-edit can
+  silently fail validation and make the collection vanish from the UI. It writes
+  the canonical `data/skills/<slug>/schema.json` and mirrors it for you — same
+  destination as authoring, just validated. (Creating a *new* collection still
+  means Writing `SKILL.md` + `schema.json` under `data/skills/<slug>/`, since
+  there's nothing to `getSchema` yet.)
 - **Do NOT use the `mc-` prefix** for skills you create. `mc-*` is reserved for
   the bundled presets (`mc-cooking-coach`, `mc-library`, `mc-wiki-*`,
   `mc-manage-*`); the server overwrites those on every boot, so your edits would
@@ -67,7 +77,8 @@ description: A personal recipe box. Use whenever the user asks to add, list,
   (one JSON per recipe); the user views them at `/collections/recipes`,
   rendered from `schema.json` by the host. Record I/O via the
   `manageCollection` tool (raw Read / Write / Edit on the JSON files is the
-  escape hatch).
+  escape hatch); schema/structure edits via `manageCollection`
+  `schemaDocs` / `getSchema` / `putSchema`.
 ---
 
 # Recipes (schema-driven collection)
@@ -90,6 +101,12 @@ the WHOLE record and would erase every optional field the row omits.
 host-computed `derived` / `toggle` / `embed` values (the stored JSON never
 contains them); pass `ids` / `fields` on large collections.
 **Delete** — remove the record file.
+**Change the schema** (add / rename / remove a field, view, or action) —
+`manageCollection` `schemaDocs` for the field DSL, `getSchema` to read the
+current schema, then `putSchema` to validate-and-write it. Do NOT hand-edit
+`schema.json` with Read / Write / Edit — `putSchema` validates the whole schema
+first and tells you exactly what's wrong, where a raw edit can silently fail
+discovery's validation and make the collection vanish.
 Don't recite the whole table in chat. After adding or updating a record,
 call `presentCollection` (with the collection slug and the record's id) to
 show it inline; for a plain "show/list" request, call `presentCollection`
@@ -713,6 +730,27 @@ single source of truth and the "done" checkbox is a `toggle` field projecting it
    requires `completionField` and names a real field.
    (A schema that fails validation is logged server-side and silently skipped
    at discovery.)
+
+## Editing an existing collection's schema
+
+To change the structure of a collection that already exists (add a field,
+rename a label, add a view or action), go through `manageCollection` rather than
+hand-editing the file:
+
+1. `manageCollection` `schemaDocs` — reload this reference for the field DSL.
+2. `manageCollection` `getSchema` (slug) — read the current `schema.json`
+   verbatim. You don't need to know where the file lives.
+3. Apply your change to that object, then `manageCollection` `putSchema`
+   (slug, schema) — it validates the whole schema against the same rules
+   discovery enforces and either writes it (canonical `data/skills/<slug>/`,
+   mirrored for you) or returns the exact field + problem to fix and retry.
+4. Call `presentCollection` to show the updated collection.
+
+Why not raw Read / Write / Edit on `schema.json`? A hand-edit that fails
+validation is **silently skipped** at discovery — the collection disappears from
+the UI with no error. `putSchema` catches the mistake before the write and hands
+you an actionable message. (`putSchema` is edit-only and refuses user-scope and
+`mc-*` preset collections; create a new collection with the Write flow above.)
 
 ## Worked reference: the billing suite
 

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -36,7 +36,7 @@ import path from "node:path";
 import {
   COMPUTED_TYPES,
   CollectionSchemaZ,
-  acceptParsedSchema,
+  resolveDataDir,
   enrichItems,
   listItems,
   loadCollection,
@@ -347,6 +347,22 @@ async function writeAndMirrorSchema(slug: string, schema: unknown, deps: ManageC
   }
 }
 
+/** The post-Zod acceptance gates discovery applies before a parsed schema
+ *  becomes a live collection. Mirrors collection-plugin's discovery checks
+ *  (`loadOneCollection`) but lives host-side and is built only on
+ *  already-published primitives (`resolveDataDir` + plain field access) — so
+ *  the standalone launcher boots against the published collection-plugin
+ *  rather than depending on a new cross-package export. putSchema only runs
+ *  for project-scope collections, so the feed-`ingest` gate doesn't apply.
+ *  Returns a one-line reason, or null when the schema would be accepted. */
+function schemaDiscoveryGate(schema: CollectionSchema, base: string): string | null {
+  const primaryField = schema.fields[schema.primaryKey];
+  if (!primaryField) return `primaryKey '${schema.primaryKey}' is not one of the declared fields`;
+  if (primaryField.primary !== true) return `the primaryKey field '${schema.primaryKey}' must be flagged \`primary: true\``;
+  if (resolveDataDir(schema.dataPath, base) === null) return `dataPath '${schema.dataPath}' escapes the workspace`;
+  return null;
+}
+
 /** Validate a schema against CollectionSchemaZ and, on success, persist it.
  *  Edit-only: a new collection is created by writing SKILL.md + schema.json
  *  under data/skills/<slug>/ (the normal create flow), not through here. */
@@ -364,9 +380,9 @@ async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCol
   if (!parsed.success) return formatSchemaIssues(parsed.error.issues);
   // Run the SAME post-Zod gates discovery applies, so a write can't pass
   // here yet be silently skipped on the next load (hiding the collection).
-  const acceptance = acceptParsedSchema(parsed.data, { source: collection.source, workspaceRoot: resolveBase(deps) });
-  if (!acceptance.ok) {
-    return `manageCollection: schema rejected — ${acceptance.reason} (call schemaDocs for the field reference). It passes basic validation but discovery would skip it, hiding the collection.`;
+  const gate = schemaDiscoveryGate(parsed.data, resolveBase(deps));
+  if (gate) {
+    return `manageCollection: schema rejected — ${gate} (call schemaDocs for the field reference). It passes basic validation but discovery would skip it, hiding the collection.`;
   }
   // Path from the discovered (sanitized) slug, never the raw arg.
   await writeAndMirrorSchema(collection.slug, parsed.data, deps);

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -36,6 +36,7 @@ import path from "node:path";
 import {
   COMPUTED_TYPES,
   CollectionSchemaZ,
+  acceptParsedSchema,
   enrichItems,
   listItems,
   loadCollection,
@@ -63,7 +64,7 @@ const SCHEMA_FILE = "schema.json";
 /** The collection-authoring reference, served by the `schemaDocs` action. */
 const SCHEMA_DOCS_FILE = "collection-skills.md";
 /** Cap the rejected-schema issue list so a deeply-broken schema can't flood the result. */
-const MAX_SCHEMA_ISSUES = 20;
+export const MAX_SCHEMA_ISSUES = 20;
 
 /** Workspace-targeting overrides, threaded to every collections call.
  *  Production: `{}` (live workspace). Tests: a tmpdir + empty user
@@ -285,7 +286,8 @@ async function handleSchemaDocs(deps: ManageCollectionDeps): Promise<string> {
 async function handleGetSchema(slug: string, deps: ManageCollectionDeps): Promise<string> {
   const collection = await loadCollection(slug, deps);
   if (!collection) return unknownCollection(slug);
-  const candidates = [path.join(dataSkillDir(resolveBase(deps), slug), SCHEMA_FILE), path.join(collection.skillDir, SCHEMA_FILE)];
+  // Path from the discovered (sanitized) slug, never the raw arg.
+  const candidates = [path.join(dataSkillDir(resolveBase(deps), collection.slug), SCHEMA_FILE), path.join(collection.skillDir, SCHEMA_FILE)];
   for (const candidate of candidates) {
     try {
       return await readFile(candidate, "utf-8");
@@ -311,11 +313,11 @@ function schemaEditRefusal(collection: LoadedCollection, slug: string): string |
 /** Turn a CollectionSchemaZ failure into a short, actionable list the
  *  agent can fix, pointing back at the field reference. */
 function formatSchemaIssues(issues: readonly { path: PropertyKey[]; message: string }[]): string {
-  const lines = issues
-    .slice(0, MAX_SCHEMA_ISSUES)
-    .map((issue) => `- ${issue.path.map(String).join(".") || "(root)"}: ${defangForPrompt(issue.message)}`)
-    .join("\n");
-  return `manageCollection: schema rejected — fix and retry (call schemaDocs for the field reference):\n${lines}`;
+  const shown = issues.slice(0, MAX_SCHEMA_ISSUES);
+  const lines = shown.map((issue) => `- ${issue.path.map(String).join(".") || "(root)"}: ${defangForPrompt(issue.message)}`).join("\n");
+  const omitted = issues.length - shown.length;
+  const more = omitted > 0 ? `\n- …and ${omitted} more issue(s); fix these first and retry.` : "";
+  return `manageCollection: schema rejected — fix and retry (call schemaDocs for the field reference):\n${lines}${more}`;
 }
 
 /** Best-effort post-write refresh. Discovery re-reads schema.json from
@@ -359,8 +361,15 @@ async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCol
   if (refusal) return refusal;
   const parsed = CollectionSchemaZ.safeParse(schemaArg);
   if (!parsed.success) return formatSchemaIssues(parsed.error.issues);
-  await writeAndMirrorSchema(slug, parsed.data, deps);
-  return JSON.stringify({ collection: slug, written: true });
+  // Run the SAME post-Zod gates discovery applies, so a write can't pass
+  // here yet be silently skipped on the next load (hiding the collection).
+  const acceptance = acceptParsedSchema(parsed.data, { source: collection.source, workspaceRoot: resolveBase(deps) });
+  if (!acceptance.ok) {
+    return `manageCollection: schema rejected — ${acceptance.reason} (call schemaDocs for the field reference). It passes basic validation but discovery would skip it, hiding the collection.`;
+  }
+  // Path from the discovered (sanitized) slug, never the raw arg.
+  await writeAndMirrorSchema(collection.slug, parsed.data, deps);
+  return JSON.stringify({ collection: collection.slug, written: true });
 }
 
 export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -14,12 +14,28 @@
 //     model can fix and retry — instead of writing a broken file and
 //     meeting it later in the presentCollection repair loop.
 //
+// It is also the paved road for a collection's STRUCTURE — so an edit
+// gets the same authoring reference + validation a create does:
+//
+//   - schemaDocs: the collection-authoring reference (`collection-skills.md`)
+//     delivered as a method, so the agent never needs to know the help
+//     file's path or that it exists — the gap that made schema EDITS fail
+//     (create-time prompts point at the doc; edit-time had no pointer).
+//   - getSchema / putSchema: read the raw schema.json, and validate it
+//     against `CollectionSchemaZ` BEFORE writing the canonical staging
+//     copy + mirroring it active (an internal write skips the skill-bridge
+//     hook, so the mirror is explicit). Edit-only; creation stays the
+//     normal "write SKILL.md + schema.json under data/skills/" flow.
+//
 // Like `spawnBackgroundChat`, the workspace lookups are injected so the
 // unit test can point everything at a tmpdir workspace; the production
 // singleton binds the live modules with default (real-workspace) opts.
 
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import {
   COMPUTED_TYPES,
+  CollectionSchemaZ,
   enrichItems,
   listItems,
   loadCollection,
@@ -32,16 +48,42 @@ import {
 import type { CollectionItem, CollectionSchema, LoadedCollection } from "../../workspace/collections/index.js";
 import type { DiscoveryOptions } from "@mulmoclaude/collection-plugin/server";
 import { defangForPrompt } from "@mulmoclaude/collection-plugin";
+import { dataSkillDir, mirrorSkillWrite } from "@mulmoclaude/skill-bridge";
+import { helpsAssetDir, isPresetSlug } from "@mulmoclaude/workspace-setup";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
 
 /** Refuse an unselective getItems beyond this many records — a silent
  *  truncation would read as "covered everything", and an unbounded dump
  *  of a large collection is a token bomb. `ids` or `fields` lifts it. */
 export const MAX_UNSELECTIVE_ITEMS = 200;
 
+/** schema.json basename under a skill dir (canonical staging + active mirror). */
+const SCHEMA_FILE = "schema.json";
+/** The collection-authoring reference, served by the `schemaDocs` action. */
+const SCHEMA_DOCS_FILE = "collection-skills.md";
+/** Cap the rejected-schema issue list so a deeply-broken schema can't flood the result. */
+const MAX_SCHEMA_ISSUES = 20;
+
 /** Workspace-targeting overrides, threaded to every collections call.
  *  Production: `{}` (live workspace). Tests: a tmpdir + empty user
- *  skills dir. */
-export type ManageCollectionDeps = DiscoveryOptions;
+ *  skills dir. `refreshAfterWrite` is the best-effort UI-refresh fired
+ *  after a `putSchema` write (default: the same refreshers
+ *  `/api/config/refresh` wraps); tests inject a no-op so they never
+ *  touch the real workspace. */
+export type ManageCollectionDeps = DiscoveryOptions & { refreshAfterWrite?: () => Promise<void> };
+
+/** Resolve the workspace root the same way every collections call does:
+ *  the injected override (tests) or the live workspace path (prod). */
+function resolveBase(deps: ManageCollectionDeps): string {
+  return deps.workspaceRoot ?? workspacePath;
+}
+
+/** Shared "unknown collection" message — its schema.json is missing or
+ *  failed validation, so discovery skipped it. */
+function unknownCollection(slug: string): string {
+  return `manageCollection: unknown collection '${defangForPrompt(slug)}' — its schema.json is missing or failed validation.`;
+}
 
 interface GetItemsArgs {
   slug: string;
@@ -220,17 +262,118 @@ function parsePutItems(args: Record<string, unknown>, slug: string): PutItemsArg
   return { slug, items: items as CollectionItem[], mode: (mode as PutItemsArgs["mode"] | undefined) ?? "upsert" };
 }
 
+/** Return the collection-authoring reference (`collection-skills.md`).
+ *  Workspace copy first (reflects user edits), bundled asset as the
+ *  always-present fallback. Both reads guarded; if neither resolves the
+ *  agent still gets an actionable message instead of a thrown call. */
+async function handleSchemaDocs(deps: ManageCollectionDeps): Promise<string> {
+  const candidates = [path.join(resolveBase(deps), WORKSPACE_DIRS.helps, SCHEMA_DOCS_FILE), path.join(helpsAssetDir(), SCHEMA_DOCS_FILE)];
+  for (const candidate of candidates) {
+    try {
+      return await readFile(candidate, "utf-8");
+    } catch {
+      // try the next source
+    }
+  }
+  return `manageCollection: could not read the collection-authoring reference (${SCHEMA_DOCS_FILE}).`;
+}
+
+/** Return the raw schema.json of an existing collection, for editing.
+ *  Staging (the canonical writable copy) first, the active mirror as a
+ *  fallback for user-scope skills that have no staging copy. Raw text —
+ *  not the parsed schema — so the agent edits the true on-disk source. */
+async function handleGetSchema(slug: string, deps: ManageCollectionDeps): Promise<string> {
+  const collection = await loadCollection(slug, deps);
+  if (!collection) return unknownCollection(slug);
+  const candidates = [path.join(dataSkillDir(resolveBase(deps), slug), SCHEMA_FILE), path.join(collection.skillDir, SCHEMA_FILE)];
+  for (const candidate of candidates) {
+    try {
+      return await readFile(candidate, "utf-8");
+    } catch {
+      // fall through to the next location
+    }
+  }
+  return `manageCollection: '${defangForPrompt(slug)}' has no readable ${SCHEMA_FILE}.`;
+}
+
+/** Refuse a schema edit the host can't honour: user-scope/feed collections
+ *  are read-only, and presets (mc-*) re-seed on restart so an edit is lost. */
+function schemaEditRefusal(collection: LoadedCollection, slug: string): string | null {
+  if (collection.source !== "project") {
+    return `manageCollection: '${defangForPrompt(slug)}' is ${collection.source}-scope and read-only here — only project collections (data/skills/) can be edited.`;
+  }
+  if (isPresetSlug(slug)) {
+    return `manageCollection: '${defangForPrompt(slug)}' is a preset (mc-*) and re-seeds on restart — copy it under a different slug to customise.`;
+  }
+  return null;
+}
+
+/** Turn a CollectionSchemaZ failure into a short, actionable list the
+ *  agent can fix, pointing back at the field reference. */
+function formatSchemaIssues(issues: readonly { path: PropertyKey[]; message: string }[]): string {
+  const lines = issues
+    .slice(0, MAX_SCHEMA_ISSUES)
+    .map((issue) => `- ${issue.path.map(String).join(".") || "(root)"}: ${defangForPrompt(issue.message)}`)
+    .join("\n");
+  return `manageCollection: schema rejected — fix and retry (call schemaDocs for the field reference):\n${lines}`;
+}
+
+/** Best-effort post-write refresh. Discovery re-reads schema.json from
+ *  disk on every call, so a failed refresh only delays the live UI
+ *  update — never the data. Default loads the refreshers lazily to keep
+ *  this module's static import graph (and the unit test) light. */
+async function defaultRefresh(): Promise<void> {
+  const [{ refreshScheduledSkills }, { refreshUserTasks }] = await Promise.all([
+    import("../../workspace/skills/scheduler.js"),
+    import("../../workspace/skills/user-tasks.js"),
+  ]);
+  await Promise.all([refreshScheduledSkills(), refreshUserTasks()]);
+}
+
+/** Write the validated schema to the canonical staging copy, then mirror
+ *  it into the active `.claude/skills/` tree discovery reads — an internal
+ *  write doesn't fire the skill-bridge hook, so we mirror explicitly. */
+async function writeAndMirrorSchema(slug: string, schema: unknown, deps: ManageCollectionDeps): Promise<void> {
+  const base = resolveBase(deps);
+  await writeFileAtomic(path.join(dataSkillDir(base, slug), SCHEMA_FILE), `${JSON.stringify(schema, null, 2)}\n`);
+  mirrorSkillWrite(base, { slug, relSegments: [SCHEMA_FILE] });
+  try {
+    await (deps.refreshAfterWrite ?? defaultRefresh)();
+  } catch {
+    // best-effort — see defaultRefresh
+  }
+}
+
+/** Validate a schema against CollectionSchemaZ and, on success, persist it.
+ *  Edit-only: a new collection is created by writing SKILL.md + schema.json
+ *  under data/skills/<slug>/ (the normal create flow), not through here. */
+async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCollectionDeps): Promise<string> {
+  if (!schemaArg || typeof schemaArg !== "object" || Array.isArray(schemaArg)) {
+    return "manageCollection: `schema` is required for putSchema — the full collection schema object.";
+  }
+  const collection = await loadCollection(slug, deps);
+  if (!collection) {
+    return `manageCollection: unknown collection '${defangForPrompt(slug)}' — create it by writing SKILL.md + ${SCHEMA_FILE} under data/skills/${defangForPrompt(slug)}/, then edit it here.`;
+  }
+  const refusal = schemaEditRefusal(collection, slug);
+  if (refusal) return refusal;
+  const parsed = CollectionSchemaZ.safeParse(schemaArg);
+  if (!parsed.success) return formatSchemaIssues(parsed.error.issues);
+  await writeAndMirrorSchema(slug, parsed.data, deps);
+  return JSON.stringify({ collection: slug, written: true });
+}
+
 export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
   return {
     definition: {
       name: "manageCollection",
       description:
-        "Read and write records of a schema-driven collection through the host. getItems returns records WITH computed values (derived formulas, toggles, embeds) the stored JSON files don't contain; putItems validates each row against the collection's schema before writing and reports per-row rejects. Prefer it over raw file I/O on collection records.",
+        "Read and write a schema-driven collection through the host — both its records and its structure. getItems returns records WITH computed values (derived formulas, toggles, embeds) the stored JSON files don't contain; putItems validates each row against the schema before writing. schemaDocs returns the collection-authoring reference; getSchema/putSchema read and validate-then-write the collection's schema.json. Prefer it over raw file I/O on collections.",
       inputSchema: {
         type: "object",
         properties: {
-          action: { type: "string", enum: ["getItems", "putItems"], description: "What to do." },
-          slug: { type: "string", description: "The collection's slug (its directory name, e.g. `stock-quotes`)." },
+          action: { type: "string", enum: ["getItems", "putItems", "schemaDocs", "getSchema", "putSchema"], description: "What to do." },
+          slug: { type: "string", description: "The collection's slug (its directory name, e.g. `stock-quotes`). Required for everything except schemaDocs." },
           ids: {
             type: "array",
             items: { type: "string" },
@@ -252,8 +395,13 @@ export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
             description:
               'putItems: "upsert" (default) replaces existing records WHOLE; "create" rejects rows whose id already exists; "merge" updates only the fields a row carries, keeping the rest of the existing record (rejects unknown ids). Use "merge" when changing a few fields.',
           },
+          schema: {
+            type: "object",
+            description:
+              "putSchema: the full collection schema object (same shape as schema.json — title, icon, dataPath, primaryKey, fields, …). Call getSchema first for the current one, and schemaDocs for the field DSL.",
+          },
         },
-        required: ["action", "slug"],
+        required: ["action"],
       },
     },
 
@@ -263,18 +411,24 @@ export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
     alwaysActive: true,
 
     prompt:
-      "Use `manageCollection` instead of raw Read/Write/Edit when working with a collection's records (raw file I/O stays available as the escape hatch). " +
+      "Use `manageCollection` instead of raw Read/Write/Edit when working with a collection's records OR its schema (raw file I/O stays available as the escape hatch). " +
+      "Before authoring or changing a collection's `schema.json`, call `schemaDocs` to load the field/DSL reference, then read with `getSchema` and write with `putSchema` — `putSchema` validates the whole schema before writing and returns actionable errors instead of silently failing discovery's validation. " +
       "`getItems` is the only way to see computed values — `derived` fields (e.g. a portfolio's value), `toggle` projections, and `embed` records are host-computed and never present in the stored JSON files. On large collections pass `ids` and/or `fields` to keep the result small. " +
       "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write. " +
       'To update a few fields of an existing record, use `mode: "merge"` with a partial row ({ id, <changed fields> }) — the default upsert replaces the WHOLE record, so a partial upsert would silently erase every optional field it omits.',
 
     async handler(args: Record<string, unknown>): Promise<string> {
       const action = typeof args.action === "string" ? args.action : "";
+      if (action === "schemaDocs") return handleSchemaDocs(deps);
       const slug = typeof args.slug === "string" ? args.slug.trim() : "";
       if (!slug) return "manageCollection: `slug` is required (the collection's slug).";
-      if (action !== "getItems" && action !== "putItems") return 'manageCollection: `action` must be "getItems" or "putItems".';
+      if (action === "getSchema") return handleGetSchema(slug, deps);
+      if (action === "putSchema") return handlePutSchema(slug, args.schema, deps);
+      if (action !== "getItems" && action !== "putItems") {
+        return 'manageCollection: `action` must be "getItems", "putItems", "schemaDocs", "getSchema", or "putSchema".';
+      }
       const collection = await loadCollection(slug, deps);
-      if (!collection) return `manageCollection: unknown collection '${defangForPrompt(slug)}' — its schema.json is missing or failed validation.`;
+      if (!collection) return unknownCollection(slug);
       if (action === "getItems") {
         const ids = optionalStringArray(args.ids, "ids");
         if (!ids.ok) return ids.error;

--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -237,7 +237,8 @@ async function putOneItem(
   if (invalid) return reject(itemId, invalid);
   const result = await writeItem(collection.dataDir, itemId, toWrite, { refuseOverwrite: mode === "create", workspaceRoot: deps.workspaceRoot });
   if (result.kind === "ok") return { written: result.itemId };
-  if (result.kind === "invalid-id") return reject(itemId, `'${itemId}' is not a valid record id (letters/digits with - or _ inside, no path characters)`);
+  if (result.kind === "invalid-id")
+    return reject(itemId, `'${itemId}' is not a valid record id (letters/digits at the ends; -, _, or . inside; no '..' or path characters)`);
   if (result.kind === "conflict") return reject(itemId, `'${itemId}' already exists — mode "create" refuses overwrite; use "upsert" to update it`);
   return reject(itemId, "write refused: the collection's data dir escapes the workspace");
 }

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -14674,6 +14674,15 @@ function safeSlugName(slug) {
   if (basename !== slug) return null;
   return basename;
 }
+var SAFE_RECORD_ID_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9_.-]*[a-zA-Z0-9])?$/;
+function safeRecordId(recordId) {
+  if (typeof recordId !== "string") return null;
+  if (!SAFE_RECORD_ID_PATTERN.test(recordId)) return null;
+  if (recordId.includes("..")) return null;
+  const basename = path3.basename(recordId);
+  if (basename !== recordId) return null;
+  return basename;
+}
 var TEMPLATES_PREFIX = "templates/";
 function isSafeTemplatePath(value) {
   if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
@@ -14899,8 +14908,8 @@ var CollectionSchemaZ = external_exports.object({
   views: external_exports.array(CustomViewSchema).optional(),
   notifyWhen: WhenSchema.optional(),
   ingest: IngestSchemaZ.optional()
-}).refine((schema) => schema.singleton === void 0 || safeSlugName(schema.singleton) !== null, {
-  message: "schema `singleton` must be a valid item id (alphanumeric / hyphen / underscore, no path separators)",
+}).refine((schema) => schema.singleton === void 0 || safeRecordId(schema.singleton) !== null, {
+  message: "schema `singleton` must be a valid item id (alphanumeric / hyphen / underscore / interior dot, no `..` or path separators)",
   path: ["singleton"]
 }).refine((schema) => schema.actions === void 0 || new Set(schema.actions.map((action) => action.id)).size === schema.actions.length, {
   message: "schema `actions` must have unique `id`s",

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -1,4 +1,12 @@
-export { discoverCollections, loadCollection, toSummary, toDetail, CollectionSchemaZ, type LoadedCollection } from "@mulmoclaude/collection-plugin/server";
+export {
+  discoverCollections,
+  loadCollection,
+  toSummary,
+  toDetail,
+  CollectionSchemaZ,
+  acceptParsedSchema,
+  type LoadedCollection,
+} from "@mulmoclaude/collection-plugin/server";
 export { validateCollectionRecords, validateRecordObject, COMPUTED_TYPES, type RecordIssue } from "@mulmoclaude/collection-plugin/server";
 export { enrichItems } from "@mulmoclaude/collection-plugin/server";
 export { deleteCollection, deleteCollectionRefusalMessage, type DeleteCollectionResult } from "@mulmoclaude/collection-plugin/server";

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -4,7 +4,7 @@ export {
   toSummary,
   toDetail,
   CollectionSchemaZ,
-  acceptParsedSchema,
+  resolveDataDir,
   type LoadedCollection,
 } from "@mulmoclaude/collection-plugin/server";
 export { validateCollectionRecords, validateRecordObject, COMPUTED_TYPES, type RecordIssue } from "@mulmoclaude/collection-plugin/server";

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -13,7 +13,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { makeManageCollectionTool, MAX_UNSELECTIVE_ITEMS } from "../../server/agent/mcp-tools/manageCollection.js";
+import { makeManageCollectionTool, MAX_UNSELECTIVE_ITEMS, MAX_SCHEMA_ISSUES } from "../../server/agent/mcp-tools/manageCollection.js";
 import { mcpTools } from "../../server/agent/mcp-tools/index.js";
 
 let workdir: string;
@@ -368,5 +368,37 @@ describe("manageCollection — putSchema", () => {
 
   it("refuses an unknown collection with a create hint", async () => {
     assert.match(await putRun({ action: "putSchema", slug: "ghost", schema: quotesSchema }), /create it by writing SKILL\.md/);
+  });
+
+  // Post-Zod gates discovery applies — a schema that passes CollectionSchemaZ
+  // but fails one of these would write cleanly yet vanish on next discovery.
+  const noStagingWrite = () => assert.ok(!existsSync(path.join(workdir, "data/skills/stock-quotes/schema.json")), "no staging write on rejection");
+
+  it("rejects a primaryKey that is not a declared field", async () => {
+    const bad = { ...quotesSchema, primaryKey: "ghostkey" };
+    assert.match(await putRun({ action: "putSchema", slug: "stock-quotes", schema: bad }), /not one of the declared fields/);
+    noStagingWrite();
+  });
+
+  it("rejects a primaryKey field not flagged primary: true", async () => {
+    const bad = { ...quotesSchema, fields: { ...quotesSchema.fields, symbol: { type: "string", label: "Symbol", required: true } } };
+    assert.match(await putRun({ action: "putSchema", slug: "stock-quotes", schema: bad }), /must be flagged `primary: true`/);
+    noStagingWrite();
+  });
+
+  it("rejects a dataPath that escapes the workspace", async () => {
+    const bad = { ...quotesSchema, dataPath: "../../etc/evil" };
+    assert.match(await putRun({ action: "putSchema", slug: "stock-quotes", schema: bad }), /escapes the workspace/);
+    noStagingWrite();
+  });
+
+  it("caps the issue list and flags how many were omitted", async () => {
+    const fields: Record<string, unknown> = {};
+    for (let i = 0; i < MAX_SCHEMA_ISSUES + 5; i++) fields[`f${i}`] = { type: "not-a-real-type", label: `F${i}` };
+    const msg = await putRun({ action: "putSchema", slug: "stock-quotes", schema: { ...quotesSchema, fields } });
+    const bullets = msg.split("\n").filter((line) => line.startsWith("- "));
+    const issueBullets = bullets.filter((line) => !line.includes("…and"));
+    assert.equal(issueBullets.length, MAX_SCHEMA_ISSUES, "issue bullets capped at MAX_SCHEMA_ISSUES");
+    assert.match(msg, /…and \d+ more issue\(s\)/);
   });
 });

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -291,3 +291,82 @@ describe("manageCollection — putItems", () => {
     assert.match((computed.rejected as { problem: string }[])[0]?.problem ?? "", /'value' is derived/);
   });
 });
+
+describe("manageCollection — schemaDocs", () => {
+  it("returns the bundled authoring reference when the workspace has none", async () => {
+    const docs = await run({ action: "schemaDocs" });
+    assert.doesNotMatch(docs, /could not read/);
+    assert.match(docs, /Collection skills/); // heading from the bundled collection-skills.md
+  });
+
+  it("prefers the workspace copy over the bundled asset", async () => {
+    const helpsDir = path.join(workdir, "config/helps");
+    mkdirSync(helpsDir, { recursive: true });
+    writeFileSync(path.join(helpsDir, "collection-skills.md"), "SENTINEL workspace doc");
+    assert.equal(await run({ action: "schemaDocs" }), "SENTINEL workspace doc");
+  });
+
+  it("needs no slug", async () => {
+    assert.doesNotMatch(await run({ action: "schemaDocs" }), /`slug` is required/);
+  });
+});
+
+describe("manageCollection — getSchema", () => {
+  it("returns the raw schema.json of an existing collection", async () => {
+    const parsed = JSON.parse(await run({ action: "getSchema", slug: "portfolio" })) as Record<string, unknown>;
+    assert.equal(parsed.title, "Portfolio");
+    assert.ok((parsed.fields as Record<string, unknown>).value, "derived field present");
+  });
+
+  it("reports an unknown collection", async () => {
+    assert.match(await run({ action: "getSchema", slug: "nope" }), /unknown collection 'nope'/);
+  });
+});
+
+describe("manageCollection — putSchema", () => {
+  // Inject a no-op refresh so the write never touches the real workspace.
+  let putTool: ReturnType<typeof makeManageCollectionTool>;
+  const putRun = (args: Record<string, unknown>) => putTool.handler(args);
+  const readJson = (rel: string) => JSON.parse(readFileSync(path.join(workdir, rel), "utf-8")) as Record<string, unknown>;
+  const withField = (fields: Record<string, unknown>) => ({ ...quotesSchema, fields: { ...quotesSchema.fields, ...fields } });
+
+  beforeEach(() => {
+    putTool = makeManageCollectionTool({ workspaceRoot: workdir, userSkillsDir: emptyUserDir, refreshAfterWrite: async () => {} });
+  });
+
+  it("validates, writes to data/skills staging, and mirrors to .claude/skills", async () => {
+    const updated = withField({ volume: { type: "number", label: "Volume" } });
+    const result = JSON.parse(await putRun({ action: "putSchema", slug: "stock-quotes", schema: updated })) as Record<string, unknown>;
+    assert.equal(result.written, true);
+    assert.ok((readJson("data/skills/stock-quotes/schema.json").fields as Record<string, unknown>).volume, "new field in canonical staging copy");
+    assert.ok((readJson(".claude/skills/stock-quotes/schema.json").fields as Record<string, unknown>).volume, "new field mirrored to active copy");
+  });
+
+  it("rejects an invalid schema, points at schemaDocs, and writes nothing", async () => {
+    const msg = await putRun({ action: "putSchema", slug: "stock-quotes", schema: { ...quotesSchema, primaryKey: "" } });
+    assert.match(msg, /schema rejected/);
+    assert.match(msg, /schemaDocs/);
+    assert.ok(!existsSync(path.join(workdir, "data/skills/stock-quotes/schema.json")), "no staging file on rejection");
+  });
+
+  it("requires a schema object", async () => {
+    assert.match(await putRun({ action: "putSchema", slug: "stock-quotes" }), /`schema` is required/);
+  });
+
+  it("refuses a user-scope collection (read-only)", async () => {
+    const dir = path.join(emptyUserDir, "house-rules");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "SKILL.md"), "---\nname: house-rules\ndescription: test fixture\n---\nbody\n");
+    writeFileSync(path.join(dir, "schema.json"), JSON.stringify(quotesSchema));
+    assert.match(await putRun({ action: "putSchema", slug: "house-rules", schema: quotesSchema }), /user-scope and read-only/);
+  });
+
+  it("refuses a preset (mc-*) collection", async () => {
+    writeSkill("mc-budget", quotesSchema);
+    assert.match(await putRun({ action: "putSchema", slug: "mc-budget", schema: quotesSchema }), /preset \(mc-\*\)/);
+  });
+
+  it("refuses an unknown collection with a create hint", async () => {
+    assert.match(await putRun({ action: "putSchema", slug: "ghost", schema: quotesSchema }), /create it by writing SKILL\.md/);
+  });
+});

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -292,6 +292,31 @@ describe("manageCollection — putItems", () => {
   });
 });
 
+describe("manageCollection — dotted record ids", () => {
+  // A natural key with interior dots (Slack ts) must round-trip through every
+  // targeted op, not just the full-scan listing (issue #1735).
+  const tsId = "1718900000.123456";
+
+  it("create / get-by-id / merge all accept an interior-dot id", async () => {
+    const created = await runJson({ action: "putItems", slug: "stock-quotes", items: [{ symbol: tsId, price: 1 }], mode: "create" });
+    assert.deepEqual(created.written, [tsId]);
+    assert.ok(existsSync(path.join(workdir, `data/stock-quotes/items/${tsId}.json`)), "record file written under the dotted id");
+
+    const got = await runJson({ action: "getItems", slug: "stock-quotes", ids: [tsId] });
+    assert.equal(got.count, 1);
+    assert.equal((got.items as Record<string, unknown>[])[0]?.symbol, tsId);
+    assert.deepEqual(got.missing ?? [], []);
+
+    const merged = await runJson({ action: "putItems", slug: "stock-quotes", items: [{ symbol: tsId, price: 2 }], mode: "merge" });
+    assert.deepEqual(merged.written, [tsId]);
+  });
+
+  it("still rejects a `..` id", async () => {
+    const result = await runJson({ action: "putItems", slug: "stock-quotes", items: [{ symbol: "a..b", price: 1 }], mode: "create" });
+    assert.match((result.rejected as { problem: string }[])[0]?.problem ?? "", /not a valid record id/);
+  });
+});
+
 describe("manageCollection — schemaDocs", () => {
   it("returns the bundled authoring reference when the workspace has none", async () => {
     const docs = await run({ action: "schemaDocs" });

--- a/test/workspace/collections/test_paths.ts
+++ b/test/workspace/collections/test_paths.ts
@@ -16,7 +16,7 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { isContainedInRoot, safeSlugName } from "@mulmoclaude/collection-plugin/server";
+import { isContainedInRoot, safeRecordId, safeSlugName } from "@mulmoclaude/collection-plugin/server";
 
 let rootDir: string;
 let outsideDir: string;
@@ -106,5 +106,35 @@ describe("safeSlugName", () => {
     assert.equal(safeSlugName(null as unknown as string), null);
     assert.equal(safeSlugName(undefined as unknown as string), null);
     assert.equal(safeSlugName(42 as unknown as string), null);
+  });
+});
+
+describe("safeRecordId", () => {
+  it("accepts everything a slug accepts, including repeated -/_", () => {
+    assert.equal(safeRecordId("acme-corp"), "acme-corp");
+    assert.equal(safeRecordId("client42"), "client42");
+    assert.equal(safeRecordId("a--b"), "a--b");
+    assert.equal(safeRecordId("a__b"), "a__b");
+  });
+
+  it("accepts natural keys with interior dots", () => {
+    assert.equal(safeRecordId("1718900000.123456"), "1718900000.123456"); // Slack ts
+    assert.equal(safeRecordId("1.2.3"), "1.2.3"); // SemVer
+  });
+
+  it("rejects `..`, path separators, and leading/trailing dots", () => {
+    assert.equal(safeRecordId("a..b"), null);
+    assert.equal(safeRecordId(".."), null);
+    assert.equal(safeRecordId(".hidden"), null);
+    assert.equal(safeRecordId("trailing."), null);
+    assert.equal(safeRecordId("../etc"), null);
+    assert.equal(safeRecordId("a/b"), null);
+    assert.equal(safeRecordId("a\\b"), null);
+  });
+
+  it("rejects non-string and empty input", () => {
+    assert.equal(safeRecordId(""), null);
+    assert.equal(safeRecordId(null as unknown as string), null);
+    assert.equal(safeRecordId(42 as unknown as string), null);
   });
 });


### PR DESCRIPTION
## Why

Creating a collection works well: the create-time flow steers the agent to read `config/helps/collection-skills.md` first. **Editing** an existing collection's `schema.json` failed more often — schema changes went through raw Read/Write/Edit, which carry no authoring guidance and no validation. So at edit time the agent couldn't see the DSL reference and could write a schema that silently fails `CollectionSchemaZ` validation (discovery then skips it, and the collection vanishes from the UI with no error).

## What

Make `manageCollection` — the always-active data plane already used for records — the paved road for a collection's **structure** too. Three new actions:

- **`schemaDocs`** — returns the authoring reference (`collection-skills.md`) as a method (workspace-first, bundled-asset fallback), so the agent never needs to know the help file's path or that it exists.
- **`getSchema`** — returns the raw `schema.json` (staging-first, skillDir fallback) for editing.
- **`putSchema`** — validates against `CollectionSchemaZ`, writes the canonical `data/skills/<slug>/schema.json`, then explicitly mirrors to `.claude/skills/` (an internal write skips the skill-bridge hook). Edit-only: refuses unknown slugs, user-scope/feed collections, and `mc-*` presets; rejections name the failing field path and point back at `schemaDocs`.

Creating a new collection is **unchanged** (still the Write-under-`data/skills/` flow).

The companion docs commit closes the edit-time pointer gap: the `collection-skills.md` reference and the SKILL.md template now steer structure edits to these actions instead of leaving "raw Read/Write/Edit" as the path for the schema.

## Verified

- Unit tests for all three actions (schemaDocs fallback/override, getSchema round-trip, putSchema valid/invalid/scope-gates).
- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` all green.
- Confirmed working end-to-end in a live instance: agent called `getSchema` + `schemaDocs` → `putSchema` (`{written:true}`) → `presentCollection` to add a rating field to the `recipes` collection.

## Follow-ups (out of scope)

- Optional `$comment` pointer baked into generated `schema.json`, made a first-class preserved field on `CollectionSchemaZ`, naming `schemaDocs`.
- Collapsing the 8 hardcoded locale launcher strings + role queries onto `schemaDocs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route collection schema authoring through the manageCollection tool by adding schema-focused actions, validation, and docs updates.

New Features:
- Expose schemaDocs, getSchema, and putSchema actions on manageCollection to read authoring docs, fetch existing schema.json, and validate-then-write updated schemas.

Enhancements:
- Extend manageCollection dependencies to support workspace resolution and optional post-schema-write refresh, with safe handling of unknown collections and read-only scopes.
- Improve manageCollection prompt and input schema to guide agents toward schemaDocs/getSchema/putSchema for structural changes instead of raw file I/O.

Documentation:
- Update collection authoring docs and SKILL.md guidance to recommend manageCollection schemaDocs/getSchema/putSchema for editing existing schemas and explain why raw schema.json edits are discouraged.

Tests:
- Add unit tests covering schemaDocs resolution precedence, getSchema behavior for existing and unknown collections, and putSchema validation, mirroring, and scope restrictions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collection-schema authoring/editing to the collection management toolchain, including schema docs lookup, schema retrieval, and fully validated schema publishing.

* **Bug Fixes**
  * Strengthened schema safety checks for `primaryKey` (including singleton), workspace-safe data paths, and ingest requirements.
  * Improved record-id validation for item operations and reduced unnecessary reconcile warnings for empty vs unparseable dates.

* **Documentation**
  * Updated the collection maintenance guide with a safe, step-by-step workflow for changing an existing collection’s schema.

* **Tests**
  * Expanded MCP and end-to-end tests for schema docs, get/update schema flows, and validation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->