### PR TITLE
fix(ci): stop duplicate close-comments on auto-triaged PRs (#1869 follow-up)

### DIFF
--- a/.github/workflows/pr_triage.yaml
+++ b/.github/workflows/pr_triage.yaml
@@ -37,7 +37,22 @@ on:
     # then edit it to point at main. That arrives as `edited`, not
     # `opened` / `reopened`, so triage would otherwise never fire on
     # the retargeted PR. CodeRabbit + Codex review on PR #1708.
-    types: [opened, reopened, synchronize, edited]
+    #
+    # `synchronize` removed (#1869 follow-up): a `synchronize` event
+    # arrives a few seconds after we call `gh pr close` on a large
+    # PR, and the post-close `edited` event from CodeRabbit's title /
+    # body edits arrives a beat later. Both re-ran this workflow and
+    # each posted another copy of the closing comment (PR #1869
+    # received three identical close comments inside 90 s). The
+    # `if: state == 'open'` guard below catches the residual `edited`
+    # case; dropping `synchronize` removes the primary duplicate
+    # source. Net behaviour: a contributor who opens a small PR and
+    # later pushes a large commit is no longer auto-closed, but the
+    # PR is still in the human review queue (and the doc-link in the
+    # opening comment still points at the policy) — that's an
+    # acceptable trade for not spamming three copies of the same
+    # close comment every time.
+    types: [opened, reopened, edited]
     branches: [main]
 
 permissions:
@@ -51,6 +66,14 @@ concurrency:
 
 jobs:
   triage:
+    # Skip everything once the PR is closed. Without this, a residual
+    # `edited` event (e.g. CodeRabbit re-summarising the title/body
+    # after we already closed) re-runs the whole script — `gh pr close`
+    # on a closed PR is a no-op, but the `gh pr comment` above it is
+    # NOT idempotent and posts another copy of the closing template.
+    # This guard is the second half of the #1869 fix (the first half
+    # is dropping `synchronize` from `types` above).
+    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     env:


### PR DESCRIPTION
## Summary

PR #1869 received **three identical** "this PR is being closed automatically" comments inside 90 seconds. The root cause is in our own \`pr_triage.yaml\` — the workflow listens on four \`pull_request_target\` event types and \`gh pr comment\` is not idempotent, so every event after the first re-runs the script and posts another copy of the template.

## What the logs show (PR #1869)

| Time (UTC) | Run | Trigger event | Action |
|---|---|---|---|
| 20:23:17 | 28400285929 | \`opened\` | Comment + \`gh pr close\` |
| 20:23:26 | 28400295145 | \`synchronize\` (residual webhook ~9 s after the close call) | Another comment |
| 20:24:26 | 28400350043 | \`edited\` (CodeRabbit re-summarised the title/body) | Another comment |

The \`concurrency: cancel-in-progress\` group doesn't help — run 1 finishes in 4–5 s, so by the time run 2 starts there's nothing left to cancel.

## Fix

Two surgical changes, both required:

1. **Drop \`synchronize\` from the trigger types.** Its primary signal — "force-push; re-evaluate size" — bypasses the workflow's design intent (triage at open time), and firing it right after \`gh pr close\` is the primary duplicate source.
2. **Add \`if: github.event.pull_request.state == 'open'\` at the job level.** CodeRabbit / Sourcery often edit the title or body of an already-closed PR; without this guard, that \`edited\` event re-runs the script and posts comment #3.

\`edited\` is **kept** in the trigger list — it's the only event that catches the base-branch retarget bypass that #1708 added (a contributor opens against a non-main branch and edits to main afterwards).

## Items to Confirm / Review

- **Defence in depth**: \`if: state == 'open'\` is the durable guard. Even if a future GitHub change starts firing \`opened\` events on an already-closed PR (unlikely but possible), no duplicate comment lands.
- **Trade-off**: a small PR that grows via \`synchronize\` push is no longer auto-closed. It still sits in the human review queue, and the opening comment (if any) still points at the policy doc — acceptable per #1869 conversation.
- **\`#1708\` defence intact**: \`edited\` is still listened on, so the base-branch retarget bypass remains closed.

## Diff

```yaml
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, edited]

 jobs:
   triage:
+    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
```

(With explanatory comments referencing #1869 and the timeline above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust PR triage workflow to avoid posting duplicate automatic closing comments on already-closed, auto-triaged pull requests.

CI:
- Remove the `synchronize` pull_request_target trigger from pr_triage to prevent re-running triage after auto-closure.
- Add a job-level guard to only run the triage job when the pull request state is `open`, preventing post-close edited events from retriggering comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate closing comments from being posted on pull requests that receive later edit events after being closed.
  * Improved pull request triage behavior so it runs only for open pull requests and on relevant update events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->