### PR TITLE
fix(chat-index): skip sessions whose jsonl hasn't been touched since the last index (#1929)

### DIFF
--- a/plans/fix-1929-chat-index-skip-unchanged.md
+++ b/plans/fix-1929-chat-index-skip-unchanged.md
@@ -1,0 +1,57 @@
+# fix #1929: chat-index scheduler skips content-unchanged sessions
+
+## User prompt (JP)
+
+> ログ見ると `[chat-index] indexed` が出過ぎにみえる。更新ないものはupdateしなくてよいのでもっと減るべきに見えるけど。。。
+
+## Frequency (answering the follow-up)
+
+`server/index.ts:1149-1155` registers `system:chat-index` on `intervalMs: ONE_HOUR_MS` — the scheduler ticks it every hour, with a `runOnce` catch-up policy. Plus:
+
+- Agent finally hook calls `maybeIndexSession()` after each turn (with a 15-min `isFresh` throttle).
+- `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1` runs backfill once at boot when set.
+- `POST /api/chat-index/rebuild` is the manual on-demand path.
+
+## Root cause
+
+`backfillAllSessions()` at `server/workspace/chat-index/index.ts:117-120` unconditionally passes `force: true` to every `indexSession()` call. The 15-min freshness throttle (`isFresh`) is the only skip logic in `indexSession`, and `force: true` bypasses it. Consequence: the hourly scheduler tick re-summarises every session — Claude CLI call + `[chat-index] indexed` log per session — even when the jsonl has not been touched since the last index.
+
+## Fix
+
+Two complementary changes:
+
+### 1. New `sessionJsonlChangedSinceIndex` helper (indexer.ts)
+
+Reads the entry file, extracts `indexedAt` as a millisecond timestamp, `stat`s the jsonl, returns `true` iff the jsonl's `mtimeMs > indexedAt`. Missing entry / malformed entry → `true` (index it). Missing jsonl → `false` (nothing to reindex).
+
+Gate it inside `indexSession()` alongside the existing `isFresh` check, both guarded on `!force`:
+
+```ts
+if (!force) {
+  if (await isFresh(...)) return null;                          // 15-min throttle
+  if (!(await sessionJsonlChangedSinceIndex(...))) return null; // content unchanged
+}
+```
+
+### 2. Make `force` opt-in on `backfillAllSessions` (index.ts)
+
+- Add `force?: boolean` to the options bag. Default `false`.
+- Remove the hardcoded `force: true` on the `indexSession` call.
+- Thread the option through.
+
+### 3. Callers
+
+- `server/index.ts:1154` scheduler task: leave as `backfillAllSessions()` — default no force, respects both gates.
+- `server/index.ts:~941` startup switch (`CHAT_INDEX_FORCE_RUN_ON_STARTUP`): pass `{ force: true }`.
+- `server/api/routes/chat-index.ts:34` manual rebuild endpoint: pass `{ force: true }` (endpoint comment already says "force-rebuild every session's summary on demand").
+
+## Tests
+
+- `test_indexer.ts`: three new tests — skip when jsonl mtime ≤ indexedAt; re-index when jsonl mtime > indexedAt; `force: true` bypasses the content-changed gate.
+- `test_maybe_index_session.ts`: adjust existing "backfillAllSessions re-indexes fresh sessions" test to pass `{ force: true }` explicitly (previously relied on the hardcoded force). Add a new "without force, skips content-unchanged sessions" test that uses `utimes` to control the jsonl mtime.
+
+## Non-goals
+
+- No change to `isFresh` or the 15-min throttle — it protects the agent finally hook during active conversations.
+- No change to the scheduler interval (still 1 hour). The complaint is about work-per-tick, not tick frequency.
+- No change to the `indexed` log level — after this fix, only actual work emits a log line, so the volume drops to the real update rate.

