### PR TITLE
fix(sandbox): register ESM resolver hook so @mulmoclaude/* resolves on Windows Docker (#1982)

### DIFF
--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -171,8 +171,9 @@ jobs:
             -v "${wsLinux}/packages/plugins/email-plugin:/app/pkg_modules/@mulmoclaude/email-plugin:ro" `
             -v "${wsLinux}/packages/core:/app/pkg_modules/@mulmoclaude/core:ro" `
             -v "${wsLinux}/server/plugins:/app/server-plugins:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro" `
             -v "${wsLinux}/test/sandbox-repro:/repro:ro" `
             -e NODE_PATH=/app/node_modules:/app/pkg_modules `
             -w /app `
             node:22-slim `
-            bash -c "npm install -g tsx --silent && tsx /repro/probe.ts"
+            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-loader.mjs /repro/probe.ts"

--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -172,8 +172,9 @@ jobs:
             -v "${wsLinux}/packages/core:/app/pkg_modules/@mulmoclaude/core:ro" `
             -v "${wsLinux}/server/plugins:/app/server-plugins:ro" `
             -v "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-bootstrap.mjs:/app/server/agent/mcp-esm-bootstrap.mjs:ro" `
             -v "${wsLinux}/test/sandbox-repro:/repro:ro" `
             -e NODE_PATH=/app/node_modules:/app/pkg_modules `
             -w /app `
             node:22-slim `
-            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-loader.mjs /repro/probe.ts"
+            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /repro/probe.ts"

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -25,7 +25,13 @@ export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 // `@mulmoclaude/<name>` and this dir is appended to NODE_PATH — CJS
 // resolution falls through to it when the primary link fails to resolve.
 // Only mounted for win32 source builds; a no-op path elsewhere.
+//
+// NODE_PATH is CJS-only per Node's spec, so the paired
+// `mcp-esm-loader.mjs` (registered via `--import`) covers the ESM side
+// by reading each pkg's package.json under this root and returning the
+// resolved entry URL (#1982).
 const CONTAINER_WORKSPACE_MODULES_PATH = "/app/pkg_modules";
+const CONTAINER_ESM_LOADER_URL = "file:///app/server/agent/mcp-esm-loader.mjs";
 
 // `Skill` is the tool Claude Code uses to execute a discovered
 // `.claude/skills/<name>/SKILL.md`. Because `--allowedTools` is passed
@@ -312,7 +318,12 @@ function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; a
     // started silently failing some time after the CLI update.
     type: "stdio",
     command,
-    args: [mcpServerPath],
+    // Docker path: register the ESM resolver hook that plugs the
+    // Windows-junction gap in the ESM loader (#1946/#1982). Passed
+    // as a Node CLI flag; tsx forwards `--import` through. No-op on
+    // Linux/macOS Docker (the hook's catch never fires). Native
+    // mode never sees this flag.
+    args: useDocker ? ["--import", CONTAINER_ESM_LOADER_URL, mcpServerPath] : [mcpServerPath],
     env: {
       SESSION_ID: chatSessionId,
       PORT: String(port),

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -31,7 +31,11 @@ export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
 // by reading each pkg's package.json under this root and returning the
 // resolved entry URL (#1982).
 const CONTAINER_WORKSPACE_MODULES_PATH = "/app/pkg_modules";
-const CONTAINER_ESM_LOADER_URL = "file:///app/server/agent/mcp-esm-loader.mjs";
+// `--import` this bootstrap; the bootstrap in turn calls
+// `node:module.register()` on the loader. Pointing `--import`
+// straight at the loader would just evaluate its top level and
+// leave the exported `resolve()` inert.
+const CONTAINER_ESM_BOOTSTRAP_URL = "file:///app/server/agent/mcp-esm-bootstrap.mjs";
 
 // `Skill` is the tool Claude Code uses to execute a discovered
 // `.claude/skills/<name>/SKILL.md`. Because `--allowedTools` is passed
@@ -323,7 +327,7 @@ function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; a
     // as a Node CLI flag; tsx forwards `--import` through. No-op on
     // Linux/macOS Docker (the hook's catch never fires). Native
     // mode never sees this flag.
-    args: useDocker ? ["--import", CONTAINER_ESM_LOADER_URL, mcpServerPath] : [mcpServerPath],
+    args: useDocker ? ["--import", CONTAINER_ESM_BOOTSTRAP_URL, mcpServerPath] : [mcpServerPath],
     env: {
       SESSION_ID: chatSessionId,
       PORT: String(port),

--- a/server/agent/mcp-esm-bootstrap.mjs
+++ b/server/agent/mcp-esm-bootstrap.mjs
@@ -1,0 +1,16 @@
+// Bootstrap module for the Docker sandbox MCP child (#1982).
+//
+// `tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs`
+// runs this file at process startup. Its ONLY job is to call
+// `node:module.register()` pointing at the actual resolver hook —
+// without that call, `--import` merely evaluates the target
+// module's top level and the exported `resolve()` never runs
+// (Codex review on PR #1995).
+//
+// Separated from `mcp-esm-loader.mjs` so the loader stays pure and
+// unit-testable (importing the loader from a test doesn't trigger
+// a register() side effect).
+
+import { register } from "node:module";
+
+register("./mcp-esm-loader.mjs", import.meta.url);

--- a/server/agent/mcp-esm-loader.d.mts
+++ b/server/agent/mcp-esm-loader.d.mts
@@ -1,0 +1,28 @@
+// Type declarations for the ESM resolver hook (`mcp-esm-loader.mjs`).
+// Kept alongside the .mjs so it stays in step with any signature changes.
+
+export interface ScopedSpecifierSplit {
+  pkg: string;
+  subpath: string;
+}
+
+export interface PackageManifest {
+  exports?: string | Record<string, unknown> | null;
+  main?: string;
+  [key: string]: unknown;
+}
+
+export function splitScopedSpecifier(specifier: string): ScopedSpecifierSplit;
+
+export function pickEntry(manifest: PackageManifest, subpath: string): string | null;
+
+export function resolveFromFallback(pkg: string, subpath: string, fallbackRoot?: string): string | null;
+
+/** Node ESM resolver hook. Contract matches Node's `--import`/`register`
+ *  loader API: intercept the specifier, delegate to `nextResolve` first,
+ *  and only rewrite when the primary resolution throws. */
+export function resolve(
+  specifier: string,
+  context: unknown,
+  nextResolve: (specifier: string, context: unknown) => Promise<{ url: string; shortCircuit?: boolean; format?: string }>,
+): Promise<{ url: string; shortCircuit?: boolean; format?: string }>;

