### PR TITLE
refactor(server): dedup /artifacts path-guards and directory-tree builders

### DIFF
--- a/plans/refactor-dedup-server-path-guards.md
+++ b/plans/refactor-dedup-server-path-guards.md
@@ -1,0 +1,72 @@
+# refactor: dedup artifact path-guards + directory-tree builders (server/)
+
+Issue: #2140
+
+## Context
+
+The `duplication-scan` (jscpd) Code Scanning gate (#2129) surfaced ~192
+clone pairs. Most are natural duplication that should NOT be touched
+(per-package `vite.config.ts`, per-plugin `lang/*` i18n, `bridges/*`
+adapter boilerplate, cross-package pairs that can't be DRY'd without
+violating the dependency-direction rules). This PR fixes the subset that
+IS genuine knowledge duplication: two clusters in `server/`, both fully
+inside host code (no package-boundary concerns).
+
+## What this fixes
+
+### 1. `server/index.ts` — `/artifacts/{images,html,svg}` mounts
+
+All three static mounts inlined the same path guard: decode the request
+path (fail-closed on malformed `%`), realpath-confine it under the
+storage root, and (html/svg) reject dotfile segments. Three copies of a
+**security guard** is exactly the `truncate()`-grew-to-6 hazard (#1304):
+a fix has to land in all three or one drifts.
+
+- Extract `resolveArtifactRequestPath(rootReal, reqPath, denyDotfiles)`
+  into `safe.ts` (co-located with `resolveWithinRoot` /
+  `containsDotfileSegment`).
+- Extract `makeCachedRealpath(dir)` — the three `getXDirReal()` getters
+  were the same lazy-cached-realpath pattern.
+- Behaviour preserved exactly: images passes `denyDotfiles: false` (it
+  never short-circuits, so `express.static`'s `dotfiles: "deny"` stays
+  the authority); html/svg pass `true` (they serve the file themselves,
+  bypassing express.static).
+
+### 2. `server/api/routes/files.ts` — tree builders
+
+The directory-entry visibility filter (hidden/sensitive/symlink/
+gitignore/stat) was copied between the recursive `buildTreeAsync` and
+`dirEntryToNode`; the assemble-and-sort tail was copied between
+`buildTreeAsync` and `listDirShallow`.
+
+- Extract `resolveVisibleChild(entry, absPath, relPath, localFilter)`
+  and `assembleDirNode(childPromises, relPath, modifiedMs)`.
+- Covered by existing `test_filesTreeAsync.ts` / `test_filesRoute.ts`.
+
+## Deliberately NOT in this PR
+
+- `files.ts` POST-create / PUT-content validation preamble — the two
+  handlers diverge; extracting risks over-abstraction.
+- `agent/stream.ts` stateful vs stateless parser — intentionally
+  separate; DRYing would couple the test-convenience path to production.
+- Package-level duplication (bridges, cross-package) — will go in a
+  follow-up via a shared/common package (the "pull shared code into
+  core / a leaf lib" pattern), not addressed here.
+
+Also queued for follow-up server-route dedup: `wiki/history.ts`
+(snapshot-param preamble), `collections.ts` (custom-view resolve).
+
+## Result
+
+jscpd clone pairs (same base, `--format typescript`, tests excluded):
+**192 → 187** (index.ts 3→0, files.ts 4→2). The two remaining files.ts
+pairs are the deliberately-skipped route preamble + one cross-file pair.
+
+## Verification
+
+- New unit test `test/utils/files/test_safe_artifact.ts` locks the
+  extracted guard (in-root accept, malformed-`%` reject, traversal
+  reject, dotfile deny/allow per flag, encoded-backslash, cached
+  realpath).
+- `yarn lint` / `typecheck:server` / `typecheck:test` clean; existing
+  file-tree + safe tests pass (96/96).

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -452,6 +452,53 @@ function pipeWithErrorHandling(stream: ReadStream, res: Response<ErrorResponse>)
   stream.pipe(res);
 }
 
+// Apply the UI-visibility filters (hidden dirs, sensitive files,
+// symlinks, .gitignore matches) to a single directory entry and stat
+// it. Returns the resolved child paths + stat, or null when the entry
+// should not surface. The recursive walk and the shallow lazy-expand
+// path share this so the filter policy lives in exactly one place.
+async function resolveVisibleChild(
+  entry: Dirent,
+  absPath: string,
+  relPath: string,
+  localFilter: GitignoreFilter | undefined,
+): Promise<{ childRel: string; childAbs: string; childStat: Stats } | null> {
+  if (HIDDEN_DIRS.has(entry.name)) return null;
+  if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
+  if (entry.isSymbolicLink()) return null;
+  const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
+  // .gitignore check: for directories, append trailing / so
+  // directory-only patterns (e.g. "node_modules/") match.
+  if (localFilter) {
+    const testPath = entry.isDirectory() ? `${childRel}/` : childRel;
+    if (localFilter.ignores(testPath)) return null;
+  }
+  const childAbs = path.join(absPath, entry.name);
+  const childStat = await statSafeAsync(childAbs);
+  if (!childStat) return null;
+  return { childRel, childAbs, childStat };
+}
+
+// Await a directory's child-node promises, drop the filtered-out nulls,
+// sort (dirs before files, alphabetical within type), and wrap them in
+// the parent's `dir` TreeNode. Shared by the recursive and shallow
+// builders so the assembly + ordering is defined once.
+async function assembleDirNode(childPromises: Promise<TreeNode | null>[], relPath: string, modifiedMs: number): Promise<TreeNode> {
+  const resolved = await Promise.all(childPromises);
+  const children = resolved.filter((childNode): childNode is TreeNode => childNode !== null);
+  children.sort((leftChild, rightChild) => {
+    if (leftChild.type !== rightChild.type) return leftChild.type === "dir" ? -1 : 1;
+    return leftChild.name.localeCompare(rightChild.name);
+  });
+  return {
+    name: relPath ? path.basename(relPath) : "",
+    path: relPath,
+    type: "dir",
+    modifiedMs,
+    children,
+  };
+}
+
 // Async workspace tree walker — recurses through the workspace with
 // the same security filters as the original sync implementation
 // (hidden dirs, sensitive files, symlinks all rejected) and the same
@@ -489,55 +536,23 @@ export async function buildTreeAsync(absPath: string, relPath: string, gitFilter
   // root .gitignore (it's for git, not the UI). Pass a fresh empty
   // filter so children pick up THEIR .gitignore files.
   const localFilter = gitFilter ? gitFilter.childForDir(absPath) : new GitignoreFilter();
-  // Build every surviving child concurrently. Filter:
-  // skip hidden dirs, sensitive files, symlinks, .gitignore matches,
-  // and entries that fail to stat.
+  // Build every surviving child concurrently, recursing into the ones
+  // that pass the visibility filter.
   const childPromises: Promise<TreeNode | null>[] = entries.map(async (entry): Promise<TreeNode | null> => {
-    if (HIDDEN_DIRS.has(entry.name)) return null;
-    if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
-    if (entry.isSymbolicLink()) return null;
-    const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
-    // .gitignore check: for directories, append trailing / so
-    // directory-only patterns (e.g. "node_modules/") match.
-    if (localFilter) {
-      const testPath = entry.isDirectory() ? `${childRel}/` : childRel;
-      if (localFilter.ignores(testPath)) return null;
-    }
-    const childAbs = path.join(absPath, entry.name);
-    const childStat = await statSafeAsync(childAbs);
-    if (!childStat) return null;
-    return buildTreeAsync(childAbs, childRel, localFilter);
+    const child = await resolveVisibleChild(entry, absPath, relPath, localFilter);
+    if (!child) return null;
+    return buildTreeAsync(child.childAbs, child.childRel, localFilter);
   });
-  const resolved = await Promise.all(childPromises);
-  const children = resolved.filter((childNode): childNode is TreeNode => childNode !== null);
-  children.sort((leftChild, rightChild) => {
-    if (leftChild.type !== rightChild.type) return leftChild.type === "dir" ? -1 : 1;
-    return leftChild.name.localeCompare(rightChild.name);
-  });
-  return {
-    name: relPath ? path.basename(relPath) : "",
-    path: relPath,
-    type: "dir",
-    modifiedMs: stat.mtimeMs,
-    children,
-  };
+  return assembleDirNode(childPromises, relPath, stat.mtimeMs);
 }
 
 // Map a single directory entry to a shallow TreeNode, applying the
 // same hidden/sensitive/symlink/gitignore filters as the recursive
 // walk. Returns null for entries that should not surface in the UI.
 async function dirEntryToNode(entry: Dirent, absPath: string, relPath: string, localFilter: GitignoreFilter | undefined): Promise<TreeNode | null> {
-  if (HIDDEN_DIRS.has(entry.name)) return null;
-  if (!entry.isDirectory() && isSensitivePath(entry.name)) return null;
-  if (entry.isSymbolicLink()) return null;
-  const childRel = relPath ? path.join(relPath, entry.name) : entry.name;
-  if (localFilter) {
-    const testPath = entry.isDirectory() ? `${childRel}/` : childRel;
-    if (localFilter.ignores(testPath)) return null;
-  }
-  const childAbs = path.join(absPath, entry.name);
-  const childStat = await statSafeAsync(childAbs);
-  if (!childStat) return null;
+  const child = await resolveVisibleChild(entry, absPath, relPath, localFilter);
+  if (!child) return null;
+  const { childRel, childStat } = child;
   if (childStat.isDirectory()) {
     return {
       name: entry.name,
@@ -580,19 +595,7 @@ export async function listDirShallow(absPath: string, relPath: string, gitFilter
   // filter so children pick up THEIR .gitignore files.
   const localFilter = gitFilter ? gitFilter.childForDir(absPath) : new GitignoreFilter();
   const childPromises = entries.map((entry) => dirEntryToNode(entry, absPath, relPath, localFilter));
-  const resolved = await Promise.all(childPromises);
-  const children = resolved.filter((childNode): childNode is TreeNode => childNode !== null);
-  children.sort((leftChild, rightChild) => {
-    if (leftChild.type !== rightChild.type) return leftChild.type === "dir" ? -1 : 1;
-    return leftChild.name.localeCompare(rightChild.name);
-  });
-  return {
-    name: relPath ? path.basename(relPath) : "",
-    path: relPath,
-    type: "dir",
-    modifiedMs: stat.mtimeMs,
-    children,
-  };
+  return assembleDirNode(childPromises, relPath, stat.mtimeMs);
 }
 
 router.get(API_ROUTES.files.tree, async (_req: Request<object, unknown, unknown, object>, res: Response<TreeNode | ErrorResponse>) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -97,8 +97,7 @@ import { migrateCookingRecipesFromPlugin } from "./workspace/cooking-recipes/mig
 import { env, isAblated, isGeminiAvailable } from "./system/env.js";
 import { buildSandboxStatus } from "./api/sandboxStatus.js";
 import { existsSync, readFileSync } from "fs";
-import { realpath as fsRealpath } from "fs/promises";
-import { containsDotfileSegment, resolveWithinRoot } from "./utils/files/safe.js";
+import { makeCachedRealpath, resolveArtifactRequestPath } from "./utils/files/safe.js";
 import { cpus, loadavg } from "os";
 import { isDockerAvailable, ensureSandboxImage } from "./system/docker.js";
 import { maybeRunJournal } from "./workspace/journal/index.js";
@@ -355,17 +354,7 @@ app.use("/api", (req, res, next) => {
 //  3. `dotfiles: deny` + `fallthrough: false` on `express.static`
 //     itself, plus its built-in `..` normalize for path traversal.
 const IMAGE_EXT_RE = /\.(png|jpe?g|webp|gif|svg|mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)$/i;
-let imagesDirReal: string | null = null;
-async function getImagesDirReal(): Promise<string | null> {
-  if (imagesDirReal) return imagesDirReal;
-  try {
-    imagesDirReal = await fsRealpath(WORKSPACE_PATHS.images);
-    return imagesDirReal;
-  } catch {
-    // Dir not yet materialised (fresh workspace, no image saved).
-    return null;
-  }
-}
+const getImagesDirReal = makeCachedRealpath(WORKSPACE_PATHS.images);
 app.use(
   "/artifacts/images",
   async (req, res, next) => {
@@ -378,17 +367,9 @@ app.use(
       res.status(404).end();
       return;
     }
-    let relPath: string;
-    try {
-      // decodeURIComponent throws URIError on malformed escapes
-      // (`%ZZ`, stray `%`). Fail closed so a junk URL returns 404
-      // instead of bubbling a 500 out of the express error chain.
-      relPath = decodeURIComponent(req.path.replace(/^\//, ""));
-    } catch {
-      res.status(404).end();
-      return;
-    }
-    if (!resolveWithinRoot(root, relPath)) {
+    // No explicit dotfile check here: this mount never short-circuits,
+    // so `express.static`'s `dotfiles: "deny"` below is the authority.
+    if (resolveArtifactRequestPath(root, req.path, false) === null) {
       res.status(404).end();
       return;
     }
@@ -444,16 +425,7 @@ app.use(
 // eslint-disable-next-line sonarjs/regex-complexity -- flat extension allowlist with no nested quantifiers, ReDoS-safe; complexity is just the disjunction count
 const HTML_PREVIEW_EXT_RE = /\.(html?|png|jpe?g|webp|gif|svg|ico|mp4|webm|mov|m4v|ogv|mp3|ogg|oga|wav|m4a|aac)$/i;
 const HTML_DOCUMENT_EXT_RE = /\.html?$/i;
-let htmlsDirReal: string | null = null;
-async function getHtmlsDirReal(): Promise<string | null> {
-  if (htmlsDirReal) return htmlsDirReal;
-  try {
-    htmlsDirReal = await fsRealpath(WORKSPACE_PATHS.htmls);
-    return htmlsDirReal;
-  } catch {
-    return null;
-  }
-}
+const getHtmlsDirReal = makeCachedRealpath(WORKSPACE_PATHS.htmls);
 
 // Honour `X-Forwarded-*` so dev (Vite proxies `/artifacts/html` →
 // `localhost:3001` with `changeOrigin: true`) emits the browser-
@@ -492,26 +464,13 @@ app.use(
       res.status(404).end();
       return;
     }
-    let relPath: string;
-    try {
-      relPath = decodeURIComponent(req.path.replace(/^\//, ""));
-    } catch {
-      res.status(404).end();
-      return;
-    }
-    if (!resolveWithinRoot(root, relPath)) {
-      res.status(404).end();
-      return;
-    }
-    // Dotfile deny — `express.static` below enforces this for the
-    // non-HTML branch via `dotfiles: "deny"`, but the HTML short-
-    // circuit added in #1056 was bypassing the guard and would
-    // happily serve `/artifacts/html/.hidden.html` (Codex review on
-    // #1056). Apply the same policy uniformly so both branches
-    // refuse any path component starting with `.`. The helper
-    // splits on both `/` and `\` so an encoded backslash (`%5C`)
-    // can't sneak a `dir\.hidden.html` past the check on Windows.
-    if (containsDotfileSegment(relPath)) {
+    // denyDotfiles: the HTML short-circuit below serves the file itself
+    // (bypassing `express.static`'s `dotfiles: "deny"`), so this mount
+    // must reject dotfile segments in the guard — without it,
+    // `/artifacts/html/.hidden.html` would be served (Codex review on
+    // #1056).
+    const relPath = resolveArtifactRequestPath(root, req.path, true);
+    if (relPath === null) {
       res.status(404).end();
       return;
     }
@@ -564,16 +523,7 @@ const SVG_RESPONSE_CSP = "default-src 'none'; style-src 'unsafe-inline'; img-src
 // `<img src>` request can't carry an Authorization header. Loopback-
 // only listener + `requireSameOrigin` remain the trust boundary.
 const SVG_EXT_RE = /\.svg$/i;
-let svgsDirReal: string | null = null;
-async function getSvgsDirReal(): Promise<string | null> {
-  if (svgsDirReal) return svgsDirReal;
-  try {
-    svgsDirReal = await fsRealpath(WORKSPACE_PATHS.svgs);
-    return svgsDirReal;
-  } catch {
-    return null;
-  }
-}
+const getSvgsDirReal = makeCachedRealpath(WORKSPACE_PATHS.svgs);
 app.use(
   "/artifacts/svg",
   async (req, res, next) => {
@@ -586,18 +536,10 @@ app.use(
       res.status(404).end();
       return;
     }
-    let relPath: string;
-    try {
-      relPath = decodeURIComponent(req.path.replace(/^\//, ""));
-    } catch {
-      res.status(404).end();
-      return;
-    }
-    if (!resolveWithinRoot(root, relPath)) {
-      res.status(404).end();
-      return;
-    }
-    if (containsDotfileSegment(relPath)) {
+    // denyDotfiles for the same reason as the html mount: this handler
+    // sets headers and serves via a bearer-bypassed <img> path, so the
+    // dotfile guard can't be left solely to `express.static`.
+    if (resolveArtifactRequestPath(root, req.path, true) === null) {
       res.status(404).end();
       return;
     }

--- a/server/utils/files/safe.ts
+++ b/server/utils/files/safe.ts
@@ -99,6 +99,45 @@ export function hasTraversalSegment(value: string): boolean {
   return value.split(/[/\\]/).some((segment) => segment === ".." || segment === ".");
 }
 
+// Lazily realpath a directory once and cache the result. Returns null
+// until the directory exists on disk (a fresh workspace hasn't created
+// it yet) and retries on the next call. The /artifacts/* static mounts
+// each need their storage root as a realpath for the traversal check,
+// but the root may not be materialised at boot.
+export function makeCachedRealpath(dir: string): () => Promise<string | null> {
+  let cached: string | null = null;
+  return async () => {
+    if (cached) return cached;
+    try {
+      cached = await promises.realpath(dir);
+      return cached;
+    } catch {
+      return null;
+    }
+  };
+}
+
+// Decode and traversal-guard an `/artifacts/*` request path against an
+// already-realpath'd storage root. Returns the in-root relative path to
+// serve, or null when the URL is malformed, escapes the root, or (when
+// `denyDotfiles`) touches a dotfile segment. The images / html / svg
+// static mounts share this so the decode + traversal + dotfile policy is
+// defined once. `rootReal` MUST be a realpath (see `resolveWithinRoot`).
+export function resolveArtifactRequestPath(rootReal: string, reqPath: string, denyDotfiles: boolean): string | null {
+  let relPath: string;
+  try {
+    // decodeURIComponent throws URIError on malformed escapes (`%ZZ`,
+    // stray `%`). Fail closed so a junk URL 404s instead of bubbling a
+    // 500 out of the express error chain.
+    relPath = decodeURIComponent(reqPath.replace(/^\//, ""));
+  } catch {
+    return null;
+  }
+  if (!resolveWithinRoot(rootReal, relPath)) return null;
+  if (denyDotfiles && containsDotfileSegment(relPath)) return null;
+  return relPath;
+}
+
 // `rootReal` MUST already be a realpath. Returns null on traversal or if either path doesn't exist on disk.
 export function resolveWithinRoot(rootReal: string, relPath: string): string | null {
   const normalized = path.normalize(relPath || "");

--- a/test/utils/files/test_safe_artifact.ts
+++ b/test/utils/files/test_safe_artifact.ts
@@ -1,0 +1,90 @@
+// Unit tests for `resolveArtifactRequestPath` and `makeCachedRealpath`,
+// the shared plumbing behind the `/artifacts/{images,html,svg}` static
+// mounts. The three mounts used to inline the same decode + traversal +
+// dotfile guard; these lock the extracted helper's behaviour so a future
+// change can't silently loosen one mount's path safety.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { resolveArtifactRequestPath, makeCachedRealpath } from "../../../server/utils/files/safe.ts";
+
+let rootDir: string;
+let rootReal: string;
+
+before(async () => {
+  rootDir = await mkdtemp(path.join(tmpdir(), "mulmoclaude-artifact-guard-"));
+  rootReal = await realpath(rootDir);
+  await writeFile(path.join(rootReal, "img.png"), "x");
+  await mkdir(path.join(rootReal, "sub"), { recursive: true });
+  await writeFile(path.join(rootReal, "sub", "nested.png"), "x");
+  await writeFile(path.join(rootReal, ".hidden.png"), "x");
+  await mkdir(path.join(rootReal, ".secret"), { recursive: true });
+  await writeFile(path.join(rootReal, ".secret", "in.png"), "x");
+});
+
+after(async () => {
+  if (rootDir) await rm(rootDir, { recursive: true, force: true });
+});
+
+describe("resolveArtifactRequestPath — accepts in-root files", () => {
+  it("returns the decoded relPath for a flat file", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/img.png", false), "img.png");
+  });
+
+  it("returns the decoded relPath for a nested file", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/sub/nested.png", false), "sub/nested.png");
+  });
+
+  it("decodes percent-encoded segments", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/sub%2Fnested.png", false), "sub/nested.png");
+  });
+});
+
+describe("resolveArtifactRequestPath — rejects", () => {
+  it("returns null for a malformed percent-escape (fail closed, no throw)", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/%ZZ.png", false), null);
+    assert.equal(resolveArtifactRequestPath(rootReal, "/%.png", false), null);
+  });
+
+  it("returns null for a traversal escape", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/../outside.png", false), null);
+  });
+
+  it("returns null for a file that does not exist on disk", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/missing.png", false), null);
+  });
+});
+
+describe("resolveArtifactRequestPath — dotfile policy", () => {
+  it("rejects a dotfile when denyDotfiles is true", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/.hidden.png", true), null);
+    assert.equal(resolveArtifactRequestPath(rootReal, "/.secret/in.png", true), null);
+  });
+
+  it("allows the same dotfile when denyDotfiles is false (images mount defers to express.static)", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/.hidden.png", false), ".hidden.png");
+  });
+
+  it("rejects a dotfile hidden behind an encoded backslash on the deny path", () => {
+    assert.equal(resolveArtifactRequestPath(rootReal, "/sub%5C.hidden.png", true), null);
+  });
+});
+
+describe("makeCachedRealpath", () => {
+  it("resolves and caches the directory's realpath", async () => {
+    const get = makeCachedRealpath(rootDir);
+    assert.equal(await get(), rootReal);
+    assert.equal(await get(), rootReal);
+  });
+
+  it("returns null until the directory exists, then resolves once created", async () => {
+    const missing = path.join(rootReal, "not-yet");
+    const get = makeCachedRealpath(missing);
+    assert.equal(await get(), null);
+    await mkdir(missing, { recursive: true });
+    assert.equal(await get(), await realpath(missing));
+  });
+});


### PR DESCRIPTION
## Summary

jscpd の Code Scanning ゲート（#2129）が挙げた重複のうち、**本物の「知識の重複」だけ**を潰す第一弾。`server/`（ホストコード）内で完結する2クラスタ。**挙動は完全保存**の純リファクタ。

- `server/index.ts` — `/artifacts/{images,html,svg}` の3マウントが**パス検証ガードを丸ごと重複**（セキュリティガードの3重複＝#1304 の `truncate()` 6実装と同じ危険）。`resolveArtifactRequestPath` + `makeCachedRealpath` を `safe.ts` に抽出
- `server/api/routes/files.ts` — エントリ可視性フィルタと組み立て末尾が3関数で重複。`resolveVisibleChild` + `assembleDirNode` を抽出

jscpd 重複ペア **192 → 187**（index.ts 3→0 / files.ts 4→2）。

Closes #2140

## Items to Confirm / Review

1. **セキュリティガードの挙動保存が最重要。** `resolveArtifactRequestPath(rootReal, reqPath, denyDotfiles)` は元の decode→realpath 封じ込め→dotfile 拒否と**同順**。`denyDotfiles` は images=`false`（短絡しないので express.static の `dotfiles:"deny"` が権威）、html/svg=`true`（自前でファイルを返すため in-guard で拒否必須）。この対応が元コードと一致しているか。
2. **`safe.ts` の関数宣言順**: `resolveArtifactRequestPath` は `resolveWithinRoot`（後方定義）を呼ぶが、関数宣言は巻き上げられるので実行時・型ともに問題なし。
3. **`makeCachedRealpath` のキャッシュ意味論**: 成功時のみ永続キャッシュ、失敗時は null 返しで次回リトライ — 元の `getXDirReal` と同じ。

## User Prompt

- https://github.com/receptron/mulmoclaude/security/code-scanning で duplicated が指摘されている。直せるものは直して。
- どんどん重複へらして。
- （パッケージ系は common パッケージを作って共通関数を置いてもよい）

## 対象の選別

192 ペアを精査し、分類:

| 分類 | 件数 | 方針 |
|---|---|---|
| 同一ファイル内 | 51 | ✅ 本命（うち今回2クラスタ） |
| 同一エリア内 | 47 | △ 一部 |
| エリア跨ぎ | 51 | ⚠️ 境界跨ぎは依存方向ルール抵触 → common パッケージ経由で別 PR |
| i18n `lang/*` | 17 | ❌ 自然な重複 |
| bridges 定型 | 14 | ❌ common パッケージ経由で別 PR 検討 |
| vite.config | 12 | ❌ 各pkg必須 |

## 対象外（意図的に触らない）

- `files.ts` の POST-create / PUT-content 検証プリアンブル — ハンドラが分岐、過度な抽象化リスク
- `agent/stream.ts` のステートフル/ステートレスパーサ — 意図的に分離（DRY 化すると test 用パスが本番に結合）
- **パッケージ系（bridges 等）→ 共通パッケージ経由で別 PR**
- 続く server-route 候補: `wiki/history.ts`, `collections.ts`（次 PR）

## 検証

| 項目 | 結果 |
|---|---|
| 新規ユニットテスト `test_safe_artifact.ts` | in-root 受理 / 不正`%`拒否 / traversal 拒否 / dotfile フラグ別 / エンコード backslash / キャッシュ realpath |
| 既存 file-tree + safe テスト | 96/96 pass |
| lint / typecheck:server / typecheck:test | クリーン |
| precommit フル gate（build/format/lint/typecheck/build/test） | pass（コミット時） |
| jscpd 再計測（同一ベース） | 192 → 187 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact path validation to safely handle malformed URLs, traversal attempts, missing files, and encoded hidden paths.
  * Applied consistent filtering for hidden files, sensitive files, symlinks, and ignored content in directory listings.
  * Ensured directory trees and shallow listings are sorted and displayed consistently.

* **Tests**
  * Added coverage for artifact path safety, hidden-file policies, and realpath caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->