### PR TITLE
feat(share): Download (zip) button in the HTML view (Phase 1b)

### DIFF
--- a/packages/plugins/html-plugin/src/core/contract.ts
+++ b/packages/plugins/html-plugin/src/core/contract.ts
@@ -20,8 +20,27 @@ export interface SaveHtmlArgs {
   html: string;
 }
 
-/** Discriminated union of every action the View can `dispatch`. */
+/** Discriminated union of every action the View's *package* router
+ *  (`executeHtmlDispatch`) serves. `packHtml` is deliberately NOT here:
+ *  bundling needs binary asset reads + zip, which live host-side, so the
+ *  host intercepts it before delegating (see `PackHtmlArgs`). */
 export type HtmlDispatchArgs = LoadHtmlArgs | SaveHtmlArgs;
+
+/** Bundle an HTML artifact + its referenced local assets into a
+ *  self-contained zip. Dispatched by the View, handled host-side (not by
+ *  the pure package router). */
+export interface PackHtmlArgs {
+  kind: "packHtml";
+  /** Workspace-relative path under `artifacts/html/…`. */
+  path: string;
+}
+
+/** Result of `packHtml`: base64 keeps the zip bytes JSON-safe over the
+ *  dispatch transport; the View decodes it to a Blob download. */
+export interface PackHtmlResult {
+  filename: string;
+  zipBase64: string;
+}
 
 /** Maps a dispatch `kind` to its result shape so the View can call
  *  `dispatch<HtmlDispatchResult["loadHtml"]>(…)` without a cast. */

--- a/packages/plugins/html-plugin/src/core/index.ts
+++ b/packages/plugins/html-plugin/src/core/index.ts
@@ -2,5 +2,5 @@ export type { HtmlArgs, PresentHtmlData, UpdateHtmlArgs } from "./types";
 export { TOOL_NAME, TOOL_DEFINITION } from "./definition";
 export { executeHtml, executeHtmlUpdate, pluginCore, type HtmlExecuteContext, type UpdateHtmlResult } from "./plugin";
 export { executeHtmlDispatch, type HtmlDispatchContext } from "./dispatch";
-export type { HtmlDispatchArgs, HtmlDispatchResult, LoadHtmlArgs, SaveHtmlArgs } from "./contract";
+export type { HtmlDispatchArgs, HtmlDispatchResult, LoadHtmlArgs, SaveHtmlArgs, PackHtmlArgs, PackHtmlResult } from "./contract";
 export { htmlArtifactPath, htmlArtifactPreviewUrl, isHtmlArtifactPath, toArtifactsRelative, slugify, type HtmlPath } from "./paths";

