### PR TITLE
refactor(whisper): split createVoiceCapture into module-scope helpers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -483,7 +483,7 @@ export default [
   // its entry; when the list is empty, delete this block. Do NOT add
   // new files — a new over-budget function must be split, not listed.
   {
-    files: ["packages/core/src/whisper/client.ts", "packages/core/src/whisper/sidecar.ts", "server/events/relay-client.ts"],
+    files: ["packages/core/src/whisper/sidecar.ts", "server/events/relay-client.ts"],
     rules: {
       "max-lines-per-function": ["warn", { max: 50, skipBlankLines: true, skipComments: true, IIFEs: true }],
     },

--- a/packages/core/src/whisper/client.ts
+++ b/packages/core/src/whisper/client.ts
@@ -305,7 +305,10 @@ async function bootstrapCapture(callbacks: VoiceCaptureCallbacks, generationAtSt
   try {
     audioGraph.attach(acquired);
   } catch (err) {
-    acquired.getTracks().forEach((track) => track.stop());
+    // teardown() is null-safe and closes any half-created AudioContext AND
+    // stops the mic tracks — the pre-refactor code only stopped tracks and
+    // leaked the context (codex/CodeRabbit findings on this PR).
+    audioGraph.teardown();
     throw err;
   }
   return { audioGraph, mimeType };

--- a/packages/core/src/whisper/client.ts
+++ b/packages/core/src/whisper/client.ts
@@ -220,125 +220,48 @@ export function createSegmentQueue(options: SegmentQueueOptions): SegmentQueue {
   return { enqueue };
 }
 
-export function createVoiceCapture(transport: VoiceCaptureTransport, language: () => string, callbacks: VoiceCaptureCallbacks): VoiceCapture {
-  const state = createCaptureState(callbacks.onState);
-  const poller = createAvailabilityPoller(transport, state.setAvailable);
+export interface AudioGraph {
+  /** True between `attach()` and the next `teardown()`. */
+  isAttached: () => boolean;
+  /** Read the current PCM window into an internal buffer and return it.
+   *  Callers must not mutate the returned array. */
+  sample: () => Float32Array;
+  /** Live mic stream — the outer needs it to hand to MediaRecorder. */
+  getStream: () => MediaStream | null;
+  /** Attach a fresh mic stream: create AudioContext + AnalyserNode + VAD buffer,
+   *  connect the source. Called only by `bootstrapCapture` after the caller has
+   *  passed the stale-generation / permission checks. */
+  attach: (stream: MediaStream) => void;
+  /** Close the AudioContext, stop the mic tracks, null everything. Safe to
+   *  call before `attach()` or twice in a row. */
+  teardown: () => void;
+}
 
+// Owns the browser-side audio pipeline: mic stream + AudioContext + AnalyserNode
+// + the reusable Float32 buffer VAD reads samples into. Separated from
+// `createVoiceCapture` so its four browser-API fields don't inflate the parent
+// factory's line count and so the setup/teardown ordering is in one place.
+function createAudioGraph(): AudioGraph {
   let stream: MediaStream | null = null;
   let audioCtx: AudioContext | null = null;
   let analyser: AnalyserNode | null = null;
   let vadBuffer = new Float32Array(0);
-  let monitorHandle: number | null = null;
-  let recorder: MediaRecorder | null = null;
-  let chunks: Blob[] = [];
-  let mimeType = "";
-  let segmentHasSpeech = false;
-  let silenceStart: number | null = null;
-  let segmentStart = 0;
-  // Bumped on stop(). Segments captured / sends resolved under an older
-  // generation are dropped, so a late transcript never leaks across sessions.
-  let generation = 0;
-  let segmentGeneration = 0;
-  // Single-flight guard for start(): true between entry and the moment capture
-  // is set up (or the attempt aborts), so a second start can't race the first.
-  let startInFlight = false;
 
-  const segments = createSegmentQueue({
-    transport,
-    language,
-    callbacks,
-    setPending: state.setPending,
-    getGeneration: () => generation,
-  });
-
-  function onSegmentStop(): void {
-    const hadSpeech = segmentHasSpeech;
-    const gen = segmentGeneration;
-    const blob = new Blob(chunks, { type: containerTypeFromMime(mimeType) });
-    if (state.isListening()) startRecorder();
-    if (hadSpeech && blob.size > 0 && gen === generation) segments.enqueue(blob, gen);
+  function attach(nextStream: MediaStream): void {
+    stream = nextStream;
+    audioCtx = new AudioContext();
+    analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 2048;
+    vadBuffer = new Float32Array(analyser.fftSize);
+    audioCtx.createMediaStreamSource(nextStream).connect(analyser);
   }
 
-  function startRecorder(): void {
-    if (!stream) return;
-    chunks = [];
-    segmentHasSpeech = false;
-    silenceStart = null;
-    segmentStart = Date.now();
-    segmentGeneration = generation;
-    recorder = new MediaRecorder(stream, { mimeType });
-    recorder.ondataavailable = (event) => {
-      if (event.data.size > 0) chunks.push(event.data);
-    };
-    recorder.onstop = onSegmentStop;
-    recorder.start();
+  function sample(): Float32Array {
+    analyser?.getFloatTimeDomainData(vadBuffer);
+    return vadBuffer;
   }
 
-  function cutSegment(): void {
-    if (recorder && recorder.state === "recording") recorder.stop();
-  }
-
-  function monitorTick(): void {
-    if (!analyser) return;
-    analyser.getFloatTimeDomainData(vadBuffer);
-    const rms = computeRms(vadBuffer);
-    const { hasSpeech, silenceStart: nextSilence, cut } = evaluateVad({ hasSpeech: segmentHasSpeech, silenceStart }, segmentStart, rms, Date.now(), VAD_CONFIG);
-    segmentHasSpeech = hasSpeech;
-    silenceStart = nextSilence;
-    if (cut) cutSegment();
-  }
-
-  async function start(): Promise<boolean> {
-    // Single-flight: `listening` only flips true AFTER getUserMedia resolves, so
-    // a benign skip returns true (a start is already active / in progress).
-    if (startInFlight || state.isListening()) return true;
-    startInFlight = true;
-    const startGen = generation;
-    try {
-      mimeType = pickRecorderMime() ?? "";
-      if (!mimeType || !navigator.mediaDevices?.getUserMedia) {
-        callbacks.onError?.("unsupported");
-        return false;
-      }
-      let acquired: MediaStream;
-      try {
-        acquired = await navigator.mediaDevices.getUserMedia({ audio: true });
-      } catch {
-        callbacks.onError?.("permission-denied");
-        return false;
-      }
-      // stop() bumps the generation; if it fired while we awaited permission
-      // this start is stale — release the mic and abort.
-      if (startGen !== generation) {
-        acquired.getTracks().forEach((track) => track.stop());
-        return false;
-      }
-      stream = acquired;
-      audioCtx = new AudioContext();
-      analyser = audioCtx.createAnalyser();
-      analyser.fftSize = 2048;
-      vadBuffer = new Float32Array(analyser.fftSize);
-      audioCtx.createMediaStreamSource(stream).connect(analyser);
-      state.setListening(true);
-      startRecorder();
-      monitorHandle = window.setInterval(monitorTick, MONITOR_INTERVAL_MS);
-      return true;
-    } finally {
-      startInFlight = false;
-    }
-  }
-
-  function stop(): void {
-    // Bump the generation so any in-flight/queued segment is dropped rather than
-    // applied after the user stops or switches sessions.
-    generation += 1;
-    state.setListening(false);
-    if (monitorHandle !== null) {
-      window.clearInterval(monitorHandle);
-      monitorHandle = null;
-    }
-    if (recorder && recorder.state === "recording") recorder.stop();
-    recorder = null;
+  function teardown(): void {
     if (audioCtx) {
       audioCtx.close().catch(() => undefined);
       audioCtx = null;
@@ -346,6 +269,217 @@ export function createVoiceCapture(transport: VoiceCaptureTransport, language: (
     analyser = null;
     stream?.getTracks().forEach((track) => track.stop());
     stream = null;
+  }
+
+  return { isAttached: () => analyser !== null, sample, getStream: () => stream, attach, teardown };
+}
+
+interface BootstrappedCapture {
+  audioGraph: AudioGraph;
+  mimeType: string;
+}
+
+// Acquire the mic + probe MediaRecorder support + wire an AudioGraph, returning
+// null (with `callbacks.onError` fired) on any recoverable failure. Deliberately
+// does NOT touch `state` or start the recorder — the caller commits the session
+// only after this resolves successfully, so a stale `generation` detected mid-
+// flight can drop the tracks and bail without partially publishing state.
+async function bootstrapCapture(callbacks: VoiceCaptureCallbacks, generationAtStart: number, generationNow: () => number): Promise<BootstrappedCapture | null> {
+  const mimeType = pickRecorderMime() ?? "";
+  if (!mimeType || !navigator.mediaDevices?.getUserMedia) {
+    callbacks.onError?.("unsupported");
+    return null;
+  }
+  let acquired: MediaStream;
+  try {
+    acquired = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch {
+    callbacks.onError?.("permission-denied");
+    return null;
+  }
+  if (generationAtStart !== generationNow()) {
+    acquired.getTracks().forEach((track) => track.stop());
+    return null;
+  }
+  const audioGraph = createAudioGraph();
+  try {
+    audioGraph.attach(acquired);
+  } catch (err) {
+    acquired.getTracks().forEach((track) => track.stop());
+    throw err;
+  }
+  return { audioGraph, mimeType };
+}
+
+export interface RecorderSession {
+  isRecording: () => boolean;
+  hadSpeech: () => boolean;
+  markSpeech: () => void;
+  /** Start a new segment on `stream`, tagged with `gen`. Resets per-segment
+   *  state (chunks + hadSpeech) synchronously so a subsequent VAD tick sees
+   *  a fresh window. */
+  startNext: (stream: MediaStream, mimeType: string, gen: number) => void;
+  /** Force-close the current segment (silence exceeded or MAX_SEGMENT_MS). */
+  cut: () => void;
+}
+
+interface RecorderSessionDeps {
+  /** Fires each time a segment finishes. The parent decides whether to
+   *  restart (via `session.startNext`) and whether to enqueue the blob. */
+  onSegmentEnd: (blob: Blob, hadSpeech: boolean, gen: number) => void;
+}
+
+// Owns MediaRecorder + its per-segment scratchpad (chunks, hadSpeech, gen,
+// mimeType). The parent keeps VAD state and the global generation, and calls
+// `startNext` on both initial-start and post-onstop restart paths.
+function createRecorderSession(deps: RecorderSessionDeps): RecorderSession {
+  let recorder: MediaRecorder | null = null;
+  let chunks: Blob[] = [];
+  let segmentHasSpeech = false;
+  let sessionGen = 0;
+  let sessionMimeType = "";
+
+  function onStop(): void {
+    // Snapshot BEFORE the parent's onSegmentEnd callback runs; `startNext`
+    // (if the parent chooses to restart) will clear chunks synchronously.
+    const hadSpeech = segmentHasSpeech;
+    const gen = sessionGen;
+    const blob = new Blob(chunks, { type: containerTypeFromMime(sessionMimeType) });
+    deps.onSegmentEnd(blob, hadSpeech, gen);
+  }
+
+  function startNext(stream: MediaStream, mimeType: string, gen: number): void {
+    chunks = [];
+    segmentHasSpeech = false;
+    sessionGen = gen;
+    sessionMimeType = mimeType;
+    recorder = new MediaRecorder(stream, { mimeType });
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) chunks.push(event.data);
+    };
+    recorder.onstop = onStop;
+    recorder.start();
+  }
+
+  return {
+    isRecording: () => recorder?.state === "recording",
+    hadSpeech: () => segmentHasSpeech,
+    markSpeech: () => {
+      segmentHasSpeech = true;
+    },
+    startNext,
+    cut: () => {
+      if (recorder?.state === "recording") recorder.stop();
+    },
+  };
+}
+
+// Zero-values used to seed a fresh `CaptureRuntime` at the top of every
+// `createVoiceCapture` call. Kept module-scope so the seed doesn't inflate the
+// factory's line count.
+const INITIAL_RUNTIME: Readonly<CaptureRuntime> = {
+  audioGraph: null,
+  monitorHandle: null,
+  mimeType: "",
+  silenceStart: null,
+  segmentStart: 0,
+  generation: 0,
+  startInFlight: false,
+};
+
+// Mutable capture-time state, kept as one object so module-scope helpers
+// (`stopCapture`, `monitorTick`) can be typed against one shape rather than
+// threading each field through their signatures.
+interface CaptureRuntime {
+  audioGraph: AudioGraph | null;
+  monitorHandle: number | null;
+  mimeType: string;
+  silenceStart: number | null;
+  segmentStart: number;
+  /** Bumped on stop(); segments captured under an older value are dropped so a
+   *  late transcript never leaks across sessions. */
+  generation: number;
+  /** Single-flight guard on start() — true between entry and completion so a
+   *  second start can't race the first before `listening` flips. */
+  startInFlight: boolean;
+}
+
+// Tear down the browser-side resources. `state.setListening(false)` MUST happen
+// BEFORE `session.cut()` so the parent's onSegmentEnd callback sees
+// isListening()===false and does NOT restart. The monitor interval MUST clear
+// BEFORE `audioGraph.teardown()` so a scheduled tick can't run against a
+// half-closed AudioContext.
+function stopCapture(runtime: CaptureRuntime, state: CaptureStateController, session: RecorderSession): void {
+  runtime.generation += 1;
+  state.setListening(false);
+  if (runtime.monitorHandle !== null) {
+    window.clearInterval(runtime.monitorHandle);
+    runtime.monitorHandle = null;
+  }
+  session.cut();
+  runtime.audioGraph?.teardown();
+  runtime.audioGraph = null;
+}
+
+// One VAD tick against the audio graph's current window. No-op when the graph
+// is not attached (defensive: `stopCapture` clears `monitorHandle` before
+// `audioGraph.teardown()`, so this is the belt-and-braces for any late fire).
+function monitorTick(runtime: CaptureRuntime, session: RecorderSession): void {
+  if (!runtime.audioGraph?.isAttached()) return;
+  const rms = computeRms(runtime.audioGraph.sample());
+  const {
+    hasSpeech,
+    silenceStart: nextSilence,
+    cut,
+  } = evaluateVad({ hasSpeech: session.hadSpeech(), silenceStart: runtime.silenceStart }, runtime.segmentStart, rms, Date.now(), VAD_CONFIG);
+  if (hasSpeech) session.markSpeech();
+  runtime.silenceStart = nextSilence;
+  if (cut) session.cut();
+}
+
+export function createVoiceCapture(transport: VoiceCaptureTransport, language: () => string, callbacks: VoiceCaptureCallbacks): VoiceCapture {
+  const state = createCaptureState(callbacks.onState);
+  const poller = createAvailabilityPoller(transport, state.setAvailable);
+  const runtime: CaptureRuntime = { ...INITIAL_RUNTIME };
+  const segments = createSegmentQueue({ transport, language, callbacks, setPending: state.setPending, getGeneration: () => runtime.generation });
+
+  const session = createRecorderSession({ onSegmentEnd: handleSegmentEnd });
+
+  function handleSegmentEnd(blob: Blob, hadSpeech: boolean, gen: number): void {
+    // Restart FIRST so audio-loss between segments is minimal; the snapshot
+    // in blob/hadSpeech/gen is already independent of session state.
+    if (state.isListening()) startRecorder();
+    if (hadSpeech && blob.size > 0 && gen === runtime.generation) segments.enqueue(blob, gen);
+  }
+
+  function startRecorder(): void {
+    const stream = runtime.audioGraph?.getStream();
+    if (!stream) return;
+    runtime.silenceStart = null;
+    runtime.segmentStart = Date.now();
+    session.startNext(stream, runtime.mimeType, runtime.generation);
+  }
+
+  async function start(): Promise<boolean> {
+    if (runtime.startInFlight || state.isListening()) return true;
+    runtime.startInFlight = true;
+    const startGen = runtime.generation;
+    try {
+      const capture = await bootstrapCapture(callbacks, startGen, () => runtime.generation);
+      if (!capture) return false;
+      runtime.audioGraph = capture.audioGraph;
+      runtime.mimeType = capture.mimeType;
+      state.setListening(true);
+      startRecorder();
+      runtime.monitorHandle = window.setInterval(() => monitorTick(runtime, session), MONITOR_INTERVAL_MS);
+      return true;
+    } finally {
+      runtime.startInFlight = false;
+    }
+  }
+
+  function stop(): void {
+    stopCapture(runtime, state, session);
   }
 
   function dispose(): void {


### PR DESCRIPTION
## Summary

- Batch 3 of the max-lines-per-function cleanup. \`createVoiceCapture\` drops **115 → 50** effective lines via three module-scope helpers plus a \`CaptureRuntime\` state object.
- Parallel to PR #2053 (batch 2, whisper sidecar + relay-client). Both branches were cut off the same main and touch different subsystems, so there's no diff conflict — the eslint.config.mjs grandfather-trim commit here removes only \`client.ts\` from the warn list.

## Items to Confirm / Review

The load-bearing invariants I explicitly preserved (walked end-to-end + independently re-verified by codex, verdict NO ISSUES):

- **\`start()\` single-flight** — \`startInFlight\` guards the ENTIRE start body; the \`finally\` reset covers every early return and throw.
- **\`stop()\` ordering** — \`state.setListening(false)\` BEFORE \`session.cut()\` so \`handleSegmentEnd\` sees \`isListening() === false\` during teardown and does not restart. \`monitorHandle\` cleared BEFORE \`audioGraph.teardown()\` so no VAD tick can fire against a half-closed AudioContext.
- **Segment-end order** — snapshot (hadSpeech, gen, blob) → restart (if listening) → enqueue. Snapshot precedes restart because \`session.startNext()\` clears chunks synchronously.
- **Stale-generation gate** — still between \`getUserMedia\` resolve and any observable state / recorder side effect (inside \`bootstrapCapture\`), and the acquired tracks are released on the bail path.
- **\`mimeType\` consistency** — one value flows probe → \`runtime.mimeType\` → \`MediaRecorder\` ctor.
- **\`session.cut()\`** guarded by \`recorder.state === \"recording\"\` so double-stop never throws.
- **\`segmentHasSpeech\` monotonicity** — the original wrote both \`true\` and \`false\`, but \`evaluateVad\`'s contract (\`hasSpeech = isSpeech(rms) || state.hasSpeech\`) makes the flag monotonic once true within a segment, so \`session.markSpeech()\` (idempotent) is semantically equivalent. Documented in the code comment above the extracted helper.
- **Track cleanup on \`AudioContext\` throw** — new \`bootstrapCapture\` stops acquired tracks if \`audioGraph.attach()\` throws. The pre-refactor code did not — a small strictly-safer improvement codex recommended in its up-front review.

## Extractions

- **\`createAudioGraph()\`** — module-scope factory. Owns stream + AudioContext + AnalyserNode + vadBuffer. \`attach\` / \`sample\` / \`getStream\` / \`teardown\` / \`isAttached\`.
- **\`bootstrapCapture()\`** — module-scope helper. Mime probe + \`getUserMedia\` + stale-generation check + \`audioGraph.attach\`. Returns null (with \`callbacks.onError\` fired) on any recoverable failure.
- **\`createRecorderSession()\`** — module-scope factory. Owns MediaRecorder + chunks + segmentHasSpeech + sessionGen + sessionMimeType. VAD state (\`silenceStart\`, \`segmentStart\`, global \`generation\`) stays in the parent.
- **\`CaptureRuntime\` state object + module-scope \`stopCapture\` / \`monitorTick\`** — the seven mutable fields the parent still owns are packed into one shape so the helpers can take one \`runtime\` param.

## Test plan

- [x] \`yarn format\` clean
- [x] \`yarn lint\` — 0 errors; \`createVoiceCapture\` warning is gone. sidecar.ts + relay-client.ts warnings remain here because this branch was cut before PR #2053; that PR removes them in its own trim commit.
- [x] \`yarn typecheck\` clean across all workspaces
- [x] \`yarn build\` clean
- [x] \`yarn test\` — 5602 / 5602 pass
- [x] Codex verify (NO ISSUES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor the Whisper voice capture pipeline by extracting audio graph, capture bootstrap, and recorder session logic into module-scope helpers to reduce createVoiceCapture complexity while preserving behavior.

Enhancements:
- Introduce an AudioGraph helper to encapsulate mic stream, AudioContext, analyser, and VAD buffer lifecycle.
- Add a bootstrapCapture helper to probe recorder support, acquire microphone access, and initialize the audio graph with safer error and stale-session handling.
- Create a RecorderSession helper to manage MediaRecorder segments, speech detection state, and segment lifecycle callbacks.
- Consolidate capture-time mutable state into a CaptureRuntime object and module-scope helpers for stopping capture and VAD monitoring.

Build:
- Remove whisper client.ts from the max-lines-per-function ESLint exception list after reducing createVoiceCapture size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the voice capture pipeline to make microphone setup, recording session lifecycle, and audio graph management more robust.
  * Preserved VAD-driven segmented recording and transcription behavior, including generation-based safeguards to avoid stale or partial segments.
  * Improved correctness of start/stop sequencing and resource teardown to enhance stability during continuous listening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->