### PR TITLE
feat(collections): chat about a specific record from the open-item view

### DIFF
--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Schema-driven Collections plugin (presentCollection) — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal. This entry is the isomorphic collection engine (derive / formula / visibility); Vue surfaces land in ./vue.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
@@ -207,6 +207,7 @@
                           v-else
                           v-model="row.text[subKey]"
                           :type="render.inputTypeFor(subField.type)"
+                          :step="render.stepFor(subField.type)"
                           :required="subField.required"
                           class="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs focus:border-indigo-500 focus:outline-none font-medium text-slate-700"
                         />
@@ -260,6 +261,7 @@
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
               :type="render.inputTypeFor(field.type)"
+              :step="render.stepFor(field.type)"
               :required="isFieldRequiredInUi(field)"
               :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
               class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
@@ -434,11 +434,43 @@
         {{ saveError }}
       </p>
     </div>
+
+    <!-- Chat about THIS record (read-only mode only): seeds a new chat with the
+         collection's skill command scoped to the open item
+         (`/<slug> id=<itemId> <message>`). The parent owns the slug/id + send
+         path; this just collects the user's message. -->
+    <div v-if="!editing" class="mt-5 pt-4 border-t border-slate-200/60" data-testid="collections-detail-chat">
+      <label class="block text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1.5" for="collections-detail-chat-input">
+        {{ t("collectionsView.itemChatLabel") }}
+      </label>
+      <div class="flex items-end gap-2">
+        <textarea
+          id="collections-detail-chat-input"
+          v-model="chatMessage"
+          rows="2"
+          :placeholder="t('collectionsView.itemChatPlaceholder')"
+          class="flex-1 bg-slate-50 border border-slate-200/80 rounded-xl px-3 py-2 text-xs placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 focus:bg-white transition-all resize-none"
+          data-testid="collections-detail-chat-input"
+          @keydown.meta.enter="submitItemChat"
+          @keydown.ctrl.enter="submitItemChat"
+        ></textarea>
+        <button
+          type="button"
+          class="h-8 px-2.5 rounded bg-indigo-600 text-white font-bold text-xs hover:bg-indigo-700 disabled:opacity-50 transition-all shadow-sm shadow-indigo-600/10 flex items-center gap-1 shrink-0"
+          :disabled="!chatMessage.trim()"
+          data-testid="collections-detail-chat-send"
+          @click="submitItemChat"
+        >
+          <span class="material-icons text-sm">forum</span>
+          <span>{{ t("collectionsView.chat") }}</span>
+        </button>
+      </div>
+    </div>
   </component>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import { useCollectionI18n } from "../lang";
 import CollectionEmbedView from "./CollectionEmbedView.vue";
 import { fieldVisible } from "../../core/actionVisible";
@@ -489,9 +521,29 @@ const emit = defineEmits<{
   close: [];
   delete: [];
   runAction: [action: CollectionAction];
+  /** The user typed a message in the per-record chat box and hit Chat — the
+   *  parent seeds a new chat scoped to the open record. */
+  itemChat: [message: string];
 }>();
 
 const { t } = useCollectionI18n();
+
+// Per-record chat draft. Cleared when the open record changes so a message
+// typed for one record never carries over to the next.
+const chatMessage = ref("");
+watch(
+  () => props.viewing,
+  () => {
+    chatMessage.value = "";
+  },
+);
+
+function submitItemChat(): void {
+  const message = chatMessage.value.trim();
+  if (!message) return;
+  emit("itemChat", message);
+  chatMessage.value = "";
+}
 
 // `embedViews` is a ComputedRef nested in the `render` object, so it isn't
 // auto-unwrapped in the template — re-expose it as a top-level computed.

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -347,6 +347,7 @@
               @close="onDayClose"
               @delete="viewing && confirmDelete(viewing)"
               @run-action="runAction"
+              @item-chat="onItemChat"
             />
           </template>
         </CollectionDayView>
@@ -637,6 +638,7 @@
         @close="closeView"
         @delete="viewing && confirmDelete(viewing)"
         @run-action="runAction"
+        @item-chat="onItemChat"
       />
     </CollectionRecordModal>
 
