### PR TITLE
fix: allow retrying the Google link after abandoning browser consent

### DIFF
--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -415,4 +415,31 @@ test.describe("Google account tab", () => {
     await expect(page.locator('[data-testid="settings-google-secret-ambiguous"]')).toBeVisible();
     await expect(page.locator('[data-testid="settings-google-connect-btn"]')).toBeDisabled();
   });
+
+  // A user who abandoned the browser consent must be able to link again without
+  // waiting out the server-side timeout — the button stays clickable while
+  // pending, and the click restarts the flow (backend aborts the stale one).
+  test("keeps the connect button clickable while a link is pending so the user can retry", async ({ page }) => {
+    await mockConfigApi(page);
+    await mockGoogleStatus(page, { linked: false, pending: true, clientSecret: "found", lastError: null });
+    let authorizeCalls = 0;
+    await page.route(
+      (url) => url.pathname === "/api/google/authorize",
+      (route) => {
+        authorizeCalls += 1;
+        return route.fulfill({ json: { authUrl: "https://accounts.google.com/o/oauth2/v2/auth?mock=retry" } });
+      },
+    );
+
+    await openGoogleTab(page);
+    await expect(page.locator('[data-testid="settings-google-status"]')).toContainText("Waiting for the browser consent");
+    const connect = page.locator('[data-testid="settings-google-connect-btn"]');
+    await expect(connect).toBeEnabled();
+
+    await page.evaluate(() => {
+      window.open = () => null;
+    });
+    await connect.click();
+    await expect.poll(() => authorizeCalls).toBe(1);
+  });
 });

--- a/packages/core/src/google/auth.ts
+++ b/packages/core/src/google/auth.ts
@@ -46,6 +46,9 @@ export interface AuthorizeGoogleOptions {
   /** Called with the consent URL; open it in a browser (and/or print it). */
   onAuthUrl?: (url: string) => void;
   timeoutMs?: number;
+  /** Abort a still-pending consent (a settings-UI restart, an explicit cancel).
+   *  Rejects the flow with {@link GOOGLE_AUTH_CANCELLED} and closes the loopback. */
+  signal?: AbortSignal;
 }
 
 const createClient = (secret: InstalledClientSecret, redirectUri?: string): OAuth2Client =>
@@ -167,35 +170,65 @@ const respondHtml = (res: http.ServerResponse, status: number, message: string):
   res.end(`<html><body><h3>${message}</h3></body></html>`);
 };
 
