### PR TITLE
feat: exclude scheduler sessions from long-running (24h+) filter (#1886)

### DIFF
--- a/plans/feat-long-running-exclude-scheduler.md
+++ b/plans/feat-long-running-exclude-scheduler.md
@@ -1,0 +1,37 @@
+# feat: exclude scheduler-origin sessions from the long-running (24h+) filter
+
+Date: 2026-07-01
+Follow-up to #1885 (long-running 24h+ filter).
+
+## Problem
+
+The `longRunning` history filter added in #1885 matches any session whose
+span (`updatedAt − startedAt`) reaches 24h. A `scheduler`-origin session is
+a single recurring session kept alive for days, so it trivially crosses the
+threshold and pollutes the filter even though it is not a conversation the
+user had.
+
+## Decision
+
+Restrict the `longRunning` filter to exclude only `scheduler`-origin
+sessions. `human`, `skill`, `bridge`, and `plugin:*` stay — those are real
+back-and-forth conversations that can legitimately run long. (Chosen over
+"human only" so bridge/skill conversations are not dropped.)
+
+## Changes
+
+- `src/utils/session/longRunning.ts`: new pure helper
+  `isLongRunningConversation(session)` = `isLongRunning(session) && origin !== scheduler`.
+- `src/components/SessionHistoryPanel.vue`: `matchesFilter` calls the new helper
+  for `longRunning` instead of `isLongRunning`.
+- `src/config/historyFilters.ts`: document the scheduler exclusion on the
+  `longRunning` entry.
+- `test/utils/session/test_longRunning.ts`: cover human / undefined / scheduler /
+  skill / bridge / plugin and short-span cases.
+
+## Notes
+
+- Pure-logic change only; no server, type, or i18n changes (the
+  "Long-running (24h+)" label is unchanged).
+- The `longRunning` pill count updates automatically — `countByOrigin` reuses
+  `matchesFilter`.

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -117,7 +117,7 @@ import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
 import { SESSION_ORIGINS } from "../types/session";
 import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, type HistoryFilter } from "../config/historyFilters";
-import { isLongRunning } from "../utils/session/longRunning";
+import { isLongRunningConversation } from "../utils/session/longRunning";
 import { formatDate } from "../utils/format/date";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 import FilterChip from "./FilterChip.vue";
@@ -163,7 +163,7 @@ function matchesFilter(session: SessionSummary, filter: HistoryFilter): boolean 
   if (filter === HISTORY_FILTERS.all) return true;
   if (filter === HISTORY_FILTERS.unread) return session.hasUnread === true;
   if (filter === HISTORY_FILTERS.bookmarked) return session.isBookmarked === true;
-  if (filter === HISTORY_FILTERS.longRunning) return isLongRunning(session);
+  if (filter === HISTORY_FILTERS.longRunning) return isLongRunningConversation(session);
   return originOf(session) === filter;
 }
 

