### PR TITLE
feat(ui): split plugin launcher into two grouped pills

### DIFF
--- a/docs/ui-cheatsheet.md
+++ b/docs/ui-cheatsheet.md
@@ -19,10 +19,11 @@ A quick visual reference so chat instructions about UI ("the bell at the top rig
 │ │                          ⚙ settings (→ Skills / Roles tabs)      │  │
 │ └──────────────────────────────────────────────────────────────────┘  │
 │ ┌─<PluginLauncher> [plugin-launcher]──────────────────────────────────┐│
-│ │ 💬Chat ‖ ⏰Actions│📖Wiki│▦Collections│📡Feeds ‖ 📁Files               ││
-│ │ [plugin-launcher-chat] [plugin-launcher-automations] … [-feeds] …    ││
-│ │   [plugin-launcher-shortcuts]→[plugin-launcher-shortcut-<kind>-<slug>]││
-│ │ Chat (always-on, carries active/unread badges) │ data plugins │ mgmt │ shortcuts ││
+│ │ [ 💬Chat 📖Wiki ▦Collections 📡Feeds 📁Files ⏰Actions (🐛Debug) ]  [ ⭐⭐ ] ││
+│ │ [plugin-launcher-chat] [-wiki] … [-files] [-automations]  gap  [-shortcuts] ││
+│ │   group 1 (own pill, one run): Chat→…→Files→Actions (+Debug in dev). ││
+│ │   Chat is leftmost, carries the active/unread badges. group 2 (sep-  ││
+│ │   arate pill after a gap): pinned favorites [plugin-launcher-shortcut-<kind>-<slug>] ││
 │ │ Skills & Roles moved into Settings (gear → Management group)           ││
 │ └─────────────────────────────────────────────────────────────────────┘│
 │ ┌─[main pane — route-specific]────┐ ┌─<SessionHistoryPanel> (/chat)┐  │
@@ -37,7 +38,7 @@ A quick visual reference so chat instructions about UI ("the bell at the top rig
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
-The `[plugin-launcher-chat]` button is the leftmost top-bar control — always visible, on every route. It resumes the most recent chat (or starts a fresh one) and carries the session-count badges: yellow `activeSessionCount` (running) + red `unreadCount` (unread replies), moved here from the history toggle (`<SessionCountBadges>`).
+The `[plugin-launcher-chat]` button is the leftmost control in **group 1** — always visible, on every route. Group 1 is its own bordered pill (Chat, Wiki, Collections, Feeds, Files, Actions/Automations, plus dev-only Debug — one run); **group 2** is a separate bordered pill, after a `gap-2`, holding the pinned collection/feed favorites. Neither pill is `overflow-hidden`, so the Chat button's count badges aren't clipped. The button resumes the most recent chat (or starts a fresh one) and carries the session-count badges: yellow `activeSessionCount` (running) + red `unreadCount` (unread replies), moved here from the history toggle (`<SessionCountBadges>`).
 
 The session-history chrome — Row 2's role selector + `[session-tab-bar]` (horizontal) and `<SessionHistoryPanel>` / `[session-history-side-panel]` (vertical) — renders **only on `/chat`**. Off-chat (`/files`, `/wiki`, …) it's gone, and the Chat button is the way back in. On `/chat`, the side panel toggles via `[session-history-toggle-on|off]`; when closed, the main pane is full-width.
 

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -1,78 +1,74 @@
 <template>
+  <!-- Two separate bordered pills with a gap between them:
+       · Group 1 (Chat → Files, +Debug in dev): the Chat button plus the
+         fixed plugin-nav buttons, all in one run.
+       · Group 2 (favorites): pinned collection / feed shortcuts.
+       Neither pill is overflow-hidden so the Chat button's session-count
+       badges (negative offsets) aren't clipped; group 2 scrolls horizontally
+       via its own overflow-x-auto. -->
   <div class="inline-flex max-w-full items-center gap-2 text-xs" data-testid="plugin-launcher">
-    <!-- Chat button. Leftmost top-bar control and the always-visible
-         entry point back into a conversation (resumes the most recent
-         chat, or starts a fresh one). Sits OUTSIDE the bordered/
-         overflow-hidden pill below so its session-count badges, which
-         use negative offsets, aren't clipped. Lights up on /chat. -->
-    <button
-      class="relative h-8 w-8 flex items-center justify-center rounded border border-gray-300 transition-colors"
-      :class="isChatActive ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50'"
-      :title="chatAccessibleName"
-      :aria-label="chatAccessibleName"
-      data-testid="plugin-launcher-chat"
-      @click="emit('navigateChat')"
+    <!-- Group 1: Chat + fixed plugin nav. Never shrinks / scrolls. -->
+    <div class="inline-flex flex-none items-stretch border border-gray-300 rounded">
+      <!-- Chat button. Leftmost control and the always-visible entry
+           point back into a conversation (resumes the most recent chat,
+           or starts a fresh one). Carries the active/unread count badges.
+           Lights up on /chat. -->
+      <button
+        class="relative h-8 w-8 flex items-center justify-center rounded-l border-r border-gray-200 transition-colors"
+        :class="isChatActive ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50'"
+        :title="chatAccessibleName"
+        :aria-label="chatAccessibleName"
+        data-testid="plugin-launcher-chat"
+        @click="emit('navigateChat')"
+      >
+        <span class="material-icons text-base">forum</span>
+        <SessionCountBadges :active-session-count="activeSessionCount" :unread-count="unreadCount" />
+      </button>
+      <button
+        v-for="target in visibleTargets"
+        :key="target.key"
+        :class="[
+          'h-8 w-8 flex items-center justify-center border-r border-gray-200 last:border-r-0 last:rounded-r transition-colors',
+          isActive(target) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
+        ]"
+        :title="target.literalTitle ?? t(`pluginLauncher.${target.key}.label`)"
+        :aria-label="target.literalLabel ?? t(`pluginLauncher.${target.key}.label`)"
+        :data-testid="`plugin-launcher-${target.key}`"
+        @click="emit('navigate', target)"
+      >
+        <span class="material-icons text-base">{{ target.icon }}</span>
+      </button>
+    </div>
+
+    <!-- Group 2 — pinned shortcuts pill (#feat-shortcut-bar). Appears only
+       when the user has pinned at least one collection / feed. Its own
+       bordered pill, separated from group 1 by the gap; scrolls horizontally
+       on overflow (no cap on the pin count) so a long list never pushes the
+       chrome past the viewport. Group 1 stays put. -->
+    <div
+      v-if="shortcuts.length > 0"
+      class="inline-flex min-w-0 items-stretch border border-gray-300 rounded overflow-x-auto [scrollbar-width:thin]"
+      :aria-label="t('shortcuts.zoneAriaLabel')"
+      data-testid="plugin-launcher-shortcuts"
     >
-      <span class="material-icons text-base">forum</span>
-      <SessionCountBadges :active-session-count="activeSessionCount" :unread-count="unreadCount" />
-    </button>
-
-    <!-- Plugin nav + shortcuts pill. Bordered, rounded, overflow-hidden
-         so the inner buttons clip cleanly and the shortcuts zone can
-         scroll horizontally without spilling. -->
-    <div class="inline-flex min-w-0 items-stretch border border-gray-300 rounded overflow-hidden">
-      <!-- Fixed groups (data plugins + management). Never shrink / scroll. -->
-      <div class="flex flex-none items-stretch">
-        <template v-for="(target, idx) in visibleTargets" :key="target.key">
-          <!-- Visual separator between data plugins and management plugins -->
-          <div v-if="idx === separatorAfterIndex" class="w-px bg-gray-300 my-0.5" />
-          <button
-            :class="[
-              'h-8 w-8 flex items-center justify-center rounded border-r border-gray-200 last:border-r-0 transition-colors',
-              isActive(target) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
-            ]"
-            :title="target.literalTitle ?? t(`pluginLauncher.${target.key}.label`)"
-            :aria-label="target.literalLabel ?? t(`pluginLauncher.${target.key}.label`)"
-            :data-testid="`plugin-launcher-${target.key}`"
-            @click="emit('navigate', target)"
-          >
-            <span class="material-icons text-base">{{ target.icon }}</span>
-          </button>
-        </template>
-      </div>
-
-      <!-- Pinned shortcuts zone (#feat-shortcut-bar). Appears only when the
-         user has pinned at least one collection / feed. Separated by a
-         second divider; scrolls horizontally on overflow (no cap on the
-         pin count) so a long list never pushes the chrome past the
-         viewport. The fixed groups above stay put. -->
-      <template v-if="shortcuts.length > 0">
-        <div class="w-px bg-gray-300 my-0.5 flex-none" />
-        <div
-          class="flex min-w-0 items-stretch overflow-x-auto [scrollbar-width:thin]"
-          :aria-label="t('shortcuts.zoneAriaLabel')"
-          data-testid="plugin-launcher-shortcuts"
-        >
-          <button
-            v-for="shortcut in shortcuts"
-            :key="`${shortcut.kind}:${shortcut.slug}`"
-            :class="[
-              'h-8 w-8 flex items-center justify-center flex-none border-r border-gray-200 last:border-r-0 transition-colors',
-              isShortcutActive(shortcut) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
-            ]"
-            :title="shortcut.title"
-            :aria-label="shortcut.title"
-            :data-testid="`plugin-launcher-shortcut-${shortcut.kind}-${shortcut.slug}`"
-            @click="emit('navigateShortcut', shortcut)"
-          >
-            <!-- Icon-only — the cached title rides the tooltip / aria-label.
-               Collections / feeds use the material-symbols font for their
-               glyphs (matches the index cards), distinct from the
-               material-icons used by the fixed launcher buttons. -->
-            <span class="material-symbols-outlined text-base">{{ shortcut.icon }}</span>
-          </button>
-        </div>
-      </template>
+      <button
+        v-for="shortcut in shortcuts"
+        :key="`${shortcut.kind}:${shortcut.slug}`"
+        :class="[
+          'h-8 w-8 flex items-center justify-center flex-none border-r border-gray-200 last:border-r-0 transition-colors',
+          isShortcutActive(shortcut) ? 'bg-blue-50 text-blue-600' : 'bg-white text-gray-600 hover:bg-gray-50',
+        ]"
+        :title="shortcut.title"
+        :aria-label="shortcut.title"
+        :data-testid="`plugin-launcher-shortcut-${shortcut.kind}-${shortcut.slug}`"
+        @click="emit('navigateShortcut', shortcut)"
+      >
+        <!-- Icon-only — the cached title rides the tooltip / aria-label.
+           Collections / feeds use the material-symbols font for their
+           glyphs (matches the index cards), distinct from the
+           material-icons used by the fixed launcher buttons. -->
+        <span class="material-symbols-outlined text-base">{{ shortcut.icon }}</span>
+      </button>
     </div>
   </div>
 </template>
