### PR TITLE
fix(sandbox): resolve @mulmoclaude/* in Docker on Windows via NODE_PATH fallback (#1946)

### DIFF
--- a/plans/fix-1946-windows-docker-sandbox-mcp.md
+++ b/plans/fix-1946-windows-docker-sandbox-mcp.md
@@ -1,0 +1,56 @@
+# fix(#1946): Windows Docker sandbox MCP server — dangling yarn-workspace junctions
+
+Issue: #1946 (Windows + Docker sandbox ON, `mcp-server.ts` crashes → `handlePermission not found`)
+
+## Root cause (confirmed in-container)
+
+On Windows, yarn workspaces write `node_modules/@mulmoclaude/*` as **absolute** junctions
+(`fs.symlink(..., "junction")` normalises the target to an absolute host path). Docker Desktop
+surfaces them as `/mnt/host/c/Users/<user>/.../packages/<name>`, a path that does not exist in the
+Linux container → the symlinks **dangle**. The MCP child (`tsx /app/server/agent/mcp-server.ts`)
+imports `@mulmoclaude/x-plugin` + `@mulmoclaude/core/*` at load, hits `MODULE_NOT_FOUND`, and dies
+before the initialize handshake → zero `mulmoclaude__*` tools registered → `handlePermission not found`.
+`DISABLE_SANDBOX=1` works because the child runs on the host where the junctions resolve.
+
+macOS/Linux are unaffected: there the links are **relative** (`../../packages/core`), which resolve
+to `/app/packages/core` — both `node_modules` and `packages/` are bind-mounted.
+
+Affected: all 14 `@mulmoclaude/*` packages (`core` + 13 `packages/plugins/*`).
+
+## Fix — approach A′ (NODE_PATH fallback root)
+
+Docker already runs the MCP child with `NODE_PATH=/app/node_modules` and tsx emits CJS in-container,
+so NODE_PATH is honoured. Extend that mechanism instead of touching the dangling junctions.
+
+1. **`buildDockerSpawnArgs`** — when `platform === "win32"` AND `packages/` exists (source/dev build),
+   add one bind mount per workspace package at a junction-free scoped root:
+   `-v <pkgDir>:/app/pkg_modules/@mulmoclaude/<name>:ro`.
+   The scoped `<name>` is read from each package's `package.json` (robust vs. dir-name assumptions;
+   also filters to `@mulmoclaude/*` only).
+2. **`buildMulmoclaudeServer`** — set the Docker `NODE_PATH` to `/app/node_modules:/app/pkg_modules`.
+
+Windows: primary `/app/node_modules/@mulmoclaude/core` dangles → CJS resolution treats it as absent and
+falls through to `/app/pkg_modules/@mulmoclaude/core` (real). Subpath exports (`@mulmoclaude/core/collection/server`)
+resolve via the located package's `exports` map. Cross-package `@mulmoclaude/*` imports resolve the same way.
+
+Non-Windows / npx: `/app/pkg_modules` is never mounted, so the extra NODE_PATH entry is a no-op; behaviour
+is byte-identical. npx installs have real `node_modules/@mulmoclaude/*` and no `packages/` dir → gated out.
+
+### Why not the alternatives
+- **A (overlay real dirs onto `/app/node_modules/@mulmoclaude/<name>`)** — bind-mounting over a dangling
+  symlink target is Docker-version-dependent (may fail / land elsewhere); issue flags it "要検証".
+- **Entrypoint re-link** — needs a writable node_modules overlay (weakens the read-only security posture)
+  and a Dockerfile change.
+
+## Tests
+- `test/agent/test_agent_config.ts` — unit-test the argv: on `win32` (temp `packageRoot` with fake
+  `packages/core` + a plugin) the `/app/pkg_modules/@mulmoclaude/*` mounts appear; on `darwin`/`linux`
+  they do not. Assert `NODE_PATH` includes `/app/pkg_modules` in the docker server config.
+- `test/agent/test_mcp_docker_smoke.ts` (docker-gated, Linux CI) — add a case that shadows
+  `/app/node_modules/@mulmoclaude` with an empty tmpfs (simulating the Windows dangle) + adds the
+  `pkg_modules` mounts + extended NODE_PATH, and asserts `initialize` + non-empty `tools/list` still
+  succeed. This proves the fallback actually resolves without needing a Windows host.
+
+## Verification constraint
+Windows-only bug; final confirmation needs @ystknsh's Windows machine. Local coverage: argv unit tests
++ (if docker present) the Linux fallback-simulation smoke test.

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -2,7 +2,7 @@ import { basename, dirname, join } from "path";
 import { homedir, tmpdir } from "os";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import type { Role } from "../../src/config/roles.js";
 import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { getActiveToolDescriptors } from "./activeTools.js";
@@ -17,6 +17,15 @@ import { log } from "../system/logger/index.js";
 import { preflightUserServers, logPreflightResult } from "./mcpPreflight.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
+
+// Junction-free NODE_PATH fallback root for the in-container MCP child.
+// On Windows the yarn-workspace `node_modules/@mulmoclaude/*` links are
+// absolute junctions that dangle inside the Linux container (#1946), so
+// each workspace package is also bind-mounted here as
+// `@mulmoclaude/<name>` and this dir is appended to NODE_PATH — CJS
+// resolution falls through to it when the primary link fails to resolve.
+// Only mounted for win32 source builds; a no-op path elsewhere.
+const CONTAINER_WORKSPACE_MODULES_PATH = "/app/pkg_modules";
 
 // `Skill` is the tool Claude Code uses to execute a discovered
 // `.claude/skills/<name>/SKILL.md`. Because `--allowedTools` is passed
@@ -282,7 +291,7 @@ function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; a
   const dockerEnv = useDocker
     ? {
         MCP_HOST: "host.docker.internal",
-        NODE_PATH: "/app/node_modules",
+        NODE_PATH: `/app/node_modules:${CONTAINER_WORKSPACE_MODULES_PATH}`,
         ...collectMcpToolSentinelEnv(),
       }
     : {};
@@ -582,6 +591,45 @@ export interface DockerSpawnArgsParams {
   sshAgentForward?: boolean;
 }
 
+// The workspace-package dirs that ship as `@mulmoclaude/*` — `packages/core`
+// plus every `packages/plugins/*`. Source/dev layout only (npx installs have
+// no `packages/`), so an absent dir yields an empty list.
+function workspacePackageDirs(packageRoot: string): string[] {
+  const core = join(packageRoot, "packages", "core");
+  const pluginsDir = join(packageRoot, "packages", "plugins");
+  const plugins = existsSync(pluginsDir)
+    ? readdirSync(pluginsDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => join(pluginsDir, entry.name))
+    : [];
+  return [core, ...plugins].filter((dir) => existsSync(join(dir, "package.json")));
+}
+
+// The `@mulmoclaude/<name>` a package declares, or null if it isn't one of
+// ours / is unreadable — a malformed package.json never breaks a spawn.
+function scopedPackageName(pkgDir: string): string | null {
+  try {
+    const { name } = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8")) as { name?: unknown };
+    return typeof name === "string" && name.startsWith("@mulmoclaude/") ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+// Windows-only bind mounts giving the in-container MCP child a junction-free
+// copy of each `@mulmoclaude/*` package under CONTAINER_WORKSPACE_MODULES_PATH
+// (#1946 — the yarn-workspace junctions dangle inside the Linux container).
+// Empty on every other platform and on npx installs (no `packages/`).
+function workspaceModuleMounts(packageRoot: string, platform: Platform, toDockerPath: (hostPath: string) => string): string[] {
+  if (platform !== "win32") return [];
+  const mounts: string[] = [];
+  for (const dir of workspacePackageDirs(packageRoot)) {
+    const name = scopedPackageName(dir);
+    if (name) mounts.push("-v", `${toDockerPath(dir)}:${CONTAINER_WORKSPACE_MODULES_PATH}/${name}:ro`);
+  }
+  return mounts;
+}
+
 // Pure helper that returns the full `docker run ... claude <args>`
 // argv array. Extracted from runAgent so the long flag list can be
 // inspected and tested without spawning a real subprocess.
@@ -673,6 +721,7 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     "-v",
     `${toDockerPath(packageRoot)}/src:/app/src:ro`,
     ...packagesMount,
+    ...workspaceModuleMounts(packageRoot, platform, toDockerPath),
     "-v",
     `${toDockerPath(workspacePath)}:${CONTAINER_WORKSPACE_PATH}`,
     "-v",

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -1,6 +1,6 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, unlinkSync } from "fs";
+import { existsSync, unlinkSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { __resetForTests as resetTokenState, generateAndWriteToken } from "../../server/api/auth/token.js";
@@ -51,6 +51,22 @@ describe("buildMcpConfig", () => {
     const server = servers.mulmoclaude as Record<string, unknown>;
     const env = server.env as Record<string, string>;
     assert.equal(env.PLUGIN_NAMES, "");
+  });
+
+  function dockerServerEnv(): Record<string, string> {
+    const config = buildMcpConfig({ chatSessionId: "s", port: 3001, activePlugins: [], useDocker: true }) as Record<string, unknown>;
+    const server = (config.mcpServers as Record<string, unknown>).mulmoclaude as Record<string, unknown>;
+    return server.env as Record<string, string>;
+  }
+
+  it("docker NODE_PATH includes the junction-free workspace-modules fallback root (#1946)", async () => {
+    assert.equal(dockerServerEnv().NODE_PATH, "/app/node_modules:/app/pkg_modules");
+  });
+
+  it("native (non-docker) server carries no NODE_PATH", async () => {
+    const config = buildMcpConfig({ chatSessionId: "s", port: 3001, activePlugins: [], useDocker: false }) as Record<string, unknown>;
+    const server = (config.mcpServers as Record<string, unknown>).mulmoclaude as Record<string, unknown>;
+    assert.equal((server.env as Record<string, string>).NODE_PATH, undefined);
   });
 });
 
@@ -342,6 +358,56 @@ describe("buildDockerSpawnArgs", () => {
     });
     // No mount line referring to /app/packages should appear.
     assert.ok(!args.some((token) => token.includes(":/app/packages:")));
+  });
+
+  // #1946: Windows yarn-workspace junctions dangle inside the Linux
+  // container, so on win32 source builds each @mulmoclaude/* package is
+  // also bind-mounted at a junction-free /app/pkg_modules/@mulmoclaude/<name>
+  // that NODE_PATH falls through to.
+  function seedWorkspacePackages(root: string): void {
+    mkdirSync(join(root, "packages", "core"), { recursive: true });
+    writeFileSync(join(root, "packages", "core", "package.json"), JSON.stringify({ name: "@mulmoclaude/core" }));
+    mkdirSync(join(root, "packages", "plugins", "x-plugin"), { recursive: true });
+    writeFileSync(join(root, "packages", "plugins", "x-plugin", "package.json"), JSON.stringify({ name: "@mulmoclaude/x-plugin" }));
+    // A non-@mulmoclaude leaf lib in the same tree must NOT be mounted.
+    mkdirSync(join(root, "packages", "plugins", "leaf-lib"), { recursive: true });
+    writeFileSync(join(root, "packages", "plugins", "leaf-lib", "package.json"), JSON.stringify({ name: "some-leaf" }));
+  }
+
+  it("win32 source build mounts each @mulmoclaude/* at /app/pkg_modules, skipping non-scoped packages (#1946)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-pkgroot-"));
+    try {
+      seedWorkspacePackages(root);
+      const args = buildDockerSpawnArgs({ ...baseParams(), platform: "win32" as Platform, packageRoot: root });
+      const toDocker = (hostPath: string): string => hostPath.replace(/\\/g, "/");
+      assert.ok(args.includes(`${toDocker(join(root, "packages", "core"))}:/app/pkg_modules/@mulmoclaude/core:ro`));
+      assert.ok(args.includes(`${toDocker(join(root, "packages", "plugins", "x-plugin"))}:/app/pkg_modules/@mulmoclaude/x-plugin:ro`));
+      assert.ok(!args.some((token) => token.includes("/app/pkg_modules/some-leaf")));
+      assert.ok(!args.some((token) => token.includes("leaf-lib:/app/pkg_modules")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT add /app/pkg_modules mounts on non-Windows platforms", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-pkgroot-"));
+    try {
+      seedWorkspacePackages(root);
+      const args = buildDockerSpawnArgs({ ...baseParams(), platform: "darwin" as Platform, packageRoot: root });
+      assert.ok(!args.some((token) => token.includes(":/app/pkg_modules/")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("win32 npx install (no packages/ dir) adds no /app/pkg_modules mounts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-pkgroot-"));
+    try {
+      const args = buildDockerSpawnArgs({ ...baseParams(), platform: "win32" as Platform, packageRoot: root });
+      assert.ok(!args.some((token) => token.includes(":/app/pkg_modules/")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   // The package bin script (`npx mulmoclaude` / `node packages/mulmoclaude/bin/...`)

--- a/test/agent/test_workspace_module_fallback.ts
+++ b/test/agent/test_workspace_module_fallback.ts
@@ -1,0 +1,51 @@
+// Validates the Node resolution assumption the #1946 fix (approach A′) rests
+// on: when a workspace package's PRIMARY `node_modules` entry is a dangling
+// symlink — exactly the Windows yarn-workspace junction that points at a host
+// path absent inside the Linux container — CJS resolution treats it as missing
+// and falls through to the next NODE_PATH root (`/app/pkg_modules`).
+//
+// The real bug only reproduces on Windows, but the RESOLUTION happens inside a
+// Linux container, so a POSIX host (Linux/macOS CI) is the accurate place to
+// prove it. Skipped on a Windows host — creating a symlink there needs elevated
+// privileges and, more importantly, isn't the production OS. Spawns a real
+// child `node` so NODE_PATH is honoured (it's read once at startup).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+describe("NODE_PATH fallback past a dangling workspace junction (#1946)", { skip: process.platform === "win32" }, () => {
+  it("resolves @mulmoclaude/x-plugin from the fallback root when the primary entry dangles", () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-nodepath-"));
+    try {
+      const primary = join(root, "node_modules");
+      const fallback = join(root, "pkg_modules");
+      // Primary: a dangling symlink, like a Windows junction whose absolute
+      // host target does not exist inside the container.
+      mkdirSync(join(primary, "@mulmoclaude"), { recursive: true });
+      symlinkSync(join(root, "absent-host-path"), join(primary, "@mulmoclaude", "x-plugin"));
+      // Fallback: the real package at the junction-free scoped root.
+      const real = join(fallback, "@mulmoclaude", "x-plugin");
+      mkdirSync(real, { recursive: true });
+      writeFileSync(join(real, "package.json"), JSON.stringify({ name: "@mulmoclaude/x-plugin", main: "index.js" }));
+      writeFileSync(join(real, "index.js"), "module.exports = 'RESOLVED_FROM_FALLBACK';");
+
+      // Run from `root` so the dangling `root/node_modules/@mulmoclaude/x-plugin`
+      // sits in the normal resolution walk — proving Node SKIPS it (not errors)
+      // before NODE_PATH's fallback resolves it. cwd isolation also keeps the
+      // repo's real installed x-plugin (which would win from the repo cwd) out
+      // of the walk. Mirrors the container's NODE_PATH=/app/node_modules:/app/pkg_modules.
+      const out = execFileSync(process.execPath, ["-e", "process.stdout.write(require('@mulmoclaude/x-plugin'))"], {
+        cwd: root,
+        env: { ...process.env, NODE_PATH: `${primary}:${fallback}` },
+        encoding: "utf-8",
+      });
+      assert.equal(out, "RESOLVED_FROM_FALLBACK");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1946 — on **Windows + Docker sandbox ON (source build)**, the in-container MCP server crashes at load and every `mulmoclaude__*` tool (incl. `handlePermission`) disappears. Root cause confirmed with in-container data (see [issue investigation comment](https://github.com/receptron/mulmoclaude/issues/1946#issuecomment-4883906025)): Windows yarn-workspace links in `node_modules/@mulmoclaude/*` are **absolute junctions** that dangle inside the Linux container → `@mulmoclaude/x-plugin` `MODULE_NOT_FOUND` → mcp-server dies before initialize.

## Items to Confirm / Review
- **Windows-only bug — I can't run it locally.** @ystknsh, could you verify on your Windows machine once this lands? 🙏
- The fix rests on one Node behaviour: *CJS resolution skips a dangling `node_modules` symlink and falls through to the next `NODE_PATH` root.* That's now **proven on CI** by `test_workspace_module_fallback.ts` (spawns a real `node` with a dangling primary entry + a fallback root) — the container is Linux, so a POSIX host is the accurate place to prove it.
- macOS/Linux/npx paths are asserted **unchanged** (fallback root only mounted on win32 source builds; extra NODE_PATH entry is a no-op otherwise).

## Fix — approach A′ (NODE_PATH fallback root)
Docker already runs the MCP child with `NODE_PATH=/app/node_modules` (tsx emits CJS in-container, so it's honoured). Extend it instead of touching the dangling junctions:
1. `buildDockerSpawnArgs` — on `win32` + `packages/` present, bind-mount each `@mulmoclaude/*` at `/app/pkg_modules/@mulmoclaude/<name>` (scoped name read from each `package.json`).
2. `buildMulmoclaudeServer` — `NODE_PATH=/app/node_modules:/app/pkg_modules`.

Windows: primary `/app/node_modules/@mulmoclaude/core` dangles → resolution falls through to `/app/pkg_modules/@mulmoclaude/core`. Subpath exports (`@mulmoclaude/core/collection/server`) and cross-package `@mulmoclaude/*` imports resolve the same way.

Alternatives rejected: **A** (overlay onto the dangling `node_modules` path — Docker-version-dependent landing), **entrypoint re-link** (needs writable node_modules → weakens the read-only posture). Detail in `plans/fix-1946-windows-docker-sandbox-mcp.md`.

## Tests
- `test/agent/test_agent_config.ts` — win32 adds the `/app/pkg_modules/@mulmoclaude/*` mounts (non-scoped packages skipped); darwin/linux + npx add none; docker `NODE_PATH` includes the fallback root; native has no `NODE_PATH`.
- `test/agent/test_workspace_module_fallback.ts` — spawned-`node` proof that a dangling primary entry is skipped and the package resolves via the `NODE_PATH` fallback (POSIX host; skipped on Windows host).

## User Prompt
> https://github.com/receptron/mulmoclaude/issues/1946 feedbackきた — [調査レポート: コンテナ内で @mulmoclaude/* symlink が全て dangling、mcp-server が @mulmoclaude/x-plugin で MODULE_NOT_FOUND]。issue に報告概要と調査内容を記載し、修正まで実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Address Windows Docker sandbox MCP server module resolution failures by providing a junction-free fallback for @mulmoclaude workspace packages and wiring it into the container environment.

Bug Fixes:
- Ensure the in-container MCP server on Windows can resolve @mulmoclaude/* workspace packages despite dangling yarn-workspace junctions in node_modules.

Enhancements:
- Add Windows-specific Docker volume mounts for each @mulmoclaude/* workspace package into a junction-free /app/pkg_modules root and extend NODE_PATH to include it.
- Introduce helper utilities to detect workspace package directories and their scoped names from package.json for robust Docker mount configuration.

Documentation:
- Add a design and investigation note documenting the root cause of the Windows Docker sandbox issue and the chosen NODE_PATH-based fix strategy.

Tests:
- Extend agent config tests to assert docker vs native NODE_PATH values and Windows-only workspace module mounts.
- Add tests ensuring /app/pkg_modules mounts are only created for @mulmoclaude/* packages on Windows source builds and not for other platforms or npx installs.
- Introduce a Node-level resolution test that validates fallback from a dangling primary node_modules entry to a secondary NODE_PATH root, mirroring the Windows Docker scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a plan outlining a Windows + Docker sandbox fix for workspace package loading.
  * Described expected behavior, fallback handling, and rejected alternatives.

* **Bug Fixes**
  * Improved module resolution in Docker on Windows so workspace packages can still load when primary links are unavailable.
  * Updated sandbox startup behavior to support affected MCP tools more reliably.

* **Tests**
  * Expanded coverage for Docker environment settings and Windows-specific mount behavior.
  * Added a new fallback-loading test to verify modules resolve correctly when the primary path is broken.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->