### PR TITLE
fix: route core collection reads through fieldText, by what the value is for

### DIFF
--- a/packages/core/src/collection/core/draft.ts
+++ b/packages/core/src/collection/core/draft.ts
@@ -4,6 +4,7 @@
 // implementation. No Vue, no I/O — every function maps a draft + schema
 // to a value, so the omission/validation semantics are unit-testable.
 
+import { fieldText } from "./fieldText";
 import { fieldVisible } from "./actionVisible";
 import { COMPUTED_TYPES } from "./schema";
 import type { CollectionFieldSpec as FieldSpec, CollectionFieldType as FieldType, CollectionItem, CollectionSchema } from "./schema";
@@ -42,7 +43,7 @@ export function rowFromItem(item: Record<string, unknown>, subFields: Record<str
       boolOriginallyPresent[subKey] = typeof raw === "boolean";
       boolTouched[subKey] = false;
     } else {
-      text[subKey] = raw === undefined || raw === null ? "" : String(raw);
+      text[subKey] = fieldText(raw);
     }
   }
   return { text, bool, boolOriginallyPresent, boolTouched };

--- a/packages/core/src/collection/core/dynamicIcon.ts
+++ b/packages/core/src/collection/core/dynamicIcon.ts
@@ -6,13 +6,14 @@
 // (`packages/core/src/collection/server/dynamicIcon.ts`) loads the source
 // collection's records and calls these.
 
+import { fieldText } from "./fieldText";
 import { matchesWhere } from "./where";
 import type { CollectionFieldSpec, CollectionItem, CollectionSchema, DynamicIconSource, DynamicIconSpec } from "./schema";
 
 /** The record with the greatest `String(record[field])` (localeCompare) —
  *  ties keep the first-seen record (stable left-to-right `reduce`). */
 function latestByField(pool: CollectionItem[], field: string): CollectionItem {
-  return pool.reduce((latest, candidate) => (String(candidate[field] ?? "").localeCompare(String(latest[field] ?? "")) > 0 ? candidate : latest));
+  return pool.reduce((latest, candidate) => (fieldText(candidate[field]).localeCompare(fieldText(latest[field])) > 0 ? candidate : latest));
 }
 
 /** Reduce `records` to the one record that decides the effective icon, per

--- a/packages/core/src/collection/core/enumColors.ts
+++ b/packages/core/src/collection/core/enumColors.ts
@@ -15,7 +15,7 @@
 // (red = urgent, amber = nudge) rather than the rotating palette.
 // `resolveEnumColor` encapsulates that rule.
 
-import { fieldTextOrNull } from "./fieldText";
+import { fieldText, fieldTextOrNull } from "./fieldText";
 import type { CollectionSchema } from "./schema";
 
 export interface EnumColorClasses {
@@ -125,7 +125,7 @@ function notifyValuesFor(schema: CollectionSchema, fieldKey: string): readonly s
 export function resolveEnumColor(schema: CollectionSchema, fieldKey: string, value: unknown): EnumColorClasses {
   const notifyValues = notifyValuesFor(schema, fieldKey);
   if (notifyValues) {
-    const str = value === undefined || value === null ? "" : String(value);
+    const str = fieldText(value);
     const rank = notifyValues.indexOf(str);
     if (rank < 0) return ENUM_NEUTRAL;
     return rank === 0 ? ENUM_ALERT : ENUM_NUDGE;

--- a/packages/core/src/collection/core/itemLabel.ts
+++ b/packages/core/src/collection/core/itemLabel.ts
@@ -2,6 +2,7 @@
 // grid + day view), so both label a record identically. Pure, type-only
 // dependency on the schema shape.
 
+import { fieldText } from "./fieldText";
 import type { CollectionItem, CollectionSchema } from "./schema";
 
 // Text-like field types that make a sensible human-readable label.
@@ -21,7 +22,7 @@ export function labelFieldFor(schema: CollectionSchema): string | null {
 
 /** A record's primary-key value as a string. */
 export function itemIdOf(item: CollectionItem, schema: CollectionSchema): string {
-  return String(item[schema.primaryKey] ?? "");
+  return fieldText(item[schema.primaryKey]);
 }
 
 /** A record's display label: the resolved `labelField` value, else the

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -16,6 +16,7 @@
 // `CollectionSchemaZ`). Runtime imports here point only at `./schema`'s
 // consts, so the module graph stays acyclic: schemaZ → schema.
 
+import { fieldTextOrNull } from "./fieldText";
 import { z } from "zod";
 import { isSafeSlug, isSafeRecordId } from "./ids";
 import { paramRefName } from "./mutateAction";
@@ -748,7 +749,8 @@ function fieldDrivenFromFieldCarried(schema: FieldDrivenSchemaView): boolean {
   if (set && Object.prototype.hasOwnProperty.call(set, driven.fromField)) {
     const raw = set[driven.fromField];
     if (raw === undefined || raw === null || raw === "") return false;
-    return Object.prototype.hasOwnProperty.call(driven.map, String(raw));
+    const key = fieldTextOrNull(raw);
+    return key !== null && Object.prototype.hasOwnProperty.call(driven.map, key);
   }
   return (carry ?? []).includes(driven.fromField);
 }

--- a/packages/core/src/collection/server/csvStore.ts
+++ b/packages/core/src/collection/server/csvStore.ts
@@ -26,6 +26,7 @@
 // dataSource collections break — see
 // packages/core/assets/helps/error-recovery.md.
 
+import { fieldTextOrNull } from "../core/fieldText";
 import { lstat, mkdir, open, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -68,6 +69,18 @@ export function decodeCsvRecordId(itemId: string): string {
  *  (date-only when the clock is exactly UTC midnight, matching the `date`
  *  field contract), exotic DuckDB values → their string form. Pure +
  *  exported for unit tests. */
