### PR TITLE
chore(mulmoclaude): publish launcher 0.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.9.6",
+  "version": "0.9.7",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Publishes `mulmoclaude@0.9.7` to npm (already published — this PR lands the version-bump commit so `main` matches the registry, and `/release-app` can tag `v0.9.7`). Patch bump over 0.9.6, shipping the changes merged since the last launcher release.

- **What shipped since 0.9.6**: chat-input buffer (queue sends while the agent runs, #2067), RemoteHost Firebase session persistence + reconnect (#2073/#2075/#2076), `@mulmoclaude/core@0.13.0`, MCP stdio-under-Docker docs.
- **Version sync**: root `package.json` and `packages/mulmoclaude/package.json` both bumped `0.9.6 → 0.9.7` in lockstep. `bin/mulmoclaude.js` reads the version dynamically from the launcher `package.json` (no hardcoded string), so `mulmoclaude --version` reports `0.9.7` automatically.
- No `@mulmobridge/*` or `@mulmoclaude/*` cascade publishing was needed — all deps were already published and matched.

## Items to Confirm / Review

- **npm publish already happened** (`+ mulmoclaude@0.9.7`, verified live via `npm view` + fresh `npx mulmoclaude@0.9.7 --version`). Merging this PR just reconciles `main` with what's on npm.
- **Root version bump is intentional** and required here (not deferred to `/release-app`) — `/publish-mulmoclaude` §5.5 keeps the launcher npm version and the `/release-app` tag in lockstep so a `v0.9.7` GitHub Release always corresponds to `mulmoclaude@0.9.7` on npm.
- Only the two `package.json` version fields changed; `yarn.lock` was unaffected by the version-only bump.

## User Prompt

- `/publish-mulmoclaude` — run the launcher publish flow.
- "Verify that `package.json`, `packages/mulmoclaude/package.json`, and the in-source version are all correctly updated and in sync."
- Chose target version **0.9.7** (patch) and confirmed the npm publish.

## Verification

All performed on this branch (base `origin/main` @ #2079, latest smoke green):

- ✅ §1 deps audit (`scripts/mulmoclaude/deps.mjs`) — no missing deps
- ✅ §2 workspace drift (`scripts/mulmoclaude/drift.mjs`) — `@mulmobridge/*` src == published
- ✅ §3 `yarn build` — succeeds
- ✅ §3.5 README review — CLI flags / env vars / bridge names accurate; ships in tarball (7.9 kB)
- ✅ §4 tarball boot (`scripts/mulmoclaude/tarball.mjs`) — HTTP 200, 4 runtime plugins, exit 0
- ✅ §6 publish + verify — `npm view` = 0.9.7, fresh `npx mulmoclaude@0.9.7 --version` = `mulmoclaude 0.9.7`
- ✅ All `@mulmoclaude/*` deps (core@0.13.0 + plugins) and `@mulmobridge/*` deps resolve on the public registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version from 0.9.6 to 0.9.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->