### PR TITLE
chore(lint): type .vue imports for the ESLint program — 148 → 122 warnings

### DIFF
--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,0 +1,19 @@
+// `.vue` module shim for the plain-TypeScript consumers of this program —
+// ESLint's type-aware rules run through `@typescript-eslint/parser`, which
+// builds a stock `tsc` program with no Vue language plugin, so every SFC
+// import resolves to nothing and lands as implicit `any`. That `any` then
+// flows through `wrapWithScope`'s generic into each plugin's registration
+// object, which is what `no-unsafe-assignment` was reporting across
+// `src/plugins/*/index.ts`.
+//
+// vue-tsc (the real `yarn typecheck` / build) resolves the SFC itself, and an
+// actual module always outranks a wildcard ambient declaration — so this
+// narrows nothing there. Mirrors `test/shims.d.ts`, which exists for the same
+// reason under `tsc -p test/tsconfig.json`.
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}


### PR DESCRIPTION
## Summary

`yarn lint` の警告を **148 → 122** に減らします。変更は `.d.ts` 1 枚のみで、**実行コードの差分はゼロ**です。

消えた 26 件はすべて `src/plugins/*/index.ts` の同じ形でした:

```ts
viewComponent: wrapWithScope("canvas", View),      // no-unsafe-assignment
previewComponent: wrapWithScope("canvas", Preview), // no-unsafe-assignment
```

## 原因は generic でもプラグイン設計でもなかった

最初はプラグイン登録側の設計か `wrapWithScope` の generic を疑いましたが、どちらも無実でした。

```ts
export function wrapWithScope<TInner extends Component | undefined>(scope: string, inner: TInner): TInner
```

generic は既にあり、正しく機能しています。**問題はその入力**です。ESLint の型認識ルールは `@typescript-eslint/parser` が組む**素の tsc プログラム**で動きます。そこには Vue の言語プラグインが無いので、SFC の import が解決できません:

```
$ npx tsc --noEmit --ignoreConfig --strict --moduleResolution bundler src/__probe.ts
error TS2307: Cannot find module './plugins/canvas/View.vue'
              or its corresponding type declarations.
```

つまり `View` / `Preview` が暗黙の `any` になり、`wrapWithScope<TInner>` は**それを忠実に伝播していただけ**でした。

これが分かると対処が変わります。**登録側をポリモーフィックに設計し直しても、入口が `any` である限り警告は消えません** — 大きな差分を出して原因が残る。逆に原因を潰せば、設計は今のままで 26 件消えます。

## 型安全を弱めていないこと（検証済み）

ワイルドカードの ambient 宣言を足すので、「vue-tsc の本物の prop 型まで潰れるのでは」が唯一の実質的リスクです。実際に確かめました。`src/plugins/wiki/View.vue` に不正な prop を渡すと:

```
TS2322: Type 'number' is not assignable to type '(text: string) => void'.
  The expected type comes from property 'sendTextMessage' which is declared here on type
  '{ readonly selectedResult?: ToolResultComplete<WikiData, unknown> | undefined;
     readonly sendTextMessage?: ((text: string) => void) | undefined; ... }'
```

**vue-tsc は今も本物の prop 型を見ています。** 実在モジュールの解決がワイルドカード ambient 宣言に優先するためです。同じ理由で `test/shims.d.ts` が既に存在していた（`tsc -p test/tsconfig.json` 用）ので、前例のあるパターンです。

## Items to Confirm / Review

- **shim の置き場所** — `src/shims-vue.d.ts` は `tsconfig.json` の `include` (`src/**/*.d.ts`) に入るので、vue-tsc のプログラムにも入ります。上記のとおり実害は無いことを確認していますが、「ambient 宣言を本番プログラムに入れたくない」という方針なら、ESLint 専用の tsconfig を分ける案もあります（その場合 lint 設定側の変更が増えます）
- **`DefineComponent<Record<string, never>, Record<string, never>, unknown>`** — `test/shims.d.ts` と同じ形にそろえました。`any` を使わない形なので、万一この宣言が効いてしまう経路があっても `any` は生みません

## 計測時の注意（レビュー時に踏むかもしれない点）

`yarn lint` は `--cache` 付きです。この変更は**型環境**を変えるだけで各ファイルの内容を変えないため、キャッシュが残っていると **148 のまま**に見えます。

```bash
rm -rf node_modules/.cache/eslint/ && yarn lint
```

で 122 になります。

## 残り 122 件について

`.vue` 起因はこれで打ち止めなので、残りは個別に `any` の出所を追う必要があります。内訳:

| ルール | 件数 |
|---|---|
| `no-unsafe-assignment` ほか `no-unsafe-*` 一族 | 約 104 |
| `sonarjs/function-return-type` | 10 |
| その他 sonarjs | 8 |

集中しているのは `packages/bridges/irc/src/index.ts` (18)、`server/api/routes/sessions.ts` (14)、`server/api/routes/roles.ts` (12)。これらは別 PR で、同じく「型だけで直る・挙動を変えない」ものを優先して進めます。

## User Prompt

- まず、リスクの低いもの、つまり型関係のコードだけで直るものを洗い出してそれを優先してほしい。挙動は変えないもの
- plugins でポリモーフィズム的なのが使えるかも検討してね
- generic かな？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript compatibility for Vue single-file components.
  * Enhanced linting and type-checking support without affecting Vue-aware tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->