### PR TITLE
feat(sessions): record user query count and add a long-running (24h+) filter

### DIFF
--- a/plans/feat-session-long-running-filter.md
+++ b/plans/feat-session-long-running-filter.md
@@ -1,0 +1,44 @@
+# feat: 単発/長期セッションを分ける — query 数記録 + 24h フィルタ (#1881)
+
+## 背景
+
+セッションが増えると目的のチャットを探すのに迷子になる（umbrella #1883）。「1回だけのセッション」と「長く続くセッション」を分けたい。最初から24時間以上会話しているものを filter したい。
+
+## 方針（#1881 で合意）
+
+- **user query 数を meta に記録**（とっておく。将来の one-shot 判定/表示用）。
+- **v1 のフィルタは時間（24h+）**。`updatedAt - startedAt >= 24h` で判定。クライアント側で既存データから導出。
+
+## 実装
+
+### データ記録（サーバ）
+
+- `server/utils/files/session-io.ts`: `SessionMeta.userQueryCount?: number` を追加。`incrementUserQueryCount(sessionId)` mutator（read → `(count ?? 0) + 1` → write、`updateHasUnread` と同形）。
+- `server/api/routes/agent.ts`: ユーザターンの `isFirstTurn` 分岐直後（メタ書込み領域）で `incrementUserQueryCount(chatSessionId)` を1回呼ぶ。`createSessionMeta` は count を seed しないので first turn は undefined→1。
+- `server/api/routes/sessions.ts`: `buildSessionSummary` で `userQueryCount` を SessionSummary に露出（`exactOptionalPropertyTypes` 準拠の条件代入）。
+
+### クライアント型/マージ
+
+- `src/types/session.ts`: `SessionSummary.userQueryCount?: number`。
+- `src/utils/session/mergeSessions.ts`: `SERVER_OVERRIDE_KEYS` に `userQueryCount` を追加（live セッションの merge でサーバ値を保持）。
+
+### フィルタ（時間 v1）
+
+- `src/utils/session/longRunning.ts`（新・pure）: `LONG_RUNNING_THRESHOLD_MS = 24h`、`sessionDurationMs()`、`isLongRunning()`。パース不能な時刻は 0 扱い（corrupt 行で落ちない）。
+- `src/config/historyFilters.ts`: `longRunning: "longRunning"` を `HISTORY_FILTERS` と `HISTORY_FILTER_ORDER`（bookmarked の後）に追加。
+- `src/components/SessionHistoryPanel.vue`: `matchesFilter` に `longRunning → isLongRunning(session)` 分岐。
+- i18n 8 locale に `filters.longRunning`（ラベルに `(24h+)` を入れ閾値を自己説明）。
+
+## テスト
+
+- `test/utils/session/test_longRunning.ts`（新）: 閾値境界（24h inclusive）、短/長、負の span、パース不能。
+- `test/utils/files/test_session_io.ts`: `incrementUserQueryCount` の undefined→1→2、meta 無し no-op、他フィールド保持。
+
+## 将来（別 issue / フォローアップ）
+
+- `userQueryCount` を使った `one-shot`（query=1）フィルタ、または件数のバッジ表示。
+- 既存セッションの count backfill（jsonl の user text を数える）。今は記録開始のみ。
+
+## 関連
+
+umbrella #1883 / #1880 / #1881

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -5,6 +5,7 @@ import {
   createSessionMeta,
   backfillFirstUserMessage as backfillMeta,
   backfillOrigin,
+  incrementUserQueryCount,
   readSessionMetaFull,
   readSessionMeta,
   setClaudeSessionId as setClaudeId,
@@ -280,6 +281,10 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
       await backfillOrigin(chatSessionId, validOrigin);
     }
   }
