### PR TITLE
fix: derive Windows sandbox probe mounts from the shipped builder

### DIFF
--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -172,30 +172,29 @@ jobs:
           Write-Host "Windows workspace: $wsWin"
           Write-Host "WSL2 mount path:   $wsLinux"
 
-          # Bind each preset package's dev-workspace path to
-          # /app/pkg_modules/@mulmoclaude/<name>. `packages/plugins` is
-          # mounted whole; the container-side symlinks resolve to the
-          # individual package roots. `packages/core` is separate (it
-          # lives at packages/core, not packages/plugins/core). Keep in
-          # sync with server/plugins/preset-list.ts when a preset is
-          # added or removed — the probe iterates PRESET_PLUGINS and
-          # will fail if a mount is missing.
-          wsl -d Ubuntu-22.04 -u root -- docker run --rm `
-            -v "${wsLinux}/node_modules:/app/node_modules:ro" `
-            -v "${wsLinux}/packages/plugins/x-plugin:/app/pkg_modules/@mulmoclaude/x-plugin:ro" `
-            -v "${wsLinux}/packages/plugins/spotify-plugin:/app/pkg_modules/@mulmoclaude/spotify-plugin:ro" `
-            -v "${wsLinux}/packages/plugins/debug-plugin:/app/pkg_modules/@mulmoclaude/debug-plugin:ro" `
-            -v "${wsLinux}/packages/plugins/edgar-plugin:/app/pkg_modules/@mulmoclaude/edgar-plugin:ro" `
-            -v "${wsLinux}/packages/plugins/email-plugin:/app/pkg_modules/@mulmoclaude/email-plugin:ro" `
-            -v "${wsLinux}/packages/core:/app/pkg_modules/@mulmoclaude/core:ro" `
-            -v "${wsLinux}/server/plugins:/app/server-plugins:ro" `
-            -v "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro" `
-            -v "${wsLinux}/server/agent/mcp-esm-bootstrap.mjs:/app/server/agent/mcp-esm-bootstrap.mjs:ro" `
-            -v "${wsLinux}/test/sandbox-repro:/repro:ro" `
-            -e NODE_PATH=/app/node_modules:/app/pkg_modules `
-            -w /app `
-            node:22-slim `
-            bash -c "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /repro/probe.ts"
+          # The per-package `/app/pkg_modules/<scope>/<name>` fallback mounts come
+          # from the SHIPPED `workspaceModuleMounts()` (via
+          # print-mcp-container-spec.ts) — the same builder the real MCP child
+          # uses. probe.ts iterates PRESET_PLUGINS, so a hand-maintained mount
+          # list here rots the moment a preset is added: that is exactly how
+          # `@mulmoclaude/google-plugin` (#2114) broke this canary while every
+          # other preset still passed. Deriving the list makes that impossible.
+          $spec = & node_modules/.bin/tsx test/sandbox-repro/print-mcp-container-spec.ts | ConvertFrom-Json
+
+          $dockerArgs = @("run", "--rm")
+          $dockerArgs += @("-v", "${wsLinux}/node_modules:/app/node_modules:ro")
+          foreach ($mount in $spec.pkgModuleMounts) { $dockerArgs += @("-v", $mount) }
+          $dockerArgs += @("-v", "${wsLinux}/server/plugins:/app/server-plugins:ro")
+          $dockerArgs += @("-v", "${wsLinux}/server/agent/mcp-esm-loader.mjs:/app/server/agent/mcp-esm-loader.mjs:ro")
+          $dockerArgs += @("-v", "${wsLinux}/server/agent/mcp-esm-bootstrap.mjs:/app/server/agent/mcp-esm-bootstrap.mjs:ro")
+          $dockerArgs += @("-v", "${wsLinux}/test/sandbox-repro:/repro:ro")
+          $dockerArgs += @("-e", "NODE_PATH=/app/node_modules:/app/pkg_modules")
+          $dockerArgs += @("-w", "/app", "node:22-slim", "bash", "-c",
+            "npm install -g tsx --silent && tsx --import file:///app/server/agent/mcp-esm-bootstrap.mjs /repro/probe.ts")
+
+          Write-Host "pkg_modules mounts: $($spec.pkgModuleMounts.Count)"
+          wsl -d Ubuntu-22.04 -u root -- docker @dockerArgs
+          if ($LASTEXITCODE -ne 0) { throw "sandbox regression probe failed (exit $LASTEXITCODE)" }
 
       # ── #2052 diagnostics ────────────────────────────────────────────
       # The probe above runs from /repro, whose sibling package.json says


### PR DESCRIPTION
## Summary

The nightly **docker sandbox (Windows junction repro)** canary is failing on `main` ([run 29658936105](https://github.com/receptron/mulmoclaude/actions/runs/29658936105/job/88118081610)):

```
FAIL  shipped resolvePresetRoot() finds @mulmoclaude/google-plugin via NODE_PATH
      shipped resolver returned null — fallback path did not resolve
