### PR TITLE
refactor(whisper,relay): shrink two lifecycle factories under 50 lines

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -483,7 +483,7 @@ export default [
   // its entry; when the list is empty, delete this block. Do NOT add
   // new files — a new over-budget function must be split, not listed.
   {
-    files: ["packages/core/src/whisper/client.ts", "packages/core/src/whisper/sidecar.ts", "server/events/relay-client.ts"],
+    files: ["packages/core/src/whisper/client.ts"],
     rules: {
       "max-lines-per-function": ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],
     },

--- a/packages/core/src/whisper/sidecar.ts
+++ b/packages/core/src/whisper/sidecar.ts
@@ -147,6 +147,45 @@ export function defaultSpawnServer(modelsDir: string, serverBinary: string, logg
   };
 }
 
+// Wires the three listeners every whisper-server child needs: stderr drain,
+// permanent `error` handler (an unhandled 'error' from ENOENT etc. would crash
+// the host), and `exit` handler that both logs and lets the caller decide
+// whether this proc is still the active one (identity check via `onExit` — a
+// stale process must not evict a newer live sidecar).
+function instrumentChildProcess(proc: ChildProcess, model: WhisperModelName, logger: WhisperLogger, onExit: (exited: ChildProcess) => void): { text: string } {
+  const stderrTail = { text: "" };
+  drainStderr(proc, stderrTail);
+  proc.on("error", (err) => logger.warn("sidecar: process error", { model, error: errorMessage(err) }));
+  proc.on("exit", (code) => {
+    logger.warn("sidecar: exited", { model, code, stderrTail: stderrTail.text.slice(-500) });
+    onExit(proc);
+  });
+  return stderrTail;
+}
+
+// Await server readiness; on failure, kill the child and surface both the
+// underlying error and the tail of stderr (whisper-server usually explains its
+// crash there). Kept at module scope so `startSidecar` stays under the
+// per-function line cap.
+async function awaitReadyOrThrow(proc: ChildProcess, port: number, stderrTail: { text: string }, waitReady: StartLifecycleDeps["waitReady"]): Promise<void> {
+  try {
+    await waitReady(proc, port);
+  } catch (err) {
+    proc.kill();
+    throw new Error(`whisper-server failed to start: ${errorMessage(err)} — stderr: ${stderrTail.text.slice(-500)}`);
+  }
+}
+
+// Abort a start that was raced by `shutdown()` (or a newer start). Compares
+// the token captured at start entry against the current token; if they differ,
+// kill the freshly-booted child rather than publish it after shutdown returned.
+function throwIfStartCancelled(startedToken: number, currentToken: number, proc: ChildProcess): void {
+  if (startedToken !== currentToken) {
+    proc.kill();
+    throw new Error("whisper-server start cancelled");
+  }
+}
+
 // Owns the single warm child's lifecycle: which model is live, the in-flight
 // start, and the cancellation token. Kept as a factory closure so the mutable
 // state is encapsulated rather than threaded through parameters.
