### PR TITLE
refactor(server): extract retry policy, skill events and message decoration from agent.ts

### DIFF
--- a/server/agent/messageDecorate.ts
+++ b/server/agent/messageDecorate.ts
@@ -1,0 +1,41 @@
+// Decoration applied to a user message strictly on the path to Claude. The
+// persisted (jsonl) and broadcast (UI) message stays the raw text — anything
+// added here is invisible to the user and only teaches the model about
+// attachments and prior-session context.
+
+import { prependJournalPointer } from "./prompt.js";
+
+const UNSAFE_MARKER_CHARS_RE = /[\r\n\]]/;
+
+type MarkerPosition = "prepend" | "append";
+
+/** Marker telling the model which workspace files are attached / selected for
+ *  this turn. One `[Attached file: <path>]` line per path so multi-file flows
+ *  (e.g. paste one image + pick another → "combine these") surface every path
+ *  to the model — `editImages` then receives the full list in `imagePaths`.
+ *  The system prompt teaches the model how to interpret them.
+ *
+ *  `position` defaults to `"prepend"`; a command turn passes `"append"` so the
+ *  leading `/` stays at position 0 (see `decorateMessageForCli`). */
+export function withAttachedFileMarker(message: string, attachedFilePaths: string[], position: MarkerPosition = "prepend"): string {
+  const safePaths = attachedFilePaths.filter((relPath) => !UNSAFE_MARKER_CHARS_RE.test(relPath));
+  if (safePaths.length === 0) return message;
+  const markerLines = safePaths.map((relPath) => `[Attached file: ${relPath}]`).join("\n");
+  return position === "append" ? `${message}\n\n${markerLines}` : `${markerLines}\n\n${message}`;
+}
+
+/** Build the CLI-bound message, preserving a leading `/` as the CLI's
+ *  deterministic slash-command trigger. The CLI resolves a slash command only
+ *  when the message STARTS with `/name`; any decoration pushed in front of it
+ *  silently drops skill selection back to the model guessing from descriptions
+ *  (#2134). A slash-first message is a command, not an open question — so skip
+ *  the journal pointer (prior-session context is irrelevant to a command) and
+ *  append the file markers after the body instead of prepending. Detection is
+ *  position-0 `startsWith` to match the CLI; the collection UI and manual entry
+ *  emit no leading whitespace. */
+export function decorateMessageForCli(args: { message: string; workspaceDir: string; attachedFilePaths: string[]; resumed: boolean }): string {
+  const { message, workspaceDir, attachedFilePaths, resumed } = args;
+  const isCommand = message.startsWith("/");
+  const base = resumed || isCommand ? message : prependJournalPointer(message, workspaceDir);
+  return withAttachedFileMarker(base, attachedFilePaths, isCommand ? "append" : "prepend");
+}

--- a/server/agent/retryPolicy.ts
+++ b/server/agent/retryPolicy.ts
@@ -1,0 +1,69 @@
+// Which agent-stream failures are worth replaying, and how long to wait first.
+//
+// Both recoveries replay a turn that produced no side effects — a stale
+// `--resume` id is rejected before the CLI runs anything, and the broker race
+// fails on the FIRST tool call. Widening either predicate to an error that can
+// fire mid-turn would replay work that already happened.
+
+import { isStaleSessionError } from "./resumeFailover.js";
+import { isMcpBrokerNotReadyError } from "./mcpBrokerFailover.js";
+import { ONE_SECOND_MS } from "../utils/time.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
+
+/** How long to let the broker finish connecting before replaying (#2057). The
+ *  forensics show it comes up a few seconds after losing the race. */
+export const BROKER_RECONNECT_WAIT_MS = 3 * ONE_SECOND_MS;
+
+export type RecoveryKind = "stale" | "broker" | null;
+
+export interface RetryBudgets {
+  stale: number;
+  broker: number;
+}
+
+interface StreamEvent {
+  type: string;
+  message?: unknown;
+}
+
+/** A stale `--resume` failure we can recover from by retrying without it: an
+ *  error event carrying a stale-session message, while failover budget remains. */
+export function isRecoverableStaleSession(event: StreamEvent, attemptsRemaining: number): boolean {
+  return attemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message);
+}
+
+/** The transient MCP-broker startup race (#2057): the CLI couldn't resolve the
+ *  permission-prompt tool because the broker's stdio wasn't connected when the
+ *  first tool call ran. Recoverable by waiting a moment and replaying the SAME
+ *  turn — nothing executed, the first tool call is what failed. Hits fresh
+ *  sessions too, so it carries a budget independent of `--resume`. */
+export function isRecoverableBrokerNotReady(event: StreamEvent, attemptsRemaining: number): boolean {
+  return attemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isMcpBrokerNotReadyError(event.message);
+}
+
+/** Classify an event into the one recovery it warrants, or null. Budgets are
+ *  consumed by the caller after a successful classification. */
+export function detectRecovery(event: StreamEvent, budgets: RetryBudgets): RecoveryKind {
+  if (isRecoverableStaleSession(event, budgets.stale)) return "stale";
+  if (isRecoverableBrokerNotReady(event, budgets.broker)) return "broker";
+  return null;
+}
+
+/** Abortable wait so a stop during the retry pause ends promptly instead of
+ *  spawning a doomed replay after the user already cancelled. */
+export const abortableSleep = (delayMs: number, signal: AbortSignal): Promise<void> =>
+  new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(resolve, delayMs);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });

