### PR TITLE
feat(remote-view): workspace image thumbnails on the phone (phase 5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "node-html-parser": "^8.0.4",
     "node-pty": "^1.1.0",
     "puppeteer": "^25.3.0",
+    "sharp": "^0.35.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "uuid": "^14.0.1",

--- a/packages/core/assets/helps/custom-view-remote.md
+++ b/packages/core/assets/helps/custom-view-remote.md
@@ -137,6 +137,9 @@ const { id: removed } = await window.__MC_VIEW.deleteItem(id);
   optimistically update your local copy from the returned `item`, or re-call
   `getItems` to refetch. The preview's real write also refreshes the desktop
   collection, so you see the true result while iterating.
+- **The returned `item` is shaped like a `getItems` item** — the view's declared
+  `imageFields` come back inlined as `data:` URLs (not bare paths), so merging the
+  result (`items[i] = { ...items[i], ...res.item }`) keeps thumbnails intact.
 - **Create is not available** in this phase — `updateItem` only patches an
   existing record; use `startChat` to ask the agent to add a new one.
 

--- a/packages/core/assets/helps/custom-view-remote.md
+++ b/packages/core/assets/helps/custom-view-remote.md
@@ -86,7 +86,8 @@ const page = await window.__MC_VIEW.getItems({
   Render the first page, then offer a **"Load more"** affordance while
   `items.length < total` (see the example).
 - **Always pass `fields`.** The projection keeps pages small (the primary key
-  is always included). List the columns your view actually renders.
+  is always included). List the columns your view actually renders — including
+  any `image`-type field you want inlined (see **Displaying images**).
 - The promise **rejects** on failure or after a 30 s timeout — catch it and
   show the message; don't fail silently.
 - **`derived` formulas that read only the record's own fields come back
@@ -139,6 +140,52 @@ const { id: removed } = await window.__MC_VIEW.deleteItem(id);
 - **Create is not available** in this phase — `updateItem` only patches an
   existing record; use `startChat` to ask the agent to add a new one.
 
+### Displaying images — `imageFields`
+
+A collection's `image`-type field holds a **workspace path** (`data/attachments/…`,
+`artifacts/images/…`) that the phone can't fetch. To render it, list the field in
+the view's **`imageFields`** and the host inlines it as a **downscaled JPEG
+`data:` URL thumbnail** inside each `getItems` page — the value your view reads is
+then a ready-to-use `data:` URL, not a path.
+
+**1. Declare the image fields** in the `views[]` entry:
+
+```jsonc
+{
+  "id": "gallery",
+  "label": "Gallery",
+  "target": "mobile",
+  "file": "views/gallery.html",
+  "imageFields": ["photo"], // inline these image-type fields as thumbnails
+  "imageMaxEdge": 384        // optional longest-edge px (default 512, clamped [64, 1024])
+}
+```
+
+**2. Render the value as an image**, and **request the field** so it survives the
+projection (a field you don't list in `fields` is never inlined):
+
+```js
+const page = await window.__MC_VIEW.getItems({ offset: 0, limit: 20, fields: ["title", "photo"] });
+// page.items[0].photo === "data:image/jpeg;base64,…"  → <img src="…">
+```
+
+- **Only `image`-type fields listed in `imageFields` are inlined.** A non-image
+  field name is ignored; a field the page's `fields` projection dropped is not
+  inlined (so paging without the image column costs nothing).
+- **Thumbnails are downscaled**, longest edge `imageMaxEdge` (default 512). Keep
+  it small and keep pages small (`limit`): every inlined image travels inside the
+  size-capped page. The host enforces a **per-page byte budget** — once a page is
+  full, further images are **left as their original path** (which renders as a
+  broken/placeholder `<img>`), never dropped silently but never overflowing the
+  channel either. Fewer, smaller images per page = more reliably rendered.
+- **A field may come back as a path, not a `data:` URL** (over budget, missing
+  file, or an undecodable source). Handle both: `onerror` a placeholder, or check
+  for the `data:` prefix before rendering.
+- **Cost**: inlined thumbnails are the one thing that grows a page's bytes;
+  they're opt-in per view and per projection precisely so a view pays only for the
+  images it shows. The preview's caption reports `N images (M over budget)` so you
+  can size `imageMaxEdge` / `limit` against the budget while iterating.
+
 ### Starting a chat — `startChat`
 
 Identical to the desktop helper: opens a **new chat with your prompt prefilled
@@ -190,8 +237,11 @@ than desktop views:
   HTML anyway (see the size budget).
 - **`<img>` / `<audio>` / `<video>` may load any `https:` URL** (plus `data:`
   / `blob:`) — a record's public image/media URL renders. A **workspace file
-  path does not** (it lives on this machine, which the phone can't reach):
-  treat `image`-type fields as desktop-only and skip or placeholder them.
+  path does not** by itself (it lives on this machine, which the phone can't
+  reach) — but the host **can inline a workspace `image`-type field** as a
+  downscaled `data:` URL thumbnail when the view declares it in `imageFields`;
+  see **Displaying images** below. `audio` / `video` and non-declared image
+  paths stay desktop-only (skip or placeholder them).
 - **Outbound links**: `<a href="…" target="_blank" rel="noopener">` opens
   normally; a same-tab `<a href>` is blocked by the sandbox.
 - No cookies, no `localStorage`, no parent access — and no token exists in
@@ -424,6 +474,57 @@ The core of `views/phone.html` (styles/`<head>` as above):
 
   load().catch(function (err) {
     document.getElementById("list").innerHTML = '<div class="err">' + err.message + "</div>";
+  });
+</script>
+```
+
+## Example — image gallery (inlined thumbnails)
+
+A phone-first photo grid. Schema has `title` (string) and `photo` (image, a
+workspace path). Registration declares the image field + a small edge:
+`{ "id": "gallery", "label": "Gallery", "target": "mobile", "file": "views/gallery.html", "imageFields": ["photo"], "imageMaxEdge": 384 }`.
+`getItems` must **request `photo`** (else it isn't inlined); the host returns it
+as a `data:` URL, and a small `limit` keeps each page under the byte budget.
+
+The core of `views/gallery.html` (styles/`<head>` as in the first example):
+
+```html
+<div id="grid" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px"></div>
+<button id="more" class="more" hidden>Load more</button>
+<script>
+  var loaded = [];
+  var total = 0;
+  var PAGE = 20; // small: every inlined thumbnail travels inside the page
+
+  function tile(item) {
+    var el = document.createElement("div");
+    el.className = "card";
+    var src = typeof item.photo === "string" && item.photo.indexOf("data:") === 0 ? item.photo : "";
+    el.innerHTML =
+      '<img loading="lazy" alt="" style="width:100%;aspect-ratio:1;object-fit:cover;border-radius:10px;background:#e2e8f0">' + "<b></b>";
+    if (src) el.querySelector("img").src = src; // else leave the placeholder background
+    el.querySelector("b").textContent = item.title || item.id;
+    return el;
+  }
+
+  async function loadMore() {
+    var page = await window.__MC_VIEW.getItems({ offset: loaded.length, limit: PAGE, fields: ["title", "photo"] });
+    total = page.total;
+    loaded = loaded.concat(page.items);
+    var grid = document.getElementById("grid");
+    page.items.forEach(function (item) {
+      grid.appendChild(tile(item));
+    });
+    document.getElementById("more").hidden = loaded.length >= total;
+  }
+
+  document.getElementById("more").onclick = function () {
+    loadMore().catch(function (e) {
+      alert(e.message);
+    });
+  };
+  loadMore().catch(function (e) {
+    document.getElementById("grid").innerHTML = '<div class="err">' + e.message + "</div>";
   });
 </script>
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client and ./remote-view entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -256,6 +256,16 @@ export interface CollectionCustomView {
   /** **Mobile-only.** When `true`, a `target: "mobile"` view may remove a
    *  record via `__MC_VIEW.deleteItem(id)`. Absent/`false` ⇒ deletes refused. */
   allowDelete?: boolean;
+  /** **Mobile-only.** `image`-type fields whose workspace path the host inlines
+   *  as a downscaled `data:` URL thumbnail in `getItems` pages, so they render
+   *  on the phone (which can't reach the host's localhost). Opt-in (absent ⇒
+   *  none); the host projects `fields` first and only inlines the declared
+   *  fields that survive, within a per-page byte budget. Ignored for desktop
+   *  views (they resolve via `/api/files/raw`). See plans/feat-remote-view-images.md. */
+  imageFields?: string[];
+  /** **Mobile-only.** Longest-edge (px) an inlined `imageFields` thumbnail is
+   *  downscaled to. Absent ⇒ 512, clamped to `[64, 1024]`. */
+  imageMaxEdge?: number;
 }
 
 /** A schema-declared, per-record action rendered as a button in the

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -252,6 +252,14 @@ const CustomViewSchema = z.object({
   // Ignored for desktop views (they use the token-scoped `capabilities` above).
   editableFields: z.array(z.string().trim().min(1)).optional(),
   allowDelete: z.boolean().optional(),
+  // Mobile-only image inlining (plans/feat-remote-view-images.md). A
+  // `target: "mobile"` view can't reach the host's localhost, so an `image`-type
+  // field's workspace path is unrenderable on the phone; listing it here makes
+  // the host inline it as a downscaled `data:` URL thumbnail in getItems pages.
+  // Opt-in (absent ⇒ none), projection- and budget-bounded host-side. Ignored
+  // for desktop views (they resolve via /api/files/raw).
+  imageFields: z.array(z.string().trim().min(1)).optional(),
+  imageMaxEdge: z.number().int().min(1).optional(),
 });
 
 // Recurrence advance for `spawn.every`. `interval` is a positive integer

--- a/packages/core/src/remote-view/index.ts
+++ b/packages/core/src/remote-view/index.ts
@@ -40,6 +40,17 @@ export const MAX_PAGE_LIMIT = 200;
  *  command document (1 MiB total), so leave envelope headroom. */
 export const REMOTE_VIEW_MAX_BYTES = 900_000;
 
+/** Hard cap on ONE `getItems` page (phase 5 — plans/feat-remote-view-images.md).
+ *  Same 1 MiB command-document envelope as the srcdoc: when a view inlines image
+ *  fields as `data:` URLs, the host stops inlining once the serialized page would
+ *  exceed this, leaving the remaining image fields as their original path (which
+ *  the view renders as a placeholder). Guards the doc-write from ever failing. */
+export const REMOTE_VIEW_ITEMS_MAX_BYTES = 900_000;
+
+/** Default longest-edge (px) a remote view's inlined image thumbnail is
+ *  downscaled to; a view may override via `imageMaxEdge`. */
+export const DEFAULT_IMAGE_MAX_EDGE = 512;
+
 /** In-iframe `getItems` timeout — matches the remote client's `callHost`
  *  response timeout so the two layers give up together. */
 const GET_ITEMS_TIMEOUT_MS = 30_000;
@@ -73,6 +84,14 @@ export const clampLimit = (value: unknown): number => {
   const num = toInt(value);
   if (num === null || num <= 0) return DEFAULT_PAGE_LIMIT;
   return Math.min(num, MAX_PAGE_LIMIT);
+};
+
+/** Clamp an `imageMaxEdge` (arrives as untyped schema/JSON) to [64, 1024];
+ *  default 512. Keeps a runaway edge from defeating the thumbnail's purpose. */
+export const clampImageMaxEdge = (value: unknown): number => {
+  const num = toInt(value);
+  if (num === null || num <= 0) return DEFAULT_IMAGE_MAX_EDGE;
+  return Math.min(Math.max(num, 64), 1024);
 };
 
 /** Coerce a `fields` projection list from untyped message JSON. */

--- a/packages/core/test/remote-view/test_remote_view.ts
+++ b/packages/core/test/remote-view/test_remote_view.ts
@@ -5,10 +5,12 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  DEFAULT_IMAGE_MAX_EDGE,
   REMOTE_VIEW_MESSAGES,
   REMOTE_VIEW_PROTOCOL,
   buildRemoteViewCsp,
   buildRemoteViewSrcdoc,
+  clampImageMaxEdge,
   clampLimit,
   clampOffset,
   handleRemoteViewMessage,
@@ -91,6 +93,15 @@ describe("clamps + projection", () => {
     assert.deepEqual(normalizeFields(["title", " ", 3, "start"]), ["title", "start"]);
     assert.equal(normalizeFields([]), undefined);
     assert.equal(normalizeFields("title"), undefined);
+  });
+
+  it("clampImageMaxEdge defaults and bounds the thumbnail edge to [64, 1024]", () => {
+    assert.equal(clampImageMaxEdge(undefined), DEFAULT_IMAGE_MAX_EDGE);
+    assert.equal(clampImageMaxEdge(0), DEFAULT_IMAGE_MAX_EDGE);
+    assert.equal(clampImageMaxEdge(-10), DEFAULT_IMAGE_MAX_EDGE);
+    assert.equal(clampImageMaxEdge(16), 64);
+    assert.equal(clampImageMaxEdge(9999), 1024);
+    assert.equal(clampImageMaxEdge("384"), 384);
   });
 
   it("projectItems keeps the primary key and only the listed fields", () => {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.1",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.0",
-    "@mulmoclaude/core": "^0.7.1",
+    "@mulmoclaude/core": "^0.8.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -58,6 +58,7 @@
     "mulmocast": "^2.6.23",
     "node-html-parser": "^8.0.4",
     "puppeteer": "^25.3.0",
+    "sharp": "^0.35.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "tsx": "^4.22.4",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -31,13 +31,13 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^0.7.0",
+    "@mulmoclaude/core": "^0.8.0",
     "gui-chat-protocol": "^0.4.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^0.7.0",
+    "@mulmoclaude/core": "^0.8.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.0",
     "@vitejs/plugin-vue": "^6.0.5",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
@@ -33,16 +33,16 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useCollectionI18n } from "../lang";
-import { deriveAll, errorMessage } from "@mulmoclaude/core/collection";
-import type { CollectionCustomView, CollectionItem, CollectionSchema } from "@mulmoclaude/core/collection";
+import { errorMessage } from "@mulmoclaude/core/collection";
+import type { CollectionCustomView } from "@mulmoclaude/core/collection";
 import {
   handleRemoteViewMessage,
-  pageFromItems,
   REMOTE_VIEW_MAX_BYTES,
   type RemoteViewItem,
   type RemoteViewMutateRequest,
   type RemoteViewMutateResult,
   type RemoteViewPage,
+  type RemoteViewPageRequest,
 } from "@mulmoclaude/core/remote-view";
 import { collectionUi } from "../uiContext";
 
@@ -51,13 +51,6 @@ const { t } = useCollectionI18n();
 const props = defineProps<{
   slug: string;
   view: CollectionCustomView;
-  /** The collection schema — the bridge derives computed fields from it and
-   *  `projectItems` always keeps its `primaryKey`. */
-  schema: CollectionSchema;
-  /** The already-loaded records the bridge pages over. Deliberately the
-   *  UNFILTERED list: the phone pages over the whole collection through the
-   *  command channel, and the preview must behave identically. */
-  items: CollectionItem[];
 }>();
 
 const emit = defineEmits<{
@@ -71,8 +64,17 @@ const error = ref<string | null>(null);
 const srcdoc = ref<string | null>(null);
 const bytes = ref(0);
 const iframeEl = ref<HTMLIFrameElement | null>(null);
+// Last page's inlined/omitted image counts — surfaced so the author sees how
+// many thumbnails fit the per-page budget while iterating (numeric, no locale
+// keys, like the byte caption).
+const imageStats = ref<{ inlined: number; omitted: number } | null>(null);
 
-const sizeCaption = computed(() => `${Math.max(1, Math.round(bytes.value / 1024))} KB / ${Math.round(REMOTE_VIEW_MAX_BYTES / 1024)} KB`);
+const sizeCaption = computed(() => {
+  const base = `${Math.max(1, Math.round(bytes.value / 1024))} KB / ${Math.round(REMOTE_VIEW_MAX_BYTES / 1024)} KB`;
+  const stats = imageStats.value;
+  if (!stats || (stats.inlined === 0 && stats.omitted === 0)) return base;
+  return stats.omitted > 0 ? `${base} · ${stats.inlined} images (${stats.omitted} over budget)` : `${base} · ${stats.inlined} images`;
+});
 
 // Monotonic load id — same stale-load guard as CollectionCustomView.
 let loadSeq = 0;
@@ -111,20 +113,22 @@ async function load(): Promise<void> {
 watch([() => props.slug, () => props.view.id, () => collectionUi().localeTag()], () => void load(), { immediate: true });
 
 // ── The parent side of the remote-view bridge ──
-// Answers ONLY what the phone parent answers — `getItems` pages (clamped +
-// fields-projected by the shared handler) and `startChat` relays. No
-// `onChange`, no `openItem`, no data plane: preview capability must equal
-// phone capability exactly (plans/feat-remote-custom-view.md, decision 5).
+// Answers ONLY what the phone parent answers — `getItems` pages and `startChat`
+// relays. No `onChange`, no `openItem`: preview capability must equal phone
+// capability exactly (plans/feat-remote-custom-view.md, decision 5).
 //
-// `props.items` are the RAW detail records: derived formulas resolve at
-// render time on the desktop, so the bridge must derive them here — with an
-// empty ref cache, exactly like the channel's `deriveItems` — before paging.
-// The JSON round-trip then strips Vue's reactive proxies (postMessage
-// structured-clone throws DataCloneError on them) and matches what the
-// command channel does to a page anyway.
-function getPage(request: Parameters<typeof pageFromItems>[1]): RemoteViewPage {
-  const derived = props.items.map((item) => deriveAll(props.schema, item, {}) as RemoteViewItem);
-  return JSON.parse(JSON.stringify(pageFromItems(derived, request, props.schema.primaryKey))) as RemoteViewPage;
+// Paging goes through the HOST (not client-side over the records) because the
+// page's declared `imageFields` are inlined as `data:` URL thumbnails the
+// browser can neither read from the workspace nor resize — the preview fetches
+// the same host page (real thumbnails, byte budget) the phone will, over the
+// identical `createRemoteViewItems` builder (plans/feat-remote-view-images.md).
+async function getPage(request: RemoteViewPageRequest): Promise<RemoteViewPage> {
+  const binding = collectionUi();
+  if (!binding.fetchRemoteViewItems) throw new Error("fetchRemoteViewItems is not wired on this host");
+  const resp = await binding.fetchRemoteViewItems(props.slug, props.view.id, request);
+  if (!resp.ok) throw new Error(resp.error);
+  imageStats.value = { inlined: resp.data.inlined, omitted: resp.data.omitted };
+  return resp.data.page;
 }
 
 // A preview mutation is a REAL host write, through the same builder + policy the

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -416,8 +416,6 @@
           v-if="activeCustomView.target === 'mobile'"
           :slug="collection.slug"
           :view="activeCustomView"
-          :schema="collection.schema"
-          :items="items"
           @start-chat="onCustomViewStartChat"
         />
         <CollectionCustomView v-else :slug="collection.slug" :view="activeCustomView" @open-item="onCustomViewOpenItem" @start-chat="onCustomViewStartChat" />

--- a/packages/plugins/collection-plugin/src/vue/index.ts
+++ b/packages/plugins/collection-plugin/src/vue/index.ts
@@ -32,6 +32,7 @@ export {
   type CollectionViewI18nResult,
   type CollectionRemoteViewResult,
   type CollectionRemoteViewMutateResult,
+  type CollectionRemoteViewItemsResult,
   type CollectionViewSrcdocBoot,
   type CollectionActionResult,
   type CollectionRefreshResult,

--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -9,7 +9,7 @@
 
 import type { Component } from "vue";
 import type { TranslateTransport } from "@mulmoclaude/core/translation/client";
-import type { RemoteViewMutateRequest } from "@mulmoclaude/core/remote-view";
+import type { RemoteViewMutateRequest, RemoteViewPage, RemoteViewPageRequest } from "@mulmoclaude/core/remote-view";
 import type {
   CollectionDetailResponse,
   ItemMutationResponse,
@@ -104,6 +104,18 @@ export interface CollectionRemoteViewResult {
  *  and the phone client see the identical shape
  *  (plans/feat-remote-writable-view.md). */
 export type CollectionRemoteViewMutateResult = { op: "update"; item: CollectionItem } | { op: "delete"; id: string };
+
+/** Server response for `fetchRemoteViewItems` — one page of a mobile view's
+ *  records with its declared `imageFields` already inlined as `data:` URL
+ *  thumbnails host-side. `inlined` / `omitted` count how many images fit the
+ *  per-page byte budget (surfaced while the user iterates on the view).
+ *  Mirrors the command channel's `getRemoteViewItems` result so preview ===
+ *  phone (plans/feat-remote-view-images.md). */
+export interface CollectionRemoteViewItemsResult {
+  page: RemoteViewPage;
+  inlined: number;
+  omitted: number;
+}
 
 /** Server response shape for `fetchViewI18n` — already locale-picked + flat.
  *  `locale === ""` means no translations were available (view has no `i18n`
@@ -227,6 +239,13 @@ export interface CollectionUi {
    *  paired with `fetchRemoteView`: a host without the remote-view surface omits
    *  both. */
   mutateRemoteView?: (slug: string, viewId: string, request: RemoteViewMutateRequest) => Promise<CollectionApiResult<CollectionRemoteViewMutateResult>>;
+  /** Page a mobile view's records with its declared `imageFields` inlined as
+   *  `data:` URL thumbnails host-side (`apiGet` over
+   *  `API_ROUTES.collections.remoteViewItems`, global bearer) — the phone-frame
+   *  preview's paging source (it cannot resize/read the workspace itself, so it
+   *  fetches the same host page the phone will). Optional + paired with
+   *  `fetchRemoteView`. */
+  fetchRemoteViewItems?: (slug: string, viewId: string, request: RemoteViewPageRequest) => Promise<CollectionApiResult<CollectionRemoteViewItemsResult>>;
   /** Wrap a custom view's HTML in a sandboxed `<iframe srcdoc>` with the token +
    *  data URL injected and the host's CSP applied. Replaces the host's
    *  `buildCustomViewSrcdoc`. */

--- a/plans/feat-remote-view-images.md
+++ b/plans/feat-remote-view-images.md
@@ -157,7 +157,7 @@ JSON, same as the pagination clamps), reused by the host builder.
 
 ## Host builder result (discriminated, like the others)
 
-```
+```text
 { kind: "ok"; page: RemoteViewPage; inlined: number; omitted: number }
 | view-not-found | not-mobile
 ```
@@ -238,4 +238,3 @@ packages/plugins/collection-plugin/src/vue/
   with real photos → preview renders the thumbnails in the 390×844 frame → the
   size caption shows the inlined-image page cost → a huge `limit` degrades to
   fewer images, never an error.
-```

--- a/plans/feat-remote-view-images.md
+++ b/plans/feat-remote-view-images.md
@@ -1,0 +1,241 @@
+# feat: Workspace images in remote custom views — phase 5: inline thumbnails
+
+## Goal
+
+Phases 2–4 let the mobile remote **read** and **write** collections, but every
+record field crosses the bridge as-is. A collection's `image`-type field holds a
+**workspace-relative path** (`data/attachments/…`, `artifacts/images/…`,
+`images/YYYY/MM/…`); on the desktop that path resolves through the localhost
+`GET /api/files/raw` route, but the phone can't reach localhost, so
+`custom-view-remote.md` today tells the agent to *"treat `image`-type fields as
+desktop-only and skip or placeholder them."*
+
+This phase makes workspace images **render on the phone** by inlining them as
+**`data:` URL thumbnails** the host produces server-side. The view declares
+which image fields to inline (`imageFields`); the host resizes + base64-encodes
+each declared field's image and substitutes the path with the `data:` URL inside
+the record page, within a byte budget that keeps the page under the 1 MiB
+command-document cap. The CSP already allows `img-src … data:` (phase 3), so the
+sandbox and transport are unchanged — this is purely a **field-value transform**
+on the read path.
+
+**This PR (host repo) ships everything except the mulmoserver client:**
+
+1. Schema: `imageFields?: string[]` + `imageMaxEdge?: number` on
+   `CustomViewSchema` (discovery) and `CollectionCustomView` (core type),
+   documented **mobile-only**. Default-none: no `imageFields` ⇒ nothing is
+   inlined (the cost-safe default — see below).
+2. A host thumbnail resolver (`server/utils/files/thumbnail-store.ts`):
+   workspace-relative path → resized JPEG `data:` URL, path-containment-guarded
+   (same discipline as `image-store.ts`), with an mtime-keyed in-memory cache so
+   repeated pages / "load more" scrolls never re-encode.
+3. A shared `createRemoteViewItems(deps)` builder in `remoteView.ts`: load view
+   (must be `target: "mobile"`) → derive → slice `offset/limit` → project
+   `fields` → inline the declared `imageFields` that survived the projection,
+   within a page byte budget → return one `RemoteViewPage`. Consumed by **two**
+   thin adapters — a `getRemoteViewItems` channel handler (for the phone) and a
+   `GET …/remote-view/:viewId/items` HTTP route (for the desktop preview). The
+   exact `getRemoteView` / `mutateRemoteView` "one builder, two consumers" shape.
+4. Desktop preview: `CollectionRemoteViewPreview.vue`'s `getPage` fetches pages
+   from the new route instead of paging client-side over `props.items`, so the
+   preview renders the **real host thumbnails** — "works in preview" means "works
+   on the phone" (decision 5 of phase 3), and the preview exercises the same
+   resolver + budget the phone will.
+5. `custom-view-remote.md`: relax the "images are desktop-only" caveat; document
+   `imageFields` / `imageMaxEdge`, the byte budget, and phone-image design
+   guidance (small thumbnails, lazy-load pages). A new image-list example.
+6. `@mulmoclaude/core` 0.7.1 → 0.8.0 (schema change + help asset).
+
+**Follow-up (separate repo/PR, after `@mulmoclaude/core@0.8.0` publishes):**
+mulmoserver answers the bridge's `getItems` by calling
+`callHost(channel, "getRemoteViewItems", { slug, viewId, offset, limit, fields })`
+— which already returns the page with `imageFields` inlined — instead of the
+phase-2 `getCollection` + client-side `projectItems`.
+
+## The decisions that shape this
+
+### 1. Inline `data:` URLs, not a public URL or a fetch (Option A)
+
+The phone can't reach the host and the CSP is `connect-src 'none'`, so an image
+can arrive only two ways: as a **public `https:` URL** the phone fetches directly
+(needs an external object store + an upload step — a different feature), or
+**inlined as a `data:` URL** in the record the bridge already delivers. This
+phase takes the inline path: no new transport, no new infrastructure, and the
+image never leaves the machine at full resolution — the host emits a downscaled
+thumbnail. `img-src … data:` is already open (phase 3), so nothing about the
+sandbox or CSP changes.
+
+### 2. The host resizes — a thumbnail, not the original
+
+A workspace image is often multi-MB; base64 inflates bytes ~33% and the whole
+page must fit the 1 MiB command doc. So the resolver **downscales** to a longest
+edge (`imageMaxEdge`, default 512, clamped `[64, 1024]`) and re-encodes as JPEG
+before base64 — the single biggest lever on both the size budget and egress cost.
+This needs a decode/resize/encode dependency; the resolver is isolated behind one
+function (`resolveThumbnail`) so the concrete library is an implementation
+detail. **`sharp`** is the choice (prebuilt binaries for linux/mac/arm, the Node
+thumbnailing standard); the resolver's signature stays library-agnostic so a
+pure-JS swap is a one-file change.
+
+### 3. Opt-in per view, projection-aware — cost is what the author declared
+
+Egress is the only marginal cost of this feature (Firestore bills operations
+per-document flat; a bigger page is bandwidth, not more ops). Two properties keep
+it near-zero and *predictable*:
+
+- **Opt-in**: no `imageFields` ⇒ zero thumbnails. A view pays for images only
+  when it asks for them; the default card list and image-free views are
+  unaffected.
+- **Projection-aware**: the builder projects `fields` **before** inlining and
+  only encodes `imageFields ∩ projected fields`. A view that pages a field list
+  without its image column ships no image bytes for that page.
+
+Firestore's ~10 GiB/mo free egress covers ~13k full image-pages/month at ~800 KB;
+past that it's ~$0.12/GiB, linear and cheap. The budget guard (decision 4) caps
+the worst case per page.
+
+### 4. A hard per-page byte budget — the 1 MiB cap is never risked
+
+The builder accumulates inlined thumbnail bytes and stops inlining once the page
+would exceed `REMOTE_VIEW_ITEMS_MAX_BYTES` (900 000 — same headroom as the
+srcdoc cap). Fields past the budget are **left as their original path string**
+(the view already treats an unresolved image gracefully — it renders a broken/
+placeholder `<img>`, same as a `null`). This means a runaway page (large images
+× large `limit`) degrades to *fewer inlined images*, never a doc-write failure.
+The resolver also returns `null` for a missing/unsupported/oversized source, and
+those fields are likewise left as the path — one uniform "couldn't inline"
+outcome the view handles the same way. Encourage small pages in the help file.
+
+### 5. Preview pages from the host now — true thumbnail parity
+
+The phase-3/4 preview paged **client-side** over `props.items` (`pageFromItems`),
+which is impossible for thumbnails: the browser can't read the workspace or run
+`sharp`. So the preview's `getPage` now fetches from
+`GET …/remote-view/:viewId/items` — a real host call through the identical
+`createRemoteViewItems` builder the phone uses. Consequences, all wanted: the
+preview shows the **actual** downscaled thumbnails at the real byte cost; it can
+neither exceed nor undershoot phone behavior; and `props.items` is no longer
+needed by the preview (removed from the component and its `CollectionView.vue`
+call site). This mirrors phase 4, which already made the preview's *writes* real
+host round-trips for the same parity reason.
+
+## The contract (core/remote-view)
+
+No bootstrap or message-shape change — `getItems` still returns a `RemoteViewPage`
+and the view still only `await`s it. What changes is purely the **value** of a
+declared image field in the returned items: a `data:image/jpeg;base64,…` string
+instead of a workspace path (or the path unchanged when it couldn't be inlined).
+
+```js
+// A view that declared "imageFields": ["photo"] sees, per record:
+const page = await window.__MC_VIEW.getItems({ offset: 0, limit: 20, fields: ["title", "photo"] });
+// page.items[0].photo === "data:image/jpeg;base64,/9j/4AAQ…"  (inlined thumbnail)
+//   …or the original path string when the host could not inline it (budget/missing/unsupported)
+```
+
+Core additions are small: `REMOTE_VIEW_ITEMS_MAX_BYTES` and a
+`DEFAULT_IMAGE_MAX_EDGE` / `clampImageMaxEdge` helper (params arrive as untyped
+JSON, same as the pagination clamps), reused by the host builder.
+
+## Schema
+
+```jsonc
+"views": [
+  { "id": "gallery", "label": "Gallery", "target": "mobile", "file": "views/gallery.html",
+    "imageFields": ["photo"],   // inline these image-type fields as data: thumbnails on the phone
+    "imageMaxEdge": 384 }        // optional longest-edge px (default 512, clamped [64, 1024])
+]
+```
+
+- `imageFields?: string[]` — the whitelist of `image`-type fields to inline.
+  Absent/empty ⇒ nothing inlined (default-none, cost-safe). A named field that is
+  not `image`-type in the schema is ignored (logged), not an error.
+- `imageMaxEdge?: number` — longest-edge pixel bound; absent ⇒ 512, clamped.
+- Both are **ignored for desktop views** (which resolve via `/api/files/raw`);
+  documented mobile-only in the type doc and the help file.
+- Every existing mobile view (no new keys) is byte-for-byte unchanged.
+
+## Host builder result (discriminated, like the others)
+
+```
+{ kind: "ok"; page: RemoteViewPage; inlined: number; omitted: number }
+| view-not-found | not-mobile
+```
+
+`inlined` / `omitted` counts feed a debug log and the preview caption so the
+author can *see* how many images fit the budget while iterating. Failure kinds
+reuse `remoteViewItemsFailureMessage(result, slug)` shared by the channel handler
+(throws) and the HTTP route (sends with status).
+
+## Where things live
+
+```text
+packages/core/src/remote-view/index.ts     ← + REMOTE_VIEW_ITEMS_MAX_BYTES,
+  DEFAULT_IMAGE_MAX_EDGE, clampImageMaxEdge (the only core code delta)
+packages/core/src/collection/server/discovery.ts ← imageFields/imageMaxEdge on CustomViewSchema
+packages/core/src/collection/core/schema.ts       ← same on CollectionCustomView
+packages/core/assets/helps/custom-view-remote.md   ← relaxed image caveat + declaration + example
+server/utils/files/thumbnail-store.ts       ← resolveThumbnail(relPath, maxEdge): data-URL | null,
+  containment-guarded, sharp resize, mtime-keyed LRU cache
+server/workspace/collections/remoteView.ts  ← createRemoteViewItems(deps): derive → slice →
+  project → inline declared imageFields within budget → RemoteViewPage
+server/remoteHost/handlers/getRemoteViewItems.ts ← channel handler over the builder (registered)
+server/api/routes/collections.ts            ← GET …/:slug/remote-view/:viewId/items (bearer)
+src/config/apiRoutes.ts                      ← API_ROUTES.collections.remoteViewItems
+packages/plugins/collection-plugin/src/vue/
+  uiContext.ts / host uiHost.ts             ← fetchRemoteViewItems binding
+  components/CollectionRemoteViewPreview.vue ← getPage → route; drop props.items paging
+  components/CollectionView.vue              ← stop passing :items to the preview
+```
+
+## Steps
+
+0. Plan file (this document) on `feat/remote-view-images`.
+1. Core: `REMOTE_VIEW_ITEMS_MAX_BYTES`, `DEFAULT_IMAGE_MAX_EDGE`,
+   `clampImageMaxEdge`. Unit tests (clamp bounds).
+2. Schema: `imageFields` / `imageMaxEdge` on `CustomViewSchema` +
+   `CollectionCustomView`. Extend discovery tests (accepts keys, rejects
+   non-array / non-number, desktop view ignores them).
+3. Resolver: `server/utils/files/thumbnail-store.ts` + `sharp` dep. Unit tests
+   (containment reject, cache hit skips re-encode, unsupported → null, resize
+   honors max edge). Stub `sharp` in tests via a resize-fn dep so no real binary
+   is needed in CI.
+4. Host builder: `createRemoteViewItems` (engine + resolver stubbed in tests) +
+   `getRemoteViewItems` channel handler (registered in `handlers/index.ts`) +
+   `GET …/remote-view/:viewId/items` route + `API_ROUTES.collections.remoteViewItems`.
+   Tests in `test/remoteHost/`: not-mobile refused; projection kept before
+   inlining; only `imageFields ∩ projected` inlined; budget stops inlining and
+   leaves the path; non-image field name ignored; result shape.
+5. Preview: `fetchRemoteViewItems` uiContext binding (+ `uiHost.ts`), `getPage`
+   → route (async), remove `props.items` from the component and `CollectionView.vue`.
+6. Help file: relaxed caveat + declaration + image-list example; core → 0.8.0.
+7. `yarn format` / `lint` (--no-cache over new files) / `typecheck` / `build` /
+   `test`; PR.
+
+## Out of scope (later)
+
+- **mulmoserver client** — needs `@mulmoclaude/core@0.8.0`; a small consumer:
+  call `getRemoteViewItems` for `getItems`, render the inlined `data:` URLs.
+- **Public-URL (Option B) images** — full-resolution galleries too big for the
+  command doc; needs an object store + publish step, its own phase.
+- **Default card-list thumbnails** — the phase-2 `CollectionCardList` remote view
+  could reuse `resolveThumbnail`, but this phase scopes to declared custom views.
+- **Non-image media** (audio/video) inlining — far larger; stays public-URL-only.
+- **Persistent / disk thumbnail cache** — the cache is in-memory per host process;
+  a cross-restart cache is a later optimization.
+
+## Test plan
+
+- **Core (`tsx --test`, packages/core)**: `clampImageMaxEdge` bounds/defaults.
+- **Resolver (`tsx --test`, test/utils)**: containment reject (path escape →
+  null), cache hit avoids a second encode (spy the resize fn), unsupported bytes
+  → null, honors `maxEdge`.
+- **Host (`tsx --test`, test/remoteHost)**: `createRemoteViewItems` — not-mobile
+  refused; page projected before inline; only declared ∩ projected fields
+  inlined; budget exceeded ⇒ remaining fields left as path + `omitted` counted;
+  non-image declared field ignored; `getRemoteViewItems` registered.
+- **Manual**: author a `target: "mobile"` view with `imageFields` on a collection
+  with real photos → preview renders the thumbnails in the 390×844 frame → the
+  size caption shows the inlined-image page cost → a huge `limit` degrades to
+  fewer images, never an error.
+```

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -608,7 +608,13 @@ router.get(API_ROUTES.collections.remoteViewItems, async (req: Request<{ slug: s
     }
     res.json({ page: result.page, inlined: result.inlined, omitted: result.omitted });
   } catch (err) {
-    log.warn("collections", "remote-view items failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
+    // Strip CR/LF from request-derived params before logging (log-injection
+    // resistance, same convention as the view-i18n handler below).
+    log.warn("collections", "remote-view items failed", {
+      slug: req.params.slug.replace(/[\r\n]/g, " "),
+      viewId: req.params.viewId.replace(/[\r\n]/g, " "),
+      error: errorMessage(err),
+    });
     serverError(res, errorMessage(err));
   }
 });

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -47,10 +47,13 @@ import {
   mutateRemoteView,
   mutateRemoteViewFailureMessage,
   remoteViewFailureMessage,
+  remoteViewItems,
+  remoteViewItemsFailureMessage,
   type MutateRemoteViewResult,
   type RemoteViewBuildResult,
+  type RemoteViewItemsResult,
 } from "../../workspace/collections/remoteView.js";
-import { normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { clampLimit, clampOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { badRequest, notFound, conflict, forbidden, serverError } from "../../utils/httpError.js";
 import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
@@ -564,6 +567,48 @@ router.post(API_ROUTES.collections.remoteViewMutate, async (req: Request<{ slug:
     res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
   } catch (err) {
     log.warn("collections", "remote-view mutate failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+});
+
+/** A `fields` projection arrives as a CSV query string (`?fields=title,photo`)
+ *  or repeated params; hand `normalizeFields` an array either way. */
+function csvParam(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) return value.map((entry) => String(entry));
+  if (typeof value === "string" && value.length > 0) return value.split(",");
+  return undefined;
+}
+
+/** Map a non-ok item-page build to its HTTP error (message shared with the
+ *  channel handler via `remoteViewItemsFailureMessage`). */
+function sendRemoteViewItemsFailure(res: Response, result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): void {
+  const message = remoteViewItemsFailureMessage(result, slug);
+  if (result.kind === "view-not-found") notFound(res, message);
+  else badRequest(res, message);
+}
+
+// One page of a mobile view's records with its declared `imageFields` inlined as
+// `data:` URL thumbnails — the desktop phone-frame preview's paging source.
+// Behind the global bearer. Same builder as the command channel's
+// `getRemoteViewItems`, so the preview pages the exact data (real thumbnails)
+// the phone will (plans/feat-remote-view-images.md).
+router.get(API_ROUTES.collections.remoteViewItems, async (req: Request<{ slug: string; viewId: string }>, res: Response) => {
+  try {
+    const { slug, viewId } = req.params;
+    const request = { offset: clampOffset(req.query.offset), limit: clampLimit(req.query.limit), fields: normalizeFields(csvParam(req.query.fields)) };
+    const collection = await loadCollection(slug);
+    if (!collection) {
+      notFound(res, `collection '${slug}' not found`);
+      return;
+    }
+    const result = await remoteViewItems(collection, viewId, request);
+    if (result.kind !== "ok") {
+      sendRemoteViewItemsFailure(res, result, slug);
+      return;
+    }
+    res.json({ page: result.page, inlined: result.inlined, omitted: result.omitted });
+  } catch (err) {
+    log.warn("collections", "remote-view items failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });

--- a/server/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/remoteHost/handlers/getRemoteViewItems.ts
@@ -1,0 +1,38 @@
+// getRemoteViewItems command handler (remote-host phase 5 —
+// plans/feat-remote-view-images.md).
+//
+// One page of a mobile view's records, view-aware so the host can inline the
+// view's declared `imageFields` as `data:` URL thumbnails (a phone can't reach
+// the workspace to render an image path). Same builder the desktop phone-frame
+// preview reads over HTTP, so preview === phone. Supersedes the phase-2
+// getCollection for a custom view's getItems: the page is already projected +
+// image-inlined, so the mulmoserver client passes it straight to the view.
+//
+// Factory (createGetRemoteViewItems) keeps the mapping unit-testable with the
+// engine stubbed; the default export wires the real functions.
+import { clampLimit, clampOffset, normalizeFields } from "@mulmoclaude/core/remote-view";
+import { loadCollection } from "../../workspace/collections/index.js";
+import { remoteViewItems, remoteViewItemsFailureMessage } from "../../workspace/collections/remoteView.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface GetRemoteViewItemsDeps {
+  loadCollection: typeof loadCollection;
+  remoteViewItems: typeof remoteViewItems;
+}
+
+export const createGetRemoteViewItems =
+  (deps: GetRemoteViewItemsDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    const slug = String(params.slug ?? "");
+    const viewId = String(params.viewId ?? "");
+    const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), fields: normalizeFields(params.fields) };
+    const collection = await deps.loadCollection(slug);
+    if (!collection) throw new Error(`collection '${slug}' not found`);
+    const result = await deps.remoteViewItems(collection, viewId, request);
+    if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
+    // Plain JSON, but the interface lacks an index signature — cast like the
+    // phase-2/3 handlers.
+    return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
+  };
+
+export const getRemoteViewItems = createGetRemoteViewItems({ loadCollection, remoteViewItems });

--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -5,6 +5,7 @@ import type { CommandHandlers } from "../commandChannel.js";
 import { getCollection } from "./getCollection.js";
 import { getFeed } from "./getFeed.js";
 import { getRemoteView } from "./getRemoteView.js";
+import { getRemoteViewItems } from "./getRemoteViewItems.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
 import { listShortcuts } from "./listShortcuts.js";
@@ -18,6 +19,7 @@ export const handlers: CommandHandlers = {
   listFeeds,
   getFeed,
   getRemoteView,
+  getRemoteViewItems,
   mutateRemoteViewItem,
   startChat,
 };

--- a/server/utils/files/thumbnail-store.ts
+++ b/server/utils/files/thumbnail-store.ts
@@ -1,0 +1,97 @@
+// Downscaled `data:` URL thumbnails for remote (mobile) custom views
+// (plans/feat-remote-view-images.md). A phone can't reach the host's localhost,
+// so an `image`-type field's workspace path is unrenderable there; a view that
+// lists the field in `imageFields` gets it inlined as a small JPEG data URL the
+// host produces here. Kept a leaf util (no collection/remote-view imports) so
+// the builder in remoteView.ts is the only wiring point.
+//
+// Reads are workspace-containment-guarded (resolveWithinRoot, same discipline as
+// image-store.ts). Results are cached by (path, mtime, maxEdge) so repeated
+// pages / "load more" scrolls never re-decode the same source.
+import { readFile, realpath, stat } from "fs/promises";
+import { workspacePath } from "../../workspace/paths.js";
+import { resolveWithinRoot } from "./safe.js";
+import { log } from "../../system/logger/index.js";
+
+/** Decode → downscale to fit `maxEdge` (never enlarge) → re-encode JPEG.
+ *  Injected so tests exercise the resolver without the native `sharp` binary. */
+export type ResizeToJpeg = (input: Buffer, maxEdge: number) => Promise<Buffer>;
+
+// JPEG quality for inlined thumbnails — a size/fidelity knob; 72 keeps a
+// 512px thumbnail in the low tens of KB, well within the page budget.
+const THUMBNAIL_JPEG_QUALITY = 72;
+
+const sharpResize: ResizeToJpeg = async (input, maxEdge) => {
+  // Dynamic import: only the default resolver pulls the native binary, so tests
+  // (which inject their own resize) and code paths that never make a thumbnail
+  // don't load it.
+  const sharp = (await import("sharp")).default;
+  // `.rotate()` bakes in EXIF orientation so portrait phone photos aren't sideways.
+  return sharp(input).rotate().resize(maxEdge, maxEdge, { fit: "inside", withoutEnlargement: true }).jpeg({ quality: THUMBNAIL_JPEG_QUALITY }).toBuffer();
+};
+
+interface CacheEntry {
+  mtimeMs: number;
+  maxEdge: number;
+  dataUrl: string;
+}
+
+// In-memory, per host process. Bounded LRU (Map keeps insertion order; a get
+// re-inserts to mark recency, a set past the cap evicts the oldest).
+const MAX_CACHE_ENTRIES = 256;
+const cache = new Map<string, CacheEntry>();
+
+function cacheGet(relPath: string, mtimeMs: number, maxEdge: number): string | null {
+  const entry = cache.get(relPath);
+  if (!entry || entry.mtimeMs !== mtimeMs || entry.maxEdge !== maxEdge) return null;
+  cache.delete(relPath);
+  cache.set(relPath, entry);
+  return entry.dataUrl;
+}
+
+function cacheSet(relPath: string, entry: CacheEntry): void {
+  cache.set(relPath, entry);
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+/** Test-only: drop the cache so a spy on the resize fn sees a fresh encode. */
+export function clearThumbnailCache(): void {
+  cache.clear();
+}
+
+/** Resolve a workspace-relative image path to a downscaled JPEG `data:` URL, or
+ *  `null` when the path escapes the workspace, is missing, or can't be decoded —
+ *  the caller then leaves the field as its original path (rendered as a
+ *  placeholder by the view). `maxEdge` should already be clamped by the caller
+ *  (`clampImageMaxEdge`). */
+export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize) {
+  return async function resolveThumbnail(relPath: string, maxEdge: number): Promise<string | null> {
+    if (typeof relPath !== "string" || relPath.length === 0) return null;
+    let root: string;
+    try {
+      root = await realpath(workspacePath);
+    } catch {
+      return null;
+    }
+    const abs = resolveWithinRoot(root, relPath);
+    if (!abs) return null;
+    const info = await stat(abs).catch(() => null);
+    if (!info?.isFile()) return null;
+    const cached = cacheGet(relPath, info.mtimeMs, maxEdge);
+    if (cached) return cached;
+    try {
+      const out = await resize(await readFile(abs), maxEdge);
+      const dataUrl = `data:image/jpeg;base64,${out.toString("base64")}`;
+      cacheSet(relPath, { mtimeMs: info.mtimeMs, maxEdge, dataUrl });
+      return dataUrl;
+    } catch (err) {
+      log.warn("thumbnail", "resolve failed", { relPath, error: String(err) });
+      return null;
+    }
+  };
+}
+
+export const resolveThumbnail = createThumbnailResolver();

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -10,9 +10,21 @@
 // its status; the channel handler converts non-ok to a thrown error via
 // `remoteViewFailureMessage`. Factory keeps the mapping unit-testable with the
 // engine stubbed.
-import { buildRemoteViewSrcdoc, REMOTE_VIEW_MAX_BYTES, type RemoteViewMutateRequest } from "@mulmoclaude/core/remote-view";
+import {
+  buildRemoteViewSrcdoc,
+  clampImageMaxEdge,
+  pageFromItems,
+  REMOTE_VIEW_ITEMS_MAX_BYTES,
+  REMOTE_VIEW_MAX_BYTES,
+  type RemoteViewItem,
+  type RemoteViewMutateRequest,
+  type RemoteViewPage,
+  type RemoteViewPageRequest,
+} from "@mulmoclaude/core/remote-view";
+import { deriveAll } from "@mulmoclaude/core/collection";
 import {
   deleteItem,
+  listItems,
   readCustomViewHtml,
   readCustomViewI18n,
   readItem,
@@ -20,8 +32,10 @@ import {
   writeItem,
   type CollectionCustomView,
   type CollectionItem,
+  type CollectionSchema,
   type LoadedCollection,
 } from "./index.js";
+import { resolveThumbnail } from "../../utils/files/thumbnail-store.js";
 
 export interface RemoteViewInfo {
   id: string;
@@ -159,6 +173,92 @@ async function updateViaView(
 }
 
 export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem });
+
+// ── Item pages with inlined image thumbnails (phase 5 — plans/feat-remote-view-images.md) ──
+// A mobile view's `getItems`, view-aware so it can inline the `imageFields` its
+// declaration whitelists: derive computed fields → slice/project (the phase-2
+// page semantics) → replace each declared image-type field's workspace path with
+// a downscaled `data:` URL thumbnail, within a per-page byte budget so the 1 MiB
+// command doc is never risked. Shared by the `getRemoteViewItems` channel handler
+// (phone) and the `…/remote-view/:viewId/items` HTTP route (desktop preview).
+
+export type RemoteViewItemsResult =
+  { kind: "ok"; page: RemoteViewPage; inlined: number; omitted: number } | { kind: "view-not-found"; viewId: string } | { kind: "not-mobile"; viewId: string };
+
+export interface RemoteViewItemsDeps {
+  listItems: typeof listItems;
+  resolveThumbnail: typeof resolveThumbnail;
+}
+
+/** The declared image fields that are actually inlineable this page: image-type
+ *  in the schema AND kept by the request's `fields` projection (a projection
+ *  that dropped the column ships no image bytes). A declared non-image field is
+ *  ignored, not an error. */
+function inlineFields(view: CollectionCustomView, schema: CollectionSchema, requested: string[] | undefined): string[] {
+  const declared = view.imageFields ?? [];
+  if (declared.length === 0) return [];
+  const kept = requested ? new Set([schema.primaryKey, ...requested]) : null;
+  return declared.filter((name) => schema.fields[name]?.type === "image" && (kept === null || kept.has(name)));
+}
+
+/** Replace declared image paths with thumbnail `data:` URLs in place, stopping
+ *  once the accumulated thumbnail bytes would exceed `budget` — a field left as
+ *  its path (over budget, unresolvable, or already inlined) counts as `omitted`
+ *  and the view renders it as a placeholder. */
+async function inlineImages(
+  items: RemoteViewItem[],
+  fields: string[],
+  maxEdge: number,
+  deps: RemoteViewItemsDeps,
+  budget: number,
+): Promise<{ inlined: number; omitted: number }> {
+  let used = 0;
+  let inlined = 0;
+  let omitted = 0;
+  for (const item of items) {
+    for (const field of fields) {
+      const value = item[field];
+      if (typeof value !== "string" || value.length === 0 || value.startsWith("data:")) continue;
+      const dataUrl = used < budget ? await deps.resolveThumbnail(value, maxEdge) : null;
+      if (dataUrl && used + dataUrl.length <= budget) {
+        item[field] = dataUrl;
+        used += dataUrl.length;
+        inlined += 1;
+      } else {
+        omitted += 1;
+      }
+    }
+  }
+  return { inlined, omitted };
+}
+
+export const createRemoteViewItems =
+  (deps: RemoteViewItemsDeps) =>
+  async (collection: LoadedCollection, viewId: string, request: RemoteViewPageRequest): Promise<RemoteViewItemsResult> => {
+    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+    if (!view) return { kind: "view-not-found", viewId };
+    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    // Derive record-local formulas with an empty ref cache — same as the phase-2
+    // channel handlers and the preview, so `getItems` numbers match the desktop.
+    const derived = (await deps.listItems(collection.dataDir)).map((item) => deriveAll(collection.schema, item, {}) as RemoteViewItem);
+    const page = pageFromItems(derived, request, collection.schema.primaryKey);
+    const fields = inlineFields(view, collection.schema, request.fields);
+    if (fields.length === 0) return { kind: "ok", page, inlined: 0, omitted: 0 };
+    // Budget the thumbnails against what's left of the doc after the (tiny,
+    // path-only) base JSON, so the serialized page stays under the cap.
+    const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - Buffer.byteLength(JSON.stringify(page), "utf8");
+    const { inlined, omitted } = await inlineImages(page.items, fields, clampImageMaxEdge(view.imageMaxEdge), deps, Math.max(0, budget));
+    return { kind: "ok", page, inlined, omitted };
+  };
+
+export const remoteViewItems = createRemoteViewItems({ listItems, resolveThumbnail });
+
+/** Message per non-ok item-page kind — shared by the channel handler (throws)
+ *  and the HTTP route (sends with the matching status). */
+export function remoteViewItemsFailureMessage(result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): string {
+  if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+  return `custom view '${result.viewId}' not found on collection '${slug}'`;
+}
 
 /** Message per non-ok mutate kind — shared by the channel handler (throws) and
  *  the HTTP route (sends with the matching status). */

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -172,10 +172,16 @@ async function updateViaView(
   // declared image fields inlined as `data:` URLs — so a view that merges the
   // result (as the help file recommends) doesn't clobber a good thumbnail with a
   // bare path. No projection here (the whole record is returned), so inline every
-  // declared image-type field; the single item easily fits the doc budget.
+  // declared image-type field. Budget the thumbnail against the serialized item
+  // (same as the page builder) so a record with large text/markdown fields can't
+  // push the mutate result over the command-document cap — over budget, the field
+  // stays a path (placeholder), never a doc-write failure.
   const item = result.item as RemoteViewItem;
   const imageFields = inlineFields(view, collection.schema, undefined);
-  if (imageFields.length > 0) await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, REMOTE_VIEW_ITEMS_MAX_BYTES);
+  if (imageFields.length > 0) {
+    const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - Buffer.byteLength(JSON.stringify(item), "utf8");
+    await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, Math.max(0, budget));
+  }
   return { kind: "ok", op: "update", item: item as CollectionItem };
 }
 

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -118,6 +118,7 @@ export interface MutateRemoteViewDeps {
   readItem: typeof readItem;
   writeItem: typeof writeItem;
   deleteItem: typeof deleteItem;
+  resolveThumbnail: typeof resolveThumbnail;
 }
 
 export const createMutateRemoteView =
@@ -127,9 +128,7 @@ export const createMutateRemoteView =
     if (!view) return { kind: "view-not-found", viewId };
     if (view.target !== "mobile") return { kind: "not-mobile", viewId };
     if (!isWritableView(view)) return { kind: "not-writable", viewId };
-    return request.op === "delete"
-      ? deleteViaView(deps, collection, view.allowDelete === true, request.id)
-      : updateViaView(deps, collection, view.editableFields ?? [], request);
+    return request.op === "delete" ? deleteViaView(deps, collection, view.allowDelete === true, request.id) : updateViaView(deps, collection, view, request);
   };
 
 async function deleteViaView(deps: MutateRemoteViewDeps, collection: LoadedCollection, allowDelete: boolean, itemId: string): Promise<MutateRemoteViewResult> {
@@ -144,13 +143,13 @@ async function deleteViaView(deps: MutateRemoteViewDeps, collection: LoadedColle
 async function updateViaView(
   deps: MutateRemoteViewDeps,
   collection: LoadedCollection,
-  editableFields: string[],
+  view: CollectionCustomView,
   request: Extract<RemoteViewMutateRequest, { op: "update" }>,
 ): Promise<MutateRemoteViewResult> {
   const { primaryKey } = collection.schema;
   const patchKeys = Object.keys(request.patch);
   if (patchKeys.length === 0) return { kind: "invalid-patch" };
-  const allowed = new Set(editableFields);
+  const allowed = new Set(view.editableFields ?? []);
   // The primary key is never patchable (it is the record id — renaming it would
   // desync the file name from the record) even if an author listed it.
   const offending = patchKeys.find((key) => key === primaryKey || !allowed.has(key));
@@ -169,10 +168,18 @@ async function updateViaView(
   if (result.kind === "invalid-id") return { kind: "invalid-id", id: result.itemId };
   if (result.kind === "path-escape") return { kind: "path-escape" };
   if (result.kind === "conflict") return { kind: "item-not-found", id: result.itemId }; // unreachable: refuseOverwrite is false
-  return { kind: "ok", op: "update", item: result.item };
+  // The returned item must be shaped like a `getItems` item — with the view's
+  // declared image fields inlined as `data:` URLs — so a view that merges the
+  // result (as the help file recommends) doesn't clobber a good thumbnail with a
+  // bare path. No projection here (the whole record is returned), so inline every
+  // declared image-type field; the single item easily fits the doc budget.
+  const item = result.item as RemoteViewItem;
+  const imageFields = inlineFields(view, collection.schema, undefined);
+  if (imageFields.length > 0) await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, REMOTE_VIEW_ITEMS_MAX_BYTES);
+  return { kind: "ok", op: "update", item: item as CollectionItem };
 }
 
-export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem });
+export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem, resolveThumbnail });
 
 // ── Item pages with inlined image thumbnails (phase 5 — plans/feat-remote-view-images.md) ──
 // A mobile view's `getItems`, view-aware so it can inline the `imageFields` its
@@ -209,7 +216,7 @@ async function inlineImages(
   items: RemoteViewItem[],
   fields: string[],
   maxEdge: number,
-  deps: RemoteViewItemsDeps,
+  resolve: typeof resolveThumbnail,
   budget: number,
 ): Promise<{ inlined: number; omitted: number }> {
   let used = 0;
@@ -219,7 +226,7 @@ async function inlineImages(
     for (const field of fields) {
       const value = item[field];
       if (typeof value !== "string" || value.length === 0 || value.startsWith("data:")) continue;
-      const dataUrl = used < budget ? await deps.resolveThumbnail(value, maxEdge) : null;
+      const dataUrl = used < budget ? await resolve(value, maxEdge) : null;
       if (dataUrl && used + dataUrl.length <= budget) {
         item[field] = dataUrl;
         used += dataUrl.length;
@@ -247,7 +254,7 @@ export const createRemoteViewItems =
     // Budget the thumbnails against what's left of the doc after the (tiny,
     // path-only) base JSON, so the serialized page stays under the cap.
     const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - Buffer.byteLength(JSON.stringify(page), "utf8");
-    const { inlined, omitted } = await inlineImages(page.items, fields, clampImageMaxEdge(view.imageMaxEdge), deps, Math.max(0, budget));
+    const { inlined, omitted } = await inlineImages(page.items, fields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, Math.max(0, budget));
     return { kind: "ok", page, inlined, omitted };
   };
 

--- a/src/composables/collections/uiHost.ts
+++ b/src/composables/collections/uiHost.ts
@@ -14,6 +14,7 @@ import {
   configureCollectionUi,
   type CollectionRemoteViewResult,
   type CollectionRemoteViewMutateResult,
+  type CollectionRemoteViewItemsResult,
   type CollectionViewI18nResult,
   type CollectionViewToken,
   type RegistryListResponse,
@@ -61,6 +62,8 @@ const viewDeleteUrl = (slug: string, viewId: string): string =>
   withSlug(API_ROUTES.collections.viewDelete, slug).replace(":viewId", encodeURIComponent(viewId));
 const remoteViewMutateUrl = (slug: string, viewId: string): string =>
   withSlug(API_ROUTES.collections.remoteViewMutate, slug).replace(":viewId", encodeURIComponent(viewId));
+const remoteViewItemsUrl = (slug: string, viewId: string): string =>
+  withSlug(API_ROUTES.collections.remoteViewItems, slug).replace(":viewId", encodeURIComponent(viewId));
 
 // ── Deferred app bindings (need a component context; set by App.vue setup) ──
 type StartChat = (prompt: string, role: string) => void;
@@ -104,6 +107,12 @@ configureCollectionUi({
   fetchViewI18n: (slug, viewId, locale) => apiGet<CollectionViewI18nResult>(withSlug(API_ROUTES.collections.viewI18n, slug), { id: viewId, locale }),
   fetchRemoteView: (slug, viewId, locale) => apiGet<CollectionRemoteViewResult>(withSlug(API_ROUTES.collections.remoteView, slug), { id: viewId, locale }),
   mutateRemoteView: (slug, viewId, request) => apiPost<CollectionRemoteViewMutateResult>(remoteViewMutateUrl(slug, viewId), request),
+  fetchRemoteViewItems: (slug, viewId, request) =>
+    apiGet<CollectionRemoteViewItemsResult>(remoteViewItemsUrl(slug, viewId), {
+      offset: request.offset,
+      limit: request.limit,
+      fields: request.fields?.join(",") || undefined,
+    }),
   buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
 
   // record CRUD + actions

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -306,6 +306,13 @@ const HOST_API_ROUTES = {
      *  command channel's `mutateRemoteViewItem` uses, so preview === phone
      *  (plans/feat-remote-writable-view.md). */
     remoteViewMutate: "/api/collections/:slug/remote-view/:viewId/mutate",
+    /** GET ?offset&limit&fields=<csv> → one page of a `target: "mobile"` view's
+     *  records with its declared `imageFields` inlined as `data:` URL thumbnails
+     *  (global-bearer auth) → { page, inlined, omitted }. Same builder as the
+     *  command channel's `getRemoteViewItems`, so the desktop phone-frame preview
+     *  pages the exact data (incl. real thumbnails) the phone will
+     *  (plans/feat-remote-view-images.md). */
+    remoteViewItems: "/api/collections/:slug/remote-view/:viewId/items",
     /** GET ?id=<viewId>&locale=<tag> → translation dict for one custom view
      *  (global-bearer auth) → { locale, dict }. `dict` is the host-picked
      *  flat map for the requested locale (fallback `"en"`, else `{}`); the

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -27,6 +27,10 @@ const deps = (overrides: Partial<MutateRemoteViewDeps> = {}): MutateRemoteViewDe
   readItem: (async () => ({ ...record })) as unknown as MutateRemoteViewDeps["readItem"],
   writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
   deleteItem: (async (_dir: string, itemId: string) => ({ kind: "ok", itemId })) as unknown as MutateRemoteViewDeps["deleteItem"],
+  // A declared-image view inlines the returned item's image fields; the default
+  // view here declares none, so this is only exercised by the dedicated test below.
+  resolveThumbnail: (async (relPath: string) =>
+    `data:image/jpeg;base64,${Buffer.from(relPath).toString("base64")}`) as MutateRemoteViewDeps["resolveThumbnail"],
   ...overrides,
 });
 
@@ -45,6 +49,25 @@ describe("createMutateRemoteView", () => {
     assert.deepEqual(result, { kind: "ok", op: "update", item: { id: "t1", title: "buy milk", done: true } });
     // The patch merges — untouched fields survive, id is pinned to the URL id.
     assert.deepEqual(written, { id: "t1", title: "buy milk", done: true });
+  });
+
+  it("inlines the view's declared image fields on the returned update item", async () => {
+    // Regression: the returned item must be shaped like a getItems item (image
+    // fields as data: URLs), else a view that merges the result clobbers its
+    // inlined thumbnail with a bare path and the image disappears.
+    const withImage = collection([{ ...writableView, editableFields: ["rating"], imageFields: ["poster"] }]);
+    withImage.schema.fields = { id: { type: "string" }, rating: { type: "string" }, poster: { type: "image" } } as unknown as typeof withImage.schema.fields;
+    const mutate = createMutateRemoteView(
+      deps({
+        readItem: (async () => ({ id: "t1", rating: "", poster: "images/a.png" })) as unknown as MutateRemoteViewDeps["readItem"],
+        writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
+      }),
+    );
+    const result = await mutate(withImage, "phone", { op: "update", id: "t1", patch: { rating: "★★★" } });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok" || result.op !== "update") return;
+    assert.equal(result.item.rating, "★★★");
+    assert.match(String(result.item.poster), /^data:image\/jpeg;base64,/); // inlined, not the path
   });
 
   it("deletes a record when allowDelete is set", async () => {

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -4,6 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
+import { REMOTE_VIEW_ITEMS_MAX_BYTES } from "@mulmoclaude/core/remote-view";
 import { createMutateRemoteView, mutateRemoteViewFailureMessage, type MutateRemoteViewDeps } from "../../server/workspace/collections/remoteView.js";
 import { createMutateRemoteViewHandler, type MutateRemoteViewHandlerDeps } from "../../server/remoteHost/handlers/mutateRemoteView.js";
 import { handlers } from "../../server/remoteHost/handlers/index.js";
@@ -68,6 +69,29 @@ describe("createMutateRemoteView", () => {
     if (result.kind !== "ok" || result.op !== "update") return;
     assert.equal(result.item.rating, "★★★");
     assert.match(String(result.item.poster), /^data:image\/jpeg;base64,/); // inlined, not the path
+  });
+
+  it("leaves the image as a path when the returned item is already over budget", async () => {
+    // A record with a huge text field (near the whole 900 KB doc budget) leaves
+    // no room for a thumbnail — the field must stay a path, not overflow the doc.
+    const withImage = collection([{ ...writableView, editableFields: ["rating"], imageFields: ["poster"] }]);
+    withImage.schema.fields = {
+      id: { type: "string" },
+      rating: { type: "string" },
+      poster: { type: "image" },
+      notes: { type: "text" },
+    } as unknown as typeof withImage.schema.fields;
+    const huge = "x".repeat(REMOTE_VIEW_ITEMS_MAX_BYTES);
+    const mutate = createMutateRemoteView(
+      deps({
+        readItem: (async () => ({ id: "t1", rating: "", poster: "images/a.png", notes: huge })) as unknown as MutateRemoteViewDeps["readItem"],
+        writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
+      }),
+    );
+    const result = await mutate(withImage, "phone", { op: "update", id: "t1", patch: { rating: "★" } });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok" || result.op !== "update") return;
+    assert.equal(result.item.poster, "images/a.png"); // left as path — no budget for a thumbnail
   });
 
   it("deletes a record when allowDelete is set", async () => {

--- a/test/remoteHost/test_remoteViewItems.ts
+++ b/test/remoteHost/test_remoteViewItems.ts
@@ -1,0 +1,141 @@
+// Unit tests for the phase-5 remote view item pages: the shared
+// createRemoteViewItems builder (engine + thumbnail resolver stubbed) and the
+// getRemoteViewItems command handler over it. See plans/feat-remote-view-images.md.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { REMOTE_VIEW_ITEMS_MAX_BYTES } from "@mulmoclaude/core/remote-view";
+import { createRemoteViewItems, remoteViewItemsFailureMessage, type RemoteViewItemsDeps } from "../../server/workspace/collections/remoteView.js";
+import { createGetRemoteViewItems, type GetRemoteViewItemsDeps } from "../../server/remoteHost/handlers/getRemoteViewItems.js";
+import { handlers } from "../../server/remoteHost/handlers/index.js";
+import type { LoadedCollection } from "../../server/workspace/collections/index.js";
+
+// A collection with an image-type `photo` field and a plain `note` field, so the
+// builder can prove it inlines only declared image-type fields.
+const collection = (view: Record<string, unknown>): LoadedCollection =>
+  ({
+    slug: "plan",
+    source: "project",
+    skillDir: "/s/plan",
+    dataDir: "/d/plan",
+    schema: {
+      primaryKey: "id",
+      fields: { id: { type: "string" }, title: { type: "string" }, photo: { type: "image" }, note: { type: "string" } },
+      views: [view],
+    },
+  }) as unknown as LoadedCollection;
+
+const RECORDS = [
+  { id: "a", title: "A", photo: "images/a.png", note: "n1" },
+  { id: "b", title: "B", photo: "images/b.png", note: "n2" },
+];
+
+const deps = (overrides: Partial<RemoteViewItemsDeps> = {}): RemoteViewItemsDeps => ({
+  listItems: (async () => RECORDS) as unknown as RemoteViewItemsDeps["listItems"],
+  // Deterministic stub: a short data URL derived from the path (no native binary).
+  resolveThumbnail: (async (relPath: string) => `data:image/jpeg;base64,${Buffer.from(relPath).toString("base64")}`) as RemoteViewItemsDeps["resolveThumbnail"],
+  ...overrides,
+});
+
+const view = (extra: Record<string, unknown> = {}) => ({ id: "gallery", label: "Gallery", target: "mobile", file: "views/gallery.html", ...extra });
+
+describe("createRemoteViewItems", () => {
+  it("refuses an unknown view and a desktop view", async () => {
+    const build = createRemoteViewItems(deps());
+    assert.deepEqual((await build(collection(view()), "ghost", { offset: 0, limit: 50 })).kind, "view-not-found");
+    const desktop = { id: "year", label: "Year", file: "views/year.html" };
+    assert.deepEqual((await build(collection(desktop), "year", { offset: 0, limit: 50 })).kind, "not-mobile");
+  });
+
+  it("returns a projected page with no inlining when no imageFields declared", async () => {
+    const build = createRemoteViewItems(deps());
+    const result = await build(collection(view()), "gallery", { offset: 0, limit: 50, fields: ["title"] });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.equal(result.inlined, 0);
+    assert.deepEqual(result.page.items[0], { id: "a", title: "A" }); // projected, photo dropped
+  });
+
+  it("inlines a declared image field that survives the projection", async () => {
+    const build = createRemoteViewItems(deps());
+    const result = await build(collection(view({ imageFields: ["photo"] })), "gallery", { offset: 0, limit: 50, fields: ["title", "photo"] });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.equal(result.inlined, 2);
+    assert.equal(result.omitted, 0);
+    assert.match(String(result.page.items[0].photo), /^data:image\/jpeg;base64,/);
+  });
+
+  it("does not inline a declared field the projection dropped", async () => {
+    const build = createRemoteViewItems(deps());
+    const result = await build(collection(view({ imageFields: ["photo"] })), "gallery", { offset: 0, limit: 50, fields: ["title"] });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.equal(result.inlined, 0);
+    assert.equal(result.page.items[0].photo, undefined); // dropped by projection, nothing to inline
+  });
+
+  it("ignores a declared field that is not image-type", async () => {
+    const build = createRemoteViewItems(deps());
+    // `note` is a plain string field — declaring it must not inline it.
+    const result = await build(collection(view({ imageFields: ["note"] })), "gallery", { offset: 0, limit: 50, fields: ["title", "note", "photo"] });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.equal(result.inlined, 0);
+    assert.equal(result.page.items[0].note, "n1"); // untouched
+    assert.equal(result.page.items[0].photo, "images/a.png"); // photo not declared → left as path
+  });
+
+  it("stops inlining once the page byte budget is exceeded, leaving the rest as paths", async () => {
+    // Each thumbnail is half the budget, so the first fits and the second overflows.
+    const big = `data:image/jpeg;base64,${"x".repeat(Math.floor(REMOTE_VIEW_ITEMS_MAX_BYTES / 2))}`;
+    const build = createRemoteViewItems(deps({ resolveThumbnail: (async () => big) as RemoteViewItemsDeps["resolveThumbnail"] }));
+    const result = await build(collection(view({ imageFields: ["photo"] })), "gallery", { offset: 0, limit: 50, fields: ["photo"] });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.equal(result.inlined, 1);
+    assert.equal(result.omitted, 1);
+    assert.equal(result.page.items[0].photo, big); // inlined
+    assert.equal(result.page.items[1].photo, "images/b.png"); // left as path (over budget)
+  });
+
+  it("maps failure kinds to actionable messages", () => {
+    assert.match(remoteViewItemsFailureMessage({ kind: "view-not-found", viewId: "v" }, "plan"), /'v' not found on collection 'plan'/);
+    assert.match(remoteViewItemsFailureMessage({ kind: "not-mobile", viewId: "v" }, "plan"), /target: "mobile"/);
+  });
+});
+
+describe("createGetRemoteViewItems", () => {
+  const handlerDeps = (overrides: Partial<GetRemoteViewItemsDeps> = {}): GetRemoteViewItemsDeps => ({
+    loadCollection: (async (slug: string) =>
+      slug === "missing" ? null : collection(view({ imageFields: ["photo"] }))) as unknown as GetRemoteViewItemsDeps["loadCollection"],
+    remoteViewItems: (async () => ({
+      kind: "ok",
+      page: { items: [], total: 0, offset: 0, limit: 50 },
+      inlined: 3,
+      omitted: 1,
+    })) as unknown as GetRemoteViewItemsDeps["remoteViewItems"],
+    ...overrides,
+  });
+
+  it("returns { page, inlined, omitted } for a mobile view", async () => {
+    const handler = createGetRemoteViewItems(handlerDeps());
+    assert.deepEqual(await handler({ slug: "plan", viewId: "gallery" }), { page: { items: [], total: 0, offset: 0, limit: 50 }, inlined: 3, omitted: 1 });
+  });
+
+  it("throws when the collection is not found", async () => {
+    const handler = createGetRemoteViewItems(handlerDeps());
+    await assert.rejects(async () => handler({ slug: "missing", viewId: "gallery" }), /collection 'missing' not found/);
+  });
+
+  it("throws the shared failure message on a non-ok build", async () => {
+    const handler = createGetRemoteViewItems(
+      handlerDeps({ remoteViewItems: (async () => ({ kind: "not-mobile", viewId: "year" })) as unknown as GetRemoteViewItemsDeps["remoteViewItems"] }),
+    );
+    await assert.rejects(async () => handler({ slug: "plan", viewId: "year" }), /not a mobile view/);
+  });
+
+  it("is registered in the runner's method table", () => {
+    assert.equal(typeof handlers.getRemoteViewItems, "function");
+  });
+});

--- a/test/utils/files/test_thumbnail_store.ts
+++ b/test/utils/files/test_thumbnail_store.ts
@@ -1,0 +1,84 @@
+// Unit tests for the remote-view thumbnail resolver (phase 5 —
+// plans/feat-remote-view-images.md). The resize step is injected so no native
+// `sharp` binary is needed; the test exercises workspace containment, the
+// mtime-keyed cache, and the graceful-null failure paths against real temp files
+// under the workspace root.
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { workspacePath } from "../../../server/workspace/paths.js";
+import { clearThumbnailCache, createThumbnailResolver, type ResizeToJpeg } from "../../../server/utils/files/thumbnail-store.js";
+
+const DIR_REL = "thumb-test";
+const DIR_ABS = path.join(workspacePath, DIR_REL);
+
+// A spy resize that records the edges it was called with and echoes them (the
+// source bytes are irrelevant — real decoding is sharp's job, stubbed out here).
+function spyResize(): ResizeToJpeg & { calls: number[] } {
+  const calls: number[] = [];
+  const resize = (async (_input: Buffer, maxEdge: number) => {
+    calls.push(maxEdge);
+    return Buffer.from(`resized@${maxEdge}`);
+  }) as ResizeToJpeg & { calls: number[] };
+  resize.calls = calls;
+  return resize;
+}
+
+beforeEach(async () => {
+  clearThumbnailCache();
+  await mkdir(DIR_ABS, { recursive: true });
+  await writeFile(path.join(DIR_ABS, "pic.png"), Buffer.from("not-a-real-png-but-fine"));
+});
+
+afterEach(async () => {
+  await rm(DIR_ABS, { recursive: true, force: true });
+});
+
+describe("resolveThumbnail", () => {
+  it("resolves a workspace image to a JPEG data URL, passing the requested edge to resize", async () => {
+    const resize = spyResize();
+    const resolve = createThumbnailResolver(resize);
+    const dataUrl = await resolve(`${DIR_REL}/pic.png`, 384);
+    assert.equal(resize.calls.length, 1);
+    assert.deepEqual(resize.calls, [384]);
+    assert.equal(dataUrl, `data:image/jpeg;base64,${Buffer.from("resized@384").toString("base64")}`);
+  });
+
+  it("serves a second call for the same (path, mtime, edge) from cache without re-encoding", async () => {
+    const resize = spyResize();
+    const resolve = createThumbnailResolver(resize);
+    const first = await resolve(`${DIR_REL}/pic.png`, 512);
+    const second = await resolve(`${DIR_REL}/pic.png`, 512);
+    assert.equal(first, second);
+    assert.equal(resize.calls.length, 1); // second was a cache hit
+  });
+
+  it("re-encodes when the requested edge differs (distinct cache key)", async () => {
+    const resize = spyResize();
+    const resolve = createThumbnailResolver(resize);
+    await resolve(`${DIR_REL}/pic.png`, 256);
+    await resolve(`${DIR_REL}/pic.png`, 512);
+    assert.deepEqual(resize.calls, [256, 512]);
+  });
+
+  it("returns null for a path escaping the workspace, without calling resize", async () => {
+    const resize = spyResize();
+    const resolve = createThumbnailResolver(resize);
+    assert.equal(await resolve("../../etc/passwd", 512), null);
+    assert.equal(resize.calls.length, 0);
+  });
+
+  it("returns null for a missing file", async () => {
+    const resolve = createThumbnailResolver(spyResize());
+    assert.equal(await resolve(`${DIR_REL}/nope.png`, 512), null);
+  });
+
+  it("returns null (not throw) when resize fails", async () => {
+    const resolve = createThumbnailResolver(async () => {
+      throw new Error("unsupported image");
+    });
+    assert.equal(await resolve(`${DIR_REL}/pic.png`, 512), null);
+  });
+});

--- a/test/workspace/collections/test_discovery_views.ts
+++ b/test/workspace/collections/test_discovery_views.ts
@@ -75,4 +75,14 @@ describe("collection schema — custom views validation", () => {
     assert.equal(withViews([{ id: "phone", label: "Phone", file: "views/phone.html", target: "mobile", editableFields: [""] }]).success, false);
     assert.equal(withViews([{ id: "phone", label: "Phone", file: "views/phone.html", target: "mobile", allowDelete: "yes" }]).success, false);
   });
+
+  it("accepts mobile imageFields / imageMaxEdge, rejects wrong types", () => {
+    const gallery = { id: "gallery", label: "Gallery", file: "views/gallery.html", target: "mobile" as const };
+    assert.equal(withViews([{ ...gallery, imageFields: ["photo"], imageMaxEdge: 384 }]).success, true);
+    assert.equal(withViews([{ ...gallery, imageFields: ["photo"] }]).success, true); // imageMaxEdge optional
+    assert.equal(withViews([{ ...gallery, imageFields: "photo" }]).success, false); // not an array
+    assert.equal(withViews([{ ...gallery, imageFields: [""] }]).success, false); // empty field name
+    assert.equal(withViews([{ ...gallery, imageMaxEdge: 384.5 }]).success, false); // not an int
+    assert.equal(withViews([{ ...gallery, imageMaxEdge: "384" }]).success, false); // not a number
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,7 +1343,7 @@
     "@iconify/types" "^2.0.0"
     import-meta-resolve "^4.2.0"
 
-"@img/colour@^1.0.0":
+"@img/colour@^1.0.0", "@img/colour@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz#b0c2c2fa661adf75effd6b4964497cd80010bb9d"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
@@ -1355,6 +1355,13 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-arm64" "1.2.4"
 
+"@img/sharp-darwin-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz#8b2740884bc58b127fc3020479a01294fa1095cb"
+  integrity sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
+
 "@img/sharp-darwin-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz#19bc1dd6eba6d5a96283498b9c9f401180ee9c7b"
@@ -1362,55 +1369,119 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-x64" "1.2.4"
 
+"@img/sharp-darwin-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz#92df91320faf57cc54b331185770d5a93d510049"
+  integrity sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+
+"@img/sharp-freebsd-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz#48018c1379a8f507d681d6cd8dbe43d9795dc809"
+  integrity sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==
+  dependencies:
+    "@img/sharp-wasm32" "0.35.3"
+
 "@img/sharp-libvips-darwin-arm64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz#2894c0cb87d42276c3889942e8e2db517a492c43"
   integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
+
+"@img/sharp-libvips-darwin-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz#227b41ffc6c99612bceaba56f994a1933d779573"
+  integrity sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==
 
 "@img/sharp-libvips-darwin-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz#e63681f4539a94af9cd17246ed8881734386f8cc"
   integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
 
+"@img/sharp-libvips-darwin-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz#694903ec410c00945ce5b0c26dac83d7184c8b86"
+  integrity sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==
+
 "@img/sharp-libvips-linux-arm64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz#b1b288b36864b3bce545ad91fa6dadcf1a4ad318"
   integrity sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==
+
+"@img/sharp-libvips-linux-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz#49ddf156728666a21deed0716f3bb72bb351179e"
+  integrity sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==
 
 "@img/sharp-libvips-linux-arm@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz#b9260dd1ebe6f9e3bdbcbdcac9d2ac125f35852d"
   integrity sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==
 
+"@img/sharp-libvips-linux-arm@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz#e60e088c806bde1ac28be648b60c3465f41c18a7"
+  integrity sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==
+
 "@img/sharp-libvips-linux-ppc64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz#4b83ecf2a829057222b38848c7b022e7b4d07aa7"
   integrity sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==
+
+"@img/sharp-libvips-linux-ppc64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz#be3161aafd659417b3e26374dfbbcd2da2bfb62c"
+  integrity sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==
 
 "@img/sharp-libvips-linux-riscv64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz#880b4678009e5a2080af192332b00b0aaf8a48de"
   integrity sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==
 
+"@img/sharp-libvips-linux-riscv64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz#bf008a6779d9be2b56a4df67b753941f767c957d"
+  integrity sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==
+
 "@img/sharp-libvips-linux-s390x@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz#74f343c8e10fad821b38f75ced30488939dc59ec"
   integrity sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==
+
+"@img/sharp-libvips-linux-s390x@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz#9583814b8db58889c85bad9e5e0b7825257ff394"
+  integrity sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==
 
 "@img/sharp-libvips-linux-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz#df4183e8bd8410f7d61b66859a35edeab0a531ce"
   integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
 
+"@img/sharp-libvips-linux-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz#abc9a3114495b705ba20b7c1568b9eecd62aebbb"
+  integrity sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==
+
 "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz#c8d6b48211df67137541007ee8d1b7b1f8ca8e06"
   integrity sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==
 
+"@img/sharp-libvips-linuxmusl-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz#e58fb14a7879f15d9e70a982870f384f39a832a2"
+  integrity sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==
+
 "@img/sharp-libvips-linuxmusl-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz#be11c75bee5b080cbee31a153a8779448f919f75"
   integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
+
+"@img/sharp-libvips-linuxmusl-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz#5611480fcb7465dd5316044db53ad7a843ed4af8"
+  integrity sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==
 
 "@img/sharp-linux-arm64@0.34.5":
   version "0.34.5"
@@ -1419,12 +1490,26 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-arm64" "1.2.4"
 
+"@img/sharp-linux-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz#44b65823ecc977d4585b308070fff3947256de04"
+  integrity sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
+
 "@img/sharp-linux-arm@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz#5fb0c3695dd12522d39c3ff7a6bc816461780a0d"
   integrity sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==
   optionalDependencies:
     "@img/sharp-libvips-linux-arm" "1.2.4"
+
+"@img/sharp-linux-arm@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz#c8da500c4016893a89d46e9832d08a06eef77f27"
+  integrity sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.3.2"
 
 "@img/sharp-linux-ppc64@0.34.5":
   version "0.34.5"
@@ -1433,12 +1518,26 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-ppc64" "1.2.4"
 
+"@img/sharp-linux-ppc64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz#ea1d7db818f52af1e1e057e82d55f23b2de3864c"
+  integrity sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
+
 "@img/sharp-linux-riscv64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz#cdd28182774eadbe04f62675a16aabbccb833f60"
   integrity sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==
   optionalDependencies:
     "@img/sharp-libvips-linux-riscv64" "1.2.4"
+
+"@img/sharp-linux-riscv64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz#722bd7994658791b02d1037ea09ca5cb78030d8d"
+  integrity sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
 
 "@img/sharp-linux-s390x@0.34.5":
   version "0.34.5"
@@ -1447,12 +1546,26 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-s390x" "1.2.4"
 
+"@img/sharp-linux-s390x@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz#e8294817d7da495541a4a870f56e6b5d0f8643cd"
+  integrity sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
+
 "@img/sharp-linux-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz#55abc7cd754ffca5002b6c2b719abdfc846819a8"
   integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
   optionalDependencies:
     "@img/sharp-libvips-linux-x64" "1.2.4"
+
+"@img/sharp-linux-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz#9843c32f39aeac4b60dd60f9e3416520a4e4de46"
+  integrity sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.3.2"
 
 "@img/sharp-linuxmusl-arm64@0.34.5":
   version "0.34.5"
@@ -1461,12 +1574,26 @@
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
 
+"@img/sharp-linuxmusl-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz#9cfee4ecc3d41ab9a274e019dfe7b4062840510c"
+  integrity sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
+
 "@img/sharp-linuxmusl-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz#d97978aec7c5212f999714f2f5b736457e12ee9f"
   integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+
+"@img/sharp-linuxmusl-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz#204d0678c8c3b15300d9a26ecb9c0dcda11ca5de"
+  integrity sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
 
 "@img/sharp-wasm32@0.34.5":
   version "0.34.5"
@@ -1475,20 +1602,49 @@
   dependencies:
     "@emnapi/runtime" "^1.7.0"
 
+"@img/sharp-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz#42f8979bdbe1a541a2e9b99d3b5be07e6b71c7c0"
+  integrity sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==
+  dependencies:
+    "@emnapi/runtime" "^1.11.1"
+
+"@img/sharp-webcontainers-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz#823aaa93d14db84999d5b5dc967ff56cf1966d9f"
+  integrity sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==
+  dependencies:
+    "@img/sharp-wasm32" "0.35.3"
+
 "@img/sharp-win32-arm64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz#3706e9e3ac35fddfc1c87f94e849f1b75307ce0a"
   integrity sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==
+
+"@img/sharp-win32-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz#f3554d45cbe24532a0adea736ec57658f74a2911"
+  integrity sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==
 
 "@img/sharp-win32-ia32@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz#0b71166599b049e032f085fb9263e02f4e4788de"
   integrity sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==
 
+"@img/sharp-win32-ia32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz#0942b2643bcb57e48419fe4119de84078ae0ac74"
+  integrity sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==
+
 "@img/sharp-win32-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
   integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
+
+"@img/sharp-win32-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz#8a25cacdc75a8c26077c07fba51e8056aae474f1"
+  integrity sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==
 
 "@inquirer/ansi@^1.0.2":
   version "1.0.2"
@@ -8656,7 +8812,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.8.4:
+semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.8.4, semver@^7.8.5:
   version "7.8.5"
   resolved "https://npm.flatt.tech/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -8762,6 +8918,41 @@ sharp@0.34.5:
     "@img/sharp-win32-arm64" "0.34.5"
     "@img/sharp-win32-ia32" "0.34.5"
     "@img/sharp-win32-x64" "0.34.5"
+
+sharp@^0.35.3:
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.35.3.tgz#41ed21a46406be163eacd0be7b364b42fcf2885f"
+  integrity sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==
+  dependencies:
+    "@img/colour" "^1.1.0"
+    detect-libc "^2.1.2"
+    semver "^7.8.5"
+  optionalDependencies:
+    "@img/sharp-darwin-arm64" "0.35.3"
+    "@img/sharp-darwin-x64" "0.35.3"
+    "@img/sharp-freebsd-wasm32" "0.35.3"
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+    "@img/sharp-libvips-linux-arm" "1.3.2"
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
+    "@img/sharp-libvips-linux-x64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
+    "@img/sharp-linux-arm" "0.35.3"
+    "@img/sharp-linux-arm64" "0.35.3"
+    "@img/sharp-linux-ppc64" "0.35.3"
+    "@img/sharp-linux-riscv64" "0.35.3"
+    "@img/sharp-linux-s390x" "0.35.3"
+    "@img/sharp-linux-x64" "0.35.3"
+    "@img/sharp-linuxmusl-arm64" "0.35.3"
+    "@img/sharp-linuxmusl-x64" "0.35.3"
+    "@img/sharp-webcontainers-wasm32" "0.35.3"
+    "@img/sharp-win32-arm64" "0.35.3"
+    "@img/sharp-win32-ia32" "0.35.3"
+    "@img/sharp-win32-x64" "0.35.3"
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

Phase 5 of the remote (mobile) custom-view line: a `target: "mobile"` view can now **display workspace images on the phone**. It declares `imageFields`; the host inlines those `image`-type fields as **downscaled JPEG `data:` URL thumbnails** inside each `getItems` page. The phone can't reach the host's localhost, and the CSP is `connect-src 'none'`, so inlining is the only way workspace images render there — and `img-src … data:` was already open (phase 3), so nothing about the sandbox or transport changes. This is a value transform on the read path.

Validated in a real workspace: an independent in-app agent, given only the help file, authored a working image gallery (`imageFields` + writable star-ratings) that renders posters on the phone.

## Design

- **Opt-in + projection-aware** — no `imageFields` ⇒ zero thumbnails; only `imageFields ∩ projected fields` are encoded, so a view pays egress only for images it shows. (Firestore bills operations per-doc flat; the only marginal cost is bandwidth, which stays inside the free tier for normal use.)
- **Sizing** — `imageMaxEdge` per view (default 512, clamped `[64, 1024]`), `fit: inside`, no enlargement, EXIF-rotated, quality 72. A 1200×900 PNG → 384×288 JPEG @ ~900 bytes.
- **Byte budget** — a per-page cap (`REMOTE_VIEW_ITEMS_MAX_BYTES` = 900 KB) stops inlining once a page would overflow the 1 MiB command doc; over-budget fields fall back to their path (placeholder), never a doc-write failure.
- **One builder, two consumers** — `createRemoteViewItems` feeds both the `getRemoteViewItems` channel handler (phone) and `GET …/remote-view/:viewId/items` (desktop preview), so the preview pages the exact data (real thumbnails) the phone will.
- **Cache** — in-process mtime-keyed LRU (256 entries), workspace-containment-guarded like `image-store.ts`.

## Included fix

`updateItem` originally returned the raw record (image as a path) while `getItems` returned it inlined; a view merging the mutate result clobbered its thumbnail and the image vanished after an edit. The update result now inlines its declared image fields too, so a mutated record is shaped identically to a `getItems` item (cache hit from the prior read, so near-free).

## New dependency

`sharp` (native, prebuilt binaries per platform via optionalDependencies). Loaded via dynamic import so only the thumbnail path pulls it. **Worth a smoke-check on the Docker/linux image build before release.**

## Follow-up (separate repo)

mulmoserver adopts `getRemoteViewItems` for `getItems` after `@mulmoclaude/core@0.8.0` publishes. Out of scope here: public-URL (full-res) images, default card-list thumbnails, audio/video inlining, disk cache.

## Test plan

- `yarn format` / `lint` (0 errors) / `typecheck` / `build`
- Full unit suite: **5153 tests, 0 fail** — new coverage for the clamp, the resolver (containment / cache / failure), the page builder (projection / inline / budget), the update-result inlining, and the schema keys
- Real `sharp` smoke: 1200×900 PNG → 384×288 JPEG @ 917 bytes
- Manual: verified in-app — posters render in the phone frame; editing a rating keeps the thumbnail

Plan: `plans/feat-remote-view-images.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile custom views can now inline thumbnail previews for opt-in `image` fields (via image field selection and a configurable thumbnail size limit).
  * Remote-view record paging is improved with a dedicated “load more” flow and host-driven page/image-budget reporting.
  * Mobile remote-view previews now reflect the current search/filter results.

* **Bug Fixes**
  * More reliable thumbnail rendering: when a thumbnail can’t be generated, the UI falls back gracefully.

* **Documentation**
  * Expanded remote-view image documentation, including worked examples and inlining/budget rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->