### PR TITLE
test: cover the mulmoscript helpers and the view-query concurrency guard

### DIFF
--- a/test/api/routes/test_collectionsViewQueryConcurrency.ts
+++ b/test/api/routes/test_collectionsViewQueryConcurrency.ts
@@ -1,0 +1,134 @@
+// The sibling per-minute limiter has tests; this in-flight cap shipped without
+// any. It is the guard that keeps a runaway dashboard loop from stacking
+// concurrent full-file DuckDB scans, and every failure mode is a leak: a slot
+// that never comes back permanently 429s the collection, a slot released twice
+// lets the cap drift upward without bound.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Request, Response, NextFunction } from "express";
+import { makeViewQueryConcurrencyGuard } from "../../../server/api/routes/collections.js";
+
+/** Captures the `close` handler so a test can end the request explicitly —
+ *  that is the only thing that returns a slot. */
+function fakeRes() {
+  let statusCode = 0;
+  let body: unknown;
+  const closeHandlers: (() => void)[] = [];
+  const res = {
+    status: (code: number) => {
+      statusCode = code;
+      return res;
+    },
+    json: (payload: unknown) => {
+      body = payload;
+      return res;
+    },
+    once: (event: string, handler: () => void) => {
+      if (event === "close") closeHandlers.push(handler);
+      return res;
+    },
+  } as unknown as Response;
+  return { res, status: () => statusCode, body: () => body, close: () => closeHandlers.forEach((handler) => handler()) };
+}
+
+const request = (slug?: string) => ({ params: slug === undefined ? {} : { slug } }) as unknown as Request<{ slug?: string }>;
+
+function call(guard: ReturnType<typeof makeViewQueryConcurrencyGuard>, slug?: string) {
+  const { res, status, body, close } = fakeRes();
+  let nexted = false;
+  guard(request(slug), res, (() => {
+    nexted = true;
+  }) as NextFunction);
+  return { nexted, status: status(), body: body(), close };
+}
+
+describe("makeViewQueryConcurrencyGuard", () => {
+  it("passes requests up to the cap", () => {
+    const guard = makeViewQueryConcurrencyGuard(2);
+    assert.equal(call(guard, "tasks").nexted, true);
+    assert.equal(call(guard, "tasks").nexted, true);
+  });
+
+  it("429s the request that exceeds the cap", () => {
+    const guard = makeViewQueryConcurrencyGuard(1);
+    call(guard, "tasks");
+    const over = call(guard, "tasks");
+    assert.equal(over.nexted, false);
+    assert.equal(over.status, 429);
+    assert.deepEqual(over.body, { error: "too many concurrent queries for this collection — retry shortly" });
+  });
+
+  it("returns the slot when the response closes", () => {
+    const guard = makeViewQueryConcurrencyGuard(1);
+    const first = call(guard, "tasks");
+    assert.equal(call(guard, "tasks").nexted, false);
+    first.close();
+    assert.equal(call(guard, "tasks").nexted, true);
+  });
+
+  // `close` also fires on a mid-request client disconnect, and nothing stops a
+  // second emit. A second release must be a no-op — otherwise it frees a slot
+  // another still-running scan is holding and the cap drifts upward.
+  //
+  // This needs a second request in flight to detect: with the counter already
+  // at zero, a stray release is absorbed by the `?? 1` fallback and looks
+  // identical to the correct behaviour.
+  it("releases a slot exactly once even if close fires twice", () => {
+    const guard = makeViewQueryConcurrencyGuard(2);
+    const stillRunning = call(guard, "tasks");
+    const finished = call(guard, "tasks");
+    finished.close();
+    finished.close();
+    assert.equal(call(guard, "tasks").nexted, true, "the finished request's slot comes back");
+    assert.equal(call(guard, "tasks").nexted, false, "the still-running request's slot must NOT have been freed too");
+    stillRunning.close();
+  });
+
+  it("counts each slug independently", () => {
+    const guard = makeViewQueryConcurrencyGuard(1);
+    assert.equal(call(guard, "tasks").nexted, true);
+    assert.equal(call(guard, "notes").nexted, true);
+    assert.equal(call(guard, "tasks").nexted, false);
+  });
+
+  // A 429 never took a slot, so it must not release one either — otherwise a
+  // burst of rejections would free capacity the in-flight scans still hold.
+  it("does not let a rejected request return a slot", () => {
+    const guard = makeViewQueryConcurrencyGuard(1);
+    const held = call(guard, "tasks");
+    const rejected = call(guard, "tasks");
+    assert.equal(rejected.nexted, false);
+    rejected.close();
+    assert.equal(call(guard, "tasks").nexted, false);
+    held.close();
+    assert.equal(call(guard, "tasks").nexted, true);
+  });
+
+  it("treats a missing slug param as its own bucket rather than throwing", () => {
+    const guard = makeViewQueryConcurrencyGuard(1);
+    assert.equal(call(guard).nexted, true);
+    assert.equal(call(guard).nexted, false);
+    assert.equal(call(guard, "tasks").nexted, true);
+  });
+
+  // Every request is over the cap, so none should ever reach the handler.
+  it("rejects everything when the cap is zero", () => {
+    const guard = makeViewQueryConcurrencyGuard(0);
+    const first = call(guard, "tasks");
+    assert.equal(first.nexted, false);
+    assert.equal(first.status, 429);
+  });
+
+  it("recovers full capacity after all in-flight requests close", () => {
+    const guard = makeViewQueryConcurrencyGuard(2);
+    const firstScan = call(guard, "tasks");
+    const secondScan = call(guard, "tasks");
+    assert.equal(call(guard, "tasks").nexted, false);
+    firstScan.close();
+    secondScan.close();
+    assert.equal(call(guard, "tasks").nexted, true);
+    assert.equal(call(guard, "tasks").nexted, true);
+    assert.equal(call(guard, "tasks").nexted, false);
+  });
+});

