### PR TITLE
feat(chat-index): configurable mode + always-on origin filter (#1944)

### DIFF
--- a/plans/feat-1944-chat-index-configurable.md
+++ b/plans/feat-1944-chat-index-configurable.md
@@ -1,0 +1,77 @@
+# feat(#1944): chat-index configurable + always-on origin filter
+
+## Summary
+
+Two behaviour changes to the background chat-index summarizer:
+
+- **Origin filter (always on)** — `indexSession` now skips sessions whose `meta.origin` is `system` (hidden worker; title never surfaces in any UI) or `scheduler` (automation; the `firstUserMessage` fallback already identifies them). Applied under every trigger — turn-finish hook, backfill, manual rebuild, forced startup — and unaffected by the `force` flag. Zero Claude CLI spend on ~30 % of the sessions on a busy workspace.
+- **Configurable model + kill switch** — new `AppSettings.chatIndex` field with three values: `"off"` (default), `"haiku"`, `"sonnet"`. Ships **off** — a fresh workspace pays nothing for indexing until the user opts in from Settings → Chat index. `haiku` and `sonnet` pick the model the summarizer spawns; `off` short-circuits `maybeIndexSession` and `backfillAllSessions` before they take the per-session lock / walk the chat dir.
+
+Related: #1929 (unchanged-session skip — the mtime gate stays), #1930 (same).
+
+## Items to Confirm / Review
+
+- **Default is `off`.** Existing users who currently have AI titles + summaries running lose that behaviour until they flip the switch. This is the user's explicit ask ("defaultで、このindex作成をoffに"), but let me know if a one-shot migration prompt is wanted.
+- **Origin filter re-runs every backfill tick** (no persistent skip marker). Cost analysis: ~1–2 ms meta read × 166 automation sessions × 4 backfills/day = ~1.3 s/day of I/O with zero Claude CLI spend. A skip marker in the manifest was considered but rejected as over-engineering — the check is cheap and the manifest stays clean of empty entries.
+- **Manual rebuild + `CHAT_INDEX_FORCE_RUN_ON_STARTUP=1`** also honour `chatIndex: "off"` — they resolve mode via the same `chatIndexMode(loadSettings())` path. If the intent is "override the switch when the user explicitly asked to rebuild", say so and we can add a `bypassOff` opt-in.
+- **Setting shape uses the same null-sentinel wire pattern** as `effortLevel` (`chatIndex?: ChatIndexMode | null` in the patch, dropped to `undefined` on the storage side). The `SettingsChatIndexTab` sends `null` when the user picks `"off"` so `settings.json` stays free of default values.
+- **i18n across 8 locales in lockstep** (en / ja / de / es / fr / ko / pt-BR / zh) — please review the non-EN copies for tone.
+
+## User Prompt
+
+> chat-index scheduler re-summarises every session every hour ... system / scheduler origins are summarized even though the title never displays. → 一旦 sonet に戻す？→ 設定化する。default で、この index 作成を off にしつつ、設定で on/off と、haiku/sonnet 切り替えできるようにしよう。off/haiku/sonnet がよいかな。origin filter もいれよう。これは常に有効。
+
+## Implementation
+
+### Server
+
+- `server/system/config.ts`:
+  - New `CHAT_INDEX_MODES = ["off", "haiku", "sonnet"] as const` + `ChatIndexMode` type.
+  - `AppSettings.chatIndex?: ChatIndexMode` field with docs pointing at Settings → Chat index.
+  - `chatIndexMode(settings)` helper — resolves undefined → `"off"` in one place so every reader agrees.
+  - `AppSettingsPatch` extended with `chatIndex?: ChatIndexMode | null` (null sentinel matches `effortLevel`).
+  - `normaliseAppSettingsPatch` drops the null sentinel.
+  - `isAppSettings` / `isAppSettingsPatch` validators updated. Complexity-relief: extracted `isOptionalString` / `isOptionalNullableEffortLevel` / `isOptionalNullableChatIndexMode` mini-validators so `isAppSettingsPatch` stays under the cognitive-complexity ceiling.
+  - `cloneAppSettings` copies the new field.
+
+- `server/workspace/chat-index/summarizer.ts`:
+  - `SummarizeFn` signature widened to accept an optional `{ model?: SummaryModel }` second arg.
+  - `defaultSummarize` reads `opts.model`, falls back to `DEFAULT_SUMMARY_MODEL` (`"sonnet"`).
+  - `spawnClaudeSummarize` takes the model as a parameter; the hard-coded `SUMMARY_MODEL` constant is gone.
+
+- `server/workspace/chat-index/indexer.ts`:
+  - `IndexerDeps.mode?: "off" | "haiku" | "sonnet"`.
+  - `NON_INDEXED_ORIGINS = new Set(["system", "scheduler"])`.
+  - `readSessionMeta` now also returns `origin`.
+  - `indexSession`: bails at the top when `mode === "off"`. Reads `meta` before the freshness / jsonl-changed / origin gates so the origin filter can short-circuit the (much heavier) jsonl load + summarizer spawn. Passes `model: mode` to `summarize`. Complexity-relief: gates extracted into `shouldSkipBeforeSummarize` helper.
+
+- `server/workspace/chat-index/index.ts`:
+  - `maybeIndexSession` and `backfillAllSessions` resolve mode from `AppSettings.chatIndex` (via `chatIndexMode(loadSettings())`) unless the caller injected one. `"off"` short-circuits BOTH before taking the per-session lock / walking the chat dir.
+
+### Client
+
+- `src/components/SettingsChatIndexTab.vue` — new tab mirroring the `SettingsModelTab` shape (select → auto-save via PUT to `API_ROUTES.config.base`). Sends `null` on `"off"` so `settings.json` stays default-clean.
+- `src/components/SettingsModal.vue` — new `chatIndex` `TabId`, added to the `llm` group (between `voice` and `tools`), reload token bumped on modal open, tab rendered via `<SettingsChatIndexTab>`.
+- 8 locales (en / ja / de / es / fr / ko / pt-BR / zh) — tab label + full `chatIndexTab` block (description, mode label, helper, per-mode name, per-mode status, load/save errors).
+
+### Tests
+
+- `test/chat-index/test_indexer.ts` — existing 30 tests updated to pass `mode: "haiku"` (or `"sonnet"`) so the new default-off gate doesn't skip them. New 6-test suite `indexSession — chat-index mode + origin filter (#1944)`:
+  - `mode: "off"` returns null and NEVER calls the summarizer.
+  - `origin: "system"` skips even under `mode: "sonnet"` + `force: true`.
+  - `origin: "scheduler"` — same.
+  - `mode: "haiku"` passes `{ model: "haiku" }` down to the summarizer.
+  - `mode: "sonnet"` passes `{ model: "sonnet" }` down.
+  - `origin: "human"` indexes normally.
+
+## Test plan
+
+- [x] `yarn tsx --test test/chat-index/test_indexer.ts` — 36 pass (30 existing + 6 new).
+- [x] `yarn tsx --test test/server/test_config.ts test/routes/test_configRoute.ts` — 60 pass.
+- [x] `yarn format` / `yarn lint` (0 errors, 26 pre-existing warnings) / `yarn typecheck` / `yarn build`.
+- Manual: open Settings → Chat index, flip through off / haiku / sonnet, confirm the auto-save banner turns green and `settings.json` updates. Trigger a chat turn under each mode; confirm the summarizer either skips or spawns with the chosen model (via `[chat-index] indexed` log entries).
+
+## Out of scope
+
+- **Persistent skip marker** for automation-origin sessions. Analysed and rejected — the meta read is cheap and the marker would pollute the manifest with empty entries.
+- **Force-rebuild bypassing `off`** — separate opt-in if we later need "override the switch when the user explicitly rebuilt". Current behaviour treats `off` as authoritative for every trigger, which matches the user's ask.

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -164,6 +164,14 @@ router.put(API_ROUTES.config.settings, (req: Request<unknown, unknown, AppSettin
   if (body.effortLevel === null) {
     delete merged.effortLevel;
   }
+  // Chat-index null-sentinel (#1944): "off" is the documented default
+  // (chatIndexMode() maps undefined → "off"), so the tab sends `null`
+  // to drop the field entirely and keep settings.json free of default
+  // values. Without this delete, the previous on-disk value would
+  // leak through the spread and stay set.
+  if (body.chatIndex === null) {
+    delete merged.chatIndex;
+  }
   if (!runSaveOrFail(res, () => saveSettings(merged), "saveSettings failed")) {
     return;
   }

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -23,6 +23,18 @@ import { isRecord, isStringArray, isStringRecord } from "../utils/types.js";
 export const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 
+// Chat-index summarizer setting (#1944). "off" disables the whole
+// AI-title / summary / keywords background indexer; "haiku" / "sonnet"
+// select the Claude model the summarizer spawns. Default (undefined)
+// is treated as "off" — indexing is opt-in from Settings → Chat index
+// so a fresh workspace doesn't burn CLI budget on scheduler/system
+// automation sessions the user may never look at (see #1929 / #1944
+// for the cost analysis). The origin filter (system + scheduler
+// sessions always skipped) is enforced separately and does NOT
+// depend on this setting.
+export const CHAT_INDEX_MODES = ["off", "haiku", "sonnet"] as const;
+export type ChatIndexMode = (typeof CHAT_INDEX_MODES)[number];
+
 export interface AppSettings {
   // Extra tool names appended to BASE_ALLOWED_TOOLS in
   // server/agent/config.ts#buildCliArgs. Typical entries are
@@ -63,6 +75,14 @@ export interface AppSettings {
     enabled: boolean;
     model?: string;
   };
+
+  // Chat-index summarizer mode (#1944). Ships "off" by default: the
+  // background AI-title / summary / keywords indexer stays disabled
+  // until the user opts in from Settings → Chat index. Flipping to
+  // "haiku" or "sonnet" selects the model the summarizer spawns per
+  // session. Non-user origins (`system`, `scheduler`) are always
+  // skipped regardless of this value — see `indexer.ts`.
+  chatIndex?: ChatIndexMode;
 }
 
 const DEFAULT_SETTINGS: AppSettings = { extraAllowedTools: [] };
@@ -94,6 +114,10 @@ function isEffortLevel(value: unknown): value is EffortLevel {
   return typeof value === "string" && (EFFORT_LEVELS as readonly string[]).includes(value);
 }
 
+function isChatIndexMode(value: unknown): value is ChatIndexMode {
+  return typeof value === "string" && (CHAT_INDEX_MODES as readonly string[]).includes(value);
+}
+
 function isVoiceInputSettings(value: unknown): value is { enabled: boolean; model?: string } {
   if (!isRecord(value)) return false;
   if (typeof value.enabled !== "boolean") return false;
@@ -108,8 +132,11 @@ export function isAppSettings(value: unknown): value is AppSettings {
   if (value.photoExif !== undefined && !isPhotoExifSettings(value.photoExif)) return false;
   if (value.effortLevel !== undefined && !isEffortLevel(value.effortLevel)) return false;
   if (value.voiceInput !== undefined && !isVoiceInputSettings(value.voiceInput)) return false;
+  if (value.chatIndex !== undefined && !isChatIndexMode(value.chatIndex)) return false;
   return true;
 }
+
+// isAppSettingsPatch adds a null sentinel to `chatIndex` (see below).
 
 /** A PUT-payload validator: every field optional, but if present
  *  it must match the AppSettings shape. Distinct from
@@ -127,28 +154,40 @@ export function isAppSettings(value: unknown): value is AppSettings {
  *  but lets nullable fields carry `null` as a "clear me" sentinel —
  *  callers normalise via `normaliseAppSettingsPatch` before merging
  *  into the storage shape (#1323). */
-export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel">> & {
+export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel" | "chatIndex">> & {
   effortLevel?: EffortLevel | null;
+  chatIndex?: ChatIndexMode | null;
 };
 
 /** Convert a wire patch to the storage-shape patch by dropping any
  *  `null` sentinels (which mean "clear" for the corresponding field). */
 export function normaliseAppSettingsPatch(patch: AppSettingsPatch): Partial<AppSettings> {
-  const { effortLevel, ...rest } = patch;
+  const { effortLevel, chatIndex, ...rest } = patch;
   const out: Partial<AppSettings> = { ...rest };
   if (effortLevel !== null && effortLevel !== undefined) {
     out.effortLevel = effortLevel;
   }
+  if (chatIndex !== null && chatIndex !== undefined) {
+    out.chatIndex = chatIndex;
+  }
   return out;
 }
+
+// Split each field's optional-with-null-sentinel validation into its own
+// mini-helper so `isAppSettingsPatch` stays under the cognitive-complexity
+// ceiling as new nullable fields land.
+const isOptionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
+const isOptionalNullableEffortLevel = (value: unknown): boolean => value === undefined || value === null || isEffortLevel(value);
+const isOptionalNullableChatIndexMode = (value: unknown): boolean => value === undefined || value === null || isChatIndexMode(value);
 
 export function isAppSettingsPatch(value: unknown): value is AppSettingsPatch {
   if (!isRecord(value)) return false;
   if (value.extraAllowedTools !== undefined && !isStringArray(value.extraAllowedTools)) return false;
-  if (value.googleMapsApiKey !== undefined && typeof value.googleMapsApiKey !== "string") return false;
+  if (!isOptionalString(value.googleMapsApiKey)) return false;
   if (value.photoExif !== undefined && !isPhotoExifSettings(value.photoExif)) return false;
-  if (value.effortLevel !== undefined && value.effortLevel !== null && !isEffortLevel(value.effortLevel)) return false;
+  if (!isOptionalNullableEffortLevel(value.effortLevel)) return false;
   if (value.voiceInput !== undefined && !isVoiceInputSettings(value.voiceInput)) return false;
+  if (!isOptionalNullableChatIndexMode(value.chatIndex)) return false;
   return true;
 }
 
@@ -182,7 +221,18 @@ function cloneAppSettings(settings: AppSettings): AppSettings {
       copy.voiceInput.model = settings.voiceInput.model;
     }
   }
+  if (settings.chatIndex !== undefined) {
+    copy.chatIndex = settings.chatIndex;
+  }
   return copy;
+}
+
+/** Chat-index mode with the documented "undefined → off" default, so
+ *  every reader (indexer, backfill scheduler, force-startup switch,
+ *  Settings tab) resolves the same way. Callers switch on the
+ *  returned literal string to decide skip vs pick a model. */
+export function chatIndexMode(settings: AppSettings): ChatIndexMode {
+  return settings.chatIndex ?? "off";
 }
 
 /** Read the photo-exif auto-capture flag with the documented

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -284,6 +284,9 @@ export function saveSettings(settings: AppSettings): void {
       payload.voiceInput.model = settings.voiceInput.model;
     }
   }
+  if (settings.chatIndex !== undefined) {
+    payload.chatIndex = settings.chatIndex;
+  }
   const serialised = JSON.stringify(payload, null, 2);
   writeFileAtomicSync(settingsPath(), `${serialised}\n`, { mode: 0o600 });
 }

--- a/server/workspace/chat-index/index.ts
+++ b/server/workspace/chat-index/index.ts
@@ -17,6 +17,7 @@ import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { ClaudeCliNotFoundError } from "../journal/archivist-cli.js";
 import { indexSession, listSessionIds, type IndexerDeps } from "./indexer.js";
 import { log } from "../../system/logger/index.js";
+import { chatIndexMode as resolveChatIndexMode, loadSettings } from "../../system/config.js";
 
 // Per-session lock. Indexing different sessions in parallel is
 // fine; indexing the same session twice concurrently would just
@@ -56,11 +57,20 @@ export async function maybeIndexSession(opts: MaybeIndexSessionOptions): Promise
   if (!force && opts.activeSessionIds?.has(sessionId)) return;
   if (running.has(sessionId)) return;
 
-  // Thread `force` through the indexer via IndexerDeps so the
-  // freshness throttle is also bypassed on forced runs.
+  // Resolve chat-index mode from settings unless the caller passed one
+  // explicitly (tests do; production callers don't). "off" short-
+  // circuits before we take the per-session lock so a disabled
+  // indexer stays a zero-work path.
+  const mode = opts.deps?.mode ?? resolveChatIndexMode(loadSettings());
+  if (mode === "off") return;
+
+  // Thread `force` + `mode` through the indexer via IndexerDeps so the
+  // freshness throttle is also bypassed on forced runs and the summarizer
+  // picks the right model.
   const effectiveDeps: IndexerDeps = {
     ...(opts.deps ?? {}),
     ...(force ? { force: true } : {}),
+    mode,
   };
 
   running.add(sessionId);
@@ -108,6 +118,14 @@ export async function backfillAllSessions(
   } = {},
 ): Promise<BackfillResult> {
   const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
+  // Resolve mode once for the whole walk (settings don't change mid-tick
+  // and re-reading per session would burn ~N syscalls for no benefit).
+  // "off" short-circuits the walk entirely — the sessions get counted
+  // as skipped instead of paying for a listing.
+  const mode = opts.deps?.mode ?? resolveChatIndexMode(loadSettings());
+  if (mode === "off") {
+    return { total: 0, indexed: 0, skipped: 0 };
+  }
   const ids = await listSessionIds(workspaceRoot);
   const result: BackfillResult = {
     total: ids.length,
@@ -124,6 +142,7 @@ export async function backfillAllSessions(
       const entry = await indexSession(workspaceRoot, sessionId, {
         ...(opts.deps ?? {}),
         ...(force ? { force: true } : {}),
+        mode,
       });
       if (entry) {
         result.indexed++;

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -45,6 +45,13 @@ export interface IndexerDeps {
   // prompt was edited and existing summaries are stale by design,
   // not by content.
   force?: boolean;
+  // Chat-index mode from `AppSettings.chatIndex` (default "off"). "off"
+  // short-circuits `indexSession` before any I/O; "haiku"/"sonnet"
+  // selects the model passed to the summariser. Injected from the
+  // callers (turn-finish hook, backfill scheduler, manual rebuild,
+  // startup force) so a single settings load happens at trigger time
+  // rather than N times inside the indexer.
+  mode?: "off" | "haiku" | "sonnet";
 }
 
 // --- manifest I/O ---------------------------------------------------
@@ -225,7 +232,17 @@ export function safeSessionIdOrNull(sessionId: string): string | null {
 interface SessionMeta {
   roleId?: string;
   startedAt?: string;
+  origin?: string;
 }
+
+// Origins the chat-index summarizer intentionally skips (#1944). `system`
+// sessions are hidden workers whose title never appears in any UI, and
+// `scheduler` sessions fall back to their own `firstUserMessage` (the
+// automation prompt) which identifies them well enough without an AI
+// summary. Kept as a plain string set — `SESSION_ORIGINS` lives in
+// src/types/session.ts and the indexer must not depend on the front-end
+// types module.
+const NON_INDEXED_ORIGINS: ReadonlySet<string> = new Set(["system", "scheduler"]);
 
 async function readSessionMeta(workspaceRoot: string, sessionId: string): Promise<SessionMeta> {
   // Defence-in-depth: only `indexSession` calls this (with an
@@ -242,6 +259,7 @@ async function readSessionMeta(workspaceRoot: string, sessionId: string): Promis
     return {
       roleId: typeof metaRecord.roleId === "string" ? metaRecord.roleId : undefined,
       startedAt: typeof metaRecord.startedAt === "string" ? metaRecord.startedAt : undefined,
+      origin: typeof metaRecord.origin === "string" ? metaRecord.origin : undefined,
     };
   } catch {
     return {};
@@ -282,6 +300,31 @@ export async function listSessionIds(workspaceRoot: string): Promise<string[]> {
 // resulting `safeId` is threaded through every downstream file
 // access, so `force: true` — a debug / rollout knob — cannot become
 // a path-injection escape hatch (Codex review on #1930).
+// Freshness / content-change / origin gates. All three are cheap-ish
+// checks that short-circuit before the summarizer spawn. Extracted so
+// `indexSession` stays under the cognitive-complexity ceiling.
+async function shouldSkipBeforeSummarize(
+  workspaceRoot: string,
+  safeId: string,
+  now: number,
+  minInterval: number,
+  force: boolean,
+  meta: SessionMeta,
+): Promise<boolean> {
+  // Origin filter (#1944). Always applied, even under `force: true`:
+  // `system` sessions never surface a title in any UI, and `scheduler`
+  // sessions fall back to `firstUserMessage` (the automation prompt)
+  // which identifies them without an AI summary.
+  if (meta.origin !== undefined && NON_INDEXED_ORIGINS.has(meta.origin)) return true;
+  if (force) return false;
+  if (await isFresh(workspaceRoot, safeId, now, minInterval)) return true;
+  // Second gate: even past the freshness window, if the jsonl has NOT
+  // been written since the last index there's no new content to
+  // summarize. Cuts idle scheduler tick cost from O(sessions) Claude
+  // CLI calls to O(actual updates) — see #1929.
+  return !(await sessionJsonlChangedSinceIndex(workspaceRoot, safeId));
+}
+
 export async function indexSession(workspaceRoot: string, sessionId: string, deps: IndexerDeps = {}): Promise<ChatIndexEntry | null> {
   const safeId = safeSessionIdOrNull(sessionId);
   if (safeId === null) return null;
@@ -289,25 +332,25 @@ export async function indexSession(workspaceRoot: string, sessionId: string, dep
   const now = (deps.now ?? Date.now)();
   const minInterval = deps.minIntervalMs ?? MIN_INDEX_INTERVAL_MS;
   const force = deps.force === true;
+  const mode = deps.mode ?? "off";
 
-  if (!force) {
-    if (await isFresh(workspaceRoot, safeId, now, minInterval)) {
-      return null;
-    }
-    // Second gate: even past the freshness window, if the jsonl has
-    // NOT been written since the last index there's no new content
-    // to summarize. Cuts idle scheduler tick cost from O(sessions)
-    // Claude CLI calls to O(actual updates) — see #1929.
-    if (!(await sessionJsonlChangedSinceIndex(workspaceRoot, safeId))) {
-      return null;
-    }
-  }
+  // Config-driven kill switch (#1944). "off" is the default so a fresh
+  // workspace doesn't burn CLI budget until the user opts in from
+  // Settings → Chat index. Bailing before any I/O keeps the check
+  // ~free (~1 branch) so a backfill tick over N sessions costs O(N)
+  // branches, not O(N × meta reads).
+  if (mode === "off") return null;
+
+  // Meta is read here (before jsonl load / summarizer spawn) so the
+  // origin filter can short-circuit heavy work; the same object is
+  // reused below when building the entry.
+  const meta = await readSessionMeta(workspaceRoot, safeId);
+  if (await shouldSkipBeforeSummarize(workspaceRoot, safeId, now, minInterval, force, meta)) return null;
 
   const input = await loadJsonlInput(sessionJsonlPathFor(workspaceRoot, safeId));
   if (!input.trim()) return null;
 
-  const summary = await summarize(input);
-  const meta = await readSessionMeta(workspaceRoot, safeId);
+  const summary = await summarize(input, { model: mode });
 
   const entry: ChatIndexEntry = {
     id: safeId,

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -39,11 +39,18 @@ const SUMMARY_SCHEMA = {
   required: ["title", "summary", "keywords"],
 };
 
-// Model used for summarization. Sonnet, not haiku: the title is the
-// primary way a user finds a past chat, so a weak title makes the
-// history list unusable. One cheap structured call per session is
-// negligible next to the agent turns it summarizes.
-const SUMMARY_MODEL = "sonnet";
+// Default model used when a caller doesn't specify one. Sonnet, not
+// haiku: the title is the primary way a user finds a past chat, so a
+// weak title makes the history list unusable. Since #1944 the model
+// is user-selectable from Settings → Chat index — "off" disables the
+// indexer, "haiku" / "sonnet" pick the model here — so this constant
+// is only the internal fallback when the indexer runs without a
+// model override (e.g. a manual rebuild triggered before the setting
+// resolves).
+const DEFAULT_SUMMARY_MODEL = "sonnet";
+// Explicit union so a bad string from the settings layer can't reach
+// the CLI unchecked. Mirror in `AppSettings.chatIndex` (server/system/config.ts).
+export type SummaryModel = "haiku" | "sonnet";
 
 // Prompt-building constants. Sized for Sonnet's large context: the
 // window is wide enough to carry a long, topic-shifting session's
@@ -68,7 +75,7 @@ const MAX_BUDGET_USD = 0.4;
 // Any module that wants to drive the summarizer — including the
 // indexer — takes a SummarizeFn so tests can supply a deterministic
 // fake. Production path is `defaultSummarize` below.
-export type SummarizeFn = (input: string) => Promise<SummaryResult>;
+export type SummarizeFn = (input: string, opts?: { model?: SummaryModel }) => Promise<SummaryResult>;
 
 interface JsonlEntry {
   source?: string;
@@ -184,7 +191,7 @@ export async function loadJsonlInput(jsonlPath: string): Promise<string> {
 
 // --- spawn layer ----------------------------------------------------
 
-function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string> {
+function spawnClaudeSummarize(input: string, timeoutMs: number, model: SummaryModel): Promise<string> {
   return new Promise((resolve, reject) => {
     const args = [
       "--print",
@@ -192,7 +199,7 @@ function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string>
       "--output-format",
       "json",
       "--model",
-      SUMMARY_MODEL,
+      model,
       "--max-budget-usd",
       String(MAX_BUDGET_USD),
       "--json-schema",
@@ -252,7 +259,8 @@ function spawnClaudeSummarize(input: string, timeoutMs: number): Promise<string>
 // Production SummarizeFn: prepare the input from a jsonl path and
 // drive the CLI. Tests inject their own SummarizeFn that bypasses
 // the CLI entirely.
-export const defaultSummarize: SummarizeFn = async (input: string) => {
-  const stdout = await spawnClaudeSummarize(input, DEFAULT_TIMEOUT_MS);
+export const defaultSummarize: SummarizeFn = async (input, opts) => {
+  const model: SummaryModel = opts?.model ?? DEFAULT_SUMMARY_MODEL;
+  const stdout = await spawnClaudeSummarize(input, DEFAULT_TIMEOUT_MS, model);
   return parseClaudeJsonResult(stdout);
 };

--- a/src/components/SettingsChatIndexTab.vue
+++ b/src/components/SettingsChatIndexTab.vue
@@ -1,0 +1,106 @@
+<template>
+  <div class="space-y-3" data-testid="settings-chat-index-tab">
+    <p class="text-sm text-gray-700">{{ t("settingsModal.chatIndexTab.description") }}</p>
+
+    <div class="space-y-2">
+      <label class="block text-sm font-medium text-gray-800" for="settings-chat-index-mode">{{ t("settingsModal.chatIndexTab.modeLabel") }}</label>
+      <select
+        id="settings-chat-index-mode"
+        v-model="modeDraft"
+        class="w-full px-3 py-2 text-sm rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        data-testid="settings-chat-index-mode-select"
+        @change="save"
+      >
+        <option v-for="mode in CHAT_INDEX_MODES" :key="mode" :value="mode">{{ t(`settingsModal.chatIndexTab.mode.${mode}`) }}</option>
+      </select>
+      <p class="text-xs text-gray-500">{{ t("settingsModal.chatIndexTab.helperText") }}</p>
+    </div>
+
+    <div v-if="loaded && !errorMessage" class="flex items-center gap-3 text-xs">
+      <span :class="statusColour" data-testid="settings-chat-index-status">
+        {{ statusText }}
+      </span>
+    </div>
+
+    <p v-if="errorMessage" class="text-sm text-red-700" role="alert" data-testid="settings-chat-index-error">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { apiGet, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+const CHAT_INDEX_MODES = ["off", "haiku", "sonnet"] as const;
+type ChatIndexMode = (typeof CHAT_INDEX_MODES)[number];
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  reloadToken: number;
+}>();
+
+const emit = defineEmits<{
+  saved: [];
+}>();
+
+interface SettingsResponse {
+  settings: { chatIndex?: ChatIndexMode };
+}
+
+const modeDraft = ref<ChatIndexMode>("off");
+const storedMode = ref<ChatIndexMode>("off");
+const loaded = ref(false);
+const saving = ref(false);
+const errorMessage = ref("");
+
+const statusText = computed(() => {
+  if (saving.value) return t("common.saving");
+  return t(`settingsModal.chatIndexTab.status.${storedMode.value}`);
+});
+
+const statusColour = computed(() => {
+  if (saving.value) return "text-gray-500";
+  return storedMode.value === "off" ? "text-gray-500" : "text-green-600";
+});
+
+async function load(): Promise<void> {
+  errorMessage.value = "";
+  const response = await apiGet<SettingsResponse>(API_ROUTES.config.base);
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.chatIndexTab.loadError");
+    return;
+  }
+  storedMode.value = response.data.settings.chatIndex ?? "off";
+  modeDraft.value = storedMode.value;
+  loaded.value = true;
+}
+
+async function save(): Promise<void> {
+  if (saving.value) return;
+  saving.value = true;
+  errorMessage.value = "";
+  // Send null explicitly when the user picks "off" so the server drops
+  // the field instead of storing "off" verbatim — keeps settings.json
+  // clean of default values.
+  const payload = { chatIndex: modeDraft.value === "off" ? null : modeDraft.value };
+  const response = await apiPut<SettingsResponse>(API_ROUTES.config.base, payload);
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.chatIndexTab.saveError");
+    saving.value = false;
+    return;
+  }
+  storedMode.value = modeDraft.value;
+  saving.value = false;
+  emit("saved");
+}
+
+watch(
+  () => props.reloadToken,
+  () => {
+    void load();
+  },
+  { immediate: true },
+);
+</script>

--- a/src/components/SettingsChatIndexTab.vue
+++ b/src/components/SettingsChatIndexTab.vue
@@ -79,21 +79,29 @@ async function load(): Promise<void> {
 
 async function save(): Promise<void> {
   if (saving.value) return;
+  if (modeDraft.value === storedMode.value) return;
+  // Capture the submitted value before await — a concurrent draft change
+  // would otherwise overwrite `storedMode` with a not-yet-saved value.
+  const requested = modeDraft.value;
   saving.value = true;
   errorMessage.value = "";
-  // Send null explicitly when the user picks "off" so the server drops
-  // the field instead of storing "off" verbatim — keeps settings.json
-  // clean of default values.
-  const payload = { chatIndex: modeDraft.value === "off" ? null : modeDraft.value };
-  const response = await apiPut<SettingsResponse>(API_ROUTES.config.base, payload);
+  // The Settings tab uses the PATCH endpoint (`config.settings`) — the
+  // full-shape `config.base` PUT expects `{ settings, mcp }` and would
+  // reject a bare `{ chatIndex }` payload. Send null on "off" so the
+  // server drops the field and settings.json stays default-clean.
+  const payload = { chatIndex: requested === "off" ? null : requested };
+  const response = await apiPut<unknown>(API_ROUTES.config.settings, payload);
+  saving.value = false;
   if (!response.ok) {
     errorMessage.value = response.error || t("settingsModal.chatIndexTab.saveError");
-    saving.value = false;
     return;
   }
-  storedMode.value = modeDraft.value;
-  saving.value = false;
+  storedMode.value = requested;
   emit("saved");
+  // If the user changed the draft while we were in flight, re-trigger.
+  if (modeDraft.value !== requested) {
+    void save();
+  }
 }
 
 watch(

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -167,6 +167,8 @@
             <SettingsModelTab v-else-if="activeTab === 'model'" :reload-token="modelReloadToken" @saved="emit('saved')" />
 
             <SettingsVoiceTab v-else-if="activeTab === 'voice'" :reload-token="voiceReloadToken" />
+
+            <SettingsChatIndexTab v-else-if="activeTab === 'chatIndex'" :reload-token="chatIndexReloadToken" @saved="emit('saved')" />
           </template>
         </div>
       </div>
@@ -197,6 +199,7 @@ import SettingsMapTab from "./SettingsMapTab.vue";
 import SettingsPhotosTab from "./SettingsPhotosTab.vue";
 import SettingsModelTab from "./SettingsModelTab.vue";
 import SettingsVoiceTab from "./SettingsVoiceTab.vue";
+import SettingsChatIndexTab from "./SettingsChatIndexTab.vue";
 import SkillsView from "../plugins/manageSkills/View.vue";
 import RolesView from "./RolesView.vue";
 import PluginScopedRoot from "./PluginScopedRoot.vue";
@@ -245,7 +248,7 @@ const emit = defineEmits<{
 // update / remove persist immediately).
 const mcpTabRef = ref<{ flushDraft: () => boolean; hasPendingDraft: () => boolean } | null>(null);
 
-type TabId = "gemini" | "tools" | "mcp" | "dirs" | "refs" | "map" | "photos" | "model" | "voice" | "skills" | "roles";
+type TabId = "gemini" | "tools" | "mcp" | "dirs" | "refs" | "map" | "photos" | "model" | "voice" | "chatIndex" | "skills" | "roles";
 
 const activeTab = ref<TabId>("tools");
 
@@ -261,7 +264,7 @@ const isFullTab = computed(() => FULL_TABS.includes(activeTab.value));
 // item is filtered out by `visibleGroups` when geminiAvailable === true
 // (env var present → user has nothing to configure).
 const GROUPS: readonly { key: string; items: readonly TabId[] }[] = [
-  { key: "llm", items: ["model", "voice", "tools", "gemini"] },
+  { key: "llm", items: ["model", "voice", "chatIndex", "tools", "gemini"] },
   { key: "servers", items: ["mcp"] },
   { key: "workspace", items: ["dirs", "refs"] },
   { key: "plugins", items: ["map", "photos"] },
@@ -294,6 +297,7 @@ function onMapSaved(): void {
 const photosReloadToken = ref(0);
 const modelReloadToken = ref(0);
 const voiceReloadToken = ref(0);
+const chatIndexReloadToken = ref(0);
 const toolsText = ref("");
 // Server truth for tools — updated on load and on a successful Save
 // from the Tools tab. `toolsDirty` compares this against `toolsText`
@@ -501,6 +505,7 @@ watch(
       photosReloadToken.value += 1;
       modelReloadToken.value += 1;
       voiceReloadToken.value += 1;
+      chatIndexReloadToken.value += 1;
       statusMessage.value = "";
       statusError.value = false;
     }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -231,6 +231,7 @@ const deMessages = {
       photos: "Fotos",
       model: "Modell",
       voice: "Sprache",
+      chatIndex: "Chat-Index",
       skills: "Skills",
       roles: "Rollen",
     },
@@ -290,6 +291,24 @@ const deMessages = {
       ready: "Modell bereit",
       downloadError: "Modell-Download fehlgeschlagen.",
       retry: "Erneut versuchen",
+      loadError: "Einstellungen konnten nicht geladen werden",
+      saveError: "Speichern fehlgeschlagen",
+    },
+    chatIndexTab: {
+      description:
+        "Automatische KI-Titel und Zusammenfassungen für den Chat-Verlauf. Standardmäßig aus — Automatisierungs-Sessions (Scheduler / System-Worker) werden auch bei aktivierter Option immer übersprungen; menschliche Sessions kosten pro beendetem Turn genau einen Summarizer-Aufruf.",
+      modeLabel: "Chat-Index-Modell",
+      helperText: "Haiku ist günstiger; Sonnet liefert schärfere Titel bei langen, themenwechselnden Sessions.",
+      mode: {
+        off: "Aus",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Indizierung ist AUS",
+        haiku: "Indizierung läuft mit Haiku",
+        sonnet: "Indizierung läuft mit Sonnet",
+      },
       loadError: "Einstellungen konnten nicht geladen werden",
       saveError: "Speichern fehlgeschlagen",
     },

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -249,6 +249,7 @@ const enMessages = {
       photos: "Photos",
       model: "Model",
       voice: "Voice",
+      chatIndex: "Chat index",
       skills: "Skills",
       roles: "Roles",
     },
@@ -306,6 +307,24 @@ const enMessages = {
       ready: "Model ready",
       downloadError: "Model download failed.",
       retry: "Retry",
+      loadError: "Failed to load settings",
+      saveError: "Failed to save",
+    },
+    chatIndexTab: {
+      description:
+        "Background AI titles + summaries for your chat history. Ships off — automation sessions (scheduler / system workers) are always skipped even when on, and human sessions only pay one summarizer call each when a turn ends.",
+      modeLabel: "Chat index model",
+      helperText: "Haiku is cheaper; Sonnet gives sharper titles for long, topic-shifting sessions.",
+      mode: {
+        off: "Off",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Indexing is OFF",
+        haiku: "Indexing with Haiku",
+        sonnet: "Indexing with Sonnet",
+      },
       loadError: "Failed to load settings",
       saveError: "Failed to save",
     },

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -234,6 +234,7 @@ const esMessages = {
       photos: "Fotos",
       model: "Modelo",
       voice: "Voz",
+      chatIndex: "Índice de chat",
       skills: "Skills",
       roles: "Roles",
     },
@@ -291,6 +292,24 @@ const esMessages = {
       ready: "Modelo listo",
       downloadError: "Error al descargar el modelo.",
       retry: "Reintentar",
+      loadError: "Error al cargar los ajustes",
+      saveError: "Error al guardar",
+    },
+    chatIndexTab: {
+      description:
+        "Títulos y resúmenes automáticos generados por IA para tu historial de chat. Sale desactivado por defecto — las sesiones de automatización (scheduler / trabajadores del sistema) siempre se omiten aunque esté activado; las sesiones humanas solo pagan una llamada al resumidor al terminar cada turno.",
+      modeLabel: "Modelo del índice de chat",
+      helperText: "Haiku es más económico; Sonnet ofrece títulos más precisos en sesiones largas con cambios de tema.",
+      mode: {
+        off: "Desactivado",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "La indexación está DESACTIVADA",
+        haiku: "Indexando con Haiku",
+        sonnet: "Indexando con Sonnet",
+      },
       loadError: "Error al cargar los ajustes",
       saveError: "Error al guardar",
     },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -229,6 +229,7 @@ const frMessages = {
       photos: "Photos",
       model: "Modèle",
       voice: "Voix",
+      chatIndex: "Index du chat",
       skills: "Skills",
       roles: "Rôles",
     },
@@ -286,6 +287,24 @@ const frMessages = {
       ready: "Modèle prêt",
       downloadError: "Échec du téléchargement du modèle.",
       retry: "Réessayer",
+      loadError: "Échec du chargement des paramètres",
+      saveError: "Échec de l'enregistrement",
+    },
+    chatIndexTab: {
+      description:
+        "Titres et résumés générés par IA pour l'historique du chat. Désactivé par défaut — les sessions d'automatisation (scheduler / workers système) sont toujours ignorées même quand c'est activé ; les sessions humaines ne paient qu'un appel au résumeur à la fin de chaque tour.",
+      modeLabel: "Modèle de l'index de chat",
+      helperText: "Haiku est moins cher ; Sonnet donne des titres plus précis pour de longues sessions changeant de sujet.",
+      mode: {
+        off: "Désactivé",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Indexation DÉSACTIVÉE",
+        haiku: "Indexation avec Haiku",
+        sonnet: "Indexation avec Sonnet",
+      },
       loadError: "Échec du chargement des paramètres",
       saveError: "Échec de l'enregistrement",
     },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -232,6 +232,7 @@ const jaMessages = {
       photos: "写真",
       model: "モデル",
       voice: "音声",
+      chatIndex: "チャットインデックス",
       skills: "スキル",
       roles: "ロール",
     },
@@ -289,6 +290,24 @@ const jaMessages = {
       ready: "モデルの準備が完了しました",
       downloadError: "モデルのダウンロードに失敗しました。",
       retry: "再試行",
+      loadError: "設定の読み込みに失敗しました",
+      saveError: "保存に失敗しました",
+    },
+    chatIndexTab: {
+      description:
+        "チャット履歴の AI タイトル/サマリー自動生成の設定です。デフォルトは off で、自動化系のセッション（scheduler / system worker）は on にしても常に除外されます。人間のセッションのみターン終了時に 1 回要約が走ります。",
+      modeLabel: "チャットインデックスのモデル",
+      helperText: "Haiku は安価。Sonnet は長く話題が移るセッションでタイトル品質が高くなります。",
+      mode: {
+        off: "オフ",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "インデックス作成: オフ",
+        haiku: "Haiku でインデックス作成中",
+        sonnet: "Sonnet でインデックス作成中",
+      },
       loadError: "設定の読み込みに失敗しました",
       saveError: "保存に失敗しました",
     },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -235,6 +235,7 @@ const koMessages = {
       photos: "사진",
       model: "모델",
       voice: "음성",
+      chatIndex: "채팅 인덱스",
       skills: "스킬",
       roles: "역할",
     },
@@ -289,6 +290,24 @@ const koMessages = {
       ready: "모델 준비 완료",
       downloadError: "모델 다운로드에 실패했습니다.",
       retry: "다시 시도",
+      loadError: "설정을 불러오지 못했습니다",
+      saveError: "저장에 실패했습니다",
+    },
+    chatIndexTab: {
+      description:
+        "채팅 기록의 AI 제목/요약 자동 생성을 설정합니다. 기본값은 off 이며, 자동화 계열 세션(scheduler / 시스템 워커)은 on 상태여도 항상 제외됩니다. 사람 세션만 턴 종료 시 요약이 한 번 실행됩니다.",
+      modeLabel: "채팅 인덱스 모델",
+      helperText: "Haiku 가 더 저렴하고, Sonnet 은 길고 주제가 바뀌는 세션에서 더 정확한 제목을 만듭니다.",
+      mode: {
+        off: "꺼짐",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "인덱싱: 꺼짐",
+        haiku: "Haiku 로 인덱싱 중",
+        sonnet: "Sonnet 으로 인덱싱 중",
+      },
       loadError: "설정을 불러오지 못했습니다",
       saveError: "저장에 실패했습니다",
     },

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -229,6 +229,7 @@ const ptBRMessages = {
       photos: "Fotos",
       model: "Modelo",
       voice: "Voz",
+      chatIndex: "Índice de chat",
       skills: "Skills",
       roles: "Papéis",
     },
@@ -285,6 +286,24 @@ const ptBRMessages = {
       ready: "Modelo pronto",
       downloadError: "Falha ao baixar o modelo.",
       retry: "Tentar novamente",
+      loadError: "Falha ao carregar as configurações",
+      saveError: "Falha ao salvar",
+    },
+    chatIndexTab: {
+      description:
+        "Títulos e resumos gerados por IA para o histórico do chat. Sai desativado por padrão — sessões de automação (scheduler / workers do sistema) sempre são ignoradas mesmo quando ativado; sessões humanas pagam apenas uma chamada ao sumarizador ao terminar cada turno.",
+      modeLabel: "Modelo do índice de chat",
+      helperText: "Haiku é mais barato; Sonnet dá títulos mais precisos em sessões longas que mudam de assunto.",
+      mode: {
+        off: "Desativado",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Indexação DESATIVADA",
+        haiku: "Indexando com Haiku",
+        sonnet: "Indexando com Sonnet",
+      },
       loadError: "Falha ao carregar as configurações",
       saveError: "Falha ao salvar",
     },

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -230,6 +230,7 @@ const zhMessages = {
       photos: "照片",
       model: "模型",
       voice: "语音",
+      chatIndex: "聊天索引",
       skills: "技能",
       roles: "角色",
     },
@@ -283,6 +284,24 @@ const zhMessages = {
       ready: "模型已就绪",
       downloadError: "模型下载失败。",
       retry: "重试",
+      loadError: "加载设置失败",
+      saveError: "保存失败",
+    },
+    chatIndexTab: {
+      description:
+        "为聊天历史自动生成 AI 标题/摘要。默认关闭。开启后自动化会话（scheduler / 系统 worker）仍会始终跳过；只有人类会话在每次轮次结束时才会调用一次摘要。",
+      modeLabel: "聊天索引模型",
+      helperText: "Haiku 更便宜；Sonnet 在长且话题多变的会话中标题更精准。",
+      mode: {
+        off: "关闭",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "索引已关闭",
+        haiku: "使用 Haiku 建立索引中",
+        sonnet: "使用 Sonnet 建立索引中",
+      },
       loadError: "加载设置失败",
       saveError: "保存失败",
     },

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -31,6 +31,7 @@ function seedSession(
     startedAt?: string;
     userMessages?: string[];
     assistantMessages?: string[];
+    origin?: string;
   } = {},
 ): string {
   const {
@@ -38,9 +39,12 @@ function seedSession(
     startedAt = "2026-04-12T10:00:00.000Z",
     userMessages = ["Can you help me plan a project?"],
     assistantMessages = ["Sure — tell me what it's about."],
+    origin,
   } = opts;
   const chatDir = join(workspace, CHAT_REL);
-  writeFileSync(join(chatDir, `${sessionId}.json`), JSON.stringify({ roleId, startedAt }));
+  const metaPayload: Record<string, string> = { roleId, startedAt };
+  if (origin !== undefined) metaPayload.origin = origin;
+  writeFileSync(join(chatDir, `${sessionId}.json`), JSON.stringify(metaPayload));
   const lines: string[] = [];
   for (let i = 0; i < Math.max(userMessages.length, assistantMessages.length); i++) {
     if (userMessages[i] !== undefined) {
@@ -95,6 +99,7 @@ describe("indexSession — happy path", () => {
     });
 
     const entry = await indexSession(workspace, "sess-A", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => Date.parse("2026-04-12T10:05:00.000Z"),
     });
@@ -127,6 +132,7 @@ describe("indexSession — freshness throttle", () => {
 
     // First run to seed the index entry at t=0.
     await indexSession(workspace, "sess-B", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -134,6 +140,7 @@ describe("indexSession — freshness throttle", () => {
 
     // Second run 5 min later — still inside the 15-min window.
     const result = await indexSession(workspace, "sess-B", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 5 * 60 * 1000,
     });
@@ -146,6 +153,7 @@ describe("indexSession — freshness throttle", () => {
     const stub = makeStubSummarize();
 
     await indexSession(workspace, "sess-C", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -153,6 +161,7 @@ describe("indexSession — freshness throttle", () => {
 
     // Advance beyond the window.
     const result = await indexSession(workspace, "sess-C", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => MIN_INDEX_INTERVAL_MS + 1,
     });
@@ -166,6 +175,7 @@ describe("indexSession — freshness throttle", () => {
 
     // Seed a fresh entry at t=0.
     await indexSession(workspace, "sess-force", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -174,6 +184,7 @@ describe("indexSession — freshness throttle", () => {
     // Second call 1 second later — normally skipped, but
     // force: true re-indexes anyway.
     const refreshed = await indexSession(workspace, "sess-force", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 1000,
       force: true,
@@ -187,12 +198,14 @@ describe("indexSession — freshness throttle", () => {
     const stub = makeStubSummarize();
 
     await indexSession(workspace, "sess-D", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
       minIntervalMs: 1000,
     });
     // 500 ms later — still fresh under the 1000 ms window.
     const skipped = await indexSession(workspace, "sess-D", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 500,
       minIntervalMs: 1000,
@@ -200,6 +213,7 @@ describe("indexSession — freshness throttle", () => {
     assert.equal(skipped, null);
     // 2000 ms later — window elapsed.
     const refreshed = await indexSession(workspace, "sess-D", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 2000,
       minIntervalMs: 1000,
@@ -212,6 +226,7 @@ describe("indexSession — skip conditions", () => {
   it("returns null for a missing jsonl", async () => {
     const stub = makeStubSummarize();
     const result = await indexSession(workspace, "no-such-session", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -223,6 +238,7 @@ describe("indexSession — skip conditions", () => {
     seedSession("sess-E", { userMessages: [], assistantMessages: [] });
     const stub = makeStubSummarize();
     const result = await indexSession(workspace, "sess-E", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -242,6 +258,7 @@ describe("indexSession — skip conditions", () => {
     writeFileSync(join(chatDir, "sess-F.jsonl"), `${JSON.stringify({ source: "tool", type: "tool_result", message: "x" })}\n`);
     const stub = makeStubSummarize();
     const result = await indexSession(workspace, "sess-F", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -259,6 +276,7 @@ describe("indexSession — manifest upsert and ordering", () => {
       keywords: ["a"],
     });
     await indexSession(workspace, "sess-G", {
+      mode: "haiku",
       summarize: firstStub.fn,
       now: () => 0,
     });
@@ -270,6 +288,7 @@ describe("indexSession — manifest upsert and ordering", () => {
       keywords: ["b"],
     });
     await indexSession(workspace, "sess-G", {
+      mode: "haiku",
       summarize: secondStub.fn,
       now: () => MIN_INDEX_INTERVAL_MS + 1,
     });
@@ -286,14 +305,17 @@ describe("indexSession — manifest upsert and ordering", () => {
 
     const stub = makeStubSummarize();
     await indexSession(workspace, "oldest", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
     await indexSession(workspace, "newest", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
     await indexSession(workspace, "middle", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
     });
@@ -316,6 +338,7 @@ describe("indexSession — error propagation", () => {
     await assert.rejects(
       () =>
         indexSession(workspace, "sess-H", {
+          mode: "haiku",
           summarize: failing,
           now: () => 0,
         }),
@@ -443,21 +466,21 @@ describe("indexSession — hostile sessionId is rejected (defence-in-depth)", ()
 
   it("returns null for `..` (traversal via basename mismatch)", async () => {
     const stub = makeStubSummarize();
-    const result = await indexSession(workspace, "..", { summarize: stub.fn, now: () => 0 });
+    const result = await indexSession(workspace, "..", { mode: "haiku", summarize: stub.fn, now: () => 0 });
     assert.equal(result, null);
     assert.equal(stub.calls.length, 0);
   });
 
   it("returns null for a slash-containing id (would escape the chat dir)", async () => {
     const stub = makeStubSummarize();
-    const result = await indexSession(workspace, "a/b", { summarize: stub.fn, now: () => 0 });
+    const result = await indexSession(workspace, "a/b", { mode: "haiku", summarize: stub.fn, now: () => 0 });
     assert.equal(result, null);
     assert.equal(stub.calls.length, 0);
   });
 
   it("returns null for `foo..bar` (basename passes, `..`-substring rejects)", async () => {
     const stub = makeStubSummarize();
-    const result = await indexSession(workspace, "foo..bar", { summarize: stub.fn, now: () => 0 });
+    const result = await indexSession(workspace, "foo..bar", { mode: "haiku", summarize: stub.fn, now: () => 0 });
     assert.equal(result, null);
     assert.equal(stub.calls.length, 0);
   });
@@ -465,6 +488,7 @@ describe("indexSession — hostile sessionId is rejected (defence-in-depth)", ()
   it("force: true does NOT bypass the sanitizer", async () => {
     const stub = makeStubSummarize();
     const result = await indexSession(workspace, "../evil", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => 0,
       force: true,
@@ -485,12 +509,12 @@ describe("indexSession — content-unchanged skip (issue #1929)", () => {
     await setJsonlMtime("skip-unchanged", 0.1);
     const stub = makeStubSummarize();
 
-    await indexSession(workspace, "skip-unchanged", { summarize: stub.fn, now: () => 1000 });
+    await indexSession(workspace, "skip-unchanged", { mode: "haiku", summarize: stub.fn, now: () => 1000 });
     assert.equal(stub.calls.length, 1);
 
     // Jump past the freshness window so isFresh returns false; the
     // ONLY remaining reason to skip is the content-unchanged gate.
-    await indexSession(workspace, "skip-unchanged", { summarize: stub.fn, now: () => MIN_INDEX_INTERVAL_MS + 10_000 });
+    await indexSession(workspace, "skip-unchanged", { mode: "haiku", summarize: stub.fn, now: () => MIN_INDEX_INTERVAL_MS + 10_000 });
     assert.equal(stub.calls.length, 1);
   });
 
@@ -499,14 +523,14 @@ describe("indexSession — content-unchanged skip (issue #1929)", () => {
     await setJsonlMtime("resume-changed", 0.1);
     const stub = makeStubSummarize();
 
-    await indexSession(workspace, "resume-changed", { summarize: stub.fn, now: () => 1000 });
+    await indexSession(workspace, "resume-changed", { mode: "haiku", summarize: stub.fn, now: () => 1000 });
     assert.equal(stub.calls.length, 1);
 
     // Simulate a new turn: bump the jsonl mtime past the entry's
     // indexedAt. Time-jump past the freshness window too so this
     // isn't just testing isFresh.
     await setJsonlMtime("resume-changed", 5000);
-    await indexSession(workspace, "resume-changed", { summarize: stub.fn, now: () => MIN_INDEX_INTERVAL_MS + 10_000 });
+    await indexSession(workspace, "resume-changed", { mode: "haiku", summarize: stub.fn, now: () => MIN_INDEX_INTERVAL_MS + 10_000 });
     assert.equal(stub.calls.length, 2);
   });
 
@@ -515,16 +539,116 @@ describe("indexSession — content-unchanged skip (issue #1929)", () => {
     await setJsonlMtime("force-through", 0.1);
     const stub = makeStubSummarize();
 
-    await indexSession(workspace, "force-through", { summarize: stub.fn, now: () => 1000 });
+    await indexSession(workspace, "force-through", { mode: "haiku", summarize: stub.fn, now: () => 1000 });
     assert.equal(stub.calls.length, 1);
 
     // Jsonl still at 100ms — content-unchanged gate would skip, but
     // force says "regenerate anyway".
     await indexSession(workspace, "force-through", {
+      mode: "haiku",
       summarize: stub.fn,
       now: () => MIN_INDEX_INTERVAL_MS + 10_000,
       force: true,
     });
     assert.equal(stub.calls.length, 2);
+  });
+});
+
+describe("indexSession — chat-index mode + origin filter (#1944)", () => {
+  it("returns null without touching the summarizer when mode is 'off'", async () => {
+    seedSession("sess-off");
+    const stub = makeStubSummarize();
+
+    const result = await indexSession(workspace, "sess-off", {
+      mode: "off",
+      summarize: stub.fn,
+      now: () => Date.parse("2026-04-12T10:05:00.000Z"),
+    });
+
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0, "off mode must skip before the summarizer runs");
+  });
+
+  it("skips a system-origin session even when mode is 'sonnet' and force is true", async () => {
+    seedSession("sess-system", { origin: "system" });
+    const stub = makeStubSummarize();
+
+    const result = await indexSession(workspace, "sess-system", {
+      mode: "sonnet",
+      summarize: stub.fn,
+      now: () => Date.parse("2026-04-12T10:05:00.000Z"),
+      force: true,
+    });
+
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0, "system origin must skip regardless of mode / force");
+  });
+
+  it("skips a scheduler-origin session for the same reason", async () => {
+    seedSession("sess-sched", { origin: "scheduler" });
+    const stub = makeStubSummarize();
+
+    const result = await indexSession(workspace, "sess-sched", {
+      mode: "sonnet",
+      summarize: stub.fn,
+      now: () => Date.parse("2026-04-12T10:05:00.000Z"),
+      force: true,
+    });
+
+    assert.equal(result, null);
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it("passes the chosen model down to the summarizer when mode is 'haiku'", async () => {
+    seedSession("sess-haiku");
+    const receivedModels: (string | undefined)[] = [];
+    const trackingSummarize = async (_input: string, opts?: { model?: string }) => {
+      receivedModels.push(opts?.model);
+      return { title: "t", summary: "s", keywords: ["k"] };
+    };
+
+    const result = await indexSession(workspace, "sess-haiku", {
+      mode: "haiku",
+      summarize: trackingSummarize,
+      now: () => Date.parse("2026-04-12T10:05:00.000Z"),
+    });
+
+    assert.ok(result !== null);
+    assert.deepEqual(receivedModels, ["haiku"]);
+  });
+
+  it("passes the chosen model down to the summarizer when mode is 'sonnet'", async () => {
+    seedSession("sess-sonnet");
+    const receivedModels: (string | undefined)[] = [];
+    const trackingSummarize = async (_input: string, opts?: { model?: string }) => {
+      receivedModels.push(opts?.model);
+      return { title: "t", summary: "s", keywords: ["k"] };
+    };
+
+    const result = await indexSession(workspace, "sess-sonnet", {
+      mode: "sonnet",
+      summarize: trackingSummarize,
+      now: () => Date.parse("2026-04-12T10:05:00.000Z"),
+    });
+
+    assert.ok(result !== null);
+    assert.deepEqual(receivedModels, ["sonnet"]);
+  });
+
+  it("indexes human-origin sessions normally when mode is on", async () => {
+    // Explicitly seed with `origin: "human"` (or leave undefined; both
+    // should be treated as indexable — only `system` / `scheduler` are
+    // in the NON_INDEXED_ORIGINS set).
+    seedSession("sess-human", { origin: "human" });
+    const stub = makeStubSummarize();
+
+    const result = await indexSession(workspace, "sess-human", {
+      mode: "haiku",
+      summarize: stub.fn,
+      now: () => Date.parse("2026-04-12T10:05:00.000Z"),
+    });
+
+    assert.ok(result !== null);
+    assert.equal(stub.calls.length, 1);
   });
 });

--- a/test/chat-index/test_maybe_index_session.ts
+++ b/test/chat-index/test_maybe_index_session.ts
@@ -64,7 +64,7 @@ describe("maybeIndexSession — active session guard", () => {
       sessionId: "live-sess",
       activeSessionIds: new Set(["live-sess", "other"]),
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
 
     assert.equal(stub.calls, 0);
@@ -79,7 +79,7 @@ describe("maybeIndexSession — active session guard", () => {
       sessionId: "done-sess",
       activeSessionIds: new Set(["other"]),
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
 
     assert.equal(stub.calls, 1);
@@ -106,7 +106,7 @@ describe("maybeIndexSession — per-session lock", () => {
     const first = maybeIndexSession({
       sessionId: "slow-sess",
       workspaceRoot: workspace,
-      deps: { summarize: slowSummarize, now: () => 0 },
+      deps: { mode: "haiku", summarize: slowSummarize, now: () => 0 },
     });
     // Call again while `first` is still blocked on the gate. This
     // second call should short-circuit via the in-process lock.
@@ -114,6 +114,7 @@ describe("maybeIndexSession — per-session lock", () => {
       sessionId: "slow-sess",
       workspaceRoot: workspace,
       deps: {
+        mode: "haiku",
         summarize: async () => {
           throw new Error("second call should not run summarize");
         },
@@ -137,12 +138,12 @@ describe("maybeIndexSession — per-session lock", () => {
       maybeIndexSession({
         sessionId: "sess-1",
         workspaceRoot: workspace,
-        deps: { summarize: stub.fn, now: () => 0 },
+        deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
       }),
       maybeIndexSession({
         sessionId: "sess-2",
         workspaceRoot: workspace,
-        deps: { summarize: stub.fn, now: () => 0 },
+        deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
       }),
     ]);
 
@@ -162,7 +163,7 @@ describe("maybeIndexSession — claude CLI missing sentinel", () => {
     await maybeIndexSession({
       sessionId: "sess-miss-1",
       workspaceRoot: workspace,
-      deps: { summarize: throwing, now: () => 0 },
+      deps: { mode: "haiku", summarize: throwing, now: () => 0 },
     });
 
     // Second call should be a no-op: even though we hand it a
@@ -172,7 +173,7 @@ describe("maybeIndexSession — claude CLI missing sentinel", () => {
     await maybeIndexSession({
       sessionId: "sess-miss-2",
       workspaceRoot: workspace,
-      deps: { summarize: workingStub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: workingStub.fn, now: () => 0 },
     });
     assert.equal(workingStub.calls, 0);
   });
@@ -190,7 +191,7 @@ describe("maybeIndexSession — unexpected error swallowing", () => {
     await maybeIndexSession({
       sessionId: "sess-err",
       workspaceRoot: workspace,
-      deps: { summarize: failing, now: () => 0 },
+      deps: { mode: "haiku", summarize: failing, now: () => 0 },
     });
   });
 
@@ -203,7 +204,7 @@ describe("maybeIndexSession — unexpected error swallowing", () => {
     await maybeIndexSession({
       sessionId: "sess-err-1",
       workspaceRoot: workspace,
-      deps: { summarize: failing, now: () => 0 },
+      deps: { mode: "haiku", summarize: failing, now: () => 0 },
     });
 
     // Subsequent call with a working summarizer should still run.
@@ -211,7 +212,7 @@ describe("maybeIndexSession — unexpected error swallowing", () => {
     await maybeIndexSession({
       sessionId: "sess-err-2",
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
     assert.equal(stub.calls, 1);
   });
@@ -226,7 +227,7 @@ describe("maybeIndexSession — force option", () => {
       sessionId: "live-force",
       activeSessionIds: new Set(["live-force"]),
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
       force: true,
     });
 
@@ -241,7 +242,7 @@ describe("maybeIndexSession — force option", () => {
     await maybeIndexSession({
       sessionId: "fresh-force",
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
     assert.equal(stub.calls, 1);
 
@@ -249,7 +250,7 @@ describe("maybeIndexSession — force option", () => {
     await maybeIndexSession({
       sessionId: "fresh-force",
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 500 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 500 },
     });
     assert.equal(stub.calls, 1);
 
@@ -257,7 +258,7 @@ describe("maybeIndexSession — force option", () => {
     await maybeIndexSession({
       sessionId: "fresh-force",
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 500 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 500 },
       force: true,
     });
     assert.equal(stub.calls, 2);
@@ -273,7 +274,7 @@ describe("backfillAllSessions", () => {
 
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
 
     assert.equal(result.total, 3);
@@ -286,7 +287,7 @@ describe("backfillAllSessions", () => {
     const stub = stubSummarize();
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
     assert.equal(result.total, 0);
     assert.equal(result.indexed, 0);
@@ -307,7 +308,7 @@ describe("backfillAllSessions", () => {
 
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: mixedSummarize, now: () => 0 },
+      deps: { mode: "haiku", summarize: mixedSummarize, now: () => 0 },
     });
 
     assert.equal(result.total, 3);
@@ -323,7 +324,7 @@ describe("backfillAllSessions", () => {
     await maybeIndexSession({
       sessionId: "warm-1",
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
     });
     assert.equal(stub.calls, 1);
 
@@ -335,7 +336,7 @@ describe("backfillAllSessions", () => {
     // exercises the force path.
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 0 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 0 },
       force: true,
     });
     assert.equal(result.indexed, 1);
@@ -354,7 +355,7 @@ describe("backfillAllSessions", () => {
     // Prime the index once via a forced backfill.
     await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 1000 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 1000 },
       force: true,
     });
     assert.equal(stub.calls, 1);
@@ -364,7 +365,7 @@ describe("backfillAllSessions", () => {
     // #1929 fix this would fire another CLI call.
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 1000 + 60 * 60 * 1000 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 1000 + 60 * 60 * 1000 },
     });
     assert.equal(result.indexed, 0);
     assert.equal(result.skipped, 1);
@@ -379,7 +380,7 @@ describe("backfillAllSessions", () => {
 
     await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 1000 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 1000 },
       force: true,
     });
     assert.equal(stub.calls, 1);
@@ -390,9 +391,44 @@ describe("backfillAllSessions", () => {
 
     const result = await backfillAllSessions({
       workspaceRoot: workspace,
-      deps: { summarize: stub.fn, now: () => 1000 + 60 * 60 * 1000 },
+      deps: { mode: "haiku", summarize: stub.fn, now: () => 1000 + 60 * 60 * 1000 },
     });
     assert.equal(result.indexed, 1);
     assert.equal(stub.calls, 2);
+  });
+});
+
+// #1944 — public-entry-point coverage for the mode kill switch. When
+// `mode: "off"` is injected via deps (or resolved from settings as
+// undefined → off), both public entry points must short-circuit
+// before spawning the summarizer.
+describe("public entry points honour chat-index mode = off (#1944)", () => {
+  it("maybeIndexSession returns without summarizing when mode is off", async () => {
+    seedSession("off-sess");
+    const stub = stubSummarize();
+
+    await maybeIndexSession({
+      sessionId: "off-sess",
+      workspaceRoot: workspace,
+      deps: { mode: "off", summarize: stub.fn, now: () => 0 },
+    });
+
+    assert.equal(stub.calls, 0);
+    await assert.rejects(() => readFile(indexEntryPathFor(workspace, "off-sess"), "utf-8"));
+  });
+
+  it("backfillAllSessions short-circuits and reports zero counts when mode is off", async () => {
+    seedSession("off-a");
+    seedSession("off-b");
+    const stub = stubSummarize();
+
+    const result = await backfillAllSessions({
+      workspaceRoot: workspace,
+      deps: { mode: "off", summarize: stub.fn, now: () => 0 },
+    });
+
+    // Total is 0 because the walk itself is skipped — nothing to count.
+    assert.deepEqual(result, { total: 0, indexed: 0, skipped: 0 });
+    assert.equal(stub.calls, 0);
   });
 });

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -238,6 +238,36 @@ describe("PUT /config/settings", () => {
     putSettingsHandler({ body: { effortLevel: "ultra" } } as Request, res);
     assert.equal(state.status, 400);
   });
+
+  // #1944: the chatIndex patch lifecycle mirrors effortLevel's — set,
+  // clear via null, reject garbage. Round-tripping via loadSettings
+  // catches the first-round bug where the mode was accepted but
+  // silently dropped on write.
+  it("sets chatIndex from a patch and roundtrips it", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"] });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { chatIndex: "haiku" } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.equal(persisted.chatIndex, "haiku");
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+  });
+
+  it("clears chatIndex when the patch sends null", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"], chatIndex: "sonnet" });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { chatIndex: null } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.equal(persisted.chatIndex, undefined);
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+  });
+
+  it("rejects unknown chatIndex values with 400", () => {
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { chatIndex: "opus" } } as Request, res);
+    assert.equal(state.status, 400);
+  });
 });
 
 describe("PUT /config (atomic)", () => {

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -90,6 +90,21 @@ describe("isAppSettingsPatch", () => {
     assert.equal(mod.isAppSettingsPatch({ effortLevel: "ultra" }), false);
     assert.equal(mod.isAppSettingsPatch({ effortLevel: 42 }), false);
   });
+
+  // #1944: same null-sentinel + strict-value pattern as effortLevel
+  // for the new chatIndex field.
+  it("accepts every known chatIndex mode and the null clear-sentinel", () => {
+    for (const mode of mod.CHAT_INDEX_MODES) {
+      assert.ok(mod.isAppSettingsPatch({ chatIndex: mode }), `expected ${mode} to be accepted`);
+    }
+    assert.ok(mod.isAppSettingsPatch({ chatIndex: null }));
+  });
+
+  it("rejects unknown chatIndex values on the patch path", () => {
+    assert.equal(mod.isAppSettingsPatch({ chatIndex: "opus" }), false);
+    assert.equal(mod.isAppSettingsPatch({ chatIndex: "" }), false);
+    assert.equal(mod.isAppSettingsPatch({ chatIndex: 42 }), false);
+  });
 });
 
 describe("normaliseAppSettingsPatch", () => {
@@ -103,6 +118,16 @@ describe("normaliseAppSettingsPatch", () => {
 
   it("preserves other fields untouched", () => {
     assert.deepEqual(mod.normaliseAppSettingsPatch({ extraAllowedTools: ["a"], effortLevel: null }), { extraAllowedTools: ["a"] });
+  });
+
+  // #1944: chatIndex null-sentinel mirrors effortLevel.
+  it("strips null chatIndex", () => {
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ chatIndex: null }), {});
+  });
+
+  it("preserves a present chatIndex", () => {
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ chatIndex: "haiku" }), { chatIndex: "haiku" });
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ chatIndex: "sonnet" }), { chatIndex: "sonnet" });
   });
 });
 
@@ -387,5 +412,38 @@ describe("saveSettings", () => {
     const leftover = entries.filter((entry) => entry.endsWith(".tmp"));
     assert.deepEqual(leftover, []);
     assert.deepEqual(mod.loadSettings(), { extraAllowedTools: ["second"] });
+  });
+
+  // #1944: without this test the earlier bug (saveSettings dropping
+  // chatIndex on write, so the mode reverted on reload) would slip
+  // past. Roundtrips both non-default modes.
+  it("persists chatIndex and roundtrips it through loadSettings", () => {
+    mod.saveSettings({ extraAllowedTools: [], chatIndex: "haiku" });
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [], chatIndex: "haiku" });
+    mod.saveSettings({ extraAllowedTools: [], chatIndex: "sonnet" });
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [], chatIndex: "sonnet" });
+  });
+
+  it("omits chatIndex when unset so settings.json stays default-clean", () => {
+    mod.saveSettings({ extraAllowedTools: [] });
+    const raw = readFileSync(mod.settingsPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    assert.equal("chatIndex" in parsed, false);
+  });
+});
+
+// #1944: the resolver is the single choke point every reader
+// (indexer, backfill, settings tab) uses to translate the on-disk
+// value into a mode literal. Belt-and-braces test that undefined /
+// missing → "off" so the docs stay honest.
+describe("chatIndexMode resolver", () => {
+  it("returns 'off' when the field is undefined (default)", () => {
+    assert.equal(mod.chatIndexMode({ extraAllowedTools: [] }), "off");
+  });
+
+  it("returns the stored value when set", () => {
+    assert.equal(mod.chatIndexMode({ extraAllowedTools: [], chatIndex: "haiku" }), "haiku");
+    assert.equal(mod.chatIndexMode({ extraAllowedTools: [], chatIndex: "sonnet" }), "sonnet");
+    assert.equal(mod.chatIndexMode({ extraAllowedTools: [], chatIndex: "off" }), "off");
   });
 });


### PR DESCRIPTION
## Summary

Two behaviour changes to the background chat-index summarizer:

- **Origin filter (always on)** — \`indexSession\` skips sessions whose \`meta.origin\` is \`system\` (hidden worker; title never surfaces in any UI) or \`scheduler\` (automation; \`firstUserMessage\` fallback already identifies them). Under every trigger — turn-finish hook, backfill, manual rebuild, forced startup — and unaffected by \`force\`.
- **Configurable model + kill switch** — new \`AppSettings.chatIndex\` field: \`"off"\` (default), \`"haiku"\`, \`"sonnet"\`. Ships **off** — a fresh workspace pays nothing until the user opts in from Settings → Chat index.

Fixes #1944.

## Items to Confirm / Review

- **Default is \`off\`.** Existing users who currently have summaries running lose it until they flip the switch. User's explicit ask ("default で this index 作成を off に") — flag if a one-shot migration prompt is wanted.
- **Origin filter re-runs every backfill tick** (no persistent skip marker). Analysed: ~1–2 ms meta read × 166 automation sessions × 4 backfills/day ≈ 1.3 s/day I/O with zero Claude spend. Skip marker rejected as over-engineering.
- **Manual rebuild + \`CHAT_INDEX_FORCE_RUN_ON_STARTUP=1\`** also honour \`chatIndex: "off"\`. If the intent is "override when the user explicitly rebuilt", add a \`bypassOff\` opt-in — happy to do it as a follow-up.
- **Setting shape** uses \`chatIndex?: ChatIndexMode | null\` null-sentinel wire pattern matching \`effortLevel\`; the tab sends \`null\` on \`"off"\` so \`settings.json\` stays default-clean.
- **i18n across 8 locales** — please glance at non-EN copies for tone.

## User Prompt

> chat-index scheduler re-summarises every session every hour ... system / scheduler origins are summarized even though the title never displays. → 一旦 sonet に戻す？→ 設定化する。default で、この index 作成を off にしつつ、設定で on/off と、haiku/sonnet 切り替えできるようにしよう。off/haiku/sonnet がよいかな。origin filter もいれよう。これは常に有効。

## Implementation

Detailed diff walk in [\`plans/feat-1944-chat-index-configurable.md\`](../blob/feat/1944-chat-index-configurable/plans/feat-1944-chat-index-configurable.md).

- **Server**: \`AppSettings.chatIndex\` + \`chatIndexMode()\` resolver, \`SummarizeFn\` takes optional \`{ model }\`, \`indexSession\` bails on \`mode: "off"\` and reads meta up-front for the origin filter, \`maybeIndexSession\` / \`backfillAllSessions\` resolve mode via \`loadSettings()\` and short-circuit \`off\` before any lock / walk.
- **Client**: new \`SettingsChatIndexTab.vue\`, wired into \`SettingsModal.vue\`'s LLM group.
- **i18n**: \`chatIndex\` tab label + full \`chatIndexTab\` block in all 8 locales.
- **Complexity relief**: \`isAppSettingsPatch\` extracted per-field mini-validators; \`indexSession\` extracted \`shouldSkipBeforeSummarize\` helper.

## Test plan

- [x] \`yarn tsx --test test/chat-index/test_indexer.ts\` — 36 pass (30 existing + 6 new).
- [x] \`yarn tsx --test test/server/test_config.ts test/routes/test_configRoute.ts\` — 60 pass.
- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\`.
- Manual: open Settings → Chat index, flip through off / haiku / sonnet, confirm auto-save, trigger a chat turn under each, confirm the summarizer either skips (\`off\`) or spawns with the chosen model (log line \`[chat-index] indexed\`).

## Out of scope

- Persistent skip marker for automation origins (over-engineering).
- Force-rebuild bypassing \`off\` (separate opt-in if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Chat index** settings tab to choose **Off**, **Haiku**, or **Sonnet**.
  * Chat indexing now uses the selected mode for summarization and updates indexing status in the UI.
  * Chat index settings can be changed and refreshed from the Settings modal.
* **Bug Fixes**
  * Prevents chat indexing from running when Chat index is set to **Off**.
  * Improves filtering by skipping **system** and **scheduler** origin sessions even when indexing is forced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->