### PR TITLE
fix: load launch-dir .env in npx launcher so GEMINI_API_KEY works (#2081)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### `@mulmoclaude/core@0.13.1` - 2026-07-14
+
+- **Docs (#2081)**: the Gemini API-key help now tells users to put `GEMINI_API_KEY` in a `.env` file **in the directory they launch MulmoClaude from** (not the isolated `~/mulmoclaude` workspace), matching the launcher's new launch-dir `.env` loading. Ships via `assets/helps/gemini.md`.
+
 ### `@mulmoclaude/core@0.13.0` - 2026-07-13
 
 RemoteHost session persistence (receptron/mulmoserver#50, case A'): a host's Firebase session is parked in the browser and restored after a server restart, without a re-login popup. First core release carrying this API (#2074) and the mulmoclaude-wiring hardening (#2076).

--- a/packages/core/assets/helps/gemini.md
+++ b/packages/core/assets/helps/gemini.md
@@ -38,7 +38,7 @@ The Gemini API has a **free tier that is sufficient for personal use**. Higher-v
 3. Copy the key — it starts with `AIza…`.
 4. Create (or open) a `.env` file **in the directory you launch MulmoClaude from** — i.e. the directory where you run `npx mulmoclaude` (in a cloned repo, that's the repo root). Add the line:
 
-   ```
+   ```dotenv
    GEMINI_API_KEY=AIza…your-key…
    ```
 

--- a/packages/core/assets/helps/gemini.md
+++ b/packages/core/assets/helps/gemini.md
@@ -36,11 +36,13 @@ The Gemini API has a **free tier that is sufficient for personal use**. Higher-v
 1. Open [Google AI Studio → API keys](https://aistudio.google.com/apikey) and sign in with a Google account.
 2. Click **Create API key**. If prompted, select or create a Google Cloud project (any project will do).
 3. Copy the key — it starts with `AIza…`.
-4. Open the project's `.env` file in the repository root (copy `.env.example` first if it doesn't exist yet) and add the line:
+4. Create (or open) a `.env` file **in the directory you launch MulmoClaude from** — i.e. the directory where you run `npx mulmoclaude` (in a cloned repo, that's the repo root). Add the line:
 
    ```
    GEMINI_API_KEY=AIza…your-key…
    ```
+
+   The key stays in your launch directory, not in the `~/mulmoclaude` workspace (which is managed by the assistant). You can also just `export GEMINI_API_KEY=…` in your shell before launching — an exported value takes precedence over the `.env` file.
 
 5. Restart MulmoClaude so the new environment variable is picked up.
 
@@ -48,7 +50,7 @@ The Gemini API has a **free tier that is sufficient for personal use**. Higher-v
 
 The quickest check: switch to the **Artist** role and ask for _"an image of a red panda"_. If a real image appears in the canvas (instead of an italic text marker or a disabled-role hint), the key is wired up correctly.
 
-You can also inspect the server log on startup: messages like `GEMINI_API_KEY not set — image placeholders will render as text markers` indicate the key is missing or misread.
+You can also inspect the server log on startup: a `GEMINI_API_KEY not set — image / audio / video generation is unavailable` warning means the key was not found (missing, misread, or placed outside your launch directory).
 
 ## Security
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -18,7 +18,7 @@ import { fileURLToPath } from "url";
 import { isPortFree, findAvailablePort, MAX_PORT_PROBES } from "../server/utils/port.mjs";
 import { parseDevPluginArgs } from "../server/utils/dev-plugin-args.mjs";
 import { cliFlagHelpLines, flagEnvOverrides } from "../server/utils/cli-flags.mjs";
-import { parseEnvFile, mergeLaunchEnv } from "../server/utils/launch-env.mjs";
+import { parseEnvFile, mergeLaunchEnv, describeLaunchEnvLoad } from "../server/utils/launch-env.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -224,11 +224,8 @@ try {
 const launchEnvPath = join(process.cwd(), ".env");
 const { exists: launchEnvExists, parsed: launchEnvParsed } = parseEnvFile(launchEnvPath);
 const { env: baseEnv, loadedKeys, skippedKeys } = mergeLaunchEnv(process.env, launchEnvParsed);
-if (launchEnvExists && loadedKeys.length > 0) {
-  // Log key NAMES only, never values.
-  const shellKept = skippedKeys.length > 0 ? ` (${skippedKeys.length} kept from shell env)` : "";
-  log(`Loaded ${loadedKeys.length} var(s) from ${launchEnvPath}: ${loadedKeys.join(", ")}${shellKept}`);
-}
+const launchEnvSummary = describeLaunchEnvLoad({ path: launchEnvPath, exists: launchEnvExists, loadedKeys, skippedKeys });
+if (launchEnvSummary) log(launchEnvSummary);
 
 const serverEnv = {
   ...baseEnv,

--- a/packages/mulmoclaude/bin/mulmoclaude.js
+++ b/packages/mulmoclaude/bin/mulmoclaude.js
@@ -18,6 +18,7 @@ import { fileURLToPath } from "url";
 import { isPortFree, findAvailablePort, MAX_PORT_PROBES } from "../server/utils/port.mjs";
 import { parseDevPluginArgs } from "../server/utils/dev-plugin-args.mjs";
 import { cliFlagHelpLines, flagEnvOverrides } from "../server/utils/cli-flags.mjs";
+import { parseEnvFile, mergeLaunchEnv } from "../server/utils/launch-env.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -216,8 +217,21 @@ try {
   process.exit(1);
 }
 
+// Load `<launch-dir>/.env` so `npx mulmoclaude` users keep secrets
+// (e.g. GEMINI_API_KEY) next to where they launch — NOT inside the
+// isolated ~/mulmoclaude workspace. Shell-exported vars win over the
+// file, so `export GEMINI_API_KEY=…` still takes precedence.
+const launchEnvPath = join(process.cwd(), ".env");
+const { exists: launchEnvExists, parsed: launchEnvParsed } = parseEnvFile(launchEnvPath);
+const { env: baseEnv, loadedKeys, skippedKeys } = mergeLaunchEnv(process.env, launchEnvParsed);
+if (launchEnvExists && loadedKeys.length > 0) {
+  // Log key NAMES only, never values.
+  const shellKept = skippedKeys.length > 0 ? ` (${skippedKeys.length} kept from shell env)` : "";
+  log(`Loaded ${loadedKeys.length} var(s) from ${launchEnvPath}: ${loadedKeys.join(", ")}${shellKept}`);
+}
+
 const serverEnv = {
-  ...process.env,
+  ...baseEnv,
   NODE_ENV: "production",
   PORT: String(port),
 };

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.5",
-    "@mulmoclaude/core": "^0.13.0",
+    "@mulmoclaude/core": "^0.13.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/plans/fix-npx-launch-env-loading.md
+++ b/plans/fix-npx-launch-env-loading.md
@@ -1,0 +1,78 @@
+# Fix: `npx mulmoclaude` never loads a workspace `.env` (GEMINI_API_KEY silently ignored)
+
+Issue: https://github.com/receptron/mulmoclaude/issues/2081
+Date: 2026-07-14
+
+## Problem
+
+Under `npx mulmoclaude`, `GEMINI_API_KEY` set in a `.env` file is never
+loaded, so image/audio/movie generation fails with
+`Google GenAI API key is required (GEMINI_API_KEY)` and there is no clear
+diagnostic.
+
+Root cause (verified in code):
+
+- `bin/mulmoclaude.js` spawns the server with `cwd: PKG_DIR` and
+  `env: { ...process.env, ... }` — it never loads any `.env`.
+- `server/index.ts:1` is `import "dotenv/config"`, which resolves `.env`
+  relative to `process.cwd()` = `PKG_DIR`. Under `npx`, `PKG_DIR` is the
+  npx cache (`~/.npm/_npx/<hash>/node_modules/mulmoclaude`) — no `.env`
+  there. Under a cloned repo (`npm run dev`) `PKG_DIR`/cwd is the repo
+  root, so the documented flow happens to work.
+- There is no Settings-UI field for the key (it is read-only from
+  `process.env`), so the ONLY working path today is exporting the var in
+  the shell before launch.
+
+## Design decision (why the launch dir, not the workspace)
+
+The MulmoClaude workspace (`server/workspace/paths.ts`) resolves to
+`~/mulmoclaude` (or `$MULMOCLAUDE_WORKSPACE_PATH`) — an **isolated,
+agent-managed data space** ("the workspace is the database"). Secrets
+like an API key must NOT live there. Therefore the correct place for a
+user's `.env` is **the directory they run `npx mulmoclaude` from**,
+which is decoupled from the workspace on purpose:
+
+- secrets / config → launch-dir `.env`
+- agent-managed data → `~/mulmoclaude`
+
+This also unifies dev and npx: in dev you launch from the repo root, so
+"the directory you launch from" already means the repo root there.
+
+## Changes
+
+1. **`server/utils/launch-env.mjs` (+ `.d.mts`)** — new, pure/testable:
+   - `parseEnvFile(path, { readFileSync?, dotenv? })` → `{ exists, parsed }`,
+     never throws on a missing file.
+   - `mergeLaunchEnv(baseEnv, parsed)` → `{ env, loadedKeys, skippedKeys }`;
+     existing (shell) vars WIN over `.env` (dotenv's no-override
+     semantics), so `export GEMINI_API_KEY=…` still takes precedence.
+   Plain `.mjs` because the launcher runs before tsx is wired (same
+   reason as `port.mjs` / `cli-flags.mjs`).
+
+2. **`packages/mulmoclaude/bin/mulmoclaude.js`** — before building
+   `serverEnv`, load `<launch-cwd>/.env` via the bundled `dotenv` and use
+   the merged env as the base. Log the loaded key NAMES only (never
+   values) + how many were overridden by the shell env.
+
+3. **`server/index.ts` (`initBootDiagnostics`)** — emit a one-line
+   startup warning when `!isGeminiAvailable()`, pointing at the launch-dir
+   `.env`. Covers dev / npx / docker uniformly. (optional-but-included.)
+
+4. **`packages/core/assets/helps/gemini.md`** — rewrite the "repository
+   root `.env`" instruction to "the directory you launch MulmoClaude
+   from", correct for both dev and npx. Per repo rule, editing
+   `assets/helps/*` bumps `@mulmoclaude/core` (0.13.0 → 0.13.1) + the
+   launcher dep range (`^0.13.0` → `^0.13.1`) + `yarn.lock`. The actual
+   `npm publish` of core@0.13.1 happens later via `/publish`.
+
+## Tests
+
+`test/utils/test_launchEnv.ts` (node:test):
+- parseEnvFile: missing file → `{ exists:false }`; present file parses.
+- mergeLaunchEnv: shell var wins; new keys applied; empty parsed; keys
+  reported correctly; base env not mutated.
+
+## Out of scope
+
+- Settings-UI field to write the key (relates to #871 web-managed
+  credentials) — noted, not implemented here.

--- a/server/index.ts
+++ b/server/index.ts
@@ -968,6 +968,17 @@ async function initBootDiagnostics(): Promise<void> {
   // later opaque crash. Never throws.
   await announceOptionalDeps();
 
+  // --- Gemini key presence (#2081) ---
+  // A missing key otherwise only surfaces as an opaque per-operation
+  // crash (movie beats) or a buried image-fill warning. Surface it once
+  // at boot, pointing at the launch-dir `.env` where it belongs.
+  if (!isGeminiAvailable()) {
+    log.warn(
+      "gemini",
+      "GEMINI_API_KEY not set — image / audio / video generation is unavailable. Set it in a .env file in the directory you launch MulmoClaude from, or export it before starting.",
+    );
+  }
+
   // --- Voice input sidecar warm-up ---
   // If local voice input is enabled and its model is already on disk,
   // pre-spawn the whisper-server sidecar now (deps were just probed) so

--- a/server/index.ts
+++ b/server/index.ts
@@ -65,6 +65,7 @@ import { createJournalRouter } from "./api/routes/journal.js";
 import { createTranslationRouter } from "./api/routes/translation.js";
 import { announcePluginMetaDiagnostics } from "./plugins/diagnostics.js";
 import { announceOptionalDeps } from "./system/announceOptionalDeps.js";
+import { announceGeminiKey } from "./system/announceGeminiKey.js";
 import { migrateLegacyBillingPresets } from "./workspace/billing-migration.js";
 import { APP_VERSION } from "./system/appVersion.js";
 import { createChatService } from "@mulmobridge/chat-service";
@@ -969,15 +970,7 @@ async function initBootDiagnostics(): Promise<void> {
   await announceOptionalDeps();
 
   // --- Gemini key presence (#2081) ---
-  // A missing key otherwise only surfaces as an opaque per-operation
-  // crash (movie beats) or a buried image-fill warning. Surface it once
-  // at boot, pointing at the launch-dir `.env` where it belongs.
-  if (!isGeminiAvailable()) {
-    log.warn(
-      "gemini",
-      "GEMINI_API_KEY not set — image / audio / video generation is unavailable. Set it in a .env file in the directory you launch MulmoClaude from, or export it before starting.",
-    );
-  }
+  announceGeminiKey();
 
   // --- Voice input sidecar warm-up ---
   // If local voice input is enabled and its model is already on disk,

--- a/server/system/announceGeminiKey.ts
+++ b/server/system/announceGeminiKey.ts
@@ -1,0 +1,17 @@
+// Boot-time warning when GEMINI_API_KEY is absent (#2081). A missing key
+// otherwise surfaces only as an opaque per-operation crash (movie beats)
+// or a buried image-fill warning; announcing it once at startup makes the
+// misconfiguration visible and points at the launch-dir `.env` where the
+// key belongs. Kept as its own module (like announceOptionalDeps) so the
+// generic boot sequence stays free of provider specifics. Never throws.
+
+import { isGeminiAvailable } from "./env.js";
+import { log } from "./logger/index.js";
+
+export const GEMINI_KEY_MISSING_MESSAGE =
+  "GEMINI_API_KEY not set — image / audio / video generation is unavailable. Set it in a .env file in the directory you launch MulmoClaude from, or export it before starting.";
+
+export function announceGeminiKey(): void {
+  if (isGeminiAvailable()) return;
+  log.warn("gemini", GEMINI_KEY_MISSING_MESSAGE);
+}

--- a/server/utils/launch-env.d.mts
+++ b/server/utils/launch-env.d.mts
@@ -20,3 +20,12 @@ export interface MergedLaunchEnv {
 }
 
 export function mergeLaunchEnv(baseEnv: Record<string, string | undefined>, parsed: Record<string, string>): MergedLaunchEnv;
+
+export interface LaunchEnvLoadSummary {
+  path: string;
+  exists: boolean;
+  loadedKeys: string[];
+  skippedKeys: string[];
+}
+
+export function describeLaunchEnvLoad(summary: LaunchEnvLoadSummary, maxKeysShown?: number): string | null;

--- a/server/utils/launch-env.d.mts
+++ b/server/utils/launch-env.d.mts
@@ -1,0 +1,22 @@
+// Type declarations for launch-env.mjs. See the .mjs file for rationale
+// on why the launcher's `.env` loader lives in plain JS.
+
+export interface ParsedEnvFile {
+  exists: boolean;
+  parsed: Record<string, string>;
+}
+
+export interface ParseEnvFileOptions {
+  readFileSync?: (path: string, encoding: "utf8") => string;
+  parse?: (src: string) => Record<string, string>;
+}
+
+export function parseEnvFile(filePath: string, options?: ParseEnvFileOptions): ParsedEnvFile;
+
+export interface MergedLaunchEnv {
+  env: Record<string, string | undefined>;
+  loadedKeys: string[];
+  skippedKeys: string[];
+}
+
+export function mergeLaunchEnv(baseEnv: Record<string, string | undefined>, parsed: Record<string, string>): MergedLaunchEnv;

--- a/server/utils/launch-env.mjs
+++ b/server/utils/launch-env.mjs
@@ -1,0 +1,51 @@
+// Launcher-side `.env` loading for `npx mulmoclaude`.
+//
+// The server's workspace (`~/mulmoclaude`, see server/workspace/paths.ts)
+// is an isolated, agent-managed data space — "the workspace is the
+// database". Secrets like an API key must NOT live there. So a user's
+// `.env` belongs in the directory they launch from; the launcher loads
+// it here and forwards the values to the spawned server via its
+// environment. Launch dir (config/secrets) and workspace (data) are
+// decoupled on purpose.
+//
+// Plain `.mjs` (with a sibling `.d.mts`) because the launcher runs
+// BEFORE tsx is wired up, so it can't import a `.ts` file — same reason
+// as port.mjs / cli-flags.mjs.
+
+import { readFileSync as fsReadFileSync } from "fs";
+import { parse as dotenvParse } from "dotenv";
+
+// Read + parse a `.env` file. Never throws on a missing / unreadable
+// file — returns `{ exists: false, parsed: {} }` so the caller no-ops.
+// The `readFileSync` / `parse` seams exist so the pure logic is unit
+// testable without touching the real filesystem.
+export function parseEnvFile(filePath, { readFileSync = fsReadFileSync, parse = dotenvParse } = {}) {
+  let contents;
+  try {
+    contents = readFileSync(filePath, "utf8");
+  } catch {
+    return { exists: false, parsed: {} };
+  }
+  return { exists: true, parsed: parse(contents) };
+}
+
+// Merge parsed `.env` values onto a base environment WITHOUT overriding
+// keys already present in the base — an exported shell var wins over the
+// file (dotenv's no-override semantics). Pure: returns a new object and
+// never mutates `baseEnv`. `loadedKeys` = keys taken from the file,
+// `skippedKeys` = file keys the shell already defined.
+export function mergeLaunchEnv(baseEnv, parsed) {
+  const env = { ...baseEnv };
+  const loadedKeys = [];
+  const skippedKeys = [];
+  for (const [key, value] of Object.entries(parsed)) {
+    const shellDefined = Object.prototype.hasOwnProperty.call(baseEnv, key) && baseEnv[key] !== undefined;
+    if (shellDefined) {
+      skippedKeys.push(key);
+      continue;
+    }
+    env[key] = value;
+    loadedKeys.push(key);
+  }
+  return { env, loadedKeys, skippedKeys };
+}

--- a/server/utils/launch-env.mjs
+++ b/server/utils/launch-env.mjs
@@ -49,3 +49,21 @@ export function mergeLaunchEnv(baseEnv, parsed) {
   }
   return { env, loadedKeys, skippedKeys };
 }
+
+// Cap so a large `.env` can't produce an unwieldy single log line.
+const MAX_LAUNCH_ENV_KEYS_LOGGED = 20;
+
+// Build the launcher's one-line summary of what a launch-dir `.env`
+// contributed — key NAMES only, never values. Returns null when there
+// is nothing worth logging (no file, or a file whose every key was
+// already set in the shell and nothing to report). Pure + testable.
+export function describeLaunchEnvLoad({ path, exists, loadedKeys, skippedKeys }, maxKeysShown = MAX_LAUNCH_ENV_KEYS_LOGGED) {
+  if (!exists) return null;
+  if (loadedKeys.length === 0) {
+    if (skippedKeys.length === 0) return null;
+    return `Found ${path}, but all ${skippedKeys.length} var(s) were already set in the shell env`;
+  }
+  const shellKept = skippedKeys.length > 0 ? ` (${skippedKeys.length} kept from shell env)` : "";
+  const shown = loadedKeys.length > maxKeysShown ? `${loadedKeys.slice(0, maxKeysShown).join(", ")}, …` : loadedKeys.join(", ");
+  return `Loaded ${loadedKeys.length} var(s) from ${path}: ${shown}${shellKept}`;
+}

--- a/test/utils/test_launchEnv.ts
+++ b/test/utils/test_launchEnv.ts
@@ -5,7 +5,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { parseEnvFile, mergeLaunchEnv } from "../../server/utils/launch-env.mjs";
+import { parseEnvFile, mergeLaunchEnv, describeLaunchEnvLoad } from "../../server/utils/launch-env.mjs";
 
 describe("launch-env parseEnvFile", () => {
   it("returns exists:false for a missing file (never throws)", () => {
@@ -81,5 +81,36 @@ describe("launch-env mergeLaunchEnv", () => {
     const { loadedKeys, skippedKeys } = mergeLaunchEnv({ A: "shell" }, { A: "file", B: "file" });
     assert.deepEqual(loadedKeys, ["B"]);
     assert.deepEqual(skippedKeys, ["A"]);
+  });
+});
+
+describe("launch-env describeLaunchEnvLoad", () => {
+  it("returns null when the file does not exist", () => {
+    assert.equal(describeLaunchEnvLoad({ path: "/x/.env", exists: false, loadedKeys: [], skippedKeys: [] }), null);
+  });
+
+  it("returns null when the file exists but contributed nothing and shadowed nothing", () => {
+    assert.equal(describeLaunchEnvLoad({ path: "/x/.env", exists: true, loadedKeys: [], skippedKeys: [] }), null);
+  });
+
+  it("reports the loaded key names (values never appear)", () => {
+    const msg = describeLaunchEnvLoad({ path: "/x/.env", exists: true, loadedKeys: ["GEMINI_API_KEY"], skippedKeys: [] });
+    assert.equal(msg, "Loaded 1 var(s) from /x/.env: GEMINI_API_KEY");
+  });
+
+  it("notes how many keys the shell kept", () => {
+    const msg = describeLaunchEnvLoad({ path: "/x/.env", exists: true, loadedKeys: ["A"], skippedKeys: ["B", "C"] });
+    assert.equal(msg, "Loaded 1 var(s) from /x/.env: A (2 kept from shell env)");
+  });
+
+  it("explains a file whose every key was already set in the shell", () => {
+    const msg = describeLaunchEnvLoad({ path: "/x/.env", exists: true, loadedKeys: [], skippedKeys: ["A", "B"] });
+    assert.equal(msg, "Found /x/.env, but all 2 var(s) were already set in the shell env");
+  });
+
+  it("caps a long key list with an ellipsis", () => {
+    const loadedKeys = ["A", "B", "C", "D"];
+    const msg = describeLaunchEnvLoad({ path: "/x/.env", exists: true, loadedKeys, skippedKeys: [] }, 2);
+    assert.equal(msg, "Loaded 4 var(s) from /x/.env: A, B, …");
   });
 });

--- a/test/utils/test_launchEnv.ts
+++ b/test/utils/test_launchEnv.ts
@@ -1,0 +1,85 @@
+// Tests for `server/utils/launch-env.mjs` — the launcher's `.env`
+// loader that lets `npx mulmoclaude` users keep secrets in the launch
+// dir instead of the isolated ~/mulmoclaude workspace. (#2081.)
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseEnvFile, mergeLaunchEnv } from "../../server/utils/launch-env.mjs";
+
+describe("launch-env parseEnvFile", () => {
+  it("returns exists:false for a missing file (never throws)", () => {
+    const result = parseEnvFile("/no/such/dir/.env");
+    assert.deepEqual(result, { exists: false, parsed: {} });
+  });
+
+  it("returns exists:false when readFileSync throws (e.g. EACCES)", () => {
+    const result = parseEnvFile("/x/.env", {
+      readFileSync: () => {
+        throw new Error("EACCES");
+      },
+    });
+    assert.equal(result.exists, false);
+    assert.deepEqual(result.parsed, {});
+  });
+
+  it("parses an existing file's contents", () => {
+    const result = parseEnvFile("/x/.env", {
+      readFileSync: () => "GEMINI_API_KEY=abc\nFOO=bar\n",
+    });
+    assert.equal(result.exists, true);
+    assert.deepEqual(result.parsed, { GEMINI_API_KEY: "abc", FOO: "bar" });
+  });
+
+  it("honours an injected parse seam", () => {
+    const result = parseEnvFile("/x/.env", {
+      readFileSync: () => "raw",
+      parse: (src) => ({ SRC: src }),
+    });
+    assert.deepEqual(result.parsed, { SRC: "raw" });
+  });
+});
+
+describe("launch-env mergeLaunchEnv", () => {
+  it("applies new keys from the file", () => {
+    const { env, loadedKeys, skippedKeys } = mergeLaunchEnv({ PATH: "/usr/bin" }, { GEMINI_API_KEY: "abc" });
+    assert.equal(env.GEMINI_API_KEY, "abc");
+    assert.equal(env.PATH, "/usr/bin");
+    assert.deepEqual(loadedKeys, ["GEMINI_API_KEY"]);
+    assert.deepEqual(skippedKeys, []);
+  });
+
+  it("lets an exported shell var win over the file", () => {
+    const { env, loadedKeys, skippedKeys } = mergeLaunchEnv({ GEMINI_API_KEY: "shell" }, { GEMINI_API_KEY: "file" });
+    assert.equal(env.GEMINI_API_KEY, "shell");
+    assert.deepEqual(loadedKeys, []);
+    assert.deepEqual(skippedKeys, ["GEMINI_API_KEY"]);
+  });
+
+  it("treats a base key whose value is undefined as absent", () => {
+    const { env, loadedKeys } = mergeLaunchEnv({ GEMINI_API_KEY: undefined }, { GEMINI_API_KEY: "file" });
+    assert.equal(env.GEMINI_API_KEY, "file");
+    assert.deepEqual(loadedKeys, ["GEMINI_API_KEY"]);
+  });
+
+  it("handles an empty parsed object", () => {
+    const base = { PATH: "/usr/bin" };
+    const { env, loadedKeys, skippedKeys } = mergeLaunchEnv(base, {});
+    assert.deepEqual(env, base);
+    assert.deepEqual(loadedKeys, []);
+    assert.deepEqual(skippedKeys, []);
+  });
+
+  it("does not mutate the base env", () => {
+    const base = { PATH: "/usr/bin" };
+    mergeLaunchEnv(base, { FOO: "bar" });
+    assert.deepEqual(base, { PATH: "/usr/bin" });
+    assert.equal("FOO" in base, false);
+  });
+
+  it("partitions mixed new / shell-defined keys", () => {
+    const { loadedKeys, skippedKeys } = mergeLaunchEnv({ A: "shell" }, { A: "file", B: "file" });
+    assert.deepEqual(loadedKeys, ["B"]);
+    assert.deepEqual(skippedKeys, ["A"]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2081. Under `npx mulmoclaude`, a `GEMINI_API_KEY` set in a `.env` file was **silently ignored**, so image/audio/movie generation crashed with an opaque `Google GenAI API key is required (GEMINI_API_KEY)`.

Root cause: the launcher spawns the server with `cwd: PKG_DIR` (the npx cache), and `server/index.ts`'s `import "dotenv/config"` resolves `.env` relative to `process.cwd()` — so under `npx` it looks in the npx cache, never the user's directory. There is also no Settings-UI field for the key (read-only from `process.env`), so the only working path was exporting the var in the shell.

**Design decision:** the MulmoClaude workspace (`~/mulmoclaude`) is an isolated, agent-managed data space — "the workspace is the database" — so secrets must NOT live there. The correct home for a user's `.env` is **the directory they launch from**, kept decoupled from the workspace. This also unifies dev and npx (in dev you launch from the repo root).

## Items to Confirm / Review

- **Launch-dir `.env`, not workspace `.env`** — the deliberate choice (secrets in launch dir, data in `~/mulmoclaude`). Please confirm this matches intent (it reverses the issue's fix suggestion #2, which proposed the workspace).
- **Shell-export precedence** — `export GEMINI_API_KEY=…` wins over the `.env` file (dotenv no-override semantics). Reasonable default?
- **Startup warning** — new one-line boot warning when the key is absent (`server/index.ts` `initBootDiagnostics`). The key is "technically optional", so this fires on every keyless boot. OK, or should it be `info`/suppressed?
- **Log line lists key NAMES** loaded from `.env` (never values). GEMINI_API_KEY etc. are not secret, but confirm you're comfortable printing names.
- **Core version bump** — editing `assets/helps/gemini.md` triggers `@mulmoclaude/core` `0.13.0 → 0.13.1` + launcher range (per the repo rule). The actual npm publish of core@0.13.1 is a later `/publish` step; CI stays green via workspace resolution until then.

## User Prompt

> このissueって実際に問題ある？ https://github.com/receptron/mulmoclaude/issues/2081
>
> `~/mulmoclaude` は隔離スペースだから `.env` は置きたくない。理想は `npx` した dir に `.env` があれば読まれること。
>
> (方針合意のうえ) 実装してマージまで進めて。startup warning も入れて。

## Changes

- **`server/utils/launch-env.mjs`** (+ `.d.mts`) — pure, testable `parseEnvFile` / `mergeLaunchEnv`. Plain `.mjs` because the launcher runs before tsx is wired (same as `port.mjs` / `cli-flags.mjs`).
- **`packages/mulmoclaude/bin/mulmoclaude.js`** — load `<launch-dir>/.env` into the spawned server env before `spawn`; log loaded key names only.
- **`server/index.ts`** — boot warning when `!isGeminiAvailable()`, pointing at the launch-dir `.env`.
- **`packages/core/assets/helps/gemini.md`** — "repository root `.env`" → "the directory you launch MulmoClaude from"; note shell-export precedence; correct the startup-log reference.
- **`@mulmoclaude/core` 0.13.0 → 0.13.1** + launcher dep range + `docs/CHANGELOG.md` entry.
- **`test/utils/test_launchEnv.ts`** — happy / edge / empty / undefined-base / no-mutation / mixed cases.

## Verification

`yarn format --check`, `yarn lint`, `yarn typecheck`, `yarn build:packages`, `yarn build`, `yarn test`, and `node scripts/mulmoclaude/launcherSync.mjs` all pass locally. Launcher module smoke-tested: file's key loaded, shell's value preserved.

## Out of scope

Settings-UI field to write the key (relates to #871 web-managed credentials) — noted, not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Load environment variables from a .env file in the launch directory for npx-based runs and surface missing Gemini API key issues more clearly.

New Features:
- Support loading a .env file from the directory MulmoClaude is launched from so environment variables like GEMINI_API_KEY are available when using the npx launcher.

Bug Fixes:
- Ensure GEMINI_API_KEY from a launch-directory .env file is respected under npx so Gemini-based image, audio, and video generation no longer fails due to a missing key.

Enhancements:
- Add a startup warning when GEMINI_API_KEY is not set to clearly indicate that Gemini-powered features are unavailable.
- Introduce a reusable launcher-side utility for parsing .env files and merging them into the server environment without overriding existing shell variables.
- Improve Gemini configuration help text to describe the correct .env location and variable precedence, and record the change via a core package version bump.

Documentation:
- Update Gemini setup documentation to instruct users to put GEMINI_API_KEY in a .env file in the launch directory and clarify shell variable precedence.
- Add a changelog entry documenting the new Gemini key loading behavior and documentation changes.

Tests:
- Add unit tests for the new launch-env utility covering .env parsing, environment merging semantics, and non-mutation of the base environment.

Chores:
- Bump @mulmoclaude/core from 0.13.0 to 0.13.1 and update the mulmoclaude package dependency range accordingly.
- Add an internal design/plan document describing the npx launch .env loading behavior and rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MulmoClaude now loads `.env` settings from the directory where you launch it.
  * Shell-exported environment variables take precedence over `.env` values.
  * Startup warnings now explain how to configure a missing `GEMINI_API_KEY` and note unavailable media-generation features.

* **Documentation**
  * Updated Gemini API-key setup and troubleshooting instructions to reflect the launch-directory configuration.

* **Chores**
  * Released `@mulmoclaude/core` version 0.13.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->