### PR TITLE
test(files): stop the open/reveal tests from launching Finder on macOS CI

### DIFF
--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -36,9 +36,34 @@ import { spawn } from "node:child_process";
 // but we CAN distinguish "spawn succeeded" from "command not found /
 // permission denied" (e.g. `xdg-open` missing on a headless Linux
 // host). Client-side error handling depends on this signal.
-function spawnDetachedOsCommand(command: string, args: readonly string[], label: string): Promise<boolean> {
+/** The argv for opening a path in the host file manager, per platform. Pure,
+ *  so the per-OS choice can be tested without spawning anything — running the
+ *  real command in a test opens Finder on macOS and Explorer on Windows. */
+export function openArgv(absPath: string, platform: typeof process.platform): { command: string; args: string[] } {
+  if (platform === "darwin") return { command: "open", args: [absPath] };
+  if (platform === "win32") return { command: "explorer.exe", args: [absPath] };
+  return { command: "xdg-open", args: [absPath] };
+}
+
+/** The argv for revealing a path (folder opened, file selected). macOS `open -R`
+ *  and Windows `explorer /select,` select the file; Linux `xdg-open <dir>` only
+ *  opens the folder — there is no portable "select this item" across Linux file
+ *  managers, and landing next to the file is enough for drag-and-drop (#1985).
+ *  Same argv-array (no shell) discipline as `openArgv`, so a filename with shell
+ *  metacharacters can never be reinterpreted as command syntax. */
+export function revealArgv(absPath: string, platform: typeof process.platform): { command: string; args: string[] } {
+  if (platform === "darwin") return { command: "open", args: ["-R", absPath] };
+  if (platform === "win32") return { command: "explorer.exe", args: [`/select,${absPath}`] };
+  return { command: "xdg-open", args: [path.dirname(absPath)] };
+}
+
+/** Injectable so a test can assert the argv without launching the real file
+ *  manager. Defaults to Node's `spawn`. */
+export type Spawner = typeof spawn;
+
+function spawnDetachedOsCommand(command: string, args: readonly string[], label: string, spawner: Spawner): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    const child = spawner(command, args as string[], { detached: true, stdio: "ignore" });
     let settled = false;
     child.once("error", (err) => {
       if (settled) return;
@@ -55,30 +80,14 @@ function spawnDetachedOsCommand(command: string, args: readonly string[], label:
   });
 }
 
-export function openInHostOs(absPath: string): Promise<boolean> {
-  const { platform } = process;
-  const [command, args] =
-    platform === "darwin" ? (["open", [absPath]] as const) : platform === "win32" ? (["explorer.exe", [absPath]] as const) : (["xdg-open", [absPath]] as const);
-  return spawnDetachedOsCommand(command, args, "open");
+export function openInHostOs(absPath: string, spawner: Spawner = spawn): Promise<boolean> {
+  const { command, args } = openArgv(absPath, process.platform);
+  return spawnDetachedOsCommand(command, args, "open", spawner);
 }
 
-// Reveal the file in the host file manager. macOS `open -R` and
-// Windows `explorer /select,` open the containing folder with the
-// file selected; Linux `xdg-open <dir>` opens the folder only —
-// there's no portable "select this item" across the many Linux file
-// managers, and landing next to the file is enough for drag-and-drop
-// (#1985 follow-up). Same argv-array (no shell) discipline as
-// `openInHostOs` so a filename with shell metacharacters can never be
-// reinterpreted as command syntax.
-export function revealInHostOs(absPath: string): Promise<boolean> {
-  const { platform } = process;
-  const [command, args] =
-    platform === "darwin"
-      ? (["open", ["-R", absPath]] as const)
-      : platform === "win32"
-        ? (["explorer.exe", [`/select,${absPath}`]] as const)
-        : (["xdg-open", [path.dirname(absPath)]] as const);
-  return spawnDetachedOsCommand(command, args, "reveal");
+export function revealInHostOs(absPath: string, spawner: Spawner = spawn): Promise<boolean> {
+  const { command, args } = revealArgv(absPath, process.platform);
+  return spawnDetachedOsCommand(command, args, "reveal", spawner);
 }
 
 const router = Router();

--- a/test/routes/test_filesRoute_open.ts
+++ b/test/routes/test_filesRoute_open.ts
@@ -7,8 +7,10 @@
 // `process.platform` and `process.env.PATH` — Codex correctly
 // flagged that as unreliable under `tsx --test` parallelism, since
 // a concurrent test file could observe the mutated globals mid-run.
-// This version routes entirely through HTTP; the platform branch
-// is exercised implicitly by whichever host CI runs on.
+// This file covers only the path-validation contract over real HTTP.
+// The platform branch is NOT exercised here — running the real command
+// opens Finder on the macOS CI runner. The argv per platform and the
+// spawn handling are tested directly in test/routes/test_osOpen.ts.
 
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -27,7 +29,6 @@ const REL_TEST_DIR = "mc-test-open-in-os";
 
 describe("POST /api/files/open (#1985)", () => {
   let fixture: AppFixture;
-  let relPath: string;
   let apiOpenRoute: string;
 
   before(async () => {
@@ -41,7 +42,6 @@ describe("POST /api/files/open (#1985)", () => {
     mkdirSync(absDir, { recursive: true });
     const absFile = join(absDir, "sample.bin");
     writeFileSync(absFile, "not a real binary but has a body");
-    relPath = `${REL_TEST_DIR}/sample.bin`;
 
     const filesRoutesModule = await import("../../server/api/routes/files.js");
     const apiRoutesModule = await import("../../src/config/apiRoutes.js");
@@ -83,35 +83,5 @@ describe("POST /api/files/open (#1985)", () => {
       body: JSON.stringify({ path: "../../../etc/passwd" }),
     });
     assert.equal(res.status, 400);
-  });
-
-  it(
-    "accepts a valid workspace path (200 on darwin, 200/500 on linux depending on xdg-open)",
-    { skip: process.platform !== "darwin" && process.platform !== "linux" },
-    async () => {
-      // macOS `open <existing-file>` succeeds even for a binary payload.
-      // Linux `xdg-open` may or may not be installed on the runner —
-      // if missing, spawn fires an `error` event → route returns 500,
-      // which is a legitimate outcome for that env.
-      const res = await fetch(`${fixture.baseUrl}${apiOpenRoute}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ path: relPath }),
-      });
-      const body = (await res.json()) as { ok?: boolean; error?: string };
-      assert.ok(res.status === 200 || res.status === 500, `expected 200 or 500, got ${res.status}: ${JSON.stringify(body)}`);
-      if (res.status === 200) assert.equal(body.ok, true);
-      else assert.ok(typeof body.error === "string");
-    },
-  );
-
-  it("accepts a valid path via the query string as well as the body (belt+suspenders)", { skip: process.platform !== "darwin" }, async () => {
-    const url = `${fixture.baseUrl}${apiOpenRoute}?path=${encodeURIComponent(relPath)}`;
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({}), // deliberately empty; server should use the query
-    });
-    assert.equal(res.status, 200);
   });
 });

--- a/test/routes/test_filesRoute_reveal.ts
+++ b/test/routes/test_filesRoute_reveal.ts
@@ -1,11 +1,9 @@
 // HTTP-level test for `POST /api/files/reveal` (#1985 follow-up).
 //
-// Mirrors test_filesRoute_open.ts: mounts the real files router and
-// hits the endpoint over real HTTP so the platform branch of
-// `revealInHostOs` is exercised implicitly by whichever host runs CI.
-// The path-validation + response contract are shared with /open via
-// `handleOsFileAction`, so this file focuses on the reveal route
-// wiring rather than re-testing every validation branch.
+// Mirrors test_filesRoute_open.ts: the reveal route's path-validation
+// contract over real HTTP. The platform branch (which runs `open -R` and
+// opens Finder on macOS) is tested via an injected spawner in
+// test/routes/test_osOpen.ts, not by firing the real command here.
 
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -24,7 +22,6 @@ const REL_TEST_DIR = "mc-test-reveal-in-os";
 
 describe("POST /api/files/reveal (#1985)", () => {
   let fixture: AppFixture;
-  let relPath: string;
   let apiRevealRoute: string;
 
   before(async () => {
@@ -34,7 +31,6 @@ describe("POST /api/files/reveal (#1985)", () => {
     mkdirSync(absDir, { recursive: true });
     const absFile = join(absDir, "sample.bin");
     writeFileSync(absFile, "not a real binary but has a body");
-    relPath = `${REL_TEST_DIR}/sample.bin`;
 
     const filesRoutesModule = await import("../../server/api/routes/files.js");
     const apiRoutesModule = await import("../../src/config/apiRoutes.js");
@@ -76,35 +72,5 @@ describe("POST /api/files/reveal (#1985)", () => {
       body: JSON.stringify({ path: "../../../etc/passwd" }),
     });
     assert.equal(res.status, 400);
-  });
-
-  it(
-    "accepts a valid workspace path (200 on darwin, 200/500 on linux depending on xdg-open)",
-    { skip: process.platform !== "darwin" && process.platform !== "linux" },
-    async () => {
-      // macOS `open -R <existing-file>` succeeds. Linux `xdg-open <dir>`
-      // may or may not be installed on the runner — if missing, spawn
-      // fires an `error` event → route returns 500, a legitimate
-      // outcome for that env.
-      const res = await fetch(`${fixture.baseUrl}${apiRevealRoute}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ path: relPath }),
-      });
-      const body = (await res.json()) as { ok?: boolean; error?: string };
-      assert.ok(res.status === 200 || res.status === 500, `expected 200 or 500, got ${res.status}: ${JSON.stringify(body)}`);
-      if (res.status === 200) assert.equal(body.ok, true);
-      else assert.ok(typeof body.error === "string");
-    },
-  );
-
-  it("accepts a valid path via the query string as well as the body (belt+suspenders)", { skip: process.platform !== "darwin" }, async () => {
-    const url = `${fixture.baseUrl}${apiRevealRoute}?path=${encodeURIComponent(relPath)}`;
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({}),
-    });
-    assert.equal(res.status, 200);
   });
 });

