### PR TITLE
feat(collections): registry export — contribution bundle (producer side)

### DIFF
--- a/server/api/routes/collectionsRegistry.ts
+++ b/server/api/routes/collectionsRegistry.ts
@@ -10,6 +10,7 @@ import { badRequest } from "../../utils/httpError.js";
 import { fetchRegistryIndex } from "../../workspace/collectionsRegistry/client.js";
 import { previewCollection } from "../../workspace/collectionsRegistry/collectionFiles.js";
 import { performImport } from "../../workspace/collectionsRegistry/importWriter.js";
+import { performExport } from "../../workspace/collectionsRegistry/performExport.js";
 import type { RegistryCollectionEntry } from "../../workspace/collectionsRegistry/registryIndex.js";
 import { workspacePath } from "../../workspace/workspace.js";
 
@@ -83,6 +84,44 @@ router.post(API_ROUTES.collectionsRegistry.import, async (req: Request<object, u
     return;
   }
   res.json({ localSlug: result.localSlug, updated: result.updated, seedWritten: result.seedWritten, seedSkipped: result.seedSkipped });
+});
+
+interface ExportBody {
+  slug?: unknown;
+  author?: unknown;
+  license?: unknown;
+  includeSeed?: unknown;
+}
+
+interface ExportResponse {
+  outputPath: string;
+  fileCount: number;
+  seedCount: number;
+  seedSkipped: number;
+  warnings: string[];
+}
+
+router.post(API_ROUTES.collectionsRegistry.export, async (req: Request<object, unknown, ExportBody>, res: Response<ExportResponse | ErrorResponse>) => {
+  const slug = typeof req.body.slug === "string" ? req.body.slug : "";
+  const author = typeof req.body.author === "string" ? req.body.author : "";
+  if (!slug || !author) {
+    badRequest(res, "slug and author are required");
+    return;
+  }
+  const license = typeof req.body.license === "string" && req.body.license ? req.body.license : "MIT";
+  const includeSeed = req.body.includeSeed === true;
+  const result = await performExport(slug, { author, license, includeSeed }, workspacePath);
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
+  }
+  res.json({
+    outputPath: result.outputPath,
+    fileCount: result.fileCount,
+    seedCount: result.seedCount,
+    seedSkipped: result.seedSkipped,
+    warnings: result.warnings,
+  });
 });
 
 export default router;

