### PR TITLE
chore: move streamToFile and downloadModel out of createModelDownloader

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -485,7 +485,6 @@ export default [
   {
     files: [
       "packages/core/src/whisper/client.ts",
-      "packages/core/src/whisper/models.ts",
       "packages/core/src/whisper/sidecar.ts",
       "packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts",
       "packages/relay/src/client.ts",

--- a/packages/core/src/whisper/models.ts
+++ b/packages/core/src/whisper/models.ts
@@ -87,6 +87,71 @@ export interface ModelDownloader {
   ensure: (name: WhisperModelName) => Promise<void>;
 }
 
+interface StreamToFileDeps {
+  downloadStatus: Map<WhisperModelName, ModelStatus>;
+  onProgress: () => void;
+}
+
+/** Drain the response stream into the `.partial` file, resetting the stall
+ *  timer on every chunk and publishing progress once the total size is known. */
+async function streamToFile(
+  body: ReadableStream<Uint8Array>,
+  partialPath: string,
+  total: number,
+  name: WhisperModelName,
+  deps: StreamToFileDeps,
+): Promise<void> {
+  const reader = body.getReader();
+  const fileStream = createWriteStream(partialPath);
+  let received = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      deps.onProgress();
+      received += value.byteLength;
+      if (!fileStream.write(value)) await once(fileStream, "drain");
+      if (total > 0) deps.downloadStatus.set(name, { state: "downloading", progress: received / total });
+    }
+    fileStream.end();
+    await once(fileStream, "finish");
+  } catch (err) {
+    fileStream.destroy();
+    throw err;
+  }
+}
+
+/** Fetch a model into a `.partial` file, reject a truncated transfer via the
+ *  size floor, then atomically rename it into place. */
+async function downloadModel(name: WhisperModelName, modelsDir: string, downloadStatus: Map<WhisperModelName, ModelStatus>): Promise<void> {
+  const spec = WHISPER_MODELS[name];
+  mkdirSync(modelsDir, { recursive: true });
+  const dest = modelFilePath(modelsDir, name);
+  const partial = `${dest}.partial`;
+  const controller = new AbortController();
+  let stallTimer: ReturnType<typeof setTimeout> | null = null;
+  const resetStall = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => controller.abort(), DOWNLOAD_STALL_TIMEOUT_MS);
+  };
+  try {
+    const response = await fetch(spec.url, { signal: controller.signal });
+    if (!response.ok || !response.body) {
+      throw new Error(`download failed: HTTP ${response.status}`);
+    }
+    const total = parseContentLength(response.headers.get("content-length"));
+    resetStall();
+    await streamToFile(response.body, partial, total, name, { downloadStatus, onProgress: resetStall });
+    if (statSync(partial).size < spec.minBytes) {
+      unlinkSync(partial);
+      throw new Error("downloaded file is smaller than expected — likely truncated");
+    }
+    renameSync(partial, dest);
+  } finally {
+    if (stallTimer) clearTimeout(stallTimer);
+  }
+}
+
 export function createModelDownloader(modelsDir: string, logger: WhisperLogger = NOOP_LOGGER): ModelDownloader {
   // A finished file on disk is the source of truth for "ready"; this map tracks
   // transient progress + the last error.
@@ -94,62 +159,6 @@ export function createModelDownloader(modelsDir: string, logger: WhisperLogger =
 
   function getStatus(name: WhisperModelName): ModelStatus {
     return pickModelStatus(downloadStatus.get(name), isModelReady(modelsDir, name));
-  }
-
-  async function streamToFile(
-    body: ReadableStream<Uint8Array>,
-    partialPath: string,
-    total: number,
-    name: WhisperModelName,
-    onProgress: () => void,
-  ): Promise<void> {
-    const reader = body.getReader();
-    const fileStream = createWriteStream(partialPath);
-    let received = 0;
-    try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        onProgress();
-        received += value.byteLength;
-        if (!fileStream.write(value)) await once(fileStream, "drain");
-        if (total > 0) downloadStatus.set(name, { state: "downloading", progress: received / total });
-      }
-      fileStream.end();
-      await once(fileStream, "finish");
-    } catch (err) {
-      fileStream.destroy();
-      throw err;
-    }
-  }
-
-  async function download(name: WhisperModelName): Promise<void> {
-    const spec = WHISPER_MODELS[name];
-    mkdirSync(modelsDir, { recursive: true });
-    const dest = modelFilePath(modelsDir, name);
-    const partial = `${dest}.partial`;
-    const controller = new AbortController();
-    let stallTimer: ReturnType<typeof setTimeout> | null = null;
-    const resetStall = () => {
-      if (stallTimer) clearTimeout(stallTimer);
-      stallTimer = setTimeout(() => controller.abort(), DOWNLOAD_STALL_TIMEOUT_MS);
-    };
-    try {
-      const response = await fetch(spec.url, { signal: controller.signal });
-      if (!response.ok || !response.body) {
-        throw new Error(`download failed: HTTP ${response.status}`);
-      }
-      const total = parseContentLength(response.headers.get("content-length"));
-      resetStall();
-      await streamToFile(response.body, partial, total, name, resetStall);
-      if (statSync(partial).size < spec.minBytes) {
-        unlinkSync(partial);
-        throw new Error("downloaded file is smaller than expected — likely truncated");
-      }
-      renameSync(partial, dest);
-    } finally {
-      if (stallTimer) clearTimeout(stallTimer);
-    }
   }
 
   // Fire-and-forget friendly: errors land in the status map, never thrown.
