### PR TITLE
fix(ui): add CJK monospace font fallback across all code-render sites (#1822)

### DIFF
--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/html-plugin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "presentHtml — self-contained HTML page tool for MulmoClaude and MulmoTerminal. Server core (validation + artifacts persistence via the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/html-plugin/src/vue/View.vue
+++ b/packages/plugins/html-plugin/src/vue/View.vue
@@ -285,7 +285,7 @@ async function printToPdf() {
   padding: 0.5rem;
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.85rem;
   flex-shrink: 0;
 }
@@ -316,7 +316,7 @@ async function printToPdf() {
   border: 1px solid #ccc;
   border-radius: 4px;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: vertical;
   margin-bottom: 0.5rem;

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/markdown-plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Full-fidelity markdown document plugin (presentDocument) — Marp slides, PDF export, AI image-fill — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/MarpSplitEditor.vue
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/MarpSplitEditor.vue
@@ -61,7 +61,7 @@ function onInput(event: Event): void {
   border: none;
   border-radius: 0;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: none;
   line-height: 1.5;

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/View.vue
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/View.vue
@@ -700,7 +700,7 @@ watch(
   padding: 0.5rem;
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.85rem;
   flex-shrink: 0;
 }
@@ -731,7 +731,7 @@ watch(
   border: 1px solid #ccc;
   border-radius: 4px;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: vertical;
   margin-bottom: 0.5rem;

--- a/src/components/JsonEditor.vue
+++ b/src/components/JsonEditor.vue
@@ -104,7 +104,7 @@ function createState(doc: string): EditorState {
       labelCompartment.of(EditorView.contentAttributes.of({ "aria-label": props.editorLabel })),
       EditorView.theme({
         "&": { fontSize: "12px" },
-        ".cm-content": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace" },
+        ".cm-content": { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, "MS Gothic", "BIZ UDGothic", monospace' },
         "&.cm-focused": { outline: "2px solid rgb(96 165 250)" },
         ".cm-scroller": { overflow: "auto" },
       }),

--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,7 @@
   padding: 0.1rem 0.3rem;
   border-radius: 0.25rem;
   font-size: 0.85em;
-  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "MS Gothic", "BIZ UDGothic", monospace;
 }
 .markdown-content pre {
   background: #f3f4f6;

--- a/src/plugins/photoLocations/View.vue
+++ b/src/plugins/photoLocations/View.vue
@@ -193,7 +193,7 @@ h2 {
   align-items: baseline;
 }
 .path {
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.75rem;
   color: #374151;
   overflow: hidden;
@@ -216,7 +216,7 @@ h2 {
   color: #4b5563;
 }
 .coords {
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
 }
 .altitude {
   color: #9ca3af;

--- a/src/plugins/presentMulmoScript/View.vue
+++ b/src/plugins/presentMulmoScript/View.vue
@@ -1718,7 +1718,7 @@ async function downloadPdf() {
   padding: 0.5rem;
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.85rem;
 }
 
@@ -1748,7 +1748,7 @@ async function downloadPdf() {
   border: 1px solid #ccc;
   border-radius: 4px;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: vertical;
   margin-bottom: 0.5rem;

--- a/src/plugins/presentSVG/View.vue
+++ b/src/plugins/presentSVG/View.vue
@@ -341,7 +341,7 @@ function triggerDownload(blob: Blob, filename: string) {
   padding: 0.5rem;
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.85rem;
   flex-shrink: 0;
 }
@@ -372,7 +372,7 @@ function triggerDownload(blob: Blob, filename: string) {
   border: 1px solid #ccc;
   border-radius: 4px;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: vertical;
   margin-bottom: 0.5rem;

--- a/src/plugins/skill/View.vue
+++ b/src/plugins/skill/View.vue
@@ -93,7 +93,7 @@ const renderedHtml = computed(() => sanitizeMarkdownHtml(marked(body.value, { br
   background-color: #f5f5f5;
   padding: 0.2em 0.4em;
   border-radius: 3px;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9em;
 }
 .markdown-content :deep(pre) {

--- a/src/plugins/spreadsheet/View.vue
+++ b/src/plugins/spreadsheet/View.vue
@@ -797,7 +797,7 @@ onUnmounted(() => {
   padding: 0.5rem;
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.85rem;
   flex-shrink: 0;
 }
@@ -828,7 +828,7 @@ onUnmounted(() => {
   border: 1px solid #ccc;
   border-radius: 4px;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: vertical;
   margin-bottom: 0.5rem;
@@ -887,7 +887,7 @@ onUnmounted(() => {
 }
 
 .cell-ref {
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-weight: 600;
   color: #217346;
   font-size: 0.85rem;

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -356,7 +356,7 @@ async function downloadPdf() {
   background-color: #f5f5f5;
   padding: 0.2em 0.4em;
   border-radius: 3px;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9em;
 }
 
@@ -450,7 +450,7 @@ async function downloadPdf() {
   padding: 0.5rem;
   background: #f5f5f5;
   border-top: 1px solid #e0e0e0;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.85rem;
   flex-shrink: 0;
 }
@@ -481,7 +481,7 @@ async function downloadPdf() {
   border: 1px solid #ccc;
   border-radius: 4px;
   color: #333;
-  font-family: "Courier New", monospace;
+  font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
   font-size: 0.9rem;
   resize: vertical;
   margin-bottom: 0.5rem;

--- a/src/plugins/wiki/components/WikiPageBody.vue
+++ b/src/plugins/wiki/components/WikiPageBody.vue
@@ -143,7 +143,7 @@ function onClick(event: MouseEvent) {
   padding: 0.1rem 0.3rem;
   border-radius: 0.25rem;
   font-size: 0.85em;
-  font-family: monospace;
+  font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;
 }
 .wiki-content :deep(pre) {
   background: #f3f4f6;


### PR DESCRIPTION
## Summary

- Close #1822 — Japanese in chat code blocks rendered as tofu (□□□) on Windows because the monospace font stack ended at the generic `monospace` keyword, which Windows resolves to **Courier New** (no CJK glyphs).
- Patch the stack to include Windows CJK monospace fonts (`"MS Gothic"` / `"BIZ UDGothic"`) before the final `monospace` fallback. macOS / Linux behavior unchanged.
- Found and fixed the same bug class in **17 other CSS / Vue declarations** across the codebase (per user request — "他にも同様な問題あるなら直してね").

## Items to Confirm / Review

- **Two published packages get a version bump.** `@mulmoclaude/html-plugin` 0.2.4 → 0.2.5 and `@mulmoclaude/markdown-plugin` 0.1.6 → 0.1.7 since they contain shipped CSS that was patched. Version-bump guard verified clean (`node scripts/check-shared-pkg-bumps.mjs`).
- **Stack pattern**: the canonical addition is `"MS Gothic", "BIZ UDGothic"` inserted before the generic `monospace`. macOS uses its built-in system-font CJK fallback, Linux uses whatever's installed (`fonts-noto-cjk` recommended — see #1821 / PR #1826 for docs). The stack matches the issue's proposed fix verbatim for `src/index.css`.
- **`server/api/routes/pdf.ts:38`** has the same bug (`code { ... font-family: monospace }` in `MARKDOWN_CSS`) but is deliberately **out of scope here** to avoid conflict with the open PR #1826 (#1821 PDF font fix). Will be addressed there as a follow-up.

## User Prompt

> 1822も対応して。
> src/components/JsonEditor.vue　も問題あるなら入れておいて。
> 他にも同様な問題あるなら直してね

## Implementation

Canonical pattern applied in 14 files:

```diff
- font-family: ui-monospace, SFMono-Regular, monospace;
+ font-family: ui-monospace, SFMono-Regular, Consolas, "MS Gothic", "BIZ UDGothic", monospace;

- font-family: monospace;
+ font-family: Consolas, "MS Gothic", "BIZ UDGothic", monospace;

- font-family: "Courier New", monospace;
+ font-family: "Courier New", "MS Gothic", "BIZ UDGothic", monospace;
```

Sites patched:
| File | Hits |
|---|---|
| `src/index.css` | 1 (chat code blocks — issue scope) |
| `src/components/JsonEditor.vue` | 1 (CodeMirror cm-content) |
| `src/plugins/photoLocations/View.vue` | 2 |
| `src/plugins/presentMulmoScript/View.vue` | 2 |
| `src/plugins/presentSVG/View.vue` | 2 |
| `src/plugins/skill/View.vue` | 1 |
| `src/plugins/spreadsheet/View.vue` | 3 |
| `src/plugins/textResponse/View.vue` | 3 |
| `src/plugins/wiki/components/WikiPageBody.vue` | 1 |
| `packages/plugins/html-plugin/src/vue/View.vue` | 2 + version bump |
| `packages/plugins/markdown-plugin/src/plugins/markdown/View.vue` | 2 + version bump |
| `packages/plugins/markdown-plugin/src/plugins/markdown/MarpSplitEditor.vue` | 1 |

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all pass
- [x] `node scripts/check-shared-pkg-bumps.mjs` passes (version bumps wired)
- [ ] Manual on Windows: ask Claude for a code snippet with Japanese variable names or comments → renders correctly (not tofu) in chat
- [ ] Manual on Windows: open JsonEditor with Japanese inside JSON string values → renders correctly
- [ ] Manual on Windows: open Marp split editor / spreadsheet editor / text-response editor with Japanese → renders correctly
- [ ] Regression on macOS: code blocks still use Menlo / SF Mono (no visual change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)