### PR TITLE
docs(core): document /image concurrency cap + 429 recovery for custom views

### DIFF
--- a/packages/core/assets/helps/custom-view.md
+++ b/packages/core/assets/helps/custom-view.md
@@ -208,11 +208,42 @@ if (res.ok) {
 } // non-ok: leave the placeholder — 404 = not an image-field value / unresolvable
 ```
 
+**Never fire one fetch per image in parallel** (`Promise.all` over every
+record) — the host caps in-flight `/image` + `/query` requests at **4 per
+collection** and answers the rest **429**, so a first paint of a dozen
+images half-fails. Resolve through a small worker pool instead:
+
+```js
+// Throttled resolver: N paths, at most 3 in flight, one retry on 429.
+async function resolveImages(paths, onResolved, workers = 3) {
+  const queue = [...paths];
+  const work = async () => {
+    for (let path = queue.shift(); path !== undefined; path = queue.shift()) {
+      let res = await fetch(dataUrl + "/image?path=" + encodeURIComponent(path) + "&maxEdge=256", {
+        headers: { Authorization: "Bearer " + token },
+      });
+      if (res.status === 429) {
+        await new Promise((r) => setTimeout(r, 500));
+        res = await fetch(dataUrl + "/image?path=" + encodeURIComponent(path) + "&maxEdge=256", {
+          headers: { Authorization: "Bearer " + token },
+        });
+      }
+      if (res.ok) onResolved(path, (await res.json()).dataUrl);
+    }
+  };
+  await Promise.all(Array.from({ length: workers }, work));
+}
+```
+
 - **Only current image-field values resolve.** The host checks `path`
   against the collection's records: it must be the CURRENT value of a
   schema `image`-type field — the token cannot read arbitrary workspace
   files. A stale or hand-built path answers 404.
 - `maxEdge` clamps to 64–1024 (default 512) — request the size you render.
+- **429 = concurrency/rate limit, not a bad path.** Both a shared in-flight
+  cap (4 per collection, shared with `/query`) and a per-minute budget guard
+  this endpoint; a 429'd path resolves fine on retry — never mark it failed
+  without one.
 - Cache the resolved `data:` URLs per path in your view (a simple `Map`)
   and re-resolve inside your `onChange` callback only for paths you haven't
   seen — each request re-scans the records server-side.

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -463,3 +463,30 @@ Two ways the link can be minted, and the tool picks automatically:
 - **Drive shows nothing / "I can't find the user's file"** — not an error. The app holds the
   `drive.file` scope, so it can only ever see files IT created; the user's wider Drive is
   invisible by design. Say so plainly instead of implying an empty Drive.
+
+## Custom view — some images 429 / only a few thumbnails render
+
+### Symptoms
+
+- A collection's custom view renders records fine, but only a handful of its
+  `image`-type field thumbnails appear; the rest stay placeholders.
+- The view's error UI (or console) shows **HTTP 429** from
+  `<dataUrl>/image` with **"too many concurrent queries for this collection —
+  retry shortly"**.
+
+### Cause
+
+The view resolves every image at once — typically a `Promise.all` over all
+records firing one `GET <dataUrl>/image` each. The host caps in-flight
+`/image` + `/query` requests at **4 per collection** (each request re-scans
+the records for authorization), and answers the overflow 429. The paths are
+valid; only the burst is.
+
+### Fix
+
+Edit the view's image-resolution code (`views/*.html` under the collection's
+skill directory) to throttle: a small worker pool (≤ 3 concurrent) draining a
+queue of paths, with one short-delay retry on 429. See the throttled-resolver
+example in `custom-view.md` ("Displaying images"). Do NOT widen the server
+cap, switch to base64-embedding images in the HTML, or treat the 429'd paths
+as bad values.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -37,7 +37,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.3",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.15.0",
-    "@mulmoclaude/core": "^0.30.0",
+    "@mulmoclaude/core": "^0.30.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.3.4",
     "@mulmoclaude/html-plugin": "^0.2.5",


### PR DESCRIPTION
## Problem

The `token-eater-characters` gallery view showed placeholders for most portraits. The view followed `custom-view.md` ("Displaying images") to the letter — but resolved all 14 thumbnails with a single `Promise.all` against `GET <dataUrl>/image`. That endpoint shares a per-collection in-flight cap with `/query` (`VIEW_QUERY_MAX_CONCURRENT = 4`, each request re-scans records for authorization), so the burst got:

```
HTTP 429: {"error":"too many concurrent queries for this collection — retry shortly"}
```

Only 6/14 resolved; the view treated 429 as terminal and left the rest as placeholders. The help doc never mentioned the cap, so every agent-generated view walks into the same bug.

## Changes

- **`custom-view.md`** ("Displaying images"): warn never to fire one fetch per image in parallel, document the 4-per-collection cap, add a throttled worker-pool resolver example (3 workers, one short-delay retry on 429), and a bullet clarifying 429 = concurrency limit, not a bad path.
- **`error-recovery.md`**: new section "Custom view — some images 429 / only a few thumbnails render" mapping the exact symptom string to the throttling fix, so the agent repairs the view instead of asking the user.
- **`@mulmoclaude/core` 0.30.0 → 0.30.1** (`assets/helps/*` ships to npm) with the launcher dep range in lockstep; `yarn check:launcher-sync` passes.

Docs + version metadata only — no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document image endpoint concurrency limits and recovery for custom views, and bump the core package version to keep dependent launcher metadata in sync.

Documentation:
- Expand custom view image documentation to explain the 4-per-collection /image concurrency cap, recommend throttled resolution with retries on 429, and clarify that 429 indicates a concurrency limit rather than an invalid path.
- Add an error-recovery guide for custom views where only some thumbnails render, mapping 429 responses to the throttling-based fix so agents can repair views automatically.

Chores:
- Bump @mulmoclaude/core from 0.30.0 to 0.30.1 and update the MulmoClaude host dependency range accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified image-loading guidance to prevent request overload and handle rate limits with throttling and retries.
  * Added troubleshooting guidance for cases where only some thumbnails load or image requests return HTTP 429.
  * Clarified image sizing limits and explained that outdated image paths may return 404.

* **Chores**
  * Updated the core package to version 0.30.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->