### PR TITLE
refactor(agent): delegate parseStreamEvent to createStreamParser().parse

### DIFF
--- a/plans/refactor-2339-stream-parser.md
+++ b/plans/refactor-2339-stream-parser.md
@@ -1,0 +1,96 @@
+# refactor(#2339): fold `parseStreamEvent` into `createStreamParser().parse`
+
+Issue: #2339 — `server/agent/stream.ts` holds two parsers for the same stream. The stateful
+`parse()` returned by `createStreamParser()` is the one the agent loop runs; the module-level
+`parseStreamEvent()` is a hand-copied stateless twin. Its comment says it is "used by tests
+and one-off parsing", so the test suite validates a code path production never executes:
+adding event handling to `parse()` leaves `parseStreamEvent` stale and the tests still green.
+
+## Step 0 — who actually calls `parseStreamEvent`?
+
+```
+$ grep -rn parseStreamEvent --include='*.ts' . | grep -v node_modules | grep -v /dist/
+test/agent/test_agent_stream.ts:3,76,82,101,123,140,162,177,187,204,214,220
+server/agent/stream.ts:179   (the definition)
+```
+
+**Zero production callers.** `server/agent/backend/claude-code.ts` — the only real consumer of
+this module — uses `createStreamParser()`. The "and one-off parsing" half of the comment is
+stale; the function exists solely to be tested. That makes the duplication strictly worse than
+it looks: the second implementation has no user other than the tests that vouch for it.
+
+## Step 1 — is `filterAssistantBlocks(blocks, false)` the identity?
+
+This is the one real divergence the issue flags: `parse()` runs assistant blocks through
+`filterAssistantBlocks(blockEvents, textStreamedFromDeltas)`, `parseStreamEvent` returns
+`blockEvents` untouched. On a fresh parser `textStreamedFromDeltas === false`.
+
+```ts
+function filterAssistantBlocks(blockEvents: AgentEvent[], deltaStreamed: boolean): AgentEvent[] {
+  return deltaStreamed ? blockEvents.filter((agentEvent) => agentEvent.type !== EVENT_TYPES.text) : blockEvents;
+}
+```
+
+**Yes — identity, for every input.** The body is a single ternary on `deltaStreamed` alone.
+With `deltaStreamed === false` the false branch returns the _same array reference_: `.filter()`
+never runs, nothing is copied, reordered, or dropped. No value of `blockEvents` — empty, all
+text, mixed, huge — can reach the filtering branch, because the branch is not selected by
+anything about `blockEvents`. This is established by reading the function, not by sampling
+inputs; a value-dependent filter would need `blockEvents` in the condition and it is not there.
+
+So the divergence named in the issue is **not** a behaviour difference on a fresh parser, and
+delegation is safe with respect to it.
+
+## Step 2 — two _other_ divergences the issue did not name
+
+Delegation swaps the whole body, so equivalence has to hold for every event type, not just the
+assistant path. Two cases differ, both in `parse()`'s favour:
+
+| event                                                          | `parse()` on a fresh parser         | old `parseStreamEvent`                                                                                                                    |
+| -------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `stream_event` carrying a `content_block_delta` / `text_delta` | `[{ type: text, message: delta }]`  | `[]` — `stream_event` is neither `assistant` nor `user`, so the early return swallows it                                                  |
+| `result` with a falsy `result` but a `session_id`              | `[{ type: claude_session_id, id }]` | `[]` — the guard is `event.type === "result" && event.result`, so a resultless event skips the whole block, including the session-id push |
+
+Both are behaviour _changes_, not silent ones: they are recorded here, called out in the PR, and
+pinned by tests. The second is a latent bug in the copy — a `session_id` arriving on a
+result event with empty text was dropped on the floor. Neither can regress production, because
+production never called `parseStreamEvent` (Step 0).
+
+## Decision
+
+`filterAssistantBlocks(blocks, false)` is the identity ⇒ take the delegation branch the issue
+proposes. `parseStreamEvent(event)` becomes `createStreamParser().parse(event)` — a fresh
+parser per call, which is exactly the "stateless" contract the old body approximated by
+copy-paste. The two Step-2 divergences ride along and are documented above.
+
+## Implementation
+
+- `server/agent/stream.ts`: replace the ~22-line duplicated body with the one-line delegation.
+  Rewrite the comment to explain _why_ a fresh parser per call (dedup needs one parser across a
+  whole turn) rather than restating what the line does.
+- `test/agent/test_agent_stream.ts`: keep the existing `parseStreamEvent` cases (they now
+  exercise the real parser through the alias) and add blocks that:
+  - asserts equivalence event-by-event across `result` (with / without `session_id`), a
+    non-`assistant`/`user` type, an `assistant` event mixing text + tool_use + tool_result +
+    unrecognised blocks, a `user` event, and `content` absent / not an array;
+  - pins the `filterAssistantBlocks` axis from both sides — identical output on a fresh parser,
+    and a stateful parser that _has_ streamed deltas dropping the text event that
+    `parseStreamEvent` keeps (which is why fresh-per-call is required, not incidental);
+  - pins the two Step-2 divergences as the new expected behaviour.
+
+## Verification
+
+Mutation checks (CLAUDE.md: a test proves nothing until the broken code makes it red). Both were
+run against the shared implementation and then reverted:
+
+1. **Drop the `"Thinking..."` status prefix** from `parse()` (`return [{status}, ...filtered]`
+   → `return filtered`) — 8 tests red, including pre-existing `parseStreamEvent` cases. Those
+   only fail if `parseStreamEvent` really routes through `parse()`, so this is the direct proof
+   that the delegation is live and that the suite no longer vouches for a second implementation.
+2. **Break the identity claim** — make `filterAssistantBlocks` filter unconditionally
+   (drop the `deltaStreamed ?` guard) — 6 tests red across both stream test files, including the
+   new `filterAssistantBlocks divergence` block. So the Step-1 finding is pinned, not just
+   asserted in prose.
+
+Suite green after restore: 50/50 across `test/agent/test_agent_stream.ts` and
+`test/agent/test_streamParser.ts`.

