### PR TITLE
feat(collections): import a registry collection into .claude/skills

### DIFF
--- a/server/api/routes/collectionsRegistry.ts
+++ b/server/api/routes/collectionsRegistry.ts
@@ -9,7 +9,9 @@ import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { badRequest } from "../../utils/httpError.js";
 import { fetchRegistryIndex } from "../../workspace/collectionsRegistry/client.js";
 import { previewCollection } from "../../workspace/collectionsRegistry/collectionFiles.js";
+import { performImport } from "../../workspace/collectionsRegistry/importWriter.js";
 import type { RegistryCollectionEntry } from "../../workspace/collectionsRegistry/registryIndex.js";
+import { workspacePath } from "../../workspace/workspace.js";
 
 const router = Router();
 
@@ -54,6 +56,33 @@ router.get(API_ROUTES.collectionsRegistry.preview, async (req: Request, res: Res
     return;
   }
   res.json({ entry: result.entry, schema: result.schema, meta: result.meta });
+});
+
+interface ImportBody {
+  author?: unknown;
+  slug?: unknown;
+}
+
+interface ImportResponse {
+  localSlug: string;
+  updated: boolean;
+  seedWritten: number;
+  seedSkipped: boolean;
+}
+
+router.post(API_ROUTES.collectionsRegistry.import, async (req: Request<object, unknown, ImportBody>, res: Response<ImportResponse | ErrorResponse>) => {
+  const author = typeof req.body.author === "string" ? req.body.author : "";
+  const slug = typeof req.body.slug === "string" ? req.body.slug : "";
+  if (!author || !slug) {
+    badRequest(res, "author and slug are required");
+    return;
+  }
+  const result = await performImport(author, slug, workspacePath);
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+  res.json({ localSlug: result.localSlug, updated: result.updated, seedWritten: result.seedWritten, seedSkipped: result.seedSkipped });
 });
 
 export default router;

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -155,20 +155,30 @@ export async function writeImportedCollection(params: {
   const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
   if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
-  // Stage the full replacement (bundle + origin) in a hidden sibling dir, then swap
-  // it in with a single rename. So a mid-write failure never destroys the prior
-  // install (it's untouched until the swap) and never leaves an origin-less partial
-  // dir that a later retry would misclassify as a foreign-collection 409. The
-  // re-import also truly replaces the bundle (files dropped from the manifest are
-  // gone after the swap). Records live in dataPath (a separate dir) and are untouched.
-  const staging = path.join(path.dirname(target.targetDir), `.importing-${entry.slug}`);
+  // Build the replacement fully in a hidden sibling staging dir (bundle + origin),
+  // so the prior install is untouched until everything is durably written. Leftover
+  // staging/backup dirs from a crashed import are cleaned first, keeping retries possible.
+  const skillsParent = path.dirname(target.targetDir);
+  const staging = path.join(skillsParent, `.importing-${entry.slug}`);
+  const backup = path.join(skillsParent, `.backup-${entry.slug}`);
   await rm(staging, { recursive: true, force: true });
+  await rm(backup, { recursive: true, force: true });
   await mkdir(staging, { recursive: true });
   await writeBundleFiles(staging, bundle, validated.schema);
   const origin: ImportOrigin = { registry, author: entry.author, slug: entry.slug, version: entry.version, contentSha: entry.contentSha, importedAt: nowIso };
   await writeFileAtomic(path.join(staging, ORIGIN_FILE), `${JSON.stringify(origin, null, 2)}\n`);
-  await rm(target.targetDir, { recursive: true, force: true });
-  await rename(staging, target.targetDir);
+
+  // Swap with rollback: move the old install aside (rename), move the new in (rename),
+  // then discard the old. If the swap fails, restore the old so we never end up with no
+  // installed collection. Records live in dataPath (a separate dir) and are untouched.
+  if (target.updated) await rename(target.targetDir, backup);
+  try {
+    await rename(staging, target.targetDir);
+  } catch (err) {
+    if (target.updated) await rename(backup, target.targetDir).catch(() => undefined);
+    throw err;
+  }
+  await rm(backup, { recursive: true, force: true });
 
   const seed = await materializeSeed(dataDir, bundle);
   return { ok: true, localSlug: entry.slug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -111,10 +111,9 @@ async function writeBundleFiles(targetDir: string, bundle: Map<string, string>, 
   }
 }
 
-async function materializeSeed(workspaceRoot: string, localSlug: string, bundle: Map<string, string>): Promise<{ written: number; skipped: boolean }> {
+async function materializeSeed(dataDir: string, bundle: Map<string, string>): Promise<{ written: number; skipped: boolean }> {
   const seedEntries = [...bundle].filter(([rel]) => rel.startsWith(SEED_PREFIX));
   if (seedEntries.length === 0) return { written: 0, skipped: false };
-  const dataDir = path.join(workspaceRoot, ...normalizedDataPath(localSlug).split("/"));
   if (!(await isEmptyOrAbsentDir(dataDir))) return { written: 0, skipped: true };
   await mkdir(dataDir, { recursive: true });
   let written = 0;
@@ -143,13 +142,20 @@ export async function writeImportedCollection(params: {
   const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
   if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
+  // Pre-flight the data dir: a non-directory at the dataPath would make mkdir throw
+  // EEXIST mid-import (a generic 500). Reject deterministically before any write.
+  const dataDir = path.join(workspaceRoot, ...normalizedDataPath(entry.slug).split("/"));
+  if ((await statType(dataDir)) === "other") {
+    return { ok: false, status: STATUS_CONFLICT, error: `data path for slug '${entry.slug}' exists and is not a directory` };
+  }
+
   // Clear any prior install so a re-import truly replaces the bundle — files that
   // disappeared from the manifest must not linger. Records live in dataPath (a
   // separate dir) and are untouched.
   await rm(target.targetDir, { recursive: true, force: true });
   await mkdir(target.targetDir, { recursive: true });
   await writeBundleFiles(target.targetDir, bundle, validated.schema);
-  const seed = await materializeSeed(workspaceRoot, entry.slug, bundle);
+  const seed = await materializeSeed(dataDir, bundle);
   const origin: ImportOrigin = { registry, author: entry.author, slug: entry.slug, version: entry.version, contentSha: entry.contentSha, importedAt: nowIso };
   await writeFileAtomic(path.join(target.targetDir, ORIGIN_FILE), `${JSON.stringify(origin, null, 2)}\n`);
   return { ok: true, localSlug: entry.slug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -46,8 +46,12 @@ export type ImportResult =
 async function statType(target: string): Promise<"dir" | "other" | "absent"> {
   try {
     return (await stat(target)).isDirectory() ? "dir" : "other";
-  } catch {
-    return "absent";
+  } catch (err) {
+    // Only a genuinely missing path is "absent". ENOTDIR (an ancestor is a file),
+    // EACCES, etc. are path-shape conflicts that mkdir would later throw on, so
+    // surface them as "other" for deterministic 409 handling.
+    if (isRecord(err) && err.code === "ENOENT") return "absent";
+    return "other";
   }
 }
 
@@ -139,15 +143,17 @@ export async function writeImportedCollection(params: {
   const { registry, entry, bundle, workspaceRoot, nowIso } = params;
   const target = await resolveTarget(workspaceRoot, registry, entry);
   if ("conflict" in target) return { ok: false, status: STATUS_CONFLICT, error: target.conflict };
-  const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
-  if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
-  // Pre-flight the data dir: a non-directory at the dataPath would make mkdir throw
-  // EEXIST mid-import (a generic 500). Reject deterministically before any write.
+  // Pre-flight the data dir before schema validation: a non-directory at the dataPath
+  // (or an ancestor that's a file → ENOTDIR) would otherwise surface as a generic 500
+  // on mkdir. statType maps ENOTDIR/other to a deterministic 409 path-shape conflict.
   const dataDir = path.join(workspaceRoot, ...normalizedDataPath(entry.slug).split("/"));
   if ((await statType(dataDir)) === "other") {
     return { ok: false, status: STATUS_CONFLICT, error: `data path for slug '${entry.slug}' exists and is not a directory` };
   }
+
+  const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
+  if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
   // Stage the full replacement (bundle + origin) in a hidden sibling dir, then swap
   // it in with a single rename. So a mid-write failure never destroys the prior

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -8,7 +8,7 @@
 // workspaceRoot/clock so it is unit-testable against a temp workspace with no
 // network; `performImport` is the thin glue that fetches and calls it.
 
-import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { acceptParsedSchema, CollectionSchemaZ, safeRecordId } from "@mulmoclaude/core/collection/server";
@@ -149,15 +149,22 @@ export async function writeImportedCollection(params: {
     return { ok: false, status: STATUS_CONFLICT, error: `data path for slug '${entry.slug}' exists and is not a directory` };
   }
 
-  // Clear any prior install so a re-import truly replaces the bundle — files that
-  // disappeared from the manifest must not linger. Records live in dataPath (a
-  // separate dir) and are untouched.
-  await rm(target.targetDir, { recursive: true, force: true });
-  await mkdir(target.targetDir, { recursive: true });
-  await writeBundleFiles(target.targetDir, bundle, validated.schema);
-  const seed = await materializeSeed(dataDir, bundle);
+  // Stage the full replacement (bundle + origin) in a hidden sibling dir, then swap
+  // it in with a single rename. So a mid-write failure never destroys the prior
+  // install (it's untouched until the swap) and never leaves an origin-less partial
+  // dir that a later retry would misclassify as a foreign-collection 409. The
+  // re-import also truly replaces the bundle (files dropped from the manifest are
+  // gone after the swap). Records live in dataPath (a separate dir) and are untouched.
+  const staging = path.join(path.dirname(target.targetDir), `.importing-${entry.slug}`);
+  await rm(staging, { recursive: true, force: true });
+  await mkdir(staging, { recursive: true });
+  await writeBundleFiles(staging, bundle, validated.schema);
   const origin: ImportOrigin = { registry, author: entry.author, slug: entry.slug, version: entry.version, contentSha: entry.contentSha, importedAt: nowIso };
-  await writeFileAtomic(path.join(target.targetDir, ORIGIN_FILE), `${JSON.stringify(origin, null, 2)}\n`);
+  await writeFileAtomic(path.join(staging, ORIGIN_FILE), `${JSON.stringify(origin, null, 2)}\n`);
+  await rm(target.targetDir, { recursive: true, force: true });
+  await rename(staging, target.targetDir);
+
+  const seed = await materializeSeed(dataDir, bundle);
   return { ok: true, localSlug: entry.slug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };
 }
 

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -8,7 +8,7 @@
 // workspaceRoot/clock so it is unit-testable against a temp workspace with no
 // network; `performImport` is the thin glue that fetches and calls it.
 
-import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { acceptParsedSchema, CollectionSchemaZ, safeRecordId } from "@mulmoclaude/core/collection/server";
@@ -43,11 +43,11 @@ export type ImportResult =
   | { ok: true; localSlug: string; updated: boolean; seedWritten: number; seedSkipped: boolean }
   | { ok: false; status: number; error: string };
 
-async function isDir(target: string): Promise<boolean> {
+async function statType(target: string): Promise<"dir" | "other" | "absent"> {
   try {
-    return (await stat(target)).isDirectory();
+    return (await stat(target)).isDirectory() ? "dir" : "other";
   } catch {
-    return false;
+    return "absent";
   }
 }
 
@@ -75,7 +75,9 @@ type TargetResolution = { targetDir: string; updated: boolean } | { conflict: st
 
 async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
   const targetDir = projectSkillDir(workspaceRoot, entry.slug);
-  if (!(await isDir(targetDir))) return { targetDir, updated: false };
+  const kind = await statType(targetDir);
+  if (kind === "absent") return { targetDir, updated: false };
+  if (kind === "other") return { conflict: `path for slug '${entry.slug}' exists and is not a directory` };
   if (originMatches(await readOrigin(targetDir), registry, entry.author, entry.slug)) return { targetDir, updated: true };
   return { conflict: `a different collection already occupies slug '${entry.slug}'` };
 }
@@ -141,6 +143,10 @@ export async function writeImportedCollection(params: {
   const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
   if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
+  // Clear any prior install so a re-import truly replaces the bundle — files that
+  // disappeared from the manifest must not linger. Records live in dataPath (a
+  // separate dir) and are untouched.
+  await rm(target.targetDir, { recursive: true, force: true });
   await mkdir(target.targetDir, { recursive: true });
   await writeBundleFiles(target.targetDir, bundle, validated.schema);
   const seed = await materializeSeed(workspaceRoot, entry.slug, bundle);

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -1,0 +1,173 @@
+// Import a registry collection into the active workspace. The writer fetches the
+// bundle, re-validates the schema with the host's own gates (R7 — the index is not
+// a trust boundary), writes the bundle into .claude/skills/<localSlug>/ with a
+// host-owned dataPath (R3), materializes any seed records into that dataPath when
+// it's empty, and records provenance in .origin.json for update detection (R5/R8).
+//
+// `writeImportedCollection` takes the already-fetched bundle + an explicit
+// workspaceRoot/clock so it is unit-testable against a temp workspace with no
+// network; `performImport` is the thin glue that fetches and calls it.
+
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { acceptParsedSchema, CollectionSchemaZ, safeRecordId } from "@mulmoclaude/core/collection/server";
+import type { CollectionSchema } from "@mulmoclaude/core/collection";
+
+import { log } from "../../system/logger/index.js";
+import { errorMessage } from "../../utils/errors.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
+import { isRecord } from "../../utils/types.js";
+import { projectSkillDir } from "../skills/paths.js";
+import { fetchRegistryIndex } from "./client.js";
+import { fetchBundle, fetchManifest, normalizedDataPath } from "./importCollection.js";
+import type { RegistryCollectionEntry } from "./registryIndex.js";
+
+const ORIGIN_FILE = ".origin.json";
+const SEED_PREFIX = "seed/items/";
+const SCHEMA_FILE = "schema.json";
+const STATUS_NOT_FOUND = 404;
+const STATUS_CONFLICT = 409;
+const STATUS_UNPROCESSABLE = 422;
+
+export interface ImportOrigin {
+  registry: string;
+  author: string;
+  slug: string;
+  version: string;
+  contentSha: string;
+  importedAt: string;
+}
+
+export type ImportResult =
+  | { ok: true; localSlug: string; updated: boolean; seedWritten: number; seedSkipped: boolean }
+  | { ok: false; status: number; error: string };
+
+async function isDir(target: string): Promise<boolean> {
+  try {
+    return (await stat(target)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function isEmptyOrAbsentDir(target: string): Promise<boolean> {
+  try {
+    return (await readdir(target)).length === 0;
+  } catch {
+    return true;
+  }
+}
+
+function originMatches(origin: unknown, registry: string, author: string, slug: string): boolean {
+  return isRecord(origin) && origin.registry === registry && origin.author === author && origin.slug === slug;
+}
+
+async function readOrigin(targetDir: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path.join(targetDir, ORIGIN_FILE), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+type TargetResolution = { targetDir: string; updated: boolean } | { conflict: string };
+
+async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
+  const targetDir = projectSkillDir(workspaceRoot, entry.slug);
+  if (!(await isDir(targetDir))) return { targetDir, updated: false };
+  if (originMatches(await readOrigin(targetDir), registry, entry.author, entry.slug)) return { targetDir, updated: true };
+  return { conflict: `a different collection already occupies slug '${entry.slug}'` };
+}
+
+type SchemaResolution = { schema: CollectionSchema } | { error: string };
+
+function validateAndNormalize(bundle: Map<string, string>, localSlug: string, workspaceRoot: string): SchemaResolution {
+  const schemaText = bundle.get(SCHEMA_FILE);
+  if (schemaText === undefined) return { error: "bundle is missing schema.json" };
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(schemaText);
+  } catch {
+    return { error: "schema.json is not valid JSON" };
+  }
+  const parsed = CollectionSchemaZ.safeParse(parsedJson);
+  if (!parsed.success) return { error: `schema.json failed validation: ${parsed.error.issues[0]?.message ?? "invalid"}` };
+  const schema: CollectionSchema = { ...parsed.data, dataPath: normalizedDataPath(localSlug) };
+  const acceptance = acceptParsedSchema(schema, { source: "project", workspaceRoot });
+  if (!acceptance.ok) return { error: `schema.json rejected: ${acceptance.reason}` };
+  return { schema };
+}
+
+async function writeBundleFiles(targetDir: string, bundle: Map<string, string>, schema: CollectionSchema): Promise<void> {
+  for (const [rel, content] of bundle) {
+    if (rel.startsWith(SEED_PREFIX)) continue; // seed goes to dataPath, not the skill dir
+    const dest = path.join(targetDir, ...rel.split("/"));
+    if (dest !== targetDir && !dest.startsWith(targetDir + path.sep)) continue; // belt-and-suspenders (paths pre-validated)
+    await mkdir(path.dirname(dest), { recursive: true });
+    await writeFile(dest, rel === SCHEMA_FILE ? `${JSON.stringify(schema, null, 2)}\n` : content, "utf-8");
+  }
+}
+
+async function materializeSeed(workspaceRoot: string, localSlug: string, bundle: Map<string, string>): Promise<{ written: number; skipped: boolean }> {
+  const seedEntries = [...bundle].filter(([rel]) => rel.startsWith(SEED_PREFIX));
+  if (seedEntries.length === 0) return { written: 0, skipped: false };
+  const dataDir = path.join(workspaceRoot, ...normalizedDataPath(localSlug).split("/"));
+  if (!(await isEmptyOrAbsentDir(dataDir))) return { written: 0, skipped: true };
+  await mkdir(dataDir, { recursive: true });
+  let written = 0;
+  for (const [rel, content] of seedEntries) {
+    const fileName = rel.slice(SEED_PREFIX.length);
+    if (fileName.includes("/") || safeRecordId(fileName.replace(/\.json$/, "")) === null) {
+      log.warn("collections-registry", "skipped unsafe seed record", { rel });
+      continue;
+    }
+    await writeFile(path.join(dataDir, fileName), content, "utf-8");
+    written += 1;
+  }
+  return { written, skipped: false };
+}
+
+export async function writeImportedCollection(params: {
+  registry: string;
+  entry: RegistryCollectionEntry;
+  bundle: Map<string, string>;
+  workspaceRoot: string;
+  nowIso: string;
+}): Promise<ImportResult> {
+  const { registry, entry, bundle, workspaceRoot, nowIso } = params;
+  const target = await resolveTarget(workspaceRoot, registry, entry);
+  if ("conflict" in target) return { ok: false, status: STATUS_CONFLICT, error: target.conflict };
+  const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
+  if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
+
+  await mkdir(target.targetDir, { recursive: true });
+  await writeBundleFiles(target.targetDir, bundle, validated.schema);
+  const seed = await materializeSeed(workspaceRoot, entry.slug, bundle);
+  const origin: ImportOrigin = { registry, author: entry.author, slug: entry.slug, version: entry.version, contentSha: entry.contentSha, importedAt: nowIso };
+  await writeFileAtomic(path.join(target.targetDir, ORIGIN_FILE), `${JSON.stringify(origin, null, 2)}\n`);
+  return { ok: true, localSlug: entry.slug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };
+}
+
+export async function performImport(author: string, slug: string, workspaceRoot: string): Promise<ImportResult> {
+  const indexResult = await fetchRegistryIndex();
+  if (!indexResult.ok) return { ok: false, status: indexResult.status, error: indexResult.error };
+  const entry = indexResult.index.collections.find((candidate) => candidate.author === author && candidate.slug === slug);
+  if (!entry) return { ok: false, status: STATUS_NOT_FOUND, error: `unknown collection: ${author}/${slug}` };
+  const manifest = await fetchManifest(entry);
+  if (!manifest.ok) return { ok: false, status: manifest.status, error: manifest.error };
+  const bundle = await fetchBundle(entry, manifest.files);
+  if (!bundle.ok) return { ok: false, status: bundle.status, error: bundle.error };
+  try {
+    return await writeImportedCollection({
+      registry: indexResult.index.registry,
+      entry,
+      bundle: bundle.files,
+      workspaceRoot,
+      nowIso: new Date().toISOString(),
+    });
+  } catch (err) {
+    log.warn("collections-registry", "import write failed", { author, slug, error: errorMessage(err) });
+    return { ok: false, status: 500, error: `import failed: ${errorMessage(err)}` };
+  }
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -292,6 +292,9 @@ const HOST_API_ROUTES = {
     list: "/api/collections-registry",
     /** GET ?author=&slug= → { entry, schema, meta } for one in-index collection. */
     preview: "/api/collections-registry/preview",
+    /** POST { author, slug } → fetch + re-validate + install into .claude/skills/,
+     *  normalize dataPath, materialize seed, record provenance. */
+    import: "/api/collections-registry/import",
   },
 
   // `scheduler` group migrated to META — see `src/plugins/scheduler/automationsMeta.ts`.

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -112,4 +112,20 @@ describe("writeImportedCollection", () => {
     assert.equal(result.ok, false);
     if (!result.ok) assert.equal(result.status, 422);
   });
+
+  it("re-import removes files that dropped out of the manifest", async () => {
+    await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle({ "templates/old.md": "old" }), workspaceRoot: wsRoot, nowIso: "t1" });
+    assert.ok(existsSync(path.join(skillDir(wsRoot), "templates", "old.md")));
+    await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
+    assert.ok(!existsSync(path.join(skillDir(wsRoot), "templates", "old.md")), "stale file removed on re-import");
+    assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")), "current bundle still installed");
+  });
+
+  it("returns 409 when the slug path exists as a non-directory file", async () => {
+    mkdirSync(path.dirname(skillDir(wsRoot)), { recursive: true });
+    writeFileSync(skillDir(wsRoot), "i am a file, not a directory");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 409);
+  });
 });

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -136,4 +136,14 @@ describe("writeImportedCollection", () => {
     assert.equal(result.ok, false);
     if (!result.ok) assert.equal(result.status, 409);
   });
+
+  it("cleans a leftover staging dir from a prior failed import and still installs", async () => {
+    const staging = path.join(wsRoot, ".claude", "skills", ".importing-movies");
+    mkdirSync(staging, { recursive: true });
+    writeFileSync(path.join(staging, "junk.txt"), "leftover from a crashed import");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.ok(result.ok);
+    assert.ok(!existsSync(staging), "leftover staging dir removed");
+    assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")));
+  });
 });

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -145,13 +145,17 @@ describe("writeImportedCollection", () => {
     if (!result.ok) assert.equal(result.status, 409);
   });
 
-  it("cleans a leftover staging dir from a prior failed import and still installs", async () => {
+  it("cleans leftover staging/backup dirs from a prior crashed import and still installs", async () => {
     const staging = path.join(wsRoot, ".claude", "skills", ".importing-movies");
+    const backup = path.join(wsRoot, ".claude", "skills", ".backup-movies");
     mkdirSync(staging, { recursive: true });
+    mkdirSync(backup, { recursive: true });
     writeFileSync(path.join(staging, "junk.txt"), "leftover from a crashed import");
+    writeFileSync(path.join(backup, "junk.txt"), "leftover from a crashed swap");
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
     assert.ok(result.ok);
     assert.ok(!existsSync(staging), "leftover staging dir removed");
+    assert.ok(!existsSync(backup), "leftover backup dir removed");
     assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")));
   });
 });

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -1,0 +1,115 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { writeImportedCollection } from "../../server/workspace/collectionsRegistry/importWriter.js";
+import type { RegistryCollectionEntry } from "../../server/workspace/collectionsRegistry/registryIndex.js";
+
+const REGISTRY = "receptron/mulmoclaude-collections";
+
+const entry: RegistryCollectionEntry = {
+  id: "isamu/movies",
+  author: "isamu",
+  slug: "movies",
+  title: "映画リスト",
+  icon: "movie",
+  description: "d",
+  version: "1.0.0",
+  tags: [],
+  license: "MIT",
+  fieldCount: 2,
+  views: [],
+  hasSeed: true,
+  seedCount: 1,
+  path: "collections/isamu/movies",
+  contentSha: "abc123",
+};
+
+function validSchema(): Record<string, unknown> {
+  return {
+    title: "映画リスト",
+    icon: "movie",
+    dataPath: "data/movies/items",
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true },
+      title: { type: "string", label: "Title" },
+    },
+  };
+}
+
+function makeBundle(overrides: Record<string, string> = {}): Map<string, string> {
+  return new Map(
+    Object.entries({
+      "SKILL.md": "---\nname: movies\ndescription: x\n---\n# Movies",
+      "schema.json": JSON.stringify(validSchema()),
+      "meta.json": JSON.stringify({ author: "isamu", slug: "movies", version: "1.0.0", title: "映画リスト", description: "d", license: "MIT" }),
+      "views/cinema.html": "<!doctype html><html></html>",
+      "seed/items/a.json": JSON.stringify({ id: "a", title: "A" }),
+      ...overrides,
+    }),
+  );
+}
+
+const skillDir = (root: string) => path.join(root, ".claude", "skills", "movies");
+const seedFile = (root: string) => path.join(root, "data", "collections", "movies", "items", "a.json");
+
+describe("writeImportedCollection", () => {
+  let wsRoot: string;
+  beforeEach(() => {
+    wsRoot = mkdtempSync(path.join(tmpdir(), "mc-import-"));
+  });
+  afterEach(() => {
+    rmSync(wsRoot, { recursive: true, force: true });
+  });
+
+  it("installs the bundle, normalizes dataPath, materializes seed, writes provenance", async () => {
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "2026-06-27T00:00:00Z" });
+    assert.ok(result.ok);
+    assert.equal(result.localSlug, "movies");
+    assert.equal(result.updated, false);
+    assert.equal(result.seedWritten, 1);
+    assert.equal(result.seedSkipped, false);
+
+    assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")));
+    assert.ok(existsSync(path.join(skillDir(wsRoot), "views", "cinema.html")));
+    assert.ok(!existsSync(path.join(skillDir(wsRoot), "seed")), "seed must not land in the skill dir");
+
+    const schema = JSON.parse(readFileSync(path.join(skillDir(wsRoot), "schema.json"), "utf-8"));
+    assert.equal(schema.dataPath, "data/collections/movies/items", "dataPath normalized (R3)");
+
+    const origin = JSON.parse(readFileSync(path.join(skillDir(wsRoot), ".origin.json"), "utf-8"));
+    assert.equal(origin.registry, REGISTRY);
+    assert.equal(origin.author, "isamu");
+    assert.equal(origin.contentSha, "abc123");
+    assert.equal(origin.importedAt, "2026-06-27T00:00:00Z");
+
+    assert.ok(existsSync(seedFile(wsRoot)), "seed record materialized into dataPath");
+  });
+
+  it("treats a same-origin re-import as an update and skips seed when data exists", async () => {
+    await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t1" });
+    const again = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
+    assert.ok(again.ok);
+    assert.equal(again.updated, true);
+    assert.equal(again.seedWritten, 0);
+    assert.equal(again.seedSkipped, true, "existing dataPath → seed skipped");
+  });
+
+  it("rejects with 409 when a different collection occupies the slug", async () => {
+    mkdirSync(skillDir(wsRoot), { recursive: true });
+    writeFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "someone else's collection");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 409);
+  });
+
+  it("rejects an invalid schema with 422", async () => {
+    const bundle = makeBundle({ "schema.json": JSON.stringify({ title: "x" }) });
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle, workspaceRoot: wsRoot, nowIso: "t" });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 422);
+  });
+});

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -137,6 +137,14 @@ describe("writeImportedCollection", () => {
     if (!result.ok) assert.equal(result.status, 409);
   });
 
