### PR TITLE
feat(collections): filter menu — boolean/toggle chips, dropdown, checkbox tri-state icons

### DIFF
--- a/e2e/tests/collection-flag-filter.spec.ts
+++ b/e2e/tests/collection-flag-filter.spec.ts
@@ -237,7 +237,7 @@ test("a toggle covering the completion pair suppresses the synthesized done chip
   // Exactly ONE "Done" filter: the toggle's own chip; no __completion twin.
   await expect(page.getByTestId("collections-flag-chip-done")).toBeVisible();
   await expect(page.getByTestId("collections-flag-chip-__completion")).toHaveCount(0);
-  await expect(page.getByTestId("collections-filter-menu-panel").getByText("Done")).toHaveCount(1);
+  await expect(page.getByTestId("collections-filter-menu-panel").getByText("Done", { exact: true })).toHaveCount(1);
 
   // And the surviving chip filters done-ness as before.
   await page.getByTestId("collections-flag-chip-done").click();

--- a/e2e/tests/collection-flag-filter.spec.ts
+++ b/e2e/tests/collection-flag-filter.spec.ts
@@ -1,9 +1,11 @@
-// E2E: the standalone /collections/:slug table's flag filter chips
-// (plans/feat-collection-flag-fields.md, reframing #2174). A `flag` field
-// gets a tri-state chip (all → hide → only) that narrows the table rows
-// and persists per-collection in localStorage; a legacy completion-pair
-// schema (no flag field) gets a synthesized "done" chip driven by the
-// same predicate, so hide-completed works without a schema edit.
+// E2E: the standalone /collections/:slug table's filter menu
+// (plans/feat-collection-flag-fields.md, reframing #2174). Predicate-shaped
+// fields — `flag`, `boolean`, `toggle` — each get a tri-state entry
+// (all → hide → only) in a dropdown behind a single "Filters" trigger; the
+// entries narrow the table rows and persist per-collection in localStorage.
+// A legacy completion-pair schema (no flag field) gets a synthesized "done"
+// entry driven by the same predicate, so hide-completed works without a
+// schema edit.
 
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
@@ -23,6 +25,8 @@ const TASKS = {
         id: { type: "string", label: "ID", primary: true, required: true },
         name: { type: "string", label: "Name" },
         status: { type: "enum", label: "Status", values: ["todo", "doing", "done", "canceled"] },
+        urgent: { type: "boolean", label: "Urgent" },
+        finished: { type: "toggle", label: "Finished", field: "status", onValue: "done", offValue: "todo" },
         isDone: { type: "flag", label: "Done", where: [{ field: "status", op: "in", value: ["done", "canceled"] }] },
         // Deliberately named after an Object.prototype member: chip-state
         // lookups must read OWN properties, or this chip reads the
@@ -32,8 +36,8 @@ const TASKS = {
     },
   },
   items: [
-    { id: "t1", name: "Open task", status: "todo" },
-    { id: "t2", name: "Finished task", status: "done" },
+    { id: "t1", name: "Open task", status: "todo", urgent: true },
+    { id: "t2", name: "Finished task", status: "done", urgent: false },
     { id: "t3", name: "Dropped task", status: "canceled" },
   ],
 };
@@ -66,11 +70,48 @@ const TODOS = {
   ],
 };
 
