### PR TITLE
fix: add Windows monospace fonts to code block font stack

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,7 @@
   padding: 0.1rem 0.3rem;
   border-radius: 0.25rem;
   font-size: 0.85em;
-  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "MS Gothic", "BIZ UDGothic", monospace;
 }
 .markdown-content pre {
   background: #f3f4f6;


### PR DESCRIPTION
Closes #1822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the code font fallback list in markdown content to improve consistency across more systems and languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->