### PR TITLE
refactor: extract handlers from wiki/mulmo/attachment routes (lint max-lines)

### DIFF
--- a/server/api/routes/attachment.ts
+++ b/server/api/routes/attachment.ts
@@ -12,7 +12,7 @@
 
 import { Router, Request, Response } from "express";
 import { extname } from "path";
-import { saveAttachment, saveCompanion, stripDataUri } from "../../utils/files/attachment-store.js";
+import { saveAttachment, saveCompanion, stripDataUri, type SavedAttachment } from "../../utils/files/attachment-store.js";
 import { convertPptxToPdf } from "../../agent/attachmentConverter.js";
 import { CLAUDE_UNSUPPORTED_IMAGE_MIMES, sharpConvertToJpeg, type ConvertToJpeg } from "../../utils/files/image-jpeg-convert.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -63,89 +63,99 @@ interface UploadAttachmentError {
   error: string;
 }
 
-router.post(
-  API_ROUTES.attachments.upload,
-  async (req: Request<object, unknown, UploadAttachmentBody>, res: Response<UploadAttachmentResponse | UploadAttachmentError>) => {
-    const { dataUrl, filename } = req.body;
-    if (!dataUrl) {
-      badRequest(res, "dataUrl is required");
-      return;
-    }
-    const parsed = stripDataUri(dataUrl);
-    if (!parsed) {
-      badRequest(res, "dataUrl must be a data: URI");
-      return;
-    }
-    log.info("attachments", "upload: start", {
-      mimeType: parsed.mimeType,
-      filename,
-      bytes: Math.floor((parsed.base64.length * 3) / 4),
+type UploadResponse = Response<UploadAttachmentResponse | UploadAttachmentError>;
+
+// PPTX → PDF companion branch. LibreOffice unavailable → return the
+// original PPTX path and let the agent loop produce its existing
+// fallback text block. Surfaces a warn so it doesn't disappear
+// silently in environments where conversion is expected.
+async function respondWithPptxCompanion(res: UploadResponse, original: SavedAttachment, base64: string): Promise<void> {
+  const pdfBuf = await convertPptxToPdf(base64);
+  if (!pdfBuf) {
+    log.warn("attachments", "upload: pptx conversion unavailable, returning original", {
+      path: original.relativePath,
     });
-    try {
-      const original = await saveAttachment(parsed.base64, parsed.mimeType);
-      if (parsed.mimeType === PPTX_MIME) {
-        const pdfBuf = await convertPptxToPdf(parsed.base64);
-        if (!pdfBuf) {
-          // LibreOffice unavailable — return the original PPTX path
-          // and let the agent loop produce its existing fallback
-          // text block. Surfaces a warn so it doesn't disappear
-          // silently in environments where conversion is expected.
-          log.warn("attachments", "upload: pptx conversion unavailable, returning original", {
-            path: original.relativePath,
-          });
-          res.json({ path: original.relativePath, originalPath: original.relativePath, mimeType: original.mimeType });
-          return;
-        }
-        const pdfPath = await saveCompanion(original.relativePath, pdfBuf, ".pdf");
-        log.info("attachments", "upload: ok", {
-          path: pdfPath,
-          originalPath: original.relativePath,
-          conversion: "pptx-to-pdf",
-        });
-        res.json({ path: pdfPath, originalPath: original.relativePath, mimeType: "application/pdf" });
-        return;
-      }
-      if (CLAUDE_UNSUPPORTED_IMAGE_MIMES.has(parsed.mimeType)) {
-        // HEIC / HEIF / TIFF / BMP / AVIF — Claude API rejects these
-        // as `image.source.media_type`, so convert to JPEG at upload
-        // and hand the LLM the companion. The original still lives on
-        // disk (archival) and the EXIF sidecar hook has already run
-        // against it in `saveAttachment` — GPS / orientation are
-        // preserved independently of the JPEG. On sharp / libheif
-        // failure we log a warn and return the original path so the
-        // upload isn't lost; the caller then hits the same 400 it
-        // would have before this branch existed.
-        let jpegBuf: Buffer;
-        try {
-          jpegBuf = await imageJpegConverter(Buffer.from(parsed.base64, "base64"), parsed.mimeType);
-        } catch (convertErr) {
-          log.warn("attachments", "upload: image-to-jpeg conversion failed, returning original", {
-            path: original.relativePath,
-            sourceMime: parsed.mimeType,
-            error: errorMessage(convertErr),
-          });
-          res.json({ path: original.relativePath, originalPath: original.relativePath, mimeType: original.mimeType });
-          return;
-        }
-        const jpegPath = await saveCompanion(original.relativePath, jpegBuf, ".jpg");
-        log.info("attachments", "upload: ok", {
-          path: jpegPath,
-          originalPath: original.relativePath,
-          conversion: `${parsed.mimeType}-to-jpeg`,
-        });
-        res.json({ path: jpegPath, originalPath: original.relativePath, mimeType: "image/jpeg" });
-        return;
-      }
-      log.info("attachments", "upload: ok", {
-        path: original.relativePath,
-        ext: extname(original.relativePath),
-      });
-      res.json({ path: original.relativePath, originalPath: original.relativePath, mimeType: original.mimeType });
-    } catch (err) {
-      log.error("attachments", "upload: threw", { error: errorMessage(err) });
-      serverError(res, errorMessage(err));
+    res.json({ path: original.relativePath, originalPath: original.relativePath, mimeType: original.mimeType });
+    return;
+  }
+  const pdfPath = await saveCompanion(original.relativePath, pdfBuf, ".pdf");
+  log.info("attachments", "upload: ok", {
+    path: pdfPath,
+    originalPath: original.relativePath,
+    conversion: "pptx-to-pdf",
+  });
+  res.json({ path: pdfPath, originalPath: original.relativePath, mimeType: "application/pdf" });
+}
+
+// HEIC / HEIF / TIFF / BMP / AVIF — Claude API rejects these as
+// `image.source.media_type`, so convert to JPEG at upload and hand
+// the LLM the companion. The original still lives on disk (archival)
+// and the EXIF sidecar hook has already run against it in
+// `saveAttachment` — GPS / orientation are preserved independently of
+// the JPEG. On sharp / libheif failure we log a warn and return the
+// original path so the upload isn't lost; the caller then hits the
+// same 400 it would have before this branch existed.
+async function respondWithJpegCompanion(res: UploadResponse, original: SavedAttachment, base64: string, sourceMime: string): Promise<void> {
+  let jpegBuf: Buffer;
+  try {
+    jpegBuf = await imageJpegConverter(Buffer.from(base64, "base64"), sourceMime);
+  } catch (convertErr) {
+    log.warn("attachments", "upload: image-to-jpeg conversion failed, returning original", {
+      path: original.relativePath,
+      sourceMime,
+      error: errorMessage(convertErr),
+    });
+    res.json({ path: original.relativePath, originalPath: original.relativePath, mimeType: original.mimeType });
+    return;
+  }
+  const jpegPath = await saveCompanion(original.relativePath, jpegBuf, ".jpg");
+  log.info("attachments", "upload: ok", {
+    path: jpegPath,
+    originalPath: original.relativePath,
+    conversion: `${sourceMime}-to-jpeg`,
+  });
+  res.json({ path: jpegPath, originalPath: original.relativePath, mimeType: "image/jpeg" });
+}
+
+async function handleUploadAttachment(req: Request<object, unknown, UploadAttachmentBody>, res: UploadResponse): Promise<void> {
+  const { dataUrl, filename } = req.body;
+  if (!dataUrl) {
+    badRequest(res, "dataUrl is required");
+    return;
+  }
+  const parsed = stripDataUri(dataUrl);
+  if (!parsed) {
+    badRequest(res, "dataUrl must be a data: URI");
+    return;
+  }
+  log.info("attachments", "upload: start", {
+    mimeType: parsed.mimeType,
+    filename,
+    bytes: Math.floor((parsed.base64.length * 3) / 4),
+  });
+  try {
+    const original = await saveAttachment(parsed.base64, parsed.mimeType);
+    if (parsed.mimeType === PPTX_MIME) {
+      await respondWithPptxCompanion(res, original, parsed.base64);
+      return;
     }
-  },
+    if (CLAUDE_UNSUPPORTED_IMAGE_MIMES.has(parsed.mimeType)) {
+      await respondWithJpegCompanion(res, original, parsed.base64, parsed.mimeType);
+      return;
+    }
+    log.info("attachments", "upload: ok", {
+      path: original.relativePath,
+      ext: extname(original.relativePath),
+    });
+    res.json({ path: original.relativePath, originalPath: original.relativePath, mimeType: original.mimeType });
+  } catch (err) {
+    log.error("attachments", "upload: threw", { error: errorMessage(err) });
+    serverError(res, errorMessage(err));
+  }
+}
+
+router.post(API_ROUTES.attachments.upload, async (req: Request<object, unknown, UploadAttachmentBody>, res: UploadResponse) =>
+  handleUploadAttachment(req, res),
 );
 
 export default router;

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -542,69 +542,66 @@ bindRoute(router, API_ROUTES.mulmoScript.beatAudio, async (req: Request<object, 
   );
 });
 
+interface GenerateBeatAudioBody {
+  filePath: string;
+  beatIndex: number;
+  force?: boolean;
+  chatSessionId?: string;
+}
+
+async function handleGenerateBeatAudio(req: Request<object, object, GenerateBeatAudioBody>, res: Response<GenerateBeatAudioResponse>): Promise<void> {
+  const { filePath, beatIndex, force, chatSessionId } = req.body;
+
+  if (!filePath || beatIndex === undefined) {
+    badRequest(res, "filePath and beatIndex are required");
+    return;
+  }
+
+  const key = String(beatIndex);
+  publishGeneration(chatSessionId, GENERATION_KINDS.beatAudio, filePath, key, false);
+  let genError: string | undefined;
+  try {
+    await withStoryContext(res, filePath, { force, operation: "generate-beat-audio" }, async ({ context }) => {
+      try {
+        await generateBeatAudio(beatIndex, context, {
+          settings: process.env as Record<string, string>,
+        } as Parameters<typeof generateBeatAudio>[2]);
+
+        const beat = context.studio.script.beats[beatIndex];
+        const audioPath = context.studio.beats[beatIndex]?.audioFile ?? getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
+
+        if (!audioPath || !existsSync(audioPath)) {
+          // Logic-flow failure (not an exception) — emit a targeted
+          // log. Don't write raw `beat.text` into persistent logs —
+          // it's free-form user content and can contain sensitive
+          // data.
+          log.error("generate-beat-audio", "audio was not generated", {
+            beatIndex,
+            audioPath,
+            exists: audioPath ? existsSync(audioPath) : false,
+            beatTextLength: typeof beat?.text === "string" ? beat.text.length : 0,
+            audioFilePresent: Boolean(context.studio.beats[beatIndex]?.audioFile),
+          });
+          genError = "Audio was not generated";
+          serverError(res, genError);
+          return;
+        }
+
+        res.json({ audio: fileToDataUri(audioPath, "audio/mpeg") });
+      } catch (err) {
+        genError = errorMessage(err);
+        throw err;
+      }
+    });
+  } finally {
+    publishGeneration(chatSessionId, GENERATION_KINDS.beatAudio, filePath, key, true, genError);
+  }
+}
+
 bindRoute(
   router,
   API_ROUTES.mulmoScript.generateBeatAudio,
-  async (
-    req: Request<
-      object,
-      object,
-      {
-        filePath: string;
-        beatIndex: number;
-        force?: boolean;
-        chatSessionId?: string;
-      }
-    >,
-    res: Response<GenerateBeatAudioResponse>,
-  ) => {
-    const { filePath, beatIndex, force, chatSessionId } = req.body;
-
-    if (!filePath || beatIndex === undefined) {
-      badRequest(res, "filePath and beatIndex are required");
-      return;
-    }
-
-    const key = String(beatIndex);
-    publishGeneration(chatSessionId, GENERATION_KINDS.beatAudio, filePath, key, false);
-    let genError: string | undefined;
-    try {
-      await withStoryContext(res, filePath, { force, operation: "generate-beat-audio" }, async ({ context }) => {
-        try {
-          await generateBeatAudio(beatIndex, context, {
-            settings: process.env as Record<string, string>,
-          } as Parameters<typeof generateBeatAudio>[2]);
-
-          const beat = context.studio.script.beats[beatIndex];
-          const audioPath = context.studio.beats[beatIndex]?.audioFile ?? getBeatAudioPathOrUrl(beat.text ?? "", context, beat, context.lang);
-
-          if (!audioPath || !existsSync(audioPath)) {
-            // Logic-flow failure (not an exception) — emit a targeted
-            // log. Don't write raw `beat.text` into persistent logs —
-            // it's free-form user content and can contain sensitive
-            // data.
-            log.error("generate-beat-audio", "audio was not generated", {
-              beatIndex,
-              audioPath,
-              exists: audioPath ? existsSync(audioPath) : false,
-              beatTextLength: typeof beat?.text === "string" ? beat.text.length : 0,
-              audioFilePresent: Boolean(context.studio.beats[beatIndex]?.audioFile),
-            });
-            genError = "Audio was not generated";
-            serverError(res, genError);
-            return;
-          }
-
-          res.json({ audio: fileToDataUri(audioPath, "audio/mpeg") });
-        } catch (err) {
-          genError = errorMessage(err);
-          throw err;
-        }
-      });
-    } finally {
-      publishGeneration(chatSessionId, GENERATION_KINDS.beatAudio, filePath, key, true, genError);
-    }
-  },
+  async (req: Request<object, object, GenerateBeatAudioBody>, res: Response<GenerateBeatAudioResponse>) => handleGenerateBeatAudio(req, res),
 );
 
 bindRoute(router, API_ROUTES.mulmoScript.renderBeat, async (req: Request<object, object, RenderBeatBody>, res: Response) => {
@@ -655,6 +652,19 @@ interface MovieProgressEvent {
   beatIndex: number;
 }
 
+// Map each beat to its array index, keyed by beat.id (falling back to
+// a synthetic `__index__<n>` for id-less beats). Shared by the movie
+// and PDF pipelines to translate mulmocast's per-beat progress events
+// (which carry the beat id) back into an index the UI can address.
+export function buildBeatIdIndex(beats: MulmoBeat[]): Map<string, number> {
+  const idToIndex = new Map<string, number>();
+  beats.forEach((beat, index) => {
+    const key = beat.id ?? `__index__${index}`;
+    idToIndex.set(key, index);
+  });
+  return idToIndex;
+}
+
 // Shared core for both the SSE-streaming `generateMovie` route and the
 // fire-and-forget background path triggered by `autoGenerateMovie`.
 // Builds the mulmo context, runs images→audio→movie, and reports
@@ -665,11 +675,7 @@ async function runMovieGeneration(absoluteFilePath: string, onProgressEvent: (ev
   const context = await buildContext(absoluteFilePath);
   if (!context) return { ok: false, error: "Failed to initialize mulmo context" };
 
-  const idToIndex = new Map<string, number>();
-  (context.studio.script.beats as MulmoBeat[]).forEach((beat, index) => {
-    const key = beat.id ?? `__index__${index}`;
-    idToIndex.set(key, index);
-  });
+  const idToIndex = buildBeatIdIndex(context.studio.script.beats as MulmoBeat[]);
 
   // Known limitation: addSessionProgressCallback is global, so when two
   // movie generations for *different* scripts run concurrently, both
@@ -1027,7 +1033,36 @@ bindRoute(
   },
 );
 
-bindRoute(router, API_ROUTES.mulmoScript.generatePdf, async (req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response) => {
+type PdfGenerationResult = { ok: true; outputPath: string } | { ok: false; error: string };
+
+// Shared core for the SSE-streaming `generatePdf` route. Mirrors the
+// movie pipeline's per-beat progress reporting so the UI's
+// pendingGenerations watcher can light spinners during the image
+// pass; the PDF action itself doesn't emit progress events, so only
+// image events are forwarded. Returns a structured failure when the
+// pipeline completes but the output file is missing.
+async function runPdfGeneration(context: StoryContext, onImageBeatDone: (beatIndex: number) => void): Promise<PdfGenerationResult> {
+  const idToIndex = buildBeatIdIndex(context.studio.script.beats as MulmoBeat[]);
+  const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
+    if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
+    const beatIndex = idToIndex.get(event.id);
+    if (beatIndex === undefined) return;
+    if (event.sessionType !== "image") return;
+    onImageBeatDone(beatIndex);
+  };
+  addSessionProgressCallback(onProgress);
+  try {
+    const imagesContext = await images(context);
+    await pdf(imagesContext, PDF_MODE, PDF_SIZE);
+    const outputPath = pdfFilePath(imagesContext, PDF_MODE);
+    if (!existsSync(outputPath)) return { ok: false, error: "PDF was not generated" };
+    return { ok: true, outputPath };
+  } finally {
+    removeSessionProgressCallback(onProgress);
+  }
+}
+
+async function handleGeneratePdf(req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response): Promise<void> {
   const { filePath, chatSessionId } = req.body;
   if (!filePath) {
     badRequest(res, "filePath is required");
@@ -1058,35 +1093,13 @@ bindRoute(router, API_ROUTES.mulmoScript.generatePdf, async (req: Request<object
       send({ type: "error", message: genError });
       return;
     }
-    // Mirror the movie pipeline's per-beat progress reporting so the
-    // UI's pendingGenerations watcher can light spinners during the
-    // image pass. The PDF action itself doesn't emit progress events.
-    const idToIndex = new Map<string, number>();
-    (context.studio.script.beats as MulmoBeat[]).forEach((beat, index) => {
-      const key = beat.id ?? `__index__${index}`;
-      idToIndex.set(key, index);
-    });
-    const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
-      if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
-      const beatIndex = idToIndex.get(event.id);
-      if (beatIndex === undefined) return;
-      if (event.sessionType !== "image") return;
-      send({ type: "beat_image_done", beatIndex });
-    };
-    addSessionProgressCallback(onProgress);
-    try {
-      const imagesContext = await images(context);
-      await pdf(imagesContext, PDF_MODE, PDF_SIZE);
-      const outputPath = pdfFilePath(imagesContext, PDF_MODE);
-      if (!existsSync(outputPath)) {
-        genError = "PDF was not generated";
-        send({ type: "error", message: genError });
-        return;
-      }
-      send({ type: "done", pdfPath: toStoryRef(outputPath) });
-    } finally {
-      removeSessionProgressCallback(onProgress);
+    const result = await runPdfGeneration(context, (beatIndex) => send({ type: "beat_image_done", beatIndex }));
+    if (!result.ok) {
+      genError = result.error;
+      send({ type: "error", message: genError });
+      return;
     }
+    send({ type: "done", pdfPath: toStoryRef(result.outputPath) });
   } catch (err) {
     genError = errorMessage(err);
     send({ type: "error", message: genError });
@@ -1095,7 +1108,11 @@ bindRoute(router, API_ROUTES.mulmoScript.generatePdf, async (req: Request<object
     publishGeneration(chatSessionId, GENERATION_KINDS.pdf, filePath, "", true, genError);
     res.end();
   }
-});
+}
+
+bindRoute(router, API_ROUTES.mulmoScript.generatePdf, async (req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response) =>
+  handleGeneratePdf(req, res),
+);
 
 bindRoute(router, API_ROUTES.mulmoScript.downloadPdf, (req: Request, res: Response) => {
   const pdfPath = getOptionalStringQuery(req, "pdfPath");

--- a/server/api/routes/wiki.ts
+++ b/server/api/routes/wiki.ts
@@ -251,6 +251,25 @@ async function handleSaveAction(
   res.json(response);
 }
 
+// Extracted from the POST switch (mirrors handleSaveAction) so the
+// route handler stays under the max-lines-per-function limit.
+// Resolves the page, logs the missing / ok distinction, and writes
+// the canvas response envelope.
+async function handlePageAction(res: Response<WikiResponse | ErrorResponse>, action: string, pageName: string | undefined): Promise<void> {
+  if (!pageName) {
+    log.warn("wiki", "POST page: missing pageName");
+    badRequest(res, "pageName required for page action");
+    return;
+  }
+  const response = await buildPageResponse(action, pageName);
+  if (!response.data.pageExists) {
+    log.warn("wiki", "POST page: not found", { pageNamePreview: previewSnippet(pageName) });
+  } else {
+    log.info("wiki", "POST page: ok", { pageNamePreview: previewSnippet(pageName), bytes: response.data.content.length });
+  }
+  res.json(response);
+}
+
 async function buildLintReportResponse(action: string): Promise<WikiResponse> {
   const issues = await collectLintIssues(workspacePath);
   const report = formatLintReport(issues);
@@ -264,7 +283,7 @@ async function buildLintReportResponse(action: string): Promise<WikiResponse> {
   };
 }
 
-router.post(API_ROUTES.wiki.base, async (req: Request<object, unknown, WikiBody>, res: Response<WikiResponse | ErrorResponse>) => {
+async function handleWikiPost(req: Request<object, unknown, WikiBody>, res: Response<WikiResponse | ErrorResponse>): Promise<void> {
   const { action, pageName } = req.body;
   log.info("wiki", "POST: start", { action, pageNamePreview: pageName ? previewSnippet(pageName) : undefined });
   try {
@@ -276,18 +295,7 @@ router.post(API_ROUTES.wiki.base, async (req: Request<object, unknown, WikiBody>
         return;
       }
       case "page": {
-        if (!pageName) {
-          log.warn("wiki", "POST page: missing pageName");
-          badRequest(res, "pageName required for page action");
-          return;
-        }
-        const response = await buildPageResponse(action, pageName);
-        if (!response.data.pageExists) {
-          log.warn("wiki", "POST page: not found", { pageNamePreview: previewSnippet(pageName) });
-        } else {
-          log.info("wiki", "POST page: ok", { pageNamePreview: previewSnippet(pageName), bytes: response.data.content.length });
-        }
-        res.json(response);
+        await handlePageAction(res, action, pageName);
         return;
       }
       case "log": {
@@ -326,6 +334,8 @@ router.post(API_ROUTES.wiki.base, async (req: Request<object, unknown, WikiBody>
     log.error("wiki", "POST: threw", { action, pageNamePreview: pageName ? previewSnippet(pageName) : undefined, error: formatError(err) });
     throw err;
   }
-});
+}
+
+router.post(API_ROUTES.wiki.base, async (req: Request<object, unknown, WikiBody>, res: Response<WikiResponse | ErrorResponse>) => handleWikiPost(req, res));
 
 export default router;

--- a/server/api/routes/wiki/history.ts
+++ b/server/api/routes/wiki/history.ts
@@ -152,7 +152,53 @@ interface InternalSnapshotBody {
   sessionId?: string;
 }
 
-router.post("/internal/snapshot", async (req: Request<object, unknown, InternalSnapshotBody>, res: Response) => {
+// Stage 3a (#963): publish a synthetic `manageWiki` toolResult
+// into the session timeline so the canvas shows what the LLM
+// just wrote. The View dispatch (existing manageWiki plugin)
+// picks up the new `page-edit` action and fetches the snapshot
+// body via /api/wiki/pages/:slug/history/:stamp on render —
+// JSONL stays small (~150 bytes per write) because we store
+// the snapshot reference, not the body. `pagePath` is a GC
+// fallback: if the snapshot is gc'd before render, the View
+// falls back to reading the live page file.
+// Wrapped in try/catch so a publish failure (e.g. JSONL append
+// throws) doesn't fail the whole route — the snapshot was
+// already written, and the hook is fire-and-forget. Without
+// this guard the route would 500 even though the wiki write
+// itself succeeded; the next save would still snapshot fine,
+// but the canvas would silently lose this one preview
+// (CodeRabbit review).
+async function publishPageEditToolResult(sessionId: string, slug: string, stamp: string): Promise<void> {
+  try {
+    const outcome = await pushToolResult(sessionId, {
+      uuid: randomUUID(),
+      toolName: TOOL_NAMES.manageWiki,
+      data: {
+        // `"page-edit"` is the action discriminator the wiki
+        // plugin's `View.vue` switches on. It's repeated in the
+        // plugin and in `src/plugins/wiki/pageEditLoader.ts`; a
+        // shared `WIKI_ACTIONS` const would be the cleaner home
+        // but that's a multi-file refactor — out of scope for
+        // this CR follow-up.
+        action: "page-edit",
+        title: slug,
+        slug,
+        stamp,
+        pagePath: path.posix.join(WORKSPACE_DIRS.wikiPages, `${slug}.md`),
+      },
+    });
+    if (outcome.kind === "skipped") {
+      log.warn("wiki", "page-edit toolResult publish skipped", { slug, reason: outcome.reason });
+    }
+  } catch (err) {
+    log.warn("wiki", "page-edit toolResult publish failed", {
+      slug,
+      error: errorMessage(err),
+    });
+  }
+}
+
+async function handleInternalSnapshot(req: Request<object, unknown, InternalSnapshotBody>, res: Response): Promise<void> {
   const { slug, sessionId } = req.body ?? {};
   if (typeof slug !== "string" || slug.length === 0) {
     badRequest(res, "slug required");
@@ -200,53 +246,13 @@ router.post("/internal/snapshot", async (req: Request<object, unknown, InternalS
   );
   log.info("wiki", "internal snapshot recorded", { slug });
 
-  // Stage 3a (#963): publish a synthetic `manageWiki` toolResult
-  // into the session timeline so the canvas shows what the LLM
-  // just wrote. The View dispatch (existing manageWiki plugin)
-  // picks up the new `page-edit` action and fetches the snapshot
-  // body via /api/wiki/pages/:slug/history/:stamp on render —
-  // JSONL stays small (~150 bytes per write) because we store
-  // the snapshot reference, not the body. `pagePath` is a GC
-  // fallback: if the snapshot is gc'd before render, the View
-  // falls back to reading the live page file.
-  // Wrapped in try/catch so a publish failure (e.g. JSONL append
-  // throws) doesn't fail the whole route — the snapshot was
-  // already written, and the hook is fire-and-forget. Without
-  // this guard the route would 500 even though the wiki write
-  // itself succeeded; the next save would still snapshot fine,
-  // but the canvas would silently lose this one preview
-  // (CodeRabbit review).
   if (typeof sessionId === "string" && sessionId.length > 0) {
-    try {
-      const outcome = await pushToolResult(sessionId, {
-        uuid: randomUUID(),
-        toolName: TOOL_NAMES.manageWiki,
-        data: {
-          // `"page-edit"` is the action discriminator the wiki
-          // plugin's `View.vue` switches on. It's repeated in the
-          // plugin and in `src/plugins/wiki/pageEditLoader.ts`; a
-          // shared `WIKI_ACTIONS` const would be the cleaner home
-          // but that's a multi-file refactor — out of scope for
-          // this CR follow-up.
-          action: "page-edit",
-          title: slug,
-          slug,
-          stamp,
-          pagePath: path.posix.join(WORKSPACE_DIRS.wikiPages, `${slug}.md`),
-        },
-      });
-      if (outcome.kind === "skipped") {
-        log.warn("wiki", "page-edit toolResult publish skipped", { slug, reason: outcome.reason });
-      }
-    } catch (err) {
-      log.warn("wiki", "page-edit toolResult publish failed", {
-        slug,
-        error: errorMessage(err),
-      });
-    }
+    await publishPageEditToolResult(sessionId, slug, stamp);
   }
 
   res.json({ slug, ok: true });
-});
+}
+
+router.post("/internal/snapshot", async (req: Request<object, unknown, InternalSnapshotBody>, res: Response) => handleInternalSnapshot(req, res));
 
 export default router;

--- a/test/routes/test_mulmoScriptHelpers.ts
+++ b/test/routes/test_mulmoScriptHelpers.ts
@@ -1,7 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { Response } from "express";
-import { withStoryContext } from "../../server/api/routes/mulmo-script.js";
+import type { MulmoBeat } from "@mulmocast/types";
+import { buildBeatIdIndex, withStoryContext } from "../../server/api/routes/mulmo-script.js";
+
+// buildBeatIdIndex only reads `beat.id`; the fixtures pass partial
+// beats cast to MulmoBeat (same convention as fakeContext below).
+const beats = (...ids: (string | undefined)[]): MulmoBeat[] => ids.map((beatId) => ({ id: beatId }) as unknown as MulmoBeat);
 
 interface RecordedResponse {
   statusCode: number;
@@ -230,5 +235,42 @@ describe("withStoryContext — happy path", () => {
       },
     });
     assert.equal(seenForce, false);
+  });
+});
+
+describe("buildBeatIdIndex", () => {
+  it("maps each beat's id to its array index", () => {
+    const index = buildBeatIdIndex(beats("intro", "body", "outro"));
+    assert.deepEqual(
+      [...index.entries()],
+      [
+        ["intro", 0],
+        ["body", 1],
+        ["outro", 2],
+      ],
+    );
+  });
+
+  it("falls back to __index__<n> for id-less beats", () => {
+    const index = buildBeatIdIndex(beats(undefined, undefined));
+    assert.equal(index.get("__index__0"), 0);
+    assert.equal(index.get("__index__1"), 1);
+  });
+
+  it("mixes explicit ids and synthetic fallbacks", () => {
+    const index = buildBeatIdIndex(beats("intro", undefined, "outro"));
+    assert.equal(index.get("intro"), 0);
+    assert.equal(index.get("__index__1"), 1);
+    assert.equal(index.get("outro"), 2);
+  });
+
+  it("returns an empty map for no beats", () => {
+    assert.equal(buildBeatIdIndex([]).size, 0);
+  });
+
+  it("keeps the last index when beats share an id", () => {
+    const index = buildBeatIdIndex(beats("dup", "dup"));
+    assert.equal(index.size, 1);
+    assert.equal(index.get("dup"), 1);
   });
 });


### PR DESCRIPTION
## Summary

Behaviour-preserving refactor to clear `max-lines-per-function` ESLint **warnings** (functions longer than 50 non-blank/non-comment lines) on four Express route handlers. Each long route arrow body was moved into a named `async function handleX(req, res, …)` invoked by a thin wrapper `async (req, res) => handleX(req, res)`; genuinely reusable/self-contained pieces were pulled out alongside. No runtime behaviour changed.

Functions extracted / added:
- **`server/api/routes/wiki.ts`** — `handleWikiPost` (moved POST body) + `handlePageAction` (mirrors the existing `handleSaveAction`). Warning at ~L267 cleared.
- **`server/api/routes/wiki/history.ts`** — `handleInternalSnapshot` (moved `/internal/snapshot` body) + `publishPageEditToolResult` (the Stage-3a synthetic-toolResult publish block, comment moved with it). Warning at ~L155 cleared.
- **`server/api/routes/mulmo-script.ts`** — `handleGenerateBeatAudio` (+ named `GenerateBeatAudioBody` interface) and `handleGeneratePdf` (+ shared `runPdfGeneration` core, mirroring the existing `runMovieGeneration`). Also extracted the pure **`buildBeatIdIndex`** helper (deduped from `runMovieGeneration` and the PDF handler). Both warnings (~L560, ~L1030) cleared.
- **`server/api/routes/attachment.ts`** — `handleUploadAttachment` (moved upload body) + `respondWithPptxCompanion` / `respondWithJpegCompanion` (the two conversion branches). Warning at ~L68 cleared.

New tests: 5 cases for the pure `buildBeatIdIndex` in `test/routes/test_mulmoScriptHelpers.ts` (id→index mapping, `__index__<n>` fallback, mixed, empty, duplicate-id last-wins).

## Items to Confirm / Review

- **`runPdfGeneration` restructure**: the PDF `generatePdf` handler previously inlined the `idToIndex` build + `onProgress` closure + `images`→`pdf` pipeline. It now calls a `runPdfGeneration(context, onImageBeatDone)` core that returns `{ ok, outputPath } | { ok, error }` and lets the handler do the `send(...)`. This mirrors how `generateMovie` already uses `runMovieGeneration`. Same wire events are emitted in the same order (`beat_image_done` during the image pass, then `done` / `error`); please confirm the equivalence is acceptable.
- **`buildBeatIdIndex` reused in `runMovieGeneration`**: the identical `idToIndex` block there was replaced with a call to the new helper (behaviour identical, DRY). It's exported solely so the unit test can import it.
- **`publishPageEditToolResult`**: the `if (sessionId …)` guard stays in the handler; the helper takes a definite `sessionId: string`. Try/catch semantics unchanged.

## User Prompt

Refactor the repo to reduce `max-lines-per-function` ESLint warnings (functions longer than 50 lines), behaviour-preserving only, limited to these handlers:
- `server/api/routes/wiki.ts` (one POST route handler, ~55 lines)
- `server/api/routes/wiki/history.ts` (one route handler, ~59 lines)
- `server/api/routes/mulmo-script.ts` (two route handlers, ~51 and ~62 lines)
- `server/api/routes/attachment.ts` (one route handler, ~68 lines)

Method: move each long arrow body into a named `async function handleX(req, res, …)` called from a thin wrapper; where a genuinely pure piece exists (e.g. request parsing/validation) extract it too and add a focused unit test. No `eslint-disable`, no behaviour changes.

## Verification

- `eslint` on all five changed files → 0 problems (no `max-lines-per-function` warnings remain on the targets).
- `tsc -p server/tsconfig.json --noEmit` and `tsc -p test/tsconfig.json --noEmit` → clean.
- Route tests (`test/routes/test_{attachmentUpload_heic,mulmoScriptHelpers,mulmoScriptValidate,wikiHelpers,wikiHistoryRoute,wikiInternalSnapshotRoute,wikiSaveRoute}.ts`) → 146 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor several Express route handlers to reduce their line counts while preserving behavior, and introduce a shared helper for mulmo beat indexing.

New Features:
- Introduce a reusable buildBeatIdIndex helper for mapping mulmo beat IDs to array indices and expose it for reuse and testing.

Enhancements:
- Extract dedicated handler functions for wiki POST actions, internal wiki snapshots, mulmo beat audio generation, mulmo PDF generation, and attachment uploads to satisfy ESLint max-lines-per-function limits.
- Refactor the mulmo PDF generation route to use a shared runPdfGeneration core that mirrors the movie pipeline’s progress reporting and returns structured success/failure results.
- Reuse the buildBeatIdIndex helper within the mulmo movie and PDF pipelines to centralize per-beat ID-to-index mapping logic.
- Factor out attachment upload companion responses into separate helpers for PPTX-to-PDF and unsupported-image-to-JPEG conversions while keeping existing logging and error behavior.

Tests:
- Add unit tests for buildBeatIdIndex covering ID mapping, synthetic index fallbacks, mixed IDs, empty input, and duplicate-ID last-wins behavior.