### PR TITLE
fix(watcher): マウント試行をマウント成功として数えていた / clock tick が多重実行しうる

### DIFF
--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -68,6 +68,15 @@ const watchers = new Map<string, CollectionWatcher>();
 let rediscoveryTimer: ReturnType<typeof setInterval> | null = null;
 let triggerTimer: ReturnType<typeof setInterval> | null = null;
 let started = false;
+/** Guards the clock tick against overlapping itself. Paired with
+ *  `watcherEpoch`: a teardown while a pass is in flight bumps the epoch, so
+ *  that pass's `finally` knows it belongs to a dead generation and must not
+ *  clear a guard the restarted watcher set now owns. `triggerTickInFlight`
+ *  is what teardown AWAITS — clearing the flag alone would let a restart run
+ *  a second pass alongside the first. */
+let triggerTickRunning = false;
+let watcherEpoch = 0;
+let triggerTickInFlight: Promise<void> | null = null;
 /** Discovery options threaded into every `discoverCollections` /
  *  `loadCollection` / `sweepStaleActiveEntries` call. Production: empty
  *  (live workspace). Tests: `{ workspaceRoot, userSkillsDir }` pointing
@@ -133,9 +142,22 @@ export async function startCollectionWatchers(opts: CollectionWatcherOptions = {
     const triggerMs = opts.triggerTickIntervalMs === undefined ? TRIGGER_TICK_INTERVAL_MS : opts.triggerTickIntervalMs;
     if (triggerMs !== null) {
       triggerTimer = setInterval(() => {
-        tickTimeTriggers().catch((err: unknown) => {
-          log().warn("watcher trigger tick failed", { error: errMsg(err) });
-        });
+        // Skip rather than overlap. The pass is idempotent and the next one
+        // is a minute away, so dropping a tick is harmless — whereas letting
+        // firings pile up on a slow pass is not.
+        if (triggerTickRunning) return;
+        triggerTickRunning = true;
+        const epoch = watcherEpoch;
+        triggerTickInFlight = tickTimeTriggers()
+          .catch((err: unknown) => {
+            log().warn("watcher trigger tick failed", { error: errMsg(err) });
+          })
+          .finally(() => {
+            // Only the generation that set the guard may clear it.
+            if (epoch !== watcherEpoch) return;
+            triggerTickRunning = false;
+            triggerTickInFlight = null;
+          });
       }, triggerMs);
       triggerTimer.unref();
     }
@@ -158,6 +180,15 @@ export async function stopCollectionWatchers(): Promise<void> {
     clearInterval(triggerTimer);
     triggerTimer = null;
   }
+  // Wait for a clock pass that is still running: the interval is disarmed
+  // above, but a pass already in flight keeps touching the notifier and the
+  // slot maps, and a restart would otherwise run a second one beside it.
+  await triggerTickInFlight;
+  triggerTickInFlight = null;
+  // Bump AFTER the await: any later `finally` from that pass is now a dead
+  // generation and becomes a no-op, so it can't undo this teardown.
+  watcherEpoch += 1;
+  triggerTickRunning = false;
   for (const watcher of watchers.values()) {
     try {
       watcher.watcher.close();
@@ -175,8 +206,8 @@ export async function stopCollectionWatchers(): Promise<void> {
 }
 
 /** Test-only: manually trigger one rediscovery + reconcile pass. */
