### PR TITLE
docs(sandbox): document the frozen-CLI failure mode — no pin (#2202)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -183,7 +183,7 @@ You never set these by hand; the server constructs them when spawning Claude ins
 
 | Script                | Notes                                                                                                                     |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `yarn sandbox:remove` | `docker rmi mulmoclaude-sandbox` — force a rebuild on next run.                                                           |
+| `yarn sandbox:remove` | `docker rmi mulmoclaude-sandbox` — rebuild on next run. Reuses the cached layers, so it does NOT refresh the bundled Claude CLI; add `docker builder prune -a -f` for that (#2202). |
 | `yarn sandbox:login`  | macOS only. Exports the Claude CLI keychain entry to `~/.claude/.credentials.json` so the sandbox container can reuse it. |
 | `yarn sandbox:logout` | Removes that file.                                                                                                        |
 
@@ -464,6 +464,15 @@ Set `VITE_LOCALE` in `.env` and restart `yarn dev`. Supported values: `en`, `ja`
 ## Docker sandbox (`Dockerfile.sandbox`)
 
 Minimal image: `node:22-slim` + `@anthropic-ai/claude-code` + `tsx`. Built lazily on first Docker-mode run; rebuilt when `Dockerfile.sandbox` changes (image SHA pinned in code). `yarn sandbox:remove` forces a rebuild.
+
+The CLI is installed unpinned, so the image freezes whatever was latest at build time, and no upstream CLI release retriggers a rebuild (the Dockerfile SHA is unchanged). `yarn sandbox:remove` alone does not refresh it either — the rebuild reuses the cached `npm install -g` layer. To move the CLI, check what the image actually has and clear the build cache too:
+
+```bash
+docker run --rm --entrypoint claude mulmoclaude-sandbox --version
+yarn sandbox:remove && docker builder prune -a -f
+```
+
+A stale CLI here surfaces as `handlePermission not found` (versions before 2.1.206 crash on `--permission-prompt-tool` before the broker connects) — see #2202 and `packages/core/assets/helps/error-recovery.md`.
 
 **Bind mounts** (constructed by `buildDockerSpawnArgs` in `server/agent/config.ts`):
 

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -248,6 +248,8 @@ stay in sync.
   listing `/app/server/agent/mcp-server.ts`.
 - Sandbox (Docker) mode only. The broker dies **permanently** — it fails on every manual retry
   too (contrast the transient scheduler race below, which succeeds on a manual re-run).
+- Three causes share this message. Only this one names a missing module in the log; if the log
+  has no `Cannot find module`, check the scheduler race and the frozen-CLI section below.
 
 ### Cause
 
@@ -320,12 +322,65 @@ so it should be rare. It is NOT a module-resolution problem — the mounts / `di
 Just re-run the task. If it recurs often on a busy schedule, spread the tasks across different
 minutes rather than stacking them on the same one.
 
+If a manual re-run fails too, it isn't this race — check the frozen-CLI section below.
+
 ### Regression coverage
 
 `.github/workflows/docker_sandbox_windows.yaml` boots the real `mcp-server.ts` inside a Linux
 container from a Windows host (WSL2 + native `dockerd`), with the same mounts / env / argv the
 shipped builders produce, and asserts `handlePermission` comes back over the MCP handshake. See
 `docs/windows-docker-ci.md`.
+
+## Sandbox CLI frozen at an old version — `handlePermission not found` that `docker rmi` won't fix
+
+### Symptoms
+
+- The SAME `MCP tool mcp__mulmoclaude__handlePermission ... not found` message as the two
+  sections above. Sandbox (Docker) mode only.
+- Fails on cold start and the automatic replay fails with it, so it looks like the permanent
+  load failure — but the mounts and `dist` are fine.
+- The tell: the CLI **inside the image** is older than the host's. Anything before 2.1.206
+  crashes when `--permission-prompt-tool` is referenced before the broker connects, instead
+  of waiting for it.
+- Deleting the image (`yarn sandbox:remove`) and letting it rebuild leaves the version
+  unchanged.
+
+### Cause
+
+`Dockerfile.sandbox` installs the CLI unpinned (`RUN npm install -g @anthropic-ai/claude-code
+tsx`), so the image freezes whatever was latest when it was built. Two mechanisms then keep it
+frozen:
+
+1. `ensureSandboxImage()` (`server/system/docker.ts`) rebuilds only when the **Dockerfile's
+   SHA** changes. A new CLI release upstream doesn't change that SHA, so nothing retriggers.
+2. Deleting the image does not delete the **build cache**. The rebuild reuses the cached
+   `npm install -g` layer (it reports `CACHED` in 0.0s) and reinstalls nothing.
+
+So the usual "remove it and let it rebuild" reflex genuinely does nothing here, which is why
+this one burns time.
+
+### Fix
+
+Check the version inside the image — the host's `claude --version` says nothing about it, and
+the entrypoint override is required because the image's ENTRYPOINT is the sandbox script:
+
+```bash
+docker run --rm --entrypoint claude mulmoclaude-sandbox --version
+```
+
+If it's behind, drop the image AND the build cache, then let the next run rebuild:
+
+```bash
+yarn sandbox:remove          # docker rmi mulmoclaude-sandbox
+docker builder prune -a -f   # the step that actually invalidates the npm layer
+```
+
+`docker builder prune -a -f` clears the builder cache for the whole daemon, not just this
+image, so unrelated builds are slower once afterwards. That is the cost of the fix, not a
+sign something went wrong.
+
+The CLI is deliberately left unpinned (#2202), so this can recur whenever an upstream fix
+matters to you — the check above is the way to rule it in or out.
 
 ---
 

--- a/plans/fix-sandbox-cli-staleness-error-recovery.md
+++ b/plans/fix-sandbox-cli-staleness-error-recovery.md
@@ -1,0 +1,74 @@
+# fix(sandbox): document the frozen-CLI failure mode (no pin)
+
+Issue: #2202 — the sandbox image freezes an unpinned Claude CLI, and `docker rmi`
+alone cannot refresh it.
+
+## Scope decision
+
+Issue #2202 proposes two remedies. **Only remedy 2 (documentation) is in scope.**
+
+- ❌ Remedy 1 — pin `@anthropic-ai/claude-code` / `tsx` in `Dockerfile.sandbox`.
+  Explicitly dropped by the requester. Pinning would trade a silently-stale CLI for a
+  silently-outdated pin that only moves when someone edits the Dockerfile, and it makes
+  every upstream CLI fix wait on a repo change.
+- ✅ Remedy 2 — make the failure self-diagnosable: put the symptom, the cause and the real
+  recovery command where the agent and the reader will actually hit them.
+
+Consequence to state honestly: **the root cause stays live.** Users still get a frozen CLI
+until they run the recovery by hand. This PR only shortens the time from symptom to fix.
+
+## Why `docker rmi` isn't enough (the non-obvious part)
+
+`Dockerfile.sandbox:92` installs the CLI unpinned:
+
+```dockerfile
+RUN npm install -g @anthropic-ai/claude-code tsx
+```
+
+Two independent mechanisms then keep the CLI frozen:
+
+1. `ensureSandboxImage()` (`server/system/docker.ts:87-106`) rebuilds only when the
+   **Dockerfile SHA** changes. A new upstream CLI release does not change that SHA.
+2. Deleting the image does **not** delete the build cache. A rebuild after `docker rmi`
+   reuses the cached `npm install -g` layer (`CACHED`, 0.0s) and reinstalls nothing.
+   Only `docker builder prune -a -f` invalidates it.
+
+`docs/developer.md` currently asserts the opposite in two places — that
+`yarn sandbox:remove` "forces a rebuild". That guidance is what sends users in circles,
+so correcting it is the highest-value part of this change.
+
+## Bug-family context
+
+`handlePermission not found` is a known family with a committed matrix
+(`plans/mcp-broker-availability-matrix.md`): Layer 1 = mount/resolution (cases A–I,
+fixed), Layer 2 = startup race (J–L, fixed). This is a **third, distinct** root cause:
+the CLI binary in the image predates the upstream fix (v2.1.206) for the cold-start
+`--permission-prompt-tool` crash. Per the repo's bug-family rule, it gets a row in the
+matrix rather than living only in a PR description.
+
+## Changes
+
+1. `packages/core/assets/helps/error-recovery.md` — new section keyed by the error string,
+   with the in-image version check and the prune-based recovery. Cross-link the two
+   existing sections that share the string so the agent can tell the three apart.
+2. `docs/developer.md` — correct both claims that `docker rmi` / `yarn sandbox:remove`
+   forces a rebuild (L186 table row, L466 sandbox section).
+3. `plans/mcp-broker-availability-matrix.md` — add Layer 3 with this case, marked
+   DOCUMENTED (not fixed), so the matrix doesn't read as "family fully closed".
+No version bump here. `assets/helps/*` ships to npm with `@mulmoclaude/core`, so this content
+does need a release to reach users — but the bump is being raised separately, so this PR leaves
+`packages/core/package.json` and the launcher's dep range untouched. **The docs land in the repo
+but do not reach installed users until that release goes out.**
+
+## Verification
+
+- `docker run --rm --entrypoint claude mulmoclaude-sandbox --version` — verified on a real
+  image before documenting it (returned `2.1.214 (Claude Code)`); the entrypoint override
+  is required because the image's ENTRYPOINT is `/sandbox-entrypoint.sh`.
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn check:launcher-sync`.
+
+## Out of scope
+
+Pinning (remedy 1), and any change to `ensureSandboxImage()`'s rebuild trigger. If the
+frozen CLI keeps biting users, the follow-up is a staleness *check* (compare in-image
+version against npm's latest and warn) rather than a pin — but that's a new issue.

--- a/plans/mcp-broker-availability-matrix.md
+++ b/plans/mcp-broker-availability-matrix.md
@@ -6,7 +6,7 @@ agent loses **every** `mcp__mulmoclaude__*` tool at once, so the CLI reports the
 missing `--permission-prompt-tool mcp__mulmoclaude__handlePermission` rather than
 the real cause. One symptom, many causes — this table keeps them straight.
 
-Two layers:
+Three layers:
 
 - **Layer 1 — broker dies at LOAD** (permanent `MODULE_NOT_FOUND`; fails on every
   manual retry). A dependency the broker imports is unreachable inside the mount
@@ -14,6 +14,9 @@ Two layers:
 - **Layer 2 — broker loses the STARTUP RACE** (transient; succeeds on a manual
   retry). The broker boots too slowly to connect before the CLI's first tool call.
   Timing → mitigated, not eliminated.
+- **Layer 3 — the CLI in the image is STALE** (permanent until the user clears the
+  Docker build cache). Our side is healthy; the consumer of the broker is an old
+  binary that predates the upstream fix. Environmental → documented, not fixed.
 
 ## Layer 1 — mount / resolution (permanent). Status: FIXED + TESTED
 
@@ -78,6 +81,26 @@ dispatch failure is still recorded immediately, but a successful dispatch record
 (and real duration) from the turn's completion hook. `finalizeRun` fires the one-shot completion
 hook for visible origins too (it was hidden-worker-only), a no-op when none is registered.
 
+## Layer 3 — stale CLI in the sandbox image (permanent). Status: DOCUMENTED, NOT FIXED
+
+| #   | Trigger                                                                                                                        | Platform | Fix                                                                       | Test                              | Status                     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------- | --------------------------------- | -------------------------- |
+| M   | `Dockerfile.sandbox` installs `@anthropic-ai/claude-code` unpinned; the image freezes it and no upstream release retriggers a rebuild (`ensureSandboxImage()` keys on the Dockerfile SHA). CLI < 2.1.206 crashes on `--permission-prompt-tool` before the broker connects (#2202, surfaced by #2201) | any      | none in-repo — user runs `yarn sandbox:remove && docker builder prune -a -f` | none (environmental, not in CI)   | **DOCUMENTED (no code fix)** |
+
+### M — why deleting the image isn't enough
+
+`docker rmi` drops the image but not the **build cache**, so the rebuild reuses the cached
+`npm install -g` layer (`CACHED`, 0.0s) and reinstalls nothing. Only `docker builder prune -a -f`
+invalidates it. Diagnose with `docker run --rm --entrypoint claude mulmoclaude-sandbox --version`
+— the host's `claude --version` says nothing about what's in the image.
+
+Pinning the CLI was proposed (#2202 remedy 1) and **deliberately declined**: it trades a silently
+stale CLI for a silently outdated pin, and makes every upstream fix wait on a repo edit. The
+consequence is accepted — this case stays live and is handled by documentation
+(`packages/core/assets/helps/error-recovery.md`, `docs/developer.md`). If it keeps costing users
+time, the better follow-up is a staleness *check* (warn when the in-image version is behind npm's
+latest), not a pin.
+
 ## Verdict
 
 - **Layer 1 is done and regression-locked** across every platform × layout × mode combination
@@ -85,6 +108,9 @@ hook for visible origins too (it was hidden-worker-only), a no-op when none is r
 - **Layer 2 is done and tested:** J (stagger) cuts multi-task contention, K (retry) self-recovers
   the single-task race that stagger can't touch, L (honest logging) makes any residual failure
   visible instead of a false success. All three ship with regression tests.
+- **Layer 3 (M) is open by choice** — no code fix, documented recovery only. The family is
+  therefore *not* fully closed; a `handlePermission not found` report that survives a manual
+  retry and shows no `Cannot find module` should be checked against M before reopening A–L.
 
 ## Residual note
 


### PR DESCRIPTION
## Summary

サンドボックスイメージ内の Claude CLI が凍結して `handlePermission not found` を出し続ける問題 (#2202) について、**対策案2（ドキュメント）のみ**を実施。**pin（対策案1）は依頼により見送り**。

そのため **根本原因は残ります**。ユーザーは手動復旧が必要なままで、本PRの効果は「症状→復旧までの時間短縮」だけです。

一番効くのは実は `docs/developer.md` の訂正でした。2箇所で「`yarn sandbox:remove` が再ビルドを強制する」と**誤った案内**をしており、これがユーザーを堂々巡りさせる原因になっていました。

## Items to Confirm / Review

レビューで特に見てほしい点:

1. **pin を見送った割り切りの是非** — 根本原因が残ることを許容する判断で良いか。plan には代替案として「pin ではなく staleness *チェック*（イメージ内バージョンが npm 最新より古ければ警告）」を別issue候補として記載しています。
2. **version bump を含めていません** — `assets/helps/*` は `@mulmoclaude/core` として npm に載るため、**この内容がインストール済みユーザーに届くには別途リリースが必要**です。bump は別途上げる方針との指示によるものですが、リリースされるまで in-repo のみである点をご確認ください。
3. **matrix を「未クローズ」に変更した点** — 既存ファミリーは Layer 1/2 とも FIXED でしたが、今回 Layer 3 (case M) を `DOCUMENTED, NOT FIXED` として追加し、Verdict も「完全にはクローズしていない」に改めました。この表現で良いか。
4. **記載コマンドは実機検証済み** — `docker run --rm --entrypoint claude mulmoclaude-sandbox --version` は実イメージで確認 (`2.1.214 (Claude Code)` を返却)。`--entrypoint` の上書きが必要なのはイメージの ENTRYPOINT が `/sandbox-entrypoint.sh` のためです。推測では書いていません。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2202 pinはなしで、エラーメッセージのフォローを。
- bumpは、、しなくてよい。別途上げるので。

## 原因（なぜ `docker rmi` では直らないか）

`Dockerfile.sandbox:92` が CLI を未 pin でインストールするため、イメージはビルド時点の最新版で凍結されます。そのうえで2つの独立した機構が凍結を維持します:

1. `ensureSandboxImage()` (`server/system/docker.ts:87-106`) は **Dockerfile の SHA** が変わった時だけ再ビルドする。CLI の上流リリースでは SHA が変わらないため再ビルドが走らない。
2. イメージを消しても **ビルドキャッシュは消えない**。再ビルドは `npm install -g` レイヤーをキャッシュ再利用し (`CACHED` 0.0s)、何も再インストールしない。無効化には `docker builder prune -a -f` が必要。

CLI 2.1.206 未満は broker 接続前に `--permission-prompt-tool` を参照してクラッシュするため、症状は `handlePermission not found` になります。

## 変更内容

| ファイル | 内容 |
|---|---|
| `packages/core/assets/helps/error-recovery.md` | エラー文言をキーにした新セクション。イメージ内バージョン確認コマンド + prune による復旧手順。同じ文言を出す既存2セクションに判別用の一行を追加し、3つの原因を切り分け可能に |
| `docs/developer.md` | L186 / L466 の「`docker rmi` で再ビルドを強制できる」という誤った案内を訂正 |
| `plans/mcp-broker-availability-matrix.md` | bug-family ルールに従い Layer 3 / case M を追加。`DOCUMENTED, NOT FIXED` と明記 |
| `plans/fix-sandbox-cli-staleness-error-recovery.md` | plan（スコープ判断と却下理由を記録） |

`error-recovery.md` を選んだ理由: agent はツール失敗時にユーザーへ質問する**前に**このファイルを読むため、PR説明や docs だけに書いた know-how は agent から見えません（CLAUDE.md の方針）。

## 検証

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn check:launcher-sync` — すべて EXIT=0
- 記載コマンドは実イメージで動作確認済み

> 補足: 作業中 typecheck が `@duckdb/node-api` 未解決で一度落ちましたが、core の package.json を HEAD に戻しても同じ失敗を確認したため本変更とは無関係で、node_modules の不整合（宣言済み・未インストール）でした。`yarn install` で復旧し、`yarn.lock` は無変更です。

Closes #2202

> pin（対策案1）は「実施しない」方針で確定。本PRのドキュメント対応をもって issue はクローズします。frozen-CLI 自体は環境要因として残り、復旧は手動（上記手順）です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


