### PR TITLE
fix: Docker credential refresh — numeric expiresAt誤判定 + node-pty spawn-helperの+x欠落 (posix_spawnp)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "packages/services/*"
   ],
   "scripts": {
+    "postinstall": "node scripts/fix-node-pty-perms.mjs",
     "plugins:codegen": "tsx scripts/codegen-plugin-barrels.ts",
     "plugins:codegen:check": "tsx scripts/codegen-plugin-barrels.ts --check",
     "check:launcher-sync": "node scripts/mulmoclaude/launcherSync.mjs",

--- a/packages/mulmoclaude/bin/fix-node-pty-perms.mjs
+++ b/packages/mulmoclaude/bin/fix-node-pty-perms.mjs
@@ -54,4 +54,9 @@ function main() {
   }
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  // Best-effort: a permission fixer must never fail `npm install` / `yarn install`.
+  console.warn(`[fix-node-pty-perms] skipped: ${err}`);
+}

--- a/packages/mulmoclaude/bin/fix-node-pty-perms.mjs
+++ b/packages/mulmoclaude/bin/fix-node-pty-perms.mjs
@@ -1,0 +1,57 @@
+// Restore the executable bit on node-pty's `spawn-helper` prebuilt binary.
+//
+// node-pty ships `spawn-helper` mode 644 in its npm tarball, and neither npm
+// nor yarn adds the executable bit on install. On Unix node-pty must exec
+// `spawn-helper` before it can exec the target command, so without +x that exec
+// fails and node-pty throws `posix_spawnp failed` (surfaced here as the OAuth
+// token renewal for the Docker sandbox failing). Runs on `postinstall`;
+// idempotent, and a no-op when node-pty (an optional dependency) is absent or
+// ships no spawn-helper (Windows uses conpty). Self-contained because this
+// package is published to npm and cannot reach the monorepo's root script.
+
+import { createRequire } from "node:module";
+import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const EXEC_BITS = 0o111;
+
+function findNodePtyRoot() {
+  const require = createRequire(import.meta.url);
+  let dir;
+  try {
+    dir = dirname(require.resolve("node-pty"));
+  } catch {
+    return null; // node-pty not installed — nothing to fix
+  }
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, "prebuilds"))) return dir;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+function restoreExecBit(helper) {
+  const { mode } = statSync(helper);
+  const withExec = mode | EXEC_BITS;
+  if (withExec === mode) return false;
+  chmodSync(helper, withExec);
+  return true;
+}
+
+function main() {
+  const root = findNodePtyRoot();
+  if (!root) return;
+  const prebuilds = join(root, "prebuilds");
+  if (!existsSync(prebuilds)) return;
+
+  const fixed = readdirSync(prebuilds)
+    .map((platform) => join(prebuilds, platform, "spawn-helper"))
+    .filter((helper) => existsSync(helper))
+    .filter(restoreExecBit).length;
+
+  if (fixed > 0) {
+    console.log(`[fix-node-pty-perms] restored +x on ${fixed} node-pty spawn-helper binary(ies)`);
+  }
+}
+
+main();

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -7,6 +7,7 @@
     "mulmoclaude": "bin/mulmoclaude.js"
   },
   "scripts": {
+    "postinstall": "node bin/fix-node-pty-perms.mjs",
     "prepack": "node bin/prepare-dist.js",
     "typecheck": "echo \"mulmoclaude: no typecheck (launcher is plain JS; server and src are dist artifacts)\"",
     "test": "echo no tests yet"

--- a/plans/fix-docker-credential-refresh.md
+++ b/plans/fix-docker-credential-refresh.md
@@ -1,0 +1,57 @@
+# fix: Docker credential refresh — posix_spawnp failure (2-bug chain)
+
+Issue: receptron/mulmoclaude#2265
+
+## Symptom
+
+On `useDocker && darwin`, every agent run logs and fails:
+
+```
+[credentials] Access token expired (could not parse expiry), launching claude CLI to renew...
+[credentials] Failed to refresh credentials from Keychain error="Error: posix_spawnp failed."
+```
+
+`npx mulmoclaude@latest` (published 1.4.0) shows neither line; local dev (same "1.4.0" but 76 commits ahead) reproduces both.
+
+## Root causes (a chain — ① is the trigger, ② the dormant fault ① exposes)
+
+**① Code regression (`40fdb7d8`).** `readExpiresAt()` ended with
+`typeof oauth.expiresAt === "string" ? oauth.expiresAt : null`, but the macOS
+Keychain stores `claudeAiOauth.expiresAt` as a **number** (epoch ms). So it
+always returned `null` → `isTokenExpired()` always `true` → a valid token was
+treated as expired and a PTY renew fired on every run. Published 1.4.0 predates
+this and used `new Date(expiresAt)` (number-safe), so it never entered the renew
+path — which is why npx never hit ② either.
+
+**② Packaging.** The renew spawns `claude` through node-pty, which first execs
+`node_modules/node-pty/prebuilds/<platform>/spawn-helper`. node-pty's npm
+tarball ships that prebuilt binary mode **644** (verified: `npm pack
+node-pty@1.1.0`), and neither npm nor yarn adds the executable bit — so the exec
+fails EACCES and node-pty throws `posix_spawnp failed`. Reproduced with a
+harmless `echo` spawn; `chmod +x` fixes it. `npx mulmoclaude@latest` avoids the
+error only because it lacks bug ① and never enters the renew path — ① was the
+sole guard. (mulmoterminal already carries the same fix in
+`server/fix-pty-perms.js`; mulmoclaude was simply missing it.)
+
+## Fix
+
+- **①** `readExpiresAt` returns `number | null` (epoch ms), accepting both a
+  numeric and an ISO-string `expiresAt`. `isTokenExpired` + the two log sites
+  follow the numeric type; logs format via `new Date(ms).toISOString()`.
+  Exported for direct testing. Regression tests added in
+  `test/system/test_credentials.ts` (number / ISO / missing / bad-JSON / wrong
+  type).
+- **② (durable)** Restore `+x` on every `node-pty/prebuilds/*/spawn-helper` via
+  a `postinstall`, in two places:
+  - `scripts/fix-node-pty-perms.mjs` at the monorepo root (dev installs).
+  - `packages/mulmoclaude/bin/fix-node-pty-perms.mjs` in the published launcher
+    (a self-contained copy, since the package can't reach the root script), so
+    npm/npx users' renews succeed when their token genuinely expires.
+  Both are idempotent; no-op when node-pty is absent or ships no spawn-helper
+  (Windows). Self-heal across reinstalls.
+
+## Notes
+
+- `mulmoterminal` also depends on `node-pty ^1.1.0` and already fixes ② in
+  `server/fix-pty-perms.js`; its fix covers its own PTY but not the separate
+  node-pty of the mulmoclaude server it launches — cross-referenced in its repo.

--- a/scripts/fix-node-pty-perms.mjs
+++ b/scripts/fix-node-pty-perms.mjs
@@ -1,0 +1,55 @@
+// Restore the executable bit on node-pty's `spawn-helper` prebuilt binary.
+//
+// node-pty execs `spawn-helper` on Unix before it can exec the target
+// command; without +x that exec fails and node-pty throws
+// `posix_spawnp failed`. Yarn Classic (1.x) drops the executable bit when it
+// extracts prebuilt binaries from its cache, so a yarn-installed tree loses it
+// (npm preserves it). Runs on `postinstall`; idempotent and a no-op when
+// node-pty is absent or ships no spawn-helper (Windows uses conpty).
+
+import { createRequire } from "node:module";
+import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const EXEC_BITS = 0o111;
+
+function findNodePtyRoot() {
+  const require = createRequire(import.meta.url);
+  let dir;
+  try {
+    dir = dirname(require.resolve("node-pty"));
+  } catch {
+    return null; // node-pty not installed — nothing to fix
+  }
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, "prebuilds"))) return dir;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+function restoreExecBit(helper) {
+  const { mode } = statSync(helper);
+  const withExec = mode | EXEC_BITS;
+  if (withExec === mode) return false;
+  chmodSync(helper, withExec);
+  return true;
+}
+
+function main() {
+  const root = findNodePtyRoot();
+  if (!root) return;
+  const prebuilds = join(root, "prebuilds");
+  if (!existsSync(prebuilds)) return;
+
+  const fixed = readdirSync(prebuilds)
+    .map((platform) => join(prebuilds, platform, "spawn-helper"))
+    .filter((helper) => existsSync(helper))
+    .filter(restoreExecBit).length;
+
+  if (fixed > 0) {
+    console.log(`[fix-node-pty-perms] restored +x on ${fixed} node-pty spawn-helper binary(ies)`);
+  }
+}
+
+main();

