### PR TITLE
fix(remote-view): resolve ref-crossing derived fields in mobile getItems

### DIFF
--- a/packages/core/assets/helps/custom-view-remote.md
+++ b/packages/core/assets/helps/custom-view-remote.md
@@ -90,10 +90,13 @@ const page = await window.__MC_VIEW.getItems({
   any `image`-type field you want inlined (see **Displaying images**).
 - The promise **rejects** on failure or after a 30 s timeout — catch it and
   show the message; don't fail silently.
-- **`derived` formulas that read only the record's own fields come back
-  resolved** (e.g. `won * 3 + drawn`). Formulas that dereference a `ref`
-  field, and `embed` fields, are NOT resolved on the phone — don't rely on
-  them; compute from base fields or omit.
+- **Computed fields resolve host-side, exactly as on desktop.** `derived`
+  formulas — including ones that dereference a `ref` into another collection
+  (e.g. `ticker.price`, `shares * ticker.price`) — plus `toggle` and `embed`
+  fields all come back fully resolved. The host does the join before serializing
+  the page; the phone just receives the plain values. A `ref` target that's
+  missing resolves that field to `null` (same fail-soft as desktop), so guard
+  for `null` rather than assuming a number is always present.
 
 ### Writing records — `updateItem` / `deleteItem`
 

--- a/packages/core/assets/helps/custom-view-remote.md
+++ b/packages/core/assets/helps/custom-view-remote.md
@@ -140,9 +140,11 @@ const { id: removed } = await window.__MC_VIEW.deleteItem(id);
   optimistically update your local copy from the returned `item`, or re-call
   `getItems` to refetch. The preview's real write also refreshes the desktop
   collection, so you see the true result while iterating.
-- **The returned `item` is shaped like a `getItems` item** — the view's declared
-  `imageFields` come back inlined as `data:` URLs (not bare paths), so merging the
-  result (`items[i] = { ...items[i], ...res.item }`) keeps thumbnails intact.
+- **The returned `item` is shaped like a `getItems` item** — host-computed fields
+  (`derived`, including ref-crossing formulas, `toggle`, `embed`) are resolved and
+  the view's declared `imageFields` come back inlined as `data:` URLs (not bare
+  paths), so merging the result (`items[i] = { ...items[i], ...res.item }`) keeps
+  computed columns and thumbnails intact — no refetch needed just to recompute them.
 - **Create is not available** in this phase — `updateItem` only patches an
   existing record; use `startChat` to ask the agent to add a new one.
 

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -21,7 +21,7 @@ import {
   type RemoteViewPage,
   type RemoteViewPageRequest,
 } from "@mulmoclaude/core/remote-view";
-import { deriveAll } from "@mulmoclaude/core/collection";
+import { enrichItems } from "@mulmoclaude/core/collection/server";
 import {
   deleteItem,
   listItems,
@@ -200,6 +200,7 @@ export type RemoteViewItemsResult =
 
 export interface RemoteViewItemsDeps {
   listItems: typeof listItems;
+  enrichItems: typeof enrichItems;
   resolveThumbnail: typeof resolveThumbnail;
 }
 
@@ -251,9 +252,13 @@ export const createRemoteViewItems =
     const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
     if (!view) return { kind: "view-not-found", viewId };
     if (view.target !== "mobile") return { kind: "not-mobile", viewId };
-    // Derive record-local formulas with an empty ref cache — same as the phase-2
-    // channel handlers and the preview, so `getItems` numbers match the desktop.
-    const derived = (await deps.listItems(collection.dataDir)).map((item) => deriveAll(collection.schema, item, {}) as RemoteViewItem);
+    // Hydrate through the SAME server resolver the desktop `dataUrl` route uses
+    // (manageCollection.getItems → enrichItems): ref targets loaded once, derived
+    // formulas evaluated with a full ref cache (`ticker.price`, `shares * ticker.price`
+    // resolve), toggles projected, embeds resolved. The phone gets plain resolved
+    // scalars — no network, no dataUrl — so mobile numbers match desktop exactly.
+    const items = await deps.listItems(collection.dataDir);
+    const derived = (await deps.enrichItems(collection, items)) as RemoteViewItem[];
     const page = pageFromItems(derived, request, collection.schema.primaryKey);
     const fields = inlineFields(view, collection.schema, request.fields);
     if (fields.length === 0) return { kind: "ok", page, inlined: 0, omitted: 0 };
@@ -264,7 +269,7 @@ export const createRemoteViewItems =
     return { kind: "ok", page, inlined, omitted };
   };
 
-export const remoteViewItems = createRemoteViewItems({ listItems, resolveThumbnail });
+export const remoteViewItems = createRemoteViewItems({ listItems, enrichItems, resolveThumbnail });
 
 /** Message per non-ok item-page kind — shared by the channel handler (throws)
  *  and the HTTP route (sends with the matching status). */

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -118,6 +118,7 @@ export interface MutateRemoteViewDeps {
   readItem: typeof readItem;
   writeItem: typeof writeItem;
   deleteItem: typeof deleteItem;
+  enrichItems: typeof enrichItems;
   resolveThumbnail: typeof resolveThumbnail;
 }
 
@@ -168,15 +169,18 @@ async function updateViaView(
   if (result.kind === "invalid-id") return { kind: "invalid-id", id: result.itemId };
   if (result.kind === "path-escape") return { kind: "path-escape" };
   if (result.kind === "conflict") return { kind: "item-not-found", id: result.itemId }; // unreachable: refuseOverwrite is false
-  // The returned item must be shaped like a `getItems` item — with the view's
-  // declared image fields inlined as `data:` URLs — so a view that merges the
-  // result (as the help file recommends) doesn't clobber a good thumbnail with a
-  // bare path. No projection here (the whole record is returned), so inline every
-  // declared image-type field. Budget the thumbnail against the serialized item
+  // The returned item must be shaped like a `getItems` item — same host-computed
+  // fields (derived, incl. ref-crossing, toggle, embed) AND the view's declared
+  // image fields inlined as `data:` URLs — so a view that merges the result (as
+  // the help file recommends) keeps its computed columns and doesn't clobber a
+  // good thumbnail with a bare path. Enrich through the SAME resolver getItems
+  // uses, then inline every declared image-type field (no projection here — the
+  // whole record is returned). Budget the thumbnail against the serialized item
   // (same as the page builder) so a record with large text/markdown fields can't
   // push the mutate result over the command-document cap — over budget, the field
   // stays a path (placeholder), never a doc-write failure.
-  const item = result.item as RemoteViewItem;
+  const [enriched] = await deps.enrichItems(collection, [result.item]);
+  const item = enriched as RemoteViewItem;
   const imageFields = inlineFields(view, collection.schema, undefined);
   if (imageFields.length > 0) {
     const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - Buffer.byteLength(JSON.stringify(item), "utf8");
@@ -185,7 +189,7 @@ async function updateViaView(
   return { kind: "ok", op: "update", item: item as CollectionItem };
 }
 
-export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem, resolveThumbnail });
+export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem, enrichItems, resolveThumbnail });
 
 // ── Item pages with inlined image thumbnails (phase 5 — plans/feat-remote-view-images.md) ──
 // A mobile view's `getItems`, view-aware so it can inline the `imageFields` its
