### PR TITLE
feat(remote-host): list accounting books + choose role on startChat

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -33,7 +33,7 @@
     "@mulmocast/types": "^2.7.0",
     "@mulmochat-plugin/quiz": "0.5.0",
     "@mulmochat-plugin/ui-image": "^0.4.0",
-    "@mulmoclaude/accounting-plugin": "^0.3.1",
+    "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.0",
     "@mulmoclaude/core": "^0.8.1",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/accounting-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Double-entry accounting plugin for MulmoClaude and MulmoTerminal. Three surfaces: ./shared (isomorphic enums/meta, browser-safe), ./vue (chat View/Preview + canvas app), ./server (createAccountingRouter — the workspace-file-backed backend, wired via dependency injection so it pulls zero host-only infra).",
   "type": "module",
   "exports": {

--- a/packages/plugins/accounting-plugin/src/server/index.ts
+++ b/packages/plugins/accounting-plugin/src/server/index.ts
@@ -14,6 +14,12 @@ export { configureAccountingServer } from "./context.js";
 export type { AccountingServerDeps, AccountingLogger, IPubSub } from "./context.js";
 export { initAccountingEventPublisher } from "./eventPublisher.js";
 
+// Read-only book list (id / name / currency / country / …) for host callers
+// that need to enumerate books outside the HTTP dispatch route — e.g. the
+// remote-host command channel surfacing a book picker to the mobile client.
+export { listBooks } from "./service.js";
+export type { BookSummary } from "./types.js";
+
 // Pure date-validation helper reused by host e2e mock fixtures so the
 // mock dispatcher rejects the same malformed dates the real service does.
 export { isValidCalendarDate } from "./journal.js";

--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -6,6 +6,7 @@ import { getCollection } from "./getCollection.js";
 import { getFeed } from "./getFeed.js";
 import { getRemoteView } from "./getRemoteView.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
+import { listAccountingBooks } from "./listAccountingBooks.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
 import { listShortcuts } from "./listShortcuts.js";
@@ -23,5 +24,6 @@ export const handlers: CommandHandlers = {
   getRemoteView,
   getRemoteViewItems,
   mutateRemoteViewItem,
+  listAccountingBooks,
   startChat,
 };

--- a/server/remoteHost/handlers/listAccountingBooks.ts
+++ b/server/remoteHost/handlers/listAccountingBooks.ts
@@ -1,0 +1,31 @@
+// listAccountingBooks command handler (remote-host).
+//
+// Returns { books: [{ id, name }] } so the mobile remote can show a book picker
+// (e.g. before starting an accounting chat). Runs in-process on the host, so it
+// bypasses the HTTP bearer layer and calls the accounting engine's listBooks
+// directly. Only id + name travel — the remote doesn't need currency / country /
+// fiscalYearEnd / createdAt, and trimming keeps the command-channel payload
+// minimal (same "only what the client needs" discipline as listSkills).
+//
+// Exposed as a factory (createListAccountingBooks) so the mapping is
+// unit-testable with listBooks stubbed; the default export wires the real
+// engine function.
+import { listBooks } from "@mulmoclaude/accounting-plugin/server";
+import type { CommandHandler, JsonObject } from "../commandChannel.js";
+
+export interface ListAccountingBooksDeps {
+  listBooks: typeof listBooks;
+}
+
+export const createListAccountingBooks =
+  (deps: ListAccountingBooksDeps): CommandHandler =>
+  // Takes no params (the `__` prefix marks it intentionally unused per lint).
+  async (__params: JsonObject) => {
+    const { books } = await deps.listBooks();
+    // { id, name } are always present on a BookSummary. The cast only satisfies
+    // the channel's structural JsonValue type, which the BookSummary interface
+    // (no index signature) can't match directly.
+    return { books: books.map((book) => ({ id: book.id, name: book.name })) } as unknown as JsonObject;
+  };
+
+export const listAccountingBooks = createListAccountingBooks({ listBooks });

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -108,11 +108,14 @@ const hasSlug = (value: JsonValue | undefined): boolean => value != null && valu
 // Resolve the optional `role` param to a concrete roleId. Absent / null / "" ⇒
 // the host default. A provided id must be a string that matches an existing
 // role (built-in or custom) — reject an unknown one so we never seed the chat
-// with the wrong (default-fallback) assistant.
+// with the wrong (default-fallback) assistant. `isDebugRole` roles are excluded:
+// the desktop picker hides them from new sessions outside dev mode
+// (RoleSelector.vue), and the remote channel is a production-facing entry point,
+// so a debug role id is treated as not selectable here (rejected as unknown).
 const resolveRoleId = (deps: StartChatDeps, role: JsonValue | undefined): string => {
   if (role == null || role === "") return DEFAULT_ROLE_ID;
   if (typeof role !== "string") throw new Error("role must be a string");
-  if (!deps.loadRoles().some((candidate) => candidate.id === role)) throw new Error(`role '${role}' not found`);
+  if (!deps.loadRoles().some((candidate) => candidate.id === role && !candidate.isDebugRole)) throw new Error(`role '${role}' not found`);
   return role;
 };
 

--- a/server/remoteHost/handlers/startChat.ts
+++ b/server/remoteHost/handlers/startChat.ts
@@ -22,9 +22,11 @@
 // │ client sends `slug` anymore.                                              │
 // └─────────────────────────────────────────────────────────────────────────┘
 //
-// Role is intentionally NOT part of the remote API — the host runs the chat in
-// its default role (spawnSystemWorker → startChat requires a concrete roleId;
-// empty is rejected).
+// Optional `role` — the id of the role the chat should run in (built-in or
+// custom). Absent / null / "" ⇒ the host default role. A provided id MUST match
+// an existing role: spawnSystemWorker requires a concrete roleId and the
+// downstream getRole silently falls back to `general` on a miss, so we validate
+// here and reject an unknown role rather than seed the wrong assistant.
 //
 // Optional `attachments` — full-res files (photos, videos, PDFs) the remote
 // staged to Storage, carried as `[{ storage_id }]`. The host ingests them into
@@ -36,6 +38,7 @@
 // engine + spawner stubbed; the default export wires the real ones.
 import { spawnSystemWorker } from "../../api/routes/agent.js";
 import { loadCollection } from "../../workspace/collections/index.js";
+import { loadAllRoles } from "../../workspace/roles.js";
 import { DEFAULT_ROLE_ID } from "../../../src/config/roles.js";
 import type { CommandHandler, JsonObject, JsonValue } from "../commandChannel.js";
 import { ingestAttachments } from "./ingestAttachments.js";
@@ -44,6 +47,7 @@ export interface StartChatDeps {
   spawn: typeof spawnSystemWorker;
   loadCollection: typeof loadCollection;
   ingest: typeof ingestAttachments;
+  loadRoles: typeof loadAllRoles;
 }
 
 // Parse the optional `attachments` param into a list of storage_ids. Absent ⇒ no
@@ -101,6 +105,17 @@ const composeCollectionSeed = async (deps: StartChatDeps, params: JsonObject, me
 // set it, so they always take the verbatim branch below.
 const hasSlug = (value: JsonValue | undefined): boolean => value != null && value !== "";
 
+// Resolve the optional `role` param to a concrete roleId. Absent / null / "" ⇒
+// the host default. A provided id must be a string that matches an existing
+// role (built-in or custom) — reject an unknown one so we never seed the chat
+// with the wrong (default-fallback) assistant.
+const resolveRoleId = (deps: StartChatDeps, role: JsonValue | undefined): string => {
+  if (role == null || role === "") return DEFAULT_ROLE_ID;
+  if (typeof role !== "string") throw new Error("role must be a string");
+  if (!deps.loadRoles().some((candidate) => candidate.id === role)) throw new Error(`role '${role}' not found`);
+  return role;
+};
+
 export const createStartChat =
   (deps: StartChatDeps): CommandHandler =>
   async (params: JsonObject) => {
@@ -110,12 +125,15 @@ export const createStartChat =
     // Current clients: `message` only ⇒ seed it verbatim. Legacy clients that
     // still send `slug` ⇒ compose the old `/<slug> [id=<itemId>] <message>` seed.
     const seed = hasSlug(params.slug) ? await composeCollectionSeed(deps, params, message) : message;
+    // Resolve the role BEFORE ingest/spawn so an unknown role rejects the
+    // command without staging work or launching a chat.
+    const roleId = resolveRoleId(deps, params.role);
     // Ingest any staged files BEFORE spawning so a download/validation failure
     // rejects the command instead of starting a chat missing its attachments.
     const attachments = await deps.ingest(readStorageIds(params.attachments));
-    const result = await deps.spawn({ message: seed, roleId: DEFAULT_ROLE_ID, hidden: false, attachments });
+    const result = await deps.spawn({ message: seed, roleId, hidden: false, attachments });
     if (!result.ok) throw new Error(result.error);
     return { started: true, chatId: result.chatId };
   };
 
-export const startChat = createStartChat({ spawn: spawnSystemWorker, loadCollection, ingest: ingestAttachments });
+export const startChat = createStartChat({ spawn: spawnSystemWorker, loadCollection, ingest: ingestAttachments, loadRoles: loadAllRoles });

--- a/test/remoteHost/test_handlers.ts
+++ b/test/remoteHost/test_handlers.ts
@@ -6,12 +6,37 @@ import assert from "node:assert/strict";
 
 import { handlers } from "../../server/remoteHost/handlers/index.js";
 import { createListCollections, type ListCollectionsDeps } from "../../server/remoteHost/handlers/listCollections.js";
+import { createListAccountingBooks, type ListAccountingBooksDeps } from "../../server/remoteHost/handlers/listAccountingBooks.js";
 
 describe("remote-host handler registry", () => {
   it("exposes every registered handler", () => {
-    for (const name of ["listCollections", "getCollection", "listShortcuts", "listSkills", "listFeeds", "getFeed", "startChat"]) {
+    for (const name of ["listCollections", "getCollection", "listShortcuts", "listSkills", "listFeeds", "getFeed", "listAccountingBooks", "startChat"]) {
       assert.equal(typeof handlers[name], "function", `missing handler: ${name}`);
     }
+  });
+});
+
+describe("createListAccountingBooks", () => {
+  it("maps books down to { id, name }, dropping the other BookSummary fields", async () => {
+    const listBooks = (async () => ({
+      books: [
+        { id: "b1", name: "Personal", currency: "USD", createdAt: "2026-01-01T00:00:00Z" },
+        { id: "b2", name: "Studio LLC", currency: "JPY", country: "JP" },
+      ],
+    })) as unknown as ListAccountingBooksDeps["listBooks"];
+    const handler = createListAccountingBooks({ listBooks });
+    assert.deepEqual(await handler({}), {
+      books: [
+        { id: "b1", name: "Personal" },
+        { id: "b2", name: "Studio LLC" },
+      ],
+    });
+  });
+
+  it("returns an empty list when there are no books", async () => {
+    const listBooks = (async () => ({ books: [] })) as unknown as ListAccountingBooksDeps["listBooks"];
+    const handler = createListAccountingBooks({ listBooks });
+    assert.deepEqual(await handler({}), { books: [] });
   });
 });
 

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -16,9 +16,10 @@ type Loaded = Awaited<ReturnType<StartChatDeps["loadCollection"]>>;
 const collection = { source: "user" } as unknown as Loaded;
 const feed = { source: "feed" } as unknown as Loaded;
 
-// Stub role registry — `general` (the default) plus one custom role, enough to
-// exercise the "known role passes / unknown role rejects" branches.
-const roles = [{ id: "general" }, { id: "accounting" }] as unknown as ReturnType<StartChatDeps["loadRoles"]>;
+// Stub role registry — `general` (the default), one custom role, and a
+// debug-only role, enough to exercise "known role passes / unknown role rejects
+// / debug role rejected" branches.
+const roles = [{ id: "general" }, { id: "accounting" }, { id: "debug", isDebugRole: true }] as unknown as ReturnType<StartChatDeps["loadRoles"]>;
 
 // Build stub deps. `loadResult` is what `loadCollection` resolves to (only the
 // legacy slug path calls it): a normal collection (default) ⇒ chat proceeds;
@@ -219,6 +220,12 @@ describe("createStartChat — role selection", () => {
   it("rejects an unknown role without spawning", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-4" });
     await assert.rejects(async () => createStartChat(deps)({ message: "hi", role: "ghost" }), /role 'ghost' not found/);
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects a debug-only role (not selectable from the production remote channel)", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-debug" });
+    await assert.rejects(async () => createStartChat(deps)({ message: "hi", role: "debug" }), /role 'debug' not found/);
     assert.equal(calls.length, 0);
   });
 

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -16,6 +16,10 @@ type Loaded = Awaited<ReturnType<StartChatDeps["loadCollection"]>>;
 const collection = { source: "user" } as unknown as Loaded;
 const feed = { source: "feed" } as unknown as Loaded;
 
+// Stub role registry — `general` (the default) plus one custom role, enough to
+// exercise the "known role passes / unknown role rejects" branches.
+const roles = [{ id: "general" }, { id: "accounting" }] as unknown as ReturnType<StartChatDeps["loadRoles"]>;
+
 // Build stub deps. `loadResult` is what `loadCollection` resolves to (only the
 // legacy slug path calls it): a normal collection (default) ⇒ chat proceeds;
 // `feed` ⇒ refused; `null` ⇒ unknown slug, rejected. `ingestOverride` swaps the
@@ -41,7 +45,8 @@ const makeDeps = (result: Awaited<ReturnType<StartChatDeps["spawn"]>>, loadResul
       ingestCalls.push(storageIds);
       return storageIds.map((storageId) => ({ path: `data/attachments/${storageId}.jpg`, mimeType: "image/jpeg" }));
     }) as StartChatDeps["ingest"]);
