### PR TITLE
fix(irc): type irc-framework locally, and stop a send failure from killing the bridge

### DIFF
--- a/packages/bridges/irc/src/index.ts
+++ b/packages/bridges/irc/src/index.ts
@@ -12,7 +12,6 @@
 //   IRC_PASSWORD   — NickServ or server password
 
 import "dotenv/config";
-// @ts-expect-error — irc-framework has no type declarations
 import { Client as IrcClient } from "irc-framework";
 import { createBridgeClient } from "@mulmobridge/client";
 
@@ -60,7 +59,24 @@ irc.on("registered", () => {
   }
 });
 
-irc.on("message", async (event: { target: string; nick: string; message: string }) => {
+interface IrcMessageEvent {
+  target: string;
+  nick: string;
+  message: string;
+}
+
+// `.on` takes a void-returning listener, so an async one hands EventEmitter a
+// floating promise: a `mulmo.send` rejection (the server being down is enough)
+// becomes an unhandled rejection, which Node turns into process exit — the
+// bridge dies on a transient error instead of logging and staying up. Keep the
+// async work in a named function and settle it here.
+irc.on("message", (event: IrcMessageEvent) => {
+  void handleMessage(event).catch((err: unknown) => {
+    console.error("[irc] message handling failed:", err);
+  });
+});
+
+async function handleMessage(event: IrcMessageEvent): Promise<void> {
   // Ignore our own messages
   if (event.nick === nick) return;
 
@@ -91,7 +107,7 @@ irc.on("message", async (event: { target: string; nick: string; message: string 
   console.log(`[irc] pm from=${event.nick} len=${text.length}`);
   const ack = await mulmo.send(chatId, text);
   sendReply(chatId, ack);
-});
+}
 
 function sendReply(target: string, ack: { ok: boolean; reply?: string; error?: string; status?: number }): void {
   if (ack.ok) {

--- a/packages/bridges/irc/src/irc-framework.d.ts
+++ b/packages/bridges/irc/src/irc-framework.d.ts
@@ -1,0 +1,36 @@
+// Minimal ambient types for `irc-framework`, which ships no declarations and
+// has no `@types/` package on npm. Replaces the `@ts-expect-error` that used
+// to sit on the import — that suppression made the whole client `any`, so
+// every `irc.say(…)` / `irc.on(…)` in this bridge was an unchecked call.
+//
+// Deliberately covers ONLY the surface this bridge uses. Signatures are read
+// off `node_modules/irc-framework/src/client.js`, not guessed:
+//
+//   class IrcClient extends EventEmitter   (so `on` comes from EventEmitter)
+//   connect(options)                       throws if never given options
+//   say(target, message, tags)             delegates to sendMessage, which
+//                                          returns nothing
+//   join(channel, key)
+//
+// Extend this file when the bridge starts using another method — do not
+// reintroduce a blanket suppression.
+
+declare module "irc-framework" {
+  import type { EventEmitter } from "node:events";
+
+  export interface IrcClientOptions {
+    host?: string;
+    port?: number;
+    nick?: string;
+    username?: string;
+    gecos?: string;
+    password?: string;
+    tls?: boolean;
+  }
+
+  export class Client extends EventEmitter {
+    connect(options?: IrcClientOptions): void;
+    say(target: string, message: string, tags?: Record<string, string>): void;
+    join(channel: string, key?: string): void;
+  }
+}


### PR DESCRIPTION
## Summary

`packages/bridges/irc` の lint 警告 18 件を消し、その過程で表に出た**実バグを 1 件修正**します。

⚠️ **この PR は挙動を変えます。** #2253（`.vue` shim / 型だけ・実行コード差分ゼロ）とは意図的に分けています。

## 発端：`@ts-expect-error` が client 全体を `any` にしていた

```ts
// @ts-expect-error — irc-framework has no type declarations
import { Client as IrcClient } from "irc-framework";
```

`irc-framework` は型を同梱せず、npm に `@types/irc-framework` もありません。この抑制は CLAUDE.md の「`@ts-expect-error` で黙らせるな、必要なら型ファイルを定義しろ」に反しているだけでなく、**`irc.say` / `irc.on` / `irc.connect` が全て無検査**になっていました（警告 18 件の正体）。

使っている面だけを宣言する `.d.ts` を追加しました。署名は**推測ではなく `node_modules/irc-framework/src/client.js` から読み取っています**:

| 実装 | 宣言 |
|---|---|
| `class IrcClient extends EventEmitter` | `class Client extends EventEmitter`（`on` は EventEmitter 由来） |
| `connect(options)` — options 無しかつ既存も無ければ throw | `connect(options?: IrcClientOptions): void` |
| `say(target, message, tags)` → `sendMessage` へ委譲、明示的 return 無し | `say(target, message, tags?): void` |
| `join(channel, key)` | `join(channel, key?): void` |

## `any` を外したら実バグが出た

型を付けた瞬間、警告 18 件が**エラー 1 件**に変わりました:

```
error  Promise returned in function argument where a void return was expected
       @typescript-eslint/no-misused-promises
```

```ts
irc.on("message", async (event) => {
  ...
  const ack = await mulmo.send(chatId, text);   // ← reject しうる
  sendReply(chatId, ack);
});
```

`.on` は void を返すリスナーを取るので、async ハンドラは EventEmitter に**浮いた promise** を渡しています。`mulmo.send` が reject すると（MulmoClaude サーバが落ちているだけで起きます）unhandled rejection になり、**Node はプロセスを終了させます** — 一時的なエラーでブリッジがログも残さず死ぬ。

`any` だったので今まで誰にも見えていませんでした。

## 修正（＝挙動の変更点）

async 処理を名前付き関数に分け、`catch` でログするようにしました。

- **従来**: `mulmo.send` の reject → unhandled rejection → プロセス終了
- **今後**: ログを出して当該メッセージだけ諦め、ブリッジは生存

ブリッジとしては後者が正しいと判断しましたが、**これは挙動の変更なので独立した PR にしています**。

## Items to Confirm / Review

- **落とすべきか、生き残るべきか** — 「送信失敗時はプロセスごと落として supervisor に再起動させたい」運用なら、この修正は方針違いです。その場合も unhandled rejection のままにするのではなく、明示的に `process.exit` させるべきなので、いずれにせよ修正は必要です
- **`.d.ts` の網羅範囲** — 現在このブリッジが使う 4 つだけを宣言しています。将来別のメソッドを使うときはこのファイルを広げる方針で、コメントにもそう書きました（抑制に戻さない）
- **テストが無い** — `packages/bridges/irc` は `"test": "echo no tests yet"` です。今回の修正は手で確認していません（IRC サーバへの実接続が要るため）。型と build は通っています

## 兄弟の確認

CLAUDE.md の「バグ家系は全ケースを潰せ」に従い、`async` ハンドラを `.on` に渡す形が他の bridge に無いか確認しました → **irc のみ**です。

```
$ grep -rn 'on("[a-z]*", async' packages/bridges/*/src/*.ts
packages/bridges/irc/src/index.ts:62
```

## 累計

`.vue` shim (#2253) と合わせて **148 → 130**。この PR 単独では 18 件減ります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing incoming IRC messages by handling errors without interrupting the bridge.
  * Improved forwarding of IRC and Mulmo messages, including clearer handling of chunked replies and errors.

* **Refactor**
  * Strengthened IRC integration validation to reduce connection and messaging issues.
  * Improved type safety and compatibility for IRC connections, channel joins, and message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->