### PR TITLE
feat(collections): let custom views open records in the host modal

### DIFF
--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Schema-driven Collections plugin (presentCollection) — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal. This entry is the isomorphic collection engine (derive / formula / visibility); Vue surfaces land in ./vue.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onBeforeUnmount } from "vue";
+import { ref, watch, onMounted, onBeforeUnmount } from "vue";
 import { useCollectionI18n } from "../lang";
 import { errorMessage } from "../../core/errorMessage";
 import type { CollectionCustomView } from "../../core/schema";
@@ -39,6 +39,12 @@ const { t } = useCollectionI18n();
 const props = defineProps<{
   slug: string;
   view: CollectionCustomView;
+}>();
+
+const emit = defineEmits<{
+  /** The view called `__MC_VIEW.openItem(id, mode)` — open the record in the
+   *  host's shared modal. */
+  openItem: [payload: { id: string; mode: "view" | "edit" }];
 }>();
 
 const loading = ref(true);
@@ -142,10 +148,27 @@ watch(
   { immediate: true },
 );
 
+// ── Open-item bridge ──
+// The view calls `__MC_VIEW.openItem(id, mode)`, which posts an `mc-open-item`
+// message up to here. Verify it came from THIS view's iframe and is for THIS
+// collection, then hand the host the record to open in its shared modal. The
+// message carries no secret; the capability token is unaffected.
+function onWindowMessage(event: MessageEvent): void {
+  if (event.source !== iframeEl.value?.contentWindow) return;
+  const msg = event.data as { type?: string; slug?: string; id?: unknown; mode?: unknown };
+  if (!msg || msg.type !== "mc-open-item" || msg.slug !== props.slug) return;
+  const itemId = typeof msg.id === "string" ? msg.id : String(msg.id ?? "");
+  if (!itemId) return;
+  emit("openItem", { id: itemId, mode: msg.mode === "edit" ? "edit" : "view" });
+}
+
+onMounted(() => window.addEventListener("message", onWindowMessage));
+
 onBeforeUnmount(() => {
   clearRefresh();
   changeUnsub?.();
   changeUnsub = null;
+  window.removeEventListener("message", onWindowMessage);
 });
 </script>
 

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -396,7 +396,7 @@
            the collection's records. Placed before the empty states so it shows
            even for an empty collection (e.g. a still-empty year grid). -->
       <div v-else-if="activeCustomView" class="h-full" data-testid="collection-custom-view-body">
-        <CollectionCustomView :slug="collection.slug" :view="activeCustomView" />
+        <CollectionCustomView :slug="collection.slug" :view="activeCustomView" @open-item="onCustomViewOpenItem" />
       </div>
 
       <div v-else-if="items.length === 0 && editing?.mode !== 'create'" class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2">
