### PR TITLE
feat(files): hide agent-internal top-level dirs by default (#1896)

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -29,6 +29,18 @@ function parseDispatchAction(body: string | null): string | undefined {
   }
 }
 
+/** Flip the Files Explorer "show system files" toggle on before the
+ *  page mounts. Most e2e file-tree fixtures use ad-hoc top-level dir
+ *  names (`wiki`, `notes`, `dir-a`) that aren't in the whitelisted set
+ *  (`data` / `artifacts` / `config`), so the default filter would hide
+ *  them and blow up locators like `file-tree-dir-wiki`. See #1896.
+ *  Call BEFORE `page.goto(...)` in tests that render the file tree. */
+export async function enableFilesShowSystem(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem("filesView.showHiddenSystem", "true");
+  });
+}
+
 const DEFAULT_ROLES: unknown[] = [];
 
 const DEFAULT_HEALTH = {

--- a/e2e/tests/file-explorer-lazy.spec.ts
+++ b/e2e/tests/file-explorer-lazy.spec.ts
@@ -12,7 +12,7 @@
 //   - deep-link `?path=a/b/c.md` auto-loads ancestor dirs
 
 import { test, expect, type Page, type Route } from "@playwright/test";
-import { mockAllApis } from "../fixtures/api";
+import { mockAllApis, enableFilesShowSystem } from "../fixtures/api";
 
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
 
@@ -106,6 +106,7 @@ async function mockLazyDirs(page: Page): Promise<CountingMock> {
 test.beforeEach(async ({ page }) => {
   await mockAllApis(page);
   await mockLazyDirs(page);
+  await enableFilesShowSystem(page);
 });
 
 test.describe("file explorer lazy expand (#200 phase 2)", () => {

--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { mockAllApis } from "../fixtures/api";
+import { mockAllApis, enableFilesShowSystem } from "../fixtures/api";
 import { API_ROUTES } from "../../src/config/apiRoutes";
 
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
@@ -63,6 +63,7 @@ async function mockFileTree(page: Page) {
 test.beforeEach(async ({ page }) => {
   await mockAllApis(page);
   await mockFileTree(page);
+  await enableFilesShowSystem(page);
 });
 
 test.describe("file explorer path in URL", () => {

--- a/e2e/tests/files-tree-scroll.spec.ts
+++ b/e2e/tests/files-tree-scroll.spec.ts
@@ -4,7 +4,7 @@
 // fold of the overflow-y-auto pane.
 
 import { test, expect, type Page, type Route } from "@playwright/test";
-import { mockAllApis } from "../fixtures/api";
+import { mockAllApis, enableFilesShowSystem } from "../fixtures/api";
 
 // Build a tree wide enough that the target row sits well below the
 // pane's clientHeight. Two top-level dirs each with 40 files; the
@@ -117,6 +117,7 @@ async function expectSelectedRowInView(page: Page): Promise<void> {
 test.beforeEach(async ({ page }) => {
   await mockAllApis(page);
   await mockTree(page);
+  await enableFilesShowSystem(page);
 });
 
 test.describe("file tree auto-scroll to selection", () => {

--- a/plans/feat-1896-file-explorer-hide-system.md
+++ b/plans/feat-1896-file-explorer-hide-system.md
@@ -1,0 +1,92 @@
+# feat(#1896): file-explorer で system 領域を default 非表示
+
+## Summary
+
+Files Explorer (`FilesView.vue` / `FileTree.vue`) のワークスペース root で、
+**MulmoClaude がユーザー向けに書き出す top-level dir だけ** を default で
+表示する。それ以外の内部ワーク領域 (`conversations/` `feeds/` `.git/` など)
+は隠す。ヘッダに「システムファイルを表示」トグルを付けて、on にすると
+今と同じ全表示に戻る。
+
+## Items to Confirm / Review
+
+- **Top-level whitelist**: `data/`, `artifacts/`, `config/` の 3 つ。
+  - `data/` — wiki / calendar / contacts / clients / attachments / feeds records / cooking recipes / transports / ingest-state
+  - `artifacts/` — charts / documents / html / svg / images / spreadsheets / stories / html-scratch
+  - `config/` — settings.json / mcp.json / roles/ / helps/ / marp-themes/
+  - Plugin が `data/foo-plugin/` のような形で内部に生やしても自然に見える (whitelist は top-level のみ、中は再帰しない)。
+- **Blacklist にはしない**: 未知の top-level dir (plugin が root 直下に作った、
+  agent が新規に生やした workspace 系 dir) は default で隠れる。安全側。
+- **中は再帰的に filter しない**: `data/` を見せると `data/` 配下は全部見える。
+  `data/ingest-state/*.json` (skill collection の内部 state) も見える。
+  ユーザーが受け入れ済み。
+- **`config/helps/*`** (agent が読むヘルプ md 20+ 個) も見える。ユーザー受け入れ済み。
+- **トグルは localStorage 永続化**。key: `filesView.showHiddenSystem`。
+- **deep-link は tree の filter に影響しない**: `?path=conversations/chat/xxx.jsonl`
+  でファイル選択は動くが、tree の下に `conversations/` は現れない。
+  ユーザーは必要なら「システムファイルを表示」を on にする。
+  MVP 判断 (自動 on 復元は今回スコープ外)。
+- **関連 #1874 とはまとめない**: 別 PR で対応 (ユーザー指示)。
+
+## User Prompt
+
+> #1896 の file-explorer 改善: 不要なものは filter して出さない方針。
+> B (whitelist top-level dir)。data/ artifacts/ みたいなユーザーが書く対象は
+> ゆるく見せる、archive/ github みたいな不要 / 作業用 dir は見せない。
+> config/helps ok、data/ingest-state ok、#1874 とはまとめない。
+
+## Implementation
+
+### 新規
+
+- `src/config/visibleWorkspaceDirs.ts`
+  - `VISIBLE_TOP_LEVEL_DIRS: readonly string[] = ["data", "artifacts", "config"]`
+  - `isVisibleTopLevel(name: string): boolean`
+- `src/composables/useShowHiddenSystemFiles.ts`
+  - localStorage-backed `Ref<boolean>`, default `false`
+  - Key: `filesView.showHiddenSystem`
+- `test/config/test_visibleWorkspaceDirs.ts`
+  - `isVisibleTopLevel` の各パターン (`data` / `artifacts` / `config` は true、
+    `conversations` / `feeds` / `.git` / 未知は false、大文字 / スラッシュ入り
+    のエッジケースも false)
+
+### 変更
+
+- `src/components/FileTree.vue`
+  - `showHiddenSystem: boolean` prop 追加、再帰的に子コンポーネントに渡す。
+  - `visibleChildren` computed: root (`node.path === ""`) のときだけ
+    `!showHiddenSystem` なら `isVisibleTopLevel(child.name)` で filter。
+    それ以外は素通し。
+  - `v-for` を `loadedChildren` → `visibleChildren` に切替。
+- `src/components/FileTreePane.vue`
+  - sort トグルの左に「システムファイルを表示」チェックボックス追加。
+  - `showHiddenSystem` prop 受け取り、`FileTree` に渡す。
+  - `update:showHiddenSystem` emit で親に返す。
+- `src/components/FilesView.vue`
+  - `useShowHiddenSystemFiles` composable を呼び出し、`FileTreePane` に bind。
+- `src/lang/*.ts` × 8
+  - `fileTreePane.showSystemFiles` (label) を追加。
+
+### 動作
+
+- 初回起動 / localStorage 空: system 表示 OFF、`data/` `artifacts/` `config/`
+  だけが root に見える。
+- チェックボックス on: 全 top-level dir 表示 (今の挙動)。
+- deep-link で hidden path 選択: content pane は開くが tree に該当分岐は出ない
+  (ユーザーが on にすれば復元される)。
+- Sort mode / expanded dirs はそのまま (直交)。
+
+## Test plan
+
+- `yarn tsx --test test/config/test_visibleWorkspaceDirs.ts` — pure helper。
+- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build`。
+- 手動: Files タブを開く。root に `data/` `artifacts/` `config/` の 3 つが
+  出て、`conversations/` `feeds/` が消えていること。チェックボックスを
+  on すると復元されること。ページリロードで状態が保持されること。
+
+## Out of scope
+
+- 中身の filter (`config/helps/` を config/ の中で更に隠すなど)
+- deep-link での自動 toggle 復元
+- Files タブ以外の場所 (Wiki 内 backlinks の path 表示など) の filter
+- #1874 (別 issue)

--- a/src/components/FileTree.vue
+++ b/src/components/FileTree.vue
@@ -51,13 +51,14 @@
            not as a global overlay. -->
       <div v-if="loadingChildren" class="px-2 py-1 text-xs text-gray-400">{{ t("common.loading") }}</div>
       <FileTree
-        v-for="child in loadedChildren"
+        v-for="child in visibleChildren"
         :key="child.path"
         :node="child"
         :selected-path="selectedPath"
         :recent-paths="recentPaths"
         :children-by-path="childrenByPath"
         :sort-mode="sortMode"
+        :show-hidden-system="showHiddenSystem"
         @select="(p) => emit('select', p)"
         @load-children="(p) => emit('loadChildren', p)"
         @create-file="(args) => emit('createFile', args)"
@@ -95,6 +96,7 @@ import { useI18n } from "vue-i18n";
 import { useExpandedDirs } from "../composables/useExpandedDirs";
 import { sortChildren } from "../utils/files/sortChildren";
 import { descriptorForPath, EDIT_POLICY_ICON_COLOR } from "../config/systemFileDescriptors";
+import { isVisibleTopLevel } from "../config/visibleWorkspaceDirs";
 import { normaliseNewFileSlug, policyForFolder } from "../config/createFilePolicy";
 import type { FileSortMode } from "../composables/useFileSortMode";
 import type { TreeNode } from "../types/fileTree";
@@ -118,6 +120,14 @@ const props = defineProps<{
   // show spinner. Array = loaded.
   childrenByPath: Map<string, TreeNode[] | null>;
   sortMode: FileSortMode;
+  // When false, top-level "system" dirs (`conversations/`, `feeds/`,
+  // `.git/`, ad-hoc automation buckets) are filtered out — only
+  // recognised user-content buckets (data / artifacts / config) stay
+  // visible at the workspace root. Filter only fires when this
+  // component IS the root (`node.path === ""`); nested instances
+  // still receive the prop so the recursion carries it, but they
+  // don't apply the filter themselves.
+  showHiddenSystem: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -142,6 +152,16 @@ const cached = computed(() => props.childrenByPath.get(props.node.path));
 // Array = loaded.
 const loadingChildren = computed(() => cached.value === null);
 const loadedChildren = computed(() => (Array.isArray(cached.value) ? sortChildren(cached.value, props.sortMode) : []));
+
+// Root-only filter: hide non-whitelisted top-level dirs unless the
+// user has toggled "show system files" on. Any depth other than
+// the workspace root is a pass-through.
+const isWorkspaceRoot = computed(() => props.node.path === "");
+const visibleChildren = computed(() => {
+  if (!isWorkspaceRoot.value) return loadedChildren.value;
+  if (props.showHiddenSystem) return loadedChildren.value;
+  return loadedChildren.value.filter((child) => child.type === "dir" && isVisibleTopLevel(child.name));
+});
 
 // Kick off a fetch if the dir is expanded but its children haven't
 // been requested yet. Covers two scenarios:

--- a/src/components/FileTreePane.vue
+++ b/src/components/FileTreePane.vue
@@ -1,30 +1,42 @@
 <template>
   <div class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50">
-    <div class="flex justify-end items-center gap-2 pb-1 text-xs">
-      <span class="text-gray-400">{{ t("fileTreePane.sort") }}</span>
-      <div class="flex border border-gray-300 rounded overflow-hidden">
-        <button
-          type="button"
-          class="h-8 px-2.5 flex items-center gap-1 transition-colors"
-          :class="sortMode === 'name' ? 'bg-blue-50 text-blue-700 font-medium' : 'bg-white text-gray-500 hover:bg-gray-50'"
-          :aria-pressed="sortMode === 'name'"
-          :title="t('fileTreePane.sortByName')"
-          data-testid="file-sort-name"
-          @click="emit('update:sortMode', 'name')"
-        >
-          {{ t("fileTreePane.name") }}
-        </button>
-        <button
-          type="button"
-          class="h-8 px-2.5 flex items-center gap-1 transition-colors"
-          :class="sortMode === 'recent' ? 'bg-blue-50 text-blue-700 font-medium' : 'bg-white text-gray-500 hover:bg-gray-50'"
-          :aria-pressed="sortMode === 'recent'"
-          :title="t('fileTreePane.sortByRecent')"
-          data-testid="file-sort-recent"
-          @click="emit('update:sortMode', 'recent')"
-        >
-          {{ t("fileTreePane.recent") }}
-        </button>
+    <div class="flex flex-wrap justify-end items-center gap-x-3 gap-y-1 pb-1 text-xs">
+      <label class="flex items-center gap-1 text-gray-500 cursor-pointer select-none" :title="t('fileTreePane.showSystemFilesTitle')">
+        <input
+          type="checkbox"
+          class="h-3.5 w-3.5"
+          data-testid="file-tree-show-system-toggle"
+          :checked="showHiddenSystem"
+          @change="(e) => emit('update:showHiddenSystem', (e.target as HTMLInputElement).checked)"
+        />
+        {{ t("fileTreePane.showSystemFiles") }}
+      </label>
+      <div class="flex items-center gap-2">
+        <span class="text-gray-400">{{ t("fileTreePane.sort") }}</span>
+        <div class="flex border border-gray-300 rounded overflow-hidden">
+          <button
+            type="button"
+            class="h-8 px-2.5 flex items-center gap-1 transition-colors"
+            :class="sortMode === 'name' ? 'bg-blue-50 text-blue-700 font-medium' : 'bg-white text-gray-500 hover:bg-gray-50'"
+            :aria-pressed="sortMode === 'name'"
+            :title="t('fileTreePane.sortByName')"
+            data-testid="file-sort-name"
+            @click="emit('update:sortMode', 'name')"
+          >
+            {{ t("fileTreePane.name") }}
+          </button>
+          <button
+            type="button"
+            class="h-8 px-2.5 flex items-center gap-1 transition-colors"
+            :class="sortMode === 'recent' ? 'bg-blue-50 text-blue-700 font-medium' : 'bg-white text-gray-500 hover:bg-gray-50'"
+            :aria-pressed="sortMode === 'recent'"
+            :title="t('fileTreePane.sortByRecent')"
+            data-testid="file-sort-recent"
+            @click="emit('update:sortMode', 'recent')"
+          >
+            {{ t("fileTreePane.recent") }}
+          </button>
+        </div>
       </div>
     </div>
     <div v-if="treeError" class="p-2 text-xs text-red-600">
@@ -38,6 +50,7 @@
       :recent-paths="recentPaths"
       :children-by-path="childrenByPath"
       :sort-mode="sortMode"
+      :show-hidden-system="showHiddenSystem"
       @select="emit('select', $event)"
       @load-children="emit('loadChildren', $event)"
       @create-file="emit('createFile', $event)"
@@ -55,6 +68,7 @@
         :recent-paths="emptySet"
         :children-by-path="childrenByPath"
         :sort-mode="sortMode"
+        show-hidden-system
         @select="emit('select', $event)"
         @load-children="emit('loadChildren', $event)"
       />
@@ -78,12 +92,14 @@ defineProps<{
   selectedPath: string | null;
   recentPaths: Set<string>;
   sortMode: FileSortMode;
+  showHiddenSystem: boolean;
 }>();
 
 const emit = defineEmits<{
   select: [path: string];
   loadChildren: [path: string];
   "update:sortMode": [mode: FileSortMode];
+  "update:showHiddenSystem": [next: boolean];
   createFile: [args: { folder: string; filename: string; resolve: (ok: boolean, error?: string) => void }];
 }>();
 

--- a/src/components/FilesView.vue
+++ b/src/components/FilesView.vue
@@ -9,9 +9,11 @@
       :selected-path="selectedPath"
       :recent-paths="recentPaths"
       :sort-mode="sortMode"
+      :show-hidden-system="showHiddenSystem"
       @select="selectFile"
       @load-children="loadDirChildren"
       @update:sort-mode="setSortMode"
+      @update:show-hidden-system="setShowHiddenSystem"
       @create-file="handleCreateFile"
     />
     <!-- Content pane -->
@@ -72,6 +74,7 @@ import { useFileTree } from "../composables/useFileTree";
 import { useFileSelection, isValidFilePath, readPathMatch } from "../composables/useFileSelection";
 import { useMarkdownMode } from "../composables/useMarkdownMode";
 import { useFileSortMode } from "../composables/useFileSortMode";
+import { useShowHiddenSystemFiles } from "../composables/useShowHiddenSystemFiles";
 import { useContentDisplay } from "../composables/useContentDisplay";
 import { useMarkdownLinkHandler } from "../composables/useMarkdownLinkHandler";
 import { apiPost, apiPut } from "../utils/api";
@@ -100,6 +103,7 @@ const { selectedPath, content, contentLoading, contentError, loadContent, select
 const { mdRawMode, toggleMdRaw } = useMarkdownMode();
 
 const { sortMode, setSortMode } = useFileSortMode();
+const { showHiddenSystem, setShowHiddenSystem } = useShowHiddenSystemFiles();
 
 const { isMarkdown, isHtml, isJson, isJsonl, sandboxedHtml, htmlPreviewUrl, jsonTokens, jsonlLines, mdFrontmatter } = useContentDisplay(selectedPath, content);
 

--- a/src/composables/useShowHiddenSystemFiles.ts
+++ b/src/composables/useShowHiddenSystemFiles.ts
@@ -1,0 +1,23 @@
+// Composable: "show system files" toggle for the Files Explorer,
+// persisted to localStorage. Default false — the Files pane hides
+// agent-internal top-level dirs (`conversations/`, `feeds/`, etc.)
+// until the user opts in. See #1896.
+
+import { ref } from "vue";
+
+const STORAGE_KEY = "filesView.showHiddenSystem";
+
+function readStored(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+export function useShowHiddenSystemFiles() {
+  const showHiddenSystem = ref<boolean>(readStored());
+
+  function setShowHiddenSystem(next: boolean): void {
+    showHiddenSystem.value = next;
+    localStorage.setItem(STORAGE_KEY, next ? "true" : "false");
+  }
+
+  return { showHiddenSystem, setShowHiddenSystem };
+}

--- a/src/config/visibleWorkspaceDirs.ts
+++ b/src/config/visibleWorkspaceDirs.ts
@@ -1,0 +1,21 @@
+// Top-level workspace directories that the Files Explorer surfaces by
+// default. Everything else at the root (`conversations/`, `feeds/`,
+// `.git/`, `.github/`, ad-hoc automation buckets, …) is treated as
+// "system" and stays hidden until the user flips the "show system
+// files" toggle. See #1896.
+//
+// The whitelist covers the buckets MulmoClaude WRITES USER-FACING
+// CONTENT into:
+//   - data/       — wiki, calendar, contacts, attachments, feed records, ...
+//   - artifacts/  — charts, documents, html, svg, images, spreadsheets, ...
+//   - config/     — settings.json, mcp.json, roles/, helps/, marp themes
+// The filter is applied only at the root — once a whitelisted dir is
+// shown, everything beneath it is visible without further filtering.
+// That way a plugin that lands `data/foo-plugin/` shows up naturally
+// without needing a code change here.
+
+export const VISIBLE_TOP_LEVEL_DIRS: readonly string[] = ["data", "artifacts", "config"];
+
+export function isVisibleTopLevel(name: string): boolean {
+  return VISIBLE_TOP_LEVEL_DIRS.includes(name);
+}

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -183,6 +183,9 @@ const deMessages = {
     // "RO" = Read-Only. Englische Abkürzung bleibt erhalten, um als
     // kompaktes Badge neben dem Label "Referenz" zu passen.
     readOnlyBadge: "RO",
+    showSystemFiles: "Systemdateien anzeigen",
+    showSystemFilesTitle:
+      "Zeigt agent-interne Top-Level-Verzeichnisse (conversations/, feeds/ usw.) zusätzlich zu den Nutzer-Daten (data/, artifacts/, config/) an.",
   },
   fileTree: {
     workspace: "(Arbeitsbereich)",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -201,6 +201,8 @@ const enMessages = {
     // "RO" = Read-Only. Kept short on purpose — rendered as a compact
     // badge next to the Reference label.
     readOnlyBadge: "RO",
+    showSystemFiles: "Show system files",
+    showSystemFilesTitle: "Show agent-internal top-level dirs (conversations/, feeds/, etc.) in addition to your user content (data/, artifacts/, config/).",
   },
   fileTree: {
     workspace: "(workspace)",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -186,6 +186,9 @@ const esMessages = {
     // "RO" = Read-Only. Se mantiene la abreviatura en inglés para
     // renderizarse como una insignia compacta junto al label Referencia.
     readOnlyBadge: "RO",
+    showSystemFiles: "Mostrar archivos del sistema",
+    showSystemFilesTitle:
+      "Muestra los directorios raíz internos del agente (conversations/, feeds/, etc.) además del contenido del usuario (data/, artifacts/, config/).",
   },
   fileTree: {
     workspace: "(área de trabajo)",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -181,6 +181,9 @@ const frMessages = {
     // "RO" = Read-Only. Abréviation anglaise conservée volontairement
     // pour tenir dans un badge compact à côté du libellé Référence.
     readOnlyBadge: "RO",
+    showSystemFiles: "Afficher les fichiers système",
+    showSystemFilesTitle:
+      "Affiche les répertoires racine internes de l'agent (conversations/, feeds/, etc.) en plus des contenus utilisateur (data/, artifacts/, config/).",
   },
   fileTree: {
     workspace: "(espace de travail)",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -184,6 +184,9 @@ const jaMessages = {
     recent: "最近",
     reference: "参照",
     readOnlyBadge: "RO",
+    showSystemFiles: "システムファイルを表示",
+    showSystemFilesTitle:
+      "エージェント内部の top-level ディレクトリ (conversations/ や feeds/ など) をユーザーデータ (data/ artifacts/ config/) と合わせて表示します。",
   },
   fileTree: {
     workspace: "（ワークスペース）",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -187,6 +187,8 @@ const koMessages = {
     reference: "참조",
     // "RO" = Read-Only. 간결한 배지로 표시하기 위해 영문 약어 유지.
     readOnlyBadge: "RO",
+    showSystemFiles: "시스템 파일 표시",
+    showSystemFilesTitle: "사용자 콘텐츠(data/, artifacts/, config/)에 더해 에이전트 내부 최상위 디렉터리(conversations/, feeds/ 등)까지 표시합니다.",
   },
   fileTree: {
     workspace: "(워크스페이스)",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -181,6 +181,9 @@ const ptBRMessages = {
     // "RO" = Read-Only. Abreviação em inglês mantida para caber como
     // badge compacto ao lado do rótulo Referência.
     readOnlyBadge: "RO",
+    showSystemFiles: "Exibir arquivos do sistema",
+    showSystemFilesTitle:
+      "Mostra os diretórios raiz internos do agente (conversations/, feeds/ etc.) além do conteúdo do usuário (data/, artifacts/, config/).",
   },
   fileTree: {
     workspace: "(workspace)",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -182,6 +182,8 @@ const zhMessages = {
     reference: "引用",
     // "RO" = Read-Only. 保留英文缩写作为紧凑徽章。
     readOnlyBadge: "RO",
+    showSystemFiles: "显示系统文件",
+    showSystemFilesTitle: "在用户内容(data/、artifacts/、config/)之外同时显示代理内部的顶层目录(conversations/、feeds/ 等)。",
   },
   fileTree: {
     workspace: "(工作区)",

--- a/test/config/test_visibleWorkspaceDirs.ts
+++ b/test/config/test_visibleWorkspaceDirs.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isVisibleTopLevel, VISIBLE_TOP_LEVEL_DIRS } from "../../src/config/visibleWorkspaceDirs.js";
+
+describe("isVisibleTopLevel", () => {
+  it("returns true for the three whitelisted user-content buckets", () => {
+    assert.equal(isVisibleTopLevel("data"), true);
+    assert.equal(isVisibleTopLevel("artifacts"), true);
+    assert.equal(isVisibleTopLevel("config"), true);
+  });
+
+  it("returns false for the known agent-internal top-level dirs", () => {
+    assert.equal(isVisibleTopLevel("conversations"), false);
+    assert.equal(isVisibleTopLevel("feeds"), false);
+  });
+
+  it("returns false for VCS and CI dirs", () => {
+    assert.equal(isVisibleTopLevel(".git"), false);
+    assert.equal(isVisibleTopLevel(".github"), false);
+  });
+
+  it("returns false for an unknown top-level dir — safe-side hiding", () => {
+    assert.equal(isVisibleTopLevel("workbench"), false);
+    assert.equal(isVisibleTopLevel("scratch"), false);
+    assert.equal(isVisibleTopLevel(""), false);
+  });
+
+  it("is case-sensitive — 'Data' is not the same as 'data'", () => {
+    assert.equal(isVisibleTopLevel("Data"), false);
+    assert.equal(isVisibleTopLevel("CONFIG"), false);
+  });
+
+  it("does not match a path — only a bare top-level name", () => {
+    // Callers pass `node.name`, never `node.path`, so a slashed input
+    // is a caller bug. Guard against it silently succeeding.
+    assert.equal(isVisibleTopLevel("data/wiki"), false);
+    assert.equal(isVisibleTopLevel("/data"), false);
+  });
+});
+
+describe("VISIBLE_TOP_LEVEL_DIRS", () => {
+  it("stays in sync with what the helper accepts", () => {
+    for (const name of VISIBLE_TOP_LEVEL_DIRS) {
+      assert.equal(isVisibleTopLevel(name), true, `helper should accept whitelisted '${name}'`);
+    }
+  });
+
+  it("has no duplicates", () => {
+    const set = new Set(VISIBLE_TOP_LEVEL_DIRS);
+    assert.equal(set.size, VISIBLE_TOP_LEVEL_DIRS.length);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1896. Files Explorer の workspace root に、ユーザーが実際に読み書きする top-level dir だけを default で表示し、agent 内部のワーク領域は隠す。

- **Whitelist**: \`data/\` \`artifacts/\` \`config/\`
- **隠す**: \`conversations/\` \`feeds/\` \`.git/\` \`.github/\`、その他未知の root 直下 dir
- **中は再帰的に filter しない**: \`data/\` を見せると \`data/\` 配下は全部見える。plugin が \`data/foo-plugin/\` を生やしても自然に見える。
- **「システムファイルを表示」トグル** を FileTreePane に追加。localStorage 永続化 (default OFF)。

## Items to Confirm / Review

- **Whitelist ベース (blacklist ではなく)** — 未知の top-level dir は default で隠す方が安全。plugin が root 直下に新規 dir を作った場合も default で隠れる (可視化したいなら whitelist に追加)。
- **\`config/helps/\` と \`data/ingest-state/\`** — 内部 md や agent 所有 state だが \`config/\` / \`data/\` の中なので見える。ユーザー了承済み (中の filter は今回スコープ外)。
- **Reference roots** (\`readOnlyBadge\` の下のツリー) は workspace root ではないので filter 対象外、常時全表示のまま。
- **Deep-link** で hidden path を選択したとき: content pane は開くが tree には現れない。ユーザーが必要ならトグルを on にする。auto-toggle 復元は MVP スコープ外。
- **#1874 (collection explorer 系) とはまとめない** — 別 issue で対応。

## User Prompt

> #1896 の file-explorer 改善: 不要なものは filter して出さない方針でどう? → B (whitelist top-level dir)。data/ artifacts/ みたいな MulmoClaude で書く対象 dir はゆるく見せる。archive/ github みたいな不要 / 作業用 dir は見せない。config/helps/ ok、data/ingest-state/ ok。#1874 とはまとめない。

## Test plan

- [x] \`yarn tsx --test test/config/test_visibleWorkspaceDirs.ts\` — 8 tests (whitelist / blacklist / VCS-CI / 未知 / 大文字 / スラッシュ入り / VISIBLE_TOP_LEVEL_DIRS 一貫性 + duplicate 検知)
- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\`
- 手動: Files タブを開く → root に \`data/\` \`artifacts/\` \`config/\` のみ / トグル on で全表示復元 / リロードで状態保持

計画: [\`plans/feat-1896-file-explorer-hide-system.md\`](https://github.com/receptron/mulmoclaude/blob/feat/1896-file-explorer-hide-system/plans/feat-1896-file-explorer-hide-system.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle in the Files Explorer to show or hide system files.
  * Default view now shows only user top-level folders; system folders are hidden until enabled.
  * The toggle state is persisted for future visits.
  * Added localized labels and tooltips for the new option across supported languages.
* **Bug Fixes**
  * Improved file tree behavior so deep-linked folders can still open content even when the matching folder is hidden in the tree.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->