### PR TITLE
refactor(server): extract the collection route's request parsers, with tests

### DIFF
--- a/server/api/routes/collectionParams.ts
+++ b/server/api/routes/collectionParams.ts
@@ -1,0 +1,45 @@
+// Request-shape parsing for the collection routes. Pure: no I/O, no Express
+// beyond the value types, so each can be exercised directly.
+//
+// `parseListParam` and `csvParam` look like duplicates and are NOT: one trims
+// and drops empty entries, the other preserves them verbatim. They serve
+// different callers on a frozen public contract (see the view-data note in
+// `collections.ts`), so merging them would change what a persisted custom view
+// receives. Kept apart deliberately.
+
+import type { CollectionItem } from "../../workspace/collections/index.js";
+import type { ViewCapability } from "../auth/viewToken.js";
+
+/** Parse a `read`/`write` capability list from a request body value.
+ *  Anything else in the list is dropped rather than rejected — the result is
+ *  then clamped against what the view itself declares, so a request can only
+ *  ever narrow, never widen. */
+export function parseCapabilities(value: unknown): ViewCapability[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const caps = value.filter((entry): entry is ViewCapability => entry === "read" || entry === "write");
+  return caps.length > 0 ? caps : undefined;
+}
+
+/** Parse a comma-separated or repeated query param into a string list. */
+export function parseListParam(value: unknown): string[] | undefined {
+  const parts = typeof value === "string" ? value.split(",") : Array.isArray(value) ? value.map(String) : [];
+  const cleaned = parts.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/** Like `parseListParam` but VERBATIM — no trimming, no empty-entry removal.
+ *  Callers on the frozen view-data contract depend on getting back exactly
+ *  what was sent. */
+export function csvParam(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) return value.map((entry) => String(entry));
+  if (typeof value === "string" && value.length > 0) return value.split(",");
+  return undefined;
+}
+
+/** A request body is a record only if it is a plain object — an array would
+ *  otherwise pass a bare `typeof === "object"` check and be written as a
+ *  record with numeric keys. */
+export function extractRecord(body: unknown): CollectionItem | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return body as CollectionItem;
+}

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -67,7 +67,8 @@ import { workspacePath } from "../../workspace/workspace.js";
 import { refreshOne } from "@mulmoclaude/core/feeds/server";
 import { manageCollection } from "../../agent/mcp-tools/manageCollection.js";
 import { dispatchAgentAction, runningAgentActions } from "./collectionAgentActions.js";
-import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "../auth/viewToken.js";
+import { clampCapabilities, mintViewToken, requireViewToken } from "../auth/viewToken.js";
+import { csvParam, extractRecord, parseCapabilities, parseListParam } from "./collectionParams.js";
 
 const router = Router();
 
@@ -252,11 +253,6 @@ router.delete(API_ROUTES.collections.detail, async (req: Request<{ slug: string 
     serverError(res, errorMessage(err));
   }
 });
