### PR TITLE
refactor(manageSkills): split View.vue into components/composables (#2301)

### DIFF
--- a/plans/refactor-2301-manageskills-split.md
+++ b/plans/refactor-2301-manageskills-split.md
@@ -1,0 +1,98 @@
+# refactor(#2301): manageSkills View.vue — component/composable split (step 2)
+
+Refs #2301. Follows the merged **safe-layer** PR (#2381), which extracted
+the pure helpers (`entryKey`, `catalogActionParams`, `groupEntriesByRepo`,
+`skillBadgeMeta`, `PRESET_SOURCE_META`, `repoLabel`) into `categories.ts`
+**with tests**. This step does the deferred follow-up: the stateful
+**composables**.
+
+## Why composables, not child components (this step)
+
+The issue calls a template→child-component split the primary prescription,
+but the safe-layer plan deferred it because of the **dynamic-testid
+hazard**:
+
+- `:data-testid="isSelectedPreset ? 'skill-unstar-btn' : 'skill-delete-btn'"`
+- `:data-testid="`skill-catalog-item-${entryKey(entry)}`"`
+
+A careless prop hand-off into a child component would silently flip a
+testid and break `e2e/tests/skills.spec.ts`. Composable extraction moves
+**only `<script setup>` logic** — the `<template>` is left **byte-for-byte
+unchanged**, so every `data-testid`, DOM nesting level, and `v-show`
+toggle the e2e traverses is provably identical. This is the safe way to
+advance the split before touching the DOM.
+
+## entryKey test coverage (prerequisite — already satisfied)
+
+The issue insists "entryKey のテストが先". `entryKey` already has thorough
+unit tests in `test/plugins/manageSkills/test_categories.ts` (external vs
+preset, slug-collision-across-repos, missing-repoId/skillFolder fallback),
+added by the safe-layer PR. No further entryKey work is required before
+relying on it. This step still touches the identity-bearing helpers only
+through the already-tested `categories.ts` surface.
+
+## Slices (each: build + unit tests green)
+
+1. **`useSkillMarkdown.ts`** (composable) — dedup the flagged duplication:
+   `renderMarkdownToSafeHtml(body)` + `useMermaidRenderer(ref, rendered)`
+   appears twice (`renderedBody`, `catalogRenderedBody`). One composable
+   `useSkillMarkdown(() => body)` → `{ markdownRef, renderedBody }`. Two
+   call sites collapse to one.
+
+2. **`categories.ts` `toggleInSet<T>` (pure) + tests** — `toggleSection`
+   and `toggleRepo` both "clone the Set, add-or-delete the key, replace
+   wholesale, persist". Extract the pure add-or-delete into
+   `toggleInSet(set, key): Set<T>`, test it (present→removed,
+   absent→added, immutability of the input), and use it in both handlers
+   (in the parent and in `useExternalRepos`). New pure logic ⇒ new tests.
+
+3. **`useSkillCatalog.ts`** (composable) — preset-catalog cluster:
+   `catalogPresets` / `catalogExternal` / `catalogError` / `selectedCatalog`
+   / `catalogDetail` / `catalogDetailLoading` / `catalogActioningKey`,
+   `loadCatalog`, `selectCatalogEntry`, `starCatalogEntry`,
+   `fetchCatalogDetail`, `selectedCatalogKey`, catalog markdown (via slice
+   1), plus `clearSelection` / `clearSelectionIfRepo` / `reconcileAfterDelete`
+   / `reset`. Depends outward on `refreshActiveList` +
+   `clearActiveSelection` callbacks (parent-owned, defined first ⇒ no
+   forward refs).
+
+4. **`useExternalRepos.ts`** (composable) — external-repo cluster:
+   `catalogRepos`, `externalGroups` (from injected `catalogExternal` +
+   owned `catalogRepos`), `repoCollapsed` / `isRepoOpen` / `toggleRepo`,
+   the add-repo modal state, `suggestions` / `selectedSuggestionUrl`,
+   `uninstallingRepoId` / `updatingRepoId`, `loadExternalRepos`,
+   `openAddRepo`, `selectSuggestion`, `installRepo`, `uninstallRepo`,
+   `updateRepo`, `resetModalState`. A leaf: it only calls **outward**
+   (`reloadCatalog`, `refreshActiveList`, `clearCatalogSelectionForRepo`);
+   nothing in the parent's selection core calls back into it.
+
+The **parent** keeps the active-skill domain (`skills`, `selectedName`,
+`detail`, edit/save/delete, `refreshActiveList`) plus section-collapse and
+badge wrappers, and orchestrates the two composables. Active-detail and
+catalog are genuinely bidirectionally coupled (starring adds to the active
+list; deleting an active skill re-syncs the catalog), so the active domain
+stays in the coordinator to avoid fragile forward-reference wiring.
+
+## Why the DOM stays identical
+
+- `<template>` is not edited at all (verified by `git diff` on the
+  template region == empty).
+- Composables return the exact same reactive names the template binds;
+  they are destructured at `<script setup>` top level so template
+  bindings resolve unchanged.
+- Pure helpers used in the template (`entryKey`, `repoLabel`) keep their
+  imports in the parent.
+
+## Constraints
+
+Composition API; `ref` over `reactive`; relative imports; `emit` (n/a —
+no new components); `$t()`/`t()` for text; no `v-html` change; functions
+< 20 lines; no `any`; no `as`. No `data-testid` touched. No version bumps.
+
+## Out of scope (still deferred)
+
+- [ ] template → child components (`SkillCatalogList.vue`,
+      `SkillRepoGroup.vue`, `SkillDetailPane.vue`, `AddRepoModal.vue`,
+      `SkillActiveList.vue`, `CatalogDetailPane.vue`) — the dynamic-testid
+      hazard; a separate PR that changes the DOM under e2e cover.
+- [ ] `useSkillDetail.ts` — kept in the parent this round (see above).

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -485,29 +485,26 @@ import { computed, onMounted, ref, shallowRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { ManageSkillsData, SkillSummary } from "./index";
-import { apiGet, apiPost, apiPut, apiDelete } from "../../utils/api";
+import { apiGet, apiPut, apiDelete } from "../../utils/api";
 import { handleExternalLinkClick } from "@mulmoclaude/markdown-utils/dom/externalLink";
-import { renderMarkdownToSafeHtml } from "../../utils/markdown/renderMarkdown";
-import { useMermaidRenderer } from "../../utils/markdown/useMermaid";
 import { pluginEndpoints } from "../api";
 import { buildRouteUrl } from "../meta-types";
 import type { SkillsEndpoints } from "./definition";
 import {
   loadCollapsedSections,
   persistCollapsedSections,
-  loadRepoCollapsed,
-  persistRepoCollapsed,
   pickInitialSelection,
   entryKey,
-  catalogActionParams,
-  groupEntriesByRepo,
   repoLabel,
+  toggleInSet,
   skillBadgeMeta,
   PRESET_SOURCE_META,
   type SkillSectionKey,
-  type CatalogSource,
 } from "./categories";
 import { isPresetActivation } from "./presetDetection";
+import { useSkillMarkdown } from "./useSkillMarkdown";
+import { useSkillCatalog } from "./useSkillCatalog";
+import { useExternalRepos } from "./useExternalRepos";
 
 const { t } = useI18n();
 
@@ -544,12 +541,7 @@ function isSectionOpen(key: SkillSectionKey): boolean {
 }
 
 function toggleSection(key: SkillSectionKey): void {
-  const next = new Set(collapsedSections.value);
-  if (next.has(key)) {
-    next.delete(key);
-  } else {
-    next.add(key);
-  }
+  const next = toggleInSet(collapsedSections.value, key);
   collapsedSections.value = next;
   persistCollapsedSections(next);
 }
@@ -566,10 +558,7 @@ const editBody = ref("");
 
 const selected = computed(() => skills.value.find((skill) => skill.name === selectedName.value) ?? null);
 
-const renderedBody = computed(() => renderMarkdownToSafeHtml(detail.value?.body));
-
-const skillMarkdownRef = ref<HTMLElement | null>(null);
-useMermaidRenderer(skillMarkdownRef, renderedBody);
+const { markdownRef: skillMarkdownRef, renderedBody } = useSkillMarkdown(() => detail.value?.body);
 
 // Edit/Delete follows the backend writer contract (writer.ts rejects
 // only source === "user"), NOT the mc- name heuristic. Under #1335
@@ -584,115 +573,78 @@ const listError = ref<string | null>(null);
 
 const endpoints = pluginEndpoints<SkillsEndpoints>("skills");
 
-// Catalog state (#1335 PR-B). Loaded on mount + after a successful
-// star so the row updates from "★ Star" → "★ Starred".
-// `catalogActioningKey` (declared below) disables the button
-// mid-request to prevent double-clicks across Star / Run once.
-interface CatalogEntry {
-  slug: string;
-  name: string;
-  description: string;
-  source: CatalogSource;
-  alreadyActive: boolean;
-  // External entries only — identify the source repo + skill folder
-  // so star / preview / run-once can address them (slug alone is the
-  // derived activeId, not enough to locate the catalog copy).
-  repoId?: string;
-  skillFolder?: string;
-  repoUrl?: string;
-}
-interface CatalogDetail {
-  slug: string;
-  source: CatalogSource;
-  description: string;
-  body: string;
-}
-interface ExternalRepo {
-  repoId: string;
-  url: string;
-  subpath?: string;
-  sha: string;
-  installedAt: string;
-}
-interface ExternalSuggestion {
-  url: string;
-  subpath?: string;
-  displayName: string;
-  description: string;
-  license?: string;
-}
-const catalogPresets = ref<CatalogEntry[]>([]);
-const catalogExternal = ref<CatalogEntry[]>([]);
-const catalogRepos = ref<ExternalRepo[]>([]);
-const catalogError = ref<string | null>(null);
-
-// True when the selected active skill has a matching entry in the
-// preset catalog — meaning a "delete" from `.claude/skills/<slug>/`
-// is recoverable, because the launcher re-syncs the catalog copy
-// under `data/skills/catalog/preset/<slug>/` on every boot
-// (see server/workspace/skills-preset.ts). We expose this case as
-// "Unstar" with a non-destructive confirm message; the underlying
-// DELETE endpoint is identical.
-//
-// Catalog membership (not the `mc-` slug prefix) is the
-// authoritative signal: the writer pipeline does not reserve the
-// `mc-` namespace, so a hand-rolled project skill named `mc-foo`
-// without a catalog entry must still surface the destructive Delete
-// copy. See isPresetActivation tests in test/plugins/manageSkills/.
-const isSelectedPreset = computed(() => isPresetActivation(detail.value?.name, catalogPresets.value));
-// Per-repo collapse set (repoId ∈ set ⇒ collapsed). shallowRef: the
-// Set is replaced wholesale on toggle.
-const repoCollapsed = shallowRef<Set<string>>(loadRepoCollapsed());
-// Add-repo modal state.
-const addRepoOpen = ref(false);
-const addRepoUrl = ref("");
-const addRepoSubpath = ref("");
-const addRepoError = ref<string | null>(null);
-const addRepoBusy = ref(false);
-const suggestions = ref<ExternalSuggestion[]>([]);
-// Which suggestion the user picked: drives the form prefill + the
-// "expanded description" / highlight. Selecting never installs —
-// install stays explicit (Install button / Enter in the URL field).
-const selectedSuggestionUrl = ref<string | null>(null);
-const uninstallingRepoId = ref<string | null>(null);
-const updatingRepoId = ref<string | null>(null);
-// Single in-flight gate covers Star / Run once on the selected
-// entry so a slow request doesn't let the user fire a second
-// action mid-flight.
-const catalogActioningKey = ref<string | null>(null);
-// Right-pane selection for a catalog entry (mutually exclusive
-// with `selectedName` — picking one clears the other).
-const selectedCatalog = ref<CatalogEntry | null>(null);
-const catalogDetail = ref<CatalogDetail | null>(null);
-const catalogDetailLoading = ref(false);
-
-const catalogRenderedBody = computed(() => renderMarkdownToSafeHtml(catalogDetail.value?.body));
-
-const catalogMarkdownRef = ref<HTMLElement | null>(null);
-useMermaidRenderer(catalogMarkdownRef, catalogRenderedBody);
-
-// External catalog entries grouped under their repo, in the repo
-// order returned by `/external/repos`. Repos with zero discoverable
-// entries still render (header + empty state) so an install that
-// found nothing is visible rather than silently absent.
-const externalGroups = computed(() => groupEntriesByRepo(catalogExternal.value, catalogRepos.value));
-
-function isRepoOpen(repoId: string): boolean {
-  return !repoCollapsed.value.has(repoId);
-}
-
-function toggleRepo(repoId: string): void {
-  const next = new Set(repoCollapsed.value);
-  if (next.has(repoId)) {
-    next.delete(repoId);
-  } else {
-    next.add(repoId);
+async function refreshActiveList(): Promise<void> {
+  // Mirrors the onMounted fetch so the left-column list reflects a
+  // newly-starred skill without waiting for the next manageSkills tool
+  // result. Errors here are non-fatal — the catalog state is the source
+  // of truth for the "Starred" badge.
+  const response = await apiGet<{ skills: SkillSummary[] }>(endpoints.list.url);
+  if (response.ok && Array.isArray(response.data.skills)) {
+    skills.value = response.data.skills;
   }
-  repoCollapsed.value = next;
-  persistRepoCollapsed(next);
 }
 
-const selectedCatalogKey = computed(() => (selectedCatalog.value ? entryKey(selectedCatalog.value) : null));
+// Active and catalog selections are mutually exclusive — selecting a
+// catalog row clears the active selection (and vice versa) so the right
+// pane has a single source of truth.
+function clearActiveSelection(): void {
+  selectedName.value = null;
+}
+
+// Preset-catalog cluster (#1335 PR-B): browse / select / ★ Star / preview.
+const catalog = useSkillCatalog({ refreshActiveList, clearActiveSelection });
+const {
+  catalogPresets,
+  catalogExternal,
+  catalogError,
+  selectedCatalog,
+  catalogDetail,
+  catalogDetailLoading,
+  catalogActioningKey,
+  selectedCatalogKey,
+  catalogRenderedBody,
+  catalogMarkdownRef,
+  loadCatalog,
+  selectCatalogEntry,
+  starCatalogEntry,
+} = catalog;
+
+// True when the selected active skill has a matching entry in the preset
+// catalog — meaning a "delete" from `.claude/skills/<slug>/` is
+// recoverable (the launcher re-syncs the catalog copy on every boot). We
+// expose this case as "Unstar" with a non-destructive confirm; the DELETE
+// endpoint is identical. Catalog membership (not the `mc-` slug prefix) is
+// the authoritative signal — see isPresetActivation tests.
+const isSelectedPreset = computed(() => isPresetActivation(detail.value?.name, catalogPresets.value));
+
+// External-repo cluster (#1383 PR-C2): installed repos + add-repo modal.
+const repos = useExternalRepos({
+  catalogExternal,
+  catalogError,
+  reloadCatalog: loadCatalog,
+  refreshActiveList,
+  clearCatalogSelectionForRepo: catalog.clearSelectionIfRepo,
+});
+const {
+  externalGroups,
+  isRepoOpen,
+  toggleRepo,
+  addRepoOpen,
+  addRepoUrl,
+  addRepoSubpath,
+  addRepoError,
+  addRepoBusy,
+  suggestions,
+  selectedSuggestionUrl,
+  uninstallingRepoId,
+  updatingRepoId,
+  loadExternalRepos,
+  openAddRepo,
+  selectSuggestion,
+  installRepo,
+  uninstallRepo,
+  updateRepo,
+} = repos;
 
 // Visual key for the provenance badge on every active row + the
 // preset rows. Provenance is derived via categorizeSkill (NOT the raw
@@ -726,216 +678,22 @@ const presetSourceMeta = computed<SourceMeta>(() => ({
   title: t(PRESET_SOURCE_META.titleKey),
 }));
 
-// Reset the selection when the tool result is replaced (e.g. the
-// user opens a newer `manageSkills` invocation from the sidebar).
-// Lives after the catalog refs so source-order use-before-define
-// is satisfied — the closure runs at watch-fire time, not at
-// module-eval time, but the lint rule is structural.
+function selectActiveSkill(name: string): void {
+  catalog.clearSelection();
+  selectedName.value = name;
+}
+
+// Reset the selection when the tool result is replaced (e.g. the user
+// opens a newer `manageSkills` invocation from the sidebar).
 watch(
   () => props.selectedResult?.uuid,
   () => {
     skills.value = props.selectedResult?.data?.skills ?? [];
     selectedName.value = pickInitialSelection(activeSkills.value, collapsedSections.value);
-    selectedCatalog.value = null;
-    catalogDetail.value = null;
-    catalogDetailLoading.value = false;
-    catalogActioningKey.value = null;
-    catalogError.value = null;
-    addRepoOpen.value = false;
-    addRepoError.value = null;
-    selectedSuggestionUrl.value = null;
-    uninstallingRepoId.value = null;
-    updatingRepoId.value = null;
+    catalog.reset();
+    repos.resetModalState();
   },
 );
-
-async function loadCatalog(): Promise<void> {
-  const response = await apiGet<{ entries: CatalogEntry[] }>(endpoints.catalogList.url);
-  if (!response.ok) {
-    catalogError.value = t("pluginManageSkills.errCatalogListFailed", { error: response.error });
-    return;
-  }
-  catalogError.value = null;
-  if (Array.isArray(response.data.entries)) {
-    catalogPresets.value = response.data.entries.filter((entry) => entry.source === "preset");
-    catalogExternal.value = response.data.entries.filter((entry) => entry.source === "external");
-  }
-}
-
-async function loadExternalRepos(): Promise<void> {
-  const response = await apiGet<{ repos: ExternalRepo[] }>(endpoints.externalReposList.url);
-  if (!response.ok) {
-    catalogError.value = t("pluginManageSkills.errCatalogRepoListFailed", { error: response.error });
-    return;
-  }
-  if (Array.isArray(response.data.repos)) catalogRepos.value = response.data.repos;
-}
-
-async function loadSuggestions(): Promise<void> {
-  const response = await apiGet<{ suggestions: ExternalSuggestion[] }>(endpoints.externalSuggestions.url);
-  if (response.ok && Array.isArray(response.data.suggestions)) suggestions.value = response.data.suggestions;
-}
-
-function openAddRepo(): void {
-  addRepoUrl.value = "";
-  addRepoSubpath.value = "";
-  addRepoError.value = null;
-  selectedSuggestionUrl.value = null;
-  addRepoOpen.value = true;
-  if (suggestions.value.length === 0) void loadSuggestions();
-}
-
-// Pick a suggestion → prefill the form so the user can review and
-// then press Install. Deliberately does NOT install (avoids the
-// accidental one-click install footgun).
-function selectSuggestion(suggestion: ExternalSuggestion): void {
-  addRepoUrl.value = suggestion.url;
-  addRepoSubpath.value = suggestion.subpath ?? "";
-  addRepoError.value = null;
-  selectedSuggestionUrl.value = suggestion.url;
-}
-
-async function installRepo(url: string, subpath?: string): Promise<void> {
-  if (addRepoBusy.value) return;
-  const trimmedUrl = url.trim();
-  if (trimmedUrl.length === 0) {
-    addRepoError.value = t("pluginManageSkills.errCatalogRepoInvalidUrl");
-    return;
-  }
-  addRepoBusy.value = true;
-  addRepoError.value = null;
-  try {
-    const trimmedSubpath = subpath?.trim();
-    const body: Record<string, string> = { url: trimmedUrl };
-    if (trimmedSubpath) body.subpath = trimmedSubpath;
-    const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
-    if (!response.ok) {
-      addRepoError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
-      return;
-    }
-    addRepoOpen.value = false;
-    await Promise.all([loadExternalRepos(), loadCatalog()]);
-  } finally {
-    addRepoBusy.value = false;
-  }
-}
-
-async function uninstallRepo(repoId: string): Promise<void> {
-  if (uninstallingRepoId.value !== null) return;
-  if (typeof window !== "undefined" && !window.confirm(t("pluginManageSkills.catalogUninstallConfirm"))) return;
-  uninstallingRepoId.value = repoId;
-  try {
-    const response = await apiDelete<{ uninstalled: true }>(buildRouteUrl(endpoints.externalReposRemove, { repoId }));
-    if (!response.ok) {
-      catalogError.value = t("pluginManageSkills.errCatalogRepoUninstallFailed", { error: response.error });
-      return;
-    }
-    catalogError.value = null;
-    if (selectedCatalog.value?.repoId === repoId) {
-      selectedCatalog.value = null;
-      catalogDetail.value = null;
-    }
-    // Starred copies survive uninstall (backend-guaranteed, C1) — pull
-    // the active list so any starred-from-this-repo rows stay visible.
-    await Promise.all([loadExternalRepos(), loadCatalog(), refreshActiveList()]);
-  } finally {
-    uninstallingRepoId.value = null;
-  }
-}
-
-// "Update" == re-install with the repo's recorded url/subpath. C1's
-// install path re-fetches upstream HEAD, wipes + re-copies the
-// catalog dir, and rewrites `.source.json` with the new SHA. Starred
-// copies under `.claude/skills/` are untouched (catalog-layer only).
-async function updateRepo(repo: ExternalRepo): Promise<void> {
-  if (updatingRepoId.value !== null) return;
-  updatingRepoId.value = repo.repoId;
-  // try/finally so the in-flight gate always clears even if the
-  // request throws — otherwise the button stays disabled forever
-  // (same hardening as the star handler, Codex review #1374).
-  try {
-    const body: Record<string, string> = { url: repo.url };
-    if (repo.subpath) body.subpath = repo.subpath;
-    const response = await apiPost<{ installed: true; repoId: string }>(endpoints.externalReposInstall.url, body);
-    if (!response.ok) {
-      catalogError.value = t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
-      return;
-    }
-    catalogError.value = null;
-    await Promise.all([loadExternalRepos(), loadCatalog()]);
-  } finally {
-    updatingRepoId.value = null;
-  }
-}
-
-async function refreshActiveList(): Promise<void> {
-  // Mirrors the onMounted fetch so the left-column list reflects the
-  // newly-starred skill without waiting for the next manageSkills
-  // tool result. Errors here are non-fatal — the catalog state is
-  // the source of truth for the "Starred" badge.
-  const response = await apiGet<{ skills: SkillSummary[] }>(endpoints.list.url);
-  if (response.ok && Array.isArray(response.data.skills)) {
-    skills.value = response.data.skills;
-  }
-}
-
-async function starCatalogEntry(entry: CatalogEntry): Promise<void> {
-  if (entry.alreadyActive) return;
-  catalogActioningKey.value = entryKey(entry);
-  const response = await apiPost<{ starred: true; slug: string }>(endpoints.catalogStar.url, catalogActionParams(entry));
-  catalogActioningKey.value = null;
-  if (!response.ok) {
-    catalogError.value = t("pluginManageSkills.errCatalogStarFailed", { error: response.error });
-    return;
-  }
-  catalogError.value = null;
-  // Refresh both lists so the row flips to "Starred" and the new
-  // active entry shows up in the left column.
-  await Promise.all([loadCatalog(), refreshActiveList()]);
-  // Reconcile the right-pane selection with the refreshed list so
-  // its `alreadyActive` flag reflects reality without forcing the
-  // user to re-click.
-  if (selectedCatalog.value && entryKey(selectedCatalog.value) === entryKey(entry)) {
-    const pool = entry.source === "external" ? catalogExternal.value : catalogPresets.value;
-    const updated = pool.find((candidate) => entryKey(candidate) === entryKey(entry));
-    if (updated) selectedCatalog.value = updated;
-  }
-}
-
-async function fetchCatalogDetail(entry: CatalogEntry): Promise<CatalogDetail | null> {
-  const response = await apiGet<{ detail: CatalogDetail }>(endpoints.catalogPreview.url, catalogActionParams(entry));
-  if (!response.ok) {
-    catalogError.value = t("pluginManageSkills.errCatalogPreviewFailed", { error: response.error });
-    return null;
-  }
-  catalogError.value = null;
-  return response.data.detail;
-}
-
-function selectActiveSkill(name: string): void {
-  // Active and catalog selections are mutually exclusive — picking
-  // one clears the other so the right pane has a single source of
-  // truth.
-  selectedCatalog.value = null;
-  catalogDetail.value = null;
-  selectedName.value = name;
-}
-
-async function selectCatalogEntry(entry: CatalogEntry): Promise<void> {
-  selectedName.value = null;
-  selectedCatalog.value = entry;
-  catalogDetail.value = null;
-  catalogDetailLoading.value = true;
-  const keyAtRequest = entryKey(entry);
-  const fetched = await fetchCatalogDetail(entry);
-  // Selection may have changed while the request was in flight —
-  // drop the response if so (same race-condition guard the active-
-  // skill detail watcher uses). Identity is the (repoId, skillFolder)
-  // composite for external entries, not the lossy slug.
-  if (!selectedCatalog.value || entryKey(selectedCatalog.value) !== keyAtRequest) return;
-  catalogDetailLoading.value = false;
-  if (fetched !== null) catalogDetail.value = fetched;
-}
 
 // Standalone mode: if no selectedResult was passed, fetch the skill
 // list from the API on mount so the view is populated.
@@ -1064,9 +822,6 @@ async function deleteSkill(): Promise<void> {
   // this call the badge + right-pane state would lag until the
   // next mount. (#1335 PR-B2 follow-up.)
   await loadCatalog();
-  if (selectedCatalog.value?.slug === name) {
-    const refreshed = catalogPresets.value.find((candidate) => candidate.slug === name);
-    if (refreshed) selectedCatalog.value = refreshed;
-  }
+  catalog.reconcileAfterDelete(name);
 }
 </script>

--- a/src/plugins/manageSkills/categories.ts
+++ b/src/plugins/manageSkills/categories.ts
@@ -79,6 +79,23 @@ export function persistCollapsedSections(state: ReadonlySet<SkillSectionKey>): v
   }
 }
 
+/**
+ * Toggle a key's membership in a set, returning a fresh set (the input
+ * is never mutated). Both sidebar collapse handlers — section-level and
+ * per-repo — clone the set, add-or-delete the key, then replace it
+ * wholesale so Vue sees a new reference; this centralises the add-or-
+ * delete so the two call sites can't drift.
+ */
+export function toggleInSet<T>(set: ReadonlySet<T>, key: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(key)) {
+    next.delete(key);
+  } else {
+    next.add(key);
+  }
+  return next;
+}
+
 // Per-external-repo collapse state (#1383 PR-C2). Distinct storage key
 // from the section-level state above: the section axis is a fixed
 // 2-value union (active/catalog), whereas repo ids are open-ended
@@ -170,6 +187,19 @@ export function catalogActionParams(entry: CatalogEntryIdentity): Record<string,
     return { source: "external", repoId: entry.repoId, skillFolder: entry.skillFolder };
   }
   return { source: entry.source, slug: entry.slug };
