### PR TITLE
chore: split mutations and deletion-sync out of useSessionHistory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -493,7 +493,6 @@ export default [
       "server/system/credentials.ts",
       "server/workspace/journal/archivist-cli.ts",
       "src/composables/useFileTree.ts",
-      "src/composables/useSessionHistory.ts",
     ],
     rules: {
       "max-lines-per-function": ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -21,6 +21,58 @@ function readDeletedIds(payload: unknown): string[] {
   return Array.isArray(ids) ? ids.filter((entry): entry is string => typeof entry === "string") : [];
 }
 
+// Cross-tab cache pruning: cursor diffs don't carry deletions
+// (deletedIds is always [] in the REST response — see #205 comments
+// in routes/sessions.ts), so we rely on the channel payload.
+//
+// Gated on getCurrentScope() so unit tests that instantiate the
+// composable outside a Vue setup don't open a real socket.io
+// connection (which would keep node's event loop alive and hang
+// the test process).
+function subscribeToSessionDeletions(sessions: Ref<SessionSummary[]>): void {
+  if (!getCurrentScope()) return;
+  const { subscribe } = usePubSub();
+  const unsubscribe = subscribe(PUBSUB_CHANNELS.sessions, (data) => {
+    const ids = readDeletedIds(data);
+    if (ids.length === 0) return;
+    const drop = new Set(ids);
+    sessions.value = sessions.value.filter((session) => !drop.has(session.id));
+  });
+  if (typeof unsubscribe === "function") onScopeDispose(unsubscribe);
+}
+
+function useSessionMutations(sessions: Ref<SessionSummary[]>, historyError: Ref<string | null>) {
+  async function setBookmark(sessionId: string, bookmarked: boolean): Promise<boolean> {
+    const path = API_ROUTES.sessions.bookmark.replace(":id", encodeURIComponent(sessionId));
+    const result = await apiPost<{ ok: boolean }>(path, { bookmarked });
+    if (!result.ok) {
+      historyError.value = result.error;
+      return false;
+    }
+    // Optimistic local update so the green-icon flip is immediate;
+    // the pub/sub round-trip will reaffirm via the cursor diff (meta
+    // mtime feeds into changeMs) and also reach other tabs.
+    sessions.value = applyBookmarkFlag(sessions.value, sessionId, bookmarked);
+    return true;
+  }
+
+  async function deleteSession(sessionId: string): Promise<boolean> {
+    const path = API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId));
+    const result = await apiDelete<{ ok: boolean }>(path);
+    if (!result.ok) {
+      historyError.value = result.error;
+      return false;
+    }
+    // Don't update locally — the server publishes `deletedIds` on the
+    // sessions channel and the subscriber below removes the row in
+    // every tab (including this one) the same way. One code path, no
+    // race between the optimistic write and the broadcast.
+    return true;
+  }
+
+  return { setBookmark, deleteSession };
+}
+
 export interface UseSessionHistory {
   sessions: Ref<SessionSummary[]>;
   historyError: Ref<string | null>;
@@ -56,52 +108,8 @@ export function useSessionHistory(): UseSessionHistory {
     return sessions.value;
   }
 
-  async function setBookmark(sessionId: string, bookmarked: boolean): Promise<boolean> {
-    const path = API_ROUTES.sessions.bookmark.replace(":id", encodeURIComponent(sessionId));
-    const result = await apiPost<{ ok: boolean }>(path, { bookmarked });
-    if (!result.ok) {
-      historyError.value = result.error;
-      return false;
-    }
-    // Optimistic local update so the green-icon flip is immediate;
-    // the pub/sub round-trip will reaffirm via the cursor diff (meta
-    // mtime feeds into changeMs) and also reach other tabs.
-    sessions.value = applyBookmarkFlag(sessions.value, sessionId, bookmarked);
-    return true;
-  }
-
-  async function deleteSession(sessionId: string): Promise<boolean> {
-    const path = API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId));
-    const result = await apiDelete<{ ok: boolean }>(path);
-    if (!result.ok) {
-      historyError.value = result.error;
-      return false;
-    }
-    // Don't update locally — the server publishes `deletedIds` on the
-    // sessions channel and the subscriber below removes the row in
-    // every tab (including this one) the same way. One code path, no
-    // race between the optimistic write and the broadcast.
-    return true;
-  }
-
-  // Cross-tab cache pruning: cursor diffs don't carry deletions
-  // (deletedIds is always [] in the REST response — see #205 comments
-  // in routes/sessions.ts), so we rely on the channel payload.
-  //
-  // Gated on getCurrentScope() so unit tests that instantiate the
-  // composable outside a Vue setup don't open a real socket.io
-  // connection (which would keep node's event loop alive and hang
-  // the test process).
-  if (getCurrentScope()) {
-    const { subscribe } = usePubSub();
-    const unsubscribe = subscribe(PUBSUB_CHANNELS.sessions, (data) => {
-      const ids = readDeletedIds(data);
-      if (ids.length === 0) return;
-      const drop = new Set(ids);
-      sessions.value = sessions.value.filter((session) => !drop.has(session.id));
-    });
-    if (typeof unsubscribe === "function") onScopeDispose(unsubscribe);
-  }
+  const { setBookmark, deleteSession } = useSessionMutations(sessions, historyError);
+  subscribeToSessionDeletions(sessions);
 
   return {
     sessions,

--- a/test/composables/test_useSessionHistory.ts
+++ b/test/composables/test_useSessionHistory.ts
@@ -156,3 +156,55 @@ describe("useSessionHistory — cursor-aware incremental fetch (#205)", () => {
     assert.deepEqual(ids, ["a", "c"]);
   });
 });
