### PR TITLE
refactor(common): migrate mastodon isObj to @mulmoclaude/common isRecord

### DIFF
--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^0.1.0",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"
   },

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -23,7 +23,8 @@
 import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
-import { isObj, parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
+import { isRecord } from "@mulmoclaude/common";
+import { parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
 
 // `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
 // binaryType is nodebuffer so a Buffer is what actually arrives, but the type
@@ -98,7 +99,7 @@ async function postOneStatus(chunk: string, opts: PostStatusOptions): Promise<st
   const payload: unknown = await res.json().catch((err) => {
     throw new Error(`Mastodon status POST returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
   });
-  if (!isObj(payload) || typeof payload.id !== "string") {
+  if (!isRecord(payload) || typeof payload.id !== "string") {
     throw new Error("Mastodon status POST response is missing id");
   }
   return payload.id;
@@ -148,7 +149,7 @@ async function collectImageAttachments(media: unknown): Promise<MulmoAttachment[
   if (!Array.isArray(media)) return [];
   const out: MulmoAttachment[] = [];
   for (const item of media) {
-    if (!isObj(item) || item.type !== "image" || typeof item.url !== "string") continue;
+    if (!isRecord(item) || item.type !== "image" || typeof item.url !== "string") continue;
     const att = await fetchImageAttachment(item.url);
     if (att) out.push(att);
   }

--- a/packages/bridges/mastodon/src/parse.ts
+++ b/packages/bridges/mastodon/src/parse.ts
@@ -1,11 +1,9 @@
 // Pure parsing helpers for the Mastodon bridge — HTML→text,
 // leading-mention strip, mention-status extraction.
 
-export type JsonRecord = Record<string, unknown>;
+import { isRecord } from "@mulmoclaude/common";
 
-export function isObj(value: unknown): value is JsonRecord {
-  return typeof value === "object" && value !== null;
-}
+export type JsonRecord = Record<string, unknown>;
 
 export interface ParsedStatus {
   statusId: string;
@@ -87,10 +85,10 @@ export function stripLeadingMentions(text: string): string {
 export function parseMentionStatus(notification: JsonRecord): ParsedStatus | null {
   if (notification.type !== "mention") return null;
   const { status } = notification;
-  if (!isObj(status)) return null;
+  if (!isRecord(status)) return null;
   const statusId = typeof status.id === "string" ? status.id : "";
   const visibility = typeof status.visibility === "string" ? status.visibility : "public";
-  const account = isObj(status.account) ? status.account : null;
+  const account = isRecord(status.account) ? status.account : null;
   const senderAcct = account && typeof account.acct === "string" ? account.acct : "";
   const content = typeof status.content === "string" ? status.content : "";
   const text = stripLeadingMentions(htmlToText(content));
@@ -109,7 +107,7 @@ export function parseNotificationRaw(raw: string): ParsedStatus | null {
   } catch {
     return null;
   }
-  if (!isObj(notif)) return null;
+  if (!isRecord(notif)) return null;
   return parseMentionStatus(notif);
 }
 
@@ -122,7 +120,7 @@ export function parseFrame(raw: unknown): StreamFrame | null {
   if (typeof raw !== "string") return null;
   try {
     const msg: unknown = JSON.parse(raw);
-    if (!isObj(msg)) return null;
+    if (!isRecord(msg)) return null;
     const event = typeof msg.event === "string" ? msg.event : "";
     const payload = typeof msg.payload === "string" ? msg.payload : "";
     if (!event || !payload) return null;

--- a/packages/bridges/mastodon/test/test_parse.ts
+++ b/packages/bridges/mastodon/test/test_parse.ts
@@ -1,22 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isObj, htmlToText, stripLeadingMentions, parseMentionStatus, parseNotificationRaw, parseFrame } from "../src/parse.js";
-
-describe("isObj", () => {
-  it("returns true for plain objects and arrays", () => {
-    assert.equal(isObj({}), true);
-    assert.equal(isObj({ a: 1 }), true);
-    assert.equal(isObj([]), true);
-  });
-
-  it("returns false for null / primitives", () => {
-    assert.equal(isObj(null), false);
-    assert.equal(isObj(undefined), false);
-    assert.equal(isObj("str"), false);
-    assert.equal(isObj(42), false);
-    assert.equal(isObj(true), false);
-  });
-});
+import { htmlToText, stripLeadingMentions, parseMentionStatus, parseNotificationRaw, parseFrame } from "../src/parse.js";
 
 describe("htmlToText", () => {
   it("strips paragraph tags and converts to plain text", () => {


### PR DESCRIPTION
## Summary

Completes the `isObj` → `@mulmoclaude/common` `isRecord` consolidation. **mastodon** was the one bridge deferred from #2269 because `parse.ts` *exported* `isObj` and `test_parse.ts` locked its array-permitting behavior (`isObj([]) === true`) — a coordinated 3-file change with a test behavior flip.

- `parse.ts` / `index.ts`: drop the local exported `isObj`, import `isRecord` from `@mulmoclaude/common`, rename all call sites. The `type JsonRecord` alias stays (used by `ParsedStatus` signatures + `index.ts`).
- `test_parse.ts`: remove the now-redundant `isObj` `describe` block — the guard is tested in `@mulmoclaude/common`'s own suite.
- `package.json`: add `@mulmoclaude/common: ^0.1.0`.

4 files, +12/−28.

## Items to Confirm / Review

1. **Behavior change (verified safe):** local `isObj` allowed arrays; `isRecord` excludes them. Every call site (`notification` / `status` / `account` / `msg` / media `item`) accesses string keys on JSON objects that are never top-level arrays, so an array was never a valid pass — excluding it only makes the guards stricter. The dropped test only asserted the array-passing quirk itself.
2. **Dropped test coverage** is not lost — `@mulmoclaude/common`'s `test_guards.ts` covers the guards. mastodon's `parse` tests still run 31/31.
3. Depends on `@mulmoclaude/common@0.1.0` (published to npm 2026-07-21). Same release model as #2269.

## User Prompt

> メモリを読んで、進行中の `@mulmoclaude/common` consolidation を続けて。次（mastodon）も完了して。

## Verification (all green)

| gate | result |
|---|---|
| `yarn format` | mastodon files unchanged |
| `yarn lint` | 40 pre-existing warnings — **0 new, 0 errors** |
| `yarn typecheck` (mastodon) | `tsc --noEmit` EXIT 0 |
| `yarn build` (mastodon) | `tsc` EXIT 0 |
| mastodon `parse` tests | 31/31 pass |

## Relationship to #2269

Sibling PR. #2269 does the 12 bridges + relay (pure mechanical rename); this finishes the set with mastodon's coordinated export/test change. Can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Mastodon responses, notifications, and media attachments.
  * Invalid or unexpected payloads are handled more safely during status posting and notification parsing.

* **Tests**
  * Updated parsing tests to reflect the improved validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->