### PR TITLE
feat(remote-view): writable mobile custom views — update/delete (phase 4)

### DIFF
--- a/packages/core/assets/helps/custom-view-remote.md
+++ b/packages/core/assets/helps/custom-view-remote.md
@@ -27,8 +27,11 @@ Same place as desktop views — the HTML lives under `views/` and must end in
   desktop view and is never served to the phone.
 - `id` / `label` / `icon` / `i18n` — as for desktop views. The selector icon
   defaults to `smartphone`.
-- **No `capabilities`** — remote views are **read-only** in this phase. There
-  is no write path; a button that should _do_ something uses `startChat`.
+- **Read-only by default.** A view with no `editableFields` and no `allowDelete`
+  cannot mutate anything — its `updateItem` / `deleteItem` reject. Declare a
+  write surface only when the user asks the view to _change_ data (toggle a
+  checkbox, delete a row); see **Writing records** below. For anything more
+  open-ended (compose a message, kick off a task) use `startChat`.
 
 Feed collections register theirs in `feeds/<slug>/schema.json` with the HTML
 at `feeds/<slug>/views/<name>.html`, like desktop views.
@@ -52,16 +55,20 @@ window.__MC_VIEW = {
   slug: "annual-plan", // this collection
   locale: "en", // active app locale ("" when no translations)
   target: "mobile",
-  protocol: 1,
+  protocol: 2,
+  writable: false, // true iff the view declared editableFields / allowDelete
   getItems: (opts) => Promise, // the ONLY way to read records — see below
+  updateItem: (id, patch) => Promise, // patch declared fields (see Writing records)
+  deleteItem: (id) => Promise, // remove a record (requires allowDelete)
   startChat: (prompt, role) => void, // draft a new chat for the user
   t: (key, named) => string, // vue-i18n-style dict lookup (same as desktop)
 };
 ```
 
 What is deliberately **absent** compared to the desktop contract: `token`,
-`dataUrl` (nothing to fetch), `onChange` (no live refresh yet — render on
-load), and `openItem` (no host record panel on the phone yet).
+`dataUrl` (nothing to fetch), `onChange` (no live refresh yet — re-call
+`getItems` after a mutate resolves), and `openItem` (no host record panel on
+the phone yet).
 
 ### Reading records — `getItems` (paginated, always)
 
@@ -86,6 +93,51 @@ const page = await window.__MC_VIEW.getItems({
   resolved** (e.g. `won * 3 + drawn`). Formulas that dereference a `ref`
   field, and `embed` fields, are NOT resolved on the phone — don't rely on
   them; compute from base fields or omit.
+
+### Writing records — `updateItem` / `deleteItem`
+
+A remote view may **change** data too — flip a todo's `done`, edit a status,
+delete a row — but only within a surface the view **declares** and the host
+**enforces**. Nothing is writable by default.
+
+**1. Declare the surface** in the `views[]` entry:
+
+```jsonc
+{
+  "id": "phone",
+  "label": "Todos",
+  "target": "mobile",
+  "file": "views/phone.html",
+  "editableFields": ["done"], // ONLY these fields may be patched
+  "allowDelete": true, // omit / false ⇒ deleteItem is refused
+}
+```
+
+**2. Call the methods** (both resolve/reject like `getItems`):
+
+```js
+const { item } = await window.__MC_VIEW.updateItem(id, { done: true });
+// patch is a partial record; the host merges it onto the stored record and
+// returns the merged { item }.
+
+const { id: removed } = await window.__MC_VIEW.deleteItem(id);
+```
+
+- **The host is the authority, not the view.** Every mutate is re-checked
+  server-side: a patch key not in `editableFields` (or the primary key) is
+  **refused**; `deleteItem` without `allowDelete` is **refused**. The promise
+  rejects with the reason — surface it. Declaring the surface honestly is how
+  you keep the blast radius small.
+- **No `writable` declaration ⇒ the methods reject** (`"this view is
+  read-only"`). Check `window.__MC_VIEW.writable` before showing edit affordances
+  if you want to degrade gracefully.
+- **`editableFields` never includes the primary key** — a record's id is fixed.
+- **Re-render after a mutate resolves.** There is no live `onChange` yet: either
+  optimistically update your local copy from the returned `item`, or re-call
+  `getItems` to refetch. The preview's real write also refreshes the desktop
+  collection, so you see the true result while iterating.
+- **Create is not available** in this phase — `updateItem` only patches an
+  existing record; use `startChat` to ask the agent to add a new one.
 
 ### Starting a chat — `startChat`
 
@@ -293,4 +345,85 @@ A phone-first record list: single column, 44px+ tap targets, paginated through
     </script>
   </body>
 </html>
