### PR TITLE
refactor(collections): import writes to data/skills/ — unify with authoring

### DIFF
--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -20,11 +20,12 @@
 // no network; `performImport` is the thin glue that fetches and calls it.
 
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
 import path from "node:path";
 
 import { acceptParsedSchema, CollectionSchemaZ, isSafeActionTemplatePath, safeRecordId } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "@mulmoclaude/core/collection";
-import { claudeSkillDir, dataSkillDir, mirrorSkillDelete, mirrorSkillWrite } from "@mulmoclaude/core/skill-bridge";
+import { claudeSkillDir, dataSkillDir, mirrorSkillWrite } from "@mulmoclaude/core/skill-bridge";
 
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -128,11 +129,13 @@ async function findMatchingInstall(skillsDir: string, registry: string, entry: R
 //
 // A slug is "free" only when BOTH `data/skills/<slug>/` AND
 // `.claude/skills/<slug>/` are absent. The mirror check matters because
-// `mirrorToClaudeSkills` calls `mirrorSkillDelete(slug)` before writing — if
-// the user has a manually-installed Claude skill at `.claude/skills/<slug>/`
-// with no corresponding `data/skills/<slug>/` (e.g. installed by the Claude
-// CLI directly, or a legacy pre-refactor import we never migrated), picking
-// that slug would silently wipe their skill (CodeRabbit review on #1839).
+// `mirrorToClaudeSkills` overwrites the mirror dir's allowlisted files and
+// prunes anything else — if the user has a manually-installed Claude skill
+// at `.claude/skills/<slug>/` with no corresponding `data/skills/<slug>/`
+// (e.g. installed by the Claude CLI directly, or a legacy pre-refactor
+// import we never migrated), picking that slug would silently overwrite
+// their SKILL.md/schema.json and prune the rest of their files (CodeRabbit
+// review on #1839).
 async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
   const skillsDir = path.dirname(dataSkillDir(workspaceRoot, entry.slug));
   const existing = await findMatchingInstall(skillsDir, registry, entry);
@@ -203,24 +206,64 @@ async function materializeSeed(dataDir: string, bundle: Map<string, string>): Pr
   return { written, skipped: false };
 }
 
+/** Compute the set of bundle-relative paths that should land in `.claude/skills/<slug>/`.
+ *  Matches the bridge allowlist exactly — SKILL.md, schema.json,
+ *  `templates/<safe>` — so anything else (seed, meta.json, views, README,
+ *  assets) stays source-side. */
+function bridgeAllowlistFiles(bundle: Map<string, string>): Set<string> {
+  const wanted = new Set<string>([SKILL_FILE, SCHEMA_FILE]);
+  for (const rel of bundle.keys()) {
+    if (rel === SKILL_FILE || rel === SCHEMA_FILE) continue;
+    if (rel.startsWith(SEED_PREFIX)) continue;
+    if (!isSafeActionTemplatePath(rel)) continue;
+    wanted.add(rel);
+  }
+  return wanted;
+}
+
+/** Recursively list every file under `root`, returned as forward-slash paths
+ *  relative to `root`. Empty list when `root` doesn't exist. Used to spot
+ *  mirror files left over from a previous install so we can prune them after
+ *  writing the new ones. */
+async function listFilesRecursive(root: string, prefix = ""): Promise<string[]> {
+  const dir = prefix ? path.join(root, ...prefix.split("/")) : root;
+  const entries: Dirent[] = await readdir(dir, { withFileTypes: true }).catch(() => [] as Dirent[]);
+  const out: string[] = [];
+  for (const entry of entries) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isFile()) out.push(rel);
+    else if (entry.isDirectory()) out.push(...(await listFilesRecursive(root, rel)));
+  }
+  return out;
+}
+
 // Mirror the just-written `data/skills/<slug>/` into `.claude/skills/<slug>/`
 // using the shared bridge package — exactly the set of files an
 // agent-authored skill would mirror, no more (SKILL.md, schema.json,
 // templates/<safe>). `.origin.json` is host bookkeeping and stays only on the
