### PR TITLE
fix: narrow two JSON.parse reads that were typed by assertion, not by check

### DIFF
--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../utils/types.js";
 import { Router, Request, Response } from "express";
 import { realpathSync } from "fs";
 import { readdir, stat } from "fs/promises";
@@ -37,20 +38,25 @@ interface SessionMeta {
   userQueryCount?: number;
 }
 
+/** The two fields every caller relies on. Both paths below already tested for
+ *  them — one behind an `as` cast, one on a `JSON.parse` result typed `any`, so
+ *  neither test actually narrowed anything. Same check, now load-bearing. */
+function isSessionMeta(value: unknown): value is SessionMeta {
+  return isRecord(value) && typeof value.roleId === "string" && typeof value.startedAt === "string";
+}
+
 async function readSessionMeta(__chatDir: string, sessionId: string): Promise<SessionMeta | null> {
   // Try new-style .json meta first
   const meta = await readSessionMetaIO(sessionId);
-  if (meta?.roleId && meta?.startedAt) {
-    return meta as SessionMeta;
-  }
+  if (isSessionMeta(meta)) return meta;
   // Legacy: read first line of .jsonl
   const jsonl = await readSessionJsonl(sessionId);
   if (jsonl) {
     const first = jsonl.split("\n").find(Boolean);
     if (first) {
       try {
-        const parsed = JSON.parse(first);
-        if (parsed.roleId && parsed.startedAt) return parsed;
+        const parsed: unknown = JSON.parse(first);
+        if (isSessionMeta(parsed)) return parsed;
       } catch {
         // ignore
       }

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "../../utils/types.js";
+import { isNonEmptyString, isRecord } from "../../utils/types.js";
 import { Router, Request, Response } from "express";
 import { realpathSync } from "fs";
 import { readdir, stat } from "fs/promises";
@@ -40,9 +40,13 @@ interface SessionMeta {
 
 /** The two fields every caller relies on. Both paths below already tested for
  *  them — one behind an `as` cast, one on a `JSON.parse` result typed `any`, so
- *  neither test actually narrowed anything. Same check, now load-bearing. */
+ *  neither test actually narrowed anything. Same check, now load-bearing.
+ *
+ *  `isNonEmptyString`, not `typeof === "string"`: the checks this replaced were
+ *  truthy tests, so a corrupt row like `{ roleId: "", startedAt: "" }` was
+ *  skipped. A plain type check would start letting those through. */
 function isSessionMeta(value: unknown): value is SessionMeta {
-  return isRecord(value) && typeof value.roleId === "string" && typeof value.startedAt === "string";
+  return isRecord(value) && isNonEmptyString(value.roleId) && isNonEmptyString(value.startedAt);
 }
 
 async function readSessionMeta(__chatDir: string, sessionId: string): Promise<SessionMeta | null> {

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -1,6 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { log } from "./logger/index.js";
+import { isRecord } from "../utils/types.js";
 import { ONE_SECOND_MS, ONE_MINUTE_MS } from "../utils/time.js";
 import { writeFileAtomic } from "../utils/files/atomic.js";
 import { claudeCredentialsPath } from "../utils/claudeConfigPath.js";
@@ -32,14 +33,6 @@ export function looksLikeClaudeResponse(text: string): boolean {
   return RESPONSE_PATTERN_RE.test(text) && text.length >= MIN_RESPONSE_CHARS;
 }
 
-interface CredentialsJson {
-  claudeAiOauth?: {
-    accessToken?: string;
-    refreshToken?: string;
-    expiresAt?: string;
-  };
-}
-
 /**
  * Read the raw credentials string from macOS Keychain.
  */
@@ -56,10 +49,30 @@ async function readFromKeychain(): Promise<string | null> {
 /**
  * Check whether the access token in the credentials JSON is expired.
  */
+/** The token's expiry as written in the Keychain blob, or null when the JSON is
+ *  unparseable or simply doesn't carry one.
+ *
+ *  `JSON.parse` returns `any`, so the previous `CredentialsJson` annotation on
+ *  its result was a claim rather than a check — nothing verified the shape, and
+ *  every read through it was unchecked. Narrowing once here gives the three
+ *  callers a `string | null` they can trust, and keeps the parse in one place.
+ *  (The interface itself is gone: it described a shape nobody validated.) */
+function readExpiresAt(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const oauth = parsed.claudeAiOauth;
+  if (!isRecord(oauth)) return null;
+  return typeof oauth.expiresAt === "string" ? oauth.expiresAt : null;
+}
+
 function isTokenExpired(raw: string): boolean {
   try {
-    const creds: CredentialsJson = JSON.parse(raw);
-    const expiresAt = creds.claudeAiOauth?.expiresAt;
+    const expiresAt = readExpiresAt(raw);
     if (!expiresAt) return true; // no expiry info — treat as expired
 
     const expiresMs = new Date(expiresAt).getTime();
@@ -187,13 +200,13 @@ export async function refreshCredentials(): Promise<boolean> {
 
     if (isTokenExpired(credentials)) {
       // Extract expiry for logging
-      try {
-        const creds: CredentialsJson = JSON.parse(credentials);
-        const expiresAt = creds.claudeAiOauth?.expiresAt ?? "unknown";
-        log.warn("credentials", `Access token expired at ${expiresAt}, launching claude CLI to renew...`);
-      } catch {
-        log.warn("credentials", "Access token expired (could not parse expiry), launching claude CLI to renew...");
-      }
+      const expiredAt = readExpiresAt(credentials);
+      log.warn(
+        "credentials",
+        expiredAt
+          ? `Access token expired at ${expiredAt}, launching claude CLI to renew...`
+          : "Access token expired (could not parse expiry), launching claude CLI to renew...",
+      );
 
       const renewed = await renewTokenViaPty();
       if (!renewed) {
@@ -217,13 +230,8 @@ export async function refreshCredentials(): Promise<boolean> {
         return false;
       }
     } else {
-      try {
-        const creds: CredentialsJson = JSON.parse(credentials);
-        const expiresAt = creds.claudeAiOauth?.expiresAt ?? "unknown";
-        log.info("credentials", `Access token is valid, expires at ${expiresAt}`);
-      } catch {
-        log.info("credentials", "Access token appears valid");
-      }
+      const validUntil = readExpiresAt(credentials);
+      log.info("credentials", validUntil ? `Access token is valid, expires at ${validUntil}` : "Access token appears valid");
     }
 
     // Atomic so a readers mid-refresh can't see a truncated creds

--- a/test/routes/test_sessionsRoute.ts
+++ b/test/routes/test_sessionsRoute.ts
@@ -339,3 +339,42 @@ describe("POST /api/sessions/:id/mark-read", () => {
     assert.equal(meta.hasUnread, false);
   });
 });
+
+// `readSessionMeta` used to gate on `meta?.roleId && meta?.startedAt` — a truthy
+// test, so a corrupt row with empty strings was skipped. Replacing that with a
+// type guard is only equivalent if the guard keeps the non-empty invariant;
+// `typeof x === "string"` alone would start letting those rows into the list.
+// Both read paths are covered because they narrow independently.
+describe("GET /api/sessions — corrupt meta rows are skipped", () => {
+  it("skips a .json meta whose roleId/startedAt are empty strings", async () => {
+    await writeFile(path.join(chatDir, "empty-meta.json"), JSON.stringify({ roleId: "", startedAt: "" }));
+    await writeFile(path.join(chatDir, "empty-meta.jsonl"), "");
+
+    const { state, res } = mockRes();
+    await getHandler({ query: {} } as unknown as Request, res);
+
+    const ids = (state.body?.sessions ?? []).map((session) => session.id);
+    assert.ok(!ids.includes("empty-meta"), `corrupt session leaked into the list: ${ids.join(", ")}`);
+  });
+
+  it("skips a legacy .jsonl first line whose roleId/startedAt are empty strings", async () => {
+    // No .json meta at all, so the handler falls through to the legacy path.
+    await writeFile(path.join(chatDir, "legacy-empty.jsonl"), `${JSON.stringify({ roleId: "", startedAt: "" })}\n`);
+
+    const { state, res } = mockRes();
+    await getHandler({ query: {} } as unknown as Request, res);
+
+    const ids = (state.body?.sessions ?? []).map((session) => session.id);
+    assert.ok(!ids.includes("legacy-empty"), `corrupt legacy session leaked into the list: ${ids.join(", ")}`);
+  });
+
+  it("still lists a session whose meta is well-formed", async () => {
+    await writeSession("good-meta", { mtimeMs: BASE_MS });
+
+    const { state, res } = mockRes();
+    await getHandler({ query: {} } as unknown as Request, res);
+
+    const ids = (state.body?.sessions ?? []).map((session) => session.id);
+    assert.ok(ids.includes("good-meta"), `well-formed session missing: ${ids.join(", ")}`);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the `no-unsafe-*` backlog, scoped to the sites that resolve inside their own file. **168 → 161.**

Both places already tested for the fields they needed. Neither test *narrowed* anything, because the value came from `JSON.parse` — which returns `any`, so an annotation on its result is a claim, and every read through it is unchecked.

## credentials.ts (3 → 0)

Three copies of the same read:

```ts
const creds: CredentialsJson = JSON.parse(raw);
const expiresAt = creds.claudeAiOauth?.expiresAt;
```

Collapsed into one `readExpiresAt()` that actually verifies the shape and returns `string | null`. The duplication went with it.

**`CredentialsJson` is deleted, not reused.** It described a shape nothing validated — keeping it would preserve the illusion that something did.

## sessions.ts (18 → 14)

```ts
if (meta?.roleId && meta?.startedAt) return meta as SessionMeta;  // checked, then cast anyway
if (parsed.roleId && parsed.startedAt) return parsed;             // checked, still `any`
```

The same condition as a type guard makes both real and removes the cast.

## Items to Confirm / Review

- **`readExpiresAt` swallows a parse failure as `null`**, where two of the three old sites logged "could not parse expiry" separately. The log lines still distinguish the cases (`expiredAt ? … : …`), but the *reason* for a null — bad JSON vs. no expiry field — is no longer separable. That was already true of the third site; flagging it as a deliberate simplification rather than an oversight.
- **`isSessionMeta` only checks the two required fields**, matching what the old code checked. The optional fields on `SessionMeta` are still unvalidated — narrowing them is a bigger change than this PR.

## Deliberately out of scope

Of the 150 `no-unsafe-*` findings:

| source | count | why not here |
|---|---|---|
| `any` propagating from upstream | 118 | needs the source typed first, not the call site patched |
| untyped package (`irc-framework`, 18 of them) | 9 files | ships no types, no `@types` package — needs a hand-written declaration |
| `JSON.parse` elsewhere | ~10 | spread across 11 files; same treatment, separate PRs |

## Verification

`build:packages` / `typecheck` / `lint` / `test` all clean, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)