### PR TITLE
fix(chat-ui): recover from missed pub/sub events + tab throttling (#1915)

### DIFF
--- a/plans/fix-1915-chat-ui-stuck-mid-turn.md
+++ b/plans/fix-1915-chat-ui-stuck-mid-turn.md
@@ -1,0 +1,61 @@
+# fix(#1915): chat UI stops updating mid-turn / thinking indicator stuck
+
+## Summary
+
+Three complementary fixes so the "考え中…" indicator can never stay stuck when the server actually finished the run:
+
+- **A** — `handleSessionFinished` flips `session.isRunning = false` locally the instant the `session_finished` event arrives, instead of waiting for the separate `sessions` channel notification to arrive on a different socket.io frame.
+- **B** — new `usePubSub().onReconnect(callback)` API. `App.vue` registers a catch-up handler that refetches `refreshSessionStates()` + the current session's transcript on every socket.io reconnect, since the pub/sub server has no replay buffer for events published during the down window.
+- **D** — the same catch-up runs on `document.visibilitychange → visible`, covering Safari's silent tab throttling (WebSocket looks `connected` server-side while delivery stops on the client — there's no `disconnect` event to hook on, so B alone doesn't cover it).
+
+**Not included** — the issue's proposed Fix C (await `persistHasUnread` in `endRun`). I traced the cursor logic; `changeMs = max(jsonl mtime, index.indexedAt, meta mtime)` in `server/api/routes/sessions.ts:212`, and jsonl mtime is dominant during a live turn. There is no real race — a session-finished summary always makes it into the diff and `applyLiveState` folds `live.isRunning = false` onto the summary. Fix C is dead-code hardening; skipping it.
+
+## Items to Confirm / Review
+
+- [ ] **Fix A trusts the event fully.** After this PR, `session.isRunning=false` is a client-side derivative of `session_finished` instead of only ever coming from the server-authoritative `sessions` list. The mutation is instant and would only be "wrong" if `session_finished` were published before the run actually ended — but `endRun()` sets `session.isRunning = false` before publishing, so the event's semantics are safe to trust.
+- [ ] **Reconnect handler runs on every socket bounce.** When the user has 20+ subscribed sessions open (a rare but real state), the catch-up will fetch session states + one transcript per bounce. Cheap in practice (transcript API is per-session, sessions list is a single `?since=` diff), but flag if you want the transcript refresh to skip when the current session was already up-to-date.
+- [ ] **`visibilitychange` fires on every tab-switch.** On a busy user (many tab flips per minute), the catch-up call rate could spike. `refreshSessionStates` is `?since=cursor`-scoped so idle calls return an empty diff — server load stays low. Still worth naming here.
+- [ ] **Safari-throttling assumption.** The reporter is on M4 MacBook Air + Safari. Safari's silent throttling is my leading suspect based on the symptom shape (delivery stops mid-turn, tab looked foreground, no server error). If the true cause is a different flow (network hiccup only), Fix B alone would cover it — D is defense-in-depth.
+
+## User Prompt
+
+> Bug で優先度高くて対応したほうが良いのを順次。
+> これって本当にバグ？再度見直してね。最良の方法をみつけて。一旦、issueの詳細は無視して、調査、再提案を。
+> issue に記載した上で実装して。
+
+## Analysis notes (posted as [issue #1915 comment](https://github.com/receptron/mulmoclaude/issues/1915#issuecomment-4869813016))
+
+### Why Fix C is unnecessary
+
+`endRun()` (`server/events/session-store/index.ts:178`) doesn't await `persistHasUnread`, but the cursor filter in the `/sessions` route uses `changeMs = max(jsonl mtime, index.indexedAt, meta mtime)`. During a live turn the jsonl mtime ticks on every agent event, so at the moment `notifySessionsChanged()` runs, the session's `changeMs` is already `> cursor`. The diff includes the session; `applyLiveState` folds the correct `live.isRunning = false` onto the summary. No race.
+
+### The Safari factor the issue missed
+
+Reporter env: M4 MacBook Air, Safari. Safari has documented WebSocket-delivery pauses under:
+- backgrounded / hidden tabs (aggressive throttling)
+- high-CPU or resource-pressure states
+- suspend/resume cycles
+
+The socket.io connection stays `connected` server-side (no `disconnect` fires) while the client stops receiving frames. When the tab comes back to foreground, socket.io does NOT re-fire `connect` because from its POV nothing broke. Fix B (reconnect handler) alone can't catch this. Fix D (visibilitychange) is what actually resolves it on Safari.
+
+## Test plan
+
+- [x] `yarn format` / `yarn lint` (0 errors, 26 pre-existing warnings) / `yarn typecheck` / `yarn build`
+- Manual e2e (macOS Safari):
+  1. Start a session, ask something that takes a full turn.
+  2. Mid-turn, switch away from the tab for ~30s, come back. Confirm the "considering..." spinner is not stuck and the tool calls / final text render without a page reload.
+  3. Same but with DevTools throttling → Offline for ~5s → back online. Confirm reconnect catch-up fires and the transcript catches up.
+- Manual e2e (Chrome/Chromium):
+  1. Same offline-toggle test. Confirm the reconnect path works on non-Safari too.
+
+## Implementation
+
+- `src/composables/usePubSub.ts` — new `onReconnect(callback): Unsubscribe`. Tracks `hasConnectedOnce` module-side so the initial `connect` doesn't fire the handler; every subsequent one does. Handler set is cleared when the socket is fully disconnected (nobody subscribed) so a fresh session doesn't inherit stale handlers.
+- `src/App.vue` — Fix A (immediate `isRunning=false` in `handleSessionFinished`) + `catchUpMissedEvents(reason)` helper registered with both `pubsubOnReconnect` and `document.visibilitychange`. Cleaned up in `onScopeDispose`.
+
+Files touched: 2. LOC delta: ~50.
+
+## Out of scope
+
+- **Automated tests** — `usePubSub` opens a real socket.io connection at module init; mocking `io()` cleanly is out of scope for this fix. `handleSessionFinished` and `catchUpMissedEvents` live inside `App.vue`'s setup closure and would need a Playwright/e2e harness to exercise. The manual test plan above is the verification path; a follow-up PR can extract `catchUpMissedEvents` to a pure module and add unit tests once the shape has bedded in.
+- **Chat-index reindexer overhead** (#1929) — separate scheduler bug, tracked separately per user instruction.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1019,24 +1019,44 @@ function handleSessionFinished(sessionId: string): void {
 //     throttling — WS keeps `connected` on the server but delivery stops
 //     while the tab is backgrounded, and there's no `disconnect` event to
 //     hook on reconnect)
-function catchUpMissedEvents(reason: "reconnect" | "visibility"): void {
+// Monotonic sequence guard so back-to-back triggers (reconnect fires
+// concurrent with a visibilitychange) can't let an older, slower
+// refreshSessionStates() response overwrite a newer isRunning=false with
+// stale state (CodeRabbit review). Every catch-up increments the token
+// before awaiting; when the await resolves, we drop the result unless
+// our token is still the latest.
+let catchUpSequence = 0;
+async function catchUpMissedEvents(reason: "reconnect" | "visibility"): Promise<void> {
   console.info(`[chat-ui] catching up after ${reason}`);
-  refreshSessionStates().catch((err) => {
-    console.warn("[chat-ui] refreshSessionStates failed:", err);
-  });
+  const token = ++catchUpSequence;
   const currentId = currentSessionId.value;
-  if (currentId) {
-    refreshSessionTranscript(currentId).catch((err) => {
-      console.warn("[chat-ui] refreshSessionTranscript failed:", err);
-    });
+  const transcriptPromise = currentId
+    ? refreshSessionTranscript(currentId).catch((err) => {
+        console.warn("[chat-ui] refreshSessionTranscript failed:", err);
+      })
+    : Promise.resolve();
+  try {
+    await refreshSessionStates();
+    if (token !== catchUpSequence) {
+      // A later catch-up has already been scheduled; drop this result so
+      // its (potentially older) view of the world can't overwrite the newer one.
+      return;
+    }
+  } catch (err) {
+    console.warn("[chat-ui] refreshSessionStates failed:", err);
   }
+  await transcriptPromise;
 }
 
-pubsubOnReconnect(() => catchUpMissedEvents("reconnect"));
+// Capture the unsubscribe so remount / HMR doesn't accumulate stale
+// module-level reconnect handlers (Codex review).
+const unsubReconnect = pubsubOnReconnect(() => {
+  void catchUpMissedEvents("reconnect");
+});
 
 function handleVisibilityChange(): void {
   if (document.visibilityState === "visible") {
-    catchUpMissedEvents("visibility");
+    void catchUpMissedEvents("visibility");
   }
 }
 
@@ -1045,6 +1065,7 @@ onMounted(() => {
 });
 onScopeDispose(() => {
   document.removeEventListener("visibilitychange", handleVisibilityChange);
+  unsubReconnect();
 });
 
 function createSessionEventHandler(session: ActiveSession, ctx: AgentEventContext): (data: unknown) => void {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1019,44 +1019,31 @@ function handleSessionFinished(sessionId: string): void {
 //     throttling — WS keeps `connected` on the server but delivery stops
 //     while the tab is backgrounded, and there's no `disconnect` event to
 //     hook on reconnect)
-// Monotonic sequence guard so back-to-back triggers (reconnect fires
-// concurrent with a visibilitychange) can't let an older, slower
-// refreshSessionStates() response overwrite a newer isRunning=false with
-// stale state (CodeRabbit review). Every catch-up increments the token
-// before awaiting; when the await resolves, we drop the result unless
-// our token is still the latest.
-let catchUpSequence = 0;
-async function catchUpMissedEvents(reason: "reconnect" | "visibility"): Promise<void> {
+// refreshSessionStates() carries its own sequence guard inside
+// useSessionSync so concurrent catch-ups can't overwrite newer live state
+// with an older-but-slower response. refreshSessionTranscript() only
+// upgrades toolResults when the server view is strictly larger, so it's
+// already idempotent against interleaving.
+function catchUpMissedEvents(reason: "reconnect" | "visibility"): void {
   console.info(`[chat-ui] catching up after ${reason}`);
-  const token = ++catchUpSequence;
-  const currentId = currentSessionId.value;
-  const transcriptPromise = currentId
-    ? refreshSessionTranscript(currentId).catch((err) => {
-        console.warn("[chat-ui] refreshSessionTranscript failed:", err);
-      })
-    : Promise.resolve();
-  try {
-    await refreshSessionStates();
-    if (token !== catchUpSequence) {
-      // A later catch-up has already been scheduled; drop this result so
-      // its (potentially older) view of the world can't overwrite the newer one.
-      return;
-    }
-  } catch (err) {
+  refreshSessionStates().catch((err) => {
     console.warn("[chat-ui] refreshSessionStates failed:", err);
+  });
+  const currentId = currentSessionId.value;
+  if (currentId) {
+    refreshSessionTranscript(currentId).catch((err) => {
+      console.warn("[chat-ui] refreshSessionTranscript failed:", err);
+    });
   }
-  await transcriptPromise;
 }
 
 // Capture the unsubscribe so remount / HMR doesn't accumulate stale
 // module-level reconnect handlers (Codex review).
-const unsubReconnect = pubsubOnReconnect(() => {
-  void catchUpMissedEvents("reconnect");
-});
+const unsubReconnect = pubsubOnReconnect(() => catchUpMissedEvents("reconnect"));
 
 function handleVisibilityChange(): void {
   if (document.visibilityState === "visible") {
-    void catchUpMissedEvents("visibility");
+    catchUpMissedEvents("visibility");
   }
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -320,7 +320,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, reactive } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onScopeDispose, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { v4 as uuidv4 } from "uuid";
 import { getPlugin } from "./tools";
@@ -425,7 +425,7 @@ const currentSessionId = ref("");
 // --- Debug beat (pub/sub) ---
 const { debugTitleStyle } = useDebugBeat();
 
-const { subscribe: pubsubSubscribe } = usePubSub();
+const { subscribe: pubsubSubscribe, onReconnect: pubsubOnReconnect } = usePubSub();
 
 // --- Routing ---
 const route = useRoute();
@@ -482,7 +482,7 @@ const pastedFiles = ref<PastedFile[]>([]);
 const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, historyError, fetchSessions, setBookmark, deleteSession: deleteSessionFromHistory } = useSessionHistory();
-const { markSessionRead } = useSessionSync({
+const { markSessionRead, refreshSessionStates } = useSessionSync({
   sessionMap,
   currentSessionId,
   fetchSessions,
@@ -991,6 +991,16 @@ function hasPendingGenerations(sessionId: string): boolean {
 }
 
 function handleSessionFinished(sessionId: string): void {
+  // Trust the definitive server signal and flip the local indicator
+  // immediately (#1915 Fix A). Without this, the "thinking" spinner stays
+  // stuck until the `sessions` channel notification arrives via a separate
+  // socket.io frame — which can go missing on a network hiccup or on
+  // Safari's tab-throttling flow while the sessionChannel frame did land.
+  const session = sessionMap.get(sessionId);
+  if (session) {
+    session.isRunning = false;
+    session.statusMessage = "";
+  }
   refreshSessionTranscript(sessionId).catch((err) => {
     console.error("[handleSessionFinished] refresh failed:", err);
   });
@@ -1000,6 +1010,42 @@ function handleSessionFinished(sessionId: string): void {
     unsubscribeSession(sessionId);
   }
 }
+
+// After the client silently loses events, this pulls fresh state from the
+// server so the UI recovers without a page reload (#1915). Two trigger
+// surfaces:
+//   - socket.io reconnect (network hiccup, WS bounce)
+//   - document visibility flips to `visible` (Safari's silent tab
+//     throttling — WS keeps `connected` on the server but delivery stops
+//     while the tab is backgrounded, and there's no `disconnect` event to
+//     hook on reconnect)
+function catchUpMissedEvents(reason: "reconnect" | "visibility"): void {
+  console.info(`[chat-ui] catching up after ${reason}`);
+  refreshSessionStates().catch((err) => {
+    console.warn("[chat-ui] refreshSessionStates failed:", err);
+  });
+  const currentId = currentSessionId.value;
+  if (currentId) {
+    refreshSessionTranscript(currentId).catch((err) => {
+      console.warn("[chat-ui] refreshSessionTranscript failed:", err);
+    });
+  }
+}
+
+pubsubOnReconnect(() => catchUpMissedEvents("reconnect"));
+
+function handleVisibilityChange(): void {
+  if (document.visibilityState === "visible") {
+    catchUpMissedEvents("visibility");
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+});
+onScopeDispose(() => {
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
+});
 
 function createSessionEventHandler(session: ActiveSession, ctx: AgentEventContext): (data: unknown) => void {
   return (data: unknown) => {

--- a/src/composables/usePubSub.ts
+++ b/src/composables/usePubSub.ts
@@ -7,15 +7,31 @@ interface PubSubMessage {
 
 type Callback = (data: unknown) => void;
 type Unsubscribe = () => void;
+type ReconnectHandler = () => void;
 
 // On reconnect we re-emit every live subscription so the rooms list survives the bounce.
 let socket: Socket | null = null;
 
 const listeners = new Map<string, Set<Callback>>();
+const reconnectHandlers = new Set<ReconnectHandler>();
+// First `connect` is the initial establishment; every subsequent one is a
+// reconnect and needs a state catch-up (missed events during the down window
+// are lost because the pub/sub server has no replay buffer). See #1915.
+let hasConnectedOnce = false;
 
 function resendSubscriptions(sock: Socket): void {
   for (const channel of listeners.keys()) {
     sock.emit("subscribe", channel);
+  }
+}
+
+function fireReconnectHandlers(): void {
+  for (const handler of reconnectHandlers) {
+    try {
+      handler();
+    } catch (err) {
+      console.error("[usePubSub] reconnect handler threw:", err);
+    }
   }
 }
 
@@ -28,7 +44,14 @@ function connect(): Socket {
     transports: ["websocket"],
   });
 
-  sock.on("connect", () => resendSubscriptions(sock));
+  sock.on("connect", () => {
+    resendSubscriptions(sock);
+    if (hasConnectedOnce) {
+      fireReconnectHandlers();
+    } else {
+      hasConnectedOnce = true;
+    }
+  });
 
   sock.on("data", (msg: PubSubMessage) => {
     const cbs = listeners.get(msg.channel);
@@ -46,6 +69,10 @@ function maybeDisconnect(): void {
   if (!socket) return;
   socket.disconnect();
   socket = null;
+  // Reset so the next `connect()` cycle is a true initial connect again —
+  // catch-up handlers only make sense against state accumulated on this
+  // socket, not across an unsubscribe/resubscribe cycle.
+  hasConnectedOnce = false;
 }
 
 export function usePubSub() {
@@ -73,5 +100,16 @@ export function usePubSub() {
     };
   }
 
-  return { subscribe };
+  // Register a handler that fires on every reconnect (not the initial
+  // connect). Callers use this to catch up on missed events after the
+  // socket bounces — the pub/sub server has no replay buffer, so anything
+  // published during the down window is gone. See #1915.
+  function onReconnect(handler: ReconnectHandler): Unsubscribe {
+    reconnectHandlers.add(handler);
+    return () => {
+      reconnectHandlers.delete(handler);
+    };
+  }
+
+  return { subscribe, onReconnect };
 }

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -30,7 +30,15 @@ export function useSessionSync(opts: {
   const { sessionMap, currentSessionId, fetchSessions, onCurrentSessionDeleted } = opts;
   const { subscribe } = usePubSub();
 
+  // Monotonic sequence token — protects sessionMap from stale overwrites when
+  // two concurrent refreshes race (e.g. reconnect fires while a
+  // visibilitychange is mid-flight). Every call increments the token before
+  // awaiting; after the fetch resolves, we mutate only if our token is still
+  // the latest, so the older-but-slower response can never regress live
+  // state (e.g. re-flip isRunning back to true after session_finished).
+  let refreshToken = 0;
   async function refreshSessionStates(): Promise<void> {
+    const myToken = ++refreshToken;
     let summaries: SessionSummary[];
     try {
       summaries = await fetchSessions();
@@ -40,6 +48,7 @@ export function useSessionSync(opts: {
       console.warn("[session-sync] failed to fetch sessions:", err);
       return;
     }
+    if (myToken !== refreshToken) return;
     for (const summary of summaries) {
       const live = sessionMap.get(summary.id);
       if (!live) continue;


### PR DESCRIPTION
## Summary

Three complementary fixes so the "考え中…" indicator can never stay stuck when the server actually finished the run:

- **A** — `handleSessionFinished` flips `session.isRunning = false` locally the instant `session_finished` arrives, instead of waiting for the separate `sessions` channel notification.
- **B** — new `usePubSub().onReconnect(callback)` API. \`App.vue\` registers a catch-up handler that refetches session states + the current transcript on every socket.io reconnect. The pub/sub server has no replay buffer.
- **D** — the same catch-up runs on \`document.visibilitychange → visible\`, covering Safari's silent tab throttling.

**Skipping the issue's Fix C** (await \`persistHasUnread\`). Cursor uses \`max(jsonl mtime, index.indexedAt, meta mtime)\` — jsonl mtime dominates during a live turn, so no real race.

Fixes #1915.

## Items to Confirm / Review

- [ ] **Fix A trusts the event fully.** \`session.isRunning=false\` becomes a client-side derivative of \`session_finished\` (safe because \`endRun()\` sets that state before publishing).
- [ ] **Reconnect handler fires per bounce.** With 20+ subscribed sessions, catch-up = 1 sessions-list call + 1 transcript call. Cheap in practice.
- [ ] **\`visibilitychange\` on every tab switch** — \`?since=cursor\`-scoped so idle diffs are empty.
- [ ] **Safari-throttling assumption.** Reporter env is M4 MBA + Safari; matches the symptom shape. If the true cause is different (network only), Fix B alone would cover it — D is defense-in-depth.

## User Prompt

> Bug で優先度高くて対応したほうが良いのを順次。
> これって本当にバグ？再度見直してね。最良の方法をみつけて。一旦、issueの詳細は無視して、調査、再提案を。
> issue に記載した上で実装して。

## Why the issue's Fix C is dropped

\`endRun()\` (\`server/events/session-store/index.ts:178\`) doesn't await \`persistHasUnread\`, but the cursor filter in \`/sessions\` uses \`changeMs = max(jsonl mtime, index.indexedAt, meta mtime)\`. During a live turn the jsonl mtime is ticking on every agent event, so at \`notifySessionsChanged()\` time the session's \`changeMs\` is already \`> cursor\`. Diff includes it; \`applyLiveState\` folds \`live.isRunning = false\`. No race.

## Why Safari is the leading suspect (issue missed this)

Reporter env: M4 MacBook Air, Safari. Safari has documented WebSocket-delivery pauses under backgrounded/hidden tabs, high-CPU states, and suspend/resume cycles. The socket.io connection stays \`connected\` server-side (no \`disconnect\` fires) while delivery stops client-side. Foregrounding the tab doesn't re-fire \`connect\`. Fix D (\`visibilitychange\`) is the one that recovers this.

Analysis was [posted on the issue](https://github.com/receptron/mulmoclaude/issues/1915#issuecomment-4869813016) before implementation, per the user's ask.

## Implementation

- \`src/composables/usePubSub.ts\` — new \`onReconnect(callback): Unsubscribe\`. Module-level \`hasConnectedOnce\` tracks initial vs reconnect. Reset when the socket is fully torn down (nobody subscribed).
- \`src/App.vue\` — Fix A + \`catchUpMissedEvents(reason)\` helper wired to both \`pubsubOnReconnect\` and \`document.visibilitychange\`. Cleaned in \`onScopeDispose\`.

Files touched: 2. Plan: \`plans/fix-1915-chat-ui-stuck-mid-turn.md\`.

## Test plan

- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\`
- Manual e2e (Safari): mid-turn tab-switch away 30s → back → spinner clears, transcript renders without reload.
- Manual e2e (Chrome): DevTools throttling → Offline for 5s → back → reconnect path catches up.

## Out of scope

- Automated unit tests for the reconnect/visibility handlers — \`usePubSub\` opens a real socket.io connection at module init; mocking cleanly is a follow-up. \`handleSessionFinished\` lives inside \`App.vue\` setup closure and would need Playwright to exercise.
- #1929 (chat-index scheduler) — being handled separately per user instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat sessions getting stuck mid-turn or showing a lingering thinking indicator.
  * Session status now clears immediately when a turn finishes.
* **New Features**
  * Improved real-time recovery: chat state refreshes automatically after reconnects and when returning to a visible tab, reducing the need to reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->