### PR TITLE
fix(spawn): cross-platform claude CLI resolver for Windows (#1757)

### DIFF
--- a/plans/fix-windows-claude-spawn-1757.md
+++ b/plans/fix-windows-claude-spawn-1757.md
@@ -1,0 +1,160 @@
+# fix-windows-claude-spawn-1757
+
+Issue: [#1757](https://github.com/receptron/mulmoclaude/issues/1757).
+Acknowledgement: original problem report + 3-failure-mode analysis by
+@lapispapyrus on the now-closed PR #1571.
+
+## Problem (restated)
+
+On Windows, every `child_process.spawn("claude", args, …)` call site
+fails one of three ways, and the three escape hatches are mutually
+exclusive — a double-bind that takes chat / journal / summarizer /
+translation offline as soon as MulmoClaude is installed on a Windows
+host.
+
+| Attempt | Why it fails |
+|---|---|
+| `spawn("claude", args)` | `ENOENT` — Node looks for an extensionless executable; npm-installed `claude.cmd` is not found. |
+| `spawn("claude.cmd", args)` | `EINVAL` — since CVE-2024-27980, Node refuses `.cmd` directly unless `shell: true`. |
+| `spawn("claude", args, { shell: true })` | "コマンドラインが長すぎます" — cmd.exe wraps the call and trips the 8191-char limit once MCP-config + system-prompt args land. |
+
+The only escape that respects all three constraints is to spawn the
+native `claude.exe` directly (no wrapper, no shell, full Win32 long-
+command-line headroom).
+
+## Target spawn surface
+
+PR #1571 listed 6 files. Two of those (`sources/classifier.ts`,
+`sources/pipeline/summarize.ts`) have been removed from main since
+then. `server/system/credentials.ts` uses `node-pty`'s `pty.spawn`
+which has its own conpty/winpty wrapping and is NOT subject to the
+CVE-2024-27980 / 8191-char issues. The remaining surface is 4 sites:
+
+| File | Line | Current call |
+|---|---|---|
+| `server/agent/backend/claude-code.ts` | 32 | `spawn("claude", cliArgs, {…})` |
+| `server/workspace/journal/archivist-cli.ts` | 32 | `spawn("claude", ["-p", "--output-format", "text"], {…})` |
+| `server/workspace/chat-index/summarizer.ts` | 198 | `spawn("claude", args, {…})` |
+| `server/services/translation/llm.ts` | 122 | `spawn("claude", buildArgs(promptInput), {…})` |
+
+Each site changes to `spawn(claudeBinPath(), args, {…})` — one-line
+swap, no shape changes to args / stdio / env.
+
+## Design: `server/utils/claudeBin.ts`
+
+Single exported function with the following contract:
+
+```ts
+export function claudeBinPath(): string;
+```
+
+### Non-Windows
+
+Returns the literal string `"claude"`. PATH lookup just works, no
+.cmd / cmd.exe involvement. Zero behaviour change for the macOS /
+Linux paths every existing CI run already covers.
+
+### Windows
+
+Returns the absolute path to a `claude.exe` we found, resolved in this
+order (first hit wins, all subsequent steps skipped):
+
+1. **`where claude.cmd` probe (canonical path)**. Run
+   `spawnSync("where", ["claude.cmd"])`; for each line of output, walk
+   parent directories looking for
+   `node_modules/@anthropic-ai/claude-code/bin/claude.exe` up to 4
+   levels. Covers npm-global (`%APPDATA%\npm`), yarn-global
+   (`%LOCALAPPDATA%\Yarn\bin`), pnpm-global (`%LOCALAPPDATA%\pnpm`),
+   nvm-windows (any prefix), Volta, and any custom `npm prefix -g`.
+2. **`npm config get prefix`**. Run `spawnSync("npm", ["config",
+   "get", "prefix"])` to discover the user's npm prefix even if PATH
+   doesn't carry it, then probe
+   `<prefix>\node_modules\@anthropic-ai\claude-code\bin\claude.exe`.
+3. **`%APPDATA%\npm`** (npm's documented Windows default).
+4. **`%LOCALAPPDATA%\Yarn\config\global`** + classic Yarn global node
+   modules layout.
+5. **`%LOCALAPPDATA%\pnpm`** + pnpm global glob (`global/*/node_modules`).
+
+If none of those hit, throw an `Error` whose message lists every path
+probed plus install instructions:
+
+```
+claude CLI binary not found. Tried:
+  - %APPDATA%\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe
+  - %LOCALAPPDATA%\Yarn\config\global\node_modules\…
+  - …
+Install with: npm install -g @anthropic-ai/claude-code
+```
+
+### Caching
+
+Resolution is a one-shot probe and the install path doesn't change
+during a process's lifetime. Cache the result of the first successful
+resolution in a module-level `cachedBin: string | null | undefined`
+(`undefined` = not probed; `null` = probed-and-missing — still throw
+each call so the error surfaces consistently, just skip re-probing).
+
+### Testability
+
+Resolution depends on the platform, `spawnSync`, `existsSync`, and env
+vars. To keep this unit-testable without actually installing the
+claude CLI, accept an `options` parameter (default `{}`) with
+injectable `platform`, `spawnSync`, `existsSync`, and `env`. Internal
+code uses real Node defaults; tests pass mocks.
+
+```ts
+export interface ResolveOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly spawnSync?: typeof import("node:child_process").spawnSync;
+  readonly existsSync?: typeof import("node:fs").existsSync;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly resetCache?: boolean;  // tests reset between cases
+}
+```
+
+## Tests (`test/utils/test_claudeBin.ts`)
+
+- Non-Windows (`platform: "darwin" | "linux"`) returns `"claude"` —
+  zero probing.
+- Windows + `where claude.cmd` → npm-style layout → returns the
+  resolved `.exe` path.
+- Windows + `where claude.cmd` → yarn-style layout (bin/ sibling of
+  node_modules) → returns the resolved `.exe`.
+- Windows + `where` empty + `npm config get prefix` returns a valid
+  path → returns the resolved `.exe`.
+- Windows + all probes miss → throws with a list of probed paths AND
+  includes the install hint string.
+- Caching: first call probes, second call doesn't (verify with a
+  spawnSync mock call counter).
+
+## Touch list
+
+| Path | Change | Lines |
+|---|---|---|
+| `server/utils/claudeBin.ts` | **new** — helper | ~120 |
+| `test/utils/test_claudeBin.ts` | **new** — 6+ cases | ~150 |
+| `server/agent/backend/claude-code.ts` | swap call | +1/-1 |
+| `server/workspace/journal/archivist-cli.ts` | swap call | +1/-1 |
+| `server/workspace/chat-index/summarizer.ts` | swap call | +1/-1 |
+| `server/services/translation/llm.ts` | swap call | +1/-1 |
+
+## Out of scope / known limits
+
+- `server/system/credentials.ts` (`node-pty`'s `pty.spawn`) is **not**
+  touched — node-pty handles its own conpty/winpty wrapping and is
+  not subject to CVE-2024-27980 / cmd.exe 8191 limits.
+- We do not bundle a fallback `claude` install — if the user hasn't
+  installed `@anthropic-ai/claude-code` globally, the new error
+  message points them at the install command.
+- We do not migrate `spawn` to any newer execa-style wrapper — the
+  patch stays within `node:child_process` to keep the diff narrow.
+
+## Acceptance
+
+- All 4 call sites compile and pass typecheck.
+- New helper has 100% branch coverage in `test_claudeBin.ts` (6+
+  scenarios) and tests pass on macOS / Linux / Windows runners.
+- The existing CI matrix continues to pass on macOS + Linux.
+- On a fresh Windows 11 install with `npm install -g
+  @anthropic-ai/claude-code`, MulmoClaude chat starts cleanly
+  without ENOENT / EINVAL / "command line too long".

--- a/plans/fix-windows-claude-spawn-1757.md
+++ b/plans/fix-windows-claude-spawn-1757.md
@@ -78,7 +78,7 @@ order (first hit wins, all subsequent steps skipped):
 If none of those hit, throw an `Error` whose message lists every path
 probed plus install instructions:
 
-```
+```text
 claude CLI binary not found. Tried:
   - %APPDATA%\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe
   - %LOCALAPPDATA%\Yarn\config\global\node_modules\…

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -188,7 +188,24 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
     effortLevel: input.effortLevel,
   });
 