--- a/test/routes/test_osOpen.ts
+++ b/test/routes/test_osOpen.ts
@@ -1,0 +1,102 @@
+// The per-platform argv for opening and revealing a file, plus the spawn
+// handling around it — WITHOUT launching anything. Running the real command in
+// a test opens Finder on macOS and Explorer on Windows, which is how the CI
+// runner ends up spawning file-manager windows. The argv choice is pure, and
+// the spawn wrapper takes an injectable spawner, so both are checked directly.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { openArgv, revealArgv, openInHostOs, revealInHostOs, type Spawner } from "../../server/api/routes/files.ts";
+
+const ABS = "/work/artifacts/report.html";
+
+describe("openArgv", () => {
+  it("uses `open` on macOS", () => {
+    assert.deepEqual(openArgv(ABS, "darwin"), { command: "open", args: [ABS] });
+  });
+
+  it("uses `explorer.exe` on Windows", () => {
+    assert.deepEqual(openArgv(ABS, "win32"), { command: "explorer.exe", args: [ABS] });
+  });
+
+  it("uses `xdg-open` on Linux and other platforms", () => {
+    assert.deepEqual(openArgv(ABS, "linux"), { command: "xdg-open", args: [ABS] });
+    assert.deepEqual(openArgv(ABS, "freebsd"), { command: "xdg-open", args: [ABS] });
+  });
+
+  // The whole point of an argv array over a shell string: a metacharacter in
+  // the path is one argument, never command syntax.
+  it("passes a metacharacter-bearing path as a single argument", () => {
+    const nasty = "/work/a; rm -rf ~/b.html";
+    assert.deepEqual(openArgv(nasty, "darwin").args, [nasty]);
+  });
+});
+
+describe("revealArgv", () => {
+  // macOS and Windows select the file inside its folder; the `-R` / `/select,`
+  // is the difference from a plain open.
+  it("selects the file on macOS with -R", () => {
+    assert.deepEqual(revealArgv(ABS, "darwin"), { command: "open", args: ["-R", ABS] });
+  });
+
+  it("selects the file on Windows with /select,", () => {
+    assert.deepEqual(revealArgv(ABS, "win32"), { command: "explorer.exe", args: [`/select,${ABS}`] });
+  });
+
+  // Linux has no portable "select this item", so it opens the CONTAINING
+  // folder — the argument is the dirname, not the file.
+  it("opens the containing folder on Linux", () => {
+    assert.deepEqual(revealArgv(ABS, "linux"), { command: "xdg-open", args: ["/work/artifacts"] });
+  });
+});
+
+/** A spawner that records its call and lets the test drive the child's events,
+ *  so nothing is actually launched. */
+function fakeSpawner() {
+  const calls: { command: string; args: readonly string[] }[] = [];
+  let child: EventEmitter & { unref?: () => void };
+  const spawner = ((command: string, args: readonly string[]) => {
+    calls.push({ command, args });
+    child = Object.assign(new EventEmitter(), { unref: () => {} });
+    return child as unknown as ChildProcess;
+  }) as unknown as Spawner;
+  return { spawner, calls, emitSpawn: () => child.emit("spawn"), emitError: (err: Error) => child.emit("error", err) };
+}
+
+describe("openInHostOs / revealInHostOs — spawn handling", () => {
+  it("spawns the open argv for the current platform and resolves true on spawn", async () => {
+    const fake = fakeSpawner();
+    const done = openInHostOs(ABS, fake.spawner);
+    fake.emitSpawn();
+    assert.equal(await done, true);
+    assert.deepEqual(fake.calls, [openArgv(ABS, process.platform)]);
+  });
+
+  it("spawns the reveal argv for the current platform", async () => {
+    const fake = fakeSpawner();
+    const done = revealInHostOs(ABS, fake.spawner);
+    fake.emitSpawn();
+    assert.equal(await done, true);
+    assert.deepEqual(fake.calls, [revealArgv(ABS, process.platform)]);
+  });
+
+  // A missing file manager (no `xdg-open` on a minimal Linux runner) fires an
+  // error event; the caller must see false, not a rejected promise.
+  it("resolves false when the spawn errors", async () => {
+    const fake = fakeSpawner();
+    const done = openInHostOs(ABS, fake.spawner);
+    fake.emitError(new Error("ENOENT"));
+    assert.equal(await done, false);
+  });
+
+  // Whichever event fires first wins; a later one must not flip the result.
+  it("ignores an error that arrives after a successful spawn", async () => {
+    const fake = fakeSpawner();
+    const done = openInHostOs(ABS, fake.spawner);
+    fake.emitSpawn();
+    fake.emitError(new Error("late"));
+    assert.equal(await done, true);
+  });
+});


