### PR TITLE
feat: confirm dialog before the Contribute (share) button launches the agent

### DIFF
--- a/e2e/tests/collection-contribute.spec.ts
+++ b/e2e/tests/collection-contribute.spec.ts
@@ -40,16 +40,21 @@ test.describe("collection Contribute button", () => {
     await mockCollections(page);
   });
 
-  test("click launches one contribute chat and does not open the collection", async ({ page }) => {
+  test("click → confirm launches one contribute chat and does not open the collection", async ({ page }) => {
     const agentRuns = await captureAgentRuns(page);
     await page.goto("/collections");
 
     await expect(page.getByTestId("collections-index-card-reading-list")).toBeVisible();
     await page.getByTestId("collections-contribute-reading-list").click();
 
+    // A confirm dialog gates the share — no chat (agent run) starts until accepted.
+    await expect(page.getByTestId("host-confirm-modal")).toBeVisible();
+    expect(agentRuns).toHaveLength(0);
+    await page.getByTestId("host-confirm-ok").click();
+
     await expect.poll(() => agentRuns.length, { timeout: 2000 }).toBe(1);
-    // A double-fire (native click + a stray @keydown handler) would arrive right
-    // after the first; give it a beat, then confirm there was only one.
+    // A double-fire would arrive right after the first; give it a beat, then
+    // confirm there was only one launch.
     await page.waitForTimeout(250);
     expect(agentRuns).toHaveLength(1);
     expect(agentRuns[0]).toContain("reading-list");
@@ -59,13 +64,31 @@ test.describe("collection Contribute button", () => {
     await expect(page).not.toHaveURL(/\/collections\/reading-list/);
   });
 
-  test("keyboard activation (Enter) launches exactly one contribute chat", async ({ page }) => {
+  test("cancelling the confirm dialog launches no chat", async ({ page }) => {
+    const agentRuns = await captureAgentRuns(page);
+    await page.goto("/collections");
+
+    await expect(page.getByTestId("collections-index-card-reading-list")).toBeVisible();
+    await page.getByTestId("collections-contribute-reading-list").click();
+
+    await expect(page.getByTestId("host-confirm-modal")).toBeVisible();
+    await page.getByTestId("host-confirm-cancel").click();
+
+    await page.waitForTimeout(300);
+    expect(agentRuns).toHaveLength(0);
+    await expect(page).not.toHaveURL(/\/collections\/reading-list/);
+  });
+
+  test("keyboard activation (Enter) → confirm launches exactly one chat", async ({ page }) => {
     const agentRuns = await captureAgentRuns(page);
     await page.goto("/collections");
 
     const button = page.getByTestId("collections-contribute-reading-list");
     await button.focus();
     await page.keyboard.press("Enter");
+
+    await expect(page.getByTestId("host-confirm-modal")).toBeVisible();
+    await page.getByTestId("host-confirm-ok").click();
 
     await expect.poll(() => agentRuns.length, { timeout: 2000 }).toBe(1);
     await page.waitForTimeout(250);

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -169,7 +169,15 @@ function startCreateCollectionChat(): void {
   cui.startChat(t("collectionsView.addCollectionPrompt"), cui.generalRoleId);
 }
 
-function startContributeChat(collection: CollectionSummary): void {
+// Contributing runs an agent that exports the collection and opens a GitHub PR —
+// confirm before launching so a stray click doesn't start a share unprompted.
+async function startContributeChat(collection: CollectionSummary): Promise<void> {
+  const confirmed = await cui.confirm({
+    message: t("collectionsView.contributeConfirm", { title: collection.title }),
+    confirmText: t("collectionsView.contribute"),
+    variant: "primary",
+  });
+  if (!confirmed) return;
   cui.startChat(t("collectionsView.contributePrompt", { title: collection.title, slug: collection.slug }), cui.generalRoleId);
 }
 

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -20,6 +20,8 @@ const deMessages: CollectionMessages = {
       open: "Öffnen",
     },
     contribute: "Beitragen",
+    contributeConfirm:
+      "Die Sammlung „{title}“ teilen? Dadurch wird eine Skill ausgeführt, die sie exportiert und einen GitHub-PR an die Sammlungsregistry (receptron/mulmoclaude-collections) öffnet.",
     contributePrompt:
       "Hilf mir, meine Sammlung „{title}“ (Slug: {slug}) zur MulmoClaude-Sammlungsregistry (receptron/mulmoclaude-collections) beizutragen. Lies zuerst `config/helps/collection-skills.md` für das Layout des Beitragspakets. Frage mich nach meinem GitHub-Benutzernamen (muss meta.author entsprechen und dient als Namespace in der Registry) und ob meine Datensätze als Beispiel-Seed-Daten enthalten sein sollen (überspringe alles, was Geheimnisse enthält). Erstelle dann das Beitragspaket (SKILL.md, schema.json, meta.json, optional seed/items), kopiere es in einen Klon der Registry unter `github/`, führe `node scripts/build-index.mjs` und `node scripts/validate.mjs` aus und öffne nach meiner Bestätigung einen PR.",
     addCollectionLabel: "Sammlung",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -18,6 +18,8 @@ const enMessages = {
       open: "Open",
     },
     contribute: "Contribute",
+    contributeConfirm:
+      'Share the "{title}" collection? This runs a skill that exports it and opens a GitHub PR to the collection registry (receptron/mulmoclaude-collections).',
     contributePrompt:
       'Help me contribute my "{title}" collection (slug: {slug}) to the MulmoClaude collection registry (receptron/mulmoclaude-collections). First read `config/helps/collection-skills.md` for the contribution bundle layout. Ask me for my GitHub username (must match meta.author, used as the registry namespace) and whether to include my records as sample seed data (skip anything containing secrets). Then build the contribution bundle (SKILL.md, schema.json, meta.json, optional seed/items), copy it into a clone of the registry under `github/`, run `node scripts/build-index.mjs` and `node scripts/validate.mjs`, and open a PR once I confirm.',
     addCollectionLabel: "Collection",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -20,6 +20,8 @@ const esMessages: CollectionMessages = {
       open: "Abrir",
     },
     contribute: "Contribuir",
+    contributeConfirm:
+      "¿Compartir la colección «{title}»? Esto ejecuta una skill que la exporta y abre un PR de GitHub al registro de colecciones (receptron/mulmoclaude-collections).",
     contributePrompt:
       "Ayúdame a contribuir mi colección «{title}» (slug: {slug}) al registro de colecciones de MulmoClaude (receptron/mulmoclaude-collections). Primero lee `config/helps/collection-skills.md` para conocer la estructura del paquete de contribución. Pregúntame mi nombre de usuario de GitHub (debe coincidir con meta.author y se usa como espacio de nombres del registro) y si incluir mis registros como datos de ejemplo (seed) (omite cualquier cosa que contenga secretos). Luego crea el paquete de contribución (SKILL.md, schema.json, meta.json, seed/items opcional), cópialo en un clon del registro en `github/`, ejecuta `node scripts/build-index.mjs` y `node scripts/validate.mjs`, y abre un PR tras mi confirmación.",
     addCollectionLabel: "Colección",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -20,6 +20,8 @@ const frMessages: CollectionMessages = {
       open: "Ouvrir",
     },
     contribute: "Contribuer",
+    contributeConfirm:
+      "Partager la collection « {title} » ? Cela exécute une skill qui l'exporte et ouvre une PR GitHub vers le registre de collections (receptron/mulmoclaude-collections).",
     contributePrompt:
       "Aide-moi à contribuer ma collection « {title} » (slug : {slug}) au registre de collections MulmoClaude (receptron/mulmoclaude-collections). Lis d'abord `config/helps/collection-skills.md` pour la structure du paquet de contribution. Demande-moi mon nom d'utilisateur GitHub (doit correspondre à meta.author et sert d'espace de noms dans le registre) et si je veux inclure mes enregistrements comme données d'exemple (seed) (ignore tout ce qui contient des secrets). Crée ensuite le paquet de contribution (SKILL.md, schema.json, meta.json, seed/items facultatif), copie-le dans un clone du registre sous `github/`, exécute `node scripts/build-index.mjs` et `node scripts/validate.mjs`, et ouvre une PR après ma confirmation.",
     addCollectionLabel: "Collection",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -20,6 +20,8 @@ const jaMessages: CollectionMessages = {
       open: "開く",
     },
     contribute: "寄稿",
+    contributeConfirm:
+      "「{title}」コレクションをシェアしますか？スキルが起動してコレクションを export し、コレクションレジストリ（receptron/mulmoclaude-collections）に GitHub PR を作成します。",
     contributePrompt:
       "自作の「{title}」コレクション（slug: {slug}）を MulmoClaude のコレクションレジストリ（receptron/mulmoclaude-collections）に寄稿したいです。まず `config/helps/collection-skills.md` を読んで寄稿バンドルの構成を確認してください。私の GitHub ユーザー名（meta.author と一致する必要があり、レジストリ上の名前空間になります）と、自分のレコードをサンプル seed データとして含めるか（秘密情報を含むものは除外）を質問してください。そのうえで寄稿バンドル（SKILL.md, schema.json, meta.json, 任意の seed/items）を作り、`github/` 配下に clone したレジストリにコピーし、`node scripts/build-index.mjs` と `node scripts/validate.mjs` を実行し、私の確認後に PR を作成してください。",
     addCollectionLabel: "コレクション",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -20,6 +20,8 @@ const koMessages: CollectionMessages = {
       open: "열기",
     },
     contribute: "기여",
+    contributeConfirm:
+      "「{title}」 컬렉션을 공유할까요? 스킬이 실행되어 컬렉션을 내보내고 컬렉션 레지스트리(receptron/mulmoclaude-collections)에 GitHub PR을 엽니다.",
     contributePrompt:
       "제 {title} 컬렉션(slug: {slug})을 MulmoClaude 컬렉션 레지스트리(receptron/mulmoclaude-collections)에 기여하고 싶어요. 먼저 `config/helps/collection-skills.md`를 읽고 기여 번들 구조를 확인하세요. 제 GitHub 사용자 이름(meta.author와 일치해야 하며 레지스트리의 네임스페이스로 사용됩니다)과 제 레코드를 샘플 seed 데이터로 포함할지(비밀 정보가 포함된 것은 제외)를 물어보세요. 그런 다음 기여 번들(SKILL.md, schema.json, meta.json, 선택적 seed/items)을 만들어 `github/` 아래에 clone한 레지스트리에 복사하고, `node scripts/build-index.mjs`와 `node scripts/validate.mjs`를 실행한 뒤, 제 확인을 받고 PR을 여세요.",
     addCollectionLabel: "컬렉션",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -20,6 +20,8 @@ const ptBRMessages: CollectionMessages = {
       open: "Abrir",
     },
     contribute: "Contribuir",
+    contributeConfirm:
+      "Compartilhar a coleção {title}? Isso executa uma skill que a exporta e abre um PR no GitHub para o registro de coleções (receptron/mulmoclaude-collections).",
     contributePrompt:
       "Ajude-me a contribuir minha coleção {title} (slug: {slug}) para o registro de coleções do MulmoClaude (receptron/mulmoclaude-collections). Primeiro leia `config/helps/collection-skills.md` para conhecer a estrutura do pacote de contribuição. Pergunte-me meu nome de usuário do GitHub (deve corresponder a meta.author e é usado como namespace no registro) e se devo incluir meus registros como dados de exemplo (seed) (ignore qualquer coisa que contenha segredos). Em seguida, crie o pacote de contribuição (SKILL.md, schema.json, meta.json, seed/items opcional), copie-o para um clone do registro em `github/`, execute `node scripts/build-index.mjs` e `node scripts/validate.mjs`, e abra um PR após minha confirmação.",
     addCollectionLabel: "Coleção",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -20,6 +20,7 @@ const zhMessages: CollectionMessages = {
       open: "打开",
     },
     contribute: "贡献",
+    contributeConfirm: "分享「{title}」集合吗？这会运行一个 skill，将其导出并向集合注册表（receptron/mulmoclaude-collections）创建一个 GitHub PR。",
     contributePrompt:
       "帮我把我的「{title}」集合（slug：{slug}）贡献到 MulmoClaude 集合注册表（receptron/mulmoclaude-collections）。请先阅读 `config/helps/collection-skills.md` 了解贡献包的结构。询问我的 GitHub 用户名（必须与 meta.author 一致，并用作注册表中的命名空间），以及是否将我的记录作为示例 seed 数据包含（跳过任何包含机密信息的内容）。然后构建贡献包（SKILL.md、schema.json、meta.json、可选的 seed/items），将其复制到 `github/` 下克隆的注册表中，运行 `node scripts/build-index.mjs` 和 `node scripts/validate.mjs`，并在我确认后创建 PR。",
     addCollectionLabel: "集合",

--- a/plans/feat-collections-contribute-confirm.md
+++ b/plans/feat-collections-contribute-confirm.md
@@ -1,0 +1,34 @@
+# feat: confirm before Contribute launches the agent (Issue #1831)
+
+## Goal
+
+Gate the collection **Contribute (share)** button behind a confirm dialog. Today a
+single click immediately starts a chat where the agent exports the collection and
+opens a GitHub PR — too destructive for a one-click, no-undo action. Ask first.
+
+Follow-up to #1828 (the Contribute button itself), now merged.
+
+## Change
+
+1. **`CollectionsIndexView.vue`** — `startContributeChat` becomes async and awaits
+   `cui.confirm({ message: t("collectionsView.contributeConfirm", { title }), confirmText: t("collectionsView.contribute"), variant: "primary" })`.
+   Returns early if the user cancels; only on confirm does `cui.startChat(...)` fire.
+   Uses the host's existing `ConfirmModal` via the `CollectionUi.confirm` capability.
+
+2. **i18n** — new `collectionsView.contributeConfirm` (interpolates `{title}`) in all
+   8 locales (en/ja/de/es/fr/ko/ptBR/zh). The confirm CTA reuses the existing
+   `collectionsView.contribute` label; cancel uses the host default.
+
+3. **e2e** (`collection-contribute.spec.ts`) — updated for the dialog:
+   - click → dialog visible, 0 runs → confirm → exactly 1 run, no detail nav.
+   - cancel → 0 runs, no detail nav.
+   - keyboard (Enter) → dialog → confirm → exactly 1 run.
+
+4. **Version bump** `@mulmoclaude/collection-plugin` 0.5.12 → 0.5.13.
+
+## Verification
+
+- `yarn workspace @mulmoclaude/collection-plugin build` (vue-tsc), `npx eslint`,
+  `yarn typecheck:e2e`, and the 3 Playwright tests all pass.
+- Manual: reload the running dev app → Share button shows the confirm dialog;
+  cancel does nothing, confirm opens the contribute chat.


### PR DESCRIPTION
## Summary
The Contribute (share) button on an Installed collection card launched the contribute chat **immediately** on click — the agent would start exporting the collection + opening a GitHub PR with no confirmation. This gates it behind the host confirm dialog: a click now shows "Share the \"{title}\" collection? This runs a skill that exports it and opens a GitHub PR to the registry." and only **confirm** fires `startChat`. Follow-up to #1828 (Contribute button, merged).

## Items to Confirm / Review
- **UX**: reuses the existing host `ConfirmModal` via `CollectionUi.confirm`; confirm CTA reuses the `contribute` label ("Contribute"/"寄稿"/…), cancel uses the host default. `variant: "primary"`. Reasonable, or want a distinct "Share" CTA / `variant`?
- **Message wording** (`contributeConfirm`): states it runs a skill, exports, and opens a GitHub PR to `receptron/mulmoclaude-collections`. Fully localized in all 8 locales (no `<...>` so vue-i18n doesn't flag HTML).

## User Prompt
> share ボタンね。これっていきなり押すと skill が動くので、ダイアログで「skill 実行して github に PR をだしてシェアするけどよい？」って聞いてほしい

## Implementation
- `CollectionsIndexView.vue` — `startContributeChat` is now async and awaits `cui.confirm(...)`; returns early on cancel, otherwise `cui.startChat(...)`.
- i18n — `collectionsView.contributeConfirm` (interpolates `{title}`) added to all 8 locale files.
- e2e `collection-contribute.spec.ts` — rewritten for the dialog: confirm-path (exactly 1 agent run + no detail nav), cancel-path (0 runs), keyboard-path.
- Version bump `@mulmoclaude/collection-plugin` 0.5.12 → 0.5.13.

Plan: `plans/feat-collections-contribute-confirm.md`. Closes #1831.

## Verification
`yarn workspace @mulmoclaude/collection-plugin build` (vue-tsc), `npx eslint`, `yarn typecheck:e2e`, and all 3 Playwright tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Collections “Contribute” flow now asks for confirmation before starting a share/export action.
  * Added localized confirmation text for multiple languages.

* **Bug Fixes**
  * Canceling the confirmation dialog now stops the action and prevents navigation.
  * Keyboard activation follows the same confirmation step and only proceeds once approved.

* **Chores**
  * Updated the collection plugin to version 0.5.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->