### PR TITLE
refactor: shrink createTaskManager (lint max-lines)

### DIFF
--- a/packages/core/src/scheduler/task-manager.ts
+++ b/packages/core/src/scheduler/task-manager.ts
@@ -38,6 +38,13 @@ export interface TaskDefinition {
   run: (ctx: TaskRunContext) => Promise<void>;
 }
 
+export interface TaskSummary {
+  id: string;
+  description?: string;
+  schedule: TaskSchedule;
+  dependsOn?: string;
+}
+
 export interface ITaskManager {
   registerTask: (def: TaskDefinition) => void;
   removeTask: (taskId: string) => void;
@@ -47,12 +54,7 @@ export interface ITaskManager {
   stop: () => void;
   /** Run one tick manually (for testing). */
   tick: () => Promise<void>;
-  listTasks: () => {
-    id: string;
-    description?: string;
-    schedule: TaskSchedule;
-    dependsOn?: string;
-  }[];
+  listTasks: () => TaskSummary[];
 }
 
 export interface TaskManagerOptions {
@@ -80,6 +82,79 @@ function isDue(now: Date, schedule: TaskSchedule, tickMs: number): boolean {
   return false;
 }
 
+/** Split the due tasks into those that may run immediately and those gated
+ *  behind a `dependsOn` edge (resolved later in the same tick cycle). */
+export function collectDueTasks(
+  currentTime: Date,
+  registry: Map<string, TaskDefinition>,
+  tickMs: number,
+): { independent: TaskDefinition[]; dependent: TaskDefinition[] } {
+  const independent: TaskDefinition[] = [];
+  const dependent: TaskDefinition[] = [];
+  for (const def of registry.values()) {
+    if (def.enabled === false) continue;
+    if (!isDue(currentTime, def.schedule, tickMs)) continue;
+    if (def.dependsOn) {
+      dependent.push(def);
+    } else {
+      independent.push(def);
+    }
+  }
+  return { independent, dependent };
+}
+
+async function runAndTrack(def: TaskDefinition, currentTime: Date, succeeded: Set<string>, log: SchedulerLogger): Promise<void> {
+  try {
+    await def.run({ taskId: def.id, now: currentTime });
+    succeeded.add(def.id);
+  } catch (err) {
+    log.error("task failed", {
+      id: def.id,
+      error: String(err),
+    });
+  }
+}
+
+async function runDependentChain(dependent: TaskDefinition[], currentTime: Date, succeeded: Set<string>, log: SchedulerLogger): Promise<void> {
+  let remaining = [...dependent];
+  let progress = true;
+  while (remaining.length > 0 && progress) {
+    progress = false;
+    const next: TaskDefinition[] = [];
+    for (const def of remaining) {
+      const dep = def.dependsOn;
+      if (!dep || !succeeded.has(dep)) {
+        next.push(def);
+        continue;
+      }
+      await runAndTrack(def, currentTime, succeeded, log);
+      progress = true;
+    }
+    remaining = next;
+  }
+}
+
+async function runTick(now: () => Date, registry: Map<string, TaskDefinition>, tickMs: number, log: SchedulerLogger): Promise<void> {
+  const currentTime = now();
+  const { independent, dependent } = collectDueTasks(currentTime, registry, tickMs);
+
+  // Per-invocation set — success does not leak across tick() calls.
+  const succeeded = new Set<string>();
+
+  await Promise.all(independent.map((def) => runAndTrack(def, currentTime, succeeded, log)));
+
+  await runDependentChain(dependent, currentTime, succeeded, log);
+}
+
+export function listTaskSummaries(registry: Map<string, TaskDefinition>): TaskSummary[] {
+  return [...registry.values()].map((taskDef) => ({
+    id: taskDef.id,
+    description: taskDef.description,
+    schedule: taskDef.schedule,
+    dependsOn: taskDef.dependsOn,
+  }));
+}
+
 export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
   const tickMs = options?.tickMs ?? ONE_MINUTE_MS;
   const now = options?.now ?? (() => new Date());
@@ -87,66 +162,7 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
   const registry = new Map<string, TaskDefinition>();
   let timer: ReturnType<typeof setInterval> | null = null;
 
-  function collectDueTasks(currentTime: Date): {
-    independent: TaskDefinition[];
-    dependent: TaskDefinition[];
-  } {
-    const independent: TaskDefinition[] = [];
-    const dependent: TaskDefinition[] = [];
-    for (const def of registry.values()) {
-      if (def.enabled === false) continue;
-      if (!isDue(currentTime, def.schedule, tickMs)) continue;
-      if (def.dependsOn) {
-        dependent.push(def);
-      } else {
-        independent.push(def);
-      }
-    }
-    return { independent, dependent };
-  }
-
-  async function runAndTrack(def: TaskDefinition, currentTime: Date, succeeded: Set<string>): Promise<void> {
-    try {
-      await def.run({ taskId: def.id, now: currentTime });
-      succeeded.add(def.id);
-    } catch (err) {
-      log.error("task failed", {
-        id: def.id,
-        error: String(err),
-      });
-    }
-  }
-
-  async function runDependentChain(dependent: TaskDefinition[], currentTime: Date, succeeded: Set<string>): Promise<void> {
-    let remaining = [...dependent];
-    let progress = true;
-    while (remaining.length > 0 && progress) {
-      progress = false;
-      const next: TaskDefinition[] = [];
-      for (const def of remaining) {
-        const dep = def.dependsOn;
-        if (!dep || !succeeded.has(dep)) {
-          next.push(def);
-          continue;
-        }
-        await runAndTrack(def, currentTime, succeeded);
-        progress = true;
-      }
-      remaining = next;
-    }
-  }
-
-  async function onTick(): Promise<void> {
-    const currentTime = now();
-    const { independent, dependent } = collectDueTasks(currentTime);
-
-    // Per-invocation set — success does not leak across tick() calls.
-    const succeeded = new Set<string>();
-
-    await Promise.all(independent.map((def) => runAndTrack(def, currentTime, succeeded)));
-
-    await runDependentChain(dependent, currentTime, succeeded);
-  }
+  const onTick = () => runTick(now, registry, tickMs, log);
 
   return {
     async tick() {
@@ -190,12 +206,7 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
     },
 
     listTasks() {
-      return [...registry.values()].map((taskDef) => ({
-        id: taskDef.id,
-        description: taskDef.description,
-        schedule: taskDef.schedule,
-        dependsOn: taskDef.dependsOn,
-      }));
+      return listTaskSummaries(registry);
     },
   };
 }

--- a/packages/core/test/scheduler/test_scheduler.ts
+++ b/packages/core/test/scheduler/test_scheduler.ts
@@ -19,6 +19,7 @@ import {
   type TaskDefinition,
   type SystemTaskDef,
 } from "../../src/scheduler/index.ts";
+import { collectDueTasks, listTaskSummaries } from "../../src/scheduler/task-manager.ts";
 
 const stubTm = (over: Partial<ITaskManager>): ITaskManager => ({
   registerTask: () => {},
@@ -98,6 +99,46 @@ test("registerTask rejects duplicate ids; updateSchedule returns false for unkno
   assert.throws(() => manager.registerTask({ id: "a", schedule: { type: SCHEDULE_TYPES.daily, time: "10:00" }, run: async () => {} }));
   assert.equal(manager.updateSchedule("missing", { type: SCHEDULE_TYPES.daily, time: "10:00" }), false);
   assert.equal(manager.updateSchedule("a", { type: SCHEDULE_TYPES.daily, time: "10:00" }), true);
+});
+
+// ── pure helpers extracted from createTaskManager ─────────────────
+
+const makeDef = (over: Partial<TaskDefinition> & { id: string }): TaskDefinition => ({
+  schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 60_000 },
+  run: async () => {},
+  ...over,
+});
+
+test("listTaskSummaries strips run and keeps the summary fields", () => {
+  const registry = new Map<string, TaskDefinition>();
+  assert.deepEqual(listTaskSummaries(registry), []);
+  registry.set("a", makeDef({ id: "a", description: "d", dependsOn: "b" }));
+  const [summary] = listTaskSummaries(registry);
+  assert.deepEqual(summary, {
+    id: "a",
+    description: "d",
+    schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 60_000 },
+    dependsOn: "b",
+  });
+  assert.equal("run" in summary, false);
+});
+
+test("collectDueTasks partitions due tasks and skips disabled/not-due", () => {
+  const midnight = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+  const registry = new Map<string, TaskDefinition>();
+  registry.set("indep", makeDef({ id: "indep" }));
+  registry.set("dep", makeDef({ id: "dep", dependsOn: "indep" }));
+  registry.set("off", makeDef({ id: "off", enabled: false }));
+  registry.set("notDue", makeDef({ id: "notDue", schedule: { type: SCHEDULE_TYPES.daily, time: "09:00" } }));
+  const { independent, dependent } = collectDueTasks(midnight, registry, 60_000);
+  assert.deepEqual(
+    independent.map((def) => def.id),
+    ["indep"],
+  );
+  assert.deepEqual(
+    dependent.map((def) => def.id),
+    ["dep"],
+  );
 });
 
 // ── adapter (catch-up + persistence + state) ──────────────────────


