### PR TITLE
feat(collections): show collection in canvas instantly on slash-command chat

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -339,7 +339,8 @@ import { EVENT_TYPES } from "./types/events";
 import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import { resolvePastedAttachment } from "./utils/agent/pastedAttachment";
 import { applyAgentEvent, type AgentEventContext } from "./utils/agent/eventDispatch";
-import { pushErrorMessage, beginUserTurn, updateResult } from "./utils/session/sessionHelpers";
+import { pushErrorMessage, beginUserTurn, updateResult, applyToolResultToSession } from "./utils/session/sessionHelpers";
+import { parseCollectionSlashSeed, makeSyntheticCollectionResult } from "./utils/collections/presentSeed";
 import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
@@ -370,6 +371,7 @@ import ConfirmModal from "./components/ConfirmModal.vue";
 import { useNotifications } from "./composables/useNotifications";
 import { collectionNotifiedSeverities } from "./utils/collections/notifiedItems";
 import { installCollectionAppBindings } from "./composables/collections/uiHost";
+import type { CollectionsListResponse } from "@mulmoclaude/collection-plugin";
 import { useHealth } from "./composables/useHealth";
 import { useSessionHistory } from "./composables/useSessionHistory";
 import { useRightSidebar } from "./composables/useRightSidebar";
@@ -1106,6 +1108,35 @@ function startNewChat(message: string, roleId?: string): void {
   // is now handled inside createNewSession via the isChatPage check.
   createNewSession(roleId);
   void sendMessage(message);
+  void seedCollectionPresentation(message);
+}
+
+// A chat seeded from a collection view carries that collection's slash command
+// (`/<slug> …`). Present the collection in the canvas immediately — a
+// client-side stand-in for the presentCollection call the agent makes moments
+// later — so the user isn't staring at an empty canvas during the round trip.
+// The placeholder is reconciled away once the real tool result arrives
+// (reconcileSyntheticCollection in eventDispatch). No-op for non-collection
+// slash commands (e.g. /deep-research) and plain prose.
+async function seedCollectionPresentation(message: string): Promise<void> {
+  const seed = parseCollectionSlashSeed(message);
+  if (!seed) return;
+  const session = activeSession.value;
+  if (!session) return;
+  if (!(await isKnownCollectionSlug(seed.slug))) return;
+  // The active session can change while the collection-list fetch is in flight
+  // (user starts another chat); only seed the session we parsed for.
+  if (activeSession.value?.id !== session.id) return;
+  applyToolResultToSession(session, makeSyntheticCollectionResult(seed.slug, seed.itemId));
+}
+
+// Confirm `slug` names a real collection before seeding — otherwise a
+// non-collection slash command would flash a "not found" collection canvas. On
+// fetch failure we skip the optimistic card; the agent still presents it.
+async function isKnownCollectionSlug(slug: string): Promise<boolean> {
+  const result = await apiGet<CollectionsListResponse>(API_ROUTES.collections.list);
+  if (!result.ok) return false;
+  return result.data.collections.some((collection) => collection.slug === slug);
 }
 
 // Like startNewChat, but prefills the composer with `message` as an editable

--- a/src/App.vue
+++ b/src/App.vue
@@ -340,7 +340,7 @@ import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import { resolvePastedAttachment } from "./utils/agent/pastedAttachment";
 import { applyAgentEvent, type AgentEventContext } from "./utils/agent/eventDispatch";
 import { pushErrorMessage, beginUserTurn, updateResult, applyToolResultToSession } from "./utils/session/sessionHelpers";
-import { parseCollectionSlashSeed, makeSyntheticCollectionResult } from "./utils/collections/presentSeed";
+import { parseCollectionSlashSeed, makeSyntheticCollectionResult, hasRealCollectionResult } from "./utils/collections/presentSeed";
 import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