--- a/server/agent/mcp-esm-loader.mjs
+++ b/server/agent/mcp-esm-loader.mjs
@@ -1,0 +1,98 @@
+// ESM resolver hook installed via `tsx --import ...` on the Docker
+// sandbox MCP child (#1982).
+//
+// Problem: NODE_PATH is a CJS-only mechanism (Node's ESM resolver
+// never consults it — per spec). On Windows the yarn-workspace
+// `node_modules/@mulmoclaude/*` links are NTFS junctions that dangle
+// inside the Linux container; PR #1974 added `/app/pkg_modules/*` as
+// a NODE_PATH fallback which fixed CJS, but static ESM imports like
+// `import { readXPost } from "@mulmoclaude/x-plugin"` in
+// `server/agent/mcp-tools/index.ts` fail before any of that fires,
+// because the ESM loader has no equivalent to NODE_PATH.
+//
+// Fix: when a `@mulmoclaude/*` specifier fails default resolution,
+// read the corresponding package.json under `/app/pkg_modules/` and
+// return the resolved entry file URL. Supports both exports-map and
+// legacy `main` shapes, plus subpath imports (`@mulmoclaude/pkg/sub`).
+//
+// No-op on Linux/macOS Docker (primary resolution succeeds via POSIX
+// symlinks in `/app/node_modules`, the catch never fires). Only
+// registered when the MCP child is spawned in Docker mode (config.ts:
+// buildMulmoclaudeServer). Native (DISABLE_SANDBOX) mode never loads
+// this file.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const SCOPE = "@mulmoclaude/";
+const FALLBACK_ROOT = "/app/pkg_modules";
+
+// Exported for the unit test (test/agent/test_mcp_esm_loader.ts). The
+// runtime hook does not consume the export.
+export function splitScopedSpecifier(specifier) {
+  const rest = specifier.slice(SCOPE.length);
+  const firstSlash = rest.indexOf("/");
+  if (firstSlash === -1) return { pkg: specifier, subpath: "." };
+  return {
+    pkg: SCOPE + rest.slice(0, firstSlash),
+    subpath: "./" + rest.slice(firstSlash + 1),
+  };
+}
+
+// Pick an entry file for the given subpath from a package.json's
+// `exports` or `main`. Handles the shapes we actually ship:
+//   - `"exports": "./dist/index.js"`
+//   - `"exports": { ".": "./dist/index.js" }`
+//   - `"exports": { ".": { "import": "./dist/index.js" } }`
+//   - `"exports": { ".": { "import": { "default": "./dist/index.js" } } }`
+//   - `"main": "./dist/index.js"` (fallback, subpath === "." only)
+export function pickEntry(manifest, subpath) {
+  const { exports: exp, main } = manifest;
+  if (typeof exp === "string") return subpath === "." ? exp : null;
+  if (exp && typeof exp === "object") {
+    const entry = exp[subpath];
+    if (typeof entry === "string") return entry;
+    if (entry && typeof entry === "object") {
+      // Prefer import > default (matches Node's conditional-export resolution).
+      const importCond = entry.import;
+      if (typeof importCond === "string") return importCond;
+      if (importCond && typeof importCond === "object" && typeof importCond.default === "string") {
+        return importCond.default;
+      }
+      if (typeof entry.default === "string") return entry.default;
+    }
+  }
+  return subpath === "." && typeof main === "string" ? main : null;
+}
+
+export function resolveFromFallback(pkg, subpath, fallbackRoot = FALLBACK_ROOT) {
+  const pkgDir = path.join(fallbackRoot, pkg);
+  const pkgJsonPath = path.join(pkgDir, "package.json");
+  if (!existsSync(pkgJsonPath)) return null;
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+  } catch {
+    return null;
+  }
+  const entry = pickEntry(manifest, subpath);
+  if (!entry) return null;
+  const absPath = path.join(pkgDir, entry);
+  if (!existsSync(absPath)) return null;
+  return pathToFileURL(absPath).href;
+}
+
+export async function resolve(specifier, context, nextResolve) {
+  if (!specifier.startsWith(SCOPE)) {
+    return nextResolve(specifier, context);
+  }
+  try {
+    return await nextResolve(specifier, context);
+  } catch (primaryErr) {
+    const { pkg, subpath } = splitScopedSpecifier(specifier);
+    const url = resolveFromFallback(pkg, subpath);
+    if (!url) throw primaryErr;
+    return { url, shortCircuit: true, format: "module" };
+  }
+}

