### PR TITLE
feat(remote-host): advertise host capabilities in the presence doc

### DIFF
--- a/docs/remote-host.md
+++ b/docs/remote-host.md
@@ -39,9 +39,11 @@ against (`@mulmoclaude/core/remote-view`).
    renders result
                                     ┌──────────────────────────────┐
                                     │  users/{uid}/hosts/mulmoclaude │  presence doc — host heartbeats
-                                    │  { online, updatedAt }         │◄──────── every 60s while connected
-                                    └──────────────────────────────┘           online:false on stop/death
-        │  reads presence → "host online?"
+                                    │  { online, updatedAt,          │◄──────── every 60s while connected
+                                    │    hostId, protocolVersion,    │           online:false on stop/death
+                                    │    capabilities:[method,…] }   │
+                                    └──────────────────────────────┘
+        │  reads presence → "host online?" + which methods it serves
 ```
 
 Both sides agree on a hardcoded **`hostId = "mulmoclaude"`** — there is no host
@@ -90,7 +92,7 @@ browser-safe boundary — mirroring `@mulmoclaude/core/remote-view`:
 
 | Import | Surface | Provides |
 |---|---|---|
-| `@mulmoclaude/core/remote-host` | **browser-safe** | Protocol wire types (`Command`, `CommandStatus`, `Channel`, `CommandHandlers`) + Firestore path helpers `commandsCollection(firestore, channel)` / `hostDoc(firestore, channel)`. Shared by host **and** the mobile client. |
+| `@mulmoclaude/core/remote-host` | **browser-safe** | Protocol wire types (`Command`, `CommandStatus`, `Channel`, `CommandHandlers`) + Firestore path helpers `commandsCollection(firestore, channel)` / `hostDoc(firestore, channel)` + the capability advertisement (`HostPresence`, `REMOTE_HOST_PROTOCOL_VERSION`, `buildHostPresence`). Shared by host **and** the mobile client. |
 | `@mulmoclaude/core/remote-host/server` | **server-only** | `startHostRunner(firestore, channel, handlers, opts)` — the command loop; `createRemoteHost(deps)` — the connect/disconnect/status lifecycle factory; `createRemoteHostAuth(auth)` + `createRemoteHostFirebase(config)` — the Firebase init/auth primitives. `firebase` is an optional peer dep of core. |
 
 Each host supplies only its own specifics under `server/remoteHost/`:
@@ -105,10 +107,42 @@ Each host supplies only its own specifics under `server/remoteHost/`:
 
 ### The command loop, precisely (core `startHostRunner`)
 
-- **Presence.** `setDoc(presence, {online:true})` on start, then a heartbeat
+- **Presence + capabilities.** `writePresence(true)` on start, then a heartbeat
   `setInterval` once a minute (`opts.heartbeatMs`, default 60 s). On `stop()` or fatal listener death it
-  writes `online:false` and clears the interval — so remotes see the host go
+  writes `writePresence(false)` and clears the interval — so remotes see the host go
   offline instead of a live-but-dead host that silently consumes no commands.
+  Every write carries the capability advertisement (next section), not just the
+  `online` flag.
+
+### Capability advertisement — presence doc, auto-derived
+
+The remote has no host registry and no way to know *which* methods a given host
+build serves — a self-hosted install may be older, or ship a plugin that adds or
+drops a capability. Rather than let the remote discover this by firing a command
+and getting `unknown_method` back, the host **advertises its capabilities in the
+presence doc** the remote already listens to:
+
+```jsonc
+// users/{uid}/hosts/mulmoclaude
+{ "online": true, "hostId": "mulmoclaude", "protocolVersion": 1,
+  "capabilities": ["listCollections", "getCollection", "startChat", …],
+  "updatedAt": <serverTimestamp> }
+```
+
+- **Push, not pull.** It rides the same `onSnapshot` the remote runs for
+  online/offline, so the remote knows the capability set the instant the host is
+  online — no extra round trip, and it can gate UI (hide "send photo" when
+  `startChat` is absent) *before* issuing anything.
+- **Auto-derived, single source of truth.** `buildHostPresence` sets
+  `capabilities = Object.keys(handlers)` from the live handler table, so
+  registering a handler in `handlers/index.ts` is the **only** step needed to
+  advertise it — there is no second list to keep in sync (the same
+  "derive, don't duplicate" discipline as the handler table itself).
+- **`protocolVersion`** (`REMOTE_HOST_PROTOCOL_VERSION`, currently `1`) lets the
+  remote gate on wire-protocol compatibility independent of the method list; bump
+  it when the command channel changes shape in a way the remote must react to.
+- The payload shape (`HostPresence`) is a **browser-safe** export both repos
+  compile against, so host and mobile client can't drift on the contract.
 - **Claim exactly once.** `claimCommand` runs a `runTransaction` that reads the
   doc and only flips `queued → processing` if it is still `queued`; a second
   host (or a snapshot replay) that races gets `null` and skips it.
@@ -247,6 +281,7 @@ names is the external mulmoserver client (which depends on the published
 | `plans/feat-remote-view-images.md` | Phase 5 — `getRemoteViewItems` image thumbnails |
 | `plans/feat-remote-chat-image-attachments.md` | `startChat` attachments + `ingestAttachments` |
 | `plans/feat-1955-remote-host-help.md` | Popover help text + mobile URL link |
+| `plans/feat-remote-host-capabilities.md` | Capability advertisement in the presence doc (`HostPresence`, `protocolVersion`) |
 
 > **Not to be confused with** MulmoBridge's "relay" (a Cloudflare Workers message
 > relay — see `docs/message_apps/relay/`). That is a separate messaging feature;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -50,6 +50,35 @@ export interface Command {
 export type CommandHandler = (params: JsonObject) => JsonValue | Promise<JsonValue>;
 export type CommandHandlers = Record<string, CommandHandler>;
 
+// Bumped when the command-channel wire protocol changes in a way the remote must
+// gate on. Advertised in the presence doc so the remote can check compatibility
+// before issuing commands.
+export const REMOTE_HOST_PROTOCOL_VERSION = 1;
+
+// The presence doc's payload: online flag + a capability advertisement. Written
+// by the host on every heartbeat; the remote reads it from the presence listener
+// it already runs (no extra round trip, known the instant the host is online).
+// Browser-safe so the mobile client compiles against the same shape.
+// `updatedAt` (a Firestore serverTimestamp) is added by the runner at write time
+// and is intentionally not part of this capability contract.
+export interface HostPresence {
+  online: boolean;
+  hostId: string;
+  protocolVersion: number;
+  // Method names the host serves — the keys of the live handler table.
+  capabilities: string[];
+}
+
+// Build the presence payload from the live handler table. Capabilities are
+// `Object.keys(handlers)` so registering a handler is the ONLY step needed to
+// advertise it — there is no second list to keep in sync.
+export const buildHostPresence = (channel: Channel, handlers: CommandHandlers, online: boolean): HostPresence => ({
+  online,
+  hostId: channel.hostId,
+  protocolVersion: REMOTE_HOST_PROTOCOL_VERSION,
+  capabilities: Object.keys(handlers),
+});
+
 // Per-host command queue: users/{uid}/hosts/{hostId}/commands.
 export const commandsCollection = (firestore: Firestore, channel: Channel): CollectionReference<DocumentData> =>
   collection(firestore, "users", channel.uid, "hosts", channel.hostId, "commands");

--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -8,7 +8,7 @@
 import { DocumentReference, Firestore, onSnapshot, query, runTransaction, serverTimestamp, setDoc, updateDoc, where } from "firebase/firestore";
 
 import { errorMessage } from "../../collection/core/errorMessage.js";
-import { Channel, Command, CommandHandler, CommandHandlers, JsonObject, commandsCollection, hostDoc } from "../index.js";
+import { Channel, Command, CommandHandler, CommandHandlers, JsonObject, buildHostPresence, commandsCollection, hostDoc } from "../index.js";
 
 const DEFAULT_HEARTBEAT_MS = 60_000;
 
@@ -85,8 +85,11 @@ const processCommand = async (firestore: Firestore, ref: DocumentReference, hand
 // Returns a stop function that goes offline and detaches the listener.
 export const startHostRunner = (firestore: Firestore, channel: Channel, handlers: CommandHandlers, options: HostRunnerOptions = {}): (() => void) => {
   const presence = hostDoc(firestore, channel);
+  // Advertise online/offline + the capability set (method names + protocol
+  // version) on the same doc the remote already listens to for presence.
+  const writePresence = (online: boolean) => setDoc(presence, { ...buildHostPresence(channel, handlers, online), updatedAt: serverTimestamp() }).catch(noop);
   const announce = () => {
-    setDoc(presence, { online: true, updatedAt: serverTimestamp() }).catch(noop);
+    writePresence(true);
   };
   announce();
   const beat = setInterval(announce, options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
@@ -108,14 +111,14 @@ export const startHostRunner = (firestore: Firestore, channel: Channel, handlers
       // write online:false) so remotes see the host as offline instead of a
       // live host that silently consumes no commands.
       clearInterval(beat);
-      setDoc(presence, { online: false, updatedAt: serverTimestamp() }).catch(noop);
+      writePresence(false);
       options.onClosed?.();
     },
   );
 
   return () => {
     clearInterval(beat);
-    setDoc(presence, { online: false, updatedAt: serverTimestamp() }).catch(noop);
+    writePresence(false);
     unsubscribe();
   };
 };

--- a/packages/core/test/remote-host/test_presence.ts
+++ b/packages/core/test/remote-host/test_presence.ts
@@ -1,0 +1,44 @@
+// Unit tests for the presence/capability advertisement (buildHostPresence):
+//   - capabilities are derived straight from the handler table keys
+//   - hostId comes from the channel, protocolVersion is the current constant
+//   - the online flag is reflected verbatim (same shape online and offline)
+//   - an empty handler table advertises an empty capability list
+//
+// The builder is pure (no Firebase), so this needs no host or firestore fakes.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { REMOTE_HOST_PROTOCOL_VERSION, buildHostPresence, type Channel, type CommandHandlers } from "../../src/remote-host/index.js";
+
+const channel: Channel = { uid: "uid-1", hostId: "test-host" };
+const handlers: CommandHandlers = {
+  listCollections: () => null,
+  startChat: () => null,
+};
+
+describe("buildHostPresence", () => {
+  it("advertises the handler table keys as capabilities", () => {
+    const presence = buildHostPresence(channel, handlers, true);
+    assert.deepEqual(presence, {
+      online: true,
+      hostId: "test-host",
+      protocolVersion: REMOTE_HOST_PROTOCOL_VERSION,
+      capabilities: ["listCollections", "startChat"],
+    });
+  });
+
+  it("capabilities track the live table — registering a handler advertises it", () => {
+    const withMore: CommandHandlers = { ...handlers, getCollection: () => null };
+    assert.deepEqual(buildHostPresence(channel, withMore, true).capabilities, ["listCollections", "startChat", "getCollection"]);
+  });
+
+  it("reflects the online flag but keeps the same capability shape offline", () => {
+    const offline = buildHostPresence(channel, handlers, false);
+    assert.equal(offline.online, false);
+    assert.deepEqual(offline.capabilities, ["listCollections", "startChat"]);
+  });
+
+  it("advertises an empty capability list for an empty handler table", () => {
+    assert.deepEqual(buildHostPresence(channel, {}, true).capabilities, []);
+  });
+});

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.0",
-    "@mulmoclaude/core": "^0.9.0",
+    "@mulmoclaude/core": "^0.10.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -31,13 +31,13 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^0.9.0",
+    "@mulmoclaude/core": "^0.10.0",
     "gui-chat-protocol": "^0.4.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^0.9.0",
+    "@mulmoclaude/core": "^0.10.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.0",
     "@vitejs/plugin-vue": "^6.0.5",

--- a/plans/feat-remote-host-capabilities.md
+++ b/plans/feat-remote-host-capabilities.md
@@ -1,0 +1,81 @@
+# feat: Advertise host capabilities to the remote client
+
+## Problem
+
+The remote-host command channel has **no mechanism for the host to tell the
+remote what it can do**. The handler table (`server/remoteHost/handlers/index.ts`)
+is the only source of truth for which methods the host serves, and the remote
+learns it purely from the **hardcoded contract both repos compiled against**.
+
+That means the remote can't tell whether *this particular* host build actually
+serves a given method — a self-hosted install may be an older version, or ship a
+plugin that adds/drops a capability. Today the remote finds out only by firing a
+command and getting an `unknown_method` error back after a full round trip, and
+its UI can't adapt (e.g. hide a "send photo" affordance when `startChat` is
+absent) because it has no capability signal.
+
+## Decision (locked)
+
+- **Transport: the presence doc (push), not a `getCapabilities` command (pull).**
+  The remote already runs an `onSnapshot` listener on `users/{uid}/hosts/{hostId}`
+  for online/offline. Advertising capabilities there means the remote knows the
+  full set the instant the host is online — zero extra round trip, and it can
+  gate UI *before* issuing any command. A pull command would cost a round trip
+  and couldn't inform the UI until after connect.
+- **Granularity: method names + a protocol version**, not rich per-method
+  descriptors. Covers the real need (feature gating) and matches how the handler
+  table is already keyed. Rich descriptors (param schema / read-write / labels)
+  are a possible future bump of `protocolVersion`, not v1.
+- **Auto-derived, not a second list.** `capabilities = Object.keys(handlers)` off
+  the live handler table, so registering a handler is the only step to advertise
+  it — no drift, same discipline as the handler table itself. Fixes both hosts
+  (MulmoClaude + MulmoTerminal) at once since the runner lives in core.
+
+## Contract (both repos depend on exactly this)
+
+Presence doc `users/{uid}/hosts/{hostId}` payload, written on every heartbeat:
+
+```jsonc
+{
+  "online": true,                 // false on stop / fatal listener death
+  "hostId": "mulmoclaude",
+  "protocolVersion": 1,           // REMOTE_HOST_PROTOCOL_VERSION
+  "capabilities": ["listCollections", "getCollection", "startChat", …],
+  "updatedAt": "<serverTimestamp>" // not part of the capability contract
+}
+```
+
+Browser-safe exports from `@mulmoclaude/core/remote-host` (both repos compile
+against them): `HostPresence`, `REMOTE_HOST_PROTOCOL_VERSION`,
+`buildHostPresence(channel, handlers, online)`.
+
+## Host-side implementation (this repo — shipped)
+
+- `packages/core/src/remote-host/index.ts` — add `REMOTE_HOST_PROTOCOL_VERSION`,
+  the `HostPresence` interface, and the pure `buildHostPresence` builder
+  (`capabilities = Object.keys(handlers)`).
+- `packages/core/src/remote-host/server/hostRunner.ts` — replace the three
+  `setDoc(presence, {online, updatedAt})` calls with a single `writePresence(online)`
+  that spreads `buildHostPresence(...)` + `updatedAt: serverTimestamp()`. So the
+  announce heartbeat and both offline paths all carry the capability set.
+- `packages/core/test/remote-host/test_presence.ts` — unit tests for the pure
+  builder (keys → capabilities, hostId/version, online flag, empty table).
+- `docs/remote-host.md` — presence diagram + "Capability advertisement" section.
+
+No host-local change under `server/remoteHost/` is needed: the runner already has
+the handler table, so capabilities flow for free.
+
+## Cross-repo follow-up (mulmoserver — NOT this repo)
+
+The mobile client consumes the new browser-safe exports to read `capabilities`
+off its existing presence listener and gate UI. It depends on a **published**
+`@mulmoclaude/core` carrying `HostPresence` / `REMOTE_HOST_PROTOCOL_VERSION`, so
+this contract is only usable cross-repo after a `@mulmoclaude/core` publish
+(local host advertising works immediately via workspace linking).
+
+## Non-goals
+
+- No `getCapabilities` pull command (presence push is sufficient for v1).
+- No per-method schema / read-write / label descriptors — a future
+  `protocolVersion` bump if a self-describing remote UI ever needs it.
+- No host discovery / registry — `hostId` stays hardcoded as today.


### PR DESCRIPTION
## Problem

The remote-host command channel has **no mechanism for the host to tell the remote what it can do**. The handler table (`server/remoteHost/handlers/index.ts`) is the only source of truth for which methods the host serves, and the remote learns it purely from the **hardcoded contract both repos compiled against**.

So the remote can't tell whether *this particular* host build actually serves a given method — a self-hosted install may be older, or ship a plugin that adds/drops a capability. Today it finds out only by firing a command and getting an `unknown_method` error back after a round trip, and its UI can't adapt (e.g. hide a "send photo" affordance when `startChat` is absent).

## Approach

Advertise the capability set on the **presence doc** the remote already listens to for online/offline (decision: push, not a pull `getCapabilities` command). The remote knows the full method set — and can gate UI — the instant the host is online, with no extra round trip.

```jsonc
// users/{uid}/hosts/mulmoclaude
{ "online": true, "hostId": "mulmoclaude", "protocolVersion": 1,
  "capabilities": ["listCollections", "getCollection", "startChat", …],
  "updatedAt": <serverTimestamp> }
