### PR TITLE
feat(accounting): add /accounting page + toolbar launcher button

### DIFF
--- a/e2e/tests/accounting-isolation.spec.ts
+++ b/e2e/tests/accounting-isolation.spec.ts
@@ -1,9 +1,10 @@
-// Hard-constraint regression for the accounting plugin: in the
-// default (General) Role environment, the plugin must be invisible.
-// No launcher button, no /accounting route. Reaching the plugin
-// requires actively switching into the built-in Accounting role
-// (or a custom role) whose `availablePlugins` include
-// `manageAccounting`.
+// Accounting plugin surface guard. The accounting (double-entry
+// bookkeeping) app has a first-class UI entry point — a launcher
+// button and a /accounting route — reachable by any user regardless
+// of role. What stays role-gated is the `manageAccounting` *tool*
+// (LLM access): it must NOT appear in the default (General) Role's
+// availablePlugins. This file guards both halves of that contract:
+// the UI entry point is present, and the tool surface stays clean.
 
 import { test, expect } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
@@ -12,23 +13,26 @@ test.beforeEach(async ({ page }) => {
   await mockAllApis(page);
 });
 
-test.describe("accounting plugin — isolation regression", () => {
-  test("PluginLauncher does not render an accounting button", async ({ page }) => {
+test.describe("accounting plugin — UI entry point + tool isolation", () => {
+  test("PluginLauncher renders an accounting button that navigates to /accounting", async ({ page }) => {
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);
     await expect(page.getByText("MulmoClaude")).toBeVisible();
     // The launcher buttons use plugin-launcher-{key} testids; the
-    // accounting plugin is NOT supposed to register one.
-    await expect(page.getByTestId("plugin-launcher-accounting")).toHaveCount(0);
+    // accounting plugin registers one in the first group.
+    const accountingButton = page.getByTestId("plugin-launcher-accounting");
+    await expect(accountingButton).toHaveCount(1);
+    await accountingButton.click();
+    await page.waitForURL(/\/accounting$/);
+    await expect(page.getByTestId("accounting-app")).toBeVisible();
   });
 
-  test("/accounting URL does not match a route — falls through to /chat", async ({ page }) => {
+  test("/accounting URL resolves to the accounting view", async ({ page }) => {
     await page.goto("/accounting");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
     const { pathname } = new URL(page.url());
-    // Bounded segment, no nested-quantifier overlap — same rationale as router-guards.spec.ts.
-    // eslint-disable-next-line security/detect-unsafe-regex -- bounded `[\w-]+`, single optional group
-    expect(pathname).toMatch(/^\/chat(?:\/[\w-]+)?$/);
+    expect(pathname).toBe("/accounting");
+    await expect(page.getByTestId("accounting-app")).toBeVisible();
   });
 
   test("Roles settings tab surfaces no manageAccounting plugin on a fresh workspace", async ({ page }) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -234,6 +234,13 @@
                directly. -->
           <CollectionView v-else-if="currentPage === 'collections' && route.params.slug" :key="String(route.params.slug)" />
           <CollectionsIndexView v-else-if="currentPage === 'collections'" />
+          <!-- Accounting — the double-entry bookkeeping app. Host
+               component (no PluginScopedRoot): the View talks to
+               /api/accounting via the host's apiCall directly and never
+               calls `useRuntime()`, so it needs no plugin scope. Mounted
+               without a `selected-result` prop — standalone it self-fetches
+               the book list and auto-selects a book on mount. -->
+          <AccountingView v-else-if="currentPage === 'accounting'" />
           <!-- Debug page (encore plan PR 1 follow-up). The View ships
                inside the @mulmoclaude/debug-plugin runtime package; we
                look it up by tool name and render the registered
@@ -335,6 +342,7 @@ import StackView from "./components/StackView.vue";
 import FilesView from "./components/FilesView.vue";
 import AutomationsView from "./plugins/scheduler/AutomationsView.vue";
 import WikiView from "./plugins/wiki/View.vue";
+import AccountingView from "./plugins/accounting/View.vue";
 import { buildWikiRouteParams } from "./plugins/wiki/route";
 import { CollectionView, CollectionsIndexView, FeedsView } from "@mulmoclaude/collection-plugin/vue";
 import PluginScopedRoot from "./components/PluginScopedRoot.vue";

--- a/src/components/PluginLauncher.vue
+++ b/src/components/PluginLauncher.vue
@@ -138,7 +138,7 @@ export type PluginLauncherKind = "view"; // Switch the canvas to a dedicated vie
 // out of this file avoids duplication across the 8 locales.
 export interface PluginLauncherTarget {
   /** Stable key for testid + dispatch in App.vue. */
-  key: "dashboard" | "automations" | "wiki" | "collections" | "feeds" | "files" | "debug";
+  key: "dashboard" | "automations" | "wiki" | "collections" | "feeds" | "accounting" | "files" | "debug";
   kind: PluginLauncherKind;
   /** Material-icons glyph. */
   icon: string;
@@ -172,6 +172,11 @@ const TARGETS: PluginLauncherTarget[] = [
   // collections. Takes the rss_feed glyph now that the legacy Sources
   // surface is gone.
   { key: "feeds", kind: "view", icon: "rss_feed" },
+  // Accounting — the double-entry bookkeeping app. Sits with the other
+  // data-app surfaces (collections / feeds). The button always shows so
+  // the books are reachable directly; the `manageAccounting` *tool*
+  // (LLM access) remains opt-in per Role, independent of this entry point.
+  { key: "accounting", kind: "view", icon: "account_balance" },
   // Skills and Roles moved into the Settings modal — both are static
   // configuration surfaces (what Claude can do / which role a chat
   // uses), not dynamic workspace data you monitor, so they belong with

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -354,6 +354,7 @@ const deMessages = {
     wiki: { label: "Wiki" },
     collections: { label: "Sammlungen" },
     feeds: { label: "Feeds" },
+    accounting: { label: "Buchhaltung" },
     files: { label: "Dateien" },
   },
   shortcuts: {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -369,6 +369,7 @@ const enMessages = {
     wiki: { label: "Wiki" },
     collections: { label: "Collections" },
     feeds: { label: "Feeds" },
+    accounting: { label: "Accounting" },
     files: { label: "Files" },
   },
   shortcuts: {

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -356,6 +356,7 @@ const esMessages = {
     wiki: { label: "Wiki" },
     collections: { label: "Colecciones" },
     feeds: { label: "Feeds" },
+    accounting: { label: "Contabilidad" },
     files: { label: "Archivos" },
   },
   shortcuts: {

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -350,6 +350,7 @@ const frMessages = {
     wiki: { label: "Wiki" },
     collections: { label: "Collections" },
     feeds: { label: "Flux" },
+    accounting: { label: "Comptabilité" },
     files: { label: "Fichiers" },
   },
   shortcuts: {

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -352,6 +352,7 @@ const jaMessages = {
     wiki: { label: "Wiki" },
     collections: { label: "コレクション" },
     feeds: { label: "フィード" },
+    accounting: { label: "会計" },
     files: { label: "ファイル" },
   },
   shortcuts: {

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -352,6 +352,7 @@ const koMessages = {
     wiki: { label: "위키" },
     collections: { label: "컬렉션" },
     feeds: { label: "피드" },
+    accounting: { label: "회계" },
     files: { label: "파일" },
   },
   shortcuts: {

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -348,6 +348,7 @@ const ptBRMessages = {
     wiki: { label: "Wiki" },
     collections: { label: "Coleções" },
     feeds: { label: "Feeds" },
+    accounting: { label: "Contabilidade" },
     files: { label: "Arquivos" },
   },
   shortcuts: {

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -344,6 +344,7 @@ const zhMessages = {
     wiki: { label: "百科" },
     collections: { label: "集合" },
     feeds: { label: "订阅源" },
+    accounting: { label: "会计" },
     files: { label: "文件" },
   },
   shortcuts: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -79,6 +79,14 @@ const routes: RouteRecordRaw[] = [
   // `/collections` lists every discovered collection;
   // `/collections/:slug` opens that collection's <CollectionView>.
   { path: "/collections/:slug?", name: PAGE_ROUTES.collections, component: Stub },
+  // Accounting — the double-entry bookkeeping app (manageAccounting).
+  // Standalone page so the user can reach the books directly without
+  // going through an LLM `openBook` tool call. The View self-fetches
+  // the book list on mount and auto-selects a book (or shows the
+  // first-run "New book" form on an empty workspace), so no route
+  // param is required. The `manageAccounting` *tool* stays opt-in per
+  // Role; this only adds a UI entry point to the same View.
+  { path: "/accounting", name: PAGE_ROUTES.accounting, component: Stub },
   // Legacy `/apps` URL — kept as a redirect for ~one release so any
   // existing bookmarks survive the rename. Safe to delete after.
   { path: "/apps", redirect: "/collections" },

--- a/src/router/pageRoutes.ts
+++ b/src/router/pageRoutes.ts
@@ -16,6 +16,7 @@ export const PAGE_ROUTES = {
   feeds: "feeds",
   debug: "debug",
   collections: "collections",
+  accounting: "accounting",
 } as const;
 
 export type PageRouteName = (typeof PAGE_ROUTES)[keyof typeof PAGE_ROUTES];


### PR DESCRIPTION
## Summary

Makes the accounting (double-entry bookkeeping) app reachable directly from the UI, instead of only via an LLM `openBook` tool call.

- **New `/accounting` route** (`PAGE_ROUTES.accounting`). The View self-fetches its book list and auto-selects a book on mount (or shows the first-run "New book" form on an empty workspace), so no route param is required.
- **Rendered in `App.vue` mounted directly** — `accounting/api.ts` uses the host's `apiCall` and nothing in the plugin calls `useRuntime()`, so it needs no `PluginScopedRoot` scope (unlike wiki).
- **Toolbar button** added to the first launcher group, next to the other data-app surfaces (collections / feeds). Navigation auto-wires via the existing `onPluginNavigate` → `router.push({ name })`.
- **i18n**: added `pluginLauncher.accounting.label` to all 8 locales.

## Note

The `manageAccounting` *tool* (LLM access) stays opt-in per Role; this only adds an always-visible UI entry point to the same View. If we'd rather keep the button/page gated on whether the active role enables the tool, that's a small follow-up.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all pass
- [x] Manually verified: button navigates to `/accounting` and the books render standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose the accounting (double-entry bookkeeping) app as a first-class page and launcher entry in the UI.

New Features:
- Add an `/accounting` route and page entry for the accounting app so users can open books directly from the UI.
- Add an Accounting launcher button alongside other data app surfaces in the toolbar.

Enhancements:
- Wire the Accounting view into the main App container using the existing page routing mechanism.
- Extend page route constants and plugin launcher target keys to include the accounting surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Accounting surface to the in-app launcher with a dedicated entry.
  * Introduced a direct **/accounting** page route that opens the Accounting view.
* **Localization**
  * Added Accounting labels for English, German, Spanish, French, Japanese, Korean, Brazilian Portuguese, and Chinese.
* **Tests**
  * Updated end-to-end coverage to ensure the Accounting entry and **/accounting** route are reachable while keeping the underlying Accounting tool properly isolated by role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->