### PR TITLE
refactor(common): consolidate bridge allowlist parsing into @mulmoclaude/common (Phase 3 PR1, graduate to 1.0.0)

### DIFF
--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/bluesky/src/index.ts
+++ b/packages/bridges/bluesky/src/index.ts
@@ -19,7 +19,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "bluesky";
 const MAX_DM_LEN = 10_000;
@@ -35,12 +35,7 @@ if (!handle || !appPassword) {
   process.exit(1);
 }
 
-const allowedDids = new Set(
-  (process.env.BLUESKY_ALLOWED_DIDS ?? "")
-    .split(",")
-    .map((did) => did.trim())
-    .filter(Boolean),
-);
+const allowedDids = parseCsvSet(process.env.BLUESKY_ALLOWED_DIDS);
 const allowAll = allowedDids.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/chatwork/src/index.ts
+++ b/packages/bridges/chatwork/src/index.ts
@@ -25,7 +25,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "chatwork";
 const API_BASE = "https://api.chatwork.com/v2";
@@ -42,12 +42,7 @@ function readRequiredEnv(): { apiToken: string } {
 }
 const { apiToken } = readRequiredEnv();
 
-const allowedRooms = new Set(
-  (process.env.CHATWORK_ALLOWED_ROOMS ?? "")
-    .split(",")
-    .map((roomId) => roomId.trim())
-    .filter(Boolean),
-);
+const allowedRooms = parseCsvSet(process.env.CHATWORK_ALLOWED_ROOMS);
 const allowAll = allowedRooms.size === 0;
 const pollIntervalSec = Math.max(2, Number(process.env.CHATWORK_POLL_INTERVAL_SEC) || 5);
 const roomsTtlMs = Math.max(30, Number(process.env.CHATWORK_ROOMS_TTL_SEC) || 180) * 1000;

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "discord.js": "^14.27.0",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/discord/src/index.ts
+++ b/packages/bridges/discord/src/index.ts
@@ -12,6 +12,7 @@
 import "dotenv/config";
 import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
 import { createBridgeClient } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "discord";
 const MAX_DISCORD_LENGTH = 2000;
@@ -22,12 +23,7 @@ if (!token) {
   process.exit(1);
 }
 
