### PR TITLE
test: extract + cover pure relay-client logic (lint max-lines)

### DIFF
--- a/server/events/relay-client-helpers.ts
+++ b/server/events/relay-client-helpers.ts
@@ -1,0 +1,67 @@
+// Pure helpers for relay-client.ts.
+//
+// Everything here is input → output with no socket / network / timer /
+// I/O and no closure-state mutation, so it can be unit-tested in
+// isolation. The stateful WebSocket + reconnect wiring stays in
+// relay-client.ts.
+
+import type { ChatService } from "@mulmobridge/chat-service";
+
+export interface RelayMessage {
+  id: string;
+  platform: string;
+  senderId: string;
+  chatId: string;
+  text: string;
+  receivedAt: string;
+  replyToken?: string;
+}
+
+type RelayResult = Awaited<ReturnType<ChatService["relay"]>>;
+
+// Close codes that indicate a permanent/terminal error — no point
+// reconnecting until the configuration is fixed.
+const TERMINAL_CLOSE_CODES = new Set([
+  1008, // Policy violation (e.g. auth rejected)
+  4401, // Custom: unauthorized
+  4403, // Custom: forbidden
+]);
+
+export function buildRelayUrl(relayUrl: string, relayToken: string): string {
+  const url = new URL(relayUrl);
+  url.searchParams.set("token", relayToken);
+  return url.toString();
+}
+
+export function nextReconnectMs(currentMs: number, maxMs: number): number {
+  return Math.min(currentMs * 2, maxMs);
+}
+
+export function isTerminalCloseCode(code: number): boolean {
+  return TERMINAL_CLOSE_CODES.has(code);
+}
+
+// Double-underscore separator avoids collisions — platform names are
+// from a fixed set (PLATFORMS constant) and none contain "__". Single
+// "-" is unsafe because "google-chat" + "X" collides with "google" +
+// "chat-X".
+export function buildExternalChatId(platform: string, chatId: string): string {
+  return `${platform}__${chatId}`;
+}
+
+export function isRelayMessage(value: unknown): value is RelayMessage {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === "string" &&
+    typeof obj.platform === "string" &&
+    typeof obj.chatId === "string" &&
+    typeof obj.text === "string" &&
+    obj.text !== "" &&
+    obj.chatId !== ""
+  );
+}
+
+export function formatReplyText(result: RelayResult): string {
+  return result.kind === "ok" ? result.reply : `Error: ${result.message}`;
+}

--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -14,20 +14,11 @@ import type { ChatService } from "@mulmobridge/chat-service";
 import { ONE_SECOND_MS } from "../utils/time.js";
 import { errorMessage } from "../utils/errors.js";
 import { resolveRelayBridgeOptions } from "./resolveRelayBridgeOptions.js";
+import { buildExternalChatId, buildRelayUrl, formatReplyText, isRelayMessage, isTerminalCloseCode, nextReconnectMs } from "./relay-client-helpers.js";
 
 type RelayFn = ChatService["relay"];
 
 // ── Types ────────────────────────────────────────────────────
