### PR TITLE
chore(google-calendar): reject an empty map, stay quiet when Google isn't linked (#2188)

### DIFF
--- a/packages/core/assets/helps/google-calendar-collection.md
+++ b/packages/core/assets/helps/google-calendar-collection.md
@@ -41,7 +41,9 @@ it isn't, sync silently does nothing until they link it in settings.
   other calendar, get its id from the `google` tool
   (`kind: "calendarListCalendars"`).
 - `map` — **your field name → the Google event field**. Pick whatever field
-  names suit the collection; the map absorbs the difference.
+  names suit the collection; the map absorbs the difference. Map at least one
+  field: an empty map syncs records that carry only the event id, so the user
+  would see rows with no content.
 
 Mappable event fields: `summary`, `start`, `end`, `htmlLink`, `colorId`,
 `status`.

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -560,7 +560,12 @@ export const GOOGLE_CALENDAR_SOURCE_FIELDS = ["summary", "start", "end", "htmlLi
 export const GoogleCalendarSyncZ = z.object({
   /** Calendar to pull from; defaults to the user's primary. */
   calendarId: z.string().trim().min(1).optional(),
-  map: z.record(z.string().trim().min(1), z.enum(GOOGLE_CALENDAR_SOURCE_FIELDS)),
+  // An empty map is silently useless rather than harmless: the sync would run
+  // and write a record per event carrying ONLY the event id, so the user gets
+  // rows with no content. Fail at load instead.
+  map: z.record(z.string().trim().min(1), z.enum(GOOGLE_CALENDAR_SOURCE_FIELDS)).refine((map) => Object.keys(map).length > 0, {
+    message: "map at least one field — a `googleCalendar` sync with an empty map writes records that carry only the event id",
+  }),
 });
 
 /** `ingest` is a discriminated union on `kind`: the three declarative

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -19,6 +19,7 @@ import type { GOOGLE_CALENDAR_SOURCE_FIELDS } from "../collection/core/schemaZ.j
 import { getGoogleAccessToken } from "./auth.js";
 import { canonicalCalendarId, syncCalendarEvents, type CalendarEventSummary } from "./calendar.js";
 import { clearCalendarSyncToken, loadCalendarSyncToken, saveCalendarSyncToken } from "./calendarSyncStore.js";
+import { loadGoogleTokens } from "./tokenStore.js";
 import { log } from "./host.js";
 
 export const GOOGLE_CALENDAR_SYNC_TASK_ID = "system:google-calendar-sync";
@@ -161,6 +162,12 @@ async function applyEventsToCollection(
   };
 }
 
+/** A refresh token is what lets the scheduler run unattended; without one
+ *  there is nothing to sync with. */
+async function isGoogleLinked(): Promise<boolean> {
+  return Boolean((await loadGoogleTokens())?.refresh_token);
+}
+
 /** Group the declaring collections by the calendar they read, so each calendar
  *  is fetched exactly once.
  *
@@ -184,6 +191,14 @@ export function groupByCalendar(collections: readonly LoadedCollection[]): Map<s
 export async function syncDueCalendarCollections(workspaceRoot: string): Promise<CalendarCollectionSyncResult[]> {
   const all = await discoverCollections({ workspaceRoot });
   const declaring = all.filter((collection) => collection.schema.googleCalendar);
+  if (declaring.length === 0) return [];
+  // Authoring the collection before linking the account is an expected state,
+  // not a failure. Checking once here keeps it a quiet skip instead of an
+  // access-token throw per calendar, every hour, until the user links (#2188).
+  if (!(await isGoogleLinked())) {
+    log.info("google", "skipping calendar sync — no Google account linked on this host", { collections: declaring.length });
+    return [];
+  }
   const results: CalendarCollectionSyncResult[] = [];
   for (const [calendarId, collections] of groupByCalendar(declaring)) {
     try {

--- a/test/workspace/collections/test_schema_google_calendar.ts
+++ b/test/workspace/collections/test_schema_google_calendar.ts
@@ -64,6 +64,17 @@ describe("collection schema — googleCalendar block (#2095)", () => {
     assert.equal(withSync({ calendarId: "   ", map: { title: "summary" } }).success, false);
   });
 
+  // An empty map is silently useless rather than harmless: the sync writes a
+  // record per event carrying only the event id, so the user sees empty rows
+  // and no error anywhere (#2188).
+  it("rejects an empty map", () => {
+    assert.equal(withSync({ map: {} }).success, false);
+  });
+
+  it("rejects a missing map outright", () => {
+    assert.equal(withSync({ calendarId: "primary" }).success, false);
+  });
+
   it("rejects the block on a read-only dataSource collection", () => {
     const parsed = CollectionSchemaZ.safeParse({
       title: "CSV backed",


### PR DESCRIPTION
## Summary

Closes #2188. Two papercuts I found while reviewing #2184. Neither is a correctness bug, but both fail in ways the user can't see.

**1. An empty `map` passed validation.** `z.record` accepts `{}`, so a collection could declare `"googleCalendar": { "map": {} }` and the sync would run happily — writing one record per event carrying **only the event id**. The user gets rows with no content, and nothing anywhere reports a problem. Now a load-time error, with the help doc stating the requirement.

**2. Log noise when Google isn't linked.** `syncDueCalendarCollections` called `getGoogleAccessToken()`, which throws when no account is linked, so the per-calendar catch emitted a warning for every declaring collection, every hour, until the user linked. Authoring the collection before linking is an expected state, not a failure — linkage is now checked once up front and the run is skipped quietly at `info`.

## Items to Confirm / Review

- **Quiet skip vs. visible signal.** I made the unlinked case an `info` log and an empty result. The alternative is surfacing it somewhere the user actually sees (the Automations UI shows the task). If you'd rather it stayed noisy, say so — I chose quiet because the user already gets a clear "not linked" answer from the `google` tool and settings.
- **Empty-map rejection is a breaking validation change** in principle: a schema that previously loaded now fails. In practice nothing can have shipped one, since the block itself only exists on unreleased core 0.25.0.

## Version

Both changes ship inside the **not-yet-published** core 0.25.0 (npm latest is 0.24.0), so no additional bump — verified with `npm view @mulmoclaude/core version`.

## User Prompt

(user: `isamu`) — after #2184 merged, asked to work through the remaining follow-ups in sequence; this is the first of them (the minor hardening I had flagged as non-blocking during that PR's review).

## Verification

`format` / `lint` / `typecheck` / `build` / `test` all green. Schema suite now 11 cases, including the two new rejections (empty map, missing map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Calendar synchronization now skips safely when no Google account is linked.
  * Invalid calendar configurations with missing or empty field mappings are rejected with a clear validation error.

* **Documentation**
  * Clarified Google Calendar mapping requirements, including the need for at least one mapped field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->