### PR TITLE
fix(attachments): stop PPTX companion save failing as a false traversal rejection

### DIFF
--- a/server/utils/files/attachment-store.ts
+++ b/server/utils/files/attachment-store.ts
@@ -10,7 +10,7 @@
 //   data/attachments/YYYY/MM/<id>.<ext>            (original, always)
 //   data/attachments/YYYY/MM/<id>.pdf              (companion, PPTX only — same <id>)
 
-import { mkdir, readFile, realpath, writeFile } from "fs/promises";
+import { mkdir, readFile, realpath } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
@@ -189,15 +189,30 @@ export async function saveAttachment(base64Data: string, mimeType: string): Prom
  *  raw Buffer — the converter already has bytes in hand and base64
  *  re-encoding would be wasted work. */
 export async function saveCompanion(originalRelativePath: string, buf: Buffer, ext: string): Promise<string> {
-  await ensureAttachmentsDir();
+  const root = await ensureAttachmentsDir();
+  // Validate the SOURCE path up front, string-only — BEFORE any fs op.
+  // The companion doesn't exist yet so it can't go through the
+  // realpath-based `safeResolve` (that ENOENTs on the missing leaf and
+  // masquerades as a traversal rejection — the bug that broke every
+  // PPTX upload). `isAttachmentPath` rejects a bad prefix or any `..`
+  // segment, so the `mkdir` below can't escape the root.
+  if (!isAttachmentPath(originalRelativePath)) {
+    throw new Error(`path traversal rejected: ${originalRelativePath}`);
+  }
   const dir = path.posix.dirname(originalRelativePath);
   const base = path.posix.basename(originalRelativePath, path.posix.extname(originalRelativePath));
   const filename = `${base}${ext}`;
   const relativePath = path.posix.join(dir, filename);
-  const absPath = await safeResolve(relativePath);
-  // mkdir-p inside safeResolve's confined root.
-  await mkdir(path.dirname(absPath), { recursive: true });
-  await writeFile(absPath, buf);
+  const dirName = dir.replace(new RegExp(`^${WORKSPACE_DIRS.attachments}/`), "");
+  await mkdir(path.join(root, dirName), { recursive: true });
+  // Defense-in-depth: realpath the now-existing dir to catch symlink
+  // escapes, and keep the leaf separator-free.
+  const dirReal = resolveWithinRoot(root, dirName);
+  if (!dirReal || hasTraversalSegment(filename) || /[/\\]/.test(filename)) {
+    throw new Error(`path traversal rejected: ${relativePath}`);
+  }
+  const absPath = path.join(dirReal, filename);
+  await writeFileAtomic(absPath, buf);
   return relativePath;
 }
 

--- a/test/utils/files/test_attachment_store.ts
+++ b/test/utils/files/test_attachment_store.ts
@@ -1,0 +1,62 @@
+// Regression test for the PPTX → PDF companion save path.
+//
+// `saveCompanion` writes a not-yet-existing file (the converted PDF)
+// next to the original upload. It must NOT route that path through the
+// realpath-based `safeResolve`, which ENOENTs on a missing leaf and
+// surfaces as a misleading "path traversal rejected" — the bug that
+// made every PPTX upload fail. These tests pin the working behaviour
+// (companion lands on disk under the same partition) and that genuine
+// traversal is still rejected.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { saveAttachment, saveCompanion } from "../../../server/utils/files/attachment-store.js";
+import { WORKSPACE_PATHS } from "../../../server/workspace/paths.js";
+
+const ONE_PIXEL_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=";
+
+describe("attachment-store — saveCompanion", () => {
+  let savedDescriptor: PropertyDescriptor | undefined;
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(path.join(tmpdir(), "attach-companion-test-"));
+    savedDescriptor = Object.getOwnPropertyDescriptor(WORKSPACE_PATHS, "attachments");
+    Object.defineProperty(WORKSPACE_PATHS, "attachments", {
+      ...(savedDescriptor ?? { configurable: true }),
+      value: path.join(workspaceRoot, "data/attachments"),
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (savedDescriptor) Object.defineProperty(WORKSPACE_PATHS, "attachments", savedDescriptor);
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("writes a companion PDF alongside the original, reusing its id + partition", async () => {
+    const original = await saveAttachment(ONE_PIXEL_PNG_BASE64, "application/pdf");
+    const buf = Buffer.from("%PDF-1.4 fake companion");
+
+    const companionPath = await saveCompanion(original.relativePath, buf, ".pdf");
+
+    // Same directory + id prefix, only the extension differs.
+    const dir = path.posix.dirname(original.relativePath);
+    const base = path.posix.basename(original.relativePath, path.posix.extname(original.relativePath));
+    assert.equal(companionPath, path.posix.join(dir, `${base}.pdf`));
+
+    const absPath = path.join(workspaceRoot, companionPath);
+    assert.ok(existsSync(absPath), "companion file should exist on disk");
+    assert.deepEqual(readFileSync(absPath), buf);
+  });
+
+  it("rejects a traversal-shaped original path instead of escaping the root", async () => {
+    await assert.rejects(() => saveCompanion("data/attachments/../../etc/passwd.pptx", Buffer.from("x"), ".pdf"), /path traversal rejected/);
+  });
+});


### PR DESCRIPTION
## What

Attaching a `.pptx` file failed with `path traversal rejected: data/attachments/YYYY/MM/<id>.pdf`, even though the path is perfectly valid.

## Why

`saveCompanion()` (which writes the PPTX→PDF companion next to the original) validated the **not-yet-written** PDF path through `safeResolve()` → `resolveWithinRoot()` → `realpathSync()`. `realpathSync` throws `ENOENT` on a missing leaf, the wrapper swallows it and returns `null`, and the caller reports it as a traversal rejection. So every PPTX upload broke in environments where LibreOffice conversion actually runs.

## How

- Validate the source path string-first via `isAttachmentPath()` **before any fs op**, so `mkdir` cannot escape the attachments root.
- After `mkdir`, `realpath` the now-existing directory as defense-in-depth against symlink escapes, and keep the leaf separator-free.
- Reads of existing files still go through `safeResolve()` unchanged.

## Testing

Added `test/utils/files/test_attachment_store.ts` covering both:
- a companion PDF lands on disk under the original's id + partition, and
- a genuine traversal-shaped path is still rejected.

`yarn format` / lint / typecheck / `yarn build` all pass.

## Repro environment

WSL2 + Docker sandbox enabled + LibreOffice conversion available; uploading a `.pptx` in chat.

---

Found and fixed while setting up MulmoClaude with Claude Code.

## Summary by Sourcery

Fix companion attachment saving to avoid false path traversal rejections and ensure PPTX-to-PDF companions are written safely alongside originals.

Bug Fixes:
- Prevent PPTX companion saves from being incorrectly rejected as path traversal when the output file does not yet exist.
- Harden companion save path validation to reject genuine traversal attempts while allowing valid attachment paths.

Tests:
- Add regression tests for saveCompanion to verify companions are written under the same partition and that traversal-shaped paths are rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved companion file storage with enhanced path validation and atomic writes.
  * Added protection against invalid file paths during companion file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->