### PR TITLE
fix(spreadsheet): resolve cross-sheet date references to raw values (#2332)

### DIFF
--- a/plans/fix-2332-cross-sheet-date.md
+++ b/plans/fix-2332-cross-sheet-date.md
@@ -1,0 +1,69 @@
+# fix(#2332): cross-sheet reference breaks date cells
+
+## Symptom
+
+Referencing a date cell on another sheet does not resolve it as a date.
+
+```
+Data!A1 = "03/04/2025"
+Summary = [ "=DAY(Data!A1)", "=Data!A1" ]
+
+actual:   [2, 3]
+expected: [4, "03/04/2025"]   (same as the identical same-sheet formula)
+```
+
+`=Data!A1` returns `3` — `parseFloat("03/04/2025")` reads only the leading `03`.
+`=DAY(Data!A1)` returns `2` because serial `3` is 1900-01-02.
+
+Same-sheet is correct: `A1="03/04/2025"`, `=DAY(A1)` → `4`, `=A1` → `"03/04/2025"`.
+
+## Root cause
+
+`calculateSheet` runs a **final display-formatting pass** (calculator.ts, the second
+row/col loop) that turns date **serial numbers** into **display strings**
+(`45720` → `"03/04/2025"`) for any cell carrying a date format code `f`.
+
+- **Same-sheet** references read the current sheet's `calculated` array *during* the
+  main evaluation loop, i.e. **before** that formatting pass runs, so they see the raw
+  serial `45720`.
+- **Cross-sheet** references resolve the target sheet by recursively calling
+  `calculateSheet(...)` and reading `.data` — the **fully formatted** output. The date
+  cell is now the string `"03/04/2025"`, which `getRawValue` feeds to `parseFloat` → `3`.
+
+So cross-sheet consumes a *presentation* value as *data*. Currency/percentage/comma
+formats survive by luck (`getRawValue` strips `$ , %`); dates have no such recovery.
+Formula-produced dates on the target sheet hit the same bug via auto-date-format.
+
+## Fix
+
+Cross-sheet target computation must return the **raw calculated values**, not the
+display-formatted ones — making cross-sheet consistent with same-sheet.
+
+- Add an internal `skipFormatting?: boolean` to `CalculateOptions`.
+- Extract the per-cell display-formatting decision into a pure, tested function
+  `formatCellForDisplay(originalCell, calculatedValue, preferDDMMYYYY)` and its
+  date-serial predicate `isLikelyDateSerial(value)`.
+- Guard the final formatting pass with `skipFormatting`.
+- Pass `skipFormatting: true` in the two cross-sheet recursive `calculateSheet` calls
+  (`getCellValue`, `collectRangeValues`).
+
+The consuming formula cell (`=Data!A1`) still auto-date-formats its own numeric result,
+so the final displayed output matches same-sheet exactly (`"03/04/2025"`).
+
+Same-sheet behaviour is untouched (it never used the formatted target output).
+
+## Tests
+
+- Regression (via `SpreadsheetEngine`): `=DAY(Data!A1)` → `4`, `=Data!A1` equals the
+  identical same-sheet formula; must go red without the fix.
+- Boundary cross-sheet reads: date, number, string, empty cell, and a
+  formula-producing cell on the source sheet.
+- Unit tests for `isLikelyDateSerial` / `formatCellForDisplay` (date, number, string,
+  empty, formula, no-format).
+
+## Notes
+
+- Only one copy of the engine exists (`src/plugins/spreadsheet/engine/`). No
+  `packages/mulmoclaude/**` mirror is present in the tree — nothing to keep in sync.
+- Change is localized to `calculator.ts` + `types.ts` (+ a small pure helper file).
+  Does not touch `evaluator.ts` or `functions/lookup.ts` (owned by parallel sessions).

--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -4,7 +4,7 @@
  * Core calculation engine with circular reference detection and cross-sheet support
  */
 
-import { formatNumber } from "./formatter";
+import { formatCellForDisplay } from "./cellFormatting";
 import { columnToIndex } from "./parser";
 import { evaluateFormula as evaluateFormulaFn } from "./evaluator";
 import { expandRangeOrCell } from "./formulaRefs";
@@ -96,6 +96,12 @@ function preprocessDates(data: SpreadsheetCell[][], preferDDMMYYYY: boolean): Sp
   );
 }
 
