### PR TITLE
refactor(plugins): extract the shared endpoint-dispatch execute() from 9 frontend plugins

### DIFF
--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -133,6 +133,7 @@ This catalog only covers **cross-cutting** helpers — formatters, error helpers
 | `src/config/pubsubChannels.ts` | `PUBSUB_CHANNELS`                                                             | Host-fixed entries + plugin `META.staticChannels` auto-merged.                                                                  |
 | `gui-chat-protocol/vue`        | `useRuntime()`                                                                | Inside a plugin's Vue component, the typed `endpoints` map.                                                                     |
 | `src/plugins/api.ts`           | `pluginEndpoints<E>(scope)`                                                   | Inside a plugin's executor, the typed endpoints.                                                                                |
+| `src/plugins/execute.ts`       | `makeRouteExecute<E, D>(scope, routeKey, toolName)` / `makePostExecute<E, D>(scope, urlKey, toolName)` | A plugin's `execute()` when it is a pass-through to one host route. Owns the tool-result convention (failure → `{toolName, uuid, message}`, success → spread + fresh `uuid`). `makePostExecute` is for host-shared groups whose entries are bare URL strings (`image`, `roles`). Reshaping the response (`manageSkills`) or decorating `data` (`presentHtml`) means writing the body by hand. |
 
 ## Logging
 

--- a/plans/refactor-2335-plugin-execute.md
+++ b/plans/refactor-2335-plugin-execute.md
@@ -1,0 +1,116 @@
+# refactor(plugins): extract the shared endpoint-dispatch `execute()` — #2335
+
+## Problem
+
+11 built-in frontend plugins hand-copy the same `execute()` body: resolve the
+plugin's endpoint group through `pluginEndpoints`, issue one `apiCall` /
+`apiPost`, return `{ toolName, uuid, message: result.error }` on failure and
+`{ ...result.data, toolName, uuid }` on success.
+
+The tool-result assembly convention (what a failure looks like, where `uuid`
+comes from) therefore lives in 11 places. Changing it means editing 11 files
+and silently breaking whichever one is missed.
+
+## Survey — what is actually identical
+
+Read all 11 before collapsing any. Three groups emerged.
+
+**Group A — `apiCall` over a `{ method, url }` route (6 plugins, byte-identical
+modulo scope / route key / data type):**
+
+| plugin | scope | route key |
+| --- | --- | --- |
+| `canvas` | `canvas` | `dispatch` |
+| `chart` | `chart` | `create` |
+| `markdown` | `markdown` | `create` |
+| `presentMulmoScript` | `mulmoScript` | `save` |
+| `presentSVG` | `svg` | `create` |
+| `spreadsheet` | `spreadsheet` | `create` |
+
+**Group B — `apiPost` over a host-shared bare-URL group (3 plugins,
+byte-identical to each other):**
+
+| plugin | scope | url key |
+| --- | --- | --- |
+| `editImages` | `image` | `edit` |
+| `generateImage` | `image` | `generate` |
+| `manageRoles` | `roles` | `manage` |
+
+`apiPost(path, body)` is defined as `apiCall(path, { method: "POST", body })`,
+so Group B is Group A with the method fixed to `POST`.
+
+**Not folded — genuinely different:**
+
+- `manageSkills` — `apiGet`, no `body`, prefixes the failure message
+  (`Failed to load skills: …`), sets an extra `error` field on failure, and
+  builds `title` / `message` / `data` itself from the response rather than
+  spreading it.
+- `presentHtml` — on success it rewrites `data` to inject the host-served
+  `previewUrl` before spreading. Host-specific transform, not a pass-through.
+
+## Design
+
+New file `src/plugins/execute.ts` — sits next to the existing plugin-side
+infrastructure (`api.ts` = endpoint DI, `scope.ts` = component wrapper,
+`meta-types.ts` = route shapes).
+
+```ts
+export type PluginExecute<D> = (context: unknown, args: unknown) => Promise<ToolResult<D>>;
+
+export const makeRouteExecute = <E extends RouteGroup, D>(scope, routeKey: keyof E & string, toolName): PluginExecute<D>
+export const makePostExecute  = <E extends UrlGroup,   D>(scope, urlKey:   keyof E & string, toolName): PluginExecute<D>
+```
+
+Both delegate to one private `runRoute` that owns the result assembly.
+
+Constraints honoured:
+
+- **No new `as` casts.** `E` is constrained to `Readonly<Record<string, ResolvedRoute>>`
+  (or `Readonly<Record<string, string>>`), so `pluginEndpoints<E>(scope)[key]`
+  is already typed — no assertion needed. The pre-existing
+  `as unknown as Component` on `viewComponent` / `previewComponent` is left
+  untouched (out of scope).
+- **Contravariance.** `context: unknown` / `args: unknown` are supertypes of
+  `ToolContext` / `object`, so `PluginExecute<D>` is assignable to
+  gui-chat-protocol's `execute` under `strictFunctionTypes` without a cast.
+- Endpoints are resolved **inside** the returned closure, not at factory-call
+  time — the host installs its context in `src/main.ts` after module load, so
+  resolving eagerly would throw at import.
+
+## Steps
+
+1. Add `src/plugins/execute.ts`.
+2. Rewrite the 9 folded plugins' `execute` to a single factory call; drop the
+   now-unused `pluginEndpoints` / `apiCall` / `apiPost` / `makeUuid` /
+   `ToolResult` imports where nothing else uses them.
+3. Add `test/plugins/test_execute.ts` (node:test): success spread, failure
+   message, per-call fresh uuid, both factories, method/url/body forwarding.
+4. Verify the tests are real by breaking the helper and watching them go red.
+5. Add the helper to `docs/shared-utils.md` (Plugin Infrastructure table).
+
+## Findings while implementing
+
+**The returned closure must be `async`.** The first draft returned
+`(_context, args) => callRoute(pluginEndpoints(scope)[key], …)`. That resolves
+the endpoint synchronously, so an unknown scope throws *out of* `execute()`
+instead of rejecting its promise — a caller's `.catch()` would miss it, unlike
+the `async execute()` bodies being replaced. The "throws on an unknown scope"
+test caught it; the factories are `async` now.
+
+**Mutation check** (each applied to `callRoute`, then reverted):
+
+| mutation | result |
+| --- | --- |
+| failure branch deleted (`return { ...result.data, … }` only) | 4 red |
+| `message: result.error` → a constant | 3 red |
+| spread order flipped (`{ toolName, uuid, ...result.data }`) | 1 red |
+| `makeUuid()` hoisted to a module constant | 2 red |
+
+## Risk
+
+Low. `src/tools/types.ts` documents that MulmoClaude **never calls
+`execute()`** — tool calls flow Claude → MCP → the REST route directly. The
+function exists to satisfy the gui-chat-protocol `ToolPlugin` shape for other
+hosts. So this is a type-level + shape-level change with no production call
+path; the new unit test is the only executing coverage, plus `vite build` for
+the bundle.

