### PR TITLE
fix(sandbox): let the MCP connect-wait ceiling actually reach the container (#2234)

### DIFF
--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -10,6 +10,7 @@ import type { EffortLevel, McpServerSpec } from "../system/config.js";
 import { startStdioHttpShim, type ShimHandle } from "./stdioHttpShim.js";
 import { claudeConfigDir, claudeConfigJson } from "../utils/claudeConfigPath.js";
 import { getCurrentToken } from "../api/auth/token.js";
+import { ONE_MINUTE_MS } from "../utils/time.js";
 import type { Attachment } from "@mulmobridge/protocol";
 import { isImageMime, isNativeAttachmentMime } from "@mulmobridge/client";
 import { convertAttachment } from "./attachmentConverter.js";
@@ -297,11 +298,32 @@ const LOCAL_MCP_SERVER_PATH = join(dirname(fileURLToPath(import.meta.url)), "mcp
  *  with the SHIPPED command/args/env instead of a hand-copied duplicate —
  *  the drift that let #1974 and #1995 ship without the smoke test ever
  *  seeing them (#2052). */
+/** Connect-wait ceiling handed to the CLI inside the sandbox container.
+ *
+ *  This is a CEILING, not a delay: a fast environment still proceeds the moment
+ *  the broker answers, so raising it costs nothing there. It exists for the slow
+ *  bind-mount case (Windows / macOS Docker Desktop), where tsx transcodes the
+ *  broker's import graph over a 9p-class mount and cold boot overruns the CLI's
+ *  ~5s default, surfacing as an intermittent
+ *  `MCP tool mcp__mulmoclaude__handlePermission not found` (#2201, #2234).
+ *
+ *  Deliberately generous rather than tuned: the only cost of overshooting is a
+ *  slower report when the broker is genuinely dead, while undershooting brings
+ *  the flake back. #2233 will measure real cold-boot time and this can tighten
+ *  to that figure plus margin. */
+const MCP_CONNECT_TIMEOUT_MS = ONE_MINUTE_MS;
+
 export interface McpStdioServerSpec {
   type: "stdio";
   command: string;
   args: string[];
   env: Record<string, string>;
+  /** Connect to this server at session start rather than lazily, so a resumed
+   *  turn doesn't race the broker's cold boot (#2234). Requires CLI ≥ 2.1.121;
+   *  older versions ignore the field. Inert on its own — the CLI still gives up
+   *  after its default connect wait, so this only helps together with the
+   *  raised `MCP_CONNECT_TIMEOUT_MS` in `buildDockerSpawnArgs`. */
+  alwaysLoad: boolean;
 }
 
 export function buildMulmoclaudeServer(params: { chatSessionId: string; port: number; activePlugins: string[]; useDocker: boolean }): McpStdioServerSpec {
@@ -333,6 +355,7 @@ export function buildMulmoclaudeServer(params: { chatSessionId: string; port: nu
     // when absent, which is why this worked through Apr 2026 and
     // started silently failing some time after the CLI update.
     type: "stdio",
+    alwaysLoad: true,
     command,
     // Docker path: register the ESM resolver hook that plugs the
     // Windows-junction gap in the ESM loader (#1946/#1982). Passed
@@ -847,6 +870,12 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     // toolResult into its timeline.
     "-e",
     `MULMOCLAUDE_CHAT_SESSION_ID=${params.chatSessionId}`,
+    // How long the CLI *inside the container* waits for the MCP broker to
+    // connect. Set here because only the vars listed in this argv reach the
+    // container — a host-side `MCP_CONNECT_TIMEOUT_MS` never arrived, so the
+    // knob was unreachable in the one environment that needs it (#2234).
+    "-e",
+    `MCP_CONNECT_TIMEOUT_MS=${MCP_CONNECT_TIMEOUT_MS}`,
     ...dockerBindMountArgs({ projectRoot, packageRoot, workspacePath, homeDir, packagesMount, platform }),
     ...sandboxAuthArgs,
     ...extraHosts,

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -45,6 +45,19 @@ describe("buildMcpConfig", () => {
     assert.equal(env.PLUGIN_NAMES, "manageBookmarks,presentDocument");
   });
 
+  // Connect at session start instead of lazily, so a resumed turn doesn't race
+  // the broker's cold boot. Inert without the raised connect ceiling — the two
+  // only work as a pair (#2234).
+  it("marks the mulmoclaude server alwaysLoad so a resumed turn doesn't race cold boot", async () => {
+    const config = buildMcpConfig({ chatSessionId: "s1", port: 3001, activePlugins: [] }) as Record<string, unknown>;
+    const servers = config.mcpServers as Record<string, unknown>;
+    const server = servers.mulmoclaude as Record<string, unknown>;
+    assert.equal(server.alwaysLoad, true);
+    // Still a stdio spawn — alwaysLoad must not have displaced the type field,
+    // whose absence makes the CLI skip the entry silently.
+    assert.equal(server.type, "stdio");
+  });
+
   it("handles empty plugins", async () => {
     const config = buildMcpConfig({
       chatSessionId: "s2",
@@ -397,6 +410,20 @@ describe("buildDockerSpawnArgs", () => {
     assert.ok(args.includes("HOST_GID=20"));
     assert.ok(args.includes("CHOWN"));
     assert.ok(args.includes("SETUID"));
+  });
+
+  // The CLI runs INSIDE the container, so only vars listed in this argv reach
+  // it — a host-side MCP_CONNECT_TIMEOUT_MS never arrived, leaving the knob
+  // unreachable in the one environment that needs it (#2234).
+  it("passes the MCP connect-wait ceiling into the container", async () => {
+    const args = buildDockerSpawnArgs(baseParams());
+    const value = args.find((arg) => arg.startsWith("MCP_CONNECT_TIMEOUT_MS="));
+    assert.ok(value, `expected an MCP_CONNECT_TIMEOUT_MS -e arg, got: ${args.join(" ")}`);
+    const timeoutMs = Number(value.split("=")[1]);
+    assert.ok(Number.isFinite(timeoutMs) && timeoutMs > 0, `expected a positive ms value, got: ${value}`);
+    // Must clear the CLI's ~5s default, which is the whole point.
+    assert.ok(timeoutMs >= 30_000, `ceiling must comfortably exceed the CLI default, got ${timeoutMs}ms`);
+    assert.equal(args[args.indexOf(value) - 1], "-e", "value must be preceded by its -e flag");
   });
 
   it("mounts the workspace at the container path", async () => {


### PR DESCRIPTION
## Summary

Closes #2234. Windows + Docker Desktop intermittently fails a turn with `MCP tool mcp__mulmoclaude__handlePermission not found`: tsx transcodes the broker's import graph over a 9p-class bind mount, cold boot overruns the CLI's ~5s connect wait, and the tools never make the registry. Most likely on a resumed turn. Analysis in #2201.

**The knob to raise that wait already existed — it just never reached the CLI.** `buildDockerSpawnArgs` forwards only the vars it lists explicitly (`HOME`, `MULMOCLAUDE_HOST`, `MULMOCLAUDE_CHAT_SESSION_ID`), and the CLI runs *inside* the container. So a host-side `MCP_CONNECT_TIMEOUT_MS` did nothing at all. **That plumbing gap is the substantive fix, and it's correct independently of whatever value we settle on.**

Also marks the `mulmoclaude` entry `alwaysLoad: true`, connecting at session start rather than lazily — the resumed-turn case. Per #2201's CLI check it is **inert on its own** (the CLI still gives up after its default wait), so the two only work as a pair.

## Items to Confirm / Review

- **60s, deliberately generous rather than tuned.** This is a **ceiling, not a delay** — a fast environment proceeds the moment the broker answers, so raising it costs nothing there. Overshooting only delays the report when the broker is genuinely dead; undershooting brings the flake back.
- **No platform gate, on purpose.** Because it's a ceiling and not a sleep, gating on Windows would add a branch for zero benefit — and macOS Docker Desktop is the same slow-bind-mount class, so a Windows-only gate would have missed it. Landing it in `buildDockerSpawnArgs` already scopes it to Docker runs; native is untouched.
- **Not blocked on #2233, contrary to the original sequencing.** I read that ticket: it states its own measurements are for *"order of magnitude and relative comparison"* because CI (WSL2 9p) and real Docker Desktop don't agree on absolute values. So it can *tighten* this constant later, but it cannot produce an exact figure — and it cannot fix the plumbing gap. If you'd still rather hold this until #2233 lands, say so and I'll park it.
- **`alwaysLoad` needs CLI ≥ 2.1.121.** The sandbox image installs the CLI unpinned (noted in CHANGELOG), so I can't guarantee the running version supports it. Older versions ignore the field — no harm — and `MCP_CONNECT_TIMEOUT_MS` still does the work.

## User Prompt

(user: `isamu`)

> #2234 って適当な時間を windows+docker で待つようにすればよいの？ → なるほど、重要な順に実施して待つのは 60s でよいよ

i.e. confirmed the "wait longer" approach and the 60s value, and asked to work the remaining issues in importance order — #2234 first as the only one carrying a `bug` label.

## Implementation

- `server/agent/config.ts` — `MCP_CONNECT_TIMEOUT_MS` constant (`ONE_MINUTE_MS`, no magic literal) with the ceiling-vs-delay rationale; `-e MCP_CONNECT_TIMEOUT_MS=…` added to `buildDockerSpawnArgs`; `alwaysLoad: boolean` added to `McpStdioServerSpec` and set on the `mulmoclaude` entry.
- `test/agent/test_agent_config.ts` — asserts the var actually reaches the container argv (paired with its `-e`) and comfortably clears the CLI default; asserts `alwaysLoad: true` **and** that `type: "stdio"` survived, since a missing `type` makes the CLI skip the entry silently (the #2052-era failure).

## Verification

`format` / `lint` / `typecheck` / `build` / `test` green; agent-config suite 91 cases.

**Not verified against the real failure.** This is an intermittent Windows + Docker Desktop race; the tests prove the wiring, not that the flake is gone. Per the issue, field confirmation follows distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved MCP server startup by connecting the built-in server eagerly when a session begins.
  * Added an explicit one-minute connection timeout for MCP broker communication in Docker-based sessions.
* **Bug Fixes**
  * Prevented resumed sessions from racing against MCP broker startup.
  * Added safeguards to ensure the configured connection timeout is passed correctly to Docker sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->