### PR TITLE
chore: extract runAgentStreamWithFailover from runAgentInBackground

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -489,7 +489,6 @@ export default [
       "packages/core/src/whisper/sidecar.ts",
       "packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts",
       "packages/relay/src/client.ts",
-      "server/api/routes/agent.ts",
       "server/events/relay-client.ts",
       "server/plugins/dev-watcher.ts",
       "server/system/credentials.ts",

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -967,6 +967,93 @@ function isRecoverableStaleSession(event: { type: string; message?: unknown }, f
   return failoverAttemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message);
 }
 
+// What the failover stream loop reads to (re)invoke `runAgent`. A
+// subset of `BackgroundRunParams` — the per-turn teardown fields
+// (resultsFilePath, requestStartedAt, toolArgsCache, origin) stay in
+// `runAgentInBackground`.
+interface FailoverStreamArgs {
+  decoratedMessage: string;
+  role: ReturnType<typeof getRole>;
+  chatSessionId: string;
+  claudeSessionId: string | undefined;
+  abortSignal: AbortSignal;
+  attachments: Attachment[] | undefined;
+  userTimezone: string | undefined;
+}
+
+// Drive `runAgent` for one turn, retrying once without `--resume` when
+// the stored claude session id turns out to be stale (#211). Returns
+// whether a real error event was yielded, so the caller's `finally` can
+// decide hidden-worker cleanup. Split out of `runAgentInBackground` to
+// keep that function under the max-lines-per-function budget.
+async function runAgentStreamWithFailover(args: FailoverStreamArgs, eventCtx: EventContext): Promise<boolean> {
+  const { decoratedMessage, role, chatSessionId, claudeSessionId, abortSignal, attachments, userTimezone } = args;
+
+  // Retry budget for the stale `--resume` id fail-over (#211). Only
+  // meaningful when we entered with a `claudeSessionId`; a fresh
+  // session can't hit that error. One retry max so a looping CLI
+  // bug can't stack infinite replays of the transcript.
+  let failoverAttemptsRemaining = claudeSessionId ? 1 : 0;
+  let currentMessage = decoratedMessage;
+  let currentClaudeSessionId = claudeSessionId;
+  // Tracks whether this run yielded a real error event, so the caller's
+  // finally can decide whether a hidden worker session's files are safe
+  // to delete (success) or should be kept for inspection (error).
+  let didError = false;
+
+  while (true) {
+    let staleSessionDetected = false;
+    for await (const event of runAgent({
+      message: currentMessage,
+      role,
+      workspacePath,
+      sessionId: chatSessionId,
+      port: PORT,
+      claudeSessionId: currentClaudeSessionId,
+      abortSignal,
+      attachments,
+      userTimezone,
+    })) {
+      if (isRecoverableStaleSession(event, failoverAttemptsRemaining)) {
+        // Swallow the error — we're about to recover. `break`
+        // abandons the current generator; since the event is only
+        // yielded after the CLI has already exited non-zero, the
+        // subprocess is dead by this point and there's nothing to
+        // clean up beyond what `for await`'s return() already does.
+        staleSessionDetected = true;
+        failoverAttemptsRemaining--;
+        break;
+      }
+      // A yielded error event (non-zero Claude exit, missing binary, a tool
+      // surfacing an error) is a real failure even though the generator
+      // didn't throw — record it so `finalizeRun`'s hidden-worker cleanup and
+      // the agent-ingest completion hook see `didError`. The stale-session
+      // failover above breaks earlier, so a recoverable id doesn't count.
+      if (event.type === EVENT_TYPES.error) didError = true;
+      await handleAgentEvent(event, eventCtx);
+    }
+    if (!staleSessionDetected) break;
+
+    // Stale `--resume` recovery: clear the bad id from meta so the
+    // next *external* read of this session doesn't see it, build a
+    // natural-language preamble from the jsonl we already have,
+    // and loop back to `runAgent` without `--resume`. Surface a
+    // status event so the UI pause doesn't look like a hang.
+    log.warn("agent", "stale claude session id — retrying without --resume", {
+      chatSessionId,
+    });
+    await clearClaudeId(chatSessionId);
+    const preamble = await readTranscriptPreamble(chatSessionId);
+    currentMessage = preamble ? `${preamble}${decoratedMessage}` : decoratedMessage;
+    currentClaudeSessionId = undefined;
+    pushSessionEvent(chatSessionId, {
+      type: EVENT_TYPES.status,
+      message: "Previous session unavailable — continuing with local transcript.",
+    });
+  }
+  return didError;
+}
+
 async function runAgentInBackground(params: BackgroundRunParams): Promise<void> {
   const { decoratedMessage, role, chatSessionId, claudeSessionId, abortSignal, resultsFilePath, requestStartedAt, toolArgsCache, attachments, userTimezone } =
     params;
@@ -979,69 +1066,13 @@ async function runAgentInBackground(params: BackgroundRunParams): Promise<void> 
     pendingSkill: null,
   };
 