+}
+
+/**
+ * Request body for the external-repo install endpoint: the URL plus an
+ * optional (trimmed, non-empty) subpath. Centralised so the two callers —
+ * a fresh install and a repo "update" (re-install with the recorded
+ * url/subpath) — send an identical shape and can't drift.
+ */
+export function buildRepoInstallBody(url: string, subpath?: string): Record<string, string> {
+  const body: Record<string, string> = { url };
+  const trimmed = subpath?.trim();
+  if (trimmed) body.subpath = trimmed;
+  return body;
 }
 
 /**

--- a/src/plugins/manageSkills/useExternalRepos.ts
+++ b/src/plugins/manageSkills/useExternalRepos.ts
@@ -1,0 +1,266 @@
+// External-repo cluster for the /skills catalog (#1383 PR-C2). Owns the
+// installed-repo list, the per-repo collapse state, the add-repo modal,
+// and the install / uninstall / update mutations. Lifted out of View.vue
+// (#2301) as a leaf composable: it only calls OUTWARD (reload the catalog,
+// refresh the active list, clear a catalog selection whose repo was
+// removed) — nothing in the parent's selection core calls back in.
+//
+// The factory stays thin: it wires the refs and delegates every action to
+// a small module-level function that receives the state bundle.
+
+import { computed, ref, shallowRef, type ComputedRef, type Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { apiGet, apiPost, apiDelete } from "../../utils/api";
+import { pluginEndpoints } from "../api";
+import { buildRouteUrl } from "../meta-types";
+import type { SkillsEndpoints } from "./definition";
+import { loadRepoCollapsed, persistRepoCollapsed, groupEntriesByRepo, toggleInSet, buildRepoInstallBody } from "./categories";
+import type { CatalogEntry } from "./useSkillCatalog";
+
+type TranslateFn = ReturnType<typeof useI18n>["t"];
+
+export interface ExternalRepo {
+  repoId: string;
+  url: string;
+  subpath?: string;
+  sha: string;
+  installedAt: string;
+}
+
+export interface ExternalSuggestion {
+  url: string;
+  subpath?: string;
+  displayName: string;
+  description: string;
+  license?: string;
+}
+
+export interface ExternalReposDeps {
+  /** External catalog entries (owned by useSkillCatalog) — read for the
+   *  per-repo grouping. */
+  catalogExternal: Ref<CatalogEntry[]>;
+  /** Shared catalog error surface (owned by useSkillCatalog) — written on
+   *  uninstall / update failure so the error shows in the same place. */
+  catalogError: Ref<string | null>;
+  reloadCatalog: () => Promise<void>;
+  refreshActiveList: () => Promise<void>;
+  /** Drop the right-pane catalog selection when its source repo is
+   *  uninstalled. */
+  clearCatalogSelectionForRepo: (repoId: string) => void;
+}
+
+export interface ExternalReposGroup {
+  repo: ExternalRepo;
+  entries: CatalogEntry[];
+}
+
+interface ReposState {
+  t: TranslateFn;
+  endpoints: SkillsEndpoints;
+  deps: ExternalReposDeps;
+  catalogRepos: Ref<ExternalRepo[]>;
+  repoCollapsed: Ref<Set<string>>;
+  addRepoOpen: Ref<boolean>;
+  addRepoUrl: Ref<string>;
+  addRepoSubpath: Ref<string>;
+  addRepoError: Ref<string | null>;
+  addRepoBusy: Ref<boolean>;
+  suggestions: Ref<ExternalSuggestion[]>;
+  selectedSuggestionUrl: Ref<string | null>;
+  uninstallingRepoId: Ref<string | null>;
+  updatingRepoId: Ref<string | null>;
+}
+
+export interface ExternalRepos {
+  catalogRepos: Ref<ExternalRepo[]>;
+  externalGroups: ComputedRef<ExternalReposGroup[]>;
+  repoCollapsed: Ref<Set<string>>;
+  isRepoOpen: (repoId: string) => boolean;
+  toggleRepo: (repoId: string) => void;
+  addRepoOpen: Ref<boolean>;
+  addRepoUrl: Ref<string>;
+  addRepoSubpath: Ref<string>;
+  addRepoError: Ref<string | null>;
+  addRepoBusy: Ref<boolean>;
+  suggestions: Ref<ExternalSuggestion[]>;
+  selectedSuggestionUrl: Ref<string | null>;
+  uninstallingRepoId: Ref<string | null>;
+  updatingRepoId: Ref<string | null>;
+  loadExternalRepos: () => Promise<void>;
+  openAddRepo: () => void;
+  selectSuggestion: (suggestion: ExternalSuggestion) => void;
+  installRepo: (url: string, subpath?: string) => Promise<void>;
+  uninstallRepo: (repoId: string) => Promise<void>;
+  updateRepo: (repo: ExternalRepo) => Promise<void>;
+  resetModalState: () => void;
+}
+
+function isRepoOpen(state: ReposState, repoId: string): boolean {
+  return !state.repoCollapsed.value.has(repoId);
+}
+
+function toggleRepo(state: ReposState, repoId: string): void {
+  const next = toggleInSet(state.repoCollapsed.value, repoId);
+  state.repoCollapsed.value = next;
+  persistRepoCollapsed(next);
+}
+
+async function loadExternalRepos(state: ReposState): Promise<void> {
+  const response = await apiGet<{ repos: ExternalRepo[] }>(state.endpoints.externalReposList.url);
+  if (!response.ok) {
+    state.deps.catalogError.value = state.t("pluginManageSkills.errCatalogRepoListFailed", { error: response.error });
+    return;
+  }
+  if (Array.isArray(response.data.repos)) state.catalogRepos.value = response.data.repos;
+}
+
+async function loadSuggestions(state: ReposState): Promise<void> {
+  const response = await apiGet<{ suggestions: ExternalSuggestion[] }>(state.endpoints.externalSuggestions.url);
+  if (response.ok && Array.isArray(response.data.suggestions)) state.suggestions.value = response.data.suggestions;
+}
+
+function openAddRepo(state: ReposState): void {
+  state.addRepoUrl.value = "";
+  state.addRepoSubpath.value = "";
+  state.addRepoError.value = null;
+  state.selectedSuggestionUrl.value = null;
+  state.addRepoOpen.value = true;
+  if (state.suggestions.value.length === 0) void loadSuggestions(state);
+}
+
+// Prefill the form so the user can review then press Install. Deliberately
+// does NOT install (avoids the one-click install footgun).
+function selectSuggestion(state: ReposState, suggestion: ExternalSuggestion): void {
+  state.addRepoUrl.value = suggestion.url;
+  state.addRepoSubpath.value = suggestion.subpath ?? "";
+  state.addRepoError.value = null;
+  state.selectedSuggestionUrl.value = suggestion.url;
+}
+
+async function installRepo(state: ReposState, url: string, subpath?: string): Promise<void> {
+  if (state.addRepoBusy.value) return;
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.length === 0) {
+    state.addRepoError.value = state.t("pluginManageSkills.errCatalogRepoInvalidUrl");
+    return;
+  }
+  state.addRepoBusy.value = true;
+  state.addRepoError.value = null;
+  try {
+    const response = await apiPost<{ installed: true; repoId: string }>(state.endpoints.externalReposInstall.url, buildRepoInstallBody(trimmedUrl, subpath));
+    if (!response.ok) {
+      state.addRepoError.value = state.t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
+      return;
+    }
+    state.addRepoOpen.value = false;
+    await Promise.all([loadExternalRepos(state), state.deps.reloadCatalog()]);
+  } finally {
+    state.addRepoBusy.value = false;
+  }
+}
+
+async function uninstallRepo(state: ReposState, repoId: string): Promise<void> {
+  if (state.uninstallingRepoId.value !== null) return;
+  if (typeof window !== "undefined" && !window.confirm(state.t("pluginManageSkills.catalogUninstallConfirm"))) return;
+  state.uninstallingRepoId.value = repoId;
+  try {
+    const response = await apiDelete<{ uninstalled: true }>(buildRouteUrl(state.endpoints.externalReposRemove, { repoId }));
+    if (!response.ok) {
+      state.deps.catalogError.value = state.t("pluginManageSkills.errCatalogRepoUninstallFailed", { error: response.error });
+      return;
+    }
+    state.deps.catalogError.value = null;
+    state.deps.clearCatalogSelectionForRepo(repoId);
+    // Starred copies survive uninstall (backend-guaranteed, C1) — pull the
+    // active list so any starred-from-this-repo rows stay visible.
+    await Promise.all([loadExternalRepos(state), state.deps.reloadCatalog(), state.deps.refreshActiveList()]);
+  } finally {
+    state.uninstallingRepoId.value = null;
+  }
+}
+
+// "Update" == re-install with the repo's recorded url/subpath. The install
+// path re-fetches upstream HEAD, wipes + re-copies the catalog dir, and
+// rewrites `.source.json`. Starred copies under `.claude/skills/` are
+// untouched (catalog-layer only). try/finally so the in-flight gate always
+// clears even if the request throws.
+async function updateRepo(state: ReposState, repo: ExternalRepo): Promise<void> {
+  if (state.updatingRepoId.value !== null) return;
+  state.updatingRepoId.value = repo.repoId;
+  try {
+    const response = await apiPost<{ installed: true; repoId: string }>(state.endpoints.externalReposInstall.url, buildRepoInstallBody(repo.url, repo.subpath));
+    if (!response.ok) {
+      state.deps.catalogError.value = state.t("pluginManageSkills.errCatalogRepoInstallFailed", { error: response.error });
+      return;
+    }
+    state.deps.catalogError.value = null;
+    await Promise.all([loadExternalRepos(state), state.deps.reloadCatalog()]);
+  } finally {
+    state.updatingRepoId.value = null;
+  }
+}
+
+function resetModalState(state: ReposState): void {
+  state.addRepoOpen.value = false;
+  state.addRepoError.value = null;
+  state.selectedSuggestionUrl.value = null;
+  state.uninstallingRepoId.value = null;
+  state.updatingRepoId.value = null;
+}
+
+function createReposState(translate: TranslateFn, endpoints: SkillsEndpoints, deps: ExternalReposDeps): ReposState {
+  return {
+    t: translate,
+    endpoints,
+    deps,
+    catalogRepos: ref<ExternalRepo[]>([]),
+    // Per-repo collapse set (repoId ∈ set ⇒ collapsed). shallowRef: the Set
+    // is replaced wholesale on toggle, so the deep proxy ref() would build
+    // is wasted.
+    repoCollapsed: shallowRef<Set<string>>(loadRepoCollapsed()),
+    addRepoOpen: ref(false),
+    addRepoUrl: ref(""),
+    addRepoSubpath: ref(""),
+    addRepoError: ref<string | null>(null),
+    addRepoBusy: ref(false),
+    suggestions: ref<ExternalSuggestion[]>([]),
+    // Which suggestion the user picked: drives the form prefill + the
+    // highlight. Selecting never installs — install stays explicit.
+    selectedSuggestionUrl: ref<string | null>(null),
+    uninstallingRepoId: ref<string | null>(null),
+    updatingRepoId: ref<string | null>(null),
+  };
+}
+
+export function useExternalRepos(deps: ExternalReposDeps): ExternalRepos {
+  const { t } = useI18n();
+  const endpoints = pluginEndpoints<SkillsEndpoints>("skills");
+  const state = createReposState(t, endpoints, deps);
+  // External catalog entries grouped under their repo, in the repo order
+  // returned by `/external/repos`. Repos with zero discoverable entries
+  // still render so an install that found nothing is visible.
+  const externalGroups = computed(() => groupEntriesByRepo(deps.catalogExternal.value, state.catalogRepos.value));
+  return {
+    catalogRepos: state.catalogRepos,
+    externalGroups,
+    repoCollapsed: state.repoCollapsed,
+    isRepoOpen: (repoId) => isRepoOpen(state, repoId),
+    toggleRepo: (repoId) => toggleRepo(state, repoId),
+    addRepoOpen: state.addRepoOpen,
+    addRepoUrl: state.addRepoUrl,
+    addRepoSubpath: state.addRepoSubpath,
+    addRepoError: state.addRepoError,
+    addRepoBusy: state.addRepoBusy,
+    suggestions: state.suggestions,
+    selectedSuggestionUrl: state.selectedSuggestionUrl,
+    uninstallingRepoId: state.uninstallingRepoId,
+    updatingRepoId: state.updatingRepoId,
+    loadExternalRepos: () => loadExternalRepos(state),
+    openAddRepo: () => openAddRepo(state),
+    selectSuggestion: (suggestion) => selectSuggestion(state, suggestion),
+    installRepo: (url, subpath) => installRepo(state, url, subpath),
+    uninstallRepo: (repoId) => uninstallRepo(state, repoId),
+    updateRepo: (repo) => updateRepo(state, repo),
+    resetModalState: () => resetModalState(state),
+  };
+}

