### PR TITLE
feat(share): Markdown / Wiki self-contained HTML zip download (Phase 3)

### DIFF
--- a/plans/feat-share-markdown-zip.md
+++ b/plans/feat-share-markdown-zip.md
@@ -1,0 +1,40 @@
+# feat: 共有機能 Phase 3 — Markdown / Wiki を自己完結HTML zip でDL
+
+Date: 2026-07-02
+Issue: #1908 · Follow-up to #1892 / #1901 / #1907
+
+## ゴール
+
+Markdown / 単一Wikiページ を **自己完結HTML（画像 data URI インライン + CSS インライン）**に変換し、
+**zip**（`index.html` 単一）でダウンロードできるようにする。対象は Markdownチャット / Wiki / エクスプローラーの `.md` の全部。
+Phase 2（S3）とは独立。
+
+## 方式（DRY: PDF パイプライン再利用）
+
+`server/api/routes/pdf.ts` の `renderMarkdownPdf` は
+`wrapHtml(inlineImages(marked.parse(source)), MARKDOWN_CSS)` で自己完結HTMLを作ってから PDF 化している。
+その **HTML 生成段を `renderMarkdownHtml(opts): Promise<string>` として抽出**し、PDF/zip 双方から使う。
+
+## 実装
+
+### Server
+- `server/api/routes/pdf.ts`: `renderMarkdownHtml(opts)`（marp/非marp両対応）を export し、
+  `renderMarkdownPdf` はそれを `renderPdf` に渡すだけに簡素化。
+- `server/utils/share/packMarkdown.ts`（新）: `packMarkdownZip(opts)` = `renderMarkdownHtml` →
+  `zipBundle([{ bundlePath:"index.html", bytes }])` → 安全なファイル名。
+- `server/api/routes/share.ts`: `POST /api/share/pack-markdown`（body 検証: markdown 必須, baseDir/marp/stripFrontmatter）→ zip 配信。
+- `src/config/apiRoutes.ts`: `share.packMarkdown`。
+
+### Client
+- `src/composables/useMarkdownZip.ts`（新, `usePdfDownload` を鏡）: markdown/opts を POST → zip blob → DL。`packing`/`packFailed`/`reset`。
+- `src/plugins/textResponse/View.vue`: 既存 PDF ボタン隣に ZIP（チャット＋エクスプローラー.md を同時にカバー）。
+- `src/plugins/wiki/View.vue`: 既存 PDF ボタン隣に ZIP（`baseDir=data/wiki/pages`, `stripFrontmatter=true` は PDF と同じ引数）。
+- i18n: 各ビューのロケールに download / downloadZip / downloadError。
+
+## テスト
+- `renderMarkdownHtml`: 自己完結（`<!DOCTYPE`, inline `<style>`, ローカル画像が data URI）。
+- `packMarkdownZip`: `index.html` を含む有効 zip・安全ファイル名。
+- 実アプリで各ビューの ZIP DL 確認。
+
+## Out of scope
+S3アップロード / 台帳（Phase 2）、Wiki 全体 SSG（不要）。

--- a/plans/feat-share-markdown-zip.md
+++ b/plans/feat-share-markdown-zip.md
@@ -20,10 +20,12 @@ Phase 2（S3）とは独立。
 ### Server
 - `server/api/routes/pdf.ts`: `renderMarkdownHtml(opts)`（marp/非marp両対応）を export し、
   `renderMarkdownPdf` はそれを `renderPdf` に渡すだけに簡素化。
-- `server/utils/share/packMarkdown.ts`（新）: `packMarkdownZip(opts)` = `renderMarkdownHtml` →
-  `zipBundle([{ bundlePath:"index.html", bytes }])` → 安全なファイル名。
-- `server/api/routes/share.ts`: `POST /api/share/pack-markdown`（body 検証: markdown 必須, baseDir/marp/stripFrontmatter）→ zip 配信。
+- `server/api/routes/share.ts`: `POST /api/share/pack-markdown`（body 検証: markdown 必須, baseDir/marp/stripFrontmatter）。
+  `renderMarkdownHtml` → **script無効化CSP注入(`withScriptCsp`)** → `zipBundle([{ bundlePath:"index.html", bytes }])` → 安全なファイル名。
+  （別utilは作らず share.ts 内の `buildMarkdownZip` に集約。）
 - `src/config/apiRoutes.ts`: `share.packMarkdown`。
