### PR TITLE
feat(remote-view): listSkills + startChat free-form text; fix listCollections feed leak

### DIFF
--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -9,6 +9,7 @@ import { getRemoteViewItems } from "./getRemoteViewItems.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
 import { listShortcuts } from "./listShortcuts.js";
+import { listSkills } from "./listSkills.js";
 import { mutateRemoteViewItem } from "./mutateRemoteView.js";
 import { startChat } from "./startChat.js";
 
@@ -16,6 +17,7 @@ export const handlers: CommandHandlers = {
   listCollections,
   getCollection,
   listShortcuts,
+  listSkills,
   listFeeds,
   getFeed,
   getRemoteView,

--- a/server/remoteHost/handlers/listCollections.ts
+++ b/server/remoteHost/handlers/listCollections.ts
@@ -4,6 +4,11 @@
 // calls the collection engine directly, returning the same shape as
 // GET /api/collections: { collections: CollectionSummary[] }.
 //
+// Feeds (`source: "feed"`) are excluded: `discoverCollections` merges the
+// feeds registry as a third root (so the desktop can show them together), but
+// the mobile remote serves feeds through the dedicated listFeeds / getFeed
+// handlers, so surfacing them here too would double-list them.
+//
 // Exposed as a factory (createListCollections) so the mapping is unit-testable
 // with discovery stubbed; the default export wires the real engine functions.
 import { discoverCollections, toSummary } from "../../workspace/collections/index.js";
@@ -19,7 +24,7 @@ export const createListCollections =
   // Handlers receive the command's params; listCollections takes none (the
   // `__` prefix marks it intentionally unused per the lint config).
   async (__params: JsonObject) => {
-    const collections = (await deps.discover()).map(deps.toSummary);
+    const collections = (await deps.discover()).filter((collection) => collection.source !== "feed").map(deps.toSummary);
     // CollectionSummary is plain JSON (slug/title/icon/source strings), so this
     // is safe — the cast only satisfies the channel's structural JsonValue type,
     // which an interface without an index signature can't match directly.

--- a/server/remoteHost/handlers/listSkills.ts
+++ b/server/remoteHost/handlers/listSkills.ts
@@ -1,0 +1,39 @@
+// listSkills command handler (remote-host).
+//
+// Returns just the ids (names) of the discoverable Claude Code skills as a
+// flat string[], mirroring the id column of GET /api/skills. Read-only:
+// creating/editing skills stays desktop-only (like listShortcuts / listFeeds).
+// Only ids travel — the phone asks for the detail it needs by other means, so
+// there is no reason to carry descriptions/source over the channel.
+//
+// Collection skills are excluded: a skill dir that ships a `schema.json` is a
+// collection (the same set `discoverCollections` finds under user/project
+// scope), and the mobile remote serves those through listCollections. Listing
+// them here too would double-list them, so we subtract the collection slugs.
+import { discoverCollections } from "../../workspace/collections/index.js";
+import { discoverSkills } from "../../workspace/skills/index.js";
+import { workspacePath } from "../../workspace/workspace.js";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface ListSkillsDeps {
+  discoverSkills: typeof discoverSkills;
+  discoverCollections: typeof discoverCollections;
+  workspaceRoot: string;
+}
+
+export const createListSkills =
+  (deps: ListSkillsDeps): CommandHandler =>
+  // Handler receives the command's params; listSkills takes none (the `__`
+  // prefix marks it intentionally unused per the lint config).
+  async (__params: JsonObject) => {
+    const [skills, collections] = await Promise.all([
+      deps.discoverSkills({ workspaceRoot: deps.workspaceRoot }),
+      deps.discoverCollections({ workspaceRoot: deps.workspaceRoot }),
+    ]);
+    // Feeds aren't skills, so only the skill-backed (user/project) collections
+    // can shadow a skill id — subtract those.
+    const collectionSlugs = new Set(collections.filter((collection) => collection.source !== "feed").map((collection) => collection.slug));
+    return { skills: skills.map((skill) => skill.name).filter((name) => !collectionSlugs.has(name)) };
+  };
+
+export const listSkills = createListSkills({ discoverSkills, discoverCollections, workspaceRoot: workspacePath });

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -1,24 +1,30 @@
 // startChat command handler (remote-host — start a chat from the mobile remote).
 //
-// Fire-and-forget: composes the collection's slash command as a prefix on the
-// user's message (`/<slug> <message>` for a collection, `/<slug> id=<itemId>
-// <message>` for one record), then spawns a VISIBLE host chat session (origin
-// `skill`, openable from history) via spawnSystemWorker, and returns the new
-// chatId. No streaming back — starting the chat on the host is enough.
+// The remote sends text; the host starts a new VISIBLE chat session (origin
+// `skill`, openable from desktop history) seeded with it, and returns the new
+// chatId. Fire-and-forget: no streaming back — starting the chat on the host is
+// enough.
 //
-// Mirrors the desktop's two entry points over the command channel: the
-// collection-level `__MC_VIEW.startChat` and the per-record chat box in
-// CollectionRecordPanel.vue (`/<slug> id=<itemId> <message>`).
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ THE CONTRACT — read this before touching the params.                      │
+// │                                                                           │
+// │ CURRENT clients send ONLY `{ message }`. The message is seeded VERBATIM   │
+// │ as the first user turn. The host does NOT interpret it, so the client is  │
+// │ free to put a slash command (`/<slug> …`), a plain question, or anything  │
+// │ else in the text. This is the ONLY form new code should emit.             │
+// │                                                                           │
+// │ `slug` (and its optional companion `itemId`) is LEGACY-ONLY. Older        │
+// │ clients still send `{ slug, itemId?, message }` to target a collection    │
+// │ or one record; we keep composing `/<slug> [id=<itemId>] <message>` for    │
+// │ them so they don't break. DO NOT add new features to this branch, and DO  │
+// │ NOT teach new clients to send `slug` — put the slash command in           │
+// │ `message` instead. The whole legacy path can be deleted once no deployed  │
+// │ client sends `slug` anymore.                                              │
+// └─────────────────────────────────────────────────────────────────────────┘
 //
-// Role is intentionally NOT part of the remote API — the caller passes only
-// message + slug + optional itemId. The host runs the chat in its default role
-// (spawnSystemWorker → startChat requires a concrete roleId; empty is rejected).
-//
-// Feeds are refused: a feed (`source === "feed"`) has no `/<slug>` skill
-// command, so a slash-command seed would invoke nothing (see desktop
-// `CollectionView.buildChatSeed`). The mobile remote doesn't offer chat for
-// feeds; this is the host-side backstop so a stray feed slug can't produce a
-// broken chat.
+// Role is intentionally NOT part of the remote API — the host runs the chat in
+// its default role (spawnSystemWorker → startChat requires a concrete roleId;
+// empty is rejected).
 //
 // Factory (createStartChat) keeps composition/wiring unit-testable with the
 // engine + spawner stubbed; the default export wires the real ones.
@@ -32,45 +38,57 @@ export interface StartChatDeps {
   loadCollection: typeof loadCollection;
 }
 
-// Prefix the message with the collection's slash command. `itemId` scopes the
-// chat to one record; empty ⇒ the whole collection. Matches the desktop
-// item-chat format documented in CollectionRecordPanel.vue.
+// LEGACY. Prefix the message with the collection's slash command. `itemId`
+// scopes the chat to one record; empty ⇒ the whole collection. Matches the
+// desktop item-chat format documented in CollectionRecordPanel.vue. Only the
+// legacy `slug` path calls this — new clients put the slash command in
+// `message` themselves.
 export const composeMessage = (slug: string, itemId: string, message: string): string => {
   const prefix = itemId ? `/${slug} id=${itemId}` : `/${slug}`;
   return `${prefix} ${message}`;
 };
 
-// slug and itemId become single tokens in the slash command (`/<slug>`,
-// `id=<itemId>`), so a whitespace-containing or non-string value would break
-// the command parse (e.g. `/   hello`). Accept only a trimmed, whitespace-free
-// string; anything else ⇒ "" so the caller rejects it.
+// LEGACY. slug and itemId become single tokens in the slash command
+// (`/<slug>`, `id=<itemId>`), so a whitespace-containing or non-string value
+// would break the command parse (e.g. `/   hello`). Accept only a trimmed,
+// whitespace-free string; anything else ⇒ "" so the caller rejects it.
 const asToken = (value: JsonValue): string => {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
   return /\s/.test(trimmed) ? "" : trimmed;
 };
 
+// LEGACY collection/record targeting for older clients that still send `slug`.
+// Compose the `/<slug> [id=<itemId>] <message>` seed the desktop uses; reject a
+// malformed or unknown slug and refuse feeds, so we never seed a `/<slug>`
+// command that resolves to nothing. New clients skip all of this by sending the
+// slash command (or plain text) in `message`.
+const composeCollectionSeed = async (deps: StartChatDeps, params: JsonObject, message: string): Promise<string> => {
+  const slug = asToken(params.slug);
+  const itemId = asToken(params.itemId);
+  if (!slug) throw new Error("slug must be a non-empty, whitespace-free string");
+  if (params.itemId != null && !itemId) throw new Error("itemId must be a non-empty, whitespace-free string when provided");
+  const target = await deps.loadCollection(slug);
+  if (!target) throw new Error(`collection '${slug}' not found`);
+  if (target.source === "feed") throw new Error("chat is not available for feeds");
+  return composeMessage(slug, itemId, message);
+};
+
+// A `slug` is "provided" (⇒ LEGACY targeting) only when it is a non-empty
+// value. Omitted / null / "" ⇒ the current free-text form. New clients never
+// set it, so they always take the verbatim branch below.
+const hasSlug = (value: JsonValue | undefined): boolean => value != null && value !== "";
+
 export const createStartChat =
   (deps: StartChatDeps): CommandHandler =>
   async (params: JsonObject) => {
     // Params arrive as JSON over the channel — coerce/validate defensively.
-    const slug = asToken(params.slug);
-    const itemId = asToken(params.itemId);
     const message = (typeof params.message === "string" ? params.message : "").trim();
-    if (!slug) throw new Error("slug must be a non-empty, whitespace-free string");
-    if (params.itemId != null && !itemId) throw new Error("itemId must be a non-empty, whitespace-free string when provided");
     if (!message) throw new Error("message is required");
-    // Resolve the target so we never seed a `/<slug>` command that resolves to
-    // nothing: an unknown/stale slug (`null`) is rejected, and a feed
-    // (`source === "feed"`, no skill command) is refused.
-    const target = await deps.loadCollection(slug);
-    if (!target) throw new Error(`collection '${slug}' not found`);
-    if (target.source === "feed") throw new Error("chat is not available for feeds");
-    const result = await deps.spawn({
-      message: composeMessage(slug, itemId, message),
-      roleId: DEFAULT_ROLE_ID,
-      hidden: false,
-    });
+    // Current clients: `message` only ⇒ seed it verbatim. Legacy clients that
+    // still send `slug` ⇒ compose the old `/<slug> [id=<itemId>] <message>` seed.
+    const seed = hasSlug(params.slug) ? await composeCollectionSeed(deps, params, message) : message;
+    const result = await deps.spawn({ message: seed, roleId: DEFAULT_ROLE_ID, hidden: false });
     if (!result.ok) throw new Error(result.error);
     return { started: true, chatId: result.chatId };
   };

--- a/test/remoteHost/test_dataHandlers.ts
+++ b/test/remoteHost/test_dataHandlers.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { createGetCollection, type GetCollectionDeps } from "../../server/remoteHost/handlers/getCollection.js";
 import { createGetFeed, type GetFeedDeps } from "../../server/remoteHost/handlers/getFeed.js";
 import { createListShortcuts, type ListShortcutsDeps } from "../../server/remoteHost/handlers/listShortcuts.js";
+import { createListSkills, type ListSkillsDeps } from "../../server/remoteHost/handlers/listSkills.js";
 import { createListFeeds, type ListFeedsDeps } from "../../server/remoteHost/handlers/listFeeds.js";
 
 const records = (count: number) => Array.from({ length: count }, (_unused, index) => ({ id: `r${index}` }));
@@ -105,6 +106,43 @@ describe("createListShortcuts", () => {
     const read = (async () => [{ kind: "collection", slug: "clients", title: "Clients", icon: "people" }]) as unknown as ListShortcutsDeps["read"];
     const handler = createListShortcuts({ read });
     assert.deepEqual(await handler({}), { shortcuts: [{ kind: "collection", slug: "clients", title: "Clients", icon: "people" }] });
+  });
+});
+
+describe("createListSkills", () => {
+  const skillsDep = (names: string[]): ListSkillsDeps["discoverSkills"] =>
+    (async () => names.map((name) => ({ name, description: "d", source: "user" }))) as unknown as ListSkillsDeps["discoverSkills"];
+  const collectionsDep = (entries: { slug: string; source: string }[]): ListSkillsDeps["discoverCollections"] =>
+    (async () => entries) as unknown as ListSkillsDeps["discoverCollections"];
+
+  it("returns just the skill ids as a flat string[]", async () => {
+    const handler = createListSkills({
+      discoverSkills: skillsDep(["deep-research", "precommit"]),
+      discoverCollections: collectionsDep([]),
+      workspaceRoot: "/ws",
+    });
+    assert.deepEqual(await handler({}), { skills: ["deep-research", "precommit"] });
+  });
+
+  it("excludes collection skills (skills whose id is a user/project collection slug)", async () => {
+    const handler = createListSkills({
+      discoverSkills: skillsDep(["deep-research", "clients", "invoices"]),
+      discoverCollections: collectionsDep([
+        { slug: "clients", source: "project" },
+        { slug: "invoices", source: "user" },
+      ]),
+      workspaceRoot: "/ws",
+    });
+    assert.deepEqual(await handler({}), { skills: ["deep-research"] });
+  });
+
+  it("does not exclude a skill that merely shares a slug with a feed", async () => {
+    const handler = createListSkills({
+      discoverSkills: skillsDep(["news"]),
+      discoverCollections: collectionsDep([{ slug: "news", source: "feed" }]),
+      workspaceRoot: "/ws",
+    });
+    assert.deepEqual(await handler({}), { skills: ["news"] });
   });
 });
 

