### PR TITLE
fix(files): linkified data/ & artifacts/ paths resolve from workspace root (#1548)

### DIFF
--- a/src/utils/markdown/workspaceLinkify.ts
+++ b/src/utils/markdown/workspaceLinkify.ts
@@ -58,7 +58,14 @@ const defaultRenderer = new Renderer();
 function wrapAsWorkspaceLink(token: Tokens.Codespan): string {
   const codeHtml = defaultRenderer.codespan(token);
   const { text } = token;
-  return `<a href="${text}" class="workspace-link" data-workspace-path="${text}">${codeHtml}</a>`;
+  // `text` is ALWAYS workspace-root-relative (WORKSPACE_PATH_PATTERN
+  // requires an `artifacts/` or `data/` prefix), so emit the href with a
+  // leading slash. Without it, FilesView's `resolveWorkspaceLink` joins
+  // the href to the *current file's* dir and double-prefixes the path
+  // (#1548). The slash routes it through resolveWorkspaceLink's
+  // workspace-absolute branch instead; `classifyWorkspacePath` (chat /
+  // wiki) drops the leading empty segment, so it's unchanged there.
+  return `<a href="/${text}" class="workspace-link" data-workspace-path="${text}">${codeHtml}</a>`;
 }
 
 export const workspaceLinkifyExtension: MarkedExtension = {

--- a/test/utils/markdown/test_workspaceLinkify.ts
+++ b/test/utils/markdown/test_workspaceLinkify.ts
@@ -86,8 +86,16 @@ describe("marked codespan → workspace-link auto-linkify", () => {
     const html = (marked.parse("see `artifacts/documents/2026/05/summary.pdf` to review") as string).trim();
     assert.match(
       html,
-      /<a href="artifacts\/documents\/2026\/05\/summary\.pdf"[^>]*class="workspace-link"[^>]*data-workspace-path="artifacts\/documents\/2026\/05\/summary\.pdf"[^>]*><code>artifacts\/documents\/2026\/05\/summary\.pdf<\/code><\/a>/,
+      /<a href="\/artifacts\/documents\/2026\/05\/summary\.pdf"[^>]*class="workspace-link"[^>]*data-workspace-path="artifacts\/documents\/2026\/05\/summary\.pdf"[^>]*><code>artifacts\/documents\/2026\/05\/summary\.pdf<\/code><\/a>/,
     );
+  });
+
+  it("emits a workspace-absolute href (leading slash) so FilesView resolves from the workspace root, not the current dir (#1548)", () => {
+    const html = (marked.parse("`data/wiki/sources/foo/lecture.md`") as string).trim();
+    // href is workspace-absolute (leading slash); data-workspace-path stays root-relative.
+    assert.match(html, /href="\/data\/wiki\/sources\/foo\/lecture\.md"/);
+    assert.match(html, /data-workspace-path="data\/wiki\/sources\/foo\/lecture\.md"/);
+    assert.doesNotMatch(html, /href="data\//); // never a no-slash href for a linkified path
   });
 
   it("leaves non-workspace-path codespans untouched", () => {
@@ -113,7 +121,7 @@ describe("marked codespan → workspace-link auto-linkify", () => {
     //   - inline code with an artifacts/ path
     //   - followed by plain Japanese text "開いて内容を確認"
     const html = (marked.parse("`artifacts/documents/2026/05/example.pdf` 開いて内容を確認") as string).trim();
-    assert.match(html, /<a href="artifacts\/documents\/2026\/05\/example\.pdf"[^>]*class="workspace-link"/);
+    assert.match(html, /<a href="\/artifacts\/documents\/2026\/05\/example\.pdf"[^>]*class="workspace-link"/);
     assert.match(html, /開いて内容を確認/);
   });
 

--- a/test/utils/path/test_relativeLink.ts
+++ b/test/utils/path/test_relativeLink.ts
@@ -59,6 +59,15 @@ describe("resolveWorkspaceLink", () => {
     assert.equal(resolveWorkspaceLink("summaries/topics/foo.md", "/wiki/foo.md"), "wiki/foo.md");
   });
 
+  it("resolves a linkified data/ path from a deep current file to the workspace root, not double-prefixed (#1548)", () => {
+    // A linkified `data/...` codespan now emits href="/data/..."; from a
+    // deeply-nested current file it must resolve to the root, not join.
+    assert.equal(
+      resolveWorkspaceLink("conversations/summaries/daily/2026/05/25.md", "/data/wiki/sources/kira/lecture-clean.md"),
+      "data/wiki/sources/kira/lecture-clean.md",
+    );
+  });
+
   it("resolves ./sibling.md correctly", () => {
     assert.equal(resolveWorkspaceLink("summaries/topics/foo.md", "./bar.md"), "summaries/topics/bar.md");
   });


### PR DESCRIPTION
## Summary

Fixes #1548. An auto-linkified `data/…` / `artifacts/…` inline-code path emitted `href="<path>"` **without a leading slash**. In FilesView, `resolveWorkspaceLink` joined it to the **current file's** dir → a double-prefixed 404 path (e.g. `/files/conversations/…/2026/05/data/wiki/…`).

**Fix:** `workspaceLinkify.ts` now emits `href="/<path>"` (workspace-absolute). These paths are ALWAYS workspace-root-relative (guaranteed by `WORKSPACE_PATH_PATTERN`), so the leading slash is correct.

## Items to Confirm / Review

- **Verified safe across all 3 click paths** (I checked each in code, not just the reporter's claim):
  1. FilesView `resolveWorkspaceLink` → workspace-absolute branch → **fixed**.
  2. Chat `classifyWorkspacePath` → its `normalizePath` drops the leading empty segment → **behavior unchanged**.
  3. Wiki `resolveWikiHref` → `classifyWorkspacePath` → same → **unchanged**.
- `data-workspace-path` attribute kept root-relative (unchanged).
- The reporter's "also check classifyWorkspacePath" note: confirmed **no change needed** there.

## Tests

- New regression in `test_workspaceLinkify.ts` (href is leading-slash absolute; never a no-slash href for a linkified path).
- New regression in `test_relativeLink.ts` (deep current file + `/data/…` resolves to the root, not double-prefixed).
- Gates: format / typecheck / build / tests green; changed files lint-clean.

## User Prompt

Triaged open issues; among the bugs, address #1548 — first independently re-verify the problem still exists in current code (don't trust prior investigation), then design and apply the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure auto-linkified workspace paths for data/ and artifacts/ codespans resolve from the workspace root instead of relative to the current file.

Bug Fixes:
- Fix workspace-linkified data/ and artifacts/ codespan hrefs to be workspace-absolute to avoid double-prefixed 404 paths in FilesView.

Tests:
- Add regression tests validating workspace-linkified hrefs include a leading slash while data-workspace-path remains root-relative, and that deep-file data/ links resolve to the workspace root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace links so they resolve from the workspace root, including links opened from deeply nested files.
  * Prevented incorrect path prefixes when navigating linked workspace content.

* **Tests**
  * Added coverage for workspace-absolute links and nested file path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->