### PR TITLE
refactor(remote-host): extract transport into @mulmoclaude/core

### DIFF
--- a/docs/remote-host.md
+++ b/docs/remote-host.md
@@ -81,21 +81,32 @@ over localhost only, never logged, not persisted to disk. The session is
 
 ---
 
-## Server code map (`server/remoteHost/`)
+## Where the code lives — shared transport in core, host specifics local
+
+The generic transport is **extracted into `@mulmoclaude/core`** so both hosts
+(MulmoClaude, MulmoTerminal) share one copy instead of each porting it from
+`../mulmoserver` (which is where it originated). Two subpaths, split on the
+browser-safe boundary — mirroring `@mulmoclaude/core/remote-view`:
+
+| Import | Surface | Provides |
+|---|---|---|
+| `@mulmoclaude/core/remote-host` | **browser-safe** | Protocol wire types (`Command`, `CommandStatus`, `Channel`, `CommandHandlers`) + Firestore path helpers `commandsCollection(firestore, channel)` / `hostDoc(firestore, channel)`. Shared by host **and** the mobile client. |
+| `@mulmoclaude/core/remote-host/server` | **server-only** | `startHostRunner(firestore, channel, handlers, opts)` — the command loop; `createRemoteHost(deps)` — the connect/disconnect/status lifecycle factory; `createRemoteHostAuth(auth)` + `createRemoteHostFirebase(config)` — the Firebase init/auth primitives. `firebase` is an optional peer dep of core. |
+
+Each host supplies only its own specifics under `server/remoteHost/`:
 
 | File | Responsibility |
 |---|---|
-| `index.ts` | Lifecycle: `createRemoteHost(deps)` factory + default singleton. `connect(idToken)` / `disconnect()` / `status()`. Serializes transitions (no double runner), authenticates **before** teardown (a failed connect leaves a healthy session untouched), reconciles state if the listener dies (`onClosed`). |
-| `auth.ts` | Firebase credential exchange — `signInHost(idToken)`, `signOutHost()`, `currentUid()`. |
-| `firebase.ts` | Node-side Firebase init (`initializeApp` + `getAuth` + `getFirestore` + `getStorage`) using the shared public `firebaseConfig`. |
-| `commandChannel.ts` | Protocol types (`Command`, `CommandStatus`, `Channel`) + Firestore path helpers `commandsCollection(channel)` / `hostDoc(channel)` + `HOST_ID = "mulmoclaude"`. Ported from `../mulmoserver` and runs unchanged in Node (modular `firebase/firestore`). |
-| `hostRunner.ts` | **The command loop.** `startHostRunner(channel, handlers, options)` — heartbeats presence, `onSnapshot(where status=="queued")`, `claimCommand` via `runTransaction`, runs the handler, writes `done`/`error`. Returns a `stop()` that goes offline + unsubscribes. |
+| `index.ts` | Binds this host's `hostId="mulmoclaude"`, handler table, firestore-bound runner, and logger to core's `createRemoteHost`; exposes the default singleton the route uses. |
+| `firebase.ts` | `createRemoteHostFirebase(firebaseConfig)` → this host's `{ firestore, auth, storage }` (Firestore must be in Native mode). |
+| `auth.ts` | `createRemoteHostAuth(auth)` → `signInHost` / `signOutHost` / `currentUid` bound to this host's Firebase auth. |
+| `commandChannel.ts` | Re-exports the core protocol + pins `HOST_ID = "mulmoclaude"`. |
 | `handlers/index.ts` | The method table — the single place the runner learns which methods it serves. |
 
-### The command loop, precisely (`hostRunner.ts`)
+### The command loop, precisely (core `startHostRunner`)
 
 - **Presence.** `setDoc(presence, {online:true})` on start, then a heartbeat
-  `setInterval` every `ONE_MINUTE_MS`. On `stop()` or fatal listener death it
+  `setInterval` once a minute (`opts.heartbeatMs`, default 60 s). On `stop()` or fatal listener death it
   writes `online:false` and clears the interval — so remotes see the host go
   offline instead of a live-but-dead host that silently consumes no commands.
 - **Claim exactly once.** `claimCommand` runs a `runTransaction` that reads the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.8.2",
-  "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client and ./remote-view entries. All host specifics are injected.",
+  "version": "0.9.0",
+  "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {
     "./collection": {
@@ -118,6 +118,18 @@
       "require": "./dist/remote-view/index.cjs",
       "default": "./dist/remote-view/index.js"
     },
