### PR TITLE
refactor(collections): dedup resolve-or-404 preambles across route handlers

### DIFF
--- a/plans/refactor-dedup-collections-route-preambles.md
+++ b/plans/refactor-dedup-collections-route-preambles.md
@@ -1,0 +1,52 @@
+# refactor: dedup collections route-handler resolve-or-404 preambles
+
+Issue: #2144
+
+## Context
+
+Follow-up to #2141 (server/ path-guard + tree-builder dedup). The
+`duplication-scan` (jscpd) gate surfaced that `server/api/routes/
+collections.ts` repeats the same resolve-or-404 preambles across its
+route handlers. This is genuine knowledge duplication — the "resolve a
+collection (or its custom view) or respond 404" contract — repeated ~16
+times, exactly the class of drift a single helper prevents.
+
+## What this fixes
+
+### `loadCollectionOr404(slug, res)`
+
+`const collection = await loadCollection(slug); if (!collection) {
+notFound(res, \`collection '<slug>' not found\`); return; }` appeared in
+**16 handlers**. Extracted to one helper; callers become
+`const collection = await loadCollectionOr404(slug, res); if (!collection) return;`.
+Behaviour is identical (same 404 message, `slug` = the same value each
+site already passed).
+
+### `resolveCustomViewOr404(slug, viewId, res)`
+
+The view-file / view-i18n / view-token routes additionally repeated the
+`loadCollectionOr404 + find view by id + 404` block. Extracted into one
+helper returning `{ collection, view }` or null.
+
+## Deliberately NOT in this PR
+
+- POST-create / PUT-item write-result handling (invalid-id / path-escape
+  / conflict) — the two handlers diverge after the shared preamble;
+  extracting the tail risks over-abstraction. Left as-is.
+- Package-level duplication (bridges etc.) — separate follow-up via a
+  shared package.
+
+## Result
+
+jscpd clone pairs touching collections.ts: **~8 → 5** (same base). The
+remaining 5 are the deliberately-skipped items write region. Beyond the
+flagged count, the 16→1 collapse of the load-or-404 contract is the real
+win — a future change to the 404 behaviour now lands in one place.
+
+## Verification
+
+- `yarn lint` / `typecheck:server` clean (lint caught + fixed one
+  dead-store `collection` in the view-token route where only `view` is
+  used).
+- Pure extraction, no behaviour change; covered by the full `yarn test`
+  gate on commit. No dedicated route test exists for this file to extend.

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -69,6 +69,34 @@ import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability
 
 const router = Router();
 
+// Load a collection by slug or send a 404 and return null. Callers do
+// `const collection = await loadCollectionOr404(slug, res); if (!collection) return;`.
+// The load-or-404 preamble was repeated across ~16 route handlers.
+async function loadCollectionOr404(slug: string, res: Response): Promise<LoadedCollection | null> {
+  const collection = await loadCollection(slug);
+  if (!collection) {
+    notFound(res, `collection '${slug}' not found`);
+    return null;
+  }
+  return collection;
+}
+
+type CustomView = NonNullable<LoadedCollection["schema"]["views"]>[number];
+
+// Resolve a collection + one of its custom views by id, or send a 404
+// (missing collection or missing view) and return null. Shared by the
+// view-file / view-i18n / view-token routes.
+async function resolveCustomViewOr404(slug: string, viewId: string, res: Response): Promise<{ collection: LoadedCollection; view: CustomView } | null> {
+  const collection = await loadCollectionOr404(slug, res);
+  if (!collection) return null;
+  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+  if (!view) {
+    notFound(res, `custom view '${viewId}' not found on collection '${slug}'`);
+    return null;
+  }
+  return { collection, view };
+}
+
 interface CollectionsListResponse {
   collections: CollectionSummary[];
 }
