### PR TITLE
fix(spreadsheet): #2360 (partial) STDEV/VAR sample estimator + HLOOKUP/VLOOKUP approximate match

### DIFF
--- a/plans/fix-2360-stdev-hlookup.md
+++ b/plans/fix-2360-stdev-hlookup.md
@@ -1,0 +1,63 @@
+# fix(spreadsheet): #2360 (partial) — STDEV/VAR sample estimator + HLOOKUP/VLOOKUP approximate match
+
+Date: 2026-07-24
+Issue: #2360 (partial — this PR fixes only the two items below; the IF / IFERROR
+items stay open under the #2362 / #2448 line to avoid touching `logical.ts`).
+
+## Scope
+
+Two mismatches from the #2360 table, plus their tests. Nothing else in the
+issue is touched here.
+
+Excluded on purpose (other open PRs own these): `functions/logical.ts`
+(IF / IFERROR — #2431 / #2448), `functions/mathematical.ts` (#2432), and the
+error-value representation refactor (#2451). Excel error strings are returned
+the same way the current code already does (`"#DIV/0!"`, `"#N/A"`).
+
+## 1. STDEV / VAR use population (n) instead of sample (n-1)
+
+`src/plugins/spreadsheet/engine/functions/statistical.ts`
+
+- Current: `variance = Σ(x-μ)² / n` — that is the POPULATION estimator (Excel's
+  `STDEVP` / `VARP`), and empty input silently returns `0`.
+- Excel: `STDEV` / `VAR` are the SAMPLE estimators — divide by `n - 1`. With
+  fewer than two values there is no `n - 1` to divide by, so Excel returns
+  `#DIV/0!`.
+- `STDEVP` / `VARP` are not registered in this engine, so nothing there changes.
+
+Fix: extract pure `sampleVariance(values)` / `sampleStdev(values)` into
+`functions/statistical-math.ts` (same pattern as the existing `computeMode`),
+returning `DIV_ZERO_ERROR` when `values.length < 2`. Handlers call them.
+
+Characterization: `STDEV({2,4,4,4,5,5,7,9})` = 2.138… (sample) vs 2.0
+(population). Boundary: single value / empty → `#DIV/0!`.
+
+## 2. HLOOKUP / VLOOKUP 4th arg TRUE behaves as exact
+
+`src/plugins/spreadsheet/engine/functions/lookup.ts`
+
+- Current: `isApproximate(rangeLookup)` accepts only `true | 1 | "1"`. The
+  literal `TRUE` reaches the handler as the STRING `"TRUE"` (the evaluator
+  leaves bare words unquoted), so `HLOOKUP("Axles", A1:C10, 2, TRUE)` silently
+  falls back to `matchType = 0` (exact) and returns `#N/A`.
+- Excel: TRUE / omitted → approximate match (largest first-row/col value ≤ the
+  lookup key in a sorted range); FALSE → exact.
+
+Fix: extract a pure `isApproximateMatch(rangeLookup)` into
+`functions/lookup-math.ts` that reads the range_lookup argument the way Excel
+coerces a logical: boolean as-is, non-zero number → TRUE, and the strings
+`"TRUE"` / `"1"` → TRUE, `"FALSE"` / `"0"` / blank → FALSE (case-insensitive).
+The existing `findMatchIndex(matchType = 1)` already implements largest-≤ and
+returns `-1` (→ `#N/A`) below the smallest key, so only the argument reading is
+wrong.
+
+Characterization (through the engine): approximate VLOOKUP/HLOOKUP with an
+explicit `TRUE` returns the largest-≤ match. Boundaries: below smallest key →
+`#N/A`; `FALSE` exact path unchanged.
+
+## Verification
+
+- Add failing characterization tests first, confirm each fails when the fix is
+  reverted (stated in the PR).
+- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, spreadsheet
+  engine tests all green. No package version bumps.

--- a/src/plugins/spreadsheet/engine/functions/lookup-math.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup-math.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure lookup rules, separated from the range-reading handlers so they can be
+ * unit-tested directly.
+ */
+
+import type { CellValue } from "../types";
+
+/**
+ * Interpret VLOOKUP/HLOOKUP's 4th argument (range_lookup): TRUE (or omitted) =
+ * approximate match, FALSE = exact.
+ *
+ * The literal `TRUE` reaches the handler as the STRING `"TRUE"` — the evaluator
+ * leaves bare words unquoted — so an accept-only-`true | 1 | "1"` check silently
+ * fell back to exact match and returned `#N/A` for a valid approximate lookup
+ * (#2360). Read it the way Excel coerces a logical instead: a boolean as-is, a
+ * non-zero number as TRUE, and the words `TRUE` / `FALSE` (case-insensitive)
+ * and `"1"` / `"0"` as their logical value. Anything else (blank, stray text)
+ * is treated as FALSE, matching Excel's coercion of a blank range_lookup.
+ */
+export function isApproximateMatch(rangeLookup: CellValue): boolean {
+  if (typeof rangeLookup === "boolean") return rangeLookup;
+  if (typeof rangeLookup === "number") return rangeLookup !== 0;
+  const normalized = rangeLookup.trim().toUpperCase();
+  return normalized === "TRUE" || normalized === "1";
+}

--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -5,11 +5,8 @@
 import { functionRegistry, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
 import { indexToColumn } from "../parser";
 import { parseRangeBounds, resolveIndexTarget } from "../formulaRefs";
+import { isApproximateMatch } from "./lookup-math";
 import type { CellValue } from "../types";
-
-// The 4th VLOOKUP/HLOOKUP argument (rangeLookup) is approximate-match when TRUE,
-// 1, "1", or omitted; FALSE/0 forces an exact match.
-const isApproximate = (rangeLookup: CellValue): boolean => rangeLookup === true || rangeLookup === 1 || rangeLookup === "1";
 
 const inclusiveRange = (start: number, end: number): number[] => Array.from({ length: Math.max(0, end - start + 1) }, (_, i) => start + i);
 
@@ -106,7 +103,7 @@ const vlookupHandler: FunctionHandler = (args, context) => {
   if (!bounds) throw new Error("Invalid table array range");
   const colIndexNum = toNumber(context.evaluateFormula(args[2]));
   const rangeLookup = args.length === 4 ? context.evaluateFormula(args[3]) : true;
-  const matchType = isApproximate(rangeLookup) ? 1 : 0;
+  const matchType = isApproximateMatch(rangeLookup) ? 1 : 0;
 
   const startColStr = indexToColumn(bounds.startCol);
   const lookupArray = columnValues(context, bounds.sheetPrefix, startColStr, bounds.startRow, bounds.endRow);
@@ -128,7 +125,7 @@ const hlookupHandler: FunctionHandler = (args, context) => {
   if (!bounds) throw new Error("Invalid range format");
   const rowIndexNum = toNumber(context.evaluateFormula(args[2]));
   const rangeLookup = args.length === 4 ? context.evaluateFormula(args[3]) : true;
-  const matchType = isApproximate(rangeLookup) ? 1 : 0;
+  const matchType = isApproximateMatch(rangeLookup) ? 1 : 0;
 
   const lookupArray = rowValues(context, bounds.sheetPrefix, bounds.startRow, bounds.startCol, bounds.endCol);
   const matchIdx = findMatchIndex(lookupValue, lookupArray, matchType);

--- a/src/plugins/spreadsheet/engine/functions/statistical-math.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical-math.ts
@@ -34,3 +34,28 @@ export function computeMode(values: number[]): number | string {
   const REPEAT_THRESHOLD = 2;
   return topFrequency >= REPEAT_THRESHOLD ? mode : NA_ERROR;
 }
+
+/** Sample size below which a sample variance/stdev is undefined. */
+const MIN_SAMPLE_SIZE = 2;
+
+const arithmeticMean = (values: number[]): number => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+/**
+ * Sample variance (Excel VAR): the mean squared deviation divided by `n - 1`,
+ * not `n`. Dividing by `n` is the POPULATION variance (Excel's VARP); using it
+ * for VAR understates the spread. Fewer than two values leave no `n - 1` to
+ * divide by, so Excel reports `#DIV/0!` rather than a silent 0.
+ */
+export function sampleVariance(values: number[]): number | string {
+  if (values.length < MIN_SAMPLE_SIZE) return DIV_ZERO_ERROR;
+  const mean = arithmeticMean(values);
+  const sumSquaredDiffs = values.reduce((sum, value) => sum + (value - mean) ** 2, 0);
+  return sumSquaredDiffs / (values.length - 1);
+}
+
+/** Sample standard deviation (Excel STDEV): the square root of the sample
+ *  variance, and `#DIV/0!` on the same fewer-than-two-values boundary. */
+export function sampleStdev(values: number[]): number | string {
+  const variance = sampleVariance(values);
+  return typeof variance === "number" ? Math.sqrt(variance) : variance;
+}

--- a/src/plugins/spreadsheet/engine/functions/statistical.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical.ts
@@ -3,7 +3,7 @@
  */
 
 import { functionRegistry, toNumber, parseCriteria, type FunctionContext, type FunctionHandler } from "../registry";
-import { computeMode, DIV_ZERO_ERROR } from "./statistical-math";
+import { computeMode, sampleStdev, sampleVariance, DIV_ZERO_ERROR } from "./statistical-math";
 
 const isLetter = (char: string): boolean => /[A-Z]/i.test(char);
 
@@ -111,24 +111,13 @@ const modeHandler: FunctionHandler = (args, context) => {
 const stdevHandler: FunctionHandler = (args, context) => {
   if (args.length !== 1) throw new Error("STDEV requires 1 argument");
   const values = context.getRangeValues(args[0]).map(toNumber);
-
-  if (values.length === 0) return 0;
-
-  const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
-  const squaredDiffs = values.map((val) => Math.pow(val - mean, 2));
-  const variance = squaredDiffs.reduce((sum, val) => sum + val, 0) / values.length;
-  return Math.sqrt(variance);
+  return sampleStdev(values);
 };
 
 const varHandler: FunctionHandler = (args, context) => {
   if (args.length !== 1) throw new Error("VAR requires 1 argument");
   const values = context.getRangeValues(args[0]).map(toNumber);
-
-  if (values.length === 0) return 0;
-
-  const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
-  const squaredDiffs = values.map((val) => Math.pow(val - mean, 2));
-  return squaredDiffs.reduce((sum, val) => sum + val, 0) / values.length;
+  return sampleVariance(values);
 };
 
 const countaHandler: FunctionHandler = (args, context) => {

--- a/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
@@ -58,6 +58,62 @@ describe("VLOOKUP — cross-sheet table array (#2390: no longer throws)", () => 
   });
 });
 
+// Approximate match (#2360): the 4th argument TRUE (and omitted) must do an
+// approximate match — the largest first-column/row value <= the lookup key in a
+// sorted range — not fall back to exact. The literal TRUE reaches the handler as
+// the string "TRUE", which the old accept-only-`true|1|"1"` check missed, so
+// `VLOOKUP(4, …, TRUE)` silently returned #N/A.
+describe("VLOOKUP — approximate match with TRUE (#2360)", () => {
+  const sorted: (string | number)[][] = [
+    [1, "a"],
+    [3, "b"],
+    [5, "c"],
+  ];
+
+  it("returns the largest value <= the lookup key", () => {
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(4, A1:B3, 2, TRUE)"), "b"); // 3 is the largest <= 4
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(2, A1:B3, 2, TRUE)"), "a"); // 1 is the largest <= 2
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(9, A1:B3, 2, TRUE)"), "c"); // past the end -> last row
+  });
+
+  it("matches an exact key on the approximate path too", () => {
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(3, A1:B3, 2, TRUE)"), "b");
+  });
+
+  it("treats a lowercase true the same as TRUE", () => {
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(4, A1:B3, 2, true)"), "b");
+  });
+
+  it("approximates when the 4th argument is omitted (default TRUE)", () => {
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(4, A1:B3, 2)"), "b");
+  });
+
+  it("returns #N/A when the key is below the smallest value", () => {
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(0, A1:B3, 2, TRUE)"), "#N/A");
+  });
+
+  it("keeps the exact FALSE path unchanged", () => {
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(3, A1:B3, 2, FALSE)"), "b");
+    assert.equal(evalInSheet(sorted, "=VLOOKUP(4, A1:B3, 2, FALSE)"), "#N/A");
+  });
+});
+
+describe("HLOOKUP — approximate match with TRUE (#2360)", () => {
+  const sorted: (string | number)[][] = [
+    [10, 20, 30],
+    ["x", "y", "z"],
+  ];
+
+  it("returns the row-2 value under the largest column <= the lookup key", () => {
+    assert.equal(evalInSheet(sorted, "=HLOOKUP(25, A1:C2, 2, TRUE)"), "y"); // 20 is the largest <= 25
+    assert.equal(evalInSheet(sorted, "=HLOOKUP(30, A1:C2, 2, TRUE)"), "z");
+  });
+
+  it("returns #N/A when the key is below the smallest value", () => {
+    assert.equal(evalInSheet(sorted, "=HLOOKUP(5, A1:C2, 2, TRUE)"), "#N/A");
+  });
+});
+
 describe("INDEX — bounds (#2390)", () => {
   const grid: (string | number)[][] = [
     [10, 11],

--- a/test/plugins/spreadsheet/engine/test_lookupMath.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupMath.ts
@@ -1,0 +1,43 @@
+// isApproximateMatch reads VLOOKUP/HLOOKUP's range_lookup argument (#2360). The
+// literal TRUE arrives as the STRING "TRUE" (the evaluator leaves bare words
+// unquoted), which the old accept-only-`true|1|"1"` check missed and so fell
+// back to exact match.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isApproximateMatch } from "../../../../src/plugins/spreadsheet/engine/functions/lookup-math.ts";
+
+describe("isApproximateMatch", () => {
+  it("treats a real boolean as itself", () => {
+    assert.equal(isApproximateMatch(true), true);
+    assert.equal(isApproximateMatch(false), false);
+  });
+
+  // The fix: the bare word TRUE evaluates to the string "TRUE", not a boolean.
+  it("reads the string forms of TRUE/FALSE, case-insensitively", () => {
+    assert.equal(isApproximateMatch("TRUE"), true);
+    assert.equal(isApproximateMatch("true"), true);
+    assert.equal(isApproximateMatch("True"), true);
+    assert.equal(isApproximateMatch("FALSE"), false);
+    assert.equal(isApproximateMatch("false"), false);
+  });
+
+  it("reads numeric logicals: 0 exact, non-zero approximate", () => {
+    assert.equal(isApproximateMatch(1), true);
+    assert.equal(isApproximateMatch(0), false);
+    assert.equal(isApproximateMatch(2), true);
+    assert.equal(isApproximateMatch("1"), true);
+    assert.equal(isApproximateMatch("0"), false);
+  });
+
+  it("treats blank or stray text as exact (FALSE), matching Excel coercion", () => {
+    assert.equal(isApproximateMatch(""), false);
+    assert.equal(isApproximateMatch("  "), false);
+    assert.equal(isApproximateMatch("yes"), false);
+  });
+
+  it("ignores surrounding whitespace on the string forms", () => {
+    assert.equal(isApproximateMatch(" TRUE "), true);
+    assert.equal(isApproximateMatch(" 0 "), false);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_statisticalFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_statisticalFunctions.ts
@@ -1,0 +1,45 @@
+// STDEV / VAR through the whole engine (#2360). Excel's STDEV / VAR are the
+// SAMPLE estimators (divide by n-1); the engine used to divide by n, which is
+// the POPULATION estimator (Excel's STDEVP / VARP) — a silent wrong answer.
+// A single value has no n-1 to divide by, so Excel reports #DIV/0!.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+/** Calculate `formula` in the cell just below a single column of `values`. */
+const evalOverColumn = (values: number[], formula: string): unknown => {
+  const data: { v: string | number }[][] = values.map((value) => [{ v: value }]);
+  data.push([{ v: formula }]);
+  const result = new SpreadsheetEngine().calculate({ name: "S", data });
+  return result.data[data.length - 1][0];
+};
+
+// {2,4,4,4,5,5,7,9}: mean 5, Σ(x-μ)² = 32.
+// Sample:     32 / (8-1) = 4.5714… → stdev 2.1380…
+// Population: 32 / 8      = 4       → stdev 2.0 (the old wrong answer).
+const SAMPLE_VALUES = [2, 4, 4, 4, 5, 5, 7, 9];
+
+describe("STDEV — sample estimator (#2360)", () => {
+  it("divides by n-1, not n", () => {
+    const result = evalOverColumn(SAMPLE_VALUES, "=STDEV(A1:A8)");
+    assert.equal(typeof result, "number");
+    assert.ok(Math.abs((result as number) - 2.138089935) < 1e-6, `expected ~2.1381 sample stdev, got ${result}`);
+  });
+
+  it("returns #DIV/0! for a single value (no n-1 to divide by)", () => {
+    assert.equal(evalOverColumn([42], "=STDEV(A1:A1)"), "#DIV/0!");
+  });
+});
+
+describe("VAR — sample estimator (#2360)", () => {
+  it("divides by n-1, not n", () => {
+    const result = evalOverColumn(SAMPLE_VALUES, "=VAR(A1:A8)");
+    assert.equal(typeof result, "number");
+    assert.ok(Math.abs((result as number) - 32 / 7) < 1e-9, `expected 32/7 sample variance, got ${result}`);
+  });
+
+  it("returns #DIV/0! for a single value", () => {
+    assert.equal(evalOverColumn([42], "=VAR(A1:A1)"), "#DIV/0!");
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_statisticalMath.ts
+++ b/test/plugins/spreadsheet/engine/test_statisticalMath.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { computeMode, NA_ERROR } from "../../../../src/plugins/spreadsheet/engine/functions/statistical-math.ts";
+import { computeMode, sampleVariance, sampleStdev, NA_ERROR, DIV_ZERO_ERROR } from "../../../../src/plugins/spreadsheet/engine/functions/statistical-math.ts";
 
 describe("computeMode", () => {
   it("returns the single most frequent value", () => {
@@ -31,5 +31,41 @@ describe("computeMode", () => {
   it("counts repeated negatives and zeros", () => {
     assert.equal(computeMode([0, 0, 1]), 0);
     assert.equal(computeMode([-3, -3, 4]), -3);
+  });
+});
+
+// STDEV / VAR are Excel's SAMPLE estimators: divide by n-1, not n. The old
+// handler divided by n (the POPULATION estimator, Excel's STDEVP / VARP), a
+// silent understatement of the spread (#2360).
+
+describe("sampleVariance", () => {
+  // {2,4,4,4,5,5,7,9}: mean 5, Σ(x-μ)² = 32. Sample 32/7 vs population 32/8 = 4.
+  it("divides the summed squared deviations by n-1", () => {
+    assert.equal(sampleVariance([2, 4, 4, 4, 5, 5, 7, 9]), 32 / 7);
+  });
+
+  it("gives 0.5 for two values one apart, not the population 0.25", () => {
+    assert.equal(sampleVariance([1, 2]), 0.5);
+  });
+
+  it("returns #DIV/0! for a single value (no n-1)", () => {
+    assert.equal(sampleVariance([5]), DIV_ZERO_ERROR);
+  });
+
+  it("returns #DIV/0! for an empty set", () => {
+    assert.equal(sampleVariance([]), DIV_ZERO_ERROR);
+  });
+});
+
+describe("sampleStdev", () => {
+  it("is the square root of the sample variance", () => {
+    const result = sampleStdev([2, 4, 4, 4, 5, 5, 7, 9]);
+    assert.equal(typeof result, "number");
+    assert.ok(Math.abs((result as number) - Math.sqrt(32 / 7)) < 1e-12);
+  });
+
+  it("propagates #DIV/0! from the fewer-than-two boundary", () => {
+    assert.equal(sampleStdev([5]), DIV_ZERO_ERROR);
+    assert.equal(sampleStdev([]), DIV_ZERO_ERROR);
   });
 });


### PR DESCRIPTION
## Summary

Partial fix for #2360 — the two "silently wrong" Excel-correctness bugs that are
**collision-free** with the other open PRs on that issue. The IF-returns-string
and IFERROR items from #2360's table are intentionally **left open** for the
#2362 / #2448 line, so this PR does not touch `functions/logical.ts` (and does
not touch `functions/mathematical.ts`, owned by #2432, or the error-value
representation refactor #2451). #2360 stays open.

Both bugs were the "returns a plausible wrong value, never throws" kind — exactly
the ones that stay invisible until a user notices bad numbers.

1. **STDEV / VAR used the population estimator (÷n) instead of sample (÷n-1).**
   `STDEV`/`VAR` in Excel are the SAMPLE estimators; the engine divided by `n`,
   which is Excel's `STDEVP`/`VARP`. (`STDEVP`/`VARP` are not registered in this
   engine, so nothing there changes.) A single value now returns `#DIV/0!` (there
   is no `n-1` to divide by), matching Excel, instead of a silent `0`.

2. **VLOOKUP/HLOOKUP 4th arg `TRUE` behaved as exact match.** The literal `TRUE`
   reaches the handler as the STRING `"TRUE"` (the evaluator leaves bare words
   unquoted), and the `accept-only true | 1 | "1"` check missed it, silently
   falling back to exact match and returning `#N/A` for a valid approximate
   lookup. It now does the Excel approximate match (largest first-row/col value
   ≤ the lookup key in a sorted range).

Pure decision logic was extracted into its own files so it is unit-testable
without booting the engine (mirrors the existing `statistical-math.ts`
`computeMode` pattern):
- `functions/statistical-math.ts` → `sampleVariance`, `sampleStdev`
- `functions/lookup-math.ts` → `isApproximateMatch`

### Red-verification (test fails when the fix is reverted)

- STDEV/VAR engine tests: **4/4 red** before the fix (returned population 2.0 /
  4, and `0` for a single value); green after.
- Approximate-match engine tests: **3 red** before the fix (`"TRUE"` / lowercase
  `true` / HLOOKUP approximate returned `#N/A`); green after.
- Pure `sampleVariance`/`sampleStdev`: mutating the divisor back to `÷n` turns 3
  value tests red.
- Pure `isApproximateMatch`: mutating back to the old `true|1|"1"` check turns 2
  tests red.

Boundary cases pinned: single-value / empty STDEV → `#DIV/0!`; approximate lookup
below the smallest key → `#N/A`; the exact-match `FALSE` path unchanged.

## Items to Confirm / Review

- **`isApproximateMatch` coercion policy.** It reads `range_lookup` the way Excel
  coerces a logical: boolean as-is, non-zero number → approximate, and the
  strings `"TRUE"`/`"1"` → approximate, `"FALSE"`/`"0"`/blank/other text →
  exact (case-insensitive). Please confirm the "unrecognized text → exact
  (FALSE)" default is acceptable (Excel coerces a blank `range_lookup` to
  FALSE).
- **`#DIV/0!` for n<2** is returned as the string `"#DIV/0!"` via the existing
  `DIV_ZERO_ERROR` constant, exactly like `AVERAGEIF` already does — no change to
  the error-value representation (that is #2451).
- Empty-range STDEV/VAR now returns `#DIV/0!` (was `0`); this falls out of the
  n<2 guard and matches Excel. Included because the task explicitly asked for the
  n<2 guard; flagging since the empty-range case is listed under a different
  section of #2360.

## User Prompt

Fix the unaddressed Excel-correctness issues filed under #2360+ (isamu's
issues). For this PR specifically: fix the collision-free subset of #2360 as a
**partial** fix (leave #2360 open) — namely (1) STDEV/VAR must use the sample
estimator (n-1) with a single-value `#DIV/0!` guard, without changing
STDEVP/VARP, and (2) HLOOKUP/VLOOKUP with the 4th argument `TRUE` (or omitted)
must do an approximate match, not fall back to exact. Write a failing
characterization test first for each, fix at the root cause, and add boundary
cases. Do not touch `logical.ts` (IF/IFERROR, owned by #2431/#2448) or
`mathematical.ts` (#2432), and do not change the error-value representation
(#2451). Leave #2360's IF-returns-string and IFERROR items to the #2362/#2448
line.

## Approach

- Branched from `origin/main` (includes #2441 / #2449 / #2450 / #2448).
- Plan committed at `plans/fix-2360-stdev-hlookup.md`.
- `statistical.ts` STDEV/VAR handlers now delegate to the pure
  `sampleStdev`/`sampleVariance`; `lookup.ts` VLOOKUP/HLOOKUP now call the pure
  `isApproximateMatch`. The existing `findMatchIndex(matchType = 1)` already
  implemented largest-≤ with `#N/A` below the smallest key, so only the argument
  reading needed fixing.
- `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build` all pass;
  603 spreadsheet-engine tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