@@ -163,7 +172,7 @@ export function createModelDownloader(modelsDir: string, logger: WhisperLogger =
     downloadStatus.set(name, { state: "downloading", progress: 0 });
     logger.info("model download: start", { model: name });
     try {
-      await download(name);
+      await downloadModel(name, modelsDir, downloadStatus);
       downloadStatus.set(name, { state: "ready" });
       logger.info("model download: ok", { model: name });
     } catch (err) {

--- a/packages/core/test/whisper/test_model_downloader.ts
+++ b/packages/core/test/whisper/test_model_downloader.ts
@@ -1,0 +1,135 @@
+import { describe, it, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createModelDownloader, modelFilePath, type WhisperModelName } from "../../src/whisper/models.ts";
+
+// Drive the module-scope `downloadModel` / `streamToFile` through the only
+// public seam (`createModelDownloader().ensure`), stubbing `globalThis.fetch`
+// and writing into a throwaway temp dir. "base" is the smallest registered
+// model; its multi-hundred-MB size floor is what every failure path here trips.
+const MODEL: WhisperModelName = "base";
+
+const originalFetch = globalThis.fetch;
+const tempDirs: string[] = [];
+
+function makeModelsDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "whisper-models-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const flushMicrotasks = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+function streamFromController(): { body: ReadableStream<Uint8Array>; push: (bytes: number) => void; close: () => void } {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController;
+    },
+  });
+  return { body, push: (bytes) => controller.enqueue(new Uint8Array(bytes)), close: () => controller.close() };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  tempDirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+});
+
+describe("createModelDownloader.ensure — download orchestration", () => {
+  it("rejects and cleans up a body below the size floor", async () => {
+    globalThis.fetch = async () => new Response(new Uint8Array(1024));
+    const dir = makeModelsDir();
+    const downloader = createModelDownloader(dir);
+
+    await downloader.ensure(MODEL);
+
+    const status = downloader.getStatus(MODEL);
+    assert.equal(status.state, "error");
+    assert.match(status.error ?? "", /smaller than expected/);
+    assert.equal(existsSync(`${modelFilePath(dir, MODEL)}.partial`), false);
+    assert.equal(existsSync(modelFilePath(dir, MODEL)), false);
+  });
+
+  it("reports an HTTP error without creating a partial file", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 503 });
+    const dir = makeModelsDir();
+    const downloader = createModelDownloader(dir);
+
+    await downloader.ensure(MODEL);
+
+    const status = downloader.getStatus(MODEL);
+    assert.equal(status.state, "error");
+    assert.match(status.error ?? "", /HTTP 503/);
+    assert.equal(existsSync(`${modelFilePath(dir, MODEL)}.partial`), false);
+  });
+
+  it("publishes fractional progress while streaming a known content length", async () => {
+    // A chunk under the fs write high-water mark (16 KiB) keeps `write` from
+    // returning false, so progress lands without waiting on a `drain` event.
+    const total = 40_000;
+    const source = streamFromController();
+    globalThis.fetch = async () => new Response(source.body, { headers: { "content-length": String(total) } });
+    const dir = makeModelsDir();
+    const downloader = createModelDownloader(dir);
+
+    const done = downloader.ensure(MODEL);
+    source.push(10_000);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    const mid = downloader.getStatus(MODEL);
+    assert.equal(mid.state, "downloading");
+    assert.ok(mid.progress !== undefined && mid.progress > 0 && mid.progress < 1, `progress ${mid.progress} should be a fraction`);
+
+    source.close();
+    await done;
+  });
+
+  it("does not start a second download while one is already in flight", async () => {
+    let fetchCalls = 0;
+    const source = streamFromController();
+    globalThis.fetch = async () => {
+      fetchCalls += 1;
+      return new Response(source.body, { headers: { "content-length": "1024" } });
+    };
+    const dir = makeModelsDir();
+    const downloader = createModelDownloader(dir);
+
+    const first = downloader.ensure(MODEL);
+    await downloader.ensure(MODEL);
+    assert.equal(fetchCalls, 1);
+
+    source.close();
+    await first;
+  });
+
+  it("aborts a stalled download once the stall timeout elapses", async (ctx) => {
+    mock.timers.enable({ apis: ["setTimeout"] });
+    ctx.after(() => mock.timers.reset());
+
+    globalThis.fetch = async (_input, init) => {
+      const signal = init?.signal;
+      const stalled = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal?.addEventListener("abort", () => controller.error(new Error("stalled")));
+        },
+      });
+      return new Response(stalled, { headers: { "content-length": "1024" } });
+    };
+    const dir = makeModelsDir();
+    const downloader = createModelDownloader(dir);
+
+    const done = downloader.ensure(MODEL);
+    await flushMicrotasks();
+    await flushMicrotasks();
+    mock.timers.tick(60_000);
+    await done;
+
+    const status = downloader.getStatus(MODEL);
+    assert.equal(status.state, "error");
+    assert.equal(existsSync(modelFilePath(dir, MODEL)), false);
+  });
+});


