### PR TITLE
feat(collections): Discover tab — browse & import registry collections

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -2,10 +2,33 @@
   <div class="h-full overflow-y-auto bg-slate-50/50 px-6 py-6" data-testid="collections-view-root">
     <div class="max-w-4xl mx-auto">
       <div class="flex items-center justify-between mb-6">
-        <h1 class="text-xl font-semibold text-slate-800">
-          {{ t("collectionsView.title") }}
-        </h1>
+        <div class="flex items-center gap-4">
+          <h1 class="text-xl font-semibold text-slate-800">
+            {{ t("collectionsView.title") }}
+          </h1>
+          <div class="flex items-center gap-0.5 rounded-lg bg-slate-100 p-0.5">
+            <button
+              type="button"
+              class="px-3 h-7 rounded-md text-xs font-semibold transition-colors"
+              :class="tab === 'installed' ? 'bg-white text-indigo-700 shadow-sm' : 'text-slate-500 hover:text-slate-700'"
+              data-testid="collections-tab-installed"
+              @click="tab = 'installed'"
+            >
+              {{ t("collectionsView.discover.installedTab") }}
+            </button>
+            <button
+              type="button"
+              class="px-3 h-7 rounded-md text-xs font-semibold transition-colors"
+              :class="tab === 'discover' ? 'bg-white text-teal-700 shadow-sm' : 'text-slate-500 hover:text-slate-700'"
+              data-testid="collections-tab-discover"
+              @click="tab = 'discover'"
+            >
+              {{ t("collectionsView.discover.tab") }}
+            </button>
+          </div>
+        </div>
         <button
+          v-if="tab === 'installed'"
           type="button"
           class="h-8 px-2.5 flex items-center gap-1 rounded bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs transition-colors shadow-sm"
           data-testid="collections-add-collection"
@@ -16,72 +39,75 @@
         </button>
       </div>
 
-      <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">
-        <div class="h-8 w-8 border-2 border-indigo-600/20 border-t-indigo-600 rounded-full animate-spin"></div>
-        <span>{{ t("common.loading") }}</span>
-      </div>
+      <DiscoverPanel v-if="tab === 'discover'" />
+      <template v-else>
+        <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">
+          <div class="h-8 w-8 border-2 border-indigo-600/20 border-t-indigo-600 rounded-full animate-spin"></div>
+          <span>{{ t("common.loading") }}</span>
+        </div>
 
-      <div v-else-if="loadError" class="rounded-xl border border-red-200 bg-red-50/50 p-4 text-sm text-red-800 shadow-sm flex items-center gap-3">
-        <span class="material-icons text-red-600">error</span>
-        <span>{{ t("collectionsView.loadFailed") }}: {{ loadError }}</span>
-      </div>
+        <div v-else-if="loadError" class="rounded-xl border border-red-200 bg-red-50/50 p-4 text-sm text-red-800 shadow-sm flex items-center gap-3">
+          <span class="material-icons text-red-600">error</span>
+          <span>{{ t("collectionsView.loadFailed") }}: {{ loadError }}</span>
+        </div>
 
-      <div v-else-if="collections.length === 0" class="rounded-xl border border-slate-200 bg-white px-6 py-12 text-center text-sm text-slate-500 shadow-sm">
-        <span class="material-icons text-4xl text-slate-300 mb-2">dashboard_customize</span>
-        <p class="font-medium text-slate-700">{{ t("collectionsView.indexEmpty") }}</p>
-      </div>
+        <div v-else-if="collections.length === 0" class="rounded-xl border border-slate-200 bg-white px-6 py-12 text-center text-sm text-slate-500 shadow-sm">
+          <span class="material-icons text-4xl text-slate-300 mb-2">dashboard_customize</span>
+          <p class="font-medium text-slate-700">{{ t("collectionsView.indexEmpty") }}</p>
+        </div>
 
