### PR TITLE
chore(lint): type JSON payloads in mattermost/zulip bridges

### DIFF
--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -115,33 +115,50 @@ function connectWebSocket(): void {
   });
 }
 
+function isObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+interface PostedMessage {
+  userId: string;
+  channelId: string;
+  message: string;
+}
+
+// Parse a Mattermost `posted` WebSocket frame into the fields we act on. The
+// frame is untyped JSON with a stringified `post` payload nested inside;
+// returns null for anything that isn't a usable posted message.
+function parsePostedMessage(raw: string): PostedMessage | null {
+  const event: unknown = JSON.parse(raw);
+  if (!isObj(event) || event.event !== "posted" || !isObj(event.data) || typeof event.data.post !== "string" || !event.data.post) return null;
+  const post: unknown = JSON.parse(event.data.post);
+  if (!isObj(post)) return null;
+  return {
+    userId: typeof post.user_id === "string" ? post.user_id : "",
+    channelId: typeof post.channel_id === "string" ? post.channel_id : "",
+    message: typeof post.message === "string" ? post.message : "",
+  };
+}
+
 async function onWebSocketMessage(data: { toString: () => string }): Promise<void> {
   try {
-    const event: {
-      event?: string;
-      data?: { post?: string };
-    } = JSON.parse(data.toString());
-    if (event.event !== "posted" || !event.data?.post) return;
-
-    const post: {
-      user_id: string;
-      channel_id: string;
-      message: string;
-    } = JSON.parse(event.data.post);
+    const posted = parsePostedMessage(data.toString());
+    if (!posted) return;
+    const { userId, channelId, message } = posted;
 
     // Ignore own messages
-    if (post.user_id === botUserId) return;
-    if (!post.message.trim()) return;
-    if (!allowAll && !allowedChannels.has(post.channel_id)) return;
+    if (userId === botUserId) return;
+    if (!message.trim()) return;
+    if (!allowAll && !allowedChannels.has(channelId)) return;
 
-    console.log(`[mattermost] message channel=${post.channel_id} user=${post.user_id} len=${post.message.length}`);
+    console.log(`[mattermost] message channel=${channelId} user=${userId} len=${message.length}`);
 
-    const ack = await mulmo.send(post.channel_id, post.message);
+    const ack = await mulmo.send(channelId, message);
     if (ack.ok) {
-      await postMessage(post.channel_id, ack.reply ?? "");
+      await postMessage(channelId, ack.reply ?? "");
     } else {
       const status = ack.status ? ` (${ack.status})` : "";
-      await postMessage(post.channel_id, `Error${status}: ${ack.error ?? "unknown"}`);
+      await postMessage(channelId, `Error${status}: ${ack.error ?? "unknown"}`);
     }
   } catch (err) {
     console.error(`[mattermost] message handling failed: ${err}`);

--- a/packages/bridges/zulip/src/index.ts
+++ b/packages/bridges/zulip/src/index.ts
@@ -51,8 +51,8 @@ async function zulipPost(path: string, params: Record<string, string>): Promise<
     const text = await res.text().catch(() => "");
     throw new Error(`POST ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
-  const json: JsonRecord = await res.json();
-  return json;
+  const json: unknown = await res.json();
+  return isObj(json) ? json : {};
 }
 
 async function zulipGet(path: string, params?: Record<string, string>): Promise<JsonRecord> {
@@ -65,8 +65,8 @@ async function zulipGet(path: string, params?: Record<string, string>): Promise<
     const text = await res.text().catch(() => "");
     throw new Error(`GET ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
-  const json: JsonRecord = await res.json();
-  return json;
+  const json: unknown = await res.json();
+  return isObj(json) ? json : {};
 }
 
 async function sendMessage(chatId: string, text: string): Promise<void> {


### PR DESCRIPTION
## Summary

bridges 群の最後の `no-unsafe-*` 4 件（mattermost 2 + zulip 2）を消します。どちらも `JSON.parse` / `res.json()` の any 由来です。

## 修正

**zulip（挙動不変）**
```ts
- const json: JsonRecord = await res.json();
- return json;
+ const json: unknown = await res.json();
+ return isObj(json) ? json : {};
```
これは同じリポジトリの **rocketchat が既に使っているパターン**です。`zulipPost`/`zulipGet` の呼び出し側は `result.queue_id` / `result.events` 等を**すべて `typeof` / `isObj` / `Array.isArray` でガード**して読むので、`{}` を返しても挙動は不変です。

**mattermost（正常系不変・異常系はクラッシュ回避）**
`onWebSocketMessage` の `event` / `post` を `unknown` で受け、`isObj` で narrow。post のフィールド（`user_id`/`channel_id`/`message`）は rocketchat の `parseMessage` と同じ `typeof x === "string" ? x : ""` で読みます。パース + guard は複雑度が 15 を超えたため `parsePostedMessage` に抽出しました。

挙動: **正常系は不変**。異常系は改善 — 従来は `message` 欠如で `undefined.trim()` の TypeError でしたが、今は `""` 扱いで空メッセージとしてスキップします。

## 検証

`yarn typecheck` / `yarn build` / `yarn lint` すべて green。

## シリーズ完了

これで bridges 群の lint 掃除は完了です。

| PR | 内容 | 件数 | 状態 |
|---|---|---|---|
| #2253–2259 | .vue / irc / routes / sessions / relay / 3 bridges / matrix | 97 | merged |
| #2261 | mcp-server | 7 | LGTM |
| **本 PR** | mattermost / zulip | 4 | — |

累計 **148 → 40**。残る 40 は主に **sonarjs function-return-type（10件、Result イディオムなので触らない方針）** と散らばった小物です。ここで lint 掃除は一区切りとする想定です。

## User Prompt

- 型関係のコードだけで直る・挙動を変えないものを優先（残りは挙動変更を明示しつつ続行、と合意）
- review にまわしつつ調査を並行、どんどん並列で進めて


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mattermost message processing to safely handle malformed or unexpected WebSocket messages without disrupting valid message delivery.
  * Preserved existing filtering for bot messages, empty messages, and restricted channels.
  * Improved Zulip response handling when the server returns unexpected JSON formats.
  * Existing error handling, request behavior, and bridge replies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->