### PR TITLE
refactor: extract handlers from files.ts routes (lint max-lines)

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { ReadStream, Stats, createReadStream, readFileSync, realpathSync } from "fs";
+import { Dirent, ReadStream, Stats, createReadStream, readFileSync, realpathSync } from "fs";
 import { mkdir, realpath, writeFile } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
@@ -500,6 +500,40 @@ export async function buildTreeAsync(absPath: string, relPath: string, gitFilter
   };
 }
 
+// Map a single directory entry to a shallow TreeNode, applying the
+// same hidden/sensitive/symlink/gitignore filters as the recursive
+// walk. Returns null for entries that should not surface in the UI.
+async function dirEntryToNode(entry: Dirent, absPath: string, relPath: string, localFilter: GitignoreFilter | undefined): Promise<TreeNode | null> {
+  if (HIDDEN_DIRS.has(entry.name)) return null;
+  if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
+  if (entry.isSymbolicLink()) return null;
+  const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
+  if (localFilter) {
+    const testPath = entry.isDirectory() ? `${childRel}/` : childRel;
+    if (localFilter.ignores(testPath)) return null;
+  }
+  const childAbs = path.join(absPath, entry.name);
+  const childStat = await statSafeAsync(childAbs);
+  if (!childStat) return null;
+  if (childStat.isDirectory()) {
+    return {
+      name: entry.name,
+      path: childRel,
+      type: "dir",
+      modifiedMs: childStat.mtimeMs,
+      // No `children` field — caller fetches via another
+      // /api/files/dir call on expand.
+    };
+  }
+  return {
+    name: entry.name,
+    path: childRel,
+    type: "file",
+    size: childStat.size,
+    modifiedMs: childStat.mtimeMs,
+  };
+}
+
 // Shallow variant: return the given directory's immediate children
 // only (no recursion). Used by the lazy-expand endpoint below — the
 // client fetches one level at a time as the user expands nodes,
@@ -522,36 +556,7 @@ export async function listDirShallow(absPath: string, relPath: string, gitFilter
   // root .gitignore (it's for git, not the UI). Pass a fresh empty
   // filter so children pick up THEIR .gitignore files.
   const localFilter = gitFilter ? gitFilter.childForDir(absPath) : new GitignoreFilter();
-  const childPromises: Promise<TreeNode | null>[] = entries.map(async (entry): Promise<TreeNode | null> => {
-    if (HIDDEN_DIRS.has(entry.name)) return null;
-    if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
-    if (entry.isSymbolicLink()) return null;
-    const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
-    if (localFilter) {
-      const testPath = entry.isDirectory() ? `${childRel}/` : childRel;
-      if (localFilter.ignores(testPath)) return null;
-    }
-    const childAbs = path.join(absPath, entry.name);
-    const childStat = await statSafeAsync(childAbs);
-    if (!childStat) return null;
-    if (childStat.isDirectory()) {
-      return {
-        name: entry.name,
-        path: childRel,
-        type: "dir",
-        modifiedMs: childStat.mtimeMs,
-        // No `children` field — caller fetches via another
-        // /api/files/dir call on expand.
-      };
-    }
-    return {
-      name: entry.name,
-      path: childRel,
-      type: "file",
-      size: childStat.size,
-      modifiedMs: childStat.mtimeMs,
-    };
-  });
+  const childPromises = entries.map((entry) => dirEntryToNode(entry, absPath, relPath, localFilter));
   const resolved = await Promise.all(childPromises);
   const children = resolved.filter((childNode): childNode is TreeNode => childNode !== null);
   children.sort((leftChild, rightChild) => {
@@ -583,6 +588,21 @@ router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown,
     serverError(res, "Failed to read workspace");
   }
 });
+
+// Build the gitignore filter chain for `absPath`. Start undefined at
+// the root (the workspace root's .gitignore is for git, not the UI).
+// Once we descend into a sub-dir, childForDir picks up local
+// .gitignore files. Exported for unit tests.
+export function buildGitignoreFilterChain(rootAbs: string, absPath: string): GitignoreFilter | undefined {
+  let filter: GitignoreFilter | undefined;
+  const segments = path.relative(rootAbs, absPath).split(path.sep).filter(Boolean);
+  let walkAbs = rootAbs;
+  for (const seg of segments) {
+    walkAbs = path.join(walkAbs, seg);
+    filter = filter ? filter.childForDir(walkAbs) : new GitignoreFilter().childForDir(walkAbs);
+  }
+  return filter;
+}
 
 // Lazy-expand endpoint. Returns one directory's immediate children
 // (no recursion) so the client can render the tree incrementally.
