### PR TITLE
fix(roles): stop General / Debug / role fallback from colliding with pin star (#1684)

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -46,7 +46,7 @@ export const ROLES: Role[] = [
   {
     id: "general",
     name: "General",
-    icon: "star",
+    icon: "auto_awesome",
     prompt:
       "You are a helpful assistant with access to the user's workspace. Help with tasks, answer questions, and use available tools when appropriate.\n\n" +
       "## Asking the user to choose\n\n" +
@@ -372,7 +372,7 @@ export const ROLES: Role[] = [
   {
     id: "debug",
     name: "Debug",
-    icon: "star",
+    icon: "bug_report",
     prompt:
       "You are a helpful assistant with access to the user's workspace. Help with tasks, answer questions, and use available tools when appropriate.\n\n" +
       "## Asking the user to choose\n\n" +

--- a/src/utils/role/icon.ts
+++ b/src/utils/role/icon.ts
@@ -10,9 +10,16 @@ import type { Role } from "../../config/roles";
 // don't render the literal text inside a Material Icons span.
 const MATERIAL_ICON_RE = /^[a-z_]+$/;
 
+// `smart_toy` (robot glyph) is used for both fallback cases —
+// "role not found" and "role icon isn't a valid Material Icon name".
+// Reserved specifically to avoid collision with `star`, which is the
+// PinToggle glyph for collection shortcuts; using `star` here would
+// make an unknown role look identical to a pinned collection (#1684).
+const FALLBACK_ICON = "smart_toy";
+
 export function roleIcon(roles: Role[], roleId: string): string {
-  const icon = roles.find((role) => role.id === roleId)?.icon ?? "star";
-  return MATERIAL_ICON_RE.test(icon) ? icon : "smart_toy";
+  const icon = roles.find((role) => role.id === roleId)?.icon ?? FALLBACK_ICON;
+  return MATERIAL_ICON_RE.test(icon) ? icon : FALLBACK_ICON;
 }
 
 export function roleName(roles: Role[], roleId: string): string {

--- a/test/utils/role/test_icon.ts
+++ b/test/utils/role/test_icon.ts
@@ -7,7 +7,7 @@ const roles: Role[] = [
   {
     id: "general",
     name: "General",
-    icon: "star",
+    icon: "auto_awesome",
     prompt: "",
     availablePlugins: [],
   },
@@ -29,7 +29,7 @@ const roles: Role[] = [
 
 describe("roleIcon", () => {
   it("returns the role's icon when it is a valid Material Icon name", () => {
-    assert.equal(roleIcon(roles, "general"), "star");
+    assert.equal(roleIcon(roles, "general"), "auto_awesome");
     assert.equal(roleIcon(roles, "tutor"), "school");
   });
 
@@ -37,8 +37,11 @@ describe("roleIcon", () => {
     assert.equal(roleIcon(roles, "broken"), "smart_toy");
   });
 
-  it("falls back to star when the role is unknown", () => {
-    assert.equal(roleIcon(roles, "no-such-role"), "star");
+  // Unknown role must not fall back to `star` — that's the PinToggle glyph
+  // for collection shortcuts, and collision made `General` and pinned
+  // collections indistinguishable (#1684).
+  it("falls back to smart_toy when the role is unknown (never star)", () => {
+    assert.equal(roleIcon(roles, "no-such-role"), "smart_toy");
   });
 
   it("accepts only lowercase letters and underscores as valid icons", () => {


### PR DESCRIPTION
## Summary

Material Icons name \`star\` was used in FOUR places:

- **General role** (\`roles.ts:49\`) — sidebar role selector
- **Debug role** (\`roles.ts:375\`) — sidebar role selector
- **\`roleIcon\` fallback** (\`icon.ts:14\`) — unknown-role rendering
- **PinToggle** (\`PinToggle.vue:16\`) — collection shortcut (favorite)

Since \`star = favorite\` on PinToggle is the widely-recognised UI pattern, kept that one and renamed the three role sites (issue's Case A):

- General → \`auto_awesome\` (sparkle, standard AI marker)
- Debug → \`bug_report\`
- Fallback → \`smart_toy\` (both branches — role-not-found + invalid-material-icon — consolidated into one \`FALLBACK_ICON\` constant)

Fixes #1684.

## Items to Confirm / Review

- [ ] **General → \`auto_awesome\`** — agent recommendation from the issue's Case A shortlist. Alternatives are \`chat\` / \`forum\` / \`hub\` / \`smart_toy\` / \`psychology\`. If you'd prefer one of the others, one-line swap.
- [ ] **Debug → \`bug_report\`** — the issue's single suggestion.
- [ ] **Fallback \`smart_toy\`** — chosen for both fallback branches so an unknown role can't accidentally masquerade as a pinned collection. Test now asserts "never star" with a #1684 comment so a future revert is caught.

## User Prompt

> Bug で優先度高くて対応したほうが良いのを順次。

## Implementation

- \`src/config/roles.ts\` — two icons updated (lines 49, 375).
- \`src/utils/role/icon.ts\` — introduced \`FALLBACK_ICON\` constant, used for both the "role not found" default AND the "invalid Material Icon regex" fallback. Docstring names #1684 so a well-meaning simplification doesn't re-collide.
- \`test/utils/role/test_icon.ts\` — 2 assertions updated (\`General\` returns \`auto_awesome\`, unknown-role returns \`smart_toy\`). Test comment explains why "never star."

## Test plan

- [x] \`yarn tsx --test test/utils/role/test_icon.ts\` — 6/6 pass.
- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck:vue\`.
- Manual: open the sidebar role selector — General shows a sparkle, Debug shows a bug icon. Toggle a collection's pin — the star flips correctly and no longer confused with a role glyph.

## Out of scope

- Session role icon click → bookmark toggle (#1685). Separate ask, addressed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)