### PR TITLE
feat: queue chat sends while the agent runs instead of locking the input (#2067)

### DIFF
--- a/e2e/tests/chatinput-buffer.spec.ts
+++ b/e2e/tests/chatinput-buffer.spec.ts
@@ -17,27 +17,28 @@ import { chatInput } from "../fixtures/chat";
 const HANDSHAKE = { sid: "mock-sid", upgrades: [], pingInterval: 25000, pingTimeout: 20000, maxPayload: 1_000_000 };
 
 test.describe("chat input buffer while running", () => {
-  let running: boolean;
+  // Set of session ids currently "running" — both sessions start running so
+  // the per-session buffer scoping (concurrent runs) can be exercised.
+  let running: Set<string>;
   let agentCalls: string[];
   let pushSessionsRefresh: (() => void) | null;
 
   test.beforeEach(async ({ page }) => {
-    running = true;
+    running = new Set([SESSION_A.id, SESSION_B.id]);
     agentCalls = [];
     pushSessionsRefresh = null;
 
     await mockAllApis(page);
 
     // Stateful `/api/sessions` — registered after mockAllApis so it wins
-    // (Playwright checks last-registered-first). SESSION_A's run state
-    // tracks the `running` flag the test toggles.
+    // (Playwright checks last-registered-first). Each session's run state
+    // tracks the `running` set the test toggles.
     await page.route(
       (url) => url.pathname === "/api/sessions",
       (route) => {
         if (route.request().method() !== "GET") return route.fallback();
-        return route.fulfill({
-          json: { sessions: [{ ...SESSION_A, isRunning: running }, SESSION_B], cursor: "v1:0", deletedIds: [] },
-        });
+        const sessions = [SESSION_A, SESSION_B].map((session) => ({ ...session, isRunning: running.has(session.id) }));
+        return route.fulfill({ json: { sessions, cursor: "v1:0", deletedIds: [] } });
       },
     );
 
@@ -78,10 +79,12 @@ test.describe("chat input buffer while running", () => {
     await expect(chatInput(page)).toBeVisible();
   });
 
-  async function finishRun(page: Page): Promise<void> {
-    running = false;
-    // The socket connects a beat after navigation; retry the push until
-    // the client has wired its `sessions` listener and re-fetches.
+  // Finish the run for `sessionId` (must be the displayed session so the
+  // stop-button assertion tracks it). The socket connects a beat after
+  // navigation; retry the push until the client has wired its `sessions`
+  // listener and re-fetches.
+  async function finishRun(page: Page, sessionId: string): Promise<void> {
+    running.delete(sessionId);
     await expect(async () => {
       pushSessionsRefresh?.();
       await expect(page.getByTestId("stop-btn")).toHaveCount(0, { timeout: 200 });
@@ -125,7 +128,7 @@ test.describe("chat input buffer while running", () => {
     await input.press("Enter");
     await expect(page.getByTestId("buffered-message")).toHaveCount(2);
 
-    await finishRun(page);
+    await finishRun(page, SESSION_A.id);
 
     // Chips cleared; both messages merged into the editable input,
     // oldest-first, newline separated.
@@ -133,6 +136,35 @@ test.describe("chat input buffer while running", () => {
     await expect(input).toHaveValue("one\ntwo");
     // Now idle: the send button is back for the final manual send.
     await expect(page.getByTestId("send-btn")).toBeVisible();
+  });
+
+  test("queues stay scoped to their own session across concurrent runs", async ({ page }) => {
+    const input = chatInput(page);
+
+    // Queue for session A (running).
+    await input.fill("alpha");
+    await input.press("Enter");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(1);
+
+    // Client-side switch to session B (also running, no reload so the
+    // per-session buffers survive) — A's queue must NOT show here.
+    await page.getByTestId(`session-tab-${SESSION_B.id}`).click();
+    await expect(input).toHaveValue("");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(0);
+
+    // Queue for B, then finish B: only B's message merges in (not
+    // "alpha\nbeta") — A's queue does not leak into B. This is the
+    // concurrent-run mixing bug the per-session keying fixes.
+    await input.fill("beta");
+    await input.press("Enter");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(1);
+    await finishRun(page, SESSION_B.id);
+    await expect(input).toHaveValue("beta");
+
+    // Back to A (still running): its queued message survived intact.
+    await page.getByTestId(`session-tab-${SESSION_A.id}`).click();
+    await expect(page.getByTestId("buffered-message")).toHaveCount(1);
+    await expect(page.getByTestId("buffered-message").first()).toContainText("alpha");
   });
 
   test("Ctrl+Enter inserts a newline instead of queuing", async ({ page }) => {

--- a/e2e/tests/chatinput-buffer.spec.ts
+++ b/e2e/tests/chatinput-buffer.spec.ts
@@ -62,8 +62,13 @@ test.describe("chat input buffer while running", () => {
         webSocket.send(`0${JSON.stringify(HANDSHAKE)}`);
         webSocket.onMessage((msg) => {
           const text = String(msg);
-          if (text === "2") return webSocket.send("3");
-          if (text === "40") return webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
+          if (text === "2") {
+            webSocket.send("3");
+            return;
+          }
+          if (text === "40") {
+            webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
+          }
         });
         pushSessionsRefresh = () => webSocket.send(`42${JSON.stringify(["data", { channel: "sessions", data: { updated: true } }])}`);
       },

--- a/e2e/tests/chatinput-buffer.spec.ts
+++ b/e2e/tests/chatinput-buffer.spec.ts
@@ -1,0 +1,141 @@
+// E2E for the "queue while running" chat input (#2067).
+//
+// While a run is in flight the input is no longer locked: sends are
+// queued as removable chips instead of dispatching, and merge back into
+// the input for a final manual edit + send once the run finishes.
+//
+// Run state is driven purely by what `/api/sessions` reports for the
+// displayed session (see useSessionDerived). We flip a mutable flag and
+// push a `sessions`-channel pub/sub event to make the client re-fetch and
+// observe the run finishing — the same path the real server uses.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { SESSION_A, SESSION_B } from "../fixtures/sessions";
+import { chatInput } from "../fixtures/chat";
+
+const HANDSHAKE = { sid: "mock-sid", upgrades: [], pingInterval: 25000, pingTimeout: 20000, maxPayload: 1_000_000 };
+
+test.describe("chat input buffer while running", () => {
+  let running: boolean;
+  let agentCalls: string[];
+  let pushSessionsRefresh: (() => void) | null;
+
+  test.beforeEach(async ({ page }) => {
+    running = true;
+    agentCalls = [];
+    pushSessionsRefresh = null;
+
+    await mockAllApis(page);
+
+    // Stateful `/api/sessions` — registered after mockAllApis so it wins
+    // (Playwright checks last-registered-first). SESSION_A's run state
+    // tracks the `running` flag the test toggles.
+    await page.route(
+      (url) => url.pathname === "/api/sessions",
+      (route) => {
+        if (route.request().method() !== "GET") return route.fallback();
+        return route.fulfill({
+          json: { sessions: [{ ...SESSION_A, isRunning: running }, SESSION_B], cursor: "v1:0", deletedIds: [] },
+        });
+      },
+    );
+
+    // Sends while running must NOT hit the agent — track POSTs to prove it.
+    await page.route(
+      (url) => url.pathname === "/api/agent",
+      (route) => {
+        if (route.request().method() === "POST") {
+          agentCalls.push(route.request().postData() ?? "");
+          return route.fulfill({ status: 202, json: { chatSessionId: "mock-session" } });
+        }
+        return route.fallback();
+      },
+    );
+
+    // Minimal socket.io mock: accept the handshake + subscriptions, and
+    // expose a way to push a `sessions`-channel event that makes the
+    // client re-read `/api/sessions` (how it learns the run finished).
+    await page.routeWebSocket(
+      (url) => url.pathname.startsWith("/ws/pubsub"),
+      (webSocket) => {
+        webSocket.send(`0${JSON.stringify(HANDSHAKE)}`);
+        webSocket.onMessage((msg) => {
+          const text = String(msg);
+          if (text === "2") return webSocket.send("3");
+          if (text === "40") return webSocket.send(`40${JSON.stringify({ sid: "mock-socket-sid" })}`);
+        });
+        pushSessionsRefresh = () => webSocket.send(`42${JSON.stringify(["data", { channel: "sessions", data: { updated: true } }])}`);
+      },
+    );
+
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await expect(chatInput(page)).toBeVisible();
+  });
+
+  async function finishRun(page: Page): Promise<void> {
+    running = false;
+    // The socket connects a beat after navigation; retry the push until
+    // the client has wired its `sessions` listener and re-fetches.
+    await expect(async () => {
+      pushSessionsRefresh?.();
+      await expect(page.getByTestId("stop-btn")).toHaveCount(0, { timeout: 200 });
+    }).toPass();
+  }
+
+  test("input stays editable and shows the stop button while running", async ({ page }) => {
+    await expect(chatInput(page)).toBeEnabled();
+    await expect(page.getByTestId("stop-btn")).toBeVisible();
+    await expect(page.getByTestId("send-btn")).toHaveCount(0);
+  });
+
+  test("Enter queues messages as removable chips without dispatching", async ({ page }) => {
+    const input = chatInput(page);
+
+    await input.fill("first queued");
+    await input.press("Enter");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(1);
+    await expect(page.getByTestId("buffered-message").first()).toContainText("first queued");
+    await expect(input).toHaveValue("");
+
+    await input.fill("second queued");
+    await input.press("Enter");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(2);
+
+    // Nothing was sent to the agent while running.
+    expect(agentCalls).toHaveLength(0);
+
+    // Remove the first chip via its ✕ button.
+    await page.getByTestId("buffered-message-remove").first().click();
+    await expect(page.getByTestId("buffered-message")).toHaveCount(1);
+    await expect(page.getByTestId("buffered-message").first()).toContainText("second queued");
+  });
+
+  test("queued messages merge back into the input when the run finishes", async ({ page }) => {
+    const input = chatInput(page);
+
+    await input.fill("one");
+    await input.press("Enter");
+    await input.fill("two");
+    await input.press("Enter");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(2);
+
+    await finishRun(page);
+
+    // Chips cleared; both messages merged into the editable input,
+    // oldest-first, newline separated.
+    await expect(page.getByTestId("buffered-message")).toHaveCount(0);
+    await expect(input).toHaveValue("one\ntwo");
+    // Now idle: the send button is back for the final manual send.
+    await expect(page.getByTestId("send-btn")).toBeVisible();
+  });
+
+  test("Ctrl+Enter inserts a newline instead of queuing", async ({ page }) => {
+    const input = chatInput(page);
+    await input.fill("hello");
+    await input.press("Control+Enter");
+    await expect(input).toHaveValue("hello\n");
+    await expect(page.getByTestId("buffered-message")).toHaveCount(0);
+    expect(agentCalls).toHaveLength(0);
+  });
+});

--- a/e2e/tests/slash-command-menu.spec.ts
+++ b/e2e/tests/slash-command-menu.spec.ts
@@ -67,6 +67,18 @@ test.describe("slash command menu", () => {
     await expect.poll(() => agentCalls.length, { timeout: 500 }).toBe(0);
   });
 
+  test("Ctrl+Enter inserts a newline instead of selecting the highlighted item", async ({ page }) => {
+    await fillChatInput(page, "/a");
+    await expect(page.getByTestId("slash-command-menu")).toBeVisible();
+
+    await chatInput(page).press("Control+Enter");
+
+    // Newline spliced at the caret — the highlighted skill is NOT selected
+    // (value would be "/archive ") and nothing is sent.
+    await expect(chatInput(page)).toHaveValue("/a\n");
+    await expect.poll(() => agentCalls.length, { timeout: 500 }).toBe(0);
+  });
+
   test("ArrowDown moves the highlight before Enter selects", async ({ page }) => {
     await fillChatInput(page, "/a");
     await expect(page.getByTestId("slash-command-menu")).toBeVisible();

--- a/plans/feat-chat-input-buffer.md
+++ b/plans/feat-chat-input-buffer.md
@@ -1,0 +1,89 @@
+# feat: CC実行中もユーザ入力をロックせず、送信をバッファーにためる (#2067)
+
+## 背景 / 要望
+
+現状、CC 実行中はユーザ入力 textarea が `:disabled="isRunning"` でロックされ、
+`sendMessage()` も `activeSessionRunning` 中は早期 return する。
+
+要望（terminal に近い挙動）:
+
+1. 実行中も入力欄をロックしない
+2. 実行中に送信（Enter）した内容はバッファー（キュー）にたまる。複数可
+3. 各バッファー項目は × ボタンで削除できる
+4. CC 実行が完了したら、バッファーの内容を入力欄（textarea）に改行区切りで結合して戻す
+5. ユーザが最終的に編集して手動送信する
+6. Ctrl+Enter（Mac は Cmd+Enter も）で改行を挿入できる
+
+## UX 決定（ユーザ確認済み 2026-07-12）
+
+- 完了時: 入力欄に戻して手動送信（自動送信しない）
+- 実行中のボタン列: 「停止」のみ（現状維持）。バッファー追加は Enter キー
+
+## 現状のコード
+
+- `src/App.vue`
+  - `userInput`（グローバル ref、セッション切替でクリアされない）
+  - `sendMessage()` は `activeSessionRunning` 中は return
+  - `activeSessionRunning`（表示中セッションの実行状態、`useSessionDerived` 由来）
+- `src/components/ChatInput.vue`
+  - textarea は `:value=modelValue` / `@input`、`:disabled=isRunning`
+  - 実行中は send ボタン → stop ボタン
+  - `useImeAwareEnter` で Enter 判定（Shift+Enter は素通しで改行）
+  - 添付は `pastedFiles` + `ChatAttachmentPreview` チップ（× 削除は `update:pastedFiles`）
+
+## 実装方針
+
+### 1. 純粋関数 `src/utils/chat/buffer.ts`
+
+- `mergeBufferedIntoDraft(buffered: string[], draft: string): string`
+  - `[...buffered, draft]` を `trim` + 空要素除去して `\n` で結合
+  - ユニットテスト対象
+
+### 2. `ChatInput.vue`
+
+- textarea の `:disabled="isRunning"` を削除（ロックしない）
+- 新規 prop `bufferedMessages: string[]`、emit `update:bufferedMessages`
+- textarea の上（`pastedFiles` チップと同位置）に buffered チップ一覧を描画
+  - 各チップ: メッセージ本文（省略表示、`title` に全文）+ × ボタン
+  - × で該当 index を除いた配列を `update:bufferedMessages`
+  - `data-testid="buffered-message-list"` / `data-testid="buffered-message"`
+- `onKeydown`: Ctrl/Cmd+Enter を最優先で捕捉し、カーソル位置に改行を挿入
+  （`insertNewlineAtCursor`）。IME 確定中は無視
+- 実行中でも Enter は従来どおり `emit("send")`。ボタン列は現状維持
+- 実行中プレースホルダを切り替え（任意）
+
+### 3. `App.vue`
+
+- 新規 state: `bufferedMessages = ref<string[]>([])`、`bufferedForSessionId = ref("")`
+- `sendMessage(text?)`:
+  - `if (!message) return;`
+  - `if (activeSessionRunning.value)`:
+    - バッファーに push、`bufferedForSessionId = currentSessionId`
+    - textarea 由来（`typeof text !== "string"`）なら `userInput = ""`
+    - return
+  - それ以外は従来の送信フロー
+- 完了 / 切替 watch `watch([activeSessionRunning, currentSessionId], ...)`:
+  - バッファー空 / 所有セッション ≠ 表示中 / まだ実行中 → 何もしない
+  - 所有セッションを表示中かつ非実行 →
+    `userInput = mergeBufferedIntoDraft(bufferedMessages, userInput)`、
+    バッファークリア、`focusChatInput()`
+- 両 ChatInput 呼び出し（単一 / stack レイアウト）に
+  `v-model:buffered-messages="bufferedMessages"` を追加
+
+### 4. i18n（全 8 ロケール）
+
+- `chatInput.removeBuffered`（× の aria-label）
+- `chatInput.runningPlaceholder`（実行中プレースホルダ、任意）
+
+### 5. テスト
+
+- ユニット: `test/utils/test_chat_buffer.ts`（merge の正常・空・trim・順序）
+- e2e: `e2e/tests/chatinput-buffer.spec.ts`
+  - 実行中に Enter でチップ増加 → × 削除 → 完了で textarea へ結合
+  - Ctrl+Enter で改行挿入
+
+## 既知の制限
+
+- バッファーはグローバル（`userInput` 同様）。`bufferedForSessionId` ガードで、
+  実行中セッションを離れている間は誤って dump しない。所有セッションに戻り
+  非実行になった時点で dump する。

--- a/plans/feat-chat-input-buffer.md
+++ b/plans/feat-chat-input-buffer.md
@@ -54,21 +54,23 @@
 
 ### 3. `App.vue`
 
-- 新規 state: `bufferedMessages = ref<string[]>([])`、`bufferedForSessionId = ref("")`
+- 新規 state: `bufferedMessagesBySession = ref<Record<string, string[]>>({})`
+  （セッションIDごとにキュー）+ 書込み可能 computed
+  `currentBufferedMessages`（表示中セッションのキューを get/set）
 - `sendMessage(text?)`:
   - `if (!message) return;`
   - `if (activeSessionRunning.value)`:
-    - バッファーに push、`bufferedForSessionId = currentSessionId`
+    - `currentBufferedMessages.value = [...currentBufferedMessages.value, message]`
     - textarea 由来（`typeof text !== "string"`）なら `userInput = ""`
     - return
   - それ以外は従来の送信フロー
 - 完了 / 切替 watch `watch([activeSessionRunning, currentSessionId], ...)`:
-  - バッファー空 / 所有セッション ≠ 表示中 / まだ実行中 → 何もしない
-  - 所有セッションを表示中かつ非実行 →
-    `userInput = mergeBufferedIntoDraft(bufferedMessages, userInput)`、
-    バッファークリア、`focusChatInput()`
+  - まだ実行中 / 表示中セッションのキュー空 → 何もしない
+  - 非実行かつキューあり →
+    `userInput = mergeBufferedIntoDraft(currentBufferedMessages, userInput)`、
+    当該セッションのキュークリア、`focusChatInput()`
 - 両 ChatInput 呼び出し（単一 / stack レイアウト）に
-  `v-model:buffered-messages="bufferedMessages"` を追加
+  `v-model:buffered-messages="currentBufferedMessages"` を追加
 
 ### 4. i18n（全 8 ロケール）
 
@@ -77,13 +79,15 @@
 
 ### 5. テスト
 
-- ユニット: `test/utils/test_chat_buffer.ts`（merge の正常・空・trim・順序）
+- ユニット: `test/utils/chat/test_buffer.ts`（merge の正常・空・trim・順序）
 - e2e: `e2e/tests/chatinput-buffer.spec.ts`
   - 実行中に Enter でチップ増加 → × 削除 → 完了で textarea へ結合
+  - **複数セッション同時実行でキューが混線しない**（回帰テスト）
   - Ctrl+Enter で改行挿入
 
-## 既知の制限
+## セッションスコープ
 
-- バッファーはグローバル（`userInput` 同様）。`bufferedForSessionId` ガードで、
-  実行中セッションを離れている間は誤って dump しない。所有セッションに戻り
-  非実行になった時点で dump する。
+- バッファーは `bufferedMessagesBySession`（セッションIDごと）で保持。表示中
+  セッションのキューは、そのセッションが非実行になった時点でのみ入力欄へ結合。
+  別セッションで実行中のキューは各セッション固有に保たれ、混線しない。
+- `userInput`（下書き）は従来どおりグローバル。

--- a/src/App.vue
+++ b/src/App.vue
@@ -150,7 +150,7 @@
           ref="chatInputRef"
           v-model="userInput"
           v-model:pasted-files="pastedFiles"
-          v-model:buffered-messages="bufferedMessages"
+          v-model:buffered-messages="currentBufferedMessages"
           :is-running="activeSessionRunning"
           :queries="sessionRoleQueries"
           :session-id="currentSessionId"
@@ -287,7 +287,7 @@
             ref="chatInputRef"
             v-model="userInput"
             v-model:pasted-files="pastedFiles"
-            v-model:buffered-messages="bufferedMessages"
+            v-model:buffered-messages="currentBufferedMessages"
             :is-running="activeSessionRunning"
             :queries="sessionRoleQueries"
             :session-id="currentSessionId"
@@ -497,11 +497,17 @@ const { shortcuts } = useShortcuts();
 const userInput = ref("");
 const pastedFiles = ref<PastedFile[]>([]);
 // Messages the user sends while a run is in flight queue here instead of
-// dispatching. `bufferedForSessionId` records which session they belong
-// to so switching away doesn't dump them into the wrong input; they merge
-// back into `userInput` when that session's run finishes (see watch below).
-const bufferedMessages = ref<string[]>([]);
-const bufferedForSessionId = ref("");
+// dispatching, keyed by the session they belong to so concurrent runs in
+// different sessions never mix. `currentBufferedMessages` is the displayed
+// session's queue; it merges back into `userInput` when that session's run
+// finishes (see watch below).
+const bufferedMessagesBySession = ref<Record<string, string[]>>({});
+const currentBufferedMessages = computed<string[]>({
+  get: () => bufferedMessagesBySession.value[currentSessionId.value] ?? [],
+  set: (messages) => {
+    bufferedMessagesBySession.value = { ...bufferedMessagesBySession.value, [currentSessionId.value]: messages };
+  },
+});
 const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, historyError, fetchSessions, setBookmark, deleteSession: deleteSessionFromHistory } = useSessionHistory();
@@ -1128,8 +1134,7 @@ async function sendMessage(text?: string) {
   // Run in flight: queue instead of dispatching. The input isn't locked,
   // so the user keeps composing; queued lines come back on completion.
   if (activeSessionRunning.value) {
-    bufferedMessages.value = [...bufferedMessages.value, message];
-    bufferedForSessionId.value = currentSessionId.value;
+    currentBufferedMessages.value = [...currentBufferedMessages.value, message];
     if (fromInput) userInput.value = "";
     return;
   }
@@ -1167,17 +1172,16 @@ async function sendMessage(text?: string) {
   }
 }
 
-// Drain the queued messages back into the input once their session's run
-// finishes and that session is the one on screen. Guarding on both the
-// run state and the displayed id means switching to another session while
-// the run continues won't dump the queue into the wrong input — it waits
-// until we're back on the owning session and it has gone idle.
+// Drain the displayed session's queued messages back into the input once
+// its run finishes. Keyed by `currentSessionId`, so switching to another
+// session shows (and later drains) that session's own queue — a background
+// run in a different session never dumps its queue into the wrong input.
 watch([activeSessionRunning, currentSessionId], () => {
-  if (bufferedMessages.value.length === 0) return;
   if (activeSessionRunning.value) return;
-  if (currentSessionId.value !== bufferedForSessionId.value) return;
-  userInput.value = mergeBufferedIntoDraft(bufferedMessages.value, userInput.value);
-  bufferedMessages.value = [];
+  const queued = currentBufferedMessages.value;
+  if (queued.length === 0) return;
+  userInput.value = mergeBufferedIntoDraft(queued, userInput.value);
+  currentBufferedMessages.value = [];
   focusChatInput();
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -150,6 +150,7 @@
           ref="chatInputRef"
           v-model="userInput"
           v-model:pasted-files="pastedFiles"
+          v-model:buffered-messages="bufferedMessages"
           :is-running="activeSessionRunning"
           :queries="sessionRoleQueries"
           :session-id="currentSessionId"
@@ -286,6 +287,7 @@
             ref="chatInputRef"
             v-model="userInput"
             v-model:pasted-files="pastedFiles"
+            v-model:buffered-messages="bufferedMessages"
             :is-running="activeSessionRunning"
             :queries="sessionRoleQueries"
             :session-id="currentSessionId"
@@ -367,6 +369,7 @@ import { resolvePastedAttachment } from "./utils/agent/pastedAttachment";
 import { applyAgentEvent, type AgentEventContext } from "./utils/agent/eventDispatch";
 import { pushErrorMessage, beginUserTurn, updateResult, applyToolResultToSession } from "./utils/session/sessionHelpers";
 import { parseCollectionSlashSeed, makeSyntheticCollectionResult, hasRealCollectionResult } from "./utils/collections/presentSeed";
+import { mergeBufferedIntoDraft } from "./utils/chat/buffer";
 import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
@@ -493,6 +496,12 @@ const { shortcuts } = useShortcuts();
 
 const userInput = ref("");
 const pastedFiles = ref<PastedFile[]>([]);
+// Messages the user sends while a run is in flight queue here instead of
+// dispatching. `bufferedForSessionId` records which session they belong
+// to so switching away doesn't dump them into the wrong input; they merge
+// back into `userInput` when that session's run finishes (see watch below).
+const bufferedMessages = ref<string[]>([]);
+const bufferedForSessionId = ref("");
 const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, historyError, fetchSessions, setBookmark, deleteSession: deleteSessionFromHistory } = useSessionHistory();
@@ -1113,8 +1122,17 @@ async function resolveAttachmentPaths(files: PastedFile[]): Promise<AttachmentRe
 }
 
 async function sendMessage(text?: string) {
-  const message = typeof text === "string" ? text : userInput.value.trim();
-  if (!message || activeSessionRunning.value) return;
+  const fromInput = typeof text !== "string";
+  const message = fromInput ? userInput.value.trim() : text.trim();
+  if (!message) return;
+  // Run in flight: queue instead of dispatching. The input isn't locked,
+  // so the user keeps composing; queued lines come back on completion.
+  if (activeSessionRunning.value) {
+    bufferedMessages.value = [...bufferedMessages.value, message];
+    bufferedForSessionId.value = currentSessionId.value;
+    if (fromInput) userInput.value = "";
+    return;
+  }
   userInput.value = "";
   const filesSnapshot = [...pastedFiles.value];
   pastedFiles.value = [];
@@ -1148,6 +1166,20 @@ async function sendMessage(text?: string) {
     unsubscribeSession(session.id);
   }
 }
+
+// Drain the queued messages back into the input once their session's run
+// finishes and that session is the one on screen. Guarding on both the
+// run state and the displayed id means switching to another session while
+// the run continues won't dump the queue into the wrong input — it waits
+// until we're back on the owning session and it has gone idle.
+watch([activeSessionRunning, currentSessionId], () => {
+  if (bufferedMessages.value.length === 0) return;
+  if (activeSessionRunning.value) return;
+  if (currentSessionId.value !== bufferedForSessionId.value) return;
+  userInput.value = mergeBufferedIntoDraft(bufferedMessages.value, userInput.value);
+  bufferedMessages.value = [];
+  focusChatInput();
+});
 
 // Stop the in-flight agent run for the displayed session. The server's
 // /api/agent/cancel aborts the AbortController, kills the Claude

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -461,15 +461,16 @@ watch(slashMenuOpen, (open) => {
 });
 
 function onKeydown(event: KeyboardEvent): void {
-  if (slashMenuOpen.value && handleSlashMenuKeydown(slashMenu, event, { isImeConfirmation: imeEnter.isImeConfirmation, onSelect: selectSlashSkill })) {
-    return;
-  }
-  // Ctrl/Cmd+Enter inserts a newline instead of sending. A textarea does
-  // not do this natively (only plain / Shift+Enter insert one), so we
-  // splice it in at the caret ourselves.
+  // Ctrl/Cmd+Enter inserts a newline instead of sending. Checked before the
+  // slash menu so the chord still works while a skill is highlighted (the
+  // menu's Enter handler would otherwise select it). A textarea does not
+  // insert on this chord natively, so we splice it in at the caret.
   if (isNewlineChord(event)) {
     event.preventDefault();
     insertNewlineAtCursor();
+    return;
+  }
+  if (slashMenuOpen.value && handleSlashMenuKeydown(slashMenu, event, { isImeConfirmation: imeEnter.isImeConfirmation, onSelect: selectSlashSkill })) {
     return;
   }
   imeEnter.onKeydown(event);

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -34,15 +34,40 @@
           @remove="removeFileAt(index)"
         />
       </div>
+      <!-- Messages sent while the agent is running queue here instead of
+           going out immediately; they merge back into the input for a
+           final edit + send once the run finishes (App.vue owns the
+           merge). Each chip is removable so a queued line can be dropped
+           before it comes back. -->
+      <div v-if="bufferedMessages.length > 0" class="flex flex-col gap-1 mb-1" data-testid="buffered-message-list">
+        <div
+          v-for="(message, index) in bufferedMessages"
+          :key="index"
+          class="flex items-center gap-1.5 bg-blue-50 border border-blue-200 rounded px-2 py-1 text-xs text-gray-700"
+          data-testid="buffered-message"
+        >
+          <span class="material-icons text-sm leading-none text-blue-400">schedule</span>
+          <span class="flex-1 truncate" :title="message">{{ message }}</span>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-red-600 shrink-0 flex items-center"
+            :title="t('chatInput.removeBuffered')"
+            :aria-label="t('chatInput.removeBuffered')"
+            data-testid="buffered-message-remove"
+            @click="removeBufferedAt(index)"
+          >
+            <span class="material-icons text-sm leading-none">close</span>
+          </button>
+        </div>
+      </div>
       <div class="flex gap-2" :class="{ 'mt-2': pastedFiles.length > 0 }">
         <textarea
           ref="textarea"
           :value="modelValue"
           data-testid="user-input"
-          :placeholder="t('chatInput.placeholder')"
+          :placeholder="placeholder"
           rows="2"
-          class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed resize-none"
-          :disabled="isRunning"
+          class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
           @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
           @compositionstart="imeEnter.onCompositionStart"
           @compositionend="imeEnter.onCompositionEnd"
@@ -143,6 +168,10 @@ const props = withDefaults(
     modelValue: string;
     pastedFiles: PastedFile[];
     isRunning: boolean;
+    /** Messages queued while the agent runs. Rendered as removable chips
+     *  above the input; App.vue merges them back into `modelValue` when
+     *  the run finishes. */
+    bufferedMessages?: string[];
     queries?: string[];
     /** Currently displayed session id. Voice "armed" state is reset
      *  whenever this changes so leaving a session and coming back
@@ -150,16 +179,26 @@ const props = withDefaults(
      *  persisted). */
     sessionId?: string;
   }>(),
-  { queries: () => [], sessionId: "" },
+  { bufferedMessages: () => [], queries: () => [], sessionId: "" },
 );
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
   "update:pastedFiles": [files: PastedFile[]];
+  "update:bufferedMessages": [messages: string[]];
   send: [];
   stop: [];
   "suggestion-send": [query: string];
 }>();
+
+const placeholder = computed(() => (props.isRunning ? t("chatInput.runningPlaceholder") : t("chatInput.placeholder")));
+
+function removeBufferedAt(index: number): void {
+  emit(
+    "update:bufferedMessages",
+    props.bufferedMessages.filter((_, i) => i !== index),
+  );
+}
 
 // Local voice input (Mac-only). The mic button is hidden unless the
 // backend reports voice input ready; transcripts are appended to the
@@ -425,7 +464,32 @@ function onKeydown(event: KeyboardEvent): void {
   if (slashMenuOpen.value && handleSlashMenuKeydown(slashMenu, event, { isImeConfirmation: imeEnter.isImeConfirmation, onSelect: selectSlashSkill })) {
     return;
   }
+  // Ctrl/Cmd+Enter inserts a newline instead of sending. A textarea does
+  // not do this natively (only plain / Shift+Enter insert one), so we
+  // splice it in at the caret ourselves.
+  if (isNewlineChord(event)) {
+    event.preventDefault();
+    insertNewlineAtCursor();
+    return;
+  }
   imeEnter.onKeydown(event);
+}
+
+function isNewlineChord(event: KeyboardEvent): boolean {
+  return event.key === "Enter" && (event.ctrlKey || event.metaKey) && !imeEnter.isImeConfirmation(event);
+}
+
+function insertNewlineAtCursor(): void {
+  const field = textarea.value;
+  const value = props.modelValue;
+  const start = field?.selectionStart ?? value.length;
+  const end = field?.selectionEnd ?? start;
+  emit("update:modelValue", `${value.slice(0, start)}\n${value.slice(end)}`);
+  nextTick(() => {
+    const caret = start + 1;
+    field?.focus();
+    field?.setSelectionRange(caret, caret);
+  });
 }
 
 // Selection populates `/<name> ` (trailing space dismisses the menu via the

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -35,6 +35,8 @@ const deMessages = {
     placeholder: "Nachricht an Claude…",
     send: "Senden",
     stop: "Stoppen",
+    runningPlaceholder: "Läuft… Enter reiht die Nachricht ein",
+    removeBuffered: "Nachricht aus Warteschlange entfernen",
     attachFile: "Datei anhängen",
     fileTooLarge: "Datei zu groß ({sizeMB} MB). Das Maximum beträgt 30 MB.",
     unsupportedFileType: "Dateityp nicht unterstützt. Akzeptiert: Bilder, PDF, DOCX, XLSX, PPTX, Textdateien.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -57,6 +57,8 @@ const enMessages = {
     placeholder: "Message Claude…",
     send: "Send",
     stop: "Stop",
+    runningPlaceholder: "Running… press Enter to queue for later",
+    removeBuffered: "Remove queued message",
     attachFile: "Attach file",
     fileTooLarge: "File too large ({sizeMB} MB). Maximum is 30 MB.",
     unsupportedFileType: "File type not supported. Accepted: images, PDF, DOCX, XLSX, PPTX, text files.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -40,6 +40,8 @@ const esMessages = {
     placeholder: "Mensaje para Claude…",
     send: "Enviar",
     stop: "Detener",
+    runningPlaceholder: "En ejecución… pulsa Enter para poner en cola",
+    removeBuffered: "Eliminar mensaje en cola",
     attachFile: "Adjuntar archivo",
     fileTooLarge: "El archivo es demasiado grande ({sizeMB} MB). El máximo es 30 MB.",
     unsupportedFileType: "Tipo de archivo no admitido. Se aceptan: imágenes, PDF, DOCX, XLSX, PPTX y archivos de texto.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -35,6 +35,8 @@ const frMessages = {
     placeholder: "Message à Claude…",
     send: "Envoyer",
     stop: "Arrêter",
+    runningPlaceholder: "En cours… appuyez sur Entrée pour mettre en file",
+    removeBuffered: "Supprimer le message en file",
     attachFile: "Joindre un fichier",
     fileTooLarge: "Fichier trop volumineux ({sizeMB} Mo). La limite est de 30 Mo.",
     unsupportedFileType: "Type de fichier non pris en charge. Acceptés : images, PDF, DOCX, XLSX, PPTX, fichiers texte.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -42,6 +42,8 @@ const jaMessages = {
     placeholder: "Claude にメッセージ…",
     send: "送信",
     stop: "停止",
+    runningPlaceholder: "実行中… Enter で後で送るキューに追加",
+    removeBuffered: "キューのメッセージを削除",
     attachFile: "ファイルを添付",
     fileTooLarge: "ファイルが大きすぎます（{sizeMB} MB）。上限は 30 MB です。",
     unsupportedFileType: "対応していないファイル形式です。画像・PDF・DOCX・XLSX・PPTX・テキストファイルを使用してください。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -42,6 +42,8 @@ const koMessages = {
     placeholder: "Claude에게 메시지…",
     send: "전송",
     stop: "중지",
+    runningPlaceholder: "실행 중… Enter로 대기열에 추가",
+    removeBuffered: "대기열 메시지 제거",
     attachFile: "파일 첨부",
     fileTooLarge: "파일이 너무 큽니다 ({sizeMB} MB). 최대 30 MB 까지 가능합니다.",
     unsupportedFileType: "지원되지 않는 파일 형식입니다. 이미지, PDF, DOCX, XLSX, PPTX, 텍스트 파일만 지원됩니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -35,6 +35,8 @@ const ptBRMessages = {
     placeholder: "Mensagem para Claude…",
     send: "Enviar",
     stop: "Parar",
+    runningPlaceholder: "Em execução… pressione Enter para enfileirar",
+    removeBuffered: "Remover mensagem da fila",
     attachFile: "Anexar arquivo",
     fileTooLarge: "Arquivo muito grande ({sizeMB} MB). O limite é 30 MB.",
     unsupportedFileType: "Tipo de arquivo não suportado. Aceitos: imagens, PDF, DOCX, XLSX, PPTX e arquivos de texto.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -40,6 +40,8 @@ const zhMessages = {
     placeholder: "向 Claude 发送消息…",
     send: "发送",
     stop: "停止",
+    runningPlaceholder: "运行中… 按 Enter 加入队列",
+    removeBuffered: "移除排队的消息",
     attachFile: "附加文件",
     fileTooLarge: "文件过大（{sizeMB} MB）。上限为 30 MB。",
     unsupportedFileType: "不支持的文件类型。支持:图像、PDF、DOCX、XLSX、PPTX、文本文件。",

--- a/src/utils/chat/buffer.ts
+++ b/src/utils/chat/buffer.ts
@@ -1,0 +1,11 @@
+const BUFFER_JOINER = "\n";
+
+// Messages queued while the agent runs are merged back into the input
+// draft once the run finishes, oldest-first with the live draft last, so
+// the user can edit the combined text and send it as one turn.
+export function mergeBufferedIntoDraft(buffered: string[], draft: string): string {
+  return [...buffered, draft]
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(BUFFER_JOINER);
+}

--- a/test/utils/chat/test_buffer.ts
+++ b/test/utils/chat/test_buffer.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mergeBufferedIntoDraft } from "../../../src/utils/chat/buffer.js";
+
+describe("mergeBufferedIntoDraft", () => {
+  it("joins buffered messages then the live draft with a single newline, oldest-first", () => {
+    assert.equal(mergeBufferedIntoDraft(["one", "two"], "three"), "one\ntwo\nthree");
+  });
+
+  it("returns the draft alone when nothing is buffered", () => {
+    assert.equal(mergeBufferedIntoDraft([], "draft"), "draft");
+  });
+
+  it("returns buffered messages alone when the draft is empty", () => {
+    assert.equal(mergeBufferedIntoDraft(["one", "two"], ""), "one\ntwo");
+  });
+
+  it("drops empty / whitespace-only parts and trims the rest", () => {
+    assert.equal(mergeBufferedIntoDraft(["  one  ", "   ", ""], "  two  "), "one\ntwo");
+  });
+
+  it("preserves newlines inside a single message", () => {
+    assert.equal(mergeBufferedIntoDraft(["line1\nline2"], ""), "line1\nline2");
+  });
+
+  it("returns an empty string when everything is empty", () => {
+    assert.equal(mergeBufferedIntoDraft([], ""), "");
+    assert.equal(mergeBufferedIntoDraft(["", "  "], "   "), "");
+  });
+});


### PR DESCRIPTION
## Summary

CC 実行中のチャット入力を terminal に近い挙動にした。実行中も入力欄を
ロックせず、送信したものは**キュー（削除可能なチップ）にため**、実行完了時に
**入力欄へ改行区切りで結合して戻し**、ユーザが最終編集して手動送信する。
あわせて **Ctrl/Cmd+Enter で改行挿入**を追加。

- `:disabled="isRunning"` を撤去（実行中もロックしない）
- 実行中の Enter → 送信せず `bufferedMessages` に積む（入力欄はクリア、複数可）
- 各チップは ✕ で削除可能
- 実行完了 → キューを oldest-first・改行区切りで入力欄へ結合して戻す
- Ctrl/Cmd+Enter はカーソル位置に改行を挿入（textarea 標準では入らないため手動挿入）

## Items to Confirm / Review

- **セッション誤爆ガード**: キューは `userInput` 同様グローバル。`bufferedForSessionId`
  に所有セッションIDを記録し、`watch([activeSessionRunning, currentSessionId])` で
  「所有セッションを表示中 かつ 非実行」になった時のみマージバックする設計。
  別セッションへ切替中はマージしない、という判断が妥当か確認いただきたい。
- **マージ区切り**: 当初 `\n\n`（空行）だったが、戻したとき改行が多いとの
  フィードバックで単一 `\n` に変更。メッセージ自体の複数行はそのまま保持。
- **Ctrl/Cmd+Enter**: Mac 配慮で `ctrlKey || metaKey` の両方を改行にしている。
- i18n は全8ロケールに `runningPlaceholder` / `removeBuffered` を追加。

## User Prompt

- mulmoclaude のユーザ入力部分は、動作中に lock しないで、書き込みごとに
  バッファーにためてまとめて送れるようにしたほうが terminal に近くて良い。
- CC 動作中に送信するとバッファーにたまり、複数ためられる。バツボタンクリックで
  削除もでき、CC 動作が完了したら文字バッファー（入力欄）に戻る。そして最終的に
  編集して送信できる。
- Ctrl+Enter で改行を入れられるようにする。
- （フィードバック）入力欄に戻るときに改行が多いかもしれない → 空行区切りをやめて
  単一改行に。

## 実装

| ファイル | 内容 |
|---|---|
| `src/utils/chat/buffer.ts`（新規） | `mergeBufferedIntoDraft()` 純粋関数（trim + 空要素除去 + `\n` 結合） |
| `src/components/ChatInput.vue` | `:disabled` 撤去 / バッファーチップ UI + ✕ / Ctrl+Cmd+Enter 改行 / 実行中プレースホルダ / `v-model:bufferedMessages` |
| `src/App.vue` | `bufferedMessages` + `bufferedForSessionId` / `sendMessage` を実行中はキュー化 / 完了・切替 watch でマージバック / 両 ChatInput へ配線 |
| `src/lang/*.ts`（全8） | `runningPlaceholder` / `removeBuffered` |
| `test/utils/chat/test_buffer.ts`（新規） | merge ユニット 6 件 |
| `e2e/tests/chatinput-buffer.spec.ts`（新規） | ロック無 / キュー化 / ✕削除 / 完了マージバック / Ctrl+Enter の 4 件 |
| `plans/feat-chat-input-buffer.md`（新規） | 設計プラン |

## テスト

- `yarn format` / `lint` / `typecheck`(vue,test,e2e) / `build` すべて green
- ユニット 6 件 / 新規 e2e 4 件 pass、関連 e2e（ime-enter・chat-flow・chatinput-attach・
  slash-command-menu）28 件 回帰なし

Closes #2067

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Queue chat messages typed while the agent is running and merge them back into the input after the run finishes, while keeping the chat input editable.

New Features:
- Introduce a buffered message queue that stores user sends made during an in-flight agent run and restores them to the input for manual editing and sending once the run completes.
- Add removable UI chips above the chat input to display queued messages, with per-message removal controls.
- Support Ctrl/Cmd+Enter to insert a newline at the cursor in the chat input instead of sending while preserving IME behavior.

Enhancements:
- Keep the chat input enabled while the agent is running and show a dedicated running placeholder string to indicate queuing behavior.
- Ensure buffered messages are associated with their originating session and only merged back into the input when that session becomes idle and is currently displayed.
- Add a small chat buffering utility to consistently merge queued messages into the current draft with normalized newline joining.
- Extend i18n resources across all locales for the new running placeholder and buffered-message removal labels.

Documentation:
- Document the chat input buffering design and behavior in a dedicated feature plan markdown file.

Tests:
- Add unit tests for the chat buffer merge utility to cover trimming, empty input handling, and newline preservation.
- Add end-to-end tests covering input remaining editable while running, queuing behavior and chip removal, post-run merge back into the input, and Ctrl+Enter newline insertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue chat messages while an agent run is in progress; input remains usable and queued items show as removable chips.
  * When the run finishes on the same session, queued messages are merged back into the composer as newline-separated text.
  * Ctrl/Cmd+Enter inserts a newline (no queue), while Enter queues during running.
  * Added localized UI text for the running state and removing queued messages.
* **Tests**
  * Added Playwright E2E coverage for queued-message behavior and keyboard interactions.
  * Added unit tests for buffered-to-draft message merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->