### PR TITLE
fix(chat): catch up a text card truncated mid-stream after socket.io reconnect (#2096)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -372,7 +372,7 @@ import { parseCollectionSlashSeed, makeSyntheticCollectionResult, hasRealCollect
 import { mergeBufferedIntoDraft } from "./utils/chat/buffer";
 import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
-import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
+import { buildLoadedSession, parseSessionEntries, shouldAdoptServerTranscript } from "./utils/session/sessionEntries";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { loadCspExtra } from "./composables/useCspExtra";
 import { cspViolations, dismissCspViolations, installCspViolationListener } from "./composables/useCspViolations";
@@ -991,10 +991,12 @@ async function refreshSessionTranscript(sessionId: string): Promise<void> {
   if (!response.ok) return;
   const summary = sessions.value.find((entry) => entry.id === sessionId);
   const serverResults = parseSessionEntries(response.data, summary?.origin);
-  // Only patch if the server knows more than we do — avoids
-  // replacing a richer in-flight state with a stale snapshot when
-  // session_finished races with the last few events.
-  if (serverResults.length > session.toolResults.length) {
+  // Only patch if the server knows more than we do — avoids replacing a
+  // richer in-flight state with a stale snapshot when session_finished
+  // races with the last few events. Compares total text, not just card
+  // count, so a text card truncated by a dropped socket.io frame (same
+  // count, shorter body) is still caught up (#2096).
+  if (shouldAdoptServerTranscript(serverResults, session.toolResults)) {
     session.toolResults = serverResults;
   }
 }

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -5,7 +5,7 @@
 //
 // Tracks #175.
 
-import { makeSkillResult, makeTextResult } from "../tools/result";
+import { makeSkillResult, makeTextResult, TEXT_LIKE_RESULT_TOOL_NAMES } from "../tools/result";
 import {
   isSessionOrigin,
   isSkillEntry,
@@ -87,12 +87,16 @@ export function resolveSelectedUuid(toolResults: readonly ToolResultComplete[]):
   return toolResults[toolResults.length - 1].uuid;
 }
 
-// Total character length of every card body. A streamed assistant text
-// card carries its running text in `message`, so this grows as text
-// arrives — the signal we use to spot a card that was truncated when a
-// socket.io frame dropped (#2096).
-function totalMessageLength(results: readonly ToolResultComplete[]): number {
-  return results.reduce((sum, result) => sum + (result.message?.length ?? 0), 0);
+// Total character length of the STREAMED-TEXT card bodies. Only text and
+// skill cards keep their running text in `message` (TEXT_LIKE_RESULT_TOOL_NAMES),
+// and only those grow token-by-token — so only those can be truncated by a
+// dropped socket.io frame while the card COUNT stays equal. Other cards
+// (images, charts, …) carry their payload in `data`, arrive complete in one
+// frame, and are caught by the card-count check — so they're excluded here to
+// avoid a `message` diff on a non-streamed card skewing the decision (#2096,
+// Sourcery review).
+function streamedTextLength(results: readonly ToolResultComplete[]): number {
+  return results.reduce((sum, result) => (TEXT_LIKE_RESULT_TOOL_NAMES.has(result.toolName) ? sum + (result.message?.length ?? 0) : sum), 0);
 }
 
 /** Decide whether a reconnect / finished catch-up should replace the
@@ -110,7 +114,7 @@ export function shouldAdoptServerTranscript(serverResults: readonly ToolResultCo
   if (serverResults.length !== clientResults.length) {
     return serverResults.length > clientResults.length;
   }
-  return totalMessageLength(serverResults) > totalMessageLength(clientResults);
+  return streamedTextLength(serverResults) > streamedTextLength(clientResults);
 }
 
 // Decide the `startedAt` / `updatedAt` to seed the in-memory

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -87,6 +87,32 @@ export function resolveSelectedUuid(toolResults: readonly ToolResultComplete[]):
   return toolResults[toolResults.length - 1].uuid;
 }
 
+// Total character length of every card body. A streamed assistant text
+// card carries its running text in `message`, so this grows as text
+// arrives — the signal we use to spot a card that was truncated when a
+// socket.io frame dropped (#2096).
+function totalMessageLength(results: readonly ToolResultComplete[]): number {
+  return results.reduce((sum, result) => sum + (result.message?.length ?? 0), 0);
+}
+
+/** Decide whether a reconnect / finished catch-up should replace the
+ *  client's in-memory transcript with the server's copy.
+ *
+ *  - Server has MORE cards → adopt (the client missed whole events).
+ *  - Same card count but MORE total text on the server → adopt: a dropped
+ *    socket.io frame truncated a streamed text card, so the counts match
+ *    yet the last card's body is cut off (#2096). Card-count alone missed
+ *    this, leaving "…理由によ" on screen until a reload.
+ *  - Otherwise keep the client copy — never overwrite a richer or equal
+ *    in-flight state with an equal-or-staler snapshot (the #1915 guard
+ *    that stops a `session_finished` race from clobbering live events). */
+export function shouldAdoptServerTranscript(serverResults: readonly ToolResultComplete[], clientResults: readonly ToolResultComplete[]): boolean {
+  if (serverResults.length !== clientResults.length) {
+    return serverResults.length > clientResults.length;
+  }
+  return totalMessageLength(serverResults) > totalMessageLength(clientResults);
+}
+
 // Decide the `startedAt` / `updatedAt` to seed the in-memory
 // ActiveSession with. We prefer the server summary's timestamps
 // so the restored session keeps its existing sidebar ordering;

--- a/test/utils/session/test_sessionEntries.ts
+++ b/test/utils/session/test_sessionEntries.ts
@@ -307,4 +307,15 @@ describe("shouldAdoptServerTranscript", () => {
     assert.equal(shouldAdoptServerTranscript([], []), false);
     assert.equal(shouldAdoptServerTranscript([card("a")], []), true);
   });
+
+  it("ignores non-text (tool) card message diffs — only streamed text/skill bodies count (Sourcery review)", () => {
+    const toolCard = (message: string): ToolResultComplete =>
+      ({ uuid: "img", toolName: "generateImage", message, title: "Image", data: { url: "x" } }) as ToolResultComplete;
+    // Same card count; only the non-streamed tool card's `message` differs.
+    // Its payload lives in `data` and it arrives complete, so it must NOT
+    // trigger adoption on its own.
+    const server = [card("hi"), toolCard("done rendering the sunset image")];
+    const client = [card("hi"), toolCard("rendering")];
+    assert.equal(shouldAdoptServerTranscript(server, client), false);
+  });
 });

--- a/test/utils/session/test_sessionEntries.ts
+++ b/test/utils/session/test_sessionEntries.ts
@@ -3,7 +3,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseSessionEntries, resolveSelectedUuid, resolveSessionTimestamps } from "../../../src/utils/session/sessionEntries.js";
+import { parseSessionEntries, resolveSelectedUuid, resolveSessionTimestamps, shouldAdoptServerTranscript } from "../../../src/utils/session/sessionEntries.js";
 import type { SessionEntry, SessionSummary } from "../../../src/types/session.js";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
