### PR TITLE
refactor: extract MCP tool handlers from factories (lint max-lines, batch 2)

### DIFF
--- a/server/agent/mcp-tools/manageCollection.ts
+++ b/server/agent/mcp-tools/manageCollection.ts
@@ -393,6 +393,41 @@ async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCol
   return JSON.stringify({ collection: collection.slug, written: true });
 }
 
+const MANAGE_COLLECTION_PROMPT =
+  "Use `manageCollection` instead of raw Read/Write/Edit when working with a collection's records OR its schema (raw file I/O stays available as the escape hatch). " +
+  "Before authoring or changing a collection's `schema.json`, call `schemaDocs` to load the field/DSL reference, then read with `getSchema` and write with `putSchema` — `putSchema` validates the whole schema before writing and returns actionable errors instead of silently failing discovery's validation. " +
+  "`getItems` is the only way to see computed values — `derived` fields (e.g. a portfolio's value), `toggle` projections, and `embed` records are host-computed and never present in the stored JSON files. On large collections pass `ids` and/or `fields` to keep the result small. " +
+  "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write. " +
+  'To update a few fields of an existing record, use `mode: "merge"` with a partial row ({ id, <changed fields> }) — the default upsert replaces the WHOLE record, so a partial upsert would silently erase every optional field it omits.';
+
+// The tool's action dispatch. Extracted from the factory's returned object so
+// `makeManageCollectionTool` stays under the max-lines threshold; each branch
+// already delegates to a handler. Behavior is unchanged — covered by
+// test/agent/test_manageCollection.ts.
+async function manageCollectionHandler(deps: ManageCollectionDeps, args: Record<string, unknown>): Promise<string> {
+  const action = typeof args.action === "string" ? args.action : "";
+  if (action === "schemaDocs") return handleSchemaDocs(deps);
+  const slug = typeof args.slug === "string" ? args.slug.trim() : "";
+  if (!slug) return "manageCollection: `slug` is required (the collection's slug).";
+  if (action === "getSchema") return handleGetSchema(slug, deps);
+  if (action === "putSchema") return handlePutSchema(slug, args.schema, deps);
+  if (action !== "getItems" && action !== "putItems") {
+    return 'manageCollection: `action` must be "getItems", "putItems", "schemaDocs", "getSchema", or "putSchema".';
+  }
+  const collection = await loadCollection(slug, deps);
+  if (!collection) return unknownCollection(slug);
+  if (action === "getItems") {
+    const ids = optionalStringArray(args.ids, "ids");
+    if (!ids.ok) return ids.error;
+    const fields = optionalStringArray(args.fields, "fields");
+    if (!fields.ok) return fields.error;
+    return handleGetItems(collection, { slug, ids: ids.value, fields: fields.value }, deps);
+  }
+  const parsed = parsePutItems(args, slug);
+  if (typeof parsed === "string") return parsed;
+  return handlePutItems(collection, parsed, deps);
+}
+
 export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
   return {
     definition: {
@@ -440,36 +475,9 @@ export function makeManageCollectionTool(deps: ManageCollectionDeps = {}) {
     // push unlisted roles back onto unvalidated file I/O.
     alwaysActive: true,
 
-    prompt:
-      "Use `manageCollection` instead of raw Read/Write/Edit when working with a collection's records OR its schema (raw file I/O stays available as the escape hatch). " +
-      "Before authoring or changing a collection's `schema.json`, call `schemaDocs` to load the field/DSL reference, then read with `getSchema` and write with `putSchema` — `putSchema` validates the whole schema before writing and returns actionable errors instead of silently failing discovery's validation. " +
-      "`getItems` is the only way to see computed values — `derived` fields (e.g. a portfolio's value), `toggle` projections, and `embed` records are host-computed and never present in the stored JSON files. On large collections pass `ids` and/or `fields` to keep the result small. " +
-      "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write. " +
-      'To update a few fields of an existing record, use `mode: "merge"` with a partial row ({ id, <changed fields> }) — the default upsert replaces the WHOLE record, so a partial upsert would silently erase every optional field it omits.',
+    prompt: MANAGE_COLLECTION_PROMPT,
 
-    async handler(args: Record<string, unknown>): Promise<string> {
-      const action = typeof args.action === "string" ? args.action : "";
-      if (action === "schemaDocs") return handleSchemaDocs(deps);
-      const slug = typeof args.slug === "string" ? args.slug.trim() : "";
-      if (!slug) return "manageCollection: `slug` is required (the collection's slug).";
-      if (action === "getSchema") return handleGetSchema(slug, deps);
-      if (action === "putSchema") return handlePutSchema(slug, args.schema, deps);
-      if (action !== "getItems" && action !== "putItems") {
-        return 'manageCollection: `action` must be "getItems", "putItems", "schemaDocs", "getSchema", or "putSchema".';
-      }
-      const collection = await loadCollection(slug, deps);
-      if (!collection) return unknownCollection(slug);
-      if (action === "getItems") {
-        const ids = optionalStringArray(args.ids, "ids");
-        if (!ids.ok) return ids.error;
-        const fields = optionalStringArray(args.fields, "fields");
-        if (!fields.ok) return fields.error;
-        return handleGetItems(collection, { slug, ids: ids.value, fields: fields.value }, deps);
-      }
-      const parsed = parsePutItems(args, slug);
-      if (typeof parsed === "string") return parsed;
-      return handlePutItems(collection, parsed, deps);
-    },
+    handler: (args: Record<string, unknown>): Promise<string> => manageCollectionHandler(deps, args),
   };
 }
 

--- a/server/agent/mcp-tools/spawnBackgroundChat.ts
+++ b/server/agent/mcp-tools/spawnBackgroundChat.ts
@@ -46,6 +46,45 @@ export interface SpawnBackgroundChatDeps {
   readSessionOrigin: ReadSessionOriginFn;
 }
 
+// The tool's runtime behavior. Extracted from the factory's returned object so
+// `makeSpawnBackgroundChatTool` stays under the max-lines threshold; `deps` is
+// threaded in explicitly. Behavior is unchanged — covered by
+// test/agent/test_spawnBackgroundChat.ts.
+async function spawnBackgroundChatHandler(deps: SpawnBackgroundChatDeps, args: Record<string, unknown>, ctx?: McpToolContext): Promise<string> {
+  const message = typeof args.message === "string" ? args.message.trim() : "";
+  if (!message) return "spawnBackgroundChat: `message` is required (non-empty string).";
+  const role = typeof args.role === "string" ? args.role.trim() : "";
+  if (!role) return "spawnBackgroundChat: `role` is required (non-empty string — the role id the worker runs in).";
+  const { hidden } = args;
+  if (typeof hidden !== "boolean") return "spawnBackgroundChat: `hidden` is required (boolean).";
+
+  // No nesting: a hidden worker session must not fan out further hidden
+  // workers. Only enforced when we know the caller's session.
+  if (ctx?.sessionId) {
+    const parentOrigin = await deps.readSessionOrigin(ctx.sessionId);
+    if (parentOrigin === SESSION_ORIGINS.system) {
+      return "spawnBackgroundChat: refused — a background worker session cannot spawn further background sessions. Do the work inline instead.";
+    }
+  }
+
+  const origin: SessionOrigin = hidden ? SESSION_ORIGINS.system : SESSION_ORIGINS.skill;
+  const chatId = randomUUID();
+
+  // Runaway guard: reserve the slot ATOMICALLY and BEFORE launching so
+  // concurrent calls can't all pass a check-then-reserve split and over-spawn.
+  // Released in runAgentInBackground's finally, or rolled back here on failure.
+  if (hidden && !tryReserveBackgroundSession(chatId)) {
+    return `spawnBackgroundChat: refused — too many background sessions already in flight (max ${MAX_BACKGROUND_SESSIONS}). Do the work inline instead.`;
+  }
+
+  const result = await deps.startChat({ message, roleId: role, chatSessionId: chatId, origin });
+  if (result.kind === "error") {
+    if (hidden) releaseBackgroundSession(chatId); // roll back the reservation
+    return `spawnBackgroundChat: failed to start chat: ${result.error}`;
+  }
+  return JSON.stringify({ chatId, hidden });
+}
+
 export function makeSpawnBackgroundChatTool(deps: SpawnBackgroundChatDeps) {
   return {
     definition: {
@@ -83,43 +122,7 @@ export function makeSpawnBackgroundChatTool(deps: SpawnBackgroundChatDeps) {
       "Set `hidden: true` for invisible background work (the session never appears in the user's history); `hidden: false` only when the user should be able to open the spawned chat themselves. " +
       "The `message` must be fully self-contained — the worker shares NONE of this chat's context — and should instruct the worker to write its output to disk and stop without presenting anything (no one is viewing its canvas). It returns right away with a `chatId`; it does NOT wait for the worker to finish, so always keep a graceful fallback (do the work inline) in case the worker hasn't finished by the time its output is needed.",
 
-    async handler(args: Record<string, unknown>, ctx?: McpToolContext): Promise<string> {
-      const message = typeof args.message === "string" ? args.message.trim() : "";
-      if (!message) return "spawnBackgroundChat: `message` is required (non-empty string).";
-      const role = typeof args.role === "string" ? args.role.trim() : "";
-      if (!role) return "spawnBackgroundChat: `role` is required (non-empty string — the role id the worker runs in).";
-      const { hidden } = args;
-      if (typeof hidden !== "boolean") return "spawnBackgroundChat: `hidden` is required (boolean).";
-
-      // No nesting: a hidden worker session must not fan out further
-      // hidden workers. Only enforced when we know the caller's session.
-      if (ctx?.sessionId) {
-        const parentOrigin = await deps.readSessionOrigin(ctx.sessionId);
-        if (parentOrigin === SESSION_ORIGINS.system) {
-          return "spawnBackgroundChat: refused — a background worker session cannot spawn further background sessions. Do the work inline instead.";
-        }
-      }
-
-      const origin: SessionOrigin = hidden ? SESSION_ORIGINS.system : SESSION_ORIGINS.skill;
-      const chatId = randomUUID();
-
-      // Runaway guard: cap concurrent hidden workers. Reserve the slot
-      // ATOMICALLY and BEFORE launching — a check-then-reserve split
-      // around the `await startChat` below would let concurrent calls
-      // all pass the check and over-spawn. Released in
-      // `runAgentInBackground`'s finally, or rolled back here if the
-      // launch fails.
-      if (hidden && !tryReserveBackgroundSession(chatId)) {
-        return `spawnBackgroundChat: refused — too many background sessions already in flight (max ${MAX_BACKGROUND_SESSIONS}). Do the work inline instead.`;
-      }
-
-      const result = await deps.startChat({ message, roleId: role, chatSessionId: chatId, origin });
-      if (result.kind === "error") {
-        if (hidden) releaseBackgroundSession(chatId); // roll back the reservation
-        return `spawnBackgroundChat: failed to start chat: ${result.error}`;
-      }
-      return JSON.stringify({ chatId, hidden });
-    },
+    handler: (args: Record<string, unknown>, ctx?: McpToolContext): Promise<string> => spawnBackgroundChatHandler(deps, args, ctx),
   };
 }
 


### PR DESCRIPTION
## Summary

Second, independent batch of behaviour-preserving `max-lines-per-function` cleanups (batch 1 = #2014, different files, no overlap). Extracts the two MCP tool factories' handler bodies into named functions so the factories drop under the threshold.

- `server/agent/mcp-tools/spawnBackgroundChat.ts` — `spawnBackgroundChatHandler(deps, args, ctx)`.
- `server/agent/mcp-tools/manageCollection.ts` — `manageCollectionHandler(deps, args)` + the static `prompt` string lifted to a module const.

## Items to Confirm / Review

- [ ] **Behaviour preservation**: each handler body is a pure code move (deps threaded in explicitly). The existing end-to-end tool tests are the safety net and stay green.
- [ ] Scope: only clean, test-covered server extractions. Reactive Vue composables and agent generators/loops are deliberately excluded (can't guarantee side-effect-free without runtime verification).

## Testing

`yarn format` / `lint` (0 errors, 38 warnings) / `typecheck` / `build` green. `test_spawnBackgroundChat.ts` (15) + `test_manageCollection.ts` (39) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor MCP tool implementations to keep factory functions under lint max-lines limits while preserving behavior.

Enhancements:
- Extract the spawn background chat MCP tool logic into a dedicated handler function that is injected with dependencies.
- Extract the manage collection MCP tool action dispatch into a dedicated handler function and lift the tool prompt into a shared module-level constant.