### PR TITLE
feat(share): Download (zip) in the file explorer HTML preview (Phase 1c)

### DIFF
--- a/plans/feat-share-download-explorer.md
+++ b/plans/feat-share-download-explorer.md
@@ -1,0 +1,35 @@
+# feat: 共有機能 Phase 1c — ファイルエクスプローラーのHTMLプレビューにも Download(zip)
+
+Date: 2026-07-01
+Follow-up to #1892 / #1901.
+
+## 背景
+
+Phase 1b（#1901）で **チャットのキャンバス**（presentHtml の `View.vue`）に Download(zip) を追加したが、
+**ファイルエクスプローラー**の HTML プレビュー（`FileContentRenderer.vue` の生 iframe）には出ない。
+ユーザが「ファイルを見ながら DL」する自然な導線なので、そこにも足す。
+
+## 方式
+
+`FileContentRenderer.vue` は **ホスト側(`src/`)** なので、プラグインの `runtime.dispatch` を介さず
+**既存の `/api/share/pack` ルートを直接叩ける**（`apiFetchRaw` が bearer を自動付与）。
+`usePdfDownload` と同じ blob-to-download パターンを踏襲。
+
+## 変更
+
+- `src/composables/useSharePack.ts`（新）: `POST /api/share/pack {path}` → zip blob → ダウンロード。
+  `packing` / `packError` state。`usePdfDownload` のミラー。Content-Disposition からファイル名を取得。
+- `src/components/FileContentRenderer.vue`: `artifacts/html` の iframe プレビュー（`isHtml && htmlPreviewUrl`）を
+  relative ラッパーに変え、右上に Download ボタン（`data-testid="file-html-download"`）＋エラー表示を overlay。
+- host i18n（8 locale）: `fileContentRenderer.download` / `fileContentRenderer.downloadZip`。
+
+## テスト
+
+`useSharePack` はネットワーク依存のためユニットは薄い。ボタン表示条件（`isHtml && htmlPreviewUrl` =
+artifacts/html のみ）と blob DL は型/ビルドで担保 + 実アプリで file explorer から DL 確認。
+サーバ変更なし（Phase 1 の route を再利用）。
+
+## Out of scope
+
+非 `artifacts/html/` の HTML（`srcdoc` フォールバック分）は pack 対象外（route が artifacts/html に限定）。
+S3アップロード / 台帳 / MD・Wiki は後続。

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -301,13 +301,18 @@ const emit = defineEmits<{
 
 const systemDescriptor = computed(() => (props.selectedPath ? descriptorForPath(props.selectedPath) : null));
 
-const { packing, packFailed, downloadZip } = useSharePack();
+const { packing, packFailed, downloadZip, reset: resetSharePack } = useSharePack();
 // `htmlPreviewUrl` also matches `.htm`, but the pack route only accepts
 // canonical `.html`, so gate the button on `.html` to match server policy.
 const canDownloadZip = computed(() => Boolean(props.isHtml && props.htmlPreviewUrl && props.selectedPath?.toLowerCase().endsWith(".html")));
 function downloadHtmlZip() {
   if (props.selectedPath) void downloadZip(props.selectedPath);
 }
+// Drop a stale error banner when the user navigates to another file.
+watch(
+  () => props.selectedPath,
+  () => resetSharePack(),
+);
 
 const marpMode = computed(() => Boolean(props.mdFrontmatter && isMarpDocument(props.mdFrontmatter.meta)));
 

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -128,18 +128,20 @@
                 `about:srcdoc`), but that's the historical behavior
                 for non-`artifacts/html/` HTML. -->
         <div v-else-if="isHtml && htmlPreviewUrl" class="relative w-full h-full">
-          <div class="absolute top-2 right-2 z-10 flex flex-col items-end gap-1">
+          <!-- Only `.html` is packable (server gates on `isHtmlPath`); a
+               `.htm` preview shows no button so the action can't 400. -->
+          <div v-if="canDownloadZip" class="absolute top-2 right-2 z-10 flex flex-col items-end gap-1">
             <button
               class="px-2 py-1 text-xs rounded border border-gray-300 bg-white/90 text-gray-600 hover:bg-gray-50 disabled:opacity-50 shadow-sm"
               :title="t('fileContentRenderer.downloadZip')"
