### PR TITLE
fix(collections): shadow-DOM-safe outside-click dismiss for the dropdown menus

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -36,7 +36,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.13.1",
+    "@mulmoclaude/collection-plugin": "^0.13.2",
     "@mulmoclaude/core": "^0.26.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.3.1",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "type": "module",
   "main": "./dist/vue.js",

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1301,8 +1301,19 @@ const activeFlagFilterCount = computed<number>(() => flagChips.value.filter((chi
 const filterMenuOpen = ref<boolean>(false);
 const filterMenuRef = ref<HTMLElement | null>(null);
 
+/** Shadow-DOM-safe "did this event land inside the element?". A document-level
+ *  listener sees `event.target` retargeted to the shadow HOST when the
+ *  component is mounted in a shadow root (MulmoTerminal's PluginFrame), so
+ *  `element.contains()` is always false there and the menu closes on the
+ *  mousedown before the inner button's click can fire. `composedPath()` still
+ *  lists the element for open shadow trees — and in the light DOM too, so both
+ *  hosts share this one test. */
+function eventInsideElement(event: Event, element: HTMLElement | null): boolean {
+  return element !== null && event.composedPath().includes(element);
+}
+
 function closeFilterMenuOnOutsideClick(event: MouseEvent): void {
-  if (!filterMenuRef.value?.contains(event.target as Node)) filterMenuOpen.value = false;
+  if (!eventInsideElement(event, filterMenuRef.value)) filterMenuOpen.value = false;
 }
 
 watch(filterMenuOpen, (open) => {
@@ -2052,7 +2063,7 @@ function onAddViewClick(): void {
 }
 
 function closeAddMenuOnOutsideClick(event: MouseEvent): void {
-  if (!addMenuRef.value?.contains(event.target as Node)) addMenuOpen.value = false;
+  if (!eventInsideElement(event, addMenuRef.value)) addMenuOpen.value = false;
 }
 
 watch(addMenuOpen, (open) => {


### PR DESCRIPTION
## Problem

The flag/boolean filter menu (#2186) works in MulmoClaude but is dead in MulmoTerminal: the Filters button opens the dropdown, but clicking any chip does nothing.

Both the filter menu and the "+" add-view menu dismiss via a document-level `mousedown` listener that tests `ref.contains(event.target)`. MulmoTerminal mounts every plugin inside a shadow root (`PluginFrame`) for CSS isolation, and shadow DOM **retargets** `event.target` to the shadow host at document level — so `contains()` is always false. The menu unmounts on the mousedown, and the chip's `click` never fires.

## Fix

Replace both checks with an `event.composedPath().includes(element)` membership test (shared `eventInsideElement` helper). `composedPath()` lists the element through open shadow trees and in the light DOM alike, so MulmoClaude's behavior is unchanged.

These were the only two `contains(event.target)` sites across `packages/plugins/*` and `packages/core`.

## Release

- `@mulmoclaude/collection-plugin` 0.13.1 → **0.13.2**; launcher dep range ratcheted to `^0.13.2` in lockstep.

## Verification

- `yarn lint` 0 errors / `yarn typecheck` / `yarn build` green
- `yarn test` 8/8
- `yarn test:e2e e2e/tests/collection-flag-filter.spec.ts` 6/6 (light-DOM path unchanged)
- Shadow-DOM path to be live-verified in MulmoTerminal after publish + bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection menus so they remain open correctly when used inside Shadow DOM components.
  * Fixed premature closing of flag filters and “add view” menus when interacting with their contents.

* **Chores**
  * Updated the collection plugin package to version 0.13.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->