### PR TITLE
chore(deps): bump ws to ^8.21.1 and @vitejs/plugin-vue to ^6.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "vue-router": "^5.1.0",
     "vuedraggable": "^4.1.0",
     "which": "^6",
-    "ws": "^8.21.0",
+    "ws": "^8.21.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.4.3"
   },
@@ -154,7 +154,7 @@
     "@types/uuid": "^11.0.0",
     "@types/which": "^3",
     "@types/ws": "^8.18.1",
-    "@vitejs/plugin-vue": "^6.0.7",
+    "@vitejs/plugin-vue": "^6.0.8",
     "concurrently": "^10.0.3",
     "cross-env": "^10.1.0",
     "eslint": "^10.7.0",

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.4",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
-    "ws": "^8.21.0"
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -66,7 +66,7 @@
     "tsx": "^4.23.1",
     "uuid": "^14.0.1",
     "which": "^6",
-    "ws": "^8.21.0",
+    "ws": "^8.21.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.4.3"
   },

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -59,7 +59,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "@types/express": "^5.0.6",
     "@types/node": "^26.1.1",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.8",
     "express": "^5.2.1",
     "gui-chat-protocol": "0.4.0",
     "tailwindcss": "^4.3.2",

--- a/packages/plugins/bookmarks-plugin/package.json
+++ b/packages/plugins/bookmarks-plugin/package.json
@@ -32,7 +32,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.7",
+    "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^5.0.3",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.64.0",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.8",
     "echarts": "^6.1.0",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.8.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -40,7 +40,7 @@
     "@mulmoclaude/core": "^0.13.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.1",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.8",
     "gui-chat-protocol": "^0.4.0",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",

--- a/packages/plugins/debug-plugin/package.json
+++ b/packages/plugins/debug-plugin/package.json
@@ -28,7 +28,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.7",
+    "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^5.0.3",

--- a/packages/plugins/form-plugin/package.json
+++ b/packages/plugins/form-plugin/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.64.0",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.8.0",
     "globals": "^17.7.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -44,7 +44,7 @@
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.64.0",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.8.0",
     "globals": "^17.7.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -50,7 +50,7 @@
     "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.64.0",
     "@typescript-eslint/parser": "^8.64.0",
-    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.8.0",
     "globals": "^17.7.0",

--- a/packages/plugins/recipe-book-plugin/package.json
+++ b/packages/plugins/recipe-book-plugin/package.json
@@ -32,7 +32,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.7",
+    "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^5.0.3",

--- a/packages/plugins/spotify-plugin/package.json
+++ b/packages/plugins/spotify-plugin/package.json
@@ -32,7 +32,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.7",
+    "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,10 +3052,10 @@
     d3-selection "^3.0.0"
     d3-transition "^3.0.1"
 
-"@vitejs/plugin-vue@^6.0.5", "@vitejs/plugin-vue@^6.0.7":
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz#194235d364a2c601c521b0410e524e521119059f"
-  integrity sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==
+"@vitejs/plugin-vue@^6.0.8":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz#1809d090b7c93b8f4ae83d3e7536655cbbb1c793"
+  integrity sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==
   dependencies:
     "@rolldown/pluginutils" "^1.0.1"
 
@@ -10208,6 +10208,11 @@ ws@^7.5.10:
   version "7.5.11"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
   integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
+
+ws@^8.21.1:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 wsl-utils@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

Routine patch/minor dependency refresh across the workspaces:
- `ws` `^8.21.0` → `^8.21.1`
- `@vitejs/plugin-vue` → `^6.0.8`

## Items to Confirm / Review

- **`eslint-plugin-sonarjs 4.1 → 4.2` was deliberately EXCLUDED** from this PR. Its newer rules (`no-fixed-wait-in-tests`, `explicit-test-skip`) flag **29 pre-existing patterns** in the e2e specs, which would fail `lint_test`. That bump + the required test refactor is being handled as a **separate PR** so this dep refresh stays clean and reviewable.
- All bumps are patch/minor; no API surface changes.

## Verification

- `yarn build` ✓ · `yarn typecheck` ✓ · `yarn lint` ✓ · install clean.
- Diff is package.json ranges + yarn.lock only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update websocket and Vue build tooling dependencies across the monorepo.

Enhancements:
- Bump ws to ^8.21.1 in the root app, mulmoclaude package, and bridge services.
- Align @vitejs/plugin-vue to ^6.0.8 across the root project and all Vue-based plugins.

Build:
- Refresh frontend build tooling dependencies without changing application behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WebSocket library to version 8.21.1 across the application and supported integrations.
  * Updated the Vue development plugin to version 6.0.8 across the application and plugins.
  * No user-facing features or configuration changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->