### PR TITLE
test: cover the external-skill path sanitisers and hook payload extractors

### DIFF
--- a/test/workspace/hooks/test_stdinExtractors.ts
+++ b/test/workspace/hooks/test_stdinExtractors.ts
@@ -1,0 +1,118 @@
+// The readers that pull a file path / command / tool name / session id out of
+// the PostToolUse payload Claude CLI streams on stdin.
+//
+// They are defensive by design: every one returns a benign default rather than
+// throwing, because a hook that crashes takes the user's tool turn with it.
+// That is also why they need tests — a wrong default is indistinguishable from
+// a correct one at runtime. The hook just quietly does nothing.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { extractCommand, extractFilePath, extractSessionId, extractToolName, type HookPayload } from "../../../server/workspace/hooks/shared/stdin.js";
+
+describe("extractFilePath", () => {
+  it("reads tool_input.file_path, which Write and Edit populate", () => {
+    assert.equal(extractFilePath({ tool_input: { file_path: "notes.md" } }), "notes.md");
+  });
+
+  // The response shape uses a different key; handlers should not have to know
+  // which tool they are downstream of.
+  it("falls back to tool_response.filePath", () => {
+    assert.equal(extractFilePath({ tool_response: { filePath: "notes.md" } }), "notes.md");
+  });
+
+  it("prefers tool_input over tool_response when both are present", () => {
+    assert.equal(extractFilePath({ tool_input: { file_path: "from-input.md" }, tool_response: { filePath: "from-response.md" } }), "from-input.md");
+  });
+
+  // An empty string is the "nothing to do" signal, so a non-string value must
+  // land there rather than being stringified into a bogus path.
+  it("returns an empty string for a missing or non-string path", () => {
+    assert.equal(extractFilePath({}), "");
+    assert.equal(extractFilePath({ tool_input: {} }), "");
+    assert.equal(extractFilePath({ tool_input: { file_path: 7 } }), "");
+    assert.equal(extractFilePath({ tool_input: { file_path: null } }), "");
+    assert.equal(extractFilePath({ tool_response: { filePath: ["notes.md"] } }), "");
+  });
+
+  // A non-string in tool_input must not stop the tool_response fallback.
+  it("falls through to the response when tool_input carries a non-string", () => {
+    assert.equal(extractFilePath({ tool_input: { file_path: 7 }, tool_response: { filePath: "notes.md" } }), "notes.md");
+  });
+});
+
+describe("extractCommand", () => {
+  it("reads the Bash command string", () => {
+    assert.equal(extractCommand({ tool_input: { command: "ls -la" } }), "ls -la");
+  });
+
+  it("returns an empty string for a non-Bash or malformed payload", () => {
+    assert.equal(extractCommand({}), "");
+    assert.equal(extractCommand({ tool_input: {} }), "");
+    assert.equal(extractCommand({ tool_input: { command: 7 } }), "");
+    assert.equal(extractCommand({ tool_input: { file_path: "notes.md" } }), "");
+  });
+
+  // An empty command is a real (if useless) value, and must round-trip as one
+  // rather than being conflated with "absent".
+  it("passes an empty command through unchanged", () => {
+    assert.equal(extractCommand({ tool_input: { command: "" } }), "");
+  });
+});
+
+describe("extractToolName", () => {
+  it("reads a string tool name", () => {
+    assert.equal(extractToolName({ tool_name: "Bash" }), "Bash");
+  });
+
+  it("returns an empty string when absent or not a string", () => {
+    assert.equal(extractToolName({}), "");
+    assert.equal(extractToolName({ tool_name: 7 }), "");
+    assert.equal(extractToolName({ tool_name: null }), "");
+  });
+
+  // Dispatchers compare this by exact string, so case must survive verbatim.
+  it("does not normalise case", () => {
+    assert.equal(extractToolName({ tool_name: "bash" }), "bash");
+  });
+});
+
+describe("extractSessionId", () => {
+  it("reads a non-empty session id", () => {
+    assert.equal(extractSessionId({ session_id: "abc-123" }), "abc-123");
+  });
+
+  // Unlike the others this returns `undefined`, not `""` — callers branch on
+  // presence, and an empty-string id would be treated as a real one.
+  it("returns undefined for absent, empty and non-string ids", () => {
+    assert.equal(extractSessionId({}), undefined);
+    assert.equal(extractSessionId({ session_id: "" }), undefined);
+    assert.equal(extractSessionId({ session_id: 7 }), undefined);
+    assert.equal(extractSessionId({ session_id: null }), undefined);
+  });
+});
+
+describe("hook payload extractors — hostile shapes", () => {
+  // The dispatcher hands these whatever `JSON.parse` produced. A crash here
+  // takes down the user's tool turn, so every one must degrade instead.
+  it("survives payloads whose nested fields are the wrong type", () => {
+    const hostile: HookPayload[] = [
+      { tool_input: null } as unknown as HookPayload,
+      { tool_input: "string" } as unknown as HookPayload,
+      { tool_input: [] } as unknown as HookPayload,
+      { tool_response: 7 } as unknown as HookPayload,
+    ];
+    for (const payload of hostile) {
+      assert.equal(extractFilePath(payload), "");
+      assert.equal(extractCommand(payload), "");
+    }
+  });
+
+  // `JSON.parse` makes `__proto__` an OWN data property rather than setting the
+  // prototype, so a payload written this way simply has no tool_name.
+  it("treats a JSON-parsed __proto__ key as an ordinary absent field", () => {
+    const payload = JSON.parse('{"__proto__": {"tool_name": "Bash", "session_id": "hijacked"}}') as HookPayload;
+    assert.equal(extractToolName(payload), "");
+    assert.equal(extractSessionId(payload), undefined);
+  });
+});