--- a/src/config/historyFilters.ts
+++ b/src/config/historyFilters.ts
@@ -12,7 +12,9 @@ export const HISTORY_FILTERS = {
   bookmarked: "bookmarked",
   // Session-property filter (not an origin): conversations alive for
   // 24h+ (updatedAt − startedAt). Lets a long-running chat be told
-  // apart from a one-shot.
+  // apart from a one-shot. Scheduler-origin sessions are excluded — a
+  // recurring schedule keeps one session alive for days, so it would
+  // always match without being a real conversation.
   longRunning: "longRunning",
   human: SESSION_ORIGINS.human,
   scheduler: SESSION_ORIGINS.scheduler,

--- a/src/utils/session/longRunning.ts
+++ b/src/utils/session/longRunning.ts
@@ -1,4 +1,4 @@
-import type { SessionSummary } from "../../types/session";
+import { SESSION_ORIGINS, type SessionSummary } from "../../types/session";
 
 // A session counts as "long-running" once its activity span — most
 // recent update minus start — reaches a full day. Separates sustained
@@ -19,4 +19,15 @@ export function sessionDurationMs(session: Span): number {
 
 export function isLongRunning(session: Span): boolean {
   return sessionDurationMs(session) >= LONG_RUNNING_THRESHOLD_MS;
+}
+
+type OriginedSpan = Span & Pick<SessionSummary, "origin">;
+
+// The long-running filter targets sustained conversations the user had.
+// A scheduler-origin session is excluded even past 24h: a recurring
+// schedule keeps one session alive for days, so its span trivially
+// crosses the threshold without being a real back-and-forth. Other
+// origins (human, skill, bridge, plugin) stay — those are conversations.
+export function isLongRunningConversation(session: OriginedSpan): boolean {
+  return isLongRunning(session) && session.origin !== SESSION_ORIGINS.scheduler;
 }

--- a/test/utils/session/test_longRunning.ts
+++ b/test/utils/session/test_longRunning.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isLongRunning, sessionDurationMs, LONG_RUNNING_THRESHOLD_MS } from "../../../src/utils/session/longRunning.js";
+import { isLongRunning, isLongRunningConversation, sessionDurationMs, LONG_RUNNING_THRESHOLD_MS } from "../../../src/utils/session/longRunning.js";
+import { SESSION_ORIGINS } from "../../../src/types/session.js";
 
 const START = "2026-01-01T00:00:00.000Z";
 const startMs = Date.parse(START);
@@ -40,5 +41,36 @@ describe("isLongRunning", () => {
 
   it("is false when timestamps are unparseable", () => {
     assert.equal(isLongRunning({ startedAt: "x", updatedAt: "y" }), false);
+  });
+});
+
+describe("isLongRunningConversation", () => {
+  const longSpan = { startedAt: START, updatedAt: isoAt(LONG_RUNNING_THRESHOLD_MS) };
+  const shortSpan = { startedAt: START, updatedAt: isoAt(3600_000) };
+
+  it("is true for a long human session", () => {
+    assert.equal(isLongRunningConversation({ ...longSpan, origin: SESSION_ORIGINS.human }), true);
+  });
+
+  it("is true for a long session with no origin (defaults to human)", () => {
+    assert.equal(isLongRunningConversation(longSpan), true);
+  });
+
+  it("excludes a long scheduler session", () => {
+    assert.equal(isLongRunningConversation({ ...longSpan, origin: SESSION_ORIGINS.scheduler }), false);
+  });
+
+  it("keeps long skill and bridge sessions", () => {
+    assert.equal(isLongRunningConversation({ ...longSpan, origin: SESSION_ORIGINS.skill }), true);
+    assert.equal(isLongRunningConversation({ ...longSpan, origin: SESSION_ORIGINS.bridge }), true);
+  });
+
+  it("keeps a long plugin-origin session", () => {
+    assert.equal(isLongRunningConversation({ ...longSpan, origin: "plugin:@mulmoclaude/foo" }), true);
+  });
+
+  it("is false for a short session regardless of origin", () => {
+    assert.equal(isLongRunningConversation({ ...shortSpan, origin: SESSION_ORIGINS.human }), false);
+    assert.equal(isLongRunningConversation({ ...shortSpan, origin: SESSION_ORIGINS.scheduler }), false);
   });
 });


### PR DESCRIPTION
## Summary

長時間(24h+)フィルタ (#1885 で追加) が **scheduler 由来のセッションを除外**するようにする。定期実行(scheduler)のセッションは1つが何日も生き続けるため `updatedAt − startedAt >= 24h` を常に満たし、実会話でないのに長時間フィルタを汚していた。`human` / `skill` / `bridge` / `plugin:*` は実際の会話なので残す。

## Items to Confirm / Review

- [ ] **除外範囲の選択**: 「scheduler だけ除外」を採用（human/skill/bridge/plugin は残す）。「human のみ」ではない点をご確認ください（bridge/skill の長時間会話を落とさないため）。
- [ ] **純粋関数への抽出**: 判定を `isLongRunningConversation()`（純粋・テスト可能）に切り出し、`.vue` の `matchesFilter` から呼ぶ形にした。
- [ ] **undefined origin の扱い**: origin 未設定は human 扱い（`undefined !== "scheduler"` で残る）。既存の後方互換に合致。
- [ ] **ラベル据え置き**: 「Long-running (24h+)」の i18n ラベルは変更なし（挙動の絞り込みのみ）。ピル件数 `countByOrigin` は `matchesFilter` 再利用で自動追従。

## User Prompt

> #1885 の長時間フィルタについて、表示するのはユーザが手動で開始したセッションだけにしたい。スケジューラー由来は除外する。
>
> （方針確認の回答）除外は **scheduler だけ**でよい。human / skill / bridge / plugin は残す。

## 実装

| ファイル | 変更 |
|---|---|
| `src/utils/session/longRunning.ts` | 純粋関数 `isLongRunningConversation()` を追加（`isLongRunning(s) && origin !== scheduler`） |
| `src/components/SessionHistoryPanel.vue` | `matchesFilter` の `longRunning` 分岐を新ヘルパーに変更 |
| `src/config/historyFilters.ts` | `longRunning` エントリに scheduler 除外の理由コメントを追記 |
| `test/utils/session/test_longRunning.ts` | human / 未設定 / scheduler / skill / bridge / plugin / 短時間 をカバー（+7 ケース） |
| `plans/feat-long-running-exclude-scheduler.md` | 計画書（新規） |

## テスト

`test_longRunning.ts` 14 件 pass。`yarn format` / `lint`(0 error) / `typecheck` / `build` すべてグリーン。サーバ / 型 / i18n 変更なし。

Closes #1886
follow-up of #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Exclude scheduler-origin sessions from the long-running (24h+) history filter while keeping other origins, and centralize the long-running conversation check in a reusable helper.

Bug Fixes:
- Adjust the long-running (24h+) history filter so scheduler-origin sessions are no longer included, avoiding pollution by non-conversational recurring jobs.

Enhancements:
- Introduce an `isLongRunningConversation` utility to encapsulate long-running conversation logic based on duration and origin and reuse it from the session history panel.
- Document the scheduler exclusion behavior in the `longRunning` history filter configuration and add plan documentation for this behavior.

Tests:
- Expand long-running session tests to cover various origins (human, undefined, scheduler, skill, bridge, plugin) and short-span sessions for the new helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refined the “Long-running (24h+)” session filter to exclude scheduler-origin sessions while keeping other session origins included.
  * Added clearer filter behavior so long-running counts and results better match what users expect.

* **Bug Fixes**
  * Prevented recurring scheduler sessions from appearing in long-running history results.
  * Expanded validation to cover long and short sessions across multiple origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->