### PR TITLE
refactor(mulmo-script): fold the duplicated beat-op handler skeleton

### DIFF
--- a/plans/refactor-2368-beat-ops.md
+++ b/plans/refactor-2368-beat-ops.md
@@ -1,0 +1,89 @@
+# refactor(mulmo-script): fold the duplicated beat-op handler skeleton
+
+Issue: #2368
+
+## Problem
+
+`server/api/routes/mulmo-script.ts` had two handlers — `generateBeatAudio` and
+`renderBeat` — that repeated the same eight lines:
+
+```ts
+const { filePath, beatIndex, force, chatSessionId } = req.body;
+if (typeof filePath !== "string" || !filePath || !validBeatIndex(beatIndex)) {
+  badRequest(res, "filePath and beatIndex are required");
+  return;
+}
+const result = await mulmoScriptOps.<op>({ filePath, beatIndex, force, chatSessionId });
+if (!result.ok) {
+  sendOpFailure(res, result);
+  return;
+}
+res.json({ <audio|image>: result.<audio|image> });
+```
+
+Only the op and the success key differ. `validBeatIndex` guards an array
+index, so every copy of this skeleton is a place the guard can be dropped
+when the next beat endpoint (caption, subtitle, …) is written.
+
+## Approach
+
+1. **Pin `validBeatIndex` first.** Its accept/reject matrix (0, `-0`, negative,
+   non-integer, `NaN`, infinities, numeric strings, `undefined`/`null`, other
+   types, no upper bound) goes into tests BEFORE the guard moves, so a
+   widened or narrowed condition fails loudly.
+2. Extract `server/api/routes/mulmoScriptBeatOp.ts` holding
+   `validBeatIndex`, `sendOpFailure` + its status table, `ErrorResponse`, and
+   the new `makeBeatOpHandler` factory. A separate module keeps the guard
+   testable without importing `server/plugins/mulmoscript-server.ts` (which
+   boots the whole plugin runtime).
+3. `makeBeatOpHandler(op, toResponse)` returns the Express handler.
+   `op` is generic over its success result; `toResponse` names the one
+   response key. No `any`, no `as`, validation and failure mapping shared.
+4. Each endpoint becomes a `bindRoute(router, route, makeBeatOpHandler(op, map))`
+   declaration.
+
+The error string `"filePath and beatIndex are required"` is unchanged.
+
+## Which handlers fold, which don't
+
+Folded (identical shape — body-carried `{ filePath, beatIndex, force, chatSessionId }`,
+object-arg op, single-key 200):
+
+- `generateBeatAudio` → `generateBeatAudioOp`, key `audio`
+- `renderBeat` → `renderBeatOp`, key `image`
+
+Left alone, with reasons:
+
+- `beatImage` / `beatAudio` / `beatMovie` — **GET, query-string input.** They
+  read `req.query`, must turn a string into a number before the index check,
+  and call positional ops `(filePath, beatIndex)`. Their validation is
+  already shared through `parseBeatQuery`, which is the part that carries the
+  index-guard risk; the remaining four lines are not the same shape as the
+  POST bodies and folding them would mean a second parse mode inside the
+  factory.
+- `uploadBeatImage` — POST and beat-scoped, but requires a third field
+  (`imageData`), responds with a **different** error message
+  (`"filePath, beatIndex, and imageData are required"`), and calls a
+  positional op. Bending it into the shared shape would either change its
+  wire error text or add a variadic-field escape hatch to the factory.
+- `renderCharacter` / `uploadCharacterImage` / `characterImage` — keyed by
+  `key`, not `beatIndex`; no array index involved.
+
+## Tests
+
+`test/server/api/test_mulmoScriptBeatOp.ts` (node:test), with an injected
+fake op — no real generation:
+
+- `validBeatIndex` full matrix, including the deliberate absence of an upper
+  bound (the beat count is only known after the op loads the script).
+- `sendOpFailure` status table (400 / 404 / 503 / 500).
+- Handler validation: empty / missing / non-string `filePath`, missing /
+  negative / non-integer / numeric-string / `NaN` / boolean `beatIndex`,
+  empty body — each a 400 with the unchanged message and **no op call**.
+- `beatIndex: 0` accepted (regression guard against a falsy check).
+- Op failure routes through `sendOpFailure` for every code.
+- Each endpoint's own success key (`audio` vs `image`), `force` /
+  `chatSessionId` forwarded.
+
+Mutation check: deleting the `!filePath` emptiness clause must turn the
+empty-string test red.

