### PR TITLE
chore: extract pure helpers from three server functions + unit tests

### DIFF
--- a/server/plugins/dev-watcher.ts
+++ b/server/plugins/dev-watcher.ts
@@ -42,6 +42,14 @@ export interface DevPluginChangedPayload {
   serverSideChange: boolean;
 }
 
+/** Sort the debounced file set and flag whether the server entry
+ *  (`dist/index.js`) is among the changes. */
+export function summarizeChangedFiles(files: ReadonlySet<string>): DevPluginChangedPayload {
+  const changedFiles = Array.from(files).sort();
+  const serverSideChange = changedFiles.some(isServerEntry);
+  return { changedFiles, serverSideChange };
+}
+
 export interface WatchDevPluginsOptions {
   /** Called once per debounce burst per plugin. */
   publish: (pluginName: string, payload: DevPluginChangedPayload) => void;
@@ -102,10 +110,9 @@ export function watchDevPlugins(plugins: readonly RuntimePlugin[], opts: WatchDe
           pendingFiles.delete(plugin.name);
           timers.delete(plugin.name);
           if (!files || files.size === 0) return;
-          const changedFiles = Array.from(files).sort();
-          const serverSideChange = changedFiles.some(isServerEntry);
-          if (serverSideChange) opts.warnServerSideChange?.(plugin.name);
-          opts.publish(plugin.name, { changedFiles, serverSideChange });
+          const summary = summarizeChangedFiles(files);
+          if (summary.serverSideChange) opts.warnServerSideChange?.(plugin.name);
+          opts.publish(plugin.name, summary);
         }, debounceMs),
       );
     });

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -17,6 +17,21 @@ const PTY_TIMEOUT_MS = 30 * ONE_SECOND_MS;
 /** Delay before sending input to the claude CLI. */
 const PTY_INPUT_DELAY_MS = 3 * ONE_SECOND_MS;
 
