### PR TITLE
fix(client): auto-recover from stale auth token instead of surfacing a raw 401

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -72,6 +72,62 @@ export function setAuthToken(token: string | null): void {
   authToken = token;
 }
 
+// ── Stale-token recovery ─────────────────────────────────────────────
+//
+// The server mints a fresh session token at every boot and embeds it
+// into index.html's `<meta name="mulmoclaude-auth">`. A tab that was
+// loaded BEFORE a server restart keeps sending the old bearer, so every
+// call 401s until the user figures out a manual reload — the raw
+// `Server error 401 {"error":"unauthorized"}` bubble gives no hint.
+//
+// Instead: on the first 401 we re-fetch "/" (no-store), pull the
+// CURRENT token out of the served HTML, swap it in, and retry the
+// request once. The refresh is single-flight so a burst of concurrent
+// 401s (boot fires many fetches) triggers exactly one "/" round trip.
+//
+// The meta tag is parsed with a regex rather than DOMParser on purpose:
+// this module deliberately avoids DOM lib globals (see the fetch-types
+// comment above). The attribute order is stable — it comes from our own
+// index.html template.
+
+const AUTH_META_RE = /<meta\s+name="mulmoclaude-auth"\s+content="([^"]*)"/;
+
+let tokenRefreshInflight: Promise<boolean> | null = null;
+
+/** Re-read the auth token from the served index.html. Resolves true
+ *  iff a non-empty token DIFFERENT from the current one was installed
+ *  (i.e. a retry is worth attempting). */
+function refreshStaleAuthToken(): Promise<boolean> {
+  tokenRefreshInflight ??= (async () => {
+    try {
+      const res = await fetch("/", { cache: "no-store", credentials: "same-origin" });
+      if (!res.ok) return false;
+      const fresh = AUTH_META_RE.exec(await res.text())?.[1] ?? "";
+      if (fresh === "" || fresh === authToken) return false;
+      authToken = fresh;
+      return true;
+    } catch {
+      return false;
+    } finally {
+      // Re-arm for the future — the token can rotate again on the
+      // next server restart. Deferred so every awaiter of THIS
+      // refresh shares the same result first.
+      queueMicrotask(() => {
+        tokenRefreshInflight = null;
+      });
+    }
+  })();
+  return tokenRefreshInflight;
+}
+
+/** A body we can safely send twice. Streams are consumed by the first
+ *  attempt and must not be replayed; everything MulmoClaude actually
+ *  sends (JSON strings, FormData, Blob, undefined) is replayable. */
+function isReplayableBody(body: unknown): boolean {
+  if (body === undefined || body === null || typeof body === "string") return true;
+  return typeof (body as { getReader?: unknown }).getReader !== "function";
+}
+
 // ── Types ────────────────────────────────────────────────────────────
 
 export type ApiResult<T> = { ok: true; data: T } | { ok: false; error: string; status: number };
@@ -193,6 +249,18 @@ export async function apiCall<T = unknown>(path: string, opts: ApiOptions = {}):
     lastBackendError.value = null;
   }
 
+  if (res.status === 401 && (await refreshStaleAuthToken())) {
+    // Token was stale (server restarted since this tab loaded). A
+    // fresh one is installed — replay the request once. JSON bodies
+    // are plain strings, so resending `init` verbatim is safe.
+    init.headers = buildHeaders(opts, hasBody);
+    try {
+      res = await fetch(url, init);
+    } catch (err) {
+      return { ok: false, error: errorMessage(err), status: 0 };
+    }
+  }
+
   if (!res.ok) {
     const { error, status } = await extractError(res);
     return { ok: false, error, status };
@@ -260,5 +328,14 @@ export async function apiFetchRaw(path: string, opts: RawOptions = {}): Promise<
     body: opts.body,
     signal: opts.signal,
   };
-  return fetch(url, init);
+  const res = await fetch(url, init);
+  // Same stale-token recovery as apiCall — this path carries the chat
+  // send (`POST /api/agent`, SSE), which is exactly where users see the
+  // raw 401 bubble after a server restart. Streams can't be replayed;
+  // everything else (JSON strings, FormData, Blob) can.
+  if (res.status === 401 && isReplayableBody(opts.body) && (await refreshStaleAuthToken())) {
+    init.headers = buildHeaders(opts, false);
+    return fetch(url, init);
+  }
+  return res;
 }

--- a/test/utils/test_api.ts
+++ b/test/utils/test_api.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { apiCall, apiGet, apiPost, apiPut, apiDelete, backendReachable, lastBackendError, setAuthToken } from "../../src/utils/api.ts";
+import { apiCall, apiGet, apiPost, apiPut, apiDelete, apiFetchRaw, backendReachable, lastBackendError, setAuthToken } from "../../src/utils/api.ts";
 
 // fetch mocking. Capture the URL + init passed by the api module, and
 // reply with a pre-scripted response. Each test installs its own mock