--- a/plans/refactor-2368-beat-ops.md
+++ b/plans/refactor-2368-beat-ops.md
@@ -36,8 +36,8 @@ when the next beat endpoint (caption, subtitle, …) is written.
    the new `makeBeatOpHandler` factory. A separate module keeps the guard
    testable without importing `server/plugins/mulmoscript-server.ts` (which
    boots the whole plugin runtime).
-3. `makeBeatOpHandler(op, toResponse)` returns the Express handler.
-   `op` is generic over its success result; `toResponse` names the one
+3. `makeBeatOpHandler(runOp, toResponse)` returns the Express handler.
+   `runOp` is generic over its success result; `toResponse` names the one
    response key. No `any`, no `as`, validation and failure mapping shared.
 4. Each endpoint becomes a `bindRoute(router, route, makeBeatOpHandler(op, map))`
    declaration.

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -7,14 +7,15 @@ import {
   type SaveMulmoScriptArgs,
 } from "@mulmoclaude/mulmoscript-plugin";
 import { makeArtifactsFileOps } from "../../plugins/runtime.js";
-import { buildContext, type OpFailure } from "@mulmoclaude/mulmoscript-plugin/server";
+import { buildContext } from "@mulmoclaude/mulmoscript-plugin/server";
 import { mulmoScriptOps } from "../../plugins/mulmoscript-server.js";
 import { errorMessage } from "../../utils/errors.js";
-import { badRequest, notFound, sendError } from "../../utils/httpError.js";
+import { badRequest, notFound } from "../../utils/httpError.js";
 import { getOptionalStringQuery, getSessionQuery } from "../../utils/request.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { bindRoute } from "../../utils/router.js";
 import { GENERATION_KINDS } from "../../../src/types/events.js";
+import { makeBeatOpHandler, sendOpFailure, validBeatIndex, type ErrorResponse } from "./mulmoScriptBeatOp.js";
 
 // Express adapters over the shared ops instance from
 // `server/plugins/mulmoscript-server.ts`. Every op body lives in
@@ -27,17 +28,6 @@ import { GENERATION_KINDS } from "../../../src/types/events.js";
 
 const router = Router();
 
