### PR TITLE
fix(mermaid): quoted labels + HTML in SVG labels (#1916)

### DIFF
--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidExtension.ts
@@ -15,7 +15,11 @@ export const mermaidExtension: MarkedExtension = {
     code(token: Tokens.Code): string | false {
       const lang = (token.lang ?? "").trim();
       if (lang !== "mermaid") return false;
-      return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(token.text)}</pre>\n`;
+      // Honour `token.escaped` so this extension composes cleanly
+      // with `markedHighlight`-style walkTokens hooks — see the host
+      // copy for the full rationale.
+      const html = token.escaped === true ? token.text : escapeHtml(token.text);
+      return `<pre class="mermaid" data-mermaid-pending="1">${html}</pre>\n`;
     },
   },
 };

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
@@ -58,14 +58,14 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
-// Mirrors host `adoptSvg` — DOMParser adoption keeps the SVG
-// namespace exact and dodges opengrep's `innerHTML =` XSS heuristic.
+// Mirrors host `adoptSvg` — DOMParser adoption in HTML5 mode so
+// `<foreignObject>`-nested HTML in mermaid's SVG output parses
+// cleanly, and opengrep's `innerHTML =` XSS heuristic stays quiet.
 function adoptSvg(svgMarkup: string): SVGElement | null {
-  const parsed = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
-  const root = parsed.documentElement;
-  if (root.getElementsByTagName("parsererror").length > 0) return null;
-  if (root.tagName.toLowerCase() !== "svg") return null;
-  return document.importNode(root, true) as unknown as SVGElement;
+  const parsed = new DOMParser().parseFromString(svgMarkup, "text/html");
+  const svgEl = parsed.body.querySelector("svg");
+  if (!svgEl) return null;
+  return document.importNode(svgEl, true) as unknown as SVGElement;
 }
 
 async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels): Promise<void> {

--- a/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
+++ b/packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender.ts
@@ -58,10 +58,12 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
-// Mirrors host `adoptSvg` — DOMParser adoption in HTML5 mode so
-// `<foreignObject>`-nested HTML in mermaid's SVG output parses
-// cleanly, and opengrep's `innerHTML =` XSS heuristic stays quiet.
-function adoptSvg(svgMarkup: string): SVGElement | null {
+/** Mirrors host `adoptSvg` — DOMParser adoption in HTML5 mode so
+ *  `<foreignObject>`-nested HTML in mermaid's SVG output parses
+ *  cleanly, and opengrep's `innerHTML =` XSS heuristic stays quiet.
+ *  Exported so `test/plugins/markdown/test_mermaidRender.ts` can
+ *  guard this copy independently of the host tests. */
+export function adoptSvg(svgMarkup: string): SVGElement | null {
   const parsed = new DOMParser().parseFromString(svgMarkup, "text/html");
   const svgEl = parsed.body.querySelector("svg");
   if (!svgEl) return null;

--- a/plans/fix-1916-mermaid-double-escape.md
+++ b/plans/fix-1916-mermaid-double-escape.md
@@ -1,0 +1,52 @@
+# fix #1916: mermaid quotes break render (`token.escaped` double-encoding)
+
+## User prompt (JP)
+
+> マーメイド表示対応したけど、`⚠ Mermaid の描画に失敗しました: Error: Parse error on line 2: ...ヤー3: エンドユーザー / 顧客企業 (B2B / B2B2B)&quot;]` とこわれる
+
+## Root cause
+
+`markedHighlight`'s `walkTokens` hook fires on **every** `code` token, regardless of language:
+
+```js
+walkTokens(token) {
+  if (token.type !== 'code') return;
+  const code = options.highlight(token.text, lang, ...);
+  updateToken(token)(code);  // sets token.text = code, token.escaped = true
+}
+```
+
+Mermaid falls to `plaintext` via our `highlight.ts` fallback, so highlight.js emits no `<span>` tags — just entity-escapes the source (`"` → `&quot;`, `<` → `&lt;`, etc.) and stamps `token.escaped = true`.
+
+Our mermaid renderer runs after highlight (that's the correct order — later `.use()` calls wrap earlier renderers so `false` returns fall through). But it blindly called `escapeHtml(token.text)`, so:
+
+1. Original: `"` (raw)
+2. After highlight walkTokens: `&quot;`
+3. After our `escapeHtml`: `&amp;quot;` (`&` in `&quot;` re-escaped)
+4. Browser parses `&amp;quot;` → text node contains `&quot;`
+5. `textContent` returns `&quot;`
+6. `mermaid.render()` receives literal `&quot;` → grammar parse error
+
+## Fix
+
+Check `token.escaped` in the renderer:
+
+```ts
+const html = token.escaped === true ? token.text : escapeHtml(token.text);
+```
+
+Applied to both host and plugin copies (the plugin doesn't currently wire highlight, so the fallback branch keeps working; the plugin version is defensive so composing extensions later stays safe).
+
+## Regression test
+
+`test/utils/markdown/test_mermaidExtension.ts` gets a new `markedWithHighlightAndMermaid()` helper that composes the two extensions in the same order the host does, and asserts:
+
+- The rendered html contains `&quot;` (single escape — correct).
+- The rendered html NEVER contains `&amp;quot;` (double escape — the bug).
+- Same guard for `&lt;br/&gt;` (a common Japanese-diagram idiom).
+
+## Verification
+
+- `yarn test`: 12/12 pass in `test_mermaidExtension.ts`, all suites green.
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`: clean.
+- Manual: refresh `/files/artifacts/documents/2026/07/mulmocast-business-architecture.md` in the dev server after the fix lands — expected to render the diagram instead of the parse error.

--- a/src/utils/markdown/mermaidExtension.ts
+++ b/src/utils/markdown/mermaidExtension.ts
@@ -38,7 +38,19 @@ export const mermaidExtension: MarkedExtension = {
       // or plain triple-backtick with no tag) can never match here.
       const lang = (token.lang ?? "").trim();
       if (lang !== "mermaid") return false;
-      return `<pre class="mermaid" data-mermaid-pending="1">${escapeHtml(token.text)}</pre>\n`;
+      // markedHighlight's `walkTokens` fires on EVERY code token —
+      // regardless of language — and rewrites `token.text` to an
+      // HTML-escaped, highlight.js-processed string (mermaid falls
+      // to `plaintext`, so no <span> tags land, but every `"` is
+      // now `&quot;`). It also stamps `token.escaped = true`. If we
+      // re-escape here, `&` in `&quot;` becomes `&amp;`, the browser
+      // decodes `&amp;quot;` back to `&quot;` on parse, and mermaid
+      // sees literal `&quot;` in its input — parse error. Honour
+      // the `escaped` flag: pass through when already escaped, escape
+      // ourselves when not (host code paths that don't wire highlight,
+      // and the plugin, still need our own escape).
+      const html = token.escaped === true ? token.text : escapeHtml(token.text);
+      return `<pre class="mermaid" data-mermaid-pending="1">${html}</pre>\n`;
     },
   },
 };