+// `skipFormatting` is internal, not a public knob: a cross-sheet reference
+// computes its target sheet only to READ values, so the display-formatting pass
+// is skipped there — a date must stay a serial, not become "03/04/2025" that a
+// downstream parseFloat reads as 3 (issue #2332).
+type SheetCalculateOptions = CalculateOptions & { skipFormatting?: boolean };
+
 /**
  * Calculate formulas in a single sheet
  *
@@ -103,8 +109,9 @@ function preprocessDates(data: SpreadsheetCell[][], preferDDMMYYYY: boolean): Sp
  * @param allSheets - All sheets for cross-sheet references
  * @returns Calculated sheet with formulas evaluated
  */
-export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], options: CalculateOptions = {}): CalculatedSheet {
+export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], options: SheetCalculateOptions = {}): CalculatedSheet {
   const preferDDMMYYYY = options.preferDDMMYYYY ?? false;
+  const skipFormatting = options.skipFormatting ?? false;
   // Normalize malformed data structures first
   const normalizedData = normalizeData(sheet.data);
 
@@ -259,8 +266,9 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
           const targetCalculated = targetSheet.data.map((row) => [...row]);
           sheetsCache.set(targetSheetName, targetCalculated);
 
-          // Recursively calculate the target sheet
-          const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY });
+          // Resolve cross-sheet values RAW (skip display formatting) so a date
+          // cell reads as its serial, not the presentation string "03/04/2025".
+          const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY, skipFormatting: true });
           sheetsCache.set(targetSheetName, targetResult.data);
           sheetData = targetResult.data as any[][];
         } else {
@@ -308,8 +316,9 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
           const targetCalculated = targetSheet.data.map((row) => [...row]);
           sheetsCache.set(targetSheetName, targetCalculated);
 
-          // Recursively calculate the target sheet
-          const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY });
+          // Resolve cross-sheet values RAW (skip display formatting) so a date
+          // cell reads as its serial, not the presentation string "03/04/2025".
+          const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY, skipFormatting: true });
           sheetsCache.set(targetSheetName, targetResult.data);
           sheetData = targetResult.data as any[][];
         } else {
@@ -404,35 +413,13 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
     }
   }
 