@@ -269,5 +269,42 @@ describe("resolveSessionTimestamps", () => {
       startedAt: now,
       updatedAt: now,
     });
+  });
+});
+
+// --- shouldAdoptServerTranscript (#2096) --------------------------
+
+describe("shouldAdoptServerTranscript", () => {
+  const card = (message: string): ToolResultComplete =>
+    ({ uuid: message, toolName: "text-response", message, title: "Assistant", data: {} }) as ToolResultComplete;
+
+  it("adopts when the server has more cards (client missed events)", () => {
+    assert.equal(shouldAdoptServerTranscript([card("a"), card("b")], [card("a")]), true);
+  });
+
+  it("adopts when card counts match but a text card was truncated mid-stream (#2096)", () => {
+    // Same 2 cards, but the client's last card is cut off ("理由によ")
+    // while the server has the full body — the dropped-frame case.
+    const server = [card("intro"), card("理由によって打ち手が全然違う。次の一手として、…")];
+    const client = [card("intro"), card("理由によ")];
+    assert.equal(shouldAdoptServerTranscript(server, client), true);
+  });
+
+  it("keeps the client copy when counts and total text are equal (no clobber on a finished race)", () => {
+    const same = [card("intro"), card("done")];
+    assert.equal(shouldAdoptServerTranscript(same, [card("intro"), card("done")]), false);
+  });
+
+  it("keeps the client copy when the client has richer in-flight text than the server snapshot", () => {
+    assert.equal(shouldAdoptServerTranscript([card("short")], [card("a much longer live body")]), false);
+  });
+
+  it("keeps the client copy when the server has fewer cards (stale snapshot)", () => {
+    assert.equal(shouldAdoptServerTranscript([card("a")], [card("a"), card("b")]), false);
+  });
+
+  it("handles empty transcripts", () => {
+    assert.equal(shouldAdoptServerTranscript([], []), false);
+    assert.equal(shouldAdoptServerTranscript([card("a")], []), true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2096. `refreshSessionTranscript()` only adopted the server's transcript when the server had **more cards** than the client. When a socket.io frame dropped mid-stream, the last assistant text card's body was **cut off** ("…理由によ") while the card **count** stayed equal — so the count-only check never fired, and the partial text stuck on screen until a reload.

**Fix:** extract the decision into a pure helper `shouldAdoptServerTranscript()` that adopts the server copy on *more cards* (unchanged) **or** on *equal card count with more total text* (the truncated-frame case). Equal-or-less text keeps the client copy.

## Items to Confirm / Review

- **Independently verified the bug is still live** on current `main`: `App.vue:997` is `serverResults.length > session.toolResults.length` — count only.
- **The #1915 guard is preserved.** The original comment warns against replacing a richer in-flight state with a stale snapshot when `session_finished` races the last events. The new helper still returns `false` when the server has fewer cards OR equal cards with ≤ text — so a live client that's momentarily ahead is never clobbered; it only catches up when the server genuinely carries more text.
- **This is the follow-up to #1934** (the #1915 catch-up logic), whose comparison this widens from card-count to total-text.

## Tests

`test_sessionEntries.ts` — `shouldAdoptServerTranscript`: more server cards → adopt; equal count + truncated text (the #2096 "理由によ" → full body case) → adopt; equal count + equal text → keep (no finished-race clobber); client richer than server → keep; fewer server cards → keep; empty transcripts.

Gates: format / typecheck / build green; changed files lint-clean; tests 30/0.

## User Prompt

Among the triaged bugs, address #2096 — first independently re-verify the problem exists in current code (don't trust the prior report), then design and apply the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure client chat transcript is refreshed from the server when reconnecting if the server has strictly more content, preventing truncated assistant text after dropped frames.

Bug Fixes:
- Fix chat sessions getting stuck with partially streamed assistant text when a socket.io frame is dropped mid-stream by adopting the fuller server transcript on reconnect.

Enhancements:
- Introduce a helper to decide when to adopt the server transcript based on both card count and total text length, keeping richer in-flight client state intact.

Tests:
- Add unit tests covering shouldAdoptServerTranscript behavior for differing card counts, truncated text, equal content, richer client content, fewer server cards, and empty transcripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session transcript synchronization after reconnects using content-aware server vs. client comparison.
  * Prevented in-progress (including truncated) streamed text from being overwritten by a less complete server snapshot.
  * Restores truncated streamed content when the server transcript is determined to be more complete, not merely by card count.

* **Tests**
  * Added unit coverage for server adoption decisions, including truncation handling, stale snapshots, equal-content cases, and empty-session scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->