### PR TITLE
refactor: split startRuntimeServices boot phases (lint max-lines)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -954,19 +954,7 @@ function maybeForceChatIndexBackfill(): void {
     .catch(logBackgroundError("chat-index", "forced startup backfill failed"));
 }
 
-async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: number, pubsub: IPubSub): Promise<void> {
-  log.info("server", "listening", { port });
-
-  // The notifier engine + its pubsub are now wired in the listen
-  // callback (see PR-#1196 follow-up) so requests arriving before
-  // this function runs hit a fully-initialized engine. The pubsub
-  // is forwarded in here so the rest of `startRuntimeServices` can
-  // share the same instance.
-
-  // macOS Reminder adapter wiring lives in the `app.listen` callback,
-  // alongside `initNotifier`, so it's subscribed before the first
-  // await opens a publish-can-fire-but-no-one's-listening window.
-
+async function initBootDiagnostics(): Promise<void> {
   // --- Plugin META aggregator diagnostics ---
   // After the notifier engine is initialized so the wrapper has a
   // working sink. Surfaces any host/plugin or plugin/plugin key
@@ -1005,7 +993,9 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
   startCollectionWatchers().catch((err: unknown) => {
     log.warn("collections", "watcher boot failed", { error: String(err) });
   });
+}
 
+function attachTransports(httpServer: ReturnType<typeof app.listen>, pubsub: IPubSub): void {
   // --- Chat socket transport (Phase A of #268) ---
   chatService.attachSocket(httpServer);
 
@@ -1021,113 +1011,101 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
 
   // --- Session Store ---
   initSessionStore(pubsub);
+}
 
-  // --- Task Manager ---
-  // Created BEFORE the runtime plugins block so plugin runtimes
-  // (which receive `taskManager` via `MakePluginRuntimeDeps`) can
-  // close over it. The `void (async () => ...)()` IIFE below would
-  // also work via async-yield ordering, but the lint rule forbids
-  // closing over a variable declared later in the same scope.
-  const taskManager = createTaskManager({
-    tickMs: debugMode ? ONE_SECOND_MS : ONE_MINUTE_MS,
-  });
-
-  if (debugMode) {
-    registerDebugTasks(taskManager, pubsub);
-  }
-
-  // --- Runtime plugins (#1043 C-2 + #1110) ---
-  // Two sources of plugins, same RuntimePlugin shape:
-  //   1. Presets — server/plugins/preset-list.ts (loaded from node_modules)
-  //   2. User-installed — ~/mulmoclaude/plugins/plugins.json ledger
-  //
-  // Presets are merged FIRST so they win runtime-vs-runtime collision
-  // (first-loaded wins; static MCP built-ins still win over both via
-  // MCP_PLUGIN_NAMES).
-  //
-  // Factory-shape plugins (`export default definePlugin(...)`) receive a
-  // runtime constructed by `makePluginRuntime(...)` which closes over the
-  // live pubsub. Legacy `(context, args)` plugins are loaded unchanged.
-  //
-  // Failures don't abort boot — bad plugins are skipped, healthy ones
-  // still load.
-  void (async () => {
-    try {
-      const runtimeFactory = (pkgName: string) =>
-        makePluginRuntime({
-          pkgName,
-          pubsub,
-          // v1: server-side locale is a static snapshot. The frontend
-          // BrowserPluginRuntime carries the reactive ref. Future
-          // enhancement: per-request locale from Accept-Language.
-          locale: process.env.LANG?.split(/[._]/)[0] || "en",
-          // `taskManager` is created synchronously below (see "Task
-          // Manager" block) before this async IIFE awaits and yields.
-          // By the time `runtimeFactory(pkgName)` is invoked from
-          // inside `loadPresetPlugins` / `loadRuntimePlugins` /
-          // `loadDevPlugins`, the synchronous initialisation has
-          // completed and `taskManager` is ready. Backs
-          // `runtime.tasks.register()` (Phase 1 of the Encore plan).
-          taskManager,
-        });
-      const [presets, userInstalled, devLoad] = await Promise.all([
-        loadPresetPlugins({ runtimeFactory }),
-        loadRuntimePlugins({ runtimeFactory }),
-        loadDevPlugins(parseDevPluginsEnv(process.env.MULMOCLAUDE_DEV_PLUGINS, process.cwd()), { runtimeFactory }),
-      ]);
-      // Dev plugin failures (missing dist/index.js, broken package.json,
-      // …) are a setup error the dev needs to see and fix. Hard-exit
-      // so the developer can't accidentally trial-and-error against a
-      // server that silently dropped their plugin. Same policy for
-      // collisions per #1159 PR2 spec.
-      const devGate = evaluateDevPluginGate(devLoad, [...presets, ...userInstalled]);
-      if (!devGate.ok) {
-        for (const message of devGate.fatalMessages) log.error("plugins/dev", message);
-        process.exit(1);
-      }
-      // Auto-reload (#1159 PR3): watch each dev plugin's dist/ and
-      // publish on debounced change so the browser refreshes without
-      // ⌘R. Server-side `dist/index.js` cannot be hot-replaced (Node
-      // ESM cache), so the watcher logs an explicit hint when that
-      // file is in the changed set.
-      if (devLoad.plugins.length > 0) {
-        const handle = watchDevPlugins(devLoad.plugins, {
-          publish: (name, payload) =>
-            pubsub.publish(PUBSUB_CHANNELS.devPluginChanged, {
-              name,
-              changedFiles: payload.changedFiles,
-              serverSideChange: payload.serverSideChange,
-            }),
-          warnServerSideChange: (name) => log.warn("plugins/dev", `${name}: dist/index.js changed — restart mulmoclaude to pick up server-side changes`),
-          onWatcherError: (name, error) =>
-            log.warn("plugins/dev", `${name}: watcher error — auto-reload disabled for this plugin until restart`, { error: String(error) }),
-        });
-        registerShutdownHook(() => handle.close());
-      }
-      // Pass the full static-tool set (MCP plugins + ENABLED MCP tools
-      // like readXPost / searchX) as the collision policy so the floor
-      // matches the standalone mcp-server's STATIC_TOOL_NAMES exactly
-      // (#1077 / #1116 review). Filter via `isMcpToolEnabled` so the
-      // child process's `mcpToolDefs` (only enabled tools) and the
-      // parent's reservation set agree — otherwise a runtime plugin
-      // colliding with a disabled tool would be rejected here but
-      // accepted by the child, and the child's `/dispatch` would 404
-      // because the parent never registered a route for it.
-      const staticToolNames = new Set([...MCP_PLUGIN_NAMES, ...mcpTools.filter(isMcpToolEnabled).map((tool) => tool.definition.name)]);
-      const result = registerRuntimePlugins(staticToolNames, [...presets, ...userInstalled, ...devLoad.plugins]);
-      log.info("plugins/runtime", "registered runtime plugins", {
-        presets: presets.length,
-        userInstalled: userInstalled.length,
-        dev: devLoad.plugins.length,
-        registered: result.registered.length,
-        collisions: result.collisions.length,
-        oauthAliasCollisions: result.oauthAliasCollisions.length,
+// --- Runtime plugins (#1043 C-2 + #1110) ---
+// Two sources of plugins, same RuntimePlugin shape:
+//   1. Presets — server/plugins/preset-list.ts (loaded from node_modules)
+//   2. User-installed — ~/mulmoclaude/plugins/plugins.json ledger
+//
+// Presets are merged FIRST so they win runtime-vs-runtime collision
+// (first-loaded wins; static MCP built-ins still win over both via
+// MCP_PLUGIN_NAMES).
+//
+// Factory-shape plugins (`export default definePlugin(...)`) receive a
+// runtime constructed by `makePluginRuntime(...)` which closes over the
+// live pubsub. Legacy `(context, args)` plugins are loaded unchanged.
+//
+// Failures don't abort boot — bad plugins are skipped, healthy ones
+// still load.
+async function loadRuntimePluginsFor(pubsub: IPubSub, taskManager: ITaskManager): Promise<void> {
+  try {
+    const runtimeFactory = (pkgName: string) =>
+      makePluginRuntime({
+        pkgName,
+        pubsub,
+        // v1: server-side locale is a static snapshot. The frontend
+        // BrowserPluginRuntime carries the reactive ref. Future
+        // enhancement: per-request locale from Accept-Language.
+        locale: process.env.LANG?.split(/[._]/)[0] || "en",
+        // `taskManager` is created synchronously below (see "Task
+        // Manager" block) before this async IIFE awaits and yields.
+        // By the time `runtimeFactory(pkgName)` is invoked from
+        // inside `loadPresetPlugins` / `loadRuntimePlugins` /
+        // `loadDevPlugins`, the synchronous initialisation has
+        // completed and `taskManager` is ready. Backs
+        // `runtime.tasks.register()` (Phase 1 of the Encore plan).
+        taskManager,
       });
-    } catch (err) {
-      log.error("plugins/runtime", "registry init failed; runtime plugins disabled this session", { error: String(err) });
+    const [presets, userInstalled, devLoad] = await Promise.all([
+      loadPresetPlugins({ runtimeFactory }),
+      loadRuntimePlugins({ runtimeFactory }),
+      loadDevPlugins(parseDevPluginsEnv(process.env.MULMOCLAUDE_DEV_PLUGINS, process.cwd()), { runtimeFactory }),
+    ]);
+    // Dev plugin failures (missing dist/index.js, broken package.json,
+    // …) are a setup error the dev needs to see and fix. Hard-exit
+    // so the developer can't accidentally trial-and-error against a
+    // server that silently dropped their plugin. Same policy for
+    // collisions per #1159 PR2 spec.
+    const devGate = evaluateDevPluginGate(devLoad, [...presets, ...userInstalled]);
+    if (!devGate.ok) {
+      for (const message of devGate.fatalMessages) log.error("plugins/dev", message);
+      process.exit(1);
     }
-  })();
+    // Auto-reload (#1159 PR3): watch each dev plugin's dist/ and
+    // publish on debounced change so the browser refreshes without
+    // ⌘R. Server-side `dist/index.js` cannot be hot-replaced (Node
+    // ESM cache), so the watcher logs an explicit hint when that
+    // file is in the changed set.
+    if (devLoad.plugins.length > 0) {
+      const handle = watchDevPlugins(devLoad.plugins, {
+        publish: (name, payload) =>
+          pubsub.publish(PUBSUB_CHANNELS.devPluginChanged, {
+            name,
+            changedFiles: payload.changedFiles,
+            serverSideChange: payload.serverSideChange,
+          }),
+        warnServerSideChange: (name) => log.warn("plugins/dev", `${name}: dist/index.js changed — restart mulmoclaude to pick up server-side changes`),
+        onWatcherError: (name, error) =>
+          log.warn("plugins/dev", `${name}: watcher error — auto-reload disabled for this plugin until restart`, { error: String(error) }),
+      });
+      registerShutdownHook(() => handle.close());
+    }
+    // Pass the full static-tool set (MCP plugins + ENABLED MCP tools
+    // like readXPost / searchX) as the collision policy so the floor
+    // matches the standalone mcp-server's STATIC_TOOL_NAMES exactly
+    // (#1077 / #1116 review). Filter via `isMcpToolEnabled` so the
+    // child process's `mcpToolDefs` (only enabled tools) and the
+    // parent's reservation set agree — otherwise a runtime plugin
+    // colliding with a disabled tool would be rejected here but
+    // accepted by the child, and the child's `/dispatch` would 404
+    // because the parent never registered a route for it.
+    const staticToolNames = new Set([...MCP_PLUGIN_NAMES, ...mcpTools.filter(isMcpToolEnabled).map((tool) => tool.definition.name)]);
+    const result = registerRuntimePlugins(staticToolNames, [...presets, ...userInstalled, ...devLoad.plugins]);
+    log.info("plugins/runtime", "registered runtime plugins", {
+      presets: presets.length,
+      userInstalled: userInstalled.length,
+      dev: devLoad.plugins.length,
+      registered: result.registered.length,
+      collisions: result.collisions.length,
+      oauthAliasCollisions: result.oauthAliasCollisions.length,
+    });
+  } catch (err) {
+    log.error("plugins/runtime", "registry init failed; runtime plugins disabled this session", { error: String(err) });
+  }
+}
 
+function initEventPublishers(pubsub: IPubSub): void {
   // --- File-change publisher ---
   // Wired here (not at first publish) so the very first save after
   // boot already sees a live publisher.
@@ -1136,7 +1114,11 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
   // near the route mount; only the pub/sub instance is wired here.
   initAccountingEventPublisher(pubsub);
   initCollectionChangePublisher(pubsub);
+}
 
+// System task defs + user-configurable schedule overrides. Split out
+// of `registerSystemSchedules` so each stays under the max-lines cap.
+function buildSystemTaskDefs(): SystemTaskDef[] {
   // --- Scheduler (Phase 1 of #357) ---
   // Register system tasks with persistence + catch-up. The journal
   // and chat-index also fire from the agent finally-hook for
@@ -1201,6 +1183,12 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
     }
   }
 
+  return systemTasks;
+}
+
+function registerSystemSchedules(taskManager: ITaskManager): void {
+  const systemTasks = buildSystemTaskDefs();
+
   // Feeds host is configured at module load (before app.listen) — see the
   // `configureFeeds(spawnSystemWorker)` call beside the accounting config — so it
   // is already wired by the time `initScheduler` catch-up can fire a feed refresh.
@@ -1233,6 +1221,44 @@ async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, p
       }
     })
     .catch(logBackgroundError("user-tasks", "failed to register user tasks"));