+/** `JSON.stringify` restricted to what a CSV cell can survive. Returns the
+ *  serialised value, or `String(value)` when serialisation is impossible —
+ *  losing the content of one cell is bad, failing the entire query is worse. */
+function safeJsonCell(value: object): string {
+  try {
+    const json = JSON.stringify(value, (_key, entry: unknown) => (typeof entry === "bigint" ? entry.toString() : entry));
+    return json ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
 export function normalizeCsvValue(value: unknown): unknown {
   if (typeof value === "bigint") {
     return value <= BigInt(Number.MAX_SAFE_INTEGER) && value >= BigInt(-Number.MAX_SAFE_INTEGER) ? Number(value) : value.toString();
@@ -76,7 +89,17 @@ export function normalizeCsvValue(value: unknown): unknown {
     const iso = value.toISOString();
     return iso.endsWith("T00:00:00.000Z") ? iso.slice(0, 10) : iso;
   }
-  if (value !== null && typeof value === "object") return String(value);
+  // A DuckDB STRUCT / LIST / MAP arrives as an object. `String(...)` renders it
+  // "[object Object]" — the cell's content is simply gone. Serialise instead:
+  // this is a data cell, not an id or a matcher key, so preserving what the
+  // column holds beats reducing it to a placeholder.
+  //
+  // Guarded, because `JSON.stringify` is not total on what DuckDB can hand us:
+  // it throws on a BIGINT nested in a struct (the branch above only unwraps a
+  // top-level bigint) and on a circular ref, and returns undefined when an
+  // object's `toJSON` does. A cell that cannot be serialised falls back to the
+  // old rendering rather than aborting the whole read.
+  if (value !== null && typeof value === "object") return safeJsonCell(value);
   return value;
 }
 
@@ -88,8 +111,12 @@ export function normalizeCsvValue(value: unknown): unknown {
 export function csvRowToItem(row: Record<string, unknown>, primaryKey: string): CollectionItem | null {
   const normalized = Object.fromEntries(Object.entries(row).map(([key, value]) => [key, normalizeCsvValue(value)]));
   const rawKey = normalized[primaryKey];
-  if (rawKey === null || rawKey === undefined || String(rawKey) === "") return null;
-  return { ...normalized, [primaryKey]: encodeCsvRecordId(String(rawKey)) };
+  // Identity: same rule as every other primaryKey read. `normalizeCsvValue` has
+  // already flattened objects to JSON, so anything without a text form here is
+  // genuinely unaddressable.
+  const keyText = fieldTextOrNull(rawKey);
+  if (keyText === null || keyText === "") return null;
+  return { ...normalized, [primaryKey]: encodeCsvRecordId(keyText) };
 }
 
 /** Dedupe by record id, LAST row wins (matches `csvRead`'s last-match

--- a/packages/core/src/collection/server/derive.ts
+++ b/packages/core/src/collection/server/derive.ts
@@ -103,7 +103,7 @@ function projectBacklinks(
 ): CollectionItem[] {
   const source = linked[field.from];
   if (!source) return [];
-  const selfId = String(enriched[schema.primaryKey] ?? "");
+  const selfId = fieldText(enriched[schema.primaryKey]);
   return backlinkRows(field, selfId, Object.values(source.byId)).map((row) => projectBacklinkRow(row, field.display, source.schema.primaryKey));
 }
 
@@ -140,7 +140,7 @@ function projectRollups(schema: CollectionSchema, record: CollectionItem, linked
     if (field.type !== "rollup") continue;
     if (out === record) out = { ...record };
     const source = linked[field.from];
-    const selfId = String(record[schema.primaryKey] ?? "");
+    const selfId = fieldText(record[schema.primaryKey]);
     out[key] = source ? rollupValue(field, selfId, Object.values(source.byId)) : null;
   }
   return out;

--- a/packages/core/src/collection/server/dynamicIcon.ts
+++ b/packages/core/src/collection/server/dynamicIcon.ts
@@ -3,6 +3,7 @@
 // `../core/dynamicIcon` with the one bit of I/O it needs: loading the
 // source collection's raw stored records.
 
+import { fieldText } from "../core/fieldText";
 import { firstDateField, resolveIcon, selectDynamicRecord } from "../core/dynamicIcon";
 import { loadCollection, type DiscoveryOptions } from "./discovery";
 import { storeFor } from "./store";
@@ -26,7 +27,7 @@ function buildRecordsById(items: CollectionItem[], primaryKey: string): Record<s
  *  ties pick a different record — and thus a different icon — between
  *  reconciles. A stable id sort pins one answer. */
 function sortByPrimaryKey(items: CollectionItem[], primaryKey: string): CollectionItem[] {
-  return [...items].sort((left, right) => String(left[primaryKey] ?? "").localeCompare(String(right[primaryKey] ?? "")));
+  return [...items].sort((left, right) => fieldText(left[primaryKey]).localeCompare(fieldText(right[primaryKey])));
 }
 
 /** Compute the effective launcher icon for `collection`: its static

--- a/packages/core/src/collection/server/spawn.ts
+++ b/packages/core/src/collection/server/spawn.ts
@@ -20,6 +20,7 @@
 // never drifts (it clamps per-month at compute time, not stored
 // clamped). See `advanceTriggerDate`.
 
+import { fieldTextOrNull } from "../core/fieldText";
 import { log } from "./host";
 import { errorMessage, ONE_DAY_MS } from "./util";
 import type { IoOptions } from "./io";
@@ -136,7 +137,8 @@ export function successorId(sourceId: string, next: CivilDate): string {
 function matchesWhen(when: CollectionWhen | undefined, schema: CollectionSchema, item: CollectionItem): boolean {
   if (when) {
     const raw = item[when.field];
-    return raw !== undefined && raw !== null && when.in.includes(String(raw));
+    const text = fieldTextOrNull(raw);
+    return text !== null && when.in.includes(text);
   }
   return itemIsDone(schema, item);
 }
@@ -151,7 +153,8 @@ export function resolveEvery(every: CollectionSpawnEvery, sourceItem: Collection
   if (!isFieldDrivenEvery(every)) return every;
   const raw = sourceItem[every.fromField];
   if (raw === undefined || raw === null || raw === "") return null;
-  return every.map[String(raw)] ?? null;
+  const key = fieldTextOrNull(raw);
+  return key === null ? null : (every.map[key] ?? null);
 }
 
 export interface ComputedSuccessor {

--- a/packages/core/src/collection/server/store.ts
+++ b/packages/core/src/collection/server/store.ts
@@ -41,6 +41,7 @@
 // params or message types, never change existing response shapes, never
 // let a new backend alter what an existing view observes.
 
+import { fieldText } from "../core/fieldText";
 import type { CollectionItem, CollectionStorageKind } from "../core/schema";
 import type { CollectionQuery } from "../core/queryZ";
 import { isReadOnlySchema, storageKindFor } from "../core/schema";
@@ -109,8 +110,8 @@ export interface CollectionStore {
  *  is filesystem-dependent; paging needs determinism. */
 function sortByRecordId(items: CollectionItem[], primaryKey: string): CollectionItem[] {
   return [...items].sort((left, right) => {
-    const leftId = String(left[primaryKey] ?? "");
-    const rightId = String(right[primaryKey] ?? "");
+    const leftId = fieldText(left[primaryKey]);
+    const rightId = fieldText(right[primaryKey]);
     if (leftId < rightId) return -1;
     return leftId > rightId ? 1 : 0; // 0 on equality — a comparator that never ties breaks sort's contract
   });

--- a/packages/core/src/collection/server/validate.ts
+++ b/packages/core/src/collection/server/validate.ts
@@ -6,6 +6,7 @@
 // closing the loop so the model fixes the file instead of a human noticing
 // missing rows much later.
 
+import { fieldText } from "../core/fieldText";
 import { readdir, readFile, lstat } from "node:fs/promises";
 import path from "node:path";
 import { getWorkspaceRoot, log } from "./host";
@@ -89,7 +90,7 @@ async function validateStoreRecords(collection: LoadedCollection, opts: { worksp
   const issues: RecordIssue[] = [];
   for (const item of items) {
     if (issues.length >= MAX_ISSUES) break;
-    const itemId = String(item[collection.schema.primaryKey] ?? "");
+    const itemId = fieldText(item[collection.schema.primaryKey]);
     const problem = validateRecordObject(item, itemId, collection.schema, "strict");
     if (problem) issues.push({ file: itemId, problem });
   }
@@ -134,6 +135,16 @@ async function inspectRecord(fullPath: string, name: string, schema: CollectionS
   return problem ? { file: name, problem } : null;
 }
 
+/** What a non-string primary key actually is, for the error message. Names the
+ *  shape rather than stringifying the value — "[object Object]" tells the reader
+ *  nothing about what is wrong. */
+function describeIdType(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "missing";
+  if (Array.isArray(value)) return "an array";
+  return `a ${typeof value}`;
+}
+
 /** First schema problem on an in-memory record (primaryKey↔id mismatch,
  *  then the compiled per-field checks — see `../core/recordZ` for the two
  *  tiers), or null when it's fine. One issue per record keeps the report
@@ -145,8 +156,16 @@ async function inspectRecord(fullPath: string, name: string, schema: CollectionS
  *  report-only surfaces. */
 export function validateRecordObject(record: CollectionItem, itemId: string, schema: CollectionSchema, tier: RecordCheckTier = "enforced"): string | null {
   const idValue = record[schema.primaryKey];
-  if (typeof idValue !== "string" || idValue !== itemId) {
-    return `'${schema.primaryKey}' is '${String(idValue ?? "")}' but must equal the filename ('${itemId}'), or the record can't be opened`;
+  // Two distinct failures, reported distinctly. A non-string id used to be
+  // rendered with `String(...)`, so an object arrived in the message as
+  // "[object Object]" — which reads like a value the user typed rather than a
+  // type error, and no longer matched the (now text-derived) `itemId` it was
+  // being compared against.
+  if (typeof idValue !== "string") {
+    return `'${schema.primaryKey}' must be a string, but is ${describeIdType(idValue)} — must equal the filename ('${itemId}'), or the record can't be opened`;
+  }
+  if (idValue !== itemId) {
+    return `'${schema.primaryKey}' is '${idValue}' but must equal the filename ('${itemId}'), or the record can't be opened`;
   }
   return firstRecordProblem(record, schema, tier);
 }

--- a/test/workspace/collections/test_dataSource.ts
+++ b/test/workspace/collections/test_dataSource.ts
@@ -139,6 +139,35 @@ describe("CSV pure helpers", () => {
     assert.equal(normalizeCsvValue("x"), "x");
   });
 
+  // A STRUCT / LIST / MAP cell used to render "[object Object]" — the column's
+  // content simply gone. It is serialised now, but `JSON.stringify` is not total
+  // on what DuckDB hands back: a BIGINT nested in a struct throws, and so does a
+  // circular ref. Losing one cell is bad; aborting the whole CSV read is worse,
+  // so serialisation failures fall back rather than propagate.
+  it("normalizeCsvValue serialises object cells instead of rendering [object Object]", () => {
+    assert.equal(normalizeCsvValue({ a: 1, b: "x" }), '{"a":1,"b":"x"}');
+    assert.equal(normalizeCsvValue([1, 2, 3]), "[1,2,3]");
+    assert.equal(String({ a: 1 }), "[object Object]"); // what it used to produce
+  });
+
+  it("normalizeCsvValue survives values JSON.stringify cannot handle", () => {
+    // The branch above only unwraps a TOP-LEVEL bigint, so a nested one reaches
+    // the serialiser — where plain JSON.stringify throws.
+    assert.throws(() => JSON.stringify({ big: 1n }), TypeError);
+    assert.doesNotThrow(() => normalizeCsvValue({ big: 1n }));
+    assert.equal(normalizeCsvValue({ big: 1n }), '{"big":"1"}');
+
+    const circular: Record<string, unknown> = { name: "loop" };
+    circular.self = circular;
+    assert.throws(() => JSON.stringify(circular), TypeError);
+    assert.doesNotThrow(() => normalizeCsvValue(circular));
+    assert.equal(normalizeCsvValue(circular), "[object Object]"); // falls back, does not abort
+
+    // `toJSON` returning undefined makes JSON.stringify yield undefined, which
+    // must not become the cell's value.
+    assert.equal(normalizeCsvValue({ toJSON: () => undefined }), "[object Object]");
+  });
+
   it("csvRowToItem overwrites the key field with the record id and skips empty keys", () => {
     const item = csvRowToItem({ student_id: "山田001", name: "山田" }, "student_id");
     assert.ok(item);


### PR DESCRIPTION
## Summary

Moves the remaining `packages/core/src/collection` sites onto the shared helpers — **38 findings → 21**. Sorted by what each value is used *for*, because the right answer differs:

| use | sites | treatment |
|---|---|---|
| identity | `itemIdOf`, `derive.ts` selfId ×2, `store.ts` sort ids, `validate.ts` | `fieldText` — both sides of a comparison derive the key the same way |
| matcher | `spawn.ts` ×2, `schemaZ.ts` | `fieldTextOrNull` — no text form means no match, as absent already did |
| display | `dynamicIcon` ×2, `draft.ts`, `enumColors.ts` | `fieldText` with the existing fallback |

`derive.ts` is the **server half** of the asymmetry fixed client-side in #2223 — the split was still live here. A backlink self-id computed with `String()` on one side and `fieldTextOrNull()` on the other could never agree on a non-scalar id.

## csvStore is deliberately not on `fieldText`

Those are **data cells**, not ids. An object reduced to `""` loses the column's content outright — worse than the bug being fixed. A DuckDB `STRUCT`/`LIST`/`MAP` is serialised instead.

**That serialisation needed a guard, and why is the part worth reading.** `JSON.stringify` is not total on what DuckDB returns:

```
BigInt nested in a struct → TypeError: Do not know how to serialize a BigInt
circular ref              → TypeError
toJSON returning undefined → undefined
```

The first one matters most: `normalizeCsvValue` **exists to unwrap top-level bigints**, so nested ones are entirely expected here. Shipping bare `JSON.stringify` would have traded a quiet per-cell data loss for **an abort of the whole CSV read**. `safeJsonCell` stringifies nested bigints and falls back to the old rendering on failure.

I'd written that bare version first. A local codex review caught it — same failure shape as the `Invalid Date` crash in #2208, which is twice now that reaching for "stop losing data quietly" produced "fail loudly instead".

## validate.ts had a half-change

I moved the comparison (`:92`) to `fieldText` but left the error message (`:149`) building from `String(idValue)` — so a non-string id printed as `"[object Object]"` while being compared against `""`. The two failures are now reported separately:

```
'id' must be a string, but is an array — must equal the filename ('x')
'id' is 'other' but must equal the filename ('x')
```

Kept the `must equal the filename` wording: two existing tests assert on it, and rewording is a separate concern from this fix.

## Items to Confirm / Review

- **CSV behaviour change**: a `LIST` cell rendered `"a,b"` before and renders `["a","b"]` now. More faithful (elements containing commas no longer corrupt), but user-visible for CSV-backed collections with struct/list columns.
- **`itemIdOf` is the central id function** — many callers. Codex specifically checked for callers that still compare against a `String()`-derived value and found none; I'd flag that as the main thing worth a second opinion.
- **Date-valued ids start matching** where they previously couldn't (one side ISO, one side locale string). Improvement, but a behaviour change.

## Verification

`build:packages` / `typecheck` / `lint` / `test` all clean. New tests pin the crash guard — against the unguarded version:

```
✖ normalizeCsvValue survives values JSON.stringify cannot handle
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when handling missing, numeric, boolean, and other non-text field values across records, sorting, labels, notifications, and linked-field calculations.
  - CSV imports now preserve structured values such as objects, arrays, and maps instead of reducing them to generic text.
  - CSV rows with missing or unusable primary keys are skipped safely.
  - Primary-key validation now provides clearer, more specific error messages.
  - Recurring and conditional record rules now handle empty or unsupported values more reliably.

- **Tests**
  - Added coverage for structured CSV values and serialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->