### PR TITLE
chore: clear max-lines-per-function warnings in archivist-cli

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -491,7 +491,6 @@ export default [
       "packages/relay/src/client.ts",
       "server/events/relay-client.ts",
       "server/system/credentials.ts",
-      "server/workspace/journal/archivist-cli.ts",
       "src/composables/useFileTree.ts",
       "src/composables/useSessionHistory.ts",
     ],

--- a/server/workspace/journal/archivist-cli.ts
+++ b/server/workspace/journal/archivist-cli.ts
@@ -1,6 +1,6 @@
 // Spawning the Claude Code CLI runs summarization against the user's subscription quota rather than the API-key budget.
 
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { CLI_SUBPROCESS_TIMEOUT_MS } from "../../utils/time.js";
 import { claudeBinPath, ClaudeCliNotFoundError } from "../../utils/claudeBin.js";
 
@@ -48,6 +48,32 @@ export function buildCliPayload(systemPrompt: string, userPrompt: string): strin
   return `${systemPrompt}\n\n---\n\n${userPrompt}`;
 }
 
+interface ChildOutput {
+  stdout: string;
+  stderr: string;
+}
+
+function collectChildOutput(child: ChildProcessWithoutNullStreams): ChildOutput {
+  const output: ChildOutput = { stdout: "", stderr: "" };
+  child.stdout.on("data", (chunk: Buffer) => {
+    output.stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    output.stderr += chunk.toString();
+  });
+  return output;
+}
+
+// Wait for "drain" on backpressure before end() so the buffer fully flushes — large excerpts can hit this path.
+function writeStdinAndClose(child: ChildProcessWithoutNullStreams, payload: string): void {
+  const flushed = child.stdin.write(payload);
+  if (flushed) {
+    child.stdin.end();
+  } else {
+    child.stdin.once("drain", () => child.stdin.end());
+  }
+}
+
 // Pipe the combined prompt via stdin to dodge shell-argv limits for large day excerpts.
 export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
   new Promise((resolve, reject) => {
@@ -56,8 +82,7 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    let stdout = "";
-    let stderr = "";
+    const output = collectChildOutput(child);
     let timedOut = false;
     let settled = false;
 
@@ -65,13 +90,6 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
       timedOut = true;
       child.kill("SIGKILL");
     }, CLI_TIMEOUT_MS);
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
 
     child.on("error", (err: Error & { code?: string }) => {
       if (settled) return;
@@ -89,13 +107,13 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
       settled = true;
       clearTimeout(timeout);
       if (timedOut) {
-        reject(new ClaudeCliFailedError(null, `timed out after ${CLI_TIMEOUT_MS}ms\n${stderr}`));
+        reject(new ClaudeCliFailedError(null, `timed out after ${CLI_TIMEOUT_MS}ms\n${output.stderr}`));
         return;
       }
       if (code === 0) {
-        resolve(stdout);
+        resolve(output.stdout);
       } else {
-        reject(new ClaudeCliFailedError(code, stderr));
+        reject(new ClaudeCliFailedError(code, output.stderr));
       }
     });
 
@@ -107,12 +125,5 @@ export const runClaudeCli: Summarize = async (systemPrompt, userPrompt, opts) =>
       reject(err);
     });
 
-    // Wait for "drain" on backpressure before end() so the buffer fully flushes — large excerpts can hit this path.
-    const payload = buildCliPayload(systemPrompt, userPrompt);
-    const flushed = child.stdin.write(payload);
-    if (flushed) {
-      child.stdin.end();
-    } else {
-      child.stdin.once("drain", () => child.stdin.end());
-    }
+    writeStdinAndClose(child, buildCliPayload(systemPrompt, userPrompt));
   });


### PR DESCRIPTION
## Summary

Clears both `max-lines-per-function` warnings in `server/workspace/journal/archivist-cli.ts` with a strictly behavior-preserving refactor, and removes the file from the eslint grandfather block.

The `runClaudeCli` Promise executor was over the 50-line budget. Two module-scope helpers were extracted from it:

- `collectChildOutput(child)` — attaches the `stdout`/`stderr` `"data"` accumulators (same order, same accumulation) and returns a `{ stdout, stderr }` object the close/timeout handlers read.
- `writeStdinAndClose(child, payload)` — the stdin write + backpressure/drain-then-`end()` logic (comment preserved on the helper).

Both helpers are typed against `ChildProcessWithoutNullStreams` (the actual `spawn(...)` return type for `stdio: ["pipe","pipe","pipe"]`). No `any`, no `as` casts.

### Counted lines (rule: `max: 50`, skip blanks/comments)

| function | before | after |
|---|---|---|
| outer `runClaudeCli` async arrow | 58 | 45 |
| inner `new Promise` executor arrow | 57 | 44 |

New helpers: `collectChildOutput` 10 lines, `writeStdinAndClose` 8 lines — both well under budget.

## Items to Confirm / Review

- **Behavior preservation**: the `settled` single-flight guard, `clearTimeout(timeout)` in every handler, `resolve`/`reject` calls, ENOENT→`ClaudeCliNotFoundError`, timeout→SIGKILL + `ClaudeCliFailedError(null, ...)`, `code===0`→resolve else `ClaudeCliFailedError(code, stderr)`, and stdin EPIPE reject all stay **inside** the executor and are unchanged — only the two accumulators and the stdin write moved out. Listener attachment order is identical.
- **Child type**: `ChildProcessWithoutNullStreams` imported from `node:child_process` (not invented) — this is what `spawn` returns with all-pipe stdio, so `child.stdin/stdout/stderr` stay non-null.
- `buildClaudeCliArgs` / `buildCliPayload` remain exported and unchanged; `runClaudeCli`'s `Summarize` type is unchanged.

## Verification

- `eslint server/workspace/journal/archivist-cli.ts` → 0 warnings, 0 errors (both `max-lines` warnings gone; no warning on either arrow or the two new helpers).
- `tsc -p server/tsconfig.json --noEmit` and `tsc -p test/tsconfig.json --noEmit` → clean.
- `tsx --test test/journal/test_archivist_cli.ts` → 10/10 pass (existing pure-helper suite).
- `prettier --check` on both changed files → clean.
- Grandfather entry `"server/workspace/journal/archivist-cli.ts"` removed from `eslint.config.mjs`.

The two extracted helpers take a `ChildProcessWithoutNullStreams`; unit-testing them with a fake child would require an `as` cast (a full stub isn't structurally assignable), which the repo style forbids, so their coverage rests on the existing suite plus tsc/eslint. No new tests added.

## User Prompt

Clear both `max-lines-per-function` warnings in `server/workspace/journal/archivist-cli.ts` with a strictly behavior-preserving refactor by extracting two module-scope helpers (`collectChildOutput` for the stdout/stderr accumulators and `writeStdinAndClose` for the stdin write+drain) from the `runClaudeCli` Promise executor, then remove the file from the eslint grandfather list. No version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting guidance to keep a couple of existing long functions flagged as warnings, while no longer applying that exception to another older file.
* **Bug Fixes**
  * Improved command execution handling so output is collected more reliably and input is written with proper flow control, which should make failures and timeouts report more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->