### PR TITLE
fix: make collection id lookups agree on how a field becomes text

### DIFF
--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -16,6 +16,7 @@
 // `field.type === "enum"` (etc.) before reading a variant key like `values`,
 // `to`, `formula`, or `of`.
 
+import { fieldText } from "./fieldText";
 import type { z } from "zod";
 import type {
   ActionSpecZ,
@@ -272,6 +273,6 @@ export type CollectionItem = Record<string, unknown>;
 export function embedTargetId(field: CollectionFieldSpec, record: CollectionItem | null): string {
   if (field.type !== "embed") return "";
   if (field.id) return field.id;
-  if (field.idField && record) return String(record[field.idField] ?? "");
+  if (field.idField && record) return fieldText(record[field.idField]);
   return "";
 }

--- a/packages/core/src/collection/server/derive.ts
+++ b/packages/core/src/collection/server/derive.ts
@@ -11,6 +11,7 @@ import { deriveAll, type DeriveRefRecords } from "../core/deriveAll";
 import { loadCollection, type DiscoveryOptions } from "./discovery";
 import type { LoadedCollection } from "./discoveredCollection";
 import { storeFor } from "./store";
+import { fieldText } from "../core/fieldText";
 import { embedTargetId } from "../core/schema";
 import type { CollectionFieldSpec, CollectionItem, CollectionSchema } from "../core/schema";
 
@@ -113,7 +114,7 @@ function projectBacklinks(
 function projectComputed(schema: CollectionSchema, enriched: CollectionItem, linked: Record<string, LinkedTarget>): CollectionItem {
   for (const [key, field] of Object.entries(schema.fields)) {
     if (field.type === "toggle" && field.field) {
-      enriched[key] = String(enriched[field.field] ?? "") === field.onValue;
+      enriched[key] = fieldText(enriched[field.field]) === field.onValue;
     }
     if (field.type === "embed" && field.to) {
       const targetId = embedTargetId(field, enriched);

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts
@@ -4,7 +4,7 @@
 // function of its arguments. The composable imports these and calls them
 // from inside its computed/watch closures; behaviour is identical.
 
-import { deriveAll } from "@mulmoclaude/core/collection";
+import { deriveAll, fieldText } from "@mulmoclaude/core/collection";
 import type {
   CollectionDetailResponse,
   CollectionItem,
@@ -45,8 +45,8 @@ export function isExternalUrl(value: unknown): boolean {
 }
 
 export function detailText(value: unknown): string {
-  if (value === undefined || value === null || value === "") return EM_DASH;
-  return String(value);
+  const text = fieldText(value, EM_DASH);
+  return text === "" ? EM_DASH : text;
 }
 
 export function formatCell(value: unknown, type: FieldType): string {
@@ -75,7 +75,7 @@ export function resolveCurrency(field: FieldSpec, record: CollectionItem | null 
 export function formatMoney(value: unknown, currency: string | undefined, displayLocale: string): string {
   if (value === undefined || value === "") return EM_DASH;
   const amount = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(amount)) return String(value);
+  if (!Number.isFinite(amount)) return fieldText(value, EM_DASH);
   const currencyCode = currency && currency.length > 0 ? currency : DEFAULT_CURRENCY;
   try {
     return new Intl.NumberFormat(displayLocale, { style: "currency", currency: currencyCode }).format(amount);
@@ -193,7 +193,7 @@ export function buildEmbedOptions(schema: CollectionSchema, items: CollectionIte
   const displayField = displayFieldFor(fields, primaryKey);
   return items
     .map((item) => {
-      const slug = String(item[primaryKey] ?? "");
+      const slug = fieldText(item[primaryKey]);
       const labelRaw = item[displayField];
       const display = typeof labelRaw === "string" && labelRaw.length > 0 ? labelRaw : slug;
       return { slug, display };

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.renderers.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.renderers.ts
@@ -5,7 +5,7 @@
 // can wire them with thin closures while they stay unit-testable in isolation.
 // NO vue / DOM / I/O / reactive state here — every function is pure.
 
-import { backlinkRows, deriveAll, embedTargetId, rollupValue } from "@mulmoclaude/core/collection";
+import { backlinkRows, deriveAll, embedTargetId, fieldText, rollupValue } from "@mulmoclaude/core/collection";
 import type {
   BacklinksView,
   CollectionItem,
@@ -56,7 +56,7 @@ export function resolveEmbed(
   const targetId = embedTargetId(field, record);
   const data = targetId ? embedCache[field.to] : undefined;
   if (!data) return { schema: null, item: null };
-  const item = data.items.find((entry) => String(entry[data.schema.primaryKey] ?? "") === targetId) ?? null;
+  const item = data.items.find((entry) => fieldText(entry[data.schema.primaryKey]) === targetId) ?? null;
   return { schema: data.schema, item };
 }
 
@@ -131,7 +131,7 @@ export function buildBacklinksViews(
       continue;
     }
     for (const column of columns) column.label = data.schema.fields[column.key]?.label ?? column.key;
-    const selfId = String(record?.[schema.primaryKey] ?? "");
+    const selfId = fieldText(record?.[schema.primaryKey]);
     // Index the derived source records EXACTLY like the server's
     // `loadTarget` (shared memo over `derivedRecordsById`): non-empty
     // string ids, one record per id — so the client can never surface a
@@ -139,7 +139,7 @@ export function buildBacklinksViews(
     // every rendered row is navigable with a unique Vue key.
     const sourceItems = derivedSourceItems(embedCache, field.from) ?? [];
     const rows = backlinkRows(field, selfId, sourceItems).map((row) => ({
-      id: String(row[data.schema.primaryKey] ?? ""),
+      id: fieldText(row[data.schema.primaryKey]),
       cells: columns.map((column) => formatBacklinkCell(data.schema.fields[column.key], row[column.key], row, locale)),
     }));
     out[key] = { found: true, columns, rows, fromSlug: field.from };
@@ -183,7 +183,7 @@ export function rollupValueFor(field: FieldSpec, record: CollectionItem | null, 
   // No empty-id guard here: an empty primaryKey matches nothing inside
   // `backlinkRows` and yields a real 0 — exactly what the server's
   // `projectRollups` returns for the same record (Codex on PR #2116).
-  return rollupValue(field, String(record[schema.primaryKey] ?? ""), items);
+  return rollupValue(field, fieldText(record[schema.primaryKey]), items);
 }
 
 /** Display string for a rollup cell: the aggregate as a plain number,

--- a/test/utils/collections/test_fieldText.ts
+++ b/test/utils/collections/test_fieldText.ts
@@ -9,7 +9,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { fieldText, fieldTextOrNull } from "@mulmoclaude/core/collection";
+import { embedTargetId, fieldText, fieldTextOrNull } from "@mulmoclaude/core/collection";
+import type { CollectionFieldSpec } from "@mulmoclaude/core/collection";
 
 describe("fieldTextOrNull", () => {
   it("returns the text of a primitive", () => {
@@ -75,5 +76,38 @@ describe("fieldText", () => {
     assert.equal(fieldText("value", "—"), "value");
     assert.equal(fieldText(0, "—"), "0");
     assert.equal(fieldText(false, "—"), "false");
+  });
+});
+
+// Identity comparisons only hold if BOTH sides derive the id the same way.
+// `embedTargetId` produces the lookup key and the renderers produce the
+// candidate key; while one used `String(...)` and the other `fieldText(...)`,
+// a non-scalar id could match on one path and not the other. These pin the two
+// together — a future edit that reintroduces `String()` on either side breaks
+// here rather than in a silently-unresolved embed.
+describe("embedTargetId agrees with fieldText on both sides of the lookup", () => {
+  const idField = (name: string): CollectionFieldSpec => ({ type: "embed", to: "other", idField: name }) as CollectionFieldSpec;
+
+  it("produces the same key as fieldText for scalars", () => {
+    for (const value of ["abc", 42, 0, true, false]) {
+      const record = { ref: value };
+      assert.equal(embedTargetId(idField("ref"), record), fieldText(value), `mismatch for ${JSON.stringify(value)}`);
+    }
+  });
+
+  it("yields no key for a value that has no text form", () => {
+    for (const value of [{ nested: true }, ["a"], null, undefined]) {
+      const record = { ref: value };
+      assert.equal(embedTargetId(idField("ref"), record), "", `expected no key for ${JSON.stringify(value)}`);
+    }
+  });
+
+  // The bug this closes: two unrelated records both stringified to
+  // "[object Object]", so an embed resolved to whichever happened to be first.
+  it("cannot make two different objects produce the same lookup key", () => {
+    assert.equal(String({ a: 1 }), String({ b: 2 })); // the trap
+    assert.equal(embedTargetId(idField("ref"), { ref: { a: 1 } }), "");
+    assert.equal(embedTargetId(idField("ref"), { ref: { b: 2 } }), "");
+    // "" is falsy, and every caller guards on it — so neither resolves at all.
   });
 });


### PR DESCRIPTION
## Summary

Routes collection-plugin's renderers onto `fieldText` (added in #2208) — **7 findings → 0** — and fixes the asymmetry that surfaced while doing it.

## The real finding: both sides of an id comparison disagreed

Four of the seven sites are identity comparisons: an embed target, a backlink self-id, a rollup self-id, a slug. Those only work if **both sides derive the key the same way**. They didn't:

```ts
// core/schema.ts — produced the LOOKUP key
if (field.idField && record) return String(record[field.idField] ?? "");

// server/derive.ts — but the index only accepted real strings
if (typeof itemId === "string" && itemId.length > 0) byId[itemId] = ...
```

So the server refused non-string ids while the plugin happily matched them — **and matched them wrongly**, since two unrelated records both stringify to `"[object Object]"` and the embed resolved to whichever came first.

Moving `embedTargetId` onto `fieldText` puts all three of its callers and the server's guard on one rule.

## Also fixed, not flagged by the linter

`derive.ts`'s toggle projection compared `String(enriched[field.field] ?? "")` against the enum's `onValue` — same shape, found while reading the neighbours.

## Where I disagreed with the review

I ran `/codex-local-review` on this before opening it. Codex flagged the embed asymmetry (correct, and it's the reason this PR grew a core change) but read **backlinks/rollup as asymmetric too — they aren't**:

```ts
export function backlinkRows(spec, recordId, sourceItems) {
  if (!recordId) return [];
  return sourceItems.filter((item) => fieldTextOrNull(item[spec.via]) === recordId && ...);
}
```

Both sides already went through the `fieldText` family after #2208, and the empty-id guard short-circuits. A **Date-valued id actually starts matching now** — previously one side rendered ISO and the other a locale string, so it could never match at all.

## Items to Confirm / Review

- **This PR touches `packages/core`, not just the plugin.** That's deliberate — fixing only the plugin side would have left the comparison mismatched in the other direction. If you'd rather keep core changes separate, I can split, but the two halves are only correct together.
- **Behaviour change for non-scalar ids**: an embed whose target id is an array/object now resolves to *nothing* instead of to an arbitrary record. I believe unresolved beats silently-wrong, but it is a change. No schema in the workspace uses a non-scalar primaryKey.
- **Scalars are a no-op** — verified: `0` → `"0"`, `false` → `"false"`, `formatMoney("abc")` → `"abc"`.

## Verification

`build:packages` / `lint` / `typecheck` / `test` all clean. Tests pin the two sides together; against the previous code:

```
✖ yields no key for a value that has no text form
✖ cannot make two different objects produce the same lookup key
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)