### PR TITLE
fix: close two type-guard drifts from the #2219 duplicate audit (#2220, #2221)

### DIFF
--- a/packages/plugins/spotify-plugin/src/normalize.ts
+++ b/packages/plugins/spotify-plugin/src/normalize.ts
@@ -48,7 +48,11 @@ interface SpotifyPlaylist {
   images?: unknown;
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+// Kept local: this plugin has no `@mulmoclaude/core` dependency. Must stay
+// identical to the canonical guard in `server/utils/types.ts` — `!Array.isArray`
+// is what stops an array narrowing to `Record` and being indexed by string key
+// (#2220).
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
 
 function smallestImageUrl(images: unknown): string | undefined {
   if (!Array.isArray(images) || images.length === 0) return undefined;

--- a/packages/plugins/x-plugin/src/internal.ts
+++ b/packages/plugins/x-plugin/src/internal.ts
@@ -36,7 +36,13 @@ export function toUtcIsoDate(timestamp: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-export type FetchWithTimeoutInit = Parameters<typeof fetch>[1] & { timeoutMs?: number };
+/** `signal` is deliberately excluded. This compact port owns the signal it
+ *  passes to `fetch`, so a caller-supplied one would be silently overwritten
+ *  and dropped — no type error, no runtime error, just an abort that never
+ *  arrives (#2221). Omitting it from the type turns that misuse into a compile
+ *  error instead. If external cancellation is ever needed here, port the
+ *  bridging from `server/utils/fetch.ts` rather than re-widening this type. */
+export type FetchWithTimeoutInit = Omit<NonNullable<Parameters<typeof fetch>[1]>, "signal"> & { timeoutMs?: number };
 
 /** `fetch` with a finite timeout that aborts the request once `timeoutMs`
  *  elapses. Compact port of server/utils/fetch.ts `fetchWithTimeout` — the X

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -26,6 +26,7 @@ import type { PluginRuntime, ToolDefinition } from "gui-chat-protocol";
 import { isPluginFactory } from "gui-chat-protocol";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
 import { readLedger, type LedgerEntry } from "../utils/files/plugins-io.js";
+import { isRecord } from "../utils/types.js";
 import { log } from "../system/logger/index.js";
 
 const LOG_PREFIX = "plugins/runtime";
@@ -72,8 +73,6 @@ interface PackageJson {
   main?: string;
   module?: string;
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 const isToolDefinition = (value: unknown): value is ToolDefinition => {
   if (!isRecord(value)) return false;

--- a/test/plugins/spotify/test_normalize.ts
+++ b/test/plugins/spotify/test_normalize.ts
@@ -285,3 +285,30 @@ describe("normalisePlaylistList", () => {
     assert.equal(result[0].id, "ok");
   });
 });
+
+// --- array inputs are not records (#2220) ----------------------------
+// The local `isRecord` copy had lost the `!Array.isArray` guard, so an array
+// narrowed to `Record<string, unknown>` and got indexed by string key. No
+// observable misbehaviour resulted — every normaliser's next field check
+// rejected the array anyway — so these assertions pass before the fix too.
+// They pin the entry-point contract so a future path that DOES depend on the
+// distinction can't regress silently.
+
+describe("normalisers reject array input", () => {
+  it("normaliseTrack returns null for an array", () => {
+    assert.equal(normaliseTrack([]), null);
+    assert.equal(normaliseTrack([{ id: "x", name: "y" }]), null);
+  });
+
+  it("normaliseAlbum / normaliseArtist / normalisePlaylist return null for an array", () => {
+    assert.equal(normaliseAlbum([]), null);
+    assert.equal(normaliseArtist([]), null);
+    assert.equal(normalisePlaylist([]), null);
+  });
+
+  it("list normalisers return [] for an array payload (items[] is expected, not a bare array)", () => {
+    assert.deepEqual(normaliseTrackList([], "track"), []);
+    assert.deepEqual(normalisePlaylistList([]), []);
+    assert.deepEqual(normaliseRecentlyPlayed([]), []);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2220. Closes #2221.

Two findings from the #2219 duplicate audit. **Neither misbehaves today** — both issues say so, and I re-verified it rather than taking it on trust. What's wrong in both cases is that a guard no longer guards what its name promises, so it fails silently the moment the surrounding assumption moves.

### #2220 — `isRecord` copies without the array guard

Two local copies had dropped `!Array.isArray`, so `isRecord([1,2,3])` returned `true` and an array narrowed to `Record<string, unknown>` to be indexed by string key.

- **`server/plugins/runtime-loader.ts`** — plain `server/` code with no dependency constraint, so the local copy is deleted and the canonical `server/utils/types.ts` guard imported. (That module also exports `isObj` for the arrays-allowed case, so both shapes were already available — the comment at its top even says it exists "to eliminate 40+ hand-written inline checks", which is exactly what recurred here.)
- **`spotify-plugin`** — has no `@mulmoclaude/core` dependency, so the copy stays local but now matches canonical, with a comment recording why it is duplicated and what must not drift again.

### #2221 — `fetchWithTimeout` silently dropping a caller `signal`

`x-plugin`'s port accepted `signal` in its type (`Parameters<typeof fetch>[1] & …`) but destructured only `timeoutMs`, leaving `signal` in `rest` where the following `signal: controller.signal` overwrote it. No type error, no runtime error — an already-aborted signal still issued the request, and a mid-flight abort was ignored until the 10s timeout.

The X tools never pass one today, an intentional simplification the code comments already record. So rather than porting the bridging from `server/utils/fetch.ts`, `signal` is now **removed from `FetchWithTimeoutInit`**, turning that misuse into a compile error. That's the issue's own preferred option (#1 of the three listed): it states the current assumption in the type instead of leaving it to a comment that nothing enforces.

## Items to Confirm / Review

- **The new tests pass before the fix too — deliberately.** I checked whether array input actually changes behaviour and it does not: `normaliseTrack([])` already returned `null`, because the very next field check rejects the array. So these assertions pin the entry-point contract for a future path that *would* depend on the distinction; they are not a regression catch. Flagging it so the coverage isn't read as stronger than it is.
- **`Omit<NonNullable<Parameters<typeof fetch>[1]>, "signal">`** — the `NonNullable` is needed because that parameter is optional, so `Omit` on the bare type would not compile. Worth a glance that this is the shape you'd want.
- **#2222 (the third audit finding) is not in this PR.** It proposes flipping the host's `uniqueTmp` default, which changes behaviour for existing callers and needs its own impact review.

## User Prompt

(user: `isamu`) — asked to look at the issues from #2220 onward, then: fix #2220 and #2221; investigate #2234 and fix only if needed.

**#2234 is intentionally not here** — investigated and reported separately. It is implementable (`alwaysLoad` on the mcp-config entry + `-e MCP_CONNECT_TIMEOUT_MS` in `buildDockerSpawnArgs`), but the issue makes the timeout value depend on #2233's measurements, and the user chose to hold it.

## Verification

`format` / `lint` / `typecheck` / `build` / `test` all green. Spotify normalise suite now 32 cases.
The #2221 change has no runtime surface — `yarn typecheck` is what enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align type guards and fetch timeout typings to match intended contracts and prevent future silent misbehaviour.

Bug Fixes:
- Correct the spotify normaliser `isRecord` guard so arrays are no longer treated as records and reused the canonical implementation in the runtime loader.
- Tighten the `FetchWithTimeoutInit` type in the x plugin to disallow caller-supplied `signal` values that would be silently ignored.

Tests:
- Add spotify normaliser tests that assert array inputs are rejected or normalised to empty lists, pinning the expected entry-point behaviour.