### PR TITLE
feat(remote-host): phase-2 host — getCollection, getFeed, listShortcuts, listFeeds

### DIFF
--- a/plans/feat-remote-collection-view.md
+++ b/plans/feat-remote-collection-view.md
@@ -1,0 +1,304 @@
+# feat: Remote collection view — phase 2: view one collection on mobile
+
+## Goal
+
+Let the **mobile remote** (the `mulmoserver` app) open a single collection and
+browse its records, **optimized for a phone**. Builds directly on phase 1
+(`listCollections`, shipped): the remote already lists the host's collections
+with icon/title/slug and auto-fetches on connect. Phase 2 makes each list row
+tappable → a mobile-first detail page that renders the collection's records.
+
+**Phase 2 scope:** **read-only**, **paginated**, **field-schema-driven** card
+list → tap a record → record detail. **No** calendar/kanban/dashboard/custom-HTML
+views, **no** images, **no** editing. Those are later phases (the host API
+already supports them, so they're clean extensions).
+
+Phase 2 also exposes the user's **pinned shortcuts (favorites)** — the same
+`config/shortcuts.json` list the desktop launcher shows — so the remote can offer
+quick access to starred collections/feeds. Read-only: a new `listShortcuts`
+handler mirrors `GET /api/shortcuts`; editing the pin list stays desktop-only.
+
+And it exposes **feeds** the same way as collections. A feed *is* a
+`LoadedCollection` with an `ingest` block, so its records read through the exact
+same `listItems(dataDir)` path: `listFeeds` mirrors `GET /api/feeds` (the feed
+registry with kind/schedule/last-fetch), and `getFeed` returns one feed's detail
++ a page of records — identical result shape to `getCollection`, so the remote
+reuses the same card renderer. Read-only; refresh/retrieval stays desktop-only.
+
+## Background / what already exists
+
+- **Channel**: proven command channel over Firestore — `callHost(channel,
+  method, params)` on the remote, `startHostRunner(channel, handlers)` on the
+  host, one document per call under `users/{uid}/hosts/mulmoclaude/commands`.
+  Phase 1 added the `mulmoclaude` host + `listCollections` handler.
+- **Host already has the desktop API** this phase mirrors:
+  `GET /api/collections/:slug → { collection: CollectionDetail, items:
+  CollectionItem[] }` (see `server/api/routes/collections.ts`). We reuse the same
+  in-process helpers it calls, bypassing the HTTP/view-token layer:
+  - `loadCollection(slug): Promise<LoadedCollection | null>` — `null` ⇒ not found.
+    Carries `.dataDir`, `.schema` (`primaryKey`, `displayField?`, `fields:
+    Record<string, CollectionFieldSpec>`), and `toSummary(collection)` →
+    `CollectionSummary`.
+  - `listItems(dataDir): Promise<CollectionItem[]>` — `CollectionItem =
+    Record<string, unknown>`.
+  Both exported from `server/workspace/collections/index.ts`.
+- **Host already has the shortcuts API** this phase mirrors: `GET /api/shortcuts
+  → { shortcuts: Shortcut[] }` (`server/api/routes/shortcuts.ts`), backed by
+  `readShortcuts(): Promise<Shortcut[]>` (`server/utils/files/shortcuts-io.ts`).
+  `Shortcut = { kind: "collection" | "feed", slug, title, icon }` is browser-safe
+  plain JSON (`src/types/shortcuts.ts`).
+- **Host already has the feeds API** this phase mirrors: `GET /api/feeds →
+  { feeds: FeedSummary[] }` (`server/api/routes/feeds.ts`), backed by
+  `listFeeds(workspaceRoot): Promise<LoadedCollection[]>` + `readFeedState(...)`
+  (`@mulmoclaude/core/feeds/server`). A feed is a `LoadedCollection` with an
+  `ingest` block, so its records read via the same `listItems(feed.dataDir)`.
+- **Remote already has** `useCollections` + the Collections page
+  (`../mulmoserver/src/composables/useCollections.ts`,
+  `src/views/Collections.vue`). This phase adds a sibling `useCollection(slug)`
+  and a `/collections/:slug` route.
+
+## The three decisions that shape this
+
+### 1. The 1 MB Firestore document limit (the important one)
+The command channel writes the **result inside the command document**, and
+Firestore caps a document at 1 MiB. A collection with many/large records will
+exceed that. So the host handler **must paginate**:
+
+- Params: `{ slug: string, offset?: number, limit?: number }` (default limit
+  e.g. 50).
+- Result: `{ collection: CollectionDetail, items: CollectionItem[], total:
+  number, offset: number, limit: number }`.
+- The remote fetches a page at a time; the detail page appends on scroll
+  ("Load more") and shows `items.length / total`.
+
+Optional refinement if single records are still large: a **projected** list
+payload (only the fields the card shows) + a separate `getRecord(slug, id)` for
+the full record on tap. Start without projection; add it only if a real
+collection blows the budget.
+
+### 2. Images / media — out of scope in phase 2
+`image` fields point at bytes on the host's `localhost`; a phone can't fetch
+those URLs. Options for later: inline small thumbnails as data-URLs (eats the
+1 MB budget) or stand up an image relay. **Phase 2 renders image fields as a
+placeholder chip, not the image.**
+
+### 3. Renderer scope — mobile-first, field-schema-driven, read-only
+Do **not** reproduce the desktop's calendar/kanban/dashboard or sandboxed
+custom-HTML views. Walk `schema.fields` and render a **card per record**:
+
+- **Card title** = `record[schema.displayField]` when set and non-empty, else
+  `record[schema.primaryKey]`.
+- **Card body** = a few scalar fields as label/value rows.
+- Render these field types natively; **skip or summarize** the rest in phase 2:
+  - `text`, `number`, `date`, `money` → formatted value.
+  - `enum` → a colored badge.
+  - `ref` → the stored slug as plain text (no navigation yet).
+  - `table` → "N rows" summary chip.
+  - `embed`, `image`, `derived` → skip in the card (show on the record detail as
+    a placeholder / best-effort).
+- **Tap a card** → a record detail panel listing every scalar field label/value.
+- Respect each field's `when` visibility predicate if cheap; otherwise defer.
+
+## Reusable collection-view component (the template for LLM custom views)
+
+**Design constraint (decided):** the collection view must be built as a
+**reusable component that accesses item collections through a stable contract**,
+*not* as a page that reaches into the channel inline. The default card renderer
+shipped in phase 2 becomes the **reference template** for a later phase where an
+**LLM generates a bespoke "custom mobile view" per collection** from the user's
+request (the mobile-native analogue of the desktop's sandboxed custom-HTML
+`views`). So the seam has to exist from day one — build the default view *as if*
+it were one of many interchangeable views.
+
+Two layers, split cleanly:
+
+1. **Data access — `useCollection(uid, hostId, slug)` (channel-aware, reusable).**
+   The *only* thing that knows about `callHost`/Firestore. Exposes a plain,
+   view-agnostic surface: `{ collection, schema, items, total, pending, error,
+   load(), loadMore() }`. Every view — the default one and any future
+   LLM-generated one — consumes exactly this; none of them import the channel.
+
+2. **Presentation — a `CollectionView`-shaped component over a documented prop
+   contract.** The default `CollectionCardList.vue` is the reference
+   implementation. Its inputs are the whole contract:
+
+   ```ts
+   // The view contract every mobile collection view implements.
+   interface CollectionViewProps {
+     schema: CollectionSchema;      // field specs, primaryKey, displayField
+     items: CollectionItem[];       // the current page of records (read-only)
+     total: number;                 // full count, for "Load more" / progress
+     pending: boolean;
+   }
+   // emits: (e: "load-more") — the page owns pagination; the view just asks.
+   ```
+
+   A custom view is a drop-in component satisfying the same props/emit — the page
+   swaps which component it renders, nothing else changes.
+
+3. **Shared, view-usable helpers.** Keep the pure `collectionSchema.ts` helpers
+   (`recordTitle`, `visibleScalarFields`, `formatFieldValue`, `enumBadgeClass`)
+   dependency-free so *any* view — including generated ones — can reuse title and
+   per-type formatting logic instead of re-deriving it. These plus the prop
+   contract are the surface an LLM targets.
+
+The page (`Collection.vue`) wires it together: `useCollection(slug)` → chooses a
+view (phase 2: always `CollectionCardList`; later: the collection's custom view
+when present, else the default) → renders it and handles `load-more`. Keep the
+default view free of collection-specific assumptions so it stays a faithful
+template.
+
+## Host side (MulmoClaude — the other terminal)
+
+`server/remoteHost/handlers/getCollection.ts` — reuse `toDetail(collection)` (the
+exact helper `GET /api/collections/:slug` uses; it *is* `{ ...toSummary, schema }`)
+rather than rebuilding the shape, and follow the `createListCollections(deps)`
+factory pattern so the mapping is unit-testable with the engine stubbed:
+
+```ts
+import { loadCollection, listItems, toDetail } from "../../workspace/collections/index.js";
+// params arrive as JSON over the channel — coerce defensively:
+//   slug -> String; offset -> non-negative int (default 0);
+//   limit -> int clamped to [1, MAX_LIMIT] (default 50) so a runaway page
+//   can't blow the 1 MB Firestore result-document budget.
+export const getCollection = async ({ slug, offset, limit }) => {
+  const collection = await loadCollection(String(slug));
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const all = await listItems(collection.dataDir);
+  const off = clampOffset(offset), lim = clampLimit(limit);
+  return { collection: toDetail(collection), items: all.slice(off, off + lim), total: all.length, offset: off, limit: lim };
+};
+```
+
+`server/remoteHost/handlers/listShortcuts.ts` — the favorites list, mirroring
+`GET /api/shortcuts`:
+
+```ts
+import { readShortcuts } from "../../utils/files/shortcuts-io.js";
+export const listShortcuts = async () => ({ shortcuts: await readShortcuts() });
+```
+
+`server/remoteHost/handlers/listFeeds.ts` + `getFeed.ts` — the feed registry and
+one feed's records, mirroring `GET /api/feeds` and reusing the collection page
+builder (a feed is a `LoadedCollection`):
+
+```ts
+import { listFeeds, readFeedState } from "@mulmoclaude/core/feeds/server";
+import { workspacePath } from "../../workspace/workspace.js";
+// listFeeds -> { feeds: FeedSummary[] } (slug/title/icon/kind/schedule/lastFetchedAt)
+// getFeed({ slug, offset, limit }) -> find the feed by slug, then the SAME
+//   { collection: toDetail(feed), items, total, offset, limit } shape as getCollection.
+```
+
+Shared pagination lives in `server/remoteHost/handlers/collectionPage.ts`
+(`clampOffset` / `clampLimit` / `pageResult`) so `getCollection` and `getFeed`
+don't duplicate the 1 MB-budget clamping and slicing.
+
+Register all of them in `server/remoteHost/handlers/index.ts` alongside
+`listCollections` (the single place the runner learns its methods). `getCollection`
+/ `getFeed` mirror the not-found behavior (throw → the runner writes an error
+result). All return values are plain JSON but their interfaces lack an index
+signature, so cast to the channel's `JsonObject` like `listCollections`.
+
+## Remote side (mulmoserver)
+
+- **Data hook (shared by collections *and* feeds)** —
+  `src/composables/useCollection.ts` — `useCollection(uid, hostId, slug,
+  method = "getCollection")`: the only channel-aware piece. Calls
+  `callHost(channel, method, { slug, offset, limit })`; exposes the view-agnostic
+  surface `{ collection, schema, items, total, pending, error, load(),
+  loadMore() }`. Because `getFeed` returns the **identical** `{ collection,
+  items, total, offset, limit }` shape, a feed detail page reuses this hook by
+  passing `method: "getFeed"` — **no duplicate hook, no second renderer**. (A
+  one-line `useFeed = (uid, hostId, slug) => useCollection(uid, hostId, slug,
+  "getFeed")` alias is fine if it reads better at call sites.) Mirrors
+  `useCollections`.
+- **Shared helpers** — `src/firestore/collectionSchema.ts` — **firebase-free**
+  pure helpers (so they unit-test under `tsx --test`, like `commandFormat.ts`,
+  and so any view — default or generated — can reuse them): `recordTitle(schema,
+  record)`, `visibleScalarFields(schema)`, `formatFieldValue(spec, value)`,
+  `enumBadgeClass(value)`. `import type` only.
+- **Reusable view (the template)** — `src/components/collection/CollectionCardList.vue`
+  — presentational only, over the `CollectionViewProps` contract
+  (`schema`/`items`/`total`/`pending`, emits `load-more`). Renders the card list,
+  record detail on tap, and the "Load more" affordance. Imports **no** channel
+  code — this is what a future LLM-generated custom view is modeled on. **Feeds
+  render through this same component** (a feed is a `LoadedCollection`).
+- **Collection page** — `src/views/Collection.vue` — wires it together: header
+  (title + the same connection status icon) + `useCollection(slug)` → renders the
+  chosen view component (phase 2: always `CollectionCardList`) and handles
+  `load-more`, loading / empty / error states.
+- **Feed page** — `src/views/Feed.vue` — the same shape as `Collection.vue` but
+  calls `useCollection(slug, "getFeed")` and renders the same
+  `CollectionCardList`. Thin wrapper; exists mainly to give feeds their own route
+  and (later) surface feed-registry metadata (kind/schedule/last-fetch) in the
+  header.
+- **Feeds list** — `src/composables/useFeeds.ts` (calls `listFeeds`) + a
+  `src/views/Feeds.vue` list page, mirroring `useCollections` + `Collections.vue`
+  (rows → `/feeds/:slug`). Add a `feeds` toolbar entry (e.g. `rss_feed` icon) next
+  to `collections`.
+- **Shortcuts launcher** — `src/composables/useShortcuts.ts` (calls
+  `listShortcuts`) + a launcher surface (a section on the home/Collections page,
+  or its own small `Shortcuts.vue`) rendering each pinned `Shortcut`
+  (`{ kind, slug, title, icon }`) as a tappable row. The `kind` discriminant
+  routes: `collection` → `/collections/:slug`, `feed` → `/feeds/:slug`. This is a
+  navigation list, **not** a card renderer — no `CollectionCardList` here.
+- Routes: add `collections/:slug`, `feeds/:slug`, and `feeds` to `routeChildren`
+  in `src/router/index.ts` (all work under `/en` and `/ja`). Make each row in
+  `Collections.vue` / `Feeds.vue` a `router-link` to the localized detail path.
+
+## Steps
+
+0. Host: add `getCollection`, `listShortcuts`, `listFeeds`, `getFeed` handlers +
+   register them; unit-test the mapping (engine/IO stubbed) and smoke-test from
+   the remote client (`callHost(channel, "getCollection", { slug })`,
+   `listShortcuts`, `listFeeds`, `getFeed`).
+1. Remote: `collectionSchema.ts` pure helpers + unit tests (`recordTitle`,
+   `formatFieldValue`, `visibleScalarFields`).
+2. Remote: `useCollection` data hook (paginated `load` / `loadMore`,
+   `method`-parameterized so feeds reuse it).
+3. Remote: `CollectionCardList.vue` reusable view over the `CollectionViewProps`
+   contract (no channel imports); then `Collection.vue` page wires
+   `useCollection` → the view + `load-more`; wire the `collections/:slug` route;
+   make `Collections.vue` rows navigate.
+4. Remote (feeds + shortcuts, reusing step 2/3): `useFeeds` + `Feeds.vue` list
+   and `Feed.vue` detail (via `useCollection(slug, "getFeed")` →
+   `CollectionCardList`) with `feeds` / `feeds/:slug` routes and a toolbar entry;
+   `useShortcuts` + the launcher list routing by `kind`.
+5. Manual end-to-end: connect the host → open a collection **and** a feed on a
+   phone → records render through the same card view, "Load more" pages through a
+   large one; the shortcuts launcher routes to both.
+
+## Out of scope (later phases)
+
+- **LLM-generated custom mobile views.** Phase 2 establishes the seam — the data
+  hook, the `CollectionViewProps` contract, and the default view as its reference
+  implementation — but does **not** build the generation/selection mechanism
+  (host stores a per-collection custom view; the page picks it when present).
+  That is the next phase, and it should require *no* change to the data hook.
+- Editing (create/update/delete items — the host API already supports it).
+- Images/media, `embed` resolution, `ref` navigation between collections.
+- Calendar / kanban / dashboard / desktop custom-HTML views.
+- Live updates (re-fetch on open / manual refresh is enough for now).
+
+## Test plan (`tsx --test`, both repos)
+
+- **Remote pure-logic**: `recordTitle` (displayField → primaryKey fallback),
+  `formatFieldValue` per type (date/number/money/enum), `visibleScalarFields`
+  (skips table/embed/image/derived). No Firebase at import time.
+- **Remote contract/source-text**: `useCollection` calls `callHost` with a
+  `method` param (default `"getCollection"`) plus `slug`/`offset`/`limit`, so
+  `Feed.vue` reuses it with `"getFeed"`; `CollectionCardList.vue` imports **no**
+  channel/Firestore code (it's a pure view over props) and emits `load-more`
+  gated on `items.length < total`; `Collection.vue` and `Feed.vue` both render
+  that same view and own pagination; the `collections/:slug`, `feeds`, and
+  `feeds/:slug` routes are registered; `Collections.vue` / `Feeds.vue` rows link
+  to their detail paths; the shortcuts launcher routes by `kind` (`collection` →
+  `/collections/:slug`, `feed` → `/feeds/:slug`).
+- **Host**: `getCollection`, `listShortcuts`, `listFeeds`, `getFeed` registered;
+  `getCollection`/`getFeed` return `{ collection, items, total, offset, limit }`,
+  not-found throws, pagination slices by `offset`/`limit` and clamps a runaway
+  `limit` (`loadCollection`/`listFeeds`/`listItems`/`toDetail` stubbed);
+  `listShortcuts` returns `{ shortcuts }` (`readShortcuts` stubbed); `listFeeds`
+  returns `{ feeds }` (`listFeeds`/`readFeedState` stubbed).
+```

--- a/server/remoteHost/handlers/collectionPage.ts
+++ b/server/remoteHost/handlers/collectionPage.ts
@@ -1,0 +1,29 @@
+// Shared pagination for the collection/feed record handlers.
+//
+// The command channel writes the result INSIDE the command document, and
+// Firestore caps a document at 1 MiB. offset/limit slice the records; limit is
+// clamped to [1, MAX_LIMIT] (default 50) so a runaway page can't blow that
+// budget. Params arrive as JSON over the channel, so coerce defensively.
+import type { JsonObject, JsonValue } from "../commandChannel.js";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+const toInt = (value: JsonValue): number | null => {
+  const num = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(num) ? Math.floor(num) : null;
+};
+
+export const clampOffset = (value: JsonValue): number => Math.max(0, toInt(value) ?? 0);
+
+export const clampLimit = (value: JsonValue): number => {
+  const num = toInt(value);
+  if (num === null || num <= 0) return DEFAULT_LIMIT;
+  return Math.min(num, MAX_LIMIT);
+};
+
+// Build the paginated result. `detail` (a CollectionDetail) and `items`
+// (CollectionItem[]) are plain JSON, but their interfaces lack an index
+// signature so they don't structurally match JsonValue — the cast is safe.
+export const pageResult = (detail: unknown, items: unknown[], offset: number, limit: number): JsonObject =>
+  ({ collection: detail, items: items.slice(offset, offset + limit), total: items.length, offset, limit }) as unknown as JsonObject;

--- a/server/remoteHost/handlers/getCollection.ts
+++ b/server/remoteHost/handlers/getCollection.ts
@@ -1,0 +1,32 @@
+// getCollection command handler (remote-host phase 2).
+//
+// Returns one collection's detail + a PAGE of its records, mirroring
+// GET /api/collections/:slug (loadCollection + listItems + toDetail), running
+// in-process on the host (bypasses the HTTP view-token layer). Pagination is
+// mandatory — see collectionPage.ts for the 1 MiB Firestore-document rationale.
+//
+// Factory (createGetCollection) keeps the mapping unit-testable with the engine
+// stubbed; the default export wires the real engine functions.
+import { listItems, loadCollection, toDetail } from "../../workspace/collections/index.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+import { clampLimit, clampOffset, pageResult } from "./collectionPage.js";
+
+export interface GetCollectionDeps {
+  loadCollection: typeof loadCollection;
+  listItems: typeof listItems;
+  toDetail: typeof toDetail;
+}
+
+export const createGetCollection =
+  (deps: GetCollectionDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    const slug = String(params.slug ?? "");
+    const offset = clampOffset(params.offset);
+    const limit = clampLimit(params.limit);
+    const collection = await deps.loadCollection(slug);
+    if (!collection) throw new Error(`collection '${slug}' not found`);
+    const all = await deps.listItems(collection.dataDir);
+    return pageResult(deps.toDetail(collection), all, offset, limit);
+  };
+
+export const getCollection = createGetCollection({ loadCollection, listItems, toDetail });

--- a/server/remoteHost/handlers/getFeed.ts
+++ b/server/remoteHost/handlers/getFeed.ts
@@ -1,0 +1,35 @@
+// getFeed command handler (remote-host phase 2).
+//
+// Returns one feed's detail + a PAGE of its records. A feed IS a
+// LoadedCollection with an `ingest` block, so this reuses the exact collection
+// page path (listItems + toDetail + collectionPage) and returns the SAME shape
+// as getCollection — the remote renders feed records with the same card view.
+// The feed is located via the feed registry (listFeeds), since feeds live under
+// their own registry rather than the collections dir.
+import { listFeeds as listFeedsRegistry } from "@mulmoclaude/core/feeds/server";
+import { listItems, toDetail } from "../../workspace/collections/index.js";
+import { workspacePath } from "../../workspace/workspace.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+import { clampLimit, clampOffset, pageResult } from "./collectionPage.js";
+
+export interface GetFeedDeps {
+  listFeeds: typeof listFeedsRegistry;
+  listItems: typeof listItems;
+  toDetail: typeof toDetail;
+  workspaceRoot: string;
+}
+
+export const createGetFeed =
+  (deps: GetFeedDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    const slug = String(params.slug ?? "");
+    const offset = clampOffset(params.offset);
+    const limit = clampLimit(params.limit);
+    const feeds = await deps.listFeeds(deps.workspaceRoot);
+    const feed = feeds.find((entry) => entry.slug === slug);
+    if (!feed) throw new Error(`feed '${slug}' not found`);
+    const all = await deps.listItems(feed.dataDir);
+    return pageResult(deps.toDetail(feed), all, offset, limit);
+  };
+
+export const getFeed = createGetFeed({ listFeeds: listFeedsRegistry, listItems, toDetail, workspaceRoot: workspacePath });

--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -2,6 +2,16 @@
 // runner learns which methods it serves. Add a capability by importing its
 // handler and adding it here.
 import type { CommandHandlers } from "../commandChannel.js";
+import { getCollection } from "./getCollection.js";
+import { getFeed } from "./getFeed.js";
 import { listCollections } from "./listCollections.js";
+import { listFeeds } from "./listFeeds.js";
+import { listShortcuts } from "./listShortcuts.js";
 
-export const handlers: CommandHandlers = { listCollections };
+export const handlers: CommandHandlers = {
+  listCollections,
+  getCollection,
+  listShortcuts,
+  listFeeds,
+  getFeed,
+};

--- a/server/remoteHost/handlers/listFeeds.ts
+++ b/server/remoteHost/handlers/listFeeds.ts
@@ -1,0 +1,37 @@
+// listFeeds command handler (remote-host phase 2).
+//
+// Returns the feed registry with retrieval kind / schedule / last-fetch time,
+// mirroring GET /api/feeds → { feeds: FeedSummary[] }. Read-only: feeds are
+// created/removed/refreshed desktop-side only.
+import { listFeeds as listFeedsRegistry, readFeedState } from "@mulmoclaude/core/feeds/server";
+import { workspacePath } from "../../workspace/workspace.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface ListFeedsDeps {
+  listFeeds: typeof listFeedsRegistry;
+  readFeedState: typeof readFeedState;
+  workspaceRoot: string;
+}
+
+export const createListFeeds =
+  (deps: ListFeedsDeps): CommandHandler =>
+  // Handler receives the command's params; listFeeds takes none.
+  async (__params: JsonObject) => {
+    const feeds = await deps.listFeeds(deps.workspaceRoot);
+    const summaries = [];
+    for (const feed of feeds) {
+      const state = await deps.readFeedState(deps.workspaceRoot, feed);
+      const { ingest } = feed.schema;
+      summaries.push({
+        slug: feed.slug,
+        title: feed.schema.title,
+        icon: feed.schema.icon,
+        kind: ingest?.kind ?? "rss",
+        schedule: ingest?.schedule ?? "on-demand",
+        lastFetchedAt: state.lastFetchedAt,
+      });
+    }
+    return { feeds: summaries } as unknown as JsonObject;
+  };
+
+export const listFeeds = createListFeeds({ listFeeds: listFeedsRegistry, readFeedState, workspaceRoot: workspacePath });

--- a/server/remoteHost/handlers/listShortcuts.ts
+++ b/server/remoteHost/handlers/listShortcuts.ts
@@ -1,0 +1,24 @@
+// listShortcuts command handler (remote-host phase 2).
+//
+// Returns the user's pinned launcher shortcuts (favorites), mirroring
+// GET /api/shortcuts → { shortcuts: Shortcut[] }. Read-only: editing the pin
+// list stays desktop-only.
+import { readShortcuts } from "../../utils/files/shortcuts-io.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface ListShortcutsDeps {
+  read: typeof readShortcuts;
+}
+
+export const createListShortcuts =
+  (deps: ListShortcutsDeps): CommandHandler =>
+  // Handler receives the command's params; listShortcuts takes none (the `__`
+  // prefix marks it intentionally unused per the lint config).
+  async (__params: JsonObject) => {
+    const shortcuts = await deps.read();
+    // Shortcut is plain JSON (string fields) but the interface lacks an index
+    // signature, so it doesn't structurally match JsonValue — cast is safe.
+    return { shortcuts } as unknown as JsonObject;
+  };
+
+export const listShortcuts = createListShortcuts({ read: readShortcuts });

--- a/test/remoteHost/test_dataHandlers.ts
+++ b/test/remoteHost/test_dataHandlers.ts
@@ -1,0 +1,124 @@
+// Unit tests for the phase-2 remote-host data handlers: getCollection, getFeed
+// (paginated records), listShortcuts, listFeeds. Engine/IO stubbed so the tests
+// assert wiring, coercion, and pagination — not the real collection engine.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createGetCollection, type GetCollectionDeps } from "../../server/remoteHost/handlers/getCollection.js";
+import { createGetFeed, type GetFeedDeps } from "../../server/remoteHost/handlers/getFeed.js";
+import { createListShortcuts, type ListShortcutsDeps } from "../../server/remoteHost/handlers/listShortcuts.js";
+import { createListFeeds, type ListFeedsDeps } from "../../server/remoteHost/handlers/listFeeds.js";
+
+const records = (count: number) => Array.from({ length: count }, (_unused, index) => ({ id: `r${index}` }));
+
+const collectionDeps = (all: { id: string }[]): GetCollectionDeps => ({
+  loadCollection: (async (slug: string) =>
+    slug === "missing" ? null : { slug, dataDir: `/d/${slug}`, schema: { primaryKey: "id" } }) as unknown as GetCollectionDeps["loadCollection"],
+  listItems: (async () => all) as unknown as GetCollectionDeps["listItems"],
+  toDetail: ((collection: { slug: string; schema: unknown }) => ({
+    slug: collection.slug,
+    title: collection.slug,
+    icon: "x",
+    source: "preset",
+    schema: collection.schema,
+  })) as unknown as GetCollectionDeps["toDetail"],
+});
+
+describe("createGetCollection", () => {
+  it("returns a page of records + detail + total", async () => {
+    const handler = createGetCollection(collectionDeps(records(5)));
+    const result = (await handler({ slug: "clients", offset: 1, limit: 2 })) as {
+      collection: { slug: string };
+      items: { id: string }[];
+      total: number;
+      offset: number;
+      limit: number;
+    };
+    assert.equal(result.total, 5);
+    assert.deepEqual(result.items, [{ id: "r1" }, { id: "r2" }]);
+    assert.equal(result.offset, 1);
+    assert.equal(result.limit, 2);
+    assert.equal(result.collection.slug, "clients");
+  });
+
+  it("throws when the collection is not found", async () => {
+    const handler = createGetCollection(collectionDeps(records(3)));
+    await assert.rejects(async () => {
+      await handler({ slug: "missing" });
+    }, /collection 'missing' not found/);
+  });
+
+  it("clamps a runaway limit and a negative offset, defaults a bad limit", async () => {
+    const handler = createGetCollection(collectionDeps(records(500)));
+    const huge = (await handler({ slug: "x", limit: 100000 })) as { limit: number };
+    assert.equal(huge.limit, 200); // MAX_LIMIT
+    const neg = (await handler({ slug: "x", offset: -5, limit: 0 })) as { offset: number; limit: number };
+    assert.equal(neg.offset, 0);
+    assert.equal(neg.limit, 50); // DEFAULT_LIMIT
+  });
+});
+
+describe("createGetFeed", () => {
+  const feedDeps = (all: { id: string }[]): GetFeedDeps => ({
+    listFeeds: (async () => [{ slug: "news", dataDir: "/f/news", schema: {} }]) as unknown as GetFeedDeps["listFeeds"],
+    listItems: (async () => all) as unknown as GetFeedDeps["listItems"],
+    toDetail: ((feed: { slug: string }) => ({
+      slug: feed.slug,
+      title: feed.slug,
+      icon: "rss",
+      source: "feed",
+      schema: {},
+    })) as unknown as GetFeedDeps["toDetail"],
+    workspaceRoot: "/ws",
+  });
+
+  it("returns a page of a feed's records via the registry", async () => {
+    const handler = createGetFeed(feedDeps(records(4)));
+    const result = (await handler({ slug: "news", offset: 0, limit: 3 })) as { items: unknown[]; total: number; collection: { slug: string } };
+    assert.equal(result.total, 4);
+    assert.equal(result.items.length, 3);
+    assert.equal(result.collection.slug, "news");
+  });
+
+  it("throws when the feed slug is not in the registry", async () => {
+    const handler = createGetFeed(feedDeps(records(2)));
+    await assert.rejects(async () => {
+      await handler({ slug: "ghost" });
+    }, /feed 'ghost' not found/);
+  });
+});
+
+describe("createListShortcuts", () => {
+  it("returns the pinned shortcuts", async () => {
+    const read = (async () => [{ kind: "collection", slug: "clients", title: "Clients", icon: "people" }]) as unknown as ListShortcutsDeps["read"];
+    const handler = createListShortcuts({ read });
+    assert.deepEqual(await handler({}), { shortcuts: [{ kind: "collection", slug: "clients", title: "Clients", icon: "people" }] });
+  });
+});
+
+describe("createListFeeds", () => {
+  it("maps the feed registry + state into { feeds }", async () => {
+    const deps: ListFeedsDeps = {
+      listFeeds: (async () => [
+        { slug: "news", schema: { title: "News", icon: "rss", ingest: { kind: "rss", schedule: "hourly" } } },
+      ]) as unknown as ListFeedsDeps["listFeeds"],
+      readFeedState: (async () => ({ lastFetchedAt: "2026-07-01T00:00:00Z" })) as unknown as ListFeedsDeps["readFeedState"],
+      workspaceRoot: "/ws",
+    };
+    const handler = createListFeeds(deps);
+    assert.deepEqual(await handler({}), {
+      feeds: [{ slug: "news", title: "News", icon: "rss", kind: "rss", schedule: "hourly", lastFetchedAt: "2026-07-01T00:00:00Z" }],
+    });
+  });
+
+  it("falls back to rss / on-demand when ingest fields are absent", async () => {
+    const deps: ListFeedsDeps = {
+      listFeeds: (async () => [{ slug: "x", schema: { title: "X", icon: "feed" } }]) as unknown as ListFeedsDeps["listFeeds"],
+      readFeedState: (async () => ({ lastFetchedAt: null })) as unknown as ListFeedsDeps["readFeedState"],
+      workspaceRoot: "/ws",
+    };
+    const result = (await createListFeeds(deps)({})) as { feeds: { kind: string; schedule: string }[] };
+    assert.equal(result.feeds[0].kind, "rss");
+    assert.equal(result.feeds[0].schedule, "on-demand");
+  });
+});

--- a/test/remoteHost/test_handlers.ts
+++ b/test/remoteHost/test_handlers.ts
@@ -8,8 +8,10 @@ import { handlers } from "../../server/remoteHost/handlers/index.js";
 import { createListCollections, type ListCollectionsDeps } from "../../server/remoteHost/handlers/listCollections.js";
 
 describe("remote-host handler registry", () => {
-  it("exposes listCollections", () => {
-    assert.equal(typeof handlers.listCollections, "function");
+  it("exposes every phase-1/2 handler", () => {
+    for (const name of ["listCollections", "getCollection", "listShortcuts", "listFeeds", "getFeed"]) {
+      assert.equal(typeof handlers[name], "function", `missing handler: ${name}`);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Host side of **phase 2** (remote collection view — `plans/feat-remote-collection-view.md`). Phase 1 (#1909) stood up the Firestore command channel + `listCollections`; this adds the read-only capabilities the mobile remote (mulmoserver) needs to browse a collection's records, its feeds, and the user's favorites. **Read-only, paginated.** The remote UI (composable, card renderer, routing) lives in the mulmoserver repo — separate.

## Handlers (all mirror an existing desktop API, registered in the command table)

| Handler | Mirrors | Result |
|---|---|---|
| `getCollection` | `GET /api/collections/:slug` | `{ collection, items, total, offset, limit }` |
| `getFeed` | a feed *is* a `LoadedCollection` | same shape as `getCollection` |
| `listShortcuts` | `GET /api/shortcuts` | `{ shortcuts }` |
| `listFeeds` | `GET /api/feeds` | `{ feeds }` (slug/title/icon/kind/schedule/lastFetchedAt) |

## Design

- **Pagination is mandatory** — the channel writes the result *inside* the command document, and Firestore caps a document at 1 MiB. `collectionPage.ts` holds the shared `offset`/`limit` clamping (limit capped at 200) + result builder; `getCollection` and `getFeed` both use it. (A real feed here has 100 records, so this is not hypothetical.)
- **`getFeed` returns the identical shape as `getCollection`** — feeds read through the same `listItems(dataDir)` + `toDetail` path, located via the feed registry (`listFeeds`), so the remote renders feed records with one card view.
- **Reuses the canonical engine helpers** (`loadCollection` / `listItems` / `toDetail` / `readShortcuts` / `listFeeds` / `readFeedState`) — no reimplementation; params are coerced defensively since they arrive as JSON over the channel.
- **Factory pattern** (`createGetCollection(deps)` etc.) keeps the mapping/coercion/pagination unit-testable with the engine stubbed.

## Testing

- `test/remoteHost/*` — 17 tests pass (lifecycle 6, registry + listCollections 3, phase-2 data handlers 8): registry shape, pagination + clamping, not-found throws, feed-registry lookup, shortcuts/feeds mapping + ingest fallbacks.
- **Verified in-process against a real workspace**: `getCollection(clients)` (8 records, paged), `getFeed` (100-record feed, paged), `listShortcuts` (real favorites), `listFeeds` (3 feeds).
- `yarn format` / `lint` (0 errors) / `typecheck` / `build` all green.

## Notes

`{ ... } as unknown as JsonObject` casts are intentional (documented): `CollectionDetail` / `CollectionItem` / `Shortcut` are plain JSON but their interfaces lack an index signature, so they don't structurally match the channel's recursive `JsonValue` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile access to collection and feed detail pages with paginated record browsing.
  * Added a feeds list and shortcut launcher support for quicker navigation.
  * Introduced localized routes for collections, feeds, and shortcuts.

* **Bug Fixes**
  * Improved pagination handling for large lists, including safer limits and non-negative offsets.
  * Added clearer missing-content behavior when a collection or feed can’t be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->