### PR TITLE
chore(mulmoclaude): publish launcher 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "0.9.7",
+  "version": "1.0.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "0.9.7",
+  "version": "1.0.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Publishes **`mulmoclaude@1.0.0`** — the first 1.0 release (already on npm; this PR lands the version-bump commit so `main` matches the registry and `/release-app` can tag `v1.0.0`).

Ships since 0.9.7: **Web Push on task finish** (#2086), launch-dir `.env` loading (#2081), RemoteHost session persistence, chat-input buffer, and the dependency refresh (#2088).

## Items to Confirm / Review

- **`mulmoclaude@1.0.0` is already published** (verified: `npm view` = 1.0.0; fresh `npx mulmoclaude@1.0.0 --version` = `mulmoclaude 1.0.0`). Merging this PR reconciles `main` with npm.
- **Cascade publish**: the launcher's `@mulmoclaude/core: ^0.13.1` dep was **unpublished** — a prior `chore(release)` (#2081) bumped `packages/core` to 0.13.1 without publishing, so npm only had 0.13.0. Published **`@mulmoclaude/core@0.13.1`** first, otherwise `npx mulmoclaude@1.0.0` would ETARGET on install. (This is the §6 `@mulmoclaude/*`-not-audited trap.)
- **Version = 1.0.0 (major)** per your call — bumped from 0.9.7 (0.10.0 was the earlier pick, overridden to 1.0.0).
- Only the two `package.json` version fields changed; `yarn.lock` unaffected by the version-only bump.

## User Prompt

- "このまま main で pull して publish" → publish the current `main` (web-push + dep updates) as the next launcher release.
- Version: **1.0.0**.

## Verification

- §0 preconditions ✓ (branch, `npm whoami`) · §1 deps audit ✓ · §2 drift (`@mulmobridge/*`) ✓
- §3 `yarn build` ✓ · §3.5 README current (web-push / collections / voice / Marp, 141 lines) ✓
- §4 tarball boot (`scripts/mulmoclaude/tarball.mjs`) — HTTP 200, exit 0, 4 runtime plugins ✓
- §6 publish + verify — `@mulmoclaude/core@0.13.1` and `mulmoclaude@1.0.0` both live; fresh `npx mulmoclaude@1.0.0` resolves all deps
- Go/no-go: `MulmoClaude publish smoke` green on `main` (#2088)

## Follow-ups

- Tag + GH release `@mulmoclaude/core@0.13.1` (`--latest=false`).
- `/release-app` to tag `v1.0.0` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and package version to **1.0.0**.
  * Marks the first stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->