@@ -1995,6 +1995,22 @@ function onCalendarSelect(itemId: string | null): void {
   if (calendarActive.value) openDay.value = dayOfItem(item);
   showDetail(item);
   writeSelectedToUrl(itemId);
+}
+
+/** A custom (sandboxed) view asked to open a record in the shared modal.
+ *  `view` → read-only detail, `edit` → straight into the editor. Ungated: the
+ *  capability token governs the view's *code*, not user actions through the
+ *  host's own trusted modal (no write happens without an explicit Save). */
+function onCustomViewOpenItem(payload: { id: string; mode: "view" | "edit" }): void {
+  const item = findItemById(payload.id);
+  if (!item) return;
+  if (editing.value) closeEditor();
+  if (payload.mode === "edit") {
+    openEdit(item);
+    return;
+  }
+  showDetail(item);
+  writeSelectedToUrl(payload.id);
 }
 
 /** A calendar day cell was activated → open its popup on a clean slate

--- a/packages/services/workspace-setup/assets/helps/custom-view.md
+++ b/packages/services/workspace-setup/assets/helps/custom-view.md
@@ -62,6 +62,7 @@ window.__MC_VIEW = {
   token: "<scoped capability token>", // Authorization bearer
   dataUrl: "http://localhost:3001/api/collections/annual-plan/view-data",
   onChange: (cb) => unsubscribe, // live refresh — see "Staying live" below
+  openItem: (id, mode) => void, // open a record in the host's panel — see "Opening a record"
 };
 ```
 
@@ -132,6 +133,36 @@ What you need to know:
 - **No extra capability needed** — a read-only view can use `onChange`.
 - It returns an **unsubscribe** function; you rarely need it (the view is torn
   down with the iframe), but it's there for fine-grained control.
+
+### Opening a record — `openItem`
+
+Your view owns the *layout* (a grid, a chart, a board); it doesn't have to
+rebuild a form to view or edit one record. Call `openItem` to hand a record to
+the host's own panel — the same detail/edit modal the user gets clicking a row
+in the table view — centred over your view:
+
+```js
+window.__MC_VIEW.openItem("task-3"); // read-only detail (default)
+window.__MC_VIEW.openItem("task-3", "edit"); // jump straight into the editor
+```
+
+- **`id`** — the record's `primaryKey` value. If it isn't a loaded record,
+  nothing happens (fire-and-forget; returns nothing).
+- **`mode`** — `"view"` (default) opens read-only detail with the panel's own
+  Edit button; `"edit"` opens the editor directly.
+- **No `write` capability required — even for `"edit"`.** Opening the host's
+  panel is a *user* action in the host's trusted UI: the user still has to press
+  Save, and the write goes through the host, not your scoped token. So a
+  `["read"]` view can offer a full "edit this record" affordance without
+  widening its own capabilities. (Capabilities gate what your view's *code* may
+  do to the data; they don't restrict what the user may do through the host.)
+- **Pair it with `onChange`.** After the user saves in the panel, your
+  `onChange` callback fires (the data changed), so a live view repaints itself —
+  no extra wiring needed.
+
+This is the right tool whenever a record's full detail is richer than your
+view's summary, or whenever the user wants to edit but you don't want a
+`write`-capable view doing its own PUTs.
 
 ## Sandbox rules (what the view may and may not do)
 
@@ -223,6 +254,7 @@ fields `start` / `end` and a `title`. `capabilities: ["read"]`.
         border-radius: 4px;
         padding: 2px 6px;
         margin-bottom: 4px;
+        cursor: pointer;
       }
       .err {
         color: #b91c1c;
@@ -242,13 +274,25 @@ fields `start` / `end` and a `title`. `capabilities: ["read"]`.
         const buckets = MONTHS.map(() => []);
         for (const it of items) {
           const m = it.start ? new Date(it.start).getMonth() : -1;
-          if (m >= 0 && m < 12) buckets[m].push(it.title || it.id);
+          if (m >= 0 && m < 12) buckets[m].push(it); // keep the item, not just its title — we need the id
         }
         const root = document.getElementById("root");
         root.className = "grid";
         root.innerHTML = MONTHS.map(
-          (name, i) => '<div class="month"><h2>' + name + "</h2>" + buckets[i].map((t) => '<div class="chip">' + t + "</div>").join("") + "</div>",
+          (name, i) =>
+            '<div class="month"><h2>' +
+            name +
+            "</h2>" +
+            buckets[i].map((it) => '<div class="chip" data-id="' + it.id + '">' + (it.title || it.id) + "</div>").join("") +
+            "</div>",
         ).join("");
+        // Click a chip → open that record in the host's panel (read-only detail;
+        // the panel's own Edit button takes it from there). Pass "edit" to jump
+        // straight into the editor — no `write` capability needed.
+        root.onclick = (e) => {
+          const chip = e.target.closest(".chip");
+          if (chip) window.__MC_VIEW.openItem(chip.dataset.id);
+        };
       }
       main().catch((e) => {
         document.getElementById("root").innerHTML = '<span class="err">Could not load: ' + e.message + "</span>";

--- a/packages/services/workspace-setup/package.json
+++ b/packages/services/workspace-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/workspace-setup",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Workspace bootstrap for MulmoClaude and MulmoTerminal — seeds the bundled help docs + preset skills into a workspace so a fresh workspace created by either app is set up identically. Server-only (`.`); browser-safe isPresetSlug at `./slug`. ESM-only (assets resolve via import.meta.url).",
   "type": "module",
   "main": "./dist/index.js",

--- a/plans/feat-collections-custom-views.md
+++ b/plans/feat-collections-custom-views.md
@@ -260,6 +260,12 @@ correctly is dead weight. Must cover, terse and operational:
 - **How to write data** (write-capability views only): `PUT` to `dataUrl` with
   `{ items, mode }`, the validation contract, and the per-row `rejected`
   shape to surface to the user. Note: **no delete**.
+- **How to open a record**: `window.__MC_VIEW.openItem(id, mode)` posts an
+  `mc-open-item` ping to the host, which opens the record in its shared
+  detail/edit modal (`mode`: `"view"` default / `"edit"`). Needs **no `write`
+  capability** even for `"edit"` — the host owns the save, so it's a user action
+  through trusted UI, not a view-code write. Pair with `onChange` to repaint
+  after the user saves.
 - **The sandbox rules**: inline `<script>`/`<style>` only; external resources
   limited to the CDN allowlist (`HTML_PREVIEW_CSP_ALLOWED_CDNS` — jsdelivr /
   unpkg / cdnjs / Google Fonts / plotly); **`fetch` is allowed only to

--- a/src/utils/html/customViewSrcdoc.ts
+++ b/src/utils/html/customViewSrcdoc.ts
@@ -7,9 +7,11 @@
 // view's own scripts:
 //   1. a CSP <meta> with connect-src = the server origin (the view may fetch
 //      its data endpoint but no third party), and
-//   2. `window.__MC_VIEW = { slug, token, dataUrl, onChange }` — the scoped
-//      capability token + the absolute data URL the view reads, plus an
-//      `onChange(cb)` live-refresh subscription (see below).
+//   2. `window.__MC_VIEW = { slug, token, dataUrl, origin, onChange, openItem }`
+//      — the scoped capability token + the absolute data URL the view reads,
+//      plus an `onChange(cb)` live-refresh subscription and an
+//      `openItem(id, mode)` helper that asks the host to open a record in its
+//      shared modal (see below).
 
 import { buildCustomViewCsp } from "./previewCsp";
 
@@ -17,21 +19,30 @@ import { buildCustomViewCsp } from "./previewCsp";
  *  parent change-pings (e.g. a bulk write) into a single `onChange` callback. */
 const ONCHANGE_DEBOUNCE_MS = 150;
 
