### PR TITLE
fix(markdown-utils): stop makeTasksInteractive scanning superlinearly

### DIFF
--- a/packages/markdown-utils/src/markdown/taskList.ts
+++ b/packages/markdown-utils/src/markdown/taskList.ts
@@ -173,8 +173,11 @@ export function makeTasksInteractive(html: string): string {
   // marked v18 default output:
   //   <input disabled="" type="checkbox">         (unchecked)
   //   <input checked="" disabled="" type="checkbox">  (checked)
-  // Both end with ` type="checkbox">`. Capture everything between
-  // `<input ` and `disabled=""` (typically empty or `checked="" `)
-  // and re-emit with `class="md-task"` in disabled's slot.
-  return html.replace(/<input ([^>]*)disabled="" type="checkbox">/g, '<input $1class="md-task" type="checkbox">');
+  // Match those two shapes exactly and re-emit with `class="md-task"` in
+  // disabled's slot. The middle was `[^>]*` once, which is what made this
+  // quadratic: on input full of `<input =` the engine re-scans the run for
+  // every start position looking for a `disabled=""` that never arrives.
+  // An optional literal group can't backtrack, and marked emits nothing else
+  // here — the checked/unchecked pair above is the whole surface.
+  return html.replace(/<input (checked="" )?disabled="" type="checkbox">/g, '<input $1class="md-task" type="checkbox">');
 }

--- a/test/utils/markdown/test_taskList.ts
+++ b/test/utils/markdown/test_taskList.ts
@@ -233,6 +233,23 @@ describe("makeTasksInteractive", () => {
     const transformed = '<input class="md-task" type="checkbox">';
     assert.equal(makeTasksInteractive(transformed), transformed);
   });
+
+  it("leaves a checkbox with unexpected extra attributes alone", () => {
+    // The pattern is deliberately narrow — anything outside marked's two
+    // shapes is passed through rather than half-rewritten.
+    const html = '<input data-x="1" disabled="" type="checkbox">';
+    assert.equal(makeTasksInteractive(html), html);
+  });
+
+  // Regression: the previous `[^>]*` middle made this quadratic, so a long run
+  // of near-misses took superlinear time. It should now finish promptly and
+  // return the input untouched.
+  it("stays fast on input full of partial `<input` matches", () => {
+    const hostile = `<input ${"<input =".repeat(40000)}`;
+    const startedAt = Date.now();
+    assert.equal(makeTasksInteractive(hostile), hostile);
+    assert.ok(Date.now() - startedAt < 2000, "makeTasksInteractive should not scan superlinearly");
+  });
 });
 
 // `makeTasksInteractive` is a regex over the literal string `marked`


### PR DESCRIPTION
## Summary

`makeTasksInteractive` の正規表現の中間が `[^>]*` だったため、近い形だが一致しない入力が続くと、開始位置ごとにその区間を再走査していました（CodeQL `js/polynomial-redos` #403）。

実測（40,000 回繰り返しの入力）:

| | 所要 |
|---|---|
| 修正前 | **18,348 ms** |
| 修正後 | **1 ms** |

marked が出力するのはコメントに記載の checked / unchecked の 2 形態だけなので、そこを省略可能なリテラル group として書くと、同じ範囲をカバーしたまま後戻りが発生しなくなります。

## Items to Confirm / Review

- **パターンを意図的に狭めました。** 従来の `[^>]*` は「`<input ` と `disabled=""` の間に何が来ても拾う」防御的な書き方でしたが、新しい形は marked の 2 形態のみに一致します。将来 marked が属性の順序や種類を変えた場合、**黙って変換されなくなる**（＝チェックボックスが interactive にならない）挙動になります。想定外の属性列はそのまま通す、という回帰テストを追加してあります。
- 既存の期待値は変更していません（unchecked / checked / 複数 / 非タスク input / 冪等性）。

## テスト

- `test/utils/markdown/test_taskList.ts` に 2 件追加（想定外属性の素通し、長い near-miss 入力での所要時間）。
- 同ファイル **41 tests pass**、`eslint` / `tsc` クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize markdown task list checkbox transformation to avoid superlinear regex scanning while keeping marked’s default unchecked/checked outputs interactive.

Bug Fixes:
- Prevent makeTasksInteractive from exhibiting quadratic performance on inputs with many partial `<input` matches, ensuring it completes promptly.

Enhancements:
- Restrict the task list checkbox matching pattern to marked’s two known shapes and leave unexpected attribute combinations untouched.

Tests:
- Add regression tests covering unexpected checkbox attribute layouts and performance on long near-miss input to validate the new behavior and timing constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-list checkbox processing to target only supported checkbox markup.
  * Preserved unexpected or additional checkbox attributes instead of modifying them.
  * Improved performance when processing content containing many partial checkbox patterns.
* **Tests**
  * Added coverage for unsupported checkbox attributes and high-volume input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->