### PR TITLE
fix(logging): validate LOG_LEVEL by own property, not `in`

### DIFF
--- a/server/system/logger/config.ts
+++ b/server/system/logger/config.ts
@@ -52,10 +52,16 @@ export const DEFAULT_CONFIG: LoggerConfig = {
   },
 };
 
+// `in` walks the prototype chain, so `LOG_LEVEL=constructor` used to pass as a
+// level. `LEVEL_PRIORITY["constructor"]` is then a FUNCTION, and every
+// `priority <= function` comparison is false — the process ran with every log
+// record silently discarded and nothing said so.
+const isLogLevel = (value: string): value is LogLevel => Object.prototype.hasOwnProperty.call(LEVEL_PRIORITY, value);
+
 function parseLevel(raw: string | undefined): LogLevel | undefined {
   if (!raw) return undefined;
   const normalized = raw.toLowerCase();
-  return normalized in LEVEL_PRIORITY ? (normalized as LogLevel) : undefined;
+  return isLogLevel(normalized) ? normalized : undefined;
 }
 
 function parseFormat(raw: string | undefined): LogFormat | undefined {

--- a/test/logger/test_config.ts
+++ b/test/logger/test_config.ts
@@ -28,6 +28,25 @@ describe("resolveConfig", () => {
     assert.equal(config.sinks.console.level, DEFAULT_CONFIG.sinks.console.level);
   });
 
+  // A membership test written with `in` walks the prototype chain, so these
+  // used to pass as levels. `LEVEL_PRIORITY["constructor"]` is then a function,
+  // every `priority <= function` comparison is false, and the process runs with
+  // every log record discarded — with no error and no way to notice (#2321).
+  it("rejects a level named after an Object.prototype member", () => {
+    for (const level of ["constructor", "tostring", "valueof", "hasownproperty"]) {
+      const config = resolveConfig({ LOG_LEVEL: level });
+      assert.equal(config.sinks.console.level, DEFAULT_CONFIG.sinks.console.level, `${level} must not be accepted`);
+      assert.equal(config.sinks.file.level, DEFAULT_CONFIG.sinks.file.level, `${level} must not be accepted`);
+    }
+  });
+
+  it("rejects a prototype-named level on the per-sink overrides too", () => {
+    const config = resolveConfig({ LOG_CONSOLE_LEVEL: "constructor", LOG_FILE_LEVEL: "constructor", LOG_TELEMETRY_LEVEL: "constructor" });
+    assert.equal(config.sinks.console.level, DEFAULT_CONFIG.sinks.console.level);
+    assert.equal(config.sinks.file.level, DEFAULT_CONFIG.sinks.file.level);
+    assert.equal(config.sinks.telemetry.level, DEFAULT_CONFIG.sinks.telemetry.level);
+  });
+
   it("accepts format overrides per sink", () => {
     const config = resolveConfig({
       LOG_CONSOLE_FORMAT: "json",


### PR DESCRIPTION
## Summary

`LOG_LEVEL=constructor` が**検証を通過**していました。`in` はプロトタイプチェーンを見るので `"constructor" in LEVEL_PRIORITY` が true になり、`LEVEL_PRIORITY["constructor"]` は**関数**を返します。

`recordPriority <= <関数>` は常に false なので、**全ログレコードが黙って捨てられた状態でプロセスが動き続けます** — 起動エラーもフォールバック警告も無く、気づく手がかりは「ログが空」だけです。

型述語ガード + `hasOwnProperty.call` に変更。認識できないレベルは `LOG_LEVEL=chatty` と同じく既定にフォールバックします。`in` のために必要だった `as LogLevel` アサーションも消えました。

`LOG_LEVEL` / `LOG_CONSOLE_LEVEL` / `LOG_FILE_LEVEL` / `LOG_TELEMETRY_LEVEL` の4つすべてが `parseLevel` を共有しているので、まとめて直ります。

## Items to Confirm / Review

1. **未知レベル時の警告は入れていません。** 設定解決はロガーが存在する前に走るので、循環依存なしに警告を出す先がありません。この判断が妥当かご確認ください。

2. **到達性**: タイプミスで踏むことはまず無く、悪意ある設定が必要です。ただし**症状が「ログが出ない」なので、踏んだときに原因を突き止めるのが極めて難しい**タイプです。観測性が失われる点を重く見ています。

3. **修正前のコードで 2 件落ちることを確認済み。**

## Test plan

- `yarn test` — 7942 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

Fixes #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