@@ -629,16 +649,7 @@ router.get(API_ROUTES.files.dir, async (req: Request<object, unknown, unknown, P
     return;
   }
   try {
-    // Build the gitignore filter chain. Start undefined at root
-    // (workspace root .gitignore is for git, not the UI). Once we
-    // descend into a sub-dir, childForDir picks up local .gitignore.
-    let filter: GitignoreFilter | undefined;
-    const segments = path.relative(workspaceReal, absPath).split(path.sep).filter(Boolean);
-    let walkAbs = workspaceReal;
-    for (const seg of segments) {
-      walkAbs = path.join(walkAbs, seg);
-      filter = filter ? filter.childForDir(walkAbs) : new GitignoreFilter().childForDir(walkAbs);
-    }
+    const filter = buildGitignoreFilterChain(workspaceReal, absPath);
     const listing = await listDirShallow(absPath, path.relative(workspaceReal, absPath), filter);
     res.json(listing);
   } catch (err) {
@@ -727,6 +738,45 @@ function resolveAndStatFileByPath<T>(relPath: string, res: Response<T | ErrorRes
   return { relPath, absPath, stat };
 }
 
+// Decide the metadata-only response for a resolved file based on its
+// classified kind and byte size — media/pdf/image return metadata,
+// oversized or binary files return a message, everything else returns
+// null so the caller reads and returns the file as text. Pure;
+// exported for unit tests.
+export function decideContentResponse(kind: ContentKind, meta: { path: string; size: number; modifiedMs: number }): FileContentMeta | null {
+  const { size } = meta;
+  // Audio/video stream via Range requests, so they get the looser
+  // MAX_MEDIA_BYTES cap. Everything else (images/PDFs/binary) is
+  // loaded whole by the browser and stays at MAX_RAW_BYTES.
+  const isStreamingMedia = kind === "audio" || kind === "video";
+  const sizeCap = isStreamingMedia ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
+  if (size > sizeCap) {
+    return {
+      kind: "too-large",
+      ...meta,
+      message: `File too large to preview (${size} bytes)`,
+    };
+  }
+  if (kind === "image" || kind === "pdf" || kind === "audio" || kind === "video") {
+    return { kind, ...meta };
+  }
+  if (kind === "binary") {
+    return {
+      kind: "binary",
+      ...meta,
+      message: "Binary file — preview not supported",
+    };
+  }
+  if (size > MAX_PREVIEW_BYTES) {
+    return {
+      kind: "too-large",
+      ...meta,
+      message: `Text file too large to preview (${size} bytes)`,
+    };
+  }
+  return null;
+}
+
 router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, PathQuery>, res: Response<FileContentResponse | ErrorResponse>) => {
   const requestedPath = getOptionalStringQuery(req, "path") ?? "";
   log.info("files", "GET content: start", { pathPreview: previewSnippet(requestedPath) });
@@ -747,38 +797,9 @@ router.get(API_ROUTES.files.content, (req: Request<object, unknown, unknown, Pat
   };
 
   const kind = classify(absPath);
-  // Audio/video stream via Range requests, so they get the looser
-  // MAX_MEDIA_BYTES cap. Everything else (images/PDFs/binary) is
-  // loaded whole by the browser and stays at MAX_RAW_BYTES.
-  const isStreamingMedia = kind === "audio" || kind === "video";
-  const sizeCap = isStreamingMedia ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
-  if (stat.size > sizeCap) {
-    res.json({
-      kind: "too-large",
-      ...meta,
-      message: `File too large to preview (${stat.size} bytes)`,
-    });
-    return;
-  }
-
-  if (kind === "image" || kind === "pdf" || kind === "audio" || kind === "video") {
-    res.json({ kind, ...meta });
-    return;
-  }
-  if (kind === "binary") {
-    res.json({
-      kind: "binary",
-      ...meta,
-      message: "Binary file — preview not supported",
-    });
-    return;
-  }
-  if (stat.size > MAX_PREVIEW_BYTES) {
-    res.json({
-      kind: "too-large",
-      ...meta,
-      message: `Text file too large to preview (${stat.size} bytes)`,
-    });
+  const preview = decideContentResponse(kind, meta);
+  if (preview) {
+    res.json(preview);
     return;
   }
   let content: string;
@@ -966,6 +987,56 @@ async function resolveNewFilePath(
   return { ok: true, absPath: finalAbs, workspaceRoot: rootAsync };
 }
 
+// Perform the exclusive create write for POST /files/create. Atomic
+// create via `wx` (POSIX O_EXCL) — fails with EEXIST if the target
+// already exists, closing the check-then-write TOCTOU that Codex
+// flagged on earlier iterations. Wiki pages route through
+// `writeWikiPage` with `exclusive: true` so the same exclusive
+// primitive applies after the frontmatter stamp. On failure this
+// writes the appropriate 4xx/5xx response and returns false; the
+// caller bails.
+async function performCreateWrite(
+  resolved: { absPath: string; workspaceRoot: string },
+  content: string,
+  relPath: string,
+  res: Response<WriteContentResponse | ErrorResponse>,
+): Promise<boolean> {
+  try {
+    // `resolved.workspaceRoot` is the async-realpath form, matching
+    // `resolved.absPath`'s form. Passing the sync-form `workspaceReal`
+    // would make `classifyAsWikiPage` fail to match the prefix on
+    // Windows (8.3 short-name vs. long-name) — we'd fall into the
+    // plain-file branch and skip the wiki frontmatter stamp.
+    const wikiClass = classifyAsWikiPage(resolved.absPath, { workspaceRoot: resolved.workspaceRoot });
+    if (wikiClass.wiki) {
+      await writeWikiPage(wikiClass.slug, content, { editor: "user" }, { workspaceRoot: resolved.workspaceRoot, exclusive: true });
+    } else {
+      await mkdir(path.dirname(resolved.absPath), { recursive: true });
+      await writeFile(resolved.absPath, content, { flag: "wx" });
+    }
+  } catch (err) {
+    const { code } = err as { code?: string };
+    if (code === "EEXIST") {
+      log.warn("files", "POST create: conflict", { pathPreview: previewSnippet(relPath) });
+      sendError(res, 409, "File already exists");
+      return false;
+    }
+    // EISDIR: the target path already exists as a directory. That's
+    // a client-visible conflict (you can't replace a dir with a
+    // file via this endpoint), not a server error. Maps to the same
+    // 409 lane so the inline UI shows the localised "exists" copy.
+    if (code === "EISDIR") {
+      log.warn("files", "POST create: target is a directory", { pathPreview: previewSnippet(relPath) });
+      sendError(res, 409, "Target is a directory");
+      return false;
+    }
+    log.error("files", "POST create: write threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
+    serverError(res, "Failed to create file");
+    return false;
+  }
+  return true;
+}
+
 // Create a new text file. Refuses to overwrite — that's PUT's job and
 // requires a separate explicit-overwrite UX. Used by the File
 // Explorer's "New file" context menu (#1598) where the client already
@@ -992,44 +1063,8 @@ router.post(API_ROUTES.files.create, async (req: Request<object, unknown, WriteC
     badRequest(res, jsonError);
     return;
   }
-  // Atomic create: `wx` (POSIX O_EXCL) — fails with EEXIST if the
-  // target already exists, closing the check-then-write TOCTOU that
-  // Codex flagged on earlier iterations. Wiki pages route through
-  // `writeWikiPage` with `exclusive: true` so the same exclusive
-  // primitive applies after the frontmatter stamp.
-  try {
-    // `resolved.workspaceRoot` is the async-realpath form, matching
-    // `resolved.absPath`'s form. Passing the sync-form `workspaceReal`
-    // would make `classifyAsWikiPage` fail to match the prefix on
-    // Windows (8.3 short-name vs. long-name) — we'd fall into the
-    // plain-file branch and skip the wiki frontmatter stamp.
-    const wikiClass = classifyAsWikiPage(resolved.absPath, { workspaceRoot: resolved.workspaceRoot });
-    if (wikiClass.wiki) {
-      await writeWikiPage(wikiClass.slug, content, { editor: "user" }, { workspaceRoot: resolved.workspaceRoot, exclusive: true });
-    } else {
-      await mkdir(path.dirname(resolved.absPath), { recursive: true });
-      await writeFile(resolved.absPath, content, { flag: "wx" });
-    }
-  } catch (err) {
-    const { code } = err as { code?: string };
-    if (code === "EEXIST") {
-      log.warn("files", "POST create: conflict", { pathPreview: previewSnippet(relPath) });
-      sendError(res, 409, "File already exists");
-      return;
-    }
-    // EISDIR: the target path already exists as a directory. That's
-    // a client-visible conflict (you can't replace a dir with a
-    // file via this endpoint), not a server error. Maps to the same
-    // 409 lane so the inline UI shows the localised "exists" copy.
-    if (code === "EISDIR") {
-      log.warn("files", "POST create: target is a directory", { pathPreview: previewSnippet(relPath) });
-      sendError(res, 409, "Target is a directory");
-      return;
-    }
-    log.error("files", "POST create: write threw", { pathPreview: previewSnippet(relPath), error: errorMessage(err) });
-    serverError(res, "Failed to create file");
-    return;
-  }
+  const created = await performCreateWrite(resolved, content, relPath, res);
+  if (!created) return;
   const fresh = await statSafeAsync(resolved.absPath);
   log.info("files", "POST create: ok", {
     pathPreview: previewSnippet(relPath),

--- a/test/routes/test_filesRouteHelpers.ts
+++ b/test/routes/test_filesRouteHelpers.ts
@@ -1,0 +1,108 @@
+// Unit tests for the pure helpers extracted from the `/api/files`
+// route handlers: `buildGitignoreFilterChain` (walks the .gitignore
+// chain from the workspace root down to a directory) and
+// `decideContentResponse` (maps a classified file kind + byte size to
+// the metadata-only preview response, or null to read as text).
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { buildGitignoreFilterChain, decideContentResponse } from "../../server/api/routes/files.js";
+
+const KIB = 1024;
+const MIB = 1024 * KIB;
+const MAX_PREVIEW_BYTES = MIB;
+const MAX_RAW_BYTES = 50 * MIB;
+
+const META = { path: "dir/file.bin", size: 0, modifiedMs: 42 };
+const metaOf = (size: number) => ({ ...META, size });
+
+describe("buildGitignoreFilterChain", () => {
+  let root: string;
+
+  before(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "files-gitignore-"));
+    // root/.gitignore is intentionally IGNORED by the chain (the
+    // workspace root .gitignore is for git, not the Files UI).
+    await writeFile(path.join(root, ".gitignore"), "*.secret\n");
+    await mkdir(path.join(root, "a", "b"), { recursive: true });
+    await writeFile(path.join(root, "a", ".gitignore"), "*.log\n");
+    await writeFile(path.join(root, "a", "b", ".gitignore"), "*.tmp\n");
+  });
+
+  after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns undefined when the target IS the root (no segments to walk)", () => {
+    assert.equal(buildGitignoreFilterChain(root, root), undefined);
+  });
+
+  it("applies a sub-directory's own .gitignore", () => {
+    const filter = buildGitignoreFilterChain(root, path.join(root, "a"));
+    assert.ok(filter);
+    assert.equal(filter.ignores("a/debug.log"), true);
+    assert.equal(filter.ignores("a/debug.txt"), false);
+  });
+
+  it("inherits parent-directory rules down the chain", () => {
+    const filter = buildGitignoreFilterChain(root, path.join(root, "a", "b"));
+    assert.ok(filter);
+    // From a/.gitignore (inherited) and b/.gitignore (local).
+    assert.equal(filter.ignores("a/b/keep.log"), true);
+    assert.equal(filter.ignores("a/b/scratch.tmp"), true);
+    assert.equal(filter.ignores("a/b/keep.md"), false);
+  });
+
+  it("does NOT apply the workspace root .gitignore", () => {
+    const filter = buildGitignoreFilterChain(root, path.join(root, "a"));
+    assert.ok(filter);
+    assert.equal(filter.ignores("a/token.secret"), false);
+  });
+});
+
+describe("decideContentResponse", () => {
+  it("returns null for small text so the caller reads it as text", () => {
+    assert.equal(decideContentResponse("text", metaOf(100)), null);
+  });
+
+  it("returns null for text at exactly the preview byte cap (strict >)", () => {
+    assert.equal(decideContentResponse("text", metaOf(MAX_PREVIEW_BYTES)), null);
+  });
+
+  it("returns metadata-only (no message) for previewable media kinds", () => {
+    for (const kind of ["image", "pdf", "audio", "video"] as const) {
+      const result = decideContentResponse(kind, metaOf(100));
+      assert.ok(result);
+      assert.equal(result.kind, kind);
+      assert.equal("message" in result, false);
+      assert.equal(result.path, META.path);
+      assert.equal(result.modifiedMs, META.modifiedMs);
+    }
+  });
+
+  it("returns a binary message for binary files", () => {
+    const result = decideContentResponse("binary", metaOf(100));
+    assert.ok(result);
+    assert.equal(result.kind, "binary");
+    assert.equal(result.message, "Binary file — preview not supported");
+  });
+
+  it("flags oversized text with the text-specific message", () => {
+    const size = 2 * MIB; // above preview cap, below the raw cap
+    const result = decideContentResponse("text", metaOf(size));
+    assert.ok(result);
+    assert.equal(result.kind, "too-large");
+    assert.equal(result.message, `Text file too large to preview (${size} bytes)`);
+  });
+
+  it("flags files past the raw byte cap with the generic message", () => {
+    const size = MAX_RAW_BYTES + 1;
+    const result = decideContentResponse("image", metaOf(size));
+    assert.ok(result);
+    assert.equal(result.kind, "too-large");
+    assert.equal(result.message, `File too large to preview (${size} bytes)`);
+  });
+});


### PR DESCRIPTION
## Summary

Behaviour-preserving cleanup that clears the four `max-lines-per-function` ESLint **warnings** in `server/api/routes/files.ts` (functions over 50 lines). Each fix moves a coherent sub-block into a named helper — code is **moved, not rewritten** — so every original code path and response is preserved.

| Flagged function | Was | Extracted helper |
|---|---|---|
| `listDirShallow` (async) | 54 | `dirEntryToNode` — the per-entry → `TreeNode` mapping (hidden/sensitive/symlink/gitignore filters + stat) |
| `GET /files/dir` handler | 52 | `buildGitignoreFilterChain(rootAbs, absPath)` — **pure**, exported for tests (parameterised on root so it's testable against a fixture) |
| `GET /files/content` handler | 56 | `decideContentResponse(kind, meta)` — **pure**, exported; maps classified kind + byte size to the metadata-only response (or `null` to read as text). Each `res.json({...})` body moved verbatim into a `return {...}` |
| `POST /files/create` handler | 56 | `performCreateWrite(...)` — the wiki-aware exclusive (`wx`) write + EEXIST/EISDIR/error mapping; returns `false` after writing the error response so the caller bails |

No function was skipped — all four extracted cleanly.

## Items to Confirm / Review

- **`decideContentResponse` response-shape fidelity**: for `image`/`pdf`/`audio`/`video` it returns `{ kind, ...meta }` with **no** `message` field (matching the pre-refactor `res.json`); `too-large`/`binary` include the same message strings. Please sanity-check that the two distinct "too large" messages ("File too large to preview" for the media/raw cap vs. "Text file too large to preview" for the 1 MB preview cap) still map to the same branches.
- **`performCreateWrite` bail semantics**: it returns `false` on EEXIST (409), EISDIR (409), and other errors (500), each after writing the response — the handler does `if (!created) return;` before the success `stat`/`res.json`. Equivalent to the old inline `return` statements.
- The existing `err as { code?: string }` cast in the create write path was moved verbatim (not introduced here).

## Behaviour preservation

- Existing route tests are the safety net and all pass unchanged: `test/routes/test_filesRoute.ts`, `test_filesRoute_open.ts`, `test_filesCreateRoute.ts`, `test_filesPutRoute.ts`, `test_filesTreeAsync.ts` (102 tests).
- Added `test/routes/test_filesRouteHelpers.ts` with 10 focused unit tests for the two **pure** exported helpers (`buildGitignoreFilterChain`, `decideContentResponse`), including boundary cases (byte-cap thresholds, root-.gitignore-skipped, metadata-only vs. message).

## Verification

- `yarn lint` → 0 errors; the four `files.ts` warnings are gone (31 pre-existing warnings elsewhere remain, out of scope).
- `yarn typecheck` → clean.
- `yarn build` → succeeds.
- `npx tsx --test test/routes/test_files*.ts` → 112 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor file routes to extract reusable helpers and add focused tests while preserving existing behavior.

Enhancements:
- Extract a reusable dirEntryToNode helper to map directory entries to shallow tree nodes with consistent filtering.
- Introduce a buildGitignoreFilterChain helper to construct gitignore filter chains for directory listings and reuse it in the /files/dir handler.
- Add a decideContentResponse helper to centralize file content preview decision logic based on content kind and size.
- Extract performCreateWrite to encapsulate exclusive file creation behavior and error handling for the /files/create route.

Tests:
- Add unit tests for buildGitignoreFilterChain and decideContentResponse to cover gitignore chaining and file preview boundary cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file browsing and preview handling for more consistent behavior across folders and file types.
  * Streamlined file creation flow for more reliable exclusive creates.

* **Bug Fixes**
  * Fixed directory filtering so hidden items, symlinks, sensitive names, and ignore rules are applied more consistently.
  * Improved preview responses for images, PDFs, audio, video, binary files, and oversized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->