-              :disabled="packing || !selectedPath"
+              :disabled="packing"
               data-testid="file-html-download"
               @click="downloadHtmlZip"
             >
               <span class="material-icons text-sm align-middle">download</span>
               {{ t("fileContentRenderer.download") }}
             </button>
-            <span v-if="packError" class="text-xs text-red-600 bg-white/90 px-1 rounded" role="alert">{{ packError }}</span>
+            <span v-if="packFailed" class="text-xs text-red-600 bg-white/90 px-1 rounded" role="alert">{{ t("fileContentRenderer.downloadError") }}</span>
           </div>
           <iframe :src="htmlPreviewUrl" class="w-full h-full border-0" sandbox="allow-scripts" :title="t('fileContentRenderer.htmlPreview')" />
         </div>
@@ -299,7 +301,10 @@ const emit = defineEmits<{
 
 const systemDescriptor = computed(() => (props.selectedPath ? descriptorForPath(props.selectedPath) : null));
 
-const { packing, packError, downloadZip } = useSharePack();
+const { packing, packFailed, downloadZip } = useSharePack();
+// `htmlPreviewUrl` also matches `.htm`, but the pack route only accepts
+// canonical `.html`, so gate the button on `.html` to match server policy.
+const canDownloadZip = computed(() => Boolean(props.isHtml && props.htmlPreviewUrl && props.selectedPath?.toLowerCase().endsWith(".html")));
 function downloadHtmlZip() {
   if (props.selectedPath) void downloadZip(props.selectedPath);
 }

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -127,13 +127,22 @@
                 paths don't resolve under `srcdoc` (base URL is
                 `about:srcdoc`), but that's the historical behavior
                 for non-`artifacts/html/` HTML. -->
-        <iframe
-          v-else-if="isHtml && htmlPreviewUrl"
-          :src="htmlPreviewUrl"
-          class="w-full h-full border-0"
-          sandbox="allow-scripts"
-          :title="t('fileContentRenderer.htmlPreview')"
-        />
+        <div v-else-if="isHtml && htmlPreviewUrl" class="relative w-full h-full">
+          <div class="absolute top-2 right-2 z-10 flex flex-col items-end gap-1">
+            <button
+              class="px-2 py-1 text-xs rounded border border-gray-300 bg-white/90 text-gray-600 hover:bg-gray-50 disabled:opacity-50 shadow-sm"
+              :title="t('fileContentRenderer.downloadZip')"
+              :disabled="packing || !selectedPath"
+              data-testid="file-html-download"
+              @click="downloadHtmlZip"
+            >
+              <span class="material-icons text-sm align-middle">download</span>
+              {{ t("fileContentRenderer.download") }}
+            </button>
+            <span v-if="packError" class="text-xs text-red-600 bg-white/90 px-1 rounded" role="alert">{{ packError }}</span>
+          </div>
+          <iframe :src="htmlPreviewUrl" class="w-full h-full border-0" sandbox="allow-scripts" :title="t('fileContentRenderer.htmlPreview')" />
+        </div>
         <iframe
           v-else-if="isHtml"
           :srcdoc="sandboxedHtml"
@@ -247,6 +256,7 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import { formatScalarField, type MarkdownDocView } from "../composables/useMarkdownDoc";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
+import { useSharePack } from "../composables/useSharePack";
 import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
 import { isMarpDocument } from "../utils/markdown/marpDetect";
 import { buildPdfFilename } from "../utils/files/filename";
@@ -288,6 +298,11 @@ const emit = defineEmits<{
 }>();
 
 const systemDescriptor = computed(() => (props.selectedPath ? descriptorForPath(props.selectedPath) : null));
+
+const { packing, packError, downloadZip } = useSharePack();
+function downloadHtmlZip() {
+  if (props.selectedPath) void downloadZip(props.selectedPath);
+}
 
 const marpMode = computed(() => Boolean(props.mdFrontmatter && isMarpDocument(props.mdFrontmatter.meta)));
 

