### PR TITLE
fix: clear the last no-base-to-string findings, ratchet the rule to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -557,7 +557,12 @@ export default [
       "@typescript-eslint/no-unsafe-enum-comparison": "warn",
       "@typescript-eslint/no-unsafe-declaration-merging": "warn",
       // (2) Bugs only the type checker can see.
-      "@typescript-eslint/no-base-to-string": "warn",
+      // Drained to zero and ratcheted, same as the promise rules above. Every
+      // remaining `String(x)` on a possibly-object value is either a real read
+      // (now going through a typed helper) or a last-resort fallback carrying an
+      // audited eslint-disable with its reason. A new one is a regression, not a
+      // warning to file behind 168 others.
+      "@typescript-eslint/no-base-to-string": "error",
       // Drained to zero and ratcheted to `error` per docs/lint-policy.md — a
       // dropped `await` or an async callback handed to a sync-only API is a
       // real bug, and the backlog for these three is empty, so there is nothing

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -25,6 +25,14 @@ import WebSocket from "ws";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
 import { isObj, parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
 
+// `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
+// binaryType is nodebuffer so a Buffer is what actually arrives, but the type
+// admits ArrayBuffer — whose `toString()` is the literal "[object ArrayBuffer]",
+// i.e. a frame silently parsed as garbage. Normalise instead of trusting the
+// runtime default to hold.
+const frameText = (data: Buffer | ArrayBuffer | Buffer[]): string =>
+  Buffer.isBuffer(data) ? data.toString("utf8") : Array.isArray(data) ? Buffer.concat(data).toString("utf8") : Buffer.from(data).toString("utf8");
+
 const TRANSPORT_ID = "mastodon";
 const MAX_STATUS_LEN = 500; // Mastodon's default soft limit; many instances raise to 1000+
 const FETCH_TIMEOUT_MS = 15_000;
@@ -194,7 +202,7 @@ function connect(): void {
   });
 
   socket.on("message", (buffer) => {
-    const frame = parseFrame(buffer.toString());
+    const frame = parseFrame(frameText(buffer));
     if (!frame || frame.event !== "notification") return;
     handleNotification(frame.payload).catch((err) => console.error(`[mastodon] notification handler error: ${err}`));
   });

--- a/packages/bridges/signal/src/index.ts
+++ b/packages/bridges/signal/src/index.ts
@@ -19,6 +19,14 @@ import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 
+// `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
+// binaryType is nodebuffer so a Buffer is what actually arrives, but the type
+// admits ArrayBuffer — whose `toString()` is the literal "[object ArrayBuffer]",
+// i.e. a frame silently parsed as garbage. Normalise instead of trusting the
+// runtime default to hold.
+const frameText = (data: Buffer | ArrayBuffer | Buffer[]): string =>
+  Buffer.isBuffer(data) ? data.toString("utf8") : Array.isArray(data) ? Buffer.concat(data).toString("utf8") : Buffer.from(data).toString("utf8");
+
 const TRANSPORT_ID = "signal";
 const MAX_SIGNAL_TEXT = 4_000;
 const FETCH_TIMEOUT_MS = 15_000;
@@ -193,7 +201,7 @@ function connect(): void {
   });
 
   socket.on("message", (buffer) => {
-    handleEnvelope(buffer.toString()).catch((err) => console.error(`[signal] envelope handler error: ${err}`));
+    handleEnvelope(frameText(buffer)).catch((err) => console.error(`[signal] envelope handler error: ${err}`));
   });
 
   socket.on("error", (err) => {

--- a/packages/core/src/collection/server/csvStore.ts
+++ b/packages/core/src/collection/server/csvStore.ts
@@ -75,8 +75,10 @@ export function decodeCsvRecordId(itemId: string): string {
 function safeJsonCell(value: object): string {
   try {
     const json = JSON.stringify(value, (_key, entry: unknown) => (typeof entry === "bigint" ? entry.toString() : entry));
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- last resort: JSON.stringify returned undefined (an object whose toJSON does). "[object Object]" at least says "this cell held an object"; "" would erase that it existed.
     return json ?? String(value);
   } catch {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- the serialiser threw (circular ref). Same reasoning as above: a placeholder beats losing the cell entirely.
     return String(value);
   }
 }

--- a/packages/core/src/whisper/client.ts
+++ b/packages/core/src/whisper/client.ts
@@ -42,6 +42,7 @@ function pickRecorderMime(): string | undefined {
 function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- FileReader.result is `string | ArrayBuffer | null`; readAsDataURL always yields the string branch, and the rule cannot narrow it.
     reader.onload = () => resolve(String(reader.result));
     reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
     reader.readAsDataURL(blob);

--- a/packages/plugins/x-plugin/src/index.ts
+++ b/packages/plugins/x-plugin/src/index.ts
@@ -44,7 +44,10 @@ export const readXPost: XTool = {
   prompt: "Use the readXPost tool whenever the user shares a URL from x.com or twitter.com.",
 
   async handler(args: Record<string, unknown>): Promise<string> {
-    const url = String(args.url ?? "");
+    // `args` is model-generated, so `url` can be any JSON type. `String({})` is
+    // "[object Object]", which `extractTweetId` would then reject with a message
+    // quoting that literal back at the user as if they had typed it.
+    const url = typeof args.url === "string" ? args.url : "";
     const tweetId = extractTweetId(url);
     if (!tweetId) return `Could not extract a tweet ID from: ${url}. Provide a full x.com URL or a numeric tweet ID.`;
 
@@ -96,7 +99,7 @@ export const searchX: XTool = {
   prompt: "Use the searchX tool to find recent posts on X by keyword or topic.",
 
   async handler(args: Record<string, unknown>): Promise<string> {
-    const query = String(args.query ?? "").trim();
+    const query = (typeof args.query === "string" ? args.query : "").trim();
     if (!query) return "A search query is required.";
 
     const maxResults = Math.min(100, Math.max(10, Number(args.max_results ?? 10)));

--- a/packages/plugins/x-plugin/src/index.ts
+++ b/packages/plugins/x-plugin/src/index.ts
@@ -9,6 +9,15 @@
 import { errorMessage } from "./internal";
 import { EXPANSIONS, extractTweetId, fetchX, formatTweet, TWEET_FIELDS, USER_FIELDS, type XApiResponse, type XTweet, type XUser } from "./client";
 
+/** A tweet URL or bare id from model-emitted args: a string as given, a finite
+ *  integer rendered as its digits, and nothing else. Objects/arrays have no id
+ *  in them and must not reach `extractTweetId` as "[object Object]". */
+export function readUrlArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) return String(value);
+  return "";
+}
+
 /** Minimal MCP-tool shape these tools conform to. Structurally compatible
  *  with the host's `McpTool` interface (server/agent/mcp-tools/index.ts), so
  *  a host can drop these straight into its `McpTool[]` registry. */
@@ -44,10 +53,14 @@ export const readXPost: XTool = {
   prompt: "Use the readXPost tool whenever the user shares a URL from x.com or twitter.com.",
 
   async handler(args: Record<string, unknown>): Promise<string> {
-    // `args` is model-generated, so `url` can be any JSON type. `String({})` is
-    // "[object Object]", which `extractTweetId` would then reject with a message
-    // quoting that literal back at the user as if they had typed it.
-    const url = typeof args.url === "string" ? args.url : "";
+    // `args` is model-generated, so `url` can be any JSON type. Objects and
+    // arrays must not get through — `String({})` is "[object Object]", which
+    // `extractTweetId` would reject with a message quoting that literal back at
+    // the user as if they had typed it. A NUMBER, though, is a legitimate way
+    // for a model to emit a bare tweet id: the schema calls it a "bare tweet
+    // ID", `extractTweetId` matches `/^\d+$/`, and the failure message offers
+    // it. Accept those two, reject the rest.
+    const url = readUrlArg(args.url);
     const tweetId = extractTweetId(url);
     if (!tweetId) return `Could not extract a tweet ID from: ${url}. Provide a full x.com URL or a numeric tweet ID.`;
 

--- a/packages/plugins/x-plugin/test/test_format.ts
+++ b/packages/plugins/x-plugin/test/test_format.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { extractTweetId, tweetBody, formatTweet } from "../src/index";
+import { extractTweetId, readUrlArg, tweetBody, formatTweet } from "../src/index";
 
 test("extractTweetId: full x.com URL", () => {
   assert.equal(extractTweetId("https://x.com/jack/status/20"), "20");
@@ -39,4 +39,29 @@ test("formatTweet: byline includes author + UTC date", () => {
   assert.match(out, /^@jane \(Jane\) · 2026-04-11/);
   assert.match(out, /Likes: 3 \| Retweets: 1 \| Replies: 0/);
   assert.match(out, /https:\/\/x\.com\/jane\/status\/1$/);
+});
+
+// `args` is model-generated, so `url` arrives as whatever JSON the model chose.
+// Both directions matter here, and the first one is a regression this very
+// change introduced before review caught it.
+test("readUrlArg: a numeric tweet id is a legitimate model emission", () => {
+  // The schema calls the field a "bare tweet ID", extractTweetId matches /^\d+$/,
+  // and the failure message offers it — so {"url": 20} must keep working.
+  assert.equal(readUrlArg(20), "20");
+  assert.equal(extractTweetId(readUrlArg(20)), "20");
+  assert.equal(readUrlArg(0), "0");
+});
+
+test("readUrlArg: objects and arrays are rejected, not stringified", () => {
+  assert.equal(String({ url: "x" }), "[object Object]"); // the trap
+  assert.equal(readUrlArg({ url: "x" }), "");
+  assert.equal(readUrlArg(["https://x.com/jack/status/20"]), "");
+  assert.equal(readUrlArg(null), "");
+  assert.equal(readUrlArg(undefined), "");
+});
+
+test("readUrlArg: non-integer and unsafe numbers are not ids", () => {
+  assert.equal(readUrlArg(1.5), "");
+  assert.equal(readUrlArg(-20), "");
+  assert.equal(readUrlArg(Number.MAX_SAFE_INTEGER + 2), "");
 });

--- a/server/events/relay-client.ts
+++ b/server/events/relay-client.ts
@@ -37,6 +37,14 @@ interface Logger {
   error: (prefix: string, msg: string, data?: Record<string, unknown>) => void;
 }
 
+// `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
+// binaryType is nodebuffer so a Buffer is what actually arrives, but the type
+// admits ArrayBuffer — whose `toString()` is the literal "[object ArrayBuffer]",
+// i.e. a frame silently parsed as garbage. Normalise instead of trusting the
+// runtime default to hold.
+const frameText = (data: Buffer | ArrayBuffer | Buffer[]): string =>
+  Buffer.isBuffer(data) ? data.toString("utf8") : Array.isArray(data) ? Buffer.concat(data).toString("utf8") : Buffer.from(data).toString("utf8");
+
 export interface RelayClientDeps {
   relayUrl: string;
   relayToken: string;
@@ -280,7 +288,7 @@ function attachSocketHandlers(socket: WebSocket, deps: AttachSocketHandlersDeps)
     // One bad message must not take the socket down: `handleRelayMessage`
     // already logs the failures it anticipates, so anything reaching here is
     // unexpected and only needs to be recorded, not propagated.
-    void handleRelayMessage(String(data), { relay, logger, sendResponse: queue.send }).catch((err: unknown) => {
+    void handleRelayMessage(frameText(data), { relay, logger, sendResponse: queue.send }).catch((err: unknown) => {
       logger.error(LOG_PREFIX, "relay message handler threw", { error: String(err) });
     });
   });

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -316,6 +316,7 @@ function resolveOauthCallbackAlias(name: string, mod: Record<string, unknown>): 
   const raw = mod.OAUTH_CALLBACK_ALIAS;
   if (raw === undefined) return null;
   if (typeof raw !== "string" || !OAUTH_CALLBACK_ALIAS_RE.test(raw)) {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- this branch exists BECAUSE `raw` is the wrong shape; echoing whatever it stringifies to is the diagnostic.
     log.warn(LOG_PREFIX, "OAUTH_CALLBACK_ALIAS export is not a valid alias — ignoring", { name, raw: String(raw) });
     return null;
   }

--- a/server/system/logger/formatters.ts
+++ b/server/system/logger/formatters.ts
@@ -19,6 +19,7 @@ function stringifyScalar(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string -- JSON.stringify threw on this log value. A log line reading "[object Object]" is poor; a log line reading "" hides that anything was logged at all.
     return String(value);
   }
 }

--- a/src/composables/useMarkdownDoc.ts
+++ b/src/composables/useMarkdownDoc.ts
@@ -18,9 +18,11 @@ export function formatScalarField(value: unknown): string {
       return JSON.stringify(value);
     } catch {
       // Cyclic object → can't stringify; fall back to String() rather than throw inside a template.
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string -- that fallback is the point: rendering "[object Object]" in the doc beats throwing mid-render.
       return String(value);
     }
   }
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string -- unreachable for objects: the `typeof value === "object"` branch above returns. Only primitives arrive here, and the rule does not narrow through the early return.
   return String(value);
 }
 

--- a/src/plugins/wiki/history/diff.ts
+++ b/src/plugins/wiki/history/diff.ts
@@ -141,5 +141,6 @@ function formatYamlValue(value: unknown): string {
     if (/^[A-Za-z0-9_\-./]+$/.test(value)) return value;
     return JSON.stringify(value);
   }
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string -- reached only for values JSON.stringify cannot represent; a diff line showing "[object Object]" is more informative than an empty one.
   return String(value);
 }


### PR DESCRIPTION
## Summary

The final **13 → 0**, and the rule graduates from `warn` to **`error`**.

They split three ways, and reading them one at a time was the only way to tell which was which — a blanket treatment would have been wrong for two of the three groups.

## Genuine bugs I nearly waved through (3)

I had the WebSocket handlers filed as false positives: a `Buffer` stringifies fine, so `.toString()` looked harmless. Checking the actual type says otherwise — `ws` types the listener argument `Buffer | ArrayBuffer | Buffer[]`:

```
Buffer.toString()      -> "hi"
Buffer[].toString()    -> "a,b"
ArrayBuffer.toString() -> "[object ArrayBuffer]"
```

The default `binaryType` is `nodebuffer`, so a Buffer is what arrives in practice — but nothing in the type guarantees it, and an `ArrayBuffer` would be parsed as a frame of garbage with no error. `frameText()` normalises all three shapes in mastodon, signal and relay-client.

Had I trusted my first read, these would have gone in under an "audited" disable — a label that would then have been actively misleading.

## Real reads (2)

`x-plugin`'s `url` and `query` come from model-generated tool args — same shape as the `manageSkills` name in #2211. Now `typeof`-checked.

## Audited disables (8)

Per [`docs/lint-policy.md`](../blob/main/docs/lint-policy.md)'s `--` rationale convention. All are places where **`JSON.stringify` has already failed**, plus one value the rule can't narrow and one deliberate diagnostic:

| site | why |
|---|---|
| `csvStore` ×2 | serialiser returned undefined / threw — `""` would erase that the cell held anything |
| `logger/formatters` | a log line reading `""` hides that anything was logged |
| `useMarkdownDoc` ×2 | cyclic object mid-render; one site is unreachable for objects at all |
| `wiki/history/diff` | a diff line showing `[object Object]` beats an empty one |
| `whisper/client` | `FileReader.result` is `string \| ArrayBuffer \| null`; `readAsDataURL` always yields the string branch |
| `runtime-loader` | logs a value **because** it is the wrong shape — echoing it is the diagnostic |

Each carries its own reason, not a boilerplate one.

## Items to Confirm / Review

- **The disables are the part worth a second opinion.** I read each as "losing the value entirely is worse than a placeholder", but that's a judgement call per site — if any of them should instead return `""` or throw, this is the moment to say so.
- **`frameText` is duplicated across three files** rather than shared. They're in three different packages (`bridges/*`, `server/`) with no common util, and it's four lines. Happy to pull it into a shared module if you'd rather.
- **Ratchet**: with the count at zero there's nothing to grandfather, so a new `String(possiblyObject)` now fails CI instead of joining a 168-warning backlog.

## Verification

`build:packages` / `typecheck` / `lint` / `test` all clean; repo errors 0 with the rule at `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket message decoding across Mastodon, Signal, and relay connections, correctly handling binary payloads (e.g., `Buffer`/`ArrayBuffer`) instead of producing incorrect string output.
  * Improved notification/relay frame parsing and X post/search input handling by rejecting invalid non-text/non-integer values rather than coercing them into misleading strings.
* **Tests**
  * Added coverage for the new X URL-argument validation behavior, including edge cases like `0` and rejection of unsafe/non-integer inputs.
* **Chores**
  * Tightened TypeScript linting around base-to-string conversions and added targeted lint suppressions where stringification is explicitly intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->