### PR TITLE
fix(gitleaks): allowlist Firebase Web SDK apiKey (public by design) (#1911)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -30,3 +30,14 @@
 # prefix match. Not a real key.
 877b5911b33153ac3794a8d824ec49d2230006ae:test/plugins/test_map_integration.ts:generic-api-key:93
 877b5911b33153ac3794a8d824ec49d2230006ae:test/plugins/test_map_integration.ts:generic-api-key:109
+
+# src/config/firebaseConfig.ts holds the Firebase Web SDK config for
+# the shared `mulmoserver` project. Firebase's apiKey in a web config
+# is a project identifier, NOT a secret — access is gated by
+# Firestore security rules + Firebase Auth, not by keeping the key
+# hidden. Google explicitly documents this at
+# https://firebase.google.com/docs/projects/api-keys#apikey-restrictions
+# ("Firebase-related APIs do not use API keys for authorization").
+# gitleaks' generic gcp-api-key rule fires on the AIza… prefix, which
+# is unavoidable with this config shape.
+7332183f0e0e6f982fc151350e5a612bc0ed9303:src/config/firebaseConfig.ts:gcp-api-key:11

--- a/plans/fix-1911-gitleaks-firebase-web-config.md
+++ b/plans/fix-1911-gitleaks-firebase-web-config.md
@@ -1,0 +1,44 @@
+# fix #1911: allowlist Firebase Web SDK apiKey in gitleaks
+
+## User prompt (JP)
+
+> gitleakのci、firestoreのは公開okだから別ブランチでPRつくれる？
+
+## Context
+
+`secret-scan` (gitleaks) has been failing on every PR — including `main` after PR #1906 (mermaid) merged — because gitleaks scans the full ref graph via `fetch-depth: 0` and picks up commit `7332183f` on the yet-to-merge branch `feat/remote-host-firestore-list-collections`. That commit adds `src/config/firebaseConfig.ts`, which contains the Firebase Web SDK config for the shared `mulmoserver` project. gitleaks' `gcp-api-key` rule fires on the `AIza…` prefix in `apiKey`.
+
+Firebase Web SDK config is public by design:
+- Google's own docs: https://firebase.google.com/docs/projects/api-keys#apikey-restrictions ("Firebase-related APIs do not use API keys for authorization").
+- Access enforcement lives in Firestore Security Rules + Firebase Auth, not in secrecy of the key.
+- The file header comment already states this.
+
+## Fix
+
+One-line addition to `.gitleaksignore` following the existing fingerprint convention:
+
+```
+7332183f0e0e6f982fc151350e5a612bc0ed9303:src/config/firebaseConfig.ts:gcp-api-key:11
+```
+
+Rationale block above the entry documents:
+- Why Firebase Web SDK apiKey is not a secret (link to Google docs).
+- Why the generic gitleaks rule fires anyway (the `AIza…` prefix match).
+- Reminder that this is targeted — the fingerprint is scoped to that exact commit+file+line, so a NEW copy or a new leak on the same rule still surfaces.
+
+The .gitleaksignore comment does NOT include the literal apiKey value (per the file's own instruction — gitleaks scans the ignore file too).
+
+## Verification
+
+Local run with gitleaks 8.30.1 (same version CI uses):
+
+```
+$ gitleaks detect --source . --redact --exit-code 1
+4029 commits scanned. no leaks found.
+```
+
+## Not in scope
+
+- No change to `src/config/firebaseConfig.ts` itself (still lives on the `feat/remote-host-firestore-list-collections` branch, will merge on its own timeline).
+- No change to the gitleaks workflow — the version pin, SHA verification, and full-history scan mode stay as-is.
+- No global config rework — the existing fingerprint-per-file convention is preserved.


### PR DESCRIPTION
## Summary

`secret-scan` has been failing on every PR — including \`main\` after #1906 (mermaid) merged — because gitleaks with \`fetch-depth: 0\` walks every fetched ref via \`git log --all\` internally, and the unmerged branch \`feat/remote-host-firestore-list-collections\` adds \`src/config/firebaseConfig.ts\` containing the Firebase Web SDK apiKey. The generic \`gcp-api-key\` rule fires on the \`AIza…\` prefix.

Firebase Web SDK apiKey is a **project identifier, not a secret** — Google explicitly documents this at https://firebase.google.com/docs/projects/api-keys#apikey-restrictions ("Firebase-related APIs do not use API keys for authorization"). Access enforcement lives in Firestore Security Rules + Firebase Auth. The file's own header comment already flags this ("Safe to commit").

Closes #1911.

## Items to Confirm / Review

- **Fingerprint is targeted, not blanket.** The one-line addition scopes to \`<commit>:<file>:gcp-api-key:11\`. If a NEW copy of the key lands elsewhere, or the rule id changes on a gitleaks version bump, the entry stops matching and the finding resurfaces — that's the intended behaviour (matches the file's existing "Forward note" comment).
- **The ignore-file rationale does NOT include the literal apiKey.** \`.gitleaksignore\` is also scanned by gitleaks; the comment describes the shape (\"generic \`gcp-api-key\` rule fires on the \`AIza…\` prefix\") without pasting the actual key. Confirming: no new leak surface.
- **No change to \`src/config/firebaseConfig.ts\` itself.** That file still lives on the yet-to-merge branch \`feat/remote-host-firestore-list-collections\` and will land on its own PR timeline. This PR just unblocks secret-scan on \`main\` and every unrelated PR in the meantime.

## User Prompt

> gitleakのci、firestoreのは公開okだから別ブランチでPRつくれる？

## Root cause

- \`.github/workflows/secret-scan.yml\` sets \`fetch-depth: 0\` on \`actions/checkout@v6\`, which fetches ALL branches into the local repo — visible in the CI log as many \`* [new branch] … -> origin/…\` lines and a total of \`4023 commits scanned\`, more than \`main\`'s own history.
- \`gitleaks detect\` walks the full commit graph via \`git log --all\` semantics.
- Therefore an unmerged branch tip whose commit adds a false-positive-shaped file trips the scan on EVERY PR / push to main, even though the file itself is not in \`main\`'s tree.

Verified locally:
\`\`\`
$ git merge-base --is-ancestor 7332183f origin/main; echo \$?
1                                              # not reachable from main
$ git branch --all --contains 7332183f
  remotes/origin/feat/remote-host-firestore-list-collections
$ git ls-tree origin/main -- src/config/firebaseConfig.ts
                                               # empty → not in main's tree
\`\`\`

## Verification

Local run with the CI-pinned gitleaks version (8.30.1):

\`\`\`
$ gitleaks detect --source . --redact --exit-code 1
4029 commits scanned. no leaks found.
\`\`\`

## Test plan

- [ ] Wait for CI. The \`secret-scan\` job on this PR should turn green (previously red on every PR since the Firebase branch was pushed).
- [ ] After merge, watch the next unrelated PR to confirm the noise stopped on \`main\`'s scan too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)