### PR TITLE
fix(collections): imported project view 404 — fall back to skillDir in readCustomViewHtml

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client and ./workspace-setup/slug entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/src/collection/server/io.ts
+++ b/packages/core/src/collection/server/io.ts
@@ -254,8 +254,13 @@ export async function readCustomViewHtml(
     if (resolved === null) continue;
     try {
       return await readFile(resolved, "utf-8");
-    } catch {
-      // missing in this base — try the next one
+    } catch (err) {
+      // Only the "file missing here" codes should trigger the fallback. A
+      // permission denial / disk error must propagate — silently falling back
+      // would mask a real failure as a stale-from-other-base success or a
+      // misleading 404 (CodeRabbit review on #1836).
+      const { code } = err as { code?: string };
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw err;
     }
   }
   return null;

--- a/packages/core/src/collection/server/io.ts
+++ b/packages/core/src/collection/server/io.ts
@@ -228,12 +228,18 @@ export function generateItemId(): string {
  *  schema-validated `views/*.html` path, resolved with realpath containment.
  *  Returns the HTML, or null when the path is unsafe or the file is missing.
  *
- *  The base dir is source-aware: a **project** collection authors views in the
- *  `data/skills/<slug>/` staging dir (custom-view HTML is staging-only — NOT
- *  mirrored to `.claude/skills`, because rendering is host-side; see
- *  plans/done/feat-collections-custom-views.md), whereas a **user** / **feed**
- *  collection is authored directly in its own discovered `skillDir`. Reading
- *  relative to the wrong tree would 404 a perfectly valid view. */
+ *  The base dir is source-aware. A **project** collection AUTHORED in-place
+ *  keeps its views in the `data/skills/<slug>/` staging dir (host-side
+ *  rendering; see plans/done/feat-collections-custom-views.md). A **project**
+ *  collection that was IMPORTED via the discover panel (rename-on-conflict)
+ *  carries its views inside `.claude/skills/<slug>/views/` — the skill folder
+ *  itself — without a staging-dir mirror; reading only the staging path would
+ *  404 a perfectly valid imported view. We try staging first, then fall back
+ *  to the discovered `skillDir`, so both layouts read cleanly. A **user** /
+ *  **feed** collection is always authored in its own discovered `skillDir`,
+ *  so it only needs the single lookup. `resolveTemplatePath` does the
+ *  containment / `..` defense per base, so the fallback never broadens the
+ *  attack surface. */
 export async function readCustomViewHtml(
   collection: Pick<LoadedCollection, "slug" | "source" | "skillDir">,
   viewFile: string,
@@ -242,14 +248,17 @@ export async function readCustomViewHtml(
   const safeSlug = safeSlugName(collection.slug);
   if (safeSlug === null) return null;
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
-  const base = collection.source === "project" ? path.join(skillsStagingDir(workspaceRoot), safeSlug) : collection.skillDir;
-  const resolved = resolveTemplatePath(base, viewFile);
-  if (resolved === null) return null;
-  try {
-    return await readFile(resolved, "utf-8");
-  } catch {
-    return null;
+  const bases = collection.source === "project" ? [path.join(skillsStagingDir(workspaceRoot), safeSlug), collection.skillDir] : [collection.skillDir];
+  for (const base of bases) {
+    const resolved = resolveTemplatePath(base, viewFile);
+    if (resolved === null) continue;
+    try {
+      return await readFile(resolved, "utf-8");
+    } catch {
+      // missing in this base — try the next one
+    }
   }
+  return null;
 }
 
 /** The item id a CREATE should use for `schema`, or null when the

--- a/packages/core/src/collection/server/views.ts
+++ b/packages/core/src/collection/server/views.ts
@@ -4,18 +4,22 @@
 //   1. an entry in the collection's schema.json `views[]` array
 //   2. its HTML file at `<base>/views/<file>` (the entry's `file` field)
 //
-// The base dir is source-aware, mirroring `readCustomViewHtml`: a PROJECT
-// collection authors into the staging tree (`data/skills/<slug>/`) and
-// discovery scans an active mirror (`.claude/skills/<slug>/`, i.e.
-// `collection.skillDir`) — so the schema edit must touch BOTH copies. The
-// skill-bridge hook that normally keeps them in sync only fires on the agent's
-// own tool calls, never from an API route, exactly as `deleteCollection`
-// reasons. A FEED / USER collection is a single tree at `collection.skillDir`.
+// The base dir is source-aware, mirroring `readCustomViewHtml`. A PROJECT
+// collection authored in-place keeps schema + view HTML in the staging tree
+// (`data/skills/<slug>/`) AND mirrors schema into the active dir
+// (`.claude/skills/<slug>/`, i.e. `collection.skillDir`). A PROJECT collection
+// IMPORTED via the discover panel (rename-on-conflict) lives entirely under
+// the active dir — no staging mirror is created. We pick the canonical base
+// (and the schema-write set) by *what's actually on disk*, so both layouts
+// delete cleanly without ENOENT. The skill-bridge hook that normally keeps
+// staging+active in sync only fires on the agent's own tool calls, never from
+// an API route — exactly as `deleteCollection` reasons. A FEED / USER
+// collection is a single tree at `collection.skillDir`.
 //
 // Custom-view HTML is staging-only for project collections (never mirrored —
 // rendering is host-side), so only the canonical base's copy is unlinked.
 
-import { readFile, unlink } from "node:fs/promises";
+import { readFile, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { writeFileAtomic } from "./atomic";
 import { getWorkspaceRoot, isPresetSlug, skillsStagingDir } from "./host";
@@ -30,20 +34,43 @@ export type DeleteViewResult =
   | { kind: "preset" }
   | { kind: "unsafe-path"; viewId: string };
 
-/** The authoritative base dir for a collection's schema.json + view HTML —
- *  the staging tree for a project collection, else its own skill dir. Matches
- *  `readCustomViewHtml`'s resolution so reads and deletes agree. */
-function canonicalBase(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): string {
-  return collection.source === "project" ? path.join(skillsStagingDir(workspaceRoot), safeSlug) : collection.skillDir;
+async function fileExists(target: string): Promise<boolean> {
+  try {
+    await stat(target);
+    return true;
+  } catch (err) {
+    const { code } = err as { code?: string };
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    throw err;
+  }
 }
 
-/** Every on-disk schema.json that must reflect the removal. For a project
- *  collection that's the staging copy AND the active mirror; otherwise just
- *  the single skill-dir copy. */
-function schemaWriteTargets(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): string[] {
+/** The authoritative base dir for a collection's schema.json + view HTML.
+ *  For a project collection, prefer the staging tree when its schema.json is
+ *  present (authoring layout); otherwise fall back to the active skill dir
+ *  (imported layout — staging never materialised). For feed / user, it's
+ *  always the discovered skillDir. Matches `readCustomViewHtml` so reads and
+ *  deletes agree on both layouts. */
+async function canonicalBase(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): Promise<string> {
+  if (collection.source !== "project") return collection.skillDir;
+  const staging = path.join(skillsStagingDir(workspaceRoot), safeSlug);
+  if (await fileExists(path.join(staging, SCHEMA_FILE))) return staging;
+  return collection.skillDir;
+}
+
+/** Every on-disk schema.json that must reflect the removal. The active
+ *  `<skillDir>/schema.json` is the discovery anchor and is always present.
+ *  The staging copy is included only when it actually exists, so an imported
+ *  project collection (no staging mirror) doesn't have an empty staging tree
+ *  materialised by a side effect of the delete. */
+async function schemaWriteTargets(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): Promise<string[]> {
   const active = path.join(collection.skillDir, SCHEMA_FILE);
-  if (collection.source === "project") return [path.join(skillsStagingDir(workspaceRoot), safeSlug, SCHEMA_FILE), active];
-  return [active];
+  if (collection.source !== "project") return [active];
+  const stagingSchema = path.join(skillsStagingDir(workspaceRoot), safeSlug, SCHEMA_FILE);
+  const targets: string[] = [];
+  if (await fileExists(stagingSchema)) targets.push(stagingSchema);
+  targets.push(active);
+  return targets;
 }
 
 /** Idempotent unlink — a missing file is fine (the schema entry still gets
@@ -61,11 +88,12 @@ async function unlinkIfPresent(target: string): Promise<void> {
  *  raw (not `collection.schema`) so fields the typed schema doesn't model are
  *  preserved verbatim. */
 async function removeViewFromSchemas(collection: LoadedCollection, viewId: string, workspaceRoot: string, safeSlug: string): Promise<void> {
-  const canonical = path.join(canonicalBase(collection, workspaceRoot, safeSlug), SCHEMA_FILE);
+  const base = await canonicalBase(collection, workspaceRoot, safeSlug);
+  const canonical = path.join(base, SCHEMA_FILE);
   const parsed = JSON.parse(await readFile(canonical, "utf-8")) as { views?: { id?: unknown }[] };
   if (Array.isArray(parsed.views)) parsed.views = parsed.views.filter((entry) => entry?.id !== viewId);
   const serialized = `${JSON.stringify(parsed, null, 2)}\n`;
-  for (const target of schemaWriteTargets(collection, workspaceRoot, safeSlug)) {
+  for (const target of await schemaWriteTargets(collection, workspaceRoot, safeSlug)) {
     await writeFileAtomic(target, serialized);
   }
 }
@@ -82,7 +110,7 @@ export async function deleteCustomView(collection: LoadedCollection, viewId: str
   const view = views.find((entry) => entry.id === viewId);
   if (!view) return { kind: "not-found", viewId };
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
-  const htmlPath = resolveTemplatePath(canonicalBase(collection, workspaceRoot, safeSlug), view.file);
+  const htmlPath = resolveTemplatePath(await canonicalBase(collection, workspaceRoot, safeSlug), view.file);
   if (htmlPath === null) return { kind: "unsafe-path", viewId };
   // Rewrite the schema BEFORE unlinking: if the write fails the request errors
   // out, but the HTML stays put and the still-registered view keeps working —

--- a/test/workspace/collections/test_io.ts
+++ b/test/workspace/collections/test_io.ts
@@ -13,18 +13,40 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  configureCollectionHost,
   listItems,
   readItem,
   writeItem,
   deleteItem,
   resolveCreateItemId,
   readSkillTemplate,
+  readCustomViewHtml,
   buildActionSeedPrompt,
   buildCollectionActionSeedPrompt,
   setCollectionChangePublisher,
   type CollectionChangePayload,
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
+
+// `readCustomViewHtml` resolves its base path through the configured host
+// (`skillsStagingDir`), so this suite must wire a host stub once. Every test
+// passes `workspaceRoot: workdir` explicitly, so the host's `workspaceRoot`
+// field is only a placeholder — the staging-dir factory is what's exercised.
+// `configureCollectionHost` is a no-op if called again with the same object,
+// which keeps re-runs idempotent.
+const TEST_HOST_PATHS = {
+  userSkillsDir: "/dev/null/.claude/skills",
+  projectSkillsDir: (root: string) => path.join(root, ".claude", "skills"),
+  feedsRoot: (root: string) => path.join(root, "feeds"),
+  skillsStagingDir: (root: string) => path.join(root, "data", "skills"),
+  archiveDir: ".archive",
+};
+configureCollectionHost({
+  workspaceRoot: "/tmp/__test_io_placeholder__",
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  paths: TEST_HOST_PATHS,
+  isPresetSlug: () => false,
+});
 
 let workdir: string;
 let dataDir: string;
@@ -128,6 +150,74 @@ describe("readSkillTemplate — path-safe template read", () => {
     const skillDir = path.join(workdir, ".claude", "skills", "mc-x");
     mkdirSync(skillDir, { recursive: true });
     assert.equal(await readSkillTemplate(skillDir, "templates/nope.md"), null);
+  });
+});
+
+describe("readCustomViewHtml — source-aware base + import fallback", () => {
+  // Mirrors the two real on-disk shapes a project collection can have:
+  //   - AUTHORED in-place: views live in <workspace>/data/skills/<slug>/views/
+  //     (the staging dir; host-side rendering),
+  //   - IMPORTED via the discover panel (rename-on-conflict): everything,
+  //     views included, lands in <workspace>/.claude/skills/<slug>/views/
+  //     with NO staging-dir mirror — this is what 404'd before the fallback.
+  const slug = "movies-2";
+  const viewFile = "views/cinema.html";
+  const html = "<!doctype html><body>cinema</body>";
+
+  function authoredProjectCollection() {
+    return { slug, source: "project" as const, skillDir: path.join(workdir, ".claude", "skills", slug) };
+  }
+
+  function userCollection() {
+    return { slug, source: "user" as const, skillDir: path.join(workdir, ".claude", "skills", slug) };
+  }
+
+  it("reads project views from the staging dir (authoring layout)", async () => {
+    const stagingViews = path.join(workdir, "data", "skills", slug, "views");
+    mkdirSync(stagingViews, { recursive: true });
+    writeFileSync(path.join(stagingViews, "cinema.html"), html);
+    const result = await readCustomViewHtml(authoredProjectCollection(), viewFile, { workspaceRoot: workdir });
+    assert.equal(result, html);
+  });
+
+  it("falls back to skillDir when a project view only exists there (imported layout)", async () => {
+    // No staging-dir copy at all — the import flow only wrote the skill folder.
+    const skillViews = path.join(workdir, ".claude", "skills", slug, "views");
+    mkdirSync(skillViews, { recursive: true });
+    writeFileSync(path.join(skillViews, "cinema.html"), html);
+    const result = await readCustomViewHtml(authoredProjectCollection(), viewFile, { workspaceRoot: workdir });
+    assert.equal(result, html, "imported project view must read from skillDir, not 404");
+  });
+
+  it("prefers the staging-dir copy over the skillDir copy when both exist", async () => {
+    const stagingViews = path.join(workdir, "data", "skills", slug, "views");
+    const skillViews = path.join(workdir, ".claude", "skills", slug, "views");
+    mkdirSync(stagingViews, { recursive: true });
+    mkdirSync(skillViews, { recursive: true });
+    writeFileSync(path.join(stagingViews, "cinema.html"), "STAGING");
+    writeFileSync(path.join(skillViews, "cinema.html"), "SKILL");
+    const result = await readCustomViewHtml(authoredProjectCollection(), viewFile, { workspaceRoot: workdir });
+    assert.equal(result, "STAGING", "staging dir (the authoring path) wins when present");
+  });
+
+  it("returns null when the view is absent from both bases", async () => {
+    const result = await readCustomViewHtml(authoredProjectCollection(), viewFile, { workspaceRoot: workdir });
+    assert.equal(result, null);
+  });
+
+  it("reads user-collection views from the discovered skillDir", async () => {
+    const skillViews = path.join(workdir, ".claude", "skills", slug, "views");
+    mkdirSync(skillViews, { recursive: true });
+    writeFileSync(path.join(skillViews, "cinema.html"), html);
+    const result = await readCustomViewHtml(userCollection(), viewFile, { workspaceRoot: workdir });
+    assert.equal(result, html);
+  });
+
+  it("refuses path traversal even with the fallback active", async () => {
+    // A staging-dir-relative `..`-escape must not be permitted, and the
+    // fallback must not retry with the same unsafe path against skillDir.
+    const result = await readCustomViewHtml(authoredProjectCollection(), "../../../etc/passwd", { workspaceRoot: workdir });
+    assert.equal(result, null);
   });
 });
 

--- a/test/workspace/collections/test_views.ts
+++ b/test/workspace/collections/test_views.ts
@@ -48,6 +48,18 @@ function seedProject(slug: string, views: CollectionCustomView[]): LoadedCollect
   return { slug, source: "project", schema, dataDir: path.join(workdir, "data", slug, "items"), skillDir: active };
 }
 
+/** Imported project collection: rename-on-conflict via the discover panel.
+ *  Schema + view HTML live ONLY under the active dir (.claude/skills/<slug>/);
+ *  no staging mirror is ever created. */
+function seedImportedProject(slug: string, views: CollectionCustomView[]): LoadedCollection {
+  const schema = schemaWith(slug, views);
+  const active = path.join(workdir, ".claude", "skills", slug);
+  mkdirSync(path.join(active, "views"), { recursive: true });
+  writeFileSync(path.join(active, "schema.json"), JSON.stringify(schema, null, 2));
+  for (const view of views) writeFileSync(path.join(active, view.file), "<html></html>");
+  return { slug, source: "project", schema, dataDir: path.join(workdir, "data", slug, "items"), skillDir: active };
+}
+
 /** Feed (or user) collection: a single tree at skillDir holds schema.json and
  *  the view HTML. */
 function seedSingleTree(slug: string, source: CollectionSource, root: string, views: CollectionCustomView[]): LoadedCollection {
@@ -138,6 +150,25 @@ describe("deleteCustomView", () => {
 
     assert.equal(result.kind, "preset");
     assert.deepEqual(readViewIds(path.join(workdir, "data", "skills", "mc-invoice", "schema.json")), ["year"]);
+  });
+
+  it("deletes from skillDir when the project collection was imported (no staging mirror)", async () => {
+    // Repro of the layout that 404'd reads and ENOENT'd deletes before the
+    // source-aware fallback (movies-2 / Codex #1836).
+    const collection = seedImportedProject("events-imp", [YEAR_VIEW, MONTH_VIEW]);
+    const staging = path.join(workdir, "data", "skills", "events-imp");
+    const active = path.join(workdir, ".claude", "skills", "events-imp");
+
+    const result = await deleteCustomView(collection, "year", { workspaceRoot: workdir });
+
+    assert.equal(result.kind, "ok");
+    // Schema in the active dir reflects the removal.
+    assert.deepEqual(readViewIds(path.join(active, "schema.json")), ["month"]);
+    // HTML unlinked from the active dir; sibling survives.
+    assert.equal(existsSync(path.join(active, "views", "year.html")), false, "deleted view HTML must be unlinked from skillDir");
+    assert.equal(existsSync(path.join(active, "views", "month.html")), true, "sibling view HTML must remain in skillDir");
+    // Staging tree must NOT have been materialised as a side effect.
+    assert.equal(existsSync(staging), false, "imported layout must not be back-filled with a staging mirror by delete");
   });
 
   it("refuses a view whose file path escapes its base and deletes nothing", async () => {


### PR DESCRIPTION
## Summary
Fix the `HTTP 404` shown when switching to a **custom view on an imported project collection** (rename-on-conflict via the discover panel — e.g. `movies` → `movies-2`, opening the "シネマ" view).

## Items to Confirm / Review
- Project collections have **two valid on-disk layouts** depending on origin:
  - **AUTHORED in-place**: schema in `<workspace>/.claude/skills/<slug>/`, view HTML in `<workspace>/data/skills/<slug>/views/` (the staging dir; host-side rendering — see `plans/done/feat-collections-custom-views.md`).
  - **IMPORTED via the discover panel** (rename-on-conflict): everything, views included, in `<workspace>/.claude/skills/<slug>/views/`. The staging dir is never created.
- `readCustomViewHtml` was source-aware on `"project"` but only looked at the staging path → 404 for every imported project view.
- This PR adds a **staging → skillDir fallback** for `source === "project"`. `user` / `feed` unchanged.
- `resolveTemplatePath` containment runs per base, so the fallback doesn't broaden the attack surface — covered by a path-traversal regression that exercises both bases.

## User Prompt
> `http://localhost:5173/collections/movies-2` で view をかえると、「シネマ」ビュー、このビューを読み込めませんでした: HTTP 404 になった。直せたら直して。
>
> あ、これ名前がconflictして別名で取り込んだcollectionだ。バグかも知れない。調査を。
>
> とりこんだときに別名にするとだめ、もしくはcustom viewがとりこまていないかのいずれかだ。

## Implementation

### `packages/core/src/collection/server/io.ts:readCustomViewHtml`
- Old: single base — staging dir for project, skillDir for user/feed.
- New: array of bases; project gets `[stagingDir, skillDir]`. First base where the file resolves wins.
- Doc comment updated to describe both layouts and why the fallback is safe.

### `test/workspace/collections/test_io.ts`
- New describe block `readCustomViewHtml — source-aware base + import fallback`, 6 cases:
  1. project, authored layout (staging dir) — reads.
  2. project, imported layout (skillDir only, no staging) — **the bug**; reads via fallback.
  3. project, both present — staging wins (preserves authoring precedence).
  4. project, neither present — `null`.
  5. user collection — reads from skillDir.
  6. path traversal (`../../../etc/passwd`) — refused even with fallback active.
- Wires the collection host once at module top with stub paths so `skillsStagingDir()` is callable inside the test process.

## Why this is the right fix, not the import flow

The import flow could also be patched to mirror views into the staging dir, but:
- it doesn't help collections already imported (the user's `movies-2`),
- it duplicates files on disk for no rendering benefit,
- the read-side fallback is one function, one place — strictly less surface than per-import flow changes.

The staging-dir invariant for newly authored project collections is preserved.

## Validation
- `yarn lint` / `typecheck` / `build`: clean.
- `npx tsx --test test/workspace/collections/test_io.ts` → **28/28 pass** (6 new + 22 existing).

## Test Plan
- [ ] CI green.
- [ ] On a live workspace with an imported renamed collection (e.g. `movies-2`), switch to the custom view — renders instead of 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-view HTML loading for project collections so views are found in both authored and imported layouts.
  * Added fallback lookup behavior to prefer the main staging location, then use the discovered skill location if needed.
  * Strengthened path safety to prevent directory traversal when resolving view files.
  * Kept user collection view loading working as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->