### PR TITLE
feat(chat-index): summarize with sonnet and a wider input window

### DIFF
--- a/plans/feat-chat-summarizer-sonnet.md
+++ b/plans/feat-chat-summarizer-sonnet.md
@@ -1,0 +1,46 @@
+# feat: chat-index summarizer を sonnet 化 + 入力窓を拡大
+
+## 背景
+
+セッションが増えるとチャットを探すのに迷子になる（umbrella #1883）。タイトル付与（#1880）を検討する中で、**タイトルは既に自動生成されている**ことが分かった：`server/workspace/chat-index/` の summarizer が毎ターン後（15分スロットル）+ 1h backfill で `claude` を回し `{title, summary, keywords}` を生成し、サイドバーの `preview` に表示している。
+
+つまり要望「手動は大変→自動でサマリータイトル」は仕組みとしては動いている。残る問題は **タイトル/サマリーの品質** で、原因は2つ：
+
+1. **モデルが haiku**（事後要約の弱モデル）→ 内容の頭打ち。
+2. **入力窓が狭い**（`MAX_INPUT_CHARS = 8000`、先頭3000 + 末尾5000）→ 長い・話題が変遷したセッションの **中盤が要約に入らない**。各メッセージも500字で切り詰め。
+
+短いセッション（少ターン）はターン数のゲートが無いので問題なく要約される（テキストが1つでもあれば対象。skip は「実行中」「テキスト皆無」のみ）。
+
+## 変更（すべて `server/workspace/chat-index/summarizer.ts`）
+
+| 定数 | 旧 | 新 | 理由 |
+|---|---|---|---|
+| model | `haiku` | `sonnet`（新 `SUMMARY_MODEL`） | 内容品質 |
+| `MAX_BUDGET_USD` | `0.15` | `0.40` | sonnet 単価＋初回キャッシュ生成。低すぎると budget 超過で**要約が付かない** |
+| `MAX_INPUT_CHARS` | `8000` | `30000` | 長セッションの中盤を拾う |
+| `HEAD_CHARS` | `3000` | `12000` | 窓拡大に追従 |
+| `TAIL_CHARS` | `5000` | `16000` | 同上（head+tail=28000 < 30000 を維持し truncate が必ず縮む） |
+| `PER_MESSAGE_MAX` | `500` | `1500` | 長い発言の過剰な切り詰めを緩和 |
+
+- 4つの窓定数を `export` し、`test/chat-index/test_summarizer.ts` がそこから fixture を導出するよう変更（定数変更でテストが腐らない）。
+- コストは sonnet で1セッションあたり概ね $0.03〜0.13、100件 backfill でも数ドル程度。
+
+## 効果
+
+- 短い → これまで通り確実に付く。
+- 長い → 中盤も要約に入る。
+- 内容 → sonnet で底上げ。
+
+## テスト
+
+- `test/chat-index/test_summarizer.ts`：`truncateMiddle` / per-message クリップを export 定数ベースに更新。`extractText` / `parseClaudeJsonResult` / `validateSummaryResult` / `formatSpawnError` は不変。
+- summarizer はモデル名以外の spawn 経路を変えていないので既存の DI フェイク（`IndexerDeps.summarize`）テストはそのまま通る。
+
+## 将来（別 issue）
+
+- #1880：agent 主導タイトル（`updateSessionTitle` MCP ツール）。本変更で summarizer 品質が上がれば不要かもしれず、必要なら **置き換えではなく override**（`meta.agentTitle ?? indexEntry.title ?? firstUserMessage` の precedence、indexer は放置）。理由：agent 主導単独は「ツールを呼ぶ確実性」と「話題 pivot 後の追従性」を失うため、haiku/sonnet ベースラインを安全網に残す。
+- #1881：単発/長期フィルタ（user query count を meta に記録 + 24h 時間フィルタ）。
+
+## 関連
+
+umbrella #1883 / #1880 / #1881

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -39,23 +39,31 @@ const SUMMARY_SCHEMA = {
   required: ["title", "summary", "keywords"],
 };
 
-// Prompt-building constants.
-const MAX_INPUT_CHARS = 8000;
-const HEAD_CHARS = 3000;
-const TAIL_CHARS = 5000;
-const PER_MESSAGE_MAX = 500;
+// Model used for summarization. Sonnet, not haiku: the title is the
+// primary way a user finds a past chat, so a weak title makes the
+// history list unusable. One cheap structured call per session is
+// negligible next to the agent turns it summarizes.
+const SUMMARY_MODEL = "sonnet";
+
+// Prompt-building constants. Sized for Sonnet's large context: the
+// window is wide enough to carry a long, topic-shifting session's
+// middle (not just head + tail), and per-message clipping keeps the
+// substance of long turns. Exported so the summarizer tests derive
+// their fixtures from them rather than hard-coding sizes that rot.
+export const MAX_INPUT_CHARS = 30000;
+export const HEAD_CHARS = 12000;
+export const TAIL_CHARS = 16000;
+export const PER_MESSAGE_MAX = 1500;
 
 // Spawn / budget constants.
 const DEFAULT_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
 // Budget cap per summarization call, forwarded to `claude