### PR DESCRIPTION
## Summary

Clears the single `max-lines-per-function` ESLint warning on `packages/core/src/scheduler/task-manager.ts` (`createTaskManager` was 104 counted lines, max 50). Behaviour-preserving refactor only — no logic rewritten.

What changed:
- Moved the nested tick-engine helpers (`collectDueTasks`, `runAndTrack`, `runDependentChain`, and `onTick`→`runTick`) out of `createTaskManager` to module scope. The closure state they used (`registry`, `tickMs`, `log`, `now`) is now threaded in as explicit params instead of captured variables. Code moved verbatim; rationale comments moved with it.
- `createTaskManager` keeps a one-line `const onTick = () => runTick(...)` so `tick()` and `start()` still share the same thunk (no duplication, identical behaviour).
- Extracted the pure `listTaskSummaries(registry)` mapping (the old `listTasks` body).
- Named the `listTasks` inline return type as `TaskSummary` (structurally identical) to avoid duplicating the shape and to type the new pure helper without `any`.
- Added focused `node:test` unit tests for the two pure extractions (`collectDueTasks`, `listTaskSummaries`).

Verification (run via the parent repo's binaries — the worktree has no `node_modules`):
- `eslint` on the file → clean; scoped lint (`src server test e2e e2e-live packages`) → 0 errors (22 pre-existing warnings, none in this file).
- `tsc --noEmit` on `packages/core` → clean.
- `vite build` (cjs + esm) for `@mulmoclaude/core` → succeeds.
- Behaviour-preservation net: `packages/core/test/scheduler/test_scheduler.ts` (9 tests incl. 2 new), `test/plugins/test_runtime_loader_factory.ts`, `test/events/test_task_dependencies.ts`, `test/skills/test_skill_scheduler.ts` → all pass.

## Items to Confirm / Review

- **`TaskSummary` type addition + `ITaskManager.listTasks` return type change.** The inline object-array return type was replaced with a named `export interface TaskSummary`. It is structurally identical, so consumers of `@mulmoclaude/core/scheduler` are unaffected — please confirm you're OK with the new exported type name (and the newly-exported `collectDueTasks` / `listTaskSummaries` helpers, exported so the unit tests can reach them).
- **Threading `log` / `registry` / `tickMs` / `now` as params** instead of closures: verify the extracted helpers preserve exact ordering/error semantics (independent tasks via `Promise.all`, dependent chain resolved iteratively, per-tick `succeeded` set not leaking across `tick()` calls).

## User Prompt

Refactor to reduce ONE `max-lines-per-function` ESLint warning, behaviour-preserving only, scoped to `packages/core/src/scheduler/task-manager.ts` → `createTaskManager`. Extract coherent sub-blocks into named helpers so the factory drops under 50 lines; move code rather than rewrite it; thread closure state in as explicit params or keep closures but extract pure/leaf pieces; prefer a genuinely pure extraction and add a focused unit test for it. Never `eslint-disable`, never change behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor the task scheduler’s task manager to extract reusable helpers, reduce the size of createTaskManager, and add tests for the new pure functions while preserving behavior.

New Features:
- Introduce an exported TaskSummary interface to represent the shape of task listing entries.
- Expose collectDueTasks and listTaskSummaries helper functions from the scheduler task manager module.

Enhancements:
- Refactor createTaskManager by moving tick-processing helpers to module scope and delegating to a shared runTick function.
- Simplify listTasks implementation to delegate to the new listTaskSummaries helper while keeping its public behavior unchanged.

Tests:
- Add focused unit tests for listTaskSummaries to verify it returns only summary fields and omits the run function.
- Add focused unit tests for collectDueTasks to verify correct partitioning of due, dependent, and skipped tasks.