### PR TITLE
refactor(collection): single-source registry types from core (#2407)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -10,6 +10,10 @@
 import type { Component } from "vue";
 import type { TranslateTransport } from "@mulmoclaude/core/translation/client";
 import type { RemoteViewMutateRequest, RemoteViewPage, RemoteViewPageRequest } from "@mulmoclaude/core/remote-view";
+// Registry Discover-catalog contract — single-sourced in core (browser-safe
+// subpath) so a server-side shape change is a compile error here, not silent
+// drift (#2407). Re-exported below for this plugin's own consumers.
+import type { RegistryEntry, RegistrySummary, RegistryListResponse, RegistryImportResponse } from "@mulmoclaude/core/collection/registry";
 import type {
   CollectionDetailResponse,
   ItemMutationResponse,
@@ -142,60 +146,10 @@ export interface CollectionConfirmOptions {
   variant?: "primary" | "success" | "danger";
 }
 
-/** One collection in a curated registry's published index (the host fetches
- *  each registry's index.json and proxies them all to the Discover tab). */
-export interface RegistryEntry {
-  id: string;
-  author: string;
-  slug: string;
-  title: string;
-  icon: string;
-  description: string;
-  version: string;
-  tags: string[];
-  license: string;
-  fieldCount: number;
-  views: string[];
-  hasSeed: boolean;
-  seedCount: number;
-  screenshot?: string;
-  path: string;
-  contentSha: string;
-  /** Label of the source registry — `"official"` for the canonical
-   *  receptron/mulmoclaude-collections, otherwise the `name` of an entry in
-   *  the user's `config/collections-registries.json`. The Discover card shows
-   *  this as a small badge so users can tell apart same-title collections from
-   *  different sources. */
-  registryName: string;
-}
-
-/** Per-registry summary in the merged Discover response. */
-export interface RegistrySummary {
-  name: string;
-  /** `ok` = fresh, `stale` = served from cache because the upstream failed,
-   *  `failed` = no cache to fall back to (the entries contribution is 0). */
-  status: "ok" | "stale" | "failed";
-  generatedAt: string | null;
-  error: string | null;
-  entryCount: number;
-}
-
-/** `GET …collectionsRegistry.list` — the Discover catalog merged across every
- *  configured registry. */
-export interface RegistryListResponse {
-  registries: RegistrySummary[];
-  /** Convenience flag: true iff any single registry's contribution was stale. */
-  stale: boolean;
-  collections: RegistryEntry[];
-}
-
-/** `POST …collectionsRegistry.import` — install result. */
-export interface RegistryImportResponse {
-  localSlug: string;
-  updated: boolean;
-  seedWritten: number;
-  seedSkipped: boolean;
-}
+// The Discover-catalog registry contract (entry / summary / list / import
+// response) is owned by `@mulmoclaude/core/collection/registry` and re-exported
+// here so this plugin's consumers keep importing it from one place.
+export type { RegistryEntry, RegistrySummary, RegistryListResponse, RegistryImportResponse };
 
 export interface CollectionUi {
   /** Fetch a collection's detail (schema + records) by slug — backs both the

--- a/plans/refactor-2407-collection-registry-types.md
+++ b/plans/refactor-2407-collection-registry-types.md
@@ -1,0 +1,61 @@
+# refactor(collection): single-source the registry Discover-catalog types (#2407)
+
+## Problem
+
+The collection registry's Discover-catalog contract is declared **twice**:
+
+| Canonical (core) | Duplicate (plugin) |
+|---|---|
+| `packages/core/src/collection/registry/registryIndex.ts` — `RegistryEntry` | `packages/plugins/collection-plugin/src/vue/uiContext.ts:147-170` — `RegistryEntry` |
+| `packages/core/src/collection/registry/types.ts` — `RegistrySummary` / `RegistryListResponse` / `RegistryImportResponse` | `uiContext.ts:173-198` — same three |
+
+jscpd flagged both blocks (80 / 75 tokens). This is the same class of bug as #2334
+(`SessionSummary` twin): while two copies of the type exist, the compiler cannot see
+the boundary. If the server adds a field to a registry entry, the plugin's copy stays
+stale and the build is still green — silent drift.
+
+## Key facts
+
+- The parser (`parseRegistryIndex`) and all four types already live in core and are
+  already exported from the **browser-safe** subpath `@mulmoclaude/core/collection/registry`
+  (its barrel is explicitly documented "Browser-safe"; the parser only depends on a pure
+  `isRecord` guard, no `node:` imports).
+- `server/api/routes/collectionsRegistry.ts` already imports `RegistryEntry`,
+  `RegistryListResponse`, `RegistryImportResponse` from that subpath — so it is a proven,
+  published surface.
+- The plugin **never re-implemented the parser** — it only re-declared the types. So the
+  "index parsing" jscpd hit is really the `RegistryEntry` interface that happens to sit at
+  the top of `registryIndex.ts`. The fix is entirely type-level; no runtime logic moves.
+- Package direction is respected: plugin → core is the allowed (downhill) direction. Core
+  is untouched, so nothing imports uphill.
+
+## Approach
+
+1. In `uiContext.ts`, delete the four duplicate `interface` declarations
+   (`RegistryEntry`, `RegistrySummary`, `RegistryListResponse`, `RegistryImportResponse`).
+2. Add `import type { … } from "@mulmoclaude/core/collection/registry"` and re-export the
+   same four names, so the plugin's existing consumers (`DiscoverPanel.vue`,
+   `vue/index.ts`) keep importing them from `../uiContext` unchanged. Public surface and
+   runtime behavior are identical — types are erased at build time, so no `node:` code
+   reaches the browser bundle.
+
+## Version discipline
+
+No `@mulmoclaude/core` change → no version bump, no subpath added, no consumer-range sweep.
+The subpath already existed and shipped. This is a plugin-only, type-level refactor.
+
+## Tests
+
+The pure parser logic is already covered by
+`packages/core/test/collection-registry/test_registryIndex.ts` (happy path, non-object,
+schemaVersion, missing fields, count validation, traversal-poisoned author/slug, tag/view
+filtering, registryName stamping). No new pure logic is introduced, so no new test file is
+warranted.
+
+**Boundary proof** (the point of the refactor, per the issue): temporarily add a required
+field to core's `RegistryEntry`, run the plugin's `vue-tsc`, confirm it now errors at the
+plugin boundary, then revert. Recorded in the PR's "Items to Confirm / Review".
+
+## Verify
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`.


### PR DESCRIPTION
## Summary

The collection registry's Discover-catalog contract (`RegistryEntry`, `RegistrySummary`, `RegistryListResponse`, `RegistryImportResponse`) was declared **twice** — canonically in `@mulmoclaude/core` and again, byte-for-byte, in the collection-plugin's `vue/uiContext.ts` (jscpd 80/75 tokens). While two copies exist the compiler can't see the boundary, so a server-side entry-shape change drifts silently against the plugin's stale copy (same failure class as #2334's `SessionSummary`).

This PR deletes the plugin's four duplicate `interface` declarations and re-exports the same names from the existing **browser-safe** subpath `@mulmoclaude/core/collection/registry` — which the server (`server/api/routes/collectionsRegistry.ts`) already imports from. The change is **type-only**: types are erased at build time, so no `node:` code reaches the browser bundle, and the plugin's public surface + runtime behavior are unchanged.

Net: 51 lines of duplicated types removed from one file; single source of truth restored.

## Items to Confirm / Review

- **Boundary proof (the point of the refactor).** I temporarily renamed `title` → `titleZZZ` in core's `RegistryEntry`, rebuilt core, and ran the plugin's `vue-tsc`: it errored at `DiscoverPanel.vue:31` — `Property 'title' does not exist`. Before this PR that rename would have gone undetected. Reverted after verifying. Drift is now compiler-detected.
- **No parser was moved / duplicated.** The plugin never re-implemented `parseRegistryIndex` — it only re-declared the *types*. The "index parsing" jscpd hit is the `RegistryEntry` interface that sits at the top of `registryIndex.ts`. So this is purely type-level; the pure parser stays in core and keeps its existing coverage (`packages/core/test/collection-registry/test_registryIndex.ts`, 13 tests, all green). No new test file is warranted since no new pure logic is introduced.
- **Subpath choice.** I import from `@mulmoclaude/core/collection/registry` (the dedicated, already-published, browser-safe registry subpath) rather than adding a re-export to `@mulmoclaude/core/collection`, to avoid a new barrel (CLAUDE.md: no re-export barrels without reason). The issue text loosely said `@mulmoclaude/core/collection`; the registry subpath is the precise browser-safe home and matches what the server already uses.
- **No version bump.** Core is untouched (the subpath already shipped), so no `@mulmoclaude/core` bump, no consumer-range sweep, no launcher change. Plugin-only, type-level refactor.

## User Prompt

Work through the open code-dedup refactor issues (#2398+) in parallel; this PR implements **#2407** (collection registry types + index parsing declared twice: core ↔ collection-plugin uiContext). Skip spreadsheet code. Do not merge.

## Approach & Decisions

1. `uiContext.ts` — added `import type { RegistryEntry, RegistrySummary, RegistryListResponse, RegistryImportResponse } from "@mulmoclaude/core/collection/registry"` and replaced the four duplicate `interface` blocks with a single `export type { … }` re-export, so existing consumers (`DiscoverPanel.vue`, `vue/index.ts`) keep importing them from `../uiContext` unchanged.
2. Package dependency direction respected: plugin → core is downhill (allowed); core imports nothing from the plugin.
3. Plan committed at `plans/refactor-2407-collection-registry-types.md`.

## Verification

- `yarn format` — clean
- `yarn lint` — 0 errors (40 pre-existing warnings, none in collection-plugin)
- `yarn typecheck` — exit 0
- `yarn build` — succeeds
- `yarn test` (core registry parser suite) — 13/13 pass
- Boundary-drift proof — confirmed (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Single-source the collection registry Discover-catalog types in the collection plugin by importing them from the core browser-safe registry subpath and re-exporting them for existing consumers.

Enhancements:
- Replace duplicated registry type interfaces in the collection plugin with type imports from @mulmoclaude/core/collection/registry to enforce a shared contract boundary.
- Add a refactor plan document describing the registry type deduplication and its rationale for issue #2407.

Documentation:
- Document the registry type deduplication approach and versioning/testing considerations in a new refactor plan markdown file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized Discover catalog registry types to improve consistency across the application.
  * Existing plugin consumers continue using the same registry type names and interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->