### PR TITLE
chore: split content-loading out of useFileSelection

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -494,7 +494,6 @@ export default [
       "server/plugins/dev-watcher.ts",
       "server/system/credentials.ts",
       "server/workspace/journal/archivist-cli.ts",
-      "src/composables/useFileSelection.ts",
       "src/composables/useFileTree.ts",
       "src/composables/useSessionHistory.ts",
     ],

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -263,7 +263,7 @@ import { computed, defineAsyncComponent, ref, watch, type Component } from "vue"
 import { useI18n } from "vue-i18n";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import SystemFileBanner from "./SystemFileBanner.vue";
-import type { FileContent } from "../composables/useFileSelection";
+import type { FileContent } from "../composables/useFileContentLoader";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { TextResponseData } from "../plugins/textResponse/types";
 import { JSON_TOKEN_CLASS } from "../utils/format/jsonSyntax";

--- a/src/composables/useContentDisplay.ts
+++ b/src/composables/useContentDisplay.ts
@@ -2,7 +2,7 @@
 // current selection. Extracted from FilesView.vue (#507 step 5).
 
 import { computed, watch, type Ref } from "vue";
-import type { FileContent } from "./useFileSelection";
+import type { FileContent } from "./useFileContentLoader";
 import { wrapHtmlWithPreviewCsp } from "../utils/html/previewCsp";
 import { cspExtra, loadCspExtra } from "./useCspExtra";
 import { tokenizeJson, tokenizeJsonl, prettyJson } from "../utils/format/jsonSyntax";

--- a/src/composables/useFileContentLoader.ts
+++ b/src/composables/useFileContentLoader.ts
@@ -1,0 +1,67 @@
+// Composable: fetch file content, aborting an in-flight load when a
+// newer one starts. Split out of useFileSelection (#507) so the abort
+// invariant can be exercised without a vue-router context.
+
+import { ref } from "vue";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+
+interface TextContent {
+  kind: "text";
+  path: string;
+  content: string;
+  size: number;
+  modifiedMs: number;
+}
+
+interface MetaContent {
+  kind: "image" | "pdf" | "audio" | "video" | "binary" | "too-large";
+  path: string;
+  size: number;
+  modifiedMs: number;
+  message?: string;
+}
+
+export type FileContent = TextContent | MetaContent;
+
+export function useFileContentLoader() {
+  const content = ref<FileContent | null>(null);
+  const contentLoading = ref(false);
+  const contentError = ref<string | null>(null);
+
+  let contentAbort: AbortController | null = null;
+
+  async function loadContent(filePath: string): Promise<void> {
+    contentAbort?.abort();
+    const controller = new AbortController();
+    contentAbort = controller;
+
+    contentLoading.value = true;
+    contentError.value = null;
+    content.value = null;
+    try {
+      const result = await apiGet<FileContent>(API_ROUTES.files.content, { path: filePath }, { signal: controller.signal });
+      if (controller.signal.aborted) return;
+      if (!result.ok) {
+        contentError.value = result.error;
+      } else {
+        content.value = result.data;
+      }
+    } finally {
+      // A stale request resolving after a newer one started must not
+      // clear the newer request's loading state.
+      if (contentAbort === controller) {
+        contentLoading.value = false;
+        contentAbort = null;
+      }
+    }
+  }
+
+  function abortContent(): void {
+    contentAbort?.abort();
+    contentAbort = null;
+    contentLoading.value = false;
+  }
+
+  return { content, contentLoading, contentError, loadContent, abortContent };
+}

--- a/src/composables/useFileSelection.ts
+++ b/src/composables/useFileSelection.ts
@@ -1,29 +1,11 @@
-// Composable: file selection, content loading with abort, URL sync.
-// Extracted from FilesView.vue (#507 step 2).
+// Composable: file selection + URL sync. Content loading/abort is
+// owned by useFileContentLoader; this composes it and keeps the
+// route-sync concern. Extracted from FilesView.vue (#507 step 2).
 
 import { ref } from "vue";
 import { useRoute, useRouter, isNavigationFailure } from "vue-router";
-import { apiGet } from "../utils/api";
-import { API_ROUTES } from "../config/apiRoutes";
 import { isNonEmptyString } from "../utils/types";