+// After the echo, only treat output as a successful renewal when it
+// looks like a real Claude response — a conversational opener
+// (Hello / Hi / I'm / …) AND a non-trivial amount of text. Error
+// chunks ("Please log in", "Invalid credentials", network blips)
+// don't match both conditions, so they fall through to the timeout and
+// we treat the renewal as failed. A final safety net: refreshCredentials()
+// re-reads the Keychain and calls isTokenExpired() before writing, so
+// even a false positive here can't persist a stale token.
+const RESPONSE_PATTERN_RE = /\b(Hello|Hi|I['’]m|I can|How can)\b/i;
+const MIN_RESPONSE_CHARS = 20;
+
+export function looksLikeClaudeResponse(text: string): boolean {
+  return RESPONSE_PATTERN_RE.test(text) && text.length >= MIN_RESPONSE_CHARS;
+}
+
 interface CredentialsJson {
   claudeAiOauth?: {
     accessToken?: string;
@@ -114,17 +129,6 @@ async function renewTokenViaPty(): Promise<boolean> {
     // false-positive the echo detection.
     const ECHO_RE = /\bhi\b/;
 
-    // After the echo, only treat output as a successful renewal when
-    // it looks like a real Claude response — a conversational opener
-    // (Hello / Hi / I'm / …) AND a non-trivial amount of text. Error
-    // chunks ("Please log in", "Invalid credentials", network blips)
-    // don't match both conditions, so they fall through to the
-    // 30-second timeout and we treat the renewal as failed. A final
-    // safety net: `refreshCredentials()` re-reads the Keychain and
-    // calls `isTokenExpired()` before writing, so even a false
-    // positive here can't persist a stale token.
-    const RESPONSE_PATTERN_RE = /\b(Hello|Hi|I['’]m|I can|How can)\b/i;
-    const MIN_RESPONSE_CHARS = 20;
     let echoEndIdx = -1;
 
     proc.onData((data: string) => {
@@ -143,7 +147,7 @@ async function renewTokenViaPty(): Promise<boolean> {
       }
 
       const response = buffer.slice(echoEndIdx);
-      if (response.length >= MIN_RESPONSE_CHARS && RESPONSE_PATTERN_RE.test(response)) {
+      if (looksLikeClaudeResponse(response)) {
         finish(true);
       }
     });

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -32,18 +32,26 @@ export class ClaudeCliFailedError extends Error {
   }
 }
 
+// `opts?.model` is threaded from `Settings → Journal` via maybeRunJournal
+// so the user's model choice reaches the CLI. When undefined we omit the
+// flag entirely and let the CLI use its own default — preserves the
+// pre-#1944 archivist behaviour for direct-CLI callers with no model.
+export function buildClaudeCliArgs(model?: JournalSummaryModel): string[] {
+  const args = ["-p", "--output-format", "text"];
+  if (model) {
+    args.push("--model", model);
+  }
+  return args;
+}
+
+export function buildCliPayload(systemPrompt: string, userPrompt: string): string {
+  return `${systemPrompt}\n\n---\n\n${userPrompt}`;
+}
+
 // Pipe the combined prompt via stdin to dodge shell-argv limits for large day excerpts.
 export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
   new Promise((resolve, reject) => {
-    // `opts?.model` is threaded from `Settings → Journal` via
-    // maybeRunJournal so the user's model choice reaches the CLI.
-    // When undefined we omit the flag entirely and let the CLI use
-    // its own default — preserves the pre-#1944 archivist behaviour
-    // for direct-CLI callers that don't specify a model.
-    const args = ["-p", "--output-format", "text"];
-    if (opts?.model) {
-      args.push("--model", opts.model);
-    }
+    const args = buildClaudeCliArgs(opts?.model);
     const child = spawn(claudeBinPath(), args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -100,7 +108,7 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
     });
 
     // Wait for "drain" on backpressure before end() so the buffer fully flushes — large excerpts can hit this path.
-    const payload = `${systemPrompt}\n\n---\n\n${userPrompt}`;
+    const payload = buildCliPayload(systemPrompt, userPrompt);
     const flushed = child.stdin.write(payload);
     if (flushed) {
       child.stdin.end();

--- a/test/journal/test_archivist_cli.ts
+++ b/test/journal/test_archivist_cli.ts
@@ -1,0 +1,54 @@
+// Tests for the pure helpers of `server/workspace/journal/archivist-cli.ts` —
+// the argv builder + stdin payload composer used to invoke the claude CLI.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildClaudeCliArgs, buildCliPayload } from "../../server/workspace/journal/archivist-cli.js";
+
+describe("buildClaudeCliArgs", () => {
+  it("omits --model when no model is given", () => {
+    assert.deepEqual(buildClaudeCliArgs(), ["-p", "--output-format", "text"]);
+  });
+
+  it("omits --model when model is undefined", () => {
+    assert.deepEqual(buildClaudeCliArgs(undefined), ["-p", "--output-format", "text"]);
+  });
+
+  it("appends --model haiku after the base flags", () => {
+    assert.deepEqual(buildClaudeCliArgs("haiku"), ["-p", "--output-format", "text", "--model", "haiku"]);
+  });
+
+  it("appends --model sonnet after the base flags", () => {
+    assert.deepEqual(buildClaudeCliArgs("sonnet"), ["-p", "--output-format", "text", "--model", "sonnet"]);
+  });
+
+  it("returns a fresh array on each call (no shared mutable state)", () => {
+    const first = buildClaudeCliArgs("haiku");
+    const second = buildClaudeCliArgs();
+    assert.notEqual(first, second);
+    assert.deepEqual(second, ["-p", "--output-format", "text"]);
+  });
+});
+
+describe("buildCliPayload", () => {
+  it("joins system + user prompts with the ---separator", () => {
+    assert.equal(buildCliPayload("SYS", "USER"), "SYS\n\n---\n\nUSER");
+  });
+
+  it("handles empty prompts", () => {
+    assert.equal(buildCliPayload("", ""), "\n\n---\n\n");
+  });
+
+  it("handles an empty system prompt", () => {
+    assert.equal(buildCliPayload("", "USER"), "\n\n---\n\nUSER");
+  });
+
+  it("handles an empty user prompt", () => {
+    assert.equal(buildCliPayload("SYS", ""), "SYS\n\n---\n\n");
+  });
+
+  it("preserves multiline content verbatim", () => {
+    assert.equal(buildCliPayload("line1\nline2", "a\nb\nc"), "line1\nline2\n\n---\n\na\nb\nc");
+  });
+});

--- a/test/plugins/test_dev_watcher.ts
+++ b/test/plugins/test_dev_watcher.ts
@@ -5,7 +5,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 
-import { watchDevPlugins } from "../../server/plugins/dev-watcher.js";
+import { watchDevPlugins, summarizeChangedFiles } from "../../server/plugins/dev-watcher.js";
 import type { RuntimePlugin } from "../../server/plugins/runtime-loader.js";
 
 // Make a fake `FSWatcher`. `node:fs.watch` returns an EventEmitter +
@@ -296,5 +296,38 @@ describe("watchDevPlugins — close()", () => {
     const rig = makeRig(plugin, 30);
     rig.close();
     assert.doesNotThrow(() => rig.close());
+  });
+});
+
+describe("summarizeChangedFiles", () => {
+  it("returns empty + no server-side change for an empty set", () => {
+    assert.deepEqual(summarizeChangedFiles(new Set()), { changedFiles: [], serverSideChange: false });
+  });
+
+  it("sorts the changed files alphabetically", () => {
+    const summary = summarizeChangedFiles(new Set(["vue.js", "definition-Dvdjo6Xe.js", "style.css"]));
+    assert.deepEqual(summary.changedFiles, ["definition-Dvdjo6Xe.js", "style.css", "vue.js"]);
+  });
+
+  it("flags serverSideChange when the server entry `index.js` is present", () => {
+    const summary = summarizeChangedFiles(new Set(["index.js", "vue.js"]));
+    assert.equal(summary.serverSideChange, true);
+    assert.deepEqual(summary.changedFiles, ["index.js", "vue.js"]);
+  });
+
+  it("does NOT flag serverSideChange for browser-only files", () => {
+    assert.equal(summarizeChangedFiles(new Set(["vue.js", "style.css"])).serverSideChange, false);
+  });
+
+  it("does NOT flag nested `assets/index.js` chunks (vite code-split output)", () => {
+    assert.equal(summarizeChangedFiles(new Set(["assets/index.js"])).serverSideChange, false);
+  });
+
+  it("normalizes Windows-style backslash paths for the server entry check", () => {
+    assert.equal(summarizeChangedFiles(new Set(["assets\\index.js"])).serverSideChange, false);
+  });
+
+  it("returns a single entry for a one-file set", () => {
+    assert.deepEqual(summarizeChangedFiles(new Set(["index.js"])), { changedFiles: ["index.js"], serverSideChange: true });
   });
 });

--- a/test/system/test_credentials.ts
+++ b/test/system/test_credentials.ts
@@ -1,0 +1,55 @@
+// Tests for the pure response-detection predicate of
+// `server/system/credentials.ts`. `looksLikeClaudeResponse` decides
+// whether PTY output looks like a real Claude reply (conversational
+// opener AND >= 20 chars) versus an error chunk that should time out.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { looksLikeClaudeResponse } from "../../server/system/credentials.js";
+
+describe("looksLikeClaudeResponse", () => {
+  it("returns true for a conversational opener with enough text", () => {
+    assert.equal(looksLikeClaudeResponse("Hello! How can I help you today?"), true);
+  });
+
+  it("returns true for an `I'm` opener (straight apostrophe) past the length floor", () => {
+    assert.equal(looksLikeClaudeResponse("I'm here to help you out."), true);
+  });
+
+  it("returns true for an `I'm` opener (curly apostrophe) past the length floor", () => {
+    assert.equal(looksLikeClaudeResponse("I’m ready to assist you now."), true);
+  });
+
+  it("returns false when the opener matches but the text is too short (< 20 chars)", () => {
+    assert.equal(looksLikeClaudeResponse("Hi there"), false);
+  });
+
+  it("returns false at the boundary (exactly 19 chars, matching opener)", () => {
+    const text = "Hi! short reply...."; // 19 chars, matches "Hi"
+    assert.equal(text.length, 19);
+    assert.equal(looksLikeClaudeResponse(text), false);
+  });
+
+  it("returns true at the boundary (exactly 20 chars, matching opener)", () => {
+    const text = "Hi! twentycharsxxxxx"; // 20 chars, matches "Hi"
+    assert.equal(text.length, 20);
+    assert.equal(looksLikeClaudeResponse(text), true);
+  });
+
+  it("returns false for a login-error chunk", () => {
+    assert.equal(looksLikeClaudeResponse("Please log in"), false);
+  });
+
+  it("returns false for an invalid-credentials chunk", () => {
+    assert.equal(looksLikeClaudeResponse("Invalid credentials"), false);
+  });
+
+  it("returns false for long text without a conversational opener", () => {
+    assert.equal(looksLikeClaudeResponse("Please log in to continue your session now."), false);
+  });
+
+  it("returns false for an empty string", () => {
+    assert.equal(looksLikeClaudeResponse(""), false);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts genuinely-pure sub-logic from three server functions currently flagged by `max-lines-per-function` into exported, unit-tested helpers. **Strictly behavior-preserving** — the exact expressions were moved, not rewritten. The impure cores (`child_process.spawn`, PTY, `fs.watch`, timers, promise executors) stay exactly where they were.

The primary win is **test coverage of previously-untested pure logic** (27 new unit tests). The `max-lines-per-function` warnings mostly remain by design — the impure cores are still >50 lines; only the pure fragments moved out.

## Items to Confirm / Review

- **`credentials.ts` predicate ordering**: `looksLikeClaudeResponse` is `RESPONSE_PATTERN_RE.test(text) && text.length >= MIN_RESPONSE_CHARS`. The original inline check was `response.length >= MIN_RESPONSE_CHARS && RESPONSE_PATTERN_RE.test(response)`. Both operands are pure (regex has no `g` flag → no `lastIndex` side effect), so the `&&` result is identical regardless of order.
- **Consts hoisted to module scope**: `RESPONSE_PATTERN_RE` and `MIN_RESPONSE_CHARS` moved from function-local to module-level so the extracted predicate can use them (values unchanged; the curly-apostrophe `I['’]m` char class preserved verbatim).
- **Echo detection left inline**: the `ECHO_RE` match is entangled with buffer-index state (`match.index + match[0].length` feeds `echoEndIdx`), so it is NOT a clean pure boolean — left untouched per scope.
- **`summarizeChangedFiles` returns `DevPluginChangedPayload`**: reuses the existing exported interface (same `{ changedFiles, serverSideChange }` shape) instead of a duplicate inline literal.

## User Prompt

Extract genuinely-pure sub-logic from three server functions (flagged `max-lines-per-function`) into exported pure helpers and add unit tests. Behavior-preserving only.

1. `server/workspace/journal/archivist-cli.ts` (`runClaudeCli`): extract `buildClaudeCliArgs(model?)` and `buildCliPayload(systemPrompt, userPrompt)`.
2. `server/system/credentials.ts` (`renewTokenViaPty`): extract the pure predicate `looksLikeClaudeResponse(text)`; leave the PTY spawn / buffer / timers / echo-index logic alone.
3. `server/plugins/dev-watcher.ts` (`watchDevPlugins`): extract `summarizeChangedFiles(files)` reusing the module's `isServerEntry`.

Cover happy / edge / empty / boundary / invalid cases and keep the existing module exports intact.

## Changes

| File | Extraction | `max-lines` before → after |
|---|---|---|
| `server/workspace/journal/archivist-cli.ts` | `buildClaudeCliArgs`, `buildCliPayload` | 61 → 58 |
| `server/system/credentials.ts` | `looksLikeClaudeResponse` | 56 → 54 |
| `server/plugins/dev-watcher.ts` | `summarizeChangedFiles` | 58 → 57 |

## Tests (27 new)

- `test/journal/test_archivist_cli.ts` (10): `buildClaudeCliArgs` (haiku / sonnet / undefined → no `--model`, fresh array per call) and `buildCliPayload` (empty / multiline / exact `\n\n---\n\n` separator).
- `test/system/test_credentials.ts` (10): `looksLikeClaudeResponse` — matching opener + ≥20 chars → true; 19-char boundary → false; 20-char boundary → true; "Please log in" / "Invalid credentials" / long-non-opener / empty → false; straight and curly `I'm` openers.
- `test/plugins/test_dev_watcher.ts` (+7): `summarizeChangedFiles` — empty set, sorting, server entry present → true, browser-only → false, nested `assets/index.js` and Windows backslash paths → false.

## Verification

- `eslint` on all 6 files: **0 errors** (only the pre-existing `max-lines-per-function` warnings remain).
- `tsc -p server/tsconfig.json` and `tsc -p test/tsconfig.json`: **clean**.
- `tsx --test` on the three files: **41 pass / 0 fail** (14 pre-existing dev-watcher + 27 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)