### PR TITLE
chore(lint): add a type-aware ESLint pass for `any` leaks and async bugs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -471,5 +471,62 @@ export default [
       ],
     },
   },
+  // Type-aware pass. `projectService` builds the TypeScript program so rules can
+  // reason about real types; that program is the whole cost (measured: five
+  // rules cost the same as all 44), and it runs the full scope in ~26s over the
+  // untyped pass.
+  //
+  // Only rules that earn that cost are on. The rest of `strictTypeChecked` was
+  // measured across the repo and is dominated by style — `restrict-template-
+  // expressions` alone accounts for 439 of its 1213 findings — which would bury
+  // the two things type information is actually needed for here:
+  //
+  //   1. the `any` that `no-explicit-any` structurally cannot see (values from
+  //      untyped libraries, `JSON.parse()`, `as unknown as T` double casts)
+  //   2. mistakes no syntactic rule can catch at all (a dropped `await`, an
+  //      async callback handed to a sync-only API, an object stringified into
+  //      "[object Object]")
+  //
+  // Scoped to source: tests / e2e stay on the untyped pass to keep the program
+  // small. Everything is `warn` per docs/lint-policy.md — a backlog to drain,
+  // not a gate — so this can never fail CI on its own.
+  {
+    files: ["server/**/*.ts", "src/**/*.ts", "packages/**/src/**/*.ts"],
+    languageOptions: {
+      parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      // (1) `any` that survives no-explicit-any.
+      "@typescript-eslint/no-unsafe-assignment": "warn",
+      "@typescript-eslint/no-unsafe-member-access": "warn",
+      "@typescript-eslint/no-unsafe-argument": "warn",
+      "@typescript-eslint/no-unsafe-call": "warn",
+      "@typescript-eslint/no-unsafe-return": "warn",
+      // Zero findings today — on to keep it that way.
+      "@typescript-eslint/no-unsafe-enum-comparison": "warn",
+      "@typescript-eslint/no-unsafe-declaration-merging": "warn",
+      // (2) Bugs only the type checker can see.
+      "@typescript-eslint/no-base-to-string": "warn",
+      "@typescript-eslint/no-floating-promises": "warn",
+      "@typescript-eslint/no-misused-promises": "warn",
+      "@typescript-eslint/await-thenable": "warn",
+      // sonarjs ships type-aware rules of its own. They sit dormant without a
+      // TypeScript program, so `projectService` wakes them — and they'd land at
+      // the `error` severity the sonarjs preset sets above, failing CI on code
+      // that was never linted by them before. Same backlog treatment as the
+      // typescript-eslint set: surface them, don't gate on them.
+      "sonarjs/no-alphabetical-sort": "warn",
+      "sonarjs/prefer-regexp-exec": "warn",
+      "sonarjs/different-types-comparison": "warn",
+      "sonarjs/function-return-type": "warn",
+      "sonarjs/no-misleading-array-reverse": "warn",
+      "sonarjs/reduce-initial-value": "warn",
+      "sonarjs/deprecation": "warn",
+      "sonarjs/no-selector-parameter": "warn",
+      "sonarjs/no-undefined-argument": "warn",
+      "sonarjs/post-message": "warn",
+      "sonarjs/no-redundant-optional": "warn",
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,29 @@ import vuePlugin from "eslint-plugin-vue";
 import vueParser from "vue-eslint-parser";
 import vueI18n from "@intlify/eslint-plugin-vue-i18n";
 
+// sonarjs ships type-aware rules of its own. They sit dormant without a
+// TypeScript program, so enabling `projectService` below wakes them — at the
+// `error` severity sonarjs's preset sets, on code they had never linted before.
+//
+// Derived from the plugin's own `requiresTypeChecking` metadata rather than a
+// hand-listed set, so a sonarjs upgrade that adds type-aware rules can't
+// silently start failing CI. Intersected with what `recommended` actually turns
+// on: 14 of the 70 type-aware rules are `off` there, and naming them here would
+// ENABLE them rather than downgrade them (`strings-comparison` alone adds 32
+// findings that way). This set is exactly what `projectService` wakes — every
+// rule in it is dormant today, so it weakens no gate that currently runs.
+const sonarRecommendedRules = sonarjs.configs.recommended?.rules ?? {};
+const isEnabled = (level) => {
+  const severity = Array.isArray(level) ? level[0] : level;
+  return severity !== undefined && severity !== "off" && severity !== 0;
+};
+
+const sonarTypeAwareRulesAsWarn = Object.fromEntries(
+  Object.entries(sonarjs.rules ?? {})
+    .filter(([name, rule]) => rule?.meta?.docs?.requiresTypeChecking && isEnabled(sonarRecommendedRules[`sonarjs/${name}`]))
+    .map(([name]) => [`sonarjs/${name}`, "warn"]),
+);
+
 export default [
   {
     files: ["{src,test}/**/*.{js,ts,yaml,yml,vue}", "assets/html/js/**/*.js"],
@@ -510,22 +533,8 @@ export default [
       "@typescript-eslint/no-floating-promises": "warn",
       "@typescript-eslint/no-misused-promises": "warn",
       "@typescript-eslint/await-thenable": "warn",
-      // sonarjs ships type-aware rules of its own. They sit dormant without a
-      // TypeScript program, so `projectService` wakes them — and they'd land at
-      // the `error` severity the sonarjs preset sets above, failing CI on code
-      // that was never linted by them before. Same backlog treatment as the
-      // typescript-eslint set: surface them, don't gate on them.
-      "sonarjs/no-alphabetical-sort": "warn",
-      "sonarjs/prefer-regexp-exec": "warn",
-      "sonarjs/different-types-comparison": "warn",
-      "sonarjs/function-return-type": "warn",
-      "sonarjs/no-misleading-array-reverse": "warn",
-      "sonarjs/reduce-initial-value": "warn",
-      "sonarjs/deprecation": "warn",
-      "sonarjs/no-selector-parameter": "warn",
-      "sonarjs/no-undefined-argument": "warn",
-      "sonarjs/post-message": "warn",
-      "sonarjs/no-redundant-optional": "warn",
+      // Same backlog treatment for the sonarjs rules this block wakes.
+      ...sonarTypeAwareRulesAsWarn,
     },
   },
   eslintConfigPrettier,


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-explicit-any` only sees the **keyword**. It cannot see an `any` that arrives from an untyped library, out of `JSON.parse()`, or through an `as unknown as T` double cast — and no syntactic rule can see a dropped `await` at all. Both need type information.

This enables `projectService` and turns on the eleven type-aware rules that earn its cost. Everything is `warn` per [`docs/lint-policy.md`](../blob/main/docs/lint-policy.md), so **this cannot fail CI on its own**.

## Measured, not guessed (full lint scope, 1938 files, cold cache)

| config | time | errors | warnings |
|---|---|---|---|
| today (no type info) | 75.9s | 0 | 0 |
| all 44 `strictTypeChecked` rules | 102.0s | **79** ❌ | 1213 |
| **this change** | **94.9s** | **0** ✅ | **339** |

Cost: **+19s (+25%)**.

## Why a subset, and why *this* subset

Two measurements drove it:

**1. Rule count is not what costs time — building the TypeScript program is.** Enabling five rules measured the same as enabling all 44. So the price is paid the moment `projectService` is on; the only question is which rules are worth reading. That argues for picking on signal, not on cost.

**2. The full set is dominated by style.** `restrict-template-expressions` alone is **439 of its 1213** findings; with `no-unnecessary-condition` (194) and `no-confusing-void-expression` (150) that's 65% of the output, none of it about `any` or correctness. Enabling everything would bury the signal under a backlog nobody drains.

So the set is scoped to the two things type information is actually needed for here:

**(1) `any` that survives `no-explicit-any`** — 161 findings
`no-unsafe-assignment` (73), `no-unsafe-member-access` (52), `no-unsafe-argument` (17), `no-unsafe-call` (15), `no-unsafe-return` (4), plus `no-unsafe-enum-comparison` / `no-unsafe-declaration-merging` (0 today — on to keep it that way).

**(2) Bugs no syntactic rule can catch** — 99 findings
`no-base-to-string` (75, the `"[object Object]"` class of bug), `no-floating-promises` (15), `no-misused-promises` (7), `await-thenable` (2).

Those last three are the part I'd have missed by cherry-picking up front: **24 genuine async bugs — dropped `await`s and async callbacks handed to sync-only APIs — that were structurally invisible to the current lint.** Trying the full set first is what surfaced them.

## Items to Confirm / Review

- **The +19s lands on the pre-commit hook too**, not just CI. That's the main thing to accept or reject here.
- **The sonarjs downgrade is load-bearing, and it's a hardcoded list.** Enabling `projectService` also wakes sonarjs's *own* type-aware rules, which fire at the `error` severity its preset sets — 79 of them, on code they had never linted before. They're pinned to `warn` in the same block. ⚠️ If sonarjs adds type-aware rules in a future release, they'll wake at `error` and break CI — the same hand-maintained-list drift that broke the Windows sandbox canary earlier today (#2178). I don't see a programmatic way to enumerate "sonarjs rules that need type info"; suggestions welcome.
- **339 warnings as a backlog.** Biggest blocks: `no-base-to-string` (75), `no-unsafe-assignment` (73), `no-unsafe-member-access` (52). Per lint-policy these are a backlog to drain, not a baseline — worth agreeing on whether anyone owns draining them, or whether some rule should be dropped instead.
- **Scope**: `server/**`, `src/**`, `packages/**/src/**`. Tests / e2e stay on the untyped pass to keep the program small. `.vue` files are excluded — SFC type-aware linting is a separate lift.

## User Prompt

Started from a question about the ESLint snippet:

> ```
> ...tseslint.configs.strictTypeChecked,
> { languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: import.meta.dirname } } },
> ```
> できる？

Follow-ups: 「実際にCIでまわしてみよう！！絞り込みて。warnでよいよ」 → 「strictTypeChecked 丸ごといれてもよいのかん。」 (measured it wholesale — that's where the 79 sonarjs errors and the 24 async bugs came from) → 「warnでている必要な設定だけ追加するのでどうかな？」 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a type-aware ESLint pass focused on `any` safety and async correctness for TypeScript source files.

Enhancements:
- Enable ESLint `projectService` to build the TypeScript program and run selected strictTypeChecked rules over server, src, and package source files.
- Configure targeted type-aware rules to flag unsafe `any` usage and common async bugs as warnings to create a backlog without gating CI.
- Activate sonarjs type-aware rules under the new type-aware pass while downgrading them to warning severity to avoid new hard CI failures.

Build:
- Extend eslint.config.mjs with a scoped, type-aware lint configuration for TypeScript source files using projectService and warn-only rules.