### PR TITLE
fix(collections): resolve spawn intervals by own property, not prototype chain

### DIFF
--- a/packages/core/src/collection/server/spawn.ts
+++ b/packages/core/src/collection/server/spawn.ts
@@ -154,7 +154,14 @@ export function resolveEvery(every: CollectionSpawnEvery, sourceItem: Collection
   const raw = sourceItem[every.fromField];
   if (raw === undefined || raw === null || raw === "") return null;
   const key = fieldTextOrNull(raw);
-  return key === null ? null : (every.map[key] ?? null);
+  // Own-property lookup, not a bare index: a record whose driver field reads
+  // `constructor` / `toString` would otherwise resolve to an `Object.prototype`
+  // member. `?? null` cannot catch that — a function is not undefined — so the
+  // interval would flow into `advanceTriggerDate` and produce a NaN successor
+  // date. Matches the own-property check `schemaRules` already uses on the same
+  // map at validation time.
+  if (key === null || !Object.hasOwn(every.map, key)) return null;
+  return every.map[key] ?? null;
 }
 
 export interface ComputedSuccessor {

--- a/test/workspace/collections/test_spawn.ts
+++ b/test/workspace/collections/test_spawn.ts
@@ -315,6 +315,21 @@ describe("resolveEvery", () => {
     assert.equal(resolveEvery(FREQ_EVERY, { frequency: "" }), null); // empty
     assert.equal(resolveEvery(FREQ_EVERY, {}), null); // missing
   });
+
+  // A bare `map[key]` resolves these to `Object.prototype` members, and the
+  // `?? null` fallback cannot catch it — a function is not undefined. The
+  // interval then reaches `advanceTriggerDate` and yields a NaN date, so the
+  // successor lands on disk as `<stem>-0NaNNaNNaN` with nothing thrown (#2314).
+  it("returns null for a driver value that names an Object.prototype member", () => {
+    for (const frequency of ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"]) {
+      assert.equal(resolveEvery(FREQ_EVERY, { frequency }), null, `expected ${frequency} to resolve to null`);
+    }
+  });
+
+  it("does not build a successor for a driver value naming a prototype member", () => {
+    const result = computeSuccessor(freqSchema(), { id: "rent", dueOn: "2026-06-10", frequency: "constructor", status: "paid" }, "rent");
+    assert.equal(result, null);
+  });
 });
 
 describe("computeSuccessor — field-driven every", () => {


### PR DESCRIPTION
## Summary

繰り返しレコード（`spawn`）のフィールド駆動 `every` が、**プロトタイプチェーン経由の値を間隔として返していた**バグの修正です。

レコードの駆動フィールドが `constructor` / `toString` / `valueOf` などのとき、`?? null` のフォールバックは効きません（**関数は undefined ではない**ため）。実行して確認した結果:

```
resolveEvery(every, { frequency: "constructor" })  => function Object() { [native code] }
advanceTriggerDate({y:2026,m:7,d:22}, <その関数>)   => { y: null, m: null, d: null }
successorId("rent", <上記>)                         => "rent-0NaNNaNNaN"
```

**例外は一切出ません。** `rent-0NaNNaNNaN` という後継レコードが静かにディスクへ書かれ、日付が NaN なのでカレンダーにもかんばんにも乗らず、ユーザーからは「変なレコードが勝手にできた」としか見えません。

## Items to Confirm / Review

1. **同じリポジトリ内に正しい実装があった。** スキーマ検証側の `schemaRules` は同じ `map` に対して `Object.prototype.hasOwnProperty.call(...)` を使っています。つまり**バリデータは own-property、実行時は proto 込み**という規律の不一致でした。今回それを揃えています。

2. **挙動が変わるのは proto キーのケースのみ。** `null` を返すようになり、呼び出し側が既に持っている「マップに無い値」の分岐に合流します。正当なレコードは 1 件も影響を受けません。

3. **到達経路**: レコードの JSON はユーザー / LLM が直接編集できます（CLAUDE.md の「ワークスペースがデータベース」原則）。API 経由の enum 検証を通らない書き換えで踏めます。

4. **回帰テストが修正前のコードで落ちることを確認済み**（2 件赤）。テストだけ足して満足していないことの確認として。

## この修正で終わりではありません

同じ型の箇所を横断調査したところ、**`packages/core/src/collection/**` を中心に 17 箇所**見つかりました。とくに深刻なのは:

- `schemaRules.ts` の**フィールドポインタ検証群**（`schema.fields[name] !== undefined`）— 「実在フィールドを指しているか」の検証が丸ごと素通りする
- `mutate.ts:48` の未宣言パラメータ拒否
- `schedulerHandlers.ts:194` / `hostRunner.ts:128` のハンドラ dispatch（未知アクションが「成功」として実行されうる）

これらは別 issue に切り出します。この PR は #2314 の 1 件のみに絞っています。

## User Prompt

> 他にもテストを増やしたほうが良いかもね、バグあるから。pure関数で出せるところをもっと探して。広い範囲で。
>
> 全部 issue 化してそれを処理しつつ、他の調査やテスト０を増やすのを並列してどんどんやって。

## Test plan

- `test/workspace/collections/test_spawn.ts` に回帰テスト 2 件追加（38 件 pass）
- `yarn test` — 7740 件 pass / 0 fail
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn build:packages` — すべて green

Fixes #2314

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of field-driven recurrence values that match built-in property names.
  * Invalid mappings are now safely rejected instead of being interpreted as valid values or generating successor records.
  * Added safeguards for edge cases involving names such as `constructor`, `toString`, and `__proto__`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->