### PR TITLE
fix(chat-index): source CHAT_DIR from WORKSPACE_DIRS (#1902)

### DIFF
--- a/plans/fix-1902-chat-index-path.md
+++ b/plans/fix-1902-chat-index-path.md
@@ -1,0 +1,47 @@
+# fix #1902: chat-index CHAT_DIR is stale (`chat/` vs `conversations/chat/`)
+
+## User prompt (JP)
+
+> https://github.com/receptron/mulmoclaude/pull/1884 これってこの変更以前から一覧のタイトル部分にサマリーが反映されてない。サマリー的なタイトルが作れらていないか、表示に失敗しているので調査して。
+>
+> 未来だけ動けば良い。修正して。
+
+## Root cause
+
+`server/workspace/chat-index/paths.ts:8` hardcodes `CHAT_DIR = "chat"`. The workspace layout moved to `conversations/chat` in the #284 reorg (`server/workspace/paths.ts:96` — `chat: "conversations/chat"`), but this file was not updated.
+
+Consequence: `backfillAllSessions`, `listSessionIds`, `indexSession` all read/write `<workspace>/chat/…` (an empty dir since #284). Every `readManifest` in `sessions.ts:225` returns `{ entries: [] }`, so `indexById.get(sessionId)` is always undefined, and `preview` in `buildSessionSummary` (`sessions.ts:163`) falls back to `meta.firstUserMessage`. AI-generated titles are never persisted or displayed.
+
+Introduced by `f0c5f46b6` (Apr 12, 2026 — chat-index feature). PR #1884 improves summary quality but does not touch this path.
+
+## Fix
+
+Derive `CHAT_DIR` from `WORKSPACE_DIRS.chat` so the two stay in lockstep. No migration of orphaned legacy entries (`~/mulmoclaude/conversations/chat/index/*` from Apr 16 and earlier) — user requested "future only".
+
+### Change
+
+**`server/workspace/chat-index/paths.ts`**
+
+```ts
+import { WORKSPACE_DIRS } from "../paths.js";
+export const CHAT_DIR = WORKSPACE_DIRS.chat;
+```
+
+`chatDirFor(workspaceRoot)` returns `path.join(workspaceRoot, CHAT_DIR)`, which resolves to `<workspaceRoot>/conversations/chat` — matching what `sessions.ts` list handler reads at line 224.
+
+### Test updates
+
+- `test/chat-index/test_paths.ts` — replace hardcoded `"chat"` expectations with `path.join("conversations", "chat")` and update the `CHAT_DIR` value assertion.
+- `test/chat-index/test_indexer.ts` — change the seed helper to `mkdirSync(join(workspace, "conversations", "chat"), …)` and use the same path for chatDir.
+- `test/chat-index/test_maybe_index_session.ts` — same seed-helper adjustment.
+- `test/routes/test_sessionsRoute.ts` — no change needed. It already resolves both dirs via runtime `import` of `WORKSPACE_PATHS.chat` and `indexDirFor(workspacePth)`, so the drift-comment on line 84-85 becomes obsolete (both trees will collapse into one) but the test itself still passes; the stale comment gets updated.
+
+## What is NOT changed
+
+- No backfill migration script for orphaned `~/mulmoclaude/conversations/chat/index/*.json` written before Apr 16. New indexer runs will refresh entries lazily via `maybeIndexSession` from the agent finally-hook.
+- No env-driven force backfill added. Users who want immediate rebuild can run `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1` (already exists in `server/index.ts:930`).
+
+## Verification
+
+1. `yarn format && yarn lint && yarn typecheck && yarn build && yarn test`
+2. Manual: start the server, open a session, complete a turn, confirm `<workspace>/conversations/chat/index/<sessionId>.json` is written and the sessions list shows the AI-generated title.

--- a/server/workspace/chat-index/paths.ts
+++ b/server/workspace/chat-index/paths.ts
@@ -4,8 +4,14 @@
 // claude CLI spawn code).
 
 import path from "node:path";
+import { WORKSPACE_DIRS } from "../paths.js";
 
-export const CHAT_DIR = "chat";
+// Sourced from WORKSPACE_DIRS so the layout move in #284
+// (`chat/` → `conversations/chat/`) can't drift again — a hardcoded
+// literal here silently detached the indexer from the real session
+// tree between Apr and Jul 2026, leaving every session listing
+// preview to fall back to `meta.firstUserMessage` (issue #1902).
+export const CHAT_DIR = WORKSPACE_DIRS.chat;
 export const INDEX_DIR = "index";
 export const MANIFEST_FILE = "manifest.json";
 

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -9,10 +9,13 @@ import { indexEntryPathFor, manifestPathFor } from "../../server/workspace/chat-
 import type { SummaryResult } from "../../server/workspace/chat-index/types.js";
 
 let workspace: string;
+// Mirrors WORKSPACE_DIRS.chat (`conversations/chat`) — the value
+// the indexer resolves through `chatDirFor` at runtime.
+const CHAT_REL = join("conversations", "chat");
 
 beforeEach(() => {
   workspace = mkdtempSync(join(tmpdir(), "chat-index-test-"));
-  mkdirSync(join(workspace, "chat"), { recursive: true });
+  mkdirSync(join(workspace, CHAT_REL), { recursive: true });
 });
 
 afterEach(() => {
@@ -36,7 +39,7 @@ function seedSession(
     userMessages = ["Can you help me plan a project?"],
     assistantMessages = ["Sure — tell me what it's about."],
   } = opts;
-  const chatDir = join(workspace, "chat");
+  const chatDir = join(workspace, CHAT_REL);
   writeFileSync(join(chatDir, `${sessionId}.json`), JSON.stringify({ roleId, startedAt }));
   const lines: string[] = [];
   for (let i = 0; i < Math.max(userMessages.length, assistantMessages.length); i++) {
@@ -228,7 +231,7 @@ describe("indexSession — skip conditions", () => {
   });
 
   it("returns null when the jsonl only has tool_result entries", async () => {
-    const chatDir = join(workspace, "chat");
+    const chatDir = join(workspace, CHAT_REL);
     writeFileSync(
       join(chatDir, "sess-F.json"),
       JSON.stringify({
@@ -333,14 +336,14 @@ describe("readManifest", () => {
   });
 
   it("returns an empty manifest when the file is corrupted", async () => {
-    mkdirSync(join(workspace, "chat", "index"), { recursive: true });
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
     writeFileSync(manifestPathFor(workspace), "{ not json");
     const manifest = await readManifest(workspace);
     assert.deepEqual(manifest, { version: 1, entries: [] });
   });
 
   it("returns an empty manifest for a version mismatch", async () => {
-    mkdirSync(join(workspace, "chat", "index"), { recursive: true });
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
     writeFileSync(manifestPathFor(workspace), JSON.stringify({ version: 99, entries: [] }));
     const manifest = await readManifest(workspace);
     assert.deepEqual(manifest, { version: 1, entries: [] });
@@ -354,14 +357,14 @@ describe("isFresh", () => {
   });
 
   it("returns true when the entry is within the window", async () => {
-    mkdirSync(join(workspace, "chat", "index"), { recursive: true });
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
     writeFileSync(indexEntryPathFor(workspace, "x"), JSON.stringify({ indexedAt: new Date(0).toISOString() }));
     const out = await isFresh(workspace, "x", 5000, MIN_INDEX_INTERVAL_MS);
     assert.equal(out, true);
   });
 
   it("returns false when the entry is outside the window", async () => {
-    mkdirSync(join(workspace, "chat", "index"), { recursive: true });
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
     writeFileSync(indexEntryPathFor(workspace, "x"), JSON.stringify({ indexedAt: new Date(0).toISOString() }));
     const out = await isFresh(workspace, "x", MIN_INDEX_INTERVAL_MS + 1, MIN_INDEX_INTERVAL_MS);
     assert.equal(out, false);

--- a/test/chat-index/test_maybe_index_session.ts
+++ b/test/chat-index/test_maybe_index_session.ts
@@ -10,11 +10,14 @@ import { ClaudeCliNotFoundError } from "../../server/workspace/journal/archivist
 import type { SummaryResult } from "../../server/workspace/chat-index/types.js";
 
 let workspace: string;
+// Mirrors WORKSPACE_DIRS.chat (`conversations/chat`) — the value
+// the indexer resolves through `chatDirFor` at runtime.
+const CHAT_REL = join("conversations", "chat");
 
 beforeEach(() => {
   __resetForTests();
   workspace = mkdtempSync(join(tmpdir(), "chat-index-maybe-"));
-  mkdirSync(join(workspace, "chat"), { recursive: true });
+  mkdirSync(join(workspace, CHAT_REL), { recursive: true });
 });
 
 afterEach(() => {
@@ -22,7 +25,7 @@ afterEach(() => {
 });
 
 function seedSession(sessionId: string): void {
-  const chatDir = join(workspace, "chat");
+  const chatDir = join(workspace, CHAT_REL);
   writeFileSync(
     join(chatDir, `${sessionId}.json`),
     JSON.stringify({

--- a/test/chat-index/test_paths.ts
+++ b/test/chat-index/test_paths.ts
@@ -21,52 +21,58 @@ import {
 // matches on Windows (backslashes) as well as POSIX.
 const workspace = path.join(path.sep, "tmp", "ws");
 
+// The chat dir is sourced from WORKSPACE_DIRS.chat so the layout
+// move in #284 (`chat/` → `conversations/chat/`) can't silently
+// drift again. `CHAT_REL` reflects the current on-disk relative
+// path used by every joined-path expectation below.
+const CHAT_REL = path.join("conversations", "chat");
+
 describe("constants", () => {
   it("exports expected directory and file name constants", () => {
-    assert.equal(CHAT_DIR, "chat");
+    assert.equal(CHAT_DIR, CHAT_REL);
     assert.equal(INDEX_DIR, "index");
     assert.equal(MANIFEST_FILE, "manifest.json");
   });
 });
 
 describe("chatDirFor", () => {
-  it("returns workspace/chat", () => {
-    assert.equal(chatDirFor(workspace), path.join(workspace, "chat"));
+  it("returns workspace/conversations/chat", () => {
+    assert.equal(chatDirFor(workspace), path.join(workspace, CHAT_REL));
   });
 });
 
 describe("indexDirFor", () => {
-  it("returns workspace/chat/index", () => {
-    assert.equal(indexDirFor(workspace), path.join(workspace, "chat", "index"));
+  it("returns workspace/conversations/chat/index", () => {
+    assert.equal(indexDirFor(workspace), path.join(workspace, CHAT_REL, "index"));
   });
 });
 
 describe("sessionJsonlPathFor", () => {
-  it("returns workspace/chat/<sessionId>.jsonl", () => {
-    assert.equal(sessionJsonlPathFor(workspace, "sess-abc"), path.join(workspace, "chat", "sess-abc.jsonl"));
+  it("returns workspace/conversations/chat/<sessionId>.jsonl", () => {
+    assert.equal(sessionJsonlPathFor(workspace, "sess-abc"), path.join(workspace, CHAT_REL, "sess-abc.jsonl"));
   });
 
   it("handles UUID-style session IDs", () => {
     const sessionId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
-    assert.equal(sessionJsonlPathFor(workspace, sessionId), path.join(workspace, "chat", `${sessionId}.jsonl`));
+    assert.equal(sessionJsonlPathFor(workspace, sessionId), path.join(workspace, CHAT_REL, `${sessionId}.jsonl`));
   });
 });
 
 describe("sessionMetaPathFor", () => {
-  it("returns workspace/chat/<sessionId>.json", () => {
-    assert.equal(sessionMetaPathFor(workspace, "sess-abc"), path.join(workspace, "chat", "sess-abc.json"));
+  it("returns workspace/conversations/chat/<sessionId>.json", () => {
+    assert.equal(sessionMetaPathFor(workspace, "sess-abc"), path.join(workspace, CHAT_REL, "sess-abc.json"));
   });
 });
 
 describe("indexEntryPathFor", () => {
-  it("returns workspace/chat/index/<sessionId>.json", () => {
-    assert.equal(indexEntryPathFor(workspace, "sess-abc"), path.join(workspace, "chat", "index", "sess-abc.json"));
+  it("returns workspace/conversations/chat/index/<sessionId>.json", () => {
+    assert.equal(indexEntryPathFor(workspace, "sess-abc"), path.join(workspace, CHAT_REL, "index", "sess-abc.json"));
   });
 });
 
 describe("manifestPathFor", () => {
-  it("returns workspace/chat/index/manifest.json", () => {
-    assert.equal(manifestPathFor(workspace), path.join(workspace, "chat", "index", "manifest.json"));
+  it("returns workspace/conversations/chat/index/manifest.json", () => {
+    assert.equal(manifestPathFor(workspace), path.join(workspace, CHAT_REL, "index", "manifest.json"));
   });
 });
 

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -80,9 +80,10 @@ const BASE_MS = Math.floor((Date.now() - 10 * 86_400_000) / 1000) * 1000;
 
 let tmpRoot: string;
 let chatDir: string;
-// The manifest lives under a DIFFERENT tree from the session files —
-// `chatDirFor(workspaceRoot)` = `<workspace>/chat/index/manifest.json`
-// while WORKSPACE_PATHS.chat may be `<workspace>/conversations/chat/`.
+// Resolved at runtime from the same modules the handler uses, so
+// tests keep working if the on-disk layout moves again (issue
+// #1902 fixed the drift where the two used to point at different
+// trees).
 let manifestDir: string;
 let originalHome: string | undefined;
 let originalUserProfile: string | undefined;
@@ -153,9 +154,8 @@ before(async () => {
   // mirrors the setup in test_configRoute.ts.
   process.env.HOME = tmpRoot;
   process.env.USERPROFILE = tmpRoot;
-  // Use the real dir names from the workspace/paths and chat-index
-  // modules — they may differ (e.g. `conversations/chat` for session
-  // files, `chat/index` for the manifest after #284).
+  // Resolve both roots from the real modules so the test still
+  // agrees with production paths no matter how the layout evolves.
   const { WORKSPACE_PATHS } = await import("../../server/workspace/paths.js");
   const { indexDirFor } = await import("../../server/workspace/chat-index/paths.js");
   const { workspacePath: workspacePth } = await import("../../server/workspace/workspace.js");


### PR DESCRIPTION
## Summary

Source `CHAT_DIR` in `server/workspace/chat-index/paths.ts` from `WORKSPACE_DIRS.chat` so the indexer / listing paths stay in lockstep with the workspace layout. The hardcoded `"chat"` string dated from Apr 12; the #284 reorg moved sessions to `conversations/chat/` and this file was missed. Result: AI-generated session titles were never persisted or displayed.

Closes #1902.

## Items to Confirm / Review

- **Import direction.** `chat-index/paths.ts` now imports `WORKSPACE_DIRS` from `../paths.ts`. `workspace/paths.ts` has no runtime side effects on module load (it only reads `homedir()` and aggregates plugin metas), and the workspace paths module is already loaded elsewhere in every process that touches chat-index, so this doesn't introduce a new eager dep or slow boot.
- **No migration.** Per user request ("未来だけ動けば良い"), pre-Apr-16 legacy entries at `~/mulmoclaude/conversations/chat/index/*.json` are left as-is. New sessions index correctly via the agent finally-hook; users who want to backfill can set `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1`.
- **Test stance.** `test_paths.ts` now hardcodes `"conversations/chat"` alongside `WORKSPACE_DIRS.chat`. If the layout moves again, both the runtime constant and the test literal need updating together — that's intentional (the test is a change-detector for the on-disk contract).

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/1884 これってこの変更以前から一覧のタイトル部分にサマリーが反映されてない。サマリー的なタイトルが作れらていないか、表示に失敗しているので調査して。
>
> 未来だけ動けば良い。修正して。

## Root cause

`server/workspace/chat-index/paths.ts:8` hardcoded `CHAT_DIR = "chat"`. The workspace layout moved to `conversations/chat` in the #284 reorg (`WORKSPACE_DIRS.chat = "conversations/chat"` in `server/workspace/paths.ts:96`), but this file was never updated.

Downstream:
- `backfillAllSessions` / `listSessionIds` read from `<workspace>/chat/` (0 files today) → 0 sessions indexed.
- `indexSession` reads jsonl from `<workspace>/chat/<id>.jsonl` (nonexistent) → returns null.
- `readManifest(workspacePath)` in `sessions.ts:225` reads `<workspace>/chat/index/manifest.json` — always empty.
- `sessions.ts:163` `preview = indexEntry?.title ?? meta.firstUserMessage ?? ""` — since `indexEntry` is always undefined, list always shows `firstUserMessage`, never the AI title.

Introduced by `f0c5f46b6` (Apr 12, 2026). PR #1884 improves summary quality but does not touch this configuration — the visible symptom predates that PR.

## Implementation

```ts
import { WORKSPACE_DIRS } from "../paths.js";
export const CHAT_DIR = WORKSPACE_DIRS.chat;
```

`chatDirFor(workspaceRoot)` now resolves to `<workspaceRoot>/conversations/chat`, matching what `sessions.ts` reads via `WORKSPACE_PATHS.chat`.

## Test updates

- `test/chat-index/test_paths.ts` — expectations rewritten around `path.join("conversations", "chat")`; `CHAT_DIR` value assertion updated.
- `test/chat-index/test_indexer.ts`, `test/chat-index/test_maybe_index_session.ts` — seed helper directories switched to `join(workspace, "conversations", "chat")`.
- `test/routes/test_sessionsRoute.ts` — stale drift-warning comment replaced; test infrastructure unchanged since it already resolved both roots at runtime.

## Verification

- `yarn format`, `yarn lint` — clean (no new errors; existing 26 warnings unrelated).
- `yarn typecheck`, `yarn build` — pass.
- `yarn test` — all 21 suites pass, 0 fail.
- Focused: `tsx --test test/chat-index/* test/routes/test_sessionsRoute.ts` → 53/53 pass.

## Test plan

- [ ] Start the server, complete an agent turn on a fresh session, confirm `~/mulmoclaude/conversations/chat/index/<sessionId>.json` is written with `title`/`summary`/`keywords`.
- [ ] Reload the sessions list, confirm the row displays the AI title (not the first user message).
- [ ] Optional: set `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1`, restart, confirm the backfill picks up pre-existing sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat session indexing now follows the current workspace folder layout, helping keep session lists and generated titles in sync.
* **Tests**
  * Updated path-related tests and fixtures to use the new chat directory location.
  * Adjusted route test notes to match runtime path resolution.
* **Documentation**
  * Added a fix plan with root cause, verification steps, and notes on expected behavior for existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->