### PR TITLE
chore(release): @mulmoclaude/google-plugin@0.3.1 — repair same-version drift

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/collection-plugin": "^0.13.1",
     "@mulmoclaude/core": "^0.25.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
-    "@mulmoclaude/google-plugin": "^0.3.0",
+    "@mulmoclaude/google-plugin": "^0.3.1",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
     "@mulmoclaude/mulmoscript-plugin": "^0.2.2",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/google-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Google integration tool for MulmoClaude — operates the user's locally linked Google account (Calendar now; Tasks / Drive ride the same grant later). Server-only; no Vue View.",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,7 +21,7 @@
     "test": "tsx --test test/test_*.ts"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^0.25.0"
+    "@mulmoclaude/core": "^0.25.1"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^0.4.0",


### PR DESCRIPTION
## Summary

Repairs a same-version-different-bits drift on `@mulmoclaude/google-plugin`: npm's `0.3.0` was published at `2bec67ff`, but three real changes landed on the workspace copy afterwards **without a bump** — incremental calendar sync via `syncToken` (`6cf453ca` + review fixes) and the LLM-free scheduled sync into a collection (`6a86e185`), plus the `@mulmoclaude/core` range moving to `^0.25.x`. This is exactly the drift class the bump-in-PR rule from #2186 exists to prevent (pre-existing — surfaced while porting MulmoTerminal to core 0.25.1).

## Changes

- `@mulmoclaude/google-plugin` `0.3.0` → **`0.3.1`** — a PATCH per the drift-repair policy, so every existing `^0.3.0` consumer (launcher, MulmoTerminal) resolves to the fixed bits with one copy; a minor bump would strand them on the stale npm 0.3.0.
- Its `@mulmoclaude/core` range ratchets `^0.25.0` → `^0.25.1` (the published latest) — this is the plugin's next real bump, which is when the ratchet-with-next-real-bump rule says to do it.
- Launcher dep range lockstepped to `^0.3.1`; the launcher's OWN version untouched (reserved for `/publish-mulmoclaude`).

## Gates / checks

- `launcherSync.mjs` OK, `drift.mjs` OK
- lint 0 errors / typecheck clean / build green

**Publish of 0.3.1 to npm happens after merge, on request** (until then the npm smoke state is unchanged — 0.3.0 stays latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Google plugin to version 0.3.1.
  * Aligned the plugin with the latest compatible core package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->