### PR TITLE
docs(core): document the ASCII-only aggregate alias constraint (#2276)

### DIFF
--- a/packages/core/assets/helps/custom-view.md
+++ b/packages/core/assets/helps/custom-view.md
@@ -131,6 +131,11 @@ const { rows } = await res.json(); // [{ Category, total, n }, ...] — chart th
   ops: `eq/ne/in/gt/gte/lt/lte/contains`; at least one of
   `groupBy`/`aggregates`; `orderBy` sorts by a groupBy column or an
   aggregate alias; result rows clamp at 1,000 by default.
+- Aggregate aliases (the keys of `aggregates`) must be simple ASCII
+  identifiers (`/^[A-Za-z_]\w{0,63}$/`) — non-ASCII keys (e.g. Japanese)
+  are rejected by validation. This applies **only to aliases**: column
+  references (`column`, `groupBy`, `where.field`) accept the source's
+  headers as-is, including non-ASCII CSV headers like `価格`.
 - Structured JSON only — there is **no SQL surface**, by design.
 - Combine with `onChange` (below) to stay live: in the callback, re-run
   **this POST query** (wrap it in your own `refresh()` and register that)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^1.0.0",
     "@mulmoclaude/collection-plugin": "^1.0.0",
     "@mulmoclaude/common": "^1.0.0",
-    "@mulmoclaude/core": "^1.0.0",
+    "@mulmoclaude/core": "^1.0.1",
     "@mulmoclaude/form-plugin": "^1.0.0",
     "@mulmoclaude/google-plugin": "^1.0.0",
     "@mulmoclaude/html-plugin": "^1.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -31,14 +31,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.0.0",
+    "@mulmoclaude/core": "^1.0.1",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^1.1.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^1.0.0",
+    "@mulmoclaude/core": "^1.0.1",
     "echarts": "^6.1.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.1",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -21,7 +21,7 @@
     "test": "tsx --test test/test_*.ts"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.0.0"
+    "@mulmoclaude/core": "^1.0.1"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.1.0",


### PR DESCRIPTION
## Summary

custom-view help（`packages/core/assets/helps/custom-view.md`）の Aggregation queries 節に、集計エイリアスの ASCII 制約を1 bullet 追記しました。

**コードとの一致を検証済み**: `aggregates` のキーは `queryZ.ts:91` で `SAFE_ALIAS_PATTERN = /^[A-Za-z_]\w{0,63}$/`（ASCII 識別子のみ）で検証される一方、`column` / `groupBy` / `where.field` は `z.string().min(1)` のみでパターン制約なし。**エイリアスだけが制約される非対称**は help を読んでも推測できず、日本語ワークスペースでダッシュボードを頼むと `在庫切れ件数` のような日本語エイリアスが reject され、往復とエラーログが積まれる（issue に2セッションの観測）。

Closes #2276

## Items to Confirm / Review

- **`@mulmoclaude/core` を 1.0.0 → 1.0.1 に bump し、publish 済み**です。`assets/helps/*` は core に同梱される（`files: ["dist","assets"]`）ため、help 変更を bump なしにするとエージェントに届かず、#1945 の drift になります。**npm 上 latest = 1.0.1 を確認済み**。
- **依存レンジは `^1.0.1` に追従**しました。機能上は `^1.0.0` でも 1.0.1 を受け取りますが、`launcherSync.mjs` の下限ゲート（`launcherRange.lowerBound == workspace.version`）が `^1.0.1` を要求するため更新しています（collection-plugin / google-plugin / launcher）。
- **プラグインの再 publish は不要**です。core 単独の変更で、キャレット範囲が 1.0.1 を自動追従します。
- **文面は issue の文案そのまま**採用しています。

## テスト

`check:launcher-sync` OK、core ビルド PASS、dry-run で `custom-view.md`（追記済み）の同梱と version 1.0.1 を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified aggregation query alias rules.
  * Aliases must use simple ASCII identifiers, begin with a letter or underscore, and contain no more than 64 characters.
  * Non-ASCII characters are not allowed in aliases.
  * Clarified that source column and header references—including non-ASCII headers—remain supported in `column`, `groupBy`, and `where.field` expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->