### PR TITLE
fix(google): normalise synced calendar datetimes to the shape collections parse

### DIFF
--- a/docs/shared-utils.md
+++ b/docs/shared-utils.md
@@ -17,6 +17,7 @@ This catalog only covers **cross-cutting** helpers — formatters, error helpers
 | `src/utils/format/date.ts` | `formatDate`, `formatDateTime`, `formatTime`, `formatShortDate`, `formatShortTime`, `formatMonthYear`, `formatSmartTime`, `formatRelativeTime`            | User-facing date display in Vue Views. Prefer over inline `toLocaleString()`.                                 |
 | `src/utils/format/date.ts` | `isSameDay`, `isToday`                                                                                                                                    | Day-boundary comparisons.                                                                                     |
 | `server/utils/date.ts`     | `toUtcIsoDate(...)` and friends                                                                                                                            | Server-side UTC date normalisation (`YYYY-MM-DD`). Distinct from the frontend display formatters above.        |
+| `packages/core/src/google/collectionDateTime.ts` (`@mulmoclaude/core/google`) | `toCollectionDateTime(value)` | RFC3339-with-zone / date-only → the `YYYY-MM-DDTHH:MM[:SS]` shape a collection `datetime` field is linted and rendered against (#2310): the zone designator is dropped (wall clock kept, never converted to host-local) and an all-day date gains `T00:00`. Pure. Used by the Google Calendar → collection sync; reuse it for any other importer writing into a `datetime` field instead of re-deriving the stripping. |
 
 ## Errors
 

--- a/packages/core/src/google/collectionDateTime.ts
+++ b/packages/core/src/google/collectionDateTime.ts
@@ -1,0 +1,36 @@
+// Google Calendar date/dateTime → the shape a collection `datetime` field is
+// validated against (#2310).
+//
+// Google answers with RFC3339 including a zone designator for timed events
+// (`2026-05-12T08:45:00+09:00`, sometimes `…Z`) and a bare `YYYY-MM-DD` for
+// all-day ones. `parseIsoDateTime` — which the record lint, the calendar grid
+// and the day view all share — accepts only `YYYY-MM-DDTHH:MM[:SS]`, so both
+// shapes were stored and then reported as data problems on every synced record.
+//
+// The offset is DROPPED, not applied: the stored clock is then the one the user
+// reads off Google Calendar, and it stays that clock wherever the workspace is
+// opened. Converting to the host's local time would make a record's value
+// depend on the machine that happened to run the sync, and silently shift every
+// record when that machine moves timezone.
+//
+// Pure: no I/O, no clock, no locale.
+
+/** All-day events carry no clock; midnight is where the day view places them. */
+const ALL_DAY_CLOCK = "00:00";
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+/** RFC3339 zone designator: `Z`, `+09:00`, `-0500`. */
+const ZONE_SUFFIX_RE = /(?:Z|[+-]\d{2}:?\d{2})$/;
+/** Fractional seconds have no place in the collection datetime shape. */
+const FRACTIONAL_SECONDS_RE = /\.\d+$/;
+
+/** Normalise one Google Calendar time value for storage in a `datetime` field.
+ *  Anything that isn't a recognisable Google shape (empty string, non-string,
+ *  free text) is returned untouched — the record lint should report it rather
+ *  than have this function invent a value. */
+export function toCollectionDateTime(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (DATE_ONLY_RE.test(trimmed)) return `${trimmed}T${ALL_DAY_CLOCK}`;
+  if (!trimmed.includes("T")) return value;
+  return trimmed.replace(ZONE_SUFFIX_RE, "").replace(FRACTIONAL_SECONDS_RE, "");
+}

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -15,10 +15,11 @@ import { getWorkspaceRoot } from "../collection/server/host.js";
 import type { LoadedCollection } from "../collection/server/discoveredCollection.js";
 import type { DeleteItemResult, WriteItemResult } from "../collection/server/io.js";
 import { storeFor } from "../collection/server/store.js";
-import type { CollectionItem } from "../collection/core/schema.js";
+import type { CollectionFieldSpec, CollectionItem } from "../collection/core/schema.js";
 import type { GOOGLE_CALENDAR_SOURCE_FIELDS } from "../collection/core/schemaZ.js";
 import { getGoogleAccessToken } from "./auth.js";
 import { canonicalCalendarId, syncCalendarEvents, type CalendarEventSummary } from "./calendar.js";
+import { toCollectionDateTime } from "./collectionDateTime.js";
 import { clearCalendarSyncToken, loadCalendarSyncToken, saveCalendarSyncToken } from "./calendarSyncStore.js";
 import { loadGoogleTokens } from "./tokenStore.js";
 import { log } from "./host.js";
@@ -42,11 +43,33 @@ export interface CalendarCollectionSyncResult {
  *  `CalendarEventSummary` so the projection below needs no cast. */
 type GoogleCalendarSourceField = (typeof GOOGLE_CALENDAR_SOURCE_FIELDS)[number];
 
+const DATETIME_FIELD_TYPE = "datetime";
+
+/** Own-property lookup, mirroring what the record lint reads: a spec reachable
+ *  only through the prototype chain is not a DECLARED field, so it must not
+ *  decide how a value is stored. */
+function declaredSpec(fields: Record<string, CollectionFieldSpec>, field: string): CollectionFieldSpec | undefined {
+  return Object.hasOwn(fields, field) ? fields[field] : undefined;
+}
+
+/** Google's raw value is normalised only into a field the schema declares as
+ *  `datetime` — that is the type whose stored shape the record lint, the
+ *  calendar grid and the day view all parse (#2310). A user who maps `start`
+ *  onto a `string` field asked for Google's value verbatim and keeps it. */
+function projectValue(fields: Record<string, CollectionFieldSpec>, field: string, value: string): unknown {
+  return declaredSpec(fields, field)?.type === DATETIME_FIELD_TYPE ? toCollectionDateTime(value) : value;
+}
+
 /** Project one Google event onto the collection's own field names. The
  *  primary field always takes the event id — upsert-by-id is what keeps the
  *  sync idempotent, so it is deliberately not remappable. */
-export function toCollectionRecord(event: CalendarEventSummary, map: Record<string, GoogleCalendarSourceField>, primaryKey: string): CollectionItem {
-  const mapped = Object.entries(map).map(([field, source]) => [field, event[source]]);
+export function toCollectionRecord(
+  event: CalendarEventSummary,
+  map: Record<string, GoogleCalendarSourceField>,
+  primaryKey: string,
+  fields: Record<string, CollectionFieldSpec>,
+): CollectionItem {
+  const mapped = Object.entries(map).map(([field, source]) => [field, projectValue(fields, field, event[source])]);
   return { ...Object.fromEntries(mapped), [primaryKey]: event.id };
 }
 
@@ -91,7 +114,7 @@ async function applyEvent(collection: LoadedCollection, event: CalendarEventSumm
       const deleted = await store.delete(event.id);
       return classifyDelete(event.id, deleted.kind);
     }
-    const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey);
+    const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey, schema.fields);
     const written = await store.write(event.id, record);
     return classifyWrite(event.id, written.kind);
   } catch (error) {

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -49,6 +49,7 @@ export {
   type SyncEventsInput,
 } from "./calendar.js";
 export { calendarSyncStatePath, clearCalendarSyncToken, loadCalendarSyncToken, saveCalendarSyncToken } from "./calendarSyncStore.js";
+export { toCollectionDateTime } from "./collectionDateTime.js";
 export {
   googleCalendarSyncTaskDef,
   classifyDelete,

--- a/plans/fix-2310-gcal-datetime.md
+++ b/plans/fix-2310-gcal-datetime.md
@@ -1,0 +1,94 @@
+# fix(#2310): googleCalendar sync writes datetimes the collection validator rejects
+
+Issue: #2310 — every record written by the `googleCalendar` block is reported as a data
+problem ("23件のレコードファイルにデータの問題があり…"). The data is intact; the stored
+values are simply not in the shape a `datetime` field is validated against.
+
+## Root cause (verified, not assumed)
+
+Three layers, all doing exactly what they were written to do:
+
+| Layer | File | Behaviour |
+|---|---|---|
+| REST projection | `packages/core/src/google/calendar.ts` → `eventTime()` | returns Google's raw value: `value.dateTime` (`2026-05-12T08:45:00+09:00`, sometimes `…Z`) or `value.date` (`2026-03-18`) |
+| Record projection | `packages/core/src/google/collectionSync.ts` → `toCollectionRecord()` | copies it into the record with no normalisation |
+| Record lint | `packages/core/src/collection/core/recordZ.ts` → `strictTypeProblem()` | validates `datetime` with `parseIsoDateTime` (`collection/core/calendarGrid.ts`) |
+
+`parseIsoDateTime` requires `YYYY-MM-DDTHH:MM[:SS]`. Reproduced against the built package:
+
+```
+"2026-05-12T08:45:00+09:00" -> null     # split(":") yields 4 parts
+"2026-05-12T08:45:00Z"      -> null     # "00Z" is not two digits
+"2026-03-18"                -> null     # no "T"
+"2026-05-12T08:45:00-05:00" -> null
+"2026-05-12T08:45:00"       -> ok
+"2026-05-12T08:45"          -> ok
+```
+
+## Decision: fix the sync path, not the validator
+
+The validator's strict shape is deliberate — its own comment says a `Z` suffix is
+something the day view cannot place. Loosening it would turn a visible lint error into an
+invisible "event missing from the calendar" bug. So the sync normalises on write.
+
+- **Timed events** — drop the zone designator, keep the wall clock:
+  `2026-05-12T08:45:00+09:00` → `2026-05-12T08:45:00`. This is the time the user sees in
+  Google Calendar, and it does not depend on the host's clock/TZ. A trailing `Z` is
+  handled the same way. **No conversion to local time.**
+- **All-day events** — `2026-03-18` → `2026-03-18T00:00`.
+- **Target-type driven** — normalise only when the *mapped collection field* is declared
+  `datetime`. A user who maps `start` onto a `string` field asked for Google's raw value
+  and keeps it.
+
+## Changes
+
+- **new** `packages/core/src/google/collectionDateTime.ts` — `toCollectionDateTime(value)`,
+  a pure function in its own file (no I/O, no clock), so the rule is unit-testable.
+- `packages/core/src/google/collectionSync.ts` — `toCollectionRecord()` takes the schema's
+  `fields` as a 4th parameter and routes each mapped value through the normaliser only
+  when that field's spec type is `datetime`. Field lookup is own-property (`Object.hasOwn`),
+  matching the hardening in #2320/#2322.
+- `packages/core/src/google/index.ts` — export the normaliser.
+- `docs/shared-utils.md` — catalog entry (CLAUDE.md requires it in the same PR).
+
+## Tests
+
+`test/services/google/test_calendarDateTime.ts` (new) — `+09:00`, a negative offset, `Z`,
+no offset at all, date-only, seconds present/absent, fractional seconds, empty string,
+non-string, whitespace, and unparseable junk. Every normalised output is asserted against
+the real `parseIsoDateTime` (imported, not a guessed regex) so the test pins the actual
+contract rather than a restatement of the implementation.
+
+`test/services/google/test_calendarCollectionSync.ts` — extended: a `datetime` target is
+normalised, a `string` target is passed through byte-for-byte, an undeclared field falls
+back to raw, and the all-day → `T00:00` case replaces the old "carries date values through
+unchanged" expectation.
+
+Verification: reverting `toCollectionDateTime` to `(value) => value` must turn the new
+tests RED (recorded in the PR).
+
+## Migration — existing broken records do NOT self-heal
+
+The sync upserts by event id and only fetches what changed since the stored sync token
+(`packages/core/src/google/calendarSyncStore.ts`). Google never resends an unchanged
+event, so the ~23 records already on disk keep their rejected values until each event is
+edited in Google.
+
+Remedy (manual, one line): delete `<workspace>/data/calendar/.sync-state.json` (or the one
+`tokens` entry for that calendar) and let the next scheduled run do a full walk — writes
+are keyed by event id, so every existing record is rewritten in place, not duplicated.
+`clearCalendarSyncToken(calendarId, workspaceRoot)` is the programmatic equivalent; it is
+currently called only on Google's 410 (expired token).
+
+An automatic remedy (e.g. a one-shot token clear on upgrade) is **proposed in the PR, not
+implemented here** — a forced full walk over a calendar with years of history is a real
+cost and should be an explicit choice.
+
+## Out of scope
+
+- A timed event mapped onto a `date` (not `datetime`) field still stores the raw value and
+  still lints. Deliberate: the decision is to key off the declared target type, and no
+  recipe maps `start` onto `date`.
+- Loosening `parseIsoDateTime` — see above.
+- `@mulmoclaude/core` version bump: this PR touches `src` only (no `assets/helps/*`
+  change), and the repo's convention is that `src` fixes ride the next `chore(release)`.

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -8,6 +8,8 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { classifyDelete, classifyWrite, groupByCalendar, toCollectionRecord } from "@mulmoclaude/core/google";
 import type { CalendarEventSummary } from "@mulmoclaude/core/google";
+import { parseIsoDateTime } from "@mulmoclaude/core/collection";
+import type { CollectionFieldSpec } from "@mulmoclaude/core/collection";
 import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
 
 const event = (overrides: Partial<CalendarEventSummary> = {}): CalendarEventSummary => ({
@@ -21,38 +23,41 @@ const event = (overrides: Partial<CalendarEventSummary> = {}): CalendarEventSumm
   ...overrides,
 });
 
+// The recipe shape from `assets/helps/google-calendar-collection.md`: the
+// start/end columns are `datetime`, everything else is text.
+const recipeFields: Record<string, CollectionFieldSpec> = {
+  gid: { type: "string", label: "ID", primary: true },
+  title: { type: "string", label: "Event" },
+  on: { type: "datetime", label: "Start" },
+  until: { type: "datetime", label: "End" },
+  colour: { type: "string", label: "Colour" },
+};
+
 describe("toCollectionRecord (#2095)", () => {
   it("projects mapped event fields onto the collection's own field names", () => {
-    const record = toCollectionRecord(event(), { title: "summary", on: "start", until: "end" }, "gid");
+    const record = toCollectionRecord(event(), { title: "summary", on: "start", until: "end" }, "gid", recipeFields);
     assert.equal(record.title, "Standup");
-    assert.equal(record.on, "2026-07-19T09:00:00+09:00");
-    assert.equal(record.until, "2026-07-19T09:15:00+09:00");
+    assert.equal(record.on, "2026-07-19T09:00:00");
+    assert.equal(record.until, "2026-07-19T09:15:00");
   });
 
   it("always writes the Google event id into the primary field", () => {
-    const record = toCollectionRecord(event({ id: "abc123" }), { title: "summary" }, "gid");
+    const record = toCollectionRecord(event({ id: "abc123" }), { title: "summary" }, "gid", recipeFields);
     assert.equal(record.gid, "abc123");
   });
 
   it("writes ONLY the mapped fields plus the primary — no stray event fields leak in", () => {
-    const record = toCollectionRecord(event(), { title: "summary" }, "gid");
+    const record = toCollectionRecord(event(), { title: "summary" }, "gid", recipeFields);
     assert.deepEqual(Object.keys(record).sort(), ["gid", "title"]);
   });
 
   it("supports an empty map (records then carry just the id)", () => {
-    const record = toCollectionRecord(event(), {}, "gid");
+    const record = toCollectionRecord(event(), {}, "gid", recipeFields);
     assert.deepEqual(record, { gid: "ev-1" });
   });
 
-  it("carries an all-day event's date values through unchanged", () => {
-    const allDay = event({ start: "2026-07-19", end: "2026-07-20" });
-    const record = toCollectionRecord(allDay, { on: "start", until: "end" }, "gid");
-    assert.equal(record.on, "2026-07-19");
-    assert.equal(record.until, "2026-07-20");
-  });
-
   it("keeps an empty optional value as an empty string rather than dropping the key", () => {
-    const record = toCollectionRecord(event({ colorId: "" }), { colour: "colorId" }, "gid");
+    const record = toCollectionRecord(event({ colorId: "" }), { colour: "colorId" }, "gid", recipeFields);
     assert.equal(record.colour, "");
     assert.ok("colour" in record);
   });
@@ -60,8 +65,53 @@ describe("toCollectionRecord (#2095)", () => {
   it("lets the primary field win even if the map tries to target it", () => {
     // Schema validation rejects this, but the projection must not corrupt the
     // id if a hand-edited schema slips through.
-    const record = toCollectionRecord(event({ id: "real-id" }), { gid: "summary" }, "gid");
+    const record = toCollectionRecord(event({ id: "real-id" }), { gid: "summary" }, "gid", recipeFields);
     assert.equal(record.gid, "real-id");
+  });
+});
+
+// Google's own shapes are rejected by the `datetime` record lint, so every
+// synced record was reported as a data problem until the projection normalised
+// them (#2310). Normalisation keys off the TARGET field's declared type, never
+// the source field name.
+describe("toCollectionRecord datetime normalisation (#2310)", () => {
+  it("stores a timed event in the shape the collection parses", () => {
+    const record = toCollectionRecord(event(), { on: "start", until: "end" }, "gid", recipeFields);
+    assert.notEqual(parseIsoDateTime(record.on), null, "a synced start must satisfy the datetime lint");
+    assert.notEqual(parseIsoDateTime(record.until), null, "a synced end must satisfy the datetime lint");
+  });
+
+  it("anchors an all-day event at midnight so it parses as a datetime", () => {
+    const allDay = event({ start: "2026-07-19", end: "2026-07-20" });
+    const record = toCollectionRecord(allDay, { on: "start", until: "end" }, "gid", recipeFields);
+    assert.equal(record.on, "2026-07-19T00:00");
+    assert.equal(record.until, "2026-07-20T00:00");
+    assert.notEqual(parseIsoDateTime(record.on), null);
+  });
+
+  it("leaves a `string` target byte-for-byte alone — the user asked for Google's raw value", () => {
+    const stringFields: Record<string, CollectionFieldSpec> = { on: { type: "string", label: "Start" } };
+    const record = toCollectionRecord(event(), { on: "start" }, "gid", stringFields);
+    assert.equal(record.on, "2026-07-19T09:00:00+09:00");
+  });
+
+  it("leaves a field the schema does not declare alone", () => {
+    const record = toCollectionRecord(event(), { stray: "start" }, "gid", recipeFields);
+    assert.equal(record.stray, "2026-07-19T09:00:00+09:00");
+  });
+
+  it("ignores a spec reachable only through the prototype chain", () => {
+    // The declared shape is what the record lint reads, and it reads own
+    // properties. Typing a field off an inherited spec would normalise a value
+    // the collection never declared as a datetime.
+    const inheritedFields: Record<string, CollectionFieldSpec> = Object.create({ on: { type: "datetime", label: "Start" } });
+    const record = toCollectionRecord(event(), { on: "start" }, "gid", inheritedFields);
+    assert.equal(record.on, "2026-07-19T09:00:00+09:00");
+  });
+
+  it("keeps an empty datetime value empty instead of inventing a time", () => {
+    const record = toCollectionRecord(event({ start: "" }), { on: "start" }, "gid", recipeFields);
+    assert.equal(record.on, "");
   });
 });
 

--- a/test/services/google/test_calendarDateTime.ts
+++ b/test/services/google/test_calendarDateTime.ts
@@ -1,0 +1,117 @@
+// Unit tests for the Google Calendar → collection `datetime` normaliser
+// (#2310). Google answers RFC3339-with-zone for timed events and a bare date
+// for all-day ones; a collection `datetime` field is linted with
+// `parseIsoDateTime`, which accepts neither — so every synced record was
+// reported as a data problem.
+//
+// The contract these tests pin is deliberately NOT a restatement of the
+// implementation's regexes: every normalised value is fed to the real
+// `parseIsoDateTime`, so the tests fail if that parser's shape ever moves.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toCollectionDateTime } from "@mulmoclaude/core/google";
+import { parseIsoDateTime } from "@mulmoclaude/core/collection";
+
+/** Normalise, and assert on the way out that the result is something the
+ *  collection's own parser accepts — the real reason the value is stored at
+ *  all. Callers still assert the exact text, so a change in either the shape
+ *  or the parser turns these red. */
+const normalizedForCollection = (raw: string): unknown => {
+  const normalized = toCollectionDateTime(raw);
+  assert.notEqual(parseIsoDateTime(normalized), null, `'${String(normalized)}' must satisfy parseIsoDateTime`);
+  return normalized;
+};
+
+describe("toCollectionDateTime — timed events (#2310)", () => {
+  it("drops a positive offset and keeps the wall clock", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45:00+09:00"), "2026-05-12T08:45:00");
+  });
+
+  it("drops a negative offset without shifting the clock", () => {
+    // The point of stripping rather than converting: 08:45 in New York stays
+    // 08:45, so the stored value matches what the user reads off Google
+    // Calendar no matter which host ran the sync.
+    assert.equal(normalizedForCollection("2026-05-12T08:45:00-05:00"), "2026-05-12T08:45:00");
+  });
+
+  it("drops a `Z` suffix", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45:00Z"), "2026-05-12T08:45:00");
+  });
+
+  it("drops a compact `+0900` offset (no colon)", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45:00+0900"), "2026-05-12T08:45:00");
+  });
+
+  it("leaves a value that already has no offset alone", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45:00"), "2026-05-12T08:45:00");
+  });
+
+  it("keeps seconds when Google sends them", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45:37+09:00"), "2026-05-12T08:45:37");
+  });
+
+  it("accepts a value with no seconds at all", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45+09:00"), "2026-05-12T08:45");
+  });
+
+  it("drops fractional seconds, which the collection shape has no room for", () => {
+    assert.equal(normalizedForCollection("2026-05-12T08:45:00.123Z"), "2026-05-12T08:45:00");
+  });
+
+  it("trims surrounding whitespace", () => {
+    assert.equal(normalizedForCollection("  2026-05-12T08:45:00+09:00  "), "2026-05-12T08:45:00");
+  });
+
+  it("keeps midnight at midnight rather than rolling the day", () => {
+    assert.equal(normalizedForCollection("2026-05-12T00:00:00+09:00"), "2026-05-12T00:00:00");
+  });
+});
+
+describe("toCollectionDateTime — all-day events (#2310)", () => {
+  it("anchors a date-only value at midnight", () => {
+    assert.equal(normalizedForCollection("2026-03-18"), "2026-03-18T00:00");
+  });
+
+  it("anchors the exclusive end date the same way", () => {
+    assert.equal(normalizedForCollection("2026-03-19"), "2026-03-19T00:00");
+  });
+
+  it("anchors a date-only value with surrounding whitespace", () => {
+    assert.equal(normalizedForCollection(" 2026-03-18 "), "2026-03-18T00:00");
+  });
+});
+
+// Anything that is not a Google shape is returned untouched: inventing a value
+// would hide the problem, while passing it through leaves the record lint free
+// to report it.
+describe("toCollectionDateTime — values it must not invent (#2310)", () => {
+  it("passes an empty string through unchanged", () => {
+    assert.equal(toCollectionDateTime(""), "");
+  });
+
+  it("passes a whitespace-only string through unchanged", () => {
+    assert.equal(toCollectionDateTime("   "), "   ");
+  });
+
+  it("passes a non-string value through unchanged", () => {
+    assert.equal(toCollectionDateTime(undefined), undefined);
+    assert.equal(toCollectionDateTime(null), null);
+    assert.equal(toCollectionDateTime(42), 42);
+    const nested = { dateTime: "2026-05-12T08:45:00+09:00" };
+    assert.equal(toCollectionDateTime(nested), nested);
+  });
+
+  it("passes free text through rather than manufacturing a datetime", () => {
+    assert.equal(toCollectionDateTime("tomorrow"), "tomorrow");
+    assert.equal(parseIsoDateTime(toCollectionDateTime("tomorrow")), null);
+  });
+
+  it("does not turn an impossible day into a valid-looking datetime", () => {
+    // `2026-02-30` matches the date-only SHAPE, so it gains a clock — but the
+    // strict parser still rejects it, which is the correct outcome: the lint
+    // must keep reporting a day that does not exist.
+    assert.equal(toCollectionDateTime("2026-02-30"), "2026-02-30T00:00");
+    assert.equal(parseIsoDateTime("2026-02-30T00:00"), null);
+  });
+});