-      <div v-else class="grid gap-4 sm:grid-cols-2">
-        <div
-          v-for="collection in collections"
-          :key="collection.slug"
-          class="group relative rounded-xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md hover:border-indigo-300 transition-all duration-300 cursor-pointer flex items-center gap-4 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
-          role="button"
-          tabindex="0"
-          :aria-label="t('collectionsView.openCollection', { title: collection.title })"
-          :data-testid="`collections-index-card-${collection.slug}`"
-          @click="openCollection(collection.slug)"
-          @keydown.enter.self="openCollection(collection.slug)"
-          @keydown.space.self.prevent="openCollection(collection.slug)"
-        >
-          <!-- Left border color line showing source -->
+        <div v-else class="grid gap-4 sm:grid-cols-2">
           <div
-            class="absolute left-0 top-0 bottom-0 w-1 rounded-l-xl transition-all duration-300 group-hover:w-1.5"
-            :class="collection.source === 'project' ? 'bg-indigo-600' : 'bg-violet-600'"
-          ></div>
-
-          <!-- Styled icon badge -->
-          <div
-            class="h-12 w-12 flex items-center justify-center rounded-xl transition-all duration-300 group-hover:scale-105 shadow-sm"
-            :class="
-              collection.source === 'project'
-                ? 'bg-indigo-50 text-indigo-600 group-hover:bg-indigo-100/80 border border-indigo-100/50'
-                : 'bg-violet-50 text-violet-600 group-hover:bg-violet-100/80 border border-violet-100/50'
-            "
+            v-for="collection in collections"
+            :key="collection.slug"
+            class="group relative rounded-xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md hover:border-indigo-300 transition-all duration-300 cursor-pointer flex items-center gap-4 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
+            role="button"
+            tabindex="0"
+            :aria-label="t('collectionsView.openCollection', { title: collection.title })"
+            :data-testid="`collections-index-card-${collection.slug}`"
+            @click="openCollection(collection.slug)"
+            @keydown.enter.self="openCollection(collection.slug)"
+            @keydown.space.self.prevent="openCollection(collection.slug)"
           >
-            <span class="material-symbols-outlined text-2xl">{{ collection.icon }}</span>
-          </div>
+            <!-- Left border color line showing source -->
+            <div
+              class="absolute left-0 top-0 bottom-0 w-1 rounded-l-xl transition-all duration-300 group-hover:w-1.5"
+              :class="collection.source === 'project' ? 'bg-indigo-600' : 'bg-violet-600'"
+            ></div>
 
-          <div class="flex-1 min-w-0">
-            <span class="block font-semibold text-slate-800 text-[15px] group-hover:text-indigo-950 transition-colors truncate">
-              {{ collection.title }}
-            </span>
-            <span class="block text-[10px] text-slate-400 mt-1 tracking-wider font-semibold uppercase flex items-center gap-1.5">
-              <span class="h-1.5 w-1.5 rounded-full" :class="collection.source === 'project' ? 'bg-indigo-500' : 'bg-violet-500'"></span>
-              {{ t(`collectionsView.source.${collection.source}`) }} ·
-              <code class="text-[10px] bg-slate-100 px-1 rounded lowercase text-slate-500 font-mono font-normal">{{ collection.slug }}</code>
-            </span>
-          </div>
+            <!-- Styled icon badge -->
+            <div
+              class="h-12 w-12 flex items-center justify-center rounded-xl transition-all duration-300 group-hover:scale-105 shadow-sm"
+              :class="
+                collection.source === 'project'
+                  ? 'bg-indigo-50 text-indigo-600 group-hover:bg-indigo-100/80 border border-indigo-100/50'
+                  : 'bg-violet-50 text-violet-600 group-hover:bg-violet-100/80 border border-violet-100/50'
+              "
+            >
+              <span class="material-symbols-outlined text-2xl">{{ collection.icon }}</span>
+            </div>
 
