### PR TITLE
chore(release): mulmoclaude@0.9.4

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Launcher npm release **mulmoclaude@0.9.4** (patch from 0.9.3). Already published to npm and verified — this PR records the version-bump commit (the release identity per the `/publish-mulmoclaude` flow).

Bumps **only** `packages/mulmoclaude/package.json`'s own `version` (the bin reads it dynamically). No `@mulmobridge/*` cascade — drift check clean.

## Items to Confirm / Review
- Single-line change: `version 0.9.3 → 0.9.4`. No dep-range or workspace-package changes.
- 0.9.4 was previously *drafted then rolled back to 0.9.3* (commit `25248c4b`, per the #1945 anti-pattern), so it had never actually shipped — `npm publish` of 0.9.4 succeeded with no collision.

## Pre-publish checks (all green)
| Check | Result |
|---|---|
| Smoke CI on `main` (go/no-go) | ✅ green |
| §1 deps audit (`deps.mjs`) | ✅ no missing deps |
| §2 workspace drift (`drift.mjs`) | ✅ chat-service 0.1.7 / client 0.1.5 / protocol 0.1.4 all match published |
| §3 build | ✅ |
| §3.5 README | ✅ current & accurate (flags/bridges/env verified) |
| §4 tarball boot (`smoke.mjs`) | ✅ HTTP 200 from packed tarball |
| Post-publish `npx mulmoclaude@0.9.4 --version` | ✅ `mulmoclaude 0.9.4` |

## User Prompt
> /publish-mulmoclaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to `0.9.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->