### PR TITLE
fix(sandbox): log claude's workspace-trust stderr notice at debug, not error (#2055)

### DIFF
--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -127,6 +127,25 @@ export function brokerNotReadyErrorEvent(stderrOutput: string): { type: typeof E
   return isMcpBrokerNotReadyError(stderrOutput) ? { type: EVENT_TYPES.error, message: stderrOutput } : null;
 }
 
+// Not every claude CLI stderr line is an error. The sandbox workspace-trust
+// notice (#2055) is the common benign case: the container's workspace path
+// (`/home/node/mulmoclaude`) isn't among the host `~/.claude.json`'s trusted
+// projects, so claude ignores the workspace `permissions.allow` entries. That's
+// harmless here — tool permissions come from `--allowedTools` + the mulmoclaude
+// MCP permission handler, not the workspace `.claude/settings.json` — but
+// logging it at ERROR on every spawn made it look like a failure and buried
+// real errors. Recognise it so the stderr router can log it at debug instead.
+export function isBenignClaudeStderr(line: string): boolean {
+  return line.includes("has not been trusted");
+}
+
+// Route a claude CLI stderr line to the right log level: benign notices at
+// debug, genuine errors at error (so they stop burying each other).
+function logAgentStderr(line: string): void {
+  if (isBenignClaudeStderr(line)) log.debug("agent-stderr", line);
+  else log.error("agent-stderr", line);
+}
+
 async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
@@ -137,7 +156,7 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
     const lines = stderrBuffer.split("\n");
     stderrBuffer = lines.pop() ?? "";
     for (const line of lines) {
-      if (line.trim()) log.error("agent-stderr", line);
+      if (line.trim()) logAgentStderr(line);
     }
   });
 
@@ -182,7 +201,7 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
 
   const { code: exitCode, signal } = await closed;
 
-  if (stderrBuffer.trim()) log.error("agent-stderr", stderrBuffer);
+  if (stderrBuffer.trim()) logAgentStderr(stderrBuffer);
   log.info("agent", "claude exited", { exitCode, signal });
   mcpTracker.logIfSuspicious();
 

--- a/test/agent/test_abort_caused_exit.ts
+++ b/test/agent/test_abort_caused_exit.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isAbortCausedExit, buildExitErrorEvent, brokerNotReadyErrorEvent } from "../../server/agent/backend/claude-code.js";
+import { isAbortCausedExit, buildExitErrorEvent, brokerNotReadyErrorEvent, isBenignClaudeStderr } from "../../server/agent/backend/claude-code.js";
 
 // Regression coverage for the stop-button false-error fix (#1625).
 // readAgentEvents only suppresses the exit-error event when
@@ -79,4 +79,17 @@ test("brokerNotReadyErrorEvent complements buildExitErrorEvent on a clean exit",
   assert.equal(buildExitErrorEvent(0, null, undefined, raceStderr), null); // clean exit → no exit error
   assert.equal(brokerNotReadyErrorEvent(raceStderr)?.message, raceStderr); // …but the race is still surfaced
   assert.equal(brokerNotReadyErrorEvent("all good, no tools needed"), null);
+});
+
+test("isBenignClaudeStderr recognises the sandbox workspace-trust notice (#2055)", () => {
+  const trustLine =
+    'Ignoring 4 permissions.allow entries from .claude/settings.json: this workspace has not been trusted. Run Claude Code interactively here once and accept the trust dialog, or set projects["/home/node/mulmoclaude"].hasTrustDialogAccepted: true in /home/node/.claude.json.';
+  assert.equal(isBenignClaudeStderr(trustLine), true);
+});
+
+test("isBenignClaudeStderr does not swallow genuine errors", () => {
+  assert.equal(isBenignClaudeStderr("Error: ENOENT: no such file or directory"), false);
+  assert.equal(isBenignClaudeStderr("permission denied while writing config"), false);
+  assert.equal(isBenignClaudeStderr("MCP server crashed with exit code 1"), false);
+  assert.equal(isBenignClaudeStderr(""), false);
 });


### PR DESCRIPTION
## Summary

Fixes #2055. `readAgentEvents` logged **every** claude CLI stderr line at `ERROR`. In Docker sandbox mode the container workspace (`/home/node/mulmoclaude`) isn't among the host `~/.claude.json`'s trusted projects, so claude prints a benign notice — *on every spawn* — that it's ignoring the workspace `permissions.allow` entries. That's harmless (tool permissions come from `--allowedTools` + the mulmoclaude MCP permission handler, not `.claude/settings.json`), but at `ERROR` it looked like a failure and buried real errors.

**Fix:** route stderr by content — the benign trust notice → `debug`, genuine errors stay `error`.

## Items to Confirm / Review

- **I did NOT take the issue's proposed auto-trust approach** (writing `hasTrustDialogAccepted` into the user's shared `~/.claude.json`). I judged it riskier — concurrent-write races with claude's own frequent rewrites, reformatting/corruption of a 160+-project config file claude owns — for **zero functional gain** (the ignored allow entries are already covered by `--allowedTools`). The log fix directly resolves the actual complaint (ERROR noise) with no external-file writes.
- **Match is intentionally narrow** (`"has not been trusted"`) so genuine errors are never downgraded — covered by a test.
- Independently verified the bug is real: my `~/.claude.json` has 162 projects but no `/home/node/mulmoclaude` entry (untrusted).

## Tests

- `test_abort_caused_exit.ts`: `isBenignClaudeStderr` matches the exact trust notice; does NOT match real errors (ENOENT / permission denied / crash / empty).
- Gates: format / typecheck green; changed files lint-clean; tests 11/0.

## User Prompt

Among the triaged bugs, address #2055 — first independently re-verify the problem in current code (don't trust prior investigation), then design the fix anew. User chose the log-level approach (B) over auto-trust (A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust agent stderr logging to treat Claude CLI workspace-trust notices as benign debug messages instead of errors, preventing noisy false alarms while preserving real error visibility.

Bug Fixes:
- Downgrade known harmless Claude CLI workspace-trust stderr output from error to debug logging so sandbox runs no longer appear to fail.

Tests:
- Add unit tests ensuring benign workspace-trust stderr lines are correctly identified and that genuine error messages are not misclassified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Claude workspace trust notices by recording them as debug information instead of errors.
  * Continued reporting genuine Claude and MCP failures as errors.
  * Improved consistency when processing stderr output during and after agent execution.

* **Tests**
  * Added coverage to verify trusted-workspace notices are recognized correctly without masking real errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->