### PR TITLE
feat(collections): field-driven spawn interval (every.fromField + map)

### DIFF
--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Schema-driven Collections plugin (presentCollection) — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal. This entry is the isomorphic collection engine (derive / formula / visibility); Vue surfaces land in ./vue.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/collection-plugin/src/core/schema.ts
+++ b/packages/plugins/collection-plugin/src/core/schema.ts
@@ -95,6 +95,32 @@ export interface CollectionEvery {
   dayOfMonth?: number | "last";
 }
 
+/** Field-driven recurrence: the advance interval is selected PER RECORD by
+ *  the value of an `enum` field (`fromField`), looked up in `map`. Lets one
+ *  collection mix daily / weekly / monthly obligations in a single list — the
+ *  host reads `record[fromField]`, finds the matching `CollectionEvery`, and
+ *  advances by it. `fromField` must point at a top-level `enum` field whose
+ *  `values` the `map` keys exactly cover (validated at discovery), and must
+ *  itself be carried/`set` onto the successor so the chain keeps recurring. */
+export interface CollectionEveryFieldDriven {
+  /** Top-level `enum` field whose value selects the interval. */
+  fromField: string;
+  /** Interval per enum value. Keys exactly cover `fromField`'s `values`;
+   *  each value is a literal {@link CollectionEvery}. */
+  map: Record<string, CollectionEvery>;
+}
+
+/** The `every` of a `spawn`: either a single literal interval applied to
+ *  every record, or a per-record interval selected by an `enum` field. The
+ *  literal arm is what `advanceTriggerDate` consumes — the field-driven arm
+ *  is resolved down to one of its `map` values before the date math runs. */
+export type CollectionSpawnEvery = CollectionEvery | CollectionEveryFieldDriven;
+
+/** Narrowing guard: true when `every` is the field-driven arm. */
+export function isFieldDrivenEvery(every: CollectionSpawnEvery): every is CollectionEveryFieldDriven {
+  return "fromField" in every;
+}
+
 /** Host-driven recurrence: when a record satisfies `when`, the host
  *  creates the next record with a forward-advanced `triggerField` date.
  *  The successor's id and contents are a pure function of (source
@@ -106,8 +132,9 @@ export interface CollectionSpawn {
    *  "`completionField` value ∈ `completionDoneValues`" (i.e. spawn the
    *  next instance when this one is done). */
   when?: CollectionWhen;
-  /** How to advance `triggerField` from the source to the successor. */
-  every: CollectionEvery;
+  /** How to advance `triggerField` from the source to the successor —
+   *  either a single literal interval or a per-record, field-driven map. */
+  every: CollectionSpawnEvery;
   /** Record fields copied verbatim onto the successor. Fields not listed
    *  here, not in `set`, and not the trigger / primary keys start
    *  blank. */

