### PR TITLE
docs(CLAUDE): forbid preemptive launcher version bump in chore(release) commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,13 @@ Full layout + workspace tree + process map: [`docs/developer.md`](docs/developer
 | **Add / write an e2e test** (mock or live) | [`docs/developer.md#e2e-testing-playwright`](docs/developer.md#e2e-testing-playwright) for mock, [`docs/e2e-live-testing.md`](docs/e2e-live-testing.md) for live (must-read before adding a `e2e-live/tests/*.spec.ts`) |
 | **Manual-test scenarios that can't be automated** | [`docs/manual-testing.md`](docs/manual-testing.md) |
 | **Reference the centralised constants** (`API_ROUTES`, `TOOL_NAMES`, `WORKSPACE_DIRS`, `PUBSUB_CHANNELS`, `EVENT_TYPES`, `SCHEDULE_TYPES`) | [`docs/developer.md#centralized-constants`](docs/developer.md#centralized-constants). For the four plugin-aware aggregators, edit the plugin's `meta.ts` — never the host record. |
+
+### `chore(release)` commits — never bump the launcher preemptively
+
+A `chore(release)` commit that publishes a shared workspace package (e.g. `@mulmoclaude/core`, `@mulmoclaude/collection-plugin`) MUST bump only that package's `version` and the launcher's DEP RANGE for it (to keep the `launcherSync.mjs` workspace-lockstep invariant green). It MUST NOT bump the launcher's OWN `version` field — that field is reserved for the `/publish-mulmoclaude` workflow that actually publishes the npm launcher.
+
+Rationale: the launcher-sync gate enforces `launcherRange.lowerBound == workspace.version` for dep ratchet, but it never touches or checks the launcher's OWN `version`. Bumping the launcher preemptively "for tidiness" while skipping the actual npm publish creates a silent drift where `packages/mulmoclaude/package.json` runs ahead of npm's latest — future readers can't tell what the next actual publish should be, and end up either skipping the drafted-but-unpublished identity (leaving numbering gaps) or publishing a version whose intent no longer matches the current code. See #1945 for the pattern that motivated this rule.
+
+When to bump `packages/mulmoclaude/package.json`'s `version`:
+- Inside the `/publish-mulmoclaude` flow, right before the actual `npm publish`. That commit becomes the identity of the release.
+- Never as part of a `chore(release)` that publishes only shared packages.


### PR DESCRIPTION
## Summary

Follow-up rule after v0.9.3 (#1945 rollback). Codifies:

- \`chore(release)\` commits that publish a shared workspace package MAY bump that package's \`version\` + the launcher's DEP RANGE for it (needed to keep the \`launcherSync.mjs\` workspace-lockstep invariant green).
- They MUST NOT bump the launcher's OWN \`version\` field — that field is reserved for the \`/publish-mulmoclaude\` workflow that actually publishes the tarball.

Prior \`chore(release)\` commits (89c8417e, 90413383) bumped the launcher \`0.9.2 → 0.9.3 → 0.9.4\` preemptively even though the actual launcher publish was deferred, forcing the rollback PR (#1945) before we could cut v0.9.3. This rule closes the gap.

## Items to Confirm / Review

- [ ] **Rule scope** — narrowly targets \`chore(release)\` semantic; not a hard-coded "never touch launcher version outside publish-mulmoclaude" prohibition. If a legit reason surfaces to bump outside the publish flow, the rule can be relaxed.
- [ ] **Placement** — dropped into "When you do certain tasks" section under the release skill table, so anyone reaching for \`/publish\` sees it.

## User Prompt

> え。なんで publish してないのにバージョン上がっているの？？おかしくないか？
> 「chore(release) 誘発 preemptive bump 問題」の follow-up 対応 → 全部推奨で。

## Implementation

- \`CLAUDE.md\` — new subsection immediately after the release skill table. Explains what \`chore(release)\` MAY / MUST NOT change, states the rationale (launcher-sync gate enforces dep range but not launcher's own version), and refs #1945 as the motivating case.

## Test plan

- [x] \`yarn format\`.
- No runtime effect — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Document constraints on what chore(release) commits may change in workspace package versions and launcher dependency ranges, and reserve launcher version bumps for the publish-mulmoclaude flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to clarify versioning rules for shared package publishes.
  * Ensures launcher and shared package versions stay in sync during release workflows.
  * Clarifies when the app package version should be updated versus left unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->