+  // Count this user turn (createSessionMeta seeds no count, so the first
+  // turn bumps undefined→1). Lets the sidebar tell a one-shot apart from
+  // a long conversation.
+  await incrementUserQueryCount(chatSessionId);
 
   // Append user message for this turn
   await appendSessionLine(

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -34,6 +34,7 @@ interface SessionMeta {
   hasUnread?: boolean;
   isBookmarked?: boolean;
   origin?: SessionOrigin;
+  userQueryCount?: number;
 }
 
 async function readSessionMeta(__chatDir: string, sessionId: string): Promise<SessionMeta | null> {
@@ -77,6 +78,9 @@ export interface SessionSummary {
   // User-toggled bookmark — surfaced in the history panel as a
   // dedicated filter chip and a green role-icon tint.
   isBookmarked?: boolean;
+  // Number of user turns sent to this session. Lets the history panel
+  // tell a one-shot (1) apart from a long-running conversation.
+  userQueryCount?: number;
   // Live state from the in-memory session store. Absent when the
   // session has no active entry in the store (i.e. idle / historical).
   //
@@ -130,6 +134,20 @@ interface SessionRow {
   changeMs: number;
 }
 
+// Fold the live in-memory session state onto a summary. Extracted so
+// `buildSessionSummary` stays under the cognitive-complexity threshold.
+function applyLiveState(summary: SessionSummary, live: NonNullable<ReturnType<typeof getSession>>): void {
+  // Background generations (image/audio/movie) keep the session "busy"
+  // even when the agent turn has ended, so the sidebar indicator stays
+  // lit across view navigation.
+  summary.isRunning = live.isRunning || Object.keys(live.pendingGenerations).length > 0;
+  // Narrow predicate — must stay byte-identical to the DELETE 409 gate
+  // (`getSession(sessionId)?.isRunning`) so a caller polling this can
+  // trust "false ⇒ DELETE will be accepted".
+  summary.liveIsRunning = live.isRunning;
+  summary.statusMessage = live.statusMessage;
+}
+
 // Build a SessionSummary from the gathered inputs. Conditional spreads
 // honour the server tsconfig's `exactOptionalPropertyTypes`; that's
 // why each optional field is set with `if (… !== undefined)` rather
@@ -153,19 +171,10 @@ function buildSessionSummary(
   };
   if (meta.origin) summary.origin = meta.origin;
   if (meta.isBookmarked) summary.isBookmarked = true;
+  if (typeof meta.userQueryCount === "number") summary.userQueryCount = meta.userQueryCount;
   if (indexEntry?.summary !== undefined) summary.summary = indexEntry.summary;
   if (indexEntry?.keywords !== undefined) summary.keywords = indexEntry.keywords;
-  if (live) {
-    // Background generations (image/audio/movie) keep the session
-    // "busy" even when the agent turn has ended, so the sidebar
-    // indicator stays lit across view navigation.
-    summary.isRunning = live.isRunning || Object.keys(live.pendingGenerations).length > 0;
-    // Narrow predicate — must stay byte-identical to the DELETE
-    // 409 gate (`getSession(sessionId)?.isRunning`) so a caller
-    // polling this can trust "false ⇒ DELETE will be accepted".
-    summary.liveIsRunning = live.isRunning;
-    summary.statusMessage = live.statusMessage;
-  }
+  if (live) applyLiveState(summary, live);
   return summary;
 }
 

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -27,6 +27,10 @@ export interface SessionMeta {
   hasUnread?: boolean;
   isBookmarked?: boolean;
   origin?: SessionOrigin;
+  /** Number of user turns (queries) sent to this session. Bumped once
+   *  per user message so a one-shot session (1) can be told apart from
+   *  a long-running conversation. */
+  userQueryCount?: number;
   [key: string]: unknown;
 }
 
@@ -97,6 +101,13 @@ export async function updateIsBookmarked(sessionId: string, isBookmarked: boolea
   const meta = await readSessionMeta(sessionId, rootOverride);
   if (!meta) return;
   await writeSessionMeta(sessionId, { ...meta, isBookmarked }, rootOverride);
+}
+
+export async function incrementUserQueryCount(sessionId: string, rootOverride?: string): Promise<void> {
+  const meta = await readSessionMeta(sessionId, rootOverride);
+  if (!meta) return;
+  const current = typeof meta.userQueryCount === "number" ? meta.userQueryCount : 0;
+  await writeSessionMeta(sessionId, { ...meta, userQueryCount: current + 1 }, rootOverride);
 }
 
 // Hard-deletes the session's .jsonl event log and .json meta sidecar.

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -117,6 +117,7 @@ import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
 import { SESSION_ORIGINS } from "../types/session";
 import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, type HistoryFilter } from "../config/historyFilters";
+import { isLongRunning } from "../utils/session/longRunning";
 import { formatDate } from "../utils/format/date";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 import FilterChip from "./FilterChip.vue";
@@ -162,6 +163,7 @@ function matchesFilter(session: SessionSummary, filter: HistoryFilter): boolean 
   if (filter === HISTORY_FILTERS.all) return true;
   if (filter === HISTORY_FILTERS.unread) return session.hasUnread === true;
   if (filter === HISTORY_FILTERS.bookmarked) return session.isBookmarked === true;
+  if (filter === HISTORY_FILTERS.longRunning) return isLongRunning(session);
   return originOf(session) === filter;
 }
 

