### PR TITLE
docs(system-prompt): teach the agent to consult docs/ on tool errors

### DIFF
--- a/server/prompts/system/system.md
+++ b/server/prompts/system/system.md
@@ -94,3 +94,20 @@ System tasks (journal, chat-index) have default schedules. Users can override th
 
 When the user asks to change a system task's frequency, use the WebFetch tool to PUT to `/api/config/scheduler-overrides` with `{ "overrides": { "system:journal": { "intervalMs": <ms> } } }`. This saves the config and applies the change immediately without a server restart.
 
+## Error troubleshooting via docs/
+
+When a tool call fails (Bash gh/git, sandbox credential errors, etc.), before asking the user a clarifying question or giving up, look up the relevant doc under `docs/` and walk the user through the documented fix in plain language. Cite the doc path you consulted so the user can follow up later.
+
+Common error-area → doc mapping:
+
+- `gh auth` / `git push` refused / SSH key not forwarded / "Could not resolve host" inside the sandbox → `docs/sandbox-credentials.md`
+- Marp slide PDF empty / image / font issues → `docs/marp-themes.md`
+- Collection registry import / Discover / Contribute failure → `docs/collection-registries.md`
+- Bridge / messaging adapter errors → `docs/mulmobridge-guide.md`
+- Build / yarn workspace ordering / "Cannot find module @mulmoclaude/*" → `docs/build-orchestration.md`
+- Lint / type / format → `docs/lint-policy.md`
+- Plugin runtime install / drift → `docs/plugin-runtime.md`
+- E2E test setup → `docs/e2e-live-testing.md`
+
+For anything else: `ls docs/` first, pick the file whose name best matches the failing area, then Read it. If no matching doc exists, surface the raw error to the user and say "no documented fix found — falling back to asking you" rather than silently guessing.
+


### PR DESCRIPTION
## Summary

When a tool call fails (gh / git / sandbox credentials / Marp / etc.) the agent today either surfaces the raw error and asks the user a clarifying question, or guesses at a fix. The official `docs/` directory already has the documented resolution for most common failure areas — we just weren't pointing the agent at them.

Add a single **"Error troubleshooting via docs/"** section to `server/prompts/system/system.md` with a short error-area → doc mapping and a fallback rule (`ls docs/`, pick the closest match). The instruction: read the doc, walk the user through the documented fix in plain language, and cite the doc path so the user can follow up.

## User Prompt

> collectionのcontributeでgithubのgit処理でエラーになったときなど https://github.com/receptron/mulmoclaude/blob/main/docs/sandbox-credentials.md を参考にヘルプを出してほしい。他も、エラー時にはできる限りそれをユーザにllmが解説してほしいけど、そういう仕組簡単にできる？できる限りdocs以下の公式情報を使ってサポートしてほしい

## Items to Confirm / Review (please decide @snakajima)

1. **Right level of generality?** The system-prompt approach is global — applies to every chat, every error. Alternative would be per-feature (e.g. enrich the Contribute prompt with a git/sandbox-credentials hint, repeat for each feature). System-prompt is one place to update and naturally extensible as new docs land; per-feature is more targeted but requires editing every feature's seed prompt + i18n.
2. **The doc mapping list.** I picked 8 areas based on the docs/ layout. Acceptable additions / removals / different mappings?
   - `gh auth` / `git push` / SSH key forward / "Could not resolve host" → `docs/sandbox-credentials.md`
   - Marp PDF empty / image / font → `docs/marp-themes.md`
   - Collection registry import / Discover / Contribute → `docs/collection-registries.md`
   - Bridge / messaging adapter → `docs/mulmobridge-guide.md`
   - Build / yarn workspace ordering / "Cannot find module @mulmoclaude/*" → `docs/build-orchestration.md`
   - Lint / type / format → `docs/lint-policy.md`
   - Plugin runtime install / drift → `docs/plugin-runtime.md`
   - E2E test setup → `docs/e2e-live-testing.md`
3. **Fallback behavior.** If no mapping fits, the agent is told to (a) `ls docs/`, (b) pick the closest match, (c) Read it. If nothing matches, surface the raw error to the user. Acceptable, or too cautious / too aggressive?
4. **Context cost.** The section is ~17 lines, ~700 tokens — adds a small but real per-turn baseline to every session. Worth it for the better diagnostic UX? Or should we make this opt-in (only inject when the previous turn had a tool error)?
5. **Per-feature seed prompts.** Should the Contribute prompt also be updated to reference `docs/sandbox-credentials.md` proactively (so the agent reads it BEFORE attempting the git push, not just on failure)? That's an i18n-lockstep change for 8 locales + a `@mulmoclaude/collection-plugin` version bump — happy to do it as a follow-up if you'd like.

## Implementation

```diff
+## Error troubleshooting via docs/
+
+When a tool call fails (Bash gh/git, sandbox credential errors, etc.), before asking the user a clarifying question or giving up, look up the relevant doc under `docs/` and walk the user through the documented fix in plain language. Cite the doc path you consulted so the user can follow up later.
+
+Common error-area → doc mapping:
+
+- `gh auth` / `git push` refused / SSH key not forwarded / "Could not resolve host" inside the sandbox → `docs/sandbox-credentials.md`
+- Marp slide PDF empty / image / font issues → `docs/marp-themes.md`
+- ...
+
+For anything else: `ls docs/` first, pick the file whose name best matches the failing area, then Read it. If no matching doc exists, surface the raw error to the user and say "no documented fix found — falling back to asking you" rather than silently guessing.
```

No public surface changes — server-internal prompt only; no `@mulmoclaude/*` version bump required.

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck:server` all green
- [ ] Manual: trigger the Contribute flow on a workspace without `~/.ssh/config` / `gh auth` set up → confirm the agent reads `docs/sandbox-credentials.md` and walks the user through the SSH agent forward + allowlisted config mount steps before retrying `git push`
- [ ] Manual: trigger a Marp PDF export error (e.g. invalid theme name) → confirm the agent reads `docs/marp-themes.md` and points the user at the troubleshooting section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guided troubleshooting for tool-call failures using the most relevant documentation.
  - Expanded coverage for common error types, including auth/SSH, PDF generation, registry/import, messaging, build, lint/format, plugin runtime, and E2E setup issues.
  - When no exact match exists, the assistant now looks for the best-fit doc and reports the raw error if no documented fix is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->