### PR TITLE
refactor(sessions): make src/types/session.ts the single source of truth for SessionSummary

### DIFF
--- a/plans/refactor-2334-session-summary.md
+++ b/plans/refactor-2334-session-summary.md
@@ -1,0 +1,69 @@
+# refactor: unify the duplicated `SessionSummary` declaration
+
+Issue: #2334
+
+## Context
+
+`jscpd` flagged 75 tokens / 42 lines duplicated between
+`server/api/routes/sessions.ts` (71-110) and `src/types/session.ts` (59-85):
+the same `interface SessionSummary` written out twice, once per side of the
+`GET /api/sessions` boundary.
+
+Unlike the other dedup issues in this batch, the payoff here is not line
+count — it is that **TypeScript cannot police an API boundary described by two
+independent types**. Add a field server-side and forget the client copy: no
+error, the field is just permanently `undefined` at runtime. Add it
+client-side only: same silence, opposite direction.
+
+## Pre-check: are they actually identical today?
+
+Yes. Stripping comments from both declarations gives a byte-identical field
+list — same 14 fields, same order, same types, same optionality:
+
+```
+id, roleId, startedAt, updatedAt, preview, summary?, keywords?, origin?,
+isBookmarked?, userQueryCount?, isRunning?, liveIsRunning?, hasUnread?,
+statusMessage?
+```
+
+No live drift to report. Only the comment prose differs.
+
+## Change
+
+- `src/types/session.ts` keeps the declaration and becomes the single source
+  of truth. Comment blocks from both sides are merged into it (the `#123`
+  chat-indexer origin of `summary`/`keywords`, the `#486` origin field, the
+  `#1195` broad-`isRunning` vs narrow-`liveIsRunning` split and why the narrow
+  one must stay byte-identical to the DELETE 409 gate).
+- `server/api/routes/sessions.ts` drops its copy and widens its existing
+  `../../../src/types/session.js` import to pull in `type SessionSummary`.
+  The route already imports `SESSION_ORIGINS` / `SessionOrigin` from that same
+  path and `API_ROUTES` from `../../../src/config/apiRoutes.js`, so no new
+  dependency direction is introduced.
+- The server's `export` on the interface is dropped, not converted to a
+  re-export: nothing imported `SessionSummary` from the route module, and
+  CLAUDE.md forbids unjustified re-exports.
+
+## Deliberately NOT touched
+
+- `packages/chat-service/src/types.ts` also declares a `SessionSummary`, but
+  it is a genuinely different, narrower shape (`id`, `roleId`, `preview`,
+  `updatedAt`) belonging to the bridge chat-service contract. Not a duplicate.
+- `test/routes/test_sessionsRoute.ts` declares a local 5-field
+  `SessionSummary` for its response assertions. Deliberately narrow — the test
+  asserts on the subset it cares about and should not be coupled to every
+  optional field the route may add.
+
+## Verification
+
+Type-only change, so the type checkers are the test:
+
+- `yarn typecheck` (vue + server + test + e2e + e2e-live + packages) and
+  `npx vite build`.
+- `test/routes/test_sessionsRoute.ts`, `test/utils/session/*`,
+  `test/composables/test_useSessionHistoryHelpers.ts`.
+- Boundary proof: temporarily add a field to the shared `SessionSummary` and
+  confirm `typecheck:server` now sees it from `server/api/routes/sessions.ts`
+  (it did — the excess-property check fired inside `buildSessionSummary`),
+  then remove it. Before this change the same experiment would have been
+  invisible to the server.

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -20,7 +20,7 @@ import { markRead, getSession, evictSession, publishSessionsChanged } from "../.
 import { notFound } from "../../utils/httpError.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
-import { SESSION_ORIGINS, type SessionOrigin } from "../../../src/types/session.js";
+import { SESSION_ORIGINS, type SessionOrigin, type SessionSummary } from "../../../src/types/session.js";
 import { env } from "../../system/env.js";
 import { ONE_DAY_MS } from "../../utils/time.js";
 import { encodeCursor, parseCursor, sessionChangeMs } from "./sessionsCursor.js";
@@ -67,46 +67,6 @@ async function readSessionMeta(__chatDir: string, sessionId: string): Promise<Se
     }
   }
   return null;