--- a/src/config/historyFilters.ts
+++ b/src/config/historyFilters.ts
@@ -10,6 +10,10 @@ export const HISTORY_FILTERS = {
   all: "all",
   unread: "unread",
   bookmarked: "bookmarked",
+  // Session-property filter (not an origin): conversations alive for
+  // 24h+ (updatedAt − startedAt). Lets a long-running chat be told
+  // apart from a one-shot.
+  longRunning: "longRunning",
   human: SESSION_ORIGINS.human,
   scheduler: SESSION_ORIGINS.scheduler,
   skill: SESSION_ORIGINS.skill,
@@ -25,6 +29,7 @@ export const HISTORY_FILTER_ORDER: readonly HistoryFilter[] = [
   HISTORY_FILTERS.all,
   HISTORY_FILTERS.unread,
   HISTORY_FILTERS.bookmarked,
+  HISTORY_FILTERS.longRunning,
   HISTORY_FILTERS.human,
   HISTORY_FILTERS.scheduler,
   HISTORY_FILTERS.skill,

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -52,6 +52,7 @@ const deMessages = {
       all: "Alle",
       unread: "Ungelesen",
       bookmarked: "Gemerkt",
+      longRunning: "Langlaufend (24h+)",
       human: "Mensch",
       scheduler: "Scheduler",
       skill: "Skill",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -74,6 +74,7 @@ const enMessages = {
       all: "All",
       unread: "Unread",
       bookmarked: "Bookmarked",
+      longRunning: "Long-running (24h+)",
       human: "Human",
       scheduler: "Scheduler",
       skill: "Skill",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -57,6 +57,7 @@ const esMessages = {
       all: "Todas",
       unread: "No leídas",
       bookmarked: "Marcadas",
+      longRunning: "De larga duración (24h+)",
       human: "Persona",
       scheduler: "Programador",
       skill: "Skill",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -52,6 +52,7 @@ const frMessages = {
       all: "Toutes",
       unread: "Non lues",
       bookmarked: "Favoris",
+      longRunning: "Longue durée (24h+)",
       human: "Humain",
       scheduler: "Planificateur",
       skill: "Skill",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -59,6 +59,7 @@ const jaMessages = {
       all: "すべて",
       unread: "未読",
       bookmarked: "ブックマーク",
+      longRunning: "長期 (24h+)",
       human: "手動",
       scheduler: "スケジューラ",
       skill: "スキル",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -59,6 +59,7 @@ const koMessages = {
       all: "전체",
       unread: "읽지 않음",
       bookmarked: "북마크",
+      longRunning: "장기 (24h+)",
       human: "사람",
       scheduler: "스케줄러",
       skill: "스킬",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -52,6 +52,7 @@ const ptBRMessages = {
       all: "Todas",
       unread: "Não lidas",
       bookmarked: "Favoritas",
+      longRunning: "De longa duração (24h+)",
       human: "Pessoa",
       scheduler: "Agendador",
       skill: "Skill",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -57,6 +57,7 @@ const zhMessages = {
       all: "全部",
       unread: "未读",
       bookmarked: "已收藏",
+      longRunning: "长期 (24h+)",
       human: "人工",
       scheduler: "调度器",
       skill: "技能",

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -68,6 +68,9 @@ export interface SessionSummary {
   origin?: SessionOrigin;
   /** User-set bookmark flag. Persisted in the meta sidecar. */
   isBookmarked?: boolean;
+  /** Number of user turns sent to this session (server-derived from the
+   *  meta sidecar). One-shot sessions have 1; long conversations more. */
+  userQueryCount?: number;
   // Live state from the server session store (present when the
   // session has an active in-memory entry on the server).
   //

--- a/src/utils/session/longRunning.ts
+++ b/src/utils/session/longRunning.ts
@@ -1,0 +1,22 @@
+import type { SessionSummary } from "../../types/session";
+
+// A session counts as "long-running" once its activity span — most
+// recent update minus start — reaches a full day. Separates sustained
+// conversations from one-shot sessions in the history filter.
+export const LONG_RUNNING_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+type Span = Pick<SessionSummary, "startedAt" | "updatedAt">;
+
+// Elapsed time between a session's start and its most recent activity.
+// Unparseable timestamps yield 0 so a corrupt row is treated as short
+// rather than crashing the filter.
+export function sessionDurationMs(session: Span): number {
+  const startedMs = Date.parse(session.startedAt);
+  const updatedMs = Date.parse(session.updatedAt);
+  if (Number.isNaN(startedMs) || Number.isNaN(updatedMs)) return 0;
+  return Math.max(0, updatedMs - startedMs);
+}
+
+export function isLongRunning(session: Span): boolean {
+  return sessionDurationMs(session) >= LONG_RUNNING_THRESHOLD_MS;
+}

--- a/src/utils/session/mergeSessions.ts
+++ b/src/utils/session/mergeSessions.ts
@@ -18,7 +18,7 @@ import type { SessionSummary, ActiveSession } from "../../types/session";
 // local fallback — copy them only when the server has actually set
 // them, otherwise they'd surface as explicit `undefined` in shallow
 // copies downstream.
-const SERVER_OVERRIDE_KEYS = ["summary", "keywords", "origin", "isBookmarked", "hasUnread", "statusMessage"] as const;
+const SERVER_OVERRIDE_KEYS = ["summary", "keywords", "origin", "isBookmarked", "hasUnread", "statusMessage", "userQueryCount"] as const;
 
 export function pickServerOverrides(serverEntry: SessionSummary | undefined): Partial<SessionSummary> {
   if (!serverEntry) return {};

--- a/test/utils/files/test_session_io.ts
+++ b/test/utils/files/test_session_io.ts
@@ -8,6 +8,7 @@ import {
   readSessionMeta,
   writeSessionMeta,
   updateHasUnread,
+  incrementUserQueryCount,
   backfillFirstUserMessage,
   setClaudeSessionId,
   clearClaudeSessionId,
@@ -76,6 +77,30 @@ describe("updateHasUnread", () => {
   it("no-ops when session meta does not exist", async () => {
     // Should not throw
     await updateHasUnread("ghost", false, root);
+  });
+});
+
+describe("incrementUserQueryCount", () => {
+  it("bumps undefined → 1 on the first turn, then 1 → 2", async () => {
+    await writeSessionMeta("count-test", { roleId: "general" }, root);
+    await incrementUserQueryCount("count-test", root);
+    assert.equal((await readSessionMeta("count-test", root))?.userQueryCount, 1);
+    await incrementUserQueryCount("count-test", root);
+    assert.equal((await readSessionMeta("count-test", root))?.userQueryCount, 2);
+  });
+
+  it("no-ops when session meta does not exist", async () => {
+    await incrementUserQueryCount("count-ghost", root);
+    assert.equal(await readSessionMeta("count-ghost", root), null);
+  });
+
+  it("preserves other meta fields", async () => {
+    await writeSessionMeta("count-preserve", { roleId: "office", isBookmarked: true }, root);
+    await incrementUserQueryCount("count-preserve", root);
+    const meta = await readSessionMeta("count-preserve", root);
+    assert.equal(meta?.roleId, "office");
+    assert.equal(meta?.isBookmarked, true);
+    assert.equal(meta?.userQueryCount, 1);
   });
 });
 

--- a/test/utils/session/test_longRunning.ts
+++ b/test/utils/session/test_longRunning.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isLongRunning, sessionDurationMs, LONG_RUNNING_THRESHOLD_MS } from "../../../src/utils/session/longRunning.js";
+
+const START = "2026-01-01T00:00:00.000Z";
+const startMs = Date.parse(START);
+const isoAt = (offsetMs: number) => new Date(startMs + offsetMs).toISOString();
+
+describe("sessionDurationMs", () => {
+  it("returns the span between startedAt and updatedAt", () => {
+    assert.equal(sessionDurationMs({ startedAt: START, updatedAt: isoAt(3600_000) }), 3600_000);
+  });
+
+  it("clamps a negative span (updatedAt before startedAt) to 0", () => {
+    assert.equal(sessionDurationMs({ startedAt: START, updatedAt: isoAt(-5000) }), 0);
+  });
+
+  it("returns 0 for unparseable timestamps", () => {
+    assert.equal(sessionDurationMs({ startedAt: "not-a-date", updatedAt: START }), 0);
+    assert.equal(sessionDurationMs({ startedAt: START, updatedAt: "" }), 0);
+  });
+});
+
+describe("isLongRunning", () => {
+  it("is false for a short, one-shot session", () => {
+    assert.equal(isLongRunning({ startedAt: START, updatedAt: isoAt(3600_000) }), false);
+  });
+
+  it("is true exactly at the 24h threshold (inclusive)", () => {
+    assert.equal(isLongRunning({ startedAt: START, updatedAt: isoAt(LONG_RUNNING_THRESHOLD_MS) }), true);
+  });
+
+  it("is false just under the threshold", () => {
+    assert.equal(isLongRunning({ startedAt: START, updatedAt: isoAt(LONG_RUNNING_THRESHOLD_MS - 1000) }), false);
+  });
+
+  it("is true for a multi-day conversation", () => {
+    assert.equal(isLongRunning({ startedAt: START, updatedAt: isoAt(LONG_RUNNING_THRESHOLD_MS * 5) }), true);
+  });
+
+  it("is false when timestamps are unparseable", () => {
+    assert.equal(isLongRunning({ startedAt: "x", updatedAt: "y" }), false);
+  });
+});


### PR DESCRIPTION
## Summary

セッション履歴で「単発のセッション」と「長く続くセッション」を分けられるようにする (#1881)。2つの独立した変更:

1. **user query 数を記録**: ユーザターンごとに `meta.userQueryCount` を +1。one-shot（1）と長い会話を将来確実に区別できるよう、今からデータを貯め始める。
2. **`long-running` フィルタ（時間ベース v1）**: 履歴パネルに「24h+」フィルタを追加。`updatedAt − startedAt >= 24h` を既存データから導出（サーバ追加クエリ不要）。

## Items to Confirm / Review

- [ ] **「24時間以上」の定義**: 「開始から最終活動までの経過」(`updatedAt − startedAt`) を採用。実会話時間ではない。これで意図に合うか。
- [ ] **`userQueryCount` は記録のみで未フィルタ**: 合意どおり v1 は時間でフィルタし、query 数は将来の one-shot 判定/表示用に貯めるだけ。これでよいか。
- [ ] **既存セッションは count 無し**（`undefined`）。backfill はしていない（今から記録開始）。必要なら別途。
- [ ] **増分ポイント**: `agent.ts` のユーザターン `isFirstTurn` 分岐直後で1回。first turn は `createSessionMeta` が seed しないので undefined→1。多重カウントが無いか。
- [ ] フィルタの並び順: ピル行で `bookmarked` の後（origin フィルタ群の前）に配置。

## User Prompt

> filter で「1回だけのセッション」と「長いセッション」を分けたい。最初から24時間以上会話しているセッションにフラグを立てて（もしくは時間を record して）filter したい。
>
> （実装方針として）ターン数というか、ユーザのクエリ数はとっておいたほうがよい。そのうえで時間で filter がよい。まずはそれで。（#1880 の summarizer PR と）並行して #1881 も。

## 実装

### データ記録（サーバ）
- `server/utils/files/session-io.ts`: `SessionMeta.userQueryCount?: number` + `incrementUserQueryCount()` mutator（`updateHasUnread` と同形）。
- `server/api/routes/agent.ts`: ユーザターンの meta 書込み領域で `incrementUserQueryCount(chatSessionId)` を1回。
- `server/api/routes/sessions.ts`: ローカル `SessionMeta` / `SessionSummary` に `userQueryCount` を追加し `buildSessionSummary` で露出。ついでに複雑度を閾値内に保つため live 適用を `applyLiveState()` に抽出。

### クライアント
- `src/types/session.ts` + `src/utils/session/mergeSessions.ts`（`SERVER_OVERRIDE_KEYS`）: `userQueryCount` を型に追加し merge で保持。
- `src/utils/session/longRunning.ts`（新・pure）: `LONG_RUNNING_THRESHOLD_MS = 24h`、`sessionDurationMs()`、`isLongRunning()`。パース不能な時刻は 0 扱い。
- `src/config/historyFilters.ts`: `longRunning` フィルタを追加。
- `src/components/SessionHistoryPanel.vue`: `matchesFilter` に分岐。
- i18n 8 locale に `filters.longRunning`（ラベルに `(24h+)` を入れ閾値を自己説明）。

## テスト

- `test/utils/session/test_longRunning.ts`（新）: 24h 境界（inclusive）、短/長、負の span、パース不能。
- `test/utils/files/test_session_io.ts`: `incrementUserQueryCount` の undefined→1→2、meta 無し no-op、他フィールド保持。
- 影響範囲（session-io / sessionsRoute / mergeSessions / agent route / lang）テスト全パス。`yarn format` / `lint`(0 err) / `typecheck` / `build` グリーン。

## 将来（フォローアップ）
- `userQueryCount` を使った `one-shot`(=1) フィルタ／件数バッジ。
- 既存セッションの count backfill（jsonl の user text を数える）。

## 関連
umbrella #1883 / #1880 / #1881。plan: `plans/feat-session-long-running-filter.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Track per-session user query counts and add a long-running (24h+) history filter to distinguish sustained conversations from one-shot sessions.

New Features:
- Record user query counts in session metadata and expose them in session summaries for future one-shot vs long-conversation distinctions.
- Introduce a long-running (24h+) filter in the session history panel based on session duration derived from existing timestamps.

Enhancements:
- Refactor session summary construction by extracting live state merging into a dedicated helper to reduce complexity.

Documentation:
- Add a lightweight plan document describing the approach for separating one-shot and long-term sessions via query counting and a 24h duration filter.

Tests:
- Add unit tests for long-running session duration and threshold behavior, including edge cases and invalid timestamps.
- Extend session meta tests to cover user query count incrementation, no-op behavior when meta is missing, and preservation of other fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Long-running (24h+)” session history filter to help find conversations that stay active over multiple days.
  * Session history now shows more accurate session summaries, including a new count of user turns where available.

* **Bug Fixes**
  * Improved handling of session timing so unusually formatted or incomplete timestamps are treated safely.
  * Preserved server-provided session counts when merging live session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->