### PR TITLE
fix: narrow the jsonl line parsers instead of reading any off them

### DIFF
--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -27,7 +27,7 @@ import { getOrCreateSession, beginRun, endRun, cancelRun, pushSessionEvent, push
 import { workspacePath } from "../../workspace/workspace.js";
 import { discoverSkills } from "../../workspace/skills/discovery.js";
 import type { Skill } from "../../workspace/skills/types.js";
-import { isRecord } from "../../utils/types.js";
+import { isNonEmptyString, isRecord } from "../../utils/types.js";
 import { maybeRunJournal } from "../../workspace/journal/index.js";
 import { maybeIndexSession } from "../../workspace/chat-index/index.js";
 import { maybeAppendWikiBacklinks } from "../../workspace/wiki-backlinks/index.js";
@@ -1330,8 +1330,11 @@ async function readClaudeSessionIdFromSession(chatSessionId: string): Promise<st
   const lines = jsonl.split("\n").filter(Boolean);
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
-      const entry = JSON.parse(lines[i]);
-      if (entry.type === EVENT_TYPES.claudeSessionId && entry.id) return entry.id;
+      // `JSON.parse` hands back `any`, so the `.type`/`.id` reads below were
+      // unchecked — a line of the wrong shape produced whatever it happened to
+      // hold. Narrow first; a malformed line is skipped either way.
+      const entry: unknown = JSON.parse(lines[i]);
+      if (isRecord(entry) && entry.type === EVENT_TYPES.claudeSessionId && isNonEmptyString(entry.id)) return entry.id;
     } catch {
       // skip malformed lines
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -120,6 +120,7 @@ import { isViewDataPath } from "./api/auth/viewToken.js";
 import { deleteTokenFile, generateAndWriteToken, getCurrentToken } from "./api/auth/token.js";
 import { log } from "./system/logger/index.js";
 import { logBackgroundError } from "./utils/logBackgroundError.js";
+import { isNonEmptyString, isRecord } from "./utils/types.js";
 import { errorMessage } from "./utils/errors.js";
 import { registerScheduledSkills } from "./workspace/skills/scheduler.js";
 import { registerUserTasks } from "./workspace/skills/user-tasks.js";
@@ -671,10 +672,10 @@ async function getSessionHistoryForBridge(sessionId: string, opts: { limit: numb
   // Collect all text events newest-first
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
-      const entry = JSON.parse(lines[i]);
-      if (entry.type === EVENT_TYPES.text && typeof entry.message === "string") {
+      const entry: unknown = JSON.parse(lines[i]);
+      if (isRecord(entry) && entry.type === EVENT_TYPES.text && typeof entry.message === "string") {
         allMessages.push({
-          source: entry.source ?? "unknown",
+          source: isNonEmptyString(entry.source) ? entry.source : "unknown",
           text: entry.message,
         });
       }

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -83,6 +83,17 @@ interface JsonlEntry {
   message?: string;
 }
 
+/** A jsonl line we can read. Only the fields the caller touches are required to
+ *  be the right type; anything else on the line is ignored. */
+function isJsonlEntry(value: unknown): value is JsonlEntry {
+  if (!isRecord(value)) return false;
+  return (
+    (value.source === undefined || typeof value.source === "string") &&
+    (value.type === undefined || typeof value.type === "string") &&
+    (value.message === undefined || typeof value.message === "string")
+  );
+}
+
 function trimMessage(text: string): string {
   if (text.length <= PER_MESSAGE_MAX) return text;
   return `${text.slice(0, PER_MESSAGE_MAX)}…`;
@@ -96,12 +107,16 @@ export function extractText(jsonlContent: string): string {
   const lines = jsonlContent.split("\n").filter(Boolean);
   const parts: string[] = [];
   for (const line of lines) {
-    let entry: JsonlEntry;
+    let entry: unknown;
     try {
       entry = JSON.parse(line);
     } catch {
       continue;
     }
+    // The `JsonlEntry` annotation used to sit on the parse result, which is
+    // `any` — it described the line without verifying it. The guard does the
+    // describing now.
+    if (!isJsonlEntry(entry)) continue;
     const { source } = entry;
     if ((source === "user" || source === "assistant") && entry.type === EVENT_TYPES.text && typeof entry.message === "string") {
       parts.push(`[${source}] ${trimMessage(entry.message)}`);


### PR DESCRIPTION
## Summary

Second `no-unsafe-*` slice. **161 → 155** (unsafe: 143 → 137) — three edits, six findings.

Three places read a chat `.jsonl` line the same way: parse, then reach for `.type` / `.message` / `.source`. `JSON.parse` returns `any`, so those reads were unchecked and a line of the wrong shape yielded whatever it happened to hold.

`summarizer.ts` had the same shape as the `CredentialsJson` case in #2241 — a `JsonlEntry` annotation sitting on the parse result, **describing** the line without verifying it:

```ts
let entry: JsonlEntry;
try { entry = JSON.parse(line); } catch { continue; }
```

`isJsonlEntry` does the describing now, and only requires the fields the caller actually touches to be the right type.

No new helper — `isRecord` and `isNonEmptyString` already cover this. Checked `docs/shared-utils.md` first.

## Items to Confirm / Review

- **One small behaviour change**: `server/index.ts` used `entry.source ?? "unknown"`, which only catches null/undefined — a numeric or object `source` became the label as-is. It now falls back to `"unknown"` for any non-string. That's a fix, but it is a change.
- Otherwise behaviour is unchanged for well-formed lines. A malformed one was already skipped by the surrounding `try`/`catch` or the field test; it's now skipped for a reason the types agree with.

## Deliberately not touched

`readJsonOrNull<T>` (×2) and `apiCall<T>` parse into a **caller-supplied `T`**:

```ts
export async function readJsonOrNull<T>(filePath: string): Promise<T | null> {
  const parsed: T = JSON.parse(content);
```

That annotation is the function's contract, not a local claim. Changing it to `unknown` doesn't fix anything — it moves the assertion to every call site. Worth doing, but it's a different piece of work with a much wider blast radius.

Also skipped: the bridge/relay parses, which each have package-local response types and want judging one at a time.

## Verification

`build:packages` / `typecheck` / `lint` / `test` all clean, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unexpected session history data.
  * Prevented invalid transcript entries from appearing in chat history or summaries.
  * Improved reliability when reading legacy session identifiers and message sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->