--- a/test/remoteHost/test_handlers.ts
+++ b/test/remoteHost/test_handlers.ts
@@ -9,7 +9,7 @@ import { createListCollections, type ListCollectionsDeps } from "../../server/re
 
 describe("remote-host handler registry", () => {
   it("exposes every registered handler", () => {
-    for (const name of ["listCollections", "getCollection", "listShortcuts", "listFeeds", "getFeed", "startChat"]) {
+    for (const name of ["listCollections", "getCollection", "listShortcuts", "listSkills", "listFeeds", "getFeed", "startChat"]) {
       assert.equal(typeof handlers[name], "function", `missing handler: ${name}`);
     }
   });
@@ -35,6 +35,16 @@ describe("createListCollections", () => {
         { slug: "beta", title: "BETA", icon: "folder", source: "preset" },
       ],
     });
+  });
+
+  it("excludes feeds — feeds are served by listFeeds, not listCollections", async () => {
+    const discover = (async () => [
+      { slug: "alpha", source: "project" },
+      { slug: "news", source: "feed" },
+    ]) as unknown as ListCollectionsDeps["discover"];
+    const toSummary = ((col: { slug: string; source: string }) => ({ slug: col.slug, source: col.source })) as unknown as ListCollectionsDeps["toSummary"];
+    const handler = createListCollections({ discover, toSummary });
+    assert.deepEqual(await handler({}), { collections: [{ slug: "alpha", source: "project" }] });
   });
 
   it("returns an empty list when discovery finds nothing", async () => {

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -1,8 +1,10 @@
-// Unit tests for the startChat remote-host handler: message composition (the
-// collection slash-command prefix, with/without itemId), coercion/validation,
-// feed refusal, and the spawn wiring. The host spawner + collection engine are
-// stubbed so the test asserts what message is spawned — not that a real chat
-// subprocess launches.
+// Unit tests for the startChat remote-host handler.
+//
+// Two forms (see the handler header): the CURRENT free-text form (`{ message }`
+// only, seeded verbatim) and the LEGACY `slug` form (`/<slug> [id=<itemId>]
+// <message>` composition, feed refusal, token validation). The host spawner +
+// collection engine are stubbed so the test asserts what message is spawned —
+// not that a real chat subprocess launches.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
@@ -14,20 +16,81 @@ type Loaded = Awaited<ReturnType<StartChatDeps["loadCollection"]>>;
 const collection = { source: "user" } as unknown as Loaded;
 const feed = { source: "feed" } as unknown as Loaded;
 
-// Build stub deps. `loadResult` is what `loadCollection` resolves to: a normal
-// collection (default) ⇒ the chat proceeds; `feed` ⇒ refused; `null` ⇒ unknown
-// slug, rejected. `calls` captures the spawn arguments.
+// Build stub deps. `loadResult` is what `loadCollection` resolves to (only the
+// legacy slug path calls it): a normal collection (default) ⇒ chat proceeds;
+// `feed` ⇒ refused; `null` ⇒ unknown slug, rejected. `calls` captures the spawn
+// arguments; `loadCalls` records whether the collection engine was consulted.
 const makeDeps = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>, loadResult: Loaded = collection) => {
   const calls: SpawnArgs[] = [];
+  const loadCalls: string[] = [];
   const spawn = (async (args: SpawnArgs) => {
     calls.push(args);
     return result;
   }) as StartChatDeps["spawn"];
-  const loadCollection = (async () => loadResult) as StartChatDeps["loadCollection"];
-  return { deps: { spawn, loadCollection } as StartChatDeps, calls };
+  const loadCollection = (async (slug: string) => {
+    loadCalls.push(slug);
+    return loadResult;
+  }) as StartChatDeps["loadCollection"];
+  return { deps: { spawn, loadCollection } as StartChatDeps, calls, loadCalls };
 };
 
-describe("composeMessage", () => {
+// ── CURRENT form: `{ message }` only, seeded verbatim ──────────────────────
+describe("createStartChat — free-text form (current clients)", () => {
+  it("spawns a visible chat with the message verbatim and returns the chatId", async () => {
+    const { deps, calls, loadCalls } = makeDeps({ ok: true, chatId: "chat-1" });
+    const result = await createStartChat(deps)({ message: "who is overdue?" });
+    assert.deepEqual(result, { started: true, chatId: "chat-1" });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].message, "who is overdue?");
+    assert.equal(calls[0].hidden, false);
+    // The collection engine is NOT consulted when no slug is sent.
+    assert.equal(loadCalls.length, 0);
+  });
+
+  it("trims surrounding whitespace from the message", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-2" });
+    await createStartChat(deps)({ message: "  hello  " });
+    assert.equal(calls[0].message, "hello");
+  });
+
+  it("passes a slash-command message through untouched (the host does not interpret it)", async () => {
+    const { deps, calls, loadCalls } = makeDeps({ ok: true, chatId: "chat-3" });
+    await createStartChat(deps)({ message: "/clients id=acme draft a follow-up" });
+    assert.equal(calls[0].message, "/clients id=acme draft a follow-up");
+    assert.equal(loadCalls.length, 0);
+  });
+
+  it("treats a null or empty-string slug as absent (free-text, no collection load)", async () => {
+    const { deps, calls, loadCalls } = makeDeps({ ok: true, chatId: "chat-4" });
+    await createStartChat(deps)({ message: "hi", slug: "" });
+    await createStartChat(deps)({ message: "hi", slug: null });
+    assert.deepEqual(
+      calls.map((call) => call.message),
+      ["hi", "hi"],
+    );
+    assert.equal(loadCalls.length, 0);
+  });
+
+  it("throws when message is blank, without spawning", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-5" });
+    await assert.rejects(async () => createStartChat(deps)({ message: "   " }), /message is required/);
+    assert.equal(calls.length, 0);
+  });
+
+  it("throws when message is missing or non-string", async () => {
+    const { deps } = makeDeps({ ok: true, chatId: "chat-6" });
+    await assert.rejects(async () => createStartChat(deps)({}), /message is required/);
+    await assert.rejects(async () => createStartChat(deps)({ message: 123 }), /message is required/);
+  });
+
+  it("surfaces a spawn failure as a thrown error", async () => {
+    const { deps } = makeDeps({ ok: false, error: "too many background sessions" });
+    await assert.rejects(async () => createStartChat(deps)({ message: "hi" }), /too many background sessions/);
+  });
+});
+
+// ── LEGACY form: `{ slug, itemId?, message }` → composed slash command ──────
+describe("composeMessage (legacy)", () => {
   it("prefixes the collection slash command for a whole-collection chat", () => {
     assert.equal(composeMessage("clients", "", "who is overdue?"), "/clients who is overdue?");
   });
@@ -37,17 +100,16 @@ describe("composeMessage", () => {
   });
 });
 