-const allowedChannels = new Set(
-  (process.env.DISCORD_ALLOWED_CHANNELS ?? "")
-    .split(",")
-    .map((channelId) => channelId.trim())
-    .filter(Boolean),
-);
+const allowedChannels = parseCsvSet(process.env.DISCORD_ALLOWED_CHANNELS);
 const allowAll = allowedChannels.size === 0;
 
 const discord = new Client({

--- a/packages/bridges/email/package.json
+++ b/packages/bridges/email/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "imapflow": "^1.4.7",
     "mailparser": "^3.9.14",

--- a/packages/bridges/email/src/index.ts
+++ b/packages/bridges/email/src/index.ts
@@ -22,6 +22,7 @@ import { ImapFlow } from "imapflow";
 import { simpleParser, type ParsedMail } from "mailparser";
 import nodemailer from "nodemailer";
 import { createBridgeClient } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "email";
 const MAX_BODY_LEN = 100_000; // truncate inbound email text before forwarding to MulmoClaude
@@ -62,12 +63,7 @@ const imapTls = (process.env.EMAIL_IMAP_TLS ?? "true").toLowerCase() !== "false"
 const smtpPort = Number(process.env.EMAIL_SMTP_PORT) || 587;
 const smtpSecure = process.env.EMAIL_SMTP_TLS ? process.env.EMAIL_SMTP_TLS.toLowerCase() === "true" : smtpPort === 465;
 const pollIntervalSec = Math.max(10, Number(process.env.EMAIL_POLL_INTERVAL_SEC) || DEFAULT_POLL_SEC);
-const allowedSenders = new Set(
-  (process.env.EMAIL_ALLOWED_SENDERS ?? "")
-    .split(",")
-    .map((addr) => addr.trim().toLowerCase())
-    .filter(Boolean),
-);
+const allowedSenders = parseCsvSet(process.env.EMAIL_ALLOWED_SENDERS, { lowercase: true });
 const allowAll = allowedSenders.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -28,7 +28,7 @@ import { readFileSync } from "fs";
 import type { Request, Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "line-works";
 const MAX_TEXT = 1_000;
@@ -70,12 +70,7 @@ function resolvePrivateKey(): string | null {
   return null;
 }
 
-const allowedUsers = new Set(
-  (process.env.LINEWORKS_ALLOWED_USERS ?? "")
-    .split(",")
-    .map((user) => user.trim())
-    .filter(Boolean),
-);
+const allowedUsers = parseCsvSet(process.env.LINEWORKS_ALLOWED_USERS);
 const allowAll = allowedUsers.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"
   },

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -23,7 +23,7 @@
 import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 import { parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
 
 // `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
@@ -47,12 +47,7 @@ if (!instanceUrl || !accessToken) {
   process.exit(1);
 }
 
-const allowedAccts = new Set(
-  (process.env.MASTODON_ALLOWED_ACCTS ?? "")
-    .split(",")
-    .map((acct) => acct.trim())
-    .filter(Boolean),
-);
+const allowedAccts = parseCsvSet(process.env.MASTODON_ALLOWED_ACCTS);
 const allowAll = allowedAccts.size === 0;
 const dmOnly = (process.env.MASTODON_DM_ONLY ?? "true").toLowerCase() !== "false";
 

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "matrix-js-sdk": "^41.9.0"
   },

--- a/packages/bridges/matrix/src/index.ts
+++ b/packages/bridges/matrix/src/index.ts
@@ -15,6 +15,7 @@
 import "dotenv/config";
 import { createClient, RoomEvent, type MatrixClient, type MatrixEvent, type Room } from "matrix-js-sdk";
 import { createBridgeClient } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "matrix";
 
@@ -26,12 +27,7 @@ if (!homeserverUrl || !accessToken || !userId) {
   process.exit(1);
 }
 
-const allowedRooms = new Set(
-  (process.env.MATRIX_ALLOWED_ROOMS ?? "")
-    .split(",")
-    .map((roomId) => roomId.trim())
-    .filter(Boolean),
-);
+const allowedRooms = parseCsvSet(process.env.MATRIX_ALLOWED_ROOMS);
 const allowAll = allowedRooms.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"
   },

--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -13,7 +13,7 @@
 import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "mattermost";
 
@@ -28,12 +28,7 @@ function readRequiredEnv(): { mmUrl: string; botToken: string } {
 }
 const { mmUrl, botToken } = readRequiredEnv();
 
-const allowedChannels = new Set(
-  (process.env.MATTERMOST_ALLOWED_CHANNELS ?? "")
-    .split(",")
-    .map((channelId) => channelId.trim())
-    .filter(Boolean),
-);
+const allowedChannels = parseCsvSet(process.env.MATTERMOST_ALLOWED_CHANNELS);
 const allowAll = allowedChannels.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "nostr-tools": "^2.23.12"
   },

--- a/packages/bridges/nostr/src/index.ts
+++ b/packages/bridges/nostr/src/index.ts
@@ -29,6 +29,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { SimplePool, finalizeEvent, getPublicKey, nip04, nip19, type Event } from "nostr-tools";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { parseCsvSet, parseCsvList } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "nostr";
 const MAX_DM_LEN = 50_000;
@@ -55,20 +56,12 @@ if (!rawKey || !relayCsv) {
   process.exit(1);
 }
 
-const relays = relayCsv
-  .split(",")
-  .map((url) => url.trim())
-  .filter(Boolean);
+const relays = parseCsvList(relayCsv);
 
 const privateKeyBytes = decodeKey(rawKey);
 const publicKey = getPublicKey(privateKeyBytes);
 
-const allowedPubkeys = new Set(
-  (process.env.NOSTR_ALLOWED_PUBKEYS ?? "")
-    .split(",")
-    .map((key) => key.trim().toLowerCase())
-    .filter(Boolean),
-);
+const allowedPubkeys = parseCsvSet(process.env.NOSTR_ALLOWED_PUBKEYS, { lowercase: true });
 const allowAll = allowedPubkeys.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/rocketchat/src/index.ts
+++ b/packages/bridges/rocketchat/src/index.ts
@@ -18,7 +18,7 @@
 
 import "dotenv/config";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "rocketchat";
 const MAX_MSG_LEN = 4_000;
@@ -36,12 +36,7 @@ function readRequiredEnv(): { baseUrl: string; userId: string; authToken: string
 }
 const { baseUrl, userId, authToken } = readRequiredEnv();
 