-  return { deps: { spawn, loadCollection, ingest } as StartChatDeps, calls, loadCalls, ingestCalls };
+  const loadRoles = (() => roles) as StartChatDeps["loadRoles"];
+  return { deps: { spawn, loadCollection, ingest, loadRoles } as StartChatDeps, calls, loadCalls, ingestCalls };
 };
 
 // ── CURRENT form: `{ message }` only, seeded verbatim ──────────────────────
@@ -183,6 +188,43 @@ describe("createStartChat — file attachments", () => {
     }) as StartChatDeps["ingest"];
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-4" }, collection, failing);
     await assert.rejects(async () => createStartChat(deps)({ message: "hi", attachments: [{ storage_id: "aaa" }] }), /storage 404/);
+    assert.equal(calls.length, 0);
+  });
+});
+
+// ── Role selection: { message, role } ──────────────────────────────────────
+describe("createStartChat — role selection", () => {
+  it("defaults to the general role when no role is sent", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-1" });
+    await createStartChat(deps)({ message: "hi" });
+    assert.equal(calls[0].roleId, "general");
+  });
+
+  it("treats null / empty-string role as absent (default role)", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-2" });
+    await createStartChat(deps)({ message: "hi", role: "" });
+    await createStartChat(deps)({ message: "hi", role: null });
+    assert.deepEqual(
+      calls.map((call) => call.roleId),
+      ["general", "general"],
+    );
+  });
+
+  it("runs the chat in a known role when one is sent", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-3" });
+    await createStartChat(deps)({ message: "record today's receipt", role: "accounting" });
+    assert.equal(calls[0].roleId, "accounting");
+  });
+
+  it("rejects an unknown role without spawning", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-4" });
+    await assert.rejects(async () => createStartChat(deps)({ message: "hi", role: "ghost" }), /role 'ghost' not found/);
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects a non-string role without spawning", async () => {
+    const { deps, calls } = makeDeps({ ok: true, chatId: "chat-5" });
+    await assert.rejects(async () => createStartChat(deps)({ message: "hi", role: 7 }), /role must be a string/);
     assert.equal(calls.length, 0);
   });
 });