-          <component :is="pinToggle" kind="collection" :slug="collection.slug" :title="collection.title" :icon="collection.icon" />
+            <div class="flex-1 min-w-0">
+              <span class="block font-semibold text-slate-800 text-[15px] group-hover:text-indigo-950 transition-colors truncate">
+                {{ collection.title }}
+              </span>
+              <span class="block text-[10px] text-slate-400 mt-1 tracking-wider font-semibold uppercase flex items-center gap-1.5">
+                <span class="h-1.5 w-1.5 rounded-full" :class="collection.source === 'project' ? 'bg-indigo-500' : 'bg-violet-500'"></span>
+                {{ t(`collectionsView.source.${collection.source}`) }} ·
+                <code class="text-[10px] bg-slate-100 px-1 rounded lowercase text-slate-500 font-mono font-normal">{{ collection.slug }}</code>
+              </span>
+            </div>
 
-          <div
-            class="h-8 w-8 flex items-center justify-center rounded-lg bg-slate-50 group-hover:bg-indigo-50 text-slate-400 group-hover:text-indigo-600 transition-all duration-300"
-          >
-            <span class="material-icons text-lg transition-transform duration-300 group-hover:translate-x-0.5">chevron_right</span>
+            <component :is="pinToggle" kind="collection" :slug="collection.slug" :title="collection.title" :icon="collection.icon" />
+
+            <div
+              class="h-8 w-8 flex items-center justify-center rounded-lg bg-slate-50 group-hover:bg-indigo-50 text-slate-400 group-hover:text-indigo-600 transition-all duration-300"
+            >
+              <span class="material-icons text-lg transition-transform duration-300 group-hover:translate-x-0.5">chevron_right</span>
+            </div>
           </div>
         </div>
-      </div>
+      </template>
     </div>
   </div>
 </template>
@@ -90,6 +116,7 @@
 import { onMounted, ref } from "vue";
 import { useCollectionI18n } from "../lang";
 import { collectionUi } from "../uiContext";
+import DiscoverPanel from "./DiscoverPanel.vue";
 import type { CollectionSummary } from "@mulmoclaude/core/collection";
 
 const { t } = useCollectionI18n();
@@ -97,6 +124,7 @@ const { t } = useCollectionI18n();
 const cui = collectionUi();
 const { pinToggle, reconcileShortcuts } = cui;
 
+const tab = ref<"installed" | "discover">("installed");
 const collections = ref<CollectionSummary[]>([]);
 const loading = ref(true);
 const loadError = ref<string | null>(null);

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -39,7 +39,7 @@
         </button>
       </div>
 
-      <DiscoverPanel v-if="tab === 'discover'" />
+      <DiscoverPanel v-if="tab === 'discover'" @imported="loadCollections" />
       <template v-else>
         <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">
           <div class="h-8 w-8 border-2 border-indigo-600/20 border-t-indigo-600 rounded-full animate-spin"></div>

