### PR TITLE
Serialize bridge chat turns per external chat

### DIFF
--- a/packages/chat-service/src/relay.ts
+++ b/packages/chat-service/src/relay.ts
@@ -53,8 +53,14 @@ const REPLY_TIMEOUT_MS = 5 * 60 * 1000;
 
 export function createRelay(deps: RelayDeps): RelayFn {
   const { store, handleCommand, startChat, onSessionEvent, getRole, defaultRoleId, logger } = deps;
+  const relayLocks = new Map<string, Promise<void>>();
 
   return async function relayMessage(params: RelayParams): Promise<RelayResult> {
+    const lockKey = JSON.stringify([params.transportId, params.externalChatId]);
+    return withRelayLock(relayLocks, lockKey, async () => relayMessageUnlocked(params));
+  };
+
+  async function relayMessageUnlocked(params: RelayParams): Promise<RelayResult> {
     const { transportId, externalChatId, attachments, bridgeOptions } = params;
     let { text } = params;
 
@@ -150,7 +156,7 @@ export function createRelay(deps: RelayDeps): RelayFn {
         message: "Error: failed to collect agent reply",
       };
     }
-  };
+  }
 }
 
 // ── Internals ────────────────────────────────────────────────
@@ -216,4 +222,26 @@ function collectAgentReply(onSessionEvent: OnSessionEventFn, chatSessionId: stri
       }
     });
   });
+}
+
+async function withRelayLock<T>(locks: Map<string, Promise<void>>, key: string, task: () => Promise<T>): Promise<T> {
+  const previous = locks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const ready = previous.catch(() => undefined);
+  const next = ready.then(() => current);
+
+  locks.set(key, next);
+  await ready;
+
+  try {
+    return await task();
+  } finally {
+    release();
+    if (locks.get(key) === next) {
+      locks.delete(key);
+    }
+  }
 }

--- a/packages/chat-service/test/test_relay.ts
+++ b/packages/chat-service/test/test_relay.ts
@@ -1,0 +1,118 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EVENT_TYPES } from "@mulmobridge/protocol";
+import { createRelay } from "../src/relay.ts";
+import type { ChatStateStore, TransportChatState } from "../src/chat-state.ts";
+import type { Logger, SessionEventListener, StartChatParams } from "../src/types.ts";
+
+const logger: Logger = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
+describe("relayMessage", () => {
+  it("serializes concurrent turns for the same external chat before creating state", async () => {
+    let state: TransportChatState | null = null;
+    let sessionCounter = 0;
+    const startCalls: StartChatParams[] = [];
+    const listeners = new Map<string, SessionEventListener[]>();
+
+    const store: ChatStateStore = {
+      getChatState: async () => state,
+      setChatState: async (_transportId, nextState) => {
+        state = nextState;
+      },
+      resetChatState: async (transportId, externalChatId, roleId) => {
+        const now = new Date().toISOString();
+        const nextState: TransportChatState = {
+          externalChatId,
+          sessionId: `${transportId}-${externalChatId}-${++sessionCounter}`,
+          roleId,
+          startedAt: now,
+          updatedAt: now,
+        };
+        state = nextState;
+        return nextState;
+      },
+      connectSession: async () => null,
+      generateSessionId: (transportId, externalChatId) => `${transportId}-${externalChatId}-generated`,
+    };
+
+    const relay = createRelay({
+      store,
+      handleCommand: async () => null,
+      startChat: async (params) => {
+        startCalls.push(params);
+        return { kind: "started", chatSessionId: params.chatSessionId };
+      },
+      onSessionEvent: (sessionId, listener) => {
+        const sessionListeners = listeners.get(sessionId) ?? [];
+        sessionListeners.push(listener);
+        listeners.set(sessionId, sessionListeners);
+        return () => {
+          const current = listeners.get(sessionId) ?? [];
+          listeners.set(
+            sessionId,
+            current.filter((candidate) => candidate !== listener),
+          );
+        };
+      },
+      getRole: (roleId) => ({ id: roleId, name: roleId }),
+      defaultRoleId: "general",
+      logger,
+    });
+
+    const first = relay({ transportId: "slack", externalChatId: "channel1", text: "first" });
+    const second = relay({ transportId: "slack", externalChatId: "channel1", text: "second" });
+
+    await waitFor(() => startCalls.length >= 1, "first relay did not start");
+    await waitFor(() => listenerCount(listeners, startCalls[0].chatSessionId) > 0, "first relay did not subscribe to events");
+    await flushAsync();
+    const callsBeforeFirstFinished = startCalls.length;
+
+    const finishedCallIndexes = new Set<number>();
+    const finishCall = async (index: number, text: string) => {
+      if (finishedCallIndexes.has(index)) return;
+      await waitFor(() => listenerCount(listeners, startCalls[index].chatSessionId) > 0, "relay did not subscribe to events");
+      finishedCallIndexes.add(index);
+      const sessionId = startCalls[index].chatSessionId;
+      for (const listener of listeners.get(sessionId) ?? []) {
+        listener({ type: EVENT_TYPES.text, message: text });
+        listener({ type: EVENT_TYPES.sessionFinished });
+      }
+    };
+
+    await finishCall(0, "first reply");
+    if (startCalls[1]) {
+      await finishCall(1, "second reply");
+    }
+
+    await waitFor(() => startCalls.length >= 2, "second relay did not start");
+    await finishCall(1, "second reply");
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    assert.equal(callsBeforeFirstFinished, 1);
+    assert.equal(startCalls[0].chatSessionId, startCalls[1].chatSessionId);
+    assert.deepEqual(firstResult, { kind: "ok", reply: "first reply" });
+    assert.deepEqual(secondResult, { kind: "ok", reply: "second reply" });
+  });
+});
+
+async function flushAsync(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (condition()) return;
+    await flushAsync();
+  }
+  assert.fail(message);
+}
+
+function listenerCount(listeners: Map<string, SessionEventListener[]>, sessionId: string): number {
+  return listeners.get(sessionId)?.length ?? 0;
+}


