### PR TITLE
chore: extract handleRelayMessage and createResponseQueue from connectRelay

### DIFF
--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -10,7 +10,15 @@ import type { ChatService } from "@mulmobridge/chat-service";
 import { ONE_SECOND_MS } from "../utils/time.js";
 import { errorMessage } from "../utils/errors.js";
 import { resolveRelayBridgeOptions } from "./resolveRelayBridgeOptions.js";
-import { buildExternalChatId, buildRelayUrl, formatReplyText, isRelayMessage, isTerminalCloseCode, nextReconnectMs } from "./relay-client-helpers.js";
+import {
+  buildExternalChatId,
+  buildRelayUrl,
+  formatReplyText,
+  isRelayMessage,
+  isTerminalCloseCode,
+  nextReconnectMs,
+  type RelayMessage,
+} from "./relay-client-helpers.js";
 
 type RelayFn = ChatService["relay"];
 
@@ -48,6 +56,139 @@ const MIN_RECONNECT_MS = ONE_SECOND_MS;
 const MAX_RECONNECT_MS = 30 * ONE_SECOND_MS;
 const MAX_RESPONSE_QUEUE = 100;
 
+// ── Incoming message handling ────────────────────────────────
+
+interface HandleRelayMessageDeps {
+  relay: RelayFn;
+  logger: Logger;
+  sendResponse: (response: RelayResponse) => void;
+}
+
+function replyTo(msg: RelayMessage, text: string, sendResponse: (response: RelayResponse) => void): void {
+  sendResponse({
+    platform: msg.platform,
+    chatId: msg.chatId,
+    text,
+    replyToken: msg.replyToken,
+  });
+}
+
+// Parse one raw relay frame, forward it to the chat-service relay
+// function, and ship the reply back. Closes over no socket / timer /
+// mutable state, so it is unit-testable in isolation.
+export async function handleRelayMessage(raw: string, deps: HandleRelayMessageDeps): Promise<void> {
+  const { relay, logger, sendResponse } = deps;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    logger.warn(LOG_PREFIX, "invalid JSON from relay", {
+      length: raw.length,
+    });
+    return;
+  }
+
+  if (!isRelayMessage(parsed)) {
+    logger.warn(LOG_PREFIX, "malformed relay message");
+    return;
+  }
+  const msg = parsed;
+
+  logger.info(LOG_PREFIX, "message received", {
+    id: msg.id,
+    platform: msg.platform,
+    chatId: msg.chatId,
+    textLength: msg.text.length,
+  });
+
+  const externalChatId = buildExternalChatId(msg.platform, msg.chatId);
+
+  try {
+    // Per-platform default-role resolution (#739). Mirrors the
+    // bridges-side handshake (#729): each platform can pin its own
+    // default role via `RELAY_<PLATFORM>_DEFAULT_ROLE`, with
+    // `RELAY_DEFAULT_ROLE` as the blanket fallback. The helper
+    // never forwards `RELAY_TOKEN` / `RELAY_URL` — they aren't on
+    // the recognised-keys allowlist.
+    const bridgeOptions = resolveRelayBridgeOptions(msg.platform, process.env);
+    const result = await relay({
+      transportId: TRANSPORT_ID,
+      externalChatId,
+      text: msg.text,
+      bridgeOptions,
+    });
+
+    replyTo(msg, formatReplyText(result), sendResponse);
+  } catch (err) {
+    logger.error(LOG_PREFIX, "relay processing failed", {
+      id: msg.id,
+      error: errorMessage(err),
+    });
+    replyTo(msg, "Error: failed to process message", sendResponse);
+  }
+}
+
+// ── Response queue ───────────────────────────────────────────
+
+interface ResponseQueue {
+  enqueue: (response: RelayResponse) => void;
+  send: (response: RelayResponse) => void;
+  flush: () => void;
+}
+
+interface ResponseQueueDeps {
+  logger: Logger;
+  trySend: (response: RelayResponse) => boolean;
+}
+
+// A bounded FIFO of outgoing responses that owns its own buffer. The
+// live socket stays in the parent; `trySend` is injected as the
+// transport strategy (it returns false when the socket is missing /
+// not OPEN), so the queue never touches the socket directly.
+export function createResponseQueue(deps: ResponseQueueDeps): ResponseQueue {
+  const { logger, trySend } = deps;
+  const responseQueue: RelayResponse[] = [];
+
+  function enqueue(response: RelayResponse): void {
+    if (responseQueue.length >= MAX_RESPONSE_QUEUE) {
+      logger.error(LOG_PREFIX, "response queue full, dropping oldest", {
+        platform: response.platform,
+        chatId: response.chatId,
+      });
+      responseQueue.shift();
+    }
+    responseQueue.push(response);
+  }
+
+  function send(response: RelayResponse): void {
+    if (trySend(response)) return;
+    enqueue(response);
+    logger.error(LOG_PREFIX, "response queued (not connected)", {
+      platform: response.platform,
+      chatId: response.chatId,
+      queueSize: responseQueue.length,
+    });
+  }
+
+  function flush(): void {
+    if (responseQueue.length === 0) return;
+    logger.info(LOG_PREFIX, "flushing response queue", {
+      count: responseQueue.length,
+    });
+    // `trySend` returns false when the socket isn't OPEN, so it alone
+    // gates the drain — stop at the first response we can't send and
+    // leave it (plus the rest) queued for the next flush.
+    while (responseQueue.length > 0) {
+      const [response] = responseQueue;
+      if (!trySend(response)) break;
+      responseQueue.shift();
+    }
+  }
+
+  return { enqueue, send, flush };
+}
+
 // ── Factory ─────────────────────────────────────────────────
 
 export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
