### PR TITLE
feat(chat-service): HTTP /connect resolves target session's role (#1894)

### DIFF
--- a/packages/chat-service/package.json
+++ b/packages/chat-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/chat-service",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Server-side chat service for MulmoBridge — socket.io + REST bridge to Claude Code agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/chat-service/src/index.ts
+++ b/packages/chat-service/src/index.ts
@@ -149,7 +149,16 @@ export function createChatService(deps: ChatServiceDeps): ChatService {
       return;
     }
 
-    const updated = await store.connectSession(transportId, externalChatId, chatSessionId);
+    // Resolve the target session's role BEFORE calling connectSession so the
+    // persisted state's `roleId` tracks the new session's role — otherwise the
+    // next relay's `startChat` would resume the new session under the previous
+    // role (#1888 / #1894). When the DI lookup returns null (unknown session
+    // or role not recorded), or when no `getSessionRole` was wired at all,
+    // fall back to the previous "session-id-only" behaviour: preserve the
+    // existing role. That keeps the route backward-compatible for hosts that
+    // haven't wired the resolver.
+    const resolvedRole = deps.getSessionRole ? await deps.getSessionRole(chatSessionId) : null;
+    const updated = await store.connectSession(transportId, externalChatId, chatSessionId, resolvedRole ?? undefined);
     if (!updated) {
       notFound(res, "No chat state found for this transport");
       return;

--- a/packages/chat-service/src/index.ts
+++ b/packages/chat-service/src/index.ts
@@ -152,12 +152,26 @@ export function createChatService(deps: ChatServiceDeps): ChatService {
     // Resolve the target session's role BEFORE calling connectSession so the
     // persisted state's `roleId` tracks the new session's role — otherwise the
     // next relay's `startChat` would resume the new session under the previous
-    // role (#1888 / #1894). When the DI lookup returns null (unknown session
-    // or role not recorded), or when no `getSessionRole` was wired at all,
-    // fall back to the previous "session-id-only" behaviour: preserve the
-    // existing role. That keeps the route backward-compatible for hosts that
-    // haven't wired the resolver.
-    const resolvedRole = deps.getSessionRole ? await deps.getSessionRole(chatSessionId) : null;
+    // role (#1888 / #1894). Three fallback paths all treated as "preserve
+    // existing role":
+    //   1. No `getSessionRole` wired at all (backward compat for older hosts).
+    //   2. Resolver returns null (unknown / corrupt session metadata).
+    //   3. Resolver throws (host bug / timeout / IO error) — catch here so
+    //      the route can never bubble the failure as a 500 to the API caller
+    //      (codex review on #1895; the MulmoClaude host's resolver is
+    //      hardened but the DI contract doesn't require hosts to be).
+    let resolvedRole: string | null = null;
+    if (deps.getSessionRole) {
+      try {
+        resolvedRole = await deps.getSessionRole(chatSessionId);
+      } catch (err) {
+        logger.warn("chat-service", "getSessionRole threw; falling back to preserving existing role", {
+          chatSessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        resolvedRole = null;
+      }
+    }
     const updated = await store.connectSession(transportId, externalChatId, chatSessionId, resolvedRole ?? undefined);
     if (!updated) {
       notFound(res, "No chat state found for this transport");

--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -133,6 +133,17 @@ export interface ChatServiceDeps {
     total: number;
   }>;
   /**
+   * Resolve the roleId a given session was started with. Used by the HTTP
+   * `/connect` route so the persisted bridge state's role tracks the target
+   * session's role after a repoint — same drift-fix as bridge `/switch`
+   * (issue #1888 / #1894), but for API callers that only supply a session ID.
+   * Returns null when the session isn't found OR when its role isn't known;
+   * on null the route falls back to the previous "preserve current role"
+   * behaviour (safe default). Omit this dep entirely to keep the old
+   * session-id-only semantics.
+   */
+  getSessionRole?: (sessionId: string) => Promise<string | null>;
+  /**
    * Return the skills the bridge command handler should expose. The
    * handler uses the result for two things:
    *   (1) Decide whether an unknown bridge slash command (e.g. `/foo`

--- a/packages/chat-service/test/test_connect_route.ts
+++ b/packages/chat-service/test/test_connect_route.ts
@@ -4,7 +4,7 @@
 // persisted bridge state's `roleId` tracks the new session's role, avoiding
 // the same drift the `/switch` command was hit by.
 
-import { describe, it, after } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
 import express from "express";
@@ -113,9 +113,16 @@ async function startHarness(opts: HarnessOpts = {}): Promise<{ harness: Harness;
 }
 
 describe("POST /connect — role propagation (issue #1894)", () => {
+  // Every test brings up its own harness (fresh port + tmp transports dir);
+  // afterEach tears it down BEFORE the next `it()` re-assigns `currentShutdown`.
+  // A suite-level `after` would only close the last harness and leak the
+  // earlier ones' HTTP servers + tmp dirs (CodeRabbit review on #1895).
   let currentShutdown: (() => Promise<void>) | null = null;
-  after(async () => {
-    if (currentShutdown) await currentShutdown();
+  afterEach(async () => {
+    if (!currentShutdown) return;
+    const shutdown = currentShutdown;
+    currentShutdown = null;
+    await shutdown();
   });
 
   it("resolves the target session's role and stamps it into the persisted state", async () => {
@@ -186,7 +193,37 @@ describe("POST /connect — role propagation (issue #1894)", () => {
     assert.equal(response.status, 200);
 
     const state = await harness.readState("telegram", "chat-1");
+    assert.ok(state);
+    assert.equal(state?.sessionId, "any-session", "no resolver still repoints the session (only the role stays put)");
     assert.equal(state?.roleId, "general", "no resolver ⇒ preserve prior role (backward compat)");
+  });
+
+  it("preserves the previous role when the resolver throws (codex review on #1895)", async () => {
+    // Third fallback path documented in the /connect handler: a host-provided
+    // resolver that throws (bug, timeout, IO error) must be caught inside the
+    // route so an API caller sees a 200 with role preserved instead of a
+    // 500 bubble. The MulmoClaude host's resolver is already hardened, but
+    // the DI contract doesn't require every host to be — the route defends
+    // itself.
+    const { harness, shutdown } = await startHarness({
+      getSessionRole: async () => {
+        throw new Error("resolver blew up");
+      },
+    });
+    currentShutdown = shutdown;
+
+    await harness.seedState("telegram", "chat-1", "general", "sess-general");
+    const response = await fetch(`${harness.url}/api/transports/telegram/chats/chat-1/connect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatSessionId: "some-session" }),
+    });
+    assert.equal(response.status, 200, "throw must not bubble as 500");
+
+    const state = await harness.readState("telegram", "chat-1");
+    assert.ok(state);
+    assert.equal(state?.sessionId, "some-session", "session should still be repointed");
+    assert.equal(state?.roleId, "general", "throw ⇒ preserve prior role, same as null-return path");
   });
 
   it("returns 404 when no chat state exists yet for the transport chat", async () => {

--- a/packages/chat-service/test/test_connect_route.ts
+++ b/packages/chat-service/test/test_connect_route.ts
@@ -1,0 +1,209 @@
+// HTTP integration test for the `/connect` route (#1894 follow-up to #1888):
+// verifies the route resolves the target session's role via the DI-injected
+// `getSessionRole`, then passes it through to `store.connectSession` — so the
+// persisted bridge state's `roleId` tracks the new session's role, avoiding
+// the same drift the `/switch` command was hit by.
+
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import express from "express";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createChatService } from "../src/index.ts";
+import { createChatStateStore } from "../src/chat-state.ts";
+import type { ChatServiceDeps, Logger } from "../src/types.ts";
+
+const silentLogger: Logger = {
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+};
+
+interface HarnessOpts {
+  getSessionRole?: (sessionId: string) => Promise<string | null>;
+}
+
+interface Harness {
+  url: string;
+  transportsDir: string;
+  seedState: (transportId: string, externalChatId: string, roleId: string, sessionId: string) => Promise<void>;
+  readState: (transportId: string, externalChatId: string) => Promise<{ sessionId: string; roleId: string } | null>;
+  connectCalls: Array<{ sessionId: string; roleId?: string }>;
+}
+
+async function startHarness(opts: HarnessOpts = {}): Promise<{ harness: Harness; shutdown: () => Promise<void> }> {
+  const transportsDir = mkdtempSync(path.join(tmpdir(), "connect-route-"));
+  const connectCalls: Array<{ sessionId: string; roleId?: string }> = [];
+
+  // Real store for readback, but wrapped to capture connectSession args so we
+  // can pin the exact roleId the route passed through.
+  const store = createChatStateStore({ transportsDir, logger: silentLogger });
+  const originalConnect = store.connectSession;
+  store.connectSession = async (t, c, sid, roleId) => {
+    connectCalls.push({ sessionId: sid, roleId });
+    return originalConnect(t, c, sid, roleId);
+  };
+
+  // Minimal deps stub — everything below what the /connect route touches is a
+  // no-op. `startChat` etc. are typed non-nullable on ChatServiceDeps, so
+  // stub them out; if the route ever calls them the test will fail loudly.
+  const deps: ChatServiceDeps = {
+    startChat: async () => {
+      throw new Error("startChat should not be called by /connect");
+    },
+    onSessionEvent: () => () => undefined,
+    loadAllRoles: () => [],
+    getRole: () => ({ id: "unused", name: "Unused" }),
+    defaultRoleId: "general",
+    transportsDir,
+    logger: silentLogger,
+    getSessionRole: opts.getSessionRole,
+  };
+
+  // Swap createChatStateStore's factory so createChatService uses OUR wrapped
+  // store instead of a fresh one. Simplest way: call createChatService, then
+  // reach in — but that's a private-field poke. Cleaner: don't use
+  // createChatService here; construct the router manually with the same shape.
+  // Since we only care about the /connect route wiring, this is fine.
+  const service = createChatService(deps);
+  // createChatService constructs its own store internally, so `connectCalls`
+  // above wouldn't capture. Bypass: seed / read via a store rooted at the
+  // SAME transportsDir; the file layout matches, so what the service writes,
+  // we read below. connectCalls stays empty (which is fine — we assert on
+  // the persisted state instead of the call spy).
+  const observedStore = createChatStateStore({ transportsDir, logger: silentLogger });
+
+  const app = express();
+  app.use(express.json());
+  app.use(service.router);
+  const httpServer = http.createServer(app);
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  const address = httpServer.address();
+  if (!address || typeof address === "string") throw new Error("no port");
+  const url = `http://127.0.0.1:${address.port}`;
+
+  const harness: Harness = {
+    url,
+    transportsDir,
+    connectCalls,
+    seedState: async (transportId, externalChatId, roleId, sessionId) => {
+      // reset then connect (real API) to lay down a state with the given role
+      // and sessionId. resetChatState creates it; connectSession would repoint.
+      const reset = await observedStore.resetChatState(transportId, externalChatId, roleId);
+      // Sanity: reset gives us a state with the requested role. Then update
+      // the sessionId to the seed value via a direct setChatState.
+      await observedStore.setChatState(transportId, { ...reset, sessionId });
+    },
+    readState: async (transportId, externalChatId) => {
+      const state = await observedStore.getChatState(transportId, externalChatId);
+      return state ? { sessionId: state.sessionId, roleId: state.roleId } : null;
+    },
+  };
+
+  const shutdown = async () => {
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    rmSync(transportsDir, { recursive: true, force: true });
+  };
+
+  return { harness, shutdown };
+}
+
+describe("POST /connect — role propagation (issue #1894)", () => {
+  let currentShutdown: (() => Promise<void>) | null = null;
+  after(async () => {
+    if (currentShutdown) await currentShutdown();
+  });
+
+  it("resolves the target session's role and stamps it into the persisted state", async () => {
+    // The bridge chat is currently in `general`. `/connect` retargets it at
+    // `office-session-42`, whose role is "office" per the injected resolver.
+    // The persisted state must land on `roleId: "office"` — that's what the
+    // next relay's startChat picks up.
+    const { harness, shutdown } = await startHarness({
+      getSessionRole: async (sessionId) => (sessionId === "office-session-42" ? "office" : null),
+    });
+    currentShutdown = shutdown;
+
+    await harness.seedState("telegram", "chat-1", "general", "sess-general");
+
+    const response = await fetch(`${harness.url}/api/transports/telegram/chats/chat-1/connect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatSessionId: "office-session-42" }),
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { ok: boolean };
+    assert.equal(body.ok, true);
+
+    const state = await harness.readState("telegram", "chat-1");
+    assert.ok(state);
+    assert.equal(state?.sessionId, "office-session-42");
+    assert.equal(state?.roleId, "office", "persisted state must reflect the target session's role");
+  });
+
+  it("preserves the previous role when the resolver returns null (unknown session)", async () => {
+    // A DI resolver that can't identify the session (missing metadata, corrupt
+    // file, deleted session) returns null. The route MUST fall back to the
+    // previous behaviour: preserve the current state's role. Otherwise a bad
+    // lookup would silently blank out the role.
+    const { harness, shutdown } = await startHarness({
+      getSessionRole: async () => null,
+    });
+    currentShutdown = shutdown;
+
+    await harness.seedState("telegram", "chat-1", "general", "sess-general");
+    const response = await fetch(`${harness.url}/api/transports/telegram/chats/chat-1/connect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatSessionId: "unknown-session" }),
+    });
+    assert.equal(response.status, 200);
+
+    const state = await harness.readState("telegram", "chat-1");
+    assert.ok(state);
+    assert.equal(state?.sessionId, "unknown-session");
+    assert.equal(state?.roleId, "general", "null resolver ⇒ preserve prior role, don't blank");
+  });
+
+  it("preserves the previous role when no resolver is wired (backward compat)", async () => {
+    // Hosts that haven't wired `getSessionRole` at all — the field is
+    // optional. The route must keep the old session-id-only semantics
+    // (preserve current role) so upgrading chat-service without wiring the
+    // new dep doesn't change behaviour.
+    const { harness, shutdown } = await startHarness({ getSessionRole: undefined });
+    currentShutdown = shutdown;
+
+    await harness.seedState("telegram", "chat-1", "general", "sess-general");
+    const response = await fetch(`${harness.url}/api/transports/telegram/chats/chat-1/connect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatSessionId: "any-session" }),
+    });
+    assert.equal(response.status, 200);
+
+    const state = await harness.readState("telegram", "chat-1");
+    assert.equal(state?.roleId, "general", "no resolver ⇒ preserve prior role (backward compat)");
+  });
+
+  it("returns 404 when no chat state exists yet for the transport chat", async () => {
+    // The route was already 404 in this case; we just want to make sure the
+    // new resolver path doesn't accidentally create a state or change the
+    // error semantics.
+    const { harness, shutdown } = await startHarness({
+      getSessionRole: async () => "office",
+    });
+    currentShutdown = shutdown;
+
+    // No seedState call — the chat doesn't exist.
+    const response = await fetch(`${harness.url}/api/transports/telegram/chats/never-existed/connect`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chatSessionId: "any" }),
+    });
+    assert.equal(response.status, 404);
+  });
+});

--- a/server/api/bridge/sessionRole.ts
+++ b/server/api/bridge/sessionRole.ts
@@ -1,0 +1,47 @@
+// Session-id-safe wrapper for the `getSessionRole` DI the chat-service
+// package exposes to the HTTP `/connect` route. Extracted from server/index.ts
+// so the hostile-input + IO-error semantics can be pinned in a focused test
+// (codex review on #1895).
+
+/** Character-class + length bound. `\w` covers UUIDs (`randomUUID()`)
+ *  and the transport-chat-timestamp triples chat-state emits for fresh
+ *  bridge chats; `.` and `-` cover the separator variants used in the
+ *  wild. `/` and `\` are excluded, so single-dot / single-hyphen
+ *  separators are fine but a whole-string `..` slips through this
+ *  check alone — the `isSafeSessionId` wrapper below rejects `..`
+ *  sequences as a second gate. Exported for direct unit testing. */
+export const SAFE_SESSION_ID_RE = /^[\w.-]{1,200}$/;
+
+/** True iff `sessionId` is safe to hand to `readSessionMeta`. Combines
+ *  the character-class regex with an explicit `..` rejection —
+ *  otherwise a literal `..` (or `foo..bar`) would pass the class check
+ *  and let `path.join(dir, "..json")` escape the CHAT dir on any
+ *  reader that trusts its input (`readTextUnder` is documented as
+ *  "internal fixed paths only, no traversal guard"). */
+export function isSafeSessionId(sessionId: string): boolean {
+  if (!SAFE_SESSION_ID_RE.test(sessionId)) return false;
+  if (sessionId.includes("..")) return false;
+  return true;
+}
+
+/** Read one session's `roleId` for the HTTP `/connect` role-resolver
+ *  path. The `sessionId` MUST NOT be handed to the underlying reader
+ *  unvalidated — see `readTextUnder`'s "internal fixed paths only, no
+ *  `..` traversal guard" contract. Returns null in three cases, all
+ *  treated by the route as "preserve the previous role":
+ *
+ *    1. `sessionId` fails the safe-id shape check (hostile input).
+ *    2. Metadata is absent or corrupt (the reader itself returns null).
+ *    3. Any unexpected IO error (permission denied, disk error). Left
+ *       unwrapped, `rethrowUnexpected` inside the reader would surface
+ *       as a 500 from the `/connect` handler — that's a hostile-input
+ *       surface too, so degrade to null instead. */
+export async function resolveBridgeSessionRole(sessionId: string, readMeta: (id: string) => Promise<{ roleId?: string } | null>): Promise<string | null> {
+  if (!isSafeSessionId(sessionId)) return null;
+  try {
+    const meta = await readMeta(sessionId);
+    return meta?.roleId ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -67,6 +67,7 @@ import { migrateLegacyBillingPresets } from "./workspace/billing-migration.js";
 import { APP_VERSION } from "./system/appVersion.js";
 import { createChatService } from "@mulmobridge/chat-service";
 import { readSessionJsonl, readSessionMeta } from "./utils/files/session-io.js";
+import { resolveBridgeSessionRole } from "./api/bridge/sessionRole.js";
 import { onSessionEvent, initSessionStore } from "./events/session-store/index.js";
 import { initFileChangePublisher } from "./events/file-change.js";
 import { initCollectionChangePublisher } from "./events/collection-change.js";
@@ -699,15 +700,11 @@ async function listSessionsForBridge(opts: { limit: number; offset: number }) {
   }));
   return { sessions, total };
 }
-// Resolve a session's original roleId via its persisted metadata file.
-// Wired into the chat-service factory so the HTTP `/connect` route can
-// keep the bridge state's role in sync with the target session — same
-// drift-fix as `/switch` (#1888) applied to the API surface (#1894).
-// `readSessionMeta` is null-safe: missing or corrupt metadata returns
-// null, which the route treats as "preserve the previous role".
+// See `resolveBridgeSessionRole` for the safe-id shape check + IO-error
+// degradation contract (extracted for direct unit testing under
+// test/server/api/bridge/test_sessionRole.ts; codex review on #1895).
 async function getSessionRoleForBridge(sessionId: string): Promise<string | null> {
-  const meta = await readSessionMeta(sessionId);
-  return meta?.roleId ?? null;
+  return resolveBridgeSessionRole(sessionId, readSessionMeta);
 }
 async function getSessionHistoryForBridge(sessionId: string, opts: { limit: number; offset: number }) {
   const content = await readSessionJsonl(sessionId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -66,7 +66,7 @@ import { announceOptionalDeps } from "./system/announceOptionalDeps.js";
 import { migrateLegacyBillingPresets } from "./workspace/billing-migration.js";
 import { APP_VERSION } from "./system/appVersion.js";
 import { createChatService } from "@mulmobridge/chat-service";
-import { readSessionJsonl } from "./utils/files/session-io.js";
+import { readSessionJsonl, readSessionMeta } from "./utils/files/session-io.js";
 import { onSessionEvent, initSessionStore } from "./events/session-store/index.js";
 import { initFileChangePublisher } from "./events/file-change.js";
 import { initCollectionChangePublisher } from "./events/collection-change.js";
@@ -699,6 +699,16 @@ async function listSessionsForBridge(opts: { limit: number; offset: number }) {
   }));
   return { sessions, total };
 }
+// Resolve a session's original roleId via its persisted metadata file.
+// Wired into the chat-service factory so the HTTP `/connect` route can
+// keep the bridge state's role in sync with the target session — same
+// drift-fix as `/switch` (#1888) applied to the API surface (#1894).
+// `readSessionMeta` is null-safe: missing or corrupt metadata returns
+// null, which the route treats as "preserve the previous role".
+async function getSessionRoleForBridge(sessionId: string): Promise<string | null> {
+  const meta = await readSessionMeta(sessionId);
+  return meta?.roleId ?? null;
+}
 async function getSessionHistoryForBridge(sessionId: string, opts: { limit: number; offset: number }) {
   const content = await readSessionJsonl(sessionId);
   if (!content) return { messages: [], total: 0 };
@@ -750,6 +760,7 @@ const chatService = createChatService({
   tokenProvider: getCurrentToken,
   listSessions: listSessionsForBridge,
   getSessionHistory: getSessionHistoryForBridge,
+  getSessionRole: getSessionRoleForBridge,
   listRegisteredSkills,
 });
 app.use(chatService.router);

--- a/test/server/api/bridge/test_sessionRole.ts
+++ b/test/server/api/bridge/test_sessionRole.ts
@@ -1,0 +1,88 @@
+// Pins the hostile-input + IO-error semantics of `resolveBridgeSessionRole` —
+// the wrapper the HTTP `/connect` route runs on an untrusted sessionId before
+// letting it reach the filesystem via `readSessionMeta` (codex review on #1895).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { isSafeSessionId, resolveBridgeSessionRole } from "../../../../server/api/bridge/sessionRole.ts";
+
+describe("isSafeSessionId", () => {
+  it("accepts every legitimate session-id form we ship", () => {
+    // UUID v4 from `randomUUID()` — server-side sessions
+    assert.ok(isSafeSessionId("001dfd79-d6c5-4be4-9afa-454675aafc1e"));
+    // transport-chat-timestamp triple — chat-state.ts:generateSessionId
+    assert.ok(isSafeSessionId("telegram-chat123-1719822000000"));
+    // Short IDs (16-hex) — generateShortId
+    assert.ok(isSafeSessionId("a1b2c3d4e5f60718"));
+    // Names with dots (e.g. legacy formats) — still safe
+    assert.ok(isSafeSessionId("session.v2.abc"));
+  });
+
+  it("rejects path-traversal + separator patterns", () => {
+    for (const hostile of ["../etc/passwd", "..", "../../secret", "/absolute/path", "chat/../../etc", "..\\windows\\file", "sess/../evil", "a/b", "a\\b"]) {
+      assert.equal(isSafeSessionId(hostile), false, `${hostile} should be rejected`);
+    }
+  });
+
+  it("rejects the empty string and overlong inputs", () => {
+    assert.equal(isSafeSessionId(""), false);
+    assert.equal(isSafeSessionId("a".repeat(201)), false);
+    assert.equal(isSafeSessionId("a".repeat(200)), true);
+  });
+
+  it("rejects characters outside the safe-id class", () => {
+    for (const hostile of ["a b", "a\nb", "a\0b", "a;b", "a$b", "a{b}", 'a"b', "abc\r"]) {
+      assert.equal(isSafeSessionId(hostile), false, `${JSON.stringify(hostile)} should be rejected`);
+    }
+  });
+});
+
+describe("resolveBridgeSessionRole", () => {
+  it("returns the roleId when the reader finds valid metadata", async () => {
+    const role = await resolveBridgeSessionRole("valid-session-id", async () => ({ roleId: "office" }));
+    assert.equal(role, "office");
+  });
+
+  it("returns null when the reader returns null (missing / corrupt meta)", async () => {
+    const role = await resolveBridgeSessionRole("valid-session-id", async () => null);
+    assert.equal(role, null);
+  });
+
+  it("returns null when the meta has no roleId field", async () => {
+    const role = await resolveBridgeSessionRole("valid-session-id", async () => ({}));
+    assert.equal(role, null);
+  });
+
+  it("returns null WITHOUT invoking the reader on a hostile sessionId", async () => {
+    // The main security invariant: a traversal-shaped input never reaches
+    // the filesystem, even if the reader would have swallowed it.
+    let readerCalls = 0;
+    const role = await resolveBridgeSessionRole("../etc/passwd", async () => {
+      readerCalls += 1;
+      return { roleId: "leaked" };
+    });
+    assert.equal(role, null);
+    assert.equal(readerCalls, 0, "hostile input must be blocked BEFORE the reader is consulted");
+  });
+
+  it("returns null when the reader throws (IO error), never bubbles a 500", async () => {
+    // `readTextUnder`'s `rethrowUnexpected` re-throws EACCES / EIO etc.
+    // Unwrapped that would surface as a 500 from `/connect` — same hostile-
+    // input surface, so degrade to null.
+    const role = await resolveBridgeSessionRole("valid-session-id", async () => {
+      throw new Error("EACCES: permission denied");
+    });
+    assert.equal(role, null);
+  });
+
+  it("returns null when the reader throws a non-Error value", async () => {
+    // Defensive: catch { ... } swallows anything, not just Error subclasses.
+    // Reject with a string via a Promise so the rule targeting production
+    // throw-literal usage doesn't fire on a test that specifically pins the
+    // "reader threw something weird" recovery path.
+    // eslint-disable-next-line prefer-promise-reject-errors
+    const role = await resolveBridgeSessionRole("valid-session-id", () => Promise.reject("boom"));
+    assert.equal(role, null);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1894 (follow-up to #1888 / #1893).

The bridge `/switch` command was fixed in #1893: it passes the target session's `roleId` to `connectSession`, so the persisted state's role tracks the resumed session. The HTTP `/connect` route had the same drift shape but was left session-id-only because chat-service didn't have a way to resolve the target's role from inside the package.

This PR wires the missing lookup via a new optional DI dep, keeping the route fully backward-compatible.

## Changes

- **`ChatServiceDeps.getSessionRole?: (sessionId) => Promise<string | null>`** — new optional resolver hosts inject over their session-metadata source.
- **`/connect` handler** in `packages/chat-service/src/index.ts` — calls the resolver before `store.connectSession(...)`, passes the resolved role through as the 4th arg. When the resolver returns null (unknown session, corrupt metadata) OR isn't wired at all, falls back to the previous "preserve current role" behaviour.
- **Host wire-up** in `server/index.ts` — `getSessionRoleForBridge(sessionId)` reads `readSessionMeta(sessionId)?.roleId`. Missing / corrupt metadata → null, handled by the route.
- **HTTP integration test** (`test/test_connect_route.ts`, new) drives the route through an express harness (mirrors `test_socket.ts`) and pins four scenarios.

## Items to Confirm / Review

- **Optional dep, safe default.** Hosts that upgrade `@mulmobridge/chat-service@0.1.6` without wiring `getSessionRole` see identical behaviour to 0.1.5 (`/connect` preserves the previous role). No breaking-change surface.
- **Null-on-lookup ⇒ preserve, not blank.** Explicit choice: if the resolver returns null (missing session, corrupt meta), the route keeps the existing role rather than silently blanking it out. Reasoning: a stale role is better than a null one — the next relay still runs SOMETHING, and the user notices the mismatch and can `/switch`. If we blanked, `startChat` would need to defend against null roles everywhere.
- **Resolver reads `readSessionMeta` (not `loadAllSessions`)** — O(1) file read per call, not a scan. Same source `createSessionMeta` writes at session-start time, so the roleId is always what `startChat` originally recorded.
- **`/switch` command unchanged.** It already had `SessionSummary.roleId` from `/sessions` — that fix landed in #1893 and doesn't need reworking here. The two paths are consistent: bridge state's role always tracks the target session's role after a repoint.
- **404 semantics unchanged.** The new resolver code runs BEFORE `store.connectSession`, but the "no state for this chat" case is still detected by the null return from `connectSession` — 404 semantics untouched. Test #4 pins this.

## Regression scenario (the /switch-parallel one)

- API client (some UI or automation) POSTs to `/api/transports/telegram/chats/chat-1/connect` with `{"chatSessionId": "office-session-42"}`.
- Persisted bridge state was `roleId: "general"`.
- Before the fix: `connectSession(...)` gets 3 args, state's roleId stays `general`, next relay's `startChat("office-session-42", "general")` runs the office session under general.
- After the fix: `getSessionRole("office-session-42")` returns `"office"`, `connectSession(..., "office")` stamps it, next relay's `startChat("office-session-42", "office")` runs under the right role. Verified by test #1.

## Test plan

- [x] `tsx --test packages/chat-service/test/test_connect_route.ts` — 4 / 4 pass
- [x] `tsx --test packages/chat-service/test/*.ts` — all pass (nothing else touched)
- [x] `yarn workspace @mulmobridge/chat-service run typecheck` — clean
- [x] `yarn typecheck:server` — clean (host wire-up)
- [x] `yarn format` / focused `yarn eslint` on touched files — clean
- [ ] Manual: hit the HTTP `/connect` route from an API client, confirm the persisted bridge state's role changes to the target session's role

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat session connections now persist an associated role into bridge state for more consistent reconnections.
* **Bug Fixes**
  * When role metadata is unavailable, unknown, or resolution fails, the system preserves the previously stored role instead of overwriting it.
  * Connecting without saved chat state still returns a proper not-found response.
  * Role resolution now safely handles invalid session identifiers and degrades gracefully.
* **Tests**
  * Added integration and unit coverage for role resolution, fallbacks, and safety checks.
* **Chores**
  * Bumped the chat service version to 0.1.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->