### PR TITLE
feat(ui): make chat-history chrome chat-only; add always-visible Chat button

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -19,13 +19,13 @@ A quick visual reference so chat instructions about UI ("the bell at the top rig
 │ │                          ⚙ settings (→ Skills / Roles tabs)      │  │
 │ └──────────────────────────────────────────────────────────────────┘  │
 │ ┌─<PluginLauncher> [plugin-launcher]──────────────────────────────────┐│
-│ │ ⏰Actions│📖Wiki│▦Collections│📡Feeds ‖ 📁Files ‖ ▦Invoices│📡Weather    ││
-│ │ [plugin-launcher-automations] … [plugin-launcher-feeds] …            ││
+│ │ 💬Chat ‖ ⏰Actions│📖Wiki│▦Collections│📡Feeds ‖ 📁Files               ││
+│ │ [plugin-launcher-chat] [plugin-launcher-automations] … [-feeds] …    ││
 │ │   [plugin-launcher-shortcuts]→[plugin-launcher-shortcut-<kind>-<slug>]││
-│ │ data plugins (0–3) │ ‖ │ management (Files) │ ‖ │ pinned shortcuts (scrolls) ││
+│ │ Chat (always-on, carries active/unread badges) │ data plugins │ mgmt │ shortcuts ││
 │ │ Skills & Roles moved into Settings (gear → Management group)           ││
 │ └─────────────────────────────────────────────────────────────────────┘│
-│ ┌─[main pane — route-specific]────┐ ┌─<SessionHistoryPanel>────────┐  │
+│ ┌─[main pane — route-specific]────┐ ┌─<SessionHistoryPanel> (/chat)┐  │
 │ │                                 │ │ [session-history-side-panel] │  │
 │ │  (the active /route's content)  │ │ ┌─[session-filter-bar]─────┐ │  │
 │ │                                 │ │ │ All │Unread│Running│...   │ │  │
@@ -37,7 +37,9 @@ A quick visual reference so chat instructions about UI ("the bell at the top rig
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
-Sidebar visibility toggles via the canvas-layout state. When closed, the main pane is full-width.
+The `[plugin-launcher-chat]` button is the leftmost top-bar control — always visible, on every route. It resumes the most recent chat (or starts a fresh one) and carries the session-count badges: yellow `activeSessionCount` (running) + red `unreadCount` (unread replies), moved here from the history toggle (`<SessionCountBadges>`).
+
+The session-history chrome — Row 2's role selector + `[session-tab-bar]` (horizontal) and `<SessionHistoryPanel>` / `[session-history-side-panel]` (vertical) — renders **only on `/chat`**. Off-chat (`/files`, `/wiki`, …) it's gone, and the Chat button is the way back in. On `/chat`, the side panel toggles via `[session-history-toggle-on|off]`; when closed, the main pane is full-width.
 
 ## `<SessionSidebar>` — left column on every chat session (single layout)
 

--- a/e2e/tests/plugin-launcher.spec.ts
+++ b/e2e/tests/plugin-launcher.spec.ts
@@ -42,4 +42,24 @@ test.describe("plugin launcher — navigation path", () => {
     expect(url.pathname).toBe("/files");
     expect(url.searchParams.get("path")).toBeNull();
   });
+
+  // The Chat button is a dedicated control (not a TARGETS entry): it
+  // resumes-or-creates a chat rather than pushing a fixed route, and it
+  // stays visible on every page so the session-history chrome can be
+  // chat-only.
+  test("Chat button is always visible and returns to /chat from another page", async ({ page }) => {
+    await page.goto("/wiki");
+    await page.waitForURL(/\/wiki/);
+
+    // Chat-only chrome (history side panel + role selector) is gone here.
+    await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
+    await expect(page.getByTestId("role-selector-btn")).toBeHidden();
+
+    // The Chat button persists and lands back on /chat, where the role
+    // selector reappears.
+    await expect(page.getByTestId("plugin-launcher-chat")).toBeVisible();
+    await page.getByTestId("plugin-launcher-chat").click();
+    await page.waitForURL(/\/chat\//);
+    await expect(page.getByTestId("role-selector-btn")).toBeVisible();
+  });
 });

--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -112,16 +112,19 @@ test.describe("session-history side-panel toggle", () => {
     await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();
   });
 
-  test("side panel stays visible across page navigation", async ({ page }) => {
+  test("side panel is chat-only — hidden off /chat, restored on return", async ({ page }) => {
     // Enable the toggle on /chat first so the preference is on.
     await page.goto("/chat");
     await page.getByTestId("session-history-toggle-off").click();
     await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
 
-    // Navigate off chat — panel stays up. `sidePanelVisible` is the
-    // single flag driving the column; it does not depend on the
-    // current route, so Files / Wiki / etc. render alongside it.
+    // Navigate off chat — the session-history chrome is chat-only, so
+    // the panel unmounts even though `sidePanelVisible` is still on.
     await page.goto("/files");
+    await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
+
+    // Returning to /chat restores it (the preference persisted).
+    await page.goto("/chat");
     await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
   });
 });

--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -139,6 +139,9 @@ test.describe("session-history side-panel toggle", () => {
 
     // Expand to full-width, then navigate off chat via the Files button.
     await page.getByTestId("session-history-expand-off").click();
+    // Confirm the expand actually took effect — otherwise the test could
+    // pass even if the toggle broke, since it never reproduces the bug.
+    await expect(page.getByTestId("session-history-expand-on")).toBeVisible();
     await page.getByTestId("plugin-launcher-files").click();
     await page.waitForURL(/\/files(?:$|\?)/);
 

--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -127,4 +127,23 @@ test.describe("session-history side-panel toggle", () => {
     await page.goto("/chat");
     await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
   });
+
+  test("leaving /chat while the panel is expanded still renders the plugin page", async ({ page }) => {
+    // Regression: the side panel is chat-only chrome and unmounts off
+    // /chat, but the canvas/sidebar stay gated by `!sidePanelExpanded`.
+    // Without resetting the transient expanded flag on chat→non-chat,
+    // navigating away while expanded would blank the body.
+    await page.goto("/chat");
+    await page.getByTestId("session-history-toggle-off").click();
+    await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
+
+    // Expand to full-width, then navigate off chat via the Files button.
+    await page.getByTestId("session-history-expand-off").click();
+    await page.getByTestId("plugin-launcher-files").click();
+    await page.waitForURL(/\/files(?:$|\?)/);
+
+    // The plugin page renders — the body is not blanked.
+    await expect(page.getByTestId("files-view-root")).toBeVisible();
+    await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
+  });
 });

--- a/e2e/tests/session-tab-bar.spec.ts
+++ b/e2e/tests/session-tab-bar.spec.ts
@@ -64,13 +64,12 @@ test.describe("session tab bar — visible per-tab info", () => {
     await expect(tabB.getByLabel("Started by bridge")).toBeVisible();
   });
 
-  test("unread dot stays visible when the user leaves /chat for a plugin page", async ({ page }) => {
-    // Regression: the dot was gated on `sessions[i].id !==
-    // currentSessionId`, which evaluates the same way on /wiki /files
-    // etc. because `currentSessionId` doesn't clear when the user
-    // navigates off chat. That meant the tab the user was reading
-    // before navigating away would silently lose its unread dot the
-    // moment a new reply arrived — exactly when they need it most.
+  test("unread count surfaces on the Chat button after the user leaves /chat", async ({ page }) => {
+    // The session-tab bar is chat-only, so its per-tab unread dots
+    // unmount off /chat. The aggregate unread count instead rides the
+    // always-visible Chat button (SessionCountBadges), so the user can
+    // still tell replies are waiting from any page — without that, the
+    // unread signal would vanish the moment they navigate away.
     await mockAllApis(page, {
       sessions: [
         { ...SESSION_A, hasUnread: true },
@@ -78,22 +77,18 @@ test.describe("session tab bar — visible per-tab info", () => {
       ],
     });
 
-    // On /chat, the active session's dot is suppressed (the user is
-    // literally looking at that conversation).
+    const chatBtn = page.getByTestId("plugin-launcher-chat");
+
+    // On /chat, the Chat button already carries the unread badge.
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await expect(page.getByTestId(`session-tab-${SESSION_B.id}`)).toBeVisible();
-    // Query by `aria-current="page"` to identify the active tab —
-    // reading data-testid from a tab we selected by id (the previous
-    // approach) was tautological and would pass even if the tabs
-    // were swapped. SESSION_B is newer → it's the displayed chat.
-    const activeTabId = await page.locator("button[aria-current='page'][data-testid^='session-tab-']").getAttribute("data-testid");
-    expect(activeTabId).toBe(`session-tab-${SESSION_B.id}`);
+    await expect(chatBtn.getByTestId("session-count-unread")).toBeVisible();
 
-    // Navigate off chat. The dot on tab B must now appear, because
-    // B is no longer on-screen.
+    // Navigate off chat. The tab bar (and its per-tab dots) unmounts,
+    // but the unread badge on the Chat button persists — at least one
+    // session is still unread.
     await page.goto("/wiki");
-    await expect(page.getByTestId(`session-tab-${SESSION_B.id}`).getByLabel("New reply")).toBeVisible();
-    await expect(page.getByTestId(`session-tab-${SESSION_A.id}`).getByLabel("New reply")).toBeVisible();
+    await expect(page.getByTestId(`session-tab-${SESSION_B.id}`)).toBeHidden();
+    await expect(chatBtn.getByTestId("session-count-unread")).toBeVisible();
   });
 });

--- a/e2e/tests/wiki-navigation.spec.ts
+++ b/e2e/tests/wiki-navigation.spec.ts
@@ -368,24 +368,21 @@ test.describe("wiki navigation — from manageWiki tool result", () => {
     await expect(page.getByRole("heading", { level: 1, name: "Onboarding" })).toBeVisible();
   });
 
-  test("session tab click from /wiki navigates back to /chat for that session", async ({ page }) => {
-    // Regression: loadSession used to early-return whenever
-    // `sessionId === currentSessionId.value`, which left the user
-    // stuck on /wiki because currentSessionId is not reset when
-    // navigating to a non-chat page. The guard now also checks the
-    // URL so cross-page re-selection actually navigates.
+  test("Chat button returns to /chat from /wiki (session-tab bar is chat-only)", async ({ page }) => {
     await page.goto("/chat/wiki-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
 
-    // Leave /chat for /wiki.
+    // Leave /chat for /wiki. The session-history chrome is now
+    // chat-only, so the session-tab bar unmounts off /chat.
     await page.goto("/wiki");
     await expect(page.getByTestId("wiki-page-entry-onboarding")).toBeVisible();
     expect(page.url()).toContain("/wiki");
+    await expect(page.getByTestId("session-tab-wiki-session")).toBeHidden();
 
-    // Re-select the same session from the tab bar — this was a no-op.
-    await page.getByTestId("session-tab-wiki-session").click();
-
-    await page.waitForURL(/\/chat\/wiki-session/);
-    expect(new URL(page.url()).pathname).toBe("/chat/wiki-session");
+    // The always-visible Chat button in the top bar is the way back
+    // into a conversation (resumes the most recent chat).
+    await page.getByTestId("plugin-launcher-chat").click();
+    await page.waitForURL(/\/chat\//);
+    expect(new URL(page.url()).pathname).toMatch(/^\/chat\//);
   });
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,25 +21,28 @@
             :active-tool-name="selectedResult?.toolName ?? null"
             :active-view-mode="currentPage"
             :shortcuts="shortcuts"
+            :active-session-count="activeSessionCount"
+            :unread-count="unreadCount"
             @navigate="onPluginNavigate"
             @navigate-shortcut="onShortcutNavigate"
+            @navigate-chat="handleHomeClick"
           />
         </div>
       </div>
-      <!-- Row 2: role selector + session tabs. Shown whenever the
-           side panel is hidden — Row 2 and the side panel are
-           mutually exclusive. The header-controls wrapper is pinned
-           to 264px (w-72 minus px-3 padding on each side) so that
+      <!-- Row 2: role selector + session tabs. Chat-only chrome — shown
+           on /chat whenever the side panel is hidden (Row 2 and the
+           side panel are mutually exclusive). Off /chat the whole row
+           is gone; the always-visible Chat button in Row 1 is the way
+           back into a conversation. The header-controls wrapper is
+           pinned to 264px (w-72 minus px-3 padding on each side) so
            RoleSelector / + / toggle occupy the exact same x-range as
            they do inside the open side panel — toggling the panel
            therefore doesn't shift those controls. -->
-      <div v-if="!sidePanelVisible" class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
+      <div v-if="isChatPage && !sidePanelVisible" class="flex items-center gap-2 px-3 py-2 border-b border-gray-100">
         <div class="w-[264px] shrink-0">
           <SessionHeaderControls
             :roles="roles"
             :side-panel-visible="sidePanelVisible"
-            :active-session-count="activeSessionCount"
-            :unread-count="unreadCount"
             @role-change="onRoleChange"
             @new-session="handleNewSessionClick"
             @update:side-panel-visible="setSidePanelVisible"
@@ -53,12 +56,12 @@
     <div class="flex flex-1 min-h-0">
       <!-- Session-history side panel. Opt-in column to the left of
            the chat sidebar / canvas, toggled via
-           SessionHistoryToggleButton. Renders on every page when
-           `sidePanelVisible` is true. Row 2 of the top bar hides when
-           the panel is open — the panel's own header supplies the
-           role selector + new-session button instead. -->
+           SessionHistoryToggleButton. Chat-only chrome — renders on
+           /chat when `sidePanelVisible` is true. Row 2 of the top bar
+           hides when the panel is open — the panel's own header
+           supplies the role selector + new-session button instead. -->
       <div
-        v-if="sidePanelVisible"
+        v-if="isChatPage && sidePanelVisible"
         class="relative border-r border-gray-200 bg-white text-gray-900 flex flex-col min-w-0 overflow-hidden"
         :class="sidePanelExpanded ? 'flex-1' : 'w-72 flex-shrink-0'"
         data-testid="session-history-side-panel"
@@ -72,8 +75,6 @@
           <SessionHeaderControls
             :roles="roles"
             :side-panel-visible="sidePanelVisible"
-            :active-session-count="activeSessionCount"
-            :unread-count="unreadCount"
             @role-change="onRoleChange"
             @new-session="handleNewSessionClick"
             @update:side-panel-visible="setSidePanelVisibleAndCollapse"

--- a/src/App.vue
+++ b/src/App.vue
@@ -679,10 +679,18 @@ const canvasDropHandlers = computed(() =>
 // don't persist empty sessions on the server. Fires true → false only;
 // an empty → /chat transition is handled by the route-params watcher
 // and onMounted.
+//
+// Also collapse the side panel's transient full-width mode. The panel
+// itself is chat-only chrome (`isChatPage && sidePanelVisible`), so it
+// unmounts off /chat — but the canvas/sidebar stay gated by
+// `!sidePanelExpanded`. Without this reset, leaving /chat while expanded
+// would unmount the panel AND keep the canvas hidden, blanking plugin
+// pages until the panel is collapsed again.
 watch(isChatPage, (isChat, wasChat) => {
   if (!(wasChat && !isChat)) return;
   removeCurrentIfEmpty();
   currentSessionId.value = "";
+  sidePanelExpanded.value = false;
 });
 
 function handleSessionSelect(sessionId: string): void {

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -8,8 +8,8 @@
     <button
       class="relative h-8 w-8 flex items-center justify-center rounded border border-gray-300 transition-colors"
       :class="isChatActive ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50'"
-      :title="t('pluginLauncher.chat.label')"
-      :aria-label="t('pluginLauncher.chat.label')"
+      :title="chatAccessibleName"
+      :aria-label="chatAccessibleName"
       data-testid="plugin-launcher-chat"
       @click="emit('navigateChat')"
     >
@@ -113,6 +113,25 @@ const isChatActive = computed(() => route.name === PAGE_ROUTES.chat);
 
 const activeSessionCount = computed(() => props.activeSessionCount ?? 0);
 const unreadCount = computed(() => props.unreadCount ?? 0);
+
+// The Chat button is the only off-chat surface for the active/unread
+// session counts, so its accessible name must spell them out — a bare
+// "Chat" aria-label would override the badge text and leave screen
+// readers with no unread/running signal on /wiki, /files, etc. Reuses
+// the same localized plural strings as the badges. (No aria-live: a
+// polite region here would re-announce background count changes while
+// the user is reading another page; the name is announced when the
+// control is focused.)
+const chatAccessibleName = computed(() => {
+  const parts = [t("pluginLauncher.chat.label")];
+  if (activeSessionCount.value > 0) {
+    parts.push(t("sessionTabBar.activeSessions", activeSessionCount.value, { named: { count: activeSessionCount.value } }));
+  }
+  if (unreadCount.value > 0) {
+    parts.push(t("sessionTabBar.unreadReplies", unreadCount.value, { named: { count: unreadCount.value } }));
+  }
+  return parts.join(", ");
+});
 
 export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated view mode
 

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -1,57 +1,79 @@
 <template>
-  <div class="inline-flex max-w-full items-stretch border border-gray-300 rounded overflow-hidden text-xs" data-testid="plugin-launcher">
-    <!-- Fixed groups (data plugins + management). Never shrink / scroll. -->
-    <div class="flex flex-none items-stretch">
-      <template v-for="(target, idx) in visibleTargets" :key="target.key">
-        <!-- Visual separator between data plugins and management plugins -->
-        <div v-if="idx === separatorAfterIndex" class="w-px bg-gray-300 my-0.5" />
-        <button
-          :class="[
-            'h-8 w-8 flex items-center justify-center rounded border-r border-gray-200 last:border-r-0 transition-colors',
-            isActive(target) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
-          ]"
-          :title="target.literalTitle ?? t(`pluginLauncher.${target.key}.label`)"
-          :aria-label="target.literalLabel ?? t(`pluginLauncher.${target.key}.label`)"
-          :data-testid="`plugin-launcher-${target.key}`"
-          @click="emit('navigate', target)"
-        >
-          <span class="material-icons text-base">{{ target.icon }}</span>
-        </button>
-      </template>
-    </div>
+  <div class="inline-flex max-w-full items-center gap-2 text-xs" data-testid="plugin-launcher">
+    <!-- Chat button. Leftmost top-bar control and the always-visible
+         entry point back into a conversation (resumes the most recent
+         chat, or starts a fresh one). Sits OUTSIDE the bordered/
+         overflow-hidden pill below so its session-count badges, which
+         use negative offsets, aren't clipped. Lights up on /chat. -->
+    <button
+      class="relative h-8 w-8 flex items-center justify-center rounded border border-gray-300 transition-colors"
+      :class="isChatActive ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50'"
+      :title="t('pluginLauncher.chat.label')"
+      :aria-label="t('pluginLauncher.chat.label')"
+      data-testid="plugin-launcher-chat"
+      @click="emit('navigateChat')"
+    >
+      <span class="material-icons text-base">forum</span>
+      <SessionCountBadges :active-session-count="activeSessionCount" :unread-count="unreadCount" />
+    </button>
 
-    <!-- Pinned shortcuts zone (#feat-shortcut-bar). Appears only when the
+    <!-- Plugin nav + shortcuts pill. Bordered, rounded, overflow-hidden
+         so the inner buttons clip cleanly and the shortcuts zone can
+         scroll horizontally without spilling. -->
+    <div class="inline-flex min-w-0 items-stretch border border-gray-300 rounded overflow-hidden">
+      <!-- Fixed groups (data plugins + management). Never shrink / scroll. -->
+      <div class="flex flex-none items-stretch">
+        <template v-for="(target, idx) in visibleTargets" :key="target.key">
+          <!-- Visual separator between data plugins and management plugins -->
+          <div v-if="idx === separatorAfterIndex" class="w-px bg-gray-300 my-0.5" />
+          <button
+            :class="[
+              'h-8 w-8 flex items-center justify-center rounded border-r border-gray-200 last:border-r-0 transition-colors',
+              isActive(target) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
+            ]"
+            :title="target.literalTitle ?? t(`pluginLauncher.${target.key}.label`)"
+            :aria-label="target.literalLabel ?? t(`pluginLauncher.${target.key}.label`)"
+            :data-testid="`plugin-launcher-${target.key}`"
+            @click="emit('navigate', target)"
+          >
+            <span class="material-icons text-base">{{ target.icon }}</span>
+          </button>
+        </template>
+      </div>
+
+      <!-- Pinned shortcuts zone (#feat-shortcut-bar). Appears only when the
          user has pinned at least one collection / feed. Separated by a
          second divider; scrolls horizontally on overflow (no cap on the
          pin count) so a long list never pushes the chrome past the
          viewport. The fixed groups above stay put. -->
-    <template v-if="shortcuts.length > 0">
-      <div class="w-px bg-gray-300 my-0.5 flex-none" />
-      <div
-        class="flex min-w-0 items-stretch overflow-x-auto [scrollbar-width:thin]"
-        :aria-label="t('shortcuts.zoneAriaLabel')"
-        data-testid="plugin-launcher-shortcuts"
-      >
-        <button
-          v-for="shortcut in shortcuts"
-          :key="`${shortcut.kind}:${shortcut.slug}`"
-          :class="[
-            'h-8 w-8 flex items-center justify-center flex-none border-r border-gray-200 last:border-r-0 transition-colors',
-            isShortcutActive(shortcut) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
-          ]"
-          :title="shortcut.title"
-          :aria-label="shortcut.title"
-          :data-testid="`plugin-launcher-shortcut-${shortcut.kind}-${shortcut.slug}`"
-          @click="emit('navigateShortcut', shortcut)"
+      <template v-if="shortcuts.length > 0">
+        <div class="w-px bg-gray-300 my-0.5 flex-none" />
+        <div
+          class="flex min-w-0 items-stretch overflow-x-auto [scrollbar-width:thin]"
+          :aria-label="t('shortcuts.zoneAriaLabel')"
+          data-testid="plugin-launcher-shortcuts"
         >
-          <!-- Icon-only — the cached title rides the tooltip / aria-label.
+          <button
+            v-for="shortcut in shortcuts"
+            :key="`${shortcut.kind}:${shortcut.slug}`"
+            :class="[
+              'h-8 w-8 flex items-center justify-center flex-none border-r border-gray-200 last:border-r-0 transition-colors',
+              isShortcutActive(shortcut) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
+            ]"
+            :title="shortcut.title"
+            :aria-label="shortcut.title"
+            :data-testid="`plugin-launcher-shortcut-${shortcut.kind}-${shortcut.slug}`"
+            @click="emit('navigateShortcut', shortcut)"
+          >
+            <!-- Icon-only — the cached title rides the tooltip / aria-label.
                Collections / feeds use the material-symbols font for their
                glyphs (matches the index cards), distinct from the
                material-icons used by the fixed launcher buttons. -->
-          <span class="material-symbols-outlined text-base">{{ shortcut.icon }}</span>
-        </button>
-      </div>
-    </template>
+            <span class="material-symbols-outlined text-base">{{ shortcut.icon }}</span>
+          </button>
+        </div>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -61,6 +83,7 @@ import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import { PAGE_ROUTES } from "../router/pageRoutes";
 import type { Shortcut, ShortcutKind } from "../types/shortcuts";
+import SessionCountBadges from "./SessionCountBadges.vue";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -75,9 +98,21 @@ const props = defineProps<{
   activeViewMode?: string | null;
   /** Pinned shortcuts (collections / feeds) rendered as the third zone. */
   shortcuts?: Shortcut[];
+  /** Running-session count — yellow badge on the Chat button. */
+  activeSessionCount?: number;
+  /** Unread-reply count — red badge on the Chat button. */
+  unreadCount?: number;
 }>();
 
 const shortcuts = computed<Shortcut[]>(() => props.shortcuts ?? []);
+
+// The Chat button highlights whenever the chat page is active. Unlike
+// the data-plugin buttons (matched by `activeViewMode`), chat is a
+// dedicated control, so we read the route name directly.
+const isChatActive = computed(() => route.name === PAGE_ROUTES.chat);
+
+const activeSessionCount = computed(() => props.activeSessionCount ?? 0);
+const unreadCount = computed(() => props.unreadCount ?? 0);
 
 export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated view mode
 
@@ -183,5 +218,6 @@ function isShortcutActive(shortcut: Shortcut): boolean {
 const emit = defineEmits<{
   navigate: [target: PluginLauncherTarget];
   navigateShortcut: [shortcut: Shortcut];
+  navigateChat: [];
 }>();
 </script>

--- a/src/components/SessionCountBadges.vue
+++ b/src/components/SessionCountBadges.vue
@@ -1,0 +1,32 @@
+<template>
+  <!-- Active-session + unread-reply count badges. Presentational only;
+       the parent element must be `position: relative` so the absolute
+       offsets anchor to it. Extracted from SessionHistoryToggleButton so
+       the counts can ride the top-bar Chat button (always visible) while
+       the history toggle itself is chat-only. -->
+  <span
+    v-if="activeSessionCount > 0"
+    class="absolute -top-0.5 -left-0.5 min-w-[1rem] h-4 px-0.5 bg-yellow-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
+    data-testid="session-count-active"
+    :title="t('sessionTabBar.activeSessions', activeSessionCount, { named: { count: activeSessionCount } })"
+    >{{ activeSessionCount }}</span
+  >
+  <span
+    v-if="unreadCount > 0"
+    class="absolute -top-0.5 -right-0.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
+    data-testid="session-count-unread"
+    :title="t('sessionTabBar.unreadReplies', unreadCount, { named: { count: unreadCount } })"
+    >{{ unreadCount }}</span
+  >
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+
+defineProps<{
+  activeSessionCount: number;
+  unreadCount: number;
+}>();
+</script>

--- a/src/components/SessionHeaderControls.vue
+++ b/src/components/SessionHeaderControls.vue
@@ -26,12 +26,7 @@
       >
         <span class="material-icons text-sm">add</span>
       </button>
-      <SessionHistoryToggleButton
-        :model-value="sidePanelVisible"
-        :active-session-count="activeSessionCount"
-        :unread-count="unreadCount"
-        @update:model-value="(value: boolean) => emit('update:sidePanelVisible', value)"
-      />
+      <SessionHistoryToggleButton :model-value="sidePanelVisible" @update:model-value="(value: boolean) => emit('update:sidePanelVisible', value)" />
     </div>
   </div>
 </template>
@@ -49,8 +44,6 @@ const { t } = useI18n();
 const props = defineProps<{
   roles: Role[];
   sidePanelVisible: boolean;
-  activeSessionCount: number;
-  unreadCount: number;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/SessionHistoryToggleButton.vue
+++ b/src/components/SessionHistoryToggleButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="relative flex items-center justify-center w-8 h-8 rounded text-gray-400 hover:text-gray-700 transition-colors hover:bg-gray-100"
+    class="flex items-center justify-center w-8 h-8 rounded text-gray-400 hover:text-gray-700 transition-colors hover:bg-gray-100"
     :title="modelValue ? t('sessionHistoryToggle.hideTooltip') : t('sessionHistoryToggle.showTooltip')"
     :aria-label="modelValue ? t('sessionHistoryToggle.hide') : t('sessionHistoryToggle.show')"
     :aria-pressed="modelValue"
@@ -8,18 +8,6 @@
     @click="emit('update:modelValue', !modelValue)"
   >
     <span class="material-symbols-outlined text-lg" aria-hidden="true">{{ modelValue ? "dock_to_right" : "toolbar" }}</span>
-    <span
-      v-if="activeSessionCount > 0"
-      class="absolute -top-0.5 -left-0.5 min-w-[1rem] h-4 px-0.5 bg-yellow-400 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
-      :title="t('sessionTabBar.activeSessions', activeSessionCount, { named: { count: activeSessionCount } })"
-      >{{ activeSessionCount }}</span
-    >
-    <span
-      v-if="unreadCount > 0"
-      class="absolute -top-0.5 -right-0.5 min-w-[1rem] h-4 px-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center leading-none cursor-help"
-      :title="t('sessionTabBar.unreadReplies', unreadCount, { named: { count: unreadCount } })"
-      >{{ unreadCount }}</span
-    >
   </button>
 </template>
 
@@ -30,8 +18,6 @@ const { t } = useI18n();
 
 defineProps<{
   modelValue: boolean;
-  activeSessionCount: number;
-  unreadCount: number;
 }>();
 
 const emit = defineEmits<{

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -337,6 +337,7 @@ const deMessages = {
     errLabelConflict: 'Label "{label}" existiert bereits',
   },
   pluginLauncher: {
+    chat: { label: "Chat" },
     automations: { label: "Aktionen" },
     wiki: { label: "Wiki" },
     collections: { label: "Sammlungen" },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -352,6 +352,7 @@ const enMessages = {
     errLabelConflict: 'Label "{label}" already exists',
   },
   pluginLauncher: {
+    chat: { label: "Chat" },
     automations: { label: "Actions" },
     wiki: { label: "Wiki" },
     collections: { label: "Collections" },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -339,6 +339,7 @@ const esMessages = {
     errLabelConflict: 'La etiqueta "{label}" ya existe',
   },
   pluginLauncher: {
+    chat: { label: "Chat" },
     automations: { label: "Acciones" },
     wiki: { label: "Wiki" },
     collections: { label: "Colecciones" },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -333,6 +333,7 @@ const frMessages = {
     errLabelConflict: 'L\'étiquette "{label}" existe déjà',
   },
   pluginLauncher: {
+    chat: { label: "Discussion" },
     automations: { label: "Actions" },
     wiki: { label: "Wiki" },
     collections: { label: "Collections" },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -335,6 +335,7 @@ const jaMessages = {
     errLabelConflict: "ラベル「{label}」は既に使用されています",
   },
   pluginLauncher: {
+    chat: { label: "チャット" },
     automations: { label: "自動化" },
     wiki: { label: "Wiki" },
     collections: { label: "コレクション" },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -335,6 +335,7 @@ const koMessages = {
     errLabelConflict: '라벨 "{label}" 은(는) 이미 사용 중입니다',
   },
   pluginLauncher: {
+    chat: { label: "채팅" },
     automations: { label: "자동화" },
     wiki: { label: "위키" },
     collections: { label: "컬렉션" },

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -331,6 +331,7 @@ const ptBRMessages = {
     errLabelConflict: 'Rótulo "{label}" já existe',
   },
   pluginLauncher: {
+    chat: { label: "Chat" },
     automations: { label: "Ações" },
     wiki: { label: "Wiki" },
     collections: { label: "Coleções" },

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -327,6 +327,7 @@ const zhMessages = {
     errLabelConflict: '标签 "{label}" 已存在',
   },
   pluginLauncher: {
+    chat: { label: "聊天" },
     automations: { label: "自动化" },
     wiki: { label: "百科" },
     collections: { label: "集合" },


### PR DESCRIPTION
## Summary

The session-history bar (horizontal `SessionTabBar` / vertical `SessionHistoryPanel`) and the role selector previously rendered on **every** route — `/files`, `/wiki`, `/collections`, etc. — even though they only make sense inside a conversation. They now render **only on `/chat`**.

Because hiding that chrome off-chat removes the only on-screen way back into a conversation, this adds a dedicated **Chat** button as the leftmost control in `PluginLauncher`. It resumes the most recent chat (or starts a fresh one; first-ever chat defaults to the `general` role) and highlights when on `/chat`.

The two session-count badges (yellow `activeSessionCount` / red `unreadCount`) move off the now-chat-only history toggle onto the always-visible Chat button — extracted into a reusable `SessionCountBadges` component — so that signal stays visible from any page.

## Changes

- **`src/App.vue`** — gate Row 2 + side panel on `isChatPage`; wire the Chat button to `resumeOrCreateChatSession`; pass counts to `PluginLauncher`; drop the count props from both `SessionHeaderControls` usages.
- **`src/components/PluginLauncher.vue`** — leading Chat button placed just outside the bordered/`overflow-hidden` pill (so the negative-offset badges aren't clipped), `navigate-chat` emit, count props, `plugin-launcher-chat` testid, `forum` icon, lights up via `route.name === chat`.
- **`src/components/SessionCountBadges.vue`** (new) — extracted the two badge spans, with `session-count-active` / `session-count-unread` testids.
- **`src/components/SessionHistoryToggleButton.vue`** / **`SessionHeaderControls.vue`** — drop the badges and the now-unused count props.
- **`src/lang/*.ts`** (all 8) — `pluginLauncher.chat` label, translated per locale.
- **`docs/ui-cheatsheet.md`** — update the top-level chrome block.
- **e2e** — invert the two tests that asserted off-chat history persistence (`session-history-side-panel`, `wiki-navigation`); repurpose the tab-bar unread test to the Chat-button badge (`session-tab-bar`); add a chat-only-chrome + Chat-button test (`plugin-launcher`).

## Verification

- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` — all clean (typecheck confirms i18n lockstep across 8 locales).
- `yarn test` — pass.
- `yarn test:e2e` — **440 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an always-visible **Chat** button in the top bar with active-session and unread-reply badges.
  * **Chat** navigation now routes directly back to the chat page.
* **Bug Fixes**
  * Chat-only UI (session history row/side panel) now shows only on the chat route, even if the toggle is enabled.
  * Leaving chat now resets transient expanded state to prevent blank/hidden canvas behavior on return.
  * Per-session unread dots no longer show off-chat; the aggregated unread badge on the **Chat** button remains.
* **Documentation**
  * Updated the UI cheatsheet to reflect the launcher and `/chat` session-history behavior.
* **Tests**
  * Updated and added Playwright coverage for chat-only visibility and unread indicator behavior across route changes.
* **Chores**
  * Added localized **Chat** labels across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->