### PR TITLE
feat(collections): scheduled agent-ingest refresh (`ingest.kind: "agent"`)

### DIFF
--- a/packages/core/assets/helps/collection-skills.md
+++ b/packages/core/assets/helps/collection-skills.md
@@ -49,7 +49,7 @@ data/<name>/items/             ← the records (separate from the skill dir)
   discovery enforces and reports the exact problem, where a hand-edit can
   silently fail validation and make the collection vanish from the UI. It writes
   the canonical `data/skills/<slug>/schema.json` and mirrors it for you — same
-  destination as authoring, just validated. (Creating a *new* collection still
+  destination as authoring, just validated. (Creating a _new_ collection still
   means writing `SKILL.md` + `schema.json` under `data/skills/<slug>/`, since
   there's nothing to `getSchema` yet.)
 - **Do NOT use the `mc-` prefix** for skills you create. `mc-*` is reserved for
@@ -127,7 +127,7 @@ skipped, never crashes the host):
 | `title`                | Human name shown in the sidebar / header. Required.                                                                                                                                                                                                                                                                                                                                                                           |
 | `icon`                 | A **Material Symbols** name (`receipt_long`, `people`, `schedule`, `menu_book`). Required.                                                                                                                                                                                                                                                                                                                                    |
 | `dataPath`             | Workspace-relative records folder, e.g. `data/recipes/items`. Must stay under the workspace. Required.                                                                                                                                                                                                                                                                                                                        |
-| `primaryKey`           | The field name whose value is the filename. That field MUST set `primary: true`. The value must be a valid record id (see the **Records** section's id-charset rule). Required.                                                                                                                                                                                                                                                |
+| `primaryKey`           | The field name whose value is the filename. That field MUST set `primary: true`. The value must be a valid record id (see the **Records** section's id-charset rule). Required.                                                                                                                                                                                                                                               |
 | `singleton`            | Optional. When set, at most one record exists, pinned to this exact id (e.g. `me`). Host pre-fills + locks the create form and hides Add once it exists.                                                                                                                                                                                                                                                                      |
 | `fields`               | Ordered map of field-name → field spec. **Insertion order = column order** in the table. Required.                                                                                                                                                                                                                                                                                                                            |
 | `actions`              | Optional array of per-record buttons (see below).                                                                                                                                                                                                                                                                                                                                                                             |
@@ -492,7 +492,7 @@ month's rent `paid`, and next month's pending record appears on its own.
   - **Field-driven interval** (one list, mixed cadences): instead of a single
     `{ unit, interval }`, `every` may select the interval **per record** from
     an `enum` field. Use `{ "fromField": "<enum field>", "map": { <value>:
-    { unit, interval, … } } }` — the host reads the record's value and
+{ unit, interval, … } } }` — the host reads the record's value and
     advances by the matching entry. This lets one collection carry daily,
     weekly, and monthly obligations together:
 
@@ -513,6 +513,7 @@ month's rent `paid`, and next month's pending record appears on its own.
     by `set`) so the successor keeps its frequency and the chain keeps
     recurring. Each `map` value is a literal `every` (same `unit` / `interval`
     / `dayOfMonth` rules as above).
+
 - **`carry`** — record fields copied verbatim onto the successor (must name
   real fields). Fields not in `carry` / `set` / the trigger+primary keys start
   blank.
@@ -537,6 +538,53 @@ How it behaves (worth understanding so it doesn't surprise you):
 This covers _periodic_ obligations. It does **not** do escalating, multi-stage
 reminders over a long prep window (info → warning → urgent) — that is
 intentionally out of scope for collections.
+
+### Scheduled agent refresh (`ingest.kind: "agent"`)
+
+When a collection's records need to be **refreshed on a schedule by judgment**
+— fetch today's stock quotes for every ticker, re-check each watched URL, pull
+fresh figures that a static feed URL can't express — add an `ingest` block with
+`kind: "agent"`. On schedule (and on the **Refresh** button, which appears on
+any collection with an `ingest` block), the host launches a **hidden background
+worker** in `role`, seeded with your `template` plus the same compact
+all-records summary a collection-level action gets. The worker edits the records
+itself via its collection tools, then finishes silently — nothing shows in the
+chat list. Host stays generic: all the domain logic lives in the template prose.
+
+```json
+"ingest": {
+  "kind": "agent",
+  "schedule": "daily",
+  "atHour": 22,
+  "role": "investor",
+  "template": "templates/refresh.md"
+}
+```
+
+- **`schedule`**: `hourly` | `daily` | `weekly` | `on-demand`. `on-demand` never
+  auto-runs (Refresh button only). Cadence is elapsed-based ("≥24 h since the
+  last run, checked hourly") unless you anchor it (below).
+- **`atHour`** (optional, `daily` only): the hour (0–23) to run around. The host
+  ticks hourly, so the run lands within that hour.
+  **⚠ `atHour` is UTC — NOT the user's local time.** A bare `"atHour": 9` fires
+  at 09:00 UTC (= 18:00 JST, = 04:00 ET), which is almost never what "9am" means
+  to the user. So when the user says a local time, **always convert to UTC
+  first**: 07:00 JST → `"atHour": 22`; 9am ET ≈ `"atHour": 13`; 9am PT ≈
+  `"atHour": 17`. (UTC is used for an unambiguous, DST-free comparison, matching
+  the rest of the scheduler.)
+- **`role`**: the role the worker runs in — it must own the tools the refresh
+  needs (e.g. `investor` for the Yahoo Finance endpoints).
+- **`template`**: a path-safe `templates/…md` file (same rule as action
+  templates) whose prose tells the worker exactly what to do. End it with "edit
+  the records and stop — do not present anything" (no one is watching its
+  canvas).
+- No `url`/`map` — the agent owns retrieval and record shape; its writes are
+  still schema-validated. A failed run raises a single bell ("Collection refresh
+  failed: `<slug>`") that clears on the next success.
+
+Reach for `ingest.kind: "agent"` (not a `manageAutomations` task) whenever the
+schedule belongs to one collection: it travels with the schema, dies with the
+collection, and needs no separate setup.
 
 ### Calendar view
 
@@ -713,7 +761,7 @@ single source of truth and the "done" checkbox is a `toggle` field projecting it
   separators, **no** leading/trailing dot, and **no** `..` substring. If your
   natural key contains anything else (a space, `/`, `:`, a leading dot), sanitise
   it first — e.g. replace each illegal run with `_`. Note `manageCollection`
-  enforces this on every targeted read/write, so an id that only *looks* fine in
+  enforces this on every targeted read/write, so an id that only _looks_ fine in
   a full `getItems` listing but violates the rule can't be updated or deleted by
   id — fix the id, don't work around it with raw file I/O.
 - **The file MUST be valid JSON.** A malformed record is **silently skipped** at

--- a/packages/core/assets/helps/feeds.md
+++ b/packages/core/assets/helps/feeds.md
@@ -16,8 +16,8 @@ engine does that automatically: the first time the feed's view is opened, on an
 hourly schedule thereafter, and when the user clicks **Refresh feed**. Records
 render in the standard collection view at `/feeds/<slug>`.
 
-This is the project philosophy: *the workspace is the database; you are the
-intelligent interface.* Adding a feed = **fetch the URL, look at its real
+This is the project philosophy: _the workspace is the database; you are the
+intelligent interface._ Adding a feed = **fetch the URL, look at its real
 fields, and write one `schema.json`.**
 
 ## Workflow to add a feed
@@ -45,11 +45,11 @@ lists all registered feeds, and its delete button does the same.
   "primaryKey": "id",
   "displayField": "headline",
   "fields": {
-    "id":        { "type": "string",   "label": "ID", "primary": true },
-    "headline":  { "type": "string",   "label": "Headline" },
-    "url":       { "type": "string",   "label": "URL" },
-    "published": { "type": "date",     "label": "Published" },
-    "summary":   { "type": "markdown", "label": "Summary" }
+    "id": { "type": "string", "label": "ID", "primary": true },
+    "headline": { "type": "string", "label": "Headline" },
+    "url": { "type": "string", "label": "URL" },
+    "published": { "type": "date", "label": "Published" },
+    "summary": { "type": "markdown", "label": "Summary" }
   },
   "ingest": {
     "kind": "rss",
@@ -87,6 +87,10 @@ lists all registered feeds, and its delete button does the same.
 - `url`: the feed / API endpoint (must be public http/https; the host refuses
   private/loopback addresses).
 - `schedule`: `hourly` | `daily` | `weekly` | `on-demand`.
+- `atHour` (optional, `daily` only): the hour (0–23) to anchor a daily feed to
+  (the host ticks hourly, so the run lands within that hour). **⚠ UTC, NOT local
+  time** — `"atHour": 9` is 09:00 UTC (= 18:00 JST). Always convert the user's
+  local time to UTC before writing.
 - `map`: `{ <yourFieldName>: <sourcePath> }` — a dot/bracket path into each
   fetched item. **Map the fields you actually saw when you inspected the feed.**
   - rss/atom: each item is the parsed XML element. Tags are keys (`title`,
@@ -106,6 +110,11 @@ lists all registered feeds, and its delete button does the same.
 - http-json needs an array of objects. Columnar/parallel-array APIs (e.g.
   Open-Meteo weather: `hourly.time[]` + `hourly.temperature_2m[]`) are not
   supported yet.
+- When a refresh needs **judgment** the declarative `map` can't express — auth
+  headers, per-record requests, picking which symbols to fetch, computing a
+  value — use `ingest.kind: "agent"` instead (a scheduled hidden worker; see
+  `config/helps/collection-skills.md` → "Scheduled agent refresh"). It works on
+  any collection, not just feeds.
 - A malformed `schema.json` is skipped at load time (with a diagnostic on the
   notification bell), so double-check the shape above before writing.
 - A feed can carry **custom views** just like any collection — author the HTML at

--- a/packages/core/assets/skills-preset/mc-manage-automations/SKILL.md
+++ b/packages/core/assets/skills-preset/mc-manage-automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mc-manage-automations
-description: Schedule, list, edit, or remove a recurring agent task (cron / interval). Use when the user wants the agent to run a prompt on a schedule ("毎朝7時に天気", "every weekday 8am check email", "schedule a weekly cleanup"), list active automations, or stop one. Edits `config/scheduler/tasks.json` (cwd-relative — the agent already runs with cwd = workspace); the auto-refresh hook re-registers tasks on save.
+description: Schedule, list, edit, or remove a recurring agent task (cron / interval) in `config/scheduler/tasks.json`. Use for cross-collection digests, notifications, or any standalone recurring prompt ("毎朝7時に天気", "every weekday 8am check email", "schedule a weekly cleanup"), or to list/stop automations. EXCEPTION — do NOT create a task here to keep ONE collection's records fresh (e.g. "update the stock-quotes daily", "refresh these quotes every morning", "re-poll these URLs"): instead add an `ingest` block with `kind: "agent"` to THAT collection's own `schema.json` (it self-refreshes on schedule and from its Refresh button; syntax in `config/helps/collection-skills.md` → "Scheduled agent refresh"). Read this skill body in full before writing `tasks.json` — the entry format is structured, not free-form.
 ---
 
 # Automations manager
@@ -18,6 +18,40 @@ take effect immediately.
 End with a one-line confirmation ("Scheduled weather-morning, daily 07:00
 UTC." / "Stopped weekly-cleanup.") so the user can verify without scrolling.
 
+## First: is this just refreshing ONE collection?
+
+Before writing a `tasks.json` automation, check what the recurring work
+actually is. If it's **"keep one collection's records up to date"** — refresh
+stock quotes, re-poll a set of watched URLs, pull fresh figures for every row —
+do **NOT** create an automation here. Add an `ingest` block to _that
+collection's own_ `schema.json` instead:
+
+```json
+"ingest": {
+  "kind": "agent",
+  "schedule": "daily",
+  "atHour": 21,
+  "role": "<a role that owns the tools the refresh needs>",
+  "template": "templates/refresh.md"
+}
+```
+
+and write `templates/refresh.md` telling the worker how to refresh the records.
+The full contract is in `config/helps/collection-skills.md` → "Scheduled agent
+refresh". On schedule (and on the collection's **Refresh** button) the host runs
+a hidden background worker that edits the records.
+
+Prefer this over a `tasks.json` automation whenever the work is one collection's
+refresh: the schedule lives **with** the collection — it travels when the skill
+is copied and is deleted when the collection is, instead of leaving an orphan
+task here whose prompt points at records that may no longer exist. (Editing
+`data/stock-quotes/items/*.json` daily? That's `ingest.kind: "agent"` on the
+stock-quotes schema, not an automation.)
+
+Use the `tasks.json` automation below only for work that **isn't** one
+collection's refresh: cross-collection digests, notifications, or an arbitrary
+recurring prompt.
+
 ## Workflow 1: schedule a new automation
 
 **Triggers**: "毎朝 7 時に天気を", "every weekday 8am check email",
@@ -26,7 +60,7 @@ UTC." / "Stopped weekly-cleanup.") so the user can verify without scrolling.
 **Step 1 — convert local time to UTC.** Schedules are stored / compared in
 UTC (the task-manager calls `Date.getUTCHours/Minutes`). When the user gives
 a local time, convert before writing. E.g. "07:00 JST" → `"16:00"` of the
-*previous* UTC day? No — `07:00 JST` is `22:00 UTC` of the *previous* day.
+_previous_ UTC day? No — `07:00 JST` is `22:00 UTC` of the _previous_ day.
 JST is UTC+9, so `07:00 JST = 22:00 UTC (yesterday)`. (Run the math, don't
 trust your reflex — UTC offsets are a classic typo source.)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client and ./workspace-setup/slug entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -20,16 +20,41 @@
  *  these three + the presence check. */
 export interface CollectionIngest {
   kind: string;
-  url: string;
   schedule: string;
+  /** Optional time-of-day anchor for `schedule: "daily"` — the hour (0–23) to
+   *  refresh around (the host ticks hourly, so the run lands within that hour).
+   *  Ignored for non-daily schedules. Absent ⇒ elapsed-based daily ("≥24 h since
+   *  the last run"). NOTE: **UTC**, not local — compared via `getUTCHours()` for
+   *  an unambiguous, DST-free check (matching the rest of the scheduler), so
+   *  convert local times before writing (e.g. 07:00 JST → `atHour: 22`). */
+  atHour?: number;
+  /** Declarative retrievers (`rss`/`atom`/`http-json`) only — the host fetches
+   *  this URL on the schedule. Absent for `kind: "agent"`, where the agent owns
+   *  retrieval. */
+  url?: string;
+  /** `kind: "agent"` only: role id the scheduled hidden worker runs in. */
+  role?: string;
+  /** `kind: "agent"` only: skill-relative template path (under `templates/`)
+   *  whose prose tells the worker how to refresh the records. */
+  template?: string;
 }
 
-/** Retriever kinds a Feed's `ingest.kind` may declare. The host's feeds engine
- *  dispatches on these; they live here (with the schema contract) so the schema
- *  validator can enforce them. The host re-exports these from
+/** Declarative retriever kinds a Feed's `ingest.kind` may declare. The host's
+ *  feeds engine dispatches on these; they live here (with the schema contract)
+ *  so the schema validator can enforce them. The host re-exports these from
  *  `server/workspace/feeds/ingestTypes.ts`. */
 export const INGEST_KINDS = ["rss", "atom", "http-json"] as const;
 export type IngestKind = (typeof INGEST_KINDS)[number];
+
+/** The agent-performed ingest kind. Instead of a declarative fetch, the host
+ *  dispatches a hidden background chat (origin `system`) in `ingest.role`,
+ *  seeded with `ingest.template` + a summary of every record, on the
+ *  `ingest.schedule` cadence; the worker edits records via the collections io
+ *  layer. Kept separate from {@link INGEST_KINDS} (which the declarative
+ *  retriever registry keys on) so the schema validator can model `ingest` as a
+ *  discriminated union without the feeds engine gaining an "agent" retriever. */
+export const AGENT_INGEST_KIND = "agent" as const;
+export type AgentIngestKind = typeof AGENT_INGEST_KIND;
 
 /** Refresh cadences a Feed's `ingest.schedule` may declare. */
 export const FEED_SCHEDULES = ["hourly", "daily", "weekly", "on-demand"] as const;
@@ -402,12 +427,15 @@ export interface CollectionSchema {
    *  notify for every open record (the prior behaviour). `notifyWhen.field`
    *  must name a real top-level field. */
   notifyWhen?: CollectionWhen;
-  /** Optional declarative retrieval config. When present, this collection
-   *  is a "Feed": the host periodically fetches `ingest.url`, maps the
-   *  response into records, and upserts them by `primaryKey`. Only feeds
-   *  discovered from the `<workspace>/feeds/` registry carry this; skill
-   *  collections omit it. The host's feeds subsystem narrows this to its
-   *  richer `IngestSpec` (which `extends CollectionIngest`). */
+  /** Optional scheduled-retrieval config. When present, the host refreshes
+   *  this collection on `ingest.schedule`. Two flavours: a declarative Feed
+   *  (`kind: rss/atom/http-json`) periodically fetches `ingest.url`, maps the
+   *  response into records, and upserts them by `primaryKey` — only feeds
+   *  discovered from the `<workspace>/feeds/` registry carry this. Or
+   *  `kind: "agent"`, valid on any (incl. skill-backed) collection: the host
+   *  dispatches a hidden background worker in `ingest.role` seeded with
+   *  `ingest.template`, and the worker edits the records itself. The host's
+   *  feeds subsystem narrows this to its richer `IngestSpec`. */
   ingest?: CollectionIngest;
 }
 

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -9,7 +9,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import { log, getWorkspaceRoot, userSkillsDir, projectSkillsDir, feedsRoot } from "./host";
-import { INGEST_KINDS, FEED_SCHEDULES, isFieldDrivenEvery } from "../core/schema";
+import { INGEST_KINDS, AGENT_INGEST_KIND, FEED_SCHEDULES, isFieldDrivenEvery } from "../core/schema";
 import { SCHEMA_FILE, resolveDataDir, safeRecordId, safeSlugName } from "./paths";
 import type { LoadedCollection } from "./discoveredCollection";
 import { isSafeActionTemplatePath, isSafeCustomViewPath } from "./templatePath";
@@ -395,14 +395,14 @@ function fieldDrivenFromFieldCarried(schema: FieldDrivenSchemaView): boolean {
 }
 
 // Declarative retrieval config for a Feed (a collection that refills
-// itself from the internet). Optional on every schema — skill-backed
-// collections omit it; only feeds discovered from `<workspace>/feeds/`
-// carry it. `http-json` needs a path to the items array; rss/atom
-// yield items natively and ignore `itemsAt`.
-const IngestSchemaZ = z.object({
+// itself from the internet). `http-json` needs a path to the items array;
+// rss/atom yield items natively and ignore `itemsAt`.
+const DeclarativeIngestZ = z.object({
   kind: z.enum(INGEST_KINDS),
   url: z.string().url(),
   schedule: z.enum(FEED_SCHEDULES),
+  // Optional UTC hour (0–23) to anchor a `daily` schedule; ignored otherwise.
+  atHour: z.number().int().min(0).max(23).optional(),
   itemsAt: z.string().trim().min(1).optional(),
   map: z.record(z.string().trim().min(1), z.string().trim().min(1)),
   idFrom: z.string().trim().min(1).optional(),
@@ -411,6 +411,31 @@ const IngestSchemaZ = z.object({
 // `itemsAt` is always optional: http-json omits it when the response body
 // is itself the items array (the engine falls back to the top-level array);
 // rss/atom ignore it. So no kind-specific requirement here.
+
+// Agent-performed retrieval. Valid on any collection (the primary consumer is
+// skill-backed collections — feeds keep their declarative kinds). No `url`/`map`:
+// the worker owns retrieval and record shape, seeded by `template` + a summary
+// of every record, run in `role`. `template` is validated the SAME way an
+// action's template is (safe path under `templates/`), so the skill-bridge
+// mirrors it identically.
+const AgentIngestZ = z.object({
+  kind: z.literal(AGENT_INGEST_KIND),
+  schedule: z.enum(FEED_SCHEDULES),
+  // Optional UTC hour (0–23) to anchor a `daily` schedule; ignored otherwise.
+  atHour: z.number().int().min(0).max(23).optional(),
+  role: z.string().trim().min(1),
+  template: z
+    .string()
+    .trim()
+    .min(1)
+    .refine(isSafeActionTemplatePath, "must be a safe path under `templates/` (e.g. `templates/refresh.md`; no `..`, no leading `/`, no backslash)"),
+});
+
+// `ingest` is a discriminated union on `kind`: the three declarative
+// retrievers fetch-and-map; `agent` dispatches a hidden worker. Optional on
+// every schema — skill-backed collections usually omit it; only feeds
+// discovered from `<workspace>/feeds/` are REQUIRED to carry it (gate below).
+const IngestSchemaZ = z.discriminatedUnion("kind", [DeclarativeIngestZ, AgentIngestZ]);
 
 export const CollectionSchemaZ = z
   .object({

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1398,10 +1398,16 @@ async function refreshItemsInPlace(slug: string): Promise<void> {
 // so data appears without a manual Refresh. Guarded per slug so the reload
 // `refreshFeed` triggers can't loop; the view re-mounts per slug, so each
 // open retries at most once.
+//
+// Restricted to ACTUAL feeds (`source === "feed"`): a declarative feed
+// populates synchronously here, but a skill-backed `ingest.kind: "agent"`
+// collection would dispatch a VISIBLE worker and navigate the user to its
+// chat just by opening an empty collection — those refresh on schedule or an
+// explicit Refresh click only.
 function maybeAutoRefreshFeed(slug: string): void {
   if (embedded.value) return;
   const current = collection.value;
-  if (current?.slug !== slug || !current.schema.ingest) return;
+  if (current?.slug !== slug || current.source !== "feed") return;
   if (items.value.length > 0 || autoRefreshedSlug.value === slug) return;
   autoRefreshedSlug.value = slug;
   void refreshFeed();

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -111,6 +111,18 @@
       </button>
     </header>
 
+    <!-- Transient note for an agent-ingest Refresh: the worker runs in the
+         background, so records don't update synchronously — tell the user the
+         refresh started rather than leaving the click feeling like a no-op. -->
+    <div
+      v-if="refreshNote"
+      class="mx-6 mt-2 rounded-lg border border-indigo-200 bg-indigo-50/60 px-4 py-2 text-sm text-indigo-800 flex items-center gap-2"
+      data-testid="collections-refresh-note"
+    >
+      <span class="material-icons text-base text-indigo-600">hourglass_top</span>
+      <span class="flex-1">{{ refreshNote }}</span>
+    </div>
+
     <!-- Search Toolbar. Shown when there are items to search OR when a view
          toggle is available — the toggle must reach an empty date-bearing
          collection (empty-day create) and a collection whose only views are
@@ -872,6 +884,11 @@ const notifiedSeverities = computed<Map<string, CollectionNotifySeverity>>(() =>
 });
 /** True while a feed collection's manual refresh is in flight. */
 const refreshing = ref(false);
+/** Transient note shown after an agent-ingest Refresh dispatches a background
+ *  worker (records update asynchronously, so there's nothing to show inline).
+ *  Auto-clears; `refreshNoteTimer` cancels a pending clear on re-trigger. */
+const refreshNote = ref<string | null>(null);
+let refreshNoteTimer: ReturnType<typeof setTimeout> | undefined;
 /** Slug already auto-refreshed on first open — prevents a reload loop
  *  (the auto-refresh reloads the view, which would re-trigger otherwise). */
 const autoRefreshedSlug = ref<string | null>(null);
@@ -1126,7 +1143,25 @@ async function refreshFeed(): Promise<void> {
   // surface them — otherwise a failed refresh looks like success.
   if (result.data.errors.length > 0) {
     inlineError.value = t("collectionsView.refreshFailed", { error: result.data.errors.join("; ") });
+    return;
   }
+  // Agent ingest dispatched a worker — records update later. A manual refresh
+  // runs a VISIBLE session: open it so the user can watch/debug the run. Fall
+  // back to a transient note if the host can't navigate (router-less embed).
+  if (result.data.dispatched) {
+    if (result.data.chatId && cui.navigate) cui.navigate(`/chat/${result.data.chatId}`);
+    else showRefreshNote(t("collectionsView.refreshDispatched"));
+  }
+}
+
+/** Show a transient refresh note, replacing any pending auto-clear. */
+function showRefreshNote(message: string): void {
+  refreshNote.value = message;
+  if (refreshNoteTimer !== undefined) clearTimeout(refreshNoteTimer);
+  refreshNoteTimer = setTimeout(() => {
+    refreshNote.value = null;
+    refreshNoteTimer = undefined;
+  }, 6000);
 }
 
 /** Collection-level header actions. No `when` predicate (no record). */
@@ -1231,12 +1266,14 @@ function closeChat(): void {
  *  (`feeds/<slug>/schema.json` and `<dataPath>/`) and let it act on the
  *  request directly. */
 function buildChatSeed(slug: string, message: string, itemId?: string): string {
-  const schema = collection.value?.schema;
-  // A feed carries an `ingest` block; a plain collection does not. Checked
-  // here (rather than via the `isFeed` computed, defined further down) to
-  // keep this helper self-contained and avoid a use-before-define.
-  if (!schema?.ingest) return itemId ? `/${slug} id=${itemId} ${message}` : `/${slug} ${message}`;
-  const dataPath = schema.dataPath ?? `data/feeds/${slug}`;
+  const current = collection.value;
+  // Only an actual Feed (source `feed`) is skill-less + data-only. A
+  // skill-backed collection — even one carrying an agent-ingest block — DOES
+  // have a `/<slug>` skill command, so seed that. (Checked via `source`
+  // directly, not the `isFeed` computed defined further down, to keep this
+  // helper self-contained and avoid a use-before-define.)
+  if (current?.source !== "feed") return itemId ? `/${slug} id=${itemId} ${message}` : `/${slug} ${message}`;
+  const dataPath = current.schema.dataPath ?? `data/feeds/${slug}`;
   // A feed has no skill command — point the agent at a specific record by id
   // inside the same schema-driven seed.
   const scoped = itemId ? `(for record \`${itemId}\`) ${message}` : message;
@@ -1409,10 +1446,13 @@ const canDeleteCollection = computed<boolean>(() => {
   return current.source === "project" && !current.slug.startsWith("mc-");
 });
 
-// True when this view was opened as a feed (`/feeds/:slug`): the schema
-// carries an `ingest` block. Feeds are deleted via DELETE /api/feeds/:slug,
-// not the project-scope collection delete above.
-const isFeed = computed<boolean>(() => Boolean(collection.value?.schema.ingest));
+// True only for an actual Feed (discovered from `feeds/<slug>/`, source
+// `feed`) — NOT merely any collection carrying an `ingest` block. A
+// skill-backed collection can now declare `ingest.kind: "agent"` (scheduled
+// agent refresh) yet still be a project-scope collection, deleted the normal
+// way; keying off `schema.ingest` here used to surface a SECOND delete button
+// on those. Feeds are deleted via DELETE /api/feeds/:slug.
+const isFeed = computed<boolean>(() => collection.value?.source === "feed");
 const canDeleteFeed = computed<boolean>(() => isFeed.value && !embedded.value);
 
 // Which list to return to from the back arrow: feeds opened via /feeds
@@ -1517,7 +1557,7 @@ const canAddCustomView = computed<boolean>(() => Boolean(collection.value) && !e
 function addCustomView(): void {
   const current = collection.value;
   if (!current) return;
-  const base = current.schema.ingest ? `feeds/${current.slug}` : `data/skills/${current.slug}`;
+  const base = current.source === "feed" ? `feeds/${current.slug}` : `data/skills/${current.slug}`;
   const prompt = t("collectionsView.addViewPrompt", { title: current.title, base });
   if (props.sendTextMessage) {
     props.sendTextMessage(prompt);
@@ -2198,6 +2238,7 @@ onUnmounted(() => {
   changeUnsub?.();
   changeUnsub = null;
   clearLiveRefreshTimer();
+  if (refreshNoteTimer !== undefined) clearTimeout(refreshNoteTimer);
 });
 
 // Embedded mode: report view/anchor changes so the chat card persists them

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -45,6 +45,7 @@ const deMessages: CollectionMessages = {
     chat: "Chat",
     refreshFeed: "Aktualisieren",
     refreshFailed: "Aktualisierung fehlgeschlagen: {error}",
+    refreshDispatched: "Aktualisierung im Hintergrund gestartet.",
     feedChatSeed:
       "Der Feed {slug} ist durch das Schema `feeds/{slug}/schema.json` definiert und seine Datensätze liegen in `{dataPath}/` (eine `<id>.json`-Datei pro Datensatz). Nutze dieses Schema und diese Daten, um auf die folgende Anfrage zu antworten: {message}",
     feedsTitle: "Datenquellen-Feeds",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -43,6 +43,7 @@ const enMessages = {
     chat: "Chat",
     refreshFeed: "Refresh",
     refreshFailed: "Refresh failed: {error}",
+    refreshDispatched: "Refresh started in the background.",
     feedChatSeed:
       'The "{slug}" feed is defined by the schema at `feeds/{slug}/schema.json` and its records live in `{dataPath}/` (one `<id>.json` per record). Using that schema and data, respond to this request: {message}',
     feedsTitle: "Data-source feeds",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -45,6 +45,7 @@ const esMessages: CollectionMessages = {
     chat: "Chat",
     refreshFeed: "Actualizar",
     refreshFailed: "Error al actualizar: {error}",
+    refreshDispatched: "Actualización iniciada en segundo plano.",
     feedChatSeed:
       "El feed «{slug}» está definido por el esquema `feeds/{slug}/schema.json` y sus registros se guardan en `{dataPath}/` (un archivo `<id>.json` por registro). Usa ese esquema y esos datos para responder a esta solicitud: {message}",
     feedsTitle: "Fuentes de datos",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -46,6 +46,7 @@ const frMessages: CollectionMessages = {
     chat: "Discussion",
     refreshFeed: "Actualiser",
     refreshFailed: "Échec de l'actualisation : {error}",
+    refreshDispatched: "Actualisation lancée en arrière-plan.",
     feedChatSeed:
       "Le flux « {slug} » est défini par le schéma `feeds/{slug}/schema.json` et ses enregistrements se trouvent dans `{dataPath}/` (un fichier `<id>.json` par enregistrement). Utilise ce schéma et ces données pour répondre à cette demande : {message}",
     feedsTitle: "Flux de données",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -45,6 +45,7 @@ const jaMessages: CollectionMessages = {
     chat: "チャット",
     refreshFeed: "更新",
     refreshFailed: "更新に失敗しました: {error}",
+    refreshDispatched: "バックグラウンドで更新を開始しました。",
     feedChatSeed:
       "フィード「{slug}」はスキーマ `feeds/{slug}/schema.json` で定義され、レコードは `{dataPath}/`（1 レコードにつき `<id>.json` 1 ファイル）に保存されています。このスキーマとデータを使って、次のリクエストに応えてください: {message}",
     feedsTitle: "データソースフィード",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -45,6 +45,7 @@ const koMessages: CollectionMessages = {
     chat: "채팅",
     refreshFeed: "새로고침",
     refreshFailed: "새로고침 실패: {error}",
+    refreshDispatched: "백그라운드에서 새로고침을 시작했습니다.",
     feedChatSeed:
       "“{slug}” 피드는 스키마 `feeds/{slug}/schema.json`로 정의되며, 레코드는 `{dataPath}/`(레코드당 `<id>.json` 파일 하나)에 저장됩니다. 이 스키마와 데이터를 사용하여 다음 요청에 응답하세요: {message}",
     feedsTitle: "데이터 소스 피드",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -45,6 +45,7 @@ const ptBRMessages: CollectionMessages = {
     chat: "Chat",
     refreshFeed: "Atualizar",
     refreshFailed: "Falha ao atualizar: {error}",
+    refreshDispatched: "Atualização iniciada em segundo plano.",
     feedChatSeed:
       'O feed "{slug}" é definido pelo esquema `feeds/{slug}/schema.json` e seus registros ficam em `{dataPath}/` (um arquivo `<id>.json` por registro). Use esse esquema e esses dados para responder a esta solicitação: {message}',
     feedsTitle: "Feeds de dados",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -45,6 +45,7 @@ const zhMessages: CollectionMessages = {
     chat: "对话",
     refreshFeed: "刷新",
     refreshFailed: "刷新失败：{error}",
+    refreshDispatched: "已在后台开始刷新。",
     feedChatSeed:
       "订阅源“{slug}”由 schema `feeds/{slug}/schema.json` 定义，其记录保存在 `{dataPath}/`（每条记录一个 `<id>.json` 文件）。请使用该 schema 和数据来响应以下请求：{message}",
     feedsTitle: "数据源订阅",

--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -40,11 +40,16 @@ export interface CollectionActionResult {
   role: string;
 }
 
-/** A feed refresh's result — counts + per-source errors. */
+/** A collection refresh's result — counts + per-source errors. `dispatched` is
+ *  true for agent ingest (a worker was launched; records update async).
+ *  `chatId` is the visible worker's session (manual Refresh) so the client can
+ *  open it to watch the run. */
 export interface CollectionRefreshResult {
   refreshed: boolean;
   written: number;
   errors: string[];
+  dispatched?: boolean;
+  chatId?: string;
 }
 
 /** Scoped capability token for a sandboxed custom view (mirrors the host's mint

--- a/server/agent/backgroundSessions.ts
+++ b/server/agent/backgroundSessions.ts
@@ -42,4 +42,32 @@ export function releaseBackgroundSession(chatSessionId: string): void {
   inFlight.delete(chatSessionId);
 }
 
+// ── Completion hooks ────────────────────────────────────────────────
+//
+// A generic, one-shot callback fired when a hidden worker session finishes
+// (success or error). Any host spawner of hidden workers can register one to
+// learn the outcome without polling — the agent-ingest dispatcher uses it to
+// track consecutive failures and raise/clear a failure bell. Best-effort: a
+// server restart mid-run drops the Map, but the next scheduled tick
+// re-dispatches anyway, so nothing is permanently lost.
+
+/** Outcome handed to a completion hook. */
+export type CompletionHook = (outcome: { didError: boolean }) => void | Promise<void>;
+
+const completionHooks = new Map<string, CompletionHook>();
+
+/** Register a one-shot completion hook for a hidden worker session. Replaces
+ *  any existing hook for the same id (last writer wins). */
+export function registerCompletionHook(chatSessionId: string, hook: CompletionHook): void {
+  completionHooks.set(chatSessionId, hook);
+}
+
+/** Remove and return the completion hook for a session, if any. One-shot:
+ *  the entry is deleted so the hook can't fire twice. */
+export function takeCompletionHook(chatSessionId: string): CompletionHook | undefined {
+  const hook = completionHooks.get(chatSessionId);
+  if (hook) completionHooks.delete(chatSessionId);
+  return hook;
+}
+
 export { MAX_BACKGROUND_SESSIONS };

--- a/server/agent/backgroundSessions.ts
+++ b/server/agent/backgroundSessions.ts
@@ -62,12 +62,20 @@ export function registerCompletionHook(chatSessionId: string, hook: CompletionHo
   completionHooks.set(chatSessionId, hook);
 }
 
-/** Remove and return the completion hook for a session, if any. One-shot:
- *  the entry is deleted so the hook can't fire twice. */
-export function takeCompletionHook(chatSessionId: string): CompletionHook | undefined {
+/** Run the one-shot completion hook for a session, if one is registered, then
+ *  remove it (so it can't fire twice). No-op when none is registered.
+ *
+ *  Owning the lookup+invocation here — rather than exposing a `takeHook` that
+ *  the caller invokes — keeps the call target a closure WE registered under a
+ *  server-generated id, never a value the caller selects by a request-derived
+ *  key at its own call site (which static analysis flags as a dynamic-dispatch
+ *  risk). The hook is best-effort: a throwing hook rejects the returned promise
+ *  for the caller to catch+log. */
+export async function runCompletionHook(chatSessionId: string, outcome: { didError: boolean }): Promise<void> {
   const hook = completionHooks.get(chatSessionId);
-  if (hook) completionHooks.delete(chatSessionId);
-  return hook;
+  if (!hook) return;
+  completionHooks.delete(chatSessionId);
+  await hook(outcome);
 }
 
 export { MAX_BACKGROUND_SESSIONS };

--- a/server/agent/backgroundSessions.ts
+++ b/server/agent/backgroundSessions.ts
@@ -56,6 +56,12 @@ export type CompletionHook = (outcome: { didError: boolean }) => void | Promise<
 
 const completionHooks = new Map<string, CompletionHook>();
 
+// Hook keys are server-generated session ids (`randomUUID()`). Validate the
+// shape before using a session id to look up + invoke a hook, so a malformed or
+// foreign id can never select an unexpected call target (defensive — and it
+// keeps the dynamic call off a request-derived, unvalidated string).
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /** Register a one-shot completion hook for a hidden worker session. Replaces
  *  any existing hook for the same id (last writer wins). */
 export function registerCompletionHook(chatSessionId: string, hook: CompletionHook): void {
@@ -72,6 +78,7 @@ export function registerCompletionHook(chatSessionId: string, hook: CompletionHo
  *  risk). The hook is best-effort: a throwing hook rejects the returned promise
  *  for the caller to catch+log. */
 export async function runCompletionHook(chatSessionId: string, outcome: { didError: boolean }): Promise<void> {
+  if (!SESSION_ID_RE.test(chatSessionId)) return;
   const hook = completionHooks.get(chatSessionId);
   if (!hook) return;
   completionHooks.delete(chatSessionId);

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { Router, Request, Response } from "express";
 import { getSessionQuery } from "../../utils/request.js";
 import {
@@ -33,7 +34,14 @@ import { createArgsCache, recordToolEvent } from "../../workspace/tool-trace/ind
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { isSessionOrigin, SESSION_ORIGINS, type SessionOrigin } from "../../../src/types/session.js";
-import { releaseBackgroundSession } from "../../agent/backgroundSessions.js";
+import {
+  tryReserveBackgroundSession,
+  releaseBackgroundSession,
+  registerCompletionHook,
+  takeCompletionHook,
+  MAX_BACKGROUND_SESSIONS,
+  type CompletionHook,
+} from "../../agent/backgroundSessions.js";
 // Imports kept commented (instead of deleted) alongside the
 // publishNotification call in `runPostTurnSideEffects` — see the
 // duplicate-notification comment there for context. (`SESSION_ORIGINS`
@@ -132,6 +140,46 @@ export interface StartChatParams {
 }
 
 export type StartChatResult = { kind: "started"; chatSessionId: string } | { kind: "error"; error: string; status?: number };
+
+/** Outcome of launching a worker session. */
+export type SpawnSystemWorkerResult = { ok: true; chatId: string } | { ok: false; error: string };
+
+// Launch a host-side worker session. `hidden` decides visibility:
+//   - true  → origin `system`: never appears in the session list, runaway-cap
+//             reserved, `finalizeRun` invokes the completion hook + cleans up.
+//             Used for SCHEDULED agent-ingest refreshes (no one is watching).
+//   - false → origin `skill`: a normal visible chat the user can open from
+//             history, no cap, NO completion hook (the user watches it run
+//             directly). Used for a MANUAL Refresh-button refresh so it's
+//             debuggable.
+// Exported so non-MCP host callers (the agent-ingest engine, wired in via
+// `setAgentWorkerRunner`) can spawn one without going through the tool layer.
+export async function spawnSystemWorker(args: {
+  message: string;
+  roleId: string;
+  hidden: boolean;
+  onComplete?: CompletionHook;
+}): Promise<SpawnSystemWorkerResult> {
+  const chatId = randomUUID();
+  const origin: SessionOrigin = args.hidden ? SESSION_ORIGINS.system : SESSION_ORIGINS.skill;
+  // The runaway cap guards hidden workers only — a visible run is user-initiated
+  // and self-limiting. Reserve ATOMICALLY before launching; rolled back below if
+  // the launch fails (otherwise released in `runAgentInBackground`'s finally).
+  if (args.hidden && !tryReserveBackgroundSession(chatId)) {
+    return { ok: false, error: `too many background sessions already in flight (max ${MAX_BACKGROUND_SESSIONS})` };
+  }
+  const result = await startChat({ message: args.message, roleId: args.roleId, chatSessionId: chatId, origin });
+  if (result.kind === "error") {
+    if (args.hidden) releaseBackgroundSession(chatId); // roll back the reservation
+    return { ok: false, error: result.error };
+  }
+  // Register the completion hook AFTER a successful launch (the subprocess can't
+  // finish before this synchronous code returns, so `finalizeRun` won't miss
+  // it). Only hidden (system) sessions run it — `finalizeRun` skips the hook for
+  // visible origins, which take the normal post-turn path instead.
+  if (args.hidden && args.onComplete) registerCompletionHook(chatId, args.onComplete);
+  return { ok: true, chatId };
+}
 
 export async function startChat(params: StartChatParams): Promise<StartChatResult> {
   const { message, roleId, chatSessionId, selectedImageData, attachments, userTimezone } = params;
@@ -978,6 +1026,11 @@ async function finalizeRun(chatSessionId: string, origin: SessionOrigin | undefi
     // plumbing and pollute wiki backlinks), and clean up its files on
     // success — keep them on error so a failed worker stays inspectable.
     releaseBackgroundSession(chatSessionId);
+    // Fire any one-shot completion hook (e.g. agent-ingest failure tracking)
+    // AFTER the slot is freed, BEFORE files are cleaned up. Best-effort —
+    // a throwing hook is logged, never propagated.
+    const hook = takeCompletionHook(chatSessionId);
+    if (hook) await Promise.resolve(hook({ didError })).catch(logBackgroundError("background-session-completion-hook"));
     if (!didError) {
       await deleteSessionFiles(chatSessionId).catch(logBackgroundError("background-session-cleanup"));
     }

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -38,7 +38,7 @@ import {
   tryReserveBackgroundSession,
   releaseBackgroundSession,
   registerCompletionHook,
-  takeCompletionHook,
+  runCompletionHook,
   MAX_BACKGROUND_SESSIONS,
   type CompletionHook,
 } from "../../agent/backgroundSessions.js";
@@ -1029,8 +1029,7 @@ async function finalizeRun(chatSessionId: string, origin: SessionOrigin | undefi
     // Fire any one-shot completion hook (e.g. agent-ingest failure tracking)
     // AFTER the slot is freed, BEFORE files are cleaned up. Best-effort —
     // a throwing hook is logged, never propagated.
-    const hook = takeCompletionHook(chatSessionId);
-    if (hook) await Promise.resolve(hook({ didError })).catch(logBackgroundError("background-session-completion-hook"));
+    await runCompletionHook(chatSessionId, { didError }).catch(logBackgroundError("background-session-completion-hook"));
     if (!didError) {
       await deleteSessionFiles(chatSessionId).catch(logBackgroundError("background-session-cleanup"));
     }

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -168,7 +168,15 @@ export async function spawnSystemWorker(args: {
   if (args.hidden && !tryReserveBackgroundSession(chatId)) {
     return { ok: false, error: `too many background sessions already in flight (max ${MAX_BACKGROUND_SESSIONS})` };
   }
-  const result = await startChat({ message: args.message, roleId: args.roleId, chatSessionId: chatId, origin });
+  let result: StartChatResult;
+  try {
+    result = await startChat({ message: args.message, roleId: args.roleId, chatSessionId: chatId, origin });
+  } catch (err) {
+    // `startChat` is normally fire-and-forget, but a synchronous setup failure
+    // can reject — release the reservation so the slot isn't leaked until restart.
+    if (args.hidden) releaseBackgroundSession(chatId);
+    return { ok: false, error: errorMessage(err) };
+  }
   if (result.kind === "error") {
     if (args.hidden) releaseBackgroundSession(chatId); // roll back the reservation
     return { ok: false, error: result.error };
@@ -918,6 +926,12 @@ export const _splitSkillAndReplyForTest = splitSkillAndReply;
 //   }
 // }
 
+/** A stale `--resume` failure we can recover from by retrying without it: an
+ *  error event carrying a stale-session message, while failover budget remains. */
+function isRecoverableStaleSession(event: { type: string; message?: unknown }, failoverAttemptsRemaining: number): boolean {
+  return failoverAttemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message);
+}
+
 async function runAgentInBackground(params: BackgroundRunParams): Promise<void> {
   const { decoratedMessage, role, chatSessionId, claudeSessionId, abortSignal, resultsFilePath, requestStartedAt, toolArgsCache, attachments, userTimezone } =
     params;
@@ -956,7 +970,7 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
         attachments,
         userTimezone,
       })) {
-        if (failoverAttemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message)) {
+        if (isRecoverableStaleSession(event, failoverAttemptsRemaining)) {
           // Swallow the error — we're about to recover. `break`
           // abandons the current generator; since the event is only
           // yielded after the CLI has already exited non-zero, the
@@ -966,6 +980,12 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
           failoverAttemptsRemaining--;
           break;
         }
+        // A yielded error event (non-zero Claude exit, missing binary, a tool
+        // surfacing an error) is a real failure even though the generator
+        // didn't throw — record it so `finalizeRun`'s hidden-worker cleanup and
+        // the agent-ingest completion hook see `didError`. The stale-session
+        // failover above returns earlier, so a recoverable id doesn't count.
+        if (event.type === EVENT_TYPES.error) didError = true;
         await handleAgentEvent(event, eventCtx);
       }
       if (!staleSessionDetected) break;

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -279,6 +279,13 @@ interface RefreshResponse {
   refreshed: true;
   written: number;
   errors: string[];
+  /** True when an agent-ingest refresh dispatched a worker (fire-and-forget):
+   *  records update asynchronously, so the client shows a note rather than a
+   *  written count. */
+  dispatched?: boolean;
+  /** The visible worker's chat session id (manual Refresh only) so the client
+   *  can open it to watch the refresh run. */
+  chatId?: string;
 }
 
 // Re-run a feed collection's retrieval now. Generic over kind — the
@@ -296,9 +303,12 @@ router.post(API_ROUTES.collections.refresh, async (req: Request<{ slug: string }
     return;
   }
   try {
-    const result = await refreshOne(workspacePath, collection);
-    log.info("collections", "feed refreshed via collection route", { slug: collection.slug, written: result.written });
-    res.json({ refreshed: true, written: result.written, errors: result.errors });
+    // Manual Refresh button → run a VISIBLE worker (hidden:false) so the user
+    // can open the session and watch/debug it. Scheduled refreshes (the
+    // `refreshDue` loop) stay hidden. Declarative feeds ignore the flag.
+    const result = await refreshOne(workspacePath, collection, { hidden: false });
+    log.info("collections", "feed refreshed via collection route", { slug: collection.slug, written: result.written, dispatched: result.dispatched ?? false });
+    res.json({ refreshed: true, written: result.written, errors: result.errors, dispatched: result.dispatched, chatId: result.chatId });
   } catch (err) {
     log.warn("collections", "feed refresh failed", { slug: collection.slug, error: errorMessage(err) });
     serverError(res, errorMessage(err));

--- a/server/api/routes/feeds.ts
+++ b/server/api/routes/feeds.ts
@@ -33,7 +33,7 @@ router.get(API_ROUTES.feeds.list, async (_req: Request, res: Response<FeedsListR
     const feeds = await listFeeds(workspacePath);
     const summaries: FeedSummary[] = [];
     for (const feed of feeds) {
-      const state = await readFeedState(workspacePath, feed.slug);
+      const state = await readFeedState(workspacePath, feed);
       const { ingest } = feed.schema;
       summaries.push({
         slug: feed.slug,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1171,6 +1171,13 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
     }
   }
 
+  // Wire the agent-ingest dispatcher's hidden-worker launcher (DI seam — keeps
+  // the feeds engine from importing the routes layer) BEFORE scheduler init:
+  // `initScheduler` runs catch-up, which can fire `system:feed-refresh` and
+  // dispatch agent ingest immediately. Wiring after would make those first
+  // refreshes fail with "worker runner not configured".
+  setAgentWorkerRunner(spawnSystemWorker);
+
   initScheduler(taskManager, systemTasks).catch((err) => {
     log.error("scheduler", "init failed (non-fatal)", {
       error: String(err),
@@ -1191,11 +1198,6 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
       }
     })
     .catch(logBackgroundError("skills", "failed to register scheduled skills"));
-
-  // Wire the agent-ingest dispatcher's hidden-worker launcher (DI seam — keeps
-  // the feeds engine from importing the routes layer). Must be set before the
-  // scheduler ticks, since `system:feed-refresh` may dispatch agent ingest.
-  setAgentWorkerRunner(spawnSystemWorker);
 
   // Register user-created scheduled tasks from tasks.json.
   registerUserTasks({ taskManager, startChat })

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import "./workspace/collections/configure.js";
 import express, { Request, Response, NextFunction } from "express";
 import path from "path";
 import { fileURLToPath } from "url";
-import agentRoutes, { startChat } from "./api/routes/agent.js";
+import agentRoutes, { startChat, spawnSystemWorker } from "./api/routes/agent.js";
 import { createAccountingRouter, initAccountingEventPublisher, configureAccountingServer } from "@mulmoclaude/accounting-plugin/server";
 import photoLocationsRoutes from "./api/routes/photo-locations.js";
 import schedulerRoutes from "./api/routes/scheduler.js";
@@ -92,7 +92,7 @@ import { cpus, loadavg } from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./system/docker.js";
 import { maybeRunJournal } from "./workspace/journal/index.js";
 import { backfillAllSessions } from "./workspace/chat-index/index.js";
-import { refreshDue as refreshDueFeeds } from "./workspace/feeds/index.js";
+import { refreshDue as refreshDueFeeds, setAgentWorkerRunner } from "./workspace/feeds/index.js";
 import { createPubSub } from "./events/pub-sub/index.js";
 import { PUBSUB_CHANNELS } from "../src/config/pubsubChannels.js";
 import { createTaskManager } from "./events/task-manager/index.js";
@@ -1133,8 +1133,12 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
     },
     {
       id: "system:feed-refresh",
-      name: "Data-source feed refresh",
-      description: "Fetch declarative data-source feeds (RSS / JSON) into their collections",
+      name: "Scheduled collection refresh",
+      // Drives ALL scheduled ingest now: declarative feeds (RSS / JSON) AND
+      // skill-backed collections with `ingest.kind: "agent"` (which dispatch a
+      // hidden worker rather than fetching). Id kept as `system:feed-refresh`
+      // so its scheduler-state row isn't orphaned by a rename.
+      description: "Refresh due collections — fetch declarative feeds + dispatch agent-ingest workers",
       schedule: { type: SCHEDULE_TYPES.interval, intervalMs: ONE_HOUR_MS },
       missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
       run: () => refreshDueFeeds().then(() => {}),
@@ -1187,6 +1191,11 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
       }
     })
     .catch(logBackgroundError("skills", "failed to register scheduled skills"));
+
+  // Wire the agent-ingest dispatcher's hidden-worker launcher (DI seam — keeps
+  // the feeds engine from importing the routes layer). Must be set before the
+  // scheduler ticks, since `system:feed-refresh` may dispatch agent ingest.
+  setAgentWorkerRunner(spawnSystemWorker);
 
   // Register user-created scheduled tasks from tasks.json.
   registerUserTasks({ taskManager, startChat })

--- a/server/workspace/feeds/agentIngest.ts
+++ b/server/workspace/feeds/agentIngest.ts
@@ -68,15 +68,24 @@ export async function refreshViaAgent(workspaceRoot: string, collection: LoadedC
   const items = await listItems(collection.dataDir, { workspaceRoot });
   const message = buildCollectionActionSeedPrompt(items, collection.schema, template);
 
-  const launch = await workerRunner({
-    message,
-    roleId: ingest.role,
-    hidden,
-    // A visible manual run is watched directly — only hidden runs get the
-    // completion hook (failure bell + consecutiveFailures); `finalizeRun` only
-    // fires it for system-origin sessions anyway.
-    onComplete: hidden ? (outcome) => recordOutcome(workspaceRoot, collection, outcome.didError) : undefined,
-  });
+  // The runner is injected, so guard its promise here to honour the
+  // failure-isolated contract (a rejection must become an `errors` entry, not
+  // escape into the scheduler loop / route handler).
+  let launch: AgentWorkerResult;
+  try {
+    launch = await workerRunner({
+      message,
+      roleId: ingest.role,
+      hidden,
+      // A visible manual run is watched directly — only hidden runs get the
+      // completion hook (failure bell + consecutiveFailures); `finalizeRun` only
+      // fires it for system-origin sessions anyway.
+      onComplete: hidden ? (outcome) => recordOutcome(workspaceRoot, collection, outcome.didError) : undefined,
+    });
+  } catch (err) {
+    log.warn("feeds", "agent ingest worker launch threw", { slug, error: String(err) });
+    return result(slug, { errors: [String(err)], dispatched: false });
+  }
   if (!launch.ok) {
     // Cap-miss or launch error: do NOT touch lastFetchedAt — the next due tick
     // (or manual Refresh) redials. Surface it so a manual refresh reads honest.

--- a/server/workspace/feeds/agentIngest.ts
+++ b/server/workspace/feeds/agentIngest.ts
@@ -1,0 +1,138 @@
+// Agent-performed ingest (`ingest.kind: "agent"`). On schedule (or a manual
+// Refresh), the host seeds a hidden background worker — origin `system`, so
+// it never appears in the user's session list — in the collection's declared
+// role with its template + a summary of every record, and the worker edits the
+// records itself via the collections io layer. The host stays domain-free:
+// everything stock-specific (or whatever the collection does) is prose in the
+// template.
+//
+// DI seam: the worker is launched through a runner injected at boot
+// (`setAgentWorkerRunner`), not imported directly, because this module lives in
+// `server/workspace/` and must not import `server/api/routes/agent.ts` (that
+// would form a workspace→routes cycle). `server/index.ts` wires
+// `spawnSystemWorker` in as the runner.
+
+import { log } from "../../system/logger/index.js";
+import { listItems, readSkillTemplate, buildCollectionActionSeedPrompt, type LoadedCollection } from "../collections/index.js";
+import { publish as publishNotifier, clear as clearNotifier } from "../../notifier/engine.js";
+import { readFeedState, writeFeedState, type FeedState } from "./state.js";
+import type { AgentIngestSpec } from "./ingestTypes.js";
+import type { RefreshResult } from "./refreshResult.js";
+
+/** Outcome of launching one hidden worker. `chatId` lets the caller register a
+ *  completion hook so a failed refresh doesn't die silently. */
+export type AgentWorkerResult = { ok: true; chatId: string } | { ok: false; error: string };
+
+/** Launches a worker chat. Injected at boot to avoid a workspace→routes import
+ *  cycle. `hidden` chooses an invisible system worker (scheduled refresh) vs a
+ *  visible session the user can watch (manual Refresh — debuggable).
+ *  `onComplete` is a one-shot completion hook (only honoured for hidden workers)
+ *  so the dispatcher learns success/failure. Returns `ok:false` on the
+ *  concurrency-cap miss or a launch error — the caller leaves state untouched
+ *  and retries next tick. */
+export type AgentWorkerRunner = (args: {
+  message: string;
+  roleId: string;
+  hidden: boolean;
+  onComplete?: (outcome: { didError: boolean }) => void | Promise<void>;
+}) => Promise<AgentWorkerResult>;
+
+let workerRunner: AgentWorkerRunner | null = null;
+
+/** Wire the hidden-worker launcher. Called once at boot from `server/index.ts`. */
+export function setAgentWorkerRunner(runner: AgentWorkerRunner): void {
+  workerRunner = runner;
+}
+
+function result(slug: string, patch: Partial<RefreshResult>): RefreshResult {
+  return { slug, written: 0, removed: 0, errors: [], ...patch };
+}
+
+/** Dispatch one agent-ingest refresh: build the seed, launch a worker, and (on a
+ *  successful launch) stamp `lastFetchedAt` with the DISPATCH time — not
+ *  completion. That's what gates the due-loop, so a slow worker can't cause a
+ *  double-dispatch. `opts.hidden` (default true) runs an invisible system worker
+ *  for SCHEDULED refreshes; a MANUAL Refresh passes `hidden:false` for a visible,
+ *  debuggable session. Failure-isolated: never throws; cap-miss / template-miss /
+ *  launch error leave state untouched and report via `errors`. */
+export async function refreshViaAgent(workspaceRoot: string, collection: LoadedCollection, opts?: { hidden?: boolean }): Promise<RefreshResult> {
+  const hidden = opts?.hidden ?? true;
+  const { slug } = collection;
+  const ingest = collection.schema.ingest as AgentIngestSpec | undefined;
+  if (!ingest || ingest.kind !== "agent") return result(slug, { errors: ["collection has no agent ingest config"] });
+  if (!workerRunner) return result(slug, { errors: ["agent ingest worker runner not configured"] });
+
+  const template = await readSkillTemplate(collection.skillDir, ingest.template);
+  if (template === null) return result(slug, { errors: [`ingest template '${ingest.template}' could not be read`] });
+
+  const items = await listItems(collection.dataDir, { workspaceRoot });
+  const message = buildCollectionActionSeedPrompt(items, collection.schema, template);
+
+  const launch = await workerRunner({
+    message,
+    roleId: ingest.role,
+    hidden,
+    // A visible manual run is watched directly — only hidden runs get the
+    // completion hook (failure bell + consecutiveFailures); `finalizeRun` only
+    // fires it for system-origin sessions anyway.
+    onComplete: hidden ? (outcome) => recordOutcome(workspaceRoot, collection, outcome.didError) : undefined,
+  });
+  if (!launch.ok) {
+    // Cap-miss or launch error: do NOT touch lastFetchedAt — the next due tick
+    // (or manual Refresh) redials. Surface it so a manual refresh reads honest.
+    log.info("feeds", "agent ingest dispatch skipped", { slug, error: launch.error });
+    return result(slug, { errors: [launch.error], dispatched: false });
+  }
+
+  const state = await readFeedState(workspaceRoot, collection);
+  await writeFeedState(workspaceRoot, collection, { ...state, lastFetchedAt: new Date().toISOString() });
+  log.info("feeds", "agent ingest dispatched", { slug, role: ingest.role, chatId: launch.chatId, hidden, items: items.length });
+  // Surface the chatId only for a visible run so the client can open it; a hidden
+  // session is excluded from every listing and can't be navigated to anyway.
+  return result(slug, { dispatched: true, ...(hidden ? {} : { chatId: launch.chatId }) });
+}
+
+/** Completion hook: reconcile failure tracking when a dispatched worker
+ *  finishes. On error, bump `consecutiveFailures` and raise a single failure
+ *  bell (deduped via the persisted `failureBellId`). On success, reset the
+ *  counter and clear any standing bell. Best-effort + failure-isolated — it
+ *  runs inside the agent run's teardown, so it must never throw. */
+async function recordOutcome(workspaceRoot: string, collection: LoadedCollection, didError: boolean): Promise<void> {
+  const state = await readFeedState(workspaceRoot, collection);
+  const next: FeedState = didError ? await onWorkerError(state, collection) : await onWorkerSuccess(state, collection);
+  await writeFeedState(workspaceRoot, collection, next);
+}
+
+async function onWorkerError(state: FeedState, collection: LoadedCollection): Promise<FeedState> {
+  const next: FeedState = { ...state, consecutiveFailures: state.consecutiveFailures + 1 };
+  log.warn("feeds", "agent ingest worker failed", { slug: collection.slug, consecutiveFailures: next.consecutiveFailures });
+  // Raise a single bell on the first failure; a standing one isn't piled onto.
+  if (!state.failureBellId) {
+    try {
+      const { id } = await publishNotifier({
+        pluginPkg: "host",
+        severity: "nudge",
+        lifecycle: "fyi",
+        title: "Collection refresh failed",
+        body: `“${collection.schema.title}” (${collection.slug}) couldn't refresh. Open it to retry.`,
+        navigateTarget: `/collections/${collection.slug}`,
+      });
+      next.failureBellId = id;
+    } catch (err) {
+      log.warn("feeds", "failed to publish ingest failure bell", { slug: collection.slug, error: String(err) });
+    }
+  }
+  return next;
+}
+
+async function onWorkerSuccess(state: FeedState, collection: LoadedCollection): Promise<FeedState> {
+  log.info("feeds", "agent ingest worker completed", { slug: collection.slug });
+  if (state.failureBellId) {
+    await clearNotifier(state.failureBellId).catch((err) =>
+      log.warn("feeds", "failed to clear ingest failure bell", { slug: collection.slug, error: String(err) }),
+    );
+  }
+  const next: FeedState = { ...state, consecutiveFailures: 0 };
+  delete next.failureBellId;
+  return next;
+}

--- a/server/workspace/feeds/engine.ts
+++ b/server/workspace/feeds/engine.ts
@@ -7,13 +7,24 @@
 
 import { workspacePath } from "../workspace.js";
 import { log } from "../../system/logger/index.js";
-import { deleteItem, listItems, writeItem, type CollectionItem, type CollectionSchema, type LoadedCollection } from "../collections/index.js";
+import {
+  deleteItem,
+  discoverCollections,
+  listItems,
+  writeItem,
+  type CollectionItem,
+  type CollectionSchema,
+  type LoadedCollection,
+} from "../collections/index.js";
 import { ONE_HOUR_MS, ONE_DAY_MS } from "../../utils/time.js";
 import { getRetriever } from "./retrievers/index.js";
 import "./retrievers/registerAll.js";
-import { listFeeds } from "./registry.js";
 import { readFeedState, writeFeedState, type FeedState } from "./state.js";
-import { DEFAULT_FEED_MAX_ITEMS, type FeedSchedule, type IngestSpec } from "./ingestTypes.js";
+import { DEFAULT_FEED_MAX_ITEMS, AGENT_INGEST_KIND, type FeedSchedule, type IngestSpec } from "./ingestTypes.js";
+import { refreshViaAgent } from "./agentIngest.js";
+import type { RefreshResult } from "./refreshResult.js";
+
+export type { RefreshResult } from "./refreshResult.js";
 
 /** Feed schemas carry the rich `IngestSpec` (validated at discovery —
  *  `source === "feed"` requires `ingest`), but the canonical
@@ -21,14 +32,6 @@ import { DEFAULT_FEED_MAX_ITEMS, type FeedSchedule, type IngestSpec } from "./in
  *  Narrow here so the engine can read the retrieval fields type-safely. */
 function feedIngest(schema: CollectionSchema): IngestSpec | undefined {
   return schema.ingest as IngestSpec | undefined;
-}
-
-export interface RefreshResult {
-  slug: string;
-  written: number;
-  /** Old records deleted by the maxItems cap this run. */
-  removed: number;
-  errors: string[];
 }
 
 async function upsertItems(workspaceRoot: string, feed: LoadedCollection, items: CollectionItem[]): Promise<number> {
@@ -63,7 +66,10 @@ function recordTime(item: CollectionItem, field: string): number {
  *  the schema's date field, delete the rest. No-op when the cap is 0/absent
  *  of a date field, or when under the cap. Returns the number deleted. */
 async function pruneFeed(workspaceRoot: string, feed: LoadedCollection): Promise<number> {
-  const cap = feedIngest(feed.schema)?.maxItems ?? DEFAULT_FEED_MAX_ITEMS;
+  const ingest = feedIngest(feed.schema);
+  // maxItems is a declarative-feed concept; agent ingest manages its own record
+  // set, so it's never pruned here (and `refreshOne` never calls pruneFeed for it).
+  const cap = (ingest && ingest.kind !== AGENT_INGEST_KIND ? ingest.maxItems : undefined) ?? DEFAULT_FEED_MAX_ITEMS;
   if (cap <= 0) return 0;
   const dateField = firstDateField(feed.schema);
   if (!dateField) {
@@ -85,22 +91,27 @@ async function pruneFeed(workspaceRoot: string, feed: LoadedCollection): Promise
 
 /** Fetch one feed now, upsert its records, then enforce the maxItems cap.
  *  Failure-isolated: returns an errors array rather than throwing. */
-export async function refreshOne(workspaceRoot: string, feed: LoadedCollection): Promise<RefreshResult> {
+export async function refreshOne(workspaceRoot: string, feed: LoadedCollection, opts?: { hidden?: boolean }): Promise<RefreshResult> {
   const { slug } = feed;
   const ingest = feedIngest(feed.schema);
   if (!ingest) return { slug, written: 0, removed: 0, errors: ["collection has no ingest config"] };
+  // `agent` ingest dispatches a worker instead of fetching: branch off BEFORE
+  // the retriever registry (which only knows declarative kinds). `opts.hidden`
+  // (manual Refresh passes false) only affects the agent path; declarative
+  // feeds ignore it.
+  if (ingest.kind === AGENT_INGEST_KIND) return refreshViaAgent(workspaceRoot, feed, opts);
   const retriever = getRetriever(ingest.kind);
   if (!retriever) return { slug, written: 0, removed: 0, errors: [`no retriever registered for kind '${ingest.kind}'`] };
-  const state = await readFeedState(workspaceRoot, slug);
+  const state = await readFeedState(workspaceRoot, feed);
   try {
     const result = await retriever(ingest, feed.schema, state);
     const written = await upsertItems(workspaceRoot, feed, result.items);
-    await writeFeedState(workspaceRoot, slug, { ...state, lastFetchedAt: new Date().toISOString(), cursor: result.cursor, consecutiveFailures: 0 });
+    await writeFeedState(workspaceRoot, feed, { ...state, lastFetchedAt: new Date().toISOString(), cursor: result.cursor, consecutiveFailures: 0 });
     const removed = await pruneFeed(workspaceRoot, feed);
     log.info("feeds", "feed refreshed", { slug, written, removed, fetched: result.items.length });
     return { slug, written, removed, errors: [] };
   } catch (error) {
-    await writeFeedState(workspaceRoot, slug, { ...state, consecutiveFailures: state.consecutiveFailures + 1 });
+    await writeFeedState(workspaceRoot, feed, { ...state, consecutiveFailures: state.consecutiveFailures + 1 });
     const message = String(error);
     log.warn("feeds", "feed refresh failed", { slug, error: message });
     return { slug, written: 0, removed: 0, errors: [message] };
@@ -118,26 +129,46 @@ function dueIntervalMs(schedule: FeedSchedule): number {
   }
 }
 
-/** True iff a feed is due to refresh given its schedule + last fetch.
- *  `on-demand` feeds are never auto-due. */
+/** True iff a `daily` schedule with a UTC `atHour` anchor is due. The system
+ *  task ticks hourly, so "due" means: we're in the anchor hour AND we haven't
+ *  already run in roughly the last day. The 23 h floor (not 24 h) tolerates the
+ *  tick landing a few minutes earlier than the previous run, while staying well
+ *  above 1 h so a second tick in the same anchor hour can't double-fire. */
+function isDailyAtHourDue(now: Date, atHour: number, lastFetchedAt: string | null): boolean {
+  if (now.getUTCHours() !== atHour) return false;
+  if (!lastFetchedAt) return true;
+  const elapsed = now.getTime() - Date.parse(lastFetchedAt);
+  if (!Number.isFinite(elapsed)) return true;
+  return elapsed >= 23 * ONE_HOUR_MS;
+}
+
+/** True iff a collection is due to refresh given its schedule + last run.
+ *  `on-demand` is never auto-due; a `daily` schedule with `atHour` anchors to
+ *  that UTC hour, otherwise cadence is elapsed-based. */
 function isFeedDue(feed: LoadedCollection, state: FeedState): boolean {
-  const schedule = feedIngest(feed.schema)?.schedule;
+  const ingest = feedIngest(feed.schema);
+  const schedule = ingest?.schedule;
   if (!schedule || schedule === "on-demand") return false;
+  if (schedule === "daily" && typeof ingest?.atHour === "number") {
+    return isDailyAtHourDue(new Date(), ingest.atHour, state.lastFetchedAt);
+  }
   if (!state.lastFetchedAt) return true;
   const elapsed = Date.now() - Date.parse(state.lastFetchedAt);
   if (!Number.isFinite(elapsed)) return true;
   return elapsed >= dueIntervalMs(schedule);
 }
 
-/** Refresh every feed whose schedule says it's due. Called by the
+/** Refresh every collection whose ingest schedule says it's due — declarative
+ *  feeds AND skill-backed collections with `ingest.kind: "agent"`. Called by the
  *  hourly system task. Sequential + failure-isolated. */
 export async function refreshDue(workspaceRoot: string = workspacePath): Promise<RefreshResult[]> {
-  const feeds = await listFeeds(workspaceRoot);
+  const all = await discoverCollections({ workspaceRoot });
+  const withIngest = all.filter((collection) => collection.schema.ingest);
   const results: RefreshResult[] = [];
-  for (const feed of feeds) {
-    const state = await readFeedState(workspaceRoot, feed.slug);
-    if (!isFeedDue(feed, state)) continue;
-    results.push(await refreshOne(workspaceRoot, feed));
+  for (const collection of withIngest) {
+    const state = await readFeedState(workspaceRoot, collection);
+    if (!isFeedDue(collection, state)) continue;
+    results.push(await refreshOne(workspaceRoot, collection));
   }
   return results;
 }

--- a/server/workspace/feeds/engine.ts
+++ b/server/workspace/feeds/engine.ts
@@ -166,9 +166,17 @@ export async function refreshDue(workspaceRoot: string = workspacePath): Promise
   const withIngest = all.filter((collection) => collection.schema.ingest);
   const results: RefreshResult[] = [];
   for (const collection of withIngest) {
-    const state = await readFeedState(workspaceRoot, collection);
-    if (!isFeedDue(collection, state)) continue;
-    results.push(await refreshOne(workspaceRoot, collection));
+    // Isolate per-collection failures: `readFeedState`/`refreshOne` (esp. the
+    // agent path) can throw, and one bad collection must not abort the whole
+    // due-loop. Capture it as an errors result and move on.
+    try {
+      const state = await readFeedState(workspaceRoot, collection);
+      if (!isFeedDue(collection, state)) continue;
+      results.push(await refreshOne(workspaceRoot, collection));
+    } catch (error) {
+      log.warn("feeds", "scheduled refresh failed for collection", { slug: collection.slug, error: String(error) });
+      results.push({ slug: collection.slug, written: 0, removed: 0, errors: [String(error)] });
+    }
   }
   return results;
 }

--- a/server/workspace/feeds/index.ts
+++ b/server/workspace/feeds/index.ts
@@ -3,6 +3,7 @@
 
 export { listFeeds, removeFeed } from "./registry.js";
 export { refreshOne, refreshDue, type RefreshResult } from "./engine.js";
+export { setAgentWorkerRunner, type AgentWorkerRunner, type AgentWorkerResult } from "./agentIngest.js";
 export { feedsRoot, feedDir, feedStatePath, FEEDS_DIR } from "./paths.js";
 export { readFeedState, type FeedState } from "./state.js";
 export { INGEST_KINDS, FEED_SCHEDULES, isFeedSchedule, type IngestSpec, type IngestKind, type FeedSchedule } from "./ingestTypes.js";

--- a/server/workspace/feeds/ingestTypes.ts
+++ b/server/workspace/feeds/ingestTypes.ts
@@ -8,13 +8,21 @@
 // now lives in @mulmoclaude/core/collection alongside the schema contract, so
 // the package's schema validator can enforce it. Re-exported here so the feeds
 // engine's existing importers resolve them unchanged.
-import { type CollectionIngest, INGEST_KINDS, FEED_SCHEDULES, type IngestKind, type FeedSchedule } from "@mulmoclaude/core/collection";
+import {
+  type CollectionIngest,
+  INGEST_KINDS,
+  AGENT_INGEST_KIND,
+  FEED_SCHEDULES,
+  type IngestKind,
+  type AgentIngestKind,
+  type FeedSchedule,
+} from "@mulmoclaude/core/collection";
 //
-// Declarative-only for now; the `kind` enum reserves room for future
-// "code" (LLM-generated transform) and "prompt" (LLM-performed fetch)
-// retrievers without reshaping the engine.
+// Two flavours: the declarative kinds (`rss`/`atom`/`http-json`) fetch-and-map,
+// and `agent` dispatches a hidden worker. The `code` kind (LLM-generated
+// deterministic transform) is still reserved for a future retriever.
 
-export { INGEST_KINDS, FEED_SCHEDULES, type IngestKind, type FeedSchedule };
+export { INGEST_KINDS, AGENT_INGEST_KIND, FEED_SCHEDULES, type IngestKind, type AgentIngestKind, type FeedSchedule };
 
 const FEED_SCHEDULE_SET: ReadonlySet<string> = new Set(FEED_SCHEDULES);
 
@@ -31,12 +39,13 @@ export const DEFAULT_FEED_MAX_ITEMS = 100;
  *  `"data.name"`). */
 export type IngestFieldMap = Record<string, string>;
 
-/** The `ingest` block carried on a Feed's `CollectionSchema`. The canonical
- *  schema (in @mulmoclaude/core/collection) only promises the minimal
- *  `CollectionIngest` (kind/url/schedule as plain strings); this feeds-only
- *  subtype narrows those + adds the retrieval fields the engine needs. */
-export interface IngestSpec extends CollectionIngest {
-  /** Which retriever handles this feed. */
+/** Declarative retrieval (`rss`/`atom`/`http-json`): the host fetches `url`
+ *  and projects each item through `map`. The canonical schema (in
+ *  @mulmoclaude/core/collection) only promises the minimal `CollectionIngest`;
+ *  this feeds-only subtype narrows those + adds the retrieval fields the engine
+ *  needs. */
+export interface DeclarativeIngestSpec extends CollectionIngest {
+  /** Which declarative retriever handles this feed. */
   kind: IngestKind;
   /** Endpoint to fetch (http/https). */
   url: string;
@@ -60,3 +69,20 @@ export interface IngestSpec extends CollectionIngest {
    *  when the schema has no `date` field to order by. */
   maxItems?: number;
 }
+
+/** Agent-performed retrieval (`kind: "agent"`). No `url`/`map`: the host seeds
+ *  a hidden background worker (origin `system`) in `role` with `template` + a
+ *  summary of every record, and the worker edits the records itself via the
+ *  collections io layer. Valid on any collection (primarily skill-backed). */
+export interface AgentIngestSpec extends CollectionIngest {
+  kind: AgentIngestKind;
+  /** Refresh cadence (same vocabulary as declarative feeds). */
+  schedule: FeedSchedule;
+  /** Role id the scheduled hidden worker runs in. */
+  role: string;
+  /** Skill-relative template path (under `templates/`) seeding the worker. */
+  template: string;
+}
+
+/** The `ingest` block carried on a `CollectionSchema`, discriminated on `kind`. */
+export type IngestSpec = DeclarativeIngestSpec | AgentIngestSpec;

--- a/server/workspace/feeds/ingestTypes.ts
+++ b/server/workspace/feeds/ingestTypes.ts
@@ -8,21 +8,22 @@
 // now lives in @mulmoclaude/core/collection alongside the schema contract, so
 // the package's schema validator can enforce it. Re-exported here so the feeds
 // engine's existing importers resolve them unchanged.
-import {
-  type CollectionIngest,
-  INGEST_KINDS,
-  AGENT_INGEST_KIND,
-  FEED_SCHEDULES,
-  type IngestKind,
-  type AgentIngestKind,
-  type FeedSchedule,
-} from "@mulmoclaude/core/collection";
+import { type CollectionIngest, INGEST_KINDS, FEED_SCHEDULES, type IngestKind, type FeedSchedule } from "@mulmoclaude/core/collection";
 //
 // Two flavours: the declarative kinds (`rss`/`atom`/`http-json`) fetch-and-map,
 // and `agent` dispatches a hidden worker. The `code` kind (LLM-generated
 // deterministic transform) is still reserved for a future retriever.
 
-export { INGEST_KINDS, AGENT_INGEST_KIND, FEED_SCHEDULES, type IngestKind, type AgentIngestKind, type FeedSchedule };
+// The agent ingest kind. Defined HERE (not imported from core) on purpose: the
+// host only needs the literal to branch in the engine, and importing it as a
+// VALUE from `@mulmoclaude/core` would make the launcher fail to boot against a
+// core version published before this feature (ESM "no export named
+// AGENT_INGEST_KIND"). Core owns its own copy for the schema validator; this
+// matches the same literal. The published core catches up on the next cascade.
+export const AGENT_INGEST_KIND = "agent" as const;
+export type AgentIngestKind = typeof AGENT_INGEST_KIND;
+
+export { INGEST_KINDS, FEED_SCHEDULES, type IngestKind, type FeedSchedule };
 
 const FEED_SCHEDULE_SET: ReadonlySet<string> = new Set(FEED_SCHEDULES);
 

--- a/server/workspace/feeds/paths.ts
+++ b/server/workspace/feeds/paths.ts
@@ -10,6 +10,7 @@
 
 import path from "node:path";
 import { workspacePath } from "../workspace.js";
+import { WORKSPACE_DIRS } from "../paths.js";
 
 export const FEEDS_DIR = "feeds";
 export const FEED_STATE_FILE = "_state.json";
@@ -27,4 +28,18 @@ export function feedDir(slug: string, workspaceRoot: string = workspacePath): st
 /** Absolute path to one feed's retrieval-state file. */
 export function feedStatePath(slug: string, workspaceRoot: string = workspacePath): string {
   return path.join(feedsRoot(workspaceRoot), slug, FEED_STATE_FILE);
+}
+
+/** Directory holding retrieval state for NON-feed collections with an
+ *  `ingest` block (`kind: "agent"`). One file per collection. */
+export function ingestStateDir(workspaceRoot: string = workspacePath): string {
+  return path.join(workspaceRoot, WORKSPACE_DIRS.ingestState);
+}
+
+/** Absolute path to a non-feed collection's ingest-state file
+ *  (`data/ingest-state/<slug>.json`). Kept OUT of the collection's dataDir
+ *  (where `listItems` would read it as a record) and out of `feeds/` (a
+ *  schema-less `feeds/<slug>/` dir confuses feed discovery). */
+export function ingestStatePath(slug: string, workspaceRoot: string = workspacePath): string {
+  return path.join(ingestStateDir(workspaceRoot), `${slug}.json`);
 }

--- a/server/workspace/feeds/projectItem.ts
+++ b/server/workspace/feeds/projectItem.ts
@@ -12,7 +12,7 @@
 import { createHash } from "node:crypto";
 import { getByPath } from "./pathResolver.js";
 import type { CollectionItem, CollectionSchema } from "../collections/index.js";
-import type { IngestSpec } from "./ingestTypes.js";
+import type { DeclarativeIngestSpec } from "./ingestTypes.js";
 
 function asKeyString(value: unknown): string | null {
   if (typeof value === "string" && value.trim().length > 0) return value.trim();
@@ -66,7 +66,7 @@ function toSafeId(natural: string): string {
   return slug.length > 80 ? `${slug.slice(0, 60)}-${hash}` : `feed-${hash}`;
 }
 
-function naturalKey(record: CollectionItem, rawItem: unknown, ingest: IngestSpec, schema: CollectionSchema): string {
+function naturalKey(record: CollectionItem, rawItem: unknown, ingest: DeclarativeIngestSpec, schema: CollectionSchema): string {
   const fromMapped = asKeyString(record[schema.primaryKey]);
   if (fromMapped) return fromMapped;
   if (ingest.idFrom) {
@@ -81,7 +81,7 @@ function naturalKey(record: CollectionItem, rawItem: unknown, ingest: IngestSpec
  *  the raw item and normalized per the target field's declared type. The
  *  returned record's primaryKey is set to the derived safe id (so it
  *  doubles as the filename). */
-export function projectRecord(rawItem: unknown, ingest: IngestSpec, schema: CollectionSchema): CollectionItem {
+export function projectRecord(rawItem: unknown, ingest: DeclarativeIngestSpec, schema: CollectionSchema): CollectionItem {
   const record: CollectionItem = {};
   for (const [targetField, sourcePath] of Object.entries(ingest.map)) {
     const value = normalizeValue(getByPath(rawItem, sourcePath), schema.fields?.[targetField]?.type);

--- a/server/workspace/feeds/refreshResult.ts
+++ b/server/workspace/feeds/refreshResult.ts
@@ -1,0 +1,21 @@
+// Shared result shape for a single collection refresh, in its own module so
+// both the engine (declarative path) and the agent-ingest dispatcher can use
+// it without forming an `engine.ts` ↔ `agentIngest.ts` import cycle.
+
+export interface RefreshResult {
+  slug: string;
+  /** Records written this run. Always 0 for agent ingest (the worker writes
+   *  records asynchronously, after this returns). */
+  written: number;
+  /** Old records deleted by the maxItems cap this run. */
+  removed: number;
+  errors: string[];
+  /** True when an agent-ingest run dispatched a worker (fire-and-forget): the
+   *  records update later when the worker finishes. Absent/false for declarative
+   *  feeds, which write records synchronously before returning. */
+  dispatched?: boolean;
+  /** The dispatched worker's chat session id. Set only for a VISIBLE (manual)
+   *  agent-ingest run so the client can open the session to watch it; absent for
+   *  hidden scheduled runs and declarative feeds. */
+  chatId?: string;
+}

--- a/server/workspace/feeds/retrievers/index.ts
+++ b/server/workspace/feeds/retrievers/index.ts
@@ -1,10 +1,11 @@
-// Pluggable retriever registry. Each `ingest.kind` maps to one
+// Pluggable retriever registry. Each declarative `ingest.kind` maps to one
 // RetrieveFn that fetches the endpoint and returns projected records.
 // Side-effect registration keeps the engine decoupled from the kinds.
-// New kinds (`code`, `prompt`) register here without touching the engine.
+// The `agent` kind is NOT a retriever (it dispatches a hidden worker before
+// the engine consults this registry); a future `code` kind would register here.
 
 import type { CollectionItem, CollectionSchema } from "../../collections/index.js";
-import type { IngestSpec } from "../ingestTypes.js";
+import type { DeclarativeIngestSpec } from "../ingestTypes.js";
 import type { FeedState } from "../state.js";
 
 export interface RetrieveResult {
@@ -14,7 +15,10 @@ export interface RetrieveResult {
   cursor: Record<string, string>;
 }
 
-export type RetrieveFn = (ingest: IngestSpec, schema: CollectionSchema, state: FeedState) => Promise<RetrieveResult>;
+// Declarative-only: the engine branches `agent` ingest off BEFORE looking up a
+// retriever, so a RetrieveFn never sees a non-fetch spec (and rss/http-json can
+// read `ingest.url`/`map` without union narrowing).
+export type RetrieveFn = (ingest: DeclarativeIngestSpec, schema: CollectionSchema, state: FeedState) => Promise<RetrieveResult>;
 
 const registry = new Map<string, RetrieveFn>();
 

--- a/server/workspace/feeds/state.ts
+++ b/server/workspace/feeds/state.ts
@@ -1,22 +1,46 @@
-// Per-feed retrieval state — when we last fetched, the retriever's
-// cursor (for incremental fetches), and a consecutive-failure counter.
-// NOT committed to git; lives at `<workspace>/feeds/<slug>/_state.json`.
+// Per-collection retrieval state — when we last fetched/dispatched, the
+// retriever's cursor (for incremental fetches), and a consecutive-failure
+// counter. NOT committed to git. Location depends on the collection's source:
+// feeds keep it alongside the schema at `<workspace>/feeds/<slug>/_state.json`;
+// skill-backed collections with `ingest.kind: "agent"` store it at
+// `<workspace>/data/ingest-state/<slug>.json` (a schema-less `feeds/<slug>/`
+// dir would confuse feed discovery, and `_state.json` must never live in a
+// collection's dataDir where `listItems` would read it as a record).
 // Deliberately minimal: the legacy `sources` tree carries richer backoff
-// state, but the Feeds engine starts simple and grows on real need.
+// state, but the engine starts simple and grows on real need.
 
 import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import type { CollectionSource } from "@mulmoclaude/core/collection";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { log } from "../../system/logger/index.js";
-import { feedDir, feedStatePath } from "./paths.js";
+import { feedStatePath, ingestStatePath } from "./paths.js";
+
+/** Minimal shape needed to locate a collection's state file. `LoadedCollection`
+ *  satisfies it. */
+export interface StateTarget {
+  slug: string;
+  source: CollectionSource;
+}
+
+/** Resolve the on-disk state file for a collection, branching on source. */
+function stateFilePath(target: StateTarget, workspaceRoot: string): string {
+  return target.source === "feed" ? feedStatePath(target.slug, workspaceRoot) : ingestStatePath(target.slug, workspaceRoot);
+}
 
 export interface FeedState {
   slug: string;
-  /** ISO timestamp of the last successful fetch, or null if never. */
+  /** ISO timestamp of the last successful fetch (declarative) or dispatch
+   *  (agent ingest), or null if never. */
   lastFetchedAt: string | null;
   /** Free-form retriever cursor (e.g. last-seen id / etag). */
   cursor: Record<string, string>;
-  /** Consecutive failed fetches; reset to 0 on success. */
+  /** Consecutive failed fetches/runs; reset to 0 on success. */
   consecutiveFailures: number;
+  /** Agent ingest only: the notifier entry id of the active "refresh failed"
+   *  bell, so a later success can clear exactly that entry. Absent when no
+   *  failure bell is showing. */
+  failureBellId?: string;
 }
 
 export function defaultFeedState(slug: string): FeedState {
@@ -31,13 +55,16 @@ function normalizeState(slug: string, parsed: Partial<FeedState>): FeedState {
     lastFetchedAt: typeof parsed.lastFetchedAt === "string" ? parsed.lastFetchedAt : base.lastFetchedAt,
     cursor,
     consecutiveFailures: typeof parsed.consecutiveFailures === "number" ? parsed.consecutiveFailures : base.consecutiveFailures,
+    ...(typeof parsed.failureBellId === "string" ? { failureBellId: parsed.failureBellId } : {}),
   };
 }
 
-/** Read a feed's state, tolerating a missing file (first run → default). */
-export async function readFeedState(workspaceRoot: string, slug: string): Promise<FeedState> {
+/** Read a collection's retrieval state, tolerating a missing file (first run →
+ *  default). The state path branches on `target.source`. */
+export async function readFeedState(workspaceRoot: string, target: StateTarget): Promise<FeedState> {
+  const { slug } = target;
   try {
-    const raw = await readFile(feedStatePath(slug, workspaceRoot), "utf-8");
+    const raw = await readFile(stateFilePath(target, workspaceRoot), "utf-8");
     return normalizeState(slug, JSON.parse(raw) as Partial<FeedState>);
   } catch (err) {
     const error = err as { code?: string };
@@ -48,8 +75,10 @@ export async function readFeedState(workspaceRoot: string, slug: string): Promis
   }
 }
 
-/** Persist a feed's state atomically (creating the feed dir if needed). */
-export async function writeFeedState(workspaceRoot: string, slug: string, state: FeedState): Promise<void> {
-  await mkdir(feedDir(slug, workspaceRoot), { recursive: true });
-  await writeFileAtomic(feedStatePath(slug, workspaceRoot), `${JSON.stringify(state, null, 2)}\n`);
+/** Persist a collection's retrieval state atomically (creating the parent dir
+ *  if needed). The state path branches on `target.source`. */
+export async function writeFeedState(workspaceRoot: string, target: StateTarget, state: FeedState): Promise<void> {
+  const file = stateFilePath(target, workspaceRoot);
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFileAtomic(file, `${JSON.stringify(state, null, 2)}\n`);
 }

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -119,6 +119,13 @@ const HOST_WORKSPACE_DIRS = {
   // Non-skill data-source feed registry: feeds/<slug>/schema.json (+
   // _state.json). Records land under each schema's dataPath (data/feeds/*).
   feeds: "feeds",
+  // Retrieval state for NON-feed collections with an `ingest` block
+  // (`kind: "agent"` on a skill-backed collection). Feeds keep their state
+  // at feeds/<slug>/_state.json; skill collections can't (a feeds/<slug>/
+  // dir without schema.json confuses feed discovery, and _state.json must
+  // never live in a collection's dataDir where listItems would read it as a
+  // record). One file per collection: data/ingest-state/<slug>.json.
+  ingestState: "data/ingest-state",
   translation: "data/translation",
   // Pasted/dropped chat attachments — saved at upload time so the
   // LLM can be handed a stable workspace path instead of inline

--- a/test/workspace/collections/test_discovery.ts
+++ b/test/workspace/collections/test_discovery.ts
@@ -861,6 +861,100 @@ describe("discoverCollections — actions", () => {
   });
 });
 
+describe('discoverCollections — agent ingest (`ingest.kind: "agent"`)', () => {
+  const fields = { id: { type: "string", label: "ID", primary: true, required: true } };
+
+  it("accepts a valid agent ingest block", async () => {
+    writeSkill("test-agent-ingest", {
+      title: "Quotes",
+      icon: "trending_up",
+      dataPath: "data/quotes/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "agent", schedule: "daily", role: "investor", template: "templates/refresh.md" },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.ingest?.kind, "agent");
+    assert.equal(collections[0]?.schema.ingest?.role, "investor");
+    assert.equal(collections[0]?.schema.ingest?.template, "templates/refresh.md");
+  });
+
+  it("accepts an agent ingest with a UTC atHour anchor", async () => {
+    writeSkill("test-agent-athour", {
+      title: "Quotes",
+      icon: "trending_up",
+      dataPath: "data/athour/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "agent", schedule: "daily", atHour: 13, role: "investor", template: "templates/refresh.md" },
+    });
+    const collections = await listCollections();
+    assert.equal(collections.length, 1);
+    assert.equal(collections[0]?.schema.ingest?.atHour, 13);
+  });
+
+  it("rejects an agent ingest missing role", async () => {
+    writeSkill("test-agent-no-role", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/agnorole/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "agent", schedule: "daily", template: "templates/refresh.md" },
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects an agent ingest template with path traversal", async () => {
+    writeSkill("test-agent-traversal", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/agtrav/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "agent", schedule: "daily", role: "investor", template: "../../etc/passwd" },
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects an agent ingest template not under templates/", async () => {
+    writeSkill("test-agent-bare-template", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/agbare/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "agent", schedule: "daily", role: "investor", template: "refresh.md" },
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects an atHour outside 0–23", async () => {
+    writeSkill("test-agent-bad-athour", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/agbadhour/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "agent", schedule: "daily", atHour: 24, role: "investor", template: "templates/refresh.md" },
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+
+  it("rejects an unknown ingest kind", async () => {
+    writeSkill("test-ingest-bad-kind", {
+      title: "X",
+      icon: "warning",
+      dataPath: "data/badkind/items",
+      primaryKey: "id",
+      fields,
+      ingest: { kind: "telepathy", schedule: "daily", role: "investor", template: "templates/refresh.md" },
+    });
+    assert.equal((await listCollections()).length, 0);
+  });
+});
+
 describe("discoverCollections — field visibility (`when`)", () => {
   it("accepts a field with a valid `when` predicate naming a sibling field", async () => {
     writeSkill("test-field-when", {

--- a/test/workspace/feeds/test_agentIngest.ts
+++ b/test/workspace/feeds/test_agentIngest.ts
@@ -1,0 +1,150 @@
+import "../../../server/workspace/collections/configure.js"; // configure @mulmoclaude/core/collection host binding for tests
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { refreshViaAgent, setAgentWorkerRunner, type AgentWorkerResult } from "../../../server/workspace/feeds/agentIngest.js";
+import { readFeedState } from "../../../server/workspace/feeds/state.js";
+import { _setFilePathsForTesting, initNotifier } from "../../../server/notifier/engine.js";
+import type { LoadedCollection } from "../../../server/workspace/collections/index.js";
+
+// The failure path publishes/clears a notifier bell — point the engine at temp
+// files and inject a no-op pub-sub so publish/clear don't throw in tests.
+function configureTempNotifier(): void {
+  const dir = mkdtempSync(path.join(tmpdir(), "agent-ingest-notifier-"));
+  _setFilePathsForTesting({ active: path.join(dir, "active.json"), history: path.join(dir, "history.json") });
+  initNotifier({ publish: () => {} });
+}
+
+// Hand-build a skill-backed collection with agent ingest. `withTemplate`
+// controls whether the on-disk template exists (the missing-template path).
+function makeAgentCollection(root: string, slug: string, withTemplate: boolean): LoadedCollection {
+  const skillDir = path.join(root, ".claude", "skills", slug);
+  const dataDir = path.join(root, "data", slug);
+  mkdirSync(dataDir, { recursive: true });
+  if (withTemplate) {
+    mkdirSync(path.join(skillDir, "templates"), { recursive: true });
+    writeFileSync(path.join(skillDir, "templates", "refresh.md"), "Refresh each record. Edit and stop.\n");
+  }
+  return {
+    slug,
+    source: "user",
+    schema: {
+      title: "Quotes",
+      icon: "trending_up",
+      dataPath: `data/${slug}`,
+      primaryKey: "id",
+      fields: { id: { type: "string", label: "ID", primary: true } },
+      ingest: { kind: "agent", schedule: "daily", role: "investor", template: "templates/refresh.md" },
+    },
+    dataDir,
+    skillDir,
+  } as unknown as LoadedCollection;
+}
+
+beforeEach(() => {
+  configureTempNotifier();
+});
+
+describe("refreshViaAgent — dispatch", () => {
+  it("dispatches a worker and stamps lastFetchedAt on a successful launch", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-ingest-"));
+    const collection = makeAgentCollection(root, "quotes-ok", true);
+    let seenRole: string | null = null;
+    let seenHidden: boolean | undefined;
+    setAgentWorkerRunner(async (args): Promise<AgentWorkerResult> => {
+      seenRole = args.roleId;
+      seenHidden = args.hidden;
+      return { ok: true, chatId: "chat-1" };
+    });
+
+    const result = await refreshViaAgent(root, collection);
+    assert.equal(result.dispatched, true);
+    assert.equal(result.errors.length, 0);
+    assert.equal(seenRole, "investor", "worker runs in the ingest role");
+    assert.equal(seenHidden, true, "scheduled refresh runs a hidden worker by default");
+
+    const state = await readFeedState(root, collection);
+    assert.ok(state.lastFetchedAt, "lastFetchedAt stamped at dispatch time");
+  });
+
+  it("runs a VISIBLE worker with no completion hook when hidden:false (manual Refresh)", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-ingest-"));
+    const collection = makeAgentCollection(root, "quotes-manual", true);
+    let seenHidden: boolean | undefined;
+    let seenOnComplete: unknown = "unset";
+    setAgentWorkerRunner(async (args): Promise<AgentWorkerResult> => {
+      seenHidden = args.hidden;
+      seenOnComplete = args.onComplete;
+      return { ok: true, chatId: "chat-manual" };
+    });
+
+    const result = await refreshViaAgent(root, collection, { hidden: false });
+    assert.equal(result.dispatched, true);
+    assert.equal(seenHidden, false, "manual refresh runs a visible session");
+    assert.equal(seenOnComplete, undefined, "a visible run carries no completion hook (the user watches it)");
+  });
+
+  it("leaves state untouched and reports the error on a cap-miss", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-ingest-"));
+    const collection = makeAgentCollection(root, "quotes-cap", true);
+    setAgentWorkerRunner(async (): Promise<AgentWorkerResult> => ({ ok: false, error: "too many background sessions" }));
+
+    const result = await refreshViaAgent(root, collection);
+    assert.equal(result.dispatched, false);
+    assert.equal(result.errors.length, 1);
+
+    const state = await readFeedState(root, collection);
+    assert.equal(state.lastFetchedAt, null, "no dispatch ⇒ no lastFetchedAt, so the next tick retries");
+  });
+
+  it("reports a missing template without dispatching", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-ingest-"));
+    const collection = makeAgentCollection(root, "quotes-notmpl", false);
+    let launched = false;
+    setAgentWorkerRunner(async (): Promise<AgentWorkerResult> => {
+      launched = true;
+      return { ok: true, chatId: "chat-x" };
+    });
+
+    const result = await refreshViaAgent(root, collection);
+    assert.equal(result.dispatched, undefined);
+    assert.equal(result.errors.length, 1);
+    assert.equal(launched, false, "no worker launched when the template can't be read");
+  });
+});
+
+describe("refreshViaAgent — completion outcome", () => {
+  it("increments consecutiveFailures and raises a bell on error, then clears on success", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "agent-ingest-"));
+    const collection = makeAgentCollection(root, "quotes-outcome", true);
+    let onComplete: ((o: { didError: boolean }) => void | Promise<void>) | undefined;
+    setAgentWorkerRunner(async (args): Promise<AgentWorkerResult> => {
+      ({ onComplete } = args);
+      return { ok: true, chatId: "chat-2" };
+    });
+
+    await refreshViaAgent(root, collection);
+    assert.ok(onComplete, "runner received an onComplete hook");
+
+    // Worker failed.
+    await onComplete?.({ didError: true });
+    let state = await readFeedState(root, collection);
+    assert.equal(state.consecutiveFailures, 1);
+    assert.ok(state.failureBellId, "a failure bell id is persisted");
+
+    // A second failure doesn't pile up a second bell.
+    const firstBell = state.failureBellId;
+    await onComplete?.({ didError: true });
+    state = await readFeedState(root, collection);
+    assert.equal(state.consecutiveFailures, 2);
+    assert.equal(state.failureBellId, firstBell, "same bell, deduped");
+
+    // Worker succeeded → counter resets and the bell clears.
+    await onComplete?.({ didError: false });
+    state = await readFeedState(root, collection);
+    assert.equal(state.consecutiveFailures, 0);
+    assert.equal(state.failureBellId, undefined, "bell cleared on success");
+  });
+});

--- a/test/workspace/feeds/test_projectItem.ts
+++ b/test/workspace/feeds/test_projectItem.ts
@@ -2,12 +2,12 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { projectRecord } from "../../../server/workspace/feeds/projectItem.js";
 import type { CollectionSchema } from "../../../server/workspace/collections/index.js";
-import type { IngestSpec } from "../../../server/workspace/feeds/ingestTypes.js";
+import type { DeclarativeIngestSpec } from "../../../server/workspace/feeds/ingestTypes.js";
 
 // projectRecord only reads schema.primaryKey, so a minimal cast suffices.
 const schema = { primaryKey: "id" } as unknown as CollectionSchema;
 
-function rssIngest(extra: Partial<IngestSpec> = {}): IngestSpec {
+function rssIngest(extra: Partial<DeclarativeIngestSpec> = {}): DeclarativeIngestSpec {
   return {
     kind: "rss",
     url: "https://example.com/feed",

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -52,6 +52,7 @@ describe("WORKSPACE_DIRS expected keys", () => {
     "html",
     "htmls",
     "images",
+    "ingestState",
     "locations",
     "markdowns",
     "marpThemes",


### PR DESCRIPTION
## What

Lets a collection refresh its own records on a schedule by dispatching a background **agent worker**, instead of a detached `manageAutomations` task. The schedule lives with the schema — it travels when the skill is copied and dies with the collection.

```json
"ingest": { "kind": "agent", "schedule": "daily", "atHour": 22, "role": "finance", "template": "templates/refresh.md" }
```

On schedule (and on the **Refresh** button) the host seeds a worker in the declared role with the collection's template + an all-records summary; the worker edits the records itself, then stops silently.

## Highlights

- **Schema**: `ingest` is now a discriminated union — declarative feeds (`rss`/`atom`/`http-json`) vs `kind: "agent"` (`role` + path-safe `templates/…` + optional **UTC** `atHour` daily anchor). Validated in core discovery; `putSchema` accepts it.
- **Engine**: `refreshOne`/`refreshDue` widened to every collection carrying `ingest`. Agent branch dispatches a worker; declarative path unchanged. Non-feed ingest state lives at `data/ingest-state/<slug>.json` (feeds keep `feeds/<slug>/_state.json`).
- **Worker**: `spawnSystemWorker` extracted next to `startChat`; one-shot completion hooks on `backgroundSessions` + `finalizeRun` drive a per-collection failure bell (deduped via persisted `failureBellId`).
- **Manual vs scheduled**: scheduled runs are **hidden** (origin `system`, auto-cleaned). A manual **Refresh runs visible** (origin `skill`) and the UI **opens the session** so the user can watch/debug it.
- **UI fix**: corrected two `schema.ingest`-as-"is-a-feed" proxies that surfaced a **second delete button** / wrong chat-seed on agent-ingest skill collections (now keyed on `source === "feed"`). New `refreshDispatched` key in all 8 locales.
- **Discovery/docs**: `collection-skills.md` gains a "Scheduled agent refresh" section (with a strong **UTC-not-local** `atHour` warning); `feeds.md` pointer; the `mc-manage-automations` skill now redirects single-collection refreshes to `ingest.kind: "agent"`.
- Bumped `@mulmoclaude/core` 0.2.1 → 0.2.2.

## Tests

`yarn format`/`lint`/`typecheck`/`build` clean; full suite green (5084 + workspace pkgs, 0 fail). New: agent-ingest zod accept/reject matrix (discovery), `test_agentIngest.ts` (dispatch / cap-miss / template-miss / completion hook / hidden vs visible).

## Verify

Add `ingest.kind:"agent"` to a collection's schema, click **Refresh** → a visible worker session opens and updates records; scheduled runs (hourly `system:feed-refresh`) dispatch hidden workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add agent-based ingest for collections, enabling scheduled background refresh via worker sessions alongside existing declarative feeds.

New Features:
- Allow collections to declare `ingest.kind: "agent"` with schedule, optional UTC anchor hour, role, and template to drive scheduled agent-based refreshes.
- Enable the feeds engine to refresh any collection with ingest, including dispatching background workers for agent ingest and honoring `atHour` daily anchors.
- Expose a manual Refresh path that launches a visible worker session and optionally navigates to it, with a transient UI note when records update asynchronously.

Enhancements:
- Persist ingest state for non-feed collections under a new `data/ingest-state` directory and extend feed state with failure-bell tracking.
- Introduce a generic system worker spawner and completion hooks for hidden background sessions, wiring them into the scheduler for agent ingest.
- Tighten collection/feeds UI logic to distinguish true feeds from agent-ingest collections for delete and chat seeding, and add localized messaging for background refresh dispatch.
- Update collection and feeds documentation plus the `mc-manage-automations` skill guidance to steer single-collection schedules toward `ingest.kind: "agent"`.
- Refine ingest type definitions into declarative vs agent unions and adjust feed retrievers, pruning, and scheduler wiring accordingly.

Tests:
- Add discovery tests for agent ingest schema validation, including required role, safe template paths, valid `atHour`, and allowed kinds.
- Add agent ingest engine tests covering worker dispatch, concurrency-cap failures, missing templates, and completion-hook outcome handling.
- Update workspace path shape tests to cover the new ingest-state directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-driven scheduled collection refreshes (`ingest.kind: "agent"`) using daily/hourly timing anchored by `atHour` in **UTC**.
  * Manual refresh can now surface “refresh started” feedback and show optional execution metadata when available.
* **Bug Fixes**
  * Improved refresh UI/type handling to more reliably distinguish feed collections vs other collection types.
  * Refresh failure notifications now correctly persist and auto-clear after the next successful refresh.
* **Documentation**
  * Expanded collection, feeds, and automation guidance for scheduled agent refresh and UTC `atHour` usage.
* **Tests**
  * Added coverage for agent ingest discovery and refresh dispatch/completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->