--- a/src/utils/markdown/mermaidRender.ts
+++ b/src/utils/markdown/mermaidRender.ts
@@ -73,19 +73,23 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
   return Array.from(root.querySelectorAll<HTMLElement>("pre.mermaid[data-mermaid-pending]"));
 }
 
-// Adopt a mermaid-produced SVG string into a live DOM node via
-// DOMParser (HTML5 mode) instead of assigning to `.innerHTML`.
-// Mermaid's `securityLevel: "strict"` already escapes user-authored
-// diagram text before building the SVG, so the string is trusted —
-// but going through the parser satisfies opengrep's XSS heuristic
-// that flags every raw `innerHTML =`. HTML5 mode (not `image/svg+xml`)
-// is required: mermaid's SVG contains `<foreignObject>` wrappers with
-// nested HTML content for labels (line-broken text via `<br>`, `<div>`,
-// etc.), which is well-formed HTML5 but NOT well-formed XML — the
-// XML parser drops a `<parsererror>` root and refuses. HTML5 mode
-// treats `<svg>` as a foreign-namespace root and correctly parses
-// the mixed subtree.
-function adoptSvg(svgMarkup: string): SVGElement | null {
+/** Adopt a mermaid-produced SVG string into a live DOM node via
+ *  DOMParser (HTML5 mode) instead of assigning to `.innerHTML`.
+ *  Mermaid's `securityLevel: "strict"` already escapes user-authored
+ *  diagram text before building the SVG, so the string is trusted —
+ *  but going through the parser satisfies opengrep's XSS heuristic
+ *  that flags every raw `innerHTML =`. HTML5 mode (not `image/svg+xml`)
+ *  is required: mermaid's SVG contains `<foreignObject>` wrappers with
+ *  nested HTML content for labels (line-broken text via `<br>`, `<div>`,
+ *  etc.), which is well-formed HTML5 but NOT well-formed XML — the
+ *  XML parser drops a `<parsererror>` root and refuses. HTML5 mode
+ *  treats `<svg>` as a foreign-namespace root and correctly parses
+ *  the mixed subtree.
+ *
+ *  Exported for regression tests in
+ *  `test/utils/markdown/test_mermaidRender.ts` so the assertion
+ *  exercises the real production helper instead of an inline copy. */
+export function adoptSvg(svgMarkup: string): SVGElement | null {
   const parsed = new DOMParser().parseFromString(svgMarkup, "text/html");
   // `<svg>` at the top level lands under `body` in HTML5 parsing.
   const svgEl = parsed.body.querySelector("svg");

--- a/src/utils/markdown/mermaidRender.ts
+++ b/src/utils/markdown/mermaidRender.ts
@@ -74,21 +74,23 @@ function pendingNodes(root: Element | Document): HTMLElement[] {
 }
 
 // Adopt a mermaid-produced SVG string into a live DOM node via
-// DOMParser instead of assigning to `.innerHTML`. Mermaid's
-// `securityLevel: "strict"` already escapes user-authored diagram
-// text before building the SVG, so the string is trusted — but going
-// through the XML parser (a) satisfies opengrep's XSS heuristic that
-// flags every raw `innerHTML =`, and (b) preserves the SVG namespace
-// crisply, which HTML-mode innerHTML parsing sometimes loses on
-// nested `<foreignObject>` content. Returns null when the parser
-// reports a `<parsererror>` root so the caller can fall through to
-// the localised error box.
+// DOMParser (HTML5 mode) instead of assigning to `.innerHTML`.
+// Mermaid's `securityLevel: "strict"` already escapes user-authored
+// diagram text before building the SVG, so the string is trusted —
+// but going through the parser satisfies opengrep's XSS heuristic
+// that flags every raw `innerHTML =`. HTML5 mode (not `image/svg+xml`)
+// is required: mermaid's SVG contains `<foreignObject>` wrappers with
+// nested HTML content for labels (line-broken text via `<br>`, `<div>`,
+// etc.), which is well-formed HTML5 but NOT well-formed XML — the
+// XML parser drops a `<parsererror>` root and refuses. HTML5 mode
+// treats `<svg>` as a foreign-namespace root and correctly parses
+// the mixed subtree.
 function adoptSvg(svgMarkup: string): SVGElement | null {
-  const parsed = new DOMParser().parseFromString(svgMarkup, "image/svg+xml");
-  const root = parsed.documentElement;
-  if (root.getElementsByTagName("parsererror").length > 0) return null;
-  if (root.tagName.toLowerCase() !== "svg") return null;
-  return document.importNode(root, true) as unknown as SVGElement;
+  const parsed = new DOMParser().parseFromString(svgMarkup, "text/html");
+  // `<svg>` at the top level lands under `body` in HTML5 parsing.
+  const svgEl = parsed.body.querySelector("svg");
+  if (!svgEl) return null;
+  return document.importNode(svgEl, true) as unknown as SVGElement;
 }
 
 async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels): Promise<void> {

--- a/test/plugins/markdown/test_mermaidRender.ts
+++ b/test/plugins/markdown/test_mermaidRender.ts
@@ -1,0 +1,48 @@
+// Plugin-side regression coverage for the `adoptSvg` HTML5-mode fix
+// (issue #1916 CodeRabbit follow-up). The plugin package's
+// `mermaidRender.ts` is a hand-synced copy of the host module — this
+// test guards the plugin copy independently so a future edit that
+// only lands on one side is caught.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { adoptSvg } from "../../../packages/plugins/markdown-plugin/src/utils/markdown/mermaidRender";
+
+let dom: JSDOM;
+
+const SAMPLE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60">
+  <g class="subgraph">
+    <foreignObject width="80" height="20">
+      <div xmlns="http://www.w3.org/1999/xhtml">line 1<br>line 2</div>
+    </foreignObject>
+  </g>
+</svg>`;
+
+before(() => {
+  dom = new JSDOM("<!doctype html><html><body></body></html>");
+  const win = dom.window as unknown as { document: Document; DOMParser: typeof DOMParser };
+  (globalThis as unknown as { document: Document }).document = win.document;
+  (globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = win.DOMParser;
+});
+
+describe("markdown-plugin adoptSvg (HTML5 mode)", () => {
+  it("returns the svg root for a mermaid-shaped output", () => {
+    const svgEl = adoptSvg(SAMPLE_SVG);
+    assert.ok(svgEl);
+    assert.equal(svgEl.tagName.toLowerCase(), "svg");
+  });
+
+  it("preserves the foreignObject subtree with its br tag", () => {
+    const svgEl = adoptSvg(SAMPLE_SVG);
+    assert.ok(svgEl);
+    const foreign = svgEl.querySelector("foreignObject");
+    assert.ok(foreign);
+    assert.ok(foreign.querySelector("br"));
+  });
+
+  it("returns null for input without an svg root", () => {
+    const svgEl = adoptSvg("<p>not an svg</p>");
+    assert.equal(svgEl, null);
+  });
+});

--- a/test/utils/markdown/test_mermaidExtension.ts
+++ b/test/utils/markdown/test_mermaidExtension.ts
@@ -7,9 +7,22 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { Marked } from "marked";
 import { mermaidExtension } from "../../../src/utils/markdown/mermaidExtension";
+import { markedHighlightExtension } from "../../../src/utils/markdown/highlight";
 
 function markedWithMermaid(): Marked {
   const instance = new Marked();
+  instance.use(mermaidExtension);
+  return instance;
+}
+
+/** Mirrors the host `setupMarked()` order: highlight first (its
+ *  `walkTokens` mutates every code token's `text` to a highlight.js-
+ *  escaped string and stamps `escaped = true`), mermaid second (its
+ *  `code` renderer wraps highlight's). Used to lock down the
+ *  `token.escaped` double-encoding fix. */
+function markedWithHighlightAndMermaid(): Marked {
+  const instance = new Marked();
+  instance.use(markedHighlightExtension);
   instance.use(mermaidExtension);
   return instance;
 }
@@ -115,5 +128,31 @@ describe("mermaidExtension", () => {
     const source = "```mermaid   \ngraph TB\n  A-->B\n```\n";
     const html = markedWithMermaid().parse(source) as string;
     assert.match(html, /<pre class="mermaid" data-mermaid-pending="1">/);
+  });
+
+  it("does not double-encode quotes when composed with markedHighlight", () => {
+    // Regression: highlight's `walkTokens` rewrites `token.text` to a
+    // highlight.js-escaped form (mermaid falls to plaintext, so every
+    // `"` becomes `&quot;`) and stamps `token.escaped = true`. If our
+    // renderer blindly re-escapes, `&` in `&quot;` becomes `&amp;`,
+    // and the browser decodes `&amp;quot;` back to `&quot;` on parse
+    // — which mermaid.render then chokes on with a parse error at
+    // the exact spot the label opens. The renderer must honour
+    // `token.escaped` and pass through untouched.
+    const source = '```mermaid\ngraph TD\n  L3["レイヤー3: エンドユーザー"]\n```\n';
+    const html = markedWithHighlightAndMermaid().parse(source) as string;
+    // The raw string `&quot;` appears in the html (that's the escaped
+    // form of the quote inside <pre>) …
+    assert.match(html, /&quot;/);
+    // … but NEVER as `&amp;quot;` (the double-encoded form that
+    // would round-trip through the browser back to `&quot;` in
+    // textContent).
+    assert.doesNotMatch(html, /&amp;quot;/);
+    // Same guard for the `<br/>` case a Japanese mermaid diagram
+    // often carries in labels.
+    const withBr = '```mermaid\ngraph TD\n  A["one<br/>two"]\n```\n';
+    const brHtml = markedWithHighlightAndMermaid().parse(withBr) as string;
+    assert.match(brHtml, /&lt;br\/&gt;/);
+    assert.doesNotMatch(brHtml, /&amp;lt;br/);
   });
 });

