### PR TITLE
feat(google-calendar): non-primary calendars + event/calendar colour sync

### DIFF
--- a/docs/remote-host.md
+++ b/docs/remote-host.md
@@ -173,8 +173,10 @@ calling the collection engine directly. Added incrementally across phases:
 | `mutateRemoteViewItem` | Applies an update/delete from a mobile view; policy enforced **host-side** | 4 |
 | `startChat` | Starts a visible chat from the phone (message + optional role + attachments) | — |
 | `ingestAttachments` | Pulls staged files from Firebase Storage into the workspace | — |
-| `google.calendar.createEvent` | Creates a Google Calendar event (`{ event }`); params `summary`, `start`, `end` (ISO 8601), optional `description` | — |
-| `google.calendar.listEvents` | Upcoming primary-calendar events (`{ events }`); optional `timeMin`, `maxResults` (≤ 50) | — |
+| `google.calendar.createEvent` | Creates a Google Calendar event (`{ event }`); params `summary`, `start`, `end` (ISO 8601), optional `description`, `calendarId`, `colorId` | — |
+| `google.calendar.listEvents` | Upcoming events (`{ events }`, each with `colorId`); optional `calendarId` (default primary), `timeMin`, `maxResults` (≤ 50) | — |
+| `google.calendar.listCalendars` | Calendars the user has added/subscribed to (`{ calendars }` — id, summary, primary, colours) | — |
+| `google.calendar.colors` | Event/calendar colour palettes mapping `colorId` → hex (`{ colors }`) | — |
 
 The `google.calendar.*` handlers run against the **host's own Google OAuth
 grant** (independent of Firebase Auth): the user links the account once — from

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -338,6 +338,7 @@ shipped builders produce, and asserts `handlePermission` comes back over the MCP
 - **"multiple client_secret_*.json files found"**.
 - **"Google Calendar API: HTTP 403"** with a hint about enabling the API.
 - **"could not obtain a Google access token"** (grant revoked).
+- `calendarListCalendars` / non-primary calendar lookups fail with **HTTP 401/403 / insufficient scope**, or the list comes back empty even though the user has other calendars.
 
 ### Cause
 
@@ -358,6 +359,11 @@ Two ways the link can be minted, and the tool picks automatically:
 - **Not linked / grant revoked** — ask the user to link (or re-link) the account from this app's
   settings, then retry. Do NOT tell them to create a Google Cloud project, and do NOT try to
   create or edit the token file yourself.
+- **Calendar-list / non-primary lookup fails with insufficient scope (or lists nothing)** — the
+  account was linked before the calendar-list read scope (`calendar.calendarlist.readonly`) was
+  added, so the stored grant predates it. Ask the user to re-link from settings to add the scope,
+  then retry. Reading events on a non-primary calendar by id needs no re-link once the calendar
+  list is visible.
 - **Sign-in service unreachable / HTTP error** — the broker is down or the network is blocked.
   It is only needed to link and to renew an expired access token; ask the user to retry shortly.
   (A user with their own `~/.secrets/client_secret_*.json` never depends on it.)

--- a/packages/core/src/google/auth.ts
+++ b/packages/core/src/google/auth.ts
@@ -22,12 +22,18 @@ import { clientSecretPresence, loadClientSecret, type InstalledClientSecret } fr
 import { deleteGoogleTokens, loadGoogleTokens, saveGoogleTokens, type IssuedVia } from "./tokenStore.js";
 
 export const GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.events";
+/** Minimal read scope for the calendar list + per-calendar colours.
+ *  `calendar.events` already covers reading/writing events on any calendar, but
+ *  discovering WHICH calendars the user has (CalendarList.list) needs a
+ *  calendar-list read scope — this is the narrowest one that grants it. Kept in
+ *  step with the broker's consent scopes so local- and broker-linked accounts
+ *  grant the same set. */
+export const GOOGLE_CALENDARLIST_SCOPE = "https://www.googleapis.com/auth/calendar.calendarlist.readonly";
 export const GOOGLE_TASKS_SCOPE = "https://www.googleapis.com/auth/tasks";
 export const GOOGLE_DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file";
 /** Requested at consent as one set — matches the scopes registered on the
- *  OAuth consent screen, so a single re-link covers every supported API
- *  (Calendar now; Tasks / Drive tools ride the same grant later). */
-export const GOOGLE_SCOPES = [GOOGLE_CALENDAR_SCOPE, GOOGLE_TASKS_SCOPE, GOOGLE_DRIVE_FILE_SCOPE];
+ *  OAuth consent screen, so a single re-link covers every supported API. */
+export const GOOGLE_SCOPES = [GOOGLE_CALENDAR_SCOPE, GOOGLE_CALENDARLIST_SCOPE, GOOGLE_TASKS_SCOPE, GOOGLE_DRIVE_FILE_SCOPE];
 const CALLBACK_PATH = "/oauth2callback";
 const AUTH_TIMEOUT_MS = 5 * ONE_MINUTE_MS;
 const STATE_BYTES = 16;

--- a/packages/core/src/google/calendar.ts
+++ b/packages/core/src/google/calendar.ts
@@ -7,6 +7,11 @@ import { isRecord } from "./util.js";
 const CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
 const CALENDAR_API_LABEL = "Google Calendar API";
 const DEFAULT_CALENDAR_ID = "primary";
+// CalendarList.list is paginated; page through nextPageToken so an account
+// with many subscribed calendars isn't silently truncated. The page cap is a
+// runaway guard — 250 * 40 = 10k calendars, far beyond any real account.
+const CALENDAR_LIST_PAGE_SIZE = 250;
+const MAX_CALENDAR_LIST_PAGES = 40;
 
 // `||` (not `??`) so an empty-string calendarId also falls back to primary
 // instead of building a malformed `/calendars//events` URL.
@@ -136,12 +141,39 @@ export async function listCalendarEvents(accessToken: string, input: ListEventsI
   return itemsOf(listed).map(toEventSummary);
 }
 
+export interface CalendarListPage {
+  items: unknown[];
+  nextPageToken?: string;
+}
+
+/** Pagination loop for CalendarList.list, extracted so it can be tested without
+ *  network. Stops at the last page (no token) or the runaway page cap. */
+export async function collectCalendarPages(
+  fetchPage: (pageToken?: string) => Promise<CalendarListPage>,
+  maxPages = MAX_CALENDAR_LIST_PAGES,
+): Promise<CalendarSummary[]> {
+  const calendars: CalendarSummary[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < maxPages; page += 1) {
+    const { items, nextPageToken } = await fetchPage(pageToken);
+    calendars.push(...items.map(toCalendarSummary));
+    if (!nextPageToken) break;
+    pageToken = nextPageToken;
+  }
+  return calendars;
+}
+
 /** The calendars the user has added/subscribed to (primary + secondary +
- *  shared), each with its id, name and colour. Needs the calendar-list read
- *  scope (GOOGLE_CALENDARLIST_SCOPE). */
+ *  shared), each with its id, name and colour, following pagination. Needs the
+ *  calendar-list read scope (GOOGLE_CALENDARLIST_SCOPE). */
 export async function listCalendars(accessToken: string): Promise<CalendarSummary[]> {
-  const listed = await googleRequest(CALENDAR_API_LABEL, accessToken, `${CALENDAR_BASE_URL}/users/me/calendarList`);
-  return itemsOf(listed).map(toCalendarSummary);
+  return collectCalendarPages(async (pageToken) => {
+    const params = new URLSearchParams({ maxResults: String(CALENDAR_LIST_PAGE_SIZE) });
+    if (pageToken) params.set("pageToken", pageToken);
+    const payload = await googleRequest(CALENDAR_API_LABEL, accessToken, `${CALENDAR_BASE_URL}/users/me/calendarList?${params.toString()}`);
+    const record = asRecord(payload);
+    return { items: itemsOf(payload), nextPageToken: typeof record.nextPageToken === "string" ? record.nextPageToken : undefined };
+  });
 }
 
 /** Resolve a `colorId` (on an event or calendar) to its hex background/foreground. */