--- a/src/plugins/canvas/index.ts
+++ b/src/plugins/canvas/index.ts
@@ -1,33 +1,14 @@
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import toolDefinition, { TOOL_NAME, type CanvasEndpoints, type ImageToolData } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makeRouteExecute } from "../execute";
 import { wrapWithScope } from "../scope";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
-import { apiCall } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 const canvasPlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<CanvasEndpoints>("canvas");
-    const { method, url } = endpoints.dispatch;
-    const result = await apiCall<ToolResult<ImageToolData>>(url, { method, body: args });
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makeRouteExecute<CanvasEndpoints, ImageToolData>("canvas", "dispatch", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Opening drawing canvas...",

--- a/src/plugins/chart/index.ts
+++ b/src/plugins/chart/index.ts
@@ -1,16 +1,13 @@
 import type { Component } from "vue";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import { View, Preview, TOOL_DEFINITION, type PresentChartData } from "@mulmoclaude/chart-plugin/vue";
 // The package's component scoped styles are compiled into a standalone
 // stylesheet; Vite lib mode does NOT auto-inject it, so the consumer must
 // import it — same as @mulmoclaude/{form,markdown}-plugin.
 import "@mulmoclaude/chart-plugin/style.css";
 import { TOOL_NAME, type ChartEndpoints } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makeRouteExecute } from "../execute";
 import { wrapWithScope } from "../scope";
-import { apiCall } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 // The chart's schema, validation, View, and Preview come from the shared
 // @mulmoclaude/chart-plugin package. MulmoClaude keeps the client-side create
