### PR TITLE
chore(lint): demote assertions-in-tests to warn, fix the 16 other sonarjs errors

### DIFF
--- a/config/eslint.packages.mjs
+++ b/config/eslint.packages.mjs
@@ -15,6 +15,11 @@ export default [
     plugins: { prettier: prettierPlugin },
     rules: {
       "prettier/prettier": "error",
+      // Mirror the root config: many node:test cases drive an observed
+      // side-effect (no throw / no log) and intentionally have no
+      // inline assert. Demoted to warn so reviewers still see it
+      // without blocking CI.
+      "sonarjs/assertions-in-tests": "warn",
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^__", varsIgnorePattern: "^__" },

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -271,7 +271,12 @@ test.describe("accounting plugin — flow", () => {
 
     // Tab strip is rendered but disabled — clicking a tab does
     // nothing while the notice is up. Verify by clicking journal and
-    // confirming the notice stays.
+    // confirming the notice stays. `force: true` is required because
+    // the whole point of this assertion is to drive a click at the
+    // DOM regardless of Playwright's actionability check — the
+    // expected behaviour is that the disabled tab swallows the click
+    // and the notice stays.
+    // eslint-disable-next-line sonarjs/no-forced-browser-interaction -- intentional: probing a disabled-state guard
     await page.getByTestId("accounting-tab-journal").click({ force: true });
     await expect(page.getByTestId("accounting-deleted-notice")).toBeVisible();
 

--- a/e2e/tests/collection-contribute.spec.ts
+++ b/e2e/tests/collection-contribute.spec.ts
@@ -144,7 +144,7 @@ test.describe("collection Contribute button", () => {
     // Use a real newline (not the literal two-char `\n` sequence) so a
     // regression that lets `\n` through the sanitiser actually fails
     // here (codex review on #1830).
-    // eslint-disable-next-line sonarjs/slow-regex -- bounded `\s*` followed by a literal terminator; no catastrophic backtracking possible
+    // eslint-disable-next-line sonarjs/super-linear-regex -- bounded `\s*` followed by a literal terminator; no catastrophic backtracking possible
     expect(body).not.toMatch(/\n\s*NEW INSTRUCTION:/);
     // The slug still lands verbatim — only the title was crafted.
     expect(body).toContain("danger");

--- a/e2e/tests/lock-status-popup.spec.ts
+++ b/e2e/tests/lock-status-popup.spec.ts
@@ -23,7 +23,7 @@ test.describe("LockStatusPopup", () => {
     // them in sync when adding / removing sample queries.
     const queries = page.getByTestId("sandbox-test-query");
     await expect(queries.first()).toBeVisible();
-    expect(await queries.count()).toBe(5);
+    await expect(queries).toHaveCount(5);
   });
 
   test("clicking a test query closes the popup", async ({ page }) => {

--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -521,7 +521,7 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     await page.getByTestId("skill-add-repo-suggestion-https://github.com/anthropics/skills").click();
     await expect(page.getByTestId("skill-add-repo-url")).toHaveValue("https://github.com/anthropics/skills");
     await expect(page.getByTestId("skill-add-repo-subpath")).toHaveValue("skills");
-    expect(calls.install.length).toBe(0);
+    expect(calls.install).toHaveLength(0);
 
     // Explicit Install is what actually installs.
     await page.getByTestId("skill-add-repo-submit").click();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -291,6 +291,13 @@ export default [
       // via PATH is normal operation, not a server-side injection risk.
       "sonarjs/no-os-command-from-path": "off",
       "sonarjs/cors": "off",
+      // Many of our `node:test` cases drive an observed side-effect
+      // (no throw / no log / DOM mutation watched elsewhere) and
+      // intentionally have no inline assert. The rule has no per-case
+      // opt-out, so blocking CI on each one creates churn without
+      // catching real "did we forget the assert?" bugs. Demoted to
+      // warn so reviewers still see it on new tests.
+      "sonarjs/assertions-in-tests": "warn",
       // ── eslint-plugin-security tuning ──────────────────────────
       // Three high-volume rules are disabled because they fire on
       // patterns that are normal in this codebase, drowning the

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-security": "^4.0.1",
-    "eslint-plugin-sonarjs": "^4.0.3",
+    "eslint-plugin-sonarjs": "^4.1.0",
     "eslint-plugin-vue": "^10.9.2",
     "globals": "^17.7.0",
     "jsdom": "^29.1.1",

--- a/packages/core/src/collection/server/io.ts
+++ b/packages/core/src/collection/server/io.ts
@@ -372,7 +372,7 @@ function sanitizeForPrompt(value: string): string {
   let prev: string;
   do {
     prev = current;
-    // eslint-disable-next-line sonarjs/slow-regex -- bounded tag strip, mirrors legacy escapeForPrompt
+    // eslint-disable-next-line sonarjs/super-linear-regex -- bounded tag strip, mirrors legacy escapeForPrompt
     current = current.replace(/<[^>]*>/g, "");
   } while (current !== prev);
   return current.replace(/`/g, "'").replace(/\$\{/g, "\\${");

--- a/packages/core/src/feeds/server/projectItem.ts
+++ b/packages/core/src/feeds/server/projectItem.ts
@@ -56,7 +56,7 @@ function toSafeId(natural: string): string {
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-");
-  // eslint-disable-next-line sonarjs/slow-regex -- anchored hyphen trim, linear, no catastrophic backtracking
+  // eslint-disable-next-line sonarjs/super-linear-regex -- anchored hyphen trim, linear, no catastrophic backtracking
   const slug = collapsed.replace(/^-+|-+$/g, "");
   if (slug.length > 0 && slug.length <= 80) return slug;
   const hash = createHash("sha256")

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -248,7 +248,6 @@ waitUntilReady(port, () => {
   const openCmd = pickOpenCommand();
   try {
     // openCmd is a hard-coded literal; url is http://localhost:<numeric-port>.
-    // eslint-disable-next-line sonarjs/os-command
     execSync(`${openCmd} ${url}`, { stdio: "pipe" });
   } catch {
     log(`Open your browser: ${url}`);

--- a/server/agent/sandboxMounts.ts
+++ b/server/agent/sandboxMounts.ts
@@ -210,7 +210,7 @@ export interface ResolveSandboxAuthParams {
    *  to generate a restrictive `~/.ssh/config`. */
   sshAllowedHosts?: string;
   configMountNames: readonly string[];
-  sshAuthSock?: string | undefined;
+  sshAuthSock?: string;
   home?: string;
 }
 

--- a/server/api/sandboxStatus.ts
+++ b/server/api/sandboxStatus.ts
@@ -32,7 +32,7 @@ export interface BuildSandboxStatusParams {
   sandboxEnabled: boolean;
   sshAgentForward: boolean;
   configMountNames: readonly string[];
-  sshAuthSock?: string | undefined;
+  sshAuthSock?: string;
   home?: string;
   /** Injected for tests; defaults to `process.platform`. */
   platform?: typeof process.platform;

--- a/src/plugins/presentMulmoScript/helpers.ts
+++ b/src/plugins/presentMulmoScript/helpers.ts
@@ -50,7 +50,7 @@ export function parseSSEEventLine(line: string): SSEEvent | null {
  * characters must be rendered first so they can be referenced by
  * any character-using beat.
  */
-export function shouldAutoRenderBeat(beat: { image?: { type?: string } | undefined }, hasCharacters: boolean, autoRenderTypes: readonly string[]): boolean {
+export function shouldAutoRenderBeat(beat: { image?: { type?: string } }, hasCharacters: boolean, autoRenderTypes: readonly string[]): boolean {
   if (hasCharacters) return false;
   const type = beat.image?.type;
   if (typeof type !== "string") return false;

--- a/src/utils/image/htmlSrcAttrs.ts
+++ b/src/utils/image/htmlSrcAttrs.ts
@@ -161,7 +161,7 @@ const TAG_NAME_RE = /^<([a-z]+)/i;
 //      quote as the value
 //
 // All quantifiers bounded — verified ReDoS-safe in test_htmlSrcAttrs.ts.
-// eslint-disable-next-line sonarjs/slow-regex, sonarjs/regex-complexity, security/detect-unsafe-regex -- bounded quantifiers, ReDoS-safe (test in test_htmlSrcAttrs.ts)
+// eslint-disable-next-line sonarjs/super-linear-regex, sonarjs/regex-complexity, security/detect-unsafe-regex -- bounded quantifiers, ReDoS-safe (test in test_htmlSrcAttrs.ts)
 const ATTR_ITER_RE = /(\s+)([A-Za-z][\w:-]*)(?:(\s*=\s*)("([^"]*)"|'([^']*)'|([^\s>"'][^\s>]*)))?/g;
 
 /** Transform every URL-bearing attribute on a recognised tag.

--- a/test/system/test_macosNotify.ts
+++ b/test/system/test_macosNotify.ts
@@ -122,8 +122,10 @@ describe("pushToMacosReminderWithDeps — failure handling", () => {
     const throwingSpawner: Spawner = () => {
       throw new Error("synchronous spawn failure");
     };
-    await pushToMacosReminderWithDeps({ spawner: throwingSpawner, platform: "darwin", disabled: false }, "Hello");
-    // Reaching this line means no rejection — that's the assertion.
-    assert.ok(true);
+    // The assertion is that the await resolves at all — a synchronous
+    // throw inside the spawner must not reject the promise. Phrase it
+    // as `doesNotReject` so the failure mode is explicit rather than
+    // relying on "reached the next line".
+    await assert.doesNotReject(() => pushToMacosReminderWithDeps({ spawner: throwingSpawner, platform: "darwin", disabled: false }, "Hello"));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,23 +4170,24 @@ eslint-plugin-security@^4.0.1:
   dependencies:
     safe-regex "^2.1.1"
 
-eslint-plugin-sonarjs@^4.0.3:
-  version "4.0.3"
-  resolved "https://npm.flatt.tech/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz#78bda46bd2f91d0f7445f974fd417dce088b2efa"
-  integrity sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==
+eslint-plugin-sonarjs@^4.1.0:
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.1.0.tgz#61879e5a8536a5e53b5240187cc113a683f7105e"
+  integrity sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw==
   dependencies:
     "@eslint-community/regexpp" "^4.12.2"
     builtin-modules "^3.3.0"
     bytes "^3.1.2"
     functional-red-black-tree "^1.0.1"
-    globals "^17.4.0"
+    globals "^17.6.0"
     jsx-ast-utils-x "^0.1.0"
     lodash.merge "^4.6.2"
     minimatch "^10.2.5"
     scslre "^0.3.0"
-    semver "^7.7.4"
+    semver "^7.8.4"
     ts-api-utils "^2.5.0"
     typescript ">=5"
+    yaml "^2.9.0"
 
 eslint-plugin-vue@^10.8.0, eslint-plugin-vue@^10.9.2:
   version "10.9.2"
@@ -4831,7 +4832,7 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
-globals@^17.0.0, globals@^17.4.0, globals@^17.7.0:
+globals@^17.0.0, globals@^17.6.0, globals@^17.7.0:
   version "17.7.0"
   resolved "https://npm.flatt.tech/globals/-/globals-17.7.0.tgz#553d55090b4dde8209ec2da42580d6e7e7d8b10d"
   integrity sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==
@@ -7470,10 +7471,15 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.7.4:
+semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.8.4:
+  version "7.8.5"
+  resolved "https://npm.flatt.tech/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@^1.1.0, send@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
## Summary

`yarn lint` was failing with 42 issues. **0 errors / 26 warnings** after this PR.

- **26 × `sonarjs/assertions-in-tests`** — demoted to `warn` in both the root config and the shared packages config. The rule has no per-case opt-out; every `node:test` case that exercises a side-effect (no throw / DOM mutation watched elsewhere) was either getting a no-op `assert.ok(true)` cargo-culted in or holding up CI. Reviewers still see it on new tests; existing tests stop creating noise.
- **16 other errors** — fixed for real:
  - `sonarjs/no-redundant-optional` × 3 — dropped explicit `| undefined` next to `?`.
  - `sonarjs/prefer-specific-assertions` × 2 — switched to `.toHaveCount(...)` / `.toHaveLength(...)`.
  - `sonarjs/no-trivial-assertions` × 1 — rewrote a "no rejection by reaching this line" trick as `assert.doesNotReject(...)`.
  - `sonarjs/no-forced-browser-interaction` × 1 — the test deliberately probes a disabled tab guard, so `force: true` is the point; inline disable with rationale.
  - `sonarjs/super-linear-regex` × 4 + 4 stale `sonarjs/slow-regex` disable directives — rule was renamed between sonarjs 4.0.x and 4.1.x; renamed the disables.
  - Unused `sonarjs/os-command` disable — removed.

Bumps `eslint-plugin-sonarjs` to `^4.1.0` (where the rule rename landed and `assertions-in-tests` got its current shape).

## Items to Confirm / Review

1. **`assertions-in-tests` as warn, not off** — keeping it visible on new tests is the whole point. Confirm warn (rather than off) is the right floor — the alternative is letting reviewers eyeball every new `it(...)` block manually.
2. **`force: true` exemption in `e2e/tests/accounting-flow.spec.ts:275`** — the disabled-tab guard is exactly what the test is asserting holds, so the disable comment explains "intentional: probing a disabled-state guard". Confirm the wording is clear enough.
3. **Rule rename: `slow-regex` → `super-linear-regex`** — the per-line rationale (`bounded`, `ReDoS-safe`, etc.) is unchanged; only the rule id moved.
4. **sonarjs 4.0.3 → 4.1.0 bump** — minor, no breaking-change notes for our usage. Required because the warn demote on `assertions-in-tests` and the new rule id both depend on it.

## User Prompt

> ブランチ切ってlintをfixして。warnにへんこうでもよいよ
> いっぱい出るのはwarnにかえて、直せるものは直して。

## Out of scope (pre-existing on main, unrelated to lint)

- `yarn typecheck:server` fails with `Could not find a declaration file for module 'js-yaml'` — js-yaml 5.x's bundled types aren't resolving because three transitive deps (`@eslint/eslintrc`, `@intlify/eslint-plugin-vue-i18n`, `@marp-team/marpit`) pull in js-yaml ^4.1.x and hoisting picks 4.2.0 for the top-level `node_modules/js-yaml/`. Separate regression from the js-yaml 5.x PR (#1854); will file / fix separately.
- 3 unit tests fail on main as well. Separate scope.

## Verification

```
$ yarn lint
… (no error output) …
✖ 26 problems (0 errors, 26 warnings)
Done in 3.42s.
```

`yarn format` clean, `yarn build` clean (rolldown warnings already suppressed in #1855).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified several end-to-end and system tests, making assertions more explicit and easier to read.
  * Improved handling checks for disabled interactions, popups, and failure cases.

* **Chores**
  * Updated lint rule settings and dependency versions to keep checks aligned with current tooling.

* **Refactor**
  * Tightened a few TypeScript types without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->