--- a/server/agent/mcp-esm-loader.mjs
+++ b/server/agent/mcp-esm-loader.mjs
@@ -35,9 +35,21 @@ export function splitScopedSpecifier(specifier) {
   const firstSlash = rest.indexOf("/");
   if (firstSlash === -1) return { pkg: specifier, subpath: "." };
   return {
-    pkg: SCOPE + rest.slice(0, firstSlash),
-    subpath: "./" + rest.slice(firstSlash + 1),
+    pkg: `${SCOPE}${rest.slice(0, firstSlash)}`,
+    subpath: `./${rest.slice(firstSlash + 1)}`,
   };
+}
+
+// Walk a conditional-export block preferring `import.default` >
+// `import` > `default`, matching Node's conditional-export precedence
+// for the "import" condition set.
+function pickConditional(entry) {
+  const importCond = entry.import;
+  if (typeof importCond === "string") return importCond;
+  if (importCond && typeof importCond === "object" && typeof importCond.default === "string") {
+    return importCond.default;
+  }
+  return typeof entry.default === "string" ? entry.default : null;
 }
 
 // Pick an entry file for the given subpath from a package.json's
@@ -53,15 +65,7 @@ export function pickEntry(manifest, subpath) {
   if (exp && typeof exp === "object") {
     const entry = exp[subpath];
     if (typeof entry === "string") return entry;
-    if (entry && typeof entry === "object") {
-      // Prefer import > default (matches Node's conditional-export resolution).
-      const importCond = entry.import;
-      if (typeof importCond === "string") return importCond;
-      if (importCond && typeof importCond === "object" && typeof importCond.default === "string") {
-        return importCond.default;
-      }
-      if (typeof entry.default === "string") return entry.default;
-    }
+    if (entry && typeof entry === "object") return pickConditional(entry);
   }
   return subpath === "." && typeof main === "string" ? main : null;
 }

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -69,13 +69,17 @@ describe("buildMcpConfig", () => {
     assert.equal((server.env as Record<string, string>).NODE_PATH, undefined);
   });
 
