### PR TITLE
refactor(packages): fold small in-package clones (#2412)

### DIFF
--- a/packages/chat-service/src/commands.ts
+++ b/packages/chat-service/src/commands.ts
@@ -5,7 +5,7 @@
 // reset arrive via the factory so this file has zero imports from
 // the host app — only sibling module types.
 
-import type { BridgeSkillSummary, Role, SessionSummary } from "./types.js";
+import type { BridgeSkillSummary, GetSessionHistoryFn, ListSessionsFn, Role, SessionSummary } from "./types.js";
 import type { ChatStateStore, TransportChatState } from "./chat-state.js";
 
 // ── Types ────────────────────────────────────────────────────
@@ -80,14 +80,8 @@ export function createCommandHandler(opts: {
   getRole: (roleId: string) => Role;
   resetChatState: ChatStateStore["resetChatState"];
   connectSession: ChatStateStore["connectSession"];
-  listSessions?: (opts: { limit: number; offset: number }) => Promise<{ sessions: SessionSummary[]; total: number }>;
-  getSessionHistory?: (
-    sessionId: string,
-    opts: { limit: number; offset: number },
-  ) => Promise<{
-    messages: Array<{ source: string; text: string }>;
-    total: number;
-  }>;
+  listSessions?: ListSessionsFn;
+  getSessionHistory?: GetSessionHistoryFn;
   /** Lists the skills the bridge command handler should expose.
    *  Drives both the slash-command allowlist (only matching names
    *  are forwarded to the agent) and the "Skills:" section in the

--- a/packages/chat-service/src/types.ts
+++ b/packages/chat-service/src/types.ts
@@ -94,6 +94,15 @@ export interface SessionSummary {
   updatedAt: string;
 }
 
+/** List recent sessions (paged). Backs the `/sessions` bridge command. */
+export type ListSessionsFn = (opts: { limit: number; offset: number }) => Promise<{ sessions: SessionSummary[]; total: number }>;
+
+/** Recent messages in a session (paged, newest-first). Backs `/history`. */
+export type GetSessionHistoryFn = (
+  sessionId: string,
+  opts: { limit: number; offset: number },
+) => Promise<{ messages: Array<{ source: string; text: string }>; total: number }>;
+
 export interface ChatServiceDeps {
   /** Relay a user turn into the agent loop. */
   startChat: StartChatFn;
@@ -120,18 +129,12 @@ export interface ChatServiceDeps {
    * Omit if session listing is not available (command will reply
    * "not available").
    */
-  listSessions?: (opts: { limit: number; offset: number }) => Promise<{ sessions: SessionSummary[]; total: number }>;
+  listSessions?: ListSessionsFn;
   /**
    * Get recent messages from a session. Used by /history command.
    * Returns newest-first array of {source, text} pairs.
    */
-  getSessionHistory?: (
-    sessionId: string,
-    opts: { limit: number; offset: number },
-  ) => Promise<{
-    messages: Array<{ source: string; text: string }>;
-    total: number;
-  }>;
+  getSessionHistory?: GetSessionHistoryFn;
   /**
    * Resolve the roleId a given session was started with. Used by the HTTP
    * `/connect` route so the persisted bridge state's role tracks the target

--- a/packages/core/src/collection/core/draft.ts
+++ b/packages/core/src/collection/core/draft.ts
@@ -10,36 +10,20 @@ import { COMPUTED_TYPES } from "./schema";
 import type { CollectionFieldSpec as FieldSpec, CollectionFieldType as FieldType, CollectionItem, CollectionSchema } from "./schema";
 import type { EditState, TableRowDraft } from "./uiTypes";
 
-/** A fresh, empty row draft for a `table` field's sub-schema. */
-export function emptyRow(subFields: Record<string, FieldSpec>): TableRowDraft {
+/** Build a row draft, reading each sub-field's persisted value via
+ *  `readSub`. An empty row passes a reader that always returns
+ *  `undefined`; a row-from-item reads the source record. Boolean
+ *  presence uses `typeof raw === "boolean"` so an existing explicit
+ *  `false` is recorded as present and round-trips on a no-op save. */
+function buildTableRowDraft(subFields: Record<string, FieldSpec>, readSub: (subKey: string) => unknown): TableRowDraft {
   const text: Record<string, string> = {};
   const bool: Record<string, boolean> = {};
   const boolOriginallyPresent: Record<string, boolean> = {};
   const boolTouched: Record<string, boolean> = {};
   for (const [subKey, subField] of Object.entries(subFields)) {
-    if (subField.type === "boolean") {
-      bool[subKey] = false;
-      boolOriginallyPresent[subKey] = false; // brand-new row
-      boolTouched[subKey] = false;
-    } else {
-      text[subKey] = "";
-    }
-  }
-  return { text, bool, boolOriginallyPresent, boolTouched };
-}
-
-/** Build a row draft from an existing persisted row. */
-export function rowFromItem(item: Record<string, unknown>, subFields: Record<string, FieldSpec>): TableRowDraft {
-  const text: Record<string, string> = {};
-  const bool: Record<string, boolean> = {};
-  const boolOriginallyPresent: Record<string, boolean> = {};
-  const boolTouched: Record<string, boolean> = {};
-  for (const [subKey, subField] of Object.entries(subFields)) {
-    const raw = item[subKey];
+    const raw = readSub(subKey);
     if (subField.type === "boolean") {
       bool[subKey] = raw === true;
-      // `typeof raw === "boolean"` so an existing explicit `false` is
-      // recorded as present and round-trips on a no-op save.
       boolOriginallyPresent[subKey] = typeof raw === "boolean";
       boolTouched[subKey] = false;
     } else {
@@ -47,6 +31,16 @@ export function rowFromItem(item: Record<string, unknown>, subFields: Record<str
     }
   }
   return { text, bool, boolOriginallyPresent, boolTouched };
+}
+
+/** A fresh, empty row draft for a `table` field's sub-schema. */
+export function emptyRow(subFields: Record<string, FieldSpec>): TableRowDraft {
+  return buildTableRowDraft(subFields, () => undefined);
+}
+
+/** Build a row draft from an existing persisted row. */
+export function rowFromItem(item: Record<string, unknown>, subFields: Record<string, FieldSpec>): TableRowDraft {
+  return buildTableRowDraft(subFields, (subKey) => item[subKey]);
 }
 
 /** Decide whether a boolean field's draft value should be emitted (vs.

--- a/packages/core/src/collection/server/io.ts
+++ b/packages/core/src/collection/server/io.ts
@@ -48,15 +48,20 @@ export async function isRegularFile(filePath: string): Promise<boolean> {
  *  or has a read/parse error. Caller logs the per-entry skip — this
  *  helper just classifies. Split out to keep `listItems` under the
  *  `sonarjs/cognitive-complexity` threshold. */
+/** Parse a record file's text into a plain-object `CollectionItem`, or
+ *  null when it isn't a JSON object (array / scalar / null). */
+function parseRecordJson(raw: string): CollectionItem | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as CollectionItem;
+  }
+  return null;
+}
+
 async function tryReadRecord(filePath: string): Promise<CollectionItem | null> {
   if (!(await isRegularFile(filePath))) return null;
   try {
-    const raw = await readFile(filePath, "utf-8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as CollectionItem;
-    }
-    return null;
+    return parseRecordJson(await readFile(filePath, "utf-8"));
   } catch {
     return null;
   }
@@ -109,12 +114,7 @@ export async function readItem(dataDir: string, itemId: string, opts: IoOptions 
   const filePath = itemFilePath(dataDir, safeId);
   if (!(await isRegularFile(filePath))) return null;
   try {
-    const raw = await readFile(filePath, "utf-8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as CollectionItem;
-    }
-    return null;
+    return parseRecordJson(await readFile(filePath, "utf-8"));
   } catch (err) {
     const error = err as { code?: string };
     if (error.code === "ENOENT") return null;

--- a/packages/core/src/notifier/engine.ts
+++ b/packages/core/src/notifier/engine.ts
@@ -316,28 +316,27 @@ export async function publish<TPluginData = unknown>(input: PublishInput<TPlugin
   return { id: entryId };
 }
 
-export async function clear(entryId: string): Promise<void> {
+/** Remove an active entry and record its terminal history. `clear`
+ *  (user dismissed) and `cancel` (producer withdrew) differ only in the
+ *  emitted event / history reason. No-op when the id is unknown. */
+async function terminateEntry(entryId: string, reason: "cleared" | "cancelled"): Promise<void> {
   await enqueue((state) => {
     const entry = state.entries[entryId];
     if (!entry) return null;
     state.entries = removeEntry(state, entryId);
     return {
-      event: { type: "cleared", id: entryId },
-      historyEntry: buildHistoryEntry(entry, "cleared"),
+      event: reason === "cleared" ? { type: "cleared", id: entryId } : { type: "cancelled", id: entryId },
+      historyEntry: buildHistoryEntry(entry, reason),
     };
   });
 }
 
+export async function clear(entryId: string): Promise<void> {
+  await terminateEntry(entryId, "cleared");
+}
+
 export async function cancel(entryId: string): Promise<void> {
-  await enqueue((state) => {
-    const entry = state.entries[entryId];
-    if (!entry) return null;
-    state.entries = removeEntry(state, entryId);
-    return {
-      event: { type: "cancelled", id: entryId },
-      historyEntry: buildHistoryEntry(entry, "cancelled"),
-    };
-  });
+  await terminateEntry(entryId, "cancelled");
 }
 
 /** In-place update for an active entry. Only the fields present on

--- a/packages/plugins/mulmoscript-plugin/src/core/validate.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/validate.ts
@@ -31,6 +31,19 @@ function formatZodIssues(
   return issues.length > 3 ? `${head} (+${issues.length - 3} more)` : head;
 }
 
+/** Shared prelude: require an object body carrying a non-empty
+ *  `filePath`. On success returns the narrowed record + filePath so the
+ *  caller reads the remaining fields without re-narrowing. */
+function validateFilePathBody(body: unknown): ValidationResult<{ record: Record<string, unknown>; filePath: string }> {
+  if (!isRecord(body)) {
+    return { ok: false, error: "body must be an object" };
+  }
+  if (typeof body.filePath !== "string" || body.filePath === "") {
+    return { ok: false, error: "filePath must be a non-empty string" };
+  }
+  return { ok: true, value: { record: body, filePath: body.filePath } };
+}
+
 /**
  * Validate the `update-script` request body. Returns the parsed,
  * schema-conformant script on success, or a human-readable error
@@ -40,16 +53,13 @@ export function validateUpdateScriptBody(body: unknown): ValidationResult<{
   filePath: string;
   script: unknown;
 }> {
-  if (!isRecord(body)) {
-    return { ok: false, error: "body must be an object" };
-  }
-  if (typeof body.filePath !== "string" || body.filePath === "") {
-    return { ok: false, error: "filePath must be a non-empty string" };
-  }
-  if (body.script === undefined) {
+  const base = validateFilePathBody(body);
+  if (!base.ok) return base;
+  const { record, filePath } = base.value;
+  if (record.script === undefined) {
     return { ok: false, error: "script is required" };
   }
-  const parsed = mulmoScriptSchema.safeParse(body.script);
+  const parsed = mulmoScriptSchema.safeParse(record.script);
   if (!parsed.success) {
     return {
       ok: false,
@@ -58,7 +68,7 @@ export function validateUpdateScriptBody(body: unknown): ValidationResult<{
   }
   return {
     ok: true,
-    value: { filePath: body.filePath as string, script: parsed.data },
+    value: { filePath, script: parsed.data },
   };
 }
 
@@ -72,19 +82,17 @@ export function validateUpdateBeatBody(body: unknown): ValidationResult<{
   beatIndex: number;
   beat: unknown;
 }> {
-  if (!isRecord(body)) {
-    return { ok: false, error: "body must be an object" };
-  }
-  if (typeof body.filePath !== "string" || body.filePath === "") {
-    return { ok: false, error: "filePath must be a non-empty string" };
-  }
-  if (typeof body.beatIndex !== "number" || !Number.isInteger(body.beatIndex) || body.beatIndex < 0) {
+  const base = validateFilePathBody(body);
+  if (!base.ok) return base;
+  const { record, filePath } = base.value;
+  const beatIndex = record.beatIndex;
+  if (typeof beatIndex !== "number" || !Number.isInteger(beatIndex) || beatIndex < 0) {
     return { ok: false, error: "beatIndex must be a non-negative integer" };
   }
-  if (body.beat === undefined) {
+  if (record.beat === undefined) {
     return { ok: false, error: "beat is required" };
   }
-  const parsed = mulmoBeatSchema.safeParse(body.beat);
+  const parsed = mulmoBeatSchema.safeParse(record.beat);
   if (!parsed.success) {
     return {
       ok: false,
@@ -94,8 +102,8 @@ export function validateUpdateBeatBody(body: unknown): ValidationResult<{
   return {
     ok: true,
     value: {
-      filePath: body.filePath as string,
-      beatIndex: body.beatIndex as number,
+      filePath,
+      beatIndex,
       beat: parsed.data,
     },
   };

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -135,6 +135,36 @@ export function buildBeatIdIndex(beats: MulmoBeat[]): Map<string, number> {
   return idToIndex;
 }
 
+// Run `body` with a mulmocast per-beat progress callback registered.
+// `onBeat` receives each beat event's sessionType + resolved index; the
+// caller decides which sessionTypes to forward. The callback is always
+// unregistered, even when `body` throws.
+//
+// Known limitation: addSessionProgressCallback is global, so when two
+// generations for *different* scripts run concurrently, both closures
+// are invoked for every beat event and rely on idToIndex to filter out
+// the other run's events. That filter is reliable only when each beat
+// carries an explicit `id`. Beats without one fall back to
+// "__index__${index}", and identical fallback ids across scripts collide
+// → progress meant for script A surfaces on script B. Fixing this
+// properly needs mulmocast to attach a per-run identifier to its
+// progress events (or a global serialization gate); tracked separately.
+async function withBeatProgress<T>(beats: MulmoBeat[], onBeat: (sessionType: string, beatIndex: number) => void, body: () => Promise<T>): Promise<T> {
+  const idToIndex = buildBeatIdIndex(beats);
+  const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
+    if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
+    const beatIndex = idToIndex.get(event.id);
+    if (beatIndex === undefined) return;
+    onBeat(event.sessionType, beatIndex);
+  };
+  addSessionProgressCallback(onProgress);
+  try {
+    return await body();
+  } finally {
+    removeSessionProgressCallback(onProgress);
+  }
+}
+
 /** Map identity for the in-flight tracker. JSON array keeps the three
  *  fields unambiguous (a human-visible delimiter could collide). */
 function generationMapKey(kind: GenerationKind, filePath: string, key: string): string {
@@ -593,44 +623,28 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     const context = await buildContext(absoluteFilePath);
     if (!context) return { ok: false, error: "Failed to initialize mulmo context" };
 
-    const idToIndex = buildBeatIdIndex(context.studio.script.beats as MulmoBeat[]);
+    return withBeatProgress(
+      context.studio.script.beats as MulmoBeat[],
+      (sessionType, beatIndex) => {
+        if (sessionType !== "image" && sessionType !== "audio") return;
+        onProgressEvent({ kind: sessionType, beatIndex });
+      },
+      async () => {
+        // Order matters: audio() must run before images(). For html_tailwind
+        // beats with `animation: true`, mulmocast only emits the per-beat
+        // `_animated.mp4` when the beat's duration is already known (see
+        // processHtmlTailwindAnimated in mulmocast). Durations are populated
+        // by audio(), so running images() first leaves the .mp4 files
+        // missing and movie() then fails in validateBeatSource.
+        const audioContext = await audio(context);
+        const imagesContext = await images(audioContext);
+        await movie(imagesContext);
 
-    // Known limitation: addSessionProgressCallback is global, so when two
-    // movie generations for *different* scripts run concurrently, both
-    // closures are invoked for every beat event and rely on idToIndex to
-    // filter out the other run's events. That filter is reliable only
-    // when each beat carries an explicit `id`. Beats without one fall
-    // back to "__index__${index}", and identical fallback ids across
-    // scripts collide → progress meant for script A surfaces on script B.
-    // Fixing this properly needs mulmocast to attach a per-run identifier
-    // to its progress events (or a global serialization gate); tracked
-    // separately.
-    const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
-      if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
-      const beatIndex = idToIndex.get(event.id);
-      if (beatIndex === undefined) return;
-      if (event.sessionType !== "image" && event.sessionType !== "audio") return;
-      onProgressEvent({ kind: event.sessionType, beatIndex });
-    };
-
-    addSessionProgressCallback(onProgress);
-    try {
-      // Order matters: audio() must run before images(). For html_tailwind
-      // beats with `animation: true`, mulmocast only emits the per-beat
-      // `_animated.mp4` when the beat's duration is already known (see
-      // processHtmlTailwindAnimated in mulmocast). Durations are populated
-      // by audio(), so running images() first leaves the .mp4 files
-      // missing and movie() then fails in validateBeatSource.
-      const audioContext = await audio(context);
-      const imagesContext = await images(audioContext);
-      await movie(imagesContext);
-
-      const outputPath = movieFilePath(imagesContext);
-      if (!existsSync(outputPath)) return { ok: false, error: "Movie was not generated" };
-      return { ok: true, outputPath };
-    } finally {
-      removeSessionProgressCallback(onProgress);
-    }
+        const outputPath = movieFilePath(imagesContext);
+        if (!existsSync(outputPath)) return { ok: false, error: "Movie was not generated" };
+        return { ok: true, outputPath };
+      },
+    );
   }
 
   /**
@@ -760,24 +774,20 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   }
 
   async function runPdfPipeline(context: StoryContext, onImageBeatDone: (beatIndex: number) => void): Promise<PdfGenerationResult> {
-    const idToIndex = buildBeatIdIndex(context.studio.script.beats as MulmoBeat[]);
-    const onProgress = (event: { kind: string; sessionType: string; id?: string; inSession: boolean }) => {
-      if (event.kind !== "beat" || event.inSession || event.id === undefined) return;
-      const beatIndex = idToIndex.get(event.id);
-      if (beatIndex === undefined) return;
-      if (event.sessionType !== "image") return;
-      onImageBeatDone(beatIndex);
-    };
-    addSessionProgressCallback(onProgress);
-    try {
-      const imagesContext = await images(context);
-      await pdf(imagesContext, PDF_MODE, PDF_SIZE);
-      const outputPath = pdfFilePath(imagesContext, PDF_MODE);
-      if (!existsSync(outputPath)) return { ok: false, error: "PDF was not generated" };
-      return { ok: true, outputPath };
-    } finally {
-      removeSessionProgressCallback(onProgress);
-    }
+    return withBeatProgress(
+      context.studio.script.beats as MulmoBeat[],
+      (sessionType, beatIndex) => {
+        if (sessionType !== "image") return;
+        onImageBeatDone(beatIndex);
+      },
+      async () => {
+        const imagesContext = await images(context);
+        await pdf(imagesContext, PDF_MODE, PDF_SIZE);
+        const outputPath = pdfFilePath(imagesContext, PDF_MODE);
+        if (!existsSync(outputPath)) return { ok: false, error: "PDF was not generated" };
+        return { ok: true, outputPath };
+      },
+    );
   }
 
   /** Long-held foreground PDF generation (the package View's `generatePdf`

--- a/packages/plugins/recipe-book-plugin/src/index.ts
+++ b/packages/plugins/recipe-book-plugin/src/index.ts
@@ -25,29 +25,23 @@ const RECIPES_DIR = "recipes";
 const FRONTMATTER_OPEN = /^---\r?\n/;
 const FRONTMATTER_CLOSE = /(?:^|\r?\n)---\s*(?:\r?\n|$)/;
 
+// Shared field shape for the `save` and `update` members — the two
+// carry an identical record body and differ only in `kind`.
+const recipeWriteFields = {
+  slug: z.string(),
+  title: z.string(),
+  tags: z.array(z.string()).optional(),
+  servings: z.number().int().nonnegative().optional(),
+  prepTime: z.number().int().nonnegative().optional(),
+  cookTime: z.number().int().nonnegative().optional(),
+  body: z.string(),
+};
+
 const Args = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("list") }),
   z.object({ kind: z.literal("read"), slug: z.string() }),
-  z.object({
-    kind: z.literal("save"),
-    slug: z.string(),
-    title: z.string(),
-    tags: z.array(z.string()).optional(),
-    servings: z.number().int().nonnegative().optional(),
-    prepTime: z.number().int().nonnegative().optional(),
-    cookTime: z.number().int().nonnegative().optional(),
-    body: z.string(),
-  }),
-  z.object({
-    kind: z.literal("update"),
-    slug: z.string(),
-    title: z.string(),
-    tags: z.array(z.string()).optional(),
-    servings: z.number().int().nonnegative().optional(),
-    prepTime: z.number().int().nonnegative().optional(),
-    cookTime: z.number().int().nonnegative().optional(),
-    body: z.string(),
-  }),
+  z.object({ kind: z.literal("save"), ...recipeWriteFields }),
+  z.object({ kind: z.literal("update"), ...recipeWriteFields }),
   z.object({ kind: z.literal("delete"), slug: z.string() }),
 ]);
 
@@ -178,6 +172,15 @@ function summarise(recipe: Recipe): RecipeSummary {
   };
 }
 
+type WritableArgsError = { ok: false; error: "invalid_slug"; slug: string } | { ok: false; error: "missing_title" };
+
+/** Slug + title precheck shared by `save` and `update`; null when valid. */
+function validateWritableArgs(args: { slug: string; title: string }): WritableArgsError | null {
+  if (!isValidSlug(args.slug)) return { ok: false, error: "invalid_slug", slug: args.slug };
+  if (args.title.trim().length === 0) return { ok: false, error: "missing_title" };
+  return null;
+}
+
 export default definePlugin(({ pubsub, files, log }) => {
   // Serialise read-modify-write through a per-plugin promise chain so
   // two parallel save / update / delete calls can't race the on-disk
@@ -238,12 +241,8 @@ export default definePlugin(({ pubsub, files, log }) => {
         }
 
         case "save": {
-          if (!isValidSlug(args.slug)) {
-            return { ok: false, error: "invalid_slug", slug: args.slug };
-          }
-          if (args.title.trim().length === 0) {
-            return { ok: false, error: "missing_title" };
-          }
+          const invalid = validateWritableArgs(args);
+          if (invalid) return invalid;
           return withWriteLock(async () => {
             if (await files.data.exists(recipePath(args.slug))) {
               return { ok: false, error: "exists", slug: args.slug };
@@ -268,12 +267,8 @@ export default definePlugin(({ pubsub, files, log }) => {
         }
 
         case "update": {
-          if (!isValidSlug(args.slug)) {
-            return { ok: false, error: "invalid_slug", slug: args.slug };
-          }
-          if (args.title.trim().length === 0) {
-            return { ok: false, error: "missing_title" };
-          }
+          const invalid = validateWritableArgs(args);
+          if (invalid) return invalid;
           return withWriteLock(async () => {
             const existing = await readRecipe(args.slug);
             if (!existing) return { ok: false, error: "not_found", slug: args.slug };

--- a/packages/plugins/spotify-plugin/src/playback.ts
+++ b/packages/plugins/spotify-plugin/src/playback.ts
@@ -63,18 +63,21 @@ export async function playerPrevious(deps: PlaybackDeps, deviceId?: string): Pro
   return mapVoidResult(result);
 }
 
-export async function playerSeek(deps: PlaybackDeps, positionMs: number, deviceId?: string): Promise<Result<null>> {
-  const params = new URLSearchParams({ position_ms: String(positionMs) });
-  const path = appendQueryParam(`/v1/me/player/seek?${params.toString()}`, "device_id", deviceId);
+/** PUT a Player endpoint whose only query is one required param plus an
+ *  optional `device_id` (seek, volume). */
+async function playerPutWithParam(deps: PlaybackDeps, basePath: string, param: Record<string, string>, deviceId?: string): Promise<Result<null>> {
+  const params = new URLSearchParams(param);
+  const path = appendQueryParam(`${basePath}?${params.toString()}`, "device_id", deviceId);
   const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", path, {}, deps.now);
   return mapVoidResult(result);
 }
 
+export async function playerSeek(deps: PlaybackDeps, positionMs: number, deviceId?: string): Promise<Result<null>> {
+  return playerPutWithParam(deps, "/v1/me/player/seek", { position_ms: String(positionMs) }, deviceId);
+}
+
 export async function playerSetVolume(deps: PlaybackDeps, volumePercent: number, deviceId?: string): Promise<Result<null>> {
-  const params = new URLSearchParams({ volume_percent: String(volumePercent) });
-  const path = appendQueryParam(`/v1/me/player/volume?${params.toString()}`, "device_id", deviceId);
-  const result = await spotifyApi(deps.runtime, deps.clientId, deps.tokens, "PUT", path, {}, deps.now);
-  return mapVoidResult(result);
+  return playerPutWithParam(deps, "/v1/me/player/volume", { volume_percent: String(volumePercent) }, deviceId);
 }
 
 export async function playerTransfer(deps: PlaybackDeps, deviceId: string, play: boolean | undefined): Promise<Result<null>> {

--- a/plans/refactor-2412-package-clones-sweep.md
+++ b/plans/refactor-2412-package-clones-sweep.md
@@ -27,12 +27,17 @@ here would muddy the review.
 | 9 | `chat-service/src/{commands,types}.ts` | 80tok | Named `ListSessionsFn` / `GetSessionHistoryFn` type aliases in `types.ts`, reused by `ChatServiceDeps` and `createCommandHandler`'s opts. |
 
 New tests:
-- `test/plugins/mulmoscript/test_validate.ts` — the two body validators were previously **untested**; covers the shared precheck + beatIndex + schema-reject branches.
-- `test/utils/collections/test_draft_rows.ts` — `emptyRow` / `rowFromItem` were not directly covered; locks the boolean-present semantics the refactor threads through `buildTableRowDraft`.
+- `test/utils/collections/test_draft_rows.ts` — `emptyRow` / `rowFromItem` had **no**
+  coverage anywhere; locks the boolean-present semantics the refactor threads through
+  `buildTableRowDraft`, and the `emptyRow == rowFromItem({})` equivalence.
 
 The other refactors are internal helpers already exercised end-to-end by existing
 tests (`test/workspace/collections/test_io.ts`, `test/server/notifier/test_engine.ts`,
-`test/plugins/test_recipe_book_integration.ts`, the spotify handler tests).
+`test/plugins/test_recipe_book_integration.ts`, the spotify handler tests, and — for the
+shared filePath precheck — the already-comprehensive
+`packages/plugins/mulmoscript-plugin/test/test_validate.ts`). No redundant root-level
+validator test was added since that workspace suite already runs in CI and covers every
+precheck branch.
 
 No new **cross-cutting** shared helper is introduced (every extraction is a private,
 in-file helper), so per `docs/shared-utils.md`'s own scope rule ("one plugin's parser

--- a/plans/refactor-2412-package-clones-sweep.md
+++ b/plans/refactor-2412-package-clones-sweep.md
@@ -1,0 +1,78 @@
+# refactor(#2412): sweep of small in-package clones
+
+Issue #2412 is a triage list of small clones (jscpd 50–117 tokens), split into
+**in-package** (same file / same package) and **host↔package** groups. The issue
+says fold the in-package ones unconditionally; the host↔package ones need a
+dependency-direction / intentional-copy judgment first.
+
+This PR takes the **in-package** subset only — the unconditionally-safe category —
+and defers every host↔package item to a follow-up, with a reason recorded per item
+below. Rationale: the in-package dedups involve zero import-direction risk and make
+one cohesive, easily-reviewable PR. The host↔package items each need their own
+direction call (and several are deliberate structural duplicates), so batching them
+here would muddy the review.
+
+## Done (in-package, behavior-preserving)
+
+| # | File | Clone | Change |
+|---|------|-------|--------|
+| 1 | `recipe-book-plugin/src/index.ts` | 32-42↔42-51 (117tok) | Shared Zod field object for the `save` / `update` union members. |
+| 2 | `recipe-book-plugin/src/index.ts` | 240-247↔270-277 (66tok) | Extract `validateWritableArgs` (slug + title precheck) shared by `save` / `update`. |
+| 3 | `mulmoscript-plugin/src/core/validate.ts` | 41-49↔73-81 (57tok) | Extract `validateFilePathBody` (object + non-empty `filePath`) shared by the script / beat validators. Also drops two `body.filePath as string` casts (now narrowed). |
+| 4 | `mulmoscript-plugin/src/server/ops.ts` | 596-612↔763-768 (92tok) | Extract module-level `withBeatProgress(beats, onBeat, body)` — wires the global `addSessionProgressCallback` guard + `idToIndex` filter around the movie / PDF pipeline bodies. |
+| 5 | `spotify-plugin/src/playback.ts` | 68-73↔75-80 (52tok) | Extract `playerPutWithParam` shared by `playerSeek` / `playerSetVolume`. |
+| 6 | `core/src/collection/core/draft.ts` | 14-19↔32-37 (81tok) | Extract `buildTableRowDraft(subFields, readSub)` shared by `emptyRow` / `rowFromItem`. `emptyRow` == `rowFromItem` with an always-`undefined` reader (verified `fieldText(undefined) === ""`). |
+| 7 | `core/src/collection/server/io.ts` | 52-60↔110-118 (68tok) | Extract `parseRecordJson` (parse → object-not-array narrow) shared by `tryReadRecord` / `readItem`. |
+| 8 | `core/src/notifier/engine.ts` | 319-325↔331-337 (55tok) | Extract `terminateEntry(entryId, reason)` shared by `clear` / `cancel`. |
+| 9 | `chat-service/src/{commands,types}.ts` | 80tok | Named `ListSessionsFn` / `GetSessionHistoryFn` type aliases in `types.ts`, reused by `ChatServiceDeps` and `createCommandHandler`'s opts. |
+
+New tests:
+- `test/plugins/mulmoscript/test_validate.ts` — the two body validators were previously **untested**; covers the shared precheck + beatIndex + schema-reject branches.
+- `test/utils/collections/test_draft_rows.ts` — `emptyRow` / `rowFromItem` were not directly covered; locks the boolean-present semantics the refactor threads through `buildTableRowDraft`.
+
+The other refactors are internal helpers already exercised end-to-end by existing
+tests (`test/workspace/collections/test_io.ts`, `test/server/notifier/test_engine.ts`,
+`test/plugins/test_recipe_book_integration.ts`, the spotify handler tests).
+
+No new **cross-cutting** shared helper is introduced (every extraction is a private,
+in-file helper), so per `docs/shared-utils.md`'s own scope rule ("one plugin's parser
+… stays inside that plugin; it doesn't belong here") there is no catalog entry to add.
+
+No package `version` bumped → no dep-range sweep needed.
+
+## Deferred (with reason)
+
+In-package, but skipped in this PR:
+- `core/src/collection/server/io.ts` 151-161↔198-203 (53tok) — `writeItem` / `deleteItem`
+  id+containment preamble. `writeItem` and `deleteItem` return **different** discriminated
+  unions and `writeItem` re-checks containment a second time after `mkdir` with a distinct
+  log message; a shared precheck would have to thread a neutral discriminated result and
+  re-map it per caller, which reads worse than the duplication. Deferred.
+- `spotify-plugin/src/listening.ts`↔`search.ts` (51tok) — the `…Deps` interface + `Result<T>`
+  alias (also in `playback.ts`). Type-only; consolidating means a new shared module + renaming
+  three `Deps` interfaces used across the package. Low value vs. churn. Deferred.
+
+host↔package (all deferred — each needs a direction call; several are intentional):
+- `chat-service/src/types.ts`↔`server/api/routes/agent.ts` (53tok) — `types.ts` is
+  `@package-contract`: its types are **deliberately** structural duplicates so the package
+  keeps no compile link to the host. Not a defect.
+- `x-plugin/src/internal.ts`↔`server/utils/date.ts` (72tok) — plugin↔host; a plugin can't
+  import host `server/`. The `toUtcIsoDate` family (3 copies incl. x-plugin) is already noted
+  in the duplicates table as soft-forced; a real fix means a core home. Out of scope here.
+- `mulmoscript-plugin/src/server/support.ts`↔`server/utils/files/safe.ts` and
+  ↔`x-plugin/src/internal.ts` (91/93tok) — same: host or cross-plugin; needs a core extraction.
+- `client/src/options.ts`↔`server/events/resolveRelayBridgeOptions.ts` (69/60tok) — needs a
+  home judgment; deferred.
+- `core/src/wiki/render.ts`↔`src/utils/markdown/wikiEmbeds.ts` (62tok) — `escapeHtml`, a
+  5-copy family. Fixing one pair without the family is what the duplicates-table guidance warns
+  against; deferred to a dedicated `escapeHtml` sweep.
+- `collection-plugin/src/vue/useStarterTranslations.ts`↔`src/composables/useTranslatedStrings.ts`
+  (97tok) — Vue composables on opposite sides of the host/plugin boundary (plugin can't import
+  host `src/`). The shared core cache (`@mulmoclaude/core/translation/client`) is already used by
+  both; the residue is the Vue wrapper. Deferred.
+- `core/src/scheduler/task-manager.ts`↔`mulmoscript-plugin/src/server/types.ts` (62tok) —
+  type shape; needs a judgment on the right core home. Deferred.
+- `plugins/shared/components/confirm.ts`↔`src/composables/useConfirm.ts` (177/62tok) —
+  `plugins/shared/` has no `package.json` and is imported from nowhere. The issue asks to first
+  decide "scaffold source vs. dead code" and only delete if dead. Deletion is riskier than a
+  fold and needs that determination; deferred out of a clone-fold PR.

--- a/test/utils/collections/test_draft_rows.ts
+++ b/test/utils/collections/test_draft_rows.ts
@@ -1,0 +1,58 @@
+// Unit tests for emptyRow / rowFromItem in @mulmoclaude/core/collection.
+// They share the internal buildTableRowDraft accumulator; these tests pin
+// the boolean-presence semantics (an explicit persisted `false` is
+// "present" and round-trips; an absent boolean is not) and the
+// emptyRow == "read undefined for every sub-field" equivalence.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { emptyRow, rowFromItem, type CollectionFieldSpec as FieldSpec } from "@mulmoclaude/core/collection";
+
+const subFields: Record<string, FieldSpec> = {
+  name: { type: "string", label: "Name" },
+  done: { type: "boolean", label: "Done" },
+};
+
+describe("emptyRow", () => {
+  it("blank text slots and all-false, all-absent boolean slots", () => {
+    assert.deepEqual(emptyRow(subFields), {
+      text: { name: "" },
+      bool: { done: false },
+      boolOriginallyPresent: { done: false },
+      boolTouched: { done: false },
+    });
+  });
+});
+
+describe("rowFromItem", () => {
+  it("reads text and marks a present boolean as originally present", () => {
+    assert.deepEqual(rowFromItem({ name: "Milk", done: true }, subFields), {
+      text: { name: "Milk" },
+      bool: { done: true },
+      boolOriginallyPresent: { done: true },
+      boolTouched: { done: false },
+    });
+  });
+
+  it("treats an explicit persisted `false` as present (round-trips on no-op save)", () => {
+    const row = rowFromItem({ name: "Milk", done: false }, subFields);
+    assert.equal(row.bool.done, false);
+    assert.equal(row.boolOriginallyPresent.done, true);
+  });
+
+  it("treats an absent boolean as not present", () => {
+    const row = rowFromItem({ name: "Milk" }, subFields);
+    assert.equal(row.bool.done, false);
+    assert.equal(row.boolOriginallyPresent.done, false);
+  });
+
+  it("stringifies a non-string scalar via fieldText", () => {
+    const row = rowFromItem({ name: 42 }, subFields);
+    assert.equal(row.text.name, "42");
+  });
+
+  it("equals emptyRow when the source record is empty", () => {
+    assert.deepEqual(rowFromItem({}, subFields), emptyRow(subFields));
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **in-package** subset of the #2412 clone-triage list — the category the
issue says to "fold unconditionally". Every change single-sources a jscpd-flagged clone
and is behavior-preserving; zero import-direction risk (nothing crosses a package
boundary). No spreadsheet code touched. No package `version` bumped, so no dep-range
sweep is required.

**Done (9 clones across 8 files):**

| File | Clone | Change |
|------|-------|--------|
| `recipe-book-plugin/src/index.ts` | 32-42↔42-51 (117tok) | Shared Zod field object for the `save`/`update` union members |
| `recipe-book-plugin/src/index.ts` | 240-247↔270-277 (66tok) | Extract `validateWritableArgs` (slug + title precheck) |
| `mulmoscript-plugin/src/core/validate.ts` | 41-49↔73-81 (57tok) | Extract `validateFilePathBody` prelude; also drops two `body.filePath as string` casts |
| `mulmoscript-plugin/src/server/ops.ts` | 596-612↔763-768 (92tok) | Extract `withBeatProgress(beats, onBeat, body)` |
| `spotify-plugin/src/playback.ts` | 68-73↔75-80 (52tok) | Extract `playerPutWithParam` for seek/volume |
| `core/src/collection/core/draft.ts` | 14-19↔32-37 (81tok) | Extract `buildTableRowDraft` for `emptyRow`/`rowFromItem` |
| `core/src/collection/server/io.ts` | 52-60↔110-118 (68tok) | Extract `parseRecordJson` for `tryReadRecord`/`readItem` |
| `core/src/notifier/engine.ts` | 319-325↔331-337 (55tok) | Extract `terminateEntry` for `clear`/`cancel` |
| `chat-service/src/{commands,types}.ts` | 80tok | Named `ListSessionsFn`/`GetSessionHistoryFn` aliases reused by both |

**Deferred (with reasons — full detail in `plans/refactor-2412-package-clones-sweep.md`):**

- `io.ts` 151-161↔198-203 — `writeItem`/`deleteItem` preamble returns **different**
  discriminated unions + `writeItem` re-checks containment post-`mkdir`; a shared precheck
  would read worse than the duplication.
- `spotify listening.ts↔search.ts` (51tok) — type-only `Deps`/`Result` dup; consolidating
  needs a new module + renaming 3 interfaces. Low value vs. churn.
- **All host↔package items** — each needs a dependency-direction call and several are
  deliberate: `chat-service/types.ts↔agent.ts` is `@package-contract` (structural dup by
  design); `x-plugin`/`mulmoscript support` date+path helpers would be uphill or cross-plugin
  (need a core home); `escapeHtml` (`core/wiki↔wikiEmbeds`) is a 5-copy family better swept
  as one; the translation composables straddle the host/plugin boundary; `plugins/shared/
  confirm.ts` needs a dead-code-vs-scaffold determination before any delete.

## Items to Confirm / Review

- **`notifier terminateEntry`** — the shared helper builds the event via
  `reason === "cleared" ? {type:"cleared"} : {type:"cancelled"}` (a plain `{type: reason}`
  is **not** assignable to the `NotifierEvent` discriminated union). `clear`/`cancel` keep
  their `export async function` signatures. Please confirm the narrowing reads acceptably.
- **`draft buildTableRowDraft`** — `emptyRow` is now `buildTableRowDraft(subFields, () => undefined)`.
  This relies on `fieldText(undefined) === ""` (verified: `fieldTextOrNull(undefined)` → `null`,
  `?? ""`), so the old `text[k] = ""` is preserved exactly. New test pins it.
- **`mulmoscript withBeatProgress`** — moved the "global callback / idToIndex collision"
  known-limitation comment onto the shared helper; the movie pipeline's "audio before images"
  ordering comment stays with its body. Behavior identical (movie forwards image+audio, PDF
  forwards image only — now decided in each caller's `onBeat`).
- **`validate.ts`** — the two `body.filePath as string` / `body.beatIndex as number` casts are
  gone because `validateFilePathBody` narrows `filePath` and `beatIndex` is read from the
  narrowed record; please sanity-check the returned `value` shapes are unchanged.

## User Prompt

Work through the open refactor issues (#2398+) in parallel; for this PR implement GitHub
issue #2412 (a triage list of small in-package and host↔package clones) and open a PR to
`main` without merging. Pick the clearly-safe, self-contained items and clearly defer the
rest with reasons. Do not touch spreadsheet code. Obey the repo dependency-direction rules
(never import uphill or cross-plugin; shared code goes down into core / a leaf lib).

## Approach & decisions

- Scoped this PR to the **in-package** clones only — one cohesive, low-risk review unit — and
  deferred every host↔package item because each needs its own direction judgment (and several
  are intentional structural duplicates). The plan file records the done/deferred decision per
  triage item.
- Every extraction is a **private, in-file helper** (or, for chat-service, a same-package type
  alias). None is a new cross-cutting shared helper, so per `docs/shared-utils.md`'s own scope
  rule there is no catalog entry to add.
- **Tests:** added `test/utils/collections/test_draft_rows.ts` because `emptyRow`/`rowFromItem`
  had no coverage anywhere — it locks the boolean-presence semantics and the
  `emptyRow == rowFromItem({})` equivalence. The mulmoscript validators are already fully
  covered by `packages/plugins/mulmoscript-plugin/test/test_validate.ts` (every precheck
  branch), so no redundant root test was added. Other refactors are regression-guarded by
  existing suites (collection io, notifier engine, recipe-book integration, spotify handlers).
- **Verification:** `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build` all
  pass; affected suites green — core 488, chat-service 107, mulmoscript 116, collection io 111,
  spotify handlers, recipe-book integration, and the new draft-rows test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
