### PR TITLE
chore(mulmoclaude): bump launcher to 0.9.5 (published)

### DIFF
--- a/.claude/skills/publish-mulmoclaude/SKILL.md
+++ b/.claude/skills/publish-mulmoclaude/SKILL.md
@@ -136,7 +136,20 @@ Expected: **`✓ MulmoClaude is ready` banner + `HTTP 200`**. Any ERR_MODULE_NOT
 
 ### 5. Test-only version rule
 
-When iterating (known-broken 0.1.0 → fixed 0.1.1), keep the published version on a throwaway `0.1.x` line and **don't commit the bumps** until a real test-passed version is confirmed. The `console.log("mulmoclaude X.Y.Z")` string inside `bin/mulmoclaude.js` must match the `package.json` version — update both together (both uncommitted while iterating).
+When iterating (known-broken 0.1.0 → fixed 0.1.1), keep the published version on a throwaway `0.1.x` line and **don't commit the bumps** until a real test-passed version is confirmed. The `console.log("mulmoclaude X.Y.Z")` string inside `bin/mulmoclaude.js` must match the `package.json` version — update both together (both uncommitted while iterating). Recent versions read `version` dynamically from `package.json`, so only `package.json` needs the bump — confirm with `grep "mulmoclaude \${version}" packages/mulmoclaude/bin/mulmoclaude.js` before touching bin.
+
+### 5.5. Sync the ROOT `package.json` version
+
+The launcher's `packages/mulmoclaude/package.json` version is the identity that ships to npm. But the ROOT `package.json` is the identity `/release-app` tags — and they MUST stay in lockstep so a v0.9.5 GitHub Release always corresponds to `mulmoclaude@0.9.5` on npm (no "which one am I running?" ambiguity).
+
+`/publish-mulmoclaude` bumps ROOT to the same version as the launcher, in the same commit. `/release-app` then just reads root, tags it, and writes CHANGELOG — it does NOT bump root again.
+
+```bash
+# Same X.Y.Z as the launcher bump in §5.
+node -e "const fs=require('fs');const p='package.json';const d=JSON.parse(fs.readFileSync(p,'utf8'));d.version='<X.Y.Z>';fs.writeFileSync(p, JSON.stringify(d,null,2)+'\n');"
+jq -r .version package.json   # → <X.Y.Z>
+jq -r .version packages/mulmoclaude/package.json   # must match
+```
 
 ### 6. Publish
 
@@ -144,12 +157,28 @@ When iterating (known-broken 0.1.0 → fixed 0.1.1), keep the published version 
 cd packages/mulmoclaude && npm publish --access public --registry https://registry.npmjs.org/
 ```
 
-Verify:
+Verify. The verify's `npx` step needs `--registry=https://registry.npmjs.org/` explicitly — the local environment's default registry is a private mirror that lags the public npm registry by a few minutes after a fresh publish, so the plain `npx --yes mulmoclaude@X.Y.Z` fails with `ETARGET / No matching version found` even when npm.org already has it:
 
 ```bash
-npm view mulmoclaude version
+npm view mulmoclaude version --registry https://registry.npmjs.org/
 rm -rf /tmp/npx-fresh && mkdir /tmp/npx-fresh && cd /tmp/npx-fresh
-npx --yes mulmoclaude@<X.Y.Z> --version
+npx --yes --registry=https://registry.npmjs.org/ mulmoclaude@<X.Y.Z> --version
+```
+
+`/publish-mulmoclaude`'s §2 drift check only covers `@mulmobridge/*` scope — `@mulmoclaude/*` workspace packages (core + plugins under `packages/plugins/*`) are NOT audited. Before publishing the launcher, manually verify every `@mulmoclaude/<name>` in `packages/mulmoclaude/package.json`'s `dependencies` resolves on the public registry:
+
+```bash
+# Local vs npm — a mismatch means a prior chore(release) bumped local
+# without publishing. Publish the missing one from packages/<pkg-dir>
+# BEFORE republishing the launcher, or `npx mulmoclaude@X.Y.Z` fails
+# with ETARGET on the first install.
+for pkg in $(jq -r '.dependencies | keys[] | select(startswith("@mulmoclaude/"))' packages/mulmoclaude/package.json); do
+  dir=$(echo "$pkg" | sed 's|@mulmoclaude/|packages/plugins/|; s|^packages/plugins/core$|packages/core|')
+  local=$(jq -r .version "$dir/package.json" 2>/dev/null)
+  npmv=$(npm view "$pkg" version --registry https://registry.npmjs.org/ 2>/dev/null)
+  marker=" "; [ "$local" != "$npmv" ] && marker="⚠"
+  echo " $marker $pkg local=$local npm=$npmv"
+done
 ```
 
 ### 7. Tag + GitHub release (only for @mulmobridge/* packages that were cascade-bumped)
@@ -180,13 +209,14 @@ EOF
 
 ### 8. Commit + PR
 
-Commit the real (non-test) version bumps + dep additions, push to a feature branch, open a PR. Never push directly to main.
+Commit the real (non-test) version bumps + dep additions, push to a feature branch, open a PR. Never push directly to main. **The root `package.json` bump from §5.5 MUST be part of this commit** so `/release-app` reads the correct version straight away.
 
 ```bash
-git add packages/protocol/package.json packages/chat-service/package.json \
+git add package.json \
+        packages/protocol/package.json packages/chat-service/package.json \
         packages/mulmoclaude/package.json packages/mulmoclaude/bin/mulmoclaude.js \
         yarn.lock
-git commit -m "fix(mulmoclaude): <what>"
+git commit -m "chore(mulmoclaude): bump launcher + root to X.Y.Z"
 git push -u origin <branch>
 gh pr create --title "..." --body "..."
 ```
