### PR TITLE
release: mulmoclaude@0.9.1

### DIFF
--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -115,7 +115,7 @@ ${cliFlagHelpLines()}
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.9.0");
+  console.log("mulmoclaude 0.9.1");
   process.exit(0);
 }
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release of the npm launcher: bumps `mulmoclaude` 0.9.0 → 0.9.1 (both `package.json` and the `bin/mulmoclaude.js` version string per `/publish-mulmoclaude` §5).

Already **published to npm** (`npx mulmoclaude@0.9.1 --version` returns "mulmoclaude 0.9.1"). This PR carries the version-bump commit so the branch's source matches what was published.

## What's bundled since 0.9.0

| PR | Change |
|---|---|
| #1837 | Multi-registry Discover — additional registries via `~/mulmoclaude/config/collections-registries.json` |
| #1839 | Import writes to `data/skills/` (unifies with authoring) |
| #1841 | Fix delete of imported collections whose dataPath is `data/collections/<slug>/` |
| #1842 | Custom-view i18n |
| #1845 | Collections Contribute fork flow |
| #1846 | `error-recovery.md` help + system-prompt rule "read it on tool failure" |
| cascade | `@mulmoclaude/core` 0.2.7 → 0.2.12, `collection-plugin` 0.5.11 → 0.5.16, initial publishes for `bookmarks-plugin` / `debug-plugin` / `recipe-book-plugin` |

## /publish-mulmoclaude smoke (all green locally before publishing)

- §1 deps audit (`scripts/mulmoclaude/deps.mjs`): `OK — no missing dependencies`
- §2 drift check (`scripts/mulmoclaude/drift.mjs`): `OK — no workspace drift detected` (all 3 `@mulmobridge/*` checked)
- §4 tarball boot (`scripts/mulmoclaude/tarball.mjs`): `OK — HTTP 200 on port 56118 after 9 attempt(s) (4033ms); runtime plugins=0`

Plus: latest `MulmoClaude publish smoke` workflow run on main is green.

## Test plan

- [x] `npx mulmoclaude@0.9.1 --version` → "mulmoclaude 0.9.1"
- [x] `/publish-mulmoclaude` §1 / §2 / §4 all OK
- [ ] Manual: `npx mulmoclaude@0.9.1` boots, opens http://localhost:3001, agent reads `config/helps/error-recovery.md` on a forced tool failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI and package version to **0.9.1**.
  * The `--version` output now reflects the new release number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->