### PR TITLE
docs(core): route the schema author to the googleCalendar block (#2312)

### DIFF
--- a/packages/core/assets/helps/collection-skills.md
+++ b/packages/core/assets/helps/collection-skills.md
@@ -146,6 +146,7 @@ skipped, never crashes the host):
 | `calendarTimeField`    | Optional. Name of a string field holding a free-form time or time-range (`"14:00-17:00"`, `"17:00-"`, `"16:30"`) used to place records on the calendar's **day (time-allocation) view**. Consulted only when the date fields are date-only — a `datetime` anchor/end pair carries its own clock and takes precedence. Requires `calendarField`. See "Calendar view" below.                                                                                                                                                                                                         |
 | `kanbanField`          | Optional. Name of an `enum` field that groups records into columns on the **Kanban board** (one column per declared value). When unset, the Kanban toggle still appears if the schema has any `enum` field — the first one is used, switchable in-view. Set this to pin a specific group field. Must name a real `enum` field. See "Kanban view" below.                                                                                                                                                                                                                            |
 | `views`                | Optional. Custom (LLM-authored) HTML views: `[{ id, label, icon?, file, capabilities?, target? }]`. Each renders an HTML file under `views/*.html` in a sandboxed iframe over the records, for layouts the built-ins don't cover (year/quarter overview, Gantt, report). `capabilities` is `["read"]` (default) or `["read","write"]`. `target: "mobile"` makes it a **remote view** for the phone app (different runtime contract — **`config/helps/custom-view-remote.md`**). See "Custom views" below and **`config/helps/custom-view.md`** for the desktop authoring contract. |
+| `googleCalendar`       | Optional. `{ "calendarId": "primary", "map": { "<field>": "summary" } }` — the host mirrors one of the user's **Google calendars** into this collection on a schedule, **LLM-free**: no tool call, no tokens per sync. Reach for it whenever the user asks for a collection that syncs with Google Calendar — never an `ingest.kind: "agent"` worker or the `google` MCP tools, which spend an LLM turn per refresh doing what the host does for free. Needs `dataPath`. See "Google Calendar sync" below and **`config/helps/google-calendar-collection.md`**.                    |
 
 ### Field types
 
@@ -709,6 +710,33 @@ chat list. Host stays generic: all the domain logic lives in the template prose.
 Reach for `ingest.kind: "agent"` (not a `manageAutomations` task) whenever the
 schedule belongs to one collection: it travels with the schema, dies with the
 collection, and needs no separate setup.
