### PR TITLE
refactor(common): route bridges + relay isObj through @mulmoclaude/common isRecord (Phase 2)

### DIFF
--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/bluesky/src/index.ts
+++ b/packages/bridges/bluesky/src/index.ts
@@ -19,6 +19,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "bluesky";
 const MAX_DM_LEN = 10_000;
@@ -60,10 +61,6 @@ let session: Session | null = null;
 
 type JsonRecord = Record<string, unknown>;
 
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
-
 function asString(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
@@ -80,7 +77,7 @@ async function createSession(): Promise<Session> {
     throw new Error(`createSession failed: ${res.status} ${text.slice(0, 200)}`);
   }
   const body: unknown = await res.json();
-  if (!isObj(body)) throw new Error("createSession: non-object response");
+  if (!isRecord(body)) throw new Error("createSession: non-object response");
   const did = asString(body.did);
   const accessJwt = asString(body.accessJwt);
   const refreshJwt = asString(body.refreshJwt);
@@ -96,7 +93,7 @@ async function refreshSession(current: Session): Promise<Session> {
   });
   if (!res.ok) throw new Error(`refreshSession failed: ${res.status}`);
   const body: unknown = await res.json();
-  if (!isObj(body)) throw new Error("refreshSession: non-object response");
+  if (!isRecord(body)) throw new Error("refreshSession: non-object response");
   return {
     did: asString(body.did) || current.did,
     accessJwt: asString(body.accessJwt),
@@ -143,7 +140,7 @@ async function parseChatResponse(res: Response, method: string, path: string): P
     throw new Error(`${method} ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
   const json: unknown = await res.json();
-  return isObj(json) ? json : {};
+  return isRecord(json) ? json : {};
 }
 
 async function chatRequest(method: "GET" | "POST", path: string, body?: JsonRecord, query?: Record<string, string>): Promise<JsonRecord> {
@@ -180,10 +177,10 @@ function parseMessageLog(log: JsonRecord, selfDid: string): IncomingMessage | nu
   if (log.$type !== "chat.bsky.convo.defs#logCreateMessage") return null;
   const convoId = asString(log.convoId);
   const { message } = log;
-  if (!isObj(message)) return null;
+  if (!isRecord(message)) return null;
   const text = asString(message.text);
   if (!text) return null;
-  const sender = isObj(message.sender) ? message.sender : null;
+  const sender = isRecord(message.sender) ? message.sender : null;
   const senderDid = sender ? asString(sender.did) : "";
   if (!convoId || !senderDid) return null;
   if (senderDid === selfDid) return null; // ignore our own
@@ -213,7 +210,7 @@ async function handleMessage(msg: IncomingMessage): Promise<void> {
 
 async function processLogEntries(logs: unknown[], selfDid: string): Promise<void> {
   for (const entry of logs) {
-    if (!isObj(entry)) continue;
+    if (!isRecord(entry)) continue;
     const parsed = parseMessageLog(entry, selfDid);
     if (parsed) await handleMessage(parsed);
   }

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/chatwork/src/index.ts
+++ b/packages/bridges/chatwork/src/index.ts
@@ -25,6 +25,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "chatwork";
 const API_BASE = "https://api.chatwork.com/v2";
@@ -60,10 +61,6 @@ mulmo.onPush((pushEvent) => {
 // ── Chatwork REST helpers ───────────────────────────────────────
 
 type JsonRecord = Record<string, unknown>;
-
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
 
 // Shared 429 backoff — any 429 response pauses all subsequent
 // requests until `retryAfter`. Keeps multiple concurrent callers
@@ -129,7 +126,7 @@ async function cwFetch(method: "GET" | "POST" | "PUT", path: string, form?: Reco
 
 async function getBotAccountId(): Promise<number> {
   const profile = await cwFetch("GET", "/me");
-  if (!isObj(profile) || typeof profile.account_id !== "number") {
+  if (!isRecord(profile) || typeof profile.account_id !== "number") {
     throw new Error("/me returned unexpected shape");
   }
   return profile.account_id;
@@ -155,7 +152,7 @@ async function getRoomIds(): Promise<string[]> {
   if (!Array.isArray(rooms)) {
     return roomsCache?.ids ?? [];
   }
-  const ids = rooms.filter((room): room is JsonRecord => isObj(room) && typeof room.room_id === "number").map((room) => String(room.room_id));
+  const ids = rooms.filter((room): room is JsonRecord => isRecord(room) && typeof room.room_id === "number").map((room) => String(room.room_id));
   roomsCache = { ids, fetchedAt: now };
   return ids;
 }
@@ -181,10 +178,10 @@ interface ParsedMessage {
 }
 
 function parseMessage(raw: unknown): ParsedMessage | null {
-  if (!isObj(raw)) return null;
+  if (!isRecord(raw)) return null;
   const messageId = typeof raw.message_id === "string" ? raw.message_id : "";
   const body = typeof raw.body === "string" ? raw.body : "";
-  const account = isObj(raw.account) ? raw.account : null;
+  const account = isRecord(raw.account) ? raw.account : null;
   if (!messageId || !body || !account) return null;
   const accountId = typeof account.account_id === "number" ? account.account_id : -1;
   const accountName = typeof account.name === "string" ? account.name : "unknown";

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -24,6 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -20,6 +20,7 @@ import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { configureTrustProxy, createWebhookRateLimit } from "@mulmobridge/webhook-runtime";
 import { createBridgeClient } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "google-chat";
 const PORT = Number(process.env.GOOGLE_CHAT_BRIDGE_PORT) || 3005;
@@ -37,10 +38,6 @@ mulmo.onPush((pushEvent) => {
   // available in synchronous webhook mode. Log for now.
   console.log(`[google-chat] push (not delivered): ${pushEvent.chatId} ${pushEvent.message}`);
 });
-
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 // ── JWT verification (Google Chat OIDC) ────────────────────────
 //
@@ -76,10 +73,10 @@ async function fetchJwks(): Promise<JwkKey[]> {
       throw new Error(`JWKS fetch failed: ${res.status}`);
     }
     const data: unknown = await res.json();
-    if (!isObj(data) || !Array.isArray(data.keys)) throw new Error("Invalid JWKS response");
+    if (!isRecord(data) || !Array.isArray(data.keys)) throw new Error("Invalid JWKS response");
     cachedKeys = data.keys.filter(
       (keyCandidate): keyCandidate is JwkKey =>
-        isObj(keyCandidate) && typeof keyCandidate.kid === "string" && typeof keyCandidate.n === "string" && typeof keyCandidate.e === "string",
+        isRecord(keyCandidate) && typeof keyCandidate.kid === "string" && typeof keyCandidate.n === "string" && typeof keyCandidate.e === "string",
     );
     cacheExpiresAt = Date.now() + JWKS_CACHE_TTL_MS;
     return cachedKeys;
@@ -107,7 +104,7 @@ function parseJwtParts(token: string): JwtParts | null {
   try {
     const header: unknown = JSON.parse(base64UrlDecode(parts[0]).toString());
     const payload: unknown = JSON.parse(base64UrlDecode(parts[1]).toString());
-    if (!isObj(header) || !isObj(payload)) return null;
+    if (!isRecord(header) || !isRecord(payload)) return null;
     return {
       header,
       payload,
@@ -198,7 +195,7 @@ configureTrustProxy(app);
 app.use(express.json({ limit: BODY_LIMIT }));
 
 function extractEventType(body: unknown): string {
-  if (!isObj(body) || typeof body.type !== "string") return "";
+  if (!isRecord(body) || typeof body.type !== "string") return "";
   return body.type;
 }
 
@@ -209,14 +206,14 @@ interface ParsedMessage {
 }
 
 function extractMessage(body: unknown): ParsedMessage | null {
-  if (!isObj(body)) return null;
+  if (!isRecord(body)) return null;
   const msg = body.message;
-  if (!isObj(msg)) return null;
+  if (!isRecord(msg)) return null;
   if (typeof msg.text !== "string") return null;
   const { space } = msg;
-  if (!isObj(space) || typeof space.name !== "string") return null;
+  if (!isRecord(space) || typeof space.name !== "string") return null;
   const { sender } = msg;
-  const senderName = isObj(sender) && typeof sender.displayName === "string" ? sender.displayName : "unknown";
+  const senderName = isRecord(sender) && typeof sender.displayName === "string" ? sender.displayName : "unknown";
   return { spaceName: space.name, senderName, text: msg.text };
 }
 

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -24,6 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -28,6 +28,7 @@ import { readFileSync } from "fs";
 import type { Request, Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "line-works";
 const MAX_TEXT = 1_000;
@@ -179,22 +180,16 @@ async function sendLineWorks(userId: string, text: string): Promise<void> {
 
 // ── Payload parsing ────────────────────────────────────────────
 
-type JsonRecord = Record<string, unknown>;
-
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
-
 interface IncomingLineWorks {
   userId: string;
   text: string;
 }
 
 function parseEvent(body: unknown): IncomingLineWorks | null {
-  if (!isObj(body)) return null;
+  if (!isRecord(body)) return null;
   if (body.type !== "message") return null;
-  const source = isObj(body.source) ? body.source : null;
-  const content = isObj(body.content) ? body.content : null;
+  const source = isRecord(body.source) ? body.source : null;
+  const content = isRecord(body.content) ? body.content : null;
   if (!source || !content) return null;
   const userId = typeof source.userId === "string" ? source.userId : "";
   const text = content.type === "text" && typeof content.text === "string" ? String(content.text).trim() : "";

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"
   },

--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -13,6 +13,7 @@
 import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "mattermost";
 
@@ -115,10 +116,6 @@ function connectWebSocket(): void {
   });
 }
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 interface PostedMessage {
   userId: string;
   channelId: string;
@@ -130,9 +127,9 @@ interface PostedMessage {
 // returns null for anything that isn't a usable posted message.
 function parsePostedMessage(raw: string): PostedMessage | null {
   const event: unknown = JSON.parse(raw);
-  if (!isObj(event) || event.event !== "posted" || !isObj(event.data) || typeof event.data.post !== "string" || !event.data.post) return null;
+  if (!isRecord(event) || event.event !== "posted" || !isRecord(event.data) || typeof event.data.post !== "string" || !event.data.post) return null;
   const post: unknown = JSON.parse(event.data.post);
-  if (!isObj(post)) return null;
+  if (!isRecord(post)) return null;
   return {
     userId: typeof post.user_id === "string" ? post.user_id : "",
     channelId: typeof post.channel_id === "string" ? post.channel_id : "",

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -24,6 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -15,6 +15,7 @@ import "dotenv/config";
 import type { Request, Response } from "express";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 import { narrowChallenge } from "./verify.js";
 
 const TRANSPORT_ID = "messenger";
@@ -153,24 +154,20 @@ interface ExtractedMessage {
   text: string;
 }
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 function parseOneEvent(event: unknown): ExtractedMessage | null {
-  if (!isObj(event)) return null;
-  if (!isObj(event.sender) || typeof event.sender.id !== "string") return null;
-  if (!isObj(event.message) || typeof event.message.text !== "string") return null;
+  if (!isRecord(event)) return null;
+  if (!isRecord(event.sender) || typeof event.sender.id !== "string") return null;
+  if (!isRecord(event.message) || typeof event.message.text !== "string") return null;
   const text = event.message.text.trim();
   if (!text) return null;
   return { senderId: event.sender.id, text };
 }
 
 function extractMessages(body: unknown): ExtractedMessage[] {
-  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  if (!isRecord(body) || !Array.isArray(body.entry)) return [];
   const out: ExtractedMessage[] = [];
   for (const entry of body.entry) {
-    if (!isObj(entry) || !Array.isArray(entry.messaging)) continue;
+    if (!isRecord(entry) || !Array.isArray(entry.messaging)) continue;
     for (const event of entry.messaging) {
       const msg = parseOneEvent(event);
       if (msg) out.push(msg);

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/rocketchat/src/index.ts
+++ b/packages/bridges/rocketchat/src/index.ts
@@ -18,6 +18,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "rocketchat";
 const MAX_MSG_LEN = 4_000;
@@ -55,10 +56,6 @@ mulmo.onPush((pushEvent) => {
 
 type JsonRecord = Record<string, unknown>;
 
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
-
 // `Array.isArray(x: unknown)` narrows to `any[]`, which reintroduces `any`;
 // this preserves the element type as `unknown` so downstream stays checked.
 function isUnknownArray(value: unknown): value is unknown[] {
@@ -83,7 +80,7 @@ async function rcGet(path: string, query?: Record<string, string>): Promise<Json
     throw new Error(`GET ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
   const json: unknown = await res.json();
-  return isObj(json) ? json : {};
+  return isRecord(json) ? json : {};
 }
 
 async function rcPost(path: string, body: JsonRecord): Promise<JsonRecord> {
@@ -98,7 +95,7 @@ async function rcPost(path: string, body: JsonRecord): Promise<JsonRecord> {
     throw new Error(`POST ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
   const json: unknown = await res.json();
-  return isObj(json) ? json : {};
+  return isRecord(json) ? json : {};
 }
 
 // ── Send / receive ──────────────────────────────────────────────
@@ -124,10 +121,10 @@ interface IncomingMessage {
 }
 
 function parseMessage(raw: unknown, roomId: string): IncomingMessage | null {
-  if (!isObj(raw)) return null;
+  if (!isRecord(raw)) return null;
   const msgId = typeof raw._id === "string" ? raw._id : "";
   const text = typeof raw.msg === "string" ? raw.msg : "";
-  const user = isObj(raw.u) ? raw.u : null;
+  const user = isRecord(raw.u) ? raw.u : null;
   const senderUsername = user && typeof user.username === "string" ? user.username : "";
   const senderId = user && typeof user._id === "string" ? user._id : "";
   const tsIso = typeof raw.ts === "string" ? raw.ts : new Date().toISOString();
@@ -187,7 +184,7 @@ async function listDmRoomIds(): Promise<string[]> {
     });
     const rooms = Array.isArray(result.ims) ? result.ims : [];
     for (const room of rooms) {
-      if (isObj(room) && typeof room._id === "string") ids.push(room._id);
+      if (isRecord(room) && typeof room._id === "string") ids.push(room._id);
     }
     offset += rooms.length;
     const total = typeof result.total === "number" ? result.total : null;

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"
   },

--- a/packages/bridges/signal/src/index.ts
+++ b/packages/bridges/signal/src/index.ts
@@ -18,6 +18,7 @@
 import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 // `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
 // binaryType is nodebuffer so a Buffer is what actually arrives, but the type
@@ -92,10 +93,6 @@ async function sendSignal(chatId: string, text: string): Promise<void> {
 
 type JsonRecord = Record<string, unknown>;
 
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
-
 interface IncomingSignal {
   sourceNumber: string;
   /** Stable conversation id. For DMs = sourceNumber; for groups =
@@ -114,9 +111,9 @@ function extractGroupId(dataMessage: JsonRecord): string {
   //   - v2: dataMessage.groupInfo.groupId (base64)
   //   - new: dataMessage.groupV2.id (also base64)
   // Either form is accepted as a recipient prefix.
-  const groupV2 = isObj(dataMessage.groupV2) ? dataMessage.groupV2 : null;
+  const groupV2 = isRecord(dataMessage.groupV2) ? dataMessage.groupV2 : null;
   if (groupV2 && typeof groupV2.id === "string" && groupV2.id.length > 0) return groupV2.id;
-  const info = isObj(dataMessage.groupInfo) ? dataMessage.groupInfo : null;
+  const info = isRecord(dataMessage.groupInfo) ? dataMessage.groupInfo : null;
   if (info && typeof info.groupId === "string" && info.groupId.length > 0) return info.groupId;
   return "";
 }
@@ -133,8 +130,8 @@ function parseEnvelope(raw: string): IncomingSignal | null {
   } catch {
     return null;
   }
-  if (!isObj(parsed)) return null;
-  const envelope = isObj(parsed.envelope) ? parsed.envelope : null;
+  if (!isRecord(parsed)) return null;
+  const envelope = isRecord(parsed.envelope) ? parsed.envelope : null;
   if (!envelope) return null;
 
   // Signal envelopes carry both `source` (may be phone or UUID) and
@@ -144,7 +141,7 @@ function parseEnvelope(raw: string): IncomingSignal | null {
   // null — we can't reply to them at all, so drop the message rather
   // than attempt a failing send. See CodeRabbit review on #611.
   const sourceNumber = typeof envelope.sourceNumber === "string" && E164_PHONE.test(envelope.sourceNumber) ? envelope.sourceNumber : "";
-  const dataMessage = isObj(envelope.dataMessage) ? envelope.dataMessage : null;
+  const dataMessage = isRecord(envelope.dataMessage) ? envelope.dataMessage : null;
   const text = dataMessage && typeof dataMessage.message === "string" ? dataMessage.message.trim() : "";
   if (!sourceNumber || !text || !dataMessage) return null;
 

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -24,6 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -19,6 +19,7 @@ import "dotenv/config";
 import type { Request, Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "viber";
 const MAX_VIBER_TEXT = 7_000;
@@ -102,12 +103,6 @@ async function sendViber(receiverId: string, text: string): Promise<void> {
 
 // ── Webhook handler ────────────────────────────────────────────
 
-type JsonRecord = Record<string, unknown>;
-
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
-
 interface IncomingViber {
   // Raw Viber user id, e.g. "01234567890A=". Kept so allowlist /
   // log lookups compare against what the operator actually sees in
@@ -117,10 +112,10 @@ interface IncomingViber {
 }
 
 function parseMessageEvent(body: unknown): IncomingViber | null {
-  if (!isObj(body)) return null;
+  if (!isRecord(body)) return null;
   if (body.event !== "message") return null;
-  const sender = isObj(body.sender) ? body.sender : null;
-  const message = isObj(body.message) ? body.message : null;
+  const sender = isRecord(body.sender) ? body.sender : null;
+  const message = isRecord(body.message) ? body.message : null;
   if (!sender || !message) return null;
   const rawSenderId = typeof sender.id === "string" ? sender.id : "";
   const textFieldOk = message.type === "text" && typeof message.text === "string";

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/webhook/src/index.ts
+++ b/packages/bridges/webhook/src/index.ts
@@ -27,6 +27,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "webhook";
 const PORT = Number(process.env.WEBHOOK_PORT) || 3009;
@@ -73,19 +74,13 @@ function secretOk(provided: string | undefined): boolean {
 
 // ── Payload extraction ─────────────────────────────────────────
 
-type JsonRecord = Record<string, unknown>;
-
-function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
-
 interface Extracted {
   chatId: string;
   text: string;
 }
 
 function extractPayload(body: unknown): Extracted | null {
-  if (!isObj(body)) return null;
+  if (!isRecord(body)) return null;
   const text = typeof body.text === "string" ? body.text.trim() : "";
   const chatId = typeof body.chatId === "string" && body.chatId.length > 0 ? body.chatId : "default";
   if (!text) return null;

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -24,6 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -17,6 +17,7 @@ import "dotenv/config";
 import type { Request, Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
+import { isRecord } from "@mulmoclaude/common";
 import { narrowChallenge } from "./verify.js";
 
 const TRANSPORT_ID = "whatsapp";
@@ -103,10 +104,6 @@ interface WhatsAppTextMessage {
   text: { body: string };
 }
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 // `Array.isArray(x: unknown)` narrows to `any[]`, which reintroduces `any`;
 // this preserves the element type as `unknown` so the spread stays checked.
 function isUnknownArray(value: unknown): value is unknown[] {
@@ -114,21 +111,21 @@ function isUnknownArray(value: unknown): value is unknown[] {
 }
 
 function parseOneMessage(msg: unknown): WhatsAppTextMessage | null {
-  if (!isObj(msg)) return null;
+  if (!isRecord(msg)) return null;
   if (msg.type !== "text" || typeof msg.from !== "string") return null;
-  if (!isObj(msg.text)) return null;
+  if (!isRecord(msg.text)) return null;
   const { body } = msg.text;
   if (typeof body !== "string" || !body.trim()) return null;
   return { from: msg.from, text: { body } };
 }
 
 function collectRawMessages(body: unknown): unknown[] {
-  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  if (!isRecord(body) || !Array.isArray(body.entry)) return [];
   const raw: unknown[] = [];
   for (const entry of body.entry) {
-    if (!isObj(entry) || !Array.isArray(entry.changes)) continue;
+    if (!isRecord(entry) || !Array.isArray(entry.changes)) continue;
     for (const change of entry.changes) {
-      if (!isObj(change) || !isObj(change.value)) continue;
+      if (!isRecord(change) || !isRecord(change.value)) continue;
       const { messages } = change.value;
       if (isUnknownArray(messages)) raw.push(...messages);
     }

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/zulip/src/index.ts
+++ b/packages/bridges/zulip/src/index.ts
@@ -10,6 +10,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "zulip";
 const POLL_TIMEOUT_SEC = 30;
@@ -52,7 +53,7 @@ async function zulipPost(path: string, params: Record<string, string>): Promise<
     throw new Error(`POST ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
   const json: unknown = await res.json();
-  return isObj(json) ? json : {};
+  return isRecord(json) ? json : {};
 }
 
 async function zulipGet(path: string, params?: Record<string, string>): Promise<JsonRecord> {
@@ -66,7 +67,7 @@ async function zulipGet(path: string, params?: Record<string, string>): Promise<
     throw new Error(`GET ${path}: ${res.status} ${text.slice(0, 200)}`);
   }
   const json: unknown = await res.json();
-  return isObj(json) ? json : {};
+  return isRecord(json) ? json : {};
 }
 
 async function sendMessage(chatId: string, text: string): Promise<void> {
@@ -99,10 +100,6 @@ async function sendMessage(chatId: string, text: string): Promise<void> {
 
 // ── Event polling ───────────────────────────────────────────────
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 async function registerQueue(): Promise<{
   queue_id: string;
   last_event_id: number;
@@ -118,9 +115,9 @@ async function registerQueue(): Promise<{
 async function processEvents(events: unknown[]): Promise<number | undefined> {
   let latestId: number | undefined;
   for (const event of events) {
-    if (!isObj(event)) continue;
+    if (!isRecord(event)) continue;
     if (typeof event.id === "number") latestId = event.id;
-    if (event.type !== "message" || !isObj(event.message)) continue;
+    if (event.type !== "message" || !isRecord(event.message)) continue;
     await handleMessage(event.message);
   }
   return latestId;

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -32,6 +32,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5"
+    "@mulmobridge/client": "^0.1.5",
+    "@mulmoclaude/common": "^0.1.0"
   }
 }

--- a/packages/relay/src/webhooks/google-chat.ts
+++ b/packages/relay/src/webhooks/google-chat.ts
@@ -12,6 +12,7 @@
 // the message but cannot send replies back.
 
 import { chunkText } from "@mulmobridge/client/text";
+import { isRecord } from "@mulmoclaude/common";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
@@ -104,21 +105,17 @@ async function verifyGoogleJwt(authHeader: string | undefined, projectNumber: st
 
 // ── Payload parsing ─────────────────────────────────────────────
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 interface ChatMessage {
   spaceName: string;
   text: string;
 }
 
 function parseMessage(body: unknown): ChatMessage | null {
-  if (!isObj(body) || body.type !== "MESSAGE") return null;
+  if (!isRecord(body) || body.type !== "MESSAGE") return null;
   const msg = body.message;
-  if (!isObj(msg) || typeof msg.text !== "string") return null;
+  if (!isRecord(msg) || typeof msg.text !== "string") return null;
   const { space } = msg;
-  if (!isObj(space) || typeof space.name !== "string") return null;
+  if (!isRecord(space) || typeof space.name !== "string") return null;
   return { spaceName: space.name, text: msg.text.trim() };
 }
 
@@ -132,7 +129,7 @@ interface ServiceAccount {
 function parseServiceAccount(raw: string): ServiceAccount | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    if (!isObj(parsed) || typeof parsed.client_email !== "string" || typeof parsed.private_key !== "string") return null;
+    if (!isRecord(parsed) || typeof parsed.client_email !== "string" || typeof parsed.private_key !== "string") return null;
     return { client_email: parsed.client_email, private_key: parsed.private_key };
   } catch {
     return null;

--- a/packages/relay/src/webhooks/messenger.ts
+++ b/packages/relay/src/webhooks/messenger.ts
@@ -6,6 +6,7 @@
 //   MESSENGER_VERIFY_TOKEN      — Arbitrary string for webhook verification
 
 import { chunkText } from "@mulmobridge/client/text";
+import { isRecord } from "@mulmoclaude/common";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { envSecret, requireEnvSecret } from "../utils/envSecret.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
@@ -20,23 +21,19 @@ interface ExtractedMessage {
   text: string;
 }
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 function parseOneEvent(event: unknown): ExtractedMessage | null {
-  if (!isObj(event) || !isObj(event.sender) || typeof event.sender.id !== "string") return null;
-  if (!isObj(event.message) || typeof event.message.text !== "string") return null;
+  if (!isRecord(event) || !isRecord(event.sender) || typeof event.sender.id !== "string") return null;
+  if (!isRecord(event.message) || typeof event.message.text !== "string") return null;
   const text = event.message.text.trim();
   if (!text) return null;
   return { senderId: event.sender.id, text };
 }
 
 function extractMessages(body: unknown): ExtractedMessage[] {
-  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  if (!isRecord(body) || !Array.isArray(body.entry)) return [];
   const out: ExtractedMessage[] = [];
   for (const entry of body.entry) {
-    if (!isObj(entry) || !Array.isArray(entry.messaging)) continue;
+    if (!isRecord(entry) || !Array.isArray(entry.messaging)) continue;
     for (const event of entry.messaging) {
       const msg = parseOneEvent(event);
       if (msg) out.push(msg);

--- a/packages/relay/src/webhooks/teams.ts
+++ b/packages/relay/src/webhooks/teams.ts
@@ -25,6 +25,7 @@
 // existing RelayMessage.replyToken channel (opaque to the relay core).
 
 import { chunkText } from "@mulmobridge/client/text";
+import { isRecord } from "@mulmoclaude/common";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
@@ -41,10 +42,6 @@ const JWKS_CACHE_TTL_MS = ONE_HOUR_MS;
 const TOKEN_REFRESH_SKEW_SEC = 300; // refresh 5 min before expiry
 
 // ── Type guards ─────────────────────────────────────────────────
-
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
 
 // ── Config helpers ──────────────────────────────────────────────
 
@@ -113,7 +110,7 @@ async function fetchJwks(url: string): Promise<JwkKey[]> {
   const data: { keys?: unknown[] } = await res.json();
   if (!Array.isArray(data.keys)) return cached?.keys ?? [];
   const keys = data.keys
-    .filter((key): key is Record<string, unknown> => isObj(key) && typeof key.kid === "string" && typeof key.n === "string")
+    .filter((key): key is Record<string, unknown> => isRecord(key) && typeof key.kid === "string" && typeof key.n === "string")
     .map((key): JwkKey => {
       const endorsements = Array.isArray(key.endorsements) ? key.endorsements.filter((entry): entry is string => typeof entry === "string") : undefined;
       return {
@@ -217,7 +214,7 @@ export function parseWebhookBody(body: string): TeamsMessage | null {
 }
 
 function parseActivity(body: unknown): TeamsMessage | null {
-  if (!isObj(body)) return null;
+  if (!isRecord(body)) return null;
   // Non-message activities (conversationUpdate, invoke, typing, …) are
   // legit but we don't forward them to MulmoClaude.
   if (body.type !== "message") return null;
@@ -227,8 +224,8 @@ function parseActivity(body: unknown): TeamsMessage | null {
   const { from } = body;
   const serviceUrl = typeof body.serviceUrl === "string" ? body.serviceUrl.trim() : "";
   const channelId = typeof body.channelId === "string" ? body.channelId.trim() : "";
-  if (!isObj(conversation) || typeof conversation.id !== "string") return null;
-  if (!isObj(from) || typeof from.id !== "string") return null;
+  if (!isRecord(conversation) || typeof conversation.id !== "string") return null;
+  if (!isRecord(from) || typeof from.id !== "string") return null;
   if (!serviceUrl) return null;
   return {
     conversationId: conversation.id,

--- a/packages/relay/src/webhooks/whatsapp.ts
+++ b/packages/relay/src/webhooks/whatsapp.ts
@@ -7,6 +7,7 @@
 //   WHATSAPP_VERIFY_TOKEN      — Arbitrary string for webhook verification
 
 import { chunkText } from "@mulmobridge/client/text";
+import { isRecord } from "@mulmoclaude/common";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { envSecret, requireEnvSecret } from "../utils/envSecret.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
@@ -22,23 +23,19 @@ interface WaTextMessage {
   text: { body: string };
 }
 
-function isObj(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 function parseOneWaMessage(msg: unknown): WaTextMessage | null {
-  if (!isObj(msg) || msg.type !== "text" || typeof msg.from !== "string") return null;
-  if (!isObj(msg.text) || typeof msg.text.body !== "string" || !msg.text.body.trim()) return null;
+  if (!isRecord(msg) || msg.type !== "text" || typeof msg.from !== "string") return null;
+  if (!isRecord(msg.text) || typeof msg.text.body !== "string" || !msg.text.body.trim()) return null;
   return { from: msg.from, text: { body: msg.text.body } };
 }
 
 function extractWaMessages(body: unknown): WaTextMessage[] {
-  if (!isObj(body) || !Array.isArray(body.entry)) return [];
+  if (!isRecord(body) || !Array.isArray(body.entry)) return [];
   const raw: unknown[] = [];
   for (const entry of body.entry) {
-    if (!isObj(entry) || !Array.isArray(entry.changes)) continue;
+    if (!isRecord(entry) || !Array.isArray(entry.changes)) continue;
     for (const change of entry.changes) {
-      if (!isObj(change) || !isObj(change.value) || !Array.isArray(change.value.messages)) continue;
+      if (!isRecord(change) || !isRecord(change.value) || !Array.isArray(change.value.messages)) continue;
       raw.push(...change.value.messages);
     }
   }

--- a/plans/refactor-common-phase2-isrecord.md
+++ b/plans/refactor-common-phase2-isrecord.md
@@ -1,0 +1,53 @@
+# Phase 2 — bridges + relay `isObj` → `@mulmoclaude/common` `isRecord`
+
+Follows Phase 1 (#2267, merged): `@mulmoclaude/common` leaf package now holds the shared
+runtime type guards, and the host (`server/utils/types.ts`, `src/utils/types.ts`) re-exports it.
+
+## Goal
+
+Remove the 16 hand-written local `isObj` guards in the bridges + relay and route them
+through `isRecord` from `@mulmoclaude/common`, so the guard stops being re-implemented in
+every package.
+
+## Scope (16 source files, 13 package.json)
+
+Bridges (12): chatwork, google-chat, webhook, line-works, messenger, zulip, bluesky,
+mattermost, rocketchat, signal, viber, whatsapp.
+Relay (4 webhook files, 1 package): google-chat, messenger, teams, whatsapp.
+
+**Excluded — mastodon.** It *exports* `isObj` from `parse.ts` and unit-tests it
+(`test_parse.ts` asserts `isObj([]) === true`). Switching it to array-excluding `isRecord`
+is a 3-file coordinated change with a behavior flip in the test — done separately.
+
+## Semantic note (array handling)
+
+Local `isObj` = `typeof x === "object" && x !== null` (arrays **allowed**, narrowed to
+`Record<string, unknown>` / `JsonRecord`). `isRecord` additionally excludes arrays.
+Verified behavior-safe: every call site immediately accesses string keys or does a
+following `Array.isArray(x.prop)` check, so an array argument was never a valid pass —
+excluding it only makes the guard more correct. No call site passes a value expected to
+be an array.
+
+## Per-file mechanics
+
+1. Delete the local `function isObj(...) { ... }`.
+2. For webhook, line-works, viber — the `type JsonRecord = Record<string, unknown>` alias
+   becomes unused once `isObj` is gone, so delete it too. (chatwork, bluesky, rocketchat,
+   signal, zulip keep the alias — used by other signatures.)
+3. Add `import { isRecord } from "@mulmoclaude/common";` after the last `@mulmobridge/*`
+   import (alphabetical: `@mulmobridge` < `@mulmoclaude`).
+4. Rename every `isObj(` call to `isRecord(`.
+5. Add `"@mulmoclaude/common": "^0.1.0"` to each bridge's `dependencies` and to relay's.
+
+## Release prerequisite (must note in PR)
+
+`@mulmoclaude/common` is **not yet published to npm** (workspace-only, created in Phase 1).
+Bridges build with `tsc` (no bundling) and ship raw runtime deps, so `@mulmoclaude/common`
+**must be published to npm before the next bridge / relay publish**, or `npm i` of those
+packages breaks. Same obligation Phase 1 already created for the launcher. Merging this PR
+is safe (workspace resolves via symlink); only the *next publish* of a consumer is gated.
+
+## Verify
+
+`yarn install` (relink) → `yarn format` → `yarn lint` → `yarn typecheck` → `yarn build`.
+Bridges/relay have no unit tests for this; the guards are exercised via the host suite.


### PR DESCRIPTION
## Summary

Phase 2 of the `@mulmoclaude/common` consolidation (Phase 1: #2267). Removes **16 hand-written local `isObj` guards** across **12 bridges + relay** and routes them through `isRecord` from `@mulmoclaude/common`, so the guard stops being re-implemented in every package.

- Deletes each local `function isObj(...)`; `webhook`/`line-works`/`viber` also drop the now-unused `type JsonRecord` alias.
- Adds `import { isRecord } from "@mulmoclaude/common"` after the last `@mulmobridge/*` import (alphabetical order).
- Adds `"@mulmoclaude/common": "^0.1.0"` to each bridge + relay `package.json`.
- **mastodon excluded** — it *exports* `isObj` from `parse.ts` and unit-tests it (`isObj([]) === true`); flipping it to array-excluding `isRecord` is a 3-file coordinated change with a test behavior flip, done separately.

29 code files (16 src + 13 `package.json`) + 1 plan file.

## Items to Confirm / Review

1. **⚠️ Release prerequisite (not blocking merge):** `@mulmoclaude/common` is **not yet published to npm** (workspace-only, created in Phase 1). Bridges build with `tsc` (no bundling) and ship raw runtime deps, so **`@mulmoclaude/common` MUST be published to npm before the next bridge / relay publish**, or `npm i @mulmobridge/<x>` breaks. This is the same obligation Phase 1 already created for the launcher. Merging is safe (the workspace resolves via symlink); only the *next publish* of a consumer is gated.
2. **Array-handling semantic diff (verified behavior-preserving):** local `isObj` = `typeof x === "object" && x !== null` (arrays **allowed**); `isRecord` additionally excludes arrays. Every call site immediately accesses string keys or does a following `Array.isArray(x.prop)` check, so an array argument was never a valid pass — excluding it only makes the guard stricter. The only "bare gate" sites (`isRecord(x) ? x : null/{}` with no following key access) are all well-defined API object fields (`account`, `source`, `sender`, `envelope`, REST responses) that are never top-level arrays.
3. **Import placement / dep range** — `@mulmoclaude/common` sorts after `@mulmobridge/*`; range pinned to `^0.1.0` matching the launcher's Phase 1 declaration.

## User Prompt

> メモリを読んで、進行中の `@mulmoclaude/common` consolidation 作業を続けて。

(Note: the project memory recorded Phase 2 as an existing open PR `#2274`, but that PR/branch never existed — Phase 2 was unimplemented. This PR implements it from scratch.)

## Verification (all green)

| gate | result |
|---|---|
| `yarn format` | clean, no noise |
| `yarn lint` | 40 pre-existing warnings only — **0 new, 0 errors** |
| `yarn typecheck` | every workspace (incl. all bridges + relay) EXIT 0 |
| `yarn build` | EXIT 0 (`@mulmoclaude/common` builds in tier 1, before bridges) |
| `@mulmoclaude/common` guard tests | 9/9 pass |
| `deps` / `drift` / `smoke` audits | all OK |

## Follow-ups (unchanged from the consolidation plan)

- **mastodon** `isObj` → separate coordinated change (export + `test_parse.ts`).
- **Phase 3**: bridge-*specific* dupes go to `@mulmobridge/client`, not common (`parseAllowlist`, `fetchJsonOrThrow`, `frameText`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of incoming webhook and API data across messaging integrations.
  * Invalid or unexpected payloads are now handled more safely, reducing parsing errors.
  * Webhook messages continue to reject empty or malformed content consistently.
* **Documentation**
  * Added an implementation plan for standardizing payload validation across integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->