-const allowedUsers = new Set(
-  (process.env.ROCKETCHAT_ALLOWED_USERS ?? "")
-    .split(",")
-    .map((name) => name.trim())
-    .filter(Boolean),
-);
+const allowedUsers = parseCsvSet(process.env.ROCKETCHAT_ALLOWED_USERS);
 const allowAll = allowedUsers.size === 0;
 const pollIntervalSec = Math.max(2, Number(process.env.ROCKETCHAT_POLL_INTERVAL_SEC) || 5);
 

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "ws": "^8.21.1"
   },

--- a/packages/bridges/signal/src/index.ts
+++ b/packages/bridges/signal/src/index.ts
@@ -18,7 +18,7 @@
 import "dotenv/config";
 import WebSocket from "ws";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 // `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
 // binaryType is nodebuffer so a Buffer is what actually arrives, but the type
@@ -41,12 +41,7 @@ if (!apiUrl || !botNumber) {
   process.exit(1);
 }
 
-const allowedNumbers = new Set(
-  (process.env.SIGNAL_ALLOWED_NUMBERS ?? "")
-    .split(",")
-    .map((num) => num.trim())
-    .filter(Boolean),
-);
+const allowedNumbers = parseCsvSet(process.env.SIGNAL_ALLOWED_NUMBERS);
 const allowAll = allowedNumbers.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "@slack/socket-mode": "^3.0.0",
     "@slack/web-api": "^8.0.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -23,6 +23,7 @@ import "dotenv/config";
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import { createBridgeClient, formatAckReply } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 import { buildExternalChatId, effectiveThreadTs, parseExternalChatId, parseGranularity } from "./sessionId.js";
 import { parseAckReaction } from "./ackReaction.js";
 import { redactUser } from "./redactUser.js";
@@ -36,12 +37,7 @@ if (!botToken || !appToken) {
   process.exit(1);
 }
 