--- a/packages/plugins/html-plugin/src/lang/de.ts
+++ b/packages/plugins/html-plugin/src/lang/de.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const de: Messages = {
   saveAsPdf: "Als PDF speichern (öffnet Druckdialog)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "Als eigenständiges ZIP herunterladen (Assets gebündelt)",
+  downloadError: (error) => `⚠ Download fehlgeschlagen: ${error}`,
   untitled: "HTML-Seite",
   editSource: "HTML-Quelltext bearbeiten",
   cancel: "Abbrechen",

--- a/packages/plugins/html-plugin/src/lang/en.ts
+++ b/packages/plugins/html-plugin/src/lang/en.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const en: Messages = {
   saveAsPdf: "Save as PDF (opens print dialog)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "Download as a self-contained zip (assets bundled)",
+  downloadError: (error) => `⚠ Download failed: ${error}`,
   untitled: "HTML Page",
   editSource: "Edit HTML Source",
   cancel: "Cancel",

--- a/packages/plugins/html-plugin/src/lang/es.ts
+++ b/packages/plugins/html-plugin/src/lang/es.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const es: Messages = {
   saveAsPdf: "Guardar como PDF (abre el diálogo de impresión)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "Descargar como zip autónomo (recursos incluidos)",
+  downloadError: (error) => `⚠ Error al descargar: ${error}`,
   untitled: "Página HTML",
   editSource: "Editar código HTML",
   cancel: "Cancelar",

--- a/packages/plugins/html-plugin/src/lang/fr.ts
+++ b/packages/plugins/html-plugin/src/lang/fr.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const fr: Messages = {
   saveAsPdf: "Enregistrer en PDF (ouvre la boîte de dialogue d'impression)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "Télécharger en zip autonome (ressources incluses)",
+  downloadError: (error) => `⚠ Échec du téléchargement : ${error}`,
   untitled: "Page HTML",
   editSource: "Modifier la source HTML",
   cancel: "Annuler",

--- a/packages/plugins/html-plugin/src/lang/ja.ts
+++ b/packages/plugins/html-plugin/src/lang/ja.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const ja: Messages = {
   saveAsPdf: "PDF として保存（印刷ダイアログを開きます）",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "自己完結zipでダウンロード（アセット同梱）",
+  downloadError: (error) => `⚠ ダウンロード失敗: ${error}`,
   untitled: "HTML ページ",
   editSource: "HTML ソースを編集",
   cancel: "キャンセル",

--- a/packages/plugins/html-plugin/src/lang/ko.ts
+++ b/packages/plugins/html-plugin/src/lang/ko.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const ko: Messages = {
   saveAsPdf: "PDF 로 저장 (인쇄 대화 상자 열기)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "자체 포함 zip으로 다운로드(에셋 포함)",
+  downloadError: (error) => `⚠ 다운로드 실패: ${error}`,
   untitled: "HTML 페이지",
   editSource: "HTML 소스 편집",
   cancel: "취소",

--- a/packages/plugins/html-plugin/src/lang/messages.ts
+++ b/packages/plugins/html-plugin/src/lang/messages.ts
@@ -1,6 +1,9 @@
 export interface Messages {
   saveAsPdf: string;
   pdf: string;
+  download: string;
+  downloadZip: string;
+  downloadError(error: string): string;
   untitled: string;
   editSource: string;
   cancel: string;

--- a/packages/plugins/html-plugin/src/lang/ptBR.ts
+++ b/packages/plugins/html-plugin/src/lang/ptBR.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const ptBR: Messages = {
   saveAsPdf: "Salvar como PDF (abre o diálogo de impressão)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "Baixar como zip autônomo (recursos incluídos)",
+  downloadError: (error) => `⚠ Falha no download: ${error}`,
   untitled: "Página HTML",
   editSource: "Editar fonte HTML",
   cancel: "Cancelar",

--- a/packages/plugins/html-plugin/src/lang/zh.ts
+++ b/packages/plugins/html-plugin/src/lang/zh.ts
@@ -3,6 +3,9 @@ import type { Messages } from "./messages";
 const zh: Messages = {
   saveAsPdf: "另存为 PDF(打开打印对话框)",
   pdf: "PDF",
+  download: "ZIP",
+  downloadZip: "下载为自包含 zip(含资源)",
+  downloadError: (error) => `⚠ 下载失败：${error}`,
   untitled: "HTML 页面",
   editSource: "编辑 HTML 源代码",
   cancel: "取消",

--- a/packages/plugins/html-plugin/src/vue/View.vue
+++ b/packages/plugins/html-plugin/src/vue/View.vue
@@ -1,12 +1,25 @@
 <template>
   <div class="html-container">
-    <div class="px-4 py-2 border-b border-gray-100 shrink-0 flex items-center justify-between">
+    <div class="px-4 py-2 border-b border-gray-100 shrink-0 flex items-center justify-between gap-2">
       <span class="text-sm font-medium text-gray-700 truncate">{{ title ?? t.untitled }}</span>
-      <button class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50 shrink-0" :title="t.saveAsPdf" @click="printToPdf">
-        <span class="material-icons text-sm align-middle">picture_as_pdf</span>
-        {{ t.pdf }}
-      </button>
+      <div class="flex items-center gap-2 shrink-0">
+        <button
+          class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+          :title="t.downloadZip"
+          :disabled="downloading || !filePath"
+          data-testid="present-html-download"
+          @click="downloadZip"
+        >
+          <span class="material-icons text-sm align-middle">download</span>
+          {{ t.download }}
+        </button>
+        <button class="px-2 py-1 text-xs rounded border border-gray-300 text-gray-500 hover:bg-gray-50" :title="t.saveAsPdf" @click="printToPdf">
+          <span class="material-icons text-sm align-middle">picture_as_pdf</span>
+          {{ t.pdf }}
+        </button>
+      </div>
     </div>
+    <div v-if="downloadError" class="download-error" role="alert">{{ t.downloadError(downloadError) }}</div>
     <div class="iframe-wrapper">
       <iframe v-if="frameSrc" data-testid="present-html-iframe" :src="frameSrc" sandbox="allow-scripts" class="w-full h-full border-0" />
       <div v-else class="h-full flex items-center justify-center text-sm text-gray-500">
@@ -43,7 +56,7 @@
 import { computed, ref, watch } from "vue";
 import { useRuntime, type ToolResultComplete } from "gui-chat-protocol/vue";
 import type { PresentHtmlData } from "../core/types";
-import type { HtmlDispatchResult } from "../core/contract";
+import type { HtmlDispatchResult, PackHtmlResult } from "../core/contract";
 import { htmlArtifactPreviewUrl } from "../core/paths";
 import { useT } from "../lang";
 import { buildPrintCspContent } from "./previewCsp";
@@ -106,6 +119,35 @@ const sourceError = ref<string | null>(null);
 const editableHtml = ref("");
 const saving = ref(false);
 const saveError = ref<string | null>(null);
+const downloading = ref(false);
+const downloadError = ref<string | null>(null);
+
+// Decode the base64 zip returned by the host into a Blob and trigger a
+// browser download — keeps the transport JSON-safe over `dispatch`.
+function triggerBlobDownload(zipBase64: string, filename: string) {
+  const bytes = Uint8Array.from(atob(zipBase64), (char) => char.charCodeAt(0));
+  const url = URL.createObjectURL(new Blob([bytes], { type: "application/zip" }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+async function downloadZip() {
+  const path = filePath.value;
+  if (!path || downloading.value) return;
+  downloading.value = true;
+  downloadError.value = null;
+  try {
+    const { zipBase64, filename } = await runtime.dispatch<PackHtmlResult>({ kind: "packHtml", path });
+    triggerBlobDownload(zipBase64, filename);
+  } catch (err) {
+    downloadError.value = errorMessage(err);
+  } finally {
+    downloading.value = false;
+  }
+}
 
 const cachedSource = computed(() => (filePath.value ? (sourceCache.value[filePath.value] ?? null) : null));
 const hasChanges = computed(() => cachedSource.value !== null && editableHtml.value !== cachedSource.value);
@@ -389,6 +431,15 @@ async function printToPdf() {
   border: 1px solid #f5c2c7;
   border-radius: 4px;
   font-size: 0.875rem;
+}
+
+.download-error {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  background: #fdecea;
+  color: #b71c1c;
+  border-bottom: 1px solid #f5c2c7;
+  font-size: 0.85rem;
 }
 
 .cancel-btn {

--- a/plans/feat-share-download-ui.md
+++ b/plans/feat-share-download-ui.md
@@ -1,0 +1,43 @@
+# feat: 共有機能 Phase 1b — HTMLビューに「Download (zip)」導線
+
+Date: 2026-07-01
+Follow-up to #1889 / #1892 (Phase 1 backend).
+
+## ゴール
+
+Phase 1 の pack+zip をブラウザから使えるようにする。HTMLビューに Download ボタンを足し、
+クリックで自己完結zipをダウンロードできるようにする（ユーザ／e2e が実際にクリックしてテスト可能に）。
+
+## 制約と方式
+
+HTMLビュー（`@mulmoclaude/html-plugin` の `View.vue`）は host-agnostic で、ホストへは
+`useRuntime().dispatch()` 経由でのみ到達できる（ホストが bearer を自動付与、JSON を返す）。
+バンドル処理（バイナリ読取＋zip）は host 側 `server/utils/share` にあり、プラグインは
+host を import 不可。そこで:
+
+- View → `runtime.dispatch({ kind: "packHtml", path })`（JSON: base64 zip を受領）。
+- `packHtml` は **host 側 dispatch ハンドラ（`html-builtin.ts`）で intercept** し、
+  `server/utils/share` を使って処理。プラグインの純粋ルータ `executeHtmlDispatch` は不変
+  （`packHtml` は `HtmlDispatchArgs` union に入れない）。
+
+## 変更
+
+- `server/utils/share/packHtml.ts`: `packHtmlZip()`（bundle→zip→安全なファイル名）を追加。
+  route と dispatch で共有（DRY）。
+- `server/api/routes/share.ts`: `packHtmlZip` を使うよう簡素化。
+- `packages/plugins/html-plugin/src/core/contract.ts`（+ `core/index.ts`）: `PackHtmlArgs` /
+  `PackHtmlResult`（base64）を追加・公開。
+- `server/plugins/html-builtin.ts`: dispatch で `packHtml` を intercept → `isHtmlPath` 検証 →
+  `packHtmlZip` → base64 返却。
+- `packages/plugins/html-plugin/src/vue/View.vue`: ヘッダに Download ボタン、`dispatch` →
+  base64→Blob→ダウンロード、エラーバナー。
+- lang（messages + 8 locale）: `download` / `downloadZip` / `downloadError`。
+
+## テスト
+
+- `test/utils/share/test_packHtml.ts`: `packHtmlZip`（ファイル名 + zip 構造）。
+- View の Blob ダウンロードはブラウザ専用のため、型/ビルドで担保（e2e は将来）。
+
+## Out of scope
+
+S3互換アップロード / 共有台帳 / Markdown・Wiki アダプタ（後続フェーズ）。

--- a/server/api/routes/share.ts
+++ b/server/api/routes/share.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
-import { packHtmlBundle, zipBundle } from "../../utils/share/packHtml.js";
+import { packHtmlZip } from "../../utils/share/packHtml.js";
 import { isHtmlPath } from "../../utils/files/html-store.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -22,10 +22,6 @@ export function isPackablePath(value: unknown): value is string {
   return typeof value === "string" && isHtmlPath(value);
 }
 
-function safeFilename(name: string): string {
-  return name.replace(/[^\w.-]+/g, "_") || "share";
-}
-
 // POST /api/share/pack — bundle an HTML artifact and its referenced
 // local assets into a single self-contained zip (index.html + assets/),
 // returned as a download. Paths are rewritten to be relative so the
@@ -37,11 +33,10 @@ router.post(API_ROUTES.share.pack, async (req: Request<object, unknown, PackBody
     return;
   }
   try {
-    const bundle = await packHtmlBundle(htmlPath);
-    const zip = await zipBundle(bundle.files);
-    log.info("share", "pack: ok", { path: htmlPath, files: bundle.files.length, bytes: zip.length });
+    const { filename, zip } = await packHtmlZip(htmlPath);
+    log.info("share", "pack: ok", { path: htmlPath, bytes: zip.length });
     res.setHeader("Content-Type", "application/zip");
-    res.setHeader("Content-Disposition", `attachment; filename="${safeFilename(bundle.name)}.zip"`);
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
     res.send(zip);
   } catch (err) {
     // Log the detail server-side; return a generic message so an internal

--- a/server/plugins/html-builtin.ts
+++ b/server/plugins/html-builtin.ts
@@ -7,17 +7,31 @@
 // Imported for side effect at boot (server/index.ts) so the dispatch resolves.
 
 import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
-import type { HtmlDispatchArgs } from "@mulmoclaude/html-plugin";
+import type { HtmlDispatchArgs, PackHtmlArgs, PackHtmlResult } from "@mulmoclaude/html-plugin";
 import { makeArtifactsFileOps } from "./runtime.js";
 import { publishFileChange } from "../events/file-change.js";
 import { registerBuiltinDispatch } from "./builtin-dispatch.js";
+import { packHtmlZip } from "../utils/share/packHtml.js";
+import { isHtmlPath } from "../utils/files/html-store.js";
 
 /** Scope name — matches `wrapWithScope("html", …)` in
  *  `src/plugins/presentHtml/index.ts`, which is what the View's
  *  `useRuntime().dispatch` uses as the `:pkg` path segment. */
 const HTML_SCOPE = "html";
 
+// `packHtml` bundles the page + its local assets into a self-contained
+// zip. It lives host-side (binary reads + zip via server/utils/share),
+// so it's intercepted here rather than in the package's pure router.
+async function packHtmlForDownload(args: PackHtmlArgs): Promise<PackHtmlResult> {
+  if (!isHtmlPath(args.path)) throw new Error("path must be a canonical artifacts/html/*.html file");
+  const { filename, zip } = await packHtmlZip(args.path);
+  return { filename, zipBase64: zip.toString("base64") };
+}
+
 registerBuiltinDispatch(HTML_SCOPE, async (args) => {
+  if ((args as { kind?: string }).kind === "packHtml") {
+    return packHtmlForDownload(args as unknown as PackHtmlArgs);
+  }
   const dispatchArgs = args as unknown as HtmlDispatchArgs;
   const result = await executeHtmlDispatch({ files: { artifacts: makeArtifactsFileOps() } }, dispatchArgs);
   // saveHtml changed bytes on disk → nudge subscribed View tabs (load is read-only).

--- a/server/utils/share/packHtml.ts
+++ b/server/utils/share/packHtml.ts
@@ -93,3 +93,16 @@ export function zipBundle(files: PackedFile[]): Promise<Buffer> {
   for (const file of files) zip.file(file.bundlePath, file.bytes);
   return zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE", compressionOptions: { level: 9 } });
 }
+
+function safeZipName(name: string): string {
+  const cleaned = name.replace(/[^\w.-]+/g, "_");
+  return `${cleaned || "share"}.zip`;
+}
+
+// One-call pack: bundle → zip → suggested download filename. Shared by
+// the HTTP route (streams the buffer) and the View dispatch (base64).
+export async function packHtmlZip(htmlRelPath: string): Promise<{ filename: string; zip: Buffer }> {
+  const bundle = await packHtmlBundle(htmlRelPath);
+  const zip = await zipBundle(bundle.files);
+  return { filename: safeZipName(bundle.name), zip };
+}

--- a/test/utils/share/test_packHtml.ts
+++ b/test/utils/share/test_packHtml.ts
@@ -4,7 +4,7 @@ import { mkdir, writeFile, rm } from "fs/promises";
 import path from "path";
 import JSZip from "jszip";
 import { resolveWorkspacePath } from "../../../server/utils/files/workspace-io.js";
-import { packHtmlBundle, zipBundle, type PackedBundle, type PackedFile } from "../../../server/utils/share/packHtml.js";
+import { packHtmlBundle, zipBundle, packHtmlZip, type PackedBundle, type PackedFile } from "../../../server/utils/share/packHtml.js";
 
 const TOKEN = "__share_pack_test__";
 const HTML_REL = `artifacts/html/${TOKEN}/page.html`;
@@ -90,5 +90,15 @@ describe("zipBundle", () => {
     const foo = zip.file("assets/foo.png");
     assert.ok(foo, "asset in zip");
     assert.deepEqual(await foo.async("nodebuffer"), IMG_BYTES);
+  });
+});
+
+describe("packHtmlZip", () => {
+  it("returns a safe .zip filename and a valid zip buffer", async () => {
+    const { filename, zip } = await packHtmlZip(HTML_REL);
+    assert.equal(filename, "page.zip");
+    const loaded = await JSZip.loadAsync(zip);
+    assert.ok(loaded.file("index.html"), "index.html in zip");
+    assert.ok(loaded.file("assets/foo.png"), "asset in zip");
   });
 });


### PR DESCRIPTION
## Summary

共有機能 Phase 1（#1892）の pack+zip を **ブラウザから使えるように**する。HTMLビューに **Download (zip)** ボタンを追加し、クリックで自己完結zip（`index.html` + `assets/`、相対パスに書換済み）をダウンロードできる。これで**ユーザ／e2e が実際にクリックしてテスト可能**になる。

## Items to Confirm / Review

- [ ] **境界の守り方**: HTMLビュー(`View.vue`)は host-agnostic で `runtime.dispatch()` 経由でのみホストに到達（bearer は自動付与）。バンドルは host 側 `server/utils/share` にあるため、**`packHtml` を host の dispatch ハンドラ(`html-builtin.ts`)で intercept**。プラグインの純粋ルータ `executeHtmlDispatch` は不変（`packHtml` を `HtmlDispatchArgs` union に入れない）。
- [ ] **transport**: dispatch は JSON を返すため zip は **base64** で受け渡し、View で Blob 化してダウンロード。バンドルは小さい（1ページ + 数アセット）ので base64 で問題なし。
- [ ] **DRY**: route と dispatch が共有する `packHtmlZip()`（bundle→zip→安全なファイル名）を追加し、既存 route も簡素化。
- [ ] **検証範囲**: `packHtmlZip` はユニットテスト。View の base64→Blob→DL はブラウザ専用のため型/ビルドで担保（自動 e2e は将来）。手元では実パイプラインで zip 生成→`file://` 表示まで確認済み（Phase 1）。

## User Prompt

> mulmoclaude で作った HTML を簡単にシェアしたい。まず pack して download できるUIが欲しい。UIで実際にクリックしてテストできる形にして。

（Phase 1 でバックエンド、本PR=Phase 1b で UI 導線。）

## 実装

| ファイル | 変更 |
|---|---|
| `server/utils/share/packHtml.ts` | `packHtmlZip()` 追加（route/dispatch 共有） |
| `server/api/routes/share.ts` | `packHtmlZip` 利用に簡素化 |
| `packages/plugins/html-plugin/src/core/contract.ts` (+`core/index.ts`) | `PackHtmlArgs` / `PackHtmlResult`(base64) を追加・公開 |
| `server/plugins/html-builtin.ts` | dispatch で `packHtml` を intercept → `isHtmlPath` 検証 → `packHtmlZip` → base64 |
| `packages/plugins/html-plugin/src/vue/View.vue` | Download ボタン + Blob DL + エラーバナー（`data-testid="present-html-download"`） |
| lang (messages + 8 locale) | `download` / `downloadZip` / `downloadError` |

## テスト

share/route ユニット **29件 pass**（`packHtmlZip` 追加）。`yarn format` / `lint`(0 error) / `typecheck`(全ステップ) / `build` / 全 `yarn test` グリーン。i18n は `Messages` 型で 8 locale ロックステップを型保証。

## ロードマップ

- Phase 1（#1892 済）: pack + download バックエンド
- **Phase 1b（本PR）**: UI 導線
- Phase 2: S3互換アップロード + 共有台帳
- Phase 3: Markdown / 単一Wikiページ

🤖 Generated with [Claude Code](https://claude.com/claude-code)