@@ -57,7 +198,7 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
   let reconnectMs = MIN_RECONNECT_MS;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
-  const responseQueue: RelayResponse[] = [];
+  const queue = createResponseQueue({ logger, trySend });
 
   function connect(): void {
     if (stopped) return;
@@ -75,11 +216,11 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
     socket.on("open", () => {
       logger.info(LOG_PREFIX, "connected", { url: relayUrl });
       reconnectMs = MIN_RECONNECT_MS;
-      flushResponseQueue();
+      queue.flush();
     });
 
     socket.on("message", (data) => {
-      handleMessage(String(data));
+      handleRelayMessage(String(data), { relay, logger, sendResponse: queue.send });
     });
 
     socket.on("close", (code, reason) => {
@@ -116,80 +257,6 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
     reconnectMs = nextReconnectMs(reconnectMs, MAX_RECONNECT_MS);
   }
 
-  async function handleMessage(raw: string): Promise<void> {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      logger.warn(LOG_PREFIX, "invalid JSON from relay", {
-        length: raw.length,
-      });
-      return;
-    }
-
-    if (!isRelayMessage(parsed)) {
-      logger.warn(LOG_PREFIX, "malformed relay message");
-      return;
-    }
-    const msg = parsed;
-
-    logger.info(LOG_PREFIX, "message received", {
-      id: msg.id,
-      platform: msg.platform,
-      chatId: msg.chatId,
-      textLength: msg.text.length,
-    });
-
-    const externalChatId = buildExternalChatId(msg.platform, msg.chatId);
-
-    try {
-      // Per-platform default-role resolution (#739). Mirrors the
-      // bridges-side handshake (#729): each platform can pin its own
-      // default role via `RELAY_<PLATFORM>_DEFAULT_ROLE`, with
-      // `RELAY_DEFAULT_ROLE` as the blanket fallback. The helper
-      // never forwards `RELAY_TOKEN` / `RELAY_URL` — they aren't on
-      // the recognised-keys allowlist.
-      const bridgeOptions = resolveRelayBridgeOptions(msg.platform, process.env);
-      const result = await relay({
-        transportId: TRANSPORT_ID,
-        externalChatId,
-        text: msg.text,
-        bridgeOptions,
-      });
-
-      const replyText = formatReplyText(result);
-
-      sendResponse({
-        platform: msg.platform,
-        chatId: msg.chatId,
-        text: replyText,
-        replyToken: msg.replyToken,
-      });
-    } catch (err) {
-      logger.error(LOG_PREFIX, "relay processing failed", {
-        id: msg.id,
-        error: errorMessage(err),
-      });
-      sendResponse({
-        platform: msg.platform,
-        chatId: msg.chatId,
-        text: "Error: failed to process message",
-        replyToken: msg.replyToken,
-      });
-    }
-  }
-
-  function enqueueResponse(response: RelayResponse): void {
-    if (responseQueue.length >= MAX_RESPONSE_QUEUE) {
-      logger.error(LOG_PREFIX, "response queue full, dropping oldest", {
-        platform: response.platform,
-        chatId: response.chatId,
-      });
-      responseQueue.shift();
-    }
-    responseQueue.push(response);
-  }
-
   function trySend(response: RelayResponse): boolean {
     if (!socket || socket.readyState !== WebSocket.OPEN) return false;
     try {
@@ -200,35 +267,12 @@ export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
             chatId: response.chatId,
             error: err.message,
           });
-          enqueueResponse(response);
+          queue.enqueue(response);
         }
       });
       return true;
     } catch {
       return false;
-    }
-  }
-
-  function sendResponse(response: RelayResponse): void {
-    if (trySend(response)) return;
-    enqueueResponse(response);
-    logger.error(LOG_PREFIX, "response queued (not connected)", {
-      platform: response.platform,
-      chatId: response.chatId,
-      queueSize: responseQueue.length,
-    });
-  }
-
-  function flushResponseQueue(): void {
-    if (responseQueue.length === 0) return;
-    logger.info(LOG_PREFIX, "flushing response queue", {
-      count: responseQueue.length,
-    });
-    while (responseQueue.length > 0) {
-      if (!socket || socket.readyState !== WebSocket.OPEN) break;
-      const [response] = responseQueue;
-      if (!trySend(response)) break;
-      responseQueue.shift();
     }
   }
 

