### PR TITLE
chore(guard): exempt non-shipping package.json diffs from bump requirement

### DIFF
--- a/scripts/check-shared-pkg-bumps.d.mts
+++ b/scripts/check-shared-pkg-bumps.d.mts
@@ -1,0 +1,17 @@
+// Type declarations for check-shared-pkg-bumps.mjs. Kept as a sidecar
+// so the script itself stays plain JS (easy to run with `node` on a
+// fresh clone without a build step) while still giving the unit test
+// a typed import surface. Mirrors the pattern used by the other CLI
+// scripts under scripts/mulmoclaude/ (deps.d.mts, drift.d.mts, ...).
+
+/** Top-level package.json fields whose isolated diffs do NOT alter what
+ *  consumers install — `devDependencies`, `scripts`, `version`. See
+ *  the comment block above the runtime `NON_SHIPPING_PKG_JSON_KEYS`
+ *  for the rationale. */
+export const NON_SHIPPING_PKG_JSON_KEYS: ReadonlySet<string>;
+
+/** Pure helper: true when every key whose value differs between
+ *  `baseJson` and `headJson` is in `NON_SHIPPING_PKG_JSON_KEYS`.
+ *  False otherwise — including when a shipping field appears in
+ *  only one of the two objects. */
+export function packageJsonDiffShipsNothing(baseJson: Record<string, unknown>, headJson: Record<string, unknown>): boolean;

--- a/scripts/check-shared-pkg-bumps.mjs
+++ b/scripts/check-shared-pkg-bumps.mjs
@@ -28,6 +28,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const SHARED_DIRS = ["packages/plugins", "packages/services"];
 const SCOPE = "@mulmoclaude/";
@@ -73,6 +74,67 @@ function isHigher(a, b) {
   return false;
 }
 
