### PR TITLE
fix: allow file downloads from sandboxed collection views

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -35,7 +35,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.7.3",
+    "@mulmoclaude/collection-plugin": "^0.7.4",
     "@mulmoclaude/core": "^0.12.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
@@ -13,7 +13,9 @@
          (`<a target="_blank">` / `window.open`) as a normal new tab — e.g. a
          feed card linking to its article. Opening requires a user gesture and
          `target="_blank"` defaults to `noopener`, so the popup can't reach back
-         into the view; the token stays isolated. -->
+         into the view; the token stays isolated. `allow-downloads` lets a view
+         save files (e.g. an .ics iCalendar export) — without it the browser
+         silently blocks any download the frame initiates. -->
     <iframe
       v-else-if="srcdoc"
       ref="iframeEl"
@@ -21,7 +23,7 @@
       data-testid="collection-custom-view-iframe"
       :title="view.label"
       :srcdoc="srcdoc"
-      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads"
       class="w-full h-full border-0"
     />
   </div>

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
@@ -11,7 +11,9 @@
            origin — the view can't read the parent's storage; here there is no
            token to protect, but the phone renders under the same rules and the
            preview must match it exactly). `allow-popups*` lets outbound
-           `target="_blank"` links open as normal tabs. -->
+           `target="_blank"` links open as normal tabs. `allow-downloads` lets
+           a view save files (e.g. an .ics iCalendar export); the phone grants
+           it too, so the preview must match. -->
       <div class="phone-frame">
         <iframe
           ref="iframeEl"
@@ -19,7 +21,7 @@
           data-testid="collection-remote-view-iframe"
           :title="view.label"
           :srcdoc="srcdoc"
-          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads"
           class="phone-screen"
         />
       </div>


### PR DESCRIPTION
## Problem

Collection custom views run inside an **opaque-origin sandboxed iframe**. The sandbox lacked `allow-downloads`, so any download a view initiated (e.g. an iCalendar `.ics` export button) was silently blocked by the browser. This affects both host-side surfaces:

- `CollectionCustomView.vue` — the desktop custom-view iframe
- `CollectionRemoteViewPreview.vue` — the phone-frame preview

## Fix

Add `allow-downloads` to both iframe sandboxes. It permits saving files **without** granting `allow-same-origin`, so the opaque-origin posture (views can't read the parent's token/localStorage) is unchanged.

## Context

This is the desktop-side counterpart to receptron/mulmoserver#38, which added the same flag to the mobile client (`CollectionRemoteView.vue`) and was **verified working on iPhone Safari**. Without this change the "works in preview means works on the phone" invariant is broken — a view author testing an `.ics` button in the desktop preview would see it silently fail even though it works on the deployed mobile client.

Note: `@mulmoclaude/core` needs no change — it holds no `<iframe>` element (it only builds the `srcdoc` + CSP, and the CSP has no `sandbox` directive). The sandbox attribute is per-host, applied where the iframe is mounted.

## Testing

`yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow sandboxed collection custom view iframes to initiate file downloads while preserving opaque-origin isolation.

Bug Fixes:
- Enable file downloads (e.g. .ics exports) from desktop collection custom views that were previously blocked by the iframe sandbox.
- Align the collection remote view preview sandbox with the mobile client by permitting file downloads from the preview iframe.

Documentation:
- Clarify iframe sandbox behavior in collection view components, documenting that allow-downloads is required for file-saving flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled file downloads from sandboxed collection views and previews, including export actions initiated inside embedded views.
  * Updated embedded preview behavior to better match the phone experience for downloading/exporting files.
* **Chores**
  * Bumped the collection plugin package version to 0.7.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->