### PR TITLE
chore(release): @mulmobridge/client@0.2.0 (drift fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@gui-chat-plugin/mindmap": "^1.0.0",
     "@gui-chat-plugin/present3d": "^1.0.0",
     "@marp-team/marp-core": "^4.4.0",
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmocast/deck": "^1.0.0",
     "@mulmocast/deck-web": "^1.1.1",
     "@mulmocast/types": "^2.9.0",

--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/cli/package.json
+++ b/packages/bridges/cli/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "discord.js": "^14.27.0",

--- a/packages/bridges/email/package.json
+++ b/packages/bridges/email/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^1.0.0",
     "@mulmoclaude/common": "^1.1.0",

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0",
     "irc-framework": "^4.14.0"

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^1.0.0",
     "@mulmoclaude/common": "^1.1.0",

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^1.0.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^1.0.0",
     "@mulmoclaude/common": "^1.1.0",

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "@slack/socket-mode": "^3.0.0",

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "botbuilder": "^4.23.0",

--- a/packages/bridges/telegram/package.json
+++ b/packages/bridges/telegram/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^1.0.0",
     "@mulmoclaude/common": "^1.1.0",

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/webhook-runtime": "^1.0.0",
     "@mulmoclaude/common": "^1.1.0",

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "@xmpp/client": "^0.14.0",

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmoclaude/common": "^1.1.0",
     "dotenv": "^17.0.0"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/client",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Socket.io client library for MulmoBridge — shared by all bridge implementations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -29,7 +29,7 @@
     "@gui-chat-plugin/present3d": "^1.0.0",
     "@marp-team/marp-core": "^4.4.0",
     "@mulmobridge/chat-service": "^0.1.7",
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmobridge/protocol": "^0.1.4",
     "@mulmobridge/web-push": "^0.2.0",
     "@mulmocast/types": "^2.9.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -32,7 +32,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mulmobridge/client": "^0.1.5",
+    "@mulmobridge/client": "^0.2.0",
     "@mulmoclaude/common": "^1.1.0"
   }
 }


### PR DESCRIPTION
## Summary
`@mulmobridge/client` gained 3 runtime exports in #2403 (`fetchJsonRecord`, `asJsonRecord`, `frameText`) but its version was intentionally left at 0.1.5 (per the "bump once at publish" preference). The `smoke` CI job's **drift check** (`@mulmobridge/*` only) therefore fails: `localCount (8) > published distCount (6)` while local version == published — which npm-installed users would hit as "does not provide an export named X".

This PR bumps `@mulmobridge/client` **0.1.5 → 0.2.0** and sweeps **every** declared range `^0.1.5 → ^0.2.0` (root `package.json`, launcher, 25 bridges, relay — 28 files), turning drift status `drifted` → `pending-publish` (green) and keeping the `launcher-sync` gate green.

## Items to Confirm / Review
- Version-and-range-only change; no code touched. `launcherSync.mjs` passes locally.
- The test fixture `test/scripts/mulmoclaude/fixtures/drift-drifted/...` `^0.1.0` is intentionally left as-is (it's a fixture, not a real consumer).
- `smoke` will go from red to green for this and subsequent PRs once merged.

## User Prompt
Fix the `@mulmobridge/client` smoke-drift now (user: "今 client を bump") so all PRs' smoke checks go green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)