### PR TITLE
feat(files): "Open in OS" button on binary / unsupported previews (#1985)

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -23,17 +23,34 @@ import { spawn } from "node:child_process";
 // could be reinterpreted as command syntax (Codex + CodeQL flagged
 // this on #1985). `explorer.exe <path>` is fed to CreateProcess as an
 // array argv (no shell parsing) and treats the argument as a
-// filesystem path. explorer.exe intentionally returns exit code 1 even
-// on success, so we `spawn` + `unref()` instead of awaiting a subprocess
-// exit — the whole operation is fire-and-forget anyway (we can't tell
-// whether the associated app actually opened a window).
-function openInHostOs(absPath: string): void {
+// filesystem path.
+//
+// Returns a promise that settles based on `spawn` vs `error` events —
+// NOT process exit. We can't tell whether the associated app actually
+// opened a window (explorer.exe returns exit code 1 even on success),
+// but we CAN distinguish "spawn succeeded" from "command not found /
+// permission denied" (e.g. `xdg-open` missing on a headless Linux
+// host). Client-side error handling depends on this signal.
+export function openInHostOs(absPath: string): Promise<boolean> {
   const { platform } = process;
   const [command, args] =
     platform === "darwin" ? (["open", [absPath]] as const) : platform === "win32" ? (["explorer.exe", [absPath]] as const) : (["xdg-open", [absPath]] as const);
-  const child = spawn(command, args, { detached: true, stdio: "ignore" });
-  child.on("error", (err) => log.warn("files", "open: spawn error", { platform, error: err.message }));
-  child.unref();
+  return new Promise<boolean>((resolve) => {
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    let settled = false;
+    child.once("error", (err) => {
+      if (settled) return;
+      settled = true;
+      log.warn("files", "open: spawn error", { platform, error: err.message });
+      resolve(false);
+    });
+    child.once("spawn", () => {
+      if (settled) return;
+      settled = true;
+      child.unref();
+      resolve(true);
+    });
+  });
 }
 
 const router = Router();
@@ -1154,7 +1171,11 @@ router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFile
   (req.query as PathQuery).path = requestedPath;
   const ctx = resolveAndStatFile(req, res);
   if (!ctx) return;
-  openInHostOs(ctx.absPath);
+  const spawned = await openInHostOs(ctx.absPath);
+  if (!spawned) {
+    serverError(res, "Failed to launch OS file handler");
+    return;
+  }
   res.json({ ok: true });
 });
 

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -14,11 +14,27 @@ import { classifyAsWikiPage, writeWikiPage } from "../../workspace/wiki-pages/io
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
 import { publishFileChange } from "../../events/file-change.js";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../../utils/time.js";
+import { spawn } from "node:child_process";
 
-const execFileAsync = promisify(execFile);
+// Cross-platform "open this file with the host's default handler" that
+// never lets the path travel through a shell parser. Windows earlier
+// used `cmd /c start "" <path>` — `cmd` DOES tokenise the arguments,
+// so a workspace filename with `&` / `|` / `^` / a leading `-` / etc.
+// could be reinterpreted as command syntax (Codex + CodeQL flagged
+// this on #1985). `explorer.exe <path>` is fed to CreateProcess as an
+// array argv (no shell parsing) and treats the argument as a
+// filesystem path. explorer.exe intentionally returns exit code 1 even
+// on success, so we `spawn` + `unref()` instead of awaiting a subprocess
+// exit — the whole operation is fire-and-forget anyway (we can't tell
+// whether the associated app actually opened a window).
+function openInHostOs(absPath: string): void {
+  const { platform } = process;
+  const [command, args] =
+    platform === "darwin" ? (["open", [absPath]] as const) : platform === "win32" ? (["explorer.exe", [absPath]] as const) : (["xdg-open", [absPath]] as const);
+  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  child.on("error", (err) => log.warn("files", "open: spawn error", { platform, error: err.message }));
+  child.unref();
+}
 
 const router = Router();
 
@@ -1138,24 +1154,8 @@ router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFile
   (req.query as PathQuery).path = requestedPath;
   const ctx = resolveAndStatFile(req, res);
   if (!ctx) return;
