### PR TITLE
release: mulmoclaude@0.9.0 (npm launcher)

### DIFF
--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -115,7 +115,7 @@ ${cliFlagHelpLines()}
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.8.0");
+  console.log("mulmoclaude 0.9.0");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Publishes \`mulmoclaude@0.9.0\` (already on npm at the time this PR opens). Companion to the just-tagged \`v0.9.0\` app release. Only files changed: \`packages/mulmoclaude/package.json\` version + the \`--version\` string in \`bin/mulmoclaude.js\`.

## What 0.9.0 brings

Full release notes in [\`docs/CHANGELOG.md#090---2026-06-25\`](https://github.com/receptron/mulmoclaude/blob/main/docs/CHANGELOG.md#090---2026-06-25). Headline:

- 🎤 **Local voice input** — push-to-talk via on-device whisper.cpp (macOS first), extracted as \`@mulmoclaude/whisper\`
- ⚡ **Collection instant-present** — collection canvas pops the moment a slash-command chat references it
- 📦 **Plugin extraction sweep** — \`@mulmoclaude/collection-plugin\` 0.3 → 0.5.2 (full Vue UI + i18n + router-less host), \`@mulmoclaude/html-plugin\` 0.1 → 0.2.2 (server core + Vue View), \`@mulmoclaude/whisper\` 0.1.x (sidecar core)
- 📝 **\`mc-zenn\` preset skill** — share work as a Zenn article
- 🔧 **\`mulmocast@2.6.22\`** diagnostic-error sweep picks up (TTS Gemini stops masking ffmpeg SIGABRT; Replicate / OpenAI / ElevenLabs agents interpolate underlying error.message into catch-all throws)

## Items to Confirm / Review

- **§1 deps audit (\`scripts/mulmoclaude/deps.mjs\`)**: clean, no missing dependencies in \`packages/mulmoclaude/package.json\`.
- **§2 drift (\`scripts/mulmoclaude/drift.mjs\`)**: \`@mulmobridge/chat-service\`, \`client\`, \`protocol\` all show \`src == published\` — **no cascade tag/release needed**, no \`@mulmobridge/*\` package bump in this PR.
- **§4 tarball smoke (\`scripts/mulmoclaude/tarball.mjs\`)**: \`npm pack\` + clean install + launcher start → **HTTP 200 on /, 4 runtime plugins loaded**.
- **No npm publish in this PR** — \`mulmoclaude@0.9.0\` was published from the branch state before opening this PR; the PR just lands the committed version bumps so \`main\` matches the registry.

## Verification

\`\`\`
npm view mulmoclaude version          # → 0.9.0
npx --yes mulmoclaude@0.9.0 --version # → mulmoclaude 0.9.0  ✓ verified
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Expose mulmoclaude 0.9.0 as the published npm package version for the launcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s version to **0.9.0**.
  * The `--version` command now reports the new release number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->