### PR TITLE
fix(mulmoclaude): read version from package.json in bin, not hardcoded

### DIFF
--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -115,7 +115,8 @@ ${cliFlagHelpLines()}
 }
 
 if (args.includes("--version")) {
-  console.log("mulmoclaude 0.9.1");
+  const { version } = require(join(PKG_DIR, "package.json"));
+  console.log(`mulmoclaude ${version}`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

- \`bin/mulmoclaude.js\` の \`--version\` 出力を \`package.json\` から読むよう変更 (旧: hardcoded string、新: \`require(package.json).version\`)
- 0.9.2 を publish した直後 \`npx mulmoclaude --version\` が **0.9.1** を返した (hardcoded の同期漏れ) の再発防止

## Items to Confirm / Review

- [ ] 変更は 2 行だけ (hardcoded string → require + template literal)。 テスト追加は不要と判断
- [ ] 反映は次の launcher publish (0.9.3) 以降。 0.9.2 では \`--version\` が 0.9.1 と表示される既知不具合が残るが cosmetic 且つ実 package.json は正しく 0.9.2 なので blocker 扱い不要

## User Prompt

> bin/mulmoclaude.js は package.json を参照するように！！

## Test plan

- [x] \`node packages/mulmoclaude/bin/mulmoclaude.js --version\` → \`mulmoclaude 0.9.2\` 出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix mulmoclaude --version reporting an outdated version by sourcing the version from package.json.