### PR TITLE
fix: guard handler-dispatch lookups against prototype keys (#2319)

### DIFF
--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -71,6 +71,12 @@ const claimCommand = (firestore: Firestore, ref: DocumentReference): Promise<Cla
     return { method: data.method, params: data.params ?? {} };
   });
 
+// Own-property lookup: a bare `handlers[method]` with a method name written by a
+// remote terminal resolves `constructor` / `toString` to an Object.prototype
+// function, which is truthy and slips past the unknown-method check (#2319).
+export const resolveCommandHandler = (handlers: CommandHandlers, method: string): CommandHandler | undefined =>
+  Object.hasOwn(handlers, method) ? handlers[method] : undefined;
+
 const runHandler = async (ref: DocumentReference, claim: Claim, handler: CommandHandler): Promise<HostEvent> => {
   try {
     const result = await handler(claim.params);
@@ -125,7 +131,7 @@ const processCommand = async (ctx: RunnerContext, ref: DocumentReference, comman
     return;
   }
   options.onEvent?.({ phase: "received", method: claim.method });
-  const handler: CommandHandler | undefined = handlers[claim.method];
+  const handler = resolveCommandHandler(handlers, claim.method);
   if (!handler) {
     await writeError(ref, "unknown_method", `No handler for method: ${claim.method}`);
     options.onEvent?.({ phase: "error", method: claim.method, message: "unknown method" });

--- a/packages/core/test/remote-host/test_hostRunner.ts
+++ b/packages/core/test/remote-host/test_hostRunner.ts
@@ -1,0 +1,44 @@
+// Unit tests for the command-dispatch lookup (resolveCommandHandler):
+//   - a registered method name returns its handler
+//   - an unregistered method name returns undefined (→ unknown_method)
+//   - proto-key regression (#2319): a method name written by an untrusted remote
+//     terminal that collides with an Object.prototype member must NOT resolve to
+//     an inherited function and run as if it were registered
+//   - boundary: a handler legitimately registered under a proto-collision name
+//     is still returned (own property wins)
+//
+// The lookup is extracted as a pure helper so it is tested directly, without a
+// Firestore mock for processCommand.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveCommandHandler } from "../../src/remote-host/server/hostRunner.js";
+import type { CommandHandlers } from "../../src/remote-host/index.js";
+
+const handlers: CommandHandlers = {
+  listCollections: () => null,
+  startChat: () => null,
+};
+
+describe("resolveCommandHandler", () => {
+  it("returns the handler for a registered method", () => {
+    assert.equal(resolveCommandHandler(handlers, "listCollections"), handlers.listCollections);
+  });
+
+  it("returns undefined for an unregistered method", () => {
+    assert.equal(resolveCommandHandler(handlers, "nope"), undefined);
+  });
+
+  for (const proto of ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"]) {
+    it(`returns undefined for the prototype key "${proto}"`, () => {
+      // A bare `handlers[proto]` would resolve to an Object.prototype member.
+      assert.equal(resolveCommandHandler(handlers, proto), undefined);
+    });
+  }
+
+  it("returns a handler legitimately registered under a proto-collision name (boundary)", () => {
+    const ownToString: CommandHandlers["toString"] = () => "real";
+    const withOwn: CommandHandlers = { ...handlers, toString: ownToString };
+    assert.equal(resolveCommandHandler(withOwn, "toString"), ownToString);
+  });
+});

--- a/plans/fix-2319-dispatch-protokey.md
+++ b/plans/fix-2319-dispatch-protokey.md
@@ -1,0 +1,44 @@
+# fix: guard handler-dispatch lookups against prototype keys (#2319)
+
+Last member of the proto-key bug family (siblings: #2314, #2307, #2315, #2318,
+#2324 → PR #2438, #2323 → PR #2443). Three **handler-dispatch** sites index a
+plain-object lookup table with an untrusted action/method name via a bare
+`table[key]`. Because `Object` is truthy AND `typeof Object === "function"`, a
+key like `constructor` / `toString` / `valueOf` / `hasOwnProperty` resolves to an
+inherited `Object.prototype` member and slips past the "unknown handler" guard —
+then runs as if it were a registered handler. No error, no "unknown action" log:
+the call "succeeds" and returns a nonsense value.
+
+Fix discipline matches the rest of the codebase (`backlinks.ts`,
+`resolveActiveTools.ts`, `sandboxMounts.ts`, `discovery.ts`): guard the read with
+`Object.hasOwn(table, key) ? table[key] : undefined` before the existing
+falsy/typeof check. All three sites are server / core (ES2022 lib), so
+`Object.hasOwn` is available. Only proto keys change behavior; every registered
+handler is preserved.
+
+## Dispatch-site matrix
+
+| # | Dispatch site | Reachability | Symptom (bare index) | Guard | Test |
+|---|---------------|--------------|----------------------|-------|------|
+| 1 | `server/api/routes/schedulerHandlers.ts` `dispatchScheduler` (`HANDLERS[action]`) | **External** — `action` = `req.body.action` (LLM tool arg / HTTP) via `scheduler.ts` | `HANDLERS["constructor"]`→`Object` (truthy) skips the 400; `Object(items,input)` returns `items`, `result.kind` undefined flows to `respondWithDispatchResult`, `shouldPersist` true → can persist broken state. `toString`→`Object.prototype.toString` returns a string. `__proto__`→`Object.prototype` (not callable) → thrown 500 instead of clean 400. | `Object.hasOwn(HANDLERS, action) ? HANDLERS[action] : undefined` | `test/routes/test_schedulerHandlers.ts` — `constructor`/`toString`/`valueOf`/`hasOwnProperty`/`__proto__` → 400 unknown; real actions still dispatch (boundary) |
+| 2 | `packages/core/src/remote-host/server/hostRunner.ts` `processCommand` (`handlers[claim.method]`) | **External** — `claim.method` = the `method` field of a command doc a remote terminal writes to Firestore | proto `method` resolves to a prototype fn → skips the `unknown_method` write, runs `Object.prototype.<x>(params)`, writes a bogus "done" result back to the command doc on the remote-control channel. | extract pure `resolveCommandHandler(handlers, method)` = `Object.hasOwn(handlers, method) ? handlers[method] : undefined`; `processCommand` calls it | `packages/core/test/remote-host/test_hostRunner.ts` — proto method → undefined; registered handler returned even when named `toString` (boundary) |
+| 3 | `server/plugins/runtime-loader.ts` `resolveExecute` (`carrier[definitionName]`) | plugin-controlled — `definitionName` = `TOOL_DEFINITION.name` (third-party tarball) | the existing `typeof handler !== "function"` gate is **defeated** for `constructor`/`toString`/`valueOf`/`hasOwnProperty` (all functions on `Object.prototype`): a plugin exporting no matching function gets `Object`/`Object.prototype.toString` registered and dispatch calls it, skipping the "no function exported → null → 500 log" branch. (`__proto__`→`Object.prototype`, an object, is already caught by the typeof gate.) | `Object.hasOwn(carrier, definitionName) ? carrier[definitionName] : undefined`; export `resolveExecute` for direct testing | `test/plugins/test_runtime_loader.ts` — `constructor`/`toString`/`valueOf`/`hasOwnProperty` → null; carrier owning a real `toString` fn → returned (boundary) |
+
+## Not in scope (owned by merged siblings — NOT re-touched)
+
+- #2438 (`fix/2324-proto-key-lookups`): backlinks / draft / discovery / manageTool /
+  pathResolver / mcp-server / resolveActiveTools / sandboxMounts / wikiEmbedHandlers /
+  create-mulmoclaude-plugin template. `src/tools/index.ts` already uses
+  `Object.create(null)` + `hasOwnProperty.call`.
+- #2443 (`fix/2318-2323-protokey-fields`): `schemaRules.ts` / `where.ts` own-key helpers.
+
+None of those files are touched here — this PR is only the three **dispatch** sites they did not cover.
+
+## Verification
+
+Each guard is mutation-checked: revert to the bare index, confirm the new test
+goes red, restore. For site 1 the `constructor`/`toString` cases return a wrong
+object/string (assertion fails) and `__proto__` throws (test errors) on the buggy
+form — all red. Site 2's lookup decision is extracted to an exported pure helper
+so it is tested directly without a Firestore mock. Site 3's `resolveExecute` is
+exported and tested with plain-object carriers.

--- a/server/api/routes/schedulerHandlers.ts
+++ b/server/api/routes/schedulerHandlers.ts
@@ -191,7 +191,10 @@ const HANDLERS: Record<string, (items: ScheduledItem[], input: SchedulerActionIn
 };
 
 export function dispatchScheduler(action: string, items: ScheduledItem[], input: SchedulerActionInput): SchedulerActionResult {
-  const handler = HANDLERS[action];
+  // Own-property guard: a bare `HANDLERS[action]` with an untrusted action name
+  // resolves `constructor` / `toString` to an Object.prototype function, which
+  // is truthy and slips past the unknown-action check (#2319).
+  const handler = Object.hasOwn(HANDLERS, action) ? HANDLERS[action] : undefined;
   if (!handler) {
     return { kind: "error", status: 400, error: `Unknown action: ${action}` };
   }

--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -291,12 +291,15 @@ function resolveCarrier(name: string, mod: Record<string, unknown>, deps: Loader
  *  handlers keep the `(context, args)` signature unchanged. Returns
  *  null when no function is exported under `definition.name` — the
  *  plugin still appears in `tools/list` but dispatch logs + 500s. */
-function resolveExecute(
+export function resolveExecute(
   carrier: Record<string, unknown>,
   definitionName: string,
   usingFactory: boolean,
 ): ((context: unknown, args: unknown) => unknown) | null {
-  const handler = carrier[definitionName];
+  // Own-property guard: a bare `carrier[definitionName]` for a plugin naming its
+  // tool `constructor` / `toString` resolves to an Object.prototype function,
+  // defeating the `typeof … !== "function"` gate below (#2319).
+  const handler = Object.hasOwn(carrier, definitionName) ? carrier[definitionName] : undefined;
   if (typeof handler !== "function") return null;
   if (usingFactory) {
     const factoryHandler = handler as (args: unknown) => unknown;

--- a/test/plugins/test_runtime_loader.ts
+++ b/test/plugins/test_runtime_loader.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { loadPluginFromCacheDir, isCacheValid, EXTRACT_MARKER, ensureInsideBase } from "../../server/plugins/runtime-loader.js";
+import { loadPluginFromCacheDir, isCacheValid, EXTRACT_MARKER, ensureInsideBase, resolveExecute } from "../../server/plugins/runtime-loader.js";
 
 interface FixtureOpts {
   exportsImport?: string;
@@ -177,6 +177,35 @@ describe("loadPluginFromCacheDir", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mulmo-runtime-cache-complete-"));
     writeFileSync(path.join(dir, EXTRACT_MARKER), "");
     assert.equal(isCacheValid(dir), true);
+  });
+
+  // Proto-key regression (#2319): `definitionName` is a plugin-controlled
+  // `TOOL_DEFINITION.name`. A bare `carrier[definitionName]` for a proto name
+  // resolves to an Object.prototype function, DEFEATING the `typeof !==
+  // "function"` gate — a plugin exporting no matching handler gets `Object` /
+  // `Object.prototype.toString` registered and dispatched instead of null.
+  describe("resolveExecute — prototype-key guard", () => {
+    // `__proto__` resolves to Object.prototype (an object), already caught by the
+    // typeof gate; the callable Object.prototype functions are the real hazard.
+    for (const proto of ["constructor", "toString", "valueOf", "hasOwnProperty"]) {
+      it(`returns null for the prototype key "${proto}" on a carrier that does not own it`, () => {
+        assert.equal(resolveExecute({}, proto, false), null);
+      });
+    }
+
+    it("returns null for a normal unexported name", () => {
+      assert.equal(resolveExecute({}, "myTool", false), null);
+    });
+
+    it("returns the legacy handler a carrier actually exports", () => {
+      const handler = () => undefined;
+      assert.equal(resolveExecute({ myTool: handler }, "myTool", false), handler);
+    });
+
+    it("returns a handler legitimately exported under a proto-collision name (boundary)", () => {
+      const handler = () => "real";
+      assert.equal(resolveExecute({ toString: handler }, "toString", false), handler);
+    });
   });
 
   it("returns null when entry file is missing on disk", async () => {

--- a/test/routes/test_schedulerHandlers.ts
+++ b/test/routes/test_schedulerHandlers.ts
@@ -450,4 +450,18 @@ describe("dispatchScheduler", () => {
     });
     assert.equal(result.kind, "success");
   });
+
+  // Proto-key regression (#2319): `action` is untrusted (LLM tool arg / HTTP
+  // body). A bare `HANDLERS[action]` resolves `constructor`/`toString` to an
+  // Object.prototype function that is truthy and callable, so it slips past the
+  // unknown-action guard and RUNS instead of being rejected.
+  for (const proto of ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"]) {
+    it(`rejects the prototype key "${proto}" as an unknown action`, () => {
+      const result = dispatchScheduler(proto, [makeItem({ id: "a" })], {});
+      assert.equal(result.kind, "error");
+      if (result.kind !== "error") return;
+      assert.equal(result.status, 400);
+      assert.equal(result.error, `Unknown action: ${proto}`);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Last member of the proto-key bug family (siblings #2314, #2307, #2315, #2318, #2324 → PR #2438, #2323 → PR #2443). Three **handler-dispatch** sites indexed a plain-object lookup table with an untrusted action/method name via a bare `table[key]`. Because `Object` is truthy **and** `typeof Object === "function"`, a key like `constructor` / `toString` / `valueOf` / `hasOwnProperty` resolved to an inherited `Object.prototype` member and slipped past the "unknown handler" guard — then ran as if it were a registered handler. No error, no "unknown action" log: the call "succeeds" and returns a nonsense value.

Fix: guard each read with `Object.hasOwn(table, key) ? table[key] : undefined` before the existing falsy/typeof check — the same discipline the merged siblings use (`resolveActiveTools`, `sandboxMounts`, `backlinks`, `discovery`). All three sites are server/core (ES2022 lib). Only proto keys change behavior; every registered handler is preserved.

### Dispatch-site matrix

| # | Site | Reachability | Symptom (bare index) | Guard |
|---|------|--------------|----------------------|-------|
| 1 | `server/api/routes/schedulerHandlers.ts` `dispatchScheduler` (`HANDLERS[action]`) | **External** — `action` = `req.body.action` (LLM tool arg / HTTP) | `HANDLERS["constructor"]`→`Object` (truthy) skips the 400; `Object(items,input)` returns `items`, `result.kind` undefined flows on, `shouldPersist` true → can persist broken state. `toString` returns a string. `__proto__` (not callable) → thrown 500 instead of clean 400. | `Object.hasOwn(HANDLERS, action) ? … : undefined` |
| 2 | `packages/core/src/remote-host/server/hostRunner.ts` `processCommand` (`handlers[claim.method]`) | **External** — `claim.method` = the `method` field of a command doc a remote terminal writes to Firestore | proto `method` resolves to a prototype fn → skips the `unknown_method` write, runs `Object.prototype.<x>(params)`, writes a bogus "done" result back onto the remote-control channel. | extract pure `resolveCommandHandler(handlers, method)`; `processCommand` calls it |
| 3 | `server/plugins/runtime-loader.ts` `resolveExecute` (`carrier[definitionName]`) | plugin-controlled — `definitionName` = `TOOL_DEFINITION.name` (third-party tarball) | the existing `typeof handler !== "function"` gate is **defeated** for the callable proto members: a plugin exporting no matching function gets `Object` / `Object.prototype.toString` registered and dispatched, skipping the "no function → null → 500 log" branch. | `Object.hasOwn(carrier, definitionName) ? … : undefined`; export for testing |

## Items to Confirm / Review

- **Site 2 extraction**: the handler-lookup decision was pulled out of `processCommand` into an exported pure `resolveCommandHandler` so it is unit-tested directly (no Firestore mock needed). Please confirm the extraction reads cleanly.
- **Site 3 `__proto__` exclusion**: for `resolveExecute`, `__proto__` resolves to `Object.prototype` (an object) which the `typeof !== "function"` gate already rejects — so only the *callable* proto members (`constructor`/`toString`/`valueOf`/`hasOwnProperty`) are the hazard, and those are what the regression test asserts. The other two sites test `__proto__` too.
- **Boundary preserved**: a handler *legitimately* registered/exported under a proto-collision name (an own property) is still returned — covered by boundary tests in sites 2 and 3.
- **No overlap** with #2438 / #2443: none of their files are touched here; this PR is only the three dispatch sites they did not cover.
- No package version bumps.

## User Prompt

Progress the remaining proto-key issues I created. #2438 and #2443 handled the rest of the family; #2319 is the last one — the handler-`dispatch` sites (scheduler / remote-host command dispatch / plugin runtime loader) that execute prototype keys (`constructor`, `__proto__`, `toString`, …) as if they were valid actions. Open a PR; do not merge. Do not touch spreadsheet code.

## Approach

1. Guarded each of the three dispatch reads with `Object.hasOwn(table, key) ? table[key] : undefined`, reusing the sibling PRs' idiom.
2. Where the decision was buried in I/O (`hostRunner.processCommand`), extracted a pure `resolveCommandHandler` and tested it directly; exported `resolveExecute` for the same reason.
3. Added regression tests dispatching `constructor` / `toString` / `valueOf` / `hasOwnProperty` (+ `__proto__` where it manifests) asserting rejection, plus boundary tests that an own-property handler under a colliding name still resolves.
4. Mutation-verified every guard: reverted to the bare index, watched the new tests go red, restored.
5. `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` all pass.

Plan: `plans/fix-2319-dispatch-protokey.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