-  const { absPath } = ctx;
-  const { platform } = process;
-  try {
-    if (platform === "darwin") {
-      await execFileAsync("open", [absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
-    } else if (platform === "win32") {
-      // `start` is a cmd built-in; the empty "" is a title placeholder
-      // required when the target path is quoted (else cmd interprets
-      // the first quoted arg as the window title, not the file).
-      await execFileAsync("cmd", ["/c", "start", "", absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
-    } else {
-      await execFileAsync("xdg-open", [absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
-    }
-    res.json({ ok: true });
-  } catch (err) {
-    log.warn("files", "POST open: spawn failed", { platform, error: errorMessage(err) });
-    serverError(res, `Failed to open file in OS: ${errorMessage(err)}`);
-  }
+  openInHostOs(ctx.absPath);
+  res.json({ ok: true });
 });
 
 router.get(API_ROUTES.files.refRoots, async (_req: Request, res: Response<TreeNode[]>) => {

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -670,7 +670,10 @@ function resolveAndStatFile<T>(
   req: Request<object, unknown, unknown, PathQuery>,
   res: Response<T | ErrorResponse>,
 ): { relPath: string; absPath: string; stat: Stats } | null {
-  const relPath = getOptionalStringQuery(req, "path") ?? "";
+  return resolveAndStatFileByPath(getOptionalStringQuery(req, "path") ?? "", res);
+}
+
+function resolveAndStatFileByPath<T>(relPath: string, res: Response<T | ErrorResponse>): { relPath: string; absPath: string; stat: Stats } | null {
   if (!relPath) {
     badRequest(res, "path required");
     return null;
@@ -1168,8 +1171,7 @@ router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFile
     badRequest(res, "path required");
     return;
   }
-  (req.query as PathQuery).path = requestedPath;
-  const ctx = resolveAndStatFile(req, res);
+  const ctx = resolveAndStatFileByPath(requestedPath, res);
   if (!ctx) return;
   const spawned = await openInHostOs(ctx.absPath);
   if (!spawned) {

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -14,6 +14,11 @@ import { classifyAsWikiPage, writeWikiPage } from "../../workspace/wiki-pages/io
 import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
 import { publishFileChange } from "../../events/file-change.js";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../../utils/time.js";
+
+const execFileAsync = promisify(execFile);
 
 const router = Router();
 
@@ -1110,6 +1115,48 @@ router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQue
 // Returns configured reference directories as top-level TreeNode[]
 // for the file explorer. Each node's path uses the @ref/<label>
 // prefix so subsequent /dir and /content requests route correctly.
+
+// POST /api/files/open — spawn the host OS's default handler for a
+// file. Backing the "Open in OS" button on the Files view's binary /
+// unsupported preview so a `.xlsx` / `.pptx` reachable via the file
+// tree can be viewed in Excel / Keynote when in-browser preview isn't
+// available (#1985). Cross-platform: macOS `open`, Linux `xdg-open`,
+// Windows `start` (via cmd). Workspace-scoped path validation same as
+// every other files route. Accepts `path` from body OR query so a
+// swallowed body doesn't stop the button (belt + suspenders).
+interface OpenFileRequest {
+  path?: unknown;
+}
+router.post(API_ROUTES.files.open, async (req: Request<object, unknown, OpenFileRequest, PathQuery>, res: Response<{ ok: boolean } | ErrorResponse>) => {
+  const bodyPath = typeof req.body?.path === "string" ? req.body.path : "";
+  const queryPath = getOptionalStringQuery(req, "path") ?? "";
+  const requestedPath = bodyPath || queryPath;
+  if (!requestedPath) {
+    badRequest(res, "path required");
+    return;
+  }
+  (req.query as PathQuery).path = requestedPath;
+  const ctx = resolveAndStatFile(req, res);
+  if (!ctx) return;
+  const { absPath } = ctx;
+  const { platform } = process;
+  try {
+    if (platform === "darwin") {
+      await execFileAsync("open", [absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    } else if (platform === "win32") {
+      // `start` is a cmd built-in; the empty "" is a title placeholder
+      // required when the target path is quoted (else cmd interprets
+      // the first quoted arg as the window title, not the file).
+      await execFileAsync("cmd", ["/c", "start", "", absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    } else {
+      await execFileAsync("xdg-open", [absPath], { timeout: SUBPROCESS_PROBE_TIMEOUT_MS });
+    }
+    res.json({ ok: true });
+  } catch (err) {
+    log.warn("files", "POST open: spawn failed", { platform, error: errorMessage(err) });
+    serverError(res, `Failed to open file in OS: ${errorMessage(err)}`);
+  }
+});
 
 router.get(API_ROUTES.files.refRoots, async (_req: Request, res: Response<TreeNode[]>) => {
   log.info("files", "GET ref-roots: start");

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -238,8 +238,21 @@
         <video :key="selectedPath" :src="rawUrl(selectedPath)" controls preload="metadata" class="max-w-full max-h-full" />
       </div>
       <!-- Binary or too-large -->
-      <div v-else class="p-4 text-sm text-gray-500">
+      <div v-else class="p-4 text-sm text-gray-500 flex flex-col gap-3">
         <template v-if="'message' in content">{{ content.message }}</template>
+        <div v-if="selectedPath">
+          <button
+            type="button"
+            class="h-8 px-3 flex items-center gap-1 rounded border border-gray-300 bg-white hover:bg-gray-50 text-gray-700 font-medium disabled:opacity-50"
+            :disabled="openInOsBusy"
+            data-testid="file-open-in-os"
+            @click="openInOs"
+          >
+            <span class="material-icons text-sm">open_in_new</span>
+            {{ openInOsBusy ? t("fileContentRenderer.openingInOs") : t("fileContentRenderer.openInOs") }}
+          </button>
+          <p v-if="openInOsError" class="mt-2 text-xs text-red-600">{{ openInOsError }}</p>
+        </div>
       </div>
     </template>
   </div>
@@ -258,6 +271,7 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import { formatScalarField, type MarkdownDocView } from "../composables/useMarkdownDoc";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
+import { apiPost } from "../utils/api";
 import { useSharePack } from "../composables/useSharePack";
 import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
 import { isMarpDocument } from "../utils/markdown/marpDetect";
@@ -337,6 +351,28 @@ const marpPdfFilename = computed(() => {
 
 // Inline JSON editor (#833 Phase 1). Available only for policy-editable
 // JSON config files; the read-only pretty-print stays the default.
+// "Open in OS" button on the binary / unsupported fallback (#1985).
+// Fire-and-forget — success just means the server spawned the OS
+// handler; whether the app actually surfaces is out of scope.
+const openInOsBusy = ref(false);
+const openInOsError = ref<string | null>(null);
+async function openInOs(): Promise<void> {
+  if (!props.selectedPath) return;
+  openInOsBusy.value = true;
+  openInOsError.value = null;
+  try {
+    // Send path in BOTH the body and the query — the server accepts
+    // either. Defensive against a proxy/middleware chain that swallows
+    // the JSON body (#1985 early report: "path required" back to a
+    // request whose body should have carried the path).
+    const url = `${API_ROUTES.files.open}?path=${encodeURIComponent(props.selectedPath)}`;
+    const result = await apiPost<{ ok: boolean }>(url, { path: props.selectedPath });
+    if (!result.ok) openInOsError.value = result.error || t("fileContentRenderer.openInOsFailed");
+  } finally {
+    openInOsBusy.value = false;
+  }
+}
+
 const jsonEditing = ref(false);
 const jsonDraft = ref("");
 

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -352,10 +352,20 @@ const marpPdfFilename = computed(() => {
 // Inline JSON editor (#833 Phase 1). Available only for policy-editable
 // JSON config files; the read-only pretty-print stays the default.
 // "Open in OS" button on the binary / unsupported fallback (#1985).
-// Fire-and-forget — success just means the server spawned the OS
-// handler; whether the app actually surfaces is out of scope.
+// Success just means the server successfully spawned the OS handler;
+// whether the app actually surfaces a window is out of scope.
 const openInOsBusy = ref(false);
 const openInOsError = ref<string | null>(null);
+// Reset button state whenever the user navigates to a different file —
+// otherwise an error from file A would linger while viewing file B
+// (Codex review on #1988).
+watch(
+  () => props.selectedPath,
+  () => {
+    openInOsBusy.value = false;
+    openInOsError.value = null;
+  },
+);
 async function openInOs(): Promise<void> {
   if (!props.selectedPath) return;
   openInOsBusy.value = true;

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -271,8 +271,9 @@ import type { JsonToken, JsonlLine } from "../utils/format/jsonSyntax";
 import { formatScalarField, type MarkdownDocView } from "../composables/useMarkdownDoc";
 import { rewriteMarkdownImageRefs } from "../utils/image/rewriteMarkdownImageRefs";
 import { API_ROUTES } from "../config/apiRoutes";
-import { apiPost } from "../utils/api";
 import { useSharePack } from "../composables/useSharePack";
+import { useOpenInOs } from "../composables/useOpenInOs";
+import { toRef } from "vue";
 import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
 import { isMarpDocument } from "../utils/markdown/marpDetect";
 import { buildPdfFilename } from "../utils/files/filename";
@@ -349,39 +350,9 @@ const marpPdfFilename = computed(() => {
   return buildPdfFilename({ name: stem, fallback: "slides" });
 });
 
-// Inline JSON editor (#833 Phase 1). Available only for policy-editable
-// JSON config files; the read-only pretty-print stays the default.
 // "Open in OS" button on the binary / unsupported fallback (#1985).
-// Success just means the server successfully spawned the OS handler;
-// whether the app actually surfaces a window is out of scope.
-const openInOsBusy = ref(false);
-const openInOsError = ref<string | null>(null);
-// Reset button state whenever the user navigates to a different file —
-// otherwise an error from file A would linger while viewing file B
-// (Codex review on #1988).
-watch(
-  () => props.selectedPath,
-  () => {
-    openInOsBusy.value = false;
-    openInOsError.value = null;
-  },
-);
-async function openInOs(): Promise<void> {
-  if (!props.selectedPath) return;
-  openInOsBusy.value = true;
-  openInOsError.value = null;
-  try {
-    // Send path in BOTH the body and the query — the server accepts
-    // either. Defensive against a proxy/middleware chain that swallows
-    // the JSON body (#1985 early report: "path required" back to a
-    // request whose body should have carried the path).
-    const url = `${API_ROUTES.files.open}?path=${encodeURIComponent(props.selectedPath)}`;
-    const result = await apiPost<{ ok: boolean }>(url, { path: props.selectedPath });
-    if (!result.ok) openInOsError.value = result.error || t("fileContentRenderer.openInOsFailed");
-  } finally {
-    openInOsBusy.value = false;
-  }
-}
+// State machine + fetch lives in useOpenInOs so it's unit-testable.
+const { busy: openInOsBusy, error: openInOsError, open: openInOs } = useOpenInOs(toRef(props, "selectedPath"), () => t("fileContentRenderer.openInOsFailed"));
 
 const jsonEditing = ref(false);
 const jsonDraft = ref("");

--- a/src/composables/useOpenInOs.ts
+++ b/src/composables/useOpenInOs.ts
@@ -1,0 +1,45 @@
+import { ref, watch, type Ref } from "vue";
+import { apiPost } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+// UI state + trigger for the "Open in OS" button on the binary-file
+// fallback in FileContentRenderer. Extracted so the state machine
+// (busy / error / auto-reset on path change) is unit-testable
+// without mounting the full component.
+//
+// - `selectedPath` is watched: when it changes, error + busy reset
+//   so an error from file A doesn't linger while viewing file B.
+// - `fallbackErrorMessage` is used when the server returns `ok:
+//   false` without an `error` string.
+
+export interface UseOpenInOsResult {
+  busy: Ref<boolean>;
+  error: Ref<string | null>;
+  open: () => Promise<void>;
+}
+
+export function useOpenInOs(selectedPath: Ref<string | null>, fallbackErrorMessage: () => string): UseOpenInOsResult {
+  const busy = ref(false);
+  const error = ref<string | null>(null);
+
+  watch(selectedPath, () => {
+    busy.value = false;
+    error.value = null;
+  });
+
+  async function open(): Promise<void> {
+    const path = selectedPath.value;
+    if (!path) return;
+    busy.value = true;
+    error.value = null;
+    try {
+      const url = `${API_ROUTES.files.open}?path=${encodeURIComponent(path)}`;
+      const result = await apiPost<{ ok: boolean }>(url, { path });
+      if (!result.ok) error.value = result.error || fallbackErrorMessage();
+    } finally {
+      busy.value = false;
+    }
+  }
+
+  return { busy, error, open };
+}

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -115,6 +115,13 @@ const HOST_API_ROUTES = {
     create: "/api/files/create",
     raw: "/api/files/raw",
     refRoots: "/api/files/ref-roots",
+    /** POST { path } — spawn the host OS's default handler for the
+     *  file (`open` on macOS, `xdg-open` on Linux, `start` on
+     *  Windows). The Files view exposes this as an "Open in OS"
+     *  button on binary / unsupported previews so `.xlsx` / `.pptx`
+     *  can be viewed in the native app when in-browser preview
+     *  isn't available (#1985). */
+    open: "/api/files/open",
   },
 
   // `html` group migrated to META — see `src/plugins/presentHtml/meta.ts`.

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -447,6 +447,9 @@ const deMessages = {
     redo: "Wiederholen",
     editMarp: "Folienquelle bearbeiten",
     marpEditorLabel: "Marp-Folienquelle",
+    openInOs: "Im Betriebssystem oeffnen",
+    openingInOs: "Wird geoeffnet…",
+    openInOsFailed: "Konnte nicht im Betriebssystem geoeffnet werden",
   },
   filesView: {
     chatPlaceholder: "Frage zu dieser Datei stellen…",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -460,6 +460,9 @@ const enMessages = {
     redo: "Redo",
     editMarp: "Edit slide source",
     marpEditorLabel: "Marp slide source",
+    openInOs: "Open in OS",
+    openingInOs: "Opening…",
+    openInOsFailed: "Failed to open in OS",
   },
   filesView: {
     chatPlaceholder: "Ask about this file…",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -448,6 +448,9 @@ const esMessages = {
     redo: "Rehacer",
     editMarp: "Editar fuente de la diapositiva",
     marpEditorLabel: "Fuente de diapositivas Marp",
+    openInOs: "Abrir en el SO",
+    openingInOs: "Abriendo…",
+    openInOsFailed: "No se pudo abrir en el SO",
   },
   filesView: {
     chatPlaceholder: "Pregunta sobre este archivo…",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -443,6 +443,9 @@ const frMessages = {
     redo: "Rétablir",
     editMarp: "Modifier la source de la diapositive",
     marpEditorLabel: "Source des diapositives Marp",
+    openInOs: "Ouvrir dans le système",
+    openingInOs: "Ouverture…",
+    openInOsFailed: "Échec de l'ouverture dans le système",
   },
   filesView: {
     chatPlaceholder: "Posez une question sur ce fichier…",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -444,6 +444,9 @@ const jaMessages = {
     redo: "やり直し",
     editMarp: "スライドソースを編集",
     marpEditorLabel: "Marp スライドソース",
+    openInOs: "OS で開く",
+    openingInOs: "開いています…",
+    openInOsFailed: "OS で開けませんでした",
   },
   filesView: {
     chatPlaceholder: "このファイルについて質問…",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -443,6 +443,9 @@ const koMessages = {
     redo: "다시 실행",
     editMarp: "슬라이드 소스 편집",
     marpEditorLabel: "Marp 슬라이드 소스",
+    openInOs: "OS에서 열기",
+    openingInOs: "여는 중…",
+    openInOsFailed: "OS에서 열 수 없습니다",
   },
   filesView: {
     chatPlaceholder: "이 파일에 대해 질문하세요…",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -440,6 +440,9 @@ const ptBRMessages = {
     redo: "Refazer",
     editMarp: "Editar código do slide",
     marpEditorLabel: "Código do slide Marp",
+    openInOs: "Abrir no SO",
+    openingInOs: "Abrindo…",
+    openInOsFailed: "Falha ao abrir no SO",
   },
   filesView: {
     chatPlaceholder: "Pergunte sobre este arquivo…",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -435,6 +435,9 @@ const zhMessages = {
     redo: "重做",
     editMarp: "编辑幻灯片源代码",
     marpEditorLabel: "Marp 幻灯片源代码",
+    openInOs: "在系统中打开",
+    openingInOs: "正在打开…",
+    openInOsFailed: "无法在系统中打开",
   },
   filesView: {
     chatPlaceholder: "询问关于此文件的问题…",

--- a/test/composables/test_useOpenInOs.ts
+++ b/test/composables/test_useOpenInOs.ts
@@ -1,0 +1,136 @@
+// Unit test for `useOpenInOs` composable that backs the "Open in OS"
+// button on FileContentRenderer's binary-file fallback (#1985).
+// Codex iter-4 asked for coverage of the busy/error state transitions
+// and the auto-reset behaviour when `selectedPath` changes — the
+// composable exists so those transitions can be tested without
+// mounting the full component.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { nextTick, ref } from "vue";
+import { useOpenInOs } from "../../src/composables/useOpenInOs.ts";
+
+interface FetchStubResponse {
+  status: number;
+  jsonBody: unknown;
+}
+
+let fetchCalls: { url: string; init?: { method?: string; body?: string } }[] = [];
+let nextResponse: FetchStubResponse = { status: 200, jsonBody: { ok: true } };
+let shouldThrow: Error | null = null;
+
+const originalFetch = globalThis.fetch;
+
+function installFetchStub(): void {
+  fetchCalls = [];
+  nextResponse = { status: 200, jsonBody: { ok: true } };
+  shouldThrow = null;
+  globalThis.fetch = (async (input: unknown, init?: unknown) => {
+    fetchCalls.push({ url: String(input), init: init as { method?: string; body?: string } | undefined });
+    if (shouldThrow) throw shouldThrow;
+    const { status, jsonBody } = nextResponse;
+    const makeResponse = (): Response =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: "",
+        json: async () => jsonBody,
+        text: async () => JSON.stringify(jsonBody),
+        clone: () => makeResponse(),
+      }) as unknown as Response;
+    return makeResponse();
+  }) as typeof fetch;
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = originalFetch;
+}
+
+describe("useOpenInOs", () => {
+  beforeEach(installFetchStub);
+  afterEach(restoreFetch);
+
+  it("starts idle: busy=false, error=null", () => {
+    const path = ref<string | null>("dir/file.pptx");
+    const { busy, error } = useOpenInOs(path, () => "fallback");
+    assert.equal(busy.value, false);
+    assert.equal(error.value, null);
+  });
+
+  it("does nothing when selectedPath is null", async () => {
+    const path = ref<string | null>(null);
+    const { busy, error, open } = useOpenInOs(path, () => "fallback");
+    await open();
+    assert.equal(busy.value, false);
+    assert.equal(error.value, null);
+    assert.equal(fetchCalls.length, 0);
+  });
+
+  it("posts to /api/files/open with the path in both query and body", async () => {
+    const path = ref<string | null>("docs/report.pptx");
+    const { open } = useOpenInOs(path, () => "fallback");
+    await open();
+    assert.equal(fetchCalls.length, 1);
+    const [call] = fetchCalls;
+    assert.match(call.url, /\/api\/files\/open\?path=docs%2Freport\.pptx$/);
+    assert.equal(call.init?.method, "POST");
+    const parsed = JSON.parse(call.init?.body ?? "{}") as { path?: string };
+    assert.equal(parsed.path, "docs/report.pptx");
+  });
+
+  it("clears error on successful open and leaves busy=false when settled", async () => {
+    const path = ref<string | null>("a.pptx");
+    const { busy, error, open } = useOpenInOs(path, () => "fallback");
+    await open();
+    assert.equal(busy.value, false);
+    assert.equal(error.value, null);
+  });
+
+  it("surfaces server error message when the response says ok:false", async () => {
+    nextResponse = { status: 500, jsonBody: { error: "Failed to launch OS file handler" } };
+    const path = ref<string | null>("a.pptx");
+    const { busy, error, open } = useOpenInOs(path, () => "fallback message");
+    await open();
+    assert.equal(busy.value, false);
+    assert.equal(error.value, "Failed to launch OS file handler");
+  });
+
+  it("resets busy and error when selectedPath changes to a different file", async () => {
+    nextResponse = { status: 500, jsonBody: { error: "boom" } };
+    const path = ref<string | null>("a.pptx");
+    const { busy, error, open } = useOpenInOs(path, () => "fallback");
+    await open();
+    assert.equal(error.value, "boom");
+
+    // Simulate user navigating to a different file — error and busy
+    // must reset so file B's UI doesn't inherit file A's error banner.
+    path.value = "b.pptx";
+    await nextTick();
+    assert.equal(busy.value, false);
+    assert.equal(error.value, null);
+  });
+
+  it("resets state on selectedPath -> null too (deselection)", async () => {
+    nextResponse = { status: 500, jsonBody: { error: "boom" } };
+    const path = ref<string | null>("a.pptx");
+    const { busy, error, open } = useOpenInOs(path, () => "fallback");
+    await open();
+    assert.equal(error.value, "boom");
+    path.value = null;
+    await nextTick();
+    assert.equal(busy.value, false);
+    assert.equal(error.value, null);
+  });
+
+  it("re-arms after an error: a second open clears the error before making the request", async () => {
+    nextResponse = { status: 500, jsonBody: { error: "boom" } };
+    const path = ref<string | null>("a.pptx");
+    const { error, open } = useOpenInOs(path, () => "fallback");
+    await open();
+    assert.equal(error.value, "boom");
+
+    nextResponse = { status: 200, jsonBody: { ok: true } };
+    await open();
+    assert.equal(error.value, null);
+  });
+});

--- a/test/routes/test_filesRoute_open.ts
+++ b/test/routes/test_filesRoute_open.ts
@@ -1,55 +1,117 @@
-// Unit test for `openInHostOs` — the cross-platform OS-launch helper
-// backing `POST /api/files/open` (#1985). Covers the two settle paths
-// the client-facing response depends on: `spawn` fires → resolve(true),
-// `error` fires → resolve(false).
+// HTTP-level test for `POST /api/files/open` (#1985).
 //
-// The real OS command (`open` / `xdg-open` / `explorer.exe`) is not
-// invoked. Instead we swap `process.platform` and pass abs paths that
-// force the desired outcome — no monkeypatching of `spawn` needed.
+// Mounts the real files router on an Express app and hits the
+// endpoint with a real HTTP request via fetch (same pattern as
+// `test/server/test_csrfGuard_http.ts`). The earlier iteration of
+// this file unit-tested `openInHostOs` by mutating
+// `process.platform` and `process.env.PATH` — Codex correctly
+// flagged that as unreliable under `tsx --test` parallelism, since
+// a concurrent test file could observe the mutated globals mid-run.
+// This version routes entirely through HTTP; the platform branch
+// is exercised implicitly by whichever host CI runs on.
 
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { openInHostOs } from "../../server/api/routes/files.js";
+import express from "express";
+import http from "node:http";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
 
-const originalPlatform = process.platform;
-
-function withPlatform(platform: typeof process.platform, run: () => Promise<void>): Promise<void> {
-  Object.defineProperty(process, "platform", { value: platform, configurable: true });
-  return run().finally(() => Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true }));
+interface AppFixture {
+  baseUrl: string;
+  close: () => Promise<void>;
 }
 
-describe("openInHostOs — spawn signalling (#1985)", () => {
-  it("resolves false when the OS handler binary is missing (error event)", async () => {
-    // Force the Linux branch on any host — `xdg-open-does-not-exist-9f2c1`
-    // as a filename doesn't matter; what matters is that the executable
-    // name is `xdg-open` and it's absent from PATH on macOS / Windows CI
-    // (and on most Linux hosts we run tests on, since we override PATH).
-    await withPlatform("linux", async () => {
-      // Constrain PATH so no `xdg-open` is reachable regardless of the host distro.
-      const originalPath = process.env.PATH;
-      process.env.PATH = "";
-      try {
-        const spawned = await openInHostOs("/nonexistent/path/does-not-matter.txt");
-        assert.equal(spawned, false, "spawn error should surface as false");
-      } finally {
-        process.env.PATH = originalPath;
-      }
-    });
+const REL_TEST_DIR = "mc-test-open-in-os";
+
+describe("POST /api/files/open (#1985)", () => {
+  let fixture: AppFixture;
+  let relPath: string;
+  let apiOpenRoute: string;
+
+  before(async () => {
+    // The workspace realpath is captured at module-load time inside
+    // server/api/routes/files.ts. Create the workspace dir + the
+    // test file BEFORE importing so the realpathSync call there
+    // succeeds and points at the on-disk dir.
+    const { workspacePath } = await import("../../server/workspace/workspace.js");
+    mkdirSync(workspacePath, { recursive: true });
+    const absDir = join(workspacePath, REL_TEST_DIR);
+    mkdirSync(absDir, { recursive: true });
+    const absFile = join(absDir, "sample.bin");
+    writeFileSync(absFile, "not a real binary but has a body");
+    relPath = `${REL_TEST_DIR}/sample.bin`;
+
+    const filesRoutesModule = await import("../../server/api/routes/files.js");
+    const apiRoutesModule = await import("../../src/config/apiRoutes.js");
+    apiOpenRoute = apiRoutesModule.API_ROUTES.files.open;
+
+    const app = express();
+    app.use(express.json());
+    app.use(filesRoutesModule.default);
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const { port } = server.address() as AddressInfo;
+    fixture = {
+      baseUrl: `http://127.0.0.1:${port}`,
+      close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+    };
   });
 
-  it("resolves true when the OS handler binary spawns successfully", async () => {
-    // Every POSIX host we run on has `/bin/true` (or `/usr/bin/true`).
-    // Fake a platform whose handler is `true` — but we can't; the real
-    // implementation hard-codes `open` / `xdg-open` / `explorer.exe`. So
-    // instead pick the macOS branch on a real mac, or the Linux branch
-    // where `xdg-open` is present. Skip when neither is available so the
-    // suite stays green on containers without either binary.
-    if (originalPlatform !== "darwin" && originalPlatform !== "linux") return;
-    const spawned = await openInHostOs("/");
-    // On darwin `open /` opens Finder at root; on Linux `xdg-open /` may
-    // succeed (spawn event fires) or fail (no xdg-open installed). Only
-    // assert the shape, not the outcome — either boolean is a valid
-    // response for this env-dependent path.
-    assert.equal(typeof spawned, "boolean");
+  after(async () => {
+    const { workspacePath } = await import("../../server/workspace/workspace.js");
+    rmSync(join(workspacePath, REL_TEST_DIR), { recursive: true, force: true });
+    await fixture.close();
+  });
+
+  it("returns 400 when the body carries no path", async () => {
+    const res = await fetch(`${fixture.baseUrl}${apiOpenRoute}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { error?: string };
+    assert.match(body.error ?? "", /path required/);
+  });
+
+  it("returns 400 when the path escapes the workspace", async () => {
+    const res = await fetch(`${fixture.baseUrl}${apiOpenRoute}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: "../../../etc/passwd" }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it(
+    "accepts a valid workspace path (200 on darwin, 200/500 on linux depending on xdg-open)",
+    { skip: process.platform !== "darwin" && process.platform !== "linux" },
+    async () => {
+      // macOS `open <existing-file>` succeeds even for a binary payload.
+      // Linux `xdg-open` may or may not be installed on the runner —
+      // if missing, spawn fires an `error` event → route returns 500,
+      // which is a legitimate outcome for that env.
+      const res = await fetch(`${fixture.baseUrl}${apiOpenRoute}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path: relPath }),
+      });
+      const body = (await res.json()) as { ok?: boolean; error?: string };
+      assert.ok(res.status === 200 || res.status === 500, `expected 200 or 500, got ${res.status}: ${JSON.stringify(body)}`);
+      if (res.status === 200) assert.equal(body.ok, true);
+      else assert.ok(typeof body.error === "string");
+    },
+  );
+
+  it("accepts a valid path via the query string as well as the body (belt+suspenders)", { skip: process.platform !== "darwin" }, async () => {
+    const url = `${fixture.baseUrl}${apiOpenRoute}?path=${encodeURIComponent(relPath)}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}), // deliberately empty; server should use the query
+    });
+    assert.equal(res.status, 200);
   });
 });

--- a/test/routes/test_filesRoute_open.ts
+++ b/test/routes/test_filesRoute_open.ts
@@ -1,0 +1,55 @@
+// Unit test for `openInHostOs` — the cross-platform OS-launch helper
+// backing `POST /api/files/open` (#1985). Covers the two settle paths
+// the client-facing response depends on: `spawn` fires → resolve(true),
+// `error` fires → resolve(false).
+//
+// The real OS command (`open` / `xdg-open` / `explorer.exe`) is not
+// invoked. Instead we swap `process.platform` and pass abs paths that
+// force the desired outcome — no monkeypatching of `spawn` needed.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { openInHostOs } from "../../server/api/routes/files.js";
+
+const originalPlatform = process.platform;
+
+function withPlatform(platform: typeof process.platform, run: () => Promise<void>): Promise<void> {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  return run().finally(() => Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true }));
+}
+
+describe("openInHostOs — spawn signalling (#1985)", () => {
+  it("resolves false when the OS handler binary is missing (error event)", async () => {
+    // Force the Linux branch on any host — `xdg-open-does-not-exist-9f2c1`
+    // as a filename doesn't matter; what matters is that the executable
+    // name is `xdg-open` and it's absent from PATH on macOS / Windows CI
+    // (and on most Linux hosts we run tests on, since we override PATH).
+    await withPlatform("linux", async () => {
+      // Constrain PATH so no `xdg-open` is reachable regardless of the host distro.
+      const originalPath = process.env.PATH;
+      process.env.PATH = "";
+      try {
+        const spawned = await openInHostOs("/nonexistent/path/does-not-matter.txt");
+        assert.equal(spawned, false, "spawn error should surface as false");
+      } finally {
+        process.env.PATH = originalPath;
+      }
+    });
+  });
+
+  it("resolves true when the OS handler binary spawns successfully", async () => {
+    // Every POSIX host we run on has `/bin/true` (or `/usr/bin/true`).
+    // Fake a platform whose handler is `true` — but we can't; the real
+    // implementation hard-codes `open` / `xdg-open` / `explorer.exe`. So
+    // instead pick the macOS branch on a real mac, or the Linux branch
+    // where `xdg-open` is present. Skip when neither is available so the
+    // suite stays green on containers without either binary.
+    if (originalPlatform !== "darwin" && originalPlatform !== "linux") return;
+    const spawned = await openInHostOs("/");
+    // On darwin `open /` opens Finder at root; on Linux `xdg-open /` may
+    // succeed (spawn event fires) or fail (no xdg-open installed). Only
+    // assert the shape, not the outcome — either boolean is a valid
+    // response for this env-dependent path.
+    assert.equal(typeof spawned, "boolean");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1985 (最小版)。バイナリ扱いになる \`.xlsx\` / \`.pptx\` 等が Files ビューで「Binary file — preview not supported」でも、そのまま **「OS で開く」ボタン** で macOS の Finder / Excel / Keynote (Linux は default handler、Windows は関連付けアプリ) にジャンプできるように。

前 PR (#1986) で xlsx→table / docx→text / pptx→LibreOffice PDF まで狙ったけど、**pptx が LibreOffice 依存で「入ってないと見えない機能」になる** ため、\`Open in OS\` 一本に絞って作り直した最小 PR です。豊富な preview はあとで別 issue でやれば OK。

## Items to Confirm / Review

- **依存追加なし**: Node の \`child_process\` だけ。
- **plat 分岐**: macOS \`open\`, Linux \`xdg-open\`, Windows \`cmd /c start ""\`。
- **path 送信**: body と query の両方に入れる (前回テストで body が空になる事例があったので防御的に)。サーバはどちらでも受ける。
- **workspace scope**: 既存の \`resolveAndStatFile\` に通して out-of-workspace を弾く。
- **fire-and-forget**: 成功 = subprocess spawn できた、ではない。ネイティブアプリが実際に表示されたかまでは server は分からない。
- **i18n**: 8 ロケール lockstep で 3 キー追加 (\`openInOs\`, \`openingInOs\`, \`openInOsFailed\`)。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1985 viewer 追加できる? office 系はできるだけ見えたほうがよい。
> [Preview の PR test 中] LibreOffice がないと動かないなら、この機能は不要。os で open のみで。

## Test plan

- [x] \`yarn format\` / \`yarn lint\` (0 errors) / \`yarn typecheck\` / \`yarn build\`
- 手動: \`.xlsx\` や \`.pptx\` を Files ビューで開いて fallback 表示 → 「OS で開く」ボタン → 対応アプリが起動することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Open in OS” action for supported files, launching the system default handler (macOS/Windows/Linux) via a new `POST /api/files/open` endpoint.
  * Updated the file viewer UI with a new button, loading state, and inline error display, using new localized text across supported languages.

* **Bug Fixes**
  * Improved request handling by resolving and validating the requested path before attempting to open it on the host OS.

* **Tests**
  * Added/updated tests to cover the new endpoint end-to-end and the UI composable’s request/state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->