-// data side. Drop the prior mirror first so a template removed in this
-// version doesn't linger from the previous install.
-function mirrorToClaudeSkills(workspaceRoot: string, localSlug: string, bundle: Map<string, string>): void {
-  mirrorSkillDelete(workspaceRoot, localSlug);
-  // SKILL.md + schema.json are required (the writer wouldn't have reached here
-  // without them); template paths come from the bundle, pre-filtered through
-  // the same safety predicate the schema validator uses.
-  mirrorSkillWrite(workspaceRoot, { slug: localSlug, relSegments: [SKILL_FILE] });
-  mirrorSkillWrite(workspaceRoot, { slug: localSlug, relSegments: [SCHEMA_FILE] });
-  for (const rel of bundle.keys()) {
-    if (rel === SKILL_FILE || rel === SCHEMA_FILE) continue;
-    if (rel.startsWith(SEED_PREFIX)) continue; // seed lives in dataPath, not the skill dir
-    if (!isSafeActionTemplatePath(rel)) continue; // matches bridge allowlist
+// data side.
+//
+// **Write-then-prune ordering** (Codex review on #1839): write the new
+// bundle's allowlisted files FIRST (each is a per-file tmp+rename, atomic),
+// THEN prune mirror files that aren't in the new bundle. A transient mirror
+// failure during the writes leaves the previous mirror's files in place —
+// agent discovery keeps working with the prior state instead of finding an
+// empty `.claude/skills/<slug>/`. The prune step is best-effort: a failure
+// there leaves harmless stale leftovers but doesn't break the new install.
+// Compare with the old `mirrorSkillDelete`-first ordering, which could
+// silently leave an empty mirror if a subsequent write threw.
+async function mirrorToClaudeSkills(workspaceRoot: string, localSlug: string, bundle: Map<string, string>): Promise<void> {
+  const wanted = bridgeAllowlistFiles(bundle);
+  // 1. Write the new set first (overwrites existing via tmp+rename).
+  for (const rel of wanted) {
     mirrorSkillWrite(workspaceRoot, { slug: localSlug, relSegments: rel.split("/") });
+  }
+  // 2. Prune files that exist in the mirror but aren't in the new bundle.
+  const mirrorRoot = claudeSkillDir(workspaceRoot, localSlug);
+  const existing = await listFilesRecursive(mirrorRoot);
+  for (const rel of existing) {
+    if (wanted.has(rel)) continue;
+    await rm(path.join(mirrorRoot, ...rel.split("/")), { force: true }).catch(() => undefined);
   }
 }
 
@@ -278,13 +321,16 @@ export async function writeImportedCollection(params: {
 
   // Replicate the new `data/skills/<slug>/` set into `.claude/skills/<slug>/`
   // via the shared bridge package — same allowlist + tmp+rename semantics the
-  // hook uses for agent-authored writes. A mirror failure here is logged but
-  // doesn't undo the data-side write (the user can fix it by retriggering the
-  // mirror — same as for any other mirror failure).
+  // hook uses for agent-authored writes. Write-then-prune ordering inside
+  // mirrorToClaudeSkills means a transient failure here can't leave the mirror
+  // empty (Codex review on #1839); the worst case is a half-written mirror
+  // where the new install's SKILL.md/schema.json may not have updated, but the
+  // prior install remains accessible to the agent until the next mirror
+  // attempt. Logged-not-thrown matches the hook's posture for agent writes.
   try {
-    mirrorToClaudeSkills(workspaceRoot, localSlug, bundle);
+    await mirrorToClaudeSkills(workspaceRoot, localSlug, bundle);
   } catch (err) {
-    log.warn("collections-registry", "mirror to .claude/skills/ failed (data/skills write succeeded)", {
+    log.warn("collections-registry", "mirror to .claude/skills/ failed (data/skills write succeeded; prior mirror left intact)", {
       localSlug,
       error: errorMessage(err),
     });

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -1,24 +1,35 @@
-// Import a registry collection into the active workspace. The writer fetches the
-// bundle, re-validates the schema with the host's own gates (R7 — the index is not
-// a trust boundary), writes the bundle into .claude/skills/<localSlug>/ with a
-// host-owned dataPath (R3), materializes any seed records into that dataPath when
-// it's empty, and records provenance in .origin.json for update detection (R5/R8).
+// Import a registry collection into the active workspace. The writer fetches
+// the bundle, re-validates the schema with the host's own gates (R7 — the
+// index is not a trust boundary), writes the bundle into `data/skills/<localSlug>/`
+// with a host-owned dataPath (R3), materializes any seed records into that
+// dataPath when it's empty, and records provenance in `.origin.json` for
+// update detection (R5/R8). After the data-skills swap, the bundle's
+// allowlisted files (SKILL.md, schema.json, templates/<safe>) are mirrored
+// 1:1 into `.claude/skills/<localSlug>/` via the same `@mulmoclaude/core/skill-bridge`
+// rules an agent-authored skill would go through — so an authored and an
+// imported collection live in EXACTLY the same place on disk, and the user
+// can edit either one identically.
+//
+// `.origin.json` lives ONLY in `data/skills/<slug>/.origin.json` and is NOT
+// mirrored — the skill-bridge allowlist deliberately excludes host
+// bookkeeping. Its presence is what distinguishes "imported" from
+// "user-authored" in every downstream tool.
 //
 // `writeImportedCollection` takes the already-fetched bundle + an explicit
-// workspaceRoot/clock so it is unit-testable against a temp workspace with no
-// network; `performImport` is the thin glue that fetches and calls it.
+// workspaceRoot/clock so it is unit-testable against a temp workspace with
+// no network; `performImport` is the thin glue that fetches and calls it.
 
 import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { acceptParsedSchema, CollectionSchemaZ, safeRecordId } from "@mulmoclaude/core/collection/server";
+import { acceptParsedSchema, CollectionSchemaZ, isSafeActionTemplatePath, safeRecordId } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "@mulmoclaude/core/collection";
+import { claudeSkillDir, dataSkillDir, mirrorSkillDelete, mirrorSkillWrite } from "@mulmoclaude/core/skill-bridge";
 
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { isRecord } from "../../utils/types.js";
-import { projectSkillDir } from "../skills/paths.js";
 import { fetchRegistryIndex } from "./client.js";
 import { fetchBundle, fetchManifest, normalizedDataPath } from "./importCollection.js";
 import type { RegistryCollectionEntry } from "./registryIndex.js";
@@ -26,6 +37,7 @@ import type { RegistryCollectionEntry } from "./registryIndex.js";
 const ORIGIN_FILE = ".origin.json";
 const SEED_PREFIX = "seed/items/";
 const SCHEMA_FILE = "schema.json";
+const SKILL_FILE = "SKILL.md";
 const STATUS_NOT_FOUND = 404;
 const STATUS_CONFLICT = 409;
 const STATUS_UNPROCESSABLE = 422;
@@ -77,10 +89,11 @@ async function readOrigin(targetDir: string): Promise<unknown> {
 
 type TargetResolution = { targetDir: string; localSlug: string; updated: boolean } | { conflict: string };
 
-// Only bounds the fresh-slug search (a safety cap, far above any realistic number of
-// same-named collections — the first free slug is normally found in 1–2 iterations).
-// An EXISTING install is found via the directory scan below, not this loop, so updates
-// are never missed regardless of how high the rename suffix is.
+// Only bounds the fresh-slug search (a safety cap, far above any realistic
+// number of same-named collections — the first free slug is normally found in
+// 1–2 iterations). An EXISTING install is found via the directory scan below,
+// not this loop, so updates are never missed regardless of how high the rename
+// suffix is.
 const MAX_SLUG_ATTEMPTS = 10000;
 
 const renameCandidate = (slug: string, attempt: number): string => (attempt === 0 ? slug : `${slug}-${attempt + 1}`);
@@ -93,9 +106,11 @@ function isRenameOf(name: string, slug: string): boolean {
   return suffix.length > 0 && /^\d+$/.test(suffix);
 }
 
-// Find an existing install of this registry collection at ANY rename suffix by scanning
-// the active skills dir — independent of any candidate bound, so a re-import always
-// updates the existing install rather than duplicating it (even if an earlier slug freed up).
+// Find an existing install of this registry collection at ANY rename suffix
+// by scanning `data/skills/` — independent of any candidate bound, so a
+// re-import always updates the existing install rather than duplicating it
+// (even if an earlier slug freed up). An authored skill without `.origin.json`
+// is invisible to this scan and so never collides with an update.
 async function findMatchingInstall(skillsDir: string, registry: string, entry: RegistryCollectionEntry): Promise<string | null> {
   const names = await readdir(skillsDir).catch(() => [] as string[]);
   for (const name of names) {
@@ -106,17 +121,19 @@ async function findMatchingInstall(skillsDir: string, registry: string, entry: R
   return null;
 }
 
-// Pick the local install slug (rename-on-collision, R8). First reuse an existing matching
-// install (update). Otherwise install fresh at the first free slug — the registry slug,
-// else `<slug>-2`, `-3`, … — never clobbering a user's own same-named collection.
+// Pick the local install slug (rename-on-collision, R8). First reuse an
+// existing matching install (update). Otherwise install fresh at the first
+// free slug — the registry slug, else `<slug>-2`, `-3`, … — never clobbering
+// a user's own same-named collection (`data/skills/<slug>/` without
+// `.origin.json` matching ⇒ treat as taken, walk forward).
 async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
-  const skillsDir = path.dirname(projectSkillDir(workspaceRoot, entry.slug));
+  const skillsDir = path.dirname(dataSkillDir(workspaceRoot, entry.slug));
   const existing = await findMatchingInstall(skillsDir, registry, entry);
-  if (existing) return { targetDir: projectSkillDir(workspaceRoot, existing), localSlug: existing, updated: true };
+  if (existing) return { targetDir: dataSkillDir(workspaceRoot, existing), localSlug: existing, updated: true };
   for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
     const localSlug = renameCandidate(entry.slug, attempt);
-    if ((await statType(projectSkillDir(workspaceRoot, localSlug))) === "absent") {
-      return { targetDir: projectSkillDir(workspaceRoot, localSlug), localSlug, updated: false };
+    if ((await statType(dataSkillDir(workspaceRoot, localSlug))) === "absent") {
+      return { targetDir: dataSkillDir(workspaceRoot, localSlug), localSlug, updated: false };
     }
   }
   return { conflict: `couldn't find an available slug for '${entry.slug}'` };
@@ -169,6 +186,27 @@ async function materializeSeed(dataDir: string, bundle: Map<string, string>): Pr
   return { written, skipped: false };
 }
 
+// Mirror the just-written `data/skills/<slug>/` into `.claude/skills/<slug>/`
+// using the shared bridge package — exactly the set of files an
+// agent-authored skill would mirror, no more (SKILL.md, schema.json,
+// templates/<safe>). `.origin.json` is host bookkeeping and stays only on the
+// data side. Drop the prior mirror first so a template removed in this
+// version doesn't linger from the previous install.
+function mirrorToClaudeSkills(workspaceRoot: string, localSlug: string, bundle: Map<string, string>): void {
+  mirrorSkillDelete(workspaceRoot, localSlug);
+  // SKILL.md + schema.json are required (the writer wouldn't have reached here
+  // without them); template paths come from the bundle, pre-filtered through
+  // the same safety predicate the schema validator uses.
+  mirrorSkillWrite(workspaceRoot, { slug: localSlug, relSegments: [SKILL_FILE] });
+  mirrorSkillWrite(workspaceRoot, { slug: localSlug, relSegments: [SCHEMA_FILE] });
+  for (const rel of bundle.keys()) {
+    if (rel === SKILL_FILE || rel === SCHEMA_FILE) continue;
+    if (rel.startsWith(SEED_PREFIX)) continue; // seed lives in dataPath, not the skill dir
+    if (!isSafeActionTemplatePath(rel)) continue; // matches bridge allowlist
+    mirrorSkillWrite(workspaceRoot, { slug: localSlug, relSegments: rel.split("/") });
+  }
+}
+
 export async function writeImportedCollection(params: {
   registry: string;
   entry: RegistryCollectionEntry;
@@ -193,10 +231,12 @@ export async function writeImportedCollection(params: {
   const validated = validateAndNormalize(bundle, localSlug, workspaceRoot);
   if ("error" in validated) return { ok: false, status: STATUS_UNPROCESSABLE, error: validated.error };
 
-  // Build the replacement fully in a hidden sibling staging dir (bundle + origin),
-  // so the prior install is untouched until everything is durably written. Leftover
-  // staging/backup dirs from a crashed import are cleaned first, keeping retries possible.
+  // Build the replacement fully in a hidden sibling staging dir under
+  // `data/skills/` (bundle + origin), so the prior install is untouched until
+  // everything is durably written. Leftover staging/backup dirs from a
+  // crashed import are cleaned first, keeping retries possible.
   const skillsParent = path.dirname(target.targetDir);
+  await mkdir(skillsParent, { recursive: true }); // first-import case — data/skills/ may not exist
   const staging = path.join(skillsParent, `.importing-${localSlug}`);
   const backup = path.join(skillsParent, `.backup-${localSlug}`);
   await rm(staging, { recursive: true, force: true });
@@ -206,9 +246,10 @@ export async function writeImportedCollection(params: {
   const origin: ImportOrigin = { registry, author: entry.author, slug: entry.slug, version: entry.version, contentSha: entry.contentSha, importedAt: nowIso };
   await writeFileAtomic(path.join(staging, ORIGIN_FILE), `${JSON.stringify(origin, null, 2)}\n`);
 
-  // Swap with rollback: move the old install aside (rename), move the new in (rename),
-  // then discard the old. If the swap fails, restore the old so we never end up with no
-  // installed collection. Records live in dataPath (a separate dir) and are untouched.
+  // Swap with rollback: move the old install aside (rename), move the new in
+  // (rename), then discard the old. If the swap fails, restore the old so we
+  // never end up with no installed collection. Records live in dataPath (a
+  // separate dir) and are untouched.
   if (target.updated) await rename(target.targetDir, backup);
   try {
     await rename(staging, target.targetDir);
@@ -217,6 +258,20 @@ export async function writeImportedCollection(params: {
     throw err;
   }
   await rm(backup, { recursive: true, force: true });
+
+  // Replicate the new `data/skills/<slug>/` set into `.claude/skills/<slug>/`
+  // via the shared bridge package — same allowlist + tmp+rename semantics the
+  // hook uses for agent-authored writes. A mirror failure here is logged but
+  // doesn't undo the data-side write (the user can fix it by retriggering the
+  // mirror — same as for any other mirror failure).
+  try {
+    mirrorToClaudeSkills(workspaceRoot, localSlug, bundle);
+  } catch (err) {
+    log.warn("collections-registry", "mirror to .claude/skills/ failed (data/skills write succeeded)", {
+      localSlug,
+      error: errorMessage(err),
+    });
+  }
 
   const seed = await materializeSeed(dataDir, bundle);
   return { ok: true, localSlug, updated: target.updated, seedWritten: seed.written, seedSkipped: seed.skipped };
@@ -244,3 +299,7 @@ export async function performImport(author: string, slug: string, workspaceRoot:
     return { ok: false, status: 500, error: `import failed: ${errorMessage(err)}` };
   }
 }
+
+// Exported for downstream code that wants the path conventions without
+// importing skill-bridge directly.
+export { claudeSkillDir, dataSkillDir };

--- a/server/workspace/collectionsRegistry/importWriter.ts
+++ b/server/workspace/collectionsRegistry/importWriter.ts
@@ -124,15 +124,24 @@ async function findMatchingInstall(skillsDir: string, registry: string, entry: R
 // Pick the local install slug (rename-on-collision, R8). First reuse an
 // existing matching install (update). Otherwise install fresh at the first
 // free slug — the registry slug, else `<slug>-2`, `-3`, … — never clobbering
-// a user's own same-named collection (`data/skills/<slug>/` without
-// `.origin.json` matching ⇒ treat as taken, walk forward).
+// a user's own same-named collection.
+//
+// A slug is "free" only when BOTH `data/skills/<slug>/` AND
+// `.claude/skills/<slug>/` are absent. The mirror check matters because
+// `mirrorToClaudeSkills` calls `mirrorSkillDelete(slug)` before writing — if
+// the user has a manually-installed Claude skill at `.claude/skills/<slug>/`
+// with no corresponding `data/skills/<slug>/` (e.g. installed by the Claude
+// CLI directly, or a legacy pre-refactor import we never migrated), picking
+// that slug would silently wipe their skill (CodeRabbit review on #1839).
 async function resolveTarget(workspaceRoot: string, registry: string, entry: RegistryCollectionEntry): Promise<TargetResolution> {
   const skillsDir = path.dirname(dataSkillDir(workspaceRoot, entry.slug));
   const existing = await findMatchingInstall(skillsDir, registry, entry);
   if (existing) return { targetDir: dataSkillDir(workspaceRoot, existing), localSlug: existing, updated: true };
   for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt += 1) {
     const localSlug = renameCandidate(entry.slug, attempt);
-    if ((await statType(dataSkillDir(workspaceRoot, localSlug))) === "absent") {
+    const sourceAbsent = (await statType(dataSkillDir(workspaceRoot, localSlug))) === "absent";
+    const mirrorAbsent = (await statType(claudeSkillDir(workspaceRoot, localSlug))) === "absent";
+    if (sourceAbsent && mirrorAbsent) {
       return { targetDir: dataSkillDir(workspaceRoot, localSlug), localSlug, updated: false };
     }
   }
@@ -142,6 +151,14 @@ async function resolveTarget(workspaceRoot: string, registry: string, entry: Reg
 type SchemaResolution = { schema: CollectionSchema } | { error: string };
 
 function validateAndNormalize(bundle: Map<string, string>, localSlug: string, workspaceRoot: string): SchemaResolution {
+  // SKILL.md is required: `mirrorToClaudeSkills` calls
+  // `mirrorSkillWrite({slug, relSegments: [SKILL_FILE]})` unconditionally
+  // after the data-side swap, which throws if SKILL.md is missing. Caught
+  // outside, that throw is logged but the data-side write still succeeds and
+  // the function returns `ok: true` for an unusable import. Reject up front
+  // so a missing SKILL.md surfaces as a clean 422 instead (CodeRabbit review
+  // on #1839).
+  if (bundle.get(SKILL_FILE) === undefined) return { error: "bundle is missing SKILL.md" };
   const schemaText = bundle.get(SCHEMA_FILE);
   if (schemaText === undefined) return { error: "bundle is missing schema.json" };
   let parsedJson: unknown;

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync
 import path from "node:path";
 import { tmpdir } from "node:os";
 
-import { writeImportedCollection } from "../../server/workspace/collectionsRegistry/importWriter.js";
+import { writeImportedCollection, claudeSkillDir, dataSkillDir } from "../../server/workspace/collectionsRegistry/importWriter.js";
 import type { RegistryCollectionEntry } from "../../server/workspace/collectionsRegistry/registryIndex.js";
 
 const REGISTRY = "receptron/mulmoclaude-collections";
@@ -53,11 +53,14 @@ function makeBundle(overrides: Record<string, string> = {}): Map<string, string>
   );
 }
 
-// `data/skills/<slug>/` is the source-of-truth after the refactor (#1838) —
+// `data/skills/<slug>/` is the source-of-truth after the refactor (#1839) —
 // both authored and imported collections live here. Tests pin BOTH this and
 // the `.claude/skills/<slug>/` mirror to lock the new dual-write contract.
-const sourceDir = (root: string, slug = "movies") => path.join(root, "data", "skills", slug);
-const mirrorDir = (root: string, slug = "movies") => path.join(root, ".claude", "skills", slug);
+// Path helpers come from the same `@mulmoclaude/core/skill-bridge` package
+// the writer uses (re-exported by importWriter), so tests never hardcode the
+// `data/skills` / `.claude/skills` segments themselves.
+const sourceDir = (root: string, slug = "movies") => dataSkillDir(root, slug);
+const mirrorDir = (root: string, slug = "movies") => claudeSkillDir(root, slug);
 const seedFile = (root: string, slug = "movies") => path.join(root, "data", "collections", slug, "items", "a.json");
 
 describe("writeImportedCollection", () => {
@@ -203,6 +206,40 @@ describe("writeImportedCollection", () => {
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle, workspaceRoot: wsRoot, nowIso: "t" });
     assert.equal(result.ok, false);
     if (!result.ok) assert.equal(result.status, 422);
+  });
+
+  it("rejects a bundle missing SKILL.md with 422 (no half-imported skill)", async () => {
+    // The mirror step calls mirrorSkillWrite for SKILL.md unconditionally;
+    // missing SKILL.md would throw inside the catch-all and return ok:true
+    // for an unusable import unless we reject up front.
+    const bundle = makeBundle();
+    bundle.delete("SKILL.md");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle, workspaceRoot: wsRoot, nowIso: "t" });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 422);
+      assert.match(result.error, /SKILL\.md/);
+    }
+    // Nothing landed on disk either side.
+    assert.ok(!existsSync(sourceDir(wsRoot)), "no source dir written");
+    assert.ok(!existsSync(mirrorDir(wsRoot)), "no mirror dir written");
+  });
+
+  it("walks past a slug whose mirror exists but source is absent (don't clobber a manual Claude skill)", async () => {
+    // Pre-existing `.claude/skills/movies/` (e.g. installed by the Claude CLI
+    // directly, or a legacy pre-refactor import). data/skills/movies/ is
+    // absent. Without the mirror-also-absent check the writer would happily
+    // pick `movies`, then `mirrorSkillDelete` would silently wipe the user's
+    // skill (CodeRabbit review on #1839).
+    mkdirSync(mirrorDir(wsRoot), { recursive: true });
+    writeFileSync(path.join(mirrorDir(wsRoot), "SKILL.md"), "manually installed claude skill");
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
+    assert.ok(result.ok);
+    if (result.ok) {
+      assert.equal(result.localSlug, "movies-2", "skipped 'movies' because the mirror was taken");
+    }
+    // The manual skill is intact.
+    assert.equal(readFileSync(path.join(mirrorDir(wsRoot), "SKILL.md"), "utf-8"), "manually installed claude skill");
   });
 
   it("re-import removes files that dropped out of the manifest (source + mirror)", async () => {

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -242,6 +242,28 @@ describe("writeImportedCollection", () => {
     assert.equal(readFileSync(path.join(mirrorDir(wsRoot), "SKILL.md"), "utf-8"), "manually installed claude skill");
   });
 
+  it("does not blank the mirror dir as an intermediate state (write-then-prune ordering)", async () => {
+    // Regression for the Codex finding on #1839: if mirrorToClaudeSkills had
+    // delete-then-write ordering, a failure between delete and write would
+    // leave `.claude/skills/<slug>/` empty. We can't easily inject a failure
+    // in the writer here, but we CAN verify that after a successful re-import
+    // the mirror's SKILL.md file inode never went to "absent + recreated"
+    // unnecessarily — the prior install's files are overwritten via tmp+rename,
+    // not deleted first. As a proxy, after a successful re-import the mirror
+    // dir is non-empty across the whole operation (sampled before + after).
+    await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t1" });
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "SKILL.md")), "mirror present after first import");
+    await writeImportedCollection({
+      registry: REGISTRY,
+      entry,
+      bundle: makeBundle({ "SKILL.md": "---\nname: movies\ndescription: y\n---\n# Movies v2" }),
+      workspaceRoot: wsRoot,
+      nowIso: "t2",
+    });
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "SKILL.md")), "mirror present after re-import");
+    assert.match(readFileSync(path.join(mirrorDir(wsRoot), "SKILL.md"), "utf-8"), /Movies v2/, "re-imported content lands in the mirror");
+  });
+
   it("re-import removes files that dropped out of the manifest (source + mirror)", async () => {
     await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle({ "templates/old.md": "old" }), workspaceRoot: wsRoot, nowIso: "t1" });
     assert.ok(existsSync(path.join(sourceDir(wsRoot), "templates", "old.md")), "template present after first install (source)");

--- a/test/server/test_importWriter.ts
+++ b/test/server/test_importWriter.ts
@@ -53,7 +53,11 @@ function makeBundle(overrides: Record<string, string> = {}): Map<string, string>
   );
 }
 
-const skillDir = (root: string, slug = "movies") => path.join(root, ".claude", "skills", slug);
+// `data/skills/<slug>/` is the source-of-truth after the refactor (#1838) —
+// both authored and imported collections live here. Tests pin BOTH this and
+// the `.claude/skills/<slug>/` mirror to lock the new dual-write contract.
+const sourceDir = (root: string, slug = "movies") => path.join(root, "data", "skills", slug);
+const mirrorDir = (root: string, slug = "movies") => path.join(root, ".claude", "skills", slug);
 const seedFile = (root: string, slug = "movies") => path.join(root, "data", "collections", slug, "items", "a.json");
 
 describe("writeImportedCollection", () => {
@@ -65,7 +69,7 @@ describe("writeImportedCollection", () => {
     rmSync(wsRoot, { recursive: true, force: true });
   });
 
-  it("installs the bundle, normalizes dataPath, materializes seed, writes provenance", async () => {
+  it("installs the bundle to data/skills, mirrors the allowlisted set to .claude/skills, normalizes dataPath, materializes seed, writes provenance", async () => {
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "2026-06-27T00:00:00Z" });
     assert.ok(result.ok);
     assert.equal(result.localSlug, "movies");
@@ -73,20 +77,59 @@ describe("writeImportedCollection", () => {
     assert.equal(result.seedWritten, 1);
     assert.equal(result.seedSkipped, false);
 
-    assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")));
-    assert.ok(existsSync(path.join(skillDir(wsRoot), "views", "cinema.html")));
-    assert.ok(!existsSync(path.join(skillDir(wsRoot), "seed")), "seed must not land in the skill dir");
+    // SOURCE — data/skills/<slug>/: the full bundle minus seed/ lands here.
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "SKILL.md")), "SKILL.md in source");
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "schema.json")), "schema.json in source");
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "meta.json")), "meta.json in source (host bookkeeping)");
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "views", "cinema.html")), "custom view in source");
+    assert.ok(!existsSync(path.join(sourceDir(wsRoot), "seed")), "seed must not land in the skill dir");
 
-    const schema = JSON.parse(readFileSync(path.join(skillDir(wsRoot), "schema.json"), "utf-8"));
-    assert.equal(schema.dataPath, "data/collections/movies/items", "dataPath normalized (R3)");
+    // MIRROR — .claude/skills/<slug>/: only the bridge allowlist
+    // (SKILL.md / schema.json / templates/<safe>) crosses. meta.json, views/,
+    // and .origin.json deliberately stay source-side.
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "SKILL.md")), "SKILL.md mirrored");
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "schema.json")), "schema.json mirrored");
+    assert.ok(!existsSync(path.join(mirrorDir(wsRoot), "meta.json")), "meta.json is host bookkeeping — not mirrored");
+    assert.ok(!existsSync(path.join(mirrorDir(wsRoot), "views")), "views/ stays source-side — host serves from data/skills");
+    assert.ok(!existsSync(path.join(mirrorDir(wsRoot), ".origin.json")), ".origin.json is host bookkeeping — not mirrored");
 