+  it("returns 409 when an ancestor of the data path is a non-directory file", async () => {
+    mkdirSync(path.join(wsRoot, "data", "collections"), { recursive: true });
+    writeFileSync(path.join(wsRoot, "data", "collections", "movies"), "ancestor is a file, not a dir");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 409);
+  });
+
   it("cleans a leftover staging dir from a prior failed import and still installs", async () => {
     const staging = path.join(wsRoot, ".claude", "skills", ".importing-movies");
     mkdirSync(staging, { recursive: true });

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -128,4 +128,12 @@ describe("writeImportedCollection", () => {
     assert.equal(result.ok, false);
     if (!result.ok) assert.equal(result.status, 409);
   });
+
+  it("returns 409 when the data path exists as a non-directory file", async () => {
+    mkdirSync(path.join(wsRoot, "data", "collections", "movies"), { recursive: true });
+    writeFileSync(path.join(wsRoot, "data", "collections", "movies", "items"), "i am a file, not a directory");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 409);
+  });
 });


### PR DESCRIPTION
## Summary

Workstream A slice 2b-2 of the curated collection registry (#1814). Adds the **import** action: `POST /api/collections-registry/import` installs an in-index collection into the active workspace.

Builds on the merged fetch/normalize layer (#1815). The Discover-tab UI (the clickable button) is the remaining slice.

## What it does
1. Resolve the entry in the published index; fetch its `manifest.json` + bundle from raw (path-safety enforced).
2. **Re-validate** the fetched `schema.json` with the host's own gates — `CollectionSchemaZ` + `acceptParsedSchema` (R7; the index is not a trust boundary).
3. Write the bundle into `.claude/skills/<localSlug>/` with a **host-owned dataPath** `data/collections/<localSlug>/items` (R3 — the registry's authored dataPath is never trusted). Seed files are excluded from the skill dir.
4. **Materialize seed** records into that dataPath **only when it's empty** (skip-on-conflict; each id `safeRecordId`-checked).
5. Record **provenance** in `.origin.json` (`registry/author/slug/version/contentSha/importedAt`).

## Items to Confirm / Review
- **Collision (R8)**: a same-origin re-import is treated as an **update** (bundle replaced, records preserved); a slug occupied by a **different** collection → **409** (won't clobber the user's own). Invalid schema → **422**.
- **dataPath normalization (R3)** rewrites the schema before install.
- Writer is split so `writeImportedCollection` is unit-tested against a **temp workspace** (4 cases: install+seed+provenance, update+seed-skip, 409, 422); `performImport` is the thin network glue.

## User Prompt
配布のユーザシナリオ：他ユーザが mulmoclaude からレジストリを参照し、良いコレクションを発見したら取り込む。取り込み側は raw の manifest 経由（GitHub構造含め設計）。B方式（per-collection manifest）で実装。

Refs #1814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new import action for collection registry entries.
  * Imported collections can now be installed into a workspace with provenance tracking and seed data handling.
  * The app now documents the new import endpoint in its API routing.

* **Bug Fixes**
  * Added validation for required import details and clearer error responses for missing, invalid, or conflicting imports.
  * Re-importing the same collection now updates it cleanly and avoids duplicating existing seed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->