--- a/server/agent/skillEvents.ts
+++ b/server/agent/skillEvents.ts
@@ -1,0 +1,71 @@
+// Skill bookkeeping over the raw agent event stream (#1218).
+//
+// When the model invokes a skill, Claude CLI emits the SKILL.md body as the
+// next assistant text. Both halves of that expectation live here: tracking
+// which skill is pending, and splitting the body back off the reply once the
+// text arrives. The structural signal is `toolName === "Skill"` + the `skill`
+// slug in args — not a body-text prefix — so it survives any rewording Claude
+// CLI does to the synthesised body.
+
+import { isRecord } from "../utils/types.js";
+
+export interface PendingSkill {
+  skillName: string;
+  toolUseId: string;
+}
+
+/** Only the slot the state machine reads and mutates, so callers with a bigger
+ *  event context (and tests with none) can both pass something valid. */
+export interface PendingSkillSlot {
+  pendingSkill: PendingSkill | null;
+}
+
+export function updatePendingSkillOnToolCall(ctx: PendingSkillSlot, event: { toolName: string; toolUseId: string; args: unknown }): void {
+  // Any non-Skill tool_call resets the pending state. Without this, a Skill
+  // call followed by another tool (Bash, etc.) without a body flush in between
+  // would leak `pendingSkill` and miscategorise a later unrelated assistant
+  // text as a skill body.
+  if (event.toolName !== "Skill") {
+    ctx.pendingSkill = null;
+    return;
+  }
+  const skillSlug = isRecord(event.args) && typeof event.args.skill === "string" ? event.args.skill : null;
+  ctx.pendingSkill = skillSlug ? { skillName: skillSlug, toolUseId: event.toolUseId } : null;
+}
+
+// The Skill's own tool_call_result (matching toolUseId) carries "Launching
+// skill: X" content; the body follows in the next text event so we leave
+// `pendingSkill` set. A tool_call_result with any OTHER id means a different
+// tool's result interleaved before the body — sequence broken, clear the flag
+// so a later unrelated assistant text isn't mis-tagged as `type: "skill"`.
+export function updatePendingSkillOnToolCallResult(ctx: PendingSkillSlot, toolUseId: string): void {
+  if (ctx.pendingSkill && toolUseId !== ctx.pendingSkill.toolUseId) {
+    ctx.pendingSkill = null;
+  }
+}
+
+/** Split an assistant text that carries a skill body from the model's own reply
+ *  to the user (Claude CLI concatenates them when the SKILL.md ends with a
+ *  "respond now" instruction).
+ *
+ *  Structural split: the SKILL.md body is on disk, available via
+ *  `discoverSkills()`. We find that exact substring inside the message and
+ *  slice. The optional `ARGUMENTS: <user_input>` line that Claude CLI appends
+ *  when the SKILL.md uses `{{ARGUMENTS}}` is consumed too. Returns the whole
+ *  message as `skillPart` with empty `replyPart` when `skillBody` is empty
+ *  (discovery missed) or not found verbatim (Claude CLI changed the inlining
+ *  format — the caller's canary log warn fires in that case). */
+export function splitSkillAndReply(message: string, skillBody: string | null): { skillPart: string; replyPart: string } {
+  if (!skillBody) return { skillPart: message, replyPart: "" };
+  const trimmedBody = skillBody.trim();
+  if (!trimmedBody) return { skillPart: message, replyPart: "" };
+  const idx = message.indexOf(trimmedBody);
+  if (idx < 0) return { skillPart: message, replyPart: "" };
+  let cursor = idx + trimmedBody.length;
+  // Skip the optional ARGUMENTS line + trailing whitespace.
+  const argMatch = /^\s*ARGUMENTS:[^\n]*\n?/.exec(message.slice(cursor));
+  if (argMatch) cursor += argMatch[0].length;
+  const skillPart = message.slice(0, cursor).trimEnd();
+  const replyPart = message.slice(cursor).replace(/^\s+/, "");
+  return { skillPart, replyPart };
+}

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -18,11 +18,11 @@ import {
 } from "../../utils/files/session-io.js";
 import { getRole } from "../../workspace/roles.js";
 import { runAgent } from "../../agent/index.js";