### PR DESCRIPTION
## Summary

Records synced by the `googleCalendar` block were rejected by the collection `datetime`
validator — the UI reported every one of them as having a data problem (#2310).
`toCollectionRecord()` stored Google's value verbatim, and neither of Google's two shapes
survives the record lint:

| Google value | why `parseIsoDateTime` rejects it |
|---|---|
| `2026-05-12T08:45:00+09:00` | the offset makes `split(":")` yield 4 parts |
| `2026-05-12T08:45:00Z` | `"00Z"` is not a two-digit field |
| `2026-03-18` (all-day) | no `T` at all |

Fixed **in the sync path, not in the validator.** The validator's strict shape is
deliberate — its own comment says a `Z` suffix is something the day view cannot place — so
loosening it would trade a visible lint error for an invisible "event silently missing from
the calendar" bug.

- **new** `packages/core/src/google/collectionDateTime.ts` — `toCollectionDateTime(value)`,
  a pure function in its own file (no I/O, no clock). Drops the zone designator and keeps
  the **wall clock**: `2026-05-12T08:45:00+09:00` → `2026-05-12T08:45:00`. That is the time
  the user reads off Google Calendar, and it does not depend on which host ran the sync —
  converting to local time would silently shift every record when the machine moves
  timezone. `Z` and fractional seconds are handled the same way; an all-day `2026-03-18`
  becomes `2026-03-18T00:00`. Anything unrecognisable is returned **untouched** rather than
  invented, so the lint keeps reporting it.
- `toCollectionRecord()` now takes the schema's `fields` as a 4th parameter and normalises
  based on the **target field's declared type**, never the source field name. A user who
  maps `start` onto a `string` field keeps Google's raw value. Field lookup is own-property,
  matching the hardening in #2320 / #2322.
- `docs/shared-utils.md` — catalog entry, per CLAUDE.md.

## Items to Confirm / Review

@ystknsh — please re-verify against your calendar once this merges.

1. **Your existing 23 records will NOT self-heal.** The sync upserts by event id behind a
   stored sync token (`packages/core/src/google/calendarSyncStore.ts`), and Google never
   resends an event that has not changed. Those records keep their rejected values until
   each event is edited in Google.
   **Remedy (one step, safe):** delete `<workspace>/data/calendar/.sync-state.json` — or
   just the one `tokens` entry for that calendar — and let the next scheduled run do a full
   walk. Writes are keyed by event id, so every existing record is **rewritten in place, not
   duplicated**. `clearCalendarSyncToken(calendarId, workspaceRoot)` is the programmatic
   equivalent; today it is only called on Google's 410 (expired token).
   **Proposal, deliberately not implemented here:** a one-shot token clear on upgrade would
   make this automatic, but a forced full walk over a calendar with years of history is a
   real cost (the first sync covers *all* dates — Google forbids a date window together with
   incremental sync). That should be an explicit choice, so I would rather add it as a
   follow-up if you want it.
2. **All-day events change how the day view draws them.** Before, an all-day value was
   date-only, so `recordSpan` found no clock and the record landed in the day view's all-day
   strip. `T00:00` gives it a clock, so it now renders as a 00:00→24:00 block. The month
   grid is unaffected. This follows from the decision to make all-day values parse as
   datetimes; flag it if you would rather the day view kept the strip.
3. **`toCollectionRecord` gained a required 4th parameter.** It is exported from
   `@mulmoclaude/core/google`, so this is technically a public-API change — but the only
   consumers are this repo's own sync path and its tests. Made required rather than
   defaulted on purpose: a silent default is exactly the failure mode that produced this bug.
4. **No `@mulmoclaude/core` version bump in this PR.** It touches `src` only — no
   `assets/helps/*` change, which is what CLAUDE.md ties the bump rule to — and the repo's
   convention is that `src` fixes ride the next `chore(release)` (cf. #2320, #2322). Say the
   word if you want 1.0.1 → 1.0.2 plus the consumer-range sweep in here instead.
5. **Out of scope, on purpose:** a timed event mapped onto a `date` (not `datetime`) field
   still stores the raw value and still lints. The decision was to key off the declared
   target type, and no recipe maps `start` onto `date`.

## User Prompt

> 2310~2312もみてね

## Implementation

Plan: `plans/fix-2310-gcal-datetime.md` (committed).

**Root cause, verified rather than assumed** — reproduced against the built package before
touching anything:

```
"2026-05-12T08:45:00+09:00" -> null
"2026-05-12T08:45:00Z"      -> null
"2026-03-18"                -> null
"2026-05-12T08:45:00-05:00" -> null
"2026-05-12T08:45:00"       -> ok
"2026-05-12T08:45"          -> ok
```

Three layers, each doing what it was written to do: `calendar.ts`'s `eventTime()` returns
Google's raw `dateTime` / `date`; `collectionSync.ts`'s `toCollectionRecord()` copies it in
with no normalisation; `recordZ.ts`'s `strictTypeProblem()` lints `datetime` with
`parseIsoDateTime` from `collection/core/calendarGrid.ts`.

**Tests** — `test/services/google/test_calendarDateTime.ts` (new): `+09:00`, a negative
offset, `Z`, compact `+0900`, no offset at all, date-only, seconds present vs absent,
fractional seconds, whitespace, empty string, non-string values, free text, and an
impossible day. `test/services/google/test_calendarCollectionSync.ts` (extended): a
`datetime` target is normalised, a `string` target is passed through byte-for-byte, an
undeclared field falls back to raw, an inherited spec is ignored, and an empty value stays
empty.

Every normalised output is asserted against the **real `parseIsoDateTime`** (imported, not
a guessed regex), so the tests pin the actual contract and go red if that parser's shape
ever moves.

**The tests were verified to be real** — three separate mutations, each rebuilt and re-run:

| mutation | result |
|---|---|
| `toCollectionDateTime` → `(value) => value` | **16 of 44 red** |
| normalise regardless of the field's declared type | the `string` pass-through case goes **red** |
| own-property lookup → plain `fields[field]` | the prototype-chain case goes **red** |

All restored afterwards; the final tree is green.

**Gates** (all run in a dedicated worktree with its own `node_modules`): `yarn format` ✅ ·
`yarn lint` ✅ 0 errors (40 pre-existing warnings, none in touched files) · `yarn typecheck`
✅ · `yarn build` ✅ · `yarn test` ✅ 6573 pass / 0 fail (+ `yarn workspaces run test` ✅).

Closes #2310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