--- a/test/api/routes/test_collectionsViewQueryConcurrency.ts
+++ b/test/api/routes/test_collectionsViewQueryConcurrency.ts
@@ -6,30 +6,45 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import type { Request, Response, NextFunction } from "express";
 import { makeViewQueryConcurrencyGuard } from "../../../server/api/routes/collections.js";
 
-/** Captures the `close` handler so a test can end the request explicitly —
- *  that is the only thing that returns a slot. */
+/** A real `EventEmitter` backs the `close` event rather than a handler array.
+ *  Express's `Response` IS an emitter, so `once` must actually deregister after
+ *  the first emit — a stub that re-invokes handlers on every emit lets a test
+ *  assert behaviour that cannot happen in production (Codex review). */
+function closeEvents() {
+  const emitter = new EventEmitter();
+  return {
+    subscribeOnce: (event: string, handler: () => void): void => void emitter.once(event, handler),
+    emitClose: (): void => void emitter.emit("close"),
+  };
+}
+
+interface ResponseState {
+  statusCode: number;
+  body: unknown;
+}
+
 function fakeRes() {
-  let statusCode = 0;
-  let body: unknown;
-  const closeHandlers: (() => void)[] = [];
+  const state: ResponseState = { statusCode: 0, body: undefined };
+  const events = closeEvents();
   const res = {
     status: (code: number) => {
-      statusCode = code;
+      state.statusCode = code;
       return res;
     },
     json: (payload: unknown) => {
-      body = payload;
+      state.body = payload;
       return res;
     },
     once: (event: string, handler: () => void) => {
-      if (event === "close") closeHandlers.push(handler);
+      events.subscribeOnce(event, handler);
       return res;
     },
   } as unknown as Response;
-  return { res, status: () => statusCode, body: () => body, close: () => closeHandlers.forEach((handler) => handler()) };
+  return { res, status: () => state.statusCode, body: () => state.body, close: events.emitClose };
 }
 
 const request = (slug?: string) => ({ params: slug === undefined ? {} : { slug } }) as unknown as Request<{ slug?: string }>;
@@ -67,14 +82,16 @@ describe("makeViewQueryConcurrencyGuard", () => {
     assert.equal(call(guard, "tasks").nexted, true);
   });
 
-  // `close` also fires on a mid-request client disconnect, and nothing stops a
-  // second emit. A second release must be a no-op — otherwise it frees a slot
-  // another still-running scan is holding and the cap drifts upward.
+  // `close` can be emitted more than once (response finish, then a client
+  // disconnect). One emitted event must free exactly one slot, or the cap
+  // drifts upward and lets extra concurrent scans through. Two mechanisms
+  // uphold that together: `once` deregisters the listener, and the guard's own
+  // `released` latch. Neither alone is asserted here — the invariant is.
   //