--- a/test/workspace/skills/test_externalId.ts
+++ b/test/workspace/skills/test_externalId.ts
@@ -1,0 +1,146 @@
+// The sanitisers that stand between a caller-supplied repo id / subpath and
+// `path.join` + git's sparse-checkout patterns. All four shipped untested.
+//
+// Their failure mode is the dangerous one: they return a STRING, not a throw.
+// A hole here does not crash — it hands a traversal token to a path join and
+// the escape happens quietly, one layer down.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isSafeRepoId, safeRepoId, safeSkillFolder, sanitiseSubpath } from "../../../server/workspace/skills/external/id.js";
+
+describe("isSafeRepoId", () => {
+  it("accepts the shape deriveRepoId produces", () => {
+    assert.equal(isSafeRepoId("owner-repo"), true);
+    assert.equal(isSafeRepoId("a"), true);
+    assert.equal(isSafeRepoId("a1"), true);
+    assert.equal(isSafeRepoId("my-org-my-repo"), true);
+  });
+
+  it("rejects uppercase — ids are lowercased at derivation", () => {
+    assert.equal(isSafeRepoId("Owner-Repo"), false);
+  });
+
+  it("rejects leading and trailing hyphens", () => {
+    assert.equal(isSafeRepoId("-repo"), false);
+    assert.equal(isSafeRepoId("repo-"), false);
+  });
+
+  it("rejects the empty string", () => {
+    assert.equal(isSafeRepoId(""), false);
+  });
+
+  // These are the characters that would matter if one slipped into a path.
+  it("rejects separators, dots and traversal tokens", () => {
+    for (const bad of ["..", ".", "a/b", "a\\b", "a.b", "a_b", "a b", "a\0b"]) {
+      assert.equal(isSafeRepoId(bad), false, `expected ${JSON.stringify(bad)} to be rejected`);
+    }
+  });
+
+  // A `$` anchor alone would let a newline-terminated string through; the regex
+  // must not treat the value as multiline.
+  it("rejects a value with a trailing newline", () => {
+    assert.equal(isSafeRepoId("repo\n"), false);
+    assert.equal(isSafeRepoId("repo\nrm -rf /"), false);
+  });
+});
+
+describe("safeRepoId", () => {
+  it("returns the id unchanged when it is already safe", () => {
+    assert.equal(safeRepoId("owner-repo"), "owner-repo");
+  });
+
+  it("returns null for anything the shape check rejects", () => {
+    for (const bad of ["", "..", "a/b", "Owner", "-x", "x-"]) {
+      assert.equal(safeRepoId(bad), null, `expected ${JSON.stringify(bad)} to be rejected`);
+    }
+  });
+
+  // The basename round-trip is what CodeQL recognises as the path-injection
+  // sanitiser; the regex alone is not enough, so it must actually run.
+  it("returns null when the value is not its own basename", () => {
+    assert.equal(safeRepoId("dir/owner-repo"), null);
+  });
+});
+
+describe("safeSkillFolder", () => {
+  it("accepts an ordinary folder leaf", () => {
+    assert.equal(safeSkillFolder("my-skill"), "my-skill");
+    assert.equal(safeSkillFolder("My_Skill"), "My_Skill");
+  });
+
+  // Deliberately more permissive than the repo-id rule: install discovery
+  // accepts these, and the read side must agree or an installed skill becomes
+  // invisible.
+  it("allows interior dots and mixed case", () => {
+    assert.equal(safeSkillFolder("v1.2"), "v1.2");
+    assert.equal(safeSkillFolder("Skill.v2"), "Skill.v2");
+  });
+
+  it("rejects empty, dot and dot-dot", () => {
+    assert.equal(safeSkillFolder(""), null);
+    assert.equal(safeSkillFolder("."), null);
+    assert.equal(safeSkillFolder(".."), null);
+  });
+
+  it("rejects hidden folders", () => {
+    assert.equal(safeSkillFolder(".git"), null);
+    assert.equal(safeSkillFolder(".hidden-skill"), null);
+  });
+
+  it("rejects separators and NUL", () => {
+    for (const bad of ["a/b", "a\\b", "../escape", "a\0b", "/abs"]) {
+      assert.equal(safeSkillFolder(bad), null, `expected ${JSON.stringify(bad)} to be rejected`);
+    }
+  });
+});
+
+describe("sanitiseSubpath", () => {
+  it("returns a normalised a/b/c path", () => {
+    assert.equal(sanitiseSubpath("skills/mine"), "skills/mine");
+    assert.equal(sanitiseSubpath("one"), "one");
+  });
+
+  // Empty and `.` segments are dropped rather than rejected, so a trailing or
+  // doubled slash normalises instead of failing.
+  it("drops empty and dot segments", () => {
+    assert.equal(sanitiseSubpath("a//b/"), "a/b");
+    assert.equal(sanitiseSubpath("a/./b"), "a/b");
+    assert.equal(sanitiseSubpath("a/."), "a");
+  });
+
+  it("rejects a leading slash", () => {
+    assert.equal(sanitiseSubpath("/etc/passwd"), null);
+  });
+
+  // The value flows into `path.join(cacheDir, subpath)` AND into a git
+  // sparse-checkout pattern, so traversal and pattern-injection characters
+  // both have to die here.
+  it("rejects traversal segments anywhere in the path", () => {
+    assert.equal(sanitiseSubpath(".."), null);
+    assert.equal(sanitiseSubpath("../etc"), null);
+    assert.equal(sanitiseSubpath("a/../../etc"), null);
+    assert.equal(sanitiseSubpath("a/b/.."), null);
+  });
+
+  it("rejects NUL, backslash and newlines", () => {
+    assert.equal(sanitiseSubpath("a\0b"), null);
+    assert.equal(sanitiseSubpath("a\\b"), null);
+    assert.equal(sanitiseSubpath("a\nb"), null);
+    assert.equal(sanitiseSubpath("a\rb"), null);
+  });
+
+  // A segment must be alnum plus `.`, `-`, `_`; anything a shell or a git
+  // pattern would treat specially is out.
+  it("rejects segments with characters outside the allowlist", () => {
+    for (const bad of ["a b", "a*b", "a?b", "a|b", "a;b", "a$b", "a{b}"]) {
+      assert.equal(sanitiseSubpath(bad), null, `expected ${JSON.stringify(bad)} to be rejected`);
+    }
+  });
+
+  it("rejects a path that reduces to nothing", () => {
+    assert.equal(sanitiseSubpath(""), null);
+    assert.equal(sanitiseSubpath("."), null);
+    assert.equal(sanitiseSubpath("//"), null);
+  });
+});