--- a/test/events/test_relayClient.ts
+++ b/test/events/test_relayClient.ts
@@ -1,0 +1,332 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { ChatService } from "@mulmobridge/chat-service";
+import { createResponseQueue, handleRelayMessage } from "../../server/events/relay-client.js";
+
+type RelayFn = ChatService["relay"];
+type RelayParams = Parameters<RelayFn>[0];
+
+// Structural mirror of the module-private RelayResponse — lets the
+// tests capture/assert responses without widening the public surface.
+interface RelayResponseLike {
+  platform: string;
+  chatId: string;
+  text: string;
+  replyToken?: string;
+}
+
+// Mirror of MAX_RESPONSE_QUEUE in relay-client.ts (kept private there).
+const QUEUE_CAP = 100;
+
+interface LogCall {
+  level: "info" | "warn" | "error";
+  prefix: string;
+  msg: string;
+  data?: Record<string, unknown>;
+}
+
+function createFakeLogger() {
+  const calls: LogCall[] = [];
+  const record =
+    (level: LogCall["level"]) =>
+    (prefix: string, msg: string, data?: Record<string, unknown>): void => {
+      calls.push({ level, prefix, msg, data });
+    };
+  const logger = { info: record("info"), warn: record("warn"), error: record("error") };
+  const findByMsg = (msg: string): LogCall | undefined => calls.find((call) => call.msg === msg);
+  const countByMsg = (msg: string): number => calls.filter((call) => call.msg === msg).length;
+  return { logger, calls, findByMsg, countByMsg };
+}
+
+const validMessage = {
+  id: "msg-1",
+  platform: "line",
+  senderId: "u-1",
+  chatId: "c-1",
+  text: "hello",
+  receivedAt: "2026-07-09T00:00:00Z",
+  replyToken: "tok-1",
+};
+
+const capture = () => {
+  const responses: RelayResponseLike[] = [];
+  const sendResponse = (res: RelayResponseLike): void => {
+    responses.push(res);
+  };
+  return { responses, sendResponse };
+};
+
+describe("handleRelayMessage", () => {
+  it("invalid JSON → warns and calls neither relay nor sendResponse", async () => {
+    const { logger, findByMsg } = createFakeLogger();
+    let relayCalls = 0;
+    const relay: RelayFn = async () => {
+      relayCalls += 1;
+      return { kind: "ok", reply: "x" };
+    };
+    const { responses, sendResponse } = capture();
+
+    await handleRelayMessage("{ not json", { relay, logger, sendResponse });
+
+    assert.equal(relayCalls, 0);
+    assert.equal(responses.length, 0);
+    const warn = findByMsg("invalid JSON from relay");
+    assert.equal(warn?.level, "warn");
+    assert.equal(warn?.data?.length, "{ not json".length);
+  });
+
+  it("malformed message → warns and calls neither relay nor sendResponse", async () => {
+    const { logger, findByMsg } = createFakeLogger();
+    let relayCalls = 0;
+    const relay: RelayFn = async () => {
+      relayCalls += 1;
+      return { kind: "ok", reply: "x" };
+    };
+    const { responses, sendResponse } = capture();
+
+    // Valid JSON but missing required `text` / `chatId`.
+    await handleRelayMessage(JSON.stringify({ id: "x", platform: "line" }), { relay, logger, sendResponse });
+
+    assert.equal(relayCalls, 0);
+    assert.equal(responses.length, 0);
+    assert.equal(findByMsg("malformed relay message")?.level, "warn");
+  });
+
+  it("happy path → forwards to relay and sends the formatted reply", async () => {
+    const { logger } = createFakeLogger();
+    const captured: RelayParams[] = [];
+    const relay: RelayFn = async (params) => {
+      captured.push(params);
+      return { kind: "ok", reply: "pong" };
+    };
+    const { responses, sendResponse } = capture();
+
+    await handleRelayMessage(JSON.stringify(validMessage), { relay, logger, sendResponse });
+
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].transportId, "relay");
+    assert.equal(captured[0].externalChatId, "line__c-1");
+    assert.equal(captured[0].text, "hello");
+    assert.equal(typeof captured[0].bridgeOptions, "object");
+    assert.notEqual(captured[0].bridgeOptions, null);
+
+    assert.deepEqual(responses, [{ platform: "line", chatId: "c-1", text: "pong", replyToken: "tok-1" }]);
+  });
+
+  it("error-kind result → sends the 'Error: <message>' reply", async () => {
+    const { logger } = createFakeLogger();
+    const relay: RelayFn = async () => ({ kind: "error", status: 500, message: "nope" });
+    const { responses, sendResponse } = capture();
+
+    await handleRelayMessage(JSON.stringify(validMessage), { relay, logger, sendResponse });
+
+    assert.equal(responses.length, 1);
+    assert.equal(responses[0].text, "Error: nope");
+    assert.equal(responses[0].replyToken, "tok-1");
+  });
+
+  it("relay throws → sends the fallback error reply and logs the failure", async () => {
+    const { logger, findByMsg } = createFakeLogger();
+    const relay: RelayFn = async () => {
+      throw new Error("boom");
+    };
+    const { responses, sendResponse } = capture();
+
+    await handleRelayMessage(JSON.stringify(validMessage), { relay, logger, sendResponse });
+
+    assert.deepEqual(responses, [{ platform: "line", chatId: "c-1", text: "Error: failed to process message", replyToken: "tok-1" }]);
+    const err = findByMsg("relay processing failed");
+    assert.equal(err?.level, "error");
+    assert.equal(err?.data?.id, "msg-1");
+    assert.match(String(err?.data?.error), /boom/);
+  });
+
+  it("preserves an absent replyToken", async () => {
+    const { logger } = createFakeLogger();
+    const relay: RelayFn = async () => ({ kind: "ok", reply: "pong" });
+    const { responses, sendResponse } = capture();
+    const noToken = { ...validMessage };
+    delete (noToken as { replyToken?: string }).replyToken;
+
+    await handleRelayMessage(JSON.stringify(noToken), { relay, logger, sendResponse });
+
+    assert.equal(responses.length, 1);
+    assert.equal(responses[0].replyToken, undefined);
+  });
+});
+
+const makeResponse = (num: number): RelayResponseLike => ({ platform: "line", chatId: `c-${num}`, text: `t-${num}` });
+
+// A trySend stub whose result is scripted per call. Records every
+// response it was handed, in order.
+function scriptedTrySend(results: boolean[]) {
+  const seen: RelayResponseLike[] = [];
+  let idx = 0;
+  const trySend = (response: RelayResponseLike): boolean => {
+    seen.push(response);
+    const result = idx < results.length ? results[idx] : false;
+    idx += 1;
+    return result;
+  };
+  return { trySend, seen };
+}
+
+// A trySend that always accepts and records what it drained.
+function drainingTrySend() {
+  const delivered: RelayResponseLike[] = [];
+  const trySend = (response: RelayResponseLike): boolean => {
+    delivered.push(response);
+    return true;
+  };
+  return { trySend, delivered };
+}
+
+// A trySend whose transport can be opened/closed at runtime: while
+// closed it rejects (returns false) like a disconnected socket; while
+// open it accepts and records. Models the flush-after-reconnect path.
+function gatedTrySend() {
+  const gate = { open: false };
+  const delivered: RelayResponseLike[] = [];
+  const trySend = (response: RelayResponseLike): boolean => {
+    if (!gate.open) return false;
+    delivered.push(response);
+    return true;
+  };
+  return { trySend, delivered, gate };
+}
+
+describe("createResponseQueue", () => {
+  it("send delivers straight through when trySend returns true", () => {
+    const { logger, calls } = createFakeLogger();
+    const { trySend, delivered } = drainingTrySend();
+    const queue = createResponseQueue({ logger, trySend });
+
+    queue.send(makeResponse(1));
+
+    assert.deepEqual(delivered, [makeResponse(1)]);
+    assert.equal(calls.length, 0);
+
+    // Nothing was queued, so a subsequent flush drains nothing (trySend
+    // is not called again; `delivered` is unchanged).
+    queue.flush();
+    assert.deepEqual(delivered, [makeResponse(1)]);
+  });
+
+  it("send queues and logs the queueSize when trySend returns false", () => {
+    const { logger, findByMsg } = createFakeLogger();
+    const rejecting = scriptedTrySend([false]);
+    const queue = createResponseQueue({ logger, trySend: rejecting.trySend });
+
+    queue.send(makeResponse(1));
+
+    assert.deepEqual(rejecting.seen, [makeResponse(1)]);
+    const log = findByMsg("response queued (not connected)");
+    assert.equal(log?.level, "error");
+    assert.equal(log?.data?.queueSize, 1);
+    assert.equal(log?.data?.chatId, "c-1");
+  });
+
+  it("send then flush drains the queued item once the transport accepts", () => {
+    const { logger } = createFakeLogger();
+    const { trySend, delivered, gate } = gatedTrySend();
+    const queue = createResponseQueue({ logger, trySend });
+
+    queue.send(makeResponse(1));
+    assert.equal(delivered.length, 0);
+
+    gate.open = true;
+    queue.flush();
+    assert.deepEqual(delivered, [makeResponse(1)]);
+  });
+
+  it("enqueue drops the oldest response at the cap", () => {
+    const { logger, findByMsg, countByMsg } = createFakeLogger();
+    const { trySend, delivered } = drainingTrySend();
+    const queue = createResponseQueue({ logger, trySend });
+
+    for (let num = 1; num <= QUEUE_CAP; num += 1) queue.enqueue(makeResponse(num));
+    // The (cap + 1)-th enqueue evicts the oldest (c-1) before pushing.
+    queue.enqueue(makeResponse(QUEUE_CAP + 1));
+
+    assert.equal(countByMsg("response queue full, dropping oldest"), 1);
+    assert.equal(findByMsg("response queue full, dropping oldest")?.data?.chatId, `c-${QUEUE_CAP + 1}`);
+
+    queue.flush();
+    assert.equal(delivered.length, QUEUE_CAP);
+    assert.equal(delivered[0].chatId, "c-2");
+    assert.equal(delivered[QUEUE_CAP - 1].chatId, `c-${QUEUE_CAP + 1}`);
+    assert.ok(!delivered.some((res) => res.chatId === "c-1"));
+  });
+
+  it("flush stops at the first failed trySend and does not try later items", () => {
+    const { logger } = createFakeLogger();
+    // Accept c-1, reject c-2 (and would-be c-3).
+    const first = scriptedTrySend([true, false, false]);
+    const queue = createResponseQueue({ logger, trySend: first.trySend });
+
+    queue.enqueue(makeResponse(1));
+    queue.enqueue(makeResponse(2));
+    queue.enqueue(makeResponse(3));
+
+    queue.flush();
+    // Tried c-1 (ok, shifted) then c-2 (rejected → break). c-3 never tried.
+    assert.deepEqual(
+      first.seen.map((res) => res.chatId),
+      ["c-1", "c-2"],
+    );
+    // Retention + FIFO order of the unsent tail is covered by the
+    // "flush preserves order" test below (needs a re-openable transport).
+  });
+
+  it("flush preserves order of unsent items across successive flushes", () => {
+    const { logger } = createFakeLogger();
+    const { trySend, delivered, gate } = gatedTrySend();
+    const queue = createResponseQueue({ logger, trySend });
+
+    queue.enqueue(makeResponse(1));
+    queue.enqueue(makeResponse(2));
+    queue.enqueue(makeResponse(3));
+
+    // Transport closed: flush sends nothing, loses nothing.
+    queue.flush();
+    assert.equal(delivered.length, 0);
+
+    // Transport open: flush drains everything in FIFO order.
+    gate.open = true;
+    queue.flush();
+    assert.deepEqual(
+      delivered.map((res) => res.chatId),
+      ["c-1", "c-2", "c-3"],
+    );
+  });
+
+  it("flush on an empty queue does nothing", () => {
+    const { logger, calls } = createFakeLogger();
+    let tryCalls = 0;
+    const trySend = (): boolean => {
+      tryCalls += 1;
+      return true;
+    };
+    const queue = createResponseQueue({ logger, trySend });
+
+    queue.flush();
+
+    assert.equal(tryCalls, 0);
+    assert.equal(calls.length, 0);
+  });
+
+  it("send-failure requeue path: enqueue re-adds a response that trySend later drains", () => {
+    // Mirrors what connectRelay's trySend does on an async send error:
+    // it calls queue.enqueue(response). Verify the item is retained and
+    // drains in order on the next flush.
+    const { logger } = createFakeLogger();
+    const { trySend, delivered, gate } = gatedTrySend();
+    const queue = createResponseQueue({ logger, trySend });
+
+    queue.enqueue(makeResponse(1)); // simulated requeue after send failure
+    gate.open = true;
+    queue.flush();
+
+    assert.deepEqual(delivered, [makeResponse(1)]);
+  });
+});