--- a/server/agent/stream.ts
+++ b/server/agent/stream.ts
@@ -174,29 +174,11 @@ export function createStreamParser(): {
   return { parse };
 }
 
-// Stateless convenience — used by tests and one-off parsing.
-// For the agent loop, use createStreamParser() to get dedup.
+// Stateless convenience: one throwaway parser per event, so no dedup
+// state survives the call. The agent loop must keep a single
+// createStreamParser() across the whole turn instead — dedup works by
+// remembering what earlier events in that turn already emitted, which
+// a per-event parser can never observe.
 export function parseStreamEvent(event: RawStreamEvent): AgentEvent[] {
-  if (event.type === "result" && event.result) {
-    const events: AgentEvent[] = [{ type: EVENT_TYPES.text, message: event.result }];
-    if (event.session_id) {
-      events.push({
-        type: EVENT_TYPES.claudeSessionId,
-        id: event.session_id,
-      });
-    }
-    return events;
-  }
-
-  if (event.type !== "assistant" && event.type !== "user") {
-    return [];
-  }
-
-  const content = event.message?.content;
-  const blockEvents = Array.isArray(content) ? content.map(blockToEvent).filter((agentEvent): agentEvent is AgentEvent => agentEvent !== null) : [];
-
-  if (event.type === "assistant") {
-    return [{ type: EVENT_TYPES.status, message: "Thinking..." }, ...blockEvents];
-  }
-  return blockEvents;
+  return createStreamParser().parse(event);
 }