-}
-
-export interface SessionSummary {
-  id: string;
-  roleId: string;
-  startedAt: string;
-  // ISO timestamp of the jsonl file's most recent mtime — i.e. the
-  // last time the session had an event appended. Clients sort the
-  // sidebar history list by this so active sessions float to the top.
-  updatedAt: string;
-  preview: string;
-  // Populated when the chat indexer has produced a summary for this
-  // session. The frontend renders `summary` as a smaller second line
-  // under the preview in the history popup. See #123.
-  summary?: string;
-  keywords?: string[];
-  // Where this session originated (#486). Missing = "human".
-  origin?: SessionOrigin;
-  // User-toggled bookmark — surfaced in the history panel as a
-  // dedicated filter chip and a green role-icon tint.
-  isBookmarked?: boolean;
-  // Number of user turns sent to this session. Lets the history panel
-  // tell a one-shot (1) apart from a long-running conversation.
-  userQueryCount?: number;
-  // Live state from the in-memory session store. Absent when the
-  // session has no active entry in the store (i.e. idle / historical).
-  //
-  // `isRunning` is the BROAD predicate: agent turn live OR any
-  // background generation (image/audio/movie) still pending. Drives
-  // the sidebar "busy" indicator that must stay lit across nav.
-  //
-  // `liveIsRunning` is the NARROW predicate: exactly the
-  // `DELETE /api/sessions/:id` 409 gate (`getSession()?.isRunning`).
-  // Exposed for cleanup-style callers (e2e-live `waitForSessionIdle`)
-  // that need to poll "is DELETE accepted yet" without over-waiting
-  // on lingering pendingGenerations. See issue #1195.
-  isRunning?: boolean;
-  liveIsRunning?: boolean;
-  hasUnread?: boolean;
-  statusMessage?: string;
 }
 
 // Public response envelope for GET /api/sessions (issue #205).

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -47,37 +47,45 @@ export function isSessionOrigin(value: unknown): value is SessionOrigin {
   return pluginPkgFromOrigin(value) !== null;
 }
 
