### PR TITLE
refactor(remoteView): centralise the mobile-target guard in resolveMobileView

### DIFF
--- a/plans/refactor-2344-remoteview-guard.md
+++ b/plans/refactor-2344-remoteview-guard.md
@@ -1,0 +1,106 @@
+# refactor: centralise the remote-view mobile-target guard
+
+Issue: #2345 (branch/worktree were numbered `2344`; see "Issue numbering" below)
+
+## Context
+
+`jscpd` flagged the same three lines at the head of all three exported factories
+in `server/workspace/collections/remoteView.ts` (alerts #375 / #302, 62 tokens
+each):
+
+| Factory                  | Entry point it backs                                  |
+| ------------------------ | ----------------------------------------------------- |
+| `createBuildRemoteView`  | `getRemoteView` channel handler + preview HTTP route  |
+| `createMutateRemoteView` | `mutateRemoteViewItem` handler + `…/mutate` route     |
+| `createRemoteViewItems`  | `getRemoteViewItems` handler + `…/items` route        |
+
+```ts
+const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+if (!view) return { kind: "view-not-found", viewId };
+if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+```
+
+## Why this is worth fixing
+
+`view.target !== "mobile"` is not a formatting nicety — it is an **access
+decision**. A desktop view's HTML is written against the token/dataUrl contract
+(it fetches `/api/files/raw` with a scoped token); served to a phone it would
+render broken, so the host refuses it rather than shipping a broken page.
+
+Hand-copied into three entry points, the guard is one forgotten line away from a
+fourth remote-view operation being exposed without it. Centralising makes the
+guard structurally unavoidable: a new operation cannot resolve a view without
+passing through it.
+
+Only `createBuildRemoteView` carried the comment explaining *why* the guard
+exists. Moving that comment onto the shared helper makes the WHY apply to every
+path instead of one of three.
+
+## What this changes
+
+- New exported `resolveMobileView(collection, viewId): ResolveMobileViewResult`
+  in the same module, holding the lookup, both refusals, and the WHY comment.
+- The three factories replace their opening three lines with:
+  ```ts
+  const resolved = resolveMobileView(collection, viewId);
+  if (resolved.kind !== "ok") return resolved;
+  const { view } = resolved;
+  ```
+- No behaviour change: same lookup, same order (`view-not-found` before
+  `not-mobile`), same result objects.
+
+`(collection.schema.views ?? [])` is preserved verbatim — `views` is
+`z.array(CustomViewZ).optional()`, so a collection that declares no views has
+`schema.views === undefined` and the fallback is what keeps this a
+`view-not-found` instead of a `TypeError`.
+
+## Result-type compatibility
+
+The helper's two non-ok members had to stay assignable to all three existing
+public result types, without widening any of them. Checked before designing:
+
+| Member                                     | `RemoteViewBuildResult` | `MutateRemoteViewResult` | `RemoteViewItemsResult` |
+| ------------------------------------------ | ----------------------- | ------------------------ | ----------------------- |
+| `{ kind: "view-not-found"; viewId: string }` | yes                   | yes                      | yes                     |
+| `{ kind: "not-mobile"; viewId: string }`     | yes                   | yes                      | yes                     |
+
+Identical in all three, so `return resolved;` after a `kind !== "ok"` narrowing
+type-checks at every call site with no adapter and no public type widened.
+
+The `ok` branch carries a plain `CollectionCustomView` (as the issue proposes).
+A `CollectionCustomView & { target: "mobile" }` intersection was considered and
+rejected: no caller reads `view.target` (`createBuildRemoteView` writes the
+`"mobile"` literal into `RemoteViewInfo`), so it would add a type plus a type
+predicate for zero consumer benefit.
+
+## Tests
+
+New `test/remoteHost/test_resolveMobileView.ts` covers the helper directly:
+`views` undefined, `views` empty, id not matched, `target: "desktop"`, `target`
+absent, plus the happy path (and that lookup precedes the target check).
+
+The per-factory "the guard still fires through this entry point" tests already
+exist and are **not** duplicated — they are the regression net that protects
+against a future fourth caller:
+
+| Factory                  | Existing test                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `createBuildRemoteView`  | `test_getRemoteView.ts` — "refuses an unknown view, a desktop view, …"          |
+| `createMutateRemoteView` | `test_mutateRemoteView.ts` — "refuses a read-only mobile view, a desktop view…" |
+| `createRemoteViewItems`  | `test_remoteViewItems.ts` — "refuses an unknown view and a desktop view"        |
+
+## Verification
+
+Mutation-checked, not just "tests pass": with `if (view.target !== "mobile")`
+deleted from the helper, the new helper tests and all three per-factory guard
+tests must go **red**; restoring it returns them to green.
+
+## Issue numbering
+
+This work was scheduled as `2344` (worktree, branch, and this file's name), but
+the content it implements is issue **#2345**
+(`refactor(remoteView): the mobile-target guard is hand-copied into three entry
+points`). Issue #2344 is the unrelated frontend mutation-queue dedup, handled on
+`refactor/2345-mutation-queue` — the two branch names are swapped relative to
+their issues. The filename is left as-is so it matches the branch it ships on;
+the PR closes #2345.

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -35,6 +35,23 @@ import {
 } from "./index.js";
 import { resolveThumbnail } from "../../utils/files/thumbnail-store.js";
 
+/** Shared head of every remote-view operation. Its non-ok members are shaped to
+ *  be assignable to all three public result types below, so a caller can return
+ *  a refusal straight through without re-mapping it. */
+export type ResolveMobileViewResult =
+  { kind: "ok"; view: CollectionCustomView } | { kind: "view-not-found"; viewId: string } | { kind: "not-mobile"; viewId: string };
+
+/** Look up a declared view and refuse it unless it targets mobile. EVERY remote
+ *  entry point resolves its view through here, so the guard cannot be forgotten
+ *  by a new one: a desktop view's HTML assumes the token/dataUrl contract and
+ *  would just break on the phone — refuse it instead of serving a broken page. */
+export function resolveMobileView(collection: LoadedCollection, viewId: string): ResolveMobileViewResult {
+  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+  if (!view) return { kind: "view-not-found", viewId };
+  if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+  return { kind: "ok", view };
+}
+
 export interface RemoteViewInfo {
   id: string;
   label: string;
@@ -57,11 +74,9 @@ export interface BuildRemoteViewDeps {
 export const createBuildRemoteView =
   (deps: BuildRemoteViewDeps) =>
   async (collection: LoadedCollection, viewId: string, locale: string): Promise<RemoteViewBuildResult> => {
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) return { kind: "view-not-found", viewId };
-    // A desktop view's HTML assumes the token/dataUrl contract and would just
-    // break on the phone — refuse it instead of serving a broken page.
-    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    const resolved = resolveMobileView(collection, viewId);
+    if (resolved.kind !== "ok") return resolved;
+    const { view } = resolved;
     const html = await deps.readCustomViewHtml(collection, view.file);
     if (html === null) return { kind: "file-missing", file: view.file };
     const i18n = view.i18n ? await deps.readCustomViewI18n(collection, view.i18n, locale) : { locale: "", dict: {} };
@@ -123,9 +138,9 @@ export interface MutateRemoteViewDeps {
 export const createMutateRemoteView =
   (deps: MutateRemoteViewDeps) =>
   async (collection: LoadedCollection, viewId: string, request: RemoteViewMutateRequest): Promise<MutateRemoteViewResult> => {
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) return { kind: "view-not-found", viewId };
-    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    const resolved = resolveMobileView(collection, viewId);
+    if (resolved.kind !== "ok") return resolved;
+    const { view } = resolved;
     // A dataSource collection is read-only regardless of what write surface
     // the view declares — the collection-level rule outranks the view's. The
     // store encodes it as absent write/delete methods.
@@ -270,9 +285,9 @@ async function inlineImages(
 export const createRemoteViewItems =
   (deps: RemoteViewItemsDeps) =>
   async (collection: LoadedCollection, viewId: string, request: RemoteViewPageRequest): Promise<RemoteViewItemsResult> => {
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) return { kind: "view-not-found", viewId };
-    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    const resolved = resolveMobileView(collection, viewId);
+    if (resolved.kind !== "ok") return resolved;
+    const { view } = resolved;
     // Hydrate through the SAME server resolver the desktop `dataUrl` route uses
     // (manageCollection.getItems → enrichItems): ref targets loaded once, derived
     // formulas evaluated with a full ref cache (`ticker.price`, `shares * ticker.price`

--- a/test/remoteHost/test_resolveMobileView.ts
+++ b/test/remoteHost/test_resolveMobileView.ts
@@ -1,0 +1,62 @@
+// Unit tests for the shared remote-view access guard. `resolveMobileView` is the
+// single place a remote entry point may resolve a view, so a desktop-only view
+// can never be served to a phone — these pin every way that refusal is reached.
+// The per-factory "the guard fires through this entry point too" cases live with
+// their factories (test_getRemoteView / test_mutateRemoteView / test_remoteViewItems).
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveMobileView } from "../../server/workspace/collections/remoteView.js";
+import type { LoadedCollection } from "../../server/workspace/collections/index.js";
+
+const collection = (views: unknown[] | undefined): LoadedCollection =>
+  ({
+    slug: "plan",
+    source: "project",
+    skillDir: "/s/plan",
+    dataDir: "/d/plan",
+    schema: { primaryKey: "id", fields: {}, views },
+  }) as unknown as LoadedCollection;
+
+const mobileView = { id: "phone", label: "Phone", target: "mobile", file: "views/phone.html" };
+const desktopView = { id: "year", label: "Year", target: "desktop", file: "views/year.html" };
+// `target` is optional in the schema, so an entry that omits it is a desktop
+// view by default — the guard must refuse it, not read it as "unset means allow".
+const untargetedView = { id: "year", label: "Year", file: "views/year.html" };
+
+describe("resolveMobileView", () => {
+  it("returns the matching mobile view", () => {
+    assert.deepEqual(resolveMobileView(collection([desktopView, mobileView]), "phone"), { kind: "ok", view: mobileView });
+  });
+
+  it("reports view-not-found when the collection declares no views at all", () => {
+    // `schema.views` is optional; the `?? []` fallback is what keeps this a
+    // refusal instead of a TypeError on `.find`.
+    assert.deepEqual(resolveMobileView(collection(undefined), "phone"), { kind: "view-not-found", viewId: "phone" });
+  });
+
+  it("reports view-not-found for an empty views array", () => {
+    assert.deepEqual(resolveMobileView(collection([]), "phone"), { kind: "view-not-found", viewId: "phone" });
+  });
+
+  it("reports view-not-found when no entry matches the id", () => {
+    assert.deepEqual(resolveMobileView(collection([mobileView]), "ghost"), { kind: "view-not-found", viewId: "ghost" });
+  });
+
+  it("refuses an explicit desktop target", () => {
+    assert.deepEqual(resolveMobileView(collection([desktopView]), "year"), { kind: "not-mobile", viewId: "year" });
+  });
+
+  it("refuses an entry with no target declared", () => {
+    assert.deepEqual(resolveMobileView(collection([untargetedView]), "year"), { kind: "not-mobile", viewId: "year" });
+  });
+
+  it("checks existence before target, so an unknown id on a desktop-only collection is view-not-found", () => {
+    assert.deepEqual(resolveMobileView(collection([desktopView]), "phone"), { kind: "view-not-found", viewId: "phone" });
+  });
+
+  it("matches by id rather than position, so a later mobile entry still resolves", () => {
+    const second = { ...mobileView, id: "phone2" };
+    assert.deepEqual(resolveMobileView(collection([desktopView, mobileView, second]), "phone2"), { kind: "ok", view: second });
+  });
+});


### PR DESCRIPTION
## Summary

`server/workspace/collections/remoteView.ts` opened all three of its exported factories — `createBuildRemoteView`, `createMutateRemoteView`, `createRemoteViewItems` — with the same three lines: find the view by id, `view-not-found` if absent, `not-mobile` if `view.target !== "mobile"`.

That third line is **an access decision, not boilerplate**. It stops a desktop-only view — whose HTML is written against the token/dataUrl contract and would render broken on a phone — from being served to the remote client. Hand-copied into three entry points, it is one forgotten line away from a fourth remote-view operation shipping without it. And only `createBuildRemoteView` carried the comment explaining *why* the guard exists; the other two just had the bare condition.

This extracts `resolveMobileView(collection, viewId)` returning a discriminated union, routes all three factories through it, and **moves the existing WHY comment onto the helper** so the reason now applies to every path instead of one of three. A new remote-view operation cannot resolve a view without passing the guard.

Behaviour-preserving: same lookup, same `(collection.schema.views ?? [])` fallback, same refusal order (`view-not-found` before `not-mobile`), same result objects.

Closes #2345

## Items to Confirm / Review

- **Issue number vs. branch name.** The branch/worktree were scheduled as `2344`, but the content implemented here is issue **#2345** (`refactor(remoteView): the mobile-target guard is hand-copied into three entry points`). Issue #2344 is the unrelated frontend mutation-queue dedup, being handled on `refactor/2345-mutation-queue` — the two branch names are swapped relative to their issues. This PR therefore closes **#2345**, not #2344. Flagging so the numbering is not "corrected" in the wrong direction at merge.
- **Result-type compatibility (the main design constraint).** Checked all three public result types before designing the helper's return shape. `{ kind: "view-not-found"; viewId: string }` and `{ kind: "not-mobile"; viewId: string }` were already present, identically, in `RemoteViewBuildResult`, `MutateRemoteViewResult` **and** `RemoteViewItemsResult` — so `return resolved;` after a `kind !== "ok"` narrowing type-checks at every call site. **No caller's public result type was widened** and no call-site adapter was needed. Worth a second pair of eyes that this is genuinely structural and not something the compiler let through loosely.
- **`ok` branch carries a plain `CollectionCustomView`.** A `CollectionCustomView & { target: "mobile" }` intersection (with a type predicate, since TS won't narrow the object itself from a property check) was considered and rejected: no caller reads `view.target` — `createBuildRemoteView` writes the `"mobile"` literal into `RemoteViewInfo` — so it would add a type plus a predicate for zero consumer benefit. Say the word if you'd rather have the guarantee in the type.
- **No `docs/shared-utils.md` entry.** That catalog is explicitly scoped to cross-cutting helpers ("one route's validator stays inside that route; it doesn't belong here"). `resolveMobileView` is one module's guard shared by three functions in that same module, so it was left out. Push back if you read the scope differently.
- **`?? []` preserved deliberately.** `views` is `z.array(CustomViewZ).optional()`, so a collection declaring no views has `schema.views === undefined`; the fallback is what makes that a `view-not-found` rather than a `TypeError` on `.find`. Pinned by a test.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> 並列でね
>
> issueつくったらどんどんすすめて
>
> PRも確認して問題ないのはmerge
>
> #2342〜#2345もね

## Implementation

Plan file: `plans/refactor-2344-remoteview-guard.md` (named for the branch it ships on; its "Issue numbering" section records the #2344/#2345 swap).

### The helper

```ts
export type ResolveMobileViewResult =
  { kind: "ok"; view: CollectionCustomView } | { kind: "view-not-found"; viewId: string } | { kind: "not-mobile"; viewId: string };

export function resolveMobileView(collection: LoadedCollection, viewId: string): ResolveMobileViewResult {
  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
  if (!view) return { kind: "view-not-found", viewId };
  if (view.target !== "mobile") return { kind: "not-mobile", viewId };
  return { kind: "ok", view };
}
```

Each of the three factories now opens with:

```ts
const resolved = resolveMobileView(collection, viewId);
if (resolved.kind !== "ok") return resolved;
const { view } = resolved;
```

### Tests

New `test/remoteHost/test_resolveMobileView.ts` covers the helper directly: `views` undefined, `views` empty, id not matched, `target: "desktop"`, `target` absent (optional in the schema — "unset" must not read as "allow"), the happy path, that existence is checked before target, and that matching is by id rather than position.

The per-factory "the guard still fires through this entry point" tests **already existed** and were not duplicated — they are the regression net that protects against a future fourth caller:

| Factory | Existing test |
| --- | --- |
| `createBuildRemoteView` | `test_getRemoteView.ts` — "refuses an unknown view, a desktop view, and a missing file" |
| `createMutateRemoteView` | `test_mutateRemoteView.ts` — "refuses a read-only mobile view, a desktop view, and an unknown view" |
| `createRemoteViewItems` | `test_remoteViewItems.ts` — "refuses an unknown view and a desktop view" |

### Verification — the tests were checked to be real

Not just "tests pass". `if (view.target !== "mobile")` was deleted from the helper and the suite re-run:

```
ℹ tests 46
ℹ pass 41
ℹ fail 5

✖ refuses an unknown view, a desktop view, and a missing file          (createBuildRemoteView)
✖ refuses a read-only mobile view, a desktop view, and an unknown view (createMutateRemoteView)
✖ refuses an unknown view and a desktop view                           (createRemoteViewItems)
✖ refuses an explicit desktop target                                   (resolveMobileView)
✖ refuses an entry with no target declared                             (resolveMobileView)
```

Both dedicated helper cases **and all three entry-point cases** go red — confirming the per-factory tests genuinely exercise the guard through the shared helper, which is exactly the property that protects a future fourth caller. The line was then restored: 46/46 green.

### Gate

| Step | Result |
| --- | --- |
| `yarn format` | clean |
| `yarn lint` | 0 errors, 40 warnings — all pre-existing baseline, **none** in the touched files |
| `yarn typecheck` | exit 0 |
| `yarn build` | exit 0 |
| `yarn test` | 6559 tests, 0 fail (exit 0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized remote view handling across build, update, and item-loading operations.
  * Remote views now consistently reject missing, desktop-targeted, or unspecified-target views.
  * Preserved clear not-found behavior when requested views are unavailable.

* **Tests**
  * Added coverage for mobile view resolution, missing views, invalid targets, lookup ordering, and matching by view ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->