### PR TITLE
docs(mulmoclaude): refresh npm-shown README + add skill verify-step

### DIFF
--- a/.claude/skills/publish-mulmoclaude/SKILL.md
+++ b/.claude/skills/publish-mulmoclaude/SKILL.md
@@ -77,6 +77,28 @@ yarn install         # picks up any new deps from §1
 yarn build           # builds workspace packages AND dist/client (Vite)
 ```
 
+### 3.5. README content check (catches "npm-shown README is stale")
+
+`packages/mulmoclaude/README.md` is the file npm displays on the package page. It is hand-curated, NOT auto-copied from the repo root README — so every release should re-read it against what's actually shipping. Run BEFORE §4 / §6.
+
+Open `packages/mulmoclaude/README.md` and verify each of:
+
+- **Features added since the last release** are reflected (collections / Discover / Contribute, Marp slides, sandbox credential flags, new bridges, voice input, plugin authoring, etc.) — at least a one-line mention each.
+- **Removed / renamed features** no longer appear (don't ship `npx mulmoclaude --old-flag` examples after the flag was renamed).
+- **CLI flags** in the "Options" table match `bin/mulmoclaude.js` exactly. Diff: `grep -E "^  --" packages/mulmoclaude/bin/mulmoclaude.js | head -20`.
+- **Env vars** (`MULMOCLAUDE_AUTH_TOKEN`, `SANDBOX_FORWARD_SSH_AGENT`, `SANDBOX_MOUNT_CONFIGS`, `GEMINI_API_KEY`, `DISABLE_SANDBOX`) match the launcher's behaviour.
+- **Bridge npm names** (`@mulmobridge/<x>`) match what's currently published. New bridges added since last release? Add them. Drop any deprecated.
+- **Length** is in the right zone — the file is a focused npm landing page, not a full developer guide. Don't paste in the full repo README (~700 lines today). Target: ~150-200 lines; defer the rest to `docs/` in the repo via links.
+
+When in doubt about a feature's npm-user relevance, default to including a short mention with a "see docs/<file>.md" link rather than a full how-to.
+
+The README is shipped via `package.json`'s standard inclusion — no explicit `files: [...]` entry needed for it. Confirm it's in the tarball:
+
+```bash
+cd packages/mulmoclaude && npm pack --dry-run 2>&1 | grep -E "README" | head -3
+# expect: npm notice <kB> README.md
+```
+
 ### 4. Local tarball test — verified by CI on every PR, rerun locally when needed
 
 `prepare-dist` runs via `prepack`, so `npm pack` exercises the exact same flow `npm publish` would. CI runs the full pack → clean install → boot → HTTP 200 probe on every PR; before releasing, confirm the latest `MulmoClaude publish smoke` run on `main` is green.

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -1,19 +1,37 @@
 # MulmoClaude
 
-Experience GUI-chat with Claude Code — and long-term memory!
+GUI front-end for Claude Code — chat with rich visual output, schema-driven data apps, and long-term memory. AI-native application platform that runs locally on your machine.
 
 ## Quick Start
 
 ```bash
 # Prerequisites: Node.js 20+, Claude Code CLI
 npm install -g @anthropic-ai/claude-code
-claude auth login
+claude              # one-time OAuth — completes the CLI setup
 
 # Launch MulmoClaude
-npx mulmoclaude
+npx mulmoclaude@latest
 ```
 
 Your browser opens to `http://localhost:3001`. That's it.