+// The real-world todos shape: a "Done" toggle projecting the status enum
+// AND the legacy completion pair over the same value. The toggle's chip
+// expresses the completion predicate exactly, so NO extra done chip may
+// be synthesized (else the menu shows two "Done" filters).
+const CHORES = {
+  collection: {
+    slug: "chores",
+    title: "Chores",
+    icon: "checklist",
+    source: "user",
+    schema: {
+      title: "Chores",
+      icon: "checklist",
+      dataPath: "data/chores/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        done: { type: "toggle", label: "Done", field: "status", onValue: "done", offValue: "todo" },
+        name: { type: "string", label: "Name" },
+        status: { type: "enum", label: "Status", values: ["todo", "done"] },
+      },
+      completionField: "status",
+      completionDoneValues: ["done"],
+    },
+  },
+  items: [
+    { id: "c1", name: "Open chore", status: "todo" },
+    { id: "c2", name: "Finished chore", status: "done" },
+  ],
+};
+
 async function mockCollection(page: Page, slug: string, payload: object): Promise<void> {
   await page.route(
     (url) => url.pathname === `/api/collections/${slug}`,
     (route) => route.fulfill({ json: payload }),
   );
+}
+
+/** Open the "Filters" dropdown that hosts the chips. */
+async function openFilterMenu(page: Page): Promise<void> {
+  await page.getByTestId("collections-filter-menu").click();
+  await expect(page.getByTestId("collections-filter-menu-panel")).toBeVisible();
 }
 
 /** Assert exactly `ids` render as table rows (order-insensitive here —
@@ -90,10 +131,11 @@ test("flag chip cycles all → hide → only, filters the table, and persists", 
   await page.goto("/collections/tasks");
   await expectRows(page, ["t1", "t2", "t3"]);
 
+  await openFilterMenu(page);
   const chip = page.getByTestId("collections-flag-chip-isDone");
   await expect(chip).toContainText("Done");
 
-  // hide → only the open task remains.
+  // hide → only the open task remains; the menu stays open for chaining.
   await chip.click();
   await expectRows(page, ["t1"]);
 
@@ -101,13 +143,43 @@ test("flag chip cycles all → hide → only, filters the table, and persists", 
   await chip.click();
   await expectRows(page, ["t2", "t3"]);
 
-  // Reload: the "only" state must survive (localStorage, keyed by slug).
+  // Reload: the "only" state must survive (localStorage, keyed by slug)
+  // and show on the collapsed trigger as an active-count badge.
   await page.reload();
   await expectRows(page, ["t2", "t3"]);
+  await expect(page.getByTestId("collections-filter-menu")).toContainText("1");
 
   // Third click clears the filter → everything again.
+  await openFilterMenu(page);
   await page.getByTestId("collections-flag-chip-isDone").click();
   await expectRows(page, ["t1", "t2", "t3"]);
+});
+
+test("boolean and toggle fields get filter chips too", async ({ page }) => {
+  await mockAllApis(page);
+  await mockCollection(page, "tasks", TASKS);
+
+  await page.goto("/collections/tasks");
+  await expectRows(page, ["t1", "t2", "t3"]);
+  await openFilterMenu(page);
+
+  // boolean: hide urgent (t1) → only urgent → back to all.
+  const urgent = page.getByTestId("collections-flag-chip-urgent");
+  await urgent.click();
+  await expectRows(page, ["t2", "t3"]);
+  await urgent.click();
+  await expectRows(page, ["t1"]);
+  await urgent.click();
+  await expectRows(page, ["t1", "t2", "t3"]);
+
+  // toggle: checked ⇔ projected enum equals onValue ("done" — t2 only;
+  // the canceled row is NOT the toggle's on-state even though the isDone
+  // flag counts it).
+  const finished = page.getByTestId("collections-flag-chip-finished");
+  await finished.click(); // hide
+  await expectRows(page, ["t1", "t3"]);
+  await finished.click(); // only
+  await expectRows(page, ["t2"]);
 });
 
 test("a flag named after an Object.prototype member still cycles", async ({ page }) => {
@@ -116,6 +188,7 @@ test("a flag named after an Object.prototype member still cycles", async ({ page
 
   await page.goto("/collections/tasks");
   await expectRows(page, ["t1", "t2", "t3"]);
+  await openFilterMenu(page);
 
   // `toString` shadows Object.prototype — a plain-object lookup would read
   // the inherited function, leaving this chip stuck in the default state.
@@ -147,7 +220,26 @@ test("legacy completion pair gets a synthesized done chip (no schema edit)", asy
   await expectRows(page, ["t1", "t2"]);
 
   // hide → the done todo disappears; the count summary reflects it.
+  await openFilterMenu(page);
   await page.getByTestId("collections-flag-chip-__completion").click();
   await expectRows(page, ["t1"]);
   await expect(page.getByText("Showing 1 of 2")).toBeVisible();
+});
+
+test("a toggle covering the completion pair suppresses the synthesized done chip", async ({ page }) => {
+  await mockAllApis(page);
+  await mockCollection(page, "chores", CHORES);
+
+  await page.goto("/collections/chores");
+  await expectRows(page, ["c1", "c2"]);
+  await openFilterMenu(page);
+
+  // Exactly ONE "Done" filter: the toggle's own chip; no __completion twin.
+  await expect(page.getByTestId("collections-flag-chip-done")).toBeVisible();
+  await expect(page.getByTestId("collections-flag-chip-__completion")).toHaveCount(0);
+  await expect(page.getByTestId("collections-filter-menu-panel").getByText("Done")).toHaveCount(1);
+
+  // And the surviving chip filters done-ness as before.
+  await page.getByTestId("collections-flag-chip-done").click();
+  await expectRows(page, ["c1"]);
 });

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -175,31 +175,59 @@
         </button>
       </div>
       <div class="flex items-center gap-2">
-        <!-- Flag filter chips (table view only): one tri-state chip per
-             `flag` field (all → hide → only), plus a synthesized "done"
-             chip for legacy completion-pair schemas. State is a shared
-             per-collection localStorage preference, like the table sort. -->
-        <div
-          v-if="activeView === 'table' && flagChips.length > 0 && items.length > 0"
-          class="flex items-center gap-0.5"
-          role="group"
-          :aria-label="t('collectionsView.flagFilterGroup')"
-        >
+        <!-- Filter menu (table view only): one tri-state entry (all → hide
+             → only) per predicate-shaped field — `flag`, `boolean`,
+             `toggle` — plus a synthesized "done" entry for legacy
+             completion-pair schemas. Collapsed behind a single trigger so
+             a chip-heavy schema can't flood the chrome row, and styled as
+             a dashed pill (soft-tinted when active) so it never reads as
+             another view-toggle button. State is a shared per-collection
+             localStorage preference, like the table sort. -->
+        <div v-if="activeView === 'table' && flagChips.length > 0 && items.length > 0" ref="filterMenuRef" class="relative">
           <button
-            v-for="chip in flagChips"
-            :key="chip.key"
             type="button"
-            class="h-8 px-2.5 flex items-center gap-1 rounded text-xs font-bold transition-colors"
-            :class="flagChipClass(chip.key)"
-            :title="flagChipTitle(chip)"
-            :aria-label="flagChipTitle(chip)"
-            :aria-pressed="flagFilterMode(chip.key) !== undefined"
-            :data-testid="`collections-flag-chip-${chip.key}`"
-            @click="cycleFlagFilter(chip.key)"
+            class="h-8 px-2.5 flex items-center gap-1 rounded-full text-xs font-medium transition-colors"
+            :class="
+              activeFlagFilterCount > 0
+                ? 'bg-indigo-50 text-indigo-700 border border-indigo-300'
+                : 'bg-transparent text-slate-500 border border-dashed border-slate-300 hover:bg-slate-50'
+            "
+            :aria-label="t('collectionsView.flagFilterButton')"
+            :aria-expanded="filterMenuOpen"
+            data-testid="collections-filter-menu"
+            @click="filterMenuOpen = !filterMenuOpen"
           >
-            <span class="material-icons text-sm" aria-hidden="true">{{ flagChipIcon(chip.key) }}</span>
-            <span>{{ chip.label }}</span>
+            <span class="material-icons text-sm" aria-hidden="true">filter_alt</span>
+            <span>{{ t("collectionsView.flagFilterButton") }}</span>
+            <span
+              v-if="activeFlagFilterCount > 0"
+              class="min-w-4 h-4 px-1 flex items-center justify-center rounded-full bg-indigo-600 text-white text-[10px] font-bold"
+              >{{ activeFlagFilterCount }}</span
+            >
           </button>
+          <div
+            v-if="filterMenuOpen"
+            class="absolute left-0 top-full mt-1 z-20 min-w-max rounded border border-slate-200 bg-white shadow-lg py-1"
+            role="group"
+            :aria-label="t('collectionsView.flagFilterButton')"
+            data-testid="collections-filter-menu-panel"
+          >
+            <button
+              v-for="chip in flagChips"
+              :key="chip.key"
+              type="button"
+              class="w-full h-8 px-3 flex items-center gap-2 text-xs font-medium transition-colors hover:bg-slate-50"
+              :class="flagChipClass(chip.key)"
+              :title="flagChipTitle(chip)"
+              :aria-label="flagChipTitle(chip)"
+              :aria-pressed="flagFilterMode(chip.key) !== undefined"
+              :data-testid="`collections-flag-chip-${chip.key}`"
+              @click="cycleFlagFilter(chip.key)"
+            >
+              <span class="material-icons text-sm" :class="flagChipIconClass(chip.key)" aria-hidden="true">{{ flagChipIcon(chip.key) }}</span>
+              <span class="flex-1 text-left">{{ chip.label }}</span>
+            </button>
+          </div>
         </div>
         <!-- View toggle: table ↔ calendar ↔ kanban. Calendar shows only when
              the schema has a `date` field, kanban only with an `enum` field;
@@ -1140,25 +1168,54 @@ interface FlagChip {
   key: string;
   label: string;
   /** Set on the synthesized legacy-completion chip (predicate =
-   *  `itemIsDone`); absent on chips backed by a real flag field. */
+   *  `itemIsDone`); absent on chips backed by a real field. */
   synthetic?: boolean;
