### PR TITLE
feat: desktop view image endpoint + storage-virtualization follow-through

### DIFF
--- a/packages/core/assets/helps/collection-skills.md
+++ b/packages/core/assets/helps/collection-skills.md
@@ -228,6 +228,9 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
   collection). No extra keys. Great for photos like a business card: read the
   details off the attached image and write its path into the image field.
   Write the bare workspace-relative path — never an `/api/files/raw?...` URL.
+  A **custom view** renders these via `GET <dataUrl>/image` (see
+  `config/helps/custom-view.md` "Displaying images"; remote views declare
+  `imageFields` instead) — never by base64-embedding them into the view HTML.
 - **`file`** — stores a **workspace-relative file path** as a plain string (e.g.
   `artifacts/html/the-solar-system-1777158558023.html`). Rendered as a
   **clickable link** in both the list table and the detail view (unlike `image`,
@@ -1054,17 +1057,21 @@ expected to grow far beyond what a folder of JSON files handles comfortably
 (thousands of records). For everything else prefer `dataPath` — record files
 are transparent, diffable, and every feature supports them.
 
-v1 limits (schema-enforced or documented):
+Notes:
 
 - Requires **Node.js >= 22.5** (built-in `node:sqlite`); on an older runtime
   only sqlite collections fail, with a clear error (see
   `config/helps/error-recovery.md`).
-- Cannot declare `spawn`, `completionField`, or `triggerField` (those paths
-  still read record files — the schema validator rejects the combination).
-- The record Repair pass doesn't see sqlite records, and deleting the
-  collection leaves the `.db` file in place (remove it manually if asked).
-- Editing the `.db` file externally does not trigger live view refreshes
-  (writes through the host do).
+- The full write machinery works: `spawn`, `completionField` /
+  `triggerField` bells, `singleton`, `ingest`, and mutate actions all go
+  through the storage layer, and a watcher on the db file drives bell
+  reconciliation + live view refreshes — including after EXTERNAL edits to
+  the `.db`.
+- The Repair pass validates records through the storage backend (schema
+  violations are reported by record id); a row so corrupt the backend
+  can't parse it is skipped silently, unlike a malformed record FILE.
+- Deleting the collection archives the `.db` alongside the skill under
+  `archive/…` and removes the live file.
 
 Minimal example:
 

--- a/packages/core/assets/helps/custom-view.md
+++ b/packages/core/assets/helps/custom-view.md
@@ -189,6 +189,40 @@ if (res.ok) {
 - A 409 means the record's current state fails the action's `require` — treat
   it as "button disabled", not an error to retry.
 
+### Displaying images — `GET <dataUrl>/image`
+
+An `image`-type field stores a **workspace path** (`data/attachments/…`,
+`data/<name>/logos/…`) that a sandboxed view cannot load directly — the
+iframe has an opaque origin and `<img>` can't attach the bearer token. To
+render one, ask the host to resolve it into a downscaled thumbnail:
+
+```js
+// Request the image field in your projection so you have its path,
+// then resolve each path into a data: URL and assign it to the <img>.
+const res = await fetch(dataUrl + "/image?path=" + encodeURIComponent(item.photo) + "&maxEdge=256", {
+  headers: { Authorization: "Bearer " + token },
+});
+if (res.ok) {
+  const { dataUrl: src } = await res.json();
+  img.src = src; // "data:image/jpeg;base64,…"
+} // non-ok: leave the placeholder — 404 = not an image-field value / unresolvable
+```
+
+- **Only current image-field values resolve.** The host checks `path`
+  against the collection's records: it must be the CURRENT value of a
+  schema `image`-type field — the token cannot read arbitrary workspace
+  files. A stale or hand-built path answers 404.
+- `maxEdge` clamps to 64–1024 (default 512) — request the size you render.
+- Cache the resolved `data:` URLs per path in your view (a simple `Map`)
+  and re-resolve inside your `onChange` callback only for paths you haven't
+  seen — each request re-scans the records server-side.
+- A record field holding a public **`https:` URL needs none of this** —
+  `<img src>` may load any https host directly (see the sandbox rules).
+- **Do NOT base64-embed images into the view HTML itself.** It bloats the
+  file, goes stale the moment a record's image changes, and needs manual
+  regeneration — this endpoint (or an https URL field) is always the
+  better answer.
+
 ### Staying live — `onChange`
 
 By default a view paints once, on load. To keep it fresh, register a callback —

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -237,11 +237,11 @@ Diagnosis + fixes, in order:
    `<id>.json` files; a schema flip alone would make the collection look
    empty, not migrate it.
 
-Known v1 limits of sqlite storage (by design, not bugs to fix in place):
-`spawn`, `completionField`, and `triggerField` are schema-rejected (those
-paths still read record files), the record Repair/validation pass sees no
-records (it scans record files), and deleting the collection archives the
-skill + phantom data dir but leaves the `.db` file in place.
+Known limits of sqlite storage (by design, not bugs to fix in place):
+a db row so corrupt the backend can't parse it is skipped silently (the
+Repair pass reports schema violations by record id, but has no
+"malformed file" classification), and the completion/spawn watcher
+reconciles the WHOLE collection per db change (no per-record events).
 
 ## Fallback
 

--- a/packages/core/src/collection-watchers/index.ts
+++ b/packages/core/src/collection-watchers/index.ts
@@ -27,5 +27,6 @@ export {
   _syncWatchersForTesting,
   _tickTimeTriggersForTesting,
   _scheduleItemReconcileForTesting,
+  _scheduleStorageReconcileForTesting,
   type CollectionWatcherOptions,
 } from "./watcher.js";

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -23,7 +23,15 @@
 
 import { clear as notifierClear, listAll, publish as notifierPublish, updateForPlugin as notifierUpdate, type NotifierEntry } from "../notifier";
 import { itemIsDone, whenMatches, type CollectionItem, type CollectionSchema } from "../collection";
-import { type DiscoveryOptions, listItems, readItem, type IoOptions, isTriggerDue, maybeSpawnSuccessor, loadCollection } from "../collection/server";
+import {
+  type DiscoveryOptions,
+  type IoOptions,
+  isTriggerDue,
+  maybeSpawnSuccessor,
+  loadCollection,
+  storeFor,
+  type LoadedCollection,
+} from "../collection/server";
 import { type CompletionPriority, errMsg, log, requireAdapter } from "./config.js";
 import { evalNow } from "./clock.js";
 
@@ -203,27 +211,22 @@ export async function clearItemNotification(slug: string, itemId: string): Promi
   }
 }
 
-/** Reconcile one item to the desired bell state. Re-reads the record from
- *  disk so the decision is grounded in current truth, not in the event
- *  payload. Safe to call when the file is missing (delete path).
+/** Reconcile one item to the desired bell state. Re-reads the record
+ *  through the collection's STORE (file, sqlite, …) so the decision is
+ *  grounded in current truth, not in the event payload. Safe to call when
+ *  the record is missing (delete path).
  *
- *  `ioOpts` flows into `readItem`'s workspace-containment check —
+ *  `ioOpts` flows into the store's workspace-containment checks —
  *  production callers (the watcher) pass nothing; tests pass
  *  `{ workspaceRoot: <tmpdir> }` so the check accepts a fixture dataDir. */