--- a/src/plugins/manageSkills/useSkillCatalog.ts
+++ b/src/plugins/manageSkills/useSkillCatalog.ts
@@ -1,0 +1,216 @@
+// Preset-catalog cluster for the /skills page (#1335 PR-B). Owns the
+// browsable catalog entries, the right-pane catalog selection + detail,
+// and the ★ Star action. Lifted out of View.vue (#2301) so the stateful
+// catalog logic lives in one cohesive unit; the parent orchestrates the
+// active-skill list and hands this composable two outward callbacks.
+//
+// The factory stays thin: it wires the refs and delegates every action to
+// a small module-level function that receives the state bundle. That keeps
+// each action independently small (and testable with a fake state).
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { apiGet, apiPost } from "../../utils/api";
+import { pluginEndpoints } from "../api";
+import type { SkillsEndpoints } from "./definition";
+import { entryKey, catalogActionParams, type CatalogSource } from "./categories";
+import { useSkillMarkdown } from "./useSkillMarkdown";
+
+type TranslateFn = ReturnType<typeof useI18n>["t"];
+
+export interface CatalogEntry {
+  slug: string;
+  name: string;
+  description: string;
+  source: CatalogSource;
+  alreadyActive: boolean;
+  // External entries only — identify the source repo + skill folder so
+  // star / preview / run-once can address them (slug alone is the derived
+  // activeId, not enough to locate the catalog copy).
+  repoId?: string;
+  skillFolder?: string;
+  repoUrl?: string;
+}
+
+export interface CatalogDetail {
+  slug: string;
+  source: CatalogSource;
+  description: string;
+  body: string;
+}
+
+export interface SkillCatalogDeps {
+  /** Re-pull the active skill list after a star so the new entry shows. */
+  refreshActiveList: () => Promise<void>;
+  /** Clear the active-skill selection (mutually exclusive with catalog). */
+  clearActiveSelection: () => void;
+}
+
+interface CatalogState {
+  t: TranslateFn;
+  endpoints: SkillsEndpoints;
+  deps: SkillCatalogDeps;
+  catalogPresets: Ref<CatalogEntry[]>;
+  catalogExternal: Ref<CatalogEntry[]>;
+  catalogError: Ref<string | null>;
+  selectedCatalog: Ref<CatalogEntry | null>;
+  catalogDetail: Ref<CatalogDetail | null>;
+  catalogDetailLoading: Ref<boolean>;
+  catalogActioningKey: Ref<string | null>;
+}
+
+export interface SkillCatalog {
+  catalogPresets: Ref<CatalogEntry[]>;
+  catalogExternal: Ref<CatalogEntry[]>;
+  catalogError: Ref<string | null>;
+  selectedCatalog: Ref<CatalogEntry | null>;
+  catalogDetail: Ref<CatalogDetail | null>;
+  catalogDetailLoading: Ref<boolean>;
+  catalogActioningKey: Ref<string | null>;
+  selectedCatalogKey: ComputedRef<string | null>;
+  catalogRenderedBody: ComputedRef<string>;
+  catalogMarkdownRef: Ref<HTMLElement | null>;
+  loadCatalog: () => Promise<void>;
+  selectCatalogEntry: (entry: CatalogEntry) => Promise<void>;
+  starCatalogEntry: (entry: CatalogEntry) => Promise<void>;
+  clearSelection: () => void;
+  clearSelectionIfRepo: (repoId: string) => void;
+  reconcileAfterDelete: (name: string) => void;
+  reset: () => void;
+}
+
+async function loadCatalog(state: CatalogState): Promise<void> {
+  const response = await apiGet<{ entries: CatalogEntry[] }>(state.endpoints.catalogList.url);
+  if (!response.ok) {
+    state.catalogError.value = state.t("pluginManageSkills.errCatalogListFailed", { error: response.error });
+    return;
+  }
+  state.catalogError.value = null;
+  if (Array.isArray(response.data.entries)) {
+    state.catalogPresets.value = response.data.entries.filter((entry) => entry.source === "preset");
+    state.catalogExternal.value = response.data.entries.filter((entry) => entry.source === "external");
+  }
+}
+
+async function fetchCatalogDetail(state: CatalogState, entry: CatalogEntry): Promise<CatalogDetail | null> {
+  const response = await apiGet<{ detail: CatalogDetail }>(state.endpoints.catalogPreview.url, catalogActionParams(entry));
+  if (!response.ok) {
+    state.catalogError.value = state.t("pluginManageSkills.errCatalogPreviewFailed", { error: response.error });
+    return null;
+  }
+  state.catalogError.value = null;
+  return response.data.detail;
+}
+
+// After a star both lists reload; reconcile the right-pane selection with
+// the refreshed pool so its `alreadyActive` flag reflects reality without
+// forcing the user to re-click.
+function reconcileSelectionAfterStar(state: CatalogState, entry: CatalogEntry): void {
+  const { selectedCatalog } = state;
+  if (!selectedCatalog.value || entryKey(selectedCatalog.value) !== entryKey(entry)) return;
+  const pool = entry.source === "external" ? state.catalogExternal.value : state.catalogPresets.value;
+  const updated = pool.find((candidate) => entryKey(candidate) === entryKey(entry));
+  if (updated) selectedCatalog.value = updated;
+}
+
+async function starCatalogEntry(state: CatalogState, entry: CatalogEntry): Promise<void> {
+  if (entry.alreadyActive) return;
+  state.catalogActioningKey.value = entryKey(entry);
+  const response = await apiPost<{ starred: true; slug: string }>(state.endpoints.catalogStar.url, catalogActionParams(entry));
+  state.catalogActioningKey.value = null;
+  if (!response.ok) {
+    state.catalogError.value = state.t("pluginManageSkills.errCatalogStarFailed", { error: response.error });
+    return;
+  }
+  state.catalogError.value = null;
+  // Refresh both lists so the row flips to "Starred" and the new active
+  // entry shows up in the left column.
+  await Promise.all([loadCatalog(state), state.deps.refreshActiveList()]);
+  reconcileSelectionAfterStar(state, entry);
+}
+
+async function selectCatalogEntry(state: CatalogState, entry: CatalogEntry): Promise<void> {
+  state.deps.clearActiveSelection();
+  state.selectedCatalog.value = entry;
+  state.catalogDetail.value = null;
+  state.catalogDetailLoading.value = true;
+  const keyAtRequest = entryKey(entry);
+  const fetched = await fetchCatalogDetail(state, entry);
+  // Selection may have changed while the request was in flight — drop the
+  // response if so. Identity is the (repoId, skillFolder) composite for
+  // external entries, not the lossy slug.
+  if (!state.selectedCatalog.value || entryKey(state.selectedCatalog.value) !== keyAtRequest) return;
+  state.catalogDetailLoading.value = false;
+  if (fetched !== null) state.catalogDetail.value = fetched;
+}
+
+function clearCatalogSelection(state: CatalogState): void {
+  state.selectedCatalog.value = null;
+  state.catalogDetail.value = null;
+}
+
+function clearSelectionIfRepo(state: CatalogState, repoId: string): void {
+  if (state.selectedCatalog.value?.repoId === repoId) clearCatalogSelection(state);
+}
+
+// A deleted (un-starred) preset reverts to ☆ Star: re-point the right pane
+// at the refreshed catalog copy so its state stops lagging.
+function reconcileAfterDelete(state: CatalogState, name: string): void {
+  if (state.selectedCatalog.value?.slug !== name) return;
+  const refreshed = state.catalogPresets.value.find((candidate) => candidate.slug === name);
+  if (refreshed) state.selectedCatalog.value = refreshed;
+}
+
+function resetCatalog(state: CatalogState): void {
+  clearCatalogSelection(state);
+  state.catalogDetailLoading.value = false;
+  state.catalogActioningKey.value = null;
+  state.catalogError.value = null;
+}
+
+export function useSkillCatalog(deps: SkillCatalogDeps): SkillCatalog {
+  const { t } = useI18n();
+  const endpoints = pluginEndpoints<SkillsEndpoints>("skills");
+  const catalogPresets = ref<CatalogEntry[]>([]);
+  const catalogExternal = ref<CatalogEntry[]>([]);
+  const catalogError = ref<string | null>(null);
+  const selectedCatalog = ref<CatalogEntry | null>(null);
+  const catalogDetail = ref<CatalogDetail | null>(null);
+  const catalogDetailLoading = ref(false);
+  // Single in-flight gate covers Star on the selected entry so a slow
+  // request doesn't let the user fire a second action mid-flight.
+  const catalogActioningKey = ref<string | null>(null);
+  const selectedCatalogKey = computed(() => (selectedCatalog.value ? entryKey(selectedCatalog.value) : null));
+  const { markdownRef: catalogMarkdownRef, renderedBody: catalogRenderedBody } = useSkillMarkdown(() => catalogDetail.value?.body);
+  const state: CatalogState = {
+    t,
+    endpoints,
+    deps,
+    catalogPresets,
+    catalogExternal,
+    catalogError,
+    selectedCatalog,
+    catalogDetail,
+    catalogDetailLoading,
+    catalogActioningKey,
+  };
+  return {
+    catalogPresets,
+    catalogExternal,
+    catalogError,
+    selectedCatalog,
+    catalogDetail,
+    catalogDetailLoading,
+    catalogActioningKey,
+    selectedCatalogKey,
+    catalogRenderedBody,
+    catalogMarkdownRef,
+    loadCatalog: () => loadCatalog(state),
+    selectCatalogEntry: (entry) => selectCatalogEntry(state, entry),
+    starCatalogEntry: (entry) => starCatalogEntry(state, entry),
+    clearSelection: () => clearCatalogSelection(state),
+    clearSelectionIfRepo: (repoId) => clearSelectionIfRepo(state, repoId),
+    reconcileAfterDelete: (name) => reconcileAfterDelete(state, name),
+    reset: () => resetCatalog(state),
+  };
+}

