### PR TITLE
fix: resolve the `handlePermission not found` MCP family (#2052, #2056, #2057)

### DIFF
--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -88,6 +88,13 @@ jobs:
       - name: Build @mulmoclaude/x-plugin (probe imports its built ESM entry)
         run: yarn workspace @mulmoclaude/x-plugin run build
 
+      # The #2052 end-to-end step boots the real mcp-server.ts, which imports
+      # @mulmoclaude/core, @mulmobridge/protocol, @mulmobridge/client and the
+      # preset plugins through their built `dist/`. Production ships built dist;
+      # this repro must too.
+      - name: Build every workspace package (the e2e MCP child imports their dist)
+        run: yarn build:packages:dev
+
       # windows-latest ships Docker CLI + a Windows-only engine, no Docker
       # Desktop. Docker Desktop in CI needs UI dialogs on first launch and
       # is flake-prone. Instead we use the preinstalled WSL2 with Ubuntu +
@@ -241,6 +248,49 @@ jobs:
             -w /app `
             node:22-slim `
             bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /app/server/agent/diagnose-2052.ts"
+
+      # ── #2052 end-to-end: the real MCP child, the shipped mounts ──────
+      # The regression this closes: `workspacePackageDirs()` only listed
+      # `@mulmoclaude/*`, so `@mulmobridge/protocol` (reached via
+      # src/types/events.ts) had no /app/pkg_modules fallback. Its junction
+      # dangled inside the container and mcp-server.ts died at load — every
+      # tool, `handlePermission` included, vanished from the agent registry.
+      #
+      # Mounts / env / argv come from the SHIPPED builders via
+      # print-mcp-container-spec.ts, so this can never drift the way the
+      # hardcoded smoke test did.
+      - name: "#2052 — end-to-end: real mcp-server.ts answers initialize + tools/list"
+        shell: pwsh
+        run: |
+          $wsWin = "${{ github.workspace }}"
+          $drive = $wsWin.Substring(0, 1).ToLower()
+          $rest = $wsWin.Substring(3) -replace '\\', '/'
+          $wsLinux = "/mnt/$drive/$rest"
+
+          $spec = & node_modules/.bin/tsx test/sandbox-repro/print-mcp-container-spec.ts | ConvertFrom-Json
+
+          $dockerArgs = @("run", "--rm", "-i")
+          $dockerArgs += @("-v", "${wsLinux}/node_modules:/app/node_modules:ro")
+          $dockerArgs += @("-v", "${wsLinux}/packages:/app/packages:ro")
+          $dockerArgs += @("-v", "${wsLinux}/server:/app/server:ro")
+          $dockerArgs += @("-v", "${wsLinux}/src:/app/src:ro")
+          $dockerArgs += @("-v", "${wsLinux}/test/sandbox-repro:/repro:ro")
+          foreach ($mount in $spec.pkgModuleMounts) { $dockerArgs += @("-v", $mount) }
+          foreach ($entry in $spec.env.PSObject.Properties) { $dockerArgs += @("-e", "$($entry.Name)=$($entry.Value)") }
+          $dockerArgs += @("-w", "/app", "node:22-slim", "bash", "-c",
+            "npm install -g tsx --silent && cat /repro/mcp-handshake.jsonl | $($spec.command) $($spec.args -join ' ')")
+
+          Write-Host "pkg_modules mounts: $($spec.pkgModuleMounts.Count)"
+          $out = wsl -d Ubuntu-22.04 -u root -- docker @dockerArgs 2>&1 | Out-String
+          Write-Host $out
+
+          if ($out -notmatch '"serverInfo"') {
+            throw "MCP server never answered initialize — the child died at load. See stderr above."
+          }
+          if ($out -notmatch '"name":"handlePermission"') {
+            throw "tools/list did not include handlePermission — this is the #2052 symptom."
+          }
+          Write-Host "OK: mcp-server.ts started and listed handlePermission under real NTFS junctions."
 
       - name: "#2052 — reproduce the crash verbatim (static import, production layout)"
         shell: pwsh

--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -189,3 +189,75 @@ jobs:
             -w /app `
             node:22-slim `
             bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /repro/probe.ts"
+
+      # ── #2052 diagnostics ────────────────────────────────────────────
+      # The probe above runs from /repro, whose sibling package.json says
+      # `type: module` — so it exercises the ESM resolver hook. The real MCP
+      # child runs /app/server/agent/mcp-server.ts, and dockerBindMountArgs()
+      # never mounts a package.json under /app. These steps put the SAME
+      # diagnostic file in the production package scope and read off which
+      # module format Node actually picks, with and without a /app manifest.
+      #
+      # They REPORT; they do not gate the job. Reading the log is the point.
+
+      - name: "#2052 — diagnose: production layout (no /app/package.json)"
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $wsWin = "${{ github.workspace }}"
+          $drive = $wsWin.Substring(0, 1).ToLower()
+          $rest = $wsWin.Substring(3) -replace '\\', '/'
+          $wsLinux = "/mnt/$drive/$rest"
+
+          wsl -d Ubuntu-22.04 -u root -- docker run --rm `
+            -v "${wsLinux}/node_modules:/app/node_modules:ro" `
+            -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
+            -v "${wsLinux}/server:/app/server:ro" `
+            -v "${wsLinux}/test/sandbox-repro/diagnose-2052.ts:/app/server/agent/diagnose-2052.ts:ro" `
+            -e NODE_PATH=/app/node_modules:/app/pkg_modules `
+            -w /app `
+            node:22-slim `
+            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /app/server/agent/diagnose-2052.ts"
+
+      - name: "#2052 — diagnose: same, but with a {type:module} /app/package.json"
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $wsWin = "${{ github.workspace }}"
+          $drive = $wsWin.Substring(0, 1).ToLower()
+          $rest = $wsWin.Substring(3) -replace '\\', '/'
+          $wsLinux = "/mnt/$drive/$rest"
+
+          # The candidate fix, expressed as one extra bind mount.
+          wsl -d Ubuntu-22.04 -u root -- docker run --rm `
+            -v "${wsLinux}/node_modules:/app/node_modules:ro" `
+            -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
+            -v "${wsLinux}/server:/app/server:ro" `
+            -v "${wsLinux}/test/sandbox-repro/package.json:/app/package.json:ro" `
+            -v "${wsLinux}/test/sandbox-repro/diagnose-2052.ts:/app/server/agent/diagnose-2052.ts:ro" `
+            -e NODE_PATH=/app/node_modules:/app/pkg_modules `
+            -w /app `
+            node:22-slim `
+            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /app/server/agent/diagnose-2052.ts"
+
+      - name: "#2052 — reproduce the crash verbatim (static import, production layout)"
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $wsWin = "${{ github.workspace }}"
+          $drive = $wsWin.Substring(0, 1).ToLower()
+          $rest = $wsWin.Substring(3) -replace '\\', '/'
+          $wsLinux = "/mnt/$drive/$rest"
+
+          # Expected to exit non-zero BEFORE the fix, with the exact
+          # `Cannot find module '@mulmoclaude/x-plugin'` + `Require stack:`
+          # trace from the issue. That is the reproduction.
+          wsl -d Ubuntu-22.04 -u root -- docker run --rm `
+            -v "${wsLinux}/node_modules:/app/node_modules:ro" `
+            -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
+            -v "${wsLinux}/server:/app/server:ro" `
+            -v "${wsLinux}/test/sandbox-repro/static-import-2052.ts:/app/server/agent/static-import-2052.ts:ro" `
+            -e NODE_PATH=/app/node_modules:/app/pkg_modules `
+            -w /app `
+            node:22-slim `
+            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /app/server/agent/static-import-2052.ts"

--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -212,7 +212,8 @@ jobs:
           wsl -d Ubuntu-22.04 -u root -- docker run --rm `
             -v "${wsLinux}/node_modules:/app/node_modules:ro" `
             -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
-            -v "${wsLinux}/server:/app/server:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-bootstrap.mjs:/app/server/agent/mcp-esm-bootstrap.mjs:ro" `
             -v "${wsLinux}/test/sandbox-repro/diagnose-2052.ts:/app/server/agent/diagnose-2052.ts:ro" `
             -e NODE_PATH=/app/node_modules:/app/pkg_modules `
             -w /app `
@@ -232,7 +233,8 @@ jobs:
           wsl -d Ubuntu-22.04 -u root -- docker run --rm `
             -v "${wsLinux}/node_modules:/app/node_modules:ro" `
             -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
-            -v "${wsLinux}/server:/app/server:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-bootstrap.mjs:/app/server/agent/mcp-esm-bootstrap.mjs:ro" `
             -v "${wsLinux}/test/sandbox-repro/package.json:/app/package.json:ro" `
             -v "${wsLinux}/test/sandbox-repro/diagnose-2052.ts:/app/server/agent/diagnose-2052.ts:ro" `
             -e NODE_PATH=/app/node_modules:/app/pkg_modules `
@@ -255,7 +257,8 @@ jobs:
           wsl -d Ubuntu-22.04 -u root -- docker run --rm `
             -v "${wsLinux}/node_modules:/app/node_modules:ro" `
             -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
-            -v "${wsLinux}/server:/app/server:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro" `
+            -v "${wsLinux}/server/agent/mcp-esm-bootstrap.mjs:/app/server/agent/mcp-esm-bootstrap.mjs:ro" `
             -v "${wsLinux}/test/sandbox-repro/static-import-2052.ts:/app/server/agent/static-import-2052.ts:ro" `
             -e NODE_PATH=/app/node_modules:/app/pkg_modules `
             -w /app `

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ playwright-report-live/
 test-results-live/
 .playwright-mcp/
 .mcp.json
+
+# Local, machine-only secrets files — never commit
+.twitter_memo

--- a/docs/windows-docker-ci.md
+++ b/docs/windows-docker-ci.md
@@ -10,10 +10,10 @@ walks `<dir>/node_modules/<pkg>/package.json` misses the package.
 
 Two bugs of this shape have shipped and been fixed:
 
-| Issue | Symptom | Fix |
-|---|---|---|
-| [#1946](https://github.com/receptron/mulmoclaude/issues/1946) | MCP server dies at load: `MODULE_NOT_FOUND: @mulmoclaude/x-plugin` | PR [#1974](https://github.com/receptron/mulmoclaude/pull/1974) mounts each workspace package at `/app/pkg_modules/@mulmoclaude/<name>` and appends that dir to `NODE_PATH` so Node's CJS resolver falls through it |
-| [#1982](https://github.com/receptron/mulmoclaude/issues/1982) | Silent preset-plugin load failure — `spotify` / `debug` / `edgar` / `email` MCP tools missing | PR [#1984](https://github.com/receptron/mulmoclaude/pull/1984) replaces the hand-rolled parent-walk in `resolvePresetRoot()` with `require.resolve.paths()`, which inherits the NODE_PATH fallback |
+| Issue                                                         | Symptom                                                                                       | Fix                                                                                                                                                                                                                |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [#1946](https://github.com/receptron/mulmoclaude/issues/1946) | MCP server dies at load: `MODULE_NOT_FOUND: @mulmoclaude/x-plugin`                            | PR [#1974](https://github.com/receptron/mulmoclaude/pull/1974) mounts each workspace package at `/app/pkg_modules/@mulmoclaude/<name>` and appends that dir to `NODE_PATH` so Node's CJS resolver falls through it |
+| [#1982](https://github.com/receptron/mulmoclaude/issues/1982) | Silent preset-plugin load failure — `spotify` / `debug` / `edgar` / `email` MCP tools missing | PR [#1984](https://github.com/receptron/mulmoclaude/pull/1984) replaces the hand-rolled parent-walk in `resolvePresetRoot()` with `require.resolve.paths()`, which inherits the NODE_PATH fallback                 |
 
 Both bugs were reported by Windows users and fixed blind (the maintainers
 run on macOS / Linux). CI didn't catch either regression because there's no
@@ -172,6 +172,27 @@ which point at `dist/` files that aren't built in this CI job — the check
 would fail without proving anything about the resolver.
 `require.resolve.paths()` returns the search-path list without touching
 main entries.
+
+## The end-to-end step: boot the real MCP child (#2052)
+
+The probe above proves the _preset resolver_ survives dangling junctions. It says nothing about
+whether the MCP child actually **starts**. #2052 slipped through exactly there: the fallback mount
+list covered `@mulmoclaude/*` but not `@mulmobridge/protocol`, which `mcp-server.ts` reaches through
+`src/types/events.ts`. Every unit test passed; the child died at load on Windows and the agent lost
+all its tools.
+
+So the workflow also runs the real `server/agent/mcp-server.ts` in the container and speaks the MCP
+handshake to it (`test/sandbox-repro/mcp-handshake.jsonl`), asserting `handlePermission` comes back
+in `tools/list`.
+
+Crucially, the mounts, env and argv are **not written in the workflow**. They come from
+`test/sandbox-repro/print-mcp-container-spec.ts`, which calls the shipped `buildMulmoclaudeServer()`
+and `workspaceModuleMounts()`. Hand-copied container args are how #2052 hid for two releases: the
+Docker smoke test duplicated them and silently kept reproducing the pre-fix layout, so two shipped
+fixes were invisible to it. Derive; never duplicate.
+
+This step needs `yarn build:packages:dev` — the child imports the workspace packages' built `dist/`,
+and production ships built output.
 
 ## Gotchas
 

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -177,3 +177,49 @@ yourself — additions to `config/helps/error-recovery.md` are managed
 by the project maintainers so the canonical copy in
 `packages/core/assets/helps/error-recovery.md` and the installed copy
 stay in sync.
+
+## Sandbox MCP server dies at load — `Cannot find module '@…/…'`
+
+### Symptoms
+
+- Chatting fails before any tool runs, with:
+  `Error: MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found.`
+- Or, in the server log: `[agent-stderr] Error: Cannot find module '@mulmobridge/protocol'`
+  followed by a `Require stack:` listing `/app/server/agent/mcp-server.ts`.
+- Windows hosts only, sandbox (Docker) mode only. macOS / Linux are unaffected.
+
+### Cause
+
+`yarn` links workspace packages into `node_modules/` as **NTFS junctions** on Windows. Those
+junctions store an absolute Windows target (`C:\Users\…`), which does not exist inside the Linux
+sandbox container — every one of them dangles there, and Node's resolver skips them.
+
+`server/agent/config.ts` bind-mounts a junction-free copy of each workspace package at
+`/app/pkg_modules/<name>` and puts that dir on the child's `NODE_PATH`. If a package the MCP child
+imports is **missing from that mount list**, its junction is the only path Node can see, so the
+child dies at load and the agent loses every MCP tool at once — `handlePermission` included, which
+is why the CLI complains about the permission-prompt tool rather than about the module.
+
+### Fix
+
+Nothing to do by hand: the mount list is derived from the `packages/` tree, so every scope
+(`@mulmoclaude/*`, `@mulmobridge/*`, …) is covered. If you see this anyway:
+
+```bash
+# Confirm the package really is missing from the fallback, not just unbuilt.
+docker run --rm -v "<repo>/packages/<pkg>:/app/pkg_modules/<name>:ro" node:22-slim \
+  ls /app/pkg_modules/<name>/package.json
+
+# The workspace dists must exist — production ships built output.
+yarn build:packages:dev
+```
+
+A stale `dist/` looks identical from the outside: the mount is there, but its `exports` target is
+absent. Rebuild before suspecting the mounts.
+
+### Regression coverage
+
+`.github/workflows/docker_sandbox_windows.yaml` boots the real `mcp-server.ts` inside a Linux
+container from a Windows host (WSL2 + native `dockerd`), with the same mounts / env / argv the
+shipped builders produce, and asserts `handlePermission` comes back over the MCP handshake. See
+`docs/windows-docker-ci.md`.

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -185,25 +185,34 @@ stay in sync.
 - Chatting fails before any tool runs, with:
   `Error: MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found.`
 - Or, in the server log: `[agent-stderr] Error: Cannot find module '@mulmobridge/protocol'`
-  followed by a `Require stack:` listing `/app/server/agent/mcp-server.ts`.
-- Windows hosts only, sandbox (Docker) mode only. macOS / Linux are unaffected.
+  (or `@mulmoclaude/chart-plugin`, `@gui-chat-plugin/camera`, …) followed by a `Require stack:`
+  listing `/app/server/agent/mcp-server.ts`.
+- Sandbox (Docker) mode only. The broker dies **permanently** — it fails on every manual retry
+  too (contrast the transient scheduler race below, which succeeds on a manual re-run).
 
 ### Cause
 
-`yarn` links workspace packages into `node_modules/` as **NTFS junctions** on Windows. Those
-junctions store an absolute Windows target (`C:\Users\…`), which does not exist inside the Linux
-sandbox container — every one of them dangles there, and Node's resolver skips them.
+The MCP child resolves its imports against `/app/node_modules` plus the `/app/pkg_modules`
+fallback on `NODE_PATH`. It dies at load when a package it imports is reachable from neither. Two
+layouts cause that:
 
-`server/agent/config.ts` bind-mounts a junction-free copy of each workspace package at
-`/app/pkg_modules/<name>` and puts that dir on the child's `NODE_PATH`. If a package the MCP child
-imports is **missing from that mount list**, its junction is the only path Node can see, so the
-child dies at load and the agent loses every MCP tool at once — `handlePermission` included, which
-is why the CLI complains about the permission-prompt tool rather than about the module.
+1. **Windows source checkout.** `yarn` links workspace packages into `node_modules/` as **NTFS
+   junctions**; their absolute Windows target (`C:\Users\…`) does not exist in the Linux container,
+   so every junction dangles. `server/agent/config.ts` bind-mounts a junction-free copy of each
+   workspace package at `/app/pkg_modules/<name>`; a package missing from that list is invisible.
+2. **npx install with nested `node_modules`.** npm sometimes places a dep in the nested
+   `<packageRoot>/node_modules` (a version conflict, or a half-deduped npx cache from repeated
+   overwrite-updates) instead of hoisting it to `<projectRoot>/node_modules`. Only the latter is
+   mounted to `/app/node_modules`, so the nested dep is invisible.
+
+Either way the child dies before the MCP handshake, so the agent loses **every** MCP tool at once —
+`handlePermission` included, which is why the CLI complains about the permission-prompt tool rather
+than about the missing module.
 
 ### Fix
 
-Nothing to do by hand: the mount list is derived from the `packages/` tree, so every scope
-(`@mulmoclaude/*`, `@mulmobridge/*`, …) is covered. If you see this anyway:
+Both layouts are handled automatically: the Windows case mounts every workspace scope, and the npx
+case mounts the nested `<packageRoot>/node_modules` onto `/app/pkg_modules`. If you see this anyway:
 
 ```bash
 # Check the SHIPPED mount list, not a hand-mounted copy: does the package the
@@ -217,6 +226,40 @@ yarn build:packages:dev
 
 A stale `dist/` looks identical from the outside: the mount is there, but its `exports` target is
 absent. Rebuild before suspecting the mounts.
+
+For an **npx** install specifically, the quickest user-side unblock is to clear the npx cache so
+the next launch installs a clean, fully-hoisted tree:
+
+```bash
+rm -rf ~/.npm/_npx        # then re-run:
+npx mulmoclaude@latest
+```
+
+## Scheduled run fails once with `handlePermission not found`, but works on a manual retry
+
+### Symptoms
+
+- A scheduled skill / user task fails with the SAME
+  `MCP tool mcp__mulmoclaude__handlePermission ... not found` message — but running the identical
+  skill by hand immediately afterwards succeeds.
+- More frequent when several tasks are scheduled for the same minute (e.g. multiple 20:00 UTC
+  jobs). The failed run's transcript is tiny (a few hundred bytes to a few KB) and its recorded
+  duration is only milliseconds.
+
+### Cause
+
+This is a transient STARTUP RACE, not the permanent load failure above. Each scheduled chat spawns
+its own `mulmoclaude` MCP broker; when many chats launch in the same instant the broker boots under
+contention and can connect a moment after the agent's first tool call, so the permission-prompt
+tool is briefly absent. The broker connects seconds later — which is why a manual re-run works.
+
+The scheduler now staggers same-minute firings by a second each to reduce this contention (#2057),
+so it should be rare. It is NOT a module-resolution problem — the mounts / `dist` are fine.
+
+### Fix
+
+Just re-run the task. If it recurs often on a busy schedule, spread the tasks across different
+minutes rather than stacking them on the same one.
 
 ### Regression coverage
 

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -206,9 +206,10 @@ Nothing to do by hand: the mount list is derived from the `packages/` tree, so e
 (`@mulmoclaude/*`, `@mulmobridge/*`, …) is covered. If you see this anyway:
 
 ```bash
-# Confirm the package really is missing from the fallback, not just unbuilt.
-docker run --rm -v "<repo>/packages/<pkg>:/app/pkg_modules/<name>:ro" node:22-slim \
-  ls /app/pkg_modules/<name>/package.json
+# Check the SHIPPED mount list, not a hand-mounted copy: does the package the
+# child failed on appear in what workspaceModuleMounts() actually produces?
+node_modules/.bin/tsx test/sandbox-repro/print-mcp-container-spec.ts \
+  | grep pkg_modules/<name>       # <name> e.g. @mulmobridge/protocol
 
 # The workspace dists must exist — production ships built output.
 yarn build:packages:dev

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/core/src/scheduler/task-manager.ts
+++ b/packages/core/src/scheduler/task-manager.ts
@@ -21,13 +21,20 @@ const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 // its window.
 const DEFAULT_FIRING_STAGGER_MS = ONE_SECOND_MS;
 
+// The total stagger must stay well inside one tick, or the tail tasks start in a
+// LATER tick window and two ticks overlap. Cap all starts to this fraction of
+// `tickMs` regardless of task count or the configured gap — this keeps a debug
+// `tickMs === firingStaggerMs` (see server boot) from degenerating.
+const MAX_STAGGER_FRACTION_OF_TICK = 0.5;
+
 const realSleep = (delayMs: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, delayMs));
 
-/** Delay before the Nth independently-due task in a tick starts. */
-type StaggerFn = (index: number) => Promise<void>;
-
-function makeStagger(staggerMs: number, sleep: (delayMs: number) => Promise<void>): StaggerFn {
-  return (index: number) => (staggerMs > 0 && index > 0 ? sleep(index * staggerMs) : Promise.resolve());
+// Per-task stagger step: the configured gap, shrunk so the last of `count` tasks
+// still starts within MAX_STAGGER_FRACTION_OF_TICK of the tick. 0 disables it.
+function staggerStepMs(staggerMs: number, tickMs: number, count: number): number {
+  if (staggerMs <= 0 || count <= 1) return 0;
+  const maxStepMs = (tickMs * MAX_STAGGER_FRACTION_OF_TICK) / (count - 1);
+  return Math.min(staggerMs, maxStepMs);
 }
 
 /** Minimal logger the engine logs through. Absent one, runs silent. */
@@ -159,24 +166,32 @@ async function runDependentChain(dependent: TaskDefinition[], currentTime: Date,
   }
 }
 
-async function runTick(now: () => Date, registry: Map<string, TaskDefinition>, tickMs: number, log: SchedulerLogger, stagger: StaggerFn): Promise<void> {
+interface TickConfig {
+  tickMs: number;
+  staggerMs: number;
+  sleep: (delayMs: number) => Promise<void>;
+  log: SchedulerLogger;
+}
+
+async function runTick(now: () => Date, registry: Map<string, TaskDefinition>, cfg: TickConfig): Promise<void> {
   const currentTime = now();
-  const { independent, dependent } = collectDueTasks(currentTime, registry, tickMs);
+  const { independent, dependent } = collectDueTasks(currentTime, registry, cfg.tickMs);
 
   // Per-invocation set — success does not leak across tick() calls.
   const succeeded = new Set<string>();
 
-  // Staggered start (#2057), still concurrent: each fires after its own delay
-  // but the tick awaits them all, preserving the previous "all due tasks ran
-  // this tick" contract.
+  // Staggered start (#2057), still concurrent: each fires after its own capped
+  // delay but the tick awaits them all, preserving the previous "all due tasks
+  // ran this tick" contract.
+  const stepMs = staggerStepMs(cfg.staggerMs, cfg.tickMs, independent.length);
   await Promise.all(
     independent.map(async (def, index) => {
-      await stagger(index);
-      await runAndTrack(def, currentTime, succeeded, log);
+      if (stepMs > 0 && index > 0) await cfg.sleep(index * stepMs);
+      await runAndTrack(def, currentTime, succeeded, cfg.log);
     }),
   );
 
-  await runDependentChain(dependent, currentTime, succeeded, log);
+  await runDependentChain(dependent, currentTime, succeeded, cfg.log);
 }
 
 export function listTaskSummaries(registry: Map<string, TaskDefinition>): TaskSummary[] {
@@ -188,16 +203,42 @@ export function listTaskSummaries(registry: Map<string, TaskDefinition>): TaskSu
   }));
 }
 
