### PR TITLE
chore: extract createPluginWatcher from watchDevPlugins

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -491,7 +491,6 @@ export default [
       "packages/relay/src/client.ts",
       "server/api/routes/agent.ts",
       "server/events/relay-client.ts",
-      "server/plugins/dev-watcher.ts",
       "server/system/credentials.ts",
       "server/workspace/journal/archivist-cli.ts",
       "src/composables/useFileSelection.ts",

--- a/server/plugins/dev-watcher.ts
+++ b/server/plugins/dev-watcher.ts
@@ -50,6 +50,11 @@ export function summarizeChangedFiles(files: ReadonlySet<string>): DevPluginChan
   return { changedFiles, serverSideChange };
 }
 
+/** Binds a watcher to `absDistPath` and forwards each changed relative
+ *  path to `onChange`. Injectable so tests drive synthetic file events
+ *  without touching the real filesystem. */
+type WatcherFactory = (absDistPath: string, onChange: (relativePath: string) => void) => FSWatcher;
+
 export interface WatchDevPluginsOptions {
   /** Called once per debounce burst per plugin. */
   publish: (pluginName: string, payload: DevPluginChangedPayload) => void;
@@ -68,7 +73,7 @@ export interface WatchDevPluginsOptions {
   /** Override for testing. */
   debounceMs?: number;
   /** Override the watcher factory for tests. Default uses node:fs. */
-  watcherFactory?: (absDistPath: string, onChange: (relativePath: string) => void) => FSWatcher;
+  watcherFactory?: WatcherFactory;
 }
 
 export interface DevWatcherHandle {
@@ -84,6 +89,61 @@ function defaultWatcherFactory(absDistPath: string, onChange: (relativePath: str
   });
 }
 
+interface PluginWatchContext {
+  factory: WatcherFactory;
+  opts: WatchDevPluginsOptions;
+  debounceMs: number;
+  timers: Map<string, ReturnType<typeof setTimeout>>;
+  pendingFiles: Map<string, Set<string>>;
+}
+
+/** Watch one plugin's `dist/`, debouncing each burst of file writes
+ *  into a single publish. Mutates the shared `timers` / `pendingFiles`
+ *  maps keyed by plugin name so `close()` can cancel every plugin's
+ *  in-flight burst. */
+function createPluginWatcher(plugin: RuntimePlugin, ctx: PluginWatchContext): FSWatcher {
+  const { factory, opts, debounceMs, timers, pendingFiles } = ctx;
+  const absDistPath = path.join(plugin.cachePath, "dist");
+  const watcher = factory(absDistPath, (relativePath) => {
+    const buffer = pendingFiles.get(plugin.name) ?? new Set<string>();
+    buffer.add(relativePath);
+    pendingFiles.set(plugin.name, buffer);
+
+    const existing = timers.get(plugin.name);
+    if (existing) clearTimeout(existing);
+    timers.set(
+      plugin.name,
+      setTimeout(() => {
+        const files = pendingFiles.get(plugin.name);
+        pendingFiles.delete(plugin.name);
+        timers.delete(plugin.name);
+        if (!files || files.size === 0) return;
+        const summary = summarizeChangedFiles(files);
+        if (summary.serverSideChange) opts.warnServerSideChange?.(plugin.name);
+        opts.publish(plugin.name, summary);
+      }, debounceMs),
+    );
+  });
+  // Isolate each watcher's failure: log + close just this one instead
+  // of letting the unhandled `error` event terminate the whole server.
+  // Real-world trigger: `rm -rf dist && yarn build` emits ENOENT
+  // mid-watch (fs.watch surfaces it as an `error`, not a `change`).
+  // Production wires onWatcherError through the structured logger.
+  watcher.on("error", (err) => {
+    opts.onWatcherError?.(plugin.name, err);
+    try {
+      watcher.close();
+    } catch {
+      // Already torn down — nothing to do.
+    }
+    const pending = timers.get(plugin.name);
+    if (pending) clearTimeout(pending);
+    timers.delete(plugin.name);
+    pendingFiles.delete(plugin.name);
+  });
+  return watcher;
+}
+
 /** Attach a debounced watcher to each dev plugin's `dist/`. Returns a
  *  handle whose `close()` shuts every watcher down — call it from the
  *  graceful shutdown path. */
@@ -95,46 +155,7 @@ export function watchDevPlugins(plugins: readonly RuntimePlugin[], opts: WatchDe
   const pendingFiles = new Map<string, Set<string>>();
 
   for (const plugin of plugins) {
-    const absDistPath = path.join(plugin.cachePath, "dist");
-    const watcher = factory(absDistPath, (relativePath) => {
-      const buffer = pendingFiles.get(plugin.name) ?? new Set<string>();
-      buffer.add(relativePath);
-      pendingFiles.set(plugin.name, buffer);
-
-      const existing = timers.get(plugin.name);
-      if (existing) clearTimeout(existing);
-      timers.set(
-        plugin.name,
-        setTimeout(() => {
-          const files = pendingFiles.get(plugin.name);
-          pendingFiles.delete(plugin.name);
-          timers.delete(plugin.name);
-          if (!files || files.size === 0) return;
-          const summary = summarizeChangedFiles(files);
-          if (summary.serverSideChange) opts.warnServerSideChange?.(plugin.name);
-          opts.publish(plugin.name, summary);
-        }, debounceMs),
-      );
-    });
-    // Isolate each watcher's failure: log + close just this one
-    // instead of letting the unhandled `error` event terminate the
-    // whole server. Real-world trigger: `rm -rf dist && yarn build`
-    // emits ENOENT mid-watch (fs.watch surfaces it as an `error`,
-    // not a `change`). Production wires onWatcherError through the
-    // structured logger.
-    watcher.on("error", (err) => {
-      opts.onWatcherError?.(plugin.name, err);
-      try {
-        watcher.close();
-      } catch {
-        // Already torn down — nothing to do.
-      }
-      const pending = timers.get(plugin.name);
-      if (pending) clearTimeout(pending);
-      timers.delete(plugin.name);
-      pendingFiles.delete(plugin.name);
-    });
-    watchers.push(watcher);
+    watchers.push(createPluginWatcher(plugin, { factory, opts, debounceMs, timers, pendingFiles }));
   }
 
   let closed = false;


### PR DESCRIPTION
## Summary

Behavior-preserving extraction that brings `watchDevPlugins` in `server/plugins/dev-watcher.ts` back under the 50-line `max-lines-per-function` budget, then removes the file from the eslint grandfather list.

The per-plugin loop body (dist path resolution + debounced `ondata` callback + `error` crash-isolation handler) moves into a new module-scope helper `createPluginWatcher(plugin, ctx)`. It takes a 2-arg shape — the plugin plus a context object `{ factory, opts, debounceMs, timers, pendingFiles }` — and mutates the shared `timers` / `pendingFiles` maps exactly as the inline loop did, so `close()` can still cancel every plugin's in-flight burst. The `watcherFactory` inline type is lifted to a named `WatcherFactory` type reused by the option field and the context.

The loop is now a one-liner:

    for (const plugin of plugins) watchers.push(createPluginWatcher(plugin, { factory, opts, debounceMs, timers, pendingFiles }));

## Items to Confirm / Review

- **Behavior identical** — the debounce accumulation, one-warn-per-burst `warnServerSideChange`, `publish`, and the `error` handler (close watcher + clear/delete this plugin's timer & pending entry) are moved verbatim, not rewritten. `summarizeChangedFiles` / `isServerEntry` are untouched.
- **Shared-map mutation** — `timers` and `pendingFiles` are passed by reference into the helper; the returned `close()` handle still owns clearing/closing them.
- **No new public API** — `createPluginWatcher` and `PluginWatchContext` stay module-private; nothing new is exported.

## Verification

- `eslint server/plugins/dev-watcher.ts` → exit 0 (0 errors, 0 warnings). Before: `watchDevPlugins` warned at 57 lines (grandfathered). After: both `watchDevPlugins` and `createPluginWatcher` are under 50 counted lines, passing at error level with the grandfather entry removed.
- `tsc -p server/tsconfig.json --noEmit` and `tsc -p test/tsconfig.json --noEmit` → clean.
- `tsx --test test/plugins/test_dev_watcher.ts` → 21/21 pass (burst coalescing, per-plugin independence, server-side classification, error isolation, `close()` idempotency).
- `prettier --check` → clean.

No new test was added: `createPluginWatcher` is module-private and the existing suite already exercises every branch of it through `watchDevPlugins` (burst coalescing, multi-plugin independence, error isolation, close). Adding one would either widen the API surface or duplicate existing coverage.

## User Prompt

Behavior-preserving extraction to bring `watchDevPlugins` under the 50-line `max-lines-per-function` budget by extracting the per-plugin loop body into a module-scope `createPluginWatcher` helper (2-arg shape: plugin + context object over the shared `factory`/`opts`/`debounceMs`/`timers`/`pendingFiles`), then remove `server/plugins/dev-watcher.ts` from the eslint grandfather list. Behavior must be identical. Recommended by a Codex consult.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-watching reliability during development, reducing missed updates and limiting impact when one watcher fails.
  * Better handling of change bursts so related plugin updates are grouped more consistently.

* **Chores**
  * Relaxed a few internal function-length lint checks to keep existing longer files from failing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->