@@ -1127,6 +1127,10 @@ async function seedCollectionPresentation(message: string): Promise<void> {
   // The active session can change while the collection-list fetch is in flight
   // (user starts another chat); only seed the session we parsed for.
   if (activeSession.value?.id !== session.id) return;
+  // Race guard: if the agent's real presentCollection result already arrived
+  // (fast agent, slow collection-list fetch), reconcile has nothing to remove,
+  // so seeding now would append a stale duplicate. Skip — the real card is up.
+  if (hasRealCollectionResult(session, seed.slug)) return;
   applyToolResultToSession(session, makeSyntheticCollectionResult(seed.slug, seed.itemId));
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1111,13 +1111,14 @@ function startNewChat(message: string, roleId?: string): void {
   void seedCollectionPresentation(message);
 }
 
-// A chat seeded from a collection view carries that collection's slash command
+// A chat started from a collection view carries that collection's slash command
 // (`/<slug> …`). Present the collection in the canvas immediately — a
-// client-side stand-in for the presentCollection call the agent makes moments
-// later — so the user isn't staring at an empty canvas during the round trip.
-// The placeholder is reconciled away once the real tool result arrives
-// (reconcileSyntheticCollection in eventDispatch). No-op for non-collection
-// slash commands (e.g. /deep-research) and plain prose.
+// client-side stand-in for the presentCollection call the agent makes when the
+// message is sent — so the collection is visible up front (#1768). Used by both
+// entry points: startNewChat (message sent) and startNewChatDraft (message left
+// as an editable draft). The placeholder is reconciled away once the real tool
+// result arrives (reconcileSyntheticCollection in eventDispatch). No-op for
+// non-collection slash commands (e.g. /deep-research) and plain prose.
 async function seedCollectionPresentation(message: string): Promise<void> {
   const seed = parseCollectionSlashSeed(message);
   if (!seed) return;
@@ -1148,13 +1149,16 @@ async function isKnownCollectionSlug(slug: string): Promise<boolean> {
 // Used by custom collection views (`__MC_VIEW.startChat`) so a view button can
 // propose a chat without the view's code triggering an agent run on its own.
 // `roleId` is validated against the known roles and falls back to General
-// (createNewSession does not validate the id it is handed).
+// (createNewSession does not validate the id it is handed). When the draft is a
+// collection slash command, the collection is presented in the canvas up front
+// (#1768) — presentCollection first, then the prefilled draft.
 function startNewChatDraft(message: string, roleId?: string): void {
   const rId = roleId && roles.value.some((role) => role.id === roleId) ? roleId : BUILTIN_ROLE_IDS.general;
   createNewSession(rId);
   userInput.value = message;
   chatInputRef.value?.collapseSuggestions();
   nextTick(() => focusChatInput());
+  void seedCollectionPresentation(message);
 }
 
 function handleAskGemini(): void {

--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -8,6 +8,7 @@ import type { ToolCallHistoryItem } from "../../types/toolCallHistory";
 import { findPendingToolCall, toToolCallEntry } from "./toolCalls";
 import { extractMcpHint } from "./mcpHint";
 import { pushErrorMessage, applySkillEvent, applyTextEvent, applyToolResultToSession } from "../session/sessionHelpers";
+import { reconcileSyntheticCollection } from "../collections/presentSeed";
 
 export interface AgentEventContext {
   session: ActiveSession;
@@ -71,6 +72,9 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       });
       return;
     case EVENT_TYPES.toolResult:
+      // Drop any client-seeded placeholder for this collection first, so the
+      // real presentCollection result replaces it instead of stacking.
+      reconcileSyntheticCollection(session, event.result);
       applyToolResultToSession(session, event.result);
       return;
     case EVENT_TYPES.error:

--- a/src/utils/collections/presentSeed.ts
+++ b/src/utils/collections/presentSeed.ts
@@ -1,0 +1,87 @@
+// Client-side seeding of a presentCollection card. When a chat is started from
+// a collection view, its seed message carries the collection's slash command
+// (`/<slug> …`). We show the collection in the canvas immediately — a stand-in
+// for the presentCollection call the agent makes moments later — so the user
+// isn't staring at an empty canvas during the round trip. The placeholder is
+// reconciled away when the real tool result arrives (see eventDispatch).
+//
+// Kept out of the generic session helpers so `sessionHelpers.ts` stays free of
+// any plugin coupling; the collection-specific knowledge lives here.
+
+import { v4 as uuidv4 } from "uuid";
+import { TOOL_NAME as PRESENT_COLLECTION_TOOL_NAME, type PresentCollectionData } from "@mulmoclaude/collection-plugin";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import type { ActiveSession } from "../../types/session";
+
+export interface CollectionSlashSeed {
+  slug: string;
+  itemId?: string;
+}
+
+/** Parse a collection slash-command chat seed (`/<slug> …` or
+ *  `/<slug> id=<itemId> …`, the shapes built by CollectionView's
+ *  `buildChatSeed`) into the addressing a synthetic presentCollection card
+ *  needs. The slug must not contain `/`, so a path-like input isn't mistaken
+ *  for a collection. Returns null when the message is not a slash command.
+ *  Pure; token-split rather than one regex to avoid a ReDoS-flagged pattern. */
+export function parseCollectionSlashSeed(message: string): CollectionSlashSeed | null {
+  const trimmed = message.trimStart();
+  if (!trimmed.startsWith("/")) return null;
+  const [slug, second] = trimmed.slice(1).split(/\s+/);
+  if (!slug || slug.includes("/")) return null;
+  const itemId = second?.startsWith("id=") ? second.slice(3) : "";
+  return itemId ? { slug, itemId } : { slug };
+}
+
+// Marker stashed on a client-seeded placeholder so the agent's real
+// presentCollection result supersedes it instead of stacking. Client-only;
+// never sent to the server.
+type SyntheticCollectionResult = ToolResultComplete<PresentCollectionData, PresentCollectionData> & {
+  syntheticCollection: true;
+};
+
+function isSyntheticCollection(result: ToolResultComplete): result is SyntheticCollectionResult {
+  return (result as Partial<SyntheticCollectionResult>).syntheticCollection === true;
+}
+
+function collectionSlugOf(result: ToolResultComplete): string | undefined {
+  const data = (result.data ?? result.jsonData) as PresentCollectionData | undefined;
+  return data?.collectionSlug;
+}
+
+/** Build the placeholder presentCollection card shown the instant a chat is
+ *  started from a collection view. Same render contract as the real tool
+ *  result — the View self-fetches from `collectionSlug` — but flagged so
+ *  {@link reconcileSyntheticCollection} drops it once the agent's real result
+ *  lands. */
+export function makeSyntheticCollectionResult(collectionSlug: string, itemId?: string): ToolResultComplete {
+  const data: PresentCollectionData = itemId ? { collectionSlug, itemId } : { collectionSlug };
+  const target = itemId ? `${collectionSlug} / ${itemId}` : collectionSlug;
+  const result: SyntheticCollectionResult = {
+    uuid: uuidv4(),
+    toolName: PRESENT_COLLECTION_TOOL_NAME,
+    message: `Presented collection ${target}`,
+    data,
+    jsonData: data,
+    syntheticCollection: true,
+  };
+  return result;
+}
+
+/** Option-2 reconcile: drop the client-seeded placeholder for the collection
+ *  that `incoming` (the agent's real presentCollection result) presents, so the
+ *  two don't stack. No-op unless `incoming` is a real presentCollection result
+ *  with a matching placeholder. Call BEFORE the result is applied. */
+export function reconcileSyntheticCollection(session: ActiveSession, incoming: ToolResultComplete): void {
+  if (incoming.toolName !== PRESENT_COLLECTION_TOOL_NAME || isSyntheticCollection(incoming)) return;
+  const slug = collectionSlugOf(incoming);
+  if (!slug) return;
+  const idx = session.toolResults.findIndex((candidate) => isSyntheticCollection(candidate) && collectionSlugOf(candidate) === slug);
+  if (idx < 0) return;
+  const [removed] = session.toolResults.splice(idx, 1);
+  session.resultTimestamps.delete(removed.uuid);
+  // The placeholder held the canvas selection; clear it so the real result's
+  // insert (applyToolResultToSession) re-selects and the canvas doesn't blink
+  // to a different card in between.
+  if (session.selectedResultUuid === removed.uuid) session.selectedResultUuid = null;
+}

--- a/src/utils/collections/presentSeed.ts
+++ b/src/utils/collections/presentSeed.ts
@@ -49,6 +49,17 @@ function collectionSlugOf(result: ToolResultComplete): string | undefined {
   return data?.collectionSlug;
 }
 
+/** True when the session already holds the agent's *real* presentCollection
+ *  result for `slug`. Guards the seeding path against the race where the
+ *  collection-list validation fetch resolves after the real result has already
+ *  arrived: by then {@link reconcileSyntheticCollection} has run with nothing to
+ *  remove, so inserting the placeholder would leave a stale duplicate card. */
+export function hasRealCollectionResult(session: ActiveSession, slug: string): boolean {
+  return session.toolResults.some(
+    (result) => result.toolName === PRESENT_COLLECTION_TOOL_NAME && !isSyntheticCollection(result) && collectionSlugOf(result) === slug,
+  );
+}
+
 /** Build the placeholder presentCollection card shown the instant a chat is
  *  started from a collection view. Same render contract as the real tool
  *  result — the View self-fetches from `collectionSlug` — but flagged so

--- a/test/utils/collections/test_presentSeed.ts
+++ b/test/utils/collections/test_presentSeed.ts
@@ -1,0 +1,91 @@
+// Covers the client-side presentCollection seeding: parsing a collection
+// slash-command chat seed, building the synthetic placeholder card, and the
+// option-2 reconcile that drops the placeholder when the agent's real
+// presentCollection result arrives (so the two don't stack).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseCollectionSlashSeed, makeSyntheticCollectionResult, reconcileSyntheticCollection } from "../../../src/utils/collections/presentSeed.js";
+import { createEmptySession } from "../../../src/utils/session/sessionFactory.js";
+import { TOOL_NAME as PRESENT_COLLECTION } from "@mulmoclaude/collection-plugin";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+
+describe("parseCollectionSlashSeed", () => {
+  it("parses a bare slash command", () => {
+    assert.deepEqual(parseCollectionSlashSeed("/clients"), { slug: "clients" });
+  });
+
+  it("parses a slash command with a trailing message", () => {
+    assert.deepEqual(parseCollectionSlashSeed("/clients add a new lead"), { slug: "clients" });
+  });
+
+  it("extracts an immediate id= selector", () => {
+    assert.deepEqual(parseCollectionSlashSeed("/invoices id=inv_42 mark as paid"), { slug: "invoices", itemId: "inv_42" });
+  });
+
+  it("ignores id= that is not the first token after the slug", () => {
+    assert.deepEqual(parseCollectionSlashSeed("/invoices mark id=inv_42"), { slug: "invoices" });
+  });
+
+  it("returns null for plain prose and path-like input", () => {
+    assert.equal(parseCollectionSlashSeed("just chatting"), null);
+    assert.equal(parseCollectionSlashSeed("/"), null);
+    assert.equal(parseCollectionSlashSeed("/foo/bar"), null);
+  });
+});
+
+describe("makeSyntheticCollectionResult", () => {
+  it("builds a presentCollection-shaped card the View can render from", () => {
+    const card = makeSyntheticCollectionResult("clients", "c_1");
+    assert.equal(card.toolName, PRESENT_COLLECTION);
+    assert.deepEqual(card.data, { collectionSlug: "clients", itemId: "c_1" });
+    assert.deepEqual(card.jsonData, { collectionSlug: "clients", itemId: "c_1" });
+    assert.ok(card.uuid.length > 0);
+  });
+
+  it("omits itemId when not given", () => {
+    assert.deepEqual(makeSyntheticCollectionResult("clients").data, { collectionSlug: "clients" });
+  });
+});
+
+// Build a real (non-synthetic) presentCollection result as the agent would emit.
+function realResult(slug: string): ToolResultComplete {
+  return { uuid: `real-${slug}`, toolName: PRESENT_COLLECTION, message: `Presented ${slug}`, data: { collectionSlug: slug } };
+}
+
+describe("reconcileSyntheticCollection", () => {
+  it("drops the placeholder for the same slug and clears its selection", () => {
+    const session = createEmptySession("s1", "general");
+    const placeholder = makeSyntheticCollectionResult("clients");
+    session.toolResults.push(placeholder);
+    session.resultTimestamps.set(placeholder.uuid, 1);
+    session.selectedResultUuid = placeholder.uuid;
+
+    reconcileSyntheticCollection(session, realResult("clients"));
+
+    assert.equal(session.toolResults.length, 0);
+    assert.equal(session.resultTimestamps.has(placeholder.uuid), false);
+    assert.equal(session.selectedResultUuid, null);
+  });
+
+  it("leaves placeholders for other collections untouched", () => {
+    const session = createEmptySession("s1", "general");
+    const placeholder = makeSyntheticCollectionResult("invoices");
+    session.toolResults.push(placeholder);
+
+    reconcileSyntheticCollection(session, realResult("clients"));
+
+    assert.equal(session.toolResults.length, 1);
+    assert.equal(session.toolResults[0].uuid, placeholder.uuid);
+  });
+
+  it("ignores a synthetic incoming result (no self-reconcile)", () => {
+    const session = createEmptySession("s1", "general");
+    const placeholder = makeSyntheticCollectionResult("clients");
+    session.toolResults.push(placeholder);
+
+    reconcileSyntheticCollection(session, makeSyntheticCollectionResult("clients"));
+
+    assert.equal(session.toolResults.length, 1);
+  });
+});

--- a/test/utils/collections/test_presentSeed.ts
+++ b/test/utils/collections/test_presentSeed.ts
@@ -5,7 +5,12 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseCollectionSlashSeed, makeSyntheticCollectionResult, reconcileSyntheticCollection } from "../../../src/utils/collections/presentSeed.js";
+import {
+  parseCollectionSlashSeed,
+  makeSyntheticCollectionResult,
+  reconcileSyntheticCollection,
+  hasRealCollectionResult,
+} from "../../../src/utils/collections/presentSeed.js";
 import { createEmptySession } from "../../../src/utils/session/sessionFactory.js";
 import { TOOL_NAME as PRESENT_COLLECTION } from "@mulmoclaude/collection-plugin";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
@@ -87,5 +92,32 @@ describe("reconcileSyntheticCollection", () => {
     reconcileSyntheticCollection(session, makeSyntheticCollectionResult("clients"));
 
     assert.equal(session.toolResults.length, 1);
+  });
+});
+
+describe("hasRealCollectionResult — race guard for the seeding path", () => {
+  it("is true once the agent's real result for the slug has landed", () => {
+    const session = createEmptySession("s1", "general");
+    session.toolResults.push(realResult("clients"));
+    assert.equal(hasRealCollectionResult(session, "clients"), true);
+  });
+
+  it("is false for a different slug or when only a placeholder exists", () => {
+    const session = createEmptySession("s1", "general");
+    session.toolResults.push(realResult("invoices"));
+    session.toolResults.push(makeSyntheticCollectionResult("clients"));
+    // 'clients' has only a synthetic placeholder, and 'invoices' is unrelated.
+    assert.equal(hasRealCollectionResult(session, "clients"), false);
+    assert.equal(hasRealCollectionResult(session, "leads"), false);
+  });
+
+  it("guards the fast-agent / slow-fetch ordering: real first, then seed is a no-op", () => {
+    // Reproduces the reviewed race: the real result arrives (reconcile finds no
+    // placeholder), and only afterwards does the seeding fetch resolve. The
+    // guard must prevent appending a duplicate placeholder.
+    const session = createEmptySession("s1", "general");
+    reconcileSyntheticCollection(session, realResult("clients")); // no-op: nothing to remove yet
+    session.toolResults.push(realResult("clients")); // real card applied
+    assert.equal(hasRealCollectionResult(session, "clients"), true); // → seeding would be skipped
   });
 });


### PR DESCRIPTION
Closes #1768.

## Problem

When a chat is started from a collection view, the seed message carries that collection's slash command (`/<slug> …`). The collection only appears in the canvas after the full agent round-trip — the LLM invokes the skill, calls `presentCollection`, and the result streams back. Until then the canvas is empty.

## Approach

Show the collection **immediately** as a client-side stand-in for the `presentCollection` call the agent makes moments later, then reconcile when the real result arrives (option 2 — reconcile on arrival).

The collection View only needs `collectionSlug` to render — it self-fetches the schema + records — so the synthetic card uses the exact same render contract as the real tool result.

## Changes

- **`src/utils/collections/presentSeed.ts`** (new) — collection-specific logic, kept out of generic session code:
  - `parseCollectionSlashSeed` — pure parser for `/<slug>` / `/<slug> id=<itemId> …` seeds.
  - `makeSyntheticCollectionResult` — builds a `presentCollection`-shaped `ToolResultComplete` flagged `syntheticCollection`.
  - `reconcileSyntheticCollection` — drops the placeholder (and clears its selection) when the real `presentCollection` result for the same slug arrives, so the two don't stack.
- **`src/utils/agent/eventDispatch.ts`** — reconcile before applying the real `toolResult`. `sessionHelpers.ts` stays plugin-agnostic.
- **`src/App.vue`** — `startNewChat` detects a `/<slug>` collection seed, confirms it's a real collection (`GET /api/collections`), and injects the placeholder. Guards against the active session changing mid-fetch; fetch failure skips the optimistic card (the agent still presents it).

Host-only — no change to the shared `@mulmoclaude/collection-plugin` package. As a bonus, manually-typed `/<slug>` chats also get the instant canvas.

## Notes / trade-off

The collection-existence check is a fresh `GET /api/collections` per slash-seeded new chat (always current, so newly-created collections work; one extra request on an explicit user action, not cached). Easy to switch to a cached slug set if preferred.

No-op for non-collection slash commands (e.g. `/deep-research`) and plain prose.

## Testing

- New `test/utils/collections/test_presentSeed.ts` — 10 tests: parse edge cases (bare, trailing message, `id=`, mis-ordered `id=`, prose, `/`, path-like), synthetic card shape, and all three reconcile branches.
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all green; `yarn test` 5238/5238.
- Manually verified: typing `/<slug>` paints the collection instantly and the real result replaces the placeholder without duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection slash commands now seed a collection card immediately in the canvas while the real result loads in the background.
  * Commands can include an optional `id=` selector to target a specific item within the collection.

* **Bug Fixes**
  * The final collection result now replaces the temporary preview instead of creating duplicates.
  * Previews no longer appear in the wrong chat when switching sessions.

* **Tests**
  * Added coverage for slash-seed parsing, placeholder creation/reconciliation, and duplicate/pre-race protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->