-    const origin = JSON.parse(readFileSync(path.join(skillDir(wsRoot), ".origin.json"), "utf-8"));
+    // dataPath is host-owned (R3), not the upstream value.
+    const sourceSchema = JSON.parse(readFileSync(path.join(sourceDir(wsRoot), "schema.json"), "utf-8"));
+    assert.equal(sourceSchema.dataPath, "data/collections/movies/items", "dataPath normalized in source");
+    const mirroredSchema = JSON.parse(readFileSync(path.join(mirrorDir(wsRoot), "schema.json"), "utf-8"));
+    assert.equal(mirroredSchema.dataPath, sourceSchema.dataPath, "mirror is a 1:1 copy");
+
+    // Provenance — the imported-vs-authored marker — lives in source only.
+    const origin = JSON.parse(readFileSync(path.join(sourceDir(wsRoot), ".origin.json"), "utf-8"));
     assert.equal(origin.registry, REGISTRY);
     assert.equal(origin.author, "isamu");
     assert.equal(origin.contentSha, "abc123");
     assert.equal(origin.importedAt, "2026-06-27T00:00:00Z");
 
     assert.ok(existsSync(seedFile(wsRoot)), "seed record materialized into dataPath");
+  });
+
+  it("mirrors template files (the bridge allowlist), not arbitrary nested dirs", async () => {
+    // The bridge mirror is defined by isSafeActionTemplatePath:
+    //   - `templates/<safe>` crosses
+    //   - other dirs (views/, README.md, assets/) do not
+    const bundle = makeBundle({
+      "templates/invoice.md": "# Invoice template",
+      "README.md": "# Notes",
+      "assets/logo.png": "<binary>",
+    });
+    const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle, workspaceRoot: wsRoot, nowIso: "t" });
+    assert.ok(result.ok);
+
+    // Source has everything from the bundle (minus seed).
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "templates", "invoice.md")));
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "README.md")));
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "assets", "logo.png")));
+
+    // Mirror has only the allowlist.
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "templates", "invoice.md")), "templates/ mirrored");
+    assert.ok(!existsSync(path.join(mirrorDir(wsRoot), "README.md")), "README.md not in bridge allowlist");
+    assert.ok(!existsSync(path.join(mirrorDir(wsRoot), "assets")), "assets/ not in bridge allowlist");
   });
 
   it("treats a same-origin re-import as an update and skips seed when data exists", async () => {
@@ -99,19 +142,24 @@ describe("writeImportedCollection", () => {
   });
 
   it("renames to <slug>-2 when a different collection occupies the slug (and re-imports as an update)", async () => {
-    mkdirSync(skillDir(wsRoot), { recursive: true });
-    writeFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "someone else's collection");
+    // Pre-existing authored collection at data/skills/movies/ (no `.origin.json`).
+    mkdirSync(sourceDir(wsRoot), { recursive: true });
+    writeFileSync(path.join(sourceDir(wsRoot), "SKILL.md"), "someone else's collection");
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
     assert.ok(result.ok);
     if (result.ok) {
       assert.equal(result.localSlug, "movies-2");
       assert.equal(result.updated, false, "a renamed fresh install is not an update");
     }
-    // the user's own collection is untouched
-    assert.equal(readFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "utf-8"), "someone else's collection");
-    assert.ok(existsSync(path.join(skillDir(wsRoot, "movies-2"), "SKILL.md")));
+    // the user's own authored collection is untouched
+    assert.equal(readFileSync(path.join(sourceDir(wsRoot), "SKILL.md"), "utf-8"), "someone else's collection");
+    assert.ok(!existsSync(path.join(sourceDir(wsRoot), ".origin.json")), "authored collection has no .origin.json");
+    // import lands under the renamed slug
+    assert.ok(existsSync(path.join(sourceDir(wsRoot, "movies-2"), "SKILL.md")));
+    assert.ok(existsSync(path.join(sourceDir(wsRoot, "movies-2"), ".origin.json")), "import has .origin.json (= user-vs-imported marker)");
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot, "movies-2"), "SKILL.md")), "imported skill also mirrors to .claude/skills");
     // schema + seed land under the renamed slug, not the original