--- a/src/plugins/manageSkills/useSkillMarkdown.ts
+++ b/src/plugins/manageSkills/useSkillMarkdown.ts
@@ -1,0 +1,23 @@
+// Shared markdown pipeline for the /skills right pane. The active-skill
+// body and the catalog-preview body both render markdown → sanitized
+// HTML and post-process mermaid the same way; centralising the pair here
+// keeps the two viewers from drifting on which sanitiser or mermaid
+// wiring they use (the duplication #2301 flagged).
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { renderMarkdownToSafeHtml } from "../../utils/markdown/renderMarkdown";
+import { useMermaidRenderer } from "../../utils/markdown/useMermaid";
+
+export interface SkillMarkdown {
+  /** Bind to the `v-html` container so mermaid can post-process it. */
+  markdownRef: Ref<HTMLElement | null>;
+  /** Sanitised HTML for the `v-html` binding. */
+  renderedBody: ComputedRef<string>;
+}
+
+export function useSkillMarkdown(source: () => string | null | undefined): SkillMarkdown {
+  const markdownRef = ref<HTMLElement | null>(null);
+  const renderedBody = computed(() => renderMarkdownToSafeHtml(source()));
+  useMermaidRenderer(markdownRef, renderedBody);
+  return { markdownRef, renderedBody };
+}

