### PR TITLE
fix(windows): stop libuv aborting on 8.3 short paths; unbreak the ref-dir test

### DIFF
--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -25,7 +25,7 @@
 // vs `change`, atomic-write coalescence, filename === null on some
 // platforms) don't need special handling.
 
-import { watch, type FSWatcher } from "node:fs";
+import { realpathSync, watch, type FSWatcher } from "node:fs";
 import { access, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { discoverCollections, itemFilePath, loadCollection, publishCollectionChange, type DiscoveryOptions, type LoadedCollection } from "../collection/server";
@@ -369,6 +369,28 @@ function scheduleDataSourcePublish(slug: string): void {
   dataSourceTimers.set(slug, timer);
 }
 
+/** The path to hand `watch()`, with Windows 8.3 short names resolved away.
+ *
+ *  ReadDirectoryChangesW reports filenames against the LONG path, but a watch
+ *  opened on a short path (`C:\Users\RUNNER~1\…` — what `os.tmpdir()` returns
+ *  on GitHub's Windows runners) keeps the short form. libuv's
+ *  `assert(!_wcsnicmp(filename, dir, dirlen))` in `src/win/fs-event.c` then
+ *  aborts the PROCESS on the first event — a native assert, so neither
+ *  `watcher.on("error")` nor a try/catch can contain it.
+ *
+ *  POSIX is deliberately left alone: `realpath` there also collapses symlinks
+ *  (`/var` → `/private/var` on macOS), which we neither need nor want to
+ *  change. A failure falls back to the original path — worst case we are no
+ *  worse off than before. */
+function watchablePath(dir: string): string {
+  if (process.platform !== "win32") return dir;
+  try {
+    return realpathSync.native(dir);
+  } catch {
+    return dir;
+  }
+}
+
 /** Watch a dataSource collection's external data file. The watch mounts
  *  on the PARENT directory (watching the file itself goes stale after an
  *  atomic replace — the inode changes) and filters events to the file's
@@ -381,7 +403,7 @@ async function startDataSourceWatcher(collection: LoadedCollection): Promise<boo
   const base = path.basename(file);
   try {
     await mkdir(dir, { recursive: true });
-    const watcher = watch(dir, { persistent: false }, (_eventType, filename) => {
+    const watcher = watch(watchablePath(dir), { persistent: false }, (_eventType, filename) => {
       if (filename !== null && filename !== base) return;
       scheduleDataSourcePublish(collection.slug);
     });
@@ -412,7 +434,7 @@ async function startStorageWatcher(collection: LoadedCollection): Promise<boolea
   try {
     await mkdir(dir, { recursive: true });
     await reconcileAllItems(collection, discoveryOpts);
-    const watcher = watch(dir, { persistent: false }, (_eventType, rawFilename) => {
+    const watcher = watch(watchablePath(dir), { persistent: false }, (_eventType, rawFilename) => {
       // fs.watch can hand back a Buffer on some platforms despite the
       // string typing — stringify defensively (a Buffer has no startsWith,
       // so calling it directly would throw inside the callback and crash).
@@ -465,7 +487,7 @@ async function startWatcherFor(collection: LoadedCollection): Promise<boolean> {
     // watcher: a pending item the user added during downtime needs its
     // bell entry even if no event fires today.
     await reconcileAllItems(collection, discoveryOpts);
-    const watcher = watch(dataDir, { persistent: false }, (_eventType, filename) => {
+    const watcher = watch(watchablePath(dataDir), { persistent: false }, (_eventType, filename) => {
       // Errors from inside the callback would propagate as unhandled
       // rejections — wrap so a single bad event can't unwind the watcher.
       onEvent(slug, filename).catch((err: unknown) => {

--- a/test/workspace/test_reference_dirs.ts
+++ b/test/workspace/test_reference_dirs.ts
@@ -81,8 +81,13 @@ describe("validateReferenceDirs — error text", () => {
   });
 
   it("still reports a genuine string path in the error", () => {
-    const result = validateReferenceDirs([{ hostPath: "/etc" }]);
+    // The filesystem root is the one blocked path that holds on every
+    // platform. `/etc` does NOT: Windows resolves it to `<drive>:\etc`, which
+    // matches nothing in the POSIX-only SYSTEM_BLOCKED_PREFIXES list, so the
+    // entry validates and there is no error to inspect.
+    const blocked = path.parse(path.resolve(".")).root;
+    const result = validateReferenceDirs([{ hostPath: blocked }]);
     assert.ok("error" in result);
-    assert.match(result.error, /\/etc/);
+    assert.ok(result.error.includes(blocked), `expected the error to echo ${blocked}, got: ${result.error}`);
   });
 });


### PR DESCRIPTION
## Summary

`lint_test_windows (24.x)` の失敗を修正します。**原因は無関係な2つ**でした。

1つ目はテストの失敗ではなく、**libuv のネイティブ assert によるプロセスクラッシュ**でした。

## Items to Confirm / Review

1. **`test_watcher.ts` は assertion で落ちたのではなく、プロセスごと死んでいました**（ログ上は `'test failed'` としか出ないため見落としやすい）。native assert なので `watcher.on("error")` や try/catch では**原理的に捕捉できません**。CI の一時的な不安定さではなく、条件が揃えば必ず落ちる性質のものです。
2. **`realpathSync.native` を win32 限定にしています** — POSIX では realpath がシンボリックリンクも解決してしまい（macOS の `/var` → `/private/var`）、必要のない挙動変更になるためです。失敗時は元のパスにフォールバックするので、最悪でも現状維持です。
3. **ref-dir テストの修正は「テストの前提」だけを直しています** — ブロックリスト自体は POSIX 専用のままです。テストを通すために検査を緩めたわけではないことを確認してください。Windows のシステムディレクトリが未ブロックである件は #2245 に分離しました。

## User Prompt

- fix https://github.com/receptron/mulmoclaude/actions/runs/29726601553/job/88301071356#step:15:9673

## 原因1: libuv が 8.3 短縮パスで abort する

```
INFO [collections] storage watcher started file=C:\Users\RUNNER~1\...\test-watcher-db.db
Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72
```

`ReadDirectoryChangesW` はファイル名を**長いパス基準**で通知しますが、監視を 8.3 短縮パスで開くとディレクトリ側は短縮形のまま保持されます。libuv はこの2つの前置一致を assert しており、一致しないと **abort します**。

GitHub の Windows ランナーでは `os.tmpdir()` が `C:\Users\RUNNER~1\...` を返すため、そこに mount した watcher は**最初のイベントでプロセスを道連れにする**状態でした。

修正: 3箇所の `watch()` すべてで win32 のときに `realpathSync.native` を通します（`C:\Users\RUNNER~1\...` → `C:\Users\runneradmin\...`）。

なお `watchers` マップに記録する `dataDir` は帳簿用で、アイテム解決には `collection.dataDir` が使われているため（`watcher.ts:551`）、監視パスの正規化による副作用はありません。

## 原因2: `/etc` は Windows でブロックされない

`validateReferenceDirs — still reports a genuine string path in the error` が `assert.ok("error" in result)` で失敗していました。

`validateReferenceDirs([{ hostPath: "/etc" }])` はエラーを返す前提でしたが、Windows では:

- `path.isAbsolute("/etc")` → `true`
- `path.resolve("/etc")` → `D:\etc`
- `SYSTEM_BLOCKED_PREFIXES` は POSIX パスのみ → **一致せず、ブロックされない**

結果としてエントリが検証を通り、エラーが存在しないため assertion が落ちていました。

修正: 全プラットフォームで確実にブロックされる**ファイルシステムルート**（既存の `normalized === path.parse(normalized).root` で拒否される）を使います。これにより「不正な形式」ではなく「ブロック済みパス」の分岐を引き続き検証できます。

## 変更内容

| ファイル | 内容 |
|---|---|
| `packages/core/src/collection-watchers/watcher.ts` | `watchablePath()` を追加し、3箇所の `watch()` に適用 |
| `test/workspace/test_reference_dirs.ts` | `/etc` 前提を外し、ファイルシステムルートを使用 |

## 検証

- `npx tsx --test test/workspace/test_reference_dirs.ts` → 6 pass / 0 fail
- `npx tsx --test test/workspace/collections/test_watcher.ts` → 10 pass / 0 fail
- `yarn format` / `build:packages` / `typecheck` / `lint` / `test` / `build` — すべて EXIT=0

> ローカルは macOS のため、原因1の再現・修正確認は **Windows CI 頼み**です。`realpathSync.native` は win32 のみを通るコードパスなので、macOS では実質no-opである点をご承知おきください。

## 分離した課題

- **#2245** — ブロックリストが POSIX 専用で、Windows のシステムディレクトリ（`C:\Windows` 等）が未ブロック。加えて Windows のパスは大文字小文字を区別しないため、比較方法も要検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and directory change monitoring on Windows by resolving short paths before watching, preventing potential process crashes.
  * Updated validation error coverage to work consistently across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->