### PR TITLE
chore(lint): type the RELAY durable-object binding — drops 9 warnings

### DIFF
--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef -- Cloudflare Workers ambient types (DurableObjectNamespace) live in @cloudflare/workers-types, which tsc sees via tsconfig `types` but eslint's globals list does not. Same reason durable-object.ts disables it. */
 // Relay message format — normalized from platform-specific webhooks.
 
 export const PLATFORMS = {
@@ -45,8 +46,7 @@ export interface RelayResponse {
 // can access their own secrets without extending this interface.
 // Each plugin checks for its own keys via `env.KEY_NAME`.
 export interface Env {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RELAY: any;
+  RELAY: DurableObjectNamespace;
   RELAY_TOKEN: string;
   // Platform-specific secrets are accessed dynamically.
   // Known keys for reference (not exhaustive):


### PR DESCRIPTION
## Summary

`packages/relay/src/types.ts` の `RELAY: any`(Cloudflare Durable Object の namespace binding)を正しく型付けし、lint 警告を **9 件**消します。**`index.ts` は 1 行も変わりません**（型が正しくなっただけ）。

## 原因

`RELAY: any` が、`index.ts` の `forwardToDurableObject` 全体を `any` にしていました:

```ts
const durableObjectId = env.RELAY.idFromName("singleton");  // .idFromName が any
const stub = env.RELAY.get(durableObjectId);                // .get が any → stub も any
return stub.fetch(new Request(url.toString(), request));    // .fetch が any → 戻り値も unsafe
```

これで 9 件の `no-unsafe-*`（member-access / call / assignment / return）。

## 修正

`RELAY` は Cloudflare ランタイムの binding で、**静的に型が決まっています**（パース済みデータではないので検証は不要）。`@cloudflare/workers-types` は既に relay の `package.json` と `tsconfig.json` の `types` に入っているので、型を正しく宣言するだけです:

```ts
- // eslint-disable-next-line @typescript-eslint/no-explicit-any
- RELAY: any;
+ RELAY: DurableObjectNamespace;
```

使用箇所との照合（型は `node_modules/@cloudflare/workers-types` の実体で確認）:
- `idFromName(name): DurableObjectId` ✓
- `get(id): DurableObjectStub` ✓
- `DurableObjectStub` は `Fetcher` を継承 → `fetch(): Promise<Response>` ✓（関数の宣言戻り値 `Promise<Response>` と一致し no-unsafe-return も解消）

## eslint の no-undef について

`RELAY: DurableObjectNamespace` にすると eslint の `no-undef` が「`DurableObjectNamespace` is not defined」と出ます。Cloudflare の ambient 型は `globals` パッケージに無く、**tsc は tsconfig の `types` 経由で見えるが eslint の globals list には無い**ためです。

これは既に `durable-object.ts` が file-level `/* eslint-disable no-undef */` で対処している確立パターンなので、`types.ts` にも rationale 付きで対称に追加しました。**`any` を隠すための抑制ではなく**、eslint の globals 限界に対する既存パターンです（`lint-policy.md`: rationale 付き disable は意図的、という方針にも沿います）。

正味の disable 増減: 元の `RELAY: any` に付いていた `eslint-disable no-explicit-any`（next-line 1つ）を削除し、`no-undef`（file-level 1つ）を追加。any の隠蔽を、Cloudflare 型の正しい宣言 + eslint の限界の明示に置き換えています。

## 検証

- `git diff packages/relay/src/index.ts` は空（実行コード完全不変で 9 件消えた）
- `yarn typecheck` / `yarn build` / `yarn lint` すべて green

## シリーズ進捗

| PR | 内容 | 件数 | 状態 |
|---|---|---|---|
| #2253 | .vue shim | 26 | merged |
| #2254 | irc bridge（挙動変更） | 18 | merged |
| #2255 | routes req.body | 25 | merged |
| #2256 | sessions 型ガード | 14 | LGTM |
| **本 PR** | relay durable-object | 9 | — |

合わせて **148 → 56**。残りは bridges 5 件（TYPE-ONLY）、matrix（irc と同じ実バグ）、mcp-server（型ガード要）、sonarjs function-return-type（Result イディオム、触らない方針）など。

## Summary by Sourcery

Enhancements:
- Replace the RELAY env binding type from any to DurableObjectNamespace and document the eslint no-undef suppression rationale for Cloudflare Workers ambient types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety for Cloudflare Workers environment configuration.
  * Replaced an untyped relay binding with a specific Durable Object namespace type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->