### PR TITLE
chore: extract awaitTokenRenewal from renewTokenViaPty

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -490,7 +490,6 @@ export default [
       "packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts",
       "packages/relay/src/client.ts",
       "server/events/relay-client.ts",
-      "server/system/credentials.ts",
       "server/workspace/journal/archivist-cli.ts",
       "src/composables/useFileTree.ts",
       "src/composables/useSessionHistory.ts",

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -77,17 +77,7 @@ function isTokenExpired(raw: string): boolean {
  * OAuth token. The CLI handles the refresh internally and writes the new
  * token back to the macOS Keychain.
  */
-async function renewTokenViaPty(): Promise<boolean> {
-  // Dynamic import — node-pty is a native module that may not be present
-  // on all platforms. Guard with try/catch.
-  let pty: typeof import("node-pty");
-  try {
-    pty = await import("node-pty");
-  } catch {
-    log.error("credentials", "node-pty not available, cannot renew token");
-    return false;
-  }
-
+function awaitTokenRenewal(pty: typeof import("node-pty")): Promise<boolean> {
   return new Promise((resolve) => {
     const proc = pty.spawn("claude", [], {
       name: "xterm-color",
@@ -159,6 +149,20 @@ async function renewTokenViaPty(): Promise<boolean> {
       }
     }, PTY_INPUT_DELAY_MS);
   });
+}
+
+async function renewTokenViaPty(): Promise<boolean> {
+  // Dynamic import — node-pty is a native module that may not be present
+  // on all platforms. Guard with try/catch.
+  let pty: typeof import("node-pty");
+  try {
+    pty = await import("node-pty");
+  } catch {
+    log.error("credentials", "node-pty not available, cannot renew token");
+    return false;
+  }
+
+  return awaitTokenRenewal(pty);
 }
 
 /**


### PR DESCRIPTION
## Summary

`renewTokenViaPty` in `server/system/credentials.ts` was 54 counted lines — over the repo's `max-lines-per-function` budget (`{ max: 50, skipBlankLines: true, skipComments: true }`) — and was pinned to `warn` via the eslint grandfather list. This PR performs a strictly behavior-preserving split into two concerns:

- `renewTokenViaPty` (10 counted lines): the guarded dynamic `import("node-pty")` (try/catch → `return false` on failure), then `return awaitTokenRenewal(pty)`.
- `awaitTokenRenewal(pty)` (47 counted lines): the entire `new Promise((resolve) => { … })` PTY renewal handshake, moved verbatim.

The `server/system/credentials.ts` entry is removed from the `max-lines-per-function` grandfather block in `eslint.config.mjs`. Both functions are now under the 50-line budget and the file passes eslint at `error` level.

## Items to Confirm / Review

- **Behavior preserved verbatim**: the PTY spawn options, the mutual `finish`/`timeout` pair (including its `eslint-disable-next-line prefer-const` comment and rationale), `settled`/`responded`/`buffer`/`echoEndIdx` semantics, the `ECHO_RE` echo detection (`match.index + match[0].length`), the `looksLikeClaudeResponse(buffer.slice(echoEndIdx))` success check, `PTY_TIMEOUT_MS`, and the `PTY_INPUT_DELAY_MS`-delayed `proc.write("hi\r")` guarded by `!settled` are all unchanged.
- `cwd: process.cwd()` stays evaluated at call time (kept inside the spawn call, not hoisted to a module const), so nothing about when it is read changes.
- No comments were deleted — the rule skips comments, so trimming them saves nothing; only real code moved.

## Verification

- `eslint server/system/credentials.ts` → 0 errors, no `max-lines-per-function` warning/error on either function (before and after removing the grandfather entry).
- `tsc -p server/tsconfig.json --noEmit` and `tsc -p test/tsconfig.json --noEmit` → clean.
- `tsx --test test/system/test_credentials.ts` → 10/10 pass.
- `prettier --check` on both changed files → clean.

## Counted line numbers

| Function | Before | After |
|---|---|---|
| `renewTokenViaPty` | 54 | 10 |
| `awaitTokenRenewal` | — | 47 |

## User Prompt

Bring `renewTokenViaPty` in `server/system/credentials.ts` under the 50-line `max-lines-per-function` budget with a strictly behavior-preserving move: extract the entire `new Promise((resolve) => { … })` executor into a module-scope `awaitTokenRenewal(pty)` helper, leaving `renewTokenViaPty` as just the guarded dynamic import plus `return awaitTokenRenewal(pty)`. Then remove `server/system/credentials.ts` from the eslint `max-lines-per-function` grandfather list. Preserve all comments and PTY logic exactly. No version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential refresh reliability by streamlining the token renewal flow.
* **Chores**
  * Tightened code-quality checks for one previously exempted area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->