### PR TITLE
feat(files): Office (xlsx / docx / pptx) preview + open-in-OS fallback (#1985)

### DIFF
--- a/plans/feat-1985-office-file-preview.md
+++ b/plans/feat-1985-office-file-preview.md
@@ -1,0 +1,131 @@
+# feat(#1985): Office (xlsx / docx / pptx) file preview + open-in-OS fallback
+
+## Summary
+
+`GET /api/files/content` を拡張して、Office 系ファイル (xlsx / docx / pptx) を
+サーバ側で変換して preview 用データを返す。加えて `/api/files/open` を新設し、
+OS のファイルマネージャで開くボタン (「Finder で開く」等) を全ての "supported
+だけど editor で直接編集できない" 系のファイルに追加。
+
+- **xlsx**: SheetJS で CSV per sheet に変換 → sheet 情報付き JSON で返す →
+  frontend で `<table>` 化 (最初のシートだけ表示、複数シートは tab or select)
+- **docx**: mammoth で plain text 抽出 → 既存の text kind で返す
+- **pptx**: 既存の `convertPptxToPdf()` を preview 用にも呼ぶ → 変換済み PDF
+  を per-request temp に置く → 既存の PDF viewer で表示。LibreOffice 未検出時は
+  fallback に落ちる
+- **共通**: 上記のいずれも変換失敗 or 大きすぎるときは "OS で開く" ボタンを
+  fallback として表示
+
+## Items to Confirm / Review
+
+- **Deps は既に揃っている**: `mammoth` / `xlsx` (SheetJS) は attachment 変換
+  で既に import 済み、LibreOffice も Docker sandbox で使用済み。今回追加の
+  npm dep は無し。
+- **キャッシュ戦略**: xlsx/docx 変換は速い (数十 ms) ので毎回変換で OK。
+  pptx は LibreOffice subprocess で 2-5s かかるので **mtime + size でキャッシュ**
+  ハッシュ、`os.tmpdir()/mulmoclaude-office-cache/<hash>.pdf` に保存。同一
+  ファイルの再閲覧を即時化。
+- **サイズ制限**: 既存の `MAX_RAW_BYTES` を xlsx/docx/pptx にも適用。過大
+  ファイルは変換前に too-large 応答して conversion CPU を守る。
+- **セキュリティ**: `/api/files/open` は既存の `resolveWithinRoot` を使って
+  workspace 内のパスのみ許可。実行は per-platform:
+  - macOS: `open <abs-path>`
+  - Linux: `xdg-open <abs-path>` (headless 環境では失敗するが害なし)
+  - Windows: `start "" <abs-path>` (cmd 経由、パス quote 必須)
+  Docker sandbox 内は host の OS にアクセスできないので、`DISABLE_SANDBOX`
+  未設定でも host 側 Express が spawn する形。
+- **i18n**: 8 ロケール lockstep で新規キー追加。
+- **既存の "text file" 大き過ぎるとき用 too-large 挙動は流用**: xlsx/docx で
+  変換後テキストが `MAX_PREVIEW_BYTES` 越えたら too-large にする。
+
+## User Prompt
+
+> https://github.com/receptron/mulmoclaude/issues/1985 viewer を追加できる？
+> office 系の document できるだけみえたほうがよいね。
+> B: preview + Finder fallback (Recommended).
+
+## Implementation
+
+### Server
+
+1. **`server/utils/officePreview.ts`** (新規、~150 lines):
+   - `previewXlsx(absPath: string): Promise<{ sheets: { name: string; csv: string }[] } | null>`
+   - `previewDocx(absPath: string): Promise<string | null>` (plain text)
+   - `previewPptxAsPdf(absPath: string): Promise<string | null>` (returns path
+     to a cached temp PDF, or null if LibreOffice not available). Cache key:
+     `sha1(absPath + mtimeMs + size)` → `<tmp>/mulmoclaude-office-cache/<key>.pdf`
+   - Deps: `mammoth`, `xlsx`, subprocess spawn for LibreOffice, `crypto.createHash`
+2. **`server/api/routes/files.ts`** の `GET /api/files/content`:
+   - `classify()` に新 kind `office-xlsx` / `office-docx` / `office-pptx` を追加
+   - handler で該当拡張子なら converter を呼び、変換結果 (xlsx→sheets, docx→text,
+     pptx→pdf-path) を response body に含める
+3. **新規 `GET /api/files/preview-raw`** (pptx の変換済み PDF を stream):
+   - path + workspace 内 gate、`previewPptxAsPdf()` の返す absolute path から
+     stream。既存 `/api/files/raw` と同じ safety パターン
+4. **新規 `POST /api/files/open`**:
+   - body: `{ path: string }`, workspace 内 gate
+   - platform 判定して `open` / `xdg-open` / `start` を spawn (detached, timeout)
+   - respose: `{ ok: true }` (成功) or `{ ok: false, error: string }` (spawn 失敗)
+
+### Client
+
+5. **`src/config/apiRoutes.ts`**: `files.open`, `files.previewRaw` 追加
+6. **`src/composables/useFileSelection.ts`**: `FileContent` 型に新 variants:
+   ```typescript
+   | { kind: "office-xlsx"; sheets: { name: string; csv: string }[]; ...meta }
+   | { kind: "office-docx"; content: string; ...meta }
+   | { kind: "office-pptx"; previewUrl: string; ...meta }
+   ```
+7. **`src/components/FileContentRenderer.vue`**:
+   - xlsx: sheet 選択 UI (最初は 1 sheet だけならそのまま) + CSV を `<table>`
+     化する軽い parser (ダブルクォート考慮)
+   - docx: `<pre class="whitespace-pre-wrap">` で text 表示
+   - pptx: 既存の PDF `<iframe>` を previewUrl 経由で使用
+   - fallback (variant なし or 変換失敗): "OS で開く" ボタン + 従来の
+     `content.message` 表示
+8. **`src/components/FileContentHeader.vue`** or `FileContentRenderer.vue` の
+   fallback branch: `apiPost(API_ROUTES.files.open, { path: selectedPath })`
+   を叩くボタン。任意のファイル種でも表示 (unsupported preview のとき最も
+   便利、supported でも Excel で直接開きたい時に有用)
+9. **`src/lang/*.ts` × 8**: `filesView.openInOs` (mac は "Finder で表示",
+   linux は "ファイルマネージャで開く", windows は "エクスプローラで開く" —
+   実際は "Open in OS" 相当の共通文言で ok)、`filesView.officePreviewFailed`
+   (LibreOffice 未検出等の fallback メッセージ)、xlsx の sheet 選択ラベル等
+
+### Tests
+
+10. **`test/routes/test_filesRoute_office.ts`** (新規):
+    - `.xlsx` GET → `sheets: [{ name, csv }]` の shape assert
+    - `.docx` GET → `content: "..."` の text
+    - `.pptx` GET → LibreOffice ある環境なら `previewUrl` 返り + preview-raw
+      から PDF binary が取れる、無い環境なら fallback binary kind
+    - `/api/files/open` — mac / linux / windows の 3 分岐で `execFile` を
+      spy して呼ばれる引数を assert (実際に spawn はしない)
+11. **`test/utils/officePreview.spec.ts`** (新規): SheetJS wrapper + docx
+    wrapper の pure conversion test。既存の attachment converter test が
+    参考になる
+
+### Docs
+
+12. `docs/manual-testing.md` に追記: xlsx/docx/pptx の preview 動作確認手順、
+    LibreOffice 未検出時の fallback 挙動。
+
+## Test plan
+
+- [ ] `yarn tsx --test test/utils/officePreview.spec.ts test/routes/test_filesRoute_office.ts` — pure + integration
+- [ ] `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build`
+- [ ] 手動: `data/attachments` に生成された `.xlsx` / `.docx` / `.pptx` を
+  Files ビューで開いて preview 表示を確認、"OS で開く" ボタンでネイティブ
+  アプリが起動することを確認
+- [ ] LibreOffice 無い環境で pptx を開いて fallback UI が表示されることを
+  確認 (Homebrew の libreoffice を temporarily unlink して検証)
+
+## Out of scope
+
+- **Editing** (xlsx セルの編集、docx の re-write): preview のみ。編集は "OS で開く"
+  で Excel/Word/Keynote に任せる
+- **PPTX の高精度レンダリング**: LibreOffice の PDF 変換の見た目 (フォント差異)
+  を修正するのは範囲外
+- **doc / xls (旧バイナリ形式)** のサポート: 今回は Open XML (docx/xlsx/pptx)
+  のみ。旧形式の需要が出たら別 issue で
+- **Remote host からの preview**: remote-view API に埋め込むのは別スコープ

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -1216,18 +1216,27 @@ router.get(API_ROUTES.files.previewRaw, async (req: Request<object, unknown, unk
 // validation mirrors every other files route. Fire-and-forget: we
 // return once the subprocess has been spawned; anything the OS does
 // afterwards is out of our hands (and the user's problem).
+//
+// Accepts `path` in EITHER the JSON body or the query string so the
+// route stays working when a request lands without a parsed body
+// (proxy edge case, empty POST from a script). `resolveAndStatFile`
+// reads path from the query, so we canonicalise onto that.
 interface OpenFileRequest {
   path?: unknown;
 }
-router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFileRequest>, res: Response<{ ok: boolean } | ErrorResponse>) => {
-  const requestedPath = typeof req.body?.path === "string" ? req.body.path : "";
+router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFileRequest, PathQuery>, res: Response<{ ok: boolean } | ErrorResponse>) => {
+  const bodyPath = typeof req.body?.path === "string" ? req.body.path : "";
+  const queryPath = getOptionalStringQuery(req, "path") ?? "";
+  const requestedPath = bodyPath || queryPath;
   if (!requestedPath) {
+    log.warn("files", "POST open: no path", {
+      hasBody: req.body !== undefined && req.body !== null,
+      bodyPathType: typeof req.body?.path,
+      queryPath: previewSnippet(queryPath),
+    });
     badRequest(res, "path required");
     return;
   }
-  // Reuse the same resolve+stat gate as /content. Set the path onto
-  // the query object so `resolveAndStatFile` (which reads from the
-  // query) accepts the POST body's path.
   (req.query as PathQuery).path = requestedPath;
   const ctx = resolveAndStatFile(req, res);
   if (!ctx) return;

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -13,7 +13,13 @@ import { getCachedReferenceDirs } from "../../workspace/reference-dirs.js";
 import { classifyAsWikiPage, writeWikiPage } from "../../workspace/wiki-pages/io.js";
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
+import { officeKind, previewXlsx, previewDocx, previewPptxAsPdf } from "../../utils/officePreview.js";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../../utils/time.js";
 import { publishFileChange } from "../../events/file-change.js";
+
+const execFileAsync = promisify(execFile);
 
 const router = Router();
 
@@ -177,7 +183,36 @@ interface FileContentMeta {
   message?: string;
 }
 
-type FileContentResponse = FileContentText | FileContentMeta;
+// Office document previews (#1985). All server-converted server-side
+// so the client renders a table / text / PDF without shipping mammoth /
+// SheetJS / LibreOffice to the browser.
+interface FileContentOfficeXlsx {
+  kind: "office-xlsx";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  /** One entry per worksheet; `csv` is SheetJS `sheet_to_csv` output. */
+  sheets: { name: string; csv: string }[];
+}
+interface FileContentOfficeDocx {
+  kind: "office-docx";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  /** Plain text extracted via mammoth. */
+  content: string;
+}
+interface FileContentOfficePptx {
+  kind: "office-pptx";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  /** Client fetches the converted PDF from this URL. Present only when
+   *  LibreOffice was available and conversion succeeded. */
+  previewUrl: string;
+}
+
+type FileContentResponse = FileContentText | FileContentMeta | FileContentOfficeXlsx | FileContentOfficeDocx | FileContentOfficePptx;
 
 export type ContentKind = "text" | "image" | "pdf" | "audio" | "video" | "binary";
 
@@ -686,7 +721,38 @@ function resolveAndStatFile<T>(
   return { relPath, absPath, stat };
 }
 
-router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, PathQuery>, res: Response<FileContentResponse | ErrorResponse>) => {
+interface FileMeta {
+  path: string;
+  size: number;
+  modifiedMs: number;
+}
+
+/** Server-side conversion of Office Open XML formats for the Files view
+ *  (#1985). Returns the specific `office-*` response shape on success,
+ *  or `null` when the file isn't office or every converter failed —
+ *  callers fall through to the generic "binary" response. Split out of
+ *  the content route to keep that handler under the cognitive-complexity
+ *  ceiling. */
+async function tryOfficePreview(absPath: string, relPath: string, meta: FileMeta): Promise<FileContentResponse | null> {
+  const office = officeKind(absPath);
+  if (office === "office-xlsx") {
+    const sheets = await previewXlsx(absPath);
+    return sheets === null ? null : { kind: "office-xlsx", ...meta, sheets };
+  }
+  if (office === "office-docx") {
+    const content = await previewDocx(absPath);
+    return content === null ? null : { kind: "office-docx", ...meta, content };
+  }
+  if (office === "office-pptx") {
+    const pdfPath = await previewPptxAsPdf(absPath);
+    if (pdfPath === null) return null;
+    const previewUrl = `${API_ROUTES.files.previewRaw}?path=${encodeURIComponent(relPath)}`;
+    return { kind: "office-pptx", ...meta, previewUrl };
+  }
+  return null;
+}
+
+router.get(API_ROUTES.files.content, async (req: Request<object, unknown, unknown, PathQuery>, res: Response<FileContentResponse | ErrorResponse>) => {
   const requestedPath = getOptionalStringQuery(req, "path") ?? "";
   log.info("files", "GET content: start", { pathPreview: previewSnippet(requestedPath) });
   const ctx = resolveAndStatFile(req, res);
@@ -725,6 +791,16 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
     return;
   }
   if (kind === "binary") {
+    // Office Open XML formats (.xlsx / .docx / .pptx) get server-side
+    // conversion so the Files view can render them inline (#1985). All
+    // three converters return null on failure — we then fall through to
+    // the generic "binary" response and the client shows the "Open in
+    // OS" fallback UI.
+    const officePreview = await tryOfficePreview(absPath, relPath, meta);
+    if (officePreview !== null) {
+      res.json(officePreview);
+      return;
+    }
     res.json({
       kind: "binary",
       ...meta,
@@ -1110,6 +1186,70 @@ router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQue
 // Returns configured reference directories as top-level TreeNode[]
 // for the file explorer. Each node's path uses the @ref/<label>
 // prefix so subsequent /dir and /content requests route correctly.
+
+// GET /api/files/preview-raw?path=<rel> — stream the server-converted
+// PDF preview of a .pptx file (#1985). Path validation mirrors every
+// other files route; refuses when the target isn't a pptx or when
+// LibreOffice isn't available for conversion. Cached on disk under
+// `os.tmpdir()/mulmoclaude-office-preview/` so re-opens don't re-run
+// LibreOffice.
+router.get(API_ROUTES.files.previewRaw, async (req: Request<object, unknown, unknown, PathQuery>, res: Response<ErrorResponse>) => {
+  const ctx = resolveAndStatFile(req, res);
+  if (!ctx) return;
+  const { absPath } = ctx;
+  if (officeKind(absPath) !== "office-pptx") {
+    notFound(res, "preview-raw is only available for .pptx files");
+    return;
+  }
+  const pdfPath = await previewPptxAsPdf(absPath);
+  if (!pdfPath) {
+    notFound(res, "pptx preview not available (LibreOffice missing or conversion failed)");
+    return;
+  }
+  res.setHeader("Content-Type", "application/pdf");
+  createReadStream(pdfPath).pipe(res);
+});
+
+// POST /api/files/open — ask the host OS to open the file in its
+// default application / file manager (#1985). Cross-platform: macOS
+// `open`, Linux `xdg-open`, Windows `start`. Workspace-scoped path
+// validation mirrors every other files route. Fire-and-forget: we
+// return once the subprocess has been spawned; anything the OS does
+// afterwards is out of our hands (and the user's problem).
+interface OpenFileRequest {
+  path?: unknown;
+}
+router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFileRequest>, res: Response<{ ok: boolean } | ErrorResponse>) => {
+  const requestedPath = typeof req.body?.path === "string" ? req.body.path : "";
+  if (!requestedPath) {
+    badRequest(res, "path required");
+    return;
+  }
+  // Reuse the same resolve+stat gate as /content. Set the path onto
+  // the query object so `resolveAndStatFile` (which reads from the
+  // query) accepts the POST body's path.
+  (req.query as PathQuery).path = requestedPath;
+  const ctx = resolveAndStatFile(req, res);
+  if (!ctx) return;
+  const { absPath } = ctx;
+  const { platform } = process;
+  try {
+    if (platform === "darwin") {
+      await execFileAsync("open", [absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    } else if (platform === "win32") {
+      // `start` is a cmd built-in; the empty "" is a title placeholder
+      // required when the target path is quoted (else cmd interprets
+      // the first quoted arg as the window title, not the file).
+      await execFileAsync("cmd", ["/c", "start", "", absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    } else {
+      await execFileAsync("xdg-open", [absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    }
+    res.json({ ok: true });
+  } catch (err) {
+    log.warn("files", "POST open: spawn failed", { platform, error: errorMessage(err) });
+    serverError(res, `Failed to open file in OS: ${errorMessage(err)}`);
+  }
+});
 
 router.get(API_ROUTES.files.refRoots, async (_req: Request, res: Response<TreeNode[]>) => {
   log.info("files", "GET ref-roots: start");

--- a/server/utils/officePreview.ts
+++ b/server/utils/officePreview.ts
@@ -1,0 +1,133 @@
+// Preview conversions for Office Open XML formats. Read the file from
+// disk, convert with the same libraries the attachment converter uses
+// (mammoth / xlsx / libreoffice), and return a shape that the client
+// can render inline (#1985).
+//
+// Deliberately separated from `server/agent/attachmentConverter.ts`
+// because attachment conversion is turn-scoped (feed data into Claude's
+// context) whereas preview is UI-scoped and needs to hit an on-disk
+// path — the two call signatures don't overlap cleanly enough to share
+// a common function.
+
+import { readFile, mkdtemp, stat, mkdir, copyFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import mammoth from "mammoth";
+import * as XLSX from "xlsx";
+import { SUBPROCESS_PROBE_TIMEOUT_MS, SUBPROCESS_WORK_TIMEOUT_MS } from "./time.js";
+import { log } from "../system/logger/index.js";
+import { errorMessage } from "./errors.js";
+
+const execFileAsync = promisify(execFile);
+const LOG_PREFIX = "office-preview";
+
+export interface XlsxSheetPreview {
+  name: string;
+  /** CSV representation of the sheet (SheetJS `sheet_to_csv`). */
+  csv: string;
+}
+
+export async function previewXlsx(absPath: string): Promise<XlsxSheetPreview[] | null> {
+  try {
+    const buf = await readFile(absPath);
+    const workbook = XLSX.read(buf, { type: "buffer" });
+    return workbook.SheetNames.map((name) => ({
+      name,
+      csv: XLSX.utils.sheet_to_csv(workbook.Sheets[name]),
+    }));
+  } catch (err) {
+    log.warn(LOG_PREFIX, "xlsx preview failed", { path: absPath, error: errorMessage(err) });
+    return null;
+  }
+}
+
+export async function previewDocx(absPath: string): Promise<string | null> {
+  try {
+    const buf = await readFile(absPath);
+    const result = await mammoth.extractRawText({ buffer: buf });
+    return result.value;
+  } catch (err) {
+    log.warn(LOG_PREFIX, "docx preview failed", { path: absPath, error: errorMessage(err) });
+    return null;
+  }
+}
+
+// ── PPTX → PDF via LibreOffice (cached) ─────────────────────────
+
+async function hasNativeLibreOffice(): Promise<boolean> {
+  try {
+    await execFileAsync("libreoffice", ["--version"], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Cache converted PDFs by (path + mtime + size). LibreOffice takes 2-5s
+// per conversion; caching makes re-opening the same slide instant. The
+// cache lives under the OS tmp dir so it clears between reboots.
+const CACHE_DIR = path.join(tmpdir(), "mulmoclaude-office-preview");
+
+async function ensureCacheDir(): Promise<void> {
+  if (!existsSync(CACHE_DIR)) await mkdir(CACHE_DIR, { recursive: true });
+}
+
+function cacheKey(absPath: string, mtimeMs: number, size: number): string {
+  // SHA-256 rather than SHA-1: this is only a cache path, not a
+  // security guarantee, but sonarjs/hashing bans SHA-1 project-wide.
+  return createHash("sha256").update(`${absPath}|${mtimeMs}|${size}`).digest("hex");
+}
+
+/** Convert a `.pptx` to PDF via LibreOffice, cached on disk keyed by
+ *  path+mtime+size. Returns the absolute PDF path on success, `null`
+ *  when LibreOffice is unavailable or conversion fails — callers fall
+ *  back to the "open in OS" UI. */
+export async function previewPptxAsPdf(absPath: string): Promise<string | null> {
+  if (!(await hasNativeLibreOffice())) return null;
+
+  let fileStat;
+  try {
+    fileStat = await stat(absPath);
+  } catch (err) {
+    log.warn(LOG_PREFIX, "pptx stat failed", { path: absPath, error: errorMessage(err) });
+    return null;
+  }
+
+  await ensureCacheDir();
+  const key = cacheKey(absPath, fileStat.mtimeMs, fileStat.size);
+  const cachedPdf = path.join(CACHE_DIR, `${key}.pdf`);
+  if (existsSync(cachedPdf)) return cachedPdf;
+
+  // Convert into a per-conversion temp dir, then move to the cache.
+  // Doing the conversion straight into the cache dir would let a
+  // concurrent request see a half-written PDF.
+  const tmp = await mkdtemp(path.join(tmpdir(), "mc-pptx-"));
+  try {
+    // LibreOffice reads the file in place; write nothing extra.
+    await execFileAsync("libreoffice", ["--headless", "--convert-to", "pdf", "--outdir", tmp, absPath], { timeout: SUBPROCESS_WORK_TIMEOUT_MS });
+    const baseName = path.basename(absPath, path.extname(absPath));
+    const convertedPdf = path.join(tmp, `${baseName}.pdf`);
+    if (!existsSync(convertedPdf)) {
+      log.warn(LOG_PREFIX, "pptx conversion produced no output", { path: absPath, expected: convertedPdf });
+      return null;
+    }
+    await copyFile(convertedPdf, cachedPdf);
+    return cachedPdf;
+  } catch (err) {
+    log.warn(LOG_PREFIX, "pptx conversion failed", { path: absPath, error: errorMessage(err) });
+    return null;
+  }
+}
+
+/** Classify an office file by its extension. `null` for non-office. */
+export function officeKind(filename: string): "office-xlsx" | "office-docx" | "office-pptx" | null {
+  const ext = path.extname(filename).toLowerCase();
+  if (ext === ".xlsx") return "office-xlsx";
+  if (ext === ".docx") return "office-docx";
+  if (ext === ".pptx") return "office-pptx";
+  return null;
+}

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -237,9 +237,51 @@
       <div v-else-if="content.kind === 'video' && selectedPath" class="h-full flex items-center justify-center p-4 bg-black">
         <video :key="selectedPath" :src="rawUrl(selectedPath)" controls preload="metadata" class="max-w-full max-h-full" />
       </div>
+      <!-- XLSX (server-converted to CSV per sheet, rendered as a table) -->
+      <div v-else-if="content.kind === 'office-xlsx' && selectedPath" class="h-full flex flex-col overflow-hidden">
+        <div v-if="content.sheets.length > 1" class="flex-shrink-0 px-3 pt-2 flex items-center gap-2 border-b border-gray-200 text-xs">
+          <span class="text-gray-500">{{ t("fileContentRenderer.xlsxSheet") }}:</span>
+          <select v-model="activeXlsxSheet" class="px-2 py-1 border border-gray-300 rounded">
+            <option v-for="s in content.sheets" :key="s.name" :value="s.name">{{ s.name }}</option>
+          </select>
+        </div>
+        <div class="flex-1 overflow-auto p-3">
+          <table class="text-xs border-collapse">
+            <tbody>
+              <tr v-for="(row, ri) in currentXlsxRows" :key="ri">
+                <td v-for="(cell, ci) in row" :key="ci" class="border border-gray-200 px-2 py-1 whitespace-pre align-top">{{ cell }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <!-- DOCX (server-extracted plain text) -->
+      <pre v-else-if="content.kind === 'office-docx' && selectedPath" class="p-4 text-sm whitespace-pre-wrap font-sans text-gray-800 overflow-auto h-full">{{
+        content.content
+      }}</pre>
+      <!-- PPTX (server-converted to PDF via LibreOffice) -->
+      <iframe
+        v-else-if="content.kind === 'office-pptx' && selectedPath"
+        :src="content.previewUrl"
+        class="w-full h-full border-0"
+        :title="t('fileContentRenderer.pptxPreview')"
+      />
       <!-- Binary or too-large -->
-      <div v-else class="p-4 text-sm text-gray-500">
+      <div v-else class="p-4 text-sm text-gray-500 flex flex-col gap-3">
         <template v-if="'message' in content">{{ content.message }}</template>
+        <div v-if="selectedPath">
+          <button
+            type="button"
+            class="h-8 px-3 flex items-center gap-1 rounded border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 font-medium disabled:opacity-50"
+            :disabled="openInOsBusy"
+            data-testid="file-open-in-os"
+            @click="openInOs"
+          >
+            <span class="material-icons text-sm">open_in_new</span>
+            {{ openInOsBusy ? t("fileContentRenderer.openingInOs") : t("fileContentRenderer.openInOs") }}
+          </button>
+          <p v-if="openInOsError" class="mt-2 text-xs text-red-600">{{ openInOsError }}</p>
+        </div>
       </div>
     </template>
   </div>
@@ -258,6 +300,7 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import { formatScalarField, type MarkdownDocView } from "../composables/useMarkdownDoc";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
+import { apiPost } from "../utils/api";
 import { useSharePack } from "../composables/useSharePack";
 import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
 import { isMarpDocument } from "../utils/markdown/marpDetect";
@@ -334,6 +377,82 @@ const marpPdfFilename = computed(() => {
   const stem = dot > 0 ? base.slice(0, dot) : base;
   return buildPdfFilename({ name: stem, fallback: "slides" });
 });
+
+// ── Office preview (#1985) ───────────────────────────────────────
+
+// Which xlsx sheet the user picked from the selector. Auto-resets to
+// the first sheet whenever a new xlsx file loads so the tabs don't
+// stick on a sheet name that doesn't exist in the new workbook.
+const activeXlsxSheet = ref<string>("");
+watch(
+  () => props.content,
+  (loaded) => {
+    if (loaded && loaded.kind === "office-xlsx") activeXlsxSheet.value = loaded.sheets[0]?.name ?? "";
+  },
+  { immediate: true },
+);
+// Parse the selected sheet's CSV into rows of cell strings. CSV comes
+// from SheetJS (`sheet_to_csv`) which uses `,` separators and quotes
+// only when needed — a minimal RFC 4180 tokeniser covers it.
+const currentXlsxRows = computed<string[][]>(() => {
+  if (props.content?.kind !== "office-xlsx") return [];
+  const sheet = props.content.sheets.find((entry) => entry.name === activeXlsxSheet.value) ?? props.content.sheets[0];
+  return sheet ? parseCsv(sheet.csv) : [];
+});
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuote = false;
+  for (let idx = 0; idx < text.length; idx++) {
+    const char = text[idx];
+    if (inQuote) {
+      if (char === '"' && text[idx + 1] === '"') {
+        cell += '"';
+        idx++;
+      } else if (char === '"') {
+        inQuote = false;
+      } else {
+        cell += char;
+      }
+    } else if (char === '"') {
+      inQuote = true;
+    } else if (char === ",") {
+      row.push(cell);
+      cell = "";
+    } else if (char === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+    } else if (char !== "\r") {
+      // \r on its own is dropped; the paired \n commits the row.
+      cell += char;
+    }
+  }
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows;
+}
+
+// "Open in OS" button on the binary/unsupported fallback (and any
+// preview surface where the user wants the native app). Fire-and-
+// forget — success just means the server spawned the OS handler.
+const openInOsBusy = ref(false);
+const openInOsError = ref<string | null>(null);
+async function openInOs(): Promise<void> {
+  if (!props.selectedPath) return;
+  openInOsBusy.value = true;
+  openInOsError.value = null;
+  try {
+    const result = await apiPost<{ ok: boolean }>(API_ROUTES.files.open, { path: props.selectedPath });
+    if (!result.ok) openInOsError.value = result.error || t("fileContentRenderer.openInOsFailed");
+  } finally {
+    openInOsBusy.value = false;
+  }
+}
 
 // Inline JSON editor (#833 Phase 1). Available only for policy-editable
 // JSON config files; the read-only pretty-print stays the default.

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -447,7 +447,12 @@ async function openInOs(): Promise<void> {
   openInOsBusy.value = true;
   openInOsError.value = null;
   try {
-    const result = await apiPost<{ ok: boolean }>(API_ROUTES.files.open, { path: props.selectedPath });
+    // Send path in BOTH the body and the query — the server accepts
+    // either. Defensive against a proxy/middleware chain that swallows
+    // the JSON body (#1985 initial bug report: "path required" on a
+    // request whose body should have carried the path).
+    const url = `${API_ROUTES.files.open}?path=${encodeURIComponent(props.selectedPath)}`;
+    const result = await apiPost<{ ok: boolean }>(url, { path: props.selectedPath });
     if (!result.ok) openInOsError.value = result.error || t("fileContentRenderer.openInOsFailed");
   } finally {
     openInOsBusy.value = false;

--- a/src/composables/useFileSelection.ts
+++ b/src/composables/useFileSelection.ts
@@ -23,7 +23,34 @@ interface MetaContent {
   message?: string;
 }
 
-export type FileContent = TextContent | MetaContent;
+// Office document previews (#1985). Server converts on the fly via
+// mammoth / SheetJS / LibreOffice and returns a shape the client can
+// render inline — table for xlsx, plain text for docx, PDF (already
+// wired for `kind: "pdf"`) for pptx.
+interface XlsxContent {
+  kind: "office-xlsx";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  sheets: { name: string; csv: string }[];
+}
+interface DocxContent {
+  kind: "office-docx";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  content: string;
+}
+interface PptxContent {
+  kind: "office-pptx";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  /** URL the client uses to fetch the server-converted PDF. */
+  previewUrl: string;
+}
+
+export type FileContent = TextContent | MetaContent | XlsxContent | DocxContent | PptxContent;
 
 /** Segment-wise traversal check: rejects `../` path components
  *  but allows legitimate filenames like `my..notes.txt`. */

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -115,6 +115,15 @@ const HOST_API_ROUTES = {
     create: "/api/files/create",
     raw: "/api/files/raw",
     refRoots: "/api/files/ref-roots",
+    /** GET the server-converted PDF preview of a `.pptx` file. Backed
+     *  by `previewPptxAsPdf` (LibreOffice), cached on disk. Returns
+     *  404 when the file isn't a pptx or when LibreOffice is
+     *  unavailable — the client falls back to the "Open in OS" UI. */
+    previewRaw: "/api/files/preview-raw",
+    /** POST { path } — ask the server to open the file in the host
+     *  OS's file manager (`open` / `xdg-open` / `start`). Workspace-
+     *  scoped path validation same as every other files route. */
+    open: "/api/files/open",
   },
 
   // `html` group migrated to META — see `src/plugins/presentHtml/meta.ts`.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -447,6 +447,11 @@ const deMessages = {
     redo: "Wiederholen",
     editMarp: "Folienquelle bearbeiten",
     marpEditorLabel: "Marp-Folienquelle",
+    xlsxSheet: "Tabellenblatt",
+    pptxPreview: "PowerPoint-Vorschau (in PDF konvertiert)",
+    openInOs: "Im Betriebssystem oeffnen",
+    openingInOs: "Wird geoeffnet…",
+    openInOsFailed: "Konnte nicht im Betriebssystem geoeffnet werden",
   },
   filesView: {
     chatPlaceholder: "Frage zu dieser Datei stellen…",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -460,6 +460,11 @@ const enMessages = {
     redo: "Redo",
     editMarp: "Edit slide source",
     marpEditorLabel: "Marp slide source",
+    xlsxSheet: "Sheet",
+    pptxPreview: "PowerPoint preview (converted to PDF)",
+    openInOs: "Open in OS",
+    openingInOs: "Opening…",
+    openInOsFailed: "Failed to open in OS",
   },
   filesView: {
     chatPlaceholder: "Ask about this file…",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -448,6 +448,11 @@ const esMessages = {
     redo: "Rehacer",
     editMarp: "Editar fuente de la diapositiva",
     marpEditorLabel: "Fuente de diapositivas Marp",
+    xlsxSheet: "Hoja",
+    pptxPreview: "Vista previa de PowerPoint (convertido a PDF)",
+    openInOs: "Abrir en el SO",
+    openingInOs: "Abriendo…",
+    openInOsFailed: "No se pudo abrir en el SO",
   },
   filesView: {
     chatPlaceholder: "Pregunta sobre este archivo…",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -443,6 +443,11 @@ const frMessages = {
     redo: "Rétablir",
     editMarp: "Modifier la source de la diapositive",
     marpEditorLabel: "Source des diapositives Marp",
+    xlsxSheet: "Feuille",
+    pptxPreview: "Aperçu PowerPoint (converti en PDF)",
+    openInOs: "Ouvrir dans le système",
+    openingInOs: "Ouverture…",
+    openInOsFailed: "Échec de l'ouverture dans le système",
   },
   filesView: {
     chatPlaceholder: "Posez une question sur ce fichier…",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -444,6 +444,11 @@ const jaMessages = {
     redo: "やり直し",
     editMarp: "スライドソースを編集",
     marpEditorLabel: "Marp スライドソース",
+    xlsxSheet: "シート",
+    pptxPreview: "PowerPoint プレビュー (PDF に変換)",
+    openInOs: "OS で開く",
+    openingInOs: "開いています…",
+    openInOsFailed: "OS で開けませんでした",
   },
   filesView: {
     chatPlaceholder: "このファイルについて質問…",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -443,6 +443,11 @@ const koMessages = {
     redo: "다시 실행",
     editMarp: "슬라이드 소스 편집",
     marpEditorLabel: "Marp 슬라이드 소스",
+    xlsxSheet: "시트",
+    pptxPreview: "PowerPoint 미리보기 (PDF로 변환)",
+    openInOs: "OS에서 열기",
+    openingInOs: "여는 중…",
+    openInOsFailed: "OS에서 열 수 없습니다",
   },
   filesView: {
     chatPlaceholder: "이 파일에 대해 질문하세요…",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -440,6 +440,11 @@ const ptBRMessages = {
     redo: "Refazer",
     editMarp: "Editar código do slide",
     marpEditorLabel: "Código do slide Marp",
+    xlsxSheet: "Planilha",
+    pptxPreview: "Prévia do PowerPoint (convertido para PDF)",
+    openInOs: "Abrir no SO",
+    openingInOs: "Abrindo…",
+    openInOsFailed: "Falha ao abrir no SO",
   },
   filesView: {
     chatPlaceholder: "Pergunte sobre este arquivo…",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -435,6 +435,11 @@ const zhMessages = {
     redo: "重做",
     editMarp: "编辑幻灯片源代码",
     marpEditorLabel: "Marp 幻灯片源代码",
+    xlsxSheet: "工作表",
+    pptxPreview: "PowerPoint 预览（转换为 PDF）",
+    openInOs: "在系统中打开",
+    openingInOs: "正在打开…",
+    openInOsFailed: "无法在系统中打开",
   },
   filesView: {
     chatPlaceholder: "询问关于此文件的问题…",


### PR DESCRIPTION
## Summary

Closes #1985. `.xlsx` / `.docx` / `.pptx` を Files ビューでクリックすると **「Binary file — preview not supported」で終わっていた** のを、サーバ側で変換してインラインプレビュー表示 + フォールバックとして OS で開くボタンを提供。

| 形式 | 変換 (サーバ) | 表示 (クライアント) |
|---|---|---|
| xlsx | SheetJS `sheet_to_csv` per sheet | シート選択 + \`<table>\` (最小 RFC 4180 tokeniser) |
| docx | mammoth `extractRawText` | \`<pre>\` (whitespace-pre-wrap) |
| pptx | LibreOffice \`--convert-to pdf\` (path+mtime+size でキャッシュ) | 既存の PDF iframe |
| その他 unsupported | — | **OS で開く** ボタン (\`open\` / \`xdg-open\` / \`start\`) |

## Items to Confirm / Review

- **新規 npm dep なし**: mammoth / xlsx / LibreOffice は attachment 変換で既に導入済み、そのまま流用。
- **キャッシュ**: pptx→pdf のみ \`os.tmpdir()/mulmoclaude-office-preview/\` に SHA-256(path+mtime+size) キーで保存。xlsx/docx は変換が数十 ms なので毎回変換。
- **LibreOffice が無い環境**: pptx の \`previewPptxAsPdf()\` が null を返し、そのまま fallback 分岐 (「OS で開く」ボタン) に落ちる。手動テストで LibreOffice を unlink して確認予定。
- **セキュリティ**: 3 route (\`GET /content\`, \`GET /preview-raw\`, \`POST /open\`) は全て既存の \`resolveAndStatFile\` / workspace-scope gate を通す。\`POST /open\` の platform 分岐:
  - macOS: \`open <abs>\`
  - Windows: \`cmd /c start "" <abs>\` (空文字 title 必須、パスが quote されるため)
  - Linux: \`xdg-open <abs>\` (headless では失敗するが害なし)
- **i18n**: 8 ロケール lockstep で 5 キー追加 (\`xlsxSheet\`, \`pptxPreview\`, \`openInOs\`, \`openingInOs\`, \`openInOsFailed\`).
- **既存挙動を壊さない**: 新規は \`kind: \"office-*\"\` の判別分岐追加のみ。text / image / pdf / audio / video / binary(true) / too-large は無変更。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1985 viewer を追加できる?
> office 系の document できるだけ見えたほうがよいね。
> B: preview + Finder fallback (Recommended).

## Test plan

- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\`
- 手動: \`data/attachments\` に生成 \`.xlsx\` / \`.docx\` / \`.pptx\` を Files ビューで開いて preview を確認、\"OS で開く\" ボタンでネイティブアプリが起動することを確認。LibreOffice unlink 状態で pptx が fallback に落ちることも確認。

計画: [\`plans/feat-1985-office-file-preview.md\`](https://github.com/receptron/mulmoclaude/blob/feat/1985-office-file-preview/plans/feat-1985-office-file-preview.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline preview support for Office files: spreadsheets (sheet-based CSV), documents (extracted text), and presentations (PDF preview).
  * Added an “Open in OS” action for supported Office files when inline preview isn’t sufficient.
* **Bug Fixes**
  * Improved fallback behavior when previews can’t be generated for a given file type/format.
* **Documentation**
  * Updated UI labels and status/error messages across supported languages for Office previews and “Open in OS.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->