### PR TITLE
refactor(spreadsheet): remove duplicated handler-side arg-count checks (#2397)

### DIFF
--- a/plans/refactor-2397-argcount-dedup.md
+++ b/plans/refactor-2397-argcount-dedup.md
@@ -1,0 +1,148 @@
+# refactor(spreadsheet): remove duplicated handler-side argument-count checks (#2397)
+
+## Problem
+
+`evaluator.ts` (L296-301) already validates every function's arity against the
+registry's `minArgs`/`maxArgs` **before** calling the handler:
+
+```ts
+if (func.minArgs !== undefined && args.length < func.minArgs) throw ... "requires at least N argument(s)";
+if (func.maxArgs !== undefined && args.length > func.maxArgs) throw ... "accepts at most N argument(s)";
+```
+
+Yet nearly every handler starts with its own `if (args.length ... ) throw`. When
+the registry `minArgs`/`maxArgs` fully expresses the valid arity, that handler
+check is **unreachable dead code**, and its wording ("requires N") disagrees with
+the evaluator's ("requires at least N" / "accepts at most N").
+
+## Rule applied
+
+- **REMOVE** the handler arg-count guard when the registry `minArgs`/`maxArgs`
+  fully expresses the valid arity (exact `N` = min==max; a contiguous range
+  `[min,max]`; or an open `>= min` with no max). The evaluator already rejects
+  every out-of-range call with a single consistent message.
+- **KEEP** the guard only when the shape is **not** expressible by `minArgs`/`maxArgs`:
+  a non-contiguous constraint. In this codebase that is **only IFS** (must be an
+  **even** count `>= 2`).
+- **KEEP** non-arity guards untouched (empty-range checks, invalid-range-bounds
+  checks) — they are not argument-count validation.
+
+### Discrepancy with the issue text (SUMIF / AVERAGEIF)
+
+The issue lists "SUMIF/AVERAGEIF's `2 or 3`" as an inexpressible shape to keep.
+That is **outdated**: in the current registry both are `minArgs: 2, maxArgs: 3`,
+which fully expresses the contiguous range `{2,3}`, so the evaluator already
+rejects 1-arg and 4-arg calls. Their handler checks are therefore unreachable
+dead code — identical in form to FIND/SEARCH (also `min 2, max 3`). Keeping SUMIF
+but removing FIND would be arbitrary. Applying the **principle** (registry fully
+expresses arity → remove), SUMIF/AVERAGEIF checks are **removed** too. IFS's
+even-count is the only genuinely inexpressible shape and is kept.
+
+Verified via `git log -S` that `maxArgs: 3` on SUMIF/AVERAGEIF has existed since
+the first spreadsheet commit — it was never absent.
+
+### Financial safety precondition (#2394 / PR #2442)
+
+The issue warns that IPMT/PPMT once called `pmtHandler([...])` / `fvHandler([...])`
+**directly**, bypassing the evaluator, so their handler-side arg check was the
+only validation. After #2394 (PR #2442, merged) `ipmtHandler`/`ppmtHandler` call
+the pure functions `computeIpmt`/`computePpmt` from `financial-math.ts` with
+already-parsed numeric arguments. `grep` confirms **no** remaining
+handler-to-handler calls anywhere in `functions/`. Every financial handler is now
+reached only through the evaluator, which validates arity first. All financial
+handler arg-count guards are therefore safe to remove.
+
+## Remove / Keep table
+
+Legend: registry `[min,max]`; "—" = no maxArgs.
+
+### functions/logical.ts (⚠ #2431/#2448 touch this file; #2448 already merged to main)
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| IF | `!== 3` | [3,3] | REMOVE |
+| AND | `=== 0` | [1,—] | REMOVE (evaluator `< 1`) |
+| OR | `=== 0` | [1,—] | REMOVE (evaluator `< 1`) |
+| NOT | `!== 1` | [1,1] | REMOVE |
+| IFERROR | `!== 2` | [2,2] | REMOVE |
+| IFNA | `!== 2` | [2,2] | REMOVE |
+| **IFS** | `< 2 || % 2 !== 0` | [2,—] | **KEEP** (even-count inexpressible) |
+| TRUE | `!== 0` | [0,0] | REMOVE |
+| FALSE | `!== 0` | [0,0] | REMOVE |
+
+### functions/mathematical.ts (⚠ #2432 touches this file)
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| ROUND/ROUNDUP/ROUNDDOWN/FLOOR/CEILING/POWER/MOD | `!== 2` | [2,2] | REMOVE |
+| ABS/SQRT/INT/SIGN/EXP/LN/LOG10 | `!== 1` | [1,1] | REMOVE |
+| PI | `!== 0` | [0,0] | REMOVE |
+| TRUNC | `< 1 || > 2` | [1,2] | REMOVE |
+| LOG | `< 1 || > 2` | [1,2] | REMOVE |
+
+### functions/statistical.ts
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| SUM/AVERAGE/COUNT/MEDIAN/MODE/STDEV/VAR/COUNTA | `!== 1` | [1,1] | REMOVE |
+| MAX | `=== 0` | [1,—] | REMOVE (evaluator `< 1`); keep `values.length>0?…:0` |
+| MIN | `=== 0` | [1,—] | REMOVE (evaluator `< 1`); keep `values.length>0?…:0` |
+| COUNTIF | `!== 2` | [2,2] | REMOVE |
+| SUMIF | `< 2 || > 3` | [2,3] | REMOVE (see discrepancy note) |
+| AVERAGEIF | `< 2 || > 3` | [2,3] | REMOVE (see discrepancy note) |
+
+### functions/text.ts
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| CONCATENATE (+CONCAT alias) | `=== 0` | [1,—] | REMOVE |
+| LEFT/RIGHT | `< 1 || > 2` | [1,2] | REMOVE |
+| MID | `!== 3` | [3,3] | REMOVE |
+| LEN/UPPER/LOWER/PROPER/TRIM/VALUE | `!== 1` | [1,1] | REMOVE |
+| SUBSTITUTE | `< 3 || > 4` | [3,4] | REMOVE |
+| REPLACE | `!== 4` | [4,4] | REMOVE |
+| FIND/SEARCH | `< 2 || > 3` | [2,3] | REMOVE |
+| TEXT/EXACT | `!== 2` | [2,2] | REMOVE |
+
+### functions/lookup.ts
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| VLOOKUP/HLOOKUP | `< 3 || > 4` | [3,4] | REMOVE (keep `if (!bounds)` range-format check) |
+| MATCH | `< 2 || > 3` | [2,3] | REMOVE |
+| INDEX | `< 2 || > 4` | [2,4] | REMOVE (keep `if (!bounds)` check) |
+| XLOOKUP | `< 3 || > 6` | [3,6] | REMOVE |
+
+### functions/date.ts
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| NOW/TODAY | `!== 0` | [0,0] | REMOVE |
+| DATE/TIME/DATEDIF | `!== 3` | [3,3] | REMOVE |
+| YEAR/MONTH/DAY/HOUR/MINUTE/SECOND | `!== 1` | [1,1] | REMOVE |
+
+### functions/financial.ts
+| Handler | Guard | Registry | Action |
+|---|---|---|---|
+| FV/PV/PMT/NPER | `< 3 || > 5` | [3,5] | REMOVE |
+| RATE | `< 3 || > 6` | [3,6] | REMOVE |
+| IPMT/PPMT | `< 4 || > 6` | [4,6] | REMOVE (now via computeIpmt/computePpmt) |
+| NPV | `< 2` | [2,—] | REMOVE (evaluator `< 2`) |
+| IRR | `< 1 || > 2` | [1,2] | REMOVE arg check; **KEEP** `if (values.length === 0)` (empty-range, not arity) |
+
+## Behavior
+
+- Valid inputs: identical.
+- Invalid arity: now surfaces the evaluator's single consistent message
+  (`#ERROR!`, type `unknown`) — e.g. "ROUND requires at least 2 arguments" /
+  "ABS accepts at most 1 argument" — instead of the divergent handler wording.
+- IFS odd/short and IRR empty-range: still rejected by the kept guards.
+
+## Tests
+
+New `test/plugins/spreadsheet/engine/test_argCountValidation.ts`:
+- Evaluator-level arity error fires for representative removed-guard functions
+  (min side and max side), asserting the consistent evaluator message.
+- IFS still rejects odd arity via the kept handler guard (red-on-break target).
+- SUMIF/AVERAGEIF still reject 1-arg / 4-arg via the evaluator.
+- IRR still rejects an empty range via the kept non-arity guard.
+
+## Verify
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, spreadsheet engine
+tests. No package version bumps. Diff confined to deleting top-of-handler arg-count
+guard lines (no function-body/logic changes) to minimize conflict with #2431/#2432.

--- a/src/plugins/spreadsheet/engine/functions/date.ts
+++ b/src/plugins/spreadsheet/engine/functions/date.ts
@@ -8,8 +8,7 @@ import { functionRegistry, toNumber, toString, type FunctionHandler } from "../r
 import { computeDatedif } from "../datedif";
 import { dateToSerial, serialToDate } from "../date-utils";
 
-const nowHandler: FunctionHandler = (args) => {
-  if (args.length !== 0) throw new Error("NOW requires 0 arguments");
+const nowHandler: FunctionHandler = () => {
   // Return current date and time as serial number
   // We need to adjust for timezone offset because Excel dates are "local" usually
   // But for simplicity we'll use local time converted to serial
@@ -19,16 +18,13 @@ const nowHandler: FunctionHandler = (args) => {
   return dateToSerial(localAsUtc);
 };
 
-const todayHandler: FunctionHandler = (args) => {
-  if (args.length !== 0) throw new Error("TODAY requires 0 arguments");
+const todayHandler: FunctionHandler = () => {
   const now = new Date();
   const today = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
   return dateToSerial(today);
 };
 
 const dateHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 3) throw new Error("DATE requires 3 arguments");
-
   const year = toNumber(context.evaluateFormula(args[0]));
   const month = toNumber(context.evaluateFormula(args[1]));
   const day = toNumber(context.evaluateFormula(args[2]));
@@ -40,8 +36,6 @@ const dateHandler: FunctionHandler = (args, context) => {
 };
 
 const timeHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 3) throw new Error("TIME requires 3 arguments");
-
   const hour = toNumber(context.evaluateFormula(args[0]));
   const minute = toNumber(context.evaluateFormula(args[1]));
   const second = toNumber(context.evaluateFormula(args[2]));
@@ -59,28 +53,24 @@ const timeHandler: FunctionHandler = (args, context) => {
 };
 
 const yearHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("YEAR requires 1 argument");
   const serial = toNumber(context.evaluateFormula(args[0]));
   const date = serialToDate(serial);
   return date.getUTCFullYear();
 };
 
 const monthHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("MONTH requires 1 argument");
   const serial = toNumber(context.evaluateFormula(args[0]));
   const date = serialToDate(serial);
   return date.getUTCMonth() + 1; // 1-indexed
 };
 
 const dayHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("DAY requires 1 argument");
   const serial = toNumber(context.evaluateFormula(args[0]));
   const date = serialToDate(serial);
   return date.getUTCDate();
 };
 
 const hourHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("HOUR requires 1 argument");
   const serial = toNumber(context.evaluateFormula(args[0]));
   // Get fractional part
   const timePart = serial - Math.floor(serial);