+
+### Google Calendar sync (`googleCalendar`)
+
+A collection opts into **Google Calendar sync** the same way a feed opts into
+retrieval — by declaring a block. Add `googleCalendar` and the host pulls the
+user's changed events on a schedule and writes them as records **without calling
+you**: no tool call, no tokens per sync.
+
+```json
+"googleCalendar": {
+  "calendarId": "primary",
+  "map": { "title": "summary", "on": "start", "until": "end" }
+}
+```
+
+This is the answer whenever the user asks for a collection that syncs with
+Google Calendar — **not** an `ingest.kind: "agent"` worker and **not** the
+`google` MCP calendar tools, both of which spend an LLM turn on every refresh to
+produce what the host produces for free. `map` reads _your_ field name → the
+Google event field (`summary`, `start`, `end`, `htmlLink`, `colorId`, `status`);
+at least one entry is required. Never map the `primaryKey` — it always holds the
+Google event id, which is what makes a re-sync update a record instead of
+duplicating it.
+
+The rest of the contract — finding a non-primary `calendarId`, how deletions
+propagate, and the first-run caveat — is
+**`config/helps/google-calendar-collection.md`**. Read it before authoring one.
 
 ### Calendar view
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view and ./remote-host entries. All host specifics are injected.",
   "type": "module",
   "exports": {

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^1.0.0",
     "@mulmoclaude/collection-plugin": "^1.0.0",
     "@mulmoclaude/common": "^1.0.0",
-    "@mulmoclaude/core": "^1.0.1",
+    "@mulmoclaude/core": "^1.0.2",
     "@mulmoclaude/form-plugin": "^1.0.0",
     "@mulmoclaude/google-plugin": "^1.0.0",
     "@mulmoclaude/html-plugin": "^1.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -31,14 +31,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.0.1",
+    "@mulmoclaude/core": "^1.0.2",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^1.1.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^1.0.1",
+    "@mulmoclaude/core": "^1.0.2",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.1",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -21,7 +21,7 @@
     "test": "tsx --test test/test_*.ts"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.0.1"
+    "@mulmoclaude/core": "^1.0.2"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.1.0",

--- a/plans/docs-2312-gcal-schemadocs.md
+++ b/plans/docs-2312-gcal-schemadocs.md
@@ -1,0 +1,99 @@
+# docs(2312): route the schema author to the `googleCalendar` block
+
+Issue: #2312 — "schemaDocs has no mention of googleCalendar — agent cannot discover the feature"
+
+## Problem
+
+Asked to "create a collection that syncs with Google Calendar", the agent builds
+the collection the old way: a Google MCP connector plus an `ingest: { kind: "agent" }`
+worker that re-fetches events with an LLM turn on every refresh. The zero-token
+`googleCalendar` schema block — the host-side sync that exists precisely for this —
+is never used.
+
+Verified cause: `packages/core/assets/helps/collection-skills.md` (1175 lines) is the
+schema DSL reference the agent reads while authoring a schema, and it contains **zero**
+occurrences of `googleCalendar` or "Google Calendar". The feature is documented in
+`packages/core/assets/helps/google-calendar-collection.md` and indexed in `helps/index.md`,
+but nothing routes the agent there at the moment the question arises:
+
+- `error-recovery.md` is read on tool failure — the MCP path *succeeds*, so it never fires.
+- No keyword routing surfaces `google-calendar-collection.md`.
+
+The reporter's two prompts differ only by "helps/ の md を参照してください"; with that
+sentence the agent finds the block, without it the agent never does.
+
+## Delivery constraint that decides the placement
+
+`manageCollection: { action: "schemaDocs" }` does **not** return the whole file.
+`packages/core/src/collection/server/schemaDocs.ts` sections it:
+
+- no `topic` → the doc intro + the **own prose** of the core sections
+  (`CORE_SECTION_PATTERNS = ["anatomy", "skill.md", "the dsl", "field types", "end-to-end", "editing an existing"]`)
+  + a table of contents listing **every** heading;
+- `topic: "<heading>"` → that section's subtree;
+- `topic: "all"` → the full dump.
+
+The own prose of `## schema.json — the DSL` is the **top-level shape table**, and it is
+served on every no-topic call. An `###` subsection under it is *not* served by default —
+it only reaches the agent through the TOC or an explicit `topic`.
+
+So a mention buried in a new `###` section alone would still be invisible on the default
+call. The fix must land in the table.
+
+## Change (option A from the issue)
+
+`packages/core/assets/helps/collection-skills.md`:
+
+1. **A `googleCalendar` row in the top-level shape table** (`## schema.json — the DSL`).
+   This is the sentence the agent meets on the default `schemaDocs` call, in the same
+   place it is already reading `dataPath` / `spawn` / `views`. It states the LLM-free
+   selling point, says explicitly to prefer it over an `ingest: { kind: "agent" }` worker
+   or the `google` MCP tools, and points at `config/helps/google-calendar-collection.md`.
+
+2. **A short `### Google Calendar sync (`googleCalendar`)` section**, placed immediately
+   after `### Scheduled agent refresh (ingest.kind: "agent")` — its sibling opt-in block,
+   and the section an agent lands in when it asks "how does a collection refresh itself on
+   a schedule". Adds the TOC entry `Google Calendar sync (googleCalendar)` and makes
+   `topic: "google calendar"` resolve. Format follows the neighbouring `### Custom views`
+   entry: the block, why to reach for it, the one trap that is not guessable
+   (never map the `primaryKey`), then a pointer.
+
+Deliberately **not** duplicating `google-calendar-collection.md` — deletion semantics, the
+`calendarId` lookup, and the first-run full-walk caveat stay in the one file that owns them.
+
+Assertions checked against the implementation, not memory:
+
+- `packages/core/src/collection/core/schemaZ.ts` — `GoogleCalendarSyncZ` = `{ calendarId?: string, map: Record<string, GOOGLE_CALENDAR_SOURCE_FIELDS> }`,
+  `map` non-empty (refine), `GOOGLE_CALENDAR_SOURCE_FIELDS = ["summary","start","end","htmlLink","colorId","status"]`.
+- `googleCalendarMapNamesStoredFields` (`schemaRules.ts`) — a map key must name a declared,
+  non-computed field and never the `primaryKey`.
+- `dataSource` collections cannot declare `googleCalendar` (read-only refine, schemaZ.ts:798).
+
+## Not changed, and why
+
+- `helps/index.md` — its `collection-skills.md` summary describes the DSL, and a dedicated
+  `Google Calendar sync` entry already exists two lines above. The routing gap was *inside*
+  `collection-skills.md`; the index was never the failure point.
+- `docs/` — developer docs, not agent-facing; nothing there discusses the schema DSL surface.
+- No source change. Option B (keyword routing over the helps index) is a real feature and
+  stays out of a docs fix.
+
+## Test
+
+`test/agent/test_manageCollection.ts` (`manageCollection — schemaDocs`) is where the real
+bundled doc is exercised. Add:
+
+- the **default** reply (no topic) names `googleCalendar` and points at
+  `config/helps/google-calendar-collection.md` — this is the regression test for the exact
+  reported failure;
+- `topic: "google calendar"` resolves to the new section.
+
+Mutation check: revert the doc edit, watch both go red, restore.
+
+## Release
+
+`assets/helps/*` ships to npm with `@mulmoclaude/core` (`files: ["dist", "assets"]`), so an
+unpublished help edit is invisible to installed users. Bump `@mulmoclaude/core` 1.0.1 → 1.0.2
+and sweep every consumer range to `^1.0.2` (`packages/mulmoclaude`, `collection-plugin` deps +
+peerDeps, `google-plugin`) to keep the launcher-sync invariant green. Same shape as c97d9a82.
+The launcher's own `version` is untouched.

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -453,10 +453,30 @@ describe("manageCollection — schemaDocs", () => {
     assert.ok(docs.length < 40_000, `default reply must stay well under the full doc (${docs.length} chars)`);
   });
 
+  // #2312: the agent authored Google Calendar collections with an MCP
+  // connector + an `ingest: { kind: "agent" }` worker because the DEFAULT
+  // reply — the only part it reads before writing a schema — never named the
+  // LLM-free `googleCalendar` block. A mention in a `###` subsection would
+  // not fix that: renderDefault serves only the core sections' own prose, so
+  // the pointer has to live in the top-level shape table.
+  it("names the googleCalendar block in the default reply and routes to its help file", async () => {
+    const docs = await run({ action: "schemaDocs" });
+    assert.match(docs, /`googleCalendar`/, "the sync block is discoverable without a topic");
+    assert.match(docs, /config\/helps\/google-calendar-collection\.md/, "the default reply routes to the full contract");
+    assert.match(docs, /- Google Calendar sync \(`googleCalendar`\)/, "the section is listed in the TOC");
+  });
+
   it("serves a single section by topic", async () => {
     const docs = await run({ action: "schemaDocs", topic: "kanban" });
     assert.match(docs, /gains a \*\*Kanban board\*\* toggle/);
     assert.doesNotMatch(docs, /### Field types/);
+  });
+
+  it('serves the Google Calendar sync section for topic "google calendar"', async () => {
+    const docs = await run({ action: "schemaDocs", topic: "google calendar" });
+    assert.match(docs, /### Google Calendar sync \(`googleCalendar`\)/);
+    assert.match(docs, /"map": \{ "title": "summary"/, "the block example is included");
+    assert.doesNotMatch(docs, /### Field types/, "one section, not the whole doc");
   });
 
   it('serves the full doc for topic "all"', async () => {


### PR DESCRIPTION
## Summary

Asked to "create a collection that syncs with Google Calendar", the agent built it the **old** way — a Google MCP connector plus an `ingest: { kind: "agent" }` worker that spends an LLM turn on every refresh — and never reached the zero-token `googleCalendar` schema block.

Cause: `packages/core/assets/helps/collection-skills.md`, the schema-DSL reference the agent reads *while authoring a collection*, had **zero** occurrences of `googleCalendar` or "Google Calendar". The feature is fully documented in `google-calendar-collection.md` and linked from `helps/index.md`, but nothing routed the agent there mid-authoring.

This is option A from the issue: make `collection-skills.md` name the block and point at the file that owns it.

**Where the mention had to go.** `manageCollection: { action: "schemaDocs" }` does not return the whole file. `packages/core/src/collection/server/schemaDocs.ts` sections it: with no `topic` it returns the **own prose** of the core sections (`CORE_SECTION_PATTERNS`) plus a table of contents. The own prose of `## schema.json — the DSL` is the **top-level shape table** — that is what the agent actually reads before writing a schema. An `###` subsection is *not* in the default reply. So a new section alone would not have fixed anything. Two placements:

1. **A `googleCalendar` row in the top-level shape table** — in the default reply, alongside the `dataPath` / `spawn` / `views` rows the agent is already scanning.
2. **A short `### Google Calendar sync (`googleCalendar`)` section**, immediately after its sibling opt-in `### Scheduled agent refresh (ingest.kind: "agent")` — this adds the TOC entry and makes `topic: "google calendar"` resolve (it previously returned *"no schemaDocs section matches"*).

The full contract (finding a non-primary `calendarId`, deletion propagation, the first-run full-walk caveat) deliberately stays in `google-calendar-collection.md`. No duplication, no new doc-drift surface.

## Items to Confirm / Review

- **Is the wording strong enough to actually flip the agent's choice?** The row and the section both say, in as many words, "not an `ingest.kind: "agent"` worker and not the `google` MCP calendar tools". That is a prompt-engineering judgement call, not a provable one — please sanity-check the phrasing.
- **Table-row placement (last row, after `views`).** The table omits `ingest`, `collectionActions` and `dynamicIcon` today, so it is not a complete mirror of `CollectionObjectZ`. I added `googleCalendar` anyway because it is the row that fixes the reported bug; I did **not** backfill the other three (out of scope). Say the word if you'd rather the table became exhaustive in a follow-up.
- **Default-reply headroom.** `renderDefault`'s budget is `SCHEMA_DOCS_RESULT_BUDGET` (36,000). The default reply went 34,125 → 34,763 chars. Still no `[Omitted for size — …]` note and every core section intact, but headroom is now ~1.2 KB — the next sizeable addition to a *core* section will start dropping sections into the pointer note.
- **`dataSource` row not touched.** `schemaZ.ts:798` rejects `googleCalendar` on a read-only `dataSource` collection, but the `dataSource` table row still lists only `singleton` / `ingest` / `spawn` / mutate actions as mutually exclusive. Widening that cell would have forced a re-pad of the whole 22-row table (prettier does not format `.md` here — the glob is `{ts,json,yaml,vue}` — so alignment is hand-maintained). My row says the block needs `dataPath`, and `google-calendar-collection.md` has a "Not for this" section. Flagging it as a known, deliberate gap.
- **Version bump.** `@mulmoclaude/core` 1.0.1 → 1.0.2, consumer ranges swept to `^1.0.2` (launcher, collection-plugin deps + peerDeps, google-plugin). Same shape as c97d9a82. The launcher's **own** `version` is untouched, per CLAUDE.md.

## User Prompt

> 2310~2312もみてね

## Implementation

Plan: [`plans/docs-2312-gcal-schemadocs.md`](plans/docs-2312-gcal-schemadocs.md) (committed).

### `packages/core/assets/helps/collection-skills.md`

Everything asserted about the block was read off the implementation, not recalled:

- `GoogleCalendarSyncZ` (`packages/core/src/collection/core/schemaZ.ts:602`) — `{ calendarId?: string, map: Record<string, …> }`, `map` refined non-empty.
- `GOOGLE_CALENDAR_SOURCE_FIELDS` (`schemaZ.ts:597`) — `summary`, `start`, `end`, `htmlLink`, `colorId`, `status`.
- `googleCalendarMapNamesStoredFields` (`schemaRules.ts:255`) — a map key must name a declared, non-computed field and never the `primaryKey`.
- The "opts in by declaring a block, exactly the way a feed opts in by declaring `ingest`" framing is the module comment on `packages/core/src/google/collectionSync.ts:8` — the doc now uses the same framing, in the section next to `ingest`'s.

### Verification — the sentence the agent now meets

The reported failure is "the agent calls `schemaDocs`, gets no hint, and improvises." So the check is what a **no-topic** `schemaDocs` call returns. Rendered through the real `renderSchemaDocs`:

| | before | after |
|---|---|---|
| default reply length | 34,125 | 34,763 |
| contains `googleCalendar` | **no** | yes |
| contains `config/helps/google-calendar-collection.md` | **no** | yes |
| `topic: "google calendar"` | `no schemaDocs section matches 'google calendar'` | the `### Google Calendar sync` section |
| any core section omitted for size | no | no |

The row it now hits, inside the table it is already reading to pick `dataPath` / `primaryKey` / `calendarField`:

> **`googleCalendar`** — Optional. `{ "calendarId": "primary", "map": { "<field>": "summary" } }` — the host mirrors one of the user's **Google calendars** into this collection on a schedule, **LLM-free**: no tool call, no tokens per sync. Reach for it whenever the user asks for a collection that syncs with Google Calendar — never an `ingest.kind: "agent"` worker or the `google` MCP tools, which spend an LLM turn per refresh doing what the host does for free. Needs `dataPath`. See "Google Calendar sync" below and **`config/helps/google-calendar-collection.md`**.

That is enough to route it because the row (a) appears at the exact moment the agent is choosing top-level schema keys, (b) names the alternative it was wrongly picking and says not to, and (c) gives the file path, so the "helps/ の md を参照してください" instruction the user had to supply by hand is now supplied by the document itself.

### Tests — `test/agent/test_manageCollection.ts`

`packages/core/test/collection/test_schemaDocs.ts` deliberately runs against a synthetic doc (it pins the sectioning *rules*), so the content guard belongs in the suite that exercises the **real bundled doc**:

- `names the googleCalendar block in the default reply and routes to its help file` — the direct regression test for the issue: no `topic`, must contain `` `googleCalendar` ``, the help path, and the TOC entry.
- `serves the Google Calendar sync section for topic "google calendar"` — the section resolves and is not the whole doc.

**Mutation check performed**: reverted `collection-skills.md` to `HEAD`, both tests went red; restored, both green. They are not passing for an unrelated reason.

`test/workspace/test_helps_registry.ts` already guards `index.md`, and needed no change — `google-calendar-collection.md` has had an entry there all along. The index was never the failure point, so I left it alone. Nothing under `docs/` discusses the schema DSL surface, so nothing there needed updating either.

### Gates

`yarn format` (glob is `{ts,json,yaml,vue}` — it does **not** touch `.md`, so the table was hand-padded to the existing 22/564 column widths and no unrelated line reflowed), `yarn lint` (0 errors, 40 pre-existing warnings), `yarn typecheck`, `yarn build`, `yarn test` (all suites green), `yarn check:launcher-sync` (OK).

---

@ystknsh — 報告ありがとうございました。マージ後に、**「helps/ の md を参照してください」を入れていない方**の元のプロンプトをもう一度実行して、エージェントが自力で `googleCalendar` ブロックに辿り着くか確認していただけますか。うまくいかない場合は、そのときエージェントが実際に読んだ `schemaDocs` の出力を貼っていただけると助かります（issue の option B、ヘルプのキーワード・ルーティングが必要という判断材料になります）。

Closes #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

