### PR TITLE
chore(lint): add max-lines-per-function (warn, 50) with test/ excluded

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -259,6 +259,13 @@ export default [
       complexity: ["error", { max: 15 }],
       "max-depth": ["error", { max: 4 }],
       "max-params": ["error", { max: 6 }],
+      // Soft-launched as `warn` per CLAUDE.md's 20-line target — starts
+      // as advisory nudges so existing violations don't block CI. Bumping
+      // to `error` (or lowering `max`) once the count is drained is a
+      // one-line follow-up. skipBlankLines + skipComments so heavily-
+      // documented small functions don't count as "long"; IIFEs kept in
+      // so top-level `(() => { … })()` blocks are measured too.
+      "max-lines-per-function": ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],
       quotes: "off",
       "no-shadow": "error",
       "no-param-reassign": "error",
@@ -345,7 +352,7 @@ export default [
     // to just those categories so no-shadow / cognitive-complexity /
     // no-unused-vars / no-floating-promises etc. stay at `error`
     // across the whole repo — those *do* catch real bugs in tests.
-    files: ["test/**/*.{ts,js}", "e2e/**/*.{ts,js}", "packages/**/test/**/*.{ts,js}"],
+    files: ["test/**/*.{ts,js}", "e2e/**/*.{ts,js}", "e2e-live/**/*.{ts,js}", "packages/**/test/**/*.{ts,js}"],
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -362,6 +369,12 @@ export default [
       // `no-explicit-any` at `error` in production code; demote to
       // warn inside tests.
       "@typescript-eslint/no-explicit-any": "warn",
+      // Test files (describe/it blocks, seed helpers, fixture
+      // builders) legitimately have long function bodies. The
+      // 20-line target CLAUDE.md sets is for production code
+      // readability — it doesn't map onto a describe() block that
+      // happens to hold ten it() cases.
+      "max-lines-per-function": "off",
     },
   },
   {


### PR DESCRIPTION
## Summary

Soft-launches CLAUDE.md's 20-line function-length target as an ESLint rule:

- `max-lines-per-function: ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }]`
- Test dirs (\`test/\`, \`e2e/\`, \`e2e-live/\`, \`packages/**/test/\`) get the rule turned off — they legitimately hold long \`describe\` / seed-helper bodies that don't map onto the production-code target.

Warning volume today: **41** on production code (0 in tests). Set as \`warn\` so existing violations stay advisory — CI stays green; the goal is to drain them over time before promoting to \`error\` or lowering \`max\`.

## Items to Confirm / Review

- **Starting cap `max: 50`.** Two considerations here — CLAUDE.md's stated target is 20 lines, but jumping straight there would light up hundreds of pre-existing violations and drown the signal. 50 is a middle ground that surfaces genuinely long functions without a wall of noise. Sweep numbers for context (from local runs): max 20 → ~360 warnings, 30 → ~160, 40 → ~90, 50 → 41, 75 → ~15, 100 → single digits. If you'd rather aim higher first and pull down later, one-line adjust.
- **Level = `warn`, not `error`.** Existing violations don't block CI; new ones surface visibly in lint output. Promoting to \`error\` is a follow-up once the count is drained.
- **Options tuned.** \`skipBlankLines\` + \`skipComments\` means a heavily-documented small function isn't measured as "long"; \`IIFEs: true\` catches top-level \`(() => { … })()\` blocks that would otherwise hide from the rule.
- **Test override matches existing scoping.** The new \`max-lines-per-function: "off"\` sits inside the same block that already relaxes \`sonarjs/publicly-writable-directories\` etc. for tests — same \`files\` glob, extended to include \`e2e-live/\` for parity (previously that dir wasn't in the scope). Confirming: no other test-adjacent dirs to add (packages/plugins/*/test/… ? scripts/?) — call out any I missed.

## User prompt (JP)

> eslintで複雑さとか、関数の大きさの規約って入っている？
>
> まじか。max-lines-per-functionをwarnでいれて、適当な長さに調整してみよう
>
> testは除外で
>
> あ、もう一方設定し、testは除外してそのままcommit.

## Approach

One config change in \`eslint.config.mjs\`:

- **Main rules block** — add the rule.
- **Test override block** — add \`max-lines-per-function: "off"\`, and add \`e2e-live/**/*.{ts,js}\` to the block's file globs so the existing set of exempted directories keeps parity.

Nothing else in the config touched — sonarjs / typescript-eslint / vue-i18n rules all preserved.

## Verification

- \`yarn format\`, \`yarn lint\` — 0 errors, 67 warnings (41 new from this rule + 26 pre-existing).
- Not tightening test-file linting was deliberate; verified by pointing the rule at test paths and seeing describe blocks light up before scoping the exemption.

## Test plan

- [ ] Merge, then in a follow-up look at the top offenders (\`yarn lint 2>&1 | grep max-lines-per-function\` sorted by frequency-per-file) and pick a first batch to split. Bumping the max down / level up as we clear the count is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an ESLint max-lines-per-function rule for production code with a soft warning threshold and exclude test-related directories from this limit.

Enhancements:
- Add max-lines-per-function ESLint rule configured as a warning with a 50-line threshold for non-test code.
- Extend the test linting override block to include e2e-live files and explicitly disable the max-lines-per-function rule for all test-related directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new code-style warning for overly long functions to help keep the codebase easier to maintain.
  * Expanded test and end-to-end file coverage so additional automation files are included in the same checks.
  * Relaxed the function-length warning for test and end-to-end code to avoid unnecessary noise during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->