### PR TITLE
chore: split start lifecycle and postInference out of createSidecar

### DIFF
--- a/packages/core/src/whisper/sidecar.ts
+++ b/packages/core/src/whisper/sidecar.ts
@@ -17,7 +17,7 @@ const READY_POLL_INTERVAL_MS = 500;
 const INFERENCE_TIMEOUT_MS = 2 * ONE_MINUTE_MS;
 const STDERR_TAIL_MAX_CHARS = 4_000;
 
-interface ActiveSidecar {
+export interface ActiveSidecar {
   readonly port: number;
   readonly proc: ChildProcess;
   readonly model: WhisperModelName;
@@ -101,7 +101,60 @@ function waitForReadyOrFailure(proc: ChildProcess, port: number): Promise<void> 
   });
 }
 
-export function createSidecar(modelsDir: string, serverBinary = "whisper-server", logger: WhisperLogger = NOOP_LOGGER): Sidecar {
+// POST the wav to whisper-server's `/inference` and return the transcript.
+// Isolated from the lifecycle so the HTTP contract is unit-testable without a
+// live child (stub `fetch`, hand it a real wav path).
+export async function postInference(port: number, wavPath: string, language: string): Promise<string> {
+  const buf = await readFile(wavPath);
+  const form = new FormData();
+  form.append("file", new Blob([buf], { type: "audio/wav" }), "audio.wav");
+  form.append("response_format", "json");
+  form.append("language", language || "auto");
+  let res: Response;
+  try {
+    res = await fetch(`http://${HOST}:${port}/inference`, { method: "POST", body: form, signal: AbortSignal.timeout(INFERENCE_TIMEOUT_MS) });
+  } catch (err) {
+    throw new Error(`whisper-server request failed: ${errorMessage(err)}`);
+  }
+  if (!res.ok) throw new Error(`whisper-server returned HTTP ${res.status}`);
+  return parseInferenceText(await res.json());
+}
+
+export interface SidecarLaunch {
+  readonly proc: ChildProcess;
+  readonly port: number;
+}
+
+// The impure primitives the start lifecycle depends on, injected so the
+// cancellation / single-flight / model-switch logic can be driven with fakes.
+export interface StartLifecycleDeps {
+  /** Spawn the whisper-server child on a free port; resolves before readiness. */
+  spawnServer: (model: WhisperModelName) => Promise<SidecarLaunch>;
+  /** Resolve once the child answers HTTP, or reject on spawn failure / early exit. */
+  waitReady: (proc: ChildProcess, port: number) => Promise<void>;
+  logger: WhisperLogger;
+}
+
+export interface StartLifecycle {
+  ensureSidecar: (model: WhisperModelName) => Promise<ActiveSidecar>;
+  shutdown: () => void;
+}
+
+function defaultSpawnServer(modelsDir: string, serverBinary: string, logger: WhisperLogger): StartLifecycleDeps["spawnServer"] {
+  return async (model: WhisperModelName): Promise<SidecarLaunch> => {
+    const port = await findFreePort();
+    const args = buildServerArgs(modelFilePath(modelsDir, model), HOST, port);
+    logger.info("sidecar: spawning", { model, port });
+    const proc = spawn(serverBinary, args, { stdio: ["ignore", "ignore", "pipe"] });
+    return { proc, port };
+  };
+}
+
+// Owns the single warm child's lifecycle: which model is live, the in-flight
+// start, and the cancellation token. Kept as a factory closure so the mutable
+// state is encapsulated rather than threaded through parameters.
+export function createStartLifecycle(deps: StartLifecycleDeps): StartLifecycle {
+  const { spawnServer, waitReady, logger } = deps;
   let sidecar: ActiveSidecar | null = null;
   let starting: { model: WhisperModelName; promise: Promise<ActiveSidecar> } | null = null;
   // The child of an in-flight start (before it's published as `sidecar`), plus a
@@ -124,10 +177,7 @@ export function createSidecar(modelsDir: string, serverBinary = "whisper-server"
 
   async function startSidecar(model: WhisperModelName): Promise<ActiveSidecar> {
     const token = ++startToken;
-    const port = await findFreePort();
-    const args = buildServerArgs(modelFilePath(modelsDir, model), HOST, port);
-    logger.info("sidecar: spawning", { model, port });
-    const proc = spawn(serverBinary, args, { stdio: ["ignore", "ignore", "pipe"] });
+    const { proc, port } = await spawnServer(model);
     startingProc = proc;
     const stderrTail = { text: "" };
     drainStderr(proc, stderrTail);
@@ -139,7 +189,7 @@ export function createSidecar(modelsDir: string, serverBinary = "whisper-server"
       if (sidecar?.proc === proc) sidecar = null;
     });
     try {
-      await waitForReadyOrFailure(proc, port);
+      await waitReady(proc, port);
     } catch (err) {
       proc.kill();
       throw new Error(`whisper-server failed to start: ${errorMessage(err)} — stderr: ${stderrTail.text.slice(-500)}`);
@@ -184,30 +234,28 @@ export function createSidecar(modelsDir: string, serverBinary = "whisper-server"
     }
   }
 
+  return { ensureSidecar, shutdown };
+}
+
+export function createSidecar(modelsDir: string, serverBinary = "whisper-server", logger: WhisperLogger = NOOP_LOGGER): Sidecar {
+  const lifecycle = createStartLifecycle({
+    spawnServer: defaultSpawnServer(modelsDir, serverBinary, logger),
+    waitReady: waitForReadyOrFailure,
+    logger,
+  });
+
   async function warmup(model: WhisperModelName): Promise<void> {
     try {
-      await ensureSidecar(model);
+      await lifecycle.ensureSidecar(model);
     } catch (err) {
       logger.warn("sidecar: warmup failed", { model, error: errorMessage(err) });
     }
   }
 
   async function transcribeWav(wavPath: string, language: string, model: WhisperModelName): Promise<string> {
-    const active = await ensureSidecar(model);
-    const buf = await readFile(wavPath);
-    const form = new FormData();
-    form.append("file", new Blob([buf], { type: "audio/wav" }), "audio.wav");
-    form.append("response_format", "json");
-    form.append("language", language || "auto");
-    let res: Response;
-    try {
-      res = await fetch(`http://${HOST}:${active.port}/inference`, { method: "POST", body: form, signal: AbortSignal.timeout(INFERENCE_TIMEOUT_MS) });
-    } catch (err) {
-      throw new Error(`whisper-server request failed: ${errorMessage(err)}`);
-    }
-    if (!res.ok) throw new Error(`whisper-server returned HTTP ${res.status}`);
-    return parseInferenceText(await res.json());
+    const active = await lifecycle.ensureSidecar(model);
+    return postInference(active.port, wavPath, language);
   }
 
-  return { transcribeWav, warmup, shutdown };
+  return { transcribeWav, warmup, shutdown: lifecycle.shutdown };
 }

--- a/packages/core/src/whisper/sidecar.ts
+++ b/packages/core/src/whisper/sidecar.ts
@@ -120,16 +120,15 @@ export async function postInference(port: number, wavPath: string, language: str
   return parseInferenceText(await res.json());
 }
 
-export interface SidecarLaunch {
-  readonly proc: ChildProcess;
-  readonly port: number;
-}
-
 // The impure primitives the start lifecycle depends on, injected so the
 // cancellation / single-flight / model-switch logic can be driven with fakes.
 export interface StartLifecycleDeps {
-  /** Spawn the whisper-server child on a free port; resolves before readiness. */
-  spawnServer: (model: WhisperModelName) => Promise<SidecarLaunch>;
+  /** Reserve a free TCP port for the next child — the sole async step of a start. */
+  allocatePort: () => Promise<number>;
+  /** Spawn the whisper-server child on `port`. MUST be synchronous so the spawn
+   *  and the `startingProc` handoff stay in one tick: `shutdown()` has to be able
+   *  to kill an in-flight child immediately, with no await gap after it exists. */
+  spawnServer: (model: WhisperModelName, port: number) => ChildProcess;
   /** Resolve once the child answers HTTP, or reject on spawn failure / early exit. */
   waitReady: (proc: ChildProcess, port: number) => Promise<void>;
   logger: WhisperLogger;
@@ -140,13 +139,11 @@ export interface StartLifecycle {
   shutdown: () => void;
 }
 
-function defaultSpawnServer(modelsDir: string, serverBinary: string, logger: WhisperLogger): StartLifecycleDeps["spawnServer"] {
-  return async (model: WhisperModelName): Promise<SidecarLaunch> => {
-    const port = await findFreePort();
+export function defaultSpawnServer(modelsDir: string, serverBinary: string, logger: WhisperLogger): StartLifecycleDeps["spawnServer"] {
+  return (model: WhisperModelName, port: number): ChildProcess => {
     const args = buildServerArgs(modelFilePath(modelsDir, model), HOST, port);
     logger.info("sidecar: spawning", { model, port });
-    const proc = spawn(serverBinary, args, { stdio: ["ignore", "ignore", "pipe"] });
-    return { proc, port };
+    return spawn(serverBinary, args, { stdio: ["ignore", "ignore", "pipe"] });
   };
 }
 
@@ -154,7 +151,7 @@ function defaultSpawnServer(modelsDir: string, serverBinary: string, logger: Whi
 // start, and the cancellation token. Kept as a factory closure so the mutable
 // state is encapsulated rather than threaded through parameters.
 export function createStartLifecycle(deps: StartLifecycleDeps): StartLifecycle {
-  const { spawnServer, waitReady, logger } = deps;
+  const { allocatePort, spawnServer, waitReady, logger } = deps;
   let sidecar: ActiveSidecar | null = null;
   let starting: { model: WhisperModelName; promise: Promise<ActiveSidecar> } | null = null;
   // The child of an in-flight start (before it's published as `sidecar`), plus a
@@ -177,7 +174,8 @@ export function createStartLifecycle(deps: StartLifecycleDeps): StartLifecycle {
 
   async function startSidecar(model: WhisperModelName): Promise<ActiveSidecar> {
     const token = ++startToken;
-    const { proc, port } = await spawnServer(model);
+    const port = await allocatePort();
+    const proc = spawnServer(model, port);
     startingProc = proc;
     const stderrTail = { text: "" };
     drainStderr(proc, stderrTail);
@@ -239,6 +237,7 @@ export function createStartLifecycle(deps: StartLifecycleDeps): StartLifecycle {
 
 export function createSidecar(modelsDir: string, serverBinary = "whisper-server", logger: WhisperLogger = NOOP_LOGGER): Sidecar {
   const lifecycle = createStartLifecycle({
+    allocatePort: findFreePort,
     spawnServer: defaultSpawnServer(modelsDir, serverBinary, logger),
     waitReady: waitForReadyOrFailure,
     logger,

--- a/packages/core/test/whisper/test_post_inference.ts
+++ b/packages/core/test/whisper/test_post_inference.ts
@@ -1,0 +1,86 @@
+import { describe, it, afterEach, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { postInference } from "../../src/whisper/sidecar.ts";
+
+// `postInference` reads a real wav path and POSTs it, so we hand it a throwaway
+// file and stub `globalThis.fetch` to inspect the request and shape the reply.
+const originalFetch = globalThis.fetch;
+const wavBytes = new Uint8Array([1, 2, 3, 4, 5]);
+let dir: string;
+let wavPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "whisper-post-"));
+  wavPath = path.join(dir, "audio.wav");
+  writeFileSync(wavPath, wavBytes);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("postInference", () => {
+  it("posts the wav as multipart form-data and returns the transcript", async () => {
+    let url = "";
+    let method: string | undefined;
+    let responseFormat: unknown;
+    let language: unknown;
+    let fileType = "";
+    let fileBytes: number[] = [];
+    globalThis.fetch = async (input, init) => {
+      url = String(input);
+      method = init?.method;
+      const form = init?.body;
+      if (form instanceof FormData) {
+        responseFormat = form.get("response_format");
+        language = form.get("language");
+        const file = form.get("file");
+        if (file instanceof Blob) {
+          fileType = file.type;
+          fileBytes = [...new Uint8Array(await file.arrayBuffer())];
+        }
+      }
+      return new Response(JSON.stringify({ text: "hello world" }), { status: 200 });
+    };
+
+    const text = await postInference(8080, wavPath, "ja");
+
+    assert.equal(text, "hello world");
+    assert.equal(url, "http://127.0.0.1:8080/inference");
+    assert.equal(method, "POST");
+    assert.equal(responseFormat, "json");
+    assert.equal(language, "ja");
+    assert.equal(fileType, "audio/wav");
+    assert.deepEqual(fileBytes, [...wavBytes]);
+  });
+
+  it("defaults an empty language to auto", async () => {
+    let language: unknown;
+    globalThis.fetch = async (_input, init) => {
+      const form = init?.body;
+      if (form instanceof FormData) language = form.get("language");
+      return new Response(JSON.stringify({ text: "" }), { status: 200 });
+    };
+
+    await postInference(1234, wavPath, "");
+
+    assert.equal(language, "auto");
+  });
+
+  it("throws a labelled error on a non-ok HTTP status", async () => {
+    globalThis.fetch = async () => new Response("nope", { status: 503 });
+    await assert.rejects(() => postInference(8080, wavPath, ""), /whisper-server returned HTTP 503/);
+  });
+
+  it("wraps a fetch/network failure", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    await assert.rejects(() => postInference(8080, wavPath, ""), /whisper-server request failed: ECONNREFUSED/);
+  });
+});

--- a/packages/core/test/whisper/test_start_lifecycle.ts
+++ b/packages/core/test/whisper/test_start_lifecycle.ts
@@ -1,14 +1,15 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, ChildProcess } from "node:child_process";
 
 import { NOOP_LOGGER } from "../../src/whisper/internal.ts";
-import { createStartLifecycle } from "../../src/whisper/sidecar.ts";
+import { createStartLifecycle, defaultSpawnServer } from "../../src/whisper/sidecar.ts";
 import type { WhisperModelName } from "../../src/whisper/models.ts";
 
-// Drive the lifecycle with a fake `spawnServer` that hands back a REAL but inert
-// child (so `proc` is a genuine ChildProcess — no unsafe cast) and a fake
-// `waitReady` whose readiness we resolve/reject on demand. No sockets, no HTTP.
+// Drive the lifecycle with a fake, SYNCHRONOUS `spawnServer` that hands back a
+// REAL but inert child (so `proc` is a genuine ChildProcess — no unsafe cast)
+// and a fake `waitReady` whose readiness we resolve/reject on demand. Port
+// allocation is the one async step, matching the production seam. No HTTP.
 const INERT_SCRIPT = "setInterval(function () {}, 1e9);";
 const spawned: ChildProcess[] = [];
 
@@ -58,14 +59,14 @@ function makeHarness(): Harness {
   const launches: Launch[] = [];
   const gateByProc = new Map<ChildProcess, ReadyGate>();
   const lifecycle = createStartLifecycle({
-    spawnServer: async (model) => {
+    allocatePort: async () => 40000 + launches.length,
+    spawnServer: (model, port) => {
       spawnCalls.push(model);
       const proc = spawnInert();
       const gate = makeReadyGate();
       gateByProc.set(proc, gate);
-      const port = 40000 + launches.length;
       launches.push({ proc, port, gate });
-      return { proc, port };
+      return proc;
     },
     waitReady: (proc) => gateByProc.get(proc)?.promise ?? Promise.reject(new Error("waitReady for unknown proc")),
     logger: NOOP_LOGGER,
@@ -79,6 +80,7 @@ describe("createStartLifecycle", () => {
 
     const first = harness.lifecycle.ensureSidecar("base");
     const second = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks(); // let the single start reach spawn
     assert.equal(harness.spawnCalls.length, 1);
 
     harness.launches[0].gate.resolve();
@@ -92,6 +94,7 @@ describe("createStartLifecycle", () => {
     const harness = makeHarness();
 
     const pending = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks();
     harness.launches[0].gate.resolve();
     const active = await pending;
     assert.equal(active.proc.killed, false);
@@ -115,6 +118,7 @@ describe("createStartLifecycle", () => {
 
     // A fresh start must spawn a brand-new child, not resurrect the stale one.
     const retry = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks();
     assert.equal(harness.spawnCalls.length, 2);
     harness.launches[1].gate.resolve();
     const active = await retry;
@@ -126,13 +130,15 @@ describe("createStartLifecycle", () => {
     const harness = makeHarness();
 
     const pBase = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks();
     harness.launches[0].gate.resolve();
     const base = await pBase;
     assert.equal(base.model, "base");
     assert.equal(base.proc.killed, false);
 
     const pSmall = harness.lifecycle.ensureSidecar("small");
-    assert.equal(base.proc.killed, true); // switching shut the old child down first
+    assert.equal(base.proc.killed, true); // switching shuts the old child down synchronously
+    await flushMicrotasks();
     assert.equal(harness.spawnCalls.length, 2);
 
     harness.launches[1].gate.resolve();
@@ -153,8 +159,60 @@ describe("createStartLifecycle", () => {
 
     // The failed start left no in-flight `starting` behind — a retry spawns again.
     const retry = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks();
     assert.equal(harness.spawnCalls.length, 2);
     harness.launches[1].gate.resolve();
     assert.equal((await retry).model, "base");
+  });
+
+  // Regression: shutdown must be able to kill a child the instant it is spawned.
+  // The child is only ever exposed to shutdown via `startingProc`, assigned in
+  // the SAME synchronous tick as the (synchronous) spawn — so once port
+  // allocation resolves and the child exists, a shutdown reaches it with no await
+  // gap, rather than the child surviving until waitReady times out.
+  it("shutdown immediately kills a child once it is spawned (spawn/track adjacency)", async () => {
+    let releasePort!: (port: number) => void;
+    const portReady = new Promise<number>((res) => {
+      releasePort = res;
+    });
+    const children: ChildProcess[] = [];
+    const gates: ReadyGate[] = [];
+    const gateByProc = new Map<ChildProcess, ReadyGate>();
+    const lifecycle = createStartLifecycle({
+      allocatePort: () => portReady,
+      spawnServer: () => {
+        const proc = spawnInert();
+        const gate = makeReadyGate();
+        gateByProc.set(proc, gate);
+        gates.push(gate);
+        children.push(proc);
+        return proc;
+      },
+      waitReady: (proc) => gateByProc.get(proc)?.promise ?? Promise.reject(new Error("unknown proc")),
+      logger: NOOP_LOGGER,
+    });
+
+    const pending = lifecycle.ensureSidecar("base");
+    assert.equal(children.length, 0); // still awaiting the port — nothing spawned yet
+
+    releasePort(45000);
+    await flushMicrotasks(); // port resolves → spawn + startingProc handoff, one tick
+
+    assert.equal(children.length, 1);
+    const [child] = children;
+    assert.equal(child.killed, false);
+    lifecycle.shutdown(); // reaches the in-flight child with no await gap
+    assert.equal(child.killed, true);
+
+    gates[0].resolve(); // let waitReady settle so the (now-stale) start reaches its cancellation check
+    await assert.rejects(pending, /whisper-server start cancelled/);
+  });
+
+  it("the default spawnServer is synchronous (keeps spawn adjacent to the startingProc handoff)", () => {
+    const spawnServer = defaultSpawnServer("/tmp/whisper-models", process.execPath, NOOP_LOGGER);
+    const result = spawnServer("base", 45001);
+    spawned.push(result);
+    assert.ok(result instanceof ChildProcess); // a live child, not a Promise
+    assert.equal(typeof result.kill, "function");
   });
 });

--- a/packages/core/test/whisper/test_start_lifecycle.ts
+++ b/packages/core/test/whisper/test_start_lifecycle.ts
@@ -1,0 +1,160 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+
+import { NOOP_LOGGER } from "../../src/whisper/internal.ts";
+import { createStartLifecycle } from "../../src/whisper/sidecar.ts";
+import type { WhisperModelName } from "../../src/whisper/models.ts";
+
+// Drive the lifecycle with a fake `spawnServer` that hands back a REAL but inert
+// child (so `proc` is a genuine ChildProcess — no unsafe cast) and a fake
+// `waitReady` whose readiness we resolve/reject on demand. No sockets, no HTTP.
+const INERT_SCRIPT = "setInterval(function () {}, 1e9);";
+const spawned: ChildProcess[] = [];
+
+function spawnInert(): ChildProcess {
+  const proc = spawn(process.execPath, ["-e", INERT_SCRIPT], { stdio: ["ignore", "ignore", "ignore"] });
+  proc.unref();
+  spawned.push(proc);
+  return proc;
+}
+
+afterEach(() => {
+  spawned.splice(0).forEach((proc) => proc.kill());
+});
+
+const flushMicrotasks = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+interface ReadyGate {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
+}
+
+function makeReadyGate(): ReadyGate {
+  let resolve!: () => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+interface Launch {
+  proc: ChildProcess;
+  port: number;
+  gate: ReadyGate;
+}
+
+interface Harness {
+  lifecycle: ReturnType<typeof createStartLifecycle>;
+  spawnCalls: WhisperModelName[];
+  launches: Launch[];
+}
+
+function makeHarness(): Harness {
+  const spawnCalls: WhisperModelName[] = [];
+  const launches: Launch[] = [];
+  const gateByProc = new Map<ChildProcess, ReadyGate>();
+  const lifecycle = createStartLifecycle({
+    spawnServer: async (model) => {
+      spawnCalls.push(model);
+      const proc = spawnInert();
+      const gate = makeReadyGate();
+      gateByProc.set(proc, gate);
+      const port = 40000 + launches.length;
+      launches.push({ proc, port, gate });
+      return { proc, port };
+    },
+    waitReady: (proc) => gateByProc.get(proc)?.promise ?? Promise.reject(new Error("waitReady for unknown proc")),
+    logger: NOOP_LOGGER,
+  });
+  return { lifecycle, spawnCalls, launches };
+}
+
+describe("createStartLifecycle", () => {
+  it("reuses a single in-flight start for concurrent requests of the same model", async () => {
+    const harness = makeHarness();
+
+    const first = harness.lifecycle.ensureSidecar("base");
+    const second = harness.lifecycle.ensureSidecar("base");
+    assert.equal(harness.spawnCalls.length, 1);
+
+    harness.launches[0].gate.resolve();
+    const [sidecarA, sidecarB] = await Promise.all([first, second]);
+    assert.equal(sidecarA, sidecarB);
+    assert.equal(sidecarA.model, "base");
+    assert.equal(harness.spawnCalls.length, 1);
+  });
+
+  it("shutdown kills the live sidecar", async () => {
+    const harness = makeHarness();
+
+    const pending = harness.lifecycle.ensureSidecar("base");
+    harness.launches[0].gate.resolve();
+    const active = await pending;
+    assert.equal(active.proc.killed, false);
+
+    harness.lifecycle.shutdown();
+    assert.equal(active.proc.killed, true);
+  });
+
+  it("discards a start that finishes after shutdown (no stale publish)", async () => {
+    const harness = makeHarness();
+
+    const pending = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks(); // let the start register its in-flight child
+    const [firstLaunch] = harness.launches;
+
+    harness.lifecycle.shutdown(); // bumps the cancellation token + kills the in-flight child
+    firstLaunch.gate.resolve(); // readiness resolves, but this start is now stale
+
+    await assert.rejects(pending, /whisper-server start cancelled/);
+    assert.equal(firstLaunch.proc.killed, true);
+
+    // A fresh start must spawn a brand-new child, not resurrect the stale one.
+    const retry = harness.lifecycle.ensureSidecar("base");
+    assert.equal(harness.spawnCalls.length, 2);
+    harness.launches[1].gate.resolve();
+    const active = await retry;
+    assert.notEqual(active.proc, firstLaunch.proc);
+    assert.equal(active.proc, harness.launches[1].proc);
+  });
+
+  it("shuts down a live sidecar of a different model before starting the new one", async () => {
+    const harness = makeHarness();
+
+    const pBase = harness.lifecycle.ensureSidecar("base");
+    harness.launches[0].gate.resolve();
+    const base = await pBase;
+    assert.equal(base.model, "base");
+    assert.equal(base.proc.killed, false);
+
+    const pSmall = harness.lifecycle.ensureSidecar("small");
+    assert.equal(base.proc.killed, true); // switching shut the old child down first
+    assert.equal(harness.spawnCalls.length, 2);
+
+    harness.launches[1].gate.resolve();
+    const small = await pSmall;
+    assert.equal(small.model, "small");
+    assert.notEqual(small.proc, base.proc);
+  });
+
+  it("propagates a readiness failure and clears the in-flight start", async () => {
+    const harness = makeHarness();
+
+    const pending = harness.lifecycle.ensureSidecar("base");
+    await flushMicrotasks();
+    harness.launches[0].gate.reject(new Error("boom"));
+
+    await assert.rejects(pending, /whisper-server failed to start: boom/);
+    assert.equal(harness.launches[0].proc.killed, true);
+
+    // The failed start left no in-flight `starting` behind — a retry spawns again.
+    const retry = harness.lifecycle.ensureSidecar("base");
+    assert.equal(harness.spawnCalls.length, 2);
+    harness.launches[1].gate.resolve();
+    assert.equal((await retry).model, "base");
+  });
+});


### PR DESCRIPTION
## Summary

`createSidecar` in `packages/core/src/whisper/sidecar.ts` was a single 90-line factory closure. This splits it into independently unit-testable pieces without changing behavior:

- **`postInference(port, wavPath, language)`** — the HTTP half of `transcribeWav` (read wav, build multipart `FormData`, POST `/inference`, error-wrap, parse). Module-scope, exported.
- **`createStartLifecycle(deps)`** — the warm-child start/state machine. It **owns** all four mutable state vars (`sidecar`, `starting`, `startingProc`, `startToken`) — no state threading — and takes injectable primitives that **default to the real impls**, so production behavior is byte-identical while tests drive it with fakes.
- **`createSidecar`** is now a thin façade wiring the lifecycle + `postInference`.

### The injected seam is two-part, and that is load-bearing

`startSidecar` must keep the original **single-await topology**: exactly one `await` (port allocation), then a *synchronous* spawn-and-publish block, so `spawn()` and the `startingProc = proc` assignment sit in the same tick. If they were separated by an await, a `shutdown()` landing in that microtask window would bump the cancellation token but see `startingProc === null` — unable to kill the just-spawned child, which would then survive until `waitReady` settles (up to `READY_TIMEOUT_MS`, 60s) before the token check finally kills it. That is a shutdown-latency regression, so the seam is split accordingly:

```ts
const token = ++startToken;
const port = await allocatePort();     // the ONLY async step (default: findFreePort)
const proc = spawnServer(model, port); // SYNCHRONOUS (default: buildServerArgs + logger.info + spawn)
startingProc = proc;                   // adjacent to spawn — shutdown can reach an in-flight child immediately
```

`StartLifecycleDeps.spawnServer` is typed `(model, port) => ChildProcess` (not `=> Promise<…>`), so the synchronous contract is enforced at compile time.

### Before / after (counted lines: `max-lines-per-function`, skipBlank+skipComments)

| Function | Before | After |
|---|---|---|
| `createSidecar` | 90 | **19** |
| `postInference` (new) | — | 15 |
| `defaultSpawnServer` (new) | — | 9 |
| `createStartLifecycle` (new) | — | **66** |

## Items to Confirm / Review

- **Behavior is meant to be byte-identical.** The state machine (`shutdown` / `startSidecar` / `beginStart` / `ensureSidecar`) was moved **verbatim** into `createStartLifecycle`; the only change is the two-part seam above (`allocatePort` + synchronous `spawnServer`, both defaulting to the real code). The token capture (`++startToken`) still runs synchronously before the single await, `startingProc = proc` is still adjacent to the spawn, and all `proc.on(error/exit)` / `finally` / cancellation-token semantics are preserved. Every rationale comment (start-cancellation, backstop listener, `no-loop-func`, the `eslint-disable` for the timing-attack false positive) was kept **with the code it guards**.
- **The 50-line target was NOT fully met, by design.** `createStartLifecycle` is 66 lines: its verbatim state machine can't be pulled further apart without threading the owned state through params/callbacks (the anti-pattern), so I stopped there. **`sidecar.ts` therefore stays on the eslint `max-lines-per-function` grandfather list** — the warning relocated from `createSidecar` to `createStartLifecycle` in the same file; it did not clear, so the grandfather entry is left in place. `eslint.config.mjs` is untouched.
- The lifecycle tests spawn a **real but inert** node child (`setInterval(…, 1e9)`) so `proc` is a genuine `ChildProcess` (avoids an unsafe cast); readiness is fully controlled by the fake `waitReady`, and port allocation is the single controllable async step. Each spawned child is `unref()`'d and killed in `afterEach`.

## User Prompt

Bring `createSidecar` under the 50-line `max-lines-per-function` budget with a strictly behavior-preserving split, add unit tests for the newly-testable pieces, and remove `sidecar.ts` from the eslint grandfather list if the warning clears. Priority (mid-task correction): **don't fixate on the 50-line rule — decompose safely.** Do the clearly-safe, testability-improving extractions (`postInference` is the obvious one); attempt the start-lifecycle factory but stop if the boundary feels forced or the cancellation/single-flight semantics get subtle to preserve. Tests are the main deliverable. Only remove the grandfather entry if the warning actually clears and the split is confidently safe; otherwise leave it and say so plainly.

Follow-up correction: the first cut of the lifecycle seam made `spawnServer` async, which reopened a microtask gap between `spawn()` and `startingProc = proc` and weakened the shutdown-kill guarantee. Split the seam into an async `allocatePort` + a synchronous `spawnServer(model, port)` to restore the original single-await topology, add a regression test for the window, and re-verify.

## Tests

`packages/core/test/whisper/`:

- **`test_post_inference.ts`** (4): happy path (asserts URL, `POST`, `response_format`/`language` fields, file blob type+bytes, returned text), empty-language → `"auto"`, non-ok HTTP → `HTTP 503`, network throw → `request failed:`.
- **`test_start_lifecycle.ts`** (7): single-flight reuse (2 concurrent → spawn once, same object), shutdown kills live child, post-shutdown cancellation (start finishing after `shutdown()` rejects `start cancelled`, child killed, retry spawns fresh), model switch (live `base` killed before `small` starts), readiness failure (`failed to start: boom`, child killed, `starting` cleared → retry spawns), **regression: shutdown immediately kills a child once it is spawned** (hand-controlled `allocatePort`; proves spawn↔`startingProc` adjacency — shutdown reaches the in-flight child with no await gap), and **the default `spawnServer` is synchronous** (returns a live `ChildProcess`, not a thenable — the compile-time-enforced invariant the guarantee rests on).

## Verification

- `eslint` on `sidecar.ts` + both test files: **0 errors**, 1 warning (the expected grandfathered `createStartLifecycle` max-lines).
- `tsc -p packages/core/tsconfig.json --noEmit` (the config that type-checks the changed source + new tests): clean.
- `tsx --test packages/core/test/whisper/test_*.ts`: **57 pass / 0 fail** (was 46; +4 `postInference`, +7 `createStartLifecycle`), stable across 3 runs.
- `prettier --check` on all changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Whisper sidecar lifecycle to improve reliability during model switching and rapid start/stop scenarios.
* **Bug Fixes**
  * Improved transcription request handling with more consistent multipart uploads and clearer, labeled errors for non-OK inference responses or network failures.
  * Fixed edge cases where concurrent starts could previously spawn duplicate sidecar processes, and ensured cancelled starts don’t resurrect stale processes.
* **Tests**
  * Added dedicated test coverage for request upload behavior and sidecar start/shutdown lifecycle (including race conditions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->