-export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
+// A tick runner that skips re-entry: if the previous tick is still draining its
+// staggered starts, drop this one so a slow tick + short tickMs can never run
+// two ticks concurrently.
+function makeGuardedTick(now: () => Date, registry: Map<string, TaskDefinition>, cfg: TickConfig): () => Promise<void> {
+  let ticking = false;
+  return async () => {
+    if (ticking) return;
+    ticking = true;
+    try {
+      await runTick(now, registry, cfg);
+    } finally {
+      ticking = false;
+    }
+  };
+}
+
+function resolveTickConfig(options?: TaskManagerOptions): { tickMs: number; now: () => Date; cfg: TickConfig } {
   const tickMs = options?.tickMs ?? ONE_MINUTE_MS;
-  const now = options?.now ?? (() => new Date());
-  const log = options?.log ?? NOOP_LOG;
-  const staggerMs = options?.firingStaggerMs ?? DEFAULT_FIRING_STAGGER_MS;
-  const stagger = makeStagger(staggerMs, options?.sleep ?? realSleep);
+  return {
+    tickMs,
+    now: options?.now ?? (() => new Date()),
+    cfg: {
+      tickMs,
+      staggerMs: options?.firingStaggerMs ?? DEFAULT_FIRING_STAGGER_MS,
+      sleep: options?.sleep ?? realSleep,
+      log: options?.log ?? NOOP_LOG,
+    },
+  };
+}
+
+export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
+  const { tickMs, now, cfg } = resolveTickConfig(options);
+  const { log } = cfg;
   const registry = new Map<string, TaskDefinition>();
   let timer: ReturnType<typeof setInterval> | null = null;
