### PR TITLE
fix: reject non-string skill names in manageSkills instead of String()-ing them

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -399,10 +399,21 @@ async function handleManageSkillsList(): Promise<string> {
   return `Listed ${skills.length} skill${suffix}`;
 }
 
+// `args` is whatever the model emitted, so `name` can be any JSON type. These
+// three used `String(args.name ?? "")` with the stated intent of never
+// interpolating an accidental object into `/${name}` — but `String({})` is
+// exactly the "[object Object]" that would then be POSTed to the API and read
+// back to the user as a skill name. Rejecting a non-string outright is what the
+// comment always meant, and matches how `action` is read in the dispatcher.
+function skillNameArg(args: Record<string, unknown>): string {
+  if (!isNonEmptyString(args.name)) {
+    throw new Error("manageSkills: `name` must be a non-empty string");
+  }
+  return args.name;
+}
+
 async function handleManageSkillsSave(args: Record<string, unknown>): Promise<string> {
-  // Normalize name once up front so log / result messages below never
-  // interpolate an accidental object / number into `/${name}`.
-  const name = String(args.name ?? "");
+  const name = skillNameArg(args);
   const res = await postJson(
     API_ROUTES.skills.create.url,
     {
@@ -420,7 +431,7 @@ async function handleManageSkillsSave(args: Record<string, unknown>): Promise<st
 }
 
 async function handleManageSkillsUpdate(args: Record<string, unknown>): Promise<string> {
-  const name = String(args.name ?? "");
+  const name = skillNameArg(args);
   const url = `${BASE_URL}/api/skills/${encodeURIComponent(name)}?session=${encodeURIComponent(SESSION_ID)}`;
   let res: Response;
   try {
@@ -443,7 +454,7 @@ async function handleManageSkillsUpdate(args: Record<string, unknown>): Promise<
 }
 
 async function handleManageSkillsDelete(args: Record<string, unknown>): Promise<string> {
-  const name = String(args.name ?? "");
+  const name = skillNameArg(args);
   const url = `/api/skills/${encodeURIComponent(name)}?session=${encodeURIComponent(SESSION_ID)}`;
   let res: Response;
   try {

--- a/test/agent/test_mcp_smoke.ts
+++ b/test/agent/test_mcp_smoke.ts
@@ -29,6 +29,8 @@ interface JsonRpcResponse {
     capabilities?: { tools?: { listChanged?: boolean } };
     serverInfo?: { name: string };
     tools?: { name: string; description: string }[];
+    content?: { type: string; text?: string }[];
+    isError?: boolean;
   };
   error?: { code: number; message: string };
 }
@@ -156,5 +158,50 @@ describe("MCP server subprocess smoke test", () => {
     // tools/list, so an ask-mode permission check at session start never
     // hits "MCP tool mcp__mulmoclaude__handlePermission ... not found" (#1698).
     assert.ok(toolNames.includes("handlePermission"), `handlePermission not in tools: ${toolNames.join(", ")}`);
+  });
+
+  // `name` comes from the model, so it can be any JSON type. It used to be read
+  // as `String(args.name ?? "")`, which turns an object into the literal
+  // "[object Object]" — POSTed to /api/skills as a skill name and read back to
+  // the user as one. The guard must reject it before any of that.
+  //
+  // Driven through the subprocess because mcp-server.ts is an stdio entry point
+  // with no exports; there is no unit-level seam to reach the guard.
+  it("rejects a non-string skill name instead of acting on [object Object]", async () => {
+    const env: Record<string, string> = {
+      SESSION_ID: "test-smoke-bad-name",
+      PORT: "0",
+      PLUGIN_NAMES: TOOL_NAMES.manageSkills,
+    };
+
+    const responses = await sendAndReceive(
+      [
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "0.0.0" } },
+        }),
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: TOOL_NAMES.manageSkills,
+            arguments: { action: "save", name: { nested: "oops" }, description: "d", body: "b" },
+          },
+        }),
+      ],
+      env,
+    );
+
+    const call = responses.find((response) => response.id === 2);
+    assert.ok(call, `no response for tools/call: ${JSON.stringify(responses)}`);
+
+    const text = JSON.stringify(call);
+    // The guard's message, not an HTTP failure from the unreachable PORT=0 —
+    // proving it fired before the request was attempted.
+    assert.match(text, /name.{0,40}must be a non-empty string/i, `expected the name guard to fire, got: ${text.slice(0, 400)}`);
+    assert.doesNotMatch(text, /\[object Object\]/, `the object name reached the API path: ${text.slice(0, 400)}`);
   });
 });


### PR DESCRIPTION
## Summary

Next slice of the `no-base-to-string` backlog: the **3** findings in `server/agent/mcp-server.ts`, all the same shape. `args` is whatever the model emitted, so `name` can be any JSON type.

The existing comment already states the intent:

> Normalize name once up front so log / result messages below never interpolate an accidental **object** / number into `/${name}`.

`String()` achieves that for a number. For an object it produces **exactly the `"[object Object]"` the comment is trying to avoid** — which was then POSTed to `/api/skills` as the skill name, placed in the URL of the update/delete calls, and read back to the user as `Saved skill [object Object]`.

## Consistent with the file's own convention

The dispatcher immediately above already reads a sibling field the right way:

```ts
const action = typeof args.action === "string" ? args.action : "list";
```

So this isn't a new convention — `name` was the one that got `String()`. `isNonEmptyString` was already imported; empty and whitespace-only names were never valid either.

## Items to Confirm / Review

- **No unit test, and I want to flag that rather than have it found.** `mcp-server.ts` has no exports — it's a stdio entry point — so `skillNameArg` can't be imported. The existing `test/agent/test_mcp_smoke.ts` spawns the real subprocess and drives JSON-RPC, so a test would mean sending a `tools/call` with an object `name` and asserting the error. Doable, but it's a process-spawn test for an argument guard. Say the word and I'll add it; I'd rather ask than pad the suite.
- **Behaviour change**: a non-string `name` now throws (surfacing to the model as a tool error it can correct) instead of silently operating on `"[object Object]"`. That's the point, but it is a change — previously `manageSkills` would have created a skill literally named `[object Object]`.
- **Only `name` is guarded.** `description` and `body` still pass through as `unknown` to the API, which validates them server-side. Left alone deliberately — they aren't interpolated into URLs or messages.

## Verification

`format` / `typecheck` / `lint` clean; the three findings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skill management validation by requiring a non-empty, non-string skill name when saving, updating, or deleting skills.
  - Invalid or missing names now return a clear validation error instead of being silently coerced into empty text.
- **Tests**
  - Added a smoke test to verify the tool call rejects invalid skill-name payloads and returns the expected validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->