### PR TITLE
test: extract + cover pure useCollectionRendering logic (lint max-lines)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts
@@ -1,0 +1,179 @@
+// Pure, reactivity-free data transforms extracted from
+// useCollectionRendering.ts so they can be unit-tested in isolation. NO
+// vue / DOM / I/O / reactive state here — every function is a plain
+// function of its arguments. The composable imports these and calls them
+// from inside its computed/watch closures; behaviour is identical.
+
+import { deriveAll } from "@mulmoclaude/core/collection";
+import type {
+  CollectionDetailResponse,
+  CollectionItem,
+  CollectionSchema,
+  CollectionFieldSpec as FieldSpec,
+  CollectionFieldType as FieldType,
+  RefDisplayMap,
+  RefOption,
+  RefRecordMap,
+} from "@mulmoclaude/core/collection";
+
+const EM_DASH = "—";
+const DEFAULT_CURRENCY = "USD";
+// Markdown cells are single-line list previews; longer text is elided so
+// the table row stays one line.
+const MARKDOWN_CELL_PREVIEW_MAX = 80;
+
+// `<input type="number">` defaults to step="1", which makes the browser
+// reject any decimal value (e.g. 0.1) as invalid. Emit step="any" for
+// numeric fields so fractional values can be entered and saved.
+export function stepForFieldType(type: FieldType): string | undefined {
+  if (type === "money") return "0.01";
+  if (type === "number") return "any";
+  return undefined;
+}
+
+export function inputTypeFor(type: FieldType): string {
+  if (type === "email") return "email";
+  if (type === "number") return "number";
+  if (type === "money") return "number";
+  if (type === "date") return "date";
+  if (type === "datetime") return "datetime-local";
+  return "text";
+}
+
+export function isExternalUrl(value: unknown): boolean {
+  return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
+export function detailText(value: unknown): string {
+  if (value === undefined || value === null || value === "") return EM_DASH;
+  return String(value);
+}
+
+export function formatCell(value: unknown, type: FieldType): string {
+  if (value === undefined || value === null || value === "") return EM_DASH;
+  if (type === "markdown" && typeof value === "string") {
+    return value.length > MARKDOWN_CELL_PREVIEW_MAX ? `${value.slice(0, MARKDOWN_CELL_PREVIEW_MAX)}…` : value;
+  }
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  return JSON.stringify(value);
+}
+
+/** Resolve the ISO 4217 code for a money field: a per-record
+ *  `currencyField` (when present and non-blank) wins over the field's
+ *  literal `currency`. */
+export function resolveCurrency(field: FieldSpec, record: CollectionItem | null | undefined): string | undefined {
+  if (field.currencyField && record) {
+    const code = record[field.currencyField];
+    if (typeof code === "string" && code.trim().length > 0) return code;
+  }
+  return field.currency;
+}
+
+export function formatMoney(value: unknown, currency: string | undefined, displayLocale: string): string {
+  if (value === undefined || value === "") return EM_DASH;
+  const amount = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(amount)) return String(value);
+  const currencyCode = currency && currency.length > 0 ? currency : DEFAULT_CURRENCY;
+  try {
+    return new Intl.NumberFormat(displayLocale, { style: "currency", currency: currencyCode }).format(amount);
+  } catch {
+    return String(amount);
+  }
+}
+
+export function currencySymbolForLocale(currency: string | undefined, locale: string): string {
+  const code = currency && currency.length > 0 ? currency : DEFAULT_CURRENCY;
+  try {
+    const parts = new Intl.NumberFormat(locale, { style: "currency", currency: code }).formatToParts(0);
+    return parts.find((entry) => entry.type === "currency")?.value ?? code;
+  } catch {
+    return code;
+  }
+}
+
+export function tableRows(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row));
+}
+
+export function hasTableRows(value: unknown): boolean {
+  return tableRows(value).length > 0;
+}
+
+/** Pick the field used to label a referenced/embedded record: prefer a
+ *  `name` field, then `title`, else fall back to the primary key. */
+export function displayFieldFor(fields: Record<string, FieldSpec>, primaryKey: string): string {
+  if ("name" in fields) return "name";
+  if ("title" in fields) return "title";
+  return primaryKey;
+}
+
+export function uniqueRefTargets(schema: CollectionSchema): string[] {
+  const targets = new Set<string>();
+  const walk = (fields: Record<string, FieldSpec>): void => {
+    for (const field of Object.values(fields)) {
+      if (field.type === "ref" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
+      // Sub-fields of a table can also be refs; walk one level deep
+      // (nested tables are schema-rejected, so one recursion suffices).
+      if (field.type === "table" && field.of) walk(field.of);
+    }
+  };
+  walk(schema.fields);
+  return [...targets];
+}
+
+export function uniqueEmbedTargets(schema: CollectionSchema): string[] {
+  const targets = new Set<string>();
+  // Embeds are top-level only (the schema rejects `embed` inside a
+  // table's `of`), so no recursion.
+  for (const field of Object.values(schema.fields)) {
+    if (field.type === "embed" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
+  }
+  return [...targets];
+}
+
+export function buildRefDisplayMap(detail: CollectionDetailResponse): RefDisplayMap {
+  const { fields, primaryKey } = detail.collection.schema;
+  const displayField = displayFieldFor(fields, primaryKey);
+  const map: RefDisplayMap = {};
+  for (const item of detail.items) {
+    const slugRaw = item[primaryKey];
+    if (typeof slugRaw !== "string" || slugRaw.length === 0) continue;
+    const displayRaw = item[displayField];
+    map[slugRaw] = typeof displayRaw === "string" && displayRaw.length > 0 ? displayRaw : slugRaw;
+  }
+  return map;
+}
+
+export function buildRefRecordMap(detail: CollectionDetailResponse): RefRecordMap {
+  const { schema } = detail.collection;
+  const map: RefRecordMap = {};
+  for (const item of detail.items) {
+    const slugRaw = item[schema.primaryKey];
+    if (typeof slugRaw === "string" && slugRaw.length > 0) map[slugRaw] = deriveAll(schema, item, {});
+  }
+  return map;
+}
+
+export function sortedRefOptions(map: RefDisplayMap): RefOption[] {
+  return Object.entries(map)
+    .map(([slug, display]) => ({ slug, display }))
+    .sort((left, right) => left.display.localeCompare(right.display));
+}
+
+/** Dropdown options for an `embed` field's per-record picker: every
+ *  record in the target collection, labelled by its name/title (or
+ *  primary key), skipping records without a slug and sorted by label. */
+export function buildEmbedOptions(schema: CollectionSchema, items: CollectionItem[]): RefOption[] {
+  const { fields, primaryKey } = schema;
+  const displayField = displayFieldFor(fields, primaryKey);
+  return items
+    .map((item) => {
+      const slug = String(item[primaryKey] ?? "");
+      const labelRaw = item[displayField];
+      const display = typeof labelRaw === "string" && labelRaw.length > 0 ? labelRaw : slug;
+      return { slug, display };
+    })
+    .filter((opt) => opt.slug.length > 0)
+    .sort((left, right) => left.display.localeCompare(right.display));
+}

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
@@ -6,6 +6,10 @@
 // templates render (ref labels, money/currency, derived formulas, embed
 // rows). Pure-but-stateful: instantiate ONCE per collection surface and
 // pass the returned object down to child panels.
+//
+// The pure, reactivity-free transforms this composable relies on live in
+// `useCollectionRendering.helpers.ts` (plain TS, unit-tested); only the
+// ref/computed/watch-bound glue stays here.
 
 import { ref, type Ref } from "vue";
 import { collectionUi } from "./uiContext";
@@ -16,16 +20,31 @@ import type {
   CollectionSchema,
   CollectionFieldSpec as FieldSpec,
   CollectionFieldType as FieldType,
-  CollectionDetailResponse,
   EmbedCache,
   EmbedRow,
   EmbedView,
   RefCache,
-  RefDisplayMap,
   RefOption,
   RefRecordCache,
-  RefRecordMap,
 } from "@mulmoclaude/core/collection";
+import {
+  buildEmbedOptions,
+  buildRefDisplayMap,
+  buildRefRecordMap,
+  currencySymbolForLocale,
+  detailText,
+  formatCell,
+  formatMoney,
+  hasTableRows,
+  inputTypeFor,
+  isExternalUrl,
+  resolveCurrency,
+  sortedRefOptions,
+  stepForFieldType,
+  tableRows,
+  uniqueEmbedTargets,
+  uniqueRefTargets,
+} from "./useCollectionRendering.helpers";
 
 export interface CollectionRendering {
   refCache: Ref<RefCache>;
@@ -55,15 +74,6 @@ export interface CollectionRendering {
   derivedDisplay: (field: FieldSpec, computedValue: unknown, record: CollectionItem | null) => string;
 }
 
-// `<input type="number">` defaults to step="1", which makes the browser
-// reject any decimal value (e.g. 0.1) as invalid. Emit step="any" for
-// numeric fields so fractional values can be entered and saved.
-export function stepForFieldType(type: FieldType): string | undefined {
-  if (type === "money") return "0.01";
-  if (type === "number") return "any";
-  return undefined;
-}
-
 export function useCollectionRendering(collection: Ref<CollectionDetail | null>, locale: Ref<string>): CollectionRendering {
   const refCache = ref<RefCache>({});
   const refRecordCache = ref<RefRecordCache>({});
@@ -73,53 +83,6 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     refCache.value = {};
     refRecordCache.value = {};
     embedCache.value = {};
-  }
-
-  function uniqueRefTargets(schema: CollectionSchema): string[] {
-    const targets = new Set<string>();
-    const walk = (fields: Record<string, FieldSpec>): void => {
-      for (const field of Object.values(fields)) {
-        if (field.type === "ref" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
-        // Sub-fields of a table can also be refs; walk one level deep
-        // (nested tables are schema-rejected, so one recursion suffices).
-        if (field.type === "table" && field.of) walk(field.of);
-      }
-    };
-    walk(schema.fields);
-    return [...targets];
-  }
-
-  function uniqueEmbedTargets(schema: CollectionSchema): string[] {
-    const targets = new Set<string>();
-    // Embeds are top-level only (the schema rejects `embed` inside a
-    // table's `of`), so no recursion.
-    for (const field of Object.values(schema.fields)) {
-      if (field.type === "embed" && typeof field.to === "string" && field.to.length > 0) targets.add(field.to);
-    }
-    return [...targets];
-  }
-
-  function buildRefDisplayMap(detail: CollectionDetailResponse): RefDisplayMap {
-    const { fields, primaryKey } = detail.collection.schema;
-    const displayField = "name" in fields ? "name" : "title" in fields ? "title" : primaryKey;
-    const map: RefDisplayMap = {};
-    for (const item of detail.items) {
-      const slugRaw = item[primaryKey];
-      if (typeof slugRaw !== "string" || slugRaw.length === 0) continue;
-      const displayRaw = item[displayField];
-      map[slugRaw] = typeof displayRaw === "string" && displayRaw.length > 0 ? displayRaw : slugRaw;
-    }
-    return map;
-  }
-
-  function buildRefRecordMap(detail: CollectionDetailResponse): RefRecordMap {
-    const { schema } = detail.collection;
-    const map: RefRecordMap = {};
-    for (const item of detail.items) {
-      const slugRaw = item[schema.primaryKey];
-      if (typeof slugRaw === "string" && slugRaw.length > 0) map[slugRaw] = deriveAll(schema, item, {});
-    }
-    return map;
   }
 
   async function loadLinkedCollections(schema: CollectionSchema, expectedSlug: string): Promise<void> {
@@ -166,10 +129,7 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
 
   function refOptions(targetSlug: string): RefOption[] {
     const map = refCache.value[targetSlug];
-    if (!map) return [];
-    return Object.entries(map)
-      .map(([slug, display]) => ({ slug, display }))
-      .sort((left, right) => left.display.localeCompare(right.display));
+    return map ? sortedRefOptions(map) : [];
   }
 
   /** Dropdown options for an `embed` field's per-record picker (`idField`):
@@ -178,18 +138,7 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
    *  that aren't also `ref` targets (the profile collection, say). */
   function embedOptions(targetSlug: string): RefOption[] {
     const data = embedCache.value[targetSlug];
-    if (!data) return [];
-    const { fields, primaryKey } = data.schema;
-    const displayField = "name" in fields ? "name" : "title" in fields ? "title" : primaryKey;
-    return data.items
-      .map((item) => {
-        const slug = String(item[primaryKey] ?? "");
-        const labelRaw = item[displayField];
-        const display = typeof labelRaw === "string" && labelRaw.length > 0 ? labelRaw : slug;
-        return { slug, display };
-      })
-      .filter((opt) => opt.slug.length > 0)
-      .sort((left, right) => left.display.localeCompare(right.display));
+    return data ? buildEmbedOptions(data.schema, data.items) : [];
   }
 
   function resolveEmbed(field: FieldSpec, record: CollectionItem | null): { schema: CollectionSchema | null; item: CollectionItem | null } {
@@ -230,45 +179,8 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return out;
   }
 
-  function resolveCurrency(field: FieldSpec, record: CollectionItem | null | undefined): string | undefined {
-    if (field.currencyField && record) {
-      const code = record[field.currencyField];
-      if (typeof code === "string" && code.trim().length > 0) return code;
-    }
-    return field.currency;
-  }
-
   function currencySymbol(currency: string | undefined): string {
-    const code = currency && currency.length > 0 ? currency : "USD";
-    try {
-      const parts = new Intl.NumberFormat(locale.value, { style: "currency", currency: code }).formatToParts(0);
-      return parts.find((entry) => entry.type === "currency")?.value ?? code;
-    } catch {
-      return code;
-    }
-  }
-
-  function formatMoney(value: unknown, currency: string | undefined, displayLocale: string): string {
-    if (value === undefined || value === "") return "—";
-    const amount = typeof value === "number" ? value : Number(value);
-    if (!Number.isFinite(amount)) return String(value);
-    const currencyCode = currency && currency.length > 0 ? currency : "USD";
-    try {
-      return new Intl.NumberFormat(displayLocale, { style: "currency", currency: currencyCode }).format(amount);
-    } catch {
-      return String(amount);
-    }
-  }
-
-  function formatCell(value: unknown, type: FieldType): string {
-    if (value === undefined || value === null || value === "") return "—";
-    if (type === "markdown" && typeof value === "string") return value.length > 80 ? `${value.slice(0, 80)}…` : value;
-    if (typeof value === "string" || typeof value === "number") return String(value);
-    return JSON.stringify(value);
-  }
-
-  function isExternalUrl(value: unknown): boolean {
-    return typeof value === "string" && /^https?:\/\//i.test(value);
+    return currencySymbolForLocale(currency, locale.value);
   }
 
   // A `file` field holds a workspace-relative path. When it points at an
@@ -288,33 +200,10 @@ export function useCollectionRendering(collection: Ref<CollectionDetail | null>,
     return collectionUi().fileRoutePath(value);
   }
 
-  function detailText(value: unknown): string {
-    if (value === undefined || value === null || value === "") return "—";
-    return String(value);
-  }
-
-  function tableRows(value: unknown): Record<string, unknown>[] {
-    if (!Array.isArray(value)) return [];
-    return value.filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row));
-  }
-
-  function hasTableRows(value: unknown): boolean {
-    return tableRows(value).length > 0;
-  }
-
   function formatSubCell(subField: FieldSpec, value: unknown, record: CollectionItem | null): string {
     if (subField.type === "money") return formatMoney(value, resolveCurrency(subField, record), locale.value);
     if (subField.type === "ref" && subField.to && typeof value === "string" && value.length > 0) return refDisplay(subField.to, value);
     return formatCell(value, subField.type);
-  }
-
-  function inputTypeFor(type: FieldType): string {
-    if (type === "email") return "email";
-    if (type === "number") return "number";
-    if (type === "money") return "number";
-    if (type === "date") return "date";
-    if (type === "datetime") return "datetime-local";
-    return "text";
   }
 
   const stepFor = stepForFieldType;

--- a/test/plugins/collection/test_collectionRenderingHelpers.ts
+++ b/test/plugins/collection/test_collectionRenderingHelpers.ts
@@ -1,0 +1,307 @@
+// Unit tests for the pure, reactivity-free transforms extracted from the
+// collection rendering composable
+// (packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts).
+// These are plain functions of their arguments — no vue / DOM / caches —
+// so they pin the money/label/target/option logic the templates depend on.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type {
+  CollectionDetail,
+  CollectionDetailResponse,
+  CollectionItem,
+  CollectionSchema,
+  CollectionFieldSpec as FieldSpec,
+  CollectionFieldType as FieldType,
+} from "@mulmoclaude/core/collection";
+import {
+  buildEmbedOptions,
+  buildRefDisplayMap,
+  buildRefRecordMap,
+  currencySymbolForLocale,
+  detailText,
+  displayFieldFor,
+  formatCell,
+  formatMoney,
+  hasTableRows,
+  inputTypeFor,
+  isExternalUrl,
+  resolveCurrency,
+  sortedRefOptions,
+  stepForFieldType,
+  tableRows,
+  uniqueEmbedTargets,
+  uniqueRefTargets,
+} from "../../../packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers";
+
+const field = (type: FieldType, extra: Partial<FieldSpec> = {}): FieldSpec => ({ type, label: type, ...extra });
+
+const makeSchema = (fields: Record<string, FieldSpec>, primaryKey = "id"): CollectionSchema => ({
+  title: "Test",
+  icon: "list",
+  dataPath: "collections/test",
+  primaryKey,
+  fields,
+});
+
+const makeDetail = (schema: CollectionSchema, items: CollectionItem[]): CollectionDetailResponse => {
+  const collection: CollectionDetail = { slug: "test", title: "Test", icon: "list", source: "user", schema };
+  return { collection, items };
+};
+
+describe("stepForFieldType", () => {
+  it("emits a 2-decimal step for money and step=any for number", () => {
+    assert.equal(stepForFieldType("money"), "0.01");
+    assert.equal(stepForFieldType("number"), "any");
+  });
+  it("is undefined for non-numeric field types", () => {
+    assert.equal(stepForFieldType("text"), undefined);
+    assert.equal(stepForFieldType("date"), undefined);
+  });
+});
+
+describe("inputTypeFor", () => {
+  it("maps money to the number input", () => {
+    assert.equal(inputTypeFor("money"), "number");
+    assert.equal(inputTypeFor("number"), "number");
+  });
+  it("maps datetime to datetime-local and passes through email/date", () => {
+    assert.equal(inputTypeFor("datetime"), "datetime-local");
+    assert.equal(inputTypeFor("email"), "email");
+    assert.equal(inputTypeFor("date"), "date");
+  });
+  it("falls back to text for everything else", () => {
+    assert.equal(inputTypeFor("markdown"), "text");
+    assert.equal(inputTypeFor("ref"), "text");
+  });
+});
+
+describe("isExternalUrl", () => {
+  it("accepts http and https, case-insensitively", () => {
+    assert.equal(isExternalUrl("http://example.com"), true);
+    assert.equal(isExternalUrl("https://example.com"), true);
+    assert.equal(isExternalUrl("HTTPS://EXAMPLE.COM"), true);
+  });
+  it("rejects non-http schemes, relative paths, and non-strings", () => {
+    assert.equal(isExternalUrl("ftp://example.com"), false);
+    assert.equal(isExternalUrl("/local/path"), false);
+    assert.equal(isExternalUrl(""), false);
+    assert.equal(isExternalUrl(42), false);
+    assert.equal(isExternalUrl(null), false);
+  });
+});
+
+describe("detailText", () => {
+  it("renders an em-dash for empty-ish values", () => {
+    assert.equal(detailText(undefined), "—");
+    assert.equal(detailText(null), "—");
+    assert.equal(detailText(""), "—");
+  });
+  it("stringifies real values, including falsy-but-present ones", () => {
+    assert.equal(detailText("hello"), "hello");
+    assert.equal(detailText(0), "0");
+    assert.equal(detailText(false), "false");
+  });
+});
+
+describe("formatCell", () => {
+  it("renders an em-dash for empty-ish values", () => {
+    assert.equal(formatCell(undefined, "text"), "—");
+    assert.equal(formatCell(null, "text"), "—");
+    assert.equal(formatCell("", "text"), "—");
+  });
+  it("passes markdown through untouched at or below the preview length", () => {
+    const exactly80 = "a".repeat(80);
+    assert.equal(formatCell(exactly80, "markdown"), exactly80);
+    assert.equal(formatCell("short", "markdown"), "short");
+  });
+  it("truncates markdown longer than 80 chars with an ellipsis", () => {
+    const long = "a".repeat(81);
+    const out = formatCell(long, "markdown");
+    assert.equal(out, `${"a".repeat(80)}…`);
+    assert.equal(out.length, 81); // 80 chars + the single ellipsis glyph
+  });
+  it("stringifies primitives and JSON-encodes objects", () => {
+    assert.equal(formatCell(7, "number"), "7");
+    assert.equal(formatCell("x", "text"), "x");
+    assert.equal(formatCell({ a: 1 }, "text"), '{"a":1}');
+  });
+});
+
+describe("resolveCurrency", () => {
+  it("prefers a per-record currencyField over the literal currency", () => {
+    const spec = field("money", { currency: "USD", currencyField: "cur" });
+    assert.equal(resolveCurrency(spec, { cur: "JPY" }), "JPY");
+  });
+  it("falls back to the literal currency when the field is blank or absent", () => {
+    const spec = field("money", { currency: "USD", currencyField: "cur" });
+    assert.equal(resolveCurrency(spec, { cur: "   " }), "USD");
+    assert.equal(resolveCurrency(spec, {}), "USD");
+    assert.equal(resolveCurrency(spec, null), "USD");
+  });
+  it("returns the literal currency when no currencyField is declared", () => {
+    assert.equal(resolveCurrency(field("money", { currency: "EUR" }), { cur: "JPY" }), "EUR");
+  });
+});
+
+describe("formatMoney", () => {
+  it("renders an em-dash for empty-ish input", () => {
+    assert.equal(formatMoney(undefined, "USD", "en-US"), "—");
+    assert.equal(formatMoney("", "USD", "en-US"), "—");
+  });
+  it("formats numeric and numeric-string amounts", () => {
+    assert.ok(formatMoney(1234.5, "USD", "en-US").includes("1,234.50"));
+    assert.ok(formatMoney("12.5", "USD", "en-US").includes("12.50"));
+  });
+  it("defaults a missing currency to USD", () => {
+    assert.ok(formatMoney(1, undefined, "en-US").includes("$"));
+  });
+  it("returns the raw string for non-finite amounts", () => {
+    assert.equal(formatMoney("abc", "USD", "en-US"), "abc");
+  });
+  it("degrades to the plain number when the currency code is invalid", () => {
+    assert.equal(formatMoney(5, "NOTACODE", "en-US"), "5");
+  });
+});
+
+describe("currencySymbolForLocale", () => {
+  it("returns the localized symbol for known codes", () => {
+    assert.equal(currencySymbolForLocale("USD", "en-US"), "$");
+    assert.equal(currencySymbolForLocale("JPY", "en-US"), "¥");
+    assert.equal(currencySymbolForLocale("EUR", "en-US"), "€");
+  });
+  it("defaults a blank currency to USD", () => {
+    assert.equal(currencySymbolForLocale(undefined, "en-US"), "$");
+    assert.equal(currencySymbolForLocale("", "en-US"), "$");
+  });
+  it("returns the code itself when it is not a valid currency", () => {
+    assert.equal(currencySymbolForLocale("NOTACODE", "en-US"), "NOTACODE");
+  });
+});
+
+describe("tableRows / hasTableRows", () => {
+  it("keeps only plain-object rows", () => {
+    const rows = tableRows([{ a: 1 }, null, [1, 2], "x", 5, { b: 2 }]);
+    assert.deepEqual(rows, [{ a: 1 }, { b: 2 }]);
+  });
+  it("returns an empty array for non-arrays and empty input", () => {
+    assert.deepEqual(tableRows(undefined), []);
+    assert.deepEqual(tableRows("nope"), []);
+    assert.deepEqual(tableRows([]), []);
+  });
+  it("hasTableRows reflects whether any valid row survives", () => {
+    assert.equal(hasTableRows([{ a: 1 }]), true);
+    assert.equal(hasTableRows([null, [1], "x"]), false);
+    assert.equal(hasTableRows([]), false);
+    assert.equal(hasTableRows(undefined), false);
+  });
+});
+
+describe("displayFieldFor", () => {
+  it("prefers name, then title, else the primary key", () => {
+    assert.equal(displayFieldFor({ name: field("text"), title: field("text") }, "id"), "name");
+    assert.equal(displayFieldFor({ title: field("text") }, "id"), "title");
+    assert.equal(displayFieldFor({ other: field("text") }, "id"), "id");
+  });
+});
+
+describe("uniqueRefTargets", () => {
+  it("collects top-level and one-level table ref targets, de-duplicated", () => {
+    const schema = makeSchema({
+      author: field("ref", { to: "people" }),
+      editor: field("ref", { to: "people" }),
+      lines: field("table", { of: { who: field("ref", { to: "vendors" }), qty: field("number") } }),
+      note: field("text"),
+    });
+    assert.deepEqual(uniqueRefTargets(schema).sort(), ["people", "vendors"]);
+  });
+  it("ignores refs with an empty target and tables without an of-schema", () => {
+    const schema = makeSchema({ a: field("ref", { to: "" }), b: field("table"), c: field("text") });
+    assert.deepEqual(uniqueRefTargets(schema), []);
+  });
+});
+
+describe("uniqueEmbedTargets", () => {
+  it("collects top-level embed targets only, de-duplicated", () => {
+    const schema = makeSchema({
+      billFrom: field("embed", { to: "profiles", id: "me" }),
+      billTo: field("embed", { to: "profiles", idField: "customerId" }),
+      author: field("ref", { to: "people" }),
+    });
+    assert.deepEqual(uniqueEmbedTargets(schema), ["profiles"]);
+  });
+  it("ignores embeds with an empty target", () => {
+    assert.deepEqual(uniqueEmbedTargets(makeSchema({ a: field("embed", { to: "" }) })), []);
+  });
+});
+
+describe("buildRefDisplayMap", () => {
+  it("maps primary-key slug to the name field, falling back to slug", () => {
+    const schema = makeSchema({ id: field("text"), name: field("text") });
+    const detail = makeDetail(schema, [{ id: "a", name: "Alice" }, { id: "b" }]);
+    assert.deepEqual(buildRefDisplayMap(detail), { a: "Alice", b: "b" });
+  });
+  it("uses title when there is no name field", () => {
+    const schema = makeSchema({ id: field("text"), title: field("text") });
+    const detail = makeDetail(schema, [{ id: "a", title: "Hello" }]);
+    assert.deepEqual(buildRefDisplayMap(detail), { a: "Hello" });
+  });
+  it("skips items whose primary key is missing or not a string", () => {
+    const schema = makeSchema({ id: field("text"), name: field("text") });
+    const detail = makeDetail(schema, [{ id: "", name: "X" }, { name: "Y" }, { id: 3, name: "Z" }]);
+    assert.deepEqual(buildRefDisplayMap(detail), {});
+  });
+});
+
+describe("buildRefRecordMap", () => {
+  it("keys full records by slug and runs the derive loop", () => {
+    const schema = makeSchema({
+      id: field("text"),
+      qty: field("number"),
+      price: field("number"),
+      total: field("derived", { formula: "qty * price" }),
+    });
+    const detail = makeDetail(schema, [{ id: "a", qty: 2, price: 10 }]);
+    const map = buildRefRecordMap(detail);
+    assert.deepEqual(Object.keys(map), ["a"]);
+    assert.equal(map.a.total, 20);
+    assert.equal(map.a.qty, 2);
+  });
+  it("skips items without a valid string primary key", () => {
+    const schema = makeSchema({ id: field("text") });
+    const detail = makeDetail(schema, [{ id: "" }, { id: 5 }]);
+    assert.deepEqual(buildRefRecordMap(detail), {});
+  });
+});
+
+describe("sortedRefOptions", () => {
+  it("turns a display map into options sorted by label", () => {
+    assert.deepEqual(sortedRefOptions({ b: "Beta", a: "Alpha", c: "Gamma" }), [
+      { slug: "a", display: "Alpha" },
+      { slug: "b", display: "Beta" },
+      { slug: "c", display: "Gamma" },
+    ]);
+  });
+  it("returns an empty array for an empty map", () => {
+    assert.deepEqual(sortedRefOptions({}), []);
+  });
+});
+
+describe("buildEmbedOptions", () => {
+  it("labels each record, drops slug-less rows, and sorts by label", () => {
+    const schema = makeSchema({ id: field("text"), name: field("text") });
+    const items: CollectionItem[] = [{ id: "z", name: "Zed" }, { id: "a", name: "Amy" }, { name: "no-slug" }];
+    assert.deepEqual(buildEmbedOptions(schema, items), [
+      { slug: "a", display: "Amy" },
+      { slug: "z", display: "Zed" },
+    ]);
+  });
+  it("falls back to the slug when the label field is empty", () => {
+    const schema = makeSchema({ id: field("text"), name: field("text") });
+    assert.deepEqual(buildEmbedOptions(schema, [{ id: "solo" }]), [{ slug: "solo", display: "solo" }]);
+  });
+  it("returns an empty array for no items", () => {
+    assert.deepEqual(buildEmbedOptions(makeSchema({ id: field("text") }), []), []);
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage to the largest untested function in the collection plugin —
`useCollectionRendering` (~241-line Vue composable) — by extracting its **pure,
reactivity-free sub-logic** into a new sibling `useCollectionRendering.helpers.ts`
(plain TS, no vue import) and unit-testing each helper. This is **behaviour-preserving
+ test-adding**, not a rewrite: the composable imports the helpers and calls them from
inside the same computed/watch closures.

All `ref` / `computed` / `watch` / reactive code (caches, the fan-out fetch, the
locale-bound wrappers, the embed view-model builder, the derived-formula wrappers)
**stays in the composable**. Only the plain input→output transforms moved.

`useCollectionRendering.ts` shrank 368 → 257 lines (-111); that logic now lives in the
179-line, independently-testable helpers file. The composable **function body** dropped
from ~292 lines to 136 (the `max-lines-per-function` metric).

## Items to Confirm / Review

- **Behaviour preservation** — every helper was moved verbatim; the only intentional
  changes are (a) magic literals named as constants (`EM_DASH`, `DEFAULT_CURRENCY`,
  `MARKDOWN_CELL_PREVIEW_MAX = 80`) and (b) a shared `displayFieldFor()` that replaces
  the duplicated `"name" in fields ? … : primaryKey` expression in `buildRefDisplayMap`
  and `buildEmbedOptions`. Please confirm those two dedup/rename moves read as
  equivalent.
- **`stepForFieldType` moved** — it was a top-level `export` of `useCollectionRendering.ts`;
  it now lives in the helpers file and is imported. Nothing outside the module imported
  it (only the generated `dist/*.d.ts` + the composable itself), and `vue/index.ts` only
  re-exports `useCollectionRendering` / `CollectionRendering`, so the public surface is
  unchanged.
- **Expected residual lint warning** — `useCollectionRendering` still trips
  `max-lines-per-function` (136 > 50). That's expected: the reactive core cannot be
  pulled into pure helpers. The count dropped substantially (was ~292).

## Pure helpers extracted (17)

`stepForFieldType`, `inputTypeFor`, `isExternalUrl`, `detailText`, `formatCell`,
`resolveCurrency`, `formatMoney`, `currencySymbolForLocale` (locale passed as an arg
instead of read from the `locale` ref — the composable keeps a thin `currencySymbol`
wrapper), `tableRows`, `hasTableRows`, `displayFieldFor`, `uniqueRefTargets`,
`uniqueEmbedTargets`, `buildRefDisplayMap`, `buildRefRecordMap`, `sortedRefOptions`
(pure core of `refOptions`), `buildEmbedOptions` (pure core of `embedOptions`).

Left in place (reactive / context / I/O — NOT pure): `loadLinkedCollections`,
`refDisplay`, `refOptions`/`embedOptions`/`currencySymbol` wrappers, `resolveEmbed`,
`embedValue`, `embedViewsFor`, `artifactUrl`, `fileRoutePath`, `formatSubCell`,
`evaluateDerivedAgainstItem`, `derivedDisplay`.

## Tests

`test/plugins/collection/test_collectionRenderingHelpers.ts` — **42 `node:test` cases**
across 16 suites: happy path + edge cases (empty list, missing/blank field, non-string
primary key, boundary at the 80-char markdown-preview cutoff, invalid currency code,
falsy-but-present values, de-dup of ref/embed targets, one-level table-ref recursion).

## Verification

- `vue-tsc --noEmit` on the plugin (`tsconfig.json` + `tsconfig.build.json`): clean
- test-project typecheck (`tsc -p test/tsconfig.json --noEmit`): clean
- `eslint` on the 3 changed files: **0 errors** (1 expected `max-lines-per-function`
  warning, see above)
- new tests: **42/42 pass**

_Note: full `yarn build` was not run inside the isolated git worktree (no local
node_modules); the build's only type gate is `vue-tsc`, which passes. `vite build`
performs no type-checking._