-import { prependJournalPointer } from "../../agent/prompt.js";
 import { notifyTaskFinished } from "../../agent/webPush.js";
-import { buildTranscriptPreamble, isStaleSessionError } from "../../agent/resumeFailover.js";
-import { isMcpBrokerNotReadyError } from "../../agent/mcpBrokerFailover.js";
-import { ONE_SECOND_MS } from "../../utils/time.js";
+import { buildTranscriptPreamble } from "../../agent/resumeFailover.js";
+import { abortableSleep, BROKER_RECONNECT_WAIT_MS, detectRecovery, type RecoveryKind, type RetryBudgets } from "../../agent/retryPolicy.js";
+import { splitSkillAndReply, updatePendingSkillOnToolCall, updatePendingSkillOnToolCallResult, type PendingSkill } from "../../agent/skillEvents.js";
+import { decorateMessageForCli } from "../../agent/messageDecorate.js";
 import { getOrCreateSession, beginRun, endRun, cancelRun, pushSessionEvent, pushToolResult, getActiveSessionIds } from "../../events/session-store/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
 import { discoverSkills } from "../../workspace/skills/discovery.js";
@@ -586,51 +586,6 @@ async function loadImageFromPath(value: string, declaredMimeType: string | undef
   }
 }
 
-// Drop any path containing characters that could break the
-// `[Attached file: <path>]` marker line (`\r`, `\n`) or its closing
-// bracket (`]`). Such a path would let request-controlled input
-// inject arbitrary text into the privileged prompt prefix — the
-// path itself reaches the marker straight from the request body.
-// CodeRabbit review on #1045.
-const UNSAFE_MARKER_CHARS_RE = /[\r\n\]]/;
-
-type MarkerPosition = "prepend" | "append";
-
-/** Marker attached to the LLM-bound user message that tells the
- *  model which workspace files are attached / selected for this turn.
- *  One `[Attached file: <path>]` line is emitted per path so multi-
- *  file flows (e.g. paste one image + pick another → "combine these")
- *  surface every path to the model — `editImages` then receives the
- *  full list in `imagePaths`. The user's persisted (jsonl) and
- *  broadcast (UI) message is the raw text — these marker lines are
- *  added strictly on the path to Claude. The system prompt teaches
- *  the model how to interpret them.
- *
- *  `position` defaults to `"prepend"`; a command turn passes `"append"`
- *  so the leading `/` stays at position 0 (see `decorateMessageForCli`). */
-export function withAttachedFileMarker(message: string, attachedFilePaths: string[], position: MarkerPosition = "prepend"): string {
-  const safePaths = attachedFilePaths.filter((relPath) => !UNSAFE_MARKER_CHARS_RE.test(relPath));
-  if (safePaths.length === 0) return message;
-  const markerLines = safePaths.map((relPath) => `[Attached file: ${relPath}]`).join("\n");
-  return position === "append" ? `${message}\n\n${markerLines}` : `${markerLines}\n\n${message}`;
-}
-
-/** Build the CLI-bound message, preserving a leading `/` as the CLI's
- *  deterministic slash-command trigger. The CLI resolves a slash command
- *  only when the message STARTS with `/name`; any decoration pushed in
- *  front of it silently drops skill selection back to the model guessing
- *  from descriptions (#2134). A slash-first message is a command, not an
- *  open question — so skip the journal pointer (prior-session context is
- *  irrelevant to a command) and append the file markers after the body
- *  instead of prepending. Detection is position-0 `startsWith` to match
- *  the CLI; the collection UI and manual entry emit no leading whitespace. */
-export function decorateMessageForCli(args: { message: string; workspaceDir: string; attachedFilePaths: string[]; resumed: boolean }): string {
-  const { message, workspaceDir, attachedFilePaths, resumed } = args;
-  const isCommand = message.startsWith("/");
-  const base = resumed || isCommand ? message : prependJournalPointer(message, workspaceDir);
-  return withAttachedFileMarker(base, attachedFilePaths, isCommand ? "append" : "prepend");
-}
-
 // ── HTTP route ──────────────────────────────────────────────────────
 
 // HTTP route body — used by the Vue UI only. Paste/drop and sidebar
