### PR TITLE
fix(collections): enforce the same write-time validation on REST as on the agent path

### DIFF
--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -32,6 +32,7 @@ import {
   toDetail,
   toSummary,
   validateCollectionRecords,
+  validateRecordObject,
   writeItem,
 } from "../../workspace/collections/index.js";
 import type {
@@ -208,6 +209,15 @@ router.post(API_ROUTES.collections.items, async (req: Request<{ slug: string }>,
   // generated id (Codex P1 on #1510).
   const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
+  // Same write-time gate as the agent path (manageCollection putItems)
+  // — REST and MCP must enforce identical rules or "neither path is
+  // privileged" silently breaks (agent writes were validated, direct
+  // API/custom-view writes were not).
+  const invalid = validateRecordObject(recordWithId, itemId, collection.schema);
+  if (invalid) {
+    badRequest(res, `record rejected: ${invalid}`);
+    return;
+  }
   try {
     const result = await writeItem(collection.dataDir, itemId, recordWithId, { refuseOverwrite: true, slug: collection.slug });
     if (result.kind === "invalid-id") {
@@ -252,6 +262,14 @@ router.put(API_ROUTES.collections.item, async (req: Request<{ slug: string; item
   // mismatched primary-key value in the body so the file's id and its
   // record id never drift.
   const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
+  // Mirror of the create-path gate above (and of manageCollection's
+  // putItems) — updates must not be able to strip required fields or
+  // set out-of-enum values that a create would have rejected.
+  const invalidUpdate = validateRecordObject(recordWithId, req.params.itemId, collection.schema);
+  if (invalidUpdate) {
+    badRequest(res, `record rejected: ${invalidUpdate}`);
+    return;
+  }
   try {
     const result = await writeItem(collection.dataDir, req.params.itemId, recordWithId, { slug: collection.slug });
     if (result.kind === "invalid-id") {


### PR DESCRIPTION
## Problem

`manageCollection putItems` (the agent write path) gates every write on `validateRecordObject`, but the REST create/update routes (`POST/PUT /api/collections/:slug/items`) write records with only id / path-containment / overwrite checks. Direct API calls and custom views can store records the agent path would have rejected — missing required fields, out-of-enum values.

This breaks the "neither path is privileged" symmetry in the stricter-agent direction: the same record is rejected via MCP but accepted via REST, and the invalid record then surfaces only as a read-time `issues` entry.

## Fix

POST and PUT now run the identical `validateRecordObject` gate before `writeItem`, rejecting with the same LLM/user-readable message shape the agent path uses.

## Verification

Live-tested against a `todos` collection:

| Request | Result |
|---|---|
| POST missing required `text` | `400 {"error":"record rejected: missing required field 'text'"}` |
| POST `status: "invalid-status"` | `400 {"error":"record rejected: 'status' = 'invalid-status' is not one of [todo, doing, done]"}` |
| POST valid record | `200` created |

`yarn typecheck:server` green; all 303 collection tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for collection item create and update requests before saving.
  * Invalid records now return a clear `400 Bad Request` response with a rejection message instead of reaching the save step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->