### PR TITLE
fix(whisper): drop YouTube-caption hallucinations from voice input

### DIFF
--- a/packages/core/src/whisper/whisper.ts
+++ b/packages/core/src/whisper/whisper.ts
@@ -43,9 +43,72 @@ export interface Whisper {
 // empty so the UI shows "didn't catch that" rather than a literal marker.
 const BLANK_MARKERS = new Set(["[blank_audio]", "[silence]", "(silence)", "[ inaudible ]"]);
 
-function normalizeTranscript(raw: string): string {
+// Whisper was trained on YouTube-style captions, so on near-silent / non-speech
+// segments it hallucinates the boilerplate that ends such videos ("thanks for
+// watching", "please subscribe", …). These arrive as real-looking text, so the
+// BLANK_MARKERS set alone won't catch them. We drop a segment only when its
+// ENTIRE content (after stripping punctuation and de-duplicating repeats) is one
+// of these phrases — genuine speech that merely contains the phrase survives.
+const HALLUCINATION_PHRASES = new Set([
+  // Japanese (the ones the user actually hit come first)
+  "ご視聴ありがとうございました",
+  "ご視聴ありがとうございます",
+  "ご視聴いただきありがとうございました",
+  "ご視聴いただきありがとうございます",
+  "最後までご視聴いただきありがとうございました",
+  "最後までご視聴いただきありがとうございます",
+  "ありがとうございました",
+  "ありがとうございます",
+  "またお会いしましょう",
+  "また次回お会いしましょう",
+  "次回もお楽しみに",
+  "チャンネル登録をお願いします",
+  "チャンネル登録よろしくお願いします",
+  "おやすみなさい",
+  // English equivalents whisper emits in the same situation
+  "thank you",
+  "thank you for watching",
+  "thanks for watching",
+  "please subscribe",
+  "thank you very much",
+  "you",
+]);
+
+// Punctuation + whitespace whisper may add around a hallucinated phrase. We
+// strip ALL of it (including internal spaces) before matching so multi-word
+// English phrases like "thank you for watching" compare cleanly against a
+// space-free canonical form; Japanese phrases have no spaces so are unaffected.
+const NOISE_CHARS = /[。、．，！？.!?…\s]+/g;
+
+function canonical(s: string): string {
+  return s.replace(NOISE_CHARS, "").toLowerCase();
+}
+
+/** Collapse the transcript to its "meaningful" core so a segment that is nothing
+ *  but hallucinated boilerplate (possibly repeated, possibly punctuated) reduces
+ *  to the empty string and gets dropped. */
+function isPureHallucination(trimmed: string): boolean {
+  let remaining = canonical(trimmed);
+  if (remaining.length === 0) return false;
+  const phrases = [...HALLUCINATION_PHRASES].map(canonical).sort((a, b) => b.length - a.length);
+  let changed = true;
+  while (changed && remaining.length > 0) {
+    changed = false;
+    for (const phrase of phrases) {
+      while (remaining.startsWith(phrase)) {
+        remaining = remaining.slice(phrase.length);
+        changed = true;
+      }
+    }
+  }
+  return remaining.length === 0;
+}
+
+export function normalizeTranscript(raw: string): string {
   const trimmed = raw.trim().replace(/\s+/g, " ");
-  return BLANK_MARKERS.has(trimmed.toLowerCase()) ? "" : trimmed;
+  if (BLANK_MARKERS.has(trimmed.toLowerCase())) return "";
+  if (isPureHallucination(trimmed)) return "";
+  return trimmed;
 }
 
 export function createWhisper(opts: WhisperOptions): Whisper {

--- a/packages/core/test/whisper/test_normalize_transcript.ts
+++ b/packages/core/test/whisper/test_normalize_transcript.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeTranscript } from "../../src/whisper/whisper.ts";
+
+describe("normalizeTranscript", () => {
+  it("trims and collapses internal whitespace", () => {
+    assert.equal(normalizeTranscript("  hello   world  "), "hello world");
+  });
+
+  it("drops whisper.cpp blank sentinels", () => {
+    assert.equal(normalizeTranscript("[blank_audio]"), "");
+    assert.equal(normalizeTranscript("(silence)"), "");
+    assert.equal(normalizeTranscript("[ inaudible ]"), "");
+  });
+
+  it("drops the classic Japanese YouTube-caption hallucinations", () => {
+    assert.equal(normalizeTranscript("ご視聴ありがとうございました"), "");
+    assert.equal(normalizeTranscript("ご視聴ありがとうございました。"), "");
+    assert.equal(normalizeTranscript("またお会いしましょう"), "");
+    assert.equal(normalizeTranscript("チャンネル登録をお願いします"), "");
+  });
+
+  it("drops repeated / punctuated hallucination runs", () => {
+    assert.equal(normalizeTranscript("ご視聴ありがとうございました。ご視聴ありがとうございました。"), "");
+    assert.equal(normalizeTranscript("ありがとうございました、ありがとうございました！"), "");
+  });
+
+  it("drops the English equivalents", () => {
+    assert.equal(normalizeTranscript("Thank you for watching."), "");
+    assert.equal(normalizeTranscript("Please subscribe!"), "");
+  });
+
+  it("keeps genuine speech that merely contains a boilerplate phrase", () => {
+    assert.equal(normalizeTranscript("動画をご視聴ありがとうございました、では本題に入ります"), "動画をご視聴ありがとうございました、では本題に入ります");
+    assert.equal(normalizeTranscript("会議の時間を教えて"), "会議の時間を教えて");
+    assert.equal(normalizeTranscript("Thank you for the report, can you resend it?"), "Thank you for the report, can you resend it?");
+  });
+});


### PR DESCRIPTION
Whisper was trained on YouTube-style captions, so on near-silent or
non-speech segments it hallucinates the boilerplate that ends such
videos ("ご視聴ありがとうございました", "thank you for watching", …).
These arrived as real-looking text and slipped past the BLANK_MARKERS
sentinel filter, landing in the chat input.

normalizeTranscript now drops a segment when its ENTIRE content — after
stripping punctuation/whitespace and collapsing repeats — is one of a
known set of hallucination phrases (JA + EN). Genuine speech that merely
contains such a phrase (e.g. "動画をご視聴ありがとうございました、では本題に…")
survives because the remainder is non-empty.

Exports normalizeTranscript and adds unit coverage.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript cleanup by filtering out blank-audio markers, silence indicators, and recognized hallucinated boilerplate.
  * Handles repeated, punctuated, and multilingual variants more reliably.
  * Preserves genuine speech when boilerplate appears alongside meaningful content.

* **Tests**
  * Added coverage for whitespace normalization, empty-output detection, and preservation of valid transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->