+}
+
+/** The field types that earn a filter-menu entry: declared predicates
+ *  (`flag`) plus the fields that ARE a predicate already — a stored
+ *  `boolean` and a `toggle`'s projected on/off state. Enums stay out:
+ *  they need a value picker, and kanban already slices by enum. */
+const CHIP_FIELD_TYPES = new Set(["flag", "boolean", "toggle"]);
+
+/** True when an existing FIELD chip already expresses the legacy
+ *  completion predicate exactly, so a synthesized "done" chip would be a
+ *  duplicate: a boolean `completionField` (done ⇔ `"true"` ⇔ the
+ *  boolean's own chip), or a `toggle` projecting the `completionField`
+ *  whose `onValue` is the single done value (the todos-schema shape:
+ *  toggle "Done" on `status` + `completionDoneValues: ["done"]`). A
+ *  superset pair (extra done values) still synthesizes — no field chip
+ *  covers it. */
+function completionCoveredByFieldChip(schema: {
+  fields: Record<string, FieldSpec>;
+  completionField?: string;
+  completionDoneValues?: readonly string[];
+}): boolean {
+  const { completionField, completionDoneValues } = schema;
+  if (completionDoneValues?.length !== 1) return false;
+  const [doneValue] = completionDoneValues;
+  if (schema.fields[completionField ?? ""]?.type === "boolean") return doneValue === "true";
+  return Object.values(schema.fields).some((field) => field.type === "toggle" && field.field === completionField && field.onValue === doneValue);
 }
 
 const flagChips = computed<FlagChip[]>(() => {
   const schema = collection.value?.schema;
   if (!schema) return [];
   const chips: FlagChip[] = Object.entries(schema.fields)
-    .filter(([, field]) => field.type === "flag")
+    .filter(([, field]) => CHIP_FIELD_TYPES.has(field.type))
     .map(([key, field]) => ({ key, label: field.label ?? key }));
   // Legacy completion pair (completionField NOT naming a flag) → one
   // synthesized done chip; a flag-form completion is already covered by
-  // that flag's own chip. Skipped when a field happens to be named
+  // that flag's own chip, and a pair a boolean/toggle chip expresses
+  // exactly is covered by THAT chip (else e.g. the todos schema shows
+  // two "Done" filters). Skipped when a field happens to be named
   // `__completion`, so the chip key (filter state / testid / Vue :key)
   // can never collide with a real field's.
   if (
     schema.completionField &&
     schema.completionDoneValues &&
     schema.fields[schema.completionField]?.type !== "flag" &&
+    !completionCoveredByFieldChip(schema) &&
     schema.fields[COMPLETION_CHIP_KEY] === undefined
   ) {
     chips.push({ key: COMPLETION_CHIP_KEY, label: t("collectionsView.flagDoneChip"), synthetic: true });
@@ -1184,11 +1241,16 @@ function flagValueOf(key: string, item: CollectionItem): boolean {
 }
 
 /** The chip's boolean for one row — `itemIsDone` for the synthesized
- *  completion chip, the computed flag value otherwise. */
+ *  completion chip, the stored/projected value for `boolean`/`toggle`
+ *  fields, the computed flag value otherwise. */
 function chipMatches(chip: FlagChip, item: CollectionItem): boolean {
   const schema = collection.value?.schema;
   if (!schema) return false;
-  return chip.synthetic ? itemIsDone(schema, item) : flagValueOf(chip.key, item);
+  if (chip.synthetic) return itemIsDone(schema, item);
+  const field = schema.fields[chip.key];
+  if (field?.type === "toggle") return toggleChecked(item, field);
+  if (field?.type === "boolean") return item[chip.key] === true;
+  return flagValueOf(chip.key, item);
 }
 
 /** `filteredItems` further narrowed by every ACTIVE chip (AND). Consumed
@@ -1207,19 +1269,46 @@ function cycleFlagFilter(key: string): void {
   flagFilters.value = next ? { ...rest, [key]: next } : rest;
 }
 
+// Checkbox metaphor for the tri-state: checked = only the ON rows,
+// unchecked = only the OFF rows, faint unchecked = not filtering. The
+// icon glyph alone can't show the third state (Material Icons has no
+// dotted box), so `flagChipIconClass` greys it out instead.
 function flagChipIcon(key: string): string {
-  const mode = flagFilterMode(key);
-  return mode === "hide" ? "visibility_off" : mode === "only" ? "filter_alt" : "visibility";
+  return flagFilterMode(key) === "only" ? "check_box" : "check_box_outline_blank";
 }
 
-// Mirrors the view-toggle button states: neutral when inactive; slate for
-// "hide" (rows removed), indigo for "only" (rows isolated).
+function flagChipIconClass(key: string): string {
+  const mode = flagFilterMode(key);
+  if (mode === "hide") return "text-slate-600";
+  if (mode === "only") return "text-indigo-600";
+  return "text-slate-300";
+}
+
+// Menu-entry state tints (the distinct-from-view-toggle treatment lives
+// on the trigger pill): slate for "hide" (rows removed), indigo for
+// "only" (rows isolated), neutral when inactive.
 function flagChipClass(key: string): string {
   const mode = flagFilterMode(key);
-  if (mode === "hide") return "bg-slate-600 text-white";
-  if (mode === "only") return "bg-indigo-600 text-white";
-  return "bg-white text-slate-500 border border-slate-200 hover:bg-slate-50";
+  if (mode === "hide") return "bg-slate-100 text-slate-700";
+  if (mode === "only") return "bg-indigo-50 text-indigo-700";
+  return "text-slate-500";
 }
+
+/** How many chips currently filter (badge on the menu trigger). */
+const activeFlagFilterCount = computed<number>(() => flagChips.value.filter((chip) => flagFilterMode(chip.key) !== undefined).length);
+
+// ── Filter dropdown open/close (same pattern as the "+" add-view menu) ──
+const filterMenuOpen = ref<boolean>(false);
+const filterMenuRef = ref<HTMLElement | null>(null);
+
+function closeFilterMenuOnOutsideClick(event: MouseEvent): void {
+  if (!filterMenuRef.value?.contains(event.target as Node)) filterMenuOpen.value = false;
+}
+
+watch(filterMenuOpen, (open) => {
+  if (open) document.addEventListener("mousedown", closeFilterMenuOnOutsideClick);
+  else document.removeEventListener("mousedown", closeFilterMenuOnOutsideClick);
+});
 
 function flagChipTitle(chip: FlagChip): string {
   const mode = flagFilterMode(chip.key);
@@ -2571,6 +2660,7 @@ watch(
       anchorOverride.value = null;
       kanbanOverride.value = null;
       addMenuOpen.value = false;
+      filterMenuOpen.value = false;
       // A sort belongs to a collection's own schema, so don't carry it across —
       // restore the new collection's stored (shared) sort instead. Same for
       // the flag filter chips.

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -2746,6 +2746,7 @@ onUnmounted(() => {
   clearLiveRefreshTimer();
   if (refreshNoteTimer !== undefined) clearTimeout(refreshNoteTimer);
   document.removeEventListener("mousedown", closeAddMenuOnOutsideClick);
+  document.removeEventListener("mousedown", closeFilterMenuOnOutsideClick);
 });
 
 // Embedded mode: report view/anchor changes so the chat card persists them

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -72,7 +72,7 @@ const deMessages: CollectionMessages = {
     searchSummary: "{shown} von {total} werden angezeigt",
     noMatchingItems: "Keine passenden Einträge",
     clearSearch: "Suche zurücksetzen",
-    flagFilterGroup: "Flag-Filter",
+    flagFilterButton: "Filter",
     flagFilterAll: "Nach {label} filtern",
     flagFilterHide: "{label} ausgeblendet",
     flagFilterOnly: "Nur {label}",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -69,7 +69,7 @@ const enMessages = {
     searchSummary: "Showing {shown} of {total}",
     noMatchingItems: "No matching items",
     clearSearch: "Clear search",
-    flagFilterGroup: "Flag filters",
+    flagFilterButton: "Filters",
     flagFilterAll: "Filter by {label}",
     flagFilterHide: "Hiding {label}",
     flagFilterOnly: "Only {label}",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -72,7 +72,7 @@ const esMessages: CollectionMessages = {
     searchSummary: "Mostrando {shown} de {total}",
     noMatchingItems: "No hay elementos coincidentes",
     clearSearch: "Borrar búsqueda",
-    flagFilterGroup: "Filtros por indicador",
+    flagFilterButton: "Filtros",
     flagFilterAll: "Filtrar por {label}",
     flagFilterHide: "Ocultando {label}",
     flagFilterOnly: "Solo {label}",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -73,7 +73,7 @@ const frMessages: CollectionMessages = {
     searchSummary: "Affichage de {shown} sur {total}",
     noMatchingItems: "Aucun élément correspondant",
     clearSearch: "Effacer la recherche",
-    flagFilterGroup: "Filtres par indicateur",
+    flagFilterButton: "Filtres",
     flagFilterAll: "Filtrer par {label}",
     flagFilterHide: "{label} masqué",
     flagFilterOnly: "Uniquement {label}",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -71,7 +71,7 @@ const jaMessages: CollectionMessages = {
     searchSummary: "{total} 件中 {shown} 件を表示",
     noMatchingItems: "一致する項目がありません",
     clearSearch: "検索をクリア",
-    flagFilterGroup: "フラグで絞り込み",
+    flagFilterButton: "絞り込み",
     flagFilterAll: "{label} で絞り込む",
     flagFilterHide: "{label} を非表示中",
     flagFilterOnly: "{label} のみ表示中",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -71,7 +71,7 @@ const koMessages: CollectionMessages = {
     searchSummary: "{total}개 중 {shown}개 표시",
     noMatchingItems: "일치하는 항목이 없습니다",
     clearSearch: "검색 지우기",
-    flagFilterGroup: "플래그 필터",
+    flagFilterButton: "필터",
     flagFilterAll: "{label}(으)로 필터",
     flagFilterHide: "{label} 숨김",
     flagFilterOnly: "{label}만 표시",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -72,7 +72,7 @@ const ptBRMessages: CollectionMessages = {
     searchSummary: "Mostrando {shown} de {total}",
     noMatchingItems: "Nenhum item correspondente",
     clearSearch: "Limpar busca",
-    flagFilterGroup: "Filtros por marcador",
+    flagFilterButton: "Filtros",
     flagFilterAll: "Filtrar por {label}",
     flagFilterHide: "Ocultando {label}",
     flagFilterOnly: "Somente {label}",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -70,7 +70,7 @@ const zhMessages: CollectionMessages = {
     searchSummary: "显示 {total} 条中的 {shown} 条",
     noMatchingItems: "没有匹配的项目",
     clearSearch: "清除搜索",
-    flagFilterGroup: "标记筛选",
+    flagFilterButton: "筛选",
     flagFilterAll: "按{label}筛选",
     flagFilterHide: "已隐藏{label}",
     flagFilterOnly: "仅显示{label}",


### PR DESCRIPTION
## Summary

Reworks the table view's flag filter chips (#2176 follow-up) into a general **filter menu**:

- **boolean and toggle fields get tri-state filter chips too** (all → hide → only) — they are predicates already, so wrapping them in a `flag` was pure ceremony. Enums stay out: they need a value picker, and kanban already slices by enum.
- **All chips collapse behind a single "Filters" dropdown trigger** (same pattern as the "+" add-view menu), so a chip-heavy schema can't flood the chrome row. The trigger is a dashed pill with a soft indigo tint + active-count badge when filtering — deliberately NOT the view-toggle recipe, so it never reads as another view.
- **Checkbox metaphor for chip states**: checked box = only the ON rows, unchecked box = only the OFF rows, faint grey unchecked box = not filtering.
- **Duplicate "Done" chip suppressed**: a legacy completion pair that an existing boolean/toggle chip expresses exactly (e.g. a "Done" toggle projecting `status` + `completionDoneValues: ["done"]`) no longer synthesizes a second done chip. Superset pairs (extra done values) still synthesize.
- i18n: `flagFilterGroup` → `flagFilterButton` ("Filters") across all 8 locales in lockstep.

Plugin-only change — `collection-skills.md` doesn't document the chip UI, so no `@mulmoclaude/core` bump.

## Test plan

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` green
- e2e (`collection-flag-filter.spec.ts`, all green): chip cycle through the dropdown, boolean + toggle chips (incl. toggle `onValue` vs flag semantics), localStorage persistence + active-count badge after reload, prototype-shadowing field name, legacy-pair synthesized chip, and duplicate-done suppression with the real-world todos schema shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Replaced always-visible filter chips with a collapsible **Filters** dropdown menu.
  - Added an active-filter count badge and clearer tri-state filter indicators.
  - Expanded filtering to support flag, boolean, and toggle-based predicates (including legacy completion behavior).
  - Filter selections persist, can be cleared from the menu, and the menu closes on outside click.

- **Bug Fixes**
  - Improved filter behavior when switching collections and when completion-related filters overlap (prevents duplicated “Done” filtering).

- **Localization**
  - Updated the **Filters** label across all supported languages.

- **Tests**
  - Updated and expanded end-to-end coverage for the dropdown-driven filter UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->