### PR TITLE
fix(sandbox-repro): force ESM so the Windows-junction probe survives tsx CJS-default drift

### DIFF
--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -77,6 +77,17 @@ jobs:
             throw "expected NTFS Junction, got '$($x.LinkType)' — probe assumption violated"
           }
 
+      # The probe's ESM check actually LOADS `@mulmoclaude/x-plugin` through
+      # the resolver hook, so its built entry (`dist/index.js`, per the
+      # package's `exports` map) must exist in the mounted dev-workspace dir —
+      # production ships built dist, this repro must too. `yarn install`
+      # doesn't build it (no `prepare` script) and the plugin is a
+      # self-contained bundle (no `@mulmoclaude/core` or npm deps at load
+      # time, `vite build` inlines everything), so building just this one
+      # package is enough for the import to resolve.
+      - name: Build @mulmoclaude/x-plugin (probe imports its built ESM entry)
+        run: yarn workspace @mulmoclaude/x-plugin run build
+
       # windows-latest ships Docker CLI + a Windows-only engine, no Docker
       # Desktop. Docker Desktop in CI needs UI dialogs on first launch and
       # is flake-prone. Instead we use the preinstalled WSL2 with Ubuntu +

--- a/test/sandbox-repro/package.json
+++ b/test/sandbox-repro/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test/sandbox-repro/probe.ts
+++ b/test/sandbox-repro/probe.ts
@@ -33,6 +33,14 @@
 // `tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs` — the
 // bootstrap registers the loader so the ESM step below exercises the
 // shipped resolve hook end-to-end.
+//
+// The sibling `test/sandbox-repro/package.json` (`{ "type": "module" }`)
+// is mounted as `/repro/package.json` so tsx transforms this probe as
+// ESM — matching the real MCP server (ESM via the app's type:module
+// package.json) and enabling the top-level `await` in the ESM check
+// below. Without it, tsx treats an ambiguous `.ts` as CJS and esbuild
+// rejects top-level await (`"cjs" output format`) — which broke this
+// canary when an unpinned global `tsx` upgrade flipped that default.
 
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";


### PR DESCRIPTION
## Summary

The daily **`docker sandbox (Windows junction repro)`** canary went red ([run 28897618924](https://github.com/receptron/mulmoclaude/actions/runs/28897618924)). It had **two** independent problems — the first masked the second, which had never actually run in CI.

### Problem 1 — regression (the red flip): probe transformed as CJS
The workflow installs an *unpinned* global `tsx` (`npm install -g tsx`). `/repro` is bind-mounted from `test/sandbox-repro/`, which had **no `package.json`**, so `probe.ts` had no `"type": "module"` ancestor in the container. A newer `tsx`/`esbuild` flipped its default for an ambiguous `.ts` from ESM → CJS, and esbuild rejects the probe's top-level `await` under CJS:

```
/repro/probe.ts: ERROR: Top-level await is currently not supported with the "cjs" output format
```

**Fix:** add `test/sandbox-repro/package.json` = `{ "type": "module" }` → mounts as `/repro/package.json`, so tsx transforms the probe as ESM regardless of the tsx default — faithfully mirroring production (the real MCP server is ESM via an ancestor `type:module` package.json). Production code untouched.

### Problem 2 — never-passed check exposed: ESM import couldn't load
Once the probe ran as ESM, it finally reached its last check — `import("@mulmoclaude/x-plugin")` through the mcp-esm resolver hook (added in #1982, but every prior run died earlier at Problem 1, so it had **never executed**). It failed:

```
ESM import failed — loader hook not effective.
Cannot find package '@mulmoclaude/x-plugin' imported from /repro/probe.ts
```

**Root cause:** the loader is correct. It maps the dangling `@mulmoclaude/*` junction to the `/app/pkg_modules` fallback and reads that package.json's `exports` → `dist/index.js`. But `yarn install` never builds the plugin (no `prepare` script) and the workflow had no build step, so `dist/index.js` didn't exist → `resolveFromFallback` returns null → the primary "cannot find package" error is re-thrown. **Production is unaffected — it ships built dist.**

**Fix:** build `@mulmoclaude/x-plugin` on the host before the probe. It's a self-contained `vite build` bundle (no `@mulmoclaude/core` or npm deps at load time), so one targeted build is enough — no full `build:packages`.

## Verification

- **Real Windows/WSL2/Docker canary, my branch: fully green** ([run 28901846858](https://github.com/receptron/mulmoclaude/actions/runs/28901846858)) — `Build @mulmoclaude/x-plugin ✓` and `Run the sandbox regression probe ✓`, all probe checks including the ESM import pass.
- **Local POSIX (same OS as the container), real loader + `node:module.register()` bootstrap:** a dangling primary junction + a built fallback resolves and loads (`LOADED_FROM_FALLBACK`); removing the built entry reproduces the exact CI error; an ambiguous `.ts` with top-level `await` fails identically to CI without the package.json and passes with it.

## Items to Confirm / Review

- **Targeted build vs. `build:packages`**: I build only `x-plugin` because it's the one module the probe imports and it's self-contained (verified: its `dist/index.js` has zero imports). If the probe later imports another plugin, that build must be extended — noted in the step comment.
- **`type: module` via ancestor package.json vs. `.mts`**: chose the ancestor package.json so the canary keeps mirroring production's ESM mechanism (a `type:module` ancestor), not a file-extension trick.
- **No workspace/tsconfig fallout**: `test/sandbox-repro` isn't matched by any `workspaces` glob and is already excluded in `test/tsconfig.json`; `yarn install` emits identical (zero) workspace warnings with/without the new file.

## User Prompt

> ci失敗 https://github.com/receptron/mulmoclaude/actions/runs/28897618924
> (＋ 続けて再度「ci失敗」— 私のブランチでの workflow_dispatch 検証で露呈した2つ目の問題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)