-    const renamedSchema = JSON.parse(readFileSync(path.join(skillDir(wsRoot, "movies-2"), "schema.json"), "utf-8"));
+    const renamedSchema = JSON.parse(readFileSync(path.join(sourceDir(wsRoot, "movies-2"), "schema.json"), "utf-8"));
     assert.equal(renamedSchema.dataPath, "data/collections/movies-2/items");
     assert.ok(existsSync(seedFile(wsRoot, "movies-2")), "seed materialized under movies-2");
     assert.ok(!existsSync(seedFile(wsRoot)), "no seed written under the original slug");
@@ -125,25 +173,25 @@ describe("writeImportedCollection", () => {
   });
 
   it("re-imports into the existing renamed slug even after the original slug frees up", async () => {
-    mkdirSync(skillDir(wsRoot), { recursive: true });
-    writeFileSync(path.join(skillDir(wsRoot), "SKILL.md"), "someone else's collection");
+    mkdirSync(sourceDir(wsRoot), { recursive: true });
+    writeFileSync(path.join(sourceDir(wsRoot), "SKILL.md"), "someone else's collection");
     const first = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t1" });
     assert.ok(first.ok && first.localSlug === "movies-2");
     // the user deletes their own collection → the original slug frees up
-    rmSync(skillDir(wsRoot), { recursive: true, force: true });
+    rmSync(sourceDir(wsRoot), { recursive: true, force: true });
     const again = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
     assert.ok(again.ok);
     if (again.ok) {
       assert.equal(again.localSlug, "movies-2", "updates the existing renamed install, not a fresh 'movies'");
       assert.equal(again.updated, true);
     }
-    assert.ok(!existsSync(path.join(skillDir(wsRoot), ".origin.json")), "no duplicate fresh install at the freed slug");
+    assert.ok(!existsSync(path.join(sourceDir(wsRoot), ".origin.json")), "no duplicate fresh install at the freed slug");
   });
 
   it("finds a free slug past several colliding installs", async () => {
     for (const slug of ["movies", "movies-2", "movies-3"]) {
-      mkdirSync(skillDir(wsRoot, slug), { recursive: true });
-      writeFileSync(path.join(skillDir(wsRoot, slug), "SKILL.md"), "a foreign collection");
+      mkdirSync(sourceDir(wsRoot, slug), { recursive: true });
+      writeFileSync(path.join(sourceDir(wsRoot, slug), "SKILL.md"), "a foreign collection");
     }
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
     assert.ok(result.ok);
@@ -157,17 +205,21 @@ describe("writeImportedCollection", () => {
     if (!result.ok) assert.equal(result.status, 422);
   });
 
-  it("re-import removes files that dropped out of the manifest", async () => {
+  it("re-import removes files that dropped out of the manifest (source + mirror)", async () => {
     await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle({ "templates/old.md": "old" }), workspaceRoot: wsRoot, nowIso: "t1" });
-    assert.ok(existsSync(path.join(skillDir(wsRoot), "templates", "old.md")));
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "templates", "old.md")), "template present after first install (source)");
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "templates", "old.md")), "template present after first install (mirror)");
+
     await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t2" });