-  // Retry budget for the stale `--resume` id fail-over (#211). Only
-  // meaningful when we entered with a `claudeSessionId`; a fresh
-  // session can't hit that error. One retry max so a looping CLI
-  // bug can't stack infinite replays of the transcript.
-  let failoverAttemptsRemaining = claudeSessionId ? 1 : 0;
-  let currentMessage = decoratedMessage;
-  let currentClaudeSessionId = claudeSessionId;
-  // Tracks whether this run threw, so the finally can decide whether a
-  // hidden worker session's files are safe to delete (success) or
-  // should be kept for inspection (error).
+  // Tracks whether this run threw or yielded an error event, so the
+  // finally can decide whether a hidden worker session's files are safe
+  // to delete (success) or should be kept for inspection (error).
   let didError = false;
 
   try {
-    while (true) {
-      let staleSessionDetected = false;
-      for await (const event of runAgent({
-        message: currentMessage,
-        role,
-        workspacePath,
-        sessionId: chatSessionId,
-        port: PORT,
-        claudeSessionId: currentClaudeSessionId,
-        abortSignal,
-        attachments,
-        userTimezone,
-      })) {
-        if (isRecoverableStaleSession(event, failoverAttemptsRemaining)) {
-          // Swallow the error — we're about to recover. `break`
-          // abandons the current generator; since the event is only
-          // yielded after the CLI has already exited non-zero, the
-          // subprocess is dead by this point and there's nothing to
-          // clean up beyond what `for await`'s return() already does.
-          staleSessionDetected = true;
-          failoverAttemptsRemaining--;
-          break;
-        }
-        // A yielded error event (non-zero Claude exit, missing binary, a tool
-        // surfacing an error) is a real failure even though the generator
-        // didn't throw — record it so `finalizeRun`'s hidden-worker cleanup and
-        // the agent-ingest completion hook see `didError`. The stale-session
-        // failover above returns earlier, so a recoverable id doesn't count.
-        if (event.type === EVENT_TYPES.error) didError = true;
-        await handleAgentEvent(event, eventCtx);
-      }
-      if (!staleSessionDetected) break;
-
-      // Stale `--resume` recovery: clear the bad id from meta so the
-      // next *external* read of this session doesn't see it, build a
-      // natural-language preamble from the jsonl we already have,
-      // and loop back to `runAgent` without `--resume`. Surface a
-      // status event so the UI pause doesn't look like a hang.
-      log.warn("agent", "stale claude session id — retrying without --resume", {
-        chatSessionId,
-      });
-      await clearClaudeId(chatSessionId);
-      const preamble = await readTranscriptPreamble(chatSessionId);
-      currentMessage = preamble ? `${preamble}${decoratedMessage}` : decoratedMessage;
-      currentClaudeSessionId = undefined;
-      pushSessionEvent(chatSessionId, {
-        type: EVENT_TYPES.status,
-        message: "Previous session unavailable — continuing with local transcript.",
-      });
-    }
+    didError = await runAgentStreamWithFailover({ decoratedMessage, role, chatSessionId, claudeSessionId, abortSignal, attachments, userTimezone }, eventCtx);
     // Flush any accumulated streaming text as a single consolidated
     // line in the jsonl. This prevents per-chunk lines that would
     // appear as separate cards on session reload.


### PR DESCRIPTION
## Summary

Behavior-preserving refactor: the stale `--resume` failover `while (true)` loop is extracted out of `runAgentInBackground` (in `server/api/routes/agent.ts`) into a new module-scope helper `runAgentStreamWithFailover`. This brings both functions under the 50-line `max-lines-per-function` budget, so `server/api/routes/agent.ts` is removed from the eslint grandfather list and now passes the repo-wide `error` rule on its own.

**Line counts (eslint-counted, `skipBlankLines` + `skipComments`):**

| function | before | after |
|---|---|---|
| `runAgentInBackground` | 69 | 33 |
| `runAgentStreamWithFailover` (new) | — | 42 |

Both are under 50.

## Items to Confirm / Review

- **Behavior is a pure MOVE.** The failover loop body is transplanted verbatim. The only source changes are: (1) the loop now lives in a helper that owns `failoverAttemptsRemaining` / `currentMessage` / `currentClaudeSessionId` / a local `didError` and `return`s `didError`; (2) `runAgentInBackground` assigns that return into its own `didError` (still declared before the `try` because the `finally` reads it). Please confirm the `didError` handoff preserves the original semantics — in particular that a helper that throws after setting its local `didError = true` still ends with `didError === true` at `finalizeRun` (the outer `catch` sets it, exactly as before).
- The one-retry-only budget (`claudeSessionId ? 1 : 0`), the `isRecoverableStaleSession` check, the `break` / `if (!staleSessionDetected) break;`, and the recovery sequence (`clearClaudeId` → `readTranscriptPreamble` → preamble-prefixed `currentMessage` → `currentClaudeSessionId = undefined` → status `pushSessionEvent`) are unchanged. The `runAgent({...})` call args are unchanged.
- One comment wording tweak: the moved comment said the failover "returns earlier"; the code actually `break`s, so it now reads "breaks earlier". No behavior impact.

## User Prompt

Behavior-preserving refactor (recommended by a Codex consult) to bring `runAgentInBackground` in `server/api/routes/agent.ts` under the 50-line `max-lines-per-function` budget, then remove that file from the eslint grandfather list. Extract the entire stale-`--resume` failover `while (true)` loop into a new module-scope async helper `runAgentStreamWithFailover(args, eventCtx): Promise<boolean>` that owns the loop's mutable locals and returns `didError`. Preserve behavior byte-identically. Do not introduce dependency injection or change how `runAgent` is called/imported. Do not touch `finalizeRun`.

## Verification

- `eslint server/api/routes/agent.ts` → 0 errors (was 1 `max-lines-per-function` warning). Grandfather entry `"server/api/routes/agent.ts",` removed from `eslint.config.mjs`; file now passes at `error` level.
- `tsc -p server/tsconfig.json --noEmit` and `tsc -p test/tsconfig.json --noEmit` → clean.
- `prettier --check` on both changed files → clean.
- Tests run (via parent `tsx`): `test/agent/test_resumeFailover.ts` (15 pass), plus the failover-adjacent guards `test_agent_lifecycle_resilience.ts` / `test_fake_backend_scenarios.ts` / `test_agent_config.ts` / `test_cliArgsForInput.ts` (93 pass). No new test added — this is a pure move and `runAgentInBackground` is not exported, so coverage rests on `test_resumeFailover.ts` (stale-session detection + transcript-preamble building) and the loop-mirroring resilience/fake-backend tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent run reliability when a saved session can no longer be resumed.
  * If resuming fails due to a stale session, runs now automatically continue without interrupting the workflow.
  * Status updates now make it clearer when a run proceeds without using the previous resume state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->