### PR TITLE
docs: add remote-host user help page + General role sample prompt

### DIFF
--- a/packages/core/assets/helps/index.md
+++ b/packages/core/assets/helps/index.md
@@ -69,7 +69,7 @@ See [Wiki](config/helps/wiki.md) for details on how it works.
 - [Sandbox](config/helps/sandbox.md) — how the Docker sandbox isolates the agent, what it can access, and how to disable it
 - [Error recovery](config/helps/error-recovery.md) — the lookup the agent reads on tool failures (gh/git/SSH inside the sandbox, Marp PDF, registry import, build/workspace, plugin runtime) before asking the user
 - [Telegram Bridge](config/helps/telegram.md) — how to talk to MulmoClaude from the Telegram app: creating a bot, starting the bridge, allowlisting chat IDs, commands, and troubleshooting
-- [Remote host](config/helps/remote-host.md) — drive MulmoClaude from a phone at mulmoserver.web.app: connecting via Google sign-in, what works while the host is online vs. offline (queued chats, 7-day expiry), photo attachments, and the security model
+- [Remote host](config/helps/remote-host.md) — drive MulmoClaude from a phone at mulmoserver.web.app: Google sign-in connect, host online vs. offline (queued chats, 7-day expiry), photo attachments, and the security model
 - [Feeds](config/helps/feeds.md) — register a self-refreshing data feed (RSS/Atom/JSON) by authoring `feeds/<slug>/schema.json`: schema shape, the `ingest` block, raw-item field mapping, and `maxItems` retention
 - [GitHub repositories in the workspace](config/helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
 - [Collection skills](config/helps/collection-skills.md) — build a data app (model + UI + relations + computed fields + action buttons) by authoring a `schema.json` collection skill: the DSL, field types, derived formulas, actions, records

--- a/packages/core/assets/helps/index.md
+++ b/packages/core/assets/helps/index.md
@@ -69,6 +69,7 @@ See [Wiki](config/helps/wiki.md) for details on how it works.
 - [Sandbox](config/helps/sandbox.md) — how the Docker sandbox isolates the agent, what it can access, and how to disable it
 - [Error recovery](config/helps/error-recovery.md) — the lookup the agent reads on tool failures (gh/git/SSH inside the sandbox, Marp PDF, registry import, build/workspace, plugin runtime) before asking the user
 - [Telegram Bridge](config/helps/telegram.md) — how to talk to MulmoClaude from the Telegram app: creating a bot, starting the bridge, allowlisting chat IDs, commands, and troubleshooting
+- [Remote host](config/helps/remote-host.md) — drive MulmoClaude from a phone at mulmoserver.web.app: connecting via Google sign-in, what works while the host is online vs. offline (queued chats, 7-day expiry), photo attachments, and the security model
 - [Feeds](config/helps/feeds.md) — register a self-refreshing data feed (RSS/Atom/JSON) by authoring `feeds/<slug>/schema.json`: schema shape, the `ingest` block, raw-item field mapping, and `maxItems` retention
 - [GitHub repositories in the workspace](config/helps/github.md) — clone-destination rules under `github/<name>/` and how to handle existing directories with matching or different remotes
 - [Collection skills](config/helps/collection-skills.md) — build a data app (model + UI + relations + computed fields + action buttons) by authoring a `schema.json` collection skill: the DSL, field types, derived formulas, actions, records

--- a/packages/core/assets/helps/remote-host.md
+++ b/packages/core/assets/helps/remote-host.md
@@ -1,0 +1,122 @@
+# Remote Host — Your MulmoClaude from Your Phone
+
+The remote host feature lets you use your MulmoClaude from a phone browser at
+**https://mulmoserver.web.app** — browse your collections, open mobile custom
+views, edit records, and start chats with photos taken on the spot — while the
+server keeps running privately on your own computer.
+
+Nothing on your computer is exposed to the internet: no open ports, no public
+URL, no tunnels. Phone and server talk through a **cloud message queue**
+(Google Firestore): the phone drops a request into your private queue, your
+server picks it up, does the work, and drops the answer back. Both directions
+happen in real time.
+
+## Connecting
+
+1. On your computer, click the **phone icon** (`phonelink`) in the MulmoClaude
+   toolbar and press **Connect**. A Google sign-in popup opens — sign in with
+   your Google account. The icon turns green when the host is connected.
+2. On your phone, open **https://mulmoserver.web.app** and sign in with the
+   **same Google account**. The app shows your host as online and lists what it
+   can do.
+
+The two sides find each other purely through the shared Google account — there
+is no pairing code and no IP address to type.
+
+The connection lives only as long as the server process: restarting MulmoClaude
+drops it, and you reconnect with the same one click. **Disconnect** in the same
+popover stops it immediately.
+
+## What You Can Do from the Phone
+
+- **Browse collections** — list your collections and page through their records.
+- **Mobile custom views** — open views authored for the phone
+  (`target: "mobile"` in a collection's `views[]`; see
+  [Remote custom views](config/helps/custom-view-remote.md)). Views can show
+  image thumbnails and, where the view allows it, **update or delete records**.
+- **Start a chat** — send a message (optionally with a role and **photo
+  attachments**) that opens a visible chat session on your computer, as if you
+  had typed it there.
+- **Browse feeds, shortcuts, and skills** — read-only listings of what the
+  workspace offers.
+
+The phone app only shows actions your host actually supports — an older host
+simply advertises a shorter menu, so you never tap a button that can't work.
+
+## When the Host Is Online
+
+Everything above works live. The host announces itself once a minute, so the
+phone reliably shows it as online and results come back within moments.
+
+## When the Host Is Offline
+
+If your computer is asleep or MulmoClaude isn't connected, the phone shows the
+host as **offline**. Browsing (collections, views, feeds) needs a live host and
+is unavailable — but **starting a chat still works**:
+
+- The message (and any attached photos) is **queued** in the cloud. The moment
+  your host reconnects, it drains the queue — oldest first — and starts the
+  chats as if they had just arrived.
+- Queued messages **expire after 7 days**. An expired message is deleted
+  outright, along with its uploaded photos — it will not surprise you by
+  starting a week-old chat.
+- The phone lists your pending messages, and you can delete one before the
+  host picks it up.
+
+This makes the chat queue a fire-and-forget inbox: jot an idea or snap a
+receipt on the go, and it is waiting for your MulmoClaude the next time it
+comes online.
+
+## Photos and Attachments
+
+Photos attached to a chat are uploaded to a private staging area (Firebase
+Storage) under your account, downloaded into your workspace when the host
+handles the message, and then **deleted from the cloud**. Photos belonging to
+an expired queued message are deleted too. As a backstop, anything somehow left
+behind is automatically swept after 14 days.
+
+## How Secure Is It?
+
+**Your server stays private.** It only makes *outbound* connections to Google's
+Firestore — it never listens on a public address, so there is nothing on your
+machine for an attacker to scan or reach.
+
+**Everything is scoped to your Google account.** Both the phone and the host
+sign in as *you*, and the cloud's security rules restrict each signed-in user
+to their own private area — no other user can read your data or send commands
+to your host, and your host cannot touch anyone else's data.
+
+**Sign-in is one-shot and in-memory.** Connect passes a short-lived Google
+sign-in token from your browser to the server over `localhost` only; it is
+used once, never written to a log or to disk. The resulting session lives in
+server memory — restarting the server forgets it, and Disconnect ends it on
+the spot.
+
+**Mobile views are sandboxed.** A custom view rendered on the phone runs in a
+locked-down frame with **all network access disabled** — data reaches it only
+through a controlled message channel, so a view (which may be LLM-authored)
+cannot leak your data to the outside. Record edits made from a view are
+validated and policy-checked by *your host*, not trusted from the phone.
+
+**What passes through the cloud.** Requests, results (record pages, view HTML,
+thumbnails), and staged photo uploads transit — and are temporarily stored in —
+your private area of a Google Firebase project while in flight. Access is
+limited to your account, and the data is deleted as soon as it has been
+delivered — the cloud is a relay, not a copy of your workspace.
+
+**The one thing to protect is your Google account.** Anyone who can sign in to
+it can command your host with the full capability list above (though never
+beyond it — the host only executes its fixed, built-in set of operations).
+Use a strong password and two-factor authentication, and Disconnect the host
+when you don't need remote access.
+
+## Good to Know
+
+- **Host shows offline right after a restart** — reconnecting is manual by
+  design (the sign-in lives in memory). Click the phone icon → Connect.
+- **A queued chat used a role that no longer exists** — the message fails with
+  an error the phone can display, rather than silently starting the wrong chat.
+- **Not the same thing as the MulmoBridge messenger bridges** — Telegram / LINE
+  bridges relay *conversations* through a bot; the remote host is a *control
+  channel* for collections, views, and chat-starting from the dedicated phone
+  app.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.5",
-    "@mulmoclaude/core": "^0.12.0",
+    "@mulmoclaude/core": "^0.12.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -68,6 +68,7 @@ export const ROLES: Role[] = [
     queries: [
       "Tell me about this app, MulmoClaude.",
       "What are collections in this app, and how do I build one just by describing what I want?",
+      "How do I access MulmoClaude from my phone with the remote host feature, and how secure is it?",
       "What is the wiki in this app and how do I use it?",
       "Tell me about the sandbox feature of this app.",
       "What is the role of the Gemini API key in this app?",


### PR DESCRIPTION
## Summary

- New user-facing help page `packages/core/assets/helps/remote-host.md` explaining the remote-host feature: connecting from a phone at https://mulmoserver.web.app with the same Google account, what works while the host is online vs. offline (chat queueing with 7-day expiry, photo staging + cleanup), and the security model (outbound-only connections, account-scoped Firestore rules, one-shot in-memory sign-in token, sandboxed mobile views with no network access, cloud-as-relay data handling).
- Registered the page in the helps index (`index.md`).
- Added a third General-role sample prompt — "How do I access MulmoClaude from my phone with the remote host feature, and how secure is it?" — which resolves through the help index to the new page (verified end-to-end: the agent answers accurately from it).
- Bumped `@mulmoclaude/core` 0.12.0 → 0.12.1 (required whenever `assets/helps/*` changes) and the launcher dep range to `^0.12.1` for the lockstep gate. Launcher's own version untouched; npm publish of core to follow after merge.

## Test plan

- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` all pass
- Manually exercised the new sample prompt in the General role; the agent found the help page via the index and produced an accurate summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Help page for using MulmoClaude from a phone via a remote host, including sign-in, offline behavior, photo attachments, and security details.
  * Added a built-in help prompt covering phone access and setup.

* **Documentation**
  * Expanded the Help Pages list with the new remote host guide.

* **Chores**
  * Updated package versions to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->