-// --max-budget-usd`. Previously 0.05 but that was tight enough
-// that a first-burst call — which pays a one-time cache creation
-// cost on haiku (~28k cache-creation tokens) — would trip the cap
-// and fail with `error_max_budget_usd` even for tiny 600-char
-// transcripts. 0.15 leaves comfortable headroom for cache
-// creation + a generous output allowance while still capping a
-// full 100-session backfill to well under $20.
-const MAX_BUDGET_USD = 0.15;
+// --max-budget-usd`. A first-burst call pays a one-time cache-creation
+// cost (~28k tokens) that on Sonnet's pricing would trip a tighter cap
+// and fail with `error_max_budget_usd` — yielding NO title at all.
+// 0.40 leaves headroom for cache creation plus the wider input window
+// while still bounding a full backfill.
+const MAX_BUDGET_USD = 0.4;
 
 // Any module that wants to drive the summarizer — including the
 // indexer — takes a SummarizeFn so tests can supply a deterministic
@@ -95,7 +103,7 @@ export function extractText(jsonlContent: string): string {
   return parts.join("\n\n");
 }
 
-// Long sessions are clipped to first ~3000 + last ~5000 chars so
+// Long sessions are clipped to first ~12000 + last ~16000 chars so
 // claude sees both the original topic and the most recent state.
 // Distinct from the simple-tail `truncate()` in `server/utils/text.ts`
 // — the summarizer needs context from both ends, not just the head.
@@ -184,7 +192,7 @@ function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string>
       "--output-format",
       "json",
       "--model",
-      "haiku",
+      SUMMARY_MODEL,
       "--max-budget-usd",
       String(MAX_BUDGET_USD),
       "--json-schema",

