### PR TITLE
feat(remote-host): listCollections handler (phase 1b) + 60s heartbeat & popover auto-close

### DIFF
--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -1,9 +1,7 @@
-// Command-handler table for the remote-host runner.
-//
-// Phase 1a ships an EMPTY table: the connect → heartbeat presence loop is
-// testable without any capability (startHostRunner still heartbeats). Phase 1b
-// adds `listCollections` here (see the plan). Keep this the single place the
-// runner learns which methods it serves.
+// Command-handler table for the remote-host runner — the single place the
+// runner learns which methods it serves. Add a capability by importing its
+// handler and adding it here.
 import type { CommandHandlers } from "../commandChannel.js";
+import { listCollections } from "./listCollections.js";
 
-export const handlers: CommandHandlers = {};
+export const handlers: CommandHandlers = { listCollections };

--- a/server/remoteHost/handlers/listCollections.ts
+++ b/server/remoteHost/handlers/listCollections.ts
@@ -1,0 +1,27 @@
+// listCollections command handler (remote-host phase 1b).
+//
+// Runs in-process on the host, so it bypasses the HTTP view-token layer and
+// calls the collection engine directly, returning the same shape as
+// GET /api/collections: { collections: CollectionSummary[] }.
+//
+// Exposed as a factory (createListCollections) so the mapping is unit-testable
+// with discovery stubbed; the default export wires the real engine functions.
+import { discoverCollections, toSummary } from "../../workspace/collections/index.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface ListCollectionsDeps {
+  discover: typeof discoverCollections;
+  toSummary: typeof toSummary;
+}
+
+export const createListCollections =
+  (deps: ListCollectionsDeps): CommandHandler =>
+  async () => {
+    const collections = (await deps.discover()).map(deps.toSummary);
+    // CollectionSummary is plain JSON (slug/title/icon/source strings), so this
+    // is safe — the cast only satisfies the channel's structural JsonValue type,
+    // which an interface without an index signature can't match directly.
+    return { collections } as unknown as JsonObject;
+  };
+
+export const listCollections = createListCollections({ discover: discoverCollections, toSummary });