-/** The in-iframe bootstrap appended after `window.__MC_VIEW = {…}`. It adds
- *  `onChange(cb)`: the view author's one-line opt-in to live refresh. The host
- *  parent (`CollectionCustomView.vue`) relays a `{ type: "mc-collection-changed",
- *  slug }` message into the iframe whenever the collection's data changes; this
- *  validates the message came from the parent, is for THIS collection, debounces,
- *  and invokes every registered callback. The message carries no secret and only
- *  triggers a re-fetch through the token the view already holds — so it grants
- *  no new capability. Self-contained string (no `</script>` sequence, no `<`). */
-function onChangeBootstrap(): string {
+/** The in-iframe bootstrap appended after `window.__MC_VIEW = {…}`. It installs
+ *  the view↔host bridge:
+ *
+ *  - `onChange(cb)`: the view author's one-line opt-in to live refresh. The host
+ *    parent (`CollectionCustomView.vue`) relays a `{ type: "mc-collection-changed",
+ *    slug }` message into the iframe whenever the collection's data changes; this
+ *    validates the message came from the parent, is for THIS collection,
+ *    debounces, and invokes every registered callback. The message carries no
+ *    secret and only triggers a re-fetch through the token the view already holds.
+ *  - `openItem(id, mode)`: posts a `{ type: "mc-open-item", slug, id, mode }`
+ *    ping up to the parent, which opens the record in the host's shared modal.
+ *    The payload carries no secret (slug + id are already known to the view) and
+ *    is sent to the known parent origin (`v.origin`). Opening the host's own
+ *    modal is a user action through trusted UI, so it needs no `write`
+ *    capability even for `mode: "edit"` — the save still goes through the host.
+ *
+ *  Self-contained string (no `</script>` sequence, no `<`, no `${`). */
+function viewBridgeBootstrap(): string {
   // One line on purpose — it's inlined into the iframe's bootstrap <script>.
   // Uses single quotes throughout (no `</script>`, no `<`, no `${`) so it stays
   // intact inside the template literal and inside the script element.
   // `cbs.slice()` snapshots the listeners before dispatch so a callback that
   // unsubscribes itself can't shift the array and skip the next one.
-  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};})();`;
+  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};v.openItem=function(id,mode){window.parent.postMessage({type:'mc-open-item',slug:v.slug,id:String(id),mode:mode==='edit'?'edit':'view'},v.origin);};})();`;
 }
 
 export interface CustomViewBootstrap {
@@ -59,8 +70,9 @@ export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): 
     slug: boot.slug,
     token: boot.token,
     dataUrl: absoluteDataUrl(boot.dataUrl, boot.origin),
+    origin: boot.origin, // target origin for openItem's postMessage to the parent
   }).replace(/</g, "\\u003c");
-  const injection = `${cspMeta}<script>window.__MC_VIEW=${json};${onChangeBootstrap()}</script>`;
+  const injection = `${cspMeta}<script>window.__MC_VIEW=${json};${viewBridgeBootstrap()}</script>`;
   if (/<head\b[^>]*>/i.test(html)) {
     return html.replace(/(<head\b[^>]*>)/i, `$1${injection}`);
   }

