### PR TITLE
fix(chat-ui): catch up a truncated final text card on equal card count (#1915)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ playwright-report-live/
 test-results-live/
 .playwright-mcp/
 .mcp.json
+.mulmoterminal.json
 
 # Local, machine-only secrets files — never commit
 .twitter_memo

--- a/plans/fix-1915-transcript-catchup-equal-count.md
+++ b/plans/fix-1915-transcript-catchup-equal-count.md
@@ -1,0 +1,63 @@
+# fix #1915 (reopened) — catch-up misses a truncated final text card
+
+## Context
+
+#1934 fixed the stuck "thinking" indicator (Fix A/B/D). The reporter
+(`ystknsh`) reopened with a remaining UI-sync hole:
+
+- A long assistant response stops mid-sentence on screen (e.g. `理由によ`).
+- The run itself completed; the server jsonl has the full text.
+- Reload shows the whole response.
+
+So the server transcript is complete; only the client's live local state is
+truncated.
+
+## Root cause
+
+`refreshSessionTranscript()` (`src/App.vue`) adopts the server transcript only
+when it has **more cards** than the client:
+
+```ts
+if (serverResults.length > session.toolResults.length) {
+  session.toolResults = serverResults;
+}
+```
+
+In the reported case the card **count is identical** — only the last assistant
+text card's body is longer on the server (the live stream stalled mid-text and
+the tail deltas were lost). The count check is false, so catch-up never runs and
+the truncated card stays.
+
+## Fix
+
+Extract a pure predicate `serverTranscriptAheadOfClient(server, client)` in
+`src/utils/session/sessionEntries.ts` and use it as the guard:
+
+- counts differ → keep the original behavior (`server.length > client.length`).
+- counts equal → upgrade only when the **final card is strictly longer**
+  server-side.
+
+Only the trailing card can lag mid-stream (earlier cards freeze once a newer one
+opens), so comparing the final card is sufficient and — crucially — never
+downgrades a richer in-flight state: during normal streaming the client's last
+card is equal-or-ahead of the server's on-disk copy, so the predicate returns
+false and nothing is touched.
+
+## Why this is side-effect-free
+
+- `handleSessionFinished` path: the turn is over, no concurrent streaming —
+  replacing a truncated final card is always safe.
+- `catchUpMissedEvents` path (reconnect / visibility): fires only after events
+  were genuinely dropped; socket.io does not redeliver missed events, so there
+  are no in-flight deltas to double-append. `appendToLastAssistantText` appends
+  to the last card **by position**, so a replaced array still accepts later
+  appends correctly.
+- Strict "longer" comparison preserves the original no-downgrade guard.
+
+## Files
+
+- `src/utils/session/sessionEntries.ts` — new `serverTranscriptAheadOfClient`.
+- `src/App.vue` — use it in `refreshSessionTranscript`; refresh the two stale
+  comments describing the guard.
+- `test/utils/session/test_sessionEntries.ts` — 7 cases incl. the reopened bug
+  (equal count, longer last card) and the no-downgrade guarantees.