+
+> Closing the terminal stops the server. Run inside `tmux` / `screen` (macOS / Linux) or a Task Scheduler task (Windows) to keep it up.
+
+## What can you do?
+
+| Ask Claude to…                  | What you get                                          |
+| ------------------------------- | ----------------------------------------------------- |
+| "Write a project proposal"      | Rich markdown document in the canvas                  |
+| "Chart last quarter's revenue"  | Interactive ECharts visualization                     |
+| "Create a trip plan for Kyoto"  | Illustrated guide with images                         |
+| "Set up a todo list"            | Schema-driven collection with table / kanban / calendar |
+| "Ingest this article: URL"      | Wiki page with `[[links]]` for long-term memory       |
+| "Schedule a daily news digest"  | Recurring task that runs automatically                |
+| "Generate an image of a sunset" | AI-generated image (Gemini)                           |
+| "Make slides on …"              | Marp-rendered slide deck with PDF export              |
+| "Subscribe to this RSS feed"    | Data feed on `/feeds`, fetched on a schedule          |
+
+**Pages you can visit directly**: `/wiki` (browse + lint), `/feeds` (data feeds), `/collections` (data apps — Discover tab to import community collections, Contribute to share your own), `/automations` (recurring tasks), `/files`, `/skills`, `/roles`. Each page has its own chat composer that spawns a fresh chat already aware of the page context.
 
 ## Options
 
@@ -21,62 +39,101 @@ Your browser opens to `http://localhost:3001`. That's it.
 npx mulmoclaude                              # Default (port 3001, opens browser)
 npx mulmoclaude --port 8080                  # Custom port
 npx mulmoclaude --no-open                    # Don't open browser
-npx mulmoclaude --dev-plugin ./my-plugin     # Load a plugin from a local
-                                             # project dir (repeatable;
-                                             # path can be relative or absolute)
+npx mulmoclaude --disable-sandbox            # Run the agent directly on the host
+npx mulmoclaude --dev-plugin ./my-plugin     # Load a runtime plugin from a local
+                                             # project dir (repeatable; relative or
+                                             # absolute path)
 npx mulmoclaude --version                    # Show version
 ```
 
-`--dev-plugin <path>` is the plugin author's dev loop. Pair with
-`yarn dev` (vite watch) in the plugin directory: edits → vite
-rebuilds `dist/` → **the browser auto-reloads** via a debounced
-watcher on the plugin's `dist/`. The plugin's `package.json` name +
-`dist/index.js` must already be in place; the launcher refuses to
-start on missing files or on a name collision with an already-
-installed plugin. Server-side `definePlugin` factory edits still
-require a launcher restart (Node ESM has no cache invalidation API);
-the launcher log explicitly says so when `dist/index.js` changes.
-
 ## How it works
 
-The npm package ships with the pre-built client (Vite) and the server
-source — TypeScript, executed directly via `tsx`. No cloning, no
-build step for end users: `npx` downloads the package and starts the
-Express server.
+The npm package ships with the pre-built client (Vite) and the server source — TypeScript, executed directly via `tsx`. No cloning, no build step for end users: `npx` downloads the package and starts the Express server.
 
-Your data lives in `~/mulmoclaude/` (created on first run).
+Your data lives in `~/mulmoclaude/` (created on first run): conversations, memory, calendar, contacts, wiki, collections, scheduled tasks, generated artifacts. Plain files; the workspace IS the database.
 
-## Auth token for long-running bridges
+## Sandbox (recommended)
 
-By default the server generates a fresh bearer token on every startup
-and writes it to `~/mulmoclaude/.session-token`. Bridges
-(`@mulmobridge/telegram`, `@mulmobridge/discord`, …) read that file
-once at launch — so if you restart the server while a bridge is
-running, the bridge keeps the old token and every API call then
-returns **401**, silently.
+When Docker is available, the Claude Code agent runs inside a credential-free Docker sandbox so it can't see anything outside the workspace. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and the launcher detects it automatically.
 
-**Fix**: set `MULMOCLAUDE_AUTH_TOKEN` to the same long random value
-on both the server and the bridge. The server uses it verbatim
-instead of regenerating, so the token survives restarts.
+The sandbox is off by default for credentials (`gh auth`, SSH keys). Opt into the host's credential flow for the agent's `git` / `gh` commands:
 
 ```bash