-
-  const onTick = () => runTick(now, registry, tickMs, log, stagger);
+  const onTick = makeGuardedTick(now, registry, cfg);
 
   return {
     async tick() {

--- a/packages/core/src/scheduler/task-manager.ts
+++ b/packages/core/src/scheduler/task-manager.ts
@@ -10,6 +10,26 @@ const ONE_SECOND_MS = 1000;
 const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 
+// Gap between the START of each independently-due task within one tick. When
+// many tasks come due at the same minute (system journal + feed-refresh + a few
+// user tasks all at 20:00 UTC), firing every chat in the same event-loop turn
+// floods the machine; the mulmoclaude MCP broker each chat spawns then boots
+// under contention and can lose the startup race to the CLI's first tool call,
+// so that turn fails with `handlePermission not found` (#2057). Spacing the
+// launches by a second gives each broker room to connect. Far under one tick
+// (a handful of tasks spread over a few seconds), so nothing is delayed past
+// its window.
+const DEFAULT_FIRING_STAGGER_MS = ONE_SECOND_MS;
+
+const realSleep = (delayMs: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, delayMs));
+
+/** Delay before the Nth independently-due task in a tick starts. */
+type StaggerFn = (index: number) => Promise<void>;
+
+function makeStagger(staggerMs: number, sleep: (delayMs: number) => Promise<void>): StaggerFn {
+  return (index: number) => (staggerMs > 0 && index > 0 ? sleep(index * staggerMs) : Promise.resolve());
+}
+
 /** Minimal logger the engine logs through. Absent one, runs silent. */
 export interface SchedulerLogger {
   info: (message: string, data?: Record<string, unknown>) => void;
@@ -61,6 +81,11 @@ export interface TaskManagerOptions {
   tickMs?: number; // default: ONE_MINUTE_MS
   now?: () => Date; // default: () => new Date()
   log?: SchedulerLogger; // default: noop
+  /** Gap between the start of each independently-due task in a tick (#2057).
+   *  Default DEFAULT_FIRING_STAGGER_MS; 0 fires them all at once. */
+  firingStaggerMs?: number;
+  /** Injected so tests advance time without real timers. Default setTimeout. */
+  sleep?: (delayMs: number) => Promise<void>;
 }
 
 function isDue(now: Date, schedule: TaskSchedule, tickMs: number): boolean {
@@ -134,14 +159,22 @@ async function runDependentChain(dependent: TaskDefinition[], currentTime: Date,
   }
 }
 
-async function runTick(now: () => Date, registry: Map<string, TaskDefinition>, tickMs: number, log: SchedulerLogger): Promise<void> {
+async function runTick(now: () => Date, registry: Map<string, TaskDefinition>, tickMs: number, log: SchedulerLogger, stagger: StaggerFn): Promise<void> {
   const currentTime = now();
   const { independent, dependent } = collectDueTasks(currentTime, registry, tickMs);
 
   // Per-invocation set — success does not leak across tick() calls.
   const succeeded = new Set<string>();
 
-  await Promise.all(independent.map((def) => runAndTrack(def, currentTime, succeeded, log)));
+  // Staggered start (#2057), still concurrent: each fires after its own delay
+  // but the tick awaits them all, preserving the previous "all due tasks ran
+  // this tick" contract.
+  await Promise.all(
+    independent.map(async (def, index) => {
+      await stagger(index);
+      await runAndTrack(def, currentTime, succeeded, log);
+    }),
+  );
 
   await runDependentChain(dependent, currentTime, succeeded, log);
 }
@@ -159,10 +192,12 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
   const tickMs = options?.tickMs ?? ONE_MINUTE_MS;
   const now = options?.now ?? (() => new Date());
   const log = options?.log ?? NOOP_LOG;
+  const staggerMs = options?.firingStaggerMs ?? DEFAULT_FIRING_STAGGER_MS;
+  const stagger = makeStagger(staggerMs, options?.sleep ?? realSleep);
   const registry = new Map<string, TaskDefinition>();
   let timer: ReturnType<typeof setInterval> | null = null;
 
-  const onTick = () => runTick(now, registry, tickMs, log);
+  const onTick = () => runTick(now, registry, tickMs, log, stagger);
 
   return {
     async tick() {

--- a/packages/core/test/scheduler/test_scheduler.ts
+++ b/packages/core/test/scheduler/test_scheduler.ts
@@ -119,6 +119,31 @@ test("staggers the start of independently-due tasks by firingStaggerMs (#2057)",
   assert.deepEqual(requestedDelays, [500, 1000]);
 });
 
+test("caps the total stagger to half a tick so tasks never spill into the next tick (#2057)", async () => {
+  // Debug-mode shape: tickMs == firingStaggerMs. Without the cap the 2nd task
+  // would start a full tick late and ticks would overlap. The cap shrinks the
+  // step to (tickMs * 0.5) / (count - 1) = (1000 * 0.5) / 2 = 250ms.
+  const requestedDelays: number[] = [];
+  const manager = createTaskManager({
+    tickMs: 1000,
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, 0)),
+    firingStaggerMs: 1000,
+    sleep: async (delayMs) => {
+      requestedDelays.push(delayMs);
+    },
+  });
+  for (const taskId of ["a", "b", "c"]) {
+    manager.registerTask({
+      id: taskId,
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 1000 },
+      run: async () => {},
+    });
+  }
+  await manager.tick();
+  assert.deepEqual(requestedDelays, [250, 500]);
+  assert.ok(Math.max(...requestedDelays) < 1000, "last start stays within the tick");
+});
+
 test("firingStaggerMs: 0 fires all due tasks without any delay", async () => {
   const requestedDelays: number[] = [];
   const manager = createTaskManager({

--- a/packages/core/test/scheduler/test_scheduler.ts
+++ b/packages/core/test/scheduler/test_scheduler.ts
@@ -93,6 +93,53 @@ test("dependsOn enforces ordering within a tick; dependent skipped if dep fails"
   assert.deepEqual(order2, []); // child never runs because dep did not succeed
 });
 
+test("staggers the start of independently-due tasks by firingStaggerMs (#2057)", async () => {
+  const requestedDelays: number[] = [];
+  const ran: string[] = [];
+  const manager = createTaskManager({
+    tickMs: 60_000,
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, 0)),
+    firingStaggerMs: 500,
+    sleep: async (delayMs) => {
+      requestedDelays.push(delayMs);
+    },
+  });
+  for (const taskId of ["a", "b", "c"]) {
+    manager.registerTask({
+      id: taskId,
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 60_000 },
+      run: async () => {
+        ran.push(taskId);
+      },
+    });
+  }
+  await manager.tick();
+  assert.deepEqual(ran.sort(), ["a", "b", "c"]); // every due task still runs this tick
+  // First task starts immediately (no sleep); the rest are offset by index * gap.
+  assert.deepEqual(requestedDelays, [500, 1000]);
+});
+
+test("firingStaggerMs: 0 fires all due tasks without any delay", async () => {
+  const requestedDelays: number[] = [];
+  const manager = createTaskManager({
+    tickMs: 60_000,
+    now: () => new Date(Date.UTC(2026, 0, 1, 0, 0, 0)),
+    firingStaggerMs: 0,
+    sleep: async (delayMs) => {
+      requestedDelays.push(delayMs);
+    },
+  });
+  for (const taskId of ["a", "b"]) {
+    manager.registerTask({
+      id: taskId,
+      schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 60_000 },
+      run: async () => {},
+    });
+  }
+  await manager.tick();
+  assert.deepEqual(requestedDelays, []);
+});
+
 test("registerTask rejects duplicate ids; updateSchedule returns false for unknown", () => {
   const manager = createTaskManager();
   manager.registerTask({ id: "a", schedule: { type: SCHEDULE_TYPES.daily, time: "09:00" }, run: async () => {} });

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.5",
-    "@mulmoclaude/core": "^0.12.1",
+    "@mulmoclaude/core": "^0.12.2",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/plans/fix-2052-windows-docker-esm-hook.md
+++ b/plans/fix-2052-windows-docker-esm-hook.md
@@ -72,7 +72,7 @@ condition would have broken it.
 Measured, not guessed. Running the real `mcp-server.ts` under the production spec with dangling
 junctions:
 
-```
+```text
 Error: Cannot find module '@mulmobridge/protocol'
 Require stack:
 - /app/src/types/events.ts

--- a/plans/fix-2052-windows-docker-esm-hook.md
+++ b/plans/fix-2052-windows-docker-esm-hook.md
@@ -13,7 +13,7 @@ Windows 23H2 + Docker Desktop (WSL2), source checkout, sandbox ON, at commit `c1
 
 1. Chatting → `ERROR [agent-stderr] Error: MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found.`
 2. `npx tsx --test test/agent/test_mcp_docker_smoke.ts` → **the exact same error text as before PR #1974**:
-   ```
+   ```text
    node:internal/modules/cjs/loader:1430
    Error: Cannot find module '@mulmoclaude/x-plugin'
    Require stack:

--- a/plans/fix-2052-windows-docker-esm-hook.md
+++ b/plans/fix-2052-windows-docker-esm-hook.md
@@ -1,0 +1,134 @@
+# fix #2052 — the ESM resolver hook never fires in the Windows Docker sandbox
+
+Issue: [#2052](https://github.com/receptron/mulmoclaude/issues/2052)
+Related: #1946 → PR #1974 · #1982 → PR #1984 · PR #1995 (the hook that "doesn't take effect")
+
+## User prompt
+
+> https://github.com/receptron/mulmoclaude/issues/2052 これ、つめていける？windowsのciなどを使って直したい。
+
+## What the reporter saw
+
+Windows 23H2 + Docker Desktop (WSL2), source checkout, sandbox ON, at commit `c15980d0`:
+
+1. Chatting → `ERROR [agent-stderr] Error: MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found.`
+2. `npx tsx --test test/agent/test_mcp_docker_smoke.ts` → **the exact same error text as before PR #1974**:
+   ```
+   node:internal/modules/cjs/loader:1430
+   Error: Cannot find module '@mulmoclaude/x-plugin'
+   Require stack:
+     /app/server/agent/mcp-tools/index.ts
+     /app/server/agent/mcp-server.ts
+   ```
+
+## Findings (static, before touching CI)
+
+### F1 — the smoke test is stale, and that explains symptom 2
+
+`test/agent/test_mcp_docker_smoke.ts` **hardcodes** its `docker run` argv instead of deriving
+it from the shipped builders. It is missing everything the two prior fixes added:
+
+| production (`server/agent/config.ts`) | the smoke test |
+|---|---|
+| `workspaceModuleMounts()` → `-v <pkg>:/app/pkg_modules/@mulmoclaude/<name>:ro` (PR #1974) | **absent** |
+| `NODE_PATH=/app/node_modules:/app/pkg_modules` (PR #1974) | `NODE_PATH=/app/node_modules` |
+| `tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs <server>` (PR #1995) | `tsx <server>` |
+
+So the test reproduces the **pre-#1974** configuration. Its failure is an artifact of the test,
+not evidence that PR #1995 is broken. A test that cannot see the fix cannot verify the fix.
+
+### F2 — `/app` has no `package.json`, so the container runs the server graph as **CJS**
+
+`dockerBindMountArgs()` mounts `/app/node_modules`, `/app/server`, `/app/src`, `/app/packages`,
+`/app/pkg_modules/*`, the workspace and the claude config. **It never mounts a `package.json`
+into `/app`.** The repo root declares `"type": "module"`, but that file is invisible inside the
+container, so `tsx` resolves `/app/server/agent/*.ts` to **CommonJS**.
+
+`module.register()` — what `mcp-esm-bootstrap.mjs` calls — installs a hook on the **ESM**
+resolver only. It is never consulted by `require()`. Hence the `Require stack:` in the
+reporter's trace: the hook is registered and then never asked anything.
+
+**PR #1995 cannot work as written, on any host, in this container.** Linux/macOS simply never
+notice because `/app/node_modules/@mulmoclaude/*` are live POSIX symlinks there, so primary
+resolution succeeds and no fallback is needed.
+
+### F3 — the Windows CI probe passes because it tests a layout production does not have
+
+`.github/workflows/docker_sandbox_windows.yaml` runs `tsx --import <bootstrap> /repro/probe.ts`,
+and `test/sandbox-repro/package.json` is `{"private": true, "type": "module"}`. That one file
+puts the probe in ESM mode, so the hook fires and the probe goes green — while the real MCP
+child, which has no such file, runs CJS. The probe validates a configuration that does not ship.
+
+### F4 — `@mulmoclaude/core` violates the repo's own export rule
+
+CLAUDE.md: *"Package exports: include `require` and `default` conditions (Docker CJS mode)"*.
+`./workspace-setup` and `./workspace-setup/slug` expose only `types` / `import` / `default`.
+Under CJS they fall through to an ESM `default`. Latent, and it must be fixed regardless.
+
+## The one thing still unmeasured
+
+In the **real** layout (CJS + `NODE_PATH=/app/node_modules:/app/pkg_modules`), does
+`require("@mulmoclaude/x-plugin")` fall through `Module.globalPaths` to `/app/pkg_modules`,
+or does `tsx`'s CJS require hook bypass `NODE_PATH`?
+
+Every `@mulmoclaude/*` specifier the MCP child imports **does** carry a `require` condition whose
+target exists (checked statically), so if `globalPaths` is consulted, CJS should already work.
+That contradicts symptom 1 — which means something else is failing, and we must **measure, not
+guess**. That is what the Windows CI job is for.
+
+## Plan
+
+### P1 — make the smoke test faithful (so it can never drift again)
+
+Rewrite `test/agent/test_mcp_docker_smoke.ts` to derive its `docker run` argv from the shipped
+`buildDockerSpawnArgs()` / `buildMulmoclaudeServer()` rather than hardcoding it. Add a POSIX unit
+test asserting the derived argv contains the `/app/pkg_modules` mounts, the two-entry `NODE_PATH`,
+and the `--import <bootstrap>` flag. This turns symptom 2 into a faithful reproduction and stops
+the class of bug where a fix ships but the test never sees it.
+
+### P2 — reproduce the production layout on Windows CI and take a reading
+
+Extend `.github/workflows/docker_sandbox_windows.yaml` with a **diagnostic job** that mounts
+exactly what production mounts (crucially: **no** `package.json` under `/app`) and runs a probe
+that reports, rather than asserts:
+
+- the module format Node picks for `/app/server/agent/mcp-server.ts` (CJS or ESM)
+- whether the registered ESM `resolve()` hook is ever invoked
+- `process.env.NODE_PATH` and `module.globalPaths`
+- for every `@mulmoclaude/*` specifier `mcp-tools/index.ts` imports: `require.resolve()`,
+  `require.resolve.paths()`, and `await import()` — each with its error, if any
+- `lstat` of `/app/node_modules/@mulmoclaude/x-plugin` (proving the junction dangles)
+
+Trigger it with `workflow_dispatch` on the fix branch. Read the evidence.
+
+### P3 — fix, guided by P2
+
+Leading candidate: give the container a `package.json` declaring `"type": "module"` for the
+mounted server tree, so the graph is ESM and PR #1995's hook actually applies. Alternative /
+complement: `module.registerHooks()` (Node 22) installs **synchronous** hooks that also cover
+`require()`, which would make the fix format-agnostic. Choose after reading P2, not before.
+
+### P4 — close F4
+
+Add `require` conditions to `@mulmoclaude/core`'s `./workspace-setup` and
+`./workspace-setup/slug` exports, and make sure the built `.cjs` targets exist.
+
+### P5 — permanent regression coverage
+
+- The Windows probe must run the **production** layout. Keep an explicit assertion that
+  `/app/package.json` is absent-or-present exactly as production has it, so F3 cannot recur.
+- Add a section to `packages/core/assets/helps/error-recovery.md` describing this failure mode
+  (`Cannot find module '@mulmoclaude/*'` + `Require stack:` inside the sandbox) and its check.
+
+## Verification
+
+- `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` green.
+- The rewritten smoke test passes on Linux (CI) and, per the reporter, on Windows.
+- The Windows CI job runs the production layout and passes.
+- Manual: the reporter re-runs the chat flow and `handlePermission` resolves.
+
+## Non-goals
+
+- Rewriting the sandbox mount scheme.
+- Making the Windows job part of every PR (it stays schedule + `workflow_dispatch`; see
+  `docs/windows-docker-ci.md`).

--- a/plans/fix-2052-windows-docker-esm-hook.md
+++ b/plans/fix-2052-windows-docker-esm-hook.md
@@ -28,11 +28,11 @@ Windows 23H2 + Docker Desktop (WSL2), source checkout, sandbox ON, at commit `c1
 `test/agent/test_mcp_docker_smoke.ts` **hardcodes** its `docker run` argv instead of deriving
 it from the shipped builders. It is missing everything the two prior fixes added:
 
-| production (`server/agent/config.ts`) | the smoke test |
-|---|---|
-| `workspaceModuleMounts()` → `-v <pkg>:/app/pkg_modules/@mulmoclaude/<name>:ro` (PR #1974) | **absent** |
-| `NODE_PATH=/app/node_modules:/app/pkg_modules` (PR #1974) | `NODE_PATH=/app/node_modules` |
-| `tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs <server>` (PR #1995) | `tsx <server>` |
+| production (`server/agent/config.ts`)                                                     | the smoke test                |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| `workspaceModuleMounts()` → `-v <pkg>:/app/pkg_modules/@mulmoclaude/<name>:ro` (PR #1974) | **absent**                    |
+| `NODE_PATH=/app/node_modules:/app/pkg_modules` (PR #1974)                                 | `NODE_PATH=/app/node_modules` |
+| `tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs <server>` (PR #1995)         | `tsx <server>`                |
 
 So the test reproduces the **pre-#1974** configuration. Its failure is an artifact of the test,
 not evidence that PR #1995 is broken. A test that cannot see the fix cannot verify the fix.
@@ -94,10 +94,10 @@ every tool — `handlePermission` included — disappears from the agent registr
 
 Proof, same container, only the scope filter changed:
 
-| `scopedPackageName` accepts | result |
-|---|---|
-| `@mulmoclaude/` only (before) | `Cannot find module '@mulmobridge/protocol'`, exit 1 |
-| any `@scope/` (after) | `serverInfo` + `handlePermission` in `tools/list`, exit 0 |
+| `scopedPackageName` accepts   | result                                                    |
+| ----------------------------- | --------------------------------------------------------- |
+| `@mulmoclaude/` only (before) | `Cannot find module '@mulmobridge/protocol'`, exit 1      |
+| any `@scope/` (after)         | `serverInfo` + `handlePermission` in `tools/list`, exit 0 |
 
 ## Superseded: the one thing that was unmeasured
 

--- a/plans/fix-2052-windows-docker-esm-hook.md
+++ b/plans/fix-2052-windows-docker-esm-hook.md
@@ -59,13 +59,47 @@ and `test/sandbox-repro/package.json` is `{"private": true, "type": "module"}`. 
 puts the probe in ESM mode, so the hook fires and the probe goes green — while the real MCP
 child, which has no such file, runs CJS. The probe validates a configuration that does not ship.
 
-### F4 — `@mulmoclaude/core` violates the repo's own export rule
+### F4 — WITHDRAWN. `@mulmoclaude/core`'s `workspace-setup` is ESM-only on purpose
 
-CLAUDE.md: *"Package exports: include `require` and `default` conditions (Docker CJS mode)"*.
-`./workspace-setup` and `./workspace-setup/slug` expose only `types` / `import` / `default`.
-Under CJS they fall through to an ESM `default`. Latent, and it must be fixed regardless.
+I flagged the missing `require` condition on `./workspace-setup` as a rule violation. It is not:
+`vite.esm.config.ts` builds that entry ESM-only because it uses `import.meta.url` for asset
+resolution, which cannot be emitted as CJS. There is no `.cjs` to point a `require` condition at,
+and Node's `require(esm)` (>= 22.12) loads it fine — as the end-to-end run confirms. Adding the
+condition would have broken it.
 
-## The one thing still unmeasured
+### F5 — THE ACTUAL BUG: the fallback only ever covered `@mulmoclaude/*`
+
+Measured, not guessed. Running the real `mcp-server.ts` under the production spec with dangling
+junctions:
+
+```
+Error: Cannot find module '@mulmobridge/protocol'
+Require stack:
+- /app/src/types/events.ts
+- /app/server/agent/mcp-tools/spawnBackgroundChat.ts
+- /app/server/agent/mcp-tools/index.ts
+- /app/server/agent/mcp-server.ts
+```
+
+yarn junctions **every** workspace package — `packages/*`, `packages/bridges/*`,
+`packages/plugins/*`, `packages/services/*`. But:
+
+- `workspacePackageDirs()` scanned only `packages/core` + `packages/plugins/*`
+- `scopedPackageName()` accepted only names starting with `@mulmoclaude/`
+- `mcp-esm-loader.mjs` hardcoded `const SCOPE = "@mulmoclaude/"`
+
+So `@mulmobridge/protocol` (reached through `src/types/events.ts`) and `@mulmobridge/client` had
+no `/app/pkg_modules` fallback. On Windows their junctions dangle, the MCP child dies at load, and
+every tool — `handlePermission` included — disappears from the agent registry. **That is symptom 1.**
+
+Proof, same container, only the scope filter changed:
+
+| `scopedPackageName` accepts | result |
+|---|---|
+| `@mulmoclaude/` only (before) | `Cannot find module '@mulmobridge/protocol'`, exit 1 |
+| any `@scope/` (after) | `serverInfo` + `handlePermission` in `tools/list`, exit 0 |
+
+## Superseded: the one thing that was unmeasured
 
 In the **real** layout (CJS + `NODE_PATH=/app/node_modules:/app/pkg_modules`), does
 `require("@mulmoclaude/x-plugin")` fall through `Module.globalPaths` to `/app/pkg_modules`,
@@ -108,10 +142,12 @@ mounted server tree, so the graph is ESM and PR #1995's hook actually applies. A
 complement: `module.registerHooks()` (Node 22) installs **synchronous** hooks that also cover
 `require()`, which would make the fix format-agnostic. Choose after reading P2, not before.
 
-### P4 — close F4
+### P4 — fix F5 (the real bug)
 
-Add `require` conditions to `@mulmoclaude/core`'s `./workspace-setup` and
-`./workspace-setup/slug` exports, and make sure the built `.cjs` targets exist.
+- `workspacePackageDirs()` walks `packages/*` and descends one level into grouping dirs
+  (`plugins/`, `bridges/`, `services/`), matching the workspace globs structurally.
+- `scopedPackageName()` accepts any `@scope/` name; only the unscoped `mulmoclaude` launcher is skipped.
+- `mcp-esm-loader.mjs` drops its hardcoded scope for the same reason.
 
 ### P5 — permanent regression coverage
 

--- a/plans/handoff-2052-2056-2057.md
+++ b/plans/handoff-2052-2056-2057.md
@@ -1,0 +1,158 @@
+# Handoff — the `handlePermission not found` family (#2052 / #2056 / #2057)
+
+Session handoff note. Read this first, then `plans/fix-2052-windows-docker-esm-hook.md`
+for the full #2052 investigation record.
+
+Date written: 2026-07-11. Branch: `fix/2052-windows-docker-esm-hook`. HEAD: `3abfecad`.
+
+## TL;DR
+
+One surface error — `Error: MCP tool mcp__mulmoclaude__handlePermission (passed via
+--permission-prompt-tool) not found.` — has **three distinct root causes**. They are NOT
+the same bug. Fixing one does not fix the others.
+
+All three are now fixed/mitigated in **PR #2058** (this branch), at the user's request to cover the
+whole family in one PR.
+
+| Issue | Layer | Root cause | Nature | Status in PR #2058 |
+| ----- | ----- | ---------- | ------ | ------ |
+| **#2052** | Docker mount / Windows | workspace `@…/*` junctions dangle in the Linux container; `@mulmobridge/*` was missing from the `/app/pkg_modules` fallback | permanent — MODULE_NOT_FOUND at broker load | **FIXED** — cover every workspace scope |
+| **#2056** | Docker mount / npx | npx nested `packageRoot/node_modules` is never mounted (only `projectRoot/node_modules` is) | permanent — MODULE_NOT_FOUND at broker load | **FIXED** — mount the nested tree onto `/app/pkg_modules` |
+| **#2057** | Scheduler / runtime | MCP broker's stdio connection isn't ready before the first tool call, worst under same-minute fan-out | transient — startup race, no module error | **MITIGATED** — stagger same-tick firings; honest-logging follow-up deferred |
+
+### Relatedness
+
+- **#2052 and #2056 are siblings.** Same mechanism: the MCP broker dies at load because a
+  dependency isn't reachable inside the Docker container → every `mcp__mulmoclaude__*` tool
+  disappears at once → the CLI reports the missing `handlePermission` permission-prompt tool.
+  Both fixes converge on `/app/pkg_modules` (already on the child's `NODE_PATH` and the ESM
+  resolver hook's search path). Different trigger only: Windows dangling junction (#2052) vs
+  npm placing deps in the nested `node_modules` (#2056). **Two holes in the same wall.**
+- **#2057 only shares the surface error string.** It's a startup race — the broker starts
+  fine, module resolution never fails, and a manual re-run succeeds. #2056's own text
+  separates it under "類似症状との区別". Different layer, different fix.
+
+## What PR #2058 (this branch) actually does — #2052 only
+
+Root cause (measured on real Windows CI, not guessed): the `/app/pkg_modules` junction-fallback
+only ever covered `@mulmoclaude/*`. `@mulmobridge/protocol` (reached via `src/types/events.ts`)
+and `@mulmobridge/client` had no fallback, their Windows junctions dangle in the Linux
+container, the broker dies at load, and all MCP tools vanish. The issue's own title ("ESM hook
+never fires") was a wrong diagnosis — see `plans/fix-2052-windows-docker-esm-hook.md` F1–F5.
+
+The fix — cover **every** workspace scope, not just `@mulmoclaude/`:
+
+- `server/agent/config.ts`
+  - `scopedPackageName()`: `name.startsWith("@")` (any scope) instead of `"@mulmoclaude/"`;
+    still skips the unscoped `mulmoclaude` launcher.
+  - `workspacePackageDirs()`: walks the `packages/` tree structurally (iterate `packages/*`;
+    if a child has `package.json` it is a package, else descend one level into grouping dirs
+    `plugins/` / `bridges/` / `services/`). NOT driven by the root manifest `workspaces` field
+    (a manifest-reading version was tried and backed out — the test fixture has no root
+    package.json and produced ZERO mounts).
+  - Exported `buildMulmoclaudeServer()` (typed `McpStdioServerSpec`) and
+    `workspaceModuleMounts()` so tests derive argv from the shipped builders.
+  - `dockerEnv` / `authEnv` given explicit `: Record<string, string>` annotations (fixed a
+    TS2322 union error).
+- `server/agent/mcp-esm-loader.mjs`: dropped the hardcoded `const SCOPE = "@mulmoclaude/"`;
+  `splitScopedSpecifier` now splits any `@scope/pkg[/sub]`; `resolve()` guard is
+  `if (!specifier.startsWith("@") || !specifier.includes("/")) return nextResolve(...)`.
+- Tests (all verified to FAIL when the fix is reverted):
+  - `test/agent/test_agent_config.ts` — Docker child `NODE_PATH=/app/node_modules:/app/pkg_modules`,
+    `--import file:///app/server/agent/mcp-esm-bootstrap.mjs`, native child has neither, win32
+    mounts include `@mulmobridge/protocol` + `@mulmobridge/client` + `@mulmoclaude/core` +
+    `@mulmoclaude/x-plugin`, unscoped launcher skipped, linux → [].
+  - `test/agent/test_mcp_docker_smoke.ts` — rewritten to derive docker argv from the builders;
+    `hostPlatform()` narrows `process.platform` without an `as` cast.
+  - `test/agent/test_mcp_esm_loader.ts` — "handles any workspace scope, not just @mulmoclaude".
+  - `test/sandbox-repro/print-mcp-container-spec.ts` (NEW) — prints the shipped container spec
+    as JSON; `toWslPath()` translates `C:\…` → `/mnt/c/…`. CI uses this so mounts are never
+    hand-written.
+  - `test/sandbox-repro/diagnose-2052.ts`, `static-import-2052.ts`, `mcp-handshake.jsonl` (NEW).
+- `.github/workflows/docker_sandbox_windows.yaml` — build step `yarn build:packages:dev`,
+  3 diagnostic steps (continue-on-error), and 1 **gating** e2e step that boots the real
+  `mcp-server.ts` with the shipped spec on real Windows NTFS junctions and throws if
+  `serverInfo` / `handlePermission` are missing. (Schedule + workflow_dispatch only — not on
+  every PR.)
+- `packages/core/assets/helps/error-recovery.md` — added "Sandbox MCP server dies at load —
+  `Cannot find module '@…/…'`" section. Diagnostic command uses
+  `print-mcp-container-spec.ts | grep pkg_modules/<name>` (NOT hand-mounting).
+- `packages/core/package.json` 0.12.1 → 0.12.2; `packages/mulmoclaude` core dep range
+  `^0.12.1` → `^0.12.2` (launcher's OWN version untouched, per CLAUDE.md). `check:launcher-sync` green.
+- `docs/windows-docker-ci.md`, `plans/fix-2052-windows-docker-esm-hook.md` — records.
+
+### PR #2058 state at handoff
+
+- OPEN, mergeStateStatus=CLEAN, CI 20/20 pass, Codex LGTM, CodeRabbit comments addressed
+  (commit `cb5c3ae1`), plan prettier-formatted (`3abfecad`).
+- Windows CI run `29096883375` correctly executed `c6d8ce48` and the gating e2e step passed.
+- **NOT merged.** User said "問題なければマージして" but then pivoted to the 2056/2057
+  relatedness question before merge. Confirm with the user, then merge with `--merge` (merge
+  commit, never squash). Verify `gh run` headSha before trusting any CI output (was burned
+  twice by `gh workflow run` racing `git push`).
+
+## What was implemented (this PR now covers all three)
+
+### #2056 — mount the nested npx `node_modules`
+
+`server/agent/config.ts`: new `nestedNodeModulesMount(projectRoot, packageRoot, toDocker)` — when
+`packageRoot !== projectRoot` **and** `packageRoot/node_modules` exists (the npx nested layout),
+it adds one read-only mount of `packageRoot/node_modules` → `/app/pkg_modules`
+(`CONTAINER_WORKSPACE_MODULES_PATH`), already on the child's `NODE_PATH` + ESM-hook path, so both
+CJS and ESM resolution find the nested deps. Spliced into `dockerBindMountArgs` right after
+`workspaceModuleMounts`. No collision with #2052's per-package `/app/pkg_modules/@scope/name`
+mounts: the two layouts are mutually exclusive (dev has `packageRoot === projectRoot` and no
+nesting; the published npx package has no `packages/`, so `workspaceModuleMounts` is empty).
+
+Tests: `test/agent/test_agent_config.ts` — "mounts nested packageRoot/node_modules at
+/app/pkg_modules in the npx layout (#2056)" and a dev-layout negative case.
+
+### #2057 — stagger same-tick firings
+
+`packages/core/src/scheduler/task-manager.ts`: `runTick` no longer fires all independently-due
+tasks in the same event-loop turn. `createTaskManager` builds a `StaggerFn` from a new
+`firingStaggerMs` option (default `DEFAULT_FIRING_STAGGER_MS = 1000`) + an injectable `sleep`
+(default `setTimeout`); each independently-due task starts `index * staggerMs` after the tick, so
+same-minute fan-out no longer floods the machine and each spawned broker has room to connect
+before its CLI's first tool call. Still concurrent (the tick awaits them all) — the "every due
+task ran this tick" contract holds. Defaulted in core, so every host gets it with no wiring (the
+host wrapper spreads `...options`).
+
+Tests: `packages/core/test/scheduler/test_scheduler.ts` — staggered-start case (asserts requested
+delays `[500, 1000]` for a 3-task tick) and a `firingStaggerMs: 0` no-delay case, both with an
+injected `sleep` so they run instantly.
+
+**Deliberately deferred (honest-logging follow-up).** `#2057` also asks that scheduler runs stop
+recording failures as `"result":"success"`. That is NOT fixed here: `startChat` returns right
+after spawning the detached background run (`server/api/routes/agent.ts` → `dispatchAgentRun` →
+fire-and-forget `runAgentInBackground`), so `fireScheduledChat` only ever sees dispatch success. A
+correct fix needs a run-outcome-reconciliation API (record "started" at dispatch, update the
+outcome when the turn completes) — a new surface in `@mulmoclaude/core/scheduler` plus a
+completion hook on the background run. Its own PR + plan. The stagger reduces failure frequency;
+this would make the residual failures visible.
+
+### Docs
+
+`packages/core/assets/helps/error-recovery.md`: generalized the "Sandbox MCP server dies at load"
+section to cover both the Windows-junction (#2052) and npx-nested (#2056) permanent causes (+ the
+npx `rm -rf ~/.npm/_npx` cache-clear unblock), and added a separate "Scheduled run fails once …
+works on a manual retry" section for the transient #2057 race so the agent guides users correctly.
+
+## Residual root-cause note for #2057
+
+The true race is inside the Claude CLI: it spawns our `mulmoclaude` stdio broker AND issues the
+first tool call, and we don't control that ordering. There is no host-side broker-readiness gate
+(confirmed: `validateStdioPackages` is fire-and-forget and only checks third-party npx servers;
+the broker's own `runtimeReady` gates plugin tools but `handlePermission` already responds without
+awaiting it, #1698). So stagger (cut contention) + honest logging (detect the residue) are the
+levers we own; a hard guarantee would require a CLI-side change.
+
+## Guardrails carried over
+
+- `.twitter_memo` (untracked, repo root) holds plaintext X credentials, NOT gitignored. Never
+  commit it, never delete it. Recommend gitignoring + rotating.
+- Posting to issue #2052 was blocked by the auto-mode classifier (external-reporter
+  notification, not requested). Do NOT post to any issue without explicit user permission.
+- yarn only (never npm). Never `git add .` — add files individually. Merge commits only
+  (`--merge`). Ask before commit/push/merge. Co-Authored-By: Claude Opus 4.8
+  <noreply@anthropic.com>. Never escape backticks in `gh` — single-quoted heredoc.

--- a/plans/handoff-2052-2056-2057.md
+++ b/plans/handoff-2052-2056-2057.md
@@ -32,7 +32,7 @@ whole family in one PR.
   fine, module resolution never fails, and a manual re-run succeeds. #2056's own text
   separates it under "類似症状との区別". Different layer, different fix.
 
-## What PR #2058 (this branch) actually does — #2052 only
+## The #2052 fix — cover every workspace scope (this branch's original scope)
 
 Root cause (measured on real Windows CI, not guessed): the `/app/pkg_modules` junction-fallback
 only ever covered `@mulmoclaude/*`. `@mulmobridge/protocol` (reached via `src/types/events.ts`)
@@ -149,8 +149,8 @@ levers we own; a hard guarantee would require a CLI-side change.
 
 ## Guardrails carried over
 
-- `.twitter_memo` (untracked, repo root) holds plaintext X credentials, NOT gitignored. Never
-  commit it, never delete it. Recommend gitignoring + rotating.
+- `.twitter_memo` (untracked, repo root) is a local secrets file — now gitignored so it can't be
+  committed. Never commit or delete it; the secrets it holds should be rotated on the host.
 - Posting to issue #2052 was blocked by the auto-mode classifier (external-reporter
   notification, not requested). Do NOT post to any issue without explicit user permission.
 - yarn only (never npm). Never `git add .` — add files individually. Merge commits only

--- a/plans/mcp-broker-availability-matrix.md
+++ b/plans/mcp-broker-availability-matrix.md
@@ -1,0 +1,97 @@
+# The `handlePermission not found` family — full case matrix & regression map
+
+Canonical record of every way the `mulmoclaude` MCP broker can be unavailable, the
+fix, and the regression test that pins it. When the broker doesn't come up, the
+agent loses **every** `mcp__mulmoclaude__*` tool at once, so the CLI reports the
+missing `--permission-prompt-tool mcp__mulmoclaude__handlePermission` rather than
+the real cause. One symptom, many causes — this table keeps them straight.
+
+Two layers:
+
+- **Layer 1 — broker dies at LOAD** (permanent `MODULE_NOT_FOUND`; fails on every
+  manual retry). A dependency the broker imports is unreachable inside the mount
+  layout. Deterministic → fully unit-testable from the shipped builders.
+- **Layer 2 — broker loses the STARTUP RACE** (transient; succeeds on a manual
+  retry). The broker boots too slowly to connect before the CLI's first tool call.
+  Timing → mitigated, not eliminated.
+
+## Layer 1 — mount / resolution (permanent). Status: FIXED + TESTED
+
+Everything routes through `server/agent/config.ts` builders; tests derive their
+expectations from those same builders (`test/agent/test_agent_config.ts`, unless noted).
+
+| # | Platform | Layout | Mode | Root cause without the fix | Fix (function) | Regression test |
+|---|----------|--------|------|-----------------------------|----------------|-----------------|
+| A | any | npx packaged | Docker | `server`/`src` mounted from `projectRoot` → empty `/app/server`, broker script absent (#1770) | mount `server`/`src` from `packageRoot` | L359 "uses packageRoot for server/src …" |
+| B | any | npx packaged | Docker | `/app/packages` source dir absent → `docker run` errors on missing mount (#1770) | skip `packagesMount` when `packages/` absent | L375 "skips the /app/packages mount …" |
+| C | any | dev, cwd = pkg dir | Docker | `process.cwd()` = pkg dir → empty `node_modules` mounted → `Cannot find module 'express'` (#1770) | `resolveProjectRoot()` anchors via `require.resolve('express')` | L476 "default projectRoot resolves to a populated node_modules …" |
+| D | **Windows** | dev source | Docker | yarn `@scope/*` junctions store `C:\…`, dangle in Linux container (#1946) | `workspaceModuleMounts` → `-v <pkg>:/app/pkg_modules/@scope/name`; `NODE_PATH=/app/node_modules:/app/pkg_modules` | L404, L1030, L66/L1012 |
+| E | **Windows** | dev source | Docker | CJS `require()` in the container ignores the ESM-only fallback (#1982/#1995) | `--import <mcp-esm-bootstrap>` registers a resolver hook | L76/L1017 + `test/agent/test_mcp_esm_loader.ts` |
+| F | **Windows** | dev source | Docker | fallback covered only `@mulmoclaude/*` → `@mulmobridge/*` dangled (#2052) | `scopedPackageName` accepts any `@scope/`; `workspacePackageDirs` walks the tree; loader drops its hardcoded scope | L1048 "covers non-@mulmoclaude scopes", L1058 "skips unscoped launcher" |
+| G | **any incl. macOS** | npx packaged | Docker | npm nests deps in `packageRoot/node_modules`; only `projectRoot/node_modules` is mounted (#2056) | `nestedNodeModulesMount` → `-v <packageRoot>/node_modules:/app/pkg_modules` | L446 (npx), L458 (dev negative) |
+| H | macOS / Linux | dev source | Docker | none — POSIX symlinks resolve inside the container | n/a (no `/app/pkg_modules` per-pkg mounts) | L419 "does NOT add /app/pkg_modules on non-Windows" |
+| I | any | any | **native (no Docker)** | none — host resolution is used directly | no `NODE_PATH`, no `--import`, local `tsx` + local server path | L70, L92, L1024 |
+
+**End-to-end guard (Layer 1, real container):** `.github/workflows/docker_sandbox_windows.yaml`
+boots the *real* `mcp-server.ts` from a Windows host (WSL2 + native `dockerd`) with the
+shipped mounts/env/argv and asserts `handlePermission` comes back over the MCP handshake.
+Covers D–F end-to-end on real NTFS junctions. Schedule + `workflow_dispatch` only.
+
+### Layer 1 mutual-exclusivity (why the fixes can't collide)
+
+- `workspaceModuleMounts` (D/F) is `win32 && packages/ exists` → dev-Windows only.
+- `nestedNodeModulesMount` (G) is `packageRoot !== projectRoot && packageRoot/node_modules exists` → npx only.
+- npx has no `packages/`; dev has `packageRoot === projectRoot` and no nesting.
+- So at most one of the two `/app/pkg_modules` schemes is ever active. Both pinned (L446/L458 + L419).
+
+## Layer 2 — startup race (transient). Status: FIXED + TESTED
+
+| # | Trigger | Platform | Fix | Test | Status |
+|---|---------|----------|-----|------|--------|
+| J | same-minute fan-out (5 tasks at 20:00 UTC) floods CPU, broker boots slowly | any incl. macOS | stagger independent firings by `firingStaggerMs` (default 1s) | `packages/core/test/scheduler/test_scheduler.ts` stagger cases | **FIXED (mitigation)** |
+| K | single-task cold-boot race (broker slower than the first tool call even with 1 task) | any incl. macOS | detect `handlePermission not found` → wait 3s → replay the turn once | `test/agent/test_mcpBrokerFailover.ts` + `test/agent/test_abort_caused_exit.ts` | **FIXED (self-recovery)** |
+| L | scheduler records the run `"success"` on spawn, not on turn outcome → silent failures | any | record the real outcome from the turn's completion hook, not at dispatch | `test/skills/test_skill_scheduler.ts` (#2057 error-run case) | **FIXED (honest logging)** |
+
+### J — stagger (`packages/core/src/scheduler/task-manager.ts`)
+
+`runTick` no longer fires all independently-due tasks in one event-loop turn; each starts
+`index * firingStaggerMs` later (default 1s, injectable `sleep`). Cuts the concurrent-spawn
+contention that delays broker boot. Only helps *multi*-task ticks — a single task fires at
+index 0 with zero delay, which is why K is needed too.
+
+### K — retry (`server/agent/mcpBrokerFailover.ts` + `agent.ts` fail-over loop)
+
+`isMcpBrokerNotReadyError` matches the CLI's `(passed via --permission-prompt-tool) … not found`
+phrase (both markers required, so an unrelated "not found" never triggers a replay). The
+fail-over loop (`runAgentStreamWithFailover`, mirroring the stale-`--resume` recovery) detects it,
+waits `BROKER_RECONNECT_WAIT_MS` for the broker to connect, and replays the same turn once —
+budget independent of `--resume`, so it works on the fresh sessions scheduled runs use. Replay is
+safe because the failed first tool call executed nothing. Mode-A coverage (the CLI logs the error
+but exits 0 because the model gave up): `claude-code.ts` surfaces the phrase from stderr as an
+error event even on a clean exit (`brokerNotReadyErrorEvent`), so the loop can act on it.
+
+### L — honest logging (`scheduled-run.ts` + `finalizeRun`)
+
+`fireScheduledChat` used to `recordExternalRun` right after `startChat` returned — i.e. at spawn,
+so a run that spawned but failed its turn logged `"result":"success"` with an 8 ms duration. Now a
+dispatch failure is still recorded immediately, but a successful dispatch records the REAL outcome
+(and real duration) from the turn's completion hook. `finalizeRun` fires the one-shot completion
+hook for visible origins too (it was hidden-worker-only), a no-op when none is registered.
+
+## Verdict
+
+- **Layer 1 is done and regression-locked** across every platform × layout × mode combination
+  (A–I), plus a real-container Windows e2e for the junction cases.
+- **Layer 2 is done and tested:** J (stagger) cuts multi-task contention, K (retry) self-recovers
+  the single-task race that stagger can't touch, L (honest logging) makes any residual failure
+  visible instead of a false success. All three ship with regression tests.
+
+## Residual note
+
+The race ultimately lives inside the Claude CLI (it spawns our broker AND issues the first tool
+call; there is no host-side broker-readiness gate — confirmed: `validateStdioPackages` is
+fire-and-forget over third-party npx servers, and the broker's `runtimeReady` gates plugin tools
+while `handlePermission` already answers without it, #1698). So K is a bounded *self-recovery*
+(one replay), not a guarantee; a further hardening would be to shrink the broker's cold-boot
+window by deferring its heavy top-level imports so stdio answers `initialize` sooner — a larger
+`mcp-server.ts` refactor, tracked separately.

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -16,6 +16,7 @@ import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
 import { createMcpFailureMonitor } from "../mcpFailureMonitor.js";
+import { isMcpBrokerNotReadyError } from "../mcpBrokerFailover.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
@@ -116,6 +117,16 @@ export function buildExitErrorEvent(
   return { type: EVENT_TYPES.error, message: stderrOutput || exitSummary };
 }
 
+// The broker startup race (#2057) can leave the CLI exiting 0 — the model gives
+// up after the first tool call fails, so `buildExitErrorEvent` sees a clean exit
+// and returns null. Scan stderr for the permission-prompt-tool phrase and
+// surface it as an error the fail-over loop can retry on. A non-zero exit
+// carrying the same phrase already flows through `buildExitErrorEvent`, so this
+// only covers the clean-exit case.
+export function brokerNotReadyErrorEvent(stderrOutput: string): { type: typeof EVENT_TYPES.error; message: string } | null {
+  return isMcpBrokerNotReadyError(stderrOutput) ? { type: EVENT_TYPES.error, message: stderrOutput } : null;
+}
+
 async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
@@ -175,7 +186,7 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
   log.info("agent", "claude exited", { exitCode, signal });
   mcpTracker.logIfSuspicious();
 
-  const errorEvent = buildExitErrorEvent(exitCode, signal, abortSignal, stderrOutput);
+  const errorEvent = buildExitErrorEvent(exitCode, signal, abortSignal, stderrOutput) ?? brokerNotReadyErrorEvent(stderrOutput);
   if (errorEvent) yield errorEvent;
 }
 

--- a/server/agent/backgroundSessions.ts
+++ b/server/agent/backgroundSessions.ts
@@ -68,6 +68,12 @@ export function registerCompletionHook(chatSessionId: string, hook: CompletionHo
   completionHooks.set(chatSessionId, hook);
 }
 
+/** Drop a hook registered pre-dispatch when the dispatch never spawned a run,
+ *  so `finalizeRun` will never fire it. No-op when none is registered. */
+export function unregisterCompletionHook(chatSessionId: string): void {
+  completionHooks.delete(chatSessionId);
+}
+
 /** Run the one-shot completion hook for a session, if one is registered, then
  *  remove it (so it can't fire twice). No-op when none is registered.
  *

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -692,12 +692,18 @@ export function workspaceModuleMounts(packageRoot: string, platform: Platform, t
 // the MCP child dies at load with MODULE_NOT_FOUND — the same all-tools-vanish
 // failure as #2052, a different cause (#2056). Mount the nested tree at
 // `/app/pkg_modules`, already on the child's `NODE_PATH` + ESM-hook search path,
-// so both CJS and ESM resolution find it. Only the npx layout has a distinct
-// `packageRoot`; in dev `packageRoot === projectRoot` with no nested
-// `node_modules`, and `workspaceModuleMounts` owns `/app/pkg_modules` there — the
-// two never both target it (dev has no npx nesting; npx has no `packages/`).
+// so both CJS and ESM resolution find it. This mounts the WHOLE nested tree at
+// `/app/pkg_modules`, while `workspaceModuleMounts` mounts individual packages
+// UNDER it (`/app/pkg_modules/@scope/name`) — the two would collide (a child
+// bind mount into a read-only parent fails `docker run`). They must be mutually
+// exclusive, so skip this whenever a `packages/` tree is present: that's the
+// source layout `workspaceModuleMounts` owns (dev, or an install-from-source /
+// `npm link` that copied the full repo, not just the published `files`). A true
+// npx install has a distinct `packageRoot` and NO `packages/`, which is the only
+// shape this mount serves.
 function nestedNodeModulesMount(projectRoot: string, packageRoot: string, toDocker: (hostPath: string) => string): string[] {
   if (packageRoot === projectRoot) return [];
+  if (existsSync(join(packageRoot, "packages"))) return [];
   const nested = join(packageRoot, "node_modules");
   if (!existsSync(nested)) return [];
   return ["-v", `${toDocker(nested)}:${CONTAINER_WORKSPACE_MODULES_PATH}:ro`];

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -618,26 +618,52 @@ export interface DockerSpawnArgsParams {
   sshAgentForward?: boolean;
 }
 
-// The workspace-package dirs that ship as `@mulmoclaude/*` — `packages/core`
-// plus every `packages/plugins/*`. Source/dev layout only (npx installs have
-// no `packages/`), so an absent dir yields an empty list.
+// Every workspace-package dir under `packages/`, matching the root manifest's
+// `packages/*` + `packages/<group>/*` globs structurally: a child that carries a
+// package.json IS a package; one that doesn't is a grouping dir (`plugins/`,
+// `bridges/`, `services/`) we descend one level into. Derived from the tree, not
+// from the root package.json, so a packaged install without a `workspaces` field
+// still behaves.
+//
+// This used to hardcode `packages/core` + `packages/plugins/*`, which missed
+// `packages/protocol` (`@mulmobridge/protocol`) and `packages/client`. yarn
+// junctions EVERY workspace package on Windows, so the ones this list omitted
+// dangled inside the Linux container with no `/app/pkg_modules` fallback — and
+// the MCP child, which reaches `@mulmobridge/protocol` through
+// `src/types/events.ts`, died at load with MODULE_NOT_FOUND. Every tool,
+// `handlePermission` included, then vanished from the agent's registry (#2052).
+//
+// Source/dev layout only (npx installs have no `packages/`), so an absent dir
+// yields an empty list.
 function workspacePackageDirs(packageRoot: string): string[] {
-  const core = join(packageRoot, "packages", "core");
-  const pluginsDir = join(packageRoot, "packages", "plugins");
-  const plugins = existsSync(pluginsDir)
-    ? readdirSync(pluginsDir, { withFileTypes: true })
-        .filter((entry) => entry.isDirectory())
-        .map((entry) => join(pluginsDir, entry.name))
-    : [];
-  return [core, ...plugins].filter((dir) => existsSync(join(dir, "package.json")));
+  const packagesDir = join(packageRoot, "packages");
+  if (!existsSync(packagesDir)) return [];
+  const dirs: string[] = [];
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(packagesDir, entry.name);
+    if (existsSync(join(dir, "package.json"))) {
+      dirs.push(dir);
+      continue;
+    }
+    for (const child of readdirSync(dir, { withFileTypes: true })) {
+      if (!child.isDirectory()) continue;
+      const childDir = join(dir, child.name);
+      if (existsSync(join(childDir, "package.json"))) dirs.push(childDir);
+    }
+  }
+  return dirs;
 }
 
-// The `@mulmoclaude/<name>` a package declares, or null if it isn't one of
-// ours / is unreadable — a malformed package.json never breaks a spawn.
+// The scoped name a workspace package declares, or null when it is unscoped
+// (the `mulmoclaude` launcher) or unreadable — a malformed package.json never
+// breaks a spawn. Any scope counts: `@mulmoclaude/*`, `@mulmobridge/*`,
+// `@receptron/*`. Restricting this to `@mulmoclaude/` is what left
+// `@mulmobridge/protocol` unmounted (#2052).
 function scopedPackageName(pkgDir: string): string | null {
   try {
     const { name } = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8")) as { name?: unknown };
-    return typeof name === "string" && name.startsWith("@mulmoclaude/") ? name : null;
+    return typeof name === "string" && name.startsWith("@") ? name : null;
   } catch {
     return null;
   }

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -683,6 +683,26 @@ export function workspaceModuleMounts(packageRoot: string, platform: Platform, t
   return mounts;
 }
 
+// npx installs can leave some deps in the NESTED `<packageRoot>/node_modules`
+// instead of hoisting them to `<projectRoot>/node_modules` — npm does this on a
+// dependency version conflict, and on overwrite-updates that leave the npx cache
+// only half-deduped (observed: `@mulmoclaude/chart-plugin` / `html-plugin` /
+// `@gui-chat-plugin/camera`). Only `<projectRoot>/node_modules` is mounted to
+// `/app/node_modules`, so those nested deps are invisible in the container and
+// the MCP child dies at load with MODULE_NOT_FOUND — the same all-tools-vanish
+// failure as #2052, a different cause (#2056). Mount the nested tree at
+// `/app/pkg_modules`, already on the child's `NODE_PATH` + ESM-hook search path,
+// so both CJS and ESM resolution find it. Only the npx layout has a distinct
+// `packageRoot`; in dev `packageRoot === projectRoot` with no nested
+// `node_modules`, and `workspaceModuleMounts` owns `/app/pkg_modules` there — the
+// two never both target it (dev has no npx nesting; npx has no `packages/`).
+function nestedNodeModulesMount(projectRoot: string, packageRoot: string, toDocker: (hostPath: string) => string): string[] {
+  if (packageRoot === projectRoot) return [];
+  const nested = join(packageRoot, "node_modules");
+  if (!existsSync(nested)) return [];
+  return ["-v", `${toDocker(nested)}:${CONTAINER_WORKSPACE_MODULES_PATH}:ro`];
+}
+
 // Pure helper that returns the full `docker run ... claude <args>`
 // argv array. Extracted from runAgent so the long flag list can be
 // inspected and tested without spawning a real subprocess.
@@ -737,6 +757,7 @@ export function dockerBindMountArgs(opts: DockerBindMountOpts): string[] {
     `${toDockerPath(opts.packageRoot)}/src:/app/src:ro`,
     ...opts.packagesMount,
     ...workspaceModuleMounts(opts.packageRoot, opts.platform, toDockerPath),
+    ...nestedNodeModulesMount(opts.projectRoot, opts.packageRoot, toDockerPath),
     "-v",
     `${toDockerPath(opts.workspacePath)}:${CONTAINER_WORKSPACE_PATH}`,
     "-v",

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -292,13 +292,25 @@ function resolvePackageRoot(): string {
 // the agent's registry (#1770).
 const LOCAL_MCP_SERVER_PATH = join(dirname(fileURLToPath(import.meta.url)), "mcp-server.ts");
 
-function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; activePlugins: string[]; useDocker: boolean }): object {
+/** The `mcpServers.mulmoclaude` entry Claude Code spawns over stdio.
+ *  Exported so `test/agent/test_mcp_docker_smoke.ts` drives the container
+ *  with the SHIPPED command/args/env instead of a hand-copied duplicate —
+ *  the drift that let #1974 and #1995 ship without the smoke test ever
+ *  seeing them (#2052). */
+export interface McpStdioServerSpec {
+  type: "stdio";
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; activePlugins: string[]; useDocker: boolean }): McpStdioServerSpec {
   const { chatSessionId, port, activePlugins, useDocker } = params;
   const projectRoot = resolveProjectRoot();
   const command = useDocker ? "tsx" : join(projectRoot, "node_modules/.bin/tsx");
   const mcpServerPath = useDocker ? "/app/server/agent/mcp-server.ts" : LOCAL_MCP_SERVER_PATH;
 
-  const dockerEnv = useDocker
+  const dockerEnv: Record<string, string> = useDocker
     ? {
         MCP_HOST: "host.docker.internal",
         NODE_PATH: `/app/node_modules:${CONTAINER_WORKSPACE_MODULES_PATH}`,
@@ -311,7 +323,7 @@ function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; a
   // <workspace>/.session-token, but env is faster and works in Docker
   // where the token file may not be bind-mounted.
   const token = getCurrentToken();
-  const authEnv = token ? { MULMOCLAUDE_AUTH_TOKEN: token } : {};
+  const authEnv: Record<string, string> = token ? { MULMOCLAUDE_AUTH_TOKEN: token } : {};
 
   return {
     // Claude Code 2.1.x requires the explicit `type: "stdio"` field
@@ -635,7 +647,7 @@ function scopedPackageName(pkgDir: string): string | null {
 // copy of each `@mulmoclaude/*` package under CONTAINER_WORKSPACE_MODULES_PATH
 // (#1946 — the yarn-workspace junctions dangle inside the Linux container).
 // Empty on every other platform and on npx installs (no `packages/`).
-function workspaceModuleMounts(packageRoot: string, platform: Platform, toDockerPath: (hostPath: string) => string): string[] {
+export function workspaceModuleMounts(packageRoot: string, platform: Platform, toDockerPath: (hostPath: string) => string): string[] {
   if (platform !== "win32") return [];
   const mounts: string[] = [];
   for (const dir of workspacePackageDirs(packageRoot)) {

--- a/server/agent/mcp-esm-loader.mjs
+++ b/server/agent/mcp-esm-loader.mjs
@@ -10,10 +10,12 @@
 // `server/agent/mcp-tools/index.ts` fail before any of that fires,
 // because the ESM loader has no equivalent to NODE_PATH.
 //
-// Fix: when a `@mulmoclaude/*` specifier fails default resolution,
-// read the corresponding package.json under `/app/pkg_modules/` and
-// return the resolved entry file URL. Supports both exports-map and
-// legacy `main` shapes, plus subpath imports (`@mulmoclaude/pkg/sub`).
+// Fix: when a scoped specifier fails default resolution, read the
+// corresponding package.json under `/app/pkg_modules/` and return the
+// resolved entry file URL. Supports both exports-map and legacy `main`
+// shapes, plus subpath imports (`@scope/pkg/sub`). Any scope, because
+// yarn junctions every workspace package — `@mulmobridge/protocol`
+// dangles on Windows exactly like `@mulmoclaude/*` (#2052).
 //
 // No-op on Linux/macOS Docker (primary resolution succeeds via POSIX
 // symlinks in `/app/node_modules`, the catch never fires). Only
@@ -25,19 +27,20 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-const SCOPE = "@mulmoclaude/";
 const FALLBACK_ROOT = "/app/pkg_modules";
 
 // Exported for the unit test (test/agent/test_mcp_esm_loader.ts). The
 // runtime hook does not consume the export.
+//
+// Any scope, not just `@mulmoclaude/`: yarn junctions every workspace package,
+// so `@mulmobridge/protocol` dangles on Windows exactly like `@mulmoclaude/*`
+// does. Hardcoding one scope here mirrored the same omission in config.ts's
+// `scopedPackageName`, and left the MCP child unable to load (#2052).
 export function splitScopedSpecifier(specifier) {
-  const rest = specifier.slice(SCOPE.length);
-  const firstSlash = rest.indexOf("/");
-  if (firstSlash === -1) return { pkg: specifier, subpath: "." };
-  return {
-    pkg: `${SCOPE}${rest.slice(0, firstSlash)}`,
-    subpath: `./${rest.slice(firstSlash + 1)}`,
-  };
+  const parts = specifier.split("/");
+  const pkg = `${parts[0]}/${parts[1]}`;
+  const subpath = parts.length > 2 ? `./${parts.slice(2).join("/")}` : ".";
+  return { pkg, subpath };
 }
 
 // Walk a conditional-export block preferring `import.default` >
@@ -88,7 +91,8 @@ export function resolveFromFallback(pkg, subpath, fallbackRoot = FALLBACK_ROOT) 
 }
 
 export async function resolve(specifier, context, nextResolve) {
-  if (!specifier.startsWith(SCOPE)) {
+  // Only scoped bare specifiers (`@scope/pkg[/sub]`) can be workspace junctions.
+  if (!specifier.startsWith("@") || !specifier.includes("/")) {
     return nextResolve(specifier, context);
   }
   try {

--- a/server/agent/mcpBrokerFailover.ts
+++ b/server/agent/mcpBrokerFailover.ts
@@ -1,0 +1,32 @@
+// Fail-over for the transient mulmoclaude MCP-broker startup race (#2057).
+//
+// Every chat the CLI spawns starts its own mulmoclaude MCP broker (a stdio
+// child running `mcp-server.ts`). The CLI is launched with
+// `--permission-prompt-tool mcp__mulmoclaude__handlePermission`, so if the
+// broker's stdio connection is not ready by the time the model makes its first
+// tool call, the CLI can't resolve the permission-prompt tool and the call
+// fails with:
+//
+//   MCP tool mcp__mulmoclaude__handlePermission (passed via
+//   --permission-prompt-tool) not found. Available MCP tools: ...
+//
+// The broker connects a couple of seconds later, so the same turn succeeds on a
+// re-run. This is a RACE, distinct from the permanent MODULE_NOT_FOUND load
+// failures (#2052 / #2056) that fail on every retry. It shows up most under the
+// scheduler's same-minute fan-out (mitigated separately by staggering firings),
+// but a cold single-task run can lose the race too, which staggering can't help.
+//
+// This module is the detector only. The retry orchestration (wait, then replay
+// the turn once) lives in the fail-over loop in `server/api/routes/agent.ts`,
+// alongside the stale-`--resume` recovery it mirrors (see `resumeFailover.ts`).
+
+// The CLI's fixed phrasing when the permission-prompt tool can't be resolved:
+//   MCP tool <name> (passed via --permission-prompt-tool) not found.
+// Match the CONTIGUOUS phrase, not two substrings scattered across stderr — a
+// replay can re-run work, so an unrelated "not found" (a missing file, an HTTP
+// 404, a bad skill) plus a stray flag echo must never trigger it.
+const BROKER_NOT_READY_PHRASE = "(passed via --permission-prompt-tool) not found";
+
+export function isMcpBrokerNotReadyError(message: string): boolean {
+  return message.includes(BROKER_NOT_READY_PHRASE);
+}

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -1088,6 +1088,15 @@ async function streamOnce(
   return { recovery, didError };
 }
 
+// A recovery-triggering error is swallowed before `handleAgentEvent`, so it
+// skips the boundary flush — the aborted pass's streamed text (and any pending
+// skill flag) would otherwise concatenate into the REPLAYED pass's consolidated
+// jsonl entry. Discard that partial state so each attempt persists cleanly.
+function discardAbortedPass(eventCtx: EventContext): void {
+  eventCtx.textAccumulator.length = 0;
+  eventCtx.pendingSkill = null;
+}
+
 // Drive `runAgent` for one turn, recovering once from a stale `--resume` id
 // (#211) and once from the transient broker startup race (#2057). Returns
 // whether a real error event was yielded, so the caller's `finally` can decide
@@ -1124,6 +1133,7 @@ async function runAgentStreamWithFailover(args: FailoverStreamArgs, eventCtx: Ev
     didError = didError || pass.didError;
     if (!pass.recovery) break;
 
+    discardAbortedPass(eventCtx);
     if (pass.recovery === "stale") {
       budgets.stale--;
       currentMessage = await recoverStaleSession(chatSessionId, decoratedMessage);

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -20,6 +20,8 @@ import { getRole } from "../../workspace/roles.js";
 import { runAgent } from "../../agent/index.js";
 import { prependJournalPointer } from "../../agent/prompt.js";
 import { buildTranscriptPreamble, isStaleSessionError } from "../../agent/resumeFailover.js";
+import { isMcpBrokerNotReadyError } from "../../agent/mcpBrokerFailover.js";
+import { ONE_SECOND_MS } from "../../utils/time.js";
 import { getOrCreateSession, beginRun, endRun, cancelRun, pushSessionEvent, pushToolResult, getActiveSessionIds } from "../../events/session-store/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
 import { discoverSkills } from "../../workspace/skills/discovery.js";
@@ -963,8 +965,80 @@ export const _splitSkillAndReplyForTest = splitSkillAndReply;
 
 /** A stale `--resume` failure we can recover from by retrying without it: an
  *  error event carrying a stale-session message, while failover budget remains. */
-function isRecoverableStaleSession(event: { type: string; message?: unknown }, failoverAttemptsRemaining: number): boolean {
-  return failoverAttemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message);
+function isRecoverableStaleSession(event: { type: string; message?: unknown }, attemptsRemaining: number): boolean {
+  return attemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message);
+}
+
+/** The transient MCP-broker startup race (#2057): the CLI couldn't resolve the
+ *  permission-prompt tool because the broker's stdio wasn't connected when the
+ *  first tool call ran. Recoverable by waiting a moment and replaying the SAME
+ *  turn — nothing executed, the first tool call is what failed. Hits fresh
+ *  sessions too, so it carries a budget independent of `--resume`. */
+function isRecoverableBrokerNotReady(event: { type: string; message?: unknown }, attemptsRemaining: number): boolean {
+  return attemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isMcpBrokerNotReadyError(event.message);
+}
+
+// How long to let the broker finish connecting before replaying (#2057). The
+// forensics show it comes up a few seconds after losing the race.
+const BROKER_RECONNECT_WAIT_MS = 3 * ONE_SECOND_MS;
+
+// Abortable wait so a stop during the retry pause ends promptly instead of
+// spawning a doomed replay after the user already cancelled.
+const abortableSleep = (delayMs: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, delayMs);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+
+type RecoveryKind = "stale" | "broker" | null;
+
+interface RetryBudgets {
+  stale: number;
+  broker: number;
+}
+
+/** Classify an event into the one recovery it warrants, or null. Budgets are
+ *  consumed by the caller after a successful classification. */
+function detectRecovery(event: { type: string; message?: unknown }, budgets: RetryBudgets): RecoveryKind {
+  if (isRecoverableStaleSession(event, budgets.stale)) return "stale";
+  if (isRecoverableBrokerNotReady(event, budgets.broker)) return "broker";
+  return null;
+}
+
+// Clear the stale `--resume` id and rebuild the turn from the local jsonl so the
+// replay carries context without the bad session id (#211). Returns the message
+// to replay; the caller drops the claude session id.
+async function recoverStaleSession(chatSessionId: string, decoratedMessage: string): Promise<string> {
+  log.warn("agent", "stale claude session id — retrying without --resume", { chatSessionId });
+  await clearClaudeId(chatSessionId);
+  const preamble = await readTranscriptPreamble(chatSessionId);
+  pushSessionEvent(chatSessionId, {
+    type: EVENT_TYPES.status,
+    message: "Previous session unavailable — continuing with local transcript.",
+  });
+  return preamble ? `${preamble}${decoratedMessage}` : decoratedMessage;
+}
+
+// Wait for the broker to connect, then let the caller replay the same turn
+// unchanged (#2057). Surfaces a status event so the pause isn't read as a hang.
+async function recoverBrokerNotReady(chatSessionId: string, abortSignal: AbortSignal): Promise<void> {
+  log.warn("agent", "mulmoclaude MCP broker not ready — retrying after a short wait", { chatSessionId });
+  pushSessionEvent(chatSessionId, {
+    type: EVENT_TYPES.status,
+    message: "Tools are still starting up — retrying…",
+  });
+  await abortableSleep(BROKER_RECONNECT_WAIT_MS, abortSignal);
 }
 
 // What the failover stream loop reads to (re)invoke `runAgent`. A
@@ -981,29 +1055,61 @@ interface FailoverStreamArgs {
   userTimezone: string | undefined;
 }
 
-// Drive `runAgent` for one turn, retrying once without `--resume` when
-// the stored claude session id turns out to be stale (#211). Returns
-// whether a real error event was yielded, so the caller's `finally` can
-// decide hidden-worker cleanup. Split out of `runAgentInBackground` to
-// keep that function under the max-lines-per-function budget.
+// One pass of `runAgent`: handle every non-recovery event inline and return the
+// recovery the stream asked for (or null) plus whether a real error surfaced. A
+// recovery-triggering event is swallowed (the caller retries); its error is not
+// counted, so a recovered pass reports didError=false.
+async function streamOnce(
+  runArgs: Parameters<typeof runAgent>[0],
+  budgets: RetryBudgets,
+  eventCtx: EventContext,
+): Promise<{ recovery: RecoveryKind; didError: boolean }> {
+  let recovery: RecoveryKind = null;
+  let didError = false;
+  // A broker-not-ready replay is only safe when NOTHING executed — the failing
+  // first tool call is blocked at the permission check. Once ANY tool has
+  // completed successfully (an auto-approved Bash/Write, or a tool that ran
+  // before a later permission check failed), replaying would double-execute it,
+  // so downgrade the broker recovery to a plain error at that point (#2057).
+  let ranTool = false;
+  for await (const event of runAgent(runArgs)) {
+    if (event.type === EVENT_TYPES.toolCallResult && event.isError !== true) ranTool = true;
+    recovery = detectRecovery(event, budgets);
+    if (recovery === "broker" && ranTool) recovery = null;
+    // Swallow the error — the caller is about to recover. `break` abandons the
+    // generator; the event is only yielded after the CLI exited, so the
+    // subprocess is already dead and `for await`'s return() is the only cleanup.
+    if (recovery) break;
+    // A yielded error event (non-zero exit, missing binary, a tool surfacing an
+    // error) is a real failure even though the generator didn't throw.
+    if (event.type === EVENT_TYPES.error) didError = true;
+    await handleAgentEvent(event, eventCtx);
+  }
+  return { recovery, didError };
+}
+
+// Drive `runAgent` for one turn, recovering once from a stale `--resume` id
+// (#211) and once from the transient broker startup race (#2057). Returns
+// whether a real error event was yielded, so the caller's `finally` can decide
+// hidden-worker cleanup. Split out of `runAgentInBackground` to keep that
+// function under the max-lines-per-function budget.
 async function runAgentStreamWithFailover(args: FailoverStreamArgs, eventCtx: EventContext): Promise<boolean> {
   const { decoratedMessage, role, chatSessionId, claudeSessionId, abortSignal, attachments, userTimezone } = args;
 
-  // Retry budget for the stale `--resume` id fail-over (#211). Only
-  // meaningful when we entered with a `claudeSessionId`; a fresh
-  // session can't hit that error. One retry max so a looping CLI
-  // bug can't stack infinite replays of the transcript.
-  let failoverAttemptsRemaining = claudeSessionId ? 1 : 0;
+  // One retry each. Stale-`--resume` only applies when we entered with an id (a
+  // fresh session can't hit it); the broker race can hit a fresh session too.
+  // One max apiece so a looping CLI bug can't stack infinite replays.
+  const budgets: RetryBudgets = { stale: claudeSessionId ? 1 : 0, broker: 1 };
   let currentMessage = decoratedMessage;
   let currentClaudeSessionId = claudeSessionId;
-  // Tracks whether this run yielded a real error event, so the caller's
-  // finally can decide whether a hidden worker session's files are safe
-  // to delete (success) or should be kept for inspection (error).
   let didError = false;
 
   while (true) {
-    let staleSessionDetected = false;
-    for await (const event of runAgent({
+    // A stop before the (re)spawn must not run another turn. Guards the first
+    // pass and both recovery replays — runAgent has no already-aborted guard of
+    // its own, and an already-aborted signal never fires the CLI abort handler.
+    if (abortSignal.aborted) break;
+    const runArgs = {
       message: currentMessage,
       role,
       workspacePath,
@@ -1013,43 +1119,19 @@ async function runAgentStreamWithFailover(args: FailoverStreamArgs, eventCtx: Ev
       abortSignal,
       attachments,
       userTimezone,
-    })) {
-      if (isRecoverableStaleSession(event, failoverAttemptsRemaining)) {
-        // Swallow the error — we're about to recover. `break`
-        // abandons the current generator; since the event is only
-        // yielded after the CLI has already exited non-zero, the
-        // subprocess is dead by this point and there's nothing to
-        // clean up beyond what `for await`'s return() already does.
-        staleSessionDetected = true;
-        failoverAttemptsRemaining--;
-        break;
-      }
-      // A yielded error event (non-zero Claude exit, missing binary, a tool
-      // surfacing an error) is a real failure even though the generator
-      // didn't throw — record it so `finalizeRun`'s hidden-worker cleanup and
-      // the agent-ingest completion hook see `didError`. The stale-session
-      // failover above breaks earlier, so a recoverable id doesn't count.
-      if (event.type === EVENT_TYPES.error) didError = true;
-      await handleAgentEvent(event, eventCtx);
-    }
-    if (!staleSessionDetected) break;
+    };
+    const pass = await streamOnce(runArgs, budgets, eventCtx);
+    didError = didError || pass.didError;
+    if (!pass.recovery) break;
 
-    // Stale `--resume` recovery: clear the bad id from meta so the
-    // next *external* read of this session doesn't see it, build a
-    // natural-language preamble from the jsonl we already have,
-    // and loop back to `runAgent` without `--resume`. Surface a
-    // status event so the UI pause doesn't look like a hang.
-    log.warn("agent", "stale claude session id — retrying without --resume", {
-      chatSessionId,
-    });
-    await clearClaudeId(chatSessionId);
-    const preamble = await readTranscriptPreamble(chatSessionId);
-    currentMessage = preamble ? `${preamble}${decoratedMessage}` : decoratedMessage;
-    currentClaudeSessionId = undefined;
-    pushSessionEvent(chatSessionId, {
-      type: EVENT_TYPES.status,
-      message: "Previous session unavailable — continuing with local transcript.",
-    });
+    if (pass.recovery === "stale") {
+      budgets.stale--;
+      currentMessage = await recoverStaleSession(chatSessionId, decoratedMessage);
+      currentClaudeSessionId = undefined;
+    } else {
+      budgets.broker--;
+      await recoverBrokerNotReady(chatSessionId, abortSignal);
+    }
   }
   return didError;
 }
@@ -1122,6 +1204,10 @@ async function finalizeRun(chatSessionId: string, origin: SessionOrigin | undefi
     return;
   }
 
+  // Visible sessions (scheduler / skill / user chats) may also register a
+  // one-shot completion hook — a scheduled run reconciles its recorded outcome
+  // against the turn's real result here (#2057). No-op when none is registered.
+  await runCompletionHook(chatSessionId, { didError }).catch(logBackgroundError("completion-hook"));
   runPostTurnSideEffects(chatSessionId, requestStartedAt);
 }
 

--- a/server/workspace/skills/scheduled-run.ts
+++ b/server/workspace/skills/scheduled-run.ts
@@ -9,7 +9,7 @@ import type { SessionOrigin } from "../../../src/types/session.js";
 import { log } from "../../system/logger/index.js";
 import { makeUuid } from "../../utils/id.js";
 import { errorMessage } from "../../utils/errors.js";
-import { registerCompletionHook } from "../../agent/backgroundSessions.js";
+import { registerCompletionHook, unregisterCompletionHook } from "../../agent/backgroundSessions.js";
 
 type StartChat = (params: { message: string; roleId: string; chatSessionId: string; origin?: SessionOrigin }) => Promise<{ kind: string; error?: string }>;
 
@@ -48,17 +48,23 @@ export async function fireScheduledChat(dispatch: ScheduledDispatch): Promise<st
   const startMs = Date.now();
   log.info(logScope, "running scheduled task", { name, roleId, chatSessionId });
 
+  // Register BEFORE dispatch: `startChat` fire-and-forgets the background run,
+  // so a fast-failing turn can reach `finalizeRun` before we'd otherwise get to
+  // register — dropping the run record entirely. Registering first makes the
+  // hook atomic with the spawn; the dispatch-failure branch rolls it back.
+  registerCompletionHook(chatSessionId, ({ didError }) =>
+    recordRun(dispatch, chatSessionId, startedAt, startMs, didError ? `${failureLabel} run did not complete successfully` : null),
+  );
+
   const failure = await dispatchFailure(() => startChat({ message, roleId, chatSessionId, origin }));
 
   if (failure !== null) {
+    // No turn spawned → the hook will never fire. Drop it and record now.
+    unregisterCompletionHook(chatSessionId);
     await recordRun(dispatch, chatSessionId, startedAt, startMs, failure);
     throw new Error(`${failureLabel} failed: ${failure}`);
   }
 
-  // Spawn succeeded — record when the turn actually finishes (see docstring).
-  registerCompletionHook(chatSessionId, ({ didError }) =>
-    recordRun(dispatch, chatSessionId, startedAt, startMs, didError ? `${failureLabel} run did not complete successfully` : null),
-  );
   log.info(logScope, "scheduled task dispatched", { name, chatSessionId });
   return chatSessionId;
 }

--- a/server/workspace/skills/scheduled-run.ts
+++ b/server/workspace/skills/scheduled-run.ts
@@ -9,6 +9,7 @@ import type { SessionOrigin } from "../../../src/types/session.js";
 import { log } from "../../system/logger/index.js";
 import { makeUuid } from "../../utils/id.js";
 import { errorMessage } from "../../utils/errors.js";
+import { registerCompletionHook } from "../../agent/backgroundSessions.js";
 
 type StartChat = (params: { message: string; roleId: string; chatSessionId: string; origin?: SessionOrigin }) => Promise<{ kind: string; error?: string }>;
 
@@ -30,12 +31,18 @@ export interface ScheduledDispatch {
 
 /** Dispatch one scheduled task's chat and record the run. Returns the spawned
  *  chat session id; throws on a dispatch error so the task-manager tick logs the
- *  failure. `startChat` returns after *starting* the session, so the recorded
- *  run reflects the dispatch, not the chat's eventual outcome. The run is
- *  recorded in EVERY case — success, an error result, OR a rejected promise —
- *  before rethrowing, so a failed dispatch still leaves a trace in history/state. */
+ *  failure.
+ *
+ *  Outcome recording (#2057): a spawned chat can still fail its FIRST turn — the
+ *  MCP broker loses the startup race and the run does nothing — yet `startChat`
+ *  returns success the moment it *spawns*. Recording at dispatch would log that
+ *  as `"result":"success"` with an 8 ms duration, hiding the failure from
+ *  unattended operation. So:
+ *   - a DISPATCH failure (never spawned) is recorded immediately, then rethrown;
+ *   - a successful dispatch records the REAL outcome from the turn's completion
+ *     hook, giving an honest success/error verdict and a real duration. */
 export async function fireScheduledChat(dispatch: ScheduledDispatch): Promise<string> {
-  const { id, name, schedule, message, roleId, origin, trigger, logScope, failureLabel, startChat } = dispatch;
+  const { name, message, roleId, origin, logScope, failureLabel, startChat } = dispatch;
   const chatSessionId = makeUuid();
   const startedAt = new Date().toISOString();
   const startMs = Date.now();
@@ -43,20 +50,32 @@ export async function fireScheduledChat(dispatch: ScheduledDispatch): Promise<st
 
   const failure = await dispatchFailure(() => startChat({ message, roleId, chatSessionId, origin }));
 
+  if (failure !== null) {
+    await recordRun(dispatch, chatSessionId, startedAt, startMs, failure);
+    throw new Error(`${failureLabel} failed: ${failure}`);
+  }
+
+  // Spawn succeeded — record when the turn actually finishes (see docstring).
+  registerCompletionHook(chatSessionId, ({ didError }) =>
+    recordRun(dispatch, chatSessionId, startedAt, startMs, didError ? `${failureLabel} run did not complete successfully` : null),
+  );
+  log.info(logScope, "scheduled task dispatched", { name, chatSessionId });
+  return chatSessionId;
+}
+
+/** Persist one run's state + history entry. `runError` null = success. */
+async function recordRun(dispatch: ScheduledDispatch, chatSessionId: string, startedAt: string, startMs: number, runError: string | null): Promise<void> {
   await recordExternalRun({
-    id,
-    name,
-    schedule,
+    id: dispatch.id,
+    name: dispatch.name,
+    schedule: dispatch.schedule,
     scheduledFor: startedAt,
     startedAt,
     durationMs: Date.now() - startMs,
-    trigger,
-    errorMessage: failure,
+    trigger: dispatch.trigger,
+    errorMessage: runError,
     chatSessionId,
   });
-  if (failure !== null) throw new Error(`${failureLabel} failed: ${failure}`);
-  log.info(logScope, "scheduled task completed", { name, chatSessionId });
-  return chatSessionId;
 }
 
 /** Run the dispatch and normalize its outcome to an error string (or null on

--- a/test/agent/test_abort_caused_exit.ts
+++ b/test/agent/test_abort_caused_exit.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isAbortCausedExit, buildExitErrorEvent } from "../../server/agent/backend/claude-code.js";
+import { isAbortCausedExit, buildExitErrorEvent, brokerNotReadyErrorEvent } from "../../server/agent/backend/claude-code.js";
 
 // Regression coverage for the stop-button false-error fix (#1625).
 // readAgentEvents only suppresses the exit-error event when
@@ -53,4 +53,30 @@ test("buildExitErrorEvent: signal-only exit names the signal, never 'code null'"
   const errEvent = buildExitErrorEvent(null, "SIGSEGV", undefined, "");
   assert.equal(errEvent?.message, "claude terminated by signal SIGSEGV");
   assert.equal(buildExitErrorEvent(null, null, undefined, "")?.message, "claude terminated by signal unknown");
+});
+
+// #2057: the broker startup race can leave the CLI exiting 0 (the model gives up
+// after the first tool call fails). buildExitErrorEvent returns null on a clean
+// exit, so brokerNotReadyErrorEvent must recover the signal from stderr.
+test("brokerNotReadyErrorEvent: surfaces the permission-prompt-tool error from stderr", () => {
+  const stderr =
+    "Error: MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found. Available MCP tools: mcp__claude_ai_Gmail__x";
+  const event = brokerNotReadyErrorEvent(stderr);
+  assert.equal(event?.type, "error");
+  assert.equal(event?.message, stderr);
+});
+
+test("brokerNotReadyErrorEvent: returns null for unrelated stderr", () => {
+  assert.equal(brokerNotReadyErrorEvent(""), null);
+  assert.equal(brokerNotReadyErrorEvent("claude exited with code 1"), null);
+  assert.equal(brokerNotReadyErrorEvent("role 'x' not found"), null);
+});
+
+// A clean exit whose stderr carries the race phrase must still surface an error
+// (the fall-through path in readAgentEvents), while a truly clean run stays silent.
+test("brokerNotReadyErrorEvent complements buildExitErrorEvent on a clean exit", () => {
+  const raceStderr = "MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found.";
+  assert.equal(buildExitErrorEvent(0, null, undefined, raceStderr), null); // clean exit → no exit error
+  assert.equal(brokerNotReadyErrorEvent(raceStderr)?.message, raceStderr); // …but the race is still surfaced
+  assert.equal(brokerNotReadyErrorEvent("all good, no tools needed"), null);
 });

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -7,6 +7,7 @@ import { __resetForTests as resetTokenState, generateAndWriteToken } from "../..
 import {
   buildCliArgs,
   buildDockerSpawnArgs,
+  buildMulmoclaudeServer,
   dockerUserCapArgs,
   dockerBindMountArgs,
   buildMcpConfig,
@@ -17,6 +18,7 @@ import {
   resolveMcpConfigPaths,
   rewriteLocalhostForDocker,
   userServerAllowedToolNames,
+  workspaceModuleMounts,
 } from "../../server/agent/config.js";
 import type { McpServerSpec } from "../../server/system/config.js";
 
@@ -964,5 +966,48 @@ describe("dockerBindMountArgs", () => {
   it("converts Windows backslash host paths to forward slashes for -v", () => {
     const args = dockerBindMountArgs({ ...opts, projectRoot: "C:\\Users\\me\\proj" });
     assert.ok(args.includes("C:/Users/me/proj/node_modules:/app/node_modules:ro"));
+  });
+});
+
+// #2052: `test/agent/test_mcp_docker_smoke.ts` used to hardcode its `docker run`
+// argv, so PR #1974 (the /app/pkg_modules fallback) and PR #1995 (the --import
+// bootstrap) shipped without the smoke test ever seeing them. It kept
+// reproducing the pre-#1974 layout, and a Windows user re-reported the old
+// error as proof the fixes hadn't landed. The smoke test now derives its argv
+// from the shipped builders; these assertions pin that wiring on every PR,
+// where the Docker-dependent smoke test cannot run.
+describe("MCP child wiring (regression guard for #2052)", () => {
+  const REPO_ROOT = join(import.meta.dirname, "../..");
+  const identity = (hostPath: string): string => hostPath;
+
+  it("gives the Docker child the /app/pkg_modules fallback on NODE_PATH", () => {
+    const spec = buildMulmoclaudeServer({ chatSessionId: "s", port: 1, activePlugins: [], useDocker: true });
+    assert.equal(spec.env.NODE_PATH, "/app/node_modules:/app/pkg_modules");
+  });
+
+  it("registers the ESM resolver bootstrap via --import on the Docker child", () => {
+    const spec = buildMulmoclaudeServer({ chatSessionId: "s", port: 1, activePlugins: [], useDocker: true });
+    assert.equal(spec.command, "tsx");
+    assert.deepEqual(spec.args.slice(0, 2), ["--import", "file:///app/server/agent/mcp-esm-bootstrap.mjs"]);
+    assert.equal(spec.args.at(-1), "/app/server/agent/mcp-server.ts");
+  });
+
+  it("leaves the native child alone: no NODE_PATH, no --import", () => {
+    const spec = buildMulmoclaudeServer({ chatSessionId: "s", port: 1, activePlugins: [], useDocker: false });
+    assert.equal(spec.env.NODE_PATH, undefined);
+    assert.equal(spec.args.includes("--import"), false);
+  });
+
+  it("mounts every workspace package under /app/pkg_modules on win32 only", () => {
+    const win = workspaceModuleMounts(REPO_ROOT, "win32", identity);
+    assert.ok(
+      win.some((arg) => arg.endsWith(":/app/pkg_modules/@mulmoclaude/x-plugin:ro")),
+      `x-plugin fallback mount missing from: ${win.join(" ")}`,
+    );
+    assert.ok(
+      win.some((arg) => arg.endsWith(":/app/pkg_modules/@mulmoclaude/core:ro")),
+      `core fallback mount missing from: ${win.join(" ")}`,
+    );
+    assert.deepEqual(workspaceModuleMounts(REPO_ROOT, "linux", identity), []);
   });
 });

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -1010,4 +1010,24 @@ describe("MCP child wiring (regression guard for #2052)", () => {
     );
     assert.deepEqual(workspaceModuleMounts(REPO_ROOT, "linux", identity), []);
   });
+
+  // The actual #2052 production bug: the fallback only covered `@mulmoclaude/*`,
+  // but yarn junctions EVERY workspace package. `@mulmobridge/protocol` (reached
+  // via src/types/events.ts) and `@mulmobridge/client` dangled inside the Linux
+  // container on a Windows host, so the MCP child died at load with
+  // MODULE_NOT_FOUND and every tool — `handlePermission` included — disappeared.
+  it("covers non-@mulmoclaude workspace scopes the MCP child imports", () => {
+    const win = workspaceModuleMounts(REPO_ROOT, "win32", identity);
+    for (const pkg of ["@mulmobridge/protocol", "@mulmobridge/client"]) {
+      assert.ok(
+        win.some((arg) => arg.endsWith(`:/app/pkg_modules/${pkg}:ro`)),
+        `${pkg} fallback mount missing — the MCP child cannot load without it`,
+      );
+    }
+  });
+
+  it("skips the unscoped launcher package", () => {
+    const win = workspaceModuleMounts(REPO_ROOT, "win32", identity);
+    assert.ok(!win.some((arg) => arg.endsWith(":/app/pkg_modules/mulmoclaude:ro")));
+  });
 });

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -437,6 +437,35 @@ describe("buildDockerSpawnArgs", () => {
     }
   });
 
+  // #2056: npx can nest deps in `<packageRoot>/node_modules` instead of
+  // hoisting them to `<projectRoot>/node_modules` (version conflict, or a
+  // half-deduped npx cache). Only projectRoot's node_modules is mounted to
+  // /app/node_modules, so those nested deps are invisible and the broker dies
+  // at load. Mount the nested tree onto /app/pkg_modules (on NODE_PATH + the
+  // ESM hook path). Platform-agnostic — the npx nesting happens on macOS too.
+  it("mounts nested packageRoot/node_modules at /app/pkg_modules in the npx layout (#2056)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-npxroot-"));
+    try {
+      mkdirSync(join(root, "node_modules", "@mulmoclaude", "chart-plugin"), { recursive: true });
+      const args = buildDockerSpawnArgs({ ...baseParams(), projectRoot: "/consumer", packageRoot: root });
+      const toDocker = (hostPath: string): string => hostPath.replace(/\\/g, "/");
+      assert.ok(args.includes(`${toDocker(join(root, "node_modules"))}:/app/pkg_modules:ro`));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("adds no nested-node_modules mount in the dev layout where packageRoot === projectRoot (#2056)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-devroot-"));
+    try {
+      mkdirSync(join(root, "node_modules", "express"), { recursive: true });
+      const args = buildDockerSpawnArgs({ ...baseParams(), projectRoot: root, packageRoot: root });
+      assert.ok(!args.some((token) => token.endsWith(":/app/pkg_modules:ro")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   // The package bin script (`npx mulmoclaude` / `node packages/mulmoclaude/bin/...`)
   // sets cwd to the package dir, where yarn-workspace dev installs leave an
   // empty `node_modules/`. If the default falls back to `process.cwd()` the

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -466,6 +466,27 @@ describe("buildDockerSpawnArgs", () => {
     }
   });
 
+  // The nested-tree mount (whole dir at /app/pkg_modules) and the per-package
+  // mounts (/app/pkg_modules/@scope/name) would collide — a child bind mount
+  // into a read-only parent fails `docker run`. They must stay exclusive. An
+  // install-from-source / `npm link` on Windows has BOTH a `packages/` tree AND
+  // a distinct packageRoot with a nested node_modules; the per-package mounts
+  // own /app/pkg_modules there, so the whole-tree mount must NOT be added.
+  it("skips the nested mount when a packages/ tree is present, avoiding a /app/pkg_modules collision (#2056)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mc-srcinstall-"));
+    try {
+      seedWorkspacePackages(root); // creates packages/…
+      mkdirSync(join(root, "node_modules", "@mulmoclaude", "chart-plugin"), { recursive: true });
+      const args = buildDockerSpawnArgs({ ...baseParams(), platform: "win32" as Platform, projectRoot: "/consumer", packageRoot: root });
+      // Per-package mounts present (workspaceModuleMounts owns /app/pkg_modules)…
+      assert.ok(args.some((token) => token.includes("/app/pkg_modules/@mulmoclaude/core:ro")));
+      // …and the whole-tree nested mount is NOT added (no collision).
+      assert.ok(!args.some((token) => token.endsWith(":/app/pkg_modules:ro")));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   // The package bin script (`npx mulmoclaude` / `node packages/mulmoclaude/bin/...`)
   // sets cwd to the package dir, where yarn-workspace dev installs leave an
   // empty `node_modules/`. If the default falls back to `process.cwd()` the

--- a/test/agent/test_mcpBrokerFailover.ts
+++ b/test/agent/test_mcpBrokerFailover.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isMcpBrokerNotReadyError } from "../../server/agent/mcpBrokerFailover.ts";
+
+// #2057: the retry that recovers a lost broker startup race hinges entirely on
+// this detector. It must fire on the CLI's real message and stay silent on every
+// other "not found" so a replay never masks a genuine failure (a bad skill, a
+// missing file, a stale --resume id).
+
+describe("isMcpBrokerNotReadyError", () => {
+  it("matches the CLI's real permission-prompt-tool error verbatim", () => {
+    const line =
+      "Error: MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found. " +
+      "Available MCP tools: mcp__claude_ai_Gmail__search_threads, mcp__claude_ai_Google_Drive__search_files";
+    assert.equal(isMcpBrokerNotReadyError(line), true);
+  });
+
+  it("matches when wrapped by surrounding stderr (phrase intact)", () => {
+    const msg = "2026-07-11 WARN prior log line\nError: MCP tool x (passed via --permission-prompt-tool) not found.\ntrailing";
+    assert.equal(isMcpBrokerNotReadyError(msg), true);
+  });
+
+  it("requires the CONTIGUOUS phrase — the flag echo alone does not match", () => {
+    assert.equal(isMcpBrokerNotReadyError("usage: claude --permission-prompt-tool <name>"), false);
+  });
+
+  it("requires the CONTIGUOUS phrase — a scattered flag + 'not found' does not match", () => {
+    // The two markers present but not adjacent must NOT trigger a replay.
+    const scattered = "started with --permission-prompt-tool mcp__x__h\n... later: some unrelated resource not found";
+    assert.equal(isMcpBrokerNotReadyError(scattered), false);
+  });
+
+  it("does not fire on unrelated 'not found' errors (no false replay)", () => {
+    assert.equal(isMcpBrokerNotReadyError("role 'writer' not found"), false);
+    assert.equal(isMcpBrokerNotReadyError("collection 'inbox' not found"), false);
+    assert.equal(isMcpBrokerNotReadyError("Cannot find module '@mulmobridge/protocol'"), false);
+    assert.equal(isMcpBrokerNotReadyError("ENOENT: no such file or directory"), false);
+    assert.equal(isMcpBrokerNotReadyError("HTTP 404 not found"), false);
+  });
+
+  it("does not collide with the stale-session failover phrase", () => {
+    // Both recoveries inspect the same error events; each must own its trigger.
+    assert.equal(isMcpBrokerNotReadyError("No conversation found with session ID: abc-123"), false);
+  });
+
+  it("returns false for empty input", () => {
+    assert.equal(isMcpBrokerNotReadyError(""), false);
+  });
+});

--- a/test/agent/test_mcp_docker_smoke.ts
+++ b/test/agent/test_mcp_docker_smoke.ts
@@ -6,6 +6,16 @@
 //   - package.json exports issues (e.g. missing "require" condition)
 //   - Module resolution failures in the container's Node.js version
 //
+// The container command, args and env come from the SHIPPED
+// `buildMulmoclaudeServer()`, and the junction-fallback mounts from the
+// SHIPPED `workspaceModuleMounts()`. Do not hand-copy them here again.
+// This file used to hardcode both, so it silently kept reproducing the
+// pre-#1974 layout: no `/app/pkg_modules` mounts, `NODE_PATH` without
+// the fallback root, and no `--import` bootstrap. Two fixes shipped that
+// the smoke test could not see, and a Windows user re-reported the old
+// error as if nothing had changed (#2052). A test that cannot see the
+// fix cannot verify the fix.
+//
 // NOT run in CI (Docker unavailable). Run locally after:
 //   - Adding/changing workspace package exports
 //   - Modifying Docker volume mounts in server/agent/config.ts
@@ -18,6 +28,7 @@ import assert from "node:assert/strict";
 import { execSync, spawn } from "node:child_process";
 import path from "node:path";
 
+import { buildMulmoclaudeServer, workspaceModuleMounts, type Platform } from "../../server/agent/config.ts";
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, "../..");
@@ -52,11 +63,32 @@ interface JsonRpcResponse {
   };
 }
 
+const ACTIVE_PLUGINS = ["manageSkills", "presentMulmoScript"];
+
+// `process.platform` is NodeJS.Platform; the repo's `Platform` union lists the
+// same members. Narrow through the union rather than casting.
+function hostPlatform(): Platform {
+  const platforms: Platform[] = ["aix", "android", "darwin", "freebsd", "haiku", "linux", "openbsd", "sunos", "win32", "cygwin", "netbsd"];
+  const found = platforms.find((candidate) => candidate === process.platform);
+  if (!found) throw new Error(`unrecognised platform: ${process.platform}`);
+  return found;
+}
+
 const canRunDocker = isDockerAvailable() && isSandboxImageAvailable();
 
 describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
   it("responds to initialize + tools/list inside Docker container", async () => {
     const toDockerPath = (filePath: string): string => filePath.replace(/\\/g, "/");
+
+    // The exact spec Claude Code would spawn: `tsx --import <bootstrap>
+    // /app/server/agent/mcp-server.ts` with NODE_PATH carrying the
+    // `/app/pkg_modules` fallback root.
+    const server = buildMulmoclaudeServer({
+      chatSessionId: "docker-smoke-test",
+      port: 9999,
+      activePlugins: ACTIVE_PLUGINS,
+      useDocker: true,
+    });
 
     const dockerArgs = [
       "run",
@@ -70,17 +102,12 @@ describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
       `${toDockerPath(PROJECT_ROOT)}/server:/app/server:ro`,
       "-v",
       `${toDockerPath(PROJECT_ROOT)}/src:/app/src:ro`,
-      "-e",
-      "NODE_PATH=/app/node_modules",
-      "-e",
-      "SESSION_ID=docker-smoke-test",
-      "-e",
-      "PORT=9999",
-      "-e",
-      "PLUGIN_NAMES=manageSkills,presentMulmoScript",
+      // Windows-only junction fallback (#1974). Empty elsewhere.
+      ...workspaceModuleMounts(PROJECT_ROOT, hostPlatform(), toDockerPath),
+      ...Object.entries(server.env).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
       "mulmoclaude-sandbox",
-      "tsx",
-      "/app/server/agent/mcp-server.ts",
+      server.command,
+      ...server.args,
     ];
 
     const responses = await new Promise<JsonRpcResponse[]>((resolve, reject) => {

--- a/test/agent/test_mcp_esm_loader.ts
+++ b/test/agent/test_mcp_esm_loader.ts
@@ -28,6 +28,21 @@ describe("splitScopedSpecifier", () => {
       subpath: "./util/log",
     });
   });
+
+  // #2052: the loader hardcoded `@mulmoclaude/`. yarn junctions EVERY workspace
+  // package, so `@mulmobridge/protocol` — which the MCP child reaches through
+  // src/types/events.ts — dangled on Windows with no fallback and killed the
+  // server at load.
+  it("handles any workspace scope, not just @mulmoclaude", () => {
+    assert.deepEqual(splitScopedSpecifier("@mulmobridge/protocol"), {
+      pkg: "@mulmobridge/protocol",
+      subpath: ".",
+    });
+    assert.deepEqual(splitScopedSpecifier("@receptron/task-scheduler/sub"), {
+      pkg: "@receptron/task-scheduler",
+      subpath: "./sub",
+    });
+  });
 });
 
 describe("pickEntry", () => {

--- a/test/sandbox-repro/diagnose-2052.ts
+++ b/test/sandbox-repro/diagnose-2052.ts
@@ -1,0 +1,74 @@
+// Diagnostic probe for #2052 — does the MCP child run as CJS or ESM inside
+// the sandbox container, and does NODE_PATH rescue the dangling junction?
+//
+// This file is bind-mounted to `/app/server/agent/diagnose-2052.ts` so it sits
+// in the SAME package scope as the real `mcp-server.ts`. That is the whole
+// point: `tsx` picks a module format from the nearest `package.json`, and the
+// production mount layout never puts one under `/app`. The sibling probe
+// (`probe.ts`) is mounted at `/repro/` next to a `{"type":"module"}` manifest,
+// which is exactly why it has never reproduced this bug.
+//
+// It REPORTS rather than asserts. Reading the output is the deliverable; the
+// fix is chosen from it. Every lookup is wrapped so a failure prints its error
+// instead of killing the process before the later facts are gathered.
+//
+// Must stay valid under BOTH transpile targets: no `import.meta`, no
+// top-level `await`, no static import of a `@mulmoclaude/*` package.
+
+import { existsSync, lstatSync, readlinkSync } from "node:fs";
+import Module, { createRequire } from "node:module";
+
+const SPECIFIER = "@mulmoclaude/x-plugin";
+const PRIMARY_LINK = "/app/node_modules/@mulmoclaude/x-plugin";
+const REQUIRE_CONTEXT = "/app/server/agent/mcp-tools/index.ts";
+
+function line(label: string, value: unknown): void {
+  console.log(`${label.padEnd(34)} ${typeof value === "string" ? value : JSON.stringify(value)}`);
+}
+
+function attempt(label: string, probe: () => unknown): void {
+  try {
+    line(label, probe());
+  } catch (err) {
+    line(label, `ERROR: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`);
+  }
+}
+
+console.log("=== #2052 sandbox module-resolution diagnostic ===");
+
+// 1. The decisive fact. `typeof require === "function"` in a transpiled CJS
+//    module; in ESM output esbuild leaves `require` undefined.
+const isCjs = typeof require === "function";
+line("module format of this .ts", isCjs ? "CommonJS  <-- module.register() ESM hook is INERT" : "ESM");
+line("/app/package.json present", existsSync("/app/package.json"));
+line("node version", process.version);
+
+// 2. Is the NODE_PATH fallback wired, and does Node's own resolver see it?
+line("process.env.NODE_PATH", process.env.NODE_PATH ?? "(unset)");
+line("Module.globalPaths", Module.globalPaths);
+
+// 3. Prove the container really reproduces the Windows failure mode: the
+//    primary yarn-workspace link must dangle.
+attempt("lstat(primary link)", () => (lstatSync(PRIMARY_LINK).isSymbolicLink() ? "symlink" : "not a symlink"));
+attempt("readlink(primary link)", () => readlinkSync(PRIMARY_LINK));
+line("primary target resolves", existsSync(`${PRIMARY_LINK}/package.json`));
+line("fallback mount present", existsSync(`/app/pkg_modules/${SPECIFIER}/package.json`));
+
+// 4. The question PR #1974 answers only if tsx's CJS hook honours globalPaths.
+const req = createRequire(REQUIRE_CONTEXT);
+attempt("require.resolve.paths()", () => req.resolve.paths(SPECIFIER));
+attempt("require.resolve(x-plugin)", () => req.resolve(SPECIFIER));
+attempt("require(x-plugin) keys", () => Object.keys(req(SPECIFIER) as object));
+
+// 5. The question PR #1995 answers — but only ever reachable from ESM.
+//    `.then()` rather than top-level await so the file transpiles under CJS.
+import(SPECIFIER).then(
+  (mod: object) => {
+    line("await import(x-plugin) keys", Object.keys(mod));
+    console.log("=== end (import resolved) ===");
+  },
+  (err: unknown) => {
+    line("await import(x-plugin)", `ERROR: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`);
+    console.log("=== end (import rejected) ===");
+  },
+);

--- a/test/sandbox-repro/mcp-handshake.jsonl
+++ b/test/sandbox-repro/mcp-handshake.jsonl
@@ -1,0 +1,2 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"windows-ci-probe","version":"0.0.0"}}}
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}

--- a/test/sandbox-repro/print-mcp-container-spec.ts
+++ b/test/sandbox-repro/print-mcp-container-spec.ts
@@ -1,0 +1,49 @@
+// Prints the SHIPPED MCP-child container spec as JSON, with Windows host paths
+// translated to their WSL2 `/mnt/<drive>/...` form.
+//
+// `.github/workflows/docker_sandbox_windows.yaml` consumes this so the
+// end-to-end step drives `docker run` with the same mounts / env / argv that
+// `server/agent/config.ts` hands Claude Code — instead of a hand-copied list
+// that silently rots. That rot is exactly what #2052 was: the smoke test's
+// duplicated argv never received PR #1974's fallback mounts or PR #1995's
+// `--import` bootstrap.
+//
+// Usage (from the repo root, on the Windows runner):
+//   node_modules/.bin/tsx test/sandbox-repro/print-mcp-container-spec.ts
+
+import { buildMulmoclaudeServer, workspaceModuleMounts } from "../../server/agent/config.ts";
+
+const ACTIVE_PLUGINS = ["manageSkills", "presentMulmoScript"];
+
+/** `C:\a\repo\packages\core` → `/mnt/c/a/repo/packages/core`. Docker runs inside
+ *  WSL2, which sees the Windows FS under `/mnt/<drive>`. */
+function toWslPath(hostPath: string): string {
+  const drive = /^([A-Za-z]):[\\/](.*)$/.exec(hostPath);
+  if (!drive) return hostPath.replace(/\\/g, "/");
+  return `/mnt/${drive[1].toLowerCase()}/${drive[2].replace(/\\/g, "/")}`;
+}
+
+// `workspaceModuleMounts` returns a flat ["-v", "<spec>", "-v", "<spec>", …].
+// Pull out the specs; the caller re-adds the flags.
+const flatMounts = workspaceModuleMounts(process.cwd(), "win32", toWslPath);
+const pkgModuleMounts = flatMounts.filter((_, index) => index % 2 === 1);
+
+const server = buildMulmoclaudeServer({
+  chatSessionId: "windows-ci-probe",
+  port: 9999,
+  activePlugins: ACTIVE_PLUGINS,
+  useDocker: true,
+});
+
+console.log(
+  JSON.stringify(
+    {
+      pkgModuleMounts,
+      env: server.env,
+      command: server.command,
+      args: server.args,
+    },
+    null,
+    2,
+  ),
+);

--- a/test/sandbox-repro/static-import-2052.ts
+++ b/test/sandbox-repro/static-import-2052.ts
@@ -1,0 +1,14 @@
+// Reproduces the #2052 crash verbatim, in the production package scope.
+//
+// Bind-mounted to `/app/server/agent/static-import-2052.ts`, i.e. next to the
+// real `mcp-server.ts`, with the same mounts and NODE_PATH the sandbox uses.
+// The static import is the one `server/agent/mcp-tools/index.ts` line 2 makes.
+//
+// Expected BEFORE the fix: a CJS `Cannot find module '@mulmoclaude/x-plugin'`
+// with a `Require stack:` — byte-identical to the trace in issue #2052,
+// proving that PR #1995's ESM hook never gets consulted.
+// Expected AFTER the fix: prints the resolved export.
+
+import { readXPost } from "@mulmoclaude/x-plugin";
+
+console.log(`static import resolved: readXPost is ${typeof readXPost}`);

--- a/test/skills/test_skill_scheduler.ts
+++ b/test/skills/test_skill_scheduler.ts
@@ -148,4 +148,41 @@ describe("skill scheduler visibility + manual run (#2012)", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // The completion hook must be registered BEFORE dispatch: startChat
+  // fire-and-forgets the background run, so a fast-finishing turn can complete
+  // (finalizeRun → runCompletionHook) before fireScheduledChat's post-await
+  // code. If the hook were registered after, that run record would be dropped.
+  it("records a run that finishes during dispatch (hook registered pre-dispatch, #2057)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "skillsched-"));
+    try {
+      configureScheduler({
+        workspaceRoot: root,
+        writeFileAtomic: async (filePath, content) => {
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, content);
+        },
+      });
+      await initScheduler(stubTm(), []);
+      await writeScheduledSkill(root, "fast-skill");
+      await registerScheduledSkills({
+        taskManager: stubTm(),
+        workspaceRoot: root,
+        // Simulate the background run completing DURING dispatch.
+        startChat: async (params) => {
+          await runCompletionHook(params.chatSessionId, { didError: false });
+          return { kind: "started" };
+        },
+      });
+
+      const chatSessionId = await runScheduledSkillNow("skill.fast-skill");
+      assert.ok(chatSessionId);
+      // Recorded despite finishing before dispatch returned — hook pre-existed.
+      const state = getSchedulerTaskState("skill.fast-skill");
+      assert.equal(state.totalRuns, 1);
+      assert.equal(state.lastRunResult, "success");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/skills/test_skill_scheduler.ts
+++ b/test/skills/test_skill_scheduler.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { configureScheduler, initScheduler, getSchedulerTaskState, resetSchedulerForTesting } from "@mulmoclaude/core/scheduler";
 import { registerScheduledSkills, getScheduledSkills, runScheduledSkillNow } from "../../server/workspace/skills/scheduler.js";
+import { runCompletionHook } from "../../server/agent/backgroundSessions.js";
 import type { ITaskManager } from "../../server/events/task-manager/index.js";
 
 const stubTm = (over: Partial<ITaskManager> = {}): ITaskManager => ({
@@ -63,7 +64,13 @@ describe("skill scheduler visibility + manual run (#2012)", () => {
       assert.equal(calls.length, 1);
       assert.equal(calls[0].message, "/news-filter");
 
-      // B: the run is recorded as state (history/last-run) under the skill id.
+      // B: a successful DISPATCH does not record a run yet — the outcome is
+      // recorded from the turn's completion hook, not at spawn time (#2057), so
+      // a run that spawns but fails its first turn can't log a false success.
+      assert.equal(getSchedulerTaskState("skill.news-filter").totalRuns, 0);
+
+      // The turn finishes without error → recorded as a successful run.
+      await runCompletionHook(chatSessionId, { didError: false });
       const state = getSchedulerTaskState("skill.news-filter");
       assert.equal(state.totalRuns, 1);
       assert.equal(state.lastRunResult, "success");
@@ -101,6 +108,42 @@ describe("skill scheduler visibility + manual run (#2012)", () => {
       assert.equal(state.totalRuns, 1);
       assert.equal(state.lastRunResult, "error");
       assert.match(state.lastErrorMessage ?? "", /spawn crashed/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // #2057: the failure this whole family is about — a run that SPAWNS fine but
+  // loses the MCP-broker startup race and does nothing. Its completion hook
+  // reports didError, so it must be recorded as an error, never a false success.
+  it("records a spawned-but-failed turn as an error run, not a false success (#2057)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "skillsched-"));
+    try {
+      configureScheduler({
+        workspaceRoot: root,
+        writeFileAtomic: async (filePath, content) => {
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, content);
+        },
+      });
+      await initScheduler(stubTm(), []);
+      await writeScheduledSkill(root, "race-skill");
+      await registerScheduledSkills({
+        taskManager: stubTm(),
+        workspaceRoot: root,
+        startChat: async () => ({ kind: "started" }),
+      });
+
+      const chatSessionId = await runScheduledSkillNow("skill.race-skill");
+      assert.ok(chatSessionId);
+      // Dispatch succeeded, so nothing is recorded yet…
+      assert.equal(getSchedulerTaskState("skill.race-skill").totalRuns, 0);
+
+      // …then the turn finishes having errored (broker never came up).
+      await runCompletionHook(chatSessionId, { didError: true });
+      const state = getSchedulerTaskState("skill.race-skill");
+      assert.equal(state.totalRuns, 1);
+      assert.equal(state.lastRunResult, "error");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

One user-facing error — `MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found` — has **three distinct root causes** reported as #2052, #2056, #2057. When the `mulmoclaude` MCP broker fails to come up, the agent loses *every* `mcp__mulmoclaude__*` tool at once, so the CLI complains about the permission-prompt tool rather than the real cause. This PR resolves the whole family, organized as a two-layer case matrix (`plans/mcp-broker-availability-matrix.md`):

**Layer 1 — broker dies at LOAD** (permanent `MODULE_NOT_FOUND`; a dependency is unreachable in the mount layout):

| Issue | Layer | Root cause | Fix |
|---|---|---|---|
| **#2052** | Docker mount / Windows | workspace `@…/*` junctions dangle; `@mulmobridge/*` missing from the `/app/pkg_modules` fallback | cover **every** workspace scope |
| **#2056** | Docker mount / npx | npx nests deps in `<packageRoot>/node_modules`; only `<projectRoot>/node_modules` is mounted | mount the nested tree onto `/app/pkg_modules` |

**Layer 2 — broker loses the STARTUP RACE** (transient; works on a manual retry — `mcp__mulmoclaude__*` absent while other MCP servers are present):

| Trigger | Fix |
|---|---|
| **#2057 J** — same-minute fan-out floods CPU, broker boots slowly | **stagger** independent firings (capped to ½ tick) |
| **#2057 K** — single-task cold race (stagger can't help one task) | **retry** once: detect `handlePermission not found` → wait → replay the turn |
| **#2057 L** — a spawned-but-failed run logged `"result":"success"` | record the **real** outcome from the turn's completion hook |

## ⚠️ Items to Confirm / Review

- **#2057 K replay safety (double-execution).** A replay only fires when *nothing* executed — the failing first tool call is blocked at the permission check. Once any tool completes successfully (an auto-approved Bash/Write, or a tool before a later permission check), the broker recovery is downgraded to a plain error so it is never re-run. Budget is one replay, independent of `--resume`.
- **#2057 K abort handling.** An abort before any (re)spawn, or during the reconnect wait, ends the loop — no doomed replay. The wait itself is abortable.
- **#2057 K residual.** The race ultimately lives in the Claude CLI (it spawns our broker AND issues the first tool call; there's no host-side readiness gate). Retry is a bounded *self-recovery*, not a guarantee — a further hardening (shrinking the broker's cold-boot window) is noted in the matrix as a separate task.
- **#2057 L timing change.** Scheduled runs now appear in history when the turn *finishes*, not when it spawns. A process killed mid-run records nothing (vs. a former false success) — an accepted trade-off for honest logging.
- **#2056 mount exclusivity.** The nested-tree mount and the per-package mounts both target `/app/pkg_modules` and would collide (a child bind mount into a read-only parent fails `docker run`). They're now structurally exclusive: the nested mount is skipped whenever a `packages/` tree is present. This closes an install-from-source / `npm link`-on-Windows gap surfaced by an adversarial bug hunt.
- **#2052 scope widening.** `scopedPackageName()` accepts any `@scope/` (launcher still skipped); `workspacePackageDirs()` walks the tree, not the root manifest. `@mulmoclaude/core` bumped 0.12.1 → 0.12.2; launcher dep range in lockstep, **launcher version untouched** per CLAUDE.md.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2052 これ、つめていける？windowsのciなどを使って直したい。
>
> 修正して、windows ciで確認して
>
> 2057, 2056, 2052って関連している？もしそうなら包括的に見てほしい
>
> あ、やっぱりここでこのまま進めて。できれば今のPRを３つのissueに対応して直してほしい
>
> えーーと、全ケース、mac/windowsできちんと動くように整理て。課題にadhocに直すだけだとダメだから、現状整理して、そして全てのケースで、できればテストをしてほしい。報告ないバグないかもきちんとみてね

---

# #2052 — Windows junction fallback only covered `@mulmoclaude/*`

**The issue's own diagnosis was wrong twice over.** The ESM resolver hook (#1995) is irrelevant to the static `require()` that failed, and the specifier the issue names (`@mulmoclaude/x-plugin`) resolves fine under the production layout on real Windows NTFS junctions. The trace the reporter pasted came from a **stale smoke test** that hardcoded its `docker run` argv and never received #1974's or #1995's wiring.

Verified on **real Windows CI** (WSL2 + native `dockerd`, real NTFS junctions): the real `mcp-server.ts` now boots and answers `tools/list` with `handlePermission`. Run [29096883375](https://github.com/receptron/mulmoclaude/actions/runs/29096883375).

Root cause, measured — booting the real `mcp-server.ts` with dangling junctions and only `@mulmoclaude/` covered → `Cannot find module '@mulmobridge/protocol'`, exit 1; with any `@scope/` covered → `serverInfo` + `handlePermission`, exit 0.

**Fix:** `workspacePackageDirs()` walks the `packages/` tree structurally; `scopedPackageName()` accepts any scope; `mcp-esm-loader.mjs` drops its hardcoded `SCOPE`. Guarded by POSIX unit tests (each verified to fail when its invariant is broken) + a Windows CI e2e that boots the real broker on real NTFS junctions.

# #2056 — npx nested `node_modules` never mounted

npx sometimes leaves deps in the **nested** `<packageRoot>/node_modules` (a version conflict, or a half-deduped npx cache) — observed: `@mulmoclaude/chart-plugin`, `@mulmoclaude/html-plugin`, `@gui-chat-plugin/camera`. Only `<projectRoot>/node_modules` is mounted, so the broker dies at load. **Fix:** `nestedNodeModulesMount()` mounts the nested tree onto `/app/pkg_modules` when `packageRoot !== projectRoot`, `packageRoot/node_modules` exists, and no `packages/` tree is present (kept exclusive from the per-package mounts). Cache-clear workaround (`rm -rf ~/.npm/_npx`) documented in `error-recovery.md`.

# #2057 — scheduler startup race (works on a manual retry)

Each scheduled chat spawns its own broker; under same-minute fan-out (or a cold single-task run) the broker connects *after* the CLI's first tool call. Forensics attributed real failures to this — including this very working session's noon `email-triage`.

- **J (stagger):** `runTick` starts each independently-due task `index * step` later (default 1s, capped to ½ tick so tasks never spill into the next tick / overlap). Cuts the multi-task contention.
- **K (retry):** `isMcpBrokerNotReadyError` → the fail-over loop waits `BROKER_RECONNECT_WAIT_MS` and replays the turn once. Works on fresh sessions (what scheduled runs use). Safe against double-execution and aborts (see Items to Confirm).
- **L (honest logging):** the real turn outcome is recorded from the completion hook, not at spawn — a spawned-but-failed run now logs an error with a real duration instead of a false 8 ms success.

## Adversarial bug hunt

A read-only agent hunted the whole family for unreported defects; the confirmed ones are fixed here and each has a regression test: the mount collision (#2056 exclusivity), the retry's abort handling + double-execution guard + marker tightening (#2057 K), and the unbounded stagger / tick re-entry (#2057 J). Dormant/no-op findings are noted in the matrix.

## Verification

- Windows CI run [29096883375](https://github.com/receptron/mulmoclaude/actions/runs/29096883375) — all steps green; e2e prints `OK: mcp-server.ts started and listed handlePermission under real NTFS junctions`.
- `yarn lint` 0 errors · `yarn typecheck` clean · `yarn build` clean · `yarn test` **6773/6773** · `yarn format` clean · `yarn check:launcher-sync` green.
- New/updated unit tests: #2056 npx-nested mount + collision-exclusivity; #2057 J stagger + cap, K detector + exit-event surfacing, L honest success/error recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Docker sandbox module resolution to support all scoped workspace packages (`@scope/*`, not just `@mulmoclaude/*`), fixing missing-module crashes affecting MCP startup and tool availability.
* **Tests**
  * Added Windows sandbox diagnostics and reproduction for `#2052`, plus enhanced regression-guard coverage validating Docker vs native MCP wiring and ESM resolver behavior.
* **Documentation**
  * Expanded Windows Docker CI notes and added error-recovery guidance for sandboxed MCP crashes due to workspace module resolution.
* **Chores**
  * Bumped `@mulmoclaude/core`/`mulmoclaude` to `0.12.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