--- a/packages/plugins/collection-plugin/src/vue/components/DiscoverPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/DiscoverPanel.vue
@@ -1,0 +1,141 @@
+<template>
+  <div data-testid="discover-panel">
+    <div v-if="loading" class="flex flex-col items-center justify-center py-20 text-sm text-slate-500 gap-3">
+      <div class="h-8 w-8 border-2 border-teal-600/20 border-t-teal-600 rounded-full animate-spin"></div>
+      <span>{{ t("common.loading") }}</span>
+    </div>
+
+    <div v-else-if="loadError" class="rounded-xl border border-red-200 bg-red-50/50 p-4 text-sm text-red-800 shadow-sm flex items-center gap-3">
+      <span class="material-icons text-red-600">error</span>
+      <span>{{ t("collectionsView.discover.loadFailed") }}: {{ loadError }}</span>
+    </div>
+
+    <div v-else-if="entries.length === 0" class="rounded-xl border border-slate-200 bg-white px-6 py-12 text-center text-sm text-slate-500 shadow-sm">
+      <span class="material-icons text-4xl text-slate-300 mb-2">travel_explore</span>
+      <p class="font-medium text-slate-700">{{ t("collectionsView.discover.empty") }}</p>
+    </div>
+
+    <div v-else class="grid gap-4 sm:grid-cols-2">
+      <div
+        v-for="entry in entries"
+        :key="entry.id"
+        class="relative rounded-xl border border-slate-200 bg-white p-5 shadow-sm flex flex-col gap-3"
+        :data-testid="`discover-card-${entry.slug}`"
+      >
+        <div class="absolute left-0 top-0 bottom-0 w-1 rounded-l-xl bg-teal-500"></div>
+        <div class="flex items-center gap-3">
+          <div class="h-11 w-11 flex items-center justify-center rounded-xl bg-teal-50 text-teal-600 border border-teal-100/50 shadow-sm shrink-0">
+            <span class="material-symbols-outlined text-2xl">{{ entry.icon || "dataset" }}</span>
+          </div>
+          <div class="flex-1 min-w-0">
+            <span class="block font-semibold text-slate-800 text-[15px] truncate">{{ entry.title }}</span>
+            <span class="block text-[11px] text-slate-400 mt-0.5 truncate">
+              {{ t("collectionsView.discover.by", { author: entry.author }) }} ·
+              <code class="bg-slate-100 px-1 rounded text-slate-500 font-mono">{{ entry.slug }}</code>
+            </span>
+          </div>
+        </div>
+
+        <p v-if="entry.description" class="text-xs text-slate-500 leading-relaxed line-clamp-2">{{ entry.description }}</p>
+
+        <div class="flex items-center gap-2 text-[10px] text-slate-400 uppercase tracking-wider font-semibold flex-wrap">
+          <span>{{ t("collectionsView.discover.fields", { count: entry.fieldCount }) }}</span>
+          <span v-if="entry.views.length" class="text-teal-600">· {{ entry.views.join(" · ") }}</span>
+          <span v-if="entry.hasSeed">· {{ t("collectionsView.discover.samples", { count: entry.seedCount }) }}</span>
+        </div>
+
+        <div class="flex items-center justify-between pt-1 border-t border-slate-100">
+          <span class="text-[10px] text-slate-400 font-mono">v{{ entry.version }}</span>
+          <div class="flex items-center gap-2">
+            <span v-if="stateOf(entry).status === 'error'" class="text-[11px] text-red-600" :data-testid="`discover-error-${entry.slug}`">
+              {{ stateOf(entry).error }}
+            </span>
+            <button
+              v-if="stateOf(entry).status === 'done'"
+              type="button"
+              class="h-7 px-2.5 flex items-center gap-1 rounded text-teal-700 hover:bg-teal-50 font-semibold text-xs transition-colors"
+              :data-testid="`discover-open-${entry.slug}`"
+              @click="openImported(entry)"
+            >
+              <span class="material-icons text-sm">north_east</span>
+              <span
+                >{{ stateOf(entry).updated ? t("collectionsView.discover.updated") : t("collectionsView.discover.imported") }} ·
+                {{ t("collectionsView.discover.open") }}</span
+              >
+            </button>
+            <button
+              v-else
+              type="button"
+              class="h-7 px-3 flex items-center gap-1 rounded bg-teal-600 hover:bg-teal-700 disabled:opacity-50 text-white font-bold text-xs transition-colors shadow-sm"
+              :disabled="stateOf(entry).status === 'importing'"
+              :data-testid="`discover-import-${entry.slug}`"
+              @click="doImport(entry)"
+            >
+              <span v-if="stateOf(entry).status === 'importing'" class="h-3 w-3 border-2 border-white/30 border-t-white rounded-full animate-spin"></span>
+              <span v-else class="material-icons text-sm">download</span>
+              <span>{{ stateOf(entry).status === "importing" ? t("collectionsView.discover.importing") : t("collectionsView.discover.import") }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useCollectionI18n } from "../lang";
+import { collectionUi, type RegistryEntry } from "../uiContext";
+
+const { t } = useCollectionI18n();
+const cui = collectionUi();
+
+interface ImportState {
+  status: "idle" | "importing" | "done" | "error";
+  localSlug?: string;
+  updated?: boolean;
+  error?: string;
+}
+
+const entries = ref<RegistryEntry[]>([]);
+const loading = ref(true);
+const loadError = ref<string | null>(null);
+const importStates = ref<Record<string, ImportState>>({});
+
+function stateOf(entry: RegistryEntry): ImportState {
+  return importStates.value[entry.id] ?? { status: "idle" };
+}
+
+function setState(entry: RegistryEntry, state: ImportState): void {
+  importStates.value = { ...importStates.value, [entry.id]: state };
+}
+
+async function load(): Promise<void> {
+  loading.value = true;
+  loadError.value = null;
+  const result = await cui.listRegistry();
+  loading.value = false;
+  if (!result.ok) {
+    loadError.value = result.error;
+    return;
+  }
+  entries.value = result.data.collections;
+}
+
+async function doImport(entry: RegistryEntry): Promise<void> {
+  setState(entry, { status: "importing" });
+  const result = await cui.importRegistry(entry.author, entry.slug);
+  if (!result.ok) {
+    setState(entry, { status: "error", error: result.error });
+    return;
+  }
+  setState(entry, { status: "done", localSlug: result.data.localSlug, updated: result.data.updated });
+}
+
+function openImported(entry: RegistryEntry): void {
+  const state = stateOf(entry);
+  if (state.localSlug) cui.gotoDetail("collection", state.localSlug);
+}
+
+onMounted(load);
+</script>

