### PR TITLE
fix: node-pty spawn の posix_spawnp をランタイムでも防ぐ（--ignore-scripts 対策の backstop + 自己修復テスト）

### DIFF
--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -1,5 +1,8 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { chmodSync, existsSync, readdirSync, statSync } from "fs";
+import { createRequire } from "module";
+import { dirname, join } from "path";
 import { log } from "./logger/index.js";
 import { isRecord } from "../utils/types.js";
 import { ONE_SECOND_MS, ONE_MINUTE_MS } from "../utils/time.js";
@@ -7,6 +10,8 @@ import { writeFileAtomic } from "../utils/files/atomic.js";
 import { claudeCredentialsPath } from "../utils/claudeConfigPath.js";
 
 const execFileAsync = promisify(execFile);
+
+const SPAWN_HELPER_EXEC_BITS = 0o111;
 
 const CREDENTIALS_PATH = claudeCredentialsPath();
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
@@ -157,6 +162,40 @@ function awaitTokenRenewal(pty: typeof import("node-pty")): Promise<boolean> {
   });
 }
 
+/** node-pty's prebuilds directory, resolved from wherever it's installed
+ *  (hoisted or nested), or null when node-pty can't be found. */
+function nodePtyPrebuildsDir(): string | null {
+  const require = createRequire(import.meta.url);
+  let dir = dirname(require.resolve("node-pty"));
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, "prebuilds"))) return join(dir, "prebuilds");
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+/** Runtime backstop for `posix_spawnp failed`. node-pty execs its prebuilt
+ *  `spawn-helper` before the target command, but ships it mode 644 in the npm
+ *  tarball; an install that skipped lifecycle scripts (`--ignore-scripts`,
+ *  some `npm ci` setups) leaves it non-executable and every spawn throws. The
+ *  postinstall normally restores +x — this covers installs that never ran it,
+ *  so it also protects end users who never run the test suite. Best-effort:
+ *  any failure is swallowed and we still attempt the spawn. */
+export function ensureSpawnHelperExecutable(): void {
+  try {
+    const prebuilds = nodePtyPrebuildsDir();
+    if (!prebuilds || !existsSync(prebuilds)) return;
+    for (const platform of readdirSync(prebuilds)) {
+      const helper = join(prebuilds, platform, "spawn-helper");
+      if (!existsSync(helper)) continue;
+      const { mode } = statSync(helper);
+      if ((mode | SPAWN_HELPER_EXEC_BITS) !== mode) chmodSync(helper, mode | SPAWN_HELPER_EXEC_BITS);
+    }
+  } catch {
+    // best-effort — fall through to the spawn attempt regardless
+  }
+}
+
 async function renewTokenViaPty(): Promise<boolean> {
   // Dynamic import — node-pty is a native module that may not be present
   // on all platforms. Guard with try/catch.
@@ -168,6 +207,7 @@ async function renewTokenViaPty(): Promise<boolean> {
     return false;
   }
 
+  ensureSpawnHelperExecutable();
   return awaitTokenRenewal(pty);
 }
 

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -165,13 +165,31 @@ function awaitTokenRenewal(pty: typeof import("node-pty")): Promise<boolean> {
 /** node-pty's prebuilds directory, resolved from wherever it's installed
  *  (hoisted or nested), or null when node-pty can't be found. */
 export function nodePtyPrebuildsDir(): string | null {
-  const require = createRequire(import.meta.url);
-  let dir = dirname(require.resolve("node-pty"));
-  while (dir !== dirname(dir)) {
-    if (existsSync(join(dir, "prebuilds"))) return join(dir, "prebuilds");
-    dir = dirname(dir);
+  try {
+    const require = createRequire(import.meta.url);
+    let dir = dirname(require.resolve("node-pty"));
+    while (dir !== dirname(dir)) {
+      if (existsSync(join(dir, "prebuilds"))) return join(dir, "prebuilds");
+      dir = dirname(dir);
+    }
+  } catch {
+    // node-pty not resolvable — nothing to fix
   }
   return null;
+}
+
+/** Restore +x on one prebuild's `spawn-helper`, if it's a regular file that
+ *  lacks it. Errors are per-entry so one bad platform bundle can't abort the
+ *  repair of the others. */
+function restoreSpawnHelperExec(helper: string): void {
+  try {
+    if (!existsSync(helper)) return;
+    const info = statSync(helper);
+    if (!info.isFile()) return;
+    if ((info.mode | SPAWN_HELPER_EXEC_BITS) !== info.mode) chmodSync(helper, info.mode | SPAWN_HELPER_EXEC_BITS);
+  } catch {
+    // best-effort — skip this entry, keep repairing the rest
+  }
 }
 
 /** Runtime backstop for `posix_spawnp failed`. node-pty execs its prebuilt
@@ -182,19 +200,15 @@ export function nodePtyPrebuildsDir(): string | null {
  *  so it also protects end users who never run the test suite. Best-effort:
  *  any failure is swallowed and we still attempt the spawn. */
 export function ensureSpawnHelperExecutable(): void {
+  const prebuilds = nodePtyPrebuildsDir();
+  if (prebuilds === null) return;
+  let platforms: string[];
   try {
-    const prebuilds = nodePtyPrebuildsDir();
-    if (!prebuilds || !existsSync(prebuilds)) return;
-    for (const platform of readdirSync(prebuilds)) {
-      const helper = join(prebuilds, platform, "spawn-helper");
-      if (!existsSync(helper)) continue;
-      const info = statSync(helper);
-      if (!info.isFile()) continue;
-      if ((info.mode | SPAWN_HELPER_EXEC_BITS) !== info.mode) chmodSync(helper, info.mode | SPAWN_HELPER_EXEC_BITS);
-    }
+    platforms = readdirSync(prebuilds);
   } catch {
-    // best-effort — fall through to the spawn attempt regardless
+    return;
   }
+  for (const platform of platforms) restoreSpawnHelperExec(join(prebuilds, platform, "spawn-helper"));
 }
 
 async function renewTokenViaPty(): Promise<boolean> {

--- a/server/system/credentials.ts
+++ b/server/system/credentials.ts
@@ -164,7 +164,7 @@ function awaitTokenRenewal(pty: typeof import("node-pty")): Promise<boolean> {
 
 /** node-pty's prebuilds directory, resolved from wherever it's installed
  *  (hoisted or nested), or null when node-pty can't be found. */
-function nodePtyPrebuildsDir(): string | null {
+export function nodePtyPrebuildsDir(): string | null {
   const require = createRequire(import.meta.url);
   let dir = dirname(require.resolve("node-pty"));
   while (dir !== dirname(dir)) {
@@ -188,8 +188,9 @@ export function ensureSpawnHelperExecutable(): void {
     for (const platform of readdirSync(prebuilds)) {
       const helper = join(prebuilds, platform, "spawn-helper");
       if (!existsSync(helper)) continue;
-      const { mode } = statSync(helper);
-      if ((mode | SPAWN_HELPER_EXEC_BITS) !== mode) chmodSync(helper, mode | SPAWN_HELPER_EXEC_BITS);
+      const info = statSync(helper);
+      if (!info.isFile()) continue;
+      if ((info.mode | SPAWN_HELPER_EXEC_BITS) !== info.mode) chmodSync(helper, info.mode | SPAWN_HELPER_EXEC_BITS);
     }
   } catch {
     // best-effort — fall through to the spawn attempt regardless

--- a/test/system/test_pty_spawn.ts
+++ b/test/system/test_pty_spawn.ts
@@ -1,0 +1,73 @@
+// Regression guard for `posix_spawnp failed`. node-pty execs its prebuilt
+// `spawn-helper` before the target command, and that binary ships mode 644 in
+// node-pty's npm tarball. This reproduces the broken end-user state — strip the
+// executable bit as an `--ignore-scripts` install would leave it — then asserts
+// the runtime guard restores it AND a real node-pty spawn succeeds instead of
+// throwing. Skipped on Windows, where node-pty uses conpty and there is no
+// spawn-helper.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+import { spawn, type IPty } from "node-pty";
+
+import { ensureSpawnHelperExecutable } from "../../server/system/credentials.js";
+
+const EXEC_BITS = 0o111;
+const PTY_TIMEOUT_MS = 10_000;
+const MARKER = "pty-spawn-ok";
+
+function spawnHelperPaths(): string[] {
+  const require = createRequire(import.meta.url);
+  let dir = dirname(require.resolve("node-pty"));
+  while (dir !== dirname(dir) && !existsSync(join(dir, "prebuilds"))) dir = dirname(dir);
+  const prebuilds = join(dir, "prebuilds");
+  if (!existsSync(prebuilds)) return [];
+  return readdirSync(prebuilds)
+    .map((platform) => join(prebuilds, platform, "spawn-helper"))
+    .filter((helper) => existsSync(helper));
+}
+
+function spawnMarker(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let proc: IPty;
+    try {
+      proc = spawn("node", ["-e", `process.stdout.write("${MARKER}")`], { name: "xterm-color", cols: 80, rows: 30, cwd: process.cwd() });
+    } catch (err) {
+      // A non-executable spawn-helper surfaces here as "posix_spawnp failed".
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    let buffer = "";
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`node-pty spawn timed out after ${PTY_TIMEOUT_MS}ms`));
+    }, PTY_TIMEOUT_MS);
+    proc.onData((data) => {
+      buffer += data;
+    });
+    proc.onExit(() => {
+      clearTimeout(timer);
+      resolve(buffer);
+    });
+  });
+}
+
+describe("ensureSpawnHelperExecutable", () => {
+  it("restores +x on a non-executable spawn-helper and lets node-pty spawn", { skip: process.platform === "win32" }, async () => {
+    const helpers = spawnHelperPaths();
+    assert.ok(helpers.length > 0, "expected at least one node-pty spawn-helper prebuild");
+
+    for (const helper of helpers) chmodSync(helper, statSync(helper).mode & ~EXEC_BITS);
+    ensureSpawnHelperExecutable();
+    for (const helper of helpers) {
+      assert.ok((statSync(helper).mode & EXEC_BITS) !== 0, `guard should have restored +x on ${helper}`);
+    }
+
+    const output = await spawnMarker();
+    assert.ok(output.includes(MARKER), `expected PTY output to include "${MARKER}", got: ${JSON.stringify(output)}`);
+  });
+});

--- a/test/system/test_pty_spawn.ts
+++ b/test/system/test_pty_spawn.ts
@@ -9,23 +9,19 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import { spawn, type IPty } from "node-pty";
 
-import { ensureSpawnHelperExecutable } from "../../server/system/credentials.js";
+import { ensureSpawnHelperExecutable, nodePtyPrebuildsDir } from "../../server/system/credentials.js";
 
 const EXEC_BITS = 0o111;
 const PTY_TIMEOUT_MS = 10_000;
 const MARKER = "pty-spawn-ok";
 
 function spawnHelperPaths(): string[] {
-  const require = createRequire(import.meta.url);
-  let dir = dirname(require.resolve("node-pty"));
-  while (dir !== dirname(dir) && !existsSync(join(dir, "prebuilds"))) dir = dirname(dir);
-  const prebuilds = join(dir, "prebuilds");
-  if (!existsSync(prebuilds)) return [];
+  const prebuilds = nodePtyPrebuildsDir();
+  if (prebuilds === null) return [];
   return readdirSync(prebuilds)
     .map((platform) => join(prebuilds, platform, "spawn-helper"))
     .filter((helper) => existsSync(helper));


### PR DESCRIPTION
## Summary

Follow-up to #2266. That PR fixed `posix_spawnp failed` two ways: a code fix for the numeric-`expiresAt` regression, and a **postinstall** that restores `+x` on node-pty's `spawn-helper` (node-pty ships it mode 644 in its tarball).

The postinstall only runs when lifecycle scripts run. An **end user** who installs with `--ignore-scripts` (or a `npm ci` setup that skips scripts) still gets a non-executable `spawn-helper` and hits `posix_spawnp failed` on the Docker OAuth renew. A CI regression test would only protect *us* (developers running the suite), not them.

This PR adds a **runtime backstop**: right before the PTY spawn we best-effort `chmod +x` the `spawn-helper`, so **every install path is covered regardless of whether scripts ran**.

```ts
// renewTokenViaPty(), before awaiting the spawn:
ensureSpawnHelperExecutable();   // resolve node-pty's prebuilds, restore +x, swallow errors
return awaitTokenRenewal(pty);
```

node-pty is spawned only in this renew path, so guarding right before the spawn is equivalent to a startup check but without wasted work when Docker isn't used.

Related: #2265.

## Items to Confirm / Review

- **Runtime chmod of a dependency file** (`node_modules/node-pty/prebuilds/*/spawn-helper`): best-effort — any error (EPERM, read-only FS) is swallowed and the spawn is still attempted, so it can never make things worse than today.
- **The postinstall from #2266 is kept** as the first line (fixes it once at install); this runtime guard is the backstop for installs that skipped scripts. Confirm we want both rather than dropping the now-partly-redundant postinstall.
- **Placement**: called in `renewTokenViaPty` before the spawn (node-pty's only spawn site), not at server boot — same protection, no cost when the renew never runs.
- **Resolution duplication**: `nodePtyPrebuildsDir()` re-derives node-pty's prebuilds like the postinstall scripts do. The scripts run at install time (standalone `.mjs`, the launcher's is self-contained for npm), so runtime and install-time contexts can't share one module — inherent.

## User Prompt

- （#2266 マージ後）「CIの回帰テストを追加」する話だったが、**一般ユーザーはテストを走らせない**。npx/npm でインストールした人（`--ignore-scripts` 等で postinstall を踏まない）はテストでは守れない。
- **起動時(ランタイム)に確認する方が良いのでは？**
- → 方針A: `credentials.ts` に spawn 直前のランタイムガードを追加し、テストは「単に spawn できる」ではなく「+x を剥がしてもガードが自己修復して spawn 成功する」検証に作り替える。

## 実装詳細

- `server/system/credentials.ts`:
  - `nodePtyPrebuildsDir()` — node-pty のインストール場所（hoist/nested 両対応）から `prebuilds/` を解決。
  - `ensureSpawnHelperExecutable()`（export）— `prebuilds/*/spawn-helper` が非実行なら `+x` を復元。全て try/catch で best-effort。
  - `renewTokenViaPty()` の `pty.spawn` 前で呼ぶ。
- `test/system/test_pty_spawn.ts`（新規）:
  - spawn-helper の `+x` を剥がして `--ignore-scripts` 相当の壊れた状態を再現 → `ensureSpawnHelperExecutable()` → `+x` 復元を assert → 実際に `node-pty` で `node -e` を spawn し出力を assert。
  - Windows（conpty・spawn-helper なし）は skip。

## テスト / ゲート

- `yarn format` / `yarn lint` / `yarn typecheck`（exit 0）/ `yarn build`（exit 0）/ `yarn test`（exit 0、system 19 テスト）すべて緑。
- 新テスト単体: 壊れた状態から自己修復して `pty-spawn-ok` を受信して PASS（513ms）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS credential refresh reliability by automatically restoring execute permissions for the bundled terminal helper when they’re missing after certain installations.
  * Prevented token renewal failures caused by non-executable helper binaries.

* **Tests**
  * Added a regression test that simulates non-executable helper permissions, verifies they’re corrected, and confirms PTY-based sessions still start successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->