### PR TITLE
feat(collections): let custom view buttons start a draft chat (startChat)

### DIFF
--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Schema-driven Collections plugin (presentCollection) — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal. This entry is the isomorphic collection engine (derive / formula / visibility); Vue surfaces land in ./vue.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
@@ -45,6 +45,9 @@ const emit = defineEmits<{
   /** The view called `__MC_VIEW.openItem(id, mode)` — open the record in the
    *  host's shared modal. */
   openItem: [payload: { id: string; mode: "view" | "edit" }];
+  /** The view called `__MC_VIEW.startChat(prompt, role)` — open a new chat with
+   *  `prompt` prefilled as an editable draft (host validates `role`). */
+  startChat: [payload: { prompt: string; role?: string }];
 }>();
 
 const loading = ref(true);
@@ -148,18 +151,29 @@ watch(
   { immediate: true },
 );
 
-// ── Open-item bridge ──
-// The view calls `__MC_VIEW.openItem(id, mode)`, which posts an `mc-open-item`
-// message up to here. Verify it came from THIS view's iframe and is for THIS
-// collection, then hand the host the record to open in its shared modal. The
-// message carries no secret; the capability token is unaffected.
+// ── View → host action bridge ──
+// The view calls `__MC_VIEW.openItem(id, mode)` / `.startChat(prompt, role)`,
+// which post an `mc-open-item` / `mc-start-chat` message up to here. Verify it
+// came from THIS view's iframe and is for THIS collection, then hand the action
+// to the host. The messages carry no secret; the capability token is unaffected.
+function handleOpenItem(body: { id?: unknown; mode?: unknown }): void {
+  const itemId = typeof body.id === "string" ? body.id : String(body.id ?? "");
+  if (!itemId) return;
+  emit("openItem", { id: itemId, mode: body.mode === "edit" ? "edit" : "view" });
+}
+
+function handleStartChat(body: { prompt?: unknown; role?: unknown }): void {
+  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+  if (!prompt) return;
+  emit("startChat", { prompt, role: typeof body.role === "string" ? body.role : undefined });
+}
+
 function onWindowMessage(event: MessageEvent): void {
   if (event.source !== iframeEl.value?.contentWindow) return;
-  const msg = event.data as { type?: string; slug?: string; id?: unknown; mode?: unknown };
-  if (!msg || msg.type !== "mc-open-item" || msg.slug !== props.slug) return;
-  const itemId = typeof msg.id === "string" ? msg.id : String(msg.id ?? "");
-  if (!itemId) return;
-  emit("openItem", { id: itemId, mode: msg.mode === "edit" ? "edit" : "view" });
+  const msg = event.data as { type?: string; slug?: string; id?: unknown; mode?: unknown; prompt?: unknown; role?: unknown };
+  if (!msg || msg.slug !== props.slug) return;
+  if (msg.type === "mc-open-item") handleOpenItem(msg);
+  else if (msg.type === "mc-start-chat") handleStartChat(msg);
 }
 
 onMounted(() => window.addEventListener("message", onWindowMessage));

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -396,7 +396,7 @@
            the collection's records. Placed before the empty states so it shows
            even for an empty collection (e.g. a still-empty year grid). -->
       <div v-else-if="activeCustomView" class="h-full" data-testid="collection-custom-view-body">
-        <CollectionCustomView :slug="collection.slug" :view="activeCustomView" @open-item="onCustomViewOpenItem" />
+        <CollectionCustomView :slug="collection.slug" :view="activeCustomView" @open-item="onCustomViewOpenItem" @start-chat="onCustomViewStartChat" />
       </div>
 
       <div v-else-if="items.length === 0 && editing?.mode !== 'create'" class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2">
@@ -2011,6 +2011,16 @@ function onCustomViewOpenItem(payload: { id: string; mode: "view" | "edit" }): v
   }
   showDetail(item);
   writeSelectedToUrl(payload.id);
+}
+
+/** The custom view called `__MC_VIEW.startChat(prompt, role)` — open a new chat
+ *  with the prompt prefilled as an editable draft. The host validates `role`
+ *  (falls back to General). The view's code only proposes text; the user
+ *  approves / edits / sends, so no capability is required. */
+function onCustomViewStartChat(payload: { prompt: string; role?: string }): void {
+  const prompt = payload.prompt.trim();
+  if (!prompt) return;
+  cui.startNewChatDraft(prompt, payload.role);
 }
 
 /** A calendar day cell was activated → open its popup on a clean slate

--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -170,6 +170,11 @@ export interface CollectionUi {
   // ── app integration ──
   /** Start a new chat with a seed prompt + role (host: `useAppApi().startNewChat`). */
   startChat: (prompt: string, role: string) => void;
