### PR TITLE
fix: stop the accounting router stringifying action args past the service guard

### DIFF
--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -86,7 +86,7 @@ async function handleOpenBook(rest: ActionRest): Promise<OpenBookToolResult> {
 }
 
 async function handleGetReport(rest: ActionRest): Promise<unknown> {
-  const kind = String(rest.kind ?? "");
+  const kind = typeof rest.kind === "string" ? rest.kind : "";
   const periodInput = rest.period as { kind: "month"; period: string } | { kind: "range"; from: string; to: string } | undefined;
   const bookId = rest.bookId as string | undefined;
   if (kind === "balance") {
@@ -118,7 +118,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
     // `data` carries it like every other write action — the View
     // uses it to preselect the new book on mount.
     const result = await createBook({
-      name: String(rest.name ?? ""),
+      name: typeof rest.name === "string" ? rest.name : "",
       currency: typeof rest.currency === "string" ? rest.currency : undefined,
       country: typeof rest.country === "string" ? rest.country : undefined,
       // Passed through raw — the service coerces + validates it (number,
@@ -129,7 +129,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   },
   [ACCOUNTING_ACTIONS.updateBook]: async (rest) => {
     const result = await updateBook({
-      bookId: String(rest.bookId ?? ""),
+      bookId: typeof rest.bookId === "string" ? rest.bookId : "",
       name: typeof rest.name === "string" ? rest.name : undefined,
       country: typeof rest.country === "string" ? rest.country : undefined,
       // Passed through raw — the service coerces + validates it.
@@ -137,7 +137,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
     });
     return { bookId: result.book.id, ...result };
   },
-  [ACCOUNTING_ACTIONS.deleteBook]: (rest) => deleteBook({ bookId: String(rest.bookId ?? ""), confirm: rest.confirm === true }),
+  [ACCOUNTING_ACTIONS.deleteBook]: (rest) => deleteBook({ bookId: typeof rest.bookId === "string" ? rest.bookId : "", confirm: rest.confirm === true }),
   [ACCOUNTING_ACTIONS.getAccounts]: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
   [ACCOUNTING_ACTIONS.upsertAccount]: (rest) =>
     upsertAccount({
@@ -154,7 +154,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   [ACCOUNTING_ACTIONS.voidEntry]: (rest) =>
     voidEntry({
       bookId: rest.bookId as string | undefined,
-      entryId: String(rest.entryId ?? ""),
+      entryId: typeof rest.entryId === "string" ? rest.entryId : "",
       reason: rest.reason as string | undefined,
       voidDate: rest.voidDate as string | undefined,
     }),
@@ -169,7 +169,7 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   [ACCOUNTING_ACTIONS.setOpeningBalances]: (rest) =>
     setOpeningBalances({
       bookId: rest.bookId as string | undefined,
-      asOfDate: String(rest.asOfDate ?? ""),
+      asOfDate: typeof rest.asOfDate === "string" ? rest.asOfDate : "",
       lines: (rest.lines ?? []) as never,
       memo: rest.memo as string | undefined,
     }),

--- a/packages/plugins/accounting-plugin/test/accounting/test_service.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_service.ts
@@ -61,6 +61,35 @@ describe("createBook id validation", () => {
   });
 });
 
+// The service rejects a non-string name — but only if it still looks non-string
+// by the time it gets here. The router used to read `String(rest.name ?? "")`,
+// which turns `{}` into "[object Object]": a perfectly non-empty string that
+// sails past this guard and names the book that. These pin the guard so it
+// stays the thing a caller must not defeat.
+describe("createBook name validation", () => {
+  it("rejects a missing or blank name", async () => {
+    const root = makeTmp();
+    await assert.rejects(() => createBook({ name: "" }, root), AccountingError);
+    await assert.rejects(() => createBook({ name: "   " }, root), AccountingError);
+  });
+
+  it("rejects a non-string name rather than stringifying it", async () => {
+    const root = makeTmp();
+    for (const notAName of [{ nested: true }, ["a"], 42, null]) {
+      await assert.rejects(() => createBook({ name: notAName as unknown as string }, root), AccountingError, `should reject ${JSON.stringify(notAName)}`);
+    }
+  });
+
+  it("would have accepted the stringified form — which is why the router must not stringify", async () => {
+    const root = makeTmp();
+    // Documents the hole rather than asserting a wrong behaviour: this string
+    // IS valid as far as the service is concerned, so the only defence is the
+    // caller passing the value through untouched.
+    const result = await createBook({ name: String({ nested: true }) }, root);
+    assert.equal(result.book.name, "[object Object]");
+  });
+});
+
 describe("upsertAccount synthetic-code guard", () => {
   it("rejects account codes starting with _ (reserved for synthetic rows)", async () => {
     const root = makeTmp();


### PR DESCRIPTION
## Summary

Next slice: the **6** `no-base-to-string` findings in `accounting-plugin/src/server/router.ts`. One of them is a real hole, and it has a shape worth naming.

## The service guard was already there

```ts
// service.ts — createBook
if (typeof input.name !== "string" || input.name.trim() === "") {
  throw new AccountingError(400, "name is required");
}
```

The router handed it `String(rest.name ?? "")`. An object arrives as `"[object Object]"` — a perfectly non-empty string — so **the guard passes and the book is created under that name**.

The defence was written correctly. The caller undid it.

This is the same shape as the dead `typeof rawPath !== "string"` check in `workspace/custom-dirs.ts` from #2210: a validator that can never fire because everything reaching it has already been coerced to a string. Two instances now, in unrelated subsystems — `String()` at a boundary doesn't just lose information, it defeats the check downstream.

## Not a new convention

All six move to `typeof x === "string" ? x : ""` — the form **this same file already uses**, sometimes one line away:

```ts
name: String(rest.name ?? ""),                                    // was
currency: typeof rest.currency === "string" ? rest.currency : undefined,  // already correct
```

The outliers now match their neighbours.

## Items to Confirm / Review

- **Impact varies by field, and only one mattered.** `bookId` / `entryId` / `asOfDate` become lookups that miss, so the service 404s either way — those six findings are mostly hygiene. `createBook`'s `name` is the one that silently succeeded. I'd rather say that plainly than imply all six were live bugs.
- **The third test documents the hole instead of asserting around it:**
  ```ts
  const result = await createBook({ name: String({ nested: true }) }, root);
  assert.equal(result.book.name, "[object Object]");
  ```
  That's deliberate — `"[object Object]"` genuinely is a valid name at the service layer, so the only defence is callers not stringifying. If you'd rather the service also rejected that literal, say so and I'll add it there instead; I didn't want to blocklist a string that a user could conceivably type.
- **`String(...)` remains elsewhere in the plugin** where the rule didn't flag it (typed bindings). Same reasoning would apply; out of scope here.

## Verification

`lint` / `typecheck` / `test` clean, 33/33 in the accounting service suite. Findings in `accounting-plugin`: 6 → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accounting request validation by rejecting non-string values instead of converting them automatically.
  * Added stricter validation for report types, book names and IDs, entry IDs, and opening-balance dates.
  * Prevented invalid book names, including blank and non-text values, from being accepted.

* **Tests**
  * Added coverage for invalid and missing book names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->