@@ -709,56 +664,10 @@ interface EventContext {
   resultsFilePath: string;
   toolArgsCache: ReturnType<typeof createArgsCache>;
   textAccumulator: string[];
-  pendingSkill: { skillName: string; toolUseId: string } | null;
+  pendingSkill: PendingSkill | null;
 }
 
 const CLAUDE_CLI_SKILL_BODY_PREFIX = "Base directory for this skill: ";
-
-// #1218 — state-machine helpers for `pendingSkill`. Extracted so
-// `handleAgentEvent` stays under the cognitive-complexity cap and so
-// the leak-fix logic (Codex iter-2: clear on mismatched
-// tool_call_result + claudeSessionId, in addition to the iter-1
-// "non-Skill tool_call" clear) lives in one named place.
-//
-// When the model invokes a skill, Claude CLI emits the SKILL.md
-// body as the next assistant text. We track that expectation here:
-// the structural signal is `toolName === "Skill"` + `args.skill`
-// slug, not a body-text prefix, so it survives any rewording Claude
-// CLI might do to the synthesised body.
-
-// Narrow the helpers to only the slot they read/mutate so the
-// state-machine unit test in test/agent/ doesn't have to construct
-// the full `EventContext` (chatSessionId, resultsFilePath, etc).
-type PendingSkillSlot = Pick<EventContext, "pendingSkill">;
-
-function updatePendingSkillOnToolCall(ctx: PendingSkillSlot, event: { toolName: string; toolUseId: string; args: unknown }): void {
-  // Any non-Skill tool_call resets the pending state. Without this,
-  // a Skill call followed by another tool (Bash, etc.) without a
-  // body flush in between would leak `pendingSkill` and miscategorise
-  // a later unrelated assistant text as a skill body.
-  if (event.toolName !== "Skill") {
-    ctx.pendingSkill = null;
-    return;
-  }
-  const skillSlug = isRecord(event.args) && typeof event.args.skill === "string" ? event.args.skill : null;
-  ctx.pendingSkill = skillSlug ? { skillName: skillSlug, toolUseId: event.toolUseId } : null;
-}
-
-// The Skill's own tool_call_result (matching toolUseId) carries
-// "Launching skill: X" content; the body follows in the next text
-// event so we leave `pendingSkill` set. A tool_call_result with any
-// OTHER id means a different tool's result interleaved before the
-// body — sequence broken, clear the flag so a later unrelated
-// assistant text isn't mis-tagged as `type: "skill"`.
-function updatePendingSkillOnToolCallResult(ctx: PendingSkillSlot, toolUseId: string): void {
-  if (ctx.pendingSkill && toolUseId !== ctx.pendingSkill.toolUseId) {
-    ctx.pendingSkill = null;
-  }
-}
-
-// Exported for the unit test in test/agent/test_pendingSkillStateMachine.ts.
-export const _updatePendingSkillOnToolCallForTest = updatePendingSkillOnToolCall;
-export const _updatePendingSkillOnToolCallResultForTest = updatePendingSkillOnToolCallResult;
 
 // Returns true if the event was handled "out of band" (no pub-sub
 // broadcast, no jsonl append). Right now only `claudeSessionId`
@@ -947,40 +856,6 @@ async function resolveSkillMetadata(skillName: string): Promise<SkillMetadata> {
   }
 }
 
