### PR TITLE
fix(mcp-server): type the JSON response bodies, drop an as-cast

### DIFF
--- a/server/agent/mcp-server.ts
+++ b/server/agent/mcp-server.ts
@@ -371,8 +371,11 @@ async function fetchSkillsList(): Promise<{ name: string }[]> {
     const body = await safeResponseText(res);
     throw new Error(`HTTP ${res.status} calling /api/skills: ${body}`);
   }
-  const body: { skills: { name: string }[] } = await res.json();
-  return body.skills;
+  const body: unknown = await res.json();
+  if (!isRecord(body) || !Array.isArray(body.skills)) {
+    throw new Error(`Unexpected /api/skills response: expected { skills: [...] }`);
+  }
+  return body.skills.filter((skill): skill is { name: string } => isRecord(skill) && typeof skill.name === "string");
 }
 
 async function pushSkillsListResult(message: string): Promise<void> {
@@ -472,6 +475,22 @@ async function handleManageSkillsDelete(args: Record<string, unknown>): Promise<
   return `Deleted skill ${name}.`;
 }
 
+// Render a pure-MCP-tool response body to the string the CLI returns. The
+// body is untyped JSON, so `error`/`result` are read through guards: a
+// non-string `error` falls back to the status code (avoids stringifying an
+// object), and a non-string `result` is JSON-encoded — with a "null" fallback
+// because `JSON.stringify(undefined)` is itself `undefined`, which the return
+// type forbids.
+async function formatMcpToolResponse(res: Response): Promise<string> {
+  const json: unknown = await res.json();
+  if (!res.ok) {
+    const errValue = isRecord(json) && typeof json.error === "string" ? json.error : undefined;
+    return `Error: ${errValue ?? res.status}`;
+  }
+  const resultValue = isRecord(json) ? json.result : undefined;
+  return typeof resultValue === "string" ? resultValue : (JSON.stringify(resultValue) ?? "null");
+}
+
 async function handleToolCall(name: string, args: Record<string, unknown>): Promise<string> {
   if (name === "manageSkills") return handleManageSkills(args);
 
@@ -487,9 +506,7 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
       allowHttpError: true,
       timeoutMs: MCP_TOOL_BRIDGE_TIMEOUT_MS,
     });
-    const json = await res.json();
-    if (!res.ok) return `Error: ${json.error ?? res.status}`;
-    return typeof json.result === "string" ? json.result : JSON.stringify(json.result);
+    return formatMcpToolResponse(res);
   }
 
   const tool = tools.find((toolDef) => toolDef.name === name);
@@ -501,7 +518,8 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   // for the slowest realistic completion — see PLUGIN_BRIDGE_TIMEOUT_MS
   // and the timeout-policy comment on `postJson`.
   const res = await postJson(tool.endpoint, args, { timeoutMs: PLUGIN_BRIDGE_TIMEOUT_MS });
-  const result = ((await res.json()) ?? {}) as PluginResultEnvelope;
+  const rawResult: unknown = (await res.json()) ?? {};
+  const result: PluginResultEnvelope = isRecord(rawResult) ? rawResult : {};
 
   // Push visual ToolResult to the frontend via the session — but
   // only when the handler set `data`, which is the protocol's


### PR DESCRIPTION
## Summary

`server/agent/mcp-server.ts` の `Response.json()`(DOM 型では `Promise<any>`)由来の `no-unsafe-*` を **7 件**消し、CLAUDE.md 違反の `as PluginResultEnvelope` を 1 箇所解消します。手本は `server/utils/fetch.ts` の `extractFetchError`(unknown で受けて `isRecord` で narrow)。

⚠️ **一部挙動が変わります**（`any` が隠していた既存の緩さ/バグを型ガードで露出し、明示的に処理）。

## 3 箇所の修正

**① fetchSkillsList**
```ts
- const body: { skills: { name: string }[] } = await res.json();
- return body.skills;
+ const body: unknown = await res.json();
+ if (!isRecord(body) || !Array.isArray(body.skills)) throw new Error("Unexpected /api/skills response: ...");
+ return body.skills.filter((skill): skill is { name: string } => isRecord(skill) && typeof skill.name === "string");
```
呼び出し側は `skills.length` / `data: { skills }` として配列を前提にしています。**正常系は不変**。異常系は改善: 従来は `skills` が非配列だと `undefined.length` の不明瞭な TypeError でしたが、今は明示的な throw になります。

**② MCP tool 応答（Site B）**
`json.error` / `json.result` を `isRecord` 経由で読みます。複雑度が 15 を超えたため `formatMcpToolResponse` に抽出。
- `error` は **string の場合のみ**使用（でないと `[object Object]` 化 = `no-base-to-string`）
- 非 string の `result` は `JSON.stringify`、ただし `JSON.stringify(undefined)` 自体が `undefined` なので `"null"` にフォールバック（戻り値型 `string` を守る。従来は `any` のまま `undefined` を返しうる緩さがあった）

**③ plugin 応答（`as` 違反）**
```ts
- const result = ((await res.json()) ?? {}) as PluginResultEnvelope;
+ const rawResult: unknown = (await res.json()) ?? {};
+ const result: PluginResultEnvelope = isRecord(rawResult) ? rawResult : {};
```
`PluginResultEnvelope` は全フィールド optional + `[key: string]: unknown` なので `Record<string, unknown>` と互換で、`as` は不要でした。**挙動不変**（配列・オブジェクトは `raw` のまま、primitive は `{}` に落ちるが、後続の `result.data` アクセスはどちらも `undefined` で同じ結果）。

## 挙動変更点（明示）

①の異常系 throw と②の `undefined → "null"` フォールバックは、`any` が隠していた既存の緩さ/バグを型ガードで露出させ、最小限の明示的処理に置き換えたものです（不明瞭クラッシュ → 明示 throw、`undefined` 返し → `"null"`）。いずれも改善方向で、正常系は不変です。

## 検証

- `test/agent` の MCP テスト 14 件 pass
- `yarn typecheck` / `yarn build` / `yarn lint` すべて green

## シリーズ進捗

| 範囲 | 件数 | 状態 |
|---|---|---|
| #2253–2259 | 97 | merged（実バグ 2 件含む） |
| **本 PR** | 7 | — |

累計 **148 → 44**。残りは mattermost/zulip（挙動変更）と sonarjs function-return-type（Result イディオム、触らない方針）など。

## User Prompt

- 型関係のコードだけで直る・挙動を変えないものを優先（残りグループは挙動変更を明示しつつ続行、と合意）
- review にまわしつつ調査を並行、どんどん並列で進めて

## Summary by Sourcery

Strengthen typing and validation of MCP server JSON responses to eliminate unsafe casts and clarify error handling.

Bug Fixes:
- Validate /api/skills responses and fail with an explicit error when the payload shape is unexpected instead of crashing on malformed data.
- Ensure MCP tool responses always return a string by handling non-string error and result payloads safely and normalizing undefined results to "null".

Enhancements:
- Filter the skills list to only include entries with a valid string name before returning them from the MCP server.
- Replace an unsafe cast when reading plugin responses with a guarded conversion to PluginResultEnvelope to align with the actual JSON shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected or malformed skill-service responses.
  * Standardized tool responses, including clearer error messages for failed requests.
  * Improved reliability when processing plugin tool results that do not match the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->