-export async function _syncWatchersForTesting(): Promise<void> {
-  await syncWatchers();
+export async function _syncWatchersForTesting(): Promise<boolean> {
+  return syncWatchers();
 }
 
 /** Test-only: drive one wall-clock tick synchronously, with an optional
@@ -212,21 +243,21 @@ async function tickTimeTriggers(now: Date = evalNow()): Promise<void> {
  *  their items), drops watchers for vanished slugs, and re-reconciles
  *  items for collections whose schema changed. Runs a final sweep when
  *  this tick changed the watcher set or any schema. */
-async function syncWatchers(): Promise<void> {
+async function syncWatchers(): Promise<boolean> {
   let collections;
   try {
     collections = await discoverCollections(discoveryOpts);
   } catch (err) {
     log().warn("watcher discover failed", { error: errMsg(err) });
-    return;
+    return false;
   }
   const liveSlugs = new Set(collections.map((collection) => collection.slug));
   const vanishedMutated = stopVanishedWatchers(liveSlugs);
   const schemaMutated = await reconcileChangedSchemas(collections);
   const addedMutated = await startNewWatchers(collections);
-  if (vanishedMutated || schemaMutated || addedMutated) {
-    await sweepStaleActiveEntries(discoveryOpts);
-  }
+  if (!vanishedMutated && !schemaMutated && !addedMutated) return false;
+  await sweepStaleActiveEntries(discoveryOpts);
+  return true;
 }
 
 function stopVanishedWatchers(liveSlugs: Set<string>): boolean {
@@ -304,14 +335,23 @@ async function reconcileChangedSchemas(collections: readonly LoadedCollection[])
   return mutated;
 }
 
+/** Mount a watcher for every collection that doesn't have one yet. Returns
+ *  whether the watcher SET actually changed — the starters report whether
+ *  they mounted, because ATTEMPTING is not mounting. A start that throws
+ *  (logged and swallowed inside the starter) leaves `watchers` untouched, so
+ *  the collection is retried next tick; counting that as a mutation made
+ *  `syncWatchers` sweep on every tick for as long as the failure persisted. */
 async function startNewWatchers(collections: readonly LoadedCollection[]): Promise<boolean> {
   let mutated = false;
   for (const collection of collections) {
     if (watchers.has(collection.slug)) continue;
-    if (collection.schema.dataSource !== undefined) await startDataSourceWatcher(collection);
-    else if (collection.schema.storage !== undefined) await startStorageWatcher(collection);
-    else await startWatcherFor(collection);
-    mutated = true;
+    const mounted =
+      collection.schema.dataSource !== undefined
+        ? await startDataSourceWatcher(collection)
+        : collection.schema.storage !== undefined
+          ? await startStorageWatcher(collection)
+          : await startWatcherFor(collection);
+    if (mounted) mutated = true;
   }
   return mutated;
 }
@@ -334,9 +374,9 @@ function scheduleDataSourcePublish(slug: string): void {
  *  atomic replace — the inode changes) and filters events to the file's
  *  basename; a null filename (platform quirk) is treated as a hit. No
  *  reconciler involvement — replacing the CSV just refreshes the views. */
-async function startDataSourceWatcher(collection: LoadedCollection): Promise<void> {
+async function startDataSourceWatcher(collection: LoadedCollection): Promise<boolean> {
   const file = collection.dataSourceFile;
-  if (file === undefined) return;
+  if (file === undefined) return false;
   const dir = path.dirname(file);
   const base = path.basename(file);
   try {
@@ -350,8 +390,10 @@ async function startDataSourceWatcher(collection: LoadedCollection): Promise<voi
     });
     watchers.set(collection.slug, { slug: collection.slug, dataDir: dir, watcher, schemaJson: JSON.stringify(collection.schema), collection });
     log().info("dataSource watcher started", { slug: collection.slug, file });
+    return true;
   } catch (err) {
     log().warn("dataSource watcher start failed", { slug: collection.slug, error: errMsg(err) });
+    return false;
   }
 }
 
@@ -362,9 +404,9 @@ async function startDataSourceWatcher(collection: LoadedCollection): Promise<voi
  *  already publish their own change events; the extra ping is debounced
  *  and idempotent). Mounts on the parent dir, same as the dataSource
  *  watcher, so an atomic replace can't strand the watch. */
-async function startStorageWatcher(collection: LoadedCollection): Promise<void> {
+async function startStorageWatcher(collection: LoadedCollection): Promise<boolean> {
   const file = collection.storageFile;
-  if (file === undefined) return;
+  if (file === undefined) return false;
   const dir = path.dirname(file);
   const base = path.basename(file);
   try {
@@ -387,8 +429,10 @@ async function startStorageWatcher(collection: LoadedCollection): Promise<void> 
     });
     watchers.set(collection.slug, { slug: collection.slug, dataDir: dir, watcher, schemaJson: JSON.stringify(collection.schema), collection });
     log().info("storage watcher started", { slug: collection.slug, file });
+    return true;
   } catch (err) {
     log().warn("storage watcher start failed", { slug: collection.slug, error: errMsg(err) });
+    return false;
   }
 }
 
