### PR TITLE
refactor: extract pure helpers from long functions (lint max-lines, batch 1)

### DIFF
--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -648,6 +648,66 @@ function workspaceModuleMounts(packageRoot: string, platform: Platform, toDocker
 // Pure helper that returns the full `docker run ... claude <args>`
 // argv array. Extracted from runAgent so the long flag list can be
 // inspected and tested without spawning a real subprocess.
+// Windows host paths use `\`; Docker's `-v` wants `/`. Pure.
+const toDockerPath = (hostPath: string): string => hostPath.replace(/\\/g, "/");
+
+// Cap/user posture. With SSH-agent forwarding the entrypoint needs 5 caps +
+// HOST_UID/GID to fix /etc/passwd + chown/chmod the socket, then drops them on
+// exec (`setpriv --inh-caps=-all`). Without SSH, run the whole container as the
+// host user — zero caps from the start (pre-#259 posture). Pure.
+export function dockerUserCapArgs(sshAgentForward: boolean, uid: number, gid: number): string[] {
+  if (!sshAgentForward) return ["--user", `${uid}:${gid}`];
+  return [
+    "--cap-add",
+    "CHOWN",
+    "--cap-add",
+    "FOWNER",
+    "--cap-add",
+    "DAC_OVERRIDE",
+    "--cap-add",
+    "SETUID",
+    "--cap-add",
+    "SETGID",
+    "-e",
+    `HOST_UID=${uid}`,
+    "-e",
+    `HOST_GID=${gid}`,
+  ];
+}
+
+interface DockerBindMountOpts {
+  projectRoot: string;
+  packageRoot: string;
+  workspacePath: string;
+  homeDir: string;
+  packagesMount: string[];
+  platform: Platform;
+}
+
+// The `-v` bind mounts, in order. node_modules stays on projectRoot (hoisted
+// deps live next to the consumer's package.json, not mulmoclaude's package dir,
+// #1770); server/src come from packageRoot (repo root in dev, the installed
+// package in npx). Pure given its inputs. Extracted to keep buildDockerSpawnArgs
+// under the max-lines threshold.
+export function dockerBindMountArgs(opts: DockerBindMountOpts): string[] {
+  return [
+    "-v",
+    `${toDockerPath(opts.projectRoot)}/node_modules:/app/node_modules:ro`,
+    "-v",
+    `${toDockerPath(opts.packageRoot)}/server:/app/server:ro`,
+    "-v",
+    `${toDockerPath(opts.packageRoot)}/src:/app/src:ro`,
+    ...opts.packagesMount,
+    ...workspaceModuleMounts(opts.packageRoot, opts.platform, toDockerPath),
+    "-v",
+    `${toDockerPath(opts.workspacePath)}:${CONTAINER_WORKSPACE_PATH}`,
+    "-v",
+    `${toDockerPath(claudeConfigDir(opts.homeDir))}:/home/node/.claude`,
+    "-v",
+    `${toDockerPath(claudeConfigJson(opts.homeDir))}:/home/node/.claude.json`,
+  ];
+}
+
 export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
   const {
     workspacePath,
@@ -661,7 +721,6 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     sandboxAuthArgs = [],
     sshAgentForward = false,
   } = params;
-  const toDockerPath = (hostPath: string): string => hostPath.replace(/\\/g, "/");
   const extraHosts: string[] = platform === "linux" ? ["--add-host", "host.docker.internal:host-gateway"] : [];
   // `packages/` ships in the dev monorepo but NOT in the published
   // mulmoclaude package (the `files` whitelist in
@@ -682,32 +741,7 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     "-i",
     "--cap-drop",
     "ALL",
-    // When SSH agent forwarding is active, the entrypoint needs root
-    // to fix /etc/passwd, chown /home/node, and chmod the socket.
-    // These 5 caps are the minimum set; setpriv --inh-caps=-all
-    // drops them on exec so Claude runs with zero capabilities.
-    //
-    // When SSH is OFF, use the simpler `--user uid:gid` which runs
-    // the entire container as the host user — zero caps from the
-    // start, identical to the pre-#259 security posture.
-    ...(sshAgentForward
-      ? [
-          "--cap-add",
-          "CHOWN",
-          "--cap-add",
-          "FOWNER",
-          "--cap-add",
-          "DAC_OVERRIDE",
-          "--cap-add",
-          "SETUID",
-          "--cap-add",
-          "SETGID",
-          "-e",
-          `HOST_UID=${uid}`,
-          "-e",
-          `HOST_GID=${gid}`,
-        ]
-      : ["--user", `${uid}:${gid}`]),
+    ...dockerUserCapArgs(sshAgentForward, uid, gid),
     "-e",
     "HOME=/home/node",
     // Wiki-history hook (#763 PR 2) runs inside this container after
@@ -724,25 +758,7 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     // toolResult into its timeline.
     "-e",
     `MULMOCLAUDE_CHAT_SESSION_ID=${params.chatSessionId}`,
-    "-v",
-    // node_modules stays on projectRoot because hoisted deps live next
-    // to the consumer's package.json, not inside mulmoclaude's package
-    // dir (#1770).
-    `${toDockerPath(projectRoot)}/node_modules:/app/node_modules:ro`,
-    "-v",
-    // server/src come from packageRoot — in dev that's the repo root,
-    // in npx it's `<consumer>/node_modules/mulmoclaude/`.
-    `${toDockerPath(packageRoot)}/server:/app/server:ro`,
-    "-v",
-    `${toDockerPath(packageRoot)}/src:/app/src:ro`,
-    ...packagesMount,
-    ...workspaceModuleMounts(packageRoot, platform, toDockerPath),
-    "-v",
-    `${toDockerPath(workspacePath)}:${CONTAINER_WORKSPACE_PATH}`,
-    "-v",
-    `${toDockerPath(claudeConfigDir(homeDir))}:/home/node/.claude`,
-    "-v",
-    `${toDockerPath(claudeConfigJson(homeDir))}:/home/node/.claude.json`,
+    ...dockerBindMountArgs({ projectRoot, packageRoot, workspacePath, homeDir, packagesMount, platform }),
     ...sandboxAuthArgs,
     ...extraHosts,
     "mulmoclaude-sandbox",

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -191,24 +191,30 @@ export async function loadJsonlInput(jsonlPath: string): Promise<string> {
 
 // --- spawn layer ----------------------------------------------------
 
+// The `claude` CLI argv for one summarization. Pure — extracted so the spawn
+// executor stays small and the flag list is unit-testable on its own.
+export function buildSummarizeCliArgs(input: string, model: SummaryModel): string[] {
+  return [
+    "--print",
+    "--no-session-persistence",
+    "--output-format",
+    "json",
+    "--model",
+    model,
+    "--max-budget-usd",
+    String(MAX_BUDGET_USD),
+    "--json-schema",
+    JSON.stringify(SUMMARY_SCHEMA),
+    "--system-prompt",
+    SYSTEM_PROMPT,
+    "-p",
+    input,
+  ];
+}
+
 function spawnClaudeSummarize(input: string, timeoutMs: number, model: SummaryModel): Promise<string> {
   return new Promise((resolve, reject) => {
-    const args = [
-      "--print",
-      "--no-session-persistence",
-      "--output-format",
-      "json",
-      "--model",
-      model,
-      "--max-budget-usd",
-      String(MAX_BUDGET_USD),
-      "--json-schema",
-      JSON.stringify(SUMMARY_SCHEMA),
-      "--system-prompt",
-      SYSTEM_PROMPT,
-      "-p",
-      input,
-    ];
+    const args = buildSummarizeCliArgs(input, model);
     // Run from tmpdir so claude does not load the project's
     // CLAUDE.md / plugins / memory and inflate the context.
     const proc = spawn(claudeBinPath(), args, {

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -7,6 +7,8 @@ import { __resetForTests as resetTokenState, generateAndWriteToken } from "../..
 import {
   buildCliArgs,
   buildDockerSpawnArgs,
+  dockerUserCapArgs,
+  dockerBindMountArgs,
   buildMcpConfig,
   buildUserMessageLine,
   CONTAINER_WORKSPACE_PATH,
@@ -912,5 +914,55 @@ describe("buildMcpConfig — bearer token env (#325)", () => {
     const server = servers.mulmoclaude as Record<string, unknown>;
     const env = server.env as Record<string, string>;
     assert.equal(env.MULMOCLAUDE_AUTH_TOKEN, undefined);
+  });
+});
+
+describe("dockerUserCapArgs", () => {
+  it("runs the container as the host user (zero caps) when SSH forward is off", () => {
+    assert.deepEqual(dockerUserCapArgs(false, 501, 20), ["--user", "501:20"]);
+  });
+
+  it("adds the 5 minimum caps + HOST_UID/GID (no --user) when SSH forward is on", () => {
+    const args = dockerUserCapArgs(true, 501, 20);
+    assert.ok(!args.includes("--user"), "must not also pass --user");
+    for (const cap of ["CHOWN", "FOWNER", "DAC_OVERRIDE", "SETUID", "SETGID"]) {
+      assert.ok(args.includes(cap), `missing cap ${cap}`);
+    }
+    assert.ok(args.includes("HOST_UID=501"));
+    assert.ok(args.includes("HOST_GID=20"));
+  });
+});
+
+describe("dockerBindMountArgs", () => {
+  const opts = {
+    projectRoot: "/proj",
+    packageRoot: "/pkg",
+    workspacePath: "/ws",
+    homeDir: "/home/u",
+    packagesMount: ["-v", "/pkg/packages:/app/packages:ro"],
+    platform: "linux" as Platform,
+  };
+
+  it("mounts node_modules from projectRoot and server/src from packageRoot, read-only", () => {
+    const args = dockerBindMountArgs(opts);
+    assert.ok(args.includes("/proj/node_modules:/app/node_modules:ro"));
+    assert.ok(args.includes("/pkg/server:/app/server:ro"));
+    assert.ok(args.includes("/pkg/src:/app/src:ro"));
+  });
+
+  it("splices in the caller's packagesMount and mounts the workspace + .claude config", () => {
+    const args = dockerBindMountArgs(opts);
+    assert.ok(args.includes("/pkg/packages:/app/packages:ro"), "packagesMount not spliced in");
+    assert.ok(
+      args.some((arg) => arg.startsWith("/ws:")),
+      "workspace mount missing",
+    );
+    assert.ok(args.some((arg) => arg.endsWith(":/home/node/.claude")));
+    assert.ok(args.some((arg) => arg.endsWith(":/home/node/.claude.json")));
+  });
+
+  it("converts Windows backslash host paths to forward slashes for -v", () => {
+    const args = dockerBindMountArgs({ ...opts, projectRoot: "C:\\Users\\me\\proj" });
+    assert.ok(args.includes("C:/Users/me/proj/node_modules:/app/node_modules:ro"));
   });
 });

--- a/test/chat-index/test_summarizer.ts
+++ b/test/chat-index/test_summarizer.ts
@@ -10,6 +10,7 @@ import {
   HEAD_CHARS,
   TAIL_CHARS,
   PER_MESSAGE_MAX,
+  buildSummarizeCliArgs,
 } from "../../server/workspace/chat-index/summarizer.js";
 
 describe("extractText", () => {
@@ -231,5 +232,25 @@ describe("formatSpawnError", () => {
     const msg = formatSpawnError(1, "", long);
     // 500 chars cap, plus the prefix "...exited 1: "
     assert.ok(msg.length < 600);
+  });
+});
+
+describe("buildSummarizeCliArgs", () => {
+  it("puts the model after --model and the transcript last after -p", () => {
+    const args = buildSummarizeCliArgs("the transcript", "sonnet");
+    assert.equal(args[args.indexOf("--model") + 1], "sonnet");
+    assert.equal(args[args.length - 2], "-p");
+    assert.equal(args[args.length - 1], "the transcript");
+  });
+
+  it("requests strict json output against the summary schema and runs non-interactively", () => {
+    const args = buildSummarizeCliArgs("x", "haiku");
+    assert.ok(args.includes("--print"));
+    assert.ok(args.includes("--no-session-persistence"));
+    assert.equal(args[args.indexOf("--output-format") + 1], "json");
+    assert.ok(args.includes("--json-schema"));
+    // the schema arg is valid JSON carrying the title/summary/keywords shape
+    const schema = JSON.parse(args[args.indexOf("--json-schema") + 1]);
+    assert.deepEqual(Object.keys(schema.properties).sort(), ["keywords", "summary", "title"]);
   });
 });


### PR DESCRIPTION
## Summary

Behaviour-preserving cleanup of `max-lines-per-function` lint warnings by extracting **pure, testable helpers**. No runtime change — the existing full-array / summarizer tests still pass, proving the assembled output is byte-identical.

Batch 1 (server, non-reactive, test-covered):

- `server/workspace/chat-index/summarizer.ts` — `buildSummarizeCliArgs(input, model)` (the `claude` argv). Clears 2 warnings (function + Promise executor).
- `server/agent/config.ts` — `dockerUserCapArgs()` + `dockerBindMountArgs()` out of `buildDockerSpawnArgs`. Clears 1 warning; still fully covered by its existing full-array test.

40 → 37 warnings.

## Items to Confirm / Review

- [ ] **Behaviour preservation**: each extraction is a pure code move; `test_agent_config.ts` (full argv assertions) and `test_summarizer.ts` are the safety net and stay green.
- [ ] New pure helpers each got a focused unit test (per request: pure fn ⇒ test).

## Approach

Only genuinely **pure** pieces were extracted (argv/mount/cap array builders). Reactive Vue composables and agent generators/loops were deliberately left out — splitting those can't be guaranteed side-effect-free without runtime verification; a separate batch covers the remaining safe server functions.

## Testing

`yarn format` / `lint` (0 errors, 37 warnings) / `typecheck` / `build` green. `test_agent_config.ts` (75) + `test_summarizer.ts` (27) pass, including the new helper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor long Docker spawn and summarizer functions by extracting pure, testable helper utilities while preserving existing behavior.

Enhancements:
- Extract dockerUserCapArgs and dockerBindMountArgs helpers from buildDockerSpawnArgs to encapsulate capability, user, and bind-mount argument construction.
- Extract buildSummarizeCliArgs helper from spawnClaudeSummarize to centralize construction of claude CLI arguments for summarization.

Tests:
- Add focused unit tests for dockerUserCapArgs and dockerBindMountArgs to validate Docker capability, user, and bind-mount argument composition.
- Add unit tests for buildSummarizeCliArgs to verify structure and options of generated claude CLI arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how container startup options are assembled, including mount paths and user permissions.
  * Simplified CLI argument construction for chat summarization.

* **Tests**
  * Added coverage for container permission/mount behavior.
  * Added coverage for summarization command argument generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->