```

- **Auto-derived, single source of truth.** `buildHostPresence` sets `capabilities = Object.keys(handlers)` off the live handler table — registering a handler in `handlers/index.ts` is the **only** step to advertise it. No second list, no drift. Because the runner lives in core, **MulmoTerminal gets this for free** too.
- **`protocolVersion`** (`REMOTE_HOST_PROTOCOL_VERSION`, currently `1`) lets the remote gate wire-protocol compatibility independent of the method list.
- The payload shape (`HostPresence`) is a **browser-safe** export both repos compile against, so host and mobile client can't drift.

## Changes

- **`packages/core/src/remote-host/index.ts`** — `REMOTE_HOST_PROTOCOL_VERSION`, the `HostPresence` interface, and the pure `buildHostPresence(channel, handlers, online)` builder.
- **`packages/core/src/remote-host/server/hostRunner.ts`** — the three bare `setDoc(presence, {online, updatedAt})` calls collapse into one `writePresence(online)` that carries the capability payload on the announce heartbeat and both offline paths.
- **`packages/core/test/remote-host/test_presence.ts`** — unit tests for the pure builder (keys → capabilities, hostId/version, online flag, empty table).
- **`docs/remote-host.md`** — presence diagram + a new "Capability advertisement" section + roadmap row.
- **`plans/feat-remote-host-capabilities.md`** — plan record (decisions locked, cross-repo follow-up).

## Version

Bumps **`@mulmoclaude/core` `0.9.0` → `0.10.0`** (additive — new exports, no breaking change; **already published to npm**), with the launcher dep range and collection-plugin peer range widened in lockstep. `launcherSync` gate is green; the launcher's own `version` is untouched.

## Cross-repo follow-up (not this PR)

The mulmoserver mobile client consumes the new browser-safe exports to read `capabilities` off its existing presence listener and gate UI. It depends on the now-published `@mulmoclaude/core@0.10.0`.

## Test plan

- [x] `packages/core` unit tests pass (`buildHostPresence` — 10/10)
- [x] `yarn typecheck` + `yarn build` (all packages) green
- [x] `yarn lint` clean (0 errors)
- [x] `launcherSync` lockstep gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote hosts now publish a richer presence payload including protocol version and an advertised capabilities list, allowing clients to determine which methods are available.
* **Bug Fixes**
  * Presence updates are now consistent across heartbeat, stop, and listener error scenarios, ensuring hosts correctly transition online/offline.
* **Documentation**
  * Updated remote-host documentation to reflect capability advertisement semantics and added a new design/roadmap note for the feature.
* **Tests**
  * Added unit tests validating capability derivation and the correctness of the generated presence payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->