### PR TITLE
feat(journal): configurable mode + always-on origin filter (#1944 follow-up)

### DIFF
--- a/plans/feat-1944-journal-configurable.md
+++ b/plans/feat-1944-journal-configurable.md
@@ -1,0 +1,123 @@
+# feat(#1944 follow-up): journal daily pass configurable + origin filter
+
+## Summary
+
+Follow-up to #1949 (chat-index configurable). Same three-state opt-out
+mechanism for the journal daily pass:
+
+- **`AppSettings.journal`** — `"off"` (default) / `"haiku"` / `"sonnet"`.
+  `"off"` short-circuits `maybeRunJournal` before it takes the in-process
+  lock or reads the pass state file. `"haiku"` / `"sonnet"` pick the
+  model the archivist CLI spawns.
+- **Origin filter** (always on, mirrors chat-index): sessions whose
+  `meta.origin` is `system` or `scheduler` are excluded from
+  `loadDirtySessionExcerpts` regardless of the mode. They surface no
+  user-authored content worth summarising into a personal journal.
+- **`--model` flag** now passed to `claude` when the model is known,
+  threaded via a widened `Summarize` type. The CLI-only call path is
+  preserved for direct callers that don't specify a model.
+
+## Items to Confirm / Review
+
+- **Default `off`.** Existing users with the journal running silently
+  will notice titles + memory stop generating until they opt in. The
+  user asked for the same UX pattern as chat-index; this matches.
+- **Origin filter caveat.** The filter reads meta per dirty session on
+  each pass. Journal already reads meta downstream (`readRoleIdFromMeta`),
+  so the extra read is one more per dirty session — negligible next to
+  the archivist CLI cost.
+- **`--model` threading via a pre-bound closure.** `runJournalPass`
+  wraps the raw `summarize` in `(sys, user) => rawSummarize(sys, user,
+  { model })` so downstream layers (`dailyPass`, `optimizationPass`,
+  `memoryExtractor`) don't need signature changes.
+- **`JournalSummaryModel` union** deliberately excludes `"off"` so a bad
+  string can't reach `--model` — the entry-point (`maybeRunJournal`)
+  filters that state out before we get here.
+- **i18n**: 8 locales in lockstep (en / ja / de / es / fr / ko / pt-BR / zh).
+
+## User Prompt
+
+> どうように、Journal dailly pass もoptoutできるように設定を追加したい。
+> B (3-state matching chatIndex, with default off)
+> Journal dailly pass もsystem / scheduler のチャットを除外するのがよい？
+
+## Implementation
+
+### Server
+
+- `server/system/config.ts` — `JOURNAL_MODES` + `JournalMode` type +
+  `AppSettings.journal?` field + `isJournalMode` validator +
+  `isOptionalNullableJournalMode` mini-helper (complexity-relief) +
+  `AppSettingsPatch.journal?: JournalMode | null` + patch normaliser
+  drops null sentinel + `cloneAppSettings` copies the field +
+  `saveSettings` persists it + `journalMode(settings)` resolver.
+
+- `server/api/routes/config.ts` — new `body.journal === null → delete
+  merged.journal` branch mirrors the chatIndex one.
+
+- `server/workspace/journal/archivist-cli.ts` — `JournalSummaryModel =
+  "haiku" | "sonnet"` type; `Summarize` type widened to accept an
+  optional `{ model?: JournalSummaryModel }` third arg; `runClaudeCli`
+  appends `--model <model>` to the CLI args when a model is supplied.
+
+- `server/workspace/journal/index.ts` — `MaybeRunJournalOptions.mode`
+  injectable, defaults to `journalMode(loadSettings())`. `mode === "off"`
+  short-circuits before locking. `runJournalPass` receives the resolved
+  model and pre-binds it onto the summarize callable, so no downstream
+  signatures change.
+
+- `server/workspace/journal/dailyPass.ts` —
+  `isEligibleForJournalByOrigin` filter drops `system` / `scheduler`
+  sessions inside `loadDirtySessionExcerpts` before the excerpt read.
+  `NON_INDEXED_ORIGINS` set mirrors the chat-index one exactly (no
+  shared import to keep the modules loosely coupled).
+
+### Client
+
+- `src/components/SettingsJournalTab.vue` — new tab, mirrors
+  `SettingsChatIndexTab.vue` (3-state select, auto-save, null sentinel
+  on "off").
+- `src/components/SettingsModal.vue` — new `journal` `TabId` in the LLM
+  group after `chatIndex`; reload token bumped on modal open; tab
+  rendered via `<SettingsJournalTab>`.
+- 8 locales — `journal` tab label + full `journalTab` block.
+
+### Tests
+
+- `test/server/test_config.ts` — 4 new blocks: `isAppSettingsPatch`
+  accepts every JOURNAL_MODES value + null / rejects unknown;
+  `normaliseAppSettingsPatch` strips null / preserves value;
+  `saveSettings` persists and roundtrips; `saveSettings` omits the
+  field when unset; new `journalMode` resolver suite.
+- `test/routes/test_configRoute.ts` — 3 new tests for PUT
+  `/api/config/settings`: sets from patch and roundtrips through
+  `loadSettings`; clears when the patch sends null; rejects unknown
+  values with 400.
+- `test/journal/test_maybeRunJournal.ts` — 4 existing calls pinned
+  `mode: "haiku"` (previously ambient-settings dependent). New
+  `mode kill switch` describe block: `mode: "off" + force: true` must
+  short-circuit before summarize; `mode: "sonnet"` threads the model
+  through to every summarize call.
+
+## Test plan
+
+- [x] `yarn tsx --test test/server/test_config.ts test/routes/test_configRoute.ts test/journal/test_maybeRunJournal.ts` — 86 pass.
+- [x] `yarn tsx --test test/chat-index/*.ts test/journal/*.ts` — 337 pass (no regressions in either subsystem).
+- [x] `yarn format` / `yarn lint` (0 errors, 26 pre-existing warnings) / `yarn typecheck` / `yarn build`.
+- Manual: Settings → Journal, flip through off / haiku / sonnet.
+  Confirm auto-save banner turns green and `settings.json` gains /
+  drops the field. With `journal: "haiku"`, trigger a chat turn that
+  crosses the daily interval; confirm the log line shows the
+  archivist CLI was invoked and its `--model` flag was `haiku`. Repeat
+  for `sonnet`. Flip to `off`; confirm the hourly scheduler is
+  effectively silent.
+
+## Out of scope
+
+- Migrating existing users' journal pass state on first launch —
+  they'll notice "no new journal entries" until they opt in. Same
+  behaviour as chat-index; if this is a support pain point we can add
+  a one-shot banner in a follow-up.
+- Extending the same 3-state / off-default pattern to other
+  summarizer entry points (memory extraction re-uses `summarize`, so
+  its model already follows the journal mode via the closure).

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -172,6 +172,10 @@ router.put(API_ROUTES.config.settings, (req: Request<unknown, unknown, AppSettin
   if (body.chatIndex === null) {
     delete merged.chatIndex;
   }
+  // Journal null-sentinel — mirrors chatIndex / effortLevel.
+  if (body.journal === null) {
+    delete merged.journal;
+  }
   if (!runSaveOrFail(res, () => saveSettings(merged), "saveSettings failed")) {
     return;
   }

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -35,6 +35,15 @@ export type EffortLevel = (typeof EFFORT_LEVELS)[number];
 export const CHAT_INDEX_MODES = ["off", "haiku", "sonnet"] as const;
 export type ChatIndexMode = (typeof CHAT_INDEX_MODES)[number];
 
+// Journal daily-pass setting (follow-up to #1944). Same three states as
+// chat-index: "off" disables both the turn-end hook and the hourly
+// scheduled pass; "haiku" / "sonnet" pick the Claude model the archivist
+// CLI spawns for its summary calls. Default (undefined) is "off" so a
+// fresh workspace doesn't burn CLI budget until the user opts in from
+// Settings → Journal.
+export const JOURNAL_MODES = ["off", "haiku", "sonnet"] as const;
+export type JournalMode = (typeof JOURNAL_MODES)[number];
+
 export interface AppSettings {
   // Extra tool names appended to BASE_ALLOWED_TOOLS in
   // server/agent/config.ts#buildCliArgs. Typical entries are
@@ -83,6 +92,16 @@ export interface AppSettings {
   // session. Non-user origins (`system`, `scheduler`) are always
   // skipped regardless of this value — see `indexer.ts`.
   chatIndex?: ChatIndexMode;
+
+  // Journal daily-pass mode (follow-up to #1944). Ships "off" by
+  // default: the archivist that summarizes chat sessions into
+  // journal/*.md stays disabled until the user opts in from Settings →
+  // Journal. Flipping to "haiku" / "sonnet" enables the run and picks
+  // the Claude model the archivist CLI spawns. The turn-end hook
+  // (`maybeRunJournal` in the agent finally block) and the hourly
+  // `system:journal` scheduled task both honour this — off short-
+  // circuits before the interval gate is even consulted.
+  journal?: JournalMode;
 }
 
 const DEFAULT_SETTINGS: AppSettings = { extraAllowedTools: [] };
@@ -118,6 +137,10 @@ function isChatIndexMode(value: unknown): value is ChatIndexMode {
   return typeof value === "string" && (CHAT_INDEX_MODES as readonly string[]).includes(value);
 }
 
+function isJournalMode(value: unknown): value is JournalMode {
+  return typeof value === "string" && (JOURNAL_MODES as readonly string[]).includes(value);
+}
+
 function isVoiceInputSettings(value: unknown): value is { enabled: boolean; model?: string } {
   if (!isRecord(value)) return false;
   if (typeof value.enabled !== "boolean") return false;
@@ -133,10 +156,11 @@ export function isAppSettings(value: unknown): value is AppSettings {
   if (value.effortLevel !== undefined && !isEffortLevel(value.effortLevel)) return false;
   if (value.voiceInput !== undefined && !isVoiceInputSettings(value.voiceInput)) return false;
   if (value.chatIndex !== undefined && !isChatIndexMode(value.chatIndex)) return false;
+  if (value.journal !== undefined && !isJournalMode(value.journal)) return false;
   return true;
 }
 
-// isAppSettingsPatch adds a null sentinel to `chatIndex` (see below).
+// isAppSettingsPatch adds a null sentinel to `chatIndex` / `journal` (see below).
 
 /** A PUT-payload validator: every field optional, but if present
  *  it must match the AppSettings shape. Distinct from
@@ -154,21 +178,25 @@ export function isAppSettings(value: unknown): value is AppSettings {
  *  but lets nullable fields carry `null` as a "clear me" sentinel —
  *  callers normalise via `normaliseAppSettingsPatch` before merging
  *  into the storage shape (#1323). */
-export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel" | "chatIndex">> & {
+export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel" | "chatIndex" | "journal">> & {
   effortLevel?: EffortLevel | null;
   chatIndex?: ChatIndexMode | null;
+  journal?: JournalMode | null;
 };
 
 /** Convert a wire patch to the storage-shape patch by dropping any
  *  `null` sentinels (which mean "clear" for the corresponding field). */
 export function normaliseAppSettingsPatch(patch: AppSettingsPatch): Partial<AppSettings> {
-  const { effortLevel, chatIndex, ...rest } = patch;
+  const { effortLevel, chatIndex, journal, ...rest } = patch;
   const out: Partial<AppSettings> = { ...rest };
   if (effortLevel !== null && effortLevel !== undefined) {
     out.effortLevel = effortLevel;
   }
   if (chatIndex !== null && chatIndex !== undefined) {
     out.chatIndex = chatIndex;
+  }
+  if (journal !== null && journal !== undefined) {
+    out.journal = journal;
   }
   return out;
 }
@@ -179,6 +207,7 @@ export function normaliseAppSettingsPatch(patch: AppSettingsPatch): Partial<AppS
 const isOptionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
 const isOptionalNullableEffortLevel = (value: unknown): boolean => value === undefined || value === null || isEffortLevel(value);
 const isOptionalNullableChatIndexMode = (value: unknown): boolean => value === undefined || value === null || isChatIndexMode(value);
+const isOptionalNullableJournalMode = (value: unknown): boolean => value === undefined || value === null || isJournalMode(value);
 
 export function isAppSettingsPatch(value: unknown): value is AppSettingsPatch {
   if (!isRecord(value)) return false;
@@ -188,6 +217,7 @@ export function isAppSettingsPatch(value: unknown): value is AppSettingsPatch {
   if (!isOptionalNullableEffortLevel(value.effortLevel)) return false;
   if (value.voiceInput !== undefined && !isVoiceInputSettings(value.voiceInput)) return false;
   if (!isOptionalNullableChatIndexMode(value.chatIndex)) return false;
+  if (!isOptionalNullableJournalMode(value.journal)) return false;
   return true;
 }
 
@@ -224,6 +254,9 @@ function cloneAppSettings(settings: AppSettings): AppSettings {
   if (settings.chatIndex !== undefined) {
     copy.chatIndex = settings.chatIndex;
   }
+  if (settings.journal !== undefined) {
+    copy.journal = settings.journal;
+  }
   return copy;
 }
 
@@ -233,6 +266,14 @@ function cloneAppSettings(settings: AppSettings): AppSettings {
  *  returned literal string to decide skip vs pick a model. */
 export function chatIndexMode(settings: AppSettings): ChatIndexMode {
   return settings.chatIndex ?? "off";
+}
+
+/** Journal mode with the documented "undefined → off" default, so
+ *  every reader (turn-end hook, hourly scheduler, force-startup
+ *  switch, Settings tab) resolves the same way. Callers switch on
+ *  the returned literal string to decide skip vs pick a model. */
+export function journalMode(settings: AppSettings): JournalMode {
+  return settings.journal ?? "off";
 }
 
 /** Read the photo-exif auto-capture flag with the documented
@@ -286,6 +327,9 @@ export function saveSettings(settings: AppSettings): void {
   }
   if (settings.chatIndex !== undefined) {
     payload.chatIndex = settings.chatIndex;
+  }
+  if (settings.journal !== undefined) {
+    payload.journal = settings.journal;
   }
   const serialised = JSON.stringify(payload, null, 2);
   writeFileAtomicSync(settingsPath(), `${serialised}\n`, { mode: 0o600 });

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -4,7 +4,12 @@ import { spawn } from "node:child_process";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
 import { claudeBinPath, ClaudeCliNotFoundError } from "../../utils/claudeBin.js";
 
-export type Summarize = (systemPrompt: string, userPrompt: string) => Promise<string>;
+// User-selectable model for the archivist CLI call. `journalMode`
+// widens to `"off"` too; the entry-point (`maybeRunJournal`) filters
+// that out before we get here — this union is intentionally narrow so
+// a bad string can't reach `--model`.
+export type JournalSummaryModel = "haiku" | "sonnet";
+export type Summarize = (systemPrompt: string, userPrompt: string, opts?: { model?: JournalSummaryModel }) => Promise<string>;
 
 const CLI_TIMEOUT_MS = CLI_SUBPROCESS_TIMEOUT_MS;
 
@@ -28,9 +33,18 @@ export class ClaudeCliFailedError extends Error {
 }
 
 // Pipe the combined prompt via stdin to dodge shell-argv limits for large day excerpts.
-export const runClaudeCli: Summarize = async (systemPrompt, userPrompt) =>
+export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
   new Promise((resolve, reject) => {
-    const child = spawn(claudeBinPath(), ["-p", "--output-format", "text"], {
+    // `opts?.model` is threaded from `Settings → Journal` via
+    // maybeRunJournal so the user's model choice reaches the CLI.
+    // When undefined we omit the flag entirely and let the CLI use
+    // its own default — preserves the pre-#1944 archivist behaviour
+    // for direct-CLI callers that don't specify a model.
+    const args = ["-p", "--output-format", "text"];
+    if (opts?.model) {
+      args.push("--model", opts.model);
+    }
+    const child = spawn(claudeBinPath(), args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -422,9 +422,28 @@ export function advanceJournalState(prev: JournalState, justCompleted: readonly 
 }
 
 // Malformed sessions are logged and skipped so one bad jsonl can't crash the pass.
+// Origins the journal pass intentionally skips (mirror of the chat-index
+// filter added in #1944). `system` sessions are hidden host workers
+// (thumbnail generation, background exports); `scheduler` sessions are
+// automation-driven with prompts the user did not author. Neither
+// surfaces content worth summarising into a personal daily journal.
+const NON_INDEXED_ORIGINS: ReadonlySet<string> = new Set(["system", "scheduler"]);
+
+async function isEligibleForJournalByOrigin(sessionId: string, workspaceRoot: string): Promise<boolean> {
+  try {
+    const meta = await readSessionMetaIO(sessionId, workspaceRoot);
+    if (meta && typeof meta.origin === "string" && NON_INDEXED_ORIGINS.has(meta.origin)) return false;
+  } catch {
+    // meta unreadable → treat as eligible; the excerpt loader will
+    // still bail if the jsonl itself is malformed.
+  }
+  return true;
+}
+
 async function loadDirtySessionExcerpts(chatDir: string, dirty: readonly string[], workspaceRoot: string): Promise<Map<string, Map<string, SessionExcerpt>>> {
   const perSession = new Map<string, Map<string, SessionExcerpt>>();
   for (const sessionId of dirty) {
+    if (!(await isEligibleForJournalByOrigin(sessionId, workspaceRoot))) continue;
     try {
       const excerpts = await loadSessionExcerptsByDate(chatDir, sessionId, workspaceRoot);
       if (excerpts.size > 0) perSession.set(sessionId, excerpts);

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -74,17 +74,24 @@ export async function buildDailyPassPlan(state: JournalState, deps: DailyPassDep
   const { dirty } = findDirtySessions(eligible, state.processedSessions);
   if (dirty.length === 0) return null;
 
-  const perSessionExcerpts = await loadDirtySessionExcerpts(chatDir, dirty, workspaceRoot);
+  const dirtyMetaById = new Map(eligible.map((sessionMeta) => [sessionMeta.id, sessionMeta]));
+  const { journalDirty, silentlyProcessed } = await partitionDirtyByOrigin(dirty, dirtyMetaById, workspaceRoot);
+
+  const perSessionExcerpts = await loadDirtySessionExcerpts(chatDir, journalDirty, workspaceRoot);
   const { dayBuckets, sessionToDays } = buildDayBuckets(perSessionExcerpts);
 
   const existingTopics = await readAllTopics(workspaceRoot);
   const newTopicsSeen = new Set<string>(state.knownTopics);
   // Do NOT bump lastDailyRunAt here — outer runner does it after optimization, so partial progress isn't a complete pass.
+  // Silently mark origin-filtered dirty sessions as processed at their current
+  // mtime so they don't reappear as dirty on every pass. Without this, a
+  // workspace with many automation sessions pays an O(N) meta re-read on
+  // every hourly run.
   const initialNextState: JournalState = {
     ...state,
+    processedSessions: applyProcessed(state.processedSessions, silentlyProcessed),
     knownTopics: [...newTopicsSeen].sort(),
   };
-  const dirtyMetaById = new Map(eligible.map((sessionMeta) => [sessionMeta.id, sessionMeta]));
   const orderedDays = [...dayBuckets.keys()].sort();
 
   return {
@@ -440,10 +447,34 @@ async function isEligibleForJournalByOrigin(sessionId: string, workspaceRoot: st
   return true;
 }
 
+interface DirtyPartition {
+  journalDirty: string[];
+  // origin-filtered dirty sessions — marked processed at their current mtime
+  // so the next pass doesn't re-inspect them.
+  silentlyProcessed: SessionFileMeta[];
+}
+
+async function partitionDirtyByOrigin(
+  dirty: readonly string[],
+  dirtyMetaById: ReadonlyMap<string, SessionFileMeta>,
+  workspaceRoot: string,
+): Promise<DirtyPartition> {
+  const journalDirty: string[] = [];
+  const silentlyProcessed: SessionFileMeta[] = [];
+  for (const sessionId of dirty) {
+    if (await isEligibleForJournalByOrigin(sessionId, workspaceRoot)) {
+      journalDirty.push(sessionId);
+      continue;
+    }
+    const meta = dirtyMetaById.get(sessionId);
+    if (meta) silentlyProcessed.push(meta);
+  }
+  return { journalDirty, silentlyProcessed };
+}
+
 async function loadDirtySessionExcerpts(chatDir: string, dirty: readonly string[], workspaceRoot: string): Promise<Map<string, Map<string, SessionExcerpt>>> {
   const perSession = new Map<string, Map<string, SessionExcerpt>>();
   for (const sessionId of dirty) {
-    if (!(await isEligibleForJournalByOrigin(sessionId, workspaceRoot))) continue;
     try {
       const excerpts = await loadSessionExcerptsByDate(chatDir, sessionId, workspaceRoot);
       if (excerpts.size > 0) perSession.set(sessionId, excerpts);

--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -15,9 +15,10 @@ import { readState, writeState, isDailyDue, isOptimizationDue } from "./state.js
 import { runDailyPass } from "./dailyPass.js";
 import { runOptimizationPass } from "./optimizationPass.js";
 import { buildIndexMarkdown, type IndexTopicEntry, type IndexDailyEntry } from "./indexFile.js";
-import { runClaudeCli, ClaudeCliNotFoundError, type Summarize } from "./archivist-cli.js";
+import { runClaudeCli, ClaudeCliNotFoundError, type Summarize, type JournalSummaryModel } from "./archivist-cli.js";
 import { extractFirstH1 } from "../../../src/utils/markdown/extractFirstH1.js";
 import { log } from "../../system/logger/index.js";
+import { journalMode as resolveJournalMode, loadSettings } from "../../system/config.js";
 
 export { extractFirstH1 };
 
@@ -39,14 +40,24 @@ export interface MaybeRunJournalOptions {
   activeSessionIds?: ReadonlySet<string>;
   // Bypass the interval gate; the disable flags (CLI missing, in-process lock) still apply.
   force?: boolean;
+  // Injectable journal mode — defaults to `journalMode(loadSettings())`
+  // when omitted. "off" short-circuits before any lock / state read;
+  // "haiku" / "sonnet" pick the model the archivist CLI spawns. Tests
+  // and the force-run switch inject this directly; production callers
+  // (turn-end hook, scheduled task) let the resolver pick it up.
+  mode?: JournalSummaryModel | "off";
 }
 
 export async function maybeRunJournal(opts: MaybeRunJournalOptions = {}): Promise<void> {
   if (disabled) return;
   if (running) return;
+  // Config-driven kill switch. Resolve at entry time so a settings edit
+  // takes effect on the very next turn without a server restart.
+  const mode = opts.mode ?? resolveJournalMode(loadSettings());
+  if (mode === "off") return;
   running = true;
   try {
-    await runJournalPass(opts);
+    await runJournalPass(opts, mode);
   } catch (err) {
     if (err instanceof ClaudeCliNotFoundError) {
       disabled = true;
@@ -61,9 +72,14 @@ export async function maybeRunJournal(opts: MaybeRunJournalOptions = {}): Promis
   }
 }
 
-async function runJournalPass(opts: MaybeRunJournalOptions): Promise<void> {
+async function runJournalPass(opts: MaybeRunJournalOptions, model: JournalSummaryModel): Promise<void> {
   const workspaceRoot = opts.workspaceRoot ?? defaultWorkspacePath;
-  const summarize = opts.summarize ?? runClaudeCli;
+  // Pre-bind the model into the summarize callable so every layer
+  // downstream (dailyPass / optimizationPass / memoryExtractor) picks
+  // the user-selected model without threading the parameter through
+  // half a dozen call sites.
+  const rawSummarize = opts.summarize ?? runClaudeCli;
+  const summarize: Summarize = (sys, user) => rawSummarize(sys, user, { model });
   const activeSessionIds = opts.activeSessionIds ?? new Set<string>();
 
   const state = await readState(workspaceRoot);

--- a/src/components/SettingsJournalTab.vue
+++ b/src/components/SettingsJournalTab.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="space-y-3" data-testid="settings-journal-tab">
+    <p class="text-sm text-gray-700">{{ t("settingsModal.journalTab.description") }}</p>
+
+    <div class="space-y-2">
+      <label class="block text-sm font-medium text-gray-800" for="settings-journal-mode">{{ t("settingsModal.journalTab.modeLabel") }}</label>
+      <select
+        id="settings-journal-mode"
+        v-model="modeDraft"
+        class="w-full px-3 py-2 text-sm rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        data-testid="settings-journal-mode-select"
+        @change="save"
+      >
+        <option v-for="mode in JOURNAL_MODES" :key="mode" :value="mode">{{ t(`settingsModal.journalTab.mode.${mode}`) }}</option>
+      </select>
+      <p class="text-xs text-gray-500">{{ t("settingsModal.journalTab.helperText") }}</p>
+    </div>
+
+    <div v-if="loaded && !errorMessage" class="flex items-center gap-3 text-xs">
+      <span :class="statusColour" data-testid="settings-journal-status">
+        {{ statusText }}
+      </span>
+    </div>
+
+    <p v-if="errorMessage" class="text-sm text-red-700" role="alert" data-testid="settings-journal-error">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { apiGet, apiPut } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+const JOURNAL_MODES = ["off", "haiku", "sonnet"] as const;
+type JournalMode = (typeof JOURNAL_MODES)[number];
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  reloadToken: number;
+}>();
+
+const emit = defineEmits<{
+  saved: [];
+}>();
+
+interface SettingsResponse {
+  settings: { journal?: JournalMode };
+}
+
+const modeDraft = ref<JournalMode>("off");
+const storedMode = ref<JournalMode>("off");
+const loaded = ref(false);
+const saving = ref(false);
+const errorMessage = ref("");
+
+const statusText = computed(() => {
+  if (saving.value) return t("common.saving");
+  return t(`settingsModal.journalTab.status.${storedMode.value}`);
+});
+
+const statusColour = computed(() => {
+  if (saving.value) return "text-gray-500";
+  return storedMode.value === "off" ? "text-gray-500" : "text-green-600";
+});
+
+async function load(): Promise<void> {
+  errorMessage.value = "";
+  const response = await apiGet<SettingsResponse>(API_ROUTES.config.base);
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.journalTab.loadError");
+    return;
+  }
+  storedMode.value = response.data.settings.journal ?? "off";
+  modeDraft.value = storedMode.value;
+  loaded.value = true;
+}
+
+async function save(): Promise<void> {
+  if (saving.value) return;
+  if (modeDraft.value === storedMode.value) return;
+  const requested = modeDraft.value;
+  saving.value = true;
+  errorMessage.value = "";
+  // PATCH endpoint (not the atomic base) so a bare `{ journal }` body
+  // is accepted. Send null on "off" so settings.json stays default-clean.
+  const payload = { journal: requested === "off" ? null : requested };
+  const response = await apiPut<unknown>(API_ROUTES.config.settings, payload);
+  saving.value = false;
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.journalTab.saveError");
+    return;
+  }
+  storedMode.value = requested;
+  emit("saved");
+  if (modeDraft.value !== requested) {
+    void save();
+  }
+}
+
+watch(
+  () => props.reloadToken,
+  () => {
+    void load();
+  },
+  { immediate: true },
+);
+</script>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -169,6 +169,8 @@
             <SettingsVoiceTab v-else-if="activeTab === 'voice'" :reload-token="voiceReloadToken" />
 
             <SettingsChatIndexTab v-else-if="activeTab === 'chatIndex'" :reload-token="chatIndexReloadToken" @saved="emit('saved')" />
+
+            <SettingsJournalTab v-else-if="activeTab === 'journal'" :reload-token="journalReloadToken" @saved="emit('saved')" />
           </template>
         </div>
       </div>
@@ -200,6 +202,7 @@ import SettingsPhotosTab from "./SettingsPhotosTab.vue";
 import SettingsModelTab from "./SettingsModelTab.vue";
 import SettingsVoiceTab from "./SettingsVoiceTab.vue";
 import SettingsChatIndexTab from "./SettingsChatIndexTab.vue";
+import SettingsJournalTab from "./SettingsJournalTab.vue";
 import SkillsView from "../plugins/manageSkills/View.vue";
 import RolesView from "./RolesView.vue";
 import PluginScopedRoot from "./PluginScopedRoot.vue";
@@ -248,7 +251,7 @@ const emit = defineEmits<{
 // update / remove persist immediately).
 const mcpTabRef = ref<{ flushDraft: () => boolean; hasPendingDraft: () => boolean } | null>(null);
 
-type TabId = "gemini" | "tools" | "mcp" | "dirs" | "refs" | "map" | "photos" | "model" | "voice" | "chatIndex" | "skills" | "roles";
+type TabId = "gemini" | "tools" | "mcp" | "dirs" | "refs" | "map" | "photos" | "model" | "voice" | "chatIndex" | "journal" | "skills" | "roles";
 
 const activeTab = ref<TabId>("tools");
 
@@ -264,7 +267,7 @@ const isFullTab = computed(() => FULL_TABS.includes(activeTab.value));
 // item is filtered out by `visibleGroups` when geminiAvailable === true
 // (env var present → user has nothing to configure).
 const GROUPS: readonly { key: string; items: readonly TabId[] }[] = [
-  { key: "llm", items: ["model", "voice", "chatIndex", "tools", "gemini"] },
+  { key: "llm", items: ["model", "voice", "chatIndex", "journal", "tools", "gemini"] },
   { key: "servers", items: ["mcp"] },
   { key: "workspace", items: ["dirs", "refs"] },
   { key: "plugins", items: ["map", "photos"] },
@@ -298,6 +301,7 @@ const photosReloadToken = ref(0);
 const modelReloadToken = ref(0);
 const voiceReloadToken = ref(0);
 const chatIndexReloadToken = ref(0);
+const journalReloadToken = ref(0);
 const toolsText = ref("");
 // Server truth for tools — updated on load and on a successful Save
 // from the Tools tab. `toolsDirty` compares this against `toolsText`
@@ -506,6 +510,7 @@ watch(
       modelReloadToken.value += 1;
       voiceReloadToken.value += 1;
       chatIndexReloadToken.value += 1;
+      journalReloadToken.value += 1;
       statusMessage.value = "";
       statusError.value = false;
     }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -232,6 +232,7 @@ const deMessages = {
       model: "Modell",
       voice: "Sprache",
       chatIndex: "Chat-Index",
+      journal: "Journal",
       skills: "Skills",
       roles: "Rollen",
     },
@@ -308,6 +309,25 @@ const deMessages = {
         off: "Indizierung ist AUS",
         haiku: "Indizierung läuft mit Haiku",
         sonnet: "Indizierung läuft mit Sonnet",
+      },
+      loadError: "Einstellungen konnten nicht geladen werden",
+      saveError: "Speichern fehlgeschlagen",
+    },
+    journalTab: {
+      description:
+        "Automatisiertes Tages-Journal — fasst kürzliche Chat-Sessions in journal/*.md zusammen und extrahiert dauerhafte Memory-Notizen. Standardmäßig aus. Automatisierungs-Sessions (Scheduler / System-Worker) werden unabhängig von dieser Einstellung immer ausgeschlossen.",
+      modeLabel: "Journal-Modell",
+      helperText:
+        "Haiku ist günstiger; Sonnet liefert reichhaltigere Tages- und Themen-Zusammenfassungen. Der stündliche Lauf startet nur, wenn dies gesetzt ist.",
+      mode: {
+        off: "Aus",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Journal ist AUS",
+        haiku: "Journal läuft mit Haiku",
+        sonnet: "Journal läuft mit Sonnet",
       },
       loadError: "Einstellungen konnten nicht geladen werden",
       saveError: "Speichern fehlgeschlagen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -250,6 +250,7 @@ const enMessages = {
       model: "Model",
       voice: "Voice",
       chatIndex: "Chat index",
+      journal: "Journal",
       skills: "Skills",
       roles: "Roles",
     },
@@ -324,6 +325,24 @@ const enMessages = {
         off: "Indexing is OFF",
         haiku: "Indexing with Haiku",
         sonnet: "Indexing with Sonnet",
+      },
+      loadError: "Failed to load settings",
+      saveError: "Failed to save",
+    },
+    journalTab: {
+      description:
+        "Automated daily journal — summarises recent chat sessions into journal/*.md and extracts durable memory notes. Ships off. Automation sessions (scheduler / system workers) are always excluded regardless of this setting.",
+      modeLabel: "Journal model",
+      helperText: "Haiku is cheaper; Sonnet produces richer daily / topic summaries. The hourly pass runs only when this is set.",
+      mode: {
+        off: "Off",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Journal is OFF",
+        haiku: "Journal running with Haiku",
+        sonnet: "Journal running with Sonnet",
       },
       loadError: "Failed to load settings",
       saveError: "Failed to save",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -235,6 +235,7 @@ const esMessages = {
       model: "Modelo",
       voice: "Voz",
       chatIndex: "Índice de chat",
+      journal: "Diario",
       skills: "Skills",
       roles: "Roles",
     },
@@ -309,6 +310,24 @@ const esMessages = {
         off: "La indexación está DESACTIVADA",
         haiku: "Indexando con Haiku",
         sonnet: "Indexando con Sonnet",
+      },
+      loadError: "Error al cargar los ajustes",
+      saveError: "Error al guardar",
+    },
+    journalTab: {
+      description:
+        "Diario automático — resume las sesiones de chat recientes en journal/*.md y extrae notas de memoria duradera. Sale desactivado. Las sesiones de automatización (scheduler / trabajadores del sistema) se excluyen siempre, independientemente de esta configuración.",
+      modeLabel: "Modelo del diario",
+      helperText: "Haiku es más económico; Sonnet produce resúmenes diarios y por tema más ricos. El pase horario solo se ejecuta cuando esto está activado.",
+      mode: {
+        off: "Desactivado",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "El diario está DESACTIVADO",
+        haiku: "Diario en ejecución con Haiku",
+        sonnet: "Diario en ejecución con Sonnet",
       },
       loadError: "Error al cargar los ajustes",
       saveError: "Error al guardar",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -230,6 +230,7 @@ const frMessages = {
       model: "Modèle",
       voice: "Voix",
       chatIndex: "Index du chat",
+      journal: "Journal",
       skills: "Skills",
       roles: "Rôles",
     },
@@ -304,6 +305,25 @@ const frMessages = {
         off: "Indexation DÉSACTIVÉE",
         haiku: "Indexation avec Haiku",
         sonnet: "Indexation avec Sonnet",
+      },
+      loadError: "Échec du chargement des paramètres",
+      saveError: "Échec de l'enregistrement",
+    },
+    journalTab: {
+      description:
+        "Journal quotidien automatisé — résume les sessions de chat récentes dans journal/*.md et extrait des notes de mémoire persistante. Désactivé par défaut. Les sessions d'automatisation (scheduler / workers système) sont toujours exclues, quel que soit ce réglage.",
+      modeLabel: "Modèle du journal",
+      helperText:
+        "Haiku est moins cher ; Sonnet produit des résumés quotidiens et thématiques plus riches. Le passage horaire ne s'exécute que lorsque c'est activé.",
+      mode: {
+        off: "Désactivé",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Journal DÉSACTIVÉ",
+        haiku: "Journal en cours avec Haiku",
+        sonnet: "Journal en cours avec Sonnet",
       },
       loadError: "Échec du chargement des paramètres",
       saveError: "Échec de l'enregistrement",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -233,6 +233,7 @@ const jaMessages = {
       model: "モデル",
       voice: "音声",
       chatIndex: "チャットインデックス",
+      journal: "ジャーナル",
       skills: "スキル",
       roles: "ロール",
     },
@@ -307,6 +308,24 @@ const jaMessages = {
         off: "インデックス作成: オフ",
         haiku: "Haiku でインデックス作成中",
         sonnet: "Sonnet でインデックス作成中",
+      },
+      loadError: "設定の読み込みに失敗しました",
+      saveError: "保存に失敗しました",
+    },
+    journalTab: {
+      description:
+        "ジャーナル日次パスの設定です。最近のチャットセッションを journal/*.md に要約し、恒久メモリ（memory.md）を抽出します。デフォルトは off。自動化系セッション（scheduler / system worker）はこの設定に関わらず常に除外されます。",
+      modeLabel: "ジャーナルのモデル",
+      helperText: "Haiku は安価。Sonnet は日次/トピックまとめの質が高くなります。毎時のパスはここが on の時のみ実行されます。",
+      mode: {
+        off: "オフ",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "ジャーナル: オフ",
+        haiku: "Haiku でジャーナル実行中",
+        sonnet: "Sonnet でジャーナル実行中",
       },
       loadError: "設定の読み込みに失敗しました",
       saveError: "保存に失敗しました",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -236,6 +236,7 @@ const koMessages = {
       model: "모델",
       voice: "음성",
       chatIndex: "채팅 인덱스",
+      journal: "저널",
       skills: "스킬",
       roles: "역할",
     },
@@ -307,6 +308,24 @@ const koMessages = {
         off: "인덱싱: 꺼짐",
         haiku: "Haiku 로 인덱싱 중",
         sonnet: "Sonnet 으로 인덱싱 중",
+      },
+      loadError: "설정을 불러오지 못했습니다",
+      saveError: "저장에 실패했습니다",
+    },
+    journalTab: {
+      description:
+        "일일 저널 자동 생성 설정입니다. 최근 채팅 세션을 journal/*.md 로 요약하고 지속 메모(memory.md)를 추출합니다. 기본값은 off. 자동화 세션(scheduler / 시스템 워커)은 이 설정과 무관하게 항상 제외됩니다.",
+      modeLabel: "저널 모델",
+      helperText: "Haiku 가 더 저렴하고, Sonnet 은 일일/주제 요약 품질이 더 좋습니다. 매시 실행은 이 설정이 켜져 있을 때만 동작합니다.",
+      mode: {
+        off: "꺼짐",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "저널: 꺼짐",
+        haiku: "Haiku 로 저널 실행 중",
+        sonnet: "Sonnet 으로 저널 실행 중",
       },
       loadError: "설정을 불러오지 못했습니다",
       saveError: "저장에 실패했습니다",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -230,6 +230,7 @@ const ptBRMessages = {
       model: "Modelo",
       voice: "Voz",
       chatIndex: "Índice de chat",
+      journal: "Diário",
       skills: "Skills",
       roles: "Papéis",
     },
@@ -303,6 +304,24 @@ const ptBRMessages = {
         off: "Indexação DESATIVADA",
         haiku: "Indexando com Haiku",
         sonnet: "Indexando com Sonnet",
+      },
+      loadError: "Falha ao carregar as configurações",
+      saveError: "Falha ao salvar",
+    },
+    journalTab: {
+      description:
+        "Diário diário automatizado — resume sessões recentes de chat em journal/*.md e extrai notas de memória duradoura. Sai desativado por padrão. Sessões de automação (scheduler / workers do sistema) são sempre excluídas, independentemente desta configuração.",
+      modeLabel: "Modelo do diário",
+      helperText: "Haiku é mais barato; Sonnet produz resumos diários / por tópico mais ricos. A passagem horária só é executada quando isto está ativado.",
+      mode: {
+        off: "Desativado",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "Diário DESATIVADO",
+        haiku: "Diário em execução com Haiku",
+        sonnet: "Diário em execução com Sonnet",
       },
       loadError: "Falha ao carregar as configurações",
       saveError: "Falha ao salvar",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -231,6 +231,7 @@ const zhMessages = {
       model: "模型",
       voice: "语音",
       chatIndex: "聊天索引",
+      journal: "日志",
       skills: "技能",
       roles: "角色",
     },
@@ -301,6 +302,24 @@ const zhMessages = {
         off: "索引已关闭",
         haiku: "使用 Haiku 建立索引中",
         sonnet: "使用 Sonnet 建立索引中",
+      },
+      loadError: "加载设置失败",
+      saveError: "保存失败",
+    },
+    journalTab: {
+      description:
+        "自动化每日日志 — 将近期聊天会话摘要为 journal/*.md，并抽取持久化记忆笔记。默认关闭。自动化会话（scheduler / 系统 worker）无论此设置如何都会始终排除。",
+      modeLabel: "日志模型",
+      helperText: "Haiku 更便宜；Sonnet 生成的每日/主题摘要更丰富。仅在此设置开启时每小时的轮次才会运行。",
+      mode: {
+        off: "关闭",
+        haiku: "Haiku",
+        sonnet: "Sonnet",
+      },
+      status: {
+        off: "日志已关闭",
+        haiku: "使用 Haiku 运行日志中",
+        sonnet: "使用 Sonnet 运行日志中",
       },
       loadError: "加载设置失败",
       saveError: "保存失败",

--- a/test/journal/test_buildDailyPassPlan.ts
+++ b/test/journal/test_buildDailyPassPlan.ts
@@ -141,4 +141,39 @@ describe("buildDailyPassPlan", () => {
     // anything downstream could (in principle) mark it processed.
     assert.ok(plan.dirtyMetaById.has(sessionId), "metadata-only session is still tracked as dirty");
   });
+
+  it("silently marks origin-filtered dirty sessions as processed at their current mtime (Codex iter-1)", async () => {
+    // A dirty session with meta.origin === "scheduler" must not be
+    // summarised, but MUST be recorded in processedSessions at its
+    // current mtime — otherwise it stays dirty forever and every
+    // subsequent pass re-reads its meta (O(N) per pass in workspaces
+    // with many automation sessions).
+    const sessionId = "33333333-3333-3333-3333-333333333333";
+    const chatDir = path.join(workspaceRoot, "conversations", "chat");
+    const sessionFile = path.join(chatDir, `${sessionId}.jsonl`);
+    const metaFile = path.join(chatDir, `${sessionId}.json`);
+    await mkdir(chatDir, { recursive: true });
+    const event = {
+      type: "user_message",
+      timestamp: "2026-04-25T01:00:00Z",
+      message: "scheduled ping",
+    };
+    await writeFile(sessionFile, `${JSON.stringify(event)}\n`);
+    await writeFile(metaFile, JSON.stringify({ origin: "scheduler", roleId: "general" }));
+
+    const plan = await buildDailyPassPlan(defaultState(), {
+      workspaceRoot,
+      summarize: noopSummarize,
+      activeSessionIds: new Set(),
+    });
+
+    assert.ok(plan, "plan should be non-null when there's a dirty scheduler session");
+    assert.equal(plan.perSessionExcerpts.has(sessionId), false, "scheduler session excerpts must be dropped");
+    assert.equal(plan.dayBuckets.size, 0, "no day buckets for origin-filtered dirty session");
+    assert.ok(
+      plan.initialNextState.processedSessions[sessionId],
+      "origin-filtered dirty session must be recorded in processedSessions to prevent per-pass rescan",
+    );
+    assert.ok(plan.initialNextState.processedSessions[sessionId].lastMtimeMs > 0, "lastMtimeMs must reflect the current file mtime");
+  });
 });

--- a/test/journal/test_maybeRunJournal.ts
+++ b/test/journal/test_maybeRunJournal.ts
@@ -48,7 +48,7 @@ describe("maybeRunJournal — feature gates", () => {
       throw new ClaudeCliNotFoundError();
     };
 
-    await maybeRunJournal({ workspaceRoot, summarize, force: true });
+    await maybeRunJournal({ workspaceRoot, mode: "haiku", summarize, force: true });
     assert.equal(summarizeCalls, 1, "first call should hit summarize and trip the disable latch");
 
     let secondSummarizeCalls = 0;
@@ -56,7 +56,7 @@ describe("maybeRunJournal — feature gates", () => {
       secondSummarizeCalls++;
       return '{"dailySummaryMarkdown":"# x","topicUpdates":[]}';
     };
-    await maybeRunJournal({ workspaceRoot, summarize: livelyStub, force: true });
+    await maybeRunJournal({ workspaceRoot, mode: "haiku", summarize: livelyStub, force: true });
     assert.equal(secondSummarizeCalls, 0, "after disable, summarize must not be reached");
   });
 
@@ -88,10 +88,45 @@ describe("maybeRunJournal — feature gates", () => {
       return '{"dailySummaryMarkdown":"# x","topicUpdates":[]}';
     };
 
-    await maybeRunJournal({ workspaceRoot, summarize });
+    await maybeRunJournal({ workspaceRoot, mode: "haiku", summarize });
     assert.equal(summarizeCalls, 0, "without force the recent timestamps should gate out");
 
-    await maybeRunJournal({ workspaceRoot, summarize, force: true });
+    await maybeRunJournal({ workspaceRoot, mode: "haiku", summarize, force: true });
     assert.ok(summarizeCalls >= 1, "force must bypass the interval gate and reach summarize");
+  });
+});
+
+// Follow-up to #1944: `mode: "off"` is a hard kill switch. Even under
+// `force: true` the pass must return without touching the summarizer or
+// state files.
+describe("maybeRunJournal — mode kill switch", () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    __resetForTests();
+    workspaceRoot = await makeFreshWorkspace();
+  });
+
+  it("returns immediately when mode is 'off' — no summarize, even with force", async () => {
+    let summarizeCalls = 0;
+    const summarize: Summarize = async () => {
+      summarizeCalls++;
+      return '{"dailySummaryMarkdown":"# x","topicUpdates":[]}';
+    };
+
+    await maybeRunJournal({ workspaceRoot, mode: "off", summarize, force: true });
+    assert.equal(summarizeCalls, 0, "off must short-circuit before summarize");
+  });
+
+  it("threads the selected model through to the archivist summarize call", async () => {
+    const received: (string | undefined)[] = [];
+    const summarize: Summarize = async (_sys, _user, opts) => {
+      received.push(opts?.model);
+      return '{"dailySummaryMarkdown":"# x","topicUpdates":[]}';
+    };
+
+    await maybeRunJournal({ workspaceRoot, mode: "sonnet", summarize, force: true });
+    assert.ok(received.length >= 1, "summarize must have been called at least once");
+    assert.deepEqual(new Set(received), new Set(["sonnet"]), "every summarize call must receive the selected model");
   });
 });

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -268,6 +268,32 @@ describe("PUT /config/settings", () => {
     putSettingsHandler({ body: { chatIndex: "opus" } } as Request, res);
     assert.equal(state.status, 400);
   });
+
+  it("sets journal from a patch and roundtrips it", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"] });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { journal: "sonnet" } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.equal(persisted.journal, "sonnet");
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+  });
+
+  it("clears journal when the patch sends null", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"], journal: "haiku" });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { journal: null } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.equal(persisted.journal, undefined);
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+  });
+
+  it("rejects unknown journal values with 400", () => {
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { journal: "opus" } } as Request, res);
+    assert.equal(state.status, 400);
+  });
 });
 
 describe("PUT /config (atomic)", () => {

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -105,6 +105,21 @@ describe("isAppSettingsPatch", () => {
     assert.equal(mod.isAppSettingsPatch({ chatIndex: "" }), false);
     assert.equal(mod.isAppSettingsPatch({ chatIndex: 42 }), false);
   });
+
+  // Same null-sentinel + strict-value contract for `journal` (follow-up
+  // to #1944, mirroring chatIndex).
+  it("accepts every known journal mode and the null clear-sentinel", () => {
+    for (const mode of mod.JOURNAL_MODES) {
+      assert.ok(mod.isAppSettingsPatch({ journal: mode }), `expected ${mode} to be accepted`);
+    }
+    assert.ok(mod.isAppSettingsPatch({ journal: null }));
+  });
+
+  it("rejects unknown journal values on the patch path", () => {
+    assert.equal(mod.isAppSettingsPatch({ journal: "opus" }), false);
+    assert.equal(mod.isAppSettingsPatch({ journal: "" }), false);
+    assert.equal(mod.isAppSettingsPatch({ journal: 42 }), false);
+  });
 });
 
 describe("normaliseAppSettingsPatch", () => {
@@ -128,6 +143,15 @@ describe("normaliseAppSettingsPatch", () => {
   it("preserves a present chatIndex", () => {
     assert.deepEqual(mod.normaliseAppSettingsPatch({ chatIndex: "haiku" }), { chatIndex: "haiku" });
     assert.deepEqual(mod.normaliseAppSettingsPatch({ chatIndex: "sonnet" }), { chatIndex: "sonnet" });
+  });
+
+  it("strips null journal", () => {
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ journal: null }), {});
+  });
+
+  it("preserves a present journal", () => {
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ journal: "haiku" }), { journal: "haiku" });
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ journal: "sonnet" }), { journal: "sonnet" });
   });
 });
 
@@ -430,6 +454,20 @@ describe("saveSettings", () => {
     const parsed = JSON.parse(raw);
     assert.equal("chatIndex" in parsed, false);
   });
+
+  it("persists journal and roundtrips it through loadSettings", () => {
+    mod.saveSettings({ extraAllowedTools: [], journal: "haiku" });
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [], journal: "haiku" });
+    mod.saveSettings({ extraAllowedTools: [], journal: "sonnet" });
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [], journal: "sonnet" });
+  });
+
+  it("omits journal when unset so settings.json stays default-clean", () => {
+    mod.saveSettings({ extraAllowedTools: [] });
+    const raw = readFileSync(mod.settingsPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    assert.equal("journal" in parsed, false);
+  });
 });
 
 // #1944: the resolver is the single choke point every reader
@@ -445,5 +483,17 @@ describe("chatIndexMode resolver", () => {
     assert.equal(mod.chatIndexMode({ extraAllowedTools: [], chatIndex: "haiku" }), "haiku");
     assert.equal(mod.chatIndexMode({ extraAllowedTools: [], chatIndex: "sonnet" }), "sonnet");
     assert.equal(mod.chatIndexMode({ extraAllowedTools: [], chatIndex: "off" }), "off");
+  });
+});
+
+describe("journalMode resolver", () => {
+  it("returns 'off' when the field is undefined (default)", () => {
+    assert.equal(mod.journalMode({ extraAllowedTools: [] }), "off");
+  });
+
+  it("returns the stored value when set", () => {
+    assert.equal(mod.journalMode({ extraAllowedTools: [], journal: "haiku" }), "haiku");
+    assert.equal(mod.journalMode({ extraAllowedTools: [], journal: "sonnet" }), "sonnet");
+    assert.equal(mod.journalMode({ extraAllowedTools: [], journal: "off" }), "off");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to [#1949](https://github.com/receptron/mulmoclaude/pull/1949) (chat-index configurable). Same three-state opt-out mechanism for the journal daily pass:

- **\`AppSettings.journal\`** — \`"off"\` (default) / \`"haiku"\` / \`"sonnet"\`. \`"off"\` short-circuits \`maybeRunJournal\` before it takes the in-process lock or reads pass state. \`"haiku"\` / \`"sonnet"\` pick the Claude model the archivist CLI spawns; the model is threaded through \`Summarize\` via an optional \`{ model }\` third arg and \`runClaudeCli\` appends \`--model <model>\` to its CLI args when supplied.
- **Origin filter** (always on, mirrors chat-index): sessions with \`meta.origin\` \`system\` or \`scheduler\` are dropped inside \`loadDirtySessionExcerpts\`. Same rationale — automation origins never surface user-authored content worth summarising into a personal journal.

## Items to Confirm / Review

- **Default \`off\`** — existing users with the journal running silently will notice titles + memory stop generating until they opt in. Matches the chat-index behaviour.
- **Origin filter caveat** — one extra meta read per dirty session; negligible next to the archivist CLI cost. Journal already reads meta downstream (\`readRoleIdFromMeta\`).
- **\`--model\` threading via a pre-bound closure** in \`runJournalPass\` — downstream layers (\`dailyPass\` / \`optimizationPass\` / \`memoryExtractor\`) don't need signature changes.
- **\`JournalSummaryModel\` union excludes \`"off"\`** so a bad string can't reach \`--model\`; \`maybeRunJournal\` filters that state out first.
- **i18n** in lockstep across 8 locales (en / ja / de / es / fr / ko / pt-BR / zh).

## User Prompt

> どうように、Journal dailly pass もoptoutできるように設定を追加したい。 B (3-state matching chatIndex, default off). Journal dailly pass もsystem / scheduler のチャットを除外するのがよい？

## Test plan

- [x] \`yarn tsx --test test/server/test_config.ts test/routes/test_configRoute.ts test/journal/test_maybeRunJournal.ts\` — 86 pass.
- [x] \`yarn tsx --test test/chat-index/*.ts test/journal/*.ts\` — 337 pass (no regressions in either subsystem).
- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\`.
- Manual: Settings → Journal, flip through off / haiku / sonnet. Confirm auto-save, \`settings.json\` gains / drops the field, archivist CLI \`--model\` flag matches selection under \`haiku\` / \`sonnet\`, and \`off\` silences the hourly pass.

Plan: [\`plans/feat-1944-journal-configurable.md\`](https://github.com/receptron/mulmoclaude/blob/feat/1944-journal-configurable/plans/feat-1944-journal-configurable.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Journal settings tab with off/Haiku/Sonnet options.
  * Journal runs now respect the selected mode, including a full off switch.

* **Bug Fixes**
  * Sessions from system/scheduler sources are now skipped from journal excerpts while still being marked processed.
  * Clearing the Journal setting now properly removes the saved value instead of keeping the previous one.

* **Tests**
  * Added coverage for journal mode saving, clearing, validation, and journal run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->