### PR TITLE
fix: absorb late partial-file open error in whisper streamToFile

### DIFF
--- a/packages/core/src/whisper/models.ts
+++ b/packages/core/src/whisper/models.ts
@@ -116,6 +116,11 @@ async function streamToFile(
     fileStream.end();
     await once(fileStream, "finish");
   } catch (err) {
+    // `createWriteStream` opens lazily. Destroying it while that open is still
+    // in flight lets the open's own failure land later as an `error` event with
+    // no listener — an uncaughtException that kills the process. `err` already
+    // carries the real cause, so absorb the late one.
+    fileStream.on("error", () => {});
     fileStream.destroy();
     throw err;
   }

--- a/packages/core/test/whisper/test_model_downloader.ts
+++ b/packages/core/test/whisper/test_model_downloader.ts
@@ -106,6 +106,31 @@ describe("createModelDownloader.ensure — download orchestration", () => {
     await first;
   });
 
+  it("absorbs a partial-file open that fails after the stream already errored", async () => {
+    // The stream errors synchronously, so `streamToFile` destroys the write
+    // stream while `createWriteStream`'s open() is still in libuv's threadpool.
+    // Removing the dir makes that open land ENOENT — it must not escape as an
+    // uncaughtException (node:test would fail the whole file).
+    globalThis.fetch = async () => {
+      const errored = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error("stream died"));
+        },
+      });
+      return new Response(errored, { headers: { "content-length": "1024" } });
+    };
+    const dir = makeModelsDir();
+    const downloader = createModelDownloader(dir);
+
+    await downloader.ensure(MODEL);
+    rmSync(dir, { recursive: true, force: true });
+    await flushMicrotasks();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    assert.equal(downloader.getStatus(MODEL).state, "error");
+  });
+
   it("aborts a stalled download once the stall timeout elapses", async (ctx) => {
     mock.timers.enable({ apis: ["setTimeout"] });
     ctx.after(() => mock.timers.reset());


### PR DESCRIPTION
## Summary
Fixes an intermittent CI failure on `main` (`lint_test (24.x, ubuntu-latest)`) and the latent production bug behind it.

## Root cause
`createWriteStream` opens lazily. When the response stream errors **before** that open lands, `streamToFile`'s catch calls `fileStream.destroy()` while the open is still in libuv's threadpool. The open's own failure then fires an `error` event with **no listener** → `uncaughtException` → process death.

CI surfaced it as:
```
Test "aborts a stalled download once the stall timeout elapses" generated asynchronous
activity after the test ended. This activity created the error
"ENOENT: ... /ggml-base.bin.partial" and would have caused the test to fail,
but instead triggered an uncaughtException event.
```
The stall-abort test added in #2042 exposed it (it removes the temp dir immediately after the aborted download). **The gap itself predates that PR** — the `destroy(); throw err;` pattern was moved verbatim during the `createModelDownloader` refactor.

## Fix
Attach a no-op `error` listener before `destroy()`. `err` already carries the real cause, so the late one is absorbed instead of raised. The happy path and the in-loop error paths are untouched — `once(fileStream, "drain")` / `once(fileStream, "finish")` still reject on a genuine stream error.

## Verification (deterministic, not "looks fine")
A repro that errors the stream synchronously (so `destroy()` runs while the open is pending) and then removes the models dir:

| | result |
|---|---|
| without the fix | **3/3 CRASHED** — the exact CI `ENOENT ... .partial` uncaughtException |
| with the fix | **3/3 SURVIVED** (status correctly `error`) |

- New regression test `absorbs a partial-file open that fails after the stream already errored` — **fails without the fix**, passes with it.
- `packages/core` whisper suite: **46/46 pass**, 0 failures across **10 consecutive runs**.
- eslint 0 errors; `tsc -p packages/core/tsconfig.json --noEmit` clean; prettier clean.

## Items to Confirm / Review
- The no-op listener only guards the already-failing path (inside `catch`, immediately before `destroy()`), so it cannot mask a fresh error that the awaits would otherwise surface.
- This unblocks #2045, whose CI was red purely from this pre-existing flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle late write-stream open errors safely in whisper's model downloader to avoid process crashes and validate the behavior with a dedicated regression test.

Bug Fixes:
- Prevent uncaughtExceptions from late partial-file open errors in whisper's streamToFile model downloader logic.

Tests:
- Add a regression test ensuring partial-file open failures after a stream error are absorbed and reported via downloader status instead of crashing.