### PR TITLE
fix: resolve the remaining promise findings in packages/, ratchet the rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -530,9 +530,14 @@ export default [
       "@typescript-eslint/no-unsafe-declaration-merging": "warn",
       // (2) Bugs only the type checker can see.
       "@typescript-eslint/no-base-to-string": "warn",
-      "@typescript-eslint/no-floating-promises": "warn",
-      "@typescript-eslint/no-misused-promises": "warn",
-      "@typescript-eslint/await-thenable": "warn",
+      // Drained to zero and ratcheted to `error` per docs/lint-policy.md — a
+      // dropped `await` or an async callback handed to a sync-only API is a
+      // real bug, and the backlog for these three is empty, so there is nothing
+      // to grandfather. Re-introducing one now fails CI instead of joining a
+      // warning list nobody reads.
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/await-thenable": "error",
       // Same backlog treatment for the sonarjs rules this block wakes.
       ...sonarTypeAwareRulesAsWarn,
     },

--- a/packages/bridges/discord/src/index.ts
+++ b/packages/bridges/discord/src/index.ts
@@ -39,7 +39,11 @@ const discord = new Client({
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });
 
-mulmo.onPush(async (pushEvent) => {
+mulmo.onPush((pushEvent) => {
+  onPushEvent(pushEvent).catch((err) => console.error(`[discord] push handler error: ${err}`));
+});
+
+async function onPushEvent(pushEvent: { chatId: string; message: string }): Promise<void> {
   try {
     const channel = discord.channels.cache.get(pushEvent.chatId) ?? (await discord.channels.fetch(pushEvent.chatId).catch(() => null));
     if (channel?.isTextBased() && "send" in channel) {
@@ -51,9 +55,13 @@ mulmo.onPush(async (pushEvent) => {
   } catch (err) {
     console.error(`[discord] push send failed: ${err}`);
   }
+}
+
+discord.on("messageCreate", (msg: Message) => {
+  onMessageCreate(msg).catch((err) => console.error(`[discord] messageCreate handler error: ${err}`));
 });
 
-discord.on("messageCreate", async (msg: Message) => {
+async function onMessageCreate(msg: Message): Promise<void> {
   if (msg.author.bot) return;
   const { channelId } = msg;
   const text = msg.content.trim();
@@ -73,7 +81,7 @@ discord.on("messageCreate", async (msg: Message) => {
   } catch (err) {
     console.error(`[discord] message handling failed: ${err}`);
   }
-});
+}
 
 async function sendChunked(msg: Message, text: string): Promise<void> {
   if (text.length === 0) {

--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -99,37 +99,10 @@ function connectWebSocket(): void {
     );
   });
 
-  webSocket.on("message", async (data) => {
-    try {
-      const event: {
-        event?: string;
-        data?: { post?: string };
-      } = JSON.parse(data.toString());
-      if (event.event !== "posted" || !event.data?.post) return;
-
-      const post: {
-        user_id: string;
-        channel_id: string;
-        message: string;
-      } = JSON.parse(event.data.post);
-
-      // Ignore own messages
-      if (post.user_id === botUserId) return;
-      if (!post.message.trim()) return;
-      if (!allowAll && !allowedChannels.has(post.channel_id)) return;
-
-      console.log(`[mattermost] message channel=${post.channel_id} user=${post.user_id} len=${post.message.length}`);
-
-      const ack = await mulmo.send(post.channel_id, post.message);
-      if (ack.ok) {
-        await postMessage(post.channel_id, ack.reply ?? "");
-      } else {
-        const status = ack.status ? ` (${ack.status})` : "";
-        await postMessage(post.channel_id, `Error${status}: ${ack.error ?? "unknown"}`);
-      }
-    } catch (err) {
-      console.error(`[mattermost] message handling failed: ${err}`);
-    }
+  // Listener stays sync so a rejection has somewhere to go — an async listener
+  // hands its promise to the emitter, which drops it.
+  webSocket.on("message", (data) => {
+    onWebSocketMessage(data).catch((err) => console.error(`[mattermost] message handler error: ${err}`));
   });
 
   webSocket.on("close", () => {
@@ -140,6 +113,39 @@ function connectWebSocket(): void {
   webSocket.on("error", (err) => {
     console.error(`[mattermost] WebSocket error: ${err.message}`);
   });
+}
+
+async function onWebSocketMessage(data: { toString: () => string }): Promise<void> {
+  try {
+    const event: {
+      event?: string;
+      data?: { post?: string };
+    } = JSON.parse(data.toString());
+    if (event.event !== "posted" || !event.data?.post) return;
+
+    const post: {
+      user_id: string;
+      channel_id: string;
+      message: string;
+    } = JSON.parse(event.data.post);
+
+    // Ignore own messages
+    if (post.user_id === botUserId) return;
+    if (!post.message.trim()) return;
+    if (!allowAll && !allowedChannels.has(post.channel_id)) return;
+
+    console.log(`[mattermost] message channel=${post.channel_id} user=${post.user_id} len=${post.message.length}`);
+
+    const ack = await mulmo.send(post.channel_id, post.message);
+    if (ack.ok) {
+      await postMessage(post.channel_id, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await postMessage(post.channel_id, `Error${status}: ${ack.error ?? "unknown"}`);
+    }
+  } catch (err) {
+    console.error(`[mattermost] message handling failed: ${err}`);
+  }
 }
 
 async function main(): Promise<void> {

--- a/packages/bridges/nostr/src/index.ts
+++ b/packages/bridges/nostr/src/index.ts
@@ -107,7 +107,7 @@ async function sendDm(recipientPubkey: string, text: string): Promise<void> {
   const chunks = chunkText(text, MAX_DM_LEN);
   for (const chunk of chunks) {
     try {
-      const ciphertext = await nip04.encrypt(privateKeyBytes, recipientPubkey, chunk);
+      const ciphertext = nip04.encrypt(privateKeyBytes, recipientPubkey, chunk);
       const signed = finalizeEvent(
         {
           kind: KIND_ENCRYPTED_DM,
@@ -163,7 +163,7 @@ async function handleEvent(evt: Event): Promise<void> {
 
   let plaintext: string;
   try {
-    plaintext = await nip04.decrypt(privateKeyBytes, evt.pubkey, evt.content);
+    plaintext = nip04.decrypt(privateKeyBytes, evt.pubkey, evt.content);
   } catch (err) {
     console.warn(`[nostr] decrypt failed from=${senderPubkey.slice(0, 12)}…: ${err}`);
     return;

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -83,7 +83,31 @@ client.onPush((pushEvent) => {
     .catch((err) => console.error(`[slack] push send failed: ${err}`));
 });
 
-socketMode.on("message", async ({ event, ack }) => {
+/** The slice of Socket Mode's `message` envelope this bridge reads. Spelled out
+ *  because extracting the handler out of the `.on(…)` call loses the inferred
+ *  parameter type. `thread_ts` / `channel_type` are consumed by
+ *  `effectiveThreadTs`, which takes them as `unknown`. */
+interface SlackMessageEnvelope {
+  event: {
+    subtype?: unknown;
+    bot_id?: unknown;
+    user?: string;
+    channel: string;
+    text?: string;
+    ts?: unknown;
+    thread_ts?: unknown;
+    channel_type?: unknown;
+  };
+  ack: () => Promise<void>;
+}
+
+// Listener stays sync so a rejection has somewhere to go — an async listener
+// hands its promise to the emitter, which drops it.
+socketMode.on("message", (envelope: SlackMessageEnvelope) => {
+  onSocketMessage(envelope).catch((err) => console.error(`[slack] message handler error: ${err}`));
+});
+
+async function onSocketMessage({ event, ack }: SlackMessageEnvelope): Promise<void> {
   await ack();
 
   // Ignore bot's own messages, message_changed, etc.
@@ -112,7 +136,7 @@ socketMode.on("message", async ({ event, ack }) => {
   } catch (err) {
     console.error(`[slack] message handling failed: ${err}`);
   }
-});
+}
 
 // Fire-and-forget "seen" reaction. Deliberately not awaited so the
 // agent processing starts immediately; errors (missing_scope,

--- a/packages/bridges/xmpp/src/index.ts
+++ b/packages/bridges/xmpp/src/index.ts
@@ -129,10 +129,12 @@ xmpp.on("offline", () => {
   console.warn("[xmpp] offline");
 });
 
-xmpp.on("online", async (address: { toString: () => string }) => {
+xmpp.on("online", (address: { toString: () => string }) => {
   console.log(`[xmpp] online as ${address.toString()}`);
-  // Presence broadcast so contacts can see the bot is available.
-  await xmpp.send(xml("presence"));
+  // Presence broadcast so contacts can see the bot is available. Same shape as
+  // the "stanza" handler below: the listener stays sync so the send's rejection
+  // has somewhere to go instead of escaping the emitter.
+  xmpp.send(xml("presence")).catch((err) => console.error(`[xmpp] presence broadcast failed: ${err}`));
 });
 
 xmpp.on("stanza", (stanza: XmlElement) => {

--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -142,7 +142,13 @@ export const startHostRunner = (firestore: Firestore, channel: Channel, handlers
   const presence = hostDoc(firestore, channel);
   // Advertise online/offline + the capability set (method names + protocol
   // version) on the same doc the remote already listens to for presence.
-  const writePresence = (online: boolean) => setDoc(presence, { ...buildHostPresence(channel, handlers, online), updatedAt: serverTimestamp() }).catch(noop);
+  // Returns void, not the promise: presence is advertised best-effort from
+  // three call sites (announce, the snapshot-error path, the teardown), none of
+  // which can await. Terminating the chain here with `.catch(noop)` keeps every
+  // caller from floating a promise it has no way to handle.
+  const writePresence = (online: boolean): void => {
+    setDoc(presence, { ...buildHostPresence(channel, handlers, online), updatedAt: serverTimestamp() }).catch(noop);
+  };
   const announce = () => {
     writePresence(true);
   };

--- a/packages/core/src/scheduler/task-manager.ts
+++ b/packages/core/src/scheduler/task-manager.ts
@@ -269,7 +269,13 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
 
     start() {
       if (timer) return;
-      timer = setInterval(onTick, tickMs);
+      // `onTick` guards re-entry but not failure — it has a `finally`, no
+      // `catch` — so handing it straight to setInterval let a rejected tick
+      // escape as an unhandled rejection, which the host turns into a process
+      // exit. The scheduler must outlive one bad tick.
+      timer = setInterval(() => {
+        onTick().catch((err: unknown) => log.error("tick failed", { error: String(err) }));
+      }, tickMs);
       log.info("started", { tickMs });
     },
 

--- a/packages/core/test/scheduler/test_scheduler.ts
+++ b/packages/core/test/scheduler/test_scheduler.ts
@@ -362,3 +362,31 @@ test("recordExternalRun records a failed dispatch as an error run", async () => 
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// `makeGuardedTick` has a `finally` but no `catch`, so a tick that rejects
+// propagates. Awaiting `tick()` hands that to the caller, which is fine — but
+// `start()` drives the same function from `setInterval`, where a rejection has
+// nowhere to go and the host turns it into a process exit. One bad tick used to
+// be able to take the server down; this pins that it no longer can, and that
+// the interval keeps firing afterwards.
+test("start(): a rejected tick is logged and later ticks keep running", async () => {
+  const errors: string[] = [];
+  let nowCalls = 0;
+  const manager = createTaskManager({
+    tickMs: 5,
+    log: { info: () => {}, warn: () => {}, error: (message) => errors.push(message) },
+    // `runTick` calls `now()` first thing, so throwing here rejects the tick
+    // itself rather than an individual task (those are caught per-task).
+    now: () => {
+      nowCalls += 1;
+      throw new Error("clock exploded");
+    },
+  });
+
+  manager.start();
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  manager.stop();
+
+  assert.ok(nowCalls >= 2, `interval stopped after the first rejection (${nowCalls} tick(s))`);
+  assert.ok(errors.includes("tick failed"), `expected a "tick failed" log, got ${JSON.stringify(errors)}`);
+});


### PR DESCRIPTION
## Summary

Second and final slice of the async backlog opened by #2183 — the **11** findings in `packages/` — plus the ratchet that closes it. `no-floating-promises`, `no-misused-promises` and `await-thenable` graduate from `warn` to **`error`**: the count is now **0 repo-wide**, so there is nothing to grandfather and per [`docs/lint-policy.md`](../blob/main/docs/lint-policy.md) they should gate rather than sit on a list nobody drains.

Together with #2185, all 24 findings of this class are gone.

## One real bug — the scheduler could take the server down

`makeGuardedTick` wraps its work in `try`/`finally` with **no `catch`**:

```js
return async () => {
  if (ticking) return;
  ticking = true;
  try { await runTick(now, registry, cfg); } finally { ticking = false; }
};
```

Through `tick()` that's fine — the caller awaits and the rejection propagates to an explicit API boundary. But `setInterval(onTick, tickMs)` had nowhere for it to go, and the host turns an unhandled rejection into `process.exit(1)`. **A single failing scheduled task could bounce the whole server.** The interval now logs and keeps scheduling — a scheduler should outlive one bad tick.

## The rest were structural

- **`hostRunner`** — `writePresence` returned the promise it had *already* terminated with `.catch(noop)`, so all three call sites floated it. Returning `void` fixes three findings in one place.
- **`discord` / `mattermost` / `slack` / `xmpp`** — async listeners handed to `.on(…)`, whose return value the emitter drops. Each is now a sync listener delegating to a named async function with a `.catch`. That's not an invention: xmpp's own `"stanza"` handler already had exactly this shape, so the bridges are now internally consistent.
- **`nostr`** — two `await`s on `nip04.encrypt` / `decrypt`, which nostr-tools 2.23.12 types as returning `string`, not `Promise<string>`.

## Items to Confirm / Review

- **The `nostr` `await` removals** are the ones I'd look at hardest. I checked the installed types (`export declare function encrypt(…): string`) rather than assuming, and awaiting a non-promise only costs a microtask — but if anyone knows a runtime where that call is genuinely async, say so.
- **The scheduler now swallows a tick failure** instead of exiting. Same trade as #2185's `BEHAVIOUR NOTE`s: better availability, but a supervisor no longer restarts out of a persistently broken tick. The failure is logged at `error`.
- **`connectWebSocket` refactor** — hoisting mattermost's handler pushed it to 53 lines, over the 50 budget. Everything it closes over is module-scope, so the handler moved out too. Bigger diff than the other bridges, but `connectWebSocket` is now just connect + wire.
- **The ratchet is the point of the PR.** If anyone expects to add a deliberate fire-and-forget later, it now needs a real terminal handler rather than a bare `void` — which is the lesson #2185's review landed on.

## Verification

`format` / `typecheck` / `lint` / `test` / `build` all clean. The three rules report **0 across `src`, `server`, `test`, `e2e`, `e2e-live`, `packages`** at `error` severity.

Remaining type-aware backlog after this: 305 warnings (`no-base-to-string` 74, `no-unsafe-*` 161, sonarjs 79) — next batches.

## User Prompt

> mergeしたらいま出たwarnをなおしていける？ / はい。順次１課題ずつPR / どんどん進めて。できれば並列で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across Discord, Mattermost, Slack, XMPP, and scheduled tasks by ensuring asynchronous errors are captured and logged instead of being silently dropped.
  * Prevented rejected background operations from escaping event handlers or interrupting host processes.
  * Preserved existing message processing, filtering, routing, and response behavior.

* **Chores**
  * Strengthened linting checks so promise-handling violations now fail CI rather than generating warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->