@@ -410,7 +454,7 @@ export function _scheduleStorageReconcileForTesting(slug: string): Promise<void>
   return scheduleStorageReconcile(slug);
 }
 
-async function startWatcherFor(collection: LoadedCollection): Promise<void> {
+async function startWatcherFor(collection: LoadedCollection): Promise<boolean> {
   const { slug, schema, dataDir } = collection;
   try {
     // `fs.watch` throws on a missing dir, so ensure it exists. New
@@ -433,8 +477,10 @@ async function startWatcherFor(collection: LoadedCollection): Promise<void> {
     });
     watchers.set(slug, { slug, dataDir, watcher, schemaJson: JSON.stringify(schema), collection });
     log().info("watcher started", { slug, dataDir });
+    return true;
   } catch (err) {
     log().warn("watcher start failed", { slug, error: errMsg(err) });
+    return false;
   }
 }
 

--- a/packages/core/test/collection-watchers/test_watcher.ts
+++ b/packages/core/test/collection-watchers/test_watcher.ts
@@ -52,7 +52,15 @@ const adapter: CollectionNotificationAdapter = {
   priorityToSeverity: () => "nudge",
   buildNavigateTarget: (slug, itemId) => `/x/${slug}/${itemId}`,
   buildPluginData: ({ legacyId }) => ({ kind: "cw", legacyId }),
-  readEntry: () => null,
+  // Must round-trip `buildPluginData`: the stale sweep skips any entry whose
+  // `readEntry` returns null, so a stub returning null unconditionally makes
+  // every sweep a silent no-op — a test asserting sweep behaviour would pass
+  // no matter what the sweep did.
+  readEntry: (pluginData) => {
+    if (typeof pluginData !== "object" || pluginData === null) return null;
+    const record = pluginData as Record<string, unknown>;
+    return record.kind === "cw" && typeof record.legacyId === "string" ? { legacyId: record.legacyId, priority: "normal" } : null;
+  },
 };
 configureCollectionWatchers({ adapter });
 

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -304,3 +304,64 @@ describe("storage (sqlite) collection reconciliation", () => {
     assert.ok(!legacyIds.includes(`collection-completion:${DB_SLUG}:b`), "bell must clear when the record is deleted");
   });
 });
+
+describe("watcher set bookkeeping", () => {
+  const BAD_SLUG = "test-watcher-unmountable";
+
+  // Discovery accepts this collection (the dataPath resolves inside the
+  // workspace and need not exist yet), but mounting it CANNOT succeed: a
+  // regular file sits where the records directory would go, so the starter's
+  // `mkdir` throws ENOTDIR, gets logged, and the collection stays out of
+  // `watchers` — the "attempted but not mounted" shape.
+  function writeUnmountableSchema(): void {
+    // The records dir path itself is a regular FILE: discovery still accepts
+    // the schema (the path resolves inside the workspace), but the starter's
+    // `mkdir` on it throws, so the watcher never mounts.
+    const blocker = path.join(workdir, "data", "blocked", "items");
+    mkdirSync(path.dirname(blocker), { recursive: true });
+    writeFileSync(blocker, "not a directory");
+    const skillDir = path.join(workdir, ".claude/skills", BAD_SLUG);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(path.join(skillDir, "SKILL.md"), `---\nname: ${BAD_SLUG}\ndescription: test\n---\nbody\n`);
+    writeFileSync(
+      path.join(skillDir, "schema.json"),
+      JSON.stringify({
+        title: "Unmountable",
+        icon: "warning",
+        dataPath: "data/blocked/items",
+        primaryKey: "id",
+        fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+      }),
+    );
+  }
+
+  it("a collection that never mounts does not make every tick look like a mutation", async () => {
+    writeUnmountableSchema();
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+      triggerTickIntervalMs: null,
+    });
+
+    // Nothing changed between these two ticks. Before the fix, the retried
+    // collection reported a mutation every time, so the stale sweep ran on
+    // every rediscovery poll for as long as the failure persisted.
+    assert.equal(await _syncWatchersForTesting(), false, "a quiet tick must not sweep");
+    assert.equal(await _syncWatchersForTesting(), false, "and must stay quiet");
+  });
+
+  it("still reports a mutation when a watcher really mounts", async () => {
+    writeUnmountableSchema();
+    await startCollectionWatchers({
+      discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+      rediscoveryIntervalMs: null,
+      triggerTickIntervalMs: null,
+    });
+    assert.equal(await _syncWatchersForTesting(), false);
+
+    // A real, mountable collection appearing IS a mutation — the fix must not
+    // suppress that signal.
+    writeSchema(buildSchema());
+    assert.equal(await _syncWatchersForTesting(), true, "a newly mounted watcher must still sweep");
+  });
+});


