### PR TITLE
fix: address CodeRabbit review comments from #1951

### DIFF
--- a/server/workspace/journal/index.ts
+++ b/server/workspace/journal/index.ts
@@ -18,7 +18,7 @@ import { buildIndexMarkdown, type IndexTopicEntry, type IndexDailyEntry } from "
 import { runClaudeCli, ClaudeCliNotFoundError, type Summarize, type JournalSummaryModel } from "./archivist-cli.js";
 import { extractFirstH1 } from "../../../src/utils/markdown/extractFirstH1.js";
 import { log } from "../../system/logger/index.js";
-import { journalMode as resolveJournalMode, loadSettings } from "../../system/config.js";
+import { journalMode as resolveJournalMode, loadSettings, type JournalMode } from "../../system/config.js";
 
 export { extractFirstH1 };
 
@@ -45,7 +45,7 @@ export interface MaybeRunJournalOptions {
   // "haiku" / "sonnet" pick the model the archivist CLI spawns. Tests
   // and the force-run switch inject this directly; production callers
   // (turn-end hook, scheduled task) let the resolver pick it up.
-  mode?: JournalSummaryModel | "off";
+  mode?: JournalMode;
 }
 
 export async function maybeRunJournal(opts: MaybeRunJournalOptions = {}): Promise<void> {

--- a/src/components/SettingsChatIndexTab.vue
+++ b/src/components/SettingsChatIndexTab.vue
@@ -29,7 +29,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { apiGet, apiPut } from "../utils/api";
+import { apiGet, apiPut, type ApiResult } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 
 const CHAT_INDEX_MODES = ["off", "haiku", "sonnet"] as const;
@@ -80,8 +80,6 @@ async function load(): Promise<void> {
 async function save(): Promise<void> {
   if (saving.value) return;
   if (modeDraft.value === storedMode.value) return;
-  // Capture the submitted value before await — a concurrent draft change
-  // would otherwise overwrite `storedMode` with a not-yet-saved value.
   const requested = modeDraft.value;
   saving.value = true;
   errorMessage.value = "";
@@ -92,16 +90,23 @@ async function save(): Promise<void> {
   const payload = { chatIndex: requested === "off" ? null : requested };
   const response = await apiPut<unknown>(API_ROUTES.config.settings, payload);
   saving.value = false;
+  applySaveOutcome(response, requested);
+}
+
+// On failure with drift, respect the user's newer selection and retry.
+// On failure without drift, revert modeDraft so re-selecting the same
+// option fires @change again — otherwise the select value hasn't
+// changed and the user is stuck with no way to retry.
+function applySaveOutcome(response: ApiResult<unknown>, requested: ChatIndexMode): void {
   if (!response.ok) {
     errorMessage.value = response.error || t("settingsModal.chatIndexTab.saveError");
+    if (modeDraft.value !== requested) void save();
+    else modeDraft.value = storedMode.value;
     return;
   }
   storedMode.value = requested;
   emit("saved");
-  // If the user changed the draft while we were in flight, re-trigger.
-  if (modeDraft.value !== requested) {
-    void save();
-  }
+  if (modeDraft.value !== requested) void save();
 }
 
 watch(

--- a/src/components/SettingsJournalTab.vue
+++ b/src/components/SettingsJournalTab.vue
@@ -29,7 +29,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { apiGet, apiPut } from "../utils/api";
+import { apiGet, apiPut, type ApiResult } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 
 const JOURNAL_MODES = ["off", "haiku", "sonnet"] as const;
@@ -88,15 +88,23 @@ async function save(): Promise<void> {
   const payload = { journal: requested === "off" ? null : requested };
   const response = await apiPut<unknown>(API_ROUTES.config.settings, payload);
   saving.value = false;
+  applySaveOutcome(response, requested);
+}
+
+// On failure with drift, respect the user's newer selection and retry.
+// On failure without drift, revert modeDraft so re-selecting the same
+// option fires @change again — otherwise the select value hasn't
+// changed and the user is stuck with no way to retry.
+function applySaveOutcome(response: ApiResult<unknown>, requested: JournalMode): void {
   if (!response.ok) {
     errorMessage.value = response.error || t("settingsModal.journalTab.saveError");
+    if (modeDraft.value !== requested) void save();
+    else modeDraft.value = storedMode.value;
     return;
   }
   storedMode.value = requested;
   emit("saved");
-  if (modeDraft.value !== requested) {
-    void save();
-  }
+  if (modeDraft.value !== requested) void save();
 }
 
 watch(

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -313,7 +313,7 @@ const enMessages = {
     },
     chatIndexTab: {
       description:
-        "Background AI titles + summaries for your chat history. Ships off — automation sessions (scheduler / system workers) are always skipped even when on, and human sessions only pay one summarizer call each when a turn ends.",
+        "Background AI titles + summaries for your chat history. Off by default — automation sessions (scheduler / system workers) are always skipped even when on, and human sessions only pay one summarizer call each when a turn ends.",
       modeLabel: "Chat index model",
       helperText: "Haiku is cheaper; Sonnet gives sharper titles for long, topic-shifting sessions.",
       mode: {
@@ -331,7 +331,7 @@ const enMessages = {
     },
     journalTab: {
       description:
-        "Automated daily journal — summarises recent chat sessions into journal/*.md and extracts durable memory notes. Ships off. Automation sessions (scheduler / system workers) are always excluded regardless of this setting.",
+        "Automated daily journal — summarises recent chat sessions into journal/*.md and extracts durable memory notes. Off by default. Automation sessions (scheduler / system workers) are always excluded regardless of this setting.",
       modeLabel: "Journal model",
       helperText: "Haiku is cheaper; Sonnet produces richer daily / topic summaries. The hourly pass runs only when this is set.",
       mode: {


### PR DESCRIPTION
## Summary

Follow-up to [#1951](https://github.com/receptron/mulmoclaude/pull/1951). CodeRabbit posted its review a few seconds after the merge, so these fixes never landed on main. Timing note added on #1951 for the record.

Three fixes:

1. **Major functional bug** — `SettingsJournalTab.vue.save()` (and the copy-source `SettingsChatIndexTab.vue.save()`) silently drops a newer draft on failure. Sequence: user picks `haiku` → `save()` starts (`saving=true`) → user picks `sonnet` (`@change` is a no-op) → `haiku` POST fails → `save()` returns; `sonnet` is lost, and re-selecting the same failing value doesn't fire `@change` again (select value hasn't visibly changed). Fixed in both tabs:
   - Failure **with** drift → honour the newer selection and re-invoke `save()`.
   - Failure **without** drift → revert `modeDraft` to `storedMode` so re-selecting the same option triggers a fresh save.
   - Extracted `applySaveOutcome()` so `save()` stays under the 20-line ceiling and both branches share one drift-check point.

2. **en.ts typo** — "Ships off." → "Off by default." in both `chatIndexTab` and `journalTab` descriptions. Other 7 locales already read cleanly ("Off by default." / "Standardmäßig aus." / "デフォルトは off." / etc.).

3. **Type reuse** — `server/workspace/journal/index.ts` `MaybeRunJournalOptions.mode` was typed `JournalSummaryModel | "off"`, duplicating the `JournalMode` union already exported from `server/system/config.ts`. Now imports and reuses `JournalMode` so future mode additions stay in lockstep automatically.

## Items to Confirm / Review

- **The chat-index bug** shipped in #1949; this PR is the first place it's been fixed, so please double-check the `SettingsChatIndexTab.vue` change even though the PR title reads as journal follow-up.
- **`applySaveOutcome()` control flow** — the drift/no-drift branch on failure is the semantic core of the fix; both tabs share the same shape.
- **CodeRabbit nitpicks deliberately skipped**:
  - `cloneAppSettings` / `saveSettings` past 20 lines — pre-existing debt across 6 optional fields, out of scope.
  - `partitionDirtyByOrigin` sequential meta reads — mirrors the sequential loop in `loadDirtySessionExcerpts`; parallelising one without the other is inconsistent, and the perf win at typical dirty-session counts is negligible.
  - Default-mode `maybeRunJournal` test — `loadSettings()` reads from a fixed `WORKSPACE_PATHS.configs` path; a hermetic default-path test would race with the real `~/.mulmoclaude/settings.json`. `journalMode()` resolver already has direct coverage in `test_config.ts`.

## User Prompt

> どうように、Journal dailly pass もoptoutできるように設定を追加したい。 B (3-state matching chatIndex, default off). Journal dailly pass もsystem / scheduler のチャットを除外するのがよい？ (Iter-2 fixes below are the CodeRabbit-flagged issues that landed after the parent PR was merged.)

## Test plan

- [x] `yarn tsx --test test/journal/test_maybeRunJournal.ts test/journal/test_buildDailyPassPlan.ts test/server/test_config.ts test/routes/test_configRoute.ts` — 92 pass.
- [x] `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build`.
- Manual: Settings → Journal / Chat index tab, force a save failure (offline / server-off), confirm subsequent re-select of the same option retries and drift-during-in-flight selects don't get dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)