### PR DESCRIPTION
## What

Two new capabilities on the mobile-remote command channel (`server/remoteHost/handlers/`), the RPC-over-Firestore layer the phone reaches via `callHost(...)`.

### 1. List accounting books (id + name)
- New handler `listAccountingBooks` → returns `{ books: [{ id, name }] }` so the remote can render a book picker.
- Runs in-process on the host, bypassing the HTTP bearer layer; only `id` + `name` travel (drops currency/country/fiscalYearEnd/createdAt) to keep the command payload minimal — same discipline as `listSkills`.
- Exports `listBooks` (+ `BookSummary` type) from `@mulmoclaude/accounting-plugin/server` so the host can enumerate books outside the HTTP dispatch route.
- Registered in the handler table.

### 2. Specify the role when starting a chat
- `startChat` now accepts an optional `role` param (a role id). Absent / `null` / `""` → the default `general` role (byte-for-byte the prior behaviour).
- A provided id is validated against `loadAllRoles()` (built-in **and** custom roles, so `accounting` works); an unknown or non-string role rejects the command **before** any ingest/spawn.
- This intentionally reverses the handler's old "role is NOT part of the remote API" stance — the header comment is updated to document the new contract.

## Tests
Unit tests added: the `{ id, name }` mapping (+ empty list) and the default / known / unknown / non-string role branches. Full suite green (`yarn test`), plus `format` / `lint` / `typecheck` / `build`.