-export const waitForAuthCode = (server: http.Server, expectedState: string, timeoutMs: number): Promise<string> =>
-  new Promise((resolve, reject) => {
+/** Reject reason when a pending flow is torn down (a settings-UI restart or an
+ *  explicit cancel), kept distinct from a real authorization error so callers
+ *  can treat it as "user changed their mind", not "linking failed". */
+export const GOOGLE_AUTH_CANCELLED = "authorization cancelled";
+
+interface AuthCodeSettle {
+  resolve: (code: string) => void;
+  reject: (err: unknown) => void;
+}
+
+// Answers one loopback request. A terminal callback settles the flow; a
+// wrong-path or wrong-state request is answered but leaves the flow waiting —
+// a drive-by localhost probe or stale tab must not abort a pending consent.
+const handleCallbackRequest = (req: http.IncomingMessage, res: http.ServerResponse, expectedState: string, settle: AuthCodeSettle): void => {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== CALLBACK_PATH) {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+  if (url.searchParams.get("state") !== expectedState) {
+    respondHtml(res, 400, "Invalid authorization callback. You can close this tab.");
+    return;
+  }
+  try {
+    const code = authCodeFromCallback(url, expectedState);
+    respondHtml(res, 200, "Authorization complete — you can close this tab.");
+    settle.resolve(code);
+  } catch (err) {
+    // Static text only — the failure detail echoes query-string content, which
+    // must not be reflected into HTML. The CLI prints the detail.
+    respondHtml(res, 400, "Authorization failed — see the terminal for details. You can close this tab.");
+    settle.reject(err);
+  }
+};
+
+// Resolves with the OAuth code from the loopback callback, or rejects on the
+// timeout or on `signal` firing (a restart / cancel) — whichever comes first.
+export const waitForAuthCode = (server: http.Server, expectedState: string, timeoutMs: number, signal?: AbortSignal): Promise<string> =>
+  new Promise<string>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`authorization timed out after ${timeoutMs / ONE_SECOND_MS}s`)), timeoutMs);
-    server.on("request", (req, res) => {
-      const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      if (url.pathname !== CALLBACK_PATH) {
-        res.writeHead(404);
-        res.end();
-        return;
-      }
-      // A wrong-state request is not our callback (drive-by localhost probe
-      // or stale tab) — answer it but keep waiting for the real redirect, so
-      // an unauthenticated request can't abort the pending flow.
-      if (url.searchParams.get("state") !== expectedState) {
-        respondHtml(res, 400, "Invalid authorization callback. You can close this tab.");
-        return;
-      }
-      clearTimeout(timer);
-      try {
-        const code = authCodeFromCallback(url, expectedState);
-        respondHtml(res, 200, "Authorization complete — you can close this tab.");
+    const settle: AuthCodeSettle = {
+      resolve: (code) => {
+        clearTimeout(timer);
         resolve(code);
-      } catch (err) {
-        // Static text only — the failure detail echoes query-string content,
-        // which must not be reflected into HTML. The CLI prints the detail.
-        respondHtml(res, 400, "Authorization failed — see the terminal for details. You can close this tab.");
-        reject(err);
+      },
+      reject: (err) => {
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    };
+    if (signal) {
+      if (signal.aborted) {
+        settle.reject(new Error(GOOGLE_AUTH_CANCELLED));
+        return;
       }
-    });
+      signal.addEventListener("abort", () => settle.reject(new Error(GOOGLE_AUTH_CANCELLED)), { once: true });
+    }
+    server.on("request", (req, res) => handleCallbackRequest(req, res, expectedState, settle));
   });
 
 // `access_type: offline` + `prompt: consent` force Google to return a refresh
