### PR TITLE
fix(mulmoScript): re-offer audio generation after a beat text edit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## npm packages — 2026-07-17 (8)
+
+- **`@mulmoclaude/mulmoscript-plugin@0.2.2`** — presentMulmoScript: updating a beat's `text` via the per-beat JSON source editor now drops that beat's cached narration audio, so the "Generate Audio" button reappears for the new text (previously only Play showed, with no way to re-generate). Audio files are content-addressed by text hash, so the view re-probes disk after the edit — reverting the text restores the existing audio without a paid TTS call.
+
+---
+
 ## npm packages — 2026-07-17 (7)
 
 presentMulmoScript `filePath` base clarified (the wire form `stories/<name>.json` has been **artifacts-relative, not workspace-relative**, ever since #284 moved the stories dir to `artifacts/stories/` — the tool description was never updated):

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -42,7 +42,7 @@
     "@mulmoclaude/google-plugin": "^0.2.1",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
-    "@mulmoclaude/mulmoscript-plugin": "^0.2.1",
+    "@mulmoclaude/mulmoscript-plugin": "^0.2.2",
     "@mulmoclaude/spotify-plugin": "^0.1.1",
     "@mulmoclaude/x-plugin": "^0.1.2",
     "@receptron/task-scheduler": "^0.1.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -1117,6 +1117,11 @@ async function updateBeat(index: number) {
   // matches previously generated audio (e.g. the edit was a revert),
   // the probe restores Play without a paid TTS call.
   if (beat.text !== prevText) {
+    // If this beat's old narration is mid-playback, stop it first —
+    // the deletes below remove the Play/Stop control from the row,
+    // which would otherwise leave the stale audio playing with no
+    // way to stop it (Codex review on #2143).
+    if (playingAudio.value?.index === index) stopAllPlayback();
     Reflect.deleteProperty(beatAudios, index);
     Reflect.deleteProperty(audioState, index);
     Reflect.deleteProperty(audioErrors, index);

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -1085,6 +1085,7 @@ async function updateBeat(index: number) {
     return;
   }
   const prevImage = JSON.stringify(effectiveBeat(index).image);
+  const prevText = effectiveBeat(index).text;
 
   const requestedFilePath = filePath.value;
   Reflect.deleteProperty(beatSaveErrors, index);
@@ -1107,6 +1108,19 @@ async function updateBeat(index: number) {
   if (JSON.stringify(beat.image) !== prevImage) {
     Reflect.deleteProperty(renderedImages, index);
     renderBeat(index);
+  }
+
+  // Audio files are content-addressed by the beat's text
+  // (getBeatAudioPathOrUrl hashes text + voice), so after a text edit
+  // the cached data URI belongs to the OLD narration. Drop it so the
+  // "Generate Audio" button reappears, then re-probe — if the new text
+  // matches previously generated audio (e.g. the edit was a revert),
+  // the probe restores Play without a paid TTS call.
+  if (beat.text !== prevText) {
+    Reflect.deleteProperty(beatAudios, index);
+    Reflect.deleteProperty(audioState, index);
+    Reflect.deleteProperty(audioErrors, index);
+    if (beat.text) void loadExistingBeatAudio(index);
   }
 }
 


### PR DESCRIPTION
## Summary

In the presentMulmoScript view, editing a beat's `text` through the per-beat JSON source editor left the beat's old narration audio in the UI: `updateBeat` only invalidated the rendered image when `beat.image` changed, so the audio controls kept showing **Play** (for the now-stale audio) with no way to generate narration for the new text.

## Fix

`updateBeat` now captures the beat's previous `text` and, when it changed after a successful save:

- drops the beat's local audio state (`beatAudios` / `audioState` / `audioErrors`) so the **Generate Audio** button reappears, and
- re-probes disk via `loadExistingBeatAudio`. Audio files are content-addressed by text hash (`getBeatAudioPathOrUrl`), so a revert to previously narrated text restores the existing audio (Play comes back) without a paid TTS call, while genuinely new text keeps the Generate button.

Image handling is untouched — text-derived beat images already have an always-visible regenerate (↺) affordance.

## Releases

- `@mulmoclaude/mulmoscript-plugin@0.2.2` (bump in-PR; publish after merge) + launcher dep range ratchet; CHANGELOG entry added.

## Verification

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved beat editing behavior: when narration text is changed in the per-beat editor, the “Generate Audio” option becomes available for the updated text.

* **Bug Fixes**
  * Cached narration audio is cleared when narration text changes, ensuring playback/generation controls match the new text.
  * If narration text is reverted, previously generated audio is restored from cache to avoid unnecessary regeneration.

* **Documentation**
  * Updated the changelog with the new unreleased entry and package version details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->