-# Launch the server with a pinned token
+SANDBOX_FORWARD_SSH_AGENT=1 \
+SANDBOX_MOUNT_CONFIGS=gh \
+  npx mulmoclaude
+```
+
+Or run directly on the host (no sandbox, full access):
+
+```bash
+npx mulmoclaude --disable-sandbox
+```
+
+## Bridges — talk to MulmoClaude from messaging apps
+
+Bridges are separate npx-able processes that connect a messaging platform to the running server via socket.io. Each bridge supports real-time text streaming; CLI / Telegram also support file attachments.
+
+```bash
+# Run the server first (any terminal)
+npx mulmoclaude
+
+# Then in another terminal, any of:
+npx @mulmobridge/cli@latest          # interactive CLI on the same machine
+npx @mulmobridge/telegram@latest     # Telegram bot (needs TELEGRAM_BOT_TOKEN)
+npx @mulmobridge/slack@latest        # Slack
+npx @mulmobridge/discord@latest      # Discord
+npx @mulmobridge/line@latest         # LINE
+npx @mulmobridge/whatsapp@latest     # WhatsApp
+npx @mulmobridge/email@latest        # Email (IMAP + SMTP)
+# …matrix, mastodon, bluesky, signal, teams, zulip, irc, rocketchat,
+#   chatwork, xmpp, viber, messenger, google-chat, twilio-sms, webhook, nostr, line-works
+```
+
+Full bridge list and platform-specific setup: <https://github.com/receptron/mulmoclaude/blob/main/docs/mulmobridge-guide.md>
+
+### Auth token persistence across server restarts
+
+The server regenerates a fresh bearer token on every startup and writes it to `~/mulmoclaude/.session-token`. A bridge that started before the restart keeps the OLD token in memory, so every subsequent API call returns 401 silently.
+
+Fix: set `MULMOCLAUDE_AUTH_TOKEN` to the same long random value on both the server and the bridge. The server uses it verbatim instead of regenerating, so the token survives restarts.
+
+```bash
+# Server (one-time setup — pin a strong random value)
 MULMOCLAUDE_AUTH_TOKEN=long-random-string npx mulmoclaude
 
 # Bridge (separate process / machine — same value)
 MULMOCLAUDE_AUTH_TOKEN=long-random-string \
-  TELEGRAM_BOT_TOKEN=... \
+  TELEGRAM_BOT_TOKEN=… \
   npx @mulmobridge/telegram@latest
 ```
 
-Recommended: ≥ 32 characters of random data (shorter values trigger a
-startup warning).
+Recommended: ≥ 32 characters of random data (shorter values trigger a startup warning).
+
+## Roles, skills, and collections
+
+- **Roles** (sidebar selector): General, Office, Guide & Planner, Artist, Tutor, Storyteller, Settings. Each one biases Claude toward a workflow and surfaces its sample prompts.
+- **Skills** (`~/.claude/skills/<name>/SKILL.md`): personal skills shared across every project, plus project skills under `<workspace>/.claude/skills/`. Bundled "preset" skills (`mc-*`) re-seed on each boot.
+- **Collections**: schema-driven data apps. Author your own (`data/skills/<slug>/schema.json` declares the model + UI), or use the Discover tab on `/collections` to import community collections from the official registry — or your own org / community registry by dropping `config/collections-registries.json` in the workspace.
+
+## Optional features
+
+- **Gemini API key** (`GEMINI_API_KEY` in environment or `.env`) — enables AI image generation (`generateImage`), audio / video. Free tier suffices for everyday use; get one from [Google AI Studio](https://aistudio.google.com/).
+- **Local voice input** (macOS only, opt-in) — `whisper.cpp` for dictating chat messages without sending audio to a cloud API.
+- **Marp slides** — `marp: true` frontmatter on any markdown file renders a slide deck in the canvas with PDF export. Custom themes via `config/marp-themes/<name>.css`.
+- **Auto memory** — the agent maintains a typed memory layout (`conversations/memory/<type>/<topic>.md`) and reads it ambient-style.
+
+## Plugin authoring (`--dev-plugin`)
+
+`--dev-plugin <path>` is the runtime-plugin author's dev loop. Pair with `yarn dev` in the plugin directory (vite watch): edits → vite rebuilds `dist/` → the browser auto-reloads via a debounced watcher on the plugin's `dist/`. The plugin's `package.json#name` + `dist/index.js` must already be present; the launcher refuses to start on missing files or on a name collision with an already-installed plugin.
+
+Server-side `definePlugin` factory edits still require a launcher restart (Node ESM has no cache invalidation API); the launcher log explicitly says so when `dist/index.js` changes.
 
 ## For developers
 