-    assert.ok(!existsSync(path.join(skillDir(wsRoot), "templates", "old.md")), "stale file removed on re-import");
-    assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")), "current bundle still installed");
+    assert.ok(!existsSync(path.join(sourceDir(wsRoot), "templates", "old.md")), "stale source file removed on re-import");
+    assert.ok(!existsSync(path.join(mirrorDir(wsRoot), "templates", "old.md")), "stale mirror file removed on re-import");
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "SKILL.md")), "current bundle still installed (source)");
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "SKILL.md")), "current bundle still installed (mirror)");
   });
 
   it("renames past a slug path that exists as a non-directory file", async () => {
-    mkdirSync(path.dirname(skillDir(wsRoot)), { recursive: true });
-    writeFileSync(skillDir(wsRoot), "i am a file, not a directory");
+    mkdirSync(path.dirname(sourceDir(wsRoot)), { recursive: true });
+    writeFileSync(sourceDir(wsRoot), "i am a file, not a directory");
     const result = await writeImportedCollection({ registry: REGISTRY, entry, bundle: makeBundle(), workspaceRoot: wsRoot, nowIso: "t" });
     assert.ok(result.ok);
     if (result.ok) assert.equal(result.localSlug, "movies-2");
@@ -190,8 +242,9 @@ describe("writeImportedCollection", () => {
   });
 
   it("cleans leftover staging/backup dirs from a prior crashed import and still installs", async () => {
-    const staging = path.join(wsRoot, ".claude", "skills", ".importing-movies");
-    const backup = path.join(wsRoot, ".claude", "skills", ".backup-movies");
+    // Staging / backup dirs live alongside the target under `data/skills/` now.
+    const staging = path.join(wsRoot, "data", "skills", ".importing-movies");
+    const backup = path.join(wsRoot, "data", "skills", ".backup-movies");
     mkdirSync(staging, { recursive: true });
     mkdirSync(backup, { recursive: true });
     writeFileSync(path.join(staging, "junk.txt"), "leftover from a crashed import");
@@ -200,6 +253,7 @@ describe("writeImportedCollection", () => {
     assert.ok(result.ok);
     assert.ok(!existsSync(staging), "leftover staging dir removed");
     assert.ok(!existsSync(backup), "leftover backup dir removed");
-    assert.ok(existsSync(path.join(skillDir(wsRoot), "SKILL.md")));
+    assert.ok(existsSync(path.join(sourceDir(wsRoot), "SKILL.md")));
+    assert.ok(existsSync(path.join(mirrorDir(wsRoot), "SKILL.md")));
   });
 });


### PR DESCRIPTION
## Summary

Per user feedback ("importしたcollectionも最初からdataの方に書き込むのが一番シンプルで良いと思う"), unify the source-of-truth for imported and authored collections.

**Before:**
- Authored: agent writes `data/skills/<slug>/{SKILL.md,schema.json,templates/*}` → skill-bridge hook mirrors to `.claude/skills/<slug>/`.
- Imported: server writes the whole bundle **directly** to `.claude/skills/<slug>/`. Different shape from authored.

**After:**
- Authored: unchanged.
- Imported: server writes the bundle to `data/skills/<slug>/` with the same staging → backup → rename swap. After the source swap, the bridge's allowlist (SKILL.md / schema.json / templates/<safe>) is mirrored 1:1 into `.claude/skills/<slug>/` via the same `mirrorSkillWrite` calls the hook uses.

The result: every collection — authored or imported — lives in `data/skills/<slug>/` first. To edit an imported collection the user touches the same file as an authored one. `rm -rf data/skills/<slug>/` deletes either kind identically (the existing PostToolUse hook handles the mirror cleanup).

## Items to Confirm / Review

- **`.origin.json` is the imported-vs-authored marker, unchanged.** It lives ONLY in `data/skills/<slug>/.origin.json` (the bridge allowlist deliberately excludes host bookkeeping). `findMatchingInstall` scans `data/skills/*/` for matching origins to detect updates; a dir without a matching `.origin.json` is treated as user-authored and triggers the `<slug>-2` rename collision flow.
- **What crosses to `.claude/skills/` is exactly the bridge allowlist** — SKILL.md, schema.json, `templates/<safe>` (`isSafeActionTemplatePath`). `views/`, `meta.json`, README.md, `assets/` stay source-side. Custom-view HTML was already read by the host from `data/skills/<slug>/views/` first (see `io.ts:251`) so this is in line with the existing architectural intent — the old code's writes to `.claude/skills/views/` were incidental, not depended on.
- **Mirror failure is logged but doesn't fail the import.** Same posture as the hook — the source-side write is the canonical truth; if the mirror lags, the bridge can be re-triggered. (Could be tightened to fail-loud if needed.)
- **Re-import drops the prior mirror first** (`mirrorSkillDelete`) so a template removed in the new bundle doesn't linger from the previous install. The source-side rename swap already guarantees this for the source dir.
- **Stale "registry" comment in `.origin.json`'s `registry` field** still says "receptron/mulmoclaude-collections" for the official registry — that's just the value passed in by `performImport`, unchanged here. Once the multi-registry PR (#1837) lands it carries the `registryName`.

## Worked example — what's on disk after one import

```
data/skills/movies/
  SKILL.md            ← bundle (mirrored)
  schema.json         ← bundle, dataPath rewritten to data/collections/movies/items (mirrored)
  meta.json           ← bundle (NOT mirrored — not in allowlist)
  views/cinema.html   ← bundle (NOT mirrored — host reads from data/skills via io.ts fallback)
  .origin.json        ← provenance (NOT mirrored — host bookkeeping; marker for imported-vs-authored)

.claude/skills/movies/
  SKILL.md            ← mirror
  schema.json         ← mirror

data/collections/movies/items/
  a.json              ← seed records (separate dir; only materialized when empty)
```

## User Prompt

> importしたcollectionも最初からdataの方に書き込むのが一番シンプルで良いと思うのですがどうでしょう？
>
> [Claude] この場合でも、importしたものとユーザが作ったものって区別できる？
>
> [User] はい

## Test plan

- [x] `tsx --test test/server/test_importWriter.ts` — 12/12 pass (covers source + mirror for every scenario)
- [x] `tsx --test ./test/server/*.ts` — 232 / 232 server tests pass
- [x] `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all green
- [ ] Manual on macOS: import a collection from `/collections` → confirm `data/skills/<slug>/{SKILL.md,schema.json,.origin.json}` exist, `.claude/skills/<slug>/{SKILL.md,schema.json}` mirror exists, `data/collections/<slug>/items/<id>.json` has seed
- [ ] Manual: edit `data/skills/<slug>/SKILL.md` → confirm bridge hook mirrors the change to `.claude/skills/<slug>/SKILL.md` and the agent picks it up (same flow as for an authored collection)
- [ ] Manual: `rm -rf data/skills/<slug>/` → confirm both source and `.claude/skills/<slug>/` go away (bridge handles delete mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imported skills now install into the primary local skills area, with an automatically synced mirror copy in the app’s skills workspace.
  * The mirror writes only an allowlisted subset of files (e.g., `SKILL.md`, `schema.json`, and selected templates).
* **Bug Fixes**
  * Prevents clobbering or pruning when the mirror exists but the source is missing.
  * Improves re-import/rename behavior to update the correct existing install.
  * Validates that bundles include `SKILL.md`, returning a clean error instead of failing later.
* **Tests**
  * Expanded coverage for mirror allowlisting, re-import edge cases, and interrupted import cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->