-
-interface RelayMessage {
-  id: string;
-  platform: string;
-  senderId: string;
-  chatId: string;
-  text: string;
-  receivedAt: string;
-  replyToken?: string;
-}
 
 interface RelayResponse {
   platform: string;
@@ -61,29 +52,6 @@ const MIN_RECONNECT_MS = ONE_SECOND_MS;
 const MAX_RECONNECT_MS = 30 * ONE_SECOND_MS;
 const MAX_RESPONSE_QUEUE = 100;
 
-// Close codes that indicate a permanent/terminal error — no point
-// reconnecting until the configuration is fixed.
-const TERMINAL_CLOSE_CODES = new Set([
-  1008, // Policy violation (e.g. auth rejected)
-  4401, // Custom: unauthorized
-  4403, // Custom: forbidden
-]);
-
-// ── Helpers ─────────────────────────────────────────────────
-
-function isRelayMessage(value: unknown): value is RelayMessage {
-  if (!value || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-  return (
-    typeof obj.id === "string" &&
-    typeof obj.platform === "string" &&
-    typeof obj.chatId === "string" &&
-    typeof obj.text === "string" &&
-    obj.text !== "" &&
-    obj.chatId !== ""
-  );
-}
-
 // ── Factory ─────────────────────────────────────────────────
 
 export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
@@ -95,17 +63,11 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
   let stopped = false;
   const responseQueue: RelayResponse[] = [];
 
-  function buildUrl(): string {
-    const url = new URL(relayUrl);
-    url.searchParams.set("token", relayToken);
-    return url.toString();
-  }
-
   function connect(): void {
     if (stopped) return;
 
     try {
-      socket = new WebSocket(buildUrl());
+      socket = new WebSocket(buildRelayUrl(relayUrl, relayToken));
     } catch (err) {
       logger.error(LOG_PREFIX, "failed to create WebSocket", {
         error: errorMessage(err),
@@ -126,7 +88,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
 
     socket.on("close", (code, reason) => {
       socket = null;
-      if (TERMINAL_CLOSE_CODES.has(code)) {
+      if (isTerminalCloseCode(code)) {
         logger.error(LOG_PREFIX, "terminal close, not reconnecting", {
           code,
           reason: String(reason),
@@ -155,7 +117,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       reconnectTimer = null;
       connect();
     }, reconnectMs);
-    reconnectMs = Math.min(reconnectMs * 2, MAX_RECONNECT_MS);
+    reconnectMs = nextReconnectMs(reconnectMs, MAX_RECONNECT_MS);
   }
 
   async function handleMessage(raw: string): Promise<void> {
@@ -182,11 +144,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
       textLength: msg.text.length,
     });
 
-    // Double-underscore separator avoids collisions — platform names
-    // are from a fixed set (PLATFORMS constant) and none contain "__".
-    // Single "-" is unsafe because "google-chat" + "X" collides with
-    // "google" + "chat-X".
-    const externalChatId = `${msg.platform}__${msg.chatId}`;
+    const externalChatId = buildExternalChatId(msg.platform, msg.chatId);
 
     try {
       // Per-platform default-role resolution (#739). Mirrors the
@@ -203,7 +161,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
         bridgeOptions,
       });
 
-      const replyText = result.kind === "ok" ? result.reply : `Error: ${result.message}`;
+      const replyText = formatReplyText(result);
 
       sendResponse({
         platform: msg.platform,

--- a/test/events/test_relayClientHelpers.ts
+++ b/test/events/test_relayClientHelpers.ts
@@ -1,0 +1,135 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildExternalChatId,
+  buildRelayUrl,
+  formatReplyText,
+  isRelayMessage,
+  isTerminalCloseCode,
+  nextReconnectMs,
+} from "../../server/events/relay-client-helpers.js";
+
+describe("buildRelayUrl", () => {
+  it("appends the token as a query param", () => {
+    assert.equal(buildRelayUrl("wss://relay.example.com/ws", "abc123"), "wss://relay.example.com/ws?token=abc123");
+  });
+
+  it("preserves an existing path and query, overwriting only token", () => {
+    assert.equal(buildRelayUrl("wss://relay.example.com/ws?token=stale&region=us", "fresh"), "wss://relay.example.com/ws?token=fresh&region=us");
+  });
+
+  it("URL-encodes tokens with reserved characters", () => {
+    assert.equal(buildRelayUrl("wss://relay.example.com/", "a b&c=d"), "wss://relay.example.com/?token=a+b%26c%3Dd");
+  });
+
+  it("throws on a malformed base URL (mirrors the try/catch at the call site)", () => {
+    assert.throws(() => buildRelayUrl("not a url", "abc"));
+  });
+});
+
+describe("nextReconnectMs", () => {
+  const MAX = 30_000;
+
+  it("doubles below the cap", () => {
+    assert.equal(nextReconnectMs(1_000, MAX), 2_000);
+    assert.equal(nextReconnectMs(2_000, MAX), 4_000);
+  });
+
+  it("caps at the maximum", () => {
+    assert.equal(nextReconnectMs(20_000, MAX), MAX);
+  });
+
+  it("returns the cap exactly when doubling lands on it", () => {
+    assert.equal(nextReconnectMs(15_000, MAX), MAX);
+  });
+
+  it("never exceeds the cap even when current already exceeds it", () => {
+    assert.equal(nextReconnectMs(40_000, MAX), MAX);
+  });
+
+  it("doubles zero to zero (degenerate boundary)", () => {
+    assert.equal(nextReconnectMs(0, MAX), 0);
+  });
+});
+
+describe("isTerminalCloseCode", () => {
+  it("treats policy-violation and custom auth codes as terminal", () => {
+    assert.equal(isTerminalCloseCode(1008), true);
+    assert.equal(isTerminalCloseCode(4401), true);
+    assert.equal(isTerminalCloseCode(4403), true);
+  });
+
+  it("treats normal and transient close codes as non-terminal", () => {
+    assert.equal(isTerminalCloseCode(1000), false);
+    assert.equal(isTerminalCloseCode(1006), false);
+    assert.equal(isTerminalCloseCode(4400), false);
+  });
+});
+
+describe("buildExternalChatId", () => {
+  it("joins platform and chatId with a double underscore", () => {
+    assert.equal(buildExternalChatId("line", "abc"), "line__abc");
+  });
+
+  it("avoids the single-dash collision between (google-chat, X) and (google, chat-X)", () => {
+    assert.notEqual(buildExternalChatId("google-chat", "X"), buildExternalChatId("google", "chat-X"));
+  });
+
+  it("handles empty components", () => {
+    assert.equal(buildExternalChatId("", ""), "__");
+  });
+});
+
+describe("isRelayMessage", () => {
+  const valid = {
+    id: "msg-1",
+    platform: "line",
+    senderId: "u-1",
+    chatId: "c-1",
+    text: "hello",
+    receivedAt: "2026-07-09T00:00:00Z",
+  };
+
+  it("accepts a well-formed message (extra fields allowed)", () => {
+    assert.equal(isRelayMessage(valid), true);
+    assert.equal(isRelayMessage({ ...valid, replyToken: "tok", extra: 1 }), true);
+  });
+
+  it("rejects non-objects", () => {
+    assert.equal(isRelayMessage(null), false);
+    assert.equal(isRelayMessage(undefined), false);
+    assert.equal(isRelayMessage("hello"), false);
+    assert.equal(isRelayMessage(42), false);
+  });
+
+  it("rejects when a required field is missing", () => {
+    const noId: Record<string, unknown> = { ...valid };
+    delete noId.id;
+    assert.equal(isRelayMessage(noId), false);
+  });
+
+  it("rejects wrong-typed required fields", () => {
+    assert.equal(isRelayMessage({ ...valid, id: 123 }), false);
+    assert.equal(isRelayMessage({ ...valid, platform: null }), false);
+  });
+
+  it("rejects empty text and empty chatId", () => {
+    assert.equal(isRelayMessage({ ...valid, text: "" }), false);
+    assert.equal(isRelayMessage({ ...valid, chatId: "" }), false);
+  });
+});
+
+describe("formatReplyText", () => {
+  it("returns the reply for an ok result", () => {
+    assert.equal(formatReplyText({ kind: "ok", reply: "done" }), "done");
+  });
+
+  it("prefixes error results with 'Error: '", () => {
+    assert.equal(formatReplyText({ kind: "error", status: 500, message: "boom" }), "Error: boom");
+  });
+
+  it("handles empty strings on both branches", () => {
+    assert.equal(formatReplyText({ kind: "ok", reply: "" }), "");
+    assert.equal(formatReplyText({ kind: "error", status: 400, message: "" }), "Error: ");
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage to the previously-untested `connectRelay` in `server/events/relay-client.ts` by extracting its **genuinely pure** sub-computations into named, exported helpers (new `server/events/relay-client-helpers.ts`) and covering them with `node:test`. Behaviour-preserving pure moves only — no socket / reconnect / event-wiring / queue logic was touched or changed.

Side benefit: `connectRelay`'s `max-lines-per-function` warning drops from **175 → 170** lines (pre-existing warning, not introduced here).

## Items to Confirm / Review

- **Pure moves are line-identical.** Each helper is a verbatim lift of the original expression/function; please confirm none changed behaviour:
  - `buildRelayUrl` ← inner `buildUrl()` (still called inside the same `try` in `connect()`, so a malformed-URL throw is still caught).
  - `nextReconnectMs(current, max)` ← `Math.min(reconnectMs * 2, MAX_RECONNECT_MS)` (cap passed as an arg for testability; call site passes the same constant).
  - `isTerminalCloseCode` + its `TERMINAL_CLOSE_CODES` set ← moved wholesale.
  - `buildExternalChatId` ← the `` `${platform}__${chatId}` `` join (the collision-avoidance WHY comment moved with it).
  - `isRelayMessage` + `RelayMessage` type ← moved wholesale (the `value as Record<string,unknown>` cast is preserved verbatim from the original).
  - `formatReplyText(result)` ← `result.kind === "ok" ? result.reply : ` + `` `Error: ${result.message}` ``. The `RelayResult` type is derived structurally via `Awaited<ReturnType<ChatService["relay"]>>` (the package doesn't export it directly).
- **Deliberately left untouched (not pure):** WebSocket creation + event handlers (`open`/`message`/`close`/`error`), `scheduleReconnect` timer, `handleMessage` async flow, the response queue (`enqueueResponse`/`trySend`/`sendResponse`/`flushResponseQueue`), and `disconnect`. These mutate closure state / do I/O and were left in place.

## Helpers extracted

| Helper | Source expression | Kind |
|---|---|---|
| `buildRelayUrl(relayUrl, relayToken)` | `buildUrl()` | URL building |
| `nextReconnectMs(currentMs, maxMs)` | backoff `Math.min(*2, cap)` | backoff calc |
| `isTerminalCloseCode(code)` | `TERMINAL_CLOSE_CODES.has(code)` | config lookup |
| `buildExternalChatId(platform, chatId)` | `` `${p}__${c}` `` | envelope construction |
| `isRelayMessage(value)` | inbound validation type-guard | message validation |
| `formatReplyText(result)` | ok/error reply serialization | outbound serialization |

## Tests

`test/events/test_relayClientHelpers.ts` — 22 `node:test` cases: happy paths + boundaries (backoff cap, doubling-lands-on-cap, current-already-over-cap, attempt-0; empty/missing/wrong-typed/non-object relay messages; empty text/chatId; malformed base URL throws; ok vs error reply formatting incl. empty strings).

## Verification

- `typecheck:server` (`tsc -p server/tsconfig.json`) → clean
- `typecheck:test` (`tsc -p test/tsconfig.json`) → clean
- `eslint` on the 3 files → **0 errors** (1 pre-existing `max-lines-per-function` warning on `connectRelay`, reduced 175→170)
- `tsx --test test/events/test_relayClientHelpers.ts` → **22 pass / 0 fail**
- Server code runs via `tsx` (not part of the vite/packages build pipeline), so `typecheck:server` is the gate.

## User Prompt

Add test coverage to a currently-untested function (`connectRelay` in `server/events/relay-client.ts`) by extracting its pure sub-logic into named exported functions and unit-testing them. Behaviour-preserving + test-adding, not a rewrite: extract genuinely pure bits (backoff calc, URL building, message parsing/validation, serialization, envelope construction) into exported pure functions, call them from the original so behaviour is identical, and add focused `node:test` tests (happy + boundary + invalid/empty) at `test/events/test_relayClientHelpers.ts`. Do not extract or change the socket/reconnect/event-wiring/closure code; do not change behaviour; never `eslint-disable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)