### PR TITLE
fix(mastodon): validate attachment URLs before fetching them

### DIFF
--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -25,6 +25,7 @@ import WebSocket from "ws";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 import { parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
+import { resolvePublicUrl } from "./urlGuard.js";
 
 // `ws` hands the listener `Buffer | ArrayBuffer | Buffer[]`. The default
 // binaryType is nodebuffer so a Buffer is what actually arrives, but the type
@@ -37,6 +38,9 @@ const frameText = (data: Buffer | ArrayBuffer | Buffer[]): string =>
 const TRANSPORT_ID = "mastodon";
 const MAX_STATUS_LEN = 500; // Mastodon's default soft limit; many instances raise to 1000+
 const FETCH_TIMEOUT_MS = 15_000;
+/** Cap on one fetched attachment. Without it a remote sender could point the
+ *  bridge at an arbitrarily large file and have it buffered, then base64'd. */
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 60_000;
 
@@ -127,12 +131,46 @@ interface MulmoAttachment {
   filename?: string;
 }
 
-async function fetchImageAttachment(url: string): Promise<MulmoAttachment | null> {
+/** Read at most `MAX_IMAGE_BYTES`, aborting mid-stream rather than after the
+ *  fact — `arrayBuffer()` would have already materialised the whole body. */
+async function readCappedBody(res: Response): Promise<Buffer | null> {
+  const declared = Number(res.headers.get("content-length") ?? "");
+  if (Number.isFinite(declared) && declared > MAX_IMAGE_BYTES) return null;
+  const { body } = res;
+  if (!body) return null;
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_IMAGE_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function fetchImageAttachment(rawUrl: string): Promise<MulmoAttachment | null> {
+  // The URL comes from a remote sender, so it has to clear the SSRF guard
+  // before it can become an outbound request.
+  const url = await resolvePublicUrl(rawUrl);
+  if (url === null) {
+    console.warn("[mastodon] image fetch refused: url failed the safety check");
+    return null;
+  }
   try {
-    const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), redirect: "error" });
     if (!res.ok) return null;
     const mimeType = res.headers.get("content-type") ?? "image/jpeg";
-    const buf = Buffer.from(await res.arrayBuffer());
+    const buf = await readCappedBody(res);
+    if (buf === null) {
+      console.warn("[mastodon] image fetch refused: body over the size cap");
+      return null;
+    }
     return { mimeType, data: buf.toString("base64") };
   } catch (err) {
     console.warn(`[mastodon] image fetch failed: ${err}`);

--- a/packages/bridges/mastodon/src/urlGuard.ts
+++ b/packages/bridges/mastodon/src/urlGuard.ts
@@ -1,0 +1,123 @@
+// Guard for attachment URLs that arrive from remote Mastodon users.
+//
+// `handleNotification` fetches image URLs straight out of an incoming
+// notification, and with `MASTODON_ALLOWED_ACCTS` unset every account on the
+// fediverse can reach that path — so an unchecked fetch is a server-side
+// request forgery primitive against whatever the bridge host can see
+// (loopback services, RFC1918 neighbours, the cloud metadata endpoint).
+//
+// Residual risk worth knowing: the DNS answer we validate is not the one the
+// subsequent fetch necessarily uses, so a rebinding attacker with a very short
+// TTL can still slip through. Pinning the resolved address into the connection
+// would need a custom agent; this raises the bar without that surgery.
+
+/* eslint-disable sonarjs/no-hardcoded-ip -- the blocked ranges ARE this module's
+   specification; writing them as literals is the point, not an oversight. */
+
+import { lookup } from "node:dns/promises";
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+const BLOCKED_HOSTNAMES = new Set(["localhost", "ip6-localhost", "ip6-loopback"]);
+const BLOCKED_HOSTNAME_SUFFIXES = [".localhost", ".local", ".internal"];
+
+/** IPv4 ranges that must never be fetched, as [firstAddress, prefixLength]. */
+const BLOCKED_V4_RANGES: readonly (readonly [string, number])[] = [
+  ["0.0.0.0", 8], // "this network"
+  ["10.0.0.0", 8], // RFC1918
+  ["100.64.0.0", 10], // CGNAT
+  ["127.0.0.0", 8], // loopback
+  ["169.254.0.0", 16], // link-local — includes the 169.254.169.254 metadata endpoint
+  ["172.16.0.0", 12], // RFC1918
+  ["192.0.0.0", 24], // IETF protocol assignments
+  ["192.168.0.0", 16], // RFC1918
+  ["198.18.0.0", 15], // benchmarking
+  ["224.0.0.0", 4], // multicast
+  ["240.0.0.0", 4], // reserved / broadcast
+];
+
+function ipv4ToInt(address: string): number | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    value = value * 256 + octet;
+  }
+  return value;
+}
+
+function isBlockedV4(address: string): boolean {
+  const value = ipv4ToInt(address);
+  if (value === null) return false;
+  return BLOCKED_V4_RANGES.some(([base, prefix]) => {
+    const baseValue = ipv4ToInt(base);
+    if (baseValue === null) return false;
+    // `>>> 0` keeps the mask unsigned; a /0 shift would be a no-op anyway.
+    const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+    return (value & mask) === (baseValue & mask);
+  });
+}
+
+function isBlockedV6(address: string): boolean {
+  const lower = address.toLowerCase().replace(/^\[|\]$/g, "");
+  if (lower === "::1" || lower === "::") return true;
+  // IPv4-mapped (::ffff:127.0.0.1) re-enters the v4 rules.
+  const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(lower);
+  if (mapped) return isBlockedV4(mapped[1]);
+  const [head] = lower.split(":");
+  if (head.length === 0) return false;
+  const leading = Number.parseInt(head, 16);
+  if (Number.isNaN(leading)) return false;
+  if ((leading & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((leading & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  return false;
+}
+
+/** True when this literal address is one the bridge must never fetch. Pure —
+ *  the DNS-dependent decision lives in `resolvePublicUrl`. */
+export function isBlockedAddress(address: string): boolean {
+  return address.includes(":") ? isBlockedV6(address) : isBlockedV4(address);
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase().replace(/\.$/, "");
+  if (BLOCKED_HOSTNAMES.has(lower)) return true;
+  return BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+/** Parse and apply every check that doesn't need the network: shape, scheme,
+ *  obviously-internal hostname, and literal addresses. Returns null on reject. */
+export function parseSafeUrlShape(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) return null;
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  if (hostname.length === 0) return null;
+  if (isBlockedHostname(hostname)) return null;
+  if (isBlockedAddress(hostname)) return null;
+  return url;
+}
+
+/** Full check: shape rules, then every address the hostname resolves to.
+ *  Returns the URL when it's safe to fetch, or null when it must be refused. */
+export async function resolvePublicUrl(raw: string): Promise<URL | null> {
+  const url = parseSafeUrlShape(raw);
+  if (url === null) return null;
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  // A literal address was already vetted above and has nothing to resolve.
+  if (/^[\d.]+$/.test(hostname) || hostname.includes(":")) return url;
+  try {
+    const addresses = await lookup(hostname, { all: true });
+    if (addresses.length === 0) return null;
+    return addresses.every((entry) => !isBlockedAddress(entry.address)) ? url : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/bridges/mastodon/test/test_urlGuard.ts
+++ b/packages/bridges/mastodon/test/test_urlGuard.ts
@@ -1,0 +1,123 @@
+// Attachment URLs arrive from remote senders, and with the allowlist unset any
+// account can reach that path — so these cases are the boundary between "fetch
+// an image" and "make the bridge probe its own network".
+
+/* eslint-disable sonarjs/no-hardcoded-ip -- literal addresses are the fixtures
+   under test here; parameterising them would test nothing. */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { isBlockedAddress, parseSafeUrlShape, resolvePublicUrl } from "../src/urlGuard.js";
+
+describe("isBlockedAddress", () => {
+  it("blocks IPv4 loopback", () => {
+    assert.equal(isBlockedAddress("127.0.0.1"), true);
+    assert.equal(isBlockedAddress("127.255.255.254"), true);
+  });
+
+  it("blocks the cloud metadata endpoint", () => {
+    assert.equal(isBlockedAddress("169.254.169.254"), true);
+  });
+
+  it("blocks the RFC1918 ranges", () => {
+    assert.equal(isBlockedAddress("10.0.0.1"), true);
+    assert.equal(isBlockedAddress("172.16.0.1"), true);
+    assert.equal(isBlockedAddress("172.31.255.255"), true);
+    assert.equal(isBlockedAddress("192.168.1.1"), true);
+  });
+
+  it("allows addresses just outside the RFC1918 boundaries", () => {
+    assert.equal(isBlockedAddress("172.15.255.255"), false);
+    assert.equal(isBlockedAddress("172.32.0.1"), false);
+    assert.equal(isBlockedAddress("11.0.0.1"), false);
+  });
+
+  it("blocks CGNAT, unspecified, multicast and reserved space", () => {
+    assert.equal(isBlockedAddress("100.64.0.1"), true);
+    assert.equal(isBlockedAddress("0.0.0.0"), true);
+    assert.equal(isBlockedAddress("224.0.0.1"), true);
+    assert.equal(isBlockedAddress("255.255.255.255"), true);
+  });
+
+  it("allows ordinary public addresses", () => {
+    assert.equal(isBlockedAddress("1.1.1.1"), false);
+    assert.equal(isBlockedAddress("93.184.216.34"), false);
+  });
+
+  it("blocks IPv6 loopback, unspecified, ULA and link-local", () => {
+    assert.equal(isBlockedAddress("::1"), true);
+    assert.equal(isBlockedAddress("::"), true);
+    assert.equal(isBlockedAddress("fc00::1"), true);
+    assert.equal(isBlockedAddress("fd12:3456::1"), true);
+    assert.equal(isBlockedAddress("fe80::1"), true);
+  });
+
+  it("unwraps IPv4-mapped IPv6 rather than trusting the wrapper", () => {
+    assert.equal(isBlockedAddress("::ffff:127.0.0.1"), true);
+    assert.equal(isBlockedAddress("::ffff:169.254.169.254"), true);
+    assert.equal(isBlockedAddress("::ffff:1.1.1.1"), false);
+  });
+
+  it("allows a public IPv6 address", () => {
+    assert.equal(isBlockedAddress("2606:4700:4700::1111"), false);
+  });
+});
+
+describe("parseSafeUrlShape", () => {
+  it("accepts an ordinary https URL", () => {
+    assert.notEqual(parseSafeUrlShape("https://example.com/a.png"), null);
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    assert.equal(parseSafeUrlShape("file:///etc/passwd"), null);
+    assert.equal(parseSafeUrlShape("ftp://example.com/a.png"), null);
+    assert.equal(parseSafeUrlShape("data:image/png;base64,AAAA"), null);
+  });
+
+  it("rejects unparseable input", () => {
+    assert.equal(parseSafeUrlShape("not a url"), null);
+    assert.equal(parseSafeUrlShape(""), null);
+  });
+
+  it("rejects localhost by name", () => {
+    assert.equal(parseSafeUrlShape("http://localhost:3001/x"), null);
+    assert.equal(parseSafeUrlShape("http://LOCALHOST/x"), null);
+    assert.equal(parseSafeUrlShape("http://foo.localhost/x"), null);
+  });
+
+  it("rejects internal-looking suffixes", () => {
+    assert.equal(parseSafeUrlShape("http://printer.local/x"), null);
+    assert.equal(parseSafeUrlShape("http://db.internal/x"), null);
+  });
+
+  it("rejects a trailing-dot localhost", () => {
+    assert.equal(parseSafeUrlShape("http://localhost./x"), null);
+  });
+
+  it("rejects literal internal addresses", () => {
+    assert.equal(parseSafeUrlShape("http://127.0.0.1/x"), null);
+    assert.equal(parseSafeUrlShape("http://169.254.169.254/latest/meta-data/"), null);
+    assert.equal(parseSafeUrlShape("http://[::1]/x"), null);
+  });
+});
+
+describe("resolvePublicUrl", () => {
+  it("refuses a literal internal address without touching DNS", async () => {
+    assert.equal(await resolvePublicUrl("http://127.0.0.1/x"), null);
+  });
+
+  it("refuses a hostname that resolves to loopback", async () => {
+    // `localhost` is caught by name, but this asserts the resolve path too.
+    assert.equal(await resolvePublicUrl("http://localhost/x"), null);
+  });
+
+  it("refuses a hostname that does not resolve", async () => {
+    assert.equal(await resolvePublicUrl("http://no-such-host.invalid/x"), null);
+  });
+
+  it("passes a literal public address straight through", async () => {
+    const url = await resolvePublicUrl("https://1.1.1.1/a.png");
+    assert.notEqual(url, null);
+  });
+});


### PR DESCRIPTION
## Summary

Mastodon ブリッジが受信通知の添付画像URLを検証せずに `fetch` していたため、URL の検証と取得サイズの上限を追加します。

- **スキーム制限** — `http:` / `https:` のみ
- **ホスト名/アドレス検査** — 内部向けホスト名を拒否し、リテラルおよび DNS 解決後の全アドレスを loopback / RFC1918 / CGNAT / link-local / multicast / reserved の各レンジと照合
- **リダイレクト不追従** — 追従すると検証済みの宛先から外れるため
- **サイズ上限** — 従来 `arrayBuffer()` を無制限に読んでいたので、ストリームで読みつつ上限超過で打ち切り

IP 判定は純粋関数に切り出し、境界値までテストしています。

## Items to Confirm / Review

- **`redirect: "error"` は挙動変更です。** 安全側に倒していますが、リダイレクトを返す配信経路の画像は取得できなくなります。実運用で不都合があれば「各ホップを検証しつつ追従」に変える必要があります — 実環境の事情をご確認ください。
- **残存リスク（コード内にも明記）**: 検証したアドレスを接続にピン留めしていないため、DNS リバインディングは塞げていません。対応には custom agent が必要で今回のスコープ外です。
- **CodeQL は `js/request-forgery` を出し続けます。** ガード関数をサニタイザとして認識できないためで、判定の扱いは別途相談させてください。
- `sonarjs/no-hardcoded-ip` はファイル単位で理由付き disable にしました（ブロック範囲そのものが仕様であり、テストもリテラルIPでなければ意味がないため）。`docs/lint-policy.md` の「`--` 付き disable は監査済み」に沿っています。

## テスト / ゲート

- `test/test_urlGuard.ts` 新規 — IPv4/IPv6 の各レンジ、境界値、IPv4-mapped IPv6 の展開、スキーム拒否、ホスト名の別表記、DNS 解決経路。
- ブリッジ全体で **51 tests pass**、`tsc --noEmit` / `eslint` クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
