### PR TITLE
docs(plans): document trust model for remote collection read handlers

### DIFF
--- a/plans/feat-remote-collection-view.md
+++ b/plans/feat-remote-collection-view.md
@@ -57,6 +57,35 @@ reuses the same card renderer. Read-only; refresh/retrieval stays desktop-only.
   `src/views/Collections.vue`). This phase adds a sibling `useCollection(slug)`
   and a `/collections/:slug` route.
 
+### Trust model — why reading an arbitrary slug is safe
+
+The infra sections below detail *how* records are paged under the 1 MiB limit;
+this paragraph records *why* an unauthenticated-at-the-handler `getCollection(slug)`
+/ `getFeed(slug)` is not a data-leak. The entire security boundary is the
+**Firestore rules layer, scoped by uid** — there is deliberately **no per-method
+authz in the handlers**:
+
+- Everything lives under `users/{uid}/hosts/{hostId}/**` (the `commands`
+  subcollection and the presence doc), which the deployed rule restricts to
+  `request.auth != null && request.auth.uid == uid`. In mulmoserver this is the
+  broader `match /users/{uid}/{document=**}` rule, whose recursive wildcard
+  already covers the hosts subtree. So a remote can only ever enqueue commands in
+  **its own** uid's queue; a different signed-in user cannot reach this host.
+- That rule was established in **phase-1 (#1909)** and is live in production —
+  it is a prerequisite of this phase, not something phase-2 adds.
+- The handlers being read-only is what makes uid-scope-only sufficient: a
+  request already proves ownership of the workspace by virtue of writing to
+  `users/{uid}/…`, and read-only handlers can't cross that boundary.
+- **Phase-3+ caveat:** when write/delete or cross-collection `ref`/`embed`
+  handlers are added, re-evaluate — they may need handler-side authz (per-slug
+  scope, rate limits) on top of the rules layer, since "can write to my own
+  queue" no longer implies "may mutate this specific record/collection."
+
+The one boundary *outside* Firestore is the auth entry point: `signInHost`'s
+Google OAuth ID token must be accepted only from the localhost owner
+(`/api/remote-host/connect`), so a hostile page can't turn the server into a host
+for someone else's workspace.
+
 ## The three decisions that shape this
 
 ### 1. The 1 MB Firestore document limit (the important one)


### PR DESCRIPTION
## Summary

Adds a "Trust model — why reading an arbitrary slug is safe" section to the phase-2 remote-collection-view plan (`plans/feat-remote-collection-view.md`).

It records the security reasoning for the upcoming `getCollection` / `getFeed` handlers:

- The entire boundary is the **Firestore rules layer scoped by uid** (`users/{uid}/hosts/{hostId}/**`, covered by the recursive `match /users/{uid}/{document=**}` rule) — deliberately **no per-method authz in the handlers**.
- That rule shipped in phase-1 (#1909) and is live in production; it is a prerequisite of phase 2, not something phase 2 adds.
- Read-only handlers are what make uid-scope-only sufficient, with an explicit **phase-3+ caveat**: write/delete or cross-collection `ref`/`embed` handlers must re-evaluate and may need handler-side authz.
- The one boundary outside Firestore: `signInHost`'s Google OAuth ID token must be accepted only from the localhost owner (`/api/remote-host/connect`).

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security note explaining why reading remote collections and feeds by slug is safe.
  * Clarified that access is limited by user-scoped rules, preventing cross-workspace data exposure.
  * Documented the token-acceptance boundary for host connections.
  * Added a note that future write or mutation actions may need extra authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->