### PR TITLE
fix: 到達できないバックエンドを「データが無い」に潰さない

### DIFF
--- a/packages/core/src/collection/core/ontologyGraph.ts
+++ b/packages/core/src/collection/core/ontologyGraph.ts
@@ -30,7 +30,11 @@ export interface CollectionOntologyEntry {
   /** The effective display field: the schema's `displayField`, falling
    *  back to the primaryKey exactly as render-time labelling does. */
   displayField: string;
-  recordCount: number;
+  /** Records in the collection, or `null` when the backend couldn't be
+   *  reached to count them (an engine that failed to load, a closed
+   *  session). Deliberately not 0: an unreachable collection reported as
+   *  empty invites "restoring" data that is intact but out of reach. */
+  recordCount: number | null;
   relations: OntologyRelation[];
 }
 
@@ -38,7 +42,7 @@ export interface OntologyGraphNode {
   slug: string;
   title: string;
   icon: string;
-  recordCount: number;
+  recordCount: number | null;
   /** No discovered collection has this slug — the node exists only
    *  because a relation points at it. Rendered as a ghost so the graph
    *  doubles as a broken-ref lint surface (lint, not lock). */
@@ -120,6 +124,8 @@ export const buildOntologyGraph = (entries: CollectionOntologyEntry[]): Ontology
   const known = new Set(entries.map((entry) => entry.slug));
   const nodes: OntologyGraphNode[] = entries.map(({ slug, title, icon, recordCount }) => ({ slug, title, icon, recordCount }));
   for (const slug of ghostSlugs(edges, known)) {
+    // A ghost node has no collection behind it at all, so it genuinely holds
+    // no records — 0, not the "couldn't count" null.
     nodes.push({ slug, title: slug, icon: "", recordCount: 0, missing: true });
   }
   return { nodes, edges };

--- a/packages/core/src/collection/server/backendAvailability.ts
+++ b/packages/core/src/collection/server/backendAvailability.ts
@@ -1,0 +1,30 @@
+// "The backend can't serve this right now" — as distinct from "the record
+// isn't there" or "the stored record is malformed".
+//
+// Both non-file backends have such a state, and neither is a data problem:
+//
+//   - sqlite: `node:sqlite` needs Node >= 22.5, and the app's floor is 20.12,
+//     so on an older runtime ONLY sqlite collections fail (sqliteStore.ts).
+//   - csv/dataSource: `@duckdb/node-api` is a native module whose prebuilt
+//     binding can be missing for the platform (csvStore.ts).
+//
+// The distinction matters because the layers above catch broadly. Without a
+// type to test, `store.read(...).catch(() => null)` reports "record missing",
+// a merge reports "malformed stored file", and an ontology count reports 0 —
+// each of which sends the agent after a data problem that does not exist, and
+// the last of which can have it offer to recreate records that are intact.
+//
+// Anything that summarises or swallows a store error MUST re-check with
+// `isBackendUnavailable` and let it through.
+
+/** Thrown by a store when its engine or session cannot serve the request. */
+export class BackendUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BackendUnavailableError";
+  }
+}
+
+export function isBackendUnavailable(err: unknown): err is BackendUnavailableError {
+  return err instanceof BackendUnavailableError;
+}

--- a/packages/core/src/collection/server/csvStore.ts
+++ b/packages/core/src/collection/server/csvStore.ts
@@ -27,6 +27,7 @@
 // packages/core/assets/helps/error-recovery.md.
 
 import { fieldTextOrNull } from "../core/fieldText";
