### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`mulmoclaude@1.1.1` を npm publish 済み（`/publish-mulmoclaude` フロー）。launcher + root を lockstep で 1.1.1 に。

## Items to Confirm / Review

- publish 済み・フレッシュ `npx mulmoclaude@1.1.1 --version` 検証済み（core 0.20.1 / google-plugin 0.1.1 を含む全依存の registry 解決を確認）
- deps / drift / @mulmoclaude/* local↔npm 一致 / launcher-sync すべてクリーン、main の publish smoke green
- 1.1.0 との差分: README のトークンパス表記（`~/.config/mulmo/`）+ core ^0.20.1 / google-plugin ^0.1.1 range（#2124）

## User Prompt

- 「mulmoclaude も新たに publish して」「1.1.0 の release も無いので、終わったらまとめて changelog 含めて作って release まで」

マージ後、v1.1.0 / v1.1.1 の app release（CHANGELOG 込み）を作成予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)