--- a/packages/plugins/collection-plugin/src/server/discovery.ts
+++ b/packages/plugins/collection-plugin/src/server/discovery.ts
@@ -375,11 +375,22 @@ function fieldDrivenMapCoversValues(schema: FieldDrivenSchemaView): boolean {
 // resolve an interval, silently halting the recurrence. Hard error, not a warn
 // (see plan §6) — authoring a field-driven spawn without propagating its driver
 // is almost always a mistake.
+//
+// `set` writes a FIXED value, so it must itself be a key of `map` (else the
+// successor is born with an unresolvable driver and `resolveEvery` skips it —
+// the exact silent-halt §4.5 exists to prevent). `carry` copies the source's
+// own value, which — for a record that matched the spawn — is one of the
+// enum's values, all of which `map` covers by §4.2; so a carried driver is
+// always resolvable and needs no value check here.
 function fieldDrivenFromFieldCarried(schema: FieldDrivenSchemaView): boolean {
   const driven = fieldDrivenSpawnEvery(schema);
   if (!driven) return true;
   const { carry, set } = schema.spawn ?? {};
-  if (set && Object.prototype.hasOwnProperty.call(set, driven.fromField)) return true;
+  if (set && Object.prototype.hasOwnProperty.call(set, driven.fromField)) {
+    const raw = set[driven.fromField];
+    if (raw === undefined || raw === null || raw === "") return false;
+    return Object.prototype.hasOwnProperty.call(driven.map, String(raw));
+  }
   return (carry ?? []).includes(driven.fromField);
 }
 
@@ -598,7 +609,8 @@ export const CollectionSchemaZ = z
   // onto the successor, or the next spawn in the chain can't resolve an
   // interval and the recurrence silently halts.
   .refine((schema) => fieldDrivenFromFieldCarried(schema), {
-    message: "`spawn.every.fromField` must appear in `spawn.carry` (or be written by `spawn.set`) so the successor keeps its recurrence interval",
+    message:
+      "`spawn.every.fromField` must appear in `spawn.carry`, or be written by `spawn.set` to a value present in `spawn.every.map`, so the successor keeps a resolvable recurrence interval",
     path: ["spawn"],
   })
   // `calendarField` must name a real `date`/`datetime` field — the calendar

--- a/packages/plugins/collection-plugin/src/server/discovery.ts
+++ b/packages/plugins/collection-plugin/src/server/discovery.ts
@@ -9,11 +9,11 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import { log, getWorkspaceRoot, userSkillsDir, projectSkillsDir, feedsRoot } from "./host";
-import { INGEST_KINDS, FEED_SCHEDULES } from "../core/schema";
+import { INGEST_KINDS, FEED_SCHEDULES, isFieldDrivenEvery } from "../core/schema";
 import { SCHEMA_FILE, resolveDataDir, safeRecordId, safeSlugName } from "./paths";
 import type { LoadedCollection } from "./discoveredCollection";
 import { isSafeActionTemplatePath, isSafeCustomViewPath } from "./templatePath";
-import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
+import type { CollectionDetail, CollectionEveryFieldDriven, CollectionSchema, CollectionSource, CollectionSpawnEvery, CollectionSummary } from "../core/schema";
 
 // Cross-field refines, factored out so they can apply at both the
 // top-level FieldSpec and the table-row SubFieldSpec without prose
@@ -226,11 +226,32 @@ const CustomViewSchema = z.object({
 // Recurrence advance for `spawn.every`. `interval` is a positive integer
 // count of `unit`s; `dayOfMonth` (month/year only) is the canonical
 // day-of-month anchor (1-31) or the `"last"` sentinel for end-of-month.
-const EverySchema = z.object({
-  unit: z.enum(["day", "week", "month", "year"]),
-  interval: z.number().int().min(1),
-  dayOfMonth: z.union([z.number().int().min(1).max(31), z.literal("last")]).optional(),
-});
+// `.strict()` so the union below cleanly rejects an object carrying BOTH
+// `unit` and `fromField` (it fails this arm on the unknown `fromField`).
+const EveryLiteralSchema = z
+  .object({
+    unit: z.enum(["day", "week", "month", "year"]),
+    interval: z.number().int().min(1),
+    dayOfMonth: z.union([z.number().int().min(1).max(31), z.literal("last")]).optional(),
+  })
+  .strict();
+
+// Field-driven recurrence: pick the interval per-record by an `enum` field's
+// value. `map` keys are validated to exactly cover that field's `values` by a
+// `CollectionSchemaZ` refine (which can see the sibling `fields`); here each
+// map value just has to be a well-formed literal `every`. `.strict()` mirrors
+// the literal arm so a both-keys object fails this arm too.
+const EveryFieldDrivenSchema = z
+  .object({
+    fromField: z.string().trim().min(1),
+    map: z.record(z.string(), EveryLiteralSchema),
+  })
+  .strict();
+
+// Either a single literal interval (today's behaviour, byte-identical) or the
+// field-driven map. Two `.strict()` arms mean "both keys" and "neither key"
+// both fail validation, with no extra refine.
+const EverySchema = z.union([EveryLiteralSchema, EveryFieldDrivenSchema]);
 
 // Host-driven recurrence. `when` defaults to the completion-done
 // condition; `every` is required; `carry`/`set` shape the successor.
@@ -305,6 +326,61 @@ function spawnSuccessorStartsInert(schema: {
     return !values.includes(String(spawn.set[field])); // `set` wins over `carry`
   }
   return !(spawn.carry ?? []).includes(field); // carried ⇒ inherits the matching value
+}
+
+// The slice of a parsed schema the field-driven `spawn.every` refines read.
+interface FieldDrivenSchemaView {
+  fields: Record<string, { type: string; values?: readonly string[] }>;
+  spawn?: {
+    every?: CollectionSpawnEvery;
+    carry?: readonly string[];
+    set?: Record<string, unknown>;
+  };
+}
+
+// Resolve the field-driven arm of `spawn.every`, or null when spawn is absent
+// or its `every` is the literal arm. Lets each refine below short-circuit
+// (return valid) without re-checking the discriminant.
+function fieldDrivenSpawnEvery(schema: FieldDrivenSchemaView): CollectionEveryFieldDriven | null {
+  const every = schema.spawn?.every;
+  if (!every || !isFieldDrivenEvery(every)) return null;
+  return every;
+}
+
+// §4.1 — `fromField` must name a real top-level `enum` field. The `map` keys
+// are only meaningful against a closed value set, and the field renders as a
+// form `<select>`; a non-enum target has no finite values to validate against.
+function fieldDrivenFromFieldIsEnum(schema: FieldDrivenSchemaView): boolean {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  return schema.fields[driven.fromField]?.type === "enum";
+}
+
+// §4.2 — `map` keys must EXACTLY cover the enum's `values` (no missing keys —
+// a record could pick an unmapped frequency and silently stall; no extra keys
+// — a stale map outliving an enum edit). Mirrors `everyToggleProjectsValidEnum`'s
+// "author values ⊆ enum's closed set" shape, tightened to set equality.
+function fieldDrivenMapCoversValues(schema: FieldDrivenSchemaView): boolean {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  const target = schema.fields[driven.fromField];
+  if (!target || target.type !== "enum" || target.values === undefined) return true; // §4.1 reports the type error
+  const values = new Set(target.values);
+  const keys = Object.keys(driven.map);
+  return keys.length === values.size && keys.every((key) => values.has(key));
+}
+
+// §4.5 — `fromField` must reach the successor (via `carry` or `set`); otherwise
+// the successor loses its frequency and the NEXT spawn along the chain can't
+// resolve an interval, silently halting the recurrence. Hard error, not a warn
+// (see plan §6) — authoring a field-driven spawn without propagating its driver
+// is almost always a mistake.
+function fieldDrivenFromFieldCarried(schema: FieldDrivenSchemaView): boolean {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  const { carry, set } = schema.spawn ?? {};
+  if (set && Object.prototype.hasOwnProperty.call(set, driven.fromField)) return true;
+  return (carry ?? []).includes(driven.fromField);
 }
 
 // Declarative retrieval config for a Feed (a collection that refills
@@ -502,6 +578,27 @@ export const CollectionSchemaZ = z
   .refine((schema) => spawnSuccessorStartsInert(schema), {
     message:
       "`spawn` must leave the successor in a non-matching state (e.g. `set` the status to a pending value); seeding the predicate field to a matching value via `set`/`carry` would respawn forever",
+    path: ["spawn"],
+  })
+  // Field-driven `spawn.every` (§4.1): `fromField` must name a top-level
+  // `enum` — the only field type with a closed, finite value set to drive
+  // the `map` and the form `<select>`.
+  .refine((schema) => fieldDrivenFromFieldIsEnum(schema), {
+    message: "`spawn.every.fromField` must name a top-level `enum` field declared in `fields`",
+    path: ["spawn"],
+  })
+  // Field-driven `spawn.every` (§4.2): the `map` keys must exactly cover the
+  // enum's `values` — a missing key would stall a record at that frequency;
+  // an extra key signals a map left stale after an enum edit.
+  .refine((schema) => fieldDrivenMapCoversValues(schema), {
+    message: "`spawn.every.map` keys must exactly cover the `values` of the `enum` named by `fromField` (no missing or extra keys)",
+    path: ["spawn"],
+  })
+  // Field-driven `spawn.every` (§4.5): `fromField` must be carried (or `set`)
+  // onto the successor, or the next spawn in the chain can't resolve an
+  // interval and the recurrence silently halts.
+  .refine((schema) => fieldDrivenFromFieldCarried(schema), {
+    message: "`spawn.every.fromField` must appear in `spawn.carry` (or be written by `spawn.set`) so the successor keeps its recurrence interval",
     path: ["spawn"],
   })
   // `calendarField` must name a real `date`/`datetime` field — the calendar

--- a/packages/plugins/collection-plugin/src/server/spawn.ts
+++ b/packages/plugins/collection-plugin/src/server/spawn.ts
@@ -23,7 +23,8 @@
 import { log } from "./host";
 import { errorMessage, ONE_DAY_MS } from "./util";
 import { writeItem, type IoOptions } from "./io";
-import type { CollectionEvery, CollectionItem, CollectionSchema, CollectionWhen } from "../core/schema";
+import { isFieldDrivenEvery } from "../core/schema";
+import type { CollectionEvery, CollectionItem, CollectionSchema, CollectionSpawnEvery, CollectionWhen } from "../core/schema";
 
 /** A timezone-free calendar date. `m` is 1-12. */
 export interface CivilDate {
@@ -139,6 +140,19 @@ function matchesWhen(when: CollectionWhen | undefined, schema: CollectionSchema,
   return raw !== undefined && raw !== null && completionDoneValues.includes(String(raw));
 }
 
+/** Resolve the literal `every` that applies to `sourceItem`. Literal-arm
+ *  `spawn.every` passes through unchanged. Field-driven `spawn.every` reads
+ *  `sourceItem[fromField]` and looks it up in `map`; an empty field or a
+ *  value with no map entry yields null (caller skips + logs — see plan §5).
+ *  Discovery rejects a map that doesn't cover the enum's values, so null
+ *  here means a record that predates a map/enum edit. */
+export function resolveEvery(every: CollectionSpawnEvery, sourceItem: CollectionItem): CollectionEvery | null {
+  if (!isFieldDrivenEvery(every)) return every;
+  const raw = sourceItem[every.fromField];
+  if (raw === undefined || raw === null || raw === "") return null;
+  return every.map[String(raw)] ?? null;
+}
+
 export interface ComputedSuccessor {
   id: string;
   record: CollectionItem;
@@ -152,7 +166,9 @@ export function computeSuccessor(schema: CollectionSchema, sourceItem: Collectio
   if (!spawn || !triggerField) return null;
   const srcDate = parseCivil(sourceItem[triggerField]);
   if (srcDate === null) return null;
-  const next = advanceTriggerDate(srcDate, spawn.every);
+  const every = resolveEvery(spawn.every, sourceItem);
+  if (every === null) return null;
+  const next = advanceTriggerDate(srcDate, every);
   const nextId = successorId(sourceId, next);
   const record: CollectionItem = {};
   for (const field of spawn.carry ?? []) {
@@ -162,6 +178,24 @@ export function computeSuccessor(schema: CollectionSchema, sourceItem: Collectio
   record[triggerField] = formatCivil(next);
   record[schema.primaryKey] = nextId;
   return { id: nextId, record };
+}
+
+/** Warn precisely about which of `computeSuccessor`'s two null causes fired
+ *  (plan §5): an unparseable source trigger date (the original cause), or a
+ *  field-driven `every` whose record value has no `map` entry (a record that
+ *  predates a map/enum edit — discovery rejects this statically otherwise). */
+function logSpawnSkip(slug: string, triggerField: string, every: CollectionSpawnEvery, sourceItem: CollectionItem, sourceId: string): void {
+  if (parseCivil(sourceItem[triggerField]) === null) {
+    log.warn("collections", "spawn skipped: source trigger date unparseable", { slug, sourceId, triggerField });
+    return;
+  }
+  const fromField = isFieldDrivenEvery(every) ? every.fromField : undefined;
+  log.warn("collections", "spawn skipped: no `every` mapping for frequency value", {
+    slug,
+    sourceId,
+    fromField,
+    value: fromField === undefined ? undefined : sourceItem[fromField],
+  });
 }
 
 /** Idempotently create the successor for `sourceItem` when it matches the
@@ -182,7 +216,7 @@ export async function maybeSpawnSuccessor(
   if (!matchesWhen(spawn.when, schema, sourceItem)) return;
   const computed = computeSuccessor(schema, sourceItem, sourceId);
   if (computed === null) {
-    log.warn("collections", "spawn skipped: source trigger date unparseable", { slug, sourceId, triggerField: schema.triggerField });
+    logSpawnSkip(slug, schema.triggerField, spawn.every, sourceItem, sourceId);
     return;
   }
   // Runaway guard: a successor born already matching its own `when` would

--- a/packages/services/workspace-setup/assets/helps/collection-skills.md
+++ b/packages/services/workspace-setup/assets/helps/collection-skills.md
@@ -489,6 +489,30 @@ month's rent `paid`, and next month's pending record appears on its own.
     short months don't cause drift — "31st of every month" yields
     31 → 28/29 → 31 → 30 … correctly. Omit it for days ≤ 28 and the source
     date's day is preserved.
+  - **Field-driven interval** (one list, mixed cadences): instead of a single
+    `{ unit, interval }`, `every` may select the interval **per record** from
+    an `enum` field. Use `{ "fromField": "<enum field>", "map": { <value>:
+    { unit, interval, … } } }` — the host reads the record's value and
+    advances by the matching entry. This lets one collection carry daily,
+    weekly, and monthly obligations together:
+
+    ```json
+    "every": {
+      "fromField": "frequency",
+      "map": {
+        "daily":   { "unit": "day",   "interval": 1 },
+        "weekly":  { "unit": "week",  "interval": 1 },
+        "monthly": { "unit": "month", "interval": 1, "dayOfMonth": 1 }
+      }
+    }
+    ```
+
+    Rules (all enforced at write time): `fromField` must name a top-level
+    `enum` field; the `map` keys must **exactly cover** that enum's `values`
+    (no missing or extra keys); and `fromField` must be in `carry` (or written
+    by `set`) so the successor keeps its frequency and the chain keeps
+    recurring. Each `map` value is a literal `every` (same `unit` / `interval`
+    / `dayOfMonth` rules as above).
 - **`carry`** — record fields copied verbatim onto the successor (must name
   real fields). Fields not in `carry` / `set` / the trigger+primary keys start
   blank.

--- a/packages/services/workspace-setup/package.json
+++ b/packages/services/workspace-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/workspace-setup",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Workspace bootstrap for MulmoClaude and MulmoTerminal — seeds the bundled help docs + preset skills into a workspace so a fresh workspace created by either app is set up identically. Server-only (`.`); browser-safe isPresetSlug at `./slug`. ESM-only (assets resolve via import.meta.url).",
   "type": "module",
   "main": "./dist/index.js",

--- a/plans/feat-collections-field-driven-spawn.md
+++ b/plans/feat-collections-field-driven-spawn.md
@@ -1,0 +1,298 @@
+# Plan: field-driven `spawn` interval — `every.fromField` + interval map
+
+Follow-up to the time-driven collections work
+(`feat-collections-time-trigger.md`). That line shipped `triggerField`
+(per-record time gate) and `spawn` (host-driven succession). This plan adds
+**one composable extension**: let a single collection carry records that
+recur at *different* intervals (daily / weekly / monthly), driven
+declaratively by an `enum` field on each record.
+
+## Hard constraint: zero domain-specific host code
+
+Same discipline as every collections primitive. The host learns one new
+generic concept — "the recurrence interval may be selected per-record by an
+`enum` field's value, via a declared map" — and holds no frequency / rent /
+bill / domain literals. All meaning lives in `schema.json` and the records.
+
+---
+
+## 1. Problem
+
+Today `spawn.every` is a **single literal** in `schema.json`, applied
+uniformly to every record in the collection:
+
+```json
+"every": { "unit": "month", "interval": 1, "dayOfMonth": 1 }
+```
+
+A collection that mixes daily, weekly, and monthly obligations cannot be
+served by any single `every`: whichever cadence you pick breaks the others.
+Adding a `frequency` column to records does not help, because `spawn` has no
+way to read it and vary the interval.
+
+The two existing workarounds each give up one half of the goal:
+
+- **A — scheduler + agent:** a daily job reads `frequency` and creates the
+  next record in agent logic. Keeps one list, but is *not* host-native.
+- **B — three collections, one cadence each:** each uses the existing
+  literal `spawn`. Fully host-native, but the list is split in three.
+
+"One list" and "fully host-native automation" cannot coexist today. This
+plan removes that constraint.
+
+---
+
+## 2. Proposal: `every` becomes a discriminated union
+
+Extend `every` from a fixed literal to **either** the existing literal form
+**or** a field-driven form (`fromField` + `map`).
+
+```json
+"triggerField": "nextDue",
+"spawn": {
+  "when": { "field": "status", "in": ["paid"] },
+  "every": {
+    "fromField": "frequency",
+    "map": {
+      "daily":   { "unit": "day",   "interval": 1 },
+      "weekly":  { "unit": "week",  "interval": 1 },
+      "monthly": { "unit": "month", "interval": 1, "dayOfMonth": 1 }
+    }
+  },
+  "carry": ["name", "amount", "payee", "method", "frequency"],
+  "set": { "status": "unpaid" }
+}
+```
+
+**Semantics:** when `spawn` fires, the host reads the source record's
+`fromField` value, looks up the matching `{ unit, interval, ... }` in `map`,
+and advances `triggerField` by that interval. Different records advance by
+different intervals.
+
+This rides the existing date math unchanged. `advanceTriggerDate(source,
+every)` in
+`packages/plugins/collection-plugin/src/server/spawn.ts:87-99` already takes
+`every` as an argument — the only change is *which* `every` we resolve before
+calling it. Month-end clamping (`Math.min(anchor, dim)`) and
+`dayOfMonth: "last"` are untouched.
+
+### Why `enum`-only
+
+`fromField` must point at an `enum`-typed field. The value set is then
+closed and finite, the `map` can be validated for exhaustive coverage at
+discovery time, and the field maps cleanly to the form `<select>`.
+
+---
+
+## 3. Backward compatibility
+
+- `every` with `unit` → **literal mode** (today's behaviour, byte-identical).
+- `every` with `fromField` → **field-driven mode**.
+- Both, or neither → validation error.
+- Existing schemas are unchanged at the JSON level and entirely unaffected.
+
+### Zod shape — `z.union`, not `z.discriminatedUnion`
+
+The two arms share **no common literal discriminant key** (`unit` vs
+`fromField`), so `z.discriminatedUnion` does not apply. Implement
+`EverySchema` (`discovery.ts:229-233`) as
+`z.union([EveryLiteralSchema, EveryFieldDrivenSchema])` where **both arms
+are `.strict()`**. This makes the "both, or neither → error" rule fall out
+for free: an object carrying both `unit` and `fromField` fails the literal
+arm (unknown `fromField`) *and* the field-driven arm (unknown `unit`); an
+empty object fails both (each requires its discriminating key). No extra
+refine needed for §3's mutual exclusion.
+
+### Type model — keep `CollectionEvery` literal; widen only `spawn.every`
+
+Do **not** widen `CollectionEvery`
+(`packages/plugins/collection-plugin/src/core/schema.ts:83-96`) into the
+union. `advanceTriggerDate` (`spawn.ts:87-99`) destructures `every.unit` and
+`every.dayOfMonth`, which exist only on the literal arm — widening that type
+breaks its signature and forces casts. Instead:
+
+- `CollectionEvery` stays the **literal** shape (unchanged) — still what
+  `advanceTriggerDate` takes.
+- Add `CollectionEveryFieldDriven` (`{ fromField: string; map: Record<string,
+  CollectionEvery> }`).
+- `CollectionSpawn.every`
+  (`schema.ts:110`) widens to `CollectionEvery | CollectionEveryFieldDriven`.
+
+So `advanceTriggerDate` is **literally untouched** — the per-record
+resolution narrows to a `CollectionEvery` before calling it.
+
+---
+
+## 4. Discovery-time validation (new refines)
+
+Added alongside the existing `spawn` refines in `CollectionSchemaZ`
+(`discovery.ts:480-506`, next to the `spawn.carry` check and
+`spawnSuccessorStartsInert`):
+
+1. `fromField` names a real **top-level** field **and** that field is
+   `type: "enum"` (same `schema.fields[...]` discipline as `triggerField` /
+   `when.field`).
+2. `map`'s key set **exactly covers** `fromField`'s `values` (no missing
+   keys, no extra keys). **Precedent to follow:** toggle-field validation
+   already checks author values against an enum's closed `values` set —
+   `collectToggleFieldRefs` (`discovery.ts:274-282`) + its refine
+   (`discovery.ts:553-556`). Mirror that shape (`new Set(field.values)` vs
+   `Object.keys(map)`) rather than inventing a new idiom.
+3. Each map value satisfies the existing `every` constraints — **reuse
+   `EveryLiteralSchema` as the per-map-value type** (`unit ∈ {day, week,
+   month, year}`, `interval ≥ 1`, `dayOfMonth` only on month/year, `1–31` or
+   `"last"`), so the constraint is defined once and the field-driven arm is
+   literally `z.record(z.string(), EveryLiteralSchema)`. Checks 2 and 3
+   (coverage + per-value shape) are then split: shape is enforced by the arm
+   itself in Zod; coverage is a `CollectionSchemaZ` refine (it needs the
+   sibling `fields[fromField].values`, which the `every` arm can't see).
+4. `spawn` still requires `triggerField` (unchanged).
+5. **`fromField` MUST appear in `carry` (or be written by `set`)** — a hard
+   error, not a warning. If the successor loses its frequency, the next
+   `spawn` along the chain silently halts, which defeats the whole point of
+   "fully automatic". Reject the schema rather than warn. (See §6.)
+
+These checks are unaffected by — and do not affect — the existing
+`spawnSuccessorStartsInert` guard (`spawn.ts:294-308`) or the runtime
+runaway guard (`maybeSpawnSuccessor`, `spawn.ts:193-200`), because both
+operate on `when` / `set` / `carry`, never on `every`. This is a key
+"nothing else breaks" property and should be asserted in tests.
+
+### Host-side gate mirror — expected to be a no-op here
+
+All five checks (§4.1–4.5) are **schema-internal** — they read only
+`schema.fields`, `spawn.every`, `spawn.carry`, and `spawn.set`, never the
+filesystem or cross-package state. So all five are **Zod refines inside
+`CollectionSchemaZ`** (or, for §4.3, the `every` arm itself). That object is
+the *same* one `handlePutSchema` already runs via
+`CollectionSchemaZ.safeParse` (`manageCollection.ts:379`), so the refines
+fire host-side automatically.
+
+`schemaDiscoveryGate` (`manageCollection.ts:358-364`) exists only for the
+handful of gates Zod **cannot** express — filesystem `dataPath` resolution
+and `primary: true`. Nothing in §4 fits that category, so **`manageCollection.ts`
+needs no change**. The gate-drift warning ("keep putSchema gates host-side")
+stays relevant only as a guardrail: *if* a future check ever needs
+out-of-Zod state, it MUST be added to both discovery and `schemaDiscoveryGate`.
+That is not the case for any check in this plan.
+
+---
+
+## 5. Runtime changes
+
+Single touch point: `computeSuccessor`
+(`packages/plugins/collection-plugin/src/server/spawn.ts:150-165`).
+
+Resolve the effective `every` per-record before advancing:
+
+- If `spawn.every` is literal → use it as today.
+- If field-driven → read `sourceItem[spawn.every.fromField]`, look up the
+  map. On a **missing/unknown value** or **empty field**, return `null`
+  (caller does not write) — consistent with the existing "source trigger
+  date unparseable → skip + log" path in `maybeSpawnSuccessor`
+  (`spawn.ts:172-212`). This is the runtime backstop for the case where an
+  `enum` gained a value but the `map` was not updated (discovery would
+  normally reject that, but a record could predate the map update).
+
+**Distinct skip message (required).** `computeSuccessor` returning `null`
+today means exactly one thing — the source trigger date is unparseable — and
+the caller hardcodes that wording (`spawn.ts:185`: *"spawn skipped: source
+trigger date unparseable"*). Field-driven resolution adds a **second** null
+cause; emitting the date-unparseable message for an unknown-frequency skip
+would be actively misleading in logs. Pin the requirement: the two skip
+reasons MUST log distinctly (e.g. *"spawn skipped: no `every` mapping for
+frequency value '<v>'"*). Suggested mechanics — keep `computeSuccessor` pure
+(still returns `null`), and have `maybeSpawnSuccessor` distinguish by which
+precondition failed: if `parseCivil(sourceItem[triggerField])` is null →
+date message; otherwise → frequency message. Re-parsing the date in the
+caller is cheap and avoids threading a tagged reason through the return type.
+Implementation is free to choose a tagged return instead, but the two
+messages must not collide.
+
+No change to `successorId`, the reconciler tick
+(`packages/services/collection-watchers/src/reconciler.ts:225-276`), or the
+watcher cadence.
+
+---
+
+## 6. `fromField` carry: hard error vs auto-carry
+
+Two ways to guarantee the successor keeps its frequency:
+
+- **Hard error (recommended):** discovery rejects a field-driven `spawn`
+  whose `fromField` is absent from both `carry` and `set` keys. Explicit,
+  matches the project's "fail loud, never silently stop" posture, easy to
+  add to the existing carry refine.
+- **Auto-carry:** the host implicitly appends `fromField` to `carry`.
+  Friendlier but adds implicit behaviour.
+
+Decision: **hard error.** Authoring a field-driven spawn without carrying
+the driver is almost always a mistake, and the error message can point
+straight at the fix.
+
+---
+
+## 7. Deferred: `triggerLeadDays` field-driven (separate phase)
+
+A natural follow-on is per-frequency notification lead time (daily → 0 days,
+monthly → 10 days). It is **deliberately out of scope here** because of a
+design gap that must be resolved first:
+
+`triggerField` / `triggerLeadDays` live at **schema top level** and gate
+notifications even when `spawn` is absent (`reconciler.ts:256-267`), whereas
+`fromField` lives **inside `spawn.every`**. A field-driven
+`triggerLeadDaysMap` therefore cannot implicitly borrow
+`spawn.every.fromField` — it needs **its own** `fromField` declaration so it
+works on trigger-only collections and can key off a different column than
+spawn. Shape (later):
+
+```json
+"triggerLeadDays": {
+  "fromField": "frequency",
+  "map": { "daily": 0, "weekly": 1, "monthly": 10 }
+}
+```
+
+with: key set covers the field's `values`; each value a non-negative
+integer; mutually exclusive with the single-value `triggerLeadDays`. Ship
+the interval-driven `spawn` first, observe usage, then add this.
+
+---
+
+## 8. Edge cases
+
+| Case | Behaviour |
+| --- | --- |
+| Month-end (`dayOfMonth: "last"` / `31`) | Reuse existing canonical clamp (`advanceTriggerDate`, `Math.min(anchor, dim)`) — no change. |
+| Map missing a value (enum extended, map not updated) | Discovery rejects (§4.2). Runtime backstop for pre-existing records: skip + log (§5). |
+| Empty `fromField` on a record | Skip + log. |
+| Literal `every` (no `fromField`) | Fully unchanged behaviour. |
+| `fromField` not carried | Discovery rejects (§4.5 / §6). |
+
+---
+
+## 9. Files touched
+
+| File | Change |
+| --- | --- |
+| `packages/plugins/collection-plugin/src/core/schema.ts` | `CollectionEvery` stays literal (untouched); add `CollectionEveryFieldDriven`; widen `CollectionSpawn.every` to the union. |
+| `packages/plugins/collection-plugin/src/server/discovery.ts` | `EverySchema` → `z.union` of two `.strict()` arms (literal + field-driven); new `CollectionSchemaZ` refines (§4.1, §4.2, §4.5). |
+| `packages/plugins/collection-plugin/src/server/spawn.ts` | `computeSuccessor` narrows the union to a literal `every` per-record before `advanceTriggerDate`; **distinct** skip-log for unknown/empty frequency vs unparseable date (§5). |
+| `server/agent/mcp-tools/manageCollection.ts` | **No change expected** — every §4 check is a Zod refine, run host-side via the existing `CollectionSchemaZ.safeParse`. Listed only as the place to add a host gate *if* a future check ever needs out-of-Zod state. |
+| `docs/` (collection schema reference / `schemaDocs`) | Document field-driven `every`. |
+| tests | Date-advance per frequency; discovery accept/reject (coverage, enum-type, carry rule); runtime skip+log; assert `spawnSuccessorStartsInert` + runaway guard still hold under field-driven mode. |
+
+---
+
+## 10. Scope decision
+
+- **§2–§6 (interval-driven `spawn`): Go.** Condition: §4.5/§6 carry rule as
+  a hard error. (The host-gate-mirror condition is resolved up front — all
+  §4 checks are Zod refines, so no host-side gate is added; see §4.)
+- **§7 (`triggerLeadDays` field-driven): deferred** to a later phase, after
+  the independent `fromField` design above is settled.
+
+The result: a single list manages daily / weekly / monthly obligations, and
+the moment a record is marked done the next one is generated **fully
+host-native** — while the value set stays closed (enum) so validation is
+tractable and the UI dropdown maps directly.

--- a/plans/feat-collections-field-driven-spawn.md
+++ b/plans/feat-collections-field-driven-spawn.md
@@ -9,7 +9,7 @@ declaratively by an `enum` field on each record.
 
 ## Hard constraint: zero domain-specific host code
 
-Same discipline as every collections primitive. The host learns one new
+Same discipline as every collection primitive. The host learns one new
 generic concept — "the recurrence interval may be selected per-record by an
 `enum` field's value, via a declared map" — and holds no frequency / rent /
 bill / domain literals. All meaning lives in `schema.json` and the records.
@@ -151,6 +151,14 @@ Added alongside the existing `spawn` refines in `CollectionSchemaZ`
    error, not a warning. If the successor loses its frequency, the next
    `spawn` along the chain silently halts, which defeats the whole point of
    "fully automatic". Reject the schema rather than warn. (See §6.)
+   When satisfied via `set`, the written value must itself be a **key of
+   `map`** (and non-empty): `set` writes a fixed value, so an unmapped one
+   (`set: { frequency: "yearly" }`) would birth the successor with an
+   unresolvable driver — `resolveEvery` returns null on its next completion
+   and the chain halts, the exact failure this rule prevents. A `carry`ed
+   driver needs no value check: it copies the source's own value, which —
+   for a record that matched the spawn — is one of the enum's values, all of
+   which `map` covers by §4.2, so it is always resolvable.
 
 These checks are unaffected by — and do not affect — the existing
 `spawnSuccessorStartsInert` guard (`spawn.ts:294-308`) or the runtime

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -14908,7 +14908,11 @@ function fieldDrivenFromFieldCarried(schema) {
   const driven = fieldDrivenSpawnEvery(schema);
   if (!driven) return true;
   const { carry, set: set2 } = schema.spawn ?? {};
-  if (set2 && Object.prototype.hasOwnProperty.call(set2, driven.fromField)) return true;
+  if (set2 && Object.prototype.hasOwnProperty.call(set2, driven.fromField)) {
+    const raw = set2[driven.fromField];
+    if (raw === void 0 || raw === null || raw === "") return false;
+    return Object.prototype.hasOwnProperty.call(driven.map, String(raw));
+  }
   return (carry ?? []).includes(driven.fromField);
 }
 var IngestSchemaZ = external_exports.object({
@@ -14994,7 +14998,7 @@ var CollectionSchemaZ = external_exports.object({
   message: "`spawn.every.map` keys must exactly cover the `values` of the `enum` named by `fromField` (no missing or extra keys)",
   path: ["spawn"]
 }).refine((schema) => fieldDrivenFromFieldCarried(schema), {
-  message: "`spawn.every.fromField` must appear in `spawn.carry` (or be written by `spawn.set`) so the successor keeps its recurrence interval",
+  message: "`spawn.every.fromField` must appear in `spawn.carry`, or be written by `spawn.set` to a value present in `spawn.every.map`, so the successor keeps a resolvable recurrence interval",
   path: ["spawn"]
 }).refine((schema) => schema.calendarField === void 0 || isDateLike(schema.fields[schema.calendarField]?.type), {
   message: "schema `calendarField` must name a top-level `date` or `datetime` field declared in `fields`",

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -135,7 +135,7 @@ async function handleConfigRefresh(payload) {
 import path4 from "node:path";
 import { mkdirSync, readFileSync as readFileSync2, renameSync, rmSync, writeFileSync } from "node:fs";
 
-// packages/plugins/collection-plugin/dist/schema-DyfSfVzh.js
+// packages/plugins/collection-plugin/dist/schema-BcnitlL8.js
 var INGEST_KINDS = [
   "rss",
   "atom",
@@ -147,6 +147,9 @@ var FEED_SCHEDULES = [
   "weekly",
   "on-demand"
 ];
+function isFieldDrivenEvery(every) {
+  return "fromField" in every;
+}
 
 // packages/plugins/collection-plugin/dist/server.js
 import path3 from "node:path";
@@ -14826,7 +14829,7 @@ var CustomViewSchema = external_exports.object({
   file: external_exports.string().trim().min(1).refine(isSafeCustomViewPath, "must be a safe path under `views/` ending in `.html` (e.g. `views/year.html`; no `..`, no leading `/`, no backslash)"),
   capabilities: external_exports.array(external_exports.enum(["read", "write"])).optional()
 });
-var EverySchema = external_exports.object({
+var EveryLiteralSchema = external_exports.object({
   unit: external_exports.enum([
     "day",
     "week",
@@ -14835,7 +14838,12 @@ var EverySchema = external_exports.object({
   ]),
   interval: external_exports.number().int().min(1),
   dayOfMonth: external_exports.union([external_exports.number().int().min(1).max(31), external_exports.literal("last")]).optional()
-});
+}).strict();
+var EveryFieldDrivenSchema = external_exports.object({
+  fromField: external_exports.string().trim().min(1),
+  map: external_exports.record(external_exports.string(), EveryLiteralSchema)
+}).strict();
+var EverySchema = external_exports.union([EveryLiteralSchema, EveryFieldDrivenSchema]);
 var SpawnSchema = external_exports.object({
   when: WhenSchema.optional(),
   every: EverySchema,
@@ -14876,6 +14884,32 @@ function spawnSuccessorStartsInert(schema) {
   if (!field || !values) return true;
   if (spawn.set && Object.prototype.hasOwnProperty.call(spawn.set, field)) return !values.includes(String(spawn.set[field]));
   return !(spawn.carry ?? []).includes(field);
+}
+function fieldDrivenSpawnEvery(schema) {
+  const every = schema.spawn?.every;
+  if (!every || !isFieldDrivenEvery(every)) return null;
+  return every;
+}
+function fieldDrivenFromFieldIsEnum(schema) {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  return schema.fields[driven.fromField]?.type === "enum";
+}
+function fieldDrivenMapCoversValues(schema) {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  const target = schema.fields[driven.fromField];
+  if (!target || target.type !== "enum" || target.values === void 0) return true;
+  const values = new Set(target.values);
+  const keys = Object.keys(driven.map);
+  return keys.length === values.size && keys.every((key) => values.has(key));
+}
+function fieldDrivenFromFieldCarried(schema) {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  const { carry, set: set2 } = schema.spawn ?? {};
+  if (set2 && Object.prototype.hasOwnProperty.call(set2, driven.fromField)) return true;
+  return (carry ?? []).includes(driven.fromField);
 }
 var IngestSchemaZ = external_exports.object({
   kind: external_exports.enum(INGEST_KINDS),
@@ -14952,6 +14986,15 @@ var CollectionSchemaZ = external_exports.object({
   path: ["spawn"]
 }).refine((schema) => spawnSuccessorStartsInert(schema), {
   message: "`spawn` must leave the successor in a non-matching state (e.g. `set` the status to a pending value); seeding the predicate field to a matching value via `set`/`carry` would respawn forever",
+  path: ["spawn"]
+}).refine((schema) => fieldDrivenFromFieldIsEnum(schema), {
+  message: "`spawn.every.fromField` must name a top-level `enum` field declared in `fields`",
+  path: ["spawn"]
+}).refine((schema) => fieldDrivenMapCoversValues(schema), {
+  message: "`spawn.every.map` keys must exactly cover the `values` of the `enum` named by `fromField` (no missing or extra keys)",
+  path: ["spawn"]
+}).refine((schema) => fieldDrivenFromFieldCarried(schema), {
+  message: "`spawn.every.fromField` must appear in `spawn.carry` (or be written by `spawn.set`) so the successor keeps its recurrence interval",
   path: ["spawn"]
 }).refine((schema) => schema.calendarField === void 0 || isDateLike(schema.fields[schema.calendarField]?.type), {
   message: "schema `calendarField` must name a top-level `date` or `datetime` field declared in `fields`",

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -1135,6 +1135,44 @@ describe("discoverCollections — field-driven spawn.every validation", () => {
     assert.equal((await listCollections()).length, 1);
   });
 
+  it("rejects when `set` writes fromField to a value not present in the map", async () => {
+    // `yearly` isn't a map key, so the successor would be born with an
+    // unresolvable driver and the chain would silently halt after one step.
+    writeSkill(
+      "test-freq-set-unmapped",
+      freqSchema(undefined, {
+        spawn: {
+          when: { field: "status", in: ["paid"] },
+          every: {
+            fromField: "frequency",
+            map: { daily: { unit: "day", interval: 1 }, weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1, dayOfMonth: 1 } },
+          },
+          carry: ["amount"],
+          set: { status: "pending", frequency: "yearly" },
+        },
+      }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects when `set` writes fromField to an empty value", async () => {
+    writeSkill(
+      "test-freq-set-empty",
+      freqSchema(undefined, {
+        spawn: {
+          when: { field: "status", in: ["paid"] },
+          every: {
+            fromField: "frequency",
+            map: { daily: { unit: "day", interval: 1 }, weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1, dayOfMonth: 1 } },
+          },
+          carry: ["amount"],
+          set: { status: "pending", frequency: "" },
+        },
+      }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+
   it("rejects an `every` carrying BOTH unit and fromField (strict union)", async () => {
     writeSkill("test-freq-both", freqSchema({ unit: "month", interval: 1, fromField: "frequency", map: { daily: { unit: "day", interval: 1 } } }));
     assert.equal((await listCollections()).length, 0);

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -1026,6 +1026,137 @@ describe("discoverCollections — triggerField + spawn validation", () => {
   });
 });
 
+describe("discoverCollections — field-driven spawn.every validation", () => {
+  // A bills collection whose recurrence interval is chosen per-record by the
+  // `frequency` enum. Base is well-formed (frequency is an enum, the map
+  // covers its values exactly, and frequency is carried onto the successor).
+  function freqSchema(spawnEvery: unknown = undefined, extra: Record<string, unknown> = {}): Record<string, unknown> {
+    const every = spawnEvery ?? {
+      fromField: "frequency",
+      map: {
+        daily: { unit: "day", interval: 1 },
+        weekly: { unit: "week", interval: 1 },
+        monthly: { unit: "month", interval: 1, dayOfMonth: 1 },
+      },
+    };
+    return {
+      title: "Bills",
+      icon: "receipt",
+      dataPath: "data/bills/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        dueOn: { type: "date", label: "Due", required: true },
+        amount: { type: "number", label: "Amount" },
+        frequency: { type: "enum", values: ["daily", "weekly", "monthly"], label: "Frequency", required: true },
+        status: { type: "enum", values: ["pending", "paid"], label: "Status", required: true },
+      },
+      completionField: "status",
+      completionDoneValues: ["paid"],
+      triggerField: "dueOn",
+      spawn: { when: { field: "status", in: ["paid"] }, every, carry: ["amount", "frequency"], set: { status: "pending" } },
+      ...extra,
+    };
+  }
+
+  it("accepts a well-formed field-driven spawn (enum field, exact map, carried)", async () => {
+    writeSkill("test-freq-ok", freqSchema());
+    assert.equal((await listCollections()).length, 1);
+  });
+
+  it("rejects fromField that is not an enum field", async () => {
+    writeSkill("test-freq-non-enum", freqSchema({ fromField: "amount", map: { daily: { unit: "day", interval: 1 } } }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects fromField naming a missing field", async () => {
+    writeSkill("test-freq-missing", freqSchema({ fromField: "ghost", map: { daily: { unit: "day", interval: 1 } } }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a map that misses an enum value", async () => {
+    // `monthly` is a value of `frequency` but absent from the map.
+    writeSkill(
+      "test-freq-missing-key",
+      freqSchema({ fromField: "frequency", map: { daily: { unit: "day", interval: 1 }, weekly: { unit: "week", interval: 1 } } }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a map with an extra key not in the enum", async () => {
+    writeSkill(
+      "test-freq-extra-key",
+      freqSchema({
+        fromField: "frequency",
+        map: {
+          daily: { unit: "day", interval: 1 },
+          weekly: { unit: "week", interval: 1 },
+          monthly: { unit: "month", interval: 1 },
+          yearly: { unit: "year", interval: 1 },
+        },
+      }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects when fromField is not carried (and not set) onto the successor", async () => {
+    writeSkill(
+      "test-freq-not-carried",
+      freqSchema(undefined, {
+        spawn: {
+          when: { field: "status", in: ["paid"] },
+          every: {
+            fromField: "frequency",
+            map: { daily: { unit: "day", interval: 1 }, weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1, dayOfMonth: 1 } },
+          },
+          carry: ["amount"],
+          set: { status: "pending" },
+        },
+      }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("accepts when fromField is written by `set` instead of carried", async () => {
+    writeSkill(
+      "test-freq-set-driver",
+      freqSchema(undefined, {
+        spawn: {
+          when: { field: "status", in: ["paid"] },
+          every: {
+            fromField: "frequency",
+            map: { daily: { unit: "day", interval: 1 }, weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1, dayOfMonth: 1 } },
+          },
+          carry: ["amount"],
+          set: { status: "pending", frequency: "monthly" },
+        },
+      }),
+    );
+    assert.equal((await listCollections()).length, 1);
+  });
+
+  it("rejects an `every` carrying BOTH unit and fromField (strict union)", async () => {
+    writeSkill("test-freq-both", freqSchema({ unit: "month", interval: 1, fromField: "frequency", map: { daily: { unit: "day", interval: 1 } } }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects an `every` carrying NEITHER unit nor fromField (strict union)", async () => {
+    writeSkill("test-freq-neither", freqSchema({ map: { daily: { unit: "day", interval: 1 } } }));
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects a bad interval inside a map value", async () => {
+    writeSkill(
+      "test-freq-bad-map-interval",
+      freqSchema({
+        fromField: "frequency",
+        map: { daily: { unit: "day", interval: 0 }, weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1 } },
+      }),
+    );
+    assert.equal((await listCollections()).length, 0);
+  });
+});
+
 describe("discoverCollections — calendarField + calendarEndField validation", () => {
   // A collection with two date fields, cloned + mutated per case.
   function calendarSchema(extra: Record<string, unknown> = {}): Record<string, unknown> {

--- a/test/workspace/collections/test_spawn.ts
+++ b/test/workspace/collections/test_spawn.ts
@@ -18,12 +18,13 @@ import {
   isTriggerDue,
   maybeSpawnSuccessor,
   parseCivil,
+  resolveEvery,
   successorId,
   type CivilDate,
   readItem,
   writeItem,
 } from "@mulmoclaude/collection-plugin/server";
-import type { CollectionEvery, CollectionSchema } from "../../../server/workspace/collections/types.js";
+import type { CollectionEvery, CollectionSchema, CollectionSpawnEvery } from "../../../server/workspace/collections/types.js";
 
 describe("daysInMonth", () => {
   it("knows month lengths incl. leap years", () => {
@@ -258,5 +259,108 @@ describe("maybeSpawnSuccessor", () => {
     const source = { id: "rent-20260610", dueOn: "2026-06-10", amount: 1500, status: "paid" };
     await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
     assert.notEqual(await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir }), null);
+  });
+});
+
+// --- Field-driven `every` (per-record interval via an enum field) ---
+
+const FREQ_EVERY: CollectionSpawnEvery = {
+  fromField: "frequency",
+  map: {
+    daily: { unit: "day", interval: 1 },
+    weekly: { unit: "week", interval: 1 },
+    monthly: { unit: "month", interval: 1, dayOfMonth: 1 },
+  },
+};
+
+// A bills schema whose interval is selected per record by `frequency`.
+function freqSchema(extra: Partial<CollectionSchema> = {}): CollectionSchema {
+  return {
+    title: "Bills",
+    icon: "receipt",
+    dataPath: "data/bills/items",
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      dueOn: { type: "date", label: "Due", required: true },
+      frequency: { type: "enum", values: ["daily", "weekly", "monthly"], label: "Frequency", required: true },
+      status: { type: "enum", values: ["pending", "paid"], label: "Status", required: true },
+    },
+    completionField: "status",
+    completionDoneValues: ["paid"],
+    triggerField: "dueOn",
+    spawn: { when: { field: "status", in: ["paid"] }, every: FREQ_EVERY, carry: ["frequency"], set: { status: "pending" } },
+    ...extra,
+  };
+}
+
+describe("resolveEvery", () => {
+  it("passes a literal `every` through unchanged", () => {
+    const literal: CollectionEvery = { unit: "month", interval: 1, dayOfMonth: 10 };
+    assert.equal(resolveEvery(literal, { frequency: "weekly" }), literal);
+  });
+
+  it("maps the record's enum value to its interval", () => {
+    assert.deepEqual(resolveEvery(FREQ_EVERY, { frequency: "weekly" }), { unit: "week", interval: 1 });
+    assert.deepEqual(resolveEvery(FREQ_EVERY, { frequency: "monthly" }), { unit: "month", interval: 1, dayOfMonth: 1 });
+  });
+
+  it("returns null on an unmapped value or an empty/missing field", () => {
+    assert.equal(resolveEvery(FREQ_EVERY, { frequency: "yearly" }), null); // value not in map
+    assert.equal(resolveEvery(FREQ_EVERY, { frequency: "" }), null); // empty
+    assert.equal(resolveEvery(FREQ_EVERY, {}), null); // missing
+  });
+});
+
+describe("computeSuccessor — field-driven every", () => {
+  it("advances by the per-record interval (weekly)", () => {
+    const result = computeSuccessor(freqSchema(), { id: "netflix-20260610", dueOn: "2026-06-10", frequency: "weekly", status: "paid" }, "netflix-20260610");
+    assert.deepEqual(result, {
+      id: "netflix-20260617",
+      record: { frequency: "weekly", status: "pending", dueOn: "2026-06-17", id: "netflix-20260617" },
+    });
+  });
+
+  it("advances by the per-record interval (monthly, dayOfMonth anchor)", () => {
+    const result = computeSuccessor(freqSchema(), { id: "rent-20260601", dueOn: "2026-06-01", frequency: "monthly", status: "paid" }, "rent-20260601");
+    assert.equal(result?.record.dueOn, "2026-07-01");
+  });
+
+  it("returns null when the record's frequency isn't in the map", () => {
+    assert.equal(computeSuccessor(freqSchema(), { id: "x", dueOn: "2026-06-10", frequency: "yearly", status: "paid" }, "x"), null);
+  });
+});
+
+describe("maybeSpawnSuccessor — field-driven every", () => {
+  let workdir: string;
+  let dataDir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(path.join(tmpdir(), "test-spawn-freq-"));
+    dataDir = path.join(workdir, "data", "bills", "items");
+  });
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it("creates a weekly successor 7 days out and carries the frequency driver", async () => {
+    const source = { id: "gym-20260610", dueOn: "2026-06-10", frequency: "weekly", status: "paid" };
+    await maybeSpawnSuccessor("bills", freqSchema(), dataDir, source, "gym-20260610", { workspaceRoot: workdir });
+    const next = await readItem(dataDir, "gym-20260617", { workspaceRoot: workdir });
+    assert.deepEqual(next, { frequency: "weekly", status: "pending", dueOn: "2026-06-17", id: "gym-20260617" });
+  });
+
+  it("skips (no write) when the record's frequency isn't in the map", async () => {
+    const source = { id: "odd-20260610", dueOn: "2026-06-10", frequency: "yearly", status: "paid" };
+    await maybeSpawnSuccessor("bills", freqSchema(), dataDir, source, "odd-20260610", { workspaceRoot: workdir });
+    assert.equal(await readItem(dataDir, "odd-20260617", { workspaceRoot: workdir }), null);
+  });
+
+  it("runaway guard still fires under field-driven every (successor born matching its predicate)", async () => {
+    // `set` seeds status back to a done value → the successor would respawn.
+    const schema = freqSchema({ spawn: { when: { field: "status", in: ["paid"] }, every: FREQ_EVERY, carry: ["frequency"], set: { status: "paid" } } });
+    const source = { id: "gym-20260610", dueOn: "2026-06-10", frequency: "weekly", status: "paid" };
+    await maybeSpawnSuccessor("bills", schema, dataDir, source, "gym-20260610", { workspaceRoot: workdir });
+    assert.equal(await readItem(dataDir, "gym-20260617", { workspaceRoot: workdir }), null);
   });
 });


### PR DESCRIPTION
## What

Lets a single collection mix daily / weekly / monthly obligations in **one list**: `spawn.every` may now select the recurrence interval **per record** from an `enum` field, instead of a single literal applied to every record.

```json
"triggerField": "nextDue",
"spawn": {
  "when": { "field": "status", "in": ["paid"] },
  "every": {
    "fromField": "frequency",
    "map": {
      "daily":   { "unit": "day",   "interval": 1 },
      "weekly":  { "unit": "week",  "interval": 1 },
      "monthly": { "unit": "month", "interval": 1, "dayOfMonth": 1 }
    }
  },
  "carry": ["name", "amount", "frequency"],
  "set":   { "status": "unpaid" }
}
```

When `spawn` fires, the host reads the source record's `fromField` value, looks up the matching `{ unit, interval, … }` in `map`, and advances `triggerField` by that interval. Different records advance by different intervals. **Zero domain-specific host code** — all meaning stays in `schema.json`.

Follow-up to the time-driven collections work (`triggerField` + literal `spawn`). Full design in `plans/feat-collections-field-driven-spawn.md`.

## How

- **`every` becomes a union** — the existing literal form **or** `{ fromField, map }`. Implemented as `z.union` of two `.strict()` arms, so "both keys" and "neither key" both fail validation with no extra refine.
- **Type model** keeps `CollectionEvery` literal (untouched — still what `advanceTriggerDate` consumes); adds `CollectionEveryFieldDriven` and widens only `CollectionSpawn.every`. New `isFieldDrivenEvery` guard.
- **Discovery refines** (all schema-internal Zod refines, so they run host-side too via the shared `CollectionSchemaZ.safeParse` — no `manageCollection.ts` change):
  - `fromField` names a top-level `enum` field
  - `map` keys **exactly cover** that enum's `values` (no missing / extra keys)
  - `fromField` is carried (or `set`) onto the successor — a **hard error**, since losing it silently halts the chain
- **Runtime** — `computeSuccessor` resolves the effective `every` per record via `resolveEvery`; an unknown/empty value → skip. Distinct skip-log (`logSpawnSkip`) so a missing-frequency skip isn't mis-reported as an unparseable date.
- **Backward compatible** — literal `every` is byte-identical; the month-end clamp, `dayOfMonth: "last"`, `successorId`, the reconciler tick, and the runaway guard are untouched.

## Docs

Field-driven `every` section added to `collection-skills.md` (the `schemaDocs` authoring reference).

## Tests

- `resolveEvery` — literal passthrough; map hit; unknown/empty/missing → null
- Field-driven `computeSuccessor` / `maybeSpawnSuccessor` — advances by per-record interval, carries the driver, skips on unmapped value
- Discovery accept/reject — enum-type, exact coverage (missing & extra keys), carry rule, strict-union both/neither, bad map-value interval
- Asserts the runaway guard still fires under field-driven mode

All collection tests pass (138). `yarn format` / `lint` / `typecheck` / `build` clean.

## Verified live

Ran the real discoverer against a workspace whose `recurring-payments` collection was migrated to this mechanism: the schema is accepted, and daily records spawn next-day successors while a monthly record waits for its own cadence — confirming mixed intervals in one list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow collections to drive spawn recurrence intervals per record via an enum field while preserving existing literal `every` behaviour.

New Features:
- Support a field-driven spawn interval where `spawn.every` can select the recurrence per record from an enum field and interval map instead of a single literal.
- Expose a discriminated type for `spawn.every` that can be either a literal interval or a field-driven map, with a type guard for the field-driven form.

Enhancements:
- Tighten collection schema validation to ensure field-driven spawn uses an enum `fromField`, map keys exactly match the enum values, and the driver field is propagated to successors.
- Improve spawn logging by distinguishing between skips caused by invalid trigger dates and those caused by missing interval mappings.
- Document the field-driven `every` mechanism and authoring rules in the collection skills reference.
- Capture the design and rationale for field-driven spawn intervals in a dedicated plan document.

Tests:
- Add discovery tests covering valid and invalid field-driven spawn configurations, including enum type checks, map coverage, carry requirements, and bad map intervals.
- Add runtime tests for resolving per-record intervals, computing successors with field-driven `every`, ensuring skips on unmapped values, and verifying the runaway guard under field-driven mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collections now support field-driven `spawn.every`, letting each record pick a recurrence interval from a designated top-level enum field using a required interval mapping.

* **Bug Fixes**
  * Improved successor recurrence resolution and spawn-skip behavior when the driven interval is missing, unmapped, or cannot be determined.

* **Tests**
  * Added discovery-time validation and runtime successor/recurrence tests for the field-driven interval mode, including carry/set propagation rules.

* **Documentation**
  * Updated `spawn.every` documentation with the new field-driven configuration and chaining constraints.

* **Chores**
  * Bumped collection-plugin and workspace-setup package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->