-  it("docker server registers the ESM resolver hook via --import (#1982)", async () => {
+  it("docker server registers the ESM resolver hook via a bootstrap that calls register() (#1982)", async () => {
     const config = buildMcpConfig({ chatSessionId: "s", port: 3001, activePlugins: [], useDocker: true }) as Record<string, unknown>;
     const server = (config.mcpServers as Record<string, unknown>).mulmoclaude as Record<string, unknown>;
     const args = server.args as string[];
     const importIdx = args.indexOf("--import");
     assert.ok(importIdx !== -1, "--import flag must be present so the ESM loader hook is registered");
-    assert.equal(args[importIdx + 1], "file:///app/server/agent/mcp-esm-loader.mjs");
+    // Points at the bootstrap — NOT the loader directly. `--import
+    // <loader>` only evaluates the module's top level; a bootstrap
+    // that calls `register()` is what actually wires the resolve
+    // hook into Node's loader chain (Codex review).
+    assert.equal(args[importIdx + 1], "file:///app/server/agent/mcp-esm-bootstrap.mjs");
     // The mcp-server script must still be the LAST arg so tsx treats it
     // as the entry point rather than a flag operand.
     assert.equal(args[args.length - 1], "/app/server/agent/mcp-server.ts");

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -68,6 +68,25 @@ describe("buildMcpConfig", () => {
     const server = (config.mcpServers as Record<string, unknown>).mulmoclaude as Record<string, unknown>;
     assert.equal((server.env as Record<string, string>).NODE_PATH, undefined);
   });
+
+  it("docker server registers the ESM resolver hook via --import (#1982)", async () => {
+    const config = buildMcpConfig({ chatSessionId: "s", port: 3001, activePlugins: [], useDocker: true }) as Record<string, unknown>;
+    const server = (config.mcpServers as Record<string, unknown>).mulmoclaude as Record<string, unknown>;
+    const args = server.args as string[];
+    const importIdx = args.indexOf("--import");
+    assert.ok(importIdx !== -1, "--import flag must be present so the ESM loader hook is registered");
+    assert.equal(args[importIdx + 1], "file:///app/server/agent/mcp-esm-loader.mjs");
+    // The mcp-server script must still be the LAST arg so tsx treats it
+    // as the entry point rather than a flag operand.
+    assert.equal(args[args.length - 1], "/app/server/agent/mcp-server.ts");
+  });
+
+  it("native (non-docker) server does NOT include --import (loader hook is a Docker-only fix)", async () => {
+    const config = buildMcpConfig({ chatSessionId: "s", port: 3001, activePlugins: [], useDocker: false }) as Record<string, unknown>;
+    const server = (config.mcpServers as Record<string, unknown>).mulmoclaude as Record<string, unknown>;
+    const args = server.args as string[];
+    assert.ok(!args.includes("--import"), "--import must not leak into native mode where the loader isn't relevant");
+  });
 });
 
 describe("buildCliArgs", () => {

--- a/test/agent/test_mcp_esm_loader.ts
+++ b/test/agent/test_mcp_esm_loader.ts
@@ -1,0 +1,113 @@
+// Unit tests for the ESM resolver hook that plugs the Windows-Docker
+// junction gap for ESM callers (#1982).
+//
+// The runtime hook itself is tested at the Node-loader integration
+// level by `test/sandbox-repro/probe.ts` inside the Windows CI Docker
+// job. Here we cover the pure helpers: specifier splitting, entry
+// picking, and the file-system-anchored fallback resolver.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { splitScopedSpecifier, pickEntry, resolveFromFallback } from "../../server/agent/mcp-esm-loader.mjs";
+
+describe("splitScopedSpecifier", () => {
+  it("splits a bare @mulmoclaude package into pkg + '.' subpath", () => {
+    assert.deepEqual(splitScopedSpecifier("@mulmoclaude/x-plugin"), {
+      pkg: "@mulmoclaude/x-plugin",
+      subpath: ".",
+    });
+  });
+
+  it("splits a subpath specifier into pkg + './sub' subpath", () => {
+    assert.deepEqual(splitScopedSpecifier("@mulmoclaude/core/util/log"), {
+      pkg: "@mulmoclaude/core",
+      subpath: "./util/log",
+    });
+  });
+});
+
+describe("pickEntry", () => {
+  it("returns the string exports value when subpath is '.'", () => {
+    assert.equal(pickEntry({ exports: "./dist/index.js" }, "."), "./dist/index.js");
+  });
+
+  it("returns null for a subpath when exports is a bare string (only '.' is valid)", () => {
+    assert.equal(pickEntry({ exports: "./dist/index.js" }, "./sub"), null);
+  });
+
+  it("returns the ./sub value from an object exports map", () => {
+    assert.equal(pickEntry({ exports: { ".": "./a.js", "./sub": "./b.js" } }, "./sub"), "./b.js");
+  });
+
+  it("prefers exports['.'].import.default over .default", () => {
+    const manifest = {
+      exports: { ".": { import: { default: "./dist/esm/index.js" }, default: "./dist/legacy.js" } },
+    };
+    assert.equal(pickEntry(manifest, "."), "./dist/esm/index.js");
+  });
+
+  it("falls back to exports['.'].default when import is missing", () => {
+    assert.equal(pickEntry({ exports: { ".": { default: "./dist/legacy.js" } } }, "."), "./dist/legacy.js");
+  });
+
+  it("falls back to `main` when exports is absent and subpath is '.'", () => {
+    assert.equal(pickEntry({ main: "./dist/index.js" }, "."), "./dist/index.js");
+  });
+
+  it("returns null when no entry matches", () => {
+    assert.equal(pickEntry({ exports: { ".": "./a.js" } }, "./missing"), null);
+    assert.equal(pickEntry({}, "."), null);
+  });
+});
+
+describe("resolveFromFallback (fs-anchored)", () => {
+  let tmpDir = "";
+  let fallbackRoot = "";
+
+  before(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), "mulmo-esm-loader-"));
+    fallbackRoot = path.join(tmpDir, "pkg_modules");
+    // A pretend `@mulmoclaude/foo-plugin` with an exports.import.default entry.
+    const pkgDir = path.join(fallbackRoot, "@mulmoclaude", "foo-plugin");
+    mkdirSync(path.join(pkgDir, "dist"), { recursive: true });
+    writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@mulmoclaude/foo-plugin",
+        exports: { ".": { import: { default: "./dist/index.js" } } },
+      }),
+    );
+    writeFileSync(path.join(pkgDir, "dist", "index.js"), "export const x = 1;\n");
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns a file:// URL to the resolved entry when the package + entry both exist", () => {
+    const url = resolveFromFallback("@mulmoclaude/foo-plugin", ".", fallbackRoot);
+    assert.equal(url, pathToFileURL(path.join(fallbackRoot, "@mulmoclaude", "foo-plugin", "dist", "index.js")).href);
+  });
+
+  it("returns null when the package.json is missing", () => {
+    assert.equal(resolveFromFallback("@mulmoclaude/nope-plugin", ".", fallbackRoot), null);
+  });
+
+  it("returns null when the entry file itself is missing on disk", () => {
+    const pkgDir = path.join(fallbackRoot, "@mulmoclaude", "broken-plugin");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify({ main: "./dist/missing.js" }));
+    assert.equal(resolveFromFallback("@mulmoclaude/broken-plugin", ".", fallbackRoot), null);
+  });
+
+  it("returns null when the package.json is unparseable", () => {
+    const pkgDir = path.join(fallbackRoot, "@mulmoclaude", "corrupt-plugin");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(path.join(pkgDir, "package.json"), "{ not valid json");
+    assert.equal(resolveFromFallback("@mulmoclaude/corrupt-plugin", ".", fallbackRoot), null);
+  });
+});

