### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -29,7 +29,8 @@ Your browser opens to `http://localhost:3001`. That's it.
 | "Schedule a daily news digest"  | Recurring task that runs automatically                |
 | "Generate an image of a sunset" | AI-generated image (Gemini)                           |
 | "Make slides on …"              | Marp-rendered slide deck with PDF export              |
-| "Add this to my calendar"       | Event in your Google Calendar (local OAuth link)      |
+| "Add this to my calendar"       | Event in your Google Calendar (sign in, no setup)     |
+| "Put that on my task list"      | Task in Google Tasks, with notes and a due date       |
 | "Subscribe to this RSS feed"    | Data feed on `/feeds`, fetched on a schedule          |
 
 **Pages you can visit directly**: `/wiki` (browse + lint), `/feeds` (data feeds), `/collections` (data apps — Discover tab to import community collections, Contribute to share your own), `/automations` (recurring tasks), `/files`, `/skills`, `/roles`. Each page has its own chat composer that spawns a fresh chat already aware of the page context.

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`mulmoclaude@1.2.0` を npm publish 済み。launcher + root を lockstep で 1.2.0 に。

## Items to Confirm / Review

- **この publish は必須だった**: 0.x パッケージの caret は patch しか跨がないため、公開済み launcher 1.1.1 の range（`core: ^0.20.1` / `google-plugin: ^0.1.1`）では **#2115 の Tasks / Drive も #2131 の broker も解決されなかった**。1.1.1 のユーザーには Calendar までしか届いていない状態だった
- フレッシュ `npx mulmoclaude@1.2.0 --version` で全依存の registry 解決を検証済み
- deps / drift / `@mulmoclaude/*` local↔npm 一致 / launcher-sync すべてクリーン
- minor バンプの理由: Tasks / Drive ツールと broker 連携という新機能を含むため

## 1.1.1 → 1.2.0 の内容

- **Google Tasks / Drive ツール**（#2115 / PR #2132）— `google` ツールに 7 kind 追加。Drive は `drive.file`（アプリ作成分のみ）
- **GCP 設定なしの Google 連携**（#2131 / PR #2135）— mulmoserver broker が client secret を代行、トークンはローカルのみ。自前 desktop クライアントがあればフルローカル経路
- **連携案内の host 中立化**（#2128 / PR #2130）
- README: Tasks の例を追加、Google 連携の説明を「設定不要」に更新

## User Prompt

- 「これおわったらpublish必要なものある？」→「おけおけ。それをすすめて。おわったらmulmoterminalにissueたてて、それをひきつげるように。」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Calendar additions now require only sign-in, with no additional setup.

- **Documentation**
  - Updated capability information to reflect the simplified calendar setup.

- **Chores**
  - Released version 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->