### PR DESCRIPTION
## Summary

`connectRelay` in `server/events/relay-client.ts` was a single 170-line
closure (grandfathered past the 50-line `max-lines-per-function` budget).
This PR pulls the two **clearly-safe, independently-testable** seams out
to module scope and adds real unit tests for them:

- **`handleRelayMessage(raw, deps)`** — parse a relay frame, forward it to
  the chat-service `relay` fn, ship the reply. Closes over **no mutable
  parent state** (only the immutable `logger`/`relay` + a `sendResponse`
  callback), so it moved verbatim and is now unit-testable directly. A
  small private `replyTo()` helper DRYs its two `sendResponse` sites.
- **`createResponseQueue({ logger, trySend })`** — a bounded FIFO that
  **owns its own buffer** and exposes `enqueue` / `send` / `flush`. The
  live socket stays in the parent; `trySend` is injected as the transport
  strategy (it returns `false` when the socket is missing / not `OPEN`),
  so the queue never touches the socket.

The WebSocket **reconnect/backoff lifecycle** (`connect`,
`scheduleReconnect`, `trySend`, `disconnect`) is deliberately **left in
`connectRelay`** — see "Items to Confirm" below.

`connectRelay` drops from **170 → 89** counted lines but stays over the
50-line budget, so its eslint grandfather entry is **kept** (not removed).