--- a/test/sandbox-repro/probe.ts
+++ b/test/sandbox-repro/probe.ts
@@ -22,14 +22,17 @@
 //   /app/pkg_modules/@mulmoclaude/<name>           — Windows FS per package (fallback)
 //   /app/server-plugins                            — Windows FS: server/plugins/
 //   /app/server/agent/mcp-esm-loader.mjs           — Windows FS: the ESM resolver hook
-//                                                    (#1982) registered via --import
+//                                                    (#1982) — resolve() live here
+//   /app/server/agent/mcp-esm-bootstrap.mjs        — bootstrap that calls
+//                                                    node:module.register(loader)
 //   /repro                                         — Windows FS: test/sandbox-repro/
 // NODE_PATH=/app/node_modules:/app/pkg_modules
 //
 // Runs on: node:22-slim + a global `tsx` install so this TS file can
 // import the shipped `.ts` source directly. The workflow launches with
-// `tsx --import file:///app/server/agent/mcp-esm-loader.mjs` so the ESM
-// step below exercises the shipped loader hook.
+// `tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs` — the
+// bootstrap registers the loader so the ESM step below exercises the
+// shipped resolve hook end-to-end.
 
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";

--- a/test/sandbox-repro/probe.ts
+++ b/test/sandbox-repro/probe.ts
@@ -17,15 +17,19 @@
 // inline code.
 //
 // Required container mounts (see the workflow for the full argv):
