### PR TITLE
fix(spreadsheet): DATEDIF "MD" no longer returns negative days (#2414)

### DIFF
--- a/plans/fix-2414-datedif-md.md
+++ b/plans/fix-2414-datedif-md.md
@@ -1,0 +1,39 @@
+# fix(spreadsheet): DATEDIF "MD" no longer returns negative days (#2414)
+
+## Problem
+
+`DATEDIF(Jan 30 2023, Mar 1 2023, "MD")` returned `-1` (Excel: a positive value).
+The `"MD"` unit — day-of-month difference ignoring months and years — must be
+non-negative.
+
+## Root cause
+
+`computeDatedif`'s `"MD"` branch borrowed the length of the calendar month
+BEFORE `end` when the end day was earlier: `prevMonthLastDay - startD + endD`.
+For Jan 30 → Mar 1 that is Feb's 28 days: `28 - 30 + 1 = -1`. When the start day
+outruns the preceding month's length, the result goes negative.
+
+## Fix
+
+Compute MD as the day remainder after the complete months `DATEDIF "M"` counts,
+anchored on `start + <complete months>` (with day clamped to the target month's
+length). This keeps the invariant `start + M months + MD days == end`, so the
+result is non-negative by construction and still correct for multi-month spans
+(where the naive borrow was already right).
+
+- New pure helper `addMonthsClamped(date, months)` — adds months, clamping the
+  day so Jan 30 + 1 month → Feb 28/29 rather than overflowing into March.
+- `MONTHS_PER_YEAR` constant replaces the inline `12`s in the same file.
+
+## Chosen semantics (Excel is itself inconsistent here)
+
+- Jan 30 → Mar 1 = **1** (one complete month to Feb 28/29, then one day). Excel's
+  DATEDIF "MD" is officially unreliable in this pathological case; `1` is the
+  value consistent with the M+MD invariant, and it is the same for leap and
+  non-leap years.
+
+## Tests (test_datedif.ts, expectations updated from the pinned buggy values)
+
+- End day later: unchanged (`Jan 10 → Mar 25 = 15`).
+- Multi-month remainder: `Jan 15 → Mar 10 = 23`.
+- Non-negative pathological cases: `Jan 30 → Mar 1 = 1` (2023 and leap 2024).

--- a/src/plugins/spreadsheet/engine/datedif.ts
+++ b/src/plugins/spreadsheet/engine/datedif.ts
@@ -62,7 +62,11 @@ export function computeDatedif(startSerial: number, endSerial: number, unit: str
       // Jan 30 → Mar 1 borrowed Feb's 28 days and returned -1.
       const completeMonths = yearDiff * MONTHS_PER_YEAR + monthDiff - (dayDiff < 0 ? 1 : 0);
       const anchor = addMonthsClamped(startDate, completeMonths);
-      return Math.round((endDate.getTime() - anchor.getTime()) / MS_PER_DAY);
+      // Compare whole days only. `end` may carry a time-of-day (a datetime
+      // serial); anchor is already UTC midnight, so strip end's time too or the
+      // remainder would swing with the clock (Codex review).
+      const endMidnight = Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate());
+      return Math.round((endMidnight - anchor.getTime()) / MS_PER_DAY);
     }
 
     case "YM": {

--- a/src/plugins/spreadsheet/engine/datedif.ts
+++ b/src/plugins/spreadsheet/engine/datedif.ts
@@ -10,6 +10,19 @@
 import { serialToDate } from "./date-utils";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MONTHS_PER_YEAR = 12;
+
+/** `date` advanced by `months`, clamping the day to the target month's length so
+ *  adding a month to Jan 30 lands on the last day of a shorter month instead of
+ *  overflowing into the next one. */
+function addMonthsClamped(date: Date, months: number): Date {
+  const monthIndex = date.getUTCMonth() + months;
+  const year = date.getUTCFullYear() + Math.floor(monthIndex / MONTHS_PER_YEAR);
+  const month = ((monthIndex % MONTHS_PER_YEAR) + MONTHS_PER_YEAR) % MONTHS_PER_YEAR;
+  const lastDayOfMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const day = Math.min(date.getUTCDate(), lastDayOfMonth);
+  return new Date(Date.UTC(year, month, day));
+}
 
 /** Complete `unit`s between two dates, or `"#NUM!"` when start is after end or
  *  the unit is not one of Y / M / D / MD / YM / YD. `unit` is matched
@@ -34,7 +47,7 @@ export function computeDatedif(startSerial: number, endSerial: number, unit: str
 
     case "M": {
       // Complete months, backing off one when the day-of-month has not been reached.
-      const months = yearDiff * 12 + monthDiff;
+      const months = yearDiff * MONTHS_PER_YEAR + monthDiff;
       return dayDiff < 0 ? months - 1 : months;
     }
 
@@ -42,19 +55,20 @@ export function computeDatedif(startSerial: number, endSerial: number, unit: str
       return Math.floor(endSerial - startSerial);
 
     case "MD": {
-      // Day-of-month difference, ignoring months and years. When the end day is
-      // earlier in its month, borrow the length of the month before the end.
-      const startD = startDate.getUTCDate();
-      const endD = endDate.getUTCDate();
-      if (endD >= startD) return endD - startD;
-      const prevMonthLastDay = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), 0)).getUTCDate();
-      return prevMonthLastDay - startD + endD;
+      // Days left after the complete months "M" counts. Anchoring on start plus
+      // those months keeps the result non-negative and self-consistent (start +
+      // M months + MD days == end). Subtracting the calendar month before `end`
+      // instead goes negative when the start day outruns that month's length —
+      // Jan 30 → Mar 1 borrowed Feb's 28 days and returned -1.
+      const completeMonths = yearDiff * MONTHS_PER_YEAR + monthDiff - (dayDiff < 0 ? 1 : 0);
+      const anchor = addMonthsClamped(startDate, completeMonths);
+      return Math.round((endDate.getTime() - anchor.getTime()) / MS_PER_DAY);
     }
 
     case "YM": {
       // Month difference, ignoring years — wraps into 0..11.
       const ym = dayDiff < 0 ? monthDiff - 1 : monthDiff;
-      return ym < 0 ? ym + 12 : ym;
+      return ym < 0 ? ym + MONTHS_PER_YEAR : ym;
     }
 
     case "YD": {

--- a/test/plugins/spreadsheet/engine/test_datedif.ts
+++ b/test/plugins/spreadsheet/engine/test_datedif.ts
@@ -71,6 +71,15 @@ describe("computeDatedif — MD (day-of-month diff, months ignored)", () => {
     assert.equal(diff([2023, 1, 30], [2023, 3, 1], "MD"), 1, "Jan 30 + 1 month → Feb 28, then 1 day");
     assert.equal(diff([2024, 1, 30], [2024, 3, 1], "MD"), 1, "leap year: Jan 30 + 1 month → Feb 29, then 1 day");
   });
+
+  // The remainder counts whole days: a datetime serial's time-of-day must not
+  // change the result (an 18:00 fraction on `end` once rounded MD up to 2).
+  it("ignores the time-of-day of a datetime serial", () => {
+    const start = serial(2023, 1, 30);
+    const end = serial(2023, 3, 1);
+    assert.equal(computeDatedif(start, end + 0.75, "MD"), 1, "end at 18:00 still yields 1");
+    assert.equal(computeDatedif(start + 0.75, end + 0.25, "MD"), 1, "start and end times both ignored");
+  });
 });
 
 describe("computeDatedif — YM (month diff, years ignored)", () => {

--- a/test/plugins/spreadsheet/engine/test_datedif.ts
+++ b/test/plugins/spreadsheet/engine/test_datedif.ts
@@ -1,7 +1,8 @@
 // DATEDIF's per-unit elapsed-time math. Each unit has its own boundary handling
 // — complete years/months back off when the day-of-month has not been reached,
-// MD borrows the previous month's length, YD wraps into the end's year — and a
-// wrong branch returns a plausible number rather than an error.
+// MD is the day remainder after the complete months (always non-negative), YD
+// wraps into the end's year — and a wrong branch returns a plausible number
+// rather than an error.
 //
 // Inputs are Excel serials, so tests build them from a known date via a helper
 // rather than hardcoding the serial arithmetic (that is covered in
@@ -56,15 +57,19 @@ describe("computeDatedif — MD (day-of-month diff, months ignored)", () => {
     assert.equal(diff([2023, 1, 10], [2023, 3, 25], "MD"), 15);
   });
 
-  // When the end day is earlier, the code borrows the length of the month
-  // BEFORE the end (Feb here) rather than the month before the start (Jan).
-  // For Jan 30 → Mar 1 that gives `28 - 30 + 1 = -1` — a NEGATIVE day count,
-  // which is wrong (Excel returns a positive number). Pinned as the current,
-  // buggy behaviour so the extraction is faithful; the fix belongs with the
-  // DATEDIF-boundary bug, not this refactor.
-  it("returns the current (buggy) borrow result when the end day is earlier", () => {
-    assert.equal(diff([2023, 1, 30], [2023, 3, 1], "MD"), -1, "borrows Feb's 28 days: 28 - 30 + 1");
-    assert.equal(diff([2024, 1, 30], [2024, 3, 1], "MD"), 0, "borrows Feb's 29 days");
+  // Multi-month spans still measure the day remainder correctly: Jan 15 → Mar 10
+  // has one complete month (to Feb 15), leaving 23 days to Mar 10.
+  it("measures the day remainder across several months", () => {
+    assert.equal(diff([2023, 1, 15], [2023, 3, 10], "MD"), 23);
+  });
+
+  // The day remainder is anchored on start-plus-complete-months, so it is never
+  // negative even when the start day outruns the month before `end`. Jan 30 →
+  // Mar 1 has one complete month (clamped to Feb 28/29), leaving one day — where
+  // the old borrow-the-previous-month math returned -1 (#2414).
+  it("stays non-negative when the start day outruns the preceding month", () => {
+    assert.equal(diff([2023, 1, 30], [2023, 3, 1], "MD"), 1, "Jan 30 + 1 month → Feb 28, then 1 day");
+    assert.equal(diff([2024, 1, 30], [2024, 3, 1], "MD"), 1, "leap year: Jan 30 + 1 month → Feb 29, then 1 day");
   });
 });
 


### PR DESCRIPTION
## Summary
`DATEDIF(Jan 30 2023, Mar 1 2023, "MD")` returned `-1`; the `"MD"` unit (day-of-month difference, months/years ignored) must be non-negative. Fixed by computing MD as the day remainder after the complete months `DATEDIF "M"` counts, anchored on `start + <complete months>` with the day clamped to the target month's length. This keeps the invariant `start + M months + MD days == end`, so the result is non-negative by construction and still correct for multi-month spans.

## Items to Confirm / Review
- **Pathological-case value is a chosen convention.** Excel's `DATEDIF "MD"` is officially unreliable when the start day outruns the month before `end`. I standardised on `Jan 30 → Mar 1 = 1` (one complete month to Feb 28/29, then one day) — consistent for leap and non-leap years and with the M+MD invariant. Please confirm this convention is acceptable.
- New pure helper `addMonthsClamped` clamps day overflow (Jan 30 + 1 month → Feb 28/29, not Mar 2).
- The existing `test_datedif.ts` cases that pinned the buggy `-1` / `0` values were updated to the new expected `1`.

## User Prompt
他もスプシ関係のissueを並列でどんどん進めて — the user asked to work through the open spreadsheet bug issues in parallel, one PR per issue.

## Implementation
- `datedif.ts`: `"MD"` branch now uses `addMonthsClamped(start, completeMonths)` and returns the day gap to `end`; added `MONTHS_PER_YEAR` constant (replacing the inline `12`s).
- `test_datedif.ts`: added a multi-month remainder case (`Jan 15 → Mar 10 = 23`) and non-negative pathological cases; updated the header comment.
- Plan: `plans/fix-2414-datedif-md.md`.

Fixes #2414