### PR TITLE
fix(matrix): typed RoomEvent API + stop a handler throw from killing the bridge

### DIFF
--- a/packages/bridges/matrix/src/index.ts
+++ b/packages/bridges/matrix/src/index.ts
@@ -13,7 +13,7 @@
 //   MATRIX_ALLOWED_ROOMS   — CSV of room IDs (empty = all joined rooms)
 
 import "dotenv/config";
-import { createClient, type MatrixClient, type MatrixEvent, type Room } from "matrix-js-sdk";
+import { createClient, RoomEvent, type MatrixClient, type MatrixEvent, type Room } from "matrix-js-sdk";
 import { createBridgeClient } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "matrix";
@@ -46,10 +46,20 @@ mulmo.onPush((pushEvent) => {
   matrixClient.sendTextMessage(pushEvent.chatId, pushEvent.message).catch((err: unknown) => console.error(`[matrix] push send failed: ${err}`));
 });
 
-// The matrix-js-sdk event emitter types are narrowly typed; the
-// Room.timeline event name requires a cast.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(matrixClient as any).on("Room.timeline", async (event: MatrixEvent, room: Room | null) => {
+// `.on` takes a void-returning listener, so an async one hands the emitter a
+// floating promise: a throw in the synchronous prelude (getType/getContent,
+// which run before mulmo.send's own error handling) would become an unhandled
+// rejection that crashes the process. Keep the listener sync and settle the
+// async work with `.catch()`. `RoomEvent.Timeline` is the typed event key —
+// the old `"Room.timeline"` string + `as any` cast only masked the emitter's
+// precise typing.
+matrixClient.on(RoomEvent.Timeline, (event: MatrixEvent, room: Room | undefined) => {
+  void handleTimelineEvent(event, room).catch((err: unknown) => {
+    console.error(`[matrix] message handling failed: ${err}`);
+  });
+});
+
+async function handleTimelineEvent(event: MatrixEvent, room: Room | undefined): Promise<void> {
   if (!room) return;
   if (event.getType() !== "m.room.message") return;
   if (event.getSender() === userId) return;
@@ -66,18 +76,14 @@ mulmo.onPush((pushEvent) => {
 
   console.log(`[matrix] message room=${roomId} sender=${event.getSender()} len=${text.length}`);
 
-  try {
-    const ack = await mulmo.send(roomId, text);
-    if (ack.ok) {
-      await sendChunked(roomId, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await matrixClient.sendTextMessage(roomId, `Error${status}: ${ack.error ?? "unknown"}`);
-    }
-  } catch (err) {
-    console.error(`[matrix] message handling failed: ${err}`);
+  const ack = await mulmo.send(roomId, text);
+  if (ack.ok) {
+    await sendChunked(roomId, ack.reply ?? "");
+  } else {
+    const status = ack.status ? ` (${ack.status})` : "";
+    await matrixClient.sendTextMessage(roomId, `Error${status}: ${ack.error ?? "unknown"}`);
   }
-});
+}
 
 async function sendChunked(roomId: string, text: string): Promise<void> {
   // Matrix has no strict char limit but we chunk at 4000 for readability


### PR DESCRIPTION
## Summary

**irc(#2254)とまったく同じ floating-promise 実バグ**が matrix bridge にもありました。⚠️ **挙動を変えます**（プロセスクラッシュ → ログして継続）。

```ts
// eslint-disable-next-line @typescript-eslint/no-explicit-any
(matrixClient as any).on("Room.timeline", async (event, room) => { … })
```

`as any`（CLAUDE.md 二重違反: `as` + `any`）が emitter の型を潰して警告 2 件を黙らせていました。しかし matrix-js-sdk は**完全な型を持っています**。`.on` は void を返すリスナーを取るので、async ハンドラは**浮いた promise** を渡しており、ハンドラ前半（`getType`/`getSender`/`getContent`）は元の try/catch の外で走るため、そこで throw すると unhandled rejection → **Node がプロセスを落とします**。一時的なイベントでブリッジが死にます。

## 修正（irc と同じ様式）

- 文字列 `"Room.timeline"` を typed な `RoomEvent.Timeline` に。値は同一文字列で、`node_modules/matrix-js-sdk` の `room.d.ts:62`（`Timeline = "Room.timeline"`）と `event-timeline-set.d.ts:58`（handler 型 `(event, room: Room | undefined, …) => void`）で確認しました。
- リスナーを sync にして、async 処理を名前付き関数 `handleTimelineEvent` に分離し `.catch()` で settle。前半の throw も `mulmo.send` の reject も全て捕捉されます。
- `room` の型を typed API に合わせて `Room | null` → `Room | undefined`（`!room` チェックはどちらも通る）。`as any` と `eslint-disable` を削除。

## 挙動の変更点

- **従来**: ハンドラ内（特に try/catch 外の前半）の throw → unhandled rejection → プロセス終了
- **今後**: ログして当該イベントだけ諦め、ブリッジは生存

ブリッジとしては後者が正しく、irc(#2254、マージ済み)で承認された修正とまったく同じクラスです。

## Items to Confirm / Review

- **落とすか生き残るか** — irc と同じく「送信/処理失敗でプロセスごと落として supervisor に再起動させたい」運用なら方針違いですが、その場合も unhandled rejection のままにするのではなく明示的に落とすべきなので、いずれにせよ修正は必要です。
- **テストが無い** — `packages/bridges/matrix` にテストはなく（bridges 共通）、手動確認は未（Matrix サーバへの実接続が要る）。typecheck / build / lint は green。

## 兄弟確認

`async` ハンドラを `.on` に渡すパターンが他 bridge に残っていないことを確認済み（`grep 'on(.*async' packages/bridges/*/src`）→ **irc / matrix で打ち止め**。

## シリーズ位置づけ

lint 掃除の調査で発見した 2 つ目の実バグ（1 つ目は irc）。純粋な lint 消しではなく、`any` が隠していたクラッシュバグの修正です。残りの挙動変更グループ: mattermost, zulip, mcp-server。

## User Prompt

- 型関係のコードだけで直る・挙動を変えないものを優先（本 PR は例外的に実バグ修正）
- review にまわしつつ調査を並行、どんどん並列で進めて

## Summary by Sourcery

Harden Matrix bridge room timeline handling by using the typed RoomEvent API and preventing handler errors from crashing the process.

Bug Fixes:
- Stop unhandled rejections from the Matrix Room.timeline handler from crashing the Node process by keeping the event listener synchronous and explicitly catching async errors.
- Align the Matrix bridge room parameter type with the matrix-js-sdk RoomEvent.Timeline signature to avoid relying on an any cast.

Enhancements:
- Switch the Matrix bridge to the typed RoomEvent.Timeline key instead of the raw "Room.timeline" string and remove the any cast and linter suppression around the event listener.