### PR TITLE
docs: extract Plugin Development out of CLAUDE.md → docs/plugin-development.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,14 +123,9 @@ The script runs **four tiers in order**:
 
 Tiers 3 and 4 are auto-discovered by `scripts/build-workspaces.mjs`. Tiers 1 and 2 stay explicit in `package.json` because their dep-graph order can't be globbed.
 
-**Adding a new bridge or runtime plugin: just create the workspace directory — no `package.json` edit needed.** Selection rules are strict:
+**Adding a new bridge: just create `packages/bridges/<name>/` with name `@mulmobridge/<name>` and `scripts.build`** — auto-discovery in tier 3 picks it up, no root `package.json` edit needed. Non-bridge `@mulmobridge/*` (like `mock-server`) MUST be added to the explicit tier-1 / tier-2 enumeration; same for any `@receptron/*` or core package other workspaces depend on.
 
-- **Bridge**: lives at `packages/bridges/<name>/`, name `@mulmobridge/<name>`, has `scripts.build`
-- **Runtime plugin**: lives at `packages/plugins/<name>-plugin/`, name `@mulmoclaude/<name>-plugin`, has `scripts.build`
-
-If a workspace doesn't fit either pattern — e.g. a `@receptron/*` package, or a non-bridge `@mulmobridge/*` like `mock-server` — **MUST add it to the explicit tier-1 / tier-2 enumeration in `package.json`**; auto-discovery won't pick it up. Same goes for any new top-level core package that other workspaces depend on.
-
-NEVER name a non-runtime-plugin package `@mulmoclaude/foo-plugin` (e.g. a helper library); the build driver will try to run its `build` script in tier 4, after every consumer has already been built. Pick a different name (`@mulmoclaude/foo`, `@mulmoclaude/foo-helpers`, …) or move it to tier 2.
+For **runtime plugins** + the `@mulmoclaude/foo-plugin` naming trap, see [`docs/plugin-development.md`](docs/plugin-development.md#build-orchestration-rules-plugin-relevant-subset).
 
 The yarn 4 smoke workflow (`yarn4_smoke`) verifies the chain still works under yarn 4. Both tiers' driver only spawns `yarn workspace <name> run build` — identical syntax in yarn 1 and 4 — so portability is preserved.
 
@@ -173,40 +168,9 @@ artifacts/       ← charts/, documents/, html/, images/, spreadsheets/
 
 ## Plugin Development
 
-Full reference: [`docs/developer.md`](docs/developer.md#plugin-development) (built-in) / [`docs/plugin-runtime.md`](docs/plugin-runtime.md) (runtime / npm-package plugins)
+When creating or editing a plugin → **[`docs/plugin-development.md`](docs/plugin-development.md)**. It covers: the plugin-vs-host boundary, built-in vs runtime choice, the 6-plugin-local + 3-host-barrel checklist, scaffold CLI sync (`packages/create-mulmoclaude-plugin`), plugin-aware host aggregators (`API_ROUTES` / `TOOL_NAMES` / `WORKSPACE_DIRS` / `PUBSUB_CHANNELS`), and the "extract shared code into `@mulmoclaude/core`" pattern.
 
-**Plugin-vs-host boundary (always apply).** Per-feature integrations (Spotify / GitHub / Apple Music / weather / bookmarks / …) live in `packages/plugins/<name>-plugin/` as **runtime plugins**. Host code (`server/`, `src/plugins/`, `src/config/`) only gets **generic infrastructure that benefits multiple plugins** — never provider-specific code. Examples of generic host infra: the `/api/plugins/runtime/:pkg/dispatch` route, the asset-mount route, the `/api/plugins/runtime/:pkg/oauth/callback` route (#1162). A new "Spotify route" or "GitHub route" in `server/api/routes/` is a smell — re-think whether the work belongs in the plugin package and whether the host's infra needs a generic extension instead.
-
-**Plugin owns its identity** (built-in path). Each built-in plugin declares its `toolName`, `apiRoutes`, `workspaceDirs`, and `staticChannels` in its own `src/plugins/<name>/meta.ts`. Host aggregators (`API_ROUTES`, `TOOL_NAMES`, `WORKSPACE_DIRS`, `PUBSUB_CHANNELS`) auto-merge those contributions via `defineHostAggregate` — host code holds zero plugin-specific literals.
-
-Adding a built-in plugin touches **6 plugin-local files** and **3 host barrels**:
-
-- `src/plugins/<name>/meta.ts` — `definePluginMeta({ toolName, apiRoutesKey?, apiRoutes?, workspaceDirs?, staticChannels? })`
-- `src/plugins/<name>/definition.ts` — MCP `ToolDefinition`; derive `TOOL_NAME = META.toolName`, endpoint types from `typeof META.apiRoutes`
-- `src/plugins/<name>/index.ts` — `PluginRegistration` (View / Preview wrapped via `wrapWithScope(scope, …)`, executor calls `pluginEndpoints<E>(scope)`)
-- `src/plugins/<name>/View.vue` / `Preview.vue` — Vue surfaces; call `useRuntime()` from `gui-chat-protocol/vue` for the typed `endpoints` map
-- `src/plugins/metas.ts` — append the META to `BUILT_IN_PLUGIN_METAS`
-- `src/plugins/index.ts` — append the registration to `BUILT_IN_PLUGINS`
-- `src/plugins/server.ts` — append `{ def, endpoint }` to `BUILT_IN_SERVER_BINDINGS` (skip for GUI-only plugins like wiki)
-- `server/api/routes/<name>.ts` — Express route handlers (only when the plugin owns endpoints)
-- `src/main.ts` — entry in the host endpoint registry passed to `installHostContext({ endpoints })`
-
-Adding to a Role's `availablePlugins` (`src/config/roles.ts`) is separate — roles gate which plugins each chat sees, independent of plugin registration.
-
-Standalone routes (`/todos`, `/calendar`, …) and inline file previews (`FileContentRenderer` rendering `data/todos/todos.json`) must wrap the plugin component with `<PluginScopedRoot pkg-name :endpoints>` so descendant `useRuntime()` calls resolve. The plugin registry's `wrapWithScope` already covers chat-mounted variants.
-
-### Plugin scaffold sync (`packages/create-mulmoclaude-plugin`)
-
-The scaffold CLI (`npx create-mulmoclaude-plugin`) embeds `package.json` + `vite.config.ts` + `tsconfig.json` + ESLint config as **string literals** in `packages/create-mulmoclaude-plugin/src/template.ts`. Newly-generated plugins inherit those literals verbatim, so they DO NOT pick up version bumps you make to the in-tree plugins.
-
-When you bump a build-toolchain dep (`vite` / `typescript` / `vite-plugin-dts` / `@vitejs/plugin-vue` / `vue`) or change the build-config shape (e.g. dropping `rollupTypes: true` for a TS-major bump), apply the same change to `packages/create-mulmoclaude-plugin/src/template.ts` in the **same PR**:
-
-1. Update the `PACKAGE_JSON` template's `devDependencies` caret ranges to match `packages/plugins/bookmarks-plugin/package.json` (the canonical reference).
-2. If the build-config shape changed, mirror it into `VITE_CONFIG` (the multi-line string just below).
-3. Run `yarn workspace create-mulmoclaude-plugin run build` to regenerate the CLI's own dist.
-4. Optionally bump the CLI's own `version` and re-publish if external users will fetch via `npx`.
-
-If you forget step 1 / 2, generated plugins ship with stale toolchains and may hit the same issue you just fixed in the in-tree plugin (e.g. empty `.d.ts` from api-extractor + TS 6).
+Day-to-day code edits don't need that doc — the only plugin rule that applies broadly is the dependency direction (above): plugins MAY import from `@mulmoclaude/core` / leaf libs, MUST NOT import another `*-plugin`.
 
 ## Centralized Constants
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,146 @@
+# Plugin Development
+
+This is the consolidated reference for **creating** or **editing** a plugin in MulmoClaude. Read this when you're about to touch `packages/plugins/<name>-plugin/` or `src/plugins/<name>/`. For day-to-day work that doesn't touch a plugin's surface, the load-bearing rules in [`CLAUDE.md`](../CLAUDE.md) are enough.
+
+Related docs:
+- [`docs/developer.md`](developer.md) — full developer guide (envs / scripts / process map / workspace layout)
+- [`docs/plugin-runtime.md`](plugin-runtime.md) — runtime / npm-package plugin internals (the `/api/plugins/runtime/:pkg/*` dispatch surface, OAuth callback flow, role gating)
+- [`CLAUDE.md`](../CLAUDE.md) — section "Package dependency direction" — the import-direction rule that applies to **every** code edit, plugin or not (load-bearing across all sessions, not duplicated here)
+
+There are two flavours of plugin in this repo:
+
+| Kind | Lives at | Distribution | Examples |
+|---|---|---|---|
+| **Built-in plugin** | `src/plugins/<name>/` | bundled into the host's Vite client + Express server | wiki, news, presentMulmoScript |
+| **Runtime plugin** | `packages/plugins/<name>-plugin/` | standalone `@mulmoclaude/<name>-plugin` npm package, dispatched via `/api/plugins/runtime/:pkg`, gated by roles | bookmarks, chart, collection, debug, edgar, email, form, html, markdown, recipe-book, spotify, todo, x |
+
+**Default to runtime plugin** for per-feature integrations (Spotify / GitHub / Apple Music / weather / bookmarks / …). Built-in is appropriate only for surfaces deeply tied to the host shell (wiki, news, the `presentMulmoScript` canvas).
+
+---
+
+## Plugin-vs-host boundary (always apply)
+
+Per-feature integrations live in `packages/plugins/<name>-plugin/`. Host code (`server/`, `src/plugins/`, `src/config/`) only gets **generic infrastructure that benefits multiple plugins** — never provider-specific code.
+
+Examples of generic host infra:
+- the `/api/plugins/runtime/:pkg/dispatch` route
+- the asset-mount route
+- the `/api/plugins/runtime/:pkg/oauth/callback` route (#1162)
+
+A new "Spotify route" or "GitHub route" in `server/api/routes/` is a smell — re-think whether the work belongs in the plugin package and whether the host's infra needs a *generic* extension instead.
+
+---
+
+## Built-in plugin path
+
+### Plugin owns its identity
+
+Each built-in plugin declares its `toolName`, `apiRoutes`, `workspaceDirs`, and `staticChannels` in its own `src/plugins/<name>/meta.ts`. Host aggregators (`API_ROUTES`, `TOOL_NAMES`, `WORKSPACE_DIRS`, `PUBSUB_CHANNELS`) auto-merge those contributions via `defineHostAggregate` — host code holds zero plugin-specific literals.
+
+### The 6 plugin-local files + 3 host barrels
+
+Adding a built-in plugin touches:
+
+**Plugin-local (6 files under `src/plugins/<name>/`):**
+
+- `meta.ts` — `definePluginMeta({ toolName, apiRoutesKey?, apiRoutes?, workspaceDirs?, staticChannels? })`
+- `definition.ts` — MCP `ToolDefinition`; derive `TOOL_NAME = META.toolName`, endpoint types from `typeof META.apiRoutes`
+- `index.ts` — `PluginRegistration` (View / Preview wrapped via `wrapWithScope(scope, …)`, executor calls `pluginEndpoints<E>(scope)`)
+- `View.vue` / `Preview.vue` — Vue surfaces; call `useRuntime()` from `gui-chat-protocol/vue` for the typed `endpoints` map
+
+**Host barrels (3 files):**
+
+- `src/plugins/metas.ts` — append the META to `BUILT_IN_PLUGIN_METAS`
+- `src/plugins/index.ts` — append the registration to `BUILT_IN_PLUGINS`
+- `src/plugins/server.ts` — append `{ def, endpoint }` to `BUILT_IN_SERVER_BINDINGS` (skip for GUI-only plugins like wiki)
+
+**Optional endpoint surface:**
+
+- `server/api/routes/<name>.ts` — Express route handlers (only when the plugin owns endpoints)
+- `src/main.ts` — entry in the host endpoint registry passed to `installHostContext({ endpoints })`
+
+Adding to a Role's `availablePlugins` (`src/config/roles.ts`) is separate — roles gate which plugins each chat sees, independent of plugin registration.
+
+### Standalone routes + inline previews must scope
+
+Standalone routes (`/todos`, `/calendar`, …) and inline file previews (`FileContentRenderer` rendering `data/todos/todos.json`) must wrap the plugin component with `<PluginScopedRoot pkg-name :endpoints>` so descendant `useRuntime()` calls resolve. The plugin registry's `wrapWithScope` already covers chat-mounted variants.
+
+---
+
+## Runtime plugin path
+
+Use the scaffold:
+
+```bash
+npx create-mulmoclaude-plugin <name>
+```
+
+That stamps `packages/plugins/<name>-plugin/` with a working `package.json` + Vite + TypeScript config + ESLint config. From there, see [`docs/plugin-runtime.md`](plugin-runtime.md) for the dispatch / runtime protocol details.
+
+### Plugin scaffold sync (`packages/create-mulmoclaude-plugin`)
+
+The scaffold CLI embeds `package.json` + `vite.config.ts` + `tsconfig.json` + ESLint config as **string literals** in `packages/create-mulmoclaude-plugin/src/template.ts`. Newly-generated plugins inherit those literals verbatim, so they DO NOT pick up version bumps you make to the in-tree plugins.
+
+**When you bump a build-toolchain dep** (`vite` / `typescript` / `vite-plugin-dts` / `@vitejs/plugin-vue` / `vue`) or change the build-config shape (e.g. dropping `rollupTypes: true` for a TS-major bump), apply the same change to `packages/create-mulmoclaude-plugin/src/template.ts` in the **same PR**:
+
+1. Update the `PACKAGE_JSON` template's `devDependencies` caret ranges to match `packages/plugins/bookmarks-plugin/package.json` (the canonical reference).
+2. If the build-config shape changed, mirror it into `VITE_CONFIG` (the multi-line string just below).
+3. Run `yarn workspace create-mulmoclaude-plugin run build` to regenerate the CLI's own dist.
+4. Optionally bump the CLI's own `version` and re-publish if external users will fetch via `npx`.
+
+If you forget step 1 / 2, generated plugins ship with stale toolchains and may hit the same issue you just fixed in the in-tree plugin (e.g. empty `.d.ts` from api-extractor + TS 6).
+
+---
+
+## Build orchestration rules (plugin-relevant subset)
+
+The full overview is in [`CLAUDE.md`](../CLAUDE.md) under "Build orchestration". The plugin-specific bits:
+
+- **Runtime plugin** workspace selection: lives at `packages/plugins/<name>-plugin/`, package name `@mulmoclaude/<name>-plugin`, has `scripts.build`. The build driver (`scripts/build-workspaces.mjs`) auto-discovers it from tier 4 — **no `package.json` edit needed**.
+- **NEVER** name a non-runtime-plugin package `@mulmoclaude/foo-plugin` (e.g. a helper library). The build driver will try to run its `build` script in tier 4, after every consumer has already been built. Pick `@mulmoclaude/foo` / `@mulmoclaude/foo-helpers` / move it into `@mulmoclaude/core` instead.
+- Non-bridge, non-runtime-plugin workspaces (e.g. `@receptron/*`, `@mulmobridge/mock-server`) **MUST** be added to the explicit tier-1 / tier-2 enumeration in the root `package.json` — auto-discovery won't pick them up.
+
+---
+
+## Plugin-aware host aggregators
+
+When adding a plugin's `meta.ts`, its contributions auto-merge into these centralised constants — **never** edit the aggregator records directly for a plugin literal:
+
+| Aggregator | Source of truth | Plugin contribution |
+|---|---|---|
+| `API_ROUTES` | `src/config/apiRoutes.ts` | `META.apiRoutes` |
+| `TOOL_NAMES` | `src/config/toolNames.ts` | `META.toolName` |
+| `WORKSPACE_DIRS` / `WORKSPACE_PATHS` | `server/workspace/paths.ts` | `META.workspaceDirs` |
+| `PUBSUB_CHANNELS` | `src/config/pubsubChannels.ts` | `META.staticChannels` |
+
+Edits to a plugin's `meta.ts` propagate; collisions surface as boot-time diagnostics on the bell (first-write-wins semantics).
+
+---
+
+## When you need shared code across plugins
+
+You don't import from another plugin (that's a peer-tier violation — see the dependency-direction rule in [`CLAUDE.md`](../CLAUDE.md)). Instead:
+
+1. **Pull the shared code OUT of the plugin into `@mulmoclaude/core`** under a new subpath (e.g. `@mulmoclaude/core/<feature>` + optionally `@mulmoclaude/core/<feature>/server`).
+2. Both plugins (and any consumer) import from core.
+
+The canonical example is [`plans/done/refactor-shared-core.md`](../plans/done/refactor-shared-core.md): `isSafeActionTemplatePath` / `discoverCollections` / `whenMatches` used to live inside `@mulmoclaude/collection-plugin`. The skill-bridge and collection-watchers services needed them, so they reached uphill into the plugin — a violation that forced a `tier 3 → 4 → 3` build-order shuffle and a `--first=notifier` flag (PR #1789). PR #1795 extracted the engine into `@mulmoclaude/core/collection/server`; everyone now consumes from core and the build order is irrelevant.
+
+---
+
+## Quick checklist when creating a runtime plugin
+
+1. `npx create-mulmoclaude-plugin <name>` from the repo root.
+2. Implement the plugin's MCP tool + Vue View / Preview inside `packages/plugins/<name>-plugin/`.
+3. If you need shared infra: import from `@mulmoclaude/core/<subpath>` — DO NOT import from another `*-plugin`.
+4. Add to a role's `availablePlugins` in `src/config/roles.ts` if you want it gated to a specific role.
+5. `yarn build:packages` confirms tier 4 auto-discovers your new workspace.
+6. Smoke-test: `yarn dev`, switch to the role, dispatch the tool from the chat.
+
+## Quick checklist when creating a built-in plugin
+
+1. Use an existing built-in (`src/plugins/wiki/` or `src/plugins/news/`) as a template — copy the 4 plugin-local files (`meta.ts` / `definition.ts` / `index.ts` / `View.vue` + `Preview.vue` if any).
+2. Append to the 3 host barrels: `src/plugins/metas.ts`, `src/plugins/index.ts`, `src/plugins/server.ts`.
+3. If the plugin owns endpoints, add `server/api/routes/<name>.ts` and wire it from `src/main.ts`'s endpoint registry.
+4. `yarn typecheck:vue` confirms the META → aggregator merge typechecks.
+5. Add to a role's `availablePlugins` if role-gated.


### PR DESCRIPTION
## Summary

\`CLAUDE.md\` auto-loads on every session turn, so every code edit pays for content that's only relevant when actually creating or editing a plugin — which is rare compared to day-to-day work.

This PR extracts the plugin-creation content out into a new \`docs/plugin-development.md\` (146 lines) and trims \`CLAUDE.md\` accordingly (−40 / +4 lines).

## What moved

- Plugin-vs-host boundary rule
- Built-in vs runtime decision matrix
- The 6 plugin-local + 3 host barrel checklist (for built-in plugins)
- Scaffold CLI sync caveats (\`packages/create-mulmoclaude-plugin\`)
- Build-orchestration rules specific to plugin packages (the \`@mulmoclaude/foo-plugin\` naming trap)
- Plugin-aware host aggregators table
- "Extract shared code into \`@mulmoclaude/core\` instead of importing uphill" pattern (the #1795 lesson)
- Quick checklists for runtime + built-in plugin authoring

## What stays in CLAUDE.md

- **Package dependency direction** (from #1797) — not plugin-specific, governs every import direction across the monorepo
- All non-plugin sections (Project Overview, Key Commands, Key Rules, Build orchestration overview, Architecture summary, Centralized Constants, Testing, Server Logging, Tech Stack)
- A 3-line pointer to \`docs/plugin-development.md\` where the plugin section used to be
- A one-line pointer in Build orchestration for the runtime-plugin tier-4 selection trap

## Items to Confirm / Review

- **Net effect on per-turn context cost**: −40 lines from CLAUDE.md. Plugin-creation sessions explicitly Read the new doc; non-plugin sessions don't pay for it.
- **Companion to #1797**: both PRs are CLAUDE.md hygiene from the same review session. PR #1797 added the dependency-direction rule; this PR factors the plugin chapter out. Both can land independently — no merge ordering required (the new doc's reference to the dep-direction rule still resolves to the section in CLAUDE.md whether #1797 lands first or later).
- **No content lost**: every paragraph in the original Plugin Development + Plugin scaffold sync sections lives in the new file. Where the source was a single dense block in CLAUDE.md, the new doc rephrases / regroups for the standalone reading order (Plugin-vs-host → Built-in path → Runtime path → Build orchestration → Aggregators → Sharing → Checklists).
- **Quick checklists added** at the end of the new doc — not in the original CLAUDE.md, but a natural addition for a standalone "how to make a plugin" reference.

## User prompt

> ok だたし、claude.md が増えてきたから分割したほうがよくない？プラグインは稀にしか作らないからプラグインをつくるときに参照するファイルを作ってそこにまとめて、それを参照させたい

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract plugin development guidance from CLAUDE.md into a dedicated docs/plugin-development.md reference and leave CLAUDE.md leaner with pointers to the new doc.

Documentation:
- Add a standalone docs/plugin-development.md guide that consolidates built-in and runtime plugin authoring, host/plugin boundaries, and plugin-related build rules.
- Update CLAUDE.md to point plugin authors to the new plugin development guide while retaining only universally applicable rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new consolidated guide for creating and editing plugins.
  * Clarified the differences between built-in and runtime plugins, including how they’re organized and registered.
  * Documented key rules for plugin boundaries and shared code usage.
  * Simplified existing build and plugin guidance to point to the new reference and highlight the most important workflow constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->