### PR TITLE
docs(changelog): record @mulmoclaude/core@0.28.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,14 @@ Ships `@mulmoclaude/core@0.23.0`, `@mulmoclaude/collection-plugin@0.12.0`, `@mul
 
 ---
 
+## npm packages — 2026-07-20 (10)
+
+`@mulmoclaude/core@0.28.0` — a wiki fix: two files the host reads on its own had no writer.
+
+- **`@mulmoclaude/core@0.28.0`** (#2226) — `server/agent/prompt.ts` loads `data/wiki/summary.md` into the system prompt of **every session**, and points every role at `data/wiki/SCHEMA.md` when it exists. Both are declared `editPolicy: "agent-managed"`, but nothing ever instructed the agent to create or update them — they appeared only in a folder-layout diagram in the help, never in the Ingest or Lint operations. A wiki in real use for two months (202 pages) had neither file, and the failure is silent: with no `summary.md` the host falls back to a generic hint, so accumulated knowledge stops reaching ordinary conversations and nothing reports it. `assets/helps/wiki.md` now instructs Ingest to refresh `summary.md` (about a screenful — it costs context every session; topic areas and anchor pages, not a page list), makes Lint flag both files as missing or stale, marks both as agent-maintained in the layout, and adds a section on what belongs in each. That section also records why `summary.md` must never be phrased as instructions: the host wraps it in a `<reference>` block telling the model to ignore instructions inside it, because the summary derives from user-supplied sources and is therefore a prompt-injection surface. Help-only; no code changed.
+
+---
+
 ## npm packages — 2026-07-20 (9)
 
 Two behaviour fixes, one hardening fix, and a floating-promise sweep across the chat bridges. Shipped alongside `@mulmoclaude/core@0.27.0`, `@mulmoclaude/collection-plugin@0.14.0`, and `@mulmoclaude/google-plugin@0.3.2`.


### PR DESCRIPTION
## Summary

`@mulmoclaude/core@0.28.0` の publish 記録を `docs/CHANGELOG.md` に追加します。CHANGELOG のみの変更です。

- npm: https://www.npmjs.com/package/@mulmoclaude/core/v/0.28.0
- tag: `@mulmoclaude/core@0.28.0` → `0d97ebbb`（#2226 のマージコミット）
- release: https://github.com/receptron/mulmoclaude/releases/tag/%40mulmoclaude/core%400.28.0

既存の `## npm packages — 2026-07-20 (9)` の直前に `(10)` として差し込み、日付は `date` コマンドで確認しています。

## 気づいた点（本PRの対象外）

publish 作業中に、**core のタグが 6 バージョン分抜けている**ことが分かりました。

npm には `0.23.1` / `0.24.0` / `0.25.0` / `0.25.1` / `0.26.0` / `0.27.0` が公開されていますが、対応する git タグがありません（`@mulmoclaude/core@0.23.0` の次が今回の `0.28.0`）。

そのため `--generate-notes` の範囲が 0.23.0 まで遡ってしまい、0.28.0 のリリースノートには実際より広い履歴が載っています。リリース本文にその旨を注記しました。

過去分のタグを遡って打つべきか（打てば範囲が正確になりますが、履歴の後付けになります）は判断が要るので、本PRでは触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)