### PR TITLE
refactor(spreadsheet): extract DATEDIF unit math into a pure function

### DIFF
--- a/src/plugins/spreadsheet/engine/datedif.ts
+++ b/src/plugins/spreadsheet/engine/datedif.ts
@@ -1,0 +1,74 @@
+/**
+ * DATEDIF — complete elapsed time between two dates, in a chosen unit.
+ *
+ * Pure: two Excel serials and a unit in, a number (or an Excel error string)
+ * out. The unit branches each have their own boundary handling (month-end
+ * borrowing, year wraparound), which is exactly what makes them worth testing
+ * apart from the handler that reads the arguments.
+ */
+
+import { serialToDate } from "./date-utils";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Complete `unit`s between two dates, or `"#NUM!"` when start is after end or
+ *  the unit is not one of Y / M / D / MD / YM / YD. `unit` is matched
+ *  case-insensitively. */
+export function computeDatedif(startSerial: number, endSerial: number, unit: string): number | string {
+  if (startSerial > endSerial) return "#NUM!";
+
+  const startDate = serialToDate(startSerial);
+  const endDate = serialToDate(endSerial);
+
+  const yearDiff = endDate.getUTCFullYear() - startDate.getUTCFullYear();
+  const monthDiff = endDate.getUTCMonth() - startDate.getUTCMonth();
+  const dayDiff = endDate.getUTCDate() - startDate.getUTCDate();
+
+  switch (unit.toUpperCase()) {
+    case "Y": {
+      // Complete years: back off one if the end has not yet reached the
+      // start's month-and-day within its year.
+      const years = yearDiff;
+      return monthDiff < 0 || (monthDiff === 0 && dayDiff < 0) ? years - 1 : years;
+    }
+
+    case "M": {
+      // Complete months, backing off one when the day-of-month has not been reached.
+      const months = yearDiff * 12 + monthDiff;
+      return dayDiff < 0 ? months - 1 : months;
+    }
+
+    case "D":
+      return Math.floor(endSerial - startSerial);
+
+    case "MD": {
+      // Day-of-month difference, ignoring months and years. When the end day is
+      // earlier in its month, borrow the length of the month before the end.
+      const startD = startDate.getUTCDate();
+      const endD = endDate.getUTCDate();
+      if (endD >= startD) return endD - startD;
+      const prevMonthLastDay = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 0)).getUTCDate();
+      return prevMonthLastDay - startD + endD;
+    }
+
+    case "YM": {
+      // Month difference, ignoring years — wraps into 0..11.
+      const ym = dayDiff < 0 ? monthDiff - 1 : monthDiff;
+      return ym < 0 ? ym + 12 : ym;
+    }
+
+    case "YD": {
+      // Day difference, ignoring years: move the start into the end's year,
+      // stepping back a year if that would put it after the end.
+      const startInEndYear = new Date(startDate);
+      startInEndYear.setUTCFullYear(endDate.getUTCFullYear());
+      if (startInEndYear.getTime() - endDate.getTime() > 0) {
+        startInEndYear.setUTCFullYear(endDate.getUTCFullYear() - 1);
+      }
+      return Math.floor((endDate.getTime() - startInEndYear.getTime()) / MS_PER_DAY);
+    }
+
+    default:
+      return "#NUM!";
+  }
+}

--- a/src/plugins/spreadsheet/engine/functions/date.ts
+++ b/src/plugins/spreadsheet/engine/functions/date.ts
@@ -5,9 +5,8 @@
  */
 
 import { functionRegistry, toNumber, toString, type FunctionHandler } from "../registry";
