### PR TITLE
refactor(collections): dedup store-failure → HTTP mapping and view/action lookups

### DIFF
--- a/plans/refactor-2342-collections-routes.md
+++ b/plans/refactor-2342-collections-routes.md
@@ -1,0 +1,79 @@
+# refactor: dedup store-failure → HTTP mapping and view/action resolution in the collections routes
+
+Issue: #2342 — follow-up to #2144 (resolve-or-404 preambles in the same file).
+
+## Context
+
+`server/api/routes/collections.ts` still repeats three shapes that jscpd
+flags (#373 / #374 / #366 / #273):
+
+1. **store-failure → HTTP** in item create / update / delete — the same
+   `invalid-id` / `path-escape` / `conflict` / `not-found` ladder written
+   out three times.
+2. **custom-view resolution** — `viewFile` and `viewI18n` both read
+   `:slug` + `?id=`, call `resolveCustomViewOr404`, and destructure.
+3. **action lookup** — `collection.schema.actions?.find(...)` plus the
+   identical `notFound` wording, in the bearer item-action route and the
+   view-token action route.
+
+`path-escape` → 403 is a workspace-escape REFUSAL. Hand-written in three
+places, one site could be downgraded to a 400 (or dropped) and the other
+two would silently keep the old behaviour — exactly the drift a single
+site prevents.
+
+## What this does
+
+### `sendStoreFailure(res, failure, { slug, onConflict })`
+
+One mapper over `Exclude<WriteItemResult | DeleteItemResult, { kind: "ok" }>`:
+
+| kind | response |
+|---|---|
+| `invalid-id` | 400 `invalid item id: <itemId>` |
+| `path-escape` | 403 `data directory for collection '<slug>' escapes the workspace` |
+| `not-found` | 404 `item '<itemId>' not found` |
+| `conflict` + `onConflict: "duplicate"` | 409 `item '<itemId>' already exists` |
+| `conflict` + `onConflict: "unreachable"` | 500 `unexpected conflict on update` |
+
+`onConflict` exists because create and update genuinely differ: create
+writes with `refuseOverwrite`, so a duplicate id is a real 409; update
+never sets the flag, so its `conflict` branch is unreachable and only
+survives for exhaustiveness. That WHY moves onto the helper. Delete's
+result type carries no `conflict` at all, so it passes `"unreachable"`
+too. Every status and message is byte-identical to the code it replaces.
+
+### `resolveViewRequest(req, res)`
+
+`:slug` + `?id=` → `{ collection, view }` or a 404 + `null`. Built from
+`stringParam` (new, in `collectionParams.ts` beside the other request
+parsers) and `findViewOr404`, which is split out of
+`resolveCustomViewOr404` so the "view missing on a real collection" 404
+is testable without touching the filesystem.
+
+`stringParam` also replaces the `typeof req.query.x === "string" ? … : ""`
+ternary in the `remoteView` route (id + locale) and `viewI18n` (locale) —
+same rule, and a repeated `?id=a&id=b` (which arrives as an array) must
+keep reading as absent.
+
+### `findActionOr404(collection, actionId, res)`
+
+Record-level action lookup + the shared 404 wording. Twin of
+`findViewOr404`. The `collectionActions` lookup keeps its own wording and
+its own array, so it stays where it is.
+
+## Deliberately NOT in this PR
+
+- The `collectionActions` lookup (different array, different message).
+- `viewToken` / `viewDataAction` body reads (`.trim()`ed, body not query).
+- The remote-view / delete-view failure mappers — already single-site.
+
+## Tests
+
+`test/api/routes/test_collectionsStoreFailure.ts` (new): every `kind`
+branch of `sendStoreFailure` for both `onConflict` values, an out-of-union
+kind (must still answer rather than hang), the exact message strings, plus
+`findActionOr404` / `findViewOr404` happy path + missing + absent-array.
+`stringParam` cases go in the existing `test_collectionParams.ts`.
+
+Mutation check: flipping `path-escape` from `forbidden` to `badRequest`
+must turn the suite red before the change is accepted.

--- a/server/api/routes/collectionParams.ts
+++ b/server/api/routes/collectionParams.ts
@@ -36,6 +36,14 @@ export function csvParam(value: unknown): string[] | undefined {
   return undefined;
 }
 
+/** A single-valued query param (`?id=`, `?locale=`): the string only when it
+ *  arrived exactly once, "" otherwise. A repeated param parses as an array,
+ *  and stringifying that would forge an id/locale nobody asked for — reading
+ *  it as absent lets the caller's own 404 / fallback answer instead. */
+export function stringParam(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
 /** A request body is a record only if it is a plain object — an array would
  *  otherwise pass a bare `typeof === "object"` check and be written as a
  *  record with numeric keys. */

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -36,15 +36,18 @@ import {
   validateCollectionRecords,
 } from "../../workspace/collections/index.js";
 import type {
+  CollectionAction,
   CollectionMutateAction,
   CollectionSeededAction,
   CollectionDetail,
   CollectionItem,
   CollectionOntologyEntry,
   CollectionSummary,
+  DeleteItemResult,
   DeleteViewResult,
   LoadedCollection,
   RecordIssue,
+  WriteItemResult,
 } from "../../workspace/collections/index.js";
 import {
   buildRemoteView,
@@ -68,7 +71,7 @@ import { refreshOne } from "@mulmoclaude/core/feeds/server";
 import { manageCollection } from "../../agent/mcp-tools/manageCollection.js";
 import { dispatchAgentAction, runningAgentActions } from "./collectionAgentActions.js";
 import { clampCapabilities, mintViewToken, requireViewToken } from "../auth/viewToken.js";
-import { csvParam, extractRecord, parseCapabilities, parseListParam } from "./collectionParams.js";
+import { csvParam, extractRecord, parseCapabilities, parseListParam, stringParam } from "./collectionParams.js";
 
 const router = Router();
 
@@ -86,18 +89,91 @@ async function loadCollectionOr404(slug: string, res: Response): Promise<LoadedC
 
 type CustomView = NonNullable<LoadedCollection["schema"]["views"]>[number];
 
+interface ResolvedCustomView {
+  collection: LoadedCollection;
+  view: CustomView;
+}
+
+/** Find a custom view by id on an already-loaded collection, or send the
+ *  404 and return null. Exported for the unit test. */
+export function findViewOr404(collection: LoadedCollection, viewId: string, res: Response): CustomView | null {
+  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+  if (!view) {
+    notFound(res, `custom view '${viewId}' not found on collection '${collection.slug}'`);
+    return null;
+  }
+  return view;
+}
+
 // Resolve a collection + one of its custom views by id, or send a 404
 // (missing collection or missing view) and return null. Shared by the
 // view-file / view-i18n / view-token routes.
-async function resolveCustomViewOr404(slug: string, viewId: string, res: Response): Promise<{ collection: LoadedCollection; view: CustomView } | null> {
+async function resolveCustomViewOr404(slug: string, viewId: string, res: Response): Promise<ResolvedCustomView | null> {
   const collection = await loadCollectionOr404(slug, res);
   if (!collection) return null;
-  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-  if (!view) {
-    notFound(res, `custom view '${viewId}' not found on collection '${slug}'`);
+  const view = findViewOr404(collection, viewId, res);
+  if (!view) return null;
+  return { collection, view };
+}
+
+// `:slug` + `?id=` → the custom view they name, or a 404 + null. The
+// view-file and view-i18n routes share this whole preamble; an absent
+// `?id=` reads as "" and 404s like an unknown id.
+async function resolveViewRequest(req: Request<{ slug: string }>, res: Response): Promise<ResolvedCustomView | null> {
+  return resolveCustomViewOr404(req.params.slug, stringParam(req.query.id), res);
+}
+
+/** Find a record-level action by id, or send the 404 and return null.
+ *  Shared by the bearer item-action route and the token-scoped view
+ *  action route. Exported for the unit test. */
+export function findActionOr404(collection: LoadedCollection, actionId: string, res: Response): CollectionAction | null {
+  const action = collection.schema.actions?.find((entry) => entry.id === actionId);
+  if (!action) {
+    notFound(res, `action '${actionId}' not found on collection '${collection.slug}'`);
     return null;
   }
-  return { collection, view };
+  return action;
+}
+
+/** Every non-ok outcome a collection store's write / delete can report. */
+export type StoreFailure = Exclude<WriteItemResult | DeleteItemResult, { kind: "ok" }>;
+
+/** What a `kind: "conflict"` means to the caller. Create writes with
+ *  `refuseOverwrite`, so a duplicate id is a real 409. Update never sets
+ *  the flag — its conflict branch is unreachable and survives only to
+ *  keep the union exhaustive — so it answers 500 rather than a
+ *  misleading "already exists"; delete's result carries no conflict at
+ *  all and passes the same value. */
+type ConflictOutcome = "duplicate" | "unreachable";
+
+interface StoreFailureContext {
+  slug: string;
+  onConflict: ConflictOutcome;
+}
+
+/** Map a store write / delete failure onto its HTTP response — the same
+ *  ladder was hand-written in the item create / update / delete handlers.
+ *  `path-escape` is a workspace-escape REFUSAL (403, never a 400): with
+ *  one site, downgrading it can no longer happen in one handler and go
+ *  unnoticed in the others. Exported for the unit test. */
+export function sendStoreFailure(res: Response, failure: StoreFailure, context: StoreFailureContext): void {
+  if (failure.kind === "invalid-id") {
+    badRequest(res, `invalid item id: ${failure.itemId}`);
+    return;
+  }
+  if (failure.kind === "path-escape") {
+    forbidden(res, `data directory for collection '${context.slug}' escapes the workspace`);
+    return;
+  }
+  if (failure.kind === "not-found") {
+    notFound(res, `item '${failure.itemId}' not found`);
+    return;
+  }
+  if (context.onConflict === "duplicate") {
+    conflict(res, `item '${failure.itemId}' already exists`);
+    return;
+  }
+  serverError(res, "unexpected conflict on update");
 }
 
 interface CollectionsListResponse {
@@ -278,16 +354,8 @@ router.post(API_ROUTES.collections.items, async (req: Request<{ slug: string }>,
   const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
   try {
     const result = await createStore(itemId, recordWithId, { refuseOverwrite: true });
-    if (result.kind === "invalid-id") {
-      badRequest(res, `invalid item id: ${result.itemId}`);
-      return;
-    }
-    if (result.kind === "path-escape") {
-      forbidden(res, `data directory for collection '${collection.slug}' escapes the workspace`);
-      return;
-    }
-    if (result.kind === "conflict") {
-      conflict(res, `item '${result.itemId}' already exists`);
+    if (result.kind !== "ok") {
+      sendStoreFailure(res, result, { slug: collection.slug, onConflict: "duplicate" });
       return;
     }
     log.info("collections", "item created", { slug: collection.slug, itemId: result.itemId });
@@ -324,18 +392,8 @@ router.put(API_ROUTES.collections.item, async (req: Request<{ slug: string; item
   const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
   try {
     const result = await updateStore(req.params.itemId, recordWithId);
-    if (result.kind === "invalid-id") {
-      badRequest(res, `invalid item id: ${result.itemId}`);
-      return;
-    }
-    if (result.kind === "path-escape") {
-      forbidden(res, `data directory for collection '${collection.slug}' escapes the workspace`);
-      return;
-    }
-    if (result.kind === "conflict") {
-      // refuseOverwrite was false — this branch is unreachable, but
-      // typescript needs the exhaustive switch.
-      serverError(res, "unexpected conflict on update");
+    if (result.kind !== "ok") {
+      sendStoreFailure(res, result, { slug: collection.slug, onConflict: "unreachable" });
       return;
     }
     log.info("collections", "item updated", { slug: collection.slug, itemId: result.itemId });
@@ -356,16 +414,8 @@ router.delete(API_ROUTES.collections.item, async (req: Request<{ slug: string; i
   }
   try {
     const result = await deleteStore(req.params.itemId);
-    if (result.kind === "invalid-id") {
-      badRequest(res, `invalid item id: ${result.itemId}`);
-      return;
-    }
-    if (result.kind === "path-escape") {
-      forbidden(res, `data directory for collection '${collection.slug}' escapes the workspace`);
-      return;
-    }
-    if (result.kind === "not-found") {
-      notFound(res, `item '${result.itemId}' not found`);
+    if (result.kind !== "ok") {
+      sendStoreFailure(res, result, { slug: collection.slug, onConflict: "unreachable" });
       return;
     }
     log.info("collections", "item deleted", { slug: collection.slug, itemId: result.itemId });
@@ -483,11 +533,8 @@ async function respondForMutateAction(
 router.post(API_ROUTES.collections.itemAction, async (req: Request<{ slug: string; itemId: string; actionId: string }>, res: Response<ActionRunResponse>) => {
   const collection = await loadCollectionOr404(req.params.slug, res);
   if (!collection) return;
-  const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
-  if (!action) {
-    notFound(res, `action '${req.params.actionId}' not found on collection '${collection.slug}'`);
-    return;
-  }
+  const action = findActionOr404(collection, req.params.actionId, res);
+  if (!action) return;
   try {
     const record = await storeFor(collection).read(req.params.itemId);
     if (!record) {
@@ -672,9 +719,7 @@ router.options(API_ROUTES.collections.viewData, viewDataCors, (_req: Request, re
 // `views/*.html` file, resolved with realpath containment.
 router.get(API_ROUTES.collections.viewFile, async (req: Request<{ slug: string }>, res: Response) => {
   try {
-    const { slug } = req.params;
-    const viewId = typeof req.query.id === "string" ? req.query.id : "";
-    const resolved = await resolveCustomViewOr404(slug, viewId, res);
+    const resolved = await resolveViewRequest(req, res);
     if (!resolved) return;
     const { collection, view } = resolved;
     // Path-safe, source-aware read through the collections domain layer (no raw
@@ -707,8 +752,8 @@ function sendRemoteViewFailure(res: Response, result: Exclude<RemoteViewBuildRes
 router.get(API_ROUTES.collections.remoteView, async (req: Request<{ slug: string }>, res: Response) => {
   try {
     const { slug } = req.params;
-    const viewId = typeof req.query.id === "string" ? req.query.id : "";
-    const locale = typeof req.query.locale === "string" ? req.query.locale : "";
+    const viewId = stringParam(req.query.id);
+    const locale = stringParam(req.query.locale);
     const collection = await loadCollectionOr404(slug, res);
     if (!collection) return;
     const result = await buildRemoteView(collection, viewId, locale);
@@ -810,10 +855,8 @@ router.get(API_ROUTES.collections.remoteViewItems, async (req: Request<{ slug: s
 // key, so an i18n-less view keeps working unchanged.
 router.get(API_ROUTES.collections.viewI18n, async (req: Request<{ slug: string }>, res: Response) => {
   try {
-    const { slug } = req.params;
-    const viewId = typeof req.query.id === "string" ? req.query.id : "";
-    const locale = typeof req.query.locale === "string" ? req.query.locale : "";
-    const resolved = await resolveCustomViewOr404(slug, viewId, res);
+    const locale = stringParam(req.query.locale);
+    const resolved = await resolveViewRequest(req, res);
     if (!resolved) return;
     const { collection, view } = resolved;
     if (!view.i18n) {
@@ -1059,11 +1102,8 @@ router.post(
     try {
       const collection = await loadCollectionOr404(req.params.slug, res);
       if (!collection) return;
-      const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
-      if (!action) {
-        notFound(res, `action '${req.params.actionId}' not found on collection '${collection.slug}'`);
-        return;
-      }
+      const action = findActionOr404(collection, req.params.actionId, res);
+      if (!action) return;
       if (action.kind !== "mutate") {
         forbidden(res, `action '${action.id}' has kind "${action.kind}" — view tokens can only invoke "mutate" actions`);
         return;

--- a/test/api/routes/test_collectionParams.ts
+++ b/test/api/routes/test_collectionParams.ts
@@ -7,7 +7,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { csvParam, extractRecord, parseCapabilities, parseListParam } from "../../../server/api/routes/collectionParams.js";
+import { csvParam, extractRecord, parseCapabilities, parseListParam, stringParam } from "../../../server/api/routes/collectionParams.js";
 
 describe("parseCapabilities", () => {
   it("keeps the known capabilities", () => {
@@ -101,6 +101,31 @@ describe("csvParam", () => {
     assert.equal(csvParam(undefined), undefined);
     assert.equal(csvParam(null), undefined);
     assert.equal(csvParam(7), undefined);
+  });
+});
+
+describe("stringParam", () => {
+  it("returns the value of a single-valued param verbatim", () => {
+    assert.equal(stringParam("board"), "board");
+    assert.equal(stringParam(" board "), " board "); // no trimming — the id is matched exactly
+  });
+
+  // A repeated param (`?id=a&id=b`) parses as an array. Stringifying it
+  // would forge an id nobody asked for; "" lets the caller's 404 answer.
+  it("reads a repeated param as absent", () => {
+    assert.equal(stringParam(["a", "b"]), "");
+    assert.equal(stringParam(["a"]), "");
+  });
+
+  it("reads a missing or non-string param as an empty string", () => {
+    assert.equal(stringParam(undefined), "");
+    assert.equal(stringParam(null), "");
+    assert.equal(stringParam(7), "");
+    assert.equal(stringParam({ id: "board" }), "");
+  });
+
+  it("preserves an explicitly empty value", () => {
+    assert.equal(stringParam(""), "");
   });
 });
 

--- a/test/api/routes/test_collectionsRouteHelpers.ts
+++ b/test/api/routes/test_collectionsRouteHelpers.ts
@@ -1,0 +1,152 @@
+// The shared refusal helpers behind the collection routes: the
+// store-failure → HTTP mapper (item create / update / delete) and the
+// find-or-404 lookups (custom view, record-level action).
+//
+// The statuses AND the exact wording are the contract here — the client
+// surfaces the message verbatim, and `path-escape` → 403 is a
+// workspace-escape REFUSAL, not a validation complaint. Both are pinned
+// literally so a "tidy-up" of either shows up as a failing test.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Response } from "express";
+
+import { findActionOr404, findViewOr404, sendStoreFailure, type StoreFailure } from "../../../server/api/routes/collections.js";
+import type { LoadedCollection } from "../../../server/workspace/collections/index.js";
+
+function fakeRes() {
+  let statusCode: number | undefined;
+  let body: unknown;
+  const res = {
+    status: (code: number) => {
+      statusCode = code;
+      return res;
+    },
+    json: (payload: unknown) => {
+      body = payload;
+      return res;
+    },
+  } as unknown as Response;
+  return { res, status: () => statusCode, error: () => (body as { error?: string } | undefined)?.error };
+}
+
+function sent(failure: StoreFailure, onConflict: "duplicate" | "unreachable") {
+  const { res, status, error } = fakeRes();
+  sendStoreFailure(res, failure, { slug: "invoices", onConflict });
+  return { status: status(), error: error() };
+}
+
+describe("sendStoreFailure", () => {
+  it("400s an invalid id, echoing the rejected id", () => {
+    assert.deepEqual(sent({ kind: "invalid-id", itemId: "../etc/passwd" }, "duplicate"), {
+      status: 400,
+      error: "invalid item id: ../etc/passwd",
+    });
+  });
+
+  // A data dir that escapes the workspace is a refusal, not bad input:
+  // 403 regardless of which handler asked, and the message names the
+  // collection (not the item).
+  it("403s a path escape for every caller, naming the collection", () => {
+    const expected = { status: 403, error: "data directory for collection 'invoices' escapes the workspace" };
+    assert.deepEqual(sent({ kind: "path-escape", itemId: "inv-1" }, "duplicate"), expected);
+    assert.deepEqual(sent({ kind: "path-escape", itemId: "inv-1" }, "unreachable"), expected);
+  });
+
+  it("404s a missing record (delete)", () => {
+    assert.deepEqual(sent({ kind: "not-found", itemId: "inv-9" }, "unreachable"), {
+      status: 404,
+      error: "item 'inv-9' not found",
+    });
+  });
+
+  // Create writes with `refuseOverwrite`, so a duplicate id is a real 409.
+  it("409s a conflict when the caller refuses to overwrite", () => {
+    assert.deepEqual(sent({ kind: "conflict", itemId: "inv-1" }, "duplicate"), {
+      status: 409,
+      error: "item 'inv-1' already exists",
+    });
+  });
+
+  // Update leaves `refuseOverwrite` false and delete cannot report a
+  // conflict at all, so reaching this branch means the store changed
+  // underneath the routes — say so with a 500 rather than inventing an
+  // "already exists" the client would show to a user.
+  it("500s a conflict the caller cannot legitimately reach", () => {
+    assert.deepEqual(sent({ kind: "conflict", itemId: "inv-1" }, "unreachable"), {
+      status: 500,
+      error: "unexpected conflict on update",
+    });
+  });
+
+  // The union is exhaustive today; a new store backend adding a kind must
+  // still get an answer — an unanswered request hangs until the client
+  // times out, which is the worst of the available failures.
+  it("still answers a kind outside the declared union", () => {
+    const unknownKind = { kind: "quota-exceeded", itemId: "inv-1" } as unknown as StoreFailure;
+    assert.equal(sent(unknownKind, "duplicate").status, 409);
+    assert.equal(sent(unknownKind, "unreachable").status, 500);
+  });
+});
+
+function collectionWith(schema: Record<string, unknown>): LoadedCollection {
+  return { slug: "invoices", source: "project", schema, dataDir: "/d/invoices", skillDir: "/s/invoices" } as unknown as LoadedCollection;
+}
+
+describe("findViewOr404", () => {
+  const collection = collectionWith({
+    views: [
+      { id: "board", file: "views/board.html" },
+      { id: "grid", file: "views/grid.html" },
+    ],
+  });
+
+  it("returns the named view and sends nothing", () => {
+    const { res, status } = fakeRes();
+    assert.deepEqual(findViewOr404(collection, "grid", res), { id: "grid", file: "views/grid.html" });
+    assert.equal(status(), undefined);
+  });
+
+  it("404s an unknown view id, naming both the view and the collection", () => {
+    const { res, status, error } = fakeRes();
+    assert.equal(findViewOr404(collection, "ghost", res), null);
+    assert.equal(status(), 404);
+    assert.equal(error(), "custom view 'ghost' not found on collection 'invoices'");
+  });
+
+  // An absent `?id=` reaches here as "" — the same 404, not a crash and
+  // not the first view.
+  it("404s a blank id and a collection that declares no views", () => {
+    assert.equal(findViewOr404(collection, "", fakeRes().res), null);
+    assert.equal(findViewOr404(collectionWith({}), "board", fakeRes().res), null);
+  });
+});
+
+describe("findActionOr404", () => {
+  const collection = collectionWith({
+    actions: [
+      { id: "pay", kind: "mutate" },
+      { id: "draft", kind: "chat" },
+    ],
+  });
+
+  it("returns the named action and sends nothing", () => {
+    const { res, status } = fakeRes();
+    assert.deepEqual(findActionOr404(collection, "pay", res), { id: "pay", kind: "mutate" });
+    assert.equal(status(), undefined);
+  });
+
+  it("404s an unknown action id, naming both the action and the collection", () => {
+    const { res, status, error } = fakeRes();
+    assert.equal(findActionOr404(collection, "delete-everything", res), null);
+    assert.equal(status(), 404);
+    assert.equal(error(), "action 'delete-everything' not found on collection 'invoices'");
+  });
+
+  // `actions` is optional in the schema — a collection without any must
+  // 404 rather than throw on the undefined array.
+  it("404s a blank id and a collection that declares no actions", () => {
+    assert.equal(findActionOr404(collection, "", fakeRes().res), null);
+    assert.equal(findActionOr404(collectionWith({}), "pay", fakeRes().res), null);
+  });
+});


### PR DESCRIPTION
## Summary

`server/api/routes/collections.ts` repeated three shapes (jscpd alerts #373 / #374 / #366 / #273). Each is now one helper; the handlers keep only their success path.

| Extracted | Replaces |
|---|---|
| `sendStoreFailure(res, failure, { slug, onConflict })` | the `invalid-id` / `path-escape` / `conflict` / `not-found` ladder in the item **create / update / delete** handlers |
| `resolveViewRequest(req, res)` | `:slug` + `?id=` → `resolveCustomViewOr404` → destructure, in **viewFile** and **viewI18n** |
| `findActionOr404(collection, actionId, res)` | `collection.schema.actions?.find(...)` + the identical 404 wording, in the **bearer item-action** and **view-token action** routes |

Two supporting splits: `findViewOr404` comes out of `resolveCustomViewOr404` so the missing-view 404 is testable without touching the filesystem, and `stringParam` (new, in `collectionParams.ts` beside the other request parsers) is the single-valued query reader — it also replaces the `typeof req.query.x === "string" ? … : ""` ternaries in the remote-view route.

**No user-visible error string changed.** Every `badRequest|forbidden|notFound|conflict|serverError(res, …)` literal in the file was extracted and diffed before/after: the only differences are the variable a template reads (`result.itemId` → `failure.itemId`, `collection.slug` → `context.slug`). Statuses are unchanged, including `path-escape` → **403** (a workspace-escape refusal, not a 400) at all three former sites.

jscpd clones involving `collections.ts` under `server/api/routes`: **8 → 0** (directory total 9 → 5; the remaining 5 are `files.ts` / `mulmo-script.ts` / `presentHtml.ts` / `skills.ts`).

## Items to Confirm / Review

1. **`onConflict: "duplicate" | "unreachable"`** — create and update genuinely disagree about `kind: "conflict"`, so the mapper takes it as a parameter rather than guessing. Create writes with `refuseOverwrite` → 409 `item '<id>' already exists`; update never sets the flag → its branch is unreachable and answers 500 `unexpected conflict on update`. That is the WHY the update handler's inline comment used to carry; it now lives on the `ConflictOutcome` type. Delete passes `"unreachable"` too — its result type has no `conflict` member at all. Please sanity-check that this reads better than three hand-written ladders.
2. **`findViewOr404` interpolates `collection.slug` where the old code interpolated the request `slug`.** These are provably the same string: `loadCollection` only returns non-null after `safeSlugName(slug)` (which returns the slug verbatim or `null`), and `loadOneCollection` sets `slug: safeName`. So the 404 text is byte-identical — but it is the one place where the message is built from a different expression, so worth a second pair of eyes.
3. **Fall-through on an out-of-union `kind`.** The last branch is reached by elimination (same style as the neighbouring `sendDeleteViewRefusal`). If a future store backend adds a failure kind, it answers 409/500 rather than silently sending nothing — a hung request is the worse failure. Pinned by a test; say the word if you'd rather it were an explicit `kind === "conflict"` check.
4. **Scope**: `stringParam` touches the `remoteView` route (its `id` + `locale` reads) beyond the three handlers the issue names. Same rule, no behaviour change — drop it if you want the PR narrower.
5. Deliberately untouched: the `collectionActions` lookup (different array, different message), the `viewToken` / `viewDataAction` body reads (`.trim()`ed, body not query), and the already-single-site remote-view / delete-view mappers.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> 並列でね
>
> issueつくったらどんどんすすめて
>
> PRも確認して問題ないのはmerge
>
> #2342〜#2345もね

## Implementation

Plan: `plans/refactor-2342-collections-routes.md` (committed with the change).

Consistent with #2144, which de-duplicated the resolve-or-404 preambles in this same file: helpers live at the top of `collections.ts`, take `res` and return `null` after sending, and callers read `const x = helperOr404(...); if (!x) return;`. Nothing new was invented here — `findActionOr404` / `findViewOr404` are the same shape as `loadCollectionOr404` / `resolveCustomViewOr404`.

The store-failure mapper is typed over `Exclude<WriteItemResult | DeleteItemResult, { kind: "ok" }>`, so a new failure kind on either store result is a compile-time visit to one function instead of three.

### Tests

- `test/api/routes/test_collectionsRouteHelpers.ts` (new): every `kind` of `sendStoreFailure` for both `onConflict` values with the **exact** status + message asserted, an out-of-union kind, plus `findViewOr404` / `findActionOr404` happy path (returns the entry, sends nothing), unknown id, blank id, and a collection declaring no `views` / `actions`.
- `test/api/routes/test_collectionParams.ts`: `stringParam` — single value verbatim (no trimming), repeated param (arrives as an array) read as absent, missing / non-string / explicitly-empty.

### The tests were verified to actually bite

Three mutations, each reverted after:

| Mutation | Result |
|---|---|
| `path-escape` → `badRequest` (403 → 400) | ✗ 1 failing (`403s a path escape for every caller`) |
| conflict always 409 (ignore `onConflict`) | ✗ 2 failing (`500s a conflict the caller cannot legitimately reach`, out-of-union kind) |
| action 404 reworded `not found` → `missing` | ✗ 1 failing (`404s an unknown action id`) |

### Gate

`yarn format --check`, `yarn lint` (0 errors, 40 warnings — unchanged baseline, none in the touched files), `yarn typecheck`, `yarn build`, `yarn test` (6567 tests, 0 failures) — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2342