@@ -196,7 +200,10 @@ export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, de
 // (phone) and the `…/remote-view/:viewId/items` HTTP route (desktop preview).
 
 export type RemoteViewItemsResult =
-  { kind: "ok"; page: RemoteViewPage; inlined: number; omitted: number } | { kind: "view-not-found"; viewId: string } | { kind: "not-mobile"; viewId: string };
+  | { kind: "ok"; page: RemoteViewPage; inlined: number; omitted: number }
+  | { kind: "view-not-found"; viewId: string }
+  | { kind: "not-mobile"; viewId: string }
+  | { kind: "too-large"; bytes: number };
 
 export interface RemoteViewItemsDeps {
   listItems: typeof listItems;
@@ -260,11 +267,17 @@ export const createRemoteViewItems =
     const items = await deps.listItems(collection.dataDir);
     const derived = (await deps.enrichItems(collection, items)) as RemoteViewItem[];
     const page = pageFromItems(derived, request, collection.schema.primaryKey);
+    // Resolving an `embed` column attaches a whole target record per row, so the
+    // base (path-only) page JSON can itself blow the doc budget before a single
+    // thumbnail is added. Reject with an actionable error rather than letting the
+    // oversized doc fail downstream at the command-channel write.
+    const baseBytes = Buffer.byteLength(JSON.stringify(page), "utf8");
+    if (baseBytes > REMOTE_VIEW_ITEMS_MAX_BYTES) return { kind: "too-large", bytes: baseBytes };
     const fields = inlineFields(view, collection.schema, request.fields);
     if (fields.length === 0) return { kind: "ok", page, inlined: 0, omitted: 0 };
-    // Budget the thumbnails against what's left of the doc after the (tiny,
-    // path-only) base JSON, so the serialized page stays under the cap.
-    const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - Buffer.byteLength(JSON.stringify(page), "utf8");
+    // Budget the thumbnails against what's left of the doc after the base JSON,
+    // so the serialized page stays under the cap.
+    const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - baseBytes;
     const { inlined, omitted } = await inlineImages(page.items, fields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, Math.max(0, budget));
     return { kind: "ok", page, inlined, omitted };
   };
