### PR TITLE
fix(security): block Windows system dirs in reference-dirs (#2245)

### DIFF
--- a/server/workspace/reference-dirs.ts
+++ b/server/workspace/reference-dirs.ts
@@ -31,8 +31,31 @@ const CONTAINER_MOUNT_ROOT = "/mnt/readonly";
 /** Home-relative directories that must never be mounted. */
 const HOME_RELATIVE_BLOCKED = [".ssh", ".aws", ".gnupg", ".config/gh", ".kube", ".docker"];
 
-/** Absolute system paths that must never be mounted. */
-const SYSTEM_BLOCKED_PREFIXES = ["/etc", "/root", "/var", "/proc", "/sys", "/boot", "/private/etc", "/private/var", "/System", "/Library"];
+const IS_WINDOWS = process.platform === "win32";
+
+/** Absolute system paths that must never be mounted, POSIX spelling. */
+const POSIX_SYSTEM_BLOCKED = ["/etc", "/root", "/var", "/proc", "/sys", "/boot", "/private/etc", "/private/var", "/System", "/Library"];
+
+/** The Windows equivalents, read from the environment rather than hardcoded:
+ *  the system drive is not always `C:`, and a hardcoded letter would silently
+ *  block nothing on a machine that boots from another one. Entries the OS
+ *  doesn't set are simply absent. */
+function windowsSystemBlocked(): string[] {
+  const candidates = [process.env.SystemRoot, process.env.windir, process.env.ProgramFiles, process.env["ProgramFiles(x86)"], process.env.ProgramData];
+  return candidates.filter((value): value is string => typeof value === "string" && value.length > 0).map((value) => path.resolve(value));
+}
+
+// The POSIX list is dead weight on Windows — `path.resolve("/etc")` yields
+// `<drive>:\etc`, which matches no entry — so each platform carries only its
+// own vocabulary.
+const SYSTEM_BLOCKED_PREFIXES = IS_WINDOWS ? windowsSystemBlocked() : POSIX_SYSTEM_BLOCKED;
+
+/** Comparison key for a path. Windows filesystems are case-insensitive, so
+ *  `c:\windows` and `C:\Windows` name the same directory — comparing them
+ *  verbatim would let the lowercase spelling walk straight past the blocklist. */
+function pathKey(absPath: string): string {
+  return IS_WINDOWS ? absPath.toLowerCase() : absPath;
+}
 
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_RE_G = /[\x00-\x1f]/g;
@@ -48,6 +71,7 @@ function expandHome(inputPath: string): string {
 
 function isSensitivePath(absPath: string): boolean {
   const normalized = path.resolve(absPath);
+  const key = pathKey(normalized);
 
   // Reject filesystem root
   if (normalized === path.parse(normalized).root) return true;
@@ -55,20 +79,23 @@ function isSensitivePath(absPath: string): boolean {
   const home = homedir();
 
   // Block $HOME itself (transitively exposes .ssh etc.)
-  if (normalized === home) return true;
+  if (key === pathKey(home)) return true;
 
   // Block home-relative sensitive dirs
-  if (
-    HOME_RELATIVE_BLOCKED.some((blockedPath) => {
-      const full = path.join(home, blockedPath);
-      return normalized === full || normalized.startsWith(full + path.sep);
-    })
-  ) {
+  if (HOME_RELATIVE_BLOCKED.some((blockedPath) => isAtOrUnder(key, path.join(home, blockedPath)))) {
     return true;
   }
 
   // Block system directories
-  return SYSTEM_BLOCKED_PREFIXES.some((blockedPrefix) => normalized === blockedPrefix || normalized.startsWith(blockedPrefix + path.sep));
+  return SYSTEM_BLOCKED_PREFIXES.some((blockedPrefix) => isAtOrUnder(key, blockedPrefix));
+}
+
+/** True when `key` (already a `pathKey`) is the blocked dir itself or sits
+ *  underneath it. The `+ path.sep` guard is what keeps `/etc-backup` out of
+ *  `/etc`'s subtree. */
+function isAtOrUnder(key: string, blockedDir: string): boolean {
+  const blocked = pathKey(blockedDir);
+  return key === blocked || key.startsWith(blocked + path.sep);
 }
 
 function sanitizeLabel(raw: string): string {

--- a/test/workspace/test_reference_dirs.ts
+++ b/test/workspace/test_reference_dirs.ts
@@ -73,6 +73,65 @@ describe("loadReferenceDirs — non-string fields", () => {
   });
 });
 
+describe("system directory blocklist — per platform", () => {
+  /** The system dir this OS is expected to block. `null` means we have nothing
+   *  reliable to assert on (a Windows box exposing neither SystemRoot nor
+   *  windir), so those cases skip rather than assert something false. */
+  const blockedSystemDir = (): string | null => {
+    if (process.platform === "win32") return process.env.SystemRoot ?? process.env.windir ?? null;
+    return "/etc";
+  };
+
+  const NO_SYSTEM_DIR = "no system dir to assert on (Windows without SystemRoot/windir)";
+
+  const isBlocked = (hostPath: string): boolean => "error" in validateReferenceDirs([{ hostPath, label: "x" }]);
+
+  it("blocks this platform's system directory", (ctx) => {
+    const dir = blockedSystemDir();
+    if (dir === null) {
+      ctx.skip(NO_SYSTEM_DIR);
+      return;
+    }
+    assert.ok(isBlocked(dir), `expected ${dir} to be blocked`);
+  });
+
+  it("blocks a subdirectory of it too", (ctx) => {
+    const dir = blockedSystemDir();
+    if (dir === null) {
+      ctx.skip(NO_SYSTEM_DIR);
+      return;
+    }
+    const sub = path.join(dir, "sub");
+    assert.ok(isBlocked(sub), `expected ${sub} to be blocked`);
+  });
+
+  it("does NOT block a sibling whose name merely starts the same way", (ctx) => {
+    // `/etc-backup` must not be swallowed by `/etc`'s subtree — that is what
+    // the `+ path.sep` guard in isAtOrUnder buys.
+    const dir = blockedSystemDir();
+    if (dir === null) {
+      ctx.skip(NO_SYSTEM_DIR);
+      return;
+    }
+    const sibling = `${dir}-backup`;
+    assert.ok(!isBlocked(sibling), `expected ${sibling} to validate`);
+  });
+
+  it("blocks the lowercase spelling on Windows (case-insensitive filesystem)", (ctx) => {
+    // POSIX filesystems really are case-sensitive, so there is nothing to assert.
+    if (process.platform !== "win32") {
+      ctx.skip("win32 only");
+      return;
+    }
+    const dir = blockedSystemDir();
+    if (dir === null) {
+      ctx.skip(NO_SYSTEM_DIR);
+      return;
+    }
+    assert.ok(isBlocked(dir.toLowerCase()), `expected ${dir.toLowerCase()} to be blocked`);
+  });
+});
+
 describe("validateReferenceDirs — error text", () => {
   it("does not echo [object Object] back as the offending path", () => {
     const result = validateReferenceDirs([{ hostPath: { nested: true } }]);
@@ -81,10 +140,9 @@ describe("validateReferenceDirs — error text", () => {
   });
 
   it("still reports a genuine string path in the error", () => {
-    // The filesystem root is the one blocked path that holds on every
-    // platform. `/etc` does NOT: Windows resolves it to `<drive>:\etc`, which
-    // matches nothing in the POSIX-only SYSTEM_BLOCKED_PREFIXES list, so the
-    // entry validates and there is no error to inspect.
+    // The filesystem root is blocked on every platform, so this test says
+    // nothing about which system dirs a given OS blocks — see the
+    // platform-specific suite below for that.
     const blocked = path.parse(path.resolve(".")).root;
     const result = validateReferenceDirs([{ hostPath: blocked }]);
     assert.ok("error" in result);


### PR DESCRIPTION
## Summary

reference-dir のブロックリストが POSIX 専用だったため、**Windows ではシステムディレクトリを reference dir として登録でき、その内容がエージェントに露出する**状態でした。#2245 の修正です。

## Items to Confirm / Review

1. **ドライブレターを決め打ちしていません** — `C:\Windows` とハードコードすると、別ドライブから起動しているマシンでは**何もブロックしない**ことになります。`SystemRoot` / `windir` / `ProgramFiles` / `ProgramFiles(x86)` / `ProgramData` を環境変数から読みます。OS が設定していない項目は単に不在として扱います。
2. **win32 では比較を case-fold しています** — Windows のファイルシステムは大文字小文字を区別しないため、従来の `===` / `startsWith` では `c:\windows` が `C:\Windows` の指定をすり抜けていました。POSIX は本当に case-sensitive なので変更していません。
3. **プラットフォームごとに自分の語彙だけを持たせました** — POSIX のリストは Windows では死に設定です（`path.resolve("/etc")` → `<drive>:\etc` でどれとも一致しない）。逆も同様のため、`process.platform` で切り替えます。
4. **`isAtOrUnder` に切り出した際、`+ path.sep` ガードを保持しています** — `/etc-backup` が `/etc` の配下として誤ってブロックされないためのものです。**従来テストが無かった**ので今回追加しました。

## User Prompt

- （#2245 を指して）すすめる

## 問題の詳細

`server/workspace/reference-dirs.ts` のブロックリスト:

```ts
const SYSTEM_BLOCKED_PREFIXES = ["/etc", "/root", "/var", "/proc", "/sys", "/boot", "/private/etc", "/private/var", "/System", "/Library"];
```

Windows では二重に機能していませんでした:

- `C:\Windows`、`C:\Program Files`、`C:\ProgramData` は**そもそもリストに無い**
- POSIX の項目も一致しない（`path.resolve("/etc")` が `<drive>:\etc` になるため）

加えて比較が case-sensitive だったため、仮に `C:\Windows` を追加しても `c:\windows` は通り抜けていました。

## 元から効いていたガード（変更なし）

全面的に無防備だったわけではありません。以下は Windows でも機能しています:

- ファイルシステムルートの拒否
- `$HOME` 自体の拒否
- home 相対のセンシティブディレクトリ（`.ssh`、`.aws`、`.gnupg`、`.config/gh`、`.kube`、`.docker`）

これらは `homedir()` を基準にしているため、元から POSIX 依存ではありませんでした。**欠けていたのは「システムディレクトリ」の層だけ**です。

## 検証

- `test/workspace/test_reference_dirs.ts` — **9 pass / 1 skip / 0 fail**（macOS。win32 専用ケースは `ctx.skip()` で明示的にスキップ）
- 新規テスト4件: システムディレクトリ本体 / その配下 / **同名前置の兄弟（`-backup`）が誤爆しないこと** / Windows の小文字表記
- win32 分岐は macOS では実行されないため、**ロジック単体を切り出して検証**しました:

| 入力 | ブロック | 期待 |
|---|---|---|
| `C:\Windows` | ✅ | ✅ |
| `c:\windows` | ✅ | ✅ |
| `C:\WINDOWS\System32` | ✅ | ✅ |
| `C:\Program Files` / `C:\ProgramData\foo` | ✅ | ✅ |
| `C:\Windows-backup` | ❌ | ❌ |
| `C:\Users\me\docs` / `D:\data` | ❌ | ❌ |

- `yarn format` / `lint`（**0 errors**）/ `typecheck` / `test` / `build` — すべて EXIT=0

> **マージ前に Windows CI での実証を推奨します。** `lint_test_windows.yaml` は `pull_request` で走らないため、この PR の CI には Windows ジョブが含まれません:
> ```bash
> gh workflow run lint_test_windows.yaml --ref fix/2245-windows-system-dir-blocklist
> ```

Closes #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