-// Server `/api/sessions` summary. Optional `summary` and `keywords`
-// are populated by the chat indexer (#123) when present.
-//
-// `updatedAt` is the most recent activity timestamp — taken from the
-// jsonl file's mtime on the server side and bumped whenever the
-// client appends a message in-memory. Used for the "most recently
-// touched" sort order in the session history sidebar (users expect
-// active sessions to float to the top, not to stay pinned in
-// creation order).
+// Response shape of `GET /api/sessions`. Single source of truth for both
+// sides of that boundary — `server/api/routes/sessions.ts` imports this type
+// rather than restating it, so a field added on one side can't silently be
+// missing on the other.
 export interface SessionSummary {
   id: string;
   roleId: string;
   startedAt: string;
+  /** Most recent activity: the jsonl file's mtime server-side, bumped
+   *  in-memory whenever the client appends a message. The history sidebar
+   *  sorts on it, so active sessions float to the top instead of staying
+   *  pinned in creation order. */
   updatedAt: string;
   preview: string;
+  /** Produced by the chat indexer (#123); rendered as a smaller second line
+   *  under `preview` in the history popup. */
   summary?: string;
   keywords?: string[];
-  /** Where this session originated. Missing = "human" (backward compat). */
+  /** Where this session originated (#486). Missing = "human" (backward
+   *  compat). */
   origin?: SessionOrigin;
-  /** User-set bookmark flag. Persisted in the meta sidecar. */
+  /** User-set bookmark flag, persisted in the meta sidecar. Surfaced as a
+   *  dedicated history filter chip and a green role-icon tint. */
   isBookmarked?: boolean;
-  /** Number of user turns sent to this session (server-derived from the
-   *  meta sidecar). One-shot sessions have 1; long conversations more. */
+  /** Number of user turns, server-derived from the meta sidecar. Lets the
+   *  history panel tell a one-shot (1) apart from a long conversation. */
   userQueryCount?: number;
-  // Live state from the server session store (present when the
-  // session has an active in-memory entry on the server).
+  // Live state from the server's in-memory session store. Absent when the
+  // session has no active entry there (i.e. idle / historical).
   //
-  // `isRunning` — broad: agent turn live OR background generation
-  // pending. Drives the sidebar busy indicator.
-  // `liveIsRunning` — narrow: mirrors the DELETE 409 gate exactly
-  // (#1195). `false` ⇒ a DELETE on this session will be accepted.
+  // `isRunning` is the BROAD predicate: agent turn live OR any background
+  // generation (image/audio/movie) still pending. Drives the sidebar busy
+  // indicator, which has to stay lit across navigation.
+  //
+  // `liveIsRunning` is the NARROW predicate: byte-identical to the
+  // `DELETE /api/sessions/:id` 409 gate (`getSession()?.isRunning`), so
+  // `false` ⇒ a DELETE will be accepted. Exposed for cleanup-style callers
+  // (e2e-live `waitForSessionIdle`) that must not over-wait on lingering
+  // pendingGenerations (#1195).
   isRunning?: boolean;
   liveIsRunning?: boolean;
   hasUnread?: boolean;


### PR DESCRIPTION
## Summary

`interface SessionSummary` was declared **twice** — `server/api/routes/sessions.ts` (71-110) and `src/types/session.ts` (59-85) — with a field-for-field identical body and separately-written comments.

The problem isn't the ~40 duplicated lines, it's that **two independent types mean TypeScript cannot police the `GET /api/sessions` boundary**. Add a field server-side and forget the client copy: no error, the field is just permanently `undefined` at runtime. Add it client-side only: same silence, opposite direction.

`src/types/session.ts` is now the single source of truth; the server `import type`s it.

## Items to Confirm / Review

1. **The two declarations were verified identical before merging them.** Stripping comments from both gives a byte-identical 14-field list (`id, roleId, startedAt, updatedAt, preview, summary?, keywords?, origin?, isBookmarked?, userQueryCount?, isRunning?, liveIsRunning?, hasUnread?, statusMessage?`) — same order, types, and optionality. **No live drift existed**, so nothing was silently picked over the other. Worth a second pair of eyes on that claim since it's the whole premise of the change.

2. **Comment merge is the only lossy part.** Both copies carried different history and I consolidated into one block, keeping the WHY and dropping restatements of WHAT: `#123` (chat-indexer `summary`/`keywords`), `#486` (`origin`, missing = `"human"`), `#1195` (broad `isRunning` vs narrow `liveIsRunning` and why the narrow one must stay byte-identical to the `DELETE` 409 gate), plus `updatedAt`'s mtime-derivation + sidebar-sort rationale and `isBookmarked`'s filter-chip/role-icon surfacing. Please check nothing load-bearing was dropped.

3. **`export` was removed, not converted to a re-export.** Nothing imported `SessionSummary` from the route module (`grep -rn "SessionSummary"` across the repo, `server/remoteHost/` included, confirms zero importers), and CLAUDE.md forbids unjustified re-exports.

4. **Dependency direction.** The server importing from `src/` is pre-existing here — the same file already imports `SESSION_ORIGINS` / `SessionOrigin` from `../../../src/types/session.js` and `API_ROUTES` from `../../../src/config/apiRoutes.js`. The change widens an existing import rather than adding a new edge, and the specifier style (`.js` extension, relative path) matches its neighbours.

5. **Two other `SessionSummary` declarations were deliberately left alone** (see "Deliberately NOT touched" below) — confirm you agree they're genuinely different types, not more of the same duplication.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> 並列でね
>
> issueつくったらどんどんすすめて

## Implementation

Plan: [`plans/refactor-2334-session-summary.md`](plans/refactor-2334-session-summary.md)

### Change

- `src/types/session.ts` keeps the declaration, with the comment blocks from both sides merged in.
- `server/api/routes/sessions.ts` drops its copy; its existing `../../../src/types/session.js` import widens to `import { SESSION_ORIGINS, type SessionOrigin, type SessionSummary }`.

Net `-60 / +28` across the two source files. `SessionsResponse`, `SessionRow`, `applyLiveState` and `buildSessionSummary` all keep working against the imported type unchanged.

### Deliberately NOT touched

- `packages/chat-service/src/types.ts` also declares a `SessionSummary`, but it is a genuinely narrower, different shape (`id`, `roleId`, `preview`, `updatedAt`) belonging to the bridge chat-service contract. Not a duplicate.
- `test/routes/test_sessionsRoute.ts` declares a local 5-field `SessionSummary` for its response assertions. Deliberately narrow — the test asserts on the subset it cares about and shouldn't be coupled to every optional field the route may grow.

### Proving the fix (this is a type-only change, so the type checker IS the test)

There is no behaviour to regression-test, so instead I verified the boundary is genuinely shared, in both directions:

**After the change** — temporarily added a required `boundaryProbe2334: string` to the shared `SessionSummary`. The server immediately fails to compile:

```
server/api/routes/sessions.ts:134:9 - error TS2741: Property 'boundaryProbe2334' is missing in type
'{ id: string; roleId: string; startedAt: string; updatedAt: string; preview: string; hasUnread: boolean; }'
but required in type 'SessionSummary'.
  src/types/session.ts:55:3
    'boundaryProbe2334' is declared here.
```

**Before the change** — with the probe field still in `src/types/session.ts`, I reverted only `server/api/routes/sessions.ts` to its `main` state (its own local declaration) and re-ran `tsc -p server/tsconfig.json`: **clean, exit 0.** The new field was completely invisible to the server. That is exactly the silent drift this issue describes.

The probe field was then removed and the server typecheck re-confirmed clean.

### Checks

| Check | Result |
|---|---|
| `yarn format` | clean, no diff on either file |
| `eslint` (both changed paths) | clean |
| `tsc -p server/tsconfig.json` | pass |
| `vue-tsc --noEmit` | pass |
| `tsc -p test/tsconfig.json` | pass |
| `tsc -p e2e/tsconfig.json` | pass |
| `tsc -p e2e-live/tsconfig.json` | pass |
| `vite build` | pass |
| Session unit tests | **146/146 pass** — `test_sessionsRoute`, `test_sessionsCursor`, `test_mergeSessions`, `test_sessionEntries`, `test_sessionEntries_skill`, `test_sessionPreview`, `test_longRunning`, `test_assistantTextInterrupt`, `test_useSessionHistory`, `test_useSessionHistoryHelpers` |

Closes #2334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