-//   /app/node_modules                      — Windows FS via WSL2 (primary,
-//                                            junctions dangle here)
-//   /app/pkg_modules/@mulmoclaude/<name>   — Windows FS per package (fallback)
-//   /app/server-plugins                    — Windows FS: server/plugins/
-//   /repro                                 — Windows FS: test/sandbox-repro/
+//   /app/node_modules                              — Windows FS via WSL2 (primary,
+//                                                    junctions dangle here)
+//   /app/pkg_modules/@mulmoclaude/<name>           — Windows FS per package (fallback)
+//   /app/server-plugins                            — Windows FS: server/plugins/
+//   /app/server/agent/mcp-esm-loader.mjs           — Windows FS: the ESM resolver hook
+//                                                    (#1982) registered via --import
+//   /repro                                         — Windows FS: test/sandbox-repro/
 // NODE_PATH=/app/node_modules:/app/pkg_modules
 //
 // Runs on: node:22-slim + a global `tsx` install so this TS file can
-// import the shipped `.ts` source directly.
+// import the shipped `.ts` source directly. The workflow launches with
+// `tsx --import file:///app/server/agent/mcp-esm-loader.mjs` so the ESM
+// step below exercises the shipped loader hook.
 
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -118,6 +122,35 @@ step("shipped resolvePresetRoot() returns null for a non-existent preset name", 
   const resolved = resolvePresetRoot("@mulmoclaude/definitely-does-not-exist-plugin");
   if (resolved !== null) throw new Error(`shipped resolver returned ${resolved} for a non-existent package`);
 });
