### PR TITLE
chore: extract generation handlers from applyAgentEvent (clear max-lines warning)

### DIFF
--- a/src/utils/agent/eventDispatch.ts
+++ b/src/utils/agent/eventDispatch.ts
@@ -2,8 +2,8 @@
 // via the AgentEventContext adapter. No Vue refs, no component scope.
 
 import type { ActiveSession } from "../../types/session";
-import type { SseEvent, SseToolCallResult } from "../../types/sse";
-import { EVENT_TYPES, generationKey } from "../../types/events";
+import type { SseEvent, SseToolCallResult, SseGenerationStarted, SseGenerationFinished } from "../../types/sse";
+import { EVENT_TYPES, generationKey, type PendingGeneration } from "../../types/events";
 import type { ToolCallHistoryItem } from "../../types/toolCallHistory";
 import { findPendingToolCall, toToolCallEntry } from "./toolCalls";
 import { extractMcpHint } from "./mcpHint";
@@ -36,6 +36,18 @@ function applyToolCallResult(history: ToolCallHistoryItem[], event: SseToolCallR
     return;
   }
   entry.result = event.content;
+}
+
+export function addPendingGeneration(pending: Record<string, PendingGeneration>, event: SseGenerationStarted): void {
+  const { kind, filePath, key } = event;
+  pending[generationKey(kind, filePath, key)] = { kind, filePath, key };
+}
+
+// Returns whether the map is now empty, so the caller can fire the
+// drain callback only on the transition to "no background work left".
+export function removePendingGeneration(pending: Record<string, PendingGeneration>, event: SseGenerationFinished): boolean {
+  Reflect.deleteProperty(pending, generationKey(event.kind, event.filePath, event.key));
+  return Object.keys(pending).length === 0;
 }
 
 export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): Promise<void> {
@@ -83,21 +95,10 @@ export async function applyAgentEvent(event: SseEvent, ctx: AgentEventContext): 
       return;
     case EVENT_TYPES.sessionFinished:
       return;
-    case EVENT_TYPES.generationStarted: {
-      const mapKey = generationKey(event.kind, event.filePath, event.key);
-      session.pendingGenerations[mapKey] = {
-        kind: event.kind,
-        filePath: event.filePath,
-        key: event.key,
-      };
+    case EVENT_TYPES.generationStarted:
+      addPendingGeneration(session.pendingGenerations, event);
       return;
-    }
-    case EVENT_TYPES.generationFinished: {
-      const mapKey = generationKey(event.kind, event.filePath, event.key);
-      Reflect.deleteProperty(session.pendingGenerations, mapKey);
-      if (Object.keys(session.pendingGenerations).length === 0) {
-        ctx.onGenerationsDrained();
-      }
-    }
+    case EVENT_TYPES.generationFinished:
+      if (removePendingGeneration(session.pendingGenerations, event)) ctx.onGenerationsDrained();
   }
 }

--- a/test/utils/agent/test_eventDispatch.ts
+++ b/test/utils/agent/test_eventDispatch.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { addPendingGeneration, removePendingGeneration } from "../../../src/utils/agent/eventDispatch.js";
+import { generationKey, type PendingGeneration, GENERATION_KINDS } from "@mulmobridge/protocol";
+import type { SseGenerationStarted, SseGenerationFinished } from "../../../src/types/sse.js";
+import { EVENT_TYPES } from "../../../src/types/events.js";
+
+const kind = GENERATION_KINDS.beatImage;
+
+const started = (filePath: string, key: string): SseGenerationStarted => ({
+  type: EVENT_TYPES.generationStarted,
+  kind,
+  filePath,
+  key,
+});
+
+const finished = (filePath: string, key: string): SseGenerationFinished => ({
+  type: EVENT_TYPES.generationFinished,
+  kind,
+  filePath,
+  key,
+});
+
+describe("addPendingGeneration", () => {
+  it("stores the decomposed generation under its stable key", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    addPendingGeneration(pending, started("a.png", "k1"));
+    assert.deepEqual(pending[generationKey(kind, "a.png", "k1")], { kind, filePath: "a.png", key: "k1" });
+  });
+
+  it("keeps distinct generations side by side", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    addPendingGeneration(pending, started("a.png", "k1"));
+    addPendingGeneration(pending, started("b.png", "k2"));
+    assert.equal(Object.keys(pending).length, 2);
+  });
+
+  it("overwrites the same key idempotently", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    addPendingGeneration(pending, started("a.png", "k1"));
+    addPendingGeneration(pending, started("a.png", "k1"));
+    assert.equal(Object.keys(pending).length, 1);
+  });
+});
+
+describe("removePendingGeneration", () => {
+  it("removes the matching entry and reports the map is now empty", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    addPendingGeneration(pending, started("a.png", "k1"));
+    const isEmpty = removePendingGeneration(pending, finished("a.png", "k1"));
+    assert.equal(isEmpty, true);
+    assert.equal(Object.keys(pending).length, 0);
+  });
+
+  it("reports not-empty while other generations remain", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    addPendingGeneration(pending, started("a.png", "k1"));
+    addPendingGeneration(pending, started("b.png", "k2"));
+    const isEmpty = removePendingGeneration(pending, finished("a.png", "k1"));
+    assert.equal(isEmpty, false);
+    assert.equal(Object.keys(pending).length, 1);
+  });
+
+  it("treats removing from an already-empty map as empty", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    assert.equal(removePendingGeneration(pending, finished("a.png", "k1")), true);
+  });
+
+  it("reports not-empty when the removed key was absent but others exist", () => {
+    const pending: Record<string, PendingGeneration> = {};
+    addPendingGeneration(pending, started("a.png", "k1"));
+    assert.equal(removePendingGeneration(pending, finished("missing.png", "kX")), false);
+    assert.equal(Object.keys(pending).length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
Behavior-preserving decomposition of `applyAgentEvent` (`src/utils/agent/eventDispatch.ts`). The `generationStarted` / `generationFinished` switch cases carried the `generationKey` compute + `pendingGenerations` mutation inline; they're moved into two small exported helpers. This drops `applyAgentEvent` from **58 → under 50 lines**, clearing its `max-lines-per-function` warning — the last of the remaining warned functions that could be split without a structural rewrite.

## Items to Confirm / Review
- **Behavior parity** (the point of the change):
  - `addPendingGeneration(pending, event)` = the old `mapKey = generationKey(...); pending[mapKey] = { kind, filePath, key }`.
  - `removePendingGeneration(pending, event)` deletes the key and **returns whether the map is now empty**; the dispatcher calls `ctx.onGenerationsDrained()` iff `true` — identical to the old `if (Object.keys(...).length === 0)` guard.
  - Helpers operate on the `Record<string, PendingGeneration>` map (narrow scope) rather than the whole `ActiveSession`, so they're unit-testable without a session fake.
- The `generationFinished` case keeps no trailing `return` (it's the last case), matching the original.

## Tests
`test/utils/agent/test_eventDispatch.ts` — 7 cases: add stores under stable key / distinct coexist / same-key idempotent; remove empties-and-reports-true / not-empty-while-others-remain / empty-map / absent-key-with-others-remaining.

## Verification
eslint 0 errors + **warning gone**, `tsc -p test/tsconfig.json` clean, 7/7 tests pass, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of generation status updates so active items are tracked and cleared more consistently.
  * Fixed the “all done” notification to trigger only when the last pending generation finishes, preserving expected behavior.
* **Tests**
  * Added coverage for adding, updating, and removing pending generation entries, including edge cases with multiple items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->