### PR TITLE
refactor: extract helpers from backfill + external install (lint max-lines, batch 3)

### DIFF
--- a/server/workspace/chat-index/index.ts
+++ b/server/workspace/chat-index/index.ts
@@ -105,6 +105,34 @@ export interface BackfillResult {
   skipped: number;
 }
 
+// Index one session for the backfill walk, returning the outcome so the caller
+// keeps ownership of the counters + the module-level `disabled` latch.
+// Extracted to keep backfillAllSessions under the max-lines threshold; covered
+// by test/chat-index/test_maybe_index_session.ts.
+async function indexSessionForBackfill(
+  workspaceRoot: string,
+  sessionId: string,
+  deps: IndexerDeps | undefined,
+  force: boolean,
+  mode: IndexerDeps["mode"],
+): Promise<"indexed" | "skipped" | "disable"> {
+  try {
+    const entry = await indexSession(workspaceRoot, sessionId, { ...(deps ?? {}), ...(force ? { force: true } : {}), mode });
+    if (entry) {
+      log.info("chat-index", "indexed", { sessionId, title: entry.title });
+      return "indexed";
+    }
+    return "skipped";
+  } catch (err) {
+    if (err instanceof ClaudeCliNotFoundError) {
+      log.warn("chat-index", err.message);
+      return "disable";
+    }
+    log.warn("chat-index", "failed to index", { sessionId, error: String(err) });
+    return "skipped";
+  }
+}
+
 export async function backfillAllSessions(
   opts: {
     workspaceRoot?: string;
@@ -138,33 +166,12 @@ export async function backfillAllSessions(
       result.skipped++;
       continue;
     }
-    try {
-      const entry = await indexSession(workspaceRoot, sessionId, {
-        ...(opts.deps ?? {}),
-        ...(force ? { force: true } : {}),
-        mode,
-      });
-      if (entry) {
-        result.indexed++;
-        log.info("chat-index", "indexed", {
-          sessionId,
-          title: entry.title,
-        });
-      } else {
-        result.skipped++;
-      }
-    } catch (err) {
-      if (err instanceof ClaudeCliNotFoundError) {
-        disabled = true;
-        log.warn("chat-index", err.message);
-        result.skipped++;
-        continue;
-      }
+    const outcome = await indexSessionForBackfill(workspaceRoot, sessionId, opts.deps, force, mode);
+    if (outcome === "indexed") {
+      result.indexed++;
+    } else {
       result.skipped++;
-      log.warn("chat-index", "failed to index", {
-        sessionId,
-        error: String(err),
-      });
+      if (outcome === "disable") disabled = true;
     }
   }
   return result;

--- a/server/workspace/skills/external/install.ts
+++ b/server/workspace/skills/external/install.ts
@@ -221,19 +221,28 @@ async function existingCanonicalUrl(metadataPath: string): Promise<string | null
 }
 
 /** Install an external skill repo into the catalog. */
-export async function installExternalRepo(opts: InstallRepoOptions, deps: ExternalInstallOptions = {}): Promise<InstallExternalRepoResult> {
+// Validate + normalise the install inputs: derive the repoId slug and sanitise
+// the subpath BEFORE it reaches `path.join` / the git sparse-checkout pattern
+// (`path.join` collapses `..`, so an un-validated subpath could escape the
+// scratch cache dir). Pure — returns either the clean inputs or the early
+// error result. Exported for unit tests.
+export function resolveInstallInputs(
+  opts: InstallRepoOptions,
+): { ok: true; repoId: string; subpath?: string } | { ok: false; result: InstallExternalRepoResult } {
   const repoId = deriveRepoId(opts.url);
-  if (!repoId) return { kind: "invalid-url", url: opts.url };
-
-  // Sanitise the subpath BEFORE it reaches `path.join` / the git
-  // sparse-checkout pattern. `path.join` collapses `..`, so an
-  // un-validated subpath could escape the scratch cache dir.
-  let subpath: string | undefined;
+  if (!repoId) return { ok: false, result: { kind: "invalid-url", url: opts.url } };
   if (opts.subpath !== undefined) {
     const clean = sanitiseSubpath(opts.subpath);
-    if (clean === null) return { kind: "invalid-subpath", subpath: opts.subpath };
-    subpath = clean;
+    if (clean === null) return { ok: false, result: { kind: "invalid-subpath", subpath: opts.subpath } };
+    return { ok: true, repoId, subpath: clean };
   }
+  return { ok: true, repoId };
+}
+
+export async function installExternalRepo(opts: InstallRepoOptions, deps: ExternalInstallOptions = {}): Promise<InstallExternalRepoResult> {
+  const inputs = resolveInstallInputs(opts);
+  if (!inputs.ok) return inputs.result;
+  const { repoId, subpath } = inputs;
 
   const workspaceRoot = deps.workspaceRoot ?? workspacePath;
   let clone: CloneResult;

--- a/test/workspace/skills/external/test_install.ts
+++ b/test/workspace/skills/external/test_install.ts
@@ -19,7 +19,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { installExternalRepo, uninstallExternalRepo, listInstalledRepos } from "../../../../server/workspace/skills/external/install.js";
+import { installExternalRepo, uninstallExternalRepo, listInstalledRepos, resolveInstallInputs } from "../../../../server/workspace/skills/external/install.js";
 import type { RunGit } from "../../../../server/workspace/skills/external/clone.js";
 import { urlCacheKey } from "../../../../server/workspace/skills/external/id.js";
 
@@ -429,5 +429,31 @@ describe("uninstallExternalRepo", () => {
     const result = await uninstallExternalRepo("foo-bar", { workspaceRoot: workdir, cacheRoot });
     assert.equal(result.kind, "uninstalled");
     assert.equal(existsSync(path.join(activeDir, "SKILL.md")), true);
+  });
+});
+
+describe("resolveInstallInputs", () => {
+  it("derives a repoId from a valid GitHub URL", () => {
+    const res = resolveInstallInputs({ url: "https://github.com/owner/repo" });
+    assert.equal(res.ok, true);
+    if (res.ok) assert.ok(res.repoId.length > 0);
+  });
+
+  it("rejects a non-GitHub / unparseable URL as invalid-url", () => {
+    const res = resolveInstallInputs({ url: "not a url" });
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.equal(res.result.kind, "invalid-url");
+  });
+
+  it("rejects a subpath that escapes the cache dir as invalid-subpath", () => {
+    const res = resolveInstallInputs({ url: "https://github.com/owner/repo", subpath: "../../etc/passwd" });
+    assert.equal(res.ok, false);
+    if (!res.ok) assert.equal(res.result.kind, "invalid-subpath");
+  });
+
+  it("passes a clean subpath through", () => {
+    const res = resolveInstallInputs({ url: "https://github.com/owner/repo", subpath: "skills/foo" });
+    assert.equal(res.ok, true);
+    if (res.ok) assert.equal(res.subpath, "skills/foo");
   });
 });


### PR DESCRIPTION
## Summary

Third independent batch of behaviour-preserving `max-lines-per-function` cleanups (batches 1/2 = #2014 / #2015, different files, no overlap).

- `server/workspace/chat-index/index.ts` — `indexSessionForBackfill()` returns an `"indexed" | "skipped" | "disable"` outcome so `backfillAllSessions` keeps ownership of the counters + the module-level `disabled` latch. Control-flow preserved (the `disable` outcome sets the latch exactly as the old `catch` did).
- `server/workspace/skills/external/install.ts` — `resolveInstallInputs()`, the **pure** URL→repoId + subpath-sanitisation validation lifted out of `installExternalRepo`, with new unit tests.

## Items to Confirm / Review

- [ ] **backfill control flow**: verify `indexSessionForBackfill` → outcome mapping matches the old inline loop (indexed++/skipped++/disabled latch). Covered by `test_maybe_index_session.ts`.
- [ ] `resolveInstallInputs` is pure and unit-tested (invalid-url / invalid-subpath / clean pass-through).

## Testing

`yarn format` / `lint` (0 errors) / `typecheck` / `build` green. `test_maybe_index_session.ts` (17) + `test_install.ts` (24, incl. new resolveInstallInputs tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor chat session backfill indexing and external skill installation input handling to stay within linting constraints while preserving behavior.

Bug Fixes:
- Prevent potentially unsafe external skill subpaths from escaping the scratch cache directory via improved input validation.

Enhancements:
- Extract indexSessionForBackfill helper to encapsulate per-session indexing outcomes while keeping backfillAllSessions responsible for counters and disable latch state.
- Introduce resolveInstallInputs helper to derive repo identifiers and sanitise optional subpaths as a pure, reusable validation layer for external repo installation.

Tests:
- Add unit tests for resolveInstallInputs covering valid GitHub URLs, invalid URLs, unsafe subpaths, and clean subpaths.
- Update existing backfill tests to cover the new indexSessionForBackfill control flow indirectly via test_maybe_index_session.ts.