### PR TITLE
chore(lint): switch off three sonarjs rules that don't hold here

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -568,6 +568,31 @@ export default [
       "@typescript-eslint/await-thenable": "error",
       // Same backlog treatment for the sonarjs rules this block wakes.
       ...sonarTypeAwareRulesAsWarn,
+
+      // Three of those woken rules are off entirely rather than warned. Each
+      // was checked against all of its findings in this repo, and none of them
+      // pointed at a bug — the first would have introduced one.
+      //
+      // `no-alphabetical-sort` wants `localeCompare` on every bare `.sort()`.
+      // Its real target is `[10, 9, 1].sort()` returning `[1, 10, 9]`; this
+      // repo has no numeric sort like that. What it flags instead is sorting
+      // that must stay locale-INDEPENDENT: the Twilio request signature
+      // (`Object.keys(params).sort()`, where the server recomputes the same
+      // order to verify), frontmatter keys, record ids, ISO-dated filenames.
+      // `localeCompare` varies with ICU data and locale, so following the rule
+      // makes those non-deterministic — a broken signature, not a fixed sort.
+      "sonarjs/no-alphabetical-sort": "off",
+      // `prefer-regexp-exec` prefers `re.exec(str)` over `str.match(re)` for a
+      // marginal speed win on non-global patterns. It inverts subject and
+      // pattern at every call site — `url.match(/status\/(\d+)/)` reads as "does
+      // this url match", `/status\/(\d+)/.exec(url)` reads pattern-first — for
+      // no correctness difference.
+      "sonarjs/prefer-regexp-exec": "off",
+      // `no-misleading-array-reverse` catches in-place `.sort()`/`.reverse()` on
+      // an array someone else still holds. Every finding here mutates an array
+      // the same function just built (`picked`, `removed`, `missing`) or a fresh
+      // `readdir` result — nothing is shared, so there is no one to surprise.
+      "sonarjs/no-misleading-array-reverse": "off",
     },
   },
   eslintConfigPrettier,


### PR DESCRIPTION
## Summary

Read all **49** findings from three sonarjs rules woken by the type-aware pass (#2183). None pointed at a bug, and following the first would have **introduced** one. So the rules go off rather than the code being bent to satisfy them.

No source changes. Warnings drop **305 → 260**; errors stay 0.

## `no-alphabetical-sort` (24) — following it breaks Twilio authentication

The rule wants `localeCompare` on every bare `.sort()`. Its real target is `[10, 9, 1].sort()` returning `[1, 10, 9]` — and **this repo has no numeric sort like that**. What it actually flags is sorting that must stay locale-*independent*. Most sharply:

```js
// packages/bridges/twilio-sms/src/index.ts:80
// Twilio: sort params by key, concat key+value, prepend URL, sign with auth token.
const sortedKeys = Object.keys(params).sort();
```

Twilio recomputes that exact ordering server-side to verify the signature. `localeCompare` varies with locale and ICU data, so "fixing" this yields a signature the server rejects — an auth outage, produced by satisfying a linter. The other findings are the same shape: frontmatter keys, record ids, ISO-dated log filenames.

## `prefer-regexp-exec` (19) — inverts reading order for a micro-optimisation

`url.match(/status\/(\d+)/)` reads as *"does this url match"*. `/status\/(\d+)/.exec(url)` puts the pattern first at every call site. The rule's justification is a marginal speed win on non-global patterns; there is no correctness difference.

## `no-misleading-array-reverse` (6) — nothing is actually shared

The rule catches in-place `.sort()`/`.reverse()` on an array someone else still holds. All six mutate an array the same function just built (`picked`, `removed`, `missing`) or a fresh `readdir` result.

I initially flagged `server/index.ts:650` here as a likely real bug — `rows.sort(...)` on a function's return value. Checked it: `loadAllSessions()` does a `readdir` and builds a new array per call, as does `listRecordFilenames`. Nothing is shared, so there is no one to surprise. Correcting my own earlier read.

## Items to Confirm / Review

- **This is a judgement call about rules, not code**, so it's the kind of thing worth disagreeing with. Each rule carries its rationale inline in `eslint.config.mjs` so the decision can be revisited without re-deriving it.
- **`different-types-comparison` (17) is deliberately left on** even though it's in the same "small sonarjs rule" bucket. It flags comparisons the types make unreachable — e.g. `closeMatch.index === undefined` where `RegExpExecArray.index` is a required `number`. That's either dead code or a type narrower than reality, and both are worth draining. Just not in this batch.
- **Alternative if you'd rather not lose the coverage**: `no-alphabetical-sort` could stay on with a targeted disable at the signature/id/filename sites. I judged 24 disable comments to be worse than one documented off, but that's arguable.

## Verification

`format` / `typecheck` / `lint` / `test` / `build` all clean. The three rules report 0 findings; the remaining 260 are `no-base-to-string` (76), `no-unsafe-*` (145), `different-types-comparison` (17) and a handful of singletons — future batches.

## User Prompt

> 簡単そうなのからね / おかしなルールだったらルールをoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to prevent three problematic static-analysis warnings from being reported.
  * Added explanatory configuration notes for these exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->