### PR TITLE
fix(spreadsheet): replace date-format tokens in one pass

### DIFF
--- a/src/plugins/spreadsheet/engine/formatter.ts
+++ b/src/plugins/spreadsheet/engine/formatter.ts
@@ -31,6 +31,12 @@ function isDateFormat(format: string): boolean {
  * @param format - Date format code
  * @returns Formatted date string
  */
+// Every token, longest-first within each family so `MMMM` wins over `MMM` and
+// `MM`. Matched in ONE pass: a sequence of `replace` calls re-scans its own
+// output, so an inserted "March" had its `M` rewritten by the later month-number
+// step and "AM/PM" was destroyed before the meridiem branch could see it.
+const DATE_TOKEN_RE = /YYYY|YY|MMMM|MMM|MM|M|dddd|ddd|DD|D|AM\/PM|am\/pm|HH|H|hh|h|mm|ss/g;
+
 function formatDate(serial: number, format: string): string {
   const date = serialToDate(serial);
 
@@ -42,46 +48,34 @@ function formatDate(serial: number, format: string): string {
   const seconds = date.getUTCSeconds();
   const dayOfWeek = date.getUTCDay(); // 0-6
 
-  let result = format;
+  // `h` means the 12-hour clock only when the format also asks for a meridiem;
+  // decided from the ORIGINAL format, before any substitution.
+  const uses12Hour = /AM\/PM|am\/pm/.test(format);
+  const hours12 = hours % 12 || 12; // 0 becomes 12
+  const isPM = hours >= 12;
 
-  // Replace year tokens
-  result = result.replace(/YYYY/g, year.toString());
-  result = result.replace(/YY/g, (year % 100).toString().padStart(2, "0"));
+  const replacements: Record<string, string> = {
+    YYYY: year.toString(),
+    YY: (year % 100).toString().padStart(2, "0"),
+    MMMM: MONTH_NAMES_FULL[month] ?? MONTH_NAMES_FULL[0],
+    MMM: MONTH_NAMES_SHORT[month] ?? MONTH_NAMES_SHORT[0],
+    MM: (month + 1).toString().padStart(2, "0"),
+    M: (month + 1).toString(),
+    dddd: DAY_NAMES_FULL[dayOfWeek] ?? DAY_NAMES_FULL[0],
+    ddd: DAY_NAMES_SHORT[dayOfWeek] ?? DAY_NAMES_SHORT[0],
+    DD: day.toString().padStart(2, "0"),
+    D: day.toString(),
+    "AM/PM": isPM ? "PM" : "AM",
+    "am/pm": isPM ? "pm" : "am",
+    HH: hours.toString().padStart(2, "0"),
+    H: hours.toString(),
+    hh: (uses12Hour ? hours12 : hours).toString().padStart(2, "0"),
+    h: (uses12Hour ? hours12 : hours).toString(),
+    mm: minutes.toString().padStart(2, "0"),
+    ss: seconds.toString().padStart(2, "0"),
+  };
 
-  // Replace month tokens (order matters - do longer patterns first)
-  result = result.replace(/MMMM/g, MONTH_NAMES_FULL[month] || MONTH_NAMES_FULL[0]);
-  result = result.replace(/MMM/g, MONTH_NAMES_SHORT[month] || MONTH_NAMES_SHORT[0]);
-  result = result.replace(/MM/g, (month + 1).toString().padStart(2, "0"));
-  result = result.replace(/M/g, (month + 1).toString());
-
-  // Replace day tokens
-  result = result.replace(/DD/g, day.toString().padStart(2, "0"));
-  result = result.replace(/D/g, day.toString());
-
-  // Replace day of week tokens
-  result = result.replace(/dddd/g, DAY_NAMES_FULL[dayOfWeek] || DAY_NAMES_FULL[0]);
-  result = result.replace(/ddd/g, DAY_NAMES_SHORT[dayOfWeek] || DAY_NAMES_SHORT[0]);
-
-  // Replace time tokens
-  // Handle 12-hour format with AM/PM
-  if (result.includes("AM/PM") || result.includes("am/pm")) {
-    const isPM = hours >= 12;
-    const hours12 = hours % 12 || 12; // 0 becomes 12
-
-    result = result.replace(/h/g, hours12.toString());
-    result = result.replace(/AM\/PM/g, isPM ? "PM" : "AM");
-    result = result.replace(/am\/pm/g, isPM ? "pm" : "am");
-  } else {
-    // 24-hour format
-    result = result.replace(/HH/g, hours.toString().padStart(2, "0"));
-    result = result.replace(/H/g, hours.toString());
-    result = result.replace(/h/g, hours.toString());
-  }
-
-  result = result.replace(/mm/g, minutes.toString().padStart(2, "0"));
-  result = result.replace(/ss/g, seconds.toString().padStart(2, "0"));
-
-  return result;
+  return format.replace(DATE_TOKEN_RE, (token) => replacements[token] ?? token);
 }
 
 /**

--- a/test/plugins/spreadsheet/engine/test_formatter.ts
+++ b/test/plugins/spreadsheet/engine/test_formatter.ts
@@ -1,0 +1,136 @@
+// Excel format codes → display strings. Nothing here throws: a bad format code
+// produces a bad-looking cell, and a wrong decimal count produces a number that
+// is simply off. Both read as ordinary output.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatNumber } from "../../../../src/plugins/spreadsheet/engine/formatter.ts";
+import { dateToSerial } from "../../../../src/plugins/spreadsheet/engine/date-utils.ts";
+
+const serialOf = (year: number, month: number, day: number, hour = 0, minute = 0, second = 0) =>
+  dateToSerial(new Date(Date.UTC(year, month - 1, day, hour, minute, second)));
+
+const MAR_4_2025 = serialOf(2025, 3, 4);
+
+describe("formatNumber — numeric date formats", () => {
+  it("renders the padded and unpadded numeric orders", () => {
+    assert.equal(formatNumber(MAR_4_2025, "MM/DD/YYYY"), "03/04/2025");
+    assert.equal(formatNumber(MAR_4_2025, "M/D/YYYY"), "3/4/2025");
+    assert.equal(formatNumber(MAR_4_2025, "YYYY-MM-DD"), "2025-03-04");
+    assert.equal(formatNumber(MAR_4_2025, "DD/MM/YYYY"), "04/03/2025");
+  });
+
+  it("renders a two-digit year", () => {
+    assert.equal(formatNumber(MAR_4_2025, "MM/DD/YY"), "03/04/25");
+  });
+});
+
+describe("formatNumber — month-name formats", () => {
+  // The regression from #2330: substitution used to run as a sequence of
+  // replaces, so `/M/g` fired AFTER the month name had been inserted and
+  // rewrote the M inside "Mar" / "March" — and "March" then lost its "h" to
+  // the hour token, giving "3arc0".
+  it("renders month names intact", () => {
+    assert.equal(formatNumber(MAR_4_2025, "DD-MMM-YYYY"), "04-Mar-2025");
+    assert.equal(formatNumber(MAR_4_2025, "MMM D, YYYY"), "Mar 4, 2025");
+    assert.equal(formatNumber(MAR_4_2025, "MMMM D, YYYY"), "March 4, 2025");
+  });
+
+  // These are the shapes `getDefaultDateFormat` hands back for the matching
+  // input, so a user typing "4-Mar-2025" gets this format applied to their own
+  // cell without asking for it.
+  it("round-trips the formats getDefaultDateFormat infers", () => {
+    assert.equal(formatNumber(serialOf(2025, 9, 30), "MMMM D, YYYY"), "September 30, 2025");
+    assert.equal(formatNumber(serialOf(2025, 12, 1), "DD-MMM-YYYY"), "01-Dec-2025");
+  });
+
+  it("renders weekday names", () => {
+    assert.equal(formatNumber(MAR_4_2025, "dddd"), "Tuesday");
+    assert.equal(formatNumber(MAR_4_2025, "ddd"), "Tue");
+  });
+});
+
+describe("formatNumber — time formats", () => {
+  it("renders 24-hour time", () => {
+    assert.equal(formatNumber(serialOf(2025, 3, 4, 13, 45, 30), "HH:mm:ss"), "13:45:30");
+    assert.equal(formatNumber(serialOf(2025, 3, 4, 9, 5, 0), "HH:mm"), "09:05");
+  });
+
+  it("renders 12-hour time with a meridiem", () => {
+    assert.equal(formatNumber(serialOf(2025, 3, 4, 13, 45), "h:mm AM/PM"), "1:45 PM");
+    assert.equal(formatNumber(serialOf(2025, 3, 4, 9, 5), "h:mm AM/PM"), "9:05 AM");
+  });
+
+  // Midnight and noon are the two values a `% 12` gets wrong without the
+  // `|| 12` fallback.
+  it("renders midnight as 12 AM and noon as 12 PM", () => {
+    assert.equal(formatNumber(serialOf(2025, 3, 4, 0, 0), "h:mm AM/PM"), "12:00 AM");
+    assert.equal(formatNumber(serialOf(2025, 3, 4, 12, 0), "h:mm AM/PM"), "12:00 PM");
+  });
+});
+
+describe("formatNumber — currency", () => {
+  it("renders a currency amount with separators and decimals", () => {
+    assert.equal(formatNumber(1234.5, "$#,##0.00"), "$1,234.50");
+    assert.equal(formatNumber(1234.5, "$#,##0"), "$1,235");
+    assert.equal(formatNumber(1234.5, "$0.00"), "$1234.50");
+  });
+
+  it("groups every three digits", () => {
+    assert.equal(formatNumber(1234567.89, "$#,##0.00"), "$1,234,567.89");
+    assert.equal(formatNumber(100, "$#,##0"), "$100");
+    assert.equal(formatNumber(1000, "$#,##0"), "$1,000");
+  });
+
+  // The sign goes outside the symbol: "-$1,000.00", not "$-1,000.00".
+  it("puts the minus sign before the currency symbol", () => {
+    assert.equal(formatNumber(-1000, "$#,##0.00"), "-$1,000.00");
+  });
+
+  it("renders zero", () => {
+    assert.equal(formatNumber(0, "$#,##0.00"), "$0.00");
+  });
+});
+
+describe("formatNumber — percentage", () => {
+  it("multiplies by 100 and appends the sign", () => {
+    assert.equal(formatNumber(0.5, "0.0%"), "50.0%");
+    assert.equal(formatNumber(0.1234, "0.00%"), "12.34%");
+    assert.equal(formatNumber(1, "0.00%"), "100.00%");
+  });
+
+  // The decimal count is read from a `.0+` run in the format. A format with no
+  // such run falls back to 2 for percentages while currency falls back to 0 —
+  // an asymmetry worth knowing about, since "0%" renders as "50.00%".
+  it("falls back to two decimals when the format declares none", () => {
+    assert.equal(formatNumber(0.5, "0%"), "50.00%");
+  });
+});
+
+describe("formatNumber — plain numbers", () => {
+  it("renders a fixed number of decimals", () => {
+    assert.equal(formatNumber(1234.5678, "0.00"), "1234.57");
+    assert.equal(formatNumber(1234.5678, "0.000"), "1234.568");
+  });
+
+  it("renders thousands separators without a currency symbol", () => {
+    assert.equal(formatNumber(1234567, "#,##0"), "1,234,567");
+    assert.equal(formatNumber(1234.5, "#,##0.00"), "1,234.50");
+    assert.equal(formatNumber(-1234.5, "#,##0.00"), "-1,234.50");
+  });
+
+  it("returns the raw number when there is no format", () => {
+    assert.equal(formatNumber(1234.5, ""), "1234.5");
+  });
+
+  // `#` placeholders are not read at all — only a literal `.0+` run sets the
+  // decimal count — so a format built from them is ignored entirely.
+  it("ignores a format whose decimals are written with # placeholders", () => {
+    assert.equal(formatNumber(0.5, "0.##"), "0.5");
+    assert.equal(formatNumber(1234.5678, "0.###"), "1234.5678");
+  });
+
+  it("reads the decimal count from the leading .0 run of a mixed format", () => {
+    assert.equal(formatNumber(0.5, "0.0#"), "0.5");
+  });
+});


### PR DESCRIPTION
## Summary

月名と12時間表記の日付フォーマットが**壊れた文字列を表示していた**バグの修正です。

```
DD-MMM-YYYY    → "04-3ar-2025"
MMM D, YYYY    → "3ar 4, 2025"
MMMM D, YYYY   → "3arc0 4, 2025"
h:mm AM/PM     → "13:45 A3/P3"
```

## 原因

`formatDate` はトークンを **`replace` の連鎖**で置換しており、各呼び出しが**前の呼び出しの出力を再走査**していました。

月番号のための `/M/g` が、月**名**を挿入した**後**に走るため、`"Mar"` / `"March"` の中の `M` を書き換えます。`"March"` はさらに `h` を時刻トークンとして奪われ `"3arc0"` になります。

同じ `/M/g` がリテラルの `"AM/PM"` も `"A3/P3"` に破壊するため、**12時間表記の分岐に到達できず**、該当フォーマットはすべて 24時間表記＋壊れたマーカーで描画されていました。

## 到達経路（設定不要、通常操作で踏める）

1. セルに `4-Mar-2025` と入力
2. `getDefaultDateFormat` が `DD-MMM-YYYY` を推定
3. そのフォーマットで描画され、**`04-3ar-2025`** が表示される

## 修正

**1 回の `replace`** に変更しました。family ごとに長いものを先に並べた alternation と、トークン → 値のルックアップ表です。

単一パスは自分の出力を再走査しないので、**この種の破壊は構造的に起きなくなります**（個別に潰したのではなく、起こりえない形にしました）。12/24 時間の判定は、置換前の**元のフォーマット文字列**から取ります。

`hh` も追加しました — 連鎖版には**そもそも存在せず**、`hh:mm` はリテラルの `"hh"` を残していました。

## Items to Confirm / Review

1. **修正前のコードで 4 件落ちることを確認済み。**
2. **同ファイルの残り 2 件は別 PR にします。** どちらも「何を描画するか」ではなく「どちらのフォーマッタに振り分けるか」を変える話なので、分けた方が安全です:
   - `isDateFormat` の `[YMD]` が**大小無視**のため `"#,##0 USD"` が日付として処理される（`"#,##0 US18"` になる）
   - 小数桁がリテラルの `.0+` からしか読まれないため、`"0.##"` は無視され、`"0"` は丸めない
3. **e2e への影響**: `e2e/tests/spreadsheet.spec.ts` に月名フォーマットのアサーションは無く（日付は ISO のみ）、影響しないはずですが CI で確認します。

## User Prompt

> スプレッドシートは、とくに入念に関数分けてテストを作って〜〜〜
> PRは細かく作って / そして、もっと細かく見ていって / 両方並行でどんどんつくっていいて。

## Test plan

- `test/plugins/spreadsheet/engine/test_formatter.ts` — 19 件（このモジュール初）
- `yarn test` — 7757 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

Fixes #2330

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Excel-style date and time formatting, including reliable 12-hour and 24-hour display behavior.
  * Corrected handling for midnight, noon, month names, weekdays, years, and date token combinations.

* **Tests**
  * Added coverage for date, time, currency, percentage, and numeric formatting scenarios.
  * Verified decimal precision, thousands separators, signs, zero values, and default formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->