### PR TITLE
refactor(server): dedup catalog-source + mulmo-script resolve-or-respond preambles

### DIFF
--- a/plans/refactor-dedup-catalog-mulmoscript-preambles.md
+++ b/plans/refactor-dedup-catalog-mulmoscript-preambles.md
@@ -1,0 +1,25 @@
+# refactor: dedup catalog-source + mulmo-script resolve-or-respond preambles
+
+Issue: #2156
+
+## Context
+
+"1 から順に" #3. Two more genuine same-file resolve-or-respond duplications.
+
+## What this fixes
+
+- `server/workspace/skills/external/catalog.ts` — `readExternalCatalogDetail`
+  and `starExternalCatalogEntry` shared "`resolveSource` → classify the
+  failure (bad-shape id → `invalid-id`, else missing → `not-found`)".
+  Extract `resolveSourceOrError`; the error type is a subset of both
+  routes' result types.
+- `server/api/routes/mulmo-script.ts` — the movie and PDF SSE routes shared
+  "validate filePath → ffmpeg guard → resolveStory → absolutePath".
+  Extract `resolveStoryRequest(req, res)` returning
+  `{ filePath, absoluteFilePath, chatSessionId }` (filePath is still needed
+  for the `publishGeneration` calls downstream).
+
+## Verification
+
+- Pure extraction, behaviour preserved. `test_catalog.ts` 19/19 pass;
+  `typecheck:server` + lint clean.

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -282,30 +282,44 @@ bindRoute(router, API_ROUTES.mulmoScript.renderBeat, async (req: Request<object,
   res.json({ image: result.image });
 });
 
