### PR TITLE
feat: error-recovery help; agent reads it on tool failure (re-do of #1844 per @snakajima)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ NEVER use raw `fs.readFile` / `fs.writeFile` in route handlers. Use `server/util
 
 NEVER escape backticks with `\`` in `gh` commands. Use single-quoted heredoc (`<<'EOF'`).
 
+### Error-recovery know-how — keep `error-recovery.md` in sync
+
+When you (or a PR you're reviewing) adds a new diagnostic / fix for a recurring failure mode — sandbox auth, build ordering, plugin install, anything the agent might hit at runtime — also add a section (or extend an existing one) in [`packages/core/assets/helps/error-recovery.md`](packages/core/assets/helps/error-recovery.md). The agent reads that file BEFORE asking the user a clarifying question on a tool failure (see the "When a tool call fails" section in `server/prompts/system/system.md`), so know-how that lives only in a PR description / commit message / `docs/` is invisible to it. Bump `@mulmoclaude/core` whenever `assets/helps/*` changes (it ships to npm via `files: ["dist", "assets"]`).
+
 ### Edit-time deeper rules (read when relevant)
 
 - **Lint warnings + `eslint-disable` etiquette** → [`docs/lint-policy.md`](docs/lint-policy.md)

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -1,0 +1,179 @@
+# Error recovery — when a tool call fails
+
+This is the lookup the agent reads BEFORE asking the user a clarifying
+question or giving up on a failing tool call. Each section is keyed by
+the error message you'd see in tool output, with the cause and the
+documented fix.
+
+Cite the section you used in your reply so the user can follow up
+(e.g. "Per `config/helps/error-recovery.md` § gh-auth / SSH …").
+
+If no section here matches, list the workspace's other help files
+(`ls config/helps/`) and Read whichever name best matches the failing
+area (`sandbox.md`, `github.md`, `collection-skills.md`, etc.) before
+falling back to asking the user.
+
+## gh / git / SSH errors inside the sandbox
+
+### Symptoms
+
+- `gh: To authenticate, please run gh auth login`
+- `git@github.com: Permission denied (publickey)`
+- `Could not resolve host: github.com`
+- `Permission denied (publickey)` on `git push` / `git clone <ssh-url>`
+- `fatal: Could not read from remote repository`
+
+### Cause
+
+The Claude Code agent runs inside a credential-free Docker sandbox by
+default. The host's SSH agent and `gh` config aren't exposed unless the
+user opts them in.
+
+### Fix
+
+Tell the user to enable the two opt-in mounts on the next agent spawn
+(see also `config/helps/sandbox.md` for the full contract):
+
+```bash
+# Forward the host's SSH agent into the container.
+# Private keys stay on the host; only the signing oracle is exposed.
+SANDBOX_FORWARD_SSH_AGENT=1 \
+# Mount allowlisted config files/dirs read-only — including ~/.config/gh.
+SANDBOX_MOUNT_CONFIGS=gh \
+  yarn dev   # or: npx mulmoclaude
+```
+
+Equivalent CLI flags: `--sandbox-forward-ssh-agent --sandbox-mount-configs=gh`.
+
+After restart, inside the agent's first tool turn verify:
+
+```bash
+ssh-add -l                      # should list at least one key
+gh auth status                  # should report logged in
+```
+
+If `ssh-add -l` fails, the host's SSH agent isn't running — tell the
+user to start it (`ssh-add ~/.ssh/id_*` on macOS / Linux). If
+`gh auth status` fails, the user needs to run `gh auth login` on the
+host first (host config is mounted read-only into the sandbox).
+
+### When neither helps
+
+The sandbox itself can be turned off for the session with
+`DISABLE_SANDBOX=1 yarn dev` / `--disable-sandbox`. The agent then
+inherits the user's full environment. Recommend this only when the
+credential mount approach didn't resolve the issue — the sandbox is
+the safer default.
+
+## Collection registry — Contribute / Discover failures
+
+### Symptoms
+
+- Contribute flow: `gh pr create` fails, `git push` rejected, or the
+  registry clone fails inside `github/`.
+- Discover tab loads no entries, or one registry's cards are missing.
+
+### Cause + fix
+
+For the Contribute side, the underlying issue is almost always
+sandbox credentials — see the gh/git/SSH section above before anything
+else.
+
+For Discover, multi-registry config lives at
+`config/collections-registries.json`. A malformed entry there is
+silently dropped; check the server log for
+`[collections-registry] registry config entry rejected`. The file
+format and validation rules are documented in
+`config/helps/collection-skills.md` (Contribute bundle layout) and the
+shipped registry repo's README. Common rejections:
+
+- URL not HTTPS, or includes embedded credentials.
+- `rawBaseUrl` contains a `?` query or `#` fragment.
+- `name` reuses the reserved value `official`.
+- `name` doesn't match `[A-Za-z0-9][A-Za-z0-9_-]{0,31}`.
+
+## Marp slide PDF — empty / image / font issues
+
+### Symptoms
+
+- PDF export of a Marp deck produces tofu (□□□) for Japanese / CJK text.
+- Inline images in a slide are missing from the PDF.
+- A custom Marp `theme: <name>` is ignored.
+
+### Fix
+
+CJK fonts (Hiragino on macOS, Yu Gothic / Meiryo on Windows, Noto Sans
+CJK on Linux) need to exist on the **host running the server**, not
+in the sandbox (PDF render happens server-side via puppeteer). On
+Linux: `sudo apt-get install fonts-noto-cjk`. Docker host:
+`apt-get install -y fonts-noto-cjk` in the production Dockerfile.
+
+Inline images missing from the PDF: paths must be relative to the
+`.md` file, NOT absolute or workspace-rooted. See the "Image
+references in markdown / HTML" section of the system prompt for the
+rule.
+
+Custom theme ignored: themes live in `~/mulmoclaude/config/marp-themes/<name>.css`.
+The filename (sans `.css`) is the theme slug; only `[A-Za-z0-9_-]` is
+allowed. Reload the browser tab after adding a theme — preview caches
+per session.
+
+## Build / yarn workspace ordering
+
+### Symptoms
+
+- `yarn dev` fails on a fresh clone with
+  `Cannot find module '@mulmoclaude/<x>-plugin/server'` or similar.
+- A workspace package's `dist/` is missing on first run.
+
+### Fix
+
+```bash
+yarn build:packages   # builds every shared workspace package in tier order
+yarn dev              # then the dev server picks them up
+```
+
+If a specific package keeps failing, build just it:
+`yarn workspace @mulmoclaude/<name> run build`. The build pipeline
+runs plugins before services so cross-package imports resolve cold.
+
+## Plugin runtime — install / drift
+
+### Symptoms
+
+- A runtime plugin shown in `/skills` doesn't load, or its routes 404.
+- After upgrading the plugin host, a previously-installed plugin
+  reports a peer-dependency mismatch (e.g. `gui-chat-protocol`
+  version skew).
+
+### Fix
+
+Runtime plugins are installed via tgz under `~/mulmoclaude/plugins/`
+with a ledger at `plugins/plugins.json`. Reinstall the failing
+plugin via the `/skills` UI to refresh both the tgz and the ledger.
+A version skew on a peer dep means the plugin was built against an
+older host — bump the plugin via the Discover tab's update flow.
+
+## Fallback
+
+If none of the above matches the failing tool output:
+
+1. `ls config/helps/` to see every shipped help file.
+2. Pick the file whose name most closely matches the failing area
+   (`sandbox.md`, `github.md`, `feeds.md`, `presentation-deck.md`,
+   `mulmoscript.md`, `spreadsheet.md`, etc.) and Read it.
+3. If you find a fix there, apply it and cite the help by path in
+   your reply.
+4. If nothing fits, surface the raw error to the user and say
+   "no documented fix found in `config/helps/` — could you share more
+   context so we can resolve this together?" rather than silently
+   guessing or retrying the same command.
+
+## When you discover a new common error
+
+If you resolve a new class of error that other users are likely to
+hit, suggest to the user that we extend this file. Don't edit it
+yourself — additions to `config/helps/error-recovery.md` are managed
+by the project maintainers so the canonical copy in
+`packages/core/assets/helps/error-recovery.md` and the installed copy
+stay in sync.

--- a/packages/core/assets/helps/index.md
+++ b/packages/core/assets/helps/index.md
@@ -63,6 +63,7 @@ See [Wiki](config/helps/wiki.md) for details on how it works.
 - [Spreadsheet](config/helps/spreadsheet.md) — cell format, formulas, date handling, and format codes for the presentSpreadsheet plugin
 - [presentHtml](config/helps/presenthtml.md) — self-contained HTML rules and the three-`../` relative-path convention used by the presentHtml plugin to keep generated files portable under `file://`
 - [Sandbox](config/helps/sandbox.md) — how the Docker sandbox isolates the agent, what it can access, and how to disable it
+- [Error recovery](config/helps/error-recovery.md) — the lookup the agent reads on tool failures (gh/git/SSH inside the sandbox, Marp PDF, registry import, build/workspace, plugin runtime) before asking the user
 - [Telegram Bridge](config/helps/telegram.md) — how to talk to MulmoClaude from the Telegram app: creating a bot, starting the bridge, allowlisting chat IDs, commands, and troubleshooting
 - [Feeds](config/helps/feeds.md) — register a self-refreshing data feed (RSS/Atom/JSON) by authoring `feeds/<slug>/schema.json`: schema shape, the `ingest` block, raw-item field mapping, and `maxItems` retention
 - [GitHub repositories in the workspace](config/helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client and ./workspace-setup/slug entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/server/prompts/system/system.md
+++ b/server/prompts/system/system.md
@@ -94,3 +94,7 @@ System tasks (journal, chat-index) have default schedules. Users can override th
 
 When the user asks to change a system task's frequency, use the WebFetch tool to PUT to `/api/config/scheduler-overrides` with `{ "overrides": { "system:journal": { "intervalMs": <ms> } } }`. This saves the config and applies the change immediately without a server restart.
 
+## When a tool call fails
+
+Read `config/helps/error-recovery.md` BEFORE asking the user a clarifying question or giving up — it indexes the documented fix for the common failure areas (gh / git / SSH in the sandbox, Marp PDF, registry import, build/workspace, plugin runtime, etc.) and points at the per-area helps for anything else.
+


### PR DESCRIPTION
## Summary

Replaces #1844 (closed). Per @snakajima feedback there:

> ソースコードのdocsは別の理由で変更したりするので、ちょっと変ですね。専用のヘルプファイルを作って、他のヘルプファイルを一緒にしまっておき、それを参照するのが良いかも。システムプロンプトが長くなるのもちょっと気になります。 / たしかに。さらにnpmで配布するとdocsがないはずなので、これはだめですね。 / helpファイル一式は、packages/core/assets/helps にあります。

So this PR:

- **Adds `packages/core/assets/helps/error-recovery.md`** — a dedicated help file that sits alongside the existing helps (`sandbox.md`, `github.md`, `collection-skills.md`, …) and gets installed into the workspace's `config/helps/` by the workspace-setup. The sandboxed agent CAN read `config/helps/*` (it can't reach the project's `docs/`), and npm-distributed `mulmoclaude` ships these helps via `@mulmoclaude/core`'s `files: ["dist", "assets"]`.
- **Two-sentence system-prompt addition** pointing the agent at that one help file. No per-feature seed prompts touched, no i18n changes.
- **Bumps `@mulmoclaude/core` 0.2.11 → 0.2.12** (assets/ change ships to npm consumers).

## Items to Confirm / Review (please decide @snakajima)

1. **File name + location.** `packages/core/assets/helps/error-recovery.md` — sits alphabetically with the other helps. Acceptable, or prefer e.g. `troubleshooting.md`?
2. **Section coverage.** Five concrete sections (gh/git/SSH in sandbox, Collection Contribute/Discover, Marp PDF, build/workspace, plugin runtime) plus a fallback that tells the agent to `ls config/helps/` and pick the closest match. Right scope, or should I trim / add?
3. **"Cite the help path in your reply"** — added so the user can follow up later. Cluttering, or useful?
4. **"New common errors should be added to this file rather than the system prompt"** — explicit project convention so the system prompt doesn't grow over time. Buy in?
5. **Last section "When you discover a new common error"** tells the agent NOT to self-edit the help file. Should it instead be allowed to propose an edit via the chat / a draft PR?

## Implementation

```diff
# packages/core/assets/helps/error-recovery.md  (new, ~180 lines)
+ # Error recovery — when a tool call fails
+ ...
+ ## gh / git / SSH errors inside the sandbox
+ ...
+ ## Collection registry — Contribute / Discover failures
+ ...
+ ## Marp slide PDF — empty / image / font issues
+ ...
+ ## Build / yarn workspace ordering
+ ...
+ ## Plugin runtime — install / drift
+ ...
+ ## Fallback (ls config/helps/, pick closest match)
+ ## When you discover a new common error
```

```diff
# server/prompts/system/system.md
+ ## When a tool call fails
+
+ Read `config/helps/error-recovery.md` BEFORE asking the user a clarifying question
+ or giving up — it indexes the documented fix for the common failure areas (gh / git
+ / SSH in the sandbox, Marp PDF, registry import, build/workspace, plugin runtime,
+ etc.) and points at the per-area helps for anything else.
```

```diff
# packages/core/package.json
- "version": "0.2.11",
+ "version": "0.2.12",
```

## Test plan

- [x] `yarn format` / `yarn lint` / `yarn typecheck:server` all green
- [x] `node scripts/check-shared-pkg-bumps.mjs` passes (core bumped)
- [ ] Manual: open a fresh sandbox without `gh auth` set up → trigger Contribute → confirm the agent reads `config/helps/error-recovery.md`, points at the gh/git/SSH section, and walks the user through the `SANDBOX_FORWARD_SSH_AGENT=1 SANDBOX_MOUNT_CONFIGS=gh` flags before retrying
- [ ] Manual: trigger a Marp PDF export with Japanese in a deck → confirm the agent points at the Marp section and the CJK font install hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new troubleshooting guide for common tool-call failures, including recovery steps for credential, export, build, and runtime issues.
  * Expanded guidance so failed tool calls are handled with clearer next steps and references to relevant help content.

* **Chores**
  * Updated the package version to **0.2.12**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->