@@ -160,11 +156,6 @@ export interface PluginLauncherTarget {
 }
 
 const TARGETS: PluginLauncherTarget[] = [
-  // ─── Data plugins ───
-  // Automations (recurring agent tasks). The former sibling Calendar
-  // entry was removed with the Calendar view + `manageCalendar` tool;
-  // dated items now live in `calendarField` collections.
-  { key: "automations", kind: "view", icon: "schedule" },
   { key: "wiki", kind: "view", icon: "menu_book" },
   // Schema-driven collections launcher — opens the collections
   // index, from which the user picks one. The index lists every
@@ -178,12 +169,16 @@ const TARGETS: PluginLauncherTarget[] = [
   // collections. Takes the rss_feed glyph now that the legacy Sources
   // surface is gone.
   { key: "feeds", kind: "view", icon: "rss_feed" },
-  // ─── Management / navigation ───
-  // Skills and Roles moved into the Settings modal (Management group) —
-  // both are static configuration surfaces (what Claude can do / which
-  // role a chat uses), not dynamic workspace data you monitor, so they
-  // belong with Tools / MCP rather than as top-level launcher pages.
+  // Skills and Roles moved into the Settings modal — both are static
+  // configuration surfaces (what Claude can do / which role a chat
+  // uses), not dynamic workspace data you monitor, so they belong with
+  // Tools / MCP rather than as top-level launcher pages.
   { key: "files", kind: "view", icon: "folder" },
+  // Automations (recurring agent tasks) — sits to the right of Files.
+  // The former sibling Calendar entry was removed with the Calendar
+  // view + `manageCalendar` tool; dated items now live in
+  // `calendarField` collections.
+  { key: "automations", kind: "view", icon: "schedule" },
   // ─── Dev-only ───
   // Encore plan PR 1 follow-up. Hidden in production builds; the
   // /debug route stays reachable by typing the URL even with the
@@ -193,29 +188,14 @@ const TARGETS: PluginLauncherTarget[] = [
   { key: "debug", kind: "view", icon: "bug_report", devOnly: true, literalLabel: "Debug", literalTitle: "Open debug playground (dev mode only)" },
 ];
 
-// Index AFTER which the visual separator is inserted (between data
-// plugins on the left and management on the right). Data plugins are
-// automations / wiki / collections / feeds (indices 0-3), so the
-// divider renders before index 4 (files).
-const SEPARATOR_AFTER_INDEX = 4;
-
 // Dev-mode flag — set `VITE_DEV_MODE=1` in `.env`. Anything else
 // (including unset) hides any target with `devOnly: true`.
 const DEV_MODE = import.meta.env.VITE_DEV_MODE === "1";
 
-// Targets that should render given the current dev-mode flag.
+// Targets that should render given the current dev-mode flag. The Chat
+// button and these plugin buttons form a single group (no internal
+// divider); the only divider is before the favorites/shortcuts zone.
 const visibleTargets = computed(() => TARGETS.filter((target) => !target.devOnly || DEV_MODE));
-
-// Recompute the separator index after the dev-only filter — without
-// this, hiding a dev-only target before the separator would shift the
-// divider one slot to the left. Today the only dev-only target sits
-// at the end, so this matches the static constant; the computed keeps
-// future entries safe.
-const separatorAfterIndex = computed(() => {
-  const fullIndexOfSeparator = SEPARATOR_AFTER_INDEX;
-  const hiddenBefore = TARGETS.slice(0, fullIndexOfSeparator).filter((target) => target.devOnly && !DEV_MODE).length;
-  return fullIndexOfSeparator - hiddenBefore;
-});
 
 function isActive(target: PluginLauncherTarget): boolean {
   return props.activeViewMode === target.key;


### PR DESCRIPTION
## What

Regroup the top-bar `PluginLauncher` into **two visually distinct bordered pills** with a gap between them, per request:

- **Group 1** (own pill): the **Chat** button followed by the fixed plugin-nav buttons in one run — Wiki, Collections, Feeds, Files, **Actions** (+ dev-only Debug). The Chat button now lives *inside* this pill as its leftmost control and keeps its yellow active / red unread count badges.
- **Group 2** (separate pill, after a `gap-2`): the pinned collection/feed **favorites**, scrolling horizontally on overflow.

Additional tweaks:
- Moved the **Automations (Actions)** button to the right of **Files**.
- Dropped the old internal data/management divider and the now-unused `SEPARATOR_AFTER_INDEX` const + `separatorAfterIndex` computed.
- Neither pill is `overflow-hidden`, so the Chat button's negative-offset badges aren't clipped.

## Before → After

```
before:  [💬]  [ ⏰ 📖 ▦ 📡 │ 📁 (🐛) │ ⭐ ⭐ ]   (chat standalone, one pill, 2 dividers)
after:   [ 💬 📖 ▦ 📡 📁 ⏰ (🐛) ]   [ ⭐ ⭐ ]      (two pills, gap between)
```

## Notes
- No `data-testid` changed (`plugin-launcher-*` intact), so existing e2e selectors still resolve.
- `docs/ui-cheatsheet.md` top-chrome block + prose updated in the same PR.

## Checks
`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)