-  // This needs a second request in flight to detect: with the counter already
-  // at zero, a stray release is absorbed by the `?? 1` fallback and looks
-  // identical to the correct behaviour.
-  it("releases a slot exactly once even if close fires twice", () => {
+  // Detecting a violation needs a second request still in flight: with the
+  // counter already at zero, a stray release is absorbed by the guard's `?? 1`
+  // fallback and looks identical to the correct behaviour.
+  it("frees exactly one slot even if close is emitted twice", () => {
     const guard = makeViewQueryConcurrencyGuard(2);
     const stillRunning = call(guard, "tasks");
     const finished = call(guard, "tasks");

--- a/test/plugins/mulmoscript/test_helpers.ts
+++ b/test/plugins/mulmoscript/test_helpers.ts
@@ -1,0 +1,199 @@
+// First tests for the mulmoscript plugin, which shipped with none. These cover
+// the pure helpers the View leans on to decide what to render, what to
+// re-fetch, and whether the deck editor mounts at all — the decisions that go
+// wrong silently (a beat that never renders, a movie probe that never fires)
+// rather than throwing.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  beatMayHaveMovie,
+  getMissingCharacterKeys,
+  isAllSlideDeck,
+  isSameScript,
+  shouldAutoRenderBeat,
+  validateBeatJSON,
+  type SafeParseSchema,
+} from "../../../packages/plugins/mulmoscript-plugin/src/vue/helpers.ts";
+
+const AUTO_RENDER_TYPES = ["slide", "chart", "html_tailwind"] as const;
+
+describe("shouldAutoRenderBeat", () => {
+  // Characters must be rendered first so character-using beats can reference
+  // them — auto-rendering ahead of that produces beats missing their cast.
+  it("refuses every beat when the script has characters", () => {
+    assert.equal(shouldAutoRenderBeat({ image: { type: "slide" } }, true, AUTO_RENDER_TYPES), false);
+  });
+
+  it("accepts an auto-render type when there are no characters", () => {
+    assert.equal(shouldAutoRenderBeat({ image: { type: "slide" } }, false, AUTO_RENDER_TYPES), true);
+  });
+
+  it("refuses a type outside the auto-render list", () => {
+    assert.equal(shouldAutoRenderBeat({ image: { type: "imagePrompt" } }, false, AUTO_RENDER_TYPES), false);
+  });
+
+  it("refuses a beat with no image, no type, or a non-string type", () => {
+    assert.equal(shouldAutoRenderBeat({}, false, AUTO_RENDER_TYPES), false);
+    assert.equal(shouldAutoRenderBeat({ image: {} }, false, AUTO_RENDER_TYPES), false);
+    assert.equal(shouldAutoRenderBeat({ image: { type: undefined } }, false, AUTO_RENDER_TYPES), false);
+  });
+
+  it("refuses everything when the auto-render list is empty", () => {
+    assert.equal(shouldAutoRenderBeat({ image: { type: "slide" } }, false, []), false);
+  });
+});
+
+describe("getMissingCharacterKeys", () => {
+  it("returns keys with neither an image nor an in-flight render", () => {
+    assert.deepEqual(getMissingCharacterKeys(["alice", "bob"], {}, {}), ["alice", "bob"]);
+  });
+
+  it("drops keys whose image is already loaded", () => {
+    assert.deepEqual(getMissingCharacterKeys(["alice", "bob"], { alice: "data:image/png;base64,AAA" }, {}), ["bob"]);
+  });
+
+  // Re-fetching a key that is mid-render would race the render that is already
+  // running and overwrite the newer result with the older one.
+  it("drops keys currently rendering", () => {
+    assert.deepEqual(getMissingCharacterKeys(["alice", "bob"], {}, { alice: "rendering" }), ["bob"]);
+  });
+
+  it("keeps a key whose render state is a non-rendering status", () => {
+    assert.deepEqual(getMissingCharacterKeys(["alice"], {}, { alice: "failed" }), ["alice"]);
+  });
+
+  // A falsy-but-present image (empty string) means "no image yet", so the key
+  // still needs fetching.
+  it("treats an empty-string image as missing", () => {
+    assert.deepEqual(getMissingCharacterKeys(["alice"], { alice: "" }, {}), ["alice"]);
+  });
+
+  it("returns an empty array for no keys", () => {
+    assert.deepEqual(getMissingCharacterKeys([], { alice: "x" }, {}), []);
+  });
+});
+
+describe("validateBeatJSON", () => {
+  const acceptAll: SafeParseSchema = { safeParse: () => ({ success: true }) };
+  const rejectAll: SafeParseSchema = { safeParse: () => ({ success: false }) };
+
+  it("accepts parseable JSON the schema approves", () => {
+    assert.equal(validateBeatJSON('{"text":"hi"}', acceptAll), true);
+  });
+
+  it("rejects parseable JSON the schema refuses", () => {
+    assert.equal(validateBeatJSON('{"text":"hi"}', rejectAll), false);
+  });
+
+  // A parse failure must not reach the schema at all — an editor mid-keystroke
+  // produces malformed JSON constantly.
+  it("rejects malformed JSON without consulting the schema", () => {
+    let consulted = false;
+    const spy: SafeParseSchema = {
+      safeParse: () => {
+        consulted = true;
+        return { success: true };
+      },
+    };
+    assert.equal(validateBeatJSON("{ not json", spy), false);
+    assert.equal(consulted, false);
+  });
+
+  it("rejects an empty string", () => {
+    assert.equal(validateBeatJSON("", acceptAll), false);
+  });
+
+  // `JSON.parse("null")` succeeds, so the schema — not the parse — is what
+  // must reject it.
+  it("passes a bare null through to the schema", () => {
+    assert.equal(validateBeatJSON("null", acceptAll), true);
+    assert.equal(validateBeatJSON("null", rejectAll), false);
+  });
+});
+
+describe("isSameScript", () => {
+  it("treats structurally identical scripts as the same", () => {
+    assert.equal(isSameScript({ beats: [{ text: "a" }] }, { beats: [{ text: "a" }] }), true);
+  });
+
+  it("treats a changed value as different", () => {
+    assert.equal(isSameScript({ beats: [{ text: "a" }] }, { beats: [{ text: "b" }] }), false);
+  });
+
+  it("treats an added key as different", () => {
+    assert.equal(isSameScript({ beats: [] }, { beats: [], title: "x" }), false);
+  });
+
+  it("treats both undefined as the same, and one undefined as different", () => {
+    assert.equal(isSameScript(undefined, undefined), true);
+    assert.equal(isSameScript(undefined, {}), false);
+  });
+
+  // Documented limitation: the comparison is JSON re-serialisation, so key
+  // ORDER counts. A false "differ" only costs a redundant emit, which is a
+  // no-op downstream — but the behaviour should be pinned, not discovered.
+  it("reports reordered keys as different (serialisation-order sensitivity)", () => {
+    assert.equal(isSameScript({ a: 1, b: 2 }, { b: 2, a: 1 }), false);
+  });
+});
+
+describe("beatMayHaveMovie", () => {
+  it("accepts a beat carrying a moviePrompt", () => {
+    assert.equal(beatMayHaveMovie({ moviePrompt: "pan across the city" }), true);
+  });
+
+  it("accepts an html_tailwind beat with animation enabled", () => {
+    assert.equal(beatMayHaveMovie({ image: { type: "html_tailwind", animation: true } }), true);
+  });
+
+  it("accepts an html_tailwind beat whose animation is an options object", () => {
+    assert.equal(beatMayHaveMovie({ image: { type: "html_tailwind", animation: { duration: 3 } } }), true);
+  });
+
+  it("refuses html_tailwind without animation", () => {
+    assert.equal(beatMayHaveMovie({ image: { type: "html_tailwind" } }), false);
+    assert.equal(beatMayHaveMovie({ image: { type: "html_tailwind", animation: false } }), false);
+  });
+
+  it("refuses a non-html_tailwind beat even with animation set", () => {
+    assert.equal(beatMayHaveMovie({ image: { type: "slide", animation: true } }), false);
+  });
+
+  it("refuses an empty beat and an empty moviePrompt", () => {
+    assert.equal(beatMayHaveMovie({}), false);
+    assert.equal(beatMayHaveMovie({ moviePrompt: "" }), false);
+  });
+});
+
+describe("isAllSlideDeck", () => {
+  const slide = { image: { type: "slide" } };
+
+  it("accepts a script whose beats are all slides", () => {
+    assert.equal(isAllSlideDeck({ beats: [slide, slide] }), true);
+  });
+
+  // Mixed scripts fall through to the per-beat list UI; mounting the deck
+  // editor on them would hide the non-slide beats entirely.
+  it("refuses a mixed script", () => {
+    assert.equal(isAllSlideDeck({ beats: [slide, { image: { type: "imagePrompt" } }] }), false);
+  });
+
+  it("refuses an empty or missing beats array", () => {
+    assert.equal(isAllSlideDeck({ beats: [] }), false);
+    assert.equal(isAllSlideDeck({}), false);
+    assert.equal(isAllSlideDeck({ beats: "not an array" }), false);
+  });
+
+  it("refuses a beat with no image or a non-record image", () => {
+    assert.equal(isAllSlideDeck({ beats: [{}] }), false);
+    assert.equal(isAllSlideDeck({ beats: [{ image: "slide" }] }), false);
+  });
+
+  it("refuses non-record scripts", () => {
+    assert.equal(isAllSlideDeck(null), false);
+    assert.equal(isAllSlideDeck(undefined), false);
+    assert.equal(isAllSlideDeck("script"), false);
+    assert.equal(isAllSlideDeck([slide]), false);
+  });
+});


### PR DESCRIPTION
## Summary

大きいファイルの棚卸しで見つかったテスト空白のうち、**本番コードに一切触れずに埋められるもの**だけを埋めた。差分はテスト 2 ファイルの追加のみ。

| 対象 | 追加 | 状況 |
|---|---|---|
| mulmoscript プラグインの `helpers.ts` 6 関数 | 32 ケース | **テストが 1 本も無かった** |
| `makeViewQueryConcurrencyGuard`（collections.ts） | 9 ケース | export 済み・未テスト。同型の `makeViewActionRateLimiter` は片方だけテスト済み |

## Items to Confirm / Review

1. **mutation 検証で 1 本落とし穴が見つかった。** 「二重 release されないこと」のテストを最初は cap=1 で書いたが、**ガードを削除しても緑のままだった**。カウント 0 での二重解放は `?? 1` フォールバックに吸収されて、正しい挙動と区別がつかない。他の scan が in-flight で残っている配置に書き直して、初めて赤くなるようになった。CLAUDE.md の「新しいテストが、それが守るコードを壊したときに落ちることを確認する」がそのまま効いたケース。

2. **赤くなることを確認した変異一覧**（いずれも修正後に復元済み）:
   - `shouldAutoRenderBeat` の `hasCharacters` ガード削除 → 1 件赤
   - `getMissingCharacterKeys` の `rendering` チェック削除 → 1 件赤
   - `beatMayHaveMovie` の `html_tailwind` 限定を外す → 1 件赤
   - `isAllSlideDeck` の空 `beats` ガード削除 → 1 件赤
   - concurrency guard の二重 release ガード削除 → 1 件赤
   - concurrency guard の slug 別カウントを潰す → 2 件赤
   - concurrency guard の `>=` を `>` に（off-by-one）→ 8 件赤

3. **`isSameScript` のキー順依存を「仕様」としてテストに固定した点**は判断が要るかもしれない。`{a:1,b:2}` と `{b:2,a:1}` を「異なる」と報告する挙動で、実装のコメントが「false positive は余分な emit を 1 回払うだけで無害」と明記しているので、バグではなく既知の割り切りとして pin した。もしこれを直す方針なら、このテストは反転させることになる。

## User Prompt

> まず、テストを追加できるものは追加して。リスクない変更で。
> その次にりすくがないものだけやって。

## なぜこの 2 つだけなのか

他の空白（`entryKey` / wiki のタグ集計 / CollectionView の sort・filter 述語など）は **`.vue` の `script setup` 内にあって export されていない**ため、テストを書くには先に関数を外へ出す必要がある。それは「本番コードに触れない」条件から外れるので、次フェーズに回した。

## Test plan

- `yarn test` — 7597 件 pass / 0 fail（+41 件）
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` — すべて green
- 本番コードの差分ゼロ（`git diff --stat` はテスト 2 ファイルのみ）

Refs #2294 #2299

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for collection view concurrency limits, including request rejection, slot release behavior, per-collection tracking, and full recovery after in-flight responses close.
  * Added coverage for mulmoscript helper functions, including auto-render gating, missing character detection, beat JSON validation, script comparison semantics, movie-capable beat detection, and slide-deck validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->