+```
+
+## Example — writable todo (toggle `done`, delete)
+
+A phone-first todo list that **checks off** and **deletes** records. Schema has
+`title` (string) and `done` (boolean). Registration declares the write surface:
+`{ "id": "phone", "label": "Todos", "target": "mobile", "file": "views/phone.html", "editableFields": ["done"], "allowDelete": true }`.
+
+The core of `views/phone.html` (styles/`<head>` as above):
+
+```html
+<div id="list"></div>
+<script>
+  var items = [];
+
+  function row(item) {
+    var el = document.createElement("div");
+    el.className = "card";
+    el.innerHTML =
+      '<label class="meta"><input type="checkbox" data-toggle="' +
+      item.id +
+      '"' +
+      (item.done ? " checked" : "") +
+      ' style="width:22px;height:22px"><b></b>' +
+      '<button class="chat" data-del="' +
+      item.id +
+      '" style="margin-left:auto">Delete</button></label>';
+    el.querySelector("b").textContent = item.title || item.id;
+    if (item.done) el.style.opacity = 0.5;
+    return el;
+  }
+
+  function render() {
+    var list = document.getElementById("list");
+    list.innerHTML = "";
+    items.forEach(function (item) {
+      list.appendChild(row(item));
+    });
+  }
+
+  async function load() {
+    var page = await window.__MC_VIEW.getItems({ offset: 0, limit: 200, fields: ["title", "done"] });
+    items = page.items;
+    render();
+  }
+
+  document.getElementById("list").addEventListener("change", async function (e) {
+    var id = e.target.dataset.toggle;
+    if (!id) return;
+    try {
+      // Host merges the patch and returns the merged record; reflect it.
+      var res = await window.__MC_VIEW.updateItem(id, { done: e.target.checked });
+      var i = items.findIndex(function (r) {
+        return String(r.id) === id;
+      });
+      if (i >= 0) items[i] = res.item;
+      render();
+    } catch (err) {
+      e.target.checked = !e.target.checked; // revert on refusal
+      alert(err.message);
+    }
+  });
+
+  document.getElementById("list").addEventListener("click", async function (e) {
+    var id = e.target.dataset.del;
+    if (!id) return;
+    try {
+      await window.__MC_VIEW.deleteItem(id);
+      items = items.filter(function (r) {
+        return String(r.id) !== id;
+      });
+      render();
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+
+  load().catch(function (err) {
+    document.getElementById("list").innerHTML = '<div class="err">' + err.message + "</div>";
+  });
+</script>
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client and ./remote-view entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client and ./remote-view entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -247,6 +247,15 @@ export interface CollectionCustomView {
    *  (`@mulmoclaude/core/remote-view` — no token, `connect-src 'none'`) and
    *  previewed on desktop inside a phone-sized frame. */
   target?: "desktop" | "mobile";
+  /** **Mobile-only** (ignored for desktop views, which use token-scoped
+   *  `capabilities`). The whitelist of field names a `target: "mobile"` view
+   *  may patch via `__MC_VIEW.updateItem(id, patch)`. Default-deny: absent or
+   *  empty ⇒ updates are refused host-side. Never include the primary key.
+   *  See plans/feat-remote-writable-view.md. */
+  editableFields?: string[];
+  /** **Mobile-only.** When `true`, a `target: "mobile"` view may remove a
+   *  record via `__MC_VIEW.deleteItem(id)`. Absent/`false` ⇒ deletes refused. */
+  allowDelete?: boolean;
 }
 
 /** A schema-declared, per-record action rendered as a button in the

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -245,6 +245,13 @@ const CustomViewSchema = z.object({
     )
     .optional(),
   capabilities: z.array(z.enum(["read", "write"])).optional(),
+  // Mobile-only write policy (plans/feat-remote-writable-view.md). Default-deny:
+  // a `target: "mobile"` view may patch ONLY these fields via
+  // `__MC_VIEW.updateItem`, and may delete only when `allowDelete` is true. The
+  // host re-derives + enforces both on every mutate — never trusting the client.
+  // Ignored for desktop views (they use the token-scoped `capabilities` above).
+  editableFields: z.array(z.string().trim().min(1)).optional(),
+  allowDelete: z.boolean().optional(),
 });
 
 // Recurrence advance for `spawn.every`. `interval` is a positive integer

--- a/packages/core/src/remote-view/index.ts
+++ b/packages/core/src/remote-view/index.ts
@@ -9,8 +9,10 @@
 // CSP locks `connect-src` to 'none' entirely.
 
 /** Bump when the bootstrap/message contract changes shape; the bootstrap
- *  exposes it as `__MC_VIEW.protocol` so a parent can refuse a stale view. */
-export const REMOTE_VIEW_PROTOCOL = 1;
+ *  exposes it as `__MC_VIEW.protocol` so a parent can refuse a stale view.
+ *  v2 (phase 4) adds the mutate pair below — a backward-compatible superset,
+ *  so a v1 (read-only) parent still serves get-items/start-chat unchanged. */
+export const REMOTE_VIEW_PROTOCOL = 2;
 
 /** postMessage types between the sandboxed view and its parent page.
  *  `startChat` reuses the desktop custom-view message type on purpose — the
@@ -20,6 +22,10 @@ export const REMOTE_VIEW_MESSAGES = {
   getItems: "mc-remote-get-items",
   /** parent → view: the reply ({ requestId, ok, page | error }). */
   items: "mc-remote-items",
+  /** view → parent: mutate one record ({ requestId, op: "update"|"delete", id, patch? }). */
+  mutate: "mc-remote-mutate",
+  /** parent → view: the mutate reply ({ requestId, ok, result | error }). */
+  mutateResult: "mc-remote-mutate-result",
   /** view → parent: open a new chat with a prefilled, NOT auto-sent draft. */
   startChat: "mc-start-chat",
 } as const;
@@ -144,13 +150,21 @@ export function buildRemoteViewCsp(cdns: readonly string[] = SANDBOXED_VIEW_CDN_
 
 /** The in-iframe bootstrap installed before any of the view's own scripts.
  *  Owns the fiddly part of the contract — request/response correlation — so an
- *  LLM-authored view only ever awaits `__MC_VIEW.getItems(...)`:
+ *  LLM-authored view only ever awaits `__MC_VIEW.getItems(...)` /
+ *  `.updateItem(...)` / `.deleteItem(...)`:
  *
  *  - `getItems({ offset, limit, fields })`: posts an `mc-remote-get-items`
  *    with a fresh `requestId`, resolves on the matching `mc-remote-items`
  *    reply (validated to come from `window.parent`), rejects on `ok: false`
  *    or after 30 s. targetOrigin `'*'` is safe: the request carries no secret
  *    and the parent is by construction the party supplying the data.
+ *  - `updateItem(id, patch)` / `deleteItem(id)` (phase 4): post an
+ *    `mc-remote-mutate` and resolve on the matching `mc-remote-mutate-result`,
+ *    sharing the same `call()` correlation as `getItems`. Installed ONLY when
+ *    the host set `writable` (the view declared `editableFields`/`allowDelete`);
+ *    otherwise both reject `"this view is read-only"` so a mis-declared view
+ *    fails loudly instead of silently no-op'ing. The HOST still re-derives and
+ *    enforces the write policy — `writable` only gates the client surface.
  *  - `startChat(prompt, role)`: same message type + semantics as the desktop
  *    bridge — the parent opens a new chat with `prompt` prefilled as an
  *    editable draft, never auto-sent.
@@ -160,7 +174,7 @@ export function buildRemoteViewCsp(cdns: readonly string[] = SANDBOXED_VIEW_CDN_
  *  Self-contained one-line string (no `<`, no `</script>`, `${}` only for the
  *  interpolated constants). */
 function remoteViewBootstrap(): string {
-  return `(function(){var v=window.__MC_VIEW,seq=0,pend={};window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='${REMOTE_VIEW_MESSAGES.items}')return;var p=pend[d.requestId];if(!p)return;delete pend[d.requestId];clearTimeout(p.timer);if(d.ok)p.resolve(d.page);else p.reject(new Error(typeof d.error==='string'?d.error:'load failed'));});v.getItems=function(opts){opts=opts&&typeof opts==='object'?opts:{};return new Promise(function(resolve,reject){var id='q'+(++seq);var timer=setTimeout(function(){delete pend[id];reject(new Error('getItems timed out'));},${GET_ITEMS_TIMEOUT_MS});pend[id]={resolve:resolve,reject:reject,timer:timer};window.parent.postMessage({type:'${REMOTE_VIEW_MESSAGES.getItems}',slug:v.slug,requestId:id,offset:opts.offset,limit:opts.limit,fields:opts.fields},'*');});};v.startChat=function(prompt,role){window.parent.postMessage({type:'${REMOTE_VIEW_MESSAGES.startChat}',slug:v.slug,prompt:String(prompt),role:typeof role==='string'?role:undefined},'*');};v.dict=v.dict||{};v.t=function(key,named){var s=v.dict[key];if(typeof s!=='string')return typeof key==='string'?key:String(key);if(!named||typeof named!=='object')return s;return s.replace(/\\{(\\w+)\\}/g,function(m,n){var x=named[n];return x==null?m:String(x);});};})();`;
+  return `(function(){var v=window.__MC_VIEW,seq=0,pend={};window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d)return;if(d.type!=='${REMOTE_VIEW_MESSAGES.items}'&&d.type!=='${REMOTE_VIEW_MESSAGES.mutateResult}')return;var p=pend[d.requestId];if(!p)return;delete pend[d.requestId];clearTimeout(p.timer);if(d.ok)p.resolve(d.type==='${REMOTE_VIEW_MESSAGES.items}'?d.page:d.result);else p.reject(new Error(typeof d.error==='string'?d.error:'request failed'));});function call(type,payload){return new Promise(function(resolve,reject){var id='q'+(++seq);var timer=setTimeout(function(){delete pend[id];reject(new Error(type+' timed out'));},${GET_ITEMS_TIMEOUT_MS});pend[id]={resolve:resolve,reject:reject,timer:timer};var m={type:type,slug:v.slug,requestId:id};for(var k in payload){m[k]=payload[k];}window.parent.postMessage(m,'*');});}v.getItems=function(opts){opts=opts&&typeof opts==='object'?opts:{};return call('${REMOTE_VIEW_MESSAGES.getItems}',{offset:opts.offset,limit:opts.limit,fields:opts.fields});};if(v.writable){v.updateItem=function(id,patch){return call('${REMOTE_VIEW_MESSAGES.mutate}',{op:'update',id:String(id),patch:patch&&typeof patch==='object'?patch:{}});};v.deleteItem=function(id){return call('${REMOTE_VIEW_MESSAGES.mutate}',{op:'delete',id:String(id)});};}else{v.updateItem=v.deleteItem=function(){return Promise.reject(new Error('this view is read-only'));};}v.startChat=function(prompt,role){window.parent.postMessage({type:'${REMOTE_VIEW_MESSAGES.startChat}',slug:v.slug,prompt:String(prompt),role:typeof role==='string'?role:undefined},'*');};v.dict=v.dict||{};v.t=function(key,named){var s=v.dict[key];if(typeof s!=='string')return typeof key==='string'?key:String(key);if(!named||typeof named!=='object')return s;return s.replace(/\\{(\\w+)\\}/g,function(m,n){var x=named[n];return x==null?m:String(x);});};})();`;
 }
 
 /** What the host injects into `window.__MC_VIEW` — note what is ABSENT
@@ -172,6 +186,10 @@ export interface RemoteViewBoot {
   /** Host-picked, locale-filtered flat string map (same contract as the
    *  desktop custom-view dict). */
   dict?: Record<string, string>;
+  /** True when the view declared a mutable surface (`editableFields` and/or
+   *  `allowDelete`). Gates the client-side `updateItem`/`deleteItem` install
+   *  only — the host re-enforces the actual policy on every mutate. */
+  writable?: boolean;
 }
 
 /** Wrap a view's HTML into the sandboxed srcdoc: CSP meta + `__MC_VIEW` boot +
@@ -188,12 +206,26 @@ export function buildRemoteViewSrcdoc(html: string, boot: RemoteViewBoot): strin
     dict: boot.dict ?? {},
     target: "mobile",
     protocol: REMOTE_VIEW_PROTOCOL,
+    writable: boot.writable ?? false,
   }).replace(/</g, "\\u003c");
   const injection = `${cspMeta}<script>window.__MC_VIEW=${json};${remoteViewBootstrap()}</script>`;
   if (/<head\b[^>]*>/i.test(html)) {
     return html.replace(/(<head\b[^>]*>)/i, `$1${injection}`);
   }
   return `<!DOCTYPE html><html><head>${injection}</head><body>${html}</body></html>`;
+}
+
+/** A normalized mutate request handed to a parent's `onMutate`
+ *  (`handleRemoteViewMessage` validates op/id/patch first). `update` carries a
+ *  partial record; the HOST decides which keys are actually writable. */
+export type RemoteViewMutateRequest = { op: "update"; id: string; patch: Record<string, unknown> } | { op: "delete"; id: string };
+
+/** The resolved value of a mutate: the merged record for an update, the removed
+ *  id for a delete. Sent back to the view as the `mc-remote-mutate-result`
+ *  `result`. */
+export interface RemoteViewMutateResult {
+  item?: RemoteViewItem;
+  id?: string;
 }
 
 /** What a parent page provides to answer the sandboxed view. Deliberately
@@ -203,8 +235,26 @@ export interface RemoteViewBridgeHandlers {
   slug: string;
   /** Answer one normalized page request (already clamped + fields-cleaned). */
   getPage: (request: RemoteViewPageRequest) => Promise<RemoteViewPage> | RemoteViewPage;
+  /** Apply one normalized mutate (update/delete). Omit on a read-only parent —
+   *  the handler then replies `ok: false, "this view is read-only"`. The parent
+   *  forwards to the host (which enforces the write policy authoritatively). */
+  onMutate?: (request: RemoteViewMutateRequest) => Promise<RemoteViewMutateResult> | RemoteViewMutateResult;
   /** Relay a `startChat` draft; omit on a parent without a chat surface. */
   onStartChat?: (prompt: string, role?: string) => void;
+}
+
+/** Coerce an untyped `mc-remote-mutate` payload to a normalized request, or
+ *  null when it is malformed (unknown op, missing id, non-object update patch —
+ *  the parent then replies with an `"invalid mutate request"` error). */
+export function normalizeMutate(data: { op?: unknown; id?: unknown; patch?: unknown }): RemoteViewMutateRequest | null {
+  const itemId = typeof data.id === "string" ? data.id : typeof data.id === "number" && Number.isFinite(data.id) ? String(data.id) : "";
+  if (!itemId) return null;
+  if (data.op === "delete") return { op: "delete", id: itemId };
+  if (data.op === "update") {
+    if (typeof data.patch !== "object" || data.patch === null || Array.isArray(data.patch)) return null;
+    return { op: "update", id: itemId, patch: data.patch as Record<string, unknown> };
+  }
+  return null;
 }
 
 async function answerGetItems(requestId: string, request: RemoteViewPageRequest, handlers: RemoteViewBridgeHandlers, reply: RemoteViewReply): Promise<void> {
@@ -213,6 +263,19 @@ async function answerGetItems(requestId: string, request: RemoteViewPageRequest,
     reply({ type: REMOTE_VIEW_MESSAGES.items, requestId, ok: true, page });
   } catch (err) {
     reply({ type: REMOTE_VIEW_MESSAGES.items, requestId, ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function answerMutate(requestId: string, request: RemoteViewMutateRequest, handlers: RemoteViewBridgeHandlers, reply: RemoteViewReply): Promise<void> {
+  if (!handlers.onMutate) {
+    reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId, ok: false, error: "this view is read-only" });
+    return;
+  }
+  try {
+    const result = await handlers.onMutate(request);
+    reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId, ok: true, result });
+  } catch (err) {
+    reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId, ok: false, error: err instanceof Error ? err.message : String(err) });
   }
 }
 
@@ -235,6 +298,9 @@ export async function handleRemoteViewMessage(data: unknown, handlers: RemoteVie
     offset?: unknown;
     limit?: unknown;
     fields?: unknown;
+    op?: unknown;
+    id?: unknown;
+    patch?: unknown;
     prompt?: unknown;
     role?: unknown;
   };
