### PR TITLE
docs: pin public registry in publish-mulmoclaude skill

### DIFF
--- a/.claude/skills/publish-mulmoclaude/SKILL.md
+++ b/.claude/skills/publish-mulmoclaude/SKILL.md
@@ -64,9 +64,13 @@ For each drifted package:
 # Bump in that package's package.json, then:
 yarn install
 yarn build:packages
-cd packages/<name> && npm publish --access public
+cd packages/<name> && npm publish --access public --registry https://registry.npmjs.org/
 # Tag + GitHub release: see §7.
 ```
+
+> MUST pass `--registry https://registry.npmjs.org/` on every `npm publish`
+> below. The environment's default registry is a private mirror, so
+> without it the package publishes to the wrong registry (or fails auth).
 
 Update mulmoclaude's refs to the new versions. If `chat-service` depends on `protocol`, bump its dep there too.
 
@@ -137,7 +141,7 @@ When iterating (known-broken 0.1.0 → fixed 0.1.1), keep the published version 
 ### 6. Publish
 
 ```bash
-cd packages/mulmoclaude && npm publish --access public
+cd packages/mulmoclaude && npm publish --access public --registry https://registry.npmjs.org/
 ```
 
 Verify:


### PR DESCRIPTION
## Summary

`.claude/skills/publish-mulmoclaude/SKILL.md` の `npm publish` コマンド2箇所に `--registry https://registry.npmjs.org/` を追加。

## User Prompt

> publish の skill に、publish 時は `--registry https://registry.npmjs.org/` を指定するよう追加して（global と mulmo の skill 両方に）。

（global 側 `~/.claude/skills/publish` は個人設定なので別途対応済み。本PRはリポジトリ管理下の mulmo skill のみ。）

## 理由

この環境のデフォルト npm レジストリが private mirror のため、明示しないと publish 先を間違える / 認証で失敗しうる。skill に registry を pin し、必須である旨の注記も追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update mulmoclaude publish skill instructions to always pass the public npmjs registry to npm publish to avoid accidentally using a private mirror.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified publish instructions to always use the public npm registry.
  * Added an explicit warning that the default registry may point to a private mirror, so publishing should use the public registry URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->