### PR TITLE
feat(collections): rename-on-collision import (R8) + 'imported as' label

### DIFF
--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",

--- a/packages/plugins/collection-plugin/src/vue/components/DiscoverPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/DiscoverPanel.vue
@@ -58,10 +58,7 @@
               @click="openImported(entry)"
             >
               <span class="material-icons text-sm">north_east</span>
-              <span
-                >{{ stateOf(entry).updated ? t("collectionsView.discover.updated") : t("collectionsView.discover.imported") }} ·
-                {{ t("collectionsView.discover.open") }}</span
-              >
+              <span>{{ doneLabel(entry) }} · {{ t("collectionsView.discover.open") }}</span>
             </button>
             <button
               v-else
@@ -111,6 +108,14 @@ function stateOf(entry: RegistryEntry): ImportState {
 
 function setState(entry: RegistryEntry, state: ImportState): void {
   importStates.value = { ...importStates.value, [entry.id]: state };
+}
+
+// "Imported as movies-2" when the install was renamed to avoid clobbering an
+// existing same-named collection; otherwise "Imported" / "Updated".
+function doneLabel(entry: RegistryEntry): string {
+  const state = stateOf(entry);
+  if (state.localSlug && state.localSlug !== entry.slug) return t("collectionsView.discover.importedAs", { slug: state.localSlug });
+  return state.updated ? t("collectionsView.discover.updated") : t("collectionsView.discover.imported");
 }
 
 async function load(): Promise<void> {

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -15,6 +15,7 @@ const deMessages: CollectionMessages = {
       import: "Importieren",
       importing: "Wird importiert…",
       imported: "Importiert",
+      importedAs: "Importiert als {slug}",
       updated: "Aktualisiert",
       open: "Öffnen",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -13,6 +13,7 @@ const enMessages = {
       import: "Import",
       importing: "Importing…",
       imported: "Imported",
+      importedAs: "Imported as {slug}",
       updated: "Updated",
       open: "Open",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -15,6 +15,7 @@ const esMessages: CollectionMessages = {
       import: "Importar",
       importing: "Importando…",
       imported: "Importada",
+      importedAs: "Importada como {slug}",
       updated: "Actualizada",
       open: "Abrir",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -15,6 +15,7 @@ const frMessages: CollectionMessages = {
       import: "Importer",
       importing: "Importation…",
       imported: "Importée",
+      importedAs: "Importée comme {slug}",
       updated: "Mise à jour",
       open: "Ouvrir",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -15,6 +15,7 @@ const jaMessages: CollectionMessages = {
       import: "取り込む",
       importing: "取り込み中…",
       imported: "取り込み済み",
+      importedAs: "{slug} として取り込み",
       updated: "更新済み",
       open: "開く",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -15,6 +15,7 @@ const koMessages: CollectionMessages = {
       import: "가져오기",
       importing: "가져오는 중…",
       imported: "가져옴",
+      importedAs: "{slug}(으)로 가져옴",
       updated: "업데이트됨",
       open: "열기",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -15,6 +15,7 @@ const ptBRMessages: CollectionMessages = {
       import: "Importar",
       importing: "Importando…",
       imported: "Importada",
+      importedAs: "Importada como {slug}",
       updated: "Atualizada",
       open: "Abrir",
     },

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -15,6 +15,7 @@ const zhMessages: CollectionMessages = {
       import: "导入",
       importing: "导入中…",
       imported: "已导入",
+      importedAs: "已导入为 {slug}",
       updated: "已更新",
       open: "打开",
     },

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -77,29 +77,48 @@ async function readOrigin(targetDir: string): Promise<unknown> {
 
 type TargetResolution = { targetDir: string; localSlug: string; updated: boolean } | { conflict: string };
 
-const MAX_SLUG_ATTEMPTS = 50;
+// Only bounds the fresh-slug search (a safety cap, far above any realistic number of
+// same-named collections — the first free slug is normally found in 1–2 iterations).
+// An EXISTING install is found via the directory scan below, not this loop, so updates
+// are never missed regardless of how high the rename suffix is.
+const MAX_SLUG_ATTEMPTS = 10000;
 
-// Pick the local install slug (rename-on-collision, R8): the registry slug, else
-// `<slug>-2`, `<slug>-3`, … An existing dir whose `.origin.json` matches this
-// registry collection is a re-import (update); a foreign dir or a non-directory at
-// the path is skipped to the next candidate, so a user's own same-named collection
-// is never clobbered and the import still succeeds under a free slug.
-async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
-  // Scan all candidate slugs once: an existing install whose origin matches this
-  // registry collection is updated in place (even if an earlier slug is now free —
-  // otherwise a re-import would duplicate the install). Only when no matching install
-  // exists do we install fresh at the first free slug.
-  let firstFree: { targetDir: string; localSlug: string } | null = null;
-  for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
-    const localSlug = attempt === 0 ? entry.slug : `${entry.slug}-${attempt + 1}`;
-    const targetDir = projectSkillDir(workspaceRoot, localSlug);
-    const kind = await statType(targetDir);
-    if (kind === "dir" && originMatches(await readOrigin(targetDir), registry, entry.author, entry.slug)) {
-      return { targetDir, localSlug, updated: true };
-    }
-    if (kind === "absent" && firstFree === null) firstFree = { targetDir, localSlug };
+const renameCandidate = (slug: string, attempt: number): string => (attempt === 0 ? slug : `${slug}-${attempt + 1}`);
+
+// True when `name` is the registry slug or a `<slug>-<n>` rename of it.
+function isRenameOf(name: string, slug: string): boolean {
+  if (name === slug) return true;
+  if (!name.startsWith(`${slug}-`)) return false;
+  const suffix = name.slice(slug.length + 1);
+  return suffix.length > 0 && /^\d+$/.test(suffix);
+}
+
+// Find an existing install of this registry collection at ANY rename suffix by scanning
+// the active skills dir — independent of any candidate bound, so a re-import always
+// updates the existing install rather than duplicating it (even if an earlier slug freed up).
+async function findMatchingInstall(skillsDir: string, registry: string, entry: RegistryCollectionEntry): Promise<string | null> {
+  const names = await readdir(skillsDir).catch(() => [] as string[]);
+  for (const name of names) {
+    if (!isRenameOf(name, entry.slug)) continue;
+    const dir = path.join(skillsDir, name);
+    if ((await statType(dir)) === "dir" && originMatches(await readOrigin(dir), registry, entry.author, entry.slug)) return name;
   }
-  if (firstFree) return { ...firstFree, updated: false };
+  return null;
+}
+
+// Pick the local install slug (rename-on-collision, R8). First reuse an existing matching
+// install (update). Otherwise install fresh at the first free slug — the registry slug,
+// else `<slug>-2`, `-3`, … — never clobbering a user's own same-named collection.
+async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
+  const skillsDir = path.dirname(projectSkillDir(workspaceRoot, entry.slug));
+  const existing = await findMatchingInstall(skillsDir, registry, entry);
+  if (existing) return { targetDir: projectSkillDir(workspaceRoot, existing), localSlug: existing, updated: true };
+  for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
+    const localSlug = renameCandidate(entry.slug, attempt);
+    if ((await statType(projectSkillDir(workspaceRoot, localSlug))) === "absent") {
+      return { targetDir: projectSkillDir(workspaceRoot, localSlug), localSlug, updated: false };
+    }
+  }
   return { conflict: `couldn't find an available slug for '${entry.slug}'` };
 }
 

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -85,15 +85,21 @@ const MAX_SLUG_ATTEMPTS = 50;
 // the path is skipped to the next candidate, so a user's own same-named collection
 // is never clobbered and the import still succeeds under a free slug.
 async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
+  // Scan all candidate slugs once: an existing install whose origin matches this
+  // registry collection is updated in place (even if an earlier slug is now free —
+  // otherwise a re-import would duplicate the install). Only when no matching install
+  // exists do we install fresh at the first free slug.
+  let firstFree: { targetDir: string; localSlug: string } | null = null;
   for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
     const localSlug = attempt === 0 ? entry.slug : `${entry.slug}-${attempt + 1}`;
     const targetDir = projectSkillDir(workspaceRoot, localSlug);
     const kind = await statType(targetDir);
-    if (kind === "absent") return { targetDir, localSlug, updated: false };
     if (kind === "dir" && originMatches(await readOrigin(targetDir), registry, entry.author, entry.slug)) {
       return { targetDir, localSlug, updated: true };
     }
+    if (kind === "absent" && firstFree === null) firstFree = { targetDir, localSlug };
   }
+  if (firstFree) return { ...firstFree, updated: false };
   return { conflict: `couldn't find an available slug for '${entry.slug}'` };
 }
 

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -75,15 +75,26 @@ async function readOrigin(targetDir: string): Promise<unknown> {
   }
 }
 
-type TargetResolution = { targetDir: string; updated: boolean } | { conflict: string };
+type TargetResolution = { targetDir: string; localSlug: string; updated: boolean } | { conflict: string };
 
+const MAX_SLUG_ATTEMPTS = 50;
+
+// Pick the local install slug (rename-on-collision, R8): the registry slug, else
+// `<slug>-2`, `<slug>-3`, … An existing dir whose `.origin.json` matches this
+// registry collection is a re-import (update); a foreign dir or a non-directory at
+// the path is skipped to the next candidate, so a user's own same-named collection
+// is never clobbered and the import still succeeds under a free slug.
 async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
-  const targetDir = projectSkillDir(workspaceRoot, entry.slug);
-  const kind = await statType(targetDir);
-  if (kind === "absent") return { targetDir, updated: false };
-  if (kind === "other") return { conflict: `path for slug '${entry.slug}' exists and is not a directory` };
-  if (originMatches(await readOrigin(targetDir), registry, entry.author, entry.slug)) return { targetDir, updated: true };
-  return { conflict: `a different collection already occupies slug '${entry.slug}'` };
+  for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
+    const localSlug = attempt === 0 ? entry.slug : `${entry.slug}-${attempt + 1}`;
+    const targetDir = projectSkillDir(workspaceRoot, localSlug);
+    const kind = await statType(targetDir);
+    if (kind === "absent") return { targetDir, localSlug, updated: false };
+    if (kind === "dir" && originMatches(await readOrigin(targetDir), registry, entry.author, entry.slug)) {
+      return { targetDir, localSlug, updated: true };
+    }
+  }
+  return { conflict: `couldn't find an available slug for '${entry.slug}'` };
 }
 
 type SchemaResolution = { schema: CollectionSchema } | { error: string };
@@ -144,23 +155,25 @@ export async function writeImportedCollection(params: {
   const target = await resolveTarget(workspaceRoot, registry, entry);
   if ("conflict" in target) return { ok: false, status: STATUS_CONFLICT, error: target.conflict };
 
+  const { localSlug } = target;
+
   // Pre-flight the data dir before schema validation: a non-directory at the dataPath
   // (or an ancestor that's a file → ENOTDIR) would otherwise surface as a generic 500
   // on mkdir. statType maps ENOTDIR/other to a deterministic 409 path-shape conflict.
-  const dataDir = path.join(workspaceRoot, ...normalizedDataPath(entry.slug).split("/"));
+  const dataDir = path.join(workspaceRoot, ...normalizedDataPath(localSlug).split("/"));
   if ((await statType(dataDir)) === "other") {
-    return { ok: false, status: STATUS_CONFLICT, error: `data path for slug '${entry.slug}' exists and is not a directory` };
+    return { ok: false, status: STATUS_CONFLICT, error: `data path for slug '${localSlug}' exists and is not a directory` };
   }
 
-  const validated = validateAndNormalize(bundle, entry.slug, workspaceRoot);
+  const validated = validateAndNormalize(bundle, localSlug, workspaceRoot);
   if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
   // Build the replacement fully in a hidden sibling staging dir (bundle + origin),
   // so the prior install is untouched until everything is durably written. Leftover
   // staging/backup dirs from a crashed import are cleaned first, keeping retries possible.
   const skillsParent = path.dirname(target.targetDir);
-  const staging = path.join(skillsParent, `.importing-${entry.slug}`);
-  const backup = path.join(skillsParent, `.backup-${entry.slug}`);
+  const staging = path.join(skillsParent, `.importing-${localSlug}`);
+  const backup = path.join(skillsParent, `.backup-${localSlug}`);
   await rm(staging, { recursive: true, force: true });
   await rm(backup, { recursive: true, force: true });
   await mkdir(staging, { recursive: true });
@@ -181,7 +194,7 @@ export async function writeImportedCollection(params: {
   await rm(backup, { recursive: true, force: true });
 
   const seed = await materializeSeed(dataDir, bundle);
-  return { ok: true, localSlug: entry.slug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };
+  return { ok: true, localSlug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };
 }
 
 export async function performImport(author: string, slug: string, workspaceRoot: string): Promise<ImportResult> {

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -98,12 +98,22 @@ describe("writeImportedCollection", () => {
     assert.equal(again.seedSkipped, true, "existing dataPath → seed skipped");
   });
 
-  it("rejects with 409 when a different collection occupies the slug", async () => {
+  it("renames to <slug>-2 when a different collection occupies the slug (and re-imports as an update)", async () => {
     mkdirSync(skillDir(wsRoot), { recursive: true });
     writeFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "someone else's collection");
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
-    assert.equal(result.ok, false);
-    if (!result.ok) assert.equal(result.status, 409);
+    assert.ok(result.ok);
+    if (result.ok) assert.equal(result.localSlug, "movies-2");
+    // the user's own collection is untouched
+    assert.equal(readFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "utf-8"), "someone else's collection");
+    assert.ok(existsSync(path.join(wsRoot, ".claude", "skills", "movies-2", "SKILL.md")));
+    // a second import reuses movies-2 (matching origin) as an update, not movies-3
+    const again = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
+    assert.ok(again.ok);
+    if (again.ok) {
+      assert.equal(again.localSlug, "movies-2");
+      assert.equal(again.updated, true);
+    }
   });
 
   it("rejects an invalid schema with 422", async () => {
@@ -121,12 +131,12 @@ describe("writeImportedCollection", () => {
     assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")), "current bundle still installed");
   });
 
-  it("returns 409 when the slug path exists as a non-directory file", async () => {
+  it("renames past a slug path that exists as a non-directory file", async () => {
     mkdirSync(path.dirname(skillDir(wsRoot)), { recursive: true });
     writeFileSync(skillDir(wsRoot), "i am a file, not a directory");
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
-    assert.equal(result.ok, false);
-    if (!result.ok) assert.equal(result.status, 409);
+    assert.ok(result.ok);
+    if (result.ok) assert.equal(result.localSlug, "movies-2");
   });
 
   it("returns 409 when the data path exists as a non-directory file", async () => {

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -140,6 +140,16 @@ describe("writeImportedCollection", () => {
     assert.ok(!existsSync(path.join(skillDir(wsRoot), ".origin.json")), "no duplicate fresh install at the freed slug");
   });
 
+  it("finds a free slug past several colliding installs", async () => {
+    for (const slug of ["movies", "movies-2", "movies-3"]) {
+      mkdirSync(skillDir(wsRoot, slug), { recursive: true });
+      writeFileSync(path.join(skillDir(wsRoot, slug), "SKILL.md"), "a foreign collection");
+    }
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.ok(result.ok);
+    if (result.ok) assert.equal(result.localSlug, "movies-4");
+  });
+
   it("rejects an invalid schema with 422", async () => {
     const bundle = makeBundle({ "schema.json": JSON.stringify({ title: "x" }) });
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle, workspaceRoot: wsRoot, nowIso: "t" });

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -116,6 +116,22 @@ describe("writeImportedCollection", () => {
     }
   });
 
+  it("re-imports into the existing renamed slug even after the original slug frees up", async () => {
+    mkdirSync(skillDir(wsRoot), { recursive: true });
+    writeFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "someone else's collection");
+    const first = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t1" });
+    assert.ok(first.ok && first.localSlug === "movies-2");
+    // the user deletes their own collection → the original slug frees up
+    rmSync(skillDir(wsRoot), { recursive: true, force: true });
+    const again = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
+    assert.ok(again.ok);
+    if (again.ok) {
+      assert.equal(again.localSlug, "movies-2", "updates the existing renamed install, not a fresh 'movies'");
+      assert.equal(again.updated, true);
+    }
+    assert.ok(!existsSync(path.join(wsRoot, ".claude", "skills", "movies", ".origin.json")), "no duplicate fresh install at the freed slug");
+  });
+
   it("rejects an invalid schema with 422", async () => {
     const bundle = makeBundle({ "schema.json": JSON.stringify({ title: "x" }) });
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle, workspaceRoot: wsRoot, nowIso: "t" });

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -53,8 +53,8 @@ function makeBundle(overrides: Record<string, string> = {}): Map<string, string>
   );
 }
 
-const skillDir = (root: string) => path.join(root, ".claude", "skills", "movies");
-const seedFile = (root: string) => path.join(root, "data", "collections", "movies", "items", "a.json");
+const skillDir = (root: string, slug = "movies") => path.join(root, ".claude", "skills", slug);
+const seedFile = (root: string, slug = "movies") => path.join(root, "data", "collections", slug, "items", "a.json");
 
 describe("writeImportedCollection", () => {
   let wsRoot: string;
@@ -103,10 +103,18 @@ describe("writeImportedCollection", () => {
     writeFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "someone else's collection");
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
     assert.ok(result.ok);
-    if (result.ok) assert.equal(result.localSlug, "movies-2");
+    if (result.ok) {
+      assert.equal(result.localSlug, "movies-2");
+      assert.equal(result.updated, false, "a renamed fresh install is not an update");
+    }
     // the user's own collection is untouched
     assert.equal(readFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "utf-8"), "someone else's collection");
-    assert.ok(existsSync(path.join(wsRoot, ".claude", "skills", "movies-2", "SKILL.md")));
+    assert.ok(existsSync(path.join(skillDir(wsRoot, "movies-2"), "SKILL.md")));
+    // schema + seed land under the renamed slug, not the original
+    const renamedSchema = JSON.parse(readFileSync(path.join(skillDir(wsRoot, "movies-2"), "schema.json"), "utf-8"));
+    assert.equal(renamedSchema.dataPath, "data/collections/movies-2/items");
+    assert.ok(existsSync(seedFile(wsRoot, "movies-2")), "seed materialized under movies-2");
+    assert.ok(!existsSync(seedFile(wsRoot)), "no seed written under the original slug");
     // a second import reuses movies-2 (matching origin) as an update, not movies-3
     const again = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
     assert.ok(again.ok);
@@ -129,7 +137,7 @@ describe("writeImportedCollection", () => {
       assert.equal(again.localSlug, "movies-2", "updates the existing renamed install, not a fresh 'movies'");
       assert.equal(again.updated, true);
     }
-    assert.ok(!existsSync(path.join(wsRoot, ".claude", "skills", "movies", ".origin.json")), "no duplicate fresh install at the freed slug");
+    assert.ok(!existsSync(path.join(skillDir(wsRoot), ".origin.json")), "no duplicate fresh install at the freed slug");
   });
 
   it("rejects an invalid schema with 422", async () => {


### PR DESCRIPTION
## Summary

Follow-up to the Discover import (#1817/#1818). Importing a registry collection whose slug is already taken by a **different** local collection used to **409** (a dead end in the Discover UI). Now it installs under the next free slug (`<slug>-2`, `-3`, …) — **rename-on-collision (R8)** — so the import always succeeds and the user's own same-named collection is never clobbered.

Motivated by real testing: a user who already has a hand-authored `movies` collection got `a different collection already occupies slug 'movies'` when importing `isamu/movies`.

## Behavior
- Slug free → install at `<slug>`.
- Slug taken by a collection with a **matching** `.origin.json` → **update** it (re-import).
- Slug taken by a **different** collection (or a non-directory at the path) → try `<slug>-2`, `-3`, … and install at the first free one.
- A re-import after a rename **reuses** the renamed slug (matching origin = update), not `-3`.
- `.origin.json` keeps the **registry** slug (for update-matching); the skill dir / dataPath / staging / backup use the **local** slug.
- The Discover card shows **"Imported as movies-2"** when renamed (otherwise "Imported"/"Updated"); "Open" navigates to the actual local slug.

## Notes
- The data-path conflict checks (a file at `data/collections/<slug>/items` or a non-directory ancestor) still return a deterministic 409 — those are workspace-shape problems, not slug collisions.
- i18n: `importedAs` added across all 8 locales (type-enforced lockstep).

`yarn typecheck` / `build` / `lint` green; importWriter tests 9/9 (incl. rename + re-import-as-update).

Refs #1814

## Summary by Sourcery

Implement rename-on-collision behavior for collection imports and surface the resulting local slug in the Discover UI.

New Features:
- Allow importing registry collections under an alternative slug (e.g., <slug>-2) when the original slug is already used by a different local collection.
- Display an "Imported as <slug>" label in the Discover panel when a collection is imported under a renamed slug.

Bug Fixes:
- Prevent collection imports from failing with a 409 when the requested slug is already occupied by an unrelated collection or a non-directory path, as long as an alternative slug is available.

Enhancements:
- Preserve and reuse the local slug for subsequent re-imports when the origin matches, treating them as updates rather than new installs.
- Extend import tests to cover rename-on-collision behavior, including subsequent re-imports and non-directory slug paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection imports now automatically use a renamed identifier when the requested one is already taken.
  * Completion UI now displays “Imported as …” when an import lands under a new identifier.

* **Bug Fixes**
  * Improved slug collision resolution to better distinguish true updates from conflicts.
  * Re-imports now correctly target and update an existing renamed installation instead of creating duplicates.

* **Documentation**
  * Added the new “Imported as …” translation string for all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->