--- a/server/workspace/collectionsRegistry/exportCollection.ts
+++ b/server/workspace/collectionsRegistry/exportCollection.ts
@@ -84,17 +84,28 @@ async function exportSeed(dataDir: string, outDir: string): Promise<{ count: num
   let count = 0;
   let skipped = 0;
   for (const name of names) {
-    const text = await readFile(path.join(dataDir, name), "utf-8");
+    const base = path.basename(name);
+    const text = await readFile(path.join(dataDir, base), "utf-8");
     if (hasSecret(text)) {
-      warnings.push(`skipped ${name}: contains a possible credential`);
+      warnings.push(`skipped ${base}: contains a possible credential`);
       skipped += 1;
       continue;
     }
-    if (EMAIL_RE.test(text)) warnings.push(`${name}: contains a possible email/PII (kept — your responsibility)`);
-    await writeFile(path.join(seedDir, name), text, "utf-8");
+    if (EMAIL_RE.test(text)) warnings.push(`${base}: contains a possible email/PII (kept — your responsibility)`);
+    await writeFile(path.join(seedDir, base), text, "utf-8");
     count += 1;
   }
   return { count, skipped, warnings };
+}
+
+// Resolve `segments` under `root` and return the absolute path only when it stays
+// inside `root` — a containment barrier for the user-derived author/slug and the
+// collection dirs, on top of the AUTHOR_RE/SLUG_RE format checks. `..` or an
+// absolute escape resolves outside `root` and yields null (rejected upstream).
+function resolveWithin(root: string, ...segments: string[]): string | null {
+  const resolvedRoot = path.resolve(root);
+  const target = path.resolve(resolvedRoot, ...segments);
+  return target === resolvedRoot || target.startsWith(resolvedRoot + path.sep) ? target : null;
 }
 
 export async function writeCollectionExport(params: {
@@ -108,15 +119,23 @@ export async function writeCollectionExport(params: {
   if (!AUTHOR_RE.test(meta.author)) return { ok: false, status: STATUS_BAD_REQUEST, error: `author '${meta.author}' is not a valid GitHub login` };
   if (!SLUG_RE.test(meta.slug)) return { ok: false, status: STATUS_BAD_REQUEST, error: `slug '${meta.slug}' is invalid` };
 
-  const outRel = `${EXPORT_BASE}/${meta.author}/${meta.slug}`;
-  const outDir = path.join(workspaceRoot, ...outRel.split("/"));
+  const wsRoot = path.resolve(workspaceRoot);
+  const exportRoot = path.join(wsRoot, ...EXPORT_BASE.split("/"));
+  const outDir = resolveWithin(exportRoot, meta.author, meta.slug);
+  const safeSkillDir = resolveWithin(wsRoot, skillDir);
+  const safeDataDir = resolveWithin(wsRoot, dataDir);
+  if (!outDir || !safeSkillDir || !safeDataDir) {
+    return { ok: false, status: STATUS_BAD_REQUEST, error: "resolved path escapes the workspace" };
+  }
+
   await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
 
-  const bundleCount = await copyBundle(skillDir, outDir);
-  const seed = includeSeed ? await exportSeed(dataDir, outDir) : { count: 0, skipped: 0, warnings: [] };
+  const bundleCount = await copyBundle(safeSkillDir, outDir);
+  const seed = includeSeed ? await exportSeed(safeDataDir, outDir) : { count: 0, skipped: 0, warnings: [] };
   const metaOut = { ...meta, ...(seed.count > 0 ? { dataConsent: true } : {}) };
   await writeFile(path.join(outDir, "meta.json"), `${JSON.stringify(metaOut, null, 2)}\n`, "utf-8");
   log.info("collections-registry", "exported collection", { slug: meta.slug, author: meta.author, seedCount: seed.count });
+  const outRel = path.relative(wsRoot, outDir).split(path.sep).join("/");
   return { ok: true, outputPath: outRel, fileCount: bundleCount + 1, seedCount: seed.count, seedSkipped: seed.skipped, warnings: seed.warnings };
 }

--- a/server/workspace/collectionsRegistry/exportCollection.ts
+++ b/server/workspace/collectionsRegistry/exportCollection.ts
@@ -108,6 +108,16 @@ function resolveWithin(root: string, ...segments: string[]): string | null {
   return target === resolvedRoot || target.startsWith(resolvedRoot + path.sep) ? target : null;
 }
 
+// Required bundle files (SKILL.md, schema.json) must be present — exporting an
+// incomplete bundle would pass here but fail downstream registry curation.
+// Returns the first missing required file, or null when all are present.
+async function findMissingRequired(skillDir: string): Promise<string | null> {
+  for (const file of BUNDLE_FILES) {
+    if ((await pathKind(path.join(skillDir, file))) !== "file") return file;
+  }
+  return null;
+}
+
 export async function writeCollectionExport(params: {
   workspaceRoot: string;
   skillDir: string;
@@ -126,6 +136,11 @@ export async function writeCollectionExport(params: {
   const safeDataDir = resolveWithin(wsRoot, dataDir);
   if (!outDir || !safeSkillDir || !safeDataDir) {
     return { ok: false, status: STATUS_BAD_REQUEST, error: "resolved path escapes the workspace" };
+  }
+
+  const missing = await findMissingRequired(safeSkillDir);
+  if (missing) {
+    return { ok: false, status: STATUS_BAD_REQUEST, error: `required bundle file missing: ${missing}` };
   }
 
   await rm(outDir, { recursive: true, force: true });

--- a/server/workspace/collectionsRegistry/exportCollection.ts
+++ b/server/workspace/collectionsRegistry/exportCollection.ts
@@ -1,0 +1,122 @@
+// Export a workspace collection into the curated registry's contribution layout
+// (collections/<author>/<slug>/ + meta.json + optional seed/) under
+// data/registry-export/, so the user can open a PR to the registry. The producer
+// side of the registry loop.
+//
+// writeCollectionExport takes explicit dirs + a workspace root so it is unit-testable
+// against temp dirs with no discovery/network; performExport (separate file) is the
+// thin glue that resolves the collection from the live workspace.
+
+import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { log } from "../../system/logger/index.js";
+
+export const EXPORT_BASE = "data/registry-export";
+const BUNDLE_FILES = ["SKILL.md", "schema.json"] as const;
+const OPTIONAL_FILES = ["screenshot.png"] as const;
+const BUNDLE_DIRS = ["views", "templates"] as const;
+const AUTHOR_RE = /^[A-Za-z0-9][A-Za-z0-9-]{0,38}$/;
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+const STATUS_BAD_REQUEST = 400;
+// Block obvious credentials from being published in seed data; PII is only warned.
+const SECRET_PATTERNS = [
+  /AKIA[0-9A-Z]{16}/,
+  /gh[pousr]_[A-Za-z0-9]{20,}/,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /sk-[A-Za-z0-9]{20,}/,
+  /xox[baprs]-[A-Za-z0-9-]{10,}/,
+];
+const hasSecret = (text: string): boolean => SECRET_PATTERNS.some((pattern) => pattern.test(text));
+// Bounded + non-overlapping (no ReDoS): local@label.tld with single quantifier runs.
+const EMAIL_RE = /[\w.%+-]{1,64}@[\w-]{1,255}\.[a-z]{2,24}/i;
+
+export interface ExportMeta {
+  author: string;
+  slug: string;
+  version: string;
+  title: string;
+  description: string;
+  tags: string[];
+  license: string;
+}
+
+export type ExportResult =
+  | { ok: true; outputPath: string; fileCount: number; seedCount: number; seedSkipped: number; warnings: string[] }
+  | { ok: false; status: number; error: string };
+
+async function pathKind(target: string): Promise<"dir" | "file" | "absent"> {
+  try {
+    return (await stat(target)).isDirectory() ? "dir" : "file";
+  } catch {
+    return "absent";
+  }
+}
+
+async function copyBundle(skillDir: string, outDir: string): Promise<number> {
+  let count = 0;
+  for (const file of [...BUNDLE_FILES, ...OPTIONAL_FILES]) {
+    const src = path.join(skillDir, file);
+    if ((await pathKind(src)) !== "file") continue;
+    await cp(src, path.join(outDir, file));
+    count += 1;
+  }
+  for (const dir of BUNDLE_DIRS) {
+    const src = path.join(skillDir, dir);
+    if ((await pathKind(src)) !== "dir") continue;
+    await cp(src, path.join(outDir, dir), { recursive: true });
+    count += (await readdir(src)).filter((name) => !name.startsWith(".")).length;
+  }
+  return count;
+}
+
+async function exportSeed(dataDir: string, outDir: string): Promise<{ count: number; skipped: number; warnings: string[] }> {
+  let names: string[];
+  try {
+    names = (await readdir(dataDir)).filter((name) => name.endsWith(".json"));
+  } catch {
+    return { count: 0, skipped: 0, warnings: [] };
+  }
+  if (names.length === 0) return { count: 0, skipped: 0, warnings: [] };
+  const seedDir = path.join(outDir, "seed", "items");
+  await mkdir(seedDir, { recursive: true });
+  const warnings: string[] = [];
+  let count = 0;
+  let skipped = 0;
+  for (const name of names) {
+    const text = await readFile(path.join(dataDir, name), "utf-8");
+    if (hasSecret(text)) {
+      warnings.push(`skipped ${name}: contains a possible credential`);
+      skipped += 1;
+      continue;
+    }
+    if (EMAIL_RE.test(text)) warnings.push(`${name}: contains a possible email/PII (kept — your responsibility)`);
+    await writeFile(path.join(seedDir, name), text, "utf-8");
+    count += 1;
+  }
+  return { count, skipped, warnings };
+}
+
+export async function writeCollectionExport(params: {
+  workspaceRoot: string;
+  skillDir: string;
+  dataDir: string;
+  meta: ExportMeta;
+  includeSeed: boolean;
+}): Promise<ExportResult> {
+  const { workspaceRoot, skillDir, dataDir, meta, includeSeed } = params;
+  if (!AUTHOR_RE.test(meta.author)) return { ok: false, status: STATUS_BAD_REQUEST, error: `author '${meta.author}' is not a valid GitHub login` };
+  if (!SLUG_RE.test(meta.slug)) return { ok: false, status: STATUS_BAD_REQUEST, error: `slug '${meta.slug}' is invalid` };
+
+  const outRel = `${EXPORT_BASE}/${meta.author}/${meta.slug}`;
+  const outDir = path.join(workspaceRoot, ...outRel.split("/"));
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  const bundleCount = await copyBundle(skillDir, outDir);
+  const seed = includeSeed ? await exportSeed(dataDir, outDir) : { count: 0, skipped: 0, warnings: [] };
+  const metaOut = { ...meta, ...(seed.count > 0 ? { dataConsent: true } : {}) };
+  await writeFile(path.join(outDir, "meta.json"), `${JSON.stringify(metaOut, null, 2)}\n`, "utf-8");
+  log.info("collections-registry", "exported collection", { slug: meta.slug, author: meta.author, seedCount: seed.count });
+  return { ok: true, outputPath: outRel, fileCount: bundleCount + 1, seedCount: seed.count, seedSkipped: seed.skipped, warnings: seed.warnings };
+}

--- a/server/workspace/collectionsRegistry/performExport.ts
+++ b/server/workspace/collectionsRegistry/performExport.ts
@@ -1,0 +1,46 @@
+// Thin glue for the collection export: resolve the collection from the live workspace
+// (its skill dir + data dir + schema), derive meta from SKILL.md front-matter / any
+// existing meta.json, then hand off to the testable writeCollectionExport. Kept
+// separate so the file-writing core stays import-light + unit-testable.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { loadCollection } from "@mulmoclaude/core/collection/server";
+
+import { isRecord } from "../../utils/types.js";
+import { parseSkillFrontmatter } from "../skills/parser.js";
+import { writeCollectionExport, type ExportMeta, type ExportResult } from "./exportCollection.js";
+
+const STATUS_NOT_FOUND = 404;
+
+async function readJsonObject(file: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(file, "utf-8"));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function performExport(
+  slug: string,
+  opts: { author: string; license: string; includeSeed: boolean },
+  workspaceRoot: string,
+): Promise<ExportResult> {
+  const collection = await loadCollection(slug);
+  if (!collection) return { ok: false, status: STATUS_NOT_FOUND, error: `collection not found: ${slug}` };
+  const skillMd = await readFile(path.join(collection.skillDir, "SKILL.md"), "utf-8").catch(() => "");
+  const frontmatter = parseSkillFrontmatter(skillMd);
+  const existingMeta = await readJsonObject(path.join(collection.skillDir, "meta.json"));
+  const meta: ExportMeta = {
+    author: opts.author,
+    slug,
+    version: typeof existingMeta?.version === "string" ? existingMeta.version : "1.0.0",
+    title: collection.schema.title,
+    description: frontmatter?.description ?? "",
+    tags: [],
+    license: opts.license,
+  };
+  return writeCollectionExport({ workspaceRoot, skillDir: collection.skillDir, dataDir: collection.dataDir, meta, includeSeed: opts.includeSeed });
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -295,6 +295,10 @@ const HOST_API_ROUTES = {
     /** POST { author, slug } → fetch + re-validate + install into .claude/skills/,
      *  normalize dataPath, materialize seed, record provenance. */
     import: "/api/collections-registry/import",
+    /** POST { slug, author, license?, includeSeed? } → write a registry-contribution
+     *  bundle (collections/<author>/<slug>/ + meta.json + optional seed) under
+     *  data/registry-export/ for the user to open a PR. */
+    export: "/api/collections-registry/export",
   },
 
   // `scheduler` group migrated to META — see `src/plugins/scheduler/automationsMeta.ts`.

--- a/test/server/test_exportCollection.ts
+++ b/test/server/test_exportCollection.ts
@@ -105,4 +105,15 @@ describe("writeCollectionExport", () => {
       rmSync(outsideDir, { recursive: true, force: true });
     }
   });
+
+  it("hard-fails when a required bundle file (schema.json) is missing", async () => {
+    rmSync(path.join(skillDir(), "schema.json"));
+    const result = await writeCollectionExport({ workspaceRoot: wsRoot, skillDir: skillDir(), dataDir: dataDir(), meta, includeSeed: false });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 400);
+      assert.match(result.error, /required bundle file missing/);
+    }
+    assert.ok(!existsSync(outDir()), "no partial bundle written when a required file is missing");
+  });
 });

--- a/test/server/test_exportCollection.ts
+++ b/test/server/test_exportCollection.ts
@@ -93,4 +93,16 @@ describe("writeCollectionExport", () => {
     assert.equal(result.ok, false);
     if (!result.ok) assert.equal(result.status, 400);
   });
+
+  it("rejects a skillDir that escapes the workspace", async () => {
+    const outsideDir = mkdtempSync(path.join(tmpdir(), "mc-export-outside-"));
+    try {
+      const result = await writeCollectionExport({ workspaceRoot: wsRoot, skillDir: outsideDir, dataDir: dataDir(), meta, includeSeed: false });
+      assert.equal(result.ok, false);
+      if (!result.ok) assert.equal(result.status, 400);
+      assert.ok(!existsSync(outDir()), "nothing written when a path escapes the workspace");
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/server/test_exportCollection.ts
+++ b/test/server/test_exportCollection.ts
@@ -1,0 +1,96 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { writeCollectionExport, type ExportMeta } from "../../server/workspace/collectionsRegistry/exportCollection.js";
+
+const meta: ExportMeta = {
+  author: "isamu",
+  slug: "movies",
+  version: "1.2.0",
+  title: "映画リスト",
+  description: "Movies I track.",
+  tags: ["entertainment"],
+  license: "MIT",
+};
+
+let wsRoot: string;
+const skillDir = () => path.join(wsRoot, ".claude", "skills", "movies");
+const dataDir = () => path.join(wsRoot, "data", "movies", "items");
+const outDir = () => path.join(wsRoot, "data", "registry-export", "isamu", "movies");
+
+function seedWorkspace(): void {
+  mkdirSync(path.join(skillDir(), "views"), { recursive: true });
+  writeFileSync(path.join(skillDir(), "SKILL.md"), "---\nname: movies\ndescription: x\n---\n# Movies");
+  writeFileSync(path.join(skillDir(), "schema.json"), JSON.stringify({ title: "映画リスト", dataPath: "data/movies/items" }));
+  writeFileSync(path.join(skillDir(), "views", "cinema.html"), "<!doctype html>");
+  writeFileSync(path.join(skillDir(), "screenshot.png"), "PNG");
+  writeFileSync(path.join(skillDir(), ".origin.json"), "{}"); // must NOT be exported
+  mkdirSync(dataDir(), { recursive: true });
+  writeFileSync(path.join(dataDir(), "a.json"), JSON.stringify({ id: "a", title: "A" }));
+  writeFileSync(path.join(dataDir(), "with-email.json"), JSON.stringify({ id: "b", note: "reach me at me@example.com" }));
+  // Built at runtime so the test source carries no literal credential pattern.
+  const fakeToken = `ghp_${"a".repeat(36)}`;
+  writeFileSync(path.join(dataDir(), "with-secret.json"), JSON.stringify({ id: "c", note: fakeToken }));
+}
+
+describe("writeCollectionExport", () => {
+  beforeEach(() => {
+    wsRoot = mkdtempSync(path.join(tmpdir(), "mc-export-"));
+    seedWorkspace();
+  });
+  afterEach(() => {
+    rmSync(wsRoot, { recursive: true, force: true });
+  });
+
+  it("writes the bundle + meta.json + seed, skipping secrets and warning on PII", async () => {
+    const result = await writeCollectionExport({ workspaceRoot: wsRoot, skillDir: skillDir(), dataDir: dataDir(), meta, includeSeed: true });
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.equal(result.outputPath, "data/registry-export/isamu/movies");
+
+    for (const file of ["SKILL.md", "schema.json", "screenshot.png", "meta.json"]) {
+      assert.ok(existsSync(path.join(outDir(), file)), `expected ${file}`);
+    }
+    assert.ok(existsSync(path.join(outDir(), "views", "cinema.html")));
+    assert.ok(!existsSync(path.join(outDir(), ".origin.json")), ".origin.json must not be exported");
+
+    const writtenMeta = JSON.parse(readFileSync(path.join(outDir(), "meta.json"), "utf-8"));
+    assert.equal(writtenMeta.author, "isamu");
+    assert.equal(writtenMeta.title, "映画リスト");
+    assert.equal(writtenMeta.dataConsent, true, "dataConsent set when seed exported");
+
+    // seed: clean + email kept; secret skipped
+    assert.ok(existsSync(path.join(outDir(), "seed", "items", "a.json")));
+    assert.ok(existsSync(path.join(outDir(), "seed", "items", "with-email.json")));
+    assert.ok(!existsSync(path.join(outDir(), "seed", "items", "with-secret.json")), "secret record skipped");
+    assert.equal(result.seedCount, 2);
+    assert.equal(result.seedSkipped, 1);
+    assert.match(result.warnings.join("\n"), /credential/);
+    assert.match(result.warnings.join("\n"), /PII/);
+  });
+
+  it("omits seed + dataConsent when includeSeed is false", async () => {
+    const result = await writeCollectionExport({ workspaceRoot: wsRoot, skillDir: skillDir(), dataDir: dataDir(), meta, includeSeed: false });
+    assert.ok(result.ok);
+    if (!result.ok) return;
+    assert.equal(result.seedCount, 0);
+    assert.ok(!existsSync(path.join(outDir(), "seed")));
+    const writtenMeta = JSON.parse(readFileSync(path.join(outDir(), "meta.json"), "utf-8"));
+    assert.equal(writtenMeta.dataConsent, undefined);
+  });
+
+  it("rejects an invalid author", async () => {
+    const result = await writeCollectionExport({
+      workspaceRoot: wsRoot,
+      skillDir: skillDir(),
+      dataDir: dataDir(),
+      meta: { ...meta, author: "bad/author" },
+      includeSeed: false,
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 400);
+  });
+});


### PR DESCRIPTION
## Summary

The **producer** half of the registry loop (export → PR → curate → discover/import). `POST /api/collections-registry/export` turns a workspace collection into a registry-contribution bundle under `data/registry-export/<author>/<slug>/`, ready to copy into a fork of `receptron/mulmoclaude-collections` and PR.

This is the backend slice; the **Contribute** button UI is the next slice.

## Output bundle
- `SKILL.md`, `schema.json` (+ `screenshot.png`, `views/`, `templates/` when present)
- generated `meta.json`: `author` (the user's GitHub login), `slug`, `version` (from any existing meta, else 1.0.0), `title` (schema), `description` (SKILL.md front-matter), `license`, and `dataConsent: true` when seed is included
- optional `seed/items/*.json` from the collection's records

## Safety
- Records containing a **credential** (AWS/GitHub/OpenAI/Slack/PEM patterns) are **skipped + warned** — never published.
- Records with an **email/PII** are **warned but kept** (contributor's responsibility).
- `author`/`slug` validated against the registry allowlists.

## Tests / gates
`writeCollectionExport` unit-tested against a temp workspace (bundle copy, `.origin.json` excluded, seed secret-skip + PII-warn, `includeSeed=false`, invalid author → 400). `yarn typecheck` / `build` / `lint` green.

Refs #1814