--- a/test/utils/html/test_customViewSrcdoc.ts
+++ b/test/utils/html/test_customViewSrcdoc.ts
@@ -69,6 +69,18 @@ describe("buildCustomViewSrcdoc", () => {
     assert.ok(out.indexOf("onChange") < out.indexOf("</head>"));
   });
 
+  it("injects the openItem bridge + origin so the view can open the host modal", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    // The origin is injected so openItem can target the parent frame's origin.
+    assert.match(out, /"origin":"http:\/\/localhost:3001"/);
+    // openItem posts an mc-open-item message up to the parent.
+    assert.match(out, /v\.openItem=function/);
+    assert.match(out, /mc-open-item/);
+    assert.match(out, /window\.parent\.postMessage\(/);
+    // Targets the known parent origin, never '*'.
+    assert.ok(out.includes("},v.origin)"), "openItem must post to the parent origin, not '*'");
+  });
+
   it("keeps the onChange bootstrap free of a </script> breakout sequence", () => {
     const out = buildCustomViewSrcdoc("<head></head>", boot);
     // The bootstrap is inlined in a <script>; a literal </script> inside it would


### PR DESCRIPTION
## What

Custom (sandboxed, LLM-authored HTML) collection views can now open a record in the host's shared detail/edit panel via a new bridge helper:

```js
window.__MC_VIEW.openItem("task-3");          // read-only detail (default)
window.__MC_VIEW.openItem("task-3", "edit");  // straight into the editor
```

Previously a custom view could only read/write data through its scoped token and `onChange` for live refresh — it had no way to reach the host's full-featured record panel. Now a view owns the *layout* (grid, chart, board) and defers per-record view/edit to the host.

## How it works

- The view posts `{ type: "mc-open-item", slug, id, mode }` to the parent's **known origin** (not `*`).
- `CollectionCustomView.vue` verifies the message came from *that* view's iframe (`event.source === iframe.contentWindow`) and matches its `slug`, then re-emits `openItem` upward.
- `CollectionView.vue` handles it by reusing the existing `findItemById` / `showDetail` / `openEdit` path — the same one calendar and kanban views already use via `select`. No new state, no new write path.

## Capability model

`mode: "edit"` is **ungated** — even a `["read"]` view can open the editor. Opening the host's own modal is a *user* action through trusted first-party UI: the user still has to press Save, and the write goes through the host, not the view's scoped token. Capabilities gate what the view's *code* may do to the data; they don't restrict what the user may do through the host.

## Files

- `src/utils/html/customViewSrcdoc.ts` — inject `origin` + the `openItem` helper into the iframe bootstrap (renamed `onChangeBootstrap` → `viewBridgeBootstrap`, since it now installs both bridges).
- `packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue` — inbound `message` listener + `openItem` emit.
- `packages/plugins/collection-plugin/src/vue/components/CollectionView.vue` — `@open-item` → `onCustomViewOpenItem`.
- `packages/services/workspace-setup/assets/helps/custom-view.md` — new "Opening a record" contract section; read-only Example 1 wired to open records on chip-click.
- `test/utils/html/test_customViewSrcdoc.ts` — asserts the `openItem` + `origin` bootstrap injection (and that it targets the parent origin, not `*`).
- `plans/feat-collections-custom-views.md` — documents `openItem` in the authoring contract.

## Version bumps

Both changed `@mulmoclaude/*` packages are also consumed by MulmoTerminal, so they're patch-bumped to avoid cross-app version skew:

- `@mulmoclaude/collection-plugin` 0.5.4 → 0.5.5 (Vue component changes)
- `@mulmoclaude/workspace-setup` 0.1.4 → 0.1.5 (shipped `custom-view.md` asset)

Consumer ranges (`^0.5.1` / `^0.1.0` / `*` / `>=0.5.0`) already cover the new versions; publishing is a separate step.

## Checks

`yarn format` · `yarn lint` · `yarn typecheck` · `yarn build` all clean. Unit tests: `customViewSrcdoc` 10/10, full suite 5153 pass / 0 fail.

## Manual smoke-test (not unit-coverable)

Mount a real custom view, call `__MC_VIEW.openItem(id, "edit")`, and confirm the modal overlays the iframe and saves correctly. The modal-host `v-if` already includes `(viewing || editing)`, so it renders over the custom-view body — but the iframe-overlay z-order is best eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom views can now open records directly in the host panel for viewing or editing.

* **Documentation**
  * Added guidance and documentation for custom view authors on implementing the new record-opening capability within custom views.

* **Tests**
  * Added test coverage for the custom view record-opening functionality.

* **Chores**
  * Version bumps in collection-plugin and workspace-setup packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->