### PR TITLE
refactor(core): give every collection-schema cross-field rule a name

### DIFF
--- a/packages/core/src/collection/core/schemaRules.ts
+++ b/packages/core/src/collection/core/schemaRules.ts
@@ -1,0 +1,477 @@
+// Cross-field rules for the collection schema — the checks a single field
+// cannot make because it cannot see its siblings.
+//
+// Each one is a named predicate over a parsed-but-unvalidated schema, returning
+// true when the schema is ACCEPTABLE. They live here rather than as anonymous
+// lambdas inside `./schemaZ`'s refine chain so each rule can be unit-tested on
+// its own, and so the chain reads as a list of rule names instead of 500 lines
+// of inline logic.
+//
+// Every rule guards a misconfiguration that would otherwise fail SILENTLY at
+// runtime: a completion bell that never rings, a spawn that fans out forever, a
+// currency that mislabels amounts. That is why they are hard errors at load
+// rather than warnings.
+//
+// The type-only import of `CollectionSchemaInput` is erased at emit, so the
+// module graph stays acyclic at runtime: schemaZ → schemaRules → schema.
+
+import { fieldTextOrNull } from "./fieldText";
+import { isSafeSlug, isSafeRecordId } from "./ids";
+import { paramRefName } from "./mutateAction";
+import { COMPUTED_TYPES } from "./schema";
+import type { CollectionSchemaInput } from "./schemaZ";
+
+type Schema = CollectionSchemaInput;
+type Fields = Schema["fields"];
+
+// The calendar anchor/end fields accept either a date-only or a datetime
+// field (the latter carries the clock for the day view).
+const isDateLike = (type: string | undefined): boolean => type === "date" || type === "datetime";
+
+// `calendarTimeField` parses a free-form time string, so it must name a
+// string-backed field — a number/enum/date column has no time-range text.
+const isTimeStringField = (type: string | undefined): boolean => type === "string" || type === "text";
+
+// Field types that can hold a currency code string. A `currencyField`
+// pointer must resolve to one of these — pointing at a number / boolean
+// / table would never yield a usable ISO code.
+const CODE_FIELD_TYPES = new Set(["string", "text", "enum"]);
+
+const namesStoredField = (fields: Fields, name: string, primaryKey: string): boolean => {
+  const target = fields[name];
+  return target !== undefined && !COMPUTED_TYPES.has(target.type) && name !== primaryKey;
+};
+
+const hasUniqueIds = (entries: { id: string }[] | undefined): boolean =>
+  entries === undefined || new Set(entries.map((entry) => entry.id)).size === entries.length;
+
+// ---------------------------------------------------------------------------
+// Storage declaration
+// ---------------------------------------------------------------------------
+
+/** Exactly one storage declaration: native records need `dataPath`, an external
+ *  data file needs `dataSource`, an alternative backend needs `storage`. Zero
+ *  (nowhere to read) and several (ambiguous which wins) are equally
+ *  meaningless — fail loudly at load instead of picking silently. */
+export function declaresExactlyOneStore(schema: Schema): boolean {
+  return [schema.dataPath, schema.dataSource, schema.storage].filter((declared) => declared !== undefined).length === 1;
+}
+
+// NOTE: `storage` collections support the full write machinery (`spawn` /
+// `completionField` / `triggerField` / `singleton` / `ingest` / mutate actions)
+// — spawn and the watcher reconcilers go through the CollectionStore seam, and
+// a db-file watcher drives their reconciliation (collection-watchers/watcher.ts).
+/** A `dataSource` collection is read-only by definition, so schema-level write
+ *  machinery can never fire: `singleton` pins CREATES, `ingest` REFILLS
+ *  records, `spawn` WRITES successor records. Rejecting them at validation
+ *  kills whole classes of writes before any runtime guard. */
+export function dataSourceDeclaresNoWriteMachinery(schema: Schema): boolean {
+  if (schema.dataSource === undefined) return true;
+  return schema.singleton === undefined && schema.ingest === undefined && schema.spawn === undefined && schema.googleCalendar === undefined;
+}
+
+/** Same rule for declarative host writes: a mutate action writes the record
+ *  it's invoked on, which a read-only collection has no business doing. */
+export function dataSourceDeclaresNoMutateAction(schema: Schema): boolean {
+  if (schema.dataSource !== undefined) {
+    return [...(schema.actions ?? []), ...(schema.collectionActions ?? [])].every((action) => action.kind !== "mutate");
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/** Action ids must be unique so the dispatch route resolves unambiguously. */
+export function actionIdsAreUnique(schema: Schema): boolean {
+  return hasUniqueIds(schema.actions);
+}
+
+/** Collection-level action ids must likewise be unique. */
+export function collectionActionIdsAreUnique(schema: Schema): boolean {
+  return hasUniqueIds(schema.collectionActions);
+}
+
+/** A mutate action's `set` writes real STORED fields: a typo'd key would write
+ *  a stray value forever, a computed/projected field is never persisted, and
+ *  the primaryKey is the filename (renaming is not a mutation). */
+export function mutateSetKeysNameStoredFields(schema: Schema): boolean {
+  return (schema.actions ?? []).every(
+    (action) => action.kind !== "mutate" || Object.keys(action.set).every((key) => namesStoredField(schema.fields, key, schema.primaryKey)),
+  );
+}
+
+/** Every `$params.<name>` reference in `set` must name a declared param — an
+ *  undeclared one would silently no-op the assignment. */
+export function mutateParamRefsAreDeclared(schema: Schema): boolean {
+  return (schema.actions ?? []).every(
+    (action) =>
+      action.kind !== "mutate" ||
+      Object.values(action.set).every((value) => {
+        const ref = paramRefName(value);
+        return ref === null || (action.params ?? {})[ref] !== undefined;
+      }),
+  );
+}
+
+/** A collection-level action has no record to write. */
+export function collectionActionsAreNotMutate(schema: Schema): boolean {
+  return (schema.collectionActions ?? []).every((action) => action.kind !== "mutate");
+}
+
+// ---------------------------------------------------------------------------
+// Singleton, currency
+// ---------------------------------------------------------------------------
+
+/** The singleton value becomes a record id (and thus a `<id>.json` filename),
+ *  so it must satisfy the SAME record-id rule the write path enforces —
+ *  otherwise the create form would lock the primary key to a value the POST
+ *  route then rejects, making the collection impossible to initialize. */
+export function singletonIsAValidRecordId(schema: Schema): boolean {
+  return schema.singleton === undefined || isSafeRecordId(schema.singleton);
+}
+
+// `type` is carried on both levels even though this helper never reads it:
+// without a required property these become weak types, and a field variant that
+// declares no `currencyField` would no longer be assignable.
+interface CurrencyBearingField {
+  type: string;
+  currencyField?: string;
+  of?: Record<string, { type: string; currencyField?: string }>;
+}
+
+// Every `currencyField` declared anywhere in the schema — top-level fields and
+// a table's `of` sub-fields. Sub-field money cells resolve currency against the
+// TOP-LEVEL record (rows carry no currency), so their pointers are validated
+// against the top-level field set too.
+function collectCurrencyFieldRefs(fields: Record<string, CurrencyBearingField>): string[] {
+  const refs: string[] = [];
+  for (const field of Object.values(fields)) {
+    if (typeof field.currencyField === "string" && field.currencyField.length > 0) refs.push(field.currencyField);
+    for (const sub of Object.values(field.of ?? {})) {
+      if (typeof sub.currencyField === "string" && sub.currencyField.length > 0) refs.push(sub.currencyField);
+    }
+  }
+  return refs;
+}
+
+/** A `currencyField` pointer must name a real top-level field that holds a code
+ *  string — a typo (`curreny`) would otherwise pass the per-field check, then
+ *  silently fall back to the literal / USD at render and mislabel amounts. */
+export function currencyFieldRefsNameCodeFields(schema: Schema): boolean {
+  return collectCurrencyFieldRefs(schema.fields).every((name) => CODE_FIELD_TYPES.has(schema.fields[name]?.type ?? ""));
+}
+
+// ---------------------------------------------------------------------------
+// Completion tracking
+// ---------------------------------------------------------------------------
+
+/** The pair must be declared together — one without the other is meaningless:
+ *  the host would either never fire (no done values to compare against) or
+ *  never clear (no field to read).
+ *
+ *  EXCEPTION: when `completionField` names a `flag` field, done ⇔ the flag's
+ *  `where` matches, so `completionDoneValues` carries no information and MUST
+ *  be omitted (declaring it would invite a contradictory second source of
+ *  truth). */
+export function completionPairIsCoherent(schema: Schema): boolean {
+  if (schema.completionField !== undefined && schema.fields[schema.completionField]?.type === "flag") {
+    return schema.completionDoneValues === undefined;
+  }
+  return (schema.completionField === undefined) === (schema.completionDoneValues === undefined);
+}
+
+/** `completionField` must name a real top-level field — a typo would silently
+ *  disable the notification mechanism otherwise. */
+export function completionFieldIsDeclared(schema: Schema): boolean {
+  return schema.completionField === undefined || schema.fields[schema.completionField] !== undefined;
+}
+
+/** A flag named by `completionField` is evaluated against the RAW record — the
+ *  reconciler (and spawn's fallback) read items straight off disk, BEFORE any
+ *  `deriveAll` enrichment — so its `where` may only reference STORED fields. A
+ *  condition over a computed sibling would see an absent key: `ne` matches
+ *  vacuously, every other op reads false, and the bell would clear wrongly /
+ *  never. General (non-completion) flags keep the full vocabulary — the UI
+ *  evaluates them post-enrichment. */
+export function completionFlagReadsOnlyStoredFields(schema: Schema): boolean {
+  const spec = schema.completionField === undefined ? undefined : schema.fields[schema.completionField];
+  if (spec?.type !== "flag") return true;
+  return spec.where.every((cond) =>
+    [cond.field, ...(cond.valueFrom ? [cond.valueFrom.field] : [])].every((name) => {
+      const target = schema.fields[name];
+      return target !== undefined && !COMPUTED_TYPES.has(target.type);
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field pointers
+// ---------------------------------------------------------------------------
+
+/** `displayField`, like `completionField`, must name a real top-level field —
+ *  a typo would silently fall back to the primaryKey forever. */
+export function displayFieldIsDeclared(schema: Schema): boolean {
+  return schema.displayField === undefined || schema.fields[schema.displayField] !== undefined;
+}
+
+/** A field's `when.field` gates its visibility against a sibling's value, so it
+ *  must name a real top-level field — a typo would silently keep the field
+ *  hidden forever (the gate never matches). */
+export function fieldVisibilityGatesNameDeclaredFields(schema: Schema): boolean {
+  return Object.values(schema.fields).every((field) => field.when === undefined || schema.fields[field.when.field] !== undefined);
+}
+
+/** A flag's `where` reads sibling fields (both `cond.field` and a same-record
+ *  `valueFrom.field`), so each must name a real top-level field — a typo would
+ *  silently pin the flag false forever (`ne`: true forever). */
+export function flagConditionsNameDeclaredFields(schema: Schema): boolean {
+  return Object.values(schema.fields).every(
+    (field) =>
+      field.type !== "flag" ||
+      field.where.every(
+        (cond) => schema.fields[cond.field] !== undefined && (cond.valueFrom === undefined || schema.fields[cond.valueFrom.field] !== undefined),
+      ),
+  );
+}
+
+/** An `embed`'s `idField` resolves the target record id from a sibling's value,
+ *  so it must name a real top-level field — and one whose stored value is a
+ *  plain id string. Only `ref` / `string` qualify: the editor writes the picked
+ *  id into that field, so a non-persisted or composite type would either not
+ *  round-trip on save or hold no usable id. */
+export function embedIdFieldsNameIdBearingFields(schema: Schema): boolean {
+  return Object.values(schema.fields).every((field) => {
+    if (field.type !== "embed" || field.idField === undefined) return true;
+    const target = schema.fields[field.idField];
+    return target !== undefined && (target.type === "ref" || target.type === "string");
+  });
+}
+
+/** The sync writes each mapped value into a declared field, and puts the Google
+ *  event id in the primary field — so a map key that names no field (or names
+ *  the primary) would silently drop data or fight the id. */
+export function googleCalendarMapNamesStoredFields(schema: Schema): boolean {
+  if (schema.googleCalendar === undefined) return true;
+  return Object.keys(schema.googleCalendar.map).every((key) => namesStoredField(schema.fields, key, schema.primaryKey));
+}
+
+// ---------------------------------------------------------------------------
+// Toggle projection
+// ---------------------------------------------------------------------------
+
+/** A `toggle` field projects an `enum` field: its `field` must name a real
+ *  top-level enum, and `onValue` / `offValue` must be members of that enum's
+ *  `values` — otherwise toggling would write a value outside the closed set
+ *  (and never appear "checked"). */
+export function togglesProjectValidEnums(schema: Schema): boolean {
+  const { fields } = schema;
+  for (const spec of Object.values(fields)) {
+    if (spec.type !== "toggle") continue;
+    const target = fields[spec.field];
+    if (!target || target.type !== "enum") return false;
+    const allowed = new Set(target.values);
+    if (!allowed.has(spec.onValue) || !allowed.has(spec.offValue)) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+/** `triggerField` requires the completion pair: the time gate only suppresses
+ *  the *completion* bell until the date, and the bell still clears via
+ *  `completionDoneValues`. Without completion there is no bell to gate. */
+export function triggerFieldRequiresCompletion(schema: Schema): boolean {
+  return schema.triggerField === undefined || schema.completionField !== undefined;
+}
+
+/** `triggerField` must name a real `date` field — the gate parses its value as
+ *  `YYYY-MM-DD`; any other type can't be compared to the clock. */
+export function triggerFieldIsADateField(schema: Schema): boolean {
+  return schema.triggerField === undefined || schema.fields[schema.triggerField]?.type === "date";
+}
+
+/** `triggerLeadDays` only means something relative to a trigger date. */
+export function triggerLeadDaysRequiresTriggerField(schema: Schema): boolean {
+  return schema.triggerLeadDays === undefined || schema.triggerField !== undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Spawn
+// ---------------------------------------------------------------------------
+
+/** `spawn` advances `triggerField` to compute the successor's trigger date, so
+ *  the schema must declare one. */
+export function spawnRequiresTriggerField(schema: Schema): boolean {
+  return schema.spawn === undefined || schema.triggerField !== undefined;
+}
+
+/** `spawn.when.field` must name a real top-level field — a typo would silently
+ *  never match. */
+export function spawnWhenFieldIsDeclared(schema: Schema): boolean {
+  return schema.spawn?.when === undefined || schema.fields[schema.spawn.when.field] !== undefined;
+}
+
+/** Every `spawn.carry` entry must name a real top-level field — a typo would
+ *  silently never copy. */
+export function spawnCarryEntriesAreDeclared(schema: Schema): boolean {
+  return (schema.spawn?.carry ?? []).every((name) => schema.fields[name] !== undefined);
+}
+
+/** A successor must NOT be born already matching its own spawn predicate — it
+ *  would re-spawn on its first reconcile, fanning out into an unbounded chain
+ *  of records. The predicate field/values are `spawn.when` when given, else the
+ *  completion-done pair. The successor's value for that field is `set[field]`
+ *  if set, else the carried source value (which matched, by definition, when
+ *  the spawn fired) if carried, else absent (safe). */
+export function spawnSuccessorStartsInert(schema: Schema): boolean {
+  const { spawn } = schema;
+  if (!spawn) return true;
+  const field = spawn.when?.field ?? schema.completionField;
+  const values = spawn.when?.in ?? schema.completionDoneValues;
+  if (!field || !values) return true; // predicate not evaluable — other rules cover this
+  if (spawn.set && Object.prototype.hasOwnProperty.call(spawn.set, field)) {
+    return !values.includes(String(spawn.set[field])); // `set` wins over `carry`
+  }
+  return !(spawn.carry ?? []).includes(field); // carried ⇒ inherits the matching value
+}
+
+/** `spawnSuccessorStartsInert` cannot see through a flag's `where` (the
+ *  predicate would need full record evaluation against `set`/`carry`). So a
+ *  schema whose completion is flag-form may only spawn with an explicit
+ *  `spawn.when` — which that check CAN evaluate. */
+export function flagCompletionSpawnDeclaresWhen(schema: Schema): boolean {
+  return schema.spawn === undefined || schema.spawn.when !== undefined || schema.fields[schema.completionField ?? ""]?.type !== "flag";
+}
+
+// Resolve the field-driven arm of `spawn.every`, or null when spawn is absent
+// or its `every` is the literal arm. Lets each rule below short-circuit
+// (return valid) without re-checking the discriminant.
+function fieldDrivenSpawnEvery(schema: Schema) {
+  const every = schema.spawn?.every;
+  if (!every || !("fromField" in every)) return null;
+  return every;
+}
+
+/** §4.1 — `fromField` must name a real top-level `enum` field. The `map` keys
+ *  are only meaningful against a closed value set, and the field renders as a
+ *  form `<select>`; a non-enum target has no finite values to validate. */
+export function fieldDrivenFromFieldIsEnum(schema: Schema): boolean {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  return schema.fields[driven.fromField]?.type === "enum";
+}
+
+/** §4.2 — `map` keys must EXACTLY cover the enum's `values` (no missing keys —
+ *  a record could pick an unmapped frequency and silently stall; no extra keys
+ *  — a stale map outliving an enum edit). */
+export function fieldDrivenMapCoversValues(schema: Schema): boolean {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  const target = schema.fields[driven.fromField];
+  if (target?.type !== "enum") return true; // §4.1 reports the type error
+  const values = new Set<string>(target.values);
+  const keys = Object.keys(driven.map);
+  return keys.length === values.size && keys.every((key) => values.has(key));
+}
+
+/** §4.5 — `fromField` must reach the successor (via `carry` or `set`);
+ *  otherwise the successor loses its frequency and the NEXT spawn along the
+ *  chain can't resolve an interval, silently halting the recurrence.
+ *
+ *  `set` writes a FIXED value, so it must itself be a key of `map` (else the
+ *  successor is born with an unresolvable driver and `resolveEvery` skips it —
+ *  the exact silent-halt §4.5 exists to prevent). `carry` copies the source's
+ *  own value, which — for a record that matched the spawn — is one of the
+ *  enum's values, all of which `map` covers by §4.2; so a carried driver is
+ *  always resolvable and needs no value check here. */
+export function fieldDrivenFromFieldCarried(schema: Schema): boolean {
+  const driven = fieldDrivenSpawnEvery(schema);
+  if (!driven) return true;
+  const { carry, set } = schema.spawn ?? {};
+  if (set && Object.prototype.hasOwnProperty.call(set, driven.fromField)) {
+    const raw = set[driven.fromField];
+    if (raw === undefined || raw === null || raw === "") return false;
+    const key = fieldTextOrNull(raw);
+    return key !== null && Object.prototype.hasOwnProperty.call(driven.map, key);
+  }
+  return (carry ?? []).includes(driven.fromField);
+}
+
+// ---------------------------------------------------------------------------
+// Calendar
+// ---------------------------------------------------------------------------
+
+/** `calendarField` must name a real `date`/`datetime` field — the calendar view
+ *  parses its value to place records on the month grid (a `datetime` anchor
+ *  also carries the clock for the day view). */
+export function calendarFieldIsDateLike(schema: Schema): boolean {
+  return schema.calendarField === undefined || isDateLike(schema.fields[schema.calendarField]?.type);
+}
+
+/** `calendarEndField` marks the end of a multi-day span, so it only means
+ *  something alongside a start anchor. */
+export function calendarEndFieldRequiresCalendarField(schema: Schema): boolean {
+  return schema.calendarEndField === undefined || schema.calendarField !== undefined;
+}
+
+/** `calendarEndField` must also name a real `date`/`datetime` field — same parse. */
+export function calendarEndFieldIsDateLike(schema: Schema): boolean {
+  return schema.calendarEndField === undefined || isDateLike(schema.fields[schema.calendarEndField]?.type);
+}
+
+/** `calendarTimeField` places records on the day view, so it only means
+ *  something alongside a start anchor. */
+export function calendarTimeFieldRequiresCalendarField(schema: Schema): boolean {
+  return schema.calendarTimeField === undefined || schema.calendarField !== undefined;
+}
+
+/** `calendarTimeField` must name a real top-level field (a free-form time
+ *  string the day view parses). */
+export function calendarTimeFieldIsDeclared(schema: Schema): boolean {
+  return schema.calendarTimeField === undefined || schema.fields[schema.calendarTimeField] !== undefined;
+}
+
+/** …and that field must be string-backed — the day view parses its value as a
+ *  time string, so a number/enum/date column can't drive it. */
+export function calendarTimeFieldIsStringBacked(schema: Schema): boolean {
+  return schema.calendarTimeField === undefined || isTimeStringField(schema.fields[schema.calendarTimeField]?.type);
+}
+
+/** `kanbanField` must name a real `enum` field — the board groups records into
+ *  one column per declared enum value; any other type has no closed set of
+ *  columns to group by. */
+export function kanbanFieldIsAnEnum(schema: Schema): boolean {
+  return schema.kanbanField === undefined || schema.fields[schema.kanbanField]?.type === "enum";
+}
+
+// ---------------------------------------------------------------------------
+// notifyWhen, custom views
+// ---------------------------------------------------------------------------
+
+/** `notifyWhen` narrows the completion bell, so it only means something with
+ *  completion tracking. */
+export function notifyWhenRequiresCompletion(schema: Schema): boolean {
+  return schema.notifyWhen === undefined || schema.completionField !== undefined;
+}
+
+/** `notifyWhen.field` must name a real top-level field. */
+export function notifyWhenFieldIsDeclared(schema: Schema): boolean {
+  return schema.notifyWhen === undefined || schema.fields[schema.notifyWhen.field] !== undefined;
+}
+
+/** Every custom view `id` must be a valid slug — it doubles as the view-mode
+ *  selector key (`custom:<id>`) and the capability-token clamp key, both of
+ *  which expect a path-safe token. */
+export function viewIdsAreSlugs(schema: Schema): boolean {
+  return schema.views === undefined || schema.views.every((view) => isSafeSlug(view.id));
+}
+
+/** Custom view ids must be unique so the selector + token clamp resolve
+ *  unambiguously. */
+export function viewIdsAreUnique(schema: Schema): boolean {
+  return hasUniqueIds(schema.views);
+}

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -16,12 +16,53 @@
 // `CollectionSchemaZ`). Runtime imports here point only at `./schema`'s
 // consts, so the module graph stays acyclic: schemaZ → schema.
 
-import { fieldTextOrNull } from "./fieldText";
 import { z } from "zod";
-import { isSafeSlug, isSafeRecordId } from "./ids";
-import { paramRefName } from "./mutateAction";
+import { isSafeSlug } from "./ids";
 import { isSafeActionTemplatePath, isSafeCustomViewI18nPath, isSafeCustomViewPath } from "./templatePath";
-import { COMPUTED_TYPES, INGEST_KINDS, AGENT_INGEST_KIND, FEED_SCHEDULES } from "./schema";
+import { INGEST_KINDS, AGENT_INGEST_KIND, FEED_SCHEDULES } from "./schema";
+import {
+  actionIdsAreUnique,
+  calendarEndFieldIsDateLike,
+  calendarEndFieldRequiresCalendarField,
+  calendarFieldIsDateLike,
+  calendarTimeFieldIsDeclared,
+  calendarTimeFieldIsStringBacked,
+  calendarTimeFieldRequiresCalendarField,
+  collectionActionIdsAreUnique,
+  collectionActionsAreNotMutate,
+  completionFieldIsDeclared,
+  completionFlagReadsOnlyStoredFields,
+  completionPairIsCoherent,
+  currencyFieldRefsNameCodeFields,
+  dataSourceDeclaresNoMutateAction,
+  dataSourceDeclaresNoWriteMachinery,
+  declaresExactlyOneStore,
+  displayFieldIsDeclared,
+  embedIdFieldsNameIdBearingFields,
+  fieldDrivenFromFieldCarried,
+  fieldDrivenFromFieldIsEnum,
+  fieldDrivenMapCoversValues,
+  fieldVisibilityGatesNameDeclaredFields,
+  flagCompletionSpawnDeclaresWhen,
+  flagConditionsNameDeclaredFields,
+  googleCalendarMapNamesStoredFields,
+  kanbanFieldIsAnEnum,
+  mutateParamRefsAreDeclared,
+  mutateSetKeysNameStoredFields,
+  notifyWhenFieldIsDeclared,
+  notifyWhenRequiresCompletion,
+  singletonIsAValidRecordId,
+  spawnCarryEntriesAreDeclared,
+  spawnRequiresTriggerField,
+  spawnSuccessorStartsInert,
+  spawnWhenFieldIsDeclared,
+  togglesProjectValidEnums,
+  triggerFieldIsADateField,
+  triggerFieldRequiresCompletion,
+  triggerLeadDaysRequiresTriggerField,
+  viewIdsAreSlugs,
+  viewIdsAreUnique,
+} from "./schemaRules";
 
 // ---------------------------------------------------------------------------
 // Shared predicate shapes
@@ -609,153 +650,6 @@ export const DynamicIconSpecZ = z.object({
 });
 
 // ---------------------------------------------------------------------------
-// Schema-level cross-field refine helpers
-// ---------------------------------------------------------------------------
-
-// The calendar anchor/end fields accept either a date-only or a datetime
-// field (the latter carries the clock for the day view).
-const isDateLike = (type: string | undefined): boolean => type === "date" || type === "datetime";
-
-// `calendarTimeField` parses a free-form time string, so it must name a
-// string-backed field — a number/enum/date column has no time-range text.
-const isTimeStringField = (type: string | undefined): boolean => type === "string" || type === "text";
-
-// Field types that can hold a currency code string. A `currencyField`
-// pointer must resolve to one of these — pointing at a number / boolean
-// / table would never yield a usable ISO code.
-const CODE_FIELD_TYPES = new Set(["string", "text", "enum"]);
-
-interface FieldLike {
-  type: string;
-  currencyField?: string;
-  of?: Record<string, { type: string; currencyField?: string }>;
-}
-
-// Every `currencyField` declared anywhere in the schema — top-level
-// fields and a table's `of` sub-fields. Sub-field money cells resolve
-// currency against the TOP-LEVEL record (rows carry no currency), so
-// their pointers are validated against the top-level field set too.
-function collectCurrencyFieldRefs(fields: Record<string, FieldLike>): string[] {
-  const refs: string[] = [];
-  for (const field of Object.values(fields)) {
-    if (typeof field.currencyField === "string" && field.currencyField.length > 0) refs.push(field.currencyField);
-    if (field.of) {
-      for (const sub of Object.values(field.of)) {
-        if (typeof sub.currencyField === "string" && sub.currencyField.length > 0) refs.push(sub.currencyField);
-      }
-    }
-  }
-  return refs;
-}
-
-// True iff every `toggle` field is a valid projection: its `field` names a
-// top-level `enum`, and both `onValue` and `offValue` are members of that
-// enum's closed `values` set.
-function everyToggleProjectsValidEnum(
-  fields: Record<string, { type: string; field?: string; onValue?: string; offValue?: string; values?: readonly string[] }>,
-): boolean {
-  for (const spec of Object.values(fields)) {
-    if (spec.type !== "toggle") continue;
-    const target = spec.field === undefined ? undefined : fields[spec.field];
-    if (!target || target.type !== "enum" || target.values === undefined) return false;
-    const allowed = new Set(target.values);
-    if (spec.onValue === undefined || !allowed.has(spec.onValue)) return false;
-    if (spec.offValue === undefined || !allowed.has(spec.offValue)) return false;
-  }
-  return true;
-}
-
-// True iff a `spawn`'s successor will NOT be born already matching its own
-// predicate (and would therefore re-spawn forever). The effective predicate
-// is `spawn.when` when present, else the completion-done pair. The successor's
-// value for the predicate field is `set[field]` if set, else the carried
-// source value (which matched when the spawn fired) if carried, else absent.
-function spawnSuccessorStartsInert(schema: {
-  spawn?: { when?: { field: string; in: readonly string[] }; carry?: readonly string[]; set?: Record<string, unknown> };
-  completionField?: string;
-  completionDoneValues?: readonly string[];
-}): boolean {
-  const { spawn } = schema;
-  if (!spawn) return true;
-  const field = spawn.when?.field ?? schema.completionField;
-  const values = spawn.when?.in ?? schema.completionDoneValues;
-  if (!field || !values) return true; // predicate not evaluable — other refines cover this
-  if (spawn.set && Object.prototype.hasOwnProperty.call(spawn.set, field)) {
-    return !values.includes(String(spawn.set[field])); // `set` wins over `carry`
-  }
-  return !(spawn.carry ?? []).includes(field); // carried ⇒ inherits the matching value
-}
-
-// The slice of a parsed schema the field-driven `spawn.every` refines read.
-interface FieldDrivenSchemaView {
-  fields: Record<string, { type: string; values?: readonly string[] }>;
-  spawn?: {
-    every?: z.infer<typeof EveryZ>;
-    carry?: readonly string[];
-    set?: Record<string, unknown>;
-  };
-}
-
-// Resolve the field-driven arm of `spawn.every`, or null when spawn is absent
-// or its `every` is the literal arm. Lets each refine below short-circuit
-// (return valid) without re-checking the discriminant. The `"fromField" in`
-// check mirrors `./schema`'s `isFieldDrivenEvery` guard (kept inline here so
-// this module's runtime imports stay limited to `./schema`'s consts).
-function fieldDrivenSpawnEvery(schema: FieldDrivenSchemaView): z.infer<typeof EveryFieldDrivenZ> | null {
-  const every = schema.spawn?.every;
-  if (!every || !("fromField" in every)) return null;
-  return every;
-}
-
-// §4.1 — `fromField` must name a real top-level `enum` field. The `map` keys
-// are only meaningful against a closed value set, and the field renders as a
-// form `<select>`; a non-enum target has no finite values to validate against.
-function fieldDrivenFromFieldIsEnum(schema: FieldDrivenSchemaView): boolean {
-  const driven = fieldDrivenSpawnEvery(schema);
-  if (!driven) return true;
-  return schema.fields[driven.fromField]?.type === "enum";
-}
-
-// §4.2 — `map` keys must EXACTLY cover the enum's `values` (no missing keys —
-// a record could pick an unmapped frequency and silently stall; no extra keys
-// — a stale map outliving an enum edit). Mirrors `everyToggleProjectsValidEnum`'s
-// "author values ⊆ enum's closed set" shape, tightened to set equality.
-function fieldDrivenMapCoversValues(schema: FieldDrivenSchemaView): boolean {
-  const driven = fieldDrivenSpawnEvery(schema);
-  if (!driven) return true;
-  const target = schema.fields[driven.fromField];
-  if (!target || target.type !== "enum" || target.values === undefined) return true; // §4.1 reports the type error
-  const values = new Set(target.values);
-  const keys = Object.keys(driven.map);
-  return keys.length === values.size && keys.every((key) => values.has(key));
-}
-
-// §4.5 — `fromField` must reach the successor (via `carry` or `set`); otherwise
-// the successor loses its frequency and the NEXT spawn along the chain can't
-// resolve an interval, silently halting the recurrence. Hard error, not a warn
-// (see plan §6) — authoring a field-driven spawn without propagating its driver
-// is almost always a mistake.
-//
-// `set` writes a FIXED value, so it must itself be a key of `map` (else the
-// successor is born with an unresolvable driver and `resolveEvery` skips it —
-// the exact silent-halt §4.5 exists to prevent). `carry` copies the source's
-// own value, which — for a record that matched the spawn — is one of the
-// enum's values, all of which `map` covers by §4.2; so a carried driver is
-// always resolvable and needs no value check here.
-function fieldDrivenFromFieldCarried(schema: FieldDrivenSchemaView): boolean {
-  const driven = fieldDrivenSpawnEvery(schema);
-  if (!driven) return true;
-  const { carry, set } = schema.spawn ?? {};
-  if (set && Object.prototype.hasOwnProperty.call(set, driven.fromField)) {
-    const raw = set[driven.fromField];
-    if (raw === undefined || raw === null || raw === "") return false;
-    const key = fieldTextOrNull(raw);
-    return key !== null && Object.prototype.hasOwnProperty.call(driven.map, key);
-  }
-  return (carry ?? []).includes(driven.fromField);
-}
-
-// ---------------------------------------------------------------------------
 // dataSource (external read-only data file)
 // ---------------------------------------------------------------------------
 
@@ -794,93 +688,99 @@ export const StorageZ = z.object({
 // The whole schema
 // ---------------------------------------------------------------------------
 
-const BareCollectionSchemaZ = z
-  .object({
-    title: z.string().min(1),
-    icon: z.string().min(1),
-    // Exactly one of `dataPath` (native JSON-file records), `dataSource`
-    // (external read-only data file), or `storage` (alternative writable
-    // backend) — enforced by a refine below.
-    dataPath: z.string().min(1).optional(),
-    dataSource: DataSourceZ.optional(),
-    storage: StorageZ.optional(),
-    primaryKey: z.string().min(1),
-    // When set, the collection holds at most one record whose primary
-    // key is this exact value (e.g. `me` for the business profile).
-    // The host fixes the create form's primary key to it and hides the
-    // Add button once the record exists.
-    singleton: z.string().trim().min(1).optional(),
-    fields: z.record(z.string(), FieldSpecZ),
-    actions: z.array(ActionSpecZ).optional(),
-    // Collection-level actions (header buttons). Same shape as `actions`;
-    // the `when` predicate is ignored (no record context). The seed
-    // prompt injects a progress summary of all records instead.
-    collectionActions: z.array(ActionSpecZ).optional(),
-    // Completion-tracking pair: when both are set, item-create fires a
-    // notification that clears once `completionField` transitions into
-    // `completionDoneValues`. The two are bound together — declaring
-    // one without the other is a misconfiguration the cross-field
-    // refine below rejects.
-    completionField: z.string().trim().min(1).optional(),
-    completionDoneValues: z.array(z.string().trim().min(1)).min(1).optional(),
-    // Optional human-readable label for the completion notification's
-    // title — names the field whose value reads better than the opaque
-    // primaryKey (e.g. a `name` field). Falls back to the primaryKey
-    // value at render time when unset or empty.
-    displayField: z.string().trim().min(1).optional(),
-    // Time gate: names a `date` field that delays the completion bell
-    // until the clock reaches it. Requires the completion pair (the bell
-    // still clears via the done value). Validated to name a real `date`
-    // field by refines below.
-    triggerField: z.string().trim().min(1).optional(),
-    // Lead time in whole days — fire the bell this many days before
-    // `triggerField`. Non-negative; requires `triggerField` (refine below).
-    triggerLeadDays: z.number().int().min(0).optional(),
-    // Host-driven recurrence; requires `triggerField`. See SpawnZ.
-    spawn: SpawnZ.optional(),
-    // Calendar view anchor: names a `date` field whose value places each
-    // record on a month grid. Validated to name a real `date` field by a
-    // refine below. Optional — the toggle auto-derives from any `date`
-    // field when this is unset.
-    calendarField: z.string().trim().min(1).optional(),
-    // Multi-day span end: a second `date` field the calendar record spans
-    // to. Requires `calendarField`; validated to name a real `date` field.
-    calendarEndField: z.string().trim().min(1).optional(),
-    // Day (time-allocation) view time source: names a string field holding a
-    // free-form time or time-range (e.g. "14:00-17:00", "17:00-", "16:30").
-    // Consulted only when the date fields are date-only. Requires
-    // `calendarField`; validated to name a real field by a refine below.
-    calendarTimeField: z.string().trim().min(1).optional(),
-    // Kanban board group: names an `enum` field whose value buckets each
-    // record into a column. Validated to name a real `enum` field by a
-    // refine below. Optional — the toggle auto-derives from any `enum`
-    // field when this is unset.
-    kanbanField: z.string().trim().min(1).optional(),
-    // Custom (LLM-authored) HTML views. Each renders in a sandboxed iframe
-    // over the records. Optional, so every existing schema validates
-    // unchanged. Ids validated to be valid + unique slugs by refines below.
-    views: z.array(CustomViewZ).optional(),
-    // Completion-bell gate: only notify for records matching this predicate
-    // (e.g. high-priority todos). Reuses the `when` shape; requires
-    // `completionField`; field validated to exist by refines below.
-    notifyWhen: WhenZ.optional(),
-    // Declarative retrieval config. Present only on Feeds (collections in
-    // the `<workspace>/feeds/` registry). Optional, so every existing
-    // skill schema validates unchanged.
-    ingest: IngestZ.optional(),
-    // Declares this collection as the destination of the LLM-free Google
-    // Calendar sync. Optional, so every existing schema validates unchanged.
-    googleCalendar: GoogleCalendarSyncZ.optional(),
-    // Data-driven launcher-icon override. Optional, so every existing
-    // schema validates unchanged; `source` is required within it.
-    dynamicIcon: DynamicIconSpecZ.optional(),
-  })
+/** The schema's SHAPE, before any cross-field rule runs. Named so the rules in
+ *  `./schemaRules` can type their argument against it — they receive whatever
+ *  this parses to, and nothing narrower. */
+const CollectionObjectZ = z.object({
+  title: z.string().min(1),
+  icon: z.string().min(1),
+  // Exactly one of `dataPath` (native JSON-file records), `dataSource`
+  // (external read-only data file), or `storage` (alternative writable
+  // backend) — enforced by a refine below.
+  dataPath: z.string().min(1).optional(),
+  dataSource: DataSourceZ.optional(),
+  storage: StorageZ.optional(),
+  primaryKey: z.string().min(1),
+  // When set, the collection holds at most one record whose primary
+  // key is this exact value (e.g. `me` for the business profile).
+  // The host fixes the create form's primary key to it and hides the
+  // Add button once the record exists.
+  singleton: z.string().trim().min(1).optional(),
+  fields: z.record(z.string(), FieldSpecZ),
+  actions: z.array(ActionSpecZ).optional(),
+  // Collection-level actions (header buttons). Same shape as `actions`;
+  // the `when` predicate is ignored (no record context). The seed
+  // prompt injects a progress summary of all records instead.
+  collectionActions: z.array(ActionSpecZ).optional(),
+  // Completion-tracking pair: when both are set, item-create fires a
+  // notification that clears once `completionField` transitions into
+  // `completionDoneValues`. The two are bound together — declaring
+  // one without the other is a misconfiguration the cross-field
+  // refine below rejects.
+  completionField: z.string().trim().min(1).optional(),
+  completionDoneValues: z.array(z.string().trim().min(1)).min(1).optional(),
+  // Optional human-readable label for the completion notification's
+  // title — names the field whose value reads better than the opaque
+  // primaryKey (e.g. a `name` field). Falls back to the primaryKey
+  // value at render time when unset or empty.
+  displayField: z.string().trim().min(1).optional(),
+  // Time gate: names a `date` field that delays the completion bell
+  // until the clock reaches it. Requires the completion pair (the bell
+  // still clears via the done value). Validated to name a real `date`
+  // field by refines below.
+  triggerField: z.string().trim().min(1).optional(),
+  // Lead time in whole days — fire the bell this many days before
+  // `triggerField`. Non-negative; requires `triggerField` (refine below).
+  triggerLeadDays: z.number().int().min(0).optional(),
+  // Host-driven recurrence; requires `triggerField`. See SpawnZ.
+  spawn: SpawnZ.optional(),
+  // Calendar view anchor: names a `date` field whose value places each
+  // record on a month grid. Validated to name a real `date` field by a
+  // refine below. Optional — the toggle auto-derives from any `date`
+  // field when this is unset.
+  calendarField: z.string().trim().min(1).optional(),
+  // Multi-day span end: a second `date` field the calendar record spans
+  // to. Requires `calendarField`; validated to name a real `date` field.
+  calendarEndField: z.string().trim().min(1).optional(),
+  // Day (time-allocation) view time source: names a string field holding a
+  // free-form time or time-range (e.g. "14:00-17:00", "17:00-", "16:30").
+  // Consulted only when the date fields are date-only. Requires
+  // `calendarField`; validated to name a real field by a refine below.
+  calendarTimeField: z.string().trim().min(1).optional(),
+  // Kanban board group: names an `enum` field whose value buckets each
+  // record into a column. Validated to name a real `enum` field by a
+  // refine below. Optional — the toggle auto-derives from any `enum`
+  // field when this is unset.
+  kanbanField: z.string().trim().min(1).optional(),
+  // Custom (LLM-authored) HTML views. Each renders in a sandboxed iframe
+  // over the records. Optional, so every existing schema validates
+  // unchanged. Ids validated to be valid + unique slugs by refines below.
+  views: z.array(CustomViewZ).optional(),
+  // Completion-bell gate: only notify for records matching this predicate
+  // (e.g. high-priority todos). Reuses the `when` shape; requires
+  // `completionField`; field validated to exist by refines below.
+  notifyWhen: WhenZ.optional(),
+  // Declarative retrieval config. Present only on Feeds (collections in
+  // the `<workspace>/feeds/` registry). Optional, so every existing
+  // skill schema validates unchanged.
+  ingest: IngestZ.optional(),
+  // Declares this collection as the destination of the LLM-free Google
+  // Calendar sync. Optional, so every existing schema validates unchanged.
+  googleCalendar: GoogleCalendarSyncZ.optional(),
+  // Data-driven launcher-icon override. Optional, so every existing
+  // schema validates unchanged; `source` is required within it.
+  dynamicIcon: DynamicIconSpecZ.optional(),
+});
+
+export type CollectionSchemaInput = z.infer<typeof CollectionObjectZ>;
+
+const BareCollectionSchemaZ = CollectionObjectZ
   // Exactly one storage declaration: native records need `dataPath`, an
   // external data file needs `dataSource`, an alternative backend needs
   // `storage`. Zero (nowhere to read) and several (ambiguous which wins)
   // are equally meaningless — fail loudly at load instead of picking
   // silently.
-  .refine((schema) => [schema.dataPath, schema.dataSource, schema.storage].filter((declared) => declared !== undefined).length === 1, {
+  .refine(declaresExactlyOneStore, {
     message:
       "declare exactly one of `dataPath` (native JSON records), `dataSource` (external read-only data file), or `storage` (alternative writable backend)",
     path: ["dataPath"],
@@ -894,100 +794,59 @@ const BareCollectionSchemaZ = z
   // write machinery can never fire: `singleton` pins CREATES, `ingest`
   // REFILLS records, `spawn` WRITES successor records. Rejecting them at
   // validation kills whole classes of writes before any runtime guard.
-  .refine(
-    (schema) =>
-      schema.dataSource === undefined ||
-      (schema.singleton === undefined && schema.ingest === undefined && schema.spawn === undefined && schema.googleCalendar === undefined),
-    {
-      message: "a `dataSource` collection is read-only — it cannot declare `singleton`, `ingest`, `spawn`, or `googleCalendar` (all of them write records)",
-      path: ["dataSource"],
-    },
-  )
+  .refine(dataSourceDeclaresNoWriteMachinery, {
+    message: "a `dataSource` collection is read-only — it cannot declare `singleton`, `ingest`, `spawn`, or `googleCalendar` (all of them write records)",
+    path: ["dataSource"],
+  })
   // The sync writes each mapped value into a declared field, and puts the
   // Google event id in the primary field — so a map key that names no field
   // (or names the primary) would silently drop data or fight the id.
-  .refine(
-    (schema) =>
-      schema.googleCalendar === undefined ||
-      Object.keys(schema.googleCalendar.map).every((key) => {
-        const target = schema.fields[key];
-        return target !== undefined && !COMPUTED_TYPES.has(target.type) && key !== schema.primaryKey;
-      }),
-    {
-      message: "a `googleCalendar` map key must name a declared, non-computed field, and never the primaryKey (that always holds the Google event id)",
-      path: ["googleCalendar"],
-    },
-  )
+  .refine(googleCalendarMapNamesStoredFields, {
+    message: "a `googleCalendar` map key must name a declared, non-computed field, and never the primaryKey (that always holds the Google event id)",
+    path: ["googleCalendar"],
+  })
   // Same rule for declarative host writes: a mutate action writes the
   // record it's invoked on.
-  .refine(
-    (schema) => schema.dataSource === undefined || [...(schema.actions ?? []), ...(schema.collectionActions ?? [])].every((action) => action.kind !== "mutate"),
-    {
-      message: 'a `dataSource` collection is read-only — its actions cannot use `kind: "mutate"` (a host write); use `chat`/`agent` actions instead',
-      path: ["dataSource"],
-    },
-  )
+  .refine(dataSourceDeclaresNoMutateAction, {
+    message: 'a `dataSource` collection is read-only — its actions cannot use `kind: "mutate"` (a host write); use `chat`/`agent` actions instead',
+    path: ["dataSource"],
+  })
   // The singleton value becomes a record id (and thus a `<id>.json`
   // filename), so it must satisfy the SAME record-id rule the write path
   // enforces — otherwise the create form would lock the primary key to a
   // value the POST route then rejects as an invalid item id, making the
   // collection impossible to initialize (Codex P1).
-  .refine((schema) => schema.singleton === undefined || isSafeRecordId(schema.singleton), {
+  .refine(singletonIsAValidRecordId, {
     message: "schema `singleton` must be a valid item id (alphanumeric / hyphen / underscore / interior dot, no `..` or path separators)",
     path: ["singleton"],
   })
   // Action ids must be unique so the dispatch route resolves
   // unambiguously.
-  .refine((schema) => schema.actions === undefined || new Set(schema.actions.map((action) => action.id)).size === schema.actions.length, {
+  .refine(actionIdsAreUnique, {
     message: "schema `actions` must have unique `id`s",
     path: ["actions"],
   })
   // Collection-level action ids must likewise be unique.
-  .refine(
-    (schema) => schema.collectionActions === undefined || new Set(schema.collectionActions.map((action) => action.id)).size === schema.collectionActions.length,
-    {
-      message: "schema `collectionActions` must have unique `id`s",
-      path: ["collectionActions"],
-    },
-  )
+  .refine(collectionActionIdsAreUnique, {
+    message: "schema `collectionActions` must have unique `id`s",
+    path: ["collectionActions"],
+  })
   // A mutate action's `set` writes real STORED fields: a typo'd key
   // would write a stray value forever, a computed/projected field is
   // never persisted, and the primaryKey is the filename (renaming is
   // not a mutation).
-  .refine(
-    (schema) =>
-      (schema.actions ?? []).every(
-        (action) =>
-          action.kind !== "mutate" ||
-          Object.keys(action.set).every((key) => {
-            const target = schema.fields[key];
-            return target !== undefined && !COMPUTED_TYPES.has(target.type) && key !== schema.primaryKey;
-          }),
-      ),
-    {
-      message: "a mutate action's `set` keys must name declared, non-computed fields (and never the primaryKey)",
-      path: ["actions"],
-    },
-  )
+  .refine(mutateSetKeysNameStoredFields, {
+    message: "a mutate action's `set` keys must name declared, non-computed fields (and never the primaryKey)",
+    path: ["actions"],
+  })
   // Every `$params.<name>` reference in `set` must name a declared
   // param — an undeclared one would silently no-op the assignment.
-  .refine(
-    (schema) =>
-      (schema.actions ?? []).every(
-        (action) =>
-          action.kind !== "mutate" ||
-          Object.values(action.set).every((value) => {
-            const ref = paramRefName(value);
-            return ref === null || (action.params ?? {})[ref] !== undefined;
-          }),
-      ),
-    {
-      message: "a mutate action's `$params.<name>` references must name keys declared in its `params`",
-      path: ["actions"],
-    },
-  )
+  .refine(mutateParamRefsAreDeclared, {
+    message: "a mutate action's `$params.<name>` references must name keys declared in its `params`",
+    path: ["actions"],
+  })
   // A collection-level action has no record to write.
-  .refine((schema) => (schema.collectionActions ?? []).every((action) => action.kind !== "mutate"), {
+  .refine(collectionActionsAreNotMutate, {
     message: '`collectionActions` cannot contain `kind: "mutate"` — a collection-level action has no record to write',
     path: ["collectionActions"],
   })
@@ -996,7 +855,7 @@ const BareCollectionSchemaZ = z
   // per-field check, then silently fall back to the literal / USD at
   // render and mislabel amounts. Checked at the schema level because a
   // field can't see its siblings.
-  .refine((schema) => collectCurrencyFieldRefs(schema.fields).every((name) => CODE_FIELD_TYPES.has(schema.fields[name]?.type ?? "")), {
+  .refine(currencyFieldRefsNameCodeFields, {
     message: "a money field's `currencyField` must name a top-level `string`, `text`, or `enum` field that holds the currency code",
     path: ["fields"],
   })
@@ -1009,26 +868,20 @@ const BareCollectionSchemaZ = z
   // flag's `where` matches, so `completionDoneValues` carries no
   // information and MUST be omitted (declaring it would invite a
   // contradictory second source of truth).
-  .refine(
-    (schema) => {
-      if (schema.completionField !== undefined && schema.fields[schema.completionField]?.type === "flag") return schema.completionDoneValues === undefined;
-      return (schema.completionField === undefined) === (schema.completionDoneValues === undefined);
-    },
-    {
-      message:
-        "schema `completionField` and `completionDoneValues` must be declared together (both set, or both omitted) — unless `completionField` names a `flag` field, in which case `completionDoneValues` must be omitted (done ⇔ the flag matches)",
-      path: ["completionField"],
-    },
-  )
+  .refine(completionPairIsCoherent, {
+    message:
+      "schema `completionField` and `completionDoneValues` must be declared together (both set, or both omitted) — unless `completionField` names a `flag` field, in which case `completionDoneValues` must be omitted (done ⇔ the flag matches)",
+    path: ["completionField"],
+  })
   // `completionField` must name a real top-level field — a typo would
   // silently disable the notification mechanism otherwise.
-  .refine((schema) => schema.completionField === undefined || schema.fields[schema.completionField] !== undefined, {
+  .refine(completionFieldIsDeclared, {
     message: "schema `completionField` must name a top-level field declared in `fields`",
     path: ["completionField"],
   })
   // `displayField`, like `completionField`, must name a real top-level
   // field — a typo would silently fall back to the primaryKey forever.
-  .refine((schema) => schema.displayField === undefined || schema.fields[schema.displayField] !== undefined, {
+  .refine(displayFieldIsDeclared, {
     message: "schema `displayField` must name a top-level field declared in `fields`",
     path: ["displayField"],
   })
@@ -1036,7 +889,7 @@ const BareCollectionSchemaZ = z
   // value, so it must name a real top-level field — a typo would
   // silently keep the field hidden forever (the gate never matches).
   // Checked at the schema level because a field can't see its siblings.
-  .refine((schema) => Object.values(schema.fields).every((field) => field.when === undefined || schema.fields[field.when.field] !== undefined), {
+  .refine(fieldVisibilityGatesNameDeclaredFields, {
     message: "a field's `when.field` must name a top-level field declared in `fields`",
     path: ["fields"],
   })
@@ -1045,20 +898,10 @@ const BareCollectionSchemaZ = z
   // field — a typo would silently pin the flag false forever (`ne`:
   // true forever). Checked at the schema level because a field can't
   // see its siblings.
-  .refine(
-    (schema) =>
-      Object.values(schema.fields).every(
-        (field) =>
-          field.type !== "flag" ||
-          field.where.every(
-            (cond) => schema.fields[cond.field] !== undefined && (cond.valueFrom === undefined || schema.fields[cond.valueFrom.field] !== undefined),
-          ),
-      ),
-    {
-      message: "a flag field's `where` conditions must name top-level fields declared in `fields` (both `field` and a same-record `valueFrom.field`)",
-      path: ["fields"],
-    },
-  )
+  .refine(flagConditionsNameDeclaredFields, {
+    message: "a flag field's `where` conditions must name top-level fields declared in `fields` (both `field` and a same-record `valueFrom.field`)",
+    path: ["fields"],
+  })
   // A flag named by `completionField` is evaluated against the RAW
   // record — the reconciler (and spawn's fallback) read items straight
   // off disk, BEFORE any `deriveAll` enrichment — so its `where` may
@@ -1067,30 +910,18 @@ const BareCollectionSchemaZ = z
   // key: `ne` matches vacuously, every other op reads false, and the
   // bell would clear wrongly / never. General (non-completion) flags
   // keep the full vocabulary — the UI evaluates them post-enrichment.
-  .refine(
-    (schema) => {
-      const spec = schema.completionField === undefined ? undefined : schema.fields[schema.completionField];
-      if (spec?.type !== "flag") return true;
-      return spec.where.every((cond) =>
-        [cond.field, ...(cond.valueFrom ? [cond.valueFrom.field] : [])].every((name) => {
-          const target = schema.fields[name];
-          return target !== undefined && !COMPUTED_TYPES.has(target.type);
-        }),
-      );
-    },
-    {
-      message:
-        "a `flag` named by `completionField` may only reference STORED fields in its `where` — completion is evaluated against the raw record (before deriveAll), where computed values (derived/rollup/toggle/flag/embed/backlinks) are absent",
-      path: ["completionField"],
-    },
-  )
+  .refine(completionFlagReadsOnlyStoredFields, {
+    message:
+      "a `flag` named by `completionField` may only reference STORED fields in its `where` — completion is evaluated against the raw record (before deriveAll), where computed values (derived/rollup/toggle/flag/embed/backlinks) are absent",
+    path: ["completionField"],
+  })
   // The spawn-inert guard (`spawnSuccessorStartsInert`) statically
   // checks that a successor is not born already matching the spawn
   // predicate; it cannot see through a flag's `where` (the predicate
   // would need full record evaluation against `set`/`carry`). So a
   // schema whose completion is flag-form may only spawn with an
   // explicit `spawn.when` — which the guard CAN check.
-  .refine((schema) => schema.spawn === undefined || schema.spawn.when !== undefined || schema.fields[schema.completionField ?? ""]?.type !== "flag", {
+  .refine(flagCompletionSpawnDeclaresWhen, {
     message:
       "a schema whose `completionField` names a `flag` field must declare an explicit `spawn.when` (the spawn-inert check cannot statically evaluate a flag's `where`)",
     path: ["spawn"],
@@ -1104,50 +935,42 @@ const BareCollectionSchemaZ = z
   // makes the misconfiguration fail at schema load, not silently at
   // render. `idField` is ignored on non-`embed` fields, so only check
   // there. Schema-level because a field can't see its siblings.
-  .refine(
-    (schema) =>
-      Object.values(schema.fields).every((field) => {
-        if (field.type !== "embed" || field.idField === undefined) return true;
-        const target = schema.fields[field.idField];
-        return target !== undefined && (target.type === "ref" || target.type === "string");
-      }),
-    {
-      message: "an embed field's `idField` must name a top-level `ref` or `string` field declared in `fields`",
-      path: ["fields"],
-    },
-  )
+  .refine(embedIdFieldsNameIdBearingFields, {
+    message: "an embed field's `idField` must name a top-level `ref` or `string` field declared in `fields`",
+    path: ["fields"],
+  })
   // `triggerField` requires the completion pair: the time gate only
   // suppresses the *completion* bell until the date, and the bell still
   // clears via `completionDoneValues`. Without completion there is no
   // bell to gate (or clear), so the declaration is meaningless.
-  .refine((schema) => schema.triggerField === undefined || schema.completionField !== undefined, {
+  .refine(triggerFieldRequiresCompletion, {
     message: "schema `triggerField` requires `completionField` / `completionDoneValues` (the gated bell still clears via the done value)",
     path: ["triggerField"],
   })
   // `triggerField` must name a real `date` field — the gate parses its
   // value as `YYYY-MM-DD`; any other type can't be compared to the clock.
-  .refine((schema) => schema.triggerField === undefined || schema.fields[schema.triggerField]?.type === "date", {
+  .refine(triggerFieldIsADateField, {
     message: "schema `triggerField` must name a top-level `date` field declared in `fields`",
     path: ["triggerField"],
   })
   // `triggerLeadDays` only means something relative to a trigger date.
-  .refine((schema) => schema.triggerLeadDays === undefined || schema.triggerField !== undefined, {
+  .refine(triggerLeadDaysRequiresTriggerField, {
     message: "schema `triggerLeadDays` requires `triggerField` (it shifts when that field's bell fires)",
     path: ["triggerLeadDays"],
   })
   // `spawn` advances `triggerField` to compute the successor's trigger
   // date, so the schema must declare one.
-  .refine((schema) => schema.spawn === undefined || schema.triggerField !== undefined, {
+  .refine(spawnRequiresTriggerField, {
     message: "schema `spawn` requires `triggerField` (the successor's trigger date is `triggerField` advanced by `spawn.every`)",
     path: ["spawn"],
   })
   // `spawn.when.field` and every `spawn.carry` entry must name real
   // top-level fields — a typo would silently never match / never copy.
-  .refine((schema) => schema.spawn?.when === undefined || schema.fields[schema.spawn.when.field] !== undefined, {
+  .refine(spawnWhenFieldIsDeclared, {
     message: "schema `spawn.when.field` must name a top-level field declared in `fields`",
     path: ["spawn"],
   })
-  .refine((schema) => (schema.spawn?.carry ?? []).every((name) => schema.fields[name] !== undefined), {
+  .refine(spawnCarryEntriesAreDeclared, {
     message: "every `spawn.carry` entry must name a top-level field declared in `fields`",
     path: ["spawn"],
   })
@@ -1159,7 +982,7 @@ const BareCollectionSchemaZ = z
   // carried source value (which matched, by definition, when the spawn
   // fired) if carried, else absent (safe). Reject the first two when they
   // land on a matching value.
-  .refine((schema) => spawnSuccessorStartsInert(schema), {
+  .refine(spawnSuccessorStartsInert, {
     message:
       "`spawn` must leave the successor in a non-matching state (e.g. `set` the status to a pending value); seeding the predicate field to a matching value via `set`/`carry` would respawn forever",
     path: ["spawn"],
@@ -1167,21 +990,21 @@ const BareCollectionSchemaZ = z
   // Field-driven `spawn.every` (§4.1): `fromField` must name a top-level
   // `enum` — the only field type with a closed, finite value set to drive
   // the `map` and the form `<select>`.
-  .refine((schema) => fieldDrivenFromFieldIsEnum(schema), {
+  .refine(fieldDrivenFromFieldIsEnum, {
     message: "`spawn.every.fromField` must name a top-level `enum` field declared in `fields`",
     path: ["spawn"],
   })
   // Field-driven `spawn.every` (§4.2): the `map` keys must exactly cover the
   // enum's `values` — a missing key would stall a record at that frequency;
   // an extra key signals a map left stale after an enum edit.
-  .refine((schema) => fieldDrivenMapCoversValues(schema), {
+  .refine(fieldDrivenMapCoversValues, {
     message: "`spawn.every.map` keys must exactly cover the `values` of the `enum` named by `fromField` (no missing or extra keys)",
     path: ["spawn"],
   })
   // Field-driven `spawn.every` (§4.5): `fromField` must be carried (or `set`)
   // onto the successor, or the next spawn in the chain can't resolve an
   // interval and the recurrence silently halts.
-  .refine((schema) => fieldDrivenFromFieldCarried(schema), {
+  .refine(fieldDrivenFromFieldCarried, {
     message:
       "`spawn.every.fromField` must appear in `spawn.carry`, or be written by `spawn.set` to a value present in `spawn.every.map`, so the successor keeps a resolvable recurrence interval",
     path: ["spawn"],
@@ -1190,43 +1013,43 @@ const BareCollectionSchemaZ = z
   // view parses its value to place records on the month grid (a `datetime`
   // anchor also carries the clock for the day view); any other type can't be
   // put on a calendar.
-  .refine((schema) => schema.calendarField === undefined || isDateLike(schema.fields[schema.calendarField]?.type), {
+  .refine(calendarFieldIsDateLike, {
     message: "schema `calendarField` must name a top-level `date` or `datetime` field declared in `fields`",
     path: ["calendarField"],
   })
   // `calendarEndField` marks the end of a multi-day span, so it only means
   // something alongside a start anchor.
-  .refine((schema) => schema.calendarEndField === undefined || schema.calendarField !== undefined, {
+  .refine(calendarEndFieldRequiresCalendarField, {
     message: "schema `calendarEndField` requires `calendarField` (it marks the end of the span that starts at `calendarField`)",
     path: ["calendarEndField"],
   })
   // `calendarEndField` must also name a real `date`/`datetime` field — same parse.
-  .refine((schema) => schema.calendarEndField === undefined || isDateLike(schema.fields[schema.calendarEndField]?.type), {
+  .refine(calendarEndFieldIsDateLike, {
     message: "schema `calendarEndField` must name a top-level `date` or `datetime` field declared in `fields`",
     path: ["calendarEndField"],
   })
   // `calendarTimeField` places records on the day view, so it only means
   // something alongside a start anchor.
-  .refine((schema) => schema.calendarTimeField === undefined || schema.calendarField !== undefined, {
+  .refine(calendarTimeFieldRequiresCalendarField, {
     message: "schema `calendarTimeField` requires `calendarField` (it supplies the time-of-day for the calendar's day view)",
     path: ["calendarTimeField"],
   })
   // `calendarTimeField` must name a real top-level field (a free-form time
   // string the day view parses).
-  .refine((schema) => schema.calendarTimeField === undefined || schema.fields[schema.calendarTimeField] !== undefined, {
+  .refine(calendarTimeFieldIsDeclared, {
     message: "schema `calendarTimeField` must name a top-level field declared in `fields`",
     path: ["calendarTimeField"],
   })
   // …and that field must be string-backed — the day view parses its value as a
   // time string, so a number/enum/date column can't drive it.
-  .refine((schema) => schema.calendarTimeField === undefined || isTimeStringField(schema.fields[schema.calendarTimeField]?.type), {
+  .refine(calendarTimeFieldIsStringBacked, {
     message: "schema `calendarTimeField` must name a top-level `string` or `text` field declared in `fields`",
     path: ["calendarTimeField"],
   })
   // `kanbanField` must name a real `enum` field — the board groups records
   // into one column per declared enum value; any other type has no closed
   // set of columns to group by.
-  .refine((schema) => schema.kanbanField === undefined || schema.fields[schema.kanbanField]?.type === "enum", {
+  .refine(kanbanFieldIsAnEnum, {
     message: "schema `kanbanField` must name a top-level `enum` field declared in `fields`",
     path: ["kanbanField"],
   })
@@ -1234,30 +1057,30 @@ const BareCollectionSchemaZ = z
   // top-level enum, and `onValue` / `offValue` must be members of that
   // enum's `values` — otherwise toggling would write a value outside the
   // closed set (and never appear "checked").
-  .refine((schema) => everyToggleProjectsValidEnum(schema.fields), {
+  .refine(togglesProjectValidEnums, {
     message: "a `toggle` field's `field` must name a top-level `enum` field, and its `onValue`/`offValue` must be values of that enum",
     path: ["fields"],
   })
   // `notifyWhen` narrows the completion bell, so it only means something with
   // completion tracking, and its `field` must name a real top-level field.
-  .refine((schema) => schema.notifyWhen === undefined || schema.completionField !== undefined, {
+  .refine(notifyWhenRequiresCompletion, {
     message: "schema `notifyWhen` requires `completionField` (it narrows that bell)",
     path: ["notifyWhen"],
   })
-  .refine((schema) => schema.notifyWhen === undefined || schema.fields[schema.notifyWhen.field] !== undefined, {
+  .refine(notifyWhenFieldIsDeclared, {
     message: "schema `notifyWhen.field` must name a top-level field declared in `fields`",
     path: ["notifyWhen"],
   })
   // Every custom view `id` must be a valid slug — it doubles as the
   // view-mode selector key (`custom:<id>`) and the capability-token clamp
   // key, both of which expect a path-safe token.
-  .refine((schema) => schema.views === undefined || schema.views.every((view) => isSafeSlug(view.id)), {
+  .refine(viewIdsAreSlugs, {
     message: "every `views[].id` must be a valid slug (alphanumeric / hyphen / underscore, no path separators)",
     path: ["views"],
   })
   // Custom view ids must be unique so the selector + token clamp resolve
   // unambiguously.
-  .refine((schema) => schema.views === undefined || new Set(schema.views.map((view) => view.id)).size === schema.views.length, {
+  .refine(viewIdsAreUnique, {
     message: "schema `views` must have unique `id`s",
     path: ["views"],
   });

--- a/test/workspace/collections/test_schema_refine_rules.ts
+++ b/test/workspace/collections/test_schema_refine_rules.ts
@@ -1,0 +1,524 @@
+import "../../../server/workspace/collections/configure.js"; // configure @mulmoclaude/core/collection host binding for tests
+
+// Characterization tests for the schema-level cross-field rules — the long
+// `.refine()` chain on the collection schema. Each rule guards a
+// misconfiguration that would otherwise fail SILENTLY at runtime (a bell that
+// never rings, a spawn that fans out forever, a currency that mislabels
+// amounts), so the thing worth pinning is that each one still REJECTS.
+//
+// Written before the chain is refactored into named predicates: a rule whose
+// condition gets inverted during the move would still parse valid schemas
+// fine, and only stop rejecting the bad ones. That direction of breakage is
+// invisible without a test per rule.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CollectionSchemaZ } from "@mulmoclaude/core/collection/server";
+
+const baseFields = {
+  id: { type: "string", label: "ID", primary: true, required: true },
+  name: { type: "string", label: "Name" },
+  status: { type: "enum", label: "Status", values: ["todo", "done"] },
+  due: { type: "date", label: "Due" },
+  startAt: { type: "datetime", label: "Start" },
+  endAt: { type: "datetime", label: "End" },
+  timeText: { type: "string", label: "Time" },
+  count: { type: "number", label: "Count" },
+  code: { type: "string", label: "Currency code" },
+};
+
+const base = {
+  title: "Tasks",
+  icon: "check_circle",
+  dataPath: "data/collections/tasks/items",
+  primaryKey: "id",
+  fields: baseFields,
+};
+
+type Overrides = Record<string, unknown>;
+
+const parse = (overrides: Overrides = {}) => CollectionSchemaZ.safeParse({ ...base, ...overrides });
+
+function messagesOf(result: ReturnType<typeof parse>): string {
+  return result.success ? "" : result.error.issues.map((issue) => issue.message).join(" || ");
+}
+
+function assertAccepts(overrides: Overrides): void {
+  const result = parse(overrides);
+  assert.equal(result.success, true, `expected acceptance, got: ${messagesOf(result)}`);
+}
+
+function assertRejects(overrides: Overrides, needle: string): void {
+  const result = parse(overrides);
+  assert.equal(result.success, false, "expected rejection, but the schema parsed");
+  const messages = messagesOf(result);
+  assert.ok(messages.includes(needle), `expected a message containing ${JSON.stringify(needle)}, got: ${messages}`);
+}
+
+describe("collection schema rules — the baseline fixture is valid", () => {
+  it("accepts the base schema", () => {
+    assertAccepts({});
+  });
+});
+
+describe("collection schema rules — storage declaration", () => {
+  it("rejects declaring none of dataPath / dataSource / storage", () => {
+    assert.equal(CollectionSchemaZ.safeParse({ title: base.title, icon: base.icon, primaryKey: "id", fields: baseFields }).success, false);
+  });
+
+  it("rejects declaring two of them", () => {
+    assertRejects({ dataSource: { type: "csv", path: "data/tasks.csv" } }, "declare exactly one of");
+  });
+
+  it("accepts dataSource alone", () => {
+    assertAccepts({ dataPath: undefined, dataSource: { type: "csv", path: "data/tasks.csv" } });
+  });
+
+  it("accepts storage alone", () => {
+    assertAccepts({ dataPath: undefined, storage: { type: "sqlite", path: "data/tasks.db" } });
+  });
+});
+
+describe("collection schema rules — dataSource is read-only", () => {
+  const readOnly = { dataPath: undefined, dataSource: { type: "csv", path: "data/tasks.csv" } };
+
+  it("rejects singleton on a dataSource collection", () => {
+    assertRejects({ ...readOnly, singleton: "the-one" }, "read-only");
+  });
+
+  it("rejects ingest on a dataSource collection", () => {
+    assertRejects({ ...readOnly, ingest: { kind: "agent", schedule: "daily", role: "assistant", template: "templates/refresh.md" } }, "read-only");
+  });
+
+  it("rejects a mutate action on a dataSource collection", () => {
+    assertRejects(
+      { ...readOnly, actions: [{ id: "done", kind: "mutate", label: "Done", set: { status: "done" } }] },
+      'its actions cannot use `kind: "mutate"`',
+    );
+  });
+});
+
+describe("collection schema rules — actions", () => {
+  it("rejects duplicate action ids", () => {
+    assertRejects(
+      {
+        actions: [
+          { id: "same", kind: "mutate", label: "A", set: { status: "done" } },
+          { id: "same", kind: "mutate", label: "B", set: { status: "todo" } },
+        ],
+      },
+      "unique `id`s",
+    );
+  });
+
+  it("rejects duplicate collectionAction ids", () => {
+    assertRejects(
+      {
+        collectionActions: [
+          { id: "same", kind: "chat", label: "A", role: "assistant", template: "templates/a.md" },
+          { id: "same", kind: "chat", label: "B", role: "assistant", template: "templates/b.md" },
+        ],
+      },
+      "unique `id`s",
+    );
+  });
+
+  // A typo'd key would write a stray value into every record forever.
+  it("rejects a mutate `set` key that names no declared field", () => {
+    assertRejects({ actions: [{ id: "a", kind: "mutate", label: "A", set: { staus: "done" } }] }, "must name declared, non-computed fields");
+  });
+
+  it("rejects a mutate `set` key that names the primaryKey", () => {
+    assertRejects({ actions: [{ id: "a", kind: "mutate", label: "A", set: { id: "x" } }] }, "never the primaryKey");
+  });
+
+  it("rejects an undeclared `$params.<name>` reference", () => {
+    assertRejects({ actions: [{ id: "a", kind: "mutate", label: "A", set: { name: "$params.who" } }] }, "must name keys declared in its `params`");
+  });
+
+  it("accepts a `$params.<name>` reference that is declared", () => {
+    assertAccepts({ actions: [{ id: "a", kind: "mutate", label: "A", set: { name: "$params.who" }, params: { who: { type: "string", label: "Who" } } }] });
+  });
+
+  // A collection-level action has no record to write.
+  it("rejects a mutate collectionAction", () => {
+    assertRejects({ collectionActions: [{ id: "a", kind: "mutate", label: "A", set: { status: "done" } }] }, "has no record to write");
+  });
+});
+
+describe("collection schema rules — singleton", () => {
+  it("rejects a singleton value that is not a valid item id", () => {
+    assertRejects({ singleton: "../escape" }, "must be a valid item id");
+  });
+
+  it("accepts a well-formed singleton value", () => {
+    assertAccepts({ singleton: "the-one" });
+  });
+});
+
+describe("collection schema rules — currency", () => {
+  it("rejects a currencyField pointing at a non-code field type", () => {
+    assertRejects(
+      { fields: { ...baseFields, amount: { type: "money", label: "Amount", currencyField: "count" } } },
+      "must name a top-level `string`, `text`, or `enum` field",
+    );
+  });
+
+  it("accepts a currencyField pointing at a string field", () => {
+    assertAccepts({ fields: { ...baseFields, amount: { type: "money", label: "Amount", currencyField: "code" } } });
+  });
+
+  it("rejects a currencyField that names nothing at all", () => {
+    assertRejects({ fields: { ...baseFields, amount: { type: "money", label: "Amount", currencyField: "curreny" } } }, "must name a top-level");
+  });
+});
+
+describe("collection schema rules — completion pair", () => {
+  it("rejects completionField without completionDoneValues", () => {
+    assertRejects({ completionField: "status" }, "must be declared together");
+  });
+
+  it("rejects completionDoneValues without completionField", () => {
+    assertRejects({ completionDoneValues: ["done"] }, "must be declared together");
+  });
+
+  it("accepts the pair declared together", () => {
+    assertAccepts({ completionField: "status", completionDoneValues: ["done"] });
+  });
+
+  it("rejects a completionField that names no declared field", () => {
+    assertRejects({ completionField: "stat", completionDoneValues: ["done"] }, "must name a top-level field");
+  });
+
+  // done ⇔ the flag's `where` matches, so a second source of truth is refused.
+  it("rejects completionDoneValues alongside a flag completionField", () => {
+    assertRejects(
+      {
+        fields: { ...baseFields, overdue: { type: "flag", label: "Overdue", where: [{ field: "status", op: "eq", value: "todo" }] } },
+        completionField: "overdue",
+        completionDoneValues: ["yes"],
+      },
+      "must be declared together",
+    );
+  });
+
+  it("accepts a flag completionField with completionDoneValues omitted", () => {
+    assertAccepts({
+      fields: { ...baseFields, overdue: { type: "flag", label: "Overdue", where: [{ field: "status", op: "eq", value: "todo" }] } },
+      completionField: "overdue",
+    });
+  });
+});
+
+describe("collection schema rules — field pointers", () => {
+  it("rejects a displayField that names no declared field", () => {
+    assertRejects({ displayField: "nmae" }, "schema `displayField` must name a top-level field");
+  });
+
+  it("rejects a field whose `when.field` names no declared field", () => {
+    assertRejects({ fields: { ...baseFields, extra: { type: "string", label: "Extra", when: { field: "nope", in: ["x"] } } } }, "`when.field` must name");
+  });
+
+  it("rejects a flag whose `where` names no declared field", () => {
+    assertRejects(
+      { fields: { ...baseFields, bad: { type: "flag", label: "Bad", where: [{ field: "nope", op: "eq", value: "x" }] } } },
+      "`where` conditions must name top-level fields",
+    );
+  });
+
+  it("rejects an embed `idField` pointing at a non-ref/string field", () => {
+    assertRejects(
+      { fields: { ...baseFields, linked: { type: "embed", label: "Linked", to: "people", idField: "count" } } },
+      "must name a top-level `ref` or `string` field",
+    );
+  });
+
+  it("rejects a kanbanField that is not an enum", () => {
+    assertRejects({ kanbanField: "name" }, "must name a top-level `enum` field");
+  });
+
+  it("accepts a kanbanField naming an enum", () => {
+    assertAccepts({ kanbanField: "status" });
+  });
+});
+
+describe("collection schema rules — toggle projection", () => {
+  const toggleOver = (spec: Record<string, unknown>) => ({ fields: { ...baseFields, done: { type: "toggle", label: "Done", ...spec } } });
+
+  it("accepts a toggle projecting onto a real enum with member values", () => {
+    assertAccepts(toggleOver({ field: "status", onValue: "done", offValue: "todo" }));
+  });
+
+  it("rejects a toggle whose target is not an enum", () => {
+    assertRejects(toggleOver({ field: "name", onValue: "a", offValue: "b" }), "must name a top-level `enum` field");
+  });
+
+  it("rejects a toggle whose onValue is outside the enum's values", () => {
+    assertRejects(toggleOver({ field: "status", onValue: "finished", offValue: "todo" }), "must be values of that enum");
+  });
+});
+
+describe("collection schema rules — trigger", () => {
+  const withCompletion = { completionField: "status", completionDoneValues: ["done"] };
+
+  it("rejects triggerField without completion tracking", () => {
+    assertRejects({ triggerField: "due" }, "requires `completionField`");
+  });
+
+  it("rejects a triggerField that is not a date field", () => {
+    assertRejects({ ...withCompletion, triggerField: "name" }, "must name a top-level `date` field");
+  });
+
+  it("accepts a date triggerField alongside completion", () => {
+    assertAccepts({ ...withCompletion, triggerField: "due" });
+  });
+
+  it("rejects triggerLeadDays without triggerField", () => {
+    assertRejects({ ...withCompletion, triggerLeadDays: 3 }, "requires `triggerField`");
+  });
+});
+
+describe("collection schema rules — spawn", () => {
+  const spawnBase = { completionField: "status", completionDoneValues: ["done"], triggerField: "due" };
+
+  it("accepts a spawn that leaves the successor inert", () => {
+    assertAccepts({ ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, set: { status: "todo" } } });
+  });
+
+  it("rejects spawn without a triggerField", () => {
+    assertRejects(
+      { completionField: "status", completionDoneValues: ["done"], spawn: { every: { unit: "week", interval: 1 }, set: { status: "todo" } } },
+      "`spawn` requires `triggerField`",
+    );
+  });
+
+  it("rejects a spawn.when.field that names no declared field", () => {
+    assertRejects(
+      { ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, when: { field: "nope", in: ["done"] }, set: { status: "todo" } } },
+      "`spawn.when.field` must name",
+    );
+  });
+
+  it("rejects a spawn.carry entry that names no declared field", () => {
+    assertRejects(
+      { ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, carry: ["nope"], set: { status: "todo" } } },
+      "every `spawn.carry` entry must name",
+    );
+  });
+
+  // A successor born already matching its own predicate re-spawns on the first
+  // reconcile and fans out into an unbounded chain of records.
+  it("rejects a spawn whose `set` seeds the predicate field to a matching value", () => {
+    assertRejects({ ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, set: { status: "done" } } }, "non-matching state");
+  });
+
+  it("rejects a spawn that carries the predicate field (inheriting the matching value)", () => {
+    assertRejects({ ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, carry: ["status"] } }, "non-matching state");
+  });
+
+  it("rejects a flag-completion schema that spawns without an explicit spawn.when", () => {
+    assertRejects(
+      {
+        fields: { ...baseFields, overdue: { type: "flag", label: "Overdue", where: [{ field: "status", op: "eq", value: "todo" }] } },
+        completionField: "overdue",
+        triggerField: "due",
+        spawn: { every: { unit: "week", interval: 1 }, set: { status: "todo" } },
+      },
+      "must declare an explicit `spawn.when`",
+    );
+  });
+});
+
+describe("collection schema rules — field-driven spawn.every", () => {
+  const drivenBase = { completionField: "status", completionDoneValues: ["done"], triggerField: "due" };
+  const freq = { type: "enum", label: "Frequency", values: ["weekly", "monthly"] };
+  const fieldsWithFreq = { ...baseFields, freq };
+
+  it("accepts a field-driven every whose map covers the enum and is carried", () => {
+    assertAccepts({
+      ...drivenBase,
+      fields: fieldsWithFreq,
+      spawn: {
+        every: { fromField: "freq", map: { weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1 } } },
+        carry: ["freq"],
+        set: { status: "todo" },
+      },
+    });
+  });
+
+  it("rejects a fromField that is not an enum", () => {
+    assertRejects(
+      { ...drivenBase, spawn: { every: { fromField: "name", map: { a: { unit: "week", interval: 1 } } }, carry: ["name"], set: { status: "todo" } } },
+      "must name a top-level `enum` field",
+    );
+  });
+
+  // A missing key stalls a record at that frequency; an extra key is a map
+  // left stale after an enum edit.
+  it("rejects a map missing one of the enum's values", () => {
+    assertRejects(
+      {
+        ...drivenBase,
+        fields: fieldsWithFreq,
+        spawn: { every: { fromField: "freq", map: { weekly: { unit: "week", interval: 1 } } }, carry: ["freq"], set: { status: "todo" } },
+      },
+      "must exactly cover the `values`",
+    );
+  });
+
+  it("rejects a map with an extra key the enum does not declare", () => {
+    assertRejects(
+      {
+        ...drivenBase,
+        fields: fieldsWithFreq,
+        spawn: {
+          every: {
+            fromField: "freq",
+            map: { weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1 }, daily: { unit: "day", interval: 1 } },
+          },
+          carry: ["freq"],
+          set: { status: "todo" },
+        },
+      },
+      "must exactly cover the `values`",
+    );
+  });
+
+  it("rejects a fromField that reaches the successor via neither carry nor set", () => {
+    assertRejects(
+      {
+        ...drivenBase,
+        fields: fieldsWithFreq,
+        spawn: {
+          every: { fromField: "freq", map: { weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1 } } },
+          set: { status: "todo" },
+        },
+      },
+      "so the successor keeps a resolvable recurrence interval",
+    );
+  });
+
+  it("accepts a fromField written by set to a value present in the map", () => {
+    assertAccepts({
+      ...drivenBase,
+      fields: fieldsWithFreq,
+      spawn: {
+        every: { fromField: "freq", map: { weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1 } } },
+        set: { status: "todo", freq: "weekly" },
+      },
+    });
+  });
+
+  it("rejects a fromField set to a value the map does not cover", () => {
+    assertRejects(
+      {
+        ...drivenBase,
+        fields: fieldsWithFreq,
+        spawn: {
+          every: { fromField: "freq", map: { weekly: { unit: "week", interval: 1 }, monthly: { unit: "month", interval: 1 } } },
+          set: { status: "todo", freq: "yearly" },
+        },
+      },
+      "so the successor keeps a resolvable recurrence interval",
+    );
+  });
+});
+
+describe("collection schema rules — calendar", () => {
+  it("rejects a calendarField that is not date-like", () => {
+    assertRejects({ calendarField: "name" }, "schema `calendarField` must name a top-level `date` or `datetime` field");
+  });
+
+  it("accepts a date and a datetime calendarField", () => {
+    assertAccepts({ calendarField: "due" });
+    assertAccepts({ calendarField: "startAt" });
+  });
+
+  it("rejects calendarEndField without calendarField", () => {
+    assertRejects({ calendarEndField: "endAt" }, "requires `calendarField`");
+  });
+
+  it("rejects a calendarEndField that is not date-like", () => {
+    assertRejects({ calendarField: "startAt", calendarEndField: "name" }, "schema `calendarEndField` must name a top-level `date` or `datetime` field");
+  });
+
+  it("rejects calendarTimeField without calendarField", () => {
+    assertRejects({ calendarTimeField: "timeText" }, "requires `calendarField`");
+  });
+
+  it("rejects a calendarTimeField that names no declared field", () => {
+    assertRejects({ calendarField: "due", calendarTimeField: "nope" }, "schema `calendarTimeField` must name a top-level field");
+  });
+
+  // The day view parses the value as a time string, so a number column can't
+  // drive it.
+  it("rejects a calendarTimeField that is not string-backed", () => {
+    assertRejects({ calendarField: "due", calendarTimeField: "count" }, "must name a top-level `string` or `text` field");
+  });
+
+  it("accepts a string calendarTimeField alongside a calendarField", () => {
+    assertAccepts({ calendarField: "due", calendarTimeField: "timeText" });
+  });
+});
+
+describe("collection schema rules — notifyWhen", () => {
+  it("rejects notifyWhen without completion tracking", () => {
+    assertRejects({ notifyWhen: { field: "status", in: ["todo"] } }, "requires `completionField`");
+  });
+
+  it("rejects a notifyWhen.field that names no declared field", () => {
+    assertRejects(
+      { completionField: "status", completionDoneValues: ["done"], notifyWhen: { field: "nope", in: ["x"] } },
+      "`notifyWhen.field` must name a top-level field",
+    );
+  });
+
+  it("accepts notifyWhen alongside completion tracking", () => {
+    assertAccepts({ completionField: "status", completionDoneValues: ["done"], notifyWhen: { field: "status", in: ["todo"] } });
+  });
+});
+
+describe("collection schema rules — custom views", () => {
+  it("rejects a view id that is not a valid slug", () => {
+    assertRejects({ views: [{ id: "../escape", label: "Bad", file: "views/bad.html" }] }, "must be a valid slug");
+  });
+
+  it("rejects duplicate view ids", () => {
+    assertRejects(
+      {
+        views: [
+          { id: "board", label: "A", file: "views/a.html" },
+          { id: "board", label: "B", file: "views/b.html" },
+        ],
+      },
+      "unique `id`s",
+    );
+  });
+
+  it("accepts distinct, slug-safe view ids", () => {
+    assertAccepts({
+      views: [
+        { id: "board", label: "A", file: "views/a.html" },
+        { id: "chart", label: "B", file: "views/b.html" },
+      ],
+    });
+  });
+});
+
+describe("collection schema rules — googleCalendar map", () => {
+  const sync = (map: Record<string, string>) => ({ googleCalendar: { calendarId: "primary", map } });
+
+  it("accepts a map naming declared, non-computed, non-primary fields", () => {
+    assertAccepts(sync({ name: "summary", startAt: "start", endAt: "end" }));
+  });
+
+  it("rejects a map key that names no declared field", () => {
+    assertRejects(sync({ nope: "summary" }), "must name a declared, non-computed field");
+  });
+
+  // The primary field always holds the Google event id, which is what keeps
+  // re-syncs idempotent.
+  it("rejects a map key that names the primaryKey", () => {
+    assertRejects(sync({ id: "summary" }), "never the primaryKey");
+  });
+});

--- a/test/workspace/collections/test_schema_refine_rules.ts
+++ b/test/workspace/collections/test_schema_refine_rules.ts
@@ -90,6 +90,26 @@ describe("collection schema rules — dataSource is read-only", () => {
     assertRejects({ ...readOnly, ingest: { kind: "agent", schedule: "daily", role: "assistant", template: "templates/refresh.md" } }, "read-only");
   });
 
+  // The rule is a conjunction over four write mechanisms; each needs its own
+  // case, or an inverted clause stays invisible behind the ones that are
+  // covered (CodeRabbit).
+  it("rejects spawn on a dataSource collection", () => {
+    assertRejects(
+      {
+        ...readOnly,
+        completionField: "status",
+        completionDoneValues: ["done"],
+        triggerField: "due",
+        spawn: { every: { unit: "week", interval: 1 }, set: { status: "todo" } },
+      },
+      "read-only",
+    );
+  });
+
+  it("rejects googleCalendar on a dataSource collection", () => {
+    assertRejects({ ...readOnly, googleCalendar: { calendarId: "primary", map: { name: "summary" } } }, "read-only");
+  });
+
   it("rejects a mutate action on a dataSource collection", () => {
     assertRejects(
       { ...readOnly, actions: [{ id: "done", kind: "mutate", label: "Done", set: { status: "done" } }] },


### PR DESCRIPTION
## Summary

コレクションスキーマのクロスフィールド検証は、**無名の述語 41 個が連なる 470 行の `.refine()` チェーン**だった。1 つ 1 つは純粋で単体検証できる内容なのに、ラムダに埋まっているせいで**呼ぶことも読むこともできない**状態。

`schemaRules.ts` に名前付きエクスポート関数として切り出し、統べる対象ごとにグループ化した（storage 宣言 / actions / completion / フィールド参照 / toggle 射影 / trigger / spawn / calendar / views）。

- `schemaZ.ts`: **1320 → 1175 行**。refine チェーンがロジックの塊ではなく**ルール名の一覧**として読めるようになった
- `schemaRules.ts`: 470 行（新規）

**メッセージ・`path`・順序はすべて元のまま。** Zod は最初に落ちた refine を報告するので、並べ替えると不正スキーマに返るエラーが変わってしまう。

## Items to Confirm / Review

1. **この refactor が抱えるリスクは「述語の反転」** — 反転しても正しいスキーマはこれまで通り通り、**不正なスキーマを弾かなくなるだけ**。何も落ちず何もログに出ない。なので先行コミットで特性テスト 70 件を入れ、移動後に**抽出した 11 ルールを 1 つずつ無効化して該当ケースが赤くなること**を確認した。

2. **コンパイラが実際の欠陥を 1 つ捕まえた。** `CurrencyBearingField` を最初は全プロパティ optional で書いたが、これは TypeScript の weak type になり、`currencyField` を持たないフィールド variant が代入不可になる。`type` を両階層に戻し、「何も読まないのになぜ必要か」をコメントに残した。

3. **循環 import に見えるが実体はない。** `schemaRules.ts` は `CollectionSchemaInput` を `import type` で受けるだけで、emit 時に消える。ランタイムのモジュールグラフは `schemaZ → schemaRules → schema` で非循環のまま。

4. **`yarn typecheck` はこの型エラーを検出しなかった** — `yarn build:packages` だけが落ちた。CI ゲートの構成として気になる点かもしれない（このPRの範囲外だが共有）。

## User Prompt

> まず、テストを追加できるものは追加して。リスクない変更で。
> その次にりすくがないものだけやって。

（大きいファイルの棚卸し #2292–#2296, #2298–#2302 のうち、リスクの低い #2296 から着手）

## コミット構成

意図的に 2 コミットに分けている。レビュー時は 1 つ目だけを見れば「移動前の挙動」が、2 つ目だけを見れば「移動そのもの」が読める。

1. `test:` — 特性テスト 70 件（本番コードの差分ゼロ）
2. `refactor:` — 抽出（テストの差分ゼロ）

## Test plan

- 特性テスト 70 件 — 抽出の前後で同一の結果
- `yarn test` — 7626 件 pass / 0 fail
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn build:packages` — すべて green

Closes #2296

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive, cross-field validation for collection schemas, including storage setup, action invariants, currency wiring, completion/flag coherence, calendar rules, spawning/trigger safety, notifications, embed/id requirements, and custom view constraints.

* **Bug Fixes**
  * Improved consistency and accuracy of schema rule enforcement by centralizing and reusing shared validation predicates.

* **Tests**
  * Added a comprehensive test suite covering many valid/invalid schema configurations and error-message expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->