### PR TITLE
fix(spreadsheet): correct IPMT sign and PPMT so IPMT+PPMT equals PMT (#2386)

### DIFF
--- a/plans/fix-2386-ipmt-ppmt.md
+++ b/plans/fix-2386-ipmt-ppmt.md
@@ -1,0 +1,44 @@
+# fix(spreadsheet): correct IPMT sign and PPMT (#2386)
+
+## Problem
+
+```
+IPMT(0.005, 1, 360, 250000) => 1250      (Excel: -1250, sign inverted)
+PPMT(0.005, 1, 360, 250000) => -2748.88  (Excel: -248.88, way off)
+PMT(0.005, 360, 250000)     => -1498.88  (correct)
+```
+
+`PMT` returns the payment as a (correct) negative outflow, but `IPMT` returned
+the interest with the wrong sign, and `PPMT = PMT - IPMT` amplified the error.
+
+## Root cause
+
+`ipmtHandler` computed `const ipmt = -fvPrevious * rate;`. `fvHandler` already
+returns the outstanding balance with Excel's payment-negative sign, so negating
+it again flipped the interest sign. `PPMT` then did `-1498.88 - (+1250) =
+-2748.88` instead of `-1498.88 - (-1250) = -248.88`.
+
+## Fix
+
+Extract the annuity math into pure numeric helpers in a new
+`engine/financial-math.ts` (`computeFv`, `computePmt`, `computeIpmt`,
+`computePpmt`) and have the FV / PMT / IPMT / PPMT handlers parse their args and
+delegate. The sign is fixed in one place: `interest = computeFv(...) * rate`
+(no extra negation). Because PPMT calls the same pure `computeIpmt`, one fix
+corrects both, and the `IPMT + PPMT == PMT` invariant holds.
+
+This also removes the awkward previous structure where IPMT/PPMT re-invoked the
+PMT/FV _handlers_ with stringified numeric args through the evaluator.
+
+## Tests (test_financialMath.ts, pure functions — no evaluator needed)
+
+- Excel values: `PMT = -1498.88`, `IPMT(1) = -1250`, `IPMT(2) = -1248.76`,
+  `PPMT(1) = -248.88`.
+- Invariant: `IPMT(per) + PPMT(per) == PMT` for per ∈ {1, 2, 12, 180, 360}.
+- Sign anchor: `computeFv(rate, 0, pmt, pv, 0) == -pv`; zero-rate streams.
+- Annuity-due first period has zero interest.
+
+## Items to confirm
+
+- Excel cash-flow sign convention (money out = negative) is followed throughout.
+- FV/PMT numeric results are unchanged (only relocated into the pure module).

--- a/src/plugins/spreadsheet/engine/financial-math.ts
+++ b/src/plugins/spreadsheet/engine/financial-math.ts
@@ -1,0 +1,41 @@
+/**
+ * Annuity math for the financial functions, as pure numeric helpers.
+ *
+ * Excel's cash-flow sign convention: money received is positive, money paid out
+ * is negative — so a loan's `pv` is positive and its payment and interest come
+ * back negative. Keeping the per-period split as plain number-in / number-out
+ * functions lets it be tested against known Excel values without routing string
+ * arguments back through the formula evaluator.
+ */
+
+/** Future value after `nper` periods. `type` is 0 (end of period) or 1 (begin). */
+export function computeFv(rate: number, nper: number, pmt: number, pv: number, type: number): number {
+  if (rate === 0) return -(pv + pmt * nper);
+  const growth = Math.pow(1 + rate, nper);
+  return -pv * growth - (pmt * (growth - 1) * (1 + rate * type)) / rate;
+}
+
+/** Constant per-period payment amortising a present value `pv` to `fv`. */
+export function computePmt(rate: number, nper: number, pv: number, fv: number, type: number): number {
+  if (rate === 0) return -(fv + pv) / nper;
+  const growth = Math.pow(1 + rate, nper);
+  return (-rate * (fv + pv * growth)) / ((growth - 1) * (1 + rate * type));
+}
+
+/** Interest portion of the `per`-th payment. */
+export function computeIpmt(rate: number, per: number, nper: number, pv: number, fv: number, type: number): number {
+  const pmt = computePmt(rate, nper, pv, fv, type);
+  if (per === 1 && type === 1) return 0;
+  const priorPeriods = type === 1 ? per - 2 : per - 1;
+  // Interest is the rate applied to the balance outstanding at the start of the
+  // period. computeFv already carries the payment-negative sign, so this product
+  // is the interest as a (negative) cash outflow — negating it again inverted the
+  // sign (IPMT came back +1250 for a -1250 payment) and PPMT amplified the error.
+  const interest = computeFv(rate, priorPeriods, pmt, pv, type) * rate;
+  return type === 1 ? interest / (1 + rate) : interest;
+}
+
+/** Principal portion of the `per`-th payment (total payment minus interest). */
+export function computePpmt(rate: number, per: number, nper: number, pv: number, fv: number, type: number): number {
+  return computePmt(rate, nper, pv, fv, type) - computeIpmt(rate, per, nper, pv, fv, type);
+}

--- a/src/plugins/spreadsheet/engine/functions/financial.ts
+++ b/src/plugins/spreadsheet/engine/functions/financial.ts
@@ -3,6 +3,7 @@
  */
 
 import { functionRegistry, toNumber, type FunctionHandler } from "../registry";
+import { computeFv, computePmt, computeIpmt, computePpmt } from "../financial-math";
 
 /**
  * FV - Future Value
@@ -25,14 +26,7 @@ const fvHandler: FunctionHandler = (args, context) => {
   const pv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
   const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
 
-  if (rate === 0) {
-    return -(pv + pmt * nper);
-  }
-
-  const pvFactor = Math.pow(1 + rate, nper);
-  const fv = -pv * pvFactor - (pmt * (pvFactor - 1) * (1 + rate * type)) / rate;
-
-  return fv;
+  return computeFv(rate, nper, pmt, pv, type);
 };
 
 /**
@@ -77,14 +71,7 @@ const pmtHandler: FunctionHandler = (args, context) => {
   const fv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
   const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
 
-  if (rate === 0) {
-    return -(fv + pv) / nper;
-  }
-
-  const pvFactor = Math.pow(1 + rate, nper);
-  const pmt = (-rate * (fv + pv * pvFactor)) / ((pvFactor - 1) * (1 + rate * type));
-
-  return pmt;
+  return computePmt(rate, nper, pv, fv, type);
 };
 
 /**
@@ -173,21 +160,12 @@ const ipmtHandler: FunctionHandler = (args, context) => {
 
   const rate = toNumber(context.evaluateFormula(args[0]));
   const per = toNumber(context.evaluateFormula(args[1]));
+  const nper = toNumber(context.evaluateFormula(args[2]));
+  const pv = toNumber(context.evaluateFormula(args[3]));
+  const fv = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
   const type = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0;
 
-  // Calculate payment first
-  const pmt = pmtHandler([args[0], args[2], args[3], ...(args.length >= 5 ? [args[4]] : []), ...(args.length >= 6 ? [args[5]] : [])], context);
-
-  if (per === 1 && type === 1) {
-    return 0; // No interest in first period when payment is at beginning
-  }
-
-  // Calculate remaining balance at previous period
-  const fvPrevious = fvHandler([args[0], String(type === 1 ? per - 2 : per - 1), String(pmt), args[3], ...(args.length >= 6 ? [args[5]] : [])], context);
-
-  const ipmt = -fvPrevious * rate;
-
-  return type === 1 ? ipmt / (1 + rate) : ipmt;
+  return computeIpmt(rate, per, nper, pv, fv, type);
 };
 
 /**
@@ -200,14 +178,14 @@ const ppmtHandler: FunctionHandler = (args, context) => {
     throw new Error("PPMT requires 4 to 6 arguments");
   }
 
-  // Calculate total payment
-  const pmt = pmtHandler([args[0], args[2], args[3], ...(args.length >= 5 ? [args[4]] : []), ...(args.length >= 6 ? [args[5]] : [])], context);
+  const rate = toNumber(context.evaluateFormula(args[0]));
+  const per = toNumber(context.evaluateFormula(args[1]));
+  const nper = toNumber(context.evaluateFormula(args[2]));
+  const pv = toNumber(context.evaluateFormula(args[3]));
+  const fv = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
+  const type = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0;
 
-  // Calculate interest payment
-  const ipmt = ipmtHandler(args, context);
-
-  // Principal payment = Total payment - Interest payment
-  return toNumber(pmt) - toNumber(ipmt);
+  return computePpmt(rate, per, nper, pv, fv, type);
 };
 
 /**

--- a/test/plugins/spreadsheet/engine/test_financialMath.ts
+++ b/test/plugins/spreadsheet/engine/test_financialMath.ts
@@ -1,0 +1,70 @@
+// The per-period interest/principal split of an annuity. The bug this covers
+// returned a plausible NUMBER — IPMT came back +1250 for a -1250 interest
+// payment (sign inverted), and PPMT (= PMT - IPMT) amplified it to -2748.88
+// instead of -248.88 (#2386). Values are checked against Excel.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeFv, computePmt, computeIpmt, computePpmt } from "../../../../src/plugins/spreadsheet/engine/financial-math.ts";
+
+const closeTo = (actual: number, expected: number, eps = 0.01): boolean => Math.abs(actual - expected) <= eps;
+
+// A 250,000 loan at 0.5%/period over 360 periods — the issue's worked example.
+const RATE = 0.005;
+const NPER = 360;
+const PRINCIPAL = 250000;
+
+describe("computePmt", () => {
+  it("matches Excel's constant payment (negative outflow)", () => {
+    assert.ok(closeTo(computePmt(RATE, NPER, PRINCIPAL, 0, 0), -1498.88), "PMT ≈ -1498.88");
+  });
+
+  it("splits a zero-interest loan evenly", () => {
+    assert.ok(closeTo(computePmt(0, 10, 1000, 0, 0), -100, 1e-9), "zero-rate PMT");
+  });
+});
+
+describe("computeIpmt", () => {
+  it("returns the first period's interest with Excel's sign", () => {
+    // Interest on the full 250,000 balance: 250000 * 0.005 = 1250, as a payment
+    // it is negative. The bug returned +1250.
+    assert.ok(closeTo(computeIpmt(RATE, 1, NPER, PRINCIPAL, 0, 0), -1250, 1e-9), "IPMT(1) = -1250");
+  });
+
+  it("decreases in magnitude as the balance is paid down", () => {
+    assert.ok(closeTo(computeIpmt(RATE, 2, NPER, PRINCIPAL, 0, 0), -1248.76), "IPMT(2) ≈ -1248.76");
+  });
+
+  it("has no interest in the first period of an annuity due", () => {
+    assert.equal(computeIpmt(RATE, 1, NPER, PRINCIPAL, 0, 1), 0);
+  });
+});
+
+describe("computePpmt", () => {
+  it("returns the first period's principal, not a wildly wrong value", () => {
+    // PMT - IPMT = -1498.88 - (-1250) = -248.88. The sign bug made this -2748.88.
+    assert.ok(closeTo(computePpmt(RATE, 1, NPER, PRINCIPAL, 0, 0), -248.88), "PPMT(1) ≈ -248.88");
+  });
+});
+
+describe("the interest and principal split reconstitutes the payment", () => {
+  it("IPMT(per) + PPMT(per) == PMT for every period", () => {
+    const pmt = computePmt(RATE, NPER, PRINCIPAL, 0, 0);
+    for (const per of [1, 2, 12, 180, 360]) {
+      const split = computeIpmt(RATE, per, NPER, PRINCIPAL, 0, 0) + computePpmt(RATE, per, NPER, PRINCIPAL, 0, 0);
+      assert.ok(closeTo(split, pmt, 1e-9), `period ${per}: IPMT + PPMT == PMT`);
+    }
+  });
+});
+
+describe("computeFv", () => {
+  it("carries the payment-negative sign the interest split relies on", () => {
+    // Balance outstanding at the start of period 1 is the present value, which
+    // FV expresses as its negative.
+    assert.ok(closeTo(computeFv(RATE, 0, computePmt(RATE, NPER, PRINCIPAL, 0, 0), PRINCIPAL, 0), -PRINCIPAL, 1e-9), "FV of pv over 0 periods = -pv");
+  });
+
+  it("sums a zero-rate stream directly", () => {
+    assert.ok(closeTo(computeFv(0, 10, -100, 0, 0), 1000, 1e-9), "zero-rate FV");
+  });
+});


### PR DESCRIPTION
## Summary
`IPMT(0.005, 1, 360, 250000)` returned `1250` (Excel: `-1250`) and `PPMT` returned `-2748.88` (Excel: `-248.88`). `IPMT` negated `fvHandler`'s balance, which already carries Excel's payment-negative sign, so the interest came back with the wrong sign; `PPMT = PMT - IPMT` amplified it. Fixed the sign in one place by extracting the annuity math into pure helpers.

## Items to Confirm / Review
- **Excel cash-flow sign convention** (money out = negative) is followed throughout; `IPMT(1) = -1250`, `PPMT(1) = -248.88`.
- **FV/PMT numeric results are unchanged** — their formulas were only relocated into the pure `financial-math.ts`; PV/NPER/RATE/NPV/IRR are untouched.
- Test float tolerance: `±0.01` for Excel display values, `1e-9` for the algebraic `IPMT+PPMT==PMT` invariant.

## User Prompt
他もスプシ関係のissueを並列でどんどん進めて — the user asked to work through the open spreadsheet bug issues in parallel, one PR per issue.

## Implementation
- New `engine/financial-math.ts`: pure `computeFv` / `computePmt` / `computeIpmt` / `computePpmt` (number in, number out). The sign fix is `interest = computeFv(...) * rate` (no extra negation).
- `functions/financial.ts`: FV / PMT / IPMT / PPMT handlers now parse args and delegate to the pure helpers, replacing the previous structure that re-invoked handlers with stringified args through the evaluator.
- Tests: `test_financialMath.ts` pins Excel values and the `IPMT(per)+PPMT(per)==PMT` invariant across periods; verified they go red when the sign bug is reintroduced.
- Plan: `plans/fix-2386-ipmt-ppmt.md`.

Fixes #2386