@@ -156,11 +184,8 @@ router.get(API_ROUTES.collections.list, async (_req: Request, res: Response<Coll
 });
 
 router.get(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>, res: Response<CollectionDetailResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   try {
     const items = await listItems(collection.dataDir);
     // Best-effort validation: a malformed record is silently skipped at
@@ -193,11 +218,8 @@ router.get(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>,
 // non-preset collections are deletable; see deleteCollection for the
 // scope rules and the archive layout.
 router.delete(API_ROUTES.collections.detail, async (req: Request<{ slug: string }>, res: Response<DeleteCollectionResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   try {
     const result = await deleteCollection(collection);
     if (result.kind !== "ok") {
@@ -218,11 +240,8 @@ function extractRecord(body: unknown): CollectionItem | null {
 }
 
 router.post(API_ROUTES.collections.items, async (req: Request<{ slug: string }>, res: Response<ItemMutationResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   const record = extractRecord(req.body);
   if (!record) {
     badRequest(res, "request body must be a JSON object");
@@ -260,11 +279,8 @@ router.post(API_ROUTES.collections.items, async (req: Request<{ slug: string }>,
 });
 
 router.put(API_ROUTES.collections.item, async (req: Request<{ slug: string; itemId: string }>, res: Response<ItemMutationResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   const record = extractRecord(req.body);
   if (!record) {
     badRequest(res, "request body must be a JSON object");
@@ -306,11 +322,8 @@ router.put(API_ROUTES.collections.item, async (req: Request<{ slug: string; item
 });
 
 router.delete(API_ROUTES.collections.item, async (req: Request<{ slug: string; itemId: string }>, res: Response<DeleteResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   try {
     const result = await deleteItem(collection.dataDir, req.params.itemId, { slug: collection.slug });
     if (result.kind === "invalid-id") {
@@ -351,11 +364,8 @@ interface RefreshResponse {
 // carries no `ingest` block (it's an ordinary skill collection, not a
 // feed). Backs the CollectionView "Refresh feed" button.
 router.post(API_ROUTES.collections.refresh, async (req: Request<{ slug: string }>, res: Response<RefreshResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   if (!collection.schema.ingest) {
     badRequest(res, `collection '${collection.slug}' is not a feed (no ingest config)`);
     return;
@@ -441,11 +451,8 @@ async function respondForMutateAction(
 // the hidden worker itself; for `kind: "mutate"`, it applies the
 // declarative write). No domain (invoice / PDF / role) literals.
 router.post(API_ROUTES.collections.itemAction, async (req: Request<{ slug: string; itemId: string; actionId: string }>, res: Response<ActionRunResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
   if (!action) {
     notFound(res, `action '${req.params.actionId}' not found on collection '${collection.slug}'`);
@@ -506,11 +513,8 @@ async function buildCollectionActionSeed(collection: LoadedCollection, action: C
 // Like the per-record route but with no `itemId`: there is no record to read or
 // gate on, so the seed injects a progress summary instead. No domain literals.
 router.post(API_ROUTES.collections.collectionAction, async (req: Request<{ slug: string; actionId: string }>, res: Response<ActionRunResponse>) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    notFound(res, `collection '${req.params.slug}' not found`);
-    return;
-  }
+  const collection = await loadCollectionOr404(req.params.slug, res);
+  if (!collection) return;
   const action = collection.schema.collectionActions?.find((entry) => entry.id === req.params.actionId);
   if (!action) {
     notFound(res, `collection action '${req.params.actionId}' not found on collection '${collection.slug}'`);
@@ -628,16 +632,9 @@ router.get(API_ROUTES.collections.viewFile, async (req: Request<{ slug: string }
   try {
     const { slug } = req.params;
     const viewId = typeof req.query.id === "string" ? req.query.id : "";
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      notFound(res, `collection '${slug}' not found`);
-      return;
-    }
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) {
-      notFound(res, `custom view '${viewId}' not found on collection '${slug}'`);
-      return;
-    }
+    const resolved = await resolveCustomViewOr404(slug, viewId, res);
+    if (!resolved) return;
+    const { collection, view } = resolved;
     // Path-safe, source-aware read through the collections domain layer (no raw
     // fs / hardcoded subpaths in the route).
     const html = await readCustomViewHtml(collection, view.file);
@@ -670,11 +667,8 @@ router.get(API_ROUTES.collections.remoteView, async (req: Request<{ slug: string
     const { slug } = req.params;
     const viewId = typeof req.query.id === "string" ? req.query.id : "";
     const locale = typeof req.query.locale === "string" ? req.query.locale : "";
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      notFound(res, `collection '${slug}' not found`);
-      return;
-    }
+    const collection = await loadCollectionOr404(slug, res);
+    if (!collection) return;
     const result = await buildRemoteView(collection, viewId, locale);
     if (result.kind !== "ok") {
       sendRemoteViewFailure(res, result, slug);
@@ -710,11 +704,8 @@ router.post(API_ROUTES.collections.remoteViewMutate, async (req: Request<{ slug:
       badRequest(res, "invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
       return;
     }
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      notFound(res, `collection '${slug}' not found`);
-      return;
-    }
+    const collection = await loadCollectionOr404(slug, res);
+    if (!collection) return;
     const result = await mutateRemoteView(collection, viewId, request);
     if (result.kind !== "ok") {
       sendMutateRemoteViewFailure(res, result, slug);
@@ -753,11 +744,8 @@ router.get(API_ROUTES.collections.remoteViewItems, async (req: Request<{ slug: s
   try {
     const { slug, viewId } = req.params;
     const request = { offset: clampOffset(req.query.offset), limit: clampLimit(req.query.limit), fields: normalizeFields(csvParam(req.query.fields)) };
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      notFound(res, `collection '${slug}' not found`);
-      return;
-    }
+    const collection = await loadCollectionOr404(slug, res);
+    if (!collection) return;
     const result = await remoteViewItems(collection, viewId, request);
     if (result.kind !== "ok") {
       sendRemoteViewItemsFailure(res, result, slug);
@@ -788,16 +776,9 @@ router.get(API_ROUTES.collections.viewI18n, async (req: Request<{ slug: string }
     const { slug } = req.params;
     const viewId = typeof req.query.id === "string" ? req.query.id : "";
     const locale = typeof req.query.locale === "string" ? req.query.locale : "";
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      notFound(res, `collection '${slug}' not found`);
-      return;
-    }
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) {
-      notFound(res, `custom view '${viewId}' not found on collection '${slug}'`);
-      return;
-    }
+    const resolved = await resolveCustomViewOr404(slug, viewId, res);
+    if (!resolved) return;
+    const { collection, view } = resolved;
     if (!view.i18n) {
       // The view declared no translation file — return the empty contract so
       // the client doesn't have to special-case "no i18n" with a different
@@ -829,16 +810,9 @@ router.post(API_ROUTES.collections.viewToken, async (req: Request<{ slug: string
       badRequest(res, "`viewId` is required");
       return;
     }
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      notFound(res, `collection '${slug}' not found`);
-      return;
-    }
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) {
-      notFound(res, `custom view '${viewId}' not found on collection '${slug}'`);
-      return;
-    }
+    const resolved = await resolveCustomViewOr404(slug, viewId, res);
+    if (!resolved) return;
+    const { view } = resolved;
     const granted = clampCapabilities(view.capabilities, parseCapabilities(body.capabilities));
     const minted = mintViewToken(slug, granted);
     if (!minted) {
@@ -903,11 +877,8 @@ router.post(
   requireViewToken("write"),
   async (req: Request<{ slug: string; actionId: string }>, res: Response<ActionRunResponse>) => {
     try {
-      const collection = await loadCollection(req.params.slug);
-      if (!collection) {
-        notFound(res, `collection '${req.params.slug}' not found`);
-        return;
-      }
+      const collection = await loadCollectionOr404(req.params.slug, res);
+      if (!collection) return;
       const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
       if (!action) {
         notFound(res, `action '${req.params.actionId}' not found on collection '${collection.slug}'`);
@@ -971,11 +942,8 @@ function sendDeleteViewRefusal(res: Response, result: Exclude<DeleteViewResult, 
 // refuses user-scope + preset collections, consistent with collection delete.
 router.delete(API_ROUTES.collections.viewDelete, async (req: Request<{ slug: string; viewId: string }>, res: Response<DeleteViewResponse>) => {
   try {
-    const collection = await loadCollection(req.params.slug);
-    if (!collection) {
-      notFound(res, `collection '${req.params.slug}' not found`);
-      return;
-    }
+    const collection = await loadCollectionOr404(req.params.slug, res);
+    if (!collection) return;
     const result = await deleteCustomView(collection, req.params.viewId);
     if (result.kind !== "ok") {
       sendDeleteViewRefusal(res, result);


### PR DESCRIPTION
## Summary

#2141 の続き。`server/api/routes/collections.ts` が各ルートハンドラで**resolve-or-404 プリアンブルを繰り返している**のを helper に集約。**純粋な抽出・挙動完全保存**。

- `loadCollectionOr404(slug, res)` — load-or-404 ブロックが**16 ハンドラ**で重複 → 1 helper
- `resolveCustomViewOr404(slug, viewId, res)` — view-file/i18n/token ルートの `collection + view 検索 + 404` を集約

jscpd collections ペア **~8 → 5**。本質は load-or-404 契約の **16→1 集約**（404 挙動の変更が1箇所で済む）。

Closes #2144

## Items to Confirm / Review

1. **挙動保存の確認が最重要。** `loadCollectionOr404` の 404 メッセージは `collection '${slug}' not found` で元と同一。各サイトの `slug` は元々渡していた `req.params.slug` またはローカル `slug`（同値）。16 箇所すべてで元の `if (!collection) { notFound; return; }` と等価か。
2. **`resolveCustomViewOr404` の返り値**: `{ collection, view }`。view-token ルートは `view` のみ使用（lint が dead-store `collection` を検出→ `const { view } = resolved` に修正済み）。viewFile/viewI18n は両方使用。
3. **`CustomView` 型**: `NonNullable<LoadedCollection["schema"]["views"]>[number]` で導出（型 import 追加なし）。

## User Prompt

- https://github.com/receptron/mulmoclaude/security/code-scanning で duplicated が指摘されている。直せるものは直して。どんどん減らして。
- i18n / vite.config / 各pkg定型は不要。他で対応できるものがあれば対応するけど、無理はしない。
- （パッケージ系は common パッケージを作って共通関数を置いてもよい）

## 対象外（意図的）

- POST-create / PUT-item の書き込み結果処理（invalid-id / path-escape / conflict）— 共有プリアンブル後で分岐 → 過度な抽象化を避け据え置き（残り5ペアはここ）
- パッケージ系（bridges 等）→ 共有パッケージ経由で別 PR

## 検証

| 項目 | 結果 |
|---|---|
| lint / typecheck:server | クリーン（lint が dead-store を検出→修正） |
| precommit フル gate（build/format/lint/typecheck/build/test） | pass（コミット時） |
| jscpd collections ペア | ~8 → 5 |
| 挙動 | 純粋な抽出・変更なし |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
