### PR TITLE
fix(spreadsheet): #2390 lookup boundary/cross-sheet + refactor #2396 range-parse consolidation

### DIFF
--- a/plans/fix-2390-refactor-2396-lookup.md
+++ b/plans/fix-2390-refactor-2396-lookup.md
@@ -1,0 +1,81 @@
+# fix #2390 + refactor #2396 — spreadsheet lookup range parsing
+
+Two paired issues that both live in `src/plugins/spreadsheet/engine/functions/lookup.ts`.
+The refactor (#2396) centralises the range/column parsing that the bug fix (#2390)
+depends on, so they ship as one PR with clearly separated commits (see "PR shape").
+
+## Canonical copy
+
+There is exactly ONE copy of the spreadsheet engine: `src/plugins/spreadsheet/**`.
+The `packages/mulmoclaude/src/plugins/spreadsheet/...` path referenced in the task
+brief does not exist on `origin/main` (verified with `find`). No dual-copy sync
+needed. Recent spreadsheet fixes (#2414, #2386, #2357, #2356) all touched only
+`src/plugins/spreadsheet/**` and `test/plugins/spreadsheet/**`.
+
+## #2396 — consolidation (foundation)
+
+`functions/lookup.ts` carried independent re-implementations of already-tested
+shared code:
+
+| lookup.ts | canonical | issue |
+|---|---|---|
+| `colToIndex` / `indexToCol` (lines 9-27) | `parser.ts` `columnToIndex` / `indexToColumn` (tested) | byte-for-byte duplicate |
+| range-bounds parse (lines 122, 148, 199, 264) | none — 4 hand-copies | one copy (line 122) rejected sheet-qualified ranges |
+
+Fix:
+- Delete `colToIndex` / `indexToCol`; import `columnToIndex` / `indexToColumn` from `parser.ts`.
+- Add pure `parseRangeBounds(range)` to `formulaRefs.ts` (alongside `expandRange` /
+  `parseSingleCellRef`). It splits an optional `Sheet!` / `'Sheet Name'!` prefix,
+  parses the `A2:C10` body into `{ sheetPrefix, startCol, startRow, endCol, endRow }`
+  (cols 0-based via `columnToIndex`, rows 1-based), and returns `null` for non-ranges.
+- Repoint VLOOKUP / HLOOKUP / INDEX to `parseRangeBounds`.
+
+Behaviour is identical for the single-sheet ranges the four copies already handled;
+the one difference is the intended one — the sheet-qualified throw disappears (below).
+
+## #2390 — three bugs
+
+### 1. Cross-sheet VLOOKUP throws (fixed BY the #2396 consolidation)
+`VLOOKUP(x, Sheet1!A2:C10, 2)` threw. Line 122 ran a *sheet-unaware* regex
+`/^([A-Z]+)\d+:...$/` against the whole `Sheet1!A2:C10` and threw "Invalid table
+array range" before the sheet-aware block at line 148 could run. `parseRangeBounds`
+strips the sheet prefix first, so the single unified parse accepts it. Regression
+test lands with the refactor commit.
+
+### 2. INDEX out-of-range reads the wrong cell → should be `#REF!`
+`INDEX(A1:A3, 5)` read A5 (outside the range); `INDEX(A2:B5, 0, 1)` read A1 (above
+the range). Root cause: `indexHandler` computed `startRow + rowNum - 1` with no
+bounds check. Fix: pure `resolveIndexTarget(bounds, rowNum, colNum)` validates the
+1-based position against the range dimensions and returns `null` (→ `#REF!`) when
+out of range. Excel's `0` = "entire row/column" selector is only representable in
+this scalar engine when that dimension is a single line; otherwise it also returns
+`#REF!` rather than silently reading an out-of-range cell. This is pinned as a test.
+
+### 3. NPV period offset
+`NPV(0.1, A1:A3, 500)` discounted 500 at period 2 (its argument index) instead of
+period 4. Root cause: the handler used the *argument* index `i` as the period, so a
+scalar after an N-cell range landed at period 2 rather than N+1. Fix: pure
+`computeNpv(rate, cashFlows)` in `financial-math.ts` discounts each flow by its
+1-based position in a single flattened, ordered list; the handler flattens ranges
+(numeric values) then scalars into that list.
+
+## Pure functions extracted (each unit-tested)
+
+- `parseRangeBounds` — `formulaRefs.ts` (range/sheet parsing; the #2396 target)
+- `resolveIndexTarget` — `formulaRefs.ts` (INDEX bounds → cell or `#REF!`)
+- `computeNpv` — `financial-math.ts` (ordered discounting)
+
+## PR shape
+
+One PR, `refactor/2396-lookup-refs`, commits kept separated:
+1. `docs(plan)` — this file
+2. `refactor(spreadsheet): #2396` — consolidation + cross-sheet VLOOKUP test
+3. `fix(spreadsheet): #2390` — INDEX `#REF!` + NPV period, with tests
+
+Two separate PRs would both edit `lookup.ts` from `main` and self-conflict (neither
+is merged in this task), so the coupled single-PR form is used per the brief.
+
+## Verification
+
+Each regression test is confirmed to go red when its fix is reverted. Full gate:
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, spreadsheet tests.

--- a/src/plugins/spreadsheet/engine/financial-math.ts
+++ b/src/plugins/spreadsheet/engine/financial-math.ts
@@ -39,3 +39,12 @@ export function computeIpmt(rate: number, per: number, nper: number, pv: number,
 export function computePpmt(rate: number, per: number, nper: number, pv: number, fv: number, type: number): number {
   return computePmt(rate, nper, pv, fv, type) - computeIpmt(rate, per, nper, pv, fv, type);
 }
+
+/** Net present value: each cash flow discounted by its 1-based period, in the
+ *  order given. The caller flattens ranges and scalars into one ordered list, so
+ *  a scalar after an N-cell range sits at period N+1 — NPV counts values, not
+ *  arguments. Using the argument index put a trailing scalar at the wrong (lower)
+ *  period (#2390). */
+export function computeNpv(rate: number, cashFlows: number[]): number {
+  return cashFlows.reduce((npv, flow, index) => npv + flow / Math.pow(1 + rate, index + 1), 0);
+}

--- a/src/plugins/spreadsheet/engine/formulaRefs.ts
+++ b/src/plugins/spreadsheet/engine/formulaRefs.ts
@@ -87,6 +87,39 @@ export function parseSingleCellRef(refStr: string): CellCoord | null {
   };
 }
 
+// Numeric bounds of a `A2:C10` range, with any `Sheet1!` / `'My Sheet'!`
+// prefix kept verbatim so callers can rebuild sheet-qualified refs. Columns
+// are 0-based (via `columnToIndex`); rows stay 1-based, matching A1 notation.
+export interface RangeBounds {
+  sheetPrefix: string;
+  startCol: number;
+  startRow: number;
+  endCol: number;
+  endRow: number;
+}
+
+// Split an optional sheet prefix from a range, then parse the `A2:C10` body.
+// The prefix is everything up to and including the last `!`, so a quoted sheet
+// name that itself contains no `!` (the common case) is preserved intact. The
+// lookup functions each carried their own copy of this parse; one copy ran a
+// sheet-unaware regex against the whole string and threw on `Sheet1!A2:C10`
+// before the sheet-aware copy could run (#2390). Returns null for anything that
+// is not a two-endpoint range so callers surface one "Invalid range" message.
+export function parseRangeBounds(range: string): RangeBounds | null {
+  const bang = range.lastIndexOf("!");
+  const sheetPrefix = bang >= 0 ? range.slice(0, bang + 1) : "";
+  const body = bang >= 0 ? range.slice(bang + 1) : range;
+  const match = body.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
+  if (!match) return null;
+  return {
+    sheetPrefix,
+    startCol: columnToIndex(match[1]),
+    startRow: parseInt(match[2], 10),
+    endCol: columnToIndex(match[3]),
+    endRow: parseInt(match[4], 10),
+  };
+}
+
 // Top-level: scan the formula, expand any ranges, then pick up
 // remaining single-cell refs, deduplicating as we go. Kept short
 // (~15 lines) so the cognitive-complexity signal lands on the

--- a/src/plugins/spreadsheet/engine/formulaRefs.ts
+++ b/src/plugins/spreadsheet/engine/formulaRefs.ts
@@ -120,6 +120,36 @@ export function parseRangeBounds(range: string): RangeBounds | null {
   };
 }
 
+// Excel's `0` row/column index selects the entire row/column. This scalar engine
+// returns a single cell, so `0` is representable only when that dimension is one
+// line long; otherwise it is out of range.
+const WHOLE_LINE_INDEX = 0;
+const FIRST_INDEX = 1;
+
+// Map a 1-based INDEX position onto a 0-based offset within a `size`-long line,
+// truncating toward zero as Excel does. Returns null when the position falls
+// outside the line — including a `0` (whole-line) request the scalar engine
+// cannot collapse to one cell. Callers turn null into #REF!.
+function lineOffset(position: number, size: number): number | null {
+  const index = Math.trunc(position);
+  if (!Number.isFinite(index)) return null;
+  if (index === WHOLE_LINE_INDEX) return size === 1 ? 0 : null;
+  if (index < FIRST_INDEX || index > size) return null;
+  return index - FIRST_INDEX;
+}
+
+// Resolve INDEX(range, rowNum, colNum)'s 1-based position to an absolute cell
+// within the range, or null (→ #REF!) when it falls outside. The former handler
+// computed the target with no bounds check, so an out-of-range index silently
+// read a cell outside the range (#2390: `INDEX(A1:A3,5)` read A5, `INDEX(A2:B5,
+// 0,1)` read A1). Returned column is 0-based; row is 1-based (A1 notation).
+export function resolveIndexTarget(bounds: RangeBounds, rowNum: number, colNum: number): { colIndex: number; row: number } | null {
+  const rowOffset = lineOffset(rowNum, bounds.endRow - bounds.startRow + 1);
+  const colOffset = lineOffset(colNum, bounds.endCol - bounds.startCol + 1);
+  if (rowOffset === null || colOffset === null) return null;
+  return { colIndex: bounds.startCol + colOffset, row: bounds.startRow + rowOffset };
+}
+
 // Top-level: scan the formula, expand any ranges, then pick up
 // remaining single-cell refs, deduplicating as we go. Kept short
 // (~15 lines) so the cognitive-complexity signal lands on the

--- a/src/plugins/spreadsheet/engine/functions/financial.ts
+++ b/src/plugins/spreadsheet/engine/functions/financial.ts
@@ -2,8 +2,8 @@
  * Financial Functions
  */
 
-import { functionRegistry, toNumber, type FunctionHandler } from "../registry";
-import { computeFv, computePmt, computeIpmt, computePpmt } from "../financial-math";
+import { functionRegistry, toNumber, type FunctionHandler, type FunctionContext } from "../registry";
+import { computeFv, computePmt, computeIpmt, computePpmt, computeNpv } from "../financial-math";
 
 /**
  * FV - Future Value
@@ -193,32 +193,20 @@ const ppmtHandler: FunctionHandler = (args, context) => {
  * Calculates the net present value of an investment based on a discount rate and a series of future cash flows.
  * NPV(rate, value1, [value2], ...)
  */
+// Flatten NPV's value arguments into one ordered list of numeric cash flows:
+// ranges expand in place (numeric cells only), scalars contribute one value.
+// The order defines each flow's discount period, so ranges and the scalars
+// after them must stay in argument order.
+const collectCashFlows = (valueArgs: string[], context: FunctionContext): number[] =>
+  valueArgs.flatMap((arg) => (arg.includes(":") ? context.getRangeValues(arg) : [context.evaluateFormula(arg)]).map(toNumber));
+
 const npvHandler: FunctionHandler = (args, context) => {
   if (args.length < 2) {
     throw new Error("NPV requires at least 2 arguments");
   }
 
   const rate = toNumber(context.evaluateFormula(args[0]));
-  let npv = 0;
-
-  // Process each cash flow
-  for (let i = 1; i < args.length; i++) {
-    // Check if argument is a range
-    if (args[i].includes(":")) {
-      const values = context.getRangeValues(args[i]);
-      for (let j = 0; j < values.length; j++) {
-        const value = toNumber(values[j]);
-        // Period starts from i for first range element, then continues
-        const period = i + j;
-        npv += value / Math.pow(1 + rate, period);
-      }
-    } else {
-      const value = toNumber(context.evaluateFormula(args[i]));
-      npv += value / Math.pow(1 + rate, i);
-    }
-  }
-
-  return npv;
+  return computeNpv(rate, collectCashFlows(args.slice(1), context));
 };
 
 /**

--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -4,7 +4,7 @@
 
 import { functionRegistry, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
 import { indexToColumn } from "../parser";
-import { parseRangeBounds } from "../formulaRefs";
+import { parseRangeBounds, resolveIndexTarget } from "../formulaRefs";
 import type { CellValue } from "../types";
 
 // The 4th VLOOKUP/HLOOKUP argument (rangeLookup) is approximate-match when TRUE,
@@ -165,10 +165,9 @@ const indexHandler: FunctionHandler = (args, context) => {
   const rowNum = toNumber(context.evaluateFormula(args[1]));
   const colNum = args.length >= 3 ? toNumber(context.evaluateFormula(args[2])) : 1; // Default to 1 if omitted (for 1D arrays)
 
-  // rowNum and colNum are 1-based relative to the range.
-  const targetRow = bounds.startRow + rowNum - 1;
-  const targetColStr = indexToColumn(bounds.startCol + colNum - 1);
-  return context.getCellValue(`${bounds.sheetPrefix}${targetColStr}${targetRow}`);
+  const target = resolveIndexTarget(bounds, rowNum, colNum);
+  if (!target) return "#REF!";
+  return context.getCellValue(`${bounds.sheetPrefix}${indexToColumn(target.colIndex)}${target.row}`);
 };
 
 const xlookupHandler: FunctionHandler = (args, context) => {

--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -2,29 +2,24 @@
  * Lookup and Reference Functions
  */
 
-import { functionRegistry, toNumber, parseCriteria, type FunctionHandler } from "../registry";
+import { functionRegistry, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
+import { indexToColumn } from "../parser";
+import { parseRangeBounds } from "../formulaRefs";
 import type { CellValue } from "../types";
 
-// Helper to convert Excel column letters to 0-based index (A=0, Z=25, AA=26, etc.)
-const colToIndex = (col: string): number => {
-  let result = 0;
-  for (let i = 0; i < col.length; i++) {
-    result = result * 26 + (col.charCodeAt(i) - 64);
-  }
-  return result - 1;
-};
+// The 4th VLOOKUP/HLOOKUP argument (rangeLookup) is approximate-match when TRUE,
+// 1, "1", or omitted; FALSE/0 forces an exact match.
+const isApproximate = (rangeLookup: CellValue): boolean => rangeLookup === true || rangeLookup === 1 || rangeLookup === "1";
 
-// Helper to convert 0-based index to Excel column letters (0=A, 25=Z, 26=AA, etc.)
-const indexToCol = (index: number): string => {
-  let col = "";
-  let num = index + 1;
-  while (num > 0) {
-    const remainder = (num - 1) % 26;
-    col = String.fromCharCode(65 + remainder) + col;
-    num = Math.floor((num - 1) / 26);
-  }
-  return col;
-};
+const inclusiveRange = (start: number, end: number): number[] => Array.from({ length: Math.max(0, end - start + 1) }, (_, i) => start + i);
+
+// Read a vertical slice (one column, `startRow`..`endRow`) as VLOOKUP's lookup column.
+const columnValues = (context: FunctionContext, sheetPrefix: string, colStr: string, startRow: number, endRow: number): CellValue[] =>
+  inclusiveRange(startRow, endRow).map((r) => context.getCellValue(`${sheetPrefix}${colStr}${r}`));
+
+// Read a horizontal slice (one row, `startCol`..`endCol`) as HLOOKUP's lookup row.
+const rowValues = (context: FunctionContext, sheetPrefix: string, row: number, startCol: number, endCol: number): CellValue[] =>
+  inclusiveRange(startCol, endCol).map((c) => context.getCellValue(`${sheetPrefix}${indexToColumn(c)}${row}`));
 
 // Helper to find match index
 const findMatchIndex = (
@@ -107,71 +102,20 @@ const vlookupHandler: FunctionHandler = (args, context) => {
   }
 
   const lookupValue = context.evaluateFormula(args[0]);
-  const tableArrayRange = args[1];
+  const bounds = parseRangeBounds(args[1]);
+  if (!bounds) throw new Error("Invalid table array range");
   const colIndexNum = toNumber(context.evaluateFormula(args[2]));
   const rangeLookup = args.length === 4 ? context.evaluateFormula(args[3]) : true;
+  const matchType = isApproximate(rangeLookup) ? 1 : 0;
 
-  // Convert rangeLookup to boolean/number logic
-  // TRUE/1/omitted = approximate match (default)
-  // FALSE/0 = exact match
-  const isApprox = rangeLookup === true || rangeLookup === 1 || rangeLookup === "1";
-  const matchType = isApprox ? 1 : 0;
-
-  // Get the full table data
-  // We need to parse the range string to get dimensions
-  const match = tableArrayRange.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-  if (!match) throw new Error("Invalid table array range");
-
-  // We need to get the first column for looking up
-  // And the specific column for the result
-  // This is a bit tricky with the current getRangeValues which flattens everything
-  // We need to manually reconstruct the table structure or request specific cells
-
-  // Let's parse the range to get start/end col/row
-  // Note: This relies on the context.getCellValue implementation details or we need to implement
-  // a smarter way to get 2D data.
-  // For now, we will iterate row by row.
-
-  // Parse range manually to get boundaries
-  // We can't easily use context.getRangeValues because it flattens 2D arrays to 1D
-  // So we will iterate through the rows of the first column
-
-  // Extract sheet name if present
-  let sheetName = "";
-  let rangePart = tableArrayRange;
-  if (tableArrayRange.includes("!")) {
-    const parts = tableArrayRange.split("!");
-    sheetName = parts[0] + "!";
-    rangePart = parts[1];
-  }
-
-  const rangeMatch = rangePart.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-  if (!rangeMatch) throw new Error("Invalid range format");
-
-  const startColStr = rangeMatch[1];
-  const startRow = parseInt(rangeMatch[2]);
-  const endRow = parseInt(rangeMatch[4]);
-
-  const startColIdx = colToIndex(startColStr);
-  const resultColIdx = startColIdx + colIndexNum - 1;
-  const resultColStr = indexToCol(resultColIdx);
-
-  // Build lookup array (first column)
-  const lookupArray: CellValue[] = [];
-  for (let r = startRow; r <= endRow; r++) {
-    const cellRef = `${sheetName}${startColStr}${r}`;
-    lookupArray.push(context.getCellValue(cellRef));
-  }
-
+  const startColStr = indexToColumn(bounds.startCol);
+  const lookupArray = columnValues(context, bounds.sheetPrefix, startColStr, bounds.startRow, bounds.endRow);
   const matchIdx = findMatchIndex(lookupValue, lookupArray, matchType);
-
   if (matchIdx === -1) return "#N/A";
 
-  // Get result
-  const resultRow = startRow + matchIdx;
-  const resultRef = `${sheetName}${resultColStr}${resultRow}`;
-
-  return context.getCellValue(resultRef);
+  const resultColStr = indexToColumn(bounds.startCol + colIndexNum - 1);
+  const resultRow = bounds.startRow + matchIdx;
+  return context.getCellValue(`${bounds.sheetPrefix}${resultColStr}${resultRow}`);
 };
 
 const hlookupHandler: FunctionHandler = (args, context) => {
@@ -180,51 +124,19 @@ const hlookupHandler: FunctionHandler = (args, context) => {
   }
 
   const lookupValue = context.evaluateFormula(args[0]);
-  const tableArrayRange = args[1];
+  const bounds = parseRangeBounds(args[1]);
+  if (!bounds) throw new Error("Invalid range format");
   const rowIndexNum = toNumber(context.evaluateFormula(args[2]));
   const rangeLookup = args.length === 4 ? context.evaluateFormula(args[3]) : true;
+  const matchType = isApproximate(rangeLookup) ? 1 : 0;
 
-  const isApprox = rangeLookup === true || rangeLookup === 1 || rangeLookup === "1";
-  const matchType = isApprox ? 1 : 0;
-
-  // Extract sheet name if present
-  let sheetName = "";
-  let rangePart = tableArrayRange;
-  if (tableArrayRange.includes("!")) {
-    const parts = tableArrayRange.split("!");
-    sheetName = parts[0] + "!";
-    rangePart = parts[1];
-  }
-
-  const rangeMatch = rangePart.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-  if (!rangeMatch) throw new Error("Invalid range format");
-
-  const startColStr = rangeMatch[1];
-  const endColStr = rangeMatch[3];
-  const startRow = parseInt(rangeMatch[2]);
-
-  const startColIdx = colToIndex(startColStr);
-  const endColIdx = colToIndex(endColStr);
-
-  // Build lookup array (first row)
-  const lookupArray: CellValue[] = [];
-  for (let c = startColIdx; c <= endColIdx; c++) {
-    const colStr = indexToCol(c);
-    const cellRef = `${sheetName}${colStr}${startRow}`;
-    lookupArray.push(context.getCellValue(cellRef));
-  }
-
+  const lookupArray = rowValues(context, bounds.sheetPrefix, bounds.startRow, bounds.startCol, bounds.endCol);
   const matchIdx = findMatchIndex(lookupValue, lookupArray, matchType);
-
   if (matchIdx === -1) return "#N/A";
 
-  // Get result
-  const resultColIdx = startColIdx + matchIdx;
-  const resultColStr = indexToCol(resultColIdx);
-  const resultRow = startRow + rowIndexNum - 1;
-  const resultRef = `${sheetName}${resultColStr}${resultRow}`;
-
-  return context.getCellValue(resultRef);
+  const resultColStr = indexToColumn(bounds.startCol + matchIdx);
+  const resultRow = bounds.startRow + rowIndexNum - 1;
+  return context.getCellValue(`${bounds.sheetPrefix}${resultColStr}${resultRow}`);
 };
 
 const matchHandler: FunctionHandler = (args, context) => {
@@ -248,35 +160,15 @@ const indexHandler: FunctionHandler = (args, context) => {
     throw new Error("INDEX requires 2 to 4 arguments");
   }
 
-  const arrayRange = args[0];
+  const bounds = parseRangeBounds(args[0]);
+  if (!bounds) throw new Error("Invalid range format");
   const rowNum = toNumber(context.evaluateFormula(args[1]));
   const colNum = args.length >= 3 ? toNumber(context.evaluateFormula(args[2])) : 1; // Default to 1 if omitted (for 1D arrays)
 
-  // Parse range to find the specific cell
-  let sheetName = "";
-  let rangePart = arrayRange;
-  if (arrayRange.includes("!")) {
-    const parts = arrayRange.split("!");
-    sheetName = parts[0] + "!";
-    rangePart = parts[1];
-  }
-
-  const rangeMatch = rangePart.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-  if (!rangeMatch) throw new Error("Invalid range format");
-
-  const startColStr = rangeMatch[1];
-  const startRow = parseInt(rangeMatch[2]);
-
-  const startColIdx = colToIndex(startColStr);
-
-  // Calculate target cell
-  // rowNum and colNum are 1-based relative to the range
-  const targetRow = startRow + rowNum - 1;
-  const targetColIdx = startColIdx + colNum - 1;
-  const targetColStr = indexToCol(targetColIdx);
-
-  const ref = `${sheetName}${targetColStr}${targetRow}`;
-  return context.getCellValue(ref);
+  // rowNum and colNum are 1-based relative to the range.
+  const targetRow = bounds.startRow + rowNum - 1;
+  const targetColStr = indexToColumn(bounds.startCol + colNum - 1);
+  return context.getCellValue(`${bounds.sheetPrefix}${targetColStr}${targetRow}`);
 };
 
 const xlookupHandler: FunctionHandler = (args, context) => {

--- a/test/plugins/spreadsheet/engine/test_financialMath.ts
+++ b/test/plugins/spreadsheet/engine/test_financialMath.ts
@@ -5,7 +5,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { computeFv, computePmt, computeIpmt, computePpmt } from "../../../../src/plugins/spreadsheet/engine/financial-math.ts";
+import { computeFv, computePmt, computeIpmt, computePpmt, computeNpv } from "../../../../src/plugins/spreadsheet/engine/financial-math.ts";
 
 const closeTo = (actual: number, expected: number, eps = 0.01): boolean => Math.abs(actual - expected) <= eps;
 
@@ -54,6 +54,31 @@ describe("the interest and principal split reconstitutes the payment", () => {
       const split = computeIpmt(RATE, per, NPER, PRINCIPAL, 0, 0) + computePpmt(RATE, per, NPER, PRINCIPAL, 0, 0);
       assert.ok(closeTo(split, pmt, 1e-9), `period ${per}: IPMT + PPMT == PMT`);
     }
+  });
+});
+
+describe("computeNpv", () => {
+  const NPV_RATE = 0.1;
+
+  // Each flow discounts by its 1-based POSITION in the flattened list. The #2390
+  // bug used the argument index, so a scalar after a 3-cell range landed at
+  // period 2 instead of 4 — the position is what makes 100/1.1 + 200/1.1^2 +
+  // 300/1.1^3 + 500/1.1^4 correct.
+  it("discounts each flow by its 1-based position", () => {
+    const expected = 100 / 1.1 + 200 / 1.1 ** 2 + 300 / 1.1 ** 3 + 500 / 1.1 ** 4;
+    assert.ok(closeTo(computeNpv(NPV_RATE, [100, 200, 300, 500]), expected, 1e-9));
+  });
+
+  it("sums flows undiscounted at a zero rate", () => {
+    assert.ok(closeTo(computeNpv(0, [100, 200, 300, 500]), 1100, 1e-9));
+  });
+
+  it("is zero for no cash flows", () => {
+    assert.equal(computeNpv(NPV_RATE, []), 0);
+  });
+
+  it("discounts a single flow by one period", () => {
+    assert.ok(closeTo(computeNpv(NPV_RATE, [100]), 100 / 1.1, 1e-9));
   });
 });
 

--- a/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
@@ -1,0 +1,59 @@
+// Lookup functions driven through the whole engine. The cross-sheet VLOOKUP case
+// is the #2390 regression: a sheet-qualified table array (`Data!A1:B3`) used to
+// throw because one of VLOOKUP's two range parses ran a sheet-unaware regex and
+// rejected the prefix before the sheet-aware parse could run. Now a single
+// `parseRangeBounds` handles both (#2396).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+/** Calculate `formula` in cell A-after-the-data of a single sheet built from `rows`. */
+const evalInSheet = (rows: (string | number)[][], formula: string): unknown => {
+  const data = rows.map((row) => row.map((v) => ({ v })));
+  data.push([{ v: formula }]);
+  const result = new SpreadsheetEngine().calculate({ name: "S", data });
+  return result.data[data.length - 1][0];
+};
+
+describe("VLOOKUP — same sheet", () => {
+  const table: (string | number)[][] = [
+    ["Alice", 10],
+    ["Bob", 20],
+    ["Carol", 30],
+  ];
+
+  it("returns the result-column value for an exact match", () => {
+    assert.equal(evalInSheet(table, '=VLOOKUP("Carol", A1:B3, 2, FALSE)'), 30);
+  });
+
+  it("returns #N/A when the value is absent", () => {
+    assert.equal(evalInSheet(table, '=VLOOKUP("Zoe", A1:B3, 2, FALSE)'), "#N/A");
+  });
+});
+
+describe("HLOOKUP — same sheet", () => {
+  it("looks across the top row and returns the row below", () => {
+    const table: (string | number)[][] = [
+      ["a", "b", "c"],
+      [1, 2, 3],
+    ];
+    assert.equal(evalInSheet(table, '=HLOOKUP("b", A1:C2, 2, FALSE)'), 2);
+  });
+});
+
+describe("VLOOKUP — cross-sheet table array (#2390: no longer throws)", () => {
+  it("resolves a sheet-qualified table array", () => {
+    const data: SheetData = {
+      name: "Data",
+      data: [
+        [{ v: "Alice" }, { v: 10 }],
+        [{ v: "Bob" }, { v: 20 }],
+        [{ v: "Carol" }, { v: 30 }],
+      ],
+    };
+    const main: SheetData = { name: "Main", data: [[{ v: '=VLOOKUP("Bob", Data!A1:B3, 2, FALSE)' }]] };
+    const [mainResult] = new SpreadsheetEngine().calculateWorkbook([main, data]);
+    assert.equal(mainResult.data[0][0], 20);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
@@ -10,7 +10,7 @@ import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/sprea
 
 /** Calculate `formula` in cell A-after-the-data of a single sheet built from `rows`. */
 const evalInSheet = (rows: (string | number)[][], formula: string): unknown => {
-  const data = rows.map((row) => row.map((v) => ({ v })));
+  const data = rows.map((row) => row.map((value) => ({ v: value })));
   data.push([{ v: formula }]);
   const result = new SpreadsheetEngine().calculate({ name: "S", data });
   return result.data[data.length - 1][0];
@@ -55,5 +55,26 @@ describe("VLOOKUP — cross-sheet table array (#2390: no longer throws)", () => 
     const main: SheetData = { name: "Main", data: [[{ v: '=VLOOKUP("Bob", Data!A1:B3, 2, FALSE)' }]] };
     const [mainResult] = new SpreadsheetEngine().calculateWorkbook([main, data]);
     assert.equal(mainResult.data[0][0], 20);
+  });
+});
+
+describe("INDEX — bounds (#2390)", () => {
+  const grid: (string | number)[][] = [
+    [10, 11],
+    [20, 21],
+    [30, 31],
+  ];
+
+  it("returns the addressed cell for an in-range position", () => {
+    assert.equal(evalInSheet(grid, "=INDEX(A1:B3, 2, 2)"), 21); // B2
+    assert.equal(evalInSheet(grid, "=INDEX(A1:A3, 3)"), 30); // A3
+  });
+
+  it("returns #REF! when the row is past the range (was reading A5)", () => {
+    assert.equal(evalInSheet(grid, "=INDEX(A1:A3, 5)"), "#REF!");
+  });
+
+  it("returns #REF! for row 0 on a multi-row range (was reading A1 above the range)", () => {
+    assert.equal(evalInSheet(grid, "=INDEX(A2:B3, 0, 1)"), "#REF!");
   });
 });

--- a/test/plugins/spreadsheet/engine/test_npvFunction.ts
+++ b/test/plugins/spreadsheet/engine/test_npvFunction.ts
@@ -1,0 +1,29 @@
+// NPV through the whole engine. The #2390 bug used each value's ARGUMENT index
+// as its discount period, so a scalar after a range was discounted too little:
+// NPV(0.1, A1:A3, 500) put 500 at period 2 instead of period 4. The period must
+// count flattened values, not arguments.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+const closeTo = (actual: unknown, expected: number, eps = 1e-6): boolean => typeof actual === "number" && Math.abs(actual - expected) <= eps;
+
+describe("NPV — range followed by a scalar (#2390)", () => {
+  it("discounts the trailing scalar at period 4, not period 2", () => {
+    const sheet = {
+      name: "S",
+      data: [[{ v: 100 }], [{ v: 200 }], [{ v: 300 }], [{ v: "=NPV(0.1, A1:A3, 500)" }]],
+    };
+    const result = new SpreadsheetEngine().calculate(sheet);
+    const expected = 100 / 1.1 + 200 / 1.1 ** 2 + 300 / 1.1 ** 3 + 500 / 1.1 ** 4;
+    assert.ok(closeTo(result.data[3][0], expected), `NPV ≈ ${expected}, got ${result.data[3][0]}`);
+  });
+
+  it("matches the all-scalar form when there is no range", () => {
+    const sheet = { name: "S", data: [[{ v: "=NPV(0.1, 100, 200, 300, 500)" }]] };
+    const result = new SpreadsheetEngine().calculate(sheet);
+    const expected = 100 / 1.1 + 200 / 1.1 ** 2 + 300 / 1.1 ** 3 + 500 / 1.1 ** 4;
+    assert.ok(closeTo(result.data[0][0], expected), `NPV ≈ ${expected}, got ${result.data[0][0]}`);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_parseRangeBounds.ts
+++ b/test/plugins/spreadsheet/engine/test_parseRangeBounds.ts
@@ -1,0 +1,61 @@
+// `parseRangeBounds` is the single range parser the lookup functions now share
+// (#2396). It carries the sheet-prefix split that one of the four former copies
+// lacked — the copy that made cross-sheet VLOOKUP throw (#2390). Columns come
+// back 0-based (A=0), rows stay 1-based (A1 notation).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseRangeBounds } from "../../../../src/plugins/spreadsheet/engine/formulaRefs.ts";
+
+describe("parseRangeBounds — plain ranges", () => {
+  it("parses A1:B10 (cols 0-based, rows 1-based)", () => {
+    assert.deepEqual(parseRangeBounds("A1:B10"), { sheetPrefix: "", startCol: 0, startRow: 1, endCol: 1, endRow: 10 });
+  });
+
+  it("parses an offset range A2:C10", () => {
+    assert.deepEqual(parseRangeBounds("A2:C10"), { sheetPrefix: "", startCol: 0, startRow: 2, endCol: 2, endRow: 10 });
+  });
+
+  // Column boundaries: A is Excel column 1 → index 0, Z is 26 → 25, AA is 27 → 26.
+  it("parses the A / Z / AA column boundaries", () => {
+    assert.equal(parseRangeBounds("A1:A1")?.startCol, 0);
+    assert.equal(parseRangeBounds("Z1:Z1")?.startCol, 25);
+    assert.equal(parseRangeBounds("AA1:AB2")?.startCol, 26);
+    assert.equal(parseRangeBounds("AA1:AB2")?.endCol, 27);
+  });
+
+  it("keeps a single-cell-wide/tall range (start == end)", () => {
+    assert.deepEqual(parseRangeBounds("B3:B3"), { sheetPrefix: "", startCol: 1, startRow: 3, endCol: 1, endRow: 3 });
+  });
+});
+
+describe("parseRangeBounds — sheet-qualified ranges (the #2390 case)", () => {
+  it("splits an unquoted sheet prefix", () => {
+    assert.deepEqual(parseRangeBounds("Sheet1!A2:C10"), { sheetPrefix: "Sheet1!", startCol: 0, startRow: 2, endCol: 2, endRow: 10 });
+  });
+
+  it("splits a quoted sheet name containing a space", () => {
+    assert.deepEqual(parseRangeBounds("'My Sheet'!A1:B2"), { sheetPrefix: "'My Sheet'!", startCol: 0, startRow: 1, endCol: 1, endRow: 2 });
+  });
+});
+
+describe("parseRangeBounds — non-ranges return null", () => {
+  it("rejects a single cell (no colon)", () => {
+    assert.equal(parseRangeBounds("A1"), null);
+    assert.equal(parseRangeBounds("Sheet1!A1"), null);
+  });
+
+  it("rejects malformed input", () => {
+    assert.equal(parseRangeBounds("not-a-range"), null);
+    assert.equal(parseRangeBounds(""), null);
+  });
+
+  // Deliberate limitation, pinned so it is not "fixed" by accident: the parser
+  // matches uppercase `[A-Z]` with no `$`, exactly as the four former copies did.
+  // The engine's own cell reader (calculator.getCellValue) is likewise
+  // uppercase-only, so accepting these here would not make them resolve.
+  it("rejects lowercase and $-absolute ranges (matches prior lookup behaviour)", () => {
+    assert.equal(parseRangeBounds("a1:b2"), null);
+    assert.equal(parseRangeBounds("$A$1:$B$2"), null);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_parseRangeBounds.ts
+++ b/test/plugins/spreadsheet/engine/test_parseRangeBounds.ts
@@ -5,7 +5,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseRangeBounds } from "../../../../src/plugins/spreadsheet/engine/formulaRefs.ts";
+import { parseRangeBounds, resolveIndexTarget, type RangeBounds } from "../../../../src/plugins/spreadsheet/engine/formulaRefs.ts";
 
 describe("parseRangeBounds — plain ranges", () => {
   it("parses A1:B10 (cols 0-based, rows 1-based)", () => {
@@ -57,5 +57,38 @@ describe("parseRangeBounds — non-ranges return null", () => {
   it("rejects lowercase and $-absolute ranges (matches prior lookup behaviour)", () => {
     assert.equal(parseRangeBounds("a1:b2"), null);
     assert.equal(parseRangeBounds("$A$1:$B$2"), null);
+  });
+});
+
+describe("resolveIndexTarget — INDEX bounds (#2390)", () => {
+  // A2:B5 → cols 0..1, rows 2..5 (4 rows × 2 cols).
+  const bounds: RangeBounds = { sheetPrefix: "", startCol: 0, startRow: 2, endCol: 1, endRow: 5 };
+
+  it("resolves an in-range 1-based position to an absolute cell", () => {
+    assert.deepEqual(resolveIndexTarget(bounds, 1, 1), { colIndex: 0, row: 2 }); // A2
+    assert.deepEqual(resolveIndexTarget(bounds, 4, 2), { colIndex: 1, row: 5 }); // B5
+  });
+
+  it("returns null (→ #REF!) when the row is past the range", () => {
+    const single: RangeBounds = { sheetPrefix: "", startCol: 0, startRow: 1, endCol: 0, endRow: 3 };
+    assert.equal(resolveIndexTarget(single, 5, 1), null); // INDEX(A1:A3,5)
+  });
+
+  it("returns null for a row/col below 1", () => {
+    assert.equal(resolveIndexTarget(bounds, -1, 1), null);
+    assert.equal(resolveIndexTarget(bounds, 1, 3), null); // col past the 2-wide range
+  });
+
+  it("treats Excel's 0 (whole line) as out of range for a multi-line dimension", () => {
+    assert.equal(resolveIndexTarget(bounds, 0, 1), null); // INDEX(A2:B5,0,1) — must NOT read A1
+  });
+
+  it("collapses 0 to the only line when that dimension is a single cell", () => {
+    const oneRow: RangeBounds = { sheetPrefix: "", startCol: 0, startRow: 3, endCol: 2, endRow: 3 };
+    assert.deepEqual(resolveIndexTarget(oneRow, 0, 2), { colIndex: 1, row: 3 }); // whole (single) row, col 2 → B3
+  });
+
+  it("truncates a fractional index toward zero, like Excel", () => {
+    assert.deepEqual(resolveIndexTarget(bounds, 2.9, 1), { colIndex: 0, row: 3 }); // 2.9 → row 2 → A3
   });
 });


### PR DESCRIPTION
## Summary

Two paired issues that both live in `src/plugins/spreadsheet/engine/functions/lookup.ts`, shipped as one PR because the refactor (#2396) centralises the range parsing the bug fix (#2390) needs. Commits are kept separated.

- **#2396 (refactor)** — Delete lookup.ts's private `colToIndex`/`indexToCol` duplicates (byte-for-byte copies of `parser.ts`'s `columnToIndex`/`indexToColumn`) and the four hand-copied range-boundary parses in VLOOKUP/HLOOKUP/INDEX. Replace them with one pure `parseRangeBounds()` in `formulaRefs.ts`.
- **#2390 (bug)** — three lookup/financial bugs:
  - **cross-sheet VLOOKUP threw** — fixed *by* the #2396 consolidation (one former parse copy ran a sheet-unaware regex and rejected `Sheet1!A2:C10` before the sheet-aware copy could run).
  - **INDEX out-of-range read the wrong cell** — `INDEX(A1:A3,5)` read A5, `INDEX(A2:B5,0,1)` read A1. Now returns `#REF!`.
  - **NPV period offset** — a scalar after a range was discounted by its argument index, so `NPV(0.1, A1:A3, 500)` put 500 at period 2 instead of 4.

Pure functions extracted (each unit-tested): `parseRangeBounds` + `resolveIndexTarget` (formulaRefs.ts), `computeNpv` (financial-math.ts).

## Items to Confirm / Review

- **INDEX `0` (whole row/column) handling.** Excel's `0` row/col index means "the entire row/column" (an array). This scalar engine returns one cell, so `resolveIndexTarget` treats `0` as representable only when that dimension is a single line; otherwise it returns `#REF!` rather than silently reading an out-of-range cell (the old A1 read). Pinned as a test — please confirm `#REF!` is the acceptable scalar-engine behaviour vs. an array spill this engine cannot produce.
- **`parseRangeBounds` deliberately matches the prior lookup behaviour**: uppercase `[A-Z]` only, no `$`-absolute or lowercase (they return `null`). The engine's own cell reader is likewise uppercase-only, so accepting them here would not make them resolve. Pinned as a test with the reasoning.
- **NPV period counting**: periods now count *flattened values*, not arguments; numeric-only range filtering (existing `getRangeValues` behaviour) is unchanged, so empty/text cells in a range still do not advance the period.
- **Single canonical copy**: there is only one spreadsheet engine, `src/plugins/spreadsheet/**`. The `packages/mulmoclaude/src/plugins/spreadsheet/...` path does not exist on `main` — no dual-copy sync was needed.

Each regression test was confirmed to go **red** when its fix is reverted (cross-sheet VLOOKUP → returns 0; INDEX → reads A5/A1; NPV range+scalar → wrong period).

## User Prompt

The user assigned the "B group" of spreadsheet lookup/evaluator/cross-sheet issues to be worked in parallel. This PR handles the two paired issues that share `lookup.ts` — **#2390** (lookup boundary + cross-sheet bugs: INDEX out-of-range, cross-sheet VLOOKUP throw, NPV period offset) and **#2396** (move `colToIndex`/`indexToCol` + range parsing out of `lookup.ts` into the shared `formulaRefs.ts`/`parser.ts`) — as one coherent piece of work, since the refactor centralises the parsing the bug fix depends on. Do not touch other spreadsheet issues owned by a separate session. Open PR(s); do not merge.

## Approach & key decisions

- **One PR, separated commits** (`docs(plan)` → `refactor(spreadsheet): #2396` → `fix(spreadsheet): #2390`). Two separate PRs would both edit `lookup.ts` from `main` and self-conflict (neither is merged here), so the coupled single-PR form was chosen per the brief. The cross-sheet VLOOKUP regression test lands with the refactor commit because the consolidation is what fixes it (as #2396 itself notes).
- **`parseRangeBounds(range)`** splits an optional `Sheet!` / `'My Sheet'!` prefix (everything up to the last `!`) then parses the `A2:C10` body into `{ sheetPrefix, startCol, startRow, endCol, endRow }` — columns 0-based via `columnToIndex`, rows 1-based. Behaviour is identical for the single-sheet ranges the four copies already handled; the one intended difference is the disappearing cross-sheet throw.
- **`resolveIndexTarget(bounds, rowNum, colNum)`** validates the 1-based position against the range dimensions, truncating fractional indices toward zero like Excel, and returns `null` (→ `#REF!`) when out of range.
- **`computeNpv(rate, cashFlows)`** discounts each flow by its 1-based position in one flattened, ordered list; the handler flattens ranges (numeric) then scalars in argument order.
- The engine directory is deliberately eslint-ignored (`eslint.config.mjs`), so the new source is code-quality-clean by hand; the added test files pass lint. `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, and all 345 spreadsheet engine tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