--- a/scripts/fix-node-pty-perms.mjs
+++ b/scripts/fix-node-pty-perms.mjs
@@ -52,4 +52,9 @@ function main() {
   }
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  // Best-effort: a permission fixer must never fail `yarn install`.
+  console.warn(`[fix-node-pty-perms] skipped: ${err}`);
+}

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -46,18 +46,14 @@ async function readFromKeychain(): Promise<string | null> {
   }
 }
 
-/**
- * Check whether the access token in the credentials JSON is expired.
- */
-/** The token's expiry as written in the Keychain blob, or null when the JSON is
- *  unparseable or simply doesn't carry one.
+/** The token's expiry as epoch milliseconds, or null when the JSON is
+ *  unparseable or carries no usable expiry.
  *
- *  `JSON.parse` returns `any`, so the previous `CredentialsJson` annotation on
- *  its result was a claim rather than a check — nothing verified the shape, and
- *  every read through it was unchecked. Narrowing once here gives the three
- *  callers a `string | null` they can trust, and keeps the parse in one place.
- *  (The interface itself is gone: it described a shape nobody validated.) */
-function readExpiresAt(raw: string): string | null {
+ *  Claude's Keychain blob stores `expiresAt` as a number (epoch ms); older CLI
+ *  builds wrote an ISO string. Accept both. A prior `typeof === "string"` guard
+ *  silently rejected the numeric form, so every token read as "no expiry →
+ *  expired" and forced a PTY renew of the CLI on every Docker run. */
+export function readExpiresAt(raw: string): number | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -67,22 +63,19 @@ function readExpiresAt(raw: string): string | null {
   if (!isRecord(parsed)) return null;
   const oauth = parsed.claudeAiOauth;
   if (!isRecord(oauth)) return null;
-  return typeof oauth.expiresAt === "string" ? oauth.expiresAt : null;
+  const { expiresAt } = oauth;
+  if (typeof expiresAt === "number") return Number.isFinite(expiresAt) ? expiresAt : null;
+  if (typeof expiresAt === "string") {
+    const parsedMs = Date.parse(expiresAt);
+    return Number.isNaN(parsedMs) ? null : parsedMs;
+  }
+  return null;
 }
 
 function isTokenExpired(raw: string): boolean {
-  try {
-    const expiresAt = readExpiresAt(raw);
-    if (!expiresAt) return true; // no expiry info — treat as expired
-
-    const expiresMs = new Date(expiresAt).getTime();
-    if (isNaN(expiresMs)) return true;
-
-    return Date.now() >= expiresMs - EXPIRY_MARGIN_MS;
-  } catch {
-    log.error("credentials", "Failed to parse credentials JSON from Keychain");
-    return true;
-  }
+  const expiresMs = readExpiresAt(raw);
+  if (expiresMs === null) return true; // no usable expiry — treat as expired
+  return Date.now() >= expiresMs - EXPIRY_MARGIN_MS;
 }
 
 /**
@@ -199,12 +192,11 @@ export async function refreshCredentials(): Promise<boolean> {
     }
 
     if (isTokenExpired(credentials)) {
-      // Extract expiry for logging
-      const expiredAt = readExpiresAt(credentials);
+      const expiresMs = readExpiresAt(credentials);
       log.warn(
         "credentials",
-        expiredAt
-          ? `Access token expired at ${expiredAt}, launching claude CLI to renew...`
+        expiresMs !== null
+          ? `Access token expired at ${new Date(expiresMs).toISOString()}, launching claude CLI to renew...`
           : "Access token expired (could not parse expiry), launching claude CLI to renew...",
       );
 
@@ -230,8 +222,8 @@ export async function refreshCredentials(): Promise<boolean> {
         return false;
       }
     } else {
-      const validUntil = readExpiresAt(credentials);
-      log.info("credentials", validUntil ? `Access token is valid, expires at ${validUntil}` : "Access token appears valid");
+      const expiresMs = readExpiresAt(credentials);
+      log.info("credentials", expiresMs !== null ? `Access token is valid, expires at ${new Date(expiresMs).toISOString()}` : "Access token appears valid");
     }
 
     // Atomic so a readers mid-refresh can't see a truncated creds

--- a/test/system/test_credentials.ts
+++ b/test/system/test_credentials.ts
@@ -1,12 +1,13 @@
-// Tests for the pure response-detection predicate of
-// `server/system/credentials.ts`. `looksLikeClaudeResponse` decides
-// whether PTY output looks like a real Claude reply (conversational
-// opener AND >= 20 chars) versus an error chunk that should time out.
+// Tests for the pure helpers of `server/system/credentials.ts`.
+// `looksLikeClaudeResponse` decides whether PTY output looks like a real Claude
+// reply (conversational opener AND >= 20 chars) versus an error chunk that
+// should time out. `readExpiresAt` narrows the Keychain blob to the token's
+// expiry in epoch ms.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { looksLikeClaudeResponse } from "../../server/system/credentials.js";
+import { looksLikeClaudeResponse, readExpiresAt } from "../../server/system/credentials.js";
 
 describe("looksLikeClaudeResponse", () => {
   it("returns true for a conversational opener with enough text", () => {
@@ -51,5 +52,45 @@ describe("looksLikeClaudeResponse", () => {
 
   it("returns false for an empty string", () => {
     assert.equal(looksLikeClaudeResponse(""), false);
+  });
+});
+
+describe("readExpiresAt", () => {
+  const wrap = (expiresAt: unknown) => JSON.stringify({ claudeAiOauth: { expiresAt } });
+
+  it("returns the epoch-ms number when expiresAt is a number (the Keychain's real shape)", () => {
+    // Regression: a `typeof === "string"` guard used to reject this, so a valid
+    // token read as "no expiry → expired" and forced a renew on every run.
+    assert.equal(readExpiresAt(wrap(1784602611420)), 1784602611420);
+  });
+
+  it("parses an ISO-8601 string expiresAt to epoch ms (legacy CLI shape)", () => {
+    const iso = "2026-07-21T03:00:00.000Z";
+    assert.equal(readExpiresAt(wrap(iso)), Date.parse(iso));
+  });
+
+  it("returns null when claudeAiOauth is absent", () => {
+    assert.equal(readExpiresAt(JSON.stringify({ other: 1 })), null);
+  });
+
+  it("returns null when expiresAt is absent", () => {
+    assert.equal(readExpiresAt(JSON.stringify({ claudeAiOauth: {} })), null);
+  });
+
+  it("returns null for a non-numeric, non-date string expiresAt", () => {
+    assert.equal(readExpiresAt(wrap("not-a-date")), null);
+  });
+
+  it("returns null for a boolean expiresAt", () => {
+    assert.equal(readExpiresAt(wrap(true)), null);
+  });
+
+  it("returns null for invalid JSON", () => {
+    assert.equal(readExpiresAt("{not json"), null);
+  });
+
+  it("returns null for a non-object top-level value", () => {
+    assert.equal(readExpiresAt("42"), null);
+    assert.equal(readExpiresAt("null"), null);
   });
 });


### PR DESCRIPTION
## Summary

Docker サンドボックス利用時（`useDocker && darwin`）、エージェント実行のたびに OAuth トークン更新 `refreshCredentials()` が走り、次の2行で失敗していた:

```
[credentials] Access token expired (could not parse expiry), launching claude CLI to renew...
[credentials] Failed to refresh credentials from Keychain error="Error: posix_spawnp failed."
```

**2つのバグの連鎖**が原因（①が引き金、②が①によって初めて顕在化する潜在不発弾）:

- **① コード regression（`40fdb7d8`）**: `readExpiresAt` が `typeof expiresAt === "string"` で絞り込んでいたが、macOS Keychain の `claudeAiOauth.expiresAt` は実際には **number（epoch ms）**。常に `null` を返し、有効なトークンでも「期限切れ」と誤判定 → 毎回 renew を起動していた。→ `number | null`（epoch ms）を返し、number と ISO 文字列の両方を受理するよう修正。
- **② パッケージング**: node-pty は prebuilt の `spawn-helper` を **mode 644 で出荷**（`npm pack node-pty@1.1.0` で確認）。npm も yarn も +x を付けず、node-pty は目的コマンドの前に `spawn-helper` を exec するため EACCES で `posix_spawnp failed`。→ `node-pty/prebuilds/*/spawn-helper` に +x を復元する postinstall を **root（開発）と launcher（公開）** の両方に追加。

`npx mulmoclaude@latest`（公開1.4.0）で出ないのは「+x が保持されるから」ではなく、**①が無く renew 経路に入らないから**（①が唯一の防波堤だった）。トークンが本当に期限切れになれば npx でも②に当たるため、launcher にも恒久対策を入れている。

Closes #2265

## Items to Confirm / Review

- `readExpiresAt` の戻り値を `string → number | null`（epoch ms）に変更。`isTokenExpired` とログ2箇所（ISO 整形）を追従。数値文字列（`"1784..."`）は非対応（実データは number なので十分）。
- 恒久対策の postinstall スクリプトが root と launcher で**重複**している。公開パッケージ（`packages/mulmoclaude`）は monorepo root のスクリプトを参照できないため自己完結コピーが不可避（`mulmoterminal` の `server/fix-pty-perms.js` も同型）。
- launcher の `node-pty` は **optionalDependency**。未インストール/Windows（conpty）では postinstall は no-op（`require.resolve` 失敗で早期 return）。
- `pty.spawn(...)` は `awaitTokenRenewal` の Promise executor 内で try/catch 外。今回は②を根本から解消したが、将来のため spawn を try/catch で包む堅牢化は別途検討余地あり（今回スコープ外）。

## User Prompt

- Docker サンドボックス利用時に出る `posix_spawnp failed`（と `could not parse expiry`）のバグを最優先で調査してほしい。
- 直近24時間の変更が原因か、公開 1.4.0 との差分の観点でも調べてほしい（`npx mulmoclaude@latest` では出ないが、ローカル開発ビルドでは出る）。
- Docker 利用時の話なので Docker 側のコードも見てほしい。
- まず issue 化してこの報告を書き、ブランチを作って**恒久対策**で修正し、`mulmoterminal` の issue にもクロス報告してほしい。

（発端は `shopping-list` collection の schema 検証エラーだったが、それはユーザーデータの問題として `shopping-list` 削除で対応済み。本 PR は posix_spawnp 側のバグ修正。）

## 実装詳細

**バグ① — `server/system/credentials.ts`**
- `readExpiresAt(raw): number | null` に変更。number はそのまま（`Number.isFinite` チェック）、string は `Date.parse`（ISO 対応）。export してテスト可能化。
- `isTokenExpired` は `readExpiresAt(raw) === null ? true : Date.now() >= ms - EXPIRY_MARGIN_MS` に簡潔化（不要な try/catch と `new Date().getTime()` 経路を削除）。
- ログ2箇所は `new Date(ms).toISOString()` で整形。
- `test/system/test_credentials.ts` に回帰テスト追加（number / ISO文字列 / claudeAiOauth欠落 / expiresAt欠落 / 非日付文字列 / boolean / 不正JSON / 非オブジェクト）。

**バグ②（恒久対策）**
- `scripts/fix-node-pty-perms.mjs`（root）+ root `package.json` の `postinstall`。
- `packages/mulmoclaude/bin/fix-node-pty-perms.mjs`（launcher、自己完結）+ launcher `package.json` の `postinstall`。`bin/` は既に `files` に含まれ公開される。
- どちらも idempotent。`require.resolve("node-pty")` から prebuilds を辿り hoist にも対応。

## テスト / ゲート

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`（`test_credentials.ts` 18件）すべて緑。
- 再現→修正検証: node-pty で無害な `echo` を spawn → 修正前 `Error: posix_spawnp failed.` / `chmod +x`（＝postinstall スクリプト）後 `SPAWN OK`。postinstall スクリプトは「+x剥がす→実行→復元→再実行で冪等」を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential expiry detection for both numeric timestamps and ISO-formatted dates.
  * Prevented unnecessary credential renewals caused by incorrectly parsed expiration values.
  * Restored executable permissions for required terminal helper binaries after installation, preventing credential refresh failures on supported systems.
* **Tests**
  * Added coverage for valid, missing, malformed, and incorrectly formatted credential expiration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->