--- a/packages/plugins/collection-plugin/src/vue/components/DiscoverPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/DiscoverPanel.vue
@@ -89,6 +89,9 @@ import { collectionUi, type RegistryEntry } from "../uiContext";
 
 const { t } = useCollectionI18n();
 const cui = collectionUi();
+// Emitted after a successful import so the parent can refresh its installed list
+// (the newly-installed collection should show up on the Installed tab right away).
+const emit = defineEmits<{ imported: [] }>();
 
 interface ImportState {
   status: "idle" | "importing" | "done" | "error";
@@ -130,6 +133,7 @@ async function doImport(entry: RegistryEntry): Promise<void> {
     return;
   }
   setState(entry, { status: "done", localSlug: result.data.localSlug, updated: result.data.updated });
+  emit("imported");
 }
 
 function openImported(entry: RegistryEntry): void {

--- a/packages/plugins/collection-plugin/src/vue/index.ts
+++ b/packages/plugins/collection-plugin/src/vue/index.ts
@@ -32,6 +32,9 @@ export {
   type CollectionViewSrcdocBoot,
   type CollectionActionResult,
   type CollectionRefreshResult,
+  type RegistryEntry,
+  type RegistryListResponse,
+  type RegistryImportResponse,
 } from "./uiContext";
 export { useCollectionRendering, type CollectionRendering } from "./useCollectionRendering";
 export {

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const deMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "Entdecken",
+      installedTab: "Installiert",
+      empty: "Noch keine Sammlungen im Registry verfügbar.",
+      loadFailed: "Registry konnte nicht geladen werden",
+      by: "von {author}",
+      fields: "{count} Felder",
+      samples: "{count} Beispiele",
+      import: "Importieren",
+      importing: "Wird importiert…",
+      imported: "Importiert",
+      updated: "Aktualisiert",
+      open: "Öffnen",
+    },
     addCollectionLabel: "Sammlung",
     addCollectionPrompt:
       "Hilf mir, eine neue Sammlung zu erstellen. Lies zuerst `config/helps/collection-skills.md` für die Konventionen schemabasierter Sammlungen. Verwende dann das Tool `presentForm` (nutze nicht AskUserQuestion), um mich zu fragen, welche Art von Daten ich verfolgen möchte, und erstelle die schema.json und SKILL.md aus meinen Antworten.",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -2,6 +2,20 @@
 // i18n migration. The plugin owns its own copy so it uses NO host i18n resources.
 const enMessages = {
   collectionsView: {
+    discover: {
+      tab: "Discover",
+      installedTab: "Installed",
+      empty: "No collections available in the registry yet.",
+      loadFailed: "Couldn't load the registry",
+      by: "by {author}",
+      fields: "{count} fields",
+      samples: "{count} samples",
+      import: "Import",
+      importing: "Importing…",
+      imported: "Imported",
+      updated: "Updated",
+      open: "Open",
+    },
     addCollectionLabel: "Collection",
     addCollectionPrompt:
       "Help me create a new collection. First read `config/helps/collection-skills.md` for the schema-driven collection conventions. Then use the `presentForm` tool (do not use AskUserQuestion) to ask me what kind of data I want to track, and author the schema.json and SKILL.md from my answers.",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const esMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "Descubrir",
+      installedTab: "Instaladas",
+      empty: "Aún no hay colecciones disponibles en el registro.",
+      loadFailed: "No se pudo cargar el registro",
+      by: "por {author}",
+      fields: "{count} campos",
+      samples: "{count} ejemplos",
+      import: "Importar",
+      importing: "Importando…",
+      imported: "Importada",
+      updated: "Actualizada",
+      open: "Abrir",
+    },
     addCollectionLabel: "Colección",
     addCollectionPrompt:
       "Ayúdame a crear una nueva colección. Primero lee `config/helps/collection-skills.md` para conocer las convenciones de las colecciones basadas en esquemas. Luego usa la herramienta `presentForm` (no uses AskUserQuestion) para preguntarme qué tipo de datos quiero registrar, y crea el schema.json y el SKILL.md a partir de mis respuestas.",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const frMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "Découvrir",
+      installedTab: "Installées",
+      empty: "Aucune collection disponible dans le registre pour l'instant.",
+      loadFailed: "Impossible de charger le registre",
+      by: "par {author}",
+      fields: "{count} champs",
+      samples: "{count} exemples",
+      import: "Importer",
+      importing: "Importation…",
+      imported: "Importée",
+      updated: "Mise à jour",
+      open: "Ouvrir",
+    },
     addCollectionLabel: "Collection",
     addCollectionPrompt:
       "Aide-moi à créer une nouvelle collection. Lis d'abord `config/helps/collection-skills.md` pour les conventions des collections basées sur un schéma. Utilise ensuite l'outil `presentForm` (n'utilise pas AskUserQuestion) pour me demander quel type de données je veux suivre, et crée le schema.json et le SKILL.md à partir de mes réponses.",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const jaMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "発見",
+      installedTab: "インストール済み",
+      empty: "レジストリに利用可能なコレクションがまだありません。",
+      loadFailed: "レジストリを読み込めませんでした",
+      by: "作者: {author}",
+      fields: "{count} フィールド",
+      samples: "サンプル {count} 件",
+      import: "取り込む",
+      importing: "取り込み中…",
+      imported: "取り込み済み",
+      updated: "更新済み",
+      open: "開く",
+    },
     addCollectionLabel: "コレクション",
     addCollectionPrompt:
       "新しいコレクションを作成したいです。まず `config/helps/collection-skills.md` を読んでスキーマ駆動コレクションの規約を確認してください。次に `presentForm` ツールを使って（AskUserQuestion は使わないで）どんなデータを管理したいか質問し、その回答をもとに schema.json と SKILL.md を作成してください。",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const koMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "둘러보기",
