### PR TITLE
chore: split state, availability polling, and segment queue out of createVoiceCapture

### DIFF
--- a/packages/core/src/whisper/client.ts
+++ b/packages/core/src/whisper/client.ts
@@ -84,13 +84,24 @@ export interface VoiceCapture {
   dispose: () => void;
 }
 
-export function createVoiceCapture(transport: VoiceCaptureTransport, language: () => string, callbacks: VoiceCaptureCallbacks): VoiceCapture {
+export interface CaptureStateController {
+  setAvailable: (value: boolean) => void;
+  setListening: (value: boolean) => void;
+  setPending: (delta: number) => void;
+  isListening: () => boolean;
+}
+
+// Owns the three observable flags. Each setter emits only on an actual change so
+// the host's reactivity never churns on a no-op write. `pending` is a private
+// counter; `transcribing` is true exactly while at least one send is in flight.
+export function createCaptureState(onState?: (state: VoiceCaptureState) => void): CaptureStateController {
   let available = false;
   let listening = false;
   let transcribing = false;
+  let pending = 0;
 
   function emit(): void {
-    callbacks.onState?.({ available, listening, transcribing });
+    onState?.({ available, listening, transcribing });
   }
   function setAvailable(value: boolean): void {
     if (available !== value) {
@@ -104,29 +115,6 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
       emit();
     }
   }
-
-  let stream: MediaStream | null = null;
-  let audioCtx: AudioContext | null = null;
-  let analyser: AnalyserNode | null = null;
-  let vadBuffer = new Float32Array(0);
-  let monitorHandle: number | null = null;
-  let recorder: MediaRecorder | null = null;
-  let chunks: Blob[] = [];
-  let mimeType = "";
-  let segmentHasSpeech = false;
-  let silenceStart: number | null = null;
-  let segmentStart = 0;
-  let pending = 0;
-  let queue: Promise<void> = Promise.resolve();
-  let availabilityPollHandle: number | null = null;
-  // Bumped on stop(). Segments captured / sends resolved under an older
-  // generation are dropped, so a late transcript never leaks across sessions.
-  let generation = 0;
-  let segmentGeneration = 0;
-  // Single-flight guard for start(): true between entry and the moment capture
-  // is set up (or the attempt aborts), so a second start can't race the first.
-  let startInFlight = false;
-
   function setPending(delta: number): void {
     pending += delta;
     const next = pending > 0;
@@ -136,47 +124,86 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
     }
   }
 
-  function stopAvailabilityPoll(): void {
+  return { setAvailable, setListening, setPending, isListening: () => listening };
+}
+
+export interface AvailabilityPoller {
+  refresh: () => Promise<void>;
+  stop: () => void;
+}
+
+// Owns the polling timer. `refresh` mirrors transport readiness into
+// `setAvailable`; while a model is downloading it self-schedules so `available`
+// flips as soon as the download finishes. A `getStatus` throw fails closed
+// (unavailable) and tears the timer down.
+export function createAvailabilityPoller(transport: VoiceCaptureTransport, setAvailable: (value: boolean) => void): AvailabilityPoller {
+  let availabilityPollHandle: number | null = null;
+
+  function stop(): void {
     if (availabilityPollHandle !== null) {
       window.clearInterval(availabilityPollHandle);
       availabilityPollHandle = null;
     }
   }
 
-  async function refreshAvailability(): Promise<void> {
+  async function refresh(): Promise<void> {
     let status: { ready: boolean; downloading: boolean };
     try {
       status = await transport.getStatus();
     } catch {
       setAvailable(false);
-      stopAvailabilityPoll();
+      stop();
       return;
     }
     setAvailable(status.ready);
     if (status.downloading) {
       if (availabilityPollHandle === null) {
         availabilityPollHandle = window.setInterval(() => {
-          void refreshAvailability();
+          void refresh();
         }, AVAILABILITY_POLL_MS);
       }
     } else {
-      stopAvailabilityPoll();
+      stop();
     }
   }
 
+  return { refresh, stop };
+}
+
+export interface SegmentQueueOptions {
+  transport: VoiceCaptureTransport;
+  language: () => string;
+  callbacks: VoiceCaptureCallbacks;
+  setPending: (delta: number) => void;
+  // Read-only epoch seam: the queue never mutates the generation, it only reads
+  // the parent's current value to drop segments captured under an older session.
+  getGeneration: () => number;
+}
+
+export interface SegmentQueue {
+  enqueue: (blob: Blob, gen: number) => void;
+}
+
+// Owns the serialized send chain. Each blob is transcribed in capture order; the
+// generation is checked at entry and again after transcription so a segment
+// belonging to a session the user already left is dropped silently.
+export function createSegmentQueue(options: SegmentQueueOptions): SegmentQueue {
+  const { transport, language, callbacks, setPending, getGeneration } = options;
+  let queue: Promise<void> = Promise.resolve();
+
   async function sendSegment(blob: Blob, gen: number): Promise<void> {
-    if (gen !== generation) return;
+    if (gen !== getGeneration()) return;
     try {
       const dataUrl = await blobToDataUrl(blob);
       const result = await transport.transcribe(dataUrl, language());
-      if (gen !== generation) return;
+      if (gen !== getGeneration()) return;
       const text = result.text.trim();
       if (text.length === 0) callbacks.onEmpty?.();
       else callbacks.onTranscript(text);
     } catch (err) {
       // Generation-guard the failure path too: a send rejected after stop()/
       // session change belongs to a session the user already left.
-      if (gen === generation) callbacks.onError?.(toMessage(err));
+      if (gen === getGeneration()) callbacks.onError?.(toMessage(err));
     }
   }
 
@@ -190,12 +217,46 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
       .finally(() => setPending(-1));
   }
 
+  return { enqueue };
+}
+
+export function createVoiceCapture(transport: VoiceCaptureTransport, language: () => string, callbacks: VoiceCaptureCallbacks): VoiceCapture {
+  const state = createCaptureState(callbacks.onState);
+  const poller = createAvailabilityPoller(transport, state.setAvailable);
+
+  let stream: MediaStream | null = null;
+  let audioCtx: AudioContext | null = null;
+  let analyser: AnalyserNode | null = null;
+  let vadBuffer = new Float32Array(0);
+  let monitorHandle: number | null = null;
+  let recorder: MediaRecorder | null = null;
+  let chunks: Blob[] = [];
+  let mimeType = "";
+  let segmentHasSpeech = false;
+  let silenceStart: number | null = null;
+  let segmentStart = 0;
+  // Bumped on stop(). Segments captured / sends resolved under an older
+  // generation are dropped, so a late transcript never leaks across sessions.
+  let generation = 0;
+  let segmentGeneration = 0;
+  // Single-flight guard for start(): true between entry and the moment capture
+  // is set up (or the attempt aborts), so a second start can't race the first.
+  let startInFlight = false;
+
+  const segments = createSegmentQueue({
+    transport,
+    language,
+    callbacks,
+    setPending: state.setPending,
+    getGeneration: () => generation,
+  });
+
   function onSegmentStop(): void {
     const hadSpeech = segmentHasSpeech;
     const gen = segmentGeneration;
     const blob = new Blob(chunks, { type: containerTypeFromMime(mimeType) });
-    if (listening) startRecorder();
-    if (hadSpeech && blob.size > 0 && gen === generation) enqueue(blob, gen);
+    if (state.isListening()) startRecorder();
+    if (hadSpeech && blob.size > 0 && gen === generation) segments.enqueue(blob, gen);
   }
 
   function startRecorder(): void {
@@ -230,7 +291,7 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
   async function start(): Promise<boolean> {
     // Single-flight: `listening` only flips true AFTER getUserMedia resolves, so
     // a benign skip returns true (a start is already active / in progress).
-    if (startInFlight || listening) return true;
+    if (startInFlight || state.isListening()) return true;
     startInFlight = true;
     const startGen = generation;
     try {
@@ -258,7 +319,7 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
       analyser.fftSize = 2048;
       vadBuffer = new Float32Array(analyser.fftSize);
       audioCtx.createMediaStreamSource(stream).connect(analyser);
-      setListening(true);
+      state.setListening(true);
       startRecorder();
       monitorHandle = window.setInterval(monitorTick, MONITOR_INTERVAL_MS);
       return true;
@@ -271,7 +332,7 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
     // Bump the generation so any in-flight/queued segment is dropped rather than
     // applied after the user stops or switches sessions.
     generation += 1;
-    setListening(false);
+    state.setListening(false);
     if (monitorHandle !== null) {
       window.clearInterval(monitorHandle);
       monitorHandle = null;
@@ -288,9 +349,9 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
   }
 
   function dispose(): void {
-    stopAvailabilityPoll();
+    poller.stop();
     stop();
   }
 
-  return { refreshAvailability, start, stop, dispose };
+  return { refreshAvailability: poller.refresh, start, stop, dispose };
 }

--- a/packages/core/test/whisper/test_availability_poller.ts
+++ b/packages/core/test/whisper/test_availability_poller.ts
@@ -1,0 +1,151 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createAvailabilityPoller, type VoiceCaptureTransport } from "../../src/whisper/client.ts";
+
+interface Status {
+  ready: boolean;
+  downloading: boolean;
+}
+
+interface FakeInterval {
+  readonly handle: number;
+  readonly callback: () => void;
+  readonly intervalMs: number;
+  cleared: boolean;
+}
+
+interface FakeTimers {
+  activeCount: () => number;
+  createdCount: () => number;
+  clearCalls: () => number;
+}
+
+// The poller reaches for `window.setInterval` / `window.clearInterval`. Install a
+// deterministic stub on globalThis so we can assert on the timer lifecycle
+// without real time. `configurable` lets each test reinstall a fresh one.
+function installFakeTimers(): FakeTimers {
+  const intervals: FakeInterval[] = [];
+  let nextHandle = 1;
+  let clearCalls = 0;
+  const setIntervalFn = (callback: () => void, intervalMs: number): number => {
+    const handle = nextHandle;
+    nextHandle += 1;
+    intervals.push({ handle, callback, intervalMs, cleared: false });
+    return handle;
+  };
+  const clearIntervalFn = (handle: number): void => {
+    clearCalls += 1;
+    const found = intervals.find((interval) => interval.handle === handle);
+    if (found) found.cleared = true;
+  };
+  Object.defineProperty(globalThis, "window", {
+    value: { setInterval: setIntervalFn, clearInterval: clearIntervalFn },
+    configurable: true,
+    writable: true,
+  });
+  return {
+    activeCount: () => intervals.filter((interval) => !interval.cleared).length,
+    createdCount: () => intervals.length,
+    clearCalls: () => clearCalls,
+  };
+}
+
+function transportWith(getStatus: () => Promise<Status>): VoiceCaptureTransport {
+  return { getStatus, transcribe: () => Promise.resolve({ text: "" }) };
+}
+
+function availableSpy(): { calls: boolean[]; fn: (value: boolean) => void } {
+  const calls: boolean[] = [];
+  return { calls, fn: (value) => calls.push(value) };
+}
+
+describe("createAvailabilityPoller", () => {
+  it("fails closed and does not poll when getStatus throws", async () => {
+    const timers = installFakeTimers();
+    const available = availableSpy();
+    const poller = createAvailabilityPoller(
+      transportWith(() => Promise.reject(new Error("down"))),
+      available.fn,
+    );
+    await poller.refresh();
+    assert.deepEqual(available.calls, [false]);
+    assert.equal(timers.createdCount(), 0);
+    assert.equal(timers.activeCount(), 0);
+  });
+
+  it("reports ready and starts no timer when not downloading", async () => {
+    const timers = installFakeTimers();
+    const available = availableSpy();
+    const poller = createAvailabilityPoller(
+      transportWith(() => Promise.resolve({ ready: true, downloading: false })),
+      available.fn,
+    );
+    await poller.refresh();
+    assert.deepEqual(available.calls, [true]);
+    assert.equal(timers.createdCount(), 0);
+  });
+
+  it("starts exactly one interval while downloading and never a second", async () => {
+    const timers = installFakeTimers();
+    const available = availableSpy();
+    const poller = createAvailabilityPoller(
+      transportWith(() => Promise.resolve({ ready: false, downloading: true })),
+      available.fn,
+    );
+    await poller.refresh();
+    assert.equal(timers.createdCount(), 1);
+    assert.equal(timers.activeCount(), 1);
+    await poller.refresh();
+    assert.equal(timers.createdCount(), 1);
+    assert.deepEqual(available.calls, [false, false]);
+  });
+
+  it("clears the interval once downloading finishes", async () => {
+    const timers = installFakeTimers();
+    const available = availableSpy();
+    let downloading = true;
+    const poller = createAvailabilityPoller(
+      transportWith(() => Promise.resolve({ ready: !downloading, downloading })),
+      available.fn,
+    );
+    await poller.refresh();
+    assert.equal(timers.activeCount(), 1);
+    downloading = false;
+    await poller.refresh();
+    assert.equal(timers.activeCount(), 0);
+    assert.deepEqual(available.calls, [false, true]);
+  });
+
+  it("tears the interval down and fails closed when getStatus throws mid-download", async () => {
+    const timers = installFakeTimers();
+    const available = availableSpy();
+    let online = true;
+    const poller = createAvailabilityPoller(
+      transportWith(() => (online ? Promise.resolve({ ready: false, downloading: true }) : Promise.reject(new Error("down")))),
+      available.fn,
+    );
+    await poller.refresh();
+    assert.equal(timers.activeCount(), 1);
+    online = false;
+    await poller.refresh();
+    assert.equal(timers.activeCount(), 0);
+    assert.equal(available.calls.at(-1), false);
+  });
+
+  it("stop() clears an active interval and is idempotent", async () => {
+    const timers = installFakeTimers();
+    const available = availableSpy();
+    const poller = createAvailabilityPoller(
+      transportWith(() => Promise.resolve({ ready: false, downloading: true })),
+      available.fn,
+    );
+    await poller.refresh();
+    assert.equal(timers.activeCount(), 1);
+    poller.stop();
+    assert.equal(timers.activeCount(), 0);
+    assert.equal(timers.clearCalls(), 1);
+    poller.stop();
+    assert.equal(timers.clearCalls(), 1);
+  });
+});

--- a/packages/core/test/whisper/test_capture_state.ts
+++ b/packages/core/test/whisper/test_capture_state.ts
@@ -10,8 +10,8 @@ function collector(): { states: VoiceCaptureState[]; onState: (state: VoiceCaptu
 
 describe("createCaptureState", () => {
   it("does not emit on creation", () => {
-    const { states } = collector();
-    createCaptureState(collector().onState);
+    const { states, onState } = collector();
+    createCaptureState(onState);
     assert.equal(states.length, 0);
   });
 

--- a/packages/core/test/whisper/test_capture_state.ts
+++ b/packages/core/test/whisper/test_capture_state.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createCaptureState, type VoiceCaptureState } from "../../src/whisper/client.ts";
+
+function collector(): { states: VoiceCaptureState[]; onState: (state: VoiceCaptureState) => void } {
+  const states: VoiceCaptureState[] = [];
+  return { states, onState: (state) => states.push(state) };
+}
+
+describe("createCaptureState", () => {
+  it("does not emit on creation", () => {
+    const { states } = collector();
+    createCaptureState(collector().onState);
+    assert.equal(states.length, 0);
+  });
+
+  it("emits with all three flags when available flips", () => {
+    const { states, onState } = collector();
+    const state = createCaptureState(onState);
+    state.setAvailable(true);
+    assert.deepEqual(states, [{ available: true, listening: false, transcribing: false }]);
+  });
+
+  it("does not emit when a setter writes the current value", () => {
+    const { states, onState } = collector();
+    const state = createCaptureState(onState);
+    state.setAvailable(false);
+    state.setListening(false);
+    assert.equal(states.length, 0);
+    state.setAvailable(true);
+    state.setAvailable(true);
+    assert.equal(states.length, 1);
+  });
+
+  it("tracks listening and exposes it via isListening", () => {
+    const { states, onState } = collector();
+    const state = createCaptureState(onState);
+    assert.equal(state.isListening(), false);
+    state.setListening(true);
+    assert.equal(state.isListening(), true);
+    assert.deepEqual(states.at(-1), { available: false, listening: true, transcribing: false });
+    state.setListening(false);
+    assert.equal(state.isListening(), false);
+  });
+
+  it("setPending(+1) turns transcribing on and setPending(-1) turns it back off", () => {
+    const { states, onState } = collector();
+    const state = createCaptureState(onState);
+    state.setPending(1);
+    assert.deepEqual(states.at(-1), { available: false, listening: false, transcribing: true });
+    state.setPending(-1);
+    assert.deepEqual(states.at(-1), { available: false, listening: false, transcribing: false });
+    assert.equal(states.length, 2);
+  });
+
+  it("counts nested pending: only the 0<->positive edges emit", () => {
+    const { states, onState } = collector();
+    const state = createCaptureState(onState);
+    state.setPending(1); // 0 -> 1, edge: emit (transcribing true)
+    state.setPending(1); // 1 -> 2, still positive: no emit
+    state.setPending(-1); // 2 -> 1, still positive: no emit
+    assert.equal(states.length, 1);
+    state.setPending(-1); // 1 -> 0, edge: emit (transcribing false)
+    assert.equal(states.length, 2);
+    assert.deepEqual(
+      states.map((snapshot) => snapshot.transcribing),
+      [true, false],
+    );
+  });
+
+  it("does not throw when no onState is provided", () => {
+    const state = createCaptureState();
+    assert.doesNotThrow(() => {
+      state.setAvailable(true);
+      state.setListening(true);
+      state.setPending(1);
+      state.setPending(-1);
+    });
+    assert.equal(state.isListening(), true);
+  });
+});

--- a/packages/core/test/whisper/test_segment_queue.ts
+++ b/packages/core/test/whisper/test_segment_queue.ts
@@ -1,0 +1,195 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createSegmentQueue, type VoiceCaptureCallbacks, type VoiceCaptureTransport } from "../../src/whisper/client.ts";
+
+// The queue's send path runs blobs through `blobToDataUrl`, which uses the web
+// `FileReader` — absent in Node. Install a deterministic stub that resolves on a
+// microtask so `sendSegment` reaches the transport with a data URL.
+class FakeFileReader {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  result: string | null = null;
+  error: unknown = null;
+  readAsDataURL(__blob: Blob): void {
+    queueMicrotask(() => {
+      this.result = "data:audio/webm;base64,AAAA";
+      this.onload?.();
+    });
+  }
+}
+Object.defineProperty(globalThis, "FileReader", { value: FakeFileReader, configurable: true, writable: true });
+
+function transportWith(transcribe: () => Promise<{ text: string }>): VoiceCaptureTransport {
+  return { transcribe, getStatus: () => Promise.resolve({ ready: true, downloading: false }) };
+}
+
+// Tracks the +1/-1 pending deltas and lets a test await the moment the counter
+// returns to zero (every enqueued send has settled, success or failure).
+function pendingTracker(): { setPending: (delta: number) => void; deltas: number[]; whenIdle: () => Promise<void> } {
+  const deltas: number[] = [];
+  let sum = 0;
+  let resolveIdle: (() => void) | null = null;
+  const setPending = (delta: number): void => {
+    deltas.push(delta);
+    sum += delta;
+    if (sum === 0 && resolveIdle) {
+      resolveIdle();
+      resolveIdle = null;
+    }
+  };
+  const whenIdle = (): Promise<void> =>
+    new Promise((resolve) => {
+      if (sum === 0) resolve();
+      else resolveIdle = resolve;
+    });
+  return { setPending, deltas, whenIdle };
+}
+
+function callbackCollector(): { transcripts: string[]; errors: string[]; emptyCount: () => number; callbacks: VoiceCaptureCallbacks } {
+  const transcripts: string[] = [];
+  const errors: string[] = [];
+  let emptyCount = 0;
+  const callbacks: VoiceCaptureCallbacks = {
+    onTranscript: (text) => transcripts.push(text),
+    onEmpty: () => {
+      emptyCount += 1;
+    },
+    onError: (message) => errors.push(message),
+  };
+  return { transcripts, errors, emptyCount: () => emptyCount, callbacks };
+}
+
+function blob(): Blob {
+  return new Blob(["audio"]);
+}
+
+describe("createSegmentQueue", () => {
+  it("delivers transcripts in capture order even when the first send is slower", async () => {
+    const pending = pendingTracker();
+    const sink = callbackCollector();
+    let call = 0;
+    const transcribe = (): Promise<{ text: string }> => {
+      call += 1;
+      const nth = call;
+      const text = nth === 1 ? "first" : "second";
+      const delayMs = nth === 1 ? 20 : 1;
+      return new Promise((resolve) => setTimeout(() => resolve({ text }), delayMs));
+    };
+    const queue = createSegmentQueue({
+      transport: transportWith(transcribe),
+      language: () => "en",
+      callbacks: sink.callbacks,
+      setPending: pending.setPending,
+      getGeneration: () => 0,
+    });
+    queue.enqueue(blob(), 0);
+    queue.enqueue(blob(), 0);
+    await pending.whenIdle();
+    assert.deepEqual(sink.transcripts, ["first", "second"]);
+    assert.deepEqual(pending.deltas, [1, 1, -1, -1]);
+  });
+
+  it("routes an empty (whitespace-only) transcript to onEmpty", async () => {
+    const pending = pendingTracker();
+    const sink = callbackCollector();
+    const queue = createSegmentQueue({
+      transport: transportWith(() => Promise.resolve({ text: "   " })),
+      language: () => "en",
+      callbacks: sink.callbacks,
+      setPending: pending.setPending,
+      getGeneration: () => 0,
+    });
+    queue.enqueue(blob(), 0);
+    await pending.whenIdle();
+    assert.equal(sink.emptyCount(), 1);
+    assert.deepEqual(sink.transcripts, []);
+    assert.deepEqual(pending.deltas, [1, -1]);
+  });
+
+  it("reports onError when the transport throws and the generation still matches", async () => {
+    const pending = pendingTracker();
+    const sink = callbackCollector();
+    const queue = createSegmentQueue({
+      transport: transportWith(() => Promise.reject(new Error("boom"))),
+      language: () => "en",
+      callbacks: sink.callbacks,
+      setPending: pending.setPending,
+      getGeneration: () => 0,
+    });
+    queue.enqueue(blob(), 0);
+    await pending.whenIdle();
+    assert.deepEqual(sink.errors, ["boom"]);
+    assert.deepEqual(pending.deltas, [1, -1]);
+  });
+
+  it("drops a segment stale at the entry guard without calling the transport", async () => {
+    const pending = pendingTracker();
+    const sink = callbackCollector();
+    let transcribeCalls = 0;
+    const queue = createSegmentQueue({
+      transport: transportWith(() => {
+        transcribeCalls += 1;
+        return Promise.resolve({ text: "late" });
+      }),
+      language: () => "en",
+      callbacks: sink.callbacks,
+      setPending: pending.setPending,
+      getGeneration: () => 1,
+    });
+    queue.enqueue(blob(), 0);
+    await pending.whenIdle();
+    assert.equal(transcribeCalls, 0);
+    assert.deepEqual(sink.transcripts, []);
+    assert.equal(sink.emptyCount(), 0);
+    assert.deepEqual(sink.errors, []);
+    assert.deepEqual(pending.deltas, [1, -1]);
+  });
+
+  it("drops a transcript when the generation advances during transcription", async () => {
+    const pending = pendingTracker();
+    const sink = callbackCollector();
+    let current = 0;
+    let transcribeCalls = 0;
+    const queue = createSegmentQueue({
+      transport: transportWith(() => {
+        transcribeCalls += 1;
+        current = 1;
+        return Promise.resolve({ text: "late" });
+      }),
+      language: () => "en",
+      callbacks: sink.callbacks,
+      setPending: pending.setPending,
+      getGeneration: () => current,
+    });
+    queue.enqueue(blob(), 0);
+    await pending.whenIdle();
+    assert.equal(transcribeCalls, 1);
+    assert.deepEqual(sink.transcripts, []);
+    assert.equal(sink.emptyCount(), 0);
+    assert.deepEqual(pending.deltas, [1, -1]);
+  });
+
+  it("suppresses onError when the generation advances before the failure settles", async () => {
+    const pending = pendingTracker();
+    const sink = callbackCollector();
+    let current = 0;
+    let transcribeCalls = 0;
+    const queue = createSegmentQueue({
+      transport: transportWith(() => {
+        transcribeCalls += 1;
+        current = 1;
+        return Promise.reject(new Error("boom"));
+      }),
+      language: () => "en",
+      callbacks: sink.callbacks,
+      setPending: pending.setPending,
+      getGeneration: () => current,
+    });
+    queue.enqueue(blob(), 0);
+    await pending.whenIdle();
+    assert.equal(transcribeCalls, 1);
+    assert.deepEqual(sink.errors, []);
+    assert.deepEqual(pending.deltas, [1, -1]);
+  });
+});


### PR DESCRIPTION
## Summary

`createVoiceCapture` in `packages/core/src/whisper/client.ts` was a 181-line factory closure with zero unit coverage over its state machine, availability polling, and send/queue logic. This PR extracts three **DOM-free** child factories, each owning its own mutable state, and adds thorough `node:test` coverage for all three. Behavior is byte-identical; the parent still composes the capture engine.

**This is not primarily a lint-number change.** After the split `createVoiceCapture` is 115 counted lines — still over the 50-line budget — so `packages/core/src/whisper/client.ts` **stays in the eslint grandfather list by design**. The warning remains; that is the accepted outcome. The point was to make the state/polling/queue logic independently testable.

| Function | before (counted lines) | after |
|---|---|---|
| `createVoiceCapture` | 181 | 115 (warning remains) |
| `createCaptureState` (new) | — | 30 |
| `createAvailabilityPoller` (new) | — | 30 |
| `createSegmentQueue` (new) | — | 25 |

## Items to Confirm / Review

- **Generation stale-drop is unchanged.** The queue reads the parent's generation through a read-only `getGeneration()` seam (not a callback bag). Both guard points are preserved: at the entry of `sendSegment` and again after `await transport.transcribe(...)`, plus the failure-path guard so `onError` only fires when `gen === generation`. Please sanity-check the seam.
- **`setPending` +1/-1 balance.** `enqueue` still does `setPending(1)` then `.then(send).catch(() => undefined).finally(() => setPending(-1))`. The queue calls the injected `setPending` (owned by `createCaptureState`); `transcribing` is driven exactly as before. Covered by tests on every path including failure and stale-drop.
- **`isListening()` accessor.** `createVoiceCapture` reads `listening` in two hot spots (`start()` single-flight guard, `onSegmentStop`); those now go through `state.isListening()`. All writes still emit only on an actual change.
- **`dispose()` order preserved:** `poller.stop()` then `stop()`.
- **New exports are additive.** `createCaptureState` / `createAvailabilityPoller` / `createSegmentQueue` (+ their interfaces) are now exported from `whisper/client`. The public `VoiceCapture` / `VoiceCaptureTransport` / `VoiceCaptureCallbacks` / `VoiceCaptureState` interfaces, `localeToWhisperLanguage`, and the `{ refreshAvailability, start, stop, dispose }` return shape are byte-for-byte unchanged. The only consumer, `src/composables/useVoiceInput.ts`, is unaffected.

## User Prompt

Split `createVoiceCapture` into independently testable child factories to make the code maintainable and to finally add tests for logic that has none. The goal is decomposition + tests, not the lint number: decompose safely, do not fixate on the 50-line rule. Ship child factories A (`createCaptureState`), B (`createAvailabilityPoller`), and C (`createSegmentQueue`), each owning its own state (not a param bag), with thorough unit tests. `createVoiceCapture` staying over budget and remaining in the eslint grandfather list is the expected, accepted outcome — leave that entry in place. Do NOT attempt the optional 4th step (lifting the capture engine into its own factory) unless it is unambiguously clean, i.e. without threading state or a bag of callbacks through the parent.

## What moved where

- **A — `createCaptureState(onState?)`**: owns `available` / `listening` / `transcribing` / `pending`. Exposes `setAvailable` / `setListening` / `setPending` / `isListening`; `emit` stays private and every setter keeps its "only emit when the value changed" guard.
- **B — `createAvailabilityPoller(transport, setAvailable)`**: owns `availabilityPollHandle`. Exposes `refresh` / `stop`. A `getStatus()` throw fails closed (`setAvailable(false)` + tear down + return); `downloading` self-schedules exactly one `window.setInterval(…, AVAILABILITY_POLL_MS)`; leaving `downloading` clears it.
- **C — `createSegmentQueue({ transport, language, callbacks, setPending, getGeneration })`**: owns the serialized `queue` promise chain plus `sendSegment` + `enqueue`. `getGeneration()` is a read-only epoch seam.
- **`createVoiceCapture`**: composes A + B + C and keeps the capture engine (`stream` / `audioCtx` / `analyser` / `vadBuffer` / recorder / VAD state / `generation` / `startInFlight`, plus `startRecorder` / `cutSegment` / `monitorTick` / `onSegmentStop` / `start` / `stop` / `dispose`).

## Tests added (`packages/core/test/whisper/`)

- `test_capture_state.ts` — no emit on creation; setters emit only on real change; `setPending` +1/-1 flips `transcribing`; nested pending only emits on the 0↔positive edges; `isListening`; works without `onState`.
- `test_availability_poller.ts` — `getStatus` throw fails closed and does not poll; `ready` → available; `downloading` starts exactly one interval and a second `refresh()` starts none; leaving `downloading` clears it; throw mid-download tears the interval down; `stop()` is idempotent. Uses a deterministic `window.setInterval`/`clearInterval` global stub.
- `test_segment_queue.ts` — transcripts delivered in capture order across two enqueues (first send deliberately slower); empty text → `onEmpty`; transport throw → `onError` when the generation matches; stale at the entry guard → dropped without calling the transport; generation advancing during transcription → dropped at the second guard; failure under an advanced generation → `onError` suppressed. `setPending` balance asserted on every path. Uses a `FileReader` global stub (absent in Node).

## Verification

- `eslint` on `client.ts` + the three new tests → 0 errors, 1 warning (`createVoiceCapture` max-lines, remains by design).
- `tsc -p packages/core/tsconfig.json` and `tsc -p test/tsconfig.json` → clean.
- `tsx --test packages/core/test/whisper/test_*.ts` → 65 pass / 0 fail (46 pre-existing + 19 new), run 3× stable.
- `prettier --check` on all changed files → clean.

## Optional 4th step — not attempted (by design)

Lifting the capture engine into a `createCaptureEngine(...)` child factory would require threading `generation` (mutated by the engine's `start`/`stop`, read by the queue via `getGeneration`) and `segmentGeneration` between the engine and its collaborators, i.e. exactly the state-threading / callback-bag anti-pattern the brief rules out. So it was not attempted; `createVoiceCapture` stays at 115 lines and `packages/core/src/whisper/client.ts` remains in the eslint grandfather list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved voice capture reliability with better handling of live availability checks and transcription flow.
  * Added more consistent state updates for listening and transcribing indicators.

* **Bug Fixes**
  * Prevented outdated transcription results and errors from showing after newer audio segments are processed.
  * Improved behavior when transcription services are unavailable or fail during polling.
  * Ensured empty audio results are handled cleanly without producing transcript text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->