+import { computeDatedif } from "../datedif";
 import { dateToSerial, serialToDate } from "../date-utils";
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const nowHandler: FunctionHandler = (args) => {
   if (args.length !== 0) throw new Error("NOW requires 0 arguments");
@@ -110,81 +109,9 @@ const datedifHandler: FunctionHandler = (args, context) => {
 
   const startSerial = toNumber(context.evaluateFormula(args[0]));
   const endSerial = toNumber(context.evaluateFormula(args[1]));
-  const unit = toString(context.evaluateFormula(args[2])).toUpperCase();
+  const unit = toString(context.evaluateFormula(args[2]));
 
-  if (startSerial > endSerial) return "#NUM!";
-
-  const startDate = serialToDate(startSerial);
-  const endDate = serialToDate(endSerial);
-
-  const yearDiff = endDate.getUTCFullYear() - startDate.getUTCFullYear();
-  const monthDiff = endDate.getUTCMonth() - startDate.getUTCMonth();
-  const dayDiff = endDate.getUTCDate() - startDate.getUTCDate();
-
-  switch (unit) {
-    case "Y": {
-      // Complete years
-      let years = yearDiff;
-      if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
-        years--;
-      }
-      return years;
-    }
-
-    case "M": {
-      // Complete months
-      let months = yearDiff * 12 + monthDiff;
-      if (dayDiff < 0) {
-        months--;
-      }
-      return months;
-    }
-
-    case "D":
-      // Complete days
-      return Math.floor(endSerial - startSerial);
-
-    case "MD": {
-      // Difference in days, ignoring months and years
-      // This is tricky. It's basically day of month difference, but handling wrap around
-      // E.g. Jan 30 to Mar 1.
-      // Standard implementation:
-      const startD = startDate.getUTCDate();
-      const endD = endDate.getUTCDate();
-
-      if (endD >= startD) return endD - startD;
-
-      // Need to borrow days from previous month
-      const prevMonthDate = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 0));
-      return prevMonthDate.getUTCDate() - startD + endD;
-    }
-
-    case "YM": {
-      // Difference in months, ignoring years
-      let ym = monthDiff;
-      if (dayDiff < 0) ym--;
-      if (ym < 0) ym += 12;
-      return ym;
-    }
-
-    case "YD": {
-      // Difference in days, ignoring years
-      // Treat start date as being in the same year as end date
-      // If start > end (after adjusting year), move start to previous year
-      const startCopy = new Date(startDate);
-      startCopy.setUTCFullYear(endDate.getUTCFullYear());
-
-      const diff = (startCopy.getTime() - endDate.getTime()) / MS_PER_DAY;
-      if (diff > 0) {
-        startCopy.setUTCFullYear(endDate.getUTCFullYear() - 1);
-      }
-
-      return Math.floor((endDate.getTime() - startCopy.getTime()) / MS_PER_DAY);
-    }
-
-    default:
-      return "#NUM!";
-  }
+  return computeDatedif(startSerial, endSerial, unit);
 };
 
 // Register functions

--- a/src/plugins/spreadsheet/engine/index.ts
+++ b/src/plugins/spreadsheet/engine/index.ts
@@ -10,6 +10,7 @@ export * from "./types";
 // Export utilities
 export * from "./parser";
 export * from "./date-locale";
+export * from "./datedif";
 export * from "./formatter";
 export * from "./evaluator";
 export * from "./calculator";