--- a/server/remoteHost/handlers/listCollections.ts
+++ b/server/remoteHost/handlers/listCollections.ts
@@ -16,7 +16,9 @@ export interface ListCollectionsDeps {
 
 export const createListCollections =
   (deps: ListCollectionsDeps): CommandHandler =>
-  async () => {
+  // Handlers receive the command's params; listCollections takes none (the
+  // `__` prefix marks it intentionally unused per the lint config).
+  async (__params: JsonObject) => {
     const collections = (await deps.discover()).map(deps.toSummary);
     // CollectionSummary is plain JSON (slug/title/icon/source strings), so this
     // is safe — the cast only satisfies the channel's structural JsonValue type,

--- a/server/remoteHost/hostRunner.ts
+++ b/server/remoteHost/hostRunner.ts
@@ -9,11 +9,11 @@
 import { DocumentReference, onSnapshot, query, runTransaction, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
 
 import { errorMessage } from "../utils/errors.js";
-import { ONE_SECOND_MS } from "../utils/time.js";
+import { ONE_MINUTE_MS } from "../utils/time.js";
 import { Channel, Command, CommandHandler, CommandHandlers, JsonObject, commandsCollection, hostDoc } from "./commandChannel.js";
 import { firestore } from "./firebase.js";
 
-const heartbeatMs = 15 * ONE_SECOND_MS;
+const heartbeatMs = ONE_MINUTE_MS;
 
 export interface HostEvent {
   phase: "received" | "done" | "error";

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -119,6 +119,7 @@ const onConnect = async () => {
       return;
     }
     status.value = res.data.status;
+    open.value = false; // close the popover after a successful login
   } catch (err) {
     error.value = errorMessage(err, t("remoteHost.signInFailed"));
   } finally {
@@ -136,6 +137,7 @@ const onDisconnect = async () => {
       return;
     }
     status.value = res.data.status;
+    open.value = false; // close the popover after a successful logout
   } catch (err) {
     error.value = errorMessage(err, t("remoteHost.disconnectFailed"));
   } finally {

--- a/test/remoteHost/test_handlers.ts
+++ b/test/remoteHost/test_handlers.ts
@@ -1,0 +1,44 @@
+// Unit tests for the remote-host command handlers.
+//   - the registry exposes listCollections
+//   - createListCollections maps discover() -> toSummary() into { collections }
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { handlers } from "../../server/remoteHost/handlers/index.js";
+import { createListCollections, type ListCollectionsDeps } from "../../server/remoteHost/handlers/listCollections.js";
+
+describe("remote-host handler registry", () => {
+  it("exposes listCollections", () => {
+    assert.equal(typeof handlers.listCollections, "function");
+  });
+});
+
+describe("createListCollections", () => {
+  it("maps discovered collections through toSummary into { collections }", async () => {
+    // Stub discovery + summary so the test asserts the wiring, not the engine.
+    const discover = (async () => [{ slug: "alpha" }, { slug: "beta" }]) as unknown as ListCollectionsDeps["discover"];
+    const toSummary = ((col: { slug: string }) => ({
+      slug: col.slug,
+      title: col.slug.toUpperCase(),
+      icon: "folder",
+      source: "preset",
+    })) as unknown as ListCollectionsDeps["toSummary"];
+
+    const handler = createListCollections({ discover, toSummary });
+    const result = await handler({});
+
+    assert.deepEqual(result, {
+      collections: [
+        { slug: "alpha", title: "ALPHA", icon: "folder", source: "preset" },
+        { slug: "beta", title: "BETA", icon: "folder", source: "preset" },
+      ],
+    });
+  });
+
+  it("returns an empty list when discovery finds nothing", async () => {
+    const discover = (async () => []) as unknown as ListCollectionsDeps["discover"];
+    const toSummary = ((col: { slug: string }) => ({ slug: col.slug })) as unknown as ListCollectionsDeps["toSummary"];
+    const handler = createListCollections({ discover, toSummary });
+    assert.deepEqual(await handler({}), { collections: [] });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1b of **remote host over Firestore** (plan: `plans/feat-remote-host-firestore-list-collections.md`), plus two small phase-1a follow-up tweaks requested before 1b.

Phase 1a (merged in #1909) stood up auth + the host command loop + presence heartbeat + the toolbar login UI, with an **empty** handler table. This PR ships the first real capability — `listCollections` — and registers it.

## Changes

**`listCollections` handler (phase 1b)**
- `server/remoteHost/handlers/listCollections.ts` — `createListCollections(deps)` factory returning `{ collections: CollectionSummary[] }`, the **same shape and engine** as `GET /api/collections` (`discoverCollections` + `toSummary` from the `server/workspace/collections` barrel). Runs in-process on the host, so it bypasses the HTTP view-token layer. Default export wires the real engine; the factory keeps the mapping unit-testable.
- `server/remoteHost/handlers/index.ts` — register `listCollections` in the command table (was empty).
- `test/remoteHost/test_handlers.ts` — registry shape + mapping with discovery stubbed (3 tests).

**Phase-1a follow-up tweaks**
- Heartbeat interval 15s → `ONE_MINUTE_MS` (60s).
- Toolbar popover auto-closes after a successful login/logout (error paths stay open to show the message).

## Testing

- `test/remoteHost/*` — 9 tests pass (lifecycle 6 + handlers 3).
- **Verified in-process against the real workspace**: the handler returns the live collection summaries (slug/title/icon/source) — same data as `GET /api/collections`.
- `yarn format` / `lint` (0 errors) / `typecheck` / `build` all green.
- Full remote round-trip (`callHost({ uid, hostId:"mulmoclaude" }, "listCollections")` from a phone / the mulmoserver client) is the manual step; the Firestore transport itself was proven in the phase-1a Step 0 spike.

## Notes

The `{ collections } as unknown as JsonObject` cast is intentional: `CollectionSummary` is plain JSON (string fields) but, lacking an index signature, doesn't structurally satisfy the channel's recursive `JsonValue` type. A comment documents this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for listing collections through the remote host, returning the same collection list format as the standard API.
  * Remote host connection controls now close automatically after successful connect or disconnect actions.

* **Bug Fixes**
  * Improved presence updates to use a consistent one-minute interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->