-export async function reconcileItem(
-  slug: string,
-  schema: CollectionSchema,
-  dataDir: string,
-  itemId: string,
-  ioOpts: IoOptions = {},
-  now: Date = evalNow(),
-): Promise<void> {
+export async function reconcileItem(collection: LoadedCollection, itemId: string, ioOpts: IoOptions = {}, now: Date = evalNow()): Promise<void> {
+  const { slug, schema } = collection;
   if (!schema.completionField) {
     // Schema doesn't track completion — drop any stale entry.
     await clearItemNotification(slug, itemId);
     return;
   }
-  const item = await readItem(dataDir, itemId, ioOpts);
+  const item = await storeFor(collection, ioOpts).read(itemId);
   if (item === null) {
     await clearItemNotification(slug, itemId);
     return;
@@ -231,7 +234,7 @@ export async function reconcileItem(
   // Recurrence: predicate-gated + create-if-absent, idempotent and
   // independent of this item's own bell state. Runs before the done-clear
   // below so marking an item done still spawns its successor.
-  await maybeSpawnSuccessor(slug, schema, dataDir, item, itemId, ioOpts);
+  await maybeSpawnSuccessor(collection, item, itemId, ioOpts);
   if (itemIsDone(schema, item)) {
     await clearItemNotification(slug, itemId);
     return;
@@ -263,24 +266,26 @@ export async function reconcileItem(
   await ensureItemNotification(slug, schema, itemId, resolveDisplayLabel(schema, item, itemId), notifyPriorityForItem(schema, item));
 }
 
-/** Boot-time reconcile: walk every record under `dataDir` once and
- *  reconcile it. Catches up changes that happened while the server was
- *  down. Deleted items are covered by `sweepStaleActiveEntries`, not this
- *  function (it only sees files that exist). */
-export async function reconcileAllItems(slug: string, schema: CollectionSchema, dataDir: string, ioOpts: IoOptions = {}, now: Date = evalNow()): Promise<void> {
+/** Boot-time reconcile: walk every record of the collection once (through
+ *  its store) and reconcile it. Catches up changes that happened while the
+ *  server was down. Deleted items are covered by
+ *  `sweepStaleActiveEntries`, not this function (it only sees records
+ *  that exist). */
+export async function reconcileAllItems(collection: LoadedCollection, ioOpts: IoOptions = {}, now: Date = evalNow()): Promise<void> {
+  const { slug, schema } = collection;
   if (!schema.completionField) return;
   let items: CollectionItem[];
   try {
-    items = await listItems(dataDir, ioOpts);
+    items = await storeFor(collection, ioOpts).list();
   } catch (err) {
-    log().warn("reconcile list failed", { slug, dataDir, error: errMsg(err) });
+    log().warn("reconcile list failed", { slug, error: errMsg(err) });
     return;
   }
   const { primaryKey } = schema;
   for (const item of items) {
     const raw = item[primaryKey];
     if (typeof raw !== "string" || raw.length === 0) continue;
-    await reconcileItem(slug, schema, dataDir, raw, ioOpts, now);
+    await reconcileItem(collection, raw, ioOpts, now);
   }
 }
 
@@ -309,7 +314,7 @@ export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Prom
         await notifierClear(entry.id);
         continue;
       }
-      const item = await readItem(collection.dataDir, itemId, opts);
+      const item = await storeFor(collection, opts).read(itemId);
       if (item === null || itemIsDone(collection.schema, item) || !whenMatches(collection.schema.notifyWhen, item)) {
         await notifierClear(entry.id);
       }

--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -380,30 +380,16 @@ async function startStorageWatcher(collection: LoadedCollection): Promise<void> 
 }
 
 function scheduleStorageReconcile(slug: string): Promise<void> {
-  const existing = storageSlots.get(slug);
-  if (existing) {
-    existing.pending = true;
-    return existing.running;
-  }
-  const slot: ReconcileSlot = { running: Promise.resolve(), pending: false };
-  slot.running = (async () => {
-    try {
-      let keepGoing = true;
-      while (keepGoing) {
-        slot.pending = false;
-        const collection = await loadCollection(slug, discoveryOpts);
-        if (collection) {
-          await reconcileAllItems(collection, discoveryOpts);
-          publishCollectionChange({ slug, op: "upsert" });
-        }
-        keepGoing = slot.pending;
-      }
-    } finally {
-      storageSlots.delete(slug);
-    }
-  })();
-  storageSlots.set(slug, slot);
-  return slot.running;
+  return runSingleFlight(storageSlots, slug, async () => {
+    const collection = await loadCollection(slug, discoveryOpts);
+    if (!collection) return;
+    await reconcileAllItems(collection, discoveryOpts);
+    // One db file holds every record, so a DELETED row leaves no per-item
+    // event — sweep the active bell so its entry converges like a
+    // file-backed delete does (same pairing as the unknown-filename path).
+    await sweepStaleActiveEntries(discoveryOpts);
+    publishCollectionChange({ slug, op: "upsert" });
+  });
 }
 
 /** Test-only: drive one storage-collection reconcile pass directly. */
@@ -453,8 +439,17 @@ export function _scheduleItemReconcileForTesting(collection: LoadedCollection, i
 }
 
 function scheduleItemReconcile(collection: LoadedCollection, itemId: string): Promise<void> {
-  const key = `${collection.slug}\x00${itemId}`;
-  const existing = itemSlots.get(key);
+  return runSingleFlight(itemSlots, `${collection.slug}\x00${itemId}`, () => reconcileItem(collection, itemId, discoveryOpts));
+}
+
+/** The shared single-flight loop behind both schedulers. Re-runs `pass`
+ *  while events keep arriving — the trailing re-run captures any state
+ *  change that landed during a prior pass. After each pass we read
+ *  `pending` and zero it before the next iteration, so an event that
+ *  fires *during* the last pass's await still triggers one more pass
+ *  before the slot is freed. */
+function runSingleFlight(slots: Map<string, ReconcileSlot>, key: string, pass: () => Promise<void>): Promise<void> {
+  const existing = slots.get(key);
   if (existing) {
     existing.pending = true;
     return existing.running;
@@ -462,22 +457,17 @@ function scheduleItemReconcile(collection: LoadedCollection, itemId: string): Pr
   const slot: ReconcileSlot = { running: Promise.resolve(), pending: false };
   slot.running = (async () => {
     try {
-      // Re-run while events keep arriving — the trailing re-run captures
-      // any state change that landed during a prior pass. After each pass
-      // we read `pending` and zero it before the next iteration, so an
-      // event that fires *during* the last reconcile's await still
-      // triggers one more pass before the slot is freed.
       let keepGoing = true;
       while (keepGoing) {
         slot.pending = false;
-        await reconcileItem(collection, itemId, discoveryOpts);
+        await pass();
         keepGoing = slot.pending;
       }
     } finally {
-      itemSlots.delete(key);
+      slots.delete(key);
     }
   })();
-  itemSlots.set(key, slot);
+  slots.set(key, slot);
   return slot.running;
 }
 

--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -49,6 +49,10 @@ interface CollectionWatcher {
    *  flipping `completionField` on or off) that don't touch any record
    *  file and would otherwise leave bell state stale indefinitely. */
   schemaJson: string;
+  /** The discovered collection this watcher was mounted for — what the
+   *  reconciler needs to pick the right STORE (file records vs a sqlite
+   *  `storage` db). Refreshed whenever `schemaJson` is. */
+  collection: LoadedCollection;
 }
 
 const watchers = new Map<string, CollectionWatcher>();
@@ -69,6 +73,11 @@ interface ReconcileSlot {
   pending: boolean;
 }
 const itemSlots = new Map<string, ReconcileSlot>();
+
+/** Per-slug single-flight for a storage (db-file) collection's full
+ *  reconcile pass — a burst of db writes collapses to one pass + one
+ *  trailing re-run, mirroring the per-item slots of the file watcher. */
+const storageSlots = new Map<string, ReconcileSlot>();
 
 /** Trailing debounce per dataSource collection: an atomic file replace
  *  (Excel save, editor rename) surfaces as 2-3 fs events — collapse them
@@ -149,6 +158,7 @@ export async function stopCollectionWatchers(): Promise<void> {
   }
   watchers.clear();
   itemSlots.clear();
+  storageSlots.clear();
   for (const timer of dataSourceTimers.values()) clearTimeout(timer);
   dataSourceTimers.clear();
   discoveryOpts = {};
@@ -180,11 +190,11 @@ async function tickTimeTriggers(now: Date = evalNow()): Promise<void> {
       log().warn("trigger tick: bad cached schema", { slug: entry.slug, error: errMsg(err) });
       continue;
     }
-    // dataSource collections have no reconcilable record files (and zod
+    // dataSource collections have no reconcilable records (and zod
     // forbids `spawn` on them) — the clock never changes their state.
     if (schema.dataSource !== undefined) continue;
     if (!schema.triggerField && !schema.spawn) continue;
-    await reconcileAllItems(entry.slug, schema, entry.dataDir, discoveryOpts, now);
+    await reconcileAllItems(entry.collection, discoveryOpts, now);
   }
 }
 
@@ -240,7 +250,7 @@ function storagePathChanged(previousJson: string, next: LoadedCollection["schema
   } catch {
     return true; // unreadable cache — remount to be safe
   }
-  return previous.dataSource?.path !== next.dataSource?.path || previous.dataPath !== next.dataPath;
+  return previous.dataSource?.path !== next.dataSource?.path || previous.dataPath !== next.dataPath || previous.storage?.path !== next.storage?.path;
 }
 
 /** Re-reconcile already-watched collections whose schema changed since
@@ -269,6 +279,7 @@ async function reconcileChangedSchemas(collections: readonly LoadedCollection[])
       continue;
     }
     existing.schemaJson = nextJson;
+    existing.collection = collection;
     if (collection.schema.dataSource !== undefined) {
       // No record files to reconcile — but a schema edit can change what
       // the views render (fields, displayField, …), so ping them.
@@ -278,7 +289,7 @@ async function reconcileChangedSchemas(collections: readonly LoadedCollection[])
       continue;
     }
     log().info("watcher schema changed, re-reconciling", { slug: collection.slug });
-    await reconcileAllItems(collection.slug, collection.schema, collection.dataDir, discoveryOpts);
+    await reconcileAllItems(collection, discoveryOpts);
     mutated = true;
   }
   return mutated;
@@ -289,7 +300,8 @@ async function startNewWatchers(collections: readonly LoadedCollection[]): Promi
   for (const collection of collections) {
     if (watchers.has(collection.slug)) continue;
     if (collection.schema.dataSource !== undefined) await startDataSourceWatcher(collection);
-    else await startWatcherFor(collection.slug, collection.schema, collection.dataDir);
+    else if (collection.schema.storage !== undefined) await startStorageWatcher(collection);
+    else await startWatcherFor(collection);
     mutated = true;
   }
   return mutated;
@@ -327,14 +339,80 @@ async function startDataSourceWatcher(collection: LoadedCollection): Promise<voi
     watcher.on("error", (err) => {
       log().warn("dataSource watcher error", { slug: collection.slug, error: errMsg(err) });
     });
-    watchers.set(collection.slug, { slug: collection.slug, dataDir: dir, watcher, schemaJson: JSON.stringify(collection.schema) });
+    watchers.set(collection.slug, { slug: collection.slug, dataDir: dir, watcher, schemaJson: JSON.stringify(collection.schema), collection });
     log().info("dataSource watcher started", { slug: collection.slug, file });
   } catch (err) {
     log().warn("dataSource watcher start failed", { slug: collection.slug, error: errMsg(err) });
   }
 }
 
-async function startWatcherFor(slug: string, schema: CollectionSchema, dataDir: string): Promise<void> {
+/** Watch a `storage` collection's database file. One db file holds every
+ *  record, so an event can't name WHICH record changed — each (debounced)
+ *  event runs a full `reconcileAllItems` pass (bells / spawn) plus a
+ *  change publish so views refetch after EXTERNAL edits too (host writes
+ *  already publish their own change events; the extra ping is debounced
+ *  and idempotent). Mounts on the parent dir, same as the dataSource
+ *  watcher, so an atomic replace can't strand the watch. */
+async function startStorageWatcher(collection: LoadedCollection): Promise<void> {
+  const file = collection.storageFile;
+  if (file === undefined) return;
+  const dir = path.dirname(file);
+  const base = path.basename(file);
+  try {
+    await mkdir(dir, { recursive: true });
+    await reconcileAllItems(collection, discoveryOpts);
+    const watcher = watch(dir, { persistent: false }, (_eventType, filename) => {
+      // Null filename (platform quirk) counts as a hit; otherwise accept
+      // the db itself plus its sqlite sidecars (`<db>-wal`, `<db>-journal`).
+      if (filename !== null && !filename.startsWith(base)) return;
+      scheduleStorageReconcile(collection.slug).catch((err: unknown) => {
+        log().warn("storage watcher reconcile failed", { slug: collection.slug, error: errMsg(err) });
+      });
+    });
+    watcher.on("error", (err) => {
+      log().warn("storage watcher error", { slug: collection.slug, error: errMsg(err) });
+    });
+    watchers.set(collection.slug, { slug: collection.slug, dataDir: dir, watcher, schemaJson: JSON.stringify(collection.schema), collection });
+    log().info("storage watcher started", { slug: collection.slug, file });
+  } catch (err) {
+    log().warn("storage watcher start failed", { slug: collection.slug, error: errMsg(err) });
+  }
+}
+
+function scheduleStorageReconcile(slug: string): Promise<void> {
+  const existing = storageSlots.get(slug);
+  if (existing) {
+    existing.pending = true;
+    return existing.running;
+  }
+  const slot: ReconcileSlot = { running: Promise.resolve(), pending: false };
+  slot.running = (async () => {
+    try {
+      let keepGoing = true;
+      while (keepGoing) {
+        slot.pending = false;
+        const collection = await loadCollection(slug, discoveryOpts);
+        if (collection) {
+          await reconcileAllItems(collection, discoveryOpts);
+          publishCollectionChange({ slug, op: "upsert" });
+        }
+        keepGoing = slot.pending;
+      }
+    } finally {
+      storageSlots.delete(slug);
+    }
+  })();
+  storageSlots.set(slug, slot);
+  return slot.running;
+}
+
+/** Test-only: drive one storage-collection reconcile pass directly. */
+export function _scheduleStorageReconcileForTesting(slug: string): Promise<void> {
+  return scheduleStorageReconcile(slug);
+}
+
+async function startWatcherFor(collection: LoadedCollection): Promise<void> {
+  const { slug, schema, dataDir } = collection;
   try {
     // `fs.watch` throws on a missing dir, so ensure it exists. New
     // collections legitimately start with no records — mkdir is the
@@ -343,7 +421,7 @@ async function startWatcherFor(slug: string, schema: CollectionSchema, dataDir: 
     // Boot reconcile this collection's existing items BEFORE mounting the
     // watcher: a pending item the user added during downtime needs its
     // bell entry even if no event fires today.
-    await reconcileAllItems(slug, schema, dataDir, discoveryOpts);
+    await reconcileAllItems(collection, discoveryOpts);
     const watcher = watch(dataDir, { persistent: false }, (_eventType, filename) => {
       // Errors from inside the callback would propagate as unhandled
       // rejections — wrap so a single bad event can't unwind the watcher.
@@ -354,7 +432,7 @@ async function startWatcherFor(slug: string, schema: CollectionSchema, dataDir: 
     watcher.on("error", (err) => {
       log().warn("watcher error", { slug, error: errMsg(err) });
     });
-    watchers.set(slug, { slug, dataDir, watcher, schemaJson: JSON.stringify(schema) });
+    watchers.set(slug, { slug, dataDir, watcher, schemaJson: JSON.stringify(schema), collection });
     log().info("watcher started", { slug, dataDir });
   } catch (err) {
     log().warn("watcher start failed", { slug, error: errMsg(err) });
@@ -370,12 +448,12 @@ async function startWatcherFor(slug: string, schema: CollectionSchema, dataDir: 
  *  and return — the running reconcile re-runs once after it completes.
  *  This collapses fs.watch's rapid-fire bursts (atomic rename surfaces as
  *  2-3 events) into a single reconcile + one trailing re-run. */
-export function _scheduleItemReconcileForTesting(slug: string, schema: CollectionSchema, dataDir: string, itemId: string): Promise<void> {
-  return scheduleItemReconcile(slug, schema, dataDir, itemId);
+export function _scheduleItemReconcileForTesting(collection: LoadedCollection, itemId: string): Promise<void> {
+  return scheduleItemReconcile(collection, itemId);
 }
 
-function scheduleItemReconcile(slug: string, schema: CollectionSchema, dataDir: string, itemId: string): Promise<void> {
-  const key = `${slug}\x00${itemId}`;
+function scheduleItemReconcile(collection: LoadedCollection, itemId: string): Promise<void> {
+  const key = `${collection.slug}\x00${itemId}`;
   const existing = itemSlots.get(key);
   if (existing) {
     existing.pending = true;
@@ -392,7 +470,7 @@ function scheduleItemReconcile(slug: string, schema: CollectionSchema, dataDir: 
       let keepGoing = true;
       while (keepGoing) {
         slot.pending = false;
-        await reconcileItem(slug, schema, dataDir, itemId, discoveryOpts);
+        await reconcileItem(collection, itemId, discoveryOpts);
         keepGoing = slot.pending;
       }
     } finally {
@@ -415,7 +493,7 @@ async function onEvent(slug: string, filename: string | Buffer | null): Promise<
     // which record changed. `reconcileAllItems` covers items whose file
     // still exists; pair it with a sweep so any record deleted inside the
     // same opaque event has its stale bell entry cleared too.
-    await reconcileAllItems(slug, collection.schema, collection.dataDir, discoveryOpts);
+    await reconcileAllItems(collection, discoveryOpts);
     await sweepStaleActiveEntries(discoveryOpts);
     return;
   }
@@ -426,5 +504,5 @@ async function onEvent(slug: string, filename: string | Buffer | null): Promise<
   // skipping early avoids needless I/O.
   if (!name.endsWith(".json") || name.startsWith(".")) return;
   const itemId = name.slice(0, -".json".length);
-  await scheduleItemReconcile(slug, collection.schema, collection.dataDir, itemId);
+  await scheduleItemReconcile(collection, itemId);
 }

--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -361,7 +361,11 @@ async function startStorageWatcher(collection: LoadedCollection): Promise<void> 
   try {
     await mkdir(dir, { recursive: true });
     await reconcileAllItems(collection, discoveryOpts);
-    const watcher = watch(dir, { persistent: false }, (_eventType, filename) => {
+    const watcher = watch(dir, { persistent: false }, (_eventType, rawFilename) => {
+      // fs.watch can hand back a Buffer on some platforms despite the
+      // string typing — stringify defensively (a Buffer has no startsWith,
+      // so calling it directly would throw inside the callback and crash).
+      const filename = rawFilename === null ? null : String(rawFilename);
       // Null filename (platform quirk) counts as a hit; otherwise accept
       // the db itself plus its sqlite sidecars (`<db>-wal`, `<db>-journal`).
       if (filename !== null && !filename.startsWith(base)) return;

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -883,21 +883,11 @@ const BareCollectionSchemaZ = z
       "declare exactly one of `dataPath` (native JSON records), `dataSource` (external read-only data file), or `storage` (alternative writable backend)",
     path: ["dataPath"],
   })
-  // Record-file machinery that a non-file backend can't serve yet:
-  // `spawn` writes successor RECORD FILES through the raw io layer (no
-  // LoadedCollection in its signature to pick a store from), and the
-  // collection watcher's reconcilers (`completionField` bell clearing,
-  // `triggerField` clock notifications) scan the dataDir's .json files —
-  // on a `storage` backend they would silently see zero records. Reject
-  // loudly until those paths are store-aware.
-  .refine(
-    (schema) => schema.storage === undefined || (schema.spawn === undefined && schema.completionField === undefined && schema.triggerField === undefined),
-    {
-      message:
-        "a `storage` collection cannot declare `spawn`, `completionField`, or `triggerField` yet — successor writes and watcher reconciliation still read record files",
-      path: ["storage"],
-    },
-  )
+  // NOTE: `storage` collections support the full write machinery
+  // (`spawn` / `completionField` / `triggerField` / `singleton` / `ingest`
+  // / mutate actions) — spawn and the watcher reconcilers go through the
+  // CollectionStore seam, and a db-file watcher drives their
+  // reconciliation (collection-watchers/watcher.ts).
   // A `dataSource` collection is read-only by definition, so schema-level
   // write machinery can never fire: `singleton` pins CREATES, `ingest`
   // REFILLS records, `spawn` WRITES successor records. Rejecting them at

--- a/packages/core/src/collection/server/delete.ts
+++ b/packages/core/src/collection/server/delete.ts
@@ -22,6 +22,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { log, getWorkspaceRoot, isPresetSlug, skillsStagingDir, archiveDir as archiveRelDir } from "./host";
 import { isContainedInRoot } from "./paths";
+import { checkpointSqliteDatabase } from "./sqliteStore";
 import type { LoadedCollection } from "./discoveredCollection";
 
 export type DeleteCollectionResult =
@@ -119,6 +120,13 @@ function isDataDirSafe(dataDir: string, slug: string, workspaceRoot: string): bo
  *  `dataSource` collection has no record files to copy (its rows live in
  *  the external data file, which the delete never touches). */
 function restoreRecordsStep(schema: LoadedCollection["schema"]): string {
+  if (schema.storage !== undefined) {
+    return `2. Records: copy the archived database file
+   \`${path.basename(schema.storage.path)}\` (next to this document) back to
+   \`${schema.storage.path}\` (workspace-relative, \`cp\`). It holds every
+   record. If \`-wal\`/\`-journal\` sidecar files were archived alongside
+   it, copy them back too.`;
+  }
   if (schema.dataPath === undefined) {
     return `2. Records: nothing to copy. This is a \`dataSource\` collection —
    its records are the rows of \`${schema.dataSource?.path}\`, which the
@@ -158,7 +166,7 @@ ${restoreRecordsStep(schema)}
 
 - slug: \`${slug}\`
 - title: ${schema.title}
-- dataPath: \`${schema.dataPath ?? `(dataSource) ${schema.dataSource?.path}`}\`
+- dataPath: \`${schema.dataPath ?? (schema.storage !== undefined ? `(storage) ${schema.storage.path}` : `(dataSource) ${schema.dataSource?.path}`)}\`
 `;
 }
 
@@ -174,10 +182,21 @@ async function writeArchive(collection: LoadedCollection, archiveDir: string, wo
   }
   // A `storage` collection's records live in its database file (the
   // dataDir is a phantom) — archive it under its own basename so RESTORE
-  // can point `storage.path` back at it. (`dataSourceFile` is deliberately
-  // NOT archived or removed: an external dataSource file is user-owned.)
+  // can point `storage.path` back at it. Checkpoint first so the main file
+  // alone is a complete snapshot (in WAL mode, committed rows can live
+  // only in `<db>-wal`); if the checkpoint fails (older Node, locked db),
+  // archive the sidecars too — either way no committed data is lost.
+  // (`dataSourceFile` is deliberately NOT archived or removed: an external
+  // dataSource file is user-owned.)
   if (collection.storageFile !== undefined && (await pathExists(collection.storageFile))) {
+    const checkpointed = await checkpointSqliteDatabase(collection.storageFile);
     await cp(collection.storageFile, path.join(archiveDir, path.basename(collection.storageFile)));
+    if (!checkpointed) {
+      for (const suffix of ["-wal", "-journal", "-shm"]) {
+        const sidecar = `${collection.storageFile}${suffix}`;
+        if (await pathExists(sidecar)) await cp(sidecar, path.join(archiveDir, path.basename(sidecar)));
+      }
+    }
   }
   await writeFile(path.join(archiveDir, "RESTORE.md"), buildRestoreDoc(collection), "utf-8");
 }

--- a/packages/core/src/collection/server/delete.ts
+++ b/packages/core/src/collection/server/delete.ts
@@ -81,7 +81,12 @@ function todayStamp(): string {
 /** Every directory the delete will touch must resolve under the
  *  workspace root — guards against a symlinked ancestor escaping it. */
 function deleteTargets(collection: LoadedCollection, workspaceRoot: string): string[] {
-  return [stagingSkillDir(workspaceRoot, collection.slug), collection.skillDir, collection.dataDir];
+  return [
+    stagingSkillDir(workspaceRoot, collection.slug),
+    collection.skillDir,
+    collection.dataDir,
+    ...(collection.storageFile !== undefined ? [collection.storageFile] : []),
+  ];
 }
 
 /** The records directory the delete recursively archives + removes
@@ -167,6 +172,13 @@ async function writeArchive(collection: LoadedCollection, archiveDir: string, wo
   if (await pathExists(collection.dataDir)) {
     await cp(collection.dataDir, path.join(archiveDir, "records"), { recursive: true });
   }
+  // A `storage` collection's records live in its database file (the
+  // dataDir is a phantom) — archive it under its own basename so RESTORE
+  // can point `storage.path` back at it. (`dataSourceFile` is deliberately
+  // NOT archived or removed: an external dataSource file is user-owned.)
+  if (collection.storageFile !== undefined && (await pathExists(collection.storageFile))) {
+    await cp(collection.storageFile, path.join(archiveDir, path.basename(collection.storageFile)));
+  }
   await writeFile(path.join(archiveDir, "RESTORE.md"), buildRestoreDoc(collection), "utf-8");
 }
 
@@ -178,6 +190,14 @@ async function removeLocations(collection: LoadedCollection, workspaceRoot: stri
   await rm(collection.skillDir, { recursive: true, force: true });
   await rm(collection.dataDir, { recursive: true, force: true });
   await rmdir(path.dirname(collection.dataDir)).catch(() => undefined);
+  // The archived copy above is the backup; remove the live db (+ sqlite
+  // sidecars) so a deleted collection doesn't leave orphaned data behind.
+  if (collection.storageFile !== undefined) {
+    await rm(collection.storageFile, { force: true });
+    await rm(`${collection.storageFile}-wal`, { force: true });
+    await rm(`${collection.storageFile}-journal`, { force: true });
+    await rm(`${collection.storageFile}-shm`, { force: true });
+  }
 }
 
 export async function deleteCollection(collection: LoadedCollection, opts: DeleteCollectionOptions = {}): Promise<DeleteCollectionResult> {

--- a/packages/core/src/collection/server/spawn.ts
+++ b/packages/core/src/collection/server/spawn.ts
@@ -22,7 +22,9 @@
 
 import { log } from "./host";
 import { errorMessage, ONE_DAY_MS } from "./util";
-import { writeItem, type IoOptions } from "./io";
+import type { IoOptions } from "./io";
+import { storeFor } from "./store";
+import type { LoadedCollection } from "./discoveredCollection";
 import { isFieldDrivenEvery } from "../core/schema";
 import { itemIsDone } from "../core/completion";
 import type { CollectionEvery, CollectionItem, CollectionSchema, CollectionSpawnEvery, CollectionWhen } from "../core/schema";
@@ -202,14 +204,8 @@ function logSpawnSkip(slug: string, triggerField: string, every: CollectionSpawn
  *  predicate doesn't match, the trigger date is unparseable, or the
  *  successor already exists (create-if-absent). Never overwrites an
  *  existing successor — protects any edits the user made to it. */
-export async function maybeSpawnSuccessor(
-  slug: string,
-  schema: CollectionSchema,
-  dataDir: string,
-  sourceItem: CollectionItem,
-  sourceId: string,
-  ioOpts: IoOptions = {},
-): Promise<void> {
+export async function maybeSpawnSuccessor(collection: LoadedCollection, sourceItem: CollectionItem, sourceId: string, ioOpts: IoOptions = {}): Promise<void> {
+  const { slug, schema } = collection;
   const { spawn } = schema;
   if (!spawn || !schema.triggerField) return;
   if (!matchesWhen(spawn.when, schema, sourceItem)) return;
@@ -232,7 +228,15 @@ export async function maybeSpawnSuccessor(
     return;
   }
   try {
-    const result = await writeItem(dataDir, computed.id, computed.record, { ...ioOpts, refuseOverwrite: true, slug });
+    // Store-mediated write: works for any writable backend (file, sqlite).
+    // A read-only store can't spawn — schema validation forbids `spawn` on
+    // dataSource collections, so an absent `write` is defense in depth.
+    const { write } = storeFor(collection, ioOpts);
+    if (!write) {
+      log.warn("collections", "spawn skipped: collection store is read-only", { slug, sourceId });
+      return;
+    }
+    const result = await write(computed.id, computed.record, { refuseOverwrite: true });
     if (result.kind === "ok") {
       log.info("collections", "spawned successor", { slug, sourceId, successorId: computed.id });
     } else if (result.kind !== "conflict") {

--- a/packages/core/src/collection/server/sqliteStore.ts
+++ b/packages/core/src/collection/server/sqliteStore.ts
@@ -263,6 +263,27 @@ async function sqliteDelete(absPath: string, itemId: string, opts: { workspaceRo
   return outcome;
 }
 
+/** Best-effort full WAL checkpoint so the MAIN db file alone is a
+ *  complete snapshot (committed pages in `<db>-wal` are folded in and the
+ *  WAL truncated). Used by `deleteCollection` before archiving. Returns
+ *  false on any failure (runtime without node:sqlite, locked db, missing
+ *  file) — the caller then archives the sidecar files alongside the db so
+ *  no committed data is lost either way. */
+export async function checkpointSqliteDatabase(absPath: string): Promise<boolean> {
+  try {
+    const { DatabaseSync } = await loadSqlite();
+    const database = new DatabaseSync(absPath);
+    try {
+      database.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } finally {
+      database.close();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** A `storage: sqlite` store over `collection.storageFile`. A schema whose
  *  `storageFile` failed to resolve yields a read-only EMPTY store rather
  *  than a writable one — same fail-closed rule as the CSV store. */

--- a/packages/core/src/collection/server/validate.ts
+++ b/packages/core/src/collection/server/validate.ts
@@ -10,6 +10,7 @@ import { readdir, readFile, lstat } from "node:fs/promises";
 import path from "node:path";
 import { getWorkspaceRoot, log } from "./host";
 import { isContainedInRoot } from "./paths";
+import { storeFor } from "./store";
 import { firstRecordProblem, type RecordCheckTier } from "../core/recordZ";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
@@ -56,6 +57,9 @@ export async function validateCollectionRecords(collection: LoadedCollection, op
   // come from the external data file (type mismatches there surface as
   // raw values in the views, not as repairable record files).
   if (collection.schema.dataSource !== undefined) return [];
+  // A `storage` collection's records live in its database, not as files —
+  // validate what the store serves instead of scanning the phantom dataDir.
+  if (collection.schema.storage !== undefined) return validateStoreRecords(collection, opts);
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
   const entries = await listRecordFilenames(collection.dataDir, workspaceRoot);
   const issues: RecordIssue[] = [];
@@ -64,6 +68,30 @@ export async function validateCollectionRecords(collection: LoadedCollection, op
     if (issues.length >= MAX_ISSUES) break;
     const issue = await inspectRecord(path.join(collection.dataDir, name), name, collection.schema);
     if (issue) issues.push(issue);
+  }
+  return issues;
+}
+
+/** Store-backed twin of the file scan: list every record through the
+ *  collection's store and lint it with the same "strict" report-only tier.
+ *  A row the store can't even parse is invisible here (the store skips
+ *  it), so the read/parse classifications of the file scan don't apply —
+ *  schema violations are what this catches. `file` carries the record id
+ *  (there is no per-record filename). */
+async function validateStoreRecords(collection: LoadedCollection, opts: { workspaceRoot?: string }): Promise<RecordIssue[]> {
+  let items: CollectionItem[];
+  try {
+    items = await storeFor(collection, { workspaceRoot: opts.workspaceRoot }).list();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return [{ file: "(store)", problem: `records could not be read from the storage backend: ${reason}` }];
+  }
+  const issues: RecordIssue[] = [];
+  for (const item of items) {
+    if (issues.length >= MAX_ISSUES) break;
+    const itemId = String(item[collection.schema.primaryKey] ?? "");
+    const problem = validateRecordObject(item, itemId, collection.schema, "strict");
+    if (problem) issues.push({ file: itemId, problem });
   }
   return issues;
 }

--- a/packages/core/test/collection-watchers/test_reconciler.ts
+++ b/packages/core/test/collection-watchers/test_reconciler.ts
@@ -19,6 +19,11 @@ import {
   resolveDisplayLabel,
   type CollectionNotificationAdapter,
 } from "../../src/collection-watchers/index.ts";
+import type { LoadedCollection } from "../../src/collection/server/index.ts";
+
+// The store-based reconciler takes the discovered collection.
+const asCollection = (slug: string, schema: unknown, dataDir: string): LoadedCollection =>
+  ({ slug, source: "project", schema, dataDir, skillDir: dataDir }) as unknown as LoadedCollection;
 
 const root = mkdtempSync(path.join(tmpdir(), "cw-root-"));
 const noopLog = { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} };
@@ -100,7 +105,7 @@ test("reconcileItem publishes a bell for a pending record via the adapter", asyn
   freshNotifierFiles();
   const dataDir = dataDirWith([{ id: "t1", name: "Pending task", done: "false" }]);
   try {
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
     const all = await listAll();
     assert.equal(all.length, 1);
     assert.equal(all[0].pluginPkg, "test-bells");
@@ -116,8 +121,8 @@ test("reconcileItem is idempotent — re-running does not duplicate the bell", a
   freshNotifierFiles();
   const dataDir = dataDirWith([{ id: "t1", name: "Pending", done: "false" }]);
   try {
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
     assert.equal((await listAll()).length, 1);
   } finally {
     rmSync(dataDir, { recursive: true, force: true });
@@ -128,10 +133,10 @@ test("reconcileItem clears the bell when the record becomes done", async () => {
   freshNotifierFiles();
   const dataDir = dataDirWith([{ id: "t1", name: "Task", done: "false" }]);
   try {
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
     assert.equal((await listAll()).length, 1);
     writeFileSync(path.join(dataDir, "t1.json"), JSON.stringify({ id: "t1", name: "Task", done: "true" }));
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
     assert.equal((await listAll()).length, 0);
     assert.deepEqual(
       events.map((event) => event.type),
@@ -146,10 +151,10 @@ test("reconcileItem clears the bell when the record file is deleted", async () =
   freshNotifierFiles();
   const dataDir = dataDirWith([{ id: "t1", name: "Task", done: "false" }]);
   try {
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
     assert.equal((await listAll()).length, 1);
     rmSync(path.join(dataDir, "t1.json"));
-    await reconcileItem("todo", SCHEMA, dataDir, "t1", { workspaceRoot: root });
+    await reconcileItem(asCollection("todo", SCHEMA, dataDir), "t1", { workspaceRoot: root });
     assert.equal((await listAll()).length, 0);
   } finally {
     rmSync(dataDir, { recursive: true, force: true });

--- a/plans/refactor-storage-virtualization.md
+++ b/plans/refactor-storage-virtualization.md
@@ -1,6 +1,6 @@
 # Collection storage virtualization — Stage 0–1
 
-**Status**: Stages 0–4 done (Stage 1 in REVISED additive form — see
+**Status**: Stages 0–4 + post-merge follow-up done (Stage 1 in REVISED additive form — see
 "Stage 1 revision"; Stage 2–4 notes below)
 **Owner**: TBD
 **Last updated**: 2026-07-19
@@ -243,11 +243,33 @@ point.
   phantom dataDir but leaves the `.db` file; external edits to the db
   don't fire change events (no watcher).
 
+## Post-merge follow-up (PR #2203 review + web-test findings) — done
+
+- **Watcher/reconciler are store-aware**: `maybeSpawnSuccessor`,
+  `reconcileItem`, `reconcileAllItems`, and the sweep all take a
+  `LoadedCollection` and go through `storeFor` — the schema-level rejection
+  of `spawn` / `completionField` / `triggerField` on `storage` collections
+  is LIFTED. A db-file watcher (parent-dir mount, sqlite sidecars
+  included, per-slug single-flight) drives full-pass reconciliation +
+  change publishes for external db edits. (Signature change — MulmoTerminal
+  needs the matching port when it ratchets to 0.25.1.)
+- **`deleteCollection`** archives the `.db` beside the skill and removes
+  the live file (+`-wal`/`-journal`/`-shm`); `dataSourceFile` stays
+  untouched (user-owned).
+- **Repair/validation** lists non-file backends through the store and
+  lints with the same strict tier (issues keyed by record id).
+- **Desktop custom-view images**: new `GET view-data/image?path=…&maxEdge=…`
+  (read capability) resolves a CURRENT image-field value into a thumbnail
+  `{ dataUrl }` — the desktop sibling of remote `imageFields`; authorization
+  set = the records' image-field values, nothing else. Documented in
+  custom-view.md "Displaying images" (born from the NPB web test, where the
+  agent base64-embedded logos into the view HTML for lack of this).
+
 ## Later stages (sketch, not in scope here)
 
 - `nativeSort` capability + sort pushdown (design against a second
-  SQL-capable backend), `list()` deprecation, spawn onto the store, db-file
-  archive on collection delete.
+  SQL-capable backend) and `list()` deprecation — the next BREAKING wave,
+  bundled so dependents ratchet once.
 
 ## Open questions
 

--- a/server/api/auth/viewToken.ts
+++ b/server/api/auth/viewToken.ts
@@ -137,6 +137,7 @@ export function requireViewToken(action: ViewCapability) {
 const VIEW_DATA_PATH_RE = /^\/(?:api\/)?collections\/[^/]+\/view-data$/;
 const VIEW_DATA_ACTION_PATH_RE = /^\/(?:api\/)?collections\/[^/]+\/view-data\/actions\/[^/]+$/;
 const VIEW_DATA_QUERY_PATH_RE = /^\/(?:api\/)?collections\/[^/]+\/view-data\/query$/;
+const VIEW_DATA_IMAGE_PATH_RE = /^\/(?:api\/)?collections\/[^/]+\/view-data\/image$/;
 
 /** True for the view-data endpoint paths (either mount base): the record
  *  read/write base path, the token-scoped mutate-action endpoint, and the
@@ -147,5 +148,10 @@ const VIEW_DATA_QUERY_PATH_RE = /^\/(?:api\/)?collections\/[^/]+\/view-data\/que
  *  add every new `/view-data/...` route to this matcher AND to the
  *  coverage in `test/server/test_viewToken.ts`. */
 export function isViewDataPath(pathname: string): boolean {
-  return VIEW_DATA_PATH_RE.test(pathname) || VIEW_DATA_ACTION_PATH_RE.test(pathname) || VIEW_DATA_QUERY_PATH_RE.test(pathname);
+  return (
+    VIEW_DATA_PATH_RE.test(pathname) ||
+    VIEW_DATA_ACTION_PATH_RE.test(pathname) ||
+    VIEW_DATA_QUERY_PATH_RE.test(pathname) ||
+    VIEW_DATA_IMAGE_PATH_RE.test(pathname)
+  );
 }

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -953,25 +953,61 @@ router.post(
   },
 );
 
-/** The set of workspace paths this collection's records CURRENTLY reference
- *  through schema `image`-type fields (top-level fields only, matching the
- *  remote view's `inlineFields` rule). This is the authorization set for the
- *  view-data image route: a scoped view token may resolve exactly these
- *  paths and nothing else — never an arbitrary workspace file. Exported for
- *  the unit test. */
-export function imageFieldPathValues(schema: LoadedCollection["schema"], items: CollectionItem[]): Set<string> {
+/** True when `relPath` is a CURRENT value of one of the schema's
+ *  `image`-type fields (top-level fields only, matching the remote view's
+ *  `inlineFields` rule) across `items`. This is the authorization rule for
+ *  the view-data image route: a scoped view token may resolve exactly these
+ *  paths and nothing else — never an arbitrary workspace file. Early-exit
+ *  scan (no per-request Set allocation). Exported for the unit test. */
+export function isAuthorizedImagePath(schema: LoadedCollection["schema"], items: CollectionItem[], relPath: string): boolean {
   const imageFields = Object.entries(schema.fields)
     .filter(([, spec]) => spec.type === "image")
     .map(([name]) => name);
-  const paths = new Set<string>();
-  for (const item of items) {
-    for (const field of imageFields) {
-      const value = item[field];
-      if (typeof value === "string" && value.length > 0) paths.add(value);
-    }
-  }
-  return paths;
+  if (imageFields.length === 0 || relPath.length === 0) return false;
+  return items.some((item) => imageFields.some((field) => item[field] === relPath));
 }
+
+export interface ViewDataImageDeps {
+  loadCollection: (slug: string) => Promise<LoadedCollection | null>;
+  listRecords: (collection: LoadedCollection) => Promise<CollectionItem[]>;
+  resolveThumbnail: typeof resolveThumbnail;
+}
+
+/** The image-route handler behind a deps seam so its contract (400 missing
+ *  path / 404 unknown collection / 404 unauthorized path / 404 unresolvable
+ *  / clamped `maxEdge` plumbing / 500 on a thrown resolver) is
+ *  unit-testable without mounting the express app — same factory pattern as
+ *  the remote-view handlers. */
+export const createViewDataImageHandler =
+  (deps: ViewDataImageDeps) =>
+  async (req: Request<{ slug: string }>, res: Response): Promise<void> => {
+    const collection = await deps.loadCollection(req.params.slug);
+    if (!collection) {
+      notFound(res, `collection '${req.params.slug}' not found`);
+      return;
+    }
+    const relPath = typeof req.query.path === "string" ? req.query.path : "";
+    if (relPath.length === 0) {
+      badRequest(res, "pass `path` — an image field's workspace-relative value");
+      return;
+    }
+    try {
+      const items = await deps.listRecords(collection);
+      if (!isAuthorizedImagePath(collection.schema, items, relPath)) {
+        notFound(res, "path is not a current value of this collection's image fields");
+        return;
+      }
+      const dataUrl = await deps.resolveThumbnail(relPath, clampImageMaxEdge(req.query.maxEdge));
+      if (dataUrl === null) {
+        notFound(res, "image could not be resolved");
+        return;
+      }
+      res.json({ path: relPath, dataUrl });
+    } catch (err) {
+      log.warn("collections", "view-data image failed", { slug: collection.slug, error: errorMessage(err) });
+      serverError(res, "image resolve failed");
+    }
+  };
 
 router.options(API_ROUTES.collections.viewDataImage, viewDataCors, (_req: Request, res: Response) => {
   res.status(204).end();
@@ -991,31 +1027,7 @@ router.get(
   viewImageRateLimit,
   viewQueryConcurrency,
   requireViewToken("read"),
-  async (req: Request<{ slug: string }>, res: Response) => {
-    const collection = await loadCollectionOr404(req.params.slug, res);
-    if (!collection) return;
-    const relPath = typeof req.query.path === "string" ? req.query.path : "";
-    if (relPath.length === 0) {
-      badRequest(res, "pass `path` — an image field's workspace-relative value");
-      return;
-    }
-    try {
-      const items = await storeFor(collection).list();
-      if (!imageFieldPathValues(collection.schema, items).has(relPath)) {
-        notFound(res, "path is not a current value of this collection's image fields");
-        return;
-      }
-      const dataUrl = await resolveThumbnail(relPath, clampImageMaxEdge(req.query.maxEdge));
-      if (dataUrl === null) {
-        notFound(res, "image could not be resolved");
-        return;
-      }
-      res.json({ path: relPath, dataUrl });
-    } catch (err) {
-      log.warn("collections", "view-data image failed", { slug: collection.slug, error: errorMessage(err) });
-      serverError(res, "image resolve failed");
-    }
-  },
+  createViewDataImageHandler({ loadCollection, listRecords: (collection) => storeFor(collection).list(), resolveThumbnail }),
 );
 
 // Scoped write: validated putItems. Requires the `write` capability.

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -55,7 +55,8 @@ import {
   type RemoteViewBuildResult,
   type RemoteViewItemsResult,
 } from "../../workspace/collections/remoteView.js";
-import { clampLimit, clampOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { clampImageMaxEdge, clampLimit, clampOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { resolveThumbnail } from "../../utils/files/thumbnail-store.js";
 import { badRequest, notFound, conflict, forbidden, methodNotAllowed, serverError, serviceUnavailable } from "../../utils/httpError.js";
 import { ONE_MINUTE_MS } from "../../utils/time.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -942,6 +943,70 @@ router.post(
       // scoped view is not a trusted audience for those.
       log.warn("collections", "view-data query failed", { slug: req.params.slug.replace(/[\r\n]/g, " "), error: errorMessage(err) });
       serverError(res, "collection query failed");
+    }
+  },
+);
+
+/** The set of workspace paths this collection's records CURRENTLY reference
+ *  through schema `image`-type fields (top-level fields only, matching the
+ *  remote view's `inlineFields` rule). This is the authorization set for the
+ *  view-data image route: a scoped view token may resolve exactly these
+ *  paths and nothing else — never an arbitrary workspace file. Exported for
+ *  the unit test. */
+export function imageFieldPathValues(schema: LoadedCollection["schema"], items: CollectionItem[]): Set<string> {
+  const imageFields = Object.entries(schema.fields)
+    .filter(([, spec]) => spec.type === "image")
+    .map(([name]) => name);
+  const paths = new Set<string>();
+  for (const item of items) {
+    for (const field of imageFields) {
+      const value = item[field];
+      if (typeof value === "string" && value.length > 0) paths.add(value);
+    }
+  }
+  return paths;
+}
+
+router.options(API_ROUTES.collections.viewDataImage, viewDataCors, (_req: Request, res: Response) => {
+  res.status(204).end();
+});
+
+// Scoped image read: resolve one record-referenced image path into a
+// downscaled `data:` thumbnail (same resolver + clamps as the remote view's
+// `imageFields` inlining). The record scan doubles as the authorization
+// check — the requested path must be a CURRENT image-field value — and runs
+// under the same in-flight cap as /query (both are per-request full scans).
+// Sandboxed views can't attach the bearer to an <img>, so the JSON
+// { dataUrl } shape (fetch → img.src) is the contract; see
+// packages/core/assets/helps/custom-view.md "Displaying images".
+router.get(
+  API_ROUTES.collections.viewDataImage,
+  viewDataCors,
+  viewQueryConcurrency,
+  requireViewToken("read"),
+  async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollectionOr404(req.params.slug, res);
+    if (!collection) return;
+    const relPath = typeof req.query.path === "string" ? req.query.path : "";
+    if (relPath.length === 0) {
+      badRequest(res, "pass `path` — an image field's workspace-relative value");
+      return;
+    }
+    try {
+      const items = await storeFor(collection).list();
+      if (!imageFieldPathValues(collection.schema, items).has(relPath)) {
+        notFound(res, "path is not a current value of this collection's image fields");
+        return;
+      }
+      const dataUrl = await resolveThumbnail(relPath, clampImageMaxEdge(req.query.maxEdge));
+      if (dataUrl === null) {
+        notFound(res, "image could not be resolved");
+        return;
+      }
+      res.json({ path: relPath, dataUrl });
+    } catch (err) {
+      log.warn("collections", "view-data image failed", { slug: collection.slug, error: errorMessage(err) });
+      serverError(res, "image resolve failed");
     }
   },
 );

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -653,6 +653,12 @@ export function makeViewActionRateLimiter(max: number, windowMs: number, now: ()
 
 const VIEW_ACTION_RATE_LIMIT_PER_MINUTE = 60;
 const viewActionRateLimit = makeViewActionRateLimiter(VIEW_ACTION_RATE_LIMIT_PER_MINUTE, ONE_MINUTE_MS);
+// Image thumbnails get their own, roomier bucket: a gallery legitimately
+// fetches dozens of images on first paint, so the action budget (60/min)
+// would starve it — while the endpoint still needs a ceiling (each request
+// is a record scan + a thumbnail decode).
+const VIEW_IMAGE_RATE_LIMIT_PER_MINUTE = 300;
+const viewImageRateLimit = makeViewActionRateLimiter(VIEW_IMAGE_RATE_LIMIT_PER_MINUTE, ONE_MINUTE_MS);
 
 router.options(API_ROUTES.collections.viewData, viewDataCors, (_req: Request, res: Response) => {
   res.status(204).end();
@@ -982,6 +988,7 @@ router.options(API_ROUTES.collections.viewDataImage, viewDataCors, (_req: Reques
 router.get(
   API_ROUTES.collections.viewDataImage,
   viewDataCors,
+  viewImageRateLimit,
   viewQueryConcurrency,
   requireViewToken("read"),
   async (req: Request<{ slug: string }>, res: Response) => {

--- a/server/workspace/collections/watcher.ts
+++ b/server/workspace/collections/watcher.ts
@@ -15,5 +15,6 @@ export {
   _syncWatchersForTesting,
   _tickTimeTriggersForTesting,
   _scheduleItemReconcileForTesting,
+  _scheduleStorageReconcileForTesting,
   type CollectionWatcherOptions,
 } from "@mulmoclaude/core/collection-watchers";

--- a/src/config/apiRoutes.ts
+++ b/src/config/apiRoutes.ts
@@ -363,6 +363,14 @@ const HOST_API_ROUTES = {
      *  read-only by construction (see core/queryZ.ts); 400 on a file-backed
      *  collection (no query engine). Backs chart-drawing custom views. */
     viewDataQuery: "/api/collections/:slug/view-data/query",
+    /** GET → resolve one record-referenced `image` field value (a workspace
+     *  path, `?path=…`) into a downscaled thumbnail → { path, dataUrl }.
+     *  Requires only the `read` capability; the path must be a CURRENT value
+     *  of one of the schema's image-type fields (no arbitrary file reads).
+     *  Optional `?maxEdge=` (clamped 64–1024, default 512). This is how a
+     *  desktop custom view displays workspace image files — sibling of the
+     *  remote view's `imageFields` inlining. */
+    viewDataImage: "/api/collections/:slug/view-data/image",
     /** DELETE → remove one custom view: drop it from schema.json `views[]` and
      *  unlink its `views/<file>.html` (global-bearer auth) → { deleted, viewId }.
      *  Source-aware; refuses user-scope + preset collections. */

--- a/test/api/routes/test_collectionsViewImage.ts
+++ b/test/api/routes/test_collectionsViewImage.ts
@@ -1,0 +1,48 @@
+// The view-data image route's authorization set: a scoped view token may
+// resolve exactly the workspace paths that are CURRENT values of the
+// schema's image-type fields — nothing else. Pins the set-building rules
+// (image fields only, top-level only, non-empty strings only) so the route
+// can never regress into an arbitrary-file oracle.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { imageFieldPathValues } from "../../../server/api/routes/collections.js";
+import type { LoadedCollection } from "../../../server/workspace/collections/index.js";
+
+type Schema = LoadedCollection["schema"];
+
+const schema = {
+  title: "Teams",
+  icon: "sports",
+  dataPath: "data/teams/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true },
+    name: { type: "string", label: "Name" },
+    logo: { type: "image", label: "Logo" },
+    banner: { type: "image", label: "Banner" },
+    site: { type: "string", label: "Site" },
+  },
+} as unknown as Schema;
+
+describe("imageFieldPathValues", () => {
+  it("collects only image-type field values, skipping empties and non-strings", () => {
+    const paths = imageFieldPathValues(schema, [
+      { id: "a", name: "A", logo: "data/teams/logos/a.png", banner: "" },
+      { id: "b", name: "B", logo: "data/teams/logos/b.png", banner: 42, site: "data/evil/not-image.png" },
+      { id: "c", name: "C" },
+    ]);
+    assert.deepEqual([...paths].sort(), ["data/teams/logos/a.png", "data/teams/logos/b.png"]);
+  });
+
+  it("never authorizes a non-image field's value, even when it looks like a path", () => {
+    const paths = imageFieldPathValues(schema, [{ id: "a", site: "data/attachments/secret.png" }]);
+    assert.equal(paths.has("data/attachments/secret.png"), false);
+    assert.equal(paths.size, 0);
+  });
+
+  it("is empty for a schema with no image fields", () => {
+    const bare = { ...schema, fields: { id: { type: "string", label: "ID", primary: true } } } as unknown as Schema;
+    assert.equal(imageFieldPathValues(bare, [{ id: "a", logo: "data/x.png" }]).size, 0);
+  });
+});

--- a/test/api/routes/test_collectionsViewImage.ts
+++ b/test/api/routes/test_collectionsViewImage.ts
@@ -1,13 +1,17 @@
-// The view-data image route's authorization set: a scoped view token may
-// resolve exactly the workspace paths that are CURRENT values of the
-// schema's image-type fields — nothing else. Pins the set-building rules
-// (image fields only, top-level only, non-empty strings only) so the route
-// can never regress into an arbitrary-file oracle.
+// The view-data image route: the authorization rule (a scoped view token
+// may resolve exactly the paths that are CURRENT values of the schema's
+// image-type fields — nothing else) and the HTTP handler contract behind
+// the deps seam (400 missing path / 404 unknown collection / 404
+// unauthorized path / 404 unresolvable / clamped maxEdge plumbing / 500 on
+// a thrown resolver). Token-middleware behavior itself is pinned by
+// test_viewToken.ts (requireViewToken + the isViewDataPath bearer
+// exemption this route depends on — Codex P1 on #2204).
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import type { Request, Response } from "express";
 
-import { imageFieldPathValues } from "../../../server/api/routes/collections.js";
-import type { LoadedCollection } from "../../../server/workspace/collections/index.js";
+import { createViewDataImageHandler, isAuthorizedImagePath, type ViewDataImageDeps } from "../../../server/api/routes/collections.js";
+import type { CollectionItem, LoadedCollection } from "../../../server/workspace/collections/index.js";
 
 type Schema = LoadedCollection["schema"];
 
@@ -25,24 +29,108 @@ const schema = {
   },
 } as unknown as Schema;
 
-describe("imageFieldPathValues", () => {
-  it("collects only image-type field values, skipping empties and non-strings", () => {
-    const paths = imageFieldPathValues(schema, [
-      { id: "a", name: "A", logo: "data/teams/logos/a.png", banner: "" },
-      { id: "b", name: "B", logo: "data/teams/logos/b.png", banner: 42, site: "data/evil/not-image.png" },
-      { id: "c", name: "C" },
-    ]);
-    assert.deepEqual([...paths].sort(), ["data/teams/logos/a.png", "data/teams/logos/b.png"]);
+const collection = { slug: "teams", source: "project", schema, dataDir: "/d/teams", skillDir: "/s/teams" } as unknown as LoadedCollection;
+
+const records: CollectionItem[] = [
+  { id: "a", name: "A", logo: "data/teams/logos/a.png", banner: "" },
+  { id: "b", name: "B", logo: "data/teams/logos/b.png", banner: 42, site: "data/evil/not-image.png" },
+  { id: "c", name: "C" },
+];
+
+describe("isAuthorizedImagePath", () => {
+  it("authorizes only image-type field values, skipping empties and non-strings", () => {
+    assert.equal(isAuthorizedImagePath(schema, records, "data/teams/logos/a.png"), true);
+    assert.equal(isAuthorizedImagePath(schema, records, "data/teams/logos/b.png"), true);
+    assert.equal(isAuthorizedImagePath(schema, records, "data/teams/logos/zz.png"), false);
+    assert.equal(isAuthorizedImagePath(schema, records, ""), false);
   });
 
   it("never authorizes a non-image field's value, even when it looks like a path", () => {
-    const paths = imageFieldPathValues(schema, [{ id: "a", site: "data/attachments/secret.png" }]);
-    assert.equal(paths.has("data/attachments/secret.png"), false);
-    assert.equal(paths.size, 0);
+    assert.equal(isAuthorizedImagePath(schema, records, "data/evil/not-image.png"), false);
   });
 
-  it("is empty for a schema with no image fields", () => {
+  it("is false for a schema with no image fields", () => {
     const bare = { ...schema, fields: { id: { type: "string", label: "ID", primary: true } } } as unknown as Schema;
-    assert.equal(imageFieldPathValues(bare, [{ id: "a", logo: "data/x.png" }]).size, 0);
+    assert.equal(isAuthorizedImagePath(bare, [{ id: "a", logo: "data/x.png" }], "data/x.png"), false);
+  });
+});
+
+function fakeReq(slug: string, query: Record<string, unknown>): Request<{ slug: string }> {
+  return { params: { slug }, query } as unknown as Request<{ slug: string }>;
+}
+
+function fakeRes() {
+  let statusCode = 200;
+  let body: unknown;
+  const res = {
+    status: (code: number) => {
+      statusCode = code;
+      return res;
+    },
+    json: (payload: unknown) => {
+      body = payload;
+      return res;
+    },
+  } as unknown as Response;
+  return { res, status: () => statusCode, body: () => body as Record<string, unknown> | undefined };
+}
+
+function deps(overrides: Partial<ViewDataImageDeps> = {}): ViewDataImageDeps {
+  return {
+    loadCollection: async (slug) => (slug === "teams" ? collection : null),
+    listRecords: async () => records,
+    resolveThumbnail: async () => "data:image/jpeg;base64,THUMB",
+    ...overrides,
+  };
+}
+
+describe("createViewDataImageHandler", () => {
+  it("resolves an authorized path into { path, dataUrl }", async () => {
+    const { res, status, body } = fakeRes();
+    await createViewDataImageHandler(deps())(fakeReq("teams", { path: "data/teams/logos/a.png" }), res);
+    assert.equal(status(), 200);
+    assert.deepEqual(body(), { path: "data/teams/logos/a.png", dataUrl: "data:image/jpeg;base64,THUMB" });
+  });
+
+  it("clamps maxEdge before it reaches the resolver (default 512, ceiling 1024, floor 64)", async () => {
+    const seen: number[] = [];
+    const handler = createViewDataImageHandler(
+      deps({
+        resolveThumbnail: async (_path, maxEdge) => {
+          seen.push(maxEdge);
+          return "data:image/jpeg;base64,T";
+        },
+      }),
+    );
+    const request = (query: Record<string, unknown>) => handler(fakeReq("teams", { path: "data/teams/logos/a.png", ...query }), fakeRes().res);
+    await request({});
+    await request({ maxEdge: "99999" });
+    await request({ maxEdge: "1" });
+    assert.deepEqual(seen, [512, 1024, 64]);
+  });
+
+  it("404s an unknown collection, an unauthorized path, and an unresolvable image; 400s a missing path", async () => {
+    const run = async (slug: string, query: Record<string, unknown>, override: Partial<ViewDataImageDeps> = {}) => {
+      const { res, status } = fakeRes();
+      await createViewDataImageHandler(deps(override))(fakeReq(slug, query), res);
+      return status();
+    };
+    assert.equal(await run("ghost", { path: "data/teams/logos/a.png" }), 404);
+    assert.equal(await run("teams", { path: "data/evil/not-image.png" }), 404); // non-image field value
+    assert.equal(await run("teams", { path: "data/teams/logos/a.png" }, { resolveThumbnail: async () => null }), 404);
+    assert.equal(await run("teams", {}), 400);
+  });
+
+  it("500s with a fixed message when the record scan or resolver throws", async () => {
+    const { res, status, body } = fakeRes();
+    await createViewDataImageHandler(
+      deps({
+        listRecords: async () => {
+          throw new Error("boom with /absolute/host/path");
+        },
+      }),
+    )(fakeReq("teams", { path: "data/teams/logos/a.png" }), res);
+    assert.equal(status(), 500);
+    assert.equal((body() as { error?: string }).error, "image resolve failed"); // never the raw error text
   });
 });

--- a/test/server/test_viewToken.ts
+++ b/test/server/test_viewToken.ts
@@ -114,6 +114,9 @@ describe("viewToken — isViewDataPath", () => {
     // is unreachable from sandboxed views (Codex P1 on #2163).
     assert.equal(isViewDataPath("/collections/my-slug/view-data/query"), true);
     assert.equal(isViewDataPath("/api/collections/my-slug/view-data/query"), true);
+    // The image-thumbnail endpoint — same failure mode (Codex P1 on #2204).
+    assert.equal(isViewDataPath("/collections/my-slug/view-data/image"), true);
+    assert.equal(isViewDataPath("/api/collections/my-slug/view-data/image"), true);
   });
 
   it("does not match sibling collection routes", () => {

--- a/test/workspace/collections/test_delete.ts
+++ b/test/workspace/collections/test_delete.ts
@@ -9,7 +9,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { deleteCollection, type LoadedCollection } from "@mulmoclaude/core/collection/server";
+import { deleteCollection, storeFor, type LoadedCollection } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema, CollectionSource } from "../../../server/workspace/collections/types.js";
 
 let workdir: string;
@@ -148,5 +148,64 @@ describe("deleteCollection", () => {
     assert.equal(existsSync(path.join(workdir, ".claude", "skills", "restaurants")), true, "mirror must survive");
     assert.equal(existsSync(path.join(workdir, "data", "restaurants", "items")), true, "records must survive");
     assert.equal(existsSync(path.join(workdir, "archive")), false, "no archive should be written on refusal");
+  });
+});
+
+describe("deleteCollection — storage (sqlite) collections", () => {
+  /** Seed a sqlite-backed collection: skill files + a REAL db (written
+   *  through the store) at data/<slug>/records.db, plus fake sidecar files
+   *  so their removal is observable. */
+  function seedStorageCollection(slug: string): LoadedCollection {
+    const schema = {
+      title: "Orders DB",
+      icon: "receipt_long",
+      storage: { type: "sqlite", path: `data/${slug}/records.db` },
+      primaryKey: "id",
+      fields: { id: { type: "string", label: "ID", primary: true } },
+    } as unknown as CollectionSchema;
+    const stagingDir = path.join(workdir, "data", "skills", slug);
+    const skillDir = path.join(workdir, ".claude", "skills", slug);
+    const dataDir = path.join(workdir, "data", "collections", slug, "items");
+    for (const dir of [stagingDir, skillDir, dataDir]) mkdirSync(dir, { recursive: true });
+    for (const dir of [stagingDir, skillDir]) {
+      writeFileSync(path.join(dir, "schema.json"), JSON.stringify(schema));
+      writeFileSync(path.join(dir, "SKILL.md"), `# ${slug}`);
+    }
+    const storageFile = path.join(workdir, "data", slug, "records.db");
+    return { slug, source: "project" as CollectionSource, schema, dataDir, skillDir, storageFile } as LoadedCollection;
+  }
+
+  it("archives the db (checkpointed), removes the live file + sidecars, and writes storage restore steps", async () => {
+    const collection = seedStorageCollection("ordersdb");
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    assert.ok(store.write);
+    assert.equal((await store.write("o1", { id: "o1" })).kind, "ok");
+    assert.equal((await store.write("o2", { id: "o2" })).kind, "ok");
+    const storageFile = collection.storageFile as string;
+    // Observable sidecars: gone after delete whether or not the checkpoint ran.
+    writeFileSync(`${storageFile}-wal`, "sidecar");
+    writeFileSync(`${storageFile}-journal`, "sidecar");
+
+    const result = await deleteCollection(collection, { workspaceRoot: workdir, dateStamp: "2026-07-19" });
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+
+    const archiveDir = path.join(workdir, result.archivePath);
+    // The db is archived under its basename and holds every committed record
+    // (the pre-archive checkpoint folds WAL pages into the main file).
+    const archivedDb = path.join(archiveDir, "records.db");
+    assert.ok(existsSync(archivedDb), "archived db must exist");
+    const archived = { ...collection, storageFile: archivedDb } as LoadedCollection;
+    const rows = await storeFor(archived, { workspaceRoot: workdir }).list();
+    assert.deepEqual(rows.map((row) => row.id).sort(), ["o1", "o2"]);
+
+    // Live db + sidecars are gone; RESTORE.md tells how to bring it back.
+    assert.equal(existsSync(storageFile), false);
+    assert.equal(existsSync(`${storageFile}-wal`), false);
+    assert.equal(existsSync(`${storageFile}-journal`), false);
+    const restore = readFileSync(path.join(archiveDir, "RESTORE.md"), "utf-8");
+    assert.ok(restore.includes("records.db"), "RESTORE.md must name the archived db file");
+    assert.ok(restore.includes(`data/ordersdb/records.db`), "RESTORE.md must point at storage.path");
+    assert.ok(restore.includes("(storage)"), "summary line must mark the storage backend");
   });
 });

--- a/test/workspace/collections/test_notifications.ts
+++ b/test/workspace/collections/test_notifications.ts
@@ -31,6 +31,10 @@ import {
   sweepStaleActiveEntries,
 } from "../../../server/workspace/collections/notifications.js";
 import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
+import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
+// The store-based reconciler takes the discovered collection.
+const asCollection = (slug: string, schema: CollectionSchema, dataDir: string): LoadedCollection =>
+  ({ slug, source: "project", schema, dataDir, skillDir: dataDir }) as unknown as LoadedCollection;
 
 let workdir: string;
 let userDir: string;
@@ -151,7 +155,7 @@ describe("reconcileItem", () => {
   it("publishes a bell entry for a pending item with no existing entry", async () => {
     const schema = buildSchema();
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const entries = await activeCompletionEntries();
     assert.equal(entries.length, 1);
     assert.equal(entries[0]?.legacyId, `collection-completion:${SLUG}:a`);
@@ -163,8 +167,8 @@ describe("reconcileItem", () => {
   it("is idempotent — a second reconcile on the same pending item doesn't dup", async () => {
     const schema = buildSchema();
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const entries = await activeCompletionEntries();
     assert.equal(entries.length, 1);
   });
@@ -172,39 +176,39 @@ describe("reconcileItem", () => {
   it("clears the bell entry when the item transitions to a done value", async () => {
     const schema = buildSchema();
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     // Flip the item to done by rewriting the file.
     writeItem("a", { read: true });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("clears the bell entry when the item file is deleted", async () => {
     const schema = buildSchema();
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     deleteItemFile("a");
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("clears the entry when the schema no longer declares completionField", async () => {
     const schema = buildSchema();
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     // Simulate a runtime schema edit that drops completion tracking.
     const flipped = buildSchema({ completionField: undefined, completionDoneValues: undefined });
-    await reconcileItem(SLUG, flipped, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, flipped, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("does NOT publish for an item born done", async () => {
     const schema = buildSchema();
     writeItem("a", { read: true });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
@@ -218,7 +222,7 @@ describe("reconcileItem", () => {
       displayField: "title",
     });
     writeItem("a", { title: "Buy milk", read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const entries = await activeCompletionEntries();
     assert.equal(entries[0]?.title, `${schema.title}: Buy milk`);
     // Deep-link still keys on the primaryKey, not the label.
@@ -235,7 +239,7 @@ describe("reconcileItem", () => {
       displayField: "title",
     });
     writeItem("a", { title: "   ", read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const entries = await activeCompletionEntries();
     assert.equal(entries[0]?.title, `${schema.title}: a`);
   });
@@ -275,7 +279,7 @@ describe("reconcileAllItems", () => {
     writeItem("a", { read: false });
     writeItem("b", { read: true });
     writeItem("c", { read: false });
-    await reconcileAllItems(SLUG, schema, dataDir, { workspaceRoot: workdir });
+    await reconcileAllItems(asCollection(SLUG, schema, dataDir), { workspaceRoot: workdir });
     const entries = await activeCompletionEntries();
     const legacyIds = entries.map((entry) => entry.legacyId).sort();
     assert.deepEqual(legacyIds, [`collection-completion:${SLUG}:a`, `collection-completion:${SLUG}:c`]);
@@ -284,7 +288,7 @@ describe("reconcileAllItems", () => {
   it("is a no-op when the schema has no completionField", async () => {
     const schema = buildSchema({ completionField: undefined, completionDoneValues: undefined });
     writeItem("a", { read: false });
-    await reconcileAllItems(SLUG, schema, dataDir, { workspaceRoot: workdir });
+    await reconcileAllItems(asCollection(SLUG, schema, dataDir), { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 });
@@ -334,7 +338,7 @@ describe("sweepStaleActiveEntries", () => {
     const schema = buildSchema();
     writeSchemaJson(schema);
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     // Delete the schema dir to simulate a collection deletion.
     deleteSchemaDir();
@@ -346,7 +350,7 @@ describe("sweepStaleActiveEntries", () => {
     const schema = buildSchema();
     writeSchemaJson(schema);
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     // Rewrite the schema without completionField.
     writeSchemaJson(buildSchema({ completionField: undefined, completionDoneValues: undefined }));
@@ -358,7 +362,7 @@ describe("sweepStaleActiveEntries", () => {
     const schema = buildSchema();
     writeSchemaJson(schema);
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     deleteItemFile("a");
     await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
@@ -369,7 +373,7 @@ describe("sweepStaleActiveEntries", () => {
     const schema = buildSchema();
     writeSchemaJson(schema);
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     // Flip the file to done without going through reconcileItem — sweep
     // is the safety net for changes made while the watcher was down.
@@ -382,7 +386,7 @@ describe("sweepStaleActiveEntries", () => {
     const schema = buildSchema();
     writeSchemaJson(schema);
     writeItem("a", { read: false });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
     assert.equal((await activeCompletionEntries()).length, 1);
@@ -416,41 +420,41 @@ describe("reconcileItem — triggerField (time gate)", () => {
   it("suppresses the bell before the trigger date", async () => {
     const schema = triggerSchema();
     writeItem("a", { dueOn: "2026-06-10", status: "pending" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, BEFORE);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, BEFORE);
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("fires the bell once the clock reaches the trigger date", async () => {
     const schema = triggerSchema();
     writeItem("a", { dueOn: "2026-06-10", status: "pending" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, ON_DAY);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, ON_DAY);
     assert.equal((await activeCompletionEntries()).length, 1);
   });
 
   it("clears a fired bell when the item is marked done", async () => {
     const schema = triggerSchema();
     writeItem("a", { dueOn: "2026-06-10", status: "pending" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, ON_DAY);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, ON_DAY);
     assert.equal((await activeCompletionEntries()).length, 1);
     writeItem("a", { dueOn: "2026-06-10", status: "done" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, ON_DAY);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, ON_DAY);
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("retracts a premature bell when the trigger is pushed to the future (convergent)", async () => {
     const schema = triggerSchema();
     writeItem("a", { dueOn: "2026-06-10", status: "pending" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, ON_DAY);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, ON_DAY);
     assert.equal((await activeCompletionEntries()).length, 1);
     writeItem("a", { dueOn: "2026-12-31", status: "pending" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, ON_DAY);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, ON_DAY);
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("suppresses the bell (no throw) when the trigger value is unparseable", async () => {
     const schema = triggerSchema();
     writeItem("a", { dueOn: "whenever", status: "pending" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, ON_DAY);
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, ON_DAY);
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
@@ -458,7 +462,7 @@ describe("reconcileItem — triggerField (time gate)", () => {
     const schema = triggerSchema();
     writeItem("a", { dueOn: "2026-06-10", status: "pending" });
     // Boot-style reconcile with `now` already well past the trigger.
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir }, new Date(2026, 11, 1));
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir }, new Date(2026, 11, 1));
     assert.equal((await activeCompletionEntries()).length, 1);
   });
 });
@@ -487,8 +491,8 @@ describe("reconcileItem — notifyWhen (condition gate)", () => {
     const schema = notifySchema();
     writeItem("a", { priority: "high", status: "Todo" });
     writeItem("b", { priority: "low", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
-    await reconcileItem(SLUG, schema, dataDir, "b", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "b", { workspaceRoot: workdir });
     const ids = (await activeCompletionEntries()).map((entry) => entry.legacyId);
     assert.deepEqual(ids, [`collection-completion:${SLUG}:a`]);
   });
@@ -496,27 +500,27 @@ describe("reconcileItem — notifyWhen (condition gate)", () => {
   it("does not fire when the gated field is missing", async () => {
     const schema = notifySchema();
     writeItem("a", { status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("clears the bell when the record stops matching (priority dropped)", async () => {
     const schema = notifySchema();
     writeItem("a", { priority: "urgent", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     writeItem("a", { priority: "low", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
   it("still clears on done even while notifyWhen matches", async () => {
     const schema = notifySchema();
     writeItem("a", { priority: "high", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     writeItem("a", { priority: "high", status: "Done" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 0);
   });
 
@@ -524,7 +528,7 @@ describe("reconcileItem — notifyWhen (condition gate)", () => {
     const schema = notifySchema();
     writeSchemaJson(schema);
     writeItem("a", { priority: "high", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     assert.equal((await activeCompletionEntries()).length, 1);
     writeItem("a", { priority: "low", status: "Todo" });
     await sweepStaleActiveEntries({ workspaceRoot: workdir, userSkillsDir: userDir });
@@ -556,8 +560,8 @@ describe("reconcileItem — notifyWhen severity", () => {
     const schema = severitySchema();
     writeItem("a", { priority: "urgent", status: "Todo" });
     writeItem("b", { priority: "high", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
-    await reconcileItem(SLUG, schema, dataDir, "b", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "b", { workspaceRoot: workdir });
     const bySlug = new Map((await activeCompletionEntries()).map((entry) => [entry.legacyId, entry.severity]));
     assert.equal(bySlug.get(`collection-completion:${SLUG}:a`), "urgent");
     assert.equal(bySlug.get(`collection-completion:${SLUG}:b`), "nudge");
@@ -566,7 +570,7 @@ describe("reconcileItem — notifyWhen severity", () => {
   it("updates a pending entry's severity in place when its flagged priority changes", async () => {
     const schema = severitySchema();
     writeItem("a", { priority: "urgent", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const before = await activeCompletionEntries();
     assert.equal(before.length, 1);
     assert.equal(before[0].severity, "urgent");
@@ -574,7 +578,7 @@ describe("reconcileItem — notifyWhen severity", () => {
     // urgent → high: still flagged, so the entry persists but must re-colour
     // to amber — and keep the SAME id (in-place update, not clear+republish).
     writeItem("a", { priority: "high", status: "Todo" });
-    await reconcileItem(SLUG, schema, dataDir, "a", { workspaceRoot: workdir });
+    await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const after = await activeCompletionEntries();
     assert.equal(after.length, 1);
     assert.equal(after[0].severity, "nudge");

--- a/test/workspace/collections/test_spawn.ts
+++ b/test/workspace/collections/test_spawn.ts
@@ -23,6 +23,7 @@ import {
   type CivilDate,
   readItem,
   writeItem,
+  type LoadedCollection,
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionEvery, CollectionSchema, CollectionSpawnEvery } from "../../../server/workspace/collections/types.js";
 
@@ -156,6 +157,10 @@ describe("successorId", () => {
   });
 });
 
+// The new store-based spawn signature takes the discovered collection.
+const asCollection = (slug: string, schema: CollectionSchema, dataDir: string): LoadedCollection =>
+  ({ slug, source: "project", schema, dataDir, skillDir: dataDir }) as unknown as LoadedCollection;
+
 function spawnSchema(extra: Partial<CollectionSchema> = {}): CollectionSchema {
   return {
     title: "Rent",
@@ -217,7 +222,7 @@ describe("maybeSpawnSuccessor", () => {
   it("creates the successor when the predicate matches", async () => {
     const schema = spawnSchema();
     const source = { id: "rent-20260610", dueOn: "2026-06-10", amount: 1500, status: "paid" };
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
     const next = await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir });
     assert.deepEqual(next, { amount: 1500, status: "pending", dueOn: "2026-07-10", id: "rent-20260710" });
   });
@@ -225,13 +230,13 @@ describe("maybeSpawnSuccessor", () => {
   it("is idempotent — spawning twice yields exactly one successor", async () => {
     const schema = spawnSchema();
     const source = { id: "rent-20260610", dueOn: "2026-06-10", amount: 1500, status: "paid" };
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
     const all = (await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir })) !== null;
     assert.equal(all, true);
     // Mutate the successor, then re-run: create-if-absent must NOT overwrite the edit.
     await writeItem(dataDir, "rent-20260710", { id: "rent-20260710", dueOn: "2026-07-10", amount: 9999, status: "pending" }, { workspaceRoot: workdir });
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
     const next = await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir });
     assert.equal((next as { amount: number }).amount, 9999);
   });
@@ -239,7 +244,7 @@ describe("maybeSpawnSuccessor", () => {
   it("does not spawn when the predicate doesn't match", async () => {
     const schema = spawnSchema();
     const source = { id: "rent-20260610", dueOn: "2026-06-10", amount: 1500, status: "pending" };
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
     assert.equal(await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir }), null);
   });
 
@@ -250,14 +255,14 @@ describe("maybeSpawnSuccessor", () => {
       spawn: { when: { field: "status", in: ["paid"] }, every: { unit: "month", interval: 1, dayOfMonth: 10 }, carry: ["amount"], set: { status: "paid" } },
     });
     const source = { id: "rent-20260610", dueOn: "2026-06-10", amount: 1500, status: "paid" };
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
     assert.equal(await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir }), null);
   });
 
   it("defaults the predicate to the completion-done condition when `when` is omitted", async () => {
     const schema = spawnSchema({ spawn: { every: { unit: "month", interval: 1, dayOfMonth: 10 }, carry: ["amount"], set: { status: "pending" } } });
     const source = { id: "rent-20260610", dueOn: "2026-06-10", amount: 1500, status: "paid" };
-    await maybeSpawnSuccessor("rent", schema, dataDir, source, "rent-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("rent", schema, dataDir), source, "rent-20260610", { workspaceRoot: workdir });
     assert.notEqual(await readItem(dataDir, "rent-20260710", { workspaceRoot: workdir }), null);
   });
 });
@@ -345,14 +350,14 @@ describe("maybeSpawnSuccessor — field-driven every", () => {
 
   it("creates a weekly successor 7 days out and carries the frequency driver", async () => {
     const source = { id: "gym-20260610", dueOn: "2026-06-10", frequency: "weekly", status: "paid" };
-    await maybeSpawnSuccessor("bills", freqSchema(), dataDir, source, "gym-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("bills", freqSchema(), dataDir), source, "gym-20260610", { workspaceRoot: workdir });
     const next = await readItem(dataDir, "gym-20260617", { workspaceRoot: workdir });
     assert.deepEqual(next, { frequency: "weekly", status: "pending", dueOn: "2026-06-17", id: "gym-20260617" });
   });
 
   it("skips (no write) when the record's frequency isn't in the map", async () => {
     const source = { id: "odd-20260610", dueOn: "2026-06-10", frequency: "yearly", status: "paid" };
-    await maybeSpawnSuccessor("bills", freqSchema(), dataDir, source, "odd-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("bills", freqSchema(), dataDir), source, "odd-20260610", { workspaceRoot: workdir });
     assert.equal(await readItem(dataDir, "odd-20260617", { workspaceRoot: workdir }), null);
   });
 
@@ -360,7 +365,7 @@ describe("maybeSpawnSuccessor — field-driven every", () => {
     // `set` seeds status back to a done value → the successor would respawn.
     const schema = freqSchema({ spawn: { when: { field: "status", in: ["paid"] }, every: FREQ_EVERY, carry: ["frequency"], set: { status: "paid" } } });
     const source = { id: "gym-20260610", dueOn: "2026-06-10", frequency: "weekly", status: "paid" };
-    await maybeSpawnSuccessor("bills", schema, dataDir, source, "gym-20260610", { workspaceRoot: workdir });
+    await maybeSpawnSuccessor(asCollection("bills", schema, dataDir), source, "gym-20260610", { workspaceRoot: workdir });
     assert.equal(await readItem(dataDir, "gym-20260617", { workspaceRoot: workdir }), null);
   });
 });

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -228,25 +228,21 @@ describe("storage schema gates (sqlite)", () => {
     assert.equal(storeFor(collection, { workspaceRoot: workdir }).capabilities.writable, true);
   });
 
-  it("rejects storage combined with dataPath or dataSource, and storage + spawn (that refine specifically)", async () => {
+  it("rejects storage combined with dataPath or dataSource; ACCEPTS the full write machinery", async () => {
     writeSkill("both-path", { ...SQLITE_SCHEMA, dataPath: "data/x/items" });
     writeSkill("both-source", { ...SQLITE_SCHEMA, dataSource: { type: "csv", path: "data/x.csv" } });
     assert.equal((await discoverCollections(discoveryOpts())).length, 0);
+    // spawn / completionField / triggerField are store-aware now — a
+    // storage schema declaring them must parse (the old v1 refine is gone).
     const parsed = CollectionSchemaZ.safeParse({
       ...SQLITE_SCHEMA,
-      triggerField: "score",
-      spawn: { when: { field: "title", in: ["x"] }, every: { unit: "month", interval: 1, dayOfMonth: 10 } },
+      fields: { ...SQLITE_SCHEMA.fields, dueOn: { type: "date", label: "Due" }, status: { type: "enum", label: "St", values: ["pending", "paid"] } },
+      completionField: "status",
+      completionDoneValues: ["paid"],
+      triggerField: "dueOn",
+      spawn: { when: { field: "status", in: ["paid"] }, every: { unit: "month", interval: 1, dayOfMonth: 10 } },
     });
-    assert.equal(parsed.success, false);
-    if (parsed.success) return;
-    assert.ok(
-      parsed.error.issues.some((issue) => issue.message.includes("cannot declare `spawn`")),
-      `expected the storage+spawn refine, got: ${parsed.error.issues.map((issue) => issue.message).join(" | ")}`,
-    );
-    // The same refine also rejects the watcher-reconciled fields — their
-    // reconcilers scan record files and would silently see zero records.
-    const withCompletion = CollectionSchemaZ.safeParse({ ...SQLITE_SCHEMA, completionField: "title", completionDoneValues: ["done"] });
-    assert.equal(withCompletion.success, false);
+    assert.equal(parsed.success, true, parsed.success ? "" : parsed.error.issues.map((issue) => issue.message).join(" | "));
   });
 
   it("rejects a storage.path escaping the workspace", async () => {

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -29,11 +29,14 @@ import path from "node:path";
 import { _setFilePathsForTesting, initNotifier, listAll } from "../../../server/notifier/engine.js";
 import {
   _scheduleItemReconcileForTesting,
+  _scheduleStorageReconcileForTesting,
   _syncWatchersForTesting,
   startCollectionWatchers,
   stopCollectionWatchers,
 } from "../../../server/workspace/collections/watcher.js";
+import { loadCollection, storeFor } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
+import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
 
 let workdir: string;
 let userDir: string;
@@ -215,7 +218,9 @@ describe("scheduleItemReconcile single-flight", () => {
     // writes are still queued, producing duplicate entries.
     const schema = buildSchema();
     const dataDir = path.join(workdir, "data", SLUG, "items");
-    const promises = Array.from({ length: 10 }, () => _scheduleItemReconcileForTesting(SLUG, schema, dataDir, "a"));
+    const promises = Array.from({ length: 10 }, () =>
+      _scheduleItemReconcileForTesting({ slug: SLUG, source: "project", schema, dataDir, skillDir: dataDir } as unknown as LoadedCollection, "a"),
+    );
     await Promise.all(promises);
 
     const after = (await activeCompletionEntries()).length;
@@ -223,5 +228,53 @@ describe("scheduleItemReconcile single-flight", () => {
     // there wasn't (baseline=0, after=1). Either way, the burst added
     // at most one entry — never two.
     assert.equal(after, Math.max(baseline, 1), "rapid-fire reconciles must not produce duplicate entries");
+  });
+});
+
+describe("storage (sqlite) collection reconciliation", () => {
+  const DB_SLUG = "test-watcher-db";
+
+  function writeDbSchema(): void {
+    const skillDir = path.join(workdir, ".claude/skills", DB_SLUG);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(path.join(skillDir, "SKILL.md"), `---\nname: ${DB_SLUG}\ndescription: test\n---\nbody\n`);
+    writeFileSync(
+      path.join(skillDir, "schema.json"),
+      JSON.stringify({
+        title: "DB Watcher",
+        icon: "check_circle",
+        storage: { type: "sqlite", path: `data/${DB_SLUG}.db` },
+        primaryKey: "id",
+        fields: {
+          id: { type: "string", label: "ID", primary: true, required: true },
+          read: { type: "boolean", label: "Read", required: true },
+        },
+        completionField: "read",
+        completionDoneValues: ["true"],
+      }),
+    );
+  }
+
+  it("bells a pending sqlite record and clears it when it turns done", async () => {
+    writeDbSchema();
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+      triggerTickIntervalMs: null,
+    });
+    const collection = await loadCollection(DB_SLUG, { workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.ok(collection);
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    assert.ok(store.write);
+
+    await store.write("a", { id: "a", read: false });
+    await _scheduleStorageReconcileForTesting(DB_SLUG);
+    let legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(legacyIds.includes(`collection-completion:${DB_SLUG}:a`), `expected a bell for a, got ${JSON.stringify(legacyIds)}`);
+
+    await store.write("a", { id: "a", read: true });
+    await _scheduleStorageReconcileForTesting(DB_SLUG);
+    legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(!legacyIds.includes(`collection-completion:${DB_SLUG}:a`), "bell must clear once the record is done");
   });
 });

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -277,4 +277,30 @@ describe("storage (sqlite) collection reconciliation", () => {
     legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
     assert.ok(!legacyIds.includes(`collection-completion:${DB_SLUG}:a`), "bell must clear once the record is done");
   });
+
+  it("clears the bell when a pending sqlite record is DELETED (stale sweep)", async () => {
+    writeDbSchema();
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+      triggerTickIntervalMs: null,
+    });
+    const collection = await loadCollection(DB_SLUG, { workspaceRoot: workdir, userSkillsDir: userDir });
+    assert.ok(collection);
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    assert.ok(store.write && store.delete);
+
+    await store.write("b", { id: "b", read: false });
+    await _scheduleStorageReconcileForTesting(DB_SLUG);
+    let legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(legacyIds.includes(`collection-completion:${DB_SLUG}:b`));
+
+    // One db file holds every record — a delete produces no per-item event,
+    // so the full-pass reconcile must pair with the stale sweep (PR #2204
+    // review finding) to clear the removed record's bell.
+    await store.delete("b");
+    await _scheduleStorageReconcileForTesting(DB_SLUG);
+    legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(!legacyIds.includes(`collection-completion:${DB_SLUG}:b`), "bell must clear when the record is deleted");
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2203, driven by two inputs: the live web test (an agent base64-embedded 12 team logos into a custom view's HTML because desktop views had no way to display workspace image files) and the plan's remaining leftovers. Plan record updated: `plans/refactor-storage-virtualization.md`.

## Desktop custom-view images — `GET view-data/image`

- New `GET /api/collections/:slug/view-data/image?path=…&maxEdge=…` (view-token `read` capability, view-data CORS, and `/query`'s in-flight concurrency cap): resolves a workspace image path into a downscaled `{ path, dataUrl }` thumbnail using the SAME resolver + `clampImageMaxEdge` as remote-view `imageFields` inlining — the desktop sibling of that contract.
- **Authorization set**: the requested `path` must be a CURRENT value of one of the schema's `image`-type fields across the collection's records (checked per request through the store). A scoped view token can never read arbitrary workspace files; the set-building helper (`imageFieldPathValues`) is exported and pinned by unit tests.
- Docs: `custom-view.md` gains a "Displaying images" section (fetch → `img.src` pattern, caching guidance, https-URL alternative, and an explicit **do-NOT-base64-embed** rule); `collection-skills.md` image bullet cross-references it. Strictly ADDITIVE on the frozen view-data contract.

## Storage-virtualization leftovers

- **Watcher/reconciler are store-aware** — the real fix for the Codex P2 from #2203: `maybeSpawnSuccessor`, `reconcileItem`, `reconcileAllItems`, and the boot sweep now take a `LoadedCollection` and read/write through `storeFor`. The v1 schema rejection of `spawn` / `completionField` / `triggerField` on `storage` collections is **lifted**. `storage` collections get a db-file watcher (parent-dir mount covering sqlite `-wal`/`-journal` sidecars, per-slug single-flight full-pass reconcile + debounced change publish), so boot, host-write, EXTERNAL-edit, and clock-tick reconciliation all work — proven by a new end-to-end test (pending sqlite record → bell fires → marked done → bell clears).
- **`deleteCollection`** archives the `.db` beside the skill under `archive/…` and removes the live file (+ sqlite sidecars). User-owned `dataSource` files stay untouched, as before.
- **Repair/validation** (`validateCollectionRecords`) lists non-file backends through the store and lints with the same strict tier — issues keyed by record id.
- Helps (`collection-skills.md`, `custom-view.md`, `error-recovery.md`) synced to the new reality.

Remaining, deliberately deferred to the next BREAKING wave (recorded in the plan): `nativeSort`/sort pushdown + `list()` deprecation, bundled so dependents ratchet once.

## Compatibility notes

- Custom views (desktop + remote): purely additive — no existing surface changed.
- Core stays at the still-unpublished **0.25.1** (same pre-publish window as #2203; no extra bump).
- **MulmoTerminal**: the reconciler/spawn signatures changed (`LoadedCollection`-based) — it needs the matching port when it ratchets to 0.25.1 (noted in plan + commit).

## Test plan

- `yarn lint` 0 errors / `yarn typecheck` clean / `yarn build` green
- Root suite **5974 pass**, core workspace **387 pass** (0 fail)
- New: sqlite bell reconcile end-to-end, image-path authorization-set units, storage schema now ACCEPTS the full write machinery (exclusivity + containment rejections unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom views can now render `image` fields via a secure, token-scoped thumbnail endpoint, including resizing (`maxEdge`), authorization based on current image paths, and per-endpoint rate limiting.
  * SQLite-backed collections now participate in the full write workflow (spawn/completion/trigger/mutate/ingest), with debounced automatic reconciliation on DB-file changes.
* **Bug Fixes**
  * Collection repair/validation now works correctly for SQLite-backed records and skips corrupt rows during repair.
  * Deleting a SQLite collection archives and removes its database artifacts cleanly.
* **Documentation**
  * Updated custom-view image and SQLite storage documentation for the new behavior and constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->