@@ -162,14 +201,10 @@ export function createStartLifecycle(deps: StartLifecycleDeps): StartLifecycle {
 
   function shutdown(): void {
     startToken += 1;
-    if (startingProc) {
-      startingProc.kill();
-      startingProc = null;
-    }
-    if (sidecar) {
-      sidecar.proc.kill();
-      sidecar = null;
-    }
+    startingProc?.kill();
+    startingProc = null;
+    sidecar?.proc.kill();
+    sidecar = null;
   }
 
   async function startSidecar(model: WhisperModelName): Promise<ActiveSidecar> {
@@ -177,41 +212,23 @@ export function createStartLifecycle(deps: StartLifecycleDeps): StartLifecycle {
     const port = await allocatePort();
     const proc = spawnServer(model, port);
     startingProc = proc;
-    const stderrTail = { text: "" };
-    drainStderr(proc, stderrTail);
-    // Permanent error listener — a missing one would let a process 'error'
-    // (e.g. ENOENT) throw uncaught and crash the host.
-    proc.on("error", (err) => logger.warn("sidecar: process error", { model, error: errorMessage(err) }));
-    proc.on("exit", (code) => {
-      logger.warn("sidecar: exited", { model, code, stderrTail: stderrTail.text.slice(-500) });
-      if (sidecar?.proc === proc) sidecar = null;
-    });
+    // onExit fires when THIS proc exits: only null out `sidecar` if it's still the live one.
+    const stderrTail = instrumentChildProcess(proc, model, logger, (exited) => sidecar?.proc === exited && (sidecar = null));
     try {
-      await waitReady(proc, port);
-    } catch (err) {
-      proc.kill();
-      throw new Error(`whisper-server failed to start: ${errorMessage(err)} — stderr: ${stderrTail.text.slice(-500)}`);
+      await awaitReadyOrThrow(proc, port, stderrTail, waitReady);
     } finally {
       if (startingProc === proc) startingProc = null;
     }
-    // shutdown() (or a newer start) ran while we were booting — discard this
-    // child instead of publishing a sidecar after shutdown returned.
-    // eslint-disable-next-line security/detect-possible-timing-attacks -- in-memory start-cancellation token, not an auth compare
-    if (token !== startToken) {
-      proc.kill();
-      throw new Error("whisper-server start cancelled");
-    }
+    throwIfStartCancelled(token, startToken, proc);
     sidecar = { port, proc, model };
     logger.info("sidecar: ready", { model, port });
     return sidecar;
   }
 
-  // Module-scoped spawn so it isn't a loop closure (no-loop-func). Only ever one
-  // start is in flight at a time, so clearing `starting` on settle is safe.
+  // Own function so it isn't a loop closure (no-loop-func). Only ever one start
+  // is in flight at a time, so clearing `starting` on settle is safe.
   function beginStart(model: WhisperModelName): Promise<ActiveSidecar> {
-    const promise = startSidecar(model).finally(() => {
-      starting = null;
-    });
+    const promise = startSidecar(model).finally(() => (starting = null));
     starting = { model, promise };
     return promise;
   }

--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -189,108 +189,148 @@ export function createResponseQueue(deps: ResponseQueueDeps): ResponseQueue {
   return { enqueue, send, flush };
 }
 
+// ── Socket wiring ───────────────────────────────────────────
+
+// Mutable state shared across the factory's helpers. Kept as a single object
+// so the module-scope helpers can be typed against one shape rather than
+// threading each field through their signatures.
+export interface RelayState {
+  socket: WebSocket | null;
+  reconnectMs: number;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  stopped: boolean;
+}
+
+// Try to write `response` over the live socket. Returns false when there is
+// no socket or it isn't OPEN (caller queues instead). On a write error the
+// callback re-enqueues via `onEnqueue`; a synchronous throw (rare, e.g. socket
+// already CLOSED between the OPEN check and .send) is caught and reported as
+// "not sent" so the caller can queue.
+export function attemptSocketSend(state: RelayState, response: RelayResponse, logger: Logger, onEnqueue: () => void): boolean {
+  const live = state.socket;
+  if (!live || live.readyState !== WebSocket.OPEN) return false;
+  try {
+    live.send(JSON.stringify(response), (err) => {
+      if (err && !state.stopped) {
+        logger.warn(LOG_PREFIX, "send failed, requeueing", { platform: response.platform, chatId: response.chatId, error: err.message });
+        onEnqueue();
+      }
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Arm the exponential-backoff reconnect timer. No-op after `stopRelay` set
+// `stopped` — otherwise a fire-in-flight timer would resurrect the socket
+// after a manual disconnect.
+function scheduleReconnectStep(state: RelayState, logger: Logger, connect: () => void): void {
+  if (state.stopped) return;
+  logger.info(LOG_PREFIX, "reconnecting", { delayMs: state.reconnectMs });
+  state.reconnectTimer = setTimeout(() => {
+    state.reconnectTimer = null;
+    connect();
+  }, state.reconnectMs);
+  state.reconnectMs = nextReconnectMs(state.reconnectMs, MAX_RECONNECT_MS);
+}
+
+// Manual shutdown. `stopped = true` MUST happen before `socket.close()` — the
+// close event will still fire, and without the guard the close handler would
+// schedule a reconnect after we asked to stop.
+export function stopRelay(state: RelayState, logger: Logger): void {
+  state.stopped = true;
+  if (state.reconnectTimer) {
+    clearTimeout(state.reconnectTimer);
+    state.reconnectTimer = null;
+  }
+  if (state.socket) {
+    state.socket.close(1000, "shutdown");
+    state.socket = null;
+  }
+  logger.info(LOG_PREFIX, "stopped");
+}
+
+interface AttachSocketHandlersDeps {
+  relayUrl: string;
+  logger: Logger;
+  relay: RelayFn;
+  queue: ResponseQueue;
+  onOpen: () => void;
+  onCloseAny: () => void;
+  onCloseTransient: () => void;
+}
+
+// Attaches open / message / close / error listeners to a live socket. The
+// close handler branches by `isTerminalCloseCode`; the caller supplies
+// `onCloseAny` (always fires — used to null the parent's `socket` ref) and
+// `onCloseTransient` (fires only on a non-terminal close — used to schedule
+// reconnect). Kept at module scope so `connectRelay` stays under the
+// per-function line cap.
+function attachSocketHandlers(socket: WebSocket, deps: AttachSocketHandlersDeps): void {
+  const { relayUrl, logger, relay, queue, onOpen, onCloseAny, onCloseTransient } = deps;
+
+  socket.on("open", () => {
+    logger.info(LOG_PREFIX, "connected", { url: relayUrl });
+    onOpen();
+    queue.flush();
+  });
+
+  socket.on("message", (data) => {
+    handleRelayMessage(String(data), { relay, logger, sendResponse: queue.send });
+  });
+
+  socket.on("close", (code, reason) => {
+    onCloseAny();
+    if (isTerminalCloseCode(code)) {
+      logger.error(LOG_PREFIX, "terminal close, not reconnecting", { code, reason: String(reason) });
+      return;
+    }
+    logger.info(LOG_PREFIX, "disconnected", { code, reason: String(reason) });
+    onCloseTransient();
+  });
+
+  socket.on("error", (err) => {
+    logger.warn(LOG_PREFIX, "connection error", { error: err.message });
+    // close event will follow, triggering reconnect
+  });
+}
+
 // ── Factory ─────────────────────────────────────────────────
 
 export function connectRelay(deps: RelayClientDeps): RelayClientHandle {
   const { relayUrl, relayToken, relay, logger } = deps;
-
-  let socket: WebSocket | null = null;
-  let reconnectMs = MIN_RECONNECT_MS;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  let stopped = false;
-  const queue = createResponseQueue({ logger, trySend });
-
+  const state: RelayState = { socket: null, reconnectMs: MIN_RECONNECT_MS, reconnectTimer: null, stopped: false };
+  const queue = createResponseQueue({
+    logger,
+    trySend: (response) => attemptSocketSend(state, response, logger, () => queue.enqueue(response)),
+  });
+  function scheduleReconnect(): void {
+    scheduleReconnectStep(state, logger, connect);
+  }
   function connect(): void {
-    if (stopped) return;
-
+    if (state.stopped) return;
     try {
-      socket = new WebSocket(buildRelayUrl(relayUrl, relayToken));
+      state.socket = new WebSocket(buildRelayUrl(relayUrl, relayToken));
     } catch (err) {
-      logger.error(LOG_PREFIX, "failed to create WebSocket", {
-        error: errorMessage(err),
-      });
+      logger.error(LOG_PREFIX, "failed to create WebSocket", { error: errorMessage(err) });
       scheduleReconnect();
       return;
     }
-
-    socket.on("open", () => {
-      logger.info(LOG_PREFIX, "connected", { url: relayUrl });
-      reconnectMs = MIN_RECONNECT_MS;
-      queue.flush();
-    });
-
-    socket.on("message", (data) => {
-      handleRelayMessage(String(data), { relay, logger, sendResponse: queue.send });
-    });
-
-    socket.on("close", (code, reason) => {
-      socket = null;
-      if (isTerminalCloseCode(code)) {
-        logger.error(LOG_PREFIX, "terminal close, not reconnecting", {
-          code,
-          reason: String(reason),
-        });
-        return;
-      }
-      logger.info(LOG_PREFIX, "disconnected", {
-        code,
-        reason: String(reason),
-      });
-      scheduleReconnect();
-    });
-
-    socket.on("error", (err) => {
-      logger.warn(LOG_PREFIX, "connection error", {
-        error: err.message,
-      });
-      // close event will follow, triggering reconnect
+    attachSocketHandlers(state.socket, {
+      relayUrl,
+      logger,
+      relay,
+      queue,
+      onOpen: () => {
+        state.reconnectMs = MIN_RECONNECT_MS;
+      },
+      onCloseAny: () => {
+        state.socket = null;
+      },
+      onCloseTransient: scheduleReconnect,
     });
   }
-
-  function scheduleReconnect(): void {
-    if (stopped) return;
-    logger.info(LOG_PREFIX, "reconnecting", { delayMs: reconnectMs });
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      connect();
-    }, reconnectMs);
-    reconnectMs = nextReconnectMs(reconnectMs, MAX_RECONNECT_MS);
-  }
-
-  function trySend(response: RelayResponse): boolean {
-    if (!socket || socket.readyState !== WebSocket.OPEN) return false;
-    try {
-      socket.send(JSON.stringify(response), (err) => {
-        if (err && !stopped) {
-          logger.warn(LOG_PREFIX, "send failed, requeueing", {
-            platform: response.platform,
-            chatId: response.chatId,
-            error: err.message,
-          });
-          queue.enqueue(response);
-        }
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  function disconnect(): void {
-    stopped = true;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
-    if (socket) {
-      socket.close(1000, "shutdown");
-      socket = null;
-    }
-    logger.info(LOG_PREFIX, "stopped");
-  }
-
-  // Start immediately
   connect();
-
-  return { disconnect };
+  return { disconnect: () => stopRelay(state, logger) };
 }

--- a/test/events/test_relayClient.ts
+++ b/test/events/test_relayClient.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { ChatService } from "@mulmobridge/chat-service";
-import { createResponseQueue, handleRelayMessage } from "../../server/events/relay-client.js";
+import { attemptSocketSend, createResponseQueue, handleRelayMessage, stopRelay, type RelayState } from "../../server/events/relay-client.js";
 
 type RelayFn = ChatService["relay"];
 type RelayParams = Parameters<RelayFn>[0];
@@ -328,5 +328,153 @@ describe("createResponseQueue", () => {
     queue.flush();
 
     assert.deepEqual(delivered, [makeResponse(1)]);
+  });
+});
+
+// ── attemptSocketSend / stopRelay direct tests ───────────────
+
+interface FakeSocket {
+  readyState: number;
+  send: (payload: string, callback: (err: Error | undefined) => void) => void;
+  close: (code?: number, reason?: string) => void;
+  sent: string[];
+  closed: { code?: number; reason?: string }[];
+}
+
+// WebSocket.OPEN is 1 per the RFC 6455 spec and the `ws` npm package.
+const OPEN = 1;
+
+function makeFakeSocket(overrides: Partial<FakeSocket> = {}): FakeSocket {
+  const socket: FakeSocket = {
+    readyState: OPEN,
+    sent: [],
+    closed: [],
+    send: (payload, callback) => {
+      socket.sent.push(payload);
+      callback(undefined);
+    },
+    close: (code, reason) => {
+      socket.closed.push({ code, reason });
+    },
+    ...overrides,
+  };
+  return socket;
+}
+
+function makeResp(seq: number): { platform: string; chatId: string; text: string } {
+  return { platform: "line", chatId: `c-${seq}`, text: `body-${seq}` };
+}
+
+describe("attemptSocketSend", () => {
+  it("returns false and does not send when state.socket is null (queue-instead path)", () => {
+    const { logger } = createFakeLogger();
+    const state: RelayState = { socket: null, reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    let enqueued = 0;
+    const result = attemptSocketSend(state, makeResp(1), logger, () => {
+      enqueued += 1;
+    });
+    assert.equal(result, false);
+    assert.equal(enqueued, 0);
+  });
+
+  it("returns false when the socket exists but readyState is not OPEN", () => {
+    const { logger } = createFakeLogger();
+    const socket = makeFakeSocket({ readyState: 0 }); // CONNECTING
+    const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    const result = attemptSocketSend(state, makeResp(1), logger, () => {});
+    assert.equal(result, false);
+    assert.equal(socket.sent.length, 0);
+  });
+
+  it("returns true and writes the JSON payload when the socket is OPEN", () => {
+    const { logger } = createFakeLogger();
+    const socket = makeFakeSocket();
+    const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    const result = attemptSocketSend(state, makeResp(7), logger, () => {});
+    assert.equal(result, true);
+    assert.deepEqual(JSON.parse(socket.sent[0]), makeResp(7));
+  });
+
+  it("re-enqueues via onEnqueue when the async send callback reports an error and state.stopped is false", () => {
+    const { logger, findByMsg } = createFakeLogger();
+    const socket = makeFakeSocket({
+      send: (_payload, callback) => callback(new Error("write EPIPE")),
+    });
+    const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    let enqueued = 0;
+    attemptSocketSend(state, makeResp(1), logger, () => {
+      enqueued += 1;
+    });
+    assert.equal(enqueued, 1);
+    assert.equal(findByMsg("send failed, requeueing")?.level, "warn");
+  });
+
+  it("does NOT re-enqueue when the async send error fires after state.stopped flipped true (shutting-down race)", () => {
+    // Fixes the corner case where a disconnect interleaves with an in-flight
+    // send; re-adding to the queue after stopRelay would just leak entries.
+    const { logger } = createFakeLogger();
+    const socket = makeFakeSocket({
+      send: (_payload, callback) => callback(new Error("closing")),
+    });
+    const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: null, stopped: true };
+    let enqueued = 0;
+    attemptSocketSend(state, makeResp(1), logger, () => {
+      enqueued += 1;
+    });
+    assert.equal(enqueued, 0);
+  });
+
+  it("returns false when socket.send synchronously throws (e.g. socket already closed)", () => {
+    const { logger } = createFakeLogger();
+    const socket = makeFakeSocket({
+      send: () => {
+        throw new Error("socket closed");
+      },
+    });
+    const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    const result = attemptSocketSend(state, makeResp(1), logger, () => {});
+    assert.equal(result, false);
+  });
+});
+
+describe("stopRelay", () => {
+  it("flips stopped, clears the timer, closes the socket with code 1000, and logs 'stopped'", () => {
+    const { logger, findByMsg } = createFakeLogger();
+    const socket = makeFakeSocket();
+    const timer = setTimeout(() => {}, 999_999);
+    const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: timer, stopped: false };
+    stopRelay(state, logger);
+    assert.equal(state.stopped, true);
+    assert.equal(state.reconnectTimer, null);
+    assert.equal(state.socket, null);
+    assert.deepEqual(socket.closed[0], { code: 1000, reason: "shutdown" });
+    assert.equal(findByMsg("stopped")?.level, "info");
+  });
+
+  it("is a no-op-except-logging when nothing is armed (state already stopped-like)", () => {
+    // Guards the reverse-of-happy-path: a caller that shuts down before
+    // the first connect() must not throw on the null socket / null timer.
+    const { logger, findByMsg } = createFakeLogger();
+    const state: RelayState = { socket: null, reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    stopRelay(state, logger);
+    assert.equal(state.stopped, true);
+    assert.equal(findByMsg("stopped")?.level, "info");
+  });
+
+  it("guarantees stopped is set BEFORE any close side-effect, so a close-event-driven reconnect is guarded", () => {
+    // Simulates the ordering the WebSocket spec forces on us: `close()`
+    // schedules the close event. If a caller queried state.stopped inside
+    // that handler, it must already read true.
+    const { logger } = createFakeLogger();
+    let stoppedAtCloseTime: boolean | null = null;
+    const state: RelayState = { socket: null, reconnectMs: 1000, reconnectTimer: null, stopped: false };
+    const socket = makeFakeSocket({
+      close: () => {
+        stoppedAtCloseTime = state.stopped;
+      },
+    });
+    state.socket = socket as unknown as RelayState["socket"];
+    stopRelay(state, logger);
+    assert.equal(stoppedAtCloseTime, true, "stopped must be true by the time socket.close() runs");
   });
 });


### PR DESCRIPTION
## Summary

- Batch 2 of the `max-lines-per-function` lint cleanup: drops `createStartLifecycle` (whisper sidecar) from 66 → 50 effective lines and `connectRelay` (relay client) from 92 → ~30 by extracting narrow module-scope helpers.
- Two functions worth of warnings removed (40 → 38). The remaining offender (`packages/core/src/whisper/client.ts` `createVoiceCapture`) is intentionally deferred — its extraction seam needs redesign work per codex's up-front review, so a separate batch will handle it.
- Adds 8 direct unit tests over the two most logic-heavy extracted helpers (`attemptSocketSend`, `stopRelay`) that lock in the load-bearing invariants the refactor preserved.

## Items to Confirm / Review

- **Semantic equivalence is the load-bearing claim here** — both files' entire branch matrices were walked against the originals: initial connect, WebSocket ctor throw, terminal vs non-terminal close, send-callback error with vs without `stopped`, disconnect ordering (`stopped=true` **before** `socket.close()` is preserved), sidecar shutdown races (token bump before `startingProc?.kill()`), `waitReady` throw path (proc killed once, error message still carries the stderr tail), cancellation between `waitReady` resolve and publish, and exit-handler identity guard when a newer start replaced an older sidecar. The trace was independently re-run by codex (`VERDICT: NO ISSUES`).
- Design constraint I deliberately picked and want a second look at: the extracted helpers live at **module scope** (not nested), because a nested named helper counts toward the enclosing function's line total under `max-lines-per-function`. The state-object pattern (`RelayState`) is the price of that — it's used in relay-client but not sidecar (sidecar's mutable state stays closed-over because the two extracted helpers can accept value parameters).
- One aggressive one-liner in `sidecar.ts` startSidecar: the exit-handler arrow `(exited) => sidecar?.proc === exited && (sidecar = null)` uses short-circuit `&&` with an assignment expression. Semantically equivalent to the original inline `if (sidecar?.proc === exited) sidecar = null;` but denser. Comment added above.
- Whisper client deferred: `createVoiceCapture` at 115 lines is too broad to split with the current sub-factory shape. Codex's pre-refactor review recommended re-thinking the seam before touching it. I'm treating that as a separate PR rather than pushing an over-broad extraction here.

## Files touched

- **`server/events/relay-client.ts`** — introduce `RelayState`; extract `attachSocketHandlers`, `attemptSocketSend`, `scheduleReconnectStep`, `stopRelay` to module scope. `connectRelay` becomes a thin coordinator.
- **`packages/core/src/whisper/sidecar.ts`** — extract `instrumentChildProcess`, `awaitReadyOrThrow`, `throwIfStartCancelled` to module scope. Compact `shutdown` with optional-chain kills. `startSidecar`, `beginStart`, `ensureSidecar` stay as closures.
- **`test/events/test_relayClient.ts`** — 8 new tests over `attemptSocketSend` (5) and `stopRelay` (3), covering the guard invariants that are hardest to see from the code alone.

## Test plan

- [x] `yarn format` clean
- [x] `yarn lint` — 0 errors; only pre-existing whisper/client.ts warning remains
- [x] `yarn typecheck` clean across all workspaces
- [x] `yarn test` — 5611 / 5611 pass
- [x] Full-suite semantic-equivalence walk (self + codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting the whisper sidecar, with better handling for readiness failures, cancellations, and recent error output.
  * Made relay WebSocket connections more resilient by tightening message sending, reconnect scheduling, and shutdown behavior to reduce stuck or duplicated states.
* **Tests**
  * Expanded automated coverage for relay message sending, queuing, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->