### PR TITLE
feat(collections): curated collection registry — discover & import (Workstream A)

### DIFF
--- a/plans/feat-collection-registry.md
+++ b/plans/feat-collection-registry.md
@@ -1,0 +1,164 @@
+# feat(collections): curated collection registry — author / curate via PR / discover & import in-app
+
+Issue: receptron/mulmoclaude#1814
+Registry repo: `receptron/mulmoclaude-collections` (public, bootstrapped by Workstream B)
+
+## Summary
+
+ユーザが作ったコレクション（`schema.json` + custom view + 任意 seed）を、我々が管理する公式レジストリ
+repo（`receptron/mulmoclaude-collections`）へ PR で寄稿 → CI＋人手で審査・merge → 他ユーザは mulmoclaude の
+`/collections`「発見」タブから **index.json 経由**で発見・取り込みできるようにする。
+
+既存 external-skill 機構（clone → catalog → ★star=fork → discovery）の**宛先・schema 検証・view サンドボックスを
+再利用**し、**供給源だけ index＋単一 collection fetch に差し替える**。書き込み系 API・discovery・検証・
+サンドボックスは無改修。
+
+## Items to Confirm / Review
+
+- R2: index を **GitHub Pages/Release 配信**（main を bot commit で汚さない）で良いか。
+- R3: 取り込み時に schema の `dataPath` を **`data/collections/<localSlug>/items` へ強制正規化**する判断。
+- R9: `meta.json.author` を **PR 作成者の GitHub login と CI で一致検証**する（なりすまし防止）。
+- seed: **実データ込みを許可**（本人責任）＋ PII スキャンは警告止まり、**credential 検出のみ hard fail**、で良いか。
+- 実装の進行は Workstream B（レジストリ repo bootstrap）→ Workstream A（host）の順。本 plan の B が先行 PR。
+
+## User Prompt（原依頼の統合）
+
+ユーザ（本アプリ作者）からの依頼を会話横断で統合:
+
+- collections 機能は「データ構造だけ」なのか「skill も含む」のか、カスタムビューは「データだけ」なのか、
+  その仕組み・仕様を知りたい。そのうえで**これらを配布する方法を考えてほしい**。
+- 配布のユーザシナリオ: ユーザが作ったコレクション・カスタムビューを **PR で我々が管理するレポジトリに送る**。
+  それを我々が審査して取り込む。他ユーザは mulmoclaude からそのレポジトリを参照し、良いコレクションを
+  発見したら取り込みたい。取り込み側は GitHub を直接ではなく、**バックエンドで GitHub の index ファイルを
+  見てデータを出しても良い**かも。その **GitHub の構造も含めて**考えてほしい。
+- 詰めた前提（フォーム回答）: ① 新規 repo `receptron/mulmoclaude-collections` を切る。② seed は**寄稿者の
+  実データ込みも許可（本人責任）**。③ 識別子は**作者名前空間 `collections/<author>/<slug>/`**。④ issue の
+  単位はおまかせ。⑤ **author は GitHub アカウントとして、CI で一致するかも確認**する。
+- 進め方: `gh issue create` で issue 化し、ブランチを切って plan を書き出し、そして実装する。collections の
+  レポジトリは作成済み。
+
+## Background — 現状の配布機構とギャップ
+
+- 既存 **external-skill 機構**（#1383 / #1386, 2026-05）: git URL を clone → `SKILL.md` を持つフォルダを発見 →
+  `data/skills/catalog/external/<repoId>/` へコピー → ★star で `.claude/skills/<slug>/` に fork → discovery が
+  `/collections/<slug>` を描画。schema 検証 = `packages/core/src/collection/server/validate.ts`（host discovery と
+  `putSchema` が共有）。view サンドボックス = CSP / CDN 許可リスト / phone-home 禁止。
+- 実績: `anthropics/skills` を出荷当日に 1 回 install したのみ、**star 実績ゼロ**。コレクションを配った実績は無い。
+- ギャップ:
+  1. star/install は **skill フォルダしか運ばない** = `data/<name>/items/` の**レコードは配布されない**。
+  2. 読み取り系 API（`catalogList`/`catalogPreview`）は **SKILL.md しか見ない** = コレクション（schema.json）か
+     判別できず、icon/fields/views を返さず、「コレクションとして発見」できない。
+  3. clone は **repo 丸ごと** = 多数 collection を抱えるレジストリには重い。
+  4. `dataPath` が schema にハードコード = 他人由来だと衝突する。
+
+## Decisions（確定 R1–R9）
+
+| # | 決定 |
+|---|---|
+| R1 | 取り込み源 = index＋単一 collection fetch を新設、clone（external-skill）は温存 |
+| R2 | index = CI 生成 → GitHub Pages/Release 配信、backend は 1GET + ETag + サーバ側キャッシュ |
+| R3 | 取り込み時 dataPath を `data/collections/<localSlug>/items` へ正規化。local 衝突時のみリネーム |
+| R4 | screenshot 任意、欠落時は「アイコン＋フィールド要約＋view ラベル」カードでフォールバック |
+| R5 | 更新 = bundle 差し替え・records 保持・field 集合差分は警告のみ。schema migration は punt（別 issue） |
+| R6 | v1 公式 1 本＋index.json を `schemaVersion` 付き公開契約として設計（将来の任意 URL 追加に備える） |
+| R7 | index は表示用。fetch した実体を `packages/core` で再検証してから着地（index は信頼境界でない） |
+| R8 | 既存 localSlug は更新（再取り込み）扱い |
+| R9 | `meta.json.author` = GitHub アカウント。CI が PR 作成者の login と一致検証。path の `<author>` とも一致必須 |
+| seed | 寄稿者の実データ込み可（本人責任）。PII/個人情報は警告止まり＋PR で本人 affirmation。credential/secret は hard fail |
+
+## 識別子・パスの確定仕様
+
+- レジストリ global id: `<author>/<slug>`（author = 認証済み GitHub login）。
+- repo path: `collections/<author>/<slug>/`。
+- local install: `localSlug` の既定は `<slug>`。local 衝突時のみ `<author>-<slug>` 等にリネーム（または取込時に
+  ユーザへ提示）。URL は `/collections/<localSlug>`。
+- dataPath: 取込時に `data/collections/<localSlug>/items` へ正規化（schema の authored dataPath は信用しない）。
+- provenance: `.claude/skills/<localSlug>/.origin.json` に
+  `{ registry, author, slug, version, contentSha, importedAt }` を記録。
+
+## Workstream B — registry repo（`receptron/mulmoclaude-collections`）★ 先行
+
+### 構造
+```
+mulmoclaude-collections/
+  index.json                         ← CI 生成。backend が読む唯一の入口（R2）
+  schema/                            ← contracts（JSON Schema）
+    meta.schema.json
+    index.schema.json
+  collections/
+    <author>/<slug>/
+      SKILL.md   schema.json   meta.json
+      screenshot.png（任意）  views/*.html  templates/*.md  seed/items/*.json（任意）
+  scripts/
+    build-index.mjs                  ← collections/ を走査して index.json を再生成
+    validate.mjs                     ← meta/schema/seed/view/identity を検証
+    lib/                             ← 共有ロジック（collection 列挙・schema 要約）
+  .github/
+    workflows/{pr-validate.yml, build-index.yml}
+    PULL_REQUEST_TEMPLATE.md
+  CONTRIBUTING.md   README.md   LICENSE
+```
+
+### meta.json（流通情報の単一ソース）
+```jsonc
+{ "author": "isamu",          // = GitHub login（R9: CI が PR 作成者と一致検証）
+  "slug": "movies",
+  "version": "1.0.0",         // semver。破壊的 schema 変更 = major
+  "title": "映画リスト", "description": "…",
+  "tags": ["entertainment"], "license": "MIT",
+  "dataConsent": true }       // seed に実データを含む場合の本人 affirmation
+```
+
+### index.json（versioned public contract）
+```jsonc
+{ "schemaVersion": 1, "generatedAt": "…", "registry": "receptron/mulmoclaude-collections",
+  "collections": [{
+    "id": "isamu/movies", "author": "isamu", "slug": "movies",
+    "title": "映画リスト", "icon": "movie", "description": "…",
+    "version": "1.0.0", "tags": ["entertainment"], "license": "MIT",
+    "fieldCount": 14, "views": ["シネマ"], "hasSeed": true, "seedCount": 16,
+    "screenshot": "collections/isamu/movies/screenshot.png",
+    "path": "collections/isamu/movies", "contentSha": "…" }] }
+```
+
+### scripts
+- `build-index.mjs`: `collections/<author>/<slug>/` を走査し、`schema.json`/`meta.json` から index エントリを
+  生成。`contentSha` は collection 配下（screenshot を除く）の安定ハッシュ。
+- `validate.mjs`: ① meta 必須項目・semver・`mc-` 禁止・slug 一意 ② schema を host と同等ルールで検証
+  ③ seed を schema＋id charset で検証、credential/secret 検出（hard fail）、PII（warn） ④ view の CSP 静的 lint
+  ⑤ identity（`--pr-author` 指定時、`meta.author` == PR 作成者・path == author/slug）。
+- 当面 validate は **自己完結（依存最小）** に実装。将来 `packages/core` の検証器を npm 経由で共有する余地を残す。
+
+### CI
+- `pr-validate.yml`（PR 時）: `node scripts/validate.mjs --changed --pr-author "${{ github.event.pull_request.user.login }}"`。
+- `build-index.yml`（main push 時）: `node scripts/build-index.mjs` → index.json を **GitHub Pages/Release** に publish
+  （main を bot commit で汚さない）。
+
+### 例 collection
+- `collections/isamu/movies/` に既存 movies コレクション（SKILL.md + schema.json + views/cinema.html）を移植し、
+  パイプライン（validate → build-index）を実証。seed は demo 用の数件のみ。
+
+## Workstream A — host（`receptron/mulmoclaude`）
+
+1. **contract 型**: index.json/meta.json の型と検証を `packages/core/src/collection/registry/`（新規）に置く。
+2. **読み取り系の新エンドポイント**（既存 `catalogList`/`catalogPreview` は無改修）:
+   - `GET /api/collections/registry/list` … index.json をサーバ側 fetch＋ETag キャッシュして返す。
+   - `GET /api/collections/registry/preview?author=&slug=` … 対象の schema.json（＋screenshot URL）を返す。
+3. **取り込み fetcher**: `collections/<author>/<slug>/` 配下を raw URL で取得 → `packages/core` で再検証（R7）→
+   `.claude/skills/<localSlug>/` へ書き込み（star=fork 流用）。
+4. **dataPath 正規化（R3）** / **seed materialize**（dataPath 空時のみ・skip-on-conflict・`safeRecordId` 検証）。
+5. **provenance/更新**: `.origin.json` 記録、index との version/contentSha 差分で「更新あり」。再取り込みは
+   bundle 差し替え・records 保持・field 差分警告（R5/R8）。
+6. **UI**: `/collections` に「発見（Discover）」タブ。clone 経路（external-skill）は温存（R1）。
+
+## Out of scope（別 issue）
+
+schema migration 付き自動更新／任意レジストリ URL 追加 UI／スクショの headless 自動生成／マーケットの評価・
+ランキング・課金。
+
+## 進め方
+
+1. 本 plan を commit（このコミット）。
+2. Workstream B（レジストリ repo bootstrap）を実装 → PR。
+3. Workstream A（host）を後続 PR で実装。
+4. push / PR は都度ユーザの明示許可を得てから。

