### PR TITLE
refactor(files): extract the shared write preamble + written-file response

### DIFF
--- a/plans/refactor-2343-files-write-response.md
+++ b/plans/refactor-2343-files-write-response.md
@@ -1,0 +1,93 @@
+# refactor: dedup the write-request preamble and written-file response in the files routes
+
+Issue: #2343
+
+## Context
+
+`jscpd` flagged two blocks (#400 / #280, 89 + 61 tokens) between
+`POST /api/files/create` and `PUT /api/files/content` in
+`server/api/routes/files.ts`. Both handlers wrap their own middle
+(path resolution + write) in the same preamble and the same tail:
+
+**Preamble** — validate body → `log.warn` + `badRequest` on rejection →
+destructure `{ relPath, content, bytes }` → `log.info("<label>: start")`.
+
+**Tail** — `statSafeAsync(absPath)` → `log.info("<label>: ok")` →
+`publishFileChange(relPath)` → `res.json({ path, size, modifiedMs })`.
+
+Only the write itself differs (`resolveNewFilePath` + `performCreateWrite`
+vs `resolveExistingTextFile` + `writeFileContent`) plus the log label.
+
+## Why it matters
+
+The tail contains `void publishFileChange(relPath)`. That call drives
+View-tab cache-busting for subscribed browsers **and** the memory
+topic-index regeneration side-effect (#1032). A future third write route
+that forgets it produces a "saved but the screen never updated" bug —
+no error, no failing request, and hard to reproduce because it only
+shows up with a live subscriber. Making the response *the* way a write
+route replies makes forgetting the publish structurally impossible.
+
+## What changes
+
+New `server/api/routes/filesWriteResponse.ts`:
+
+```ts
+validateWriteRequestOr400(body, res, logLabel): WriteRequestInputs | null
+respondWithWrittenFile(res, { absPath, relPath, fallbackBytes, logLabel }, deps?)
+```
+
+- `logLabel` is a parameter (`"POST create"` / `"PUT content"`) — the two
+  handlers keep their distinct log lines rather than being unified.
+- `deps` (`{ stat, publish, now }`) defaults to the real
+  `statSafeAsync` / `publishFileChange` / `Date.now`, mirroring the
+  `defaultUploadWriteDeps` seam already in `files.ts`, so the builder is
+  testable without touching the filesystem or the pub-sub bus.
+- `WriteContentResponse` moves into the new module; `files.ts` imports it.
+
+Both handlers lose ~16 lines of preamble/tail each.
+
+## Constraints
+
+- The response JSON shape (`path` / `size` / `modifiedMs`) is an API
+  contract consumed by the Files UI. Unchanged.
+- The `stat` fallbacks stay exactly `fresh?.size ?? fallbackBytes` and
+  `fresh?.mtimeMs ?? Date.now()` (stat can fail right after a successful
+  write — e.g. the file is removed by another process — and the request
+  still has to answer with the size we intended to write).
+- `size` is computed once and used for **both** the log line and the
+  response body, matching today's behaviour in both handlers.
+- The rejection log message keeps coming from
+  `validatePutContentRequest` (`"PUT content: missing path"` …), *not*
+  from `logLabel`. `POST create` already logs those strings today;
+  deriving them from the label would change the create route's log text.
+
+## Not changed: `POST /api/files/upload`
+
+The upload handler's tail is the same four steps and the same response
+object, but its `log.info("POST upload: ok")` reports
+`bytes: bytes.byteLength` — the decoded upload size — where create/put
+report `fresh?.size ?? contentBytes`. Adopting the helper there would
+change what that log line reports (identical in every normal case, but
+not by construction). Left as-is deliberately; the helper is available
+if a reviewer wants the log lines unified in a follow-up.
+
+## Tests
+
+`test/routes/test_filesWriteResponse.ts` (node:test + `node:assert/strict`,
+mirroring `test_dispatchResponse.ts`'s recorded-Response mock):
+
+- stat returns a size → `size` / `modifiedMs` come from stat, not the
+  fallbacks (including the wiki case where frontmatter makes the on-disk
+  size larger than the submitted content)
+- stat returns `null` → **both** fallbacks fire (`fallbackBytes`, injected `now()`)
+- zero-byte content → `size: 0` survives (`??` must not treat 0 as absent),
+  both when stat reports 0 and when stat is null; `mtimeMs: 0` likewise
+- `publish` invoked exactly once per successful write, with the rel path,
+  and **before** `res.json` so a subscriber can't miss the write
+- preamble: valid body returns the narrowed inputs (utf-8 byte count),
+  empty content is legal, and each rejection (missing path, missing
+  content, `null` body, over the 1 MB cap) writes 400 and returns `null`
+
+Mutation check: deleting the `publish` call must turn the
+"invoked exactly once" tests red.

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -9,7 +9,8 @@ import { writeNewFileExclusive } from "../../utils/files/upload-io.js";
 import { MAX_RENAME_ATTEMPTS, renamedCandidate, sanitizeUploadFilename } from "../../utils/files/upload-name.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, notFound, sendError, serverError } from "../../utils/httpError.js";
-import { jsonSyntaxError, MAX_PREVIEW_BYTES, validatePutContentRequest } from "../../utils/files/content-write-validate.js";
+import { jsonSyntaxError, MAX_PREVIEW_BYTES } from "../../utils/files/content-write-validate.js";
+import { respondWithWrittenFile, validateWriteRequestOr400, type WriteContentResponse } from "./filesWriteResponse.js";
 import { getOptionalStringQuery } from "../../utils/request.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { GitignoreFilter } from "../../utils/gitignore.js";
@@ -225,12 +226,6 @@ interface FileContentText {
 interface WriteContentRequest {
   path?: unknown;
   content?: unknown;
-}
-
-interface WriteContentResponse {
-  path: string;
-  size: number;
-  modifiedMs: number;
 }
 
 interface FileContentMeta {
@@ -1026,14 +1021,9 @@ async function performCreateWrite(
 // passes a slug for a file it believes doesn't exist; we re-check
 // here to close the TOCTOU window between two tabs.
 router.post(API_ROUTES.files.create, async (req: Request<object, unknown, WriteContentRequest>, res: Response<WriteContentResponse | ErrorResponse>) => {
-  const validation = validatePutContentRequest(req.body);
-  if (!validation.ok) {
-    log.warn("files", validation.logMsg, validation.logExtra);
-    badRequest(res, validation.message);
-    return;
-  }
-  const { relPath, content, bytes: contentBytes } = validation;
-  log.info("files", "POST create: start", { pathPreview: previewSnippet(relPath), bytes: contentBytes });
+  const inputs = validateWriteRequestOr400(req.body, res, "POST create");
+  if (!inputs) return;
+  const { relPath, content, bytes: contentBytes } = inputs;
 
   const resolved = await resolveNewFilePath(relPath);
   if (!resolved.ok) {
@@ -1054,17 +1044,7 @@ router.post(API_ROUTES.files.create, async (req: Request<object, unknown, WriteC
   }
   const created = await performCreateWrite(resolved, content, relPath, res);
   if (!created) return;
-  const fresh = await statSafeAsync(resolved.absPath);
-  log.info("files", "POST create: ok", {
-    pathPreview: previewSnippet(relPath),
-    bytes: fresh?.size ?? contentBytes,
-  });
-  void publishFileChange(relPath);
-  res.json({
-    path: relPath,
-    size: fresh?.size ?? contentBytes,
-    modifiedMs: fresh?.mtimeMs ?? Date.now(),
-  });
+  await respondWithWrittenFile(res, { absPath: resolved.absPath, relPath, fallbackBytes: contentBytes, logLabel: "POST create" });
 });
 
 /** Cap on one dropped file, in decoded bytes.
@@ -1170,6 +1150,9 @@ router.post(API_ROUTES.files.upload, async (req: Request<object, unknown, Upload
     sendError(res, written.status, written.message);
     return;
   }
+  // Kept off `respondWithWrittenFile`: the success line reports the
+  // decoded payload size the client sent, not the post-write stat that
+  // the create / overwrite routes log.
   const fresh = await statSafeAsync(written.absPath);
   log.info("files", "POST upload: ok", { pathPreview: previewSnippet(written.relPath), bytes: bytes.byteLength });
   void publishFileChange(written.relPath);
@@ -1177,14 +1160,9 @@ router.post(API_ROUTES.files.upload, async (req: Request<object, unknown, Upload
 });
 
 router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteContentRequest>, res: Response<WriteContentResponse | ErrorResponse>) => {
-  const validation = validatePutContentRequest(req.body);
-  if (!validation.ok) {
-    log.warn("files", validation.logMsg, validation.logExtra);
-    badRequest(res, validation.message);
-    return;
-  }
-  const { relPath, content, bytes: contentBytes } = validation;
-  log.info("files", "PUT content: start", { pathPreview: previewSnippet(relPath), bytes: contentBytes });
+  const inputs = validateWriteRequestOr400(req.body, res, "PUT content");
+  if (!inputs) return;
+  const { relPath, content, bytes: contentBytes } = inputs;
 
   const resolved = await resolveExistingTextFile(relPath);
   if (!resolved.ok) {
@@ -1205,21 +1183,7 @@ router.put(API_ROUTES.files.content, async (req: Request<object, unknown, WriteC
     serverError(res, "Failed to write file");
     return;
   }
-  const fresh = await statSafeAsync(resolved.absPath);
-  log.info("files", "PUT content: ok", {
-    pathPreview: previewSnippet(relPath),
-    bytes: fresh?.size ?? contentBytes,
-  });
-  // Notify subscribers + run side-effect hooks (e.g. memory topic
-  // index regeneration in #1032). Fire-and-forget; the publisher
-  // logs failures internally and the user-facing write already
-  // succeeded.
-  void publishFileChange(relPath);
-  res.json({
-    path: relPath,
-    size: fresh?.size ?? contentBytes,
-    modifiedMs: fresh?.mtimeMs ?? Date.now(),
-  });
+  await respondWithWrittenFile(res, { absPath: resolved.absPath, relPath, fallbackBytes: contentBytes, logLabel: "PUT content" });
 });
 
 router.get(API_ROUTES.files.raw, (req: Request<object, unknown, unknown, PathQuery>, res: Response<ErrorResponse>) => {

--- a/server/api/routes/filesWriteResponse.ts
+++ b/server/api/routes/filesWriteResponse.ts
@@ -1,0 +1,91 @@
+// Shared preamble + tail for the routes that write a workspace file
+// (POST /api/files/create, PUT /api/files/content). Each handler owns
+// only the middle — how the target path is resolved and how the bytes
+// land on disk; the body gate before it and the response after it are
+// identical apart from the log label.
+//
+// The tail matters more than its size: it carries `publishFileChange`,
+// which cache-busts subscribed View tabs and triggers the memory
+// topic-index regeneration (#1032). A write route that skips it still
+// returns 200, so the failure surfaces only as "I saved it but the
+// screen never updated". Routing every write reply through
+// `respondWithWrittenFile` makes that omission impossible to write.
+
+import type { Response } from "express";
+import { statSafeAsync } from "../../utils/files/index.js";
+import { badRequest } from "../../utils/httpError.js";
+import { validatePutContentRequest } from "../../utils/files/content-write-validate.js";
+import { previewSnippet } from "../../utils/logPreview.js";
+import { log } from "../../system/logger/index.js";
+import { publishFileChange } from "../../events/file-change.js";
+
+/** Body of a successful write reply. API contract with the Files UI. */
+export interface WriteContentResponse {
+  path: string;
+  size: number;
+  modifiedMs: number;
+}
+
+type WriteRouteResponse = Response<WriteContentResponse | { error: string }>;
+
+export interface WriteRequestInputs {
+  relPath: string;
+  content: string;
+  bytes: number;
+}
+
+/** Body-shape gate shared by create + overwrite. Returns the narrowed
+ *  inputs, or writes 400 and returns `null` so the caller bails.
+ *
+ *  The rejection log message comes from the validator, not from
+ *  `logLabel`: both routes have always logged its `"PUT content: …"`
+ *  strings, and deriving them from the label would silently rewrite the
+ *  create route's log text. `logLabel` only names the start/ok lines. */
+export function validateWriteRequestOr400(body: unknown, res: WriteRouteResponse, logLabel: string): WriteRequestInputs | null {
+  const validation = validatePutContentRequest(body);
+  if (!validation.ok) {
+    log.warn("files", validation.logMsg, validation.logExtra);
+    badRequest(res, validation.message);
+    return null;
+  }
+  const { relPath, content, bytes } = validation;
+  log.info("files", `${logLabel}: start`, { pathPreview: previewSnippet(relPath), bytes });
+  return { relPath, content, bytes };
+}
+
+/** Seams for `respondWithWrittenFile`, so the reply it builds can be
+ *  exercised without a filesystem or a live pub-sub bus. */
+export interface WrittenFileDeps {
+  stat: (absPath: string) => Promise<{ size: number; mtimeMs: number } | null>;
+  publish: (relPath: string) => void;
+  now: () => number;
+}
+
+const defaultWrittenFileDeps: WrittenFileDeps = {
+  stat: statSafeAsync,
+  // Fire-and-forget: the publisher logs its own failures and the
+  // user-facing write has already succeeded.
+  publish: (relPath) => void publishFileChange(relPath),
+  now: () => Date.now(),
+};
+
+export interface WrittenFile {
+  absPath: string;
+  relPath: string;
+  /** Size to report when the post-write stat fails — the byte count we
+   *  intended to write. */
+  fallbackBytes: number;
+  logLabel: string;
+}
+
+/** Log the success line, notify subscribers, and answer with the
+ *  written file's metadata. The stat is re-read rather than trusted
+ *  from the request because a wiki write stamps frontmatter, so the
+ *  on-disk size differs from the submitted content's. */
+export async function respondWithWrittenFile(res: WriteRouteResponse, written: WrittenFile, deps: WrittenFileDeps = defaultWrittenFileDeps): Promise<void> {
+  const fresh = await deps.stat(written.absPath);
+  const size = fresh?.size ?? written.fallbackBytes;
+  log.info("files", `${written.logLabel}: ok`, { pathPreview: previewSnippet(written.relPath), bytes: size });
+  deps.publish(written.relPath);
+  res.json({ path: written.relPath, size, modifiedMs: fresh?.mtimeMs ?? deps.now() });
+}

--- a/test/routes/test_filesWriteResponse.ts
+++ b/test/routes/test_filesWriteResponse.ts
@@ -1,0 +1,182 @@
+// Unit tests for the shared write-route preamble + tail extracted from
+// POST /api/files/create and PUT /api/files/content.
+//
+// Both helpers are driven with a recorded Response mock and injected
+// deps (mirroring test_dispatchResponse.ts) — no filesystem, no
+// pub-sub bus. The stat seam is what makes the two fallbacks
+// (`fresh?.size ?? fallbackBytes`, `fresh?.mtimeMs ?? now()`)
+// reachable without deleting a file mid-test.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Response } from "express";
+import { respondWithWrittenFile, validateWriteRequestOr400, type WrittenFileDeps } from "../../server/api/routes/filesWriteResponse.js";
+
+interface RecordedResponse {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => RecordedResponse;
+  json: (payload: unknown) => RecordedResponse;
+}
+
+function makeRes(): RecordedResponse {
+  const rec: RecordedResponse = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return rec;
+}
+
+const FROZEN_NOW_MS = 1_700_000_000_000;
+
+interface RecordedDeps extends WrittenFileDeps {
+  published: string[];
+}
+
+function makeDeps(fresh: { size: number; mtimeMs: number } | null): RecordedDeps {
+  const published: string[] = [];
+  return {
+    published,
+    stat: () => Promise.resolve(fresh),
+    publish: (relPath) => published.push(relPath),
+    now: () => FROZEN_NOW_MS,
+  };
+}
+
+const WRITTEN = { absPath: "/ws/notes/a.md", relPath: "notes/a.md", fallbackBytes: 42, logLabel: "PUT content" };
+
+describe("respondWithWrittenFile — stat succeeds", () => {
+  it("answers with the on-disk size and mtime, not the fallbacks", async () => {
+    const res = makeRes();
+    const deps = makeDeps({ size: 57, mtimeMs: 1234 });
+    await respondWithWrittenFile(res as unknown as Response, WRITTEN, deps);
+    assert.deepEqual(res.body, { path: "notes/a.md", size: 57, modifiedMs: 1234 });
+  });
+
+  it("publishes the written path exactly once", async () => {
+    const res = makeRes();
+    const deps = makeDeps({ size: 57, mtimeMs: 1234 });
+    await respondWithWrittenFile(res as unknown as Response, WRITTEN, deps);
+    assert.deepEqual(deps.published, ["notes/a.md"]);
+  });
+
+  it("keeps a wiki-stamped size (stat differs from the submitted bytes)", async () => {
+    const res = makeRes();
+    // writeWikiPage prepends frontmatter, so on-disk > submitted.
+    const deps = makeDeps({ size: 200, mtimeMs: 9 });
+    await respondWithWrittenFile(res as unknown as Response, { ...WRITTEN, fallbackBytes: 100 }, deps);
+    assert.deepEqual(res.body, { path: "notes/a.md", size: 200, modifiedMs: 9 });
+  });
+});
+
+describe("respondWithWrittenFile — stat returns null", () => {
+  it("falls back to the submitted byte count and the injected clock", async () => {
+    const res = makeRes();
+    const deps = makeDeps(null);
+    await respondWithWrittenFile(res as unknown as Response, WRITTEN, deps);
+    assert.deepEqual(res.body, { path: "notes/a.md", size: 42, modifiedMs: FROZEN_NOW_MS });
+  });
+
+  it("still publishes exactly once — a failed stat is not a failed write", async () => {
+    const res = makeRes();
+    const deps = makeDeps(null);
+    await respondWithWrittenFile(res as unknown as Response, WRITTEN, deps);
+    assert.deepEqual(deps.published, ["notes/a.md"]);
+  });
+});
+
+describe("respondWithWrittenFile — zero-byte content", () => {
+  it("reports size 0 from stat rather than coalescing to the fallback", async () => {
+    const res = makeRes();
+    const deps = makeDeps({ size: 0, mtimeMs: 77 });
+    await respondWithWrittenFile(res as unknown as Response, { ...WRITTEN, fallbackBytes: 42 }, deps);
+    assert.deepEqual(res.body, { path: "notes/a.md", size: 0, modifiedMs: 77 });
+  });
+
+  it("reports size 0 from the fallback when stat is null", async () => {
+    const res = makeRes();
+    const deps = makeDeps(null);
+    await respondWithWrittenFile(res as unknown as Response, { ...WRITTEN, fallbackBytes: 0 }, deps);
+    assert.deepEqual(res.body, { path: "notes/a.md", size: 0, modifiedMs: FROZEN_NOW_MS });
+  });
+
+  it("treats mtimeMs 0 as a real timestamp, not a missing one", async () => {
+    const res = makeRes();
+    const deps = makeDeps({ size: 3, mtimeMs: 0 });
+    await respondWithWrittenFile(res as unknown as Response, WRITTEN, deps);
+    assert.deepEqual(res.body, { path: "notes/a.md", size: 3, modifiedMs: 0 });
+  });
+});
+
+describe("respondWithWrittenFile — ordering", () => {
+  it("publishes before answering, so a subscriber can't miss the write", async () => {
+    const order: string[] = [];
+    const res = makeRes();
+    const recordingRes = {
+      ...res,
+      json(payload: unknown) {
+        order.push("json");
+        return res.json(payload);
+      },
+    };
+    const deps: WrittenFileDeps = {
+      stat: () => Promise.resolve({ size: 1, mtimeMs: 2 }),
+      publish: () => order.push("publish"),
+      now: () => FROZEN_NOW_MS,
+    };
+    await respondWithWrittenFile(recordingRes as unknown as Response, WRITTEN, deps);
+    assert.deepEqual(order, ["publish", "json"]);
+  });
+});
+
+describe("validateWriteRequestOr400", () => {
+  it("returns the narrowed inputs with the utf-8 byte count", () => {
+    const res = makeRes();
+    const inputs = validateWriteRequestOr400({ path: "notes/a.md", content: "あ" }, res as unknown as Response, "POST create");
+    assert.deepEqual(inputs, { relPath: "notes/a.md", content: "あ", bytes: 3 });
+    assert.equal(res.body, undefined, "a valid body must not write a response");
+  });
+
+  it("accepts empty content (0 bytes) — an empty file is a legal write", () => {
+    const res = makeRes();
+    const inputs = validateWriteRequestOr400({ path: "notes/a.md", content: "" }, res as unknown as Response, "POST create");
+    assert.deepEqual(inputs, { relPath: "notes/a.md", content: "", bytes: 0 });
+  });
+
+  it("writes 400 and returns null when path is missing", () => {
+    const res = makeRes();
+    const inputs = validateWriteRequestOr400({ content: "x" }, res as unknown as Response, "POST create");
+    assert.equal(inputs, null);
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, { error: "path required" });
+  });
+
+  it("writes 400 and returns null when content is missing", () => {
+    const res = makeRes();
+    const inputs = validateWriteRequestOr400({ path: "notes/a.md" }, res as unknown as Response, "PUT content");
+    assert.equal(inputs, null);
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, { error: "content required" });
+  });
+
+  it("rejects a null body without throwing", () => {
+    const res = makeRes();
+    assert.equal(validateWriteRequestOr400(null, res as unknown as Response, "PUT content"), null);
+    assert.equal(res.statusCode, 400);
+  });
+
+  it("rejects content over the 1 MB cap", () => {
+    const res = makeRes();
+    const oversized = "a".repeat(1024 * 1024 + 1);
+    assert.equal(validateWriteRequestOr400({ path: "notes/a.md", content: oversized }, res as unknown as Response, "PUT content"), null);
+    assert.equal(res.statusCode, 400);
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/files/create` and `PUT /api/files/content` wrapped their own write in the
same preamble and the same tail. This extracts both into
`server/api/routes/filesWriteResponse.ts`:

- `validateWriteRequestOr400(body, res, logLabel)` — body gate → `log.warn` +
  400 on rejection → narrowed `{ relPath, content, bytes }` → `"<label>: start"`.
- `respondWithWrittenFile(res, { absPath, relPath, fallbackBytes, logLabel }, deps?)` —
  `stat` → `"<label>: ok"` → `publishFileChange` → `res.json({ path, size, modifiedMs })`.

Each handler now owns only its middle (path resolution + write). `files.ts` loses
49 lines and gains 13.

**Why this one is worth doing beyond the token count**: the shared tail carries
`void publishFileChange(relPath)`. That call drives View-tab cache-busting for
subscribed browsers *and* the memory topic-index regeneration side-effect
(#1032). A future third write route that forgets it still returns 200 — the only
symptom is "I saved it but the screen never updated", with no error and no
failing request, and it only reproduces with a live subscriber attached.
Extracting the tail makes forgetting the publish structurally impossible: you
cannot write the response without it.

Behaviour is unchanged — same response JSON, same log lines, same fallbacks.

## Items to Confirm / Review

1. **`POST /api/files/upload` deliberately left alone.** Its tail is the same
   four steps and the same response object, but its success log reports
   `bytes: bytes.byteLength` (the decoded payload size) where create/put report
   `fresh?.size ?? contentBytes` (the post-write stat). Adopting the helper there
   would change what that log line reports — in practice always the same number,
   but not by construction. A comment at the call site says why. Happy to unify
   in a follow-up if you'd rather all three write routes go through the helper.
2. **The 400-rejection log message still comes from the validator**, not from
   `logLabel`. `validatePutContentRequest` hardcodes `"PUT content: missing path"`
   etc., and the create route has always logged those exact strings. Deriving
   them from `logLabel` would have been tidier but would silently rewrite the
   create route's log text, so I kept the current (slightly mislabelled) strings.
3. **`stat` fallbacks preserved verbatim**: `fresh?.size ?? fallbackBytes` and
   `fresh?.mtimeMs ?? Date.now()`. `??` (not `||`) is load-bearing — a
   zero-byte file must report `size: 0`, not fall through to the fallback.
   Pinned by tests.
4. **`size` is computed once** and used for both the log line and the response
   body, matching what both handlers did before.
5. **`WriteContentResponse` moved** out of `files.ts` into the new module (it was
   a private interface, no external consumers). Response shape `path` / `size` /
   `modifiedMs` unchanged — it is an API contract with the Files UI.
6. **Test seam**: `respondWithWrittenFile` takes an optional `deps`
   (`{ stat, publish, now }`) defaulting to the real
   `statSafeAsync` / `publishFileChange` / `Date.now`, mirroring the
   `defaultUploadWriteDeps` pattern already in `files.ts`. Route call sites pass
   no deps, so the publish cannot be swapped out by accident.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> 並列でね
>
> issueつくったらどんどんすすめて
>
> PRも確認して問題ないのはmerge
>
> #2342〜#2345もね

## Implementation

Plan: [`plans/refactor-2343-files-write-response.md`](plans/refactor-2343-files-write-response.md)

### New module

`server/api/routes/filesWriteResponse.ts` — sits next to `files.ts` like the
existing `dispatchResponse.ts` / `schedulerHandlers.ts` route helpers.

### Tests — `test/routes/test_filesWriteResponse.ts` (15 cases, node:test)

Driven with a recorded `Response` mock and injected deps, so no filesystem and
no pub-sub bus:

- stat returns a size → size / mtime come from stat, not the fallbacks
  (including the wiki case where frontmatter makes on-disk > submitted)
- stat returns `null` → **both** fallbacks fire (`fallbackBytes`, injected clock)
- zero-byte content → `size: 0` survives from stat *and* from the fallback;
  `mtimeMs: 0` likewise (would go red if `??` were `||`)
- `publish` invoked exactly once per successful write, with the rel path, and
  **before** `res.json`
- preamble: valid body → narrowed inputs with the utf-8 byte count; empty
  content is legal; missing path / missing content / `null` body / over the
  1 MB cap each write 400 and return `null`

### Verification the tests are real (mutation check)

Deleted `deps.publish(written.relPath)` from `respondWithWrittenFile` and re-ran:
**3 tests went red** ("publishes the written path exactly once", "still
publishes exactly once — a failed stat is not a failed write", "publishes before
answering"), 12 passed. Restored, all 15 green again.

### Gate

`yarn format`, `yarn lint` (0 errors; the only warning in `files.ts` is the
pre-existing `sonarjs/no-undefined-argument` at line 655), `yarn typecheck`,
`yarn build`, `yarn test` — all green. The existing route-level tests
(`test_filesCreateRoute.ts`, `test_filesPutRoute.ts`, `test_filesUpload.ts`,
50 cases) pass unchanged, which is the behaviour-preservation net.

Closes #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