-
-function extractRecord(body: unknown): CollectionItem | null {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
-  return body as CollectionItem;
-}
 
 router.post(API_ROUTES.collections.items, async (req: Request<{ slug: string }>, res: Response<ItemMutationResponse>) => {
   const collection = await loadCollectionOr404(req.params.slug, res);
@@ -588,20 +584,6 @@ router.post(API_ROUTES.collections.collectionAction, async (req: Request<{ slug:
 // failure (unknown slug, over-limit unselective read, bad putItems shape) —
 // forward parsed JSON as 200, the bare string as a 400 `{ error }`.
 
-/** Parse a `read`/`write` capability list from a request body value. */
-function parseCapabilities(value: unknown): ViewCapability[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const caps = value.filter((entry): entry is ViewCapability => entry === "read" || entry === "write");
-  return caps.length > 0 ? caps : undefined;
-}
-
-/** Parse a comma-separated or repeated query param into a string list. */
-function parseListParam(value: unknown): string[] | undefined {
-  const parts = typeof value === "string" ? value.split(",") : Array.isArray(value) ? value.map(String) : [];
-  const cleaned = parts.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
-  return cleaned.length > 0 ? cleaned : undefined;
-}
-
 function sendToolResult(res: Response, raw: string): void {
   try {
     res.json(JSON.parse(raw));
@@ -782,12 +764,6 @@ router.post(API_ROUTES.collections.remoteViewMutate, async (req: Request<{ slug:
 
 /** A `fields` projection arrives as a CSV query string (`?fields=title,photo`)
  *  or repeated params; hand `normalizeFields` an array either way. */
-function csvParam(value: unknown): string[] | undefined {
-  if (Array.isArray(value)) return value.map((entry) => String(entry));
-  if (typeof value === "string" && value.length > 0) return value.split(",");
-  return undefined;
-}
-
 /** Map a non-ok item-page build to its HTTP error (message shared with the
  *  channel handler via `remoteViewItemsFailureMessage`). */
 function sendRemoteViewItemsFailure(res: Response, result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): void {

--- a/test/api/routes/test_collectionParams.ts
+++ b/test/api/routes/test_collectionParams.ts
@@ -1,0 +1,130 @@
+// The request-shape parsers behind the collection routes. Three of the four
+// feed the view-data plane, which is a FROZEN public contract: LLM-authored
+// HTML persisted in users' workspaces calls it and cannot be migrated
+// centrally. So the edge behaviour here — what a blank entry does, whether
+// whitespace survives — is not an implementation detail to tidy up later; it
+// is the contract.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { csvParam, extractRecord, parseCapabilities, parseListParam } from "../../../server/api/routes/collectionParams.js";
+
+describe("parseCapabilities", () => {
+  it("keeps the known capabilities", () => {
+    assert.deepEqual(parseCapabilities(["read", "write"]), ["read", "write"]);
+    assert.deepEqual(parseCapabilities(["read"]), ["read"]);
+  });
+
+  // The result is clamped against what the view itself declares, so dropping
+  // unknown entries can only ever narrow — never widen — what a token grants.
+  it("drops unknown entries rather than rejecting the whole list", () => {
+    assert.deepEqual(parseCapabilities(["read", "admin", "delete"]), ["read"]);
+  });
+
+  it("returns undefined when nothing recognisable survives", () => {
+    assert.equal(parseCapabilities(["admin"]), undefined);
+    assert.equal(parseCapabilities([]), undefined);
+  });
+
+  it("returns undefined for non-array input", () => {
+    assert.equal(parseCapabilities("read"), undefined);
+    assert.equal(parseCapabilities({ read: true }), undefined);
+    assert.equal(parseCapabilities(undefined), undefined);
+    assert.equal(parseCapabilities(null), undefined);
+  });
+
+  // Case matters: the token check compares exact strings.
+  it("does not accept differently-cased capabilities", () => {
+    assert.equal(parseCapabilities(["READ"]), undefined);
+  });
+
+  it("preserves duplicates rather than collapsing them", () => {
+    assert.deepEqual(parseCapabilities(["read", "read"]), ["read", "read"]);
+  });
+});
+
+describe("parseListParam", () => {
+  it("splits a comma-separated string", () => {
+    assert.deepEqual(parseListParam("a,b,c"), ["a", "b", "c"]);
+  });
+
+  it("accepts a repeated param as an array", () => {
+    assert.deepEqual(parseListParam(["a", "b"]), ["a", "b"]);
+  });
+
+  it("trims each entry and drops blanks", () => {
+    assert.deepEqual(parseListParam(" a , b ,, c "), ["a", "b", "c"]);
+  });
+
+  it("stringifies non-string array entries", () => {
+    assert.deepEqual(parseListParam([1, 2]), ["1", "2"]);
+  });
+
+  it("returns undefined when nothing survives", () => {
+    assert.equal(parseListParam(""), undefined);
+    assert.equal(parseListParam("   "), undefined);
+    assert.equal(parseListParam(",,"), undefined);
+    assert.equal(parseListParam([]), undefined);
+  });
+
+  it("returns undefined for input that is neither string nor array", () => {
+    assert.equal(parseListParam(undefined), undefined);
+    assert.equal(parseListParam(null), undefined);
+    assert.equal(parseListParam(7), undefined);
+  });
+});
+
+describe("csvParam", () => {
+  it("splits a comma-separated string", () => {
+    assert.deepEqual(csvParam("a,b,c"), ["a", "b", "c"]);
+  });
+
+  // This is what separates it from `parseListParam`, and why the two must not
+  // be merged: callers on the frozen contract receive entries verbatim.
+  it("preserves whitespace and empty entries verbatim", () => {
+    assert.deepEqual(csvParam(" a , b "), [" a ", " b "]);
+    assert.deepEqual(csvParam("a,,b"), ["a", "", "b"]);
+  });
+
+  it("stringifies array entries without trimming", () => {
+    assert.deepEqual(csvParam([" a ", 2]), [" a ", "2"]);
+  });
+
+  // An empty array is meaningful (an explicit empty selection), unlike an
+  // empty string which means "not supplied".
+  it("returns an empty array for an empty array, but undefined for an empty string", () => {
+    assert.deepEqual(csvParam([]), []);
+    assert.equal(csvParam(""), undefined);
+  });
+
+  it("returns undefined for input that is neither string nor array", () => {
+    assert.equal(csvParam(undefined), undefined);
+    assert.equal(csvParam(null), undefined);
+    assert.equal(csvParam(7), undefined);
+  });
+});
+
+describe("extractRecord", () => {
+  it("accepts a plain object", () => {
+    assert.deepEqual(extractRecord({ id: "a", name: "x" }), { id: "a", name: "x" });
+  });
+
+  it("accepts an empty object", () => {
+    assert.deepEqual(extractRecord({}), {});
+  });
+
+  // An array passes a bare `typeof === "object"` check and would be written as
+  // a record with numeric keys.
+  it("rejects an array", () => {
+    assert.equal(extractRecord([]), null);
+    assert.equal(extractRecord([{ id: "a" }]), null);
+  });
+
+  it("rejects null, undefined and primitives", () => {
+    assert.equal(extractRecord(null), null);
+    assert.equal(extractRecord(undefined), null);
+    assert.equal(extractRecord("record"), null);
+    assert.equal(extractRecord(0), null);
+    assert.equal(extractRecord(false), null);
+  });
+});


### PR DESCRIPTION
## Summary

`server/api/routes/collections.ts`（1164行）から**純粋なリクエストパーサ 4 本**を切り出し、テストを付けた。**挙動の変更なし**（一字一句そのまま移動）。collections.ts は 1164 → 1140 行。

| 関数 | 何を決めているか | 移動前のテスト |
|---|---|---|
| `parseCapabilities` | **ビュートークンが持つ capability** | **なし** |
| `parseListParam` | クエリパラメータ → 文字列リスト（trim + 空要素除去） | なし |
| `csvParam` | 同上だが**そのまま**（trim しない） | なし |
| `extractRecord` | リクエストボディがレコードか | なし |

## Items to Confirm / Review

1. **`csvParam` と `parseListParam` は意図的に統合していない。** 見た目は重複だが、片方は trim して空要素を落とし、もう片方はそのまま返す。両方とも view-data 平面（**凍結された公開契約** — ユーザーのワークスペースに永続化された LLM 生成 HTML から呼ばれ、中央から移行できない）で使われるので、「整理」して 1 本にすると**それらのファイルが受け取る値が静かに変わる**。#2294 でこの罠を指摘しておいたもの。

   テストがこの差を押さえていることを確認済み: **`csvParam` を `parseListParam` に委譲する形に書き換えると 3 件赤くなる。**

2. **`parseCapabilities` が未テストだったのが一番まずかった** — これはトークンが持つ権限を決める関数。許可リストを「任意の文字列」に緩める変異で 3 件赤くなることを確認した。なお `clampCapabilities` とセットで初めて意味を成す（リクエストは narrow できても widen できない）ので、その関係をコメントに残している。

3. **その他の変異検証**: `extractRecord` の配列チェック削除 → 1 件赤 / `parseListParam` の空要素除去削除 → 2 件赤。

4. **`yarn build` は通ったが `yarn typecheck` が型エラーを捕まえた** — `CollectionItem` を `@mulmoclaude/core/collection/server` から import していたが、正しくは `workspace/collections/index.js`。CLAUDE.md が警告している「build は通るが typecheck が落ちる」パターンそのものだった。

   （前回の PR #2304 では逆に `typecheck` が見逃して `build:packages` だけが落ちたので、**両方回さないと穴がある**ことが 2 回連続で確認できた形）

## User Prompt

> refactoringのissueで進められそうなのを進めてほしい。こわれないやつね。

「壊れないもの」を基準に、Vue 5 件（e2e が DOM 構造・xpath に依存）を除外し、サーバ側の純粋関数の切り出しから着手した。

## Test plan

- `test/api/routes/test_collectionParams.ts` — 21 件新規
- `yarn test` — 7710 件 pass / 0 fail
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn build:packages` — すべて green

Refs #2294

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract collection route request parsers into a dedicated module and cover them with tests without changing behaviour.

Bug Fixes:
- Correct the CollectionItem import source for collection request parsing.

Enhancements:
- Move csvParam, parseListParam, parseCapabilities and extractRecord from collections route into server/api/routes/collectionParams.ts to isolate pure request-shape parsing logic.
- Add explicit tests for collection request parser edge cases to protect the frozen view-data contract and capability handling.

Tests:
- Introduce test/api/routes/test_collectionParams.ts with comprehensive coverage for collection request parsers, including capability lists, CSV params, and record extraction.