### PR TITLE
fix: restore '..' substring rejection in makePathValidator

### DIFF
--- a/server/utils/files/path-validator.ts
+++ b/server/utils/files/path-validator.ts
@@ -6,7 +6,7 @@
 // in the other four. Both are individually sound; having two for the
 // same intent is the smell (#1761).
 //
-// `makePathValidator` applies BOTH defenses:
+// `makePathValidator` applies all four defenses:
 //
 //   1. Prefix gate — value must start with `dirPrefix + "/"`.
 //   2. Optional extension gate — value must end with the configured
@@ -14,8 +14,16 @@
 //      cover many MIME types).
 //   3. Canonical-form gate — `path.posix.normalize(value) === value`
 //      (rejects empty / `.` / non-canonical segments).
-//   4. Traversal gate — `hasTraversalSegment(value)` (defense-in-depth
-//      against `..` / `.` that survived a malformed normalize).
+//   4. No `..` substring anywhere — even inside a single segment
+//      (`foo..md`, `v1..2.json`). The pre-refactor markdown / html /
+//      spreadsheet / svg validators had this guard; it was lost when
+//      the factory only inherited `hasTraversalSegment` (which checks
+//      segments-equal-`..` only). Re-added so legitimate filenames in
+//      our domain (server-generated shortIds + standard extensions)
+//      stay accepted while pathological `..`-bearing names are not.
+//      See #1764.
+//   5. Traversal gate — `hasTraversalSegment(value)` (defense-in-depth
+//      against literal `.` / `..` segments).
 
 import path from "path";
 import { hasTraversalSegment } from "./safe.js";
@@ -34,6 +42,7 @@ export function makePathValidator({ prefix, ext }: PathValidatorOptions): (value
     if (!value.startsWith(prefixWithSlash)) return false;
     if (ext && !value.endsWith(ext)) return false;
     if (path.posix.normalize(value) !== value) return false;
+    if (value.includes("..")) return false;
     if (hasTraversalSegment(value)) return false;
     return true;
   };

--- a/server/utils/files/path-validator.ts
+++ b/server/utils/files/path-validator.ts
@@ -6,7 +6,7 @@
 // in the other four. Both are individually sound; having two for the
 // same intent is the smell (#1761).
 //
-// `makePathValidator` applies all four defenses:
+// `makePathValidator` applies all five defenses:
 //
 //   1. Prefix gate — value must start with `dirPrefix + "/"`.
 //   2. Optional extension gate — value must end with the configured

--- a/test/utils/files/test_path_validator.ts
+++ b/test/utils/files/test_path_validator.ts
@@ -60,6 +60,15 @@ describe("makePathValidator — canonical-form gate", () => {
   it("rejects `..` after a backslash separator (Windows / encoded `%5C`)", () => {
     assert.equal(validator("data/things\\..\\escape.bin"), false);
   });
+
+  it("rejects `..` substring inside a single segment (#1764 regression)", () => {
+    // Pre-refactor markdown/html/spreadsheet/svg rejected these via
+    // `normalized.includes("..")`. The factory must inherit that
+    // guard; otherwise legitimate-looking filenames like `foo..bin`
+    // / `v1..2.json` slip through.
+    assert.equal(validator("data/things/foo..bin"), false);
+    assert.equal(validator("data/things/prefix..suffix.bin"), false);
+  });
 });
 
 describe("per-store validators — smoke", () => {
@@ -84,6 +93,7 @@ describe("per-store validators — smoke", () => {
     assert.equal(isMarkdownPath("artifacts/documents/2026/06/abc.md"), true);
     assert.equal(isMarkdownPath("artifacts/documents/abc.txt"), false);
     assert.equal(isMarkdownPath("artifacts/documents/../etc/x.md"), false);
+    assert.equal(isMarkdownPath("artifacts/documents/foo..md"), false);
   });
 
   it("isHtmlPath (requires .html)", () => {
@@ -96,6 +106,7 @@ describe("per-store validators — smoke", () => {
     assert.equal(isSpreadsheetPath("artifacts/spreadsheets/2026/06/abc.json"), true);
     assert.equal(isSpreadsheetPath("artifacts/spreadsheets/abc.csv"), false);
     assert.equal(isSpreadsheetPath("artifacts/spreadsheets/../etc/x.json"), false);
+    assert.equal(isSpreadsheetPath("artifacts/spreadsheets/v1..2.json"), false);
   });
 
   it("isSvgPath (requires .svg)", () => {


### PR DESCRIPTION
## Summary

- Fixes the silent path-validator relaxation Codex flagged on PR #1762.
- Pre-refactor markdown / html / spreadsheet / svg rejected ANY `..` substring via `normalized.includes("..")`. The factory inherited only `hasTraversalSegment`, which checks for segments equal to `.` or `..` — so paths like `artifacts/documents/foo..md` and `artifacts/spreadsheets/v1..2.json` silently became accepted.
- Re-adds an explicit `value.includes("..")` gate inside `makePathValidator` so all six stores get their pre-refactor strictness (and attachment / image get tightened too, matching what PR #1762 claimed).

## Items to Review

1. **Behavioral change** — `attachment` and `image` paths containing `..` substrings (e.g. a hypothetical `data/attachments/foo..pptx`) are now rejected. These never appear in real callers (server-generated shortIds + standard extensions), so the rejection is theoretical for those two.
2. **Why `value.includes("..")` over a more nuanced rule** — our domain has no use case for `..` inside filenames. The cheap substring check buys back the lost strictness without adding complexity.

## User Prompt

> 全部やってカタログにも載せよう。PR は 1 つ 1 つ
> あ、CODEX VERDICT: CHANGES REQUESTED があった
> comments は ci とともにチェックしてね

## Approach

Codex caught a legitimate regression: PR #1762's description claimed "no behavioral change for markdown/html/spreadsheet/svg" but the new `hasTraversalSegment`-only check is looser than the old `normalized.includes("..")`. Restoring the rejection in the factory keeps all six stores at their strictest historical floor.

Note: PR #1762 was merged before this Codex re-review fully surfaced. I should have triaged comments alongside CI before merging; that's the lesson and the standing rule going forward.

## Tests

`test/utils/files/test_path_validator.ts`:
- factory: rejects `foo..bin`, `prefix..suffix.bin`
- store smokes: `isMarkdownPath("foo..md")`, `isSpreadsheetPath("v1..2.json")` rejected

15/15 tests pass. Existing tests unchanged.

## Related

- Fixes #1764
- Codex CHANGES REQUESTED on #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore strict path validation by rejecting any value containing a `..` substring and align all store-specific validators with this behavior.

Bug Fixes:
- Prevent acceptance of paths with `..` substrings inside a single segment in the shared path validator factory.
- Ensure markdown and spreadsheet path helpers reject filenames like `foo..md` and `v1..2.json` to match pre-refactor behavior.

Tests:
- Add regression tests for `makePathValidator` to reject `..` substrings within a segment and for store-specific validators to enforce this rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path validation security by implementing stricter pattern rejection for unsafe file paths, adding an additional layer of defensive protection against malicious or problematic path inputs.

* **Tests**
  * Expanded test coverage to validate the strengthened path validation logic across various edge cases and filename patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->