### PR TITLE
refactor: shrink startChat + runAgent prep (lint max-lines)

### DIFF
--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -13,6 +13,7 @@ import type { Attachment } from "@mulmobridge/protocol";
 import type { AgentEvent } from "./stream.js";
 import { log } from "../system/logger/index.js";
 import { getActiveBackend } from "./backend/index.js";
+import type { AgentInput, LLMBackend } from "./backend/index.js";
 
 export interface RunAgentOptions {
   message: string;
@@ -37,17 +38,8 @@ export interface RunAgentInput {
   userTimezone?: string;
 }
 
-export async function* runAgent({
-  message,
-  role,
-  workspacePath,
-  sessionId,
-  port,
-  claudeSessionId,
-  abortSignal,
-  attachments,
-  userTimezone,
-}: RunAgentInput): AsyncGenerator<AgentEvent> {
+export async function* runAgent(input: RunAgentInput): AsyncGenerator<AgentEvent> {
+  const { role, workspacePath } = input;
   const activePlugins = getActivePlugins(role);
   const useDocker = await isDockerAvailable();
 
@@ -64,98 +56,11 @@ export async function* runAgent({
   // tears them down — otherwise host processes / ports leak for the
   // rest of the session.
   try {
-    const hasUserServers = Object.keys(userServers).length > 0;
-    const hasMcp = activePlugins.length > 0 || hasUserServers;
-
-    // Catches the "catalog entry pinned to a non-existent npm package" failure where the MCP subprocess never starts and
-    // Claude silently falls back to WebSearch. Fire-and-forget; per-package cache amortizes the network round-trip.
-    validateStdioPackages(userServers).catch(() => {});
-
-    // macOS sandbox: refresh from Keychain so expired OAuth tokens get replaced transparently.
-    if (useDocker && process.platform === "darwin") {
-      await refreshCredentials();
-    }
-
-    // Pre-load memory once (atomic vs topic format chosen inside
-    // `loadMemorySnapshot`) so prompt assembly itself stays sync.
-    const memorySnapshot = await loadMemorySnapshot(workspacePath);
-    const fullSystemPrompt = buildSystemPrompt({
-      role,
-      workspacePath: useDocker ? CONTAINER_WORKSPACE_PATH : workspacePath,
-      useDocker,
-      userTimezone,
-      memorySnapshot,
-    });
-
-    // --debug: dump the full system prompt on the first message of each session.
-    if (!claudeSessionId && process.argv.includes("--debug")) {
-      log.info("agent", `system prompt for new session:\n${fullSystemPrompt}`);
-    }
-
-    const mcpPaths = resolveMcpConfigPaths({
-      workspacePath,
-      sessionId,
-      useDocker,
-    });
-    if (useDocker) {
-      await mkdir(dirname(mcpPaths.hostPath), { recursive: true });
-    }
-
-    // Surfaced in the --debug spawn log so developers can verify Settings UI changes reach Claude Code.
-    let mcpServerNames: string[] = [];
-    if (hasMcp) {
-      const mcpConfig = buildMcpConfig({
-        chatSessionId: sessionId,
-        port,
-        activePlugins,
-        useDocker,
-        userServers,
-      });
-      mcpServerNames = Object.keys(mcpConfig.mcpServers).sort();
-      // Atomic so a concurrent claude spawn can't pick up a half-written file (they share the path under the session dir).
-      await writeJsonAtomic(mcpPaths.hostPath, mcpConfig);
-    }
-
-    // Per-invocation read so allowedTools / MCP-server changes apply without a server restart.
-    const settings = loadSettings();
-    const userServerAllowedTools = userServerAllowedToolNames(userServers, useDocker);
-
-    // Boolean presence flags only — never write raw sessionId into long-lived log sinks.
-    const backend = getActiveBackend();
-    const spawnLog: Record<string, unknown> = {
-      backend: backend.id,
-      roleId: role.id,
-      useDocker,
-      hasMcp,
-      resumed: Boolean(claudeSessionId),
-      hasSessionId: Boolean(sessionId),
-    };
-    // --debug only: kept off the default log to avoid leaking user MCP server names into long-lived sinks.
-    if (process.argv.includes("--debug") && hasMcp) {
-      spawnLog.mcpServers = mcpServerNames;
-    }
-    log.info("agent", "spawning agent", spawnLog);
-
+    const prepared = await prepareAgentRun(input, { activePlugins, useDocker, userServers });
     try {
-      yield* backend.runAgent({
-        systemPrompt: fullSystemPrompt,
-        message,
-        role,
-        workspacePath,
-        sessionId,
-        port,
-        sessionToken: claudeSessionId,
-        attachments,
-        activePlugins,
-        mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
-        extraAllowedTools: [...settings.extraAllowedTools, ...userServerAllowedTools],
-        effortLevel: settings.effortLevel,
-        abortSignal,
-        userTimezone,
-        useDocker,
-      });
+      yield* prepared.backend.runAgent(prepared.agentInput);
     } finally {
-      if (hasMcp) unlink(mcpPaths.hostPath).catch(() => {});
+      if (prepared.hasMcp) unlink(prepared.hostMcpPath).catch(() => {});
     }
   } finally {
     // Tear down any host-side stdio→HTTP shims (#1421 Phase B) —
@@ -171,4 +76,154 @@ export async function* runAgent({
       }
     }
   }
+}
+
+interface AgentRunDeps {
+  activePlugins: string[];
+  useDocker: boolean;
+  userServers: Awaited<ReturnType<typeof prepareUserServers>>["servers"];
+}
+
+type McpPaths = ReturnType<typeof resolveMcpConfigPaths>;
+
+interface PreparedAgentRun {
+  backend: LLMBackend;
+  agentInput: AgentInput;
+  hasMcp: boolean;
+  hostMcpPath: string;
+}
+
+// Assemble everything the backend needs for one turn, in the same
+// order the inlined body used to run it: validate user servers +
+// refresh credentials, build the system prompt, write the MCP config,
+// then build the AgentInput and log the spawn. Non-yielding, so it
+// lives outside the generator.
+async function prepareAgentRun(input: RunAgentInput, deps: AgentRunDeps): Promise<PreparedAgentRun> {
+  const { useDocker, userServers, activePlugins } = deps;
+  const hasUserServers = Object.keys(userServers).length > 0;
+  const hasMcp = activePlugins.length > 0 || hasUserServers;
+
+  // Catches the "catalog entry pinned to a non-existent npm package" failure where the MCP subprocess never starts and
+  // Claude silently falls back to WebSearch. Fire-and-forget; per-package cache amortizes the network round-trip.
+  validateStdioPackages(userServers).catch(() => {});
+
+  // macOS sandbox: refresh from Keychain so expired OAuth tokens get replaced transparently.
+  if (useDocker && process.platform === "darwin") {
+    await refreshCredentials();
+  }
+
+  const systemPrompt = await buildFullSystemPrompt(input, useDocker);
+  const { mcpPaths, mcpServerNames } = await writeMcpConfig(input, deps, hasMcp);
+  const { backend, agentInput } = buildAgentInput(input, deps, { systemPrompt, hasMcp, mcpPaths, mcpServerNames });
+  return { backend, agentInput, hasMcp, hostMcpPath: mcpPaths.hostPath };
+}
+
+// Load the memory snapshot and assemble the full system prompt for
+// this turn, dumping it to the log on the first message of a --debug
+// session.
+async function buildFullSystemPrompt(input: RunAgentInput, useDocker: boolean): Promise<string> {
+  const { role, workspacePath, claudeSessionId, userTimezone } = input;
+
+  // Pre-load memory once (atomic vs topic format chosen inside
+  // `loadMemorySnapshot`) so prompt assembly itself stays sync.
+  const memorySnapshot = await loadMemorySnapshot(workspacePath);
+  const fullSystemPrompt = buildSystemPrompt({
+    role,
+    workspacePath: useDocker ? CONTAINER_WORKSPACE_PATH : workspacePath,
+    useDocker,
+    userTimezone,
+    memorySnapshot,
+  });
+
+  // --debug: dump the full system prompt on the first message of each session.
+  if (!claudeSessionId && process.argv.includes("--debug")) {
+    log.info("agent", `system prompt for new session:\n${fullSystemPrompt}`);
+  }
+
+  return fullSystemPrompt;
+}
+
+// Resolve the per-session MCP config paths and, when any MCP server is
+// active, write the config file the backend will load. Returns the
+// server names for the --debug spawn log.
+async function writeMcpConfig(input: RunAgentInput, deps: AgentRunDeps, hasMcp: boolean): Promise<{ mcpPaths: McpPaths; mcpServerNames: string[] }> {
+  const { workspacePath, sessionId, port } = input;
+  const { activePlugins, useDocker, userServers } = deps;
+
+  const mcpPaths = resolveMcpConfigPaths({
+    workspacePath,
+    sessionId,
+    useDocker,
+  });
+  if (useDocker) {
+    await mkdir(dirname(mcpPaths.hostPath), { recursive: true });
+  }
+
+  // Surfaced in the --debug spawn log so developers can verify Settings UI changes reach Claude Code.
+  let mcpServerNames: string[] = [];
+  if (hasMcp) {
+    const mcpConfig = buildMcpConfig({
+      chatSessionId: sessionId,
+      port,
+      activePlugins,
+      useDocker,
+      userServers,
+    });
+    mcpServerNames = Object.keys(mcpConfig.mcpServers).sort();
+    // Atomic so a concurrent claude spawn can't pick up a half-written file (they share the path under the session dir).
+    await writeJsonAtomic(mcpPaths.hostPath, mcpConfig);
+  }
+
+  return { mcpPaths, mcpServerNames };
+}
+
+// Read per-invocation settings, resolve the active backend, log the
+// spawn, and assemble the backend-agnostic AgentInput for this turn.
+function buildAgentInput(
+  input: RunAgentInput,
+  deps: AgentRunDeps,
+  args: { systemPrompt: string; hasMcp: boolean; mcpPaths: McpPaths; mcpServerNames: string[] },
+): { backend: LLMBackend; agentInput: AgentInput } {
+  const { message, role, workspacePath, sessionId, port, claudeSessionId, abortSignal, attachments, userTimezone } = input;
+  const { activePlugins, useDocker, userServers } = deps;
+  const { systemPrompt, hasMcp, mcpPaths, mcpServerNames } = args;
+
+  // Per-invocation read so allowedTools / MCP-server changes apply without a server restart.
+  const settings = loadSettings();
+  const userServerAllowedTools = userServerAllowedToolNames(userServers, useDocker);
+
+  // Boolean presence flags only — never write raw sessionId into long-lived log sinks.
+  const backend = getActiveBackend();
+  const spawnLog: Record<string, unknown> = {
+    backend: backend.id,
+    roleId: role.id,
+    useDocker,
+    hasMcp,
+    resumed: Boolean(claudeSessionId),
+    hasSessionId: Boolean(sessionId),
+  };
+  // --debug only: kept off the default log to avoid leaking user MCP server names into long-lived sinks.
+  if (process.argv.includes("--debug") && hasMcp) {
+    spawnLog.mcpServers = mcpServerNames;
+  }
+  log.info("agent", "spawning agent", spawnLog);
+
+  const agentInput: AgentInput = {
+    systemPrompt,
+    message,
+    role,
+    workspacePath,
+    sessionId,
+    port,
+    sessionToken: claudeSessionId,
+    attachments,
+    activePlugins,
+    mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
+    extraAllowedTools: [...settings.extraAllowedTools, ...userServerAllowedTools],
+    effortLevel: settings.effortLevel,
+    abortSignal,
+    userTimezone,
+    useDocker,
+  };
+  return { backend, agentInput };
 }

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -195,7 +195,7 @@ export async function spawnSystemWorker(args: {
 }
 
 export async function startChat(params: StartChatParams): Promise<StartChatResult> {
-  const { message, roleId, chatSessionId, selectedImageData, attachments, userTimezone } = params;
+  const { message, roleId, chatSessionId, selectedImageData, attachments } = params;
   // Bridge-only compat: external bridge clients may still populate
   // `selectedImageData`. Fold it into `attachments` so the rest of
   // this function only deals with one input shape.
@@ -272,6 +272,22 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     return { kind: "error", error: "Invalid attachments payload", status: 400 };
   }
 
+  const validOrigin = await persistUserTurn(params, { isFirstTurn, attachedPaths });
+  await dispatchAgentRun(params, { extras, resultsFilePath, abortController, validOrigin });
+
+  return { kind: "started", chatSessionId };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+// Persist the user turn: write session metadata, count the query,
+// append the user message to the jsonl, and broadcast it to other
+// tabs viewing this session. Returns the validated origin so the
+// dispatch phase can reuse it.
+async function persistUserTurn(params: StartChatParams, ctx: { isFirstTurn: boolean; attachedPaths: string[] }): Promise<SessionOrigin | undefined> {
+  const { message, roleId, chatSessionId } = params;
+  const { isFirstTurn, attachedPaths } = ctx;
+
   // Now persist the user message so callers (and other tabs) see the
   // turn. Metadata first — it powers the sidebar title cache; the
   // append follows so the jsonl is always a superset of what metadata
@@ -306,6 +322,20 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     ...(attachedPaths.length > 0 ? { attachments: attachedPaths } : {}),
   });
 
+  return validOrigin;
+}
+
+// Build the LLM-bound message (journal pointer + attached-file
+// markers) and kick off the detached background agent run. The
+// background run itself is fire-and-forget; this awaits only the
+// claudeSessionId read that must precede it.
+async function dispatchAgentRun(
+  params: StartChatParams,
+  ctx: { extras: RequestExtras; resultsFilePath: string; abortController: AbortController; validOrigin: SessionOrigin | undefined },
+): Promise<void> {
+  const { message, roleId, chatSessionId, userTimezone } = params;
+  const { extras, resultsFilePath, abortController, validOrigin } = ctx;
+
   const role = getRole(roleId);
   const claudeSessionId = await readClaudeSessionIdFromSession(chatSessionId);
 
@@ -333,11 +363,7 @@ export async function startChat(params: StartChatParams): Promise<StartChatResul
     userTimezone,
     origin: validOrigin,
   });
-
-  return { kind: "started", chatSessionId };
 }
-
-// ── Helpers ──────────────────────────────────────────────────────────
 
 interface RequestExtras {
   attachments: Attachment[] | undefined;


### PR DESCRIPTION
## Summary

Behaviour-preserving refactor that clears the two `max-lines-per-function` (50) warnings on the agent-core functions by extracting coherent leaf helpers. No logic, control flow, or event ordering changed — code was **moved**, not rewritten.

- `server/api/routes/agent.ts` — `startChat` (was 91 lines) → under 50. Extracted:
  - `persistUserTurn()` — session-meta write, user-query count, jsonl append, SSE broadcast; returns the validated origin.
  - `dispatchAgentRun()` — builds the LLM-bound message (journal pointer + attached-file markers) and kicks off the fire-and-forget background run.
- `server/agent/index.ts` — `runAgent` (was 98 lines) → under 50. Extracted the **non-yielding prep** into plain helpers `buildFullSystemPrompt` / `writeMcpConfig` / `buildAgentInput`, orchestrated by `prepareAgentRun`.

## Items to Confirm / Review

- **`runAgent` is an async generator** — the constraint here is that yielding code cannot move into a non-generator helper. Only the prep (before `yield*`) was extracted; the generator body keeps the exact shape `try { prepareAgentRun } → yield* backend.runAgent(agentInput) → finally unlink hostPath → outer finally close shims`. The AgentEvent stream (the only observable event order) is untouched.
- **Prep step order preserved**: `prepareAgentRun` runs the steps in the identical order the inlined body did — validate user servers → refresh macOS credentials → build system prompt → write MCP config → assemble `AgentInput` + spawn log. The two independent side-effect groups (memory/prompt vs MCP-config write) are not reordered relative to each other.
- **`AgentInput` fields are byte-identical** to the object literal that was previously passed inline to `backend.runAgent` (same keys, same values, incl. `mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined`).
- `startChat`'s top destructure dropped the now-unused `userTimezone` local (it is read from `params` inside `dispatchAgentRun`).
- **Out of scope, left as-is**: the pre-existing `runAgentInBackground` (69 lines) warning in `agent.ts` — untouched by this PR.

## Verification

- Lint on both files: the `startChat` and `runAgent` warnings are gone; **0 errors**. Only the pre-existing `runAgentInBackground` (69) warning remains, which is out of scope.
- `tsc -p server/tsconfig.json --noEmit` (server, the real gate — server runs via tsx, no compile) → clean.
- `tsc -p test/tsconfig.json --noEmit` → clean.
- Agent behaviour tests pass: `test/agent/{test_agent_lifecycle_resilience,test_fake_backend_scenarios,test_spawnBackgroundChat,test_agent_config,test_abort_caused_exit,test_agent_stream,test_resumeFailover,test_skillTagging,test_pendingSkillStateMachine,test_skillBodySplit}.ts` and `test/remoteHost/{test_startChat,test_handlers}.ts` — all green (195 tests).
- Client `vite build` is unaffected: the changes are server-only (`src/` does not import `server/`).