-describe("createStartChat", () => {
-  it("spawns a visible chat with the composed message and returns the chatId", async () => {
-    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-1" });
+describe("createStartChat — legacy slug form", () => {
+  it("composes the /<slug> id= seed from a legacy client and returns the chatId", async () => {
+    const { deps, calls, loadCalls } = makeDeps({ ok: true, chatId: "chat-1" });
     const result = await createStartChat(deps)({ slug: "clients", itemId: "acme", message: "  hello  " });
     assert.deepEqual(result, { started: true, chatId: "chat-1" });
-    assert.equal(calls.length, 1);
     assert.equal(calls[0].message, "/clients id=acme hello");
-    assert.equal(calls[0].hidden, false);
+    assert.deepEqual(loadCalls, ["clients"]);
   });
 
-  it("omits id= when itemId is absent or null", async () => {
+  it("omits id= when itemId is absent", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-2" });
     await createStartChat(deps)({ slug: "clients", message: "hi" });
     assert.equal(calls[0].message, "/clients hi");
@@ -65,34 +127,14 @@ describe("createStartChat", () => {
     assert.equal(calls.length, 0);
   });
 
-  it("throws when slug is missing", async () => {
+  it("rejects a whitespace-containing or non-string slug (malformed prefix)", async () => {
     const { deps } = makeDeps({ ok: true, chatId: "chat-3" });
-    await assert.rejects(async () => createStartChat(deps)({ message: "hi" }), /slug must be a non-empty/);
-  });
-
-  it("rejects a whitespace-only or whitespace-containing slug (malformed prefix)", async () => {
-    const { deps } = makeDeps({ ok: true, chatId: "chat-3b" });
-    await assert.rejects(async () => createStartChat(deps)({ slug: "   ", message: "hi" }), /slug must be a non-empty/);
     await assert.rejects(async () => createStartChat(deps)({ slug: "a b", message: "hi" }), /slug must be a non-empty/);
-  });
-
-  it("rejects a non-string slug", async () => {
-    const { deps } = makeDeps({ ok: true, chatId: "chat-3c" });
     await assert.rejects(async () => createStartChat(deps)({ slug: 123, message: "hi" }), /slug must be a non-empty/);
   });
 
   it("rejects an itemId that is present but whitespace-containing", async () => {
-    const { deps } = makeDeps({ ok: true, chatId: "chat-3d" });
-    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", itemId: "a b", message: "hi" }), /itemId must be a non-empty/);
-  });
-
-  it("throws when message is blank", async () => {
     const { deps } = makeDeps({ ok: true, chatId: "chat-4" });
-    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", message: "   " }), /message is required/);
-  });
-
-  it("surfaces a spawn failure as a thrown error", async () => {
-    const { deps } = makeDeps({ ok: false, error: "too many background sessions" });
-    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", message: "hi" }), /too many background sessions/);
+    await assert.rejects(async () => createStartChat(deps)({ slug: "clients", itemId: "a b", message: "hi" }), /itemId must be a non-empty/);
   });
 });


### PR DESCRIPTION
Three changes to the remote-host command API the phone talks to.

## 1. New `listSkills` command
`server/remoteHost/handlers/listSkills.ts` (registered in `handlers/index.ts`). Returns `{ skills: string[] }` — just the skill ids, the read-only counterpart to `listShortcuts`/`listFeeds`, exposing the user's Claude Code skills to the mobile remote.

**Excludes collection skills.** A collection skill is a skill dir that ships a `schema.json` — the exact set `discoverCollections` finds under user/project scope, which the phone already reaches via `listCollections`. Those slugs are subtracted so a collection isn't double-listed. Feeds (`source: "feed"`) aren't skills, so a genuine skill that merely shares a slug with a feed is kept.

## 2. Fix: `listCollections` was leaking feeds
`discoverCollections` merges the feeds registry as a third root so the desktop can show them together, then hides them client-side (`CollectionsIndexView.vue:158`, `source !== "feed"`). The phone has no such client-side filter, so feeds were double-listed (they already come through `listFeeds`/`getFeed`). The handler now applies the same `source !== "feed"` filter server-side. Scoped to the remote handler only — `discoverCollections` and the desktop `/api/collections` route are untouched.

## 3. `startChat` takes free-form text; slug/itemId legacy-only
The remote now sends just `{ message }` and the host seeds a new visible chat with that text **verbatim** — the host no longer interprets it, so the client is free to put a slash command, a plain question, or anything else in the text. More flexible than the former fixed collection/record target.

The old `{ slug, itemId?, message }` form is kept as **LEGACY-ONLY** backward support: a non-empty `slug` composes the previous `/<slug> [id=<itemId>] <message>` seed (`itemId` stays optional), rejecting an unknown slug and refusing feeds. An omitted / null / empty slug takes the verbatim branch and never touches the collection engine. The legacy nature is documented with a boxed CONTRACT banner in the handler header plus `LEGACY` markers on every slug-path helper.

## Tests
All passing:
- `listSkills` — flat ids, collection exclusion, feed-slug-not-excluded
- `listCollections` — feed exclusion
- `startChat` — free-text form (verbatim, trimming, slash-command pass-through, null/empty slug ⇒ no collection load) and legacy slug form (composition, feed refusal, unknown/malformed slug, optional itemId)
- registry assertion updated to include `listSkills`

`yarn format`, `lint` (clean), `typecheck`, `build` (exit 0), and `yarn test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “list skills” command to retrieve available skills from the remote host.
* **Bug Fixes**
  * Prevented feed-based collections from appearing twice in collection listings.
  * Improved skill listing to avoid duplicate/overlapping entries with collection names.
  * Updated chat startup so legacy slug targeting is optional; errors for invalid slugs now only apply when a slug is provided.
* **Tests**
  * Added and expanded test coverage for the new skills command, handler registration, collection listing behavior, and both chat-start modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->