### PR TITLE
fix: write system prompt to a file, pass --system-prompt-file (Windows ENAMETOOLONG, #2078)

### DIFF
--- a/plans/fix-2078-system-prompt-file.md
+++ b/plans/fix-2078-system-prompt-file.md
@@ -1,0 +1,57 @@
+# fix #2078 — Windows ENAMETOOLONG on large inline `--system-prompt`
+
+## Problem
+
+On Windows the server spawns the `claude` CLI with the entire assembled system
+prompt inline as `--system-prompt <text>`. Windows `CreateProcess` caps the whole
+command line at ~32k chars, so any workspace whose role + plugins + memory push
+the prompt past that fails **every** message with `spawn ENAMETOOLONG` before the
+CLI even starts. It is environment-dependent and grows with workspace richness,
+so it reads as random breakage (one role works, another doesn't; yesterday's
+role starts failing after memory grows).
+
+## Fix
+
+Write the prompt to a per-session file and pass `--system-prompt-file` instead,
+reusing the exact host/container path split the per-session MCP config already
+uses (`resolveMcpConfigPaths`).
+
+- `server/agent/config.ts`
+  - `CliArgsParams.systemPrompt: string` → `systemPromptPath: string`.
+  - `buildCliArgs` emits `--system-prompt-file <path>` instead of `--system-prompt <text>`.
+  - New `resolveSystemPromptPaths(...)` mirroring `resolveMcpConfigPaths`:
+    workspace `.mulmoclaude/system-prompt-<sid>.md` under Docker (so the
+    container-side CLI reads it through the bind mount), OS tmpdir natively,
+    same `safeSessionSegment` sessionId sanitisation against path injection.
+  - The shared `{ hostPath, argPath }` return type is generalised from
+    `McpConfigPaths` to `SessionFilePaths` (both resolvers return it).
+- `server/agent/backend/claude-code.ts`
+  - `writeSystemPromptFile(input)` writes the prompt with `writeFileAtomic`
+    before spawn (one file per chat session, overwritten each turn, mirroring
+    the MCP config lifecycle) and returns the CLI arg path.
+  - `cliArgsForInput(input, systemPromptPath)` takes the resolved path.
+- `AgentInput.systemPrompt` (the text) is unchanged — the backend is the only
+  place that materialises it to a file.
+
+## Flag verification
+
+`--system-prompt-file <file>` is a real, registered Claude CLI flag (probed on
+2.1.210: unknown flags are rejected, this one reports "argument missing"). The
+issue reporter validated the same on 2.1.204.
+
+## Tests
+
+- `resolveSystemPromptPaths`: native path, docker path, docker host≠arg, and
+  path-injection/sessionId-sanitisation coverage (mirrors the existing
+  `resolveMcpConfigPaths` tests).
+- Regression: the prompt travels as a `--system-prompt-file` path and inline
+  `--system-prompt` is **never** emitted; `cliArgsForInput` carries the path,
+  not the text.
+
+## Notes / non-goals
+
+- The prompt file is overwritten each turn and not explicitly unlinked (the
+  issue's "overwrite each turn" lifecycle). Native files land in the OS tmpdir;
+  Docker files in `<workspace>/.mulmoclaude/`.
+- Windows-specific bug that cannot reproduce on macOS/Linux; correctness is
+  guarded by the unit tests above.

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -210,14 +210,16 @@ export function cliArgsForInput(input: AgentInput, systemPromptPath: string): Cl
 // `--system-prompt-file`, returning the path to put on the command line
 // (container path under Docker). Atomic so a concurrent spawn on the
 // same session never reads a half-written prompt; one file per session,
-// overwritten each turn (mirroring the MCP config lifecycle).
-async function writeSystemPromptFile(input: AgentInput): Promise<string> {
+// overwritten each turn (mirroring the MCP config lifecycle). Mode 0600
+// because the prompt carries the role / memory / plugin instructions —
+// no reason for it to be world-readable in the OS tmpdir or workspace.
+export async function writeSystemPromptFile(input: AgentInput): Promise<string> {
   const paths = resolveSystemPromptPaths({
     workspacePath: input.workspacePath,
     sessionId: input.sessionId,
     useDocker: input.useDocker,
   });
-  await writeFileAtomic(paths.hostPath, input.systemPrompt);
+  await writeFileAtomic(paths.hostPath, input.systemPrompt, { mode: 0o600 });
   return paths.argPath;
 }
 

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -11,7 +11,8 @@
 
 import { spawn, type ChildProcessByStdio } from "child_process";
 import type { Readable, Writable } from "stream";
-import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine, type CliArgsParams } from "../config.js";
+import { buildCliArgs, buildDockerSpawnArgs, buildUserMessageLine, resolveSystemPromptPaths, type CliArgsParams } from "../config.js";
+import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
@@ -190,11 +191,13 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
   if (errorEvent) yield errorEvent;
 }
 
-// The one non-pass-through mapping is `sessionToken` -> `claudeSessionId`
-// (the CLI's `--resume` id); the rest forward verbatim.
-export function cliArgsForInput(input: AgentInput): CliArgsParams {
+// The non-pass-through mappings are `sessionToken` -> `claudeSessionId`
+// (the CLI's `--resume` id) and the system prompt, which travels as a
+// file path (`systemPromptPath`) rather than inline text — see the
+// CliArgsParams field comment for the Windows ENAMETOOLONG rationale.
+export function cliArgsForInput(input: AgentInput, systemPromptPath: string): CliArgsParams {
   return {
-    systemPrompt: input.systemPrompt,
+    systemPromptPath,
     activePlugins: input.activePlugins,
     claudeSessionId: input.sessionToken,
     mcpConfigPath: input.mcpConfigPath,
@@ -203,8 +206,24 @@ export function cliArgsForInput(input: AgentInput): CliArgsParams {
   };
 }
 
+// Write the per-session system-prompt file the CLI reads via
+// `--system-prompt-file`, returning the path to put on the command line
+// (container path under Docker). Atomic so a concurrent spawn on the
+// same session never reads a half-written prompt; one file per session,
+// overwritten each turn (mirroring the MCP config lifecycle).
+async function writeSystemPromptFile(input: AgentInput): Promise<string> {
+  const paths = resolveSystemPromptPaths({
+    workspacePath: input.workspacePath,
+    sessionId: input.sessionId,
+    useDocker: input.useDocker,
+  });
+  await writeFileAtomic(paths.hostPath, input.systemPrompt);
+  return paths.argPath;
+}
+
 async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
-  const cliArgs = buildCliArgs(cliArgsForInput(input));
+  const systemPromptPath = await writeSystemPromptFile(input);
+  const cliArgs = buildCliArgs(cliArgsForInput(input, systemPromptPath));
 
   // spawnClaude can throw synchronously when `claudeBinPath()` fails
   // to locate `claude.exe` on Windows — surface that through the same

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -394,7 +394,14 @@ export function userServerAllowedToolNames(userServers: Record<string, McpServer
 }
 
 export interface CliArgsParams {
-  systemPrompt: string;
+  /** Path handed to `--system-prompt-file` (the container-side path
+   *  under Docker — see `resolveSystemPromptPaths`). The prompt travels
+   *  as a file, never as an inline `--system-prompt` argument: on
+   *  Windows the argv collapses to a single CreateProcess command line
+   *  capped at ~32k chars, so a rich role + plugins + memory pushes the
+   *  prompt past the cap and the spawn fails with ENAMETOOLONG before
+   *  the CLI even starts (#2078). */
+  systemPromptPath: string;
   activePlugins: string[];
   claudeSessionId?: string;
   mcpConfigPath?: string;
@@ -407,7 +414,7 @@ export interface CliArgsParams {
 }
 
 export function buildCliArgs(params: CliArgsParams): string[] {
-  const { systemPrompt, activePlugins, claudeSessionId, mcpConfigPath, extraAllowedTools = [], effortLevel } = params;
+  const { systemPromptPath, activePlugins, claudeSessionId, mcpConfigPath, extraAllowedTools = [], effortLevel } = params;
 
   const mcpToolNames = activePlugins.map((pluginName) => `mcp__mulmoclaude__${pluginName}`);
   // DEBUG: also pass the wildcard form `mcp__mulmoclaude` so Claude
@@ -432,8 +439,8 @@ export function buildCliArgs(params: CliArgsParams): string[] {
     "stream-json",
     "--include-partial-messages",
     "--verbose",
-    "--system-prompt",
-    systemPrompt,
+    "--system-prompt-file",
+    systemPromptPath,
     "--allowedTools",
     allowedTools.join(","),
     "-p",
@@ -554,11 +561,12 @@ function buildNativeBlock(att: Attachment): Record<string, unknown> {
   };
 }
 
-export interface McpConfigPaths {
+export interface SessionFilePaths {
   // Where the file is actually written on the host filesystem.
   hostPath: string;
-  // What gets passed to claude --mcp-config (container path under
-  // docker, identical to hostPath when running natively).
+  // The path handed to the claude CLI (e.g. via --mcp-config or
+  // --system-prompt-file): the container path under docker, read
+  // through the workspace bind mount, identical to hostPath natively.
   argPath: string;
 }
 
@@ -570,7 +578,7 @@ function safeSessionSegment(sessionId: string): string {
   return basename(sessionId).replace(/[^A-Za-z0-9_-]/g, "_");
 }
 
-export function resolveMcpConfigPaths(opts: { workspacePath: string; sessionId: string; useDocker: boolean }): McpConfigPaths {
+export function resolveMcpConfigPaths(opts: { workspacePath: string; sessionId: string; useDocker: boolean }): SessionFilePaths {
   const sid = safeSessionSegment(opts.sessionId);
   if (opts.useDocker) {
     const hostPath = join(opts.workspacePath, ".mulmoclaude", `mcp-${sid}.json`);
@@ -578,6 +586,22 @@ export function resolveMcpConfigPaths(opts: { workspacePath: string; sessionId: 
     return { hostPath, argPath };
   }
   const hostPath = join(tmpdir(), `mulmoclaude-mcp-${sid}.json`);
+  return { hostPath, argPath: hostPath };
+}
+
+// Where the per-session system-prompt file lives — same host/container
+// split as resolveMcpConfigPaths. Under Docker the file must sit inside
+// the workspace bind mount so the container-side CLI can read it via
+// --system-prompt-file; natively the OS tmpdir is fine. One file per
+// chat session — successive turns overwrite it.
+export function resolveSystemPromptPaths(opts: { workspacePath: string; sessionId: string; useDocker: boolean }): SessionFilePaths {
+  const sid = safeSessionSegment(opts.sessionId);
+  if (opts.useDocker) {
+    const hostPath = join(opts.workspacePath, ".mulmoclaude", `system-prompt-${sid}.md`);
+    const argPath = `${CONTAINER_WORKSPACE_PATH}/.mulmoclaude/system-prompt-${sid}.md`;
+    return { hostPath, argPath };
+  }
+  const hostPath = join(tmpdir(), `mulmoclaude-system-prompt-${sid}.md`);
   return { hostPath, argPath: hostPath };
 }
 

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -16,6 +16,7 @@ import {
   type Platform,
   prepareUserServers,
   resolveMcpConfigPaths,
+  resolveSystemPromptPaths,
   rewriteLocalhostForDocker,
   userServerAllowedToolNames,
   workspaceModuleMounts,
@@ -100,7 +101,7 @@ describe("buildMcpConfig", () => {
 describe("buildCliArgs", () => {
   it("includes required flags", async () => {
     const args = buildCliArgs({
-      systemPrompt: "You are helpful",
+      systemPromptPath: "/tmp/system-prompt.md",
       activePlugins: [],
     });
 
@@ -109,10 +110,26 @@ describe("buildCliArgs", () => {
     // stream-json is used for both input and output formats.
     assert.equal(args.filter((arg) => arg === "stream-json").length, 2, "stream-json should appear twice (input + output format)");
     assert.ok(args.includes("--verbose"));
-    assert.ok(args.includes("--system-prompt"));
-    assert.ok(args.includes("You are helpful"));
+    assert.ok(args.includes("--system-prompt-file"));
+    assert.ok(args.includes("/tmp/system-prompt.md"));
     assert.ok(args.includes("-p"));
     assert.ok(args.includes("--allowedTools"));
+  });
+
+  it("passes the system prompt as a file path, never inline (#2078 Windows ENAMETOOLONG)", async () => {
+    // Regression: an inline `--system-prompt <text>` puts the whole
+    // prompt on the command line. On Windows CreateProcess caps the
+    // command line at ~32k chars, so a workspace with a rich role +
+    // plugins + memory pushed the prompt past the cap and every spawn
+    // failed with ENAMETOOLONG before the CLI even started.
+    const args = buildCliArgs({
+      systemPromptPath: "/tmp/system-prompt.md",
+      activePlugins: [],
+    });
+    const fileIdx = args.indexOf("--system-prompt-file");
+    assert.ok(fileIdx >= 0, "must pass --system-prompt-file");
+    assert.equal(args[fileIdx + 1], "/tmp/system-prompt.md");
+    assert.ok(!args.includes("--system-prompt"), "inline --system-prompt must never be emitted (Windows ENAMETOOLONG)");
   });
 
   it("does NOT pass the user message as a CLI argument", async () => {
@@ -120,7 +137,7 @@ describe("buildCliArgs", () => {
     // input mode. Passing it as `-p <text>` (the old mode) bypasses
     // slash-command resolution for Claude Code skills.
     const args = buildCliArgs({
-      systemPrompt: "You are helpful",
+      systemPromptPath: "/tmp/system-prompt.md",
       activePlugins: [],
     });
     const pIdx = args.indexOf("-p");
@@ -132,7 +149,7 @@ describe("buildCliArgs", () => {
 
   it("includes MCP tool names in allowedTools", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: ["manageBookmarks"],
     });
 
@@ -148,7 +165,7 @@ describe("buildCliArgs", () => {
     // Regression guard: a strict --allowedTools that omits `Skill`
     // permission-denies every Skill({skill:"…"}) call (Execute skill
     // error + Glob fallback). See plans/done/fix-skill-tool-allowlist.md.
-    const args = buildCliArgs({ systemPrompt: "test", activePlugins: [] });
+    const args = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: [] });
     const allowedStr = args[args.indexOf("--allowedTools") + 1];
     const tools = allowedStr.split(",");
     assert.ok(tools.includes("Skill"), `--allowedTools must list "Skill" (got: ${allowedStr})`);
@@ -156,7 +173,7 @@ describe("buildCliArgs", () => {
 
   it("includes --resume when claudeSessionId provided", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
       claudeSessionId: "sess_123",
     });
@@ -168,7 +185,7 @@ describe("buildCliArgs", () => {
 
   it("omits --resume when no claudeSessionId", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
     });
 
@@ -177,7 +194,7 @@ describe("buildCliArgs", () => {
 
   it("includes --mcp-config when path provided", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: ["foo"],
       mcpConfigPath: "/tmp/mcp.json",
     });
@@ -189,7 +206,7 @@ describe("buildCliArgs", () => {
 
   it("omits --mcp-config when no path", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
     });
 
@@ -200,18 +217,18 @@ describe("buildCliArgs", () => {
     // The handler tool lives inside our MCP server. With no
     // --mcp-config the CLI can't resolve it and refuses to start;
     // gate the flag together with --mcp-config.
-    const withMcp = buildCliArgs({ systemPrompt: "x", activePlugins: ["foo"], mcpConfigPath: "/tmp/mcp.json" });
+    const withMcp = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: ["foo"], mcpConfigPath: "/tmp/mcp.json" });
     const withMcpIdx = withMcp.indexOf("--permission-prompt-tool");
     assert.ok(withMcpIdx >= 0, "must pass --permission-prompt-tool when MCP is configured");
     assert.equal(withMcp[withMcpIdx + 1], "mcp__mulmoclaude__handlePermission");
 
-    const withoutMcp = buildCliArgs({ systemPrompt: "x", activePlugins: [] });
+    const withoutMcp = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: [] });
     assert.ok(!withoutMcp.includes("--permission-prompt-tool"), "must NOT pass --permission-prompt-tool in no-MCP sessions");
   });
 
   it("includes --effort when effortLevel is set", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
       effortLevel: "high",
     });
@@ -223,7 +240,7 @@ describe("buildCliArgs", () => {
 
   it("omits --effort when effortLevel is unset", async () => {
     const args = buildCliArgs({
-      systemPrompt: "test",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
     });
 
@@ -271,6 +288,51 @@ describe("resolveMcpConfigPaths", () => {
         assert.ok(!derivedPath.includes(".."), `traversal leaked into ${derivedPath}`);
         assert.ok(!derivedPath.includes("etc"), `path component leaked into ${derivedPath}`);
         assert.ok(derivedPath.includes("mcp-pwn.json"), `expected sanitized segment, got ${derivedPath}`);
+      }
+    }
+  });
+});
+
+describe("resolveSystemPromptPaths", () => {
+  it("uses tmpdir for native runs (no docker)", async () => {
+    const paths = resolveSystemPromptPaths({
+      workspacePath: "/ws",
+      sessionId: "abc",
+      useDocker: false,
+    });
+    assert.equal(paths.hostPath, join(tmpdir(), "mulmoclaude-system-prompt-abc.md"));
+    assert.equal(paths.argPath, paths.hostPath);
+  });
+
+  it("uses workspace .mulmoclaude dir for docker runs so the container can read it", async () => {
+    const paths = resolveSystemPromptPaths({
+      workspacePath: "/ws",
+      sessionId: "abc",
+      useDocker: true,
+    });
+    assert.equal(paths.hostPath, join("/ws", ".mulmoclaude", "system-prompt-abc.md"));
+    assert.equal(paths.argPath, `${CONTAINER_WORKSPACE_PATH}/.mulmoclaude/system-prompt-abc.md`);
+  });
+
+  it("docker hostPath and argPath differ", async () => {
+    const paths = resolveSystemPromptPaths({
+      workspacePath: "/ws",
+      sessionId: "s",
+      useDocker: true,
+    });
+    assert.notEqual(paths.hostPath, paths.argPath);
+  });
+
+  it("sanitizes path-injecting sessionId (CodeQL js/path-injection)", async () => {
+    const evil = "../../etc/pwn";
+    for (const useDocker of [true, false]) {
+      const paths = resolveSystemPromptPaths({ workspacePath: "/ws", sessionId: evil, useDocker });
+      // basename collapses the traversal to "pwn"; nothing of the
+      // crafted prefix survives into either derived path.
+      for (const derivedPath of [paths.hostPath, paths.argPath]) {
+        assert.ok(!derivedPath.includes(".."), `traversal leaked into ${derivedPath}`);
+        assert.ok(!derivedPath.includes("etc"), `path component leaked into ${derivedPath}`);
+        assert.ok(derivedPath.includes("system-prompt-pwn.md"), `expected sanitized segment, got ${derivedPath}`);
       }
     }
   });
@@ -914,7 +976,7 @@ describe("buildUserMessageLine", () => {
 describe("buildCliArgs — extraAllowedTools", () => {
   it("merges extraAllowedTools into --allowedTools", async () => {
     const args = buildCliArgs({
-      systemPrompt: "s",
+      systemPromptPath: "/tmp/sp.md",
       activePlugins: [],
       extraAllowedTools: ["mcp__claude_ai_Gmail", "mcp__claude_ai_Google_Calendar"],
     });

--- a/test/agent/test_cliArgsForInput.ts
+++ b/test/agent/test_cliArgsForInput.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { cliArgsForInput } from "../../server/agent/backend/claude-code.js";
+import { readFileSync, statSync, unlinkSync } from "node:fs";
+import { cliArgsForInput, writeSystemPromptFile } from "../../server/agent/backend/claude-code.js";
 import type { AgentInput } from "../../server/agent/backend/types.js";
 import { ROLES, type Role } from "../../src/config/roles.js";
 
@@ -70,5 +71,32 @@ describe("cliArgsForInput", () => {
     assert.ok(!("message" in params));
     assert.ok(!("workspacePath" in params));
     assert.ok(!("port" in params));
+  });
+});
+
+describe("writeSystemPromptFile", () => {
+  it("writes the prompt (native path)", async () => {
+    const input = makeInput({ systemPrompt: "role + memory + plugin instructions" });
+    const promptPath = await writeSystemPromptFile(input);
+    try {
+      assert.equal(readFileSync(promptPath, "utf-8"), "role + memory + plugin instructions");
+    } finally {
+      unlinkSync(promptPath);
+    }
+  });
+
+  it("writes with mode 0600 so the prompt is not world-readable (Codex review)", async (ctx) => {
+    // The file carries role / memory / plugin instructions; on umask 022 a
+    // default write is 0644 (world-readable). chmod is a no-op on Windows.
+    if (process.platform === "win32") {
+      ctx.skip("chmod is a no-op on Windows");
+      return;
+    }
+    const promptPath = await writeSystemPromptFile(makeInput({ systemPrompt: "secret prompt" }));
+    try {
+      assert.equal(statSync(promptPath).mode & 0o777, 0o600);
+    } finally {
+      unlinkSync(promptPath);
+    }
   });
 });

--- a/test/agent/test_cliArgsForInput.ts
+++ b/test/agent/test_cliArgsForInput.ts
@@ -26,23 +26,32 @@ function makeInput(overrides: Partial<AgentInput> = {}): AgentInput {
   };
 }
 
+const PROMPT_PATH = "/tmp/system-prompt.md";
+
 describe("cliArgsForInput", () => {
   it("maps sessionToken onto claudeSessionId (the --resume id)", () => {
-    const params = cliArgsForInput(makeInput({ sessionToken: "resume-123" }));
+    const params = cliArgsForInput(makeInput({ sessionToken: "resume-123" }), PROMPT_PATH);
     assert.equal(params.claudeSessionId, "resume-123");
+  });
+
+  it("carries the system-prompt file path, not the prompt text (#2078)", () => {
+    // The prompt itself travels via --system-prompt-file; inline text on
+    // the command line ENAMETOOLONGs once it clears Windows' ~32k cap.
+    const params = cliArgsForInput(makeInput({ systemPrompt: "SP" }), PROMPT_PATH);
+    assert.equal(params.systemPromptPath, PROMPT_PATH);
+    assert.ok(!("systemPrompt" in params));
   });
 
   it("forwards the pass-through fields verbatim", () => {
     const params = cliArgsForInput(
       makeInput({
-        systemPrompt: "SP",
         activePlugins: ["a", "b"],
         mcpConfigPath: "/cfg.json",
         extraAllowedTools: ["Bash"],
         effortLevel: "high",
       }),
+      PROMPT_PATH,
     );
-    assert.equal(params.systemPrompt, "SP");
     assert.deepEqual(params.activePlugins, ["a", "b"]);
     assert.equal(params.mcpConfigPath, "/cfg.json");
     assert.deepEqual(params.extraAllowedTools, ["Bash"]);
@@ -50,14 +59,14 @@ describe("cliArgsForInput", () => {
   });
 
   it("leaves optional fields undefined when the input omits them", () => {
-    const params = cliArgsForInput(makeInput());
+    const params = cliArgsForInput(makeInput(), PROMPT_PATH);
     assert.equal(params.claudeSessionId, undefined);
     assert.equal(params.mcpConfigPath, undefined);
     assert.equal(params.effortLevel, undefined);
   });
 
   it("does not carry over non-CLI fields (message, workspacePath, port)", () => {
-    const params = cliArgsForInput(makeInput({ message: "secret", port: 9999 }));
+    const params = cliArgsForInput(makeInput({ message: "secret", port: 9999 }), PROMPT_PATH);
     assert.ok(!("message" in params));
     assert.ok(!("workspacePath" in params));
     assert.ok(!("port" in params));


### PR DESCRIPTION
## Summary

On Windows the server spawns the `claude` CLI with the **entire assembled system prompt inline** as `--system-prompt <text>`. `CreateProcess` caps the whole command line at ~32k chars, so any workspace whose role + plugins + memory push the prompt past that fails **every** message with `spawn ENAMETOOLONG` before the CLI even starts. It grows with workspace richness (memory, wiki summary, plugin instructions), so it reads as random breakage — one role works, another doesn't, and yesterday's role starts failing after memory grows.

The fix writes the prompt to a **per-session file** and passes `--system-prompt-file` instead, reusing the exact host/container path split the per-session MCP config already uses (`resolveMcpConfigPaths`).

- `server/agent/config.ts`
  - `CliArgsParams.systemPrompt: string` → `systemPromptPath: string`.
  - `buildCliArgs` emits `--system-prompt-file <path>` instead of `--system-prompt <text>`.
  - New `resolveSystemPromptPaths(...)` mirroring `resolveMcpConfigPaths`: workspace `.mulmoclaude/system-prompt-<sid>.md` under Docker (so the container-side CLI reads it through the bind mount), OS tmpdir natively, same `safeSessionSegment` sessionId sanitisation.
  - The shared `{ hostPath, argPath }` return type generalised `McpConfigPaths` → `SessionFilePaths` (both resolvers return it; only the interface name + comment changed).
- `server/agent/backend/claude-code.ts`
  - `writeSystemPromptFile(input)` writes the prompt with `writeFileAtomic` before spawn (one file per chat session, overwritten each turn, mirroring the MCP config lifecycle) and returns the CLI arg path.
  - `cliArgsForInput(input, systemPromptPath)` takes the resolved path.
- `AgentInput.systemPrompt` (the text) is unchanged — the backend is the only place that materialises it to a file.

Side benefit: the prompt no longer leaks into `ps` output.

## Items to Confirm / Review

- **Windows-specific bug, validated by tests.** The failure cannot reproduce on macOS/Linux (their `execve` arg limits are far higher), so correctness here rests on the unit tests, not a live repro. Please sanity-check the regression assertions.
- **Flag is verified real.** `--system-prompt-file <file>` was probed against the installed Claude CLI **2.1.210** (unknown flags are rejected outright; this one reports `option '--system-prompt-file <file>' argument missing`, i.e. it is a registered option). The issue reporter validated the same on 2.1.204, incl. a 40k-char prompt spawning fine as a file.
- **Prompt file lifecycle.** The file is overwritten each turn and **not** explicitly unlinked (the issue's "overwrite each turn" lifecycle). Native files land in the OS tmpdir (auto-cleaned); Docker files in `<workspace>/.mulmoclaude/`, one per chat session. If you'd prefer symmetric cleanup with the MCP config (which is unlinked each turn), say so and I'll add it.
- **Interface rename.** `McpConfigPaths` → `SessionFilePaths` is a pure rename of an internal type (referenced only at its definition + the two resolver return annotations; `index.ts` uses `ReturnType<...>`). No behaviour change.

## Tests

- `resolveSystemPromptPaths`: native path, docker path, docker host≠arg, and path-injection / sessionId-sanitisation coverage (mirrors the existing `resolveMcpConfigPaths` tests).
- Regression: the prompt travels as a `--system-prompt-file` path and inline `--system-prompt` is **never** emitted; `cliArgsForInput` carries the path, not the text.

Gates: `yarn format`, `yarn lint` (changed files clean), `yarn typecheck`, `yarn build` all pass. `npx tsx --test test/agent/test_agent_config.ts test/agent/test_cliArgsForInput.ts` → 94/94 pass. Full `test/agent/test_*.ts` → 442/444; the 2 failures are pre-existing environmental MCP smoke tests (`Cannot find module 'express'` in the spawned subprocess / unbuilt Docker sandbox) that fail identically on pristine `main` and do not reference any changed code.

## User Prompt

Fix the Windows `ENAMETOOLONG` bug where the server spawns the `claude` CLI with the entire assembled system prompt inline as `--system-prompt <text>` — CreateProcess caps the command line at ~32k chars, so a workspace whose role + plugins + memory push the prompt past that fails every message before the CLI starts. Write the prompt to a per-session file and pass `--system-prompt-file` instead, mirroring the existing per-session MCP config pattern (`resolveMcpConfigPaths`): host path + container path, sessionId sanitisation, workspace `.mulmoclaude/…-<sid>.…` under Docker and OS tmpdir natively, atomic write via `writeFileAtomic`. Add tests for the resolver (native / docker / path-injection) and a regression that inline `--system-prompt` is never emitted.

Fixes #2078

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route the agent system prompt through a per-session file and update CLI argument handling to avoid Windows ENAMETOOLONG failures when spawning the Claude CLI.

Bug Fixes:
- Fix Windows ENAMETOOLONG errors by passing the system prompt via --system-prompt-file instead of inline text on the Claude CLI command line.

Enhancements:
- Introduce shared SessionFilePaths abstraction and a resolveSystemPromptPaths helper to manage per-session system prompt file locations across native and Docker environments.

Documentation:
- Add an internal plan document describing the Windows ENAMETOOLONG issue and the system-prompt-file based fix.

Tests:
- Extend CLI arg and agent config tests to assert use of --system-prompt-file and that inline --system-prompt is never emitted, and add coverage for resolveSystemPromptPaths including Docker, native, and path-injection cases.