### PR TITLE
refactor(spreadsheet): extract evaluator Excel→JS translation into pure module (#2395)

### DIFF
--- a/plans/refactor-2395-evaluator-translate.md
+++ b/plans/refactor-2395-evaluator-translate.md
@@ -1,0 +1,53 @@
+# refactor(#2395): extract the evaluator's Excel→JS translation into a pure module
+
+## Issue
+
+[#2395](https://github.com/receptron/mulmoclaude/issues/2395) — `evaluator.ts` turns an Excel
+expression into a JS expression and hands it to `new Function`. That translation is pure string
+processing but was inline and untested, and it is where the operator gaps reported in #2359 live
+(`2^3^2` = 512 not 64, `<>` unsupported, the non-overlapping `=`→`==` replace).
+
+## Scope
+
+This is a **behaviour-preserving refactor**. It extracts the operator-translation string transforms
+into a pure, testable module and pins the CURRENT behaviour — including the known-wrong cases — with
+a characterization test suite. It does **not** fix the operator gaps; that belongs to #2359 / #2360
+and shows up later as a visible diff against these pinned tests.
+
+Deliberately out of scope to keep the change minimal and merge-clean against the parallel #2332
+cross-sheet work in `evaluator.ts`: the function-call parenthesis matching and the cell-reference
+substitution logic are left untouched. `renderOperand`, `maskStringLiterals`, `isSafeConcatExpression`,
+`findCellRefs`, `endOfStringLiteral` were already extracted by earlier PRs (#2357 / #2376) and stay put.
+
+## New module — `engine/translateFormula.ts` (pure, no engine/evaluator state)
+
+| Function | Replaces (was inline in `evaluateFormula`) |
+|---|---|
+| `caretToPow(expr)` | `expr.replace(/\^/g, "**")` |
+| `replaceConcatOperator(expr)` | the `&`→`+` char-walk loop (string-literal aware) |
+| `rewriteComparisonEq(expr)` | `expr.replace(/([^<>!])=([^=])/g, "$1==$2")` |
+| `isSafeArithmetic(expr)` | `/^[\d+\-*/(). ]+$/.test(expr)` |
+| `isSafeComparison(expr)` | `/^[\d+\-*/(). <>!=]+$/.test(expr)` |
+
+`replaceConcatOperator` faithfully reproduces the previous loop (backslash-escape aware quote
+tracking) so the `&`-inside-a-literal behaviour is byte-for-byte identical.
+
+## evaluator.ts edits (localized to the translation region of `evaluateFormula`)
+
+- add one import from `./translateFormula`
+- four call-site swaps in the lower half of `evaluateFormula` (`^` rewrite, concat loop, comparison
+  guard + `=` rewrite, arithmetic guard). No change to reference detection / substitution / function
+  replacement — the region #2332 touches.
+
+## Tests — `test/plugins/spreadsheet/engine/test_translateFormula.ts`
+
+Unit tests for every pure function (happy / edge / boundary / empty / invalid), plus end-to-end
+characterization through `SpreadsheetEngine`. Known-wrong behaviours pinned with a `(#2359)` note so a
+later fix is a reviewed flip: `2^3^2`→`2**3**2` (=512), `5=6=7`→`5==6=7`, `5=`→`5=`, `5==6`→`5===6`,
+`=5<>6`→`"5<>6"`. RED-verified: reverting `**`→`*` and dropping the in-literal `&` guard turned 7
+tests red.
+
+## Verification
+
+`yarn format`, `yarn lint` (0 errors), `yarn typecheck` (0 errors), `yarn build`, and the 345
+spreadsheet engine tests — all green. No package version bumped.

--- a/src/plugins/spreadsheet/engine/evaluator.ts
+++ b/src/plugins/spreadsheet/engine/evaluator.ts
@@ -7,6 +7,7 @@
 import { functionRegistry } from "./registry";
 import type { CellValue } from "./types";
 import { parseDate } from "./date-parser";
+import { caretToPow, replaceConcatOperator, rewriteComparisonEq, isSafeArithmetic, isSafeComparison } from "./translateFormula";
 
 /**
  * Evaluation context for formulas
@@ -390,7 +391,7 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
     });
 
     // Replace ^ with ** for exponentiation
-    expr = expr.replace(/\^/g, "**");
+    expr = caretToPow(expr);
 
     // Check if this is a string concatenation expression (contains & and quoted strings)
     const hasStringConcat = expr.includes("&");
@@ -399,34 +400,9 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
     // If it contains string concatenation, handle it specially
     if (hasStringConcat && hasQuotedStrings) {
       try {
-        // Convert & to + for JavaScript string concatenation
-        // We need to be careful to only replace & that are not inside strings
-        let inString = false;
-        let stringChar = "";
-        let result = "";
-
-        for (let index = 0; index < expr.length; index++) {
-          const char = expr[index];
-          const prevChar = index > 0 ? expr[index - 1] : "";
-
-          // Handle string boundaries
-          if ((char === '"' || char === "'") && prevChar !== "\\") {
-            if (!inString) {
-              inString = true;
-              stringChar = char;
-            } else if (char === stringChar) {
-              inString = false;
-              stringChar = "";
-            }
-          }
-
-          // Replace & with + when not in a string
-          if (char === "&" && !inString) {
-            result += "+";
-          } else {
-            result += char;
-          }
-        }
+        // Convert & to + for JavaScript string concatenation, leaving any & that
+        // sits inside a string literal untouched.
+        const result = replaceConcatOperator(expr);
 
         // Validate the STRUCTURE, not the string content: a literal may hold any
         // character, so masking the literals is what lets `=A1&"!"` and escaped
@@ -444,10 +420,10 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
 
     // Safely evaluate comparison expressions (e.g., 5=6, (5)>(6))
     // Allow numbers, comparison operators (=, !=, <, >, <=, >=), parentheses, whitespace
-    if (/^[\d+\-*/(). <>!=]+$/.test(expr)) {
+    if (isSafeComparison(expr)) {
       try {
         // Replace = with == for JavaScript comparison (but not <= or >=)
-        const jsExpr = expr.replace(/([^<>!])=([^=])/g, "$1==$2");
+        const jsExpr = rewriteComparisonEq(expr);
 
         // Use Function constructor which is safer than eval
         // eslint-disable -- sonarjs/code-eval
@@ -460,7 +436,7 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
 
     // Safely evaluate arithmetic expressions using Function constructor instead of eval
     // Allow numbers, operators, parentheses, whitespace, and decimal points
-    if (/^[\d+\-*/(). ]+$/.test(expr)) {
+    if (isSafeArithmetic(expr)) {
       try {
         // Use Function constructor which is safer than eval because:
         // 1. The expression is strictly validated (only numbers and math operators)

--- a/src/plugins/spreadsheet/engine/index.ts
+++ b/src/plugins/spreadsheet/engine/index.ts
@@ -12,6 +12,7 @@ export * from "./parser";
 export * from "./date-locale";
 export * from "./datedif";
 export * from "./formatter";
+export * from "./translateFormula";
 export * from "./evaluator";
 export * from "./calculator";
 export * from "./formulaRefs";

--- a/src/plugins/spreadsheet/engine/translateFormula.ts
+++ b/src/plugins/spreadsheet/engine/translateFormula.ts
@@ -1,0 +1,69 @@
+/**
+ * Excel-formula → JS-expression translation
+ *
+ * Pure string transforms that turn the Excel-operator form of an
+ * already-substituted expression (cell references resolved, functions replaced)
+ * into the JavaScript form handed to `new Function`, plus the character
+ * allowlists that gate that evaluation. No engine or evaluator state is
+ * captured — every function here is input → output only.
+ */
+
+/** Excel `^` exponentiation → JS `**`.
+ *
+ * Excel's `^` is left-associative (`2^3^2` = `(2^3)^2` = 64); JS `**` is
+ * right-associative (`2**3**2` = `2**(3**2)` = 512). This transform does not
+ * bridge that difference, so a chained `^` still evaluates the JS way — a known
+ * limitation tracked separately (#2359), pinned by the tests. */
+export function caretToPow(expr: string): string {
+  return expr.replace(/\^/g, "**");
+}
+
+/** Move the "inside a string literal" marker across one quote character.
+ * Empty marker means "not in a literal"; otherwise it holds the opening quote. */
+function toggleQuote(openQuote: string, char: string): string {
+  if (openQuote === "") return char;
+  return char === openQuote ? "" : openQuote;
+}
+
+/** Excel `&` string concatenation → JS `+`, leaving any `&` inside a quoted
+ *  string literal untouched. A quote toggles the "inside a literal" state only
+ *  when it is not backslash-escaped. */
+export function replaceConcatOperator(expr: string): string {
+  const out: string[] = [];
+  let openQuote = "";
+  for (let index = 0; index < expr.length; index++) {
+    const char = expr[index];
+    const escaped = index > 0 && expr[index - 1] === "\\";
+    if (!escaped && (char === '"' || char === "'")) {
+      openQuote = toggleQuote(openQuote, char);
+    }
+    out.push(char === "&" && openQuote === "" ? "+" : char);
+  }
+  return out.join("");
+}
+
+/** Excel `=` equality → JS `==`, without disturbing `<=`, `>=` or `!=`. A single
+ *  `=` is rewritten only when flanked by a non-`<>!` char on the left and a
+ *  non-`=` on the right.
+ *
+ * Known limitations, pinned by the tests and tracked separately (#2359): the
+ * match consumes both flanking characters so replacements do not overlap
+ * (`5=6=7` → `5==6=7`, only the first rewritten); a `=` at either end of the
+ * expression has no left/right neighbour and is left alone (`5=` → `5=`); and a
+ * hand-typed `==` becomes `===` (its second `=` matches). Excel never emits the
+ * last two, so they only bite malformed input. */
+export function rewriteComparisonEq(expr: string): string {
+  return expr.replace(/([^<>!])=([^=])/g, "$1==$2");
+}
+
+/** Whether an expression contains only the characters an arithmetic evaluation
+ *  may see: digits, ` + - * / ( ) . ` and spaces. Gates `new Function`. */
+export function isSafeArithmetic(expr: string): boolean {
+  return /^[\d+\-*/(). ]+$/.test(expr);
+}
+
+/** Whether an expression contains only the characters a comparison evaluation
+ *  may see: the arithmetic set plus ` < > ! = `. Gates `new Function`. */
+export function isSafeComparison(expr: string): boolean {
+  return /^[\d+\-*/(). <>!=]+$/.test(expr);
+}

--- a/test/plugins/spreadsheet/engine/test_translateFormula.ts
+++ b/test/plugins/spreadsheet/engine/test_translateFormula.ts
@@ -1,0 +1,197 @@
+// Excel-formula → JS-expression translation. These are the pure string
+// transforms the evaluator runs on an already-substituted expression before
+// handing it to `new Function`. They failed silently in the worst way: a
+// mistranslated operator produces a plausible wrong NUMBER (`=2^3^2` = 512, not
+// 64) or a valid formula returned as raw text (`=5<>6` = "5<>6"). This suite
+// PINS the current behaviour — including the known-wrong cases (#2359) that a
+// later fix will deliberately flip — so that flip is a visible, reviewed change.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  caretToPow,
+  replaceConcatOperator,
+  rewriteComparisonEq,
+  isSafeArithmetic,
+  isSafeComparison,
+  SpreadsheetEngine,
+  type SheetData,
+} from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+describe("caretToPow", () => {
+  it("rewrites a single caret to the JS exponentiation operator", () => {
+    assert.equal(caretToPow("2^3"), "2**3");
+  });
+
+  it("rewrites every caret in the expression", () => {
+    assert.equal(caretToPow("2^3+4^5"), "2**3+4**5");
+    assert.equal(caretToPow("A^B^C"), "A**B**C");
+  });
+
+  // Excel's `^` is LEFT-associative (`2^3^2` = `(2^3)^2` = 64); JS `**` is
+  // RIGHT-associative (`2**3**2` = `2**(3**2)` = 512). This transform is a plain
+  // substitution and does NOT bridge that difference — a chained caret keeps
+  // producing the JS answer. Pinned as a known limitation (#2359).
+  it("does not correct the left-vs-right associativity of chained carets", () => {
+    assert.equal(caretToPow("2^3^2"), "2**3**2");
+    assert.equal(new Function("return (2**3**2)")(), 512, "JS is right-associative, so 512 not 64");
+  });
+
+  it("leaves an expression with no caret unchanged", () => {
+    assert.equal(caretToPow("2+3*4"), "2+3*4");
+    assert.equal(caretToPow(""), "");
+  });
+});
+
+describe("replaceConcatOperator", () => {
+  it("rewrites a concatenation ampersand to +", () => {
+    assert.equal(replaceConcatOperator('"a"&"b"'), '"a"+"b"');
+    assert.equal(replaceConcatOperator("5&6"), "5+6");
+  });
+
+  it("rewrites every ampersand outside string literals", () => {
+    assert.equal(replaceConcatOperator('"a"&"b"&"c"'), '"a"+"b"+"c"');
+  });
+
+  // An ampersand INSIDE a literal is text, not an operator — flipping it would
+  // corrupt the string content.
+  it("preserves an ampersand inside a double-quoted literal", () => {
+    assert.equal(replaceConcatOperator('"a&b"&"c"'), '"a&b"+"c"');
+  });
+
+  it("preserves an ampersand inside a single-quoted literal", () => {
+    assert.equal(replaceConcatOperator("'a&b'&'c'"), "'a&b'+'c'");
+  });
+
+  // A backslash-escaped quote does not end the literal, so an ampersand after it
+  // is still inside the string and must be preserved.
+  it("honours a backslash-escaped quote when tracking literal boundaries", () => {
+    assert.equal(replaceConcatOperator('"a\\"&b"&"c"'), '"a\\"&b"+"c"');
+  });
+
+  it("leaves an expression with no ampersand unchanged", () => {
+    assert.equal(replaceConcatOperator("2+3"), "2+3");
+    assert.equal(replaceConcatOperator('"plain"'), '"plain"');
+    assert.equal(replaceConcatOperator(""), "");
+  });
+
+  it("rewrites a leading or trailing ampersand outside a literal", () => {
+    assert.equal(replaceConcatOperator('&"x"'), '+"x"');
+    assert.equal(replaceConcatOperator('"x"&'), '"x"+');
+  });
+});
+
+describe("rewriteComparisonEq", () => {
+  it("rewrites a single equality to the JS == operator", () => {
+    assert.equal(rewriteComparisonEq("5=5"), "5==5");
+    assert.equal(rewriteComparisonEq("5=6"), "5==6");
+  });
+
+  it("does not disturb <=, >= or != which are already valid JS", () => {
+    assert.equal(rewriteComparisonEq("5<=6"), "5<=6");
+    assert.equal(rewriteComparisonEq("5>=6"), "5>=6");
+    assert.equal(rewriteComparisonEq("5!=6"), "5!=6");
+  });
+
+  // The regex matches the SECOND `=` of a `==` (its left neighbour, the first
+  // `=`, is not one of `<>!`), so an already-doubled `==` becomes `===`. Excel
+  // never emits `==`, so this only bites a hand-typed oddity — pinned as a known
+  // quirk (#2359) rather than relied upon.
+  it("turns an already-doubled == into === (known quirk)", () => {
+    assert.equal(rewriteComparisonEq("5==6"), "5===6");
+  });
+
+  // The match consumes both flanking characters, so replacements cannot overlap:
+  // in `5=6=7` only the first `=` is rewritten. Pinned as a known limitation
+  // (#2359) — the non-overlapping replacement is a real bug to be fixed later.
+  it("rewrites only the first of two adjacent equalities (non-overlapping)", () => {
+    assert.equal(rewriteComparisonEq("5=6=7"), "5==6=7");
+  });
+
+  // A `=` with nothing on one side has no flanking character to match, so it is
+  // left as a lone `=`. Pinned known limitation (#2359).
+  it("does not rewrite an = at the start or end of the expression", () => {
+    assert.equal(rewriteComparisonEq("=5"), "=5");
+    assert.equal(rewriteComparisonEq("5="), "5=");
+  });
+
+  it("leaves an expression with no equals unchanged", () => {
+    assert.equal(rewriteComparisonEq("5<6"), "5<6");
+    assert.equal(rewriteComparisonEq(""), "");
+  });
+});
+
+describe("isSafeArithmetic", () => {
+  it("accepts digits, arithmetic operators, parentheses, dot and space", () => {
+    assert.equal(isSafeArithmetic("2+3*4"), true);
+    assert.equal(isSafeArithmetic("(2 + 3) / 4.5"), true);
+    assert.equal(isSafeArithmetic("2**3"), true, "** survives the caret rewrite and must pass");
+  });
+
+  it("rejects letters, quotes, ampersands and comparison characters", () => {
+    assert.equal(isSafeArithmetic("A1+2"), false);
+    assert.equal(isSafeArithmetic('"a"+"b"'), false);
+    assert.equal(isSafeArithmetic("5&6"), false);
+    assert.equal(isSafeArithmetic("5<6"), false);
+    assert.equal(isSafeArithmetic("5=6"), false);
+  });
+
+  // The allowlist requires at least one character, so the empty string is not
+  // "safe" — there is nothing to evaluate.
+  it("rejects the empty string", () => {
+    assert.equal(isSafeArithmetic(""), false);
+  });
+});
+
+describe("isSafeComparison", () => {
+  it("accepts the arithmetic set plus < > ! =", () => {
+    assert.equal(isSafeComparison("5<=6"), true);
+    assert.equal(isSafeComparison("5<>6"), true, "the raw Excel <> passes the gate even though JS rejects it");
+    assert.equal(isSafeComparison("(2**3) >= 6"), true);
+  });
+
+  it("rejects letters, quotes and ampersands", () => {
+    assert.equal(isSafeComparison("A1<6"), false);
+    assert.equal(isSafeComparison('"a"="b"'), false);
+    assert.equal(isSafeComparison("5&6"), false);
+  });
+
+  it("rejects the empty string", () => {
+    assert.equal(isSafeComparison(""), false);
+  });
+});
+
+// End-to-end characterization: the pure functions compose inside the evaluator
+// to the exact behaviour observed before the extraction. Includes the
+// intentionally-wrong cases so the eventual #2359 fix shows up as a diff here.
+describe("translation through the engine (characterization)", () => {
+  const calc = (formula: string): unknown => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
+
+  it("exponentiates (and keeps the JS-associativity quirk)", () => {
+    assert.equal(calc("=2^3"), 8);
+    assert.equal(calc("=2^3^2"), 512);
+  });
+
+  it("evaluates equality and the ordering comparisons", () => {
+    assert.equal(calc("=5=5"), true);
+    assert.equal(calc("=5=6"), false);
+    assert.equal(calc("=5<=6"), true);
+    assert.equal(calc("=5>=6"), false);
+  });
+
+  // `<>` is Excel's not-equal; it is not translated, so it reaches `new Function`
+  // as invalid JS, throws, and the raw formula text comes back. Pinned (#2359).
+  it("returns the raw text for the untranslated <> operator", () => {
+    assert.equal(calc("=5<>6"), "5<>6");
+  });
+
+  it("concatenates strings and mixed operands", () => {
+    assert.equal(calc('="a"&"b"'), "ab");
+    assert.equal(calc('="x"&5'), "x5");
+  });
+
+  it("evaluates plain arithmetic", () => {
+    assert.equal(calc("=2*3+1"), 7);
+    assert.equal(calc("=(2+3)*4"), 20);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the Excel-formula→JS-expression **operator translation** out of `evaluateFormula` (in `src/plugins/spreadsheet/engine/evaluator.ts`) into a new pure, exported module `engine/translateFormula.ts`, and adds a thorough characterization test suite. **Behaviour is identical** — this is a refactor + tests, not a fix.

New pure functions (no engine/evaluator state captured — input → output only):

| Function | Was (inline in `evaluateFormula`) |
|---|---|
| `caretToPow(expr)` | `expr.replace(/\^/g, "**")` |
| `replaceConcatOperator(expr)` | the `&`→`+` literal-aware char-walk loop |
| `rewriteComparisonEq(expr)` | `expr.replace(/([^<>!])=([^=])/g, "$1==$2")` |
| `isSafeArithmetic(expr)` | `/^[\d+\-*/(). ]+$/.test(expr)` |
| `isSafeComparison(expr)` | `/^[\d+\-*/(). <>!=]+$/.test(expr)` |

The tests **pin the current behaviour**, including the known-wrong Excel-isms from #2359, each marked with a `(#2359)` note so the eventual fix shows up as a reviewed diff:

- `2^3^2` → `2**3**2` (= 512; Excel left-assoc would be 64)
- `=5<>6` → raw text `"5<>6"` (`<>` untranslated)
- `5=6=7` → `5==6=7` (non-overlapping `=`→`==` replace)
- `5=` / `=5` → unchanged (a `=` at either end has no neighbour to match)
- `5==6` → `5===6` (the regex matches the second `=`)

## Items to Confirm / Review

- **Behaviour-preserving scope.** I intentionally did **not** fix any operator gap — that is #2359 / #2360. Confirm this refactor-only framing matches the intent of #2395.
- **`replaceConcatOperator` fidelity.** It reproduces the old loop's backslash-escape-aware quote tracking exactly (verified by test); please sanity-check the `toggleQuote` helper against the original inline logic.
- **Merge-conflict awareness (#2332).** My `evaluator.ts` edits are confined to the **translation region** of `evaluateFormula` (the `^`/`&`/`=`/arithmetic tail) plus one import line. I did **not** touch reference detection (`findCellRefs`), the substitution loop, or function-call replacement — the area the parallel #2332 cross-sheet fix modifies. Exact touch points below.
- **Left-behind extractions.** `renderOperand`, `maskStringLiterals`, `isSafeConcatExpression`, `findCellRefs`, `endOfStringLiteral` were already extracted by #2357 / #2376 and stay in `evaluator.ts` to minimize churn.

### evaluator.ts touch points (for #2332 merge)
- +1 import line (`./translateFormula`)
- Inside `evaluateFormula`, lower/tail region only:
  - `^`→`**`: `caretToPow(expr)`
  - concat `&`→`+`: replaced ~25-line inline loop with `replaceConcatOperator(expr)`
  - comparison branch: `isSafeComparison(expr)` guard + `rewriteComparisonEq(expr)`
  - arithmetic branch: `isSafeArithmetic(expr)` guard

### Dual-copy note
`packages/mulmoclaude/src/plugins/spreadsheet/...` is a **gitignored build artifact** regenerated by `packages/mulmoclaude/bin/prepare-dist.js` at pack time (verified via `git check-ignore`). The canonical source is `src/`; only it was edited. No manual sync needed.

## User Prompt

Working the "B group" of spreadsheet issues (lookup / evaluator / cross-sheet) in parallel with another session. This PR implements **#2395**: make the evaluator's Excel-formula→JS-formula translation a pure function in its own file and add tests, staying strictly within #2395's scope and keeping the `evaluator.ts` change minimal/localized so it merges cleanly against the parallel #2332 work. Determine the canonical copy vs the `packages/mulmoclaude` dual copy and keep them consistent. Do not fix the operator gaps themselves (that is #2359 / #2360).

## Approach & decisions

1. **Branch** from latest `origin/main` (parallel spreadsheet session merging).
2. **Extract** only the operator-translation transforms — the genuinely pure, self-contained string ops — into `engine/translateFormula.ts`, re-exported via `engine/index.ts`.
3. **Repoint** the four inline sites in `evaluateFormula` to the new functions; no other logic moved.
4. **Characterize**: unit tests per function (happy / edge / boundary / empty / invalid) plus end-to-end tests through `SpreadsheetEngine`, pinning current (incl. wrong) behaviour.
5. **RED-verified** the suite: reverting `**`→`*` in `caretToPow` and dropping the in-literal `&` guard turned 7 tests red; restored → 28 green.

### Verification
`yarn format`, `yarn lint` (0 errors), `yarn typecheck` (0 errors), `yarn build`, and the 345 spreadsheet engine tests — all green. No package version bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)