--- a/test/chat-index/test_summarizer.ts
+++ b/test/chat-index/test_summarizer.ts
@@ -1,6 +1,16 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { extractText, truncateMiddle, parseClaudeJsonResult, validateSummaryResult, formatSpawnError } from "../../server/workspace/chat-index/summarizer.js";
+import {
+  extractText,
+  truncateMiddle,
+  parseClaudeJsonResult,
+  validateSummaryResult,
+  formatSpawnError,
+  MAX_INPUT_CHARS,
+  HEAD_CHARS,
+  TAIL_CHARS,
+  PER_MESSAGE_MAX,
+} from "../../server/workspace/chat-index/summarizer.js";
 
 describe("extractText", () => {
   it("keeps user and assistant text turns", () => {
@@ -42,16 +52,15 @@ describe("extractText", () => {
     assert.equal(extractText(jsonl), "");
   });
 
-  it("truncates per-message at 500 chars with ellipsis", () => {
-    const long = "a".repeat(1000);
+  it("truncates an over-long message with an ellipsis", () => {
+    const long = "a".repeat(PER_MESSAGE_MAX + 1000);
     const jsonl = JSON.stringify({
       source: "user",
       type: "text",
       message: long,
     });
     const out = extractText(jsonl);
-    // Per-message limit is 500 chars + "…", still inside the
-    // overall envelope. Verify we actually clipped.
+    // Clipped to PER_MESSAGE_MAX chars + "…", so shorter than input.
     assert.ok(out.length < long.length);
     assert.ok(out.endsWith("…"));
   });
@@ -72,12 +81,12 @@ describe("truncateMiddle", () => {
     assert.equal(truncateMiddle(str), str);
   });
 
-  it("keeps head + tail for long input", () => {
-    // Anything > 8000 chars. Use distinct head/tail markers so the
-    // assertion can be specific.
-    const head = "HEAD_MARKER".padEnd(3000, "h");
-    const middle = "m".repeat(5000);
-    const tail = "TAIL_MARKER".padStart(5000, "t");
+  it("keeps head + tail and drops the middle for over-long input", () => {
+    // Distinct head/tail markers + a middle filler larger than the
+    // whole window, so the assertion can prove the middle is dropped.
+    const head = "HEAD_MARKER".padEnd(HEAD_CHARS, "h");
+    const middle = "m".repeat(MAX_INPUT_CHARS);
+    const tail = "TAIL_MARKER".padStart(TAIL_CHARS, "t");
     const out = truncateMiddle(head + middle + tail);
     assert.ok(out.length < (head + middle + tail).length);
     assert.match(out, /HEAD_MARKER/);


### PR DESCRIPTION
## Summary

チャットセッションのタイトル/サマリー品質を上げる。背景の chat-index summarizer を **haiku → sonnet** にし、**入力窓を 8000 → 30000 字**に拡げる（先頭3000+末尾5000 → 先頭12000+末尾16000、per-message 500 → 1500）。あわせて budget cap を `0.15 → 0.40` に上げ、sonnet の初回キャッシュ生成コストで budget 超過 → 無タイトルになるのを防ぐ。

タイトル自動生成自体は既に動いている（毎ターン後 + 1h backfill で summarizer が `{title, summary, keywords}` を生成し `preview` に表示）。本 PR はその**品質改善**で、特に「長い・話題が変遷したセッションで中盤が要約に入らない」弱点を窓拡大で解消する。

## Items to Confirm / Review

- [ ] **コスト**: モデルが sonnet になり 1 セッションあたり概ね $0.03〜0.13、100 件 backfill でも数ドル程度の想定。許容できるか。
- [ ] **budget cap `0.40`**: sonnet の初回キャッシュ生成（~28k tokens）＋拡大した入力窓に対して十分な余裕か（低すぎると `error_max_budget_usd` で**タイトルが付かない**）。
- [ ] **窓サイズ**（30000 / 12000 / 16000 / 1500）: sonnet の大コンテキストに対して妥当か。長セッションの中盤カバーと token コストのバランス。
- [ ] `--model sonnet` エイリアスが本番の claude CLI 経路（`claudeBinPath()`）で解決されること（既存の `haiku` と同じ渡し方）。

## User Prompt

> チャットのセッションを探すのに迷子になるので、発見性を上げたい。チャットにタイトルをつけたいが手動だと大変なので、tools で適当なタイミングでサマリーなタイトルを返してタイトルを更新したい。
>
> （調査で「タイトルは既に summarizer が自動生成している」と判明したのを受けて）これはタイミングか内容の問題だね。**モデルを sonnet に引き上げて**ほしい。ターンが少ない場合はサマライズされない？必ずよいサマリーにしたい。あと長い場合のサマリーはどうなっている？ — 実装して、この議論も issue に記載しよう。

## 実装

すべて `server/workspace/chat-index/summarizer.ts`:

| 定数 | 旧 → 新 | 理由 |
|---|---|---|
| model（新 `SUMMARY_MODEL`） | `haiku` → `sonnet` | 内容品質 |
| `MAX_BUDGET_USD` | `0.15` → `0.40` | sonnet 単価＋初回キャッシュ生成。budget 超過→無タイトル防止 |
| `MAX_INPUT_CHARS` | `8000` → `30000` | 長セッションの中盤を要約に入れる |
| `HEAD_CHARS` | `3000` → `12000` | 窓拡大 |
| `TAIL_CHARS` | `5000` → `16000` | 窓拡大（head+tail=28000 < MAX を維持し truncate が必ず縮む不変条件） |
| `PER_MESSAGE_MAX` | `500` → `1500` | 長い発言の過剰な切り詰めを緩和 |

- 4つの窓定数を `export` し、`test/chat-index/test_summarizer.ts` が定数から fixture を導出するよう変更（定数変更でテストが腐らない）。
- spawn 経路はモデル名以外不変なので、DI フェイク（`IndexerDeps.summarize`）の既存テストはそのまま通る。

### 切り分けメモ（短い/長い）

- **短い（少ターン）**: ターン数のゲートは無い。ユーザ発言が1つでもあれば要約される（skip は「実行中」「テキスト皆無」のみ）。→ 問題なし。
- **長い**: 旧設定では先頭3000+末尾5000しか見ず**中盤を捨てていた**。本 PR の窓拡大で中盤も要約に入る。

## テスト

- `test/chat-index/test_summarizer.ts` を export 定数ベースに更新。`yarn test` 該当スイート 61/61 パス。
- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn build` グリーン。

## 関連

umbrella #1883 / #1880（議論コメント記載済み）/ #1881。plan: `plans/feat-chat-summarizer-sonnet.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch the chat-index summarizer to Sonnet with a larger input window to improve session titles and summaries, and align tests and planning docs with the new configuration.

New Features:
- Improve chat session discovery by upgrading the summarizer to use the Sonnet model for generating titles, summaries, and keywords.

Enhancements:
- Expand the summarizer input window and per-message clipping limits so long, topic-shifting sessions have their middle content reflected in the summary.
- Increase the summarization budget cap to accommodate Sonnet’s pricing and cache-creation costs, reducing the chance of failed title generation.
- Export summarizer window constants and update summarizer tests to derive fixtures from them, keeping tests resilient to future tuning changes.

Documentation:
- Add a planning document outlining the Sonnet-based chat summarizer changes, rationale, and related work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sidebar summaries now use a higher-quality summarization model.
  * Summary generation can handle longer conversations with less aggressive trimming.

* **Bug Fixes**
  * Reduced excessive cutting of long messages, helping summaries retain more relevant context.
  * Improved consistency when summarizing very long single messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->