### PR DESCRIPTION
## Summary

**macOS CI ランナーで、テストが実際に Finder を開いていました。**

`test_filesRoute_open.ts` / `test_filesRoute_reveal.ts` は有効なワークスペースパスで実ルートを HTTP で叩き、そのルートの仕事は**ホストのファイルマネージャを spawn すること**です。macOS では `open <file>` と `open -R <file>` が実行され、**テスト実行のたびに Finder ウィンドウが開きます**。`tsx --test` の並列実行でこれが積み重なり、ランナーの Finder が詰まります。

（ユーザー報告「CI でアーカイブの util が mac で動いて Finder が壊れる」の正体がこれでした。テストヘッダ自身が「exercised implicitly by whichever host runs CI」と、意図的にこうしていました。）

## 修正（spawn を DI）

プラットフォーム分岐を I/O から切り離し、**何も起動せずに**テストできるようにしました。

- **`openArgv` / `revealArgv`** — 純粋関数。OS ごとの argv を返す。darwin / win32 / linux を直接検証。`reveal` が `-R` / `/select,` でファイルを選択すること、Linux では**含むフォルダ**を対象にすることも固定
- **`openInHostOs` / `revealInHostOs`** — spawner を注入可能に（既定は Node の `spawn`）。フェイク spawner が argv を記録し、子プロセスのイベントを駆動するので、「spawn で true / error で false / 先に来たイベントが勝つ」処理を**無起動で**検証

2つのルートファイルは**パス検証の契約（400 系）のみ**残しました — ここは spawn しません。実コマンドを発火していた有効パスのケースは削除し、その意図（OS ごとの argv）は副作用なしのテストで置き換えました。

## Items to Confirm / Review

1. **`test_osOpen.ts` に 11 件新規。** 変異検証済み: reveal の `-R` を落とすと 1 件、open の darwin 分岐を壊すと 1 件が赤。

2. **CLAUDE.md の「DI で境界を越える」** に沿った形です。実 `spawn` をフェイクに差し替え、モジュールモックは使っていません。

## Test plan

- `test/routes/test_osOpen.ts` — 11 件
- `test_filesRoute_open` / `_reveal` — 各 2 件（バリデーションのみ、spawn なし）
- `yarn test` — 8210 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