--- a/test/plugins/manageSkills/test_categories.ts
+++ b/test/plugins/manageSkills/test_categories.ts
@@ -22,10 +22,12 @@ import {
   persistRepoCollapsed,
   entryKey,
   catalogActionParams,
+  buildRepoInstallBody,
   groupEntriesByRepo,
   repoLabel,
   skillBadgeMeta,
   PRESET_SOURCE_META,
+  toggleInSet,
   type CatalogEntryIdentity,
 } from "../../../src/plugins/manageSkills/categories.js";
 
@@ -371,6 +373,26 @@ describe("manageSkills catalogActionParams", () => {
   });
 });
 
+// buildRepoInstallBody feeds both the fresh-install and the "update"
+// (re-install) call sites; they must send an identical shape.
+describe("manageSkills buildRepoInstallBody", () => {
+  it("carries url + trimmed subpath when a subpath is given", () => {
+    assert.deepEqual(buildRepoInstallBody("https://github.com/acme/a", "  skills  "), {
+      url: "https://github.com/acme/a",
+      subpath: "skills",
+    });
+  });
+
+  it("omits subpath when undefined", () => {
+    assert.deepEqual(buildRepoInstallBody("https://github.com/acme/a"), { url: "https://github.com/acme/a" });
+  });
+
+  it("omits subpath when it is empty or whitespace-only", () => {
+    assert.deepEqual(buildRepoInstallBody("https://github.com/acme/a", "   "), { url: "https://github.com/acme/a" });
+    assert.deepEqual(buildRepoInstallBody("https://github.com/acme/a", ""), { url: "https://github.com/acme/a" });
+  });
+});
+
 describe("manageSkills groupEntriesByRepo", () => {
   const repoA = { repoId: "repo-a", url: "https://github.com/acme/a" };
   const repoB = { repoId: "repo-b", url: "https://github.com/acme/b" };
@@ -485,5 +507,37 @@ describe("manageSkills PRESET_SOURCE_META", () => {
       colour: "text-gray-400",
       titleKey: "pluginManageSkills.sourcePresetTitle",
     });
+  });
+});
+
+// toggleInSet backs both sidebar collapse handlers (section-level and
+// per-repo). It must add-or-remove the key AND leave the input set
+// untouched — the callers replace the ref wholesale so Vue re-renders,
+// so an accidental in-place mutation would corrupt the previous value.
+describe("manageSkills toggleInSet", () => {
+  it("removes a key that is present", () => {
+    assert.deepEqual([...toggleInSet(new Set(["a", "b"]), "a")], ["b"]);
+  });
+
+  it("adds a key that is absent", () => {
+    assert.deepEqual([...toggleInSet(new Set(["a"]), "b")], ["a", "b"]);
+  });
+
+  it("toggles from empty to a single-member set and back", () => {
+    const added = toggleInSet(new Set<string>(), "x");
+    assert.deepEqual([...added], ["x"]);
+    assert.deepEqual([...toggleInSet(added, "x")], []);
+  });
+
+  it("never mutates the input set", () => {
+    const input = new Set(["a"]);
+    toggleInSet(input, "a");
+    toggleInSet(input, "b");
+    assert.deepEqual([...input], ["a"], "input must stay unchanged");
+  });
+
+  it("returns a new set instance (reference changes for reactivity)", () => {
+    const input = new Set(["a"]);
+    assert.notEqual(toggleInSet(input, "a"), input);
   });
 });


