### PR TITLE
fix(custom-view): scaffold help projects '?fields=' by default

### DIFF
--- a/packages/core/assets/helps/custom-view.md
+++ b/packages/core/assets/helps/custom-view.md
@@ -69,19 +69,36 @@ window.__MC_VIEW = {
 
 ### Reading records
 
+> **Always project `fields`.** The host refuses any read of more than 200
+> records that does not pass `?fields=…` or `?ids=…`, because an unscoped
+> fetch wastes work and bandwidth on columns your view never reads. Once a
+> user's collection grows past the threshold an unprojected view starts
+> returning `400` instead of records — write the projection from day one so
+> the same view keeps working forever.
+
 ```js
 const { token, dataUrl } = window.__MC_VIEW;
-const res = await fetch(dataUrl, { headers: { Authorization: "Bearer " + token } });
-if (!res.ok) throw new Error("load failed: " + res.status);
+// List the columns this view actually reads — never send `dataUrl` raw.
+const url = dataUrl + "?fields=" + encodeURIComponent("title,start,end,status");
+const res = await fetch(url, { headers: { Authorization: "Bearer " + token } });
+if (!res.ok) {
+  // Surface the server's reason (the 400 carries `{ error: "<message>" }`),
+  // not just the status code — that text is what tells the user / Claude
+  // how to fix the call (e.g. "pass `fields` to project only the columns").
+  const detail = await res.text();
+  throw new Error("load failed (" + res.status + "): " + detail);
+}
 const { items } = await res.json(); // { collection, count, items: [...] }
 ```
 
 Records come back **with computed fields already resolved** (derived formulas,
 toggles, embeds) — the same numbers the user sees elsewhere.
 
-- Narrow large reads: `dataUrl + "?fields=title,start,end"` or `?ids=a,b,c`
-  (comma-separated). A read of **more than 200 records** without `ids`/`fields`
-  is refused — always project `fields` for big collections.
+- **`?fields=a,b,c`** — only these columns per record (the primary key is always
+  included). Use this on every read; it is mandatory above 200 records.
+- **`?ids=x,y,z`** — only these specific record ids. Use it when the view edits
+  / shows one record at a time. Combinable with `fields`.
+- The primary key is always returned regardless of `fields`.
 
 ### Writing records (only with the `write` capability)
 
@@ -111,9 +128,11 @@ By default a view paints once, on load. To keep it fresh, register a callback �
 it runs whenever the collection's data changes on the server:
 
 ```js
+// Same projection rule as the initial read — list the columns this view uses.
+const url = dataUrl + "?fields=" + encodeURIComponent("title,start,end,status");
 async function render() {
-  const res = await fetch(dataUrl, { headers: { Authorization: "Bearer " + token } });
-  if (!res.ok) return; // handle the error per your UI
+  const res = await fetch(url, { headers: { Authorization: "Bearer " + token } });
+  if (!res.ok) return; // surface the body if you want a richer error UI
   const { items } = await res.json();
   // …draw items…
 }
@@ -303,8 +322,9 @@ fields `start` / `end` and a `title`. `capabilities: ["read"]`.
       const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
       async function main() {
         const { token, dataUrl } = window.__MC_VIEW;
-        const res = await fetch(dataUrl, { headers: { Authorization: "Bearer " + token } });
-        if (!res.ok) throw new Error("HTTP " + res.status);
+        const url = dataUrl + "?fields=" + encodeURIComponent("title,start");
+        const res = await fetch(url, { headers: { Authorization: "Bearer " + token } });
+        if (!res.ok) throw new Error("HTTP " + res.status + ": " + (await res.text()));
         const { items } = await res.json();
         const buckets = MONTHS.map(() => []);
         for (const it of items) {
@@ -382,10 +402,11 @@ writes it back. `capabilities: ["read","write"]`.
       const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
       const { token, dataUrl } = window.__MC_VIEW;
       const auth = { Authorization: "Bearer " + token, "Content-Type": "application/json" };
+      const readUrl = dataUrl + "?fields=" + encodeURIComponent("title,start");
 
       async function read() {
-        const res = await fetch(dataUrl, { headers: { Authorization: "Bearer " + token } });
-        if (!res.ok) throw new Error("HTTP " + res.status);
+        const res = await fetch(readUrl, { headers: { Authorization: "Bearer " + token } });
+        if (!res.ok) throw new Error("HTTP " + res.status + ": " + (await res.text()));
         return (await res.json()).items;
       }
       async function bump(item) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client and ./workspace-setup/slug entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/plans/fix-custom-view-help-default-fields.md
+++ b/plans/fix-custom-view-help-default-fields.md
@@ -1,0 +1,41 @@
+# fix: teach `custom-view.md` to project `?fields=` by default
+
+Tracks: #1833 (Fix A — docs/scaffold).
+
+## Problem (from #1833)
+
+A user collection grows past the unselective 200-record limit; an existing
+custom view that fetches `dataUrl` raw stops loading. The view's
+`if (!res.ok) throw new Error("HTTP " + res.status)` surfaces only `HTTP 400`,
+which is unhelpful — the server's actual refusal message ("pass `fields` to
+project only the columns you need") is in the body but never read.
+
+The `custom-view.md` help (the canonical scaffold doc Claude follows) already
+documents the rule, but the canonical `fetch` example on line 73-75 omits
+`?fields=`. New views copy the example and get the trap by default; the
+warning bullet underneath does not change that.
+
+## Fix (Fix A from #1833)
+
+Three edits in `packages/core/assets/helps/custom-view.md`:
+
+1. **Lead the "Reading records" section with the projection rule** (blockquote
+   before the example) so it is impossible to miss.
+2. **Canonical fetch example uses `?fields=`** with `encodeURIComponent` for
+   safety, and the error handler reads `await res.text()` so a future 400
+   surfaces the server's message, not just the status.
+3. **Both worked examples (year overview + weekly planner) carry the same
+   pattern.** The "Staying live" re-fetch helper too.
+
+Bump `@mulmoclaude/core` to 0.2.3 — `packages/core/assets/` ships with the
+package and is consumed by both MulmoClaude and MulmoTerminal.
+
+## Out of scope (Fix B from #1833)
+
+Runtime "ask for help" affordance on the toast / a `window.__MC_VIEW.askHostForHelp(error)`
+API — bigger surface change, separate PR.
+
+## Tests
+
+Help text is consumed by humans / LLMs at scaffolding time. No automated test.
+Doc shape verified by re-reading the updated file end-to-end.


### PR DESCRIPTION
## Summary

- Fixes [#1833](https://github.com/receptron/mulmoclaude/issues/1833) Fix A: the canonical `fetch` example in `custom-view.md` now passes `?fields=…` by default and reads the response body on `!res.ok`. New (LLM-authored) custom views inherit the projection from line 1 and surface the server's actual refusal message instead of the bare status.
- `@mulmoclaude/core` bumped to `0.2.3` (the `assets/` dir ships with the package).
- Out of scope: a runtime "ask for help" affordance on the 400 toast / `window.__MC_VIEW.askHostForHelp(error)` API — separate PR per Fix B in #1833.

## Items to Confirm / Review

1. **Projection columns in the canonical example** use `title,start,end,status` as the placeholder — confirm the headline pattern reads right. The intent is to show "list the columns this view actually reads"; the specific names are illustrative.
2. **Worked examples (Year overview, weekly planner)** project just `title,start` — they only render those, so this is intentional. If you'd rather the examples project a wider set to model "real" production-shaped projections, easy to widen.
3. **Both `fetch` URLs build via `encodeURIComponent`**, matching the safety pattern Claude already uses elsewhere. Comma-separated `fields` values do not need encoding today but the wrapper costs nothing and survives a future field name that does.
4. **Version bump** — patch (0.2.2 → 0.2.3) because the change is to documentation assets shipped with the package; no runtime semantics change. Confirm patch is the right granularity (vs. minor) for an assets-only change that affects how new views are authored.

## User Prompt

> ユーザからのフィードバック … MulmoClaude に聞いたところ以下が原因ということでした … カスタムビューを作成する skill にその情報を教えておいたほうが良いかもしれませんね … 加えて、HTTP400 エラーと言われても、最初は「？」となるので「解決策を尋ねる」みたいなボタンがあると落ち着いて行動できるかもしれないです
>
> で、直せる？
> 進めて。推奨で。

(Original feedback recorded anonymously in #1833.)

## Approach

The custom-view help is the single source of truth Claude follows when scaffolding `views/<slug>.html`. The 200-record refusal already lived in the doc — but as a bullet **below** the canonical example, so the example wins. This PR moves the rule **above** the example as a blockquote and rewrites every `fetch(dataUrl, …)` site in the file to use `?fields=` + body-aware error handling.

Three patterns updated:

1. **"Reading records"** opens with a blockquote stating the projection rule + what happens above 200 records; the canonical example uses `?fields=` and `await res.text()` on `!res.ok`.
2. **"Staying live" `onChange` re-fetch helper** uses the same projection so a user copying the live-refresh example into a new view also inherits it from line 1.
3. **Both inline worked examples** (Year overview, weekly planner) carry the same pattern.

## Out of scope (Fix B, tracked in #1833)

A runtime "ask for help" affordance — surface the server message in the iframe error toast and add an `Ask for help` button that opens a chat draft seeded with the file path, slug, server refusal text, and a recovery prompt. Bigger surface (new `window.__MC_VIEW` API, host-side iframe error capture), separate PR.

## Tests

Help text is consumed by humans / LLMs at scaffolding time. No automated test. `yarn format` / `yarn lint` clean.

## Related

- Fixes #1833 (Fix A only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