@@ -242,6 +308,15 @@ export async function handleRemoteViewMessage(data: unknown, handlers: RemoteVie
   if (msg.type === REMOTE_VIEW_MESSAGES.startChat) {
     const prompt = typeof msg.prompt === "string" ? msg.prompt.trim() : "";
     if (prompt) handlers.onStartChat?.(prompt, typeof msg.role === "string" ? msg.role : undefined);
+    return true;
+  }
+  if (msg.type === REMOTE_VIEW_MESSAGES.mutate && typeof msg.requestId === "string") {
+    const request = normalizeMutate(msg);
+    if (!request) {
+      reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: msg.requestId, ok: false, error: "invalid mutate request" });
+      return true;
+    }
+    await answerMutate(msg.requestId, request, handlers, reply);
     return true;
   }
   if (msg.type !== REMOTE_VIEW_MESSAGES.getItems || typeof msg.requestId !== "string") return false;

--- a/packages/core/src/remote-view/index.ts
+++ b/packages/core/src/remote-view/index.ts
@@ -266,7 +266,20 @@ async function answerGetItems(requestId: string, request: RemoteViewPageRequest,
   }
 }
 
-async function answerMutate(requestId: string, request: RemoteViewMutateRequest, handlers: RemoteViewBridgeHandlers, reply: RemoteViewReply): Promise<void> {
+/** Validate + dispatch a `mc-remote-mutate` payload, replying on every path
+ *  (malformed request, read-only parent, handler success/throw). Split out of
+ *  `handleRemoteViewMessage` so that function stays under the 20-line limit. */
+async function answerMutate(
+  requestId: string,
+  msg: { op?: unknown; id?: unknown; patch?: unknown },
+  handlers: RemoteViewBridgeHandlers,
+  reply: RemoteViewReply,
+): Promise<void> {
+  const request = normalizeMutate(msg);
+  if (!request) {
+    reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId, ok: false, error: "invalid mutate request" });
+    return;
+  }
   if (!handlers.onMutate) {
     reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId, ok: false, error: "this view is read-only" });
     return;
@@ -311,12 +324,7 @@ export async function handleRemoteViewMessage(data: unknown, handlers: RemoteVie
     return true;
   }
   if (msg.type === REMOTE_VIEW_MESSAGES.mutate && typeof msg.requestId === "string") {
-    const request = normalizeMutate(msg);
-    if (!request) {
-      reply({ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: msg.requestId, ok: false, error: "invalid mutate request" });
-      return true;
-    }
-    await answerMutate(msg.requestId, request, handlers, reply);
+    await answerMutate(msg.requestId, msg, handlers, reply);
     return true;
   }
   if (msg.type !== REMOTE_VIEW_MESSAGES.getItems || typeof msg.requestId !== "string") return false;

