### PR TITLE
fix(chat-service): preserve session role when /switch connects a chat (#1888)

### DIFF
--- a/packages/chat-service/package.json
+++ b/packages/chat-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/chat-service",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Server-side chat service for MulmoBridge — socket.io + REST bridge to Claude Code agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/chat-service/src/chat-state.ts
+++ b/packages/chat-service/src/chat-state.ts
@@ -26,7 +26,15 @@ export interface ChatStateStore {
   getChatState(transportId: string, externalChatId: string): Promise<TransportChatState | null>;
   setChatState(transportId: string, state: TransportChatState): Promise<void>;
   resetChatState(transportId: string, externalChatId: string, roleId: string): Promise<TransportChatState>;
-  connectSession(transportId: string, externalChatId: string, chatSessionId: string): Promise<TransportChatState | null>;
+  /** Repoint the persisted chat state at another session. `roleId` is
+   *  optional: when omitted, the existing state's roleId is preserved
+   *  (the old default, kept for HTTP `/connect` callers that only know
+   *  the session ID). Callers that DO know the target session's role —
+   *  notably the `/switch` command, which already has `SessionSummary.roleId`
+   *  from `/sessions` — MUST pass it, otherwise the file-backed state
+   *  drifts into a stale-role / new-session pair and the next relay's
+   *  `startChat` uses the mismatched pair (issue #1888). */
+  connectSession(transportId: string, externalChatId: string, chatSessionId: string, roleId?: string): Promise<TransportChatState | null>;
   generateSessionId(transportId: string, externalChatId: string): string;
 }
 
@@ -87,12 +95,17 @@ export function createChatStateStore(opts: { transportsDir: string; logger: Logg
     return state;
   };
 
-  const connectSession = async (transportId: string, externalChatId: string, chatSessionId: string): Promise<TransportChatState | null> => {
+  const connectSession = async (transportId: string, externalChatId: string, chatSessionId: string, roleId?: string): Promise<TransportChatState | null> => {
     const existing = await getChatState(transportId, externalChatId);
     if (!existing) return null;
     const updated: TransportChatState = {
       ...existing,
       sessionId: chatSessionId,
+      // A missing `roleId` arg means "preserve the current role" (that's
+      // the HTTP `/connect` route, which doesn't know the target's role);
+      // when the caller passes one (`/switch`), take theirs so state and
+      // downstream `startChat` agree on which role runs the resumed session.
+      ...(roleId !== undefined ? { roleId } : {}),
       updatedAt: new Date().toISOString(),
     };
     await setChatState(transportId, updated);
@@ -100,6 +113,7 @@ export function createChatStateStore(opts: { transportsDir: string; logger: Logg
       transportId,
       externalChatId,
       sessionId: chatSessionId,
+      roleId: updated.roleId,
     });
     return updated;
   };

--- a/packages/chat-service/src/commands.ts
+++ b/packages/chat-service/src/commands.ts
@@ -263,7 +263,12 @@ export function createCommandHandler(opts: {
         };
       }
     }
-    const updated = await connectSession(transportId, chatState.externalChatId, target.id);
+    // Pass `target.roleId` so the persisted state's role tracks the session
+    // we just repointed at. Without this, `connectSession` would swap the
+    // sessionId but leave the previous role in place, and the next relay's
+    // `startChat` would run the resumed session under the wrong role
+    // (issue #1888).
+    const updated = await connectSession(transportId, chatState.externalChatId, target.id, target.roleId);
     if (!updated) {
       return { reply: "Failed to switch session." };
     }

--- a/packages/chat-service/test/test_chat_state.ts
+++ b/packages/chat-service/test/test_chat_state.ts
@@ -1,0 +1,61 @@
+// Pins `connectSession`'s two-mode contract added for #1888:
+//   - roleId passed → persisted state's role is replaced by the caller's value
+//   - roleId omitted → persisted state's role is preserved (HTTP /connect path)
+// The rest of `chat-state.ts` is exercised through the surrounding command +
+// relay tests; this file only guards the roleId propagation semantics.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createChatStateStore } from "../src/chat-state.ts";
+import type { Logger } from "../src/types.ts";
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+describe("chat-state.connectSession — roleId propagation (issue #1888)", () => {
+  let transportsDir: string;
+
+  beforeEach(() => {
+    transportsDir = mkdtempSync(path.join(tmpdir(), "chat-state-"));
+  });
+
+  afterEach(() => {
+    rmSync(transportsDir, { recursive: true, force: true });
+  });
+
+  it("replaces roleId when the caller passes one (the /switch path)", async () => {
+    const store = createChatStateStore({ transportsDir, logger: silentLogger });
+    await store.resetChatState("telegram", "chat-1", "general");
+    const updated = await store.connectSession("telegram", "chat-1", "office-session", "office");
+    assert.ok(updated);
+    assert.equal(updated?.sessionId, "office-session");
+    assert.equal(updated?.roleId, "office", "the target session's role must overwrite the prior role");
+    // Re-read to confirm the file-backed copy matches (this is the value the
+    // next relay's startChat will pick up).
+    const reloaded = await store.getChatState("telegram", "chat-1");
+    assert.equal(reloaded?.roleId, "office");
+  });
+
+  it("preserves roleId when the caller omits it (the HTTP /connect path)", async () => {
+    const store = createChatStateStore({ transportsDir, logger: silentLogger });
+    await store.resetChatState("telegram", "chat-1", "general");
+    const updated = await store.connectSession("telegram", "chat-1", "some-session");
+    assert.ok(updated);
+    assert.equal(updated?.sessionId, "some-session");
+    assert.equal(updated?.roleId, "general", "omitted roleId ⇒ keep the existing one (backward-compat for /connect)");
+  });
+
+  it("returns null when the chat state doesn't exist yet", async () => {
+    const store = createChatStateStore({ transportsDir, logger: silentLogger });
+    const result = await store.connectSession("telegram", "never-seen", "sess", "office");
+    assert.equal(result, null);
+  });
+});

--- a/packages/chat-service/test/test_commands.ts
+++ b/packages/chat-service/test/test_commands.ts
@@ -114,6 +114,65 @@ describe("/switch command", () => {
     assert.ok(result.reply.includes("not found"));
   });
 
+  it("propagates the target session's roleId when switching by number (regression, issue #1888)", async () => {
+    // Bridge state currently uses "general"; the target session (mockSessions[1] = s2)
+    // is under "office". Before the fix, connectSession only received the sessionId
+    // so the persisted state kept roleId="general" and the next relay's startChat
+    // ran the resumed office session under the general role.
+    const capturedArgs: { sessionId?: string; roleId?: string } = {};
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: (id) => roles.find((r) => r.id === id) ?? roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      // Mock mirrors the real chat-state.ts behaviour: when roleId is passed,
+      // stamp it into the returned state; otherwise preserve the incoming role.
+      connectSession: async (_t, _c, sessionId, roleId) => {
+        capturedArgs.sessionId = sessionId;
+        capturedArgs.roleId = roleId;
+        return makeState({ sessionId, ...(roleId !== undefined ? { roleId } : {}) });
+      },
+      listSessions: async ({ limit, offset }) => ({
+        sessions: mockSessions.slice(offset, offset + limit),
+        total: mockSessions.length,
+      }),
+    });
+    await handler("/sessions", "telegram", makeState());
+    const result = await handler("/switch 2", "telegram", makeState({ roleId: "general" }));
+    assert.ok(result);
+    assert.equal(capturedArgs.sessionId, "s2");
+    assert.equal(capturedArgs.roleId, "office", "target session's roleId must reach connectSession");
+    assert.ok(result.nextState);
+    assert.equal(result.nextState?.roleId, "office", "returned nextState must reflect the target session's role");
+    assert.equal(result.nextState?.sessionId, "s2");
+  });
+
+  it("propagates the target session's roleId when switching by session ID (non-numeric branch)", async () => {
+    // Same bug shape as the numeric branch, on the `/switch <sessionId>` path
+    // (commands.ts line ~259). Covering both branches so a future refactor
+    // that only fixes one is caught.
+    const capturedArgs: { sessionId?: string; roleId?: string } = {};
+    const handler = createCommandHandler({
+      loadAllRoles: () => roles,
+      getRole: (id) => roles.find((r) => r.id === id) ?? roles[0],
+      resetChatState: async (_t, _c, roleId) => makeState({ roleId }),
+      connectSession: async (_t, _c, sessionId, roleId) => {
+        capturedArgs.sessionId = sessionId;
+        capturedArgs.roleId = roleId;
+        return makeState({ sessionId, ...(roleId !== undefined ? { roleId } : {}) });
+      },
+      listSessions: async ({ limit, offset }) => ({
+        sessions: mockSessions.slice(offset, offset + limit),
+        total: mockSessions.length,
+      }),
+    });
+    await handler("/sessions", "telegram", makeState());
+    const result = await handler("/switch s2", "telegram", makeState({ roleId: "general" }));
+    assert.ok(result);
+    assert.equal(capturedArgs.roleId, "office");
+    assert.equal(result.nextState?.roleId, "office");
+    assert.equal(result.nextState?.sessionId, "s2");
+  });
+
   it("per-chat cache isolation", async () => {
     const handler = createCommandHandler({
       loadAllRoles: () => roles,


### PR DESCRIPTION
## Summary

Closes #1888 (reported by @ag-linden — thanks for the precise diagnosis).

`ChatStateStore.connectSession` only accepted a session ID, so when `/switch` repointed the persisted state at another session the old `roleId` stayed put. The next relay's `startChat` then resumed the new session under the previous role — e.g. a Telegram chat mapped to a `general` bridge state that `/switch`ed to an `office` session kept running the office session under `general`.

Fix per the reporter's proposal:

- Extend `connectSession(...)` with an optional 4th arg `roleId`. When present, it overwrites the persisted role; when omitted, the previous role is preserved (unchanged behaviour for the HTTP `/connect` route, which doesn't know the target session's role).
- `/switch` passes `target.roleId` through — it already has `SessionSummary.roleId` from the `/sessions` cache, so the info was available and just wasn't propagated.

Bumps `@mulmobridge/chat-service` 0.1.4 → 0.1.5 (public API grows one optional param — patch bump since existing callers unchanged).

## Items to Confirm / Review

- **Backward compat**. `connectSession(t, c, sid)` — three args, no roleId — behaves exactly as before (preserves existing role). The HTTP `/connect` route in `index.ts` still calls it with three args and is unchanged.
- **Both `/switch` branches covered**. The numeric-index branch (`/switch 2`) and the non-numeric-sessionId branch (`/switch <sessionId>` at `commands.ts:259`) both take the same code path through `connectSession`, so both are now correct; regression tests pin both.
- **`chat-state.ts` two-mode contract test** (`test_chat_state.ts`, new) proves the file-backed reload also carries the new role — so the very next process spawn (relay restart, etc.) sees the updated role, not just the in-memory `nextState`.
- **Deferred**: the HTTP `/connect` route doesn't get a `roleId` — it doesn't have access to the target's role today, and wiring one in requires a server-side session-role lookup that's out of scope for this fix. Reporter flagged this in the "open question" of the issue; we can revisit if it turns out to hit the same drift in production.

## Regression scenario the reporter described (reproduced on `main`)

- Telegram chat currently mapped to a `general` bridge state.
- `/sessions` lists an existing `office` session.
- `/switch 1` replies "connected to that Office session".
- Persisted state points at the office session ID but still has `roleId: "general"`.
- Next relay turn's `startChat(office-session-id, general)` runs the office session under general's tools / system prompt.

After the fix, `roleId` becomes `"office"` on both the returned `nextState` and the reloaded file-backed state — verified by the two new command tests + the three new chat-state tests.

## Test plan

- [x] `tsx --test packages/chat-service/test/test_commands.ts packages/chat-service/test/test_chat_state.ts` — 36 pass / 0 fail
- [x] `yarn workspace @mulmobridge/chat-service run typecheck` — clean
- [x] `yarn format` / `yarn lint` on the touched files — clean
- [ ] Manual: bring up a bridge, `/switch` into an office session from general, send a message, confirm the reply uses office tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure chat session switches keep the persisted role in sync with the target session to avoid running sessions under the wrong role.

Bug Fixes:
- Fix /switch so that switching to an existing session also updates the persisted role to the target session's role instead of preserving the previous role.

Enhancements:
- Extend ChatStateStore.connectSession with an optional roleId parameter that, when provided, updates the stored role while keeping existing callers backward compatible.

Build:
- Bump @mulmobridge/chat-service package version from 0.1.4 to 0.1.5.

Tests:
- Add command and chat-state tests to cover roleId propagation for both /switch code paths and the new connectSession role handling contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switching to a saved chat session now keeps the session’s associated role instead of carrying over the previously active one.
  * Session reconnection now preserves or updates the saved role correctly, depending on the action taken.
* **Chores**
  * Updated the chat service version to `0.1.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->