--- a/src/composables/useSharePack.ts
+++ b/src/composables/useSharePack.ts
@@ -1,0 +1,67 @@
+// Download an artifacts/html page as a self-contained zip from the host
+// UI (file explorer preview). Mirrors usePdfDownload: POST the workspace
+// path to /api/share/pack, receive a binary zip, run the
+// blob-to-download dance. Any failure sets packError for the caller to
+// render below the button.
+
+import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
+import { apiFetchRaw } from "../utils/api";
+import { errorMessage } from "../utils/errors";
+
+export interface UseSharePackHandle {
+  packing: Ref<boolean>;
+  packError: Ref<string | null>;
+  downloadZip: (htmlPath: string) => Promise<void>;
+}
+
+function filenameFromDisposition(header: string | null, fallback: string): string {
+  if (!header) return fallback;
+  const match = /filename="?([^";]+)"?/.exec(header);
+  return match ? match[1] : fallback;
+}
+
+export function useSharePack(): UseSharePackHandle {
+  const packing = ref(false);
+  const packError = ref<string | null>(null);
+
+  async function downloadZip(htmlPath: string): Promise<void> {
+    packError.value = null;
+    packing.value = true;
+    let url: string | null = null;
+    try {
+      // Returns a binary zip, not JSON — use the raw Response escape
+      // hatch so we can call `.blob()` ourselves.
+      const response = await apiFetchRaw(API_ROUTES.share.pack, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: htmlPath }),
+      });
+      if (!response.ok) {
+        const errText = await response.text().catch(() => "");
+        packError.value = `Share error ${response.status}: ${errText}`;
+        return;
+      }
+      const blob = await response.blob();
+      const fallback = `${
+        htmlPath
+          .split("/")
+          .pop()
+          ?.replace(/\.html?$/i, "") || "share"
+      }.zip`;
+      const filename = filenameFromDisposition(response.headers.get("content-disposition"), fallback);
+      url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      anchor.click();
+    } catch (err) {
+      packError.value = errorMessage(err);
+    } finally {
+      if (url) URL.revokeObjectURL(url);
+      packing.value = false;
+    }
+  }
+
+  return { packing, packError, downloadZip };
+}

--- a/src/composables/useSharePack.ts
+++ b/src/composables/useSharePack.ts
@@ -1,67 +1,66 @@
 // Download an artifacts/html page as a self-contained zip from the host
 // UI (file explorer preview). Mirrors usePdfDownload: POST the workspace
 // path to /api/share/pack, receive a binary zip, run the
-// blob-to-download dance. Any failure sets packError for the caller to
-// render below the button.
+// blob-to-download dance. Failure sets `packFailed` so the caller can
+// render a localized message — the raw server body is never surfaced.
 
 import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import { apiFetchRaw } from "../utils/api";
-import { errorMessage } from "../utils/errors";
 
 export interface UseSharePackHandle {
   packing: Ref<boolean>;
-  packError: Ref<string | null>;
+  packFailed: Ref<boolean>;
   downloadZip: (htmlPath: string) => Promise<void>;
 }
 
+function fallbackName(htmlPath: string): string {
+  const base =
+    htmlPath
+      .split("/")
+      .pop()
+      ?.replace(/\.html?$/i, "") || "share";
+  return `${base}.zip`;
+}
+
 function filenameFromDisposition(header: string | null, fallback: string): string {
-  if (!header) return fallback;
-  const match = /filename="?([^";]+)"?/.exec(header);
+  const match = header ? /filename="?([^";]+)"?/.exec(header) : null;
   return match ? match[1] : fallback;
+}
+
+function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
 }
 
 export function useSharePack(): UseSharePackHandle {
   const packing = ref(false);
-  const packError = ref<string | null>(null);
+  const packFailed = ref(false);
 
   async function downloadZip(htmlPath: string): Promise<void> {
-    packError.value = null;
+    packFailed.value = false;
     packing.value = true;
-    let url: string | null = null;
     try {
-      // Returns a binary zip, not JSON — use the raw Response escape
-      // hatch so we can call `.blob()` ourselves.
       const response = await apiFetchRaw(API_ROUTES.share.pack, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ path: htmlPath }),
       });
       if (!response.ok) {
-        const errText = await response.text().catch(() => "");
-        packError.value = `Share error ${response.status}: ${errText}`;
+        packFailed.value = true;
         return;
       }