@@ -23,23 +20,7 @@ const chartPlugin: ToolPlugin<PresentChartData> = {
   // package's nominal types distinct; coerce once here.
   toolDefinition: TOOL_DEFINITION as ToolPlugin<PresentChartData>["toolDefinition"],
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<ChartEndpoints>("chart");
-    const { method, url } = endpoints.create;
-    const result = await apiCall<ToolResult<PresentChartData>>(url, { method, body: args });
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makeRouteExecute<ChartEndpoints, PresentChartData>("chart", "create", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Rendering chart…",

--- a/src/plugins/editImages/index.ts
+++ b/src/plugins/editImages/index.ts
@@ -1,32 +1,14 @@
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import toolDefinition, { TOOL_NAME, type ImageEndpoints, type ImageToolData } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makePostExecute } from "../execute";
 import { wrapWithScope } from "../scope";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
-import { apiPost } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 const editImagesPlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<ImageEndpoints>("image");
-    const result = await apiPost<ToolResult<ImageToolData>>(endpoints.edit, args);
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makePostExecute<ImageEndpoints, ImageToolData>("image", "edit", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Editing images...",

--- a/src/plugins/execute.ts
+++ b/src/plugins/execute.ts
@@ -1,0 +1,61 @@
+// Shared `execute()` factory for built-in plugins that pass straight
+// through to one host REST route.
+//
+// The tool-result assembly convention — failure returns
+// `{ toolName, uuid, message }`, success spreads the server body and
+// stamps a fresh `toolName` / `uuid` — used to be hand-copied into
+// every plugin's `index.ts` (#2335). It lives here now, so changing
+// the convention is a one-file edit.
+//
+// Two entry points because the host exposes two endpoint shapes:
+// plugin-owned groups carry `{ method, url }` (`makeRouteExecute`),
+// host-shared groups carry bare URL strings (`makePostExecute`).
+//
+// Not every plugin fits: `manageSkills` reshapes the response and
+// decorates the failure message, `presentHtml` injects a host-served
+// preview URL into `data`. Those keep their own bodies.
+
+import type { ToolResult } from "gui-chat-protocol";
+import { pluginEndpoints } from "./api";
+import type { ResolvedRoute } from "./meta-types";
+import { apiCall } from "../utils/api";
+import { makeUuid } from "../utils/id";
+
+/** What gui-chat-protocol's `ToolPlugin.execute` accepts. `unknown`
+ *  parameters are supertypes of its `ToolContext` / `object`, which is
+ *  what makes this assignable under `strictFunctionTypes` — no cast. */
+export type PluginExecute<D> = (context: unknown, args: unknown) => Promise<ToolResult<D>>;
+
+/** A plugin-owned endpoint group (`{ create: { method, url } }`). */
+type RouteGroup = Readonly<Record<string, ResolvedRoute>>;
+
+/** A host-shared endpoint group carrying bare URLs (`image`, `roles`). */
+type UrlGroup = Readonly<Record<string, string>>;
+
+async function callRoute<D>(route: ResolvedRoute, toolName: string, args: unknown): Promise<ToolResult<D>> {
+  const result = await apiCall<ToolResult<D>>(route.url, { method: route.method, body: args });
+  if (!result.ok) {
+    return { toolName, uuid: makeUuid(), message: result.error };
+  }
+  return { ...result.data, toolName, uuid: makeUuid() };
+}
+
+/** Pass-through executor over a plugin-owned route.
+ *
+ *  The endpoint group is read inside the returned closure, not here —
+ *  the host installs its context (`installHostContext`) after plugin
+ *  modules load, so resolving eagerly would throw at import time.
+ *
+ *  `async` so an unresolvable scope surfaces as a rejected promise,
+ *  matching the hand-written `async execute()` bodies this replaces —
+ *  a sync throw would escape a caller's `.catch()`. */
+export function makeRouteExecute<E extends RouteGroup, D>(scope: string, routeKey: keyof E & string, toolName: string): PluginExecute<D> {
+  return async (_context, args) => callRoute<D>(pluginEndpoints<E>(scope)[routeKey], toolName, args);
+}
+
+/** Pass-through executor over a host-shared group whose entries are
+ *  bare URLs. `POST` because that is the only method those groups are
+ *  reached with (`apiPost` is `apiCall` with `method: "POST"`). */
+export function makePostExecute<E extends UrlGroup, D>(scope: string, urlKey: keyof E & string, toolName: string): PluginExecute<D> {
+  return async (_context, args) => callRoute<D>({ method: "POST", url: pluginEndpoints<E>(scope)[urlKey] }, toolName, args);
+}

--- a/src/plugins/generateImage/index.ts
+++ b/src/plugins/generateImage/index.ts
@@ -2,13 +2,11 @@ import type { ToolResult } from "gui-chat-protocol";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
 import toolDefinition, { TOOL_NAME } from "./definition";
 import type { ImageToolData } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makePostExecute } from "../execute";
 import { wrapWithScope } from "../scope";
 import type { ImageEndpoints } from "../editImages/definition";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
-import { apiPost } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 function createUploadedImageResult(imageData: string, fileName: string, prompt: string): ToolResult<ImageToolData, never> {
   return {
@@ -22,22 +20,7 @@ function createUploadedImageResult(imageData: string, fileName: string, prompt: 
 const generateImagePlugin: ToolPlugin<ImageToolData> = {
   toolDefinition,
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<ImageEndpoints>("image");
-    const result = await apiPost<ToolResult<ImageToolData>>(endpoints.generate, args);
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makePostExecute<ImageEndpoints, ImageToolData>("image", "generate", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Generating image...",

--- a/src/plugins/manageRoles/index.ts
+++ b/src/plugins/manageRoles/index.ts
@@ -1,12 +1,9 @@
 import type { ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import toolDefinition, { TOOL_NAME, type RolesEndpoints } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makePostExecute } from "../execute";
 import { wrapWithScope } from "../scope";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
-import { apiPost } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 export interface CustomRole {
   id: string;
@@ -23,22 +20,7 @@ export interface ManageRolesData {
 
 const manageRolesPlugin: ToolPlugin = {
   toolDefinition,
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<RolesEndpoints>("roles");
-    const result = await apiPost<ToolResult<ManageRolesData>>(endpoints.manage, args);
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makePostExecute<RolesEndpoints, ManageRolesData>("roles", "manage", TOOL_NAME),
   isEnabled: () => true,
   generatingMessage: "Managing roles…",
   viewComponent: wrapWithScope("roles", View),

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -7,17 +7,14 @@
 // package's context.app create, so the legacy create route is untouched.
 import type { Component } from "vue";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import { View, Preview, TOOL_DEFINITION, TOOL_NAME, type MarkdownToolData } from "@mulmoclaude/markdown-plugin/vue";
 // The package's component scoped styles (incl. the flex/overflow layout
 // that makes the document scrollable) are compiled into a standalone
 // stylesheet; Vite lib mode does NOT auto-inject it, so the consumer
 // must import it — same as @mulmoclaude/form-plugin (task #6).
 import "@mulmoclaude/markdown-plugin/style.css";
-import { pluginEndpoints } from "../api";
+import { makeRouteExecute } from "../execute";
 import { wrapWithScope } from "../scope";
-import { apiCall } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 import { META } from "./meta";
 import type { ResolvedRoute } from "../meta-types";
 
@@ -29,23 +26,7 @@ const markdownPlugin: ToolPlugin<MarkdownToolData> = {
   // make the package's nominal types distinct; coerce once here.
   toolDefinition: TOOL_DEFINITION as ToolPlugin<MarkdownToolData>["toolDefinition"],
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<DocumentEndpoints>("markdown");
-    const { method, url } = endpoints.create;
-    const result = await apiCall<ToolResult<MarkdownToolData>>(url, { method, body: args });
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makeRouteExecute<DocumentEndpoints, MarkdownToolData>("markdown", "create", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Creating document...",

--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -10,16 +10,15 @@
 // generation indicator) and the bearer-authenticated media download.
 import { computed, defineComponent, h, markRaw, provide, type Component } from "vue";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import { View, Preview, MULMOSCRIPT_HOST_ADAPTER_KEY, type MulmoScriptData, type MulmoScriptHostAdapter } from "@mulmoclaude/mulmoscript-plugin/vue";
 // Lib mode doesn't auto-inject the package's compiled styles; the consumer
 // must import them — same as @mulmoclaude/{markdown,form,chart,html}-plugin.
 import "@mulmoclaude/mulmoscript-plugin/style.css";
 import toolDefinition, { TOOL_NAME, type MulmoScriptEndpoints } from "./definition";
 import { pluginEndpoints } from "../api";
+import { makeRouteExecute } from "../execute";
 import { wrapWithScope } from "../scope";
-import { apiCall, apiFetchRaw } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
+import { apiFetchRaw } from "../../utils/api";
 import { useActiveSession } from "../../composables/useActiveSession";
 
 // Re-exported from the shared package so anything importing the result-data
@@ -74,23 +73,7 @@ const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
   // and reopen-existing (`filePath`) modes and handles the optional
   // `autoGenerateMovie` background trigger server-side. Keeping this
   // function trivial means the two callers can never drift apart.
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<MulmoScriptEndpoints>("mulmoScript");
-    const { method, url } = endpoints.save;
-    const result = await apiCall<ToolResult<MulmoScriptData>>(url, { method, body: args });
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makeRouteExecute<MulmoScriptEndpoints, MulmoScriptData>("mulmoScript", "save", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Generating MulmoScript storyboard…",

--- a/src/plugins/presentSVG/index.ts
+++ b/src/plugins/presentSVG/index.ts
@@ -1,12 +1,9 @@
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import toolDefinition, { TOOL_NAME, type SvgEndpoints } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makeRouteExecute } from "../execute";
 import { wrapWithScope } from "../scope";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
-import { apiCall } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 export interface PresentSvgData {
   title?: string;
@@ -16,23 +13,7 @@ export interface PresentSvgData {
 const presentSvgPlugin: ToolPlugin<PresentSvgData> = {
   toolDefinition,
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<SvgEndpoints>("svg");
-    const { method, url } = endpoints.create;
-    const result = await apiCall<ToolResult<PresentSvgData>>(url, { method, body: args });
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makeRouteExecute<SvgEndpoints, PresentSvgData>("svg", "create", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Presenting SVG…",

--- a/src/plugins/spreadsheet/index.ts
+++ b/src/plugins/spreadsheet/index.ts
@@ -1,33 +1,14 @@
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
-import type { ToolResult } from "gui-chat-protocol";
 import toolDefinition, { TOOL_NAME, type SpreadsheetEndpoints, type SpreadsheetToolData } from "./definition";
-import { pluginEndpoints } from "../api";
+import { makeRouteExecute } from "../execute";
 import { wrapWithScope } from "../scope";
 import View from "./View.vue";
 import Preview from "./Preview.vue";
-import { apiCall } from "../../utils/api";
-import { makeUuid } from "../../utils/id";
 
 const spreadsheetPlugin: ToolPlugin<SpreadsheetToolData> = {
   toolDefinition,
 
-  async execute(_context, args) {
-    const endpoints = pluginEndpoints<SpreadsheetEndpoints>("spreadsheet");
-    const { method, url } = endpoints.create;
-    const result = await apiCall<ToolResult<SpreadsheetToolData>>(url, { method, body: args });
-    if (!result.ok) {
-      return {
-        toolName: TOOL_NAME,
-        uuid: makeUuid(),
-        message: result.error,
-      };
-    }
-    return {
-      ...result.data,
-      toolName: TOOL_NAME,
-      uuid: makeUuid(),
-    };
-  },
+  execute: makeRouteExecute<SpreadsheetEndpoints, SpreadsheetToolData>("spreadsheet", "create", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Creating spreadsheet...",

--- a/test/plugins/test_execute.ts
+++ b/test/plugins/test_execute.ts
@@ -1,0 +1,298 @@
+// Tests for the shared plugin `execute()` factories (#2335).
+//
+// These two factories now own the tool-result assembly convention that
+// used to be hand-copied into 9 plugin `index.ts` files: failure returns
+// `{ toolName, uuid, message }`, success spreads the server body and
+// stamps a fresh `toolName` / `uuid`. A silent regression here (dropping
+// the failure branch, reusing one uuid, spreading in the wrong order)
+// produces plausible-looking results, so each rule gets its own case.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import type { ToolResult } from "gui-chat-protocol";
+import { makeRouteExecute, makePostExecute } from "../../src/plugins/execute.ts";
+import { installHostContext, type EndpointRegistry } from "../../src/plugins/api.ts";
+import type { ResolvedRoute } from "../../src/plugins/meta-types.ts";
+import { backendReachable, lastBackendError } from "../../src/utils/api.ts";
+
+const TOOL_NAME = "presentThing";
+
+interface ThingData {
+  filePath: string;
+}
+
+type ThingRoutes = Readonly<Record<"create" | "list", ResolvedRoute>>;
+type ImageUrls = Readonly<Record<"edit" | "generate", string>>;
+
+const thingRoutes: ThingRoutes = {
+  create: { method: "POST", url: "/api/thing" },
+  list: { method: "GET", url: "/api/thing/list" },
+};
+
+const imageUrls: ImageUrls = {
+  edit: "/api/image/edit",
+  generate: "/api/image/generate",
+};
+
+const registry: EndpointRegistry = { thing: thingRoutes, image: imageUrls };
+
+function installEndpoints(endpoints: EndpointRegistry = registry): void {
+  installHostContext({
+    endpoints,
+    builtinRoleIds: {},
+    pageRoutes: {},
+    getAllPluginNames: () => [],
+  });
+}
+
+// ── fetch double (same shape as test/utils/test_api.ts) ─────────────
+
+type FetchFn = typeof fetch;
+type FetchInit = Parameters<FetchFn>[1];
+
+interface MockCall {
+  url: string;
+  init: FetchInit;
+}
+
+let calls: MockCall[] = [];
+let nextResponse: () => Response = () => new Response("{}", { status: 200 });
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function replyWith(status: number, body: unknown): void {
+  nextResponse = () => jsonResponse(status, body);
+}
+
+function installFetchMock(): void {
+  calls = [];
+  globalThis.fetch = (url, init) => {
+    calls.push({ url: String(url), init });
+    return Promise.resolve(nextResponse());
+  };
+}
+
+function restoreFetch(): void {
+  globalThis.fetch = originalFetch;
+  backendReachable.value = true;
+  lastBackendError.value = null;
+}
+
+describe("makeRouteExecute — success", () => {
+  beforeEach(() => {
+    installEndpoints();
+    installFetchMock();
+  });
+  afterEach(restoreFetch);
+
+  it("spreads the server body and attaches toolName + uuid", async () => {
+    replyWith(200, { message: "Created thing", title: "Thing", data: { filePath: "artifacts/thing.json" } });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const result = await execute({}, { name: "thing" });
+
+    assert.equal(result.message, "Created thing");
+    assert.equal(result.title, "Thing");
+    assert.deepEqual(result.data, { filePath: "artifacts/thing.json" });
+    assert.equal(result.toolName, TOOL_NAME);
+    assert.match(result.uuid ?? "", /^[0-9a-f-]{36}$/);
+  });
+
+  it("sends the route's method, url, and the args as a JSON body", async () => {
+    replyWith(200, { message: "ok" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    await execute({}, { name: "thing", count: 2 });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "/api/thing");
+    assert.equal(calls[0].init?.method, "POST");
+    assert.equal(calls[0].init?.body, JSON.stringify({ name: "thing", count: 2 }));
+  });
+
+  it("uses the route key it was given, not the first route in the group", async () => {
+    replyWith(200, { message: "ok" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "list", TOOL_NAME);
+
+    await execute({}, undefined);
+
+    assert.equal(calls[0].url, "/api/thing/list");
+    assert.equal(calls[0].init?.method, "GET");
+  });
+
+  it("overrides a toolName / uuid the server put in the body", async () => {
+    replyWith(200, { message: "ok", toolName: "someOtherTool", uuid: "server-supplied-uuid" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const result = await execute({}, {});
+
+    assert.equal(result.toolName, TOOL_NAME);
+    assert.notEqual(result.uuid, "server-supplied-uuid");
+  });
+
+  it("mints a fresh uuid per call", async () => {
+    replyWith(200, { message: "ok" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const first = await execute({}, {});
+    const second = await execute({}, {});
+
+    assert.ok(first.uuid);
+    assert.notEqual(first.uuid, second.uuid);
+  });
+
+  it("omits the request body when args is undefined", async () => {
+    replyWith(200, { message: "ok" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "list", TOOL_NAME);
+
+    await execute({}, undefined);
+
+    assert.equal(calls[0].init?.body, undefined);
+  });
+
+  it("passes an empty-object body through as {}", async () => {
+    replyWith(200, { message: "ok" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    await execute({}, {});
+
+    assert.equal(calls[0].init?.body, "{}");
+  });
+});
+
+describe("makeRouteExecute — failure", () => {
+  beforeEach(() => {
+    installEndpoints();
+    installFetchMock();
+  });
+  afterEach(restoreFetch);
+
+  it("returns the server error as the message on an HTTP error", async () => {
+    replyWith(500, { error: "disk full" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const result = await execute({}, {});
+
+    assert.equal(result.message, "disk full");
+    assert.equal(result.toolName, TOOL_NAME);
+    assert.ok(result.uuid);
+  });
+
+  it("carries no data on failure, so the host renders no card", async () => {
+    replyWith(404, { error: "no such thing" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const result = await execute({}, {});
+
+    assert.equal(result.data, undefined);
+    assert.equal(result.title, undefined);
+  });
+
+  it("surfaces a network error (fetch throws) as the message", async () => {
+    nextResponse = () => {
+      throw new Error("connection refused");
+    };
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const result = await execute({}, {});
+
+    assert.equal(result.message, "connection refused");
+    assert.equal(result.toolName, TOOL_NAME);
+  });
+
+  it("mints a fresh uuid per failed call too", async () => {
+    replyWith(500, { error: "boom" });
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    const first = await execute({}, {});
+    const second = await execute({}, {});
+
+    assert.notEqual(first.uuid, second.uuid);
+  });
+});
+
+describe("makePostExecute", () => {
+  beforeEach(() => {
+    installEndpoints();
+    installFetchMock();
+  });
+  afterEach(restoreFetch);
+
+  it("POSTs to the bare URL string the host group holds", async () => {
+    replyWith(200, { message: "edited", data: { filePath: "artifacts/images/a.png" } });
+    const execute = makePostExecute<ImageUrls, ThingData>("image", "edit", TOOL_NAME);
+
+    const result = await execute({}, { prompt: "make it blue" });
+
+    assert.equal(calls[0].url, "/api/image/edit");
+    assert.equal(calls[0].init?.method, "POST");
+    assert.equal(calls[0].init?.body, JSON.stringify({ prompt: "make it blue" }));
+    assert.deepEqual(result.data, { filePath: "artifacts/images/a.png" });
+    assert.equal(result.toolName, TOOL_NAME);
+  });
+
+  it("returns the error message on failure", async () => {
+    replyWith(502, { error: "provider unavailable" });
+    const execute = makePostExecute<ImageUrls, ThingData>("image", "generate", TOOL_NAME);
+
+    const result = await execute({}, {});
+
+    assert.equal(result.message, "provider unavailable");
+    assert.equal(result.data, undefined);
+  });
+});
+
+describe("endpoint resolution", () => {
+  beforeEach(installFetchMock);
+  afterEach(restoreFetch);
+
+  // The host installs its context AFTER plugin modules load, so a
+  // factory that resolved its endpoints eagerly would throw at import.
+  it("resolves the endpoint group lazily, at call time", async () => {
+    installEndpoints({});
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+    installEndpoints();
+    replyWith(200, { message: "ok" });
+
+    const result = await execute({}, {});
+
+    assert.equal(result.message, "ok");
+    assert.equal(calls[0].url, "/api/thing");
+  });
+
+  it("throws on an unknown scope rather than calling an undefined URL", async () => {
+    installEndpoints({});
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    await assert.rejects(() => execute({}, {}), /Unknown plugin endpoint scope: "thing"/);
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("execute shape", () => {
+  beforeEach(() => {
+    installEndpoints();
+    installFetchMock();
+  });
+  afterEach(restoreFetch);
+
+  // The factories exist to satisfy gui-chat-protocol's ToolPlugin
+  // contract; a result missing `toolName` / `uuid` is not renderable.
+  it("always returns a ToolResult with toolName and uuid populated", async () => {
+    const execute = makeRouteExecute<ThingRoutes, ThingData>("thing", "create", TOOL_NAME);
+
+    replyWith(200, { message: "ok" });
+    const success: ToolResult<ThingData> = await execute({}, {});
+    replyWith(500, { error: "boom" });
+    const failure: ToolResult<ThingData> = await execute({}, {});
+
+    [success, failure].forEach((result) => {
+      assert.equal(result.toolName, TOOL_NAME);
+      assert.equal(typeof result.uuid, "string");
+      assert.equal(typeof result.message, "string");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

11 built-in frontend plugins hand-copied the same `execute()` body (issue #2335). **9 of them were genuinely identical** and now call one shared factory; the remaining 2 are not pass-throughs and are left as-is.

New file `src/plugins/execute.ts` — next to the existing plugin-side infrastructure (`api.ts` = endpoint DI, `scope.ts` = component wrapper, `meta-types.ts` = route shapes):

```ts
export const makeRouteExecute = <E extends RouteGroup, D>(scope, routeKey, toolName): PluginExecute<D>
export const makePostExecute  = <E extends UrlGroup,   D>(scope, urlKey,   toolName): PluginExecute<D>
```

Both delegate to one private `callRoute` that owns the tool-result convention: failure → `{ toolName, uuid, message }`, success → spread the server body + stamp a fresh `toolName` / `uuid`. Net **−164 lines** across the plugins.

## Items to Confirm / Review

**Folded in (9)** — two shapes, because the host exposes two kinds of endpoint group:

| factory | plugins | scope / key |
| --- | --- | --- |
| `makeRouteExecute` (plugin-owned `{ method, url }`) | `canvas`, `chart`, `markdown`, `presentMulmoScript`, `presentSVG`, `spreadsheet` | `canvas.dispatch`, `chart.create`, `markdown.create`, `mulmoScript.save`, `svg.create`, `spreadsheet.create` |
| `makePostExecute` (host-shared bare URL strings) | `editImages`, `generateImage`, `manageRoles` | `image.edit`, `image.generate`, `roles.manage` |

**Left alone (2), please sanity-check that you agree they should stay out:**

- **`manageSkills`** — `apiGet` with no body, prefixes the failure message (`Failed to load skills: …`), sets an **extra `error` field** on failure, and builds `title` / `message` / `data` itself instead of spreading the response. Folding it would have meant changing observable behaviour.
- **`presentHtml`** — on success it rewrites `data` to inject the host-served `previewUrl` before spreading. A host-specific transform, not a pass-through.

**Things worth a human eye:**

1. **`apiPost` → `apiCall` with `method: "POST"` for the 3 Group-B plugins.** `apiPost(path, body)` is literally `apiCall(path, { ...extra, method: "POST", body })` with `extra = {}`, so this is provably the same call — but it is the one place where the emitted code differs textually from what it replaced.
2. **The factories return `async` closures on purpose.** The first draft returned a plain arrow; that made an unresolvable scope throw *synchronously out of* `execute()` instead of rejecting its promise, which a caller's `.catch()` would miss. The old `async execute()` bodies rejected. A test pins this — see the mutation table below.
3. **`makePostExecute` hardcodes `POST`.** True for all three call sites today (the host `image` / `roles` groups are only reached with POST). If a bare-URL group ever needs another verb, the factory needs a method parameter.
4. **`PluginExecute<D>` types both parameters as `unknown`.** That is what makes it assignable to gui-chat-protocol's `execute: (context: ToolContext, args: A) => …` under `strictFunctionTypes` (parameters are contravariant, `unknown` is a supertype) **without any cast**. The pre-existing `as unknown as Component` on `viewComponent` / `previewComponent` in `chart` / `markdown` / `presentHtml` / `presentMulmoScript` is untouched — out of scope per the issue.
5. **No new `as` casts were needed.** Constraining `E` to `Readonly<Record<string, ResolvedRoute>>` / `Readonly<Record<string, string>>` makes `pluginEndpoints<E>(scope)[key]` already typed, and the `keyof E & string` key parameter type-checks the route name at each call site (a typo'd `"crete"` fails to compile).
6. **`execute()` is never called in production** (documented in `src/tools/types.ts` — tool calls go Claude → MCP → REST, bypassing it). So the blast radius is the type surface plus any other gui-chat-protocol host that does invoke it; the new unit test is the only executing coverage.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> 並列でね
>
> issueつくったらどんどんすすめて

## Implementation

Plan: [`plans/refactor-2335-plugin-execute.md`](plans/refactor-2335-plugin-execute.md) (committed).

### Tests

`test/plugins/test_execute.ts` — 16 cases, node:test + node:assert, fetch stubbed the same way as `test/utils/test_api.ts`, host context installed through the real `installHostContext` DI seam with a fake registry (no module mocks).

Covered: success spreads `message` / `title` / `data` and attaches `toolName` + a UUID-shaped `uuid`; method / url / JSON body forwarding; the route key actually selects its route; server-supplied `toolName` / `uuid` are overridden (spread order); fresh uuid per call on **both** the success and failure paths; `undefined` args sends no body while `{}` sends `"{}"`; HTTP error returns `result.error` as `message` with no `data` / `title`; a `fetch` throw (network error) surfaces as `message`; `makePostExecute` POSTs to the bare URL; lazy endpoint resolution (a factory built before the host installs its context still works after); unknown scope rejects instead of calling an undefined URL.

### Mutation check (tests verified to fail when the code is broken)

Each mutation applied to `callRoute`, run, then reverted:

| mutation | result |
| --- | --- |
| failure branch deleted (`return { ...result.data, … }` only) | **4 red** |
| `message: result.error` replaced with a constant | **3 red** |
| spread order flipped to `{ toolName, uuid, ...result.data }` | **1 red** |
| `makeUuid()` hoisted to a module-level constant | **2 red** |

Restored → 16/16 green.

### Checks

| check | result |
| --- | --- |
| `prettier --write` on every changed `.ts` | all unchanged (already formatted) |
| `eslint` on all 11 changed paths (no cache) | clean |
| `yarn typecheck:vue` (`vue-tsc --noEmit`, covers `src/`) | clean |
| `yarn typecheck:test` (covers `test/`) | clean |
| `npx tsx --test ./test/plugins/test_execute.ts` | 16/16 pass |
| `npx tsx --test ./test/plugins/test_*.ts` (regression) | 160/160 pass |
| `npx vite build` | built in 2.22s |

`yarn typecheck` as a whole is **red on `main` for an unrelated reason** in this checkout: `packages/plugins/bookmarks-plugin/src/lang/index.ts` imports `createUseT` from `gui-chat-protocol/vue`, which the installed `gui-chat-protocol` does not export. Nothing in that path is touched by this PR.

### Docs

`docs/shared-utils.md` → Plugin Infrastructure table gains a row for the two factories, including when *not* to use them.

Closes #2335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
