### PR TITLE
fix: make atomic writes use a unique staging file by default (#2222)

### DIFF
--- a/server/utils/files/atomic.ts
+++ b/server/utils/files/atomic.ts
@@ -7,9 +7,34 @@ import { shortId } from "../id.js";
 
 export interface WriteAtomicOptions {
   mode?: number;
-  // Adds shortId() to the tmp filename so concurrent writers to the same path don't collide at the OS layer
-  // (chat-index hits this).
+  /** Give the staging file a `shortId()` suffix so concurrent writers to the
+   *  same destination can't collide at the OS layer.
+   *
+   *  Defaults to `true`, and opting out is almost always wrong. A shared
+   *  `${filePath}.tmp` means two writers of one file race: the second write
+   *  overwrites the first's staging file, or one rename/unlink pulls it out
+   *  from under the other, surfacing as `ENOENT … rename '<file>.tmp'`. That is
+   *  not theoretical — it fired in production on session meta, where ten
+   *  distinct callers (`setClaudeSessionId`, `backfillOrigin`,
+   *  `incrementUserQueryCount`, …) all write the same `<sessionId>.json`
+   *  (#2222).
+   *
+   *  The default used to be `false`, leaving every caller to remember the flag.
+   *  Both independently-written copies of this helper — `@mulmoclaude/core`'s
+   *  and accounting-plugin's — chose unique-by-default instead, which is what
+   *  prompted the flip.
+   *
+   *  Pass `false` only when you specifically need the staging path to be
+   *  predictable (e.g. a test that pre-creates it to force a write failure). */
   uniqueTmp?: boolean;
+}
+
+// Unique staging names are the safe default: the cost is a random suffix, the
+// cost of the alternative is a lost update under concurrency (#2222).
+const DEFAULT_UNIQUE_TMP = true;
+
+function tmpPathFor(filePath: string, uniqueTmp: boolean | undefined): string {
+  return (uniqueTmp ?? DEFAULT_UNIQUE_TMP) ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
 }
 
 // On Windows, AV / Search Indexer / Defender briefly hold handles and rename trips EPERM/EBUSY/EACCES. Retry loop is
@@ -66,7 +91,7 @@ function writeOptionsFor(content: string | Uint8Array, mode: number | undefined)
 }
 
 export async function writeFileAtomic(filePath: string, content: string | Uint8Array, opts: WriteAtomicOptions = {}): Promise<void> {
-  const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
+  const tmp = tmpPathFor(filePath, opts.uniqueTmp);
   await promises.mkdir(path.dirname(filePath), { recursive: true });
   try {
     await promises.writeFile(tmp, content, writeOptionsFor(content, opts.mode));
@@ -78,7 +103,7 @@ export async function writeFileAtomic(filePath: string, content: string | Uint8A
 }
 
 export function writeFileAtomicSync(filePath: string, content: string | Uint8Array, opts: WriteAtomicOptions = {}): void {
-  const tmp = opts.uniqueTmp ? `${filePath}.${shortId()}.tmp` : `${filePath}.tmp`;
+  const tmp = tmpPathFor(filePath, opts.uniqueTmp);
   mkdirSync(path.dirname(filePath), { recursive: true });
   try {
     writeFileSync(tmp, content, writeOptionsFor(content, opts.mode));

--- a/test/utils/files/test_atomic.ts
+++ b/test/utils/files/test_atomic.ts
@@ -154,3 +154,34 @@ describe("writeFileAtomic — binary content (#881 v1)", () => {
     assert.equal(siblings.filter((file) => file.endsWith(".tmp")).length, 0);
   });
 });
+
+// The staging name used to be the shared `${filePath}.tmp`, so two writers of
+// one destination raced: one rename/unlink pulled the staging file out from
+// under the other. It fired in production on session meta — ten callers all
+// write the same `<sessionId>.json` — as
+// `ENOENT … rename '<file>.json.tmp' -> '<file>.json'` (#2222).
+describe("writeFileAtomic — concurrent writers to one destination (#2222)", () => {
+  it("does not lose a write when several writers target the same file", async () => {
+    const file = path.join(tmpDir, "contended.json");
+    const writers = Array.from({ length: 12 }, (_, index) => writeFileAtomic(file, `payload-${index}`));
+    // Every write must resolve: none may fail because a sibling removed its
+    // staging file mid-flight.
+    await Promise.all(writers);
+    // Last writer wins, but the file must be one intact payload — never a
+    // half-written or missing file.
+    assert.match(readFileSync(file, "utf-8"), /^payload-\d+$/);
+  });
+
+  it("leaves no staging files behind after a contended burst", async () => {
+    const file = path.join(tmpDir, "contended-cleanup.json");
+    await Promise.all(Array.from({ length: 8 }, (_, index) => writeFileAtomic(file, `v${index}`)));
+    const strays = readdirSync(tmpDir).filter((name) => name.startsWith("contended-cleanup.json.") && name.endsWith(".tmp"));
+    assert.deepEqual(strays, [], `staging files leaked: ${strays.join(", ")}`);
+  });
+
+  it("still honours an explicit uniqueTmp: false for callers that need a predictable staging path", async () => {
+    const file = path.join(tmpDir, "predictable.txt");
+    await writeFileAtomic(file, "ok", { uniqueTmp: false });
+    assert.equal(readFileSync(file, "utf-8"), "ok");
+  });
+});

--- a/test/utils/test_file.ts
+++ b/test/utils/test_file.ts
@@ -82,8 +82,11 @@ describe("writeFileAtomic", () => {
   it("leaves the existing target untouched if the tmp write fails", async () => {
     const filePath = path.join(tmpDir, "out.txt");
     writeFileSync(filePath, "ORIGINAL");
+    // Occupy the staging path with a directory so the write fails. This needs
+    // the PREDICTABLE staging name, hence the explicit `uniqueTmp: false` —
+    // with the default (unique) name there is nothing to collide with (#2222).
     mkdirSync(`${filePath}.tmp`);
-    await assert.rejects(writeFileAtomic(filePath, "NEW"));
+    await assert.rejects(writeFileAtomic(filePath, "NEW", { uniqueTmp: false }));
     assert.equal(readFileSync(filePath, "utf-8"), "ORIGINAL");
   });
 


### PR DESCRIPTION
## Summary

Closes #2222. `writeFileAtomic` staged through a shared `${filePath}.tmp` unless the caller remembered `uniqueTmp: true`. Two writers of one destination then race: one overwrites the other's staging file, or a rename/unlink pulls it out from under it.

### This has already happened in production

The issue asked whether the flip is justified. It is — the repo's own log records the failure:

```
server/system/logs/server-2026-06-29.log
"persistHasUnread failed" … "ENOENT: no such file or directory,
 rename '.../conversations/chat/<id>.json.tmp' -> '.../<id>.json'"
```

Tracing it: `persistHasUnread → updateHasUnread → writeSessionMeta → writeTextUnder → writeFileAtomic`, with **no `uniqueTmp`**. And **ten distinct callers** (`setClaudeSessionId`, `backfillOrigin`, `incrementUserQueryCount`, …) all write that same `<sessionId>.json` — precisely the contended shape. The existing comment already admitted *"chat-index hits this"*; session meta is a second, logged instance.

Flipping the default makes the safe behaviour the one you get by **forgetting**. It also converges with the two independently-written copies of this helper (`@mulmoclaude/core`'s and accounting-plugin's), which both chose unique-by-default and both explain the hazard in their own words. As the issue observes, two authors independently reaching the opposite conclusion from the host is the strongest signal the host default was wrong.

## Items to Confirm / Review

- **Impact was checked, not assumed.** No implementation code depends on the literal `.tmp` name anywhere in `server/`, `src/`, or `packages/core/src/` — every hit is a comment. (The one live `.tmp` literal, `workspace-setup/sync.ts`'s `.tmp-${randomUUID()}`, is an unrelated staging *directory*.)
- **One real dependency existed, in a test.** `test/utils/test_file.ts` pre-creates the staging path as a directory to force a write failure — that needs the predictable name. It now passes `uniqueTmp: false` explicitly, preserving its intent rather than deleting the coverage.
- **87 call sites change behaviour** (they now get a random suffix). Full suite passes. The behavioural delta is only the staging filename; the destination, contents, mode, and Windows rename-retry are untouched.
- **The new tests were verified to fail against the old default** before being kept — I reverted `DEFAULT_UNIQUE_TMP` to `false` and confirmed both concurrency tests go red. Not test theatre.
- **Not addressed here:** the issue's option 2 (collapsing the three implementations into one). `writeFileAtomic` uses `node:fs`, so it is not browser-safe and cannot live in `@mulmoclaude/core/utils`; that needs a server-only subpath and is a separate change.

## User Prompt

(user: `isamu`) — after #2220/#2221 landed, chose `2222` as the next item, then approved proceeding once the impact investigation came back clean.

## Implementation

- `server/utils/files/atomic.ts` — `DEFAULT_UNIQUE_TMP = true`; both the async and sync writers now route through one `tmpPathFor()` so the default lives in a single place. The option's doc comment records why it defaults this way, the production incident, and the only legitimate reason to pass `false`.
- `test/utils/files/test_atomic.ts` — three regression tests: a contended burst loses no write, leaves no staging strays, and an explicit `uniqueTmp: false` still works.
- `test/utils/test_file.ts` — the failure-injection test opts out explicitly.

## Verification

`format` / `lint` / `typecheck` / `build` / `test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