--- a/server/api/routes/collectionsRegistry.ts
+++ b/server/api/routes/collectionsRegistry.ts
@@ -1,0 +1,36 @@
+// Read endpoints for the curated collection registry (Discover tab). Backs
+// `GET /api/collections-registry` by server-fetching the published index.json
+// (receptron/mulmoclaude-collections) and returning its entries. The host never
+// exposes the upstream URL to the client; it proxies + caches it.
+
+import { Router, Request, Response } from "express";
+
+import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { fetchRegistryIndex } from "../../workspace/collectionsRegistry/client.js";
+import type { RegistryCollectionEntry } from "../../workspace/collectionsRegistry/registryIndex.js";
+
+const router = Router();
+
+interface RegistryListResponse {
+  registry: string;
+  generatedAt: string;
+  /** True when the upstream was unreachable and a previously-cached index is served. */
+  stale: boolean;
+  collections: RegistryCollectionEntry[];
+}
+
+interface ErrorResponse {
+  error: string;
+}
+
+router.get(API_ROUTES.collectionsRegistry.list, async (_req: Request, res: Response<RegistryListResponse | ErrorResponse>) => {
+  const result = await fetchRegistryIndex();
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+  const { registry, generatedAt, collections } = result.index;
+  res.json({ registry, generatedAt, stale: result.stale, collections });
+});
+
+export default router;

--- a/server/api/routes/collectionsRegistry.ts
+++ b/server/api/routes/collectionsRegistry.ts
@@ -6,7 +6,9 @@
 import { Router, Request, Response } from "express";
 
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
+import { badRequest } from "../../utils/httpError.js";
 import { fetchRegistryIndex } from "../../workspace/collectionsRegistry/client.js";
+import { previewCollection } from "../../workspace/collectionsRegistry/collectionFiles.js";
 import type { RegistryCollectionEntry } from "../../workspace/collectionsRegistry/registryIndex.js";
 
 const router = Router();
@@ -31,6 +33,27 @@ router.get(API_ROUTES.collectionsRegistry.list, async (_req: Request, res: Respo
   }
   const { registry, generatedAt, collections } = result.index;
   res.json({ registry, generatedAt, stale: result.stale, collections });
+});
+
+interface RegistryPreviewResponse {
+  entry: RegistryCollectionEntry;
+  schema: Record<string, unknown>;
+  meta: Record<string, unknown>;
+}
+
+router.get(API_ROUTES.collectionsRegistry.preview, async (req: Request, res: Response<RegistryPreviewResponse | ErrorResponse>) => {
+  const author = typeof req.query.author === "string" ? req.query.author : "";
+  const slug = typeof req.query.slug === "string" ? req.query.slug : "";
+  if (!author || !slug) {
+    badRequest(res, "author and slug query params are required");
+    return;
+  }
+  const result = await previewCollection(author, slug);
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+  res.json({ entry: result.entry, schema: result.schema, meta: result.meta });
 });
 
 export default router;

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,6 +34,7 @@ import configRefreshRoutes from "./api/routes/config-refresh.js";
 import hookLogRoutes from "./api/routes/hookLog.js";
 import skillsRoutes from "./api/routes/skills.js";
 import collectionsRoutes from "./api/routes/collections.js";
+import collectionsRegistryRoutes from "./api/routes/collectionsRegistry.js";
 import { startCollectionWatchers } from "./workspace/collections/watcher.js";
 import runtimePluginRoutes from "./api/routes/runtime-plugin.js";
 // Side-effect: registers the built-in "markdown" dispatch handler so the
@@ -665,6 +666,7 @@ app.use(configRefreshRoutes);
 app.use(hookLogRoutes);
 app.use(skillsRoutes);
 app.use(collectionsRoutes);