+interface GenerationRequestBody {
+  filePath: string;
+  chatSessionId?: string;
+}
+
+// Validate the `{ filePath }` body, run the ffmpeg guard, and resolve the
+// script to an absolute path — responding (400 / op-failure) and returning
+// null on any failure. Shared by the movie and PDF SSE routes.
+function resolveStoryRequest(
+  req: Request<object, object, GenerationRequestBody>,
+  res: Response,
+): { filePath: string; absoluteFilePath: string; chatSessionId?: string } | null {
+  const { filePath, chatSessionId } = req.body;
+  if (typeof filePath !== "string" || !filePath) {
+    badRequest(res, "filePath is required");
+    return null;
+  }
+  const ffmpeg = mulmoScriptOps.ffmpegGuard();
+  if (ffmpeg) {
+    sendOpFailure(res, ffmpeg);
+    return null;
+  }
+  const resolved = mulmoScriptOps.resolveStory(filePath);
+  if (!resolved.ok) {
+    sendOpFailure(res, resolved);
+    return null;
+  }
+  return { filePath, absoluteFilePath: resolved.absolutePath, chatSessionId };
+}
+
 // SSE movie generation. Retained for wire compatibility (the extracted
 // View now uses the long-held `generateMovie` dispatch + generation
 // pubsub events instead); the pipeline itself is shared via
 // `mulmoScriptOps.runMovieGeneration`.
 bindRoute(router, API_ROUTES.mulmoScript.generateMovie, async (req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response) => {
-  const { filePath, chatSessionId } = req.body;
-
-  if (typeof filePath !== "string" || !filePath) {
-    badRequest(res, "filePath is required");
-    return;
-  }
-
-  const ffmpeg = mulmoScriptOps.ffmpegGuard();
-  if (ffmpeg) {
-    sendOpFailure(res, ffmpeg);
-    return;
-  }
-
-  const resolved = mulmoScriptOps.resolveStory(filePath);
-  if (!resolved.ok) {
-    sendOpFailure(res, resolved);
-    return;
-  }
-  const absoluteFilePath = resolved.absolutePath;
+  const parsed = resolveStoryRequest(req, res);
+  if (!parsed) return;
+  const { filePath, absoluteFilePath, chatSessionId } = parsed;
 
   if (mulmoScriptOps.inFlightMovies.has(absoluteFilePath)) {
     badRequest(res, "Movie generation is already in progress for this script");
@@ -465,23 +479,9 @@ bindRoute(
 // SSE PDF generation — retained for wire compatibility, same as the
 // movie SSE route above.
 async function handleGeneratePdf(req: Request<object, object, { filePath: string; chatSessionId?: string }>, res: Response): Promise<void> {
-  const { filePath, chatSessionId } = req.body;
-  if (typeof filePath !== "string" || !filePath) {
-    badRequest(res, "filePath is required");
-    return;
-  }
-  const ffmpeg = mulmoScriptOps.ffmpegGuard();
-  if (ffmpeg) {
-    sendOpFailure(res, ffmpeg);
-    return;
-  }
-
-  const resolved = mulmoScriptOps.resolveStory(filePath);
-  if (!resolved.ok) {
-    sendOpFailure(res, resolved);
-    return;
-  }
-  const absoluteFilePath = resolved.absolutePath;
+  const parsed = resolveStoryRequest(req, res);
+  if (!parsed) return;
+  const { filePath, absoluteFilePath, chatSessionId } = parsed;
 
   if (mulmoScriptOps.inFlightPdfs.has(absoluteFilePath)) {
     badRequest(res, "PDF generation is already in progress for this script");

--- a/server/workspace/skills/external/catalog.ts
+++ b/server/workspace/skills/external/catalog.ts
@@ -198,19 +198,33 @@ async function resolveSource(repoIdRaw: string, skillFolderRaw: string, workspac
   return { repoId, skillFolder, sourceDir, url: meta.url };
 }
 
+// Resolve a catalog source, or classify why it failed: a bad-shape id
+// (rejected upstream) → `invalid-id`, otherwise missing-on-disk →
+// `not-found`. The detail-read and star routes share this preamble; the
+// error variants are a subset of both routes' result types.
+type SourceError = { kind: "invalid-id" } | { kind: "not-found"; repoId: string; skillFolder: string };
+
+async function resolveSourceOrError(
+  repoIdRaw: string,
+  skillFolderRaw: string,
+  workspaceRoot: string,
+): Promise<{ ok: true; resolved: ResolvedSource } | { ok: false; error: SourceError }> {
+  const resolved = await resolveSource(repoIdRaw, skillFolderRaw, workspaceRoot);
+  if (resolved) return { ok: true, resolved };
+  if (!isSafeRepoId(repoIdRaw)) return { ok: false, error: { kind: "invalid-id" } };
+  if (skillFolderRaw !== "." && safeFolderName(skillFolderRaw) === null) return { ok: false, error: { kind: "invalid-id" } };
+  return { ok: false, error: { kind: "not-found", repoId: repoIdRaw, skillFolder: skillFolderRaw } };
+}
+
 export async function readExternalCatalogDetail(
   repoIdRaw: string,
   skillFolderRaw: string,
   opts: ExternalCatalogOptions = {},
 ): Promise<ExternalCatalogDetailResult> {
   const workspaceRoot = opts.workspaceRoot ?? workspacePath;
-  const resolved = await resolveSource(repoIdRaw, skillFolderRaw, workspaceRoot);
-  if (!resolved) {
-    // Distinguish bad shape (rejected upstream) from missing-on-disk.
-    if (!isSafeRepoId(repoIdRaw)) return { kind: "invalid-id" };
-    if (skillFolderRaw !== "." && safeFolderName(skillFolderRaw) === null) return { kind: "invalid-id" };
-    return { kind: "not-found", repoId: repoIdRaw, skillFolder: skillFolderRaw };
-  }
+  const source = await resolveSourceOrError(repoIdRaw, skillFolderRaw, workspaceRoot);
+  if (!source.ok) return source.error;
+  const { resolved } = source;
   const skillMd = path.join(resolved.sourceDir, "SKILL.md");
   let raw: string;
   try {
@@ -265,12 +279,9 @@ export type ExternalStarResult =
 
 export async function starExternalCatalogEntry(repoIdRaw: string, skillFolderRaw: string, opts: ExternalCatalogOptions = {}): Promise<ExternalStarResult> {
   const workspaceRoot = opts.workspaceRoot ?? workspacePath;
-  const resolved = await resolveSource(repoIdRaw, skillFolderRaw, workspaceRoot);
-  if (!resolved) {
-    if (!isSafeRepoId(repoIdRaw)) return { kind: "invalid-id" };
-    if (skillFolderRaw !== "." && safeFolderName(skillFolderRaw) === null) return { kind: "invalid-id" };
-    return { kind: "not-found", repoId: repoIdRaw, skillFolder: skillFolderRaw };
-  }
+  const source = await resolveSourceOrError(repoIdRaw, skillFolderRaw, workspaceRoot);
+  if (!source.ok) return source.error;
+  const { resolved } = source;
   const activeId = deriveActiveId(resolved.url, resolved.skillFolder === "." ? null : resolved.skillFolder);
   if (!activeId) return { kind: "invalid-id" };
   const activeSlugDir = path.join(activeDir(workspaceRoot), activeId);


### PR DESCRIPTION
## Summary

「1から順に」の #3。同一ファイル内の**本物の resolve-or-respond 重複**を2つ集約。**純粋な抽出・挙動保存**。

- `catalog.ts` — `readExternalCatalogDetail`/`starExternalCatalogEntry` の「resolveSource → 失敗分類」→ `resolveSourceOrError`
- `mulmo-script.ts` — movie/PDF SSE ルートの「filePath検証 → ffmpeg guard → resolveStory → absolutePath」→ `resolveStoryRequest`

Closes #2156

## Items to Confirm / Review

1. **挙動保存。** どちらも純粋な抽出。`resolveSourceOrError` の error（`invalid-id` / `not-found`）は両ルートの結果型の部分集合。`resolveStoryRequest` は **`filePath` も返す**（後続の `publishGeneration(chatSessionId, kind, filePath, ...)` が元の相対パスを要求するため）。
2. `test_catalog.ts` 19/19 pass。mulmo-script は typecheck + precommit の `yarn test` でカバー。

## User Prompt

- Code Scanning の duplicated を直して。どんどん減らして。i18n/vite/各pkg定型は不要、無理はしない。1から順に。

## 検証

| 項目 | 結果 |
|---|---|
| test_catalog.ts | 19/19 pass |
| typecheck:server / lint | クリーン |
| precommit フル gate | pass（コミット時） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
