### PR TITLE
fix(test): Windows cross-platform path bugs failing lint_test_windows

### DIFF
--- a/test/chat-index/test_paths.ts
+++ b/test/chat-index/test_paths.ts
@@ -23,9 +23,11 @@ const workspace = path.join(path.sep, "tmp", "ws");
 
 // The chat dir is sourced from WORKSPACE_DIRS.chat so the layout
 // move in #284 (`chat/` → `conversations/chat/`) can't silently
-// drift again. `CHAT_REL` reflects the current on-disk relative
-// path used by every joined-path expectation below.
-const CHAT_REL = path.join("conversations", "chat");
+// drift again. Keep this the POSIX `/` literal (as WORKSPACE_DIRS
+// stores it) rather than `path.join`, so the direct `CHAT_DIR`
+// equality below holds on Windows too; the joined expectations feed
+// it through `path.join`, which normalises the separator per platform.
+const CHAT_REL = "conversations/chat";
 
 describe("constants", () => {
   it("exports expected directory and file name constants", () => {

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -8,6 +8,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import nodeOs from "node:os";
 import * as sync from "../../../scripts/mulmoclaude/launcherSync.mjs";
 
@@ -320,7 +321,7 @@ describe("auditLauncherSync — invariant 5: gui-chat-protocol peer dep lockstep
 
 describe("auditLauncherSync — repo self-check", () => {
   it("finds no failing findings against the real repo (post PR #1921)", async () => {
-    const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..", "..");
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
     const findings = await sync.auditLauncherSync({ root: repoRoot });
     const failing = findings.filter((finding) => finding.kind !== "skipped");
     const rendered = failing.map((finding) => `  [${finding.kind}] ${finding.message}`).join("\n");


### PR DESCRIPTION
## Summary
`lint_test_windows` (`yarn test:coverage`) has been **red on every recent main push** (#1961, #1962, #1957, #1963, core@0.8.2) due to two pre-existing Windows-only test bugs. Both are green on POSIX. This fixes both so the Windows job goes green.

## Items to Confirm / Review
- Both fixes are in **test files only** — no product-code behavior changes.
- Fix relies on `path.join` normalising a `/`-form relative path per-platform (true on Node) — confirm that assumption reads fine.
- I can't run Windows locally; verified green on macOS + reasoned through the Windows path semantics. The real check is this PR's Windows CI.

## Root causes
1. **`test/chat-index/test_paths.ts`** — `CHAT_REL = path.join("conversations", "chat")` becomes `conversations\chat` on Windows, but `CHAT_DIR = WORKSPACE_DIRS.chat` is the canonical POSIX literal `conversations/chat`, so the direct `assert.equal(CHAT_DIR, CHAT_REL)` failed. Fixed by comparing against the `/` literal; the joined-path expectations still pass through `path.join` and normalise per platform.
2. **`test/scripts/mulmoclaude/test_launcherSync.ts`** — `new URL(import.meta.url).pathname` yields `/D:/…` on Windows; `path.resolve` then treats the leading slash as drive-relative and prepends the current drive → `D:\D:\…\package.json` → `ENOENT`. Fixed with `fileURLToPath(import.meta.url)` (the `node:url` conversion the repo's cross-platform rule already mandates).

## User Prompt
> これ直せる？ (pointing at the failing `lint_test_windows` job https://github.com/receptron/mulmoclaude/actions/runs/28697400041/job/85109364411)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Windows-only path handling issues in test suites so lint_test_windows passes reliably.

Bug Fixes:
- Resolve mismatch between POSIX-literal and joined chat workspace paths causing Windows assertions to fail.
- Fix repo root resolution in launcherSync tests by using fileURLToPath for cross-platform URL-to-path conversion.

Tests:
- Adjust chat index path constant to use a stable POSIX literal while keeping joined-path expectations platform-normalized.
- Update launcherSync repo self-check test to derive the repository root via fileURLToPath for Windows compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test consistency on Windows and POSIX systems.
  * Updated path handling in test checks to avoid separator-related mismatches and better reflect actual filesystem behavior.
  * Strengthened a repository self-check test by using a more reliable way to derive paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->