### PR TITLE
chore(lint): switch off different-types-comparison — its premise doesn't hold here

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -593,6 +593,19 @@ export default [
       // the same function just built (`picked`, `removed`, `missing`) or a fresh
       // `readdir` result — nothing is shared, so there is no one to surprise.
       "sonarjs/no-misleading-array-reverse": "off",
+      // `different-types-comparison` calls a comparison redundant when the types
+      // say it cannot vary. All 17 of its findings here guard a value that IS
+      // `undefined`/`null` at runtime and only looks impossible to the checker:
+      //   - `record[key] !== undefined` — `noUncheckedIndexedAccess` is off (it
+      //     is not part of `strict`), so an index read is typed as the value
+      //     type while returning undefined for a missing key.
+      //   - `JSON.stringify(v) === undefined` — the lib types say `string`, but
+      //     it does return undefined for undefined/function/symbol input.
+      //   - `headers.get(name) !== SECRET` — `get()` returns null when absent.
+      // Deleting these would strip real guards; the Telegram one is a webhook
+      // secret check, and the JSON one is followed by `.length`. The rule's
+      // premise only holds once `noUncheckedIndexedAccess` is on — revisit then.
+      "sonarjs/different-types-comparison": "off",
     },
   },
   eslintConfigPrettier,


### PR DESCRIPTION
## Summary

Read all **17** findings from `sonarjs/different-types-comparison`. Every one guards a value that is genuinely `undefined`/`null` at runtime and only *looks* impossible to the type checker. Following the rule would delete real guards — including a webhook secret check — so the rule goes off rather than the code being bent to satisfy it.

No source changes. Warnings **260 → 243**, errors stay 0.

## Why the rule misfires here

The mechanism is **`noUncheckedIndexedAccess`, which is not part of `strict`** and so is off in this repo. With it off, a `Record<string, T>` index read is typed `T` while returning `undefined` for a missing key — so every guard the rule flags is load-bearing at runtime and redundant only on paper.

Two more shapes land the same way. I checked both by running them rather than reading the signatures:

```ts
// lib types say `string`; returns undefined for undefined/function/symbol input.
// `.length` is read on the very next line.
if (JSON.stringify(value) === undefined) return "";

// `get()` returns null when the header is absent.
// This one is the Telegram webhook secret check.
if (request.headers.get(name) !== env.TELEGRAM_WEBHOOK_SECRET) throw new Error(...);

// noUncheckedIndexedAccess off → typed as T, undefined at runtime
if (record[key] !== undefined) { ... }
```

```
JSON.stringify(undefined) = undefined | typeof: undefined
JSON.stringify(fn)        = undefined | typeof: undefined
new Headers().get("x")    = null      | typeof: object
```

## Items to Confirm / Review

- **This is the fourth sonarjs rule switched off** (after #2205's three). The pattern is worth noticing: rules whose premise is "the types say this can't happen" are only as good as the type configuration. That's a reason to be sceptical of the class, not evidence that sonarjs is bad.
- **There is a real alternative here**: enabling `noUncheckedIndexedAccess` would make the rule's premise true, turn the index-read guards into genuinely-typed narrowing, and likely surface real bugs elsewhere. That's a much larger change than this PR, but it's the principled version of it — worth its own issue if there's appetite.
- **Rationale is inline in the config**, including the revisit condition, so the decision can be re-litigated without redoing the investigation.

## Verification

`format` / `typecheck` / `lint` / `test` / `build` all clean. The rule reports 0 findings; remaining backlog is 243 (`no-base-to-string` 76, `no-unsafe-*` 145, singletons 22).

## User Prompt

> A -> B

(A = this rule; B = `no-base-to-string`, the next batch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)