### PR TITLE
fix(spreadsheet): numeric coercion for ABS/SIGN, MODE, AVERAGEIF (#2391)

### DIFF
--- a/plans/fix-2391-numeric-coercion.md
+++ b/plans/fix-2391-numeric-coercion.md
@@ -1,0 +1,73 @@
+# fix #2391 — spreadsheet numeric-function coercion
+
+Issue: [#2391](https://github.com/receptron/mulmoclaude/issues/2391) — 数値関数がテキスト・論理値・空範囲を静かに 0 / 先頭値にする.
+
+Root cause: `toNumber` (parseFloat-based, in `engine/registry.ts`) silently coerces
+anything unreadable to `0`. Every numeric function leans on it, so text, logicals,
+and empty ranges produce plausible-but-wrong answers instead of the Excel error /
+value. `MODE` and `AVERAGEIF` have their own silent fallbacks (first value / `0`).
+
+## Scope
+
+IN: the four cases in the issue table (ABS/SIGN coercion, MODE no-repeat,
+AVERAGEIF no-match).
+OUT (separate in-flight PR #2383): empty-cell aggregation mixing where
+AVERAGE / COUNT / MIN / MAX count an empty cell as `0`. This PR does not touch those
+handlers' range-reading or their empty-range branches.
+
+## Matrix (function × input × today × Excel × decision)
+
+| Function  | Input                          | Today (buggy)      | Excel      | Decision                                                            |
+| --------- | ------------------------------ | ------------------ | ---------- | ------------------------------------------------------------------ |
+| ABS       | `ABS(TRUE())`                  | `0`                | `1`        | FIX — scalar coercion: boolean → 1/0                               |
+| ABS       | `ABS("abc")`                   | `0`                | `#VALUE!`  | FIX — scalar coercion: non-numeric text → `#VALUE!`               |
+| SIGN      | `SIGN(TRUE())` / `SIGN("abc")` | `0` / `0`          | `1` / `#VALUE!` | FIX — same scalar coercion as ABS (issue names ABS/SIGN)     |
+| MODE      | `MODE(1,2,3)` (no repeat)      | `1` (first value)  | `#N/A`     | FIX — `#N/A` when the top frequency is < 2                        |
+| MODE      | `MODE(1,2,2,3)`                | `2`                | `2`        | keep — most frequent, first-appearing on tie                      |
+| AVERAGEIF | `AVERAGEIF(A1:A3,">100")` (0 match) | `0`           | `#DIV/0!`  | FIX — `#DIV/0!` when the match count is 0                         |
+| AVERAGEIF | `AVERAGEIF(A1:A3,">1")` (match) | `2.5`             | `2.5`      | keep                                                               |
+| toNumber  | `toNumber(true)` / `("abc")`   | `0` / `0`          | (n/a — internal) | PIN — leave the engine-wide lenient helper unchanged; used by SUM/AVERAGE/COUNTIF/MAX/MIN/financial. Characteristic tests lock it. |
+| SUM       | text cell in range             | contributes `0`    | ignored    | PIN — lenient toNumber path unchanged (equivalent net effect)     |
+
+## Design
+
+Blast radius is the whole point of the issue's caution. The fix keeps the two
+concerns apart:
+
+- `engine/numericCoercion.ts` (new, pure):
+  - `parseNumericString(str): number | null` — the engine's long-standing lenient
+    string read (`%`, `$`, thousands, then bare `parseFloat`), returning `null`
+    instead of `0` when nothing parses. `registry.toNumber` is re-implemented on
+    top of it (behaviour-identical — DRY, removes the duplicated branch ladder).
+  - `toScalarNumber(value): number | string` — strict scalar coercion for
+    single-value math functions: boolean → 1/0, numeric text parses, non-numeric
+    text → `#VALUE!`. Contained: applied ONLY to ABS and SIGN.
+  - `VALUE_ERROR` sentinel.
+- `engine/functions/statistical-math.ts` (new, pure): `computeMode(values)` plus
+  `NA_ERROR` / `DIV_ZERO_ERROR`. MODE's "top frequency < 2 → #N/A" rule is the
+  silent-failure rule worth unit-testing directly.
+- `engine/functions/mathematical.ts`: ABS/SIGN return the `#VALUE!` string when
+  `toScalarNumber` cannot read the argument, else `Math.abs` / `Math.sign`.
+- `engine/functions/statistical.ts`: `modeHandler` → `computeMode`; `averageifHandler`
+  no-match → `DIV_ZERO_ERROR`.
+
+The global `toNumber` is deliberately NOT changed — SUM / AVERAGE / COUNTIF / MAX /
+MIN / financial keep their lenient reads. Whether to extend `toScalarNumber` to
+every scalar math function (ROUND, POWER, SQRT, MOD, …) engine-wide is flagged in
+the PR's "Items to Confirm", not decided here.
+
+## Tests (red-verified)
+
+- `test_numericCoercion.ts` — `parseNumericString`, `toScalarNumber` (new
+  behaviour), and pinned `toNumber` characteristics (boolean → 0, text → 0).
+- `test_statisticalMath.ts` — `computeMode` (no-repeat → `#N/A`, tie, single, empty).
+- `test_numericFunctions2391.ts` — the four scenarios end-to-end through the engine,
+  plus pins that the out-of-scope lenient paths (SUM/AVERAGE over text) are unchanged.
+
+Red-verification: revert each handler change, confirm its regression test fails,
+restore.
+
+## Verify
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, spreadsheet engine tests.
+No package version bumps.

--- a/src/plugins/spreadsheet/engine/functions/mathematical.ts
+++ b/src/plugins/spreadsheet/engine/functions/mathematical.ts
@@ -3,6 +3,7 @@
  */
 
 import { functionRegistry, toNumber, type FunctionHandler } from "../registry";
+import { toScalarNumber } from "../numericCoercion";
 
 const roundHandler: FunctionHandler = (args, context) => {
   if (args.length !== 2) throw new Error("ROUND requires 2 arguments");
@@ -46,8 +47,8 @@ const ceilingHandler: FunctionHandler = (args, context) => {
 
 const absHandler: FunctionHandler = (args, context) => {
   if (args.length !== 1) throw new Error("ABS requires 1 argument");
-  const number = toNumber(context.evaluateFormula(args[0]));
-  return Math.abs(number);
+  const number = toScalarNumber(context.evaluateFormula(args[0]));
+  return typeof number === "string" ? number : Math.abs(number);
 };
 
 const powerHandler: FunctionHandler = (args, context) => {
@@ -89,8 +90,8 @@ const truncHandler: FunctionHandler = (args, context) => {
 
 const signHandler: FunctionHandler = (args, context) => {
   if (args.length !== 1) throw new Error("SIGN requires 1 argument");
-  const number = toNumber(context.evaluateFormula(args[0]));
-  return Math.sign(number);
+  const number = toScalarNumber(context.evaluateFormula(args[0]));
+  return typeof number === "string" ? number : Math.sign(number);
 };
 
 const piHandler: FunctionHandler = (args) => {

--- a/src/plugins/spreadsheet/engine/functions/statistical-math.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical-math.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure statistical rules, separated from the range-reading handlers so they can
+ * be unit-tested directly.
+ */
+
+/** Returned when a statistic has no defined value (MODE with no repeat). */
+export const NA_ERROR = "#N/A";
+/** Returned when an average would divide by zero (AVERAGEIF with no match). */
+export const DIV_ZERO_ERROR = "#DIV/0!";
+
+/**
+ * The most frequently occurring value, or `#N/A` when no value repeats.
+ *
+ * Excel's MODE is undefined for an all-distinct set, so returning the first
+ * element (as a naive "highest frequency wins" loop does when every count is 1)
+ * is a silent wrong answer. Ties resolve to the value that appears first, which
+ * Map insertion order preserves.
+ */
+export function computeMode(values: number[]): number | string {
+  const frequency = new Map<number, number>();
+  for (const value of values) {
+    frequency.set(value, (frequency.get(value) ?? 0) + 1);
+  }
+
+  let topFrequency = 0;
+  let mode: number | string = NA_ERROR;
+  for (const [value, count] of frequency.entries()) {
+    if (count > topFrequency) {
+      topFrequency = count;
+      mode = value;
+    }
+  }
+
+  const REPEAT_THRESHOLD = 2;
+  return topFrequency >= REPEAT_THRESHOLD ? mode : NA_ERROR;
+}

--- a/src/plugins/spreadsheet/engine/functions/statistical.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical.ts
@@ -3,6 +3,7 @@
  */
 
 import { functionRegistry, toNumber, parseCriteria, type FunctionContext, type FunctionHandler } from "../registry";
+import { computeMode, DIV_ZERO_ERROR } from "./statistical-math";
 
 const isLetter = (char: string): boolean => /[A-Z]/i.test(char);
 
@@ -104,26 +105,7 @@ const medianHandler: FunctionHandler = (args, context) => {
 const modeHandler: FunctionHandler = (args, context) => {
   if (args.length !== 1) throw new Error("MODE requires 1 argument");
   const values = context.getRangeValues(args[0]).map(toNumber);
-
-  if (values.length === 0) return 0;
-
-  // Count frequency of each value
-  const frequency = new Map<number, number>();
-  for (const val of values) {
-    frequency.set(val, (frequency.get(val) || 0) + 1);
-  }
-
-  // Find the value with highest frequency
-  let maxFreq = 0;
-  let mode = values[0];
-  for (const [val, freq] of frequency.entries()) {
-    if (freq > maxFreq) {
-      maxFreq = freq;
-      mode = val;
-    }
-  }
-
-  return mode;
+  return computeMode(values);
 };
 
 const stdevHandler: FunctionHandler = (args, context) => {
@@ -211,7 +193,11 @@ const averageifHandler: FunctionHandler = (args, context) => {
     }
   }
 
-  return count > 0 ? sum / count : 0;
+  // Excel returns #DIV/0! when no cell matches (the average of nothing is
+  // undefined), rather than a silent 0.
+  // Excel returns #DIV/0! when no cell matches (the average of nothing is
+  // undefined), rather than a silent 0.
+  return count > 0 ? sum / count : DIV_ZERO_ERROR;
 };
 
 // Register all statistical functions

--- a/src/plugins/spreadsheet/engine/numericCoercion.ts
+++ b/src/plugins/spreadsheet/engine/numericCoercion.ts
@@ -1,0 +1,47 @@
+/**
+ * Numeric coercion helpers for the spreadsheet engine.
+ *
+ * Two intentionally different reads share one string parser (`parseNumericString`):
+ *  - `registry.toNumber` — lenient, for range aggregation (SUM / AVERAGE / …):
+ *    anything unreadable becomes 0. PINNED (booleans are 0, not Excel's 1/0).
+ *  - `toScalarNumber` — strict, for single-value math functions (ABS / SIGN):
+ *    booleans are 1/0 and non-numeric text is `#VALUE!`, matching Excel.
+ */
+
+import type { CellValue } from "./types";
+
+/** Returned (as a cell value) when a scalar coercion cannot read a number,
+ *  matching how the rest of the engine surfaces errors (functions/text.ts). */
+export const VALUE_ERROR = "#VALUE!";
+
+const numberOrNull = (num: number): number | null => (isNaN(num) ? null : num);
+
+/**
+ * Parse a spreadsheet string as a number, or `null` when it holds no number.
+ *
+ * Mirrors the engine's long-standing lenient read: a percentage, a currency
+ * amount, or a thousands-separated value, else a bare `parseFloat` (which reads a
+ * leading number out of "12abc"). The branch order is load-bearing — each strips
+ * only its own characters, so a string mixing "%" and "$" fails in the first.
+ */
+export function parseNumericString(value: string): number | null {
+  if (value.includes("%")) {
+    const num = numberOrNull(parseFloat(value.replace("%", "").trim()));
+    return num === null ? null : num / 100;
+  }
+  if (value.includes("$")) return numberOrNull(parseFloat(value.replace(/[$,]/g, "").trim()));
+  if (value.includes(",")) return numberOrNull(parseFloat(value.replace(/,/g, "").trim()));
+  return numberOrNull(parseFloat(value));
+}
+
+/**
+ * Strict scalar coercion for single-value math functions (ABS, SIGN). Follows
+ * Excel's scalar rules: a boolean is 1 / 0 and genuinely non-numeric text is
+ * `#VALUE!` rather than a silent 0. A partly-numeric string still yields its
+ * leading number, matching the engine's other numeric reads.
+ */
+export function toScalarNumber(value: CellValue): number | string {
+  if (typeof value === "number") return value;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  return parseNumericString(value) ?? VALUE_ERROR;
+}

--- a/src/plugins/spreadsheet/engine/registry.ts
+++ b/src/plugins/spreadsheet/engine/registry.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CellValue } from "./types";
+import { parseNumericString } from "./numericCoercion";
 export type { CellValue };
 export type CellGetter = (ref: string) => CellValue;
 export type RangeGetter = (range: string) => CellValue[];
@@ -67,35 +68,13 @@ class FunctionRegistry {
 export const functionRegistry = new FunctionRegistry();
 
 /**
- * Helper function to convert a value to a number
+ * Lenient numeric coercion for range aggregation: anything unreadable is 0.
+ * PINNED behaviour (booleans are 0, not Excel's 1/0) — the string parsing lives
+ * in numericCoercion.parseNumericString, shared with the strict scalar read.
  */
 export function toNumber(value: CellValue): number {
   if (typeof value === "number") return value;
-
-  // Handle percentage strings like "5%" or "0.4167%"
-  if (typeof value === "string" && value.includes("%")) {
-    const numericPart = value.replace("%", "").trim();
-    const num = parseFloat(numericPart);
-    return isNaN(num) ? 0 : num / 100;
-  }
-
-  // Handle currency strings like "$1,000" or "$1,000.00"
-  if (typeof value === "string" && value.includes("$")) {
-    const numericPart = value.replace(/[$,]/g, "").trim();
-    const num = parseFloat(numericPart);
-    return isNaN(num) ? 0 : num;
-  }
-
-  // Handle comma-separated numbers like "1,000"
-  if (typeof value === "string" && value.includes(",")) {
-    const numericPart = value.replace(/,/g, "").trim();
-    const num = parseFloat(numericPart);
-    return isNaN(num) ? 0 : num;
-  }
-
-  // Handle regular numeric strings
-  const num = parseFloat(String(value));
-  return isNaN(num) ? 0 : num;
+  return parseNumericString(String(value)) ?? 0;
 }
 
 /**

--- a/test/plugins/spreadsheet/engine/test_numericCoercion.ts
+++ b/test/plugins/spreadsheet/engine/test_numericCoercion.ts
@@ -1,0 +1,105 @@
+// Two numeric reads share one string parser (#2391). `toNumber` stays lenient for
+// range aggregation (unreadable → 0, booleans → 0 — PINNED, since changing it
+// moves every SUM / AVERAGE / COUNTIF at once). `toScalarNumber` is the strict
+// scalar read that ABS / SIGN now use: booleans are Excel's 1/0 and non-numeric
+// text is #VALUE! instead of a silent 0.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseNumericString, toScalarNumber, VALUE_ERROR } from "../../../../src/plugins/spreadsheet/engine/numericCoercion.ts";
+import { toNumber } from "../../../../src/plugins/spreadsheet/engine/registry.ts";
+
+describe("parseNumericString — reads the formats the engine has always read", () => {
+  it("reads a percentage as its decimal value", () => {
+    assert.equal(parseNumericString("5%"), 0.05);
+    assert.equal(parseNumericString("100%"), 1);
+  });
+
+  it("reads currency and thousands-separated numbers", () => {
+    assert.equal(parseNumericString("$1,000"), 1000);
+    assert.equal(parseNumericString("$1,000.50"), 1000.5);
+    assert.equal(parseNumericString("1,234,567"), 1234567);
+  });
+
+  it("reads a plain numeric string, tolerating whitespace and exponents", () => {
+    assert.equal(parseNumericString("42"), 42);
+    assert.equal(parseNumericString("  42  "), 42);
+    assert.equal(parseNumericString("-3.5"), -3.5);
+    assert.equal(parseNumericString("1e3"), 1000);
+  });
+
+  it("takes the leading number from a partly-numeric string", () => {
+    assert.equal(parseNumericString("12abc"), 12);
+    assert.equal(parseNumericString("3.5kg"), 3.5);
+  });
+
+  // The distinction that lets the two coercions differ: null, not 0, when there
+  // is no number at all. toNumber maps that to 0; toScalarNumber to #VALUE!.
+  it("returns null when nothing parses", () => {
+    assert.equal(parseNumericString("abc"), null);
+    assert.equal(parseNumericString(""), null);
+    assert.equal(parseNumericString("   "), null);
+    assert.equal(parseNumericString("N/A"), null);
+    assert.equal(parseNumericString("abc12"), null);
+  });
+});
+
+describe("toNumber — PINNED lenient behaviour (#2391 does not change this)", () => {
+  it("returns a number unchanged", () => {
+    assert.equal(toNumber(42), 42);
+    assert.equal(toNumber(0), 0);
+    assert.equal(toNumber(-7.5), -7.5);
+  });
+
+  it("maps unreadable text to 0", () => {
+    assert.equal(toNumber("hello"), 0);
+    assert.equal(toNumber(""), 0);
+    assert.equal(toNumber("N/A"), 0);
+  });
+
+  // The high-blast-radius case the issue asked to pin: booleans read as 0 here,
+  // NOT Excel's 1/0, because SUM / AVERAGE / COUNTIF all lean on this.
+  it("maps booleans to 0, not Excel's 1 and 0", () => {
+    assert.equal(toNumber(true), 0);
+    assert.equal(toNumber(false), 0);
+  });
+
+  it("still reads formatted strings", () => {
+    assert.equal(toNumber("5%"), 0.05);
+    assert.equal(toNumber("$1,000"), 1000);
+    assert.equal(toNumber("12abc"), 12);
+  });
+});
+
+describe("toScalarNumber — strict scalar read for ABS / SIGN (#2391)", () => {
+  it("returns a number unchanged", () => {
+    assert.equal(toScalarNumber(42), 42);
+    assert.equal(toScalarNumber(-7.5), -7.5);
+    assert.equal(toScalarNumber(0), 0);
+  });
+
+  // The boolean fix: TRUE=1, FALSE=0 (Excel), where toNumber gives 0 for both.
+  it("reads booleans as Excel's 1 and 0", () => {
+    assert.equal(toScalarNumber(true), 1);
+    assert.equal(toScalarNumber(false), 0);
+  });
+
+  it("parses numeric and formatted text", () => {
+    assert.equal(toScalarNumber("5"), 5);
+    assert.equal(toScalarNumber("$1,000"), 1000);
+    assert.equal(toScalarNumber("50%"), 0.5);
+  });
+
+  // The text fix: genuinely non-numeric text is an error, not a silent 0.
+  it("returns #VALUE! for non-numeric text and empty strings", () => {
+    assert.equal(toScalarNumber("abc"), VALUE_ERROR);
+    assert.equal(toScalarNumber(""), VALUE_ERROR);
+    assert.equal(toScalarNumber("   "), VALUE_ERROR);
+  });
+
+  // Deliberate leniency, pinned: a partly-numeric string keeps its leading number
+  // (matching the rest of the engine) rather than erroring as strict Excel would.
+  it("still takes the leading number from partly-numeric text", () => {
+    assert.equal(toScalarNumber("12abc"), 12);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_numericFunctions2391.ts
+++ b/test/plugins/spreadsheet/engine/test_numericFunctions2391.ts
@@ -1,0 +1,71 @@
+// The four #2391 scenarios end-to-end through the engine, plus pins that the
+// out-of-scope lenient aggregation paths (SUM / AVERAGE over text) are unchanged
+// (those blanks-as-0 cases belong to #2383, not this PR).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+// Column A holds `colA` (one value per row); `formula` goes in a row below it so a
+// range like A1:A3 never overlaps the formula cell.
+const evalWithColumnA = (formula: string, colA: (string | number)[] = []): unknown => {
+  const data: { v: string | number }[][] = colA.map((value) => [{ v: value }]);
+  data.push([{ v: formula }]);
+  const result = new SpreadsheetEngine().calculate({ name: "S", data } as SheetData);
+  return result.data[data.length - 1][0];
+};
+
+describe("ABS / SIGN — scalar coercion (#2391)", () => {
+  it("reads a logical argument as 1 / 0 (was 0)", () => {
+    assert.equal(evalWithColumnA("=ABS(TRUE())"), 1);
+    assert.equal(evalWithColumnA("=ABS(FALSE())"), 0);
+    assert.equal(evalWithColumnA("=SIGN(TRUE())"), 1);
+  });
+
+  it("returns #VALUE! for non-numeric text (was 0)", () => {
+    assert.equal(evalWithColumnA('=ABS("abc")'), "#VALUE!");
+    assert.equal(evalWithColumnA('=SIGN("abc")'), "#VALUE!");
+  });
+
+  it("errors when the argument cell holds text", () => {
+    assert.equal(evalWithColumnA("=ABS(A1)", ["abc"]), "#VALUE!");
+  });
+
+  it("still works for ordinary numbers", () => {
+    assert.equal(evalWithColumnA("=ABS(-5)"), 5);
+    assert.equal(evalWithColumnA("=SIGN(-5)"), -1);
+    assert.equal(evalWithColumnA("=ABS(A1)", [-42]), 42);
+  });
+});
+
+describe("MODE — no repeat is #N/A (#2391)", () => {
+  it("returns #N/A when every value is distinct (was the first value)", () => {
+    assert.equal(evalWithColumnA("=MODE(A1:A3)", [1, 2, 3]), "#N/A");
+  });
+
+  it("still returns the most frequent value when one repeats", () => {
+    assert.equal(evalWithColumnA("=MODE(A1:A4)", [1, 2, 2, 3]), 2);
+  });
+});
+
+describe("AVERAGEIF — no match is #DIV/0! (#2391)", () => {
+  it("returns #DIV/0! when nothing matches (was 0)", () => {
+    assert.equal(evalWithColumnA('=AVERAGEIF(A1:A3,">100")', [1, 2, 3]), "#DIV/0!");
+  });
+
+  it("still averages the matching cells", () => {
+    assert.equal(evalWithColumnA('=AVERAGEIF(A1:A3,">1")', [1, 2, 3]), 2.5);
+  });
+});
+
+describe("out-of-scope lenient paths stay unchanged (#2383, not this PR)", () => {
+  // A text cell inside a SUM range leaves the total unchanged (30, not #VALUE!) —
+  // the aggregation path keeps its lenient reading. This PR must not touch it.
+  it("SUM leaves a text cell out of the total", () => {
+    assert.equal(evalWithColumnA("=SUM(A1:A3)", [10, "abc", 20]), 30);
+  });
+
+  it("AVERAGE over numeric cells is unaffected", () => {
+    assert.equal(evalWithColumnA("=AVERAGE(A1:A3)", [10, 20, 30]), 20);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_statisticalMath.ts
+++ b/test/plugins/spreadsheet/engine/test_statisticalMath.ts
@@ -1,0 +1,35 @@
+// MODE's rule in isolation (#2391): the most frequent value, or #N/A when nothing
+// repeats. The old handler returned the FIRST value for an all-distinct set, a
+// silent wrong answer that reads like a real mode.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeMode, NA_ERROR } from "../../../../src/plugins/spreadsheet/engine/functions/statistical-math.ts";
+
+describe("computeMode", () => {
+  it("returns the single most frequent value", () => {
+    assert.equal(computeMode([1, 2, 2, 3]), 2);
+    assert.equal(computeMode([5, 5, 5, 1, 2]), 5);
+  });
+
+  // The fix: no value repeats, so the mode is undefined → #N/A, not values[0].
+  it("returns #N/A when every value is distinct", () => {
+    assert.equal(computeMode([1, 2, 3]), NA_ERROR);
+    assert.equal(computeMode([9]), NA_ERROR);
+  });
+
+  it("returns #N/A for an empty set", () => {
+    assert.equal(computeMode([]), NA_ERROR);
+  });
+
+  // On a tie the earliest-appearing value wins (Map preserves insertion order).
+  it("breaks a frequency tie toward the first-appearing value", () => {
+    assert.equal(computeMode([2, 2, 1, 1]), 2);
+    assert.equal(computeMode([1, 1, 2, 2]), 1);
+  });
+
+  it("counts repeated negatives and zeros", () => {
+    assert.equal(computeMode([0, 0, 1]), 0);
+    assert.equal(computeMode([-3, -3, 4]), -3);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the silent numeric-coercion bugs in the spreadsheet engine (#2391). `toNumber`
(parseFloat-based) coerces anything unreadable to `0`, so numeric functions returned
plausible-but-wrong values. This PR fixes the four cases in the issue table while
**deliberately leaving the engine-wide lenient `toNumber` unchanged** (its blast radius
is every SUM / AVERAGE / COUNTIF / financial call) and pinning it with characteristic
tests.

### Matrix (function × input × before × Excel × this PR)

| Function  | Input                          | Before (buggy)    | Excel      | This PR                                        |
| --------- | ------------------------------ | ----------------- | ---------- | ---------------------------------------------- |
| ABS       | `ABS(TRUE())`                  | `0`               | `1`        | **fixed** → `1` (scalar coercion: bool → 1/0) |
| ABS       | `ABS("abc")`                   | `0`               | `#VALUE!`  | **fixed** → `#VALUE!`                         |
| SIGN      | `SIGN(TRUE())` / `SIGN("abc")` | `0` / `0`         | `1` / `#VALUE!` | **fixed** (same scalar coercion)         |
| MODE      | `MODE(1,2,3)` (no repeat)      | `1` (first value) | `#N/A`     | **fixed** → `#N/A`                           |
| MODE      | `MODE(1,2,2,3)`                | `2`               | `2`        | unchanged                                      |
| AVERAGEIF | `AVERAGEIF(A1:A3,">100")` (0 match) | `0`          | `#DIV/0!`  | **fixed** → `#DIV/0!`                        |
| AVERAGEIF | `AVERAGEIF(A1:A3,">1")` (match) | `2.5`            | `2.5`      | unchanged                                      |
| `toNumber` (internal) | `true` / `"abc"`   | `0` / `0`         | (n/a)      | **pinned** — unchanged; locked by characteristic tests |
| SUM       | text cell in range             | net `0`           | ignored    | **pinned** — lenient path untouched           |

### Fixed vs pinned/deferred

- **Fixed (contained blast radius):**
  - `ABS` / `SIGN` now use a new strict scalar coercion `toScalarNumber` (booleans →
    Excel 1/0, non-numeric text → `#VALUE!`). Applied to **only** these two functions.
  - `MODE` → `#N/A` when the top frequency is `< 2` (pure `computeMode`).
  - `AVERAGEIF` → `#DIV/0!` when the match count is 0.
- **Pinned (unchanged on purpose):** the engine-wide lenient `toNumber` (booleans → 0,
  unreadable text → 0). Its string parsing was extracted to
  `numericCoercion.parseNumericString` (shared with the strict read, DRY) but its
  behaviour is byte-identical and now locked by characteristic tests.
- **Deferred / out of scope:** empty-cell aggregation mixing (AVERAGE / COUNT / MIN /
  MAX counting an empty cell as `0`) — handled by the separate in-flight #2383. This PR
  does not touch those aggregation paths (a pin test asserts SUM/AVERAGE stay unchanged).

### Design

- `engine/numericCoercion.ts` (new, pure): `parseNumericString`, `toScalarNumber`,
  `VALUE_ERROR`.
- `engine/functions/statistical-math.ts` (new, pure): `computeMode`, `NA_ERROR`,
  `DIV_ZERO_ERROR`.
- `registry.toNumber` re-implemented on `parseNumericString` (behaviour-identical).
- `mathematical.ts` ABS/SIGN, `statistical.ts` MODE/AVERAGEIF updated.

### Verification

- `yarn format` ✅, `yarn lint` ✅ (0 errors; my files add no warnings).
- All **551** spreadsheet engine tests pass, including 3 new files. Each fix was
  **red-verified**: reverting the handler makes its regression test fail, e.g.
  `AVERAGEIF` (`0 !== '#DIV/0!'`), `MODE` (distinct set no longer `#N/A`), `ABS/SIGN`
  (`0 !== '#VALUE!'`), then restored.
- `yarn typecheck` / `yarn build`: the full monorepo gates fail **only** on
  pre-existing stale-parent-package artifacts in this fresh worktree (the shared
  `node_modules/@mulmoclaude/core` symlink resolves to an out-of-sync parent checkout
  that is missing the `./plugin-vue` export the branch's own `packages/core` provides;
  likewise unbuilt `@mulmoclaude/*-plugin` `.d.ts` and a stale `@mulmobridge/client`).
  The typecheck error set is **identical with and without this diff (104 errors, same
  set, zero in the changed files)**, so these are environmental and green on CI. No
  package version bumps.

## Items to Confirm / Review

- **`toScalarNumber` for ABS/SIGN (the boolean decision):** the issue asked to be
  conservative about `toNumber`'s boolean handling because of its wide blast radius. I
  did **not** change the engine-wide `toNumber`; instead I introduced a *separate*
  strict coercion used **only** by ABS and SIGN (the two functions named in the issue).
  Please confirm the ABS/SIGN semantics (TRUE=1/FALSE=0, non-numeric text → `#VALUE!`)
  are what you want.
- **Extend `toScalarNumber` engine-wide?** Other scalar math functions (ROUND, POWER,
  SQRT, MOD, INT, …) still use the lenient `toNumber`, so e.g. `ROUND(TRUE(),0)` stays
  `0`. Extending `toScalarNumber` to all of them is a broader change I left out of this
  PR — flagging whether you'd like a follow-up.
- **Partly-numeric text is pinned as lenient:** `toScalarNumber("12abc")` yields `12`
  (leading number), not strict Excel `#VALUE!`, to match the rest of the engine. Pinned
  with a test; say if you'd prefer strict.
- **MODE of a genuinely empty range** now returns `#N/A` (was `0`). This is Excel-correct
  and distinct from the #2383 empties-as-0 case, but flagging since it borders that area.

## User Prompt

The user asked to make progress on their unaddressed spreadsheet issues (#2319+), and
specifically to fix #2391: numeric functions silently coercing text / logical values /
empty ranges to `0` or the first value (`ABS(TRUE())`→0, `ABS("abc")`→0, `MODE` no-repeat
→ first value, `AVERAGEIF` no-match → 0). Be conservative about the high-impact
`toNumber` boolean change (pin current behaviour first), fix the clear cases with
red-verified regression tests, and keep the empty-cell aggregation work (#2383) out of
scope. Open a PR (do not merge).

## Approach

Plan committed at `plans/fix-2391-numeric-coercion.md`. Root cause diagnosed (lenient
`toNumber`), current behaviour reproduced end-to-end, then: characteristic tests pinning
`toNumber` + the four scenarios; clear fixes (MODE, AVERAGEIF) with red-verified
regression tests; contained scalar coercion for ABS/SIGN; pure logic extracted to
`numericCoercion.ts` / `statistical-math.ts` for direct unit testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
