### PR TITLE
chore: sync monorepo root version to 0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.4",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",


### PR DESCRIPTION
## Summary

monorepo ルート（`mulmoclaude-monorepo`, private）の version が、公開 CLI パッケージ `packages/mulmoclaude` から取り残されてズレていた。ルートを CLI パッケージの現行版 **0.9.4** に揃える。

| | before | after |
|---|---|---|
| root `mulmoclaude-monorepo` | 0.9.1 | **0.9.4** |
| `packages/mulmoclaude` | 0.9.4 | 0.9.4 |

## Items to Confirm / Review

- ルートは `private: true` で npm 公開されないため、この version は表示・整合目的。CLI パッケージ版に合わせる方針でよいか。
- `v0.9.2` タグ時点で既に root=0.9.1 / package=0.9.2 とズレていた（リリース時にルートが bump されていなかった）。本PRはその積み残しの是正。

## User Prompt

> 最新にしてpublishしたい → （確認の結果）モノレポのバージョンとパッケージのバージョンの不整合だね。まずはそれだけ直そう

publish は行わず、version 不整合の是正のみ。

変更は `package.json` の1行（version: 0.9.1 → 0.9.4）。依存・ビルドへの影響なし。