### PR TITLE
chore(release): @mulmoclaude/core@0.23.1 + launcher range

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -37,7 +37,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.12.0",
-    "@mulmoclaude/core": "^0.23.0",
+    "@mulmoclaude/core": "^0.23.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.3.0",
     "@mulmoclaude/html-plugin": "^0.2.5",


### PR DESCRIPTION
## Summary

Version-drift repair: npm's `@mulmoclaude/core@0.23.0` was published at 04:40 UTC — **before** #2165 merged (12:30 UTC) — so the registry copy carries v1 (CSV dataSource collections) and v2 (the aggregation DSL) but **not** universal `queryItems` for file-backed collections, while the workspace `0.23.0` has all three. Same version number, different bits: any npm consumer (MulmoTerminal, launcher installs) would hit `"file-backed — use getItems"` refusals on a version that's supposed to have the feature, and the gap would be invisible to version checks.

This PR bumps core to **0.23.1** so the complete feature set publishes under a fresh identity. Two-line diff: core `version` + the launcher's core dep range (lockstep gate).

## Why patch, not 0.24.0

The already-published `collection-plugin@0.12.0` and `launcher@1.3.0` both declare `^0.23.0`, which includes 0.23.1 but — under 0.x semver — excludes 0.24.0. A minor bump would force republishing both dependents and risks npm resolving **two** core copies side by side, which is fatal for the `configureCollectionHost` singleton. 0.23.1 slots into every existing range with zero cascade.

- collection-plugin's `^0.23.0` range deliberately left un-ratcheted (ratchets ride the plugin's own next real bump).
- Launcher's own version stays **1.3.0** (reserved for `/publish-mulmoclaude`); only its core dep range moves to `^0.23.1`.
- `check:launcher-sync` + `drift` green; full pre-commit gate (build, lint, typecheck, tests) passed.

## After merge

Publish `@mulmoclaude/core@0.23.1` — no other package needs publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core package to version 0.23.1.
  * Updated the related package to use the latest core package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->