### PR TITLE
fix(#1596): isTestEnv misdetects any path containing "test" → yarn dev 401s

### DIFF
--- a/plans/fix-1596-istestenv-substring-match.md
+++ b/plans/fix-1596-istestenv-substring-match.md
@@ -1,0 +1,67 @@
+# fix #1596 — `isTestEnv` misdetects any path containing "test"
+
+## Problem
+
+`server/workspace/paths.ts` computes `isTestEnv` with a **substring** match on
+`process.argv`:
+
+```js
+process.argv.some((arg) => arg.includes("test"))
+```
+
+`yarn dev` → `tsx server/index.ts` puts the worktree's absolute tsx path in
+`process.argv` (e.g. `.../worktrees/e2e-live-docker-test-fixes/node_modules/.bin/tsx`).
+When the path contains `test` as a substring, `isTestEnv` flips to `true`, so
+`workspacePath` resolves to `tmpdir/mulmoclaude-test` instead of `~/mulmoclaude`.
+The server writes its session token there, while `vite.config.ts` reads
+`~/mulmoclaude/.session-token` → token mismatch → **every `/api/*` returns 401**
+and the app loads nothing.
+
+## Root cause
+
+Substring `includes("test")` on argv elements. The real test signals are
+exact-element / flag matches, not "the string `test` appears somewhere in a
+file path".
+
+## Verified test-runner signals (measured, Node 24 + tsx)
+
+- `tsx --test` (unit): `--test` is consumed by tsx and appears in **neither**
+  `process.argv` nor `process.execArgv`. The only reliable signal is
+  `process.env.NODE_TEST_CONTEXT` (= `"child-v8"` in the isolated child).
+- `node --test`: `--test` in `process.execArgv`.
+- `playwright test` (e2e): exact `"test"` element in `process.argv`.
+- e2e-live does **not** rely on `isTestEnv` at all — it injects
+  `MULMOCLAUDE_WORKSPACE_PATH`, which takes precedence over the whole expression.
+
+## Fix
+
+Extract the detection into a pure, testable function and use exact matches:
+
+```ts
+export const detectTestEnv = (argv, execArgv, env) =>
+  env.NODE_ENV === "test" ||
+  execArgv.includes("--test") ||   // node --test
+  argv.includes("--test") ||       // --test as an argv flag
+  argv.includes("test") ||         // playwright / vitest `test` subcommand
+  typeof env.NODE_TEST_CONTEXT !== "undefined";
+
+export const isTestEnv = detectTestEnv(process.argv, process.execArgv, process.env);
+```
+
+Taking `(argv, execArgv, env)` as parameters is what makes the bug testable:
+the current shape test can't reproduce it because the test process itself runs
+under `NODE_TEST_CONTEXT`. With the pure function we can feed the exact failing
+argv from the issue and assert `false`.
+
+## Files
+
+- `server/workspace/paths.ts` — substring → exact, via `detectTestEnv`.
+- `test/workspace/test_paths_shape.ts` — drop the re-derived mirror of the
+  expression (import the real `isTestEnv`); add `detectTestEnv` regression tests
+  covering the #1596 failing input plus every positive signal.
+
+## Verification
+
+- `yarn test` (unit) → `isTestEnv` stays `true` (temp workspace) via `NODE_TEST_CONTEXT`.
+- New `detectTestEnv` test: `.../e2e-live-docker-test-fixes/.../tsx` argv → `false`.
+- `yarn typecheck` / `yarn build` green.

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -65,12 +65,20 @@ type PluginWorkspaceDirsContribution<M> = M extends { readonly workspaceDirs: in
 
 type PluginWorkspaceDirsMap<T extends BuiltInPluginMetas> = UnionToIntersection<PluginWorkspaceDirsContribution<T[number]>>;
 
-// Detect Node test runner or other typical test environments
-export const isTestEnv =
-  process.env.NODE_ENV === "test" ||
-  process.execArgv.includes("--test") ||
-  process.argv.some((arg) => arg.includes("test")) ||
-  typeof process.env.NODE_TEST_CONTEXT !== "undefined";
+// Detect Node test runner or other typical test environments. Matches argv
+// elements EXACTLY — a substring `arg.includes("test")` here wrongly flags any
+// `yarn dev` whose tsx path contains "test" (e.g. a worktree named
+// `…-test-fixes`), silently swapping the real workspace for the throwaway test
+// one and 401ing every API (#1596). Pure over its inputs so the detection is
+// testable without a real test env (which always sets NODE_TEST_CONTEXT).
+export const detectTestEnv = (argv: readonly string[], execArgv: readonly string[], env: Record<string, string | undefined>): boolean =>
+  env.NODE_ENV === "test" ||
+  execArgv.includes("--test") || // node --test
+  argv.includes("--test") || // --test passed as an argv flag
+  argv.includes("test") || // playwright / vitest `test` subcommand
+  typeof env.NODE_TEST_CONTEXT !== "undefined";
+
+export const isTestEnv = detectTestEnv(process.argv, process.execArgv, process.env);
 
 // Detect if process.env.HOME has been overridden (a common pattern in workspace/IO integration tests to isolate runs)
 const realUserHome = (() => {

--- a/test/workspace/test_paths_shape.ts
+++ b/test/workspace/test_paths_shape.ts
@@ -2,18 +2,20 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import { homedir, tmpdir, userInfo } from "node:os";
-import { WORKSPACE_DIRS, WORKSPACE_PATHS, WORKSPACE_FILES, EAGER_WORKSPACE_DIRS, workspacePath } from "../../server/workspace/paths.js";
+import {
+  WORKSPACE_DIRS,
+  WORKSPACE_PATHS,
+  WORKSPACE_FILES,
+  EAGER_WORKSPACE_DIRS,
+  workspacePath,
+  isTestEnv,
+  detectTestEnv,
+} from "../../server/workspace/paths.js";
 
 const expectedWorkspacePath = path.join(homedir(), "mulmoclaude");
 
 describe("workspacePath", () => {
   it("points to ~/mulmoclaude or the test/env override", () => {
-    const isTestEnv =
-      process.env.NODE_ENV === "test" ||
-      process.execArgv.includes("--test") ||
-      process.argv.some((arg) => arg.includes("test")) ||
-      typeof process.env.NODE_TEST_CONTEXT !== "undefined";
-
     const realUserHome = (() => {
       try {
         return userInfo().homedir;
@@ -26,6 +28,35 @@ describe("workspacePath", () => {
     const expected =
       process.env.MULMOCLAUDE_WORKSPACE_PATH || (isTestEnv && !isHomeOverridden ? path.join(tmpdir(), "mulmoclaude-test") : expectedWorkspacePath);
     assert.equal(workspacePath, expected);
+  });
+});
+
+describe("detectTestEnv (#1596)", () => {
+  const cleanEnv: Record<string, string | undefined> = {};
+
+  it("does NOT flag `yarn dev` launched from a path containing 'test'", () => {
+    const argv = ["/usr/bin/node", "/home/u/worktrees/e2e-live-docker-test-fixes/node_modules/.bin/tsx", "server/index.ts"];
+    assert.equal(detectTestEnv(argv, [], cleanEnv), false);
+  });
+
+  it("flags `node --test` (flag in execArgv)", () => {
+    assert.equal(detectTestEnv(["node", "x.ts"], ["--test"], cleanEnv), true);
+  });
+
+  it("flags `--test` passed as an argv flag", () => {
+    assert.equal(detectTestEnv(["node", "--test", "x.ts"], [], cleanEnv), true);
+  });
+
+  it("flags `playwright test` (exact 'test' subcommand)", () => {
+    assert.equal(detectTestEnv(["node", "playwright", "test", "--config", "e2e"], [], cleanEnv), true);
+  });
+
+  it("flags the Node test runner via NODE_TEST_CONTEXT", () => {
+    assert.equal(detectTestEnv(["node", "x.ts"], [], { NODE_TEST_CONTEXT: "child-v8" }), true);
+  });
+
+  it("flags NODE_ENV=test", () => {
+    assert.equal(detectTestEnv(["node", "x.ts"], [], { NODE_ENV: "test" }), true);
   });
 });
 


### PR DESCRIPTION
## Summary

`server/workspace/paths.ts` decided "are we in a test environment?" with a **substring** match on `process.argv`:

```js
process.argv.some((arg) => arg.includes("test"))
```

`yarn dev` → `tsx server/index.ts` puts the worktree's absolute tsx path in `process.argv`. When that path contains `test` as a substring (e.g. a worktree named `…-test-fixes`), `isTestEnv` flips to `true`, so `workspacePath` resolves to `tmpdir/mulmoclaude-test` instead of `~/mulmoclaude`. The server writes its session token there while `vite.config.ts` reads `~/mulmoclaude/.session-token` → **token mismatch → every `/api/*` returns 401** and the app loads nothing.

Fix: extract detection into a pure `detectTestEnv(argv, execArgv, env)` and match argv elements **exactly**.

## Items to Confirm / Review

- **Signal coverage is measured, not assumed.** Under `tsx --test` (the repo's unit runner, Node 24), `--test` is consumed by tsx and appears in **neither** `process.argv` **nor** `process.execArgv`; the only reliable signal is `process.env.NODE_TEST_CONTEXT` (`"child-v8"`). The fix keeps that branch, so unit detection is unchanged (verified: full suite still uses the temp workspace, 5639 pass).
- **`playwright test` branch is defense-in-depth.** e2e-live does not actually rely on `isTestEnv` — its fixture injects `MULMOCLAUDE_WORKSPACE_PATH`, which takes precedence over the whole expression. The exact `argv.includes("test")` branch is kept anyway (harmless; exact match won't false-positive on a path).
- **Why refactor into a pure function rather than a one-line edit?** The pre-existing shape test *cannot* reproduce this bug — the test process itself runs under `NODE_TEST_CONTEXT`, so it's always "in test". Taking `(argv, execArgv, env)` as parameters lets the new regression test feed the exact failing argv from the issue and assert `false`.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/1596 直せる？ (can you fix it?)

## Changes

| File | Change |
|---|---|
| `server/workspace/paths.ts` | Substring → exact match, extracted into pure `detectTestEnv(argv, execArgv, env)`; `isTestEnv = detectTestEnv(process.argv, process.execArgv, process.env)`. |
| `test/workspace/test_paths_shape.ts` | Drop the re-derived mirror of the expression (import the real `isTestEnv`); add `detectTestEnv` regression tests — the #1596 failing argv → `false`, plus every positive signal (`--test` flag, exact `test` subcommand, `NODE_TEST_CONTEXT`, `NODE_ENV`). |
| `plans/fix-1596-istestenv-substring-match.md` | Design + measured signal table. |

## Verification

- `yarn test` — 5639 pass (workspace-dependent tests still resolve to the temp workspace ⇒ `isTestEnv` stays `true`).
- New regression test: `.../e2e-live-docker-test-fixes/node_modules/.bin/tsx` argv → `detectTestEnv` returns `false`.
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` green.

Closes #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine test environment detection to avoid misclassifying regular dev runs as tests, preventing workspace/session token mismatches and 401s.

Bug Fixes:
- Ensure `isTestEnv` no longer treats any argv path containing "test" as a test run, avoiding incorrect use of the temporary test workspace and resulting API 401s.

Enhancements:
- Introduce a pure `detectTestEnv(argv, execArgv, env)` helper used by `isTestEnv` for clearer, testable environment detection logic.

Documentation:
- Add a planning document explaining the `isTestEnv` misdetection issue, measured test-runner signals, and the chosen fix.

Tests:
- Update workspace path shape tests to rely on the exported `isTestEnv` and add regression coverage for `detectTestEnv`, including the failing argv scenario and all supported test signals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test-environment detection to avoid misidentifying commands or file paths that merely contain “test.”
  * Prevented workspace paths from incorrectly resolving to temporary test workspaces in affected scenarios.
  * Improved detection for supported test runner flags and environment indicators.

* **Tests**
  * Added regression coverage for false-positive command paths and common test runner configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->