### PR TITLE
fix(sessions): replace as-any + no-explicit-any escapes with real type guards

### DIFF
--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -290,18 +290,18 @@ interface SessionErrorResponse {
 // Narrow type predicate for the presentMulmoScript tool-result shape
 // the enrichment helper inspects. Returning `entry is …` lets the
 // caller drop the redundant nested checks once the predicate passes.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isPresentMulmoScriptToolResult(entry: any): entry is {
+type PresentMulmoScriptToolResult = {
   source: "tool";
   type: string;
-  result: { toolName: "presentMulmoScript"; data: { filePath: string } & Record<string, unknown> };
-} & Record<string, unknown> {
-  return (
-    entry?.source === "tool" &&
-    entry?.type === EVENT_TYPES.toolResult &&
-    entry?.result?.toolName === "presentMulmoScript" &&
-    typeof entry?.result?.data?.filePath === "string"
-  );
+  result: { toolName: "presentMulmoScript"; data: { filePath: string } & Record<string, unknown> } & Record<string, unknown>;
+} & Record<string, unknown>;
+
+function isPresentMulmoScriptToolResult(entry: unknown): entry is PresentMulmoScriptToolResult {
+  if (!isRecord(entry) || entry.source !== "tool" || entry.type !== EVENT_TYPES.toolResult) return false;
+  const { result } = entry;
+  if (!isRecord(result) || result.toolName !== "presentMulmoScript") return false;
+  const { data } = result;
+  return isRecord(data) && typeof data.filePath === "string";
 }
 
 // Re-read the MulmoScript JSON pointed at by `entry.result.data.filePath`
@@ -310,8 +310,7 @@ function isPresentMulmoScriptToolResult(entry: any): entry is {
 // path) so the detail route never breaks because of a single rotted
 // link. Path-traversal guard is realpath-based — see
 // resolveWithinRoot for why.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function enrichWithMulmoScript(entry: any): Promise<any> {
+async function enrichWithMulmoScript(entry: PresentMulmoScriptToolResult): Promise<unknown> {
   try {
     const storiesDir = path.resolve(WORKSPACE_PATHS.stories);
     let storiesReal: string;
@@ -326,13 +325,14 @@ async function enrichWithMulmoScript(entry: any): Promise<any> {
     const scriptPath = resolveWithinRoot(storiesReal, relFromStories);
     if (!scriptPath) return entry;
     const scriptJson = (await readTextSafe(scriptPath)) ?? "";
+    const script: unknown = JSON.parse(scriptJson);
     return {
       ...entry,
       result: {
         ...entry.result,
         data: {
           ...entry.result.data,
-          script: JSON.parse(scriptJson),
+          script,
         },
       },
     };
@@ -352,12 +352,12 @@ async function parseSessionEntry(line: string): Promise<unknown> {
   } catch {
     return null;
   }
-  // Skip legacy metadata entries now stored in .json
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const typed = entry as any;
-  if (typed?.type === EVENT_TYPES.sessionMeta || typed?.type === EVENT_TYPES.claudeSessionId) return null;
-  if (isPresentMulmoScriptToolResult(typed)) return enrichWithMulmoScript(typed);
-  return typed;
+  // Skip legacy metadata entries now stored in .json. A non-object line
+  // (JSON.parse can return a bare number/string) has no type field, so it
+  // falls through unchanged — same as the previous optional-chaining path.
+  if (isRecord(entry) && (entry.type === EVENT_TYPES.sessionMeta || entry.type === EVENT_TYPES.claudeSessionId)) return null;
+  if (isPresentMulmoScriptToolResult(entry)) return enrichWithMulmoScript(entry);
+  return entry;
 }
 
 router.get(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res: Response<unknown[] | SessionErrorResponse>) => {


### PR DESCRIPTION
## Summary

`sessions.ts` の JSONL エントリ処理から `any` を排除し、lint 警告を **14 件**消します。同時に **CLAUDE.md 違反を 4 件解消**します。

このファイルには:
- 明示的な `const typed = entry as any;` — CLAUDE.md の「`as` 禁止」違反
- `// eslint-disable-next-line @typescript-eslint/no-explicit-any` × 3 — 「`eslint-disable` で黙らせるな」違反

がありました。すべて「JSONL の 1 行 = 未検証の外部データ」が `any` として伝播していたものです。

## 修正

`JSON.parse` の結果は `unknown` が正しい型です。既に import 済みの `isRecord`（`server/utils/types.ts`）で段階的に絞る型ガードに置き換えました。

```ts
- function isPresentMulmoScriptToolResult(entry: any): entry is {…} {
-   return entry?.source === "tool" && entry?.type === … && typeof entry?.result?.data?.filePath === "string";
+ function isPresentMulmoScriptToolResult(entry: unknown): entry is PresentMulmoScriptToolResult {
+   if (!isRecord(entry) || entry.source !== "tool" || entry.type !== EVENT_TYPES.toolResult) return false;
+   const { result } = entry;
+   if (!isRecord(result) || result.toolName !== "presentMulmoScript") return false;
+   const { data } = result;
+   return isRecord(data) && typeof data.filePath === "string";
```

3 箇所を対応:
- **`isPresentMulmoScriptToolResult`** — 旧 optional-chaining を `isRecord` の段階チェックに。非オブジェクト／非レコードの `result` は旧実装同様 `false`。
- **`enrichWithMulmoScript`** — 引数を絞った型に、戻り値 `any → unknown`。`JSON.parse` は `const script: unknown` で受ける。
- **`parseSessionEntry`** — `entry as any` を削除し `isRecord` 分岐に。

## 挙動不変であること

**これは #2254(irc)のような挙動変更ではありません。** 既存の `typeof` チェックと optional-chaining を、型システムに正しく伝えただけです。

- 実行される分岐条件は同一（非オブジェクト行は旧 `entry?.type` でも新 `isRecord(entry) &&` でも同じく素通り）
- `parseSessionEntry` の返り値は旧 `return typed` と同じ値の `return entry`（型が `any → unknown` になるだけ、値は `JSON.parse` の結果そのもの）
- `JSON.parse` を `unknown` で受けても、オブジェクトに入る `script` の実行時の値は同一

`typeof` チェックと同じ結果を型ガードで表現しただけなので、malformed 入力の扱いも変わりません。

## 検証

`yarn typecheck` / `yarn build` / `yarn test` すべて green。

（補足: 初回コミット時に pre-commit hook が exit 2 で落ちましたが、原因はこの調査中に background で走らせていた `yarn typecheck` と hook の typecheck が同じ `tsbuildinfo` を同時に触った競合でした。各ステップ単独ではすべて exit 0 で、競合を解消して再コミットで通っています。コード起因ではありません。）

## 位置づけ

lint 掃除シリーズの一環です。`.vue`(#2253) → routes の req.body(#2255) が「純粋な型注釈のみ」だったのに対し、これは「`as any` を型ガードに置き換え」で一歩踏み込みますが、挙動は不変に保っています。CLAUDE.md 違反（`as` / `eslint-disable`）の解消という副次的価値もあります。

## User Prompt

- リスクの低い、型関係のコードだけで直る・挙動を変えないものを優先
- review にまわしつつ調査を並行、どんどん並列で進めて

## Summary by Sourcery

Replace untyped JSONL session entry handling with stricter, type-safe guards while preserving runtime behavior.

Enhancements:
- Introduce a dedicated PresentMulmoScriptToolResult type and type guard to validate tool result entries from JSONL sessions.
- Tighten enrichWithMulmoScript and parseSessionEntry to operate on unknown/typed inputs instead of any while keeping their observable behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety when processing session data and MulmoScript tool results.
  * Enhanced handling of legacy metadata and non-object JSON entries during session parsing.
  * Preserved existing session enrichment behavior while making data processing more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->