### PR TITLE
fix: emit POSIX separators in npm file: specifiers (fixes Windows CI)

### DIFF
--- a/scripts/mulmoclaude/tarball.d.mts
+++ b/scripts/mulmoclaude/tarball.d.mts
@@ -74,6 +74,11 @@ export function enumerateWorkspacePackages(
  *  excluding the root itself. Third-party deps are naturally excluded. */
 export function computeFirstPartyClosure(packages: Array<{ name: string; deps: string[] }>, rootName: string): Set<string>;
 
+/** Build an npm `file:` specifier from a native tarball path, normalising the
+ *  platform separator to `/`. `sep` defaults to `path.sep`; pass it explicitly
+ *  to exercise the Windows shape from a POSIX host. */
+export function toFileSpecifier(tarballPath: string, sep?: string): string;
+
 export interface PackWorkspaceOverridesOptions {
   root: string;
   packDir: string;

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -206,6 +206,14 @@ async function packOneWorkspacePackage({ packageDir, destDir, runCommandImpl = r
   return path.join(destDir, filename);
 }
 
+// npm reads a `file:` specifier as a URL-ish path, where `\` is not a separator.
+// `path.join` emits `\` on Windows, so normalise to `/` — Windows filesystem APIs
+// accept forward slashes. `sep` is injectable so the Windows shape is testable on
+// any host; on POSIX it defaults to `/`, leaving a literal `\` in a filename alone.
+export function toFileSpecifier(tarballPath, sep = path.sep) {
+  return `file:${tarballPath.split(sep).join("/")}`;
+}
+
 // Pack the launcher's first-party workspace dependency closure into `packDir` and
 // return an npm `overrides` map { name: "file:<abs tarball>" }. This is what lets
 // the smoke install a launcher pinned to a bumped-but-unpublished shared package
@@ -220,7 +228,7 @@ export async function packWorkspaceOverrides({ root, packDir, runCommandImpl = r
     const pkg = byName.get(name);
     if (!pkg) continue;
     const tarballPath = await packOneWorkspacePackage({ packageDir: pkg.dir, destDir: packDir, runCommandImpl, packTimeoutMs });
-    overrides[name] = `file:${tarballPath}`;
+    overrides[name] = toFileSpecifier(tarballPath);
   }
   return overrides;
 }

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -207,6 +207,20 @@ describe("computeFirstPartyClosure", () => {
   });
 });
 
+describe("toFileSpecifier", () => {
+  it("leaves a POSIX path untouched", () => {
+    assert.equal(tarball.toFileSpecifier("/tmp/packs/core-1.0.0.tgz", "/"), "file:/tmp/packs/core-1.0.0.tgz");
+  });
+
+  it("normalises Windows separators so npm sees a URL-ish path", () => {
+    assert.equal(tarball.toFileSpecifier("\\tmp\\packs\\core-1.0.0.tgz", "\\"), "file:/tmp/packs/core-1.0.0.tgz");
+  });
+
+  it("keeps the drive letter on an absolute Windows path", () => {
+    assert.equal(tarball.toFileSpecifier("C:\\Users\\ci\\packs\\core-1.0.0.tgz", "\\"), "file:C:/Users/ci/packs/core-1.0.0.tgz");
+  });
+});
+
 describe("packWorkspaceOverrides", () => {
   it("packs only the launcher's first-party closure and maps each to a file: tarball", async () => {
     const enumerateImpl = async () => [


### PR DESCRIPTION
## Summary
Fixes the long-standing red `lint_test (Windows)` on `main`.

## Root cause
`packWorkspaceOverrides` built its npm `overrides` values as:
```js
overrides[name] = `file:${path.join(destDir, filename)}`;
```
On Windows `path.join` yields backslashes, so the specifier came out `file:\tmp\packs\core-1.0.0.tgz`. npm reads a `file:` specifier as a URL-ish path, where `\` is not a separator — and `test_tarball.ts` asserts the POSIX shape, so the Windows job failed:
```
+ actual   { '@w/core': 'file:\\tmp\\packs\\core-1.0.0.tgz' }
- expected { '@w/core': 'file:/tmp/packs/core-1.0.0.tgz' }
```

This predates the current line-length work by a long way (failing since ~#2022). `lint_test (Windows)` runs **only on push to main**, never on PRs, which is why it never blocked a merge — worth knowing.

## Fix
Extract a pure `toFileSpecifier(tarballPath, sep = path.sep)` that normalises the separator to `/`:
- Windows filesystem APIs and npm both accept forward slashes, so this is the canonical shape.
- On POSIX `path.sep` is `/`, so the split/join is a no-op — a literal `\` in a POSIX filename survives untouched (which a blanket `replaceAll("\\", "/")` would have corrupted).
- `sep` is injectable so the Windows shape is unit-testable from a POSIX host, matching the repo's existing DI style (`runCommandImpl`, `enumerateImpl`, `now`, `sleep`).

## Verification
Simulated the exact CI input with `path.win32`:

| | value |
|---|---|
| before | `file:\tmp\packs\core-1.0.0.tgz` — **identical to the CI `actual`** |
| after | `file:/tmp/packs/core-1.0.0.tgz` — **identical to the CI `expected`** |
| POSIX | unchanged |

- 3 new unit tests for `toFileSpecifier` (POSIX no-op, Windows separators, drive-letter path).
- `test/scripts/mulmoclaude/*` → **115/115 pass**.
- eslint 0 errors; `tsc -p test/tsconfig.json --noEmit` clean (also type-checks the new `tarball.d.mts` declaration); prettier clean.

## Items to Confirm / Review
- The `file:` value is consumed by `npm install` in the smoke workflow. Forward slashes are accepted by npm on every platform, so the Linux/macOS smoke behaviour is byte-identical (the POSIX branch is a no-op).
- Since the Windows workflow only runs on push to `main`, this PR's own CI cannot prove the fix — the `path.win32` simulation above is the evidence, and the next push to `main` will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize npm file: specifiers for workspace tarballs so Windows CI uses POSIX-style separators.

Bug Fixes:
- Fix Windows lint_test failure by emitting forward-slash separators in npm file: overrides instead of backslashes.

Enhancements:
- Introduce a reusable toFileSpecifier helper for constructing normalized npm file: specifiers from native tarball paths.

Tests:
- Add unit tests covering toFileSpecifier behavior for POSIX paths, Windows-style relative paths, and Windows drive-letter absolute paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting local tarball paths into consistent `file:` package references.
  * Improved path handling so Windows-style separators are normalized for better cross-platform compatibility.

* **Tests**
  * Added coverage for path conversion behavior on POSIX and Windows-style paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->