## Items to Confirm / Review

1. **Scope decision — the socket lifecycle was NOT extracted.** A
   byte-identical `createReconnectingSocket` extraction required several
   subtle transformations at once (splitting the `stopped` guard,
   restructuring the backoff timer, splitting the `err && !stopped`
   send-callback check). Rather than risk the reconnect/terminal-close
   semantics, the socket lifecycle stays where it is. Because of that,
   the `max-lines-per-function` **warning on `connectRelay` remains** and
   `server/events/relay-client.ts` **stays in the grandfather list** in
   `eslint.config.mjs`. This is intentional.
2. **One behavior-relevant change to verify:** `flush()` no longer has its
   own `if (!socket || socket.readyState !== WebSocket.OPEN) break;`
   pre-check. It now relies on the injected `trySend` returning `false`
   in exactly those cases (the parent's `trySend` starts with that same
   guard and has no side effect when it returns false). Reading
   `responseQueue[0]` before calling `trySend` has no side effect, so the
   drain outcome is identical. Please sanity-check this reasoning.
3. Everything else in `connectRelay` (connect, scheduleReconnect, trySend
   body, disconnect, the `#729`/`#739` role-resolution comment) is
   byte-identical; only three call sites were swapped
   (`flushResponseQueue()` -> `queue.flush()`, `handleMessage(...)` ->
   `handleRelayMessage(..., { relay, logger, sendResponse: queue.send })`,
   `enqueueResponse(response)` -> `queue.enqueue(response)`).

