### PR TITLE
test(spreadsheet): cover A1 column conversion and Excel serial dates

### DIFF
--- a/test/plugins/spreadsheet/engine/test_dateUtils.ts
+++ b/test/plugins/spreadsheet/engine/test_dateUtils.ts
@@ -1,0 +1,123 @@
+// Excel serial-number conversion. Every date function in the engine routes
+// through this pair, and an error here is invisible: a date still renders, it
+// is just the wrong day. The epoch choice is the subtle part — Excel's serial
+// numbering embeds a 1900 leap-year bug, and the base date compensates for it.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  dateToSerial,
+  serialToDate,
+  DAY_NAMES_FULL,
+  DAY_NAMES_SHORT,
+  MONTH_NAMES_FULL,
+  MONTH_NAMES_SHORT,
+} from "../../../../src/plugins/spreadsheet/engine/date-utils.ts";
+
+const utc = (year: number, month: number, day: number, hour = 0, minute = 0, second = 0) => new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+
+describe("dateToSerial", () => {
+  it("anchors serial 0 at the Dec 30 1899 base", () => {
+    assert.equal(dateToSerial(utc(1899, 12, 30)), 0);
+    assert.equal(dateToSerial(utc(1899, 12, 31)), 1);
+  });
+
+  it("counts whole days forward", () => {
+    assert.equal(dateToSerial(utc(1900, 1, 2)), 3);
+    assert.equal(dateToSerial(utc(1900, 2, 1)), 33);
+  });
+
+  // The point of the Dec 30 1899 base: Excel counts a phantom 1900-02-29 that
+  // never existed, and starting two days early makes every serial from March
+  // 1900 onward — i.e. every date anyone actually uses — agree with Excel's.
+  it("agrees with Excel from March 1900 onward", () => {
+    assert.equal(dateToSerial(utc(1900, 3, 1)), 61); // Excel: 61
+    assert.equal(dateToSerial(utc(2000, 1, 1)), 36526); // Excel: 36526
+    assert.equal(dateToSerial(utc(2026, 7, 22)), 46225);
+  });
+
+  // The flip side of that choice, pinned so it is a known limitation rather
+  // than a surprise: for the first two months of 1900 the serials sit one
+  // ahead of Excel's, because the phantom leap day has not been passed yet.
+  it("sits one ahead of Excel for Jan and Feb 1900", () => {
+    assert.equal(dateToSerial(utc(1900, 1, 1)), 2); // Excel: 1
+    assert.equal(dateToSerial(utc(1900, 2, 28)), 60); // Excel: 59
+  });
+
+  it("represents a time of day as the fractional part", () => {
+    assert.equal(dateToSerial(utc(1899, 12, 31, 12)), 1.5);
+    assert.equal(dateToSerial(utc(1899, 12, 31, 6)), 1.25);
+  });
+
+  it("goes negative for dates before the base", () => {
+    assert.ok(dateToSerial(utc(1899, 12, 29)) < 0);
+  });
+});
+
+describe("serialToDate", () => {
+  it("maps serial 1 back to the day after the base", () => {
+    assert.equal(serialToDate(1).toISOString().slice(0, 10), "1899-12-31");
+  });
+
+  it("maps a modern serial back to its date", () => {
+    assert.equal(serialToDate(46225).toISOString().slice(0, 10), "2026-07-22");
+    assert.equal(serialToDate(61).toISOString().slice(0, 10), "1900-03-01");
+  });
+
+  it("restores the time of day from the fractional part", () => {
+    assert.equal(serialToDate(1.5).toISOString().slice(11, 19), "12:00:00");
+    assert.equal(serialToDate(1.25).toISOString().slice(11, 19), "06:00:00");
+  });
+
+  // The fraction is rounded to the nearest second, so a value that lands
+  // mid-second must not drift to the previous one.
+  it("rounds the time component to the nearest second", () => {
+    const almostOneMinute = 1 + 59.6 / 86400;
+    assert.equal(serialToDate(almostOneMinute).toISOString().slice(11, 19), "00:01:00");
+  });
+});
+
+describe("dateToSerial / serialToDate round-trip", () => {
+  it("round-trips whole days across month, year and leap boundaries", () => {
+    const dates = [utc(1900, 1, 1), utc(1900, 3, 1), utc(1999, 12, 31), utc(2000, 2, 29), utc(2024, 2, 29), utc(2026, 7, 22), utc(2100, 1, 1)];
+    for (const date of dates) {
+      const back = serialToDate(dateToSerial(date));
+      assert.equal(back.toISOString(), date.toISOString(), `round-trip failed for ${date.toISOString()}`);
+    }
+  });
+
+  it("round-trips a date carrying a time of day", () => {
+    const date = utc(2026, 7, 22, 13, 45, 30);
+    assert.equal(serialToDate(dateToSerial(date)).toISOString(), date.toISOString());
+  });
+});
+
+describe("name tables", () => {
+  // These are indexed by `getMonth()` / `getDay()` directly, so a wrong length
+  // or a shifted entry produces an off-by-one month or weekday with no error.
+  it("has twelve months starting at January", () => {
+    assert.equal(MONTH_NAMES_SHORT.length, 12);
+    assert.equal(MONTH_NAMES_FULL.length, 12);
+    assert.equal(MONTH_NAMES_SHORT[0], "Jan");
+    assert.equal(MONTH_NAMES_FULL[0], "January");
+    assert.equal(MONTH_NAMES_SHORT[11], "Dec");
+    assert.equal(MONTH_NAMES_FULL[11], "December");
+  });
+
+  it("has seven days starting at Sunday, matching Date#getDay", () => {
+    assert.equal(DAY_NAMES_SHORT.length, 7);
+    assert.equal(DAY_NAMES_FULL.length, 7);
+    assert.equal(DAY_NAMES_SHORT[0], "Sun");
+    assert.equal(DAY_NAMES_FULL[0], "Sunday");
+    assert.equal(DAY_NAMES_SHORT[6], "Sat");
+  });
+
+  it("keeps the short names as prefixes of the full names", () => {
+    MONTH_NAMES_SHORT.forEach((short, index) =>
+      assert.ok(MONTH_NAMES_FULL[index]?.startsWith(short), `${short} is not a prefix of ${String(MONTH_NAMES_FULL[index])}`),
+    );
+    DAY_NAMES_SHORT.forEach((short, index) =>
+      assert.ok(DAY_NAMES_FULL[index]?.startsWith(short), `${short} is not a prefix of ${String(DAY_NAMES_FULL[index])}`),
+    );
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_parser.ts
+++ b/test/plugins/spreadsheet/engine/test_parser.ts
@@ -1,0 +1,93 @@
+// A1-notation column conversion. Every other reference-handling path in the
+// engine is built on these two, and both fail silently: `columnToIndex` does
+// arithmetic on char codes with no validation, so a bad input returns a
+// plausible-looking number instead of throwing, and the caller reads the wrong
+// column.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { columnToIndex, indexToColumn } from "../../../../src/plugins/spreadsheet/engine/parser.ts";
+
+describe("columnToIndex", () => {
+  it("maps the single-letter columns", () => {
+    assert.equal(columnToIndex("A"), 0);
+    assert.equal(columnToIndex("B"), 1);
+    assert.equal(columnToIndex("Z"), 25);
+  });
+
+  // The bijective-base-26 boundary: AA follows Z, not "BA" or index 26+1.
+  it("maps the two-letter columns across the Z→AA boundary", () => {
+    assert.equal(columnToIndex("AA"), 26);
+    assert.equal(columnToIndex("AB"), 27);
+    assert.equal(columnToIndex("AZ"), 51);
+    assert.equal(columnToIndex("BA"), 52);
+    assert.equal(columnToIndex("ZZ"), 701);
+  });
+
+  it("maps three-letter columns", () => {
+    assert.equal(columnToIndex("AAA"), 702);
+    // XFD is Excel's last column (16384 columns, 0-based → 16383).
+    assert.equal(columnToIndex("XFD"), 16383);
+  });
+
+  // Documented current behaviour, NOT an endorsement: the function does no
+  // validation, so these return numbers rather than failing. Callers all
+  // pre-match `[A-Z]+`, which is what keeps the garbage out today — pinned so
+  // that if a caller's regex is ever relaxed, the consequence is visible here.
+  it("returns a wrong-but-plausible index for lowercase input (no validation)", () => {
+    // 'a' is 97; 97 - 64 - 1 = 32, i.e. column AG.
+    assert.equal(columnToIndex("a"), 32);
+    assert.equal(columnToIndex("z"), 57);
+  });
+
+  it("returns -1 for the empty string", () => {
+    assert.equal(columnToIndex(""), -1);
+  });
+});
+
+describe("indexToColumn", () => {
+  it("maps the single-letter columns", () => {
+    assert.equal(indexToColumn(0), "A");
+    assert.equal(indexToColumn(1), "B");
+    assert.equal(indexToColumn(25), "Z");
+  });
+
+  it("maps the two-letter columns across the Z→AA boundary", () => {
+    assert.equal(indexToColumn(26), "AA");
+    assert.equal(indexToColumn(27), "AB");
+    assert.equal(indexToColumn(51), "AZ");
+    assert.equal(indexToColumn(52), "BA");
+    assert.equal(indexToColumn(701), "ZZ");
+  });
+
+  it("maps three-letter columns", () => {
+    assert.equal(indexToColumn(702), "AAA");
+    assert.equal(indexToColumn(16383), "XFD");
+  });
+
+  it("returns an empty string for a negative index", () => {
+    assert.equal(indexToColumn(-1), "");
+  });
+});
+
+describe("columnToIndex / indexToColumn round-trip", () => {
+  // The pair is used in both directions on the same value (range expansion
+  // walks indices, then renders refs back), so an asymmetry anywhere in the
+  // range silently shifts a whole range by one column.
+  it("round-trips every index across the single/double/triple letter boundaries", () => {
+    const boundaries = [0, 1, 24, 25, 26, 27, 50, 51, 52, 700, 701, 702, 703, 16382, 16383];
+    for (const index of boundaries) {
+      assert.equal(columnToIndex(indexToColumn(index)), index, `round-trip failed at ${index}`);
+    }
+  });
+
+  it("round-trips a contiguous span with no gaps or repeats", () => {
+    const seen = new Set<string>();
+    for (let index = 0; index <= 1000; index++) {
+      const col = indexToColumn(index);
+      assert.equal(seen.has(col), false, `duplicate column label ${col} at index ${index}`);
+      seen.add(col);
+      assert.equal(columnToIndex(col), index);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

数式エンジンの**土台 2 モジュール**に初のテスト。**本番コードの差分ゼロ**、テスト 2 ファイル（26 件）。

セル参照に触るものは全部 `parser.ts` を、日付関数は全部 `date-utils.ts` を通ります。どちらも未テストで、どちらも**静かに壊れる**種類です — 列インデックスが違えば別のセルを読み、シリアル値が違えば「実在するが間違った日付」が表示されます。

## Items to Confirm / Review

1. **`columnToIndex` に検証が一切無いことをテストで明示しました。** 小文字 `"a"` は失敗せず **32（列 AG）** を返し、`""` は `-1` を返します。これは是認ではなく**記録**です — 現状ゴミが入らないのは呼び出し側が全部 `[A-Z]+` で前もって弾いているからで、その正規表現が緩められたときに**ユーザーの集計値ではなくここで**気づけるようにしました。

2. **1900年うるう年バグの扱いを両面とも固定しました。** Dec 30 1899 基準は、Excel が実在しない `1900-02-29` を数えるのに合わせるためのものです。2 日早く始めることで **1900年3月以降のシリアルが Excel と一致**します（既知値で検証: `2000-01-01` = 36526、`1900-03-01` = 61）。

   その裏返しも固定しました — **1900年1〜2月は Excel より 1 進んでいます**（`1900-01-01` はこの実装で 2、Excel は 1）。実在する制限なので、驚きではなく**記録**にしておくべきと判断しました。

3. **変異検証済み**:
   | 変異 | 赤 |
   |---|---|
   | `columnToIndex` の 0-based 変換を外す | 7 |
   | `indexToColumn` の bijective base-26 を壊す | 5 |
   | 基準日を 1 日ずらす | 7 |
   | `serialToDate` の秒丸めを `floor` に | 2 |

4. **1000 個の連続インデックスで往復検証**しています（ラベルの重複・欠落なし）。範囲展開はインデックスを歩いてから参照に戻すので、どこかに非対称があると**範囲まるごと 1 列ずれる**ためです。

## 進め方

#2325 で報告した数式エンジンの問題（`=SUM(A1)` が 0、空セルが 0 として集計に混入、日付パースの MM/DD 固定など）は、**テストゼロの状態で挙動を変えるのが最も危険**な領域です。まず土台から特性テストで固めて、その上で 1 件ずつ直します。この PR は土台の 2 モジュールのみです。

次は `date-parser.ts` / `registry.ts` / `formatter.ts` を同様に。

## User Prompt

> スプレッドシートは、とくに入念に関数分けてテストを作って〜〜〜
>
> PRは細かく作って

## Test plan

- `yarn test` — 7764 件 pass / 0 fail（+26）
- `yarn lint` / `yarn typecheck` — green
- 本番コードの差分ゼロ

Refs #2325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