+import { BackendUnavailableError } from "./backendAvailability";
 import { lstat, mkdir, open, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { createHash, randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -305,7 +306,9 @@ async function duckDbInstance(): ReturnType<DuckDbModule["DuckDBInstance"]["crea
     return await instancePromise;
   } catch (err) {
     instancePromise = null;
-    throw new Error(`DuckDB is unavailable on this host (@duckdb/node-api failed to load: ${String(err)}) — dataSource collections cannot be read`);
+    throw new BackendUnavailableError(
+      `DuckDB is unavailable on this host (@duckdb/node-api failed to load: ${String(err)}) — dataSource collections cannot be read`,
+    );
   }
 }
 

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -21,6 +21,7 @@ export * from "./paths";
 export * from "./templatePath";
 export * from "./io";
 export * from "./store";
+export { BackendUnavailableError, isBackendUnavailable } from "./backendAvailability";
 export { MAX_CSV_ROWS, encodeCsvRecordId, decodeCsvRecordId, normalizeCsvValue, csvRowToItem, dedupeByRecordId } from "./csvStore";
 export { compileCsvQuery, compileJsonlQuery } from "./csvQuery";
 export { runQueryOverRows } from "./jsonlQuery";

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -52,6 +52,7 @@ import { loadCollection, type DiscoveryOptions } from "./discovery";
 import type { LoadedCollection } from "./discoveredCollection";
 import { resolveCreateItemId } from "./io";
 import { readOnlyRefusal, storeFor, type CollectionStore } from "./store";
+import { isBackendUnavailable } from "./backendAvailability";
 import { runCollectionQuery } from "./queryRunner";
 import { enrichItems } from "./derive";
 import { validateCollectionRecords, validateRecordObject } from "./validate";
@@ -172,7 +173,13 @@ async function loadRequestedItems(
     // is null) — for the tool that's a `missing` entry, not a failed call:
     // the warning scan that runs whenever something is missing then names
     // the broken file and how to fix it.
-    const item = await store.read(recordId).catch(() => null);
+    const item = await store.read(recordId).catch((err: unknown) => {
+      // An UNAVAILABLE backend is not an absent record. Flattening it into
+      // `missing` would have the agent hunt a data problem that doesn't
+      // exist — and the repair scan then blames files that are fine.
+      if (isBackendUnavailable(err)) throw err;
+      return null;
+    });
     if (item) items.push(item);
     else missing.push(recordId);
   }
@@ -245,7 +252,11 @@ async function mergeWithExisting(
   let existing: CollectionItem | null;
   try {
     existing = await store.read(itemId);
-  } catch {
+  } catch (err) {
+    // Same distinction as loadRequestedItems: an unreachable backend is not a
+    // broken record, and telling the agent to "fix the file" points it at a
+    // file that may not even exist for this backend.
+    if (isBackendUnavailable(err)) throw err;
     return `'${itemId}' has a malformed stored file — mode "merge" needs to read it; fix the file (Read → correct → Write) or replace it whole with "upsert"`;
   }
   if (!existing) return `'${itemId}' not found — mode "merge" updates an existing record; use "upsert" or "create" to add it`;
@@ -543,6 +554,18 @@ async function dispatchRecordAction(action: string, collection: LoadedCollection
 // `makeManageCollectionTool` stays under the max-lines threshold; each branch
 // already delegates to a handler.
 async function manageCollectionHandler(deps: ManageCollectionDeps, args: Record<string, unknown>): Promise<string> {
+  try {
+    return await dispatchManageCollection(deps, args);
+  } catch (err) {
+    // An unreachable backend is an ANSWER, not a crash: the tool's contract is
+    // actionable text, and the message already says what to do about it.
+    // Letting it throw would surface as a tool failure with no guidance.
+    if (isBackendUnavailable(err)) return `manageCollection: ${err.message}`;
+    throw err;
+  }
+}
+
+async function dispatchManageCollection(deps: ManageCollectionDeps, args: Record<string, unknown>): Promise<string> {
   const action = typeof args.action === "string" ? args.action : "";
   if (action === "schemaDocs") return handleSchemaDocs(deps);
   if (action === "getOntology") return handleGetOntology(deps);

--- a/packages/core/src/collection/server/ontology.ts
+++ b/packages/core/src/collection/server/ontology.ts
@@ -11,6 +11,7 @@ import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { discoverCollections, type DiscoveryOptions } from "./discovery";
 import { storeFor } from "./store";
+import { isBackendUnavailable } from "./backendAvailability";
 import { storageKindFor } from "../core/schema";
 import { isRegularFile } from "./io";
 import { isContainedInRoot } from "./paths";
@@ -67,11 +68,15 @@ async function countRecordFiles(dataDir: string, workspaceRoot: string): Promise
  *  the readdir count would always misreport 0. Fail-soft to 0 like
  *  `countRecordFiles` (an unreadable file / missing engine must not
  *  break the whole ontology). */
-async function countRecords(collection: LoadedCollection, workspaceRoot: string): Promise<number> {
+async function countRecords(collection: LoadedCollection, workspaceRoot: string): Promise<number | null> {
   if (storageKindFor(collection.schema) !== "file") {
     try {
       return (await storeFor(collection, { workspaceRoot }).page({ limit: 0 })).total;
-    } catch {
+    } catch (err) {
+      // `null` = "couldn't count", which is NOT zero. Reporting an
+      // unreachable backend as 0 reads as "this collection is empty" and
+      // invites the agent to repopulate records that are perfectly intact.
+      if (isBackendUnavailable(err)) return null;
       return 0;
     }
   }

--- a/packages/core/src/collection/server/sqliteStore.ts
+++ b/packages/core/src/collection/server/sqliteStore.ts
@@ -27,6 +27,7 @@
 // publishes" true for every backend.
 
 import { lstat, mkdir } from "node:fs/promises";
+import { BackendUnavailableError } from "./backendAvailability";
 import path from "node:path";
 import type { CollectionItem } from "../core/schema";
 import type { LoadedCollection } from "./discoveredCollection";
@@ -61,7 +62,7 @@ function loadSqlite(): Promise<SqliteModule> {
     (mod) => mod as unknown as SqliteModule,
     (err: unknown) => {
       sqliteModule = null; // allow a retry (e.g. tests stubbing the runtime)
-      throw new Error(`sqlite storage needs the node:sqlite module (Node.js >= 22.5) — this runtime cannot load it: ${String(err)}`);
+      throw new BackendUnavailableError(`sqlite storage needs the node:sqlite module (Node.js >= 22.5) — this runtime cannot load it: ${String(err)}`);
     },
   );
   return sqliteModule;

--- a/packages/core/test/collection/test_backendAvailability.ts
+++ b/packages/core/test/collection/test_backendAvailability.ts
@@ -1,0 +1,27 @@
+// `BackendUnavailableError` exists so the layers above a store can tell
+// "the backend can't serve this" from "the record isn't there". Those layers
+// catch broadly (`catch(() => null)`, `catch { return 0 }`), so the guard is
+// load-bearing in BOTH directions: it must match the real thing, and it must
+// NOT match ordinary errors — a guard that matched everything would turn
+// every genuine failure into "unavailable" and hide real faults.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { BackendUnavailableError, isBackendUnavailable } from "../../src/collection/server/backendAvailability.ts";
+
+test("matches a backend-unavailable error and carries its message", () => {
+  const err = new BackendUnavailableError("sqlite storage needs the node:sqlite module (Node.js >= 22.5)");
+  assert.equal(isBackendUnavailable(err), true);
+  assert.match(err.message, /node:sqlite/);
+  assert.equal(err.name, "BackendUnavailableError");
+  assert.ok(err instanceof Error, "must stay a real Error so existing catch sites keep working");
+});
+
+test("does NOT match ordinary failures", () => {
+  assert.equal(isBackendUnavailable(new Error("ENOENT: no such file or directory")), false);
+  assert.equal(isBackendUnavailable(new TypeError("x is not a function")), false);
+  assert.equal(isBackendUnavailable("a string throw"), false);
+  assert.equal(isBackendUnavailable(null), false);
+  assert.equal(isBackendUnavailable(undefined), false);
+  assert.equal(isBackendUnavailable({ name: "BackendUnavailableError" }), false, "a look-alike object must not pass — the guard is by type, not by shape");
+});

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionOntologyGraphView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionOntologyGraphView.vue
@@ -42,7 +42,10 @@ let instance: echarts.ECharts | null = null;
 
 // Log-scaled by record count so a big collection reads bigger without
 // dwarfing the graph; ghosts stay minimal.
-const nodeSize = (node: OntologyGraphNode): number => (node.missing ? 14 : Math.min(40, 20 + Math.round(Math.log2(node.recordCount + 1) * 4)));
+// `recordCount === null` means the backend couldn't be counted (engine
+// failed to load, session closed) — size it like an empty collection rather
+// than pretending to know, and let the tooltip say so.
+const nodeSize = (node: OntologyGraphNode): number => (node.missing ? 14 : Math.min(40, 20 + Math.round(Math.log2((node.recordCount ?? 0) + 1) * 4)));
 
 const nodeItem = (node: OntologyGraphNode): object => ({
   id: node.slug,
@@ -66,9 +69,10 @@ const edgeItem = (edge: OntologyGraphEdge): object => ({
   reverseFields: edge.reverseFields,
 });
 
-const nodeTooltip = (data: { id: string; name: string; missing: boolean; recordCount: number }): string => {
+const nodeTooltip = (data: { id: string; name: string; missing: boolean; recordCount: number | null }): string => {
   if (data.missing) return `<b>${escapeHtml(data.id)}</b><br>${escapeHtml(t("collectionsView.mapMissingHint"))}`;
-  return `<b>${escapeHtml(data.name)}</b><br>${escapeHtml(data.id)} · ${escapeHtml(t("collectionsView.mapRecordCount", { count: data.recordCount }))}`;
+  const count = data.recordCount === null ? t("collectionsView.mapRecordCountUnknown") : t("collectionsView.mapRecordCount", { count: data.recordCount });
+  return `<b>${escapeHtml(data.name)}</b><br>${escapeHtml(data.id)} · ${escapeHtml(count)}`;
 };
 
 const edgeTooltip = (data: { source: string; target: string; field: string; kind: string; reverseFields?: string[] }): string => {

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -60,6 +60,7 @@ const deMessages: CollectionMessages = {
     mapTab: "Karte",
     mapEmpty: "Noch nichts zu zeigen — die Karte entsteht von selbst, sobald Sammlungen und ihre Verknüpfungen entstehen.",
     mapRecordCount: "{count} Einträge",
+    mapRecordCountUnknown: "Anzahl der Datensätze nicht verfügbar",
     mapMissingHint: "Keine Sammlung mit diesem Slug — eine Relation verweist darauf.",
     notFound: "Sammlung nicht gefunden",
     loadFailed: "Laden fehlgeschlagen",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -57,6 +57,7 @@ const enMessages = {
     mapTab: "Map",
     mapEmpty: "Nothing to map yet — the map draws itself as collections and the links between them appear.",
     mapRecordCount: "{count} records",
+    mapRecordCountUnknown: "record count unavailable",
     mapMissingHint: "No collection with this slug — a relation points at it.",
     notFound: "Collection not found",
     loadFailed: "Failed to load",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -60,6 +60,7 @@ const esMessages: CollectionMessages = {
     mapTab: "Mapa",
     mapEmpty: "Nada que mostrar todavía: el mapa se dibuja solo a medida que aparecen colecciones y los enlaces entre ellas.",
     mapRecordCount: "{count} registros",
+    mapRecordCountUnknown: "recuento de registros no disponible",
     mapMissingHint: "No existe una colección con este slug; una relación apunta a ella.",
     notFound: "Colección no encontrada",
     loadFailed: "Error al cargar",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -61,6 +61,7 @@ const frMessages: CollectionMessages = {
     mapTab: "Carte",
     mapEmpty: "Rien à afficher pour l'instant — la carte se dessine d'elle-même à mesure que les collections et leurs liens apparaissent.",
     mapRecordCount: "{count} enregistrements",
+    mapRecordCountUnknown: "nombre d'enregistrements indisponible",
     mapMissingHint: "Aucune collection avec ce slug — une relation pointe vers elle.",
     notFound: "Collection introuvable",
     loadFailed: "Échec du chargement",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -59,6 +59,7 @@ const jaMessages: CollectionMessages = {
     mapTab: "マップ",
     mapEmpty: "まだ表示するものがありません。コレクションとその間のリンクが増えると、マップが自動的に描かれます。",
     mapRecordCount: "{count} 件のレコード",
+    mapRecordCountUnknown: "レコード数を取得できません",
     mapMissingHint: "このスラッグのコレクションは存在しません。リレーションが参照しています。",
     notFound: "コレクションが見つかりません",
     loadFailed: "読み込みに失敗しました",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -59,6 +59,7 @@ const koMessages: CollectionMessages = {
     mapTab: "맵",
     mapEmpty: "아직 표시할 내용이 없습니다. 컬렉션과 그 사이의 링크가 생기면 맵이 자동으로 그려집니다.",
     mapRecordCount: "레코드 {count}개",
+    mapRecordCountUnknown: "레코드 수를 가져올 수 없음",
     mapMissingHint: "이 슬러그의 컬렉션이 없습니다. 관계가 이를 참조하고 있습니다.",
     notFound: "컬렉션을 찾을 수 없습니다",
     loadFailed: "불러오기에 실패했습니다",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -60,6 +60,7 @@ const ptBRMessages: CollectionMessages = {
     mapTab: "Mapa",
     mapEmpty: "Nada para mostrar ainda — o mapa se desenha sozinho conforme coleções e os vínculos entre elas aparecem.",
     mapRecordCount: "{count} registros",
+    mapRecordCountUnknown: "contagem de registros indisponível",
     mapMissingHint: "Nenhuma coleção com este slug — uma relação aponta para ela.",
     notFound: "Coleção não encontrada",
     loadFailed: "Falha ao carregar",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -58,6 +58,7 @@ const zhMessages: CollectionMessages = {
     mapTab: "地图",
     mapEmpty: "暂无可显示的内容。随着集合及其之间的链接增多，地图会自动绘制。",
     mapRecordCount: "{count} 条记录",
+    mapRecordCountUnknown: "无法获取记录数",
     mapMissingHint: "不存在此 slug 的集合，但有关系指向它。",
     notFound: "未找到集合",
     loadFailed: "加载失败",

--- a/test/utils/collections/test_ontologyGraph.ts
+++ b/test/utils/collections/test_ontologyGraph.ts
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 
 import { buildOntologyGraph, type CollectionOntologyEntry, type OntologyRelation } from "@mulmoclaude/core/collection";
 
-const entry = (slug: string, relations: OntologyRelation[] = [], recordCount = 0): CollectionOntologyEntry => ({
+const entry = (slug: string, relations: OntologyRelation[] = [], recordCount: number | null = 0): CollectionOntologyEntry => ({
   slug,
   title: slug.toUpperCase(),
   icon: "📦",
@@ -138,5 +138,27 @@ describe("buildOntologyGraph — edges", () => {
       entry("invoices", [{ field: "clientCard", kind: "embed", to: "clients" }]),
     ]);
     assert.deepEqual(graph.edges.map((edge) => edge.kind).sort(), ["backlinks", "embed"]);
+  });
+});
+
+describe("recordCount — unreachable is not empty", () => {
+  // A backend that couldn't be counted (engine failed to load, session
+  // closed) reports `null`, never 0. Zero says "this collection is empty",
+  // which invites restoring records that are intact but out of reach.
+  it("carries a null count through to the graph node", () => {
+    const graph = buildOntologyGraph([entry("cloud", [], null)]);
+    const node = graph.nodes.find((candidate) => candidate.slug === "cloud");
+    assert.ok(node);
+    assert.equal(node.recordCount, null, "an uncounted collection must stay null, not collapse to 0");
+  });
+
+  it("still uses 0 for a ghost node, which genuinely holds nothing", () => {
+    // A relation pointing at a slug no collection provides: the node exists
+    // only as a broken-ref marker, so 0 is the honest count.
+    const graph = buildOntologyGraph([entry("orders", [{ kind: "ref", field: "customer", to: "customers" }])]);
+    const ghost = graph.nodes.find((candidate) => candidate.slug === "customers");
+    assert.ok(ghost);
+    assert.equal(ghost.missing, true);
+    assert.equal(ghost.recordCount, 0);
   });
 });


### PR DESCRIPTION
## Summary

**Node 22.5 未満で sqlite collection を開くと、データは無事なのに「空のコレクション」に見えます。** 今日実在する不具合です。

sqlite と csv(dataSource) はどちらも「エンジンが使えない」状態を持ちます:

- **sqlite** — `node:sqlite` は Node >= 22.5 が必要（アプリの下限は 20.12）
- **csv** — `@duckdb/node-api` はネイティブ依存で、プラットフォームによって読めない

どちらも**データの問題ではありません**。ところが上位が広く catch していたため、別の意味に化けていました:

| 箇所 | 化けた先 | 何が起きるか |
|---|---|---|
| `manageTool` `loadRequestedItems` | `catch(() => null)` → **missing** | エージェントが存在しないデータ問題を追う |
| `manageTool` `mergeWithExisting` | **malformed stored file** | 存在しないかもしれないファイルの修復を指示 |
| `ontology` `countRecords` | `catch { return 0 }` → **0件** | **「空だから復元しよう」を誘発** |

最後が一番まずく、**無事なレコードの再作成を提案しかねません**。

#2209（Firestore backend、取り込まない方針）から切り出した2本目です（1本目は #2231）。Firestore 抜きでも既存2バックエンドに効きます。

## Items to Confirm / Review

- **`recordCount` を `number | null` にした点** — 0 は「空」を意味してしまうので、「数えられなかった」は `null` にしました。`OntologyGraphNode` にも波及し、グラフのツールチップに専用文言を追加しています（全8ロケール lockstep）。ghost ノードは**本当に空**なので 0 のままにしてあります
- **型ガードの厳しさ** — `instanceof` で判定しています。形だけ似せたオブジェクト（`{ name: "BackendUnavailableError" }`）は通しません。緩いと全ての障害が「未到達」に化けて本当の異常を隠すためで、テストでも否定側を固定しました
- **ツール契約への変換** — `manageCollectionHandler` で実行可能な文字列に変換しています。ツールの契約は throw ではなくテキストなので、そのまま throw すると案内の無い失敗になります

## テストのカバレッジ（正直な注記）

**エンドツーエンドの経路は CI で再現できません。**

- sqlite の `withDb` は missing/refused を **throw せず**扱うので、throw するのはモジュール読み込み失敗時のみ。Node 24 の CI では `node:sqlite` は必ず読めます
- DuckDB も同様に、CI では必ず読めます

そのため決定的に検証できるものだけをテストしました:

- **型ガードの両方向** — 本物に一致し、通常のエラー・文字列・null・形だけ似せたオブジェクトには一致しない
- **`null` の伝播** — グラフノードまで 0 に潰れずに届くこと、ghost は 0 のままであること

化ける側の3箇所は**読んで確認**しました。テストで押さえられていない点は認識しています。

## User Prompt

> 2209は取り込まない予定なんだけど、それベースになんとかrefactorして切り出す？
>
> （切り出し方の選択肢から）バグ修正を先に分離

## 検証

`yarn format` / `lint`(0 errors) / `typecheck` / `build` / host `test`(fail 0) / core `test`(396 pass) すべて green。main 取り込み済み。

## この後

#2209 から切り出す残りと、storage package 化に向けた道筋:

1. ~~watcher の backend 非依存バグ~~ → #2231 マージ済み
2. ~~`BackendUnavailableError`~~ → 本 PR
3. **`watch?()` を store 契約に入れて watcher から backend 分岐を消す** — package 化の前提。今は `startStorageWatcher` が sqlite の `.db` を知っているので、store だけ切り出しても「バックエンド追加＝2箇所触る」構造が残ります
4. **storage の package 化** — 契約テスト（`test_storeContract.ts`）が既にあるので境界の条件は揃っています

🤖 Generated with [Claude Code](https://claude.com/claude-code)