@@ -275,6 +288,8 @@ export const remoteViewItems = createRemoteViewItems({ listItems, enrichItems, r
  *  and the HTTP route (sends with the matching status). */
 export function remoteViewItemsFailureMessage(result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): string {
   if (result.kind === "not-mobile") return `custom view '${result.viewId}' is not a mobile view — declare target: "mobile" in its views[] entry`;
+  if (result.kind === "too-large")
+    return `mobile view page is ${result.bytes} bytes — over the ${REMOTE_VIEW_ITEMS_MAX_BYTES}-byte command-channel budget; narrow \`fields\` (drop an embed column), lower \`limit\`, or slim the records`;
   return `custom view '${result.viewId}' not found on collection '${slug}'`;
 }
 

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -104,6 +104,7 @@ function isWritableView(view: CollectionCustomView): boolean {
 export type MutateRemoteViewResult =
   | { kind: "ok"; op: "update"; item: CollectionItem }
   | { kind: "ok"; op: "delete"; id: string }
+  | { kind: "too-large"; bytes: number }
   | { kind: "view-not-found"; viewId: string }
   | { kind: "not-mobile"; viewId: string }
   | { kind: "not-writable"; viewId: string }
@@ -181,10 +182,16 @@ async function updateViaView(
   // stays a path (placeholder), never a doc-write failure.
   const [enriched] = await deps.enrichItems(collection, [result.item]);
   const item = enriched as RemoteViewItem;
+  // Enrichment can inflate the base item (an `embed` attaches a whole target
+  // record, a computed field a large payload). If the base JSON already exceeds
+  // the doc budget, no thumbnail-skipping can save it — the write DID persist,
+  // but return `too-large` (mirroring the getItems page cap) so the response
+  // fails predictably/actionably here instead of downstream on the channel write.
+  const baseBytes = Buffer.byteLength(JSON.stringify(item), "utf8");
+  if (baseBytes > REMOTE_VIEW_ITEMS_MAX_BYTES) return { kind: "too-large", bytes: baseBytes };
   const imageFields = inlineFields(view, collection.schema, undefined);
   if (imageFields.length > 0) {
-    const budget = REMOTE_VIEW_ITEMS_MAX_BYTES - Buffer.byteLength(JSON.stringify(item), "utf8");
-    await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, Math.max(0, budget));
+    await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, REMOTE_VIEW_ITEMS_MAX_BYTES - baseBytes);
   }
   return { kind: "ok", op: "update", item: item as CollectionItem };
 }
@@ -306,5 +313,7 @@ export function mutateRemoteViewFailureMessage(result: Exclude<MutateRemoteViewR
   if (result.kind === "invalid-patch") return `update patch must be a non-empty object of field changes`;
   if (result.kind === "item-not-found") return `item '${result.id}' not found in collection '${slug}'`;
   if (result.kind === "invalid-id") return `invalid item id: ${result.id}`;
+  if (result.kind === "too-large")
+    return `update succeeded but its response is ${result.bytes} bytes — over the ${REMOTE_VIEW_ITEMS_MAX_BYTES}-byte command-channel budget; slim the record (an embed/computed field is too big) and re-fetch with \`getItems\``;
   return `data directory for collection '${slug}' escapes the workspace`;
 }

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -74,27 +74,24 @@ describe("createMutateRemoteView", () => {
     assert.match(String(result.item.poster), /^data:image\/jpeg;base64,/); // inlined, not the path
   });
 
-  it("leaves the image as a path when the returned item is already over budget", async () => {
-    // A record with a huge text field (near the whole 900 KB doc budget) leaves
-    // no room for a thumbnail — the field must stay a path, not overflow the doc.
+  it("leaves the image as a path when the thumbnail would exceed the remaining budget", async () => {
+    // The base item fits, but the thumbnail is bigger than the room left under the
+    // doc budget — it must stay a path, not overflow the doc. (A base item that is
+    // itself over budget is a `too-large` failure, covered separately.)
     const withImage = collection([{ ...writableView, editableFields: ["rating"], imageFields: ["poster"] }]);
-    withImage.schema.fields = {
-      id: { type: "string" },
-      rating: { type: "string" },
-      poster: { type: "image" },
-      notes: { type: "text" },
-    } as unknown as typeof withImage.schema.fields;
-    const huge = "x".repeat(REMOTE_VIEW_ITEMS_MAX_BYTES);
+    withImage.schema.fields = { id: { type: "string" }, rating: { type: "string" }, poster: { type: "image" } } as unknown as typeof withImage.schema.fields;
+    const big = `data:image/jpeg;base64,${"x".repeat(REMOTE_VIEW_ITEMS_MAX_BYTES)}`;
     const mutate = createMutateRemoteView(
       deps({
-        readItem: (async () => ({ id: "t1", rating: "", poster: "images/a.png", notes: huge })) as unknown as MutateRemoteViewDeps["readItem"],
+        readItem: (async () => ({ id: "t1", rating: "", poster: "images/a.png" })) as unknown as MutateRemoteViewDeps["readItem"],
         writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
+        resolveThumbnail: (async () => big) as MutateRemoteViewDeps["resolveThumbnail"],
       }),
     );
     const result = await mutate(withImage, "phone", { op: "update", id: "t1", patch: { rating: "★" } });
     assert.equal(result.kind, "ok");
     if (result.kind !== "ok" || result.op !== "update") return;
-    assert.equal(result.item.poster, "images/a.png"); // left as path — no budget for a thumbnail
+    assert.equal(result.item.poster, "images/a.png"); // left as path — thumbnail over the remaining budget
   });
 
   it("returns the update item in the enriched getItems shape (computed fields resolved)", async () => {
@@ -114,6 +111,24 @@ describe("createMutateRemoteView", () => {
     assert.equal(result.kind, "ok");
     if (result.kind !== "ok" || result.op !== "update") return;
     assert.equal(result.item.value, 150); // 3 * 50 — resolved host-side, present on the returned item
+  });
+
+  it("returns too-large when enrichment inflates the response past the doc budget", async () => {
+    // The write persists, but an embed/computed payload can push the enriched item
+    // over the command-doc cap — fail predictably here, not downstream on write.
+    const huge = "x".repeat(REMOTE_VIEW_ITEMS_MAX_BYTES);
+    const mutate = createMutateRemoteView(
+      deps({
+        readItem: (async () => ({ id: "t1", done: false })) as unknown as MutateRemoteViewDeps["readItem"],
+        writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
+        enrichItems: (async (_collection: unknown, items: Record<string, unknown>[]) =>
+          items.map((entry) => ({ ...entry, embedded: huge }))) as unknown as MutateRemoteViewDeps["enrichItems"],
+      }),
+    );
+    const result = await mutate(collection([writableView]), "phone", { op: "update", id: "t1", patch: { done: true } });
+    assert.equal(result.kind, "too-large");
+    if (result.kind !== "too-large") return;
+    assert.ok(result.bytes > REMOTE_VIEW_ITEMS_MAX_BYTES);
   });
 
   it("deletes a record when allowDelete is set", async () => {
@@ -181,6 +196,7 @@ describe("createMutateRemoteView", () => {
     assert.match(mutateRemoteViewFailureMessage({ kind: "item-not-found", id: "t9" }, "todos"), /'t9' not found/);
     assert.match(mutateRemoteViewFailureMessage({ kind: "invalid-id", id: "bad/id" }, "todos"), /invalid item id: bad\/id/);
     assert.match(mutateRemoteViewFailureMessage({ kind: "path-escape" }, "todos"), /escapes the workspace/);
+    assert.match(mutateRemoteViewFailureMessage({ kind: "too-large", bytes: 1_000_000 }, "todos"), /over the 900000-byte command-channel budget/);
   });
 });
 

--- a/test/remoteHost/test_mutateRemoteView.ts
+++ b/test/remoteHost/test_mutateRemoteView.ts
@@ -28,6 +28,9 @@ const deps = (overrides: Partial<MutateRemoteViewDeps> = {}): MutateRemoteViewDe
   readItem: (async () => ({ ...record })) as unknown as MutateRemoteViewDeps["readItem"],
   writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
   deleteItem: (async (_dir: string, itemId: string) => ({ kind: "ok", itemId })) as unknown as MutateRemoteViewDeps["deleteItem"],
+  // Identity stub: fixtures have no computed fields, so the real resolver returns
+  // them unchanged — the update path just threads the written record through it.
+  enrichItems: (async (_collection: unknown, items: unknown[]) => items) as unknown as MutateRemoteViewDeps["enrichItems"],
   // A declared-image view inlines the returned item's image fields; the default
   // view here declares none, so this is only exercised by the dedicated test below.
   resolveThumbnail: (async (relPath: string) =>
@@ -92,6 +95,25 @@ describe("createMutateRemoteView", () => {
     assert.equal(result.kind, "ok");
     if (result.kind !== "ok" || result.op !== "update") return;
     assert.equal(result.item.poster, "images/a.png"); // left as path — no budget for a thumbnail
+  });
+
+  it("returns the update item in the enriched getItems shape (computed fields resolved)", async () => {
+    // Regression for the getItems/updateItem shape parity: a view that merges the
+    // update result must keep its host-computed columns (e.g. a ref-crossing
+    // `value = shares * ticker.price`), not drop them until the next refetch.
+    const mutate = createMutateRemoteView(
+      deps({
+        readItem: (async () => ({ id: "t1", shares: 2 })) as unknown as MutateRemoteViewDeps["readItem"],
+        writeItem: (async (_dir: string, itemId: string, item: unknown) => ({ kind: "ok", itemId, item })) as unknown as MutateRemoteViewDeps["writeItem"],
+        enrichItems: (async (_collection: unknown, items: Record<string, unknown>[]) =>
+          items.map((entry) => ({ ...entry, value: Number(entry.shares) * 50 }))) as unknown as MutateRemoteViewDeps["enrichItems"],
+      }),
+    );
+    const editable = collection([{ ...writableView, editableFields: ["shares"] }]);
+    const result = await mutate(editable, "phone", { op: "update", id: "t1", patch: { shares: 3 } });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok" || result.op !== "update") return;
+    assert.equal(result.item.value, 150); // 3 * 50 — resolved host-side, present on the returned item
   });
 
   it("deletes a record when allowDelete is set", async () => {

--- a/test/remoteHost/test_remoteViewItems.ts
+++ b/test/remoteHost/test_remoteViewItems.ts
@@ -32,6 +32,9 @@ const RECORDS = [
 
 const deps = (overrides: Partial<RemoteViewItemsDeps> = {}): RemoteViewItemsDeps => ({
   listItems: (async () => RECORDS) as unknown as RemoteViewItemsDeps["listItems"],
+  // Identity stub: these fixtures have no computed fields, so the real resolver
+  // (enrichItems) returns them unchanged — the builder just threads records through it.
+  enrichItems: (async (_collection: unknown, items: unknown[]) => items) as unknown as RemoteViewItemsDeps["enrichItems"],
   // Deterministic stub: a short data URL derived from the path (no native binary).
   resolveThumbnail: (async (relPath: string) => `data:image/jpeg;base64,${Buffer.from(relPath).toString("base64")}`) as RemoteViewItemsDeps["resolveThumbnail"],
   ...overrides,
@@ -97,6 +100,19 @@ describe("createRemoteViewItems", () => {
     assert.equal(result.omitted, 1);
     assert.equal(result.page.items[0].photo, big); // inlined
     assert.equal(result.page.items[1].photo, "images/b.png"); // left as path (over budget)
+  });
+
+  it("serves host-resolved computed fields (ref-crossing derived, etc.) the resolver produced", async () => {
+    // Prove the builder hydrates through enrichItems, not a record-local evaluator:
+    // a derived `value` that only the full resolver could compute (e.g. shares *
+    // ticker.price) must reach the projected page unchanged.
+    const enriched = RECORDS.map((record) => ({ ...record, value: record.id === "a" ? 100 : 250 }));
+    const build = createRemoteViewItems(deps({ enrichItems: (async () => enriched) as unknown as RemoteViewItemsDeps["enrichItems"] }));
+    const result = await build(collection(view()), "gallery", { offset: 0, limit: 50, fields: ["title", "value"] });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.deepEqual(result.page.items[0], { id: "a", title: "A", value: 100 });
+    assert.deepEqual(result.page.items[1], { id: "b", title: "B", value: 250 });
   });
 
   it("maps failure kinds to actionable messages", () => {

--- a/test/remoteHost/test_remoteViewItems.ts
+++ b/test/remoteHost/test_remoteViewItems.ts
@@ -115,9 +115,22 @@ describe("createRemoteViewItems", () => {
     assert.deepEqual(result.page.items[1], { id: "b", title: "B", value: 250 });
   });
 
+  it("rejects a page whose base JSON already exceeds the doc budget", async () => {
+    // An embed column can attach a whole record per row; if the projected base
+    // page alone overflows the budget, fail with an actionable error rather than
+    // letting the oversized doc break the downstream command-channel write.
+    const huge = "x".repeat(REMOTE_VIEW_ITEMS_MAX_BYTES);
+    const build = createRemoteViewItems(deps({ enrichItems: (async () => [{ id: "a", blob: huge }]) as unknown as RemoteViewItemsDeps["enrichItems"] }));
+    const result = await build(collection(view()), "gallery", { offset: 0, limit: 50, fields: ["blob"] });
+    assert.equal(result.kind, "too-large");
+    if (result.kind !== "too-large") return;
+    assert.ok(result.bytes > REMOTE_VIEW_ITEMS_MAX_BYTES);
+  });
+
   it("maps failure kinds to actionable messages", () => {
     assert.match(remoteViewItemsFailureMessage({ kind: "view-not-found", viewId: "v" }, "plan"), /'v' not found on collection 'plan'/);
     assert.match(remoteViewItemsFailureMessage({ kind: "not-mobile", viewId: "v" }, "plan"), /target: "mobile"/);
+    assert.match(remoteViewItemsFailureMessage({ kind: "too-large", bytes: 1_000_000 }, "plan"), /over the 900000-byte command-channel budget/);
   });
 });
 


### PR DESCRIPTION
## Problem

On the **remote (mobile)** custom view, a collection's records are read only through the injected `window.__MC_VIEW.getItems()` postMessage bridge (`connect-src 'none'` — the phone can't `fetch`). That bridge hydrated records with `deriveAll(schema, item, {})` — an **empty ref cache** — so any `derived` formula that dereferences a `ref` into another collection came back `null`/`NaN` on the phone.

Portfolio is the canonical case: `price = ticker.price` and `value = shares * ticker.price` (where `ticker` refs the `stock-quotes` collection) work on desktop but are broken on mobile, forcing a shares-only fallback.

## Root cause

Two hydration wrappers around one shared `deriveAll` core:

| Path | Resolver | Ref cache |
|---|---|---|
| Desktop `dataUrl` route (`manageCollection.getItems`) | `enrichItems` | **full** — linked collections loaded once |
| Remote `getItems` bridge (`createRemoteViewItems`) | `deriveAll(schema, item, {})` | **empty** |

Not a sandbox/CSP constraint — the **host** does the computation, then ships resolved scalars to the phone. The remote path was just wired to the weaker resolver.

## Fix

Route the remote path through the **same `enrichItems`** the desktop route uses: ref targets loaded once (deduped by slug), derived formulas evaluated with a full ref cache, toggles projected, embeds resolved. Injected as a DI dep to preserve the factory's test seam. `createRemoteViewItems` backs **both** the phone channel handler and the desktop-preview HTTP route, so `preview === phone === desktop`.

**Also fixes two latent bugs** the empty-cache path shared: `toggle` and `embed` fields were silently unresolved on mobile too.

**Byte budget is safe:** `pageFromItems` projects to `request.fields` before serialization, so an `embed` field's full target record only ships when the view explicitly requests that column.

## Changes

- `server/workspace/collections/remoteView.ts` — `createRemoteViewItems` lists records then calls `enrichItems(collection, items)` instead of the record-local `deriveAll`.
- `packages/core/assets/helps/custom-view-remote.md` — drop the obsolete "ref-crossing derived / embed are NOT resolved — compute from base fields or omit" caveat; document host-side resolution + `null` guard for a missing ref target.
- `test/remoteHost/test_remoteViewItems.ts` — `enrichItems` stub in the deps builder + a test proving a resolver-produced derived value reaches the projected page.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build` all clean; `test_remoteViewItems.ts` 12/12 pass.

## Follow-up (not in this PR)

This edits `packages/core/assets/helps/*`, so `@mulmoclaude/core` should be bumped + published (`/publish`) for the new help text to reach users / MulmoTerminal. The code fix itself needs no core republish — `enrichItems` already ships in `dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route mobile remote view item hydration through the shared server-side enrichment pipeline so computed fields on phone match desktop.

New Features:
- Ensure mobile remote custom views receive host-resolved computed fields, including ref-crossing derived formulas, toggles, and embeds.

Enhancements:
- Inject the shared enrichItems resolver into the remote view items factory and wire it into the default remoteViewItems handler to unify desktop, preview, and mobile behavior.

Documentation:
- Update remote custom view documentation to describe host-side resolution of computed fields and the null fail-soft behavior for missing ref targets.

Tests:
- Extend remote view items tests to cover enrichment via the resolver and verify computed values are projected correctly in the returned page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote view rendering and updates so host-computed fields (including derived values, toggles, embeds, and referenced-field dereferences) are preserved and returned in the expected resolved form.
  * Update flows now return items consistent with the host-resolved `getItems` shape, reducing cases where computed fields could be missing until refetch.

* **Documentation**
  * Updated remote custom view contracts to clarify full field-resolution behavior and `null` handling for missing referenced targets.

* **Tests**
  * Added/extended coverage for resolver-derived fields and “too-large” projection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->