### PR TITLE
fix(spreadsheet): expand $, lowercase and single-cell range references

### DIFF
--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -7,6 +7,7 @@
 import { formatNumber } from "./formatter";
 import { columnToIndex } from "./parser";
 import { evaluateFormula as evaluateFormulaFn } from "./evaluator";
+import { expandRangeOrCell } from "./formulaRefs";
 import { parseDate, getDefaultDateFormat } from "./date-parser";
 import type { SheetData, CellValue, CalculatedSheet, CalculationError, FormulaInfo, SpreadsheetCell } from "./types";
 import { isObj } from "../../../utils/types";
@@ -316,29 +317,22 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[]): Calcu
       }
     }
 
-    const match = rangeRef.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-    if (!match) return [];
-
-    const startCol = columnToIndex(match[1]);
-    const startRow = parseInt(match[2]) - 1;
-    const endCol = columnToIndex(match[3]);
-    const endRow = parseInt(match[4]) - 1;
+    const coords = expandRangeOrCell(rangeRef);
+    if (!coords) return [];
 
     const values: CellValue[] = [];
-    for (let row = startRow; row <= endRow; row++) {
-      for (let col = startCol; col <= endCol; col++) {
-        if (row >= 0 && row < sheetData.length && col >= 0 && col < sheetData[row].length) {
-          const cell = sheetData[row][col];
-          // Pass row/col only if current sheet (for recursive evaluation)
-          const rawValue = getRawValue(cell, isCurrentSheet ? row : undefined, isCurrentSheet ? col : undefined);
+    for (const { row, col } of coords) {
+      if (row >= 0 && row < sheetData.length && col >= 0 && col < sheetData[row].length) {
+        const cell = sheetData[row][col];
+        // Pass row/col only if current sheet (for recursive evaluation)
+        const rawValue = getRawValue(cell, isCurrentSheet ? row : undefined, isCurrentSheet ? col : undefined);
 
-          if (options.numericOnly) {
-            if (!isNaN(rawValue as number)) {
-              values.push(rawValue);
-            }
-          } else {
+        if (options.numericOnly) {
+          if (!isNaN(rawValue as number)) {
             values.push(rawValue);
           }
+        } else {
+          values.push(rawValue);
         }
       }
     }

--- a/src/plugins/spreadsheet/engine/formulaRefs.ts
+++ b/src/plugins/spreadsheet/engine/formulaRefs.ts
@@ -57,6 +57,22 @@ export function expandRange(rangeStr: string): CellCoord[] {
   return cells;
 }
 
+// Expand a range OR a single cell into coordinates, upcasing first so
+// lowercase references (`a1:b2`, which spreadsheets accept) are not dropped,
+// and falling back to a single cell when there is no colon. `collectRangeValues`
+// in the calculator used a range-only, case-sensitive regex, so `A1`,
+// `$A$1:$A$10` and `a1:a10` all silently produced no values (#2356). Ordering
+// matches `expandRange`: top-to-bottom, left-to-right.
+export function expandRangeOrCell(ref: string): CellCoord[] | null {
+  const upper = ref.trim().toUpperCase();
+  if (upper.includes(":")) {
+    const cells = expandRange(upper);
+    return cells.length > 0 ? cells : null;
+  }
+  const single = parseSingleCellRef(upper);
+  return single ? [single] : null;
+}
+
 // Parse a single cell ref (`A1`, `$A$1`, `AA100`) into a coord.
 // Returns null for malformed input rather than throwing — keeps the
 // caller's loop flat (the engine-layer `parseCellRef` throws, which

--- a/test/plugins/spreadsheet/engine/test_expandRangeOrCell.ts
+++ b/test/plugins/spreadsheet/engine/test_expandRangeOrCell.ts
@@ -1,0 +1,83 @@
+// Turning a range or single-cell reference into coordinates. The calculator's
+// old inline regex was range-only and case-sensitive and did not strip `$`, so
+// three common reference shapes fell through to "no values" — and a function
+// over an empty list is 0, not an error (#2356).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { expandRangeOrCell } from "../../../../src/plugins/spreadsheet/engine/formulaRefs.ts";
+
+describe("expandRangeOrCell — ranges", () => {
+  it("expands a simple range top-to-bottom, left-to-right", () => {
+    assert.deepEqual(expandRangeOrCell("A1:B2"), [
+      { row: 0, col: 0 },
+      { row: 0, col: 1 },
+      { row: 1, col: 0 },
+      { row: 1, col: 1 },
+    ]);
+  });
+
+  it("expands a single-column range", () => {
+    assert.deepEqual(expandRangeOrCell("A1:A3"), [
+      { row: 0, col: 0 },
+      { row: 1, col: 0 },
+      { row: 2, col: 0 },
+    ]);
+  });
+
+  // The fill-down form. The old regex left the `$` in and matched nothing.
+  it("strips absolute-reference dollar signs", () => {
+    assert.deepEqual(expandRangeOrCell("$A$1:$A$3"), expandRangeOrCell("A1:A3"));
+    assert.deepEqual(expandRangeOrCell("$A1:A$3"), expandRangeOrCell("A1:A3"));
+  });
+
+  // Spreadsheets accept lowercase and upcase it; the old regex was `[A-Z]`
+  // only, so a lowercase range silently produced nothing.
+  it("upcases lowercase references", () => {
+    assert.deepEqual(expandRangeOrCell("a1:b2"), expandRangeOrCell("A1:B2"));
+    assert.deepEqual(expandRangeOrCell("$a$1:$a$3"), expandRangeOrCell("A1:A3"));
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    assert.deepEqual(expandRangeOrCell("  A1:A2  "), expandRangeOrCell("A1:A2"));
+  });
+
+  it("crosses the Z→AA column boundary", () => {
+    assert.deepEqual(expandRangeOrCell("Z1:AA1"), [
+      { row: 0, col: 25 },
+      { row: 0, col: 26 },
+    ]);
+  });
+});
+
+describe("expandRangeOrCell — single cells", () => {
+  // The case Excel sums as one value and the old regex refused for lack of a
+  // colon.
+  it("expands a bare cell to one coordinate", () => {
+    assert.deepEqual(expandRangeOrCell("A1"), [{ row: 0, col: 0 }]);
+    assert.deepEqual(expandRangeOrCell("B3"), [{ row: 2, col: 1 }]);
+  });
+
+  it("strips dollar signs and upcases a single cell", () => {
+    assert.deepEqual(expandRangeOrCell("$A$1"), [{ row: 0, col: 0 }]);
+    assert.deepEqual(expandRangeOrCell("a1"), [{ row: 0, col: 0 }]);
+  });
+
+  it("reads a multi-letter column", () => {
+    assert.deepEqual(expandRangeOrCell("AA10"), [{ row: 9, col: 26 }]);
+  });
+});
+
+describe("expandRangeOrCell — non-references", () => {
+  // Null rather than an empty array: the caller distinguishes "not a reference"
+  // from "a valid but empty range", and returning [] for garbage would hide
+  // typos as zero-value sums.
+  it("returns null for text that is not a reference", () => {
+    assert.equal(expandRangeOrCell("hello"), null);
+    assert.equal(expandRangeOrCell(""), null);
+    assert.equal(expandRangeOrCell("A"), null);
+    assert.equal(expandRangeOrCell("1"), null);
+    assert.equal(expandRangeOrCell("A1:B"), null);
+    assert.equal(expandRangeOrCell("A1:"), null);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_rangeFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_rangeFunctions.ts
@@ -1,0 +1,44 @@
+// Range-consuming functions through the whole engine. `expandRangeOrCell` is
+// unit-tested on its own; this drives the shapes that used to return 0 with no
+// error — the failure that is invisible because 0 is a plausible answer (#2356).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+/** A single column of numbers with `formula` beside the first cell. */
+const column = (values: number[], formula: string): SheetData => ({
+  name: "S",
+  data: values.map((value, index) => (index === 0 ? [{ v: value }, { v: formula }] : [{ v: value }])),
+});
+
+const result = (values: number[], formula: string): unknown => new SpreadsheetEngine().calculate(column(values, formula)).data[0][1];
+
+describe("range references that used to return 0", () => {
+  it("sums an absolute range", () => {
+    assert.equal(result([10, 20, 30], "=SUM($A$1:$A$3)"), 60);
+  });
+
+  it("sums a lowercase range", () => {
+    assert.equal(result([10, 20, 30], "=sum(a1:a3)"), 60);
+  });
+
+  it("sums a single-cell argument", () => {
+    assert.equal(result([42], "=SUM(A1)"), 42);
+  });
+
+  // MAX/MIN took a different path already, so they worked where SUM did not.
+  // The two must agree now that both go through the same expansion.
+  it("makes SUM and MAX agree on a single cell", () => {
+    assert.equal(result([42], "=SUM(A1)"), result([42], "=MAX(A1)"));
+  });
+});
+
+describe("range functions over an absolute range", () => {
+  it("averages, counts and finds extremes", () => {
+    assert.equal(result([10, 20, 30], "=AVERAGE($A$1:$A$3)"), 20);
+    assert.equal(result([10, 20, 30], "=COUNT($A$1:$A$3)"), 3);
+    assert.equal(result([10, 20, 30], "=MAX($A$1:$A$3)"), 30);
+    assert.equal(result([10, 20, 30], "=MIN($A$1:$A$3)"), 10);
+  });
+});


### PR DESCRIPTION
## Summary

**`=SUM($A$1:$A$10)` が 0 を返していました**。`=sum(a1:a3)` も `=SUM(A1)` も同じです。

`collectRangeValues` が範囲を `/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/` で照合し、不一致なら `[]` を返していました。この正規表現は**範囲専用・大文字のみ・`$` 除去なし**なので、ユーザーが実際に書く 3 つの形を弾きます:

- `$A$1:$A$10` — 下方向フィルの標準形
- `a1:a3` — 表計算は小文字を受け付けて大文字化する
- `A1` — 単一セル引数（Excel は 1 値として合計）

**空リストに対する関数は 0（エラーではない）**なので、いずれも**もっともらしいゼロ**が返っていました。`MAX`/`MIN` は別経路で正しく動くため、`=SUM(A1)` が 0 なのに `=MAX(A1)` は正しい、という非対称が残っていました。

## 修正

参照を `expandRangeOrCell` に通します。既存の `expandRange`（`$` 除去済み）の隣に追加した純粋関数で、**大文字化し、コロンが無ければ単一セルにフォールバックし、本当に参照でないものには `[]` ではなく `null` を返します**（タイプミスが空範囲と区別できるように）。

calculator 側のインライン範囲正規表現＋展開ループも、この 1 呼び出しに置き換えました。**範囲走査ロジックの 2 個目のコピーが消えます。**

## Items to Confirm / Review

1. **`null` vs `[]`**: 本当に参照でないもの（タイプミス）に `[]` を返すと、ゼロ値の合計として隠れてしまうので `null` にしています。

2. **変異検証**:
   | 変異 | 赤 |
   |---|---|
   | 大文字化を外す | 3 |
   | 単一セルのフォールバックを外す | 5 |

3. `expandRangeOrCell` は `formulaRefs.ts` の `expandRange` / `parseSingleCellRef` を再利用しています（`$` 除去はそちらが担当）。

## User Prompt

> もっともっとpure関数とテスト化を。

範囲展開を純粋関数として切り出し、単体10件 + 統合5件でカバーしました。

## Test plan

- `test_expandRangeOrCell.ts` 10 件 + `test_rangeFunctions.ts` 5 件
- `yarn test` — 8063 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

Fixes #2356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle spreadsheet range and cell references more robustly so range functions work with absolute, lowercase, and single-cell references, and add tests to cover these cases.

New Features:
- Support single-cell references and lowercase/absolute ranges for range-consuming spreadsheet functions via a shared expansion helper.

Bug Fixes:
- Fix SUM and other range functions returning 0 for valid references like $A$1:$A$10, sum(a1:a3), and SUM(A1) by correctly expanding these references into coordinates.

Enhancements:
- Introduce a reusable expandRangeOrCell helper to centralize range and cell reference expansion and distinguish invalid references from empty ranges.
- Simplify the calculator range value collection logic by delegating coordinate generation to the shared reference expansion helper.

Tests:
- Add unit tests for expandRangeOrCell covering ranges, single cells, and invalid inputs.
- Add integration tests for range functions to verify correct behavior for absolute, lowercase, and single-cell references and alignment between SUM and MAX.