+app.use(collectionsRegistryRoutes);
 app.use(runtimePluginRoutes);
 async function listSessionsForBridge(opts: { limit: number; offset: number }) {
   const rows = await loadAllSessions();

--- a/server/workspace/collectionsRegistry/client.ts
+++ b/server/workspace/collectionsRegistry/client.ts
@@ -11,7 +11,11 @@ import { ONE_SECOND_MS } from "../../utils/time.js";
 import { parseRegistryIndex, type RegistryIndex } from "./registryIndex.js";
 
 const DEFAULT_REGISTRY_URL = "https://receptron.github.io/mulmoclaude-collections/index.json";
-const CACHE_TTL_MS = 5 * 60 * ONE_SECOND_MS;
+export const CACHE_TTL_MS = 5 * 60 * ONE_SECOND_MS;
+// During an outage (cache past TTL + failing upstream) don't re-hit the network
+// more than once per this window — serve stale immediately in between, so a down
+// upstream can't add its full timeout to every request.
+export const STALE_RETRY_BACKOFF_MS = 60 * ONE_SECOND_MS;
 const FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
 const STATUS_BAD_GATEWAY = 502;
 const STATUS_UNAVAILABLE = 503;
@@ -24,6 +28,7 @@ interface CacheEntry {
 }
 
 let cache: CacheEntry | null = null;
+let lastFailureMs: number | null = null;
 
 export function registryIndexUrl(): string {
   return process.env.COLLECTIONS_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
@@ -48,23 +53,35 @@ async function loadFromNetwork(): Promise<FetchIndexResult> {
   return { ok: true, index: parsed.index, stale: false };
 }
 
+export type IndexLoader = () => Promise<FetchIndexResult>;
+
 /** Fetch the registry index, served from cache within the TTL. On upstream
- *  failure, falls back to the last good index (marked `stale`) when available. */
-export async function fetchRegistryIndex(opts: { force?: boolean; nowMs?: number } = {}): Promise<FetchIndexResult> {
+ *  failure, falls back to the last good index (marked `stale`). After a failure
+ *  the network is not retried for `STALE_RETRY_BACKOFF_MS` while a stale cache can
+ *  be served, so a down upstream can't add its timeout to every request. `loader`
+ *  is injectable for tests; `force` bypasses both the TTL and the backoff. */
+export async function fetchRegistryIndex(opts: { force?: boolean; nowMs?: number; loader?: IndexLoader } = {}): Promise<FetchIndexResult> {
   const nowMs = opts.nowMs ?? Date.now();
+  const loader = opts.loader ?? loadFromNetwork;
   if (!opts.force && cache && nowMs - cache.atMs < CACHE_TTL_MS) {
     return { ok: true, index: cache.index, stale: false };
   }
-  const fresh = await loadFromNetwork();
+  if (!opts.force && cache && lastFailureMs !== null && nowMs - lastFailureMs < STALE_RETRY_BACKOFF_MS) {
+    return { ok: true, index: cache.index, stale: true };
+  }
+  const fresh = await loader();
   if (fresh.ok) {
     cache = { index: fresh.index, atMs: nowMs };
-    return fresh;
+    lastFailureMs = null;
+    return { ok: true, index: fresh.index, stale: false };
   }
+  lastFailureMs = nowMs;
   if (cache) return { ok: true, index: cache.index, stale: true };
   return fresh;
 }
 
-/** Test seam: reset the module cache. */
+/** Test seam: reset the module cache + failure backoff state. */
 export function resetRegistryCache(): void {
   cache = null;
+  lastFailureMs = null;
 }

--- a/server/workspace/collectionsRegistry/client.ts
+++ b/server/workspace/collectionsRegistry/client.ts
@@ -1,0 +1,70 @@
+// Server-side client for the curated collection registry's published index.json
+// (receptron/mulmoclaude-collections via GitHub Pages). Fetches over HTTPS with
+// a timeout, validates against the index contract, and memo-caches the last good
+// result so the Discover tab doesn't hammer the upstream. On a transient upstream
+// failure it serves the last good index rather than erroring.
+
+import { fetchWithTimeout } from "../../utils/fetch.js";
+import { errorMessage } from "../../utils/errors.js";
+import { log } from "../../system/logger/index.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
+import { parseRegistryIndex, type RegistryIndex } from "./registryIndex.js";
+
+const DEFAULT_REGISTRY_URL = "https://receptron.github.io/mulmoclaude-collections/index.json";
+const CACHE_TTL_MS = 5 * 60 * ONE_SECOND_MS;
+const FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
+const STATUS_BAD_GATEWAY = 502;
+const STATUS_UNAVAILABLE = 503;
+
+export type FetchIndexResult = { ok: true; index: RegistryIndex; stale: boolean } | { ok: false; status: number; error: string };
+
+interface CacheEntry {
+  index: RegistryIndex;
+  atMs: number;
+}
+
+let cache: CacheEntry | null = null;
+
+export function registryIndexUrl(): string {
+  return process.env.COLLECTIONS_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
+}
+
+async function loadFromNetwork(): Promise<FetchIndexResult> {
+  const url = registryIndexUrl();
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(url, { timeoutMs: FETCH_TIMEOUT_MS, headers: { accept: "application/json" } });
+  } catch (err) {
+    log.warn("collections-registry", "index fetch failed", { url, error: errorMessage(err) });
+    return { ok: false, status: STATUS_UNAVAILABLE, error: "registry unreachable" };
+  }
+  if (!res.ok) return { ok: false, status: STATUS_BAD_GATEWAY, error: `registry responded ${res.status}` };
+  const json: unknown = await res.json().catch(() => null);
+  const parsed = parseRegistryIndex(json);
+  if (!parsed.ok) {
+    log.warn("collections-registry", "index invalid", { url, error: parsed.error });
+    return { ok: false, status: STATUS_BAD_GATEWAY, error: `registry index invalid: ${parsed.error}` };
+  }
+  return { ok: true, index: parsed.index, stale: false };
+}
+
+/** Fetch the registry index, served from cache within the TTL. On upstream
+ *  failure, falls back to the last good index (marked `stale`) when available. */
+export async function fetchRegistryIndex(opts: { force?: boolean; nowMs?: number } = {}): Promise<FetchIndexResult> {
+  const nowMs = opts.nowMs ?? Date.now();
+  if (!opts.force && cache && nowMs - cache.atMs < CACHE_TTL_MS) {
+    return { ok: true, index: cache.index, stale: false };
+  }
+  const fresh = await loadFromNetwork();
+  if (fresh.ok) {
+    cache = { index: fresh.index, atMs: nowMs };
+    return fresh;
+  }
+  if (cache) return { ok: true, index: cache.index, stale: true };
+  return fresh;
+}
+
+/** Test seam: reset the module cache. */
+export function resetRegistryCache(): void {
+  cache = null;
+}

--- a/server/workspace/collectionsRegistry/collectionFiles.ts
+++ b/server/workspace/collectionsRegistry/collectionFiles.ts
@@ -25,9 +25,12 @@ export function rawBaseUrl(): string {
 }
 
 /** Compose the raw URL for `<dirPath>/<relFile>`. `dirPath` is an index entry's
- *  repo-relative collection dir (e.g. `collections/isamu/movies`). */
+ *  repo-relative collection dir (e.g. `collections/isamu/movies`). Empty and
+ *  traversal (`.`/`..`) segments are dropped so the URL can never escape the base,
+ *  even if an upstream check is bypassed (the index parser already rejects such
+ *  identifiers — this is defense-in-depth). */
 export function collectionFileUrl(dirPath: string, relFile: string): string {
-  const segments = dirPath.split("/").filter((segment) => segment.length > 0);
+  const segments = dirPath.split("/").filter((segment) => segment.length > 0 && segment !== "." && segment !== "..");
   return `${rawBaseUrl()}/${segments.join("/")}/${relFile}`;
 }
 

--- a/server/workspace/collectionsRegistry/collectionFiles.ts
+++ b/server/workspace/collectionsRegistry/collectionFiles.ts
@@ -1,0 +1,90 @@
+// Fetch individual files of a registry collection (schema.json, meta.json, …)
+// from the registry repo's raw content. The collection's repo-relative dir comes
+// from a trusted index entry (never raw user input), so the host can only fetch
+// files of collections that actually appear in the published index.
+//
+// The index itself is served from GitHub Pages (see client.ts); per-collection
+// files are served from raw.githubusercontent. Both are overridable for tests /
+// self-hosting.
+
+import { fetchWithTimeout } from "../../utils/fetch.js";
+import { errorMessage } from "../../utils/errors.js";
+import { isRecord } from "../../utils/types.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
+import { fetchRegistryIndex } from "./client.js";
+import type { RegistryCollectionEntry } from "./registryIndex.js";
+
+const DEFAULT_RAW_BASE = "https://raw.githubusercontent.com/receptron/mulmoclaude-collections/main";
+const FETCH_TIMEOUT_MS = 10 * ONE_SECOND_MS;
+const STATUS_BAD_GATEWAY = 502;
+const STATUS_UNAVAILABLE = 503;
+const STATUS_NOT_FOUND = 404;
+
+export function rawBaseUrl(): string {
+  return process.env.COLLECTIONS_REGISTRY_RAW_BASE ?? DEFAULT_RAW_BASE;
+}
+
+/** Compose the raw URL for `<dirPath>/<relFile>`. `dirPath` is an index entry's
+ *  repo-relative collection dir (e.g. `collections/isamu/movies`). */
+export function collectionFileUrl(dirPath: string, relFile: string): string {
+  const segments = dirPath.split("/").filter((segment) => segment.length > 0);
+  return `${rawBaseUrl()}/${segments.join("/")}/${relFile}`;
+}
+
+export type FileResult = { ok: true; text: string } | { ok: false; status: number; error: string };
+
+export async function fetchCollectionFile(dirPath: string, relFile: string): Promise<FileResult> {
+  const url = collectionFileUrl(dirPath, relFile);
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(url, { timeoutMs: FETCH_TIMEOUT_MS });
+  } catch (err) {
+    return { ok: false, status: STATUS_UNAVAILABLE, error: `fetch failed: ${errorMessage(err)}` };
+  }
+  if (!res.ok) return { ok: false, status: STATUS_BAD_GATEWAY, error: `${relFile} responded ${res.status}` };
+  return { ok: true, text: await res.text() };
+}
+
+export type JsonObjectResult = { ok: true; value: Record<string, unknown> } | { ok: false; error: string };
+
+export function parseJsonObject(text: string, label: string): JsonObjectResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: `${label} is not valid JSON` };
+  }
+  if (!isRecord(parsed)) return { ok: false, error: `${label} is not an object` };
+  return { ok: true, value: parsed };
+}
+
+async function fetchJsonObject(
+  dirPath: string,
+  relFile: string,
+  label: string,
+): Promise<{ ok: true; value: Record<string, unknown> } | { ok: false; status: number; error: string }> {
+  const file = await fetchCollectionFile(dirPath, relFile);
+  if (!file.ok) return { ok: false, status: file.status, error: `${label}: ${file.error}` };
+  const parsed = parseJsonObject(file.text, label);
+  if (!parsed.ok) return { ok: false, status: STATUS_BAD_GATEWAY, error: parsed.error };
+  return { ok: true, value: parsed.value };
+}
+
+export type PreviewResult =
+  | { ok: true; entry: RegistryCollectionEntry; schema: Record<string, unknown>; meta: Record<string, unknown> }
+  | { ok: false; status: number; error: string };
+
+/** Preview a registry collection: confirm it's in the published index, then fetch
+ *  and parse its schema.json + meta.json so the Discover tab can show fields/views
+ *  before import. Read-only; full structural re-validation happens at import. */
+export async function previewCollection(author: string, slug: string): Promise<PreviewResult> {
+  const indexResult = await fetchRegistryIndex();
+  if (!indexResult.ok) return { ok: false, status: indexResult.status, error: indexResult.error };
+  const entry = indexResult.index.collections.find((candidate) => candidate.author === author && candidate.slug === slug);
+  if (!entry) return { ok: false, status: STATUS_NOT_FOUND, error: `unknown collection: ${author}/${slug}` };
+  const schema = await fetchJsonObject(entry.path, "schema.json", "schema.json");
+  if (!schema.ok) return schema;
+  const meta = await fetchJsonObject(entry.path, "meta.json", "meta.json");
+  if (!meta.ok) return meta;
+  return { ok: true, entry, schema: schema.value, meta: meta.value };
+}

