### PR TITLE
fix(attachments): close 'pre-write safeResolve on not-yet-written path' bug class

### DIFF
--- a/plans/fix-attachment-companion-traversal.md
+++ b/plans/fix-attachment-companion-traversal.md
@@ -42,6 +42,17 @@ await saveCompanion(original.relativePath, Buffer.from("%PDF-1.4\n%%EOF\n"), ".p
 // throws — bug reproduced
 ```
 
+Diagrammed:
+
+```text
+saveCompanion("data/attachments/YYYY/MM/<id>.pptx", buf, ".pdf")
+  → derives target "data/attachments/YYYY/MM/<id>.pdf"  (does not exist)
+  → safeResolve  → resolveWithinRoot  → realpathSync(target)
+                                       ↑ ENOENT (leaf missing)
+                                     → null
+  → "path traversal rejected: data/attachments/YYYY/MM/<id>.pdf"
+```
+
 ## Fix layers
 
 ### Layer 1 — `resolveWriteWithinRoot` in `safe.ts`
@@ -81,8 +92,10 @@ bug.
 
 ## Tests
 
-- `test/utils/files/test_safe.ts` (new) — `resolveWriteWithinRoot`: happy
-  path, traversal segment, absolute path, NUL, symlink-escape via parent.
+- `test/utils/files/test_safe_write.ts` (new) — `resolveWriteWithinRoot`:
+  happy path, traversal segment, absolute path, NUL, double slash, Windows
+  drive-relative, symlink-escape via parent, symlink-escape via intermediate
+  ancestor.
 - `test/utils/files/test_attachment_store.ts` (new) — `saveCompanion`:
   companion lands under original's id + partition; traversal-shaped paths
   rejected; absolute path rejected.

--- a/plans/fix-attachment-companion-traversal.md
+++ b/plans/fix-attachment-companion-traversal.md
@@ -1,0 +1,94 @@
+# fix: close "pre-write safeResolve on not-yet-written path" bug class
+
+Tracks: #1754 (root-cause issue) — surfaces as #1744 (PPTX upload symptom).
+
+## Symptom
+
+Uploading a `.pptx` whenever LibreOffice / Docker sandbox is available throws
+`path traversal rejected: data/attachments/YYYY/MM/<id>.pdf`.
+
+## Root cause
+
+`server/utils/files/safe.ts::resolveWithinRoot()` is a **read-time** primitive:
+its boundary check is `realpathSync(resolved)`, which throws `ENOENT` on a
+missing leaf. The `try`/`catch` swallows ENOENT and a genuine traversal escape
+into the same `null` return.
+
+`server/utils/files/attachment-store.ts::saveCompanion()` calls this via
+`safeResolve()` **before writing the PDF**:
+
+```
+relativePath = "data/attachments/YYYY/MM/<id>.pdf"   ← not on disk yet
+safeResolve(relativePath)
+  → resolveWithinRoot(root, "YYYY/MM/<id>.pdf")
+  → realpathSync(...)  → ENOENT
+  → null
+→ throws "path traversal rejected: <path>"
+```
+
+PPTX is the only current patient because every other writer either uses
+`path.join` directly (`saveAttachment`, `saveImage`, `saveSpreadsheet`) or
+operates on already-existing files (`overwriteImage`, `overwriteSpreadsheet`,
+all `loadXxx`). But `safeResolve` is name-cloned across three stores with no
+hint that "write" is unsafe, so the next companion-style writer would hit it.
+
+## Repro (no LibreOffice / Docker)
+
+```ts
+process.env.MULMOCLAUDE_WORKSPACE_PATH = await mkdtemp(path.join(tmpdir(), "x-"));
+const { saveAttachment, saveCompanion } = await import("…/attachment-store.ts");
+const original = await saveAttachment(Buffer.from("x").toString("base64"), PPTX_MIME);
+await saveCompanion(original.relativePath, Buffer.from("%PDF-1.4\n%%EOF\n"), ".pdf");
+// throws — bug reproduced
+```
+
+## Fix layers
+
+### Layer 1 — `resolveWriteWithinRoot` in `safe.ts`
+
+Write-time sibling of `resolveWithinRoot`:
+
+- string-validate `relPath` (NUL, absolute, empty/`.`/`..` segments)
+- `mkdir -p` the parent dir inside `rootReal`
+- `realpath`-check the **parent** (leaf is about to be created)
+- return absolute write path or `null` on unsafe input
+
+Read-side `resolveWithinRoot` stays unchanged — ENOENT → null is correct for
+reads (delete races, dangling symlinks).
+
+### Layer 2 — `saveCompanion` uses Layer 1 + `writeFileAtomic`
+
+Replace `safeResolve(...)` with the write-time helper, and switch the raw
+`writeFile` to `writeFileAtomic` per CLAUDE.md "All writes go through
+`writeFileAtomic`".
+
+### C-2 — Share the per-store `safeResolve` wrapper
+
+`attachment-store`, `image-store`, `spreadsheet-store` each define an
+identically-shaped `safeResolve`. Replace all three with one factory in
+`server/utils/files/store-resolvers.ts`:
+
+```ts
+export function makeStoreResolvers(getRoot: () => string, dirPrefix: string): {
+  forRead: (rel: string) => Promise<string>;
+  forWrite: (rel: string) => Promise<string>;
+};
+```
+
+Naming the methods after the **side** they're safe on means a future
+companion-style writer reaches for `.forWrite` rather than re-creating the
+bug.
+
+## Tests
+
+- `test/utils/files/test_safe.ts` (new) — `resolveWriteWithinRoot`: happy
+  path, traversal segment, absolute path, NUL, symlink-escape via parent.
+- `test/utils/files/test_attachment_store.ts` (new) — `saveCompanion`:
+  companion lands under original's id + partition; traversal-shaped paths
+  rejected; absolute path rejected.
+
+## Out of scope
+
+- `saveAttachment` / `saveImage` / `saveSpreadsheet`: server-generated paths,
+  no security gain from extra realpath syscall.
+- Read-time semantics of `resolveWithinRoot`: unchanged.

--- a/server/utils/files/attachment-store.ts
+++ b/server/utils/files/attachment-store.ts
@@ -10,40 +10,15 @@
 //   data/attachments/YYYY/MM/<id>.<ext>            (original, always)
 //   data/attachments/YYYY/MM/<id>.pdf              (companion, PPTX only — same <id>)
 
-import { mkdir, readFile, realpath, writeFile } from "fs/promises";
+import { readFile } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
 import { writeFileAtomic } from "./atomic.js";
 import { yearMonthUtc } from "./naming.js";
-import { resolveWithinRoot } from "./safe.js";
+import { makeStoreResolvers } from "./store-resolvers.js";
 
-// Cache the real-path resolution per workspace root so test setups
-// that override `WORKSPACE_PATHS.attachments` mid-run still work —
-// reading the path at call time (instead of capturing it at module
-// load) means a test that points the workspace at a tmp dir
-// recomputes everything from there.
-const attachmentsDirRealByRoot = new Map<string, string>();
-
-async function ensureAttachmentsDir(): Promise<string> {
-  const root = WORKSPACE_PATHS.attachments;
-  const cached = attachmentsDirRealByRoot.get(root);
-  if (cached) return cached;
-  await mkdir(root, { recursive: true });
-  const real = await realpath(root);
-  attachmentsDirRealByRoot.set(root, real);
-  return real;
-}
-
-async function safeResolve(relativePath: string): Promise<string> {
-  const root = await ensureAttachmentsDir();
-  const name = relativePath.replace(new RegExp(`^${WORKSPACE_DIRS.attachments}/`), "");
-  const result = resolveWithinRoot(root, name);
-  if (!result) {
-    throw new Error(`path traversal rejected: ${relativePath}`);
-  }
-  return result;
-}
+const resolvers = makeStoreResolvers(() => WORKSPACE_PATHS.attachments, WORKSPACE_DIRS.attachments);
 
 // MIME ↔ extension mapping. Kept narrow on purpose — anything not
 // in this table falls back to `.bin` so we don't have to guess.
@@ -167,7 +142,6 @@ async function runSaveAttachmentHooks(absPath: string, relativePath: string, mim
  *  caller picks the ID; companions (e.g. PPTX → PDF) reuse it via
  *  `saveCompanion()` so they share the same numeric prefix. */
 export async function saveAttachment(base64Data: string, mimeType: string): Promise<SavedAttachment> {
-  await ensureAttachmentsDir();
   const partition = yearMonthUtc();
   const ext = extensionForMime(mimeType);
   const filename = `${shortId()}${ext}`;
@@ -189,26 +163,22 @@ export async function saveAttachment(base64Data: string, mimeType: string): Prom
  *  raw Buffer — the converter already has bytes in hand and base64
  *  re-encoding would be wasted work. */
 export async function saveCompanion(originalRelativePath: string, buf: Buffer, ext: string): Promise<string> {
-  await ensureAttachmentsDir();
   const dir = path.posix.dirname(originalRelativePath);
   const base = path.posix.basename(originalRelativePath, path.posix.extname(originalRelativePath));
-  const filename = `${base}${ext}`;
-  const relativePath = path.posix.join(dir, filename);
-  const absPath = await safeResolve(relativePath);
-  // mkdir-p inside safeResolve's confined root.
-  await mkdir(path.dirname(absPath), { recursive: true });
-  await writeFile(absPath, buf);
+  const relativePath = path.posix.join(dir, `${base}${ext}`);
+  const absPath = await resolvers.forWrite(relativePath);
+  await writeFileAtomic(absPath, buf);
   return relativePath;
 }
 
 export async function loadAttachmentBase64(relativePath: string): Promise<string> {
-  const absPath = await safeResolve(relativePath);
+  const absPath = await resolvers.forRead(relativePath);
   const buf = await readFile(absPath);
   return buf.toString("base64");
 }
 
 export async function loadAttachmentBytes(relativePath: string): Promise<Buffer> {
-  const absPath = await safeResolve(relativePath);
+  const absPath = await resolvers.forRead(relativePath);
   return readFile(absPath);
 }
 

--- a/server/utils/files/image-store.ts
+++ b/server/utils/files/image-store.ts
@@ -1,51 +1,29 @@
-import { mkdir, readFile, realpath } from "fs/promises";
+import { readFile } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
 import { writeFileAtomic } from "./atomic.js";
 import { yearMonthUtc } from "./naming.js";
-import { resolveWithinRoot } from "./safe.js";
+import { makeStoreResolvers } from "./store-resolvers.js";
 
-const IMAGES_DIR = WORKSPACE_PATHS.images;
-
-// resolveWithinRoot needs a realpath as its root so symlinks resolve correctly.
-let imagesDirReal: string | null = null;
-
-async function ensureImagesDir(): Promise<string> {
-  if (imagesDirReal) return imagesDirReal;
-  await mkdir(IMAGES_DIR, { recursive: true });
-  imagesDirReal = await realpath(IMAGES_DIR);
-  return imagesDirReal;
-}
-
-// Throws on traversal. Strips a leading "images/" so callers can pass either the stored form or bare filename.
-async function safeResolve(relativePath: string): Promise<string> {
-  const root = await ensureImagesDir();
-  const name = relativePath.replace(new RegExp(`^${WORKSPACE_DIRS.images}/`), "");
-  const result = resolveWithinRoot(root, name);
-  if (!result) {
-    throw new Error(`path traversal rejected: ${relativePath}`);
-  }
-  return result;
-}
+const resolvers = makeStoreResolvers(() => WORKSPACE_PATHS.images, WORKSPACE_DIRS.images);
 
 // #764 sharded under images/YYYY/MM/ (UTC). Buffer pass-through avoids re-encoding the PNG bytes.
 export async function saveImage(base64Data: string): Promise<string> {
-  await ensureImagesDir();
   const partition = yearMonthUtc();
   const filename = `${shortId()}.png`;
-  const absPath = path.join(IMAGES_DIR, partition, filename);
+  const absPath = path.join(WORKSPACE_PATHS.images, partition, filename);
   await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));
   return path.posix.join(WORKSPACE_DIRS.images, partition, filename);
 }
 
 export async function overwriteImage(relativePath: string, base64Data: string): Promise<void> {
-  const absPath = await safeResolve(relativePath);
+  const absPath = await resolvers.forWrite(relativePath);
   await writeFileAtomic(absPath, Buffer.from(base64Data, "base64"));
 }
 
 export async function loadImageBase64(relativePath: string): Promise<string> {
-  const absPath = await safeResolve(relativePath);
+  const absPath = await resolvers.forRead(relativePath);
   const buf = await readFile(absPath);
   return buf.toString("base64");
 }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -102,3 +102,36 @@ export function resolveWithinRoot(rootReal: string, relPath: string): string | n
   }
   return resolvedReal;
 }
+
+// Write-time sibling of `resolveWithinRoot`. `resolveWithinRoot`
+// runs `realpathSync` on the full path which throws `ENOENT` for a
+// leaf that does not exist yet — fine for reads, but the swallowed
+// ENOENT is indistinguishable from a traversal escape, so callers
+// pre-validating a not-yet-written path get a false "rejected".
+//
+// This variant string-validates `relPath` first, mkdir-p's the
+// parent inside `rootReal`, then realpath-checks the parent (the
+// existing dir) instead of the leaf. Returns the absolute write
+// path or null on any unsafe input. Caller still does the actual
+// write (typically `writeFileAtomic`).
+export async function resolveWriteWithinRoot(rootReal: string, relPath: string): Promise<string | null> {
+  if (!relPath || relPath.includes("\0") || path.isAbsolute(relPath)) return null;
+  const segments = relPath.split(/[/\\]/);
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) return null;
+  const leaf = segments[segments.length - 1];
+  const parentRel = segments.slice(0, -1).join(path.sep);
+  const parentAbs = path.resolve(rootReal, parentRel);
+  try {
+    await promises.mkdir(parentAbs, { recursive: true });
+  } catch {
+    return null;
+  }
+  let parentReal: string;
+  try {
+    parentReal = await promises.realpath(parentAbs);
+  } catch {
+    return null;
+  }
+  if (parentReal !== rootReal && !parentReal.startsWith(rootReal + path.sep)) return null;
+  return path.join(parentReal, leaf);
+}

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -111,10 +111,6 @@ export function resolveWithinRoot(rootReal: string, relPath: string): string | n
 // stage explicitly.
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:/;
 
-function isPathInsideRoot(candidate: string, rootReal: string): boolean {
-  return candidate === rootReal || candidate.startsWith(rootReal + path.sep);
-}
-
 function parseWriteSegments(relPath: string): { parentSegments: string[]; leaf: string } | null {
   if (!relPath || relPath.includes("\0") || path.isAbsolute(relPath) || WINDOWS_DRIVE_RE.test(relPath)) return null;
   const segments = relPath.split(/[/\\]/);
@@ -122,24 +118,32 @@ function parseWriteSegments(relPath: string): { parentSegments: string[]; leaf: 
   return { parentSegments: segments.slice(0, -1), leaf: segments[segments.length - 1] };
 }
 
+// `path.relative(root, candidate)` returns a string starting with
+// `..` if `candidate` escapes `root`. This is the canonical CodeQL
+// `js/path-injection` sanitizer pattern; using it (rather than the
+// equivalent `startsWith(root + sep)`) lets the data-flow analysis
+// recognize the lexical containment check as a sanitizer.
+function escapesRoot(rootReal: string, candidate: string): boolean {
+  const relative = path.relative(rootReal, candidate);
+  return relative.startsWith("..") || path.isAbsolute(relative);
+}
+
 // Walk rootReal → parent, realpath-checking every existing ancestor.
 // Returns false if any existing ancestor escapes root via symlink. The
 // first non-existing ancestor marks the boundary: every directory
 // below sits under verified-in-root soil and is safe to `mkdir -p`.
 //
-// The lexical `startsWith` check before `realpath` is redundant at
+// The lexical `escapesRoot` check before `realpath` is redundant at
 // runtime (parseWriteSegments rejects `..` / `.` / absolute /
 // Windows-drive inputs, so `path.resolve(rootReal, segment)` cannot
-// escape lexically) but is inlined so CodeQL's `js/path-injection`
-// data-flow analysis recognizes the standard root-prefix sanitizer
-// pattern. Two layers also catch the rare case of `rootReal`
-// containing unusual normalization edges.
+// escape lexically) but is required so CodeQL's data-flow analysis
+// recognizes the `path.relative` sanitizer pattern on every iteration
+// before the realpath sink.
 async function existingAncestorsStayInRoot(rootReal: string, parentSegments: string[]): Promise<boolean> {
-  const rootPrefix = rootReal + path.sep;
   let cursor = rootReal;
   for (const segment of parentSegments) {
     const candidate = path.resolve(cursor, segment);
-    if (candidate !== rootReal && !candidate.startsWith(rootPrefix)) return false;
+    if (escapesRoot(rootReal, candidate)) return false;
     let candidateReal: string;
     try {
       candidateReal = await promises.realpath(candidate);
@@ -147,7 +151,7 @@ async function existingAncestorsStayInRoot(rootReal: string, parentSegments: str
       if (isEnoent(err)) return true;
       throw err;
     }
-    if (candidateReal !== rootReal && !candidateReal.startsWith(rootPrefix)) return false;
+    if (escapesRoot(rootReal, candidateReal)) return false;
     cursor = candidateReal;
   }
   return true;
@@ -169,8 +173,9 @@ export async function resolveWriteWithinRoot(rootReal: string, relPath: string):
   if (!parsed) return null;
   if (!(await existingAncestorsStayInRoot(rootReal, parsed.parentSegments))) return null;
   const parentAbs = path.resolve(rootReal, parsed.parentSegments.join(path.sep));
+  if (escapesRoot(rootReal, parentAbs)) return null;
   await promises.mkdir(parentAbs, { recursive: true });
   const parentReal = await promises.realpath(parentAbs);
-  if (!isPathInsideRoot(parentReal, rootReal)) return null;
+  if (escapesRoot(rootReal, parentReal)) return null;
   return path.join(parentReal, parsed.leaf);
 }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -103,35 +103,66 @@ export function resolveWithinRoot(rootReal: string, relPath: string): string | n
   return resolvedReal;
 }
 
+// `C:foo`, `c:relative\path` — Windows drive-qualified RELATIVE paths.
+// `path.isAbsolute` returns false (they're relative to the drive's CWD,
+// not absolute), but `path.resolve(rootReal, "C:foo")` resolves onto
+// drive C: instead of staying under `rootReal`. POSIX-only repros
+// cannot trigger it, so it has to be caught at the string-validation
+// stage explicitly.
+const WINDOWS_DRIVE_RE = /^[a-zA-Z]:/;
+
 // Write-time sibling of `resolveWithinRoot`. `resolveWithinRoot`
 // runs `realpathSync` on the full path which throws `ENOENT` for a
 // leaf that does not exist yet — fine for reads, but the swallowed
 // ENOENT is indistinguishable from a traversal escape, so callers
 // pre-validating a not-yet-written path get a false "rejected".
 //
-// This variant string-validates `relPath` first, mkdir-p's the
-// parent inside `rootReal`, then realpath-checks the parent (the
-// existing dir) instead of the leaf. Returns the absolute write
-// path or null on any unsafe input. Caller still does the actual
-// write (typically `writeFileAtomic`).
+// Algorithm:
+//   1. String-validate `relPath` (NUL / absolute / Windows drive
+//      relative / empty / "."/"..").
+//   2. Walk the parent's ancestors from `rootReal` downward; at every
+//      already-existing ancestor, realpath it and confirm it is still
+//      inside `rootReal`. Reject as soon as an ancestor escapes —
+//      BEFORE `mkdir -p` creates any directory, so a symlinked
+//      intermediate component cannot cause writes outside root.
+//   3. `mkdir -p` the parent (now provably safe — the unbuilt portion
+//      sits under a confirmed-in-root ancestor).
+//   4. Realpath the parent one more time as a defense-in-depth check.
+//
+// Returns `null` ONLY when the input itself is unsafe (string
+// validation failed or a verified ancestor escapes root). Filesystem
+// errors that are NOT security-related (`EACCES`, `EROFS`, …) are
+// propagated so the caller sees the real failure mode instead of a
+// misleading "path traversal rejected".
 export async function resolveWriteWithinRoot(rootReal: string, relPath: string): Promise<string | null> {
-  if (!relPath || relPath.includes("\0") || path.isAbsolute(relPath)) return null;
+  if (!relPath || relPath.includes("\0") || path.isAbsolute(relPath) || WINDOWS_DRIVE_RE.test(relPath)) return null;
   const segments = relPath.split(/[/\\]/);
   if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) return null;
   const leaf = segments[segments.length - 1];
-  const parentRel = segments.slice(0, -1).join(path.sep);
-  const parentAbs = path.resolve(rootReal, parentRel);
-  try {
-    await promises.mkdir(parentAbs, { recursive: true });
-  } catch {
-    return null;
+  const parentSegments = segments.slice(0, -1);
+  const parentAbs = path.resolve(rootReal, parentSegments.join(path.sep));
+
+  // Walk root → parent, realpath-checking every existing ancestor.
+  // The first ancestor that does not exist marks the "all directories
+  // below this point will be created by us under verified-in-root
+  // soil" boundary.
+  let cursor = rootReal;
+  for (const segment of parentSegments) {
+    cursor = path.join(cursor, segment);
+    let cursorReal: string;
+    try {
+      cursorReal = await promises.realpath(cursor);
+    } catch (err) {
+      if (isEnoent(err)) break;
+      throw err;
+    }
+    if (cursorReal !== rootReal && !cursorReal.startsWith(rootReal + path.sep)) return null;
+    cursor = cursorReal;
   }
-  let parentReal: string;
-  try {
-    parentReal = await promises.realpath(parentAbs);
-  } catch {
-    return null;
-  }
+
+  await promises.mkdir(parentAbs, { recursive: true });
+
+  const parentReal = await promises.realpath(parentAbs);
   if (parentReal !== rootReal && !parentReal.startsWith(rootReal + path.sep)) return null;
   return path.join(parentReal, leaf);
 }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -127,27 +127,28 @@ function parseWriteSegments(relPath: string): { parentSegments: string[]; leaf: 
 // first non-existing ancestor marks the boundary: every directory
 // below sits under verified-in-root soil and is safe to `mkdir -p`.
 //
-// The lexical `isPathInsideRoot` check before `realpath` is redundant
-// at runtime (parseWriteSegments already rejected `..` / `.` / absolute
-// / Windows-drive inputs, so `path.join(rootReal, segment)` cannot
-// escape lexically) — it is kept so CodeQL's data-flow analysis can
-// see the user-derived `cursor` is constrained inside `rootReal`
-// before the filesystem call. Two layers also catch the rare case of
-// rootReal containing unusual normalization edges.
+// The lexical `startsWith` check before `realpath` is redundant at
+// runtime (parseWriteSegments rejects `..` / `.` / absolute /
+// Windows-drive inputs, so `path.resolve(rootReal, segment)` cannot
+// escape lexically) but is inlined so CodeQL's `js/path-injection`
+// data-flow analysis recognizes the standard root-prefix sanitizer
+// pattern. Two layers also catch the rare case of `rootReal`
+// containing unusual normalization edges.
 async function existingAncestorsStayInRoot(rootReal: string, parentSegments: string[]): Promise<boolean> {
+  const rootPrefix = rootReal + path.sep;
   let cursor = rootReal;
   for (const segment of parentSegments) {
-    cursor = path.join(cursor, segment);
-    if (!isPathInsideRoot(cursor, rootReal)) return false;
-    let cursorReal: string;
+    const candidate = path.resolve(cursor, segment);
+    if (candidate !== rootReal && !candidate.startsWith(rootPrefix)) return false;
+    let candidateReal: string;
     try {
-      cursorReal = await promises.realpath(cursor);
+      candidateReal = await promises.realpath(candidate);
     } catch (err) {
       if (isEnoent(err)) return true;
       throw err;
     }
-    if (!isPathInsideRoot(cursorReal, rootReal)) return false;
-    cursor = cursorReal;
+    if (candidateReal !== rootReal && !candidateReal.startsWith(rootPrefix)) return false;
+    cursor = candidateReal;
   }
   return true;
 }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -111,41 +111,22 @@ export function resolveWithinRoot(rootReal: string, relPath: string): string | n
 // stage explicitly.
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:/;
 
-// Write-time sibling of `resolveWithinRoot`. `resolveWithinRoot`
-// runs `realpathSync` on the full path which throws `ENOENT` for a
-// leaf that does not exist yet — fine for reads, but the swallowed
-// ENOENT is indistinguishable from a traversal escape, so callers
-// pre-validating a not-yet-written path get a false "rejected".
-//
-// Algorithm:
-//   1. String-validate `relPath` (NUL / absolute / Windows drive
-//      relative / empty / "."/"..").
-//   2. Walk the parent's ancestors from `rootReal` downward; at every
-//      already-existing ancestor, realpath it and confirm it is still
-//      inside `rootReal`. Reject as soon as an ancestor escapes —
-//      BEFORE `mkdir -p` creates any directory, so a symlinked
-//      intermediate component cannot cause writes outside root.
-//   3. `mkdir -p` the parent (now provably safe — the unbuilt portion
-//      sits under a confirmed-in-root ancestor).
-//   4. Realpath the parent one more time as a defense-in-depth check.
-//
-// Returns `null` ONLY when the input itself is unsafe (string
-// validation failed or a verified ancestor escapes root). Filesystem
-// errors that are NOT security-related (`EACCES`, `EROFS`, …) are
-// propagated so the caller sees the real failure mode instead of a
-// misleading "path traversal rejected".
-export async function resolveWriteWithinRoot(rootReal: string, relPath: string): Promise<string | null> {
+function isPathInsideRoot(candidate: string, rootReal: string): boolean {
+  return candidate === rootReal || candidate.startsWith(rootReal + path.sep);
+}
+
+function parseWriteSegments(relPath: string): { parentSegments: string[]; leaf: string } | null {
   if (!relPath || relPath.includes("\0") || path.isAbsolute(relPath) || WINDOWS_DRIVE_RE.test(relPath)) return null;
   const segments = relPath.split(/[/\\]/);
   if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) return null;
-  const leaf = segments[segments.length - 1];
-  const parentSegments = segments.slice(0, -1);
-  const parentAbs = path.resolve(rootReal, parentSegments.join(path.sep));
+  return { parentSegments: segments.slice(0, -1), leaf: segments[segments.length - 1] };
+}
 
-  // Walk root → parent, realpath-checking every existing ancestor.
-  // The first ancestor that does not exist marks the "all directories
-  // below this point will be created by us under verified-in-root
-  // soil" boundary.
+// Walk rootReal → parent, realpath-checking every existing ancestor.
+// Returns false if any existing ancestor escapes root via symlink. The
+// first non-existing ancestor marks the boundary: every directory
+// below sits under verified-in-root soil and is safe to `mkdir -p`.
+async function existingAncestorsStayInRoot(rootReal: string, parentSegments: string[]): Promise<boolean> {
   let cursor = rootReal;
   for (const segment of parentSegments) {
     cursor = path.join(cursor, segment);
@@ -153,16 +134,33 @@ export async function resolveWriteWithinRoot(rootReal: string, relPath: string):
     try {
       cursorReal = await promises.realpath(cursor);
     } catch (err) {
-      if (isEnoent(err)) break;
+      if (isEnoent(err)) return true;
       throw err;
     }
-    if (cursorReal !== rootReal && !cursorReal.startsWith(rootReal + path.sep)) return null;
+    if (!isPathInsideRoot(cursorReal, rootReal)) return false;
     cursor = cursorReal;
   }
+  return true;
+}
 
+// Write-time sibling of `resolveWithinRoot`. `resolveWithinRoot`
+// runs `realpathSync` on the full path which throws `ENOENT` for a
+// leaf that does not exist yet — fine for reads, but the swallowed
+// ENOENT is indistinguishable from a traversal escape, so callers
+// pre-validating a not-yet-written path get a false "rejected".
+//
+// Returns `null` ONLY when the input itself is unsafe (string
+// validation failed or a verified ancestor escapes root). Filesystem
+// errors that are NOT security-related (`EACCES`, `EROFS`, …) are
+// propagated so the caller sees the real failure mode instead of a
+// misleading "path traversal rejected".
+export async function resolveWriteWithinRoot(rootReal: string, relPath: string): Promise<string | null> {
+  const parsed = parseWriteSegments(relPath);
+  if (!parsed) return null;
+  if (!(await existingAncestorsStayInRoot(rootReal, parsed.parentSegments))) return null;
+  const parentAbs = path.resolve(rootReal, parsed.parentSegments.join(path.sep));
   await promises.mkdir(parentAbs, { recursive: true });
-
   const parentReal = await promises.realpath(parentAbs);
-  if (parentReal !== rootReal && !parentReal.startsWith(rootReal + path.sep)) return null;
-  return path.join(parentReal, leaf);
+  if (!isPathInsideRoot(parentReal, rootReal)) return null;
+  return path.join(parentReal, parsed.leaf);
 }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -126,10 +126,19 @@ function parseWriteSegments(relPath: string): { parentSegments: string[]; leaf: 
 // Returns false if any existing ancestor escapes root via symlink. The
 // first non-existing ancestor marks the boundary: every directory
 // below sits under verified-in-root soil and is safe to `mkdir -p`.
+//
+// The lexical `isPathInsideRoot` check before `realpath` is redundant
+// at runtime (parseWriteSegments already rejected `..` / `.` / absolute
+// / Windows-drive inputs, so `path.join(rootReal, segment)` cannot
+// escape lexically) — it is kept so CodeQL's data-flow analysis can
+// see the user-derived `cursor` is constrained inside `rootReal`
+// before the filesystem call. Two layers also catch the rare case of
+// rootReal containing unusual normalization edges.
 async function existingAncestorsStayInRoot(rootReal: string, parentSegments: string[]): Promise<boolean> {
   let cursor = rootReal;
   for (const segment of parentSegments) {
     cursor = path.join(cursor, segment);
+    if (!isPathInsideRoot(cursor, rootReal)) return false;
     let cursorReal: string;
     try {
       cursorReal = await promises.realpath(cursor);

--- a/server/utils/files/spreadsheet-store.ts
+++ b/server/utils/files/spreadsheet-store.ts
@@ -1,46 +1,23 @@
-import { mkdir, realpath } from "fs/promises";
 import path from "path";
 import { WORKSPACE_DIRS, WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { shortId } from "../id.js";
 import { writeFileAtomic } from "./atomic.js";
 import { yearMonthUtc } from "./naming.js";
-import { resolveWithinRoot } from "./safe.js";
+import { makeStoreResolvers } from "./store-resolvers.js";
 
-const SPREADSHEETS_DIR = WORKSPACE_PATHS.spreadsheets;
-
-// resolveWithinRoot needs a realpath as its root so symlinks resolve correctly (same pattern as image-store).
-let spreadsheetsDirReal: string | null = null;
-
-async function ensureSpreadsheetsDir(): Promise<string> {
-  if (spreadsheetsDirReal) return spreadsheetsDirReal;
-  await mkdir(SPREADSHEETS_DIR, { recursive: true });
-  spreadsheetsDirReal = await realpath(SPREADSHEETS_DIR);
-  return spreadsheetsDirReal;
-}
-
-// Throws on traversal. Strips a leading "spreadsheets/" so callers can pass either the stored form or bare filename.
-async function safeResolve(relativePath: string): Promise<string> {
-  const root = await ensureSpreadsheetsDir();
-  const name = relativePath.replace(new RegExp(`^${WORKSPACE_DIRS.spreadsheets}/`), "");
-  const result = resolveWithinRoot(root, name);
-  if (!result) {
-    throw new Error(`path traversal rejected: ${relativePath}`);
-  }
-  return result;
-}
+const resolvers = makeStoreResolvers(() => WORKSPACE_PATHS.spreadsheets, WORKSPACE_DIRS.spreadsheets);
 
 // #764 sharded under spreadsheets/YYYY/MM/ (UTC) so the dir doesn't grow unbounded; #881 atomic.
 export async function saveSpreadsheet(sheets: unknown[]): Promise<string> {
-  await ensureSpreadsheetsDir();
   const partition = yearMonthUtc();
   const filename = `${shortId()}.json`;
-  const absPath = path.join(SPREADSHEETS_DIR, partition, filename);
+  const absPath = path.join(WORKSPACE_PATHS.spreadsheets, partition, filename);
   await writeFileAtomic(absPath, JSON.stringify(sheets));
   return path.posix.join(WORKSPACE_DIRS.spreadsheets, partition, filename);
 }
 
 export async function overwriteSpreadsheet(relativePath: string, sheets: unknown[]): Promise<void> {
-  const absPath = await safeResolve(relativePath);
+  const absPath = await resolvers.forWrite(relativePath);
   await writeFileAtomic(absPath, JSON.stringify(sheets));
 }
 

--- a/server/utils/files/store-resolvers.ts
+++ b/server/utils/files/store-resolvers.ts
@@ -1,0 +1,58 @@
+// Shared resolver factory for file-store modules (attachment-store,
+// image-store, spreadsheet-store). Each store used to define its own
+// `safeResolve(relativePath)` wrapper of identical shape: ensure the
+// root dir exists, cache its realpath, strip the leading store
+// prefix, hand off to `resolveWithinRoot`. That left three name-cloned
+// `safeResolve` functions that all looked read-only but two of them
+// were also being used for writes — see #1754 / #1744.
+//
+// `makeStoreResolvers` collapses the three copies into one and
+// exposes the read/write split through method names. A caller that
+// wants to write reaches for `.forWrite`, which routes through the
+// write-time confinement primitive instead of the read-time one.
+
+import { mkdir, realpath } from "fs/promises";
+import { resolveWithinRoot, resolveWriteWithinRoot } from "./safe.js";
+
+export interface StoreResolvers {
+  forRead: (relativePath: string) => Promise<string>;
+  forWrite: (relativePath: string) => Promise<string>;
+}
+
+// Cache realpath per absolute root, not per factory instance — test
+// setups override `WORKSPACE_PATHS.<dir>` mid-run, so capturing the
+// path at factory-call time would pin every store to the original
+// workspace. Re-reading via `getRoot()` and keying the cache on the
+// returned absolute path means each tmp workspace gets its own entry.
+const realPathCacheByRoot = new Map<string, string>();
+
+async function ensureRoot(getRoot: () => string): Promise<string> {
+  const root = getRoot();
+  const cached = realPathCacheByRoot.get(root);
+  if (cached) return cached;
+  await mkdir(root, { recursive: true });
+  const real = await realpath(root);
+  realPathCacheByRoot.set(root, real);
+  return real;
+}
+
+function stripDirPrefix(relativePath: string, dirPrefix: string): string {
+  return relativePath.replace(new RegExp(`^${dirPrefix}/`), "");
+}
+
+export function makeStoreResolvers(getRoot: () => string, dirPrefix: string): StoreResolvers {
+  return {
+    forRead: async (relativePath) => {
+      const root = await ensureRoot(getRoot);
+      const result = resolveWithinRoot(root, stripDirPrefix(relativePath, dirPrefix));
+      if (!result) throw new Error(`path traversal rejected: ${relativePath}`);
+      return result;
+    },
+    forWrite: async (relativePath) => {
+      const root = await ensureRoot(getRoot);
+      const result = await resolveWriteWithinRoot(root, stripDirPrefix(relativePath, dirPrefix));
+      if (!result) throw new Error(`path traversal rejected: ${relativePath}`);
+      return result;
+    },
+  };
+}

--- a/test/routes/test_canvasImageRoutes.ts
+++ b/test/routes/test_canvasImageRoutes.ts
@@ -253,11 +253,13 @@ describe("PUT /api/images/update — overwrite pre-allocated file", () => {
     assert.match((state.body as ErrorBody).error ?? "", /invalid image relativepath/i);
   });
 
-  it("returns 500 when the target file does not exist (safeResolve requires realpath)", async () => {
-    // We never allocated this path, so overwriteImage's safeResolve
-    // will fail — surfaced as a 500 with the descriptive message.
+  it("creates the file when the target partition does not exist yet", async () => {
+    // overwriteImage uses the write-time confinement helper: it
+    // mkdir-p's the parent inside the images root and realpath-checks
+    // that parent (not the leaf). A target whose partition was never
+    // allocated still writes correctly inside root.
     const { state, res } = mockRes();
     await putImageHandler(req({ relativePath: "artifacts/images/2026/04/does-not-exist.png", imageData: `data:image/png;base64,${TEST_PNG_BASE64}` }), res);
-    assert.equal(state.status, 500);
+    assert.equal(state.status, 200);
   });
 });

--- a/test/utils/files/test_attachment_store.ts
+++ b/test/utils/files/test_attachment_store.ts
@@ -1,0 +1,128 @@
+// Regression test for #1744 / #1754. `saveCompanion()` used to call a
+// read-time confinement helper (`resolveWithinRoot` → `realpathSync`)
+// on the not-yet-written companion path. `realpathSync` ENOENT
+// collapsed to `null` and the caller mis-reported it as a traversal
+// rejection, so every PPTX upload broke on hosts with LibreOffice /
+// Docker sandbox available. The fix routes companion writes through
+// `resolveWriteWithinRoot`, which mkdir-p's the parent and only
+// realpath-checks the parent dir — not the leaf about to be created.
+
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat, mkdir, symlink } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+
+let workspaceRoot: string;
+
+before(async () => {
+  workspaceRoot = await mkdtemp(path.join(tmpdir(), "mulmoclaude-attachment-test-"));
+  process.env.MULMOCLAUDE_WORKSPACE_PATH = workspaceRoot;
+});
+
+after(async () => {
+  if (workspaceRoot) await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const FAKE_PPTX_B64 = Buffer.from("not-a-real-pptx").toString("base64");
+const FAKE_PDF = Buffer.from("%PDF-1.4\n%%EOF\n");
+
+describe("saveCompanion", () => {
+  let original: { relativePath: string; mimeType: string };
+
+  beforeEach(async () => {
+    const { saveAttachment } = await import("../../../server/utils/files/attachment-store.ts");
+    original = await saveAttachment(FAKE_PPTX_B64, PPTX_MIME);
+  });
+
+  it("writes the companion under the same partition + id as the original", async () => {
+    const { saveCompanion } = await import("../../../server/utils/files/attachment-store.ts");
+    const pdfPath = await saveCompanion(original.relativePath, FAKE_PDF, ".pdf");
+
+    const dirOrig = path.posix.dirname(original.relativePath);
+    const idOrig = path.posix.basename(original.relativePath, path.posix.extname(original.relativePath));
+    assert.equal(path.posix.dirname(pdfPath), dirOrig, "companion shares the partition dir");
+    assert.equal(path.posix.basename(pdfPath, ".pdf"), idOrig, "companion shares the id prefix");
+    const stats = await stat(path.join(workspaceRoot, pdfPath));
+    assert.ok(stats.isFile(), "companion file exists on disk");
+  });
+
+  it("rejects a `..` traversal segment", async () => {
+    const { saveCompanion } = await import("../../../server/utils/files/attachment-store.ts");
+    // Leading `..` survives path.posix.join normalization inside
+    // saveCompanion (interior `..` gets collapsed harmlessly to a path
+    // still inside root). Leading `..` is the actual escape vector.
+    await assert.rejects(() => saveCompanion("../etc/secrets.pptx", FAKE_PDF, ".pdf"), /path traversal rejected/);
+  });
+
+  it("rejects an absolute path", async () => {
+    const { saveCompanion } = await import("../../../server/utils/files/attachment-store.ts");
+    await assert.rejects(() => saveCompanion("/etc/passwd.pptx", FAKE_PDF, ".pdf"), /path traversal rejected/);
+  });
+
+  it("rejects a NUL byte in the path", async () => {
+    const { saveCompanion } = await import("../../../server/utils/files/attachment-store.ts");
+    await assert.rejects(() => saveCompanion("data/attachments/2026/06/abc\0.pptx", FAKE_PDF, ".pdf"), /path traversal rejected/);
+  });
+});
+
+describe("saveCompanion symlink escape", () => {
+  // Point a partition dir at an outside-of-root target via symlink.
+  // The write-time helper realpath-checks the parent, so the symlink
+  // escape must be rejected before the bytes are written.
+  let escapeTarget: string;
+
+  beforeEach(async () => {
+    escapeTarget = await mkdtemp(path.join(tmpdir(), "mulmoclaude-escape-"));
+  });
+
+  afterEach(async () => {
+    await rm(escapeTarget, { recursive: true, force: true });
+  });
+
+  it("rejects a partition whose realpath escapes the attachments root", async () => {
+    const { saveCompanion } = await import("../../../server/utils/files/attachment-store.ts");
+    const attachmentsRoot = path.join(workspaceRoot, "data", "attachments");
+    await mkdir(attachmentsRoot, { recursive: true });
+    const escapePartition = path.join(attachmentsRoot, "9999", "99");
+    await mkdir(path.dirname(escapePartition), { recursive: true });
+    await symlink(escapeTarget, escapePartition, "dir");
+
+    await assert.rejects(
+      () => saveCompanion("data/attachments/9999/99/<id>.pptx", FAKE_PDF, ".pdf"),
+      /path traversal rejected/,
+      "symlinked partition that escapes root must be rejected",
+    );
+  });
+});
+
+describe("loadAttachmentBase64 / loadAttachmentBytes", () => {
+  it("round-trips the bytes that saveAttachment wrote", async () => {
+    const { saveAttachment, loadAttachmentBase64, loadAttachmentBytes } = await import("../../../server/utils/files/attachment-store.ts");
+    const saved = await saveAttachment(FAKE_PPTX_B64, PPTX_MIME);
+    assert.equal(await loadAttachmentBase64(saved.relativePath), FAKE_PPTX_B64);
+    assert.deepEqual(await loadAttachmentBytes(saved.relativePath), Buffer.from(FAKE_PPTX_B64, "base64"));
+  });
+
+  it("rejects reads of paths that do not exist", async () => {
+    const { loadAttachmentBytes } = await import("../../../server/utils/files/attachment-store.ts");
+    await assert.rejects(() => loadAttachmentBytes("data/attachments/0000/00/missing.pdf"), /path traversal rejected/);
+  });
+
+  // Defense-in-depth: even though the data file exists, a traversal-shaped
+  // input string never reaches the file system because the read-time
+  // helper rejects empty / `.` / `..` segments via path.normalize +
+  // realpath-boundary check.
+  it("rejects reads of traversal-shaped paths", async () => {
+    const { loadAttachmentBytes } = await import("../../../server/utils/files/attachment-store.ts");
+    await assert.rejects(() => loadAttachmentBytes("data/attachments/../README.md"), /path traversal rejected/);
+  });
+
+  it("can read back a companion produced by saveCompanion", async () => {
+    const { saveAttachment, saveCompanion, loadAttachmentBytes } = await import("../../../server/utils/files/attachment-store.ts");
+    const orig = await saveAttachment(FAKE_PPTX_B64, PPTX_MIME);
+    const pdfPath = await saveCompanion(orig.relativePath, FAKE_PDF, ".pdf");
+    assert.deepEqual(await loadAttachmentBytes(pdfPath), FAKE_PDF);
+  });
+});

--- a/test/utils/files/test_safe_write.ts
+++ b/test/utils/files/test_safe_write.ts
@@ -1,0 +1,92 @@
+// Unit tests for `resolveWriteWithinRoot` — the write-time
+// confinement helper added in #1754. Its read-time sibling
+// `resolveWithinRoot` cannot be used to pre-validate a not-yet-
+// written path, because the `realpathSync` boundary check throws
+// ENOENT on a missing leaf and the wrapper collapses ENOENT and
+// "genuine traversal escape" into the same null return (#1744).
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, realpath, rm, stat, symlink } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { resolveWriteWithinRoot } from "../../../server/utils/files/safe.ts";
+
+let rootDir: string;
+let rootReal: string;
+
+before(async () => {
+  rootDir = await mkdtemp(path.join(tmpdir(), "mulmoclaude-write-helper-"));
+  rootReal = await realpath(rootDir);
+});
+
+after(async () => {
+  if (rootDir) await rm(rootDir, { recursive: true, force: true });
+});
+
+describe("resolveWriteWithinRoot — happy path", () => {
+  it("returns the absolute path inside root for a flat leaf", async () => {
+    const got = await resolveWriteWithinRoot(rootReal, "file.txt");
+    assert.equal(got, path.join(rootReal, "file.txt"));
+  });
+
+  it("mkdir-p's the parent for a nested leaf", async () => {
+    const got = await resolveWriteWithinRoot(rootReal, "a/b/c/file.txt");
+    assert.equal(got, path.join(rootReal, "a", "b", "c", "file.txt"));
+    const parentStat = await stat(path.join(rootReal, "a", "b", "c"));
+    assert.ok(parentStat.isDirectory(), "parent dir was created on disk");
+  });
+
+  it("accepts a leaf whose parent already exists", async () => {
+    await mkdir(path.join(rootReal, "existing"), { recursive: true });
+    const got = await resolveWriteWithinRoot(rootReal, "existing/file.txt");
+    assert.equal(got, path.join(rootReal, "existing", "file.txt"));
+  });
+});
+
+describe("resolveWriteWithinRoot — rejects", () => {
+  it("rejects empty input", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, ""), null);
+  });
+
+  it("rejects an absolute path", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "/etc/passwd"), null);
+  });
+
+  it("rejects a `..` segment", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "../escape.txt"), null);
+    assert.equal(await resolveWriteWithinRoot(rootReal, "a/../b/escape.txt"), null);
+  });
+
+  it("rejects a `.` segment", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "./file.txt"), null);
+  });
+
+  it("rejects a NUL byte", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "a\0b.txt"), null);
+  });
+
+  it("rejects double-slashed paths (empty segment)", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "a//b.txt"), null);
+  });
+});
+
+describe("resolveWriteWithinRoot — symlink defense", () => {
+  let escapeTarget: string;
+  let escapeReal: string;
+
+  beforeEach(async () => {
+    escapeTarget = await mkdtemp(path.join(tmpdir(), "mulmoclaude-escape-target-"));
+    escapeReal = await realpath(escapeTarget);
+  });
+
+  it("rejects writes whose parent realpath escapes root via symlink", async () => {
+    const symlinkDirInRoot = path.join(rootReal, "linkdir");
+    await rm(symlinkDirInRoot, { recursive: true, force: true });
+    await symlink(escapeReal, symlinkDirInRoot, "dir");
+    const got = await resolveWriteWithinRoot(rootReal, "linkdir/file.txt");
+    assert.equal(got, null, "symlinked parent dir escaping root must be rejected");
+    await rm(symlinkDirInRoot, { recursive: true, force: true });
+    await rm(escapeTarget, { recursive: true, force: true });
+  });
+});

--- a/test/utils/files/test_safe_write.ts
+++ b/test/utils/files/test_safe_write.ts
@@ -89,4 +89,34 @@ describe("resolveWriteWithinRoot — symlink defense", () => {
     await rm(symlinkDirInRoot, { recursive: true, force: true });
     await rm(escapeTarget, { recursive: true, force: true });
   });
+
+  it("rejects writes whose intermediate ancestor escapes root via symlink — before mkdir runs", async () => {
+    // The intermediate component "linkmid" is a symlink to outside-root.
+    // A naive impl would mkdir -p `<root>/linkmid/inner` first (creating
+    // `escapeTarget/inner` outside root) and only THEN realpath-check
+    // and reject. Algorithm walks ancestors and realpath-checks each
+    // existing one BEFORE any mkdir, so no outside-root dir is created.
+    const symlinkMid = path.join(rootReal, "linkmid");
+    await rm(symlinkMid, { recursive: true, force: true });
+    await symlink(escapeReal, symlinkMid, "dir");
+    const got = await resolveWriteWithinRoot(rootReal, "linkmid/inner/file.txt");
+    assert.equal(got, null, "intermediate symlink ancestor escaping root must be rejected");
+    const innerOutsideRoot = await stat(path.join(escapeReal, "inner")).catch(() => null);
+    assert.equal(innerOutsideRoot, null, "no directory was created outside root");
+    await rm(symlinkMid, { recursive: true, force: true });
+    await rm(escapeTarget, { recursive: true, force: true });
+  });
+});
+
+describe("resolveWriteWithinRoot — Windows drive-qualified relative", () => {
+  // path.isAbsolute("C:foo") === false (drive-relative, not absolute),
+  // but path.resolve on Windows would resolve onto drive C:'s CWD.
+  // The string check has to reject these explicitly.
+  it("rejects `C:foo` (drive letter + relative)", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "C:foo"), null);
+  });
+
+  it("rejects `c:relative/path.txt` (lowercase drive letter)", async () => {
+    assert.equal(await resolveWriteWithinRoot(rootReal, "c:relative/path.txt"), null);
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #1744 (PPTX upload `path traversal rejected`) by closing the underlying bug class: `resolveWithinRoot` is read-time only, but `saveCompanion` was using it to pre-validate a not-yet-written path. `realpathSync` ENOENT collapses into the same `null` as a real traversal escape, so PPTX uploads broke on every host with LibreOffice / Docker sandbox.
- Adds `resolveWriteWithinRoot` write-time sibling: string-validates input, mkdir-p's the parent, realpath-checks the **parent** (not the leaf about to be created).
- Consolidates the three name-cloned `safeResolve` wrappers (`attachment-store`, `image-store`, `spreadsheet-store`) into one `makeStoreResolvers` factory exposing `forRead` / `forWrite`. Future companion writers reach for the safe method by name instead of re-discovering the trap.
- Tracking issue: #1754.

## Items to Review

1. **Behavior change in `overwriteImage`** (`test/routes/test_canvasImageRoutes.ts:256`): the old test asserted that `overwriteImage` returns 500 when the target file does not exist yet — that was the bug being codified. After the fix, `overwriteImage` correctly creates the file. The test was updated to expect 200. Confirm this is the intended new semantics for `overwriteImage` (and by symmetry `overwriteSpreadsheet`, which has the same shape but no route test today).
2. **Scope of `saveCompanion` / `overwriteImage` / `overwriteSpreadsheet` defense-in-depth**: callers in our codebase all pass server-generated paths, so the realpath confinement is redundant for current call paths. Kept as defense-in-depth because the functions are exported.
3. `saveAttachment` / `saveImage` / `saveSpreadsheet` are deliberately **not** routed through `forWrite` — they build the absolute path via `path.join` from server-generated values and `writeFileAtomic` mkdir-p's; an extra realpath syscall per upload would buy zero security. Confirm this is the right call.
4. Confirm the read-time semantics of `resolveWithinRoot` (ENOENT → null) are preserved — reads on a path that was just deleted should still return null, not throw.

## User Prompt

> #1744 ってPPTXだけで発生する？それとも特定の拡張子以外は全てで発生する？根本的な調査をして対策を考えたい。Mac/Linux/Windowsで再現する？LibreOfficeを入れたくないけどモック関数でdockerなしでlocalで再現させたい。C2まで（write-time primitive + shared `store-resolvers` 統合）まで含めて、新しいissueにして課題を書き、報告チケットと関連付け、PRを作成して。ユーザ作成ブランチは見ないように。0から修正方法を提案してくれ。

## Approach

Three layers — deliberately structural so the bug class is closed, not just the symptom.

### Layer 1 — `resolveWriteWithinRoot` in `safe.ts`

Write-time sibling of `resolveWithinRoot`. Differences:
- string-validates `relPath` first (NUL, absolute, empty `.`/`..` segments)
- `mkdir -p` the parent inside `rootReal`
- `realpath`-checks the **parent dir** (the leaf is about to be created, so `realpath` on it would always ENOENT)
- returns absolute write path or `null` on any unsafe input

Read-side `resolveWithinRoot` semantics are unchanged — `ENOENT → null` is correct for reads (delete races, dangling symlinks).

### Layer 2 — `saveCompanion` uses Layer 1 + `writeFileAtomic`

Drop the misused `safeResolve` call, route through `forWrite`, and switch the raw `writeFile` to `writeFileAtomic` per CLAUDE.md "All writes go through `writeFileAtomic`".

### Layer 3 (C-2) — Consolidate per-store `safeResolve` duplication

`attachment-store`, `image-store`, `spreadsheet-store` each defined an identically-shaped `safeResolve`. Replaced all three with `makeStoreResolvers(getRoot, dirPrefix)` exposing `.forRead` / `.forWrite`. The method names tell future callers which side they're safe on — eliminating the next chance to re-create #1744 via DOCX→PDF, HEIC→JPG, or similar.

## Tests

- `test/utils/files/test_safe_write.ts` — `resolveWriteWithinRoot`: happy path (flat / nested / pre-existing parent), traversal segment (`..`/`.`), absolute path, NUL byte, double slash, symlink escape via parent.
- `test/utils/files/test_attachment_store.ts` — `saveCompanion`: companion lands under original's id + partition; traversal-shaped paths rejected (`../etc/x.pptx` survives `path.posix.join` normalization); absolute path rejected; NUL byte rejected; symlinked partition escape rejected. Plus `loadAttachmentBase64` / `loadAttachmentBytes` round-trip + reject vectors.
- `test/routes/test_canvasImageRoutes.ts` — updated to reflect the new correct behavior of `overwriteImage` (creates partition if needed).

## Repro (without LibreOffice / Docker)

```ts
process.env.MULMOCLAUDE_WORKSPACE_PATH = await mkdtemp(path.join(tmpdir(), "x-"));
const { saveAttachment, saveCompanion } = await import("…/attachment-store.ts");
const original = await saveAttachment(Buffer.from("x").toString("base64"), PPTX_MIME);
await saveCompanion(original.relativePath, Buffer.from("%PDF-1.4\n%%EOF\n"), ".pdf");
// Before this PR: throws "path traversal rejected: data/attachments/YYYY/MM/<id>.pdf"
// After:          companion written, returns relative path
```

## Related

- Fixes #1744
- Tracking issue: #1754

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a companion file path traversal issue during write operations for Office uploads, preventing erroneous rejections.
  * Enforced safer write-specific path resolution for companion, attachment, image, and spreadsheet saves across their workspace roots.

* **New Features**
  * Added shared store resolvers to standardize safe read vs. safe write path handling.

* **Tests**
  * Added unit tests for write-path validation (including NUL, absolute, traversal, empty segments, Windows drive-relative, and symlink-escape cases).
  * Added/expanded companion and attachment round-trip tests, including negative traversal and update behavior adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->