### PR TITLE
chore(collection-plugin): bump to 0.7.1

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -35,7 +35,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.7.0",
+    "@mulmoclaude/collection-plugin": "^0.7.1",
     "@mulmoclaude/core": "^0.9.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",


### PR DESCRIPTION
Bump `@mulmoclaude/collection-plugin` `0.7.0` → `0.7.1`, and update the launcher's dep range in `packages/mulmoclaude/package.json` to `^0.7.1` to keep the launcher-sync lockstep invariant green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the collection plugin to version 0.7.1.
  * Aligned the related package dependency to the newer 0.7.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->