--- a/server/workspace/collectionsRegistry/importCollection.ts
+++ b/server/workspace/collectionsRegistry/importCollection.ts
@@ -1,0 +1,67 @@
+// Import-side fetch + transform helpers for a registry collection. The writer
+// (writes into .claude/skills/, materializes seed, records provenance) builds on
+// these; kept separate so the pure, security-critical parts are unit-tested.
+//
+// Files to fetch come from the collection's manifest.json (published by the
+// registry's build-index). Every manifest path is re-checked for safety here —
+// the host must never write outside the target skill dir even if the manifest is
+// malformed/poisoned.
+
+import { isRecord } from "../../utils/types.js";
+import { fetchCollectionFile, parseJsonObject } from "./collectionFiles.js";
+import type { RegistryCollectionEntry } from "./registryIndex.js";
+
+const MANIFEST_FILE = "manifest.json";
+const STATUS_BAD_GATEWAY = 502;
+
+/** A manifest entry must be a relative path that stays inside the collection dir:
+ *  no absolute paths, no backslashes, no empty / `.` / `..` segments. */
+export function isSafeBundlePath(rel: unknown): rel is string {
+  if (typeof rel !== "string" || rel.length === 0) return false;
+  if (rel.startsWith("/") || rel.includes("\\")) return false;
+  return !rel.split("/").some((segment) => segment === "" || segment === "." || segment === "..");
+}
+
+export type ManifestResult = { ok: true; files: string[] } | { ok: false; error: string };
+
+export function parseManifest(value: unknown): ManifestResult {
+  if (!isRecord(value) || !Array.isArray(value.files)) return { ok: false, error: "manifest is missing a files[] array" };
+  const unsafe = value.files.find((file) => !isSafeBundlePath(file));
+  if (unsafe !== undefined) return { ok: false, error: `manifest contains an unsafe path: ${String(unsafe)}` };
+  return { ok: true, files: value.files.filter(isSafeBundlePath) };
+}
+
+/** `data/collections/<localSlug>/items` — the host owns dataPath, never the
+ *  registry's authored value, so imported collections can't collide on disk. */
+export function normalizedDataPath(localSlug: string): string {
+  return `data/collections/${localSlug}/items`;
+}
+
+export function withNormalizedDataPath(schema: Record<string, unknown>, localSlug: string): Record<string, unknown> {
+  return { ...schema, dataPath: normalizedDataPath(localSlug) };
+}
+
+export type ManifestFetch = { ok: true; files: string[] } | { ok: false; status: number; error: string };
+
+export async function fetchManifest(entry: RegistryCollectionEntry): Promise<ManifestFetch> {
+  const file = await fetchCollectionFile(entry.path, MANIFEST_FILE);
+  if (!file.ok) return { ok: false, status: file.status, error: `manifest.json: ${file.error}` };
+  const obj = parseJsonObject(file.text, "manifest.json");
+  if (!obj.ok) return { ok: false, status: STATUS_BAD_GATEWAY, error: obj.error };
+  const manifest = parseManifest(obj.value);
+  if (!manifest.ok) return { ok: false, status: STATUS_BAD_GATEWAY, error: manifest.error };
+  return { ok: true, files: manifest.files };
+}
+
+export type BundleFetch = { ok: true; files: Map<string, string> } | { ok: false; status: number; error: string };
+
+/** Fetch every manifest file. Paths are already safety-checked by parseManifest. */
+export async function fetchBundle(entry: RegistryCollectionEntry, fileList: readonly string[]): Promise<BundleFetch> {
+  const files = new Map<string, string>();
+  for (const rel of fileList) {
+    const file = await fetchCollectionFile(entry.path, rel);
+    if (!file.ok) return { ok: false, status: file.status, error: `${rel}: ${file.error}` };
+    files.set(rel, file.text);
+  }
+  return { ok: true, files };
+}

