### PR TITLE
feat(session-history): 要約を優先表示、全文はホバーで見せる (#1958)

### DIFF
--- a/plans/feat-1958-session-summary-priority.md
+++ b/plans/feat-1958-session-summary-priority.md
@@ -1,0 +1,70 @@
+# feat(#1958): セッション履歴で要約を優先表示、全文はホバーで
+
+## Summary
+
+`SessionHistoryPanel.vue` のセッション行の 2 行表示 (preview + summary)
+を 1 本に統合し、要約があれば要約を、なければ preview をフォールバック
+表示する。要約は最大 2 行 (`line-clamp-2`) まで見せ、全文はホバー
+(native `title`) で読める。
+
+## Items to Confirm / Review
+
+- **要約が truncate される場合の UX** — `line-clamp-2` + native `title`
+  で全文を出す。カスタムツールチップは付けない (シンプル、キーボード
+  フォーカスでも動く、追加依存なし)。デフォルトのブラウザツールチップ
+  の見た目は簡素だが機能は満たす。
+- **削除確認は preview のまま** — `session.preview` は「ユーザーが
+  自分でタイプした最初の一言」で、AI 要約より「どのセッションを
+  消すか」の判断に確実。要約は誤っていたり古かったりする可能性が
+  あるので、削除の同意には preview を残す。
+- **`aria-label` は要約優先** — スクリーンリーダーには要約の方が
+  中身が伝わりやすい。要約が存在する行では preview は隠れる形になる
+  (`title` と `aria-label` の重複読み上げは SR ごとに挙動が違うが、
+  ほとんどのケースで `aria-label` が勝つ)。
+- **行アイコン整列の変更** — 2 行のときアイコンが縦中央にくると
+  最初の行と揃わなくて違和感が出るので、`items-center` → `items-start`
+  + `mt-0.5` で最初の行にアイコンを合わせる。1 行のときは見た目が
+  ほぼ同じ。
+
+## User Prompt
+
+> サイドメニューの改善で要約を作っている。いま、ようやくと最初のテキストの
+> ２つがでているけど、要約がある場合にはできる限りようやくを表示させたほうが
+> 便利じゃないかな？最初のテキストは消したうえで。あとマウスをおくとホバーして
+> 要約を全体みたい。
+
+## Implementation
+
+`src/components/SessionHistoryPanel.vue` のセッション行 (template 部分):
+
+- 行 `<div>` に `:title="session.summary || session.preview || t(...)"`
+  を追加 (ホバー / フォーカスでネイティブツールチップ、全文表示)。
+- `:aria-label` を要約優先に (`session.summary || session.preview || ...`)。
+- 内部レイアウト:
+  - `<div class="flex items-center">` → `<div class="flex items-start">`
+  - `SessionRoleIcon` に `flex-shrink-0 mt-0.5` を追加 (最初の行と揃える)
+  - 要約 / preview 用 `<p>` は 1 本に統合:
+    - 内容 `session.summary || session.preview || noMessages`
+    - `:class="[previewClasses(session), session.summary ? 'line-clamp-2' : 'truncate']"`
+  - 実行中インジケータの `<span>` にも `mt-0.5`
+- 旧 2 行目 (`<p v-if="session.summary" ... mt-0.5>`) は削除。
+
+Tailwind 4 なので `line-clamp-2` は built-in、追加設定不要。
+
+## Test plan
+
+- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build`
+- 手動:
+  - 要約ありセッション: 主行が要約 (最大 2 行、超えたら `…` で切れる)、
+    preview 2 行目は消えている。ホバーで要約全文がツールチップ表示。
+  - 要約なしセッション: 主行が preview の 1 行 truncate。
+  - 要約なし + preview なし (新規空セッション): `noMessages` プレース
+    ホルダーが 1 行表示。
+  - キーボードフォーカスでも `title` が発火するか (ブラウザ依存)。
+
+## Out of scope
+
+- カスタムツールチップコンポーネント / floating-ui 導入
+- 要約の 3 行以上への拡張 (2 行 UI で十分読める設計、行高が伸びると
+  スクロールが増える)
+- 削除確認の要約表示 (根拠は上記)

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -35,7 +35,8 @@
         :key="session.id"
         tabindex="0"
         role="button"
-        :aria-label="t('sessionHistoryPanel.openRowAria', { preview: session.preview || t('sessionHistoryPanel.noMessages') })"
+        :aria-label="t('sessionHistoryPanel.openRowAria', { preview: session.summary || session.preview || t('sessionHistoryPanel.noMessages') })"
+        :title="session.summary || session.preview || t('sessionHistoryPanel.noMessages')"
         class="relative cursor-pointer rounded p-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         :class="rowClasses(session)"
         :data-testid="`session-item-${session.id}`"
@@ -91,20 +92,22 @@
             {{ t("sessionHistoryPanel.delete") }}
           </button>
         </div>
-        <div class="flex items-center gap-1.5">
-          <SessionRoleIcon :session="session" :roles="roles" size="sm" />
-          <p class="truncate flex-1 min-w-0" :class="previewClasses(session)">
-            {{ session.preview || t("sessionHistoryPanel.noMessages") }}
+        <!-- Primary line prefers the AI-generated summary (chat indexer,
+             #123) when present — it's typically more informative than
+             the first user message. Fall back to the first user message,
+             then to a "no messages" placeholder. `line-clamp-2` lets a
+             summary wrap so more of it is readable at a glance; the raw
+             first-message fallback stays on a single line via `truncate`
+             so short prompts don't disturb row heights. -->
+        <div class="flex items-start gap-1.5">
+          <SessionRoleIcon :session="session" :roles="roles" size="sm" class="flex-shrink-0 mt-0.5" />
+          <p class="flex-1 min-w-0" :class="[previewClasses(session), session.summary ? 'line-clamp-2' : 'truncate']">
+            {{ session.summary || session.preview || t("sessionHistoryPanel.noMessages") }}
           </p>
-          <span v-if="isSessionRunning(session)" class="flex-shrink-0 flex items-center" :aria-label="t('sessionHistoryPanel.running')">
+          <span v-if="isSessionRunning(session)" class="flex-shrink-0 flex items-center mt-0.5" :aria-label="t('sessionHistoryPanel.running')">
             <span class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
           </span>
         </div>
-        <!-- Optional second line: AI-generated summary of the
-             session, populated by the chat indexer (#123). -->
-        <p v-if="session.summary" class="text-xs text-gray-500 truncate mt-0.5">
-          {{ session.summary }}
-        </p>
       </div>
     </div>
   </div>

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -35,8 +35,8 @@
         :key="session.id"
         tabindex="0"
         role="button"
-        :aria-label="t('sessionHistoryPanel.openRowAria', { preview: session.summary || session.preview || t('sessionHistoryPanel.noMessages') })"
-        :title="session.summary || session.preview || t('sessionHistoryPanel.noMessages')"
+        :aria-label="t('sessionHistoryPanel.openRowAria', { preview: primaryText(session) })"
+        :title="primaryText(session)"
         class="relative cursor-pointer rounded p-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         :class="rowClasses(session)"
         :data-testid="`session-item-${session.id}`"
@@ -101,8 +101,8 @@
              so short prompts don't disturb row heights. -->
         <div class="flex items-start gap-1.5">
           <SessionRoleIcon :session="session" :roles="roles" size="sm" class="flex-shrink-0 mt-0.5" />
-          <p class="flex-1 min-w-0" :class="[previewClasses(session), session.summary ? 'line-clamp-2' : 'truncate']">
-            {{ session.summary || session.preview || t("sessionHistoryPanel.noMessages") }}
+          <p class="flex-1 min-w-0" :class="[previewClasses(session), sessionHasVisibleSummary(session) ? 'line-clamp-2' : 'truncate']">
+            {{ primaryText(session) }}
           </p>
           <span v-if="isSessionRunning(session)" class="flex-shrink-0 flex items-center mt-0.5" :aria-label="t('sessionHistoryPanel.running')">
             <span class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
@@ -121,6 +121,7 @@ import type { SessionSummary, SessionOrigin } from "../types/session";
 import { SESSION_ORIGINS } from "../types/session";
 import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, type HistoryFilter } from "../config/historyFilters";
 import { isLongRunningConversation } from "../utils/session/longRunning";
+import { resolveSessionPrimaryText, sessionHasVisibleSummary } from "../utils/session/sessionPreview";
 import { formatDate } from "../utils/format/date";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 import FilterChip from "./FilterChip.vue";
@@ -200,6 +201,15 @@ function rowClasses(session: SessionSummary): string {
 function previewClasses(session: SessionSummary): string {
   if (isSessionUnread(session)) return "text-gray-900 font-bold";
   return "text-gray-700";
+}
+
+// Primary line resolution: prefer the AI summary (trim + whitespace
+// guarded so a summarizer returning "   " doesn't blank the row) →
+// first user message → localised placeholder. Same call is used for
+// visible text, aria-label, and the hover title so all three stay in
+// lockstep.
+function primaryText(session: SessionSummary): string {
+  return resolveSessionPrimaryText(session) ?? t("sessionHistoryPanel.noMessages");
 }
 
 // ── Row action menu ─────────────────────────────────────────

--- a/src/utils/session/sessionPreview.ts
+++ b/src/utils/session/sessionPreview.ts
@@ -1,0 +1,29 @@
+// Selection helpers for the session-history sidebar row.
+//
+// The AI summary (chat indexer) is preferred over the raw first user
+// message when it's meaningful. "Meaningful" excludes undefined / empty
+// / whitespace-only strings — otherwise a summarizer that returns "   "
+// would blank out the row (no visible text, no tooltip, no aria label).
+
+export interface SessionPreviewInput {
+  summary?: string;
+  preview: string;
+}
+
+export function resolveSessionSummary(summary: string | undefined): string | null {
+  const trimmed = summary?.trim();
+  return trimmed || null;
+}
+
+// `null` means "nothing to show" — the template turns that into the
+// localised `noMessages` placeholder. Not baked in here to keep this
+// pure (no i18n dependency).
+export function resolveSessionPrimaryText(session: SessionPreviewInput): string | null {
+  const summary = resolveSessionSummary(session.summary);
+  if (summary) return summary;
+  return session.preview || null;
+}
+
+export function sessionHasVisibleSummary(session: SessionPreviewInput): boolean {
+  return resolveSessionSummary(session.summary) !== null;
+}

--- a/test/utils/session/test_sessionPreview.ts
+++ b/test/utils/session/test_sessionPreview.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSessionSummary, resolveSessionPrimaryText, sessionHasVisibleSummary } from "../../../src/utils/session/sessionPreview.js";
+
+describe("resolveSessionSummary", () => {
+  it("returns the trimmed summary when non-empty", () => {
+    assert.equal(resolveSessionSummary("  User discussed Rails migration  "), "User discussed Rails migration");
+  });
+
+  it("returns null for undefined", () => {
+    assert.equal(resolveSessionSummary(undefined), null);
+  });
+
+  it("returns null for empty string", () => {
+    assert.equal(resolveSessionSummary(""), null);
+  });
+
+  it("returns null for whitespace-only (spaces / tabs / newlines) — the Codex #1959 blank-row guard", () => {
+    assert.equal(resolveSessionSummary("   "), null);
+    assert.equal(resolveSessionSummary("\t\t"), null);
+    assert.equal(resolveSessionSummary("\n \n"), null);
+  });
+});
+
+describe("resolveSessionPrimaryText", () => {
+  it("prefers a meaningful summary over the preview", () => {
+    const result = resolveSessionPrimaryText({ summary: "AI summary", preview: "Hello" });
+    assert.equal(result, "AI summary");
+  });
+
+  it("trims the summary before returning", () => {
+    const result = resolveSessionPrimaryText({ summary: "  padded summary  ", preview: "Hello" });
+    assert.equal(result, "padded summary");
+  });
+
+  it("falls back to the preview when summary is missing", () => {
+    const result = resolveSessionPrimaryText({ preview: "Hello" });
+    assert.equal(result, "Hello");
+  });
+
+  it("falls back to the preview when summary is whitespace-only", () => {
+    const result = resolveSessionPrimaryText({ summary: "   ", preview: "Hello" });
+    assert.equal(result, "Hello");
+  });
+
+  it("returns null when both summary and preview are absent — the caller supplies the localised noMessages placeholder", () => {
+    assert.equal(resolveSessionPrimaryText({ preview: "" }), null);
+    assert.equal(resolveSessionPrimaryText({ summary: "  ", preview: "" }), null);
+  });
+
+  it("does not fall through to preview when summary is meaningful — even if preview is longer", () => {
+    const result = resolveSessionPrimaryText({ summary: "AI", preview: "A much longer first message" });
+    assert.equal(result, "AI");
+  });
+});
+
+describe("sessionHasVisibleSummary", () => {
+  it("is true only when the summary is non-whitespace", () => {
+    assert.equal(sessionHasVisibleSummary({ summary: "yes", preview: "" }), true);
+    assert.equal(sessionHasVisibleSummary({ summary: "  padded  ", preview: "" }), true);
+  });
+
+  it("is false when summary is missing / empty / whitespace", () => {
+    assert.equal(sessionHasVisibleSummary({ preview: "hi" }), false);
+    assert.equal(sessionHasVisibleSummary({ summary: "", preview: "hi" }), false);
+    assert.equal(sessionHasVisibleSummary({ summary: "   ", preview: "hi" }), false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1958. `SessionHistoryPanel.vue` のセッション行を、要約優先の 1 本表示に統合。

- **要約優先**: `session.summary || session.preview || noMessages` の順で主行に表示。旧 preview + summary の 2 行構成を廃止。
- **要約は最大 2 行** (`line-clamp-2`) で見せる。preview フォールバックは今と同じ 1 行 `truncate`。
- **全文はホバー**: 行に `:title` を追加。ネイティブブラウザツールチップで要約全文を表示。カスタムツールチップ / floating-ui の類は導入しない。
- `aria-label` も要約優先に (SR にとって要約の方が有益)。
- 2 行時の視覚崩れを防ぐため `items-center` → `items-start` + `mt-0.5` (アイコンと実行中インジケータが最初の行に揃う)。

## Items to Confirm / Review

- **削除確認は preview のまま** — `session.preview` は「ユーザーが自分でタイプした最初の一言」で、AI 要約より「どのセッションを消すか」の判断に確実。要約は誤りや古さを含み得るので、削除の同意には preview を残す判断。
- **`:title` と `:aria-label` の共存** — 大半の SR は `aria-label` を優先し、`title` は無視 or 2 番目扱い。sighted-user 向けに全文が読めるメリットが、重複読み上げのリスクより大きいと判断。
- **`line-clamp-2` のプラットフォーム挙動** — Tailwind 4 は built-in、追加設定なし。Safari / Firefox / Chrome とも `-webkit-line-clamp` 経由でサポート済み。
- **アイコン整列変更** — 要約 1 行 / preview 1 行のケースでは見た目ほぼ変わらず。要約 2 行のケースで自然な整列になる。

## User Prompt

> サイドメニューの改善で要約を作っている。いま、ようやくと最初のテキストの２つがでているけど、要約がある場合にはできる限りようやくを表示させたほうが便利じゃないかな？最初のテキストは消したうえで。あとマウスをおくとホバーして要約を全体みたい。

## Test plan

- [x] `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build`
- [x] 手動確認: 要約あり → 2 行 line-clamp + ホバー全文 / 要約なし → preview 1 行 + ホバー / 両方なし → noMessages プレースホルダー

計画: [`plans/feat-1958-session-summary-priority.md`](https://github.com/receptron/mulmoclaude/blob/feat/1958-session-summary-priority/plans/feat-1958-session-summary-priority.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prioritize showing session summaries in the session history list, consolidating summary and preview into a single primary line with improved accessibility and hover behavior.

Enhancements:
- Update session history rows to display the AI-generated summary when available, falling back to the first user message or a placeholder in a single unified line with two-line clamping for summaries.
- Adjust layout and icon alignment in the session history row to accommodate multi-line summaries while keeping running indicators visually aligned.
- Expose the full summary or preview via the native browser tooltip and update aria-labels to reflect the summary-first behavior for better screen reader output.

Documentation:
- Add a planning document describing the design, rationale, and test plan for prioritizing summaries in the session history panel.