-const allowedChannels = new Set(
-  (process.env.SLACK_ALLOWED_CHANNELS ?? "")
-    .split(",")
-    .map((channelId) => channelId.trim())
-    .filter(Boolean),
-);
+const allowedChannels = parseCsvSet(process.env.SLACK_ALLOWED_CHANNELS);
 const allowAll = allowedChannels.size === 0;
 
 const granularity = (() => {

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "botbuilder": "^4.23.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"

--- a/packages/bridges/teams/src/index.ts
+++ b/packages/bridges/teams/src/index.ts
@@ -21,6 +21,7 @@ import "dotenv/config";
 import express, { type Request, type Response } from "express";
 import { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext, type Activity } from "botbuilder";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 import { extractIncomingMessage } from "./parse.js";
 
 const TRANSPORT_ID = "teams";
@@ -38,12 +39,7 @@ function readRequiredEnv(): { appId: string; appPassword: string } {
 }
 const { appId, appPassword } = readRequiredEnv();
 
-const allowedUsers = new Set(
-  (process.env.TEAMS_ALLOWED_USERS ?? "")
-    .split(",")
-    .map((entry) => entry.trim())
-    .filter(Boolean),
-);
+const allowedUsers = parseCsvSet(process.env.TEAMS_ALLOWED_USERS);
 const allowAll = allowedUsers.size === 0;
 
 // The ConfigurationBotFrameworkAuthentication reads from a config object

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/twilio-sms/src/index.ts
+++ b/packages/bridges/twilio-sms/src/index.ts
@@ -28,6 +28,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "twilio-sms";
 const MAX_SMS_LEN = 1_600; // Twilio concatenates segments up to 1600 chars
@@ -59,12 +60,7 @@ if (!publicUrl && !allowUnverified) {
 if (!publicUrl && allowUnverified) {
   console.warn("[twilio-sms] ⚠ TWILIO_ALLOW_UNVERIFIED=1 — signature verification DISABLED. Use only in local testing.");
 }
-const allowedNumbers = new Set(
-  (process.env.TWILIO_ALLOWED_NUMBERS ?? "")
-    .split(",")
-    .map((num) => num.trim())
-    .filter(Boolean),
-);
+const allowedNumbers = parseCsvSet(process.env.TWILIO_ALLOWED_NUMBERS);
 const allowAll = allowedNumbers.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -19,7 +19,7 @@ import "dotenv/config";
 import type { Request, Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "viber";
 const MAX_VIBER_TEXT = 7_000;
@@ -38,12 +38,7 @@ function readRequiredEnv(): { authToken: string } {
 const { authToken } = readRequiredEnv();
 
 const senderName = process.env.VIBER_SENDER_NAME ?? "MulmoClaude";
-const allowedUsers = new Set(
-  (process.env.VIBER_ALLOWED_USERS ?? "")
-    .split(",")
-    .map((user) => user.trim())
-    .filter(Boolean),
-);
+const allowedUsers = parseCsvSet(process.env.VIBER_ALLOWED_USERS);
 const allowAll = allowedUsers.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"
   },

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -24,7 +24,7 @@
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^0.1.0",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.6.0"

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -17,7 +17,7 @@ import "dotenv/config";
 import type { Request, Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
-import { isRecord } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 import { narrowChallenge } from "./verify.js";
 
 const TRANSPORT_ID = "whatsapp";
@@ -39,12 +39,7 @@ function readRequiredEnv(): { accessToken: string; phoneNumberId: string; verify
 }
 const { accessToken, phoneNumberId, verifyToken, appSecret } = readRequiredEnv();
 
-const allowedNumbers = new Set(
-  (process.env.WHATSAPP_ALLOWED_NUMBERS ?? "")
-    .split(",")
-    .map((phoneNumber) => phoneNumber.trim())
-    .filter(Boolean),
-);
+const allowedNumbers = parseCsvSet(process.env.WHATSAPP_ALLOWED_NUMBERS);
 const allowAll = allowedNumbers.size === 0;
 
 const mulmo = createBridgeClient({ transportId: TRANSPORT_ID });

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
+    "@mulmoclaude/common": "^1.0.0",
     "@xmpp/client": "^0.14.0",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/xmpp/src/index.ts
+++ b/packages/bridges/xmpp/src/index.ts
@@ -27,6 +27,7 @@
 import "dotenv/config";
 import xmppPkg, { type XmlElement } from "@xmpp/client";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { parseCsvSet } from "@mulmoclaude/common";
 import { splitJid, parseStanzaFields } from "./parse.js";
 
 const { client, xml } = xmppPkg;
@@ -49,12 +50,7 @@ if (replyMode !== "bare" && replyMode !== "full") {
   process.exit(1);
 }
 const replyWithFullJid = replyMode === "full";
-const allowedJids = new Set(
-  (process.env.XMPP_ALLOWED_JIDS ?? "")
-    .split(",")
-    .map((entry) => entry.trim().toLowerCase())
-    .filter(Boolean),
-);
+const allowedJids = parseCsvSet(process.env.XMPP_ALLOWED_JIDS, { lowercase: true });
 const allowAll = allowedJids.size === 0;
 
 const { username, domain } = splitJid(jid);

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
     "@mulmobridge/protocol": "^0.1.4",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/common",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "General-purpose pure utilities (type guards, etc.) shared across the MulmoClaude host, bridges, and plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -54,3 +54,19 @@ export function hasStringProp<K extends string>(value: unknown, key: K): value i
 export function hasNumberProp<K extends string>(value: unknown, key: K): value is Record<K, number> & Record<string, unknown> {
   return isRecord(value) && typeof value[key] === "number";
 }
+
+/** Split a comma-separated env value into trimmed, non-empty entries.
+ *  `lowercase` folds case for identifiers compared case-insensitively
+ *  (JIDs, email addresses, hex pubkeys). Absent/empty input → empty list. */
+export function parseCsvList(raw: string | undefined, opts?: { lowercase?: boolean }): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((entry) => (opts?.lowercase ? entry.trim().toLowerCase() : entry.trim()))
+    .filter(Boolean);
+}
+
+/** A comma-separated env value as a Set — the canonical allowlist shape,
+ *  where an empty set is the "allow all" sentinel (`set.size === 0`). */
+export function parseCsvSet(raw: string | undefined, opts?: { lowercase?: boolean }): Set<string> {
+  return new Set(parseCsvList(raw, opts));
+}

--- a/packages/common/test/test_guards.ts
+++ b/packages/common/test/test_guards.ts
@@ -11,6 +11,8 @@ import {
   isErrorWithCode,
   hasStringProp,
   hasNumberProp,
+  parseCsvList,
+  parseCsvSet,
 } from "../src/index.ts";
 
 test("isRecord: plain objects only, arrays and null excluded", () => {
@@ -84,4 +86,22 @@ test("hasNumberProp: narrows a specific key to number", () => {
   assert.equal(hasNumberProp({ count: "3" }, "count"), false);
   assert.equal(hasNumberProp({}, "count"), false);
   assert.equal(hasNumberProp(undefined, "count"), false);
+});
+
+test("parseCsvList: trims, drops empties, optional lowercase", () => {
+  assert.deepEqual(parseCsvList("a, b ,,c"), ["a", "b", "c"]);
+  assert.deepEqual(parseCsvList(undefined), []);
+  assert.deepEqual(parseCsvList(""), []);
+  assert.deepEqual(parseCsvList("   "), []);
+  assert.deepEqual(parseCsvList("A,B"), ["A", "B"]);
+  assert.deepEqual(parseCsvList("A, B", { lowercase: true }), ["a", "b"]);
+});
+
+test("parseCsvSet: dedupes into a Set; empty input is the allow-all sentinel", () => {
+  const set = parseCsvSet("x,y,x");
+  assert.equal(set.size, 2);
+  assert.equal(set.has("x"), true);
+  assert.equal(parseCsvSet(undefined).size, 0);
+  assert.equal(parseCsvSet("").size, 0);
+  assert.equal(parseCsvSet("A,a", { lowercase: true }).size, 1);
 });

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -38,7 +38,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.3",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.15.0",
-    "@mulmoclaude/common": "^0.1.0",
+    "@mulmoclaude/common": "^1.0.0",
     "@mulmoclaude/core": "^0.30.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.3.4",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -33,6 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "@mulmobridge/client": "^0.1.5",
-    "@mulmoclaude/common": "^0.1.0"
+    "@mulmoclaude/common": "^1.0.0"
   }
 }

--- a/plans/refactor-common-phase3-allowlist.md
+++ b/plans/refactor-common-phase3-allowlist.md
@@ -1,0 +1,47 @@
+# Phase 3 PR1 — allowlist parsing → `@mulmoclaude/common` (+ common graduates to 1.0.0)
+
+Follows the Phase 3 scoping (see [`plans/done`] / memory). The single biggest bridge
+duplication — the CSV/env allowlist Set-builder — is a **generic, pure** helper, so it
+belongs in the drift-exempt leaf `@mulmoclaude/common`, NOT `@mulmobridge/client`.
+
+## What
+
+1. **`@mulmoclaude/common` gains** `parseCsvList(raw, { lowercase? })` and
+   `parseCsvSet(raw, { lowercase? })` (+ tests). Empty/absent input → empty list/set,
+   which is the canonical "allow all" sentinel (`set.size === 0`).
+2. **17 bridges** replace the hand-written
+   `new Set((process.env.X ?? "").split(",").map(v => v.trim()[.toLowerCase()]).filter(Boolean))`
+   block with `parseCsvSet(process.env.X, { lowercase? })`. nostr's relay-CSV also folds
+   into `parseCsvList`. ~85 lines removed.
+3. **`@mulmoclaude/common` graduates 0.1.0 → 1.0.0** (per the user's "packages updated
+   going forward start at 1.0.0+" directive — adding these exports is common's first
+   update). All 15 existing consumer ranges swept `^0.1.0 → ^1.0.0`; the 8 bridges newly
+   using it get `^1.0.0`. `^0.1.0` does NOT accept 1.0.0, so the sweep is mandatory for
+   the workspace to keep symlinking the local 1.0.0 instead of fetching npm's 0.1.0.
+
+## Excluded / gotchas
+
+- **telegram** — its `parseAllowlist` is numeric, **throws** on a bad entry, and treats
+  empty as **deny-all** (opposite of the string bridges' empty→allow-all). Folding it in
+  would flip its security default. Left entirely untouched.
+- **`{ lowercase: true }` is load-bearing** for xmpp (JIDs), email (addresses), nostr
+  (hex pubkeys) — case-insensitive identifiers. The other 14 stay case-sensitive.
+- Cost: `common` is outside the drift gate and not in the smoke trigger paths, so no
+  version-bump dance — same cheap target as Phases 1-2. Only the launcher range change
+  touches the launcher-sync gate, which passes (range lower-bound == workspace version).
+
+## Release prerequisite
+
+`@mulmoclaude/common@1.0.0` MUST be published to npm before any consumer (bridge / relay /
+launcher) is next published, or their `^1.0.0` range can't resolve. Merge is safe
+(workspace symlink); publish 1.0.0 right after merge via `/publish`.
+
+## Verify
+
+install → format → lint (0 new) → typecheck → build → common tests → deps/drift/smoke/
+launcher-sync — all green.
+
+## Not in this PR (deferred)
+
+- PR2: Meta `hub.challenge` verify → `@mulmobridge/webhook-runtime`.
+- `frameText` / `fetchJsonOrThrow` → `@mulmobridge/client` (expensive dance; piggyback later).


### PR DESCRIPTION
## Summary

**Phase 3 PR1.** The single biggest bridge duplication — the CSV/env allowlist `Set`-builder, ~17 near-identical copies — is a **generic, pure** helper, so it goes to the drift-exempt leaf `@mulmoclaude/common` (NOT `@mulmobridge/client`). No version-bump dance; same cheap target as Phases 1-2 (#2267/#2269/#2271).

- **`@mulmoclaude/common`** gains `parseCsvList(raw, { lowercase? })` and `parseCsvSet(raw, { lowercase? })` (+ tests). Empty/absent input → empty set = the canonical **allow-all sentinel** (`size === 0`).
- **17 bridges** replace the inline `new Set((process.env.X ?? "").split(",").map(v => v.trim()[.toLowerCase()]).filter(Boolean))` with `parseCsvSet(process.env.X, { lowercase? })`. nostr's relay-CSV folds into `parseCsvList`. **~85 lines removed.**
- **`@mulmoclaude/common` graduates `0.1.0` → `1.0.0`** and all 15 existing consumer ranges are swept `^0.1.0 → ^1.0.0` (the 8 newly-using bridges get `^1.0.0`).

43 files + 1 plan.

## Items to Confirm / Review

1. **`common` 1.0.0 graduation + range sweep is mandatory, not cosmetic.** `^0.1.0` resolves `>=0.1.0 <0.2.0`, so it does **not** accept `1.0.0`. If any consumer kept `^0.1.0`, yarn would stop symlinking the local workspace and fetch npm's `0.1.0` (which lacks the new exports) → build break. Hence every consumer moves to `^1.0.0` in this PR. Per the maintainer's "packages updated going forward start at 1.0.0+" directive, adding these exports is `common`'s first update, so it graduates now.
2. **telegram deliberately excluded.** Its `parseAllowlist` is numeric, **throws** on a bad entry, and treats empty as **deny-all** (opposite of the string bridges' empty→allow-all). Folding it into the generic helper would silently flip its security default. Left entirely untouched.
3. **`{ lowercase: true }` is load-bearing** for xmpp (JIDs), email (addresses), nostr (hex pubkeys) — case-insensitive identifiers. Verify those three kept the option; the other 14 stay case-sensitive.
4. **Release prerequisite:** `@mulmoclaude/common@1.0.0` must be **published to npm** before any consumer (bridge/relay/launcher) is next published, or `^1.0.0` can't resolve against npm's `0.1.0`. Merge is safe (workspace symlink); publish 1.0.0 right after merge via `/publish`.

## User Prompt

> `@mulmoclaude/common` consolidation を続けて（Phase 3）。allowlist を共通化。これから更新するパッケージは 1.0.0 以上にする。PR1 + PR2 両方進めて。

## Verification (all green)

| gate | result |
|---|---|
| `yarn lint` | 40 pre-existing warnings — **0 new, 0 errors** |
| `yarn typecheck` | every workspace EXIT 0 |
| `yarn build` | EXIT 0 |
| `@mulmoclaude/common` tests | 11/11 (incl. 2 new CSV cases) |
| `deps` / `drift` / `smoke` / `launcher-sync` | all OK |

## Follow-up

PR2 (stacked on this branch): Meta `hub.challenge` verify → `@mulmobridge/webhook-runtime`. `frameText` / `fetchJsonOrThrow` → `@mulmobridge/client` deferred (expensive drift+launcher-sync dance; piggyback on a future client bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent parsing for comma-separated access lists across messaging bridges.
  * Empty or missing access-list settings now consistently allow all entries.
  * Added optional normalization for case-insensitive identifiers.

* **Bug Fixes**
  * Improved handling of whitespace, empty values, duplicates, and casing in access-list configuration.

* **Documentation**
  * Added rollout and verification guidance for the shared access-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->