--- a/server/workspace/collectionsRegistry/registryIndex.ts
+++ b/server/workspace/collectionsRegistry/registryIndex.ts
@@ -1,0 +1,110 @@
+// Parse + validate the curated collection registry's published index.json.
+// Pure — no I/O. The caller fetches the JSON and hands the parsed value here.
+// Mirrors the registry repo's schema/index.schema.json contract (schemaVersion 1):
+//   receptron/mulmoclaude-collections.
+//
+// The index is host-fetched convenience data for the Discover catalog, not a
+// trust boundary: a collection's actual files are re-validated on import.
+
+import { isRecord } from "../../utils/types.js";
+
+export interface RegistryCollectionEntry {
+  /** `<author>/<slug>` — global identity. */
+  id: string;
+  author: string;
+  slug: string;
+  title: string;
+  icon: string;
+  description: string;
+  version: string;
+  tags: string[];
+  license: string;
+  fieldCount: number;
+  /** Custom view labels. */
+  views: string[];
+  hasSeed: boolean;
+  seedCount: number;
+  /** repo-relative path, omitted when absent. */
+  screenshot?: string;
+  /** repo-relative collection dir. */
+  path: string;
+  /** Stable bundle hash for update detection. */
+  contentSha: string;
+}
+
+export interface RegistryIndex {
+  schemaVersion: number;
+  generatedAt: string;
+  registry: string;
+  collections: RegistryCollectionEntry[];
+}
+
+export type ParseResult = { ok: true; index: RegistryIndex } | { ok: false; error: string };
+
+const SUPPORTED_SCHEMA_VERSION = 1;
+
+const pickString = (rec: Record<string, unknown>, key: string): string | undefined => {
+  const value = rec[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+const pickNumber = (rec: Record<string, unknown>, key: string): number | undefined => {
+  const value = rec[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+};
+
+const pickBoolean = (rec: Record<string, unknown>, key: string): boolean | undefined => {
+  const value = rec[key];
+  return typeof value === "boolean" ? value : undefined;
+};
+
+const asStringArray = (value: unknown): string[] => (Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []);
+
+function parseEntry(value: unknown, index: number): RegistryCollectionEntry | string {
+  if (!isRecord(value)) return `collections[${index}] is not an object`;
+  const entryId = pickString(value, "id");
+  const author = pickString(value, "author");
+  const slug = pickString(value, "slug");
+  const title = pickString(value, "title");
+  const version = pickString(value, "version");
+  const path = pickString(value, "path");
+  const contentSha = pickString(value, "contentSha");
+  if (!entryId || !author || !slug || !title || !version || !path || !contentSha) {
+    return `collections[${index}] is missing a required string field (id/author/slug/title/version/path/contentSha)`;
+  }
+  return {
+    id: entryId,
+    author,
+    slug,
+    title,
+    version,
+    path,
+    contentSha,
+    icon: pickString(value, "icon") ?? "",
+    description: pickString(value, "description") ?? "",
+    license: pickString(value, "license") ?? "",
+    tags: asStringArray(value.tags),
+    views: asStringArray(value.views),
+    fieldCount: pickNumber(value, "fieldCount") ?? 0,
+    seedCount: pickNumber(value, "seedCount") ?? 0,
+    hasSeed: pickBoolean(value, "hasSeed") ?? false,
+    screenshot: pickString(value, "screenshot"),
+  };
+}
+
+export function parseRegistryIndex(value: unknown): ParseResult {
+  if (!isRecord(value)) return { ok: false, error: "index is not an object" };
+  if (value.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
+    return { ok: false, error: `unsupported schemaVersion (expected ${SUPPORTED_SCHEMA_VERSION})` };
+  }
+  const registry = pickString(value, "registry");
+  const generatedAt = pickString(value, "generatedAt");
+  if (!registry || !generatedAt) return { ok: false, error: "index missing registry/generatedAt" };
+  if (!Array.isArray(value.collections)) return { ok: false, error: "index.collections must be an array" };
+
+  const parsed = value.collections.map(parseEntry);
+  const firstError = parsed.find((entry): entry is string => typeof entry === "string");
+  if (firstError !== undefined) return { ok: false, error: firstError };
+  const collections = parsed.filter((entry): entry is RegistryCollectionEntry => typeof entry !== "string");
+  return { ok: true, index: { schemaVersion: SUPPORTED_SCHEMA_VERSION, registry, generatedAt, collections } };
+}

--- a/server/workspace/collectionsRegistry/registryIndex.ts
+++ b/server/workspace/collectionsRegistry/registryIndex.ts
@@ -64,9 +64,19 @@ const pickBoolean = (rec: Record<string, unknown>, key: string): boolean | undef
 
 const asStringArray = (value: unknown): string[] => (Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []);
 
-// id/path must agree with author/slug, so a lookup by author+slug can never fetch
-// files from a different directory than requested (defense against a poisoned index).
-function consistencyError(entryId: string, author: string, slug: string, dirPath: string, index: number): string | null {
+// Identifier allowlists (mirror the registry's meta.schema.json). Crucially these
+// exclude `.`, `/`, `\`, and `..`, so a poisoned author/slug can never make
+// collectionFileUrl() escape the collections/<author>/<slug> subtree — even if the
+// entry is internally consistent. Bounded quantifiers (no ReDoS).
+const AUTHOR_RE = /^[A-Za-z0-9][A-Za-z0-9-]{0,38}$/;
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+// author/slug must be allowlisted identifiers, and id/path must agree with them, so a
+// lookup by author+slug can never fetch files from a different (or out-of-tree)
+// directory than requested (defense against a poisoned index).
+function identityError(entryId: string, author: string, slug: string, dirPath: string, index: number): string | null {
+  if (!AUTHOR_RE.test(author)) return `collections[${index}].author has an invalid format`;
+  if (!SLUG_RE.test(slug)) return `collections[${index}].slug has an invalid format`;
   if (entryId !== `${author}/${slug}`) return `collections[${index}].id must equal "${author}/${slug}"`;
   if (dirPath !== `collections/${author}/${slug}`) return `collections[${index}].path must equal "collections/${author}/${slug}"`;
   return null;
@@ -92,7 +102,7 @@ function parseEntry(value: unknown, index: number): RegistryCollectionEntry | st
   if (!entryId || !author || !slug || !title || !version || !path || !contentSha) {
     return `collections[${index}] is missing a required string field (id/author/slug/title/version/path/contentSha)`;
   }
-  const mismatch = consistencyError(entryId, author, slug, path, index);
+  const mismatch = identityError(entryId, author, slug, path, index);
   if (mismatch) return mismatch;
   const counts = validatedCounts(value, index);
   if (typeof counts === "string") return counts;

--- a/server/workspace/collectionsRegistry/registryIndex.ts
+++ b/server/workspace/collectionsRegistry/registryIndex.ts
@@ -48,10 +48,14 @@ const pickString = (rec: Record<string, unknown>, key: string): string | undefin
   return typeof value === "string" && value.length > 0 ? value : undefined;
 };
 
-const pickNumber = (rec: Record<string, unknown>, key: string): number | undefined => {
+// Count fields (fieldCount/seedCount) must be non-negative integers. A present
+// but negative/fractional value is rejected rather than served to the UI; an
+// absent value defaults to 0.
+function validatedCount(rec: Record<string, unknown>, key: string): number | "invalid" {
   const value = rec[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-};
+  if (value === undefined) return 0;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : "invalid";
+}
 
 const pickBoolean = (rec: Record<string, unknown>, key: string): boolean | undefined => {
   const value = rec[key];
@@ -72,6 +76,10 @@ function parseEntry(value: unknown, index: number): RegistryCollectionEntry | st
   if (!entryId || !author || !slug || !title || !version || !path || !contentSha) {
     return `collections[${index}] is missing a required string field (id/author/slug/title/version/path/contentSha)`;
   }
+  const fieldCount = validatedCount(value, "fieldCount");
+  const seedCount = validatedCount(value, "seedCount");
+  if (fieldCount === "invalid") return `collections[${index}].fieldCount must be a non-negative integer`;
+  if (seedCount === "invalid") return `collections[${index}].seedCount must be a non-negative integer`;
   return {
     id: entryId,
     author,
@@ -85,8 +93,8 @@ function parseEntry(value: unknown, index: number): RegistryCollectionEntry | st
     license: pickString(value, "license") ?? "",
     tags: asStringArray(value.tags),
     views: asStringArray(value.views),
-    fieldCount: pickNumber(value, "fieldCount") ?? 0,
-    seedCount: pickNumber(value, "seedCount") ?? 0,
+    fieldCount,
+    seedCount,
     hasSeed: pickBoolean(value, "hasSeed") ?? false,
     screenshot: pickString(value, "screenshot"),
   };

--- a/server/workspace/collectionsRegistry/registryIndex.ts
+++ b/server/workspace/collectionsRegistry/registryIndex.ts
@@ -64,6 +64,22 @@ const pickBoolean = (rec: Record<string, unknown>, key: string): boolean | undef
 
 const asStringArray = (value: unknown): string[] => (Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []);
 
+// id/path must agree with author/slug, so a lookup by author+slug can never fetch
+// files from a different directory than requested (defense against a poisoned index).
+function consistencyError(entryId: string, author: string, slug: string, dirPath: string, index: number): string | null {
+  if (entryId !== `${author}/${slug}`) return `collections[${index}].id must equal "${author}/${slug}"`;
+  if (dirPath !== `collections/${author}/${slug}`) return `collections[${index}].path must equal "collections/${author}/${slug}"`;
+  return null;
+}
+
+function validatedCounts(value: Record<string, unknown>, index: number): { fieldCount: number; seedCount: number } | string {
+  const fieldCount = validatedCount(value, "fieldCount");
+  const seedCount = validatedCount(value, "seedCount");
+  if (fieldCount === "invalid") return `collections[${index}].fieldCount must be a non-negative integer`;
+  if (seedCount === "invalid") return `collections[${index}].seedCount must be a non-negative integer`;
+  return { fieldCount, seedCount };
+}
+
 function parseEntry(value: unknown, index: number): RegistryCollectionEntry | string {
   if (!isRecord(value)) return `collections[${index}] is not an object`;
   const entryId = pickString(value, "id");
@@ -76,10 +92,10 @@ function parseEntry(value: unknown, index: number): RegistryCollectionEntry | st
   if (!entryId || !author || !slug || !title || !version || !path || !contentSha) {
     return `collections[${index}] is missing a required string field (id/author/slug/title/version/path/contentSha)`;
   }
-  const fieldCount = validatedCount(value, "fieldCount");
-  const seedCount = validatedCount(value, "seedCount");
-  if (fieldCount === "invalid") return `collections[${index}].fieldCount must be a non-negative integer`;
-  if (seedCount === "invalid") return `collections[${index}].seedCount must be a non-negative integer`;
+  const mismatch = consistencyError(entryId, author, slug, path, index);
+  if (mismatch) return mismatch;
+  const counts = validatedCounts(value, index);
+  if (typeof counts === "string") return counts;
   return {
     id: entryId,
     author,
@@ -93,8 +109,8 @@ function parseEntry(value: unknown, index: number): RegistryCollectionEntry | st
     license: pickString(value, "license") ?? "",
     tags: asStringArray(value.tags),
     views: asStringArray(value.views),
-    fieldCount,
-    seedCount,
+    fieldCount: counts.fieldCount,
+    seedCount: counts.seedCount,
     hasSeed: pickBoolean(value, "hasSeed") ?? false,
     screenshot: pickString(value, "screenshot"),
   };

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -280,6 +280,13 @@ const HOST_API_ROUTES = {
     viewDelete: "/api/collections/:slug/views/:viewId",
   },
 
+  // Curated collection registry (receptron/mulmoclaude-collections). The host
+  // server-fetches the published index.json (GitHub Pages) and proxies it to the
+  // /collections Discover tab — the upstream URL is never exposed to the client.
+  collectionsRegistry: {
+    list: "/api/collections-registry",
+  },
+
   // `scheduler` group migrated to META — see `src/plugins/scheduler/automationsMeta.ts`.
   // Auto-merged via `apiNamespace: "scheduler"`.
 

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -285,6 +285,8 @@ const HOST_API_ROUTES = {
   // /collections Discover tab — the upstream URL is never exposed to the client.
   collectionsRegistry: {
     list: "/api/collections-registry",
+    /** GET ?author=&slug= → { entry, schema, meta } for one in-index collection. */
+    preview: "/api/collections-registry/preview",
   },
 
   // `scheduler` group migrated to META — see `src/plugins/scheduler/automationsMeta.ts`.

--- a/test/server/test_collectionFiles.ts
+++ b/test/server/test_collectionFiles.ts
@@ -1,0 +1,47 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { collectionFileUrl, parseJsonObject, rawBaseUrl } from "../../server/workspace/collectionsRegistry/collectionFiles.js";
+
+describe("collectionFileUrl", () => {
+  afterEach(() => {
+    delete process.env.COLLECTIONS_REGISTRY_RAW_BASE;
+  });
+
+  it("composes the default raw URL", () => {
+    assert.equal(
+      collectionFileUrl("collections/isamu/movies", "schema.json"),
+      "https://raw.githubusercontent.com/receptron/mulmoclaude-collections/main/collections/isamu/movies/schema.json",
+    );
+  });
+
+  it("trims leading/trailing slashes in the dir path", () => {
+    assert.equal(collectionFileUrl("/collections/a/b/", "meta.json"), `${rawBaseUrl()}/collections/a/b/meta.json`);
+  });
+
+  it("honors the COLLECTIONS_REGISTRY_RAW_BASE override", () => {
+    process.env.COLLECTIONS_REGISTRY_RAW_BASE = "https://example.test/reg";
+    assert.equal(collectionFileUrl("collections/a/b", "schema.json"), "https://example.test/reg/collections/a/b/schema.json");
+  });
+});
+
+describe("parseJsonObject", () => {
+  it("accepts a JSON object", () => {
+    const result = parseJsonObject('{"a":1}', "x");
+    assert.ok(result.ok);
+    assert.deepEqual(result.value, { a: 1 });
+  });
+
+  it("rejects invalid JSON", () => {
+    const result = parseJsonObject("{not json", "x");
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.error, /not valid JSON/);
+  });
+
+  it("rejects non-object JSON (array, number, null)", () => {
+    for (const text of ["[]", "42", "null", '"str"']) {
+      const result = parseJsonObject(text, "x");
+      assert.equal(result.ok, false, text);
+    }
+  });
+});

--- a/test/server/test_importCollection.ts
+++ b/test/server/test_importCollection.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { isSafeBundlePath, parseManifest, normalizedDataPath, withNormalizedDataPath } from "../../server/workspace/collectionsRegistry/importCollection.js";
+
+describe("isSafeBundlePath", () => {
+  it("accepts normal relative bundle paths", () => {
+    for (const ok of ["SKILL.md", "schema.json", "views/cinema.html", "seed/items/007-a.json", "templates/x.md"]) {
+      assert.ok(isSafeBundlePath(ok), ok);
+    }
+  });
+
+  it("rejects traversal, absolute, and malformed paths", () => {
+    for (const bad of ["", "/etc/passwd", "../secret", "a/../b", "a/./b", "a//b", "a\\b", ".", "..", 42, null, undefined]) {
+      assert.ok(!isSafeBundlePath(bad), String(bad));
+    }
+  });
+});
+
+describe("parseManifest", () => {
+  it("accepts a well-formed manifest", () => {
+    const result = parseManifest({ files: ["SKILL.md", "schema.json", "seed/items/a.json"] });
+    assert.ok(result.ok);
+    assert.deepEqual(result.files, ["SKILL.md", "schema.json", "seed/items/a.json"]);
+  });
+
+  it("rejects a non-object or missing files[]", () => {
+    for (const bad of [null, 42, {}, { files: "x" }, { files: {} }]) {
+      assert.equal(parseManifest(bad).ok, false);
+    }
+  });
+
+  it("rejects a manifest containing an unsafe path", () => {
+    const result = parseManifest({ files: ["SKILL.md", "../../etc/passwd"] });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.error, /unsafe path/);
+  });
+});
+
+describe("dataPath normalization", () => {
+  it("derives data/collections/<slug>/items", () => {
+    assert.equal(normalizedDataPath("movies"), "data/collections/movies/items");
+    assert.equal(normalizedDataPath("isamu-movies"), "data/collections/isamu-movies/items");
+  });
+
+  it("replaces the authored dataPath and preserves other fields", () => {
+    const schema = { title: "X", icon: "movie", dataPath: "data/movies/items", primaryKey: "id", fields: { id: {} } };
+    const out = withNormalizedDataPath(schema, "movies");
+    assert.equal(out.dataPath, "data/collections/movies/items");
+    assert.equal(out.title, "X");
+    assert.equal(out.primaryKey, "id");
+    assert.deepEqual(out.fields, { id: {} });
+    // input not mutated
+    assert.equal(schema.dataPath, "data/movies/items");
+  });
+});

--- a/test/server/test_registryClient.ts
+++ b/test/server/test_registryClient.ts
@@ -1,0 +1,72 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  fetchRegistryIndex,
+  resetRegistryCache,
+  CACHE_TTL_MS,
+  STALE_RETRY_BACKOFF_MS,
+  type FetchIndexResult,
+} from "../../server/workspace/collectionsRegistry/client.js";
+import type { RegistryIndex } from "../../server/workspace/collectionsRegistry/registryIndex.js";
+
+const okIndex: RegistryIndex = { schemaVersion: 1, generatedAt: "t", registry: "r", collections: [] };
+const okResult: FetchIndexResult = { ok: true, index: okIndex, stale: false };
+const failResult: FetchIndexResult = { ok: false, status: 503, error: "down" };
+
+function makeLoader(results: FetchIndexResult[]) {
+  let index = 0;
+  let calls = 0;
+  const load = (): Promise<FetchIndexResult> => {
+    calls += 1;
+    return Promise.resolve(results[Math.min(index++, results.length - 1)]);
+  };
+  return { load, calls: () => calls };
+}
+
+describe("fetchRegistryIndex caching + backoff", () => {
+  beforeEach(() => resetRegistryCache());
+
+  it("serves from cache within the TTL without re-loading", async () => {
+    const loader = makeLoader([okResult]);
+    const first = await fetchRegistryIndex({ nowMs: 0, loader: loader.load });
+    assert.ok(first.ok && !first.stale);
+    const second = await fetchRegistryIndex({ nowMs: 1000, loader: loader.load });
+    assert.ok(second.ok && !second.stale);
+    assert.equal(loader.calls(), 1);
+  });
+
+  it("errors when the load fails and no cache exists", async () => {
+    const loader = makeLoader([failResult]);
+    const result = await fetchRegistryIndex({ nowMs: 0, loader: loader.load });
+    assert.equal(result.ok, false);
+  });
+
+  it("throttles network retries during an outage, serving stale in between", async () => {
+    const loader = makeLoader([okResult, failResult, failResult, failResult]);
+    await fetchRegistryIndex({ nowMs: 0, loader: loader.load }); // seed cache (call 1)
+
+    const stale1 = await fetchRegistryIndex({ nowMs: CACHE_TTL_MS + 1, loader: loader.load });
+    assert.ok(stale1.ok && stale1.stale, "past TTL + failing upstream → stale");
+    assert.equal(loader.calls(), 2, "network attempted once on first stale serve");
+
+    const stale2 = await fetchRegistryIndex({ nowMs: CACHE_TTL_MS + 1000, loader: loader.load });
+    assert.ok(stale2.ok && stale2.stale);
+    assert.equal(loader.calls(), 2, "within backoff → no network attempt");
+
+    const stale3 = await fetchRegistryIndex({ nowMs: CACHE_TTL_MS + 1 + STALE_RETRY_BACKOFF_MS, loader: loader.load });
+    assert.ok(stale3.ok && stale3.stale);
+    assert.equal(loader.calls(), 3, "after backoff window → network retried");
+  });
+
+  it("clears the backoff after a successful reload", async () => {
+    const loader = makeLoader([okResult, failResult, okResult]);
+    await fetchRegistryIndex({ nowMs: 0, loader: loader.load }); // cache (1)
+    await fetchRegistryIndex({ nowMs: CACHE_TTL_MS + 1, loader: loader.load }); // fail → stale + backoff (2)
+    const recovered = await fetchRegistryIndex({ nowMs: CACHE_TTL_MS + 1 + STALE_RETRY_BACKOFF_MS, loader: loader.load }); // ok (3)
+    assert.ok(recovered.ok && !recovered.stale);
+    const cached = await fetchRegistryIndex({ nowMs: CACHE_TTL_MS + 2 + STALE_RETRY_BACKOFF_MS, loader: loader.load });
+    assert.ok(cached.ok && !cached.stale);
+    assert.equal(loader.calls(), 3, "fresh cache hit, no extra load");
+  });
+});

--- a/test/server/test_registryIndex.ts
+++ b/test/server/test_registryIndex.ts
@@ -109,6 +109,16 @@ describe("parseRegistryIndex", () => {
     }
   });
 
+  it("rejects entries whose id/path disagree with author/slug", () => {
+    const idMismatch = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), id: "someone-else/movies" }] });
+    assert.equal(idMismatch.ok, false);
+    if (!idMismatch.ok) assert.match(idMismatch.error, /\.id must equal/);
+
+    const pathMismatch = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), path: "collections/someone-else/movies" }] });
+    assert.equal(pathMismatch.ok, false);
+    if (!pathMismatch.ok) assert.match(pathMismatch.error, /\.path must equal/);
+  });
+
   it("accepts zero and positive integer counts", () => {
     const result = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), fieldCount: 0, seedCount: 42 }] });
     assert.ok(result.ok);