-  // Final formatting pass: apply formatting to all cells with format codes
-  for (let rowIdx = 0; rowIdx < data.length; rowIdx++) {
-    for (let colIdx = 0; colIdx < data[rowIdx].length; colIdx++) {
-      const originalCell = data[rowIdx][colIdx];
-      const calculatedValue = calculated[rowIdx][colIdx];
-
-      if (isObj(originalCell) && "v" in originalCell) {
-        const isFormula = typeof originalCell.v === "string" && originalCell.v.startsWith("=");
-
-        // Apply formatting if cell has a format code and calculated value is a number
-        if ("f" in originalCell && originalCell.f && typeof calculatedValue === "number") {
-          calculated[rowIdx][colIdx] = formatNumber(calculatedValue, originalCell.f);
-        }
-        // Auto-format date serial numbers from formulas without explicit format
-        else if (
-          isFormula &&
-          typeof calculatedValue === "number" &&
-          calculatedValue >= 36000 &&
-          calculatedValue <= 63499 &&
-          Number.isInteger(calculatedValue) &&
-          (!("f" in originalCell) || !originalCell.f)
-        ) {
-          // Check if this looks like a date serial number
-          // 36000 = Jul 1998, 63499 = Dec 2073
-          // Must be integer (dates without time component)
-          // Avoids formatting calculated averages/sums as dates
-          // Apply default date format
-          calculated[rowIdx][colIdx] = formatNumber(calculatedValue, preferDDMMYYYY ? "DD/MM/YYYY" : "MM/DD/YYYY");
-        }
+  // Final display-formatting pass: turn raw serials into presentation strings.
+  // Skipped when this sheet is computed only to resolve a cross-sheet reference,
+  // so the referencing cell reads the underlying value, not a display string.
+  if (!skipFormatting) {
+    for (let rowIdx = 0; rowIdx < data.length; rowIdx++) {
+      for (let colIdx = 0; colIdx < data[rowIdx].length; colIdx++) {
+        calculated[rowIdx][colIdx] = formatCellForDisplay(data[rowIdx][colIdx], calculated[rowIdx][colIdx], preferDDMMYYYY);
       }
     }
   }

--- a/src/plugins/spreadsheet/engine/cellFormatting.ts
+++ b/src/plugins/spreadsheet/engine/cellFormatting.ts
@@ -1,0 +1,51 @@
+/**
+ * Cell display formatting
+ *
+ * Turns a cell's raw calculated value into its display value (currency,
+ * percentage, date, ...). Pure — no engine state — so cross-sheet reference
+ * resolution can deliberately SKIP it and keep raw serial numbers, while the
+ * final output pass applies it for presentation.
+ */
+
+import { formatNumber } from "./formatter";
+import { isRecord } from "../../../utils/types";
+import type { CellValue, SpreadsheetCell } from "./types";
+
+// Integer serials the engine is willing to auto-format as dates without an
+// explicit format code: ~Jul 1998 (36000) through ~Dec 2073 (63499). Narrow on
+// purpose so ordinary sums/averages are not mistaken for dates.
+const DATE_SERIAL_MIN = 36000;
+const DATE_SERIAL_MAX = 63499;
+
+const isSpreadsheetCell = (value: unknown): value is SpreadsheetCell => isRecord(value) && "v" in value;
+
+/** An integer within the date-serial window — a calculated number the engine
+ *  should display as a date when the cell carries no explicit format. */
+export const isLikelyDateSerial = (value: CellValue): boolean =>
+  typeof value === "number" && Number.isInteger(value) && value >= DATE_SERIAL_MIN && value <= DATE_SERIAL_MAX;
+
+/**
+ * Resolve the display value of one cell from its original definition and its
+ * calculated value.
+ *
+ * - Explicit format code wins (currency, percentage, date, ...).
+ * - A formula that produced a date serial auto-formats as a date.
+ * - Everything else (text, plain numbers, empty) passes through unchanged.
+ */
+export const formatCellForDisplay = (originalCell: unknown, calculatedValue: CellValue, preferDDMMYYYY: boolean): CellValue => {
+  if (!isSpreadsheetCell(originalCell) || typeof calculatedValue !== "number") {
+    return calculatedValue;
+  }
+
+  const explicitFormat = typeof originalCell.f === "string" ? originalCell.f : "";
+  if (explicitFormat) {
+    return formatNumber(calculatedValue, explicitFormat);
+  }
+
+  const isFormula = typeof originalCell.v === "string" && originalCell.v.startsWith("=");
+  if (isFormula && isLikelyDateSerial(calculatedValue)) {
+    return formatNumber(calculatedValue, preferDDMMYYYY ? "DD/MM/YYYY" : "MM/DD/YYYY");
+  }
+
+  return calculatedValue;
+};

--- a/test/plugins/spreadsheet/engine/test_cellFormatting.ts
+++ b/test/plugins/spreadsheet/engine/test_cellFormatting.ts
@@ -1,0 +1,73 @@
+// The display-formatting decision for a single cell. It runs only on the final
+// output pass — cross-sheet reference resolution deliberately skips it — so a
+// wrong branch here either hides a date or, worse, turns a raw serial into a
+// "03/04/2025" string that a downstream parseFloat reads as 3 (issue #2332).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatCellForDisplay, isLikelyDateSerial } from "../../../../src/plugins/spreadsheet/engine/cellFormatting.ts";
+import { dateToSerial } from "../../../../src/plugins/spreadsheet/engine/date-utils.ts";
+
+const serial2025Mar4 = dateToSerial(new Date(Date.UTC(2025, 2, 4)));
+
+describe("isLikelyDateSerial", () => {
+  it("accepts integers inside the date-serial window", () => {
+    assert.equal(isLikelyDateSerial(serial2025Mar4), true);
+  });
+
+  it("accepts the exact window boundaries", () => {
+    assert.equal(isLikelyDateSerial(36000), true);
+    assert.equal(isLikelyDateSerial(63499), true);
+  });
+
+  it("rejects values just outside the window", () => {
+    assert.equal(isLikelyDateSerial(35999), false);
+    assert.equal(isLikelyDateSerial(63500), false);
+  });
+
+  it("rejects non-integers (a time component is not a bare date)", () => {
+    assert.equal(isLikelyDateSerial(45720.5), false);
+  });
+
+  it("rejects non-numbers", () => {
+    assert.equal(isLikelyDateSerial("45720" as unknown as number), false);
+    assert.equal(isLikelyDateSerial(true as unknown as number), false);
+  });
+});
+
+describe("formatCellForDisplay — passthrough", () => {
+  it("returns the value unchanged when the original is not a cell", () => {
+    assert.equal(formatCellForDisplay(5, 5, false), 5);
+    assert.equal(formatCellForDisplay(null, 7, false), 7);
+  });
+
+  it("leaves text untouched", () => {
+    assert.equal(formatCellForDisplay({ v: "hello" }, "hello", false), "hello");
+  });
+
+  it("leaves a plain formula number that is not a date serial", () => {
+    assert.equal(formatCellForDisplay({ v: "=A1+A2" }, 100, false), 100);
+  });
+
+  it("leaves an empty cell's zero as a number", () => {
+    assert.equal(formatCellForDisplay({ v: "" }, 0, false), 0);
+  });
+});
+
+describe("formatCellForDisplay — formatting", () => {
+  it("applies an explicit currency format", () => {
+    assert.equal(formatCellForDisplay({ v: 1234.5, f: "$#,##0.00" }, 1234.5, false), "$1,234.50");
+  });
+
+  it("auto-formats a formula's date serial (month-first by default)", () => {
+    assert.equal(formatCellForDisplay({ v: "=A1" }, serial2025Mar4, false), "03/04/2025");
+  });
+
+  it("honours day-first preference for the auto date format", () => {
+    assert.equal(formatCellForDisplay({ v: "=A1" }, serial2025Mar4, true), "04/03/2025");
+  });
+
+  it("does NOT auto-format a non-formula date serial (only formulas opt in)", () => {
+    assert.equal(formatCellForDisplay({ v: serial2025Mar4 }, serial2025Mar4, false), serial2025Mar4);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_crossSheetReference.ts
+++ b/test/plugins/spreadsheet/engine/test_crossSheetReference.ts
@@ -1,0 +1,64 @@
+// Cross-sheet references (`=Data!A1`) must resolve a cell to the SAME value a
+// same-sheet reference would. Regression for #2332: the target sheet was being
+// resolved through its display-formatted output, so a date serial arrived as
+// the string "03/04/2025" and parseFloat read it as 3 — `=Data!A1` returned 3
+// and `=DAY(Data!A1)` returned 2. Same-sheet was always correct; these tests
+// pin cross-sheet to that same behaviour.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+const engine = new SpreadsheetEngine();
+
+const calcRow = (target: SheetData, all: SheetData[], row = 0) => engine.calculate(target, all).data[row];
+
+describe("cross-sheet date reference (#2332 regression)", () => {
+  const data: SheetData = { name: "Data", data: [[{ v: "03/04/2025" }]] };
+  const summary: SheetData = { name: "Summary", data: [[{ v: "=DAY(Data!A1)" }, { v: "=Data!A1" }]] };
+
+  it("=DAY(Data!A1) reads the date, not the leading digits", () => {
+    assert.equal(calcRow(summary, [data, summary])[0], 4);
+  });
+
+  it("=Data!A1 does not collapse to 3", () => {
+    assert.notEqual(calcRow(summary, [data, summary])[1], 3);
+  });
+
+  it("=Data!A1 matches the identical same-sheet reference", () => {
+    const sameSheet: SheetData = { name: "S", data: [[{ v: "03/04/2025" }, { v: "=DAY(A1)" }, { v: "=A1" }]] };
+    const same = calcRow(sameSheet, [sameSheet]);
+    const cross = calcRow(summary, [data, summary]);
+    assert.equal(cross[0], same[1]); // =DAY
+    assert.equal(cross[1], same[2]); // =ref -> "03/04/2025"
+  });
+});
+
+describe("cross-sheet reference — value types read straight across", () => {
+  const data: SheetData = {
+    name: "Data",
+    // date, number, text, empty, a formula that itself produces a date serial
+    data: [[{ v: "03/04/2025" }, { v: 42 }, { v: "hello" }, { v: "" }, { v: "=DATE(2025,3,4)" }]],
+  };
+  const refs: SheetData = {
+    name: "Refs",
+    data: [[{ v: "=Data!A1" }, { v: "=Data!B1" }, { v: "=Data!C1" }, { v: "=Data!D1" }, { v: "=Data!E1" }]],
+  };
+
+  it("resolves each type the way the source cell holds it", () => {
+    assert.deepEqual(calcRow(refs, [data, refs]), ["03/04/2025", 42, "hello", 0, "03/04/2025"]);
+  });
+
+  it("feeds a cross-sheet date into a date function", () => {
+    const derived: SheetData = { name: "D2", data: [[{ v: "=DAY(Data!E1)" }, { v: "=Data!B1*2" }]] };
+    assert.deepEqual(calcRow(derived, [data, derived]), [4, 84]);
+  });
+});
+
+describe("cross-sheet range aggregation stays numeric", () => {
+  it("SUM over a cross-sheet range adds the raw numbers", () => {
+    const data: SheetData = { name: "D", data: [[{ v: 10 }, { v: 20 }, { v: 30 }]] };
+    const sum: SheetData = { name: "S", data: [[{ v: "=SUM(D!A1:C1)" }]] };
+    assert.deepEqual(calcRow(sum, [data, sum]), [60]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2332. A cross-sheet reference to a date cell (`=Data!A1` where `Data!A1` holds a date) returned `3` instead of the date, and `=DAY(Data!A1)` returned `2` instead of `4`. Same-sheet references (`=A1`) were always correct.

Root cause: cross-sheet references resolved their target sheet through its **display-formatted** output, where a date serial (`45720`) has already been turned into the string `"03/04/2025"`. `getRawValue` then fed that string to `parseFloat`, reading only the leading `03` → `3`. Same-sheet references read the sheet's `calculated` array *before* the formatting pass runs, so they kept the raw serial.

Fix: when a sheet is computed **only** to resolve a cross-sheet reference, skip the display-formatting pass so the referencing cell reads the underlying value. This makes cross-sheet behaviour identical to same-sheet. The referencing formula cell (`=Data!A1`) still auto-date-formats its own numeric result, so the displayed output matches same-sheet exactly (`"03/04/2025"`).

The per-cell formatting decision is extracted into a pure, unit-tested `formatCellForDisplay` / `isLikelyDateSerial` (new `cellFormatting.ts`).

## Items to Confirm / Review

- **`skipFormatting` is deliberately internal** — it lives on a local `SheetCalculateOptions` type in `calculator.ts`, not on the public `CalculateOptions` / `EngineOptions` (keeping it out of the engine's `Required<EngineOptions>` constructor). It is only ever set `true` by the two cross-sheet recursive calls.
- **Behavioural definition of "correct"**: cross-sheet `=Data!A1` now yields the same value the identical same-sheet formula does (`"03/04/2025"`, a display-formatted date string), not a bare serial. The issue text said "expected serial"; the auto-date-format on the referencing cell is the established engine behaviour and matches same-sheet — please confirm this is the desired resolution.
- **Scope**: change is confined to `calculator.ts` + a new `cellFormatting.ts`. It does **not** touch `evaluator.ts` or `functions/lookup.ts` (owned by parallel spreadsheet sessions #2395 / #2390), so merges stay clean.
- **Dual-copy**: only one copy of the engine exists (`src/plugins/spreadsheet/engine/`). No `packages/mulmoclaude/**` mirror is present in the tree — nothing to keep in sync.

## User Prompt

> Fix GitHub issue #2332 (bug) and open a PR (do not merge). This is part of the "B group" of spreadsheet lookup / evaluator / cross-sheet issues assigned to work in parallel with another session (which owns #2429 / #2383 / #2362 / #2358 / #2357 / #2360 / #2386 / #2387 / #2389). Stay strictly within #2332's scope.
>
> #2332: a cross-sheet reference breaks date cells — `=Data!A1` where `Data!A1` holds a date returns `3` (a raw serial/number fragment) instead of the date value. Write a failing regression test first, diagnose the root cause (how a same-sheet date ref differs from a cross-sheet one), fix at the root cause with no hardcoded workarounds, keep same-sheet behaviour unchanged, and add boundary tests (date, number, string, empty, formula-producing cell — all read cross-sheet). Verify format / lint / typecheck / build and the spreadsheet tests. Do not bump any package version.

## Root cause (detail)

`calculateSheet` ends with a display-formatting pass that converts date serials to strings for any cell carrying a date format code `f` (`45720` → `"03/04/2025"`).

- **Same-sheet** references read the current sheet's `calculated` array *during* the main evaluation loop — before that pass — so they see raw serial `45720`.
- **Cross-sheet** references call `calculateSheet(...)` recursively and read `.data`, the fully formatted output. The date cell is now `"03/04/2025"`; `getRawValue` runs `parseFloat("03/04/2025")` → `3`, and `DAY(3)` → `2`.

Currency/percentage/comma formats survived by luck (`getRawValue` strips `$ , %`); dates had no such recovery. Formula-produced dates on the target sheet hit the same bug via auto-date-format.

## Fix (detail)

- Add an internal `skipFormatting` flag (local `SheetCalculateOptions` type) to `calculateSheet`; guard the final formatting pass with it.
- Pass `skipFormatting: true` from the two cross-sheet recursive calls (`getCellValue`, `collectRangeValues`), so the cached cross-sheet values stay raw.
- Extract the formatting decision into pure `formatCellForDisplay(originalCell, calculatedValue, preferDDMMYYYY)` + `isLikelyDateSerial(value)` in `cellFormatting.ts`, and unit-test them (date / number / string / empty / formula / no-format / window boundaries).

## Verification

- New regression + boundary tests (`test_crossSheetReference.ts`): `=DAY(Data!A1)` → `4`; `=Data!A1` equals the same-sheet formula; cross-sheet reads of date / number / string / empty / formula-producing cells; cross-sheet `SUM`. **Confirmed red without the fix** (5 of 6 cross-sheet assertions fail when `skipFormatting` is removed; the pure-numeric `SUM` stays green, as expected).
- `yarn format`, `yarn lint` (0 errors), `yarn typecheck` (0 errors), `yarn build` — all pass. All 336 spreadsheet engine tests pass. No package version bumped.

Plan: `plans/fix-2332-cross-sheet-date.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
