### PR TITLE
fix(#2134): preserve a leading slash so deterministic slash resolution fires

### DIFF
--- a/plans/fix-2134-preserve-leading-slash.md
+++ b/plans/fix-2134-preserve-leading-slash.md
@@ -1,0 +1,71 @@
+# fix #2134 — first-turn message decorations break deterministic slash resolution
+
+## Problem
+
+Claude Code CLI resolves a slash command deterministically only when the
+user message **starts with** `/name` (it then emits a `<command-name>`
+block and invokes the exact named skill). The server decorates the
+CLI-bound message in two places that push the slash off position 0, so
+the CLI falls back to the model *guessing* the skill from descriptions:
+
+1. **journal pointer** (`server/agent/prompt.ts` `prependJournalPointer`,
+   called at `server/api/routes/agent.ts` `dispatchAgentRun`) — prepends a
+   `<journal-context>` block on the **first turn** when the workspace has a
+   journal (`summaries/_index.md`). Used workspaces almost always have one.
+2. **attached-file marker** (`withAttachedFileMarker`) — prepends
+   `[Attached file: …]` lines on **every** turn that carries an attachment.
+
+Collection record-detail chats build `/slug id=<itemId> <text>` and start a
+**new chat**, so they are always first-turn → always decorated → always
+model-guessed. Observed failure: `/todo-malaysia …` invoked the `todo-list`
+skill (near-identical name) and wrote to the wrong collection.
+
+Empirically (issue #2134): 122/122 first-turn slash sessions arrived
+decorated (0 started with `/`, 0 deterministic resolutions); the only 6
+deterministic resolutions were all 2nd+ turns, where nothing is prepended.
+
+## Constraints
+
+- Maintainer: do **not** keep the pointer interleaved in the user message.
+- Do **not** move it into the system prompt either (keep the system prompt
+  small — explicit user constraint).
+
+## Fix — one principle: never displace a leading `/`
+
+A leading `/` is the CLI's deterministic control token. Server-side
+decorations must not push it off position 0. A slash-first message is a
+**command**, not an open question, so:
+
+- **journal pointer** → skip entirely on a command turn (prior-session
+  context is irrelevant to a deterministic command; this is exactly the set
+  of turns that were breaking, so no real feature is lost).
+- **attached-file marker** → **append** after the body on a command turn
+  (the skill still needs the paths; `/` stays first). Non-command turns keep
+  the existing **prepend**.
+
+Detection is `message.startsWith("/")` (no trim) to match the CLI's
+position-0 semantics; the collection UI and manual entry produce no leading
+whitespace.
+
+## Changes
+
+- `server/api/routes/agent.ts`
+  - `withAttachedFileMarker(message, paths, position = "prepend")` — add a
+    `"prepend" | "append"` position arg; default preserves current behavior.
+  - New pure `decorateMessageForCli({ message, workspacePath, attachedFilePaths, resumed })`
+    that encodes the whole policy (skip journal on resume/command; marker
+    position by command-ness). `dispatchAgentRun` calls it instead of the
+    inline two-liner.
+- `test/api/routes/test_agentAttachedFileMarker.ts` — append-position cases.
+- `test/api/routes/test_decorateMessageForCli.ts` (new) — the policy matrix:
+  - non-command + journal → journal prepended (unchanged)
+  - command + journal → NOT prepended, message still starts with `/`
+  - command + attachment → starts with `/`, marker appended after body
+  - resume (claudeSessionId) → never prepends journal (unchanged)
+
+## Why side-effect-free
+
+Only the **CLI-bound** copy is decorated; the persisted jsonl and the UI
+broadcast already use the raw text (`withAttachedFileMarker` docstring), so
+this changes nothing users see or that gets stored — only what the model
+receives, which is the thing that was broken.

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -328,10 +328,10 @@ async function persistUserTurn(params: StartChatParams, ctx: { isFirstTurn: bool
   return validOrigin;
 }
 
-// Build the LLM-bound message (journal pointer + attached-file
-// markers) and kick off the detached background agent run. The
-// background run itself is fire-and-forget; this awaits only the
-// claudeSessionId read that must precede it.
+// Build the LLM-bound message (see decorateMessageForCli) and kick
+// off the detached background agent run. The background run itself is
+// fire-and-forget; this awaits only the claudeSessionId read that must
+// precede it (its presence decides whether the journal pointer is added).
 async function dispatchAgentRun(
   params: StartChatParams,
   ctx: { extras: RequestExtras; resultsFilePath: string; abortController: AbortController; validOrigin: SessionOrigin | undefined },
@@ -350,8 +350,12 @@ async function dispatchAgentRun(
     resumed: Boolean(claudeSessionId),
   });
 
-  const baseMessage = claudeSessionId ? message : prependJournalPointer(message, workspacePath);
-  const decoratedMessage = withAttachedFileMarker(baseMessage, extras.attachedFilePaths);
+  const decoratedMessage = decorateMessageForCli({
+    message,
+    workspaceDir: workspacePath,
+    attachedFilePaths: extras.attachedFilePaths,
+    resumed: Boolean(claudeSessionId),
+  });
 
   runAgentInBackground({
     decoratedMessage,
@@ -577,7 +581,9 @@ async function loadImageFromPath(value: string, declaredMimeType: string | undef
 // CodeRabbit review on #1045.
 const UNSAFE_MARKER_CHARS_RE = /[\r\n\]]/;
 
-/** Marker prepended to the LLM-bound user message that tells the
+type MarkerPosition = "prepend" | "append";
+
+/** Marker attached to the LLM-bound user message that tells the
  *  model which workspace files are attached / selected for this turn.
  *  One `[Attached file: <path>]` line is emitted per path so multi-
  *  file flows (e.g. paste one image + pick another → "combine these")
@@ -585,12 +591,31 @@ const UNSAFE_MARKER_CHARS_RE = /[\r\n\]]/;
  *  full list in `imagePaths`. The user's persisted (jsonl) and
  *  broadcast (UI) message is the raw text — these marker lines are
  *  added strictly on the path to Claude. The system prompt teaches
- *  the model how to interpret them. */
-export function withAttachedFileMarker(message: string, attachedFilePaths: string[]): string {
+ *  the model how to interpret them.
+ *
+ *  `position` defaults to `"prepend"`; a command turn passes `"append"`
+ *  so the leading `/` stays at position 0 (see `decorateMessageForCli`). */
+export function withAttachedFileMarker(message: string, attachedFilePaths: string[], position: MarkerPosition = "prepend"): string {
   const safePaths = attachedFilePaths.filter((relPath) => !UNSAFE_MARKER_CHARS_RE.test(relPath));
   if (safePaths.length === 0) return message;
   const markerLines = safePaths.map((relPath) => `[Attached file: ${relPath}]`).join("\n");
-  return `${markerLines}\n\n${message}`;
+  return position === "append" ? `${message}\n\n${markerLines}` : `${markerLines}\n\n${message}`;
+}
+
+/** Build the CLI-bound message, preserving a leading `/` as the CLI's
+ *  deterministic slash-command trigger. The CLI resolves a slash command
+ *  only when the message STARTS with `/name`; any decoration pushed in
+ *  front of it silently drops skill selection back to the model guessing
+ *  from descriptions (#2134). A slash-first message is a command, not an
+ *  open question — so skip the journal pointer (prior-session context is
+ *  irrelevant to a command) and append the file markers after the body
+ *  instead of prepending. Detection is position-0 `startsWith` to match
+ *  the CLI; the collection UI and manual entry emit no leading whitespace. */
+export function decorateMessageForCli(args: { message: string; workspaceDir: string; attachedFilePaths: string[]; resumed: boolean }): string {
+  const { message, workspaceDir, attachedFilePaths, resumed } = args;
+  const isCommand = message.startsWith("/");
+  const base = resumed || isCommand ? message : prependJournalPointer(message, workspaceDir);
+  return withAttachedFileMarker(base, attachedFilePaths, isCommand ? "append" : "prepend");
 }
 
 // ── HTTP route ──────────────────────────────────────────────────────

--- a/server/prompts/system/system.md
+++ b/server/prompts/system/system.md
@@ -42,11 +42,11 @@ Raw HTML tags work inside `.md` files too — use them when markdown's `![]()` c
 
 ## Attached file marker
 
-When a user message starts with one or more lines of the form
+When a user message carries one or more lines of the form
 
 `[Attached file: <workspace-relative-path>]`
 
-the user has attached / pasted / dropped a file (or selected one in the UI) for this turn. **Each line is one file** — when the user attaches multiple files in the same turn, you will see multiple consecutive marker lines, in declaration order, before the user's actual message text. Every path always points at a real workspace file:
+the user has attached / pasted / dropped a file (or selected one in the UI) for this turn. **Each line is one file** — when the user attaches multiple files in the same turn, you will see multiple consecutive marker lines, in declaration order. They usually sit before the user's actual message text, but on a slash-command turn they follow it (so the leading `/` stays at the very start for command resolution). Every path always points at a real workspace file:
 
 - `data/attachments/YYYY/MM/<id>.<ext>` — paste/drop/file-picker uploads. The extension reflects the actual format (`.png`, `.pdf`, `.docx`, `.xlsx`, `.txt`, etc.). PPTX uploads are converted server-side and the path you receive is the resulting `.pdf`; the original `.pptx` lives next to it under the same `<id>` if you ever need to inspect it.
 - `artifacts/images/YYYY/MM/<id>.png` — a generated / canvas / edited image the user selected from the sidebar.

--- a/test/api/routes/test_agentAttachedFileMarker.ts
+++ b/test/api/routes/test_agentAttachedFileMarker.ts
@@ -56,4 +56,20 @@ describe("withAttachedFileMarker", () => {
     const result = withAttachedFileMarker("hi", ["artifacts/images/2026/04/safe.png", "data/attachments/foo\n]INJECT", "artifacts/images/2026/04/safe2.png"]);
     assert.equal(result, "[Attached file: artifacts/images/2026/04/safe.png]\n[Attached file: artifacts/images/2026/04/safe2.png]\n\nhi");
   });
+
+  // Append position — used on command turns so a leading `/` stays at
+  // position 0 for the CLI's deterministic slash resolution (#2134).
+  it("appends the marker after the body when position is 'append'", () => {
+    const result = withAttachedFileMarker("/todo id=1 done", ["data/attachments/2026/07/a.png"], "append");
+    assert.equal(result, "/todo id=1 done\n\n[Attached file: data/attachments/2026/07/a.png]");
+  });
+
+  it("appends one marker line per path, in declaration order", () => {
+    const result = withAttachedFileMarker("/skill go", ["data/attachments/2026/07/foo.png", "artifacts/images/2026/07/bar.png"], "append");
+    assert.equal(result, "/skill go\n\n[Attached file: data/attachments/2026/07/foo.png]\n[Attached file: artifacts/images/2026/07/bar.png]");
+  });
+
+  it("returns the body unchanged when there are no safe paths, regardless of position", () => {
+    assert.equal(withAttachedFileMarker("/skill go", [], "append"), "/skill go");
+  });
 });

--- a/test/api/routes/test_decorateMessageForCli.ts
+++ b/test/api/routes/test_decorateMessageForCli.ts
@@ -1,0 +1,93 @@
+// Unit tests for `decorateMessageForCli` (#2134). The Claude Code CLI
+// resolves a slash command deterministically only when the message
+// STARTS with `/name`; a decoration pushed in front of it drops skill
+// selection back to the model guessing from descriptions. These tests
+// pin the "never displace a leading `/`" policy: skip the journal
+// pointer on command turns, append (not prepend) file markers there,
+// and keep the original prepend behaviour for open-question turns.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { tmpdir } from "os";
+import { decorateMessageForCli } from "../../../server/api/routes/agent.ts";
+import { WORKSPACE_FILES } from "../../../server/workspace/paths.js";
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), "decorate-cli-test-"));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function writeJournalIndex(): void {
+  const abs = join(workspace, WORKSPACE_FILES.summariesIndex);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, "# Workspace Journal\n\n- refactoring\n");
+}
+
+function decorate(message: string, opts?: { attachedFilePaths?: string[]; resumed?: boolean }): string {
+  return decorateMessageForCli({
+    message,
+    workspaceDir: workspace,
+    attachedFilePaths: opts?.attachedFilePaths ?? [],
+    resumed: opts?.resumed ?? false,
+  });
+}
+
+describe("decorateMessageForCli (#2134)", () => {
+  it("prepends the journal pointer for an open-question first turn (unchanged)", () => {
+    writeJournalIndex();
+    const result = decorate("What did I do last week?");
+    assert.ok(result.startsWith("<journal-context>"), "open question should still get the pointer");
+    assert.ok(result.includes("What did I do last week?"));
+  });
+
+  it("does NOT prepend the journal pointer on a command turn — message stays slash-first", () => {
+    writeJournalIndex();
+    const result = decorate("/todo-malaysia id=42 done");
+    assert.ok(result.startsWith("/todo-malaysia"), `command must stay at position 0, got: ${JSON.stringify(result)}`);
+    assert.ok(!result.includes("<journal-context>"), "a command turn must not carry the journal pointer");
+  });
+
+  it("appends the file marker after a command body so the slash stays first", () => {
+    writeJournalIndex();
+    const result = decorate("/todo-malaysia id=42 done", { attachedFilePaths: ["data/attachments/2026/07/a.png"] });
+    assert.ok(result.startsWith("/todo-malaysia id=42 done"), "slash command must remain at position 0");
+    assert.ok(result.endsWith("[Attached file: data/attachments/2026/07/a.png]"), "marker should be appended after the body");
+    assert.ok(!result.includes("<journal-context>"));
+  });
+
+  it("prepends the file marker for a non-command turn (unchanged)", () => {
+    const result = decorate("combine these", { attachedFilePaths: ["artifacts/images/2026/07/x.png"] });
+    assert.ok(result.startsWith("[Attached file: artifacts/images/2026/07/x.png]"));
+    assert.ok(result.endsWith("combine these"));
+  });
+
+  it("never prepends the journal pointer on a resumed turn (unchanged)", () => {
+    writeJournalIndex();
+    const result = decorate("open question on turn 2", { resumed: true });
+    assert.equal(result, "open question on turn 2");
+  });
+
+  it("keeps a resumed command turn slash-first", () => {
+    writeJournalIndex();
+    const result = decorate("/todo-list add milk", { resumed: true });
+    assert.equal(result, "/todo-list add milk");
+  });
+
+  it("returns the raw message when there is no journal and no attachment", () => {
+    const result = decorate("plain hello");
+    assert.equal(result, "plain hello");
+  });
+
+  it("treats a leading space before the slash as a non-command (matches the CLI's position-0 check)", () => {
+    writeJournalIndex();
+    const result = decorate(" /todo-list add milk");
+    assert.ok(result.startsWith("<journal-context>"), "a space-prefixed slash is not a deterministic command, so the pointer still applies");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2134. The Claude Code CLI resolves a slash command **deterministically** only when the user message **starts with** `/name` (it then emits a `<command-name>` block and invokes that exact skill). The server decorated the CLI-bound message in two places that push the slash off position 0, so skill selection silently fell back to the **model guessing from descriptions**:

- `prependJournalPointer` — prepends a `<journal-context>` block on the **first turn** when the workspace has a journal (`summaries/_index.md`); used workspaces almost always have one.
- `withAttachedFileMarker` — prepends `[Attached file: …]` on **every** attachment turn.

Collection record-detail chats build `/slug id=<itemId> <text>` and start a **new chat**, so they hit this on every invocation. Observed failure: `/todo-malaysia …` fired the near-identical `todo-list` skill and wrote to the wrong collection. (Issue's field data: 122/122 first-turn slash sessions arrived decorated → 0 deterministic resolutions; the only 6 deterministic resolutions were 2nd+ turns, where nothing is prepended.)

The maintainer directed: don't interleave the pointer in the user message, and don't move it into the system prompt either (keep the system prompt small).

## Fix — one principle: never displace a leading `/`

`decorateMessageForCli` encodes it. A slash-first message is a **command**, not an open question:
- **journal pointer** → skipped on a command turn (prior-session context is irrelevant to a deterministic command — exactly the turns that were breaking, so no real feature is lost).
- **attached-file marker** → **appended** after the body on a command turn (skill still gets the paths; `/` stays at position 0). Non-command turns keep the original **prepend**.

Detection is `message.startsWith("/")` (no trim) to match the CLI's position-0 semantics. **Zero system-prompt growth.**

## Items to Confirm / Review

- **`startsWith("/")` faithfulness** — I assumed the CLI's trigger is a literal position-0 `/` (no leading-whitespace trim). A space-prefixed slash is treated as a non-command (pointer still applies) — pinned by a test. Confirm this matches the CLI's actual detection.
- **Appending the marker into slash args** — on a command turn the `[Attached file: …]` line now lands *after* the command, i.e. inside the slash args the skill receives. That's intended (the skill sees the path) but please sanity-check no skill parses its args in a way that trips on a trailing marker line.
- **Skipping the pointer on command turns** — acceptable? A deterministic command doesn't need journal guidance; if a specific skill ever does, that belongs in its SKILL.md, not the global system prompt.
- **No end-to-end run here** — the change is pure string composition; unit tests assert the observable contract (CLI-bound message starts with `/` for commands). A live check that the CLI now emits `<command-name>` on a first-turn slash would be the ideal final confirmation before merge.

## User Prompt

(consolidated — user: `isamu`)

> #2134 — "この journal pointer、よくないですね。外してください" と言われた。この問題と対策を詳しく教えて。system prompt はできる限り増やしたくない。提案を一旦忘れて、エレガントな解決方法は？ → (合意の上) 実装して。

i.e. explain the journal-pointer breakage and fix it **without** growing the system prompt, with an elegant approach.

## Implementation

- `server/api/routes/agent.ts`
  - `withAttachedFileMarker(message, paths, position = "prepend")` — new `"prepend" | "append"` arg; default preserves current behaviour.
  - new pure, exported `decorateMessageForCli({ message, workspaceDir, attachedFilePaths, resumed })` — the whole policy in one testable place; `dispatchAgentRun` calls it.
- `server/prompts/system/system.md` — note that the attached-file marker follows the body on a command turn.
- `test/api/routes/test_decorateMessageForCli.ts` (new) — full policy matrix (command/non-command × journal × attachment × resume).
- `test/api/routes/test_agentAttachedFileMarker.ts` — append-position cases.

Plan: `plans/fix-2134-preserve-leading-slash.md`. Only the **CLI-bound** copy is decorated — the persisted jsonl and UI broadcast already use raw text, so nothing users see or that gets stored changes.

## Verification

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all green. New `decorateMessageForCli (#2134)` matrix + extended marker suite pass (19 targeted; 116 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
