### PR TITLE
fix: pass system prompt via --system-prompt-file to avoid Windows ENAMETOOLONG

### DIFF
--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -11,7 +11,8 @@
 
 import { spawn, type ChildProcessByStdio } from "child_process";
 import type { Readable, Writable } from "stream";
-import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine, type CliArgsParams } from "../config.js";
+import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine, resolveSystemPromptPaths, type CliArgsParams } from "../config.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
@@ -190,11 +191,13 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
   if (errorEvent) yield errorEvent;
 }
 
-// The one non-pass-through mapping is `sessionToken` -> `claudeSessionId`
-// (the CLI's `--resume` id); the rest forward verbatim.
-export function cliArgsForInput(input: AgentInput): CliArgsParams {
+// The non-pass-through mappings are `sessionToken` -> `claudeSessionId`
+// (the CLI's `--resume` id) and the system prompt, which travels as a
+// file path (`systemPromptPath`) rather than inline text — see the
+// CliArgsParams field comment for the Windows ENAMETOOLONG rationale.
+export function cliArgsForInput(input: AgentInput, systemPromptPath: string): CliArgsParams {
   return {
-    systemPrompt: input.systemPrompt,
+    systemPromptPath,
     activePlugins: input.activePlugins,
     claudeSessionId: input.sessionToken,
     mcpConfigPath: input.mcpConfigPath,
@@ -203,8 +206,23 @@ export function cliArgsForInput(input: AgentInput): CliArgsParams {
   };
 }
 
+// Write the per-session system-prompt file the CLI reads via
+// `--system-prompt-file`. Returns the path to pass on the command line
+// (container path under Docker). Atomic write so a concurrent spawn on
+// the same session never sees a half-written prompt.
+async function writeSystemPromptFile(input: AgentInput): Promise<string> {
+  const paths = resolveSystemPromptPaths({
+    workspacePath: input.workspacePath,
+    sessionId: input.sessionId,
+    useDocker: input.useDocker,
+  });
+  await writeFileAtomic(paths.hostPath, input.systemPrompt);
+  return paths.argPath;
+}
+
 async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
-  const cliArgs = buildCliArgs(cliArgsForInput(input));
+  const systemPromptPath = await writeSystemPromptFile(input);
+  const cliArgs = buildCliArgs(cliArgsForInput(input, systemPromptPath));
 
   // spawnClaude can throw synchronously when `claudeBinPath()` fails
   // to locate `claude.exe` on Windows — surface that through the same

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -394,7 +394,14 @@ export function userServerAllowedToolNames(userServers: Record<string, McpServer
 }
 
 export interface CliArgsParams {
-  systemPrompt: string;
+  /** Path handed to `--system-prompt-file` (container path under
+   *  Docker — see `resolveSystemPromptPaths`). The prompt travels as
+   *  a file, never as an inline `--system-prompt` argument: on
+   *  Windows the argv becomes a single CreateProcess command line
+   *  capped at ~32k chars, and a workspace with a rich role + plugins
+   *  + memory pushes the prompt past the cap — the spawn then fails
+   *  with ENAMETOOLONG before the CLI even starts. */
+  systemPromptPath: string;
   activePlugins: string[];
   claudeSessionId?: string;
   mcpConfigPath?: string;
@@ -407,7 +414,7 @@ export interface CliArgsParams {
 }
 
 export function buildCliArgs(params: CliArgsParams): string[] {
-  const { systemPrompt, activePlugins, claudeSessionId, mcpConfigPath, extraAllowedTools = [], effortLevel } = params;
+  const { systemPromptPath, activePlugins, claudeSessionId, mcpConfigPath, extraAllowedTools = [], effortLevel } = params;
 
   const mcpToolNames = activePlugins.map((pluginName) => `mcp__mulmoclaude__${pluginName}`);
   // DEBUG: also pass the wildcard form `mcp__mulmoclaude` so Claude
@@ -432,8 +439,8 @@ export function buildCliArgs(params: CliArgsParams): string[] {
     "stream-json",
     "--include-partial-messages",
     "--verbose",
-    "--system-prompt",
-    systemPrompt,
+    "--system-prompt-file",
+    systemPromptPath,
     "--allowedTools",
     allowedTools.join(","),
     "-p",
@@ -578,6 +585,22 @@ export function resolveMcpConfigPaths(opts: { workspacePath: string; sessionId: 
     return { hostPath, argPath };
   }
   const hostPath = join(tmpdir(), `mulmoclaude-mcp-${sid}.json`);
+  return { hostPath, argPath: hostPath };
+}
+
+// Where the per-session system-prompt file lives. Same host/container
+// split as the MCP config above: under Docker the file must sit inside
+// the workspace bind mount so the container-side CLI can read it; in
+// native mode the OS tmpdir is fine. One file per chat session —
+// successive turns overwrite it, mirroring the MCP config lifecycle.
+export function resolveSystemPromptPaths(opts: { workspacePath: string; sessionId: string; useDocker: boolean }): McpConfigPaths {
+  const sid = safeSessionSegment(opts.sessionId);
+  if (opts.useDocker) {
+    const hostPath = join(opts.workspacePath, ".mulmoclaude", `system-prompt-${sid}.md`);
+    const argPath = `${CONTAINER_WORKSPACE_PATH}/.mulmoclaude/system-prompt-${sid}.md`;
+    return { hostPath, argPath };
+  }
+  const hostPath = join(tmpdir(), `mulmoclaude-system-prompt-${sid}.md`);
   return { hostPath, argPath: hostPath };
 }
 

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -16,6 +16,7 @@ import {
   type Platform,
   prepareUserServers,
   resolveMcpConfigPaths,
+  resolveSystemPromptPaths,
   rewriteLocalhostForDocker,
   userServerAllowedToolNames,
   workspaceModuleMounts,
@@ -100,7 +101,7 @@ describe("buildMcpConfig", () => {
 describe("buildCliArgs", () => {
   it("includes required flags", async () => {
     const args = buildCliArgs({
-      systemPrompt: "You are helpful",
+      systemPromptPath: "/tmp/system-prompt.md",
       activePlugins: [],
     });
 
@@ -109,10 +110,26 @@ describe("buildCliArgs", () => {
     // stream-json is used for both input and output formats.
     assert.equal(args.filter((arg) => arg === "stream-json").length, 2, "stream-json should appear twice (input + output format)");
     assert.ok(args.includes("--verbose"));
-    assert.ok(args.includes("--system-prompt"));
-    assert.ok(args.includes("You are helpful"));
+    assert.ok(args.includes("--system-prompt-file"));
+    assert.ok(args.includes("/tmp/system-prompt.md"));
     assert.ok(args.includes("-p"));
     assert.ok(args.includes("--allowedTools"));
+  });
+
+  it("passes the system prompt as a file path, never inline", async () => {
+    // Regression: an inline `--system-prompt <text>` puts the whole
+    // prompt on the command line. On Windows CreateProcess caps the
+    // command line at ~32k chars, so a workspace with a rich role +
+    // plugins + memory pushed the prompt past the cap and the spawn
+    // failed with ENAMETOOLONG before the CLI even started.
+    const args = buildCliArgs({
+      systemPromptPath: "/tmp/system-prompt.md",
+      activePlugins: [],
+    });
+    const fileIdx = args.indexOf("--system-prompt-file");
+    assert.ok(fileIdx >= 0, "must pass --system-prompt-file");
+    assert.equal(args[fileIdx + 1], "/tmp/system-prompt.md");
+    assert.ok(!args.includes("--system-prompt"), "inline --system-prompt must not be used (Windows ENAMETOOLONG)");
   });
 
   it("does NOT pass the user message as a CLI argument", async () => {
@@ -120,7 +137,7 @@ describe("buildCliArgs", () => {
     // input mode. Passing it as `-p <text>` (the old mode) bypasses
     // slash-command resolution for Claude Code skills.
     const args = buildCliArgs({
-      systemPrompt: "You are helpful",
+      systemPromptPath: "/tmp/system-prompt.md",
       activePlugins: [],
     });
     const pIdx = args.indexOf("-p");
@@ -132,7 +149,7 @@ describe("buildCliArgs", () => {
 
   it("includes MCP tool names in allowedTools", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: ["manageBookmarks"],
     });
 
@@ -148,7 +165,7 @@ describe("buildCliArgs", () => {
     // Regression guard: a strict --allowedTools that omits `Skill`
     // permission-denies every Skill({skill:"…"}) call (Execute skill
     // error + Glob fallback). See plans/done/fix-skill-tool-allowlist.md.
-    const args = buildCliArgs({ systemPrompt: "test", activePlugins: [] });
+    const args = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: [] });
     const allowedStr = args[args.indexOf("--allowedTools") + 1];
     const tools = allowedStr.split(",");
     assert.ok(tools.includes("Skill"), `--allowedTools must list "Skill" (got: ${allowedStr})`);
@@ -156,7 +173,7 @@ describe("buildCliArgs", () => {
 
   it("includes --resume when claudeSessionId provided", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
       claudeSessionId: "sess_123",
     });
@@ -168,7 +185,7 @@ describe("buildCliArgs", () => {
 
   it("omits --resume when no claudeSessionId", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
     });
 
@@ -177,7 +194,7 @@ describe("buildCliArgs", () => {
 
   it("includes --mcp-config when path provided", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: ["foo"],
       mcpConfigPath: "/tmp/mcp.json",
     });
@@ -189,7 +206,7 @@ describe("buildCliArgs", () => {
 
   it("omits --mcp-config when no path", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
     });
 
@@ -200,18 +217,18 @@ describe("buildCliArgs", () => {
     // The handler tool lives inside our MCP server. With no
     // --mcp-config the CLI can't resolve it and refuses to start;
     // gate the flag together with --mcp-config.
-    const withMcp = buildCliArgs({ systemPrompt: "x", activePlugins: ["foo"], mcpConfigPath: "/tmp/mcp.json" });
+    const withMcp = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: ["foo"], mcpConfigPath: "/tmp/mcp.json" });
     const withMcpIdx = withMcp.indexOf("--permission-prompt-tool");
     assert.ok(withMcpIdx >= 0, "must pass --permission-prompt-tool when MCP is configured");
     assert.equal(withMcp[withMcpIdx + 1], "mcp__mulmoclaude__handlePermission");
 
-    const withoutMcp = buildCliArgs({ systemPrompt: "x", activePlugins: [] });
+    const withoutMcp = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: [] });
     assert.ok(!withoutMcp.includes("--permission-prompt-tool"), "must NOT pass --permission-prompt-tool in no-MCP sessions");
   });
 
   it("includes --effort when effortLevel is set", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
       effortLevel: "high",
     });
@@ -223,7 +240,7 @@ describe("buildCliArgs", () => {
 
   it("omits --effort when effortLevel is unset", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
     });
 
@@ -271,6 +288,40 @@ describe("resolveMcpConfigPaths", () => {
         assert.ok(!derivedPath.includes(".."), `traversal leaked into ${derivedPath}`);
         assert.ok(!derivedPath.includes("etc"), `path component leaked into ${derivedPath}`);
         assert.ok(derivedPath.includes("mcp-pwn.json"), `expected sanitized segment, got ${derivedPath}`);
+      }
+    }
+  });
+});
+
+describe("resolveSystemPromptPaths", () => {
+  it("uses tmpdir for native runs (no docker)", async () => {
+    const paths = resolveSystemPromptPaths({
+      workspacePath: "/ws",
+      sessionId: "abc",
+      useDocker: false,
+    });
+    assert.equal(paths.hostPath, join(tmpdir(), "mulmoclaude-system-prompt-abc.md"));
+    assert.equal(paths.argPath, paths.hostPath);
+  });
+
+  it("uses workspace .mulmoclaude dir for docker runs so the container can read it", async () => {
+    const paths = resolveSystemPromptPaths({
+      workspacePath: "/ws",
+      sessionId: "abc",
+      useDocker: true,
+    });
+    assert.equal(paths.hostPath, join("/ws", ".mulmoclaude", "system-prompt-abc.md"));
+    assert.equal(paths.argPath, `${CONTAINER_WORKSPACE_PATH}/.mulmoclaude/system-prompt-abc.md`);
+  });
+
+  it("sanitizes path-injecting sessionId (CodeQL js/path-injection)", async () => {
+    const evil = "../../etc/pwn";
+    for (const useDocker of [true, false]) {
+      const paths = resolveSystemPromptPaths({ workspacePath: "/ws", sessionId: evil, useDocker });
+      for (const derivedPath of [paths.hostPath, paths.argPath]) {
+        assert.ok(!derivedPath.includes(".."), `traversal leaked into ${derivedPath}`);
+        assert.ok(!derivedPath.includes("etc"), `path component leaked into ${derivedPath}`);
+        assert.ok(derivedPath.includes("system-prompt-pwn.md"), `expected sanitized segment, got ${derivedPath}`);
       }
     }
   });
@@ -914,7 +965,7 @@ describe("buildUserMessageLine", () => {
 describe("buildCliArgs — extraAllowedTools", () => {
   it("merges extraAllowedTools into --allowedTools", async () => {
     const args = buildCliArgs({
-      systemPrompt: "s",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
       extraAllowedTools: ["mcp__claude_ai_Gmail", "mcp__claude_ai_Google_Calendar"],
     });

--- a/test/agent/test_cliArgsForInput.ts
+++ b/test/agent/test_cliArgsForInput.ts
@@ -26,23 +26,32 @@ function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
   };
 }
 
+const PROMPT_PATH = "/tmp/system-prompt.md";
+
 describe("cliArgsForInput", () => {
   it("maps sessionToken onto claudeSessionId (the --resume id)", () => {
-    const params = cliArgsForInput(makeInput({ sessionToken: "resume-123" }));
+    const params = cliArgsForInput(makeInput({ sessionToken: "resume-123" }), PROMPT_PATH);
     assert.equal(params.claudeSessionId, "resume-123");
+  });
+
+  it("carries the system-prompt file path, not the prompt text", () => {
+    // The prompt itself travels via --system-prompt-file (Windows
+    // command lines cap at ~32k chars — inline text ENAMETOOLONGs).
+    const params = cliArgsForInput(makeInput({ systemPrompt: "SP" }), PROMPT_PATH);
+    assert.equal(params.systemPromptPath, PROMPT_PATH);
+    assert.ok(!("systemPrompt" in params));
   });
 
   it("forwards the pass-through fields verbatim", () => {
     const params = cliArgsForInput(
       makeInput({
-        systemPrompt: "SP",
         activePlugins: ["a", "b"],
         mcpConfigPath: "/cfg.json",
         extraAllowedTools: ["Bash"],
         effortLevel: "high",
       }),
+      PROMPT_PATH,
     );
-    assert.equal(params.systemPrompt, "SP");
     assert.deepEqual(params.activePlugins, ["a", "b"]);
     assert.equal(params.mcpConfigPath, "/cfg.json");
     assert.deepEqual(params.extraAllowedTools, ["Bash"]);
@@ -50,14 +59,14 @@ describe("cliArgsForInput", () => {
   });
 
   it("leaves optional fields undefined when the input omits them", () => {
-    const params = cliArgsForInput(makeInput());
+    const params = cliArgsForInput(makeInput(), PROMPT_PATH);
     assert.equal(params.claudeSessionId, undefined);
     assert.equal(params.mcpConfigPath, undefined);
     assert.equal(params.effortLevel, undefined);
   });
 
   it("does not carry over non-CLI fields (message, workspacePath, port)", () => {
-    const params = cliArgsForInput(makeInput({ message: "secret", port: 9999 }));
+    const params = cliArgsForInput(makeInput({ message: "secret", port: 9999 }), PROMPT_PATH);
     assert.ok(!("message" in params));
     assert.ok(!("workspacePath" in params));
     assert.ok(!("port" in params));


### PR DESCRIPTION
## Problem

The full system prompt is passed inline as a `--system-prompt <text>` argument when spawning the `claude` CLI. On Windows the spawned argv becomes a single CreateProcess command line capped at ~32k chars, so a workspace with a rich role + plugins + memory pushes the prompt past the cap and **every spawn fails with `spawn ENAMETOOLONG` before the CLI even starts** — the chat UI shows `[Error] Failed to spawn claude: spawn ENAMETOOLONG` for every message.

Observed in production (Windows 11, v0.9.5): the investor role's assembled prompt reached 33,140 chars (`system-prompt exceeds warn threshold total=33140 … breakdown="base=9476 role=3616 … plugins=11392"`), while the general role at 30,348 chars still squeaked through. Any workspace whose memory/wiki/plugins grow past the cap hits this regardless of role.

## Fix

Write the prompt to a per-session file and hand the CLI `--system-prompt-file` instead. The file follows the exact host/container split the per-session MCP config already uses (`resolveMcpConfigPaths`): workspace `.mulmoclaude/system-prompt-<sid>.md` under Docker (inside the bind mount so the container-side CLI can read it), OS tmpdir natively. Written with `writeFileAtomic`, one file per chat session, successive turns overwrite — mirroring the MCP config lifecycle. Side benefit: the prompt no longer leaks into `ps` output.

`--system-prompt-file` verified against Claude CLI 2.1.204: a 40k-char prompt spawns fine as a file, and the previously-failing 33k-char investor session spawns and answers normally with this change applied.

## Changes

- `server/agent/config.ts` — `CliArgsParams.systemPrompt` → `systemPromptPath`; `buildCliArgs` emits `--system-prompt-file`; new `resolveSystemPromptPaths` (same shape + sessionId sanitisation as `resolveMcpConfigPaths`)
- `server/agent/backend/claude-code.ts` — new `writeSystemPromptFile` writes the prompt before spawn; `cliArgsForInput` takes the resolved path
- Tests: regression test asserting the prompt travels as a file path and inline `--system-prompt` is never used; `resolveSystemPromptPaths` native/docker/path-injection coverage; existing suites updated

## Testing

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all green
- `yarn test` green (the two `wiki-pages` symlink tests fail on this machine with EPERM regardless of this change — Windows symlink-privilege environment issue)
- Manual end-to-end on Windows 11: previously-failing investor-role session now spawns and responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * System prompts are now securely provided through session-specific files rather than inline command arguments.
  * Added support for resolving prompt file locations across native and Docker environments.
  * Session identifiers are sanitized when generating prompt file paths.
  * Claude CLI configuration now uses the system-prompt-file option.
  * Improved tool and MCP permission handling for Claude sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->