@@ -245,5 +245,80 @@ describe("apiCall — backendReachable signal", () => {
     assert.equal(result.ok, false);
     assert.equal(backendReachable.value, true);
     assert.equal(lastBackendError.value, null);
+  });
+});
+
+describe("stale-token recovery (401 → re-read token from index.html → retry once)", () => {
+  // Sequenced mock: each call shifts the next scripted response.
+  // Needed here because recovery involves three different exchanges
+  // (401 from the API, "/" serving fresh HTML, then the replay).
+  let seq: Response[] = [];
+  function installSeqMock(): void {
+    calls = [];
+    globalThis.fetch = ((url, init) => {
+      calls.push({ url: String(url), init });
+      const next = seq.shift() ?? new Response("", { status: 599 });
+      return Promise.resolve(next);
+    }) as typeof fetch;
+  }
+  afterEach(() => {
+    restoreMock();
+    setAuthToken(null);
+  });
+
+  function htmlWithToken(token: string): Response {
+    return new Response(`<!doctype html><head><meta name="mulmoclaude-auth" content="${token}" /></head>`, {
+      status: 200,
+      headers: { "Content-Type": "text/html" },
+    });
+  }
+
+  it("apiCall retries once with the fresh token and succeeds", async () => {
+    setAuthToken("stale-token");
+    installSeqMock();
+    seq = [jsonResponse(401, { error: "unauthorized" }), htmlWithToken("fresh-token"), jsonResponse(200, { fine: true })];
+
+    const result = await apiCall<{ fine: boolean }>("/api/anything");
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.length, 3);
+    assert.equal(calls[1].url, "/");
+    assert.equal(getHeader(calls[2], "Authorization"), "Bearer fresh-token");
+  });
+
+  it("does not retry when the served token is unchanged (genuine 401)", async () => {
+    setAuthToken("same-token");
+    installSeqMock();
+    seq = [jsonResponse(401, { error: "unauthorized" }), htmlWithToken("same-token")];
+
+    const result = await apiCall("/api/anything");
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 401);
+    assert.equal(calls.length, 2);
+  });
+
+  it("surfaces the original 401 when the token refetch itself fails", async () => {
+    setAuthToken("stale-token");
+    installSeqMock();
+    seq = [jsonResponse(401, { error: "unauthorized" }), new Response("", { status: 500 })];
+
+    const result = await apiCall("/api/anything");
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 401);
+    assert.equal(calls.length, 2);
+  });
+
+  it("apiFetchRaw (chat send path) recovers the same way", async () => {
+    setAuthToken("stale-token");
+    installSeqMock();
+    seq = [jsonResponse(401, { error: "unauthorized" }), htmlWithToken("fresh-token"), jsonResponse(200, { streaming: "ok" })];
+
+    const res = await apiFetchRaw("/api/agent", { method: "POST", body: JSON.stringify({ message: "hi" }) });
+
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 3);
+    assert.equal(getHeader(calls[2], "Authorization"), "Bearer fresh-token");
   });
 });


### PR DESCRIPTION
## Problem

The server mints a fresh session token at every boot and embeds it into `index.html`'s `<meta name="mulmoclaude-auth">`. A tab loaded **before** a server restart keeps sending the old bearer, so every request fails with an opaque `[Error] Server error 401: {"error":"unauthorized"}` bubble in the chat until the user happens to guess that a manual reload fixes it. (Hit this in real usage today — the tab had survived a server restart from the previous day.)

## Fix

On the first 401, re-fetch `/` with `cache: no-store`, extract the **current** token from the served HTML, install it into the existing module-level `authToken`, and replay the request once.

- **Single-flight**: a burst of concurrent 401s (app boot fires many fetches) triggers exactly one `/` round trip; all callers share its result.
- **Both paths covered**: `apiCall` and `apiFetchRaw` — the latter carries the chat send (`POST /api/agent`, SSE), which is exactly where users see the bubble.
- **Genuine 401s unchanged**: if the served token equals the current one (or the refetch fails), the original 401 surfaces exactly as before — no retry loop.
- **Streams are never replayed**; JSON strings / FormData / Blob bodies are.
- Regex over the fetched HTML instead of DOMParser, keeping this module free of DOM-lib globals (matches the existing `Parameters<typeof fetch>` convention).

## Tests

- 4 new cases in `test/utils/test_api.ts` (sequenced fetch mock): successful recovery with fresh-token retry, no-retry on unchanged token, refetch failure surfaces original 401, and the `apiFetchRaw` chat-send path. Full suite: 22/22 pass.
- Manual E2E on a production-mode build: load tab → restart server (token rotates) → send a chat message from the stale tab → message succeeds with no 401 bubble.

## Out of scope

The socket.io pubsub connection is untouched; if WS ever adopts bearer auth it would need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjKt7R3HEHmLVDm8R2YncC

## Summary by Sourcery

Automatically recover from stale auth tokens on 401 responses by refreshing the token from index.html and retrying once, improving resilience across server restarts.

Bug Fixes:
- Prevent stale session tokens from causing persistent 401 errors in existing tabs after a server restart by refreshing the token and replaying affected requests once.

Enhancements:
- Apply stale-token recovery to both high-level API calls and raw fetch-based chat send requests while avoiding replay of non-replayable request bodies.
- Implement single-flight token refresh to ensure concurrent 401s share a single index.html refetch result.

Tests:
- Add sequenced fetch-mock tests covering successful recovery with a fresh token, unchanged-token behavior as a genuine 401, refetch failure surfacing the original 401, and the apiFetchRaw chat-send path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when an authentication token becomes outdated.
  * Automatically retries certain failed requests after refreshing credentials, reducing unexpected sign-in failures.
  * Added support for the same recovery flow in raw API requests when it is safe to retry.

* **Tests**
  * Expanded coverage for token refresh and retry behavior, including success, unchanged token, failed refresh, and raw request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->