### PR TITLE
refactor(app): extract session lifecycle into useSessionLifecycle (safe layer of #2302)

### DIFF
--- a/plans/refactor-2302-app-session-composable.md
+++ b/plans/refactor-2302-app-session-composable.md
@@ -1,0 +1,81 @@
+# refactor(#2302): App.vue — extract session lifecycle into a composable (safe layer)
+
+Refs #2302. Mirrors the "safe layer" slices of #2382 / #2381 / #2380: keep
+the component's template + rendered DOM byte-for-byte identical, move only
+script logic out, and add unit tests for the pure rules the move exposes.
+
+## Why a composable (not `utils/`)
+
+`src/App.vue` (1376 lines) is already the most composable-ified of the five
+audited files: 30+ `use*` imports, pure helpers already living under
+`utils/session/` · `utils/agent/` · `utils/collections/`. The remaining bloat
+is one concern — **session lifecycle** — so the issue's prescription is
+composable extraction, not another `utils` pass.
+
+## This PR (safe layer)
+
+Extract the session create / switch / load cluster into
+`src/composables/useSessionLifecycle.ts`, wired by dependency injection (a
+typed options object, same shape as `useSessionSync`). Moved verbatim:
+
+- `navigateToSession` (internal)
+- `removeCurrentIfEmpty`
+- `createNewSession`
+- `activateSession` (internal)
+- `loadSession`
+- `refreshSessionTranscript`
+- `resumeOrCreateChatSession`
+- `onRoleChange`
+
+Cross-cutting deps passed in: `sessionMap`, `currentSessionId`, `isChatPage`,
+`roles`, `currentRoleId`, `sessions`, `mergedSessions`,
+`ensureSessionSubscription` (stays in App.vue — it belongs to the *event
+stream* concern that a later PR extracts into `useSessionEventStream`),
+`focusChatInput`, `collapseChatSuggestions`. `useRoute` / `useRouter` are
+called inside the composable (setup context), matching house style.
+
+App.vue keeps its template, watchers, event-stream functions
+(`ensureSessionSubscription` / `handleSessionFinished` / `catchUpMissedEvents`
+…), send flow, and app-api provider untouched; they call the destructured
+functions the composable returns.
+
+## Pure rules extracted + tested
+
+`removeCurrentIfEmpty`, `createNewSession`, `loadSession`, `activateSession`
+and `resumeOrCreateChatSession` each carry an inline DECISION that was never
+unit-tested. Move those to `src/utils/session/sessionLifecycle.ts` and test in
+`test/utils/session/test_sessionLifecycle.ts`:
+
+1. `resolveNewSessionRoleId(explicit, currentRoleId, roleIds)` — the role
+   fallback chain `explicit ?? (current || roles[0] || "")`. TOP priority: a
+   silent wrong value here starts a chat in the wrong role. Test explicit
+   wins, current fallback, first-role fallback, all-empty → "".
+2. `shouldReplaceHistory(removedEmpty, isChatPage)` — `replace` vs `push`
+   decision, shared by `createNewSession` + `loadSession`. Full truth table.
+3. `isSessionEmpty(session)` — the `removeCurrentIfEmpty` predicate.
+4. `isSessionAlreadyDisplayed(sessionId, currentSessionId, inMemory)` —
+   `loadSession`'s early-return guard.
+5. `isOnTargetSessionRoute(routeSessionId, targetSessionId, onChatPage)` —
+   `activateSession`'s "skip redundant navigate (would strip `?result=`)".
+6. `resolveResumeAction(topSessionId, topInMemory)` → `create|activate|load` —
+   `resumeOrCreateChatSession`'s branch.
+
+Each test is verified to go RED when the rule is inverted.
+
+## Out of scope (deferred, tracked by #2302)
+
+- `useSessionEventStream` (pub/sub + event dispatch + catch-up)
+- `useAppApiProvider`, `useSendMessage`, `useGoogleMapsKey`
+- template → `MainRouterOutlet.vue`
+
+## e2e / DOM safety
+
+App.vue's only two testids (`chat-sidebar`, `session-history-side-panel`) and
+their surrounding flex/nesting are untouched — this PR edits `<script setup>`
+exclusively. No testid renamed, no DOM reordered, no `SessionSidebar` prop /
+slot change. Behaviour identical (verbatim move + DI).
+
+## Constraints
+
+No `any`, no `as`, functions < 20 lines, `const` over `let`, relative imports.
+No package version bumps.

--- a/src/App.vue
+++ b/src/App.vue
@@ -337,7 +337,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onScopeDispose, reactive } from "vue";
 import { useI18n } from "vue-i18n";
-import { v4 as uuidv4 } from "uuid";
 import { getPlugin } from "./tools";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import BackendOfflineBanner from "./components/BackendOfflineBanner.vue";
@@ -364,7 +363,7 @@ import PluginScopedRoot from "./components/PluginScopedRoot.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import { PAGE_ROUTES, type PageRouteName } from "./router";
 import type { SseEvent } from "./types/sse";
