### PR TITLE
fix(core): guard prototype-key field pointers (#2318) and where lookups (#2323)

### DIFF
--- a/packages/core/src/collection/core/schemaRules.ts
+++ b/packages/core/src/collection/core/schemaRules.ts
@@ -24,6 +24,13 @@ import type { CollectionSchemaInput } from "./schemaZ";
 type Schema = CollectionSchemaInput;
 type Fields = Schema["fields"];
 
+// A field pointer names a REAL declared field only when it is an OWN key of
+// `fields`. A bare `fields[name]` reaches inherited Object.prototype members
+// (`constructor`, `__proto__`, `toString`), so an LLM-authored pointer like
+// `completionField: "constructor"` would resolve to a function and pass every
+// "names a declared field" check, then misfire silently at runtime (#2318).
+const declaredField = (fields: Fields, name: string): Fields[string] | undefined => (Object.hasOwn(fields, name) ? fields[name] : undefined);
+
 // The calendar anchor/end fields accept either a date-only or a datetime
 // field (the latter carries the clock for the day view).
 const isDateLike = (type: string | undefined): boolean => type === "date" || type === "datetime";
@@ -38,7 +45,7 @@ const isTimeStringField = (type: string | undefined): boolean => type === "strin
 const CODE_FIELD_TYPES = new Set(["string", "text", "enum"]);
 
 const namesStoredField = (fields: Fields, name: string, primaryKey: string): boolean => {
-  const target = fields[name];
+  const target = declaredField(fields, name);
   return target !== undefined && !COMPUTED_TYPES.has(target.type) && name !== primaryKey;
 };
 
@@ -160,7 +167,7 @@ function collectCurrencyFieldRefs(fields: Record<string, CurrencyBearingField>):
  *  string — a typo (`curreny`) would otherwise pass the per-field check, then
  *  silently fall back to the literal / USD at render and mislabel amounts. */
 export function currencyFieldRefsNameCodeFields(schema: Schema): boolean {
-  return collectCurrencyFieldRefs(schema.fields).every((name) => CODE_FIELD_TYPES.has(schema.fields[name]?.type ?? ""));
+  return collectCurrencyFieldRefs(schema.fields).every((name) => CODE_FIELD_TYPES.has(declaredField(schema.fields, name)?.type ?? ""));
 }
 
 // ---------------------------------------------------------------------------
@@ -176,7 +183,7 @@ export function currencyFieldRefsNameCodeFields(schema: Schema): boolean {
  *  be omitted (declaring it would invite a contradictory second source of
  *  truth). */
 export function completionPairIsCoherent(schema: Schema): boolean {
-  if (schema.completionField !== undefined && schema.fields[schema.completionField]?.type === "flag") {
+  if (schema.completionField !== undefined && declaredField(schema.fields, schema.completionField)?.type === "flag") {
     return schema.completionDoneValues === undefined;
   }
   return (schema.completionField === undefined) === (schema.completionDoneValues === undefined);
@@ -185,7 +192,7 @@ export function completionPairIsCoherent(schema: Schema): boolean {
 /** `completionField` must name a real top-level field — a typo would silently
  *  disable the notification mechanism otherwise. */
 export function completionFieldIsDeclared(schema: Schema): boolean {
-  return schema.completionField === undefined || schema.fields[schema.completionField] !== undefined;
+  return schema.completionField === undefined || declaredField(schema.fields, schema.completionField) !== undefined;
 }
 
 /** A flag named by `completionField` is evaluated against the RAW record — the
@@ -196,11 +203,11 @@ export function completionFieldIsDeclared(schema: Schema): boolean {
  *  never. General (non-completion) flags keep the full vocabulary — the UI
  *  evaluates them post-enrichment. */
 export function completionFlagReadsOnlyStoredFields(schema: Schema): boolean {
-  const spec = schema.completionField === undefined ? undefined : schema.fields[schema.completionField];
+  const spec = schema.completionField === undefined ? undefined : declaredField(schema.fields, schema.completionField);
   if (spec?.type !== "flag") return true;
   return spec.where.every((cond) =>
     [cond.field, ...(cond.valueFrom ? [cond.valueFrom.field] : [])].every((name) => {
-      const target = schema.fields[name];
+      const target = declaredField(schema.fields, name);
       return target !== undefined && !COMPUTED_TYPES.has(target.type);
     }),
   );
@@ -213,14 +220,14 @@ export function completionFlagReadsOnlyStoredFields(schema: Schema): boolean {
 /** `displayField`, like `completionField`, must name a real top-level field —
  *  a typo would silently fall back to the primaryKey forever. */
 export function displayFieldIsDeclared(schema: Schema): boolean {
-  return schema.displayField === undefined || schema.fields[schema.displayField] !== undefined;
+  return schema.displayField === undefined || declaredField(schema.fields, schema.displayField) !== undefined;
 }
 
 /** A field's `when.field` gates its visibility against a sibling's value, so it
  *  must name a real top-level field — a typo would silently keep the field
  *  hidden forever (the gate never matches). */
 export function fieldVisibilityGatesNameDeclaredFields(schema: Schema): boolean {
-  return Object.values(schema.fields).every((field) => field.when === undefined || schema.fields[field.when.field] !== undefined);
+  return Object.values(schema.fields).every((field) => field.when === undefined || declaredField(schema.fields, field.when.field) !== undefined);
 }
 
 /** A flag's `where` reads sibling fields (both `cond.field` and a same-record
@@ -231,7 +238,9 @@ export function flagConditionsNameDeclaredFields(schema: Schema): boolean {
     (field) =>
       field.type !== "flag" ||
       field.where.every(
-        (cond) => schema.fields[cond.field] !== undefined && (cond.valueFrom === undefined || schema.fields[cond.valueFrom.field] !== undefined),
+        (cond) =>
+          declaredField(schema.fields, cond.field) !== undefined &&
+          (cond.valueFrom === undefined || declaredField(schema.fields, cond.valueFrom.field) !== undefined),
       ),
   );
 }
@@ -244,7 +253,7 @@ export function flagConditionsNameDeclaredFields(schema: Schema): boolean {
 export function embedIdFieldsNameIdBearingFields(schema: Schema): boolean {
   return Object.values(schema.fields).every((field) => {
     if (field.type !== "embed" || field.idField === undefined) return true;
-    const target = schema.fields[field.idField];
+    const target = declaredField(schema.fields, field.idField);
     return target !== undefined && (target.type === "ref" || target.type === "string");
   });
 }
@@ -269,7 +278,7 @@ export function togglesProjectValidEnums(schema: Schema): boolean {
   const { fields } = schema;
   for (const spec of Object.values(fields)) {
     if (spec.type !== "toggle") continue;
-    const target = fields[spec.field];
+    const target = declaredField(fields, spec.field);
     if (!target || target.type !== "enum") return false;
     const allowed = new Set(target.values);
     if (!allowed.has(spec.onValue) || !allowed.has(spec.offValue)) return false;
@@ -291,7 +300,7 @@ export function triggerFieldRequiresCompletion(schema: Schema): boolean {
 /** `triggerField` must name a real `date` field — the gate parses its value as
  *  `YYYY-MM-DD`; any other type can't be compared to the clock. */
 export function triggerFieldIsADateField(schema: Schema): boolean {
-  return schema.triggerField === undefined || schema.fields[schema.triggerField]?.type === "date";
+  return schema.triggerField === undefined || declaredField(schema.fields, schema.triggerField)?.type === "date";
 }
 
 /** `triggerLeadDays` only means something relative to a trigger date. */
@@ -312,13 +321,13 @@ export function spawnRequiresTriggerField(schema: Schema): boolean {
 /** `spawn.when.field` must name a real top-level field — a typo would silently
  *  never match. */
 export function spawnWhenFieldIsDeclared(schema: Schema): boolean {
-  return schema.spawn?.when === undefined || schema.fields[schema.spawn.when.field] !== undefined;
+  return schema.spawn?.when === undefined || declaredField(schema.fields, schema.spawn.when.field) !== undefined;
 }
 
 /** Every `spawn.carry` entry must name a real top-level field — a typo would
  *  silently never copy. */
 export function spawnCarryEntriesAreDeclared(schema: Schema): boolean {
-  return (schema.spawn?.carry ?? []).every((name) => schema.fields[name] !== undefined);
+  return (schema.spawn?.carry ?? []).every((name) => declaredField(schema.fields, name) !== undefined);
 }
 
 /** A successor must NOT be born already matching its own spawn predicate — it
@@ -344,7 +353,7 @@ export function spawnSuccessorStartsInert(schema: Schema): boolean {
  *  schema whose completion is flag-form may only spawn with an explicit
  *  `spawn.when` — which that check CAN evaluate. */
 export function flagCompletionSpawnDeclaresWhen(schema: Schema): boolean {
-  return schema.spawn === undefined || schema.spawn.when !== undefined || schema.fields[schema.completionField ?? ""]?.type !== "flag";
+  return schema.spawn === undefined || schema.spawn.when !== undefined || declaredField(schema.fields, schema.completionField ?? "")?.type !== "flag";
 }
 
 // Resolve the field-driven arm of `spawn.every`, or null when spawn is absent
@@ -362,7 +371,7 @@ function fieldDrivenSpawnEvery(schema: Schema) {
 export function fieldDrivenFromFieldIsEnum(schema: Schema): boolean {
   const driven = fieldDrivenSpawnEvery(schema);
   if (!driven) return true;
-  return schema.fields[driven.fromField]?.type === "enum";
+  return declaredField(schema.fields, driven.fromField)?.type === "enum";
 }
 
 /** §4.2 — `map` keys must EXACTLY cover the enum's `values` (no missing keys —
@@ -371,7 +380,7 @@ export function fieldDrivenFromFieldIsEnum(schema: Schema): boolean {
 export function fieldDrivenMapCoversValues(schema: Schema): boolean {
   const driven = fieldDrivenSpawnEvery(schema);
   if (!driven) return true;
-  const target = schema.fields[driven.fromField];
+  const target = declaredField(schema.fields, driven.fromField);
   if (target?.type !== "enum") return true; // §4.1 reports the type error
   const values = new Set<string>(target.values);
   const keys = Object.keys(driven.map);
@@ -409,7 +418,7 @@ export function fieldDrivenFromFieldCarried(schema: Schema): boolean {
  *  parses its value to place records on the month grid (a `datetime` anchor
  *  also carries the clock for the day view). */
 export function calendarFieldIsDateLike(schema: Schema): boolean {
-  return schema.calendarField === undefined || isDateLike(schema.fields[schema.calendarField]?.type);
+  return schema.calendarField === undefined || isDateLike(declaredField(schema.fields, schema.calendarField)?.type);
 }
 
 /** `calendarEndField` marks the end of a multi-day span, so it only means
@@ -420,7 +429,7 @@ export function calendarEndFieldRequiresCalendarField(schema: Schema): boolean {
 
 /** `calendarEndField` must also name a real `date`/`datetime` field — same parse. */
 export function calendarEndFieldIsDateLike(schema: Schema): boolean {
-  return schema.calendarEndField === undefined || isDateLike(schema.fields[schema.calendarEndField]?.type);
+  return schema.calendarEndField === undefined || isDateLike(declaredField(schema.fields, schema.calendarEndField)?.type);
 }
 
 /** `calendarTimeField` places records on the day view, so it only means
@@ -432,20 +441,20 @@ export function calendarTimeFieldRequiresCalendarField(schema: Schema): boolean 
 /** `calendarTimeField` must name a real top-level field (a free-form time
  *  string the day view parses). */
 export function calendarTimeFieldIsDeclared(schema: Schema): boolean {
-  return schema.calendarTimeField === undefined || schema.fields[schema.calendarTimeField] !== undefined;
+  return schema.calendarTimeField === undefined || declaredField(schema.fields, schema.calendarTimeField) !== undefined;
 }
 
 /** …and that field must be string-backed — the day view parses its value as a
  *  time string, so a number/enum/date column can't drive it. */
 export function calendarTimeFieldIsStringBacked(schema: Schema): boolean {
-  return schema.calendarTimeField === undefined || isTimeStringField(schema.fields[schema.calendarTimeField]?.type);
+  return schema.calendarTimeField === undefined || isTimeStringField(declaredField(schema.fields, schema.calendarTimeField)?.type);
 }
 
 /** `kanbanField` must name a real `enum` field — the board groups records into
  *  one column per declared enum value; any other type has no closed set of
  *  columns to group by. */
 export function kanbanFieldIsAnEnum(schema: Schema): boolean {
-  return schema.kanbanField === undefined || schema.fields[schema.kanbanField]?.type === "enum";
+  return schema.kanbanField === undefined || declaredField(schema.fields, schema.kanbanField)?.type === "enum";
 }
 
 // ---------------------------------------------------------------------------
@@ -460,7 +469,7 @@ export function notifyWhenRequiresCompletion(schema: Schema): boolean {
 
 /** `notifyWhen.field` must name a real top-level field. */
 export function notifyWhenFieldIsDeclared(schema: Schema): boolean {
-  return schema.notifyWhen === undefined || schema.fields[schema.notifyWhen.field] !== undefined;
+  return schema.notifyWhen === undefined || declaredField(schema.fields, schema.notifyWhen.field) !== undefined;
 }
 
 /** Every custom view `id` must be a valid slug — it doubles as the view-mode

--- a/packages/core/src/collection/core/where.ts
+++ b/packages/core/src/collection/core/where.ts
@@ -36,6 +36,17 @@ function isMissing(raw: unknown): boolean {
   return raw === undefined || raw === null;
 }
 
+/** Own-property read for a user/LLM-controlled key (`cond.field`,
+ *  `valueFrom.record`, `valueFrom.field`). A bare `obj[key]` reaches inherited
+ *  Object.prototype members, so `field: "toString"` would read a function
+ *  instead of an absent value (spurious match), and `record: "constructor"`
+ *  would read the `Object` function whose `.name`/`.length` are plausible
+ *  bogus comparands — breaking the "unresolved ⇒ never matches" contract
+ *  (#2323). A prototype key resolves to `undefined` (absent). */
+function ownProp<T>(obj: Record<string, T>, key: string): T | undefined {
+  return Object.hasOwn(obj, key) ? obj[key] : undefined;
+}
+
 /** The effective comparison value for `cond`: its literal `value`, or — for
  *  a `valueFrom` reference — the target field read out of `recordsById`.
  *  `undefined` means UNRESOLVED (no such record, or the field on it is
@@ -44,8 +55,8 @@ function isMissing(raw: unknown): boolean {
 function resolveValue(cond: WhereCond, record: Record<string, unknown>, recordsById: Record<string, Record<string, unknown>>): string | string[] | undefined {
   if (!cond.valueFrom) return cond.value;
   const { record: refRecord, field } = cond.valueFrom;
-  const target = refRecord === undefined ? record : recordsById[refRecord];
-  const raw = target?.[field];
+  const target = refRecord === undefined ? record : ownProp(recordsById, refRecord);
+  const raw = target === undefined ? undefined : ownProp(target, field);
   return isMissing(raw) ? undefined : String(raw);
 }
 
@@ -106,7 +117,7 @@ function matchesPresent(operator: WhereOp, raw: string, value: string | string[]
  *    target record/field doesn't exist) → false for EVERY op, including
  *    `ne` — a broken reference must never spuriously match. */
 function matchesCond(cond: WhereCond, record: Record<string, unknown>, recordsById: Record<string, Record<string, unknown>>): boolean {
-  const raw = record[cond.field];
+  const raw = ownProp(record, cond.field);
   if (isMissing(raw)) return cond.op === "ne";
   const value = resolveValue(cond, record, recordsById);
   if (value === undefined) return false;

--- a/plans/fix-2318-2323-protokey-fields.md
+++ b/plans/fix-2318-2323-protokey-fields.md
@@ -1,0 +1,78 @@
+# fix(collections): guard prototype-key field pointers (#2318) and where lookups (#2323)
+
+## Problem
+
+Two sites in `packages/core/src/collection/core` read a property (or test
+membership) on a plain object with a **user/LLM-controlled key** using a bare
+index access. A bare `obj[key]` reaches inherited `Object.prototype` members
+(`constructor`, `__proto__`, `toString`, `hasOwnProperty`), so a schema pointer
+like `completionField: "constructor"` resolves to the `Object` function instead
+of "no such field". The bogus value is truthy and plausible (`Object.name` is
+`"Object"`, `Object.length` is `1`), so validations pass and runtime comparisons
+misfire — silently, with no exception.
+
+This is the same bug family as #2314 (fixed), #2320 (fixed — the `params`
+lookup, out of scope here), #2321 (fixed), #2324 (in progress under PR #2438,
+different files). This PR handles **only** #2318 (schemaRules field pointers)
+and #2323 (where lookups) and touches only those two files.
+
+## Root-cause fix
+
+Gate every user-key lookup on an **own-key** check and treat a prototype key as
+absent / not-a-field:
+
+- `schemaRules.ts`: add a local `declaredField(fields, name)` helper —
+  `Object.hasOwn(fields, name) ? fields[name] : undefined` — and route every
+  field-pointer validator through it. This also structurally ends the mixed
+  discipline the issue calls out (some rules already used
+  `Object.prototype.hasOwnProperty.call`, others bare index).
+- `where.ts`: add a local generic `ownProp(obj, key)` helper and route the three
+  user-key reads (`recordsById[refRecord]`, the target field, and
+  `record[cond.field]`) through it.
+
+`declaredField` / `ownProp` only ever return a NARROWER result (undefined
+instead of an inherited member), so a proto key flips from a false-positive to
+correctly-rejected; no valid schema/record loses acceptance. A field literally
+named `toString` (an OWN key) still resolves.
+
+Scope note: `mutateParamRefsAreDeclared` in the same file reads `params` (not
+`fields`) and is owned by the already-closed #2320 — left untouched.
+
+## Matrix (issue × site × symptom × fix)
+
+| Issue | File / function | User-controlled key | Symptom if a proto key is passed | Fix |
+|---|---|---|---|---|
+| #2318 | `schemaRules.ts` `namesStoredField` (mutate `set`, googleCalendar map) | key name | `set: { constructor: … }` / `map: { toString: … }` validates → stray write / dropped sync | `declaredField` |
+| #2318 | `currencyFieldRefsNameCodeFields` | `currencyField` | `"constructor"` passes → currency mislabels at render | `declaredField` |
+| #2318 | `completionPairIsCoherent` / `completionFieldIsDeclared` | `completionField` | `"constructor"` validates → completion bell reads `item["constructor"]` (always a fn) → never rings/clears | `declaredField` |
+| #2318 | `completionFlagReadsOnlyStoredFields` | flag `where` field / `valueFrom.field` | proto key treated as a stored field | `declaredField` |
+| #2318 | `displayFieldIsDeclared` | `displayField` | `"constructor"` validates → label reads a function | `declaredField` |
+| #2318 | `fieldVisibilityGatesNameDeclaredFields` | field `when.field` | proto gate "declared" → visibility gate never/always | `declaredField` |
+| #2318 | `flagConditionsNameDeclaredFields` | flag `where` field / `valueFrom.field` | proto key passes "names a field" | `declaredField` |
+| #2318 | `embedIdFieldsNameIdBearingFields` | embed `idField` | proto key passes then reads a fn as an id | `declaredField` |
+| #2318 | `togglesProjectValidEnums` | toggle `field` | proto key → `(fn).type` misread | `declaredField` |
+| #2318 | `triggerFieldIsADateField` | `triggerField` | proto key type-probe | `declaredField` |
+| #2318 | `spawnWhenFieldIsDeclared` / `spawnCarryEntriesAreDeclared` | `spawn.when.field` / `spawn.carry[]` | `"constructor"` validates → spawn predicate/carry over a fn | `declaredField` |
+| #2318 | `flagCompletionSpawnDeclaresWhen` | `completionField` | proto key type-probe | `declaredField` |
+| #2318 | `fieldDrivenFromFieldIsEnum` / `fieldDrivenMapCoversValues` | `spawn.every.fromField` | proto key type-probe | `declaredField` |
+| #2318 | calendar (`calendarField` / `calendarEndField` / `calendarTimeField` declared + string-backed) | those pointers | `"constructor"` validates → placement reads a fn | `declaredField` |
+| #2318 | `kanbanFieldIsAnEnum` | `kanbanField` | proto key type-probe | `declaredField` |
+| #2318 | `notifyWhenFieldIsDeclared` | `notifyWhen.field` | `"constructor"` validates | `declaredField` |
+| #2323 | `where.ts` `resolveValue` | `valueFrom.record` | `recordsById["constructor"]` → `Object` fn → `Object.name`=`"Object"` compared → "unresolved ⇒ never matches" contract broken | `ownProp` |
+| #2323 | `where.ts` `resolveValue` | `valueFrom.field` | `target["toString"]` → `String(fn)` compared | `ownProp` |
+| #2323 | `where.ts` `matchesCond` | `cond.field` | `record["toString"]` → not missing → row matches wrongly (dynamicIcon misfire) | `ownProp` |
+
+## Tests (each must go red when the guard is reverted)
+
+- `test/workspace/collections/test_schema_refine_rules.ts`: for every declared-field
+  validator, add a case that a proto-key pointer (`constructor` / `__proto__` /
+  `toString`) is REJECTED, plus a boundary case where an own field literally
+  named `toString` is ACCEPTED.
+- `test/utils/collections/test_where.ts`: proto key as `valueFrom.record`,
+  `valueFrom.field`, and `cond.field` → never matches (eq false, ne false for a
+  broken ref); own field named `toString`/`constructor` still compares normally.
+
+## Verify
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, and the
+collection/core tests. No package version bumps.

--- a/test/utils/collections/test_where.ts
+++ b/test/utils/collections/test_where.ts
@@ -147,3 +147,45 @@ describe("matchesWhere with valueFrom", () => {
     assert.equal(matchesWhere(over, { spent: "120" }), false);
   });
 });
+
+// Regression for #2323: `cond.field` / `valueFrom.record` / `valueFrom.field`
+// are LLM-authored keys. A bare index read reaches Object.prototype members —
+// `record["toString"]` is a function (`isMissing` false → spurious match),
+// `recordsById["constructor"]` is the `Object` function whose `["name"]` is the
+// plausible bogus value `"Object"`. Every such key must resolve as absent /
+// unresolved, never matching.
+describe("matchesWhere — prototype keys resolve as absent (#2323)", () => {
+  it("cond.field is a prototype key → treated as missing, not a matched value", () => {
+    // `record["toString"]` would be a function; `contains` would spuriously match.
+    assert.equal(matchesWhere([{ field: "toString", op: "contains", value: "function" }], {}), false);
+    assert.equal(matchesWhere([{ field: "constructor", op: "contains", value: "Object" }], {}), false);
+    assert.equal(matchesWhere([{ field: "hasOwnProperty", op: "contains", value: "native" }], {}), false);
+  });
+
+  it("valueFrom.record is a prototype key → unresolved, never matches (eq and ne)", () => {
+    // recordsById["constructor"] → Object fn; Object["name"] === "Object".
+    const eqWhere: Where = [{ field: "office", op: "eq", valueFrom: { record: "constructor", field: "name" } }];
+    const neWhere: Where = [{ field: "office", op: "ne", valueFrom: { record: "constructor", field: "name" } }];
+    assert.equal(matchesWhere(eqWhere, { office: "Object" }, {}), false);
+    assert.equal(matchesWhere(neWhere, { office: "tokyo" }, {}), false);
+  });
+
+  it("valueFrom.field (same record) is a prototype key → unresolved, never matches", () => {
+    // record["constructor"] would be a function; a broken ref must not match.
+    assert.equal(matchesWhere([{ field: "office", op: "ne", valueFrom: { field: "constructor" } }], { office: "tokyo" }), false);
+    assert.equal(matchesWhere([{ field: "office", op: "ne", valueFrom: { field: "toString" } }], { office: "tokyo" }), false);
+  });
+
+  it("valueFrom.field (cross record) is a prototype key → unresolved, never matches", () => {
+    const neWhere: Where = [{ field: "office", op: "ne", valueFrom: { record: "_config", field: "toString" } }];
+    assert.equal(matchesWhere(neWhere, { office: "tokyo" }, { _config: { defaultCity: "x" } }), false);
+  });
+
+  it("BOUNDARY: an OWN field literally named `toString` still resolves normally", () => {
+    assert.equal(matchesWhere([{ field: "toString", op: "eq", value: "hello" }], { toString: "hello" }), true);
+    assert.equal(matchesWhere([{ field: "toString", op: "eq", value: "hello" }], { toString: "world" }), false);
+    // …and as a valueFrom target the own value resolves too.
+    const where: Where = [{ field: "office", op: "eq", valueFrom: { record: "_config", field: "toString" } }];
+    assert.equal(matchesWhere(where, { office: "hi" }, { _config: { toString: "hi" } }), true);
+  });
+});

--- a/test/workspace/collections/test_schema_refine_rules.ts
+++ b/test/workspace/collections/test_schema_refine_rules.ts
@@ -542,3 +542,79 @@ describe("collection schema rules — googleCalendar map", () => {
     assertRejects(sync({ id: "summary" }), "never the primaryKey");
   });
 });
+
+// Regression for #2318: a field pointer is an LLM-authored key. A bare
+// `schema.fields[name]` reaches inherited Object.prototype members
+// (`constructor`, `__proto__`, `toString`), so a pointer like
+// `completionField: "constructor"` resolves to a function and PASSES the
+// "names a declared field" check — then misfires silently at runtime. Each of
+// these currently-passing schemas must be REJECTED once the lookup is gated on
+// own-key membership.
+describe("collection schema rules — prototype keys are not declared fields (#2318)", () => {
+  const spawnBase = { completionField: "status", completionDoneValues: ["done"], triggerField: "due" };
+
+  it("rejects a mutate `set` key that is a prototype name", () => {
+    assertRejects({ actions: [{ id: "a", kind: "mutate", label: "A", set: { constructor: "done" } }] }, "must name declared, non-computed fields");
+  });
+
+  it("rejects a googleCalendar map key that is a prototype name", () => {
+    assertRejects({ googleCalendar: { calendarId: "primary", map: { toString: "summary" } } }, "must name a declared, non-computed field");
+  });
+
+  it("rejects a completionField that is a prototype name", () => {
+    assertRejects({ completionField: "constructor", completionDoneValues: ["done"] }, "schema `completionField` must name a top-level field");
+  });
+
+  it("rejects a displayField that is a prototype name", () => {
+    assertRejects({ displayField: "__proto__" }, "schema `displayField` must name a top-level field");
+  });
+
+  it("rejects a field whose `when.field` is a prototype name", () => {
+    assertRejects(
+      { fields: { ...baseFields, extra: { type: "string", label: "Extra", when: { field: "constructor", in: ["x"] } } } },
+      "`when.field` must name",
+    );
+  });
+
+  it("rejects a flag whose `where` field is a prototype name", () => {
+    assertRejects(
+      { fields: { ...baseFields, bad: { type: "flag", label: "Bad", where: [{ field: "toString", op: "eq", value: "x" }] } } },
+      "`where` conditions must name top-level fields",
+    );
+  });
+
+  it("rejects a flag whose `where` valueFrom.field is a prototype name", () => {
+    assertRejects(
+      { fields: { ...baseFields, bad: { type: "flag", label: "Bad", where: [{ field: "status", op: "eq", valueFrom: { field: "constructor" } }] } } },
+      "`where` conditions must name top-level fields",
+    );
+  });
+
+  it("rejects a spawn.when.field that is a prototype name", () => {
+    assertRejects(
+      { ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, when: { field: "constructor", in: ["done"] }, set: { status: "todo" } } },
+      "`spawn.when.field` must name",
+    );
+  });
+
+  it("rejects a spawn.carry entry that is a prototype name", () => {
+    assertRejects(
+      { ...spawnBase, spawn: { every: { unit: "week", interval: 1 }, carry: ["constructor"], set: { status: "todo" } } },
+      "every `spawn.carry` entry must name",
+    );
+  });
+
+  it("rejects a notifyWhen.field that is a prototype name", () => {
+    assertRejects(
+      { completionField: "status", completionDoneValues: ["done"], notifyWhen: { field: "constructor", in: ["x"] } },
+      "schema `notifyWhen.field` must name a top-level field",
+    );
+  });
+
+  // BOUNDARY: a field literally named after a prototype member IS a real OWN
+  // key, so a pointer to it must still be accepted — the guard rejects
+  // INHERITED members, not same-named declared fields.
+  it("accepts a displayField naming an OWN field literally called `toString`", () => {
+    assertAccepts({ fields: { ...baseFields, toString: { type: "string", label: "TS" } }, displayField: "toString" });
+  });
+});


### PR DESCRIPTION
## Summary

Two sites under `packages/core/src/collection/core` read a property (or test membership) on a plain object with a **user/LLM-controlled key** using a bare index access. A bare `obj[key]` reaches inherited `Object.prototype` members (`constructor`, `__proto__`, `toString`, `hasOwnProperty`), so a schema pointer like `completionField: "constructor"` resolves to the `Object` function instead of "no such field" — the bogus value is truthy and plausible (`Object.name` is `"Object"`, `Object.length` is `1`), so validation passes and runtime comparisons misfire, silently, with no exception.

Fix: gate every user-key lookup on an **own-key** check and treat a prototype key as absent / not-a-field.
- `schemaRules.ts`: new local `declaredField(fields, name)` = `Object.hasOwn(fields, name) ? fields[name] : undefined`; every field-pointer validator routes through it (also ends the mixed own-check discipline the issue calls out).
- `where.ts`: new local generic `ownProp(obj, key)`; the three user-key reads (`recordsById[refRecord]`, the target field, `record[cond.field]`) route through it.

Both helpers only ever return a NARROWER result (undefined instead of an inherited member), so a proto key flips from a false-positive to correctly-rejected; no valid schema/record loses acceptance, and a field literally named `toString` (an OWN key) still resolves.

Scope: this PR touches **only** the two files these two issues are about (`schemaRules.ts`, `where.ts`) plus their two test files. It deliberately does **not** touch the files in the in-progress sibling PR #2438 (which fixes #2324), and does **not** touch `mutateParamRefsAreDeclared` (the `params` lookup, owned by the already-closed #2320).

### Matrix (issue × site × symptom × fix)

| Issue | File / function | User-controlled key | Symptom with a proto key | Fix |
|---|---|---|---|---|
| #2318 | `schemaRules.ts` `namesStoredField` (mutate `set` / googleCalendar map) | key name | `set: { constructor: … }` / `map: { toString: … }` validates → stray write / dropped sync | `declaredField` |
| #2318 | `currencyFieldRefsNameCodeFields` | `currencyField` | currency mislabels at render | `declaredField` |
| #2318 | `completionPairIsCoherent` / `completionFieldIsDeclared` | `completionField` | validates → bell reads `item["constructor"]` (always a fn) → never rings/clears | `declaredField` |
| #2318 | `completionFlagReadsOnlyStoredFields` | flag `where` field / `valueFrom.field` | proto key treated as a stored field | `declaredField` |
| #2318 | `displayFieldIsDeclared` | `displayField` | validates → label reads a function | `declaredField` |
| #2318 | `fieldVisibilityGatesNameDeclaredFields` | field `when.field` | proto gate "declared" | `declaredField` |
| #2318 | `flagConditionsNameDeclaredFields` | flag `where` field / `valueFrom.field` | proto key passes "names a field" | `declaredField` |
| #2318 | `embedIdFieldsNameIdBearingFields` | embed `idField` | proto key reaches type-probe as a fn | `declaredField` |
| #2318 | `togglesProjectValidEnums` | toggle `field` | `(fn).type` misread | `declaredField` |
| #2318 | `triggerFieldIsADateField` | `triggerField` | proto key type-probe | `declaredField` |
| #2318 | `spawnWhenFieldIsDeclared` / `spawnCarryEntriesAreDeclared` | `spawn.when.field` / `spawn.carry[]` | validates → spawn predicate/carry over a fn | `declaredField` |
| #2318 | `flagCompletionSpawnDeclaresWhen` | `completionField` | proto key type-probe | `declaredField` |
| #2318 | `fieldDrivenFromFieldIsEnum` / `fieldDrivenMapCoversValues` | `spawn.every.fromField` | proto key type-probe | `declaredField` |
| #2318 | calendar (`calendarField` / `calendarEndField` / `calendarTimeField` declared + string-backed) | those pointers | validates → placement reads a fn | `declaredField` |
| #2318 | `kanbanFieldIsAnEnum` | `kanbanField` | proto key type-probe | `declaredField` |
| #2318 | `notifyWhenFieldIsDeclared` | `notifyWhen.field` | validates | `declaredField` |
| #2323 | `where.ts` `resolveValue` | `valueFrom.record` | `recordsById["constructor"]` → `Object` fn → `Object.name`=`"Object"` compared → "unresolved ⇒ never matches" contract broken | `ownProp` |
| #2323 | `where.ts` `resolveValue` | `valueFrom.field` | `target["toString"]` → `String(fn)` compared | `ownProp` |
| #2323 | `where.ts` `matchesCond` | `cond.field` | `record["toString"]` → not missing → row matches wrongly (dynamicIcon misfire) | `ownProp` |

### Tests

- `test/workspace/collections/test_schema_refine_rules.ts`: +11 cases — a proto-key pointer (`constructor` / `__proto__` / `toString`) is REJECTED for each currently-vulnerable declared-field validator, plus a BOUNDARY case that an OWN field literally named `toString` is still ACCEPTED.
- `test/utils/collections/test_where.ts`: +5 cases — proto key as `cond.field`, `valueFrom.record`, `valueFrom.field` (same + cross record) never matches; BOUNDARY: an OWN field named `toString` still resolves.
- Revert-verified: reverting the two guards turns exactly the discriminating tests red — 4/5 in where.ts and 10/11 in schemaRules (the 2 boundary own-key tests correctly stay green). Restored + rebuilt after.

Verified: `yarn format`, `yarn lint` (0 errors), `yarn typecheck` (exit 0), `yarn build`, and the collection/core tests (789 core-watchers + 37 core + 108 where/schema) all green. No package version bumps.

## Items to Confirm / Review

- **Scope of #2318**: I fixed all field-pointer validators via `declaredField`, but the genuinely-exploitable false-positives (schema wrongly ACCEPTED with a proto key) are the `!== undefined` "is-declared" checks. The `?.type === X` type-probe validators already rejected proto keys (an inherited member's `.type` is `undefined`); routing them through `declaredField` is a uniform-discipline change, not a behavior change — confirm that is the desired breadth.
- **`mutateParamRefsAreDeclared` left untouched** — it reads `params` (not `fields`) and is owned by the closed #2320. Confirm that's the right call vs. also hardening it here.
- **Helper placement**: `declaredField` / `ownProp` are local to each file (per the task's "don't add a new shared module #2438 might also add"). If a shared `hasOwn`-style guard is later centralized, these are the call sites to fold in.

## User Prompt

Progress the leftover prototype-key issues I filed under #2300+ — specifically **#2318** (schemaRules field-pointer validators accept `constructor` etc. as real fields) and **#2323** (`where`'s `valueFrom.record` compares against a bogus value for a prototype key) — while the in-progress #2438 handles the rest of the family (#2324). Restrict changes to the two files those issues are about so they don't conflict with #2438. Follow the bug-family rule: map every case into a matrix and add a failing regression test per case before fixing at the root cause. Open a PR, do not merge.

## Approach

1. Read both issues and confirmed #2438's file list does not overlap `schemaRules.ts` / `where.ts`; confirmed #2320 (closed) owns the `params` lookup and left it alone.
2. Wrote `plans/fix-2318-2323-protokey-fields.md` with the matrix and committed it.
3. Added regression tests that feed prototype keys and assert rejection / never-matches, plus own-key boundary cases; confirmed they fail without the guard (via revert + rebuild, since the tests import the built `@mulmoclaude/core` dist).
4. Fixed at the root cause with the two own-key helpers and routed every user-key lookup through them.
5. Ran format / lint / typecheck / build and the collection tests; all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
