### PR TITLE
fix(ci): extend version-bump guard to cover @mulmoclaude/core

### DIFF
--- a/.github/workflows/shared_pkg_version_bump.yaml
+++ b/.github/workflows/shared_pkg_version_bump.yaml
@@ -9,9 +9,13 @@ on:
   pull_request:
     branches:
       - main
+    # MUST mirror the script's scope (SHARED_DIRS + SHARED_PACKAGE_DIRS in
+    # scripts/check-shared-pkg-bumps.mjs) — a path missing here means a PR
+    # touching only that subtree never runs the guard.
     paths:
       - 'packages/plugins/**'
       - 'packages/services/**'
+      - 'packages/core/**'
 
 permissions:
   contents: read

--- a/scripts/check-shared-pkg-bumps.mjs
+++ b/scripts/check-shared-pkg-bumps.mjs
@@ -31,6 +31,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SHARED_DIRS = ["packages/plugins", "packages/services"];
+// Cross-host `@mulmoclaude/*` packages that live DIRECTLY under `packages/`
+// (a single package dir, not a container of packages like the SHARED_DIRS
+// roots). `@mulmoclaude/core` is consumed by both apps and shares workspace
+// data, so it needs the same bump requirement — but `packages/core` isn't a
+// container, so it's checked here rather than walked under a SHARED_DIRS root.
+const SHARED_PACKAGE_DIRS = ["packages/core"];
 const SCOPE = "@mulmoclaude/";
 
 const base = process.env.BASE_SHA || process.argv[2] || "origin/main";
@@ -138,28 +144,33 @@ function runCli() {
 const failures = [];
 const packageDirs = []; // every subdir holding a package.json, for orphan exclusion
 
-for (const root of SHARED_DIRS) {
-  if (!existsSync(root)) continue;
-  for (const name of readdirSync(root)) {
-    const pkgDir = path.join(root, name);
-    const pkgJsonRel = path.join(pkgDir, "package.json");
-    if (!existsSync(pkgJsonRel)) continue;
-    packageDirs.push(pkgDir);
-    const pkg = JSON.parse(readFileSync(pkgJsonRel, "utf-8"));
-    if (!pkg.name?.startsWith(SCOPE) || pkg.private === true) continue;
-    if (changedUnder(pkgDir).length === 0) continue;
-    const baseVersion = versionAtBase(pkgJsonRel);
-    if (baseVersion === null) continue; // new package — nothing published to skew
-    // Cross-workspace devDep / script sweeps (e.g. `@types/node` patch bump
-    // touching every package.json) don't change what consumers install — skip
-    // the bump requirement so the author doesn't have to publish-bump every
-    // package for a change that ships nothing.
-    if (isNonShippingChange(pkgDir, pkgJsonRel)) continue;
-    if (!isHigher(pkg.version, baseVersion)) {
-      failures.push(`${pkg.name} — changed, but version ${pkg.version} is not greater than base ${baseVersion}`);
-    }
+// Per-package bump check: a changed, published, shared @mulmoclaude/* package
+// must have a version strictly greater than its base version. Pushes onto
+// `failures` when the rule is violated.
+function checkPackageDir(pkgDir) {
+  const pkgJsonRel = path.join(pkgDir, "package.json");
+  if (!existsSync(pkgJsonRel)) return;
+  packageDirs.push(pkgDir);
+  const pkg = JSON.parse(readFileSync(pkgJsonRel, "utf-8"));
+  if (!pkg.name?.startsWith(SCOPE) || pkg.private === true) return;
+  if (changedUnder(pkgDir).length === 0) return;
+  const baseVersion = versionAtBase(pkgJsonRel);
+  if (baseVersion === null) return; // new package — nothing published to skew
+  // Cross-workspace devDep / script sweeps (e.g. `@types/node` patch bump
+  // touching every package.json) don't change what consumers install — skip
+  // the bump requirement so the author doesn't have to publish-bump every
+  // package for a change that ships nothing.
+  if (isNonShippingChange(pkgDir, pkgJsonRel)) return;
+  if (!isHigher(pkg.version, baseVersion)) {
+    failures.push(`${pkg.name} — changed, but version ${pkg.version} is not greater than base ${baseVersion}`);
   }
 }
+
+for (const root of SHARED_DIRS) {
+  if (!existsSync(root)) continue;
+  for (const name of readdirSync(root)) checkPackageDir(path.join(root, name));
+}
+for (const pkgDir of SHARED_PACKAGE_DIRS) checkPackageDir(pkgDir);
 
 // Rule 2: changes in a non-package subtree (its first path segment under a
 // shared root has no package.json) — bundled into published packages but


### PR DESCRIPTION
Follow-up to #1793 — closes a guard gap that PR deferred.

## Problem
The shared-package version-bump guard (`scripts/check-shared-pkg-bumps.mjs`) only walks `packages/plugins` + `packages/services`. `@mulmoclaude/core` (introduced in #1793) lives at `packages/core` — a direct package, not under those container roots — so a change to it that ships **without** a version bump would NOT be caught.

That's exactly the cross-app version-skew the guard exists to prevent: `@mulmoclaude/core` is consumed by BOTH MulmoClaude and MulmoTerminal and they share one `~/mulmoclaude/` workspace, so a version skew is a data-correctness bug, not just a missing feature.

## Fix
- Add a `SHARED_PACKAGE_DIRS` list for cross-host `@mulmoclaude/*` packages that live directly under `packages/` (currently just `packages/core`).
- Extract the per-package bump check into `checkPackageDir()` and run it for both the container-walked subdirs and the direct shared packages — identical rule, no behavior change for existing packages.

## Verification
- Guard unit test (`test/scripts/test_check_shared_pkg_bumps.ts`) — 16/16.
- Probe: a committed change under `packages/core/src` with an unbumped version is now correctly flagged (`✗ @mulmoclaude/core — changed, but version 0.1.0 is not greater than base 0.1.0`); reverted after.
- `yarn typecheck:test` green (the `.d.mts` sidecar's exports are unchanged).

## Not included (and why)
`scripts/mulmoclaude/drift.mjs` (the export-line drift check) still only covers `@mulmoclaude/core`'s sibling scope `@mulmobridge/*`. Adapting it to core is non-trivial because drift.mjs keys off a single `src/index.ts` entry, whereas core is multi-entry (subpath exports, no `.`). The bump guard now requiring a version bump on **any** core change already prevents the skew drift.mjs targets, so this is left as a separate, lower-priority item rather than a fragile retrofit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded shared package version-bump checks to also cover packages located directly under the main packages directory (in addition to the existing shared roots).
  * Updated the pull request workflow triggers so changes in the core package subtree also run the shared version-bump validation, while preserving the prior handling for unchanged, private, and non-shipping updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->