--- a/packages/core/src/google/calendar.ts
+++ b/packages/core/src/google/calendar.ts
@@ -8,7 +8,9 @@ const CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
 const CALENDAR_API_LABEL = "Google Calendar API";
 const DEFAULT_CALENDAR_ID = "primary";
 
-const eventsUrl = (calendarId: string | undefined): string => `${CALENDAR_BASE_URL}/calendars/${encodeURIComponent(calendarId ?? DEFAULT_CALENDAR_ID)}/events`;
+// `||` (not `??`) so an empty-string calendarId also falls back to primary
+// instead of building a malformed `/calendars//events` URL.
+const eventsUrl = (calendarId: string | undefined): string => `${CALENDAR_BASE_URL}/calendars/${encodeURIComponent(calendarId || DEFAULT_CALENDAR_ID)}/events`;
 
 export interface CalendarEventInput {
   summary: string;

--- a/packages/core/src/google/calendar.ts
+++ b/packages/core/src/google/calendar.ts
@@ -1,20 +1,31 @@
-// Google Calendar v3 REST calls against the user's primary calendar.
-import { asRecord, googleApiError, googleRequest, stringField, DEFAULT_LIST_MAX_RESULTS } from "./apiClient.js";
+// Google Calendar v3 REST calls. Events read/write against any calendar the
+// user can access (default: their primary); the calendar list and colour
+// palette let callers show non-primary calendars and their colours.
+import { asRecord, googleApiError, googleRequest, itemsOf, stringField, DEFAULT_LIST_MAX_RESULTS } from "./apiClient.js";
 import { isRecord } from "./util.js";
 
-const CALENDAR_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+const CALENDAR_BASE_URL = "https://www.googleapis.com/calendar/v3";
 const CALENDAR_API_LABEL = "Google Calendar API";
+const DEFAULT_CALENDAR_ID = "primary";
+
+const eventsUrl = (calendarId: string | undefined): string => `${CALENDAR_BASE_URL}/calendars/${encodeURIComponent(calendarId ?? DEFAULT_CALENDAR_ID)}/events`;
 
 export interface CalendarEventInput {
   summary: string;
   startDateTime: string;
   endDateTime: string;
   description?: string;
+  /** Calendar to create the event on; defaults to the user's primary. */
+  calendarId?: string;
+  /** Event colour (Google event palette id "1".."11"); omit to inherit the calendar's colour. */
+  colorId?: string;
 }
 
 export interface ListEventsInput {
   timeMin?: string;
   maxResults?: number;
+  /** Calendar to read; defaults to the user's primary. */
+  calendarId?: string;
 }
 
 export interface CalendarEventSummary {
@@ -24,6 +35,33 @@ export interface CalendarEventSummary {
   end: string;
   htmlLink: string;
   status: string;
+  /** Google event palette id ("1".."11"), or "" when the event inherits the calendar's colour. */
+  colorId: string;
+}
+
+export interface CalendarSummary {
+  id: string;
+  summary: string;
+  description: string;
+  /** True only for the user's primary calendar. */
+  primary: boolean;
+  accessRole: string;
+  backgroundColor: string;
+  foregroundColor: string;
+  /** Calendar palette id backing background/foregroundColor. */
+  colorId: string;
+}
+
+export interface CalendarColorEntry {
+  background: string;
+  foreground: string;
+}
+
+/** Palettes from Google's `/colors` endpoint: `event` maps an event's `colorId`
+ *  and `calendar` maps a calendar's `colorId` to hex background/foreground. */
+export interface CalendarColors {
+  event: Record<string, CalendarColorEntry>;
+  calendar: Record<string, CalendarColorEntry>;
 }
 
 // All-day events carry `date`, timed events carry `dateTime`.
@@ -43,7 +81,30 @@ export const toEventSummary = (value: unknown): CalendarEventSummary => {
     end: eventTime(record.end),
     htmlLink: stringField(record, "htmlLink"),
     status: stringField(record, "status"),
+    colorId: stringField(record, "colorId"),
   };
+};
+
+export const toCalendarSummary = (value: unknown): CalendarSummary => {
+  const record = asRecord(value);
+  return {
+    id: stringField(record, "id"),
+    summary: stringField(record, "summary"),
+    description: stringField(record, "description"),
+    primary: record.primary === true,
+    accessRole: stringField(record, "accessRole"),
+    backgroundColor: stringField(record, "backgroundColor"),
+    foregroundColor: stringField(record, "foregroundColor"),
+    colorId: stringField(record, "colorId"),
+  };
+};
+
+const toColorMap = (value: unknown): Record<string, CalendarColorEntry> => {
+  const entries = Object.entries(asRecord(value)).map(([colorId, entry]): [string, CalendarColorEntry] => {
+    const record = asRecord(entry);
+    return [colorId, { background: stringField(record, "background"), foreground: stringField(record, "foreground") }];
+  });
+  return Object.fromEntries(entries);
 };
 
 /** Kept as a named export for the existing unit tests / callers; the shared
@@ -56,8 +117,9 @@ export async function createCalendarEvent(accessToken: string, input: CalendarEv
     description: input.description,
     start: { dateTime: input.startDateTime },
     end: { dateTime: input.endDateTime },
+    ...(input.colorId ? { colorId: input.colorId } : {}),
   };
-  const created = await googleRequest(CALENDAR_API_LABEL, accessToken, CALENDAR_EVENTS_URL, { method: "POST", body: JSON.stringify(body) });
+  const created = await googleRequest(CALENDAR_API_LABEL, accessToken, eventsUrl(input.calendarId), { method: "POST", body: JSON.stringify(body) });
   return toEventSummary(created);
 }
 
@@ -68,8 +130,21 @@ export async function listCalendarEvents(accessToken: string, input: ListEventsI
     singleEvents: "true",
     orderBy: "startTime",
   });
-  const listed = await googleRequest(CALENDAR_API_LABEL, accessToken, `${CALENDAR_EVENTS_URL}?${params.toString()}`);
-  const record = asRecord(listed);
-  const items = Array.isArray(record.items) ? record.items : [];
-  return items.map(toEventSummary);
+  const listed = await googleRequest(CALENDAR_API_LABEL, accessToken, `${eventsUrl(input.calendarId)}?${params.toString()}`);
+  return itemsOf(listed).map(toEventSummary);
+}
+
+/** The calendars the user has added/subscribed to (primary + secondary +
+ *  shared), each with its id, name and colour. Needs the calendar-list read
+ *  scope (GOOGLE_CALENDARLIST_SCOPE). */
+export async function listCalendars(accessToken: string): Promise<CalendarSummary[]> {
+  const listed = await googleRequest(CALENDAR_API_LABEL, accessToken, `${CALENDAR_BASE_URL}/users/me/calendarList`);
+  return itemsOf(listed).map(toCalendarSummary);
+}
+
+/** Resolve a `colorId` (on an event or calendar) to its hex background/foreground. */
+export async function getCalendarColors(accessToken: string): Promise<CalendarColors> {
+  const payload = await googleRequest(CALENDAR_API_LABEL, accessToken, `${CALENDAR_BASE_URL}/colors`);
+  const record = asRecord(payload);
+  return { event: toColorMap(record.event), calendar: toColorMap(record.calendar) };
 }

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -27,6 +27,7 @@ export { createGoogleAuthFlow, googleAuthFlow, type GoogleAuthFlow, type GoogleA
 export { googleApiError, DEFAULT_LIST_MAX_RESULTS, MAX_LIST_RESULTS } from "./apiClient.js";
 export {
   calendarApiError,
+  collectCalendarPages,
   createCalendarEvent,
   getCalendarColors,
   listCalendarEvents,
@@ -37,6 +38,7 @@ export {
   type CalendarColors,
   type CalendarEventInput,
   type CalendarEventSummary,
+  type CalendarListPage,
   type CalendarSummary,
   type ListEventsInput,
 } from "./calendar.js";

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -16,6 +16,7 @@ export {
   unlinkGoogle,
   waitForAuthCode,
   GOOGLE_CALENDAR_SCOPE,
+  GOOGLE_CALENDARLIST_SCOPE,
   GOOGLE_TASKS_SCOPE,
   GOOGLE_DRIVE_FILE_SCOPE,
   GOOGLE_SCOPES,
@@ -27,10 +28,16 @@ export { googleApiError, DEFAULT_LIST_MAX_RESULTS, MAX_LIST_RESULTS } from "./ap
 export {
   calendarApiError,
   createCalendarEvent,
+  getCalendarColors,
   listCalendarEvents,
+  listCalendars,
+  toCalendarSummary,
   toEventSummary,
+  type CalendarColorEntry,
+  type CalendarColors,
   type CalendarEventInput,
   type CalendarEventSummary,
+  type CalendarSummary,
   type ListEventsInput,
 } from "./calendar.js";
 export {

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -21,7 +21,7 @@
     "test": "tsx --test test/test_*.ts"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^0.22.0"
+    "@mulmoclaude/core": "^0.23.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^0.4.0",

--- a/packages/plugins/google-plugin/src/args.ts
+++ b/packages/plugins/google-plugin/src/args.ts
@@ -13,6 +13,9 @@ const IsoDateTimeWithOffset = z.string().refine(isIsoDateTimeWithOffset, {
 
 const MaxResults = z.number().int().min(1).max(MAX_LIST_RESULTS).optional();
 const NonEmpty = z.string().min(1);
+// Trimmed + non-empty: an empty/whitespace calendarId would build a malformed
+// `/calendars//events` URL, and colorId "" would be sent as a bad palette id.
+const OptionalNonEmpty = z.string().trim().min(1).optional();
 
 export const GoogleArgs = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("status") }),
@@ -21,7 +24,7 @@ export const GoogleArgs = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("calendarColors") }),
   z.object({
     kind: z.literal("calendarListEvents"),
-    calendarId: z.string().optional(),
+    calendarId: OptionalNonEmpty,
     timeMin: IsoDateTimeWithOffset.optional(),
     maxResults: MaxResults,
   }),
@@ -31,8 +34,8 @@ export const GoogleArgs = z.discriminatedUnion("kind", [
     start: IsoDateTimeWithOffset,
     end: IsoDateTimeWithOffset,
     description: z.string().optional(),
-    calendarId: z.string().optional(),
-    colorId: z.string().optional(),
+    calendarId: OptionalNonEmpty,
+    colorId: OptionalNonEmpty,
   }),
   // Tasks
   z.object({ kind: z.literal("taskListsList") }),

--- a/packages/plugins/google-plugin/src/args.ts
+++ b/packages/plugins/google-plugin/src/args.ts
@@ -17,8 +17,11 @@ const NonEmpty = z.string().min(1);
 export const GoogleArgs = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("status") }),
   // Calendar
+  z.object({ kind: z.literal("calendarListCalendars") }),
+  z.object({ kind: z.literal("calendarColors") }),
   z.object({
     kind: z.literal("calendarListEvents"),
+    calendarId: z.string().optional(),
     timeMin: IsoDateTimeWithOffset.optional(),
     maxResults: MaxResults,
   }),
@@ -28,6 +31,8 @@ export const GoogleArgs = z.discriminatedUnion("kind", [
     start: IsoDateTimeWithOffset,
     end: IsoDateTimeWithOffset,
     description: z.string().optional(),
+    calendarId: z.string().optional(),
+    colorId: z.string().optional(),
   }),
   // Tasks
   z.object({ kind: z.literal("taskListsList") }),

--- a/packages/plugins/google-plugin/src/definition.ts
+++ b/packages/plugins/google-plugin/src/definition.ts
@@ -14,12 +14,14 @@ export const TOOL_DEFINITION = {
     "This is independent of claude.ai Google connectors; the tool works without them. " +
     "If a call fails with 'Google account not linked', ask the user to link their Google account in this app's settings, then retry the original call.",
   description:
-    "Operate the user's Google services through the locally linked Google account: Calendar (primary calendar), Tasks, and Drive. Supported kinds:\n" +
+    "Operate the user's Google services through the locally linked Google account: Calendar, Tasks, and Drive. Supported kinds:\n" +
     " - `status`: report whether the Google account is linked on this machine — call this first when unsure.\n" +
     "\n" +
-    "Calendar:\n" +
-    " - `calendarListEvents`: list upcoming events. Optional `timeMin` (ISO 8601 date-time with timezone offset; default now) and `maxResults` (1-50, default 10).\n" +
-    " - `calendarCreateEvent`: create an event. Requires `summary`, `start`, `end` — ISO 8601 date-times WITH a timezone offset (e.g. 2026-07-17T09:00:00+09:00); optional `description`.\n" +
+    "Calendar (events default to the primary calendar; pass `calendarId` — from `calendarListCalendars` — to target another):\n" +
+    " - `calendarListCalendars`: list the calendars the user has added/subscribed to (`id`, `summary`, `primary`, `backgroundColor`/`foregroundColor` hex, `colorId`, `accessRole`). Call this to work with a non-primary calendar.\n" +
+    " - `calendarColors`: palettes that map an event/calendar `colorId` to hex — `event` for per-event colours, `calendar` for calendar colours.\n" +
+    " - `calendarListEvents`: list upcoming events (each carries `colorId`, empty when it inherits the calendar colour). Optional `calendarId`, `timeMin` (ISO 8601 date-time with timezone offset; default now), `maxResults` (1-50, default 10).\n" +
+    ' - `calendarCreateEvent`: create an event. Requires `summary`, `start`, `end` — ISO 8601 date-times WITH a timezone offset (e.g. 2026-07-17T09:00:00+09:00); optional `description`, `calendarId`, `colorId` (event palette id "1"-"11").\n' +
     "\n" +
     "Tasks:\n" +
     " - `taskListsList`: list the user's task lists (`id`, `title`). Only needed when the user means a list other than their default one.\n" +
@@ -38,6 +40,8 @@ export const TOOL_DEFINITION = {
         type: "string",
         enum: [
           "status",
+          "calendarListCalendars",
+          "calendarColors",
           "calendarListEvents",
           "calendarCreateEvent",
           "taskListsList",
@@ -49,6 +53,8 @@ export const TOOL_DEFINITION = {
           "driveRead",
         ],
       },
+      calendarId: { type: "string", description: "calendar kinds: target calendar id from calendarListCalendars (default: the user's primary)" },
+      colorId: { type: "string", description: 'calendarCreateEvent: optional event palette colour id "1"-"11"' },
       timeMin: { type: "string", description: "calendarListEvents: lower bound, ISO 8601 with timezone offset (default: now)" },
       maxResults: { type: "number", description: "list kinds: max items to return, 1-50 (default 10)" },
       summary: { type: "string", description: "calendarCreateEvent: event title" },

--- a/packages/plugins/google-plugin/src/index.ts
+++ b/packages/plugins/google-plugin/src/index.ts
@@ -13,8 +13,10 @@ import {
   createCalendarEvent,
   createDriveFile,
   createTask,
+  getCalendarColors,
   getGoogleAccessToken,
   listCalendarEvents,
+  listCalendars,
   listDriveFiles,
   listTaskLists,
   listTasks,
@@ -37,8 +39,15 @@ export default definePlugin(({ log }) => {
         const linked = Boolean(tokens?.refresh_token);
         return { ok: true, linked, clientSecret, ...(linked ? {} : { guidance: LINK_GUIDANCE }) };
       }
+      case "calendarListCalendars": {
+        return { ok: true, calendars: await listCalendars(await getGoogleAccessToken()) };
+      }
+      case "calendarColors": {
+        return { ok: true, colors: await getCalendarColors(await getGoogleAccessToken()) };
+      }
       case "calendarListEvents": {
         const events = await listCalendarEvents(await getGoogleAccessToken(), {
+          calendarId: args.calendarId,
           timeMin: args.timeMin,
           maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS,
         });
@@ -50,6 +59,8 @@ export default definePlugin(({ log }) => {
           startDateTime: args.start,
           endDateTime: args.end,
           description: args.description,
+          calendarId: args.calendarId,
+          colorId: args.colorId,
         });
         // Log ids only — titles / bodies are personal content.
         log.info("calendar event created", { id: event.id });

--- a/packages/plugins/google-plugin/test/test_args_validation.ts
+++ b/packages/plugins/google-plugin/test/test_args_validation.ts
@@ -68,6 +68,18 @@ describe("GoogleArgs", () => {
     assert.equal(args.kind === "calendarListEvents" && args.calendarId, "team@group.calendar.google.com");
   });
 
+  it("rejects an empty or whitespace calendarId (would build /calendars//events)", () => {
+    assert.throws(() => GoogleArgs.parse({ kind: "calendarListEvents", calendarId: "" }));
+    assert.throws(() => GoogleArgs.parse({ kind: "calendarListEvents", calendarId: "   " }));
+    const create = { kind: "calendarCreateEvent", summary: "x", start: "2026-07-17T09:00:00Z", end: "2026-07-17T10:00:00Z" };
+    assert.throws(() => GoogleArgs.parse({ ...create, calendarId: "" }));
+  });
+
+  it("trims calendarId whitespace", () => {
+    const args = GoogleArgs.parse({ kind: "calendarListEvents", calendarId: "  team@group.calendar.google.com  " });
+    assert.equal(args.kind === "calendarListEvents" && args.calendarId, "team@group.calendar.google.com");
+  });
+
   it("parses a full calendarCreateEvent", () => {
     const args = GoogleArgs.parse({
       kind: "calendarCreateEvent",

--- a/packages/plugins/google-plugin/test/test_args_validation.ts
+++ b/packages/plugins/google-plugin/test/test_args_validation.ts
@@ -58,6 +58,16 @@ describe("GoogleArgs", () => {
     assert.throws(() => GoogleArgs.parse({ kind: "calendarListEvents", maxResults: 2.5 }));
   });
 
+  it("parses calendarListCalendars and calendarColors", () => {
+    assert.deepEqual(GoogleArgs.parse({ kind: "calendarListCalendars" }), { kind: "calendarListCalendars" });
+    assert.deepEqual(GoogleArgs.parse({ kind: "calendarColors" }), { kind: "calendarColors" });
+  });
+
+  it("parses calendarListEvents targeting a non-primary calendar", () => {
+    const args = GoogleArgs.parse({ kind: "calendarListEvents", calendarId: "team@group.calendar.google.com" });
+    assert.equal(args.kind === "calendarListEvents" && args.calendarId, "team@group.calendar.google.com");
+  });
+
   it("parses a full calendarCreateEvent", () => {
     const args = GoogleArgs.parse({
       kind: "calendarCreateEvent",
@@ -65,8 +75,11 @@ describe("GoogleArgs", () => {
       start: "2026-07-17T09:00:00+09:00",
       end: "2026-07-17T09:15:00+09:00",
       description: "daily",
+      calendarId: "team@group.calendar.google.com",
+      colorId: "7",
     });
     assert.equal(args.kind, "calendarCreateEvent");
+    assert.equal(args.kind === "calendarCreateEvent" && args.colorId, "7");
   });
 
   it("rejects calendarCreateEvent with a date-only start", () => {

--- a/plans/feat-google-calendar-nonprimary-colors.md
+++ b/plans/feat-google-calendar-nonprimary-colors.md
@@ -1,0 +1,59 @@
+# feat(google-calendar): 非Primary カレンダー取得 + イベント/カレンダー色の同期
+
+Issue: receptron/mulmoclaude#2162
+
+## ユーザーフィードバック
+
+> Googleカレンダーの連携について、もし可能であれば、Primary以外のカレンダーの取得とカレンダー項目の色も同期できると大変助かります。次の変更の際にご検討いただけると嬉しいです
+
+要件の確認: **ユーザーが Google アカウントに登録(追加・購読)しているカレンダーの一覧を参照**し、
+そこからイベントを読み、各イベント/カレンダーの色も取得できるようにする。
+
+## スコープ
+
+現状は取得が `calendar.events` スコープ・URL が `/calendars/primary/events` に固定。
+
+- `CalendarList.list`(カレンダー一覧の発見)には読み取りスコープが必要。
+- **broker(mulmoserver)側で最小の `calendar.calendarlist.readonly` を追加済み**(ユーザー対応済み)。
+  → mulmoclaude 側の `GOOGLE_SCOPES` も `calendar.calendarlist.readonly` を追加して broker と揃える(ローカル連携パスも同じ許可を要求)。
+- 非Primary の**イベント読み取り**(ID 指定)は既存 `calendar.events` で可能。
+- イベントの `colorId` は既存スコープで Event に付いてくる。hex 解決は `/colors`(既存 `calendar.events` 内)。
+
+→ 追加スコープは最小の `calendar.calendarlist.readonly` の1個のみ。色は追加スコープ不要。
+
+## 実装
+
+### `@mulmoclaude/core` (packages/core/src/google/)
+
+- `auth.ts`: `GOOGLE_CALENDARLIST_SCOPE`(`calendar.calendarlist.readonly`)を定義し `GOOGLE_SCOPES` に追加。
+- `calendar.ts`:
+  - `CalendarEventSummary` に `colorId` を追加。
+  - `ListEventsInput` / `CalendarEventInput` に `calendarId`(既定 `primary`)を追加。create には `colorId` も。
+  - `listCalendars()` → `GET /users/me/calendarList`(id / summary / description / primary / accessRole / backgroundColor / foregroundColor / colorId)。
+  - `getCalendarColors()` → `GET /colors`(event / calendar パレット)。
+- `index.ts`: 上記の関数/型を re-export。
+
+### `@mulmoclaude/google-plugin`
+
+- `args.ts`: kinds 追加 `calendarListCalendars` / `calendarColors`。`calendarListEvents`・`calendarCreateEvent` に `calendarId`、create に `colorId`。
+- `index.ts`: dispatch 追加。
+- `definition.ts`: tool description / enum / params 更新。
+
+### host (server/)
+
+- `remoteHost/handlers/googleCalendar.ts`: 既存 list/create に `calendarId` を透過。`google.calendar.listCalendars` / `google.calendar.colors` を追加。
+- `remoteHost/handlers/index.ts`: 新コマンド登録。
+
+### tests / docs
+
+- `test/services/google/test_googleCalendar.ts`: `colorId` 反映、`toCalendarSummary` / colors マッピング追加。
+- `test/remoteHost/test_googleCalendarHandlers.ts`: `calendarId` 透過、新ハンドラ。
+- `packages/plugins/google-plugin/test/test_args_validation.ts`: 新 kinds。
+- `packages/core/assets/helps/error-recovery.md`: 新スコープに伴う **再連携** ガイド追記(古い連携では一覧/色が取れない)。
+
+## ロールアウト順
+
+1. broker が `calendar.calendarlist.readonly` を consent に追加(済)。
+2. GCP 同意画面(broker web client + desktop client)に `calendar.calendarlist.readonly` 登録を確認。
+3. mulmoclaude コードをリリース(`@mulmoclaude/core` + `google-plugin` minor → launcher 再publish)。
+4. 既存ユーザ全員が再連携して新スコープを付与。

--- a/server/remoteHost/handlers/googleCalendar.ts
+++ b/server/remoteHost/handlers/googleCalendar.ts
@@ -36,7 +36,9 @@ const optionalString = (params: JsonObject, key: string): string | undefined => 
   const value = params[key];
   if (value === undefined || value === null) return undefined;
   if (typeof value !== "string" || value.trim() === "") throw new Error(`${key} must be a non-empty string`);
-  return value;
+  // Return trimmed so whitespace can't reach the Google API (matches the
+  // plugin's Zod .trim() normalization).
+  return value.trim();
 };
 
 // Calendar's `dateTime`/`timeMin` are RFC3339 and reject date-only,

--- a/server/remoteHost/handlers/googleCalendar.ts
+++ b/server/remoteHost/handlers/googleCalendar.ts
@@ -8,21 +8,33 @@
 import {
   createCalendarEvent,
   DEFAULT_LIST_MAX_RESULTS,
+  getCalendarColors,
   getGoogleAccessToken,
   isIsoDateTimeWithOffset,
   listCalendarEvents,
+  listCalendars,
   MAX_LIST_RESULTS,
+  type CalendarColorEntry,
 } from "@mulmoclaude/core/google";
-import type { CommandHandler, JsonObject } from "../commandChannel.js";
+import type { CommandHandler, JsonObject, JsonValue } from "../commandChannel.js";
 
 export interface GoogleCalendarDeps {
   getAccessToken: typeof getGoogleAccessToken;
   createEvent: typeof createCalendarEvent;
   listEvents: typeof listCalendarEvents;
+  listCalendars: typeof listCalendars;
+  getColors: typeof getCalendarColors;
 }
 
 const requiredString = (params: JsonObject, key: string): string => {
   const value = params[key];
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${key} must be a non-empty string`);
+  return value;
+};
+
+const optionalString = (params: JsonObject, key: string): string | undefined => {
+  const value = params[key];
+  if (value === undefined || value === null) return undefined;
   if (typeof value !== "string" || value.trim() === "") throw new Error(`${key} must be a non-empty string`);
   return value;
 };
@@ -47,6 +59,14 @@ const clampMaxResults = (value: unknown): number => {
   return Math.min(Math.max(value, 1), MAX_LIST_RESULTS);
 };
 
+// Spread rebuilds an anonymous object type — the named CalendarColorEntry
+// interface (no index signature) can't satisfy the channel's structural
+// JsonValue directly (same constraint as CalendarEventSummary).
+const toColorMapJson = (map: Record<string, CalendarColorEntry>): JsonObject =>
+  Object.fromEntries(
+    Object.entries(map).map(([colorId, entry]): [string, JsonValue] => [colorId, { background: entry.background, foreground: entry.foreground }]),
+  );
+
 export const createGoogleCalendarCreateEvent =
   (deps: GoogleCalendarDeps): CommandHandler =>
   async (params: JsonObject) => {
@@ -55,6 +75,8 @@ export const createGoogleCalendarCreateEvent =
       startDateTime: asDateTime(requiredString(params, "start"), "start"),
       endDateTime: asDateTime(requiredString(params, "end"), "end"),
       description: typeof params.description === "string" ? params.description : undefined,
+      calendarId: optionalString(params, "calendarId"),
+      colorId: optionalString(params, "colorId"),
     };
     const event = await deps.createEvent(await deps.getAccessToken(), input);
     // Spread rebuilds an anonymous object type — the CalendarEventSummary
@@ -68,10 +90,33 @@ export const createGoogleCalendarListEvents =
   async (params: JsonObject) => {
     const timeMin = optionalDateTime(params, "timeMin");
     const maxResults = clampMaxResults(params.maxResults);
-    const events = await deps.listEvents(await deps.getAccessToken(), { timeMin, maxResults });
+    const calendarId = optionalString(params, "calendarId");
+    const events = await deps.listEvents(await deps.getAccessToken(), { timeMin, maxResults, calendarId });
     return { events: events.map((event) => ({ ...event })) };
   };
 
-const deps: GoogleCalendarDeps = { getAccessToken: getGoogleAccessToken, createEvent: createCalendarEvent, listEvents: listCalendarEvents };
+export const createGoogleCalendarListCalendars =
+  (deps: GoogleCalendarDeps): CommandHandler =>
+  async () => {
+    const calendars = await deps.listCalendars(await deps.getAccessToken());
+    return { calendars: calendars.map((calendar) => ({ ...calendar })) };
+  };
+
+export const createGoogleCalendarColors =
+  (deps: GoogleCalendarDeps): CommandHandler =>
+  async () => {
+    const colors = await deps.getColors(await deps.getAccessToken());
+    return { colors: { event: toColorMapJson(colors.event), calendar: toColorMapJson(colors.calendar) } };
+  };
+
+const deps: GoogleCalendarDeps = {
+  getAccessToken: getGoogleAccessToken,
+  createEvent: createCalendarEvent,
+  listEvents: listCalendarEvents,
+  listCalendars,
+  getColors: getCalendarColors,
+};
 export const googleCalendarCreateEvent = createGoogleCalendarCreateEvent(deps);
 export const googleCalendarListEvents = createGoogleCalendarListEvents(deps);
+export const googleCalendarListCalendars = createGoogleCalendarListCalendars(deps);
+export const googleCalendarColors = createGoogleCalendarColors(deps);

--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -6,7 +6,7 @@ import { getCollection } from "./getCollection.js";
 import { getFeed } from "./getFeed.js";
 import { getRemoteView } from "./getRemoteView.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
-import { googleCalendarCreateEvent, googleCalendarListEvents } from "./googleCalendar.js";
+import { googleCalendarColors, googleCalendarCreateEvent, googleCalendarListCalendars, googleCalendarListEvents } from "./googleCalendar.js";
 import { listAccountingBooks } from "./listAccountingBooks.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
@@ -29,4 +29,6 @@ export const handlers: CommandHandlers = {
   startChat,
   "google.calendar.createEvent": googleCalendarCreateEvent,
   "google.calendar.listEvents": googleCalendarListEvents,
+  "google.calendar.listCalendars": googleCalendarListCalendars,
+  "google.calendar.colors": googleCalendarColors,
 };

--- a/test/remoteHost/test_googleCalendarHandlers.ts
+++ b/test/remoteHost/test_googleCalendarHandlers.ts
@@ -176,6 +176,12 @@ describe("createGoogleCalendarListEvents", () => {
     assert.equal(calls.listInputs[0]?.calendarId, "team@group.calendar.google.com");
   });
 
+  it("trims a whitespace-padded calendarId before it reaches the engine", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarListEvents(deps)({ calendarId: "  team@group.calendar.google.com  " });
+    assert.equal(calls.listInputs[0]?.calendarId, "team@group.calendar.google.com");
+  });
+
   it("rejects a malformed timeMin", async () => {
     const { deps } = stubDeps();
     await assert.rejects(

--- a/test/remoteHost/test_googleCalendarHandlers.ts
+++ b/test/remoteHost/test_googleCalendarHandlers.ts
@@ -4,8 +4,22 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import type { JsonObject } from "../../server/remoteHost/commandChannel.js";
-import { createGoogleCalendarCreateEvent, createGoogleCalendarListEvents, type GoogleCalendarDeps } from "../../server/remoteHost/handlers/googleCalendar.js";
-import { DEFAULT_LIST_MAX_RESULTS, MAX_LIST_RESULTS, type CalendarEventInput, type CalendarEventSummary, type ListEventsInput } from "@mulmoclaude/core/google";
+import {
+  createGoogleCalendarColors,
+  createGoogleCalendarCreateEvent,
+  createGoogleCalendarListCalendars,
+  createGoogleCalendarListEvents,
+  type GoogleCalendarDeps,
+} from "../../server/remoteHost/handlers/googleCalendar.js";
+import {
+  DEFAULT_LIST_MAX_RESULTS,
+  MAX_LIST_RESULTS,
+  type CalendarColors,
+  type CalendarEventInput,
+  type CalendarEventSummary,
+  type CalendarSummary,
+  type ListEventsInput,
+} from "@mulmoclaude/core/google";
 
 const sampleEvent: CalendarEventSummary = {
   id: "ev1",
@@ -14,6 +28,23 @@ const sampleEvent: CalendarEventSummary = {
   end: "2026-07-17T09:15:00+09:00",
   htmlLink: "https://calendar.google.com/event?eid=ev1",
   status: "confirmed",
+  colorId: "7",
+};
+
+const sampleCalendar: CalendarSummary = {
+  id: "team@group.calendar.google.com",
+  summary: "Team",
+  description: "",
+  primary: false,
+  accessRole: "reader",
+  backgroundColor: "#16a765",
+  foregroundColor: "#ffffff",
+  colorId: "8",
+};
+
+const sampleColors: CalendarColors = {
+  event: { "7": { background: "#5484ed", foreground: "#1d1d1d" } },
+  calendar: { "8": { background: "#16a765", foreground: "#1d1d1d" } },
 };
 
 interface StubCalls {
@@ -37,6 +68,8 @@ const stubDeps = (): { deps: GoogleCalendarDeps; calls: StubCalls } => {
       calls.listInputs.push(input);
       return [sampleEvent];
     },
+    listCalendars: async () => [sampleCalendar],
+    getColors: async () => sampleColors,
   };
   return { deps, calls };
 };
@@ -49,13 +82,27 @@ describe("createGoogleCalendarCreateEvent", () => {
     const result = await createGoogleCalendarCreateEvent(deps)({ ...validParams, description: "daily" });
     assert.deepEqual(result, { event: sampleEvent });
     assert.equal(calls.tokenRequests, 1);
-    assert.deepEqual(calls.createInputs, [{ summary: "Standup", startDateTime: validParams.start, endDateTime: validParams.end, description: "daily" }]);
+    assert.deepEqual(calls.createInputs, [
+      { summary: "Standup", startDateTime: validParams.start, endDateTime: validParams.end, description: "daily", calendarId: undefined, colorId: undefined },
+    ]);
   });
 
   it("passes description as undefined when omitted", async () => {
     const { deps, calls } = stubDeps();
     await createGoogleCalendarCreateEvent(deps)({ ...validParams });
     assert.equal(calls.createInputs[0]?.description, undefined);
+  });
+
+  it("threads calendarId and colorId through to the engine", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarCreateEvent(deps)({ ...validParams, calendarId: "team@group.calendar.google.com", colorId: "7" });
+    assert.equal(calls.createInputs[0]?.calendarId, "team@group.calendar.google.com");
+    assert.equal(calls.createInputs[0]?.colorId, "7");
+  });
+
+  it("rejects an empty calendarId", async () => {
+    const { deps } = stubDeps();
+    await assert.rejects(Promise.resolve(createGoogleCalendarCreateEvent(deps)({ ...validParams, calendarId: "  " })), /calendarId must be a non-empty string/);
   });
 
   for (const key of ["summary", "start", "end"] as const) {
@@ -114,13 +161,19 @@ describe("createGoogleCalendarListEvents", () => {
     const { deps, calls } = stubDeps();
     const result = await createGoogleCalendarListEvents(deps)({});
     assert.deepEqual(result, { events: [sampleEvent] });
-    assert.deepEqual(calls.listInputs, [{ timeMin: undefined, maxResults: DEFAULT_LIST_MAX_RESULTS }]);
+    assert.deepEqual(calls.listInputs, [{ timeMin: undefined, maxResults: DEFAULT_LIST_MAX_RESULTS, calendarId: undefined }]);
   });
 
   it("passes a valid timeMin through", async () => {
     const { deps, calls } = stubDeps();
     await createGoogleCalendarListEvents(deps)({ timeMin: "2026-07-17T00:00:00Z" });
     assert.equal(calls.listInputs[0]?.timeMin, "2026-07-17T00:00:00Z");
+  });
+
+  it("targets a non-primary calendar via calendarId", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarListEvents(deps)({ calendarId: "team@group.calendar.google.com" });
+    assert.equal(calls.listInputs[0]?.calendarId, "team@group.calendar.google.com");
   });
 
   it("rejects a malformed timeMin", async () => {
@@ -165,4 +218,22 @@ describe("createGoogleCalendarListEvents", () => {
       assert.equal(calls.listInputs[0]?.maxResults, expected);
     });
   }
+});
+
+describe("createGoogleCalendarListCalendars", () => {
+  it("returns the calendars under { calendars }", async () => {
+    const { deps, calls } = stubDeps();
+    const result = await createGoogleCalendarListCalendars(deps)({});
+    assert.deepEqual(result, { calendars: [sampleCalendar] });
+    assert.equal(calls.tokenRequests, 1);
+  });
+});
+
+describe("createGoogleCalendarColors", () => {
+  it("returns the event/calendar palettes under { colors }", async () => {
+    const { deps, calls } = stubDeps();
+    const result = await createGoogleCalendarColors(deps)({});
+    assert.deepEqual(result, { colors: sampleColors });
+    assert.equal(calls.tokenRequests, 1);
+  });
 });

--- a/test/services/google/test_googleCalendar.ts
+++ b/test/services/google/test_googleCalendar.ts
@@ -3,7 +3,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { calendarApiError, toCalendarSummary, toEventSummary } from "@mulmoclaude/core/google";
+import { calendarApiError, collectCalendarPages, toCalendarSummary, toEventSummary, type CalendarListPage } from "@mulmoclaude/core/google";
 
 const emptyEvent = { id: "", summary: "", start: "", end: "", htmlLink: "", status: "", colorId: "" };
 
@@ -91,6 +91,40 @@ describe("toCalendarSummary", () => {
     const empty = { id: "", summary: "", description: "", primary: false, accessRole: "", backgroundColor: "", foregroundColor: "", colorId: "" };
     assert.deepEqual(toCalendarSummary({}), empty);
     assert.deepEqual(toCalendarSummary(null), empty);
+  });
+});
+
+describe("collectCalendarPages", () => {
+  it("returns a single page when there is no nextPageToken", async () => {
+    const calendars = await collectCalendarPages(async () => ({ items: [{ id: "a" }, { id: "b" }] }));
+    assert.deepEqual(
+      calendars.map((cal) => cal.id),
+      ["a", "b"],
+    );
+  });
+
+  it("follows nextPageToken and concatenates every page in order", async () => {
+    const pages: CalendarListPage[] = [{ items: [{ id: "a" }], nextPageToken: "p2" }, { items: [{ id: "b" }], nextPageToken: "p3" }, { items: [{ id: "c" }] }];
+    const seenTokens: (string | undefined)[] = [];
+    const calendars = await collectCalendarPages(async (pageToken) => {
+      seenTokens.push(pageToken);
+      return pages[seenTokens.length - 1];
+    });
+    assert.deepEqual(
+      calendars.map((cal) => cal.id),
+      ["a", "b", "c"],
+    );
+    assert.deepEqual(seenTokens, [undefined, "p2", "p3"]);
+  });
+
+  it("stops at the page cap even if the API keeps returning a token (no infinite loop)", async () => {
+    let calls = 0;
+    const calendars = await collectCalendarPages(async () => {
+      calls += 1;
+      return { items: [{ id: `c${calls}` }], nextPageToken: "always" };
+    }, 3);
+    assert.equal(calls, 3);
+    assert.equal(calendars.length, 3);
   });
 });
 

--- a/test/services/google/test_googleCalendar.ts
+++ b/test/services/google/test_googleCalendar.ts
@@ -3,14 +3,17 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { calendarApiError, toEventSummary } from "@mulmoclaude/core/google";
+import { calendarApiError, toCalendarSummary, toEventSummary } from "@mulmoclaude/core/google";
+
+const emptyEvent = { id: "", summary: "", start: "", end: "", htmlLink: "", status: "", colorId: "" };
 
 describe("toEventSummary", () => {
-  it("maps a timed event (dateTime)", () => {
+  it("maps a timed event (dateTime) with its colour", () => {
     const summary = toEventSummary({
       id: "ev1",
       summary: "Standup",
       status: "confirmed",
+      colorId: "7",
       htmlLink: "https://calendar.google.com/event?eid=ev1",
       start: { dateTime: "2026-07-17T09:00:00+09:00" },
       end: { dateTime: "2026-07-17T09:15:00+09:00" },
@@ -22,7 +25,12 @@ describe("toEventSummary", () => {
       end: "2026-07-17T09:15:00+09:00",
       htmlLink: "https://calendar.google.com/event?eid=ev1",
       status: "confirmed",
+      colorId: "7",
     });
+  });
+
+  it("leaves colorId empty when the event inherits the calendar colour", () => {
+    assert.equal(toEventSummary({ id: "ev2", start: { date: "2026-07-17" } }).colorId, "");
   });
 
   it("maps an all-day event (date)", () => {
@@ -37,16 +45,52 @@ describe("toEventSummary", () => {
   });
 
   it("fills empty strings for missing fields", () => {
-    assert.deepEqual(toEventSummary({}), { id: "", summary: "", start: "", end: "", htmlLink: "", status: "" });
+    assert.deepEqual(toEventSummary({}), emptyEvent);
   });
 
   it("tolerates a non-object payload", () => {
-    assert.deepEqual(toEventSummary(null), { id: "", summary: "", start: "", end: "", htmlLink: "", status: "" });
+    assert.deepEqual(toEventSummary(null), emptyEvent);
   });
 
   it("ignores non-string field values", () => {
-    const summary = toEventSummary({ id: 42, summary: ["x"], start: "not-an-object" });
-    assert.deepEqual(summary, { id: "", summary: "", start: "", end: "", htmlLink: "", status: "" });
+    const summary = toEventSummary({ id: 42, summary: ["x"], start: "not-an-object", colorId: 7 });
+    assert.deepEqual(summary, emptyEvent);
+  });
+});
+
+describe("toCalendarSummary", () => {
+  it("maps a calendar-list entry with its colours", () => {
+    const summary = toCalendarSummary({
+      id: "team@group.calendar.google.com",
+      summary: "Team",
+      description: "shared team calendar",
+      accessRole: "reader",
+      backgroundColor: "#16a765",
+      foregroundColor: "#ffffff",
+      colorId: "8",
+    });
+    assert.deepEqual(summary, {
+      id: "team@group.calendar.google.com",
+      summary: "Team",
+      description: "shared team calendar",
+      primary: false,
+      accessRole: "reader",
+      backgroundColor: "#16a765",
+      foregroundColor: "#ffffff",
+      colorId: "8",
+    });
+  });
+
+  it("marks the primary calendar only when primary === true", () => {
+    assert.equal(toCalendarSummary({ id: "primary", primary: true }).primary, true);
+    assert.equal(toCalendarSummary({ id: "other", primary: "true" }).primary, false);
+    assert.equal(toCalendarSummary({ id: "none" }).primary, false);
+  });
+
+  it("fills empty strings for missing fields and tolerates a non-object payload", () => {
+    const empty = { id: "", summary: "", description: "", primary: false, accessRole: "", backgroundColor: "", foregroundColor: "", colorId: "" };
+    assert.deepEqual(toCalendarSummary({}), empty);
+    assert.deepEqual(toCalendarSummary(null), empty);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2080,16 +2080,6 @@
   resolved "https://registry.yarnpkg.com/@mulmochat-plugin/ui-image/-/ui-image-0.4.1.tgz#8fd3b1c4ffe21e6bc22761ff48eac03306e0d345"
   integrity sha512-I3AqTIuQPsSMNxDON9UTxT2KO57HV6uUVotCIFskV0UqBMQrQ3FUu8J+qXRWDdjPyYaHoC8AJsi91TbNrOMwng==
 
-"@mulmoclaude/core@^0.22.0":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.22.1.tgz#56eecd90399b8dc3581eb1549beb923fa8504f39"
-  integrity sha512-BctuyJQOpCdiiz2z4RhAS6Ky4JDqw3+7R72E4O4x/2iFU1Q03w2pO0xDbU2/Pmbb9J+jhMau7AwXyjIWbiYadw==
-  dependencies:
-    fast-xml-parser "^5.10.1"
-    google-auth-library "^10.9.0"
-    js-yaml "^5.2.1"
-    zod "^4.4.3"
-
 "@napi-rs/wasm-runtime@^1.1.4", "@napi-rs/wasm-runtime@^1.1.5", "@napi-rs/wasm-runtime@^1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"


### PR DESCRIPTION
## Summary

Google カレンダー連携を拡張し、ユーザーフィードバックに対応:
1. **Primary 以外のカレンダーの取得** — 登録/購読済みカレンダー(Primary + 副 + 共有)を一覧し、任意のカレンダーのイベントを読める。
2. **カレンダー項目の色の同期** — イベントの `colorId`、カレンダーごとの背景/文字色、`colorId`→hex パレットを取得できる。

追加スコープは最小の **`calendar.calendarlist.readonly`** 1個のみ(broker 側は対応済み)。色は追加スコープ不要。

## Items to Confirm / Review

- **スコープ選定**: 一覧発見には `calendar.calendarlist.readonly`(最小)を採用。イベント読み取りは既存 `calendar.events` でカバー、`/colors` も `calendar.events` 内。→ 新スコープはこの1個だけで妥当か。
- **`/colors`(getCalendarColors)** が `calendar.events` スコープで動作する前提。実連携テストで 403 が出ないか要確認(出た場合は固定パレット定数へフォールバック可能)。
- **バージョン bump は含めていない**(publish は「レビュー後」に別ステップ)。唯一の manifest 変更は google-plugin の core 依存 `^0.22.0`→`^0.23.0`(元々 workspace 0.23.0 と不整合な stale。workspace symlink を解決させる修正)。
- **remote-host** に `google.calendar.listCalendars` / `.colors` を追加し、`calendarId`/`colorId` を既存ハンドラに透過。
- **ロールアウト**: 新スコープ反映には (1) broker GCP 同意画面に `calendar.calendarlist.readonly` 登録の確認、(2) 既存ユーザ全員の**再連携** が必要。

## User Prompt

> Googleカレンダーの連携について、もし可能であれば、Primary以外のカレンダーの取得とカレンダー項目の色も同期できると大変助かります。次の変更の際にご検討いただけると嬉しいです

(追加のやり取りで、broker には `calendar.calendarlist.readonly` のみ追加済み・mulmoclaude 側だけで進める・publish はレビュー後、を確認)

## 実装

### `@mulmoclaude/core/google`
- `auth.ts`: `GOOGLE_CALENDARLIST_SCOPE`(`calendar.calendarlist.readonly`)を `GOOGLE_SCOPES` に追加。
- `calendar.ts`: `CalendarEventSummary.colorId` 追加、`ListEventsInput`/`CalendarEventInput` に `calendarId`(既定 `primary`)、create に `colorId`。`listCalendars()`(`GET /users/me/calendarList`)、`getCalendarColors()`(`GET /colors`)、`toCalendarSummary` 追加。

### `@mulmoclaude/google-plugin`
- kinds: `calendarListCalendars` / `calendarColors`。`calendarListEvents`・`calendarCreateEvent` に `calendarId`、create に `colorId`。
- tool description / enum / params を更新。

### host (server/)
- `remoteHost/handlers/googleCalendar.ts`: `google.calendar.listCalendars` / `.colors` 追加、`calendarId`/`colorId` を list/create に透過。
- `remoteHost/handlers/index.ts`: 新コマンド登録。

### tests / docs
- 単体: `toEventSummary`(colorId)、`toCalendarSummary`、remote ハンドラ、plugin args。
- `error-recovery.md`: 新スコープに伴う **再連携** ガイド。`remote-host.md`: ハンドラ表。

## Test plan

- `yarn build` / `yarn lint` / `yarn typecheck` green。
- `yarn test`: 追加テスト含め green(DuckDB smoke は optional native dep、Docker smoke は CI 同様 skip)。
- 実連携での確認(要 再連携): `calendarListCalendars` で非Primary が列挙され、`calendarListEvents { calendarId }` で当該カレンダーのイベントが取れ、各イベントの `colorId` と `calendarColors` で色が解決できること。

Closes #2162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Calendar now supports targeting non-primary calendars for listing and creating events.
  * Events can optionally specify a palette **color ID** for the selected calendar.
  * Added calendar discovery (list calendars) and color palette retrieval (calendar/event colors), enabling correct color mapping across accessible calendars.
* **Documentation**
  * Updated Google Calendar capability documentation to include new calendar and color operations.
  * Expanded error-recovery guidance for missing/insufficient calendar-list access, including re-linking when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->