### PR TITLE
chore: bump @mulmoclaude/core and collection-plugin

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client and ./workspace-setup/slug entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",


### PR DESCRIPTION
Bump shared package versions:

- `@mulmoclaude/core` 0.2.13 → 0.2.14
- `@mulmoclaude/collection-plugin` 0.5.19 → 0.5.20

Dependent caret ranges in `packages/mulmoclaude/package.json` already cover the new versions, so no consumer edits are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions for the core package and collection plugin to newer patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->