### PR TITLE
chore: sync internal dep ranges to latest, add the rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,20 @@ Rationale: the launcher-sync gate enforces `launcherRange.lowerBound == workspac
 When to bump `packages/mulmoclaude/package.json`'s `version`:
 - Inside the `/publish-mulmoclaude` flow, right before the actual `npm publish`. That commit becomes the identity of the release.
 - Never as part of a `chore(release)` that publishes only shared packages.
+
+### Internal dep ranges — always track the latest published version
+
+Every declared range on a workspace-internal package (`@mulmoclaude/*`, `@mulmobridge/*`, `mulmoclaude`) MUST equal `^<latest version published to npm>`, in **every** `package.json` that declares it — `dependencies`, `devDependencies` and `peerDependencies` alike, in bridges and plugins, not just the launcher.
+
+Whenever you publish a workspace package, sweep every consumer's range to the new version in the same PR.
+
+Rationale: a caret range on a `0.x` package does **not** float across minor versions — `^0.23.0` resolves to `>=0.23.0 <0.24.0`. So a stale range doesn't merely look untidy, it *pins consumers to an old line* and silently withholds everything published since. This is not hypothetical: `mulmoclaude@1.3.0` shipped `@mulmoclaude/core: ^0.23.0` while npm had already served 0.24 through 0.28, so npm-installed users could not receive any of it. The `launcherSync.mjs` gate only checks the launcher, so nothing catches the same drift in the other ~50 workspaces.
+
+To audit before a release:
+
+```bash
+# for each internal dep name, compare every declared range against npm's latest
+npm view <pkg> version --registry https://registry.npmjs.org/
+```
+
+A range update reaches users only through that consumer's own next release, so it does not force an immediate republish of all 50 packages — but it MUST be in the tree before the consumer is published next.

--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/cli/package.json
+++ b/packages/bridges/cli/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "discord.js": "^14.27.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/email/package.json
+++ b/packages/bridges/email/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "imapflow": "^1.4.7",

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "irc-framework": "^4.14.0"

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "matrix-js-sdk": "^41.9.0"

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "nostr-tools": "^2.23.12"

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@slack/socket-mode": "^3.0.0",
     "@slack/web-api": "^8.0.0",

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "botbuilder": "^4.23.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/telegram/package.json
+++ b/packages/bridges/telegram/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@xmpp/client": "^0.14.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.4",
+    "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0"
   },

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -32,6 +32,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.3"
+    "@mulmobridge/client": "^0.1.5"
   }
 }


### PR DESCRIPTION
## Summary

workspace 内部パッケージの依存 range を最新公開版に揃え、その運用ルールを CLAUDE.md に追加します。

`@mulmobridge/client` の宣言が **26箇所で古いまま**でした（bridges 25件が `^0.1.4`、relay が `^0.1.3`。npm 最新は 0.1.5）。

## Items to Confirm / Review

1. **これは体裁の問題ではなく、機能的に効きます** — 0.x への caret は minor をまたぎません（`^0.1.4` = `>=0.1.4 <0.2.0`、`^0.23.0` = `>=0.23.0 <0.24.0`）。古い range は consumer を**古い系列に固定**します。
2. **実害が既に発生しています** — npm 上の `mulmoclaude@1.3.0` は `@mulmoclaude/core: ^0.23.0` を出荷しており、npm 経由のユーザーは **0.24〜0.28 の変更を一切受け取れません**。本日 publish した修正群も届きません。これは launcher を publish して初めて解消します（本PRの範囲外）。
3. **`launcherSync.mjs` は launcher しか検査しません** — 他の約50 workspace の同種ドリフトを捕まえる仕組みが無かったため、CLAUDE.md にルールと監査方法を記載しました。gate 化はしていません（必要なら別途）。
4. **本PRは再 publish を強制しません** — range 変更は各 consumer の次回リリースで初めてユーザーに届きます。26パッケージを今すぐ publish し直す必要はありませんが、次に publish する時点ではツリーに入っている必要があります。

## User Prompt

- range は常に最新に合わせるようにして
- range は常に最新に合わせる、はこのリポジトリの CLAUDE.md に入れて
- `@mulmobridge/webhook-runtime` も publish（※本PRとは別作業）

## 変更内容

| 対象 | 内容 |
|---|---|
| `packages/bridges/*/package.json` 25件 | `@mulmobridge/client` `^0.1.4` → `^0.1.5` |
| `packages/relay/package.json` | `@mulmobridge/client` `^0.1.3` → `^0.1.5` |
| `CLAUDE.md` | 「Internal dep ranges — always track the latest published version」節を追加 |

追加したルールの要点:

- `@mulmoclaude/*` / `@mulmobridge/*` / `mulmoclaude` の range は、**それを宣言する全 package.json** で `^<npm 最新>` と一致させる（`dependencies` / `devDependencies` / `peerDependencies` すべて、launcher に限らず bridges・plugins も）
- workspace パッケージを publish したら、同じ PR で全 consumer の range を掃く
- 監査方法（`npm view <pkg> version --registry ...`）を明記

## 監査方法

全 `package.json` を走査して内部依存の宣言78件を抽出し、各パッケージの npm 最新版と突き合わせました。ズレていたのは `@mulmobridge/client` の26件のみで、他は既に一致していました。

## 検証

`yarn install` / `check:launcher-sync` / `build:packages` / `typecheck` / `lint` / `test` / `build` — すべて EXIT=0。`yarn.lock` に変更はありません（0.1.5 は既に解決済みだったため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated bridge and relay components to use the latest client release, improving compatibility and consistency across supported integrations.

- **Documentation**
  - Added internal release guidance to keep component version ranges aligned with the latest published versions and reduce upgrade issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->