### PR DESCRIPTION
## Summary

Advances #2301 (the deferred follow-up to the merged safe-layer PR #2381) by extracting the stateful clusters out of `src/plugins/manageSkills/View.vue`'s `<script setup>` into composables. **The `<template>` is left byte-for-byte unchanged** — this PR touches only script logic.

- **Before:** `View.vue` = **1072 lines**
- **After:** `View.vue` = **827 lines** (−245), plus:
  - `useSkillMarkdown.ts` (23) — dedup the `marked` + `sanitizeMarkdownHtml` + `useMermaidRenderer` pipeline that #2301 flagged as duplicated across `renderedBody` and `catalogRenderedBody`.
  - `useSkillCatalog.ts` (216) — preset-catalog cluster: data (`catalogPresets`/`catalogExternal`/`catalogError`), right-pane selection + detail, ★ Star, stale-response guards.
  - `useExternalRepos.ts` (266) — external-repo cluster: installed-repo list, per-repo collapse, add-repo modal, install / uninstall / update. A leaf composable — it only calls **outward**.
  - `categories.ts` — two new pure helpers **with tests**: `toggleInSet` (DRYs the section + repo collapse toggles) and `buildRepoInstallBody` (shared by install + update so they can't drift).

Each composable factory is a thin wire-up that delegates to small module-level action functions taking a state bundle (keeps every function within the 50-line / 20-line budgets and makes the actions unit-testable with a fake state). `View.vue` keeps the active-skill domain (`skills` / `selectedName` / edit / save / delete / `refreshActiveList`) and orchestrates the two composables — active-detail and catalog are genuinely bidirectionally coupled (starring adds to the active list; deleting an active skill re-syncs the catalog), so the active domain stays in the coordinator to avoid fragile forward-reference wiring.

## Items to Confirm / Review

- **DOM / testid unchanged (the e2e-safety crux).** The whole point of doing composables (not child components) this round is the dynamic-testid hazard the safe-layer plan called out: `:data-testid="isSelectedPreset ? 'skill-unstar-btn' : 'skill-delete-btn'"` and `skill-catalog-item-<entryKey>`. Composable extraction never edits the template. **Verified:** `git diff` on template lines 1–481 is empty (byte-identical); every diff hunk is inside `<script>`. All 35 `data-testid`s and the `isSelectedPreset` computation are preserved verbatim. Please confirm the "no DOM change → e2e untouched" reasoning holds for you.
- **entryKey coverage (the "テストが先" prerequisite).** `entryKey` already had thorough tests from #2381 (external vs preset, slug-collision-across-repos, missing-repoId/skillFolder fallback), so the load-bearing identity logic was test-covered **before** this refactor relied on it. This PR routes catalog identity only through that already-tested `categories.ts` surface. New pure logic added here (`toggleInSet`, `buildRepoInstallBody`) gets its own tests.
- **Coupling / ordering.** `refreshActiveList` + `clearActiveSelection` are defined before `useSkillCatalog`; `useSkillCatalog` before `useExternalRepos`; `isSelectedPreset` after the catalog. No forward references. Please sanity-check the `reset()` / `resetModalState()` split against the original single reset watcher.
- **Behaviour parity.** All star / select / delete / install / uninstall / update flows, the stale-response guards, and the in-flight locks are moved verbatim (only `this`→`state.` rebinding). `shallowRef` for the collapse sets is preserved.

## Verification

- `yarn format` (prettier): all changed files clean.
- `yarn lint`: **0 errors** (my files: 0 findings).
- Typecheck: `vue-tsc` reports **zero errors in `View.vue` and the three composables** — verified they are actually type-checked (an injected `number = "string"` was caught, then reverted) and isolated (stash-baseline: the identical pre-existing error set appears with my changes stashed).
- Unit tests: `manageSkills` suite **75 pass / 0 fail** (incl. new `toggleInSet` ×5 and `buildRepoInstallBody` ×3).

**Environment caveat (not caused by this change):** the shared checkout's `@mulmoclaude/core` `dist` is stale — its built `package.json` lacks the `./plugin-vue` export that `origin/main`'s source defines — and the monorepo package build breaks at `chart-plugin`. That makes a full `yarn build` / `yarn typecheck` / mock-e2e impossible to run to completion in this worktree. Both are pre-existing and unrelated: this change imports none of those packages, and the failing files (`FileContentRenderer.vue`, collection prototype-key tests #2322/#2323) are untouched by it — the stash-baseline confirms the same failures occur without this change. CI, which builds packages fresh, is the source of truth for those gates.

## User Prompt

Push the #2298–#2301 View.vue splits beyond the merged safe layer: for #2301, break `src/plugins/manageSkills/View.vue` into smaller child components / composables (the deferred follow-up to #2381, which extracted only the pure catalog/badge helpers). Ensure any `entryKey`-style identity logic relied on has unit tests first. Keep the rendered DOM and all 35 `data-testid`s behaviour-identical (single-spec e2e concentration in `e2e/tests/skills.spec.ts`). If a safe further split isn't possible, PR whatever safe slice is achievable (or recommend closing if the safe layer is the safe maximum). Open a PR; do not merge.

## Approach

Plan committed at `plans/refactor-2301-manageskills-split.md`. Composable-first (DOM-safe) rather than the template→child-component split, which is deferred to a separate PR that can change the DOM under e2e cover. Deferred: `SkillCatalogList.vue` / `SkillRepoGroup.vue` / `SkillDetailPane.vue` / `AddRepoModal.vue` / `SkillActiveList.vue` / `CatalogDetailPane.vue`, and a `useSkillDetail.ts` (active-skill detail kept in the coordinator this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal management of skills catalogs, external repositories, and markdown previews while preserving the existing interface and workflows.
  * Simplified sidebar collapse and selection-state handling.

* **Bug Fixes**
  * Improved catalog selection updates after starring, deleting, or changing skills.
  * Added safer handling for external repository installation paths and concurrent actions.
  * Prevented outdated catalog preview responses from replacing current selections.

* **Tests**
  * Added coverage for repository installation data formatting and sidebar toggle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->