### PR TITLE
feat(smoke): resolve first-party deps from the workspace, not public npm

### DIFF
--- a/plans/feat-smoke-local-registry.md
+++ b/plans/feat-smoke-local-registry.md
@@ -21,40 +21,42 @@ the publish.)
 A PR can bump + validate a shared-package version **without** publishing to public
 npm. Public publish moves to a clean post-merge release step.
 
-## Options
+## Chosen approach — npm `overrides` → locally-packed `.tgz` (IMPLEMENTED)
 
-### Option A — Verdaccio throwaway local registry (highest fidelity, recommended)
+Considered a Verdaccio throwaway local registry (highest fidelity, but adds a
+service + auth-token/`.npmrc` scoping to the CI job). Chose the **service-free
+`overrides`** path: pure npm, no extra process, a targeted change to
+`scripts/mulmoclaude/tarball.mjs` + its unit tests.
 
-In the smoke workflow: start [Verdaccio](https://verdaccio.org/) on localhost,
-`npm publish` every workspace `@mulmoclaude/*` package (already built by the smoke
-build step) to it, then run the tarball install with
-`--registry http://localhost:4873`. The launcher's first-party deps resolve to the
-just-built workspace versions; third-party deps still come from the real registry
-(Verdaccio proxies uplinks).
+De-risked first: a synthetic repro confirmed npm resolves a **transitive** `file:`
+override for an unpublished-scope package fully offline (npm ≥ 8.3). Then built:
 
-- **Pro:** exercises real `npm publish` + `npm install` semantics against the
-  actual built artifacts — closest to today's fidelity, minus the public publish.
-- **Con:** adds a service to the CI job (startup, config, `.npmrc`/auth-token
-  scoping so only `@mulmoclaude:` routes to Verdaccio).
+- `enumerateWorkspacePackages(root)` — expand the root `workspaces` globs (all
+  `<dir>/*`) to `{ name, dir, private, deps }` per package (`deps` folds
+  dependencies + peer + optional).
+- `computeFirstPartyClosure(packages, "mulmoclaude")` — pure BFS for the launcher's
+  transitive **first-party** (workspace) deps, so third-party deps
+  (`@mulmochat-plugin/*`, `@mulmocast/types`, …) are left to the real registry.
+  Against the real repo this is **13 packages** (core, the bundled plugins, the
+  bridges, task-scheduler), not all 47 workspace packages.
+- `packWorkspaceOverrides(...)` — `npm pack --ignore-scripts` each closure package
+  (dist is already built by the workflow's `yarn build:packages`, so no prepack
+  rebuild) into a temp dir; returns an `overrides` map `{ name: "file:<abs.tgz>" }`.
+- `buildInstallerPackageJson({ tarballName, overrides })` — emits the `overrides`
+  block; `installTarball` writes it before `npm install`, so first-party deps
+  resolve from the just-built workspace instead of the public registry.
 
-### Option B — npm `overrides` → locally-packed `.tgz` (lighter)
+`scripts/` is not covered by `yarn lint`; the pure helpers are unit-tested in
+`test/scripts/mulmoclaude/test_tarball.ts` (closure BFS, overrides shape, the pack
+loop with injected fakes, real-repo enumeration). The full install+boot is exercised
+by the `smoke` job itself, which `paths`-triggers on `scripts/mulmoclaude/**`.
 
-Extend `buildInstallerPackageJson` (`scripts/mulmoclaude/tarball.mjs`) to `npm
-pack` each workspace `@mulmoclaude/*` dep and add an `overrides` map pointing each
-`@mulmoclaude/<name>` at its local `file:<tgz>` in the installer `package.json`.
+## The fidelity tradeoff (accepted by the maintainer)
 
-- **Pro:** no extra service; a targeted change to one script + its unit tests
-  (`buildInstallerPackageJson` is already unit-tested).
-- **Con:** relies on npm resolving **transitive** `file:` overrides correctly
-  (npm ≥ 8.3); fiddlier for scoped/peer deps; slightly less "real" than a registry.
-
-## The fidelity tradeoff (decide before implementing)
-
-Either option means `smoke` **no longer catches "you forgot to publish a
-first-party dep"** — it always uses the local build. That check must move to the
-release/publish step (the `/publish` skill already verifies a package's deps are
-published before publishing it). Confirm that relocation is acceptable to the
-maintainer; it is the one real regression in test coverage.
+`smoke` **no longer catches "you forgot to publish a first-party dep"** — it always
+installs the local build. That check lives in the release/publish step (the
+`/publish` skill verifies a package's deps are published before publishing it).
+Signed off for this change.
 
 ## Non-goals
 

--- a/scripts/mulmoclaude/tarball.d.mts
+++ b/scripts/mulmoclaude/tarball.d.mts
@@ -37,9 +37,54 @@ export interface InstallerPackageJson {
   private: true;
   description: string;
   dependencies: Record<string, string>;
+  /** npm `overrides` pinning the launcher's first-party workspace deps to local
+   *  `file:` tarballs. Omitted when the map is empty. */
+  overrides?: Record<string, string>;
 }
 
-export function buildInstallerPackageJson(options?: { tarballName?: string }): InstallerPackageJson;
+export function buildInstallerPackageJson(options?: { tarballName?: string; overrides?: Record<string, string> }): InstallerPackageJson;
+
+/** One workspace package discovered from the root `workspaces` globs. */
+export interface WorkspacePackage {
+  name: string;
+  dir: string;
+  private: boolean;
+  /** dependencies + peerDependencies + optionalDependencies names. */
+  deps: string[];
+}
+
+/** Result of the injectable command runner (npm pack). */
+export interface RunCommandResult {
+  code: number | null;
+  timedOut: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+/** Enumerate every workspace package by expanding the root `workspaces` globs. */
+export function enumerateWorkspacePackages(
+  root: string,
+  options?: {
+    readFileImpl?: (filePath: string, encoding: "utf8") => Promise<string>;
+    readdirImpl?: (dirPath: string, options: { withFileTypes: true }) => Promise<Array<{ name: string; isDirectory(): boolean }>>;
+  },
+): Promise<WorkspacePackage[]>;
+
+/** Pure BFS: transitive first-party (workspace) deps reachable from `rootName`,
+ *  excluding the root itself. Third-party deps are naturally excluded. */
+export function computeFirstPartyClosure(packages: Array<{ name: string; deps: string[] }>, rootName: string): Set<string>;
+
+export interface PackWorkspaceOverridesOptions {
+  root: string;
+  packDir: string;
+  runCommandImpl?: (cmd: string, args: string[], options?: { cwd?: string; timeoutMs?: number; env?: NodeJS.ProcessEnv }) => Promise<RunCommandResult>;
+  enumerateImpl?: (root: string) => Promise<WorkspacePackage[]>;
+  packTimeoutMs?: number;
+}
+
+/** Pack the launcher's first-party dependency closure to local tarballs and
+ *  return an npm `overrides` map `{ name: "file:<abs.tgz>" }`. */
+export function packWorkspaceOverrides(options: PackWorkspaceOverridesOptions): Promise<Record<string, string>>;
 
 export interface RunTarballSmokeOptions {
   root?: string;

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -105,9 +105,12 @@ function defaultSleep(delayMs) {
 
 // Build the throwaway package.json for the install directory. Pure
 // function so tests can lock in the shape without spinning up a
-// filesystem.
-export function buildInstallerPackageJson({ tarballName } = {}) {
-  return {
+// filesystem. `overrides` (npm `overrides`) redirects the launcher's
+// first-party workspace deps to local `file:` tarballs so the install
+// resolves them from the just-built workspace instead of the public
+// registry — see packWorkspaceOverrides / plans/feat-smoke-local-registry.md.
+export function buildInstallerPackageJson({ tarballName, overrides } = {}) {
+  const pkg = {
     name: "mulmoclaude-smoke-installer",
     version: "0.0.0",
     private: true,
@@ -118,6 +121,108 @@ export function buildInstallerPackageJson({ tarballName } = {}) {
     description: "Throwaway install root for mulmoclaude CI smoke. Not for publish.",
     dependencies: tarballName ? { mulmoclaude: `file:${tarballName}` } : {},
   };
+  if (overrides && Object.keys(overrides).length > 0) {
+    pkg.overrides = overrides;
+  }
+  return pkg;
+}
+
+// The launcher package's own name — it is installed via its tarball, never
+// overridden, and is the root of the first-party dependency closure.
+const LAUNCHER_NAME = "mulmoclaude";
+
+// Read every workspace package (name, dir, first-party-relevant dep names) by
+// expanding the root package.json `workspaces` globs. All globs are `<dir>/*`,
+// so a single readdir per parent suffices — no glob library needed. Injectable
+// fs impls keep it unit-testable. `deps` folds dependencies + peerDependencies +
+// optionalDependencies since any of them can pull a first-party package into the
+// install tree.
+export async function enumerateWorkspacePackages(root, { readFileImpl = readFile, readdirImpl = readdir } = {}) {
+  const rootPkg = JSON.parse(await readFileImpl(path.join(root, "package.json"), "utf8"));
+  const globs = rootPkg.workspaces ?? [];
+  const packages = [];
+  for (const glob of globs) {
+    const parent = glob.replace(/\/\*$/, "");
+    let entries;
+    try {
+      entries = await readdirImpl(path.join(root, parent), { withFileTypes: true });
+    } catch {
+      continue; // a globbed parent dir may not exist in every checkout
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const dir = path.join(root, parent, entry.name);
+      let pj;
+      try {
+        pj = JSON.parse(await readFileImpl(path.join(dir, "package.json"), "utf8"));
+      } catch {
+        continue; // a `<dir>/*` parent (e.g. packages/plugins) has no package.json of its own
+      }
+      const deps = [...Object.keys(pj.dependencies ?? {}), ...Object.keys(pj.peerDependencies ?? {}), ...Object.keys(pj.optionalDependencies ?? {})];
+      packages.push({ name: pj.name, dir, private: pj.private === true, deps });
+    }
+  }
+  return packages;
+}
+
+// Pure BFS: the set of first-party (workspace) package names reachable from
+// `rootName`'s deps, excluding the root itself. "First-party" = present in the
+// packages list, so third-party deps (@mulmochat-plugin/*, @mulmocast/types, …)
+// are naturally excluded and left to resolve from the public registry.
+export function computeFirstPartyClosure(packages, rootName) {
+  const byName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+  const firstParty = new Set(byName.keys());
+  const root = byName.get(rootName);
+  if (!root) return new Set();
+  const closure = new Set();
+  const queue = root.deps.filter((dep) => firstParty.has(dep));
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (closure.has(name) || name === rootName) continue;
+    closure.add(name);
+    const pkg = byName.get(name);
+    if (pkg) {
+      for (const dep of pkg.deps) {
+        if (firstParty.has(dep) && !closure.has(dep)) queue.push(dep);
+      }
+    }
+  }
+  return closure;
+}
+
+// `npm pack` one workspace package into `destDir` with --ignore-scripts (dist is
+// already built by the CI build step, so we archive it as-is rather than paying a
+// prepack rebuild per package). Returns the absolute tarball path.
+async function packOneWorkspacePackage({ packageDir, destDir, runCommandImpl = runCommand, packTimeoutMs }) {
+  const result = await runCommandImpl("npm", ["pack", packageDir, "--ignore-scripts", "--pack-destination", destDir, "--json"], {
+    timeoutMs: packTimeoutMs ?? DEFAULT_PACK_TIMEOUT_MS,
+  });
+  if (result.code !== 0 || result.timedOut) {
+    throw new Error(`npm pack failed for ${packageDir} (code=${result.code}, timedOut=${result.timedOut})\n${result.stderr}`);
+  }
+  const parsed = JSON.parse(result.stdout);
+  const filename = Array.isArray(parsed) ? parsed[0]?.filename : parsed?.filename;
+  if (!filename) throw new Error(`npm pack produced no filename for ${packageDir}`);
+  return path.join(destDir, filename);
+}
+
+// Pack the launcher's first-party workspace dependency closure into `packDir` and
+// return an npm `overrides` map { name: "file:<abs tarball>" }. This is what lets
+// the smoke install a launcher pinned to a bumped-but-unpublished shared package
+// (e.g. @mulmoclaude/core@0.12.0) without that version existing on public npm —
+// see plans/feat-smoke-local-registry.md.
+export async function packWorkspaceOverrides({ root, packDir, runCommandImpl = runCommand, enumerateImpl = enumerateWorkspacePackages, packTimeoutMs } = {}) {
+  const packages = await enumerateImpl(root);
+  const closure = computeFirstPartyClosure(packages, LAUNCHER_NAME);
+  const byName = new Map(packages.map((pkg) => [pkg.name, pkg]));
+  const overrides = {};
+  for (const name of closure) {
+    const pkg = byName.get(name);
+    if (!pkg) continue;
+    const tarballPath = await packOneWorkspacePackage({ packageDir: pkg.dir, destDir: packDir, runCommandImpl, packTimeoutMs });
+    overrides[name] = `file:${tarballPath}`;
+  }
+  return overrides;
 }
 
 // Spawn a child process, collect stdout/stderr as strings, enforce a
@@ -365,9 +470,16 @@ export async function verifySandboxFiles({ workDir, files = REQUIRED_SANDBOX_FIL
   return { ok: missing.length === 0, missing, checkedDir: installedPkgDir };
 }
 
-// Lay out a throwaway install dir and `npm install` the tarball.
-async function installTarball({ workDir, tarballAbsolutePath, installTimeoutMs }) {
-  const pkg = buildInstallerPackageJson({ tarballName: path.basename(tarballAbsolutePath) });
+// Lay out a throwaway install dir and `npm install` the tarball. First-party
+// workspace deps are packed to local tarballs and pinned via `overrides` so the
+// install resolves them from the just-built workspace, not the public registry —
+// otherwise a launcher pinned to a bumped-but-unpublished shared package would
+// fail with ETARGET (plans/feat-smoke-local-registry.md).
+async function installTarball({ workDir, tarballAbsolutePath, installTimeoutMs, root, packTimeoutMs }) {
+  const packDir = path.join(workDir, "local-deps");
+  await mkdir(packDir, { recursive: true });
+  const overrides = await packWorkspaceOverrides({ root, packDir, packTimeoutMs });
+  const pkg = buildInstallerPackageJson({ tarballName: path.basename(tarballAbsolutePath), overrides });
   await writeFile(path.join(workDir, "package.json"), JSON.stringify(pkg, null, 2), "utf8");
   const result = await runCommand("npm", ["install", tarballAbsolutePath, "--no-audit", "--no-fund"], {
     cwd: workDir,
@@ -485,7 +597,7 @@ export async function runTarballSmoke({
   let succeeded = false;
   try {
     tarballPath = await packTarball({ root, packTimeoutMs });
-    await installTarball({ workDir: runDir, tarballAbsolutePath: tarballPath, installTimeoutMs });
+    await installTarball({ workDir: runDir, tarballAbsolutePath: tarballPath, installTimeoutMs, root, packTimeoutMs });
     const sandboxCheck = await verifySandboxFiles({ workDir: runDir });
     if (!sandboxCheck.ok) {
       throw new Error(`sandbox build context missing from tarball: ${sandboxCheck.missing.join(", ")} (under ${sandboxCheck.checkedDir})`);

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -165,6 +165,79 @@ describe("buildInstallerPackageJson", () => {
     const pkg = tarball.buildInstallerPackageJson();
     assert.deepEqual(pkg.dependencies, {});
   });
+
+  it("includes an overrides block when first-party deps are pinned locally", () => {
+    const overrides = { "@mulmoclaude/core": "file:/tmp/core.tgz" };
+    const pkg = tarball.buildInstallerPackageJson({ tarballName: "mulmoclaude-0.12.0.tgz", overrides });
+    assert.deepEqual(pkg.overrides, overrides);
+  });
+
+  it("omits the overrides key entirely when the map is empty or absent", () => {
+    assert.equal("overrides" in tarball.buildInstallerPackageJson({ tarballName: "x.tgz" }), false);
+    assert.equal("overrides" in tarball.buildInstallerPackageJson({ tarballName: "x.tgz", overrides: {} }), false);
+  });
+});
+
+describe("computeFirstPartyClosure", () => {
+  // root -> a -> b (first-party chain); `c` is third-party (not a workspace
+  // package), so it must NOT appear. `b`'s dep on the external `ext` is ignored.
+  const packages = [
+    { name: "mulmoclaude", deps: ["@w/a", "ext-cli"] },
+    { name: "@w/a", deps: ["@w/b", "ext-lib"] },
+    { name: "@w/b", deps: ["@w/a"] }, // cycle back to a — must terminate
+    { name: "@w/unused", deps: [] }, // a workspace package the launcher doesn't use
+  ];
+
+  it("returns the transitive first-party deps reachable from the root", () => {
+    const closure = tarball.computeFirstPartyClosure(packages, "mulmoclaude");
+    assert.deepEqual([...closure].sort(), ["@w/a", "@w/b"]);
+  });
+
+  it("excludes the root itself, third-party deps, and unused workspace packages", () => {
+    const closure = tarball.computeFirstPartyClosure(packages, "mulmoclaude");
+    assert.equal(closure.has("mulmoclaude"), false);
+    assert.equal(closure.has("ext-cli"), false); // third-party, not a workspace pkg
+    assert.equal(closure.has("@w/unused"), false); // workspace pkg, not a launcher dep
+  });
+
+  it("returns an empty set when the root package is absent", () => {
+    assert.equal(tarball.computeFirstPartyClosure(packages, "nonexistent").size, 0);
+  });
+});
+
+describe("packWorkspaceOverrides", () => {
+  it("packs only the launcher's first-party closure and maps each to a file: tarball", async () => {
+    const enumerateImpl = async () => [
+      { name: "mulmoclaude", dir: "/repo/packages/mulmoclaude", private: false, deps: ["@w/core"] },
+      { name: "@w/core", dir: "/repo/packages/core", private: false, deps: [] },
+      { name: "@w/unused", dir: "/repo/packages/unused", private: false, deps: [] },
+    ];
+    const packedDirs: string[] = [];
+    const runCommandImpl = async (_cmd: string, args: string[]) => {
+      const [, dir] = args; // ["pack", <dir>, "--ignore-scripts", ...]
+      packedDirs.push(dir);
+      const base = dir.split("/").pop();
+      return { code: 0, timedOut: false, stdout: JSON.stringify([{ filename: `${base}-1.0.0.tgz` }]), stderr: "" };
+    };
+    const overrides = await tarball.packWorkspaceOverrides({ root: "/repo", packDir: "/tmp/packs", enumerateImpl, runCommandImpl });
+    // Only @w/core is packed — the launcher itself and the unused package are not.
+    assert.deepEqual(packedDirs, ["/repo/packages/core"]);
+    assert.deepEqual(overrides, { "@w/core": "file:/tmp/packs/core-1.0.0.tgz" });
+  });
+});
+
+describe("enumerateWorkspacePackages", () => {
+  it("finds the real workspace packages, including the launcher and core, with dep lists", async () => {
+    const path = await import("node:path");
+    const url = await import("node:url");
+    const root = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../../..");
+    const packages = await tarball.enumerateWorkspacePackages(root);
+    const byName = new Map(packages.map((pkg: { name: string }) => [pkg.name, pkg]));
+    assert.ok(byName.has("mulmoclaude"), "launcher package must be discovered");
+    const core = byName.get("@mulmoclaude/core") as { deps: string[] } | undefined;
+    assert.ok(core, "@mulmoclaude/core must be discovered");
+    assert.ok(Array.isArray((core as { deps: string[] }).deps), "each package carries a deps array");
+  });
 });
 
 describe("readTokenFromLauncherLog", () => {


### PR DESCRIPTION
## What

Eliminates the **publish-before-merge chicken-and-egg** surfaced in #1993: the `smoke` tarball test `npm install`ed the launcher's `@mulmoclaude/*` deps **from the public registry**, so a launcher pinned to a bumped-but-unpublished shared package (e.g. `@mulmoclaude/core@0.12.0`) failed `ETARGET No matching version found` → smoke red until the package was published.

Now the tarball install pins the launcher's **first-party workspace dependency closure** to locally-packed `.tgz` via npm `overrides`, so those deps resolve from the just-built workspace instead of npm. A bumped shared package no longer has to be published for `smoke` to go green — publish moves to a clean post-merge release step.

## Approach

Chose **npm `overrides` → local tarballs** (service-free) over a Verdaccio local registry (which would add a service + auth config to CI). De-risked first with a synthetic repro confirming npm resolves a **transitive** `file:` override for an unpublished-scope package fully offline (npm ≥ 8.3).

`scripts/mulmoclaude/tarball.mjs`:
- **`enumerateWorkspacePackages(root)`** — expand the root `workspaces` globs (all `<dir>/*`) to `{ name, dir, private, deps }` (`deps` folds dependencies + peer + optional).
- **`computeFirstPartyClosure(packages, "mulmoclaude")`** — pure BFS for the launcher's transitive first-party (workspace) deps. Against the real repo this is **13 packages** (core, bundled plugins, bridges, task-scheduler), not all 47; third-party deps (`@mulmochat-plugin/*`, `@mulmocast/types`, …) still resolve from the real registry.
- **`packWorkspaceOverrides(...)`** — `npm pack --ignore-scripts` each closure package (dist is already built by the workflow's `yarn build:packages`, so no prepack rebuild) and return `{ name: "file:<abs.tgz>" }`.
- **`buildInstallerPackageJson({ tarballName, overrides })`** — emits the `overrides` block; `installTarball` writes it before `npm install`.

## Fidelity tradeoff (maintainer-approved)

`smoke` **no longer catches "you forgot to publish a first-party dep"** — it always installs the local build. That check lives in the release/publish step (the `/publish` skill verifies a package's deps are published before publishing it). The launcher install+boot fidelity is otherwise unchanged.

## Tests

Unit tests (`test/scripts/mulmoclaude/test_tarball.ts`): closure BFS (transitive, cycle-terminating, excludes root/third-party/unused), overrides shape, the pack loop with injected fakes, real-repo enumeration. The full install+boot is exercised by the `smoke` job itself, which `paths`-triggers on `scripts/mulmoclaude/**` — **so this PR's own smoke run validates the change end-to-end** (installs the launcher with the new override path).

Plan: `plans/feat-smoke-local-registry.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smoke installs now use locally built workspace tarballs for first-party dependencies, improving end-to-end validation of the packaged app.
  * Added support for generating install overrides to pin workspace packages to local `file:` tarballs.

* **Bug Fixes**
  * Smoke testing now leaves third-party dependencies to the public registry while keeping first-party packages local.

* **Tests**
  * Expanded coverage for workspace discovery, dependency closure handling, and installer manifest generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->