@@ -201,3 +231,5 @@ gh pr create --title "..." --body "..."
 - `npm pack` in npm 10+ no longer fires `prepublishOnly` — a §4 tarball smoke with the old hook would ship a 4-file stub (just `bin/*`). The package now uses `prepack`, which fires on both `npm pack` and `npm publish`. Caught by the smoke workflow's first real CI run.
 - Dynamic `import("pkg")` with try/catch is a legit pattern for optional native modules (`node-pty`). The audit flags it anyway; declare the package in `optionalDependencies` to signal intent.
 - The launcher's pre-flight refuses to start if `claude --version` fails AND if `~/.claude/*` are absent. CI uses a `claude` stub on PATH + `DISABLE_SANDBOX=1` to bypass both; the smoke only needs the server to serve `/`, no real agent calls.
+- `mulmoclaude@0.9.5` failed the §6 `npx` verify with `ETARGET: @mulmoclaude/collection-plugin@^0.7.4` — a prior `chore(release)` had bumped `packages/plugins/collection-plugin/package.json` to 0.7.4 without publishing. The §2 drift check only audits `@mulmobridge/*`, so `@mulmoclaude/*` slipped through. §6 now includes a manual loop over every `@mulmoclaude/*` dep; extend `scripts/mulmoclaude/drift.mjs` to cover them when appetite for the CI change surfaces.
+- v0.9.3 release-app tagged root=0.9.3 while `mulmoclaude@0.9.4` was already on npm — one patch of drift that made "which one am I running?" ambiguous. §5.5 (root bump in this flow) exists so the launcher npm version and the `/release-app` tag always match.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.5",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- \`mulmoclaude\` launcher bumped 0.9.4 → **0.9.5** and published.
- npm 公開済: https://www.npmjs.com/package/mulmoclaude/v/0.9.5
- 検証: \`npx --registry=https://registry.npmjs.org/ mulmoclaude@0.9.5 --version\` → \`mulmoclaude 0.9.5\`
- skill \`/publish-mulmoclaude\` の §1 (deps) / §2 (drift) / §4 (tarball boot smoke) 全 green（ローカル / CI \`MulmoClaude publish smoke\` on main sha \`2da19cfc\` 両方）

## Cascade publish (unexpected)

skill §2 の drift check は \`@mulmobridge/*\` scope のみカバー。\`@mulmoclaude/*\` scope に対しては手動確認が必要でした:

- \`@mulmoclaude/collection-plugin\` local **0.7.4** vs npm **0.7.3** — 過去の \`chore(release)\` コミットで local だけ bump され npm publish されていなかった状態
- npx で \`No matching version found for @mulmoclaude/collection-plugin@^0.7.4\` エラー → \`npm publish\` で 0.7.4 を出して解決

他の \`@mulmoclaude/*\` は全て一致（\`accounting-plugin\`, \`chart-plugin\`, \`form-plugin\`, \`html-plugin\`, \`markdown-plugin\`, \`spotify-plugin\`, \`x-plugin\`, \`core\`）。

## Items to Confirm / Review

- **skill 改善提案**: drift check を \`@mulmoclaude/*\` scope にも広げる価値がある。今回の "local bumped but not published" は既存 CLAUDE.md ルール（\`chore(release)\` で launcher の own version を preemptive bump しない）と関連するが、scope 側の drift は別問題。別 issue 化推奨。
- **launcher publish 前 registry**: npx 検証時 \`.npmrc\` の private mirror が publish 直後の反映を遅らせるので \`--registry=https://registry.npmjs.org/\` を明示的に指定した。skill 記述に追記候補。

## 0.9.4 → 0.9.5 で含まれる主な変更（40 PR、直近 4-5 日）

主要なもの:

- **Windows Docker sandbox の ESM 経路修正** (#1995): NODE_PATH は CJS 専用なので \`@mulmoclaude/*\` を静的 ESM import する MCP 子プロセスで解決失敗していた。\`server/agent/mcp-esm-loader.mjs\` + \`mcp-esm-bootstrap.mjs\` を追加し \`tsx --import\` で resolve hook を登録。Windows CI probe に ESM ステップも追加
- **HEIC 添付対応** (#1998, #2000): browser preview + サーバー側の HEIC→JPEG 変換
- **assertions-in-tests lint 改善** (#1999, #2001, #2005): 26 warnings → 0 → error 昇格。\`assert.doesNotThrow/doesNotReject\` の明示化 + \`deleteProjectSkill\` user-scope refusal に本物の boundary test を追加
- ほか 36 PR

詳細は v0.9.4 タグ以降のマージ履歴参照。

## Test plan

- [x] \`node scripts/mulmoclaude/smoke.mjs\` 全 3 stage pass（deps / drift / tarball HTTP 200）
- [x] \`npm view mulmoclaude version\` → \`0.9.5\`
- [x] \`npm view @mulmoclaude/collection-plugin version --registry https://registry.npmjs.org/\` → \`0.7.4\`
- [x] \`npx --registry=https://registry.npmjs.org/ mulmoclaude@0.9.5 --version\` → \`mulmoclaude 0.9.5\`
- [ ] CI の \`mulmoclaude_smoke.yaml\` でも再検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the package versions to **0.9.5** (including the root project version and the published `mulmoclaude` package version).
* **Documentation**
  * Updated the `mulmoclaude` publishing skill guide with stricter release/version synchronization steps and clearer publish verification procedures, including checks to ensure all `@mulmoclaude/*` dependencies resolve from the public registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->