--- a/server/api/routes/chat-index.ts
+++ b/server/api/routes/chat-index.ts
@@ -31,7 +31,11 @@ const router = Router();
 router.post(API_ROUTES.chatIndex.rebuild, async (_req: Request, res: Response<RebuildResponse | RebuildErrorResponse>) => {
   try {
     log.info("chat-index", "manual rebuild triggered");
-    const result = await backfillAllSessions();
+    // Manual rebuild = "regenerate every session's summary now",
+    // matching this endpoint's original semantics (the user hit it
+    // expecting a full rebuild, not the "changed only" default that
+    // the scheduler runs). See #1929.
+    const result = await backfillAllSessions({ force: true });
     log.info("chat-index", "rebuild complete", {
       indexed: result.indexed,
       total: result.total,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1152,7 +1152,16 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
       id: "system:chat-index",
       name: "Chat index backfill",
       description: "Generate AI titles + summaries for un-indexed sessions",
-      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: ONE_HOUR_MS },
+      // Every 6 hours. The primary trigger is the agent finally-hook
+      // (per-turn, 15-min throttle), so the scheduler exists only to
+      // catch strays: a turn skipped by isFresh whose session then
+      // went idle, an out-of-band jsonl edit, or a mid-turn server
+      // crash. Since #1929 the per-tick work is O(stat + entry read)
+      // for unchanged sessions — cheap — but there's still no UX
+      // reason to run it more often than every few hours, and less
+      // frequent runs match a user's expectation of "quiet
+      // background maintenance".
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 6 * ONE_HOUR_MS },
       missedRunPolicy: MISSED_RUN_POLICIES.runOnce,
       run: () => backfillAllSessions().then(() => {}),
     },

--- a/server/index.ts
+++ b/server/index.ts
@@ -938,7 +938,10 @@ function maybeForceChatIndexBackfill(): void {
   // debugging the indexer itself.
   if (!env.chatIndexForceRunOnStartup) return;
   log.info("chat-index", "CHAT_INDEX_FORCE_RUN_ON_STARTUP=1 — running now");
-  backfillAllSessions()
+  // The startup switch is opt-in and its whole point is "regenerate
+  // every summary now"; pass `force: true` so it doesn't silently
+  // become a no-op after #1929's content-changed gate lands.
+  backfillAllSessions({ force: true })
     .then((result) => {
       log.info("chat-index", "startup backfill complete", {
         indexed: result.indexed,

--- a/server/workspace/chat-index/index.ts
+++ b/server/workspace/chat-index/index.ts
@@ -99,6 +99,12 @@ export async function backfillAllSessions(
   opts: {
     workspaceRoot?: string;
     deps?: IndexerDeps;
+    // Opt-in to "regenerate every summary, even those still current".
+    // Default false — the scheduled tick uses that so unchanged
+    // sessions cost only a stat + entry read, not a Claude CLI call.
+    // The manual rebuild endpoint and CHAT_INDEX_FORCE_RUN_ON_STARTUP
+    // opt in explicitly, matching their debug / rollout intent (#1929).
+    force?: boolean;
   } = {},
 ): Promise<BackfillResult> {
   const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
@@ -108,6 +114,7 @@ export async function backfillAllSessions(
     indexed: 0,
     skipped: 0,
   };
+  const force = opts.force === true;
   for (const sessionId of ids) {
     if (disabled) {
       result.skipped++;
@@ -116,7 +123,7 @@ export async function backfillAllSessions(
     try {
       const entry = await indexSession(workspaceRoot, sessionId, {
         ...(opts.deps ?? {}),
-        force: true,
+        ...(force ? { force: true } : {}),
       });
       if (entry) {
         result.indexed++;

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -120,32 +120,49 @@ export async function updateManifest(workspaceRoot: string, mutator: (m: ChatInd
 // disk. Both removals tolerate "missing" — sessions that were never
 // indexed have no entry to prune.
 export async function removeSessionFromIndex(workspaceRoot: string, sessionId: string): Promise<void> {
-  await rm(indexEntryPathFor(workspaceRoot, sessionId), { force: true });
+  const safeId = safeSessionIdOrNull(sessionId);
+  if (safeId === null) return;
+  await rm(indexEntryPathFor(workspaceRoot, safeId), { force: true });
   await updateManifest(workspaceRoot, (manifest) => ({
     ...manifest,
-    entries: manifest.entries.filter((entry) => entry.id !== sessionId),
+    entries: manifest.entries.filter((entry) => entry.id !== safeId),
   }));
 }
 
 // --- freshness check ------------------------------------------------
 
+// Shared parsing of `<indexDir>/<sessionId>.json` → `indexedAt` as
+// milliseconds since epoch. Returns null on any failure (file
+// missing, unreadable, JSON parse error, wrong shape, unparseable
+// timestamp) so callers can each pick their own "no entry" semantic
+// (skip vs reindex vs throttle) without duplicating the read.
+// Exported so `isFresh` / `sessionJsonlChangedSinceIndex` share one
+// canonical parse — CodeRabbit review on #1930.
+export async function readIndexedAtMs(workspaceRoot: string, sessionId: string): Promise<number | null> {
+  const safeId = safeSessionIdOrNull(sessionId);
+  if (safeId === null) return null;
+  try {
+    const raw = await readFile(indexEntryPathFor(workspaceRoot, safeId), "utf-8");
+    const entry: unknown = JSON.parse(raw);
+    if (!isRecord(entry)) return null;
+    const { indexedAt } = entry as Record<string, unknown>;
+    if (typeof indexedAt !== "string") return null;
+    const parsed = Date.parse(indexedAt);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
 // A session is "fresh" when its per-session index file exists and
 // was written less than `minIntervalMs` ago. Fresh sessions are
 // skipped so a long conversation doesn't spam the CLI on every
-// turn.
+// turn. Delegates disk / parse work to `readIndexedAtMs` so the
+// two throttles stay in lockstep on entry-file semantics.
 export async function isFresh(workspaceRoot: string, sessionId: string, now: number, minIntervalMs: number): Promise<boolean> {
-  try {
-    const raw = await readFile(indexEntryPathFor(workspaceRoot, sessionId), "utf-8");
-    const entry: unknown = JSON.parse(raw);
-    if (!isRecord(entry)) return false;
-    const { indexedAt } = entry as Record<string, unknown>;
-    if (typeof indexedAt !== "string") return false;
-    const indexedTimestamp = Date.parse(indexedAt);
-    if (Number.isNaN(indexedTimestamp)) return false;
-    return now - indexedTimestamp < minIntervalMs;
-  } catch {
-    return false;
-  }
+  const indexedMs = await readIndexedAtMs(workspaceRoot, sessionId);
+  if (indexedMs === null) return false;
+  return now - indexedMs < minIntervalMs;
 }
 
 // Returns true when the session's jsonl was written / appended AFTER
@@ -169,20 +186,7 @@ export async function isFresh(workspaceRoot: string, sessionId: string, now: num
 export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessionId: string): Promise<boolean> {
   const safeId = safeSessionIdOrNull(sessionId);
   if (safeId === null) return false;
-  let indexedMs: number | null = null;
-  try {
-    const raw = await readFile(indexEntryPathFor(workspaceRoot, safeId), "utf-8");
-    const entry: unknown = JSON.parse(raw);
-    if (isRecord(entry)) {
-      const { indexedAt } = entry as Record<string, unknown>;
-      if (typeof indexedAt === "string") {
-        const parsedMs = Date.parse(indexedAt);
-        if (!Number.isNaN(parsedMs)) indexedMs = parsedMs;
-      }
-    }
-  } catch {
-    return true;
-  }
+  const indexedMs = await readIndexedAtMs(workspaceRoot, safeId);
   if (indexedMs === null) return true;
   try {
     const info = await stat(sessionJsonlPathFor(workspaceRoot, safeId));
@@ -208,7 +212,7 @@ export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessi
 // Returns the cleaned id on success (identical to the input for
 // legit ids) or `null` on any hostile / malformed input.
 const SAFE_SESSION_ID_RE = /^[\w.-]{1,200}$/;
-function safeSessionIdOrNull(sessionId: string): string | null {
+export function safeSessionIdOrNull(sessionId: string): string | null {
   const basename = path.basename(sessionId);
   if (basename !== sessionId) return null;
   if (!SAFE_SESSION_ID_RE.test(basename)) return null;
@@ -224,8 +228,14 @@ interface SessionMeta {
 }
 
 async function readSessionMeta(workspaceRoot: string, sessionId: string): Promise<SessionMeta> {
+  // Defence-in-depth: only `indexSession` calls this (with an
+  // already-sanitized id), but a future caller wiring the helper
+  // into a new code path shouldn't be able to escape the chat dir
+  // by mistake.
+  const safeId = safeSessionIdOrNull(sessionId);
+  if (safeId === null) return {};
   try {
-    const raw = await readFile(sessionMetaPathFor(workspaceRoot, sessionId), "utf-8");
+    const raw = await readFile(sessionMetaPathFor(workspaceRoot, safeId), "utf-8");
     const parsed: unknown = JSON.parse(raw);
     if (!isRecord(parsed)) return {};
     const metaRecord = parsed as Record<string, unknown>;
@@ -239,11 +249,22 @@ async function readSessionMeta(workspaceRoot: string, sessionId: string): Promis
 }
 
 // List every session id that has a .jsonl file in the workspace
-// chat dir. Used by the backfill helper.
+// chat dir. Used by the backfill helper. Filenames from disk are
+// filtered through `safeSessionIdOrNull` so a stray file with a
+// hostile name (`.` / `..` / a slash-containing name that survived
+// readdir on some FS) can never flow through the backfill loop
+// into `indexSession`.
 export async function listSessionIds(workspaceRoot: string): Promise<string[]> {
   try {
     const files = await readdir(chatDirFor(workspaceRoot));
-    return files.filter((fileName) => fileName.endsWith(".jsonl")).map((fileName) => fileName.slice(0, -".jsonl".length));
+    const ids: string[] = [];
+    for (const fileName of files) {
+      if (!fileName.endsWith(".jsonl")) continue;
+      const stem = fileName.slice(0, -".jsonl".length);
+      const safeId = safeSessionIdOrNull(stem);
+      if (safeId !== null) ids.push(safeId);
+    }
+    return ids;
   } catch {
     return [];
   }
@@ -253,36 +274,43 @@ export async function listSessionIds(workspaceRoot: string): Promise<string[]> {
 
 // Index (or re-index) a single session. Returns the entry on
 // success, or null if the session was skipped (fresh, empty,
-// missing). The only exception that escapes is
+// missing, or hostile id). The only exception that escapes is
 // `ClaudeCliNotFoundError` — the caller uses it to disable the
 // module for the rest of the process lifetime.
+//
+// `sessionId` is sanitized at entry (`safeSessionIdOrNull`) and the
+// resulting `safeId` is threaded through every downstream file
+// access, so `force: true` — a debug / rollout knob — cannot become
+// a path-injection escape hatch (Codex review on #1930).
 export async function indexSession(workspaceRoot: string, sessionId: string, deps: IndexerDeps = {}): Promise<ChatIndexEntry | null> {
+  const safeId = safeSessionIdOrNull(sessionId);
+  if (safeId === null) return null;
   const summarize = deps.summarize ?? defaultSummarize;
   const now = (deps.now ?? Date.now)();
   const minInterval = deps.minIntervalMs ?? MIN_INDEX_INTERVAL_MS;
   const force = deps.force === true;
 
   if (!force) {
-    if (await isFresh(workspaceRoot, sessionId, now, minInterval)) {
+    if (await isFresh(workspaceRoot, safeId, now, minInterval)) {
       return null;
     }
     // Second gate: even past the freshness window, if the jsonl has
     // NOT been written since the last index there's no new content
     // to summarize. Cuts idle scheduler tick cost from O(sessions)
     // Claude CLI calls to O(actual updates) — see #1929.
-    if (!(await sessionJsonlChangedSinceIndex(workspaceRoot, sessionId))) {
+    if (!(await sessionJsonlChangedSinceIndex(workspaceRoot, safeId))) {
       return null;
     }
   }
 
-  const input = await loadJsonlInput(sessionJsonlPathFor(workspaceRoot, sessionId));
+  const input = await loadJsonlInput(sessionJsonlPathFor(workspaceRoot, safeId));
   if (!input.trim()) return null;
 
   const summary = await summarize(input);
-  const meta = await readSessionMeta(workspaceRoot, sessionId);
+  const meta = await readSessionMeta(workspaceRoot, safeId);
 
   const entry: ChatIndexEntry = {
-    id: sessionId,
+    id: safeId,
     roleId: meta.roleId ?? DEFAULT_ROLE_ID,
     startedAt: meta.startedAt ?? new Date(now).toISOString(),
     indexedAt: new Date(now).toISOString(),
@@ -294,12 +322,12 @@ export async function indexSession(workspaceRoot: string, sessionId: string, dep
   // Per-session file is written first so partial progress survives
   // a crash between the two writes: the next run can still observe
   // the fresh entry via isFresh and skip it.
-  await writeJsonAtomic(indexEntryPathFor(workspaceRoot, sessionId), entry);
+  await writeJsonAtomic(indexEntryPathFor(workspaceRoot, safeId), entry);
 
   // Upsert into manifest under the in-process lock: replace any
   // prior entry with the same id, sort newest-first by startedAt.
   await updateManifest(workspaceRoot, (current) => {
-    const filtered = current.entries.filter((entryItem) => entryItem.id !== sessionId);
+    const filtered = current.entries.filter((entryItem) => entryItem.id !== safeId);
     filtered.push(entry);
     filtered.sort((leftEntry, rightEntry) => Date.parse(rightEntry.startedAt) - Date.parse(leftEntry.startedAt));
     return { version: 1, entries: filtered };

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -9,6 +9,7 @@
 // ~/mulmoclaude.
 
 import { readdir, readFile, rm, stat } from "node:fs/promises";
+import path from "node:path";
 import { defaultSummarize, loadJsonlInput, type SummarizeFn } from "./summarizer.js";
 import { chatDirFor, indexEntryPathFor, manifestPathFor, sessionJsonlPathFor, sessionMetaPathFor } from "./paths.js";
 import type { ChatIndexEntry, ChatIndexManifest } from "./types.js";
@@ -166,10 +167,11 @@ export async function isFresh(workspaceRoot: string, sessionId: string, now: num
 //    would return null downstream anyway, but we short-circuit).
 //  - Otherwise → jsonl mtime > entry.indexedAt.
 export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessionId: string): Promise<boolean> {
-  if (!isSafeSessionId(sessionId)) return false;
+  const safeId = safeSessionIdOrNull(sessionId);
+  if (safeId === null) return false;
   let indexedMs: number | null = null;
   try {
-    const raw = await readFile(indexEntryPathFor(workspaceRoot, sessionId), "utf-8");
+    const raw = await readFile(indexEntryPathFor(workspaceRoot, safeId), "utf-8");
     const entry: unknown = JSON.parse(raw);
     if (isRecord(entry)) {
       const { indexedAt } = entry as Record<string, unknown>;
@@ -183,7 +185,7 @@ export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessi
   }
   if (indexedMs === null) return true;
   try {
-    const info = await stat(sessionJsonlPathFor(workspaceRoot, sessionId));
+    const info = await stat(sessionJsonlPathFor(workspaceRoot, safeId));
     return info.mtimeMs > indexedMs;
   } catch {
     return false;
@@ -191,16 +193,27 @@ export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessi
 }
 
 // Path-traversal guard for session IDs used to derive on-disk paths.
-// Same shape as `server/api/bridge/sessionRole.ts`'s
-// `SAFE_SESSION_ID_RE` — kept local here so the workspace layer
-// doesn't need to reach uphill into the routes layer. Rejects any id
-// containing `..` (belt-and-suspenders — a whole-string `..` passes
-// the class alone) so `path.join(dir, "<id>.jsonl")` cannot escape
-// the chat dir even if a route handler forwards an unvalidated URL
-// param down to us.
+// Two-step check so both a static analyser (CodeQL taints
+// `sessionId` as a possible route-param input) AND a human reader
+// can convince themselves the derived path stays inside the chat
+// dir:
+//
+//   1. `path.basename()` collapses any `..` / separator to the last
+//      segment. CodeQL recognises this as a barrier — a value whose
+//      taint originates upstream is neutralised here.
+//   2. `SAFE_SESSION_ID_RE` narrows the character class further
+//      (word chars, `.`, `-`, up to 200 long) and rejects any
+//      `..` substring, mirroring `server/api/bridge/sessionRole.ts`.
+//
+// Returns the cleaned id on success (identical to the input for
+// legit ids) or `null` on any hostile / malformed input.
 const SAFE_SESSION_ID_RE = /^[\w.-]{1,200}$/;
-function isSafeSessionId(sessionId: string): boolean {
-  return SAFE_SESSION_ID_RE.test(sessionId) && !sessionId.includes("..");
+function safeSessionIdOrNull(sessionId: string): string | null {
+  const basename = path.basename(sessionId);
+  if (basename !== sessionId) return null;
+  if (!SAFE_SESSION_ID_RE.test(basename)) return null;
+  if (basename.includes("..")) return null;
+  return basename;
 }
 
 // --- session metadata ----------------------------------------------

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -8,7 +8,7 @@
 // at a `mkdtempSync` directory without touching the real
 // ~/mulmoclaude.
 
-import { readdir, readFile, rm } from "node:fs/promises";
+import { readdir, readFile, rm, stat } from "node:fs/promises";
 import { defaultSummarize, loadJsonlInput, type SummarizeFn } from "./summarizer.js";
 import { chatDirFor, indexEntryPathFor, manifestPathFor, sessionJsonlPathFor, sessionMetaPathFor } from "./paths.js";
 import type { ChatIndexEntry, ChatIndexManifest } from "./types.js";
@@ -22,6 +22,12 @@ import { isRecord } from "../../utils/types.js";
 // — long enough that a single conversation doesn't re-summarize
 // every turn, short enough that a user who leaves for lunch and
 // comes back sees the title refresh.
+//
+// Complementary to the content-change gate below: `isFresh` says
+// "we JUST indexed, don't retry mid-conversation", while
+// `sessionJsonlChangedSinceIndex` says "the jsonl hasn't been
+// touched since we last indexed, no work to do". Both run when
+// `force` is false; `force: true` bypasses both.
 export const MIN_INDEX_INTERVAL_MS = 15 * ONE_MINUTE_MS;
 
 // Injection points for tests. Defaults are the production spawn +
@@ -30,10 +36,13 @@ export interface IndexerDeps {
   summarize?: SummarizeFn;
   now?: () => number;
   minIntervalMs?: number;
-  // Bypass the `isFresh` freshness throttle. Used by the
-  // backfill helper and the debug trigger endpoint so a manual
-  // "rebuild everything" run doesn't silently skip entries that
-  // happen to be within the 15-minute window.
+  // Bypass both the `isFresh` freshness throttle AND the content-
+  // changed gate (`sessionJsonlChangedSinceIndex`). Used by the
+  // manual rebuild endpoint and the `CHAT_INDEX_FORCE_RUN_ON_STARTUP`
+  // startup path so "regenerate everything" semantics keep working
+  // even when the summariser is unchanged — e.g. the summariser
+  // prompt was edited and existing summaries are stale by design,
+  // not by content.
   force?: boolean;
 }
 
@@ -138,6 +147,46 @@ export async function isFresh(workspaceRoot: string, sessionId: string, now: num
   }
 }
 
+// Returns true when the session's jsonl was written / appended AFTER
+// its last index entry — i.e. there IS new content to summarize.
+//
+// Complements `isFresh`: without this gate, the hourly scheduler
+// tick re-summarizes every session even when nothing new was
+// written since the last index (issue #1929). With it, the tick's
+// per-session cost drops to O(stat + file read) for unchanged
+// sessions and only spends a Claude CLI call on the ones that
+// actually saw a new turn.
+//
+// Return-value contract, for each unknown state:
+//  - Entry file missing/malformed → true (we've never captured this
+//    session; index it).
+//  - Jsonl file missing → false (nothing to reindex; the caller
+//    would return null downstream anyway, but we short-circuit).
+//  - Otherwise → jsonl mtime > entry.indexedAt.
+export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessionId: string): Promise<boolean> {
+  let indexedMs: number | null = null;
+  try {
+    const raw = await readFile(indexEntryPathFor(workspaceRoot, sessionId), "utf-8");
+    const entry: unknown = JSON.parse(raw);
+    if (isRecord(entry)) {
+      const { indexedAt } = entry as Record<string, unknown>;
+      if (typeof indexedAt === "string") {
+        const parsedMs = Date.parse(indexedAt);
+        if (!Number.isNaN(parsedMs)) indexedMs = parsedMs;
+      }
+    }
+  } catch {
+    return true;
+  }
+  if (indexedMs === null) return true;
+  try {
+    const info = await stat(sessionJsonlPathFor(workspaceRoot, sessionId));
+    return info.mtimeMs > indexedMs;
+  } catch {
+    return false;
+  }
+}
+
 // --- session metadata ----------------------------------------------
 
 interface SessionMeta {
@@ -184,8 +233,17 @@ export async function indexSession(workspaceRoot: string, sessionId: string, dep
   const minInterval = deps.minIntervalMs ?? MIN_INDEX_INTERVAL_MS;
   const force = deps.force === true;
 
-  if (!force && (await isFresh(workspaceRoot, sessionId, now, minInterval))) {
-    return null;
+  if (!force) {
+    if (await isFresh(workspaceRoot, sessionId, now, minInterval)) {
+      return null;
+    }
+    // Second gate: even past the freshness window, if the jsonl has
+    // NOT been written since the last index there's no new content
+    // to summarize. Cuts idle scheduler tick cost from O(sessions)
+    // Claude CLI calls to O(actual updates) — see #1929.
+    if (!(await sessionJsonlChangedSinceIndex(workspaceRoot, sessionId))) {
+      return null;
+    }
   }
 
   const input = await loadJsonlInput(sessionJsonlPathFor(workspaceRoot, sessionId));

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -158,12 +158,15 @@ export async function isFresh(workspaceRoot: string, sessionId: string, now: num
 // actually saw a new turn.
 //
 // Return-value contract, for each unknown state:
+//  - Hostile / malformed sessionId → false (skip; something upstream
+//    handed us a value that could escape the chat dir via `..`).
 //  - Entry file missing/malformed → true (we've never captured this
 //    session; index it).
 //  - Jsonl file missing → false (nothing to reindex; the caller
 //    would return null downstream anyway, but we short-circuit).
 //  - Otherwise → jsonl mtime > entry.indexedAt.
 export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessionId: string): Promise<boolean> {
+  if (!isSafeSessionId(sessionId)) return false;
   let indexedMs: number | null = null;
   try {
     const raw = await readFile(indexEntryPathFor(workspaceRoot, sessionId), "utf-8");
@@ -185,6 +188,19 @@ export async function sessionJsonlChangedSinceIndex(workspaceRoot: string, sessi
   } catch {
     return false;
   }
+}
+
+// Path-traversal guard for session IDs used to derive on-disk paths.
+// Same shape as `server/api/bridge/sessionRole.ts`'s
+// `SAFE_SESSION_ID_RE` — kept local here so the workspace layer
+// doesn't need to reach uphill into the routes layer. Rejects any id
+// containing `..` (belt-and-suspenders — a whole-string `..` passes
+// the class alone) so `path.join(dir, "<id>.jsonl")` cannot escape
+// the chat dir even if a route handler forwards an unvalidated URL
+// param down to us.
+const SAFE_SESSION_ID_RE = /^[\w.-]{1,200}$/;
+function isSafeSessionId(sessionId: string): boolean {
+  return SAFE_SESSION_ID_RE.test(sessionId) && !sessionId.includes("..");
 }
 
 // --- session metadata ----------------------------------------------

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -419,6 +419,17 @@ describe("sessionJsonlChangedSinceIndex", () => {
     writeFileSync(indexEntryPathFor(workspace, "mtime-e"), JSON.stringify({ indexedAt: new Date(0).toISOString() }));
     assert.equal(await sessionJsonlChangedSinceIndex(workspace, "mtime-e"), false);
   });
+
+  it("returns false for a hostile sessionId (path-traversal guard)", async () => {
+    // The path-traversal guard runs BEFORE any file access, so a
+    // caller handing us `..` / `../etc/passwd` never opens a file
+    // outside the chat dir. Codeql flagged this in #1930 review;
+    // pin the behaviour here.
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, ".."), false);
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "foo..bar"), false);
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "a/b"), false);
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, ""), false);
+  });
 });
 
 describe("indexSession — content-unchanged skip (issue #1929)", () => {

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -1,10 +1,10 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { indexSession, readManifest, isFresh, MIN_INDEX_INTERVAL_MS } from "../../server/workspace/chat-index/indexer.js";
+import { indexSession, readManifest, isFresh, sessionJsonlChangedSinceIndex, MIN_INDEX_INTERVAL_MS } from "../../server/workspace/chat-index/indexer.js";
 import { indexEntryPathFor, manifestPathFor } from "../../server/workspace/chat-index/paths.js";
 import type { SummaryResult } from "../../server/workspace/chat-index/types.js";
 
@@ -368,5 +368,110 @@ describe("isFresh", () => {
     writeFileSync(indexEntryPathFor(workspace, "x"), JSON.stringify({ indexedAt: new Date(0).toISOString() }));
     const out = await isFresh(workspace, "x", MIN_INDEX_INTERVAL_MS + 1, MIN_INDEX_INTERVAL_MS);
     assert.equal(out, false);
+  });
+});
+
+describe("sessionJsonlChangedSinceIndex", () => {
+  // A workspace-local jsonl path built by mirroring `chatDirFor`
+  // (`conversations/chat`) — same shape the real indexer uses.
+  const jsonlPathFor = (sessionId: string) => join(workspace, CHAT_REL, `${sessionId}.jsonl`);
+  // Utility: freeze the jsonl mtime to a chosen seconds-since-epoch
+  // so the mtime comparison against `indexedAt` is deterministic
+  // instead of racing wall-clock disk timestamps.
+  const setJsonlMtime = async (sessionId: string, epochSeconds: number) => utimes(jsonlPathFor(sessionId), epochSeconds, epochSeconds);
+
+  it("returns true when no entry file exists (never indexed)", async () => {
+    seedSession("mtime-a");
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "mtime-a"), true);
+  });
+
+  it("returns true when the entry file is malformed", async () => {
+    seedSession("mtime-b");
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
+    writeFileSync(indexEntryPathFor(workspace, "mtime-b"), "{ not json");
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "mtime-b"), true);
+  });
+
+  it("returns false when jsonl mtime is older than the entry's indexedAt (content unchanged)", async () => {
+    seedSession("mtime-c");
+    // Freeze the jsonl at t=100ms (0.1s) so it can't be newer than
+    // the entry we stamp below at t=1000ms.
+    await setJsonlMtime("mtime-c", 0.1);
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
+    writeFileSync(indexEntryPathFor(workspace, "mtime-c"), JSON.stringify({ indexedAt: new Date(1000).toISOString() }));
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "mtime-c"), false);
+  });
+
+  it("returns true when jsonl mtime is newer than the entry's indexedAt (new turn arrived)", async () => {
+    seedSession("mtime-d");
+    // Jsonl bumped forward to t=2000s (2_000_000ms epoch), long after
+    // the entry we stamp at t=1000ms.
+    await setJsonlMtime("mtime-d", 2000);
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
+    writeFileSync(indexEntryPathFor(workspace, "mtime-d"), JSON.stringify({ indexedAt: new Date(1000).toISOString() }));
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "mtime-d"), true);
+  });
+
+  it("returns false when the jsonl is missing (nothing to reindex)", async () => {
+    // Entry file exists but no jsonl companion — an inconsistency
+    // that shouldn't happen at rest, but the helper must not throw.
+    mkdirSync(join(workspace, CHAT_REL, "index"), { recursive: true });
+    writeFileSync(indexEntryPathFor(workspace, "mtime-e"), JSON.stringify({ indexedAt: new Date(0).toISOString() }));
+    assert.equal(await sessionJsonlChangedSinceIndex(workspace, "mtime-e"), false);
+  });
+});
+
+describe("indexSession — content-unchanged skip (issue #1929)", () => {
+  const jsonlPathFor = (sessionId: string) => join(workspace, CHAT_REL, `${sessionId}.jsonl`);
+  const setJsonlMtime = async (sessionId: string, epochSeconds: number) => utimes(jsonlPathFor(sessionId), epochSeconds, epochSeconds);
+
+  it("skips a session whose jsonl mtime hasn't moved since the last index", async () => {
+    seedSession("skip-unchanged");
+    // Freeze jsonl mtime at 100ms so the first-index-at-1000ms entry
+    // guarantees jsonl.mtime <= indexedAt on the second call.
+    await setJsonlMtime("skip-unchanged", 0.1);
+    const stub = makeStubSummarize();
+
+    await indexSession(workspace, "skip-unchanged", { summarize: stub.fn, now: () => 1000 });
+    assert.equal(stub.calls.length, 1);
+
+    // Jump past the freshness window so isFresh returns false; the
+    // ONLY remaining reason to skip is the content-unchanged gate.
+    await indexSession(workspace, "skip-unchanged", { summarize: stub.fn, now: () => MIN_INDEX_INTERVAL_MS + 10_000 });
+    assert.equal(stub.calls.length, 1);
+  });
+
+  it("re-indexes a session whose jsonl mtime moved forward", async () => {
+    seedSession("resume-changed");
+    await setJsonlMtime("resume-changed", 0.1);
+    const stub = makeStubSummarize();
+
+    await indexSession(workspace, "resume-changed", { summarize: stub.fn, now: () => 1000 });
+    assert.equal(stub.calls.length, 1);
+
+    // Simulate a new turn: bump the jsonl mtime past the entry's
+    // indexedAt. Time-jump past the freshness window too so this
+    // isn't just testing isFresh.
+    await setJsonlMtime("resume-changed", 5000);
+    await indexSession(workspace, "resume-changed", { summarize: stub.fn, now: () => MIN_INDEX_INTERVAL_MS + 10_000 });
+    assert.equal(stub.calls.length, 2);
+  });
+
+  it("force: true bypasses the content-unchanged gate", async () => {
+    seedSession("force-through");
+    await setJsonlMtime("force-through", 0.1);
+    const stub = makeStubSummarize();
+
+    await indexSession(workspace, "force-through", { summarize: stub.fn, now: () => 1000 });
+    assert.equal(stub.calls.length, 1);
+
+    // Jsonl still at 100ms — content-unchanged gate would skip, but
+    // force says "regenerate anyway".
+    await indexSession(workspace, "force-through", {
+      summarize: stub.fn,
+      now: () => MIN_INDEX_INTERVAL_MS + 10_000,
+      force: true,
+    });
+    assert.equal(stub.calls.length, 2);
   });
 });

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -432,6 +432,48 @@ describe("sessionJsonlChangedSinceIndex", () => {
   });
 });
 
+describe("indexSession — hostile sessionId is rejected (defence-in-depth)", () => {
+  // Codex review on #1930: the sanitizer was previously only wired
+  // into `sessionJsonlChangedSinceIndex`. `indexSession` still fed
+  // raw `sessionId` into `readSessionMeta` / `writeJsonAtomic` /
+  // `loadJsonlInput`, and `force: true` short-circuited the one
+  // helper that WAS guarded. Sanitize once at the public entry —
+  // and force MUST NOT bypass — so any of those downstream sinks
+  // is safe even against a hostile caller.
+
+  it("returns null for `..` (traversal via basename mismatch)", async () => {
+    const stub = makeStubSummarize();
+    const result = await indexSession(workspace, "..", { summarize: stub.fn, now: () => 0 });
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("returns null for a slash-containing id (would escape the chat dir)", async () => {
+    const stub = makeStubSummarize();
+    const result = await indexSession(workspace, "a/b", { summarize: stub.fn, now: () => 0 });
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("returns null for `foo..bar` (basename passes, `..`-substring rejects)", async () => {
+    const stub = makeStubSummarize();
+    const result = await indexSession(workspace, "foo..bar", { summarize: stub.fn, now: () => 0 });
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("force: true does NOT bypass the sanitizer", async () => {
+    const stub = makeStubSummarize();
+    const result = await indexSession(workspace, "../evil", {
+      summarize: stub.fn,
+      now: () => 0,
+      force: true,
+    });
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0);
+  });
+});
+
 describe("indexSession — content-unchanged skip (issue #1929)", () => {
   const jsonlPathFor = (sessionId: string) => join(workspace, CHAT_REL, `${sessionId}.jsonl`);
   const setJsonlMtime = async (sessionId: string, epochSeconds: number) => utimes(jsonlPathFor(sessionId), epochSeconds, epochSeconds);

--- a/test/chat-index/test_maybe_index_session.ts
+++ b/test/chat-index/test_maybe_index_session.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { maybeIndexSession, backfillAllSessions, __resetForTests } from "../../server/workspace/chat-index/index.js";
@@ -328,11 +328,69 @@ describe("backfillAllSessions", () => {
     assert.equal(stub.calls, 1);
 
     // Second pass via backfill with the same now() — a normal
-    // maybeIndexSession call would be skipped by freshness, but
-    // backfill sets force: true.
+    // maybeIndexSession call would be skipped by freshness. After
+    // #1929, backfill no longer forces by default (the hourly
+    // scheduler tick would otherwise re-summarise every session on
+    // every tick); opt in explicitly here so the test still
+    // exercises the force path.
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
       deps: { summarize: stub.fn, now: () => 0 },
+      force: true,
+    });
+    assert.equal(result.indexed, 1);
+    assert.equal(stub.calls, 2);
+  });
+
+  it("without force, skips sessions whose jsonl hasn't been touched since the last index (#1929)", async () => {
+    seedSession("cold-1");
+    // Pin the jsonl mtime BEFORE the first index runs. If the mtime
+    // ended up newer than `indexedAt` (real wall clock), the
+    // content-changed gate would fire on the second backfill.
+    await utimes(join(workspace, CHAT_REL, "cold-1.jsonl"), 0.1, 0.1);
+
+    const stub = stubSummarize();
+
+    // Prime the index once via a forced backfill.
+    await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 1000 },
+      force: true,
+    });
+    assert.equal(stub.calls, 1);
+
+    // Simulate the next scheduler tick an hour later — jsonl mtime
+    // hasn't moved, so nothing should be re-summarised. Without the
+    // #1929 fix this would fire another CLI call.
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 1000 + 60 * 60 * 1000 },
+    });
+    assert.equal(result.indexed, 0);
+    assert.equal(result.skipped, 1);
+    assert.equal(stub.calls, 1);
+  });
+
+  it("without force, re-indexes sessions whose jsonl mtime moved forward (#1929)", async () => {
+    seedSession("warm-2");
+    await utimes(join(workspace, CHAT_REL, "warm-2.jsonl"), 0.1, 0.1);
+
+    const stub = stubSummarize();
+
+    await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 1000 },
+      force: true,
+    });
+    assert.equal(stub.calls, 1);
+
+    // Simulate a new turn landing: bump jsonl mtime past the entry's
+    // `indexedAt`. A non-force backfill should now pick it up.
+    await utimes(join(workspace, CHAT_REL, "warm-2.jsonl"), 5000, 5000);
+
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { summarize: stub.fn, now: () => 1000 + 60 * 60 * 1000 },
     });
     assert.equal(result.indexed, 1);
     assert.equal(stub.calls, 2);


### PR DESCRIPTION
## Summary

Stops the hourly chat-index scheduler from re-summarising every session on every tick. Adds a content-changed gate (jsonl mtime > entry \`indexedAt\`) alongside the existing 15-min \`isFresh\` throttle, and promotes the previously-hardcoded \`force: true\` on \`backfillAllSessions()\` to an opt-in option so only the manual rebuild endpoint and the startup switch pass it.

Per user follow-up, the scheduler cadence also relaxes from 1h → 6h — see "Scheduler cadence" below.

Closes #1929.

## Items to Confirm / Review

- **Gate order and semantics inside \`indexSession\`.** When \`force\` is false, we run \`isFresh\` first (15-min throttle for active conversations), then \`sessionJsonlChangedSinceIndex\` (skip if the jsonl mtime is not newer than \`indexedAt\`). \`force: true\` bypasses BOTH throttles but does NOT bypass the path-safety sanitizer (Codex review — force is a debug knob, not an escape hatch).
- **\`backfillAllSessions\` default is now non-force.** Scheduled tick uses the default, matching the scheduler task description ("Generate AI titles + summaries for un-indexed sessions"). Manual endpoint (\`POST /api/chat-index/rebuild\`) and \`CHAT_INDEX_FORCE_RUN_ON_STARTUP=1\` opt in explicitly.
- **Session-id sanitizer covers every file-access sink.** \`safeSessionIdOrNull\` (basename + character class + \`..\` explicit reject) is called at every public entry in \`indexer.ts\` and on every value flowing out of \`readdir\` in \`listSessionIds\`. Verified by hostile-id regression tests including \`indexSession(dir, "../evil", { force: true })\` returning null without touching disk.
- **Shared parse helper.** \`readIndexedAtMs\` is the single canonical read of \`entry.indexedAt\`; \`isFresh\` and \`sessionJsonlChangedSinceIndex\` delegate to it. CodeRabbit follow-up.
- **Scheduler cadence 1h → 6h.** #1929's content-changed gate makes the per-tick cost O(stat + entry read) for unchanged sessions — nearly free — so the interval now determines only "how quickly we catch strays" (server-crash mid-turn, out-of-band jsonl writes, throttle-skipped final turns after a conversation goes idle). At 6h max staleness is bounded to \`15 min + 6h\`, and the agent finally-hook still updates any session the user actually revisits. User-approved as part of this PR (see conversation trail). Users who want a different cadence can override via the scheduler-overrides mechanism the runtime already exposes.

## User prompts

> [logs] \`[chat-index] indexed\` が出過ぎにみえる。更新ないものはupdateしなくてよいのでもっと減るべきに見えるけど。。。
>
> これってどれくらいの間隔で定期実行？
>
> [after presenting the tradeoffs of 1h / 6h / 24h] 6時間

## Root cause

\`server/workspace/chat-index/index.ts\` (pre-fix) passed \`force: true\` to every \`indexSession()\` call inside the backfill loop. \`force: true\` bypassed the 15-min \`isFresh\` throttle — the ONLY skip logic \`indexSession\` had. Nothing checked whether the underlying jsonl had actually changed since the last index, so the hourly scheduler tick spent N Claude CLI calls and emitted N \`[chat-index] indexed\` log lines on a workspace with N sessions, regardless of activity.

## Implementation

### \`server/workspace/chat-index/indexer.ts\`
- New \`sessionJsonlChangedSinceIndex(workspaceRoot, sessionId)\` — reads entry file, extracts \`indexedAt\`, stats the jsonl, returns true iff jsonl mtime > indexedAt (with defined behaviour on missing / malformed files).
- New \`readIndexedAtMs\` — shared entry-file parse; \`isFresh\` and \`sessionJsonlChangedSinceIndex\` delegate.
- \`indexSession\` gates on both \`isFresh\` (existing) AND \`sessionJsonlChangedSinceIndex\` (new), both under \`!force\`.
- \`safeSessionIdOrNull\` (\`path.basename\` barrier + \`SAFE_SESSION_ID_RE\` + \`..\` reject) — CodeQL-recognised sanitizer applied at every public entry point, including the readdir output of \`listSessionIds\`. \`force\` does NOT bypass.

### \`server/workspace/chat-index/index.ts\`
- \`backfillAllSessions\` accepts \`force?: boolean\` (default false). Removes the hardcoded \`force: true\`.

### Callers
- \`server/index.ts\` startup switch: passes \`{ force: true }\`.
- \`server/api/routes/chat-index.ts\` manual endpoint: passes \`{ force: true }\`.

### Scheduler cadence
- \`system:chat-index\` \`intervalMs: ONE_HOUR_MS\` → \`6 * ONE_HOUR_MS\`. See "Items to Confirm" above.

## Tests

\`test/chat-index/test_indexer.ts\`:
- \`sessionJsonlChangedSinceIndex\`: no entry / malformed / unchanged / changed / missing jsonl / hostile-id.
- \`indexSession\` content-unchanged: skip / re-index / \`force\` bypasses throttle.
- \`indexSession\` hostile-id: \`..\`, \`a/b\`, \`foo..bar\`, \`../evil\` under \`force: true\` — all return null without touching disk.

\`test/chat-index/test_maybe_index_session.ts\`:
- Existing \`force\` test updated to pass \`{ force: true }\` explicitly to \`backfillAllSessions\`.
- \`backfillAllSessions\` without force: skips unchanged / re-indexes on mtime bump.

All 40 pre-existing tests still green; 5 new hostile-id cases added.

## Verification

- \`yarn format\`, \`yarn lint\`, \`yarn typecheck\`, \`yarn build\`, \`yarn test\` — all green.
- Focused: \`tsx --test test/chat-index/*\` → 45/45 pass.

## Test plan

- [ ] Restart the server on a workspace with many existing sessions. On the next scheduler tick, watch the \`[chat-index]\` log: should emit \`indexed\` only for sessions with new turns since the last index.
- [ ] Hit \`POST /api/chat-index/rebuild\` manually — expect all sessions to re-summarise.
- [ ] Set \`CHAT_INDEX_FORCE_RUN_ON_STARTUP=1\` and restart — expect the full backfill to run once at boot, then subsequent scheduler ticks to go quiet.
- [ ] Confirm the 6h scheduler cadence is acceptable for your workspace / usage pattern; use the scheduler-overrides mechanism if you want it different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat session indexing to skip reprocessing when a session’s content hasn’t changed since the last index.
  * Reduced repeated summarization work by adding an additional “content unchanged” check alongside existing freshness logic.
  * Hardened chat indexing against malformed or hostile session identifiers to prevent incorrect filesystem reads/writes.
* **Tests**
  * Expanded coverage for the new change-detection behavior and identifier safety, including deterministic modification-time scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->