--- a/test/agent/test_agent_stream.ts
+++ b/test/agent/test_agent_stream.ts
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { blockToEvent, parseStreamEvent, type ClaudeContentBlock, type RawStreamEvent } from "../../server/agent/stream.js";
+import { blockToEvent, createStreamParser, parseStreamEvent, type ClaudeContentBlock, type RawStreamEvent } from "../../server/agent/stream.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
+
+// `content` is declared as an array, so a payload that reaches the
+// `Array.isArray` guard's false branch — the CLI is a separate process
+// and can send anything — has to be built from JSON.
+const rawEventFromJson = (json: string): RawStreamEvent => JSON.parse(json);
 
 describe("blockToEvent", () => {
   it("converts tool_use block to tool_call event", () => {
@@ -219,5 +225,139 @@ describe("parseStreamEvent", () => {
     const event: RawStreamEvent = { type: "system" };
     const result = parseStreamEvent(event);
     assert.equal(result.length, 0);
+  });
+
+  it("keeps recognised blocks and drops the rest for an assistant event mixing block types", () => {
+    const event: RawStreamEvent = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "checking" },
+          { type: "tool_use", id: "tu_mix", name: "Bash", input: { command: "ls" } },
+          { type: "tool_result", tool_use_id: "tu_mix", content: "ok", is_error: true },
+          { type: "thinking" },
+        ],
+      },
+    };
+    assert.deepEqual(parseStreamEvent(event), [
+      { type: EVENT_TYPES.status, message: "Thinking..." },
+      { type: EVENT_TYPES.text, message: "checking" },
+      { type: EVENT_TYPES.toolCall, toolUseId: "tu_mix", toolName: "Bash", args: { command: "ls" } },
+      { type: EVENT_TYPES.toolCallResult, toolUseId: "tu_mix", content: "ok", isError: true },
+    ]);
+  });
+
+  it("returns only the status for an assistant event whose content is not an array", () => {
+    assert.deepEqual(parseStreamEvent(rawEventFromJson('{"type":"assistant","message":{"content":"not-an-array"}}')), [
+      { type: EVENT_TYPES.status, message: "Thinking..." },
+    ]);
+  });
+
+  it("returns empty for a user event whose content is not an array", () => {
+    assert.deepEqual(parseStreamEvent(rawEventFromJson('{"type":"user","message":{"content":"not-an-array"}}')), []);
+  });
+
+  it("returns empty for a user event with no message at all", () => {
+    assert.deepEqual(parseStreamEvent({ type: "user" }), []);
+  });
+
+  // A result event can arrive with empty text (the reply already
+  // streamed). The session id rides on that same event, so it must not
+  // be gated on the text being present.
+  it("returns the session id for a result event carrying no text", () => {
+    assert.deepEqual(parseStreamEvent({ type: "result", result: "", session_id: "sess_empty" }), [{ type: EVENT_TYPES.claudeSessionId, id: "sess_empty" }]);
+  });
+
+  // stream_event is neither "assistant" nor "user", so a parser that
+  // reaches its type guard before extracting the delta swallows the
+  // partial-message text entirely.
+  it("emits the text of a stream_event delta", () => {
+    const event: RawStreamEvent = {
+      type: "stream_event",
+      event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "chunk" } },
+    };
+    assert.deepEqual(parseStreamEvent(event), [{ type: EVENT_TYPES.text, message: "chunk" }]);
+  });
+
+  it("returns empty for a stream_event that carries no text delta", () => {
+    assert.deepEqual(parseStreamEvent({ type: "stream_event", event: { type: "message_start" } }), []);
+  });
+});
+
+const equivalenceCases: { name: string; event: RawStreamEvent }[] = [
+  { name: "a result event with a session id", event: { type: "result", result: "answer", session_id: "sess_eq" } },
+  { name: "a result event without a session id", event: { type: "result", result: "answer" } },
+  { name: "a result event with no text but a session id", event: { type: "result", result: "", session_id: "sess_eq" } },
+  { name: "an unrecognised event type", event: { type: "system" } },
+  {
+    name: "an assistant event mixing block types",
+    event: {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "checking" },
+          { type: "tool_use", id: "tu_eq", name: "Bash", input: { command: "ls" } },
+          { type: "tool_result", tool_use_id: "tu_eq", content: "ok" },
+          { type: "thinking" },
+        ],
+      },
+    },
+  },
+  { name: "an assistant event with an empty content array", event: { type: "assistant", message: { content: [] } } },
+  { name: "a user event", event: { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "tu_eq", content: "ok" }] } } },
+  { name: "a user event with content absent", event: { type: "user", message: {} } },
+  { name: "a user event with content that is not an array", event: rawEventFromJson('{"type":"user","message":{"content":"not-an-array"}}') },
+  {
+    name: "a stream_event text delta",
+    event: { type: "stream_event", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "chunk" } } },
+  },
+];
+
+// Tautological while parseStreamEvent delegates — which is the point:
+// it turns red the moment someone re-forks the body into a second
+// implementation that these tests would vouch for instead of the
+// parser the agent loop actually runs.
+describe("parseStreamEvent matches a fresh createStreamParser().parse", () => {
+  equivalenceCases.forEach(({ name, event }) => {
+    it(`agrees on ${name}`, () => {
+      assert.deepEqual(parseStreamEvent(event), createStreamParser().parse(event));
+    });
+  });
+});
+
+// filterAssistantBlocks(blocks, false) is the identity, which is the
+// only reason a per-event parser may stand in for the stateful one.
+// Both sides are pinned here: dropping the deltaStreamed guard, or
+// making the filter depend on the blocks themselves, breaks a case
+// below instead of silently changing what reaches the client.
+describe("filterAssistantBlocks divergence between the stateless and stateful paths", () => {
+  const assistantWithText: RawStreamEvent = {
+    type: "assistant",
+    message: { content: [{ type: "text", text: "streamed" }] },
+  };
+  const textDelta: RawStreamEvent = {
+    type: "stream_event",
+    event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "streamed" } },
+  };
+
+  it("keeps the assistant text block when no delta preceded it", () => {
+    assert.deepEqual(parseStreamEvent(assistantWithText), [
+      { type: EVENT_TYPES.status, message: "Thinking..." },
+      { type: EVENT_TYPES.text, message: "streamed" },
+    ]);
+  });
+
+  it("drops the assistant text block once the same parser streamed a delta", () => {
+    const parser = createStreamParser();
+    parser.parse(textDelta);
+    assert.deepEqual(parser.parse(assistantWithText), [{ type: EVENT_TYPES.status, message: "Thinking..." }]);
+  });
+
+  it("never filters via parseStreamEvent, because each call gets an unstreamed parser", () => {
+    parseStreamEvent(textDelta);
+    assert.deepEqual(parseStreamEvent(assistantWithText), [
+      { type: EVENT_TYPES.status, message: "Thinking..." },
+      { type: EVENT_TYPES.text, message: "streamed" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

`server/agent/stream.ts` carried two parsers for the same Claude CLI stream: the stateful `parse()` returned by `createStreamParser()` (what the agent loop runs) and a hand-copied stateless twin, `parseStreamEvent()`. The copy's own comment said it was "used by tests and one-off parsing" — so the test suite was vouching for a code path production never executes, and a change to the real parser could leave the tests green.

`parseStreamEvent` is now a one-line delegation to a fresh `createStreamParser().parse(event)`. 22 duplicated lines gone; the existing tests now exercise the real implementation.

## Items to Confirm / Review

**1. Is `filterAssistantBlocks(blocks, false)` the identity? — YES.** This was the gate on whether delegating is safe, since `parse()` filters assistant blocks and the old stateless body did not.

```ts
function filterAssistantBlocks(blockEvents: AgentEvent[], deltaStreamed: boolean): AgentEvent[] {
  return deltaStreamed ? blockEvents.filter((agentEvent) => agentEvent.type !== EVENT_TYPES.text) : blockEvents;
}
```

How this was established: by reading the body, not by sampling inputs. It is a single ternary whose condition is `deltaStreamed` **alone**. With `deltaStreamed === false` the false branch returns the *same array reference* — `.filter()` never runs, nothing is copied, dropped, or reordered. No value of `blockEvents` (empty, all-text, mixed, large) can select the filtering branch, because `blockEvents` does not appear in the condition. A value-dependent filter would need it there, and it is not. On a fresh parser `textStreamedFromDeltas === false`, so this is the case delegation hits every time.

The claim is also pinned by tests rather than left as prose — see the mutation check below.

**2. Two *other* divergences existed, which the issue did not name.** Delegation replaces the whole body, so equivalence had to hold for every event type, not just the assistant path. Two cases differ, both in `parse()`'s favour:

| event | `parse()` on a fresh parser | old `parseStreamEvent` |
|---|---|---|
| `stream_event` carrying a `content_block_delta` / `text_delta` | `[{ type: text, message: delta }]` | `[]` — `stream_event` is neither `assistant` nor `user`, so the early return swallowed it |
| `result` with a falsy `result` but a `session_id` | `[{ type: claude_session_id, id }]` | `[]` — the guard was `event.type === "result" && event.result`, so a resultless event skipped the whole block, **including the session-id push** |

The second is a latent bug in the copy: a `session_id` arriving on a result event with empty text was dropped. Both are behaviour *changes* — stated here rather than shipped silently, and pinned by new tests. **Please confirm you are happy taking them**, though see point 3 for why they cannot regress anything.

**3. `parseStreamEvent` has zero production callers — the comment was stale.**

```
$ grep -rn parseStreamEvent --include='*.ts' . | grep -v node_modules | grep -v /dist/
test/agent/test_agent_stream.ts:3,76,82,…   (11 sites)
server/agent/stream.ts:179                  (the definition)
```

`server/agent/backend/claude-code.ts`, the only real consumer of this module, uses `createStreamParser()`. So the "and one-off parsing" half of the old comment was wrong: the function existed solely to be tested, which makes the duplication worse than it looked — the second implementation had no user other than the tests certifying it. It is kept (as the delegation) because the issue proposes that shape and the name is a useful one-shot entry point; deleting it and rewriting 11 call sites was judged out of scope.

**4. Mutation check — the tests were verified to go red.** Two deliberate breakages, both reverted:

| mutation | result |
|---|---|
| drop the `"Thinking..."` status prefix from `parse()` (`return [{status}, ...filtered]` → `return filtered`) | **8 tests red**, including *pre-existing* `parseStreamEvent` cases. Those can only fail if `parseStreamEvent` genuinely routes through `parse()` — this is the direct proof the delegation is live and the suite no longer certifies a second implementation. |
| break the identity: make `filterAssistantBlocks` filter unconditionally (drop the `deltaStreamed ?` guard) | **6 tests red** across both stream test files, including the new `filterAssistantBlocks divergence` block. So finding 1 is pinned by tests, not just asserted in prose. |

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> 並列でね
>
> issueつくったらどんどんすすめて

## Implementation

- **`server/agent/stream.ts`** — `parseStreamEvent` body replaced with `return createStreamParser().parse(event);`. The comment was rewritten to explain *why* a throwaway parser per call, rather than restating the line: dedup works by remembering what earlier events in the same turn emitted, which a per-event parser can never observe, so the agent loop must keep one parser across the whole turn.
- **`test/agent/test_agent_stream.ts`** — existing cases kept (they now run against the real parser) and extended with:
  - concrete-output cases for an `assistant` event mixing text + `tool_use` + `tool_result` (`is_error`) + an unrecognised block; `content` absent, and `content` present but not an array (assistant and user); a `user` event with no `message`; `result` with/without `session_id`; `result` with no text but a `session_id`; a `stream_event` text delta and a non-text `stream_event` frame.
  - a table-driven `parseStreamEvent matches a fresh createStreamParser().parse` block. It is tautological *while* the delegation stands — which is the point: it turns red the moment someone re-forks the body into a second implementation.
  - a `filterAssistantBlocks divergence` block pinning both sides of finding 1: a fresh parser keeps the assistant text block, the *same* parser drops it once it has streamed a delta, and `parseStreamEvent` never filters because each call gets an unstreamed parser.
- **`plans/refactor-2339-stream-parser.md`** — the full finding, the two extra divergences, the decision, and the mutation results.

### Notes

- No production behaviour changes: the only edited runtime function has no production callers (point 3).
- Test coverage: 50/50 green across `test/agent/test_agent_stream.ts` + `test/agent/test_streamParser.ts`.
- `docs/` / README were checked — neither mentions `parseStreamEvent` or `createStreamParser`, so no doc updates were needed.
- The pre-existing `sonarjs/no-selector-parameter` warning on `filterAssistantBlocks` is untouched (verified identical on `main`).

Closes #2339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