-      const blob = await response.blob();
-      const fallback = `${
-        htmlPath
-          .split("/")
-          .pop()
-          ?.replace(/\.html?$/i, "") || "share"
-      }.zip`;
-      const filename = filenameFromDisposition(response.headers.get("content-disposition"), fallback);
-      url = URL.createObjectURL(blob);
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.download = filename;
-      anchor.click();
-    } catch (err) {
-      packError.value = errorMessage(err);
+      saveBlob(await response.blob(), filenameFromDisposition(response.headers.get("content-disposition"), fallbackName(htmlPath)));
+    } catch {
+      packFailed.value = true;
     } finally {
-      if (url) URL.revokeObjectURL(url);
       packing.value = false;
     }
   }
 
-  return { packing, packError, downloadZip };
+  return { packing, packFailed, downloadZip };
 }

--- a/src/composables/useSharePack.ts
+++ b/src/composables/useSharePack.ts
@@ -12,6 +12,9 @@ export interface UseSharePackHandle {
   packing: Ref<boolean>;
   packFailed: Ref<boolean>;
   downloadZip: (htmlPath: string) => Promise<void>;
+  /** Clear the failed flag — call on navigation so a stale error banner
+   *  doesn't carry over to the next file. */
+  reset: () => void;
 }
 
 function fallbackName(htmlPath: string): string {
@@ -62,5 +65,9 @@ export function useSharePack(): UseSharePackHandle {
     }
   }
 
-  return { packing, packFailed, downloadZip };
+  function reset(): void {
+    packFailed.value = false;
+  }
+
+  return { packing, packFailed, downloadZip, reset };
 }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -373,6 +373,7 @@ const deMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "Als eigenständiges ZIP herunterladen (Assets gebündelt)",