### PR DESCRIPTION
## Summary

`createModelDownloader` in `packages/core/src/whisper/models.ts` was **79 counted lines** — over the 50-line `max-lines-per-function` budget — because its inner `streamToFile` and `download` bodies count toward the enclosing function. This lifts those two procedures to **module scope**, threading only the models dir and the status map they genuinely need. They are standalone I/O procedures (a byte pump and a download orchestration), so the move is a real design win, not lint-appeasement.

Behavior is **byte-identical**: the chunk loop order, stall-timer re-arming, size-floor rejection + `.partial` cleanup, atomic rename, and the fire-and-forget `ensure` semantics are all preserved unchanged.

The `models.ts` entry is removed from the eslint `max-lines-per-function` grandfather block; the file now passes the rule at **error** level.

### Counted lines (rule: `max: 50, skipBlankLines, skipComments`)

| Function | Before | After |
|---|---|---|
| `createModelDownloader` | 79 | 25 |
| `streamToFile` (now module scope) | — (was nested) | 26 |
| `downloadModel` (was nested `download`) | — (was nested) | 28 |

All three are under 50; eslint reports 0 warnings / 0 errors on the file.

## Items to Confirm / Review

- **`streamToFile` signature**: takes a `deps: { downloadStatus, onProgress }` object (5 params total, within `max-params: 6`) rather than 6 positional args. The `onProgress` callback is still `resetStall`, and `downloadStatus` is the same map instance the factory owns.
- **`downloadModel(name, modelsDir, downloadStatus)`**: identical to the old inner `download` — same `AbortController` + stall re-arm, same throw messages, same `finally { clearTimeout }`.
- **Stall-abort test uses `mock.timers`**: it fakes only `setTimeout`, ticks `DOWNLOAD_STALL_TIMEOUT_MS` (60s), and wires the stubbed `fetch` signal to error the response stream. Please sanity-check that this faithfully models a stalled connection.

## Tests

New file `packages/core/test/whisper/test_model_downloader.ts` drives the lifted procedures through the only public seam (`createModelDownloader().ensure`), stubbing `globalThis.fetch` and writing into an OS temp dir:

- size-floor rejection → `error` status + `.partial` and dest both absent
- HTTP error (503) → `error` status, no partial file created
- streaming progress → `downloading` with a fractional `progress` mid-stream
- in-flight idempotency → a second `ensure` while downloading issues no second fetch
- stall-timeout abort → `error` status after the stall timer fires

Verified (parent binaries, worktree has no `node_modules`):
- `eslint packages/core/src/whisper/models.ts` → 0 errors, 0 warnings (grandfather entry removed)
- `tsc -p packages/core/tsconfig.json --noEmit` → clean
- `tsc -p test/tsconfig.json --noEmit` → clean
- `tsx --test packages/core/test/whisper/test_*.ts` → 45 pass / 0 fail (stable across 3 runs)
- `prettier --check` on changed files → clean

## User Prompt

Bring `createModelDownloader` under the 50-line `max-lines-per-function` budget with a strictly behavior-preserving refactor, then remove the file from the eslint grandfather list. The only lever is moving real code out (comments/blanks are not counted and encode real rationale). Move `streamToFile` and `download` to module scope; add tests for the newly module-scope pieces where feasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