@@ -229,7 +262,7 @@ const authorizeWithLocalClient = async (
   if (!codeChallenge) throw new Error("failed to derive a PKCE code challenge");
   const state = randomBytes(STATE_BYTES).toString("hex");
   opts.onAuthUrl?.(buildConsentUrl(client, codeChallenge, state));
-  const code = await waitForAuthCode(server, state, opts.timeoutMs ?? AUTH_TIMEOUT_MS);
+  const code = await waitForAuthCode(server, state, opts.timeoutMs ?? AUTH_TIMEOUT_MS, opts.signal);
   const { tokens } = await client.getToken({ code, codeVerifier });
   if (!tokens.refresh_token) {
     throw new Error("Google returned no refresh token — remove this app under Google Account → Security → Third-party access, then retry");
@@ -244,7 +277,7 @@ const authorizeWithBroker = async (server: http.Server, port: number, opts: Auth
   const { codeVerifier, codeChallenge } = await generatePkce();
   const { authUrl, state } = await brokerStart(port, codeChallenge);
   opts.onAuthUrl?.(authUrl);
-  const code = await waitForAuthCode(server, state, opts.timeoutMs ?? AUTH_TIMEOUT_MS);
+  const code = await waitForAuthCode(server, state, opts.timeoutMs ?? AUTH_TIMEOUT_MS, opts.signal);
   return await brokerExchange({ code, state, codeVerifier });
 };
 

--- a/packages/core/src/google/auth.ts
+++ b/packages/core/src/google/auth.ts
@@ -281,6 +281,16 @@ const authorizeWithBroker = async (server: http.Server, port: number, opts: Auth
   return await brokerExchange({ code, state, codeVerifier });
 };
 
+// Persists the freshly linked tokens — unless a restart/cancel aborted this run
+// after the code came back. `waitForAuthCode` only guards the wait; the token
+// exchange and this save run past it, so an abandoned flow could otherwise
+// clobber the link the user actually kept. This re-checks the signal right
+// before the one persistent side effect.
+export const commitLinkedTokens = async (tokens: Credentials, issuedVia: IssuedVia, opts: AuthorizeGoogleOptions): Promise<Credentials> => {
+  if (opts.signal?.aborted) throw new Error(GOOGLE_AUTH_CANCELLED);
+  return await saveGoogleTokens({ ...tokens, issuedVia }, opts.home);
+};
+
 export async function authorizeGoogle(opts: AuthorizeGoogleOptions = {}): Promise<Credentials> {
   // A user-supplied client wins: it keeps the whole flow on this machine, and
   // silently preferring the broker would ignore a deliberate setup. Two of
@@ -299,7 +309,7 @@ export async function authorizeGoogle(opts: AuthorizeGoogleOptions = {}): Promis
     const tokens = useLocalClient
       ? await authorizeWithLocalClient(await loadClientSecret(opts.home), server, port, opts)
       : await authorizeWithBroker(server, port, opts);
-    return await saveGoogleTokens({ ...tokens, issuedVia }, opts.home);
+    return await commitLinkedTokens(tokens, issuedVia, opts);
   } finally {
     server.close();
   }

--- a/packages/core/src/google/authFlow.ts
+++ b/packages/core/src/google/authFlow.ts
@@ -1,10 +1,10 @@
-// In-flight manager for the settings-UI OAuth flow. authorizeGoogle()
-// resolves only after the user finishes the browser consent, so the HTTP
-// layer starts it in the background, returns the consent URL immediately,
-// and reports progress via status polling. One flow at a time — the guard
-// is the in-flight start promise itself (set synchronously before any
-// await), so concurrent authorize requests share one flow instead of
-// spawning parallel loopback listeners.
+// In-flight manager for the settings-UI OAuth flow. authorizeGoogle() resolves
+// only after the user finishes the browser consent, so the HTTP layer starts it
+// in the background, returns the consent URL immediately, and reports progress
+// via status polling. start() always reflects the latest intent: a new call
+// aborts any pending flow (which closes its loopback listener) before launching
+// a fresh one, so a user who abandoned the browser consent can just link again
+// instead of waiting out the server-side timeout.
 import { log } from "./host.js";
 import { errorMessage } from "./util.js";
 import { authorizeGoogle } from "./auth.js";
@@ -16,44 +16,55 @@ export interface GoogleAuthFlowStatus {
 
 export interface GoogleAuthFlow {
   start: () => Promise<{ authUrl: string }>;
+  cancel: () => void;
   status: () => GoogleAuthFlowStatus;
 }
 
 export const createGoogleAuthFlow = (authorize: typeof authorizeGoogle): GoogleAuthFlow => {
-  let inFlightStart: Promise<{ authUrl: string }> | null = null;
   let flowRunning = false;
   let lastError: string | null = null;
+  let active: AbortController | null = null;
 
-  const launchFlow = (): Promise<{ authUrl: string }> =>
-    new Promise((resolve, reject) => {
-      flowRunning = true;
-      authorize({
-        onAuthUrl: (url) => resolve({ authUrl: url }),
-      })
+  const launch = (): Promise<{ authUrl: string }> => {
+    const controller = new AbortController();
+    active = controller;
+    flowRunning = true;
+    return new Promise((resolve, reject) => {
+      authorize({ onAuthUrl: (url) => resolve({ authUrl: url }), signal: controller.signal })
         .then(() => log.info("google", "authorize flow completed"))
         .catch((err: unknown) => {
-          lastError = errorMessage(err);
-          log.warn("google", "authorize flow failed", { error: lastError });
-          // No-op when the URL already resolved; covers pre-URL failures
-          // (missing client secret, port bind error).
+          // An aborted flow is a user-initiated restart, not a failure to
+          // surface — only real errors reach lastError.
+          if (!controller.signal.aborted) {
+            lastError = errorMessage(err);
+            log.warn("google", "authorize flow failed", { error: lastError });
+          }
           reject(err instanceof Error ? err : new Error(String(err)));
         })
         .finally(() => {
-          flowRunning = false;
-          inFlightStart = null;
+          // A restart may have already installed a newer controller; only the
+          // current flow clears the shared state so it can't strand the new one.
+          if (active === controller) {
+            flowRunning = false;
+            active = null;
+          }
         });
     });
+  };
+
+  const cancel = (): void => {
+    active?.abort();
+  };
 
   const start = (): Promise<{ authUrl: string }> => {
-    if (inFlightStart) return inFlightStart;
+    cancel();
     lastError = null;
-    inFlightStart = launchFlow();
-    return inFlightStart;
+    return launch();
   };
 
   const status = (): GoogleAuthFlowStatus => ({ pending: flowRunning, lastError });
 
-  return { start, status };
+  return { start, cancel, status };
 };
 
 export const googleAuthFlow = createGoogleAuthFlow(authorizeGoogle);

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -12,9 +12,11 @@ export { deleteGoogleTokens, loadGoogleTokens, mergeGoogleTokens, saveGoogleToke
 export { brokerBaseUrl, brokerExchange, brokerRefresh, brokerStart, type BrokerStartResponse } from "./broker.js";
 export {
   authorizeGoogle,
+  commitLinkedTokens,
   getGoogleAccessToken,
   unlinkGoogle,
   waitForAuthCode,
+  GOOGLE_AUTH_CANCELLED,
   GOOGLE_CALENDAR_SCOPE,
   GOOGLE_CALENDARLIST_SCOPE,
   GOOGLE_TASKS_SCOPE,

--- a/plans/fix-google-oauth-retry.md
+++ b/plans/fix-google-oauth-retry.md
@@ -1,0 +1,58 @@
+# fix: Google 連携（OAuth）の途中放棄後にリトライできない
+
+独立したバグ修正（当初 #2170 と併せて検討したが、#2170 は不要と判断しクローズ済み。
+再リンク経路の堅牢性という一般的な問題としてこのまま進める）。
+
+## 症状
+
+設定 UI で Google 連携を開始し、ブラウザの同意を途中でやめると「ブラウザでの同意完了を待っています…」のまま、
+その後もう一度接続できない（リトライ不能）。
+
+## 根本原因（コードから特定）
+
+- `packages/core/src/google/authFlow.ts` の `flowRunning`（= `/api/google/status` の `pending`）は
+  `authorizeGoogle()` が settle するまで true。
+- `authorizeGoogle()` は loopback リスナーを立て `waitForAuthCode(server, state, AUTH_TIMEOUT_MS)` を待つ。
+  `AUTH_TIMEOUT_MS = 5 分`（`auth.ts`）。同意を放棄するとコールバックが来ないため、**5 分のタイムアウトまで settle しない**。
+- その間ずっと `pending=true`。`SettingsGoogleTab.vue` の接続ボタンは `:disabled="busy || pending || …"` なので
+  **最大 5 分、押せない = リトライできない**。
+- 進行中フローを中断する経路が無い。`start()` は進行中フローがあると同じ URL を返すだけで、やり直せない。
+
+## 方針（選択済み）
+
+- 範囲: **リトライ修正のみ**（#2170 のバックエンドは実装済み。カレンダー選択 UI は別 PR）。
+- UX: **pending 中も「接続」を押せるようにし、押したら進行中フローを中断して新規開始**。
+
+## 変更
+
+1. `packages/core/src/google/auth.ts`
+   - `AuthorizeGoogleOptions` に `signal?: AbortSignal` を追加し、`authorizeGoogle` → `authorizeWithLocalClient` /
+     `authorizeWithBroker` → `waitForAuthCode` へ通す。
+   - `waitForAuthCode(server, state, timeoutMs, signal?)`: abort でも reject（"authorization cancelled"）。
+     タイマ/リスナのクリーンアップを一箇所に集約。コールバック処理は小関数へ抽出（関数 20 行以内）。
+   - `finally { server.close() }` は既存のまま（abort でも通り loopback を閉じる）。
+2. `packages/core/src/google/authFlow.ts`
+   - 契約変更: `start()` は **進行中フローを abort してから新規 launch**（直近が勝つ）。
+   - 各フローは自分の `AbortController` を持ち、共有状態（`flowRunning` / `active`）は
+     **自分が現行のときだけ** クリア（restart で `active` が差し替わっても古い finally が新フローを潰さない）。
+   - abort 起因の失敗は `lastError` に載せない（ユーザー操作の再開でありエラーではない）。
+   - `cancel()` を公開（内部再利用 + 将来のキャンセル UI 用）。
+3. `server/api/routes/google.ts` — 変更不要（`start()` の意味が「再押下で再開」に変わるだけ）。
+4. `src/components/SettingsGoogleTab.vue`
+   - 接続ボタンの無効条件から `pending` を外す（`:disabled="busy || clientSecret === 'ambiguous'"`）。
+
+## テスト
+
+- `test/services/google/test_googleAuthFlow.ts`
+  - 旧「pending 中は同一 URL を再利用」→ 新「pending 中の start() は前フローを abort して再開」に置換
+    （callCount=2、前フローの `signal.aborted===true`、新 URL、pending 継続）。
+  - 完了/失敗/エラークリア/URL 前失敗の各既存ケースは維持。
+- `test/services/google/test_googleAuthCallback.ts`
+  - `waitForAuthCode` が abort で "cancelled" reject する回帰テストを追加。
+- 破壊しないこと: e2e `settings.spec.ts`（`missing`=有効 / `ambiguous`=無効のみを主張、pending 無効は未主張）。
+
+## リトライ機構レビュー観点（CLAUDE.md）
+
+- 二重実行: abort→reject は副作用（トークン保存）前で起こる。保存後は settle 済みで abort 無効。OK。
+- 待機中の abort: `waitForAuthCode` が signal を購読し即 reject。OK。
+- 過剰なエラーマッチ: abort とその他エラーを `signal.aborted` で分岐。abort のみ lastError から除外。OK。

--- a/src/components/SettingsGoogleTab.vue
+++ b/src/components/SettingsGoogleTab.vue
@@ -11,10 +11,13 @@
 
     <div v-if="loaded" class="flex items-center gap-3">
       <span class="text-sm" :class="statusColour" data-testid="settings-google-status">{{ statusText }}</span>
+      <!-- Stays clickable while `pending`: a user who abandoned the browser
+           consent can restart the link instead of waiting out the server-side
+           timeout (the click aborts the stale flow and opens a fresh one). -->
       <button
         v-if="!linked"
         class="px-2 py-1 text-xs rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50"
-        :disabled="busy || pending || clientSecret === 'ambiguous'"
+        :disabled="busy || clientSecret === 'ambiguous'"
         data-testid="settings-google-connect-btn"
         @click="connect"
       >

--- a/test/services/google/test_googleAuthCallback.ts
+++ b/test/services/google/test_googleAuthCallback.ts
@@ -108,4 +108,28 @@ describe("waitForAuthCode", () => {
       server.close();
     }
   });
+
+  it("rejects with 'cancelled' when the signal aborts mid-wait", async () => {
+    const { server } = await startServer();
+    const controller = new AbortController();
+    try {
+      const pending = waitForAuthCode(server, "expected", TEST_TIMEOUT_MS, controller.signal);
+      const expectation = assert.rejects(pending, /authorization cancelled/);
+      controller.abort();
+      await expectation;
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const { server } = await startServer();
+    const controller = new AbortController();
+    controller.abort();
+    try {
+      await assert.rejects(waitForAuthCode(server, "expected", TEST_TIMEOUT_MS, controller.signal), /authorization cancelled/);
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/test/services/google/test_googleAuthFlow.ts
+++ b/test/services/google/test_googleAuthFlow.ts
@@ -1,6 +1,6 @@
-// Unit tests for the settings-UI OAuth flow manager: single-flight,
-// URL reuse while pending, completion/failure state. authorizeGoogle is
-// stubbed — no network, no browser.
+// Unit tests for the settings-UI OAuth flow manager: restart-on-start (a new
+// start() aborts the pending flow), cancel, completion/failure state.
+// authorizeGoogle is stubbed — no network, no browser.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
@@ -10,11 +10,16 @@ const settleMicrotasks = async (): Promise<void> => new Promise((resolve) => set
 
 const makeAuthorizeStub = () => {
   const settlers: { complete: () => void; fail: (err: Error) => void }[] = [];
+  const signals: (AbortSignal | undefined)[] = [];
   let calls = 0;
   const authorize: typeof authorizeGoogle = async (opts = {}) => {
     calls += 1;
     const call = calls;
+    signals.push(opts.signal);
     return new Promise((resolve, reject) => {
+      // Honour the abort signal like the real authorizeGoogle does, so a
+      // restart/cancel actually settles the pending flow.
+      opts.signal?.addEventListener("abort", () => reject(new Error("authorization cancelled")), { once: true });
       settlers.push({ complete: () => resolve({ refresh_token: "stub" }), fail: reject });
       opts.onAuthUrl?.(`https://accounts.google.com/consent?call=${call}`);
     });
@@ -24,6 +29,7 @@ const makeAuthorizeStub = () => {
     callCount: () => calls,
     complete: (index: number) => settlers[index]?.complete(),
     fail: (index: number, err: Error) => settlers[index]?.fail(err),
+    signalAborted: (index: number) => signals[index]?.aborted ?? false,
   };
 };
 
@@ -36,27 +42,28 @@ describe("createGoogleAuthFlow", () => {
     assert.deepEqual(flow.status(), { pending: true, lastError: null });
   });
 
-  it("reuses the pending flow instead of starting a second one", async () => {
+  it("restarts the pending flow, aborting the previous one", async () => {
     const stub = makeAuthorizeStub();
     const flow = createGoogleAuthFlow(stub.authorize);
     const first = await flow.start();
     const second = await flow.start();
-    assert.equal(second.authUrl, first.authUrl);
-    assert.equal(stub.callCount(), 1);
+    assert.notEqual(second.authUrl, first.authUrl);
+    assert.match(second.authUrl, /call=2/);
+    assert.equal(stub.callCount(), 2);
+    assert.equal(stub.signalAborted(0), true); // the abandoned flow was cancelled
+    assert.equal(stub.signalAborted(1), false); // the fresh flow is live
+    assert.deepEqual(flow.status(), { pending: true, lastError: null });
   });
 
-  it("shares one flow across concurrent start() calls even when the URL arrives asynchronously", async () => {
-    let calls = 0;
-    const authorize: typeof authorizeGoogle = async (opts = {}) => {
-      calls += 1;
-      return new Promise(() => {
-        setImmediate(() => opts.onAuthUrl?.("https://accounts.google.com/consent?async=1"));
-      });
-    };
-    const flow = createGoogleAuthFlow(authorize);
-    const [first, second] = await Promise.all([flow.start(), flow.start()]);
-    assert.equal(first.authUrl, second.authUrl);
-    assert.equal(calls, 1);
+  it("cancel() aborts the in-flight flow and clears pending without recording an error", async () => {
+    const stub = makeAuthorizeStub();
+    const flow = createGoogleAuthFlow(stub.authorize);
+    await flow.start();
+    assert.equal(flow.status().pending, true);
+    flow.cancel();
+    await settleMicrotasks();
+    assert.equal(stub.signalAborted(0), true);
+    assert.deepEqual(flow.status(), { pending: false, lastError: null });
   });
 
   it("clears pending on completion and allows a fresh flow", async () => {

--- a/test/services/google/test_googleAuthorizeRouting.ts
+++ b/test/services/google/test_googleAuthorizeRouting.ts
@@ -8,7 +8,16 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { authorizeGoogle, clientSecretPresence, getGoogleAccessToken, googleSecretsDir, googleTokenPath, saveGoogleTokens } from "@mulmoclaude/core/google";
+import {
+  authorizeGoogle,
+  clientSecretPresence,
+  commitLinkedTokens,
+  getGoogleAccessToken,
+  googleSecretsDir,
+  googleTokenPath,
+  loadGoogleTokens,
+  saveGoogleTokens,
+} from "@mulmoclaude/core/google";
 
 const desktopSecret = JSON.stringify({ installed: { client_id: "id-123", client_secret: "secret-456" } });
 
@@ -31,6 +40,27 @@ describe("authorizeGoogle client routing", () => {
     let issuedUrl: string | null = null;
     await assert.rejects(authorizeGoogle({ home, onAuthUrl: (url) => (issuedUrl = url), timeoutMs: 1_000 }), /multiple desktop-app client_secret/);
     assert.equal(issuedUrl, null);
+  });
+});
+
+// A restart/cancel can fire after the browser callback resolves, while the
+// token exchange is still in flight. commitLinkedTokens is the last checkpoint
+// before the one persistent side effect, so an abandoned run must not overwrite
+// the link the user actually kept.
+describe("commitLinkedTokens cancellation guard", () => {
+  it("persists the tokens when the flow was not cancelled", async () => {
+    const home = await makeFakeHome();
+    const saved = await commitLinkedTokens({ refresh_token: "rt-keep" }, "local", { home });
+    assert.equal(saved.refresh_token, "rt-keep");
+    assert.equal((await loadGoogleTokens(home))?.refresh_token, "rt-keep");
+  });
+
+  it("throws and writes nothing when the run was aborted after the code arrived", async () => {
+    const home = await makeFakeHome();
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(commitLinkedTokens({ refresh_token: "rt-stale" }, "local", { home, signal: controller.signal }), /authorization cancelled/);
+    assert.equal(await loadGoogleTokens(home), null);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the Google account link flow getting stuck when the user abandons the browser consent. Before this, the settings UI stayed on "Waiting for the browser consent to finish…" with the **Connect button disabled** until the 5-minute server-side loopback timeout fired — so there was no way to retry in between.

- **`authFlow.ts`** — `start()` now aborts any pending flow before launching a fresh one (latest intent wins). Each flow owns its own `AbortController`; only the *current* flow clears the shared `pending`/`active` state, so a restart can't strand the new flow. Adds `cancel()`.
- **`auth.ts`** — `authorizeGoogle` / `waitForAuthCode` accept an `AbortSignal`. Aborting rejects with `GOOGLE_AUTH_CANCELLED` (kept distinct from real authorization errors) and the loopback server closes via the existing `finally`.
- **`SettingsGoogleTab.vue`** — the Connect button stays clickable while `pending`; a click aborts the stale flow and opens a fresh consent.

## Items to Confirm / Review

- **UX choice**: per the request, retry = *re-press Connect* (no separate Cancel button). The button now stays enabled while pending; its label is unchanged ("Connect"). Flag if you'd rather it relabel to "Restart"/"Cancel" while pending.
- **Contract change**: `createGoogleAuthFlow.start()` changed from *reuse the in-flight flow* to *restart it*. Two old unit tests encoding the reuse behavior were replaced with restart/cancel tests. Concurrent `start()` calls now serialize to "latest wins" (each aborts the previous) rather than sharing — never two live loopback listeners. Loopback ports are random (`listen(0)`), so no port contention during the brief overlap while the aborted server closes.
- **No `@mulmoclaude/core` version bump** (source change, not `assets/`); launcher-sync invariant untouched.
- **Retry-mechanism review** (per repo policy): double-execution — abort→reject happens before any token write, and once tokens are saved the flow has settled so a late abort is a no-op; abort-during-wait — `waitForAuthCode` subscribes to the signal and rejects promptly; over-broad error matching — abort vs. real error is branched on `signal.aborted`, and only real errors reach `lastError`.

## User Prompt

> Google 連携で、連携途中のままにすると、「ブラウザでの同意完了を待っています…」となって、失敗した後に retry できない。

Follow-ups: fix it alongside #2170 → chosen scope **"retry fix only (reference #2170)"** with UX **"make the Connect button re-pressable"** → then **#2170 was deemed unnecessary and closed**, so this lands as a standalone fix. (#2170's calendar-selection backend had already merged and stays.)

## Tests

- `test_googleAuthFlow.ts` — restart aborts the previous flow; `cancel()` clears pending without recording an error; completion/failure/error-clear cases retained.
- `test_googleAuthCallback.ts` — `waitForAuthCode` rejects with "cancelled" on mid-wait abort and on an already-aborted signal.
- `settings.spec.ts` (e2e) — Connect stays clickable while `pending` and the click re-triggers authorize.

Plan: `plans/fix-google-oauth-retry.md`. All of format / lint / typecheck / build / unit tests / the new e2e pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google account linking can now be cancelled and restarted while authorization is pending.
  * The Google “Connect” button stays enabled during pending, so users can retry immediately.
  * User-cancelled authorization attempts no longer show up as errors.

* **Tests**
  * Added e2e coverage for retrying when authorization is already in progress.
  * Extended unit/service tests to verify abort/cancellation behavior, including token-commit cancellation guards and flow restart/cancel handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->