### PR TITLE
chore: split linked-collection caches out of useCollectionRendering

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -487,7 +487,6 @@ export default [
       "packages/core/src/whisper/client.ts",
       "packages/core/src/whisper/models.ts",
       "packages/core/src/whisper/sidecar.ts",
-      "packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts",
       "packages/relay/src/client.ts",
       "server/events/relay-client.ts",
       "src/composables/useFileTree.ts",

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.renderers.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.renderers.ts
@@ -1,0 +1,117 @@
+// State-parameterized pure renderers for collection surfaces, extracted from
+// useCollectionRendering.ts. Unlike the leaf formatters in
+// `useCollectionRendering.helpers.ts`, these take the resolved cache values
+// and locale as EXPLICIT arguments (never a reactive ref), so the composable
+// can wire them with thin closures while they stay unit-testable in isolation.
+// NO vue / DOM / I/O / reactive state here — every function is pure.
+
+import { deriveAll, embedTargetId } from "@mulmoclaude/core/collection";
+import type {
+  CollectionItem,
+  CollectionSchema,
+  CollectionFieldSpec as FieldSpec,
+  EmbedCache,
+  EmbedRow,
+  EmbedView,
+  RefCache,
+  RefOption,
+  RefRecordCache,
+} from "@mulmoclaude/core/collection";
+import { buildEmbedOptions, detailText, formatCell, formatMoney, resolveCurrency, sortedRefOptions } from "./useCollectionRendering.helpers";
+
+export function lookupRefDisplay(refCache: RefCache, targetSlug: string, itemSlug: string): string {
+  const map = refCache[targetSlug];
+  return (map && map[itemSlug]) || itemSlug;
+}
+
+export function refOptionsFor(refCache: RefCache, targetSlug: string): RefOption[] {
+  const map = refCache[targetSlug];
+  return map ? sortedRefOptions(map) : [];
+}
+
+/** Dropdown options for an `embed` field's per-record picker (`idField`):
+ *  every record in the target collection, labelled by its name/title (or
+ *  primary key). Built from `embedCache` so it works for embed targets
+ *  that aren't also `ref` targets (the profile collection, say). */
+export function embedOptionsFor(embedCache: EmbedCache, targetSlug: string): RefOption[] {
+  const data = embedCache[targetSlug];
+  return data ? buildEmbedOptions(data.schema, data.items) : [];
+}
+
+export function resolveEmbed(
+  field: FieldSpec,
+  record: CollectionItem | null,
+  embedCache: EmbedCache,
+): { schema: CollectionSchema | null; item: CollectionItem | null } {
+  if (field.type !== "embed" || !field.to) return { schema: null, item: null };
+  const targetId = embedTargetId(field, record);
+  const data = targetId ? embedCache[field.to] : undefined;
+  if (!data) return { schema: null, item: null };
+  const item = data.items.find((entry) => String(entry[data.schema.primaryKey] ?? "") === targetId) ?? null;
+  return { schema: data.schema, item };
+}
+
+export function formatEmbedValue(field: FieldSpec, value: unknown, record: CollectionItem | null, locale: string): string {
+  if (field.type === "money") return formatMoney(value, resolveCurrency(field, record), locale);
+  return detailText(value);
+}
+
+/** Build the read-only embed view-models for one record. A function of the
+ *  open record (not a bare computed) because a per-record `idField` embed
+ *  resolves a different target per row. `schema` is the OPEN collection's
+ *  schema (null when no collection is loaded → no views). */
+export function buildEmbedViews(
+  schema: CollectionSchema | null,
+  embedCache: EmbedCache,
+  record: CollectionItem | null,
+  locale: string,
+): Record<string, EmbedView> {
+  const out: Record<string, EmbedView> = {};
+  if (!schema) return out;
+  for (const [key, field] of Object.entries(schema.fields)) {
+    if (field.type !== "embed") continue;
+    const { schema: targetSchema, item } = resolveEmbed(field, record, embedCache);
+    const rows: EmbedRow[] = [];
+    if (targetSchema && item) {
+      for (const [subKey, subField] of Object.entries(targetSchema.fields)) {
+        const value = item[subKey];
+        // Skip empty fields — the embed is a read-only summary, so
+        // unfilled optionals would just be "—" noise.
+        if (value === undefined || value === null || value === "") continue;
+        rows.push({ key: subKey, label: subField.label, type: subField.type, value, display: formatEmbedValue(subField, value, item, locale) });
+      }
+    }
+    out[key] = { found: Boolean(item), rows, targetSlug: field.to ?? "", recordId: embedTargetId(field, record) };
+  }
+  return out;
+}
+
+export function renderSubCell(subField: FieldSpec, value: unknown, record: CollectionItem | null, refCache: RefCache, locale: string): string {
+  if (subField.type === "money") return formatMoney(value, resolveCurrency(subField, record), locale);
+  if (subField.type === "ref" && subField.to && typeof value === "string" && value.length > 0) return lookupRefDisplay(refCache, subField.to, value);
+  return formatCell(value, subField.type);
+}
+
+// The derive loop itself lives in `@mulmoclaude/core/collection` (deriveAll),
+// shared with the server's manageCollection enrichment so both sides compute
+// identical values. These wrappers bind it to the open collection's schema +
+// the loaded ref records.
+
+export function evaluateDerived(
+  field: FieldSpec,
+  fieldKey: string,
+  item: CollectionItem,
+  schema: CollectionSchema | null,
+  refRecords: RefRecordCache,
+): number | null {
+  if (!field.formula || !schema) return null;
+  const enriched = deriveAll(schema, item, refRecords);
+  const result = enriched[fieldKey];
+  return typeof result === "number" && Number.isFinite(result) ? result : null;
+}
+
+export function renderDerived(field: FieldSpec, computedValue: unknown, record: CollectionItem | null, locale: string): string {
+  if (computedValue === null || computedValue === undefined) return "—";
+  if (field.display === "money") return formatMoney(computedValue, resolveCurrency(field, record), locale);
+  return formatCell(computedValue, field.display ?? "number");
+}

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
@@ -1,19 +1,21 @@
 // Rendering + linked-data layer for collection surfaces, extracted from
-// CollectionView.vue so the list/detail view AND the calendar view's
-// record panel share one implementation (and one set of ref/embed
-// caches). Owns: the per-target caches, the fan-out fetch that fills
-// them, and every helper that turns a stored value into something the
-// templates render (ref labels, money/currency, derived formulas, embed
-// rows). Pure-but-stateful: instantiate ONCE per collection surface and
-// pass the returned object down to child panels.
+// CollectionView.vue so the list/detail view AND the calendar view's record
+// panel share one implementation (and one set of ref/embed caches). This is a
+// thin composition layer: it wires two concerns and returns their union.
 //
-// The pure, reactivity-free transforms this composable relies on live in
-// `useCollectionRendering.helpers.ts` (plain TS, unit-tested); only the
-// ref/computed/watch-bound glue stays here.
+//   • `useLinkedCollectionCaches` — owns the per-target caches + the fan-out
+//     fetch that fills them (stale-write guard, best-effort fetch).
+//   • `useCollectionRendering.renderers` — pure, cache-parameterized renderers
+//     (embed views, ref labels, sub-cells, derived formulas).
+//   • `useCollectionRendering.helpers` — leaf, stateless formatters re-exposed
+//     for template convenience via `STATELESS_RENDERERS`.
+//
+// Pure-but-stateful: instantiate ONCE per collection surface and pass the
+// returned object down to child panels.
 
-import { ref, type Ref } from "vue";
+import type { Ref } from "vue";
 import { collectionUi } from "./uiContext";
-import { deriveAll, embedTargetId } from "@mulmoclaude/core/collection";
+import { deriveAll } from "@mulmoclaude/core/collection";
 import type {
   CollectionDetail,
   CollectionItem,
@@ -21,16 +23,12 @@ import type {
   CollectionFieldSpec as FieldSpec,
   CollectionFieldType as FieldType,
   EmbedCache,
-  EmbedRow,
   EmbedView,
   RefCache,
   RefOption,
   RefRecordCache,
 } from "@mulmoclaude/core/collection";
 import {
-  buildEmbedOptions,
-  buildRefDisplayMap,
-  buildRefRecordMap,
   currencySymbolForLocale,
   detailText,
   formatCell,
@@ -39,12 +37,19 @@ import {
   inputTypeFor,
   isExternalUrl,
   resolveCurrency,
-  sortedRefOptions,
   stepForFieldType,
   tableRows,
-  uniqueEmbedTargets,
-  uniqueRefTargets,
 } from "./useCollectionRendering.helpers";
+import { useLinkedCollectionCaches } from "./useLinkedCollectionCaches";
+import {
+  buildEmbedViews,
+  embedOptionsFor,
+  evaluateDerived,
+  lookupRefDisplay,
+  refOptionsFor,
+  renderDerived,
+  renderSubCell,
+} from "./useCollectionRendering.renderers";
 
 export interface CollectionRendering {
   refCache: Ref<RefCache>;
@@ -74,184 +79,41 @@ export interface CollectionRendering {
   derivedDisplay: (field: FieldSpec, computedValue: unknown, record: CollectionItem | null) => string;
 }
 
+// Leaf formatters re-exposed on the interface for template convenience — pure
+// functions with no dependency on the reactive caches or locale.
+const STATELESS_RENDERERS = {
+  resolveCurrency,
+  formatMoney,
+  formatCell,
+  detailText,
+  isExternalUrl,
+  tableRows,
+  hasTableRows,
+  inputTypeFor,
+  stepFor: stepForFieldType,
+  deriveAll,
+};
+
 export function useCollectionRendering(collection: Ref<CollectionDetail | null>, locale: Ref<string>): CollectionRendering {
-  const refCache = ref<RefCache>({});
-  const refRecordCache = ref<RefRecordCache>({});
-  const embedCache = ref<EmbedCache>({});
-
-  function resetLinkedCaches(): void {
-    refCache.value = {};
-    refRecordCache.value = {};
-    embedCache.value = {};
-  }
-
-  async function loadLinkedCollections(schema: CollectionSchema, expectedSlug: string): Promise<void> {
-    const refTargets = new Set(uniqueRefTargets(schema));
-    const embedTargets = new Set(uniqueEmbedTargets(schema));
-    const allTargets = [...new Set([...refTargets, ...embedTargets])];
-    if (allTargets.length === 0) return;
-    // Best-effort: a single target whose fetch *rejects* (vs. resolving to
-    // `{ ok: false }`) must not abort the others, so coerce a throw to a skip.
-    const binding = collectionUi();
-    const results = await Promise.all(
-      allTargets.map(async (target) => {
-        try {
-          return { target, result: await binding.fetchCollectionDetail(target) };
-        } catch {
-          return { target, result: { ok: false as const } };
-        }
-      }),
-    );
-    // Stale-write guard: a quicker subsequent load may have replaced
-    // `collection.value`; dropping the write avoids surfacing the
-    // previous collection's linked data on the current one.
-    if (collection.value?.slug !== expectedSlug) return;
-    const nextRef: RefCache = {};
-    const nextRefRecords: RefRecordCache = {};
-    const nextEmbed: EmbedCache = {};
-    for (const { target, result } of results) {
-      if (!result.ok) continue;
-      if (refTargets.has(target)) {
-        nextRef[target] = buildRefDisplayMap(result.data);
-        nextRefRecords[target] = buildRefRecordMap(result.data);
-      }
-      if (embedTargets.has(target)) nextEmbed[target] = { schema: result.data.collection.schema, items: result.data.items };
-    }
-    refCache.value = nextRef;
-    refRecordCache.value = nextRefRecords;
-    embedCache.value = nextEmbed;
-  }
-
-  function refDisplay(targetSlug: string, itemSlug: string): string {
-    const map = refCache.value[targetSlug];
-    return (map && map[itemSlug]) || itemSlug;
-  }
-
-  function refOptions(targetSlug: string): RefOption[] {
-    const map = refCache.value[targetSlug];
-    return map ? sortedRefOptions(map) : [];
-  }
-
-  /** Dropdown options for an `embed` field's per-record picker (`idField`):
-   *  every record in the target collection, labelled by its name/title (or
-   *  primary key). Built from `embedCache` so it works for embed targets
-   *  that aren't also `ref` targets (the profile collection, say). */
-  function embedOptions(targetSlug: string): RefOption[] {
-    const data = embedCache.value[targetSlug];
-    return data ? buildEmbedOptions(data.schema, data.items) : [];
-  }
-
-  function resolveEmbed(field: FieldSpec, record: CollectionItem | null): { schema: CollectionSchema | null; item: CollectionItem | null } {
-    if (field.type !== "embed" || !field.to) return { schema: null, item: null };
-    const targetId = embedTargetId(field, record);
-    const data = targetId ? embedCache.value[field.to] : undefined;
-    if (!data) return { schema: null, item: null };
-    const item = data.items.find((entry) => String(entry[data.schema.primaryKey] ?? "") === targetId) ?? null;
-    return { schema: data.schema, item };
-  }
-
-  function embedValue(field: FieldSpec, value: unknown, record: CollectionItem | null): string {
-    if (field.type === "money") return formatMoney(value, resolveCurrency(field, record), locale.value);
-    return detailText(value);
-  }
-
-  /** Build the read-only embed view-models for one record. A function of
-   *  the open record (not a bare computed) because a per-record `idField`
-   *  embed resolves a different target per row. */
-  function embedViewsFor(record: CollectionItem | null): Record<string, EmbedView> {
-    const out: Record<string, EmbedView> = {};
-    if (!collection.value) return out;
-    for (const [key, field] of Object.entries(collection.value.schema.fields)) {
-      if (field.type !== "embed") continue;
-      const { schema, item } = resolveEmbed(field, record);
-      const rows: EmbedRow[] = [];
-      if (schema && item) {
-        for (const [subKey, subField] of Object.entries(schema.fields)) {
-          const value = item[subKey];
-          // Skip empty fields — the embed is a read-only summary, so
-          // unfilled optionals would just be "—" noise.
-          if (value === undefined || value === null || value === "") continue;
-          rows.push({ key: subKey, label: subField.label, type: subField.type, value, display: embedValue(subField, value, item) });
-        }
-      }
-      out[key] = { found: Boolean(item), rows, targetSlug: field.to ?? "", recordId: embedTargetId(field, record) };
-    }
-    return out;
-  }
-
-  function currencySymbol(currency: string | undefined): string {
-    return currencySymbolForLocale(currency, locale.value);
-  }
-
-  // A `file` field holds a workspace-relative path. When it points at an
-  // HTML/SVG artifact the server serves directly, return that served URL
-  // so the rendered app can open in a new tab; otherwise null. Reject
-  // absolute / `..`-traversing paths first (same guard as fileRoutePath)
-  // — the preview-URL builders don't, so a `..` would normalize out of
-  // the intended mount.
-  function artifactUrl(value: unknown): string | null {
-    return collectionUi().fileAssetUrl(value);
-  }
-
-  // In-app File Explorer route for a workspace path — the fallback for
-  // `file` values that aren't a directly-served artifact. The host owns the
-  // path validity + route scheme.
-  function fileRoutePath(value: unknown): string | null {
-    return collectionUi().fileRoutePath(value);
-  }
-
-  function formatSubCell(subField: FieldSpec, value: unknown, record: CollectionItem | null): string {
-    if (subField.type === "money") return formatMoney(value, resolveCurrency(subField, record), locale.value);
-    if (subField.type === "ref" && subField.to && typeof value === "string" && value.length > 0) return refDisplay(subField.to, value);
-    return formatCell(value, subField.type);
-  }
-
-  const stepFor = stepForFieldType;
-
-  // The derive loop itself lives in `utils/collections/deriveAll.ts`,
-  // shared with the server's manageCollection enrichment so both sides
-  // compute identical values. This composable re-exposes it (typed with
-  // the richer client types via structural assignability) plus the
-  // collection-bound convenience wrappers below.
-
-  function evaluateDerivedAgainstItem(field: FieldSpec, fieldKey: string, item: CollectionItem): number | null {
-    if (!field.formula || !collection.value) return null;
-    const enriched = deriveAll(collection.value.schema, item, refRecordCache.value);
-    const result = enriched[fieldKey];
-    return typeof result === "number" && Number.isFinite(result) ? result : null;
-  }
-
-  function derivedDisplay(field: FieldSpec, computedValue: unknown, record: CollectionItem | null): string {
-    if (computedValue === null || computedValue === undefined) return "—";
-    if (field.display === "money") return formatMoney(computedValue, resolveCurrency(field, record), locale.value);
-    return formatCell(computedValue, field.display ?? "number");
-  }
-
+  const caches = useLinkedCollectionCaches(collection);
+  const { refCache, refRecordCache, embedCache } = caches;
   return {
-    refCache,
-    refRecordCache,
-    embedCache,
-    resetLinkedCaches,
-    loadLinkedCollections,
-    refDisplay,
-    refOptions,
-    embedOptions,
-    embedViewsFor,
-    resolveCurrency,
-    currencySymbol,
-    formatMoney,
-    formatCell,
-    detailText,
-    isExternalUrl,
-    artifactUrl,
-    fileRoutePath,
-    tableRows,
-    hasTableRows,
-    formatSubCell,
-    inputTypeFor,
-    stepFor,
-    deriveAll,
-    evaluateDerivedAgainstItem,
-    derivedDisplay,
+    ...caches,
+    ...STATELESS_RENDERERS,
+    refDisplay: (targetSlug, itemSlug) => lookupRefDisplay(refCache.value, targetSlug, itemSlug),
+    refOptions: (targetSlug) => refOptionsFor(refCache.value, targetSlug),
+    embedOptions: (targetSlug) => embedOptionsFor(embedCache.value, targetSlug),
+    embedViewsFor: (record) => buildEmbedViews(collection.value?.schema ?? null, embedCache.value, record, locale.value),
+    currencySymbol: (currency) => currencySymbolForLocale(currency, locale.value),
+    // A `file` field holds a workspace-relative path; the host resolves it to a
+    // served artifact URL (html/svg) or null. The host owns the path guard
+    // (absolute / `..`-traversal rejected before building the URL).
+    artifactUrl: (value) => collectionUi().fileAssetUrl(value),
+    // In-app File Explorer route for a workspace path — the fallback for `file`
+    // values that aren't a directly-served artifact.
+    fileRoutePath: (value) => collectionUi().fileRoutePath(value),
+    formatSubCell: (subField, value, record) => renderSubCell(subField, value, record, refCache.value, locale.value),
+    evaluateDerivedAgainstItem: (field, fieldKey, item) => evaluateDerived(field, fieldKey, item, collection.value?.schema ?? null, refRecordCache.value),
+    derivedDisplay: (field, computedValue, record) => renderDerived(field, computedValue, record, locale.value),
   };
 }

--- a/packages/plugins/collection-plugin/src/vue/useLinkedCollectionCaches.ts
+++ b/packages/plugins/collection-plugin/src/vue/useLinkedCollectionCaches.ts
@@ -1,0 +1,111 @@
+// Linked-collection cache layer for collection surfaces: owns the three
+// per-target caches (ref labels, full ref records, embed targets) and the
+// fan-out fetch that hydrates them, split out of useCollectionRendering so the
+// cache-ownership + best-effort/stale-write fetch concern is isolated and
+// unit-testable, separate from the stateless render/format layer. Instantiate
+// ONCE per collection surface; pass the caches down to the renderers.
+
+import { ref, type Ref } from "vue";
+import { collectionUi, type CollectionApiResult } from "./uiContext";
+import { buildRefDisplayMap, buildRefRecordMap, uniqueEmbedTargets, uniqueRefTargets } from "./useCollectionRendering.helpers";
+import type { CollectionDetail, CollectionDetailResponse, CollectionSchema, EmbedCache, RefCache, RefRecordCache } from "@mulmoclaude/core/collection";
+
+export interface LinkedCollectionCaches {
+  refCache: Ref<RefCache>;
+  refRecordCache: Ref<RefRecordCache>;
+  embedCache: Ref<EmbedCache>;
+  resetLinkedCaches: () => void;
+  loadLinkedCollections: (schema: CollectionSchema, expectedSlug: string) => Promise<void>;
+}
+
+export interface LinkedTargets {
+  refTargets: Set<string>;
+  embedTargets: Set<string>;
+  allTargets: string[];
+}
+
+export interface LinkedCachesSnapshot {
+  refCache: RefCache;
+  refRecordCache: RefRecordCache;
+  embedCache: EmbedCache;
+}
+
+type FetchCollectionDetail = (slug: string) => Promise<CollectionApiResult<CollectionDetailResponse>>;
+
+/** The de-duplicated ref + embed target slugs a schema links to. `allTargets`
+ *  is the union (each target fetched once even when both ref'd and embedded). */
+export function linkedTargets(schema: CollectionSchema): LinkedTargets {
+  const refTargets = new Set(uniqueRefTargets(schema));
+  const embedTargets = new Set(uniqueEmbedTargets(schema));
+  const allTargets = [...new Set([...refTargets, ...embedTargets])];
+  return { refTargets, embedTargets, allTargets };
+}
+
+/** Fan-out fetch that hydrates the linked-collection caches. Best-effort: a
+ *  target whose fetch *rejects* (vs. resolving `{ ok: false }`) is coerced to a
+ *  skip and must not abort the others. Returns null when a quicker subsequent
+ *  load has already moved on (stale-write guard) so the caller drops the write.
+ *  Pure + injectable (`fetchDetail`, `currentSlug`) so both paths are testable. */
+export async function fetchLinkedCaches(
+  targets: LinkedTargets,
+  fetchDetail: FetchCollectionDetail,
+  currentSlug: () => string | undefined,
+  expectedSlug: string,
+): Promise<LinkedCachesSnapshot | null> {
+  const { refTargets, embedTargets, allTargets } = targets;
+  const results = await Promise.all(
+    allTargets.map(async (target) => {
+      try {
+        return { target, result: await fetchDetail(target) };
+      } catch {
+        return { target, result: { ok: false as const } };
+      }
+    }),
+  );
+  // Stale-write guard: a quicker subsequent load may have replaced the open
+  // collection; dropping the write avoids surfacing the previous collection's
+  // linked data on the current one.
+  if (currentSlug() !== expectedSlug) return null;
+  const refCache: RefCache = {};
+  const refRecordCache: RefRecordCache = {};
+  const embedCache: EmbedCache = {};
+  for (const { target, result } of results) {
+    if (!result.ok) continue;
+    if (refTargets.has(target)) {
+      refCache[target] = buildRefDisplayMap(result.data);
+      refRecordCache[target] = buildRefRecordMap(result.data);
+    }
+    if (embedTargets.has(target)) embedCache[target] = { schema: result.data.collection.schema, items: result.data.items };
+  }
+  return { refCache, refRecordCache, embedCache };
+}
+
+export function useLinkedCollectionCaches(collection: Ref<CollectionDetail | null>): LinkedCollectionCaches {
+  const refCache = ref<RefCache>({});
+  const refRecordCache = ref<RefRecordCache>({});
+  const embedCache = ref<EmbedCache>({});
+
+  function resetLinkedCaches(): void {
+    refCache.value = {};
+    refRecordCache.value = {};
+    embedCache.value = {};
+  }
+
+  async function loadLinkedCollections(schema: CollectionSchema, expectedSlug: string): Promise<void> {
+    const targets = linkedTargets(schema);
+    if (targets.allTargets.length === 0) return;
+    const binding = collectionUi();
+    const snapshot = await fetchLinkedCaches(
+      targets,
+      (slug) => binding.fetchCollectionDetail(slug),
+      () => collection.value?.slug,
+      expectedSlug,
+    );
+    if (!snapshot) return;
+    refCache.value = snapshot.refCache;
+    refRecordCache.value = snapshot.refRecordCache;
+    embedCache.value = snapshot.embedCache;
+  }
+
+  return { refCache, refRecordCache, embedCache, resetLinkedCaches, loadLinkedCollections };
+}

--- a/test/plugins/collection/test_collectionRenderers.ts
+++ b/test/plugins/collection/test_collectionRenderers.ts
@@ -1,0 +1,195 @@
+// Unit tests for the state-parameterized pure renderers
+// (packages/plugins/collection-plugin/src/vue/useCollectionRendering.renderers.ts).
+// These take resolved cache values + locale as explicit args (no vue refs), so
+// they pin the embed-view / ref-label / derived-formula logic the composable
+// wires with thin closures.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type { CollectionSchema, CollectionFieldSpec as FieldSpec, CollectionFieldType as FieldType, EmbedCache, RefCache } from "@mulmoclaude/core/collection";
+import {
+  buildEmbedViews,
+  embedOptionsFor,
+  evaluateDerived,
+  formatEmbedValue,
+  lookupRefDisplay,
+  refOptionsFor,
+  renderDerived,
+  renderSubCell,
+  resolveEmbed,
+} from "../../../packages/plugins/collection-plugin/src/vue/useCollectionRendering.renderers";
+
+const field = (type: FieldType, extra: Partial<FieldSpec> = {}): FieldSpec => ({ type, label: type, ...extra });
+
+const makeSchema = (fields: Record<string, FieldSpec>, primaryKey = "id"): CollectionSchema => ({
+  title: "Test",
+  icon: "list",
+  dataPath: "collections/test",
+  primaryKey,
+  fields,
+});
+
+const profileSchema = makeSchema({ id: field("text"), name: field("text"), fee: field("money", { currency: "USD" }) });
+const embedCache: EmbedCache = {
+  profiles: {
+    schema: profileSchema,
+    items: [
+      { id: "me", name: "Me Inc", fee: 100 },
+      { id: "you", name: "You LLC", fee: 200 },
+    ],
+  },
+};
+
+describe("lookupRefDisplay", () => {
+  it("returns the mapped label, falling back to the slug", () => {
+    const cache: RefCache = { people: { a: "Alice" } };
+    assert.equal(lookupRefDisplay(cache, "people", "a"), "Alice");
+    assert.equal(lookupRefDisplay(cache, "people", "z"), "z");
+    assert.equal(lookupRefDisplay(cache, "missing", "a"), "a");
+  });
+});
+
+describe("refOptionsFor", () => {
+  it("sorts options by label; empty for an unknown target", () => {
+    const cache: RefCache = { people: { b: "Bravo", a: "Alpha" } };
+    assert.deepEqual(refOptionsFor(cache, "people"), [
+      { slug: "a", display: "Alpha" },
+      { slug: "b", display: "Bravo" },
+    ]);
+    assert.deepEqual(refOptionsFor(cache, "nope"), []);
+  });
+});
+
+describe("embedOptionsFor", () => {
+  it("builds sorted options from the embed cache; empty for an unknown target", () => {
+    assert.deepEqual(embedOptionsFor(embedCache, "profiles"), [
+      { slug: "me", display: "Me Inc" },
+      { slug: "you", display: "You LLC" },
+    ]);
+    assert.deepEqual(embedOptionsFor(embedCache, "nope"), []);
+  });
+});
+
+describe("resolveEmbed", () => {
+  it("returns null schema/item for a non-embed field", () => {
+    assert.deepEqual(resolveEmbed(field("text"), null, embedCache), { schema: null, item: null });
+  });
+  it("returns null when the per-record id resolves to nothing", () => {
+    assert.deepEqual(resolveEmbed(field("embed", { to: "profiles", idField: "x" }), {}, embedCache), { schema: null, item: null });
+  });
+  it("finds the target record by fixed id", () => {
+    const res = resolveEmbed(field("embed", { to: "profiles", id: "me" }), null, embedCache);
+    assert.equal(res.item?.name, "Me Inc");
+    assert.equal(res.schema, profileSchema);
+  });
+  it("returns null item when the target collection is not cached", () => {
+    assert.deepEqual(resolveEmbed(field("embed", { to: "missing", id: "me" }), null, embedCache), { schema: null, item: null });
+  });
+});
+
+describe("formatEmbedValue", () => {
+  it("currency-formats a money field", () => {
+    assert.ok(formatEmbedValue(field("money", { currency: "USD" }), 9, null, "en-US").includes("9"));
+  });
+  it("detailText for a non-money field, em-dash for empty", () => {
+    assert.equal(formatEmbedValue(field("text"), "hi", null, "en-US"), "hi");
+    assert.equal(formatEmbedValue(field("text"), "", null, "en-US"), "—");
+  });
+});
+
+describe("buildEmbedViews", () => {
+  it("resolves a per-record idField embed to the row-specific target", () => {
+    const schema = makeSchema({ billTo: field("embed", { to: "profiles", idField: "customerId", label: "Bill To" }) });
+    const views = buildEmbedViews(schema, embedCache, { customerId: "you" }, "en-US");
+    assert.equal(views.billTo.found, true);
+    assert.equal(views.billTo.recordId, "you");
+    assert.equal(views.billTo.targetSlug, "profiles");
+    assert.equal(views.billTo.rows.find((row) => row.key === "name")?.display, "You LLC");
+    assert.ok(views.billTo.rows.find((row) => row.key === "fee")?.display.includes("200"));
+  });
+
+  it("resolves a fixed-id embed and skips empty sub-fields", () => {
+    const schema = makeSchema({ from: field("embed", { to: "profiles", id: "me" }) });
+    const cacheWithBlank: EmbedCache = { profiles: { schema: profileSchema, items: [{ id: "me", name: "Me Inc", fee: "" }] } };
+    const views = buildEmbedViews(schema, cacheWithBlank, null, "en-US");
+    assert.equal(views.from.found, true);
+    assert.equal(
+      views.from.rows.some((row) => row.key === "fee"),
+      false,
+    );
+    assert.equal(
+      views.from.rows.some((row) => row.key === "name"),
+      true,
+    );
+  });
+
+  it("marks found=false when the idField points at a missing record", () => {
+    const schema = makeSchema({ billTo: field("embed", { to: "profiles", idField: "customerId" }) });
+    const views = buildEmbedViews(schema, embedCache, { customerId: "ghost" }, "en-US");
+    assert.equal(views.billTo.found, false);
+    assert.deepEqual(views.billTo.rows, []);
+    assert.equal(views.billTo.recordId, "ghost");
+  });
+
+  it("returns an empty object when the schema is null (no collection loaded)", () => {
+    assert.deepEqual(buildEmbedViews(null, embedCache, null, "en-US"), {});
+  });
+
+  it("ignores non-embed fields", () => {
+    const schema = makeSchema({ title: field("text"), amount: field("money") });
+    assert.deepEqual(buildEmbedViews(schema, embedCache, null, "en-US"), {});
+  });
+});
+
+describe("renderSubCell", () => {
+  const refCache: RefCache = { people: { a: "Alice" } };
+  it("currency-formats a money sub-field", () => {
+    assert.ok(renderSubCell(field("money", { currency: "USD" }), 5, null, refCache, "en-US").includes("5"));
+  });
+  it("resolves a ref sub-field to its display label", () => {
+    assert.equal(renderSubCell(field("ref", { to: "people" }), "a", null, refCache, "en-US"), "Alice");
+  });
+  it("falls through to formatCell for an empty ref value", () => {
+    assert.equal(renderSubCell(field("ref", { to: "people" }), "", null, refCache, "en-US"), "—");
+  });
+  it("passes other types through formatCell", () => {
+    assert.equal(renderSubCell(field("text"), "hi", null, refCache, "en-US"), "hi");
+  });
+});
+
+describe("evaluateDerived", () => {
+  const schema = makeSchema({
+    id: field("text"),
+    qty: field("number"),
+    price: field("number"),
+    total: field("derived", { formula: "qty * price" }),
+  });
+  it("evaluates a derived formula against the item", () => {
+    assert.equal(evaluateDerived(schema.fields.total, "total", { qty: 3, price: 4 }, schema, {}), 12);
+  });
+  it("returns null for a field without a formula", () => {
+    assert.equal(evaluateDerived(field("number"), "qty", { qty: 3 }, schema, {}), null);
+  });
+  it("returns null when the schema is null", () => {
+    assert.equal(evaluateDerived(schema.fields.total, "total", {}, null, {}), null);
+  });
+  it("returns null when the computed result is non-numeric", () => {
+    const stringSchema = makeSchema({ id: field("text"), note: field("text"), d: field("derived", { formula: "note" }) });
+    assert.equal(evaluateDerived(stringSchema.fields.d, "d", { note: "hello" }, stringSchema, {}), null);
+  });
+});
+
+describe("renderDerived", () => {
+  it("renders an em-dash for null / undefined", () => {
+    assert.equal(renderDerived(field("derived"), null, null, "en-US"), "—");
+    assert.equal(renderDerived(field("derived"), undefined, null, "en-US"), "—");
+  });
+  it("currency-formats a money display", () => {
+    assert.ok(renderDerived(field("derived", { display: "money", currency: "USD" }), 1234.5, {}, "en-US").includes("1,234.50"));
+  });
+  it("formats via the display type, defaulting to number", () => {
+    assert.equal(renderDerived(field("derived", { display: "number" }), 42, null, "en-US"), "42");
+    assert.equal(renderDerived(field("derived"), 7, null, "en-US"), "7");
+  });
+});

--- a/test/plugins/collection/test_linkedCollectionCaches.ts
+++ b/test/plugins/collection/test_linkedCollectionCaches.ts
@@ -1,0 +1,146 @@
+// Unit tests for the linked-collection cache layer
+// (packages/plugins/collection-plugin/src/vue/useLinkedCollectionCaches.ts).
+// The composable's fan-out fetch is factored into the pure, injectable
+// `fetchLinkedCaches` (+ `linkedTargets`) so the two highest-risk behaviors —
+// best-effort target isolation and the stale-write guard — are pinned directly
+// with stubs, no vue reactivity or host binding required.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type {
+  CollectionDetail,
+  CollectionDetailResponse,
+  CollectionItem,
+  CollectionSchema,
+  CollectionFieldSpec as FieldSpec,
+  CollectionFieldType as FieldType,
+} from "@mulmoclaude/core/collection";
+import type { CollectionApiResult } from "../../../packages/plugins/collection-plugin/src/vue/uiContext";
+import { fetchLinkedCaches, linkedTargets } from "../../../packages/plugins/collection-plugin/src/vue/useLinkedCollectionCaches";
+
+const field = (type: FieldType, extra: Partial<FieldSpec> = {}): FieldSpec => ({ type, label: type, ...extra });
+
+const makeSchema = (fields: Record<string, FieldSpec>, primaryKey = "id"): CollectionSchema => ({
+  title: "Test",
+  icon: "list",
+  dataPath: "collections/test",
+  primaryKey,
+  fields,
+});
+
+const makeDetail = (slug: string, schema: CollectionSchema, items: CollectionItem[]): CollectionDetailResponse => {
+  const collection: CollectionDetail = { slug, title: slug, icon: "list", source: "user", schema };
+  return { collection, items };
+};
+
+const ok = (data: CollectionDetailResponse): CollectionApiResult<CollectionDetailResponse> => ({ ok: true, data });
+const fail = (): CollectionApiResult<CollectionDetailResponse> => ({ ok: false, error: "boom", status: 500 });
+
+const nameSchema = makeSchema({ id: field("text"), name: field("text") });
+const peopleDetail = (): CollectionDetailResponse =>
+  makeDetail("people", nameSchema, [
+    { id: "a", name: "Alice" },
+    { id: "b", name: "Bob" },
+  ]);
+const profilesDetail = (): CollectionDetailResponse => makeDetail("profiles", nameSchema, [{ id: "me", name: "Me Inc" }]);
+
+const refAndEmbedSchema = makeSchema({
+  author: field("ref", { to: "people" }),
+  billFrom: field("embed", { to: "profiles", id: "me" }),
+});
+
+describe("linkedTargets", () => {
+  it("unions ref + embed targets and de-duplicates a target that is both", () => {
+    const schema = makeSchema({
+      author: field("ref", { to: "people" }),
+      billFrom: field("embed", { to: "profiles", id: "me" }),
+      self: field("embed", { to: "people", idField: "authorId" }),
+    });
+    const targets = linkedTargets(schema);
+    assert.deepEqual([...targets.refTargets].sort(), ["people"]);
+    assert.deepEqual([...targets.embedTargets].sort(), ["people", "profiles"]);
+    assert.deepEqual([...targets.allTargets].sort(), ["people", "profiles"]);
+  });
+  it("returns empty sets for a schema with no linked fields", () => {
+    const targets = linkedTargets(makeSchema({ note: field("text") }));
+    assert.equal(targets.allTargets.length, 0);
+    assert.equal(targets.refTargets.size, 0);
+    assert.equal(targets.embedTargets.size, 0);
+  });
+});
+
+describe("fetchLinkedCaches", () => {
+  it("builds ref + record + embed caches from resolved targets", async () => {
+    const fetchDetail = async (slug: string): Promise<CollectionApiResult<CollectionDetailResponse>> => {
+      if (slug === "people") return ok(peopleDetail());
+      if (slug === "profiles") return ok(profilesDetail());
+      return fail();
+    };
+    const snap = await fetchLinkedCaches(linkedTargets(refAndEmbedSchema), fetchDetail, () => "cur", "cur");
+    assert.ok(snap);
+    assert.deepEqual(snap.refCache.people, { a: "Alice", b: "Bob" });
+    assert.deepEqual(Object.keys(snap.refRecordCache.people).sort(), ["a", "b"]);
+    // profiles is embed-only, so it lands in embedCache but never refCache.
+    assert.equal(snap.refCache.profiles, undefined);
+    assert.equal(snap.embedCache.profiles?.items.length, 1);
+  });
+
+  it("is best-effort: a target whose fetch REJECTS is skipped, others still load", async () => {
+    const fetchDetail = async (slug: string): Promise<CollectionApiResult<CollectionDetailResponse>> => {
+      if (slug === "people") return ok(peopleDetail());
+      throw new Error("network down"); // profiles rejects
+    };
+    const snap = await fetchLinkedCaches(linkedTargets(refAndEmbedSchema), fetchDetail, () => "cur", "cur");
+    assert.ok(snap); // the rejection did not abort the fan-out
+    assert.deepEqual(snap.refCache.people, { a: "Alice", b: "Bob" });
+    assert.equal(snap.embedCache.profiles, undefined);
+  });
+
+  it("skips a target that resolves { ok: false } without aborting others", async () => {
+    const fetchDetail = async (slug: string): Promise<CollectionApiResult<CollectionDetailResponse>> => {
+      if (slug === "people") return ok(peopleDetail());
+      return fail(); // profiles: ok:false
+    };
+    const snap = await fetchLinkedCaches(linkedTargets(refAndEmbedSchema), fetchDetail, () => "cur", "cur");
+    assert.ok(snap);
+    assert.deepEqual(snap.refCache.people, { a: "Alice", b: "Bob" });
+    assert.equal(snap.embedCache.profiles, undefined);
+  });
+
+  it("drops the write when the open collection differs at check time (stale-write guard)", async () => {
+    const fetchDetail = async (): Promise<CollectionApiResult<CollectionDetailResponse>> => ok(peopleDetail());
+    const snap = await fetchLinkedCaches(linkedTargets(refAndEmbedSchema), fetchDetail, () => "other", "expected");
+    assert.equal(snap, null);
+  });
+
+  it("guards against a slug that changes DURING the fetch fan-out", async () => {
+    let current = "expected";
+    const fetchDetail = async (): Promise<CollectionApiResult<CollectionDetailResponse>> => {
+      current = "newer"; // a quicker subsequent load moved on while we awaited
+      return ok(peopleDetail());
+    };
+    const snap = await fetchLinkedCaches(linkedTargets(refAndEmbedSchema), fetchDetail, () => current, "expected");
+    assert.equal(snap, null); // proves the guard reads currentSlug AFTER the await
+  });
+
+  it("populates both refCache and embedCache for a target that is ref'd AND embedded", async () => {
+    const dualSchema = makeSchema({
+      author: field("ref", { to: "people" }),
+      self: field("embed", { to: "people", idField: "authorId" }),
+    });
+    const fetchDetail = async (slug: string): Promise<CollectionApiResult<CollectionDetailResponse>> => (slug === "people" ? ok(peopleDetail()) : fail());
+    const snap = await fetchLinkedCaches(linkedTargets(dualSchema), fetchDetail, () => "s", "s");
+    assert.ok(snap);
+    assert.deepEqual(snap.refCache.people, { a: "Alice", b: "Bob" });
+    assert.equal(snap.embedCache.people?.items.length, 2);
+  });
+
+  it("returns an empty snapshot for zero targets when not stale", async () => {
+    const fetchDetail = async (): Promise<CollectionApiResult<CollectionDetailResponse>> => {
+      throw new Error("fetch should not be called for a link-less schema");
+    };
+    const snap = await fetchLinkedCaches(linkedTargets(makeSchema({ note: field("text") })), fetchDetail, () => "s", "s");
+    assert.deepEqual(snap, { refCache: {}, refRecordCache: {}, embedCache: {} });
+  });
+});

--- a/test/plugins/collection/test_useCollectionRendering.ts
+++ b/test/plugins/collection/test_useCollectionRendering.ts
@@ -1,0 +1,105 @@
+// Integration tests for the composition layer
+// (packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts).
+// Imports the composable via the source path (not the package export) so it
+// exercises THIS worktree's wiring: the spread of the cache composable + the
+// stateless formatters + the thin renderer closures. Locks the returned shape
+// (byte-for-byte member set) and the closure-over-refs behavior the consumers
+// depend on.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ref } from "vue";
+
+import { deriveAll } from "@mulmoclaude/core/collection";
+import type { CollectionDetail, CollectionSchema, CollectionFieldSpec as FieldSpec, CollectionFieldType as FieldType } from "@mulmoclaude/core/collection";
+import { useCollectionRendering } from "../../../packages/plugins/collection-plugin/src/vue/useCollectionRendering";
+
+const field = (type: FieldType, extra: Partial<FieldSpec> = {}): FieldSpec => ({ type, label: type, ...extra });
+
+const makeSchema = (fields: Record<string, FieldSpec>, primaryKey = "id"): CollectionSchema => ({
+  title: "Test",
+  icon: "list",
+  dataPath: "collections/test",
+  primaryKey,
+  fields,
+});
+
+const profileSchema = makeSchema({ id: field("text"), name: field("text") });
+const orderSchema = makeSchema({
+  id: field("text"),
+  qty: field("number"),
+  price: field("number"),
+  total: field("derived", { formula: "qty * price" }),
+  billTo: field("embed", { to: "profiles", idField: "customerId" }),
+});
+const orderDetail: CollectionDetail = { slug: "orders", title: "Orders", icon: "list", source: "user", schema: orderSchema };
+
+const EXPECTED_MEMBERS = [
+  "refCache",
+  "refRecordCache",
+  "embedCache",
+  "resetLinkedCaches",
+  "loadLinkedCollections",
+  "refDisplay",
+  "refOptions",
+  "embedOptions",
+  "embedViewsFor",
+  "resolveCurrency",
+  "currencySymbol",
+  "formatMoney",
+  "formatCell",
+  "detailText",
+  "isExternalUrl",
+  "artifactUrl",
+  "fileRoutePath",
+  "tableRows",
+  "hasTableRows",
+  "formatSubCell",
+  "inputTypeFor",
+  "stepFor",
+  "deriveAll",
+  "evaluateDerivedAgainstItem",
+  "derivedDisplay",
+];
+
+describe("useCollectionRendering (composition)", () => {
+  it("returns exactly the CollectionRendering member set — no more, no less", () => {
+    const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
+    for (const key of EXPECTED_MEMBERS) assert.ok(key in render, `missing member: ${key}`);
+    assert.deepEqual(Object.keys(render).sort(), [...EXPECTED_MEMBERS].sort());
+    // The re-exposed pure helpers are the SAME references (structural passthrough).
+    assert.equal(render.deriveAll, deriveAll);
+  });
+
+  it("evaluateDerivedAgainstItem reads the live refRecordCache mutated on the returned object", () => {
+    const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
+    render.refRecordCache.value = {}; // qty * price needs no ref records
+    assert.equal(render.evaluateDerivedAgainstItem(orderSchema.fields.total, "total", { qty: 3, price: 5 }), 15);
+  });
+
+  it("embedViewsFor resolves a per-record idField embed from the live embedCache", () => {
+    const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
+    render.embedCache.value = { profiles: { schema: profileSchema, items: [{ id: "you", name: "You LLC" }] } };
+    const views = render.embedViewsFor({ customerId: "you" });
+    assert.equal(views.billTo.found, true);
+    assert.equal(views.billTo.recordId, "you");
+    assert.equal(views.billTo.rows.find((row) => row.key === "name")?.display, "You LLC");
+  });
+
+  it("resetLinkedCaches clears all three caches", () => {
+    const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
+    render.refCache.value = { profiles: { you: "You LLC" } };
+    render.refRecordCache.value = { profiles: { you: { id: "you" } } };
+    render.embedCache.value = { profiles: { schema: profileSchema, items: [] } };
+    render.resetLinkedCaches();
+    assert.deepEqual(render.refCache.value, {});
+    assert.deepEqual(render.refRecordCache.value, {});
+    assert.deepEqual(render.embedCache.value, {});
+  });
+
+  it("stepFor / currencySymbol thread through the locale-bound formatters", () => {
+    const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
+    assert.equal(render.stepFor("money"), "0.01");
+    assert.equal(render.currencySymbol("USD"), "$");
+  });
+});


### PR DESCRIPTION
## Summary

`useCollectionRendering` (136 counted lines) was the last collection-plugin file on the `max-lines-per-function` grandfather list. This splits it into a genuine separation of concerns and removes the grandfather entry. **The exported `CollectionRendering` interface and the returned object are unchanged — same 25 members, same names, types, and semantics — so no consumer changes are required.**

Three layers, composed by the original composable:

1. **`useLinkedCollectionCaches.ts`** (new) — owns `refCache` / `refRecordCache` / `embedCache` + `resetLinkedCaches` + `loadLinkedCollections`. The fan-out fetch is factored into a **pure, injectable** `fetchLinkedCaches` (+ `linkedTargets`) so the two highest-risk behaviors are testable directly with stubs.
2. **`useCollectionRendering.renderers.ts`** (new) — pure, cache-parameterized renderers (`buildEmbedViews` + `resolveEmbed` + `formatEmbedValue`, `lookupRefDisplay`, `refOptionsFor`, `embedOptionsFor`, `renderSubCell`, `evaluateDerived`, `renderDerived`) that take resolved cache values + locale as **explicit args** (never a reactive ref).
3. **`useCollectionRendering.ts`** — now a thin composition layer: `{ ...caches, ...STATELESS_RENDERERS, <10 renderer closures> }`.

## Items to Confirm / Review

- **Returned-object identity is the whole ballgame.** Verified three ways: `vue-tsc` type-checks the return against the unchanged `CollectionRendering` interface (missing/excess members would error); a new composition test asserts `Object.keys(render).sort()` equals the exact 25-member set (no leak) and `render.deriveAll === deriveAll` (structural passthrough preserved); every consumer was grepped and left untouched.
- **Stale-write guard timing.** In the original, the guard (`if (collection.value?.slug !== expectedSlug) return;`) sat between the `await Promise.all` and the cache assignment. It now lives inside `fetchLinkedCaches` (reads an injected `currentSlug()` after the await, returns `null` when stale) and the composable only assigns when a non-null snapshot comes back — same ordering, same drop-on-stale. Please sanity-check this is truly equivalent.
- **`collectionUi()` resolution timing.** Preserved exactly: the composable computes targets, early-returns on zero targets **before** touching `collectionUi()`, then resolves `const binding = collectionUi()` once (outside the try/catch), and passes `(slug) => binding.fetchCollectionDetail(slug)` so the host method keeps its `this`.
- **`no-shadow` rename.** Inside `buildEmbedViews`, the inner `resolveEmbed` result is destructured as `targetSchema` (the outer param is `schema`); pure rename, no behavior change.
- **`"—"` literal.** `renderDerived` keeps the em-dash string literal exactly as the original composable had it (the helpers file's private `EM_DASH` const isn't exported), to preserve byte-for-byte output.

## User Prompt

Bring `useCollectionRendering` under the 50-line `max-lines-per-function` budget with a **strictly behavior-preserving** split, then remove that file from the eslint grandfather list. This is the largest and riskiest of the remaining refactors — it absolutely must not regress. If a safe split to ≤50 as a genuine separation of concerns isn't possible, stop and report rather than forcing a lint-appeasing param-bag. Preserve exactly: the stale-write guard, the best-effort fetch (a rejecting target coerced to a skip, others unaffected), the zero-target early return, `collectionUi()` binding timing, `resetLinkedCaches` clearing all three caches, and the `currencySymbol` locale passthrough. Keep the exported interface and returned object byte-for-byte identical. Add tests for anything newly standalone (concurrent-fetch rejection skipping, the stale-write guard, idField-based embed rendering).

## Before / after — counted lines (rule: `max: 50, skipBlankLines, skipComments`)

| Function | File | Before | After |
|---|---|---:|---:|
| `useCollectionRendering` | useCollectionRendering.ts | **136** | **18** |
| `useLinkedCollectionCaches` | useLinkedCollectionCaches.ts | — | 26 |
| `loadLinkedCollections` | useLinkedCollectionCaches.ts | (nested) | 15 |
| `resetLinkedCaches` | useLinkedCollectionCaches.ts | (nested) | 5 |
| `fetchLinkedCaches` | useLinkedCollectionCaches.ts | — | 30 |
| `linkedTargets` | useLinkedCollectionCaches.ts | — | 6 |
| `buildEmbedViews` | renderers.ts | — | 23 |
| `resolveEmbed` | renderers.ts | — | 12 |
| `evaluateDerived` | renderers.ts | — | 12 |
| `renderSubCell` / `renderDerived` | renderers.ts | — | 5 / 5 |
| `lookupRefDisplay` / `refOptionsFor` / `embedOptionsFor` / `formatEmbedValue` | renderers.ts | — | 4 each |

Every function is well under 50; the file is off the grandfather list and the rule is `error` for it.

## Tests added (all pass; 91 total in the collection suite)

- `test/plugins/collection/test_linkedCollectionCaches.ts` — `linkedTargets` union/dedup; `fetchLinkedCaches` ref+record+embed building, **best-effort skip of a rejecting target**, skip of an `{ ok: false }` target, **stale-write guard** (both a differing slug and a slug that flips *during* the fan-out, proving the guard reads `currentSlug()` after the await), dual ref+embed target, empty-target snapshot.
- `test/plugins/collection/test_collectionRenderers.ts` — every renderer, with emphasis on **`buildEmbedViews` for `idField` targets** (row-specific resolution, empty-sub-field skipping, `found: false` for a missing record, null-schema → `{}`).
- `test/plugins/collection/test_useCollectionRendering.ts` — composition/integration against this worktree's source: exact returned member set, `deriveAll` reference identity, `evaluateDerivedAgainstItem` reading a live-mutated `refRecordCache`, `embedViewsFor` off a primed `embedCache`, `resetLinkedCaches` clearing all three, `stepFor`/`currencySymbol` locale threading.

## Verification

- `vue-tsc --noEmit` on the plugin's `tsconfig.json` and `tsconfig.build.json` → clean.
- `tsc -p test/tsconfig.json --noEmit` → clean.
- `eslint` on all three source files + all three test files → 0 problems (the `error`-level `max-lines-per-function` now applies to `useCollectionRendering.ts` and passes).
- `prettier --check` on all changed files → clean.
- Existing `test_collectionRenderingHelpers.ts` (42) and `test_derive.ts` (10) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved collection views with better handling of linked records, embedded content, and derived fields.
  * Added more reliable formatting for reference labels, embedded values, and calculated values across locales.

* **Bug Fixes**
  * Reduced display issues caused by stale linked data while collections are loading or changing.
  * Improved fallback behavior when related items or embedded data are missing.

* **Tests**
  * Added broader coverage for collection rendering and linked-data cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->