### PR TITLE
refactor: replace inlined errorMessage() pattern across 12 sites

### DIFF
--- a/scripts/memory-swap-topic-staging.ts
+++ b/scripts/memory-swap-topic-staging.ts
@@ -20,6 +20,7 @@
 // chain and goes when the chain goes (along with the
 // `yarn memory:swap` script entry in package.json).
 
+import { errorMessage } from "../server/utils/errors.js";
 import { workspacePath } from "../server/workspace/workspace.js";
 import { swapStagingIntoMemory } from "../server/workspace/memory/topic-swap.js";
 
@@ -39,6 +40,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error(`memory:swap — failed: ${err instanceof Error ? err.message : String(err)}`);
+  console.error(`memory:swap — failed: ${errorMessage(err)}`);
   process.exitCode = 1;
 });

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -17,6 +17,7 @@ import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/r
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
 import { createMcpFailureMonitor } from "../mcpFailureMonitor.js";
 import { log } from "../../system/logger/index.js";
+import { errorMessage } from "../../utils/errors.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
 import type { AgentInput, LLMBackend } from "./types.js";
@@ -202,7 +203,7 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
     });
   } catch (err) {
     const target = input.useDocker ? "docker" : "claude";
-    const message = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     log.error("agent", `failed to spawn ${target}`, { error: message });
     yield {
       type: EVENT_TYPES.error,

--- a/server/agent/backend/fake-echo.ts
+++ b/server/agent/backend/fake-echo.ts
@@ -27,6 +27,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { getCurrentToken } from "../../api/auth/token.js";
+import { errorMessage } from "../../utils/errors.js";
 import { makeUuid } from "../../utils/id.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
@@ -271,7 +272,7 @@ async function dispatchToPlugin(call: FakeToolCall, port: number, chatSessionId:
   } catch (err) {
     // Don't tear down the chat turn on plugin-dispatch failure —
     // surface the error in the tool_result so the test sees it.
-    return JSON.stringify({ error: err instanceof Error ? err.message : String(err) });
+    return JSON.stringify({ error: errorMessage(err) });
   }
 }
 

--- a/server/agent/stdioHttpShim.ts
+++ b/server/agent/stdioHttpShim.ts
@@ -24,6 +24,7 @@ import type { Readable } from "node:stream";
 
 import { findAvailablePort } from "../utils/port.mjs";
 import { log } from "../system/logger/index.js";
+import { errorMessage } from "../utils/errors.js";
 import { ONE_SECOND_MS } from "../utils/time.js";
 import type { McpStdioSpec } from "../system/config.js";
 
@@ -150,7 +151,7 @@ export async function startStdioHttpShim(serverId: string, spec: McpStdioSpec, w
   let spawnFailed = false;
   child.once("error", (err) => {
     spawnFailed = true;
-    log.warn("mcp-shim", "supergateway spawn failed", { serverId, error: err instanceof Error ? err.message : String(err) });
+    log.warn("mcp-shim", "supergateway spawn failed", { serverId, error: errorMessage(err) });
   });
 
   const close = () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -140,14 +140,14 @@ const debugMode = process.argv.includes("--debug");
 // `process.exit(1)` is non-zero so supervisors that branch on exit
 // code treat the bounce as an error condition.
 process.on("uncaughtException", (err) => {
-  log.error("uncaughtException", err instanceof Error ? err.message : String(err), {
+  log.error("uncaughtException", errorMessage(err), {
     stack: err instanceof Error ? err.stack : undefined,
   });
   // Tiny grace so the log line flushes to disk before we exit.
   setTimeout(() => process.exit(1), FATAL_LOG_FLUSH_MS);
 });
 process.on("unhandledRejection", (reason) => {
-  log.error("unhandledRejection", reason instanceof Error ? reason.message : String(reason), {
+  log.error("unhandledRejection", errorMessage(reason), {
     stack: reason instanceof Error ? reason.stack : undefined,
   });
   setTimeout(() => process.exit(1), FATAL_LOG_FLUSH_MS);
@@ -876,7 +876,7 @@ function logExternalMcpPreflight(): void {
     // per-agent-run path will still attempt the preflight and surface
     // any genuine issue when the user actually starts a chat.
     log.warn("mcp", "preflight at boot failed; will retry per-agent-run", {
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     });
   }
 }

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -126,6 +126,7 @@ import { applyCellHighlights, clearCellHighlights } from "./cellHighlights";
 import { getArrowKeyOffset, isWithinSheetBounds } from "./keyboardNav";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { errorMessage as formatErrorMessage } from "../../utils/errors";
+import { escapeHtml } from "../../utils/markdown/wikiEmbeds";
 
 // Import all spreadsheet functions to populate the function registry
 import "./engine/functions";
@@ -362,7 +363,12 @@ const renderedHtml = computed(() => {
     return html;
   } catch (error) {
     console.error("Failed to render spreadsheet:", error);
-    return `<div class="error">Failed to render spreadsheet: ${formatErrorMessage(error, "Unknown error")}</div>`;
+    // Result is fed into v-html (see :data-testid="table"). The
+    // message comes from a caught throw, which can include attacker-
+    // controlled object shapes (e.g. `{ details: "<script>..." }`)
+    // surfaced by formatErrorMessage's gRPC-style unwrap. Escape
+    // before interpolation. (Codex review on #1767.)
+    return `<div class="error">Failed to render spreadsheet: ${escapeHtml(formatErrorMessage(error, "Unknown error"))}</div>`;
   }
 });
 

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -362,7 +362,7 @@ const renderedHtml = computed(() => {
     return html;
   } catch (error) {
     console.error("Failed to render spreadsheet:", error);
-    return `<div class="error">Failed to render spreadsheet: ${error instanceof Error ? error.message : "Unknown error"}</div>`;
+    return `<div class="error">Failed to render spreadsheet: ${formatErrorMessage(error, "Unknown error")}</div>`;
   }
 });
 
@@ -386,7 +386,7 @@ const downloadExcel = () => {
     XLSX.writeFile(workbook, filename);
   } catch (error) {
     console.error("Failed to download Excel:", error);
-    alert(`Failed to download Excel file: ${error instanceof Error ? error.message : "Unknown error"}`);
+    alert(`Failed to download Excel file: ${formatErrorMessage(error, "Unknown error")}`);
   }
 };
 
@@ -525,7 +525,7 @@ function saveMiniEditor() {
     // Don't close the mini editor - keep it open so user can see the updated references
     // closeMiniEditor();
   } catch (error) {
-    alert(`Failed to save cell: ${error instanceof Error ? error.message : "Unknown error"}`);
+    alert(`Failed to save cell: ${formatErrorMessage(error, "Unknown error")}`);
   }
 }
 

--- a/src/plugins/spreadsheet/definition.ts
+++ b/src/plugins/spreadsheet/definition.ts
@@ -1,6 +1,7 @@
 import type { ToolDefinition } from "gui-chat-protocol";
 import { META } from "./meta";
 import type { ResolvedRoute } from "../meta-types";
+import { errorMessage } from "../../utils/errors";
 
 export const TOOL_NAME = META.toolName;
 export type SpreadsheetEndpoints = { readonly [K in keyof typeof META.apiRoutes]: ResolvedRoute };
@@ -99,7 +100,7 @@ export const executeSpreadsheet = async (
     try {
       sheets = JSON.parse(sheets);
     } catch (error) {
-      throw new Error(`Invalid sheets format: sheets must be an array, not a string. Parse error: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(`Invalid sheets format: sheets must be an array, not a string. Parse error: ${errorMessage(error)}`);
     }
   }
 

--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -10,6 +10,7 @@ import { evaluateFormula as evaluateFormulaFn } from "./evaluator";
 import { parseDate, getDefaultDateFormat } from "./date-parser";
 import type { SheetData, CellValue, CalculatedSheet, CalculationError, FormulaInfo, SpreadsheetCell } from "./types";
 import { isObj } from "../../../utils/types";
+import { errorMessage } from "../../../utils/errors";
 
 /**
  * Normalize malformed data structures
@@ -209,7 +210,7 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[]): Calcu
             errors.push({
               cell: { row, col },
               formula: value,
-              error: error instanceof Error ? error.message : String(error),
+              error: errorMessage(error),
               type: "unknown",
             });
             return 0;


### PR DESCRIPTION
## Summary

- Replaces 12 inlined `err instanceof Error ? err.message : String(err)` sites with the existing `errorMessage()` helper (`server/utils/errors.ts` and `src/utils/errors.ts`).
- Tracking issue #1304 has called this the most-duplicated helper for months; this PR brings the in-tree count of inline sites in scope down to zero.

## Items to Review

1. **Scope** — only in-tree app code (server/, src/, scripts/). Plugin packages (`packages/plugins/*`) each ship their own error helper because they're standalone npm packages; bringing them under one helper would mean either per-package copies (which we already have) or moving `errorMessage` to a shared workspace package. Left as a separate follow-up.
2. **Vue View.vue alias** — `src/plugins/spreadsheet/View.vue` was already importing `errorMessage as formatErrorMessage` (the local `errorMessage` ref shadowed it). The three `instanceof Error` lines in this file also used a different fallback (`"Unknown error"`) than `String(err)`; they now pass that fallback as the second argument to `formatErrorMessage`.
3. **Behavioural drift** — `errorMessage()` does more than the inline pattern: it unwraps `{ details }` / `{ message }` from non-Error objects (the gRPC `[object Object]` case). For each migrated site, this is a strict improvement (no log line was relying on `[object Object]` as a sentinel).

## User Prompt

> 全部やってカタログにも載せよう。PR は 1 つ 1 つ
> 並行してどんどん進めてPRをつくって

## Sites migrated

| File | Count |
|---|---|
| `server/index.ts` | 3 |
| `server/agent/stdioHttpShim.ts` | 1 |
| `server/agent/backend/fake-echo.ts` | 1 |
| `server/agent/backend/claude-code.ts` | 1 |
| `scripts/memory-swap-topic-staging.ts` | 1 |
| `src/plugins/spreadsheet/definition.ts` | 1 |
| `src/plugins/spreadsheet/View.vue` | 3 |
| `src/plugins/spreadsheet/engine/calculator.ts` | 1 |
| **total** | **12** |

Verified by re-grep after the migration: zero matches in scope.

## Tests

No new tests — `errorMessage()` already has full coverage in `test/utils/test_errors.ts`. `yarn lint` / `typecheck:server` / `test` all green.

## Out of scope (follow-up)

- 41 sites under `packages/plugins/*` (each plugin = standalone npm package)
- 4 sites under `e2e-live/` (test infra; not customer code)

A `no-restricted-syntax` ESLint rule banning the inline pattern would prevent re-introduction but would also trip the package and e2e-live sites; deferring until those are addressed.

## Related

- Continuation of the post-#1756 catalog-hygiene sweep (#1759, #1761, #1764, #1766)
- Background: #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate error handling across server, scripts, and spreadsheet plugin code to use the shared errorMessage helper instead of duplicated inline patterns.

Enhancements:
- Replace multiple inline instanceof Error / String(...) error formatting sites with the shared errorMessage helper for consistent logging and messages.
- Align spreadsheet plugin user-facing error messages to use the existing formatting helper while preserving custom fallbacks like "Unknown error".