### PR TITLE
chore: extract pure helpers from three composables + unit tests

### DIFF
--- a/src/composables/useFileTree.helpers.ts
+++ b/src/composables/useFileTree.helpers.ts
@@ -1,0 +1,13 @@
+/** Ancestor directory paths of a workspace-relative file, ordered
+ *  shallowest-first and EXCLUDING the file's own leaf. Returns `[]` for
+ *  a root-level file (or empty input) since it has no directory to load.
+ *  Leading and duplicate slashes are dropped as empty segments. */
+export function computeAncestorDirs(filePath: string): string[] {
+  const parts = filePath.split("/").filter(Boolean);
+  if (parts.length <= 1) return [];
+  const ancestors: string[] = [];
+  for (let i = 1; i < parts.length; i++) {
+    ancestors.push(parts.slice(0, i).join("/"));
+  }
+  return ancestors;
+}

--- a/src/composables/useFileTree.ts
+++ b/src/composables/useFileTree.ts
@@ -6,6 +6,7 @@ import type { TreeNode } from "../types/fileTree";
 import { useExpandedDirs } from "./useExpandedDirs";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { computeAncestorDirs } from "./useFileTree.helpers";
 
 export function useFileTree() {
   const { expand } = useExpandedDirs();
@@ -63,13 +64,7 @@ export function useFileTree() {
   }
 
   async function ensureAncestorsLoaded(filePath: string): Promise<void> {
-    const parts = filePath.split("/").filter(Boolean);
-    if (parts.length <= 1) return;
-    const ancestors: string[] = [];
-    for (let i = 1; i < parts.length; i++) {
-      ancestors.push(parts.slice(0, i).join("/"));
-    }
-    for (const dir of ancestors) {
+    for (const dir of computeAncestorDirs(filePath)) {
       expand(dir);
       await loadDirChildren(dir);
     }

--- a/src/composables/useSessionHistory.helpers.ts
+++ b/src/composables/useSessionHistory.helpers.ts
@@ -1,0 +1,8 @@
+import type { SessionSummary } from "../types/session";
+
+/** Return a new session list with `isBookmarked` set to `bookmarked` on
+ *  the session whose id matches `sessionId`. Non-matching sessions are
+ *  returned by reference; the input array is never mutated. */
+export function applyBookmarkFlag(sessions: SessionSummary[], sessionId: string, bookmarked: boolean): SessionSummary[] {
+  return sessions.map((session) => (session.id === sessionId ? { ...session, isBookmarked: bookmarked } : session));
+}

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -6,6 +6,7 @@ import { PUBSUB_CHANNELS, type SessionsChannelPayload } from "../config/pubsubCh
 import type { SessionSummary } from "../types/session";
 import { apiDelete, apiGet, apiPost } from "../utils/api";
 import { applySessionDiff } from "../utils/session/mergeSessions";
+import { applyBookmarkFlag } from "./useSessionHistory.helpers";
 import { usePubSub } from "./usePubSub";
 
 interface SessionsResponse {
@@ -65,7 +66,7 @@ export function useSessionHistory(): UseSessionHistory {
     // Optimistic local update so the green-icon flip is immediate;
     // the pub/sub round-trip will reaffirm via the cursor diff (meta
     // mtime feeds into changeMs) and also reach other tabs.
-    sessions.value = sessions.value.map((session) => (session.id === sessionId ? { ...session, isBookmarked: bookmarked } : session));
+    sessions.value = applyBookmarkFlag(sessions.value, sessionId, bookmarked);
     return true;
   }
 

--- a/src/composables/useVoiceInput.helpers.ts
+++ b/src/composables/useVoiceInput.helpers.ts
@@ -1,0 +1,12 @@
+import type { VoiceInputStatusResponse } from "./useVoiceInput";
+
+/** Derive the readiness flags the capture controller consumes from a
+ *  raw `GET /api/transcribe/model` status. Both flags require the host
+ *  to be capable and the feature enabled before the model state matters. */
+export function deriveVoiceModelReadiness(status: VoiceInputStatusResponse): { ready: boolean; downloading: boolean } {
+  const { capable, enabled, model } = status;
+  return {
+    ready: capable && enabled && model.state === "ready",
+    downloading: capable && enabled && model.state === "downloading",
+  };
+}

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -9,6 +9,7 @@ import { onScopeDispose, ref, type Ref } from "vue";
 import { createVoiceCapture, localeToWhisperLanguage, type VoiceCaptureTransport } from "@mulmoclaude/core/whisper/client";
 import { API_ROUTES } from "../config/apiRoutes";
 import { apiGet, apiPost } from "../utils/api";
+import { deriveVoiceModelReadiness } from "./useVoiceInput.helpers";
 
 export interface VoiceModelStatus {
   name: string;
@@ -61,11 +62,7 @@ export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
     async getStatus() {
       const result = await apiGet<VoiceInputStatusResponse>(API_ROUTES.transcribe.model);
       if (!result.ok) throw new Error(result.error || "status failed");
-      const { capable, enabled, model } = result.data;
-      return {
-        ready: capable && enabled && model.state === "ready",
-        downloading: capable && enabled && model.state === "downloading",
-      };
+      return deriveVoiceModelReadiness(result.data);
     },
   };
 

--- a/test/composables/test_useFileTreeHelpers.ts
+++ b/test/composables/test_useFileTreeHelpers.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeAncestorDirs } from "../../src/composables/useFileTree.helpers.ts";
+
+// Ancestor directory list a file's lazy-load walk iterates: shallowest
+// first, EXCLUDING the file's own leaf, `[]` for a root-level file.
+
+describe("computeAncestorDirs", () => {
+  it("returns [] for the empty string", () => {
+    assert.deepEqual(computeAncestorDirs(""), []);
+  });
+
+  it("returns [] for a single root-level segment (the file itself has no dir)", () => {
+    assert.deepEqual(computeAncestorDirs("a"), []);
+    assert.deepEqual(computeAncestorDirs("readme.md"), []);
+  });
+
+  it("returns the one parent dir for a file one level deep", () => {
+    assert.deepEqual(computeAncestorDirs("a/b"), ["a"]);
+  });
+
+  it("returns every ancestor dir shallowest-first, excluding the leaf", () => {
+    assert.deepEqual(computeAncestorDirs("a/b/c"), ["a", "a/b"]);
+    assert.deepEqual(computeAncestorDirs("a/b/c/d.md"), ["a", "a/b", "a/b/c"]);
+  });
+
+  it("drops leading slashes as empty segments", () => {
+    assert.deepEqual(computeAncestorDirs("/a/b"), ["a"]);
+    assert.deepEqual(computeAncestorDirs("/a/b/c"), ["a", "a/b"]);
+  });
+
+  it("drops duplicate slashes as empty segments", () => {
+    assert.deepEqual(computeAncestorDirs("a//b//c"), ["a", "a/b"]);
+  });
+
+  it("treats a slash-only path as having no real segments", () => {
+    assert.deepEqual(computeAncestorDirs("/"), []);
+    assert.deepEqual(computeAncestorDirs("///"), []);
+  });
+});

--- a/test/composables/test_useSessionHistoryHelpers.ts
+++ b/test/composables/test_useSessionHistoryHelpers.ts
@@ -1,0 +1,51 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyBookmarkFlag } from "../../src/composables/useSessionHistory.helpers.ts";
+import type { SessionSummary } from "../../src/types/session.ts";
+
+function session(sessionId: string, isBookmarked?: boolean): SessionSummary {
+  return { id: sessionId, roleId: "r", startedAt: "s", updatedAt: "u", preview: "p", ...(isBookmarked === undefined ? {} : { isBookmarked }) };
+}
+
+describe("applyBookmarkFlag", () => {
+  it("sets isBookmarked=true on the matching session", () => {
+    const result = applyBookmarkFlag([session("a"), session("b")], "b", true);
+    assert.equal(result[1].isBookmarked, true);
+  });
+
+  it("sets isBookmarked=false on the matching session", () => {
+    const result = applyBookmarkFlag([session("a", true)], "a", false);
+    assert.equal(result[0].isBookmarked, false);
+  });
+
+  it("leaves non-matching sessions unchanged", () => {
+    const result = applyBookmarkFlag([session("a", true), session("b", false)], "b", true);
+    assert.equal(result[0].isBookmarked, true);
+    assert.equal(result[1].isBookmarked, true);
+  });
+
+  it("returns an all-unchanged copy when no id matches", () => {
+    const input = [session("a", false), session("b", true)];
+    const result = applyBookmarkFlag(input, "missing", true);
+    assert.deepEqual(result, input);
+  });
+
+  it("returns an empty array for an empty list", () => {
+    assert.deepEqual(applyBookmarkFlag([], "a", true), []);
+  });
+
+  it("does not mutate the input array or its matching element", () => {
+    const original = session("a", false);
+    const input = [original];
+    const result = applyBookmarkFlag(input, "a", true);
+    assert.equal(original.isBookmarked, false, "original element untouched");
+    assert.notEqual(result[0], original, "matching element is a fresh object");
+    assert.notEqual(result, input, "returns a new array");
+  });
+
+  it("returns non-matching elements by reference (only the match is cloned)", () => {
+    const keep = session("a", false);
+    const result = applyBookmarkFlag([keep, session("b")], "b", true);
+    assert.equal(result[0], keep, "untouched element preserved by reference");
+  });
+});

--- a/test/composables/test_useVoiceInputHelpers.ts
+++ b/test/composables/test_useVoiceInputHelpers.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { deriveVoiceModelReadiness } from "../../src/composables/useVoiceInput.helpers.ts";
+import type { VoiceInputStatusResponse, VoiceModelStatus } from "../../src/composables/useVoiceInput.ts";
+
+// Pure derivation of the capture controller's readiness flags from a
+// raw `GET /api/transcribe/model` status. Every flag is gated on both
+// `capable` and `enabled`, then the model's own state.
+
+function status(capable: boolean, enabled: boolean, state: VoiceModelStatus["state"]): VoiceInputStatusResponse {
+  return { capable, enabled, model: { name: "whisper", state } };
+}
+
+describe("deriveVoiceModelReadiness", () => {
+  it("is ready only when capable, enabled, and model state is 'ready'", () => {
+    assert.deepEqual(deriveVoiceModelReadiness(status(true, true, "ready")), { ready: true, downloading: false });
+  });
+
+  it("is downloading only when capable, enabled, and model state is 'downloading'", () => {
+    assert.deepEqual(deriveVoiceModelReadiness(status(true, true, "downloading")), { ready: false, downloading: true });
+  });
+
+  it("is neither ready nor downloading for idle and error states", () => {
+    for (const state of ["idle", "error"] as const) {
+      assert.deepEqual(deriveVoiceModelReadiness(status(true, true, state)), { ready: false, downloading: false }, `state=${state}`);
+    }
+  });
+
+  it("forces both flags false when not capable, regardless of state", () => {
+    for (const state of ["ready", "downloading", "idle", "error"] as const) {
+      assert.deepEqual(deriveVoiceModelReadiness(status(false, true, state)), { ready: false, downloading: false }, `state=${state}`);
+    }
+  });
+
+  it("forces both flags false when not enabled, regardless of state", () => {
+    for (const state of ["ready", "downloading", "idle", "error"] as const) {
+      assert.deepEqual(deriveVoiceModelReadiness(status(true, false, state)), { ready: false, downloading: false }, `state=${state}`);
+    }
+  });
+
+  it("forces both flags false when neither capable nor enabled", () => {
+    assert.deepEqual(deriveVoiceModelReadiness(status(false, false, "ready")), { ready: false, downloading: false });
+  });
+});


### PR DESCRIPTION
## Summary

Reduces `max-lines-per-function` lint pressure and adds unit-test coverage by extracting **genuinely-pure** sub-logic from three Vue composables into exported pure helper functions. Strictly behavior-preserving — the exact expressions were moved verbatim; all reactive/IO/closure code (refs, `apiGet`/`apiPost`, watchers, generation counters) stays exactly where it was.

| Composable | New helper (new file) | Effect |
|---|---|---|
| `useVoiceInput.ts` | `deriveVoiceModelReadiness` → `useVoiceInput.helpers.ts` | **warning cleared** (body 51 → 47 lines, under the 50 limit) |
| `useFileTree.ts` | `computeAncestorDirs` → `useFileTree.helpers.ts` | test coverage (warning remains: 80 → 74 body lines) |
| `useSessionHistory.ts` | `applyBookmarkFlag` → `useSessionHistory.helpers.ts` | test coverage (warning remains: 59 body lines) |

Each helper has no Vue imports, no refs, no IO, no closure state — pure input→output.

## Items to Confirm / Review

- **`computeAncestorDirs` preserves the original `for` loop verbatim** (including `let i`) rather than rewriting it functionally, to honour the strict "move the exact expression, never rewrite logic" constraint. The original early-`return` for `parts.length <= 1` becomes an empty-array return, so the caller's `for...of` simply doesn't iterate — observably identical (no `expand`/`loadDirChildren` calls). Please confirm you're happy keeping the loop as-is vs. a `.map()` rewrite.
- **`deriveVoiceModelReadiness` return type** is the inline `{ ready: boolean; downloading: boolean }` matching the transport contract exactly; the state literals `"ready"`/`"downloading"` are kept inline (they are members of the `VoiceModelStatus["state"]` union, not magic strings).
- The helper imports `VoiceInputStatusResponse` as a **type-only** import from `useVoiceInput.ts` (erased at runtime, so the type-level cycle is safe); the interface stays where it was to avoid breaking existing exports.

## Tests

New `node:test` + `node:assert/strict` files under `test/composables/` (20 assertions, all passing):
- `test_useVoiceInputHelpers.ts` — all four model states (ready/downloading/idle/error) × capable/enabled false combinations.
- `test_useFileTreeHelpers.ts` — `""`, single segment, `a/b`, `a/b/c`, leading/duplicate/only slashes.
- `test_useSessionHistoryHelpers.ts` — no-match id, empty list, immutability (original array + matched element untouched), non-matched elements returned by reference.

## Verification

- ESLint: **0 errors** on all changed/new files; the `useVoiceInput` `max-lines-per-function` warning is **gone**. The two remaining warnings (`useFileTree`, `useSessionHistory`) are expected and pre-existing.
- Typecheck: `test/tsconfig.json` (covers `src/` + `test/`) is **clean**. Root `tsconfig.json` shows only 31 pre-existing `.vue` SFC module-resolution errors (raw `tsc` without `vue-tsc`), identical on the base branch — zero new errors from this change.
- Tests: 20/20 pass via `tsx --test`.
- Prettier: clean.

No package versions bumped.

## User Prompt

Reduce `max-lines-per-function` lint warnings by extracting genuinely-pure sub-logic from three Vue composables (`useVoiceInput`, `useFileTree`, `useSessionHistory`) into exported pure helper functions, and add unit tests for those helpers. Behavior-preserving only: move the exact expressions into pure functions (no Vue imports, refs, IO, or closure state), leave all impure reactive/IO/closure code in place. The `useVoiceInput` warning should clear; the other two are for test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder loading for files in nested paths, including paths with extra or leading slashes.
  * Made bookmark updates more reliable while keeping the session list consistent.
  * Refined voice input status handling so readiness and downloading states are reported more accurately.

* **Tests**
  * Added coverage for folder-path handling, bookmark updates, and voice input status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->