### PR DESCRIPTION
## Summary

単体テストが 1 本も無かった純粋関数 2 クラスタにテストを追加。**本番コードの差分ゼロ**、テスト 2 ファイルのみ（36 件）。

| 対象 | 件数 | 何を守っているか |
|---|---|---|
| `server/workspace/skills/external/id.ts` の 4 本 | 21 | 呼び出し側の値が `path.join` と git の sparse-checkout パターンに届く前の関門 |
| `server/workspace/hooks/shared/stdin.ts` の 4 本 | 15 | Claude CLI が stdin に流す PostToolUse ペイロードの読み取り |

## Items to Confirm / Review

1. **サニタイザ側の failure mode は throw ではなく「文字列を返す」こと。** 穴があっても落ちず、traversal トークンが 1 層下の `path.join` に渡って**脱出が静かに成立**します。だからテストが要る、という判断です。カバーしたのは: 各位置の traversal セグメント、先頭スラッシュ、NUL / バックスラッシュ / 改行、git パターンのメタ文字、隠しフォルダ、大文字（repo id は生成時に小文字化される）。

2. **意図的な非対称を1つ固定しました。** `safeSkillFolder` は内部ドット（`v1.2`）を許すのに `isSafeRepoId` は許しません。これは install 側の探索が受け入れるものと read 側の addressing が**過去に食い違って**「インストールは成功するのに一覧・プレビュー・star から見えない」状態になった経緯があるためで、揃えてはいけない差です。

3. **hook 抽出側は全部が「throw せず無害な既定値を返す」設計**（フックが落ちるとユーザーのツールターンごと巻き込むため）。それはそのままテストが要る理由でもあります — 間違った既定値は実行時に正しいものと区別がつかず、**フックが黙って何もしないだけ**になります。`extractSessionId` だけが `""` ではなく `undefined` を返す（空文字 id を本物として扱わせないため）という差も固定しました。

4. **変異検証済み**: `sanitiseSubpath` の `..` チェック削除で 1 件、先頭スラッシュ許可で 1 件、`safeSkillFolder` の隠しフォルダ許可で 2 件、repo id の文字クラスを緩めると 4 件が赤。

## User Prompt

> 他にもテストを増やしたほうが良いかもね、バグあるから。pure関数で出せるところをもっと探して。広い範囲で。

## Test plan

- `yarn test` — 7774 件 pass / 0 fail（+36）
- `yarn format` / `yarn lint` / `yarn typecheck` — すべて green
- 本番コードの差分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