### PR DESCRIPTION
## Summary

#2209（Firestore backend）の作業中に見つけた、**backend 非依存**のバグ3件です。Firestore とは無関係に **file / csv / sqlite の全てに効く**ので、あの PR から切り出して単独で出します。

#2209 自体は取り込まない方針なので、その中で価値のある部分だけを救出する最初の1本です。

### 1. マウント「試行」をマウント「成功」として数えていた

`startNewWatchers` は starter を呼んだ時点で無条件に `mutated = true` にしていました。ところが starter は失敗を内部で catch してログするだけなので、**マウントに失敗した collection は `watchers` に載らず、次の tick で再試行されます**。

つまりマウントできない collection が1つあると:

- 毎 tick `watchers.has()` が false → ループ本体に入る → `mutated = true`
- → `syncWatchers` が「変化あり」と判定 → `sweepStaleActiveEntries` を実行
- → **30秒ごとの rediscovery で永久に sweep が回り続ける**

starter が「実際にマウントしたか」を返す形にしました。

### 2. clock tick に多重実行ガードが無い

`setInterval` から `tickTimeTriggers()` を無条件に起動していたので、遅いパスに次の firing が重なりえます。

- `triggerTickRunning` で skip（パスは冪等なので tick を落として無害）
- `watcherEpoch` で世代照合し、teardown をまたいだ古いパスの `finally` が新しい guard を解除するのを防ぐ
- `stopCollectionWatchers` が **in-flight のパスを await** する。epoch だけでは guard フラグは守れても、2つのパスの直列化はできないため

### 3. テスト用 adapter の `readEntry` が常に `null`

stale sweep は `readEntry` が null のエントリを飛ばします。つまり**sweep を検証しているつもりのテストが、全て無条件 no-op になっていました**。これが 1 を隠していた原因です。

## Items to Confirm / Review

- **`syncWatchers` が boolean を返すようにした点** — 静かな tick が静かであることをテストから観測する唯一の信号がこれでした。既存の `await` 呼び出しとは後方互換ですが、内部関数の戻り値を増やすことの是非を見てほしいです
- **1 の実害の見積もり** — 現状 main で「discovery は通るがマウントできない」条件は、starter の catch 経路（mkdir/watch の失敗）だけです。頻度は高くないはずですが、起きると恒久的に空回りします
- **テストの作り方** — records ディレクトリの位置に通常ファイルを置いて `mkdir` を失敗させています。最初 `dataSource.path` をワークスペース外にする案で書きましたが、**discovery が先に弾くため何も検証していませんでした**（修正を戻しても通ってしまった）。作り直して、戻すと2件落ちることを確認済みです

## User Prompt

> 2209は取り込まない予定なんだけど、それベースになんとかrefactorして切り出す？

## 検証

`yarn format` / `lint`(0 errors) / `typecheck` / `build` / host `test`(fail 0) / core `test`(393 pass) すべて green。main 取り込み済み。

## この後

#2209 から切り出す価値がある残りは以下です。本 PR には含めていません。

- **`BackendUnavailableError` の区別** — 「バックエンドに届かない」を「レコードが無い / ファイルが壊れている / 0件」に潰さない。**sqlite にも実害があります**（Node < 22.5 で `node:sqlite` が無い場合、`manageTool.ts:175` の `catch(() => null)` と `ontology.ts` の `catch { return 0 }` により、データが無事なのに「空のコレクション」に見えます）
- **storage 層の package 化** — 契約テスト（`test_storeContract.ts`）が既にあるので境界の条件は揃っていますが、watcher 側に backend 知識が残る問題を先に解く必要があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)