### PR TITLE
fix(plugins): detect aggregate key collisions by own property

### DIFF
--- a/src/plugins/metas.ts
+++ b/src/plugins/metas.ts
@@ -73,6 +73,18 @@ export function findHostPluginCollisions(hostRecord: Readonly<Record<string, unk
   return Object.keys(pluginRecord).filter((key) => hostKeys.has(key));
 }
 
+// `Object.hasOwn` needs the es2022 lib, which this project's frontend config
+// does not enable; `hasOwnProperty.call` is the same check and is what the
+// collection schema rules already use.
+const hasOwnKey = (record: Readonly<Record<string, unknown>>, key: string): boolean => Object.prototype.hasOwnProperty.call(record, key);
+
+/** The plugin that claimed `key`, or "" when none did. Own-property only: a
+ *  key named after an `Object.prototype` member would otherwise attribute the
+ *  collision to a function. */
+function ownAttribution(pluginByKey: Readonly<Record<string, string>>, key: string): string {
+  return hasOwnKey(pluginByKey, key) ? (pluginByKey[key] ?? "") : "";
+}
+
 /** Build an attributed collision list — one entry per (key, plugin)
  *  pair, where `pluginAttribution[key]` names the plugin claiming
  *  that key. Used by aggregators that aggregate ACROSS plugins
@@ -84,7 +96,7 @@ export function attributeHostPluginCollisions(
   pluginRecord: Readonly<Record<string, unknown>>,
   pluginByKey: Readonly<Record<string, string>>,
 ): HostPluginCollision[] {
-  return findHostPluginCollisions(hostRecord, pluginRecord).map((key) => ({ label, key, plugin: pluginByKey[key] ?? "" }));
+  return findHostPluginCollisions(hostRecord, pluginRecord).map((key) => ({ label, key, plugin: ownAttribution(pluginByKey, key) }));
 }
 
 /** Build a first-write-wins aggregate of a per-plugin record across
@@ -112,8 +124,12 @@ export function buildPluginAggregate<V>(
     const record = extract(meta);
     if (!record) continue;
     for (const [key, value] of Object.entries(record)) {
-      const priorPlugin = owner[key];
-      if (priorPlugin !== undefined) {
+      // Own-property check, not a bare index: a key named `constructor` or
+      // `toString` reads an `Object.prototype` member here, so the very first
+      // plugin to claim it is reported as colliding with a plugin that does
+      // not exist, and its entry is dropped.
+      if (hasOwnKey(owner, key)) {
+        const priorPlugin = owner[key];
         // Two distinct plugins claim the same key. Keep the first
         // entry; report the offender so diagnostics can warn.
         collisions.push({ dimension, key, plugins: [priorPlugin, meta.toolName] });
@@ -144,7 +160,7 @@ export function filterPluginKeys<V>(
   const dropped: HostPluginCollision[] = [];
   for (const [key, value] of Object.entries(pluginRecord)) {
     if (hostKeys.has(key)) {
-      dropped.push({ label, key, plugin: pluginByKey[key] ?? "" });
+      dropped.push({ label, key, plugin: ownAttribution(pluginByKey, key) });
       continue;
     }
     cleaned[key] = value;

--- a/test/plugins/test_meta_aggregation.ts
+++ b/test/plugins/test_meta_aggregation.ts
@@ -209,3 +209,25 @@ test("defineHostAggregate without additionalReservedKeys preserves original beha
   assert.equal(result.merged.reservedFile, "data/x");
   assert.equal(result.hostCollisions.length, 0);
 });
+
+// A key named after an `Object.prototype` member used to read a function out
+// of the bare `{}` used as the owner map, so the FIRST plugin to claim it was
+// reported as colliding with a plugin that does not exist — and its entry was
+// dropped. The warning even named `null` as the prior claimant (#2315).
+test("a key named after an Object.prototype member is registered, not dropped as a collision", () => {
+  for (const key of ["constructor", "toString", "valueOf", "hasOwnProperty"]) {
+    const meta: PluginMeta = { toolName: "only", apiNamespace: "only", workspaceDirs: { [key]: "data/x" } };
+    const result = buildPluginAggregate<string>([meta], (entry) => entry.workspaceDirs, "workspaceDirs");
+    assert.equal(result.aggregate[key], "data/x", `${key} should be registered`);
+    assert.deepEqual(result.collisions, [], `${key} should not be reported as a collision`);
+    assert.equal(result.owner[key], "only");
+  }
+});
+
+test("two plugins claiming an Object.prototype-named key still collide, attributed to the first", () => {
+  const first: PluginMeta = { toolName: "first", apiNamespace: "first", workspaceDirs: { constructor: "data/a" } };
+  const second: PluginMeta = { toolName: "second", apiNamespace: "second", workspaceDirs: { constructor: "data/b" } };
+  const result = buildPluginAggregate<string>([first, second], (entry) => entry.workspaceDirs, "workspaceDirs");
+  assert.equal(result.aggregate.constructor, "data/a", "first write wins");
+  assert.deepEqual(result.collisions, [{ dimension: "workspaceDirs", key: "constructor", plugins: ["first", "second"] }]);
+});


### PR DESCRIPTION
## Summary

プラグインが `Object.prototype` のメンバ名（`constructor` など）のキーを宣言すると、**その登録が黙って捨てられていました**。

`owner` は素の `{}` なので `owner["constructor"]` が Object コンストラクタを返し、`!== undefined` のガードが「既に登録済み」と読み、**最初に宣言したプラグインが、存在しないプラグインとの衝突として報告**されます。

```
入力: プラグイン1つだけ、workspaceDirs: { constructor: "data/x" }

aggregate  : {}                                                    ← 登録が消えている
collisions : [{ key: "constructor", plugins: [null, "onlyPlugin"] }]
                                              ↑ 存在しない先行プラグイン
```

つまり **そのキーの機能が消え、boot 診断は衝突を訴え、しかもその相手は辿れません。**

このビルダーのコメントが謳う「merge が検出点であり first-write を強制する」も、この経路では first も second も残らないという形で破れています。

## Items to Confirm / Review

1. **同ファイルの帰属参照 2 箇所も同じ形**でした（`attributeHostPluginCollisions` / `filterPluginKeys`）。関数が「衝突を起こしたプラグイン名」として入りうるので、`hasOwnKey` ヘルパー 1 本に集約しました。

2. **`Object.hasOwn` ではなく `Object.prototype.hasOwnProperty.call` を使っています。** 前者は es2022 lib が必要で、このプロジェクトのフロントエンド設定では有効になっておらず **typecheck が拒否**します。コレクションのスキーマルールが既にこの形を使っているので、それに合わせました。

   （`yarn lint` と `yarn test` は両方通っていたので、typecheck を回していなければ CI で落ちていました）

3. **修正前のコードで 2 件落ちることを確認済み。**

## 到達性

プラグイン META のキーはプラグイン作者が書くものなので**攻撃経路ではありません**。ただし `constructor` は「コンストラクタ関連の設定」として自然に書かれうる名前です。

## User Prompt

> 全部 issue 化してそれを処理しつつ、他の調査やテスト０を増やすのを並列してどんどんやって。
> PRは細かく作って

## Test plan

- `yarn test` — 7942 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

Fixes #2315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix plugin meta aggregation to correctly handle keys that match Object.prototype members and preserve first-write attribution.

Bug Fixes:
- Ensure plugin keys like `constructor` and `toString` are registered instead of being dropped as spurious collisions with non-existent plugins.
- Correct collision attribution so only plugins that actually claimed a key are reported, avoiding misattribution to functions or null.

Enhancements:
- Introduce a shared own-property helper and attribution function to consistently detect and attribute plugin key ownership across meta aggregation paths.

Tests:
- Add regression tests covering Object.prototype-named plugin keys, verifying registration, collision handling, and first-write-wins behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin attribution and collision detection for keys such as `constructor`, `toString`, and `hasOwnProperty`.
  * Ensured valid plugin entries are retained and ownership follows first-write-wins behavior.
  * Improved reporting when multiple plugins claim the same key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->