-import type { SessionEntry, ActiveSession } from "./types/session";
+import type { ActiveSession } from "./types/session";
 import { EVENT_TYPES } from "./types/events";
 import { buildAgentRequestBody, postAgentRun } from "./utils/agent/request";
 import { resolvePastedAttachment } from "./utils/agent/pastedAttachment";
@@ -373,8 +372,6 @@ import { pushErrorMessage, beginUserTurn, updateResult, applyToolResultToSession
 import { parseCollectionSlashSeed, makeSyntheticCollectionResult, hasRealCollectionResult } from "./utils/collections/presentSeed";
 import { mergeBufferedIntoDraft } from "./utils/chat/buffer";
 import { roleName, roleIcon } from "./utils/role/icon";
-import { createEmptySession } from "./utils/session/sessionFactory";
-import { buildLoadedSession, parseSessionEntries, shouldAdoptServerTranscript } from "./utils/session/sessionEntries";
 import { usePendingCalls } from "./composables/usePendingCalls";
 import { loadCspExtra } from "./composables/useCspExtra";
 import { cspViolations, dismissCspViolations, installCspViolationListener } from "./composables/useCspViolations";
@@ -385,6 +382,7 @@ import { useChatScroll } from "./composables/useChatScroll";
 import { useFileDropZone } from "./composables/useFileDropZone";
 import { useViewLayout } from "./composables/useViewLayout";
 import { useSessionSync } from "./composables/useSessionSync";
+import { useSessionLifecycle } from "./composables/useSessionLifecycle";
 import { useSessionDerived } from "./composables/useSessionDerived";
 import { useFaviconState } from "./composables/useFaviconState";
 import { useGlobalImageErrorRepair } from "./composables/useImageErrorRepair";
@@ -450,35 +448,6 @@ const { subscribe: pubsubSubscribe, onReconnect: pubsubOnReconnect } = usePubSub
 const route = useRoute();
 const router = useRouter();
 
-function navigateToSession(sessionId: string, replace = false): void {
-  currentSessionId.value = sessionId;
-  const method = replace ? router.replace : router.push;
-  method({
-    name: PAGE_ROUTES.chat,
-    params: { sessionId },
-  }).catch((err) => {
-    if (err?.type !== 16) {
-      console.error("[navigateToSession] push failed:", err);
-    }
-  });
-}
-
-// External URL changes (back/forward button, typed URL) → update ref.
-// If the session isn't in memory, load it from the server.
-watch(
-  () => route.params.sessionId,
-  async (newId) => {
-    if (typeof newId !== "string" || newId === currentSessionId.value) return;
-    currentSessionId.value = newId;
-    if (!sessionMap.has(newId)) {
-      await loadSession(newId);
-      if (!sessionMap.has(newId)) {
-        createNewSession();
-      }
-    }
-  },
-);
-
 // --- Global state ---
 // `roles` is the merged list (built-in + custom). `currentRoleId`
 // is the role-selector dropdown's current pick — App.vue reads it
@@ -513,17 +482,6 @@ const currentBufferedMessages = computed<string[]>({
 const activePane = ref<"sidebar" | "main">("sidebar");
 
 const { sessions, historyError, fetchSessions, setBookmark, deleteSession: deleteSessionFromHistory } = useSessionHistory();
-const { markSessionRead, refreshSessionStates } = useSessionSync({
-  sessionMap,
-  currentSessionId,
-  fetchSessions,
-  // Another tab hard-deleted the chat we're currently viewing. The
-  // sessionMap eviction has already cleared the in-memory state; the
-  // URL still points at the dead id. Mirror the URL→404 fallback on
-  // line ~366 by spinning up a fresh session so the user lands on a
-  // working /chat instead of a blank pane.
-  onCurrentSessionDeleted: () => createNewSession(),
-});
 const { geminiAvailable, sandboxEnabled, cpuLoadRatio, fetchHealth } = useHealth();
 
 const { activeSession, toolResults, sidebarResults, isRunning, activeSessionRunning, statusMessage, toolCallHistory, activeSessionCount, unreadCount } =
@@ -660,6 +618,50 @@ const currentPage = computed<PageRouteName | null>(() => {
   const { name } = route;
   return typeof name === "string" && isPageRouteName(name) ? name : null;
 });
+
+// Session lifecycle (create / switch / load / resume). The event-stream
+// hook `ensureSessionSubscription` (a hoisted function below) is injected
+// so this composable stays out of the pub/sub concern.
+const { removeCurrentIfEmpty, createNewSession, onRoleChange, loadSession, refreshSessionTranscript, resumeOrCreateChatSession } = useSessionLifecycle({
+  sessionMap,
+  currentSessionId,
+  isChatPage,
+  roles,
+  currentRoleId,
+  sessions,
+  mergedSessions,
+  ensureSessionSubscription,
+  focusChatInput,
+  collapseChatSuggestions: () => chatInputRef.value?.collapseSuggestions(),
+});
+
+const { markSessionRead, refreshSessionStates } = useSessionSync({
+  sessionMap,
+  currentSessionId,
+  fetchSessions,
+  // Another tab hard-deleted the chat we're currently viewing. The
+  // sessionMap eviction has already cleared the in-memory state; the
+  // URL still points at the dead id. Mirror the URL→404 fallback in
+  // loadSession by spinning up a fresh session so the user lands on a
+  // working /chat instead of a blank pane.
+  onCurrentSessionDeleted: () => createNewSession(),
+});
+
+// External URL changes (back/forward button, typed URL) → update ref.
+// If the session isn't in memory, load it from the server.
+watch(
+  () => route.params.sessionId,
+  async (newId) => {
+    if (typeof newId !== "string" || newId === currentSessionId.value) return;
+    currentSessionId.value = newId;
+    if (!sessionMap.has(newId)) {
+      await loadSession(newId);
+      if (!sessionMap.has(newId)) {
+        createNewSession();
+      }
+    }
+  },
+);
 
 // Refresh the files tree after each agent run so newly written files
 // appear without a manual reload.
@@ -855,153 +857,6 @@ function handleUpdateResult(updatedResult: ToolResultComplete) {
 
 function onSidebarItemClick(uuid: string) {
   selectedResultUuid.value = uuid;
-}
-
-// Remove the current session from sessionMap if it's empty (no messages).
-// Returns true if a session was removed, so the caller can use
-// router.replace instead of router.push to keep the empty session out
-// of browser navigation history.
-function removeCurrentIfEmpty(): boolean {
-  const sessionId = currentSessionId.value;
-  if (!sessionId) return false;
-  const session = sessionMap.get(sessionId);
-  if (session && session.toolResults.length === 0) {
-    sessionMap.delete(sessionId);
-    return true;
-  }
-  return false;
-}
-
-// Replace vs push is derived from state, not chosen by the caller:
-// replace only when we just discarded an empty session AND we're
-// currently on that same /chat/:emptyId URL — otherwise there's
-// something worth keeping in history (a real chat transcript, or
-// a non-chat page like /wiki the user came from).
-function createNewSession(roleId?: string): ActiveSession {
-  const removedEmpty = removeCurrentIfEmpty();
-  const replace = removedEmpty && isChatPage.value;
-  // The "+" button and role-change handler always supply roleId
-  // (read from SessionHeaderControls). When omitted (plugin-driven
-  // startNewChat, initial bootstrap, post-failure recovery) inherit
-  // the dropdown's current selection so the new chat uses the role
-  // the user last picked. Final fallback to roles[0] only matters
-  // before the dropdown has seeded (very early bootstrap).
-  const rId = roleId ?? (currentRoleId.value || roles.value[0]?.id || "");
-  const session = createEmptySession(uuidv4(), rId);
-  sessionMap.set(session.id, session);
-  navigateToSession(session.id, replace);
-  chatInputRef.value?.collapseSuggestions();
-  nextTick(() => focusChatInput());
-  return session;
-}
-
-function onRoleChange(roleId: string) {
-  // On non-chat pages (wiki, files, etc.) the user is just picking
-  // the role that future new-chat actions should use — don't yank
-  // them onto /chat by creating a session here. The new selection
-  // is preserved inside SessionHeaderControls (useCurrentRole) and
-  // future "+" clicks will read it from there.
-  if (!isChatPage.value) return;
-  createNewSession(roleId);
-}
-
-// Land on /chat with no specific session in mind (initial load or
-// home-button click). Prefer the most-recent session so the user
-// resumes where they left off; only create a fresh session when they
-// have no chat history at all. Explicit "+" clicks and role switches
-// still create a new session via createNewSession() directly.
-async function resumeOrCreateChatSession(): Promise<void> {
-  const topId = mergedSessions.value[0]?.id;
-  if (!topId) {
-    createNewSession();
-    return;
-  }
-  if (sessionMap.has(topId)) {
-    activateSession(topId, false);
-    return;
-  }
-  await loadSession(topId);
-  // loadSession silently returns on fetch failure (stale summary,
-  // transient API error). Without a fallback, /chat is left with no
-  // active session and sendMessage becomes a no-op.
-  if (!sessionMap.has(topId)) {
-    createNewSession();
-  }
-}
-
-function activateSession(sessionId: string, replace: boolean): void {
-  const reactiveSession = sessionMap.get(sessionId);
-  if (reactiveSession) ensureSessionSubscription(reactiveSession);
-  // Skip the redundant navigateToSession when we're already on the
-  // matching /chat/:sessionId URL. The route-watcher path arrives
-  // here AFTER the URL has changed (notification permalink, browser
-  // back/forward, manual paste), and re-pushing the same path would
-  // strip query strings — `?result=<uuid>` for the
-  // notification-permalink case (#762) — because navigateToSession
-  // builds the location object with `params` only.
-  const onTargetSession = route.name === PAGE_ROUTES.chat && route.params.sessionId === sessionId;
-  if (!onTargetSession) {
-    navigateToSession(sessionId, replace);
-  }
-  // Closing the history popup is no longer explicit — navigating to
-  // /chat/:id via navigateToSession changes the route, and the
-  // canvas-column branches away from SessionHistoryPanel naturally.
-}
-
-async function loadSession(sessionId: string) {
-  // currentSessionId is `""` on non-chat pages, so clicking a session
-  // in the history panel from /wiki never matches and always navigates
-  // to /chat. On /chat this guard just avoids re-navigating to the
-  // session we're already displaying.
-  const alreadyOnThatChat = sessionId === currentSessionId.value && sessionMap.has(sessionId);
-  if (alreadyOnThatChat) return;
-  // Mirror createNewSession: only replace when we just discarded an
-  // empty session AND we're on that /chat/:emptyId URL. On any
-  // non-chat page selecting a session must push, otherwise the
-  // current entry would be skipped when the last chat happened to
-  // be empty.
-  const removedEmpty = removeCurrentIfEmpty();
-  const replaced = removedEmpty && isChatPage.value;
-
-  const live = sessionMap.get(sessionId);
-  if (live) {
-    activateSession(sessionId, replaced);
-    return;
-  }
-
-  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
-  if (!response.ok) return;
-
-  const newSession = buildLoadedSession({
-    id: sessionId,
-    entries: response.data,
-    defaultRoleId: roles.value[0]?.id ?? "",
-    serverSummary: sessions.value.find((summary) => summary.id === sessionId),
-    nowIso: new Date().toISOString(),
-  });
-  sessionMap.set(sessionId, newSession);
-  activateSession(sessionId, replaced);
-}
-
-// Re-fetch the transcript from the server and patch any entries the
-// client missed (e.g. due to a pub-sub disconnect during a long
-// Docker build). Called on session_finished so the user sees the
-// full response even if mid-run events were lost. See issue #350.
-async function refreshSessionTranscript(sessionId: string): Promise<void> {
-  const session = sessionMap.get(sessionId);
-  if (!session) return;
-  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
-  if (!response.ok) return;
-  const summary = sessions.value.find((entry) => entry.id === sessionId);
-  const serverResults = parseSessionEntries(response.data, summary?.origin);
-  // Only patch if the server knows more than we do — avoids replacing a
-  // richer in-flight state with a stale snapshot when session_finished
-  // races with the last few events. Compares total text, not just card
-  // count, so a text card truncated by a dropped socket.io frame (same
-  // count, shorter body) is still caught up (#2096).
-  if (shouldAdoptServerTranscript(serverResults, session.toolResults)) {
-    session.toolResults = serverResults;
-  }
 }
 
 function buildAgentEventContext(session: ActiveSession): AgentEventContext {

--- a/src/composables/useSessionLifecycle.ts
+++ b/src/composables/useSessionLifecycle.ts
@@ -1,0 +1,175 @@
+// Session lifecycle: create / switch / load / resume a chat session.
+// Extracted from App.vue (#2302) — the imperative shell over the pure
+// rules in ../utils/session/sessionLifecycle.ts. Each step is a
+// module-level function taking an explicit `LifecycleCtx` so the wiring
+// stays flat and the cross-cutting state (sessionMap, role list, session
+// summaries) plus the event-stream hook `ensureSessionSubscription` are
+// injected — App.vue remains their single owner. A later PR extracts the
+// event-stream concern (subscribe / dispatch / catch-up) on its own.
+
+import { nextTick, type ComputedRef, type Ref } from "vue";
+import { useRoute, useRouter, isNavigationFailure, NavigationFailureType } from "vue-router";
+import { v4 as uuidv4 } from "uuid";
+import type { ActiveSession, SessionEntry, SessionSummary } from "../types/session";
+import type { Role } from "../config/roles";
+import { PAGE_ROUTES } from "../router";
+import { apiGet } from "../utils/api";
+import { API_ROUTES } from "../config/apiRoutes";
+import { createEmptySession } from "../utils/session/sessionFactory";
+import { buildLoadedSession, parseSessionEntries, shouldAdoptServerTranscript } from "../utils/session/sessionEntries";
+import {
+  resolveNewSessionRoleId,
+  shouldReplaceHistory,
+  isSessionEmpty,
+  isSessionAlreadyDisplayed,
+  isOnTargetSessionRoute,
+  resolveResumeAction,
+} from "../utils/session/sessionLifecycle";
+
+interface LifecycleDeps {
+  sessionMap: Map<string, ActiveSession>;
+  currentSessionId: Ref<string>;
+  isChatPage: Ref<boolean> | ComputedRef<boolean>;
+  roles: Ref<Role[]>;
+  currentRoleId: Ref<string>;
+  sessions: Ref<SessionSummary[]>;
+  mergedSessions: Ref<SessionSummary[]> | ComputedRef<SessionSummary[]>;
+  ensureSessionSubscription: (session: ActiveSession) => void;
+  focusChatInput: () => void;
+  collapseChatSuggestions: () => void;
+}
+
+type LifecycleCtx = LifecycleDeps & {
+  route: ReturnType<typeof useRoute>;
+  router: ReturnType<typeof useRouter>;
+};
+
+// The URL is the source of truth for "which session is on /chat";
+// currentSessionId is written synchronously first so a follow-up
+// sendMessage lands in the new session before the route settles.
+function navigateToSession(ctx: LifecycleCtx, sessionId: string, replace = false): void {
+  ctx.currentSessionId.value = sessionId;
+  const method = replace ? ctx.router.replace : ctx.router.push;
+  // A duplicated-navigation rejection (pushing the route we're already on)
+  // is expected and noise; anything else is a real failure worth logging.
+  method({ name: PAGE_ROUTES.chat, params: { sessionId } }).catch((err) => {
+    if (!isNavigationFailure(err, NavigationFailureType.duplicated)) {
+      console.error("[navigateToSession] push failed:", err);
+    }
+  });
+}
+
+// Evict the displayed session when it has no messages (never persisted).
+// Returns whether it removed one, so the caller can replace instead of
+// push and keep the throwaway URL out of history.
+function removeCurrentIfEmpty(ctx: LifecycleCtx): boolean {
+  const sessionId = ctx.currentSessionId.value;
+  if (!sessionId) return false;
+  const session = ctx.sessionMap.get(sessionId);
+  if (session && isSessionEmpty(session)) {
+    ctx.sessionMap.delete(sessionId);
+    return true;
+  }
+  return false;
+}
+
+function createNewSession(ctx: LifecycleCtx, roleId?: string): ActiveSession {
+  const replace = shouldReplaceHistory(removeCurrentIfEmpty(ctx), ctx.isChatPage.value);
+  const rId = resolveNewSessionRoleId(
+    roleId,
+    ctx.currentRoleId.value,
+    ctx.roles.value.map((role) => role.id),
+  );
+  const session = createEmptySession(uuidv4(), rId);
+  ctx.sessionMap.set(session.id, session);
+  navigateToSession(ctx, session.id, replace);
+  ctx.collapseChatSuggestions();
+  void nextTick(() => ctx.focusChatInput());
+  return session;
+}
+
+// On non-chat pages the user is just picking the role that future
+// new-chat actions should use — don't yank them onto /chat.
+function onRoleChange(ctx: LifecycleCtx, roleId: string): void {
+  if (!ctx.isChatPage.value) return;
+  createNewSession(ctx, roleId);
+}
+
+function activateSession(ctx: LifecycleCtx, sessionId: string, replace: boolean): void {
+  const reactiveSession = ctx.sessionMap.get(sessionId);
+  if (reactiveSession) ctx.ensureSessionSubscription(reactiveSession);
+  const routeSessionId = typeof ctx.route.params.sessionId === "string" ? ctx.route.params.sessionId : "";
+  // Skip a redundant navigate when the URL already points at the target:
+  // re-pushing the same path strips query strings (e.g. `?result=<uuid>`,
+  // #762) because navigateToSession builds the location with params only.
+  if (!isOnTargetSessionRoute(routeSessionId, sessionId, ctx.route.name === PAGE_ROUTES.chat)) {
+    navigateToSession(ctx, sessionId, replace);
+  }
+}
+
+async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> {
+  if (isSessionAlreadyDisplayed(sessionId, ctx.currentSessionId.value, ctx.sessionMap.has(sessionId))) return;
+  const replaced = shouldReplaceHistory(removeCurrentIfEmpty(ctx), ctx.isChatPage.value);
+  if (ctx.sessionMap.has(sessionId)) {
+    activateSession(ctx, sessionId, replaced);
+    return;
+  }
+  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
+  if (!response.ok) return;
+  const newSession = buildLoadedSession({
+    id: sessionId,
+    entries: response.data,
+    defaultRoleId: ctx.roles.value[0]?.id ?? "",
+    serverSummary: ctx.sessions.value.find((summary) => summary.id === sessionId),
+    nowIso: new Date().toISOString(),
+  });
+  ctx.sessionMap.set(sessionId, newSession);
+  activateSession(ctx, sessionId, replaced);
+}
+
+// Re-fetch the transcript and patch entries missed via a dropped socket
+// frame. Only adopts the server view when it is strictly richer (#2096),
+// so it stays idempotent against races with live events.
+async function refreshSessionTranscript(ctx: LifecycleCtx, sessionId: string): Promise<void> {
+  const session = ctx.sessionMap.get(sessionId);
+  if (!session) return;
+  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
+  if (!response.ok) return;
+  const summary = ctx.sessions.value.find((entry) => entry.id === sessionId);
+  const serverResults = parseSessionEntries(response.data, summary?.origin);
+  if (shouldAdoptServerTranscript(serverResults, session.toolResults)) {
+    session.toolResults = serverResults;
+  }
+}
+
+// Land on /chat with no specific session in mind (initial load / home
+// button): resume the most-recent session, creating a fresh one only
+// when there is no history at all.
+async function resumeOrCreateChatSession(ctx: LifecycleCtx): Promise<void> {
+  const topId = ctx.mergedSessions.value[0]?.id;
+  const action = resolveResumeAction(topId, topId !== undefined && ctx.sessionMap.has(topId));
+  if (action === "create" || topId === undefined) {
+    createNewSession(ctx);
+    return;
+  }
+  if (action === "activate") {
+    activateSession(ctx, topId, false);
+    return;
+  }
+  // loadSession silently returns on fetch failure; fall back to a fresh
+  // session so /chat is never left without an active one.
+  await loadSession(ctx, topId);
+  if (!ctx.sessionMap.has(topId)) createNewSession(ctx);
+}
+
+export function useSessionLifecycle(deps: LifecycleDeps) {
+  const ctx: LifecycleCtx = { ...deps, route: useRoute(), router: useRouter() };
+  return {
+    removeCurrentIfEmpty: () => removeCurrentIfEmpty(ctx),
+    createNewSession: (roleId?: string) => createNewSession(ctx, roleId),
+    onRoleChange: (roleId: string) => onRoleChange(ctx, roleId),
+    loadSession: (sessionId: string) => loadSession(ctx, sessionId),
+    refreshSessionTranscript: (sessionId: string) => refreshSessionTranscript(ctx, sessionId),
+    resumeOrCreateChatSession: () => resumeOrCreateChatSession(ctx),
+  };
+}

--- a/src/utils/session/sessionLifecycle.ts
+++ b/src/utils/session/sessionLifecycle.ts
@@ -1,0 +1,57 @@
+// Pure decision rules pulled out of App.vue's session-lifecycle
+// functions (createNewSession / loadSession / activateSession /
+// removeCurrentIfEmpty / resumeOrCreateChatSession). Kept side-effect
+// free so the branch logic is unit-testable without a component,
+// router, or reactive state. The composable `useSessionLifecycle`
+// holds the imperative shell that calls these.
+
+// Role a freshly-created session should use. The "+" button and the
+// role-change handler pass an explicit id; plugin-driven startNewChat,
+// bootstrap, and post-failure recovery omit it and inherit the
+// dropdown's current pick, falling back to the first available role.
+// The trailing "" only matters before any role has seeded.
+export function resolveNewSessionRoleId(explicitRoleId: string | undefined, currentRoleId: string, roleIds: readonly string[]): string {
+  return explicitRoleId ?? (currentRoleId || roleIds[0] || "");
+}
+
+// router.replace vs router.push is derived from state: replace only
+// when we just discarded an empty session AND we're on /chat — that
+// keeps the throwaway empty-session URL out of browser history without
+// swallowing a real transcript or a non-chat page the user came from.
+export function shouldReplaceHistory(removedEmptySession: boolean, onChatPage: boolean): boolean {
+  return removedEmptySession && onChatPage;
+}
+
+// A session with no results was never sent to; we don't persist those,
+// so removeCurrentIfEmpty evicts them on navigate.
+export function isSessionEmpty(session: { toolResults: readonly unknown[] }): boolean {
+  return session.toolResults.length === 0;
+}
+
+// loadSession's early-return guard: nothing to do when the requested
+// session is the one already displayed on /chat. currentSessionId is
+// "" off /chat, so a history-panel click there never matches and always
+// navigates.
+export function isSessionAlreadyDisplayed(sessionId: string, currentSessionId: string, sessionInMemory: boolean): boolean {
+  return sessionId === currentSessionId && sessionInMemory;
+}
+
+// activateSession skips a redundant navigate when the URL already points
+// at the target session. Re-pushing the same path strips query strings
+// (e.g. the `?result=<uuid>` notification permalink, #762), so the guard
+// matters even though the visible route looks unchanged.
+export function isOnTargetSessionRoute(currentRouteSessionId: string, targetSessionId: string, onChatPage: boolean): boolean {
+  return onChatPage && currentRouteSessionId === targetSessionId;
+}
+
+export type ResumeAction = "create" | "activate" | "load";
+
+// Landing on /chat with no specific session in mind (initial load /
+// home button): resume the most-recent session when there is one,
+// activating it in place if already in memory, otherwise loading it;
+// only create a fresh session when there is no history at all.
+export function resolveResumeAction(topSessionId: string | undefined, topSessionInMemory: boolean): ResumeAction {
+  if (!topSessionId) return "create";
+  if (topSessionInMemory) return "activate";
+  return "load";
+}

--- a/test/utils/session/test_sessionLifecycle.ts
+++ b/test/utils/session/test_sessionLifecycle.ts
@@ -1,0 +1,128 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveNewSessionRoleId,
+  shouldReplaceHistory,
+  isSessionEmpty,
+  isSessionAlreadyDisplayed,
+  isOnTargetSessionRoute,
+  resolveResumeAction,
+} from "../../../src/utils/session/sessionLifecycle.ts";
+
+describe("resolveNewSessionRoleId", () => {
+  it("uses the explicit role id when provided", () => {
+    assert.equal(resolveNewSessionRoleId("editor", "general", ["general", "coder"]), "editor");
+  });
+
+  it("prefers the explicit id even when it is not in the known roles", () => {
+    // createNewSession does not validate the id it is handed (comment on
+    // startNewChatDraft) — the explicit id wins verbatim.
+    assert.equal(resolveNewSessionRoleId("unknown", "general", ["general"]), "unknown");
+  });
+
+  it("keeps an explicit empty string (?? only falls through on undefined)", () => {
+    // `?? ` triggers only on null/undefined, so an explicit "" is honoured
+    // rather than falling back to the dropdown pick.
+    assert.equal(resolveNewSessionRoleId("", "general", ["general"]), "");
+  });
+
+  it("falls back to the current dropdown role when no explicit id", () => {
+    assert.equal(resolveNewSessionRoleId(undefined, "coder", ["general", "coder"]), "coder");
+  });
+
+  it("falls back to the first role when both explicit and current are empty", () => {
+    assert.equal(resolveNewSessionRoleId(undefined, "", ["general", "coder"]), "general");
+  });
+
+  it("returns '' when explicit is undefined, current is empty, and no roles seeded", () => {
+    assert.equal(resolveNewSessionRoleId(undefined, "", []), "");
+  });
+});
+
+describe("shouldReplaceHistory", () => {
+  it("replaces only when an empty session was removed AND on /chat", () => {
+    assert.equal(shouldReplaceHistory(true, true), true);
+  });
+
+  it("pushes when nothing empty was removed, even on /chat", () => {
+    assert.equal(shouldReplaceHistory(false, true), false);
+  });
+
+  it("pushes when off /chat, even after removing an empty session", () => {
+    assert.equal(shouldReplaceHistory(true, false), false);
+  });
+
+  it("pushes when neither condition holds", () => {
+    assert.equal(shouldReplaceHistory(false, false), false);
+  });
+});
+
+describe("isSessionEmpty", () => {
+  it("is true for a session with no tool results", () => {
+    assert.equal(isSessionEmpty({ toolResults: [] }), true);
+  });
+
+  it("is false as soon as one result exists", () => {
+    assert.equal(isSessionEmpty({ toolResults: [{}] }), false);
+  });
+
+  it("is false for many results", () => {
+    assert.equal(isSessionEmpty({ toolResults: [{}, {}, {}] }), false);
+  });
+});
+
+describe("isSessionAlreadyDisplayed", () => {
+  it("is true only when id matches the displayed one AND it is in memory", () => {
+    assert.equal(isSessionAlreadyDisplayed("s1", "s1", true), true);
+  });
+
+  it("is false when the id matches but it is not in memory", () => {
+    assert.equal(isSessionAlreadyDisplayed("s1", "s1", false), false);
+  });
+
+  it("is false when a different session is displayed", () => {
+    assert.equal(isSessionAlreadyDisplayed("s1", "s2", true), false);
+  });
+
+  it("is false off /chat where currentSessionId is empty", () => {
+    // currentSessionId is "" on non-chat pages, so a history-panel click
+    // there never matches and always navigates.
+    assert.equal(isSessionAlreadyDisplayed("s1", "", true), false);
+  });
+});
+
+describe("isOnTargetSessionRoute", () => {
+  it("is true when on /chat and the URL already points at the target", () => {
+    assert.equal(isOnTargetSessionRoute("s1", "s1", true), true);
+  });
+
+  it("is false when the URL points at a different session", () => {
+    assert.equal(isOnTargetSessionRoute("s2", "s1", true), false);
+  });
+
+  it("is false when not on the chat route, even if ids match", () => {
+    assert.equal(isOnTargetSessionRoute("s1", "s1", false), false);
+  });
+
+  it("is false when the route has no session id", () => {
+    assert.equal(isOnTargetSessionRoute("", "s1", true), false);
+  });
+});
+
+describe("resolveResumeAction", () => {
+  it("creates a fresh session when there is no history", () => {
+    assert.equal(resolveResumeAction(undefined, false), "create");
+  });
+
+  it("activates the top session in place when it is already in memory", () => {
+    assert.equal(resolveResumeAction("s1", true), "activate");
+  });
+
+  it("loads the top session from the server when it is not in memory", () => {
+    assert.equal(resolveResumeAction("s1", false), "load");
+  });
+
+  it("creates when the top id is an empty string (falsy)", () => {
+    assert.equal(resolveResumeAction("", true), "create");
+  });
+});


### PR DESCRIPTION
## Summary

Safe-layer refactor of `src/App.vue` (#2302): extract the **session lifecycle** concern out of the 1376-line component into a focused composable, keeping the template and rendered DOM byte-for-byte identical.

- **`src/composables/useSessionLifecycle.ts`** (new) — holds `createNewSession` / `onRoleChange` / `loadSession` / `refreshSessionTranscript` / `removeCurrentIfEmpty` / `resumeOrCreateChatSession` (plus internal `navigateToSession` / `activateSession`). Wired by dependency injection through a typed context object, same shape as the existing `useSessionSync`. `ensureSessionSubscription` (the pub/sub concern a later PR extracts) is injected so App.vue stays its owner.
- **`src/utils/session/sessionLifecycle.ts`** (new) — the pure decision rules those functions carried inline, now side-effect-free and unit-testable.
- **`test/utils/session/test_sessionLifecycle.ts`** (new) — 25 tests, verified to go red when each rule is inverted.
- `src/App.vue`: 1376 → 1231 lines (net −145). Only `<script setup>` changed.

This mirrors the "safe layer" slices already merged for the sibling issues: #2382 (wiki), #2381 (manageSkills), #2380 (mulmoscript). Because App.vue is the most composable-ified of the audited files (its pure helpers already live under `utils/`), the issue's prescription is a **composable** extraction rather than another `utils` pass.

## Items to Confirm / Review

- **DOM / e2e safety (please double-check).** No template edits at all — this PR touches only `<script setup>`. App.vue's two testids (`chat-sidebar`, `session-history-side-panel`) and the `sidePanelExpanded` flex/nesting the specs rely on (`a11y-clickable-rows`, `router-navigation`, `session-history-side-panel`, `history-panel`, `chatinput-attach`, `present-mulmo-script`) are unchanged. No `SessionSidebar` prop/slot change either.
- **Setup-order reordering.** To satisfy the repo's `no-use-before-define` (variables:true) rule, the `useSessionLifecycle(...)` call is placed after its reactive deps, and the `useSessionSync` block + the `route.params.sessionId` watcher (both reference the now-`const` `createNewSession`/`loadSession`) were moved just below it. `ensureSessionSubscription` stays a hoisted function (exempt), injected by reference. Behaviour is unchanged — please sanity-check the move.
- **One deliberate non-verbatim change:** `navigateToSession`'s duplicate-navigation guard now uses `isNavigationFailure(err, NavigationFailureType.duplicated)` instead of the raw `err?.type !== 16`. Same behaviour, removes the magic number, and clears the `any`-member-access lint warning that the `.ts` context surfaces.
- **Local verification note:** `yarn format`, `yarn lint` (0 errors), and the unit tests (25/25, red-on-break verified) pass. Full `yarn typecheck` / `yarn build` could not be run to green **in this worktree** because the checkout's pre-built workspace-package `dist` is stale (missing `.d.ts`; e.g. `@mulmoclaude/core` lacks the `./plugin-vue` export) and a fresh package rebuild hits unrelated pre-existing drift (`gui-chat-protocol` not exporting `createUseT`, breaking `chart-plugin`). Every one of the 84 `vue-tsc` errors is a "Could not find a declaration file for `@mulmoclaude/*`" on an **unchanged** import (reproduces on `origin/main`); none are in the files this PR adds or edits. CI runs with a clean install and is the real gate.

## User Prompt

> Progress the leftover refactor issues I created under #2300+. Implement #2302 (refactor App.vue's session lifecycle into a composable) and open a PR — don't merge. Mirror the "safe layer" pattern of the sibling PRs #2382 / #2381 / #2380: pull pure helpers + a focused composable out, keep the component's template/behaviour identical, and add unit tests for the extracted pure logic. App.vue has e2e coverage tied to DOM structure, so keep the template and rendered output unchanged — only move script logic. Do not touch spreadsheet code. Follow the repo + global Vue rules (Composition API, `ref` over `reactive`, relative imports, no `any`, small functions, extract pure logic into its own tested file). No package version bumps.

## Approach

1. **Pure rules first** (`src/utils/session/sessionLifecycle.ts`): `resolveNewSessionRoleId` (the `explicit ?? current || roles[0] || ""` role fallback — silently wrong role if broken, so tested hardest), `shouldReplaceHistory` (replace-vs-push truth table, shared by create + load), `isSessionEmpty`, `isSessionAlreadyDisplayed`, `isOnTargetSessionRoute` (the `?result=` query-string-preserving guard, #762), and `resolveResumeAction` → `create | activate | load`.
2. **Composable** (`src/composables/useSessionLifecycle.ts`): each lifecycle step is a module-level function taking an explicit `LifecycleCtx`, and the exported composable is a thin wiring layer that binds them (keeps every function well under the 50-line lint cap and makes the ctx injectable). `useRoute` / `useRouter` are called inside, matching house style.
3. **App.vue** calls the composable and destructures the functions it still uses; the kept event-stream functions (`ensureSessionSubscription`, `handleSessionFinished`, `catchUpMissedEvents`, …), send flow, and app-api provider are untouched and call the destructured functions.

### Out of scope (deferred, still tracked by #2302)

`useSessionEventStream` (pub/sub + dispatch + catch-up), `useAppApiProvider`, `useSendMessage`, `useGoogleMapsKey`, and the template → `MainRouterOutlet.vue` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
