### PR TITLE
fix(spreadsheet): correct SUBSTITUTE/RIGHT/LEFT/PROPER edge cases (#2388)

### DIFF
--- a/plans/fix-2388-text-edges.md
+++ b/plans/fix-2388-text-edges.md
@@ -1,0 +1,30 @@
+# fix #2388 — text 関数の複数のエッジ
+
+`src/plugins/spreadsheet/engine/functions/text.ts` の複数関数が境界入力で Excel と異なる値を静かに返す。
+
+## 対応マトリクス
+
+| サブケース              | 症状（この実装）                                | 根本原因                                   | 修正                                                                  | テスト                                 |
+| ----------------------- | ----------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------- | -------------------------------------- |
+| SUBSTITUTE 空 old_text  | `SUBSTITUTE("abc","","-")` → `"a-b-c"`          | `"".split("")` が全文字間に挿入            | `substituteText`: `oldText === ""` なら text をそのまま返す           | `substituteText — empty old_text`      |
+| SUBSTITUTE instance ≤ 0 | `SUBSTITUTE("aa","a","b",0)` → `"aa"`（無変更） | `count === instance` が 0 に一致せず素通り | `Math.trunc(instance)` が非有限 or ≤ 0 なら `#VALUE!`                 | `substituteText — instance validation` |
+| RIGHT / LEFT 負値       | `RIGHT("Hello",-1)` → `""`                      | `substring` が負値を静かに空文字化         | `takeLeft` / `takeRight`: count < 0 で `#VALUE!`                      | `takeRight` / `takeLeft` describe      |
+| PROPER 句読点境界       | `PROPER("o'neil-jr")` → `"O'neil-jr"`           | 空白のみで単語分割                         | `toProperCase`: 先頭 or 非文字（`\p{L}`）の次を大文字化、他は小文字化 | `toProperCase — word boundaries`       |
+
+## 純粋関数として切り出したもの（text.ts に export）
+
+- `substituteText(text, oldText, newText, instance?)`
+- `takeLeft(text, count)` / `takeRight(text, count)`
+- `toProperCase(text)`
+- 内部: `replaceNthOccurrence`（split/join で非重複マッチ）、`isLetter`（`\p{L}` Unicode 対応）
+
+エラーは既存慣習に合わせて Excel エラー文字列（`"#VALUE!"`）を返す。
+
+## 各サブ修正の RED 確認
+
+各サブ修正を一時的に外し、対応テストが RED になることを確認済み（SUBSTITUTE 空 / instance / RIGHT 負値 / PROPER 境界）。復元後 29 件全通過。
+
+## 見送り（follow-up）
+
+- **TEXT の formatter 委譲**: `TEXT(5,"$0")` `TEXT(1234.5,"$#,##0.00")` は `formatNumber` に委譲すれば正しくなる（`"$5"` `"$1,234.50"`）。だが `TEXT(0.5,"0%")` は `formatNumber` でも `"50.00%"` になり Excel の `"50%"` にならない（`%` ブランチが小数点なし書式で既定 2 桁）。完全修正には共有の `formatNumber` のパーセント既定桁数を変える必要があり、これは `calculator.ts` のセル表示にも使われる共有関数のため e2e / 表示差分リスクがある。issue も「PR を分けてよい」としているため、TEXT は別 PR（formatter.ts 改修 + 回帰テスト付き）に送る。
+- **SEARCH ワイルドカード** (`SEARCH("a?c","abc")`): 本 issue のスコープ外。未対応。

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -6,14 +6,17 @@ import { functionRegistry, toString, type FunctionHandler } from "../registry";
 
 const VALUE_ERROR = "#VALUE!";
 
-const isLetter = (char: string): boolean => /\p{L}/u.test(char);
+// A letter or a combining mark. A decomposed accented letter (e + U+0301) is two
+// code points; counting the mark as part of the word stops PROPER from treating
+// the base letter that follows it as a new word (éclair → Éclair, not ÉClair).
+const isWordCharacter = (char: string): boolean => /[\p{L}\p{M}]/u.test(char);
 
 // Excel PROPER capitalises a letter at the start of the text or after any
 // non-letter (space, punctuation, digit) and lowercases the rest — so word
 // boundaries include "'" and "-", which a space-only split misses.
 export const toProperCase = (text: string): string => {
   const chars = Array.from(text);
-  const cased = chars.map((char, index) => (index === 0 || !isLetter(chars[index - 1]) ? char.toUpperCase() : char.toLowerCase()));
+  const cased = chars.map((char, index) => (index === 0 || !isWordCharacter(chars[index - 1]) ? char.toUpperCase() : char.toLowerCase()));
   return cased.join("");
 };
 

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -19,9 +19,24 @@ export const toProperCase = (text: string): string => {
 
 // Excel LEFT/RIGHT reject a negative count with #VALUE!; 0 and over-length
 // counts keep substring's clamping.
-export const takeLeft = (text: string, count: number): string => (count < 0 ? VALUE_ERROR : text.substring(0, count));
+// Excel truncates a fractional count toward zero and rejects a non-finite or
+// negative one with #VALUE! (LEFT/RIGHT with "x" or -1). Normalising once keeps
+// LEFT and RIGHT consistent instead of each feeding a raw Number() to substring.
+const normalizeCharCount = (count: number): number | string => {
+  // Test the sign before truncating: Math.trunc(-0.5) is -0, which is not < 0.
+  if (!Number.isFinite(count) || count < 0) return VALUE_ERROR;
+  return Math.trunc(count);
+};
 
-export const takeRight = (text: string, count: number): string => (count < 0 ? VALUE_ERROR : text.substring(text.length - count));
+export const takeLeft = (text: string, count: number): string => {
+  const chars = normalizeCharCount(count);
+  return typeof chars === "string" ? chars : text.substring(0, chars);
+};
+
+export const takeRight = (text: string, count: number): string => {
+  const chars = normalizeCharCount(count);
+  return typeof chars === "string" ? chars : text.substring(text.length - chars);
+};
 
 // Replace the nth (1-based) occurrence; split/join keeps matches non-overlapping,
 // matching the replace-all path.

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -4,6 +4,43 @@
 
 import { functionRegistry, toString, type FunctionHandler } from "../registry";
 
+const VALUE_ERROR = "#VALUE!";
+
+const isLetter = (char: string): boolean => /\p{L}/u.test(char);
+
+// Excel PROPER capitalises a letter at the start of the text or after any
+// non-letter (space, punctuation, digit) and lowercases the rest — so word
+// boundaries include "'" and "-", which a space-only split misses.
+export const toProperCase = (text: string): string => {
+  const chars = Array.from(text);
+  const cased = chars.map((char, index) => (index === 0 || !isLetter(chars[index - 1]) ? char.toUpperCase() : char.toLowerCase()));
+  return cased.join("");
+};
+
+// Excel LEFT/RIGHT reject a negative count with #VALUE!; 0 and over-length
+// counts keep substring's clamping.
+export const takeLeft = (text: string, count: number): string => (count < 0 ? VALUE_ERROR : text.substring(0, count));
+
+export const takeRight = (text: string, count: number): string => (count < 0 ? VALUE_ERROR : text.substring(text.length - count));
+
+// Replace the nth (1-based) occurrence; split/join keeps matches non-overlapping,
+// matching the replace-all path.
+const replaceNthOccurrence = (text: string, oldText: string, newText: string, nth: number): string => {
+  const parts = text.split(oldText);
+  if (nth > parts.length - 1) return text;
+  return parts.slice(0, nth).join(oldText) + newText + parts.slice(nth).join(oldText);
+};
+
+// Excel SUBSTITUTE: empty old_text returns the text unchanged (never inserts
+// between characters); a supplied instance ≤ 0 or non-finite is a #VALUE! error.
+export const substituteText = (text: string, oldText: string, newText: string, instance?: number): string => {
+  if (oldText === "") return text;
+  if (instance === undefined) return text.split(oldText).join(newText);
+  const nth = Math.trunc(instance);
+  if (!Number.isFinite(nth) || nth <= 0) return VALUE_ERROR;
+  return replaceNthOccurrence(text, oldText, newText, nth);
+};
+
 const concatenateHandler: FunctionHandler = (args, context) => {
   if (args.length === 0) throw new Error("CONCATENATE requires at least 1 argument");
 
@@ -25,7 +62,7 @@ const leftHandler: FunctionHandler = (args, context) => {
   const text = toString(context.evaluateFormula(args[0]));
   const numChars = args.length === 2 ? Number(context.evaluateFormula(args[1])) : 1;
 
-  return text.substring(0, numChars);
+  return takeLeft(text, numChars);
 };
 
 const rightHandler: FunctionHandler = (args, context) => {
@@ -36,7 +73,7 @@ const rightHandler: FunctionHandler = (args, context) => {
   const text = toString(context.evaluateFormula(args[0]));
   const numChars = args.length === 2 ? Number(context.evaluateFormula(args[1])) : 1;
 
-  return text.substring(text.length - numChars);
+  return takeRight(text, numChars);
 };
 
 const midHandler: FunctionHandler = (args, context) => {
@@ -74,11 +111,7 @@ const properHandler: FunctionHandler = (args, context) => {
   if (args.length !== 1) throw new Error("PROPER requires 1 argument");
 
   const text = toString(context.evaluateFormula(args[0]));
-  return text
-    .toLowerCase()
-    .split(" ")
-    .map((word) => (word.length > 0 ? word[0].toUpperCase() + word.slice(1) : ""))
-    .join(" ");
+  return toProperCase(text);
 };
 
 const trimHandler: FunctionHandler = (args, context) => {
@@ -97,28 +130,9 @@ const substituteHandler: FunctionHandler = (args, context) => {
   const text = toString(context.evaluateFormula(args[0]));
   const oldText = toString(context.evaluateFormula(args[1]));
   const newText = toString(context.evaluateFormula(args[2]));
+  const instance = args.length === 4 ? Number(context.evaluateFormula(args[3])) : undefined;
 
-  if (args.length === 4) {
-    // Replace specific instance
-    const instance = Number(context.evaluateFormula(args[3]));
-    let count = 0;
-    let index = 0;
-
-    while (index < text.length) {
-      const pos = text.indexOf(oldText, index);
-      if (pos === -1) break;
-
-      count++;
-      if (count === instance) {
-        return text.substring(0, pos) + newText + text.substring(pos + oldText.length);
-      }
-      index = pos + 1;
-    }
-    return text; // Instance not found
-  } else {
-    // Replace all instances
-    return text.split(oldText).join(newText);
-  }
+  return substituteText(text, oldText, newText, instance);
 };
 
 const replaceHandler: FunctionHandler = (args, context) => {

--- a/test/plugins/spreadsheet/engine/test_textFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_textFunctions.ts
@@ -1,0 +1,159 @@
+// Edge-case behaviour of the SUBSTITUTE / RIGHT / LEFT / PROPER text functions.
+//
+// Each fix targets a case that fails silently: SUBSTITUTE with an empty
+// old_text inserted the replacement between every character, a non-positive
+// instance was ignored instead of erroring, RIGHT/LEFT turned a negative count
+// into an empty string, and PROPER only broke words on spaces — all returning a
+// plausible-looking string rather than the Excel result or a #VALUE! error.
+//
+// The pure helpers are tested directly; the end-to-end path through
+// SpreadsheetEngine confirms the handlers wire them up.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { substituteText, takeLeft, takeRight, toProperCase } from "../../../../src/plugins/spreadsheet/engine/functions/text.ts";
+import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+const VALUE_ERROR = "#VALUE!";
+
+const engine = new SpreadsheetEngine();
+const evalFormula = (formula: string): unknown => engine.calculate(engine.createSheet("S", [[`=${formula}`]])).data[0][0];
+
+describe("substituteText — empty old_text", () => {
+  it("returns the text unchanged instead of inserting between characters", () => {
+    assert.equal(substituteText("abc", "", "-"), "abc");
+  });
+
+  it("stays unchanged even when an instance is supplied", () => {
+    assert.equal(substituteText("abc", "", "-", 1), "abc");
+  });
+
+  it("stays unchanged for an empty text as well", () => {
+    assert.equal(substituteText("", "", "-"), "");
+  });
+});
+
+describe("substituteText — instance validation", () => {
+  it("errors when the instance is zero", () => {
+    assert.equal(substituteText("aa", "a", "b", 0), VALUE_ERROR);
+  });
+
+  it("errors when the instance is negative", () => {
+    assert.equal(substituteText("aa", "a", "b", -1), VALUE_ERROR);
+  });
+
+  it("errors when the instance is not a finite number", () => {
+    assert.equal(substituteText("aa", "a", "b", NaN), VALUE_ERROR);
+  });
+
+  it("truncates a fractional instance toward zero, so <1 errors", () => {
+    assert.equal(substituteText("aa", "a", "b", 0.9), VALUE_ERROR);
+    assert.equal(substituteText("aaa", "a", "b", 1.9), "baa", "1.9 truncates to the 1st occurrence");
+  });
+});
+
+describe("substituteText — replacing occurrences", () => {
+  it("replaces every occurrence when no instance is given", () => {
+    assert.equal(substituteText("Hello World", "World", "Earth"), "Hello Earth");
+    assert.equal(substituteText("a-b-c", "-", "+"), "a+b+c");
+  });
+
+  it("replaces only the requested 1-based occurrence", () => {
+    assert.equal(substituteText("a-b-c", "-", "+", 1), "a+b-c");
+    assert.equal(substituteText("a-b-c", "-", "+", 2), "a-b+c");
+  });
+
+  it("returns the text unchanged when the instance exceeds the occurrence count", () => {
+    assert.equal(substituteText("a-b-c", "-", "+", 3), "a-b-c");
+  });
+
+  it("keeps matches non-overlapping like the replace-all path", () => {
+    // "aa" occurs once in "aaa" when scanned non-overlapping, so a 2nd instance
+    // does not exist and the text is returned unchanged.
+    assert.equal(substituteText("aaa", "aa", "b", 2), "aaa");
+    assert.equal(substituteText("aaa", "aa", "b", 1), "ba");
+  });
+});
+
+describe("takeRight — negative count is an error", () => {
+  it("errors on a negative count instead of returning an empty string", () => {
+    assert.equal(takeRight("Hello", -1), VALUE_ERROR);
+    assert.equal(takeRight("Hello", -0.5), VALUE_ERROR);
+  });
+
+  it("returns an empty string for a zero count", () => {
+    assert.equal(takeRight("Hello", 0), "");
+  });
+
+  it("returns the whole string when the count exceeds its length", () => {
+    assert.equal(takeRight("Hello", 10), "Hello");
+  });
+
+  it("returns the rightmost characters for a normal count", () => {
+    assert.equal(takeRight("Hello", 2), "lo");
+  });
+
+  it("returns an empty string from an empty text", () => {
+    assert.equal(takeRight("", 3), "");
+  });
+});
+
+describe("takeLeft — negative count is an error", () => {
+  it("errors on a negative count instead of returning an empty string", () => {
+    assert.equal(takeLeft("Hello", -1), VALUE_ERROR);
+  });
+
+  it("returns an empty string for a zero count", () => {
+    assert.equal(takeLeft("Hello", 0), "");
+  });
+
+  it("returns the whole string when the count exceeds its length", () => {
+    assert.equal(takeLeft("Hello", 10), "Hello");
+  });
+
+  it("returns the leftmost characters for a normal count", () => {
+    assert.equal(takeLeft("Hello", 2), "He");
+  });
+});
+
+describe("toProperCase — word boundaries include punctuation", () => {
+  it("capitalises after an apostrophe and a hyphen, not only spaces", () => {
+    assert.equal(toProperCase("o'neil-jr"), "O'Neil-Jr");
+  });
+
+  it("capitalises the first letter of each space-separated word", () => {
+    assert.equal(toProperCase("hello world"), "Hello World");
+  });
+
+  it("lowercases the remaining letters of an all-caps word", () => {
+    assert.equal(toProperCase("HELLO"), "Hello");
+  });
+
+  it("treats a digit as a non-letter boundary", () => {
+    assert.equal(toProperCase("abc2def"), "Abc2Def");
+  });
+
+  it("returns an empty string for empty input", () => {
+    assert.equal(toProperCase(""), "");
+  });
+
+  it("leaves leading punctuation in place and capitalises the first letter", () => {
+    assert.equal(toProperCase("'hello"), "'Hello");
+  });
+});
+
+describe("SpreadsheetEngine — text edge cases end to end", () => {
+  it("evaluates SUBSTITUTE with empty old_text and bad instance", () => {
+    assert.equal(evalFormula('SUBSTITUTE("abc","","-")'), "abc");
+    assert.equal(evalFormula('SUBSTITUTE("aa","a","b",0)'), VALUE_ERROR);
+  });
+
+  it("evaluates RIGHT / LEFT with a negative count as an error", () => {
+    assert.equal(evalFormula('RIGHT("Hello",-1)'), VALUE_ERROR);
+    assert.equal(evalFormula('LEFT("Hello",-1)'), VALUE_ERROR);
+  });
+
+  it("evaluates PROPER across punctuation boundaries", () => {
+    assert.equal(evalFormula('PROPER("o\'neil-jr")'), "O'Neil-Jr");
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_textFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_textFunctions.ts
@@ -93,6 +93,15 @@ describe("takeRight — negative count is an error", () => {
     assert.equal(takeRight("Hello", 2), "lo");
   });
 
+  it("truncates a fractional count toward zero", () => {
+    assert.equal(takeRight("Hello", 2.5), "lo");
+  });
+
+  it("errors on a non-finite count", () => {
+    assert.equal(takeRight("Hello", NaN), VALUE_ERROR);
+    assert.equal(takeRight("Hello", Infinity), VALUE_ERROR);
+  });
+
   it("returns an empty string from an empty text", () => {
     assert.equal(takeRight("", 3), "");
   });
@@ -113,6 +122,11 @@ describe("takeLeft — negative count is an error", () => {
 
   it("returns the leftmost characters for a normal count", () => {
     assert.equal(takeLeft("Hello", 2), "He");
+  });
+
+  it("truncates a fractional count and errors on a non-finite one", () => {
+    assert.equal(takeLeft("Hello", 2.9), "He");
+    assert.equal(takeLeft("Hello", NaN), VALUE_ERROR);
   });
 });
 
@@ -151,6 +165,12 @@ describe("SpreadsheetEngine — text edge cases end to end", () => {
   it("evaluates RIGHT / LEFT with a negative count as an error", () => {
     assert.equal(evalFormula('RIGHT("Hello",-1)'), VALUE_ERROR);
     assert.equal(evalFormula('LEFT("Hello",-1)'), VALUE_ERROR);
+  });
+
+  it("errors on a non-numeric count and truncates a fractional one", () => {
+    assert.equal(evalFormula('LEFT("Hello","x")'), VALUE_ERROR);
+    assert.equal(evalFormula('RIGHT("Hello","x")'), VALUE_ERROR);
+    assert.equal(evalFormula('RIGHT("Hello",2.5)'), "lo");
   });
 
   it("evaluates PROPER across punctuation boundaries", () => {

--- a/test/plugins/spreadsheet/engine/test_textFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_textFunctions.ts
@@ -151,6 +151,13 @@ describe("toProperCase — word boundaries include punctuation", () => {
     assert.equal(toProperCase(""), "");
   });
 
+  // A decomposed accented letter is a base letter + a combining mark; the mark
+  // must not read as a word boundary and capitalize the next letter (#2388).
+  it("keeps a decomposed accented letter as one word", () => {
+    assert.equal(toProperCase("e\u0301clair"), "E\u0301clair", "NFD: e + combining acute");
+    assert.equal(toProperCase("\u00e9clair"), "\u00c9clair", "NFC composed form");
+  });
+
   it("leaves leading punctuation in place and capitalises the first letter", () => {
     assert.equal(toProperCase("'hello"), "'Hello");
   });


### PR DESCRIPTION
## Summary

Fixes four silent edge-case bugs in `src/plugins/spreadsheet/engine/functions/text.ts` where the text functions returned a plausible-looking string instead of the Excel result (or a `#VALUE!` error). Each rule is extracted into a pure, exported helper and pinned with unit tests (29 cases, all passing).

| Function | Input | Before | After (Excel) |
|---|---|---|---|
| SUBSTITUTE | `SUBSTITUTE("abc","","-")` | `"a-b-c"` | `"abc"` |
| SUBSTITUTE | `SUBSTITUTE("aa","a","b",0)` | `"aa"` | `#VALUE!` |
| RIGHT / LEFT | `RIGHT("Hello",-1)` | `""` | `#VALUE!` |
| PROPER | `PROPER("o'neil-jr")` | `"O'neil-jr"` | `"O'Neil-Jr"` |

## Items to Confirm / Review

- **SUBSTITUTE empty `old_text`** returns the text unchanged (never inserts between characters), even when an `instance` is supplied. Excel semantics.
- **SUBSTITUTE `instance`** uses `Math.trunc(instance)`; if non-finite or `<= 0`, returns `#VALUE!`. A fractional value truncates toward zero (so `1.9` hits the 1st occurrence, `0.9` errors). The nth-occurrence replace is non-overlapping (`split`/`join`), matching the replace-all path.
- **RIGHT / LEFT negative count** returns `#VALUE!`. Zero and over-length counts keep the previous `substring` clamping behaviour.
- **PROPER word boundaries** capitalise the first letter and any letter following a non-letter (using `\p{L}`, so `'`, `-`, and digits all break words); the rest is lowercased. Matches Excel.
- **Error convention**: returns Excel error **strings** (`"#VALUE!"`), matching the existing `text.ts` (FIND/SEARCH/VALUE) and `datedif.ts` (`"#NUM!"`) convention. Added a local `VALUE_ERROR` constant.
- **Deferred — TEXT**: not fixed here. Delegating to `formatter.ts`'s `formatNumber` fixes the currency cases (`TEXT(5,"$0")` gives `"$5"`, `TEXT(1234.5,"$#,##0.00")` gives `"$1,234.50"`) but **not** `TEXT(0.5,"0%")`, which `formatNumber` still renders as `"50.00%"` (its `%` branch defaults to 2 decimals when the format has no decimal point). Making it exactly Excel-correct requires changing that default in `formatNumber`, which is **also used for cell display** (`calculator.ts:418`) — a shared-formatter change with display / e2e-snapshot risk. Per the issue ("PR を分けてよい") TEXT gets its own PR with `formatter.ts` changes + regression tests.
- **Deferred — SEARCH wildcards** (`SEARCH("a?c","abc")`): out of scope for this PR; not addressed.

## User Prompt

他もスプシ関係のissueを並列でどんどん進めて — the user asked to work through the open spreadsheet bug issues in parallel, one PR per issue.

## Implementation approach

- Extracted four pure helpers into `text.ts` (exported for direct testing): `substituteText`, `takeLeft`, `takeRight`, `toProperCase` (plus internal `replaceNthOccurrence`, `isLetter`). The registered handlers now just marshal args and delegate.
- Added `test/plugins/spreadsheet/engine/test_textFunctions.ts` (`node:test` + `node:assert/strict`): one `describe` per sub-case covering the repro plus empty / boundary / negative variants, and an end-to-end block driving `SpreadsheetEngine`.
- Verified each sub-fix catches its bug: reverted each fix in turn, confirmed the matching test went RED, then restored (all four confirmed).
- `src/plugins/spreadsheet/engine` is in the project ESLint ignore list, so `text.ts` is not CI-linted; the test file is lint-clean. Prettier applied.

Refs #2388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Excel-compatible behavior for `SUBSTITUTE`, including empty text, occurrence selection, and invalid instance values.
  * Corrected `LEFT` and `RIGHT` handling for negative, zero, and oversized character counts.
  * Improved `PROPER` capitalization around punctuation, apostrophes, hyphens, and numbers.
  * Updated affected formulas to return `#VALUE!` for invalid inputs.

* **Tests**
  * Added coverage for edge cases and formula-level behavior across the updated text functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->