### PR TITLE
docs(plans): archive csv-duckdb-source plan (v1+v2 shipped); add BI extensions plan

### DIFF
--- a/packages/core/src/collection/core/queryZ.ts
+++ b/packages/core/src/collection/core/queryZ.ts
@@ -1,5 +1,5 @@
 // The aggregation-query DSL for `dataSource` collections (v2 of
-// plans/feat-collection-csv-duckdb-source.md). A structured JSON query —
+// plans/done/feat-collection-csv-duckdb-source.md). A structured JSON query —
 // NEVER raw SQL — because SQL-the-language isn't scoped to the data file
 // (`read_csv`/`read_text`/`COPY TO` reach the whole filesystem) and the
 // query authors (custom views, the agent) are influenceable by untrusted

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -710,7 +710,7 @@ function fieldDrivenFromFieldCarried(schema: FieldDrivenSchemaView): boolean {
  *  workspace-relative and containment-checked exactly like `dataPath`. The
  *  row-id column is the schema's existing `primaryKey` — there is
  *  deliberately no second key concept here.
- *  See plans/feat-collection-csv-duckdb-source.md. */
+ *  See plans/done/feat-collection-csv-duckdb-source.md. */
 export const DataSourceZ = z.object({
   type: z.literal("csv"),
   path: z.string().min(1),

--- a/plans/done/feat-collection-csv-duckdb-source.md
+++ b/plans/done/feat-collection-csv-duckdb-source.md
@@ -1,5 +1,18 @@
 # feat(collections): 外部データ (CSV) を実体とする read-only コレクション — DuckDB クエリエンジン
 
+> **Status: 完了 — plans/done へアーカイブ（2026-07-18）**
+>
+> - **v1（read-only CSV dataSource + DuckDB store）: 実装済み**（2026-07-17、PR #2158。実装記録は v1 節）。
+> - **v2（構造化集計 DSL + `queryItems` + `view-data/query`）: 実装済み**（2026-07-18、PR #2163 / #2165。
+>   file-backed コレクションも enriched JSONL 経由で同一 DSL に対応済み — `jsonlQuery.ts`）。
+> - **未実施のまま後続へ引き継いだ残件**: npx / Docker サンドボックスでの DuckDB install
+>   マトリクス検証（v1 受け入れ基準の残件）。
+> - **当初から別フェーズ**（未着手のままスコープ外として維持）: 一覧ページング、
+>   リモート（phone）ビューへのクエリ露出、v3（xlsx 等フォーマット追加・ネイティブ昇格・
+>   メトリクス定義）。
+> - **後続プラン**: [plans/feat-collection-bi-extensions.md](../feat-collection-bi-extensions.md)
+>   （時系列 bucketing / count distinct / xlsx / install 検証の引き継ぎ）。
+
 Date: 2026-07-17
 背景: ベータユーザーのフィードバック「データさえあれば可視化が作れる。Tableau も Looker もいらないのでは」。
 BI ツール代替のユースケース（学校の生徒管理、HR 系データの分析等）を、Collections の自然な拡張として取り込む。
@@ -201,7 +214,7 @@ interface CollectionStore {
    - 日本語カバレッジは自作必須（datablist には無い）: Shift_JIS の名簿、
      日本語キー値の UTF-8（hex ID 経路）、キー重複。
 
-### v2（BI の本丸: クエリ/集計）— 設計確定（2026-07-18、会話で決定）
+### v2（BI の本丸: クエリ/集計）— **実装済み（2026-07-18、PR #2163 / #2165）**
 
 **クエリ面は構造化 DSL（生 SQL は出さない）。** SQL は言語として CSV に
 スコープされない（`read_csv`/`read_text`/`COPY TO`/`INSTALL httpfs` で

--- a/plans/feat-collection-bi-extensions.md
+++ b/plans/feat-collection-bi-extensions.md
@@ -1,0 +1,126 @@
+# feat(collections): BI クエリ拡張 — 時系列 bucketing / count distinct / xlsx
+
+Date: 2026-07-18
+先行プラン: [plans/done/feat-collection-csv-duckdb-source.md](done/feat-collection-csv-duckdb-source.md)
+（v1 read-only CSV dataSource + v2 構造化集計 DSL、実装済み）
+
+背景: 先行プラン完了時点の BI 観点評価（会話 2026-07-18）で、
+「パーソナル BI の下半分（データ接続〜集計）は完成、しかし BI の中核ワーク
+ロードが DSL にまだ無い」と整理した。ギャップの深刻度順:
+
+1. **時系列集計**（最重要）— date bucketing が無く、「月別売上」が
+   月列が既に CSV に無い限り表現不可。BI クエリの過半は「期間別 × 何か」。
+2. **count distinct** — ユニークユーザー数等、集計の基本語彙の欠落。
+3. **xlsx** — 学校/HR ユースケース（先行プランの起点フィードバック）の
+   現実のファイルは CSV より xlsx が主流。DuckDB 拡張で読める。
+4. **npx / Docker の DuckDB install マトリクス検証** — 先行プラン v1
+   受け入れ基準の**未実施残件**をここで引き継ぐ。
+5. （後続フェーズ）ref 1-hop join / named metrics — 下記「スコープ外」。
+
+## ゴール
+
+`queryItems` / `view-data/query` の同一 DSL・同一安全モデル
+（構造化 JSON、生 SQL 不可、値は prepared パラメータ、識別子はクオート）の
+まま、時系列集計と count distinct を表現可能にし、dataSource に xlsx を
+追加する。DSL の安全性の骨格（`core/queryZ.ts` の zod 検証 →
+`server/csvQuery.ts` の純関数コンパイル）は変えない。
+
+## 設計
+
+### ① 時系列 bucketing（groupBy の拡張）
+
+`groupBy` の要素を「文字列（従来どおり列名）」または「オブジェクト」の
+union にする:
+
+```jsonc
+{
+  "groupBy": [{ "column": "enrolledAt", "dateTrunc": "month", "as": "month" }],
+  "aggregates": { "n": { "op": "count" } },
+  "orderBy": [{ "field": "month", "dir": "asc" }]
+}
+```
+
+- `dateTrunc`: `"year" | "quarter" | "month" | "week" | "day" | "hour"`。
+- `as` は**オブジェクト形式では必須**（SAFE_ALIAS_PATTERN 準拠）。結果キー・
+  `orderBy` 参照名・SQL エイリアスを一意に固定し、既存の
+  case-insensitive 衝突検査（groupBy 列 × aggregate エイリアス）に
+  そのまま参加させる。素の列名を暗黙キーにする案は「同一列を粒度違いで
+  2 回 bucketing」できず、衝突規則も複雑化するため不採用。
+- コンパイル: `date_trunc('<unit>', TRY_CAST("col" AS TIMESTAMP)) AS "as"`。
+  `TRY_CAST` は sniffer が VARCHAR に倒した日付列（混在値・和暦以外の
+  非標準形式）を集計時に NULL へ落とすため — `sum`/`avg` の
+  `TRY_CAST AS DOUBLE` と同じ「standard BI tolerance」。
+  `<unit>` は zod enum からの写像でしか生成しない（ユーザー文字列を
+  SQL に直接書かない）。GROUP BY 句はエイリアスではなく式を繰り返す
+  （DuckDB はエイリアス参照可だが、SELECT との対応を明示的に保つ）。
+- `where` は今回拡張しない。日付範囲フィルタは既存の
+  `gte`/`lt` + ISO 文字列で表現できる（列が VARCHAR でも辞書順 = 時系列順）。
+
+### ② count distinct（aggregate op の追加）
+
+- `op: "count_distinct"`（`column` 必須 — zod refine を
+  「`count` のみ column 省略可」から「`count` / `count_distinct` で分岐」に）。
+- コンパイル: `count(DISTINCT "col")`。
+
+### ③ xlsx dataSource
+
+```jsonc
+{ "dataSource": { "type": "xlsx", "path": "data/students.xlsx", "sheet": "2026年度" } }
+```
+
+- `sheet` 任意（省略時は最初のシート）。値は prepared パラメータではなく
+  `read_xlsx` の named parameter — **quoteLiteral 経由の文字列リテラル**で
+  埋める（read_csv の `types={...}` struct キーと同じ扱い）。
+- DuckDB の `excel` 拡張（`read_xlsx`）を使う。**拡張のロード方式が
+  最大の調査項目**: `INSTALL excel` は実行時ネットワークを要する。
+  (a) `@duckdb/node-api` 同梱/バンドル可否、(b) 初回オンライン取得 +
+  キャッシュ、(c) 非対応環境では xlsx dataSource のみ graceful に無効化
+  （CSV は影響なし）— の順で検討。結論と検知/回避手順は
+  `packages/core/assets/helps/error-recovery.md` に追記（CLAUDE.md ルール）。
+- エンコーディング検知/iconv 経路は不要（xlsx は zip+XML で常に Unicode）。
+  一覧の行キャップ・primaryKey→行 ID エンコード（`id0x…`）・watcher
+  （親ディレクトリ監視 + デバウンス）は CSV store と共通化する。
+- registry Import/Contribute 拒否・書き込み 405 等の read-only ガードは
+  dataSource 共通判定なので追加作業なし（テストで確認のみ）。
+
+### ④ npx / Docker install マトリクス検証（先行プランからの引き継ぎ残件）
+
+- `npx mulmoclaude`（npm launcher）と Docker sandbox で
+  `@duckdb/node-api` の prebuilt binary が解決されるかを検証。
+- 落ちる環境では「dataSource コレクションだけ無効化して他は動く」
+  graceful degradation（dynamic import）を確認、検知/回避を
+  `error-recovery.md` に追記。③ の拡張ロード検証と同時にやると 1 往復で済む。
+
+## 実装ステップ
+
+1. `core/queryZ.ts`: groupBy union（文字列 | `{column, dateTrunc, as}`）、
+   `count_distinct` op、衝突検査 refine の更新。isomorphic なので
+   custom view（ブラウザ）側は zod 更新だけで新形を送れる。
+2. `server/csvQuery.ts`: `compileQuery` の SELECT/GROUP BY/ORDER BY を
+   新 groupBy 形に対応、`aggregateExpr` に `count_distinct`。
+   純関数ユニットテスト（コンパイル結果 SQL の snapshot 的検証）。
+3. `server/csvStore.ts`: xlsx 分岐（`read_xlsx` + sheet、拡張ロード）、
+   `schemaZ.ts`: `dataSource.type` に `"xlsx"`、`sheet` フィールド。
+4. help 更新: `collection-skills.md` の queryItems 節（bucketing /
+   count_distinct の例）と dataSource 節（xlsx）。custom-view help の
+   クエリ契約にも新形を追記。
+5. ④ の install マトリクス検証 + `error-recovery.md` 追記。
+6. バンプ: `@mulmoclaude/core`（minor — DSL 追加は後方互換）、
+   collection-plugin range ratchet は plugin 側の次の実バンプで
+   （plugin→core range ratchet ルール）。MulmoTerminal 側は
+   エンジン契約変更ではない（DSL 追加のみ）が、queryItems を叩く
+   backends があれば追随を確認。
+
+## スコープ外（意図的に入れない — 方向だけ記録）
+
+- **ref 1-hop join**: `getOntology` が関係を知っているのに `queryItems` が
+  辿れない断絶は認識済み。ただし join は DSL の安全モデル（単一ファイルに
+  バインドされた 1 プレースホルダ）を壊す設計変更なので別プラン。
+  当面はエージェント側合成（ontology → 複数 queryItems → メモリ内結合）を
+  help のレシピとして明文化する程度に留める。
+- **named metrics（セマンティックレイヤー）**: 「売上」の定義をワークスペース
+  内ファイルに固定する話。実利用で繰り返しが見えてから（先行プラン v3 のまま）。
+- **一覧ページング / リモート（phone）ビューへのクエリ露出**: 先行プランで
+  別フェーズとした判断を維持。
+- **外部 DB 接続 / スナップショット履歴**: BI 評価で挙がったが
+  「workspace is the database」の外の話。必要になったら別プラン。

--- a/test/workspace/collections/test_dataSource.ts
+++ b/test/workspace/collections/test_dataSource.ts
@@ -1,6 +1,6 @@
 import "../../../server/workspace/collections/configure.js"; // configure @mulmoclaude/core/collection host binding for tests
 // dataSource (external read-only CSV) collections — v1 of
-// plans/feat-collection-csv-duckdb-source.md. Locks in:
+// plans/done/feat-collection-csv-duckdb-source.md. Locks in:
 //   (1) schema validation: dataPath/dataSource exclusivity + the
 //       read-only exclusions (singleton / ingest / spawn / mutate actions);
 //   (2) discovery: dataSourceFile resolution, containment, the


### PR DESCRIPTION
## Summary

- **Archive** `plans/feat-collection-csv-duckdb-source.md` → `plans/done/`, with a status block recording exactly how far it got:
  - v1 (read-only CSV `dataSource` + DuckDB store): shipped 2026-07-17, PR #2158.
  - v2 (structured aggregation DSL + `queryItems` + `view-data/query`, file-backed collections via enriched JSONL): shipped 2026-07-18, PR #2163 / #2165. The v2 heading is updated from 設計確定 to 実装済み.
  - Remaining item carried over (not silently dropped): the npx / Docker sandbox DuckDB install-matrix verification from the v1 acceptance criteria.
- **New plan** `plans/feat-collection-bi-extensions.md` — the next BI iteration, priority-ordered from the gap analysis of the current DSL:
  1. Time-series bucketing: `groupBy` union (`string | {column, dateTrunc, as}`) compiled to `date_trunc('<unit>', TRY_CAST(col AS TIMESTAMP))`, with a required `as` alias that joins the existing case-insensitive collision checks.
  2. `count_distinct` aggregate op.
  3. `xlsx` dataSource (`read_xlsx` + optional `sheet`); the DuckDB `excel` extension load strategy is the main open question, with the conclusion to be recorded in `error-recovery.md`.
  4. The inherited install-matrix verification.
  - Explicitly out of scope (direction recorded only): ref 1-hop join, named metrics, list pagination, remote (phone) query exposure, external DBs, snapshots.
- **Repoint** the three code-comment references (`queryZ.ts`, `schemaZ.ts`, `test_dataSource.ts`) to the plan's new `plans/done/` path.

Docs + comment-only changes; `yarn format` / `lint` / `typecheck` / `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Archive the completed CSV DuckDB data source BI plan, introduce a new plan for BI query extensions, and update internal references to the archived plan path.

Enhancements:
- Update code and test comments to reference the archived CSV DuckDB plan in its new done location.

Documentation:
- Archive the CSV DuckDB data source collections plan to the done directory with a detailed completion status and linkage to a follow-up plan.
- Add a new BI query extensions planning document covering time-series bucketing, distinct counts, xlsx data sources, and installation-matrix validation scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Archived and marked the CSV/DuckDB collection data source work as complete, including delivered v1 and v2 capabilities.
  - Added a plan for future BI query enhancements, including time-series grouping, distinct counts, and XLSX data sources.
  - Clarified remaining validation tasks, follow-up work, and out-of-scope items.
  - Improved references and spacing in collection documentation.

- **Tests**
  - Updated test documentation references to reflect the completed collection data source work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->