@@ -89,7 +79,6 @@ const hourHandler: FunctionHandler = (args, context) => {
 };
 
 const minuteHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("MINUTE requires 1 argument");
   const serial = toNumber(context.evaluateFormula(args[0]));
   const timePart = serial - Math.floor(serial);
   const totalSeconds = Math.round(timePart * 86400);
@@ -97,7 +86,6 @@ const minuteHandler: FunctionHandler = (args, context) => {
 };
 
 const secondHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("SECOND requires 1 argument");
   const serial = toNumber(context.evaluateFormula(args[0]));
   const timePart = serial - Math.floor(serial);
   const totalSeconds = Math.round(timePart * 86400);
@@ -105,8 +93,6 @@ const secondHandler: FunctionHandler = (args, context) => {
 };
 
 const datedifHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 3) throw new Error("DATEDIF requires 3 arguments");
-
   const startSerial = toNumber(context.evaluateFormula(args[0]));
   const endSerial = toNumber(context.evaluateFormula(args[1]));
   const unit = toString(context.evaluateFormula(args[2]));

--- a/src/plugins/spreadsheet/engine/functions/financial.ts
+++ b/src/plugins/spreadsheet/engine/functions/financial.ts
@@ -16,10 +16,6 @@ import { computeFv, computePmt, computeIpmt, computePpmt, computePv, computeNper
  * - type: 0 = end of period, 1 = beginning of period (optional, default 0)
  */
 const fvHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 5) {
-    throw new Error("FV requires 3 to 5 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   const nper = toNumber(context.evaluateFormula(args[1]));
   const pmt = toNumber(context.evaluateFormula(args[2]));
@@ -35,10 +31,6 @@ const fvHandler: FunctionHandler = (args, context) => {
  * PV(rate, nper, pmt, [fv], [type])
  */
 const pvHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 5) {
-    throw new Error("PV requires 3 to 5 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   const nper = toNumber(context.evaluateFormula(args[1]));
   const pmt = toNumber(context.evaluateFormula(args[2]));
@@ -54,10 +46,6 @@ const pvHandler: FunctionHandler = (args, context) => {
  * PMT(rate, nper, pv, [fv], [type])
  */
 const pmtHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 5) {
-    throw new Error("PMT requires 3 to 5 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   const nper = toNumber(context.evaluateFormula(args[1]));
   const pv = toNumber(context.evaluateFormula(args[2]));
@@ -73,10 +61,6 @@ const pmtHandler: FunctionHandler = (args, context) => {
  * NPER(rate, pmt, pv, [fv], [type])
  */
 const nperHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 5) {
-    throw new Error("NPER requires 3 to 5 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   const pmt = toNumber(context.evaluateFormula(args[1]));
   const pv = toNumber(context.evaluateFormula(args[2]));
@@ -93,10 +77,6 @@ const nperHandler: FunctionHandler = (args, context) => {
  * Uses Newton-Raphson method for iteration
  */
 const rateHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 6) {
-    throw new Error("RATE requires 3 to 6 arguments");
-  }
-
   const nper = toNumber(context.evaluateFormula(args[0]));
   const pmt = toNumber(context.evaluateFormula(args[1]));
   const pv = toNumber(context.evaluateFormula(args[2]));
@@ -113,10 +93,6 @@ const rateHandler: FunctionHandler = (args, context) => {
  * IPMT(rate, per, nper, pv, [fv], [type])
  */
 const ipmtHandler: FunctionHandler = (args, context) => {
-  if (args.length < 4 || args.length > 6) {
-    throw new Error("IPMT requires 4 to 6 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   const per = toNumber(context.evaluateFormula(args[1]));
   const nper = toNumber(context.evaluateFormula(args[2]));
@@ -133,10 +109,6 @@ const ipmtHandler: FunctionHandler = (args, context) => {
  * PPMT(rate, per, nper, pv, [fv], [type])
  */
 const ppmtHandler: FunctionHandler = (args, context) => {
-  if (args.length < 4 || args.length > 6) {
-    throw new Error("PPMT requires 4 to 6 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   const per = toNumber(context.evaluateFormula(args[1]));
   const nper = toNumber(context.evaluateFormula(args[2]));
@@ -160,10 +132,6 @@ const collectCashFlows = (valueArgs: string[], context: FunctionContext): number
   valueArgs.flatMap((arg) => (arg.includes(":") ? context.getRangeValues(arg) : [context.evaluateFormula(arg)]).map(toNumber));
 
 const npvHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2) {
-    throw new Error("NPV requires at least 2 arguments");
-  }
-
   const rate = toNumber(context.evaluateFormula(args[0]));
   return computeNpv(rate, collectCashFlows(args.slice(1), context));
 };
@@ -175,10 +143,6 @@ const npvHandler: FunctionHandler = (args, context) => {
  * Uses Newton-Raphson method for iteration
  */
 const irrHandler: FunctionHandler = (args, context) => {
-  if (args.length < 1 || args.length > 2) {
-    throw new Error("IRR requires 1 or 2 arguments");
-  }
-
   const values = context.getRangeValues(args[0]).map(toNumber);
   const guess = args.length === 2 ? toNumber(context.evaluateFormula(args[1])) : 0.1;
 

--- a/src/plugins/spreadsheet/engine/functions/logical.ts
+++ b/src/plugins/spreadsheet/engine/functions/logical.ts
@@ -8,8 +8,6 @@ import { functionRegistry, type FunctionHandler } from "../registry";
 import type { CellValue } from "../types";
 
 const ifHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 3) throw new Error("IF requires 3 arguments");
-
   const condition = args[0];
   const trueValue = args[1];
   const falseValue = args[2];
@@ -59,8 +57,6 @@ const ifHandler: FunctionHandler = (args, context) => {
 };
 
 const andHandler: FunctionHandler = (args, context) => {
-  if (args.length === 0) throw new Error("AND requires at least 1 argument");
-
   for (const arg of args) {
     const value = context.evaluateFormula(arg.trim());
     // Check if value is falsy (0, false, empty string, etc.)
@@ -73,8 +69,6 @@ const andHandler: FunctionHandler = (args, context) => {
 };
 
 const orHandler: FunctionHandler = (args, context) => {
-  if (args.length === 0) throw new Error("OR requires at least 1 argument");
-
   for (const arg of args) {
     const value = context.evaluateFormula(arg.trim());
     // Check if value is truthy (non-zero, non-empty)
@@ -86,16 +80,12 @@ const orHandler: FunctionHandler = (args, context) => {
 };
 
 const notHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("NOT requires 1 argument");
-
   const value = context.evaluateFormula(args[0]);
   // Note: !value already covers false
   return !value || value === 0 || value === "0";
 };
 
 const iferrorHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("IFERROR requires 2 arguments");
-
   try {
     const result = context.evaluateFormula(args[0]);
     // Check if result is an error (NaN, Infinity, etc.)
@@ -110,8 +100,6 @@ const iferrorHandler: FunctionHandler = (args, context) => {
 };
 
 const ifnaHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("IFNA requires 2 arguments");
-
   const result = context.evaluateFormula(args[0]);
   // Check if result is N/A (could be represented as specific error value)
   if (result === null || result === undefined || result === "#N/A") {
@@ -170,15 +158,9 @@ const ifsHandler: FunctionHandler = (args, context) => {
   return "#N/A";
 };
 
-const trueHandler: FunctionHandler = (args) => {
-  if (args.length !== 0) throw new Error("TRUE requires 0 arguments");
-  return true;
-};
+const trueHandler: FunctionHandler = () => true;
 
-const falseHandler: FunctionHandler = (args) => {
-  if (args.length !== 0) throw new Error("FALSE requires 0 arguments");
-  return false;
-};
+const falseHandler: FunctionHandler = () => false;
 
 // Register all logical functions
 functionRegistry.register({

--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -97,10 +97,6 @@ const findMatchIndex = (
 };
 
 const vlookupHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 4) {
-    throw new Error("VLOOKUP requires 3 or 4 arguments");
-  }
-
   const lookupValue = context.evaluateFormula(args[0]);
   const bounds = parseRangeBounds(args[1]);
   if (!bounds) throw new Error("Invalid table array range");
@@ -119,10 +115,6 @@ const vlookupHandler: FunctionHandler = (args, context) => {
 };
 
 const hlookupHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 4) {
-    throw new Error("HLOOKUP requires 3 or 4 arguments");
-  }
-
   const lookupValue = context.evaluateFormula(args[0]);
   const bounds = parseRangeBounds(args[1]);
   if (!bounds) throw new Error("Invalid range format");
@@ -140,10 +132,6 @@ const hlookupHandler: FunctionHandler = (args, context) => {
 };
 
 const matchHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2 || args.length > 3) {
-    throw new Error("MATCH requires 2 or 3 arguments");
-  }
-
   const lookupValue = context.evaluateFormula(args[0]);
   const lookupArrayRange = args[1];
   const matchType = args.length === 3 ? toNumber(context.evaluateFormula(args[2])) : 1;
@@ -156,10 +144,6 @@ const matchHandler: FunctionHandler = (args, context) => {
 };
 
 const indexHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2 || args.length > 4) {
-    throw new Error("INDEX requires 2 to 4 arguments");
-  }
-
   const bounds = parseRangeBounds(args[0]);
   if (!bounds) throw new Error("Invalid range format");
   const rowNum = toNumber(context.evaluateFormula(args[1]));
@@ -171,10 +155,6 @@ const indexHandler: FunctionHandler = (args, context) => {
 };
 
 const xlookupHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 6) {
-    throw new Error("XLOOKUP requires 3 to 6 arguments");
-  }
-
   const lookupValue = context.evaluateFormula(args[0]);
   const lookupArrayRange = args[1];
   const returnArrayRange = args[2];

--- a/src/plugins/spreadsheet/engine/functions/mathematical.ts
+++ b/src/plugins/spreadsheet/engine/functions/mathematical.ts
@@ -6,7 +6,6 @@ import { functionRegistry, toNumber, type FunctionHandler } from "../registry";
 import { toScalarNumber } from "../numericCoercion";
 
 const roundHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("ROUND requires 2 arguments");
   const number = toNumber(context.evaluateFormula(args[0]));
   const digits = toNumber(context.evaluateFormula(args[1]));
   const multiplier = Math.pow(10, digits);
@@ -14,7 +13,6 @@ const roundHandler: FunctionHandler = (args, context) => {
 };
 
 const roundupHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("ROUNDUP requires 2 arguments");
   const number = toNumber(context.evaluateFormula(args[0]));
   const digits = toNumber(context.evaluateFormula(args[1]));
   const multiplier = Math.pow(10, digits);
@@ -22,7 +20,6 @@ const roundupHandler: FunctionHandler = (args, context) => {
 };
 
 const rounddownHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("ROUNDDOWN requires 2 arguments");
   const number = toNumber(context.evaluateFormula(args[0]));
   const digits = toNumber(context.evaluateFormula(args[1]));
   const multiplier = Math.pow(10, digits);
@@ -30,7 +27,6 @@ const rounddownHandler: FunctionHandler = (args, context) => {
 };
 
 const floorHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("FLOOR requires 2 arguments");
   const number = toNumber(context.evaluateFormula(args[0]));
   const significance = toNumber(context.evaluateFormula(args[1]));
   if (significance === 0) return 0;
@@ -38,7 +34,6 @@ const floorHandler: FunctionHandler = (args, context) => {
 };
 
 const ceilingHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("CEILING requires 2 arguments");
   const number = toNumber(context.evaluateFormula(args[0]));
   const significance = toNumber(context.evaluateFormula(args[1]));
   if (significance === 0) return 0;
@@ -46,26 +41,22 @@ const ceilingHandler: FunctionHandler = (args, context) => {
 };
 
 const absHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("ABS requires 1 argument");
   const number = toScalarNumber(context.evaluateFormula(args[0]));
   return typeof number === "string" ? number : Math.abs(number);
 };
 
 const powerHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("POWER requires 2 arguments");
   const base = toNumber(context.evaluateFormula(args[0]));
   const exponent = toNumber(context.evaluateFormula(args[1]));
   return Math.pow(base, exponent);
 };
 
 const sqrtHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("SQRT requires 1 argument");
   const number = toNumber(context.evaluateFormula(args[0]));
   return Math.sqrt(number);
 };
 
 const modHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("MOD requires 2 arguments");
   const number = toNumber(context.evaluateFormula(args[0]));
   const divisor = toNumber(context.evaluateFormula(args[1]));
   if (divisor === 0) return 0;
@@ -73,15 +64,11 @@ const modHandler: FunctionHandler = (args, context) => {
 };
 
 const intHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("INT requires 1 argument");
   const number = toNumber(context.evaluateFormula(args[0]));
   return Math.floor(number);
 };
 
 const truncHandler: FunctionHandler = (args, context) => {
-  if (args.length < 1 || args.length > 2) {
-    throw new Error("TRUNC requires 1 or 2 arguments");
-  }
   const number = toNumber(context.evaluateFormula(args[0]));
   const digits = args.length === 2 ? toNumber(context.evaluateFormula(args[1])) : 0;
   const multiplier = Math.pow(10, digits);
@@ -89,39 +76,29 @@ const truncHandler: FunctionHandler = (args, context) => {
 };
 
 const signHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("SIGN requires 1 argument");
   const number = toScalarNumber(context.evaluateFormula(args[0]));
   return typeof number === "string" ? number : Math.sign(number);
 };
 
-const piHandler: FunctionHandler = (args) => {
-  if (args.length !== 0) throw new Error("PI requires 0 arguments");
-  return Math.PI;
-};
+const piHandler: FunctionHandler = () => Math.PI;
 
 const expHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("EXP requires 1 argument");
   const number = toNumber(context.evaluateFormula(args[0]));
   return Math.exp(number);
 };
 
 const lnHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("LN requires 1 argument");
   const number = toNumber(context.evaluateFormula(args[0]));
   return Math.log(number);
 };
 
 const logHandler: FunctionHandler = (args, context) => {
-  if (args.length < 1 || args.length > 2) {
-    throw new Error("LOG requires 1 or 2 arguments");
-  }
   const number = toNumber(context.evaluateFormula(args[0]));
   const base = args.length === 2 ? toNumber(context.evaluateFormula(args[1])) : 10;
   return Math.log(number) / Math.log(base);
 };
 
 const log10Handler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("LOG10 requires 1 argument");
   const number = toNumber(context.evaluateFormula(args[0]));
   return Math.log10(number);
 };

--- a/src/plugins/spreadsheet/engine/functions/statistical.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical.ts
@@ -55,13 +55,11 @@ const collectNumericValues = (args: string[], context: FunctionContext): number[
 };
 
 const sumHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("SUM requires 1 argument");
   const values = context.getRangeValues(args[0]);
   return values.reduce((sum: number, val) => sum + toNumber(val), 0);
 };
 
 const averageHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("AVERAGE requires 1 argument");
   const values = context.getRangeValues(args[0]);
   if (values.length === 0) return 0;
   const sum = values.reduce((acc: number, val) => acc + toNumber(val), 0);
@@ -69,29 +67,21 @@ const averageHandler: FunctionHandler = (args, context) => {
 };
 
 const maxHandler: FunctionHandler = (args, context) => {
-  if (args.length === 0) {
-    throw new Error("MAX requires at least 1 argument");
-  }
   const values = collectNumericValues(args, context);
   return values.length > 0 ? Math.max(...values) : 0;
 };
 
 const minHandler: FunctionHandler = (args, context) => {
-  if (args.length === 0) {
-    throw new Error("MIN requires at least 1 argument");
-  }
   const values = collectNumericValues(args, context);
   return values.length > 0 ? Math.min(...values) : 0;
 };
 
 const countHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("COUNT requires 1 argument");
   const values = context.getRangeValues(args[0]);
   return values.length;
 };
 
 const medianHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("MEDIAN requires 1 argument");
   const values = context
     .getRangeValues(args[0])
     .map(toNumber)
@@ -103,13 +93,11 @@ const medianHandler: FunctionHandler = (args, context) => {
 };
 
 const modeHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("MODE requires 1 argument");
   const values = context.getRangeValues(args[0]).map(toNumber);
   return computeMode(values);
 };
 
 const stdevHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("STDEV requires 1 argument");
   const values = context.getRangeValues(args[0]).map(toNumber);
 
   if (values.length === 0) return 0;
@@ -121,7 +109,6 @@ const stdevHandler: FunctionHandler = (args, context) => {
 };
 
 const varHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("VAR requires 1 argument");
   const values = context.getRangeValues(args[0]).map(toNumber);
 
   if (values.length === 0) return 0;
@@ -132,14 +119,12 @@ const varHandler: FunctionHandler = (args, context) => {
 };
 
 const countaHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("COUNTA requires 1 argument");
   const values = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
   // Count non-empty cells
   return values.filter((v) => v !== null && v !== undefined && v !== "").length;
 };
 
 const countifHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("COUNTIF requires 2 arguments");
   const values = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
   const criteria = args[1].trim();
   const compareFn = parseCriteria(criteria);
@@ -147,10 +132,6 @@ const countifHandler: FunctionHandler = (args, context) => {
 };
 
 const sumifHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2 || args.length > 3) {
-    throw new Error("SUMIF requires 2 or 3 arguments");
-  }
-
   const criteriaRange = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
   const criteria = args[1].trim();
   // Raw, not numeric-only: dropping blanks here would shift the value range out
@@ -172,10 +153,6 @@ const sumifHandler: FunctionHandler = (args, context) => {
 };
 
 const averageifHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2 || args.length > 3) {
-    throw new Error("AVERAGEIF requires 2 or 3 arguments");
-  }
-
   const criteriaRange = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
   const criteria = args[1].trim();
   // Raw, to stay row-aligned with the criteria range (see SUMIF, #2358).

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -60,8 +60,6 @@ export const substituteText = (text: string, oldText: string, newText: string, i
 };
 
 const concatenateHandler: FunctionHandler = (args, context) => {
-  if (args.length === 0) throw new Error("CONCATENATE requires at least 1 argument");
-
   return args
     .map((arg) => {
       const value = context.evaluateFormula(arg.trim());
@@ -73,10 +71,6 @@ const concatenateHandler: FunctionHandler = (args, context) => {
 const concatHandler: FunctionHandler = concatenateHandler; // Alias
 
 const leftHandler: FunctionHandler = (args, context) => {
-  if (args.length < 1 || args.length > 2) {
-    throw new Error("LEFT requires 1 or 2 arguments");
-  }
-
   const text = toString(context.evaluateFormula(args[0]));
   const numChars = args.length === 2 ? Number(context.evaluateFormula(args[1])) : 1;
 
@@ -84,10 +78,6 @@ const leftHandler: FunctionHandler = (args, context) => {
 };
 
 const rightHandler: FunctionHandler = (args, context) => {
-  if (args.length < 1 || args.length > 2) {
-    throw new Error("RIGHT requires 1 or 2 arguments");
-  }
-
   const text = toString(context.evaluateFormula(args[0]));
   const numChars = args.length === 2 ? Number(context.evaluateFormula(args[1])) : 1;
 
@@ -95,8 +85,6 @@ const rightHandler: FunctionHandler = (args, context) => {
 };
 
 const midHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 3) throw new Error("MID requires 3 arguments");
-
   const text = toString(context.evaluateFormula(args[0]));
   const start = Number(context.evaluateFormula(args[1])) - 1; // 1-indexed to 0-indexed
   const numChars = Number(context.evaluateFormula(args[2]));
@@ -105,46 +93,32 @@ const midHandler: FunctionHandler = (args, context) => {
 };
 
 const lenHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("LEN requires 1 argument");
-
   const text = toString(context.evaluateFormula(args[0]));
   return text.length;
 };
 
 const upperHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("UPPER requires 1 argument");
-
   const text = toString(context.evaluateFormula(args[0]));
   return text.toUpperCase();
 };
 
 const lowerHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("LOWER requires 1 argument");
-
   const text = toString(context.evaluateFormula(args[0]));
   return text.toLowerCase();
 };
 
 const properHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("PROPER requires 1 argument");
-
   const text = toString(context.evaluateFormula(args[0]));
   return toProperCase(text);
 };
 
 const trimHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("TRIM requires 1 argument");
-
   const text = toString(context.evaluateFormula(args[0]));
   // Trim leading/trailing spaces and replace multiple spaces with single space
   return text.trim().replace(/\s+/g, " ");
 };
 
 const substituteHandler: FunctionHandler = (args, context) => {
-  if (args.length < 3 || args.length > 4) {
-    throw new Error("SUBSTITUTE requires 3 or 4 arguments");
-  }
-
   const text = toString(context.evaluateFormula(args[0]));
   const oldText = toString(context.evaluateFormula(args[1]));
   const newText = toString(context.evaluateFormula(args[2]));
@@ -154,8 +128,6 @@ const substituteHandler: FunctionHandler = (args, context) => {
 };
 
 const replaceHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 4) throw new Error("REPLACE requires 4 arguments");
-
   const oldText = toString(context.evaluateFormula(args[0]));
   const startPos = Number(context.evaluateFormula(args[1])) - 1; // 1-indexed to 0-indexed
   const numChars = Number(context.evaluateFormula(args[2]));
@@ -165,10 +137,6 @@ const replaceHandler: FunctionHandler = (args, context) => {
 };
 
 const findHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2 || args.length > 3) {
-    throw new Error("FIND requires 2 or 3 arguments");
-  }
-
   const findText = toString(context.evaluateFormula(args[0]));
   const withinText = toString(context.evaluateFormula(args[1]));
   const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
@@ -178,10 +146,6 @@ const findHandler: FunctionHandler = (args, context) => {
 };
 
 const searchHandler: FunctionHandler = (args, context) => {
-  if (args.length < 2 || args.length > 3) {
-    throw new Error("SEARCH requires 2 or 3 arguments");
-  }
-
   const findText = toString(context.evaluateFormula(args[0]));
   const withinText = toString(context.evaluateFormula(args[1]));
   const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
@@ -195,8 +159,6 @@ const searchHandler: FunctionHandler = (args, context) => {
 };
 
 const textHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("TEXT requires 2 arguments");
-
   const value = context.evaluateFormula(args[0]);
   const format = toString(context.evaluateFormula(args[1])).replace(
     // eslint-disable -- sonarjs/anchor-precedence
@@ -225,8 +187,6 @@ const textHandler: FunctionHandler = (args, context) => {
 };
 
 const valueHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 1) throw new Error("VALUE requires 1 argument");
-
   const text = toString(context.evaluateFormula(args[0]));
 
   // Remove currency symbols and commas
@@ -243,8 +203,6 @@ const valueHandler: FunctionHandler = (args, context) => {
 };
 
 const exactHandler: FunctionHandler = (args, context) => {
-  if (args.length !== 2) throw new Error("EXACT requires 2 arguments");
-
   const text1 = toString(context.evaluateFormula(args[0]));
   const text2 = toString(context.evaluateFormula(args[1]));
 

--- a/test/plugins/spreadsheet/engine/test_argCountValidation.ts
+++ b/test/plugins/spreadsheet/engine/test_argCountValidation.ts
@@ -1,0 +1,127 @@
+// #2397: the handler-side `if (args.length ...) throw` guards were removed for
+// every function whose arity is fully expressed by the registry minArgs/maxArgs.
+// The evaluator (evaluator.ts) validates arity from the registry BEFORE calling
+// the handler, so those guards were unreachable dead code with a divergent
+// message ("requires N" vs the evaluator's "requires at least N").
+//
+// These tests pin that (a) invalid arity now surfaces the evaluator's single
+// consistent message for the removed-guard functions — including the financial
+// handlers, whose only remaining validation is the evaluator after #2394/#2442 —
+// and (b) the shapes the registry CANNOT express keep their handler guard: IFS's
+// even-count requirement and IRR's empty-range check.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData, type CellValue } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+/** Calculate `sheet` and report the value, error type, and recorded message for
+ *  the cell at (row, col). */
+function cellResult(sheet: SheetData, row: number, col: number): { value: CellValue; type?: string; message?: string } {
+  const result = new SpreadsheetEngine().calculate(sheet);
+  const entry = result.errors.find((err) => err.cell.row === row && err.cell.col === col);
+  return { value: result.data[row][col], type: entry?.type, message: entry?.error };
+}
+
+/** A one-cell sheet holding `formula` at A1 (for formulas that need no other cells). */
+const soleFormula = (formula: string) => cellResult({ name: "S", data: [[{ v: formula }]] }, 0, 0);
+
+describe("#2397 removed handler guards — arity now enforced by the evaluator", () => {
+  it("too few args surfaces the evaluator's 'requires at least N' message (not the handler's)", () => {
+    const { value, type, message } = soleFormula("=ROUND(1)");
+    assert.equal(value, "#ERROR!");
+    assert.equal(type, "unknown");
+    assert.equal(message, "ROUND requires at least 2 arguments");
+  });
+
+  it("too many args surfaces the evaluator's 'accepts at most N' message", () => {
+    const { value, type, message } = soleFormula("=ROUND(1, 2, 3)");
+    assert.equal(value, "#ERROR!");
+    assert.equal(type, "unknown");
+    assert.equal(message, "ROUND accepts at most 2 arguments");
+  });
+
+  it("singular wording for a one-argument bound (ABS accepts at most 1 argument)", () => {
+    assert.equal(soleFormula("=ABS(1, 2)").message, "ABS accepts at most 1 argument");
+  });
+
+  it("singular wording for a one-argument minimum (UPPER requires at least 1 argument)", () => {
+    assert.equal(soleFormula("=UPPER()").message, "UPPER requires at least 1 argument");
+  });
+
+  it("a zero-arg function rejects any argument (PI accepts at most 0 arguments)", () => {
+    assert.equal(soleFormula("=PI(1)").message, "PI accepts at most 0 arguments");
+  });
+
+  // Financial handlers used to carry the ONLY validation (IPMT/PPMT once called
+  // pmtHandler/fvHandler directly). After #2394/#2442 they call the pure
+  // computeIpmt/computePpmt and are reached only through the evaluator, so the
+  // evaluator is now their sole arity gate.
+  it("financial: FV too few args is the evaluator error (handler no longer guards)", () => {
+    assert.equal(soleFormula("=FV(0.05, 10)").message, "FV requires at least 3 arguments");
+  });
+
+  it("financial: IPMT too many args is the evaluator error", () => {
+    assert.equal(soleFormula("=IPMT(0.05, 1, 10, 1000, 0, 0, 9)").message, "IPMT accepts at most 6 arguments");
+  });
+});
+
+describe("#2397 SUMIF / AVERAGEIF — arity fully expressed by registry [2,3], enforced by evaluator", () => {
+  // Formula in C1 so it never self-references the A/B ranges it reads.
+  const withData = (formula: string): SheetData => ({
+    name: "S",
+    data: [
+      [{ v: 1 }, { v: 10 }, { v: formula }],
+      [{ v: 2 }, { v: 20 }],
+      [{ v: 3 }, { v: 30 }],
+    ],
+  });
+
+  it("SUMIF with 1 arg is rejected with the consistent 'at least 2' message", () => {
+    const { value, message } = cellResult(withData("=SUMIF(A1:A3)"), 0, 2);
+    assert.equal(value, "#ERROR!");
+    assert.equal(message, "SUMIF requires at least 2 arguments");
+  });
+
+  it("SUMIF with 4 args is rejected with the consistent 'at most 3' message", () => {
+    const { value, message } = cellResult(withData('=SUMIF(A1:A3, ">0", B1:B3, C1)'), 0, 2);
+    assert.equal(value, "#ERROR!");
+    assert.equal(message, "SUMIF accepts at most 3 arguments");
+  });
+
+  it("AVERAGEIF with 4 args is rejected by the evaluator", () => {
+    assert.equal(cellResult(withData('=AVERAGEIF(A1:A3, ">0", B1:B3, C1)'), 0, 2).message, "AVERAGEIF accepts at most 3 arguments");
+  });
+
+  it("a valid 3-arg SUMIF still computes", () => {
+    assert.equal(cellResult(withData('=SUMIF(A1:A3, ">1", B1:B3)'), 0, 2).value, 50);
+  });
+});
+
+describe("#2397 kept guards — shapes the registry cannot express", () => {
+  // IFS is minArgs:2 with no maxArgs; the EVEN-count requirement is inexpressible
+  // by min/max, so the handler guard stays. This is the red-on-break target: if
+  // the guard is removed, a 3-arg IFS no longer reports this arity error.
+  it("IFS with an odd number of args is rejected by the kept handler guard", () => {
+    const sheet: SheetData = { name: "S", data: [[{ v: 5 }, { v: 0 }, { v: "=IFS(A1>0, 1, A1>5)" }]] };
+    const { value, type, message } = cellResult(sheet, 0, 2);
+    assert.equal(value, "#ERROR!");
+    assert.equal(type, "unknown");
+    assert.equal(message, "IFS requires an even number of arguments (condition-value pairs)");
+  });
+
+  it("a valid even-arg IFS still returns the matched value", () => {
+    const sheet: SheetData = { name: "S", data: [[{ v: 5 }, { v: '=IFS(A1>0, "yes")' }]] };
+    assert.equal(cellResult(sheet, 0, 1).value, "yes");
+  });
+
+  // IRR is minArgs:1/maxArgs:2 — its arg-count guard was removed — but the
+  // "at least one numeric value in the range" rule is not an arg count and is
+  // kept. D1:D3 is an empty range, so the kept guard fires.
+  it("IRR over an empty range is rejected by the kept empty-range guard", () => {
+    const sheet: SheetData = { name: "S", data: [[{ v: 1 }, { v: 2 }, { v: 3 }, { v: "=IRR(F1:F3)" }]] };
+    const { value, type, message } = cellResult(sheet, 0, 3);
+    assert.equal(value, "#ERROR!");
+    assert.equal(type, "unknown");
+    assert.equal(message, "IRR requires at least one value");
+  });
+});


### PR DESCRIPTION
## Summary

`evaluator.ts` already validates every function's arity against the registry `minArgs`/`maxArgs` **before** calling the handler, yet nearly every handler began with its own `if (args.length …) throw`. When the registry fully expresses the valid arity, that handler check is **unreachable dead code**, and its wording ("requires N") disagrees with the evaluator's ("requires at least N" / "accepts at most N"). This removes the dead guards; invalid arity now surfaces the evaluator's single consistent error.

**Rule:** remove the handler guard when the registry `minArgs`/`maxArgs` fully expresses the arity (exact `N` = min==max; a contiguous range `[min,max]`; or open `>= min`). Keep it only for a shape the registry **cannot** express (non-contiguous) — in this codebase that is **only IFS** (even count `>= 2`). Non-arity guards are left untouched.

### Remove / Keep table

| File | Removed (registry-expressed) | Kept |
|---|---|---|
| `logical.ts` | IF, AND, OR, NOT, IFERROR, IFNA, TRUE, FALSE | **IFS** even-count `< 2 || %2` |
| `mathematical.ts` | ROUND, ROUNDUP, ROUNDDOWN, FLOOR, CEILING, ABS, POWER, SQRT, MOD, INT, TRUNC, SIGN, PI, EXP, LN, LOG, LOG10 | — |
| `statistical.ts` | SUM, AVERAGE, MAX, MIN, COUNT, MEDIAN, MODE, STDEV, VAR, COUNTA, COUNTIF, **SUMIF**, **AVERAGEIF** | `values.length===0 → 0` result checks (untouched) |
| `text.ts` | CONCATENATE/CONCAT, LEFT, RIGHT, MID, LEN, UPPER, LOWER, PROPER, TRIM, SUBSTITUTE, REPLACE, FIND, SEARCH, TEXT, VALUE, EXACT | — |
| `lookup.ts` | VLOOKUP, HLOOKUP, MATCH, INDEX, XLOOKUP | `if (!bounds)` invalid-range-bounds |
| `date.ts` | NOW, TODAY, DATE, TIME, YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, DATEDIF | — |
| `financial.ts` | FV, PV, PMT, NPER, RATE, IPMT, PPMT, NPV, IRR (arg-count) | **IRR** `values.length===0` empty-range |

Behavior is identical for valid inputs. Invalid arity now yields the evaluator's `#ERROR!` (type `unknown`) with the consistent message. New `test/plugins/spreadsheet/engine/test_argCountValidation.ts` (14 cases) pins this and the kept guards; both kept guards were verified red-on-break.

## Items to Confirm / Review

1. **Financial internal-call safety (the #2394/#2442 precondition).** The issue warned that IPMT/PPMT once called `pmtHandler([...])`/`fvHandler([...])` **directly**, bypassing the evaluator, so their handler arg-count check was the only validation. Verified on this base (origin/main includes #2442): `ipmtHandler`/`ppmtHandler` now call the pure `computeIpmt`/`computePpmt` from `financial-math.ts` with already-parsed numeric args, and `grep` finds **no** remaining handler-to-handler calls in `functions/`. Every financial handler is reached only through the evaluator, which validates arity first — so removing their guards is safe. Please sanity-check this reasoning.

2. **SUMIF / AVERAGEIF — deliberate deviation from the issue text.** The issue lists "SUMIF/AVERAGEIF's `2 or 3`" as an *inexpressible* shape to keep. That is outdated: both are `minArgs: 2, maxArgs: 3` in the registry (verified via `git log -S` that `maxArgs: 3` has existed since the first spreadsheet commit), so the contiguous range `{2,3}` is fully expressed and the evaluator already rejects 1-arg and 4-arg calls — the handler check is unreachable dead code, identical in form to FIND/SEARCH (also `[2,3]`). Keeping SUMIF but removing FIND would be arbitrary, so I removed SUMIF/AVERAGEIF too and kept **only** IFS's even-count. The new tests assert SUMIF/AVERAGEIF still reject 1-arg and 4-arg (now via the evaluator). If you'd rather retain the (dead) SUMIF/AVERAGEIF guards to match the issue text verbatim, say so and I'll re-add them.

3. **IFS is the sole kept arity guard.** IFS is `minArgs: 2` with no `maxArgs`; the even-count rule is genuinely inexpressible, so its handler guard stays.

## User Prompt

Progress my unaddressed spreadsheet issues (#2319+). #2397 was gated on #2394 (financial pure-function extraction), which has now merged (PR #2442), so implement #2397 and open a PR (do not merge).

## Approach

Branched `refactor/2397-argcount-dedup` from `origin/main` (includes #2442, #2448, #2449, #2450). Plan committed at `plans/refactor-2397-argcount-dedup.md`. Edits are confined to deleting the top-of-handler arg-count guard lines — no function-body/logic changes — to minimize conflict with the concurrent PRs editing `logical.ts` (#2431) and `mathematical.ts` (#2432). Verified: `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, and the full spreadsheet engine test suite (594 engine + new cases) all pass. No package version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
