### PR TITLE
chore: ratchet max-lines-per-function to error with grandfather list

### DIFF
--- a/docs/lint-policy.md
+++ b/docs/lint-policy.md
@@ -8,6 +8,16 @@ Read this when you encounter a `yarn lint` warning, are tempted to add an `eslin
 
 When you touch a file, fix any warnings in it that are mechanically safe (`prefer-destructuring` auto-fix, missing `return undefined`, etc.). Don't leave a warning behind in code you just edited.
 
+## `max-lines-per-function` is ratcheted to `error` + a grandfather list
+
+The rule is `error` repo-wide (50-line budget, `skipBlankLines` + `skipComments`), so **no new function may exceed 50 lines** — it fails CI. The pre-existing violations that resist a behavior-preserving split (async generators whose yielded code can't move out, factory closures over mutable state, Vue composables holding reactive refs, impure Promise executors / fs watchers) are pinned to `warn` in a single **grandfather block at the end of `eslint.config.mjs`** (search `max-lines-per-function grandfather`).
+
+Rules for that list:
+
+- **Never add a file to it.** A new over-budget function must be split (extract pure sub-logic into tested helpers, delegate switch cases, compose sub-generators with `yield*`), not grandfathered. If a split genuinely isn't safe, that's a design discussion for the PR, not a new list entry.
+- **Drain, then delete.** When you bring a listed file's functions under 50 lines, remove its entry. When the list is empty, delete the block and the rule is plain `error` everywhere.
+- Test files and `e2e*/` keep the rule `off` (a `describe()` holding ten `it()` cases isn't the readability target) — that's a separate override block, not the grandfather list.
+
 ## Per-line `eslint-disable-next-line` is intentional
 
 When you see one with a `--` rationale (e.g. `vue/no-v-html`, `no-unmodified-loop-condition`, `no-script-url` test fixtures, `no-new` URL/Intl probes, `no-loop-func` Mocha closures), it has been audited. **Never remove these comments during refactors** — they encode a trust decision. If the surrounding code changes shape, port the disable to the new line; don't drop it.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,14 +8,11 @@ import securityPlugin from "eslint-plugin-security";
 import importPlugin from "eslint-plugin-import";
 import vuePlugin from "eslint-plugin-vue";
 import vueParser from "vue-eslint-parser";
-import vueI18n from "@intlify/eslint-plugin-vue-i18n"
+import vueI18n from "@intlify/eslint-plugin-vue-i18n";
 
 export default [
   {
-    files: [
-      "{src,test}/**/*.{js,ts,yaml,yml,vue}",
-      "assets/html/js/**/*.js",
-    ],
+    files: ["{src,test}/**/*.{js,ts,yaml,yml,vue}", "assets/html/js/**/*.js"],
   },
   {
     ignores: [
@@ -112,11 +109,7 @@ export default [
     },
   },
   {
-    files: [
-      "**/utils/html_render.ts",
-      "src/utils/dom/**/*.ts",
-      "src/composables/**/*.ts",
-    ],
+    files: ["**/utils/html_render.ts", "src/utils/dom/**/*.ts", "src/composables/**/*.ts"],
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -147,12 +140,7 @@ export default [
           // Don't flag object property keys — external API payloads
           // legitimately use short keys like `id`, `to`, `n`, `e`.
           properties: "never",
-          exceptions: [
-            "_",
-            "i",
-            "j",
-            "ok"
-          ],
+          exceptions: ["_", "i", "j", "ok"],
         },
       ],
       // Catch TDZ-style `use-before-define` (e.g. accessing a `const`
@@ -259,13 +247,16 @@ export default [
       complexity: ["error", { max: 15 }],
       "max-depth": ["error", { max: 4 }],
       "max-params": ["error", { max: 6 }],
-      // Soft-launched as `warn` per CLAUDE.md's 20-line target — starts
-      // as advisory nudges so existing violations don't block CI. Bumping
-      // to `error` (or lowering `max`) once the count is drained is a
-      // one-line follow-up. skipBlankLines + skipComments so heavily-
-      // documented small functions don't count as "long"; IIFEs kept in
-      // so top-level `(() => { … })()` blocks are measured too.
-      "max-lines-per-function": ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],
+      // Ratcheted to `error` so no NEW function can exceed the 50-line
+      // budget. Pre-existing violations that resist a behavior-preserving
+      // split are pinned to `warn` in the grandfather block at the end of
+      // this config (search "max-lines-per-function grandfather"). Drain
+      // then delete entries there; do NOT add new files to it — a new
+      // over-budget function must be split, not grandfathered.
+      // skipBlankLines + skipComments so heavily-documented small
+      // functions don't count as "long"; IIFEs kept in so top-level
+      // `(() => { … })()` blocks are measured too.
+      "max-lines-per-function": ["error", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],
       quotes: "off",
       "no-shadow": "error",
       "no-param-reassign": "error",
@@ -466,7 +457,8 @@ export default [
             },
             {
               group: ["**/tools/**"],
-              message: "Plugin code must not import value bindings from the host tool registry (`src/tools/*`). Type imports are allowed (`PluginRegistration`, `ToolPlugin`).",
+              message:
+                "Plugin code must not import value bindings from the host tool registry (`src/tools/*`). Type imports are allowed (`PluginRegistration`, `ToolPlugin`).",
               allowTypeImports: true,
             },
             {
@@ -480,4 +472,35 @@ export default [
     },
   },
   eslintConfigPrettier,
+  // ── max-lines-per-function grandfather ──────────────────────────
+  // These files hold pre-existing functions over the 50-line budget
+  // that resist a behavior-preserving split: async generators (yielded
+  // code can't move out), factory closures over mutable state, Vue
+  // composables (reactive refs), and impure Promise executors / fs
+  // watchers. See docs/lint-policy.md. The rule is `error` repo-wide
+  // (above); this block pins these known offenders to `warn` so CI
+  // stays green while they remain backlog. As each is drained, remove
+  // its entry; when the list is empty, delete this block. Do NOT add
+  // new files — a new over-budget function must be split, not listed.
+  {
+    files: [
+      "packages/core/src/whisper/client.ts",
+      "packages/core/src/whisper/models.ts",
+      "packages/core/src/whisper/sidecar.ts",
+      "packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts",
+      "packages/relay/src/client.ts",
+      "server/agent/backend/claude-code.ts",
+      "server/api/routes/agent.ts",
+      "server/events/relay-client.ts",
+      "server/plugins/dev-watcher.ts",
+      "server/system/credentials.ts",
+      "server/workspace/journal/archivist-cli.ts",
+      "src/composables/useFileSelection.ts",
+      "src/composables/useFileTree.ts",
+      "src/composables/useSessionHistory.ts",
+    ],
+    rules: {
+      "max-lines-per-function": ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
Promotes `max-lines-per-function` from `warn` to **`error`** repo-wide (50-line budget) so **no new function can exceed 50 lines** — it now fails CI. The 14 pre-existing files whose over-budget functions resist a behavior-preserving split are pinned to `warn` via a single **grandfather block** at the end of `eslint.config.mjs`.

This locks in the recent cleanup: warnings were "backlog, not baseline" but nothing stopped new violations from accreting. Now the direction is enforced going forward while the known-hard cases stay green as backlog.

## Items to Confirm / Review
- **Zero new errors**: `yarn lint` exits 0 — `15 problems (0 errors, 15 warnings)`, identical warning set to before. The current lint output showed these 14 files are the *complete* set of >50-line functions across everything the root lint touches, so error-ifying + grandfathering exactly them introduces no new failures.
- **Ratchet proven live**: a throwaway 63-line function in a non-listed `src/` file was confirmed to raise `error Function 'probe' has too many lines (63)` (probe removed, not committed).
- **Grandfather list** (drain-then-delete; never add to it):
  `whisper/{client,models,sidecar}.ts`, `collection-plugin/…/useCollectionRendering.ts`, `relay/src/client.ts`, `agent/backend/claude-code.ts`, `api/routes/agent.ts`, `events/relay-client.ts`, `plugins/dev-watcher.ts`, `system/credentials.ts`, `journal/archivist-cli.ts`, `composables/{useFileSelection,useFileTree,useSessionHistory}.ts`
- Placement: block is the **last** config element (after `eslintConfigPrettier`), so flat-config last-match-wins guarantees the `warn` override for these files. Test/`e2e*` keep the rule `off` via the existing separate override (unchanged).
- Policy documented in `docs/lint-policy.md`.

## Why these files resist splitting (kept as `warn`)
async generators (yielded code can't move to a non-generator helper), factory closures over mutable state, Vue composables (reactive refs), impure Promise executors / fs watchers. Their pure sub-logic was already extracted + tested in the preceding PRs; the remaining bodies are cohesive cores where a further split trades readability for lint-appeasement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strengthened code quality checks by making overly long functions fail instead of just warn.
  * Existing legacy exceptions remain temporarily allowed so current builds aren’t disrupted.

* **Documentation**
  * Added clearer guidance on the line-limit policy, including when long functions must be split and how exception entries are removed over time.
  * Noted that test files and certain end-to-end paths are excluded from this rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->