+/** Top-level package.json fields that, when changed in isolation, do NOT alter
+ *  what consumers install and therefore do NOT warrant a publish-bump:
+ *
+ *    - `devDependencies` — never installed by consumers (npm/yarn/pnpm skip
+ *      them on `--production` and at transitive install)
+ *    - `scripts`         — only run locally / in CI, not at consumer install
+ *    - `version`         — guard's own state; allowed here so the same exempt
+ *      pattern keeps working when the author bumps version alongside a
+ *      devDeps-only sweep (the `isHigher` check would catch that case
+ *      anyway, but listing it here lets the exempt logic stay obvious)
+ *
+ *  Everything else (`dependencies`, `peerDependencies`, `optionalDependencies`,
+ *  `exports`, `files`, `main`, `module`, `types`, `bin`, `engines`, …) MUST
+ *  trigger a bump because it changes the install-time contract consumers
+ *  observe. */
+export const NON_SHIPPING_PKG_JSON_KEYS = new Set(["devDependencies", "scripts", "version"]);
+
+/** Pure helper: compare two parsed package.json objects and return true when
+ *  every key whose value differs is in `NON_SHIPPING_PKG_JSON_KEYS`. Exported
+ *  for unit testing — the I/O-bound wrapper `isNonShippingChange` below uses
+ *  git + fs to fetch the two JSONs, then delegates the decision here. */
+export function packageJsonDiffShipsNothing(baseJson, headJson) {
+  const allKeys = new Set([...Object.keys(baseJson), ...Object.keys(headJson)]);
+  for (const key of allKeys) {
+    if (JSON.stringify(baseJson[key]) === JSON.stringify(headJson[key])) continue;
+    if (!NON_SHIPPING_PKG_JSON_KEYS.has(key)) return false;
+  }
+  return true;
+}
+
+/** True when the ONLY file this branch changed under <pkgDir> is its
+ *  package.json, AND the only top-level keys that differ between base and
+ *  HEAD are in `NON_SHIPPING_PKG_JSON_KEYS`. Lets cross-workspace devDep
+ *  sweeps (e.g. `@types/node` 26.0.0 → 26.0.1 in every package.json) land
+ *  without forcing 15+ identical publish bumps that consumers can't even
+ *  observe. */
+function isNonShippingChange(pkgDir, pkgJsonRel) {
+  const changed = changedUnder(pkgDir);
+  if (changed.length !== 1) return false;
+  if (changed[0] !== toGitPath(pkgJsonRel)) return false;
+  let baseJson;
+  try {
+    baseJson = JSON.parse(git(["show", `${base}:${toGitPath(pkgJsonRel)}`]));
+  } catch {
+    return false; // can't classify a brand-new package this way — let caller decide
+  }
+  const headJson = JSON.parse(readFileSync(pkgJsonRel, "utf-8"));
+  return packageJsonDiffShipsNothing(baseJson, headJson);
+}
+
+// Only run the CLI when this file is invoked directly. When imported by a
+// unit test (`test/scripts/test_check_shared_pkg_bumps.ts`) we want the pure
+// helpers without the side-effecting git / fs walk that follows.
+const isCli = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (!isCli) {
+  // imported as a module — pure exports above are enough.
+} else {
+  runCli();
+}
+
+function runCli() {
 const failures = [];
 const packageDirs = []; // every subdir holding a package.json, for orphan exclusion
 
@@ -88,6 +150,11 @@ for (const root of SHARED_DIRS) {
     if (changedUnder(pkgDir).length === 0) continue;
     const baseVersion = versionAtBase(pkgJsonRel);
     if (baseVersion === null) continue; // new package — nothing published to skew
+    // Cross-workspace devDep / script sweeps (e.g. `@types/node` patch bump
+    // touching every package.json) don't change what consumers install — skip
+    // the bump requirement so the author doesn't have to publish-bump every
+    // package for a change that ships nothing.
+    if (isNonShippingChange(pkgDir, pkgJsonRel)) continue;
     if (!isHigher(pkg.version, baseVersion)) {
       failures.push(`${pkg.name} — changed, but version ${pkg.version} is not greater than base ${baseVersion}`);
     }
@@ -120,5 +187,5 @@ if (failures.length > 0) {
   console.error("so an unbumped change ships a version skew between the two apps.");
   process.exit(1);
 }
-
 console.log(`✓ all changed @mulmoclaude/* shared packages are version-bumped vs ${base}`);
+}

--- a/test/scripts/test_check_shared_pkg_bumps.ts
+++ b/test/scripts/test_check_shared_pkg_bumps.ts
@@ -1,0 +1,138 @@
+// Unit tests for the pure helpers exported by
+// `scripts/check-shared-pkg-bumps.mjs`. The git + fs walk that drives the
+// CLI itself is end-to-end-tested by running it on every PR, but the
+// classification logic (which `package.json` diffs are "ships nothing")
+// has historically over-fired — a workspace-wide `@types/node` patch bump
+// tripped the guard for 15 packages despite shipping nothing. These tests
+// pin the non-shipping exemption so a future regression that re-tightens
+// the rule (e.g. someone adds `files` to the exempt set, or drops
+// `devDependencies` from it) gets caught here instead of in CI noise on
+// every routine devDeps sweep.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as guard from "../../scripts/check-shared-pkg-bumps.mjs";
+
+// Loose handle on the imported shape — the script is plain .mjs without
+// types. Declare just what we use here so the rest of the file stays typed.
+const { NON_SHIPPING_PKG_JSON_KEYS, packageJsonDiffShipsNothing } = guard as unknown as {
+  NON_SHIPPING_PKG_JSON_KEYS: Set<string>;
+  packageJsonDiffShipsNothing: (baseJson: Record<string, unknown>, headJson: Record<string, unknown>) => boolean;
+};
+
+describe("NON_SHIPPING_PKG_JSON_KEYS", () => {
+  it("contains exactly devDependencies, scripts, and version — anything else here is a regression", () => {
+    assert.deepEqual([...NON_SHIPPING_PKG_JSON_KEYS].sort(), ["devDependencies", "scripts", "version"]);
+  });
+
+  it("does NOT include dependencies (would silently skip a real consumer-facing dep bump)", () => {
+    assert.ok(!NON_SHIPPING_PKG_JSON_KEYS.has("dependencies"));
+  });
+
+  it("does NOT include peerDependencies / optionalDependencies (same reason)", () => {
+    assert.ok(!NON_SHIPPING_PKG_JSON_KEYS.has("peerDependencies"));
+    assert.ok(!NON_SHIPPING_PKG_JSON_KEYS.has("optionalDependencies"));
+  });
+
+  it("does NOT include exports / main / module / types / files / bin (install-time contract)", () => {
+    for (const key of ["exports", "main", "module", "types", "files", "bin"]) {
+      assert.ok(!NON_SHIPPING_PKG_JSON_KEYS.has(key), `${key} must NOT be in the exempt set`);
+    }
+  });
+});
+
+describe("packageJsonDiffShipsNothing — exempts non-shipping diffs", () => {
+  it("returns true when only a devDependency version differs (the canonical @types/node sweep)", () => {
+    const base = {
+      name: "@mulmoclaude/scheduler",
+      version: "0.1.0",
+      devDependencies: { "@types/node": "^26.0.0", tsx: "^4.22.4" },
+    };
+    const head = {
+      name: "@mulmoclaude/scheduler",
+      version: "0.1.0",
+      devDependencies: { "@types/node": "^26.0.1", tsx: "^4.22.4" },
+    };
+    assert.equal(packageJsonDiffShipsNothing(base, head), true);
+  });
+
+  it("returns true when only `scripts` changed (lint / test wiring)", () => {
+    const base = { name: "x", scripts: { test: "echo old" } };
+    const head = { name: "x", scripts: { test: "echo new" } };
+    assert.equal(packageJsonDiffShipsNothing(base, head), true);
+  });
+
+  it("returns true when version + devDependencies both changed (combined sweep + manual bump)", () => {
+    const base = { name: "x", version: "0.1.0", devDependencies: { "@types/node": "^26.0.0" } };
+    const head = { name: "x", version: "0.1.1", devDependencies: { "@types/node": "^26.0.1" } };
+    assert.equal(packageJsonDiffShipsNothing(base, head), true);
+  });
+
+  it("returns true for an empty diff (defensive — caller should have filtered, but be safe)", () => {
+    const base = { name: "x", version: "0.1.0" };
+    const head = { name: "x", version: "0.1.0" };
+    assert.equal(packageJsonDiffShipsNothing(base, head), true);
+  });
+});
+
+describe("packageJsonDiffShipsNothing — requires bump for shipping diffs", () => {
+  it("returns false when `dependencies` changed (real consumer-facing dep bump)", () => {
+    const base = { name: "x", dependencies: { lodash: "^4.17.0" } };
+    const head = { name: "x", dependencies: { lodash: "^4.17.1" } };
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+
+  it("returns false when `peerDependencies` changed (peer range is part of the contract)", () => {
+    const base = { name: "x", peerDependencies: { "gui-chat-protocol": "^0.3.3" } };
+    const head = { name: "x", peerDependencies: { "gui-chat-protocol": "^0.4.0" } };
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+
+  it("returns false when `exports` changed (subpath shape)", () => {
+    const base = { name: "x", exports: { ".": "./dist/index.js" } };
+    const head = { name: "x", exports: { ".": "./dist/index.js", "./vue": "./dist/vue.js" } };
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+
+  it("returns false when `files` changed (npm-publish whitelist alters the tarball)", () => {
+    const base = { name: "x", files: ["dist/"] };
+    const head = { name: "x", files: ["dist/", "client/"] };
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+
+  it("returns false when `main` / `module` / `types` / `bin` changed (entry-point contract)", () => {
+    for (const key of ["main", "module", "types", "bin"]) {
+      const base = { name: "x", [key]: "./old" };
+      const head = { name: "x", [key]: "./new" };
+      assert.equal(packageJsonDiffShipsNothing(base, head), false, `${key} change must require a bump`);
+    }
+  });
+
+  it("returns false when devDeps changed AND a shipping field also changed (don't let exempt fields mask a real change)", () => {
+    const base = {
+      name: "x",
+      version: "0.1.0",
+      devDependencies: { "@types/node": "^26.0.0" },
+      dependencies: { lodash: "^4.17.0" },
+    };
+    const head = {
+      name: "x",
+      version: "0.1.0",
+      devDependencies: { "@types/node": "^26.0.1" },
+      dependencies: { lodash: "^4.18.0" }, // dependencies also changed
+    };
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+
+  it("returns false when a brand-new shipping field appears in head (e.g. first-time exports)", () => {
+    const base = { name: "x", main: "./dist/index.js" };
+    const head = { name: "x", main: "./dist/index.js", exports: { ".": "./dist/index.js" } };
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+
+  it("returns false when a shipping field disappears in head", () => {
+    const base = { name: "x", main: "./dist/index.js", types: "./dist/index.d.ts" };
+    const head = { name: "x", main: "./dist/index.js" }; // dropped types
+    assert.equal(packageJsonDiffShipsNothing(base, head), false);
+  });
+});


### PR DESCRIPTION
## Summary

The shared-pkg version-bump guard (`scripts/check-shared-pkg-bumps.mjs`) was over-firing on workspace-wide devDependency sweeps. A routine `@types/node` patch bump (`^26.0.0` → `^26.0.1`) touching every `package.json` in `packages/{plugins,services}/` tripped the guard for **15 packages** even though those changes ship nothing to consumers — devDeps aren't installed at consume-time, and bumping 15 versions to satisfy the guard was busywork that didn't prevent any cross-app data-skew.

This PR refines the guard's classification: when the ONLY file a shared package changed is its `package.json` AND the only top-level keys that differ between base and HEAD are in `NON_SHIPPING_PKG_JSON_KEYS = {devDependencies, scripts, version}`, the bump requirement is skipped. Anything else (`dependencies` / `peerDependencies` / `optionalDependencies` / `exports` / `files` / `main` / `module` / `types` / `bin` / etc.) still requires a bump.

Caught on #1779 (now closed because the bumps weren't actually needed).

## Items to Confirm / Review

- **Exempt set is intentionally tiny** (just devDeps + scripts + version). I considered adding `description`, `keywords`, `repository`, `homepage`, `license` but those *can* affect the rendered npm page, which is technically a consumer-facing change — leaving them out keeps the rule conservative.
- **Rule 2 is unchanged**. Changes under a non-package shared subtree (`packages/plugins/shared/**` etc.) still require bumping every package that bundles them — that's about source code drift, orthogonal to this PR's package.json-only exemption.
- **Refactor for testability**: the script now exports `NON_SHIPPING_PKG_JSON_KEYS` and a pure `packageJsonDiffShipsNothing(baseJson, headJson)` helper. The side-effecting CLI walk is wrapped in `runCli()` guarded by `fileURLToPath(import.meta.url) === argv[1]`, so the unit test can import the module without triggering the git/fs walk.

## Test plan

- [x] New `test/scripts/test_check_shared_pkg_bumps.ts` — 16 cases pinning both halves of the contract:
  - **Exempt set** (true): devDeps-only diff, scripts-only diff, devDeps + version, empty diff
  - **Rejected set** (false): `dependencies`, `peerDependencies`, `exports`, `files`, `main`, `module`, `types`, `bin`, devDeps + dependencies combined, new shipping field appearing, shipping field disappearing
  - **`NON_SHIPPING_PKG_JSON_KEYS` shape**: positive (contains the 3 keys), negative (does NOT contain `dependencies` / `peerDependencies` / `optionalDependencies` / `exports` / `main` / `module` / `types` / `files` / `bin`)
- [x] CLI smoke: `node scripts/check-shared-pkg-bumps.mjs` against current main → `✓ all changed @mulmoclaude/* shared packages are version-bumped vs origin/main`
- [x] `yarn format` / `yarn lint` clean

## User Prompt

> guard、更新できる？ちょっと条件に合わないものありそうだね
> いや、、updaetするのはよいのだよ。gitが使えない方のgurdが問題

(The user pointed out that the original guard's blanket "any file change → require bump" was too aggressive for devDep sweeps. This PR codifies the "non-shipping fields are exempt" rule.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared package bump checks now skip validation when only non-shipping `package.json` fields change, reducing unnecessary version bumps.
  * Added importable helper logic to support reuse in other tooling and test setups.
  * Added TypeScript typings for the shared bump-check helpers.
* **Tests**
  * Added unit tests covering exempt vs shipping-relevant `package.json` changes, including edge cases to prevent exemptions from hiding real shipping differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->