@@ -1205,14 +1207,17 @@ function closeChat(): void {
  *  nothing. Instead, point the agent at the feed's schema + records
  *  (`feeds/<slug>/schema.json` and `<dataPath>/`) and let it act on the
  *  request directly. */
-function buildChatSeed(slug: string, message: string): string {
+function buildChatSeed(slug: string, message: string, itemId?: string): string {
   const schema = collection.value?.schema;
   // A feed carries an `ingest` block; a plain collection does not. Checked
   // here (rather than via the `isFeed` computed, defined further down) to
   // keep this helper self-contained and avoid a use-before-define.
-  if (!schema?.ingest) return `/${slug} ${message}`;
+  if (!schema?.ingest) return itemId ? `/${slug} id=${itemId} ${message}` : `/${slug} ${message}`;
   const dataPath = schema.dataPath ?? `data/feeds/${slug}`;
-  return t("collectionsView.feedChatSeed", { slug, dataPath, message });
+  // A feed has no skill command — point the agent at a specific record by id
+  // inside the same schema-driven seed.
+  const scoped = itemId ? `(for record \`${itemId}\`) ${message}` : message;
+  return t("collectionsView.feedChatSeed", { slug, dataPath, message: scoped });
 }
 
 /** Start a new general-role chat seeded from the current view. */
@@ -1228,6 +1233,23 @@ function submitChat(): void {
     return;
   }
   appApi.startNewChat(text, cui.generalRoleId);
+}
+
+/** The open record's chat box: start a chat scoped to that one record. Seeds
+ *  the collection's skill command with an `id=<itemId>` selector
+ *  (`/<slug> id=<itemId> <message>`) so the agent acts on this record. */
+function onItemChat(message: string): void {
+  if (!collection.value || !viewing.value) return;
+  const text = message.trim();
+  if (!text) return;
+  const itemId = String(viewing.value[collection.value.schema.primaryKey] ?? "");
+  const seed = buildChatSeed(collection.value.slug, text, itemId || undefined);
+  // Chat card → send into the current session; standalone → new chat.
+  if (props.sendTextMessage) {
+    props.sendTextMessage(seed);
+    return;
+  }
+  appApi.startNewChat(seed, cui.generalRoleId);
 }
 
 async function loadCollection(slug: string): Promise<void> {

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -52,6 +52,8 @@ const deMessages: CollectionMessages = {
     chatTitle: "Chat starten",
     chatPlaceholder: "Beschreibe, was du mit dieser Sammlung tun möchtest…",
     chatStart: "Chat starten",
+    itemChatLabel: "Über diesen Eintrag chatten",
+    itemChatPlaceholder: "Stelle eine Frage oder gib eine Anweisung zu diesem Eintrag…",
     viewToggle: "Ansicht",
     viewTable: "Tabelle",
     viewCalendar: "Kalender",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -50,6 +50,8 @@ const enMessages = {
     chatTitle: "Start a chat",
     chatPlaceholder: "Describe what you want to do with this collection…",
     chatStart: "Start chat",
+    itemChatLabel: "Chat about this record",
+    itemChatPlaceholder: "Ask or instruct about this record…",
     viewToggle: "View",
     viewTable: "Table",
     viewCalendar: "Calendar",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -52,6 +52,8 @@ const esMessages: CollectionMessages = {
     chatTitle: "Iniciar un chat",
     chatPlaceholder: "Describe qué quieres hacer con esta colección…",
     chatStart: "Iniciar chat",
+    itemChatLabel: "Chatear sobre este registro",
+    itemChatPlaceholder: "Pregunta o indica algo sobre este registro…",
     viewToggle: "Vista",
     viewTable: "Tabla",
     viewCalendar: "Calendario",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -53,6 +53,8 @@ const frMessages: CollectionMessages = {
     chatTitle: "Démarrer une discussion",
     chatPlaceholder: "Décrivez ce que vous voulez faire avec cette collection…",
     chatStart: "Démarrer la discussion",
+    itemChatLabel: "Discuter de cet enregistrement",
+    itemChatPlaceholder: "Posez une question ou donnez une instruction sur cet enregistrement…",
     viewToggle: "Affichage",
     viewTable: "Tableau",
     viewCalendar: "Calendrier",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -52,6 +52,8 @@ const jaMessages: CollectionMessages = {
     chatTitle: "チャットを開始",
     chatPlaceholder: "このコレクションで行いたいことを入力してください…",
     chatStart: "チャットを開始",
+    itemChatLabel: "このレコードについてチャット",
+    itemChatPlaceholder: "このレコードについて質問・指示する…",
     viewToggle: "表示",
     viewTable: "テーブル",
     viewCalendar: "カレンダー",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -52,6 +52,8 @@ const koMessages: CollectionMessages = {
     chatTitle: "채팅 시작",
     chatPlaceholder: "이 컬렉션으로 하고 싶은 작업을 설명하세요…",
     chatStart: "채팅 시작",
+    itemChatLabel: "이 레코드에 대해 채팅",
+    itemChatPlaceholder: "이 레코드에 대해 질문하거나 지시하세요…",
     viewToggle: "보기",
     viewTable: "표",
     viewCalendar: "캘린더",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -52,6 +52,8 @@ const ptBRMessages: CollectionMessages = {
     chatTitle: "Iniciar um chat",
     chatPlaceholder: "Descreva o que você quer fazer com esta coleção…",
     chatStart: "Iniciar chat",
+    itemChatLabel: "Conversar sobre este registro",
+    itemChatPlaceholder: "Pergunte ou instrua sobre este registro…",
     viewToggle: "Visualização",
     viewTable: "Tabela",
     viewCalendar: "Calendário",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -52,6 +52,8 @@ const zhMessages: CollectionMessages = {
     chatTitle: "开始对话",
     chatPlaceholder: "描述你想对这个集合做什么…",
     chatStart: "开始对话",
+    itemChatLabel: "就此记录对话",
+    itemChatPlaceholder: "询问或指示有关此记录的操作…",
     viewToggle: "视图",
     viewTable: "表格",
     viewCalendar: "日历",

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
@@ -44,6 +44,7 @@ export interface CollectionRendering {
   hasTableRows: (value: unknown) => boolean;
   formatSubCell: (subField: FieldSpec, value: unknown, record: CollectionItem | null) => string;
   inputTypeFor: (type: FieldType) => string;
+  stepFor: (type: FieldType) => string | undefined;
   deriveAll: (schema: CollectionSchema, base: CollectionItem, refRecords: RefRecordCache) => CollectionItem;
   evaluateDerivedAgainstItem: (field: FieldSpec, fieldKey: string, item: CollectionItem) => number | null;
   derivedDisplay: (field: FieldSpec, computedValue: unknown, record: CollectionItem | null) => string;
@@ -278,6 +279,15 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return "text";
   }
 
+  // `<input type="number">` defaults to step="1", which makes the browser
+  // reject any decimal value (e.g. 0.1) as invalid. Emit step="any" for
+  // numeric fields so fractional values can be entered and saved.
+  function stepFor(type: FieldType): string | undefined {
+    if (type === "money") return "0.01";
+    if (type === "number") return "any";
+    return undefined;
+  }
+
   // The derive loop itself lives in `utils/collections/deriveAll.ts`,
   // shared with the server's manageCollection enrichment so both sides
   // compute identical values. This composable re-exposes it (typed with
@@ -318,6 +328,7 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     hasTableRows,
     formatSubCell,
     inputTypeFor,
+    stepFor,
     deriveAll,
     evaluateDerivedAgainstItem,
     derivedDisplay,

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
@@ -50,6 +50,15 @@ export interface CollectionRendering {
   derivedDisplay: (field: FieldSpec, computedValue: unknown, record: CollectionItem | null) => string;
 }
 
+// `<input type="number">` defaults to step="1", which makes the browser
+// reject any decimal value (e.g. 0.1) as invalid. Emit step="any" for
+// numeric fields so fractional values can be entered and saved.
+export function stepForFieldType(type: FieldType): string | undefined {
+  if (type === "money") return "0.01";
+  if (type === "number") return "any";
+  return undefined;
+}
+
 export function useCollectionRendering(collection: Ref<CollectionDetail | null>, locale: Ref<string>): CollectionRendering {
   const refCache = ref<RefCache>({});
   const refRecordCache = ref<RefRecordCache>({});
@@ -279,14 +288,7 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return "text";
   }
 
-  // `<input type="number">` defaults to step="1", which makes the browser
-  // reject any decimal value (e.g. 0.1) as invalid. Emit step="any" for
-  // numeric fields so fractional values can be entered and saved.
-  function stepFor(type: FieldType): string | undefined {
-    if (type === "money") return "0.01";
-    if (type === "number") return "any";
-    return undefined;
-  }
+  const stepFor = stepForFieldType;
 
   // The derive loop itself lives in `utils/collections/deriveAll.ts`,
   // shared with the server's manageCollection enrichment so both sides


### PR DESCRIPTION
## Summary

Adds a **text input + Chat button at the bottom of the open-item (record detail) view**. Typing a message and pressing Chat starts a new chat seeded with the collection's skill command scoped to that record:

```
/<slug> id=<itemId> <message>
```

This complements the recently added custom-view `openItem` / `startChat` bridges — now a record opened in the host's shared detail panel can also kick off a focused, record-scoped conversation.

## Changes

- **`CollectionRecordPanel.vue`** — chat box at the bottom, gated to read-only mode (`v-if="!editing"`) so it never shows while editing/creating. `textarea` with ⌘/Ctrl+Enter to send + a **Chat** button (disabled while empty). Local draft auto-clears when the open record changes (watch on `viewing`). The panel only collects text and emits `itemChat`; the parent owns the slug/id and send path.
- **`CollectionView.vue`** — wires `@item-chat="onItemChat"` on **both** panel mounts (shared modal + calendar day-view popup). New `onItemChat` reads the open record's `primaryKey` and routes the seed the same way the existing collection-level chat does (`sendTextMessage` into the current session when mounted as a chat card, else a new general-role chat). `buildChatSeed` gains an optional `itemId`:
  - skill collection → `/<slug> id=<itemId> <message>`
  - feed (no skill) → folds the id into the existing schema-pointing seed
- **i18n** — `itemChatLabel` + `itemChatPlaceholder` added and translated across all 8 plugin locales (`en, ja, zh, ko, es, pt-BR, fr, de`), in matching key order.

## Testids

`collections-detail-chat`, `collections-detail-chat-input`, `collections-detail-chat-send`.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, and `yarn build` all pass (host app + `@mulmoclaude/collection-plugin` package build, which runs `vue-tsc` over the i18n key set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only, per-record “chat about THIS record” UI with Enter/Send submission, emitting the chat message scoped to the currently viewed record.
  * Chat draft now resets when switching records.
* **Localization**
  * Added the chat label and placeholder text to collection view translations in English, German, Spanish, French, Japanese, Korean, Portuguese (Brazil), and Chinese.
* **Improvements**
  * Updated numeric input rendering to use a field-type-based `step` helper (e.g., for money/number fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->