+- **セキュリティ**: zip は受信者がHTMLを直接開くため、`marked` の raw HTML 通過による script を CSP
+  (`script-src 'none'; object-src 'none'; base-uri 'none'`) で無効化（PDF経路は puppeteer で1回描画のみなので不要）。
 
 ### Client
 - `src/composables/useMarkdownZip.ts`（新, `usePdfDownload` を鏡）: markdown/opts を POST → zip blob → DL。`packing`/`packFailed`/`reset`。

--- a/server/api/routes/pdf.ts
+++ b/server/api/routes/pdf.ts
@@ -248,7 +248,7 @@ async function renderPdf(fullHtml: string, format: "Letter" | "A4" = "Letter"): 
   }
 }
 
-async function renderMarpPdf(markdown: string, baseDir?: string): Promise<Buffer> {
+async function renderMarpHtml(markdown: string, baseDir?: string): Promise<{ fullHtml: string; slideWidth: number; slideHeight: number }> {
   // Shared render core (@mulmoclaude/markdown-plugin) — the MarpView
   // preview and every host's PDF export use the same Marp config + theme
   // registration + custom-size bridging, so they can't drift. Twemoji
@@ -292,6 +292,11 @@ div.marpit > svg > foreignObject > section {
                "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
 }
 </style></head><body>${inlinedHtml}</body></html>`;
+  return { fullHtml, slideWidth, slideHeight };
+}
+
+async function renderMarpPdf(markdown: string, baseDir?: string): Promise<Buffer> {
+  const { fullHtml, slideWidth, slideHeight } = await renderMarpHtml(markdown, baseDir);
   const browser = await puppeteer.launch({ headless: true });
   try {
     const page = await browser.newPage();
@@ -320,18 +325,34 @@ export interface RenderMarkdownPdfOptions {
   stripFrontmatter?: boolean;
 }
 
+export interface RenderMarkdownHtmlOptions {
+  markdown: string;
+  /** Render via Marp (slide deck) instead of the `marked` pipeline. */
+  marp?: boolean;
+  /** Workspace-relative source dir for resolving relative `<img>` refs. */
+  baseDir?: string;
+  stripFrontmatter?: boolean;
+}
+
+/** Markdown (or a Marp deck) → a self-contained HTML string: CSS inlined
+ *  and local images embedded as data URIs. Shared by the PDF render
+ *  (`renderMarkdownPdf`) and the zip share (`packMarkdownZip`) so the two
+ *  can never drift. */
+export async function renderMarkdownHtml(options: RenderMarkdownHtmlOptions): Promise<string> {
+  const { markdown, marp = false, baseDir, stripFrontmatter = false } = options;
+  if (marp) return (await renderMarpHtml(markdown, baseDir)).fullHtml;
+  const source = stripFrontmatter ? parseFrontmatter(markdown).body : markdown;
+  return wrapHtml(inlineImages(await marked.parse(source), { sourceDir: baseDir }), MARKDOWN_CSS);
+}
+
 /** Render markdown (or a Marp deck) to a PDF buffer. The single code
  *  path behind both `POST /api/pdf/markdown` and the markdown plugin's
  *  `exportPdf` host capability (`server/plugins/markdown-builtin.ts`),
  *  so the HTTP route and the plugin dispatch can never drift. */
 export async function renderMarkdownPdf(options: RenderMarkdownPdfOptions): Promise<Buffer> {
-  const { markdown, marp = false, baseDir, format = "Letter", stripFrontmatter = false } = options;
-  if (marp) {
-    return renderMarpPdf(markdown, baseDir);
-  }
-  const source = stripFrontmatter ? parseFrontmatter(markdown).body : markdown;
-  const html = inlineImages(await marked.parse(source), { sourceDir: baseDir });
-  return renderPdf(wrapHtml(html, MARKDOWN_CSS), format);
+  const { markdown, marp = false, baseDir, format = "Letter" } = options;
+  if (marp) return renderMarpPdf(markdown, baseDir);
+  return renderPdf(await renderMarkdownHtml(options), format);
 }
 
 function sendPdf(res: Response, buffer: Buffer, filename: string): void {

--- a/server/api/routes/share.ts
+++ b/server/api/routes/share.ts
@@ -55,30 +55,46 @@ interface PackMarkdownBody {
   marp?: boolean;
 }
 
+// A shared markdown zip is opened directly by the recipient (unlike the
+// PDF path, which puppeteer renders once), so neutralize any script the
+// source markdown carries — `marked` passes raw HTML through. A strict
+// CSP blocks `<script>` / inline handlers / `javascript:` and plugins
+// without stripping content or touching images/styles.
+const SHARE_MARKDOWN_CSP = "script-src 'none'; object-src 'none'; base-uri 'none'";
+
+export function withScriptCsp(html: string): string {
+  return html.replace(/<head>/i, `<head><meta http-equiv="Content-Security-Policy" content="${SHARE_MARKDOWN_CSP}">`);
+}
+
+async function buildMarkdownZip(body: PackMarkdownBody): Promise<{ filename: string; zip: Buffer }> {
+  const markdown = typeof body.markdown === "string" ? body.markdown : "";
+  const baseDir = typeof body.baseDir === "string" ? body.baseDir : undefined;
+  const html = withScriptCsp(await renderMarkdownHtml({ markdown, baseDir, stripFrontmatter: body.stripFrontmatter === true, marp: body.marp === true }));
+  const zip = await zipBundle([{ bundlePath: "index.html", bytes: Buffer.from(html, "utf-8") }]);
+  const filename = typeof body.filename === "string" ? body.filename : "document";
+  return { filename: safeZipName(filename.replace(/\.(md|markdown|html?|pdf)$/i, "")), zip };
+}
+
 // POST /api/share/pack-markdown — render markdown (or a wiki page) to a
-// self-contained HTML (CSS inlined, images embedded as data URIs) and
-// return it zipped as index.html. Shares the render path with the PDF
-// route (`renderMarkdownHtml`). `baseDir` resolves relative image refs;
-// traversal is rejected downstream by the shared image resolver.
+// self-contained HTML (CSS inlined, images embedded as data URIs, scripts
+// neutralized) and return it zipped as index.html. Shares the render path
+// with the PDF route (`renderMarkdownHtml`). `baseDir` resolves relative
+// image refs; traversal is rejected downstream by the shared image resolver.
 router.post(API_ROUTES.share.packMarkdown, async (req: Request<object, unknown, PackMarkdownBody>, res: Response) => {
   const { body } = req;
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     badRequest(res, "request body must be a JSON object");
     return;
   }
-  const markdown = typeof body.markdown === "string" ? body.markdown : "";
-  if (!markdown) {
+  if (typeof body.markdown !== "string" || !body.markdown) {
     badRequest(res, "markdown is required");
     return;
   }
-  const baseDir = typeof body.baseDir === "string" ? body.baseDir : undefined;
-  const filename = typeof body.filename === "string" ? body.filename : "document";
   try {
-    const html = await renderMarkdownHtml({ markdown, baseDir, stripFrontmatter: body.stripFrontmatter === true, marp: body.marp === true });
-    const zip = await zipBundle([{ bundlePath: "index.html", bytes: Buffer.from(html, "utf-8") }]);
+    const { filename, zip } = await buildMarkdownZip(body);
     log.info("share", "pack-markdown: ok", { bytes: zip.length, marp: body.marp === true });
     res.setHeader("Content-Type", "application/zip");
-    res.setHeader("Content-Disposition", `attachment; filename="${safeZipName(filename.replace(/\.(md|markdown|html?|pdf)$/i, ""))}"`);
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
     res.send(zip);
   } catch (err) {
     log.error("share", "pack-markdown: threw", { error: errorMessage(err) });

--- a/server/api/routes/share.ts
+++ b/server/api/routes/share.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response } from "express";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
-import { packHtmlZip } from "../../utils/share/packHtml.js";
+import { packHtmlZip, zipBundle, safeZipName } from "../../utils/share/packHtml.js";
+import { renderMarkdownHtml } from "./pdf.js";
 import { isHtmlPath } from "../../utils/files/html-store.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -43,6 +44,45 @@ router.post(API_ROUTES.share.pack, async (req: Request<object, unknown, PackBody
     // path / stack never reaches the client.
     log.error("share", "pack: threw", { path: htmlPath, error: errorMessage(err) });
     serverError(res, "failed to pack HTML bundle");
+  }
+});
+
+interface PackMarkdownBody {
+  markdown?: string;
+  filename?: string;
+  baseDir?: string;
+  stripFrontmatter?: boolean;
+  marp?: boolean;
+}
+
+// POST /api/share/pack-markdown — render markdown (or a wiki page) to a
+// self-contained HTML (CSS inlined, images embedded as data URIs) and
+// return it zipped as index.html. Shares the render path with the PDF
+// route (`renderMarkdownHtml`). `baseDir` resolves relative image refs;
+// traversal is rejected downstream by the shared image resolver.
+router.post(API_ROUTES.share.packMarkdown, async (req: Request<object, unknown, PackMarkdownBody>, res: Response) => {
+  const body = req.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    badRequest(res, "request body must be a JSON object");
+    return;
+  }
+  const markdown = typeof body.markdown === "string" ? body.markdown : "";
+  if (!markdown) {
+    badRequest(res, "markdown is required");
+    return;
+  }
+  const baseDir = typeof body.baseDir === "string" ? body.baseDir : undefined;
+  const filename = typeof body.filename === "string" ? body.filename : "document";
+  try {
+    const html = await renderMarkdownHtml({ markdown, baseDir, stripFrontmatter: body.stripFrontmatter === true, marp: body.marp === true });
+    const zip = await zipBundle([{ bundlePath: "index.html", bytes: Buffer.from(html, "utf-8") }]);
+    log.info("share", "pack-markdown: ok", { bytes: zip.length, marp: body.marp === true });
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader("Content-Disposition", `attachment; filename="${safeZipName(filename.replace(/\.(md|markdown|html?|pdf)$/i, ""))}"`);
+    res.send(zip);
+  } catch (err) {
+    log.error("share", "pack-markdown: threw", { error: errorMessage(err) });
+    serverError(res, "failed to pack markdown bundle");
   }
 });
 

--- a/server/api/routes/share.ts
+++ b/server/api/routes/share.ts
@@ -61,7 +61,7 @@ interface PackMarkdownBody {
 // route (`renderMarkdownHtml`). `baseDir` resolves relative image refs;
 // traversal is rejected downstream by the shared image resolver.
 router.post(API_ROUTES.share.packMarkdown, async (req: Request<object, unknown, PackMarkdownBody>, res: Response) => {
-  const body = req.body;
+  const { body } = req;
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     badRequest(res, "request body must be a JSON object");
     return;

--- a/server/utils/share/packHtml.ts
+++ b/server/utils/share/packHtml.ts
@@ -94,7 +94,7 @@ export function zipBundle(files: PackedFile[]): Promise<Buffer> {
   return zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE", compressionOptions: { level: 9 } });
 }
 
-function safeZipName(name: string): string {
+export function safeZipName(name: string): string {
   const cleaned = name.replace(/[^\w.-]+/g, "_");
   return `${cleaned || "share"}.zip`;
 }

--- a/src/composables/useMarkdownZip.ts
+++ b/src/composables/useMarkdownZip.ts
@@ -1,0 +1,51 @@
+// Download markdown / a wiki page as a self-contained HTML zip. Parallel
+// to usePdfDownload, but hits POST /api/share/pack-markdown and receives
+// a zip (index.html with CSS + images inlined). Failure sets `zipFailed`
+// so callers render a localized message — the raw server body is never
+// surfaced.
+
+import { ref, type Ref } from "vue";
+import { API_ROUTES } from "../config/apiRoutes";
+import { apiFetchRaw } from "../utils/api";
+import { saveBlob, filenameFromDisposition } from "../utils/blobDownload";
+
+export interface DownloadMarkdownZipOptions {
+  /** Workspace-relative source dir for resolving relative `<img>` refs. */
+  baseDir?: string;
+  stripFrontmatter?: boolean;
+  marp?: boolean;
+}
+
+export interface UseMarkdownZipHandle {
+  zipDownloading: Ref<boolean>;
+  zipFailed: Ref<boolean>;
+  downloadZip: (markdown: string, filename: string, options?: DownloadMarkdownZipOptions) => Promise<void>;
+}
+
+export function useMarkdownZip(): UseMarkdownZipHandle {
+  const zipDownloading = ref(false);
+  const zipFailed = ref(false);
+
+  async function downloadZip(markdown: string, filename: string, options: DownloadMarkdownZipOptions = {}): Promise<void> {
+    zipFailed.value = false;
+    zipDownloading.value = true;
+    try {
+      const response = await apiFetchRaw(API_ROUTES.share.packMarkdown, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ markdown, filename, baseDir: options.baseDir, stripFrontmatter: options.stripFrontmatter, marp: options.marp }),
+      });
+      if (!response.ok) {
+        zipFailed.value = true;
+        return;
+      }
+      saveBlob(await response.blob(), filenameFromDisposition(response.headers.get("content-disposition"), `${filename}.zip`));
+    } catch {
+      zipFailed.value = true;
+    } finally {
+      zipDownloading.value = false;
+    }
+  }
+
+  return { zipDownloading, zipFailed, downloadZip };
+}

--- a/src/composables/useSharePack.ts
+++ b/src/composables/useSharePack.ts
@@ -7,6 +7,7 @@
 import { ref, type Ref } from "vue";
 import { API_ROUTES } from "../config/apiRoutes";
 import { apiFetchRaw } from "../utils/api";
+import { saveBlob, filenameFromDisposition } from "../utils/blobDownload";
 
 export interface UseSharePackHandle {
   packing: Ref<boolean>;
@@ -24,20 +25,6 @@ function fallbackName(htmlPath: string): string {
       .pop()
       ?.replace(/\.html?$/i, "") || "share";
   return `${base}.zip`;
-}
-
-function filenameFromDisposition(header: string | null, fallback: string): string {
-  const match = header ? /filename="?([^";]+)"?/.exec(header) : null;
-  return match ? match[1] : fallback;
-}
-
-function saveBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  anchor.click();
-  URL.revokeObjectURL(url);
 }
 
 export function useSharePack(): UseSharePackHandle {

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -142,8 +142,11 @@ const HOST_API_ROUTES = {
 
   // Sharing: pack an HTML artifact + its referenced local assets into a
   // self-contained zip (index.html + assets/), streamed as a download.
+  // `packMarkdown` renders markdown / a wiki page to a self-contained
+  // HTML (images inlined) and zips that.
   share: {
     pack: "/api/share/pack",
+    packMarkdown: "/api/share/pack-markdown",
   },
 
   mcpTools: {

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -3,6 +3,8 @@
 
 const deMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "Download fehlgeschlagen",
     save: "Speichern",
     cancel: "Abbrechen",
     loading: "Wird geladen...",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -23,6 +23,8 @@
 
 const enMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "Download failed",
     save: "Save",
     cancel: "Cancel",
     loading: "Loading...",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -8,6 +8,8 @@
 
 const esMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "Error al descargar",
     save: "Guardar",
     cancel: "Cancelar",
     loading: "Cargando...",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -3,6 +3,8 @@
 
 const frMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "Échec du téléchargement",
     save: "Enregistrer",
     cancel: "Annuler",
     loading: "Chargement...",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -8,6 +8,8 @@
 
 const jaMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "ダウンロードに失敗しました",
     save: "保存",
     cancel: "キャンセル",
     loading: "読み込み中...",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -8,6 +8,8 @@
 
 const koMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "다운로드 실패",
     save: "저장",
     cancel: "취소",
     loading: "불러오는 중...",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -3,6 +3,8 @@
 
 const ptBRMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "Falha no download",
     save: "Salvar",
     cancel: "Cancelar",
     loading: "Carregando...",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -7,6 +7,8 @@
 
 const zhMessages = {
   common: {
+    downloadZip: "ZIP",
+    downloadFailed: "下载失败",
     save: "保存",
     cancel: "取消",
     loading: "加载中...",

--- a/src/plugins/textResponse/View.vue
+++ b/src/plugins/textResponse/View.vue
@@ -40,7 +40,17 @@
         <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
         {{ t("pluginTextResponse.pdf") }}
       </button>
+      <button
+        class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        :disabled="zipDownloading"
+        data-testid="text-response-zip-button"
+        @click="downloadZipFile"
+      >
+        <span class="material-icons text-base">{{ zipDownloading ? "hourglass_empty" : "folder_zip" }}</span>
+        {{ t("common.downloadZip") }}
+      </button>
       <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginTextResponse.pdfFailed") }}</span>
+      <span v-if="zipFailed" class="text-xs text-red-500">{{ t("common.downloadFailed") }}</span>
     </div>
     <div class="flex-1 overflow-hidden relative" @click.capture="openLinksInNewTab">
       <div class="text-response-container">
@@ -95,6 +105,7 @@ import { handleExternalLinkClick } from "../../utils/dom/externalLink";
 import { classifyWorkspacePath } from "../../utils/path/workspaceLinkRouter";
 import { useAppApi } from "../../composables/useAppApi";
 import { usePdfDownload } from "../../composables/usePdfDownload";
+import { useMarkdownZip } from "../../composables/useMarkdownZip";
 import { useClipboardCopy } from "../../composables/useClipboardCopy";
 import { buildPdfFilename } from "../../utils/files/filename";
 import { extractTextResponseTitle } from "./utils";
@@ -246,6 +257,7 @@ function openLinksInNewTab(event: MouseEvent): void {
 }
 
 const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
+const { zipDownloading, zipFailed, downloadZip: rawDownloadZip } = useMarkdownZip();
 
 const editing = ref(false);
 
@@ -275,23 +287,29 @@ async function copyText() {
   await copy(props.selectedResult.data?.text ?? "");
 }
 
-async function downloadPdf() {
+// PDF and zip share the same source: display text and export source can
+// diverge (Files Explorer's .md preview pre-rewrites image refs to
+// `/api/files/raw?...` for the browser, which the server inliner can't
+// resolve back to disk), so prefer the original source when provided.
+function markdownExport(): { text: string; filename: string; baseDir?: string; stripFrontmatter?: boolean } {
   const { data } = props.selectedResult;
-  // Display text and PDF source can diverge: Files Explorer's .md
-  // preview pre-rewrites image refs to `/api/files/raw?...` for
-  // browser display, but the server PDF inliner can't resolve those
-  // back to disk. Use the original source when the caller passes it.
-  const pdfText = data?.pdfSourceText ?? data?.text ?? "";
-  const displayText = data?.text ?? "";
+  const text = data?.pdfSourceText ?? data?.text ?? "";
   const filename = buildPdfFilename({
-    name: extractTextResponseTitle(displayText),
+    name: extractTextResponseTitle(data?.text ?? ""),
     fallback: "chat",
     timestampMs: appApi.getResultTimestamp(props.selectedResult.uuid),
   });
-  await rawDownloadPdf(pdfText, filename, {
-    baseDir: data?.pdfBaseDir,
-    stripFrontmatter: data?.pdfStripFrontmatter,
-  });
+  return { text, filename, baseDir: data?.pdfBaseDir, stripFrontmatter: data?.pdfStripFrontmatter };
+}
+
+async function downloadPdf() {
+  const { text, filename, baseDir, stripFrontmatter } = markdownExport();
+  await rawDownloadPdf(text, filename, { baseDir, stripFrontmatter });
+}
+
+async function downloadZipFile() {
+  const { text, filename, baseDir, stripFrontmatter } = markdownExport();
+  await rawDownloadZip(text, filename, { baseDir, stripFrontmatter });
 }
 </script>
 

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -23,7 +23,17 @@
             <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
             {{ t("pluginWiki.pdf") }}
           </button>
+          <button
+            class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            :disabled="zipDownloading"
+            data-testid="wiki-zip-button"
+            @click="downloadZipFile"
+          >
+            <span class="material-icons text-base">{{ zipDownloading ? "hourglass_empty" : "folder_zip" }}</span>
+            {{ t("common.downloadZip") }}
+          </button>
           <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
+          <span v-if="zipFailed" class="text-xs text-red-500">{{ t("common.downloadFailed") }}</span>
         </template>
         <button
           v-if="action === 'index'"
@@ -398,6 +408,7 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry, WikiEndpoints } from "./index";
 import { useFreshPluginData } from "../../composables/useFreshPluginData";
 import { usePdfDownload } from "../../composables/usePdfDownload";
+import { useMarkdownZip } from "../../composables/useMarkdownZip";
 import { useAppApi } from "../../composables/useAppApi";
 import { buildPdfFilename } from "../../utils/files/filename";
 import PageChatComposer from "../../components/PageChatComposer.vue";
@@ -818,6 +829,7 @@ const displayTitle = computed(() => {
 });
 
 const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
+const { zipDownloading, zipFailed, downloadZip: rawDownloadZip } = useMarkdownZip();
 
 async function downloadPdf() {
   const uuid = props.selectedResult?.uuid;
@@ -832,6 +844,12 @@ async function downloadPdf() {
   // a frontmatter envelope (#895), so opt in to stripping it from the
   // PDF output.
   await rawDownloadPdf(content.value, filename, { baseDir: "data/wiki/pages", stripFrontmatter: true });
+}
+
+async function downloadZipFile() {
+  const uuid = props.selectedResult?.uuid;
+  const filename = buildPdfFilename({ name: title.value, fallback: "wiki", timestampMs: uuid ? appApi.getResultTimestamp(uuid) : undefined });
+  await rawDownloadZip(content.value, filename, { baseDir: "data/wiki/pages", stripFrontmatter: true });
 }
 
 // Graph tab response carries the link graph directly. On a page view,

--- a/src/utils/blobDownload.ts
+++ b/src/utils/blobDownload.ts
@@ -1,0 +1,17 @@
+// Shared browser blob-download helpers used by the share composables
+// (useSharePack, useMarkdownZip). Keeps the createObjectURL → click →
+// revoke dance and the Content-Disposition filename parsing in one place.
+
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function filenameFromDisposition(header: string | null, fallback: string): string {
+  const match = header ? /filename="?([^";]+)"?/.exec(header) : null;
+  return match ? match[1] : fallback;
+}

--- a/src/utils/blobDownload.ts
+++ b/src/utils/blobDownload.ts
@@ -8,7 +8,9 @@ export function saveBlob(blob: Blob, filename: string): void {
   anchor.href = url;
   anchor.download = filename;
   anchor.click();
-  URL.revokeObjectURL(url);
+  // Defer revocation to the next task: revoking synchronously right after
+  // click() can cancel the download in some browsers before the blob is read.
+  setTimeout(() => URL.revokeObjectURL(url));
 }
 
 export function filenameFromDisposition(header: string | null, fallback: string): string {

--- a/test/routes/test_renderMarkdownHtml.ts
+++ b/test/routes/test_renderMarkdownHtml.ts
@@ -1,0 +1,47 @@
+// renderMarkdownHtml (server/api/routes/pdf.ts) is the shared markdown →
+// self-contained HTML stage behind both the PDF export and the share zip.
+// Verify it inlines CSS + local images so the zipped index.html opens
+// standalone.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, writeFile, rm } from "fs/promises";
+import path from "path";
+import { resolveWorkspacePath } from "../../server/utils/files/workspace-io.js";
+import { renderMarkdownHtml } from "../../server/api/routes/pdf.js";
+
+const TOKEN = "__share_md_test__";
+const IMG_REL = `data/${TOKEN}/pic.png`;
+const IMG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]);
+const imgAbsDir = path.dirname(resolveWorkspacePath(IMG_REL));
+
+before(async () => {
+  await mkdir(imgAbsDir, { recursive: true });
+  await writeFile(resolveWorkspacePath(IMG_REL), IMG_BYTES);
+});
+
+after(async () => {
+  await rm(imgAbsDir, { recursive: true, force: true });
+});
+
+describe("renderMarkdownHtml", () => {
+  it("produces a self-contained HTML with inline CSS and data-URI images", async () => {
+    const html = await renderMarkdownHtml({ markdown: "# Title\n\n![pic](pic.png)\n", baseDir: `data/${TOKEN}` });
+    assert.match(html, /<!DOCTYPE html>/i);
+    assert.match(html, /<style>/);
+    assert.match(html, /Title<\/h1>/);
+    assert.match(html, /data:image\/png;base64,/);
+    assert.doesNotMatch(html, /src="pic\.png"/);
+  });
+
+  it("leaves a remote image url untouched", async () => {
+    const html = await renderMarkdownHtml({ markdown: "![x](https://cdn.example/x.png)" });
+    assert.match(html, /https:\/\/cdn\.example\/x\.png/);
+  });
+
+  it("strips a frontmatter envelope when asked", async () => {
+    const html = await renderMarkdownHtml({ markdown: "---\ntitle: T\n---\n\n# Body\n", stripFrontmatter: true });
+    assert.match(html, /Body<\/h1>/);
+    assert.doesNotMatch(html, /title: T/);
+  });
+});

--- a/test/routes/test_shareRoute.ts
+++ b/test/routes/test_shareRoute.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { isPackablePath } from "../../server/api/routes/share.js";
+import { isPackablePath, withScriptCsp } from "../../server/api/routes/share.js";
 
 describe("isPackablePath", () => {
   it("accepts a canonical artifacts/html/*.html path", () => {
@@ -36,5 +36,15 @@ describe("isPackablePath", () => {
     assert.equal(isPackablePath("artifacts/html/./page.html"), false);
     assert.equal(isPackablePath("artifacts/html/a..b.html"), false);
     assert.equal(isPackablePath("artifacts/html/../../../../etc/passwd"), false);
+  });
+});
+
+describe("withScriptCsp", () => {
+  it("injects a script-blocking CSP so a shared markdown script can't run", () => {
+    const out = withScriptCsp("<!DOCTYPE html><html><head><style>x</style></head><body><script>alert(1)</script></body></html>");
+    assert.match(out, /<meta http-equiv="Content-Security-Policy"/);
+    assert.match(out, /script-src 'none'/);
+    // Content is preserved (not stripped) — the CSP neutralizes it at open time.
+    assert.match(out, /<style>x<\/style>/);
   });
 });


### PR DESCRIPTION
## Summary

共有機能を **Markdown / 単一Wikiページ** に拡張。自己完結HTML（CSSインライン・ローカル画像を data URI 埋め込み）に変換し、**zip**（`index.html`）でDL。対象は **Markdownチャット（textResponse）/ エクスプローラーの .md / Wikiページ** の全部。Phase 2（S3）とは独立。

## Items to Confirm / Review

- [ ] **DRY（PDF再利用）**: `pdf.ts` の `renderMarkdownPdf` が既に作っている自己完結HTMLを `renderMarkdownHtml()` として抽出し、**PDFエクスポートと zip 共有が同一描画パス**を使う（drift防止）。Marp も対応。
- [ ] **新ルート**: `POST /api/share/pack-markdown`（body: markdown/filename/baseDir/stripFrontmatter/marp）。PDFルートと同じ body 処理。`baseDir` の traversal は共有画像リゾルバ側で拒否。
- [ ] **UI**: 既存 PDF ボタンの隣に **ZIP** ボタン。`textResponse/View.vue`（チャット＋エクスプローラー.md を同時にカバー）と `wiki/View.vue`。`data-testid`: `text-response-zip-button` / `wiki-zip-button`。
- [ ] **DRY（client）**: blob DL の共通化 `src/utils/blobDownload.ts`（`useSharePack` も採用）。`useMarkdownZip` は `usePdfDownload` の鏡。エラーは生body非表示＋ローカライズ（`common.downloadFailed`）。
- [ ] **i18n**: `common.downloadZip` / `common.downloadFailed` を 8ロケール。

## User Prompt

> 共有の Phase 3（Markdown/Wiki）を先にやりたい。対象は全部（Markdownチャット・Wiki・エクスプローラーの.md）、形式は zip。

## テスト

`test/routes/test_renderMarkdownHtml.ts`（自己完結HTML: DOCTYPE / inline CSS / data URI画像 / frontmatter strip）。format/lint/typecheck/build/全test グリーン（pre-commit フック）。

## ⚠️ dev サーバ再起動が必要

`server` スクリプトは `tsx server/index.ts`（watch 無し）。**新ルートは起動中サーバには未反映**なので、`npm run dev` の再起動が必要（クライアントのボタンは HMR で表示されるが、クリックは再起動まで 404）。

## ロードマップ

- Phase 1/1b/1c（済）: HTML成果物の pack + DL（チャット/エクスプローラー）
- **Phase 3（本PR）**: Markdown / Wiki の zip DL
- Phase 2（未）: S3互換アップロード + 共有台帳

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ZIP download support for Markdown and wiki pages, alongside the existing PDF download.
  * Downloaded bundles now contain a self-contained HTML page with bundled styling and embedded local images.
  * Added localized “ZIP” and download-failed messages across supported languages.

* **Bug Fixes**
  * Improved download handling with clearer failure states and safer downloaded filenames.
  * Reused shared export logic so PDF and ZIP downloads stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->