### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.4.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,50 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [1.4.0] - 2026-07-20
+
+**Collections grow a map, and the npm launcher finally ships what it promises.** The `/collections` page gains an ontology graph, calendar events sync into collections, and — importantly for anyone installing from npm — this launcher is the first to carry the current `@mulmoclaude/*` line.
+
+### Highlights
+
+#### Collections — ontology graph panel (#2218)
+
+The `/collections` page gains a **Map** tab that draws the ontology across your collections: each schema is a node, each `ref` field an edge, so you can see how records point at each other instead of inferring it from schema files. Reverse edges collapse by their declared `via`.
+
+#### Collections — calendar sync, file query, flag fields, delete (#2095, #2182, #2184, #2200, #2204)
+
+Google Calendar events now sync into a collection, incrementally after the first pass (#2182, #2184). `manageCollection` can delete items (#2200). New `flag` field type with its own chip styling (#2211, #2101). File-backed queries (`dataSource`) landed alongside storage virtualization for view images (#2204).
+
+#### The `String()`-coercion family (#2208, #2210, #2211, #2213, #2215, #2223, #2225)
+
+A `@typescript-eslint/no-base-to-string` sweep found seven places where a non-string value was being stringified into `"[object Object]"` on its way to a user, a filename, or a webhook signature check — collection scalar values, workspace dir names, MCP skill args, relay webhook secrets, the accounting router's action args, and two collection paths. Each was fixed at the source rather than papered over at the render site.
+
+#### Relay — fail closed on a misconfigured signing secret (#2213)
+
+A malformed or absent webhook signing secret now rejects the request instead of falling through to the handler. Credentials are read as strings-or-absent via `envSecret`, so a missing platform binding can no longer arrive as the literal `"undefined"` and be treated as configured.
+
+#### Shared helpers consolidated into core (#2217, #2219)
+
+`errorMessage` existed 14 times across 4 behaviours — gRPC-shaped errors surfaced as `"quota exceeded"` through the host copy and `"[object Object]"` through the core ones. `truncate`'s core copy had dropped the guard that keeps output inside `max`. Both now live once in the new browser-safe `@mulmoclaude/core/utils`, with the host re-exporting. `docs/shared-utils.md` gained a "Known duplicates" table, since the catalog's failure mode was naming one member of a family and hiding the rest.
+
+#### Sandbox — the frozen-CLI failure mode is now self-diagnosable (#2202, #2214)
+
+The sandbox image installs the Claude CLI unpinned, and neither an upstream release nor `docker rmi` refreshes it (the rebuild reuses the cached `npm install -g` layer). `error-recovery.md` now carries the symptom, the in-image version check, and the `docker builder prune -a -f` recovery; `docs/developer.md` no longer claims `yarn sandbox:remove` forces a rebuild.
+
+#### Google sign-in — retry after abandoning browser consent (#2171)
+
+Abandoning the browser consent screen previously left the link unretryable.
+
+### Fixes
+
+Chat sticky-bottom scroll (#2205), shadow-DOM-safe dropdown dismiss on `/collections` (#2212), collection live-refresh on direct writes (#2199), wiki summary schema left unwritten (#2226), Windows sandbox preset mount drift, floating promises across host and packages (#2191), unreachable type comparisons (#2207).
+
+Ships `@mulmoclaude/core@0.28.0`, `@mulmoclaude/collection-plugin@0.14.0`, `@mulmoclaude/google-plugin@0.3.2`, `@mulmoclaude/accounting-plugin@0.3.3`.
+
+> **Note for npm users:** `mulmoclaude@1.3.0` shipped dep ranges pinned to `@mulmoclaude/core@^0.23.0` and `@mulmoclaude/collection-plugin@^0.12.0`. A caret range on a `0.x` package does not float across minors, so installs of 1.3.0 could not receive anything published since — including most of the above. 1.4.0 is the first launcher that actually delivers it.
+
+---
+
 ## [1.3.0] - 2026-07-18
 
 **Your other calendars, in colour.** The Google tool now sees every calendar you've subscribed to — not just your primary — and carries each event's colour. Plus read-only CSV data collections backed by DuckDB.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -116,7 +116,7 @@ Recommended: ≥ 32 characters of random data (shorter values trigger a startup 
 
 - **Roles** (sidebar selector): General, Office, Guide & Planner, Artist, Tutor, Storyteller, Settings. Each one biases Claude toward a workflow and surfaces its sample prompts.
 - **Skills** (`~/.claude/skills/<name>/SKILL.md`): personal skills shared across every project, plus project skills under `<workspace>/.claude/skills/`. Bundled "preset" skills (`mc-*`) re-seed on each boot.
-- **Collections**: schema-driven data apps. Author your own (`data/skills/<slug>/schema.json` declares the model + UI), or use the Discover tab on `/collections` to import community collections from the official registry — or your own org / community registry by dropping `config/collections-registries.json` in the workspace.
+- **Collections**: schema-driven data apps. Author your own (`data/skills/<slug>/schema.json` declares the model + UI), or use the Discover tab on `/collections` to import community collections from the official registry — or your own org / community registry by dropping `config/collections-registries.json` in the workspace. The Map tab draws the ontology graph across your collections, so you can see how their records reference each other.
 
 ## Optional features
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`mulmoclaude@1.4.0` を npm に publish 済み。本PRはその version bump と CHANGELOG を取り込みます。

**このリリースの本質は依存 range です。** npm 上の `mulmoclaude@1.3.0` は `@mulmoclaude/core: ^0.23.0` / `collection-plugin: ^0.12.0` を出荷していました。0.x への caret は minor をまたがない（`^0.23.0` = `>=0.23.0 <0.24.0`）ため、**npm 経由のユーザーは core 0.24〜0.28 やそれ以降の collection 関連の変更を一切受け取れていませんでした**。1.4.0 が初めてそれらを届けます。

## Items to Confirm / Review

1. **publish は既に完了しています**（スキルの手順どおり、publish → PR → マージ後にタグ）。npm 上の 1.4.0 が出荷する range が `^0.28.0` / `^0.14.0` / `^0.3.2` / `^0.3.3` であることを確認済みです。
2. **root と launcher の version を揃えています**（両方 1.4.0）。`vX.Y.Z` タグと npm の識別子がずれると「今どれを動かしているのか」が曖昧になるため（skill §5.5、v0.9.3 の事例）。
3. **バージョン幅を minor (1.4.0) と判断しました** — ontology graph panel 等の新機能がユーザーに届くためです。patch が適切と思われる場合は指摘ください。
4. **README に1行追記しました** — 1.3.0 以降でユーザーに見える新機能のうち、`/collections` の Map タブだけ記載がありませんでした。

## User Prompt

- 本体の publish に進んで
- range は常に最新に合わせるようにして（→ 別PR #2229）
- ブリッジもバージョン上げたほうが良いの？依存変わったから

> ブリッジの bump は**不要**と判断しました。`^0.1.4` は既に `>=0.1.4 <0.2.0` なので client 0.1.5 は現状でも解決されます。range 更新は下限の保証を変えるだけで解決結果は変わらないため、各ブリッジの次回リリースに相乗りさせます（#2229 で CLAUDE.md に明記）。

## publish 前の検証（すべて green）

| チェック | 結果 |
|---|---|
| §1 依存監査 (`deps.mjs`) | OK — 不足なし |
| §2 workspace ドリフト (`drift.mjs`) | OK — chat-service / client / protocol / web-push すべて src == published |
| §6 `@mulmoclaude/*` 解決確認（手動、drift が見ない範囲） | 11件すべて local == npm == range |
| §3.5 README | CLI フラグ・env var・機能記載を照合、Map タブを追記 |
| §4 tarball スモーク | クリーンインストールから起動、**HTTP 200**、runtime plugins=5 |
| §6 検証 | `npx --registry=... mulmoclaude@1.4.0 --version` → `mulmoclaude 1.4.0` |

## 変更内容

| ファイル | 内容 |
|---|---|
| `package.json` | 1.3.0 → 1.4.0（root。`/release-app` がタグする識別子） |
| `packages/mulmoclaude/package.json` | 1.3.0 → 1.4.0（npm の識別子） |
| `packages/mulmoclaude/README.md` | `/collections` Map タブ（ontology graph, #2218）を1行追記 |
| `docs/CHANGELOG.md` | `## [1.4.0] - 2026-07-20` を追加（v1.3.0 以降の40 PR を反映） |

## マージ後の残作業

skill §9b に従い、マージ後に `main` で `v1.4.0` タグを打ち、`--latest` で GitHub リリースを作成します（アプリリリースのみ `--latest`、パッケージリリースは `--latest=false`）。**タグは push 前に確認します。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