1 check(s) failed
```

**Root cause — a sync gap, not a resolver bug.** `probe.ts` deliberately iterates `PRESET_PLUGINS` so that adding a preset automatically extends the regression coverage. But the workflow's `/app/pkg_modules/...` fallback mounts were *hand-maintained*. When `@mulmoclaude/google-plugin` joined `preset-list.ts` (#2114), its mount was never added — so the probe iterated a preset that had no fallback directory in the container. Every other preset (spotify / debug / edgar / email) still passed, which is why only this one line failed.

The workflow even predicted this: *"Keep in sync with server/plugins/preset-list.ts … will fail if a mount is missing."*

**Fix — remove the hand-maintained list.** Derive the per-package mounts from the SHIPPED `workspaceModuleMounts()` via the existing `print-mcp-container-spec.ts`, which the `#2052` end-to-end step in this same workflow already uses for exactly this anti-drift reason (*"so this can never drift the way the hardcoded smoke test did"*). Adding or removing a preset can no longer desync this canary.

## Items to Confirm / Review

- **Scope choice**: I fixed the drift class rather than just appending one `-v google-plugin` line. The one-liner would have gone green too, but the next preset would break it again. Say the word if you'd prefer the minimal patch.
- **Superset mounts**: the derived list is 49 packages (all `@mulmoclaude/*`, `@mulmobridge/*`, `@receptron/*`) vs. the previous hand-picked 6. The probe only needs the presets + `x-plugin` + `core`; the extras are harmless read-only binds, and the `#2052` e2e step in this same job already runs with the identical 49.
- **Exit-code handling**: the docker call is no longer the last statement, so failure is now surfaced explicitly via `if ($LASTEXITCODE -ne 0) { throw ... }` (same style as the e2e step). Without this the step would silently pass on probe failure — worth a second look.

## Verification

- Locally confirmed `workspaceModuleMounts(cwd, "win32", …)` enumerates **all 49** workspace packages including `@mulmoclaude/google-plugin`, every `PRESET_PLUGINS` entry, `x-plugin` and `core`.
- `actionlint` 1.7.12 passes on the changed workflow.
- Windows + WSL2 + Docker can't be reproduced locally, so the real check is a `workflow_dispatch` run on this branch — linked in a follow-up comment.

## User Prompt

> https://github.com/receptron/mulmoclaude/actions/runs/29658936105/job/88118081610　調査修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Windows docker sandbox canary workflow to derive container package mounts from the shipped MCP container spec instead of a hand-maintained list, and ensure probe failures correctly fail the job.

Bug Fixes:
- Fix Windows sandbox probe failures caused by missing preset plugin mounts in the container.

Enhancements:
- Derive pkg_modules mount points from the shipped workspaceModuleMounts() spec to prevent future drift when presets change.
- Improve Windows canary logging by printing the number of pkg_modules mounts used for the probe.
- Ensure docker probe failures are surfaced explicitly by checking the exit code and throwing on non-zero status.

CI:
- Refine the docker_sandbox_windows workflow to construct docker arguments dynamically from the generated MCP container spec rather than hardcoding volume mounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CI sandbox regression checks by dynamically mounting all required package modules.
  * Added explicit failure detection so unsuccessful probe runs are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->