## Before / After (counted lines, `{ max: 50, skipBlankLines, skipComments }`)

| Function | Before | After | Where |
|---|---|---|---|
| `connectRelay` | 170 (warn) | 89 (warn, grandfathered) | same file |
| `handleRelayMessage` | — (was inside `connectRelay`) | ~39 | module scope, exported |
| `createResponseQueue` | — (was `enqueueResponse` + `sendResponse` + `flushResponseQueue` inside `connectRelay`) | ~32 | module scope, exported |
| `replyTo` | — | ~3 | module scope, private |

No function in either changed file exceeds 50 except `connectRelay`,
which keeps its (pre-existing) grandfather warning. **0 eslint errors.**

## Tests

New `test/events/test_relayClient.ts` (14 tests, `node:test` +
`node:assert/strict`, fake logger/relay, no network/socket):

- `handleRelayMessage`: invalid JSON -> warn + no relay/sendResponse;
  malformed message -> warn + no relay/sendResponse; happy path ->
  `relay()` called with `{ transportId, externalChatId, text,
  bridgeOptions }` and reply sent with `formatReplyText(result)` +
  preserved `replyToken`; error-kind result -> `Error: <message>`;
  `relay()` throw -> `Error: failed to process message` + logged; absent
  `replyToken` preserved.