-Publish flow and the full local-test recipe (prepare-dist,
-direct launch, curl checks, tarball simulation) live in the
-header comment of `bin/prepare-dist.js`.
+- Repo: <https://github.com/receptron/mulmoclaude>
+- Architecture, scripts, and the publish flow live in `docs/developer.md` of the repo.
+- Publish flow for this package: see `bin/prepare-dist.js` header comment plus `.claude/skills/publish-mulmoclaude/SKILL.md`.
 
 ## License
 


### PR DESCRIPTION
## Summary

The npm-shown README for `mulmoclaude` was hand-curated 83 lines last touched in early 2024 — missing collections (Discover / Contribute), Marp slides, sandbox credential flags, voice input, the full bridges list, and other features that have shipped since. Refresh it.

Plus add a `/publish-mulmoclaude` skill step so this drift doesn't recur silently — every release re-verifies the README before publishing.

## Items to Confirm / Review

- **Hand-curated, not auto-copied from root README.** Root is a 700-line developer + end-user combo; the npm landing page should be focused (target 150-200 lines, this rewrite is 168), npm-first, and link out to repo for depth. (We considered auto-copying root README at `prepack` — rejected because the root has dev sections like "Run from source" that don't fit the npm npx-install user.)
- **Tarball verified.** `npm pack --dry-run | grep README` → `7.9kB README.md` (was 2.9kB).
- **Skill change**: a new `### 3.5. README content check` between Build (§3) and Tarball test (§4), with a checklist of what to verify (features-added-since-last-release, removed/renamed flags, CLI flags vs `bin/mulmoclaude.js`, env vars, bridges, length cap) and a `npm pack --dry-run | grep README` confirmation.
- **No publish in this PR**: the README change ships with the next mulmoclaude release (won't republish 0.9.1 — npm forbids version reuse). The next bump will include this rewrite.

## User Prompt

> あと、packageのreadmeってレポジトリのreadmeが反映されてない？
>
> なるほど。コピーしなくても良いけど、最新の過不足内情報をついかして。
>
> まいかい、内容確認するようにskillも更新

## Implementation

`packages/mulmoclaude/README.md` — rewritten from 83 → 168 lines covering:
- Quick Start with `claude` OAuth setup
- "What can you do?" table (10 prompts → outcomes) + Pages list
- Options (CLI flags including `--disable-sandbox`, `--dev-plugin`)
- Sandbox section + `SANDBOX_FORWARD_SSH_AGENT` / `SANDBOX_MOUNT_CONFIGS` flags
- Bridges npx list (full `@mulmobridge/*`)
- Auth token persistence (preserved + clarified)
- Roles / skills / collections (Discover / Contribute mention)
- Optional features (Gemini API key, voice input, Marp slides, auto memory)
- Plugin authoring (`--dev-plugin`)
- For developers (link to repo + skill)

`.claude/skills/publish-mulmoclaude/SKILL.md` — adds:
- `### 3.5. README content check` between Build and Tarball test
- Checklist: features added since last release, removed/renamed features, CLI flags vs `bin/mulmoclaude.js`, env vars, bridge npm names, length cap (~150-200 lines)
- `npm pack --dry-run | grep README` confirmation command

## Test plan

- [x] `yarn format` / `yarn lint` clean
- [x] `npm pack --dry-run | grep README` → `7.9kB README.md` in tarball
- [ ] After merge: verify https://www.npmjs.com/package/mulmoclaude renders the new README on the next publish
- [ ] Next release runner manually walks through §3.5 checklist before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the MulmoClaude README with clearer quick-start guidance, usage options, sandboxing, bridge authentication persistence, and new sections covering roles, skills, collections, and optional features.
  * Improved plugin authoring guidance and added more practical setup and workflow details.

* **Chores**
  * Added a release checklist step to verify the README is included in the published package and matches the shipped feature set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->