### PR TITLE
chore: clear runClaudeAgent max-lines + drop from grandfather list

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -489,7 +489,6 @@ export default [
       "packages/core/src/whisper/sidecar.ts",
       "packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts",
       "packages/relay/src/client.ts",
-      "server/agent/backend/claude-code.ts",
       "server/api/routes/agent.ts",
       "server/events/relay-client.ts",
       "server/plugins/dev-watcher.ts",

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -11,7 +11,7 @@
 
 import { spawn, type ChildProcessByStdio } from "child_process";
 import type { Readable, Writable } from "stream";
-import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine } from "../config.js";
+import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine, type CliArgsParams } from "../config.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
@@ -179,15 +179,21 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
   if (errorEvent) yield errorEvent;
 }
 
-async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
-  const cliArgs = buildCliArgs({
+// The one non-pass-through mapping is `sessionToken` -> `claudeSessionId`
+// (the CLI's `--resume` id); the rest forward verbatim.
+export function cliArgsForInput(input: AgentInput): CliArgsParams {
+  return {
     systemPrompt: input.systemPrompt,
     activePlugins: input.activePlugins,
     claudeSessionId: input.sessionToken,
     mcpConfigPath: input.mcpConfigPath,
     extraAllowedTools: input.extraAllowedTools,
     effortLevel: input.effortLevel,
-  });
+  };
+}
+
+async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
+  const cliArgs = buildCliArgs(cliArgsForInput(input));
 
   // spawnClaude can throw synchronously when `claudeBinPath()` fails
   // to locate `claude.exe` on Windows — surface that through the same

--- a/test/agent/test_cliArgsForInput.ts
+++ b/test/agent/test_cliArgsForInput.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { cliArgsForInput } from "../../server/agent/backend/claude-code.js";
+import type { AgentInput } from "../../server/agent/backend/types.js";
+import { ROLES, type Role } from "../../src/config/roles.js";
+
+function requireRole(roleId: string): Role {
+  const role = ROLES.find((candidate) => candidate.id === roleId);
+  if (!role) throw new Error(`test setup: role '${roleId}' not found`);
+  return role;
+}
+
+function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
+  return {
+    systemPrompt: "sys",
+    message: "hi",
+    role: requireRole("general"),
+    workspacePath: "/tmp/does-not-matter",
+    sessionId: `test-${randomUUID()}`,
+    port: 0,
+    activePlugins: [],
+    extraAllowedTools: [],
+    useDocker: false,
+    ...overrides,
+  };
+}
+
+describe("cliArgsForInput", () => {
+  it("maps sessionToken onto claudeSessionId (the --resume id)", () => {
+    const params = cliArgsForInput(makeInput({ sessionToken: "resume-123" }));
+    assert.equal(params.claudeSessionId, "resume-123");
+  });
+
+  it("forwards the pass-through fields verbatim", () => {
+    const params = cliArgsForInput(
+      makeInput({
+        systemPrompt: "SP",
+        activePlugins: ["a", "b"],
+        mcpConfigPath: "/cfg.json",
+        extraAllowedTools: ["Bash"],
+        effortLevel: "high",
+      }),
+    );
+    assert.equal(params.systemPrompt, "SP");
+    assert.deepEqual(params.activePlugins, ["a", "b"]);
+    assert.equal(params.mcpConfigPath, "/cfg.json");
+    assert.deepEqual(params.extraAllowedTools, ["Bash"]);
+    assert.equal(params.effortLevel, "high");
+  });
+
+  it("leaves optional fields undefined when the input omits them", () => {
+    const params = cliArgsForInput(makeInput());
+    assert.equal(params.claudeSessionId, undefined);
+    assert.equal(params.mcpConfigPath, undefined);
+    assert.equal(params.effortLevel, undefined);
+  });
+
+  it("does not carry over non-CLI fields (message, workspacePath, port)", () => {
+    const params = cliArgsForInput(makeInput({ message: "secret", port: 9999 }));
+    assert.ok(!("message" in params));
+    assert.ok(!("workspacePath" in params));
+    assert.ok(!("port" in params));
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to the ratchet (#2031). Clears the tightest grandfathered `max-lines-per-function` warning — `runClaudeAgent` (52 lines) in `server/agent/backend/claude-code.ts` — with a behavior-preserving pure extraction, and removes the file from the eslint grandfather block. Grandfather list: **14 → 13 files**; repo warnings **15 → 14**, still 0 errors.

## What changed
- Extracted the inline `buildCliArgs({ … 6 fields … })` object into a pure, exported `cliArgsForInput(input: AgentInput): CliArgsParams`. The generator now calls `buildCliArgs(cliArgsForInput(input))`, dropping it from 52 to ~45 counted lines → warning clears.
- The mapper isolates the one non-pass-through field mapping: `sessionToken` → `claudeSessionId` (the CLI `--resume` id); the rest forward verbatim.
- Removed `server/agent/backend/claude-code.ts` from the grandfather block in `eslint.config.mjs` — it now passes the repo-wide `error` rule on its own.

## Items to Confirm / Review
- **Behavior parity**: `cliArgsForInput` returns exactly the object literal that was inlined; `buildCliArgs` receives an identical `CliArgsParams`. The generator body is otherwise untouched (spawn → yield* → finally cleanup).
- Why only this one of the borderline (52–59 line) functions: the rest (`renewTokenViaPty` 54, `watchDevPlugins` 57, `runClaudeCli` 57/58, `useSessionHistory` 59) can only be shaved by hoisting option-object literals to consts or splitting single-flight Promise closures — cosmetic line-appeasement that trades readability/behavior-safety, so they stay grandfathered per `docs/lint-policy.md`.

## Tests
`test/agent/test_cliArgsForInput.ts` — 4 cases: sessionToken→claudeSessionId remap; pass-through fields verbatim; optional fields stay undefined when omitted; non-CLI fields (message/workspacePath/port) not carried over.

## Verification
`yarn lint` exits 0 (`14 problems, 0 errors, 14 warnings`), claude-code.ts no longer warned; `tsc -p test/tsconfig.json` clean; 4/4 tests pass; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