-/** Split the consolidated text Claude CLI emits after a `Skill`
- *  tool_call into the SKILL.md body half (synthesised by Claude CLI)
- *  and the LLM's actual reply half. Without this, the entire blob
- *  gets tagged `type: "skill"`, so when the user collapses the
- *  card their actual reply disappears (#1218 reproducer: shiritori
- *  skill, where the body ends with a "respond now" instruction and
- *  the LLM's first move is concatenated to the same text block).
- *
- *  Structural split: the SKILL.md body is on disk, available via
- *  `discoverSkills()`. We find that exact substring inside the
- *  message and slice. Optional `ARGUMENTS: <user_input>` line that
- *  Claude CLI appends when the SKILL.md uses `{{ARGUMENTS}}` is
- *  consumed too. Returns the whole message as `skillPart` with
- *  empty `replyPart` when `skillBody` is empty (discovery missed)
- *  or not found verbatim (Claude CLI changed the inlining format —
- *  the canary log warn fires in that case). */
-function splitSkillAndReply(message: string, skillBody: string | null): { skillPart: string; replyPart: string } {
-  if (!skillBody) return { skillPart: message, replyPart: "" };
-  const trimmedBody = skillBody.trim();
-  if (!trimmedBody) return { skillPart: message, replyPart: "" };
-  const idx = message.indexOf(trimmedBody);
-  if (idx < 0) return { skillPart: message, replyPart: "" };
-  let cursor = idx + trimmedBody.length;
-  // Skip the optional ARGUMENTS line + trailing whitespace.
-  const argMatch = /^\s*ARGUMENTS:[^\n]*\n?/.exec(message.slice(cursor));
-  if (argMatch) cursor += argMatch[0].length;
-  const skillPart = message.slice(0, cursor).trimEnd();
-  const replyPart = message.slice(cursor).replace(/^\s+/, "");
-  return { skillPart, replyPart };
-}
-
-// Exported for the unit test in test/agent/test_skillBodySplit.ts.
-export const _splitSkillAndReplyForTest = splitSkillAndReply;
-
 // Helper kept commented (instead of deleted) alongside the
 // publishNotification call below — see the duplicate-notification
 // comment near `endRun()` in `runAgentInBackground` for context.
@@ -1001,59 +876,6 @@ export const _splitSkillAndReplyForTest = splitSkillAndReply;
 //       return `✅ ${roleName} finished`;
 //   }
 // }
-
-/** A stale `--resume` failure we can recover from by retrying without it: an
- *  error event carrying a stale-session message, while failover budget remains. */
-function isRecoverableStaleSession(event: { type: string; message?: unknown }, attemptsRemaining: number): boolean {
-  return attemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isStaleSessionError(event.message);
-}
-
-/** The transient MCP-broker startup race (#2057): the CLI couldn't resolve the
- *  permission-prompt tool because the broker's stdio wasn't connected when the
- *  first tool call ran. Recoverable by waiting a moment and replaying the SAME
- *  turn — nothing executed, the first tool call is what failed. Hits fresh
- *  sessions too, so it carries a budget independent of `--resume`. */
-function isRecoverableBrokerNotReady(event: { type: string; message?: unknown }, attemptsRemaining: number): boolean {
-  return attemptsRemaining > 0 && event.type === EVENT_TYPES.error && typeof event.message === "string" && isMcpBrokerNotReadyError(event.message);
-}
-
-// How long to let the broker finish connecting before replaying (#2057). The
-// forensics show it comes up a few seconds after losing the race.
-const BROKER_RECONNECT_WAIT_MS = 3 * ONE_SECOND_MS;
-
-// Abortable wait so a stop during the retry pause ends promptly instead of
-// spawning a doomed replay after the user already cancelled.
-const abortableSleep = (delayMs: number, signal: AbortSignal): Promise<void> =>
-  new Promise((resolve) => {
-    if (signal.aborted) {
-      resolve();
-      return;
-    }
-    const timer = setTimeout(resolve, delayMs);
-    signal.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
-  });
-
-type RecoveryKind = "stale" | "broker" | null;
-
-interface RetryBudgets {
-  stale: number;
-  broker: number;
-}
-
-/** Classify an event into the one recovery it warrants, or null. Budgets are
- *  consumed by the caller after a successful classification. */
-function detectRecovery(event: { type: string; message?: unknown }, budgets: RetryBudgets): RecoveryKind {
-  if (isRecoverableStaleSession(event, budgets.stale)) return "stale";
-  if (isRecoverableBrokerNotReady(event, budgets.broker)) return "broker";
-  return null;
-}
 
 // Clear the stale `--resume` id and rebuild the turn from the local jsonl so the
 // replay carries context without the bad session id (#211). Returns the message