-const OP_FAILURE_STATUS: Record<OpFailure["code"], number> = {
-  bad_request: 400,
-  not_found: 404,
-  unavailable: 503,
-  server_error: 500,
-};
-
-function sendOpFailure(res: Response, failure: OpFailure): void {
-  sendError(res, OP_FAILURE_STATUS[failure.code], failure.error);
-}
-
 // Shared SSE preamble for the two streaming routes; returns the
 // line-writer bound to this response.
 function beginSse(res: Response): (data: unknown) => void {
@@ -47,21 +37,10 @@ function beginSse(res: Response): (data: unknown) => void {
   return (data: unknown) => res.write(`data: ${JSON.stringify(data)}\n\n`);
 }
 
-interface RenderBeatBody {
-  filePath: string;
-  beatIndex: number;
-  force?: boolean;
-  chatSessionId?: string;
-}
-
 interface UploadBeatImageBody {
   filePath: string;
   beatIndex: number;
   imageData: string; // base64 data URI
-}
-
-interface ErrorResponse {
-  error: string;
 }
 
 type BeatImageResponse = { image: string | null } | ErrorResponse;
@@ -69,7 +48,6 @@ type BeatAudioResponse = { audio: string | null } | ErrorResponse;
 type BeatMovieResponse = { moviePath: string | null } | ErrorResponse;
 type MovieStatusResponse = { moviePath: string | null } | ErrorResponse;
 type PdfStatusResponse = { pdfPath: string | null } | ErrorResponse;
-type GenerateBeatAudioResponse = { audio: string } | ErrorResponse;
 
 interface BeatQuery {
   filePath?: string;
@@ -85,14 +63,10 @@ interface FilePathQuery {
 // guards below reject non-string / non-index values before they can reach
 // any path or beat-indexed logic (CodeQL
 // js/type-confusion-through-parameter-tampering + Codex review on #2133).
+// `validBeatIndex` is shared with the beat POST handlers — see
+// `./mulmoScriptBeatOp.ts`.
 function stringQuery(value: unknown): string | null {
   return typeof value === "string" && value !== "" ? value : null;
-}
-
-// Beat indexes must be non-negative integers — `-1` / `1.5` must fail as a
-// deterministic 400 instead of indexing undefined beats downstream.
-function validBeatIndex(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 function parseBeatQuery<TRes>(req: Request<object, TRes, object, BeatQuery>, res: Response): { filePath: string; beatIndex: number } | null {
@@ -238,44 +212,19 @@ bindRoute(router, API_ROUTES.mulmoScript.beatMovie, async (req: Request<object, 
   res.json({ moviePath: result.moviePath });
 });
 
-interface GenerateBeatAudioBody {
-  filePath: string;
-  beatIndex: number;
-  force?: boolean;
-  chatSessionId?: string;
-}
-
+// Beat generation endpoints: same validation, same failure mapping — only
+// the op and the success key differ, so they declare just those two.
 bindRoute(
   router,
   API_ROUTES.mulmoScript.generateBeatAudio,
-  async (req: Request<object, object, GenerateBeatAudioBody>, res: Response<GenerateBeatAudioResponse>) => {
-    const { filePath, beatIndex, force, chatSessionId } = req.body;
-    if (typeof filePath !== "string" || !filePath || !validBeatIndex(beatIndex)) {
-      badRequest(res, "filePath and beatIndex are required");
-      return;
-    }
-    const result = await mulmoScriptOps.generateBeatAudioOp({ filePath, beatIndex, force, chatSessionId });
-    if (!result.ok) {
-      sendOpFailure(res, result);
-      return;
-    }
-    res.json({ audio: result.audio });
-  },
+  makeBeatOpHandler(mulmoScriptOps.generateBeatAudioOp, (result) => ({ audio: result.audio })),
 );
 
-bindRoute(router, API_ROUTES.mulmoScript.renderBeat, async (req: Request<object, object, RenderBeatBody>, res: Response) => {
-  const { filePath, beatIndex, force, chatSessionId } = req.body;
-  if (typeof filePath !== "string" || !filePath || !validBeatIndex(beatIndex)) {
-    badRequest(res, "filePath and beatIndex are required");
-    return;
-  }
-  const result = await mulmoScriptOps.renderBeatOp({ filePath, beatIndex, force, chatSessionId });
-  if (!result.ok) {
-    sendOpFailure(res, result);
-    return;
-  }
-  res.json({ image: result.image });
-});
+bindRoute(
+  router,
+  API_ROUTES.mulmoScript.renderBeat,
+  makeBeatOpHandler(mulmoScriptOps.renderBeatOp, (result) => ({ image: result.image })),
+);
 
 interface GenerationRequestBody {
   filePath: string;

--- a/server/api/routes/mulmoScriptBeatOp.ts
+++ b/server/api/routes/mulmoScriptBeatOp.ts
@@ -59,13 +59,13 @@ export interface BeatOpBody {
 export type BeatOpHandler<TBody> = (req: Request<object, unknown, BeatOpBody>, res: Response<TBody | ErrorResponse>) => Promise<void>;
 
 /**
- * Build the handler for one beat endpoint. `op` is the only thing that
+ * Build the handler for one beat endpoint. `runOp` is the only thing that
  * generates, and `toResponse` is the only thing that names the success key
  * (`audio`, `image`, …) — validation, failure mapping, and the 200 shape
  * are shared.
  */
 export function makeBeatOpHandler<TResult extends { ok: true }, TBody extends object>(
-  op: (args: BeatOpArgs) => Promise<TResult | OpFailure>,
+  runOp: (args: BeatOpArgs) => Promise<TResult | OpFailure>,
   toResponse: (result: TResult) => TBody,
 ): BeatOpHandler<TBody> {
   return async (req, res) => {
@@ -74,7 +74,7 @@ export function makeBeatOpHandler<TResult extends { ok: true }, TBody extends ob
       badRequest(res, "filePath and beatIndex are required");
       return;
     }
-    const result = await op({ filePath, beatIndex, force, chatSessionId });
+    const result = await runOp({ filePath, beatIndex, force, chatSessionId });
     if (!result.ok) {
       sendOpFailure(res, result);
       return;

--- a/server/api/routes/mulmoScriptBeatOp.ts
+++ b/server/api/routes/mulmoScriptBeatOp.ts
@@ -1,0 +1,84 @@
+// Shared plumbing for the beat-scoped mulmoScript REST endpoints.
+//
+// Extracted from `mulmo-script.ts` (#2368): the beat POST handlers all
+// repeated the same skeleton — validate `{ filePath, beatIndex }`, run one
+// op, map a failure onto its HTTP status, respond with a single key. That
+// skeleton carries the array-index guard, so every copy was a place the
+// guard could be forgotten when the next beat endpoint (caption, subtitle,
+// …) is added.
+//
+// Living in its own module also keeps the guard + factory testable without
+// booting the plugin runtime that `mulmo-script.ts` imports.
+
+import type { Request, Response } from "express";
+import type { OpFailure } from "@mulmoclaude/mulmoscript-plugin/server";
+import { badRequest, sendError } from "../../utils/httpError.js";
+
+export interface ErrorResponse {
+  error: string;
+}
+
+const OP_FAILURE_STATUS: Record<OpFailure["code"], number> = {
+  bad_request: 400,
+  not_found: 404,
+  unavailable: 503,
+  server_error: 500,
+};
+
+export function sendOpFailure(res: Response, failure: OpFailure): void {
+  sendError(res, OP_FAILURE_STATUS[failure.code], failure.error);
+}
+
+// Beat indexes must be non-negative integers — `-1` / `1.5` must fail as a
+// deterministic 400 instead of indexing undefined beats downstream. The
+// upper bound is deliberately NOT checked here: the beat count is only
+// known once the op has loaded the script, so an in-range-but-too-large
+// index is the op's `not_found`, not this guard's 400.
+export function validBeatIndex(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/** Arguments every beat op takes — the validated pair plus the two
+ *  optional passthroughs the generation ops use. */
+export interface BeatOpArgs {
+  filePath: string;
+  beatIndex: number;
+  force?: boolean;
+  chatSessionId?: string;
+}
+
+/** Untrusted request body: `filePath` / `beatIndex` are whatever JSON the
+ *  client sent, so they stay `unknown` until the guards run. */
+export interface BeatOpBody {
+  filePath?: unknown;
+  beatIndex?: unknown;
+  force?: boolean;
+  chatSessionId?: string;
+}
+
+export type BeatOpHandler<TBody> = (req: Request<object, unknown, BeatOpBody>, res: Response<TBody | ErrorResponse>) => Promise<void>;
+
+/**
+ * Build the handler for one beat endpoint. `op` is the only thing that
+ * generates, and `toResponse` is the only thing that names the success key
+ * (`audio`, `image`, …) — validation, failure mapping, and the 200 shape
+ * are shared.
+ */
+export function makeBeatOpHandler<TResult extends { ok: true }, TBody extends object>(
+  op: (args: BeatOpArgs) => Promise<TResult | OpFailure>,
+  toResponse: (result: TResult) => TBody,
+): BeatOpHandler<TBody> {
+  return async (req, res) => {
+    const { filePath, beatIndex, force, chatSessionId } = req.body;
+    if (typeof filePath !== "string" || !filePath || !validBeatIndex(beatIndex)) {
+      badRequest(res, "filePath and beatIndex are required");
+      return;
+    }
+    const result = await op({ filePath, beatIndex, force, chatSessionId });
+    if (!result.ok) {
+      sendOpFailure(res, result);
+      return;
+    }
+    res.json(toResponse(result));
+  };
+}

--- a/test/server/api/test_mulmoScriptBeatOp.ts
+++ b/test/server/api/test_mulmoScriptBeatOp.ts
@@ -1,0 +1,261 @@
+// Pins the beat-endpoint guard + dispatch skeleton shared by the
+// mulmoScript beat POST routes (#2368).
+//
+// `validBeatIndex` guards an ARRAY INDEX, so the matrix below is the
+// contract, not documentation: widening it (accepting "1", 1.5, -1) lets a
+// hostile body reach beat-indexed logic; narrowing it (rejecting 0) breaks
+// the first beat of every script.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Request, Response } from "express";
+
+import { makeBeatOpHandler, sendOpFailure, validBeatIndex, type BeatOpArgs, type BeatOpBody } from "../../../server/api/routes/mulmoScriptBeatOp.ts";
+
+// Derived from the helper's own signature so the test can build failures
+// without importing the plugin package.
+type OpFailure = Parameters<typeof sendOpFailure>[1];
+
+const FAILURE_STATUSES: Array<[OpFailure["code"], number]> = [
+  ["bad_request", 400],
+  ["not_found", 404],
+  ["unavailable", 503],
+  ["server_error", 500],
+];
+
+interface Recorded {
+  status: number;
+  body: unknown;
+  jsonCalled: boolean;
+}
+
+interface MockResponse {
+  status: (code: number) => MockResponse;
+  json: (body: unknown) => MockResponse;
+  recorded: Recorded;
+}
+
+function mockRes(): MockResponse {
+  const recorded: Recorded = { status: 200, body: undefined, jsonCalled: false };
+  return {
+    recorded,
+    status(code) {
+      recorded.status = code;
+      return this;
+    },
+    json(body) {
+      recorded.body = body;
+      recorded.jsonCalled = true;
+      return this;
+    },
+  };
+}
+
+// Cast once at each test boundary (same pattern as test/utils/test_httpError.ts)
+// so the production signatures keep Express's types; the handler only ever
+// touches `req.body`, `res.status`, and `res.json`.
+function asExpressRes(mock: MockResponse): Response {
+  return mock as unknown as Response;
+}
+
+function asExpressReq(body: unknown): Request<object, unknown, BeatOpBody> {
+  return { body } as unknown as Request<object, unknown, BeatOpBody>;
+}
+
+/** Fake op: records the args it was handed and returns a canned outcome. */
+function fakeOp<TResult extends { ok: true }>(outcome: TResult | OpFailure) {
+  const calls: BeatOpArgs[] = [];
+  return {
+    calls,
+    op: async (args: BeatOpArgs): Promise<TResult | OpFailure> => {
+      calls.push(args);
+      return outcome;
+    },
+  };
+}
+
+const audioSuccess = { ok: true, audio: "data:audio/mpeg;base64,AAA" } as const;
+const imageSuccess = { ok: true, image: "data:image/png;base64,BBB" } as const;
+
+const VALID_BODY = { filePath: "stories/a.json", beatIndex: 0 };
+const REQUIRED_MESSAGE = "filePath and beatIndex are required";
+
+describe("validBeatIndex", () => {
+  it("accepts zero — the first beat must not be rejected as falsy", () => {
+    assert.equal(validBeatIndex(0), true);
+  });
+
+  it("accepts positive integers", () => {
+    for (const value of [1, 2, 42, 1000]) {
+      assert.equal(validBeatIndex(value), true, `${value} should be accepted`);
+    }
+  });
+
+  it("accepts -0 (Number.isInteger(-0) is true and -0 >= 0)", () => {
+    assert.equal(validBeatIndex(-0), true);
+  });
+
+  it("has NO upper bound — the beat count is the op's business, not the guard's", () => {
+    assert.equal(validBeatIndex(1_000_000), true);
+    assert.equal(validBeatIndex(Number.MAX_SAFE_INTEGER), true);
+  });
+
+  it("rejects negative integers", () => {
+    for (const value of [-1, -2, -42, Number.MIN_SAFE_INTEGER]) {
+      assert.equal(validBeatIndex(value), false, `${value} should be rejected`);
+    }
+  });
+
+  it("rejects non-integers", () => {
+    for (const value of [1.5, 0.1, -0.5, Number.EPSILON, 2.000001]) {
+      assert.equal(validBeatIndex(value), false, `${value} should be rejected`);
+    }
+  });
+
+  it("rejects NaN and both infinities", () => {
+    assert.equal(validBeatIndex(Number.NaN), false);
+    assert.equal(validBeatIndex(Number.POSITIVE_INFINITY), false);
+    assert.equal(validBeatIndex(Number.NEGATIVE_INFINITY), false);
+  });
+
+  it('rejects numeric strings — a JSON body may send "0" and it must not index', () => {
+    for (const value of ["0", "1", "42", "1.5", "-1", ""]) {
+      assert.equal(validBeatIndex(value), false, `${JSON.stringify(value)} should be rejected`);
+    }
+  });
+
+  it("rejects undefined and null", () => {
+    assert.equal(validBeatIndex(undefined), false);
+    assert.equal(validBeatIndex(null), false);
+  });
+
+  it("rejects other types that coerce to a number", () => {
+    for (const value of [true, false, [], [0], {}, 0n, new Date(0)]) {
+      assert.equal(validBeatIndex(value), false, `${String(value)} should be rejected`);
+    }
+  });
+});
+
+describe("sendOpFailure", () => {
+  for (const [code, status] of FAILURE_STATUSES) {
+    it(`maps ${code} onto ${status}`, () => {
+      const res = mockRes();
+      sendOpFailure(asExpressRes(res), { ok: false, code, error: `${code} happened` });
+      assert.equal(res.recorded.status, status);
+      assert.deepEqual(res.recorded.body, { error: `${code} happened` });
+    });
+  }
+});
+
+describe("makeBeatOpHandler — request validation", () => {
+  async function runWith(body: unknown) {
+    const { op, calls } = fakeOp(audioSuccess);
+    const handler = makeBeatOpHandler(op, (result) => ({ audio: result.audio }));
+    const res = mockRes();
+    await handler(asExpressReq(body), asExpressRes(res));
+    return { res, calls };
+  }
+
+  it("rejects an empty filePath without calling the op", async () => {
+    const { res, calls } = await runWith({ filePath: "", beatIndex: 0 });
+    assert.equal(res.recorded.status, 400);
+    assert.deepEqual(res.recorded.body, { error: REQUIRED_MESSAGE });
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects a missing filePath", async () => {
+    const { res, calls } = await runWith({ beatIndex: 0 });
+    assert.equal(res.recorded.status, 400);
+    assert.deepEqual(res.recorded.body, { error: REQUIRED_MESSAGE });
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects non-string filePath values (parameter tampering)", async () => {
+    for (const filePath of [123, null, ["stories/a.json"], { path: "a" }, true]) {
+      const { res, calls } = await runWith({ filePath, beatIndex: 0 });
+      assert.equal(res.recorded.status, 400, `${JSON.stringify(filePath)} should be rejected`);
+      assert.deepEqual(res.recorded.body, { error: REQUIRED_MESSAGE });
+      assert.equal(calls.length, 0);
+    }
+  });
+
+  it("rejects a missing beatIndex", async () => {
+    const { res, calls } = await runWith({ filePath: "stories/a.json" });
+    assert.equal(res.recorded.status, 400);
+    assert.deepEqual(res.recorded.body, { error: REQUIRED_MESSAGE });
+    assert.equal(calls.length, 0);
+  });
+
+  it("rejects out-of-domain beatIndex values", async () => {
+    for (const beatIndex of [-1, 1.5, "0", null, Number.NaN, true]) {
+      const { res, calls } = await runWith({ filePath: "stories/a.json", beatIndex });
+      assert.equal(res.recorded.status, 400, `${JSON.stringify(beatIndex)} should be rejected`);
+      assert.deepEqual(res.recorded.body, { error: REQUIRED_MESSAGE });
+      assert.equal(calls.length, 0);
+    }
+  });
+
+  it("rejects an empty body", async () => {
+    const { res, calls } = await runWith({});
+    assert.equal(res.recorded.status, 400);
+    assert.deepEqual(res.recorded.body, { error: REQUIRED_MESSAGE });
+    assert.equal(calls.length, 0);
+  });
+
+  it("accepts beatIndex 0 and forwards the validated pair to the op", async () => {
+    const { res, calls } = await runWith(VALID_BODY);
+    assert.equal(res.recorded.status, 200);
+    assert.deepEqual(calls, [{ filePath: "stories/a.json", beatIndex: 0, force: undefined, chatSessionId: undefined }]);
+  });
+});
+
+describe("makeBeatOpHandler — op failures", () => {
+  it("routes a failing op through sendOpFailure instead of a 200", async () => {
+    const failure: OpFailure = { ok: false, code: "not_found", error: "script not found" };
+    const { op } = fakeOp<typeof audioSuccess>(failure);
+    const handler = makeBeatOpHandler(op, (result) => ({ audio: result.audio }));
+    const res = mockRes();
+    await handler(asExpressReq(VALID_BODY), asExpressRes(res));
+    assert.equal(res.recorded.status, 404);
+    assert.deepEqual(res.recorded.body, { error: "script not found" });
+  });
+
+  for (const [code, status] of FAILURE_STATUSES) {
+    it(`answers ${status} when the op fails with ${code}`, async () => {
+      const { op } = fakeOp<typeof imageSuccess>({ ok: false, code, error: "nope" });
+      const handler = makeBeatOpHandler(op, (result) => ({ image: result.image }));
+      const res = mockRes();
+      await handler(asExpressReq(VALID_BODY), asExpressRes(res));
+      assert.equal(res.recorded.status, status);
+      assert.deepEqual(res.recorded.body, { error: "nope" });
+    });
+  }
+});
+
+describe("makeBeatOpHandler — success responses", () => {
+  it("returns the audio key for the audio op", async () => {
+    const { op } = fakeOp(audioSuccess);
+    const handler = makeBeatOpHandler(op, (result) => ({ audio: result.audio }));
+    const res = mockRes();
+    await handler(asExpressReq(VALID_BODY), asExpressRes(res));
+    assert.equal(res.recorded.jsonCalled, true);
+    assert.equal(res.recorded.status, 200);
+    // deepEqual is strict: an extra key (e.g. a leaked `ok`) fails here.
+    assert.deepEqual(res.recorded.body, { audio: audioSuccess.audio });
+  });
+
+  it("returns the image key for the render op", async () => {
+    const { op } = fakeOp(imageSuccess);
+    const handler = makeBeatOpHandler(op, (result) => ({ image: result.image }));
+    const res = mockRes();
+    await handler(asExpressReq(VALID_BODY), asExpressRes(res));
+    assert.deepEqual(res.recorded.body, { image: imageSuccess.image });
+  });
+
+  it("forwards force and chatSessionId to the op", async () => {
+    const { op, calls } = fakeOp(imageSuccess);
+    const handler = makeBeatOpHandler(op, (result) => ({ image: result.image }));
+    await handler(asExpressReq({ ...VALID_BODY, beatIndex: 3, force: true, chatSessionId: "sess-1" }), asExpressRes(mockRes()));
+    assert.deepEqual(calls, [{ filePath: "stories/a.json", beatIndex: 3, force: true, chatSessionId: "sess-1" }]);
+  });
+});

--- a/test/server/api/test_mulmoScriptBeatOp.ts
+++ b/test/server/api/test_mulmoScriptBeatOp.ts
@@ -16,7 +16,7 @@ import { makeBeatOpHandler, sendOpFailure, validBeatIndex, type BeatOpArgs, type
 // without importing the plugin package.
 type OpFailure = Parameters<typeof sendOpFailure>[1];
 
-const FAILURE_STATUSES: Array<[OpFailure["code"], number]> = [
+const FAILURE_STATUSES: [OpFailure["code"], number][] = [
   ["bad_request", 400],
   ["not_found", 404],
   ["unavailable", 503],


### PR DESCRIPTION
## Summary

`generateBeatAudio` and `renderBeat` in `server/api/routes/mulmo-script.ts` repeated the same validate / dispatch / respond skeleton, differing only in which op they call and which key carries the result. That skeleton carries `validBeatIndex` — an **array-index** guard — so every copy was a place the guard could be silently dropped when the next beat endpoint (caption, subtitle, …) is written.

- New `server/api/routes/mulmoScriptBeatOp.ts` holds `validBeatIndex`, `sendOpFailure` + its status table, `ErrorResponse`, and a `makeBeatOpHandler(runOp, toResponse)` factory. Its own module so the guard is testable **without** booting the plugin runtime that `mulmo-script.ts` imports.
- Each folded endpoint is now one `bindRoute(...)` declaration naming only its op and its success key.
- The wire error string `"filePath and beatIndex are required"` is unchanged, and so is the 400 / 404 / 503 / 500 mapping.
- 29 new node:test cases pin the guard's accept/reject matrix, the failure routing, and each endpoint's response key.

Net: `mulmo-script.ts` −64 / +13 in the beat area; behaviour identical.

## Items to Confirm / Review

**1. Handlers folded — please confirm these two really are the same shape.**

| Endpoint | Op | Success key |
| --- | --- | --- |
| `generateBeatAudio` | `mulmoScriptOps.generateBeatAudioOp` | `audio` |
| `renderBeat` | `mulmoScriptOps.renderBeatOp` | `image` |

Both take the body `{ filePath, beatIndex, force, chatSessionId }`, call an **object-arg** op, and respond with one key.

**2. Handlers deliberately NOT folded — please confirm you agree with each reason.** (I surveyed every beat-shaped handler in the file rather than only the two the issue named.)

| Endpoint | Why it stays as-is |
| --- | --- |
| `beatImage`, `beatAudio`, `beatMovie` | **GET with query-string input.** They read `req.query`, must `Number()` a string before the index check, and call **positional** ops `(filePath, beatIndex)`. Their validation is already shared through `parseBeatQuery` — which is the part that carries the index-guard risk — so the duplication that remains is a 4-line tail, not the guard. Folding them would mean a second parse mode inside the factory. |
| `uploadBeatImage` | POST and beat-scoped, but requires a third field (`imageData`), returns a **different** wire error (`"filePath, beatIndex, and imageData are required"`), and calls a positional op. Bending it in would either change that error text or add a variadic-field escape hatch. |
| `renderCharacter`, `uploadCharacterImage`, `characterImage` | Keyed by `key`, not `beatIndex` — no array index, different guard. |

**3. `validBeatIndex` behaviour is unchanged but now pinned.** The implementation is byte-identical (moved, not rewritten). What it actually accepts:

- accepts `0` (the first beat — must not be rejected as falsy), positive integers, `-0`, and arbitrarily large integers
- rejects negatives, non-integers (`1.5`, `Number.EPSILON`), `NaN`, `±Infinity`, numeric **strings** (`"0"`, `"1"`), `undefined`, `null`, booleans, arrays, plain objects, `BigInt`, `Date`
- **no upper bound** — deliberate: the beat count is only known once the op has loaded the script, so a too-large index is the op's `not_found`, not this guard's 400. This is now an explicit test with the reason in a comment, so nobody "fixes" it later.

**4. Tests verified to be real (mutation check).** With the fix reverted, the tests go red:

- Removing the `!filePath` emptiness clause → **28 pass / 1 fail**, exactly `rejects an empty filePath without calling the op`. Restored, back to 29/29.
- Bonus: removing `value >= 0` from `validBeatIndex` → **27 pass / 2 fail**. So the index guard is load-bearing too.

**5. Two `as unknown as` casts live in the test file only** (`asExpressReq` / `asExpressRes`), matching the existing pattern and comment in `test/utils/test_httpError.ts`. Production code has no `any` and no casts.

**6. No `docs/shared-utils.md` entry** — that catalog is explicitly scoped to cross-cutting helpers, and states "one route's validator stays inside that route". This is one route file's factory.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning package以外で重複コードで整理できるのない？
>
> 対応必要なものは１つ１つissueにして直していこう
>
> はい、並行でci / commentの確認と、しんきissueの対応をしてね

## Implementation

Plan: [`plans/refactor-2368-beat-ops.md`](plans/refactor-2368-beat-ops.md) (committed with the change).

**Order of work** — the issue's own warning was that widening or narrowing the index check is the dangerous outcome, so the guard was pinned by tests *before* it moved.

**`server/api/routes/mulmoScriptBeatOp.ts`** (new):

```ts
export function makeBeatOpHandler<TResult extends { ok: true }, TBody extends object>(
  runOp: (args: BeatOpArgs) => Promise<TResult | OpFailure>,
  toResponse: (result: TResult) => TBody,
): BeatOpHandler<TBody> {
  return async (req, res) => {
    const { filePath, beatIndex, force, chatSessionId } = req.body;
    if (typeof filePath !== "string" || !filePath || !validBeatIndex(beatIndex)) {
      badRequest(res, "filePath and beatIndex are required");
      return;
    }
    const result = await runOp({ filePath, beatIndex, force, chatSessionId });
    if (!result.ok) {
      sendOpFailure(res, result);
      return;
    }
    res.json(toResponse(result));
  };
}
```

Key decisions:

- **Explicit generics, no casts.** `TResult extends { ok: true }` lets TS infer the op's success branch out of `TResult | OpFailure` and narrow on `result.ok`; `TBody` types the response body so the success key stays explicit at the call site rather than being a stringly-typed `Record`.
- **Returns a handler instead of registering the route.** `bindRoute` stays at the call site, so the factory can be unit-tested with a fake `req` / `res` and an injected fake op — no express app, no plugin runtime, no real generation.
- **The success key is named by a `toResponse` mapper**, not a computed key — `{ [key]: result[key] }` on a generic key does not type-check without a cast.
- `sendOpFailure` + `OP_FAILURE_STATUS` and `ErrorResponse` moved into the same module (the factory needs them; duplicating them would have been worse). `mulmo-script.ts` imports them back — no behaviour change.
- Parameter named `runOp`, not `op`: the repo's `id-length` rule requires ≥ 3 chars.

**Call sites** in `mulmo-script.ts`:

```ts
bindRoute(router, API_ROUTES.mulmoScript.generateBeatAudio, makeBeatOpHandler(mulmoScriptOps.generateBeatAudioOp, (result) => ({ audio: result.audio })));
bindRoute(router, API_ROUTES.mulmoScript.renderBeat, makeBeatOpHandler(mulmoScriptOps.renderBeatOp, (result) => ({ image: result.image })));
```

**Tests** — `test/server/api/test_mulmoScriptBeatOp.ts`, 29 cases, node:test + node:assert, injected fake op that records its args:

- `validBeatIndex` matrix (see item 3 above) — happy path, boundary (`0`, `-0`, `MAX_SAFE_INTEGER`), negative, non-integer, `NaN`/infinities, numeric strings, empty string, `undefined`/`null`, wrong types.
- `sendOpFailure` status table: `bad_request`→400, `not_found`→404, `unavailable`→503, `server_error`→500.
- Handler validation: empty / missing / non-string `filePath` (number, `null`, array, object, boolean); missing / negative / non-integer / numeric-string / `NaN` / boolean `beatIndex`; empty body. Each asserts the 400, the unchanged message, **and that the op was never called**.
- `beatIndex: 0` accepted and forwarded — regression guard against a falsy check.
- Op failure routes to `sendOpFailure` for every code instead of a 200.
- Success returns each endpoint's own key (`audio` vs `image`); `deepStrictEqual` also proves no extra key (e.g. a leaked `ok`) reaches the wire; `force` / `chatSessionId` forwarded.

**Gates** (run in the worktree, not by a hook): `yarn format` clean · `yarn lint` exit 0 · `yarn typecheck` exit 0 · `yarn build` exit 0 · `yarn test` exit 0.

Closes #2368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract shared beat POST handler logic into a reusable route helper while preserving existing behavior.

Enhancements:
- Introduce a mulmoScriptBeatOp helper module encapsulating beat index validation, op failure handling, and a generic beat-op handler factory used by multiple routes.

Documentation:
- Document the refactor and handler-folding decisions in a new planning markdown file for issue #2368.

Tests:
- Add comprehensive tests for the beat-op helper covering beat index validation, failure-to-status mapping, request validation, and success response shapes.