### PR TITLE
chore(lint): remove any-widening in 3 bridges (behavior-unchanged)

### DIFF
--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -75,8 +75,8 @@ async function fetchJwks(): Promise<JwkKey[]> {
     if (!res.ok) {
       throw new Error(`JWKS fetch failed: ${res.status}`);
     }
-    const data: { keys?: unknown[] } = await res.json();
-    if (!Array.isArray(data.keys)) throw new Error("Invalid JWKS response");
+    const data: unknown = await res.json();
+    if (!isObj(data) || !Array.isArray(data.keys)) throw new Error("Invalid JWKS response");
     cachedKeys = data.keys.filter(
       (keyCandidate): keyCandidate is JwkKey =>
         isObj(keyCandidate) && typeof keyCandidate.kid === "string" && typeof keyCandidate.n === "string" && typeof keyCandidate.e === "string",

--- a/packages/bridges/rocketchat/src/index.ts
+++ b/packages/bridges/rocketchat/src/index.ts
@@ -59,6 +59,12 @@ function isObj(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null;
 }
 
+// `Array.isArray(x: unknown)` narrows to `any[]`, which reintroduces `any`;
+// this preserves the element type as `unknown` so downstream stays checked.
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
 function authHeaders(): Record<string, string> {
   return {
     "X-Auth-Token": authToken,
@@ -207,7 +213,7 @@ async function pollRoom(roomId: string, oldestIso: string): Promise<string> {
       inclusive: "false",
       count: String(HISTORY_PAGE_SIZE),
     });
-    const messages = Array.isArray(result.messages) ? result.messages : [];
+    const messages: unknown[] = isUnknownArray(result.messages) ? result.messages : [];
     if (messages.length === 0) break;
 
     const sorted = [...messages].reverse(); // API returns newest-first

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -107,6 +107,12 @@ function isObj(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+// `Array.isArray(x: unknown)` narrows to `any[]`, which reintroduces `any`;
+// this preserves the element type as `unknown` so the spread stays checked.
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
 function parseOneMessage(msg: unknown): WhatsAppTextMessage | null {
   if (!isObj(msg)) return null;
   if (msg.type !== "text" || typeof msg.from !== "string") return null;
@@ -124,7 +130,7 @@ function collectRawMessages(body: unknown): unknown[] {
     for (const change of entry.changes) {
       if (!isObj(change) || !isObj(change.value)) continue;
       const { messages } = change.value;
-      if (Array.isArray(messages)) raw.push(...messages);
+      if (isUnknownArray(messages)) raw.push(...messages);
     }
   }
   return raw;


### PR DESCRIPTION
## Summary

3 つの chat bridge の `no-unsafe-*` 警告を **挙動完全不変**で消します（各 1 件）。

## 修正

**whatsapp / rocketchat — `Array.isArray` の widening**
`Array.isArray(x: unknown)` は x を `any[]` に narrow する TypeScript の既知の癖で、`any` が再導入されます（`raw.push(...messages)` 等が no-unsafe）。要素型を `unknown` のまま保つ型ガードを各ファイルに追加:

```ts
function isUnknownArray(value: unknown): value is unknown[] {
  return Array.isArray(value);
}
```

bridges は互いに依存しない設計（各パッケージが `isObj` をローカル定義）なので、共有せずローカルに置きました。**実行時は同じ `Array.isArray` を呼ぶだけ**で判定は不変です。

**google-chat — `res.json()` の any**
```ts
- const data: { keys?: unknown[] } = await res.json();
- if (!Array.isArray(data.keys)) throw new Error("Invalid JWKS response");
+ const data: unknown = await res.json();
+ if (!isObj(data) || !Array.isArray(data.keys)) throw new Error("Invalid JWKS response");
```
`data` が非オブジェクトなら旧実装も `data.keys === undefined` で同じ throw に落ちるので、**throw 条件は不変**です。

## 挙動不変であること

`git diff` は型注釈と guard の追加のみで、実行される判定ロジックと分岐結果は同一です。`yarn typecheck` / `yarn build` / `yarn lint` すべて green。

## 除外した 2 bridge（意図的）

同じ bridge 群の **mattermost / zulip は今回除外**しました。これらは「型だけ・挙動不変」に収まりません:

- **mattermost**: `JSON.parse` した post のフィールド（`post.user_id`, `post.message` 等）に `any` で緩くアクセスしています。厳密な型ガードを入れると、現状は素通りしていた不正入力（`user_id` 欠如など）が弾かれ、**挙動が変わります**。
- **zulip**: `res.json()` を返す関数の戻り値型（`Promise<JsonRecord>`）を変えると、呼び出し側に波及します。

これらは **matrix**（後述）や **mcp-server** と同じ「挙動変更グループ」として別途扱います。

## ⚠️ 調査中に見つけた実バグ（別 PR 予定）

このシリーズの調査で、**matrix bridge に irc(#2254) と同じ floating-promise バグ**を発見しました:

```ts
(matrixClient as any).on("Room.timeline", async (event, room) => { … })
```

`as any`(CLAUDE.md 二重違反)が `.on` を `any` にして警告を消していますが、これは async ハンドラを sync-only な EventEmitter に渡しており、ハンドラ前半（try/catch の外）で throw すると unhandled rejection → プロセスクラッシュします。irc とまったく同じ構造で、`RoomEvent.Timeline` の型付き API を使えば `no-misused-promises`(error) が発火して検出できます。これは挙動変更を伴う修正なので独立 PR にします。

## シリーズ進捗

| PR | 内容 | 件数 | 状態 |
|---|---|---|---|
| #2253–2256 | .vue / irc / routes / sessions | 83 | merged |
| #2257 | relay durable-object | 9 | LGTM |
| **本 PR** | 3 bridges（挙動不変） | 3 | — |

残りの挙動変更グループ: matrix(実バグ), mattermost, zulip, mcp-server。

## User Prompt

- 型関係のコードだけで直る・挙動を変えないものを優先
- review にまわしつつ調査を並行、どんどん並列で進めて

## Summary by Sourcery

Tighten type safety in three chat bridges to satisfy lint rules without changing runtime behavior.

Enhancements:
- Add local unknown[] array type guards in the Rocket.Chat and WhatsApp bridges to avoid any-widening from Array.isArray while preserving existing control flow.
- Strengthen JWKS response validation in the Google Chat bridge by treating JSON responses as unknown and guarding shape before use to avoid implicit any.