+
+describe("useSessionHistory — mutations (setBookmark / deleteSession)", () => {
+  it("setBookmark flips isBookmarked optimistically and returns true on success", async () => {
+    const { sessions, historyError, fetchSessions, setBookmark } = useSessionHistory();
+    stubFetch(async () => mockJsonResponse(200, envelope([row("s1"), row("s2")], "v1:1")));
+    await fetchSessions();
+
+    stubFetch(async () => mockJsonResponse(200, { ok: true }));
+    const ok = await setBookmark("s1", true);
+
+    assert.equal(ok, true);
+    assert.equal(historyError.value, null);
+    assert.equal(sessions.value.find((session) => session.id === "s1")?.isBookmarked, true);
+    assert.notEqual(sessions.value.find((session) => session.id === "s2")?.isBookmarked, true);
+  });
+
+  it("setBookmark sets historyError and leaves the flag untouched on failure", async () => {
+    const { sessions, historyError, fetchSessions, setBookmark } = useSessionHistory();
+    stubFetch(async () => mockJsonResponse(200, envelope([row("s1")], "v1:1")));
+    await fetchSessions();
+
+    stubFetch(async () => mockJsonResponse(500, { error: "bookmark write failed" }));
+    const ok = await setBookmark("s1", true);
+
+    assert.equal(ok, false);
+    assert.equal(typeof historyError.value, "string");
+    assert.notEqual(sessions.value.find((session) => session.id === "s1")?.isBookmarked, true);
+  });
+
+  it("deleteSession returns true without mutating the local list on success", async () => {
+    const { sessions, historyError, fetchSessions, deleteSession } = useSessionHistory();
+    stubFetch(async () => mockJsonResponse(200, envelope([row("a"), row("b")], "v1:1")));
+    await fetchSessions();
+
+    stubFetch(async () => mockJsonResponse(200, { ok: true }));
+    const ok = await deleteSession("a");
+
+    assert.equal(ok, true);
+    assert.equal(historyError.value, null);
+    // The pub/sub deletedIds broadcast removes the row; deleteSession must not.
+    assert.equal(sessions.value.length, 2);
+  });
+
+  it("deleteSession sets historyError and returns false on failure", async () => {
+    const { historyError, deleteSession } = useSessionHistory();
+    stubFetch(async () => mockJsonResponse(503, { error: "delete failed" }));
+    const ok = await deleteSession("a");
+
+    assert.equal(ok, false);
+    assert.equal(typeof historyError.value, "string");
+  });
+});


### PR DESCRIPTION
## Summary

Brings `useSessionHistory` (`src/composables/useSessionHistory.ts`) under the 50-line `max-lines-per-function` budget with a strictly behavior-preserving split, and removes it from the eslint grandfather list in `eslint.config.mjs`.

- Before: `useSessionHistory` = 59 counted lines (`max-lines-per-function` warning, rule is `{ max: 50, skipBlankLines: true, skipComments: true }`).
- After: `useSessionHistory` = 32 counted lines; passes at `error` level.

Two pieces were extracted (same file):

1. `subscribeToSessionDeletions(sessions: Ref<SessionSummary[]>): void` — the entire `getCurrentScope()`-guarded pub/sub block that prunes deleted sessions cross-tab, moved verbatim (early-return when `!getCurrentScope()`). Called as one line from the composable. The comment explaining the `getCurrentScope()` test guard travels with the helper.
2. `useSessionMutations(sessions, historyError)` — a small composable returning `{ setBookmark, deleteSession }`, holding those two functions verbatim (comments intact).

`fetchSessions` and the tab-scoped `cursor` stay private inside `useSessionHistory`. The returned `UseSessionHistory` interface is byte-for-byte identical.

## Items to Confirm / Review

- **Behavior preservation**: `setBookmark` / `deleteSession` / the pub/sub subscriber were moved verbatim — please confirm no logic drift. In particular `deleteSession` still returns `true` on success *without* touching the local list (the `deletedIds` broadcast removes the row), and `fetchSessions` still returns the stale `sessions.value` on `!result.ok`.
- **No comments deleted to save lines**: the rule skips comments/blank lines, so the only lever used was moving real code. All rationale comments (#205 cursor diff, stale-list-on-error UX, `getCurrentScope()` test guard, optimistic-bookmark note, delete no-local-update note) are preserved.
- **Grandfather removal**: `"src/composables/useSessionHistory.ts"` removed from the `max-lines-per-function` grandfather block; the file now lints at `error` level.

## User Prompt

> Bring `useSessionHistory` in `src/composables/useSessionHistory.ts` (currently 59 counted lines) under the 50-line `max-lines-per-function` budget with a STRICTLY behavior-preserving split, then remove that file from the eslint grandfather list. Split three concerns: extract `subscribeToSessionDeletions(sessions)` (the `getCurrentScope()`-guarded pub/sub block, early-return when `!getCurrentScope()`) and `useSessionMutations(sessions, historyError)` (returning `{ setBookmark, deleteSession }`), leaving `fetchSessions` and the tab-scoped `cursor` in the parent. The returned `UseSessionHistory` interface must be byte-for-byte identical. Do NOT delete comments to save lines. Add unit tests for the bookmark/delete happy + failure paths via `globalThis.fetch` stubbing, and remove the grandfather entry.

## Tests

- `eslint src/composables/useSessionHistory.ts test/composables/test_useSessionHistory.ts` → 0 problems, no `max-lines` warning.
- `tsc -p test/tsconfig.json --noEmit` → clean.
- `tsx --test test/composables/test_useSessionHistory.ts` → 11 pass (7 existing + 4 new mutation tests: setBookmark happy/failure, deleteSession happy/failure).
- `tsx --test test/composables/test_useSessionHistoryHelpers.ts` → 7 pass.
- `prettier --check` on changed files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)