### PR TITLE
fix(collections): reject undeclared mutate params by own property

### DIFF
--- a/packages/core/src/collection/server/mutate.ts
+++ b/packages/core/src/collection/server/mutate.ts
@@ -45,7 +45,10 @@ export type MutateActionOutcome =
 export function firstMutateParamProblem(action: CollectionMutateAction, params: Record<string, unknown>): string | null {
   const declared = action.params ?? {};
   for (const key of Object.keys(params)) {
-    if (declared[key] === undefined) return `unknown param '${key}' — not declared by action '${action.id}'`;
+    // Own-property check, not a bare index: `params` keys come from the request
+    // body, so `constructor` / `toString` would resolve to an `Object.prototype`
+    // member and slip past the rejection this loop exists to make.
+    if (!Object.hasOwn(declared, key)) return `unknown param '${key}' — not declared by action '${action.id}'`;
   }
   for (const [key, spec] of Object.entries(declared)) {
     const problem = recordFieldProblem(key, spec, params[key], "strict");

--- a/test/workspace/collections/test_mutateParams.ts
+++ b/test/workspace/collections/test_mutateParams.ts
@@ -1,0 +1,75 @@
+import "../../../server/workspace/collections/configure.js"; // configure @mulmoclaude/core/collection host binding for tests
+
+// The gate that keeps an undeclared param from riding a mutate action's `set`
+// semantics. It runs on request-body keys, and its whole job is to say no —
+// so the interesting cases are the ones where saying yes is silent: the
+// request succeeds, a stray value lands in the record, and nothing logs.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { firstMutateParamProblem } from "@mulmoclaude/core/collection/server";
+import type { CollectionMutateAction } from "../../../server/workspace/collections/types.js";
+
+const action = (params?: Record<string, unknown>): CollectionMutateAction =>
+  ({ id: "mark-paid", kind: "mutate", label: "Mark paid", set: { status: "paid" }, ...(params ? { params } : {}) }) as unknown as CollectionMutateAction;
+
+const withWho = action({ who: { type: "string", label: "Who" } });
+
+describe("firstMutateParamProblem", () => {
+  it("accepts no params at all", () => {
+    assert.equal(firstMutateParamProblem(action(), {}), null);
+  });
+
+  it("accepts a declared param with a valid value", () => {
+    assert.equal(firstMutateParamProblem(withWho, { who: "alice" }), null);
+  });
+
+  it("rejects a param the action never declared", () => {
+    const problem = firstMutateParamProblem(withWho, { nope: "x" });
+    assert.ok(problem?.includes("unknown param 'nope'"), `expected an unknown-param message, got: ${String(problem)}`);
+  });
+
+  it("rejects any param when the action declares none", () => {
+    assert.ok(firstMutateParamProblem(action(), { who: "alice" }));
+  });
+
+  // A bare `declared[key]` resolves these to `Object.prototype` members, which
+  // are not undefined — so the rejection this loop exists for never fires and
+  // the stray key rides the `set` semantics silently (#2320).
+  it("rejects params named after Object.prototype members", () => {
+    for (const key of ["constructor", "toString", "valueOf", "hasOwnProperty", "isPrototypeOf"]) {
+      const problem = firstMutateParamProblem(withWho, { [key]: "x" });
+      assert.ok(problem?.includes(`unknown param '${key}'`), `expected ${key} to be rejected, got: ${String(problem)}`);
+    }
+  });
+
+  // `__proto__` in an object literal sets the prototype rather than creating a
+  // key, so it is absent from `Object.keys` and there is nothing to reject —
+  // the loop simply never sees it. Pinned so the difference from the case
+  // above is on record rather than rediscovered.
+  it("sees no key at all for a literal __proto__", () => {
+    assert.equal(firstMutateParamProblem(withWho, { __proto__: { who: "evil" } } as Record<string, unknown>), null);
+  });
+
+  // A JSON body, by contrast, makes `__proto__` an own data property, so it IS
+  // enumerable and must be rejected like any other undeclared key.
+  it("rejects a JSON-parsed __proto__ key", () => {
+    const params = JSON.parse('{"__proto__": {"who": "evil"}}') as Record<string, unknown>;
+    assert.ok(firstMutateParamProblem(withWho, params)?.includes("unknown param"));
+  });
+
+  // Once the keys check out, each declared param goes through the shared
+  // record-field validator. Note which types that actually covers: the strict
+  // tier validates number / money / boolean / date / datetime and lets every
+  // other type through, so a `string` param accepts a number by design.
+  it("reports a declared param's own validation problem", () => {
+    const withAmount = action({ amount: { type: "number", label: "Amount" } });
+    const problem = firstMutateParamProblem(withAmount, { amount: "not a number" });
+    assert.ok(problem, "expected a validation problem for a non-numeric value");
+    assert.equal(problem?.includes("unknown param"), false, "should be a field problem, not an unknown-key problem");
+  });
+
+  it("does not type-check a string param — the strict tier only covers numeric, boolean and date types", () => {
+    assert.equal(firstMutateParamProblem(withWho, { who: 7 }), null);
+  });
+});


### PR DESCRIPTION
## Summary

`packages/core/src/collection/server/mutate.ts` の未宣言パラメータ拒否が、**リクエストボディ由来のキー**を素の添字で引いていました。

```ts
if (declared[key] === undefined)   // declared["constructor"] は Object 関数 → 偽
```

`constructor` / `toString` / `valueOf` などのキーが**このループが存在する理由そのものである拒否をすり抜け**、400 になるはずのリクエストが 200 で通り、stray key がアクションの `set` セマンティクスに黙って乗ります。関数自身のコメントが「防ぐ」と書いている失敗そのものです。

`Object.hasOwn` で修正。正当なリクエストは 1 件も影響を受けません（実際の params は `JSON.parse` の出力で own プロパティしか持たない）。

## Items to Confirm / Review

1. **矛盾に見えて矛盾していない 2 ケースをテストで明示しました。**
   - リテラルの `__proto__` は**プロトタイプを差し替える**のでキーとして存在せず、`Object.keys` に現れない → 拒否すべきものが無い
   - JSON 由来の `__proto__` は **own データプロパティ**なので列挙され、他の未宣言キーと同様に拒否される

   見た目がそっくりなので、両方残して区別を明示しています。

2. **調査中に「バグでは」と思って誤報しかけた点も固定しました。** 宣言済みパラメータの値検証は、strict tier が `number` / `money` / `boolean` / `date` / `datetime` のみを見て**それ以外の型は素通し**します。つまり `string` パラメータに数値が通るのは**仕様**です。`strictTypeProblem` の `default` アームを読むまでは検証漏れに見えるので、テストとして記録しておく価値があると判断しました。

3. **修正前のコードで 2 件落ちることを確認済み。**

## User Prompt

> 全部 issue 化してそれを処理しつつ、他の調査やテスト０を増やすのを並列してどんどんやって。
>
> PRは細かく作って

## Test plan

- `test/workspace/collections/test_mutateParams.ts` — 9 件新規（この関数の初テスト）
- `yarn test` — 7747 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build:packages` — green

Fixes #2320

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected request parameter validation so undeclared keys—including names that overlap with built-in object properties—are properly rejected.
  * Preserved validation of declared parameters, including appropriate field-level errors for invalid values.

* **Tests**
  * Added coverage for valid parameters, unknown keys, prototype-related edge cases, and JSON request bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->