### PR TITLE
chore(release): publish core 0.23.0 / collection-plugin 0.12.0 / google-plugin 0.3.0 / mulmoclaude 1.3.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [1.3.0] - 2026-07-18
+
+**Your other calendars, in colour.** The Google tool now sees every calendar you've subscribed to — not just your primary — and carries each event's colour. Plus read-only CSV data collections backed by DuckDB.
+
+### Highlights
+
+#### Google Calendar — non-primary calendars & colours (#2162, #2164)
+
+The `google` tool can now list the calendars you've added or subscribed to — primary, secondary, and shared — with `calendarListCalendars`, and read or create events on any of them by passing `calendarId` (default: your primary). Colours come through too: every event carries its `colorId`, each calendar its background/foreground hex, and `calendarColors` resolves the palette. Calendar listing follows pagination, so accounts with many calendars aren't truncated.
+
+- Adds one minimal scope, `calendar.calendarlist.readonly`. **Existing users must re-link** (Settings → Plugins → Google) to grant it. Reading events on a known calendar id needs no re-link.
+
+#### Collections — CSV dataSource via DuckDB (#2158, #2163)
+
+Read-only collections backed by a CSV file, queried through DuckDB with a structured aggregation query DSL (`queryItems`).
+
+Ships `@mulmoclaude/core@0.23.0`, `@mulmoclaude/collection-plugin@0.12.0`, `@mulmoclaude/google-plugin@0.3.0`.
+
+---
+
 ## npm packages — 2026-07-17 (8)
 
 - **`@mulmoclaude/mulmoscript-plugin@0.2.2`** — presentMulmoScript: updating a beat's `text` via the per-beat JSON source editor now drops that beat's cached narration audio, so the "Generate Audio" button reappears for the new text (previously only Play showed, with no way to re-generate). Audio files are content-addressed by text hash, so the view re-probes disk after the edit — reverting the text restores the existing audio without a paid TTS call.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/collection-plugin": "^0.12.0",
     "@mulmoclaude/core": "^0.23.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
-    "@mulmoclaude/google-plugin": "^0.2.1",
+    "@mulmoclaude/google-plugin": "^0.3.0",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
     "@mulmoclaude/mulmoscript-plugin": "^0.2.2",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/google-plugin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Google integration tool for MulmoClaude — operates the user's locally linked Google account (Calendar now; Tasks / Drive ride the same grant later). Server-only; no Vue View.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Google カレンダー拡張(非Primary + 色、PR #2164)と、既に main に merged 済みの collection dataSource/DuckDB(#2158・#2163)を npm にリリースするためのバージョン bump。**npm publish は実施済み**で、この PR は repo の version 表記を publish 済み状態に合わせるもの。

## Items to Confirm / Review

- **publish 済み(取り消し不可)**: `@mulmoclaude/core@0.23.0`、`@mulmoclaude/collection-plugin@0.12.0`、`@mulmoclaude/google-plugin@0.3.0`、`mulmoclaude@1.3.0`。`npx mulmoclaude@1.3.0 --version` で clean install 解決を確認済み。
- **launcher-sync gate**: launcher の dep range を publish 済みバージョンに整合(core `^0.23.0` / collection `^0.12.0` / google-plugin `^0.2.1`→`^0.3.0`)。
- **root `package.json` 1.3.0**(§5.5 lockstep)、launcher own version 1.3.0。
- **再連携**: `google` の calendar 一覧/色は新スコープ `calendar.calendarlist.readonly` を要するため、既存ユーザは Settings → Plugins → Google で再連携が必要。

## 変更

- `@mulmoclaude/google-plugin` 0.2.1 → 0.3.0
- `mulmoclaude`(launcher)+ root `package.json` 1.2.0 → 1.3.0
- launcher の `@mulmoclaude/google-plugin` range ^0.2.1 → ^0.3.0

core (0.23.0) と collection-plugin (0.12.0) は既に main で該当バージョンだったため version 変更なし(tag + publish のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Calendar tool can now access and read/list non-primary (secondary/shared) calendars, with per-calendar and per-event color handling during calendar browsing.
  * Added new read-only CSV collections powered by DuckDB, including support for structured query-based listing.
* **Documentation**
  * Updated the changelog with a new v1.3.0 release entry describing the highlights.
* **Chores**
  * Bumped package versions to match the latest release.
  * Updated the Google plugin integration to the newest compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->