### PR TITLE
docs(skills): add writing-style principles to mc-zenn skill

### DIFF
--- a/packages/core/assets/skills-preset/mc-zenn/SKILL.md
+++ b/packages/core/assets/skills-preset/mc-zenn/SKILL.md
@@ -43,9 +43,11 @@ unless the user already told you:
 
 - **Clone an existing Zenn repo** (they already write Zenn on GitHub). Get the
   repo URL, then:
+
   ```bash
   git clone <url> github/zenn
   ```
+
   `npx zenn` fetches zenn-cli on demand, so a missing local dependency is fine.
 
 - **Create a fresh project** (standard zenn-cli flow):
@@ -90,6 +92,7 @@ fill it in. **A published slug becomes the article URL and can't change** — pi
 it deliberately.
 
 **Step 3 — write the frontmatter** (Zenn house style):
+
 ```yaml
 ---
 title: "<a clear title, in the user's language>"
@@ -99,6 +102,7 @@ topics: ["MulmoClaude", "<related>"]
 published: true
 ---
 ```
+
 - **Always include `MulmoClaude` in `topics`.** At most 5 topics, no spaces
   inside a single topic.
 - `type` defaults to `tech`; `published` defaults to `true` (use `false` when
@@ -108,6 +112,33 @@ published: true
 implementation (fenced ` ```lang ` blocks, runnable commands) → result → a short
 wrap-up. Informative but casual; describe the work, not yourself. Put images in
 `github/zenn/images/` and reference them as `![alt](/images/<file>)`.
+
+Write it the way a person would, not the way a model defaults to. Each rule
+below comes from real reader feedback — ignore them and the draft reads as
+machine output:
+
+- **Sound human, not like a generated listicle.** Prefer flowing prose over
+  walls of bullets, use bold sparingly, and let paragraphs connect into an
+  argument. If every section is just a heading plus a list, vary the rhythm.
+- **No uncommon loanwords or jargon.** Use only terms a typical reader already
+  knows. Niche English acronyms, trendy katakana, and insider slang either get
+  dropped or replaced with plain words. A term the field itself hasn't settled
+  on ("code smell" and the like) is a red flag — say the plain thing instead
+  ("code that works now but bites you later").
+- **Define every term and acronym on first use**, in plain language, and put the
+  foundational ones up front — define "DRY" before the article leans on it. A
+  reader should never hit a word they can't parse.
+- **Carry a source's essence, don't just cite it.** When an idea comes from a
+  book or article, explain the idea itself in your own words; "see <book>"
+  teaches nothing. Search for the actual content when you're unsure what it says,
+  then write the substance.
+- **Make the article self-contained.** Anything project-specific — a repo's
+  internals, a config choice, a domain constraint — needs enough general
+  background that a reader with zero context can follow. Running longer is fine
+  when the extra length buys understanding.
+- **Match the stated audience.** "Explain to intermediate developers" means
+  patient explanations, concrete examples, real code from the work, and links —
+  not a terse summary.
 
 **Step 5 — save + preview.** Write `github/zenn/articles/<slug>.md`. Tell the
 user the path and how to preview: `cd github/zenn && npx zenn preview`


### PR DESCRIPTION
## Summary

Adds a reusable **writing-style guide** to the bundled `mc-zenn` Zenn-article skill (`packages/core/assets/skills-preset/mc-zenn/SKILL.md`, Workflow 2 / Step 4). These are generalized prose-quality principles distilled from a real article-writing session where the same feedback kept recurring — so the next time the skill drafts an article, it starts from them instead of re-learning them.

The six principles:
- **Sound human, not a generated listicle** — prose over bullet walls, sparing bold, connected paragraphs.
- **No uncommon loanwords or jargon** — only terms a typical reader knows; drop/replace niche acronyms, trendy katakana, insider slang (e.g. avoid unsettled terms like "code smell" — say "code that works now but bites you later").
- **Define every term/acronym on first use**, foundational ones up front (define "DRY" before leaning on it).
- **Carry a source's essence, don't just cite it** — explain the idea in your own words; search for the real content when unsure.
- **Make the article self-contained** — enough general background for a zero-context reader; longer is fine when it buys understanding.
- **Match the stated audience** — patient explanations, concrete examples, real code, links.

## Items to Confirm / Review

- **No version bump.** This is a content-only change to a preset skill. It intentionally does **not** bump `@mulmoclaude/core`, so the launcher-sync lockstep invariant stays green — the change ships with the next core release. Flag if you'd prefer it cut a release now.
- **Placement**: added under Step 4 (write the body). Confirm that's the right home vs. the "Tone" section.
- **Scope/length**: six bullets is longer than the surrounding prose. It's guidance the agent reads, so density is deliberate — trim if you find it heavy.

## User Prompt

During a session writing a Zenn article ("how to keep code clean when writing heavily with AI"), the user gave repeated, converging feedback on writing quality (sound human not AI-generated; ban uncommon katakana/English jargon; define every term on first use; don't just cite books — convey their essence; add general background for project-specific points; write for intermediate readers). They then asked:

> zennかくskillってある？もしればそこに反映して、今の指摘を一般論にして。
> (Is there a Zenn-writing skill? If so, reflect the current feedback into it, generalized.)

…and approved opening this PR.

## Implementation

- Located the skill: `mc-zenn` at `packages/core/assets/skills-preset/mc-zenn/SKILL.md` (source of truth; workspace copies are overwritten from here on server boot).
- Added the six principles to Workflow 2 / Step 4, in the skill's existing imperative English voice.
- Prettier-formatted; `format` / `lint` / `typecheck` / `build:packages` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the Zenn article writing preset with guidance for more natural, reader-focused content.
  * Added recommendations to reduce jargon, explain terms clearly, write in original language, ensure articles are self-contained, and match the intended audience.
  * Improved formatting around workflow examples and frontmatter instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->