--- a/test/agent/test_pendingSkillStateMachine.ts
+++ b/test/agent/test_pendingSkillStateMachine.ts
@@ -6,13 +6,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
-  _updatePendingSkillOnToolCallForTest as onToolCall,
-  _updatePendingSkillOnToolCallResultForTest as onToolCallResult,
-} from "../../server/api/routes/agent.js";
-
-interface MinimalCtx {
-  pendingSkill: { skillName: string; toolUseId: string } | null;
-}
+  updatePendingSkillOnToolCall as onToolCall,
+  updatePendingSkillOnToolCallResult as onToolCallResult,
+  type PendingSkillSlot as MinimalCtx,
+} from "../../server/agent/skillEvents.js";
 
 describe("pendingSkill state machine (#1218)", () => {
   it("Skill tool_call sets pendingSkill with skillName + toolUseId", () => {

--- a/test/agent/test_retryPolicy.ts
+++ b/test/agent/test_retryPolicy.ts
@@ -1,0 +1,125 @@
+// A replay re-runs a turn, so a false positive here re-executes side effects
+// the user already paid for. These tests pin the two things that keep that from
+// happening: only `error` events with the exact CLI phrasing classify, and a
+// budget of zero refuses regardless of the message.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { detectRecovery, isRecoverableBrokerNotReady, isRecoverableStaleSession, abortableSleep } from "../../server/agent/retryPolicy.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
+
+const STALE_MESSAGE = "No conversation found with session ID abc-123";
+const BROKER_MESSAGE = "MCP tool mcp__mulmoclaude__handlePermission (passed via --permission-prompt-tool) not found. Available MCP tools: x";
+
+const errorEvent = (message: unknown) => ({ type: EVENT_TYPES.error, message });
+
+describe("isRecoverableStaleSession", () => {
+  it("classifies a stale-resume error while budget remains", () => {
+    assert.equal(isRecoverableStaleSession(errorEvent(STALE_MESSAGE), 1), true);
+  });
+
+  it("refuses once the budget is exhausted", () => {
+    assert.equal(isRecoverableStaleSession(errorEvent(STALE_MESSAGE), 0), false);
+  });
+
+  it("refuses a negative budget", () => {
+    assert.equal(isRecoverableStaleSession(errorEvent(STALE_MESSAGE), -1), false);
+  });
+
+  it("refuses a non-error event carrying the same text", () => {
+    assert.equal(isRecoverableStaleSession({ type: EVENT_TYPES.text, message: STALE_MESSAGE }, 1), false);
+  });
+
+  it("refuses an unrelated error message", () => {
+    assert.equal(isRecoverableStaleSession(errorEvent("ENOENT: no such file or directory"), 1), false);
+  });
+
+  it("refuses an empty message", () => {
+    assert.equal(isRecoverableStaleSession(errorEvent(""), 1), false);
+  });
+
+  it("refuses a non-string message", () => {
+    assert.equal(isRecoverableStaleSession(errorEvent({ text: STALE_MESSAGE }), 1), false);
+    assert.equal(isRecoverableStaleSession(errorEvent(undefined), 1), false);
+    assert.equal(isRecoverableStaleSession(errorEvent(null), 1), false);
+  });
+});
+
+describe("isRecoverableBrokerNotReady", () => {
+  it("classifies the broker startup race while budget remains", () => {
+    assert.equal(isRecoverableBrokerNotReady(errorEvent(BROKER_MESSAGE), 1), true);
+  });
+
+  it("refuses once the budget is exhausted", () => {
+    assert.equal(isRecoverableBrokerNotReady(errorEvent(BROKER_MESSAGE), 0), false);
+  });
+
+  // The phrase must match contiguously: a replay re-runs work, so an unrelated
+  // "not found" plus a stray flag echo elsewhere in stderr must not trigger it.
+  it("refuses a scattered near-match", () => {
+    const scattered = "--permission-prompt-tool was passed. Later: skill 'foo' not found.";
+    assert.equal(isRecoverableBrokerNotReady(errorEvent(scattered), 1), false);
+  });
+
+  it("refuses a bare not-found error", () => {
+    assert.equal(isRecoverableBrokerNotReady(errorEvent("HTTP 404 not found"), 1), false);
+  });
+
+  it("refuses a non-error event carrying the same text", () => {
+    assert.equal(isRecoverableBrokerNotReady({ type: EVENT_TYPES.status, message: BROKER_MESSAGE }, 1), false);
+  });
+});
+
+describe("detectRecovery", () => {
+  it("returns null when nothing matches", () => {
+    assert.equal(detectRecovery(errorEvent("some other failure"), { stale: 3, broker: 3 }), null);
+  });
+
+  it("returns the kind that matches", () => {
+    assert.equal(detectRecovery(errorEvent(STALE_MESSAGE), { stale: 1, broker: 1 }), "stale");
+    assert.equal(detectRecovery(errorEvent(BROKER_MESSAGE), { stale: 1, broker: 1 }), "broker");
+  });
+
+  // Budgets are independent: the broker race hits fresh sessions too, so
+  // spending the `--resume` budget must not disable broker recovery.
+  it("still detects the broker race with the stale budget exhausted", () => {
+    assert.equal(detectRecovery(errorEvent(BROKER_MESSAGE), { stale: 0, broker: 1 }), "broker");
+  });
+
+  it("still detects a stale session with the broker budget exhausted", () => {
+    assert.equal(detectRecovery(errorEvent(STALE_MESSAGE), { stale: 1, broker: 0 }), "stale");
+  });
+
+  it("returns null when both budgets are exhausted", () => {
+    assert.equal(detectRecovery(errorEvent(STALE_MESSAGE), { stale: 0, broker: 0 }), null);
+    assert.equal(detectRecovery(errorEvent(BROKER_MESSAGE), { stale: 0, broker: 0 }), null);
+  });
+});
+
+// Racing against a deadline is what actually distinguishes "the abort cut the
+// wait short" from "the test just awaited a 60s timer" — a bare await passes
+// either way.
+const PATIENCE_MS = 500;
+const raceAgainstDeadline = (waited: Promise<void>): Promise<string> =>
+  Promise.race([waited.then(() => "slept"), new Promise<string>((resolve) => setTimeout(() => resolve("deadline"), PATIENCE_MS))]);
+
+describe("abortableSleep", () => {
+  it("resolves after the delay when never aborted", async () => {
+    assert.equal(await raceAgainstDeadline(abortableSleep(1, new AbortController().signal)), "slept");
+  });
+
+  // A stop during the pause must end it promptly rather than let a doomed
+  // replay spawn after the user already cancelled.
+  it("resolves immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    assert.equal(await raceAgainstDeadline(abortableSleep(60_000, controller.signal)), "slept");
+  });
+
+  it("resolves as soon as the signal aborts mid-wait", async () => {
+    const controller = new AbortController();
+    const waited = abortableSleep(60_000, controller.signal);
+    controller.abort();
+    assert.equal(await raceAgainstDeadline(waited), "slept");
+  });
+});

--- a/test/agent/test_skillBodySplit.ts
+++ b/test/agent/test_skillBodySplit.ts
@@ -7,7 +7,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { _splitSkillAndReplyForTest as splitSkillAndReply } from "../../server/api/routes/agent.js";
+import { splitSkillAndReply } from "../../server/agent/skillEvents.js";
 
 const SKILL_BODY =
   "# Shiritori (しりとり)\n\nPlay a round of しりとり with the user.\n\nStart the game now — output just your opening word + the prompt line, nothing else first.";

--- a/test/api/routes/test_agentAttachedFileMarker.ts
+++ b/test/api/routes/test_agentAttachedFileMarker.ts
@@ -8,7 +8,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { withAttachedFileMarker } from "../../../server/api/routes/agent.ts";
+import { withAttachedFileMarker } from "../../../server/agent/messageDecorate.ts";
 
 describe("withAttachedFileMarker", () => {
   it("returns the original message when no paths are attached", () => {

--- a/test/api/routes/test_decorateMessageForCli.ts
+++ b/test/api/routes/test_decorateMessageForCli.ts
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
-import { decorateMessageForCli } from "../../../server/api/routes/agent.ts";
+import { decorateMessageForCli } from "../../../server/agent/messageDecorate.ts";
 import { WORKSPACE_FILES } from "../../../server/workspace/paths.js";
 
 let workspace: string;


### PR DESCRIPTION
## Summary

`server/api/routes/agent.ts`（1353行）から純粋ロジックを 3 モジュールに切り出し、未テストだったリトライ判定にテストを付けた。**挙動の変更なし。** agent.ts は 1353 → 1177 行。

| 新モジュール | 中身 |
|---|---|
| `server/agent/retryPolicy.ts` | どのストリーム失敗を再生する価値があるか（`isRecoverableStaleSession` / `isRecoverableBrokerNotReady` / `detectRecovery` / `abortableSleep` / 予算・待機定数） |
| `server/agent/skillEvents.ts` | `pendingSkill` 状態機械 + SKILL.md 本文と返信の分割 |
| `server/agent/messageDecorate.ts` | `withAttachedFileMarker` / `decorateMessageForCli` |

**`_ForTest` 別名 3 本を削除できた。** `_updatePendingSkillOnToolCallForTest` / `_updatePendingSkillOnToolCallResultForTest` / `_splitSkillAndReplyForTest` は、テストが 1353 行のルートファイル内の純関数に届かないので**テスト専用の別名を輸出して無理やり届かせていた**もの。別ファイルに出したことで普通に import できるようになり、別名ごと消えた。

## Items to Confirm / Review

1. **リトライ判定にテストが 1 本も無かった点** — ここが無テストなのは最悪の場所で、誤検知するとターンが再生され、ユーザーが既に支払った副作用が再実行される。`test/agent/test_retryPolicy.ts` に 20 ケース追加した。とくに見てほしいのは「散らばった near-match を拒否する」ケース: `--permission-prompt-tool` の文字列と `not found` が stderr の別々の場所にあるだけでは再生してはいけない（無関係な 404 やファイル欠損で再生が走る）。
2. **mutation 検証済み** — 予算ガードを外すと 3 件、broker 判定が stale の予算を読むようにすると 1 件、abort リスナーを消すと 1 件が赤くなることを確認した。テストが実際に壊れたコードを捕まえることの確認。
3. **`startChat` / `spawnSystemWorker` は意図的に動かしていない** — `server/agent/mcp-tools/spawnBackgroundChat.ts` が `await import("../../api/routes/agent.js")` という動的 import で循環を回避しており、これらを `server/agent/` 配下に移すと循環が実体化する。今回は周辺の純関数だけを抜いた。
4. **`EventContext.pendingSkill` の所有権**はこれまで通り `runAgentInBackground` 側に残っている。`skillEvents.ts` が公開するのは「そのスロットだけを読み書きする関数」で、状態そのものは持たない。

## User Prompt

> server/index.tsってまだファイル大きくない？

（大きいファイルの棚卸しを依頼され、対象を index.ts / files.ts / agent.ts / collections.ts に広げて調査 → issue 化 → 実装、という流れ）

> 調査終わったらそれぞれのファイルで、対応が必要なものは個別にissue化しておいて。

> よくわからないけど、まず綺麗にできるならそれをしてほしい

## 実装の進め方

棚卸しで 3 ファイル共通の所見が出た: **「テストから届かせるためだけに `_ForTest` alias や deps seam を生やして純関数をルートファイルに留めている」** 状態（`agent.ts` の `_ForTest` 3 本、`collections.ts` の `createViewDataImageHandler`、`files.ts` の `UploadWriteDeps`）。いずれも「本来別ファイルにあるべき」のマーカーなので、そこから着手した。

#2292 の残り（イベント処理層 → `eventSink.ts`、`runPostTurnSideEffects` → `postTurn.ts`、添付正規化 → `attachments.ts`）は、実行ライフサイクルに触れてリスクが上がるため別 PR にする。

## Test plan

- `yarn test` — 7576 件 pass / 0 fail
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — すべて green
- 移動したテストが新しい import 経路で通ることを確認（`test_skillBodySplit` / `test_pendingSkillStateMachine` / `test_decorateMessageForCli` / `test_agentAttachedFileMarker`）

Refs #2292

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of attached file paths in messages.
  * Preserved slash-command detection when adding message context.
  * Added automatic recovery for stale sessions and temporary broker startup failures.
  * Retry delays now stop promptly when a run is cancelled.
  * Improved tracking and separation of skill-related responses.

* **Tests**
  * Added coverage for retry recovery, cancellation, skill tracking, and message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->