### PR TITLE
refactor(skills): dedup the catalog-source + external-args preamble in skills.ts

### DIFF
--- a/plans/refactor-2367-catalog-preamble.md
+++ b/plans/refactor-2367-catalog-preamble.md
@@ -1,0 +1,71 @@
+# refactor: dedup the catalog-source + external-args preamble in skills.ts
+
+Issue: #2367
+
+## Context
+
+`jscpd` flags a 56-token clone inside `server/api/routes/skills.ts`: the
+`catalogPreview` and `catalogStar` handlers open with the same
+"validate the catalog source, then validate the external arguments"
+preamble. Only four things differ — the input container (`req.query` vs
+`req.body`), the catalog op, the response formatter, and the word
+`preview` / `star` in one error message.
+
+`repoId` and `skillFolder` are path components: they are joined as
+`${repoId}/${skillFolder}` and handed to the external-repo readers. Two
+hand-written copies of that validation means a third external endpoint
+can ship with a looser one.
+
+## What this changes
+
+New `server/api/routes/skillCatalogTarget.ts` exporting
+`resolveCatalogTarget(input, action, res)`, which returns
+
+```
+{ kind: "external"; source: "external"; repoId; skillFolder }
+| { kind: "catalog";  source: "preset";   slug }
+| null   // a 400 has already been sent
+```
+
+Both handlers become `const target = resolveCatalogTarget(...); if (!target) return;`
+— the resolve-or-respond convention already used by
+`loadCollectionOr404` / `resolveCustomViewOr404` in `collections.ts`
+(#2144) and by `resolveSourceOrError` in the skills catalog (#2156).
+
+`action` is `"preview" | "star"` and only fills the one word that
+already differed between the two messages.
+
+## Constraints honoured
+
+- **No user-visible string changes.** All four messages are byte-identical
+  to what each handler sent before; only the `preview` / `star` word is
+  parameterised.
+- **`unknown` in, narrowed inside.** `req.query` values can be
+  `string | string[] | undefined` and `req.body` values are `unknown`;
+  the helper takes `unknown` fields and narrows, so neither call site is
+  loosened to match the other. An array `source` (`?source=a&source=b`)
+  still fails `isCatalogSource` exactly as before.
+- **Not `isNonEmptyString`.** `@mulmoclaude/common`'s guard trims, so
+  adopting it would newly reject a whitespace-only `repoId` — a live API
+  behaviour change. The local guard keeps the original
+  `typeof x === "string" && x.length > 0` semantics; the asymmetry is
+  pinned by a test.
+- Helper is 17 lines, cognitive complexity well under the 15 threshold.
+
+## Tests
+
+`test/api/routes/test_skillCatalogTarget.ts` (node:test + node:assert,
+mock `Response` recorder in the style of `test/utils/test_httpError.ts`):
+unknown / missing / array `source`; `external` with empty, non-string or
+missing `repoId` / `skillFolder`; a valid external pair; non-external with
+an empty or non-string `slug`; a valid non-external target; and that
+`preview` / `star` each produce their own wording. Status **and** exact
+message are asserted.
+
+Test integrity verified by reverting: dropping the `repoId.length === 0`
+half of the guard turns the empty-`repoId` cases red (helper returns an
+external target instead of a 400) and leaves the rest green.
+
+## Verification
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`.

--- a/server/api/routes/skillCatalogTarget.ts
+++ b/server/api/routes/skillCatalogTarget.ts
@@ -1,0 +1,58 @@
+// Which catalog entry does a `/api/skills/catalog*` request point at?
+// `catalogPreview` (query params) and `catalogStar` (JSON body) share the
+// same answer — a known `source`, plus either the external `repoId` +
+// `skillFolder` pair or a `slug`. `repoId` and `skillFolder` are joined into
+// a path (`${repoId}/${skillFolder}`), so a second hand-written copy of that
+// validation is how a future external endpoint ends up looser than these two.
+//
+// Resolve-or-respond convention, as in `loadCollectionOr404` (collections.ts):
+// the helper sends the 400 itself and returns null; callers write
+// `const target = resolveCatalogTarget(...); if (!target) return;`.
+
+import type { Response } from "express";
+import { isCatalogSource, type CatalogSource } from "../../workspace/skills/catalog.js";
+import { badRequest } from "../../utils/httpError.js";
+
+/** The word that goes into the external-argument error message, so `preview`
+ *  and `star` keep the exact wording each already sent. */
+export type CatalogAction = "preview" | "star";
+
+/** Raw request fields. Values are `unknown` because a query param can arrive
+ *  as `string[]` and a body field as anything at all. */
+export interface CatalogTargetInput {
+  source?: unknown;
+  slug?: unknown;
+  repoId?: unknown;
+  skillFolder?: unknown;
+}
+
+export type CatalogTarget =
+  | { kind: "external"; source: Extract<CatalogSource, "external">; repoId: string; skillFolder: string }
+  | { kind: "catalog"; source: Exclude<CatalogSource, "external">; slug: string };
+
+/** Deliberately NOT `isNonEmptyString` from `@mulmoclaude/common`: that guard
+ *  trims, which would start rejecting a whitespace-only `repoId` these
+ *  endpoints have always accepted. */
+function isPresentString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function resolveCatalogTarget(input: CatalogTargetInput, action: CatalogAction, res: Response): CatalogTarget | null {
+  const { source, slug, repoId, skillFolder } = input;
+  if (!isCatalogSource(source)) {
+    badRequest(res, "source must be a known catalog source");
+    return null;
+  }
+  if (source === "external") {
+    if (!isPresentString(repoId) || !isPresentString(skillFolder)) {
+      badRequest(res, `repoId and skillFolder are required for external ${action}`);
+      return null;
+    }
+    return { kind: "external", source, repoId, skillFolder };
+  }
+  if (!isPresentString(slug)) {
+    badRequest(res, "slug is required");
+    return null;
+  }
+  return { kind: "catalog", source, slug };
+}

--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -16,7 +16,6 @@ import { Router, Request, Response } from "express";
 import { deleteProjectSkill, discoverSkills, saveProjectSkill, updateProjectSkill } from "../../workspace/skills/index.js";
 import type { Skill, SkillSummary } from "../../workspace/skills/index.js";
 import {
-  isCatalogSource,
   listCatalogEntries,
   readCatalogEntryDetail,
   readExternalDetailAsCatalog,
@@ -27,6 +26,7 @@ import {
   type CatalogDetailResult,
   type StarResult,
 } from "../../workspace/skills/catalog.js";
+import { resolveCatalogTarget } from "./skillCatalogTarget.js";
 import { installExternalRepo, listInstalledRepos, uninstallExternalRepo, type InstalledRepo } from "../../workspace/skills/external/install.js";
 import { EXTERNAL_PRESETS, type ExternalPresetSuggestion } from "../../workspace/skills/external/presets.js";
 import { workspacePath } from "../../workspace/workspace.js";
@@ -140,26 +140,15 @@ bindRoute(
   router,
   API_ROUTES.skills.catalogPreview,
   async (req: Request<object, unknown, unknown, CatalogPreviewQuery>, res: Response<CatalogPreviewResponse | ErrorResponse>) => {
-    const { source, slug, repoId, skillFolder } = req.query;
-    if (!isCatalogSource(source)) {
-      badRequest(res, "source must be a known catalog source");
+    const target = resolveCatalogTarget(req.query, "preview", res);
+    if (!target) return;
+    if (target.kind === "external") {
+      const result = await readExternalDetailAsCatalog(target.repoId, target.skillFolder);
+      previewResponse(result, target.source, `${target.repoId}/${target.skillFolder}`, res);
       return;
     }
-    if (source === "external") {
-      if (typeof repoId !== "string" || repoId.length === 0 || typeof skillFolder !== "string" || skillFolder.length === 0) {
-        badRequest(res, "repoId and skillFolder are required for external preview");
-        return;
-      }
-      const result = await readExternalDetailAsCatalog(repoId, skillFolder);
-      previewResponse(result, source, `${repoId}/${skillFolder}`, res);
-      return;
-    }
-    if (typeof slug !== "string" || slug.length === 0) {
-      badRequest(res, "slug is required");
-      return;
-    }
-    const result = await readCatalogEntryDetail(source, slug);
-    previewResponse(result, source, slug, res);
+    const result = await readCatalogEntryDetail(target.source, target.slug);
+    previewResponse(result, target.source, target.slug, res);
   },
 );
 
@@ -191,26 +180,15 @@ interface ExternalStarBody {
 }
 
 bindRoute(router, API_ROUTES.skills.catalogStar, async (req: Request<object, unknown, ExternalStarBody>, res: Response<StarResponse | ErrorResponse>) => {
-  const { source, slug, repoId, skillFolder } = req.body;
-  if (!isCatalogSource(source)) {
-    badRequest(res, "source must be a known catalog source");
+  const target = resolveCatalogTarget(req.body, "star", res);
+  if (!target) return;
+  if (target.kind === "external") {
+    const result = await starExternalAsCatalog(target.repoId, target.skillFolder);
+    starResponse(result, target.source, `${target.repoId}/${target.skillFolder}`, res);
     return;
   }
-  if (source === "external") {
-    if (typeof repoId !== "string" || repoId.length === 0 || typeof skillFolder !== "string" || skillFolder.length === 0) {
-      badRequest(res, "repoId and skillFolder are required for external star");
-      return;
-    }
-    const result = await starExternalAsCatalog(repoId, skillFolder);
-    starResponse(result, source, `${repoId}/${skillFolder}`, res);
-    return;
-  }
-  if (typeof slug !== "string" || slug.length === 0) {
-    badRequest(res, "slug is required");
-    return;
-  }
-  const result = await starCatalogEntry(source, slug);
-  starResponse(result, source, slug, res);
+  const result = await starCatalogEntry(target.source, target.slug);
+  starResponse(result, target.source, target.slug, res);
 });
 
 // External-repo lifecycle endpoints (#1383 / #1335 PR-C). They live

--- a/test/api/routes/test_skillCatalogTarget.ts
+++ b/test/api/routes/test_skillCatalogTarget.ts
@@ -1,0 +1,188 @@
+// `resolveCatalogTarget` is the shared preamble of the catalog preview and
+// star endpoints (#2367). The messages it sends are API response bodies, so
+// every case below pins the exact status AND wording — a "clearer" rewrite of
+// one of these strings is a breaking change, not a cleanup.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveCatalogTarget } from "../../../server/api/routes/skillCatalogTarget.js";
+
+// Minimal stand-in for the Express `Response` shape the helper touches
+// (status + json), recording what it received — same pattern as
+// test/utils/test_httpError.ts.
+interface RecordedResponse {
+  status: number | null;
+  body: unknown;
+  jsonCalled: boolean;
+}
+interface MockResponse {
+  status: (code: number) => MockResponse;
+  json: (body: unknown) => MockResponse;
+  _recorded: RecordedResponse;
+}
+function mockRes(): MockResponse {
+  const recorded: RecordedResponse = { status: null, body: null, jsonCalled: false };
+  const res: MockResponse = {
+    _recorded: recorded,
+    status(code) {
+      recorded.status = code;
+      return this;
+    },
+    json(body) {
+      recorded.body = body;
+      recorded.jsonCalled = true;
+      return this;
+    },
+  };
+  return res;
+}
+
+// Cast once at the test boundary so the production signature stays clean.
+function asExpressRes(mock: MockResponse): Parameters<typeof resolveCatalogTarget>[2] {
+  return mock as unknown as Parameters<typeof resolveCatalogTarget>[2];
+}
+
+function assertRejected(res: MockResponse, message: string): void {
+  assert.equal(res._recorded.status, 400);
+  assert.deepEqual(res._recorded.body, { error: message });
+}
+
+const UNKNOWN_SOURCE = "source must be a known catalog source";
+const MISSING_SLUG = "slug is required";
+const missingExternalArgs = (action: string) => `repoId and skillFolder are required for external ${action}`;
+
+describe("resolveCatalogTarget — source validation", () => {
+  it("rejects an unknown source", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "anthropic", slug: "mc-foo" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, UNKNOWN_SOURCE);
+  });
+
+  it("rejects a missing source", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ slug: "mc-foo" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, UNKNOWN_SOURCE);
+  });
+
+  it("rejects a repeated query param, which arrives as an array", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: ["preset", "external"], slug: "mc-foo" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, UNKNOWN_SOURCE);
+  });
+
+  it("rejects an empty-string source", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "" }, "star", asExpressRes(res)), null);
+    assertRejected(res, UNKNOWN_SOURCE);
+  });
+
+  it("rejects a non-string source", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: 123 }, "star", asExpressRes(res)), null);
+    assertRejected(res, UNKNOWN_SOURCE);
+  });
+});
+
+describe("resolveCatalogTarget — external arguments", () => {
+  it("rejects an empty repoId", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external", repoId: "", skillFolder: "pptx" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("preview"));
+  });
+
+  it("rejects a non-string repoId", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external", repoId: 42, skillFolder: "pptx" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("preview"));
+  });
+
+  it("rejects an array repoId, which is what a repeated query param gives", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external", repoId: ["a", "b"], skillFolder: "pptx" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("preview"));
+  });
+
+  it("rejects an empty skillFolder", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external", repoId: "anthropics-skills", skillFolder: "" }, "star", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("star"));
+  });
+
+  it("rejects a non-string skillFolder", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external", repoId: "anthropics-skills", skillFolder: null }, "star", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("star"));
+  });
+
+  it("rejects both arguments missing", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("preview"));
+  });
+
+  it("ignores a slug when the source is external", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "external", slug: "mc-foo" }, "star", asExpressRes(res)), null);
+    assertRejected(res, missingExternalArgs("star"));
+  });
+
+  it("resolves a valid external pair without responding", () => {
+    const res = mockRes();
+    const target = resolveCatalogTarget({ source: "external", repoId: "anthropics-skills", skillFolder: "pptx" }, "preview", asExpressRes(res));
+    assert.deepEqual(target, { kind: "external", source: "external", repoId: "anthropics-skills", skillFolder: "pptx" });
+    assert.equal(res._recorded.jsonCalled, false);
+  });
+
+  it("keeps a whitespace-only repoId — the guard is length-based, not trim-based, and these endpoints have always accepted it", () => {
+    const res = mockRes();
+    const target = resolveCatalogTarget({ source: "external", repoId: " ", skillFolder: " " }, "preview", asExpressRes(res));
+    assert.deepEqual(target, { kind: "external", source: "external", repoId: " ", skillFolder: " " });
+    assert.equal(res._recorded.jsonCalled, false);
+  });
+});
+
+describe("resolveCatalogTarget — non-external slug", () => {
+  it("rejects an empty slug", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "preset", slug: "" }, "preview", asExpressRes(res)), null);
+    assertRejected(res, MISSING_SLUG);
+  });
+
+  it("rejects a missing slug", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "preset" }, "star", asExpressRes(res)), null);
+    assertRejected(res, MISSING_SLUG);
+  });
+
+  it("rejects a non-string slug", () => {
+    const res = mockRes();
+    assert.equal(resolveCatalogTarget({ source: "preset", slug: ["mc-foo"] }, "star", asExpressRes(res)), null);
+    assertRejected(res, MISSING_SLUG);
+  });
+
+  it("resolves a valid preset target without responding", () => {
+    const res = mockRes();
+    const target = resolveCatalogTarget({ source: "preset", slug: "mc-foo" }, "star", asExpressRes(res));
+    assert.deepEqual(target, { kind: "catalog", source: "preset", slug: "mc-foo" });
+    assert.equal(res._recorded.jsonCalled, false);
+  });
+
+  it("ignores external arguments when the source is not external", () => {
+    const res = mockRes();
+    const target = resolveCatalogTarget({ source: "preset", slug: "mc-foo", repoId: "", skillFolder: "" }, "preview", asExpressRes(res));
+    assert.deepEqual(target, { kind: "catalog", source: "preset", slug: "mc-foo" });
+    assert.equal(res._recorded.jsonCalled, false);
+  });
+});
+
+describe("resolveCatalogTarget — action wording", () => {
+  it("says preview for the preview endpoint and star for the star endpoint", () => {
+    const previewRes = mockRes();
+    resolveCatalogTarget({ source: "external" }, "preview", asExpressRes(previewRes));
+    assertRejected(previewRes, "repoId and skillFolder are required for external preview");
+
+    const starRes = mockRes();
+    resolveCatalogTarget({ source: "external" }, "star", asExpressRes(starRes));
+    assertRejected(starRes, "repoId and skillFolder are required for external star");
+  });
+});


### PR DESCRIPTION
## Summary

`server/api/routes/skills.ts` repeated the same preamble in `catalogPreview`
and `catalogStar`: reject a non-`isCatalogSource` `source`, then — for
`source === "external"` — require `repoId` and `skillFolder` to be non-empty
strings before calling the external op. jscpd flagged it as a 56-token clone
inside a single file.

This extracts `resolveCatalogTarget(input, action, res)` into a new
`server/api/routes/skillCatalogTarget.ts`. It returns

```
{ kind: "external"; source: "external"; repoId; skillFolder }
| { kind: "catalog";  source: "preset";   slug }
| null   // a 400 has already been sent
```

so both handlers become `const target = resolveCatalogTarget(...); if (!target) return;`
— the resolve-or-respond convention already used by `loadCollectionOr404` /
`resolveCustomViewOr404` in `collections.ts` (#2144) and by
`resolveSourceOrError` in the skills catalog (#2156).

jscpd clones in `skills.ts`: **1 → 0** (same `--min-tokens 50` base).

## Items to Confirm / Review

1. **Error strings are unchanged — please spot-check.** I diffed every
   `badRequest/notFound/conflict/forbidden` literal in `skills.ts` at
   `origin/main` against the union of `skills.ts` + `skillCatalogTarget.ts`
   after the change. The only diff is the intended collapse:

   ```
   - "repoId and skillFolder are required for external preview"
   - "repoId and skillFolder are required for external star"
   - "slug is required"                       (was twice)
   - "source must be a known catalog source"  (was twice)
   + `repoId and skillFolder are required for external ${action}`
   ```

   `action` is `"preview" | "star"`, passed by the respective handler, and a
   test pins both renderings.

2. **`isNonEmptyString` was deliberately NOT reused.** The shared guard in
   `@mulmoclaude/common` *trims*, so adopting it would newly 400 a
   whitespace-only `repoId` / `skillFolder` / `slug` that these endpoints have
   always accepted. I kept the original `typeof x === "string" && x.length > 0`
   semantics in a local `isPresentString`, with the reason in a comment and a
   test pinning the asymmetry. **If you would rather tighten to the trimming
   guard, say so — but it is an API behaviour change, not a refactor.**

3. **`source` typing.** The returned target carries `source` as
   `Extract<CatalogSource, "external">` / `Exclude<CatalogSource, "external">`
   rather than a hardcoded literal, so adding a third `CatalogSource` makes the
   `readCatalogEntryDetail(target.source, ...)` call fail to compile instead of
   silently routing a new source down the preset path.

4. **Container types stayed as-is.** The helper narrows the *values*
   (`unknown`), but still takes a typed container. A missing `req.body` would
   throw inside the helper exactly as it previously threw at the call site — I
   did not convert that into a 400, since that would be a behaviour change
   beyond the issue's scope.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> はい、並行でci / commentの確認と、しんきissueの対応をしてね

## Implementation

### New — `server/api/routes/skillCatalogTarget.ts`

`resolveCatalogTarget(input, action, res)`, 17 lines, cognitive complexity
well under the `sonarjs` threshold of 15. `CatalogTargetInput` declares all
four fields as `unknown` because a query param can arrive as `string[]`
(`?source=preset&source=external`) while a body field can be anything — so
neither call site had to be loosened to match the other. The array case still
fails `isCatalogSource` / the string guards exactly as before.

### Changed — `server/api/routes/skills.ts`

Both handlers lose the preamble; `isCatalogSource` is no longer imported here.
`previewResponse` / `starResponse` and the ops they wrap are untouched.

### Tests — `test/api/routes/test_skillCatalogTarget.ts` (20 cases)

node:test + node:assert, with the mock-`Response` recorder pattern from
`test/utils/test_httpError.ts`. Every case asserts the exact status **and**
message:

- `source`: unknown, missing, empty string, non-string, and an array (the
  repeated-query-param case)
- `external`: empty `repoId`, non-string `repoId`, array `repoId`, empty
  `skillFolder`, non-string `skillFolder`, both missing, a `slug` supplied
  instead of the pair, a valid pair, and the whitespace-only pair that pins
  the no-trim semantics
- non-external: empty `slug`, missing `slug`, non-string `slug`, a valid
  target, and external args ignored when `source` is not external
- `preview` / `star` each produce their own wording

### Test integrity verified by reverting

Dropped the `repoId.length === 0` half of the guard
(`typeof repoId !== "string" || !isPresentString(skillFolder)`) and re-ran:
**1 failure — "rejects an empty repoId" — with the other 19 still green**, then
restored the guard and confirmed 20/20. The tests fail when the code they cover
is broken.

### Gates (run in the worktree, not via the pre-commit hook)

| Gate | Result |
| --- | --- |
| `yarn format` | exit 0 (no reformat outside the touched files) |
| `yarn lint` | exit 0 — 40 pre-existing warnings, 0 errors, **none in the new/changed files** |
| `yarn typecheck` | exit 0 |
| `yarn build` | exit 0 |
| `yarn test` | exit 0 — 6575 tests, 0 fail (includes the 20 new cases) |

Closes #2367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deduplicate and centralize the catalog source and external argument validation shared by the skills catalog preview and star endpoints, and add focused tests for the new helper.

Enhancements:
- Introduce a shared resolveCatalogTarget helper to validate catalog source, external repo arguments, and slug for skills catalog endpoints.
- Simplify skills catalogPreview and catalogStar handlers to consume the resolved catalog target instead of inlining validation logic.

Documentation:
- Add a planning note documenting the refactor to share catalog preamble logic between skills endpoints.

Tests:
- Add unit tests for resolveCatalogTarget covering source validation, external argument handling, slug validation, and error message wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for catalog preview and star requests.
  * Added clearer error responses when catalog sources or required target details are missing or invalid.
  * Preserved existing behavior for valid internal and external catalog targets.

* **Tests**
  * Added coverage for valid targets, invalid inputs, repeated parameters, and action-specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->