+      installedTab: "설치됨",
+      empty: "레지스트리에 사용 가능한 컬렉션이 아직 없습니다.",
+      loadFailed: "레지스트리를 불러오지 못했습니다",
+      by: "작성자: {author}",
+      fields: "필드 {count}개",
+      samples: "샘플 {count}개",
+      import: "가져오기",
+      importing: "가져오는 중…",
+      imported: "가져옴",
+      updated: "업데이트됨",
+      open: "열기",
+    },
     addCollectionLabel: "컬렉션",
     addCollectionPrompt:
       "새 컬렉션을 만들고 싶어요. 먼저 `config/helps/collection-skills.md`를 읽고 스키마 기반 컬렉션 규칙을 확인하세요. 그런 다음 `presentForm` 도구를 사용해(AskUserQuestion은 사용하지 말고) 어떤 데이터를 관리하고 싶은지 물어보고, 제 답변을 바탕으로 schema.json과 SKILL.md를 작성해 주세요.",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const ptBRMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "Descobrir",
+      installedTab: "Instaladas",
+      empty: "Ainda não há coleções disponíveis no registro.",
+      loadFailed: "Não foi possível carregar o registro",
+      by: "por {author}",
+      fields: "{count} campos",
+      samples: "{count} amostras",
+      import: "Importar",
+      importing: "Importando…",
+      imported: "Importada",
+      updated: "Atualizada",
+      open: "Abrir",
+    },
     addCollectionLabel: "Coleção",
     addCollectionPrompt:
       "Ajude-me a criar uma nova coleção. Primeiro leia `config/helps/collection-skills.md` para conhecer as convenções de coleções baseadas em esquema. Depois use a ferramenta `presentForm` (não use AskUserQuestion) para perguntar que tipo de dados quero acompanhar, e crie o schema.json e o SKILL.md a partir das minhas respostas.",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -4,6 +4,20 @@ import type { CollectionMessages } from "./en";
 
 const zhMessages: CollectionMessages = {
   collectionsView: {
+    discover: {
+      tab: "发现",
+      installedTab: "已安装",
+      empty: "注册表中暂无可用集合。",
+      loadFailed: "无法加载注册表",
+      by: "作者：{author}",
+      fields: "{count} 个字段",
+      samples: "{count} 个示例",
+      import: "导入",
+      importing: "导入中…",
+      imported: "已导入",
+      updated: "已更新",
+      open: "打开",
+    },
     addCollectionLabel: "集合",
     addCollectionPrompt:
       "帮我创建一个新的集合。请先阅读 `config/helps/collection-skills.md` 了解基于 schema 的集合约定。然后使用 `presentForm` 工具（不要使用 AskUserQuestion）询问我想跟踪哪种数据，并根据我的回答编写 schema.json 和 SKILL.md。",

--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -78,6 +78,43 @@ export interface CollectionConfirmOptions {
   variant?: "primary" | "success" | "danger";
 }
 
+/** One collection in the curated registry's published index (the host fetches the
+ *  registry's index.json and proxies it to the Discover tab). */
+export interface RegistryEntry {
+  id: string;
+  author: string;
+  slug: string;
+  title: string;
+  icon: string;
+  description: string;
+  version: string;
+  tags: string[];
+  license: string;
+  fieldCount: number;
+  views: string[];
+  hasSeed: boolean;
+  seedCount: number;
+  screenshot?: string;
+  path: string;
+  contentSha: string;
+}
+
+/** `GET …collectionsRegistry.list` — the Discover catalog. */
+export interface RegistryListResponse {
+  registry: string;
+  generatedAt: string;
+  stale: boolean;
+  collections: RegistryEntry[];
+}
+
+/** `POST …collectionsRegistry.import` — install result. */
+export interface RegistryImportResponse {
+  localSlug: string;
+  updated: boolean;
+  seedWritten: number;
+  seedSkipped: boolean;
+}
+
 export interface CollectionUi {
   /** Fetch a collection's detail (schema + records) by slug — backs both the
    *  View's own load (reads `status` for 404 → not-found) and ref/embed
@@ -162,6 +199,12 @@ export interface CollectionUi {
   listCollections: () => Promise<CollectionApiResult<CollectionsListResponse>>;
   /** List feed-backed collections (`apiGet` over `…feeds.list`). */
   listFeeds: () => Promise<CollectionApiResult<FeedsListResponse>>;
+  /** List the curated registry's collections for the Discover tab (`apiGet` over
+   *  `…collectionsRegistry.list`). */
+  listRegistry: () => Promise<CollectionApiResult<RegistryListResponse>>;
+  /** Import a registry collection by author+slug (`apiPost` over
+   *  `…collectionsRegistry.import`). */
+  importRegistry: (author: string, slug: string) => Promise<CollectionApiResult<RegistryImportResponse>>;
   /** Bulk-reconcile pinned launcher shortcuts of one kind against the
    *  authoritative list — prune dead slugs, refresh stale labels
    *  (`useShortcuts().reconcile`). */

--- a/src/composables/collections/uiHost.ts
+++ b/src/composables/collections/uiHost.ts
@@ -10,7 +10,7 @@
 // they're deferred behind `installCollectionAppBindings`, which App.vue calls in
 // its setup (see App.vue). Until it does, `startChat` is a no-op and
 // `notifiedSeverities` returns an empty map.
-import { configureCollectionUi, type CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
+import { configureCollectionUi, type CollectionViewToken, type RegistryListResponse, type RegistryImportResponse } from "@mulmoclaude/collection-plugin/vue";
 // The package's compiled Tailwind classes — the library build extracts the SFCs'
 // styles into this file rather than injecting them, and node_modules isn't in
 // this host's Tailwind content scan, so the classes must be loaded explicitly.
@@ -132,6 +132,8 @@ configureCollectionUi({
   // index pages
   listCollections: () => apiGet<CollectionsListResponse>(API_ROUTES.collections.list),
   listFeeds: () => apiGet<FeedsListResponse>(API_ROUTES.feeds.list),
+  listRegistry: () => apiGet<RegistryListResponse>(API_ROUTES.collectionsRegistry.list),
+  importRegistry: (author, slug) => apiPost<RegistryImportResponse>(API_ROUTES.collectionsRegistry.import, { author, slug }),
   reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
 
   // app integration


### PR DESCRIPTION
## Summary

The clickable web UI for the curated collection registry (#1814). Adds a **Discover** tab to `/collections` that lists the registry's collections and imports one with a click — making the whole feature web-testable end-to-end.

Backend (list/preview/import) shipped in #1815 + #1817; this is the frontend.

## What it does
- A tab toggle (**Installed** / **Discover**) in the `/collections` header.
- **Discover** loads the registry via `GET /api/collections-registry` and renders cards (title, icon, author, description, field/view/seed counts, version).
- **Import** button → `POST /api/collections-registry/import` with per-card state: idle → importing → imported/updated (+ **Open** → jumps to `/collections/<slug>`) or error.

## Implementation
- `DiscoverPanel.vue` (new) — the catalog grid + per-card import state.
- `CollectionsIndexView.vue` — tab toggle; renders the existing installed grid or `<DiscoverPanel>`.
- `listRegistry` + `importRegistry` added to the `CollectionUi` host binding (`uiContext.ts` interface + `uiHost.ts` impl over `API_ROUTES.collectionsRegistry`).
- i18n: `collectionsView.discover.*` added across **all 8 locales** (type-enforced lockstep).

## Items to Confirm / Review
- No per-card **preview** call in v1 — the index entry already carries title/icon/description/fieldCount/views, so cards render from the list. (A full schema preview can be a follow-up.)
- 409 (slug occupied by a different collection) surfaces as the per-card error text.

## Verification
`yarn typecheck` / `yarn build` / `yarn lint` all green. `data-testid`s added for e2e (`collections-tab-discover`, `discover-card-<slug>`, `discover-import-<slug>`, …).

Refs #1814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Discover tab to Collections with a dedicated browsing panel that loads curated registry entries and lets users import items and open successfully imported collections.
  * The panel includes loading, empty, and error states, plus per-item import status feedback (importing/done/error) and updated/version details.
* **Bug Fixes**
  * Improved the Collections header layout so the title and tab controls align more cleanly, with the add-collection button scoped to the installed tab.
* **Documentation**
  * Added localized Discover UI text across supported languages (tabs, statuses, and action labels).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->