### PR TITLE
chore(mulmoclaude): bump launcher + root to 0.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.9.5",
+  "version": "0.9.6",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Records the version bump for the **already-published** `mulmoclaude@0.9.6` npm launcher. Root and launcher `package.json` are bumped to `0.9.6` in lockstep (so a future `v0.9.6` app tag matches the npm launcher).

## Items to Confirm / Review

- **Already published**: `mulmoclaude@0.9.6` is live on npm (verified: `npx --registry=https://registry.npmjs.org/ mulmoclaude@0.9.6 --version` → `mulmoclaude 0.9.6`). This PR only lands the version-bump commit into `main`, per the `/publish-mulmoclaude` flow (publish from branch → PR the bump).
- **Lockstep**: root `0.9.6` == launcher `0.9.6`. `bin/mulmoclaude.js` reads the version dynamically, so no bin change.
- **Depends on** `@mulmoclaude/core@^0.12.2` (published separately as `@mulmoclaude/core@0.12.2`).

## What this ships to `npx mulmoclaude` users

The launcher bundles `server/` + `src/`, so republishing is what actually delivers the server-side sandbox fixes merged in #2058:

- **#2052** — Windows junction fallback now covers every workspace scope (`@mulmobridge/*` included).
- **#2056** — npx nested `node_modules` is mounted into the container.
- **#2057** — MCP-broker startup-race retry (self-recovery) + honest scheduler run-outcome logging + same-tick firing stagger.

## Release preflight (all green)

- `MulmoClaude publish smoke` CI green on the `main` base (`cb6be675`).
- §1 deps audit clean · §2 workspace drift clean · §4 tarball boot → HTTP 200 (4 runtime plugins).
- Every `@mulmoclaude/*` launcher dep resolves on the public registry (core@0.12.2 ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application and package version to **0.9.6**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->