### PR TITLE
fix(dev): exclude runtime workspace data from Tailwind source scanning (full-reload flicker during agent turns)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,19 @@
 @import "tailwindcss";
 
+/* Exclude runtime workspace data from Tailwind's automatic source
+   detection. The default workspace is `~/mulmoclaude`; when the repo
+   itself is cloned there (or MULMOCLAUDE_WORKSPACE_PATH points inside
+   the repo), the server writes conversations/, data/ and artifacts/
+   into the Vite project root. Without these exclusions Tailwind scans
+   those files for class candidates, registers them as dependencies of
+   this stylesheet, and answers every chat-log append with a
+   `full-reload` — the dev app reloads several times per agent turn
+   (#1940). Directories that don't exist are a no-op, so this is safe
+   for checkouts whose workspace lives elsewhere. */
+@source not "../conversations";
+@source not "../data";
+@source not "../artifacts";
+
 @layer base {
   /* Tailwind v4 removed the default `cursor: pointer` on <button>
      from preflight (https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor).


### PR DESCRIPTION
Fixes #1940

## Root cause

With `yarn dev`, the chat page fully reloads several times during a single agent turn whenever the workspace lives **inside** the Vite project root — which is the default: the workspace resolves to `~/mulmoclaude`, so cloning the repo to `~/mulmoclaude` makes them the same directory.

The chain, confirmed by intercepting the HMR WebSocket frames:

1. During an agent turn the server appends to `conversations/chat/<id>.jsonl` / `.json`.
2. Tailwind v4's automatic source detection has no `source()` restriction here, so it scans the whole project root (minus `.gitignore`) for class candidates. `conversations/`, `data/` and `artifacts/` are not gitignored → they are scanned, and each scanned file is registered as a dependency of `src/index.css`.
3. On every append, `@tailwindcss/vite`'s `hotUpdate` hook sees a scanned-file change and sends a bare `{"type":"full-reload"}`; the stale file→module links also make Vite core itself send `full-reload` (`page reload conversations/chat/….jsonl` in the server log).
4. The browser reloads — 3-4 times per turn, which users experience as heavy flicker (each reload also re-runs boot fetches, producing the repeated runtime-plugin 404 triplets described in #1940).

Interestingly `server/system/logs/` writes never triggered this — that directory **is** gitignored, which is what narrowed the suspect list to Tailwind's gitignore-aware scanner.

## Fix

Negative `@source` directives (supported since Tailwind 4.1; the repo is on 4.3) in `src/index.css` excluding the three runtime data directories. Non-existent directories are a no-op, so checkouts whose workspace lives outside the repo are unaffected.

`server.watch.ignored` in `vite.config.ts` would also work and additionally silence the (harmless) `file-changed` custom events from `@vitejs/plugin-vue`; happy to switch or add that if preferred.

## Verification

On a checkout exhibiting the bug (macOS, Node 25, workspace == repo root):

- Before: a trivial chat turn ("reply OK only, no tools") produced 3-4 `full-reload` frames and the page's `window` marker was wiped each time (`performance.getEntriesByType('navigation')[0].type === "reload"`).
- After this change + dev-server restart: same turn produces **0** `full-reload` frames, the `window` marker survives the whole turn, and Tailwind styling is intact (checked `cursor: pointer` on buttons from the preflight override in this same file).
- A restart of `yarn dev` is required after applying, because the previously registered scanned-file → stylesheet links live in the running server's module graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjKt7R3HEHmLVDm8R2YncC

## Summary by Sourcery

Exclude runtime workspace data directories from Tailwind source scanning in development to prevent unnecessary full page reloads during chat updates.

Bug Fixes:
- Prevent repeated full page reloads in the dev chat UI caused by Tailwind scanning runtime conversation, data, and artifact files as CSS content sources.

Enhancements:
- Configure Tailwind CSS to ignore runtime workspace data directories via negative source directives without affecting checkouts whose workspace is outside the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary page reloads during chat activity, improving stability and responsiveness.
  * Prevented the app from scanning unrelated workspace content, which helps avoid excessive background updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->