### PR TITLE
ci: cache puppeteer browsers in the test jobs

### DIFF
--- a/.github/workflows/lint_test_windows.yaml
+++ b/.github/workflows/lint_test_windows.yaml
@@ -66,6 +66,19 @@ jobs:
           key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             win-node-modules-${{ matrix.node-version }}-
+      # Puppeteer downloads its browsers into ~/.cache/puppeteer during the
+      # `yarn install` postinstall — outside node_modules, so the cache above
+      # doesn't cover it, and the PDF-route tests in test:coverage launch it.
+      # Restored BEFORE install so the postinstall skips the download on a hit.
+      # Keyed on yarn.lock (busts on a puppeteer bump); restore-keys keeps a
+      # warm browser across unrelated lockfile changes.
+      - name: Cache puppeteer browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            puppeteer-${{ runner.os }}-
       - run: yarn install --frozen-lockfile --network-timeout 120000
       # Cache the output of `yarn build:packages` keyed on the source
       # files it consumes. The 25 @mulmobridge/* workspaces all run tsc

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -73,6 +73,21 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn
+    # Puppeteer's postinstall downloads chrome + chrome-headless-shell
+    # (~120 MB) into ~/.cache/puppeteer during `yarn install` — the PDF-route
+    # tests in test:coverage launch it. That dir lives OUTSIDE node_modules and
+    # the yarn cache, so without this it re-downloads on every cell of the
+    # matrix. Restored BEFORE install so the postinstall finds the browser and
+    # skips the download. Keyed on yarn.lock (busts on a puppeteer bump);
+    # restore-keys lets an unrelated lockfile change still land on a warm
+    # browser (postinstall re-downloads only if the pinned revision differs).
+    - name: Cache puppeteer browsers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/puppeteer
+        key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          puppeteer-${{ runner.os }}-
     - run: yarn install --frozen-lockfile --network-timeout 120000
     # Cache the output of `yarn build:packages` keyed on the source
     # files it consumes. The 25 @mulmobridge/* workspaces all run tsc


### PR DESCRIPTION
## Problem

The PDF-route tests in `test:coverage` (`test/routes/test_pdfInlineImages.ts` → `server/api/routes/pdf.ts`, which calls `puppeteer.launch`) need Chromium. Puppeteer downloads `chrome` + `chrome-headless-shell` (~120 MB) into `~/.cache/puppeteer` during `yarn install`'s postinstall — a directory that lives **outside** `node_modules` and the yarn cache, so nothing was caching it.

Result: every cell of the `lint_test` matrix (node 22/24 × ubuntu/macos) and the Windows job re-downloaded the puppeteer browsers on every run. This is the slowness behind the puppeteer-using CI tests.

There was never a puppeteer cache in CI — only the Playwright-browser cache (#1728), which is a separate binary set under `~/.cache/ms-playwright`.

## Fix

Add an `actions/cache` step for `~/.cache/puppeteer`, restored **before** `yarn install` so the postinstall finds the browser already present and skips the download:

```yaml
- name: Cache puppeteer browsers
  uses: actions/cache@v5
  with:
    path: ~/.cache/puppeteer
    key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
    restore-keys: |
      puppeteer-${{ runner.os }}-
```

- Keyed on `yarn.lock` so a puppeteer version bump busts it.
- `restore-keys` keeps a warm browser across unrelated lockfile changes — puppeteer's postinstall only re-downloads if the pinned Chromium revision actually differs.
- Restored before `yarn install` (the chicken-and-egg reason it's keyed on `yarn.lock` rather than the resolved puppeteer version, which isn't knowable until after install).

Applied to both jobs that run `test:coverage`: `lint_test` (`pull_request.yaml`) and `lint_test_windows.yaml`. The publish-smoke job already sets `PUPPETEER_SKIP_DOWNLOAD=1`, so it needs no cache.

This mirrors the existing Playwright-browser cache (#1728) — the puppeteer equivalent for the unit/route test jobs.

## Note on the Playwright cache

While here, I verified the Playwright cache is still working (real run logs, main @ 28014709163): `Cache hit for: playwright-Linux-1.61.0` → `Cache restored successfully`, the explicit install step skipped, and the `ensure:playwright-browsers` inside `test:e2e` produced **zero** `Downloading` lines. No regression there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cache Puppeteer browser downloads in CI test jobs to speed up PDF-route coverage tests.

CI:
- Add an actions/cache step for ~/.cache/puppeteer to the pull_request lint_test matrix job, keyed by OS and yarn.lock with restore keys for warm reuse.
- Add equivalent Puppeteer browser cache configuration to the Windows lint_test workflow so coverage tests reuse downloaded Chromium across runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build times by caching Puppeteer’s downloaded browser binaries on Windows and during the lint/test workflow, with cache keys scoped by operating system and lockfile changes.
  * Cache is restored prior to dependency installation to minimize redundant browser downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->