+}
+
+async function startRuntimeServices(httpServer: ReturnType<typeof app.listen>, port: number, pubsub: IPubSub): Promise<void> {
+  log.info("server", "listening", { port });
+
+  // The notifier engine + its pubsub are now wired in the listen
+  // callback (see PR-#1196 follow-up) so requests arriving before
+  // this function runs hit a fully-initialized engine. The pubsub
+  // is forwarded in here so the rest of `startRuntimeServices` can
+  // share the same instance.
+
+  // macOS Reminder adapter wiring lives in the `app.listen` callback,
+  // alongside `initNotifier`, so it's subscribed before the first
+  // await opens a publish-can-fire-but-no-one's-listening window.
+
+  await initBootDiagnostics();
+
+  attachTransports(httpServer, pubsub);
+
+  // --- Task Manager ---
+  // Created BEFORE the runtime plugins block so plugin runtimes
+  // (which receive `taskManager` via `MakePluginRuntimeDeps`) can
+  // close over it. The `void (async () => ...)()` IIFE below would
+  // also work via async-yield ordering, but the lint rule forbids
+  // closing over a variable declared later in the same scope.
+  const taskManager = createTaskManager({
+    tickMs: debugMode ? ONE_SECOND_MS : ONE_MINUTE_MS,
+  });
+
+  if (debugMode) {
+    registerDebugTasks(taskManager, pubsub);
+  }
+
+  void loadRuntimePluginsFor(pubsub, taskManager);
+
+  initEventPublishers(pubsub);
+
+  registerSystemSchedules(taskManager);
 
   taskManager.start();
 


### PR DESCRIPTION
## Summary

Behaviour-preserving refactor to clear one `max-lines-per-function` ESLint
warning. The boot-orchestration function `server/index.ts` →
`startRuntimeServices` was 143 lines (cap is 50). It is a long *sequence*
of `await initX(...)` / setup calls, so contiguous groups of those calls
were extracted into named helpers invoked **in the exact same order**.

`startRuntimeServices` now reads as a short boot script (~15 executable
lines). Helpers extracted (in call order):

| Helper | Moved from |
|---|---|
| `initBootDiagnostics()` | meta diagnostics, optional-dep probe, voice warm-up, billing migration, collection watchers |
| `attachTransports(httpServer, pubsub)` | chat socket, relay client, session store |
| `loadRuntimePluginsFor(pubsub, taskManager)` | the runtime-plugins IIFE (presets / user-installed / dev load + registration) |
| `initEventPublishers(pubsub)` | file-change / accounting / collection-change publishers |
| `buildSystemTaskDefs()` | system task defs + schedule overrides (pure, returns the array) |
| `registerSystemSchedules(taskManager)` | `initScheduler` + scheduled skills + user tasks |

`buildSystemTaskDefs` was split out of `registerSystemSchedules` so both
extracted helpers also stay under the 50-line cap (the first extraction
left `registerSystemSchedules` at 66 lines).

## Items to Confirm / Review

- **Call order preserved** — this is the load-bearing property. The
  sequence of side effects is byte-for-byte the same: `initBootDiagnostics`
  (awaited) → `attachTransports` → `createTaskManager` → `registerDebugTasks`
  (debug only) → `void loadRuntimePluginsFor` (fire-and-forget, was a
  `void (async () => …)()` IIFE) → `initEventPublishers` →
  `registerSystemSchedules` → `taskManager.start()` →
  `maybeForceJournalRun()` → `maybeForceChatIndexBackfill()`. No `await`
  was reordered.
- **Pure code move** — no logic rewritten. Every comment moved with its
  code. `taskManager` is still created in `startRuntimeServices` and
  threaded explicitly into `loadRuntimePluginsFor` / `registerSystemSchedules`
  / `registerDebugTasks` (previously closed over lexically). The
  runtime-plugins block stays fire-and-forget via `void`.
- One tiny addition beyond the move: a 2-line comment above
  `buildSystemTaskDefs` noting why it is split from `registerSystemSchedules`.

## Verification

- `eslint server/index.ts` → 0 problems (the `startRuntimeServices`
  `max-lines-per-function` warning is gone; no new one introduced).
- `tsc -p server/tsconfig.json --noEmit` → clean (the real gate; the
  server runs via `tsx`, not compiled at `yarn build`).
- `tsc -p test/tsconfig.json --noEmit` → clean.
- Broad server test sweep (`test/routes/*.ts test/agent/*.ts`) → green.
- `server/index.ts` is not compiled by any `yarn build` step
  (`build:packages` / `build:hooks` / `vite build` all exclude it), so the
  build is unaffected.

## User Prompt

Refactor the repo to reduce one `max-lines-per-function` ESLint warning,
behaviour-preserving only: `server/index.ts` → `startRuntimeServices`
(~143 lines), a boot-orchestration function that is a long sequence of
`await initX(...)` / setup calls. Extract contiguous groups of the
sequential setup calls into named `async function initXxx(...)` helpers,
called in the same order, preserving the order of side effects exactly
(no reordered `await`s). Move code, don't rewrite. Thread needed params
explicitly. Get the function under 50 lines. Keep every comment with its
code. Never `eslint-disable`. Never change behaviour or ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)