## Follow-up (separate repo)
The phone client lives in the sibling **`mulmoserver`** repo. To use these it needs matching calls: `callHost(..., "listAccountingBooks")` for the picker, and a `role` field added to its `startChat` params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expose a new remote-host command for listing accounting books and allow specifying a validated role when starting a chat over the remote command channel.

New Features:
- Add a listAccountingBooks remote-host handler that returns a minimal list of accounting books for mobile clients.
- Export listBooks and the BookSummary type from the accounting plugin server API for host-side enumeration of books outside HTTP routes.
- Allow the startChat remote-host handler to accept an optional role parameter to run chats under a selected role.

Bug Fixes:
- Validate provided role IDs against the role registry in startChat and reject unknown or non-string roles before spawning chats.

Tests:
- Add unit tests for the listAccountingBooks handler mapping and empty results.
- Extend startChat tests to cover default role behaviour, valid custom roles, and invalid role inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new remote-host command to list available accounting books (for picker-style flows).
  * Chat creation now supports selecting a role when starting a conversation.
  * Exposed accounting book listing in the accounting plugin’s public API for non-HTTP integrations.
* **Bug Fixes**
  * Improved role handling: missing/empty roles fall back to the default; unknown or debug-only roles are rejected before chat starts.
* **Tests**
  * Added coverage for the new book-listing command and role-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->