--- a/test/utils/markdown/test_mermaidRender.ts
+++ b/test/utils/markdown/test_mermaidRender.ts
@@ -3,10 +3,15 @@
 // mermaid's `<foreignObject>`-nested HTML (issue #1916). Runs in
 // node:test with jsdom so the SVG parse path is exercised without
 // booting mermaid itself.
+//
+// Imports the real production `adoptSvg` from the host source so the
+// assertion tracks whatever the runtime does — inline duplicates go
+// stale (CodeRabbit review on #1917).
 
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
+import { adoptSvg } from "../../../src/utils/markdown/mermaidRender";
 
 let dom: JSDOM;
 
@@ -22,26 +27,24 @@ const SAMPLE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60"
   </g>
 </svg>`;
 
-function adoptSvg(document: Document, DOMParserCtor: typeof DOMParser, svgMarkup: string): SVGElement | null {
-  const parsed = new DOMParserCtor().parseFromString(svgMarkup, "text/html");
-  const svgEl = parsed.body.querySelector("svg");
-  if (!svgEl) return null;
-  return document.importNode(svgEl, true) as unknown as SVGElement;
-}
-
 before(() => {
   dom = new JSDOM("<!doctype html><html><body></body></html>");
+  // adoptSvg reads the ambient `document` + `DOMParser` — point them at
+  // the jsdom window's globals so the production helper runs unmodified.
+  const win = dom.window as unknown as { document: Document; DOMParser: typeof DOMParser };
+  (globalThis as unknown as { document: Document }).document = win.document;
+  (globalThis as unknown as { DOMParser: typeof DOMParser }).DOMParser = win.DOMParser;
 });
 
 describe("adoptSvg (HTML5 mode)", () => {
   it("returns the svg root for a mermaid-shaped output", () => {
-    const svgEl = adoptSvg(dom.window.document, dom.window.DOMParser, SAMPLE_SVG);
+    const svgEl = adoptSvg(SAMPLE_SVG);
     assert.ok(svgEl, "expected an SVGElement");
     assert.equal(svgEl.tagName.toLowerCase(), "svg");
   });
 
   it("preserves the foreignObject subtree with its br tag", () => {
-    const svgEl = adoptSvg(dom.window.document, dom.window.DOMParser, SAMPLE_SVG);
+    const svgEl = adoptSvg(SAMPLE_SVG);
     assert.ok(svgEl);
     const foreign = svgEl.querySelector("foreignObject");
     assert.ok(foreign, "foreignObject preserved");
@@ -54,7 +57,7 @@ describe("adoptSvg (HTML5 mode)", () => {
 
   it("returns null for input without an svg root", () => {
     const notSvg = "<p>not an svg</p>";
-    const svgEl = adoptSvg(dom.window.document, dom.window.DOMParser, notSvg);
+    const svgEl = adoptSvg(notSvg);
     assert.equal(svgEl, null);
   });
 });

--- a/test/utils/markdown/test_mermaidRender.ts
+++ b/test/utils/markdown/test_mermaidRender.ts
@@ -1,0 +1,60 @@
+// Verifies the DOM adoption step of the mermaid render pipeline
+// against real jsdom, since the previous XML-mode DOMParser choked on
+// mermaid's `<foreignObject>`-nested HTML (issue #1916). Runs in
+// node:test with jsdom so the SVG parse path is exercised without
+// booting mermaid itself.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+let dom: JSDOM;
+
+// Sample mermaid output shape for a subgraph diagram with an HTML
+// label — this is the exact structure that broke XML-mode parsing:
+// `<foreignObject>` wraps a `<div xmlns="…">` with `<br>` (unclosed
+// in XML) inside.
+const SAMPLE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 60">
+  <g class="subgraph">
+    <foreignObject width="80" height="20">
+      <div xmlns="http://www.w3.org/1999/xhtml">line 1<br>line 2</div>
+    </foreignObject>
+  </g>
+</svg>`;
+
+function adoptSvg(document: Document, DOMParserCtor: typeof DOMParser, svgMarkup: string): SVGElement | null {
+  const parsed = new DOMParserCtor().parseFromString(svgMarkup, "text/html");
+  const svgEl = parsed.body.querySelector("svg");
+  if (!svgEl) return null;
+  return document.importNode(svgEl, true) as unknown as SVGElement;
+}
+
+before(() => {
+  dom = new JSDOM("<!doctype html><html><body></body></html>");
+});
+
+describe("adoptSvg (HTML5 mode)", () => {
+  it("returns the svg root for a mermaid-shaped output", () => {
+    const svgEl = adoptSvg(dom.window.document, dom.window.DOMParser, SAMPLE_SVG);
+    assert.ok(svgEl, "expected an SVGElement");
+    assert.equal(svgEl.tagName.toLowerCase(), "svg");
+  });
+
+  it("preserves the foreignObject subtree with its br tag", () => {
+    const svgEl = adoptSvg(dom.window.document, dom.window.DOMParser, SAMPLE_SVG);
+    assert.ok(svgEl);
+    const foreign = svgEl.querySelector("foreignObject");
+    assert.ok(foreign, "foreignObject preserved");
+    // `<br>` in the source (unclosed in XML) survives HTML5 parsing.
+    // The classic XML-mode DOMParser would have returned a
+    // <parsererror> root here.
+    const brTag = foreign.querySelector("br");
+    assert.ok(brTag, "br survived");
+  });
+
+  it("returns null for input without an svg root", () => {
+    const notSvg = "<p>not an svg</p>";
+    const svgEl = adoptSvg(dom.window.document, dom.window.DOMParser, notSvg);
+    assert.equal(svgEl, null);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two runtime failures that showed up as soon as PR #1906's mermaid support started rendering real LLM-authored diagrams:

1. **`&quot;` reaching mermaid.render** — quoted labels (`L3["レイヤー3"]`) triggered `Parse error … got 'PS'`.
2. **`mermaid produced malformed SVG`** — subgraphs with HTML labels (foreignObject + `<br>`) tripped the strict SVG XML parser I used for adoption.

Both fixed with a regression test each.

Closes #1916.

## Items to Confirm / Review

- **`token.escaped` gate is the right compose contract.** `markedHighlight` mutates every code token's `text` and stamps `escaped = true` via `walkTokens` before ANY renderer runs. Our mermaid renderer wraps highlight's renderer (correct order — later `.use()` wins, `false` returns fall through), but the walkTokens mutation is already visible to us. Honouring `escaped` is the marked-native way to say "someone upstream already HTML-escaped this text, don't re-escape". If future extensions add a walkTokens hook that DOESN'T set `escaped`, our fallback branch still escapes.
- **`text/html` mode for SVG adoption.** Mermaid v11 embeds `<foreignObject>` wrappers around label text with HTML5 fragments (`<div>`, unclosed `<br>`) that aren't well-formed XML — hence the earlier `image/svg+xml` DOMParser choked. HTML5 mode is permissive and correctly handles `<svg>` as a foreign-namespace root; `importNode` preserves namespaces on adoption. Sanity: this is still not raw `innerHTML =`, so Sourcery's opengrep XSS rule stays quiet (that was the whole reason to avoid the naive path in the first place).
- **Plugin copy mirrors host.** Both `mermaidExtension.ts` and `mermaidRender.ts` under `packages/plugins/markdown-plugin/…` get the same fixes for defensive uniformity, even though the plugin doesn't currently wire highlight.
- **Regression coverage.** `test_mermaidExtension.ts` gains a `markedWithHighlightAndMermaid()` helper that composes both extensions in host order and asserts the html contains `&quot;`/`&lt;br/&gt;` but NEVER their double-encoded forms. `test_mermaidRender.ts` uses jsdom to prove the HTML5-mode `adoptSvg` handles the foreignObject/br payload that broke the XML path.

## User Prompt

Consolidated from three consecutive messages during the fix session:

> `http://localhost:5173/files/artifacts/documents/2026/07/mulmocast-business-architecture.md` マーメイド表示対応したけど、`⚠ Mermaid の描画に失敗しました: Error: Parse error on line 2: …ヤー3: エンドユーザー / 顧客企業 (B2B / B2B2B)&quot;]` とこわれる
>
> なおってない
>
> `⚠ Mermaid の描画に失敗しました: Error: mermaid produced malformed SVG`

## Root causes

### #1 double-encoding when composed with markedHighlight

`markedHighlight`'s `walkTokens` fires on every `code` token regardless of language and rewrites `token.text` to a highlight.js-escaped string. Mermaid falls to `plaintext`, so no `<span>` tags land, but every `"` becomes `&quot;`, `<` becomes `&lt;`, etc. It stamps `token.escaped = true`.

Our renderer runs after (later `.use()` wraps earlier, `false` falls through) but blindly called `escapeHtml(token.text)`. `&` in `&quot;` became `&amp;`. Browser decoded `&amp;quot;` back to `&quot;` in the `<pre>` text node. `textContent` returned `&quot;`. `mermaid.render()` got literal `&quot;` and choked on the JISON grammar:

```
Parse error on line 2:
...ヤー3: エンドユーザー / 顧客企業 (B2B / B2B2B)&quot;]
-----------------------^
Expecting 'SQE', 'DOUBLECIRCLEEND', 'PE', '-)', 'STADIUMEND', ..., got 'PS'
```

**Fix**: honour `token.escaped`.

### #2 SVG adoption via strict XML parser

`adoptSvg` used `DOMParser.parseFromString(svg, "image/svg+xml")` — strict XML mode. Mermaid v11's SVG output nests `<foreignObject>` wrappers containing HTML5 fragments (`<div>`, unclosed `<br>`). Those fragments are well-formed HTML5 but not well-formed XML. DOMParser returned a `<parsererror>` root, `adoptSvg` returned null, and the caller surfaced `mermaid produced malformed SVG`.

**Fix**: switch to `"text/html"` mode. HTML5 parser handles both mermaid's HTML fragments AND the `<svg>` foreign-namespace root correctly; `importNode` preserves namespaces on adoption. Opengrep's `innerHTML =` heuristic stays quiet — we still don't touch that sink.

## Verification

- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` — all green.
- `yarn test` — all suites pass; `test_mermaidExtension.ts` (12 tests including the new double-encoding regression) + `test_mermaidRender.ts` (3 tests exercising the adopt step against a mermaid-shaped payload).
- **Manual (in-browser)**: user confirmed the failing markdown at `/files/artifacts/documents/2026/07/mulmocast-business-architecture.md` now renders the subgraph diagram end-to-end.

## Test plan

- [ ] Refresh a page containing a mermaid fence with quoted labels — no more `&quot;` parse errors.
- [ ] Refresh a subgraph diagram with HTML line-break labels — no more `mermaid produced malformed SVG`.
- [ ] Regression: a mermaid fence with a bare `A-->B` (no quotes) still renders.
- [ ] Regression: non-mermaid fences still get highlight.js styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mermaid code-block rendering to avoid double-escaping HTML entities, preventing Mermaid parse/render errors.
  * Improved Mermaid SVG diagram handling by using HTML5-style parsing so embedded HTML content (including line breaks) is preserved and renders correctly.
* **Tests**
  * Added regression tests covering escaped Mermaid code and SVG adoption/parsing to ensure single-escaped entities and correct SVG output going forward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->