### PR TITLE
chore(lint): assert.doesNotThrow/Reject on no-throw tests (batch 1/3)

### DIFF
--- a/test/plugins/spreadsheet/test_cellHighlights.ts
+++ b/test/plugins/spreadsheet/test_cellHighlights.ts
@@ -75,7 +75,7 @@ describe("highlightCell", () => {
   });
 
   it("is a no-op for a null table", () => {
-    highlightCell(null, { row: 0, col: 0 }, "x");
+    assert.doesNotThrow(() => highlightCell(null, { row: 0, col: 0 }, "x"));
   });
 
   it("is a no-op when row is out of range", () => {
@@ -111,12 +111,12 @@ describe("clearCellHighlights", () => {
   });
 
   it("is a no-op when container is null", () => {
-    clearCellHighlights(null);
+    assert.doesNotThrow(() => clearCellHighlights(null));
   });
 
   it("is a no-op when there are no previous highlights", () => {
     const container = makeContainer({});
-    clearCellHighlights(container);
+    assert.doesNotThrow(() => clearCellHighlights(container));
   });
 });
 
@@ -135,12 +135,12 @@ describe("applyCellHighlights", () => {
   });
 
   it("no-op when container is null", () => {
-    applyCellHighlights(null, { row: 0, col: 0 }, []);
+    assert.doesNotThrow(() => applyCellHighlights(null, { row: 0, col: 0 }, []));
   });
 
   it("no-op when #spreadsheet-table is missing", () => {
     const container = makeContainer({});
-    applyCellHighlights(container, { row: 0, col: 0 }, []);
+    assert.doesNotThrow(() => applyCellHighlights(container, { row: 0, col: 0 }, []));
   });
 
   it("skips editing cell when null, still applies references", () => {

--- a/test/plugins/test_dev_watcher.ts
+++ b/test/plugins/test_dev_watcher.ts
@@ -295,6 +295,6 @@ describe("watchDevPlugins — close()", () => {
     const plugin = fakePlugin("@test/close-twice");
     const rig = makeRig(plugin, 30);
     rig.close();
-    rig.close(); // must not throw
+    assert.doesNotThrow(() => rig.close());
   });
 });

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -290,7 +290,7 @@ describe("makePluginRuntime — files.data and files.config", () => {
 
   it("files.unlink is a no-op when the file does not exist", async () => {
     const runtime = runtimeFor("@example/foo");
-    await runtime.files.data.unlink("missing.json"); // should not throw
+    await assert.doesNotReject(runtime.files.data.unlink("missing.json"));
   });
 
   it("files.readDir returns [] for a plugin that never wrote", async () => {

--- a/test/system/test_macosNotify.ts
+++ b/test/system/test_macosNotify.ts
@@ -108,14 +108,14 @@ describe("pushToMacosReminderWithDeps — failure handling", () => {
     const { spawner, throwError } = makeSpawner();
     const promise = pushToMacosReminderWithDeps({ spawner, platform: "darwin", disabled: false }, "Hello");
     throwError(new Error("ENOENT"));
-    await promise; // does not reject
+    await assert.doesNotReject(promise);
   });
 
   it("resolves silently on non-zero exit", async () => {
     const { spawner, respond } = makeSpawner();
     const promise = pushToMacosReminderWithDeps({ spawner, platform: "darwin", disabled: false }, "Hello");
     respond(1, "Reminders.app is not authorised");
-    await promise; // does not reject
+    await assert.doesNotReject(promise);
   });
 
   it("resolves silently when spawn itself throws synchronously", async () => {

--- a/test/utils/files/test_session_io.ts
+++ b/test/utils/files/test_session_io.ts
@@ -75,8 +75,7 @@ describe("updateHasUnread", () => {
   });
 
   it("no-ops when session meta does not exist", async () => {
-    // Should not throw
-    await updateHasUnread("ghost", false, root);
+    await assert.doesNotReject(updateHasUnread("ghost", false, root));
   });
 });
 

--- a/test/utils/files/test_session_origin.ts
+++ b/test/utils/files/test_session_origin.ts
@@ -63,7 +63,6 @@ describe("backfillOrigin", () => {
 
   it("no-ops on missing session", async () => {
     const root = tmpRoot();
-    await backfillOrigin("nonexistent", "bridge", root);
-    // should not throw
+    await assert.doesNotReject(backfillOrigin("nonexistent", "bridge", root));
   });
 });

--- a/test/utils/image/test_imageRepairInlineScript.ts
+++ b/test/utils/image/test_imageRepairInlineScript.ts
@@ -219,8 +219,7 @@ describe("repairImageErrorTarget — runtime behavior", () => {
   });
 
   it("returns no-op when target is null", () => {
-    // No throw, no error.
-    repairImageErrorTarget(null, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    assert.doesNotThrow(() => repairImageErrorTarget(null, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED));
   });
 
   it("rewrites a <source> element via getAttribute / setAttribute", () => {

--- a/test/utils/test_fetch.ts
+++ b/test/utils/test_fetch.ts
@@ -108,7 +108,7 @@ describe("fetchWithTimeout", () => {
     // the cleanup path and would surface a leak under --detectOpenHandles.
     globalThis.fetch = async () => new Response("ok");
     for (let i = 0; i < 50; i++) {
-      await fetchWithTimeout("http://example.test/", { timeoutMs: 5_000 });
+      await assert.doesNotReject(fetchWithTimeout("http://example.test/", { timeoutMs: 5_000 }));
     }
   });
 });

--- a/test/wiki-backlinks/test_index.ts
+++ b/test/wiki-backlinks/test_index.ts
@@ -32,12 +32,13 @@ describe("maybeAppendWikiBacklinks (driver)", () => {
   });
 
   it("no-op when wiki/pages/ does not exist", async () => {
-    await maybeAppendWikiBacklinks({
-      chatSessionId: SID,
-      turnStartedAt: Date.now(),
-      workspaceRoot,
-    });
-    // Should complete without throwing. No assertion beyond that.
+    await assert.doesNotReject(
+      maybeAppendWikiBacklinks({
+        chatSessionId: SID,
+        turnStartedAt: Date.now(),
+        workspaceRoot,
+      }),
+    );
   });
 
   it("appends backlink to a page modified during the turn", async () => {


### PR DESCRIPTION
## Summary

- Prep for flipping \`sonarjs/assertions-in-tests\` from \`warn\` → \`error\`.
- Batch 1/3 covers plain node:test suites — 14 warnings across 9 files. Each fix wraps the flagged \`no-op / no-throw\` test in \`assert.doesNotThrow(() => …)\` (sync) or \`assert.doesNotReject(…)\` (async) so the "must not throw" contract is explicit.
- **細かく split する目的**: 他の in-flight テスト編集との merge conflict を避けるため。
  - batch 2: e2e / Playwright specs（wiki-nav / router-navigation / present-mulmo-script / mock-server logger など）
  - batch 3: eslint config で当該ルールを warn → error に flip

## Items to Confirm / Review

- **意味変化なし**: 元の \`await someOp()\` は例外時に test を失敗させる暗黙の assertion。\`assert.doesNotReject(someOp())\` は明示化しただけで挙動は同じ（例外時 test 失敗、成功時 pass）。
- **batch の切り方**: ここは "server/utils/plugins 系の unit test だけ" というテーマ。e2e は Playwright の \`expect(...)\` 追加が必要で編集の形が違うので分離。

## User Prompt

> lint ruleをlocalでかえてある。unit testで直せるものは直してテストをこわさないように更新して。warnが対象ね
>
> sonarjs/assertions-in-tests を warn から error に変更できるようになったら変更してね
>
> こまかくマージしたい。コンフリクトさけるため

## Files (14 warnings resolved)

- test/plugins/spreadsheet/test_cellHighlights.ts (5)
- test/system/test_macosNotify.ts (2)
- test/plugins/test_dev_watcher.ts (1)
- test/plugins/test_plugin_runtime.ts (1)
- test/utils/test_fetch.ts (1)
- test/utils/files/test_session_io.ts (1)
- test/utils/files/test_session_origin.ts (1)
- test/utils/image/test_imageRepairInlineScript.ts (1)
- test/wiki-backlinks/test_index.ts (1)

## Test plan

- [x] \`npx tsx --test\` on all 9 touched files: 126 tests pass, 0 fail
- [ ] CI matrix
- [ ] batch 2 PR で e2e/Playwright specs 対応
- [ ] batch 3 PR で rule を error に flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make no-op tests explicitly assert that operations do not throw or reject to prepare enabling stricter linting for assertions in tests.

Bug Fixes:
- Ensure various async and sync no-op behaviors are covered by explicit does-not-throw/does-not-reject assertions instead of relying on implicit success.

Tests:
- Update unit tests across plugins, system, utils, and wiki-backlinks to wrap no-op or non-throwing operations in assert.doesNotThrow/assert.doesNotReject for clearer intent and lint compliance.