--- a/test/plugins/spreadsheet/engine/test_datedif.ts
+++ b/test/plugins/spreadsheet/engine/test_datedif.ts
@@ -1,0 +1,118 @@
+// DATEDIF's per-unit elapsed-time math. Each unit has its own boundary handling
+// — complete years/months back off when the day-of-month has not been reached,
+// MD borrows the previous month's length, YD wraps into the end's year — and a
+// wrong branch returns a plausible number rather than an error.
+//
+// Inputs are Excel serials, so tests build them from a known date via a helper
+// rather than hardcoding the serial arithmetic (that is covered in
+// test_dateUtils.ts).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeDatedif } from "../../../../src/plugins/spreadsheet/engine/datedif.ts";
+import { dateToSerial } from "../../../../src/plugins/spreadsheet/engine/date-utils.ts";
+
+const serial = (year: number, month: number, day: number) => dateToSerial(new Date(Date.UTC(year, month - 1, day)));
+const diff = (start: [number, number, number], end: [number, number, number], unit: string) => computeDatedif(serial(...start), serial(...end), unit);
+
+describe("computeDatedif — Y (complete years)", () => {
+  it("counts whole years between the same month and day", () => {
+    assert.equal(diff([2020, 6, 15], [2023, 6, 15], "Y"), 3);
+  });
+
+  // The end has not yet reached the start's month/day in its year, so the last
+  // year is incomplete.
+  it("backs off a year when the anniversary has not been reached", () => {
+    assert.equal(diff([2020, 6, 15], [2023, 6, 14], "Y"), 2);
+    assert.equal(diff([2020, 6, 15], [2023, 5, 20], "Y"), 2);
+  });
+
+  it("counts the year once the anniversary is reached exactly", () => {
+    assert.equal(diff([2020, 2, 29], [2024, 2, 29], "Y"), 4, "leap day to leap day");
+  });
+});
+
+describe("computeDatedif — M (complete months)", () => {
+  it("counts whole months", () => {
+    assert.equal(diff([2023, 1, 10], [2023, 4, 10], "M"), 3);
+    assert.equal(diff([2020, 1, 1], [2023, 1, 1], "M"), 36);
+  });
+
+  it("backs off a month when the day-of-month has not been reached", () => {
+    assert.equal(diff([2023, 1, 15], [2023, 4, 10], "M"), 2);
+  });
+});
+
+describe("computeDatedif — D (calendar days)", () => {
+  it("counts the days between two dates", () => {
+    assert.equal(diff([2023, 1, 1], [2023, 1, 31], "D"), 30);
+    assert.equal(diff([2023, 1, 1], [2024, 1, 1], "D"), 365);
+    assert.equal(diff([2024, 1, 1], [2025, 1, 1], "D"), 366, "leap year");
+  });
+});
+
+describe("computeDatedif — MD (day-of-month diff, months ignored)", () => {
+  it("subtracts the days directly when the end day is later", () => {
+    assert.equal(diff([2023, 1, 10], [2023, 3, 25], "MD"), 15);
+  });
+
+  // When the end day is earlier, the code borrows the length of the month
+  // BEFORE the end (Feb here) rather than the month before the start (Jan).
+  // For Jan 30 → Mar 1 that gives `28 - 30 + 1 = -1` — a NEGATIVE day count,
+  // which is wrong (Excel returns a positive number). Pinned as the current,
+  // buggy behaviour so the extraction is faithful; the fix belongs with the
+  // DATEDIF-boundary bug, not this refactor.
+  it("returns the current (buggy) borrow result when the end day is earlier", () => {
+    assert.equal(diff([2023, 1, 30], [2023, 3, 1], "MD"), -1, "borrows Feb's 28 days: 28 - 30 + 1");
+    assert.equal(diff([2024, 1, 30], [2024, 3, 1], "MD"), 0, "borrows Feb's 29 days");
+  });
+});
+
+describe("computeDatedif — YM (month diff, years ignored)", () => {
+  it("counts months within the year", () => {
+    assert.equal(diff([2020, 1, 10], [2023, 4, 10], "YM"), 3);
+  });
+
+  // Ignoring years can leave the month difference negative; it wraps into 0..11.
+  it("wraps a negative month difference into the 0..11 range", () => {
+    assert.equal(diff([2020, 11, 10], [2023, 2, 10], "YM"), 3);
+  });
+
+  it("backs off when the day has not been reached, then wraps", () => {
+    assert.equal(diff([2020, 11, 20], [2023, 2, 10], "YM"), 2);
+  });
+});
+
+describe("computeDatedif — YD (day diff, years ignored)", () => {
+  it("counts days within the same year window", () => {
+    assert.equal(diff([2023, 1, 1], [2023, 3, 1], "YD"), 59, "Jan + Feb 2023");
+  });
+
+  // Moving the start into the end's year would put it after the end, so it
+  // steps back a year and counts across the boundary.
+  it("crosses the year boundary when the start falls later in the end's year", () => {
+    assert.equal(diff([2020, 12, 20], [2023, 1, 5], "YD"), 16, "Dec 20 to Jan 5");
+  });
+});
+
+describe("computeDatedif — errors", () => {
+  it("returns #NUM! when start is after end", () => {
+    assert.equal(diff([2023, 6, 15], [2023, 6, 10], "D"), "#NUM!");
+  });
+
+  it("returns #NUM! for an unknown unit", () => {
+    assert.equal(diff([2020, 1, 1], [2023, 1, 1], "Q"), "#NUM!");
+    assert.equal(diff([2020, 1, 1], [2023, 1, 1], ""), "#NUM!");
+  });
+
+  it("matches the unit case-insensitively", () => {
+    assert.equal(diff([2020, 1, 1], [2023, 1, 1], "y"), 3);
+    assert.equal(diff([2023, 1, 1], [2023, 1, 31], "d"), 30);
+  });
+
+  it("returns 0 for identical dates in every unit", () => {
+    for (const unit of ["Y", "M", "D", "MD", "YM", "YD"]) {
+      assert.equal(diff([2023, 6, 15], [2023, 6, 15], unit), 0, `unit ${unit}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`datedifHandler` の 80 行の switch(Y/M/D/MD/YM/YD)を純粋関数 `computeDatedif(startSerial, endSerial, unit)` に切り出しました。計算は2つの serial と unit だけに依存するので独立モジュールに。ハンドラは引数評価のみ。

## Items to Confirm / Review

1. **18 件のテスト(DATEDIF 初)**。各 unit の境界処理を固定 — 完全年/月の back-off、うるう年をまたぐ D、MD の月借り、YM の 0..11 wrap、YD の年跨ぎ、start>end と未知 unit の `#NUM!`、大文字小文字非依存、同一日で 0。変異検証: Y back-off で 1、M back-off で 1、YM wrap で 2、start>end ガードで 1 が赤。

2. **テストを書く過程で実バグを発見** → [#2414](https://github.com/receptron/mulmoclaude/issues/2414) に切り出し、ここでは**現状(バグ)として固定**しました(リファクタ中に黙って直さない)。`MD` が `Jan 30 → Mar 1` で**負の日数 -1** を返します。end の前月を借りるべきところ start の月を借りるべき、という誤り。抽出は忠実で、修正時にこの期待値を更新します。

3. **ハンドラ→純粋関数の配線もエンジン経由で確認**(`=DATEDIF(A1,B1,"Y")` が 3)。

## User Prompt

> ではおすすめ順で。

#2392(テスト土台)の次、#2393。

## Test plan

- `test_datedif.ts` 18 件
- `yarn test` — 8357 件 pass / 0 fail
- `yarn lint` / `yarn typecheck` / `yarn build` — green

Closes #2393
Refs #2360

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spreadsheet `DATEDIF` support for calculating elapsed years, months, days, and related date intervals.
  * Supports case-insensitive interval units and Excel-style serial dates.

* **Bug Fixes**
  * Invalid date ranges and unsupported interval units now return `#NUM!`.

* **Tests**
  * Added coverage for leap years, boundary dates, month wrapping, identical dates, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->