+
+// ── 5. ESM path — the class of bug that #1982 fixed ───────────────────
+// The workflow launches this file with `tsx --import <mcp-esm-loader>`
+// so the loader is registered on this process. Dynamic `import()` goes
+// through the same ESM resolver chain the failing MCP server used
+// (`server/agent/mcp-tools/index.ts:2` static import). Without the
+// loader (or with a regression), Node's ESM resolver would fail on the
+// dangling `@mulmoclaude/*` junction — NODE_PATH does not help ESM.
+
+async function esmImportCheck(): Promise<void> {
+  try {
+    // Bare specifier is critical: this is the shape production code
+    // uses and the exact shape that fails without the loader.
+    const mod = await import("@mulmoclaude/x-plugin");
+    if (typeof mod !== "object" || mod === null) {
+      throw new Error(`ESM import returned non-object: ${typeof mod}`);
+    }
+  } catch (err) {
+    throw new Error(`ESM import failed — loader hook not effective. ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+try {
+  await esmImportCheck();
+  console.log("  ok    ESM import('@mulmoclaude/x-plugin') resolves via mcp-esm-loader");
+} catch (err) {
+  failures++;
+  const message = err instanceof Error ? err.message : String(err);
+  console.log(`  FAIL  ESM import('@mulmoclaude/x-plugin') resolves via mcp-esm-loader\n        ${message}`);
+}
 
 // ──────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `NODE_PATH` is **CJS-only** per Node's spec. PR #1974 / #1984 fixed the CJS path, but ESM static imports at `server/agent/mcp-tools/index.ts:2` (`import { readXPost, searchX } from \"@mulmoclaude/x-plugin\"`) had no equivalent fallback. On Windows the yarn workspace's `@mulmoclaude/*` NTFS junctions dangle inside the Linux container, so the ESM loader dies with `Cannot find module '@mulmoclaude/x-plugin'` — mulmoclaude MCP tools all disappear.
- Fix: new `server/agent/mcp-esm-loader.mjs` — an ESM resolver hook installed via `tsx --import` on the Docker MCP child only. When `@mulmoclaude/*` fails default resolution, read the corresponding `package.json` under `/app/pkg_modules/` and return the resolved entry URL. Supports exports-map / conditional-exports / legacy `main` / subpath imports.
- CI coverage: extended `test/sandbox-repro/probe.ts` with an ESM `import(\"@mulmoclaude/x-plugin\")` step (previously all probe checks were CJS-only, so this class of bug slipped through) + workflow bind-mounts the loader and launches tsx with `--import`.

## Items to Confirm / Review

- **影響範囲**: Docker sandbox モードのみ。Native (`DISABLE_SANDBOX`) は `--import` フラグを付けないので loader file を touch すらしない。Docker on Linux/macOS ではプライマリ解決が成功するので loader の catch は fire しない (no-op)。**唯一の実質的な効き先は Docker on Windows**。
- **後方互換**: `NODE_PATH` / `/app/pkg_modules` / `workspaceModuleMounts` の既存構造は温存。既存テスト (`test_agent_config.ts`, `test_workspace_module_fallback.ts`, `probe.ts` 既存 step) は無変更で通る。
- **エントリ解決の網羅性**: exports-map の主要な形 (string / `{ import }` / `{ import: { default } }` / `{ default }`) と legacy `main` + subpath (`@mulmoclaude/core/util/log`) をユニットテストで 12 ケース網羅。想定外の exports 構造があれば primary error を throw する (silent misresolve しない)。

## Related

- Root-cause report by ystknsh: [#1982 comment 4893209136](https://github.com/receptron/mulmoclaude/issues/1982#issuecomment-4893209136)
- Prior work: #1974 (NODE_PATH fallback), #1984 (`resolvePresetRoot` CJS rewrite)

## Test plan

- [x] `yarn test` — 5326 pass, 0 fail
- [x] `yarn build` — green
- [ ] Windows CI: `.github/workflows/docker_sandbox_windows.yaml` の probe が新しい ESM ステップまで含めて緑 → これが go/no-go
- [ ] 実機 (@ystknsh 確認できれば): MCP tool `handlePermission` エラーが再現しないこと

Closes #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Docker-based Windows/WSL2 sandbox support by introducing an ESM resolver fallback that activates during startup to improve module import reliability.
* **Bug Fixes**
  * Fixed the container startup flow so the sandbox probe can correctly register the resolver hook and resolve packages in the intended bind-mount layout.
* **Tests**
  * Added/expanded automated coverage for Docker vs non-Docker behavior and for resolver helper logic, plus an ESM import regression check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->