-  const proc = spawnClaude(input.useDocker, input.workspacePath, cliArgs, input.sessionId);
+  // spawnClaude can throw synchronously when `claudeBinPath()` fails
+  // to locate `claude.exe` on Windows — surface that through the same
+  // AgentEvent error channel as the post-spawn "error" event so the
+  // server stays alive (#1364) and the user sees the actionable
+  // "install with npm install -g …" hint.
+  let proc: ReturnType<typeof spawnClaude>;
+  try {
+    proc = spawnClaude(input.useDocker, input.workspacePath, cliArgs, input.sessionId);
+  } catch (err) {
+    const target = input.useDocker ? "docker" : "claude";
+    const message = err instanceof Error ? err.message : String(err);
+    log.error("agent", `failed to resolve ${target} binary`, { error: message });
+    yield {
+      type: EVENT_TYPES.error,
+      message: `Failed to spawn ${target}: ${message}`,
+    };
+    return;
+  }
 
   // Wait for the kernel to confirm the spawn before piping anything
   // into stdin. Without this guard, a missing `claude` (or `docker`)

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -19,6 +19,7 @@ import { createMcpFailureMonitor } from "../mcpFailureMonitor.js";
 import { log } from "../../system/logger/index.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 import type { AgentInput, LLMBackend } from "./types.js";
 
 type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
