### PR TITLE
test: extract + cover pure whisper logic (lint max-lines)

### DIFF
--- a/packages/core/src/whisper/client-helpers.ts
+++ b/packages/core/src/whisper/client-helpers.ts
@@ -1,0 +1,57 @@
+// Pure, framework-neutral helpers for the browser voice-capture controller.
+// Kept separate from `client.ts` so the audio math and VAD state machine can be
+// unit-tested without a DOM / MediaRecorder / Web Audio environment.
+
+export function computeRms(buffer: Float32Array): number {
+  let sum = 0;
+  for (const sample of buffer) sum += sample * sample;
+  return Math.sqrt(sum / buffer.length);
+}
+
+/** The recorder mime can carry a codec suffix (`audio/webm;codecs=opus`); the
+ *  Blob container type is just the part before the `;`. */
+export function containerTypeFromMime(mimeType: string): string {
+  return mimeType.split(";")[0] || "audio/webm";
+}
+
+export interface VadState {
+  readonly hasSpeech: boolean;
+  readonly silenceStart: number | null;
+}
+
+export interface VadConfig {
+  readonly speechRms: number;
+  readonly silenceMs: number;
+  readonly maxSegmentMs: number;
+}
+
+export interface VadDecision {
+  readonly hasSpeech: boolean;
+  readonly silenceStart: number | null;
+  readonly cut: boolean;
+}
+
+function isSpeech(rms: number, config: VadConfig): boolean {
+  return rms > config.speechRms;
+}
+
+function nextSilenceStart(state: VadState, rms: number, nowMs: number, config: VadConfig): number | null {
+  if (isSpeech(rms, config)) return null;
+  if (state.hasSpeech && state.silenceStart === null) return nowMs;
+  return state.silenceStart;
+}
+
+function silenceExceeded(state: VadState, rms: number, nowMs: number, config: VadConfig): boolean {
+  if (isSpeech(rms, config) || !state.hasSpeech || state.silenceStart === null) return false;
+  return nowMs - state.silenceStart > config.silenceMs;
+}
+
+/** Advance the pause-detector one tick: fold the current RMS/time into the
+ *  segment state and decide whether the segment should be force-cut (either a
+ *  long-enough silence after speech, or the max-segment length reached). */
+export function evaluateVad(state: VadState, segmentStartMs: number, rms: number, nowMs: number, config: VadConfig): VadDecision {
+  const hasSpeech = isSpeech(rms, config) || state.hasSpeech;
+  const silenceStart = nextSilenceStart(state, rms, nowMs, config);
+  const maxCut = hasSpeech && nowMs - segmentStartMs > config.maxSegmentMs;
+  return { hasSpeech, silenceStart, cut: silenceExceeded(state, rms, nowMs, config) || maxCut };
+}

--- a/packages/core/src/whisper/client.ts
+++ b/packages/core/src/whisper/client.ts
@@ -4,6 +4,8 @@
 // pushed via `onState`; the host wraps this into its own reactivity (Vue refs,
 // React state, …). No framework dependency. See plans/done/feat-extract-whisper-package.md.
 
+import { computeRms, containerTypeFromMime, evaluateVad, type VadConfig } from "./client-helpers.ts";
+
 // Map a UI locale to a Whisper language code. UI language is a strong prior for
 // the spoken language; "auto" lets Whisper detect it from the audio.
 const LOCALE_TO_WHISPER: Record<string, string> = {
@@ -29,6 +31,7 @@ const SILENCE_MS = 800;
 const MAX_SEGMENT_MS = 20_000;
 const MONITOR_INTERVAL_MS = 100;
 const AVAILABILITY_POLL_MS = 2_000;
+const VAD_CONFIG: VadConfig = { speechRms: SPEECH_RMS, silenceMs: SILENCE_MS, maxSegmentMs: MAX_SEGMENT_MS };
 
 function pickRecorderMime(): string | undefined {
   const candidates = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"];
@@ -43,12 +46,6 @@ function blobToDataUrl(blob: Blob): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
     reader.readAsDataURL(blob);
   });
