### PR TITLE
docs(CLAUDE.md): codify package dependency direction (host → plugins → core → leaf)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,32 @@ NEVER name a non-runtime-plugin package `@mulmoclaude/foo-plugin` (e.g. a helper
 
 The yarn 4 smoke workflow (`yarn4_smoke`) verifies the chain still works under yarn 4. Both tiers' driver only spawns `yarn workspace <name> run build` — identical syntax in yarn 1 and 4 — so portability is preserved.
 
+## Package dependency direction (always apply)
+
+The monorepo has three package families. **Dependencies flow in ONE direction only** — violating this creates uphill imports, parallel-build races, and the tier-ordering dance that #1789 / #1795 had to dismantle.
+
+```
+                       ▲ depends on
+                       │
+        host           │   (server/, src/, packages/mulmoclaude)
+        ──────         │
+        plugins        │   (packages/plugins/*-plugin)
+        ──────         │
+   shared core         │   (@mulmoclaude/core — formerly the 7 packages/services/*)
+                       │
+        no deps        │   (leaf libs: @mulmobridge/protocol, @receptron/task-scheduler, etc.)
+                       │
+```
+
+**Rules:**
+
+- A **plugin** (`packages/plugins/<name>-plugin`) MAY import `@mulmoclaude/core/<subpath>` (or any leaf lib). It MUST NOT import another `*-plugin`. The runtime-plugin model is "1 plugin = 1 npm package, dispatched via `/api/plugins/runtime/:pkg`, gated by roles" — merging would break that model. Cross-plugin sharing goes through core.
+- **Shared core** (`@mulmoclaude/core` — provides `./collection`, `./collection/server`, `./collection-watchers`, `./skill-bridge`, `./notifier`, `./scheduler`, `./whisper`, `./whisper/client`, `./workspace-setup`, `./workspace-setup/slug`, `./file-change-publisher`) MUST NOT import any `*-plugin`. If a plugin owns code that core / another plugin needs, **pull it OUT of the plugin into core** (the `isSafeActionTemplatePath` / `discoverCollections` / `whenMatches` extraction that #1795 did is the canonical pattern), don't import uphill.
+- **Browser-safe surfaces of core** stay on dedicated subpaths (`@mulmoclaude/core/whisper/client`, `@mulmoclaude/core/workspace-setup/slug`). Everything else under `@mulmoclaude/core/*` is server-only — importing a server-only subpath from a Vue component fails the Vite browser-bundle check.
+- **Host** (`server/`, `src/`, the `packages/mulmoclaude` launcher) MAY import anything below it. Host code stays generic — provider-specific routes / handlers / config belong in the relevant plugin, not in `server/`.
+
+When the build complains "Cannot find module `@mulmoclaude/foo`" cold (after `yarn install` + `yarn build:packages`), the cause is almost always an uphill or peer import that the build-order tier system can't resolve. Don't patch with a new tier or a `--first=foo` flag — surface the import and move the code instead. Plan record: [`plans/done/refactor-shared-core.md`](plans/done/refactor-shared-core.md).
+
 ## Architecture (summary)
 
 Full reference: [`docs/developer.md`](docs/developer.md)


### PR DESCRIPTION
## Summary

Adds a new \`## Package dependency direction\` section to \`CLAUDE.md\` codifying the architectural invariant that #1795's \`@mulmoclaude/core\` consolidation established. Catches the class of regression that closed PR #1789 had to work around with a build-order shuffle + a \`--first=notifier\` flag:

\`\`\`
services/skill-bridge        → @mulmoclaude/collection-plugin/server   (uphill)
services/collection-watchers → @mulmoclaude/collection-plugin/server   (uphill)
services/collection-watchers → @mulmoclaude/notifier                   (intra-tier peer, race)
\`\`\`

The rule states:

\`\`\`
                       ▲ depends on
                       │
        host           │   (server/, src/, packages/mulmoclaude)
        ──────         │
        plugins        │   (packages/plugins/*-plugin)
        ──────         │
   shared core         │   (@mulmoclaude/core — formerly the 7 packages/services/*)
                       │
        no deps        │   (leaf libs: @mulmobridge/protocol, @receptron/task-scheduler)
\`\`\`

Plus 4 specific rules: plugins MAY import core, plugins MUST NOT import other plugins, core MUST NOT import plugins, host MAY import anything below.

## Items to Confirm / Review

- **CLAUDE.md loads every turn** — placing the rule there reaches every code-edit session without anyone needing to read the plan file. Plan record (\`plans/done/refactor-shared-core.md\`) linked at the bottom for the full rationale.
- **No code change**, doc-only. 1 file / +26 lines.
- **Forward-looking "don't do it again" half** of #1795. The source-level fix already shipped in main (skill-bridge + collection-watchers source deleted, code lives in \`@mulmoclaude/core\`); this PR is the rule that prevents a future plugin from re-introducing the same uphill import pattern.
- **The canonical fix recipe** (referenced in the rule): if a plugin owns code that core or another plugin needs, *pull it OUT of the plugin into core* — don't import uphill. That's exactly what #1795 did with \`isSafeActionTemplatePath\` / \`discoverCollections\` / \`whenMatches\`.
- **Browser-safe subpaths** of core (\`@mulmoclaude/core/whisper/client\`, \`@mulmoclaude/core/workspace-setup/slug\`) are called out explicitly so a Vue component doesn't accidentally import a server-only subpath and break the Vite browser bundle.

## User prompt

> なるほど。それを document か .claude に書いて、再発しないようにできる？

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a new CLAUDE.md section defining allowed dependency flow between host, plugins, shared core, and leaf libraries, including explicit rules for plugin/core imports and browser-safe core subpaths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear package dependency rules for the project’s main areas, including which packages can depend on others.
  * Clarified allowed import paths and dependency boundaries to reduce cross-package build issues.
  * Added guidance for troubleshooting module resolution errors and next-step refactor direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->