### PR TITLE
test(spreadsheet): cover parseFunctionArgs and normalizeData

### DIFF
--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -19,7 +19,7 @@ import { errorMessage } from "../../../utils/errors";
  * @param data - Potentially malformed sheet data
  * @returns Normalized 2D array
  */
-function normalizeData(data: any): SpreadsheetCell[][] {
+export function normalizeData(data: any): SpreadsheetCell[][] {
   // Handle null/undefined
   if (!data) {
     return [];

--- a/test/plugins/spreadsheet/engine/test_normalizeData.ts
+++ b/test/plugins/spreadsheet/engine/test_normalizeData.ts
@@ -1,0 +1,59 @@
+// Coercing whatever shape a model emitted into a 2D cell grid. It runs before
+// every calculation, and a wrong reshape silently maps every A1-style reference
+// onto a different cell — the sheet computes, just against the wrong layout.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeData } from "../../../../src/plugins/spreadsheet/engine/calculator.ts";
+
+describe("normalizeData — already valid", () => {
+  it("returns a 2D array unchanged", () => {
+    const grid = [[{ v: 1 }, { v: 2 }], [{ v: 3 }]];
+    assert.equal(normalizeData(grid), grid, "same reference, not a copy");
+  });
+
+  it("keeps an empty row structure", () => {
+    const grid = [[]];
+    assert.equal(normalizeData(grid), grid);
+  });
+});
+
+describe("normalizeData — nothing to normalise", () => {
+  it("returns empty for null, undefined and non-arrays", () => {
+    assert.deepEqual(normalizeData(null), []);
+    assert.deepEqual(normalizeData(undefined), []);
+    assert.deepEqual(normalizeData("A1"), []);
+    assert.deepEqual(normalizeData(42), []);
+    assert.deepEqual(normalizeData({ v: 1 }), []);
+  });
+
+  it("returns empty for an empty array", () => {
+    assert.deepEqual(normalizeData([]), []);
+  });
+
+  // A flat array of primitives is not a recognised shape — pairing them would
+  // invent structure, so it returns empty rather than guess.
+  it("returns empty for a flat array of primitives", () => {
+    assert.deepEqual(normalizeData([1, 2, 3]), []);
+    assert.deepEqual(normalizeData(["a", "b"]), []);
+  });
+});
+
+describe("normalizeData — flat cell array to 2D", () => {
+  // A model that emits a flat list of cell objects is reshaped into rows of two.
+  it("pairs a flat cell array into two-column rows", () => {
+    assert.deepEqual(normalizeData([{ v: 1 }, { v: 2 }, { v: 3 }, { v: 4 }]), [
+      [{ v: 1 }, { v: 2 }],
+      [{ v: 3 }, { v: 4 }],
+    ]);
+  });
+
+  // An odd length leaves a one-cell final row rather than dropping or padding.
+  it("leaves a lone final cell in its own row when the count is odd", () => {
+    assert.deepEqual(normalizeData([{ v: 1 }, { v: 2 }, { v: 3 }]), [[{ v: 1 }, { v: 2 }], [{ v: 3 }]]);
+  });
+
+  it("reshapes a single cell into one row", () => {
+    assert.deepEqual(normalizeData([{ v: 1 }]), [[{ v: 1 }]]);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_parseFunctionArgs.ts
+++ b/test/plugins/spreadsheet/engine/test_parseFunctionArgs.ts
@@ -1,0 +1,79 @@
+// Splitting a function's argument string into arguments. Exported but never
+// tested, and it decides where every multi-argument function's arguments begin
+// and end — a wrong split feeds a formula the wrong operands with no error, just
+// a wrong result.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseFunctionArgs } from "../../../../src/plugins/spreadsheet/engine/evaluator.ts";
+
+describe("parseFunctionArgs — plain splitting", () => {
+  it("splits comma-separated arguments and trims each", () => {
+    assert.deepEqual(parseFunctionArgs("A1, B2, C3"), ["A1", "B2", "C3"]);
+    assert.deepEqual(parseFunctionArgs("1,2,3"), ["1", "2", "3"]);
+  });
+
+  it("returns a single argument when there is no comma", () => {
+    assert.deepEqual(parseFunctionArgs("A1"), ["A1"]);
+    assert.deepEqual(parseFunctionArgs("A1:A10"), ["A1:A10"]);
+  });
+
+  it("returns nothing for an empty string", () => {
+    assert.deepEqual(parseFunctionArgs(""), []);
+    assert.deepEqual(parseFunctionArgs("   "), []);
+  });
+});
+
+describe("parseFunctionArgs — nesting", () => {
+  // A comma inside a nested call belongs to that call, not the outer one:
+  // SUM(A1, MAX(B1, C1)) is two arguments, not three.
+  it("keeps a comma inside a nested function with its call", () => {
+    assert.deepEqual(parseFunctionArgs("A1, MAX(B1, C1)"), ["A1", "MAX(B1, C1)"]);
+  });
+
+  it("handles multiple and deeply nested calls", () => {
+    assert.deepEqual(parseFunctionArgs("SUM(A1,A2), COUNT(B1,B2,B3)"), ["SUM(A1,A2)", "COUNT(B1,B2,B3)"]);
+    assert.deepEqual(parseFunctionArgs("ROUND(SUM(A1,A2)/COUNT(A1,A2), 2)"), ["ROUND(SUM(A1,A2)/COUNT(A1,A2), 2)"]);
+  });
+
+  it("splits at the top level around a nested call", () => {
+    assert.deepEqual(parseFunctionArgs("IF(A1>0, 1, 0), B1"), ["IF(A1>0, 1, 0)", "B1"]);
+  });
+});
+
+describe("parseFunctionArgs — strings", () => {
+  // A comma or a parenthesis inside a quoted string is text, not structure.
+  it("keeps a comma inside a quoted string", () => {
+    assert.deepEqual(parseFunctionArgs('"a, b", C1'), ['"a, b"', "C1"]);
+    assert.deepEqual(parseFunctionArgs("'x, y', 1"), ["'x, y'", "1"]);
+  });
+
+  it("keeps a parenthesis inside a quoted string from disturbing the depth", () => {
+    assert.deepEqual(parseFunctionArgs('"f(x)", A1'), ['"f(x)"', "A1"]);
+    assert.deepEqual(parseFunctionArgs('SUM(A1), "not )a close"'), ["SUM(A1)", '"not )a close"']);
+  });
+
+  it("preserves the quotes on a quoted argument", () => {
+    assert.deepEqual(parseFunctionArgs('"hello"'), ['"hello"']);
+  });
+
+  // A quote is only a boundary when it is not backslash-escaped, so an escaped
+  // quote inside a string does not close it early.
+  it("does not treat a backslash-escaped quote as a boundary", () => {
+    assert.deepEqual(parseFunctionArgs('"say \\"hi\\", ok", B1'), ['"say \\"hi\\", ok"', "B1"]);
+  });
+});
+
+describe("parseFunctionArgs — edge behaviour worth pinning", () => {
+  // Documented current behaviour, not an endorsement: a trailing empty argument
+  // is dropped, so IF(A1>0,"yes",) reads as TWO arguments, not three (#2359). A
+  // leading or interior empty argument is kept.
+  it("drops a trailing empty argument", () => {
+    assert.deepEqual(parseFunctionArgs('A1, "yes",'), ["A1", '"yes"']);
+  });
+
+  it("keeps a leading or interior empty argument", () => {
+    assert.deepEqual(parseFunctionArgs(",B1"), ["", "B1"]);
+    assert.deepEqual(parseFunctionArgs("A1,,C1"), ["A1", "", "C1"]);
+  });
+});


### PR DESCRIPTION
## Summary

数式エンジンが**毎回の計算で通る**2関数に、テストがありませんでした（`evaluator.ts` / `calculator.ts` を import しているテストが1本も無かった）。本番コードの変更は `normalizeData` への `export` 追加のみ。

どちらも**静かに壊れる**種類です — `parseFunctionArgs` の分割ミスは関数に間違った引数を渡し、`normalizeData` の変形ミスは全参照を別セルにマップします。シートは計算し続け、ただ間違った結果を出します。

| 関数 | 件数 | 状態 |
|---|---|---|
| `parseFunctionArgs`（evaluator.ts） | 12 | export 済み・未テストだった |
| `normalizeData`（calculator.ts） | 8 | export 追加（ロジック不変） |

## Items to Confirm / Review

1. **`parseFunctionArgs`**: ネスト（`SUM(A1, MAX(B1, C1))` が2引数）、引用符内のカンマ・括弧、`\`エスケープされた引用符、そして**末尾空引数の drop**（`IF(A1>0,"yes",)` が2引数になる、#2359 で報告済み）を「現状」として固定。

2. **`normalizeData`**: 実 2D グリッドの参照そのまま返し、null/非配列/プリミティブ配列の空返し、フラットセル配列の2列化（奇数長の末尾1行含む）。**変異検証**: pairing の刻みを変えると 2 件赤。

3. **本番コードは `export` 1語のみ**。リスクゼロ。

## User Prompt

> できそうなのは１つ１つissueにして、それぞれ対応していく / ではおすすめ順で。

#2392 から着手（ゼロリスクの土台）。

## Test plan

- `test_parseFunctionArgs.ts` 12 件 + `test_normalizeData.ts` 8 件
- `yarn test` — 8310 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

Closes #2392

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made spreadsheet data normalization available for broader spreadsheet engine use.

* **Tests**
  * Added coverage for valid, empty, flat, odd-length, and single-cell spreadsheet data.
  * Added coverage for parsing function arguments, including nested calls, quoted strings, escaped quotes, and empty arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->