-}
-
-function computeRms(buffer: Float32Array): number {
-  let sum = 0;
-  for (const sample of buffer) sum += sample * sample;
-  return Math.sqrt(sum / buffer.length);
 }
 
 function toMessage(err: unknown): string {
@@ -193,14 +190,10 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
       .finally(() => setPending(-1));
   }
 
-  function containerType(): string {
-    return mimeType.split(";")[0] || "audio/webm";
-  }
-
   function onSegmentStop(): void {
     const hadSpeech = segmentHasSpeech;
     const gen = segmentGeneration;
-    const blob = new Blob(chunks, { type: containerType() });
+    const blob = new Blob(chunks, { type: containerTypeFromMime(mimeType) });
     if (listening) startRecorder();
     if (hadSpeech && blob.size > 0 && gen === generation) enqueue(blob, gen);
   }
@@ -228,15 +221,10 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
     if (!analyser) return;
     analyser.getFloatTimeDomainData(vadBuffer);
     const rms = computeRms(vadBuffer);
-    const now = Date.now();
-    if (rms > SPEECH_RMS) {
-      segmentHasSpeech = true;
-      silenceStart = null;
-    } else if (segmentHasSpeech) {
-      if (silenceStart === null) silenceStart = now;
-      else if (now - silenceStart > SILENCE_MS) cutSegment();
-    }
-    if (segmentHasSpeech && now - segmentStart > MAX_SEGMENT_MS) cutSegment();
+    const { hasSpeech, silenceStart: nextSilence, cut } = evaluateVad({ hasSpeech: segmentHasSpeech, silenceStart }, segmentStart, rms, Date.now(), VAD_CONFIG);
+    segmentHasSpeech = hasSpeech;
+    silenceStart = nextSilence;
+    if (cut) cutSegment();
   }
 
   async function start(): Promise<boolean> {

--- a/packages/core/src/whisper/models.ts
+++ b/packages/core/src/whisper/models.ts
@@ -65,6 +65,20 @@ export interface ModelStatus {
   error?: string;
 }
 
+/** Report status precedence: an in-flight download wins, then an on-disk ready
+ *  file, then the last transient state (idle if none). Pure so the precedence
+ *  is unit-testable without touching the filesystem. */
+export function pickModelStatus(live: ModelStatus | undefined, isReady: boolean): ModelStatus {
+  if (live?.state === "downloading") return live;
+  if (isReady) return { state: "ready" };
+  return live ?? { state: "idle" };
+}
+
+/** Parse a `Content-Length` header to a byte count; unknown / malformed → 0. */
+export function parseContentLength(header: string | null): number {
+  return Number(header) || 0;
+}
+
 // Abort a download if no bytes arrive for this long (stalled connection).
 const DOWNLOAD_STALL_TIMEOUT_MS = ONE_MINUTE_MS;
 
@@ -79,10 +93,7 @@ export function createModelDownloader(modelsDir: string, logger: WhisperLogger =
   const downloadStatus = new Map<WhisperModelName, ModelStatus>();
 
   function getStatus(name: WhisperModelName): ModelStatus {
-    const live = downloadStatus.get(name);
-    if (live?.state === "downloading") return live;
-    if (isModelReady(modelsDir, name)) return { state: "ready" };
-    return live ?? { state: "idle" };
+    return pickModelStatus(downloadStatus.get(name), isModelReady(modelsDir, name));
   }
 
   async function streamToFile(
@@ -128,7 +139,7 @@ export function createModelDownloader(modelsDir: string, logger: WhisperLogger =
       if (!response.ok || !response.body) {
         throw new Error(`download failed: HTTP ${response.status}`);
       }
-      const total = Number(response.headers.get("content-length")) || 0;
+      const total = parseContentLength(response.headers.get("content-length"));
       resetStall();
       await streamToFile(response.body, partial, total, name, resetStall);
       if (statSync(partial).size < spec.minBytes) {

--- a/packages/core/src/whisper/sidecar-helpers.ts
+++ b/packages/core/src/whisper/sidecar-helpers.ts
@@ -1,0 +1,23 @@
+// Pure helpers for the whisper-server sidecar. Kept separate from `sidecar.ts`
+// so the argv/response/stderr logic can be unit-tested without spawning a
+// process or opening a socket.
+
+/** whisper-server CLI args to preload `modelPath` and bind to `host:port`. */
+export function buildServerArgs(modelPath: string, host: string, port: number): string[] {
+  return ["--model", modelPath, "--host", host, "--port", String(port)];
+}
+
+/** Append `chunk` to a bounded stderr tail, keeping only the last `maxChars`. */
+export function appendStderrTail(previous: string, chunk: string, maxChars: number): string {
+  return (previous + chunk).slice(-maxChars);
+}
+
+/** Extract the transcript from a whisper-server `/inference` JSON response.
+ *  Returns "" for any shape that lacks a string `text` field. */
+export function parseInferenceText(data: unknown): string {
+  if (typeof data === "object" && data !== null && "text" in data) {
+    const { text } = data as { text: unknown };
+    if (typeof text === "string") return text;
+  }
+  return "";
+}

--- a/packages/core/src/whisper/sidecar.ts
+++ b/packages/core/src/whisper/sidecar.ts
@@ -9,11 +9,13 @@ import { readFile } from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
 import { errorMessage, NOOP_LOGGER, ONE_MINUTE_MS, ONE_SECOND_MS, type WhisperLogger } from "./internal.ts";
 import { modelFilePath, type WhisperModelName } from "./models.ts";
+import { appendStderrTail, buildServerArgs, parseInferenceText } from "./sidecar-helpers.ts";
 
 const HOST = "127.0.0.1";
 const READY_TIMEOUT_MS = 60 * ONE_SECOND_MS;
 const READY_POLL_INTERVAL_MS = 500;
 const INFERENCE_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
+const STDERR_TAIL_MAX_CHARS = 4_000;
 
 interface ActiveSidecar {
   readonly port: number;
@@ -63,7 +65,7 @@ async function waitUntilReady(port: number): Promise<void> {
 function drainStderr(proc: ChildProcess, tail: { text: string }): void {
   proc.stderr?.setEncoding("utf8");
   proc.stderr?.on("data", (chunk: string) => {
-    tail.text = (tail.text + chunk).slice(-4000);
+    tail.text = appendStderrTail(tail.text, chunk, STDERR_TAIL_MAX_CHARS);
   });
 }
 
@@ -99,14 +101,6 @@ function waitForReadyOrFailure(proc: ChildProcess, port: number): Promise<void> 
   });
 }
 
-function parseInferenceText(data: unknown): string {
-  if (typeof data === "object" && data !== null && "text" in data) {
-    const { text } = data as { text: unknown };
-    if (typeof text === "string") return text;
-  }
-  return "";
-}
-
 export function createSidecar(modelsDir: string, serverBinary = "whisper-server", logger: WhisperLogger = NOOP_LOGGER): Sidecar {
   let sidecar: ActiveSidecar | null = null;
   let starting: { model: WhisperModelName; promise: Promise<ActiveSidecar> } | null = null;
@@ -131,7 +125,7 @@ export function createSidecar(modelsDir: string, serverBinary = "whisper-server"
   async function startSidecar(model: WhisperModelName): Promise<ActiveSidecar> {
     const token = ++startToken;
     const port = await findFreePort();
-    const args = ["--model", modelFilePath(modelsDir, model), "--host", HOST, "--port", String(port)];
+    const args = buildServerArgs(modelFilePath(modelsDir, model), HOST, port);
     logger.info("sidecar: spawning", { model, port });
     const proc = spawn(serverBinary, args, { stdio: ["ignore", "ignore", "pipe"] });
     startingProc = proc;

--- a/packages/core/test/whisper/test_client_helpers.ts
+++ b/packages/core/test/whisper/test_client_helpers.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeRms, containerTypeFromMime, evaluateVad, type VadConfig, type VadState } from "../../src/whisper/client-helpers.ts";
+
+const CONFIG: VadConfig = { speechRms: 0.015, silenceMs: 800, maxSegmentMs: 20_000 };
+
+describe("computeRms", () => {
+  it("computes the root-mean-square of the samples", () => {
+    assert.equal(computeRms(new Float32Array([0.5, -0.5])), 0.5);
+  });
+
+  it("is zero for pure silence", () => {
+    assert.equal(computeRms(new Float32Array([0, 0, 0, 0])), 0);
+  });
+
+  it("is the magnitude for a single sample", () => {
+    assert.equal(computeRms(new Float32Array([1])), 1);
+  });
+
+  it("is NaN for an empty buffer (0/0)", () => {
+    assert.ok(Number.isNaN(computeRms(new Float32Array(0))));
+  });
+});
+
+describe("containerTypeFromMime", () => {
+  it("strips a codec suffix", () => {
+    assert.equal(containerTypeFromMime("audio/webm;codecs=opus"), "audio/webm");
+  });
+
+  it("passes through a bare mime type", () => {
+    assert.equal(containerTypeFromMime("audio/mp4"), "audio/mp4");
+  });
+
+  it("falls back to audio/webm for an empty string", () => {
+    assert.equal(containerTypeFromMime(""), "audio/webm");
+  });
+});
+
+describe("evaluateVad", () => {
+  const speaking: VadState = { hasSpeech: true, silenceStart: null };
+
+  it("marks speech and clears any pending silence when loud", () => {
+    const state: VadState = { hasSpeech: false, silenceStart: 500 };
+    assert.deepEqual(evaluateVad(state, 0, 0.05, 1_000, CONFIG), { hasSpeech: true, silenceStart: null, cut: false });
+  });
+
+  it("starts the silence clock on the first quiet tick after speech", () => {
+    assert.deepEqual(evaluateVad(speaking, 0, 0.001, 1_000, CONFIG), { hasSpeech: true, silenceStart: 1_000, cut: false });
+  });
+
+  it("cuts once the silence exceeds the threshold", () => {
+    const state: VadState = { hasSpeech: true, silenceStart: 100 };
+    assert.deepEqual(evaluateVad(state, 0, 0.001, 1_000, CONFIG), { hasSpeech: true, silenceStart: 100, cut: true });
+  });
+
+  it("does not cut before the silence threshold is passed", () => {
+    const state: VadState = { hasSpeech: true, silenceStart: 500 };
+    assert.equal(evaluateVad(state, 0, 0.001, 1_000, CONFIG).cut, false);
+  });
+
+  it("treats rms exactly at the threshold as silence (strictly greater is speech)", () => {
+    assert.deepEqual(evaluateVad(speaking, 0, CONFIG.speechRms, 1_000, CONFIG), { hasSpeech: true, silenceStart: 1_000, cut: false });
+  });
+
+  it("does not cut at exactly the silence boundary (strictly greater)", () => {
+    const state: VadState = { hasSpeech: true, silenceStart: 200 };
+    assert.equal(evaluateVad(state, 0, 0.001, 1_000, CONFIG).cut, false);
+  });
+
+  it("force-cuts a long unbroken utterance even while still speaking", () => {
+    assert.deepEqual(evaluateVad(speaking, 0, 0.05, 25_000, CONFIG), { hasSpeech: true, silenceStart: null, cut: true });
+  });
+
+  it("never cuts before any speech is detected", () => {
+    const state: VadState = { hasSpeech: false, silenceStart: null };
+    assert.deepEqual(evaluateVad(state, 0, 0.001, 25_000, CONFIG), { hasSpeech: false, silenceStart: null, cut: false });
+  });
+});

--- a/packages/core/test/whisper/test_models_helpers.ts
+++ b/packages/core/test/whisper/test_models_helpers.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseContentLength, pickModelStatus, type ModelStatus } from "../../src/whisper/models.ts";
+
+describe("parseContentLength", () => {
+  it("parses a numeric header", () => {
+    assert.equal(parseContentLength("12345"), 12345);
+  });
+
+  it("treats a missing header as 0", () => {
+    assert.equal(parseContentLength(null), 0);
+  });
+
+  it("treats an empty / non-numeric header as 0", () => {
+    assert.equal(parseContentLength(""), 0);
+    assert.equal(parseContentLength("not-a-number"), 0);
+  });
+
+  it("parses a header with surrounding whitespace", () => {
+    assert.equal(parseContentLength(" 42 "), 42);
+  });
+});
+
+describe("pickModelStatus", () => {
+  it("prefers an in-flight download even when the file is ready", () => {
+    const live: ModelStatus = { state: "downloading", progress: 0.5 };
+    assert.deepEqual(pickModelStatus(live, true), live);
+  });
+
+  it("reports ready when the file is on disk and nothing is downloading", () => {
+    assert.deepEqual(pickModelStatus(undefined, true), { state: "ready" });
+  });
+
+  it("lets an on-disk file override a stale error state", () => {
+    assert.deepEqual(pickModelStatus({ state: "error", error: "boom" }, true), { state: "ready" });
+  });
+
+  it("keeps the last error when the file is not ready", () => {
+    const live: ModelStatus = { state: "error", error: "boom" };
+    assert.deepEqual(pickModelStatus(live, false), live);
+  });
+
+  it("falls back to idle when there is no live state and no file", () => {
+    assert.deepEqual(pickModelStatus(undefined, false), { state: "idle" });
+  });
+});

--- a/packages/core/test/whisper/test_sidecar_helpers.ts
+++ b/packages/core/test/whisper/test_sidecar_helpers.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { appendStderrTail, buildServerArgs, parseInferenceText } from "../../src/whisper/sidecar-helpers.ts";
+
+describe("buildServerArgs", () => {
+  it("builds the whisper-server argv with the port stringified", () => {
+    assert.deepEqual(buildServerArgs("/models/ggml-small.bin", "127.0.0.1", 8080), [
+      "--model",
+      "/models/ggml-small.bin",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "8080",
+    ]);
+  });
+});
+
+describe("appendStderrTail", () => {
+  it("appends when under the limit", () => {
+    assert.equal(appendStderrTail("abc", "def", 100), "abcdef");
+  });
+
+  it("keeps only the last maxChars once over the limit", () => {
+    assert.equal(appendStderrTail("12345", "6789", 4), "6789");
+  });
+
+  it("handles an empty previous tail", () => {
+    assert.equal(appendStderrTail("", "hello", 3), "llo");
+  });
+
+  it("is a no-op for an empty chunk", () => {
+    assert.equal(appendStderrTail("abc", "", 10), "abc");
+  });
+
+  it("returns the whole string when maxChars is 0 (slice(-0) === slice(0))", () => {
+    assert.equal(appendStderrTail("abc", "d", 0), "abcd");
+  });
+});
+
+describe("parseInferenceText", () => {
+  it("returns the transcript from a valid response", () => {
+    assert.equal(parseInferenceText({ text: "hello world" }), "hello world");
+  });
+
+  it("returns an empty transcript verbatim", () => {
+    assert.equal(parseInferenceText({ text: "" }), "");
+  });
+
+  it("returns '' when text is missing", () => {
+    assert.equal(parseInferenceText({}), "");
+  });
+
+  it("returns '' when text is not a string", () => {
+    assert.equal(parseInferenceText({ text: 123 }), "");
+  });
+
+  it("returns '' for null / non-object / undefined inputs", () => {
+    assert.equal(parseInferenceText(null), "");
+    assert.equal(parseInferenceText("hi"), "");
+    assert.equal(parseInferenceText(undefined), "");
+    assert.equal(parseInferenceText([]), "");
+  });
+});


### PR DESCRIPTION
## Summary

The three whisper factory functions — `createVoiceCapture` (client.ts), `createSidecar` (sidecar.ts), `createModelDownloader` (models.ts) — had no behaviour tests. This PR pulls their **genuinely-pure** sub-computations out into named, exported helpers and adds focused `node:test` unit tests. Every extraction is a behaviour-preserving pure code move; the impure stream/process/IO orchestration is left exactly as it was.

**40 whisper tests pass** (35 new + 5 existing). Core typecheck clean, core build (cjs + esm) succeeds, lint 0 errors.

## Items to Confirm / Review

- **Pure-move equivalence** is the safety argument (no existing behaviour tests). Please sanity-check the one non-trivial move: `monitorTick`'s VAD logic → `evaluateVad`. The original called `cutSegment()` up to twice per tick (silence-cut then max-segment-cut); the extracted version returns a single `cut` boolean (OR of both). `cutSegment()` is idempotent (`recorder.state === "recording"` guard, and `MediaRecorder.stop()` sets state synchronously), so one call is equivalent to the original's possible double call.
- `evaluateVad` treats `rms === speechRms` as silence (strictly-greater is speech) and does not cut at exactly the silence/max boundary — matches the original `>` comparisons. Covered by boundary tests.
- `sidecar.ts`: the previously-inline magic `4000` stderr-tail cap is now the named `STDERR_TAIL_MAX_CHARS`; `appendStderrTail(prev, chunk, 0)` returns the whole string because `slice(-0) === slice(0)` (documented in a test) — irrelevant at the real call site (always 4000).

## Pure helpers extracted + tests

**client.ts → new `client-helpers.ts`** (browser-safe, testable without DOM/MediaRecorder/Web Audio):
- `computeRms(buffer)` — RMS of float samples. Tests: two-sample RMS, silence, single sample, empty→NaN.
- `containerTypeFromMime(mime)` — strip codec suffix, fallback `audio/webm`. Tests: codec suffix, bare type, empty string.
- `evaluateVad(state, segmentStartMs, rms, nowMs, config)` — one VAD tick: fold rms/time into segment state + decide force-cut (silence-after-speech or max-segment). Tests: speech resets silence, silence onset, silence-cut, below-threshold no-cut, rms-at-threshold, silence-boundary, max-segment force-cut, no-cut-before-speech.

**sidecar.ts → new `sidecar-helpers.ts`** (testable without spawning a process/socket):
- `buildServerArgs(modelPath, host, port)` — whisper-server argv (port stringified). Test: full argv.
- `appendStderrTail(prev, chunk, maxChars)` — bounded stderr tail. Tests: under limit, over limit keeps last N, empty prev, empty chunk, maxChars=0 quirk.
- `parseInferenceText(data)` — extract `text` from `/inference` JSON, `""` for any bad shape. Tests: valid, empty, missing, non-string, null/non-object/undefined/array.

**models.ts → exported in place:**
- `pickModelStatus(live, isReady)` — status precedence (downloading > on-disk ready > last transient > idle). Tests: downloading wins over ready, ready from disk, ready overrides stale error, error persists when not ready, idle fallback.
- `parseContentLength(header)` — `Content-Length` → byte count, 0 for missing/malformed. Tests: numeric, null, empty/non-numeric, whitespace.

## Left untouched (deliberately)

The impure bodies stay as-is: MediaRecorder/Web Audio wiring, generation guards, timers, and single-flight `start()` in `createVoiceCapture`; process spawn / port binding / ready-race / fetch in `createSidecar`; fetch/stream-to-disk/rename in `createModelDownloader`. Nothing there is a pure input→output computation, so extracting it would risk behaviour and is out of scope.

## Effect on lint

Each factory keeps its single `max-lines-per-function` **warning** (the impure body is still >50 counted lines): `createVoiceCapture` 189→181, `createModelDownloader` 82→79, `createSidecar` 90 (unchanged). No warnings cleared, **no new problems introduced** — primary deliverable is test coverage, line reduction is a side benefit.

## User Prompt

Add test coverage to three currently-untested whisper functions (`createVoiceCapture`, `createSidecar`, `createModelDownloader`) by extracting their pure sub-logic into named exported functions and unit-testing them. Behaviour-preserving and test-adding, not a rewrite: only extract genuinely-pure bits (no I/O, network, timers, closure mutation, stream/process access), call them from the original code as pure moves, and add `node:test` unit tests (happy path + edge/boundary + empty/invalid). Leave impure parts alone; skip any function with no cleanly-pure logic. No `eslint-disable`. Verify typecheck/build/lint/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)