### PR TITLE
feat(form-plugin): append machine-readable JSON answers block to form submissions

### DIFF
--- a/packages/plugins/form-plugin/src/core/plugin.ts
+++ b/packages/plugins/form-plugin/src/core/plugin.ts
@@ -77,7 +77,11 @@ export const executeForm = async (_context: ToolContext, args: FormArgs): Promis
       data: formData,
       jsonData: formData,
       instructions:
-        "The form has been presented to the user. Wait for the user to fill out and submit it. They will reply with a markdown bullet list of `- {label}: {value}` lines.",
+        "The form has been presented to the user. Wait for the user to fill out and submit it. " +
+        'Their reply ends with a fenced json block: {"formAnswers": {"<fieldId>": <value>, ...}} — ' +
+        "keyed by the field ids you defined; radio/dropdown/checkbox values are the choice's canonical value; " +
+        "unanswered fields are null. Treat that JSON block as the authoritative structured response. " +
+        "The `- {label}: {value}` bullet list above it is display-only for the human transcript.",
     };
   } catch (error) {
     return {

--- a/packages/plugins/form-plugin/src/vue/View.vue
+++ b/packages/plugins/form-plugin/src/vue/View.vue
@@ -611,8 +611,56 @@ function handleSubmit(): void {
     lines.push(`- ${singleLine(field.label)}: ${renderValue(field, formValues.value[field.id])}`);
   });
 
+  // Machine-readable channel: answers keyed by stable field id, typed
+  // values, choices resolved to their canonical `value`. The bullet list
+  // above stays for the human transcript; the JSON block is what the
+  // agent parses — no free-text re-extraction (see plugin.ts
+  // instructions, which point the LLM at this block).
+  const answers: Record<string, StructuredAnswer> = {};
+  formData.value?.fields.forEach((field) => {
+    answers[field.id] = structuredAnswer(field, formValues.value[field.id]);
+  });
+  lines.push("", safeJsonFence(JSON.stringify({ formAnswers: answers }, null, 2)));
+
   submitted.value = true;
   props.sendTextMessage(lines.join("\n"));
+}
+
+type StructuredAnswer = string | number | string[] | null;
+
+// Typed answer for the JSON channel. Radio/dropdown/checkbox resolve to
+// the choice's canonical `value` (falling back to its label for plain
+// string choices) so the agent can match answers against the choices it
+// authored without positional index bookkeeping. Unanswered = null.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function structuredAnswer(field: FormField, value: any): StructuredAnswer {
+  if (field.type === "radio" || field.type === "dropdown") {
+    return typeof value === "number" && field.choices[value] !== undefined ? getChoiceValue(field.choices[value]) : null;
+  }
+  if (field.type === "checkbox") {
+    const indices: number[] = Array.isArray(value) ? value : [];
+    return indices.filter((idx) => field.choices[idx] !== undefined).map((idx) => getChoiceValue(field.choices[idx]));
+  }
+  if (field.type === "number") {
+    if (value === null || value === undefined || value === "") return null;
+    const num = typeof value === "number" ? value : Number(value);
+    return Number.isFinite(num) ? num : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+// Fence the JSON with one more backtick than the longest run inside the
+// payload, so free-text answers containing ``` can't break out of the
+// code block and smuggle markdown (or instructions) into the message.
+function safeJsonFence(json: string): string {
+  const longestRun = json.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}json\n${json}\n${fence}`;
 }
 
 // Indent so multi-line text/textarea values stay attached to their bullet


### PR DESCRIPTION
## Problem

A submitted form currently reaches the agent as a markdown bullet list of `- {label}: {value}` lines, so the agent must re-extract fields from free text. That re-parse is ambiguous when values contain colons or newlines, when labels collide, and it cannot distinguish "unanswered" from "empty string" — the structured data the user typed into a structured control is flattened to prose and probabilistically re-parsed.

## Fix

The submission message now appends a fenced json block after the human-readable list:

```json
{"formAnswers": {"<fieldId>": <value>, ...}}
```

- keyed by the stable field ids the agent defined in `presentForm`
- radio/dropdown/checkbox values resolve to the choice's canonical `value` (label for plain string choices) — no positional-index bookkeeping
- unanswered fields are `null`, distinguishable from `""`
- the fence uses one more backtick than the longest backtick run inside the payload, so free-text answers cannot break out of the code block
- `executeForm`'s instructions now point the LLM at the JSON block as the authoritative response; the bullet list stays display-only for the human transcript

## Verification

`@mulmoclaude/form-plugin` typecheck (vue-tsc) and build green. The bullet list is unchanged, so existing transcripts/UI rendering are unaffected — the JSON block is purely additive.