--- a/packages/core/test/remote-view/test_remote_view.ts
+++ b/packages/core/test/remote-view/test_remote_view.ts
@@ -13,8 +13,10 @@ import {
   clampOffset,
   handleRemoteViewMessage,
   normalizeFields,
+  normalizeMutate,
   pageFromItems,
   projectItems,
+  type RemoteViewMutateRequest,
 } from "../../src/remote-view/index.js";
 
 describe("buildRemoteViewCsp", () => {
@@ -47,6 +49,21 @@ describe("buildRemoteViewSrcdoc", () => {
     const srcdoc = buildRemoteViewSrcdoc("<p>hi</p>", { slug: "x" });
     assert.match(srcdoc, /^<!DOCTYPE html><html><head>/);
     assert.match(srcdoc, /<body><p>hi<\/p><\/body>/);
+  });
+
+  it("carries protocol 2 and defaults writable:false; installs mutators only when writable", () => {
+    const readOnlyBoot = buildRemoteViewSrcdoc("<html><head></head></html>", { slug: "x" });
+    assert.match(readOnlyBoot, new RegExp(`"protocol":${REMOTE_VIEW_PROTOCOL}`));
+    assert.equal(REMOTE_VIEW_PROTOCOL, 2);
+    assert.match(readOnlyBoot, /"writable":false/);
+    // Read-only boot: the mutators reject rather than post.
+    assert.match(readOnlyBoot, /this view is read-only/);
+
+    const writableBoot = buildRemoteViewSrcdoc("<html><head></head></html>", { slug: "x", writable: true });
+    assert.match(writableBoot, /"writable":true/);
+    // Writable boot still ships the read-only fallback string in the (untaken)
+    // else branch — assert the mutate wiring is present instead.
+    assert.match(writableBoot, new RegExp(REMOTE_VIEW_MESSAGES.mutate));
   });
 
   it("escapes `<` in the boot JSON so a hostile dict value can't break out", () => {
@@ -158,5 +175,79 @@ describe("handleRemoteViewMessage", () => {
     assert.equal(await handleRemoteViewMessage({ type: REMOTE_VIEW_MESSAGES.startChat, slug: "plan", prompt: "  do it  ", role: 3 }, handlers, reply), true);
     assert.equal(await handleRemoteViewMessage({ type: REMOTE_VIEW_MESSAGES.startChat, slug: "plan", prompt: "   " }, handlers, reply), true);
     assert.deepEqual(chats, [{ prompt: "do it", role: undefined }]);
+  });
+});
+
+describe("normalizeMutate", () => {
+  it("accepts update (object patch) and delete, coercing id to string", () => {
+    assert.deepEqual(normalizeMutate({ op: "update", id: 7, patch: { done: true } }), { op: "update", id: "7", patch: { done: true } });
+    assert.deepEqual(normalizeMutate({ op: "delete", id: "a" }), { op: "delete", id: "a" });
+  });
+
+  it("rejects unknown op, missing id, and a non-object update patch", () => {
+    assert.equal(normalizeMutate({ op: "wipe", id: "a" }), null);
+    assert.equal(normalizeMutate({ op: "delete" }), null);
+    assert.equal(normalizeMutate({ op: "update", id: "a", patch: [1, 2] }), null);
+    assert.equal(normalizeMutate({ op: "update", id: "a", patch: "x" }), null);
+  });
+});
+
+describe("handleRemoteViewMessage — mutate", () => {
+  const mutateMsg = (extra: Record<string, unknown>): Record<string, unknown> => ({
+    type: REMOTE_VIEW_MESSAGES.mutate,
+    slug: "plan",
+    requestId: "m1",
+    ...extra,
+  });
+
+  it("applies an update/delete via onMutate and replies with the result", async () => {
+    const seen: RemoteViewMutateRequest[] = [];
+    const replies: Record<string, unknown>[] = [];
+    const handlers = {
+      slug: "plan",
+      getPage: () => pageFromItems([], { offset: 0, limit: 50 }, "id"),
+      onMutate: (request: RemoteViewMutateRequest) => {
+        seen.push(request);
+        return request.op === "delete" ? { id: request.id } : { item: { id: request.id, done: true } };
+      },
+    };
+    await handleRemoteViewMessage(mutateMsg({ op: "update", id: "a", patch: { done: true } }), handlers, (msg) => replies.push(msg));
+    await handleRemoteViewMessage(mutateMsg({ op: "delete", id: "a", requestId: "m2" }), handlers, (msg) => replies.push(msg));
+    assert.deepEqual(seen, [
+      { op: "update", id: "a", patch: { done: true } },
+      { op: "delete", id: "a" },
+    ]);
+    assert.deepEqual(replies, [
+      { type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: "m1", ok: true, result: { item: { id: "a", done: true } } },
+      { type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: "m2", ok: true, result: { id: "a" } },
+    ]);
+  });
+
+  it("replies read-only when the parent supplies no onMutate", async () => {
+    const replies: Record<string, unknown>[] = [];
+    const handled = await handleRemoteViewMessage(
+      mutateMsg({ op: "update", id: "a", patch: { done: true } }),
+      { slug: "plan", getPage: () => pageFromItems([], { offset: 0, limit: 50 }, "id") },
+      (msg) => replies.push(msg),
+    );
+    assert.equal(handled, true);
+    assert.deepEqual(replies, [{ type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: "m1", ok: false, error: "this view is read-only" }]);
+  });
+
+  it("replies with the error message when onMutate throws, and rejects a malformed request", async () => {
+    const replies: Record<string, unknown>[] = [];
+    const handlers = {
+      slug: "plan",
+      getPage: () => pageFromItems([], { offset: 0, limit: 50 }, "id"),
+      onMutate: () => {
+        throw new Error("field 'x' is not editable");
+      },
+    };
+    await handleRemoteViewMessage(mutateMsg({ op: "update", id: "a", patch: { x: 1 } }), handlers, (msg) => replies.push(msg));
+    await handleRemoteViewMessage(mutateMsg({ op: "wipe", id: "a", requestId: "m3" }), handlers, (msg) => replies.push(msg));
+    assert.deepEqual(replies, [
+      { type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: "m1", ok: false, error: "field 'x' is not editable" },
+      { type: REMOTE_VIEW_MESSAGES.mutateResult, requestId: "m3", ok: false, error: "invalid mutate request" },
+    ]);
   });
 });

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.1",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.6.0",
-    "@mulmoclaude/core": "^0.6.0",
+    "@mulmoclaude/core": "^0.7.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.1",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.0",
-    "@mulmoclaude/core": "^0.7.0",
+    "@mulmoclaude/core": "^0.7.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {
@@ -35,7 +35,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/accounting-plugin": "^0.3.1",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.6.0",
+    "@mulmoclaude/collection-plugin": "^0.7.0",
     "@mulmoclaude/core": "^0.7.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -31,13 +31,13 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^0.6.0",
+    "@mulmoclaude/core": "^0.7.0",
     "gui-chat-protocol": "^0.4.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^0.6.0",
+    "@mulmoclaude/core": "^0.7.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.0",
     "@vitejs/plugin-vue": "^6.0.5",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
@@ -35,7 +35,15 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useCollectionI18n } from "../lang";
 import { deriveAll, errorMessage } from "@mulmoclaude/core/collection";
 import type { CollectionCustomView, CollectionItem, CollectionSchema } from "@mulmoclaude/core/collection";
-import { handleRemoteViewMessage, pageFromItems, REMOTE_VIEW_MAX_BYTES, type RemoteViewItem, type RemoteViewPage } from "@mulmoclaude/core/remote-view";
+import {
+  handleRemoteViewMessage,
+  pageFromItems,
+  REMOTE_VIEW_MAX_BYTES,
+  type RemoteViewItem,
+  type RemoteViewMutateRequest,
+  type RemoteViewMutateResult,
+  type RemoteViewPage,
+} from "@mulmoclaude/core/remote-view";
 import { collectionUi } from "../uiContext";
 
 const { t } = useCollectionI18n();
@@ -119,6 +127,20 @@ function getPage(request: Parameters<typeof pageFromItems>[1]): RemoteViewPage {
   return JSON.parse(JSON.stringify(pageFromItems(derived, request, props.schema.primaryKey))) as RemoteViewPage;
 }
 
+// A preview mutation is a REAL host write, through the same builder + policy the
+// phone will run (plans/feat-remote-writable-view.md, decision 4). The write
+// publishes a collection-change event, so the parent's live subscription
+// refetches `props.items` and the view's next `getItems` reflects it. A refused
+// mutate (read-only / non-editable field / …) throws the host's message, which
+// the bridge relays to the view as `ok: false`.
+async function onMutate(request: RemoteViewMutateRequest): Promise<RemoteViewMutateResult> {
+  const binding = collectionUi();
+  if (!binding.mutateRemoteView) throw new Error("mutateRemoteView is not wired on this host");
+  const resp = await binding.mutateRemoteView(props.slug, props.view.id, request);
+  if (!resp.ok) throw new Error(resp.error);
+  return resp.data.op === "update" ? { item: resp.data.item as RemoteViewItem } : { id: resp.data.id };
+}
+
 function onWindowMessage(event: MessageEvent): void {
   const target = event.source;
   if (!target || target !== iframeEl.value?.contentWindow) return;
@@ -127,6 +149,7 @@ function onWindowMessage(event: MessageEvent): void {
     {
       slug: props.slug,
       getPage,
+      onMutate,
       onStartChat: (prompt, role) => emit("startChat", { prompt, role }),
     },
     // targetOrigin "*": the sandboxed document's origin is opaque, nothing

--- a/packages/plugins/collection-plugin/src/vue/index.ts
+++ b/packages/plugins/collection-plugin/src/vue/index.ts
@@ -31,6 +31,7 @@ export {
   type CollectionViewHtmlResult,
   type CollectionViewI18nResult,
   type CollectionRemoteViewResult,
+  type CollectionRemoteViewMutateResult,
   type CollectionViewSrcdocBoot,
   type CollectionActionResult,
   type CollectionRefreshResult,

--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -9,6 +9,7 @@
 
 import type { Component } from "vue";
 import type { TranslateTransport } from "@mulmoclaude/core/translation/client";
+import type { RemoteViewMutateRequest } from "@mulmoclaude/core/remote-view";
 import type {
   CollectionDetailResponse,
   ItemMutationResponse,
@@ -96,6 +97,13 @@ export interface CollectionRemoteViewResult {
   srcdoc: string;
   bytes: number;
 }
+
+/** Server response for `mutateRemoteView` — the applied mutate echoed back:
+ *  the merged record for an update, the removed id for a delete. Mirrors the
+ *  command channel's `mutateRemoteViewItem` result so the phone-frame preview
+ *  and the phone client see the identical shape
+ *  (plans/feat-remote-writable-view.md). */
+export type CollectionRemoteViewMutateResult = { op: "update"; item: CollectionItem } | { op: "delete"; id: string };
 
 /** Server response shape for `fetchViewI18n` — already locale-picked + flat.
  *  `locale === ""` means no translations were available (view has no `i18n`
@@ -211,6 +219,14 @@ export interface CollectionUi {
    *  without the remote-view route omits it and mobile views are hidden from
    *  the view selector (purely additive, like `subscribeChanges`). */
   fetchRemoteView?: (slug: string, viewId: string, locale: string) => Promise<CollectionApiResult<CollectionRemoteViewResult>>;
+  /** Apply one update/delete requested by a mobile view, authorized by that
+   *  view's declared editableFields / allowDelete and enforced host-side
+   *  (`apiPost` over `API_ROUTES.collections.remoteViewMutate`, global bearer).
+   *  The phone-frame preview's write channel — same builder + policy the phone
+   *  client's `mutateRemoteViewItem` uses, so preview === phone. Optional +
+   *  paired with `fetchRemoteView`: a host without the remote-view surface omits
+   *  both. */
+  mutateRemoteView?: (slug: string, viewId: string, request: RemoteViewMutateRequest) => Promise<CollectionApiResult<CollectionRemoteViewMutateResult>>;
   /** Wrap a custom view's HTML in a sandboxed `<iframe srcdoc>` with the token +
    *  data URL injected and the host's CSP applied. Replaces the host's
    *  `buildCustomViewSrcdoc`. */

--- a/plans/feat-remote-writable-view.md
+++ b/plans/feat-remote-writable-view.md
@@ -1,0 +1,262 @@
+# feat: Writable remote custom views — phase 4: update / delete from the phone
+
+## Goal
+
+Phases 2–3 made the mobile remote (`mulmoserver`) **read** collections: the
+default `CollectionCardList` (phase 2) and per-collection LLM-authored mobile
+HTML views (phase 3, `plans/feat-remote-custom-view.md`). Both are strictly
+read-only — the phase-3 remote-view contract exposes only `getItems`,
+`startChat`, and `t`.
+
+This phase makes a remote view **writable**: a `target: "mobile"` view can
+**toggle a field** (check/uncheck a todo) and **delete a record**, directly —
+not by opening a chat draft. It extends the same postMessage bridge with two
+new methods and reuses the host's existing, path-safe `writeItem` / `deleteItem`
+(`packages/core/src/collection/server/io.ts`) — the exact functions the desktop
+`PUT`/`DELETE /api/collections/:slug/items/:id` routes already drive.
+
+**This PR (host repo) ships everything except the mulmoserver client:**
+
+1. Core contract: `updateItem(id, patch)` / `deleteItem(id)` on `__MC_VIEW`
+   (`@mulmoclaude/core/remote-view`), a `mc-remote-mutate` ⇄
+   `mc-remote-mutate-result` message pair, protocol bumped `1 → 2`, and the
+   parent-side `onMutate` responder in `handleRemoteViewMessage`. The methods are
+   **installed only when the view declared write intent** — a read-only view's
+   `updateItem` rejects loudly instead of silently no-op'ing.
+2. Schema: `editableFields?: string[]` + `allowDelete?: boolean` on
+   `CustomViewSchema` (discovery) and `CollectionCustomView` (core type),
+   documented **mobile-only**. Default-deny: no `editableFields` ⇒ updates
+   refused; no `allowDelete` ⇒ deletes refused.
+3. Host: a shared `createMutateRemoteView(deps)` builder in `remoteView.ts`
+   (find view → enforce mobile + write policy → merge patch / delete → `writeItem`
+   / `deleteItem`), consumed by **two** thin adapters — a `mutateRemoteViewItem`
+   channel handler (for the phone) and a `POST …/remote-view/:viewId/mutate`
+   HTTP route (for the desktop preview). One authoritative enforcement point,
+   two transports — the exact `getRemoteView` "one builder, two consumers"
+   shape (decision 2/3 of phase 3).
+4. Desktop preview: `onMutate` wired to **real host writes** through the new
+   route, so a preview toggle really flips the record and the change event
+   refreshes any open desktop view — "works in preview" means "works on the
+   phone" (decision 5 of phase 3).
+5. `custom-view-remote.md`: the write API + the `editableFields` / `allowDelete`
+   declaration, with a writable-todo example.
+6. `@mulmoclaude/core` 0.6.0 → 0.7.0 (contract change + help asset).
+
+**Follow-up (separate repo/PR, after `@mulmoclaude/core@0.7.0` publishes):**
+mulmoserver renders the srcdoc as before and answers the bridge's mutate
+requests by calling `callHost(channel, "mutateRemoteViewItem", { slug, viewId,
+op, id, patch })`, then refetches through its existing `useCollection`.
+
+## The decisions that shape this
+
+### 1. Writes stay on postMessage — CSP does not change
+
+`updateItem` / `deleteItem` post a `mc-remote-mutate` to the parent and resolve
+on the matching `mc-remote-mutate-result`, exactly like `getItems`. The view
+never touches the network, so `connect-src 'none'` is preserved verbatim: a
+writable view gains mutation power **without** gaining any network reach. The
+parent is still the sole data authority; the sandbox guarantee is untouched.
+
+### 2. Enforcement is host-side and default-deny — the client is never trusted
+
+The sandboxed view is LLM-authored HTML; the bridge parent (preview / phone)
+merely relays. **All policy lives in `createMutateRemoteView` on the host**, which
+re-loads the collection and the view entry and checks, in order:
+
+- the view exists and is `target: "mobile"` (a desktop view has no remote
+  contract);
+- **update**: every key in `patch` is listed in the view's `editableFields`
+  (absent/empty ⇒ refuse); the primary key may not appear in a patch; the
+  target record exists; the merged record is written whole via `writeItem`
+  (`refuseOverwrite: false`, crash-atomic);
+- **delete**: the view sets `allowDelete: true` (absent ⇒ refuse); `deleteItem`
+  removes the record.
+
+Both call the same `writeItem` / `deleteItem` that carry the workspace
+containment + symlink-escape guards and publish `publishCollectionChange` so
+live views refetch. A malicious or buggy view can therefore only touch the
+fields its own declaration whitelisted, on its own collection — the blast radius
+is exactly what the author declared, and nothing implicit.
+
+### 3. Trust model — the phase-2 caveat comes due, and uid-scope still holds
+
+Phase 2's trust model flagged this precise moment (its "Phase-3+ caveat"):
+read-only handlers were safe under pure uid-scoped Firestore rules because "can
+write to my own command queue" already implies workspace ownership. That
+property is unchanged for **cross-tenant** safety: a command can only ever be
+enqueued under `users/{uid}/hosts/mulmoclaude/commands`, which the deployed rule
+restricts to the owning uid, so no other signed-in user can reach this host's
+mutate handler. What the caveat actually asked for — *"per-slug scope"* so that
+queue-ownership does not blanket-authorize mutating an arbitrary record — is
+delivered by decision 2's **per-view `editableFields` / `allowDelete`
+declaration**, enforced host-side. No new authz layer is required beyond that
+declaration; the security boundary remains (a) the uid-scoped rules and (b) the
+localhost-owner-only `signInHost` entry point.
+
+### 4. Preview writes are real, through the host API
+
+The desktop preview parent (MulmoClaude) *can* reach the host, so its `onMutate`
+calls the new `POST …/remote-view/:viewId/mutate` route — a genuine write.
+Consequences, all wanted: the write runs the identical `createMutateRemoteView`
+enforcement the phone will run (preview can neither exceed nor undershoot phone
+policy); the emitted change event refreshes the preview's own record source and
+any open desktop collection view; and the author sees the true round-trip while
+iterating. A simulated in-memory mutation would make "works in preview" weaker
+and would not exercise the enforcement path — rejected for the same reason
+phase 3 rejected a preview that offered more than the phone.
+
+### 5. The view declares its own mutable surface — one place, host-enforced
+
+`editableFields` / `allowDelete` live on the view's `views[]` entry, next to
+`file`. They are the whole write contract: the host injects a `writable` boolean
+into `__MC_VIEW` (true iff the view declares either), the bootstrap installs
+`updateItem` / `deleteItem` only then, and the host re-derives and enforces the
+same policy on every mutate (never trusting `writable`). Existing desktop
+`capabilities: ["read","write"]` (token-scoped) is left untouched — it governs
+the desktop `dataUrl` write channel, which the phone does not have; conflating
+the two would overload one field across two unrelated transports.
+
+## The mutate contract (core/remote-view)
+
+```js
+window.__MC_VIEW = {
+  slug, locale, target: "mobile", protocol: 2,
+  writable,                                     // NEW — mutate methods installed iff true
+  getItems: ({ offset, limit, fields }) => Promise<page>,
+  updateItem: (id, patch) => Promise<{ item }>, // NEW — patch = partial record; rejects if !writable
+  deleteItem: (id)        => Promise<{ id }>,    // NEW — rejects if !writable
+  startChat: (prompt, role) => void,
+  t: (key, named) => string,
+};
+```
+
+- **Messages** (`REMOTE_VIEW_MESSAGES`): add `mutate: "mc-remote-mutate"` (view →
+  parent, `{ requestId, slug, op: "update" | "delete", id, patch? }`) and
+  `mutateResult: "mc-remote-mutate-result"` (parent → view, `{ requestId, ok,
+  result | error }`, where `result` is `{ item }` for update, `{ id }` for
+  delete). `getItems`/`items`/`startChat` are unchanged; protocol `2` is a
+  backward-compatible superset a stale phase-3 parent could still partly serve.
+- **Bootstrap**: a single generic `call(type, payload)` correlates by
+  `requestId` (used by `getItems` *and* both mutators, folding the existing
+  `getItems`-only pending machine into one). The reply listener resolves on
+  either `items` (→ `page`) or `mutateResult` (→ `result`). The mutators are
+  installed only when `__MC_VIEW.writable`; otherwise they are stubs that reject
+  `"this view is read-only"` so a mis-declared view fails loudly.
+- **`handleRemoteViewMessage`**: a `mutate` branch normalizes `op`
+  (`"update"|"delete"` only), `id` (→ String), and `patch` (plain object, else
+  reject), calls `handlers.onMutate?.(req)`, and replies. A parent without
+  `onMutate` (a read-only surface) replies `ok: false, "read-only"`. The `slug`
+  guard and `event.source === iframe.contentWindow` discipline are unchanged.
+- **Note — the view never sends its own `viewId`**: the parent (preview /
+  mulmoserver) knows which view it mounted and supplies `viewId` to the host, so
+  the sandboxed document stays dumb and cannot spoof a different view's policy.
+
+## Where things live
+
+```text
+packages/core/src/remote-view/index.ts     ← + mutate messages, protocol 2,
+  writable boot flag, updateItem/deleteItem bootstrap, normalizeMutate,
+  onMutate in RemoteViewBridgeHandlers + handleRemoteViewMessage
+packages/core/src/collection/server/discovery.ts ← editableFields/allowDelete on CustomViewSchema
+packages/core/src/collection/core/schema.ts      ← same on CollectionCustomView
+packages/core/assets/helps/custom-view-remote.md ← + write API + declaration + todo example
+server/workspace/collections/remoteView.ts  ← createMutateRemoteView(deps):
+  find view → mobile + write-policy guard → editableFields/allowDelete enforce →
+  merge patch / delete → writeItem / deleteItem → discriminated result
+server/remoteHost/handlers/mutateRemoteView.ts ← channel handler over the builder (registered)
+server/api/routes/collections.ts            ← POST …/:slug/remote-view/:viewId/mutate (bearer)
+src/config/apiRoutes.ts                      ← API_ROUTES.collections.remoteViewMutate
+packages/plugins/collection-plugin/src/vue/
+  uiContext.ts / host uiHost.ts              ← mutateRemoteView binding
+  components/CollectionRemoteViewPreview.vue ← onMutate → real write, reflect change
+```
+
+## Schema
+
+```jsonc
+"views": [
+  { "id": "phone", "label": "Todos", "target": "mobile", "file": "views/phone.html",
+    "editableFields": ["done"],   // only these keys are patchable from the phone
+    "allowDelete": true }          // omit (or false) to forbid delete
+]
+```
+
+- `editableFields?: string[]` — the whitelist of patchable field names. Absent or
+  empty ⇒ updates refused (default-deny). Never includes the primary key.
+- `allowDelete?: boolean` — absent/`false` ⇒ deletes refused.
+- Both are **ignored for desktop views** (they have their own token-scoped
+  `capabilities`); documented as mobile-only in the type doc and the help file.
+- Every existing mobile view (no new keys) stays exactly read-only.
+
+## Host builder result (discriminated, like `RemoteViewBuildResult`)
+
+```
+{ kind: "ok"; op: "update"; item } | { kind: "ok"; op: "delete"; id }
+| view-not-found | not-mobile | not-writable         (no editableFields & !allowDelete)
+| field-not-editable(field) | delete-not-allowed
+| item-not-found | invalid-id | path-escape | invalid-op | invalid-patch
+```
+
+`mutateRemoteViewFailureMessage(result, slug)` maps each non-ok kind to a
+message the agent can act on (shared by the channel handler, which throws it,
+and the HTTP route, which sends it with the matching status).
+
+## Steps
+
+0. Plan file (this document) on `feat/remote-writable-view`.
+1. Core: mutate messages + protocol 2 + `writable` boot flag + bootstrap
+   mutators + `normalizeMutate` + `onMutate` in the bridge handler. Unit tests
+   (`packages/core/test/remote-view/`): mutators installed only when writable;
+   `handleRemoteViewMessage` answers update/delete (ok + error), rejects bad
+   op/patch, ignores foreign slug, replies read-only when `onMutate` absent;
+   boot JSON carries `writable` + protocol 2; existing get-items/start-chat
+   tests still pass.
+2. Schema: `editableFields` / `allowDelete` on `CustomViewSchema` +
+   `CollectionCustomView`. Extend discovery tests (accepts the keys, rejects
+   non-array / non-bool, desktop view ignores them).
+3. Host: `createMutateRemoteView` builder in `remoteView.ts` (engine stubbed in
+   tests) + `mutateRemoteViewItem` channel handler (registered in
+   `handlers/index.ts`) + `POST …/remote-view/:viewId/mutate` route +
+   `API_ROUTES.collections.remoteViewMutate`. Tests in `test/remoteHost/`:
+   not-mobile / not-writable / field-not-editable / delete-not-allowed /
+   item-not-found refused; ok update returns the merged item; ok delete returns
+   the id; handler registered in the runner table.
+4. Preview: `mutateRemoteView` uiContext binding (+ `uiHost.ts` wiring calling
+   the route), `onMutate` in `CollectionRemoteViewPreview.vue` → real write →
+   re-derive/reflect (rely on the existing change subscription to refresh
+   `items`; re-`getItems` in the view after a resolved mutate is the author's
+   job, documented in the help file).
+5. Help file: write API + declaration + a **writable mobile todo** example
+   (checkbox toggles `done`, swipe/long-press deletes); core → 0.7.0.
+6. `yarn format` / `lint` (--no-cache over new files) / `typecheck` / `build` /
+   `test`; PR.
+
+## Out of scope (later)
+
+- **mulmoserver client** — needs `@mulmoclaude/core@0.7.0` on npm; a small
+  consumer: render the srcdoc, answer `mutate` via
+  `callHost("mutateRemoteViewItem", …)`, refetch through `useCollection`.
+- **Create** (new records) from the phone — this phase is update + delete only
+  (the two the read view naturally implies); create needs a form/field-init
+  contract, its own phase.
+- Multi-field transactional edits, optimistic-concurrency tokens, undo — a
+  mutate is one field-set or one delete; last-write-wins as elsewhere.
+- Feed-collection writes (`getRemoteView` / mutate load via `loadCollection`
+  only; feeds are ingest-owned and stay read-only on the remote).
+
+## Test plan
+
+- **Core (`tsx --test`, packages/core)**: bootstrap installs mutators only when
+  `writable`; message handler update/delete happy + error paths, malformed
+  op/patch rejected, foreign slug ignored, read-only parent replies `ok:false`;
+  boot carries `writable` + `protocol: 2`.
+- **Host (`tsx --test`, test/remoteHost)**: `createMutateRemoteView` — desktop /
+  unknown view refused, `not-writable` when neither `editableFields` nor
+  `allowDelete`, `field-not-editable` for a non-whitelisted key, primary-key
+  patch refused, `delete-not-allowed` without the flag, `item-not-found`,
+  ok-update merges + returns item, ok-delete returns id (io stubbed);
+  `mutateRemoteViewItem` registered; result shape as plain JSON.
+- **Manual**: author a `target: "mobile"` view with `editableFields:["done"]` +
+  `allowDelete:true` → preview renders → check a todo (record's `done` flips on
+  disk, desktop view refreshes) → delete a record (file removed) → a
+  non-whitelisted field patch is refused with the builder's message.

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -42,7 +42,15 @@ import type {
   LoadedCollection,
   RecordIssue,
 } from "../../workspace/collections/index.js";
-import { buildRemoteView, remoteViewFailureMessage, type RemoteViewBuildResult } from "../../workspace/collections/remoteView.js";
+import {
+  buildRemoteView,
+  mutateRemoteView,
+  mutateRemoteViewFailureMessage,
+  remoteViewFailureMessage,
+  type MutateRemoteViewResult,
+  type RemoteViewBuildResult,
+} from "../../workspace/collections/remoteView.js";
+import { normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { badRequest, notFound, conflict, forbidden, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
@@ -515,6 +523,47 @@ router.get(API_ROUTES.collections.remoteView, async (req: Request<{ slug: string
     res.json({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
   } catch (err) {
     log.warn("collections", "remote-view build failed", { slug: req.params.slug, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+});
+
+/** Map a non-ok mutate to its HTTP error (message shared with the channel
+ *  handler via `mutateRemoteViewFailureMessage`). */
+function sendMutateRemoteViewFailure(res: Response, result: Exclude<MutateRemoteViewResult, { kind: "ok" }>, slug: string): void {
+  const message = mutateRemoteViewFailureMessage(result, slug);
+  if (result.kind === "view-not-found" || result.kind === "item-not-found") notFound(res, message);
+  else if (result.kind === "not-writable" || result.kind === "delete-not-allowed" || result.kind === "field-not-editable" || result.kind === "path-escape")
+    forbidden(res, message);
+  else badRequest(res, message);
+}
+
+// Apply one update/delete on behalf of a mobile view — the desktop phone-frame
+// preview's write channel. Behind the global bearer. Same builder + policy as
+// the command channel's `mutateRemoteViewItem`, so a preview mutation runs the
+// EXACT enforcement the phone will (plans/feat-remote-writable-view.md).
+router.post(API_ROUTES.collections.remoteViewMutate, async (req: Request<{ slug: string; viewId: string }>, res: Response) => {
+  try {
+    const { slug, viewId } = req.params;
+    const body = (req.body ?? {}) as { op?: unknown; id?: unknown; patch?: unknown };
+    const request = normalizeMutate(body);
+    if (!request) {
+      badRequest(res, "invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
+      return;
+    }
+    const collection = await loadCollection(slug);
+    if (!collection) {
+      notFound(res, `collection '${slug}' not found`);
+      return;
+    }
+    const result = await mutateRemoteView(collection, viewId, request);
+    if (result.kind !== "ok") {
+      sendMutateRemoteViewFailure(res, result, slug);
+      return;
+    }
+    log.info("collections", "remote-view mutate", { slug, viewId, op: result.op });
+    res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
+  } catch (err) {
+    log.warn("collections", "remote-view mutate failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });

--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -8,6 +8,7 @@ import { getRemoteView } from "./getRemoteView.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
 import { listShortcuts } from "./listShortcuts.js";
+import { mutateRemoteViewItem } from "./mutateRemoteView.js";
 import { startChat } from "./startChat.js";
 
 export const handlers: CommandHandlers = {
@@ -17,5 +18,6 @@ export const handlers: CommandHandlers = {
   listFeeds,
   getFeed,
   getRemoteView,
+  mutateRemoteViewItem,
   startChat,
 };

--- a/server/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/remoteHost/handlers/mutateRemoteView.ts
@@ -1,0 +1,40 @@
+// mutateRemoteViewItem command handler (remote-host phase 4 —
+// plans/feat-remote-writable-view.md).
+//
+// Applies one update/delete requested by a `target: "mobile"` custom view on
+// the phone, authorized by that view's OWN declared surface
+// (editableFields / allowDelete) and enforced HOST-side (createMutateRemoteView)
+// — the sandboxed view is never trusted. The parent (mulmoserver) supplies the
+// `viewId` it mounted; the sandboxed document cannot spoof a different view's
+// policy. Shares the builder with the desktop preview's HTTP route so both
+// transports apply identical policy.
+//
+// Factory (createMutateRemoteView-backed) keeps the mapping unit-testable with
+// the engine stubbed; the default export wires the real functions.
+import { normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { loadCollection } from "../../workspace/collections/index.js";
+import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../workspace/collections/remoteView.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface MutateRemoteViewHandlerDeps {
+  loadCollection: typeof loadCollection;
+  mutateRemoteView: typeof mutateRemoteView;
+}
+
+export const createMutateRemoteViewHandler =
+  (deps: MutateRemoteViewHandlerDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    const slug = String(params.slug ?? "");
+    const viewId = String(params.viewId ?? "");
+    const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
+    if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
+    const collection = await deps.loadCollection(slug);
+    if (!collection) throw new Error(`collection '${slug}' not found`);
+    const result = await deps.mutateRemoteView(collection, viewId, request);
+    if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
+    // Plain JSON, but the interface lacks an index signature — cast like the
+    // other phase-2/3 handlers.
+    return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
+  };
+
+export const mutateRemoteViewItem = createMutateRemoteViewHandler({ loadCollection, mutateRemoteView });

--- a/server/workspace/collections/index.ts
+++ b/server/workspace/collections/index.ts
@@ -16,6 +16,7 @@ export {
   readItem,
   writeItem,
   deleteItem,
+  safeRecordId,
   generateItemId,
   resolveCreateItemId,
   readSkillTemplate,

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -16,6 +16,7 @@ import {
   readCustomViewHtml,
   readCustomViewI18n,
   readItem,
+  safeRecordId,
   writeItem,
   type CollectionCustomView,
   type CollectionItem,
@@ -140,6 +141,13 @@ async function updateViaView(
   // desync the file name from the record) even if an author listed it.
   const offending = patchKeys.find((key) => key === primaryKey || !allowed.has(key));
   if (offending) return { kind: "field-not-editable", field: offending };
+  // Classify a bad id BEFORE readItem — which returns null for an unsafe id, a
+  // path-escape, AND a genuinely-missing record alike — so update reports the
+  // same explicit `invalid-id` the delete path does (via deleteItem) instead of
+  // masking it as a 404. (A valid id whose dataDir escapes the workspace can
+  // hold no record, so it still resolves to item-not-found; a real write is
+  // additionally refused by writeItem's own containment guard below.)
+  if (safeRecordId(request.id) === null) return { kind: "invalid-id", id: request.id };
   const existing = await deps.readItem(collection.dataDir, request.id, { slug: collection.slug });
   if (!existing) return { kind: "item-not-found", id: request.id };
   const merged: CollectionItem = { ...existing, ...request.patch, [primaryKey]: request.id };

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -10,8 +10,17 @@
 // its status; the channel handler converts non-ok to a thrown error via
 // `remoteViewFailureMessage`. Factory keeps the mapping unit-testable with the
 // engine stubbed.
-import { buildRemoteViewSrcdoc, REMOTE_VIEW_MAX_BYTES } from "@mulmoclaude/core/remote-view";
-import { readCustomViewHtml, readCustomViewI18n, type LoadedCollection } from "./index.js";
+import { buildRemoteViewSrcdoc, REMOTE_VIEW_MAX_BYTES, type RemoteViewMutateRequest } from "@mulmoclaude/core/remote-view";
+import {
+  deleteItem,
+  readCustomViewHtml,
+  readCustomViewI18n,
+  readItem,
+  writeItem,
+  type CollectionCustomView,
+  type CollectionItem,
+  type LoadedCollection,
+} from "./index.js";
 
 export interface RemoteViewInfo {
   id: string;
@@ -43,7 +52,10 @@ export const createBuildRemoteView =
     const html = await deps.readCustomViewHtml(collection, view.file);
     if (html === null) return { kind: "file-missing", file: view.file };
     const i18n = view.i18n ? await deps.readCustomViewI18n(collection, view.i18n, locale) : { locale: "", dict: {} };
-    const srcdoc = buildRemoteViewSrcdoc(html, { slug: collection.slug, locale: i18n.locale, dict: i18n.dict });
+    // `writable` gates the client-side updateItem/deleteItem install; the host
+    // re-derives + enforces the actual policy on every mutate (createMutateRemoteView).
+    const writable = isWritableView(view);
+    const srcdoc = buildRemoteViewSrcdoc(html, { slug: collection.slug, locale: i18n.locale, dict: i18n.dict, writable });
     const bytes = Buffer.byteLength(srcdoc, "utf8");
     if (bytes > REMOTE_VIEW_MAX_BYTES) return { kind: "too-large", bytes };
     return { kind: "ok", view: { id: view.id, label: view.label, ...(view.icon ? { icon: view.icon } : {}), target: "mobile" }, srcdoc, bytes };
@@ -58,4 +70,100 @@ export function remoteViewFailureMessage(result: Exclude<RemoteViewBuildResult, 
   if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
   if (result.kind === "file-missing") return `view file '${result.file}' not found — author it at data/skills/${slug}/${result.file}`;
   return `mobile view srcdoc is ${result.bytes} bytes — over the ${REMOTE_VIEW_MAX_BYTES}-byte command-channel budget; slim the HTML`;
+}
+
+// ── Mutate (phase 4 — plans/feat-remote-writable-view.md) ──
+// A `target: "mobile"` view's update/delete, authorized by its OWN declared
+// surface (editableFields / allowDelete) and enforced HOST-side — the client is
+// never trusted. Shared by the `mutateRemoteViewItem` channel handler (phone)
+// and the `…/remote-view/:viewId/mutate` HTTP route (desktop preview), so both
+// transports apply identical policy. Discriminated result (not throw) mirrors
+// the build result above.
+
+/** True when a mobile view declared ANY write surface. Also gates the srcdoc's
+ *  `writable` boot flag so the client only exposes methods the host will honor. */
+function isWritableView(view: CollectionCustomView): boolean {
+  return (view.editableFields?.length ?? 0) > 0 || view.allowDelete === true;
+}
+
+export type MutateRemoteViewResult =
+  | { kind: "ok"; op: "update"; item: CollectionItem }
+  | { kind: "ok"; op: "delete"; id: string }
+  | { kind: "view-not-found"; viewId: string }
+  | { kind: "not-mobile"; viewId: string }
+  | { kind: "not-writable"; viewId: string }
+  | { kind: "field-not-editable"; field: string }
+  | { kind: "delete-not-allowed" }
+  | { kind: "invalid-patch" }
+  | { kind: "item-not-found"; id: string }
+  | { kind: "invalid-id"; id: string }
+  | { kind: "path-escape" };
+
+export interface MutateRemoteViewDeps {
+  readItem: typeof readItem;
+  writeItem: typeof writeItem;
+  deleteItem: typeof deleteItem;
+}
+
+export const createMutateRemoteView =
+  (deps: MutateRemoteViewDeps) =>
+  async (collection: LoadedCollection, viewId: string, request: RemoteViewMutateRequest): Promise<MutateRemoteViewResult> => {
+    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+    if (!view) return { kind: "view-not-found", viewId };
+    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    if (!isWritableView(view)) return { kind: "not-writable", viewId };
+    return request.op === "delete"
+      ? deleteViaView(deps, collection, view.allowDelete === true, request.id)
+      : updateViaView(deps, collection, view.editableFields ?? [], request);
+  };
+
+async function deleteViaView(deps: MutateRemoteViewDeps, collection: LoadedCollection, allowDelete: boolean, itemId: string): Promise<MutateRemoteViewResult> {
+  if (!allowDelete) return { kind: "delete-not-allowed" };
+  const result = await deps.deleteItem(collection.dataDir, itemId, { slug: collection.slug });
+  if (result.kind === "invalid-id") return { kind: "invalid-id", id: result.itemId };
+  if (result.kind === "path-escape") return { kind: "path-escape" };
+  if (result.kind === "not-found") return { kind: "item-not-found", id: result.itemId };
+  return { kind: "ok", op: "delete", id: result.itemId };
+}
+
+async function updateViaView(
+  deps: MutateRemoteViewDeps,
+  collection: LoadedCollection,
+  editableFields: string[],
+  request: Extract<RemoteViewMutateRequest, { op: "update" }>,
+): Promise<MutateRemoteViewResult> {
+  const { primaryKey } = collection.schema;
+  const patchKeys = Object.keys(request.patch);
+  if (patchKeys.length === 0) return { kind: "invalid-patch" };
+  const allowed = new Set(editableFields);
+  // The primary key is never patchable (it is the record id — renaming it would
+  // desync the file name from the record) even if an author listed it.
+  const offending = patchKeys.find((key) => key === primaryKey || !allowed.has(key));
+  if (offending) return { kind: "field-not-editable", field: offending };
+  const existing = await deps.readItem(collection.dataDir, request.id, { slug: collection.slug });
+  if (!existing) return { kind: "item-not-found", id: request.id };
+  const merged: CollectionItem = { ...existing, ...request.patch, [primaryKey]: request.id };
+  const result = await deps.writeItem(collection.dataDir, request.id, merged, { slug: collection.slug });
+  if (result.kind === "invalid-id") return { kind: "invalid-id", id: result.itemId };
+  if (result.kind === "path-escape") return { kind: "path-escape" };
+  if (result.kind === "conflict") return { kind: "item-not-found", id: result.itemId }; // unreachable: refuseOverwrite is false
+  return { kind: "ok", op: "update", item: result.item };
+}
+
+export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem });
+
+/** Message per non-ok mutate kind — shared by the channel handler (throws) and
+ *  the HTTP route (sends with the matching status). */
+export function mutateRemoteViewFailureMessage(result: Exclude<MutateRemoteViewResult, { kind: "ok" }>, slug: string): string {
+  if (result.kind === "view-not-found") return `custom view '${result.viewId}' not found on collection '${slug}'`;
+  if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+  if (result.kind === "not-writable")
+    return `mobile view '${result.viewId}' is read-only — declare editableFields and/or allowDelete in its views[] entry to allow writes`;
+  if (result.kind === "field-not-editable")
+    return `field '${result.field}' is not editable from this view — add it to the view's editableFields (the primary key is never editable)`;
+  if (result.kind === "delete-not-allowed") return `this view may not delete records — set allowDelete: true in its views[] entry`;
+  if (result.kind === "invalid-patch") return `update patch must be a non-empty object of field changes`;
+  if (result.kind === "item-not-found") return `item '${result.id}' not found in collection '${slug}'`;
+  if (result.kind === "invalid-id") return `invalid item id: ${result.id}`;
+  return `data directory for collection '${slug}' escapes the workspace`;
 }

--- a/src/composables/collections/uiHost.ts
+++ b/src/composables/collections/uiHost.ts
@@ -13,6 +13,7 @@
 import {
   configureCollectionUi,
   type CollectionRemoteViewResult,
+  type CollectionRemoteViewMutateResult,
   type CollectionViewI18nResult,
   type CollectionViewToken,
   type RegistryListResponse,
@@ -58,6 +59,8 @@ const collectionActionUrl = (slug: string, actionId: string): string =>
   withSlug(API_ROUTES.collections.collectionAction, slug).replace(":actionId", encodeURIComponent(actionId));
 const viewDeleteUrl = (slug: string, viewId: string): string =>
   withSlug(API_ROUTES.collections.viewDelete, slug).replace(":viewId", encodeURIComponent(viewId));
+const remoteViewMutateUrl = (slug: string, viewId: string): string =>
+  withSlug(API_ROUTES.collections.remoteViewMutate, slug).replace(":viewId", encodeURIComponent(viewId));
 
 // ── Deferred app bindings (need a component context; set by App.vue setup) ──
 type StartChat = (prompt: string, role: string) => void;
@@ -100,6 +103,7 @@ configureCollectionUi({
   },
   fetchViewI18n: (slug, viewId, locale) => apiGet<CollectionViewI18nResult>(withSlug(API_ROUTES.collections.viewI18n, slug), { id: viewId, locale }),
   fetchRemoteView: (slug, viewId, locale) => apiGet<CollectionRemoteViewResult>(withSlug(API_ROUTES.collections.remoteView, slug), { id: viewId, locale }),
+  mutateRemoteView: (slug, viewId, request) => apiPost<CollectionRemoteViewMutateResult>(remoteViewMutateUrl(slug, viewId), request),
   buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
 
   // record CRUD + actions

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -299,6 +299,13 @@ const HOST_API_ROUTES = {
      *  `getRemoteView`, so the desktop phone-frame preview renders the exact
      *  artifact the phone receives (plans/feat-remote-custom-view.md). */
     remoteView: "/api/collections/:slug/remote-view",
+    /** POST { op: "update"|"delete", id, patch? } → apply one mutate on behalf
+     *  of a `target: "mobile"` view, authorized by that view's declared
+     *  editableFields / allowDelete and enforced host-side (global-bearer auth).
+     *  The desktop phone-frame preview's write channel — same builder the
+     *  command channel's `mutateRemoteViewItem` uses, so preview === phone
+     *  (plans/feat-remote-writable-view.md). */
+    remoteViewMutate: "/api/collections/:slug/remote-view/:viewId/mutate",
     /** GET ?id=<viewId>&locale=<tag> → translation dict for one custom view
      *  (global-bearer auth) → { locale, dict }. `dict` is the host-picked
      *  flat map for the requested locale (fallback `"en"`, else `{}`); the

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -64,6 +64,13 @@ describe("createMutateRemoteView", () => {
     });
   });
 
+  it("reports invalid-id for an unsafe id on update (not a masked item-not-found)", async () => {
+    // readItem/writeItem stubs are never reached — the safeRecordId preflight
+    // classifies `bad/id` before any IO, matching the delete path's behaviour.
+    const result = await createMutateRemoteView(deps())(collection([writableView]), "phone", { op: "update", id: "bad/id", patch: { done: true } });
+    assert.deepEqual(result, { kind: "invalid-id", id: "bad/id" });
+  });
+
   it("refuses an empty patch and a missing record", async () => {
     assert.deepEqual(await createMutateRemoteView(deps())(collection([writableView]), "phone", { op: "update", id: "t1", patch: {} }), {
       kind: "invalid-patch",

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -1,0 +1,152 @@
+// Unit tests for the phase-4 writable remote-view surface: the shared
+// createMutateRemoteView builder (io stubbed) and the mutateRemoteViewItem
+// command handler over it. See plans/feat-remote-writable-view.md.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createMutateRemoteView, mutateRemoteViewFailureMessage, type MutateRemoteViewDeps } from "../../server/workspace/collections/remoteView.js";
+import { createMutateRemoteViewHandler, type MutateRemoteViewHandlerDeps } from "../../server/remoteHost/handlers/mutateRemoteView.js";
+import { handlers } from "../../server/remoteHost/handlers/index.js";
+import type { LoadedCollection } from "../../server/workspace/collections/index.js";
+
+const collection = (views: unknown[]): LoadedCollection =>
+  ({
+    slug: "todos",
+    source: "project",
+    skillDir: "/s/todos",
+    dataDir: "/d/todos",
+    schema: { primaryKey: "id", fields: {}, views },
+  }) as unknown as LoadedCollection;
+
+// A view that may toggle `done` and delete records.
+const writableView = { id: "phone", label: "Todos", target: "mobile", file: "views/phone.html", editableFields: ["done"], allowDelete: true };
+
+const record = { id: "t1", title: "buy milk", done: false };
+
+const deps = (overrides: Partial<MutateRemoteViewDeps> = {}): MutateRemoteViewDeps => ({
+  readItem: (async () => ({ ...record })) as unknown as MutateRemoteViewDeps["readItem"],
+  writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
+  deleteItem: (async (_dir: string, itemId: string) => ({ kind: "ok", itemId })) as unknown as MutateRemoteViewDeps["deleteItem"],
+  ...overrides,
+});
+
+describe("createMutateRemoteView", () => {
+  it("updates a whitelisted field, merging the patch onto the existing record", async () => {
+    let written: unknown;
+    const mutate = createMutateRemoteView(
+      deps({
+        writeItem: (async (_dir: string, itemId: string, item: unknown) => (
+          (written = item),
+          { kind: "ok", itemId, item }
+        )) as unknown as MutateRemoteViewDeps["writeItem"],
+      }),
+    );
+    const result = await mutate(collection([writableView]), "phone", { op: "update", id: "t1", patch: { done: true } });
+    assert.deepEqual(result, { kind: "ok", op: "update", item: { id: "t1", title: "buy milk", done: true } });
+    // The patch merges — untouched fields survive, id is pinned to the URL id.
+    assert.deepEqual(written, { id: "t1", title: "buy milk", done: true });
+  });
+
+  it("deletes a record when allowDelete is set", async () => {
+    const result = await createMutateRemoteView(deps())(collection([writableView]), "phone", { op: "delete", id: "t1" });
+    assert.deepEqual(result, { kind: "ok", op: "delete", id: "t1" });
+  });
+
+  it("refuses a patch touching a non-whitelisted field (and the primary key)", async () => {
+    const mutate = createMutateRemoteView(deps());
+    assert.deepEqual(await mutate(collection([writableView]), "phone", { op: "update", id: "t1", patch: { title: "x" } }), {
+      kind: "field-not-editable",
+      field: "title",
+    });
+    assert.deepEqual(await mutate(collection([writableView]), "phone", { op: "update", id: "t1", patch: { id: "hacked" } }), {
+      kind: "field-not-editable",
+      field: "id",
+    });
+  });
+
+  it("refuses an empty patch and a missing record", async () => {
+    assert.deepEqual(await createMutateRemoteView(deps())(collection([writableView]), "phone", { op: "update", id: "t1", patch: {} }), {
+      kind: "invalid-patch",
+    });
+    const noItem = createMutateRemoteView(deps({ readItem: (async () => null) as unknown as MutateRemoteViewDeps["readItem"] }));
+    assert.deepEqual(await noItem(collection([writableView]), "phone", { op: "update", id: "ghost", patch: { done: true } }), {
+      kind: "item-not-found",
+      id: "ghost",
+    });
+  });
+
+  it("refuses delete when allowDelete is absent, and update when no editableFields", async () => {
+    const deleteOnly = { id: "phone", label: "P", target: "mobile", file: "views/phone.html", allowDelete: true };
+    const updateOnly = { id: "phone", label: "P", target: "mobile", file: "views/phone.html", editableFields: ["done"] };
+    assert.deepEqual(await createMutateRemoteView(deps())(collection([updateOnly]), "phone", { op: "delete", id: "t1" }), { kind: "delete-not-allowed" });
+    // A delete-only view exposes no editable field, so any update key is refused.
+    assert.deepEqual(await createMutateRemoteView(deps())(collection([deleteOnly]), "phone", { op: "update", id: "t1", patch: { done: true } }), {
+      kind: "field-not-editable",
+      field: "done",
+    });
+  });
+
+  it("refuses a read-only mobile view, a desktop view, and an unknown view", async () => {
+    const readOnly = { id: "phone", label: "P", target: "mobile", file: "views/phone.html" };
+    const desktop = { id: "year", label: "Y", file: "views/year.html", editableFields: ["done"] };
+    const mutate = createMutateRemoteView(deps());
+    assert.deepEqual(await mutate(collection([readOnly]), "phone", { op: "delete", id: "t1" }), { kind: "not-writable", viewId: "phone" });
+    assert.deepEqual(await mutate(collection([desktop]), "year", { op: "delete", id: "t1" }), { kind: "not-mobile", viewId: "year" });
+    assert.deepEqual(await mutate(collection([writableView]), "ghost", { op: "delete", id: "t1" }), { kind: "view-not-found", viewId: "ghost" });
+  });
+
+  it("maps every failure kind to an actionable message", () => {
+    assert.match(mutateRemoteViewFailureMessage({ kind: "not-writable", viewId: "phone" }, "todos"), /read-only — declare editableFields/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "field-not-editable", field: "title" }, "todos"), /'title' is not editable/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "delete-not-allowed" }, "todos"), /allowDelete: true/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "item-not-found", id: "t9" }, "todos"), /'t9' not found/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "invalid-patch" }, "todos"), /non-empty object/);
+  });
+});
+
+describe("createMutateRemoteViewHandler", () => {
+  const handlerDeps = (overrides: Partial<MutateRemoteViewHandlerDeps> = {}): MutateRemoteViewHandlerDeps => ({
+    loadCollection: (async (slug: string) =>
+      slug === "missing" ? null : collection([writableView])) as unknown as MutateRemoteViewHandlerDeps["loadCollection"],
+    mutateRemoteView: (async () => ({
+      kind: "ok",
+      op: "update",
+      item: { id: "t1", done: true },
+    })) as unknown as MutateRemoteViewHandlerDeps["mutateRemoteView"],
+    ...overrides,
+  });
+
+  it("returns the update result for a valid request", async () => {
+    const handler = createMutateRemoteViewHandler(handlerDeps());
+    assert.deepEqual(await handler({ slug: "todos", viewId: "phone", op: "update", id: "t1", patch: { done: true } }), {
+      op: "update",
+      item: { id: "t1", done: true },
+    });
+  });
+
+  it("returns the delete result shape", async () => {
+    const handler = createMutateRemoteViewHandler(
+      handlerDeps({ mutateRemoteView: (async () => ({ kind: "ok", op: "delete", id: "t1" })) as unknown as MutateRemoteViewHandlerDeps["mutateRemoteView"] }),
+    );
+    assert.deepEqual(await handler({ slug: "todos", viewId: "phone", op: "delete", id: "t1" }), { op: "delete", id: "t1" });
+  });
+
+  it("throws on a malformed request, an unknown collection, and a non-ok mutate", async () => {
+    await assert.rejects(
+      async () => createMutateRemoteViewHandler(handlerDeps())({ slug: "todos", viewId: "phone", op: "wipe", id: "t1" }),
+      /invalid mutate request/,
+    );
+    await assert.rejects(
+      async () => createMutateRemoteViewHandler(handlerDeps())({ slug: "missing", viewId: "phone", op: "delete", id: "t1" }),
+      /collection 'missing' not found/,
+    );
+    const rejecting = createMutateRemoteViewHandler(
+      handlerDeps({ mutateRemoteView: (async () => ({ kind: "delete-not-allowed" })) as unknown as MutateRemoteViewHandlerDeps["mutateRemoteView"] }),
+    );
+    await assert.rejects(async () => rejecting({ slug: "todos", viewId: "phone", op: "delete", id: "t1" }), /allowDelete: true/);
+  });
+
+  it("is registered in the runner's method table", () => {
+    assert.equal(typeof handlers.mutateRemoteViewItem, "function");
+  });
+});

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -96,11 +96,15 @@ describe("createMutateRemoteView", () => {
   });
 
   it("maps every failure kind to an actionable message", () => {
+    assert.match(mutateRemoteViewFailureMessage({ kind: "view-not-found", viewId: "phone" }, "todos"), /'phone' not found on collection 'todos'/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "not-mobile", viewId: "year" }, "todos"), /target: "mobile"/);
     assert.match(mutateRemoteViewFailureMessage({ kind: "not-writable", viewId: "phone" }, "todos"), /read-only — declare editableFields/);
     assert.match(mutateRemoteViewFailureMessage({ kind: "field-not-editable", field: "title" }, "todos"), /'title' is not editable/);
     assert.match(mutateRemoteViewFailureMessage({ kind: "delete-not-allowed" }, "todos"), /allowDelete: true/);
-    assert.match(mutateRemoteViewFailureMessage({ kind: "item-not-found", id: "t9" }, "todos"), /'t9' not found/);
     assert.match(mutateRemoteViewFailureMessage({ kind: "invalid-patch" }, "todos"), /non-empty object/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "item-not-found", id: "t9" }, "todos"), /'t9' not found/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "invalid-id", id: "bad/id" }, "todos"), /invalid item id: bad\/id/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "path-escape" }, "todos"), /escapes the workspace/);
   });
 });
 

--- a/test/workspace/collections/test_discovery_views.ts
+++ b/test/workspace/collections/test_discovery_views.ts
@@ -65,4 +65,14 @@ describe("collection schema — custom views validation", () => {
     assert.equal(withViews([{ id: "year", label: "Year", file: "views/year.html", target: "desktop" }]).success, true);
     assert.equal(withViews([{ id: "tv", label: "TV", file: "views/tv.html", target: "tv" }]).success, false);
   });
+
+  it("accepts mobile editableFields / allowDelete, rejects wrong types", () => {
+    assert.equal(
+      withViews([{ id: "phone", label: "Phone", file: "views/phone.html", target: "mobile", editableFields: ["done"], allowDelete: true }]).success,
+      true,
+    );
+    assert.equal(withViews([{ id: "phone", label: "Phone", file: "views/phone.html", target: "mobile", editableFields: "done" }]).success, false);
+    assert.equal(withViews([{ id: "phone", label: "Phone", file: "views/phone.html", target: "mobile", editableFields: [""] }]).success, false);
+    assert.equal(withViews([{ id: "phone", label: "Phone", file: "views/phone.html", target: "mobile", allowDelete: "yes" }]).success, false);
+  });
 });


### PR DESCRIPTION
## Summary

Phase 4 of the remote custom-view line (`plans/feat-remote-writable-view.md`). Phases 2–3 let the mobile remote **read** collections and render per-collection LLM-authored HTML views; both were strictly read-only. This makes a `target: "mobile"` view **writable** — toggle a whitelisted field (check/uncheck a todo) and delete a record — directly, not via a chat draft.

Ships everything except the mulmoserver client (the post-publish follow-up).

## How it works

- **Core contract** (`@mulmoclaude/core/remote-view`): adds `updateItem(id, patch)` / `deleteItem(id)` to `__MC_VIEW`, a `mc-remote-mutate` ⇄ `mc-remote-mutate-result` message pair, protocol `1 → 2`, and a `writable` boot flag. The mutators are installed **only** when the view declared a write surface; otherwise they reject `"this view is read-only"`. Writes ride postMessage, so **CSP is unchanged** — `connect-src 'none'` still holds (a writable view gains mutation power without any network reach).
- **Schema**: `editableFields?: string[]` + `allowDelete?: boolean` on `CustomViewSchema` / `CollectionCustomView`, mobile-only, **default-deny** (no declaration ⇒ no writes). Every existing mobile view stays read-only.
- **Host**: one authoritative `createMutateRemoteView` builder (find view → enforce mobile + write policy → merge patch / delete via the existing path-safe `writeItem`/`deleteItem`) behind two transports — a `mutateRemoteViewItem` channel handler (phone) and a `POST …/remote-view/:viewId/mutate` route (desktop preview). Same "one builder, two consumers" shape as `getRemoteView`.
- **Preview**: `onMutate` wired to **real host writes**, so a preview toggle really flips the record and the change event refreshes any open desktop view — "works in preview" == "works on the phone."
- **Help**: `custom-view-remote.md` documents the write API + declaration, with a writable-todo example.
- `@mulmoclaude/core` `0.6.0 → 0.7.0` (contract + help asset; launcher/plugin ranges bumped).

## Security

The phase-2 trust model's explicit "Phase-3+ caveat" (write handlers may need per-slug scope beyond uid-scoped Firestore rules) is satisfied by the per-view `editableFields`/`allowDelete` declaration, **enforced host-side** — the sandboxed view is never trusted. Cross-tenant safety is unchanged (uid-scoped command queue). Blast radius is exactly what each view's own declaration whitelists; the primary key is never patchable.

## Testing

- `yarn format` / `yarn lint --no-cache` (0 errors) / `yarn typecheck` / `yarn build` / `yarn test` — **all green** (5133 + workspace suites, 0 failures).
- +19 unit tests (8 core contract, 11 host builder/handler) and extended discovery-schema tests.
- **End-to-end**: an agent, reading only the updated help file, authored a writable shopping-list mobile view and `putSchema` validated the new `editableFields` key (`{"written":true}`) — confirming the schema + help wiring against the real runtime.

## Out of scope (later)

- **mulmoserver client** — needs `@mulmoclaude/core@0.7.0` on npm; then it calls `callHost("mutateRemoteViewItem", …)` and refetches through `useCollection`.
- Create (new records) from the phone; multi-field transactional edits / optimistic-concurrency; feed-collection writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile remote custom views can now be writable for record **update and deletion** when explicitly enabled.
  * Added remote-view mutation support with new APIs to **updateItem** and **deleteItem**, plus host-enabled write routing and results handling.
* **Documentation**
  * Updated the writable “remote custom views” contract, including declared editing permissions (`editableFields`) and deletion gating (`allowDelete`), and added a writable todo example.
* **Bug Fixes**
  * Improved validation and failure responses for read-only views and invalid mutate requests.
* **Chores**
  * Version bumps for core and related packages; added/expanded automated coverage for mutation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->