### PR TITLE
fix(collections): 409 on file-ancestor import path is Windows-safe

### DIFF
--- a/packages/core/src/collection/registry/server/importWriter.ts
+++ b/packages/core/src/collection/registry/server/importWriter.ts
@@ -59,12 +59,33 @@ async function statType(target: string): Promise<"dir" | "other" | "absent"> {
   try {
     return (await stat(target)).isDirectory() ? "dir" : "other";
   } catch (err) {
-    // Only a genuinely missing path is "absent". ENOTDIR (an ancestor is a file),
-    // EACCES, etc. are path-shape conflicts that mkdir would later throw on, so
-    // surface them as "other" for deterministic 409 handling.
-    if (isRecord(err) && err.code === "ENOENT") return "absent";
-    return "other";
+    // EACCES etc. are path-shape conflicts mkdir would later throw on → "other".
+    // A file ancestor surfaces as ENOTDIR on POSIX but ENOENT on Windows (which
+    // reports the whole path as missing), so ENOENT can't be trusted as "absent"
+    // until we've confirmed no existing ancestor is a non-directory file.
+    if (!(isRecord(err) && err.code === "ENOENT")) return "other";
+    return (await hasNonDirAncestor(target)) ? "other" : "absent";
   }
+}
+
+// Walk up from `target` to the nearest ancestor that exists: a non-directory
+// file there means `target` can never be mkdir'd (a path-shape conflict → 409),
+// whichever errno the platform's `stat(target)` chose. An all-absent-or-directory
+// chain up to the filesystem root is a genuine "absent".
+async function hasNonDirAncestor(target: string): Promise<boolean> {
+  let current = path.dirname(target);
+  while (current !== path.dirname(current)) {
+    try {
+      return !(await stat(current)).isDirectory();
+    } catch (err) {
+      if (isRecord(err) && err.code === "ENOENT") {
+        current = path.dirname(current);
+        continue;
+      }
+      return true;
+    }
+  }
+  return false;
 }
 
 async function isEmptyOrAbsentDir(target: string): Promise<boolean> {
@@ -368,4 +389,4 @@ export async function performImport(author: string, slug: string, workspaceRoot:
 
 // Exported for downstream code that wants the path conventions without
 // importing skill-bridge directly.
-export { claudeSkillDir, dataSkillDir };
+export { claudeSkillDir, dataSkillDir, hasNonDirAncestor };

--- a/packages/core/test/collection-registry/test_importWriter.ts
+++ b/packages/core/test/collection-registry/test_importWriter.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync
 import path from "node:path";
 import { tmpdir } from "node:os";
 
-import { writeImportedCollection, claudeSkillDir, dataSkillDir } from "../../src/collection/registry/server/importWriter.ts";
+import { writeImportedCollection, claudeSkillDir, dataSkillDir, hasNonDirAncestor } from "../../src/collection/registry/server/importWriter.ts";
 import type { RegistryEntry } from "../../src/collection/registry/registryIndex.ts";
 
 // `registryName` is the short label the multi-registry refactor passes through
@@ -320,5 +320,33 @@ describe("writeImportedCollection", () => {
     assert.ok(!existsSync(backup), "leftover backup dir removed");
     assert.ok(existsSync(path.join(sourceDir(wsRoot), "SKILL.md")));
     assert.ok(existsSync(path.join(mirrorDir(wsRoot), "SKILL.md")));
+  });
+});
+
+// The ENOENT branch of `statType` is invisible to the integration tests on
+// POSIX (there a file ancestor yields ENOTDIR, not ENOENT) — but it IS the path
+// Windows takes for the same layout. Test `hasNonDirAncestor` directly so every
+// runner covers the logic that turns a file-ancestor conflict into a 409.
+describe("hasNonDirAncestor", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mc-ancestor-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("true when an ancestor of the target is a non-directory file", async () => {
+    writeFileSync(path.join(root, "a"), "i am a file");
+    assert.equal(await hasNonDirAncestor(path.join(root, "a", "b", "c")), true);
+  });
+
+  it("false when the whole existing ancestor chain is directories", async () => {
+    mkdirSync(path.join(root, "a", "b"), { recursive: true });
+    assert.equal(await hasNonDirAncestor(path.join(root, "a", "b", "c")), false);
+  });
+
+  it("false when the target is genuinely absent under an existing directory", async () => {
+    assert.equal(await hasNonDirAncestor(path.join(root, "missing", "deep", "leaf")), false);
   });
 });


### PR DESCRIPTION
## Summary
The latest `lint_test_windows` run (post #1965) failed in `test:coverage` on
`writeImportedCollection › returns 409 when an ancestor of the data path is a
non-directory file` — a **Windows-only** failure (absent from the prior run →
flaky, because Windows inconsistently reports the layout). Root cause + fix below.

## Items to Confirm / Review
- Product-code change is one branch in `statType` + a new `hasNonDirAncestor` helper — **POSIX behaviour is unchanged** (the ENOTDIR path still short-circuits to `"other"`); please sanity-check that claim.
- I can't run Windows locally: verified POSIX-green (18/18 incl. the new unit test) + reasoned through the errno difference. The real check is this PR's Windows CI — but note `lint_test_windows` runs on **main-push / daily**, not on PRs, so it confirms only after merge.

## Root cause
`statType(dataDir)` maps a `stat` error to `absent`/`other` to decide whether an
import target is a path-shape conflict (→ 409). It assumed a **file ancestor**
surfaces as `ENOTDIR`. That holds on POSIX, but **Windows returns `ENOENT`** for
`stat("…/movies/items")` when `movies` is a file — so it was treated as `"absent"`,
the 409 pre-flight was skipped, and `materializeSeed`'s `mkdir` later threw an
uncaught `ENOTDIR`.

## Fix
On `ENOENT`, walk up to the nearest existing ancestor via `hasNonDirAncestor`: a
non-directory file there is a conflict → `"other"` → 409, regardless of which
errno the platform chose for `stat(target)`. Handles both `ENOENT` (Windows) and
`ENOTDIR` (POSIX) deterministically. Added a direct unit test for the helper so
every runner (not just Windows) exercises the fixed branch.

## User Prompt
> https://github.com/receptron/mulmoclaude/actions/runs/28698205702 直せる？

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure collection imports treat file-ancestor path conflicts consistently across POSIX and Windows so they reliably return 409 instead of failing later during directory creation.

Bug Fixes:
- Fix Windows-only handling of import paths whose ancestors are files by correctly classifying them as path-shape conflicts rather than absent directories.

Enhancements:
- Introduce a reusable helper to detect non-directory ancestors and export it for downstream path validation logic.

Tests:
- Add unit tests for the non-directory ancestor detection helper to exercise the Windows-specific error handling branch on all platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or inaccessible paths so missing locations are identified more accurately.
  * Reduced false “missing path” results when an existing non-folder item blocks the target path, leading to clearer and more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->