### PR TITLE
fix: remove stale relay-client NOTE left by #2044

### DIFF
--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -2,12 +2,8 @@
 //
 // Connects to the Relay (Cloudflare Workers) and forwards incoming
 // platform messages to the chat-service relay function. Handles
-// reconnection with exponential backoff.
-//
-// NOTE: packages/relay/src/client.ts is a parallel implementation
-// for browser/edge environments using the global WebSocket API.
-// This module uses the `socket` npm package for Node.js. If you change
-// reconnection logic or URL handling here, check the other file too.
+// reconnection with exponential backoff. Uses the `ws` npm package,
+// so it is Node-only — there is no longer a browser/edge counterpart.
 
 import WebSocket from "ws";
 import type { ChatService } from "@mulmobridge/chat-service";


### PR DESCRIPTION
## Summary
Addresses the CodeRabbit review comment on #2044.

#2044 deleted `packages/relay/src/client.ts` (the unused, undocumented `@mulmobridge/relay/client` subpath export). The header of `server/events/relay-client.ts` still carried a NOTE describing that file as a "parallel implementation" and instructing readers to keep the two in sync — it now points at a file that no longer exists.

## Change
Replaced the stale 4-line NOTE with an accurate one-liner: this client is Node-only (it uses the `ws` package) and has no browser/edge counterpart.

## Verification
- Grep confirms **zero** remaining references to `packages/relay/src/client.ts`, `@mulmobridge/relay/client`, or `createRelayClient` anywhere outside `docs/CHANGELOG.md` (historical entries, correctly left alone).
- eslint: 0 errors (only the pre-existing, grandfathered `connectRelay` max-lines warning).
- `tsc -p server/tsconfig.json --noEmit` clean; prettier clean; `test/events/test_relayClientHelpers.ts` 22/22 pass.
- Comments don't count toward `max-lines-per-function` (`skipComments: true`), so `connectRelay`'s count is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the relay-client header note to remove stale references to the deleted browser/edge client and describe the current Node-only setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified connection behavior details in an internal comment.
  * Removed outdated wording about browser/edge support from that note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->