--- a/test/server/test_registryIndex.ts
+++ b/test/server/test_registryIndex.ts
@@ -100,6 +100,22 @@ describe("parseRegistryIndex", () => {
     assert.equal(entry.icon, "");
   });
 
+  it("rejects negative or fractional count fields", () => {
+    for (const bad of [-1, 1.5, -0.5]) {
+      const fieldBad = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), fieldCount: bad }] });
+      assert.equal(fieldBad.ok, false, `fieldCount ${bad}`);
+      const seedBad = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), seedCount: bad }] });
+      assert.equal(seedBad.ok, false, `seedCount ${bad}`);
+    }
+  });
+
+  it("accepts zero and positive integer counts", () => {
+    const result = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), fieldCount: 0, seedCount: 42 }] });
+    assert.ok(result.ok);
+    assert.equal(result.index.collections[0].fieldCount, 0);
+    assert.equal(result.index.collections[0].seedCount, 42);
+  });
+
   it("drops non-string members from tags/views", () => {
     const entry = { ...validEntry(), tags: ["ok", 1, null, "two"], views: [true, "v"] };
     const result = parseRegistryIndex({ ...validIndex(), collections: [entry] });

--- a/test/server/test_registryIndex.ts
+++ b/test/server/test_registryIndex.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseRegistryIndex } from "../../server/workspace/collectionsRegistry/registryIndex.js";
+
+function validEntry(): Record<string, unknown> {
+  return {
+    id: "isamu/movies",
+    author: "isamu",
+    slug: "movies",
+    title: "映画リスト",
+    icon: "movie",
+    description: "Movies I track.",
+    version: "1.0.0",
+    tags: ["entertainment"],
+    license: "MIT",
+    fieldCount: 15,
+    views: ["シネマ"],
+    hasSeed: true,
+    seedCount: 3,
+    path: "collections/isamu/movies",
+    contentSha: "305247fb2e1432da",
+  };
+}
+
+function validIndex(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-06-26T20:36:50.991Z",
+    registry: "receptron/mulmoclaude-collections",
+    collections: [validEntry()],
+  };
+}
+
+describe("parseRegistryIndex", () => {
+  it("accepts a well-formed index and preserves entries", () => {
+    const result = parseRegistryIndex(validIndex());
+    assert.ok(result.ok);
+    assert.equal(result.index.registry, "receptron/mulmoclaude-collections");
+    assert.equal(result.index.collections.length, 1);
+    const [entry] = result.index.collections;
+    assert.equal(entry.id, "isamu/movies");
+    assert.equal(entry.fieldCount, 15);
+    assert.deepEqual(entry.views, ["シネマ"]);
+    assert.equal(entry.hasSeed, true);
+  });
+
+  it("rejects a non-object", () => {
+    for (const bad of [null, 42, "x", []]) {
+      const result = parseRegistryIndex(bad);
+      assert.equal(result.ok, false);
+    }
+  });
+
+  it("rejects an unsupported schemaVersion", () => {
+    const result = parseRegistryIndex({ ...validIndex(), schemaVersion: 2 });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.error, /schemaVersion/);
+  });
+
+  it("rejects a missing registry or generatedAt", () => {
+    const noRegistry = parseRegistryIndex({ ...validIndex(), registry: "" });
+    assert.equal(noRegistry.ok, false);
+    const noGenerated = parseRegistryIndex({ ...validIndex(), generatedAt: undefined });
+    assert.equal(noGenerated.ok, false);
+  });
+
+  it("rejects when collections is not an array", () => {
+    const result = parseRegistryIndex({ ...validIndex(), collections: {} });
+    assert.equal(result.ok, false);
+  });
+
+  it("rejects an entry missing a required string field", () => {
+    const broken = validEntry();
+    delete broken.contentSha;
+    const result = parseRegistryIndex({ ...validIndex(), collections: [broken] });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.match(result.error, /collections\[0\]/);
+  });
+
+  it("defaults optional fields when omitted", () => {
+    const minimal = {
+      id: "a/b",
+      author: "a",
+      slug: "b",
+      title: "B",
+      version: "0.1.0",
+      path: "collections/a/b",
+      contentSha: "deadbeef",
+    };
+    const result = parseRegistryIndex({ ...validIndex(), collections: [minimal] });
+    assert.ok(result.ok);
+    const [entry] = result.index.collections;
+    assert.deepEqual(entry.tags, []);
+    assert.deepEqual(entry.views, []);
+    assert.equal(entry.hasSeed, false);
+    assert.equal(entry.seedCount, 0);
+    assert.equal(entry.fieldCount, 0);
+    assert.equal(entry.screenshot, undefined);
+    assert.equal(entry.icon, "");
+  });
+
+  it("drops non-string members from tags/views", () => {
+    const entry = { ...validEntry(), tags: ["ok", 1, null, "two"], views: [true, "v"] };
+    const result = parseRegistryIndex({ ...validIndex(), collections: [entry] });
+    assert.ok(result.ok);
+    assert.deepEqual(result.index.collections[0].tags, ["ok", "two"]);
+    assert.deepEqual(result.index.collections[0].views, ["v"]);
+  });
+});

