### PR TITLE
chore(lint): bump eslint-plugin-sonarjs to 4.2 + fix flagged e2e waits/skips

### DIFF
--- a/e2e/tests/a11y-clickable-rows.spec.ts
+++ b/e2e/tests/a11y-clickable-rows.spec.ts
@@ -71,6 +71,7 @@ test.describe("clickable-region a11y", () => {
       rowEl.dispatchEvent(new KeyboardEvent("keydown", { key: " ", code: "Space", bubbles: true, cancelable: true, repeat: true }));
     });
 
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: an auto-repeat keydown must NOT navigate; the absence of a navigation has no observable signal to synchronize on.
     await page.waitForTimeout(100);
     expect(page.url()).toBe(startUrl);
   });
@@ -98,6 +99,7 @@ test.describe("clickable-region a11y", () => {
 
     // Give the event loop a chance to process a navigation that
     // would happen in the broken case.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: a non-self-target Space keydown must NOT navigate; the absence of a navigation has no observable signal to synchronize on.
     await page.waitForTimeout(100);
     expect(page.url()).toBe(startUrl);
   });

--- a/e2e/tests/collection-contribute.spec.ts
+++ b/e2e/tests/collection-contribute.spec.ts
@@ -55,6 +55,7 @@ test.describe("collection Contribute button", () => {
     await expect.poll(() => agentRuns.length, { timeout: 2000 }).toBe(1);
     // A double-fire would arrive right after the first; give it a beat, then
     // confirm there was only one launch.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: a second /api/agent POST would arrive right after the first; "no double-fire" has no observable signal, so a bounded wait is required.
     await page.waitForTimeout(250);
     expect(agentRuns).toHaveLength(1);
     expect(agentRuns[0]).toContain("reading-list");
@@ -74,7 +75,9 @@ test.describe("collection Contribute button", () => {
     await expect(page.getByTestId("host-confirm-modal")).toBeVisible();
     await page.getByTestId("host-confirm-cancel").click();
 
-    await page.waitForTimeout(300);
+    // Cancel dismisses the modal without starting an agent run; a launch would
+    // have fired synchronously with the cancel handler, before the modal hides.
+    await expect(page.getByTestId("host-confirm-modal")).toBeHidden();
     expect(agentRuns).toHaveLength(0);
     await expect(page).not.toHaveURL(/\/collections\/reading-list/);
   });
@@ -91,6 +94,7 @@ test.describe("collection Contribute button", () => {
     await page.getByTestId("host-confirm-ok").click();
 
     await expect.poll(() => agentRuns.length, { timeout: 2000 }).toBe(1);
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: a keyboard-activation double-fire would arrive right after the first POST; "no second POST" has no observable signal.
     await page.waitForTimeout(250);
     expect(agentRuns).toHaveLength(1);
     expect(agentRuns[0]).toContain("reading-list");

--- a/e2e/tests/collection-new-collection-modal.spec.ts
+++ b/e2e/tests/collection-new-collection-modal.spec.ts
@@ -55,6 +55,7 @@ test.describe("new collection modal", () => {
     await expect(page.getByTestId("new-collection-starter-portfolio")).toBeVisible();
 
     // Merely opening the chooser must not launch anything.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: opening the modal must start no chat; the absence of an /api/agent POST has no observable signal.
     await page.waitForTimeout(0.2 * ONE_SECOND_MS);
     expect(agentRuns).toHaveLength(0);
   });
@@ -82,6 +83,7 @@ test.describe("new collection modal", () => {
     // and nothing is sent until the user hits Send.
     await expect(page).not.toHaveURL(/\/collections$/);
     await expect(page.getByTestId("user-input")).toHaveValue(/todo-collection\.md/);
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: a starter seeds a draft and must NOT auto-send; the absence of an /api/agent POST has no observable signal.
     await page.waitForTimeout(0.25 * ONE_SECOND_MS);
     expect(agentRuns).toHaveLength(0);
   });
@@ -97,6 +99,7 @@ test.describe("new collection modal", () => {
     // an editable draft, pointing the LLM at collection-skills.md, and auto-sends nothing.
     await expect(page).not.toHaveURL(/\/collections$/);
     await expect(page.getByTestId("user-input")).toHaveValue(/collection-skills\.md/);
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: free-form seeds a draft and must NOT auto-send; the absence of an /api/agent POST has no observable signal.
     await page.waitForTimeout(0.25 * ONE_SECOND_MS);
     expect(agentRuns).toHaveLength(0);
   });

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -65,8 +65,8 @@ test.describe("session-history side panel", () => {
 
     await page.goto("/chat");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    // Let onMount fetches settle.
-    await page.waitForTimeout(200);
+    // Wait for the onMount /api/sessions GET to land before snapshotting the baseline.
+    await expect.poll(() => sessionFetchCount).toBeGreaterThan(0);
     const countAfterMount = sessionFetchCount;
 
     await page.getByTestId("session-history-toggle-off").click();

--- a/e2e/tests/image-plugins.spec.ts
+++ b/e2e/tests/image-plugins.spec.ts
@@ -90,19 +90,18 @@ test.describe("image plugin rendering", () => {
   test("image session loads without crashing", async ({ page }) => {
     await page.goto("/chat/img-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    // The session has tool results — at least one image should render.
-    // The sidebar shows preview components for each result.
-    await page.waitForTimeout(ONE_SECOND_MS);
-    // Scope to the tool-results panel — the session-tab bar now
-    // also surfaces the preview text as a tab label, so an
-    // unscoped getByText would trip strict-mode on duplicates.
+    // The session has tool results — the tool-results panel renders a preview
+    // per result. Scope to that panel — the session-tab bar now also surfaces
+    // the preview text as a tab label, so an unscoped getByText would trip
+    // strict-mode on duplicates.
     await expect(page.getByTestId("tool-results-scroll").getByText("Generate an image")).toBeVisible();
   });
 
   test("empty imageData does not produce a broken <img> tag", async ({ page }) => {
     await page.goto("/chat/img-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await page.waitForTimeout(ONE_SECOND_MS);
+    // Wait for the tool-results to render before checking for broken images.
+    await expect(page.getByTestId("tool-results-scroll").getByText("Generate an image")).toBeVisible();
     // No <img> with empty src should exist.
     const brokenImages = page.locator('img[src=""]');
     await expect(brokenImages).toHaveCount(0);
@@ -111,7 +110,6 @@ test.describe("image plugin rendering", () => {
   test("legacy data URI image renders as an actual <img>", async ({ page }) => {
     await page.goto("/chat/img-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await page.waitForTimeout(ONE_SECOND_MS);
     // At least one <img> with a data: src should exist (the legacy entry).
     const dataImages = page.locator('img[src^="data:image"]');
     await expect(async () => {
@@ -122,7 +120,6 @@ test.describe("image plugin rendering", () => {
   test("file-path image uses /api/files/raw for src", async ({ page }) => {
     await page.goto("/chat/img-session");
     await expect(page.getByText("MulmoClaude")).toBeVisible();
-    await page.waitForTimeout(ONE_SECOND_MS);
     // At least one <img> with a /api/files/raw src should exist.
     const fileImages = page.locator('img[src*="/api/files/raw"]');
     await expect(async () => {

--- a/e2e/tests/ime-enter.spec.ts
+++ b/e2e/tests/ime-enter.spec.ts
@@ -82,6 +82,7 @@ test.describe("IME Enter handling", () => {
       { kind: "composition", type: "compositionend" },
     ]);
 
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: an isComposing keydown must NOT send; the absence of an /api/agent POST has no observable signal.
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
   });
@@ -102,6 +103,7 @@ test.describe("IME Enter handling", () => {
       { kind: "keydown", isComposing: false },
     ]);
 
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- the send is suppressed by the composable's 30 ms post-compositionend race window; asserting "not sent" requires waiting past it, and the absence of a POST has no observable signal.
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
   });
@@ -118,12 +120,12 @@ test.describe("IME Enter handling", () => {
     ]);
 
     // Wait past the 30 ms race window, then send a real Enter.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- must let the composable's 30 ms post-compositionend race window elapse before asserting no send; the window closing has no observable signal.
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
 
     await dispatchImeSequence(input, [{ kind: "keydown", isComposing: false }]);
-    await page.waitForTimeout(100);
-    expect(agentCalls).toHaveLength(1);
+    await expect.poll(() => agentCalls.length).toBe(1);
   });
 
   test("Shift+Enter does not send", async ({ page }) => {
@@ -132,6 +134,7 @@ test.describe("IME Enter handling", () => {
 
     await dispatchImeSequence(input, [{ kind: "keydown", isComposing: false, shiftKey: true }]);
 
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: Shift+Enter must NOT send; the absence of an /api/agent POST has no observable signal.
     await page.waitForTimeout(100);
     expect(agentCalls).toHaveLength(0);
   });

--- a/e2e/tests/present-mulmo-script.spec.ts
+++ b/e2e/tests/present-mulmo-script.spec.ts
@@ -10,8 +10,6 @@ import {
   waitForRenderedBeatImage,
 } from "../fixtures/present-mulmo-script";
 
-import { ONE_SECOND_MS } from "../../server/utils/time.ts";
-
 const SCRIPT_TITLE = "Test Mulmo Script";
 const SCRIPT_DESCRIPTION = "A short test script used by the smoke test.";
 const SESSION_PATH = "/chat/mulmo-session";
@@ -150,8 +148,8 @@ test.describe("presentMulmoScript plugin", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await openMulmoSessionAndSelectScript(page, SESSION_PATH);
-    // Give the View a beat to mount and kick off its fetches.
-    await page.waitForTimeout(ONE_SECOND_MS / 2);
+    // assertScriptHeader waits for the View to mount and render its header,
+    // by which point any mount-time page error would have been captured.
     await assertScriptHeader(page, SCRIPT_TITLE);
     expect(errors).toEqual([]);
   });

--- a/e2e/tests/queries-panel.spec.ts
+++ b/e2e/tests/queries-panel.spec.ts
@@ -91,6 +91,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
     await expect(textarea).toHaveValue("Tell me about this app, MulmoClaude.");
 
     // …and no message was sent.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- negative assertion: Shift+click fills the input but must NOT send; the absence of an /api/agent POST has no observable signal.
     await page.waitForTimeout(300);
     expect(captured.getBody()).toBeNull();
   });

--- a/e2e/tests/stack-map-grouping-scroll.spec.ts
+++ b/e2e/tests/stack-map-grouping-scroll.spec.ts
@@ -118,6 +118,7 @@ test.describe("StackView — session-wide map grouping (#1227)", () => {
     await openStackSession(page);
     await expect(page.getByText(MAP_PLACEHOLDER)).toHaveCount(2); // g1 = A, g2 = B
 
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- waits for the deliberately delayed (startDelayMs) live result to stream in over pubsub; its delivery has no DOM signal and the downstream scroll-metric assertions are one-shot.
     await page.waitForTimeout(streamAfterLoadMs);
     await waitForScrollHeightStable(page, "stack-scroll");
 
@@ -150,6 +151,7 @@ test.describe("StackView — session-wide map grouping (#1227)", () => {
 
     // Let the load's auto-scroll + its suppression window clear, then
     // scroll to the bottom so the B card's top crosses the active line.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- waits for the load auto-scroll suppression window (a timed debounce) to clear before scrolling; the window closing has no observable signal.
     await page.waitForTimeout(500);
     await page.getByTestId("stack-scroll").hover();
     await page.mouse.wheel(0, 6000);

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-security": "^4.0.1",
-    "eslint-plugin-sonarjs": "^4.1.0",
+    "eslint-plugin-sonarjs": "^4.2.0",
     "eslint-plugin-vue": "^10.9.2",
     "globals": "^17.7.0",
     "jsdom": "^29.1.1",

--- a/test/server/test_auth_token.ts
+++ b/test/server/test_auth_token.ts
@@ -45,8 +45,11 @@ describe("generateAndWriteToken", () => {
     assert.equal(readFileSync(tokenPath, "utf-8"), second);
   });
 
-  it("writes with mode 0600 on POSIX", async () => {
-    if (process.platform === "win32") return; // chmod 0600 is a no-op on Windows
+  it("writes with mode 0600 on POSIX", async (ctx) => {
+    if (process.platform === "win32") {
+      ctx.skip("chmod 0600 is a no-op on Windows");
+      return;
+    }
     await generateAndWriteToken(tokenPath);
     const mode = statSync(tokenPath).mode & 0o777;
     assert.equal(mode, 0o600);

--- a/test/skills/test_discovery.ts
+++ b/test/skills/test_discovery.ts
@@ -110,13 +110,18 @@ describe("collectSkillsFromDir", () => {
     assert.equal(projectSkills[0].source, "project");
   });
 
-  it("gracefully handles an unreadable SKILL.md", async () => {
-    // Windows does not honour POSIX-style chmod(0o000); the CI
-    // runner reads the file anyway and the test would fail.
-    if (process.platform === "win32") return;
-    // Some CI sandboxes run as root which also bypasses chmod. Skip
-    // when we can't actually enforce unreadable permissions.
-    if (process.getuid && process.getuid() === 0) return;
+  it("gracefully handles an unreadable SKILL.md", async (ctx) => {
+    if (process.platform === "win32") {
+      // Windows does not honour POSIX-style chmod(0o000); the CI
+      // runner reads the file anyway and the test would fail.
+      ctx.skip("Windows does not honour chmod(0o000)");
+      return;
+    }
+    if (process.getuid && process.getuid() === 0) {
+      // Some CI sandboxes run as root which also bypasses chmod.
+      ctx.skip("root bypasses chmod, cannot enforce unreadable permissions");
+      return;
+    }
     const dir = join(root, "locked");
     await mkdir(dir);
     const path = join(dir, "SKILL.md");

--- a/test/utils/files/test_atomic.ts
+++ b/test/utils/files/test_atomic.ts
@@ -46,8 +46,11 @@ describe("writeFileAtomic", () => {
     assert.equal(tmps.length, 0);
   });
 
-  it("applies file mode when specified", async () => {
-    if (process.platform === "win32") return; // chmod no-op on Windows
+  it("applies file mode when specified", async (ctx) => {
+    if (process.platform === "win32") {
+      ctx.skip("chmod is a no-op on Windows");
+      return;
+    }
     const file = path.join(tmpDir, "secret.txt");
     await writeFileAtomic(file, "secret", { mode: 0o600 });
     const stat = statSync(file);
@@ -129,8 +132,11 @@ describe("writeFileAtomic — binary content (#881 v1)", () => {
     assert.deepEqual([...read], [0x80, 0x81, 0xfe, 0xff]);
   });
 
-  it("applies file mode for Buffer content", async () => {
-    if (process.platform === "win32") return; // chmod no-op on Windows
+  it("applies file mode for Buffer content", async (ctx) => {
+    if (process.platform === "win32") {
+      ctx.skip("chmod is a no-op on Windows");
+      return;
+    }
     const file = path.join(tmpDir, "bin-mode.bin");
     await writeFileAtomic(file, Buffer.from([1, 2, 3]), { mode: 0o600 });
     const stat = statSync(file);

--- a/test/utils/test_fs.ts
+++ b/test/utils/test_fs.ts
@@ -253,8 +253,11 @@ describe("resolveWithinRoot — symlinked root directory (A1 regression)", () =>
     removeScratch(realRoot);
   });
 
-  it("resolves child paths against the realpath of a symlinked root", () => {
-    if (!existsSync(symlinkRoot)) return; // platform skip
+  it("resolves child paths against the realpath of a symlinked root", (ctx) => {
+    if (!existsSync(symlinkRoot)) {
+      ctx.skip("symlink creation unsupported on this platform");
+      return;
+    }
     // Caller realpaths the root once at module load — this is the
     // pattern routes/mulmo-script.ts uses for ensureStoriesReal().
     const rootReal = realpathSync(symlinkRoot);
@@ -263,15 +266,21 @@ describe("resolveWithinRoot — symlinked root directory (A1 regression)", () =>
     assert.equal(out, path.join(realRoot, "story.json"));
   });
 
-  it("resolves nested paths under a symlinked root", () => {
-    if (!existsSync(symlinkRoot)) return;
+  it("resolves nested paths under a symlinked root", (ctx) => {
+    if (!existsSync(symlinkRoot)) {
+      ctx.skip("symlink creation unsupported on this platform");
+      return;
+    }
     const rootReal = realpathSync(symlinkRoot);
     const out = resolveWithinRoot(rootReal, "sub/nested.mp4");
     assert.equal(out, path.join(realRoot, "sub", "nested.mp4"));
   });
 
-  it("rejects traversal even when the root is the realpath of a symlink", () => {
-    if (!existsSync(symlinkRoot)) return;
+  it("rejects traversal even when the root is the realpath of a symlink", (ctx) => {
+    if (!existsSync(symlinkRoot)) {
+      ctx.skip("symlink creation unsupported on this platform");
+      return;
+    }
     const rootReal = realpathSync(symlinkRoot);
     assert.equal(resolveWithinRoot(rootReal, "../../etc/passwd"), null);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5336,23 +5336,23 @@ eslint-plugin-security@^4.0.1:
   dependencies:
     safe-regex "^2.1.1"
 
-eslint-plugin-sonarjs@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.1.0.tgz#61879e5a8536a5e53b5240187cc113a683f7105e"
-  integrity sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw==
+eslint-plugin-sonarjs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz#34fb67be392c3f49875ce5405e02d62f2f860304"
+  integrity sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==
   dependencies:
     "@eslint-community/regexpp" "^4.12.2"
     builtin-modules "^3.3.0"
     bytes "^3.1.2"
     functional-red-black-tree "^1.0.1"
-    globals "^17.6.0"
+    globals "^17.7.0"
     jsx-ast-utils-x "^0.1.0"
     lodash.merge "^4.6.2"
     minimatch "^10.2.5"
     scslre "^0.3.0"
-    semver "^7.8.4"
+    semver "^7.8.5"
     ts-api-utils "^2.5.0"
-    typescript ">=5"
+    typescript ">=5 <6.1.0"
     yaml "^2.9.0"
 
 eslint-plugin-vue@^10.8.0, eslint-plugin-vue@^10.9.2:
@@ -6039,7 +6039,7 @@ globals@^14.0.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-14.0.0.tgz#898d7413c29babcf6bafe56fcadded858ada724e"
   integrity sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==
 
-globals@^17.0.0, globals@^17.6.0, globals@^17.7.0:
+globals@^17.0.0, globals@^17.7.0:
   version "17.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.7.0.tgz#553d55090b4dde8209ec2da42580d6e7e7d8b10d"
   integrity sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==
@@ -8843,7 +8843,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.8.4, semver@^7.8.5:
+semver@^7.3.5, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.8.5:
   version "7.8.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -9668,7 +9668,7 @@ typescript-eslint@^8.64.0:
     "@typescript-eslint/typescript-estree" "8.64.0"
     "@typescript-eslint/utils" "8.64.0"
 
-typescript@>=5, typescript@^6.0.3, typescript@~6.0.2:
+"typescript@>=5 <6.1.0", typescript@^6.0.3, typescript@~6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==


### PR DESCRIPTION
## Summary

Bumps `eslint-plugin-sonarjs` `^4.1.0` → `^4.2.0` (installed 4.2.0; `yarn.lock` updated). 4.2 turns on two rules that surfaced **29 pre-existing violations**, all in tests. All are now fixed and `yarn lint` / `yarn typecheck` / `yarn build` are green.

- **`sonarjs/no-fixed-wait-in-tests` — 22 fixed** (`page.waitForTimeout(...)` in `e2e/tests/*.spec.ts`)
  - **8 replaced with a real observable condition:**
    - Redundant fixed wait removed where the *next* auto-retrying assertion already synchronizes (`toBeVisible` / `.toPass(...)` / a header-visible helper).
    - `waitForTimeout` swapped for `await expect.poll(() => ...)` on the actual signal (fetch count reached, agent POST count reached).
    - Cancel/no-launch case swapped to `await expect(modal).toBeHidden()` before the negative assertion.
  - **14 kept behind `eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- <reason>`** — these are genuine **negative/absence assertions** ("must NOT navigate / must NOT send / no double-fire") or **timed debounce / deliberately-delayed mock** waits, which have no observable positive signal to synchronize on. Each carries a one-line justification.
- **`sonarjs/explicit-test-skip` — 7 fixed** (`node:test` `it()` callbacks that `return`-ed early on a platform/uid guard). Converted each bare early `return` into `ctx.skip("<reason>")` + `return`, threading the `TestContext` param (named `ctx` to satisfy `id-length`). No tests were un-skipped; reasons describe the real skip condition (Windows chmod no-op, root bypasses chmod, symlink unsupported).

### Approach for the `no-fixed-wait` waits (per-file)

| File | Fixed | How |
|---|---|---|
| `image-plugins.spec.ts` | 4 | 3 waits removed (following `toBeVisible`/`toPass` sync); 1 replaced with a tool-results-rendered anchor before the broken-`<img>` check |
| `ime-enter.spec.ts` | 5 | 1 → `expect.poll(agentCalls.length).toBe(1)` (positive send); 4 disabled (no-send / 30 ms IME race window) |
| `collection-contribute.spec.ts` | 3 | 1 → `expect(modal).toBeHidden()`; 2 disabled (double-fire guard) |
| `collection-new-collection-modal.spec.ts` | 3 | 3 disabled (opening/starter/free-form must not auto-send) |
| `a11y-clickable-rows.spec.ts` | 2 | 2 disabled (synthetic keydown must not navigate) |
| `history-panel.spec.ts` | 1 | → `expect.poll(sessionFetchCount).toBeGreaterThan(0)` |
| `present-mulmo-script.spec.ts` | 1 | removed (`assertScriptHeader` synchronizes; dropped now-unused `ONE_SECOND_MS` import) |
| `queries-panel.spec.ts` | 1 | disabled (Shift+click fills input, must not send) |
| `stack-map-grouping-scroll.spec.ts` | 2 | disabled (delayed pubsub delivery + auto-scroll suppression debounce) |

## Items to Confirm / Review

- **The 14 `eslint-disable` justifications.** Each is a negative assertion or a timed window with no positive observable. Reviewer should sanity-check that none of these actually *has* a clean observable I missed (I read each test's surrounding logic and downstream one-shot assertions).
- **`ctx.skip()` semantics.** In `node:test`, `context.skip(msg)` marks the test skipped but does not abort execution, so each call is paired with `return`. Behaviour is unchanged vs. the previous bare `return`.
- **e2e suite not run here** (needs a server) — the `waitFor` replacements were derived by reading each test; a CI e2e pass is the real confirmation.

## User Prompt

Bump `eslint-plugin-sonarjs` from 4.1 to 4.2 in the root `package.json` (run `yarn install`), then fix the ~29 pre-existing test violations its new rules surface:
- `sonarjs/no-fixed-wait-in-tests` (~22): replace each `page.waitForTimeout(<ms>)` fixed wait in `e2e/tests/*.spec.ts` with a condition-based wait on an observable condition, matching what the fixed wait was actually waiting for. Don't just delete the wait; where there's genuinely no observable signal (animation/debounce), use the rule's sanctioned per-line disable with a justification.
- `sonarjs/explicit-test-skip` (~7): add the explicit reason the rule wants to each skip; don't un-skip tests.

Iterate until `yarn lint` is green, and `yarn typecheck` + `yarn build` pass. Never blanket-disable a rule file-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)