### PR TITLE
chore(lint): promote sonarjs/assertions-in-tests warn → error (batch 3/3)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -298,13 +298,13 @@ export default [
       // via PATH is normal operation, not a server-side injection risk.
       "sonarjs/no-os-command-from-path": "off",
       "sonarjs/cors": "off",
-      // Many of our `node:test` cases drive an observed side-effect
-      // (no throw / no log / DOM mutation watched elsewhere) and
-      // intentionally have no inline assert. The rule has no per-case
-      // opt-out, so blocking CI on each one creates churn without
-      // catching real "did we forget the assert?" bugs. Demoted to
-      // warn so reviewers still see it on new tests.
-      "sonarjs/assertions-in-tests": "warn",
+      // Every no-throw / side-effect-only test has been rewritten to
+      // wrap its target call in `assert.doesNotThrow(...)` /
+      // `assert.doesNotReject(...)` (batches #1999 + #2001), so the
+      // rule no longer creates churn. Promoted to `error` so a new
+      // assertion-less test can't slip in unnoticed — reviewers
+      // caught them by eye before, CI enforces it now.
+      "sonarjs/assertions-in-tests": "error",
       // ── eslint-plugin-security tuning ──────────────────────────
       // Three high-volume rules are disabled because they fire on
       // patterns that are normal in this codebase, drowning the


### PR DESCRIPTION
## Summary

- Final step of the \`sonarjs/assertions-in-tests\` cleanup — flips the rule from \`warn\` to \`error\`.
- Depends on **#1999** (batch 1) and **#2001** (batch 2), both ✅ merged.
- After this PR merges, a new assertion-less test can't slip in unnoticed — CI blocks it.

## Verification

- \`yarn lint\` on main → **0 occurrences** of \`sonarjs/assertions-in-tests\`
- \`yarn lint\` on this branch → **0 errors** on that rule
- \`yarn typecheck\` → 0 errors

## Diff

Single line + comment update in \`eslint.config.mjs\`. The nearby local \`max-lines-per-function\` edit (50 → 40) is deliberately NOT included — that's a separate policy choice belonging to its own PR.

## Series recap

- #1995: ESM loader hook for Windows Docker sandbox (unrelated fix that merged around the same time)
- #1999: batch 1/3 — 14 no-throw tests in server/utils/plugins suites → \`assert.doesNotThrow / doesNotReject\`
- #2001: batch 2/3 — 12 Playwright + node:test cases (with a real \`deleteProjectSkill\` user-scope refusal test as a bonus, addressing Codex's boundary-coverage concern)
- **#2002** (this PR): flip the rule to error

## User Prompt

> lint ruleをlocalでかえてある。unit testで直せるものは直してテストをこわさないように更新して。warnが対象ね
> sonarjs/assertions-in-tests を warn から error に変更できるようになったら変更してね
> こまかくマージしたい。コンフリクトさけるため

## Test plan

- [x] main の \`yarn lint | grep sonarjs/assertions-in-tests\` → 0 hits
- [x] branch \`yarn lint\` → 0 errors on rule
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update ESLint configuration to treat sonarjs/assertions-in-tests violations as errors instead of warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened test linting so assertion-less tests are now treated as errors in CI.
  * Updated the test assertion guidance to match the current testing style and avoid unnecessary warning noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->