### PR TITLE
refactor(server): extract browser-visible origin resolution from index.ts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -85,6 +85,7 @@ import { discoverSkills } from "./workspace/skills/index.js";
 import { WORKSPACE_PATHS } from "./workspace/paths.js";
 import { resolveClientDir } from "./utils/clientDir.js";
 import { serverError } from "./utils/httpError.js";
+import { browserVisibleOrigin } from "./utils/forwardedOrigin.js";
 import { makeUuid } from "./utils/id.js";
 import { mcpToolsRouter, mcpTools, isMcpToolEnabled } from "./agent/mcp-tools/index.js";
 import { preflightUserServers, logPreflightResult } from "./agent/mcpPreflight.js";
@@ -429,31 +430,6 @@ const HTML_PREVIEW_EXT_RE = /\.(html?|png|jpe?g|webp|gif|svg|ico|mp4|webm|mov|m4
 const HTML_DOCUMENT_EXT_RE = /\.html?$/i;
 const getHtmlsDirReal = makeCachedRealpath(WORKSPACE_PATHS.htmls);
 
-// Honour `X-Forwarded-*` so dev (Vite proxies `/artifacts/html` →
-// `localhost:3001` with `changeOrigin: true`) emits the browser-
-// visible origin (`localhost:5173`) rather than the upstream socket.
-// In prod (no proxy) the headers are absent and we fall back to the
-// raw `Host` / `req.protocol`.
-//
-// `X-Forwarded-*` values can be a comma-separated proxy chain (each
-// hop appends its own value). The CSP origin only needs the
-// outermost hop — the value the browser actually sees — so we take
-// the first entry and trim. Without this, a multi-hop deployment
-// would emit `https://a.example.com, b.example.com://x` and break
-// preview resource loading at the browser (#1056 review).
-function browserVisibleOrigin(req: Request): string {
-  const fwdHost = firstForwardedValue(req.get("x-forwarded-host"));
-  const fwdProto = firstForwardedValue(req.get("x-forwarded-proto"));
-  const host = fwdHost ?? req.get("host");
-  const proto = fwdProto ?? req.protocol;
-  return `${proto}://${host}`;
-}
-
-function firstForwardedValue(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  const first = raw.split(",")[0]?.trim();
-  return first && first.length > 0 ? first : undefined;
-}
 app.use(
   "/artifacts/html",
   async (req, res, next) => {

--- a/server/utils/forwardedOrigin.ts
+++ b/server/utils/forwardedOrigin.ts
@@ -1,0 +1,36 @@
+// Resolving the origin the BROWSER sees, which is not the origin the server
+// was reached on once a proxy is in front.
+//
+// Dev puts Vite in front (it proxies `/artifacts/html` → localhost:3001 with
+// `changeOrigin: true`), so the raw `Host` is the upstream socket, not what the
+// browser typed. Prod without a proxy has no forwarded headers at all and the
+// raw values are correct. Both cases go through the same fallback chain.
+
+/** The slice of an Express `Request` this needs — a header reader and the
+ *  protocol. Narrow so a test can hand it a literal instead of a socket. */
+export interface OriginSource {
+  get: (name: string) => string | undefined;
+  protocol: string;
+}
+
+/** `X-Forwarded-*` values can be a comma-separated proxy chain, each hop
+ *  appending its own value. Only the outermost hop — the value the browser
+ *  actually sees — is wanted. Without this a multi-hop deployment emits
+ *  `https://a.example.com, b.example.com://x`, which breaks preview
+ *  subresource loading at the browser (#1056 review). */
+export function firstForwardedValue(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const first = raw.split(",")[0]?.trim();
+  return first && first.length > 0 ? first : undefined;
+}
+
+/** The `<proto>://<host>` a browser would use to reach this request, honouring
+ *  a proxy's `X-Forwarded-*` when present and falling back to the raw socket
+ *  values when it is not. */
+export function browserVisibleOrigin(req: OriginSource): string {
+  const fwdHost = firstForwardedValue(req.get("x-forwarded-host"));
+  const fwdProto = firstForwardedValue(req.get("x-forwarded-proto"));
+  const host = fwdHost ?? req.get("host");
+  const proto = fwdProto ?? req.protocol;
+  return `${proto}://${host}`;
+}

--- a/test/utils/test_forwardedOrigin.ts
+++ b/test/utils/test_forwardedOrigin.ts
@@ -1,0 +1,80 @@
+// The origin baked into the CSP for HTML artifact previews. Getting it wrong
+// does not throw — it emits a syntactically valid but wrong origin, and the
+// browser silently refuses the preview's images, styles and media. The
+// multi-hop case (#1056) shipped as exactly that kind of quiet breakage.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { browserVisibleOrigin, firstForwardedValue, type OriginSource } from "../../server/utils/forwardedOrigin.js";
+
+const source = (headers: Record<string, string>, protocol = "http"): OriginSource => ({
+  get: (name: string) => headers[name.toLowerCase()],
+  protocol,
+});
+
+describe("firstForwardedValue", () => {
+  it("returns a single value unchanged", () => {
+    assert.equal(firstForwardedValue("example.com"), "example.com");
+  });
+
+  // Each proxy hop appends its own value; only the outermost one is what the
+  // browser actually used.
+  it("takes only the first hop of a proxy chain", () => {
+    assert.equal(firstForwardedValue("a.example.com, b.internal, c.internal"), "a.example.com");
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(firstForwardedValue("  example.com  , b.internal"), "example.com");
+  });
+
+  it("returns undefined for a missing header", () => {
+    assert.equal(firstForwardedValue(undefined), undefined);
+  });
+
+  // A header present but empty must fall back to the raw socket values rather
+  // than produce `://host` or `proto://`.
+  it("returns undefined for empty and whitespace-only values", () => {
+    assert.equal(firstForwardedValue(""), undefined);
+    assert.equal(firstForwardedValue("   "), undefined);
+    assert.equal(firstForwardedValue(","), undefined);
+    assert.equal(firstForwardedValue(" , b.internal"), undefined);
+  });
+});
+
+describe("browserVisibleOrigin", () => {
+  // Production without a proxy: the forwarded headers are absent and the raw
+  // values are already correct.
+  it("falls back to Host and req.protocol when nothing is forwarded", () => {
+    assert.equal(browserVisibleOrigin(source({ host: "localhost:3001" })), "http://localhost:3001");
+  });
+
+  // Dev: Vite proxies to :3001 with changeOrigin, so Host is the upstream
+  // socket and only the forwarded header knows the browser typed :5173.
+  it("prefers the forwarded host and protocol", () => {
+    const req = source({ host: "localhost:3001", "x-forwarded-host": "localhost:5173", "x-forwarded-proto": "https" }, "http");
+    assert.equal(browserVisibleOrigin(req), "https://localhost:5173");
+  });
+
+  it("takes each forwarded value independently", () => {
+    assert.equal(browserVisibleOrigin(source({ host: "localhost:3001", "x-forwarded-proto": "https" })), "https://localhost:3001");
+    assert.equal(browserVisibleOrigin(source({ host: "localhost:3001", "x-forwarded-host": "app.example.com" })), "http://app.example.com");
+  });
+
+  // The regression #1056 was reported for: a chain leaked into the origin as
+  // `https://a.example.com, b.internal://x`.
+  it("uses only the outermost hop of a multi-hop chain", () => {
+    const req = source({ host: "10.0.0.7:3001", "x-forwarded-host": "app.example.com, gateway.internal", "x-forwarded-proto": "https, http" }, "http");
+    assert.equal(browserVisibleOrigin(req), "https://app.example.com");
+  });
+
+  it("ignores empty forwarded headers and falls back", () => {
+    const req = source({ host: "localhost:3001", "x-forwarded-host": "", "x-forwarded-proto": "  " }, "http");
+    assert.equal(browserVisibleOrigin(req), "http://localhost:3001");
+  });
+
+  it("reads the forwarded headers case-insensitively, as Express does", () => {
+    const headers: Record<string, string> = { host: "localhost:3001", "x-forwarded-host": "app.example.com" };
+    const req: OriginSource = { get: (name) => headers[name.toLowerCase()], protocol: "http" };
+    assert.equal(browserVisibleOrigin(req), "http://app.example.com");
+  });
+});


### PR DESCRIPTION
## Summary

`server/index.ts`（1419行）から `browserVisibleOrigin` / `firstForwardedValue` を切り出し、テスト 11 件を付けた。**挙動の変更なし**（一字一句そのまま移動）。index.ts は 1419 → 1395 行。

## なぜこの 2 本を選んだか

この 2 本は **HTML artifact プレビューの CSP に焼き込まれる origin** を決めている。間違えても**何も throw しない** — origin は構文的には妥当なまま値だけ間違い、ブラウザがプレビューの画像 / スタイル / メディアを黙って拒否する。#1056 はまさにその形で出荷された不具合だった（プロキシチェーンが `https://a.example.com, b.internal://x` として漏れる）。

そういう「静かに壊れる」箇所が **1419 行の boot ファイルの中で未テスト**だった。

## Items to Confirm / Review

1. **引数を `Request` から narrow な `OriginSource`（ヘッダ読み取り + `protocol`）に変えた。** テストがソケットを立ち上げずリテラルを渡せるようにするため。Express の `Request` は構造的にこれを満たすので呼び出し側は無変更で、それは typecheck が保証している。

2. **変異検証** — テストが実際に壊れたコードを捕まえることを確認:
   | 変異 | 赤くなった件数 |
   |---|---|
   | チェーン分割を削除（#1056 の再発） | 4 |
   | 空文字ガード削除 | 2 |
   | forwarded host を無視 | 4 |

3. **#2295 の残り（boot 診断 / shutdown / system タスク定義）は着手していない。** `buildSystemTaskDefs` などは移動のみで純粋ロジックが無く、テストで守れるものが増えない一方、プロセスのライフサイクルに触れるのでリスクだけが乗る。middleware（認証 / CSRF）も同じ理由で対象外。

## User Prompt

> refactoringのissueで進められそうなのを進めてほしい。こわれないやつね。

## Test plan

- `test/utils/test_forwardedOrigin.ts` — 11 件新規
- `yarn test` — 7700 件 pass / 0 fail
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn build:packages` — すべて green

Refs #2295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract browser-visible origin resolution logic from the main server entrypoint into a dedicated utility module and cover it with focused tests.

Enhancements:
- Introduce a reusable forwarded origin utility that derives the browser-visible origin from request headers via a narrow OriginSource interface, reducing server index size and coupling.

Tests:
- Add unit tests for forwarded origin resolution and forwarded header parsing, covering multi-hop proxy chains, fallbacks, empty values, and case-insensitive header handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview page compatibility when accessed through proxies or forwarded requests.
  - Corrected origin detection across forwarded host and protocol values, including multi-hop and mixed-header scenarios.
  - Added safeguards to prevent malformed origins when forwarded headers are empty or invalid.

- **Tests**
  - Added coverage for origin detection, header fallbacks, whitespace handling, and case-insensitive header names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->