--- a/test/server/test_registryIndex.ts
+++ b/test/server/test_registryIndex.ts
@@ -119,6 +119,24 @@ describe("parseRegistryIndex", () => {
     if (!pathMismatch.ok) assert.match(pathMismatch.error, /\.path must equal/);
   });
 
+  it("rejects traversal/invalid author or slug even when id/path are internally consistent", () => {
+    const poisoned = (author: string, slug: string) => ({ ...validEntry(), author, slug, id: `${author}/${slug}`, path: `collections/${author}/${slug}` });
+    const cases: [string, string][] = [
+      ["..", "movies"],
+      ["a/b", "movies"],
+      ["isamu", ".."],
+      ["isamu", "a/b"],
+      ["isamu.", "movies"],
+      ["isamu", "mov.ies"],
+      ["isa\\mu", "movies"],
+      ["-isamu", "movies"],
+    ];
+    for (const [author, slug] of cases) {
+      const result = parseRegistryIndex({ ...validIndex(), collections: [poisoned(author, slug)] });
+      assert.equal(result.ok, false, `${author}/${slug} should be rejected`);
+    }
+  });
+
   it("accepts zero and positive integer counts", () => {
     const result = parseRegistryIndex({ ...validIndex(), collections: [{ ...validEntry(), fieldCount: 0, seedCount: 42 }] });
     assert.ok(result.ok);


### PR DESCRIPTION
## Summary

キュレーション済み**コレクション・レジストリ**機構（host 側 = Workstream A）。ユーザが作った
コレクション（`schema.json` + custom view + 任意 seed）を公式レジストリ
`receptron/mulmoclaude-collections` へ PR 寄稿 → CI＋人手で審査・merge → 他ユーザは
`/collections`「発見」タブから **index.json 経由**で発見・取り込みできるようにする。

既存 external-skill 機構（clone → catalog → ★star=fork → discovery）の**宛先・schema 検証・
view サンドボックスを再利用**し、**供給源だけ index＋単一 collection fetch に差し替える**。

> **このブランチは現状 design plan（`plans/feat-collection-registry.md`）のみ**。host 実装
> （Discover エンドポイント / 取り込み fetcher / dataPath 正規化 / seed materialize /
> provenance・更新 / UI）はこのブランチに続けて載せる。Draft。

## Items to Confirm / Review

- **R2**: index を **GitHub Pages/Release 配信**（main を bot commit で汚さない）で良いか。
- **R3**: 取り込み時に schema の `dataPath` を **`data/collections/<localSlug>/items` へ強制正規化**。
- **R9**: `meta.json.author` を **PR 作成者の GitHub login と CI で一致検証**（registry 側で実装済み）。
- **seed**: 実データ込みを許可（本人責任）＋ PII は警告止まり、**credential 検出のみ hard fail**。

## Status

- [x] 設計・決定（R1–R9）— `plans/feat-collection-registry.md`
- [x] Workstream B（registry repo bootstrap）— `receptron/mulmoclaude-collections`、テスト 9/9 green
  - 構造 `collections/<author>/<slug>/`、`meta`/`index` JSON Schema 契約、zero-dep の
    `validate`/`build-index`（host 同等の schema/record 検証・R9 identity gate・secret hard-fail/PII warn・
    view CSP lint）、`pr-validate`/`build-index`(Pages) workflow、例 `isamu/movies`。
- [ ] Workstream A（host）— endpoints / fetcher / dataPath 正規化 / seed materialize / UI

## User Prompt（原依頼の統合）

- collections 機能は「データ構造だけ」か「skill も含む」か、カスタムビューは「データだけ」か、その仕組み・
  仕様を知りたい。そのうえで**これらを配布する方法を考えてほしい**。
- 配布シナリオ: ユーザが作ったコレクション・カスタムビューを **PR で我々が管理するレポジトリに送り**、
  我々が審査して取り込む。他ユーザは mulmoclaude からそのレポジトリを参照し、良いコレクションを発見したら
  取り込む。取り込み側は GitHub 直ではなく **backend が GitHub の index ファイルを見てデータを出す**のも可。
  **GitHub の構造も含めて**設計してほしい。
- 確定した前提（フォーム）: 新規 repo `receptron/mulmoclaude-collections`／seed は実データ込み可（本人責任）／
  識別子は作者名前空間 `collections/<author>/<slug>/`／author は GitHub アカウントとして **CI で一致確認**。
- 進め方: `gh issue create` で issue 化 → ブランチ → plan 書き出し → 実装。

Refs #1814

## Summary by Sourcery

Documentation:
- Add a detailed design plan for a curated collection registry, covering registry repo structure, JSON schemas, CI validation/indexing flows, and host-side discovery/import behavior.