+  /** Open a new chat with `prompt` prefilled in the composer as an editable DRAFT
+   *  (NOT auto-sent) — the user reviews / edits / sends it. Backs a custom view's
+   *  `__MC_VIEW.startChat`. `role` is optional and validated host-side (falls back
+   *  to the general role). */
+  startNewChatDraft: (prompt: string, role?: string) => void;
   /** The host's active i18n locale tag (e.g. "en", "ja"), read reactively — the
    *  plugin syncs its own self-contained i18n instance to it. */
   localeTag: () => string;

--- a/packages/services/workspace-setup/assets/helps/custom-view.md
+++ b/packages/services/workspace-setup/assets/helps/custom-view.md
@@ -63,6 +63,7 @@ window.__MC_VIEW = {
   dataUrl: "http://localhost:3001/api/collections/annual-plan/view-data",
   onChange: (cb) => unsubscribe, // live refresh — see "Staying live" below
   openItem: (id, mode) => void, // open a record in the host's panel — see "Opening a record"
+  startChat: (prompt, role) => void, // draft a new chat for the user — see "Starting a chat"
 };
 ```
 
@@ -136,7 +137,7 @@ What you need to know:
 
 ### Opening a record — `openItem`
 
-Your view owns the *layout* (a grid, a chart, a board); it doesn't have to
+Your view owns the _layout_ (a grid, a chart, a board); it doesn't have to
 rebuild a form to view or edit one record. Call `openItem` to hand a record to
 the host's own panel — the same detail/edit modal the user gets clicking a row
 in the table view — centred over your view:
@@ -151,10 +152,10 @@ window.__MC_VIEW.openItem("task-3", "edit"); // jump straight into the editor
 - **`mode`** — `"view"` (default) opens read-only detail with the panel's own
   Edit button; `"edit"` opens the editor directly.
 - **No `write` capability required — even for `"edit"`.** Opening the host's
-  panel is a *user* action in the host's trusted UI: the user still has to press
+  panel is a _user_ action in the host's trusted UI: the user still has to press
   Save, and the write goes through the host, not your scoped token. So a
   `["read"]` view can offer a full "edit this record" affordance without
-  widening its own capabilities. (Capabilities gate what your view's *code* may
+  widening its own capabilities. (Capabilities gate what your view's _code_ may
   do to the data; they don't restrict what the user may do through the host.)
 - **Pair it with `onChange`.** After the user saves in the panel, your
   `onChange` callback fires (the data changed), so a live view repaints itself —
@@ -163,6 +164,37 @@ window.__MC_VIEW.openItem("task-3", "edit"); // jump straight into the editor
 This is the right tool whenever a record's full detail is richer than your
 view's summary, or whenever the user wants to edit but you don't want a
 `write`-capable view doing its own PUTs.
+
+### Starting a chat — `startChat`
+
+Your view can't reach external services or run a skill on its own (the sandbox
+blocks it). Instead, hand the work to a chat: `startChat` opens a **new chat
+session with your prompt prefilled in the composer** — as an editable draft. It
+does **not** send. The user reads it, edits if they want, and presses Send (or
+clears it). The agent in that approved chat does the real work — file a GitHub
+issue and write the URL back, fetch a link's title/image and save them, or just
+start from a task record.
+
+```js
+const task = items.find((r) => r.id === id);
+window.__MC_VIEW.startChat(`Create a GitHub issue for this task and write the URL back to record ${id}:\n\n` + `Title: ${task.title}\n${task.body}`);
+```
+
+- **`prompt`** — the seed text. Empty / whitespace-only is ignored (no empty
+  chat). Build it from your records — that's the whole point.
+- **`role`** _(optional second argument)_ — a built-in role id to preselect for
+  the new session (e.g. `"office"`, `"investor"`); validated by the host. Omit it
+  and the chat opens in **General** — which is what you usually want.
+- **No capability required.** Your view's code only _proposes text into an input
+  field_ — nothing is created, fetched, or written until the **user** presses
+  Send, at which point it's an ordinary agent run they authored. So a `["read"]`
+  view can offer "start work on this" buttons freely.
+- **Pair it with `onChange`.** When the chat's agent later writes back to a
+  record, your `onChange` callback fires and a live view repaints.
+
+Use this — not a hidden flag the user has to reconcile later — whenever a button
+should _start backend work_: the user stays in the loop through trusted first-
+party UI, and the action runs as a normal, visible, cancellable agent turn.
 
 ## Sandbox rules (what the view may and may not do)
 
@@ -185,12 +217,15 @@ The view runs in a `sandbox="allow-scripts"` iframe with a strict CSP:
   phone-home, no third-party analytics, no fetching weather / prices / etc.
   directly from the view. If the user needs external data, put it in a (feed)
   collection and read it through `dataUrl`. (This is the channel that actually
-  matters for keeping the scoped token and records from leaking off-box.)
+  matters for keeping the scoped token and records from leaking off-box.) When a
+  button should _do_ outside work — file an issue, fetch a link's metadata, run a
+  skill — don't try to reach out from view code; use **`startChat`** (above) to
+  hand the task to a user-approved chat.
 - No access to cookies, `localStorage`, or the parent page — the iframe has an
   opaque origin. The token is the only credential, and it is scoped to this one
   collection.
 - **Opening external links is allowed** — use `<a href="…" target="_blank"