+    "./remote-host": {
+      "types": "./dist/remote-host/index.d.ts",
+      "import": "./dist/remote-host/index.js",
+      "require": "./dist/remote-host/index.cjs",
+      "default": "./dist/remote-host/index.js"
+    },
+    "./remote-host/server": {
+      "types": "./dist/remote-host/server/index.d.ts",
+      "import": "./dist/remote-host/server/index.js",
+      "require": "./dist/remote-host/server/index.cjs",
+      "default": "./dist/remote-host/server/index.js"
+    },
     "./translation/client": {
       "types": "./dist/translation/client.d.ts",
       "import": "./dist/translation/client.js",
@@ -154,7 +166,13 @@
   },
   "peerDependencies": {
     "@receptron/task-scheduler": "*",
+    "firebase": "^12.0.0",
     "gui-chat-protocol": "^0.4.0"
+  },
+  "peerDependenciesMeta": {
+    "firebase": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@receptron/task-scheduler": "*",

--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -1,0 +1,60 @@
+// Remote-host command-channel protocol — the browser-safe contract shared by a
+// host (MulmoClaude, MulmoTerminal) and the remote/mobile client (mulmoserver).
+//
+// A host signs in to Firebase as the user, listens to that user's per-host
+// command queue in Firestore, runs a handler, and writes the result back; the
+// remote writes commands and reads results via a real-time listener. This module
+// owns the wire types + the Firestore path helpers. It is the single source of
+// truth so the host runner and the client never drift on the protocol.
+//
+// Ported from ../mulmoserver/src/firestore/commandChannel.ts and the per-host
+// copy that lived in MulmoClaude's server/remoteHost/. The one change vs. those
+// copies: the path helpers take the `firestore` instance as a parameter (rather
+// than importing a module-level singleton) so a single extracted module serves
+// every host's own Firebase init. The hostId is host-specific ("mulmoclaude",
+// "mulmoterminal") and is supplied by each host — there is no discovery.
+import { CollectionReference, DocumentData, DocumentReference, Firestore, collection, doc } from "firebase/firestore";
+
+// JSON payloads carried by the command channel. Explicit JSON types keep the
+// channel typed without resorting to any/unknown.
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+export type JsonObject = Record<string, JsonValue>;
+
+// A channel routes commands to one specific host. Both sides agree on a
+// hardcoded hostId per use case (e.g. "mulmoclaude", "mulmoterminal"); there is
+// no discovery — the remote and host just share the id.
+export interface Channel {
+  uid: string;
+  hostId: string;
+}
+
+export type CommandStatus = "queued" | "processing" | "done" | "error";
+
+export interface CommandError {
+  code: string;
+  message: string;
+}
+
+// One document in a channel's commands subcollection is one API-call-like
+// request. The remote (mobile) writes method/params; the host writes
+// result/error/status.
+export interface Command {
+  method: string;
+  params: JsonObject;
+  status: CommandStatus;
+  result: JsonValue;
+  error: CommandError | null;
+  createdBy: "remote" | "host";
+}
+
+export type CommandHandler = (params: JsonObject) => JsonValue | Promise<JsonValue>;
+export type CommandHandlers = Record<string, CommandHandler>;
+
+// Per-host command queue: users/{uid}/hosts/{hostId}/commands.
+export const commandsCollection = (firestore: Firestore, channel: Channel): CollectionReference<DocumentData> =>
+  collection(firestore, "users", channel.uid, "hosts", channel.hostId, "commands");
+
+// Presence doc for a host: users/{uid}/hosts/{hostId}. The host heartbeats
+// { online, updatedAt } here; the remote reads it to know if the host is up.
+export const hostDoc = (firestore: Firestore, channel: Channel): DocumentReference<DocumentData> =>
+  doc(firestore, "users", channel.uid, "hosts", channel.hostId);

--- a/packages/core/src/remote-host/server/auth.ts
+++ b/packages/core/src/remote-host/server/auth.ts
@@ -1,0 +1,33 @@
+// Firebase credential exchange for the remote-host runner.
+//
+// The host authenticates to Firestore *as the user* (Option B) using the
+// Firebase JS SDK's signInWithCredential with a browser-minted Google OAuth ID
+// token — no Admin SDK, no project service account. Security rules keep the host
+// scoped to that user's own users/{uid}/… subtree.
+//
+// Extracted into core from MulmoClaude's server/remoteHost/auth.ts. The `auth`
+// instance is a parameter so each host binds its own Firebase init; the factory
+// returns the low-level credential primitives (the connect/disconnect lifecycle
+// that starts/stops the host runner lives in createRemoteHost).
+import { Auth, GoogleAuthProvider, signInWithCredential, signOut } from "firebase/auth";
+
+export interface RemoteHostAuth {
+  // Establish the Firebase session from a browser-minted Google OAuth ID token.
+  // The token is used once here; the JS SDK then holds its own refresh token for
+  // the process lifetime. Resolves to the authenticated uid.
+  signInHost: (idToken: string) => Promise<string>;
+  // Tear down the Firebase session (in-memory persistence → re-login on restart).
+  signOutHost: () => Promise<void>;
+  // The currently signed-in uid, or null when disconnected.
+  currentUid: () => string | null;
+}
+
+export const createRemoteHostAuth = (auth: Auth): RemoteHostAuth => ({
+  signInHost: async (idToken: string): Promise<string> => {
+    const credential = GoogleAuthProvider.credential(idToken);
+    const userCredential = await signInWithCredential(auth, credential);
+    return userCredential.user.uid;
+  },
+  signOutHost: (): Promise<void> => signOut(auth),
+  currentUid: (): string | null => auth.currentUser?.uid ?? null,
+});

--- a/packages/core/src/remote-host/server/firebase.ts
+++ b/packages/core/src/remote-host/server/firebase.ts
@@ -1,0 +1,31 @@
+// Firebase init for a remote-host runner.
+//
+// A host acts as a *host*: it signs in to Firebase as the user (via
+// signInWithCredential, see auth.ts) and listens to that user's command queue in
+// Firestore. The modular firebase/firestore + firebase/auth SDKs run in Node, so
+// this mirrors a browser init but also exposes Firestore (default database,
+// which must be in Native mode) and Storage.
+//
+// Extracted into core from MulmoClaude's server/remoteHost/firebase.ts. The
+// public web config is a parameter so each host supplies its own (both hosts
+// reuse the shared mulmoserver project).
+import { FirebaseApp, FirebaseOptions, initializeApp } from "firebase/app";
+import { Auth, getAuth } from "firebase/auth";
+import { Firestore, getFirestore } from "firebase/firestore";
+import { FirebaseStorage, getStorage } from "firebase/storage";
+
+export interface RemoteHostFirebase {
+  app: FirebaseApp;
+  auth: Auth;
+  firestore: Firestore;
+  // Storage carries the full-res attachment bytes the command channel can't (a
+  // Firestore command doc caps at ~1 MiB). The host, signed in as the user,
+  // pulls each staged upload from `users/{uid}/uploads/{id}` and deletes it
+  // after ingest.
+  storage: FirebaseStorage;
+}
+
+export const createRemoteHostFirebase = (config: FirebaseOptions): RemoteHostFirebase => {
+  const app = initializeApp(config);
+  return { app, auth: getAuth(app), firestore: getFirestore(app), storage: getStorage(app) };
+};

--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -1,19 +1,16 @@
 // Host side of the command channel: claim queued commands, run handlers, write
 // results back, and announce presence via heartbeat.
 //
-// Ported from ../mulmoserver/src/firestore/hostRunner.ts. Adaptations for this
-// repo: `db` import rewired to the Node-side `firestore` instance;
-// `errorMessage` reused from server/utils/errors.ts (the canonical helper)
-// instead of a copied commandFormat.ts; `heartbeatMs` sourced from the time
-// constants; the runTransaction callback param renamed tx -> txn (id-length).
-import { DocumentReference, onSnapshot, query, runTransaction, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
+// Extracted into core from MulmoClaude's server/remoteHost/hostRunner.ts (itself
+// ported from ../mulmoserver). The only signature change vs. that copy: the
+// `firestore` instance is a parameter (each host supplies its own Firebase init),
+// and the heartbeat interval is an option (defaults to one minute).
+import { DocumentReference, Firestore, onSnapshot, query, runTransaction, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
 
-import { errorMessage } from "../utils/errors.js";
-import { ONE_MINUTE_MS } from "../utils/time.js";
-import { Channel, Command, CommandHandler, CommandHandlers, JsonObject, commandsCollection, hostDoc } from "./commandChannel.js";
-import { firestore } from "./firebase.js";
+import { errorMessage } from "../../collection/core/errorMessage.js";
+import { Channel, Command, CommandHandler, CommandHandlers, JsonObject, commandsCollection, hostDoc } from "../index.js";
 
-const heartbeatMs = ONE_MINUTE_MS;
+const DEFAULT_HEARTBEAT_MS = 60_000;
 
 export interface HostEvent {
   phase: "received" | "done" | "error";
@@ -28,6 +25,8 @@ export interface HostRunnerOptions {
   // the runner handle so status() no longer reports connected. NOT called on a
   // normal stop().
   onClosed?: () => void;
+  // Presence heartbeat interval; defaults to one minute.
+  heartbeatMs?: number;
 }
 
 interface Claim {
@@ -43,7 +42,7 @@ const writeError = (ref: DocumentReference, code: string, message: string) =>
 
 // Atomically move a command queued -> processing so it is handled exactly once.
 // Returns the method/params to run, or null if another handler already took it.
-const claimCommand = (ref: DocumentReference): Promise<Claim | null> =>
+const claimCommand = (firestore: Firestore, ref: DocumentReference): Promise<Claim | null> =>
   runTransaction(firestore, async (txn) => {
     const data = (await txn.get(ref)).data() as Command | undefined;
     if (!data || data.status !== "queued") {
@@ -65,8 +64,8 @@ const runHandler = async (ref: DocumentReference, claim: Claim, handler: Command
   }
 };
 
-const processCommand = async (ref: DocumentReference, handlers: CommandHandlers, onEvent?: HostRunnerOptions["onEvent"]) => {
-  const claim = await claimCommand(ref);
+const processCommand = async (firestore: Firestore, ref: DocumentReference, handlers: CommandHandlers, onEvent?: HostRunnerOptions["onEvent"]) => {
+  const claim = await claimCommand(firestore, ref);
   if (!claim) {
     return;
   }
@@ -84,21 +83,21 @@ const processCommand = async (ref: DocumentReference, handlers: CommandHandlers,
 // each one through the supplied handler table. It also announces presence (a
 // heartbeat on users/{uid}/hosts/{hostId}) so the remote can tell it is online.
 // Returns a stop function that goes offline and detaches the listener.
-export const startHostRunner = (channel: Channel, handlers: CommandHandlers, options: HostRunnerOptions = {}): (() => void) => {
-  const presence = hostDoc(channel);
+export const startHostRunner = (firestore: Firestore, channel: Channel, handlers: CommandHandlers, options: HostRunnerOptions = {}): (() => void) => {
+  const presence = hostDoc(firestore, channel);
   const announce = () => {
     setDoc(presence, { online: true, updatedAt: serverTimestamp() }).catch(noop);
   };
   announce();
-  const beat = setInterval(announce, heartbeatMs);
+  const beat = setInterval(announce, options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
 
-  const queuedCommands = query(commandsCollection(channel), where("status", "==", "queued"));
+  const queuedCommands = query(commandsCollection(firestore, channel), where("status", "==", "queued"));
   const unsubscribe = onSnapshot(
     queuedCommands,
     (snapshot) => {
       snapshot.docChanges().forEach((change) => {
         if (change.type === "added") {
-          processCommand(change.doc.ref, handlers, options.onEvent).catch(noop);
+          processCommand(firestore, change.doc.ref, handlers, options.onEvent).catch(noop);
         }
       });
     },

--- a/packages/core/src/remote-host/server/index.ts
+++ b/packages/core/src/remote-host/server/index.ts
@@ -1,0 +1,16 @@
+// Server-only surface of the remote-host transport: the command loop, the
+// connect/disconnect lifecycle, and the Firebase init + auth primitives. Each
+// host (MulmoClaude, MulmoTerminal) provides its own handler table, hostId, and
+// public Firebase config; everything here is host-agnostic.
+//
+// The browser-safe protocol (wire types + Firestore path helpers) lives at the
+// parent `@mulmoclaude/core/remote-host` so the remote/mobile client can share
+// it without pulling this server surface.
+export { startHostRunner } from "./hostRunner.js";
+export type { HostEvent, HostRunnerOptions } from "./hostRunner.js";
+export { createRemoteHost } from "./lifecycle.js";
+export type { RemoteHostStatus, RemoteHostLogger, RemoteHostDeps, RemoteHostLifecycle } from "./lifecycle.js";
+export { createRemoteHostAuth } from "./auth.js";
+export type { RemoteHostAuth } from "./auth.js";
+export { createRemoteHostFirebase } from "./firebase.js";
+export type { RemoteHostFirebase } from "./firebase.js";

--- a/packages/core/src/remote-host/server/lifecycle.ts
+++ b/packages/core/src/remote-host/server/lifecycle.ts
@@ -1,0 +1,117 @@
+// Remote-host lifecycle: wire a Firebase session to the Firestore host runner so
+// connecting starts the command loop + presence heartbeat, and disconnecting
+// stops both.
+//
+// Extracted into core from MulmoClaude's server/remoteHost/index.ts. The factory
+// takes injected collaborators — real hosts bind them to Firebase; tests pass
+// fakes to exercise the invariants (non-destructive connect, serialized
+// transitions, status/liveness reconciliation on fatal listener death) without a
+// network. `hostId` and the logger are injected too, so this file imports no
+// Firebase and no host logger and stays trivially unit-testable.
+//
+// Single-account, single-host per instance, in-memory session: a host restart
+// drops the session and needs a re-connect.
+import type { Channel, CommandHandlers } from "../index.js";
+import type { HostRunnerOptions } from "./hostRunner.js";
+
+export interface RemoteHostStatus {
+  connected: boolean;
+  uid: string | null;
+}
+
+// Minimal logger the factory calls; each host adapts its own logger to this
+// shape (or omits it to run silently, as the tests do).
+export interface RemoteHostLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  debug: (msg: string) => void;
+}
+
+// Injectable collaborators — a real host binds these to Firebase + its own
+// hostId; tests pass fakes to exercise the lifecycle without a network.
+// `startRunner` is the host's `startHostRunner` pre-bound with its Firestore
+// instance, so this module needs no Firebase of its own.
+export interface RemoteHostDeps {
+  hostId: string;
+  signIn: (idToken: string) => Promise<string>;
+  signOut: () => Promise<void>;
+  currentUid: () => string | null;
+  startRunner: (channel: Channel, handlers: CommandHandlers, options: HostRunnerOptions) => () => void;
+  handlers: CommandHandlers;
+  log?: RemoteHostLogger;
+}
+
+export interface RemoteHostLifecycle {
+  connect: (idToken: string) => Promise<RemoteHostStatus>;
+  disconnect: () => Promise<RemoteHostStatus>;
+  status: () => RemoteHostStatus;
+}
+
+const noop = () => undefined;
+const silentLogger: RemoteHostLogger = { info: noop, warn: noop, debug: noop };
+
+export const createRemoteHost = (deps: RemoteHostDeps): RemoteHostLifecycle => {
+  const log = deps.log ?? silentLogger;
+
+  // The running host runner's stop() handle, or null when disconnected. Keeps
+  // the single-host invariant — one runner at a time.
+  let stopRunner: (() => void) | null = null;
+
+  // Serialize connect/disconnect so overlapping requests can't both mutate
+  // stopRunner (which would leak a second runner) or race auth against teardown.
+  // Each transition runs only after the previous one settles; a failed
+  // transition does not block the next (both handlers run the next op).
+  let transition: Promise<unknown> = Promise.resolve();
+
+  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
+    const next = transition.then(operation, operation);
+    transition = next.then(noop, noop);
+    return next;
+  };
+
+  const stopIfRunning = () => {
+    if (stopRunner) {
+      stopRunner();
+      stopRunner = null;
+    }
+  };
+
+  const status = (): RemoteHostStatus => ({ connected: stopRunner !== null, uid: deps.currentUid() });
+
+  const startRunner = (uid: string) => {
+    const runner = deps.startRunner({ uid, hostId: deps.hostId }, deps.handlers, {
+      onEvent: (event) => log.debug(`host event: ${event.phase} ${event.method}`),
+      // The listener died fatally (heartbeat already stopped + offline written);
+      // clear the handle so status() stops reporting connected — but only if it
+      // still points at THIS runner (a later reconnect may have replaced it).
+      onClosed: () => {
+        if (stopRunner === runner) {
+          stopRunner = null;
+          log.warn("host runner listener died; marked disconnected");
+        }
+      },
+    });
+    return runner;
+  };
+
+  const connect = (idToken: string): Promise<RemoteHostStatus> =>
+    serialize(async () => {
+      // Authenticate BEFORE any teardown, so a failed connect (expired/rejected
+      // token) leaves an existing healthy session untouched instead of dropping it.
+      const uid = await deps.signIn(idToken);
+      stopIfRunning();
+      stopRunner = startRunner(uid);
+      log.info(`connected as ${uid}, host runner started (hostId=${deps.hostId})`);
+      return status();
+    });
+
+  const disconnect = (): Promise<RemoteHostStatus> =>
+    serialize(async () => {
+      stopIfRunning();
+      await deps.signOut();
+      log.info("disconnected, host runner stopped");
+      return status();
+    });
+
+  return { connect, disconnect, status };
+};

--- a/packages/core/test/remote-host/test_lifecycle.ts
+++ b/packages/core/test/remote-host/test_lifecycle.ts
@@ -5,11 +5,16 @@
 //   - disconnect stops the runner + signs out
 //   - a FATAL listener death reconciles status() back to disconnected, and the
 //     reconciliation is identity-guarded (a superseded runner can't clear a newer one)
+//
+// The factory takes injected fakes (including a pre-bound startRunner + hostId),
+// so these run without Firebase.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { createRemoteHost, type RemoteHostDeps } from "../../server/remoteHost/index.js";
-import type { Channel } from "../../server/remoteHost/commandChannel.js";
+import { createRemoteHost, type RemoteHostDeps } from "../../src/remote-host/server/lifecycle.js";
+import type { Channel } from "../../src/remote-host/index.js";
+
+const HOST_ID = "test-host";
 
 interface FakeRunner {
   channel: Channel;
@@ -33,6 +38,7 @@ const makeHarness = () => {
   };
 
   const deps: RemoteHostDeps = {
+    hostId: HOST_ID,
     signIn: async (idToken: string) => {
       if (idToken === "bad") throw new Error("rejected credential");
       uid = `uid-${idToken}`;
@@ -57,7 +63,7 @@ describe("createRemoteHost lifecycle", () => {
     assert.deepEqual(status, { connected: true, uid: "uid-t1" });
     assert.equal(runners.length, 1);
     assert.equal(runners[0].stopped, false);
-    assert.deepEqual(runners[0].channel, { uid: "uid-t1", hostId: "mulmoclaude" });
+    assert.deepEqual(runners[0].channel, { uid: "uid-t1", hostId: HOST_ID });
   });
 
   it("failed reconnect is non-destructive: keeps the existing healthy session", async () => {

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -43,12 +43,17 @@ export default defineConfig({
         // Browser-safe remote custom-view contract (phase 3) — consumed by the
         // host server, the desktop phone-frame preview, and mulmoserver.
         "remote-view/index": "src/remote-view/index.ts",
+        // Remote-host transport: the browser-safe command-channel protocol
+        // (shared by host + mobile client) and the server-only host runner +
+        // connect lifecycle + Firebase init/auth. `firebase` is a peer (below).
+        "remote-host/index": "src/remote-host/index.ts",
+        "remote-host/server/index": "src/remote-host/server/index.ts",
       },
       formats: ["es", "cjs"],
       fileName: (format, entryName) => `${entryName}.${format === "es" ? "js" : "cjs"}`,
     },
     rollupOptions: {
-      external: [/^node:/, /^@receptron\//, "zod", "gui-chat-protocol", "fast-xml-parser", "js-yaml"],
+      external: [/^node:/, /^@receptron\//, /^firebase/, "zod", "gui-chat-protocol", "fast-xml-parser", "js-yaml"],
       output: { exports: "named" },
     },
     minify: false,

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.0",
-    "@mulmoclaude/core": "^0.8.2",
+    "@mulmoclaude/core": "^0.9.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -31,13 +31,13 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^0.8.0",
+    "@mulmoclaude/core": "^0.9.0",
     "gui-chat-protocol": "^0.4.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^0.8.0",
+    "@mulmoclaude/core": "^0.9.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.0",
     "@vitejs/plugin-vue": "^6.0.5",

--- a/server/remoteHost/auth.ts
+++ b/server/remoteHost/auth.ts
@@ -1,29 +1,12 @@
-// Firebase credential exchange for the remote-host runner.
+// Firebase credential exchange for this host's remote-host runner.
 //
-// The server authenticates to Firestore *as the user* (Option B) using the
-// Firebase JS SDK's signInWithCredential with a browser-minted Google OAuth ID
-// token — no Admin SDK, no project service account. Security rules keep the
-// server scoped to that user's own users/{uid}/… subtree.
-//
-// This module is the low-level credential primitive; the connect/disconnect
-// lifecycle (which also starts/stops the host runner) lives in index.ts.
-import { GoogleAuthProvider, signInWithCredential, signOut } from "firebase/auth";
+// The credential primitives (signInWithCredential as the user — Option B, no
+// Admin SDK) live in the shared `@mulmoclaude/core/remote-host/server`; this
+// module just binds them to this host's Firebase auth instance. The
+// connect/disconnect lifecycle (which starts/stops the host runner) lives in
+// index.ts.
+import { createRemoteHostAuth } from "@mulmoclaude/core/remote-host/server";
 
 import { auth } from "./firebase.js";
 
-/**
- * Establish the Firebase session from a browser-minted Google OAuth ID token.
- * The token is used once here; the JS SDK then holds its own refresh token for
- * the process lifetime. Returns the authenticated uid.
- */
-export const signInHost = async (idToken: string): Promise<string> => {
-  const credential = GoogleAuthProvider.credential(idToken);
-  const userCredential = await signInWithCredential(auth, credential);
-  return userCredential.user.uid;
-};
-
-/** Tear down the Firebase session (in-memory persistence → re-login on restart). */
-export const signOutHost = (): Promise<void> => signOut(auth);
-
-/** The currently signed-in uid, or null when disconnected. */
-export const currentUid = (): string | null => auth.currentUser?.uid ?? null;
+export const { signInHost, signOutHost, currentUid } = createRemoteHostAuth(auth);

--- a/server/remoteHost/commandChannel.ts
+++ b/server/remoteHost/commandChannel.ts
@@ -1,56 +1,11 @@
-// Command-channel protocol types + Firestore path helpers.
+// Command-channel protocol for this host.
 //
-// Ported from ../mulmoserver/src/firestore/commandChannel.ts (modular
-// firebase/firestore, runs unchanged in Node). Only the `db` import is rewired
-// to this package's Node-side `firestore` instance. The server is host-only, so
-// the remote-side callHost.ts / useHostPresence.ts are intentionally not ported.
-import { CollectionReference, DocumentData, DocumentReference, collection, doc } from "firebase/firestore";
-
-import { firestore } from "./firebase.js";
+// The wire types + Firestore path helpers now live in the shared, browser-safe
+// `@mulmoclaude/core/remote-host` (so the host runner and the mobile client
+// can't drift). This module re-exports them and pins this host's channel id.
+export * from "@mulmoclaude/core/remote-host";
 
 // This MulmoClaude server host's hardcoded channel id. The remote and host just
-// agree on the id — there is no discovery / host registry.
+// agree on the id — there is no discovery / host registry. (MulmoTerminal uses
+// its own id so the two never compete for the same command queue.)
 export const HOST_ID = "mulmoclaude";
-
-// JSON payloads carried by the command channel. Using explicit JSON types
-// keeps the channel typed without resorting to any/unknown.
-export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
-export type JsonObject = Record<string, JsonValue>;
-
-// A channel routes commands to one specific host. Both sides agree on a
-// hardcoded hostId per use case (e.g. "test", "mulmoclaude"); there is no
-// discovery — the remote and host just share the id.
-export interface Channel {
-  uid: string;
-  hostId: string;
-}
-
-export type CommandStatus = "queued" | "processing" | "done" | "error";
-
-export interface CommandError {
-  code: string;
-  message: string;
-}
-
-// One document in a channel's commands subcollection is one API-call-like
-// request. The remote (mobile) writes method/params; the host writes
-// result/error/status.
-export interface Command {
-  method: string;
-  params: JsonObject;
-  status: CommandStatus;
-  result: JsonValue;
-  error: CommandError | null;
-  createdBy: "remote" | "host";
-}
-
-export type CommandHandler = (params: JsonObject) => JsonValue | Promise<JsonValue>;
-export type CommandHandlers = Record<string, CommandHandler>;
-
-// Per-host command queue: users/{uid}/hosts/{hostId}/commands.
-export const commandsCollection = (channel: Channel): CollectionReference<DocumentData> =>
-  collection(firestore, "users", channel.uid, "hosts", channel.hostId, "commands");
-
-// Presence doc for a host: users/{uid}/hosts/{hostId}. The host heartbeats
-// { online, updatedAt } here; the remote reads it to know if the host is up.
-export const hostDoc = (channel: Channel): DocumentReference<DocumentData> => doc(firestore, "users", channel.uid, "hosts", channel.hostId);

--- a/server/remoteHost/firebase.ts
+++ b/server/remoteHost/firebase.ts
@@ -1,22 +1,12 @@
-// Node-side Firebase init for the remote-host runner.
+// Node-side Firebase init for this host's remote-host runner.
 //
-// The MulmoClaude server acts as a *host*: it signs in to Firebase as the user
-// (via signInWithCredential, see auth.ts) and listens to that user's command
-// queue in Firestore. The modular firebase/firestore + firebase/auth SDKs run
-// in Node, so this mirrors the browser init but also exposes Firestore (default
-// database, which must be in Native mode).
-import { initializeApp } from "firebase/app";
-import { getAuth } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
+// The init itself (initializeApp + getAuth/getFirestore/getStorage) lives in the
+// shared `@mulmoclaude/core/remote-host/server` so both hosts share one copy;
+// this module just supplies MulmoClaude's public web config. Firestore is the
+// default database and must be in Native mode. Storage carries the full-res
+// attachment bytes the command channel can't (see handlers/ingestAttachments.ts).
+import { createRemoteHostFirebase } from "@mulmoclaude/core/remote-host/server";
 
 import { firebaseConfig } from "../../src/config/firebaseConfig.js";
 
-export const firebaseApp = initializeApp(firebaseConfig);
-export const auth = getAuth(firebaseApp);
-export const firestore = getFirestore(firebaseApp);
-// Storage carries the full-res attachment bytes the command channel can't (a
-// Firestore command doc caps at ~1 MiB). The host, signed in as the user, pulls
-// each staged upload from `users/{uid}/uploads/{id}` and deletes it after
-// ingest — see handlers/ingestAttachments.ts.
-export const storage = getStorage(firebaseApp);
+export const { app: firebaseApp, auth, firestore, storage } = createRemoteHostFirebase(firebaseConfig);

--- a/server/remoteHost/index.ts
+++ b/server/remoteHost/index.ts
@@ -1,117 +1,41 @@
-// Remote-host lifecycle: wire the Firebase session (auth.ts) to the Firestore
-// host runner (hostRunner.ts) so that connecting from the toolbar starts the
-// command loop + presence heartbeat, and disconnecting stops both.
+// Remote-host lifecycle for this host: bind MulmoClaude's Firebase deps + hostId
+// to the shared `createRemoteHost` factory so connecting from the toolbar starts
+// the Firestore command loop + presence heartbeat, and disconnecting stops both.
 //
-// Single-account, single-host (HOST_ID = "mulmoclaude"), in-memory session:
-// a server restart drops the session and needs a re-connect (phase-1 default).
+// The transport engine (command loop, connect/disconnect invariants, Firebase
+// init/auth) lives in `@mulmoclaude/core/remote-host/server`; this module only
+// supplies host specifics — hostId, the handler table, the firestore-bound
+// runner, and a logger adapter — and exposes the default singleton the route uses.
 //
-// The lifecycle is exposed as a factory (createRemoteHost) so the invariants
-// — non-destructive connect, serialized transitions, status/liveness
-// reconciliation on fatal listener death — are unit-testable with fake deps.
-// A default singleton wired to the real Firebase deps backs the route.
+// Single-account, single-host (HOST_ID = "mulmoclaude"), in-memory session: a
+// server restart drops the session and needs a re-connect.
+import { createRemoteHost, startHostRunner } from "@mulmoclaude/core/remote-host/server";
+
 import { log } from "../system/logger/index.js";
 import { HOST_ID } from "./commandChannel.js";
-import type { CommandHandlers } from "./commandChannel.js";
 import { currentUid, signInHost, signOutHost } from "./auth.js";
+import { firestore } from "./firebase.js";
 import { handlers } from "./handlers/index.js";
-import { startHostRunner } from "./hostRunner.js";
+
+export type { RemoteHostStatus } from "@mulmoclaude/core/remote-host/server";
 
 const PREFIX = "remote-host";
 
-export interface RemoteHostStatus {
-  connected: boolean;
-  uid: string | null;
-}
-
-// Injectable collaborators — the real singleton binds these to Firebase; tests
-// pass fakes to exercise the lifecycle without a network.
-export interface RemoteHostDeps {
-  signIn: (idToken: string) => Promise<string>;
-  signOut: () => Promise<void>;
-  currentUid: () => string | null;
-  startRunner: typeof startHostRunner;
-  handlers: CommandHandlers;
-}
-
-export interface RemoteHostLifecycle {
-  connect: (idToken: string) => Promise<RemoteHostStatus>;
-  disconnect: () => Promise<RemoteHostStatus>;
-  status: () => RemoteHostStatus;
-}
-
-const noop = () => undefined;
-
-export const createRemoteHost = (deps: RemoteHostDeps): RemoteHostLifecycle => {
-  // The running host runner's stop() handle, or null when disconnected. Keeps
-  // the single-host invariant — one runner at a time.
-  let stopRunner: (() => void) | null = null;
-
-  // Serialize connect/disconnect so overlapping requests can't both mutate
-  // stopRunner (which would leak a second runner) or race auth against teardown.
-  // Each transition runs only after the previous one settles; a failed
-  // transition does not block the next (both handlers run the next op).
-  let transition: Promise<unknown> = Promise.resolve();
-
-  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
-    const next = transition.then(operation, operation);
-    transition = next.then(noop, noop);
-    return next;
-  };
-
-  const stopIfRunning = () => {
-    if (stopRunner) {
-      stopRunner();
-      stopRunner = null;
-    }
-  };
-
-  const status = (): RemoteHostStatus => ({ connected: stopRunner !== null, uid: deps.currentUid() });
-
-  const startRunner = (uid: string) => {
-    const runner = deps.startRunner({ uid, hostId: HOST_ID }, deps.handlers, {
-      onEvent: (event) => log.debug(PREFIX, `host event: ${event.phase} ${event.method}`, { event }),
-      // The listener died fatally (heartbeat already stopped + offline written);
-      // clear the handle so status() stops reporting connected — but only if it
-      // still points at THIS runner (a later reconnect may have replaced it).
-      onClosed: () => {
-        if (stopRunner === runner) {
-          stopRunner = null;
-          log.warn(PREFIX, "host runner listener died; marked disconnected");
-        }
-      },
-    });
-    return runner;
-  };
-
-  const connect = (idToken: string): Promise<RemoteHostStatus> =>
-    serialize(async () => {
-      // Authenticate BEFORE any teardown, so a failed connect (expired/rejected
-      // token) leaves an existing healthy session untouched instead of dropping it.
-      const uid = await deps.signIn(idToken);
-      stopIfRunning();
-      stopRunner = startRunner(uid);
-      log.info(PREFIX, `connected as ${uid}, host runner started (hostId=${HOST_ID})`);
-      return status();
-    });
-
-  const disconnect = (): Promise<RemoteHostStatus> =>
-    serialize(async () => {
-      stopIfRunning();
-      await deps.signOut();
-      log.info(PREFIX, "disconnected, host runner stopped");
-      return status();
-    });
-
-  return { connect, disconnect, status };
-};
-
-// Default singleton wired to the real Firebase deps — imported by the route.
+// Default singleton wired to the real Firebase deps — imported by the route. The
+// runner is pre-bound with this host's firestore instance; the logger adapts the
+// factory's plain-string calls to the host logger's (prefix, msg) shape.
 const instance = createRemoteHost({
+  hostId: HOST_ID,
   signIn: signInHost,
   signOut: signOutHost,
   currentUid,
-  startRunner: startHostRunner,
+  startRunner: (channel, hostHandlers, options) => startHostRunner(firestore, channel, hostHandlers, options),
   handlers,
+  log: {
+    info: (msg) => log.info(PREFIX, msg),
+    warn: (msg) => log.warn(PREFIX, msg),
+    debug: (msg) => log.debug(PREFIX, msg),
+  },
 });
 
 export const { connect, disconnect, status } = instance;


### PR DESCRIPTION
## Summary

Pure refactor (no behavior change): extract the generic remote-host **transport** out of MulmoClaude's `server/remoteHost/` into `@mulmoclaude/core`, so the upcoming MulmoTerminal port consumes one shared copy instead of minting a third (the code originated in `../mulmoserver`, was copied into MulmoClaude, and would otherwise be copied again).

This is **PR 1 of 2**. PR 2 = the MulmoTerminal consumer (plan: receptron/mulmoterminal#216), which is blocked on `@mulmoclaude/core@0.9.0` publishing.

## What moved to core

Two subpaths, split on the browser-safe boundary (mirrors the existing `@mulmoclaude/core/remote-view`):

| Import | Surface | Provides |
|---|---|---|
| `@mulmoclaude/core/remote-host` | browser-safe | Protocol wire types + Firestore path helpers `commandsCollection(firestore, channel)` / `hostDoc(firestore, channel)` — shared by host **and** the mobile client |
| `@mulmoclaude/core/remote-host/server` | server-only | `startHostRunner` (command loop), `createRemoteHost` (lifecycle), `createRemoteHostAuth` / `createRemoteHostFirebase` |

**One real refactor:** the path helpers + runner now take the `firestore` instance as a **parameter** (was a module-level singleton), and `createRemoteHost` takes an injected `hostId` + logger so it imports no Firebase and stays unit-testable.

## Host side is now a thin consumer

`server/remoteHost/{index,firebase,auth,commandChannel}.ts` shrink to binding MulmoClaude's `firebaseConfig`, `hostId="mulmoclaude"`, handler table, and logger to the shared engine. `hostRunner.ts` and the lifecycle test **move** into core (the test generalized for the injected hostId).

## Versioning

- `@mulmoclaude/core` 0.8.2 → **0.9.0** (new subpaths).
- `firebase` added as an **optional** `peerDependency` of core (externalized in the build — verified the dist `require("firebase/*")` rather than bundling).
- Launcher + collection-plugin peer `@mulmoclaude/core` ranges → `^0.9.0` to keep the `launcherSync.mjs` invariant green (launcher's own version untouched, per the `chore(release)` rule).

## Verification

- `yarn typecheck` ✓ (host + all plugins), `yarn build` ✓ (host + core), `yarn lint` ✓ (0 errors; `--no-cache` on the new/moved files clean)
- `yarn format` ✓
- Host tests **5296 pass / 0 fail**; remote-host suite **88 pass**; core tests **275 pass** (incl. the 6 moved lifecycle tests)
- `node scripts/mulmoclaude/launcherSync.mjs` → OK

## Follow-up

Publish `@mulmoclaude/core@0.9.0` (via `/publish`), then land the MulmoTerminal consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote host support is now available through a shared, packaged interface.
  * Host setup can now use separately initialized authentication, database, and storage services.

* **Improvements**
  * Connection handling is more reliable, with safer connect/disconnect sequencing.
  * Presence updates now support a configurable heartbeat interval.

* **Documentation**
  * Updated remote host docs to reflect the new code layout and command flow.

* **Chores**
  * Updated package versions and build outputs to include the new remote host entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->