+    downloadError: "Download fehlgeschlagen",
     selectFile: "Datei auswählen",
     htmlPreview: "HTML-Vorschau",
     pdfPreview: "PDF-Vorschau",

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -371,6 +371,8 @@ const deMessages = {
     closeFile: "Datei schließen",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "Als eigenständiges ZIP herunterladen (Assets gebündelt)",
     selectFile: "Datei auswählen",
     htmlPreview: "HTML-Vorschau",
     pdfPreview: "PDF-Vorschau",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -386,6 +386,8 @@ const enMessages = {
     closeFile: "Close file",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "Download as a self-contained zip (assets bundled)",
     selectFile: "Select a file",
     htmlPreview: "HTML preview",
     pdfPreview: "PDF preview",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -388,6 +388,7 @@ const enMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "Download as a self-contained zip (assets bundled)",
+    downloadError: "Download failed",
     selectFile: "Select a file",
     htmlPreview: "HTML preview",
     pdfPreview: "PDF preview",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -375,6 +375,7 @@ const esMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "Descargar como zip autónomo (recursos incluidos)",
+    downloadError: "Error al descargar",
     selectFile: "Selecciona un archivo",
     htmlPreview: "Vista previa HTML",
     pdfPreview: "Vista previa PDF",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -373,6 +373,8 @@ const esMessages = {
     closeFile: "Cerrar archivo",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "Descargar como zip autónomo (recursos incluidos)",
     selectFile: "Selecciona un archivo",
     htmlPreview: "Vista previa HTML",
     pdfPreview: "Vista previa PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -367,6 +367,8 @@ const frMessages = {
     closeFile: "Fermer le fichier",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "Télécharger en zip autonome (ressources incluses)",
     selectFile: "Sélectionnez un fichier",
     htmlPreview: "Aperçu HTML",
     pdfPreview: "Aperçu PDF",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -369,6 +369,7 @@ const frMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "Télécharger en zip autonome (ressources incluses)",
+    downloadError: "Échec du téléchargement",
     selectFile: "Sélectionnez un fichier",
     htmlPreview: "Aperçu HTML",
     pdfPreview: "Aperçu PDF",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -369,6 +369,8 @@ const jaMessages = {
     closeFile: "ファイルを閉じる",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "自己完結zipでダウンロード（アセット同梱）",
     selectFile: "ファイルを選択してください",
     htmlPreview: "HTML プレビュー",
     pdfPreview: "PDF プレビュー",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -371,6 +371,7 @@ const jaMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "自己完結zipでダウンロード（アセット同梱）",
+    downloadError: "ダウンロードに失敗しました",
     selectFile: "ファイルを選択してください",
     htmlPreview: "HTML プレビュー",
     pdfPreview: "PDF プレビュー",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -369,6 +369,8 @@ const koMessages = {
     closeFile: "파일 닫기",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "자체 포함 zip으로 다운로드(에셋 포함)",
     selectFile: "파일을 선택하세요",
     htmlPreview: "HTML 미리보기",
     pdfPreview: "PDF 미리보기",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -371,6 +371,7 @@ const koMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "자체 포함 zip으로 다운로드(에셋 포함)",
+    downloadError: "다운로드 실패",
     selectFile: "파일을 선택하세요",
     htmlPreview: "HTML 미리보기",
     pdfPreview: "PDF 미리보기",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -365,6 +365,8 @@ const ptBRMessages = {
     closeFile: "Fechar arquivo",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "Baixar como zip autônomo (recursos incluídos)",
     selectFile: "Selecione um arquivo",
     htmlPreview: "Pré-visualização HTML",
     pdfPreview: "Pré-visualização PDF",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -367,6 +367,7 @@ const ptBRMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "Baixar como zip autônomo (recursos incluídos)",
+    downloadError: "Falha no download",
     selectFile: "Selecione um arquivo",
     htmlPreview: "Pré-visualização HTML",
     pdfPreview: "Pré-visualização PDF",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -363,6 +363,7 @@ const zhMessages = {
   fileContentRenderer: {
     download: "ZIP",
     downloadZip: "下载为自包含 zip(含资源)",
+    downloadError: "下载失败",
     selectFile: "请选择一个文件",
     htmlPreview: "HTML 预览",
     pdfPreview: "PDF 预览",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -361,6 +361,8 @@ const zhMessages = {
     closeFile: "关闭文件",
   },
   fileContentRenderer: {
+    download: "ZIP",
+    downloadZip: "下载为自包含 zip(含资源)",
     selectFile: "请选择一个文件",
     htmlPreview: "HTML 预览",
     pdfPreview: "PDF 预览",


### PR DESCRIPTION
## Summary

Phase 1b（#1901）でチャットのキャンバス（presentHtml `View.vue`）に付けた Download(zip) を、**ファイルエクスプローラーの HTML プレビューにも**追加する。`artifacts/html/*.html` をエクスプローラーで開くと、右上に **ZIP** ボタンが出て自己完結zipをダウンロードできる。

## Items to Confirm / Review

- [ ] **経路の違い**: `FileContentRenderer.vue` は**ホスト側(`src/`)** なので、プラグインの `runtime.dispatch` ではなく **既存の `POST /api/share/pack` を直接** `apiFetchRaw`（bearer自動付与）で叩く。`usePdfDownload` と同じ blob→download パターン（新 `useSharePack`）。
- [ ] **表示条件**: `isHtml && htmlPreviewUrl`（＝ `artifacts/html/` 配信のケース）でのみボタン表示。非 artifacts/html の `srcdoc` フォールバックには出さない（route が artifacts/html 限定のため）。
- [ ] **overlay**: iframe の上に絶対配置（右上、半透明）。`data-testid="file-html-download"`、エラーは下に赤字。
- [ ] **サーバ変更なし**: Phase 1 の route を再利用。

## User Prompt

> ファイルエクスプローラーのところでは HTML でもボタン出ないの？（→ 出したい）

## 実装

| ファイル | 変更 |
|---|---|
| `src/composables/useSharePack.ts`（新） | `/api/share/pack` を叩き zip blob をダウンロード。`packing`/`packError`。Content-Disposition からファイル名取得 |
| `src/components/FileContentRenderer.vue` | artifacts/html の iframe を relative ラッパー化＋Download ボタン overlay |
| `src/lang/*.ts`（8 locale） | `fileContentRenderer.download` / `downloadZip` |

## テスト

`format`/`lint`/`typecheck`/`build`/`test` グリーン（pre-commit hook で全ゲート実行）。i18n 8ロケール。サーバ変更なし。

## ロードマップ

- Phase 1 / 1b（#1892 / #1901 済）: pack+zip バックエンド + チャットビューUI
- **Phase 1c（本PR）**: ファイルエクスプローラーUI
- Phase 2: S3互換アップロード + 共有台帳

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ZIP download button to the HTML preview, enabling users to save the page as a self-contained ZIP with bundled assets.
  * Added download state handling: button disables while preparing the ZIP and shows an inline error message on failure.
* **Localization**
  * Added new UI text for the download control and error messaging across supported languages.
* **Documentation**
  * Added an implementation plan for the “Share” Phase 1c HTML ZIP download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->