-  rel="noopener">` (or `window.open(url, "_blank")`) to open a record's URL in a
+rel="noopener">` (or `window.open(url, "_blank")`) to open a record's URL in a
   new browser tab, e.g. a feed card linking to its article. The link opens as a
   normal tab. (A plain same-tab `<a href>` would try to navigate the sandboxed
   frame itself and is blocked, so always use `target="_blank"` for outbound

--- a/packages/services/workspace-setup/package.json
+++ b/packages/services/workspace-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/workspace-setup",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Workspace bootstrap for MulmoClaude and MulmoTerminal — seeds the bundled help docs + preset skills into a workspace so a fresh workspace created by either app is set up identically. Server-only (`.`); browser-safe isPresetSlug at `./slug`. ESM-only (assets resolve via import.meta.url).",
   "type": "module",
   "main": "./dist/index.js",

--- a/plans/feat-collections-custom-view-chat.md
+++ b/plans/feat-collections-custom-view-chat.md
@@ -1,0 +1,121 @@
+# feat(collections): let custom-view buttons start a new chat (draft, user-approved)
+
+Issue: #1742 — custom-view buttons should trigger backend work, not just flip a
+flag. PR #1748 (`openItem`) established the bridge pattern; this is its action-
+oriented successor, scoped to **Option A: route through a visible, user-approved
+chat** (no headless side-effects).
+
+## Goal
+
+A custom view can hand the host a **prefilled prompt** for a brand-new chat
+session. The host opens the session and drops the prompt into the **standard
+composer as an editable draft** — it does NOT auto-send. The user reviews, edits
+if they want, then presses Send (or clears it). The agent in that approved chat
+does the real work (file the GitHub issue, fetch URL metadata + write back, start
+from the task record), so all three beta use cases in #1742 resolve through one
+primitive.
+
+```js
+window.__MC_VIEW.startChat("Start work on this task:\n\n" + recordText);
+window.__MC_VIEW.startChat(prompt, "research");   // optional role id
+```
+
+## Why this is safe (capability model)
+
+Strictly safer than `openItem` (#1748): the view's code only *proposes text into
+an input field*. Nothing is created, fetched, or written until the **user** presses
+Send, at which point it is an ordinary agent run the user authored through trusted
+first-party UI. So — like `openItem` — **no capability gate is required**; a
+`["read"]` view can call it. There is deliberately no headless "run skill in the
+background" path in this plan (that was Option B; deferred until a real no-human-in-
+the-loop need appears, because it would need a new per-skill capability gate).
+
+## Protocol
+
+View → parent: `{ type: "mc-start-chat", slug, prompt, role? }`, posted to the
+**known parent origin** (`v.origin`), never `*`. Carries no secret. Host verifies
+`event.source === iframe.contentWindow` + `slug === props.slug` before acting —
+identical guard to `mc-open-item`.
+
+`prompt` is coerced to a string; empty/whitespace-only → ignored (no empty chat).
+`role` is optional; the host validates it against the known role list and falls
+back to General when absent or unknown (see note below).
+
+## Scope decision (from design discussion)
+
+**Prompt + optional role.** The view may pass a role id to preselect the new
+session's role; host validates and falls back to General. Rationale: a triage view
+may want a chat that already carries the tools its follow-up needs.
+
+## Files
+
+### View bootstrap
+- `src/utils/html/customViewSrcdoc.ts`
+  - Add `v.startChat = function(prompt, role){ ... postMessage({type:'mc-start-chat',
+    slug:v.slug, prompt:String(prompt), role: typeof role==='string'?role:undefined},
+    v.origin); }` to `viewBridgeBootstrap()` (alongside `openItem`).
+  - Update the file header + the `viewBridgeBootstrap` doc-comment to list the new
+    bridge (same prose discipline as the `openItem` block).
+
+### Host — collection plugin
+- `packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue`
+  - Extend `onWindowMessage` (or add a sibling branch) to handle `mc-start-chat`:
+    same source+slug verification, then `emit("startChat", { prompt, role })`.
+  - Add `startChat` to `defineEmits`.
+- `packages/plugins/collection-plugin/src/vue/components/CollectionView.vue`
+  - `@start-chat="onCustomViewStartChat"` on `<CollectionCustomView>` (line ~399).
+  - `function onCustomViewStartChat({ prompt, role }) {`
+    `  const text = (prompt ?? "").trim(); if (!text) return;`
+    `  appApi.startNewChatDraft(text, role);  // role validated host-side`
+    `}`
+- `packages/plugins/collection-plugin/src/vue/uiContext.ts`
+  - Add `startNewChatDraft: (prompt: string, role?: string) => void;` to the
+    UI-context type (next to `startChat`).
+
+### Host — app wiring
+- `src/composables/collections/uiHost.ts`
+  - Add a `startNewChatDraft` binding slot mirroring `startChat` (module-level fn ref,
+    installed via `installCollectionAppBindings`, exposed on the context object).
+- `src/App.vue`
+  - New `function startNewChatDraft(message: string, roleId?: string): void`:
+    ```ts
+    const rId = roleId && roles.value.some(r => r.id === roleId)
+      ? roleId
+      : BUILTIN_ROLE_IDS.general;   // validate; fall back to General
+    createNewSession(rId);
+    userInput.value = message;       // prefill composer; do NOT sendMessage
+    // focus the composer input so the user lands ready to review/edit
+    ```
+    (Contrast with `startNewChat`, which calls `void sendMessage(message)` — this
+    one intentionally stops at the draft.)
+  - Thread `startNewChatDraft` into `installCollectionAppBindings(...)` alongside the
+    existing `startChat` binding.
+  - Wire composer focus: reuse whatever ref/method the `+`-new-session flow already
+    uses to focus `userInput` (confirm during impl; add a `nextTick` focus if none).
+
+### Docs + tests
+- `packages/services/workspace-setup/assets/helps/custom-view.md`
+  - New "Starting a chat" contract section: `startChat(prompt, role?)`, the
+    draft-not-send semantics, the no-capability-needed note, and a wired example
+    (e.g. an "Start work" chip that builds a prompt from the record).
+  - Bump `@mulmoclaude/workspace-setup` patch version (shipped asset) — consumed by
+    MulmoTerminal too, so keep versions in lockstep ([[project_shared_pkg_version_bump]]).
+- `packages/plugins/collection-plugin/package.json`
+  - Patch-bump `@mulmoclaude/collection-plugin` (Vue component change).
+- `test/utils/html/test_customViewSrcdoc.ts`
+  - Assert `startChat` helper + `mc-start-chat` wiring is injected and targets the
+    parent origin (not `*`), mirroring the existing `openItem`/`origin` assertions.
+- `plans/feat-collections-custom-views.md`
+  - Add `startChat` to the authoring-contract list (same spot `openItem` was added).
+
+## Out of scope (explicit)
+- Headless background skill execution with external side-effects (Option B).
+- Auto-sending the prompt (defeats the approve/edit/reject gate — never do this).
+- Letting the view target an existing session; always a fresh session.
+
+## Checks
+`yarn format` · `yarn lint` · `yarn typecheck` · `yarn build`; unit suite incl.
+`test_customViewSrcdoc`. Manual smoke (not unit-coverable): mount a real view, call
+`__MC_VIEW.startChat(text, role)`, confirm a new session opens with the prompt
+prefilled-but-unsent in the composer, role preselected, and that an unknown role id
+falls back to General.

--- a/plans/feat-collections-custom-views.md
+++ b/plans/feat-collections-custom-views.md
@@ -266,6 +266,14 @@ correctly is dead weight. Must cover, terse and operational:
   capability** even for `"edit"` — the host owns the save, so it's a user action
   through trusted UI, not a view-code write. Pair with `onChange` to repaint
   after the user saves.
+- **How to start a chat**: `window.__MC_VIEW.startChat(prompt, role?)` posts an
+  `mc-start-chat` ping to the host, which opens a new chat with `prompt`
+  prefilled in the composer as an editable **draft** (NOT auto-sent — the user
+  approves / edits / sends). `role` is optional and validated host-side (falls
+  back to General). Needs **no capability**: the view's code only proposes text;
+  the agent run happens only once the user sends. This is how a view button
+  triggers backend work (file an issue, fetch a link, start from a record) while
+  keeping the user in the loop. See `plans/feat-collections-custom-view-chat.md`.
 - **The sandbox rules**: inline `<script>`/`<style>` only; external resources
   limited to the CDN allowlist (`HTML_PREVIEW_CSP_ALLOWED_CDNS` — jsdelivr /
   unpkg / cdnjs / Google Fonts / plotly); **`fetch` is allowed only to

--- a/src/App.vue
+++ b/src/App.vue
@@ -1091,6 +1091,20 @@ function startNewChat(message: string, roleId?: string): void {
   void sendMessage(message);
 }
 
+// Like startNewChat, but prefills the composer with `message` as an editable
+// DRAFT instead of sending it — the user reviews / edits / sends (or clears) it.
+// Used by custom collection views (`__MC_VIEW.startChat`) so a view button can
+// propose a chat without the view's code triggering an agent run on its own.
+// `roleId` is validated against the known roles and falls back to General
+// (createNewSession does not validate the id it is handed).
+function startNewChatDraft(message: string, roleId?: string): void {
+  const rId = roleId && roles.value.some((role) => role.id === roleId) ? roleId : BUILTIN_ROLE_IDS.general;
+  createNewSession(rId);
+  userInput.value = message;
+  chatInputRef.value?.collapseSuggestions();
+  nextTick(() => focusChatInput());
+}
+
 function handleAskGemini(): void {
   startNewChat(t("settingsModal.geminiAskMessage"), BUILTIN_ROLE_IDS.general);
 }
@@ -1111,6 +1125,7 @@ provideAppApi({
 const { entries: notifierEntries } = useNotifications();
 installCollectionAppBindings({
   startChat: (prompt: string, role: string) => startNewChat(prompt, role),
+  startNewChatDraft: (prompt: string, role?: string) => startNewChatDraft(prompt, role),
   notifiedSeverities: (slug: string) => collectionNotifiedSeverities(notifierEntries.value, slug),
 });
 // Plugin Views that need to tag background work with the current

--- a/src/composables/collections/uiHost.ts
+++ b/src/composables/collections/uiHost.ts
@@ -53,14 +53,21 @@ const viewDeleteUrl = (slug: string, viewId: string): string =>
 
 // ── Deferred app bindings (need a component context; set by App.vue setup) ──
 type StartChat = (prompt: string, role: string) => void;
+type StartChatDraft = (prompt: string, role?: string) => void;
 type NotifiedSeverities = (slug: string) => Map<string, NotifierSeverity>;
 let startChatFn: StartChat | null = null;
+let startChatDraftFn: StartChatDraft | null = null;
 let notifiedSeveritiesFn: NotifiedSeverities | null = null;
 
 /** Called once from App.vue's setup, where `useAppApi()` / `useNotifications()`
- *  resolve. Wires the two capabilities that can't be set at module load. */
-export function installCollectionAppBindings(bindings: { startChat: StartChat; notifiedSeverities: NotifiedSeverities }): void {
+ *  resolve. Wires the capabilities that can't be set at module load. */
+export function installCollectionAppBindings(bindings: {
+  startChat: StartChat;
+  startNewChatDraft: StartChatDraft;
+  notifiedSeverities: NotifiedSeverities;
+}): void {
   startChatFn = bindings.startChat;
+  startChatDraftFn = bindings.startNewChatDraft;
   notifiedSeveritiesFn = bindings.notifiedSeverities;
 }
 
@@ -132,6 +139,7 @@ configureCollectionUi({
   // (the host runs vue-i18n in composition mode); `unref` returns the tag either way.
   localeTag: () => unref(hostI18n.global.locale),
   startChat: (prompt, role) => startChatFn?.(prompt, role),
+  startNewChatDraft: (prompt, role) => startChatDraftFn?.(prompt, role),
   generalRoleId: BUILTIN_ROLE_IDS.general,
   personalRoleId: BUILTIN_ROLE_IDS.personal,
   unpin: (kind, slug) => useShortcuts().unpin(kind, slug),

--- a/src/utils/html/customViewSrcdoc.ts
+++ b/src/utils/html/customViewSrcdoc.ts
@@ -7,11 +7,13 @@
 // view's own scripts:
 //   1. a CSP <meta> with connect-src = the server origin (the view may fetch
 //      its data endpoint but no third party), and
-//   2. `window.__MC_VIEW = { slug, token, dataUrl, origin, onChange, openItem }`
-//      — the scoped capability token + the absolute data URL the view reads,
-//      plus an `onChange(cb)` live-refresh subscription and an
+//   2. `window.__MC_VIEW = { slug, token, dataUrl, origin, onChange, openItem,
+//      startChat }` — the scoped capability token + the absolute data URL the
+//      view reads, plus an `onChange(cb)` live-refresh subscription, an
 //      `openItem(id, mode)` helper that asks the host to open a record in its
-//      shared modal (see below).
+//      shared modal, and a `startChat(prompt, role)` helper that asks the host
+//      to open a new chat with `prompt` prefilled for the user to approve (see
+//      below).
 
 import { buildCustomViewCsp } from "./previewCsp";
 
@@ -34,6 +36,12 @@ const ONCHANGE_DEBOUNCE_MS = 150;
  *    is sent to the known parent origin (`v.origin`). Opening the host's own
  *    modal is a user action through trusted UI, so it needs no `write`
  *    capability even for `mode: "edit"` — the save still goes through the host.
+ *  - `startChat(prompt, role)`: posts a `{ type: "mc-start-chat", slug, prompt,
+ *    role }` ping up to the parent, which opens a NEW chat session with `prompt`
+ *    prefilled in the composer as an editable draft — it does NOT auto-send. The
+ *    user reviews / edits / sends (or clears) it, so the view's code can only
+ *    propose text; no capability is required. `role` is optional and validated
+ *    host-side (falls back to the general role). Sent to `v.origin`, no secret.
  *
  *  Self-contained string (no `</script>` sequence, no `<`, no `${`). */
 function viewBridgeBootstrap(): string {
@@ -42,7 +50,7 @@ function viewBridgeBootstrap(): string {
   // intact inside the template literal and inside the script element.
   // `cbs.slice()` snapshots the listeners before dispatch so a callback that
   // unsubscribes itself can't shift the array and skip the next one.
-  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};v.openItem=function(id,mode){window.parent.postMessage({type:'mc-open-item',slug:v.slug,id:String(id),mode:mode==='edit'?'edit':'view'},v.origin);};})();`;
+  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};v.openItem=function(id,mode){window.parent.postMessage({type:'mc-open-item',slug:v.slug,id:String(id),mode:mode==='edit'?'edit':'view'},v.origin);};v.startChat=function(prompt,role){window.parent.postMessage({type:'mc-start-chat',slug:v.slug,prompt:String(prompt),role:typeof role==='string'?role:undefined},v.origin);};})();`;
 }
 
 export interface CustomViewBootstrap {

--- a/test/utils/html/test_customViewSrcdoc.ts
+++ b/test/utils/html/test_customViewSrcdoc.ts
@@ -81,6 +81,16 @@ describe("buildCustomViewSrcdoc", () => {
     assert.ok(out.includes("},v.origin)"), "openItem must post to the parent origin, not '*'");
   });
 
+  it("injects the startChat bridge so the view can draft a new chat", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    // startChat posts an mc-start-chat message up to the parent.
+    assert.match(out, /v\.startChat=function/);
+    assert.match(out, /mc-start-chat/);
+    // Carries the prompt (+ optional role); targets the known parent origin, never '*'.
+    assert.match(out, /type:'mc-start-chat'/);
+    assert.ok(out.includes("},v.origin)"), "startChat must post to the parent origin, not '*'");
+  });
+
   it("keeps the onChange bootstrap free of a </script> breakout sequence", () => {
     const out = buildCustomViewSrcdoc("<head></head>", boot);
     // The bootstrap is inlined in a <script>; a literal </script> inside it would


### PR DESCRIPTION
## What

Custom (sandboxed, LLM-authored HTML) collection views can now hand a prompt to the host via a new bridge helper:

```js
window.__MC_VIEW.startChat("Create a GitHub issue for this task…");
window.__MC_VIEW.startChat(prompt, "office"); // optional: preselect a role
```

The host opens a **new chat session with the prompt prefilled in the composer as an editable draft** — it does **not** auto-send. The user reviews / edits / sends (or clears) it. The agent in that approved chat does the real work.

This is the action-oriented successor to `openItem` (#1748) and resolves issue #1742, where a view button could only set a flag on a record and the actual work needed a separate scheduled script or manual step. The three beta use cases all resolve through this one primitive: file a GitHub issue and write the URL back, fetch a link's title/image and save them, or start a chat from a task record.

Closes #1742.

## How it works

- The view posts `{ type: "mc-start-chat", slug, prompt, role }` to the parent's **known origin** (not `*`).
- `CollectionCustomView.vue` verifies the message came from *that* view's iframe (`event.source === iframe.contentWindow`) and matches its `slug`, then re-emits `startChat` upward.
- `CollectionView.vue` handles it via a new `startNewChatDraft` host binding, which opens a fresh session and prefills the composer **without sending**.
- `role` is optional and validated host-side against the known roles; an unknown or omitted role falls back to **General** (`createNewSession` does not validate the id it is handed).

## Capability model

`startChat` is **ungated** — even a `["read"]` view can call it, and it's strictly safer than `openItem`. The view's code only *proposes text into an input field*; nothing is created, fetched, or written until the **user** presses Send, at which point it's an ordinary agent run they authored through trusted first-party UI. Capabilities gate what the view's *code* may do to the data; they don't restrict what the user may do through the host. There is deliberately **no headless skill path** (that would need a new per-skill gate; deferred until a real no-human-in-the-loop need appears).

## Files

- `src/utils/html/customViewSrcdoc.ts` — inject the `startChat` helper into the iframe bootstrap (posts `mc-start-chat` to the parent origin).
- `packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue` — inbound `mc-start-chat` handler + `startChat` emit (split into per-type handlers to stay under the cognitive-complexity gate).
- `packages/plugins/collection-plugin/src/vue/components/CollectionView.vue` — `@start-chat` → `onCustomViewStartChat`.
- `packages/plugins/collection-plugin/src/vue/uiContext.ts` — `startNewChatDraft` on the UI context type.
- `src/composables/collections/uiHost.ts` + `src/App.vue` — thread the `startNewChatDraft` binding (validate role, prefill `userInput`, focus the composer, no send).
- `packages/services/workspace-setup/assets/helps/custom-view.md` — new "Starting a chat" authoring section + a pointer from the sandbox fetch-restriction bullet.
- `test/utils/html/test_customViewSrcdoc.ts` — asserts the `startChat` bootstrap injection targets the parent origin, not `*`.
- `plans/feat-collections-custom-view-chat.md` (new) + `plans/feat-collections-custom-views.md` — plan + authoring-contract entry.

## Version bumps

Both changed `@mulmoclaude/*` packages are also consumed by MulmoTerminal, so they're patch-bumped to avoid cross-app version skew:

- `@mulmoclaude/collection-plugin` 0.5.5 → 0.5.6 (Vue component changes)
- `@mulmoclaude/workspace-setup` 0.1.5 → 0.1.6 (shipped `custom-view.md` asset)

## Checks

`yarn format` · `yarn lint` · `yarn typecheck` · `yarn build` all clean. Unit tests: full suite 5154 pass / 0 fail (incl. the new `startChat` bootstrap assertion). Manually verified: calling `__MC_VIEW.startChat(...)` opens a new session with the prompt prefilled-but-unsent in the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom collection views can now initiate chat sessions with pre-filled prompts as editable drafts without auto-sending

* **Documentation**
  * Updated custom view documentation to describe the new chat initiation capability and behavioral constraints

* **Tests**
  * Added verification for the new chat bridge functionality

* **Chores**
  * Version bumps for collection-plugin and workspace-setup packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->