### PR TITLE
chore(lint): type req.body on the routes that read it — 122 → 97 warnings

### DIFF
--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -234,20 +234,20 @@ bindRoute(
 // createMindMap — uses package execute for node layout computation
 router.post(
   API_ROUTES.plugins.mindmap,
-  wrapPluginExecute((req) => executeMindMap(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeMindMap>[1]>((req) => executeMindMap(null as never, req.body)),
 );
 
 // putQuestions — quiz
 router.post(
   API_ROUTES.plugins.quiz,
-  wrapPluginExecute((req) => executeQuiz(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeQuiz>[1]>((req) => executeQuiz(null as never, req.body)),
 );
 
 // presentForm — form
 bindRoute(
   router,
   API_ROUTES.form.dispatch,
-  wrapPluginExecute((req) => executeForm(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeForm>[1]>((req) => executeForm(null as never, req.body)),
 );
 
 // presentCollection — render a collection (or one item) as an inline,
@@ -308,7 +308,7 @@ bindRoute(
 // present3d — 3D visualization
 router.post(
   API_ROUTES.plugins.present3d,
-  wrapPluginExecute((req) => executePresent3D(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executePresent3D>[1]>((req) => executePresent3D(null as never, req.body)),
 );
 
 // mapControl — Google Map (showLocation / Places / Directions etc.)
@@ -318,7 +318,7 @@ router.post(
 // receives the API key as a prop sourced from `AppSettings`.
 router.post(
   API_ROUTES.plugins.googleMap,
-  wrapPluginExecute((req) => executeMapControl(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeMapControl>[1]>((req) => executeMapControl(null as never, req.body)),
 );
 
 // META aggregator diagnostics — boot-time host/plugin or plugin/plugin

--- a/server/api/routes/remoteHost.ts
+++ b/server/api/routes/remoteHost.ts
@@ -34,7 +34,7 @@ const respond = (res: Response<StatusResponse>, hostStatus: RemoteHostStatus): v
   res.json({ status: hostStatus, session: exportSession() });
 };
 
-router.post(API_ROUTES.remoteHost.connect, async (req: Request, res: Response<StatusResponse>) => {
+router.post(API_ROUTES.remoteHost.connect, async (req: Request<object, unknown, { idToken?: string }>, res: Response<StatusResponse>) => {
   const idToken = typeof req.body?.idToken === "string" ? req.body.idToken.trim() : "";
   if (!idToken) {
     badRequest(res, "Request body must be { idToken: string }");
@@ -49,7 +49,7 @@ router.post(API_ROUTES.remoteHost.connect, async (req: Request, res: Response<St
   }
 });
 
-router.post(API_ROUTES.remoteHost.reconnect, async (req: Request, res: Response<StatusResponse>) => {
+router.post(API_ROUTES.remoteHost.reconnect, async (req: Request<object, unknown, { session?: string }>, res: Response<StatusResponse>) => {
   const session = typeof req.body?.session === "string" ? req.body.session : "";
   if (!session) {
     badRequest(res, "Request body must be { session: string }");

--- a/server/api/routes/roles.ts
+++ b/server/api/routes/roles.ts
@@ -17,7 +17,7 @@ router.get(API_ROUTES.roles.list, (_req: Request, res: Response<Role[]>) => {
   res.json(loadCustomRoles());
 });
 
-router.post(API_ROUTES.roles.manage, async (req: Request, res: Response<Record<string, unknown>>) => {
+router.post(API_ROUTES.roles.manage, async (req: Request<object, unknown, ManageRolesInput>, res: Response<Record<string, unknown>>) => {
   const session = getSessionQuery(req);
   const action = typeof req.body?.action === "string" ? req.body.action : undefined;
   const roleId = typeof req.body?.roleId === "string" ? req.body.roleId : typeof req.body?.role?.id === "string" ? req.body.role.id : undefined;


### PR DESCRIPTION
## Summary

`server/api/routes` の 3 ファイルで `req.body` に型を当て、lint 警告を **122 → 97**（25 件減）にします。#2253（`.vue` shim）に続く「型だけ・挙動不変」シリーズです。

⚠️ **実行コードは 1 バイトも変わりません。** 差分は型注釈の追加のみです。

## 原因は #2253 と同じ構造

`req.body` は Express の型では `any`。それに触る式が芋づる式に `no-unsafe-*` になっていました。`.vue` と同じで、**入口の `any` が伝播しているだけ**なので、入口に型を当てれば連鎖的に消えます。

対処は 2 通り、どちらも **repo 内に手本があります**:

**① `roles.ts` / `remoteHost.ts` — ハンドラを `Request<object, unknown, TBody>` で注釈**
`plugins.ts:90` 等が既にこの形です。
- `roles` → 既存の `ManageRolesInput`
- `remoteHost` → 各エンドポイントの `{ idToken?: string }` / `{ session?: string }`

**② `plugins.ts` — `wrapPluginExecute<TBody>` に型引数を明示**
```ts
- wrapPluginExecute((req) => executeMindMap(null as never, req.body)),
+ wrapPluginExecute<Parameters<typeof executeMindMap>[1]>((req) => executeMindMap(null as never, req.body)),
```
型名を import せず `Parameters<typeof executeXxx>[1]` を使ったので、**execute が期待する型そのもの**が `req.body` に当たり、各プラグインの `Args` 型名に依存しません。

## 型安全性について正直に（レビュー要点）

これは `req.body` を**検証していません**。従来 `any` だったものに、その先で実際に使われている型を注釈しただけです。実行時の防御は、各ハンドラ内の既存の `typeof` チェック（`typeof req.body?.idToken === "string"` 等）と execute 側の検証に依存したままです。

型ガードによる入口検証（`req.body` を検証してから使う）は**挙動変更**になります — 今まで通っていた不正入力が弾かれうるためで、irc PR (#2254) で `any` を外したら実バグが出たのと同じリスク構造です。したがって「型だけ・挙動不変」というこの PR の約束を守るため、**検証の追加はこの PR に含めず別途**とします。

## 検証

- `git diff` は型注釈の追加のみ（`req.body` の中身・三項演算子・関数呼び出しはすべて同一）
- `yarn typecheck` / `yarn build` / `yarn test` すべて green（test fail 0）

## 計測時の注意

`yarn lint` は `--cache` 付きで、型環境だけ変えてファイル内容を変えないこの手の変更はキャッシュに隠れます。`rm -rf node_modules/.cache/eslint/ && yarn lint` で 97 になります。

## シリーズ全体の進捗

| PR | 内容 | 件数 | 状態 |
|---|---|---|---|
| #2253 | `.vue` shim | 26 | merged |
| #2254 | irc bridge（⚠️挙動変更） | 18 | LGTM / green |
| **本 PR** | routes の req.body 型注釈 | 25 | — |

3 本合わせて **148 → 79**。残りは `sessions.ts` の JSONL パース由来の `any`（型ガードが要る＝挙動変更側）や `sonarjs/function-return-type` など。

## User Prompt

- まず、リスクの低いもの、つまり型関係のコードだけで直るものを洗い出してそれを優先してほしい。挙動は変えないもの
- review にまわしつつ、調査を並行しよう


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request validation and type safety for plugin execution, remote host connections, reconnections, and role management endpoints.
  * No changes to user-facing functionality, runtime behavior, responses, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->