### PR TITLE
feat(remote-host): startChat handler — start a chat from the mobile remote

### DIFF
--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -7,6 +7,7 @@ import { getFeed } from "./getFeed.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
 import { listShortcuts } from "./listShortcuts.js";
+import { startChat } from "./startChat.js";
 
 export const handlers: CommandHandlers = {
   listCollections,
@@ -14,4 +15,5 @@ export const handlers: CommandHandlers = {
   listShortcuts,
   listFeeds,
   getFeed,
+  startChat,
 };

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -18,7 +18,7 @@
 // spawner stubbed; the default export wires the real spawnSystemWorker.
 import { spawnSystemWorker } from "../../api/routes/agent.js";
 import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
-import type { CommandHandler, JsonObject } from "../commandChannel.js";
+import type { CommandHandler, JsonObject, JsonValue } from "../commandChannel.js";
 
 export interface StartChatDeps {
   spawn: typeof spawnSystemWorker;
@@ -32,14 +32,25 @@ export const composeMessage = (slug: string, itemId: string, message: string): s
   return `${prefix} ${message}`;
 };
 
+// slug and itemId become single tokens in the slash command (`/<slug>`,
+// `id=<itemId>`), so a whitespace-containing or non-string value would break
+// the command parse (e.g. `/   hello`). Accept only a trimmed, whitespace-free
+// string; anything else ⇒ "" so the caller rejects it.
+const asToken = (value: JsonValue): string => {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  return /\s/.test(trimmed) ? "" : trimmed;
+};
+
 export const createStartChat =
   (deps: StartChatDeps): CommandHandler =>
   async (params: JsonObject) => {
-    // Params arrive as JSON over the channel — coerce defensively.
-    const slug = String(params.slug ?? "");
-    const itemId = params.itemId == null ? "" : String(params.itemId);
-    const message = String(params.message ?? "").trim();
-    if (!slug) throw new Error("slug is required");
+    // Params arrive as JSON over the channel — coerce/validate defensively.
+    const slug = asToken(params.slug);
+    const itemId = asToken(params.itemId);
+    const message = (typeof params.message === "string" ? params.message : "").trim();
+    if (!slug) throw new Error("slug must be a non-empty, whitespace-free string");
+    if (params.itemId != null && !itemId) throw new Error("itemId must be a non-empty, whitespace-free string when provided");
     if (!message) throw new Error("message is required");
     const result = await deps.spawn({
       message: composeMessage(slug, itemId, message),

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -1,0 +1,53 @@
+// startChat command handler (remote-host — start a chat from the mobile remote).
+//
+// Fire-and-forget: composes the collection's slash command as a prefix on the
+// user's message (`/<slug> <message>` for a collection, `/<slug> id=<itemId>
+// <message>` for one record), then spawns a VISIBLE host chat session (origin
+// `skill`, openable from history) via spawnSystemWorker, and returns the new
+// chatId. No streaming back — starting the chat on the host is enough.
+//
+// Mirrors the desktop's two entry points over the command channel: the
+// collection-level `__MC_VIEW.startChat` and the per-record chat box in
+// CollectionRecordPanel.vue (`/<slug> id=<itemId> <message>`).
+//
+// Role is intentionally NOT part of the remote API — the caller passes only
+// message + slug + optional itemId. The host runs the chat in its default role
+// (spawnSystemWorker → startChat requires a concrete roleId; empty is rejected).
+//
+// Factory (createStartChat) keeps composition/wiring unit-testable with the
+// spawner stubbed; the default export wires the real spawnSystemWorker.
+import { spawnSystemWorker } from "../../api/routes/agent.js";
+import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface StartChatDeps {
+  spawn: typeof spawnSystemWorker;
+}
+
+// Prefix the message with the collection's slash command. `itemId` scopes the
+// chat to one record; empty ⇒ the whole collection. Matches the desktop
+// item-chat format documented in CollectionRecordPanel.vue.
+export const composeMessage = (slug: string, itemId: string, message: string): string => {
+  const prefix = itemId ? `/${slug} id=${itemId}` : `/${slug}`;
+  return `${prefix} ${message}`;
+};
+
+export const createStartChat =
+  (deps: StartChatDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    // Params arrive as JSON over the channel — coerce defensively.
+    const slug = String(params.slug ?? "");
+    const itemId = params.itemId == null ? "" : String(params.itemId);
+    const message = String(params.message ?? "").trim();
+    if (!slug) throw new Error("slug is required");
+    if (!message) throw new Error("message is required");
+    const result = await deps.spawn({
+      message: composeMessage(slug, itemId, message),
+      roleId: DEFAULT_ROLE_ID,
+      hidden: false,
+    });
+    if (!result.ok) throw new Error(result.error);
+    return { started: true, chatId: result.chatId };
+  };
+
+export const startChat = createStartChat({ spawn: spawnSystemWorker });

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -60,9 +60,12 @@ export const createStartChat =
     if (!slug) throw new Error("slug must be a non-empty, whitespace-free string");
     if (params.itemId != null && !itemId) throw new Error("itemId must be a non-empty, whitespace-free string when provided");
     if (!message) throw new Error("message is required");
-    // Feeds have no `/<slug>` command — refuse rather than seed a broken chat.
+    // Resolve the target so we never seed a `/<slug>` command that resolves to
+    // nothing: an unknown/stale slug (`null`) is rejected, and a feed
+    // (`source === "feed"`, no skill command) is refused.
     const target = await deps.loadCollection(slug);
-    if (target?.source === "feed") throw new Error("chat is not available for feeds");
+    if (!target) throw new Error(`collection '${slug}' not found`);
+    if (target.source === "feed") throw new Error("chat is not available for feeds");
     const result = await deps.spawn({
       message: composeMessage(slug, itemId, message),
       roleId: DEFAULT_ROLE_ID,

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -14,14 +14,22 @@
 // message + slug + optional itemId. The host runs the chat in its default role
 // (spawnSystemWorker → startChat requires a concrete roleId; empty is rejected).
 //
+// Feeds are refused: a feed (`source === "feed"`) has no `/<slug>` skill
+// command, so a slash-command seed would invoke nothing (see desktop
+// `CollectionView.buildChatSeed`). The mobile remote doesn't offer chat for
+// feeds; this is the host-side backstop so a stray feed slug can't produce a
+// broken chat.
+//
 // Factory (createStartChat) keeps composition/wiring unit-testable with the
-// spawner stubbed; the default export wires the real spawnSystemWorker.
+// engine + spawner stubbed; the default export wires the real ones.
 import { spawnSystemWorker } from "../../api/routes/agent.js";
+import { loadCollection } from "../../workspace/collections/index.js";
 import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
 import type { CommandHandler, JsonObject, JsonValue } from "../commandChannel.js";
 
 export interface StartChatDeps {
   spawn: typeof spawnSystemWorker;
+  loadCollection: typeof loadCollection;
 }
 
 // Prefix the message with the collection's slash command. `itemId` scopes the
@@ -52,6 +60,9 @@ export const createStartChat =
     if (!slug) throw new Error("slug must be a non-empty, whitespace-free string");
     if (params.itemId != null && !itemId) throw new Error("itemId must be a non-empty, whitespace-free string when provided");
     if (!message) throw new Error("message is required");
+    // Feeds have no `/<slug>` command — refuse rather than seed a broken chat.
+    const target = await deps.loadCollection(slug);
+    if (target?.source === "feed") throw new Error("chat is not available for feeds");
     const result = await deps.spawn({
       message: composeMessage(slug, itemId, message),
       roleId: DEFAULT_ROLE_ID,
@@ -61,4 +72,4 @@ export const createStartChat =
     return { started: true, chatId: result.chatId };
   };
 
-export const startChat = createStartChat({ spawn: spawnSystemWorker });
+export const startChat = createStartChat({ spawn: spawnSystemWorker, loadCollection });

--- a/test/remoteHost/test_handlers.ts
+++ b/test/remoteHost/test_handlers.ts
@@ -8,8 +8,8 @@ import { handlers } from "../../server/remoteHost/handlers/index.js";
 import { createListCollections, type ListCollectionsDeps } from "../../server/remoteHost/handlers/listCollections.js";
 
 describe("remote-host handler registry", () => {
-  it("exposes every phase-1/2 handler", () => {
-    for (const name of ["listCollections", "getCollection", "listShortcuts", "listFeeds", "getFeed"]) {
+  it("exposes every registered handler", () => {
+    for (const name of ["listCollections", "getCollection", "listShortcuts", "listFeeds", "getFeed", "startChat"]) {
       assert.equal(typeof handlers[name], "function", `missing handler: ${name}`);
     }
   });

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -11,10 +11,13 @@ import { composeMessage, createStartChat, type StartChatDeps } from "../../serve
 type SpawnArgs = Parameters<StartChatDeps["spawn"]>[0];
 type Loaded = Awaited<ReturnType<StartChatDeps["loadCollection"]>>;
 
-// Build stub deps. `loadResult` is what `loadCollection` resolves to: null
-// (default) ⇒ not a feed, so the chat proceeds; a `{ source }` object lets a
-// test simulate a feed. `calls` captures the spawn arguments.
-const makeDeps = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>, loadResult: Loaded = null) => {
+const collection = { source: "user" } as unknown as Loaded;
+const feed = { source: "feed" } as unknown as Loaded;
+
+// Build stub deps. `loadResult` is what `loadCollection` resolves to: a normal
+// collection (default) ⇒ the chat proceeds; `feed` ⇒ refused; `null` ⇒ unknown
+// slug, rejected. `calls` captures the spawn arguments.
+const makeDeps = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>, loadResult: Loaded = collection) => {
   const calls: SpawnArgs[] = [];
   const spawn = (async (args: SpawnArgs) => {
     calls.push(args);
@@ -23,8 +26,6 @@ const makeDeps = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>, loadResul
   const loadCollection = (async () => loadResult) as StartChatDeps["loadCollection"];
   return { deps: { spawn, loadCollection } as StartChatDeps, calls };
 };
-
-const feed = { source: "feed" } as unknown as Loaded;
 
 describe("composeMessage", () => {
   it("prefixes the collection slash command for a whole-collection chat", () => {
@@ -55,6 +56,12 @@ describe("createStartChat", () => {
   it("refuses feeds (no /<slug> command) without spawning", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-feed" }, feed);
     await assert.rejects(async () => createStartChat(deps)({ slug: "news", message: "summarize" }), /not available for feeds/);
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects an unknown slug (loadCollection returns null) without spawning", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-missing" }, null);
+    await assert.rejects(async () => createStartChat(deps)({ slug: "ghost", message: "hi" }), /collection 'ghost' not found/);
     assert.equal(calls.length, 0);
   });
 

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -46,7 +46,23 @@ describe("createStartChat", () => {
 
   it("throws when slug is missing", async () => {
     const { spawn } = captureSpawn({ ok: true, chatId: "chat-3" });
-    await assert.rejects(async () => createStartChat({ spawn })({ message: "hi" }), /slug is required/);
+    await assert.rejects(async () => createStartChat({ spawn })({ message: "hi" }), /slug must be a non-empty/);
+  });
+
+  it("rejects a whitespace-only or whitespace-containing slug (malformed prefix)", async () => {
+    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3b" });
+    await assert.rejects(async () => createStartChat({ spawn })({ slug: "   ", message: "hi" }), /slug must be a non-empty/);
+    await assert.rejects(async () => createStartChat({ spawn })({ slug: "a b", message: "hi" }), /slug must be a non-empty/);
+  });
+
+  it("rejects a non-string slug", async () => {
+    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3c" });
+    await assert.rejects(async () => createStartChat({ spawn })({ slug: 123, message: "hi" }), /slug must be a non-empty/);
+  });
+
+  it("rejects an itemId that is present but whitespace-containing", async () => {
+    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3d" });
+    await assert.rejects(async () => createStartChat({ spawn })({ slug: "clients", itemId: "a b", message: "hi" }), /itemId must be a non-empty/);
   });
 
   it("throws when message is blank", async () => {

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -1,0 +1,61 @@
+// Unit tests for the startChat remote-host handler: message composition (the
+// collection slash-command prefix, with/without itemId), coercion, and the
+// spawn wiring. The host spawner is stubbed so the test asserts what message it
+// receives — not that a real chat subprocess launches.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { composeMessage, createStartChat, type StartChatDeps } from "../../server/remoteHost/handlers/startChat.js";
+
+type SpawnArgs = Parameters<StartChatDeps["spawn"]>[0];
+
+const captureSpawn = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>) => {
+  const calls: SpawnArgs[] = [];
+  const spawn = (async (args: SpawnArgs) => {
+    calls.push(args);
+    return result;
+  }) as StartChatDeps["spawn"];
+  return { spawn, calls };
+};
+
+describe("composeMessage", () => {
+  it("prefixes the collection slash command for a whole-collection chat", () => {
+    assert.equal(composeMessage("clients", "", "who is overdue?"), "/clients who is overdue?");
+  });
+
+  it("scopes to a record with id= when an itemId is given", () => {
+    assert.equal(composeMessage("clients", "acme", "draft a follow-up"), "/clients id=acme draft a follow-up");
+  });
+});
+
+describe("createStartChat", () => {
+  it("spawns a visible chat with the composed message and returns the chatId", async () => {
+    const { spawn, calls } = captureSpawn({ ok: true, chatId: "chat-1" });
+    const result = await createStartChat({ spawn })({ slug: "clients", itemId: "acme", message: "  hello  " });
+    assert.deepEqual(result, { started: true, chatId: "chat-1" });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].message, "/clients id=acme hello");
+    assert.equal(calls[0].hidden, false);
+  });
+
+  it("omits id= when itemId is absent or null", async () => {
+    const { spawn, calls } = captureSpawn({ ok: true, chatId: "chat-2" });
+    await createStartChat({ spawn })({ slug: "clients", message: "hi" });
+    assert.equal(calls[0].message, "/clients hi");
+  });
+
+  it("throws when slug is missing", async () => {
+    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3" });
+    await assert.rejects(async () => createStartChat({ spawn })({ message: "hi" }), /slug is required/);
+  });
+
+  it("throws when message is blank", async () => {
+    const { spawn } = captureSpawn({ ok: true, chatId: "chat-4" });
+    await assert.rejects(async () => createStartChat({ spawn })({ slug: "clients", message: "   " }), /message is required/);
+  });
+
+  it("surfaces a spawn failure as a thrown error", async () => {
+    const { spawn } = captureSpawn({ ok: false, error: "too many background sessions" });
+    await assert.rejects(async () => createStartChat({ spawn })({ slug: "clients", message: "hi" }), /too many background sessions/);
+  });
+});

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -1,22 +1,30 @@
 // Unit tests for the startChat remote-host handler: message composition (the
-// collection slash-command prefix, with/without itemId), coercion, and the
-// spawn wiring. The host spawner is stubbed so the test asserts what message it
-// receives — not that a real chat subprocess launches.
+// collection slash-command prefix, with/without itemId), coercion/validation,
+// feed refusal, and the spawn wiring. The host spawner + collection engine are
+// stubbed so the test asserts what message is spawned — not that a real chat
+// subprocess launches.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import { composeMessage, createStartChat, type StartChatDeps } from "../../server/remoteHost/handlers/startChat.js";
 
 type SpawnArgs = Parameters<StartChatDeps["spawn"]>[0];
+type Loaded = Awaited<ReturnType<StartChatDeps["loadCollection"]>>;
 
-const captureSpawn = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>) => {
+// Build stub deps. `loadResult` is what `loadCollection` resolves to: null
+// (default) ⇒ not a feed, so the chat proceeds; a `{ source }` object lets a
+// test simulate a feed. `calls` captures the spawn arguments.
+const makeDeps = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>, loadResult: Loaded = null) => {
   const calls: SpawnArgs[] = [];
   const spawn = (async (args: SpawnArgs) => {
     calls.push(args);
     return result;
   }) as StartChatDeps["spawn"];
-  return { spawn, calls };
+  const loadCollection = (async () => loadResult) as StartChatDeps["loadCollection"];
+  return { deps: { spawn, loadCollection } as StartChatDeps, calls };
 };
+
+const feed = { source: "feed" } as unknown as Loaded;
 
 describe("composeMessage", () => {
   it("prefixes the collection slash command for a whole-collection chat", () => {
@@ -30,8 +38,8 @@ describe("composeMessage", () => {
 
 describe("createStartChat", () => {
   it("spawns a visible chat with the composed message and returns the chatId", async () => {
-    const { spawn, calls } = captureSpawn({ ok: true, chatId: "chat-1" });
-    const result = await createStartChat({ spawn })({ slug: "clients", itemId: "acme", message: "  hello  " });
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-1" });
+    const result = await createStartChat(deps)({ slug: "clients", itemId: "acme", message: "  hello  " });
     assert.deepEqual(result, { started: true, chatId: "chat-1" });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].message, "/clients id=acme hello");
@@ -39,39 +47,45 @@ describe("createStartChat", () => {
   });
 
   it("omits id= when itemId is absent or null", async () => {
-    const { spawn, calls } = captureSpawn({ ok: true, chatId: "chat-2" });
-    await createStartChat({ spawn })({ slug: "clients", message: "hi" });
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-2" });
+    await createStartChat(deps)({ slug: "clients", message: "hi" });
     assert.equal(calls[0].message, "/clients hi");
   });
 
+  it("refuses feeds (no /<slug> command) without spawning", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-feed" }, feed);
+    await assert.rejects(async () => createStartChat(deps)({ slug: "news", message: "summarize" }), /not available for feeds/);
+    assert.equal(calls.length, 0);
+  });
+
   it("throws when slug is missing", async () => {
-    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3" });
-    await assert.rejects(async () => createStartChat({ spawn })({ message: "hi" }), /slug must be a non-empty/);
+    const { deps } = makeDeps({ ok: true, chatId: "chat-3" });
+    await assert.rejects(async () => createStartChat(deps)({ message: "hi" }), /slug must be a non-empty/);
   });
 
   it("rejects a whitespace-only or whitespace-containing slug (malformed prefix)", async () => {
-    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3b" });
-    await assert.rejects(async () => createStartChat({ spawn })({ slug: "   ", message: "hi" }), /slug must be a non-empty/);
-    await assert.rejects(async () => createStartChat({ spawn })({ slug: "a b", message: "hi" }), /slug must be a non-empty/);
+    const { deps } = makeDeps({ ok: true, chatId: "chat-3b" });
+    await assert.rejects(async () => createStartChat(deps)({ slug: "   ", message: "hi" }), /slug must be a non-empty/);
+    await assert.rejects(async () => createStartChat(deps)({ slug: "a b", message: "hi" }), /slug must be a non-empty/);
   });
 
   it("rejects a non-string slug", async () => {
-    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3c" });
-    await assert.rejects(async () => createStartChat({ spawn })({ slug: 123, message: "hi" }), /slug must be a non-empty/);
+    const { deps } = makeDeps({ ok: true, chatId: "chat-3c" });
+    await assert.rejects(async () => createStartChat(deps)({ slug: 123, message: "hi" }), /slug must be a non-empty/);
   });
 
   it("rejects an itemId that is present but whitespace-containing", async () => {
-    const { spawn } = captureSpawn({ ok: true, chatId: "chat-3d" });
-    await assert.rejects(async () => createStartChat({ spawn })({ slug: "clients", itemId: "a b", message: "hi" }), /itemId must be a non-empty/);
+    const { deps } = makeDeps({ ok: true, chatId: "chat-3d" });
+    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", itemId: "a b", message: "hi" }), /itemId must be a non-empty/);
   });
 
   it("throws when message is blank", async () => {
-    const { spawn } = captureSpawn({ ok: true, chatId: "chat-4" });
-    await assert.rejects(async () => createStartChat({ spawn })({ slug: "clients", message: "   " }), /message is required/);
+    const { deps } = makeDeps({ ok: true, chatId: "chat-4" });
+    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", message: "   " }), /message is required/);
   });
 
   it("surfaces a spawn failure as a thrown error", async () => {
-    const { spawn } = captureSpawn({ ok: false, error: "too many background sessions" });
-    await assert.rejects(async () => createStartChat({ spawn })({ slug: "clients", message: "hi" }), /too many background sessions/);
+    const { deps } = makeDeps({ ok: false, error: "too many background sessions" });
+    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", message: "hi" }), /too many background sessions/);
   });
 });


### PR DESCRIPTION
## What

Adds a `startChat` command-channel handler so the **mobile remote** can start a new chat on the host — either about a whole collection or about one of its records. This brings the desktop's two chat-seeding entry points to the remote:

- collection-level `__MC_VIEW.startChat` (`CollectionView` / custom views)
- the per-record chat box in `CollectionRecordPanel.vue` (`/<slug> id=<itemId> <message>`)

## How

The remote passes `{ message, slug, itemId? }`. The handler:

1. Composes the collection slash command as a prefix:
   - `/{slug} {message}` — whole collection
   - `/{slug} id={itemId} {message}` — one record
2. Spawns a **visible** host chat session (origin `skill`, openable from history) via the existing `spawnSystemWorker`, **fire-and-forget** — no streaming back; starting the chat on the host is enough.
3. Returns `{ started, chatId }`.

Role is intentionally **not** part of the remote API — the caller sends only `message` + `slug` + optional `itemId`; the host runs the chat in its default role (`spawnSystemWorker` → `startChat` requires a concrete `roleId`, so empty is rejected).

Registered in `server/remoteHost/handlers/index.ts` alongside the phase-2 read-only handlers.

### Trust model note

This is the **first write-shaped** remote-host handler (phase-2 handlers were read-only). It stays within the existing uid-scoped Firestore-rules boundary — it only acts on the owner's own workspace — but per the plan's phase-3 caveat, subsequent write/delete/cross-collection handlers should re-evaluate handler-side authz.

## Tests

`test/remoteHost/test_startChat.ts` — 7 tests: prefix composition (with/without `itemId`), param coercion, visible-spawn wiring, missing-slug / blank-message rejection, and spawn-failure surfacing. Spawner stubbed.

## Follow-up (separate repo)

The mobile-remote UI that calls `callHost(channel, "startChat", …)` lives in `mulmoserver` and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new remote-host command to start a visible host chat, with support for collection-wide chats or record-scoped chats.
  * Requests are now routed to the new command handler.
* **Bug Fixes**
  * Improved input validation and normalization for chat start parameters (including message trimming and strict token formatting).
  * Failures during chat creation now surface clearly.
* **Tests**
  * Added unit tests covering chat message formatting, successful chat creation, and error cases for invalid inputs and spawn failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->