--- a/src/App.vue
+++ b/src/App.vue
@@ -369,7 +369,7 @@ import { pushErrorMessage, beginUserTurn, updateResult, applyToolResultToSession
 import { parseCollectionSlashSeed, makeSyntheticCollectionResult, hasRealCollectionResult } from "./utils/collections/presentSeed";
 import { roleName, roleIcon } from "./utils/role/icon";
 import { createEmptySession } from "./utils/session/sessionFactory";
-import { buildLoadedSession, parseSessionEntries } from "./utils/session/sessionEntries";
+import { buildLoadedSession, parseSessionEntries, serverTranscriptAheadOfClient } from "./utils/session/sessionEntries";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { loadCspExtra } from "./composables/useCspExtra";
 import { cspViolations, dismissCspViolations, installCspViolationListener } from "./composables/useCspViolations";
@@ -976,10 +976,11 @@ async function refreshSessionTranscript(sessionId: string): Promise<void> {
   if (!response.ok) return;
   const summary = sessions.value.find((entry) => entry.id === sessionId);
   const serverResults = parseSessionEntries(response.data, summary?.origin);
-  // Only patch if the server knows more than we do — avoids
-  // replacing a richer in-flight state with a stale snapshot when
-  // session_finished races with the last few events.
-  if (serverResults.length > session.toolResults.length) {
+  // Only patch if the server is strictly ahead — more cards, or the same
+  // cards with a longer final one (a mid-stream stall left the client's
+  // last text truncated, #1915). Never downgrades a richer in-flight
+  // state when session_finished races with the last few events.
+  if (serverTranscriptAheadOfClient(serverResults, session.toolResults)) {
     session.toolResults = serverResults;
   }
 }
@@ -1038,8 +1039,8 @@ function handleSessionFinished(sessionId: string): void {
 // refreshSessionStates() carries its own sequence guard inside
 // useSessionSync so concurrent catch-ups can't overwrite newer live state
 // with an older-but-slower response. refreshSessionTranscript() only
-// upgrades toolResults when the server view is strictly larger, so it's
-// already idempotent against interleaving.
+// upgrades toolResults when the server view is strictly ahead (more cards,
+// or a longer final card), so it's already idempotent against interleaving.
 function catchUpMissedEvents(reason: "reconnect" | "visibility"): void {
   console.info(`[chat-ui] catching up after ${reason}`);
   refreshSessionStates().catch((err) => {

--- a/src/utils/session/sessionEntries.ts
+++ b/src/utils/session/sessionEntries.ts
@@ -78,6 +78,28 @@ export function parseSessionEntries(entries: readonly SessionEntry[], sessionOri
   return out;
 }
 
+// Decide whether the server's freshly-fetched transcript is strictly
+// "ahead of" the client's live copy, so a catch-up can adopt it without
+// downgrading richer in-flight state. Two cases upgrade:
+//   1. more cards than the client has — the client missed a whole event
+//      (the original #350 guard).
+//   2. the SAME cards but a longer final card — the live stream stalled
+//      mid-text, leaving the client's last card truncated (#1915). Only
+//      the trailing card can lag this way: earlier cards freeze once a
+//      newer card opens.
+// Comparing only the final card's length is what keeps this from ever
+// replacing a richer in-flight state with a stale snapshot: during
+// normal streaming the client's last card is equal-or-ahead of the
+// server's on-disk copy, so it returns false and nothing is touched.
+export function serverTranscriptAheadOfClient(serverResults: readonly ToolResultComplete[], clientResults: readonly ToolResultComplete[]): boolean {
+  if (serverResults.length !== clientResults.length) {
+    return serverResults.length > clientResults.length;
+  }
+  const lastIndex = serverResults.length - 1;
+  if (lastIndex < 0) return false;
+  return (serverResults[lastIndex].message ?? "").length > (clientResults[lastIndex].message ?? "").length;
+}
+
 // Pick the `selectedResultUuid` the session should restore to on
 // fresh load: the most recent result in the conversation, whether
 // it's a tool result or a text result. Returns null only when the

--- a/test/utils/session/test_sessionEntries.ts
+++ b/test/utils/session/test_sessionEntries.ts
@@ -3,7 +3,12 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseSessionEntries, resolveSelectedUuid, resolveSessionTimestamps } from "../../../src/utils/session/sessionEntries.js";
+import {
+  parseSessionEntries,
+  resolveSelectedUuid,
+  resolveSessionTimestamps,
+  serverTranscriptAheadOfClient,
+} from "../../../src/utils/session/sessionEntries.js";
 import type { SessionEntry, SessionSummary } from "../../../src/types/session.js";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
@@ -192,6 +197,54 @@ describe("parseSessionEntries", () => {
 function makeResult(uuid: string, toolName: string): ToolResultComplete {
   return { uuid, toolName } as unknown as ToolResultComplete;
 }
+
+// --- serverTranscriptAheadOfClient (#1915) ------------------------
+
+function textCard(message: string): ToolResultComplete {
+  return { uuid: message, toolName: "text-response", message } as unknown as ToolResultComplete;
+}
+
+describe("serverTranscriptAheadOfClient (#1915)", () => {
+  it("upgrades when the server has more cards (original #350 guard)", () => {
+    const server = [textCard("a"), textCard("b"), textCard("c")];
+    const client = [textCard("a"), textCard("b")];
+    assert.equal(serverTranscriptAheadOfClient(server, client), true);
+  });
+
+  it("does NOT upgrade when the server has fewer cards", () => {
+    const server = [textCard("a")];
+    const client = [textCard("a"), textCard("b")];
+    assert.equal(serverTranscriptAheadOfClient(server, client), false);
+  });
+
+  it("upgrades when card counts match but the final card is longer server-side (the reopened bug)", () => {
+    const server = [textCard("intro"), textCard("理由によって打ち手が全然違う。次の一手として…")];
+    const client = [textCard("intro"), textCard("理由によ")];
+    assert.equal(serverTranscriptAheadOfClient(server, client), true);
+  });
+
+  it("does NOT upgrade when counts match and the final card is identical (common no-loss case)", () => {
+    const server = [textCard("intro"), textCard("full answer")];
+    const client = [textCard("intro"), textCard("full answer")];
+    assert.equal(serverTranscriptAheadOfClient(server, client), false);
+  });
+
+  it("does NOT downgrade when the client's final card is AHEAD (session_finished races the last deltas)", () => {
+    const server = [textCard("intro"), textCard("partial")];
+    const client = [textCard("intro"), textCard("partial + a couple more live deltas")];
+    assert.equal(serverTranscriptAheadOfClient(server, client), false);
+  });
+
+  it("returns false for two empty transcripts", () => {
+    assert.equal(serverTranscriptAheadOfClient([], []), false);
+  });
+
+  it("tolerates a final card with no message field", () => {
+    const server = [{ uuid: "x", toolName: "generateImage" } as unknown as ToolResultComplete];
+    const client = [{ uuid: "x", toolName: "generateImage" } as unknown as ToolResultComplete];
+    assert.equal(serverTranscriptAheadOfClient(server, client), false);
+  });
+});
 
 describe("resolveSelectedUuid", () => {
   it("returns null for empty list", () => {


### PR DESCRIPTION
## Summary

Fixes the remaining UI-sync hole in #1915 (reopened by `ystknsh` after #1934 landed).

A long assistant response can stop mid-sentence on screen (e.g. `理由によ`) even though the run completed and the server jsonl has the full text — reload shows the whole response. The live stream stalled mid-text and the tail deltas were lost, so **only the client's last text card is truncated**; the card *count* matches the server.

`refreshSessionTranscript()` only adopted the server transcript when it had **more cards** than the client (`serverResults.length > session.toolResults.length`), so the equal-count case never triggered catch-up. This PR upgrades on an equal count when the **final card is strictly longer server-side**.

## Items to Confirm / Review

- **No-downgrade guarantee** — the core risk. During normal streaming the client's last card is equal-or-ahead of the server's on-disk copy, so the predicate returns `false` and nothing is touched. Please sanity-check the equal-count / longer-final-card branch in `serverTranscriptAheadOfClient` against that invariant.
- **"Only the trailing card can lag" assumption** — earlier cards freeze once a newer card opens, so comparing just the final card's length is claimed sufficient. Confirm no flow reopens/extends a non-final card after a newer one exists.
- **Double-append safety on the `catchUpMissedEvents` (reconnect/visibility) path** — socket.io does not redeliver missed events, and `appendToLastAssistantText` appends by position, so a replaced array still accepts later appends. Confirm there are no in-flight deltas that could double-append after the swap.
- **Manual repro** — reproduced on Safari + Apple-silicon per the reporter; a live confirm (mid-turn stall → observe truncated card → catch-up fills it without reload) would be ideal before merge.

## User Prompt

(consolidated from this session — user: `isamu`)

- Asked what uncommitted work was left in the working tree, and whether it had already been fixed via an existing issue/PR.
- Confirmed: #1915's first round (stuck "thinking" indicator + missed pub/sub event recovery) shipped in #1934; this equal-count truncation case is the reopened follow-up, present only in the local working tree, not on `main` or any PR.
- Asked to proceed: run the quality gates, commit, reopen the issue, and open this PR.

## Implementation

- **`src/utils/session/sessionEntries.ts`** — new pure predicate `serverTranscriptAheadOfClient(server, client)`:
  - counts differ → original guard `server.length > client.length` (preserves the #350 no-downgrade behavior).
  - counts equal → upgrade only when the final card's `message` is strictly longer server-side.
- **`src/App.vue`** — `refreshSessionTranscript()` uses the predicate; refreshed the two stale comments that described the old length-only guard.
- **`test/utils/session/test_sessionEntries.ts`** — 7 cases: more cards, fewer cards, equal-count-longer-final (the reopened bug), equal-identical, client-ahead (no-downgrade), two-empty, and final card with no `message`.
- **`.gitignore`** — ignore the local `.mulmoterminal.json` terminal-appearance config (separate `chore:` commit).

Plan: `plans/fix-1915-transcript-catchup-equal-count.md`.

## Verification

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all green.
- New `serverTranscriptAheadOfClient (#1915)` suite passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript catch-up when the server’s final text card contains additional content.
  * Prevented refreshed transcripts from overwriting richer in-progress client state.
  * Preserved correct behavior for transcripts with differing card counts.

* **Tests**
  * Added coverage for transcript upgrades, downgrades, equal-length transcripts, and missing card content.

* **Documentation**
  * Added planning documentation for the transcript catch-up fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->