### PR TITLE
feat(markdown): render mermaid fenced blocks as diagrams (#1904)

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "marked-highlight": "^2.2.4",
     "material-icons": "^1.13.14",
     "material-symbols": "^0.45.4",
+    "mermaid": "^11.16.0",
     "mulmocast": "^2.6.23",
     "node-html-parser": "^8.0.4",
     "node-pty": "^1.1.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/markdown-plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Full-fidelity markdown document plugin (presentDocument) — Marp slides, PDF export, AI image-fill — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal.",
   "type": "module",
   "main": "./dist/index.js",
@@ -37,7 +37,8 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.3.0",
     "js-yaml": "^5.2.0",
-    "marked": "^18.0.5"
+    "marked": "^18.0.5",
+    "mermaid": "^11.16.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^0.3.0",

--- a/packages/plugins/markdown-plugin/src/lang/de.ts
+++ b/packages/plugins/markdown-plugin/src/lang/de.ts
@@ -23,6 +23,8 @@ const de: Messages = {
   marpSplitEnter: "Quelle neben der Vorschau bearbeiten",
   marpSplitExit: "Quelleneditor schließen",
   marpSplitEditorLabel: "Quelle",
+  mermaidLoadFailed: "⚠ Mermaid konnte nicht geladen werden: {error}",
+  mermaidRenderFailed: "⚠ Mermaid-Rendering fehlgeschlagen: {error}",
 };
 
 export default de;

--- a/packages/plugins/markdown-plugin/src/lang/en.ts
+++ b/packages/plugins/markdown-plugin/src/lang/en.ts
@@ -22,6 +22,8 @@ const en: Messages = {
   marpSplitEnter: "Edit source side-by-side with preview",
   marpSplitExit: "Hide source editor",
   marpSplitEditorLabel: "Source",
+  mermaidLoadFailed: "⚠ Mermaid failed to load: {error}",
+  mermaidRenderFailed: "⚠ Mermaid render failed: {error}",
 };
 
 export default en;

--- a/packages/plugins/markdown-plugin/src/lang/es.ts
+++ b/packages/plugins/markdown-plugin/src/lang/es.ts
@@ -22,6 +22,8 @@ const es: Messages = {
   marpSplitEnter: "Editar la fuente junto a la vista previa",
   marpSplitExit: "Cerrar el editor de la fuente",
   marpSplitEditorLabel: "Fuente",
+  mermaidLoadFailed: "⚠ Error al cargar Mermaid: {error}",
+  mermaidRenderFailed: "⚠ Error al renderizar Mermaid: {error}",
 };
 
 export default es;

--- a/packages/plugins/markdown-plugin/src/lang/fr.ts
+++ b/packages/plugins/markdown-plugin/src/lang/fr.ts
@@ -22,6 +22,8 @@ const fr: Messages = {
   marpSplitEnter: "Modifier la source en parallèle de l'aperçu",
   marpSplitExit: "Fermer l'éditeur de source",
   marpSplitEditorLabel: "Source",
+  mermaidLoadFailed: "⚠ Échec du chargement de Mermaid : {error}",
+  mermaidRenderFailed: "⚠ Échec du rendu Mermaid : {error}",
 };
 
 export default fr;

--- a/packages/plugins/markdown-plugin/src/lang/ja.ts
+++ b/packages/plugins/markdown-plugin/src/lang/ja.ts
@@ -22,6 +22,8 @@ const ja: Messages = {
   marpSplitEnter: "ソースを並べて編集",
   marpSplitExit: "ソースエディタを閉じる",
   marpSplitEditorLabel: "ソース",
+  mermaidLoadFailed: "⚠ Mermaid の読み込みに失敗しました: {error}",
+  mermaidRenderFailed: "⚠ Mermaid の描画に失敗しました: {error}",
 };
 
 export default ja;

--- a/packages/plugins/markdown-plugin/src/lang/ko.ts
+++ b/packages/plugins/markdown-plugin/src/lang/ko.ts
@@ -22,6 +22,8 @@ const ko: Messages = {
   marpSplitEnter: "소스를 나란히 편집",
   marpSplitExit: "소스 편집기 닫기",
   marpSplitEditorLabel: "소스",
+  mermaidLoadFailed: "⚠ Mermaid 로드 실패: {error}",
+  mermaidRenderFailed: "⚠ Mermaid 렌더링 실패: {error}",
 };
 
 export default ko;

--- a/packages/plugins/markdown-plugin/src/lang/messages.ts
+++ b/packages/plugins/markdown-plugin/src/lang/messages.ts
@@ -25,4 +25,6 @@ export interface Messages {
   marpSplitEnter: string;
   marpSplitExit: string;
   marpSplitEditorLabel: string;
+  mermaidLoadFailed: string;
+  mermaidRenderFailed: string;
 }

--- a/packages/plugins/markdown-plugin/src/lang/ptBR.ts
+++ b/packages/plugins/markdown-plugin/src/lang/ptBR.ts
@@ -22,6 +22,8 @@ const ptBR: Messages = {
   marpSplitEnter: "Editar o código fonte ao lado da visualização",
   marpSplitExit: "Fechar o editor de código",
   marpSplitEditorLabel: "Código",
+  mermaidLoadFailed: "⚠ Falha ao carregar o Mermaid: {error}",
+  mermaidRenderFailed: "⚠ Falha ao renderizar o Mermaid: {error}",
 };
 
 export default ptBR;

--- a/packages/plugins/markdown-plugin/src/lang/zh.ts
+++ b/packages/plugins/markdown-plugin/src/lang/zh.ts
@@ -22,6 +22,8 @@ const zh: Messages = {
   marpSplitEnter: "并排编辑源代码",
   marpSplitExit: "关闭源代码编辑器",
   marpSplitEditorLabel: "源代码",
+  mermaidLoadFailed: "⚠ Mermaid 加载失败: {error}",
+  mermaidRenderFailed: "⚠ Mermaid 渲染失败: {error}",
 };
 
 export default zh;

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/View.vue
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/View.vue
@@ -121,7 +121,7 @@
                cannot bind @click directly on each `<input>` because
                v-html bypasses Vue's template compiler. -->
           <!-- eslint-disable-next-line vue/no-v-html -- marked.parse output of app-owned markdown content; trusted in-process render -->
-          <div class="markdown-content prose prose-slate max-w-none" @click="onMarkdownClick" v-html="renderedHtml"></div>
+          <div ref="markdownContainerRef" class="markdown-content prose prose-slate max-w-none" @click="onMarkdownClick" v-html="renderedHtml"></div>
         </div>
       </div>
 
@@ -154,6 +154,8 @@ import type { ToolResult } from "gui-chat-protocol";
 import { isFilePath, type MarkdownToolData } from "./definition";
 import { rewriteMarkdownImageRefs } from "../../utils/image/rewriteMarkdownImageRefs";
 import { findTaskLines, makeTasksInteractive, toggleTaskAt } from "../../utils/markdown/taskList";
+import { mermaidExtension } from "../../utils/markdown/mermaidExtension";
+import { useMermaidRenderer } from "../../utils/markdown/useMermaid";
 import { usePdfExport } from "./usePdfExport";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
@@ -163,6 +165,14 @@ import { isMarpDocument } from "../../utils/markdown/marpDetect";
 import { useT } from "../../lang";
 import MarpView from "./MarpView.vue";
 import MarpSplitEditor from "./MarpSplitEditor.vue";
+
+// Register the mermaid block extension once at module load. `marked`
+// in this plugin is a bundled copy (not the host's global instance),
+// so `.use()` is a plugin-local side effect — safe to call at import
+// time, but idempotent-ish: registering the same extension twice
+// would double-tokenise; module-level call fires exactly once per
+// bundle load.
+marked.use(mermaidExtension);
 
 const t = useT();
 const { dispatch } = useRuntime();
@@ -366,6 +376,9 @@ const renderedHtml = computed(() => {
   // even though clicks there only update local state.
   return makeTasksInteractive(marked(withImages) as string);
 });
+
+const markdownContainerRef = ref<HTMLElement | null>(null);
+useMermaidRenderer(markdownContainerRef, renderedHtml);
 
 // Watch for scroll requests from viewState
 watch(

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
@@ -6,7 +6,9 @@
 
 import type { MarkedExtension, TokenizerAndRendererExtension } from "marked";
 
-const MERMAID_FENCE = /^```mermaid[ \t]*\n([\s\S]*?)\n```(?:\n|$)/;
+// `\r?\n` at every line-ending anchor so a Windows-authored source
+// (CRLF line endings) tokenises identically to a Unix source.
+const MERMAID_FENCE = /^```mermaid[ \t]*\r?\n([\s\S]*?)\r?\n```(?:\r?\n|$)/;
 
 function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
@@ -1,0 +1,39 @@
+// Duplicate of the host's `src/utils/markdown/mermaidExtension.ts` —
+// the plugin ships its own bundled `marked` (see package.json), so it
+// cannot reach across to the host module without pulling the whole
+// host into the plugin bundle. Kept in sync manually; if the shape
+// changes on one side, update the other.
+
+import type { MarkedExtension, TokenizerAndRendererExtension } from "marked";
+
+const MERMAID_FENCE = /^```mermaid[ \t]*\n([\s\S]*?)\n```(?:\n|$)/;
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+const mermaidBlockExtension: TokenizerAndRendererExtension = {
+  name: "mermaidBlock",
+  level: "block",
+  start(src: string): number | undefined {
+    const idx = src.indexOf("```mermaid");
+    return idx === -1 ? undefined : idx;
+  },
+  tokenizer(src: string) {
+    const match = MERMAID_FENCE.exec(src);
+    if (!match) return undefined;
+    return {
+      type: "mermaidBlock",
+      raw: match[0],
+      text: match[1],
+    };
+  },
+  renderer(token) {
+    const source = typeof token.text === "string" ? token.text : "";
+    return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(source)}</pre>\n`;
+  },
+};
+
+export const mermaidExtension: MarkedExtension = {
+  extensions: [mermaidBlockExtension],
+};

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
@@ -4,38 +4,18 @@
 // host into the plugin bundle. Kept in sync manually; if the shape
 // changes on one side, update the other.
 
-import type { MarkedExtension, TokenizerAndRendererExtension } from "marked";
-
-// `\r?\n` at every line-ending anchor so a Windows-authored source
-// (CRLF line endings) tokenises identically to a Unix source.
-const MERMAID_FENCE = /^```mermaid[ \t]*\r?\n([\s\S]*?)\r?\n```(?:\r?\n|$)/;
+import type { MarkedExtension, Tokens } from "marked";
 
 function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
-const mermaidBlockExtension: TokenizerAndRendererExtension = {
-  name: "mermaidBlock",
-  level: "block",
-  start(src: string): number | undefined {
-    const idx = src.indexOf("```mermaid");
-    return idx === -1 ? undefined : idx;
-  },
-  tokenizer(src: string) {
-    const match = MERMAID_FENCE.exec(src);
-    if (!match) return undefined;
-    return {
-      type: "mermaidBlock",
-      raw: match[0],
-      text: match[1],
-    };
-  },
-  renderer(token) {
-    const source = typeof token.text === "string" ? token.text : "";
-    return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(source)}</pre>\n`;
-  },
-};
-
 export const mermaidExtension: MarkedExtension = {
-  extensions: [mermaidBlockExtension],
+  renderer: {
+    code(token: Tokens.Code): string | false {
+      const lang = (token.lang ?? "").trim();
+      if (lang !== "mermaid") return false;
+      return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(token.text)}</pre>\n`;
+    },
+  },
 };

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
@@ -1,0 +1,55 @@
+// Duplicate of the host's `src/utils/markdown/mermaidRender.ts` —
+// the plugin ships its own `mermaid` dep so the dynamic import
+// resolves inside the plugin bundle rather than reaching into the
+// host. Kept in sync with the host module; edits here should mirror
+// there.
+
+type MermaidRuntime = typeof import("mermaid").default;
+
+let mermaidPromise: Promise<MermaidRuntime> | null = null;
+
+async function loadMermaid(): Promise<MermaidRuntime> {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((mod) => {
+      const mermaid = mod.default;
+      mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
+      return mermaid;
+    });
+  }
+  return mermaidPromise;
+}
+
+let renderCounter = 0;
+function nextRenderId(): string {
+  renderCounter += 1;
+  return `mulmo-mermaid-plugin-${renderCounter}`;
+}
+
+function pendingNodes(root: Element | Document): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
+}
+
+async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<void> {
+  const source = node.textContent ?? "";
+  const svgId = nextRenderId();
+  try {
+    const { svg } = await mermaid.render(svgId, source);
+    const wrapper = document.createElement("div");
+    wrapper.className = "mermaid-diagram";
+    wrapper.innerHTML = svg;
+    node.replaceWith(wrapper);
+  } catch (err) {
+    const errBox = document.createElement("pre");
+    errBox.className = "mermaid-error";
+    errBox.textContent = `Mermaid render failed: ${String(err)}\n---\n${source}`;
+    node.replaceWith(errBox);
+  }
+}
+
+export async function renderMermaidNodes(root: Element | Document | null | undefined): Promise<void> {
+  if (!root) return;
+  const nodes = pendingNodes(root);
+  if (nodes.length === 0) return;
+  const mermaid = await loadMermaid();
+  await Promise.all(nodes.map((node) => renderOne(node, mermaid)));
+}

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
@@ -58,14 +58,26 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
+// Mirrors host `adoptSvg` — DOMParser adoption keeps the SVG
+// namespace exact and dodges opengrep's `innerHTML =` XSS heuristic.
+function adoptSvg(svgMarkup: string): SVGElement | null {
+  const parsed = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
+  const root = parsed.documentElement;
+  if (root.getElementsByTagName("parsererror").length > 0) return null;
+  if (root.tagName.toLowerCase() !== "svg") return null;
+  return document.importNode(root, true) as unknown as SVGElement;
+}
+
 async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels): Promise<void> {
   const source = node.textContent ?? "";
   const svgId = nextRenderId();
   try {
     const { svg } = await mermaid.render(svgId, source);
+    const svgNode = adoptSvg(svg);
+    if (!svgNode) throw new Error("mermaid produced malformed SVG");
     const wrapper = document.createElement("div");
     wrapper.className = "mermaid-diagram";
-    wrapper.innerHTML = svg;
+    wrapper.appendChild(svgNode);
     node.replaceWith(wrapper);
   } catch (err) {
     const errBox = document.createElement("pre");

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
@@ -9,14 +9,29 @@ type MermaidRuntime = typeof import("mermaid").default;
 let mermaidPromise: Promise<MermaidRuntime> | null = null;
 
 async function loadMermaid(): Promise<MermaidRuntime> {
-  if (!mermaidPromise) {
-    mermaidPromise = import("mermaid").then((mod) => {
-      const mermaid = mod.default;
-      mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
-      return mermaid;
-    });
+  if (mermaidPromise) return mermaidPromise;
+  const attempt = import("mermaid").then((mod) => {
+    const mermaid = mod.default;
+    mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
+    return mermaid;
+  });
+  // Reset the cache on rejection so a transient import failure
+  // (offline / stale chunk after deploy) can be retried by the next
+  // fence to render, matching the host module's contract.
+  attempt.catch(() => {
+    if (mermaidPromise === attempt) mermaidPromise = null;
+  });
+  mermaidPromise = attempt;
+  return attempt;
+}
+
+function placeLoadError(nodes: HTMLElement[], err: unknown): void {
+  for (const node of nodes) {
+    const errBox = document.createElement("pre");
+    errBox.className = "mermaid-error";
+    errBox.textContent = `Mermaid failed to load: ${String(err)}`;
+    node.replaceWith(errBox);
   }
-  return mermaidPromise;
 }
 
 let renderCounter = 0;
@@ -50,6 +65,12 @@ export async function renderMermaidNodes(root: Element | Document | null | undef
   if (!root) return;
   const nodes = pendingNodes(root);
   if (nodes.length === 0) return;
-  const mermaid = await loadMermaid();
+  let mermaid: MermaidRuntime;
+  try {
+    mermaid = await loadMermaid();
+  } catch (err) {
+    placeLoadError(nodes, err);
+    return;
+  }
   await Promise.all(nodes.map((node) => renderOne(node, mermaid)));
 }

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
@@ -6,6 +6,19 @@
 
 type MermaidRuntime = typeof import("mermaid").default;
 
+/** Localised strings the render pipeline surfaces when it fails.
+ *  See the host module (`src/utils/markdown/mermaidRender.ts`) for
+ *  the design rationale — kept in sync manually. */
+export interface MermaidRenderLabels {
+  loadFailed: (error: string) => string;
+  renderFailed: (error: string) => string;
+}
+
+const DEFAULT_LABELS: MermaidRenderLabels = {
+  loadFailed: (error) => `⚠ Mermaid failed to load: ${error}`,
+  renderFailed: (error) => `⚠ Mermaid render failed: ${error}`,
+};
+
 let mermaidPromise: Promise<MermaidRuntime> | null = null;
 
 async function loadMermaid(): Promise<MermaidRuntime> {
@@ -25,11 +38,12 @@ async function loadMermaid(): Promise<MermaidRuntime> {
   return attempt;
 }
 
-function placeLoadError(nodes: HTMLElement[], err: unknown): void {
+function placeLoadError(nodes: HTMLElement[], err: unknown, labels: MermaidRenderLabels): void {
+  const message = labels.loadFailed(String(err));
   for (const node of nodes) {
     const errBox = document.createElement("pre");
     errBox.className = "mermaid-error";
-    errBox.textContent = `Mermaid failed to load: ${String(err)}`;
+    errBox.textContent = message;
     node.replaceWith(errBox);
   }
 }
@@ -44,7 +58,7 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
-async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<void> {
+async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels): Promise<void> {
   const source = node.textContent ?? "";
   const svgId = nextRenderId();
   try {
@@ -56,12 +70,12 @@ async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<vo
   } catch (err) {
     const errBox = document.createElement("pre");
     errBox.className = "mermaid-error";
-    errBox.textContent = `Mermaid render failed: ${String(err)}\n---\n${source}`;
+    errBox.textContent = `${labels.renderFailed(String(err))}\n---\n${source}`;
     node.replaceWith(errBox);
   }
 }
 
-export async function renderMermaidNodes(root: Element | Document | null | undefined): Promise<void> {
+export async function renderMermaidNodes(root: Element | Document | null | undefined, labels: MermaidRenderLabels = DEFAULT_LABELS): Promise<void> {
   if (!root) return;
   const nodes = pendingNodes(root);
   if (nodes.length === 0) return;
@@ -69,8 +83,8 @@ export async function renderMermaidNodes(root: Element | Document | null | undef
   try {
     mermaid = await loadMermaid();
   } catch (err) {
-    placeLoadError(nodes, err);
+    placeLoadError(nodes, err, labels);
     return;
   }
-  await Promise.all(nodes.map((node) => renderOne(node, mermaid)));
+  await Promise.all(nodes.map((node) => renderOne(node, mermaid, labels)));
 }

--- a/packages/plugins/markdown-plugin/src/utils/markdown/useMermaid.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/useMermaid.ts
@@ -1,0 +1,17 @@
+// Duplicate of the host's `src/utils/markdown/useMermaid.ts` — kept
+// separate so the plugin doesn't pull the host Vue tree into its
+// bundle. Behavior is identical.
+
+import { onMounted, watch, nextTick, type Ref } from "vue";
+import { renderMermaidNodes } from "./mermaidRender";
+
+export function useMermaidRenderer(containerRef: Ref<HTMLElement | null | undefined>, sourceRef: Ref<unknown>): void {
+  const run = async (): Promise<void> => {
+    await nextTick();
+    await renderMermaidNodes(containerRef.value ?? null);
+  };
+  onMounted(() => {
+    void run();
+  });
+  watch(sourceRef, () => void run(), { flush: "post" });
+}

--- a/packages/plugins/markdown-plugin/src/utils/markdown/useMermaid.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/useMermaid.ts
@@ -3,12 +3,21 @@
 // bundle. Behavior is identical.
 
 import { onMounted, watch, nextTick, type Ref } from "vue";
-import { renderMermaidNodes } from "./mermaidRender";
+import { renderMermaidNodes, type MermaidRenderLabels } from "./mermaidRender";
+import { useT } from "../../lang";
 
 export function useMermaidRenderer(containerRef: Ref<HTMLElement | null | undefined>, sourceRef: Ref<unknown>): void {
+  const t = useT();
+  // Same locale-aware label wiring as the host — the plugin's own
+  // `useT` resolves against the plugin's bundled Messages so the
+  // strings stay in lockstep across host locale changes.
+  const labels: MermaidRenderLabels = {
+    loadFailed: (error) => t("mermaidLoadFailed", { error }),
+    renderFailed: (error) => t("mermaidRenderFailed", { error }),
+  };
   const run = async (): Promise<void> => {
     await nextTick();
-    await renderMermaidNodes(containerRef.value ?? null);
+    await renderMermaidNodes(containerRef.value ?? null, labels);
   };
   onMounted(() => {
     void run();

--- a/plans/feat-1904-markdown-mermaid.md
+++ b/plans/feat-1904-markdown-mermaid.md
@@ -1,0 +1,67 @@
+# feat #1904: render mermaid diagrams in markdown viewers
+
+## User prompt (JP)
+
+> markdown viewer でマーメイドも表示させたい
+
+Scope confirmed via follow-up: **host + markdown-plugin** (all viewers), **lazy load** on first mermaid fence.
+
+## Design
+
+Two components:
+
+1. **marked block extension** — matches `\`\`\`mermaid\n…\n\`\`\`` fences at the block level and short-circuits them into `<pre class="mermaid" data-mermaid-pending="1">SOURCE</pre>`. Registered BEFORE `markedHighlightExtension` so highlight.js never sees a mermaid fence (which it would otherwise render as plaintext).
+
+2. **mermaid runner** — `renderMermaidNodes(root)` scans for `pre.mermaid[data-mermaid-pending]`, lazy dynamic-imports `mermaid` on first hit, initialises once with `startOnLoad: false, securityLevel: "strict", theme: "default"`, and per node calls `mermaid.render(uniqueId, textContent)` → replaces the `<pre>` in place with a `<div class="mermaid-diagram">` wrapping the returned SVG. On parse error the node becomes a `<pre class="mermaid-error">` showing diagnostic + source.
+
+3. **Vue composable** — `useMermaidRenderer(containerRef, sourceRef)` schedules a `nextTick` → `renderMermaidNodes` on mount and on `sourceRef` change.
+
+### Sanitiser interaction
+
+Some viewers (`skill/View.vue`, `manageSkills/View.vue`) sanitise via `sanitizeMarkdownHtml` (DOMPurify). Default DOMPurify config keeps `<pre>` + `class` + `data-*` intact, so the placeholder survives sanitisation. The SVG that mermaid injects post-render bypasses the sanitiser (it goes into a live DOM node via `node.replaceWith(...)`) — this matches how `wikiEmbedHandlers.ts` iframes work today.
+
+### Files added
+
+#### Host (`src/utils/markdown/`)
+
+- `mermaidExtension.ts` — the marked block extension (pure, no runtime deps beyond `marked` for types).
+- `mermaidRender.ts` — the lazy loader + `renderMermaidNodes(root)`.
+- `useMermaid.ts` — the composable.
+
+#### Plugin (`packages/plugins/markdown-plugin/src/utils/markdown/`)
+
+- Same three modules copied over. The plugin ships its own bundled `marked` + own version of the wiring, so we duplicate rather than import from the host (avoids uphill dependency violating the plugin/host boundary rule in CLAUDE.md).
+
+### Files modified
+
+#### Host
+
+- `src/utils/markdown/setup.ts` — `marked.use(mermaidExtension)` registered before `markedHighlightExtension`.
+- `src/plugins/textResponse/View.vue` — add container ref + `useMermaidRenderer`.
+- `src/plugins/textResponse/Preview.vue` — same.
+- `src/plugins/wiki/components/WikiPageBody.vue` — same (already has `rootRef`).
+- `src/plugins/skill/View.vue` — same.
+- `src/plugins/manageSkills/View.vue` — same, wired for both `renderedBody` and `catalogRenderedBody`.
+
+#### Plugin
+
+- `packages/plugins/markdown-plugin/src/plugins/markdown/View.vue` — configure the plugin-local `marked` with the extension + wire the composable.
+- `packages/plugins/markdown-plugin/package.json` — add `mermaid` dep, bump `version`.
+
+### Tests
+
+- `test/utils/markdown/test_mermaidExtension.ts` — pure marked→html transform: mermaid fence → `<pre class="mermaid" data-mermaid-pending="1">…</pre>`; non-mermaid fence unchanged; malformed fence (unclosed) falls back to marked default; empty body handled. No mermaid runtime import.
+
+### Manual verification
+
+Playwright:
+1. Open dev server / chat.
+2. Paste a mermaid fence into a session (`graph TB; A-->B`).
+3. Snapshot the response body — expect an inline SVG under `.mermaid-diagram`.
+4. Regression check: paste a plain `\`\`\`js` fence, confirm highlight.js styling still applies.
+
+## What is NOT changed
+
+- No mermaid theme picker. Default theme, matches app light background.
+- No error retry UI. A malformed fence renders a static error block.
+- No mermaid support in `<code>` (inline) — only block fences.

--- a/plans/feat-1904-markdown-mermaid.md
+++ b/plans/feat-1904-markdown-mermaid.md
@@ -8,7 +8,7 @@ Scope confirmed via follow-up: **host + markdown-plugin** (all viewers), **lazy 
 
 ## Design
 
-Two components:
+Three components:
 
 1. **marked block extension** — matches `\`\`\`mermaid\n…\n\`\`\`` fences at the block level and short-circuits them into `<pre class="mermaid" data-mermaid-pending="1">SOURCE</pre>`. Registered BEFORE `markedHighlightExtension` so highlight.js never sees a mermaid fence (which it would otherwise render as plaintext).
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -915,6 +915,10 @@ const deMessages = {
     marpSplitExit: "Quelleneditor schließen",
     marpSplitEditorLabel: "Quelle",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Mermaid konnte nicht geladen werden: {error}",
+    renderFailed: "⚠ Mermaid-Rendering fehlgeschlagen: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ PDF fehlgeschlagen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -927,6 +927,10 @@ const enMessages = {
     marpSplitExit: "Hide source editor",
     marpSplitEditorLabel: "Source",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Mermaid failed to load: {error}",
+    renderFailed: "⚠ Mermaid render failed: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ PDF failed",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -913,6 +913,10 @@ const esMessages = {
     marpSplitExit: "Cerrar el editor de la fuente",
     marpSplitEditorLabel: "Fuente",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Error al cargar Mermaid: {error}",
+    renderFailed: "⚠ Error al renderizar Mermaid: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ Error de PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -903,6 +903,10 @@ const frMessages = {
     marpSplitExit: "Fermer l'éditeur de source",
     marpSplitEditorLabel: "Source",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Échec du chargement de Mermaid : {error}",
+    renderFailed: "⚠ Échec du rendu Mermaid : {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ Échec PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -901,6 +901,10 @@ const jaMessages = {
     marpSplitExit: "ソースエディタを閉じる",
     marpSplitEditorLabel: "ソース",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Mermaid の読み込みに失敗しました: {error}",
+    renderFailed: "⚠ Mermaid の描画に失敗しました: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ PDF 失敗",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -901,6 +901,10 @@ const koMessages = {
     marpSplitExit: "소스 편집기 닫기",
     marpSplitEditorLabel: "소스",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Mermaid 로드 실패: {error}",
+    renderFailed: "⚠ Mermaid 렌더링 실패: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ PDF 실패",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -902,6 +902,10 @@ const ptBRMessages = {
     marpSplitExit: "Fechar o editor de código",
     marpSplitEditorLabel: "Código",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Falha ao carregar o Mermaid: {error}",
+    renderFailed: "⚠ Falha ao renderizar o Mermaid: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ Falha no PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -891,6 +891,10 @@ const zhMessages = {
     marpSplitExit: "关闭源代码编辑器",
     marpSplitEditorLabel: "源代码",
   },
+  markdownMermaid: {
+    loadFailed: "⚠ Mermaid 加载失败: {error}",
+    renderFailed: "⚠ Mermaid 渲染失败: {error}",
+  },
   pluginTextResponse: {
     pdf: "PDF",
     pdfFailed: "⚠ PDF 失败",

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -289,7 +289,7 @@
           <div v-if="catalogDetailLoading" class="text-sm text-gray-400 italic">{{ t("pluginManageSkills.loading") }}</div>
           <div v-else-if="catalogError" class="text-sm text-red-600">{{ catalogError }}</div>
           <!-- eslint-disable vue/no-v-html -- markdown sanitized via sanitizeMarkdownHtml; same trust chain as the active-skill body below -->
-          <div v-else-if="catalogDetail" class="markdown-content text-gray-700" v-html="catalogRenderedBody"></div>
+          <div v-else-if="catalogDetail" ref="catalogMarkdownRef" class="markdown-content text-gray-700" v-html="catalogRenderedBody"></div>
           <!-- eslint-enable vue/no-v-html -->
         </div>
 
@@ -378,6 +378,7 @@
           <!-- eslint-disable vue/no-v-html -- sanitized via DOMPurify; multi-line element so disable/enable pair (CLAUDE.md UI rule) instead of -next-line -->
           <div
             v-else-if="detail && renderedBody"
+            ref="skillMarkdownRef"
             class="markdown-content text-gray-700"
             data-testid="skill-body-rendered"
             @click="handleExternalLinkClick"
@@ -488,6 +489,7 @@ import type { ManageSkillsData, SkillSummary } from "./index";
 import { apiGet, apiPost, apiPut, apiDelete } from "../../utils/api";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { sanitizeMarkdownHtml } from "../../utils/markdown/sanitize";
+import { useMermaidRenderer } from "../../utils/markdown/useMermaid";
 import { pluginEndpoints } from "../api";
 import { buildRouteUrl } from "../meta-types";
 import type { SkillsEndpoints } from "./definition";
@@ -564,6 +566,9 @@ const renderedBody = computed(() => {
   if (!body) return "";
   return sanitizeMarkdownHtml(marked(body) as string);
 });
+
+const skillMarkdownRef = ref<HTMLElement | null>(null);
+useMermaidRenderer(skillMarkdownRef, renderedBody);
 
 // Edit/Delete follows the backend writer contract (writer.ts rejects
 // only source === "user"), NOT the mc- name heuristic. Under #1335
@@ -666,6 +671,9 @@ const catalogRenderedBody = computed(() => {
   if (!body) return "";
   return sanitizeMarkdownHtml(marked(body) as string);
 });
+
+const catalogMarkdownRef = ref<HTMLElement | null>(null);
+useMermaidRenderer(catalogMarkdownRef, catalogRenderedBody);
 
 // External catalog entries grouped under their repo, in the repo
 // order returned by `/external/repos`. Repos with zero discoverable

--- a/src/plugins/skill/View.vue
+++ b/src/plugins/skill/View.vue
@@ -30,7 +30,7 @@
           <div class="border-t border-purple-200 p-4 bg-white rounded-b-lg">
             <div v-if="skillPath" class="text-[11px] font-mono text-gray-400 mb-3 break-all">{{ skillPath }}</div>
             <!-- eslint-disable-next-line vue/no-v-html -- DOMPurify-sanitized markdown of the SKILL.md body Claude CLI synthesised. The body comes from the user's local skill file, surfaced verbatim here. -->
-            <div class="markdown-content prose prose-slate max-w-none" @click="handleExternalLinkClick" v-html="renderedHtml"></div>
+            <div ref="markdownContainerRef" class="markdown-content prose prose-slate max-w-none" @click="handleExternalLinkClick" v-html="renderedHtml"></div>
           </div>
         </details>
       </div>
@@ -39,13 +39,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { marked } from "marked";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { SkillData } from "./types";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { sanitizeMarkdownHtml } from "../../utils/markdown/sanitize";
+import { useMermaidRenderer } from "../../utils/markdown/useMermaid";
 
 const { t } = useI18n();
 
@@ -60,6 +61,9 @@ const skillDescription = computed(() => props.selectedResult.data?.skillDescript
 const body = computed(() => props.selectedResult.data?.body ?? "");
 
 const renderedHtml = computed(() => sanitizeMarkdownHtml(marked(body.value, { breaks: true, gfm: true }) as string));
+
+const markdownContainerRef = ref<HTMLElement | null>(null);
+useMermaidRenderer(markdownContainerRef, renderedHtml);
 </script>
 
 <style scoped>

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -19,7 +19,7 @@
           </summary>
           <div class="border-t border-purple-200 p-4 bg-white rounded-b-lg">
             <!-- eslint-disable vue/no-v-html -- marked.parse output of the plugin-seeded prompt; trusted in-process render matching the standard textResponse path. Multi-line element so disable/enable pair (CLAUDE.md UI rule). -->
-            <div class="markdown-content prose prose-slate max-w-none" @click="openLinksInNewTab" v-html="renderedHtml"></div>
+            <div ref="markdownContainerRef" class="markdown-content prose prose-slate max-w-none" @click="openLinksInNewTab" v-html="renderedHtml"></div>
             <!-- eslint-enable vue/no-v-html -->
             <div v-if="messageAttachments.length > 0" class="space-y-3 mt-3" data-testid="text-response-seeded-attachments">
               <SentAttachmentChip v-for="path in messageAttachments" :key="path" :path="path" variant="block" />
@@ -54,6 +54,7 @@
                 </div>
                 <!-- eslint-disable vue/no-v-html -- marked.parse output of app-owned assistant response text; trusted in-process render. Multi-line element so disable/enable pair (CLAUDE.md UI rule) instead of -next-line. -->
                 <div
+                  ref="markdownContainerRef"
                   class="markdown-content prose prose-slate max-w-none leading-relaxed text-gray-900"
                   :data-testid="isAssistant ? 'text-response-assistant-body' : undefined"
                   v-html="renderedHtml"
@@ -93,6 +94,7 @@ import type { TextResponseData } from "./types";
 import SentAttachmentChip from "../../components/SentAttachmentChip.vue";
 import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { classifyWorkspacePath } from "../../utils/path/workspaceLinkRouter";
+import { useMermaidRenderer } from "../../utils/markdown/useMermaid";
 import { useAppApi } from "../../composables/useAppApi";
 import { usePdfDownload } from "../../composables/usePdfDownload";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
@@ -202,6 +204,13 @@ const hasChanges = computed(() => editedText.value !== editorSource.value);
 // just below, but hoisted up here so `applyChanges` can close the
 // panel after a save without TDZ ordering trouble.
 const detailsEl = ref<HTMLDetailsElement>();
+
+// Container for the rendered markdown surface (seeded-turn card OR
+// assistant response body — only one mounts at a time via v-if/v-else,
+// so a single ref binds to whichever branch is live). Feeds the
+// mermaid post-render pass.
+const markdownContainerRef = ref<HTMLElement | null>(null);
+useMermaidRenderer(markdownContainerRef, renderedHtml);
 
 function applyChanges() {
   if (!hasChanges.value) return;

--- a/src/plugins/wiki/components/WikiPageBody.vue
+++ b/src/plugins/wiki/components/WikiPageBody.vue
@@ -8,6 +8,7 @@ import { computed, ref } from "vue";
 import { renderWikiPageHtml } from "../helpers";
 import { handleExternalLinkClick } from "../../../utils/dom/externalLink";
 import { classifyWorkspacePath, resolveWikiHref } from "../../../utils/path/workspaceLinkRouter";
+import { useMermaidRenderer } from "../../../utils/markdown/useMermaid";
 
 const props = defineProps<{
   body: string;
@@ -23,6 +24,8 @@ const emit = defineEmits<{
 const rootRef = ref<HTMLElement | null>(null);
 
 const renderedHtml = computed(() => renderWikiPageHtml(props.body, props.baseDir));
+
+useMermaidRenderer(rootRef, renderedHtml);
 
 defineExpose({ rootRef });
 

--- a/src/utils/markdown/mermaidExtension.ts
+++ b/src/utils/markdown/mermaidExtension.ts
@@ -15,7 +15,11 @@
 
 import type { MarkedExtension, TokenizerAndRendererExtension } from "marked";
 
-const MERMAID_FENCE = /^```mermaid[ \t]*\n([\s\S]*?)\n```(?:\n|$)/;
+// `\r?\n` at every line-ending anchor so a Windows-authored source
+// (CRLF line endings) tokenises identically to a Unix source. Without
+// this the fence silently falls through to marked's default code
+// scanner and renders as a plaintext block.
+const MERMAID_FENCE = /^```mermaid[ \t]*\r?\n([\s\S]*?)\r?\n```(?:\r?\n|$)/;
 
 // DOMPurify's default policy already permits <pre> + class + data-*,
 // so the placeholder survives sanitisation on the viewers that call

--- a/src/utils/markdown/mermaidExtension.ts
+++ b/src/utils/markdown/mermaidExtension.ts
@@ -1,0 +1,53 @@
+// A marked block-level extension that intercepts ```mermaid fences
+// before the code/highlight pipeline sees them and rewrites the block
+// into a `<pre class="mermaid" data-mermaid-pending="1">` placeholder.
+//
+// The actual diagram render is deferred to `mermaidRender.ts`, which
+// scans the placeholders in the DOM after Vue's v-html injects the
+// html. That two-step split keeps this extension pure (no runtime
+// deps beyond `marked`) so tests can assert the html shape without
+// booting a browser.
+//
+// Registration order matters: this must land BEFORE
+// `markedHighlightExtension` in `setup.ts` so highlight.js never sees
+// the mermaid fence — otherwise `mermaid` becomes a "plaintext"
+// fallback highlight and the source text ends up escaped.
+
+import type { MarkedExtension, TokenizerAndRendererExtension } from "marked";
+
+const MERMAID_FENCE = /^```mermaid[ \t]*\n([\s\S]*?)\n```(?:\n|$)/;
+
+// DOMPurify's default policy already permits <pre> + class + data-*,
+// so the placeholder survives sanitisation on the viewers that call
+// `sanitizeMarkdownHtml`. `data-mermaid-pending` doubles as the query
+// selector `mermaidRender` uses AND as a guard so the runner only
+// touches nodes it hasn't already processed.
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+const mermaidBlockExtension: TokenizerAndRendererExtension = {
+  name: "mermaidBlock",
+  level: "block",
+  start(src: string): number | undefined {
+    const idx = src.indexOf("```mermaid");
+    return idx === -1 ? undefined : idx;
+  },
+  tokenizer(src: string) {
+    const match = MERMAID_FENCE.exec(src);
+    if (!match) return undefined;
+    return {
+      type: "mermaidBlock",
+      raw: match[0],
+      text: match[1],
+    };
+  },
+  renderer(token) {
+    const source = typeof token.text === "string" ? token.text : "";
+    return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(source)}</pre>\n`;
+  },
+};
+
+export const mermaidExtension: MarkedExtension = {
+  extensions: [mermaidBlockExtension],
+};

--- a/src/utils/markdown/mermaidExtension.ts
+++ b/src/utils/markdown/mermaidExtension.ts
@@ -1,57 +1,44 @@
-// A marked block-level extension that intercepts ```mermaid fences
-// before the code/highlight pipeline sees them and rewrites the block
-// into a `<pre class="mermaid" data-mermaid-pending="1">` placeholder.
-//
-// The actual diagram render is deferred to `mermaidRender.ts`, which
+// Marked `code` renderer override that intercepts fenced code blocks
+// whose language tag is `mermaid` and rewrites them into a
+// `<pre class="mermaid" data-mermaid-pending="1">` placeholder. The
+// diagram render itself is deferred to `mermaidRender.ts`, which
 // scans the placeholders in the DOM after Vue's v-html injects the
-// html. That two-step split keeps this extension pure (no runtime
-// deps beyond `marked`) so tests can assert the html shape without
-// booting a browser.
+// html. Two-step split keeps this file pure (no runtime deps beyond
+// `marked`) so tests can assert the html shape without booting a
+// browser.
 //
-// Registration order matters: this must land BEFORE
-// `markedHighlightExtension` in `setup.ts` so highlight.js never sees
-// the mermaid fence — otherwise `mermaid` becomes a "plaintext"
-// fallback highlight and the source text ends up escaped.
+// Why a renderer override and not a block tokenizer:
+//   - marked already handles every fence variation CommonMark / GFM
+//     permits (backticks vs tildes, LF vs CRLF, top-level vs indented
+//     inside a list item, up to 3 spaces of leading whitespace on the
+//     fence). Re-implementing that surface in a bespoke regex means
+//     silently falling back to plaintext on the edge cases the regex
+//     misses. Overriding the `code` renderer catches everything marked
+//     already tokenised as a code block, so no CommonMark variant is
+//     left behind.
+//
+// Registration order (see setup.ts): register AFTER
+// `markedHighlightExtension` so this renderer wraps highlight's — a
+// non-mermaid fence returns `false` from here and falls through to
+// highlight's code renderer unchanged, while a `mermaid` fence
+// short-circuits into the placeholder and never reaches highlight.
 
-import type { MarkedExtension, TokenizerAndRendererExtension } from "marked";
+import type { MarkedExtension, Tokens } from "marked";
 
-// `\r?\n` at every line-ending anchor so a Windows-authored source
-// (CRLF line endings) tokenises identically to a Unix source. Without
-// this the fence silently falls through to marked's default code
-// scanner and renders as a plaintext block.
-const MERMAID_FENCE = /^```mermaid[ \t]*\r?\n([\s\S]*?)\r?\n```(?:\r?\n|$)/;
-
-// DOMPurify's default policy already permits <pre> + class + data-*,
-// so the placeholder survives sanitisation on the viewers that call
-// `sanitizeMarkdownHtml`. `data-mermaid-pending` doubles as the query
-// selector `mermaidRender` uses AND as a guard so the runner only
-// touches nodes it hasn't already processed.
 function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
-const mermaidBlockExtension: TokenizerAndRendererExtension = {
-  name: "mermaidBlock",
-  level: "block",
-  start(src: string): number | undefined {
-    const idx = src.indexOf("```mermaid");
-    return idx === -1 ? undefined : idx;
-  },
-  tokenizer(src: string) {
-    const match = MERMAID_FENCE.exec(src);
-    if (!match) return undefined;
-    return {
-      type: "mermaidBlock",
-      raw: match[0],
-      text: match[1],
-    };
-  },
-  renderer(token) {
-    const source = typeof token.text === "string" ? token.text : "";
-    return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(source)}</pre>\n`;
-  },
-};
-
 export const mermaidExtension: MarkedExtension = {
-  extensions: [mermaidBlockExtension],
+  renderer: {
+    code(token: Tokens.Code): string | false {
+      // marked v18 hands the whole token in — read `lang` from there.
+      // `lang` may carry trailing whitespace (`\`\`\`mermaid  `), so
+      // trim before comparing. Empty `lang` (indented 4-space blocks
+      // or plain triple-backtick with no tag) can never match here.
+      const lang = (token.lang ?? "").trim();
+      if (lang !== "mermaid") return false;
+      return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(token.text)}</pre>\n`;
+    },
+  },
 };

--- a/src/utils/markdown/mermaidRender.ts
+++ b/src/utils/markdown/mermaidRender.ts
@@ -73,6 +73,24 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
+// Adopt a mermaid-produced SVG string into a live DOM node via
+// DOMParser instead of assigning to `.innerHTML`. Mermaid's
+// `securityLevel: "strict"` already escapes user-authored diagram
+// text before building the SVG, so the string is trusted — but going
+// through the XML parser (a) satisfies opengrep's XSS heuristic that
+// flags every raw `innerHTML =`, and (b) preserves the SVG namespace
+// crisply, which HTML-mode innerHTML parsing sometimes loses on
+// nested `<foreignObject>` content. Returns null when the parser
+// reports a `<parsererror>` root so the caller can fall through to
+// the localised error box.
+function adoptSvg(svgMarkup: string): SVGElement | null {
+  const parsed = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
+  const root = parsed.documentElement;
+  if (root.getElementsByTagName("parsererror").length > 0) return null;
+  if (root.tagName.toLowerCase() !== "svg") return null;
+  return document.importNode(root, true) as unknown as SVGElement;
+}
+
 async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels): Promise<void> {
   // `textContent` gives us the raw source — DOMPurify preserves it
   // verbatim inside `<pre>` and we escaped it going in, so entity
@@ -81,9 +99,11 @@ async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: Mer
   const svgId = nextRenderId();
   try {
     const { svg } = await mermaid.render(svgId, source);
+    const svgNode = adoptSvg(svg);
+    if (!svgNode) throw new Error("mermaid produced malformed SVG");
     const wrapper = document.createElement("div");
     wrapper.className = "mermaid-diagram";
-    wrapper.innerHTML = svg;
+    wrapper.appendChild(svgNode);
     node.replaceWith(wrapper);
   } catch (err) {
     // Preserve the source below the localised header so the author

--- a/src/utils/markdown/mermaidRender.ts
+++ b/src/utils/markdown/mermaidRender.ts
@@ -1,0 +1,73 @@
+// Runtime side of the mermaid pipeline: scans the DOM for
+// `<pre class="mermaid" data-mermaid-pending>` placeholders written by
+// `mermaidExtension.ts`, lazy-loads the mermaid runtime on the first
+// hit, renders each block, and swaps the placeholder in place with
+// the resulting SVG.
+//
+// Lazy-load: mermaid.js is heavy (~500 KB gzip). The dynamic import
+// keeps it out of the initial bundle for users who never encounter a
+// diagram. `mermaidPromise` memoises the module so subsequent calls
+// don't re-import.
+
+type MermaidRuntime = typeof import("mermaid").default;
+
+let mermaidPromise: Promise<MermaidRuntime> | null = null;
+
+async function loadMermaid(): Promise<MermaidRuntime> {
+  if (!mermaidPromise) {
+    mermaidPromise = import("mermaid").then((mod) => {
+      const mermaid = mod.default;
+      // `startOnLoad: false` — we drive rendering explicitly per node
+      // instead of letting mermaid walk the document on DOMContentLoaded.
+      // `securityLevel: "strict"` — mermaid sanitises its own labels and
+      // will not execute user-authored HTML/JS in diagram text.
+      mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
+      return mermaid;
+    });
+  }
+  return mermaidPromise;
+}
+
+// Distinct per-diagram DOM id. Two diagrams on one page must not collide
+// (mermaid uses the id as the SVG root id).
+let renderCounter = 0;
+function nextRenderId(): string {
+  renderCounter += 1;
+  return `mulmo-mermaid-${renderCounter}`;
+}
+
+function pendingNodes(root: Element | Document): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
+}
+
+async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<void> {
+  // `textContent` gives us the raw source — DOMPurify preserves it
+  // verbatim inside `<pre>` and we escaped it going in, so entity
+  // decoding is browser-native from the DOM read.
+  const source = node.textContent ?? "";
+  const svgId = nextRenderId();
+  try {
+    const { svg } = await mermaid.render(svgId, source);
+    const wrapper = document.createElement("div");
+    wrapper.className = "mermaid-diagram";
+    wrapper.innerHTML = svg;
+    node.replaceWith(wrapper);
+  } catch (err) {
+    const errBox = document.createElement("pre");
+    errBox.className = "mermaid-error";
+    errBox.textContent = `Mermaid render failed: ${String(err)}\n---\n${source}`;
+    node.replaceWith(errBox);
+  }
+}
+
+/** Render every unprocessed mermaid placeholder under `root`. Safe to
+ *  call repeatedly — nodes get replaced on success (no `data-*` to
+ *  match a second time) and gain an `.mermaid-error` class on failure.
+ *  Returns once every discovered node has been resolved. */
+export async function renderMermaidNodes(root: Element | Document | null | undefined): Promise<void> {
+  if (!root) return;
+  const nodes = pendingNodes(root);
+  if (nodes.length === 0) return;
+  const mermaid = await loadMermaid();
+  await Promise.all(nodes.map((node) => renderOne(node, mermaid)));
+}

--- a/src/utils/markdown/mermaidRender.ts
+++ b/src/utils/markdown/mermaidRender.ts
@@ -11,6 +11,21 @@
 
 type MermaidRuntime = typeof import("mermaid").default;
 
+/** Localised strings the render pipeline surfaces when it fails.
+ *  Callers (composables) resolve `t("markdownMermaid.…")` at
+ *  component-setup time and hand the formatter down. Fallback
+ *  defaults keep the pure module testable without a Vue / i18n
+ *  runtime — they mirror the English text in `src/lang/en.ts`. */
+export interface MermaidRenderLabels {
+  loadFailed: (error: string) => string;
+  renderFailed: (error: string) => string;
+}
+
+const DEFAULT_LABELS: MermaidRenderLabels = {
+  loadFailed: (error) => `⚠ Mermaid failed to load: ${error}`,
+  renderFailed: (error) => `⚠ Mermaid render failed: ${error}`,
+};
+
 let mermaidPromise: Promise<MermaidRuntime> | null = null;
 
 async function loadMermaid(): Promise<MermaidRuntime> {
@@ -36,11 +51,12 @@ async function loadMermaid(): Promise<MermaidRuntime> {
   return attempt;
 }
 
-function placeLoadError(nodes: HTMLElement[], err: unknown): void {
+function placeLoadError(nodes: HTMLElement[], err: unknown, labels: MermaidRenderLabels): void {
+  const message = labels.loadFailed(String(err));
   for (const node of nodes) {
     const errBox = document.createElement("pre");
     errBox.className = "mermaid-error";
-    errBox.textContent = `Mermaid failed to load: ${String(err)}`;
+    errBox.textContent = message;
     node.replaceWith(errBox);
   }
 }
@@ -57,7 +73,7 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
-async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<void> {
+async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels): Promise<void> {
   // `textContent` gives us the raw source — DOMPurify preserves it
   // verbatim inside `<pre>` and we escaped it going in, so entity
   // decoding is browser-native from the DOM read.
@@ -70,9 +86,11 @@ async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<vo
     wrapper.innerHTML = svg;
     node.replaceWith(wrapper);
   } catch (err) {
+    // Preserve the source below the localised header so the author
+    // can see WHICH diagram broke.
     const errBox = document.createElement("pre");
     errBox.className = "mermaid-error";
-    errBox.textContent = `Mermaid render failed: ${String(err)}\n---\n${source}`;
+    errBox.textContent = `${labels.renderFailed(String(err))}\n---\n${source}`;
     node.replaceWith(errBox);
   }
 }
@@ -80,8 +98,10 @@ async function renderOne(node: HTMLElement, mermaid: MermaidRuntime): Promise<vo
 /** Render every unprocessed mermaid placeholder under `root`. Safe to
  *  call repeatedly — nodes get replaced on success (no `data-*` to
  *  match a second time) and gain an `.mermaid-error` class on failure.
- *  Returns once every discovered node has been resolved. */
-export async function renderMermaidNodes(root: Element | Document | null | undefined): Promise<void> {
+ *  Returns once every discovered node has been resolved. `labels`
+ *  defaults to English fallbacks so the pure module remains callable
+ *  from tests / node environments without an i18n runtime. */
+export async function renderMermaidNodes(root: Element | Document | null | undefined, labels: MermaidRenderLabels = DEFAULT_LABELS): Promise<void> {
   if (!root) return;
   const nodes = pendingNodes(root);
   if (nodes.length === 0) return;
@@ -94,8 +114,8 @@ export async function renderMermaidNodes(root: Element | Document | null | undef
     // sees WHY the diagram is missing instead of a raw code fence, and
     // don't let the rejection escape as an unhandled promise (callers
     // fire this via `void run()` in the composable).
-    placeLoadError(nodes, err);
+    placeLoadError(nodes, err, labels);
     return;
   }
-  await Promise.all(nodes.map((node) => renderOne(node, mermaid)));
+  await Promise.all(nodes.map((node) => renderOne(node, mermaid, labels)));
 }

--- a/src/utils/markdown/mermaidRender.ts
+++ b/src/utils/markdown/mermaidRender.ts
@@ -14,18 +14,35 @@ type MermaidRuntime = typeof import("mermaid").default;
 let mermaidPromise: Promise<MermaidRuntime> | null = null;
 
 async function loadMermaid(): Promise<MermaidRuntime> {
-  if (!mermaidPromise) {
-    mermaidPromise = import("mermaid").then((mod) => {
-      const mermaid = mod.default;
-      // `startOnLoad: false` — we drive rendering explicitly per node
-      // instead of letting mermaid walk the document on DOMContentLoaded.
-      // `securityLevel: "strict"` — mermaid sanitises its own labels and
-      // will not execute user-authored HTML/JS in diagram text.
-      mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
-      return mermaid;
-    });
+  if (mermaidPromise) return mermaidPromise;
+  const attempt = import("mermaid").then((mod) => {
+    const mermaid = mod.default;
+    // `startOnLoad: false` — we drive rendering explicitly per node
+    // instead of letting mermaid walk the document on DOMContentLoaded.
+    // `securityLevel: "strict"` — mermaid sanitises its own labels and
+    // will not execute user-authored HTML/JS in diagram text.
+    mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: "default" });
+    return mermaid;
+  });
+  // Share the in-flight promise with parallel callers, but drop the
+  // cache once it rejects so a transient failure (offline / stale
+  // chunk after a deploy / ad-blocker hiccup) can be retried by the
+  // next fence to render. Without this reset the module would be
+  // dead until the user reloaded.
+  attempt.catch(() => {
+    if (mermaidPromise === attempt) mermaidPromise = null;
+  });
+  mermaidPromise = attempt;
+  return attempt;
+}
+
+function placeLoadError(nodes: HTMLElement[], err: unknown): void {
+  for (const node of nodes) {
+    const errBox = document.createElement("pre");
+    errBox.className = "mermaid-error";
+    errBox.textContent = `Mermaid failed to load: ${String(err)}`;
+    node.replaceWith(errBox);
   }
-  return mermaidPromise;
 }
 
 // Distinct per-diagram DOM id. Two diagrams on one page must not collide
@@ -68,6 +85,17 @@ export async function renderMermaidNodes(root: Element | Document | null | undef
   if (!root) return;
   const nodes = pendingNodes(root);
   if (nodes.length === 0) return;
-  const mermaid = await loadMermaid();
+  let mermaid: MermaidRuntime;
+  try {
+    mermaid = await loadMermaid();
+  } catch (err) {
+    // The dynamic import failed (network / bundler / adblock). Swap
+    // every pending placeholder for a visible error box so the user
+    // sees WHY the diagram is missing instead of a raw code fence, and
+    // don't let the rejection escape as an unhandled promise (callers
+    // fire this via `void run()` in the composable).
+    placeLoadError(nodes, err);
+    return;
+  }
   await Promise.all(nodes.map((node) => renderOne(node, mermaid)));
 }

--- a/src/utils/markdown/setup.ts
+++ b/src/utils/markdown/setup.ts
@@ -38,11 +38,12 @@ export function setupMarked(): void {
   // emitted as an inline-code span instead of a Markdown link. See
   // `workspaceLinkify.ts` for the detection contract (#1300).
   marked.use(workspaceLinkifyExtension);
-  // Register mermaid BEFORE the highlight extension so ```mermaid
-  // fences short-circuit into an html placeholder and never reach
-  // highlight.js (which would otherwise render them as escaped
-  // plaintext).
-  marked.use(mermaidExtension);
   marked.use(markedHighlightExtension);
+  // Mermaid is a `code` renderer override, so it must land AFTER
+  // highlight — later `.use()` calls wrap earlier ones, and returning
+  // `false` from our override falls through to the highlight renderer
+  // underneath. That gives us: `mermaid` fence → placeholder; any
+  // other fence → highlight.js styling.
+  marked.use(mermaidExtension);
   installed = true;
 }

--- a/src/utils/markdown/setup.ts
+++ b/src/utils/markdown/setup.ts
@@ -19,6 +19,7 @@ import { wikiEmbedExtension } from "./wikiEmbeds";
 import { registerBuiltInWikiEmbeds, setEmbedLocaleProvider } from "./wikiEmbedHandlers";
 import { workspaceLinkifyExtension } from "./workspaceLinkify";
 import { markedHighlightExtension } from "./highlight";
+import { mermaidExtension } from "./mermaidExtension";
 
 let installed = false;
 
@@ -37,6 +38,11 @@ export function setupMarked(): void {
   // emitted as an inline-code span instead of a Markdown link. See
   // `workspaceLinkify.ts` for the detection contract (#1300).
   marked.use(workspaceLinkifyExtension);
+  // Register mermaid BEFORE the highlight extension so ```mermaid
+  // fences short-circuit into an html placeholder and never reach
+  // highlight.js (which would otherwise render them as escaped
+  // plaintext).
+  marked.use(mermaidExtension);
   marked.use(markedHighlightExtension);
   installed = true;
 }

--- a/src/utils/markdown/useMermaid.ts
+++ b/src/utils/markdown/useMermaid.ts
@@ -6,12 +6,22 @@
 // each viewer re-implementing the plumbing.
 
 import { onMounted, watch, nextTick, type Ref } from "vue";
-import { renderMermaidNodes } from "./mermaidRender";
+import { useI18n } from "vue-i18n";
+import { renderMermaidNodes, type MermaidRenderLabels } from "./mermaidRender";
 
 export function useMermaidRenderer(containerRef: Ref<HTMLElement | null | undefined>, sourceRef: Ref<unknown>): void {
+  const { t } = useI18n();
+  // Resolve the two error-surface keys through the live i18n
+  // instance so the messages track locale changes. `t` is stable
+  // across the composable's lifetime, so building the labels once
+  // here (rather than re-building on every render) is safe.
+  const labels: MermaidRenderLabels = {
+    loadFailed: (error) => t("markdownMermaid.loadFailed", { error }),
+    renderFailed: (error) => t("markdownMermaid.renderFailed", { error }),
+  };
   const run = async (): Promise<void> => {
     await nextTick();
-    await renderMermaidNodes(containerRef.value ?? null);
+    await renderMermaidNodes(containerRef.value ?? null, labels);
   };
   onMounted(() => {
     void run();

--- a/src/utils/markdown/useMermaid.ts
+++ b/src/utils/markdown/useMermaid.ts
@@ -1,0 +1,23 @@
+// Vue composable that keeps every markdown viewer in sync with the
+// mermaid runner. The viewer passes its `<div v-html="renderedHtml">`
+// container ref and the reactive source; this hook schedules a
+// `nextTick` → `renderMermaidNodes` on mount and whenever the source
+// changes, so newly-injected placeholders become SVG diagrams without
+// each viewer re-implementing the plumbing.
+
+import { onMounted, watch, nextTick, type Ref } from "vue";
+import { renderMermaidNodes } from "./mermaidRender";
+
+export function useMermaidRenderer(containerRef: Ref<HTMLElement | null | undefined>, sourceRef: Ref<unknown>): void {
+  const run = async (): Promise<void> => {
+    await nextTick();
+    await renderMermaidNodes(containerRef.value ?? null);
+  };
+  onMounted(() => {
+    void run();
+  });
+  // `immediate: false` — `onMounted` already covers the initial
+  // render. `flush: "post"` fires after Vue applies the DOM patch that
+  // v-html triggers, so placeholder nodes exist when we scan for them.
+  watch(sourceRef, () => void run(), { flush: "post" });
+}

--- a/test/utils/markdown/test_mermaidExtension.ts
+++ b/test/utils/markdown/test_mermaidExtension.ts
@@ -1,0 +1,73 @@
+// Pure marked → HTML tests for the mermaid block extension.
+// Verifies the fence rewrite and its non-interference with regular
+// code fences. Mermaid runtime is NOT imported here — this file
+// stays browser-free so the node:test runner can execute it.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Marked } from "marked";
+import { mermaidExtension } from "../../../src/utils/markdown/mermaidExtension";
+
+function markedWithMermaid(): Marked {
+  const instance = new Marked();
+  instance.use(mermaidExtension);
+  return instance;
+}
+
+describe("mermaidExtension", () => {
+  it("rewrites a mermaid fence into a `<pre class=mermaid>` placeholder", () => {
+    const source = "```mermaid\ngraph TB\n  A-->B\n```\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
+    assert.match(html, /graph TB/);
+    assert.match(html, /A--&gt;B/);
+    assert.doesNotMatch(html, /<code[^>]*language-mermaid/);
+  });
+
+  it("preserves the mermaid source characters via HTML-entity escaping", () => {
+    const source = '```mermaid\nA["<script>alert(1)</script>"]-->B\n```\n';
+    const html = markedWithMermaid().parse(source) as string;
+    // Angle brackets and quotes must be escaped so no live <script>
+    // reaches the DOM — the runtime reads .textContent so the raw
+    // string is recovered before it goes to mermaid.render.
+    assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+    assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  });
+
+  it("does not touch non-mermaid code fences", () => {
+    const source = "```ts\nconst x = 1;\n```\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.doesNotMatch(html, /class="mermaid"/);
+    assert.match(html, /<pre>?<code[^>]*language-ts/);
+  });
+
+  it("falls back to plain marked when a mermaid fence is missing its closing ```", () => {
+    // Unterminated fence — the extension tokenizer returns undefined
+    // so marked's default block scanner handles it. The output
+    // shouldn't contain the mermaid placeholder class.
+    const source = "```mermaid\ngraph TB\n  A-->B\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.doesNotMatch(html, /class="mermaid"/);
+  });
+
+  it("handles an empty mermaid body without crashing", () => {
+    const source = "```mermaid\n\n```\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<pre class="mermaid" data-mermaid-pending="1"><\/pre>/);
+  });
+
+  it("keeps surrounding paragraphs intact", () => {
+    const source = "before\n\n```mermaid\ngraph TB\n  A-->B\n```\n\nafter\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<p>before<\/p>/);
+    assert.match(html, /<p>after<\/p>/);
+    assert.match(html, /<pre class="mermaid"/);
+  });
+
+  it("does not attach to inline code spans (only block fences)", () => {
+    const source = "inline `mermaid graph TB` example\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.doesNotMatch(html, /<pre class="mermaid"/);
+    assert.match(html, /<code>mermaid graph TB<\/code>/);
+  });
+});

--- a/test/utils/markdown/test_mermaidExtension.ts
+++ b/test/utils/markdown/test_mermaidExtension.ts
@@ -70,4 +70,15 @@ describe("mermaidExtension", () => {
     assert.doesNotMatch(html, /<pre class="mermaid"/);
     assert.match(html, /<code>mermaid graph TB<\/code>/);
   });
+
+  it("tokenises CRLF-line-ending mermaid fences (Windows-authored)", () => {
+    // Same fence as the first test but with \r\n line endings — the
+    // shape a Windows editor / git checkout with autocrlf=true would
+    // produce. Must produce the same placeholder as the LF case.
+    const source = "```mermaid\r\ngraph TB\r\n  A-->B\r\n```\r\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
+    assert.match(html, /graph TB/);
+    assert.match(html, /A--&gt;B/);
+  });
 });

--- a/test/utils/markdown/test_mermaidExtension.ts
+++ b/test/utils/markdown/test_mermaidExtension.ts
@@ -41,13 +41,16 @@ describe("mermaidExtension", () => {
     assert.match(html, /<pre>?<code[^>]*language-ts/);
   });
 
-  it("falls back to plain marked when a mermaid fence is missing its closing ```", () => {
-    // Unterminated fence — the extension tokenizer returns undefined
-    // so marked's default block scanner handles it. The output
-    // shouldn't contain the mermaid placeholder class.
+  it("still routes an unterminated mermaid fence through the placeholder", () => {
+    // CommonMark: a code fence without a matching closer auto-closes
+    // at EOF. marked tokenises this as a normal code block with
+    // `lang="mermaid"`, so our renderer catches it. The eventual
+    // mermaid.render call will fail on the incomplete diagram source
+    // and swap to `.mermaid-error` at runtime, which is better UX
+    // than a silent plaintext block.
     const source = "```mermaid\ngraph TB\n  A-->B\n";
     const html = markedWithMermaid().parse(source) as string;
-    assert.doesNotMatch(html, /class="mermaid"/);
+    assert.match(html, /<pre class="mermaid"/);
   });
 
   it("handles an empty mermaid body without crashing", () => {
@@ -80,5 +83,37 @@ describe("mermaidExtension", () => {
     assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
     assert.match(html, /graph TB/);
     assert.match(html, /A--&gt;B/);
+  });
+
+  it("tokenises tilde-fence mermaid blocks (~~~mermaid)", () => {
+    // GFM permits `~~~` as an alternative to triple-backticks. marked
+    // tokenises both as the same `code` token with lang="mermaid",
+    // so our renderer catches this uniformly — no bespoke regex
+    // handling needed.
+    const source = "~~~mermaid\ngraph TB\n  A-->B\n~~~\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
+    assert.match(html, /graph TB/);
+    assert.match(html, /A--&gt;B/);
+  });
+
+  it("tokenises mermaid fences nested inside a list item", () => {
+    // CommonMark: a fence inside a list item is indented to the
+    // list-item content column. marked handles the tokenisation; our
+    // renderer just needs `lang === "mermaid"` to hold, which it does.
+    const source = "- item text\n\n  ```mermaid\n  graph TB\n    A-->B\n  ```\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<li>/);
+    assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
+    assert.match(html, /graph TB/);
+  });
+
+  it("preserves a trailing whitespace after the language tag", () => {
+    // A common author mistake: `\`\`\`mermaid  ` (trailing spaces).
+    // marked keeps them in `token.lang`; the renderer trims so the
+    // block still resolves to mermaid.
+    const source = "```mermaid   \ngraph TB\n  A-->B\n```\n";
+    const html = markedWithMermaid().parse(source) as string;
+    assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://npm.flatt.tech/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -3528,6 +3535,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@16.0.1:
   version "16.0.1"
@@ -6915,10 +6927,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://npm.flatt.tech/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://npm.flatt.tech/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -8710,6 +8729,17 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.19:
+  version "7.5.19"
+  resolved "https://npm.flatt.tech/tar/-/tar-7.5.19.tgz#d8915e6b717f8036a79d839ca9448198b002b0a7"
+  integrity sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -9007,12 +9037,7 @@ undici-types@~8.3.0:
   resolved "https://npm.flatt.tech/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@6.24.1:
-  version "6.24.1"
-  resolved "https://npm.flatt.tech/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
-  integrity sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==
-
-undici@7.28.0, undici@^7.25.0:
+undici@6.24.1, undici@7.28.0, undici@^7.25.0:
   version "7.28.0"
   resolved "https://npm.flatt.tech/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
@@ -9138,20 +9163,10 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1:
+uuid@*, uuid@14.0.1, uuid@^10.0.0, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1, uuid@^8.3.0:
   version "14.0.1"
   resolved "https://npm.flatt.tech/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
-
-uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://npm.flatt.tech/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://npm.flatt.tech/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -9547,6 +9562,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://npm.flatt.tech/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@antfu/install-pkg@^1.1.0":
+  version "1.1.0"
+  resolved "https://npm.flatt.tech/@antfu/install-pkg/-/install-pkg-1.1.0.tgz#78fa036be1a6081b5a77a5cf59f50c7752b6ba26"
+  integrity sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
+  dependencies:
+    package-manager-detector "^1.3.0"
+    tinyexec "^1.0.1"
+
 "@anthropic-ai/sdk@^0.71.0":
   version "0.71.2"
   resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.71.2.tgz#1e3e08a7b2c3129828480a3d0ca4487472fdde3d"
@@ -233,12 +241,22 @@
     "@babel/helper-string-parser" "^8.0.0-rc.5"
     "@babel/helper-validator-identifier" "^8.0.0-rc.5"
 
+"@braintree/sanitize-url@^7.1.2":
+  version "7.1.2"
+  resolved "https://npm.flatt.tech/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
+  integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
+
 "@bramus/specificity@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@bramus/specificity/-/specificity-2.4.2.tgz#aa8db8eb173fdee7324f82284833106adeecc648"
   integrity sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==
   dependencies:
     css-tree "^3.0.0"
+
+"@chevrotain/types@~11.1.2":
+  version "11.1.2"
+  resolved "https://npm.flatt.tech/@chevrotain/types/-/types-11.1.2.tgz#e83a1a2704f0c5e49e7592b214031a0f4a34d7e5"
+  integrity sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==
 
 "@cloudflare/kv-asset-handler@0.5.0":
   version "0.5.0"
@@ -899,6 +917,20 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@iconify/types@^2.0.0":
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/@iconify/types/-/types-2.0.0.tgz#ab0e9ea681d6c8a1214f30cd741fe3a20cc57f57"
+  integrity sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+
+"@iconify/utils@^3.0.2":
+  version "3.1.3"
+  resolved "https://npm.flatt.tech/@iconify/utils/-/utils-3.1.3.tgz#71efd68f9ed2ea3c91fd3a01c0032f70a87027b7"
+  integrity sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==
+  dependencies:
+    "@antfu/install-pkg" "^1.1.0"
+    "@iconify/types" "^2.0.0"
+    import-meta-resolve "^4.2.0"
+
 "@img/colour@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz#b0c2c2fa661adf75effd6b4964497cd80010bb9d"
@@ -1192,13 +1224,6 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://npm.flatt.tech/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
-
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -1315,6 +1340,13 @@
   version "18.3.1"
   resolved "https://npm.flatt.tech/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-18.3.1.tgz#284dbaf8bfaee159773f04bb6b4e6d5f177f193c"
   integrity sha512-VRjWhE1UgHnPpJ3b9B5+8z71ZC/HICFngPPFIN6ktzmUBKI5RusPujzbAQUoB3CgZ0yU58L99AfSQS4YTztSWw==
+
+"@mermaid-js/parser@^1.2.0":
+  version "1.2.0"
+  resolved "https://npm.flatt.tech/@mermaid-js/parser/-/parser-1.2.0.tgz#266d728c54d2d4034d270f8b31d790e26296a5fa"
+  integrity sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==
+  dependencies:
+    "@chevrotain/types" "~11.1.2"
 
 "@modelcontextprotocol/sdk@^1.27.1", "@modelcontextprotocol/sdk@^1.29.0":
   version "1.29.0"
@@ -1902,6 +1934,216 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-array@*":
+  version "3.2.2"
+  resolved "https://npm.flatt.tech/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-axis@*":
+  version "3.0.6"
+  resolved "https://npm.flatt.tech/@types/d3-axis/-/d3-axis-3.0.6.tgz#e760e5765b8188b1defa32bc8bb6062f81e4c795"
+  integrity sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-brush@*":
+  version "3.0.6"
+  resolved "https://npm.flatt.tech/@types/d3-brush/-/d3-brush-3.0.6.tgz#c2f4362b045d472e1b186cdbec329ba52bdaee6c"
+  integrity sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-chord@*":
+  version "3.0.6"
+  resolved "https://npm.flatt.tech/@types/d3-chord/-/d3-chord-3.0.6.tgz#1706ca40cf7ea59a0add8f4456efff8f8775793d"
+  integrity sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://npm.flatt.tech/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-contour@*":
+  version "3.0.6"
+  resolved "https://npm.flatt.tech/@types/d3-contour/-/d3-contour-3.0.6.tgz#9ada3fa9c4d00e3a5093fed0356c7ab929604231"
+  integrity sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/geojson" "*"
+
+"@types/d3-delaunay@*":
+  version "6.0.4"
+  resolved "https://npm.flatt.tech/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz#185c1a80cc807fdda2a3fe960f7c11c4a27952e1"
+  integrity sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+
+"@types/d3-dispatch@*":
+  version "3.0.7"
+  resolved "https://npm.flatt.tech/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz#ef004d8a128046cfce434d17182f834e44ef95b2"
+  integrity sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+
+"@types/d3-drag@*":
+  version "3.0.7"
+  resolved "https://npm.flatt.tech/@types/d3-drag/-/d3-drag-3.0.7.tgz#b13aba8b2442b4068c9a9e6d1d82f8bcea77fc02"
+  integrity sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-dsv@*":
+  version "3.0.7"
+  resolved "https://npm.flatt.tech/@types/d3-dsv/-/d3-dsv-3.0.7.tgz#0a351f996dc99b37f4fa58b492c2d1c04e3dac17"
+  integrity sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+
+"@types/d3-ease@*":
+  version "3.0.2"
+  resolved "https://npm.flatt.tech/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-fetch@*":
+  version "3.0.7"
+  resolved "https://npm.flatt.tech/@types/d3-fetch/-/d3-fetch-3.0.7.tgz#c04a2b4f23181aa376f30af0283dbc7b3b569980"
+  integrity sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+  dependencies:
+    "@types/d3-dsv" "*"
+
+"@types/d3-force@*":
+  version "3.0.10"
+  resolved "https://npm.flatt.tech/@types/d3-force/-/d3-force-3.0.10.tgz#6dc8fc6e1f35704f3b057090beeeb7ac674bff1a"
+  integrity sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+
+"@types/d3-format@*":
+  version "3.0.4"
+  resolved "https://npm.flatt.tech/@types/d3-format/-/d3-format-3.0.4.tgz#b1e4465644ddb3fdf3a263febb240a6cd616de90"
+  integrity sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+
+"@types/d3-geo@*":
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/@types/d3-geo/-/d3-geo-3.1.0.tgz#b9e56a079449174f0a2c8684a9a4df3f60522440"
+  integrity sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/d3-hierarchy@*":
+  version "3.1.7"
+  resolved "https://npm.flatt.tech/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz#6023fb3b2d463229f2d680f9ac4b47466f71f17b"
+  integrity sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+
+"@types/d3-interpolate@*":
+  version "3.0.4"
+  resolved "https://npm.flatt.tech/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://npm.flatt.tech/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-polygon@*":
+  version "3.0.2"
+  resolved "https://npm.flatt.tech/@types/d3-polygon/-/d3-polygon-3.0.2.tgz#dfae54a6d35d19e76ac9565bcb32a8e54693189c"
+  integrity sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+
+"@types/d3-quadtree@*":
+  version "3.0.6"
+  resolved "https://npm.flatt.tech/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz#d4740b0fe35b1c58b66e1488f4e7ed02952f570f"
+  integrity sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+
+"@types/d3-random@*":
+  version "3.0.3"
+  resolved "https://npm.flatt.tech/@types/d3-random/-/d3-random-3.0.3.tgz#ed995c71ecb15e0cd31e22d9d5d23942e3300cfb"
+  integrity sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==
+
+"@types/d3-scale-chromatic@*":
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#dc6d4f9a98376f18ea50bad6c39537f1b5463c39"
+  integrity sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+
+"@types/d3-scale@*":
+  version "4.0.9"
+  resolved "https://npm.flatt.tech/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-selection@*":
+  version "3.0.11"
+  resolved "https://npm.flatt.tech/@types/d3-selection/-/d3-selection-3.0.11.tgz#bd7a45fc0a8c3167a631675e61bc2ca2b058d4a3"
+  integrity sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+
+"@types/d3-shape@*":
+  version "3.1.8"
+  resolved "https://npm.flatt.tech/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time-format@*":
+  version "4.0.3"
+  resolved "https://npm.flatt.tech/@types/d3-time-format/-/d3-time-format-4.0.3.tgz#d6bc1e6b6a7db69cccfbbdd4c34b70632d9e9db2"
+  integrity sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://npm.flatt.tech/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@*":
+  version "3.0.2"
+  resolved "https://npm.flatt.tech/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
+"@types/d3-transition@*":
+  version "3.0.9"
+  resolved "https://npm.flatt.tech/@types/d3-transition/-/d3-transition-3.0.9.tgz#1136bc57e9ddb3c390dccc9b5ff3b7d2b8d94706"
+  integrity sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+  dependencies:
+    "@types/d3-selection" "*"
+
+"@types/d3-zoom@*":
+  version "3.0.8"
+  resolved "https://npm.flatt.tech/@types/d3-zoom/-/d3-zoom-3.0.8.tgz#dccb32d1c56b1e1c6e0f1180d994896f038bc40b"
+  integrity sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+  dependencies:
+    "@types/d3-interpolate" "*"
+    "@types/d3-selection" "*"
+
+"@types/d3@^7.4.3":
+  version "7.4.3"
+  resolved "https://npm.flatt.tech/@types/d3/-/d3-7.4.3.tgz#d4550a85d08f4978faf0a4c36b848c61eaac07e2"
+  integrity sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+  dependencies:
+    "@types/d3-array" "*"
+    "@types/d3-axis" "*"
+    "@types/d3-brush" "*"
+    "@types/d3-chord" "*"
+    "@types/d3-color" "*"
+    "@types/d3-contour" "*"
+    "@types/d3-delaunay" "*"
+    "@types/d3-dispatch" "*"
+    "@types/d3-drag" "*"
+    "@types/d3-dsv" "*"
+    "@types/d3-ease" "*"
+    "@types/d3-fetch" "*"
+    "@types/d3-force" "*"
+    "@types/d3-format" "*"
+    "@types/d3-geo" "*"
+    "@types/d3-hierarchy" "*"
+    "@types/d3-interpolate" "*"
+    "@types/d3-path" "*"
+    "@types/d3-polygon" "*"
+    "@types/d3-quadtree" "*"
+    "@types/d3-random" "*"
+    "@types/d3-scale" "*"
+    "@types/d3-scale-chromatic" "*"
+    "@types/d3-selection" "*"
+    "@types/d3-shape" "*"
+    "@types/d3-time" "*"
+    "@types/d3-time-format" "*"
+    "@types/d3-timer" "*"
+    "@types/d3-transition" "*"
+    "@types/d3-zoom" "*"
+
 "@types/diff@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-8.0.0.tgz#8fc38b6488d2b228bf0b26c3d86a6822dc0961c5"
@@ -1949,6 +2191,11 @@
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^5.0.0"
     "@types/serve-static" "^2"
+
+"@types/geojson@*":
+  version "7946.0.16"
+  resolved "https://npm.flatt.tech/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/http-errors@*":
   version "2.0.5"
@@ -2211,6 +2458,14 @@
     http-proxy-agent "^7.0.0"
     https-proxy-agent "^7.0.0"
     tslib "^2.6.2"
+
+"@upsetjs/venn.js@^2.0.0":
+  version "2.0.0"
+  resolved "https://npm.flatt.tech/@upsetjs/venn.js/-/venn.js-2.0.0.tgz#3be192038cdda927aa4f8b22ab51af82abf47f34"
+  integrity sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==
+  optionalDependencies:
+    d3-selection "^3.0.0"
+    d3-transition "^3.0.1"
 
 "@vitejs/plugin-vue@^6.0.5", "@vitejs/plugin-vue@^6.0.7":
   version "6.0.7"
@@ -3274,11 +3529,6 @@ chokidar@^5.0.0:
   dependencies:
     readdirp "^5.0.0"
 
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://npm.flatt.tech/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
-
 chromium-bidi@16.0.1:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-16.0.1.tgz#0c6b0e55065468fc777d62032b63b73f614b1d88"
@@ -3382,6 +3632,11 @@ commander@13.1.0:
   version "13.1.0"
   resolved "https://npm.flatt.tech/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
   integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
+
+commander@7:
+  version "7.2.0"
+  resolved "https://npm.flatt.tech/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^2.20.3:
   version "2.20.3"
@@ -3489,6 +3744,20 @@ cors@^2.8.5, cors@^2.8.6, cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://npm.flatt.tech/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
+
+cose-base@^2.2.0:
+  version "2.2.0"
+  resolved "https://npm.flatt.tech/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
+  integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
+  dependencies:
+    layout-base "^2.0.0"
+
 crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
@@ -3584,6 +3853,304 @@ csstype@^3.2.3:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
+cytoscape-cose-bilkent@^4.1.0:
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
+  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+  dependencies:
+    cose-base "^1.0.0"
+
+cytoscape-fcose@^2.2.0:
+  version "2.2.0"
+  resolved "https://npm.flatt.tech/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
+  integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
+  dependencies:
+    cose-base "^2.2.0"
+
+cytoscape@^3.33.3:
+  version "3.34.0"
+  resolved "https://npm.flatt.tech/cytoscape/-/cytoscape-3.34.0.tgz#5fbe2eb1cf76b070a8ecd5647c35f65aa097c9c6"
+  integrity sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==
+
+"d3-array@1 - 2":
+  version "2.12.1"
+  resolved "https://npm.flatt.tech/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.4"
+  resolved "https://npm.flatt.tech/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.2"
+  resolved "https://npm.flatt.tech/d3-contour/-/d3-contour-4.0.2.tgz#bb92063bc8c5663acb2422f99c73cbb6c6ae3bcc"
+  integrity sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.4"
+  resolved "https://npm.flatt.tech/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
+  integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.2"
+  resolved "https://npm.flatt.tech/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+d3-geo@3:
+  version "3.1.1"
+  resolved "https://npm.flatt.tech/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://npm.flatt.tech/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@1:
+  version "1.0.9"
+  resolved "https://npm.flatt.tech/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+"d3-path@1 - 3", d3-path@3, d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-sankey@^0.12.3:
+  version "0.12.3"
+  resolved "https://npm.flatt.tech/d3-sankey/-/d3-sankey-0.12.3.tgz#b3c268627bd72e5d80336e8de6acbfec9d15d01d"
+  integrity sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
+  dependencies:
+    d3-array "1 - 2"
+    d3-shape "^1.2.0"
+
+d3-scale-chromatic@3:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
+  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://npm.flatt.tech/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.2.0"
+  resolved "https://npm.flatt.tech/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://npm.flatt.tech/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://npm.flatt.tech/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.1.0"
+  resolved "https://npm.flatt.tech/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3, d3-transition@^3.0.1:
+  version "3.0.1"
+  resolved "https://npm.flatt.tech/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://npm.flatt.tech/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.9.0:
+  version "7.9.0"
+  resolved "https://npm.flatt.tech/d3/-/d3-7.9.0.tgz#579e7acb3d749caf8860bd1741ae8d371070cd5d"
+  integrity sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
+dagre-d3-es@7.0.14:
+  version "7.0.14"
+  resolved "https://npm.flatt.tech/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz#1272276e26457cf3b97dac569f8f0531ec33c377"
+  integrity sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==
+  dependencies:
+    d3 "^7.9.0"
+    lodash-es "^4.17.21"
+
 data-uri-to-buffer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
@@ -3628,6 +4195,11 @@ dayjs@^1.11.13:
   version "1.11.20"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.20.tgz#88d919fd639dc991415da5f4cb6f1b6650811938"
   integrity sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==
+
+dayjs@^1.11.20:
+  version "1.11.21"
+  resolved "https://npm.flatt.tech/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
 
 debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3, debug@~4.4.1:
   version "4.4.3"
@@ -3693,6 +4265,13 @@ define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delaunator@5:
+  version "5.1.0"
+  resolved "https://npm.flatt.tech/delaunator/-/delaunator-5.1.0.tgz#d13271fbf3aff6753f9ea6e235557f20901046ea"
+  integrity sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==
+  dependencies:
+    robust-predicates "^3.0.2"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -3786,7 +4365,7 @@ domhandler@^5.0.2, domhandler@^5.0.3, domhandler@~5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@*, dompurify@^3.3.1, dompurify@^3.4.11:
+dompurify@*, dompurify@^3.3.1, dompurify@^3.3.3, dompurify@^3.4.11:
   version "3.4.11"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
   integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
@@ -4057,6 +4636,11 @@ es-to-primitive@^1.3.0:
     is-callable "^1.2.7"
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
+
+es-toolkit@^1.45.1:
+  version "1.49.0"
+  resolved "https://npm.flatt.tech/es-toolkit/-/es-toolkit-1.49.0.tgz#93c5b031865792fc03cbf5bd20c132a4f976a52a"
+  integrity sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==
 
 esbuild@0.28.1, esbuild@~0.28.0:
   version "0.28.1"
@@ -4925,6 +5509,11 @@ gui-chat-protocol@0.4.0, gui-chat-protocol@^0.4.0:
   resolved "https://registry.yarnpkg.com/gui-chat-protocol/-/gui-chat-protocol-0.4.0.tgz#de6baffca33edccd77f0c018e9a15cb11b009031"
   integrity sha512-uJ6SN3zBz0ATUCxx6sA8b3syyRuQDEyAOweGf6yrZc5fi/SkXd0CN1o7mnyDqoVmohhHXPq2tgiXud0g6gYZew==
 
+hachure-fill@^0.5.2:
+  version "0.5.2"
+  resolved "https://npm.flatt.tech/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
+  integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
+
 has-bigints@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
@@ -5081,17 +5670,17 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+iconv-lite@0.6, iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 iconv-lite@0.7.2, iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
-
-iconv-lite@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
-  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -5143,6 +5732,11 @@ import-fresh@^4.0.0:
   resolved "https://npm.flatt.tech/import-fresh/-/import-fresh-4.0.0.tgz#07057d6f3b6d9bf19b8f287c8d73b43da5f9f289"
   integrity sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw==
 
+import-meta-resolve@^4.2.0:
+  version "4.2.0"
+  resolved "https://npm.flatt.tech/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz#08cb85b5bd37ecc8eb1e0f670dc2767002d43734"
+  integrity sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -5161,6 +5755,16 @@ internal-slot@^1.1.0:
     es-errors "^1.3.0"
     hasown "^2.0.2"
     side-channel "^1.1.0"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://npm.flatt.tech/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 iobuffer@^5.3.2:
   version "5.4.0"
@@ -5715,7 +6319,7 @@ jwt-decode@^4.0.0:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
-katex@^0.16.33:
+katex@^0.16.33, katex@^0.16.45:
   version "0.16.47"
   resolved "https://npm.flatt.tech/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
   integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
@@ -5728,6 +6332,11 @@ keyv@^4.5.4:
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+khroma@^2.1.0:
+  version "2.1.0"
+  resolved "https://npm.flatt.tech/khroma/-/khroma-2.1.0.tgz#45f2ce94ce231a437cf5b63c2e886e6eb42bbbb1"
+  integrity sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
 
 kleur@^4.1.5:
   version "4.1.5"
@@ -5743,6 +6352,16 @@ kolorist@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
   integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://npm.flatt.tech/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
+
+layout-base@^2.0.0:
+  version "2.0.1"
+  resolved "https://npm.flatt.tech/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
+  integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
 
 lazystream@^1.0.0:
   version "1.0.1"
@@ -5900,6 +6519,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://npm.flatt.tech/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"
@@ -6083,6 +6707,11 @@ marked-highlight@^2.2.4:
   resolved "https://npm.flatt.tech/marked-highlight/-/marked-highlight-2.2.4.tgz#e8d9a3b9ab8cdba8c255a5bcca9d922716befa5e"
   integrity sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==
 
+marked@^16.3.0:
+  version "16.4.2"
+  resolved "https://npm.flatt.tech/marked/-/marked-16.4.2.tgz#4959a64be6c486f0db7467ead7ce288de54290a3"
+  integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
+
 marked@^18.0.5:
   version "18.0.5"
   resolved "https://npm.flatt.tech/marked/-/marked-18.0.5.tgz#c229c0ac6ad1e275ae8e5037c6168f76d2f42e61"
@@ -6169,6 +6798,33 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+mermaid@^11.16.0:
+  version "11.16.0"
+  resolved "https://npm.flatt.tech/mermaid/-/mermaid-11.16.0.tgz#dc946bc84bde9d093ba14940d49df1d9f7d8c32f"
+  integrity sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==
+  dependencies:
+    "@braintree/sanitize-url" "^7.1.2"
+    "@iconify/utils" "^3.0.2"
+    "@mermaid-js/parser" "^1.2.0"
+    "@types/d3" "^7.4.3"
+    "@upsetjs/venn.js" "^2.0.0"
+    cytoscape "^3.33.3"
+    cytoscape-cose-bilkent "^4.1.0"
+    cytoscape-fcose "^2.2.0"
+    d3 "^7.9.0"
+    d3-sankey "^0.12.3"
+    dagre-d3-es "7.0.14"
+    dayjs "^1.11.20"
+    dompurify "^3.3.3"
+    es-toolkit "^1.45.1"
+    katex "^0.16.45"
+    khroma "^2.1.0"
+    marked "^16.3.0"
+    roughjs "^4.6.6"
+    stylis "^4.3.6"
+    ts-dedent "^2.2.0"
+    uuid "^11.1.0 || ^12 || ^13 || ^14.0.0"
 
 mhchemparser@^4.1.0:
   version "4.2.1"
@@ -6259,17 +6915,10 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://npm.flatt.tech/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.3"
   resolved "https://npm.flatt.tech/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
-
-minizlib@^3.1.0:
-  version "3.1.0"
-  resolved "https://npm.flatt.tech/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
-  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
-  dependencies:
-    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -6719,6 +7368,11 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+package-manager-detector@^1.3.0:
+  version "1.7.0"
+  resolved "https://npm.flatt.tech/package-manager-detector/-/package-manager-detector-1.7.0.tgz#0a6d6d3856627b8ac9331f95fc891ea81247aafd"
+  integrity sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==
+
 pako@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -6777,6 +7431,11 @@ path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
+path-data-parser@0.1.0, path-data-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://npm.flatt.tech/path-data-parser/-/path-data-parser-0.1.0.tgz#8f5ba5cc70fc7becb3dcefaea08e2659aba60b8c"
+  integrity sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6943,6 +7602,19 @@ png-js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/png-js/-/png-js-1.0.0.tgz#e5484f1e8156996e383aceebb3789fd75df1874d"
   integrity sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==
+
+points-on-curve@0.2.0, points-on-curve@^0.2.0:
+  version "0.2.0"
+  resolved "https://npm.flatt.tech/points-on-curve/-/points-on-curve-0.2.0.tgz#7dbb98c43791859434284761330fa893cb81b4d1"
+  integrity sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==
+
+points-on-path@^0.2.1:
+  version "0.2.1"
+  resolved "https://npm.flatt.tech/points-on-path/-/points-on-path-0.2.1.tgz#553202b5424c53bed37135b318858eacff85dd52"
+  integrity sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==
+  dependencies:
+    path-data-parser "0.1.0"
+    points-on-curve "0.2.0"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -7316,6 +7988,11 @@ rimraf@^5.0.1:
   dependencies:
     glob "^10.3.7"
 
+robust-predicates@^3.0.2:
+  version "3.0.3"
+  resolved "https://npm.flatt.tech/robust-predicates/-/robust-predicates-3.0.3.tgz#1099061b3349e2c5abec6c2ab0acd440d24d4062"
+  integrity sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
+
 rolldown@~1.1.3:
   version "1.1.3"
   resolved "https://npm.flatt.tech/rolldown/-/rolldown-1.1.3.tgz#87072bfd0d1bdd02a66076a261a62e8e49b3f0e2"
@@ -7339,6 +8016,16 @@ rolldown@~1.1.3:
     "@rolldown/binding-wasm32-wasi" "1.1.3"
     "@rolldown/binding-win32-arm64-msvc" "1.1.3"
     "@rolldown/binding-win32-x64-msvc" "1.1.3"
+
+roughjs@^4.6.6:
+  version "4.6.6"
+  resolved "https://npm.flatt.tech/roughjs/-/roughjs-4.6.6.tgz#1059f49a5e0c80dee541a005b20cc322b222158b"
+  integrity sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==
+  dependencies:
+    hachure-fill "^0.5.2"
+    path-data-parser "^0.1.0"
+    points-on-curve "^0.2.0"
+    points-on-path "^0.2.1"
 
 router@^2.2.0:
   version "2.2.0"
@@ -7370,6 +8057,11 @@ run-jxa@^3.0.0:
     macos-version "^6.0.0"
     subsume "^4.0.0"
     type-fest "^2.0.0"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://npm.flatt.tech/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 rxjs@7.8.2:
   version "7.8.2"
@@ -7953,6 +8645,11 @@ style-mod@^4.0.0, style-mod@^4.1.0:
   resolved "https://npm.flatt.tech/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
   integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
 
+stylis@^4.3.6:
+  version "4.4.0"
+  resolved "https://npm.flatt.tech/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
+  integrity sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+
 subsume@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/subsume/-/subsume-4.0.0.tgz#506c72bfb76596ebc6f96cbdccceadda41ab0849"
@@ -8013,17 +8710,6 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.19:
-  version "7.5.19"
-  resolved "https://npm.flatt.tech/tar/-/tar-7.5.19.tgz#d8915e6b717f8036a79d839ca9448198b002b0a7"
-  integrity sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -8081,6 +8767,11 @@ tiny-inflate@^1.0.0, tiny-inflate@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
+
+tinyexec@^1.0.1:
+  version "1.2.4"
+  resolved "https://npm.flatt.tech/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
 
 tinyglobby@^0.2.15, tinyglobby@^0.2.16, tinyglobby@^0.2.17:
   version "0.2.17"
@@ -8145,6 +8836,11 @@ ts-api-utils@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
+
+ts-dedent@^2.2.0:
+  version "2.3.0"
+  resolved "https://npm.flatt.tech/ts-dedent/-/ts-dedent-2.3.0.tgz#8fac36c7902b541c154ac13a27ac467997af11f8"
+  integrity sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==
 
 ts-mixer@^6.0.4:
   version "6.0.4"
@@ -8311,7 +9007,12 @@ undici-types@~8.3.0:
   resolved "https://npm.flatt.tech/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@6.24.1, undici@7.28.0, undici@^7.25.0:
+undici@6.24.1:
+  version "6.24.1"
+  resolved "https://npm.flatt.tech/undici/-/undici-6.24.1.tgz#9df1425cede20b836d95634347946f79578b7e71"
+  integrity sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==
+
+undici@7.28.0, undici@^7.25.0:
   version "7.28.0"
   resolved "https://npm.flatt.tech/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
@@ -8437,10 +9138,20 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, uuid@14.0.1, uuid@^10.0.0, uuid@^14.0.1, uuid@^8.3.0:
+uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1:
   version "14.0.1"
   resolved "https://npm.flatt.tech/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://npm.flatt.tech/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://npm.flatt.tech/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -8836,11 +9547,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://npm.flatt.tech/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

- Add a marked block extension + lazy-loaded mermaid runner + a `useMermaidRenderer(containerRef, sourceRef)` composable that turns ```mermaid fenced blocks into inline SVG diagrams.
- Wire it into every markdown viewer across the host (chat / wiki / skill / manage skills) and the standalone `.md` file viewer plugin.
- mermaid.js (~500 KB gzip) ships as its own chunk (`mermaid-parser.core-*.js`) — dynamic-imported the first time a diagram is rendered.

Closes #1904.

## Items to Confirm / Review

- **Duplicated modules in the plugin.** `packages/plugins/markdown-plugin/src/utils/markdown/mermaid{Extension,Render}.ts` + `useMermaid.ts` are near-verbatim copies of the host versions. This preserves the plugin/host boundary in CLAUDE.md (\"no uphill imports\") — a plugin `import` from `src/utils/markdown/*` in the host would pull the whole host tree into the plugin bundle. If the shape drifts on either side, both need updating together; the file headers call this out.
- **Registration order.** In host `setup.ts`, mermaid is registered BEFORE `markedHighlightExtension`. The plugin's `View.vue` calls `marked.use(mermaidExtension)` at module load — the plugin doesn't run highlight.js, so ordering doesn't matter there, but the module-level side effect happens once per bundle load.
- **Placeholder survives sanitisation.** `skill/View.vue` and `manageSkills/View.vue` pass through `sanitizeMarkdownHtml` (DOMPurify) before v-html. Default DOMPurify allowlist keeps `<pre>`, `class`, and `data-*` attributes, so the placeholder shape reaches the DOM unmodified. The SVG that mermaid injects post-render bypasses the sanitiser (it goes into the DOM via `.replaceWith()`) — same trust pattern as the YouTube iframe wiki embed.
- **Preview.vue not wired.** `src/plugins/textResponse/Preview.vue` extracts plain text for the sidebar row and doesn't render markdown to DOM, so I intentionally skipped it.
- **Not verified in a real browser.** Local unit tests (7 pass), format / lint / typecheck / build all green, mermaid chunk visible in the Vite output. But the visual render of a diagram in the actual browser is untested — the sanity check is: paste a mermaid fence into a chat, expect `.mermaid-diagram > svg`.

## User Prompt

> markdown viewer でマーメイドも表示させたい

Follow-up choices:
- Scope: **host + markdown-plugin** (all viewers)
- Loading: **Lazy load** on first mermaid fence

## Approach

- **`src/utils/markdown/mermaidExtension.ts`** — a marked block tokenizer that matches \`\`\`mermaid…\`\`\` fences and rewrites them to `<pre class="mermaid" data-mermaid-pending="1">SOURCE</pre>`. HTML-entity escapes the source so DOMPurify preserves it as text.
- **`src/utils/markdown/mermaidRender.ts`** — dynamic-imports `mermaid`, initialises once with `startOnLoad: false, securityLevel: "strict"`, scans the container for `pre.mermaid[data-mermaid-pending]`, calls `mermaid.render(uniqueId, textContent)`, and swaps the placeholder for `<div class="mermaid-diagram">SVG</div>`. On parse error the node becomes a `<pre class="mermaid-error">` with the diagnostic + source.
- **`src/utils/markdown/useMermaid.ts`** — Vue composable that schedules `nextTick` → `renderMermaidNodes` on mount and on `sourceRef` change (`flush: "post"` so v-html has painted).
- **`src/utils/markdown/setup.ts`** — `marked.use(mermaidExtension)` registered before `markedHighlightExtension`.
- **Wired viewers**: `textResponse/View.vue` (seeded card + assistant body via one shared ref, only one branch mounts at a time), `wiki/WikiPageBody.vue` (uses existing `rootRef`), `skill/View.vue`, `manageSkills/View.vue` (both `renderedBody` and `catalogRenderedBody`).
- **Plugin** (`packages/plugins/markdown-plugin/`): mirror the three modules, `marked.use(mermaidExtension)` at module load in `View.vue`, add `mermaid` dep, bump `0.1.8 → 0.1.9`.

## Verification

- `yarn format`, `yarn lint` — clean (existing 26 warnings unrelated).
- `yarn typecheck`, `yarn build`, `yarn build:packages` — pass.
- `yarn test` — all suites pass; new `test/utils/markdown/test_mermaidExtension.ts` covers the block-fence rewrite, XSS escaping, non-mermaid fence pass-through, unterminated-fence fallback, empty body, surrounding paragraphs, and non-attachment to inline code (7/7 pass).
- Vite build output confirms mermaid is code-split: `dist/client/assets/mermaid-parser.core-*.js — 678 kB / gzip 146 kB` as its own chunk.

## Test plan

- [ ] Start the app, paste `\`\`\`mermaid\ngraph TB\n  A-->B\n\`\`\`` into a chat message, confirm an inline SVG renders under `.mermaid-diagram`.
- [ ] Regression: a plain `\`\`\`ts` fence still gets highlight.js styling.
- [ ] Wiki: create a page with a mermaid fence, open it, confirm the diagram appears.
- [ ] Skill: open a SKILL.md that contains a mermaid fence, confirm it renders.
- [ ] `.md` file viewer: open a workspace `.md` file with a mermaid fence, confirm it renders.
- [ ] Invalid mermaid: paste `\`\`\`mermaid\nnot a diagram\n\`\`\``, confirm a `.mermaid-error` block appears with a helpful diagnostic instead of crashing.
- [ ] Bundle sanity: initial page load does NOT ship mermaid; a mermaid fence pulls in the chunk lazily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown content now supports Mermaid diagrams across supported views, including skills, wiki, and text responses, plus the markdown plugin.
  * Mermaid diagrams are rendered automatically after markdown loads and when the markdown source updates.
  * Added localized Mermaid error messages for both load and render failures.
* **Bug Fixes**
  * Improved Mermaid fenced-block handling (including backtick/tilde fences, CRLF, and language tag whitespace) so Mermaid displays as diagrams or shows clear error output instead of plain code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->