### PR TITLE
feat: add mc-zenn preset skill for sharing work as Zenn articles

### DIFF
--- a/packages/services/workspace-setup/assets/skills-preset/mc-zenn/SKILL.md
+++ b/packages/services/workspace-setup/assets/skills-preset/mc-zenn/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: mc-zenn
+description: Turn MulmoClaude work into a Zenn tech article (markdown) inside the workspace. On first use it sets up a Zenn project at `github/zenn/` — clone an existing GitHub repo or `zenn init` a fresh one, idempotent and skipped when already initialized — then writes articles to `github/zenn/articles/<slug>.md` tagged with the `MulmoClaude` topic. Use when the user says "Zenn にまとめて", "この作業を記事にして", "share this on Zenn", "Zenn 始めたい", or "Zenn のリポを用意して".
+---
+
+# Zenn
+
+A bundled MulmoClaude preset skill (`mc-` prefix = launcher-managed; do not edit
+this file in the workspace, it is overwritten on every server boot).
+
+Help the user share what they did in MulmoClaude as a Zenn tech article. Two
+jobs in one skill: **(1) make sure a Zenn project exists in the workspace** and
+**(2) write an article from the work**. Writing auto-runs setup first when the
+project isn't there yet, so the user can jump straight to "Zenn にまとめて"
+without thinking about setup.
+
+Keep the machinery invisible — the user shouldn't have to think about slugs,
+frontmatter, or zenn-cli internals.
+
+## Where things live
+
+The Zenn project is a git repo inside the workspace at `github/zenn/`
+(cwd-relative — the agent runs with cwd = workspace, so every path here is plain
+cwd-relative). Articles are markdown files at `github/zenn/articles/<slug>.md`.
+Zenn publishes by syncing a connected GitHub repo, so this directory is a real
+git repo the user pushes to.
+
+**Is it initialized?** The project is ready when `github/zenn/articles/` exists.
+Use that as the idempotency marker — never re-init a directory that already has
+it.
+
+## Workflow 1: set up the Zenn project (idempotent)
+
+**Triggers**: "Zenn のリポを用意して", "Zenn 始めたい", "set up Zenn", "まだ
+Zenn 作ってない". Also runs automatically as Step 0 of Workflow 2.
+
+**Step 1 — check first.** If `github/zenn/articles/` already exists, the project
+is ready: say so in one line and stop. Re-initializing is never correct. Only
+continue when it's missing.
+
+**Step 2 — clone or init.** Ask which with one `presentForm` (two choices),
+unless the user already told you:
+
+- **Clone an existing Zenn repo** (they already write Zenn on GitHub). Get the
+  repo URL, then:
+  ```bash
+  git clone <url> github/zenn
+  ```
+  `npx zenn` fetches zenn-cli on demand, so a missing local dependency is fine.
+
+- **Create a fresh project** (standard zenn-cli flow):
+  ```bash
+  mkdir -p github/zenn
+  cd github/zenn && npm init --yes && npm install zenn-cli && npx zenn init
+  ```
+  (`yarn add zenn-cli` works too if the user prefers yarn.) `npx zenn init`
+  scaffolds `articles/`, `books/`, and a README. Then make it a git repo:
+  ```bash
+  cd github/zenn && git init -b main
+  ```
+
+**Step 3 — confirm + point at the next step.** One line ("Zenn project ready at
+github/zenn/."). For a freshly created project, name the one manual step Zenn
+needs: connect the GitHub repo on zenn.dev → "Deploy from GitHub" (browser only
+— it can't be automated). Then offer to write the first article.
+
+## Workflow 2: write an article from MulmoClaude work
+
+**Triggers**: "この作業を Zenn 記事にして", "今やったことを記事化", "Zenn に
+まとめて", "share this on Zenn".
+
+**Step 0 — ensure setup.** If `github/zenn/articles/` doesn't exist, run
+Workflow 1 first, then continue.
+
+**Step 1 — gather the material.** Prefer what the user points at (a wiki page,
+an artifact, files, a MulmoScript story). Otherwise use the current session's
+work: the chat transcript at `conversations/chat/<session-id>.jsonl` (list with
+`ls -t conversations/chat/*.jsonl | head` if you don't know the id) plus the
+artifacts and files it produced. Pull out **what / why / how / result** and keep
+the reproducible commands and code. Ground every claim in what actually
+happened — don't invent.
+
+**Step 2 — pick a slug.** Zenn slugs are **12–50 characters, lowercase a–z /
+0–9 / `-` / `_`** (pattern `^[a-z0-9_-]{12,50}$`). Build a readable kebab slug
+from the title's English keywords (e.g. `mulmoclaude-zenn-workflow`). Pad a
+short one with a date (`date '+%Y%m%d'`) or 4 hex chars. Check
+`github/zenn/articles/` for collisions. If a clean slug is hard, run
+`cd github/zenn && npx zenn new:article` to get a valid random-slug skeleton and
+fill it in. **A published slug becomes the article URL and can't change** — pick
+it deliberately.
+
+**Step 3 — write the frontmatter** (Zenn house style):
+```yaml
+---
+title: "<a clear title, in the user's language>"
+emoji: "<one emoji that fits the topic>"
+type: "tech" # tech: 技術記事 / idea: アイデア
+topics: ["MulmoClaude", "<related>"]
+published: true
+---
+```
+- **Always include `MulmoClaude` in `topics`.** At most 5 topics, no spaces
+  inside a single topic.
+- `type` defaults to `tech`; `published` defaults to `true` (use `false` when
+  the user wants a draft). `emoji` is exactly one character.
+
+**Step 4 — write the body.** Zenn markdown: intro (what / why) → steps or
+implementation (fenced ` ```lang ` blocks, runnable commands) → result → a short
+wrap-up. Informative but casual; describe the work, not yourself. Put images in
+`github/zenn/images/` and reference them as `![alt](/images/<file>)`.
+
+**Step 5 — save + preview.** Write `github/zenn/articles/<slug>.md`. Tell the
+user the path and how to preview: `cd github/zenn && npx zenn preview`
+(http://localhost:8000). Surface the title, slug, and topics.
+
+## Workflow 3: publish
+
+**Only when the user asks** ("公開して", "push して"). Zenn deploys on push to
+the connected branch (usually `main`); this is a content repo, so working on
+`main` is expected — no feature-branch / PR dance.
+
+- Stage the changed file(s) **individually** (never `git add .`), then commit
+  and push:
+  ```bash
+  cd github/zenn && git add articles/<slug>.md && git commit -m "docs: add <slug>" && git push
+  ```
+- Confirm before pushing. If the repo has no `origin` yet (freshly created,
+  not connected), the user must create + connect the GitHub repo on zenn.dev
+  first — point them there instead of guessing a remote.
+
+## Tone
+
+Practical and quiet about the machinery. The user wants their work shared, not a
+lecture on zenn-cli. Ask at most one thing at a time, and only when you genuinely
+can't proceed (which repo to clone, publish vs draft). Otherwise write the
+article and show them the result.

--- a/packages/services/workspace-setup/package.json
+++ b/packages/services/workspace-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/workspace-setup",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Workspace bootstrap for MulmoClaude and MulmoTerminal — seeds the bundled help docs + preset skills into a workspace so a fresh workspace created by either app is set up identically. Server-only (`.`); browser-safe isPresetSlug at `./slug`. ESM-only (assets resolve via import.meta.url).",
   "type": "module",
   "main": "./dist/index.js",

--- a/plans/feat-mc-zenn-skill.md
+++ b/plans/feat-mc-zenn-skill.md
@@ -1,0 +1,82 @@
+# Plan: `mc-zenn` preset skill — share MulmoClaude work as Zenn articles
+
+Add a bundled preset skill that turns work done in MulmoClaude into a
+[Zenn](https://zenn.dev) tech article (markdown) inside the workspace. One skill
+covers both jobs the user described: **set up a Zenn project once (idempotently)**
+and **write articles from the session's work**, always tagging `MulmoClaude`.
+
+Shape mirrors `mc-cooking-coach` (#1286): a markdown-only preset that drives
+plain files via Read / Write / Edit + shell, no runtime plugin, no Vue View.
+
+## Motivation
+
+Users build things in MulmoClaude (research, artifacts, wiki pages, MulmoScript
+stories) and want to share the process. Zenn is the low-friction target: GitHub
+repo sync, markdown, free topic tags (so a `MulmoClaude` tag is one line). The
+skill removes the setup tax — first use initializes a Zenn project in the
+workspace; after that "Zenn にまとめて" just works.
+
+## Files
+
+| Path | Action |
+|---|---|
+| `packages/services/workspace-setup/assets/skills-preset/mc-zenn/SKILL.md` (NEW) | The preset skill. Three workflows: (1) idempotent setup, (2) write article, (3) publish. |
+| `plans/feat-mc-zenn-skill.md` (NEW) | This file. |
+
+No code, manifest, or test changes are required:
+
+- Preset skills are discovered by **directory scan** of the assets dir
+  (`syncPresetSkills` in `packages/services/workspace-setup/src/sync.ts`) — any
+  `mc-*` subdir with a `SKILL.md` ships. There is no list to append to
+  (`preset-list.ts` is for **plugins**, not skills).
+- `github` is already a `WORKSPACE_DIRS` key (`server/workspace/paths.ts`), so
+  the `github/zenn/` location needs no new path constant.
+
+## Behavior
+
+### Location
+The Zenn project is a git repo at `github/zenn/` (cwd-relative). Articles live
+at `github/zenn/articles/<slug>.md`. Idempotency marker: the project is "ready"
+iff `github/zenn/articles/` exists.
+
+### Idempotent setup (Workflow 1)
+- If `github/zenn/articles/` exists → already set up, do nothing.
+- Else offer two init paths (one `presentForm`):
+  - **Clone** an existing Zenn GitHub repo: `git clone <url> github/zenn`.
+  - **Fresh**: `npm init --yes && npm install zenn-cli && npx zenn init`
+    (the standard zenn-cli flow), then `git init -b main`.
+- Fresh repos need one manual step the skill can't automate: connecting the
+  GitHub repo on zenn.dev (Deploy from GitHub). The skill tells the user.
+
+### Write article (Workflow 2)
+- Step 0 auto-runs setup if the project is missing, so the user can start from
+  "write an article" without thinking about setup.
+- Material = what the user points at, else the current session (chat transcript
+  at `conversations/chat/<id>.jsonl` + produced artifacts/files).
+- Slug: Zenn rules `^[a-z0-9_-]{12,50}$`; readable kebab from title keywords;
+  collision-checked. Published slug == URL == immutable.
+- Frontmatter house style (`title / emoji / type / topics / published`);
+  **`topics` always includes `MulmoClaude`** (max 5). Defaults `type: tech`,
+  `published: true`.
+- Save + `npx zenn preview` instructions.
+
+### Publish (Workflow 3)
+- Only on explicit ask. Content repo → push to `main` (no feature-branch / PR).
+- Stage files individually (never `git add .`), confirm before push.
+
+## Out of scope
+
+- No runtime plugin / Vue View (markdown-only, like `mc-cooking-coach`).
+- The zenn.dev ↔ GitHub deploy connection is a browser step — documented, not
+  automated.
+- Package-manager: the fresh-init flow follows Zenn's official docs (`npm`);
+  `npx zenn` works regardless of how zenn-cli is installed.
+
+## Observation (for reviewer, not changed here)
+
+`test/workspace/test_skills_preset.ts`'s "repository fixture" case anchors to the
+retired `server/workspace/skills-preset/` path and is guarded by
+`if (!existsSync(...)) return;`, so it is currently a **no-op** after the
+move to `packages/services/workspace-setup/assets/skills-preset/`. Re-pointing it
+at the new assets dir would make it actually validate the mc-* prefix rule again
+— left out of this PR to keep scope tight; flagged so it can be a follow-up.


### PR DESCRIPTION
## Summary

Adds `mc-zenn`, a bundled **preset skill** that turns work done in MulmoClaude into a [Zenn](https://zenn.dev) tech article (markdown) **inside the workspace**. One skill covers both jobs: **idempotently set up a Zenn project** at `github/zenn/` (clone an existing GitHub repo or `zenn init` a fresh one) and **write articles** from the session's work, always tagging the `MulmoClaude` topic.

Markdown-only, same shape as `mc-cooking-coach` (#1286): no runtime plugin, no Vue View. Discovered automatically by the preset-skill directory scan — **no code, manifest, or test changes**.

Files:
- `packages/services/workspace-setup/assets/skills-preset/mc-zenn/SKILL.md` (new)
- `plans/feat-mc-zenn-skill.md` (new)

## Items to Confirm / Review

AI-assisted PR — please sanity-check these decisions:

1. **Skill name & shape** — `mc-zenn`, a single skill with 3 workflows (idempotent setup / write / publish). Setup auto-runs as Step 0 of "write" so users can start straight from "Zenn にまとめて".
2. **Location** — the Zenn project lives at `github/zenn/` (a real git repo, since Zenn deploys via GitHub sync). `github` is already a `WORKSPACE_DIRS` key, so no new path constant is needed.
3. **Init flow** — follows Zenn's official docs (`npm init --yes && npm install zenn-cli && npx zenn init`). `npx zenn` works regardless of how zenn-cli was installed; a `yarn` alternative is noted inline.
4. **Idempotency marker** — "initialized" ⇔ `github/zenn/articles/` exists; the skill never re-inits a dir that already has it.
5. **Deploy connection not automated** — connecting the repo on zenn.dev (Deploy from GitHub) is browser-only; the skill documents it rather than faking it.
6. **Pre-existing stale test (intentionally not changed)** — `test/workspace/test_skills_preset.ts`'s "repository fixture" case anchors to the retired `server/workspace/skills-preset/` path and is guarded by `if (!existsSync(...)) return;`, so it's a **no-op** after the move to `packages/services/workspace-setup/assets/skills-preset/`. Left untouched to keep scope tight; flagged in the plan as a possible follow-up to re-point it at the new assets dir (which would make it validate the `mc-*` prefix rule again).

## User Prompt

Consolidated from a multi-turn MulmoClaude session (originally in Japanese):

> I want to share work I did in MulmoClaude with others by turning it into markdown articles. Zenn is the easy target, and it lets me attach a `MulmoClaude` tag — make this a skill. Also, when Zenn isn't set up yet (not cloned / no repo), first get git in order: either add to an existing Zenn repo or create a new one.
>
> Building on that: make a skill that creates Zenn docs **inside the workspace**, initialized either by `git clone` or via the zenn-cli init flow (ref: https://zenn.dev/ai4u_shunsuke/articles/zenn-cli-usage). It should be **idempotent** — if a project already exists, skip init; if I try to write an article when it isn't initialized, initialize first. Ship this as a **system (preset) skill** so it can ultimately be added to MulmoClaude.

## Implementation

- **Discovery**: preset skills are picked up by directory scan (`syncPresetSkills`, `packages/services/workspace-setup/src/sync.ts`) — any `mc-*` subdir with a `SKILL.md` ships. `preset-list.ts` is for plugins, not skills, so there is nothing to register there. `server/workspace/skills-preset.ts` is now a shim re-exporting `@mulmoclaude/workspace-setup`; the canonical asset source is the package `assets/` dir.
- **Skill body** (`mc-zenn/SKILL.md`) follows the preset house style (signature line, cwd-relative paths note, Workflow + Triggers structure, Tone):
  - **Workflow 1 — idempotent setup**: check `github/zenn/articles/`; if absent, offer clone vs `zenn init` via one `presentForm`.
  - **Workflow 2 — write article**: Step 0 auto-runs setup; gather material from what the user points at or the current session (`conversations/chat/<id>.jsonl` + produced artifacts); slug per Zenn rules (`^[a-z0-9_-]{12,50}$`); house-style frontmatter with `topics` always including `MulmoClaude` (`type: tech`, `published: true` defaults); body + `npx zenn preview`.
  - **Workflow 3 — publish**: only on request; stage files individually (never `git add .`); content repo → push to `main`.
- **Generic** — no personal repo/username hardcoded; default location is the in-workspace `github/zenn/`.

## Testing

- `npx tsx --test test/workspace/test_skills_preset.ts` → **38/38 pass** (preset sync + `mc-*` prefix fixture).
- Validated the new `SKILL.md`: frontmatter parses as YAML, `name` matches the dir (`mc-zenn`), the `bundled MulmoClaude preset skill` signature line is present, and 3 workflows are defined.
- `format` / `lint` / `build` / `typecheck` target `ts/json/yaml/vue` only — this is a markdown-only change, nothing to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new preset skill for turning MulmoClaude workspace output into Zenn tech articles, including project setup, article authoring, and publishing workflows.

New Features:
- Introduce the `mc-zenn` bundled preset skill that initializes a Zenn project in the workspace and generates tagged Zenn articles from MulmoClaude sessions.

Documentation:
- Document the `mc-zenn` preset skill behavior, workflows, triggers, and workspace layout in a new SKILL.md and accompanying planning document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Zenn preset skill for setting up a Zenn workspace, drafting tech articles, and publishing them when explicitly requested.
  * Supports creating articles from either selected source material or the current session’s content, with consistent post formatting guidance.

* **Documentation**
  * Added planning notes describing the recommended workflow, file location, naming rules, and publishing steps for the new Zenn preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->