### PR TITLE
refactor(collection-plugin): split CollectionView.vue (#2298)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -956,7 +956,6 @@ import { useCollectionRendering } from "../useCollectionRendering";
 import {
   readCollectionViewMode,
   writeCollectionViewMode,
-  readCollectionSort,
   writeCollectionSort,
   readCollectionFlagFilters,
   writeCollectionFlagFilters,
@@ -968,14 +967,12 @@ import {
 } from "../collectionViewMode";
 import { collectionUi } from "../uiContext";
 import { useClickOutside } from "../composables/useClickOutside";
-import { relatedCollections, type RelatedCollection } from "../relatedCollections";
+import { useRelatedMenu } from "../composables/useRelatedMenu";
+import { useTableSort } from "../composables/useTableSort";
 import { activateRefLink, activatePathLink } from "../refLink";
 import {
   dateOf,
   isSortableField,
-  nextSortDirection,
-  sortItems,
-  sortValueOf,
   itemMatchesQuery,
   completionCoveredByFieldChip,
   snapshotEmptyEnums,
@@ -995,7 +992,6 @@ import {
   firstMissingRequiredField,
   rowFromItem,
   type Ymd,
-  type SortState,
   type SortValueDeps,
   type CollectionAction,
   type CollectionMutateAction,
@@ -1335,54 +1331,6 @@ function flagChipTitle(chip: FlagChip): string {
 }
 
 // ── List-table sort (single active column, header toggle) ─────────
-// Calendar / kanban keep their own ordering; only the table consumes
-// `sortedItems`. The active sort is a single SHARED per-collection
-// preference in localStorage — both the standalone page and embedded chat
-// cards read AND write it, so a sort set anywhere is consistent the next
-// time the collection is viewed. Resets only when a DIFFERENT collection
-// loads (the slug watch), so the sort survives a refresh / edit / remount.
-function storedSortFor(slug: string | undefined): SortState | null {
-  return (slug && readCollectionSort(slug)) || null;
-}
-const sortState = ref<SortState | null>(storedSortFor(activeSlug.value));
-// The column whose sort button is currently hovered (at most one). Hover
-// previews the NEXT click's state, so descending visibly fades back to the
-// light-grey "off" look — signalling the next click clears the sort.
-const hoveredSortKey = ref<string | null>(null);
-
-function sortDirectionFor(key: string): "asc" | "desc" | null {
-  return sortState.value?.field === key ? sortState.value.direction : null;
-}
-
-/** The direction whose visuals to render: on hover, preview the next
- *  click's state; otherwise show the column's actual state. */
-function effectiveSortDir(key: string): "asc" | "desc" | null {
-  const current = sortDirectionFor(key);
-  return hoveredSortKey.value === key ? nextSortDirection(current) : current;
-}
-
-/** Cycle a column none → asc → desc → none; activating one clears the rest. */
-function cycleSort(key: string): void {
-  const next = nextSortDirection(sortDirectionFor(key));
-  sortState.value = next ? { field: key, direction: next } : null;
-}
-
-function sortIconName(key: string): string {
-  return effectiveSortDir(key) === "desc" ? "arrow_downward" : "arrow_upward";
-}
-
-// Dark grey while a direction is active; light grey for the "off" state —
-// so hovering a descending column previews the cleared look.
-function sortButtonClass(key: string): string {
-  return effectiveSortDir(key) ? "text-slate-600" : "text-slate-300";
-}
-
-/** ARIA `aria-sort` token for a column's header cell. */
-function sortAriaValue(key: string): "ascending" | "descending" | "none" {
-  const dir = sortDirectionFor(key);
-  return dir === "asc" ? "ascending" : dir === "desc" ? "descending" : "none";
-}
-
 // Row readers the pure `sortValueOf` can't get from the raw cell: toggle /
 // flag projections, the derived-formula evaluator, the derived-record
 // enrichment, and ref display resolution — all backed by the rendering
@@ -1395,11 +1343,24 @@ const sortValueDeps: SortValueDeps = {
   resolveRefDisplay: refDisplay,
 };
 
-const sortedItems = computed<CollectionItem[]>(() => {
-  const state = sortState.value;
-  const field = state ? collection.value?.schema.fields[state.field] : undefined;
-  if (!state || !field) return tableFilteredItems.value;
-  return sortItems(tableFilteredItems.value, state.direction, (item) => sortValueOf(field, state.field, item, sortValueDeps));
+// Sort state + header display, extracted to a composable. Calendar / kanban keep
+// their own ordering; only the table consumes `sortedItems`. The shared
+// per-collection localStorage sort is read here and reset on collection switch
+// (below); the write lives in the persist watch.
+const {
+  sortState,
+  hoveredSortKey,
+  sortedItems,
+  cycleSort,
+  sortIconName,
+  sortButtonClass,
+  sortAriaValue,
+  resetForSlug: resetSortForSlug,
+} = useTableSort({
+  collection,
+  tableFilteredItems,
+  activeSlug,
+  sortValueDeps,
 });
 
 // ────────────────────────────────────────────────────────────────
@@ -1674,58 +1635,20 @@ function closeChat(): void {
 // component's lifetime and (re)built lazily on the menu's first open, so a
 // view open that never touches the pulldown never pays for the ontology
 // scan.
-const { open: relatedMenuOpen, menuRef: relatedMenuRef } = useClickOutside();
-const relatedLoading = ref<boolean>(false);
-/** Derived neighbors for `relatedFetchedSlug` (null until first fetched). */
-const relatedList = ref<RelatedCollection[] | null>(null);
-/** Slug the cached `relatedList` was built for — a mismatch on open forces
- *  a re-fetch (e.g. after navigating to a different collection). */
-const relatedFetchedSlug = ref<string | null>(null);
-
-const showRelatedMenu = computed<boolean>(() => Boolean(collection.value) && !embedded.value && cui.fetchOntology !== undefined);
-const relatedItems = computed<RelatedCollection[]>(() => relatedList.value ?? []);
-
-function relatedDirectionIcon(direction: RelatedCollection["direction"]): string {
-  if (direction === "out") return "arrow_outward";
-  if (direction === "in") return "arrow_back";
-  return "sync_alt";
-}
-
-function relatedDirectionLabel(direction: RelatedCollection["direction"]): string {
-  if (direction === "out") return t("collectionsView.relatedOut");
-  if (direction === "in") return t("collectionsView.relatedIn");
-  return t("collectionsView.relatedBoth");
-}
-
-/** Fetch the ontology and derive this slug's neighbors. Fail-soft: a
- *  non-ok result (the `apiGet` wrapper already caught the network/HTTP
- *  error) leaves an empty list, which the panel shows as its empty row.
- *
- *  Sets `relatedFetchedSlug` synchronously (before the await) so a rapid
- *  re-open can't kick a duplicate fetch, and DROPS a stale response whose
- *  slug no longer matches the active collection — otherwise a slower fetch
- *  for a since-abandoned slug, resolving after a fast switch, would apply
- *  the wrong collection's neighbors (Codex / CodeRabbit on PR #2251). */
-async function loadRelated(slug: string): Promise<void> {
-  relatedFetchedSlug.value = slug;
-  relatedLoading.value = true;
-  const result = await cui.fetchOntology?.();
-  if (collection.value?.slug !== slug) return;
-  relatedLoading.value = false;
-  relatedList.value = result?.ok ? relatedCollections(result.data.entries, slug) : [];
-}
-
-function toggleRelatedMenu(): void {
-  relatedMenuOpen.value = !relatedMenuOpen.value;
-  const slug = collection.value?.slug;
-  if (relatedMenuOpen.value && slug && relatedFetchedSlug.value !== slug) void loadRelated(slug);
-}
-
-/** Hop to a related collection's detail page (same nav as the index cards). */
-function gotoRelated(slug: string): void {
-  relatedMenuOpen.value = false;
-  cui.gotoDetail("collection", slug);
-}
+// Reactive shell in the composable (open state, lazy per-slug ontology fetch,
+// direction glyph/label); the reset on collection switch is wired below.
+const {
+  relatedMenuOpen,
+  relatedMenuRef,
+  relatedLoading,
+  showRelatedMenu,
+  relatedItems,
+  toggleRelatedMenu,
+  gotoRelated,
+  relatedDirectionIcon,
+  relatedDirectionLabel,
+  resetForSlugChange: resetRelatedMenu,
+} = useRelatedMenu({ collection, embedded, cui, t });
 
 /** Build the chat seed text for the current view.
  *
@@ -2674,17 +2597,12 @@ watch(
       addMenuOpen.value = false;
       filterMenuOpen.value = false;
       // Drop the previous collection's cached neighbors so the next open
-      // re-derives them for the new slug. Clearing `relatedLoading` too so a
-      // just-abandoned in-flight fetch (dropped by loadRelated's stale guard)
-      // can't strand the spinner.
-      relatedMenuOpen.value = false;
-      relatedList.value = null;
-      relatedFetchedSlug.value = null;
-      relatedLoading.value = false;
+      // re-derives them for the new slug (also clears any in-flight spinner).
+      resetRelatedMenu();
       // A sort belongs to a collection's own schema, so don't carry it across —
       // restore the new collection's stored (shared) sort instead. Same for
       // the flag filter chips.
-      sortState.value = storedSortFor(slug);
+      resetSortForSlug(slug);
       flagFilters.value = storedFlagFiltersFor(slug);
     }
     if (slug) {

--- a/packages/plugins/collection-plugin/src/vue/composables/useRelatedMenu.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useRelatedMenu.ts
@@ -1,0 +1,108 @@
+// Related-collections pulldown: the standalone header control that hops to a
+// collection this one links to (its refs) or that links back. Offered only when
+// the host exposes `fetchOntology`; the neighbor list is derived lazily on the
+// menu's first open (the ontology scan is expensive and most view opens never
+// touch it) and cached per slug for the component's lifetime.
+//
+// The reactive shell for the pulldown, extracted from CollectionView so the
+// component body stays an orchestrator. The pure neighbor derivation lives in
+// `../relatedCollections`; the direction→glyph/key mapping in
+// `../relatedMenuDisplay`.
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import type { CollectionDetail } from "@mulmoclaude/core/collection";
+import { useClickOutside } from "./useClickOutside";
+import { relatedCollections, type RelatedCollection } from "../relatedCollections";
+import { relatedDirectionIcon, relatedDirectionLabelKey } from "../relatedMenuDisplay";
+import type { CollectionUi } from "../uiContext";
+import type { useCollectionI18n } from "../lang";
+
+type Translate = ReturnType<typeof useCollectionI18n>["t"];
+
+interface UseRelatedMenuParams {
+  collection: Ref<CollectionDetail | null>;
+  embedded: Readonly<Ref<boolean>>;
+  cui: CollectionUi;
+  t: Translate;
+}
+
+export interface UseRelatedMenu {
+  relatedMenuOpen: Ref<boolean>;
+  relatedMenuRef: Ref<HTMLElement | null>;
+  relatedLoading: Ref<boolean>;
+  showRelatedMenu: ComputedRef<boolean>;
+  relatedItems: ComputedRef<RelatedCollection[]>;
+  toggleRelatedMenu: () => void;
+  gotoRelated: (slug: string) => void;
+  relatedDirectionIcon: (direction: RelatedCollection["direction"]) => string;
+  relatedDirectionLabel: (direction: RelatedCollection["direction"]) => string;
+  /** Drop the cached neighbors + close state when switching collections, so the
+   *  next open re-derives for the new slug and a just-abandoned in-flight fetch
+   *  can't strand the spinner. */
+  resetForSlugChange: () => void;
+}
+
+export function useRelatedMenu({ collection, embedded, cui, t }: UseRelatedMenuParams): UseRelatedMenu {
+  const { open: relatedMenuOpen, menuRef: relatedMenuRef } = useClickOutside();
+  const relatedLoading = ref<boolean>(false);
+  /** Derived neighbors for `relatedFetchedSlug` (null until first fetched). */
+  const relatedList = ref<RelatedCollection[] | null>(null);
+  /** Slug the cached `relatedList` was built for — a mismatch on open forces a
+   *  re-fetch (e.g. after navigating to a different collection). */
+  const relatedFetchedSlug = ref<string | null>(null);
+
+  const showRelatedMenu = computed<boolean>(() => Boolean(collection.value) && !embedded.value && cui.fetchOntology !== undefined);
+  const relatedItems = computed<RelatedCollection[]>(() => relatedList.value ?? []);
+
+  const relatedDirectionLabel = (direction: RelatedCollection["direction"]): string => t(relatedDirectionLabelKey(direction));
+
+  /** Fetch the ontology and derive this slug's neighbors. Fail-soft: a non-ok
+   *  result (the `apiGet` wrapper already caught the network/HTTP error) leaves
+   *  an empty list, which the panel shows as its empty row.
+   *
+   *  Sets `relatedFetchedSlug` synchronously (before the await) so a rapid
+   *  re-open can't kick a duplicate fetch, and DROPS a stale response whose slug
+   *  no longer matches the active collection — otherwise a slower fetch for a
+   *  since-abandoned slug, resolving after a fast switch, would apply the wrong
+   *  collection's neighbors (Codex / CodeRabbit on PR #2251). */
+  async function loadRelated(slug: string): Promise<void> {
+    relatedFetchedSlug.value = slug;
+    relatedLoading.value = true;
+    const result = await cui.fetchOntology?.();
+    if (collection.value?.slug !== slug) return;
+    relatedLoading.value = false;
+    relatedList.value = result?.ok ? relatedCollections(result.data.entries, slug) : [];
+  }
+
+  function toggleRelatedMenu(): void {
+    relatedMenuOpen.value = !relatedMenuOpen.value;
+    const slug = collection.value?.slug;
+    if (relatedMenuOpen.value && slug && relatedFetchedSlug.value !== slug) void loadRelated(slug);
+  }
+
+  /** Hop to a related collection's detail page (same nav as the index cards). */
+  function gotoRelated(slug: string): void {
+    relatedMenuOpen.value = false;
+    cui.gotoDetail("collection", slug);
+  }
+
+  function resetForSlugChange(): void {
+    relatedMenuOpen.value = false;
+    relatedList.value = null;
+    relatedFetchedSlug.value = null;
+    relatedLoading.value = false;
+  }
+
+  return {
+    relatedMenuOpen,
+    relatedMenuRef,
+    relatedLoading,
+    showRelatedMenu,
+    relatedItems,
+    toggleRelatedMenu,
+    gotoRelated,
+    relatedDirectionIcon,
+    relatedDirectionLabel,
+    resetForSlugChange,
+  };
+}

--- a/packages/plugins/collection-plugin/src/vue/composables/useTableSort.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useTableSort.ts
@@ -1,0 +1,92 @@
+// List-table column sort: a single active column, toggled from its header
+// (none → asc → desc → none). Calendar / kanban keep their own ordering; only
+// the table consumes `sortedItems`. The active sort is a single SHARED
+// per-collection preference in localStorage — both the standalone page and
+// embedded chat cards read AND write it (the parent's persist watch owns the
+// write), so a sort set anywhere is consistent the next time the collection is
+// viewed. Resets only when a DIFFERENT collection loads (`resetForSlug`).
+//
+// The reactive shell, extracted from CollectionView; the value-comparison logic
+// lives in core (`sortItems` / `sortValueOf`) and the header display mapping in
+// `../tableSortDisplay`.
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import {
+  nextSortDirection,
+  sortItems,
+  sortValueOf,
+  type CollectionDetail,
+  type CollectionItem,
+  type SortState,
+  type SortValueDeps,
+} from "@mulmoclaude/core/collection";
+import { readCollectionSort } from "../collectionViewMode";
+import { previewSortDir, sortAriaTokenForDir, sortButtonClassForDir, sortIconNameForDir } from "../tableSortDisplay";
+
+interface UseTableSortParams {
+  collection: Ref<CollectionDetail | null>;
+  /** The already text/flag-filtered rows the table renders (sort is the last
+   *  transform in the chain). */
+  tableFilteredItems: Readonly<Ref<CollectionItem[]>>;
+  activeSlug: Readonly<Ref<string | undefined>>;
+  /** Row readers the pure `sortValueOf` can't get from the raw cell (toggle /
+   *  flag projections, derived-formula eval, ref display). Built by the parent
+   *  where those helpers are in scope. */
+  sortValueDeps: SortValueDeps;
+}
+
+export interface UseTableSort {
+  sortState: Ref<SortState | null>;
+  hoveredSortKey: Ref<string | null>;
+  sortedItems: ComputedRef<CollectionItem[]>;
+  cycleSort: (key: string) => void;
+  sortIconName: (key: string) => string;
+  sortButtonClass: (key: string) => string;
+  sortAriaValue: (key: string) => "ascending" | "descending" | "none";
+  /** Restore the given collection's stored (shared) sort — the switch-collection
+   *  reset; a sort belongs to a schema, so it's never carried across. */
+  resetForSlug: (slug: string | undefined) => void;
+}
+
+function storedSortFor(slug: string | undefined): SortState | null {
+  return (slug && readCollectionSort(slug)) || null;
+}
+
+export function useTableSort({ collection, tableFilteredItems, activeSlug, sortValueDeps }: UseTableSortParams): UseTableSort {
+  const sortState = ref<SortState | null>(storedSortFor(activeSlug.value));
+  // The column whose sort button is currently hovered (at most one). Hover
+  // previews the NEXT click's state, so descending visibly fades back to the
+  // light-grey "off" look — signalling the next click clears the sort.
+  const hoveredSortKey = ref<string | null>(null);
+
+  function sortDirectionFor(key: string): "asc" | "desc" | null {
+    return sortState.value?.field === key ? sortState.value.direction : null;
+  }
+
+  function effectiveSortDir(key: string): "asc" | "desc" | null {
+    return previewSortDir(sortDirectionFor(key), hoveredSortKey.value === key);
+  }
+
+  /** Cycle a column none → asc → desc → none; activating one clears the rest. */
+  function cycleSort(key: string): void {
+    const next = nextSortDirection(sortDirectionFor(key));
+    sortState.value = next ? { field: key, direction: next } : null;
+  }
+
+  const sortIconName = (key: string): string => sortIconNameForDir(effectiveSortDir(key));
+  const sortButtonClass = (key: string): string => sortButtonClassForDir(effectiveSortDir(key));
+  const sortAriaValue = (key: string): "ascending" | "descending" | "none" => sortAriaTokenForDir(sortDirectionFor(key));
+
+  const sortedItems = computed<CollectionItem[]>(() => {
+    const state = sortState.value;
+    const field = state ? collection.value?.schema.fields[state.field] : undefined;
+    if (!state || !field) return tableFilteredItems.value;
+    return sortItems(tableFilteredItems.value, state.direction, (item) => sortValueOf(field, state.field, item, sortValueDeps));
+  });
+
+  function resetForSlug(slug: string | undefined): void {
+    sortState.value = storedSortFor(slug);
+  }
+
+  return { sortState, hoveredSortKey, sortedItems, cycleSort, sortIconName, sortButtonClass, sortAriaValue, resetForSlug };
+}

--- a/packages/plugins/collection-plugin/src/vue/relatedMenuDisplay.ts
+++ b/packages/plugins/collection-plugin/src/vue/relatedMenuDisplay.ts
@@ -1,0 +1,23 @@
+// Pure presentation mapping for the related-collections pulldown: a neighbor's
+// navigation direction → the Material Icons glyph and the i18n label key shown
+// next to it. Split out of the component so the direction→glyph/key contract is
+// unit-testable and the composable stays a thin reactive shell.
+
+import type { RelatedCollection } from "./relatedCollections";
+
+type RelatedDirection = RelatedCollection["direction"];
+
+/** Direction arrow glyph: `out` points away (this collection refs the neighbor),
+ *  `in` points back (the neighbor refs this one), `both` is the two-way swap. */
+export function relatedDirectionIcon(direction: RelatedDirection): string {
+  if (direction === "out") return "arrow_outward";
+  if (direction === "in") return "arrow_back";
+  return "sync_alt";
+}
+
+/** i18n key for the direction's tooltip / aria-label. */
+export function relatedDirectionLabelKey(direction: RelatedDirection): string {
+  if (direction === "out") return "collectionsView.relatedOut";
+  if (direction === "in") return "collectionsView.relatedIn";
+  return "collectionsView.relatedBoth";
+}

--- a/packages/plugins/collection-plugin/src/vue/tableSortDisplay.ts
+++ b/packages/plugins/collection-plugin/src/vue/tableSortDisplay.ts
@@ -1,0 +1,39 @@
+// Pure presentation mappings for the list-table sort header: given a column's
+// current sort direction (and whether its button is hovered), what glyph /
+// button colour / aria-sort token to render. Split out of the component so the
+// hover-preview state machine and the a11y token are unit-testable.
+//
+// Deliberate asymmetry (pinned by tests): the ICON and the button COLOUR use the
+// hover-preview direction (so hovering a descending column visibly fades toward
+// the cleared "off" look, signalling the next click clears the sort), while the
+// ARIA token reflects the column's ACTUAL direction — assistive tech must report
+// the real state, never a hover preview.
+
+import { nextSortDirection } from "@mulmoclaude/core/collection";
+
+export type SortDir = "asc" | "desc" | null;
+
+/** The direction to render visuals for: on hover, preview the next click's
+ *  direction (none → asc → desc → none); otherwise the column's actual one. */
+export function previewSortDir(current: SortDir, isHovered: boolean): SortDir {
+  return isHovered ? nextSortDirection(current) : current;
+}
+
+/** Arrow glyph for a (preview) direction — descending points down, everything
+ *  else (ascending or off) points up. */
+export function sortIconNameForDir(dir: SortDir): string {
+  return dir === "desc" ? "arrow_downward" : "arrow_upward";
+}
+
+/** Header-button colour: dark while a direction is active, light for the "off"
+ *  state — so hovering a descending column previews the cleared look. */
+export function sortButtonClassForDir(dir: SortDir): string {
+  return dir ? "text-slate-600" : "text-slate-300";
+}
+
+/** `aria-sort` token for a column header cell. */
+export function sortAriaTokenForDir(dir: SortDir): "ascending" | "descending" | "none" {
+  if (dir === "asc") return "ascending";
+  if (dir === "desc") return "descending";
+  return "none";
+}

--- a/plans/refactor-2298-collectionview-split.md
+++ b/plans/refactor-2298-collectionview-split.md
@@ -1,0 +1,77 @@
+# refactor(collection-plugin): split CollectionView.vue (#2298)
+
+`packages/plugins/collection-plugin/src/vue/components/CollectionView.vue` is the
+largest SFC in the repo (2818 lines: template 941 / script 1875). The safe-layer
+PR (#2384, merged) already extracted the pure helpers and de-duplicated the
+click-outside menus into `composables/useClickOutside.ts`. This is the NEXT step:
+break stateful clusters out of the still-huge `<script setup>`.
+
+## DOM-safety strategy (the governing constraint)
+
+CollectionView has **51 `data-testid`s — the most of any SFC**, and #2298 flags
+concrete structural traps: `collection-image-field.spec.ts` depends on the exact
+`<thead><th>` hierarchy, and `collections-row-<id>` (6 specs) must stay on the
+root `<tr>`. Any template/DOM edit risks those.
+
+Therefore this PR extracts **composables only** — the `<template>` block is left
+**byte-for-byte identical**. Moving reactive state + logic out of `<script setup>`
+into `useXxx.ts` files changes zero rendered DOM, so every testid, every nesting
+level, and every e2e traversal is provably unchanged. Template → child-component
+extraction (which does touch DOM) is deferred to follow-up PRs where each subtree
+can get its own byte-equivalence review.
+
+Each composable is paired with a **pure, unit-tested display helper** so the move
+also lands real test coverage on the "silently wrong" presentation logic
+(a11y tokens, the hover-preview sort state machine, direction icons) that #2298
+lists as an untested gap.
+
+## Slices in THIS PR
+
+### Slice A — `useRelatedMenu` (related-collections pulldown)
+
+- New `src/vue/composables/useRelatedMenu.ts`: owns `relatedMenuOpen`/`relatedMenuRef`
+  (via `useClickOutside`), `relatedLoading`, `relatedList`, `relatedFetchedSlug`,
+  `showRelatedMenu`, `relatedItems`, `loadRelated`, `toggleRelatedMenu`,
+  `gotoRelated`, `relatedDirectionLabel`, and a `resetForSlugChange()` for the
+  `activeSlug` reset watch. Inputs (DI): `collection`, `embedded`, `cui`, `t`.
+- New pure `src/vue/relatedMenuDisplay.ts`: `relatedDirectionIcon(direction)` and
+  `relatedDirectionLabelKey(direction)` (direction → icon glyph / i18n key).
+- Component keeps the template unchanged; the reset watch calls
+  `resetForSlugChange()` instead of nulling the four refs by hand.
+- Test: `test/utils/collections/test_relatedMenuDisplay.ts` — all three directions
+  (out / in / both) for icon + label key.
+
+### Slice B — `useTableSort` (list-table column sort)
+
+- New `src/vue/composables/useTableSort.ts`: owns `sortState` (writable ref,
+  returned so the parent's persist watch keeps working), `hoveredSortKey`,
+  `sortDirectionFor`, `effectiveSortDir`, `cycleSort`, `sortIconName`,
+  `sortButtonClass`, `sortAriaValue`, `sortedItems`, and `resetForSlug(slug)`.
+  Inputs (DI): `collection`, `tableFilteredItems`, `activeSlug`, `sortValueDeps`.
+- New pure `src/vue/tableSortDisplay.ts`: `previewSortDir(current, isHovered)`,
+  `sortIconNameForDir(dir)`, `sortButtonClassForDir(dir)`, `sortAriaTokenForDir(dir)`.
+- Component keeps the template unchanged; the `activeSlug` reset watch calls
+  `resetForSlug(slug)`; the persist watch still reads the returned `sortState` ref
+  and calls `writeCollectionSort`.
+- Test: `test/utils/collections/test_tableSortDisplay.ts` — icon/class/aria tokens
+  for asc / desc / null, plus the hover-preview transitions
+  (none→asc, asc→desc, desc→none).
+
+Net: ~130 script lines leave the SFC into 2 composables + 2 pure files, template
+untouched. Reviewable diff, maximal DOM safety.
+
+## Deferred (follow-up PRs, tracked on #2298)
+
+Composables with heavier coupling or no clean pure rule, and every template →
+child-component split (each needs its own byte-equivalence pass):
+
+- `useViewMode`, `useCollectionActions`, `useFlagFilters`,
+  `useLiveCollectionRefresh`, `useRecordPanelState`, `useCollectionChat`
+- `CollectionHeader.vue`, `CollectionToolbar.vue`, `CollectionTable.vue` +
+  `CollectionCell.vue`, `CollectionChatModal.vue`, `CollectionRepairBanner.vue`
+
+## Verification
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`. Because
+the template is byte-identical, the collection mock e2e path is unaffected; the
+DOM the specs traverse is unchanged by construction. No version bumps.

--- a/test/utils/collections/test_relatedMenuDisplay.ts
+++ b/test/utils/collections/test_relatedMenuDisplay.ts
@@ -1,0 +1,25 @@
+// Unit tests for the pure related-collections direction mapping
+// (packages/plugins/collection-plugin/src/vue/relatedMenuDisplay.ts) — the
+// navigation-direction → Material Icons glyph and i18n label key shown next to
+// each neighbor in the related-collections pulldown.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { relatedDirectionIcon, relatedDirectionLabelKey } from "../../../packages/plugins/collection-plugin/src/vue/relatedMenuDisplay";
+
+describe("relatedDirectionIcon", () => {
+  it("maps each direction to its arrow glyph", () => {
+    assert.equal(relatedDirectionIcon("out"), "arrow_outward");
+    assert.equal(relatedDirectionIcon("in"), "arrow_back");
+    assert.equal(relatedDirectionIcon("both"), "sync_alt");
+  });
+});
+
+describe("relatedDirectionLabelKey", () => {
+  it("maps each direction to its i18n label key", () => {
+    assert.equal(relatedDirectionLabelKey("out"), "collectionsView.relatedOut");
+    assert.equal(relatedDirectionLabelKey("in"), "collectionsView.relatedIn");
+    assert.equal(relatedDirectionLabelKey("both"), "collectionsView.relatedBoth");
+  });
+});

--- a/test/utils/collections/test_tableSortDisplay.ts
+++ b/test/utils/collections/test_tableSortDisplay.ts
@@ -1,0 +1,78 @@
+// Unit tests for the pure list-table sort header display mappings
+// (packages/plugins/collection-plugin/src/vue/tableSortDisplay.ts) — the
+// icon glyph, button colour, aria-sort token, and hover-preview state machine
+// backing the sortable column headers. Pinned here so the component (and its
+// composable) stay thin reactive shells.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  previewSortDir,
+  sortIconNameForDir,
+  sortButtonClassForDir,
+  sortAriaTokenForDir,
+  type SortDir,
+} from "../../../packages/plugins/collection-plugin/src/vue/tableSortDisplay";
+
+describe("previewSortDir", () => {
+  it("returns the actual direction when not hovered", () => {
+    for (const dir of [null, "asc", "desc"] as const) {
+      assert.equal(previewSortDir(dir, false), dir);
+    }
+  });
+
+  it("previews the NEXT click's direction when hovered (none → asc → desc → none)", () => {
+    assert.equal(previewSortDir(null, true), "asc");
+    assert.equal(previewSortDir("asc", true), "desc");
+    assert.equal(previewSortDir("desc", true), null);
+  });
+});
+
+describe("sortIconNameForDir", () => {
+  it("points down only for descending", () => {
+    assert.equal(sortIconNameForDir("desc"), "arrow_downward");
+  });
+
+  it("points up for ascending and off", () => {
+    assert.equal(sortIconNameForDir("asc"), "arrow_upward");
+    assert.equal(sortIconNameForDir(null), "arrow_upward");
+  });
+});
+
+describe("sortButtonClassForDir", () => {
+  it("is dark while a direction is active", () => {
+    assert.equal(sortButtonClassForDir("asc"), "text-slate-600");
+    assert.equal(sortButtonClassForDir("desc"), "text-slate-600");
+  });
+
+  it("is light for the off state", () => {
+    assert.equal(sortButtonClassForDir(null), "text-slate-300");
+  });
+});
+
+describe("sortAriaTokenForDir", () => {
+  it("maps each direction to its aria-sort token", () => {
+    const cases: [SortDir, string][] = [
+      ["asc", "ascending"],
+      ["desc", "descending"],
+      [null, "none"],
+    ];
+    for (const [dir, token] of cases) {
+      assert.equal(sortAriaTokenForDir(dir), token);
+    }
+  });
+});
+
+// Deliberate asymmetry (see tableSortDisplay.ts): the icon/colour follow the
+// hover PREVIEW, while aria-sort reflects the REAL direction. Assistive tech
+// must never be told a hover preview is the current sort state.
+describe("hover-preview vs aria asymmetry", () => {
+  it("hovering a descending column previews the cleared look but keeps aria on descending", () => {
+    const real: SortDir = "desc";
+    const preview = previewSortDir(real, true);
+    assert.equal(preview, null);
+    assert.equal(sortButtonClassForDir(preview), "text-slate-300", "icon/colour follow the preview");
+    assert.equal(sortAriaTokenForDir(real), "descending", "aria stays on the real state");
+  });
+});


### PR DESCRIPTION
## Summary

Next step of the **CollectionView.vue split (#2298)** after the merged safe-layer PR (#2384). CollectionView is the repo's largest SFC (**2818 lines**) and carries **51 `data-testid`s — the most of any component**, so #2298 explicitly flags severe e2e/DOM-structure risk.

This PR extracts two cohesive **stateful clusters into composables**, chosen precisely because that approach keeps the `<template>` **byte-for-byte identical** — the strongest possible DOM-safety guarantee. Every hunk in the diff lands inside `<script setup>` (line ≥956); the template (lines 1–941) is untouched.

**Before → after:** `CollectionView.vue` **2818 → 2727 lines** (−91). Two composables + two pure, unit-tested display helpers added.

**Slices done:**
- **`useRelatedMenu`** — related-collections pulldown: open state (`useClickOutside`), lazy per-slug ontology fetch with the stale-response drop guard (#2251), direction glyph/label, and a `resetForSlugChange()` for the collection-switch watch.
- **`useTableSort`** — list-table column sort: the shared per-collection `sortState` ref, hover-preview header display, `sortedItems`, and `resetForSlug()`. The parent's persist watch still reads the returned `sortState` ref; the reset watch calls `resetForSlug`/`resetForSlugChange`.
- **`relatedMenuDisplay.ts` / `tableSortDisplay.ts`** — the pure presentation mappings (direction→icon/i18n-key; sort icon/colour/aria token + the none→asc→desc→none hover-preview state machine), each with new unit tests.

**Deferred (follow-ups on #2298, each needs its own byte-equivalence pass):** `useViewMode`, `useCollectionActions`, `useFlagFilters`, `useLiveCollectionRefresh`, `useRecordPanelState`, `useCollectionChat`; and every template→child-component split (`CollectionHeader`, `CollectionToolbar`, `CollectionTable`+`CollectionCell`, `CollectionChatModal`, `CollectionRepairBanner`). Rationale in `plans/refactor-2298-collectionview-split.md`.

## Items to Confirm / Review

- **DOM / testid unchanged (primary risk):** the `<template>` block is not modified at all — `git diff` shows all hunks at line ≥956, and the `data-testid` count stays **51**. No `<table>/<thead>/<th>` hierarchy, `collections-row-<id>` `<tr>`, or menu subtree moved. Please sanity-check that no template edit slipped in.
- **Sort persist/reset wiring:** `sortState` is now owned by `useTableSort` and returned as a writable ref; the parent's persist watch (`writeCollectionSort`) and its dependency array reference that same ref, and the switch-collection reset calls `resetForSlug(slug)` (was `sortState.value = storedSortFor(slug)`). Behavior is intended to be identical — worth a second look.
- **Dependency direction:** the pure display helpers are **plugin-local** (view presentation: tailwind classes, Material Icons glyphs, aria tokens), not core. `readCollectionSort` stays sourced from the plugin's `collectionViewMode`; only value-comparison logic (`sortItems`/`sortValueOf`/`nextSortDirection`) comes from `@mulmoclaude/core`.
- **Deliberate asymmetry pinned by tests:** sort icon/colour follow the hover *preview* while `aria-sort` reflects the *real* direction — covered by `test_tableSortDisplay.ts`.

## User Prompt

Advance issue #2298 — split `CollectionView.vue` (the repo's largest SFC) beyond the merged safe layer (#2384) — by breaking it into smaller components/composables, and open a PR (do not merge). Prefer a single well-scoped, reviewable slice (or a few) that materially reduces the file over an all-at-once rewrite. Hard constraint: rendered DOM must stay behavior-identical — never rename/remove/reorder any of the 51 `data-testid`s or change DOM nesting the e2e traverses; a subtree may move into a child component only if the emitted DOM is byte-equivalent. Composition API only, `emit` not function props, `$t()` for text, functions <20 lines, no `any`/`as`, extract pure logic into its own file + tests, respect dependency direction. If no safe further split is possible, PR whatever safe slice is achievable or recommend closing.

## Approach

Composable-first, because it makes DOM byte-equivalence provable rather than merely reviewed: moving reactive state/logic out of `<script setup>` changes zero rendered output. Both clusters are cleanly bounded — `useRelatedMenu` had a single reset touch-point; `useTableSort`'s persist/reset stay in the parent watches reading the returned ref. Each composable is paired with a pure helper so the move also lands real test coverage on the "silently wrong" presentation logic (a11y tokens, hover-preview transitions, direction icons) that #2298 lists as an untested gap.

**Verification (all green):** `yarn format`, `yarn lint` (0 errors; 40 pre-existing warnings, none in changed files), `yarn typecheck` (full: vue + test tsconfig + all workspaces), `yarn build` (packages + vite). Unit tests: `test/utils/collections/` **288 pass / 0 fail** including 10 new; mutation-checked (breaking each pure helper turns the new tests red, then restored). No version bumps. Collection mock e2e was not run in this environment, but the template — and thus the DOM every spec traverses — is unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