@@ -29,7 +30,7 @@ function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[
     // PostToolUse hook needs to publish a `page-edit` toolResult back to
     // the right session (#963). Claude CLI's own hook payload carries
     // its internal session_id, which doesn't match our session store.
-    return spawn("claude", cliArgs, {
+    return spawn(claudeBinPath(), cliArgs, {
       cwd: workspacePath,
       stdio: ["pipe", "pipe", "pipe"],
       env: { ...process.env, MULMOCLAUDE_CHAT_SESSION_ID: chatSessionId },

--- a/server/services/translation/llm.ts
+++ b/server/services/translation/llm.ts
@@ -12,6 +12,7 @@ import { errorMessage } from "../../utils/errors.js";
 import { formatSpawnFailure } from "../../utils/spawn.js";
 import { isRecord } from "../../utils/types.js";
 import { ClaudeCliNotFoundError } from "../../workspace/journal/archivist-cli.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 import type { TranslateBatchFn } from "./types.js";
 
 const SYSTEM_PROMPT =
@@ -119,7 +120,7 @@ function spawnClaudeTranslate(promptInput: string, timeoutMs: number): Promise<s
   return new Promise<string>((resolve, reject) => {
     // Run from tmpdir so claude does not load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", buildArgs(promptInput), { cwd: tmpdir(), stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn(claudeBinPath(), buildArgs(promptInput), { cwd: tmpdir(), stdio: ["ignore", "pipe", "pipe"] });
     const state: SpawnState = { stdout: "", stderr: "", settled: false };
     const timer = setTimeout(() => onTimeout(state, proc, reject, timeoutMs), timeoutMs);
     proc.stdout.on("data", (chunk: Buffer) => {

--- a/server/utils/claudeBin.ts
+++ b/server/utils/claudeBin.ts
@@ -34,6 +34,21 @@ const PACKAGE_REL_PATH = winPath.join("@anthropic-ai", "claude-code", "bin", "cl
 const PARENT_WALK_DEPTH = 4;
 const INSTALL_HINT = "Install with: npm install -g @anthropic-ai/claude-code";
 
+// Typed "claude CLI is not on this machine" error. Consumers across
+// the codebase (journal, memory, chat-index, translation) use
+// `err instanceof ClaudeCliNotFoundError` to self-disable for the
+// rest of the process lifetime instead of retrying with a generic
+// ENOENT. Lives here (not in `archivist-cli.ts`) so the synchronous
+// throw from `claudeBinPath()` produces the same typed contract as
+// the existing async ENOENT detection at every spawn site —
+// archivist-cli re-exports for backward compatibility.
+export class ClaudeCliNotFoundError extends Error {
+  constructor(message?: string) {
+    super(message ?? "`claude` CLI is not available on PATH");
+    this.name = "ClaudeCliNotFoundError";
+  }
+}
+
 export interface ResolveOptions {
   /** Defaults to `process.platform`. */
   readonly platform?: typeof process.platform;
@@ -77,7 +92,7 @@ export function claudeBinPath(options: ResolveOptions = {}): string {
     return resolved.path;
   }
   cachedBin = null;
-  throw new Error(formatNotFoundError(options));
+  throw new ClaudeCliNotFoundError(formatNotFoundError(options));
 }
 
 interface Resolved {
@@ -177,23 +192,36 @@ function* walkUpForPackage(options: ResolveOptions, startDir: string): Generator
 function* pnpmGlobalCandidates(options: ResolveOptions, dir: string): Generator<string> {
   const readdirSync = options.readdirSync ?? nodeReaddirSync;
   const globalDir = winPath.join(dir, "global");
-  let entries: ReturnType<typeof nodeReaddirSync>;
+  let result: unknown;
   try {
-    entries = readdirSync(globalDir);
+    result = readdirSync(globalDir);
   } catch {
     return;
   }
-  for (const entry of entries) {
-    const name = typeof entry === "string" ? entry : entry.name;
-    yield winPath.join(globalDir, name, "node_modules", PACKAGE_REL_PATH);
+  // `readdirSync`'s overload union (`string[] | Buffer[] | Dirent[]`)
+  // can't be narrowed by the default invocation alone; filter for the
+  // string case we care about so the helper stays robust even if a
+  // caller (test mock or alternate fs adapter) hands back a different
+  // shape.
+  if (!Array.isArray(result)) return;
+  for (const entry of result) {
+    if (typeof entry !== "string") continue;
+    yield winPath.join(globalDir, entry, "node_modules", PACKAGE_REL_PATH);
   }
 }
 
+// Probe helper for the small `where claude.cmd` / `npm config get
+// prefix` lookups during resolution. `shell: true` on Windows so the
+// `.cmd` shim for `npm` resolves cleanly (same CVE-2024-27980 reason
+// we're avoiding for the agent calls — but these probes are fixed,
+// short commands well below the cmd.exe 8191-char limit, so the
+// shell wrap is safe here).
 function runSpawnSync(options: ResolveOptions, command: string, args: readonly string[]): string | null {
   const spawnSync = options.spawnSync ?? nodeSpawnSync;
+  const useShell = (options.platform ?? process.platform) === "win32";
   let result: SpawnSyncReturns<string>;
   try {
-    result = spawnSync(command, args, { encoding: "utf8" });
+    result = spawnSync(command, args, { encoding: "utf8", shell: useShell });
   } catch {
     return null;
   }

--- a/server/utils/claudeBin.ts
+++ b/server/utils/claudeBin.ts
@@ -1,0 +1,198 @@
+// Cross-platform resolver for the `claude` CLI binary used by every
+// `child_process.spawn(...)` call site that talks to Claude Code (the
+// main agent, the journal pass, the chat-index summariser, and the
+// translation service).
+//
+// Context: on Windows, `child_process.spawn("claude", …)` falls into
+// a triple-bind that takes MulmoClaude offline as soon as it is
+// installed on a Windows host (#1757):
+//
+//   - `spawn("claude", args)`            → ENOENT (extensionless)
+//   - `spawn("claude.cmd", args)`        → EINVAL since CVE-2024-27980
+//   - `spawn("claude", args, {shell:true})`
+//                                        → cmd.exe wraps the call and
+//                                          trips the 8191-char limit
+//                                          once MCP args land
+//
+// The only escape that respects all three constraints is to spawn the
+// native `claude.exe` directly (no wrapper, no shell, full Win32
+// command-line headroom). On every non-Windows platform the literal
+// string "claude" works fine — there is no .cmd / cmd.exe involvement
+// and PATH lookup behaves the way Node's documentation describes.
+
+import { spawnSync as nodeSpawnSync, type SpawnSyncReturns } from "node:child_process";
+import { existsSync as nodeExistsSync } from "node:fs";
+import path from "node:path";
+
+// All Windows-side path joins go through `path.win32` so the candidates
+// we generate use backslash separators even when the host running this
+// code is Posix (e.g. unit tests on macOS). On a real Windows host
+// `path.win32` and `path` are the same module.
+const winPath = path.win32;
+
+const PACKAGE_REL_PATH = winPath.join("@anthropic-ai", "claude-code", "bin", "claude.exe");
+const PARENT_WALK_DEPTH = 4;
+const INSTALL_HINT = "Install with: npm install -g @anthropic-ai/claude-code";
+
+export interface ResolveOptions {
+  /** Defaults to `process.platform`. */
+  readonly platform?: typeof process.platform;
+  /** Defaults to `node:child_process` `spawnSync`. */
+  readonly spawnSync?: typeof nodeSpawnSync;
+  /** Defaults to `node:fs` `existsSync`. */
+  readonly existsSync?: typeof nodeExistsSync;
+  /** Defaults to `process.env`. */
+  readonly env?: typeof process.env;
+  /** Tests reset the module-level cache between cases. */
+  readonly resetCache?: boolean;
+}
+
+let cachedBin: string | null | undefined;
+
+/**
+ * Returns the binary to hand to `child_process.spawn(...)` for the
+ * claude CLI. On non-Windows this is the string "claude" (PATH lookup);
+ * on Windows this is the absolute path to a `claude.exe` we located
+ * via PATH probing or known package-manager prefixes.
+ *
+ * Throws a descriptive `Error` (with install hint) when every probe on
+ * Windows misses — that surfaces a clear "install the CLI" message
+ * instead of an opaque ENOENT later inside `spawn`.
+ */
+export function claudeBinPath(options: ResolveOptions = {}): string {
+  if (options.resetCache) cachedBin = undefined;
+  if (typeof cachedBin === "string") return cachedBin;
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    cachedBin = "claude";
+    return cachedBin;
+  }
+  const resolved = resolveOnWindows(options);
+  if (resolved) {
+    cachedBin = resolved.path;
+    return resolved.path;
+  }
+  cachedBin = null;
+  throw new Error(formatNotFoundError(options));
+}
+
+interface Resolved {
+  readonly path: string;
+}
+
+function resolveOnWindows(options: ResolveOptions): Resolved | null {
+  for (const candidate of windowsCandidates(options)) {
+    if (callExistsSync(options, candidate)) return { path: candidate };
+  }
+  return null;
+}
+
+// Generator of candidate `claude.exe` paths to probe, in priority
+// order. Lazy so we stop the moment `resolveOnWindows` finds a hit.
+function* windowsCandidates(options: ResolveOptions): Generator<string> {
+  yield* candidatesFromWhereProbe(options);
+  yield* candidatesFromNpmPrefix(options);
+  yield* candidatesFromEnvDefaults(options);
+}
+
+// 1. `where claude.cmd` — the canonical PATH probe. Each output line
+//    is a path to a .cmd wrapper; walk up to PARENT_WALK_DEPTH levels
+//    looking for `node_modules/@anthropic-ai/claude-code/bin/claude.exe`.
+//    Covers npm-global, yarn-global, pnpm-global, nvm-windows, Volta,
+//    and any custom `npm prefix -g` because we are starting from a
+//    real PATH entry.
+function* candidatesFromWhereProbe(options: ResolveOptions): Generator<string> {
+  const out = runSpawnSync(options, "where", ["claude.cmd"]);
+  if (!out) return;
+  for (const line of out.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    yield* walkUpForPackage(winPath.dirname(trimmed));
+  }
+}
+
+// 2. `npm config get prefix` — covers the case where the npm prefix
+//    is not on PATH (rare, but happens when shells are configured
+//    without the npm bin shim).
+function* candidatesFromNpmPrefix(options: ResolveOptions): Generator<string> {
+  const out = runSpawnSync(options, "npm", ["config", "get", "prefix"]);
+  if (!out) return;
+  const prefix = out.trim();
+  if (prefix) yield winPath.join(prefix, "node_modules", PACKAGE_REL_PATH);
+}
+
+// 3. Standard env-var-anchored defaults for npm / yarn / pnpm.
+function* candidatesFromEnvDefaults(options: ResolveOptions): Generator<string> {
+  const env = options.env ?? process.env;
+  const appData = env.APPDATA;
+  const localAppData = env.LOCALAPPDATA;
+  if (appData) {
+    // npm default global prefix.
+    yield winPath.join(appData, "npm", "node_modules", PACKAGE_REL_PATH);
+  }
+  if (localAppData) {
+    // Yarn classic global node_modules layout.
+    yield winPath.join(localAppData, "Yarn", "config", "global", "node_modules", PACKAGE_REL_PATH);
+    // pnpm global is `<root>/global/<version>/node_modules/...` —
+    // we cannot list directories without `fs` so probe the most
+    // common shape and let walk-up catch the rest from step 1.
+    yield winPath.join(localAppData, "pnpm", "global", "5", "node_modules", PACKAGE_REL_PATH);
+    yield winPath.join(localAppData, "pnpm", "global", "6", "node_modules", PACKAGE_REL_PATH);
+  }
+}
+
+// Walk up from `startDir` looking for the @anthropic-ai/claude-code
+// package's `claude.exe`. Yields candidate paths; the outer loop
+// checks `existsSync` to keep the test seam small.
+//
+// At each level we probe a handful of subpaths to cover the three
+// package managers' layouts:
+//   - npm:   `<bin-dir>/node_modules/...`               (same dir as cmd)
+//   - yarn:  `<prefix>/config/global/node_modules/...`  (sibling of bin/)
+//   - pnpm:  `<prefix>/global/<version>/node_modules/...`
+// `<bin-dir>` here is the dir that contained the `.cmd` wrapper, so
+// step 0 catches npm immediately and step 1 catches the typical yarn
+// classic install one level up.
+function* walkUpForPackage(startDir: string): Generator<string> {
+  let dir = startDir;
+  for (let depth = 0; depth <= PARENT_WALK_DEPTH; depth++) {
+    yield winPath.join(dir, "node_modules", PACKAGE_REL_PATH);
+    yield winPath.join(dir, "config", "global", "node_modules", PACKAGE_REL_PATH);
+    for (const pnpmVer of ["5", "6", "7"]) {
+      yield winPath.join(dir, "global", pnpmVer, "node_modules", PACKAGE_REL_PATH);
+    }
+    const parent = winPath.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+}
+
+function runSpawnSync(options: ResolveOptions, command: string, args: readonly string[]): string | null {
+  const spawnSync = options.spawnSync ?? nodeSpawnSync;
+  let result: SpawnSyncReturns<string>;
+  try {
+    result = spawnSync(command, args, { encoding: "utf8" });
+  } catch {
+    return null;
+  }
+  if (result.error || result.status !== 0) return null;
+  if (typeof result.stdout !== "string") return null;
+  return result.stdout;
+}
+
+function callExistsSync(options: ResolveOptions, candidate: string): boolean {
+  const existsSync = options.existsSync ?? nodeExistsSync;
+  try {
+    return existsSync(candidate);
+  } catch {
+    return false;
+  }
+}
+
+function formatNotFoundError(options: ResolveOptions): string {
+  const probed = [...windowsCandidates(options)];
+  const lines = ["claude CLI binary not found. Tried:"];
+  for (const probe of probed) lines.push(`  - ${probe}`);
+  lines.push(INSTALL_HINT);
+  return lines.join("\n");
+}

--- a/server/utils/claudeBin.ts
+++ b/server/utils/claudeBin.ts
@@ -21,7 +21,7 @@
 // and PATH lookup behaves the way Node's documentation describes.
 
 import { spawnSync as nodeSpawnSync, type SpawnSyncReturns } from "node:child_process";
-import { existsSync as nodeExistsSync } from "node:fs";
+import { existsSync as nodeExistsSync, readdirSync as nodeReaddirSync } from "node:fs";
 import path from "node:path";
 
 // All Windows-side path joins go through `path.win32` so the candidates
@@ -41,6 +41,10 @@ export interface ResolveOptions {
   readonly spawnSync?: typeof nodeSpawnSync;
   /** Defaults to `node:fs` `existsSync`. */
   readonly existsSync?: typeof nodeExistsSync;
+  /** Defaults to `node:fs` `readdirSync`. Used to enumerate pnpm's
+   *  `global/<version>/` directories so the probe stays version-
+   *  agnostic (pnpm bumps the global-store major every few releases). */
+  readonly readdirSync?: typeof nodeReaddirSync;
   /** Defaults to `process.env`. */
   readonly env?: typeof process.env;
   /** Tests reset the module-level cache between cases. */
@@ -107,7 +111,7 @@ function* candidatesFromWhereProbe(options: ResolveOptions): Generator<string> {
   for (const line of out.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    yield* walkUpForPackage(winPath.dirname(trimmed));
+    yield* walkUpForPackage(options, winPath.dirname(trimmed));
   }
 }
 
@@ -134,10 +138,9 @@ function* candidatesFromEnvDefaults(options: ResolveOptions): Generator<string> 
     // Yarn classic global node_modules layout.
     yield winPath.join(localAppData, "Yarn", "config", "global", "node_modules", PACKAGE_REL_PATH);
     // pnpm global is `<root>/global/<version>/node_modules/...` —
-    // we cannot list directories without `fs` so probe the most
-    // common shape and let walk-up catch the rest from step 1.
-    yield winPath.join(localAppData, "pnpm", "global", "5", "node_modules", PACKAGE_REL_PATH);
-    yield winPath.join(localAppData, "pnpm", "global", "6", "node_modules", PACKAGE_REL_PATH);
+    // enumerate `<root>/global/` so every current and future major
+    // (5, 6, 7, 8, …) is picked up automatically.
+    yield* pnpmGlobalCandidates(options, winPath.join(localAppData, "pnpm"));
   }
 }
 
@@ -153,17 +156,36 @@ function* candidatesFromEnvDefaults(options: ResolveOptions): Generator<string> 
 // `<bin-dir>` here is the dir that contained the `.cmd` wrapper, so
 // step 0 catches npm immediately and step 1 catches the typical yarn
 // classic install one level up.
-function* walkUpForPackage(startDir: string): Generator<string> {
+function* walkUpForPackage(options: ResolveOptions, startDir: string): Generator<string> {
   let dir = startDir;
   for (let depth = 0; depth <= PARENT_WALK_DEPTH; depth++) {
     yield winPath.join(dir, "node_modules", PACKAGE_REL_PATH);
     yield winPath.join(dir, "config", "global", "node_modules", PACKAGE_REL_PATH);
-    for (const pnpmVer of ["5", "6", "7"]) {
-      yield winPath.join(dir, "global", pnpmVer, "node_modules", PACKAGE_REL_PATH);
-    }
+    yield* pnpmGlobalCandidates(options, dir);
     const parent = winPath.dirname(dir);
     if (parent === dir) break;
     dir = parent;
+  }
+}
+
+// pnpm's global store lives at `<root>/global/<major-version>/...` and
+// the major bumps every few releases (5, 6, 7, 8, ...). Hard-coding a
+// version list ages badly — enumerate the `global/` dir at probe time
+// instead so any current and future major picks up automatically.
+// Silent-skip when `<dir>/global/` doesn't exist or isn't readable;
+// readdirSync throwing must not abort the wider candidate walk.
+function* pnpmGlobalCandidates(options: ResolveOptions, dir: string): Generator<string> {
+  const readdirSync = options.readdirSync ?? nodeReaddirSync;
+  const globalDir = winPath.join(dir, "global");
+  let entries: ReturnType<typeof nodeReaddirSync>;
+  try {
+    entries = readdirSync(globalDir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    yield winPath.join(globalDir, name, "node_modules", PACKAGE_REL_PATH);
   }
 }
 

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -22,6 +22,7 @@ import { errorMessage } from "../../utils/errors.js";
 import type { SummaryResult } from "./types.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";
 import { isRecord } from "../../utils/types.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 
 const SYSTEM_PROMPT =
   "You summarize a single chat session. Output strict JSON matching the provided schema. " +
@@ -195,7 +196,7 @@ function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string>
     ];
     // Run from tmpdir so claude does not load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
-    const proc = spawn("claude", args, {
+    const proc = spawn(claudeBinPath(), args, {
       cwd: tmpdir(),
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -2,19 +2,19 @@
 
 import { spawn } from "node:child_process";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
-import { claudeBinPath } from "../../utils/claudeBin.js";
+import { claudeBinPath, ClaudeCliNotFoundError } from "../../utils/claudeBin.js";
 
 export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
 
 const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
 
-// Subsystem-neutral message: chat-index / sources also catch this and would otherwise log a misleading "journal disabled".
-export class ClaudeCliNotFoundError extends Error {
-  constructor() {
-    super("`claude` CLI is not available on PATH");
-    this.name = "ClaudeCliNotFoundError";
-  }
-}
+// Re-exported so the dozen-plus consumers across journal/memory/chat-
+// index/translation that already import `ClaudeCliNotFoundError` from
+// this module keep working without a code mod. The canonical home is
+// `server/utils/claudeBin.ts` (where `claudeBinPath()` throws it on a
+// failed Windows probe), this re-export preserves the existing
+// import path and dependency direction.
+export { ClaudeCliNotFoundError };
 
 export class ClaudeCliFailedError extends Error {
   readonly exitCode: number | null;

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -2,6 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
+import { claudeBinPath } from "../../utils/claudeBin.js";
 
 export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
 
@@ -29,7 +30,7 @@ export class ClaudeCliFailedError extends Error {
 // Pipe the combined prompt via stdin to dodge shell-argv limits for large day excerpts.
 export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) =>
   new Promise((resolve, reject) => {
-    const child = spawn("claude", ["-p", "--output-format", "text"], {
+    const child = spawn(claudeBinPath(), ["-p", "--output-format", "text"], {
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/test/utils/test_claudeBin.ts
+++ b/test/utils/test_claudeBin.ts
@@ -7,7 +7,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { SpawnSyncReturns } from "node:child_process";
 import path from "node:path";
-import { claudeBinPath, type ResolveOptions } from "../../server/utils/claudeBin.js";
+import { claudeBinPath, ClaudeCliNotFoundError, type ResolveOptions } from "../../server/utils/claudeBin.js";
 
 // All probed paths in claudeBin.ts use `path.win32`, so tests must
 // compose / normalise expected paths the same way to compare equal
@@ -146,6 +146,12 @@ describe("claudeBinPath — Windows resolution", () => {
     assert.throws(
       () => claudeBinPath(opts),
       (err: Error) => {
+        // Must be the typed error consumers across journal / memory /
+        // chat-index / translation pattern-match on with
+        // `err instanceof ClaudeCliNotFoundError` — a generic Error
+        // here would bypass each subsystem's self-disable latch and
+        // they'd keep retrying instead.
+        assert.ok(err instanceof ClaudeCliNotFoundError, `expected ClaudeCliNotFoundError, got ${err.name}`);
         assert.match(err.message, /claude CLI binary not found/);
         assert.match(err.message, /Install with: npm install -g @anthropic-ai\/claude-code/);
         assert.match(err.message, /AppData\\Roaming\\npm/);

--- a/test/utils/test_claudeBin.ts
+++ b/test/utils/test_claudeBin.ts
@@ -1,0 +1,165 @@
+// Unit tests for `claudeBinPath()` cross-platform resolution. The
+// helper accepts injectable `platform` / `spawnSync` / `existsSync` /
+// `env` so we can simulate every install layout without actually
+// having `@anthropic-ai/claude-code` on disk.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { SpawnSyncReturns } from "node:child_process";
+import path from "node:path";
+import { claudeBinPath, type ResolveOptions } from "../../server/utils/claudeBin.js";
+
+// All probed paths in claudeBin.ts use `path.win32`, so tests must
+// compose / normalise expected paths the same way to compare equal
+// regardless of which OS the test runner is on.
+const winPath = path.win32;
+
+const FAKE_NPM_PREFIX = "C:\\Users\\test\\AppData\\Roaming\\npm";
+const FAKE_YARN_BIN = "C:\\Users\\test\\AppData\\Local\\Yarn\\bin";
+const NPM_CLAUDE_EXE = winPath.join(FAKE_NPM_PREFIX, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+const YARN_CLAUDE_EXE = winPath.join(
+  "C:\\Users\\test\\AppData\\Local\\Yarn",
+  "config",
+  "global",
+  "node_modules",
+  "@anthropic-ai",
+  "claude-code",
+  "bin",
+  "claude.exe",
+);
+
+interface FakeSpawnCase {
+  readonly command: string;
+  readonly stdout: string;
+  readonly status?: number;
+}
+
+function makeSpawnSync(cases: readonly FakeSpawnCase[]): typeof import("node:child_process").spawnSync {
+  return ((cmd: string): SpawnSyncReturns<string> => {
+    const hit = cases.find((entry) => entry.command === cmd);
+    if (!hit) return { pid: 0, output: [], stdout: "", stderr: "", status: 1, signal: null };
+    return { pid: 0, output: [], stdout: hit.stdout, stderr: "", status: hit.status ?? 0, signal: null };
+  }) as never;
+}
+
+function makeExistsSync(existingPaths: readonly string[]): typeof import("node:fs").existsSync {
+  const set = new Set(existingPaths.map((candidate) => winPath.normalize(candidate)));
+  return ((candidate: string | URL | Buffer): boolean => {
+    if (typeof candidate !== "string") return false;
+    return set.has(winPath.normalize(candidate));
+  }) as typeof import("node:fs").existsSync;
+}
+
+function commonOpts(overrides: Partial<ResolveOptions> = {}): ResolveOptions {
+  return {
+    platform: "win32",
+    env: {},
+    resetCache: true,
+    spawnSync: makeSpawnSync([]),
+    existsSync: makeExistsSync([]),
+    ...overrides,
+  };
+}
+
+describe("claudeBinPath — non-Windows", () => {
+  it("returns the literal 'claude' on darwin", () => {
+    assert.equal(claudeBinPath({ platform: "darwin", resetCache: true }), "claude");
+  });
+
+  it("returns the literal 'claude' on linux", () => {
+    assert.equal(claudeBinPath({ platform: "linux", resetCache: true }), "claude");
+  });
+
+  it("never probes spawnSync on non-Windows (no install required)", () => {
+    let calls = 0;
+    const spawnSync = ((cmd: string): SpawnSyncReturns<string> => {
+      calls++;
+      return { pid: 0, output: [], stdout: "", stderr: "", status: 0, signal: null, command: cmd } as never;
+    }) as never;
+    claudeBinPath({ platform: "darwin", spawnSync, resetCache: true });
+    assert.equal(calls, 0);
+  });
+});
+
+describe("claudeBinPath — Windows resolution", () => {
+  it("resolves via `where claude.cmd` (npm layout: bin/claude.cmd sibling of node_modules)", () => {
+    const claudeCmd = winPath.join(FAKE_NPM_PREFIX, "claude.cmd");
+    const opts = commonOpts({
+      spawnSync: makeSpawnSync([{ command: "where", stdout: `${claudeCmd}\r\n` }]),
+      existsSync: makeExistsSync([NPM_CLAUDE_EXE]),
+    });
+    assert.equal(claudeBinPath(opts), NPM_CLAUDE_EXE);
+  });
+
+  it("resolves via `where claude.cmd` (yarn layout: walk up to find node_modules)", () => {
+    // Yarn classic puts claude.cmd in AppData\Local\Yarn\bin\ but the
+    // real package lives in AppData\Local\Yarn\config\global\node_modules\…
+    // — two directories above bin/.
+    const claudeCmd = winPath.join(FAKE_YARN_BIN, "claude.cmd");
+    const opts = commonOpts({
+      spawnSync: makeSpawnSync([{ command: "where", stdout: claudeCmd }]),
+      existsSync: makeExistsSync([YARN_CLAUDE_EXE]),
+    });
+    assert.equal(claudeBinPath(opts), YARN_CLAUDE_EXE);
+  });
+
+  it("falls back to `npm config get prefix` when `where` returns nothing", () => {
+    const opts = commonOpts({
+      spawnSync: makeSpawnSync([
+        { command: "where", stdout: "", status: 1 },
+        { command: "npm", stdout: `${FAKE_NPM_PREFIX}\r\n` },
+      ]),
+      existsSync: makeExistsSync([NPM_CLAUDE_EXE]),
+    });
+    assert.equal(claudeBinPath(opts), NPM_CLAUDE_EXE);
+  });
+
+  it("falls back to %APPDATA%\\npm default when neither `where` nor `npm` produce a hit", () => {
+    const opts = commonOpts({
+      spawnSync: makeSpawnSync([]),
+      existsSync: makeExistsSync([NPM_CLAUDE_EXE]),
+      env: { APPDATA: "C:\\Users\\test\\AppData\\Roaming" },
+    });
+    assert.equal(claudeBinPath(opts), NPM_CLAUDE_EXE);
+  });
+
+  it("throws a descriptive error listing every probed path when nothing is found", () => {
+    const opts = commonOpts({
+      env: { APPDATA: "C:\\Users\\test\\AppData\\Roaming", LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
+    });
+    assert.throws(
+      () => claudeBinPath(opts),
+      (err: Error) => {
+        assert.match(err.message, /claude CLI binary not found/);
+        assert.match(err.message, /Install with: npm install -g @anthropic-ai\/claude-code/);
+        assert.match(err.message, /AppData\\Roaming\\npm/);
+        assert.match(err.message, /Yarn\\config\\global/);
+        assert.match(err.message, /pnpm/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("claudeBinPath — caching", () => {
+  it("caches the resolved path on Windows — second call doesn't re-probe", () => {
+    let spawnCalls = 0;
+    const spawnSync = ((cmd: string): SpawnSyncReturns<string> => {
+      spawnCalls++;
+      if (cmd === "where") {
+        return { pid: 0, output: [], stdout: winPath.join(FAKE_NPM_PREFIX, "claude.cmd"), stderr: "", status: 0, signal: null } as never;
+      }
+      return { pid: 0, output: [], stdout: "", stderr: "", status: 1, signal: null } as never;
+    }) as never;
+    const opts = commonOpts({
+      spawnSync,
+      existsSync: makeExistsSync([NPM_CLAUDE_EXE]),
+      resetCache: true,
+    });
+    assert.equal(claudeBinPath(opts), NPM_CLAUDE_EXE);
+    const callsAfterFirst = spawnCalls;
+    // Second call without resetCache should hit the module-level cache.
+    assert.equal(claudeBinPath({ ...opts, resetCache: false }), NPM_CLAUDE_EXE);
+    assert.equal(spawnCalls, callsAfterFirst, "spawnSync should NOT be called again after the first resolution");
+  });
+});

--- a/test/utils/test_claudeBin.ts
+++ b/test/utils/test_claudeBin.ts
@@ -50,6 +50,21 @@ function makeExistsSync(existingPaths: readonly string[]): typeof import("node:f
   }) as typeof import("node:fs").existsSync;
 }
 
+// Map directory → entry names. Lookup uses normalized win32 paths so
+// tests can declare keys in either separator style.
+function makeReaddirSync(dirs: Record<string, readonly string[]>): typeof import("node:fs").readdirSync {
+  const normalized: Record<string, readonly string[]> = {};
+  for (const [dir, entries] of Object.entries(dirs)) {
+    normalized[winPath.normalize(dir)] = entries;
+  }
+  return ((dir: string | URL | Buffer): string[] => {
+    if (typeof dir !== "string") throw new Error("ENOENT");
+    const hit = normalized[winPath.normalize(dir)];
+    if (!hit) throw new Error("ENOENT");
+    return [...hit];
+  }) as typeof import("node:fs").readdirSync;
+}
+
 function commonOpts(overrides: Partial<ResolveOptions> = {}): ResolveOptions {
   return {
     platform: "win32",
@@ -57,6 +72,7 @@ function commonOpts(overrides: Partial<ResolveOptions> = {}): ResolveOptions {
     resetCache: true,
     spawnSync: makeSpawnSync([]),
     existsSync: makeExistsSync([]),
+    readdirSync: makeReaddirSync({}),
     ...overrides,
   };
 }
@@ -134,10 +150,53 @@ describe("claudeBinPath — Windows resolution", () => {
         assert.match(err.message, /Install with: npm install -g @anthropic-ai\/claude-code/);
         assert.match(err.message, /AppData\\Roaming\\npm/);
         assert.match(err.message, /Yarn\\config\\global/);
-        assert.match(err.message, /pnpm/);
+        // pnpm coverage is asserted by the dedicated `pnpm version-
+        // agnostic global probe` tests below — the entries only appear
+        // here when readdirSync actually finds `<root>/global/<v>/`.
         return true;
       },
     );
+  });
+});
+
+describe("claudeBinPath — pnpm version-agnostic global probe", () => {
+  // Regression for the hard-coded `5/6/7` pnpm version list (Codex
+  // review on PR #1769): enumerate `<root>/global/` via readdirSync
+  // so a current pnpm install with `global/15/` is picked up.
+  it("resolves a pnpm v15 layout (`%LOCALAPPDATA%\\pnpm\\global\\15\\node_modules\\…`)", () => {
+    const pnpmRoot = "C:\\Users\\test\\AppData\\Local\\pnpm";
+    const pnpmGlobal = winPath.join(pnpmRoot, "global");
+    const claudeExe = winPath.join(pnpmGlobal, "15", "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+    const opts = commonOpts({
+      env: { LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
+      existsSync: makeExistsSync([claudeExe]),
+      readdirSync: makeReaddirSync({ [pnpmGlobal]: ["15"] }),
+    });
+    assert.equal(claudeBinPath(opts), claudeExe);
+  });
+
+  it("resolves a pnpm v8 layout when readdir yields multiple majors", () => {
+    const pnpmRoot = "C:\\Users\\test\\AppData\\Local\\pnpm";
+    const pnpmGlobal = winPath.join(pnpmRoot, "global");
+    const claudeExe = winPath.join(pnpmGlobal, "8", "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+    const opts = commonOpts({
+      env: { LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
+      existsSync: makeExistsSync([claudeExe]),
+      // Stale directories from older majors stick around — probe must
+      // try every entry and pick the one that has the binary on disk.
+      readdirSync: makeReaddirSync({ [pnpmGlobal]: ["5", "6", "7", "8"] }),
+    });
+    assert.equal(claudeBinPath(opts), claudeExe);
+  });
+
+  it("silently skips pnpm enumeration when `<root>/global` is missing", () => {
+    // No env, no spawn hits, no readdir entries — the probe must fall
+    // through to the descriptive "not found" error without crashing on
+    // a missing pnpm install.
+    const opts = commonOpts({
+      env: { LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
+    });
+    assert.throws(() => claudeBinPath(opts), /claude CLI binary not found/);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1757. On Windows, every `child_process.spawn("claude", …)` call site fell into a triple-bind that took MulmoClaude offline (chat / journal / summarizer / translation all broken) as soon as it was installed on a Windows host:

| Attempt | Failure |
|---|---|
| `spawn("claude", args)` | `ENOENT` — Node looks for an extensionless executable |
| `spawn("claude.cmd", args)` | `EINVAL` — CVE-2024-27980 hardening rejects `.cmd` |
| `spawn("claude", args, { shell: true })` | "コマンドラインが長すぎます" — cmd.exe wraps the call and trips the 8191-char limit once MCP-config + system-prompt args land |

Only escape that respects all three constraints is to spawn the native `claude.exe` directly (no wrapper, no shell, full Win32 long-command-line headroom).

## Items to Confirm / Review

- **Non-Windows is byte-for-byte unchanged.** `claudeBinPath()` returns the literal string `"claude"` when `process.platform !== "win32"`. macOS / Linux / Docker (Linux) / WSL all hit this early-return — no `spawnSync` probes, no env lookups, no caching beyond the trivial.
- **Windows resolution order**:
  1. `where claude.cmd` → walk up 4 levels probing `<dir>/node_modules/@anthropic-ai/claude-code/bin/claude.exe` plus the yarn-classic (`config/global/`) and pnpm (`global/<v>/`) subpath variants. Covers npm-global, yarn-global, pnpm-global, nvm-windows, Volta, and any custom `npm prefix -g`.
  2. `npm config get prefix` fallback.
  3. Env-anchored defaults (`%APPDATA%\npm`, `%LOCALAPPDATA%\Yarn\config\global`, `%LOCALAPPDATA%\pnpm\global\<v>`).
  4. Throws a descriptive `Error` listing every probed path + install hint.
- **All Windows-side `path.join` goes through `path.win32`** so the helper produces correct backslash paths even when running on Posix unit-test runners.
- **`server/system/credentials.ts` is intentionally NOT touched** — it uses `node-pty`'s `pty.spawn` which has its own conpty/winpty wrapping and is not subject to CVE-2024-27980 / cmd.exe limits.
- **PR #1571 listed 6 spawn sites** but two of those (`sources/classifier.ts`, `sources/pipeline/summarize.ts`) have been removed from main since the contributor opened that PR. Current surface is 4 sites — all swapped.

## Files

| Path | Change |
|---|---|
| `server/utils/claudeBin.ts` | **new** — helper |
| `test/utils/test_claudeBin.ts` | **new** — 8 cases (non-Windows pass-through, where-probe npm + yarn layouts, npm-prefix fallback, env-default fallback, descriptive not-found error, cache hit) |
| `server/agent/backend/claude-code.ts` | swap `spawn("claude", …)` → `spawn(claudeBinPath(), …)` |
| `server/workspace/journal/archivist-cli.ts` | same |
| `server/workspace/chat-index/summarizer.ts` | same |
| `server/services/translation/llm.ts` | same |
| `plans/fix-windows-claude-spawn-1757.md` | implementation plan |

## User Prompt

> 1571はissue化してこのprはclose 改めてissueをもとに対策しよう
>
> 着手！

(`@lapispapyrus`'s closed PR #1571 documented the 3-failure-mode analysis; we re-implemented from scratch to broaden path-resolution robustness across npm / yarn / pnpm / nvm-windows / Volta / custom `npm prefix -g`.)

## Test plan

- [x] `yarn test` — new `test/utils/test_claudeBin.ts` 8 cases pass
- [x] Existing tests on macOS — non-Windows path returns "claude" unchanged, so the wider suite is unaffected
- [ ] **Windows manual smoke** — fresh Win11 install with `npm install -g @anthropic-ai/claude-code` → MulmoClaude chat starts cleanly without ENOENT / EINVAL / "コマンドラインが長すぎます"

## Credit

Problem reproduction + 3-failure-mode analysis: @lapispapyrus on the now-closed PR #1571. This PR re-implements with broader package-manager coverage per the rationale in issue #1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows support when launching the Claude CLI by resolving the correct executable path instead of relying on command lookup.
  * Added clearer, more actionable error messaging when the Claude CLI can’t be located on Windows.
  * Updated multiple Claude-powered features to use the resolved executable while keeping existing input/output handling the same.
* **Tests**
  * Added unit tests covering binary resolution across common install layouts, missing-binary messaging, and resolution caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->