- `createResponseQueue`: send-through when `trySend` true; queue + log
  `queueSize` when false; drop-oldest at the cap (oldest evicted, log
  fires once); flush stops at the first failed `trySend` without trying
  later items; FIFO order preserved across successive flushes; empty
  flush is a no-op; requeue path (`enqueue` re-adds and later drains).

Verification (parent binaries, worktree copy):
- `eslint` on both files: **0 errors**, 1 grandfather warning on
  `connectRelay` (expected).
- `tsc -p server/tsconfig.json` and `tsc -p test/tsconfig.json`: clean.
- `tsx --test test/events/test_relayClient.ts`: **14/14 pass**, run 3x.
- Full `test/events`: **114/114 pass**. `prettier --check`: clean.

## Not covered (by design)

The send-failure-requeue path in `connectRelay.trySend` (async
`socket.send` callback -> `if (err && !stopped)` -> log + `queue.enqueue`)
still lives in `connectRelay` because the socket lifecycle was not
extracted, so it is not unit-tested at the seam. Its `enqueue` half is
exercised via the queue's requeue test.

## User Prompt

Bring `connectRelay` (170 lines) under the `max-lines-per-function`
budget with a strictly behavior-preserving split into testable child
units, add tests targeting the new seams, and remove the file from the
eslint grandfather list if the warning clears.

Follow-up priority change: **don't fixate on the 50-line rule —
decompose safely.** Safety and behavior-preservation outrank the lint
number. Do the extractions that are clearly safe and improve testability:
`handleRelayMessage` (no mutable parent state) and `createResponseQueue`
(owns its buffer) first. Attempt the reconnecting-socket extraction only
if confident it is byte-identical; if the boundary feels forced, stop and
leave the socket lifecycle in place. Only remove the grandfather entry if
the warning actually clears and every extraction is safe — otherwise
leave it and say so. The tests are the main deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
