### PR TITLE
feat(chat): "new messages" affordance for the sidebar chat list

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -607,6 +607,7 @@ const { focusChatInput, jumpToLatest, hasNewWhileDetached } = useChatScroll({
   toolResults,
   isRunning: activeSessionRunning,
   chatInputRef,
+  sessionId: computed(() => activeSession.value?.id ?? null),
 });
 
 // Panel-wide file drop (#1289 Step 2). The handlers are bound on

--- a/src/App.vue
+++ b/src/App.vue
@@ -126,10 +126,12 @@
           :session-role-icon="sessionRoleIcon"
           :layout-mode="layoutMode"
           :show-right-sidebar="showRightSidebar"
+          :has-new-messages="hasNewWhileDetached"
           @select="onSidebarItemClick"
           @activate="activePane = 'sidebar'"
           @update:layout-mode="setLayoutMode"
           @toggle-right-sidebar="toggleRightSidebar"
+          @jump-to-latest="jumpToLatest"
         />
 
         <!-- Shared Thinking indicator. Sits between the sidebar and
@@ -600,7 +602,7 @@ const chatInputRef = ref<{
   refreshVoiceAvailability: () => Promise<void>;
 } | null>(null);
 
-const { focusChatInput } = useChatScroll({
+const { focusChatInput, jumpToLatest, hasNewWhileDetached } = useChatScroll({
   sessionSidebarRef,
   toolResults,
   isRunning: activeSessionRunning,

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -19,31 +19,45 @@
         <CanvasViewToggle :model-value="layoutMode" @update:model-value="(mode) => emit('update:layoutMode', mode)" />
       </div>
     </div>
-    <div
-      ref="root"
-      class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 outline-none"
-      tabindex="0"
-      data-testid="tool-results-scroll"
-      @mousedown="emit('activate')"
-    >
-      <div
-        v-for="result in results"
-        :key="result.uuid"
-        class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
-        :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
-        @click="emit('select', result.uuid)"
+    <!-- `relative` so the "new messages" affordance can sit over the scroll
+         area without joining its scrolling content. -->
+    <div class="relative flex-1 min-h-0 flex flex-col">
+      <button
+        v-if="hasNewMessages"
+        type="button"
+        class="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 rounded-full bg-blue-600 px-3 py-1.5 text-xs font-medium text-white shadow-lg hover:bg-blue-700 transition-colors"
+        data-testid="chat-new-messages"
+        @click="emit('jump-to-latest')"
       >
-        <span class="absolute top-0 left-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none">
-          {{ sourceLabel(result) }}
-        </span>
-        <span
-          v-if="resultTimestamps.get(result.uuid)"
-          class="absolute top-0 right-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none"
+        {{ t("sidebarHeader.newMessages") }}
+        <span class="material-icons text-sm leading-none" aria-hidden="true">arrow_downward</span>
+      </button>
+      <div
+        ref="root"
+        class="flex-1 min-h-0 overflow-y-auto p-2 space-y-2 outline-none"
+        tabindex="0"
+        data-testid="tool-results-scroll"
+        @mousedown="emit('activate')"
+      >
+        <div
+          v-for="result in results"
+          :key="result.uuid"
+          class="relative cursor-pointer rounded border border-gray-300 text-sm text-gray-900 hover:opacity-75 transition-opacity"
+          :class="result.uuid === selectedUuid ? 'ring-2 ring-blue-500' : ''"
+          @click="emit('select', result.uuid)"
         >
-          {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
-        </span>
-        <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
-        <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
+          <span class="absolute top-0 left-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none">
+            {{ sourceLabel(result) }}
+          </span>
+          <span
+            v-if="resultTimestamps.get(result.uuid)"
+            class="absolute top-0 right-2 -translate-y-1/2 bg-gray-100 px-1 text-[10px] text-gray-400 leading-none pointer-events-none"
+          >
+            {{ formatSmartTime(resultTimestamps.get(result.uuid)!) }}
+          </span>
+          <component :is="getPlugin(result.toolName)?.previewComponent" v-if="getPlugin(result.toolName)?.previewComponent" :result="result" />
+          <span v-else class="block truncate p-2">{{ result.title || result.toolName }}</span>
+        </div>
       </div>
     </div>
   </div>
@@ -74,6 +88,10 @@ defineProps<{
   sessionRoleIcon?: string;
   layoutMode: LayoutMode;
   showRightSidebar: boolean;
+  /** Output arrived while the reader was scrolled away from the bottom.
+   *  Drives the "new messages" affordance — deliberately NOT just "scrolled
+   *  up", which would claim new output when the reader is only re-reading. */
+  hasNewMessages?: boolean;
 }>();
 
 function sourceLabel(result: ToolResultComplete): string {
@@ -93,6 +111,7 @@ const emit = defineEmits<{
   activate: [];
   "update:layoutMode": [mode: LayoutMode];
   "toggle-right-sidebar": [];
+  "jump-to-latest": [];
 }>();
 
 const root = ref<HTMLDivElement | null>(null);

--- a/src/composables/useChatScroll.ts
+++ b/src/composables/useChatScroll.ts
@@ -12,23 +12,41 @@ import { computed, nextTick, ref, watch, type ComputedRef, type Ref } from "vue"
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { useStickToBottom } from "./useStickToBottom";
 
+/** Whether the "new messages" badge should be showing after the result list
+ *  changed. Pure so the three cases it has to keep apart stay testable:
+ *  output appended while detached (news), the list swapped for another
+ *  session's (not news, and the previous session's badge doesn't carry over),
+ *  and output arriving while the reader is following (nothing to announce). */
+export function nextBadgeState(input: { previous: boolean; switchedSession: boolean; detached: boolean }): boolean {
+  if (input.switchedSession) return false;
+  return input.detached ? true : input.previous;
+}
+
+/** Changes both on new results AND on streaming updates to the last text card
+ *  (which appends in place, leaving length stable). The session id leads so a
+ *  reader of the key can tell "output was appended" from "the whole list was
+ *  swapped for another session's" — both change the tail, only one is news. */
+export function scrollKey(sessionId: string | null, list: ToolResultComplete[]): string {
+  const last = list[list.length - 1];
+  return `${sessionId ?? ""}|${list.length}:${last?.uuid ?? ""}:${last?.message?.length ?? 0}`;
+}
+
+const sessionOfKey = (key: string): string => key.slice(0, key.indexOf("|"));
+
 export function useChatScroll<T extends { focus: () => void }>(opts: {
   sessionSidebarRef: Ref<{ root: HTMLDivElement | null } | null>;
   toolResults: ComputedRef<ToolResultComplete[]>;
   isRunning: ComputedRef<boolean>;
   chatInputRef: Ref<T | null>;
+  /** Id of the session the list currently shows. Used only to tell a session
+   *  switch apart from an append — omit it and both look identical. */
+  sessionId?: ComputedRef<string | null>;
 }) {
-  const { sessionSidebarRef, toolResults, isRunning, chatInputRef } = opts;
+  const { sessionSidebarRef, toolResults, isRunning, chatInputRef, sessionId } = opts;
 
   const chatListRef = computed(() => sessionSidebarRef.value?.root ?? null);
   const { stuck, resume } = useStickToBottom(chatListRef);
-  // Key that changes both on new results AND on streaming updates to
-  // the last text card (which appends in place, leaving length stable).
-  const latestResultScrollKey = computed(() => {
-    const list = toolResults.value;
-    const last = list[list.length - 1];
-    return `${list.length}:${last?.uuid ?? ""}:${last?.message?.length ?? 0}`;
-  });
+  const latestResultScrollKey = computed(() => scrollKey(sessionId?.value ?? null, toolResults.value));
 
   function scrollChatToBottom(options: { force?: boolean } = {}): void {
     if (!options.force && !stuck.value) return;
@@ -45,15 +63,15 @@ export function useChatScroll<T extends { focus: () => void }>(opts: {
     chatInputRef.value?.focus();
   }
 
-  // Whether output actually arrived while the reader was detached. `stuck`
-  // alone can't answer that: scrolling up to re-read something old also
-  // un-sticks, and a "new messages" badge shown then would be claiming
-  // something that never happened. Set on append-while-detached, cleared the
-  // moment following is re-armed.
+  // See `nextBadgeState` for why `stuck` alone can't drive this.
   const hasNewWhileDetached = ref(false);
 
-  watch(latestResultScrollKey, () => {
-    if (!stuck.value) hasNewWhileDetached.value = true;
+  watch(latestResultScrollKey, (next, previous) => {
+    hasNewWhileDetached.value = nextBadgeState({
+      previous: hasNewWhileDetached.value,
+      switchedSession: sessionOfKey(next) !== sessionOfKey(previous),
+      detached: !stuck.value,
+    });
     scrollChatToBottom();
   });
   watch(stuck, (isStuck) => {

--- a/src/composables/useChatScroll.ts
+++ b/src/composables/useChatScroll.ts
@@ -8,7 +8,7 @@
 // read (#2179). A run starting is treated as an explicit user action
 // (they just sent something), so that one re-arms and jumps.
 
-import { computed, nextTick, watch, type ComputedRef, type Ref } from "vue";
+import { computed, nextTick, ref, watch, type ComputedRef, type Ref } from "vue";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { useStickToBottom } from "./useStickToBottom";
 
@@ -45,7 +45,20 @@ export function useChatScroll<T extends { focus: () => void }>(opts: {
     chatInputRef.value?.focus();
   }
 
-  watch(latestResultScrollKey, () => scrollChatToBottom());
+  // Whether output actually arrived while the reader was detached. `stuck`
+  // alone can't answer that: scrolling up to re-read something old also
+  // un-sticks, and a "new messages" badge shown then would be claiming
+  // something that never happened. Set on append-while-detached, cleared the
+  // moment following is re-armed.
+  const hasNewWhileDetached = ref(false);
+
+  watch(latestResultScrollKey, () => {
+    if (!stuck.value) hasNewWhileDetached.value = true;
+    scrollChatToBottom();
+  });
+  watch(stuck, (isStuck) => {
+    if (isStuck) hasNewWhileDetached.value = false;
+  });
   watch(isRunning, (running) => {
     if (running) {
       resume();
@@ -55,5 +68,13 @@ export function useChatScroll<T extends { focus: () => void }>(opts: {
     }
   });
 
-  return { scrollChatToBottom, focusChatInput, stuckToBottom: stuck };
+  /** Jump to the newest output and re-arm following. Bound to the "new
+   *  messages" affordance — the reader scrolled away, so `scrollChatToBottom`
+   *  alone would no-op on the `stuck` gate; resume first, then force. */
+  function jumpToLatest(): void {
+    resume();
+    scrollChatToBottom({ force: true });
+  }
+
+  return { scrollChatToBottom, focusChatInput, jumpToLatest, stuckToBottom: stuck, hasNewWhileDetached };
 }

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -149,6 +149,7 @@ const deMessages = {
     qrHint: "Oder scanne diesen QR-Code mit der Handykamera.",
   },
   sidebarHeader: {
+    newMessages: "Neue Nachrichten",
     home: "Zum neuesten Chat",
     toolCallHistory: "Tool-Aufrufverlauf",
     settings: "Einstellungen",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -167,6 +167,7 @@ const enMessages = {
     qrHint: "Or scan this QR code with your phone's camera.",
   },
   sidebarHeader: {
+    newMessages: "New messages",
     home: "Go to latest chat",
     toolCallHistory: "Tool call history",
     settings: "Settings",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -152,6 +152,7 @@ const esMessages = {
     qrHint: "O escanea este código QR con la cámara de tu teléfono.",
   },
   sidebarHeader: {
+    newMessages: "Mensajes nuevos",
     home: "Ir al chat más reciente",
     toolCallHistory: "Historial de llamadas a herramientas",
     settings: "Ajustes",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -147,6 +147,7 @@ const frMessages = {
     qrHint: "Ou scannez ce code QR avec l'appareil photo de votre téléphone.",
   },
   sidebarHeader: {
+    newMessages: "Nouveaux messages",
     home: "Aller à la dernière conversation",
     toolCallHistory: "Historique des appels d'outils",
     settings: "Paramètres",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -152,6 +152,7 @@ const jaMessages = {
     qrHint: "スマートフォンのカメラでこの QR コードを読み取っても開けます。",
   },
   sidebarHeader: {
+    newMessages: "新着",
     home: "最新のチャットに移動",
     toolCallHistory: "ツール呼び出し履歴",
     settings: "設定",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -153,6 +153,7 @@ const koMessages = {
     qrHint: "휴대폰 카메라로 이 QR 코드를 스캔해도 열 수 있습니다.",
   },
   sidebarHeader: {
+    newMessages: "새 메시지",
     home: "최신 채팅으로 이동",
     toolCallHistory: "도구 호출 기록",
     settings: "설정",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -147,6 +147,7 @@ const ptBRMessages = {
     qrHint: "Ou escaneie este código QR com a câmera do seu celular.",
   },
   sidebarHeader: {
+    newMessages: "Novas mensagens",
     home: "Ir para o chat mais recente",
     toolCallHistory: "Histórico de chamadas de ferramentas",
     settings: "Configurações",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -148,6 +148,7 @@ const zhMessages = {
     qrHint: "也可以用手机相机扫描此二维码打开。",
   },
   sidebarHeader: {
+    newMessages: "新消息",
     home: "前往最新对话",
     toolCallHistory: "工具调用历史",
     settings: "设置",

--- a/test/composables/test_useChatScroll.ts
+++ b/test/composables/test_useChatScroll.ts
@@ -258,3 +258,74 @@ describe("useChatScroll — sticky bottom (#2179)", () => {
     assert.ok(writes.length > writesAfterSend, "following should be re-armed after a send");
   });
 });
+
+// The "new messages" affordance (#2181). The badge claims new output arrived,
+// so it must not appear merely because the reader scrolled up — someone
+// re-reading an old card has no new messages, and saying otherwise is a lie
+// the UI can't take back. These pin the distinction.
+describe("useChatScroll — new-messages affordance", () => {
+  function mountScroll(sessionId: string, scrollEl: HTMLDivElement) {
+    const session = reactive(createEmptySession(sessionId, "general"));
+    const sessionSidebarRef = ref<{ root: HTMLDivElement | null } | null>({ root: scrollEl });
+    const toolResults = computed<ToolResultComplete[]>(() => session.toolResults);
+    const isRunning = computed(() => false);
+    const chatInputRef = ref<{ focus: () => void } | null>(null);
+    const handle = useChatScroll({ sessionSidebarRef, toolResults, isRunning, chatInputRef });
+    return { session, handle };
+  }
+
+  it("stays false while the reader sits at the bottom", async () => {
+    const { el } = makeFakeScrollEl();
+    const { session, handle } = mountScroll("n1", el);
+
+    pushResult(session, makeTextResult("Hello", "assistant"));
+    await nextTick();
+    await nextTick();
+
+    assert.equal(handle.hasNewWhileDetached.value, false, "following the stream is not 'new messages'");
+  });
+
+  it("stays false when the reader scrolls up and nothing new arrives", async () => {
+    // The condition the issue proposed (`!stuck`) would flip to true here.
+    const { el, userScrollTo } = makeFakeScrollEl({ scrollHeight: 5000, clientHeight: 1000 });
+    const { handle } = mountScroll("n2", el);
+
+    userScrollTo(0);
+    await nextTick();
+
+    assert.equal(handle.stuckToBottom.value, false, "scrolling up detaches");
+    assert.equal(handle.hasNewWhileDetached.value, false, "detached alone must not claim new messages");
+  });
+
+  it("turns true when output arrives while detached", async () => {
+    const { el, userScrollTo } = makeFakeScrollEl({ scrollHeight: 5000, clientHeight: 1000 });
+    const { session, handle } = mountScroll("n3", el);
+
+    userScrollTo(0);
+    await nextTick();
+    pushResult(session, makeTextResult("While you were away", "assistant"));
+    await nextTick();
+    await nextTick();
+
+    assert.equal(handle.hasNewWhileDetached.value, true);
+  });
+
+  it("clears once following is re-armed by jumpToLatest", async () => {
+    const { el, userScrollTo } = makeFakeScrollEl({ scrollHeight: 5000, clientHeight: 1000 });
+    const { session, handle } = mountScroll("n4", el);
+
+    userScrollTo(0);
+    await nextTick();
+    pushResult(session, makeTextResult("While you were away", "assistant"));
+    await nextTick();
+    await nextTick();
+    assert.equal(handle.hasNewWhileDetached.value, true);
+
+    handle.jumpToLatest();
+    await nextTick();
+    await nextTick();
+
+    assert.equal(handle.stuckToBottom.value, true, "jumpToLatest re-arms following");
+    assert.equal(handle.hasNewWhileDetached.value, false, "and retires the badge");
+  });
+});

--- a/test/composables/test_useChatScroll.ts
+++ b/test/composables/test_useChatScroll.ts
@@ -310,8 +310,39 @@ describe("useChatScroll — new-messages affordance", () => {
     assert.equal(handle.hasNewWhileDetached.value, true);
   });
 
-  it("clears once following is re-armed by jumpToLatest", async () => {
+  it("does not fire when switching sessions while detached", async () => {
+    // Regression (Codex review on #2291): the watched key is derived from the
+    // last result, so swapping the whole list on a session switch changes it
+    // too. Treating that as "output arrived" is the exact false positive this
+    // affordance exists to avoid — the other session's backlog is not news.
     const { el, userScrollTo } = makeFakeScrollEl({ scrollHeight: 5000, clientHeight: 1000 });
+    const sessionA = reactive(createEmptySession("swap-a", "general"));
+    const sessionB = reactive(createEmptySession("swap-b", "general"));
+    pushResult(sessionA, makeTextResult("from A", "assistant"));
+    pushResult(sessionB, makeTextResult("from B", "assistant"));
+
+    const active = ref<typeof sessionA>(sessionA);
+    const handle = useChatScroll({
+      sessionSidebarRef: ref<{ root: HTMLDivElement | null } | null>({ root: el }),
+      toolResults: computed<ToolResultComplete[]>(() => active.value.toolResults),
+      isRunning: computed(() => false),
+      chatInputRef: ref<{ focus: () => void } | null>(null),
+      sessionId: computed(() => active.value.id),
+    });
+
+    userScrollTo(0);
+    await nextTick();
+    assert.equal(handle.stuckToBottom.value, false, "reader is detached");
+
+    active.value = sessionB;
+    await nextTick();
+    await nextTick();
+
+    assert.equal(handle.hasNewWhileDetached.value, false, "a session switch is not new output");
+  });
+
+  it("clears once following is re-armed by jumpToLatest", async () => {
+    const { el, userScrollTo, writes } = makeFakeScrollEl({ scrollHeight: 5000, clientHeight: 1000 });
     const { session, handle } = mountScroll("n4", el);
 
     userScrollTo(0);
@@ -327,5 +358,8 @@ describe("useChatScroll — new-messages affordance", () => {
 
     assert.equal(handle.stuckToBottom.value, true, "jumpToLatest re-arms following");
     assert.equal(handle.hasNewWhileDetached.value, false, "and retires the badge");
+    // Re-arming is only half of it — the user pressed a button that says
+    // "jump", so the list must actually be at the bottom (CodeRabbit on #2291).
+    assert.equal(writes[writes.length - 1], 5000, "jumpToLatest scrolls to the bottom");
   });
 });


### PR DESCRIPTION
## Summary

#2179 の sticky-bottom で「読んでいる最中に流れない」は出荷済みですが、**追従が外れた後に戻る導線がありません**でした。新着があっても静かに積まれ、ユーザーが自分で最下部までスクロールする必要がありました。

チャットリストに重ねたピル型ボタンで、押すと最下部へジャンプ＋追従を再開します。i18n は **8ロケール lockstep** で追加済み（issue が「見送った主因」としていた部分）。

Closes #2181 の 1（未読アフォーダンス）。2（ビューポート上側の高さ変化補正）は引き続きオープンです。

## Items to Confirm / Review

**issue の提案した表示条件から意図的に変更しています。**

> 表示条件はこの `stuckToBottom` の反転で足りる

これだと**古いメッセージを読み返すために上へスクロールしただけ**でもバッジが出て、**来ていない新着を「新着」と主張**します。ラベルが嘘になるため、「**追従が外れている間に実際に出力が来たか**」を追跡する形にしました（追従再開で即クリア）。

この区別はテストで固定しています。**変異テストで検証済み**: issue の `!stuck` 条件に戻すと「上へスクロールしただけでは新着と主張しない」テストだけが赤くなり（`true !== false`）、他4件は緑のままでした。

その他:

- `jumpToLatest` は **resume してから scroll** します。`scrollChatToBottom` は `stuck` でゲートされているので、force だけでは no-op になるためです。
- **オーバーレイはスクロール領域の外側**に置きました。ボタンがカードと一緒にスクロールしないためと、`tool-results-scroll > div.cursor-pointer` の**直下子関係を壊さない**ためです（`internal-link-navigation.spec.ts` など3つの e2e がこのセレクタに依存しています）。
- 表示先は**チャットリストのみ**です。issue が挙げていた「StackView にも出すか」「件数を出すか（3件の新着）」は未対応で、必要なら別途。

## テスト

`test/composables/test_useChatScroll.ts` に4件追加（最下部追従中は出ない / 上スクロールのみでは出ない / 離脱中の到着で出る / `jumpToLatest` で消える）。同ファイル **13件 全pass**。

`vue-tsc` / `tsc -p test` / `yarn lint` / `yarn build` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “New messages” indicator in the session sidebar when new chat content arrives while you’re viewing older messages.
  - Added a “jump to latest” quick action that returns you to the newest messages and resumes automatic scrolling.
  - Added localized “New messages” text across all supported languages.

- **Bug Fixes**
  - Prevented incorrect “new messages” signaling when switching sessions while you’re detached from the latest chat.
  - Ensured the indicator clears after you jump back to the latest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->