### PR TITLE
fix: read remote-host command ids as strings, not String()-coerced params

### DIFF
--- a/packages/core/src/remote-view/index.ts
+++ b/packages/core/src/remote-view/index.ts
@@ -93,6 +93,14 @@ const toInt = (value: unknown): number | null => {
 /** Coerce a channel/postMessage offset (arrives as untyped JSON) to a non-negative int. */
 export const clampOffset = (value: unknown): number => Math.max(0, toInt(value) ?? 0);
 
+/** Read a channel/postMessage identifier (a slug, a view id) as a string.
+ *  Params arrive as untyped JSON, so a caller can send anything; `String(...)`
+ *  turned an object into the literal "[object Object]", which then travelled on
+ *  as if the caller had asked for a collection by that name — surfacing as
+ *  `collection '[object Object]' not found` rather than a bad-request. A value
+ *  with no string form is simply absent. */
+export const readIdParam = (value: unknown): string => (typeof value === "string" ? value : "");
+
 /** Coerce a channel/postMessage limit to [1, MAX_PAGE_LIMIT] (default 50). */
 export const clampLimit = (value: unknown): number => {
   const num = toInt(value);

--- a/packages/core/test/remote-view/test_remote_view.ts
+++ b/packages/core/test/remote-view/test_remote_view.ts
@@ -13,6 +13,7 @@ import {
   clampImageMaxEdge,
   clampLimit,
   clampOffset,
+  readIdParam,
   handleRemoteViewMessage,
   normalizeFields,
   normalizeMutate,
@@ -87,6 +88,23 @@ describe("clamps + projection", () => {
     assert.equal(clampLimit(100000), 200);
     assert.equal(clampLimit(0), 50);
     assert.equal(clampLimit("7"), 7);
+  });
+
+  // Params arrive as untyped JSON over the command channel, so a caller can send
+  // anything. `String(...)` turned an object into "[object Object]", which then
+  // travelled on as if it were the requested slug — surfacing as
+  // `collection '[object Object]' not found` instead of a bad request.
+  it("readIdParam takes only real strings", () => {
+    assert.equal(readIdParam("notes"), "notes");
+    assert.equal(readIdParam(""), "");
+    assert.equal(readIdParam(undefined), "");
+    assert.equal(readIdParam(null), "");
+    assert.equal(readIdParam({ slug: "notes" }), "");
+    assert.equal(readIdParam(["notes"]), "");
+    // Unlike clampOffset("3") === 3, an id is NOT coerced from a number — a
+    // numeric slug would address a different collection than the caller meant.
+    assert.equal(readIdParam(42), "");
+    assert.equal(String({ slug: "notes" }), "[object Object]"); // what it replaced
   });
 
   it("normalizeFields keeps only non-empty strings", () => {

--- a/server/remoteHost/handlers/collectionPage.ts
+++ b/server/remoteHost/handlers/collectionPage.ts
@@ -6,11 +6,11 @@
 // that budget. The clamps live in @mulmoclaude/core/remote-view (params arrive
 // as untyped JSON there too) so the record handlers and the remote-view bridge
 // serve identical page semantics — re-exported here for the handlers.
-import { clampLimit, clampOffset } from "@mulmoclaude/core/remote-view";
+import { clampLimit, clampOffset, readIdParam } from "@mulmoclaude/core/remote-view";
 import { deriveAll, type DerivableFieldSpec, type DerivableRecord } from "@mulmoclaude/core/collection";
 import type { JsonObject } from "../commandChannel.js";
 
-export { clampLimit, clampOffset };
+export { clampLimit, clampOffset, readIdParam };
 
 /** Resolve record-local computed fields (derived formulas) before paging, so
  *  channel consumers — the phase-2 card list and a remote view's `getItems` —

--- a/server/remoteHost/handlers/getCollection.ts
+++ b/server/remoteHost/handlers/getCollection.ts
@@ -9,7 +9,7 @@
 // stubbed; the default export wires the real engine functions.
 import { loadCollection, storeFor, toDetail, type CollectionItem, type LoadedCollection } from "../../workspace/collections/index.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
-import { clampLimit, clampOffset, deriveItems, pageResult } from "./collectionPage.js";
+import { clampLimit, clampOffset, deriveItems, pageResult, readIdParam } from "./collectionPage.js";
 
 export interface GetCollectionDeps {
   loadCollection: typeof loadCollection;
@@ -21,7 +21,7 @@ export interface GetCollectionDeps {
 export const createGetCollection =
   (deps: GetCollectionDeps): CommandHandler =>
   async (params: JsonObject) => {
-    const slug = String(params.slug ?? "");
+    const slug = readIdParam(params.slug);
     const offset = clampOffset(params.offset);
     const limit = clampLimit(params.limit);
     const collection = await deps.loadCollection(slug);

--- a/server/remoteHost/handlers/getFeed.ts
+++ b/server/remoteHost/handlers/getFeed.ts
@@ -10,7 +10,7 @@ import { listFeeds as listFeedsRegistry } from "@mulmoclaude/core/feeds/server";
 import { storeFor, toDetail, type LoadedCollection, type CollectionItem } from "../../workspace/collections/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
-import { clampLimit, clampOffset, deriveItems, pageResult } from "./collectionPage.js";
+import { clampLimit, clampOffset, deriveItems, pageResult, readIdParam } from "./collectionPage.js";
 
 export interface GetFeedDeps {
   listFeeds: typeof listFeedsRegistry;
@@ -22,7 +22,7 @@ export interface GetFeedDeps {
 export const createGetFeed =
   (deps: GetFeedDeps): CommandHandler =>
   async (params: JsonObject) => {
-    const slug = String(params.slug ?? "");
+    const slug = readIdParam(params.slug);
     const offset = clampOffset(params.offset);
     const limit = clampLimit(params.limit);
     const feeds = await deps.listFeeds(deps.workspaceRoot);

--- a/server/remoteHost/handlers/getRemoteView.ts
+++ b/server/remoteHost/handlers/getRemoteView.ts
@@ -9,6 +9,7 @@
 //
 // Factory (createGetRemoteView) keeps the mapping unit-testable with the
 // engine stubbed; the default export wires the real functions.
+import { readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { buildRemoteView, remoteViewFailureMessage } from "../../workspace/collections/remoteView.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
@@ -21,8 +22,8 @@ export interface GetRemoteViewDeps {
 export const createGetRemoteView =
   (deps: GetRemoteViewDeps): CommandHandler =>
   async (params: JsonObject) => {
-    const slug = String(params.slug ?? "");
-    const viewId = String(params.viewId ?? "");
+    const slug = readIdParam(params.slug);
+    const viewId = readIdParam(params.viewId);
     const locale = typeof params.locale === "string" ? params.locale : "";
     const collection = await deps.loadCollection(slug);
     if (!collection) throw new Error(`collection '${slug}' not found`);

--- a/server/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/remoteHost/handlers/getRemoteViewItems.ts
@@ -10,7 +10,7 @@
 //
 // Factory (createGetRemoteViewItems) keeps the mapping unit-testable with the
 // engine stubbed; the default export wires the real functions.
-import { clampLimit, clampOffset, normalizeFields } from "@mulmoclaude/core/remote-view";
+import { clampLimit, clampOffset, normalizeFields, readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { remoteViewItems, remoteViewItemsFailureMessage } from "../../workspace/collections/remoteView.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
@@ -23,8 +23,8 @@ export interface GetRemoteViewItemsDeps {
 export const createGetRemoteViewItems =
   (deps: GetRemoteViewItemsDeps): CommandHandler =>
   async (params: JsonObject) => {
-    const slug = String(params.slug ?? "");
-    const viewId = String(params.viewId ?? "");
+    const slug = readIdParam(params.slug);
+    const viewId = readIdParam(params.viewId);
     const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), fields: normalizeFields(params.fields) };
     const collection = await deps.loadCollection(slug);
     if (!collection) throw new Error(`collection '${slug}' not found`);

--- a/server/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/remoteHost/handlers/mutateRemoteView.ts
@@ -11,7 +11,7 @@
 //
 // Factory (createMutateRemoteView-backed) keeps the mapping unit-testable with
 // the engine stubbed; the default export wires the real functions.
-import { normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { normalizeMutate, readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../workspace/collections/remoteView.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
@@ -24,8 +24,8 @@ export interface MutateRemoteViewHandlerDeps {
 export const createMutateRemoteViewHandler =
   (deps: MutateRemoteViewHandlerDeps): CommandHandler =>
   async (params: JsonObject) => {
-    const slug = String(params.slug ?? "");
-    const viewId = String(params.viewId ?? "");
+    const slug = readIdParam(params.slug);
+    const viewId = readIdParam(params.viewId);
     const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
     if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
     const collection = await deps.loadCollection(slug);


### PR DESCRIPTION
## Summary

The **8** `no-base-to-string` findings in `server/remoteHost/handlers/` are all one shape:

```ts
const slug = String(params.slug ?? "");
const viewId = String(params.viewId ?? "");
```

Params arrive as untyped JSON over the Firestore command channel — a phone can send anything. An object became the literal `"[object Object]"`, which then travelled on *as the requested slug*, so the user got `collection '[object Object]' not found` instead of a bad request.

Findings: **21 → 13**.

## Not a security hole

`loadCollection` runs `safeSlugName()`, so a malformed slug can't escape the collections root. This is a **diagnosis** hole, not a traversal one — worth stating plainly rather than letting "untrusted input reaches a path lookup" imply more than it should.

## The correct form was already in one of these files

```ts
// getRemoteView.ts — one line apart
const slug = String(params.slug ?? "");                                  // was
const locale = typeof params.locale === "string" ? params.locale : "";   // already right
```

`readIdParam` lives next to `clampLimit`/`clampOffset` in `@mulmoclaude/core/remote-view` — that module exists precisely because *"params arrive as untyped JSON there too"* (its own comment), and the record handlers already re-export the clamps through `collectionPage.ts`.

## Items to Confirm / Review

- **A number no longer coerces.** `readIdParam(42)` is `""` where `String(42 ?? "")` was `"42"`. A numeric slug addresses a *different collection* than the caller meant, so silently accepting one seemed worse than rejecting it — but it is a behaviour change, and it differs from the sibling helpers on purpose (`clampOffset("3")` → `3`). The test states both next to each other so the inconsistency is deliberate and visible.
- **`viewId` gets the same treatment as `slug`** even though it's looked up differently. Consistent, and neither is meaningful as a non-string.

## Verification

`build:packages` / `typecheck` / `lint` / `test` all clean; repo lint errors 0.

One self-inflicted snag worth recording: my first pass added the import via a script that fell into the "no existing `collectionPage` import" branch on two files, producing a duplicate `@mulmoclaude/core/remote-view` import and 4 `import/no-duplicates` errors. Caught by `yarn lint` before pushing; imports merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)