-
-interface TextContent {
-  kind: "text";
-  path: string;
-  content: string;
-  size: number;
-  modifiedMs: number;
-}
-
-interface MetaContent {
-  kind: "image" | "pdf" | "audio" | "video" | "binary" | "too-large";
-  path: string;
-  size: number;
-  modifiedMs: number;
-  message?: string;
-}
-
-export type FileContent = TextContent | MetaContent;
+import { useFileContentLoader } from "./useFileContentLoader";
 
 /** Segment-wise traversal check: rejects `../` path components
  *  but allows legitimate filenames like `my..notes.txt`. */
@@ -52,37 +34,10 @@ export function useFileSelection() {
   const route = useRoute();
   const router = useRouter();
 
+  const { content, contentLoading, contentError, loadContent, abortContent } = useFileContentLoader();
+
   const pathFromRoute = readPathMatch(route.params.pathMatch);
   const selectedPath = ref<string | null>(isValidFilePath(pathFromRoute) ? pathFromRoute : null);
-  const content = ref<FileContent | null>(null);
-  const contentLoading = ref(false);
-  const contentError = ref<string | null>(null);
-
-  let contentAbort: AbortController | null = null;
-
-  async function loadContent(filePath: string): Promise<void> {
-    contentAbort?.abort();
-    const controller = new AbortController();
-    contentAbort = controller;
-
-    contentLoading.value = true;
-    contentError.value = null;
-    content.value = null;
-    try {
-      const result = await apiGet<FileContent>(API_ROUTES.files.content, { path: filePath }, { signal: controller.signal });
-      if (controller.signal.aborted) return;
-      if (!result.ok) {
-        contentError.value = result.error;
-      } else {
-        content.value = result.data;
-      }
-    } finally {
-      if (contentAbort === controller) {
-        contentLoading.value = false;
-        contentAbort = null;
-      }
-    }
-  }
 
   function selectFile(filePath: string): void {
     selectedPath.value = filePath;
@@ -102,23 +57,15 @@ export function useFileSelection() {
   }
 
   function deselectFile(): void {
-    contentAbort?.abort();
-    contentAbort = null;
+    abortContent();
     selectedPath.value = null;
     content.value = null;
-    contentLoading.value = false;
     contentError.value = null;
     router.replace({ name: "files", params: { pathMatch: [] }, query: route.query }).catch((err: unknown) => {
       if (!isNavigationFailure(err)) {
         console.error("[deselectFile] navigation failed:", err);
       }
     });
-  }
-
-  function abortContent(): void {
-    contentAbort?.abort();
-    contentAbort = null;
-    contentLoading.value = false;
   }
 
   return {

--- a/test/composables/test_useContentDisplay.ts
+++ b/test/composables/test_useContentDisplay.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { ref } from "vue";
 import { useContentDisplay, htmlPreviewUrlFor } from "../../src/composables/useContentDisplay.ts";
-import type { FileContent } from "../../src/composables/useFileSelection.ts";
+import type { FileContent } from "../../src/composables/useFileContentLoader.ts";
 
 function textContent(path: string, body: string): FileContent {
   return {

--- a/test/composables/test_useFileContentLoader.ts
+++ b/test/composables/test_useFileContentLoader.ts
@@ -1,0 +1,84 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { useFileContentLoader } from "../../src/composables/useFileContentLoader.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function textPayload(path: string, content: string) {
+  return { kind: "text" as const, path, content, size: content.length, modifiedMs: 0 };
+}
+
+interface PendingCall {
+  signal: AbortSignal | null | undefined;
+  resolve: (res: Response) => void;
+}
+
+// A fetch whose responses stay pending until the test resolves them by
+// hand — lets us interleave two loads and inspect the state in between.
+function installControllableFetch(): PendingCall[] {
+  const calls: PendingCall[] = [];
+  const impl: typeof fetch = (_input, init) => {
+    const signal = init?.signal;
+    return new Promise<Response>((resolve, reject) => {
+      calls.push({ signal, resolve });
+      signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+    });
+  };
+  globalThis.fetch = impl;
+  return calls;
+}
+
+describe("useFileContentLoader", () => {
+  it("loads text content on success", async () => {
+    globalThis.fetch = async () => jsonResponse(200, textPayload("a.txt", "hello"));
+    const { content, contentLoading, contentError, loadContent } = useFileContentLoader();
+    await loadContent("a.txt");
+    assert.deepEqual(content.value, textPayload("a.txt", "hello"));
+    assert.equal(contentLoading.value, false);
+    assert.equal(contentError.value, null);
+  });
+
+  it("surfaces the server error on an HTTP failure", async () => {
+    globalThis.fetch = async () => jsonResponse(500, { error: "boom" });
+    const { content, contentLoading, contentError, loadContent } = useFileContentLoader();
+    await loadContent("a.txt");
+    assert.equal(content.value, null);
+    assert.equal(contentError.value, "boom");
+    assert.equal(contentLoading.value, false);
+  });
+
+  it("a stale load resolving late does not clear the newer load's state", async () => {
+    const calls = installControllableFetch();
+    const loader = useFileContentLoader();
+    const stale = loader.loadContent("a.txt");
+    const fresh = loader.loadContent("b.txt");
+    await stale;
+    assert.equal(loader.contentLoading.value, true);
+    assert.equal(loader.content.value, null);
+    assert.equal(loader.contentError.value, null);
+    calls[1].resolve(jsonResponse(200, textPayload("b.txt", "fresh")));
+    await fresh;
+    assert.deepEqual(loader.content.value, textPayload("b.txt", "fresh"));
+    assert.equal(loader.contentLoading.value, false);
+    assert.equal(loader.contentError.value, null);
+  });
+
+  it("abortContent stops the in-flight load and clears loading", async () => {
+    installControllableFetch();
+    const loader = useFileContentLoader();
+    const pending = loader.loadContent("a.txt");
+    loader.abortContent();
+    assert.equal(loader.contentLoading.value, false);
+    await pending;
+    assert.equal(loader.content.value, null);
+    assert.equal(loader.contentLoading.value, false);
+  });
+});


### PR DESCRIPTION
## Summary

Behavior-preserving split of `useFileSelection` (`src/composables/useFileSelection.ts`). The content-loading/abort concern moves into a new sibling composable `useFileContentLoader`, which drops `useFileSelection`'s function from **69** counted lines to **37** (comfortably under the 50-line `max-lines-per-function` budget). The file's grandfather entry in `eslint.config.mjs` is removed, so the rule now applies to it at `error` level.

`useFileSelection`'s **returned interface is unchanged** — it still returns exactly `{ selectedPath, content, contentLoading, contentError, loadContent, selectFile, deselectFile, abortContent }` with identical types. `isValidFilePath` / `readPathMatch` stay put and exported.

## Items to Confirm / Review

- **Critical invariant preserved verbatim**: `loadContent`'s `finally` still guards with `if (contentAbort === controller) { ... }`, so a stale request resolving after a newer one started does not clear the newer loading state. This is now covered by a unit test.
- **`FileContent` type moved** from `useFileSelection` to `useFileContentLoader` (its natural home — the loader is what fetches/types content). The 3 importers (`useContentDisplay.ts`, `FileContentRenderer.vue`, `test_useContentDisplay.ts`) now import it from the loader. This avoids both an `import/no-cycle` violation and a re-export (repo forbids re-exports). Please confirm this type relocation is acceptable vs. keeping a re-export shim.
- **`deselectFile`** now calls `abortContent()` (abort + null controller + `contentLoading = false`) then clears `selectedPath` / `content` / `contentError`. End state is identical to the original inline body.

## What changed

- **New** `src/composables/useFileContentLoader.ts`: owns `content`, `contentLoading`, `contentError`, the `contentAbort` controller, `loadContent`, `abortContent`. Router-free.
- `src/composables/useFileSelection.ts`: composes the loader; keeps `selectedPath` + `selectFile` + `deselectFile` (route-sync) and re-exposes the loader's members so the return shape is unchanged.
- `eslint.config.mjs`: removed `"src/composables/useFileSelection.ts"` from the max-lines-per-function grandfather block.
- **New** `test/composables/test_useFileContentLoader.ts`: 4 tests (happy path, HTTP error, the stale-abort invariant, `abortContent`). The loader being router-free is what makes this testable — the old `useFileSelection` needed a vue-router context and was e2e-only.
- Import-path updates in the 3 `FileContent` consumers.

## Verification

- `eslint` on all changed source/test files: **0 errors** (`useFileSelection` no longer flagged for max-lines).
- `tsc -p test/tsconfig.json --noEmit`: clean.
- New loader test: 4/4 pass, including the stale-abort invariant. `test_useContentDisplay.ts`: 23/23 pass after the import-path change.

## User Prompt

Behavior-preserving split of `useFileSelection` to bring it under the 50-line `max-lines-per-function` budget, then remove that file from the eslint grandfather list. Extract the content-loading/abort concern into a separate composable, keep the returned interface identical, and preserve the abort-nulling invariant exactly. Add a test for any newly-testable pure/reactive piece, remove the grandfather entry, and confirm the file passes at error level. (Recommended by a Codex consult.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