### PR DESCRIPTION
## Summary

- Serialize relay handling per `(transportId, externalChatId)` so concurrent bridge turns use one file-backed session state sequence.
- Add a regression test covering two concurrent first messages for the same external chat.

## Root cause

Bridge relay handling read or created chat state before starting an async agent run, then wrote the state again after collecting the reply. Two first messages for the same external chat could both observe missing state, create different internal session IDs, and leave the persisted session pointer dependent on whichever turn finished last.

## Why it matters

Bridge transports present a channel, thread, or DM as one conversation. Concurrent delivery should not split that conversation across multiple internal sessions or make future replies continue from a stale session pointer.

## Validation

- `yarn workspace @mulmobridge/protocol build`
- `yarn workspace @mulmobridge/chat-service test`
- `yarn workspace @mulmobridge/chat-service typecheck`
- `yarn workspace @mulmobridge/chat-service lint`
- `yarn workspace @mulmobridge/chat-service build`
- `git diff --check`
- `yarn build:packages`
- `yarn typecheck`
- `yarn lint` (passes with existing assertion-count warnings)
- `yarn plugins:codegen:check`
- `yarn build`
- `git diff --exit-code -- server/workspace/wiki-history/hook/snapshot.mjs server/build/dispatcher.mjs`
- `yarn test:csrf-wiring`
- `yarn tsx --test test/agent/test_mcp_smoke.ts`

Known verification note: one broad `yarn test:coverage` run timed out in `test/agent/test_mcp_smoke.ts`; rerunning that exact smoke test standalone passed in 3.3s.

## Summary by Sourcery

Serialize relay handling per external chat to prevent concurrent turns from creating divergent session state.

Enhancements:
- Introduce a per-(transportId, externalChatId) relay lock to ensure sequential processing of bridge turns sharing the same conversation.

Tests:
- Add a regression test verifying that two concurrent first messages for the same external chat share a single chat session and both receive correct replies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat messages for the same conversation are now handled one at a time, preventing overlapping replies and reducing inconsistent session behavior.
  * Concurrent sends to the same chat now share the same active session until the current turn completes, improving reliability during fast repeated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->