### PR TITLE
fix(collections): stop forcing calendar view on deep-link (#1675)

### DIFF
--- a/e2e/tests/collection-calendar.spec.ts
+++ b/e2e/tests/collection-calendar.spec.ts
@@ -214,31 +214,34 @@ test.describe("collection calendar view", () => {
     await expect(page).toHaveURL(/[?&]selected=launch\b/);
   });
 
-  test("a ?selected= deep link opens the calendar day view focused on the record", async ({ page }) => {
-    // A pasted link forces the calendar view and opens the day popup on the
-    // record's day with its detail already showing.
+  test("a ?selected= deep link opens the record modal without forcing the calendar view", async ({ page }) => {
+    // #1675: previously the deep link forced the collection to `calendar` and
+    // opened the day popup, which also permanently overwrote the user's saved
+    // view mode via the localStorage watcher. It now respects whatever view
+    // the user is in (default: table) and just opens the record modal.
     await page.goto("/collections/agenda?selected=block");
-    await expect(page.getByTestId("collection-calendar")).toBeVisible();
-    await expect(page.getByTestId("collection-day-view")).toBeVisible();
-    await expect(page.getByTestId("collection-day-view-detail")).toBeVisible();
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
     await expect(page.getByTestId("collections-detail-title")).toHaveText("block");
+    // Neither the calendar grid nor the day popup should have been forced open.
+    await expect(page.getByTestId("collection-calendar")).toHaveCount(0);
+    await expect(page.getByTestId("collection-day-view")).toHaveCount(0);
   });
 
-  test("navigating back to the collection without ?selected= tears down the day popup", async ({ page }) => {
+  test("navigating back to the collection without ?selected= closes the record modal", async ({ page }) => {
     await page.goto("/collections/agenda?selected=block");
-    await expect(page.getByTestId("collection-day-view")).toBeVisible();
-    // Reopening the collection without a selection must not leave a stale popup.
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    // Reopening the collection without a selection must not leave a stale modal.
     await page.goto("/collections/agenda");
-    await expect(page.getByTestId("collection-calendar")).toBeVisible();
+    await expect(page.getByTestId("collections-detail")).toHaveCount(0);
     await expect(page.getByTestId("collection-day-view")).toHaveCount(0);
   });
 
-  test("closing the day popup detail via its X clears the selection and popup", async ({ page }) => {
+  test("closing the record modal via its X clears the selection", async ({ page }) => {
     await page.goto("/collections/agenda?selected=block");
-    await expect(page.getByTestId("collection-day-view-detail")).toBeVisible();
-    // The detail pane's close button tears down the whole popup and the URL.
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    // The modal's close button tears it down and drops ?selected= from the URL.
     await page.getByTestId("collections-detail-close").click();
-    await expect(page.getByTestId("collection-day-view")).toHaveCount(0);
+    await expect(page.getByTestId("collections-detail")).toHaveCount(0);
     await expect(page).not.toHaveURL(/selected=/);
   });
 

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1369,9 +1369,14 @@ async function loadCollection(slug: string): Promise<void> {
   // A `?selected=<id>` deep link opens that record in read-only
   // mode once its items are available. Guard against a stale load:
   // only act if we're still on the slug that triggered this fetch.
+  // Deliberately DON'T force calendar view here: the earlier
+  // `maybeOpenCalendarForSelected` behaviour also wrote "calendar" to
+  // localStorage, permanently overriding the user's table/kanban
+  // preference for that collection. Deep-linked records open in the
+  // user's saved view; if they want the calendar day popup, they can
+  // switch to calendar from the header (#1675).
   if (collection.value?.slug === slug) {
     syncViewToSelected();
-    maybeOpenCalendarForSelected();
   }
   maybeAutoRefreshFeed(slug);
 }
@@ -2141,18 +2146,6 @@ function onDayClose(): void {
   openDay.value = null;
   if (editing.value) closeEditor();
   closeView();
-}
-
-/** Deep-link entry: a `?selected=<id>` link to a calendar-capable collection
- *  opens in calendar view with the popup focused on the record's day. Runs
- *  on load / slug change only (not on in-app selection), so table users
- *  aren't forced into the calendar. */
-function maybeOpenCalendarForSelected(): void {
-  if (embedded.value || !hasCalendar.value || !viewing.value) return;
-  const day = dayOfItem(viewing.value);
-  if (!day) return;
-  view.value = "calendar";
-  openDay.value = day;
 }
 
 /** Kanban card dropped in a column → set the record's group field to the

--- a/plans/fix-1675-notification-calendar-force.md
+++ b/plans/fix-1675-notification-calendar-force.md
@@ -1,0 +1,57 @@
+# fix(#1675): deep-link into a collection stops force-switching to calendar view
+
+## Summary
+
+Cause 1 of #1675, in the reporter's split: opening a collection via a Bell notification / `?selected=<id>` deep-link path forced the view to `calendar` (via `maybeOpenCalendarForSelected` in `CollectionView.vue`), which then landed in localStorage via the view-mode watcher and permanently overrode the user's saved `table` (or `kanban`) preference for that collection.
+
+**Fix** — delete `maybeOpenCalendarForSelected` and its call site. Deep-linked records now open in the user's saved view; the record modal opens over that view via the untouched `syncViewToSelected`. If someone wants the calendar day popup, they switch to calendar from the header.
+
+Cause 2 of the same issue (modal-only editing lost inline enum column changes) is a separate design conversation and is out of scope here — the reporter explicitly asked for two PRs.
+
+## Items to Confirm / Review
+
+- [ ] **`dayOfItem`** is still used elsewhere (line 2101 for in-app calendar-day click, line 2301 for follow-selection). Kept.
+- [ ] **`openDay`** is untouched — calendar view still opens the day popup when the record is actively selected while calendar is the current view (line 2101 path). This PR only removes the FORCED switch during the load path.
+- [ ] **No localStorage repair** for users already bitten by the bug. They'll see `calendar` as their saved default one more time; a single explicit view switch persists the correct preference. I considered a one-shot migration wipe of all `collection_view_modes.<slug> === "calendar"` entries, but it over-corrects for users who genuinely picked calendar. If the reporter wants the wipe, we can bolt it on as a small follow-up.
+- [ ] **No tests added** — behaviour change is a single deletion inside a deep, script-setup Vue component. A focused unit test would need a large harness for marginal coverage; the existing e2e suite exercises the deep-link path.
+
+## User Prompt
+
+> Bug で優先度高くて対応したほうが良いのを順次。
+
+## Original bug report (isamu, #1675)
+
+> 通知 (Bell) からコレクションに飛ぶと、ユーザがそのコレクションで普段使っているビューに関わらず **calendar に強制切替** され、しかも localStorage に書き込まれて以降の default も calendar になってしまう。
+
+Cause chain confirmed against current code:
+
+```
+deep-link で slug が変わる
+  → loadCollection() 走る
+  → syncViewToSelected() で viewing.value セット (これは保持したい)
+  → maybeOpenCalendarForSelected() で「日付フィールドあり & item 日付あり」なら view.value = "calendar"  ← 削除
+  → watcher が writeCollectionViewMode(slug, "calendar") で localStorage 永続化  ← これも起こらなくなる
+  → 次回オープン時 localStorage が "calendar" を返す → カレンダーが default に  ← 起こらなくなる
+```
+
+## Implementation
+
+- `packages/plugins/collection-plugin/src/vue/components/CollectionView.vue`:
+  - Remove the `maybeOpenCalendarForSelected()` call from `loadCollection()` (line 1374).
+  - Delete the function definition (lines 2150–2156).
+  - Add an inline comment at the call site explaining why the force-switch was removed (so it doesn't get "restored" as a helpful-looking one-liner in the future).
+
+## Test plan
+
+- [x] `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` / `yarn test`.
+- Manual smoke:
+  1. Open a calendar-capable collection (with a `date` field), switch to `table` view. Confirm localStorage stores `"table"`.
+  2. Navigate to another page.
+  3. Click a Bell notification for a record in that collection.
+  4. **Expected**: land on the collection in `table` view, record modal opens for the selected item. localStorage still says `"table"`.
+  5. Switch to `calendar` view manually. Confirm the day popup still opens on the selected record's day (existing behaviour via line 2101).
+
+## Out of scope
+
+- **Cause 2** — modal-only editing lost inline enum column changes (`eefefe65` unification). Design conversation needed; separate PR per the reporter's split.
+- **localStorage cleanup** for users already polluted. Notable but potentially destructive to legitimate calendar-first users; deferred pending explicit ask.


### PR DESCRIPTION
## Summary

Cause 1 of #1675: opening a collection via a Bell notification / \`?selected=<id>\` deep-link forced \`view.value = "calendar"\` via \`maybeOpenCalendarForSelected()\` in \`CollectionView.vue\`. That value then flowed into localStorage through the view-mode watcher, permanently overriding the user's saved \`table\` / \`kanban\` preference for that collection.

**Fix**: delete \`maybeOpenCalendarForSelected\` and its call site. Deep-linked records open in the user's saved view; the record modal opens on top via the untouched \`syncViewToSelected\`.

Fixes cause 1 of #1675. Cause 2 (modal-only editing losing inline enum column changes) is a separate design conversation per the reporter's split.

## Items to Confirm / Review

- [ ] **\`dayOfItem\`** stays — still used for in-app calendar-day click (line 2101) and follow-selection (line 2301).
- [ ] **No localStorage repair** for users already bitten by the bug. They'll see \`calendar\` as their saved default once more; a single explicit view switch persists the correct preference. A one-shot migration wipe of \`collection_view_modes.<slug> === "calendar"\` was considered but over-corrects for users who genuinely picked calendar. Ready to bolt on if you want it.
- [ ] **No new tests** — one-line behaviour delete inside a deep script-setup Vue component; existing e2e path exercises deep-link.

## User Prompt

> Bug で優先度高くて対応したほうが良いのを順次。

## Cause chain confirmed against current code

\`\`\`
deep-link で slug が変わる
  → loadCollection() 走る
  → syncViewToSelected() で viewing.value セット (保持)
  → maybeOpenCalendarForSelected() で view.value = "calendar"  ← 削除
  → watcher が writeCollectionViewMode(slug, "calendar") で localStorage 永続化  ← 起こらなくなる
  → 次回オープン時 localStorage が "calendar" を返す  ← 起こらなくなる
\`\`\`

## Implementation

- \`packages/plugins/collection-plugin/src/vue/components/CollectionView.vue\`:
  - Remove call to \`maybeOpenCalendarForSelected()\` from \`loadCollection\` (line 1374).
  - Delete function definition (lines 2150–2156).
  - Inline comment at the call site explains why the force-switch is gone.

Plan file: \`plans/fix-1675-notification-calendar-force.md\`.

## Test plan

- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\` / \`yarn test\`.
- Manual smoke (isamu / reporter):
  1. Open a calendar-capable collection with a \`date\` field; switch to \`table\`. Confirm localStorage stores \`"table"\`.
  2. Navigate to another page.
  3. Click a Bell notification for a record in that collection.
  4. **Expected**: land on the collection in \`table\` view; record modal opens for the selected item. localStorage still says \`"table"\`.
  5. Switch to \`calendar\` view manually — day popup still opens on the selected record's day (existing behaviour via line 2101).

## Out of scope

- **Cause 2** — inline enum column changes lost when \`eefefe65\` unified all view modes into modal editing. Separate PR per the reporter's split.
- **localStorage cleanup** for existing pollution — considered but deferred pending explicit ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Stop forcing calendar view when opening collections via deep links or notifications so that the user’s previously chosen view mode is preserved.

Bug Fixes:
- Prevent deep-linked collection opens from overwriting the saved table/kanban view preference by removing the calendar auto-switch behavior.

Enhancements:
- Document the behavior change and its rationale in an inline comment and an accompanying plan file for issue #1675.

Documentation:
- Add a plan document describing the root cause, chosen fix, and test plan for the calendar force-switch bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deep links from notifications now open the selected record without automatically switching the collection into calendar view.
  * The record modal still opens as expected, but your previously saved view is preserved instead of being overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->