### PR TITLE
fix(helps): make billing-clients-worklog recipe reconcile pre-existing data (#1626)

### DIFF
--- a/packages/core/assets/helps/billing-clients-worklog.md
+++ b/packages/core/assets/helps/billing-clients-worklog.md
@@ -234,19 +234,27 @@ distinct from "the ref actually resolves" (clientId is a valid slug AND
      so the user can fill them in later.
    - **not a valid slug** (contains uppercase, spaces, `&`, `.`, etc.) →
      (a) generate the slug (lowercase, spaces → `-`, drop punctuation,
-     collapse repeat hyphens); (b) **check for slug collisions BEFORE
-     writing anything**: if `data/clients/items/<slug>.json` already
-     exists AND its `name` field does not match the display value being
-     reconciled, stop and disambiguate — either append a numeric suffix
-     (`acme-corp-2`) after confirming the new client is genuinely
-     distinct, or ask the user which client the worklog entries belong
-     to. Do **not** silently overwrite an existing client. Also stop
-     when two different display values in the current inventory
-     slugify to the same slug (e.g. `"ACME Corp"` and `"Acme Corp."`);
-     ask the user whether they're the same client (merge to one slug)
-     or distinct (assign each a suffixed slug). (c) create
+     collapse repeat hyphens, strip leading/trailing hyphens); (b)
+     **validate the generated slug against the `clients.id` contract**
+     (see § 1 record shape: `[a-z0-9-]`, 1–48 chars): if it is empty
+     (punctuation-only or all-whitespace input like `"!!!"`), or longer
+     than 48 chars, **stop and ask the user** for a valid slug rather
+     than writing an invalid filename. If it is >48 chars but has
+     meaningful prefix content, propose truncation at 48 (dropping any
+     trailing hyphen) and confirm with the user before proceeding; (c)
+     **check for slug collisions BEFORE writing anything**: if
+     `data/clients/items/<slug>.json` already exists AND its `name`
+     field does not match the display value being reconciled, stop and
+     disambiguate — either append a numeric suffix (`acme-corp-2`)
+     after confirming the new client is genuinely distinct, or ask the
+     user which client the worklog entries belong to. Do **not**
+     silently overwrite an existing client. Also stop when two
+     different display values in the current inventory slugify to the
+     same slug (e.g. `"ACME Corp"` and `"Acme Corp."`); ask the user
+     whether they're the same client (merge to one slug) or distinct
+     (assign each a suffixed slug); (d) create
      `data/clients/items/<slug>.json` with `id: <slug>`, `name:
-     <original display value>`, other fields blank; (d) rewrite the raw
+     <original display value>`, other fields blank; (e) rewrite the raw
      display value inside every affected `data/worklog/items/*.json`
      to the new slug in the `clientId` field (preserve every other
      field untouched).

--- a/packages/core/assets/helps/billing-clients-worklog.md
+++ b/packages/core/assets/helps/billing-clients-worklog.md
@@ -234,11 +234,22 @@ distinct from "the ref actually resolves" (clientId is a valid slug AND
      so the user can fill them in later.
    - **not a valid slug** (contains uppercase, spaces, `&`, `.`, etc.) →
      (a) generate the slug (lowercase, spaces → `-`, drop punctuation,
-     collapse repeat hyphens), (b) create `data/clients/items/<slug>.json`
-     with `id: <slug>`, `name: <original display value>`, other fields
-     blank, (c) rewrite the raw display value inside every affected
-     `data/worklog/items/*.json` to the new slug in the `clientId` field
-     (preserve every other field untouched).
+     collapse repeat hyphens); (b) **check for slug collisions BEFORE
+     writing anything**: if `data/clients/items/<slug>.json` already
+     exists AND its `name` field does not match the display value being
+     reconciled, stop and disambiguate — either append a numeric suffix
+     (`acme-corp-2`) after confirming the new client is genuinely
+     distinct, or ask the user which client the worklog entries belong
+     to. Do **not** silently overwrite an existing client. Also stop
+     when two different display values in the current inventory
+     slugify to the same slug (e.g. `"ACME Corp"` and `"Acme Corp."`);
+     ask the user whether they're the same client (merge to one slug)
+     or distinct (assign each a suffixed slug). (c) create
+     `data/clients/items/<slug>.json` with `id: <slug>`, `name:
+     <original display value>`, other fields blank; (d) rewrite the raw
+     display value inside every affected `data/worklog/items/*.json`
+     to the new slug in the `clientId` field (preserve every other
+     field untouched).
 3. **Report** what changed: how many client records were created and how
    many worklog `clientId` values were rewritten. Do not summarise the
    raw records — point at `/collections/clients` and `/collections/worklog`.

--- a/packages/core/assets/helps/billing-clients-worklog.md
+++ b/packages/core/assets/helps/billing-clients-worklog.md
@@ -26,8 +26,10 @@ user opens it at `/collections/<slug>`). **Do not use the `mc-` prefix.**
 > mimic other collections in the workspace. The whole point is a reproducible
 > billing suite. (If the user wants a *custom* collection instead, that's a
 > different task — use `config/helps/collection-skills.md`.) Existing records
-> under `data/clients/items` / `data/worklog/items` already match these schemas
-> and will render as-is once you author the skill — no data edits needed.
+> under `data/clients/items` / `data/worklog/items` will render as-is **only
+> when `worklog.clientId` values are already slugs AND a matching client
+> record exists for each of them**. If either invariant is violated, the
+> `ref` link breaks — the reconcile step below (§3) fixes both.
 
 ## Slug contract (do not change these)
 
@@ -206,10 +208,57 @@ If the user gives a clear "log N hours for X today", just write it. Use
 
 ---
 
+## 3. Reconcile pre-existing worklog data (MANDATORY before "Done")
+
+Both skills are now authored. Before telling the user setup is complete,
+audit any records that were already on disk under `data/worklog/items/` —
+they may have been written before the `clients` collection existed, so
+`clientId` values can be either display names (`"Singularity Society"`) or
+missing-slug references. Both break the `ref` link at render time.
+
+Run this reconcile every time — even when the setup looks fine — because
+"looks fine" from the LLM side (schemas written, files present) is
+distinct from "the ref actually resolves" (clientId is a valid slug AND
+`data/clients/items/<slug>.json` exists).
+
+**Steps** (idempotent; safe to re-run):
+
+1. **Inventory the existing worklog.** List `data/worklog/items/`. Read
+   every record and collect the distinct `clientId` values seen.
+   *Skip this step only when the directory does not exist at all.*
+2. **For each distinct `clientId` value**, classify it:
+   - **valid slug + matching client file exists** → no action.
+   - **valid slug but no matching `data/clients/items/<slug>.json`** →
+     create a stub client record: `id: <slug>`, `name` derived by
+     title-casing the slug (`acme-corp` → "Acme Corp"), other fields blank
+     so the user can fill them in later.
+   - **not a valid slug** (contains uppercase, spaces, `&`, `.`, etc.) →
+     (a) generate the slug (lowercase, spaces → `-`, drop punctuation,
+     collapse repeat hyphens), (b) create `data/clients/items/<slug>.json`
+     with `id: <slug>`, `name: <original display value>`, other fields
+     blank, (c) rewrite the raw display value inside every affected
+     `data/worklog/items/*.json` to the new slug in the `clientId` field
+     (preserve every other field untouched).
+3. **Report** what changed: how many client records were created and how
+   many worklog `clientId` values were rewritten. Do not summarise the
+   raw records — point at `/collections/clients` and `/collections/worklog`.
+
+If the worklog directory did not exist yet (fresh setup, no pre-existing
+data), this step is a no-op and you can proceed straight to "Done".
+
+**Don't skip this step because the LLM output says "existing records will
+render as-is."** That claim only holds when both invariants (slug format
++ matching client file) are already true; the reconcile confirms them.
+
+---
+
 ## Done
 
 Tell the user the two collections are ready at `/collections/clients` and
 `/collections/worklog`. The bridge mirrors the files and re-scans, so they appear
-without a restart. If invoicing is the goal, point them at the next step: run
-*"Set up invoicing for my business"* (the `config/helps/billing-invoice.md`
-recipe, which references these `clients` and pulls hours from this `worklog`).
+without a restart. If the reconcile in §3 created client stubs or rewrote
+`clientId` values, mention the counts so the user knows to fill in the
+stubs' contact info. If invoicing is the goal, point them at the next
+step: run *"Set up invoicing for my business"* (the
+`config/helps/billing-invoice.md` recipe, which references these
+`clients` and pulls hours from this `worklog`).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client and ./remote-view entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.1",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.0",
-    "@mulmoclaude/core": "^0.8.0",
+    "@mulmoclaude/core": "^0.8.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",


### PR DESCRIPTION
## Summary

The \`billing-clients-worklog\` recipe (\`packages/core/assets/helps/billing-clients-worklog.md\`) claimed **"existing records will render as-is once you author the skill — no data edits needed."** That claim only holds when both invariants are already true:

1. \`worklog.clientId\` values are already valid slugs.
2. A matching \`data/clients/items/<slug>.json\` file exists for each of them.

When either fails — e.g. an existing worklog whose \`clientId\` is a display name (\`"Singularity Society"\`) with an empty \`data/clients/items/\` — the \`ref\` link breaks and the LLM follows the recipe verbatim without noticing, telling the user "all set" while nothing renders.

**Fix**: soften the "no data edits needed" claim and add an explicit reconcile step (§ 3) with idempotent steps: inventory distinct \`clientId\` values, classify each, create client stubs and rewrite worklog \`clientId\` values as needed, then report the counts. The MANDATORY / verbatim-recipe tone is preserved.

Fixes #1626.

## Items to Confirm / Review

- [ ] **§ 3 tone** — the recipe already reads MANDATORY-verbatim; § 3 uses the same "run this every time" tone. Wanted to match the surrounding voice rather than adding a permissive "if it looks like ..." branch that the LLM might skip.
- [ ] **Slug normalisation prescription** — I baked in "lowercase, spaces → \`-\`, drop punctuation, collapse repeat hyphens" as the LLM's slug derivation. Matches how the recipe implicitly expects slugs elsewhere but not a shared utility spec. Let me know if we should point at a canonical slug helper.
- [ ] **Stub client fields** — § 3 populates \`id\` + \`name\` and leaves \`email\` / \`address\` / \`notes\` blank so the user can fill them later. Alternative: ask the user first. The issue's worked example auto-creates stubs, so I went with that. Flagging in case you'd prefer a prompt-first flow.
- [ ] **@mulmoclaude/core bump 0.8.0 → 0.8.1** — required by \`assets/helps/*\` shipping via npm (per CLAUDE.md). Launcher dep bumped in lockstep to satisfy the new launcher-sync gate.

## User Prompt

> Bug で優先度高くて対応したほうが良いのを順次。

## Original bug (isamu, #1626)

> レシピには「既存データはそのまま使える」と記載されているが、実際には手動での修正が必要だった。
> LLM はセットアップ完了時に clients が 0件・worklog が 3件という不整合を認識していたが、レシピの指示に従い自動修正しなかった。

## Implementation

- \`packages/core/assets/helps/billing-clients-worklog.md\`:
  - Lines 28-30: replaced the "will render as-is … no data edits needed" claim with a two-invariant statement pointing at § 3.
  - New § 3 (before "Done"): mandatory reconcile step with 3 numbered sub-steps and a idempotent-by-design contract.
  - "Done" step: mention the § 3 counts when they're non-zero so the user knows to fill in the stub contact info.
- \`packages/core/package.json\`: \`0.8.0\` → \`0.8.1\` (assets/helps ships to npm, per CLAUDE.md).
- \`packages/mulmoclaude/package.json\`: \`@mulmoclaude/core\` range bumped in lockstep to \`^0.8.1\` so the launcher-sync CI gate passes.

## Test plan

- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`node scripts/mulmoclaude/launcherSync.mjs\` (OK).
- Manual (once merged): run the reporter's original prompt against a workspace that already has 3 \`data/worklog/items/*.json\` records with \`clientId\` as display names and an empty \`data/clients/items/\`. Expect the LLM to (a) author the two skills, (b) run § 3 and report "created 2 client stubs, rewrote 3 worklog clientId values", (c) tell the user setup is complete + the stubs need contact info.

## Out of scope

- **Programmatic reconcile in the collection engine** — server-side normalisation of ref-slug values on load would remove the LLM-follows-recipe dependency but is a larger design change with implications for other \`ref\`-using collections. Recipe-level fix here is the smallest change that resolves the reporter's flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified setup requirements for client and worklog data so existing records display correctly only when corresponding client entries are valid.
  * Added a required reconciliation step to align any pre-existing worklog entries with client records before setup is marked complete.
  * Updated completion instructions to include counts of created client placeholders and adjusted worklog records.
* **Chores**
  * Bumped the core package version (patch) and aligned the related package version accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->