### PR TITLE
fix(chat): browser-decode HEIC for the pre-send preview chip

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "fast-xml-parser": "^5.9.3",
     "firebase": "12.15.0",
     "gui-chat-protocol": "0.4.0",
+    "heic2any": "^0.0.4",
     "highlight.js": "^11.11.1",
     "ignore": "^7.0.5",
     "js-yaml": "^5.2.1",

--- a/src/components/ChatAttachmentPreview.vue
+++ b/src/components/ChatAttachmentPreview.vue
@@ -43,7 +43,11 @@ const removeLabel = computed(() => t("chatInput.removeAttachment", { name: props
 // MIMEs Chrome renders directly in an `<img>` tag. HEIC / HEIF and
 // TIFF are absent — those either arrive with a `previewDataUrl`
 // filled in upstream or fall back to the file-icon chip.
-const BROWSER_RENDERABLE_IMAGE_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml", "image/avif", "image/bmp"]);
+// `image/jpg` is a common non-standard alias the browser's file
+// picker occasionally emits alongside `image/jpeg` — kept in the
+// set so a `.jpg` pick doesn't regress to the file-icon chip
+// (codex review on #2000).
+const BROWSER_RENDERABLE_IMAGE_MIMES = new Set(["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp", "image/svg+xml", "image/avif", "image/bmp"]);
 
 const imageSrc = computed(() => {
   if (props.previewDataUrl) return props.previewDataUrl;

--- a/src/components/ChatAttachmentPreview.vue
+++ b/src/components/ChatAttachmentPreview.vue
@@ -1,6 +1,6 @@
 <template>
   <div data-testid="chat-attachment-preview" class="relative inline-flex items-center gap-2 border border-gray-300 rounded overflow-hidden px-2 py-1">
-    <img v-if="isImage" :src="dataUrl" alt="Attached image" class="max-h-20 max-w-40 object-contain" />
+    <img v-if="imageSrc" :src="imageSrc" alt="Attached image" class="max-h-20 max-w-40 object-contain" />
     <div v-else class="flex items-center gap-1.5 text-xs text-gray-700">
       <span class="material-icons text-base" :class="iconColor">{{ icon }}</span>
       <span class="max-w-40 truncate">{{ filename || t("chatInput.attachmentFallbackName") }}</span>
@@ -24,7 +24,15 @@ import { useI18n } from "vue-i18n";
 const { t } = useI18n();
 
 const props = defineProps<{
+  /** Original file bytes as a data URL. Passed straight to the
+   *  upload pipeline. Also used as the `<img>` source when the
+   *  browser can render `mime` natively. */
   dataUrl: string;
+  /** Browser-decoded JPEG data URL for MIMEs Chrome can't render
+   *  (HEIC / HEIF). Populated by `ChatInput`'s pick pipeline when
+   *  needed. If left undefined for an unrenderable MIME the chip
+   *  drops back to the file-icon variant. */
+  previewDataUrl?: string;
   filename: string;
   mime: string;
 }>();
@@ -32,7 +40,16 @@ const emit = defineEmits<{ remove: [] }>();
 
 const removeLabel = computed(() => t("chatInput.removeAttachment", { name: props.filename || t("chatInput.attachmentFallbackName") }));
 
-const isImage = computed(() => props.mime.startsWith("image/"));
+// MIMEs Chrome renders directly in an `<img>` tag. HEIC / HEIF and
+// TIFF are absent — those either arrive with a `previewDataUrl`
+// filled in upstream or fall back to the file-icon chip.
+const BROWSER_RENDERABLE_IMAGE_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml", "image/avif", "image/bmp"]);
+
+const imageSrc = computed(() => {
+  if (props.previewDataUrl) return props.previewDataUrl;
+  if (BROWSER_RENDERABLE_IMAGE_MIMES.has(props.mime)) return props.dataUrl;
+  return "";
+});
 
 const icon = computed(() => {
   if (props.mime === "application/pdf") return "picture_as_pdf";

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -28,6 +28,7 @@
           v-for="(file, index) in pastedFiles"
           :key="file.name + index"
           :data-url="file.dataUrl"
+          :preview-data-url="file.previewDataUrl"
           :filename="file.name"
           :mime="file.mime"
           @remove="removeFileAt(index)"
@@ -131,6 +132,7 @@ import { useImeAwareEnter } from "../composables/useImeAwareEnter";
 import { useSkillsList, type SkillSummary } from "../composables/useSkillsList";
 import { useSlashCommandMenu, handleSlashMenuKeydown } from "../composables/useSlashCommandMenu";
 import type { PastedFile } from "../types/pastedFile";
+import { buildHeicPreviewDataUrl, needsBrowserPreviewConversion } from "../utils/attachment/heicPreview";
 
 export type { PastedFile };
 
@@ -324,10 +326,21 @@ async function processFiles(files: File[]): Promise<void> {
     return;
   }
 
-  const pending = accepted.map(async (file) => {
+  const pending = accepted.map(async (file): Promise<PastedFile | null> => {
     const dataUrl = await readFileAsDataUrl(file);
     if (!dataUrl) return null;
-    return { dataUrl, name: file.name, mime: file.type } satisfies PastedFile;
+    // Browser-side HEIC/HEIF conversion only affects the preview
+    // chip's <img src>. The original `dataUrl` still travels to the
+    // upload endpoint unchanged — server-side heic-convert produces
+    // the JPEG the LLM reads. Failed conversion → previewDataUrl
+    // stays absent and the chip falls back to a file icon.
+    const preview = needsBrowserPreviewConversion(file.type) ? await buildHeicPreviewDataUrl(file) : null;
+    return {
+      dataUrl,
+      name: file.name,
+      mime: file.type,
+      ...(preview ? { previewDataUrl: preview } : {}),
+    };
   });
 
   try {

--- a/src/types/pastedFile.ts
+++ b/src/types/pastedFile.ts
@@ -4,7 +4,17 @@
 // test tsconfig, which sees `*.vue` only as the ambient shim.
 
 export interface PastedFile {
+  /** Base64 `data:` URL of the ORIGINAL file bytes, used verbatim by
+   *  the upload pipeline. Never mutated after pick — the server-side
+   *  conversion (HEIC → JPEG, PPTX → PDF, …) works off these bytes. */
   dataUrl: string;
   name: string;
   mime: string;
+  /** Browser-decoded JPEG data URL used ONLY for the pre-send
+   *  `<img>` preview when the browser can't render `mime` natively
+   *  (Chrome refuses HEIC / HEIF). Undefined when either the browser
+   *  can render `mime` directly or when the conversion failed — the
+   *  preview component falls back to a file-icon chip in that case.
+   *  The upload pipeline never reads this field. */
+  previewDataUrl?: string;
 }

--- a/src/utils/attachment/heicPreview.ts
+++ b/src/utils/attachment/heicPreview.ts
@@ -16,12 +16,18 @@
 // leaves `previewDataUrl` unset and the preview component drops
 // back to a file-icon chip.
 
-const HEIF_LIKE_MIMES: ReadonlySet<string> = new Set(["image/heic", "image/heif"]);
+// `image/heic-sequence` / `image/heif-sequence` are the multi-frame
+// container MIMEs iOS emits for burst mode and Live Photos. Codex
+// review on #2000: without these, a Live Photo would silently miss
+// the preview conversion and land in the file-icon fallback.
+const HEIF_LIKE_MIMES: ReadonlySet<string> = new Set(["image/heic", "image/heif", "image/heic-sequence", "image/heif-sequence"]);
 
 /** True when the given MIME identifies a HEIC / HEIF variant Chrome
- *  can't render natively. Kept narrow — TIFF / BMP are technically
- *  in-band for the server-side conversion path but Chrome renders
- *  BMP natively today and heic2any doesn't decode TIFF at all. */
+ *  can't render natively (including the `-sequence` container
+ *  variants for Live Photos / burst mode). Kept narrow — TIFF / BMP
+ *  are technically in-band for the server-side conversion path but
+ *  Chrome renders BMP natively today and heic2any doesn't decode
+ *  TIFF at all. */
 export function needsBrowserPreviewConversion(mime: string): boolean {
   return HEIF_LIKE_MIMES.has(mime);
 }

--- a/src/utils/attachment/heicPreview.ts
+++ b/src/utils/attachment/heicPreview.ts
@@ -1,0 +1,59 @@
+// Browser-side HEIC / HEIF → JPEG conversion for the pre-send
+// attachment preview (`ChatAttachmentPreview.vue`). Chrome refuses
+// to render `image/heic` / `image/heif` in `<img>`, so a user who
+// pastes / drops an iPhone photo sees a broken-image icon before
+// they send the message.
+//
+// The server-side upload path is deliberately NOT touched — the
+// original HEIC bytes still travel to `/api/attachments` verbatim,
+// where a Node-side heic-convert / sharp roundtrip produces the
+// JPEG the LLM reads. This module runs entirely in-browser and only
+// affects what the user sees in the preview chip.
+//
+// `heic2any` bundles WASM libheif (~1.5 MB). We dynamic-import it
+// on first use so users who never paste HEIC don't pay the
+// download / parse cost. Failures are swallowed — the caller then
+// leaves `previewDataUrl` unset and the preview component drops
+// back to a file-icon chip.
+
+const HEIF_LIKE_MIMES: ReadonlySet<string> = new Set(["image/heic", "image/heif"]);
+
+/** True when the given MIME identifies a HEIC / HEIF variant Chrome
+ *  can't render natively. Kept narrow — TIFF / BMP are technically
+ *  in-band for the server-side conversion path but Chrome renders
+ *  BMP natively today and heic2any doesn't decode TIFF at all. */
+export function needsBrowserPreviewConversion(mime: string): boolean {
+  return HEIF_LIKE_MIMES.has(mime);
+}
+
+async function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => (typeof reader.result === "string" ? resolve(reader.result) : reject(new Error("FileReader returned non-string")));
+    reader.onerror = () => reject(new Error("FileReader failed"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+/** Decode a HEIC / HEIF File into a JPEG data URL suitable for
+ *  `<img :src>`. Returns null on any decode failure (unsupported
+ *  variant, malformed bytes, WASM load failure) — the caller uses
+ *  this to leave the preview chip in the file-icon state instead
+ *  of a broken image. */
+export async function buildHeicPreviewDataUrl(file: File): Promise<string | null> {
+  try {
+    // heic2any's default export is a function; dynamic import keeps
+    // the ~1.5 MB WASM libheif bundle out of the app's initial
+    // payload for users who never paste HEIC.
+    const heic2any = (await import("heic2any")).default;
+    const converted = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
+    // heic2any returns `Blob | Blob[]` — a multi-frame HEIC / HEIF
+    // (burst mode, live photo) returns an array. Take the first
+    // frame for the preview; the full sequence still ships as-is to
+    // the upload endpoint via the untouched `dataUrl`.
+    const jpegBlob = Array.isArray(converted) ? converted[0] : converted;
+    return await blobToDataUrl(jpegBlob);
+  } catch {
+    return null;
+  }
+}

--- a/test/utils/attachment/test_heicPreview.ts
+++ b/test/utils/attachment/test_heicPreview.ts
@@ -1,0 +1,36 @@
+// Unit test for the browser-side HEIC preview helper. The
+// heic2any WASM path can't run under node:test, so we don't
+// exercise the actual conversion here — instead we pin the
+// pure `needsBrowserPreviewConversion` predicate that decides
+// whether the browser needs to convert at all. That predicate
+// is the sole gate between "cheap default" (Chrome renders it)
+// and "pay the 1.5 MB WASM bundle" (HEIC / HEIF).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { needsBrowserPreviewConversion } from "../../../src/utils/attachment/heicPreview";
+
+describe("needsBrowserPreviewConversion", () => {
+  it("returns true for HEIC / HEIF", () => {
+    assert.equal(needsBrowserPreviewConversion("image/heic"), true);
+    assert.equal(needsBrowserPreviewConversion("image/heif"), true);
+  });
+
+  it("returns false for MIMEs Chrome renders natively", () => {
+    for (const mime of ["image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml", "image/avif", "image/bmp"]) {
+      assert.equal(needsBrowserPreviewConversion(mime), false, `${mime} is browser-renderable`);
+    }
+  });
+
+  it("returns false for non-image MIMEs (never reaches the preview img tag)", () => {
+    for (const mime of ["application/pdf", "text/plain", "application/json", ""]) {
+      assert.equal(needsBrowserPreviewConversion(mime), false, `${mime} — no img rendering path`);
+    }
+  });
+
+  it("returns false for TIFF (heic2any doesn't decode TIFF; falls back to file-icon chip)", () => {
+    // Explicit pin: the helper is HEIC/HEIF-only. TIFF preview
+    // support would need a different decoder — out of scope.
+    assert.equal(needsBrowserPreviewConversion("image/tiff"), false);
+  });
+});

--- a/test/utils/attachment/test_heicPreview.ts
+++ b/test/utils/attachment/test_heicPreview.ts
@@ -11,9 +11,14 @@ import assert from "node:assert/strict";
 import { needsBrowserPreviewConversion } from "../../../src/utils/attachment/heicPreview";
 
 describe("needsBrowserPreviewConversion", () => {
-  it("returns true for HEIC / HEIF", () => {
+  it("returns true for HEIC / HEIF (still + sequence)", () => {
     assert.equal(needsBrowserPreviewConversion("image/heic"), true);
     assert.equal(needsBrowserPreviewConversion("image/heif"), true);
+    // Sequence containers — iOS Live Photos / burst mode. Codex on
+    // #2000: without these, a Live Photo silently dropped to the
+    // file-icon fallback.
+    assert.equal(needsBrowserPreviewConversion("image/heic-sequence"), true);
+    assert.equal(needsBrowserPreviewConversion("image/heif-sequence"), true);
   });
 
   it("returns false for MIMEs Chrome renders natively", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6173,6 +6173,11 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+heic2any@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/heic2any/-/heic2any-0.0.4.tgz#eddb8e6fec53c8583a6e18b65069bb5e8d19028a"
+  integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
+
 highlight.js@^11.11.1:
   version "11.11.1"
   resolved "https://npm.flatt.tech/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"


### PR DESCRIPTION
## Summary

Chrome refuses to render \`image/heic\` / \`image/heif\` in an \`<img>\` tag. After #1998 the LLM-visible path is fine (server returns a JPEG companion), but the pre-send preview chip in \`ChatInput\` was still handed the raw HEIC data URL and showed a broken image icon.

Add \`heic2any\` (WASM libheif, browser-side) and a small \`buildHeicPreviewDataUrl(file)\` helper. On file pick, HEIC / HEIF files get browser-decoded to a JPEG data URL that lives on \`PastedFile.previewDataUrl\`, which the preview chip prefers over the original \`dataUrl\`. The upload path is **unchanged** — HEIC bytes still travel verbatim to the server per the user's requirement.

## Items to Confirm / Review

- **Upload path untouched.** \`PastedFile.dataUrl\` and \`pastedAttachment.ts\` (the code that POSTs to \`/api/attachments\`) both read the ORIGINAL HEIC bytes. \`previewDataUrl\` is preview-only; the upload pipeline never reads it. The user explicitly asked for this contract ("uploadするファイルは変更しないでね").
- **Lazy load.** \`heic2any\` is dynamic-imported on first HEIC pick. Its WASM bundle is ~1.5 MB and would inflate initial load for everyone otherwise. Users who never paste HEIC pay nothing.
- **Preview MIME set is narrower than the server's.** Server-side converts HEIC / HEIF / TIFF / BMP / AVIF. Browser preview converts only HEIC / HEIF because heic2any doesn't decode TIFF, and Chrome renders BMP / AVIF natively today. TIFF preview would need a different decoder — noted in the plan as out of scope; the chip drops to a file-icon for TIFF, which is acceptable.
- **Multi-frame HEIC** (burst mode / Live Photo) — heic2any returns an array. Preview takes the first frame; the full sequence still ships to the upload endpoint via the untouched \`dataUrl\`.
- **Failure UX.** A corrupt HEIC / a variant heic2any can't decode → \`buildHeicPreviewDataUrl\` returns null, \`previewDataUrl\` stays absent, chip shows the file-icon variant instead of a broken image. The upload still proceeds; the server-side conversion in #1998 is the real safety net.
- **This PR is independent of #1998.** #1998 fixes the LLM-visible path (server-side, upload endpoint). This PR fixes the browser-visible path (pre-send preview). They complement each other but neither depends on the other landing first — if only one is merged, the other half of the HEIC UX still improves. Recommend merging #1998 first since its user-visible impact is bigger (the chat turn actually completing), but the order can go either way.

## User prompts (JP, consolidated)

> つぎ。heicをwebでattachしてpreviewしたときに表示できない。chromeね。ブラウザで変換して表示して。uploadするファイルは変更しないでね

## Implementation

- \`src/types/pastedFile.ts\`: extend \`PastedFile\` with optional \`previewDataUrl?: string\`, documented as preview-only.
- \`src/utils/attachment/heicPreview.ts\`: new module with \`needsBrowserPreviewConversion(mime)\` predicate + \`buildHeicPreviewDataUrl(file)\` dynamic-import-and-decode helper. Failures return null.
- \`src/components/ChatInput.vue\` \`processFiles()\`: for HEIC / HEIF picks, run \`buildHeicPreviewDataUrl\` and stash on the \`PastedFile\`. All existing MIME handling untouched.
- \`src/components/ChatAttachmentPreview.vue\`: prefer \`previewDataUrl\`, fall back to \`dataUrl\` for MIMEs Chrome renders natively (JPEG / PNG / GIF / WebP / SVG / AVIF / BMP), otherwise the file-icon chip.
- \`test/utils/attachment/test_heicPreview.ts\`: pin the predicate that decides whether we pay the WASM bundle at all. The actual conversion path can't run under node:test — verified end-to-end via manual dev-server pick.

## Verification

- \`yarn format\`, \`yarn lint\`, \`yarn typecheck\`, \`yarn build\`, \`yarn test\` — all clean.
- Manual: attach the same HEIC that surfaced this issue in the ChatInput. Preview chip shows a legible JPEG rather than a broken image icon. Send the message — server log still shows \`upload: start mimeType=image/heic\` (upload path unaffected) and \`conversion=image/heic-to-jpeg\` (once #1998 is merged).

## Test plan

- [ ] Pick / drop / paste an HEIC in ChatInput — chip shows a real thumbnail (not broken image).
- [ ] Pick a JPEG / PNG / WebP — chip still shows the native browser render (no regression, no WASM load).
- [ ] Pick a corrupted HEIC — chip falls back to the file-icon variant, no console throw, upload still succeeds.
- [ ] Pick a multi-frame HEIC / Live Photo — preview shows the first frame.
- [ ] Confirm the network tab: uploaded bytes match the original HEIC (not the JPEG preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)