### PR TITLE
refactor(wiki): split View.vue into components/composables (#2300)

### DIFF
--- a/plans/refactor-2300-wiki-split.md
+++ b/plans/refactor-2300-wiki-split.md
@@ -1,0 +1,103 @@
+# refactor(wiki): split `View.vue` into components + composables (#2300)
+
+## Context
+
+`src/plugins/wiki/View.vue` is ~1029 lines. The safe-layer PR (#2382, merged)
+already extracted **all pure helpers** into `helpers.ts` and covered them with
+`test/plugins/wiki/test_helpers.ts` (`metaString` / `metaStringArray` /
+`formatUpdated` / `computeTagCounts` / `computeTagChips` / `computeToggledContent`
+are all tested). This PR does the **next** step: break the component body into
+child components and composables so the parent becomes an orchestrator.
+
+## Hard constraint — e2e is xpath-sensitive
+
+`e2e/tests/wiki-navigation.spec.ts:216` does:
+
+```js
+const wikiBody = page.getByTestId("wiki-page-body");
+const scrollContainer = wikiBody.locator("xpath=..");  // DIRECT parent of wiki-page-body
+```
+
+The scroll test depends on `wiki-page-body`'s **direct DOM parent** being the
+`ref="scrollRef"` div. If we wrap or relocate that region, the parent/child
+relationship shifts one level and the assertion silently passes against a
+non-scrolling element.
+
+Additional invariant: `ref="scrollRef"` is reused (single name) across four
+mutually-exclusive `v-if` branches — index list, page content, page-edit, log.
+The parent's `watch(content)` resets `scrollRef.value.scrollTop = 0`. Extracting
+**any** scrollRef-bearing div into a child severs that ref binding and breaks the
+scroll reset for that view.
+
+### Regions we deliberately DO NOT touch
+
+- **Page content tab body** (template ~264-331): `wiki-page-body`'s parent must
+  stay the `scrollRef` div. Never wrap/extract this subtree.
+- **Any scrollRef-bearing div** (index list, page-edit body, log/lint body):
+  left inline so the parent keeps the `scrollRef` binding + scroll reset.
+- **Page tabs strip, per-page empty states, graph region, index list**: left
+  inline this PR. They are candidate future slices but sit near scrollRef /
+  xpath-traversed DOM, so they stay for a follow-up.
+
+All 25 `data-testid`s keep their exact string, DOM nesting, and layout classes.
+
+## Slices
+
+### A. Composables — `src/plugins/wiki/composables/` (zero DOM impact)
+
+Composables move **script only**; the rendered template is untouched, so they
+carry no xpath/testid risk.
+
+| Composable | Moves out | Deps injected |
+|---|---|---|
+| `useWikiNavigation.ts` | `pushWiki` / `navigate` / `navigatePage` / `currentSlug()` / `currentSlugReactive` / `isStandaloneWikiRoute` | `pageWikiRoute`, `pageNameFromResult()` |
+| `useTagFilter.ts` | `selectedTag` / `tagCounts` / `allTags` / `visibleEntries` / `toggleTagFilter` / `setTagFilter` + clear-on-leave watcher | `pageEntries`, `action` |
+| `useWikiGraph.ts` | `graphData` / `graphError` / `loadGraph` / `syncGraphFromResult` / `linkedReferences` | `action`, `pageExists`, `currentSlug` (ref), `endpointBase` |
+| `useWikiPageSave.ts` | task-checkbox save chain (`persistWikiPage` / `onTaskCheckboxClick` / queue generation) | `action`, `content`, `navError`, `currentSlug()`, `endpointBase`, `refresh` |
+| `useWikiPageEdit.ts` | `pageEditTs` / `pageEditBanner` / `pageEditDeleted` / `loadPageEditData` / `resetPageEdit` | `content` |
+
+`currentSlug()` is DRYed to `() => currentSlugReactive.value` (the original kept
+two identical bodies with a "Mirrors the imperative body" comment).
+
+Data-fetch orchestration (`callApi` / `applyWikiResult` / `useFreshPluginData` /
+the two watchers / `onMounted`) **stays in the parent** — it writes the shared
+view refs, emits `updateResult`, and calls `syncGraphFromResult`. The parent is
+the orchestrator that wires the composables together.
+
+`navError` stays declared early in the parent (TDZ constraint: the
+`immediate: true` URL watcher runs `callApi` synchronously during setup).
+
+### B. New pure helper (tested) — `helpers.ts`
+
+- `shouldLazyLoadGraph(action, pageExists, hasGraph): boolean` — the branch
+  exposed by moving `syncGraphFromResult`. Silently-failing rule (a wrong
+  condition means backlinks never load), so it gets its own unit test.
+
+### C. Template child components — `src/plugins/wiki/components/`
+
+Both are **single-root**, **off the xpath path**, and contain **no scrollRef**,
+so their emitted DOM is byte-equivalent to the inlined markup.
+
+| Component | Template region | Root element | testids inside |
+|---|---|---|---|
+| `WikiHeader.vue` | header row (~4-91) | the header `<div class="flex items-center justify-between …">` | `wiki-zip-button`, `wiki-lint-chat-button`, `wiki-tab-graph` |
+| `WikiMetadataBar.vue` | metadata bar (~187-215) | `<div data-testid="wiki-page-metadata-bar">` | `wiki-page-metadata-{bar,created,updated,editor,tags}`, `wiki-page-metadata-tag-<tag>` |
+
+Props in, `emit` out (no function props). `$t()` used for text inside children.
+The `v-if` guarding each region stays on the parent's `<WikiHeader>` /
+`<WikiMetadataBar>` tag, so conditional rendering is identical.
+
+## Why DOM stays identical
+
+- Composables never touch the template.
+- Child components have a single root equal to the div they replace; Vue renders
+  that root in place of the tag, so nesting, classes, attributes, and testids are
+  byte-for-byte the same.
+- No scrollRef div is moved; the xpath-critical `wiki-page-body → scrollRef`
+  parent/child relationship is left completely alone.
+
+## Verification
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test`. Wiki
+mock e2e (`e2e/tests/wiki-navigation.spec.ts`) run if feasible; otherwise rely on
+the unchanged DOM argument above and say so in the PR. No version bumps.

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -1,94 +1,21 @@
 <template>
   <div class="h-full bg-white flex flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
-      <div class="flex items-center gap-2 min-w-0">
-        <button
-          v-if="action !== 'index' && isStandaloneWikiRoute"
-          class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-          :title="t('pluginWiki.backToIndex')"
-          @click="router.back()"
-        >
-          <span class="material-icons text-base">arrow_back</span>
-        </button>
-        <h2 class="text-lg font-semibold text-gray-800 truncate">{{ displayTitle }}</h2>
-      </div>
-      <div class="flex items-center gap-2">
-        <template v-if="(action === 'page' || action === 'page-edit') && content">
-          <button
-            class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
-            :disabled="pdfDownloading"
-            @click="downloadPdf"
-          >
-            <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
-            {{ t("pluginWiki.pdf") }}
-          </button>
-          <button
-            class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
-            :disabled="zipDownloading"
-            data-testid="wiki-zip-button"
-            @click="downloadZipFile"
-          >
-            <span class="material-icons text-base">{{ zipDownloading ? "hourglass_empty" : "folder_zip" }}</span>
-            {{ t("common.downloadZip") }}
-          </button>
-          <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ t("pluginWiki.pdfFailed") }}</span>
-          <span v-if="zipFailed" class="text-xs text-red-500">{{ t("common.downloadFailed") }}</span>
-        </template>
-        <button
-          v-if="action === 'index'"
-          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm transition-colors"
-          data-testid="wiki-lint-chat-button"
-          @click="startLintChat"
-        >
-          <span class="material-icons text-base">rule</span>
-          {{ t("pluginWiki.lintChat") }}
-        </button>
-        <div class="flex border border-gray-300 rounded overflow-hidden">
-          <button
-            :class="[
-              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
-              action === 'index' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
-            ]"
-            @click="navigate('index')"
-          >
-            <span class="material-icons text-sm">list</span>
-            <span>{{ t("pluginWiki.tabIndex") }}</span>
-          </button>
-          <button
-            :class="[
-              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
-              action === 'log' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
-            ]"
-            @click="navigate('log')"
-          >
-            <span class="material-icons text-sm">history</span>
-            <span>{{ t("pluginWiki.tabLog") }}</span>
-          </button>
-          <button
-            :class="[
-              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
-              action === 'lint_report' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
-            ]"
-            @click="navigate('lint_report')"
-          >
-            <span class="material-icons text-sm">rule</span>
-            <span>{{ t("pluginWiki.tabLint") }}</span>
-          </button>
-          <button
-            :class="[
-              'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
-              action === 'graph' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
-            ]"
-            data-testid="wiki-tab-graph"
-            @click="navigate('graph')"
-          >
-            <span class="material-icons text-sm">hub</span>
-            <span>{{ t("pluginWiki.tabGraph") }}</span>
-          </button>
-        </div>
-      </div>
-    </div>
+    <WikiHeader
+      :action="action"
+      :is-standalone-wiki-route="isStandaloneWikiRoute"
+      :display-title="displayTitle"
+      :has-content="!!content"
+      :pdf-downloading="pdfDownloading"
+      :pdf-error="pdfError"
+      :zip-downloading="zipDownloading"
+      :zip-failed="zipFailed"
+      @back="router.back()"
+      @download-pdf="downloadPdf"
+      @download-zip="downloadZipFile"
+      @lint-chat="startLintChat"
+      @navigate="navigate"
+    />
 
     <!-- Navigation error -->
     <div v-if="navError" class="mx-6 mt-4 rounded border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
@@ -184,35 +111,7 @@
            the existing header-less content visually unchanged.
            Stays visible across both Content and History tabs (#944
            Q11=C). -->
-      <div
-        v-if="(action === 'page' || action === 'page-edit') && hasPageMeta"
-        data-testid="wiki-page-metadata-bar"
-        class="shrink-0 border-b border-gray-100 px-6 py-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500"
-      >
-        <span v-if="pageMeta.created" data-testid="wiki-page-metadata-created">
-          <span class="text-gray-400">{{ t("pluginWiki.metadataCreated") }}:</span>
-          {{ pageMeta.created }}
-        </span>
-        <span v-if="pageMeta.updated" data-testid="wiki-page-metadata-updated">
-          <span class="text-gray-400">{{ t("pluginWiki.metadataUpdated") }}:</span>
-          {{ formatUpdated(pageMeta.updated) }}
-        </span>
-        <span v-if="pageMeta.editor" data-testid="wiki-page-metadata-editor">
-          <span class="text-gray-400">{{ t("pluginWiki.metadataEditor") }}:</span>
-          {{ pageMeta.editor }}
-        </span>
-        <span v-if="pageMeta.tags.length > 0" class="flex flex-wrap gap-1" data-testid="wiki-page-metadata-tags">
-          <button
-            v-for="tag in pageMeta.tags"
-            :key="tag"
-            class="entry-tag-chip"
-            :data-testid="`wiki-page-metadata-tag-${tag}`"
-            @click="setTagFilterAndNavigate(tag)"
-          >
-            {{ `#${tag}` }}
-          </button>
-        </span>
-      </div>
+      <WikiMetadataBar v-if="(action === 'page' || action === 'page-edit') && hasPageMeta" :meta="pageMeta" @tag-click="setTagFilterAndNavigate" />
 
       <!-- Per-page tab strip: Content | History (#763 PR 3 / #944).
            Mounted on every page view (including missing / empty
@@ -402,7 +301,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from "vue";
-import { useRoute, useRouter, isNavigationFailure } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import type { WikiData, WikiPageEntry, WikiEndpoints } from "./index";
@@ -414,29 +313,23 @@ import { buildPdfFilename } from "@mulmoclaude/markdown-utils/files/filename";
 import PageChatComposer from "../../components/PageChatComposer.vue";
 import { pluginBuiltinRoleIds, pluginEndpoints, pluginPageRoute } from "../api";
 import { useMarkdownDoc } from "@mulmoclaude/core/plugin-vue";
-import { computeTagChips, computeTagCounts, computeToggledContent, formatUpdated, metaString, metaStringArray } from "./helpers";
+import { formatUpdated, metaString, metaStringArray } from "./helpers";
 import { apiPost } from "../../utils/api";
-import {
-  WIKI_ACTION,
-  WIKI_ROUTE_SECTION,
-  buildWikiRouteParams,
-  isSafeWikiSlug,
-  readWikiRouteTarget,
-  wikiActionFor,
-  incomingLinks,
-  type WikiTarget,
-  type WikiGraph,
-} from "@mulmoclaude/core/wiki";
+import { WIKI_ACTION, readWikiRouteTarget, wikiActionFor } from "@mulmoclaude/core/wiki";
 import FilterChip from "../../components/FilterChip.vue";
 import HistoryTab from "./history/HistoryTab.vue";
 import WikiPageBody from "./components/WikiPageBody.vue";
 import WikiGraphView from "./components/WikiGraphView.vue";
-import { loadPageEdit } from "./pageEditLoader";
+import WikiHeader from "./components/WikiHeader.vue";
+import WikiMetadataBar from "./components/WikiMetadataBar.vue";
+import { useWikiNavigation } from "./composables/useWikiNavigation";
+import { useTagFilter } from "./composables/useTagFilter";
+import { useWikiGraph } from "./composables/useWikiGraph";
+import { useWikiPageSave } from "./composables/useWikiPageSave";
+import { useWikiPageEdit } from "./composables/useWikiPageEdit";
 
 const wikiEndpoints = pluginEndpoints<WikiEndpoints>("wiki");
 const PAGE_WIKI = pluginPageRoute("wiki");
-
-type WikiTabView = typeof WIKI_ACTION.log | typeof WIKI_ACTION.lintReport | typeof WIKI_ACTION.graph;
 
 // Workspace-relative wiki dirs. Centralised so future layout shifts
 // (e.g. the prior `wiki/` → `data/wiki/` move) only need to change
@@ -467,32 +360,12 @@ const content = ref(props.selectedResult?.data?.content ?? "");
 const mdDoc = useMarkdownDoc(content);
 const pageEntries = ref<WikiPageEntry[]>(props.selectedResult?.data?.pageEntries ?? []);
 const pageExists = ref(props.selectedResult?.data?.pageExists ?? true);
-// `page-edit` action state (Stage 3a, #963). Populated when an LLM
-// Write/Edit toolResult is mounted: `pageEditTs` is the snapshot's
-// own timestamp (used in the header subtitle), `pageEditBanner` is
-// shown only when the snapshot was gc'd and we fell back to the
-// live page, and `pageEditDeleted` flips on when neither survives.
-const pageEditTs = ref<string | null>(null);
-const pageEditBanner = ref<string | null>(null);
-const pageEditDeleted = ref(false);
-// View-local tag filter. Null = no filter. Not persisted to URL —
-// kept intentionally ephemeral so it doesn't leak into bookmarks
-// or the per-session stack history.
-const selectedTag = ref<string | null>(null);
 // Declared up here — not next to callApi — because the URL watcher
 // below fires with `immediate: true`, which invokes callApi
 // synchronously during setup. If this ref were declared after the
 // watcher, callApi's `navError.value = null` would hit the TDZ on
 // direct loads of /wiki and the fetch would never run.
 const navError = ref<string | null>(null);
-
-// Page→page link graph (#wiki-backlinks-graph). Loaded lazily once
-// per browsing session and reused for both the Graph tab and the
-// per-page "Linked references" panel (the graph is global, so one
-// fetch serves every page's backlinks). Refreshed on the Graph tab
-// fetch and after a page save / restore so edited links propagate.
-const graphData = ref<WikiGraph | null>(null);
-const graphError = ref<string | null>(null);
 
 // Per-page tab state for the Content / History switcher (#763 PR
 // 3 / #944). Defaults to "content" on every page navigation
@@ -510,18 +383,21 @@ const restoreToastVisible = ref(false);
 const RESTORE_TOAST_MS = 4000;
 let restoreToastTimer: ReturnType<typeof setTimeout> | null = null;
 
-// Computed slug used by the watcher and the template. Mirrors the
-// imperative `currentSlug()` body — declared up here so the
-// pageTab-reset watcher can pick up route + selectedResult changes
-// uniformly without re-walking each call site that mutates the
-// underlying state.
-const currentSlugReactive = computed<string | null>(() => {
-  const raw =
-    route.name === PAGE_WIKI && route.params.section === WIKI_ROUTE_SECTION.pages && typeof route.params.slug === "string"
-      ? route.params.slug
-      : (props.selectedResult?.data?.pageName ?? null);
-  return isSafeWikiSlug(raw) ? raw : null;
+const { currentSlugReactive, currentSlug, isStandaloneWikiRoute, navigate, navigatePage } = useWikiNavigation({
+  pageWikiRoute: PAGE_WIKI,
+  pageNameFromResult: () => props.selectedResult?.data?.pageName ?? null,
 });
+
+const { selectedTag, tagCounts, allTags, visibleEntries, toggleTagFilter, setTagFilter } = useTagFilter(pageEntries, action);
+
+const { graphData, graphError, loadGraph, syncGraphFromResult, linkedReferences } = useWikiGraph({
+  action,
+  pageExists,
+  currentSlug: currentSlugReactive,
+  endpointBase: wikiEndpoints.base,
+});
+
+const { pageEditTs, pageEditBanner, pageEditDeleted, loadPageEditData, resetPageEdit } = useWikiPageEdit({ content });
 
 watch(currentSlugReactive, (next, prev) => {
   if (next === prev) return;
@@ -534,6 +410,87 @@ watch(currentSlugReactive, (next, prev) => {
     restoreToastTimer = null;
   }
 });
+
+// ── Metadata bar (#895 PR B) ──────────────────────────────────
+//
+// Derive `Created` / `Updated` / `Editor` / `Tags` from the page's
+// frontmatter. `WikiMetadataBar` hides itself when none are present
+// (header-less pages render unchanged so old wiki content keeps its
+// current appearance).
+const pageMeta = computed(() => ({
+  created: metaString(mdDoc.value.meta.created),
+  updated: metaString(mdDoc.value.meta.updated),
+  editor: metaString(mdDoc.value.meta.editor),
+  tags: metaStringArray(mdDoc.value.meta.tags),
+}));
+
+const hasPageMeta = computed(() => {
+  const meta = pageMeta.value;
+  return meta.created !== null || meta.updated !== null || meta.editor !== null || meta.tags.length > 0;
+});
+
+// Header subtitle for the page-edit action. "Wiki edit · {slug} ·
+// {timestamp}" so the user immediately sees this is a moment-in-
+// time view, not the live page. `formatUpdated` re-uses the same
+// `YYYY-MM-DD HH:MM` shape as the metadata bar.
+const displayTitle = computed(() => {
+  if (action.value !== "page-edit") return title.value;
+  const stamp = pageEditTs.value;
+  const prefix = `${t("pluginWiki.pageEditHeader")} · ${title.value}`;
+  return stamp ? `${prefix} · ${formatUpdated(stamp)}` : prefix;
+});
+
+const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
+const { zipDownloading, zipFailed, downloadZip: rawDownloadZip } = useMarkdownZip();
+
+async function downloadPdf() {
+  const uuid = props.selectedResult?.uuid;
+  const filename = buildPdfFilename({
+    name: title.value,
+    fallback: "wiki",
+    timestampMs: uuid ? appApi.getResultTimestamp(uuid) : undefined,
+  });
+  // Wiki pages live under data/wiki/pages/ — pass the source dir so
+  // the server resolves relative `<img>` refs (`../../../artifacts/...`)
+  // against the same base the browser uses. Wiki pages always carry
+  // a frontmatter envelope (#895), so opt in to stripping it from the
+  // PDF output.
+  await rawDownloadPdf(content.value, filename, { baseDir: "data/wiki/pages", stripFrontmatter: true });
+}
+
+async function downloadZipFile() {
+  const uuid = props.selectedResult?.uuid;
+  const filename = buildPdfFilename({ name: title.value, fallback: "wiki", timestampMs: uuid ? appApi.getResultTimestamp(uuid) : undefined });
+  await rawDownloadZip(content.value, filename, { baseDir: "data/wiki/pages", stripFrontmatter: true });
+}
+
+function applyWikiResult(data: Partial<WikiData> | undefined): void {
+  action.value = data?.action ?? "index";
+  title.value = data?.title ?? "Wiki";
+  content.value = data?.content ?? "";
+  pageEntries.value = data?.pageEntries ?? [];
+  pageExists.value = data?.pageExists ?? true;
+  syncGraphFromResult(data);
+}
+
+async function callApi(body: Record<string, unknown>) {
+  navError.value = null;
+  const response = await apiPost<{ data?: Partial<WikiData> }>(wikiEndpoints.base, body);
+  if (!response.ok) {
+    navError.value = response.status === 0 ? response.error : `Wiki API error ${response.status}: ${response.error}`;
+    return;
+  }
+  const result = response.data;
+  applyWikiResult(result.data);
+  if (props.selectedResult) {
+    emit("updateResult", {
+      ...props.selectedResult,
+      ...result,
+      toolName: "manageWiki",
+      uuid: props.selectedResult.uuid,
+    });
+  }
+}
 
 const { refresh, abort: abortFreshFetch } = useFreshPluginData<WikiData>({
   // Slug-aware: when the view is currently showing a specific page,
@@ -555,6 +512,15 @@ const { refresh, abort: abortFreshFetch } = useFreshPluginData<WikiData>({
     pageEntries.value = data.pageEntries ?? [];
     pageExists.value = data.pageExists ?? true;
   },
+});
+
+const { onTaskCheckboxClick } = useWikiPageSave({
+  action,
+  content,
+  navError,
+  currentSlug,
+  endpointBase: wikiEndpoints.base,
+  refresh,
 });
 
 function handleRestored(): void {
@@ -613,32 +579,10 @@ watch(
       void loadPageEditData(data.slug, data.stamp);
       return;
     }
-    pageEditTs.value = null;
-    pageEditBanner.value = null;
-    pageEditDeleted.value = false;
+    resetPageEdit();
     void refresh();
   },
 );
-
-async function loadPageEditData(slug: string, stamp: string): Promise<void> {
-  pageEditTs.value = null;
-  pageEditBanner.value = null;
-  pageEditDeleted.value = false;
-  content.value = "";
-
-  const result = await loadPageEdit(slug, stamp);
-  if (result.kind === "snapshot") {
-    pageEditTs.value = result.ts;
-    content.value = result.content;
-    return;
-  }
-  if (result.kind === "current") {
-    pageEditBanner.value = t("pluginWiki.snapshotExpired");
-    content.value = result.content;
-    return;
-  }
-  pageEditDeleted.value = true;
-}
 
 // URL is the single source of truth for wiki navigation. Button
 // handlers push to the router; this watcher drives callApi(). Only
@@ -664,34 +608,26 @@ watch(
   { immediate: true },
 );
 
-// Tag filter chips. The counting + adaptive cutoff rules live in
-// `computeTagCounts` / `computeTagChips` (helpers.ts, tested); the
-// target chip count is the one view-level knob. `tagCounts` stays a
-// separate computed so the fallback chip below — the active filter
-// when the cutoff hides it — can read a real count instead of
-// understating a dropped non-singleton tag as 1.
-const TARGET_FILTER_CHIPS = 20;
-const tagCounts = computed<Map<string, number>>(() => computeTagCounts(pageEntries.value));
-const allTags = computed<[string, number][]>(() => computeTagChips(pageEntries.value, TARGET_FILTER_CHIPS));
+/** Base directory for wiki content, adjusted by the current view. */
+const WIKI_BASE_DIR = computed(() => (action.value === "page" || action.value === "page-edit" ? WIKI_PAGES_DIR : WIKI_DATA_DIR));
 
-const visibleEntries = computed(() =>
-  selectedTag.value === null ? pageEntries.value : pageEntries.value.filter((entry) => (entry.tags ?? []).includes(selectedTag.value as string)),
-);
+// The wiki view stays mounted across wiki navigations (the router
+// just updates params and callApi swaps content.value), so the
+// scrollable container would otherwise keep the previous page's
+// scrollTop. Reset to the top whenever the rendered body changes.
+const scrollRef = ref<HTMLElement | null>(null);
+watch(content, async () => {
+  await nextTick();
+  if (scrollRef.value) scrollRef.value.scrollTop = 0;
+});
 
-function toggleTagFilter(tag: string) {
-  selectedTag.value = selectedTag.value === tag ? null : tag;
-}
-
-// Per-entry tag chips set the filter unconditionally — clicking a
-// `#javascript` chip on a page row should always filter the index to
-// that tag, even when the user is already viewing the same filter.
-// Using `toggleTagFilter` here was unintuitive: clicking a `#tag`
-// chip on a row that's already in the active filter would clear the
-// filter, surprising the user. The filter chips at the top of the
-// list still toggle (so users have an obvious "click again to clear"
-// affordance there).
-function setTagFilter(tag: string) {
-  selectedTag.value = tag;
+// Spawn a new chat under the General role (which owns the wiki
+// tooling) regardless of the role the user is currently viewing the
+// wiki under. "lint my wiki" is a direct instruction to the agent,
+// not a tool call — the agent decides how to run the lint and
+// report back.
+function startLintChat() {
+  appApi.startNewChat("lint my wiki", pluginBuiltinRoleIds().general);
 }
 
 // Tag chips on the page metadata bar (#895 PR B) live in the
@@ -704,176 +640,6 @@ function setTagFilterAndNavigate(tag: string) {
   setTagFilter(tag);
   navigate("index");
 }
-
-// Spawn a new chat under the General role (which owns the wiki
-// tooling) regardless of the role the user is currently viewing the
-// wiki under. "lint my wiki" is a direct instruction to the agent,
-// not a tool call — the agent decides how to run the lint and
-// report back.
-function startLintChat() {
-  appApi.startNewChat("lint my wiki", pluginBuiltinRoleIds().general);
-}
-
-// Clear the filter whenever we leave the index view — otherwise
-// switching to Log / Lint and back leaves a stale filter active,
-// which feels like a bug.
-watch(action, (next) => {
-  if (next !== "index") selectedTag.value = null;
-});
-
-// The wiki view stays mounted across wiki navigations (the router
-// just updates params and callApi swaps content.value), so the
-// scrollable container would otherwise keep the previous page's
-// scrollTop. Reset to the top whenever the rendered body changes.
-const scrollRef = ref<HTMLElement | null>(null);
-watch(content, async () => {
-  await nextTick();
-  if (scrollRef.value) scrollRef.value.scrollTop = 0;
-});
-
-/** Base directory for wiki content, adjusted by the current view. */
-const WIKI_BASE_DIR = computed(() => (action.value === "page" || action.value === "page-edit" ? WIKI_PAGES_DIR : WIKI_DATA_DIR));
-
-// ── Metadata bar (#895 PR B) ──────────────────────────────────
-//
-// Show a single thin row above the rendered body with
-// `Created` / `Updated` / `Editor` / `Tags` derived from the
-// frontmatter. Hidden when none of those are present (header-less
-// pages render unchanged so old wiki content keeps its current
-// appearance).
-
-const pageMeta = computed(() => ({
-  created: metaString(mdDoc.value.meta.created),
-  updated: metaString(mdDoc.value.meta.updated),
-  editor: metaString(mdDoc.value.meta.editor),
-  tags: metaStringArray(mdDoc.value.meta.tags),
-}));
-
-const hasPageMeta = computed(() => {
-  const meta = pageMeta.value;
-  return meta.created !== null || meta.updated !== null || meta.editor !== null || meta.tags.length > 0;
-});
-
-// Header subtitle for the page-edit action. "Wiki edit · {slug} ·
-// {timestamp}" so the user immediately sees this is a moment-in-
-// time view, not the live page. `formatUpdated` re-uses the same
-// `YYYY-MM-DD HH:MM` shape as the metadata bar.
-const displayTitle = computed(() => {
-  if (action.value !== "page-edit") return title.value;
-  const stamp = pageEditTs.value;
-  const prefix = `${t("pluginWiki.pageEditHeader")} · ${title.value}`;
-  return stamp ? `${prefix} · ${formatUpdated(stamp)}` : prefix;
-});
-
-const { pdfDownloading, pdfError, downloadPdf: rawDownloadPdf } = usePdfDownload();
-const { zipDownloading, zipFailed, downloadZip: rawDownloadZip } = useMarkdownZip();
-
-async function downloadPdf() {
-  const uuid = props.selectedResult?.uuid;
-  const filename = buildPdfFilename({
-    name: title.value,
-    fallback: "wiki",
-    timestampMs: uuid ? appApi.getResultTimestamp(uuid) : undefined,
-  });
-  // Wiki pages live under data/wiki/pages/ — pass the source dir so
-  // the server resolves relative `<img>` refs (`../../../artifacts/...`)
-  // against the same base the browser uses. Wiki pages always carry
-  // a frontmatter envelope (#895), so opt in to stripping it from the
-  // PDF output.
-  await rawDownloadPdf(content.value, filename, { baseDir: "data/wiki/pages", stripFrontmatter: true });
-}
-
-async function downloadZipFile() {
-  const uuid = props.selectedResult?.uuid;
-  const filename = buildPdfFilename({ name: title.value, fallback: "wiki", timestampMs: uuid ? appApi.getResultTimestamp(uuid) : undefined });
-  await rawDownloadZip(content.value, filename, { baseDir: "data/wiki/pages", stripFrontmatter: true });
-}
-
-// Graph tab response carries the link graph directly. On a page view,
-// lazily fetch the graph once so the "Linked references" panel has
-// data — the graph is global, so one fetch serves every page. Reuses
-// the shared `WikiData` type (Partial — the server omits fields per
-// action) so the client payload shape can't drift from the server's.
-function syncGraphFromResult(data: Partial<WikiData> | undefined): void {
-  if (data?.graph) {
-    // Clear any stale error from an earlier failed loadGraph so a
-    // fresh graph payload isn't hidden behind the error banner.
-    graphError.value = null;
-    graphData.value = data.graph;
-    return;
-  }
-  if (action.value === WIKI_ACTION.page && pageExists.value && graphData.value === null) void loadGraph();
-}
-
-function applyWikiResult(data: Partial<WikiData> | undefined): void {
-  action.value = data?.action ?? "index";
-  title.value = data?.title ?? "Wiki";
-  content.value = data?.content ?? "";
-  pageEntries.value = data?.pageEntries ?? [];
-  pageExists.value = data?.pageExists ?? true;
-  syncGraphFromResult(data);
-}
-
-async function callApi(body: Record<string, unknown>) {
-  navError.value = null;
-  const response = await apiPost<{ data?: Partial<WikiData> }>(wikiEndpoints.base, body);
-  if (!response.ok) {
-    navError.value = response.status === 0 ? response.error : `Wiki API error ${response.status}: ${response.error}`;
-    return;
-  }
-  const result = response.data;
-  applyWikiResult(result.data);
-  if (props.selectedResult) {
-    emit("updateResult", {
-      ...props.selectedResult,
-      ...result,
-      toolName: "manageWiki",
-      uuid: props.selectedResult.uuid,
-    });
-  }
-}
-
-async function loadGraph(): Promise<void> {
-  graphError.value = null;
-  const response = await apiPost<{ data?: { graph?: WikiGraph } }>(wikiEndpoints.base, { action: WIKI_ACTION.graph });
-  if (!response.ok) {
-    graphError.value = response.status === 0 ? response.error : `Wiki graph error ${response.status}: ${response.error}`;
-    return;
-  }
-  graphData.value = response.data.data?.graph ?? { nodes: [], edges: [] };
-}
-
-// Pages that link TO the page currently being viewed. Derived from
-// the global graph + the current slug — empty until the graph loads
-// (lazily, via callApi on the first page view).
-const linkedReferences = computed(() => {
-  const slug = currentSlugReactive.value;
-  if (graphData.value === null || slug === null) return [];
-  return incomingLinks(graphData.value, slug);
-});
-
-function pushWiki(target: WikiTarget) {
-  router.push({ name: PAGE_WIKI, params: buildWikiRouteParams(target) }).catch((err: unknown) => {
-    if (!isNavigationFailure(err)) {
-      console.error("[wiki] navigation failed:", err);
-    }
-  });
-}
-
-function navigate(newAction: typeof WIKI_ACTION.index | WikiTabView) {
-  pushWiki(newAction === WIKI_ACTION.index ? { kind: "index" } : { kind: newAction });
-}
-
-function navigatePage(pageName: string) {
-  pushWiki({ kind: "page", slug: pageName });
-}
-
-// --- Per-page chat composer ---
-// (`appApi` itself is hoisted to the top of <script setup> alongside
-// route/router/t so the lint-by-line analysis is happy with earlier
-// uses in `startLintChat` etc.)
-
-const isStandaloneWikiRoute = computed(() => route.name === PAGE_WIKI);
 
 // Always route wiki create/update CTAs through pluginBuiltinRoleIds().general
 // (the wiki-capable role) so the new chat has the tools needed to
@@ -892,120 +658,6 @@ function requestUpdatePage() {
     `Update the existing wiki page about ${JSON.stringify(title.value)}. The page file exists but has no content. Research the topic and write a comprehensive article in ${WIKI_PAGES_DIR}/.`,
     pluginBuiltinRoleIds().general,
   );
-}
-
-function currentSlug(): string | null {
-  // Prefer the URL on /wiki (source of truth for that route); fall
-  // back to the tool-result payload when WikiView is mounted as a
-  // manageWiki result inside /chat. `isSafeWikiSlug` guards against
-  // traversal tokens — the router guard already strips these from
-  // standalone /wiki URLs, but the tool-result payload arrives from
-  // the server/agent and can't assume that upstream filter.
-  const raw =
-    route.name === PAGE_WIKI && route.params.section === WIKI_ROUTE_SECTION.pages && typeof route.params.slug === "string"
-      ? route.params.slug
-      : (props.selectedResult?.data?.pageName ?? null);
-  return isSafeWikiSlug(raw) ? raw : null;
-}
-
-// Serialised POST chain for rapid task-checkbox clicks (#775). Each
-// click queues onto the previous so a slower network can't reorder
-// writes. (The wire call is `POST /api/wiki { action: "save" }`, not
-// PUT — the comment used to say PUT and contradicted the call site.)
-//
-// `saveQueueGeneration` invalidates older queued saves after a
-// failure-triggered refresh: their captured snapshots were computed
-// against the now-discarded optimistic state, so writing them would
-// overwrite the canonical server content with stale data. We bump
-// the generation on failure; queued saves whose generation no longer
-// matches skip silently.
-let taskPersistChain: Promise<unknown> = Promise.resolve();
-let saveQueueGeneration = 0;
-
-async function persistWikiPage(pageName: string, newContent: string, generation: number): Promise<void> {
-  // Stale queued save (a previous save failed + refresh discarded
-  // the optimistic state this snapshot was based on).
-  if (generation !== saveQueueGeneration) return;
-  // Bail if the page navigation has changed mid-flight — saving the
-  // captured snapshot to a different page would clobber unrelated
-  // state. The watchers on route / selectedResult already load the
-  // new page; touching state here is wrong. `currentSlug()` returns
-  // the right source for both the standalone /wiki view (route
-  // params) and the tool-result-embedded view (selectedResult).
-  if (currentSlug() !== pageName) return;
-
-  const response = await apiPost<{ data?: { content?: string } }>(wikiEndpoints.base, {
-    action: WIKI_ACTION.save,
-    pageName,
-    content: newContent,
-  });
-
-  if (generation !== saveQueueGeneration) return;
-  if (currentSlug() !== pageName) return;
-
-  if (!response.ok) {
-    navError.value = response.status === 0 ? response.error : `Wiki save failed (${response.status}): ${response.error}`;
-    // Refresh resets local state to the canonical server content.
-    // The generation bump must come AFTER refresh completes — clicks
-    // arriving WHILE refresh is in flight capture the pre-bump
-    // generation; bumping post-refresh invalidates them too. Bumping
-    // pre-refresh would let those during-refresh clicks slip through
-    // (they'd capture the new gen and persist a toggle computed
-    // against the not-yet-reset DOM).
-    await refresh();
-    saveQueueGeneration += 1;
-    return;
-  }
-  // Successful save — clear any stale error from a prior click.
-  navError.value = null;
-}
-
-function onTaskCheckboxClick(event: MouseEvent, target: HTMLInputElement): void {
-  // Only meaningful for the page view; everything else is read-only.
-  if (action.value !== "page") {
-    target.checked = !target.checked;
-    return;
-  }
-  // `currentSlug()` covers both mount paths — standalone /wiki/<slug>
-  // (route param) and tool-result-embedded WikiView (selectedResult).
-  // The standalone path is the primary one; reading only from
-  // selectedResult would silently no-op every click on /wiki/<slug>.
-  const pageName = currentSlug();
-  if (!pageName) {
-    target.checked = !target.checked;
-    return;
-  }
-
-  const root = event.currentTarget as HTMLElement;
-  const result = computeToggledContent(target, root, content.value);
-  if (result.status !== "toggled") {
-    // `mismatch` = source/DOM task-count drift; surface it. `skip`
-    // reverts silently (target not among the tasks, or an out-of-range
-    // toggle).
-    if (result.status === "mismatch") navError.value = t("pluginWiki.taskCountMismatch");
-    target.checked = !target.checked;
-    return;
-  }
-  const newContent = result.content;
-
-  // Optimistic local update — re-render is driven by `content`'s
-  // existing watcher.
-  content.value = newContent;
-  navError.value = null;
-
-  // Capture the current generation so the queued save knows whether
-  // the chain has been broken (by a prior failure) by the time it
-  // runs. See `persistWikiPage` for the semantics.
-  const generation = saveQueueGeneration;
-  // `.catch` keeps the chain self-healing: if `persistWikiPage`
-  // throws (e.g. its post-failure `refresh()` rejects with a network
-  // error), an un-caught rejection would leave `taskPersistChain` in
-  // a permanently-rejected state, and every subsequent click's
-  // `.then()` would short-circuit silently — no more toggles ever
-  // persist. Swallow the rejection here so the next click starts
-  // from a fresh resolved chain. The error is already surfaced via
-  // `navError` inside `persistWikiPage`'s `!response.ok` branch.
-  taskPersistChain = taskPersistChain.then(() => persistWikiPage(pageName, newContent, generation)).catch(() => undefined);
 }
 </script>
 

--- a/src/plugins/wiki/components/WikiHeader.vue
+++ b/src/plugins/wiki/components/WikiHeader.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 shrink-0">
+    <div class="flex items-center gap-2 min-w-0">
+      <button
+        v-if="action !== 'index' && isStandaloneWikiRoute"
+        class="h-8 w-8 flex items-center justify-center rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+        :title="$t('pluginWiki.backToIndex')"
+        @click="emit('back')"
+      >
+        <span class="material-icons text-base">arrow_back</span>
+      </button>
+      <h2 class="text-lg font-semibold text-gray-800 truncate">{{ displayTitle }}</h2>
+    </div>
+    <div class="flex items-center gap-2">
+      <template v-if="(action === 'page' || action === 'page-edit') && hasContent">
+        <button
+          class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          :disabled="pdfDownloading"
+          @click="emit('downloadPdf')"
+        >
+          <span class="material-icons text-base">{{ pdfDownloading ? "hourglass_empty" : "download" }}</span>
+          {{ $t("pluginWiki.pdf") }}
+        </button>
+        <button
+          class="h-8 px-2.5 flex items-center gap-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 text-sm disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          :disabled="zipDownloading"
+          data-testid="wiki-zip-button"
+          @click="emit('downloadZip')"
+        >
+          <span class="material-icons text-base">{{ zipDownloading ? "hourglass_empty" : "folder_zip" }}</span>
+          {{ $t("common.downloadZip") }}
+        </button>
+        <span v-if="pdfError" class="text-xs text-red-500" :title="pdfError">{{ $t("pluginWiki.pdfFailed") }}</span>
+        <span v-if="zipFailed" class="text-xs text-red-500">{{ $t("common.downloadFailed") }}</span>
+      </template>
+      <button
+        v-if="action === 'index'"
+        class="h-8 px-2.5 flex items-center gap-1 rounded bg-green-600 hover:bg-green-700 text-white text-sm transition-colors"
+        data-testid="wiki-lint-chat-button"
+        @click="emit('lintChat')"
+      >
+        <span class="material-icons text-base">rule</span>
+        {{ $t("pluginWiki.lintChat") }}
+      </button>
+      <div class="flex border border-gray-300 rounded overflow-hidden">
+        <button
+          :class="[
+            'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+            action === 'index' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+          ]"
+          @click="emit('navigate', WIKI_ACTION.index)"
+        >
+          <span class="material-icons text-sm">list</span>
+          <span>{{ $t("pluginWiki.tabIndex") }}</span>
+        </button>
+        <button
+          :class="[
+            'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+            action === 'log' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+          ]"
+          @click="emit('navigate', WIKI_ACTION.log)"
+        >
+          <span class="material-icons text-sm">history</span>
+          <span>{{ $t("pluginWiki.tabLog") }}</span>
+        </button>
+        <button
+          :class="[
+            'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+            action === 'lint_report' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+          ]"
+          @click="emit('navigate', WIKI_ACTION.lintReport)"
+        >
+          <span class="material-icons text-sm">rule</span>
+          <span>{{ $t("pluginWiki.tabLint") }}</span>
+        </button>
+        <button
+          :class="[
+            'h-8 px-2.5 flex items-center gap-1 border-r border-gray-200 last:border-r-0 transition-colors',
+            action === 'graph' ? 'bg-blue-50 text-blue-600 font-medium' : 'bg-white text-gray-600 hover:bg-gray-50',
+          ]"
+          data-testid="wiki-tab-graph"
+          @click="emit('navigate', WIKI_ACTION.graph)"
+        >
+          <span class="material-icons text-sm">hub</span>
+          <span>{{ $t("pluginWiki.tabGraph") }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { WIKI_ACTION } from "@mulmoclaude/core/wiki";
+import type { WikiTabView } from "../composables/useWikiNavigation";
+
+defineProps<{
+  action: string;
+  isStandaloneWikiRoute: boolean;
+  displayTitle: string;
+  hasContent: boolean;
+  pdfDownloading: boolean;
+  pdfError: string | null;
+  zipDownloading: boolean;
+  zipFailed: boolean;
+}>();
+
+const emit = defineEmits<{
+  back: [];
+  downloadPdf: [];
+  downloadZip: [];
+  lintChat: [];
+  navigate: [action: typeof WIKI_ACTION.index | WikiTabView];
+}>();
+</script>

--- a/src/plugins/wiki/components/WikiMetadataBar.vue
+++ b/src/plugins/wiki/components/WikiMetadataBar.vue
@@ -1,0 +1,61 @@
+<template>
+  <div
+    data-testid="wiki-page-metadata-bar"
+    class="shrink-0 border-b border-gray-100 px-6 py-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500"
+  >
+    <span v-if="meta.created" data-testid="wiki-page-metadata-created">
+      <span class="text-gray-400">{{ $t("pluginWiki.metadataCreated") }}:</span>
+      {{ meta.created }}
+    </span>
+    <span v-if="meta.updated" data-testid="wiki-page-metadata-updated">
+      <span class="text-gray-400">{{ $t("pluginWiki.metadataUpdated") }}:</span>
+      {{ formatUpdated(meta.updated) }}
+    </span>
+    <span v-if="meta.editor" data-testid="wiki-page-metadata-editor">
+      <span class="text-gray-400">{{ $t("pluginWiki.metadataEditor") }}:</span>
+      {{ meta.editor }}
+    </span>
+    <span v-if="meta.tags.length > 0" class="flex flex-wrap gap-1" data-testid="wiki-page-metadata-tags">
+      <button v-for="tag in meta.tags" :key="tag" class="entry-tag-chip" :data-testid="`wiki-page-metadata-tag-${tag}`" @click="emit('tagClick', tag)">
+        {{ `#${tag}` }}
+      </button>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatUpdated } from "../helpers";
+
+export interface WikiPageMeta {
+  created: string | null;
+  updated: string | null;
+  editor: string | null;
+  tags: string[];
+}
+
+defineProps<{ meta: WikiPageMeta }>();
+
+const emit = defineEmits<{ tagClick: [tag: string] }>();
+</script>
+
+<style scoped>
+/* Mirrors `.entry-tag-chip` in View.vue's scoped block — the index-list
+   per-entry chips keep their copy there. Scoped CSS can't cross the component
+   boundary, so the metadata-bar chips carry the rule locally. */
+.entry-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.375rem;
+  font-size: 0.7rem;
+  line-height: 1rem;
+  border-radius: 9999px;
+  background-color: #f3f4f6;
+  color: #4b5563;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.entry-tag-chip:hover {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+}
+</style>

--- a/src/plugins/wiki/composables/useTagFilter.ts
+++ b/src/plugins/wiki/composables/useTagFilter.ts
@@ -1,0 +1,53 @@
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import type { WikiPageEntry } from "../index";
+import { computeTagChips, computeTagCounts } from "../helpers";
+
+// One view-level knob for the adaptive cutoff; the counting + cutoff rules
+// themselves live in `computeTagCounts` / `computeTagChips` (helpers.ts, tested).
+const TARGET_FILTER_CHIPS = 20;
+
+export interface TagFilter {
+  selectedTag: Ref<string | null>;
+  tagCounts: ComputedRef<Map<string, number>>;
+  allTags: ComputedRef<[string, number][]>;
+  visibleEntries: ComputedRef<WikiPageEntry[]>;
+  toggleTagFilter: (tag: string) => void;
+  setTagFilter: (tag: string) => void;
+}
+
+export function useTagFilter(pageEntries: Ref<WikiPageEntry[]>, action: Ref<string>): TagFilter {
+  // View-local, not persisted to URL — kept ephemeral so it doesn't leak into
+  // bookmarks or the per-session stack history.
+  const selectedTag = ref<string | null>(null);
+
+  // Kept a separate computed from `allTags` so the fallback chip (an active
+  // filter the adaptive cutoff hides) can read a real count instead of
+  // understating a dropped non-singleton tag as 1.
+  const tagCounts = computed<Map<string, number>>(() => computeTagCounts(pageEntries.value));
+  const allTags = computed<[string, number][]>(() => computeTagChips(pageEntries.value, TARGET_FILTER_CHIPS));
+
+  const visibleEntries = computed(() => {
+    const tag = selectedTag.value;
+    if (tag === null) return pageEntries.value;
+    return pageEntries.value.filter((entry) => (entry.tags ?? []).includes(tag));
+  });
+
+  function toggleTagFilter(tag: string): void {
+    selectedTag.value = selectedTag.value === tag ? null : tag;
+  }
+
+  // Per-entry / metadata chips set the filter unconditionally — clicking a
+  // `#tag` chip should always filter to that tag, even when it's already the
+  // active filter (toggling here surprised users by clearing it instead).
+  function setTagFilter(tag: string): void {
+    selectedTag.value = tag;
+  }
+
+  // Clear the filter whenever we leave the index view — otherwise switching to
+  // Log / Lint and back leaves a stale filter active, which feels like a bug.
+  watch(action, (next) => {
+    if (next !== "index") selectedTag.value = null;
+  });
+
+  return { selectedTag, tagCounts, allTags, visibleEntries, toggleTagFilter, setTagFilter };
+}

--- a/src/plugins/wiki/composables/useWikiGraph.ts
+++ b/src/plugins/wiki/composables/useWikiGraph.ts
@@ -1,0 +1,62 @@
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { WIKI_ACTION, incomingLinks, type WikiGraph, type WikiGraphNode } from "@mulmoclaude/core/wiki";
+import type { WikiData } from "../index";
+import { apiPost } from "../../../utils/api";
+import { shouldLazyLoadGraph } from "../helpers";
+
+interface WikiGraphDeps {
+  action: Ref<string>;
+  pageExists: Ref<boolean>;
+  currentSlug: Ref<string | null>;
+  endpointBase: string;
+}
+
+export interface WikiGraphState {
+  graphData: Ref<WikiGraph | null>;
+  graphError: Ref<string | null>;
+  loadGraph: () => Promise<void>;
+  syncGraphFromResult: (data: Partial<WikiData> | undefined) => void;
+  linkedReferences: ComputedRef<WikiGraphNode[]>;
+}
+
+export function useWikiGraph(deps: WikiGraphDeps): WikiGraphState {
+  // Loaded lazily once per browsing session and reused for both the Graph tab
+  // and the per-page "Linked references" panel (the graph is global, so one
+  // fetch serves every page's backlinks). Refreshed on the Graph tab fetch and
+  // after a page save / restore so edited links propagate.
+  const graphData = ref<WikiGraph | null>(null);
+  const graphError = ref<string | null>(null);
+
+  async function loadGraph(): Promise<void> {
+    graphError.value = null;
+    const response = await apiPost<{ data?: { graph?: WikiGraph } }>(deps.endpointBase, { action: WIKI_ACTION.graph });
+    if (!response.ok) {
+      graphError.value = response.status === 0 ? response.error : `Wiki graph error ${response.status}: ${response.error}`;
+      return;
+    }
+    graphData.value = response.data.data?.graph ?? { nodes: [], edges: [] };
+  }
+
+  // Graph tab response carries the link graph directly. On a page view, lazily
+  // fetch the graph once so the "Linked references" panel has data.
+  function syncGraphFromResult(data: Partial<WikiData> | undefined): void {
+    if (data?.graph) {
+      // Clear any stale error from an earlier failed loadGraph so a fresh graph
+      // payload isn't hidden behind the error banner.
+      graphError.value = null;
+      graphData.value = data.graph;
+      return;
+    }
+    if (shouldLazyLoadGraph(deps.action.value, deps.pageExists.value, graphData.value !== null)) void loadGraph();
+  }
+
+  // Pages that link TO the page currently being viewed. Empty until the graph
+  // loads (lazily, on the first page view).
+  const linkedReferences = computed<WikiGraphNode[]>(() => {
+    const slug = deps.currentSlug.value;
+    if (graphData.value === null || slug === null) return [];
+    return incomingLinks(graphData.value, slug);
+  });
+
+  return { graphData, graphError, loadGraph, syncGraphFromResult, linkedReferences };
+}

--- a/src/plugins/wiki/composables/useWikiNavigation.ts
+++ b/src/plugins/wiki/composables/useWikiNavigation.ts
@@ -1,0 +1,61 @@
+import { computed, type ComputedRef } from "vue";
+import { useRoute, useRouter, isNavigationFailure } from "vue-router";
+import { WIKI_ACTION, WIKI_ROUTE_SECTION, buildWikiRouteParams, isSafeWikiSlug, type WikiTarget } from "@mulmoclaude/core/wiki";
+
+export type WikiTabView = typeof WIKI_ACTION.log | typeof WIKI_ACTION.lintReport | typeof WIKI_ACTION.graph;
+
+interface WikiNavigationDeps {
+  pageWikiRoute: string;
+  // Slug carried by an embedded manageWiki tool-result (WikiView mounted inside
+  // /chat). On the standalone /wiki route the URL param wins over this.
+  pageNameFromResult: () => string | null;
+}
+
+export interface WikiNavigation {
+  currentSlugReactive: ComputedRef<string | null>;
+  currentSlug: () => string | null;
+  isStandaloneWikiRoute: ComputedRef<boolean>;
+  pushWiki: (target: WikiTarget) => void;
+  navigate: (newAction: typeof WIKI_ACTION.index | WikiTabView) => void;
+  navigatePage: (pageName: string) => void;
+}
+
+export function useWikiNavigation(deps: WikiNavigationDeps): WikiNavigation {
+  const route = useRoute();
+  const router = useRouter();
+
+  // Prefer the URL on /wiki (source of truth for that route); fall back to the
+  // tool-result payload when WikiView is mounted as a manageWiki result inside
+  // /chat. `isSafeWikiSlug` guards traversal tokens — the router guard strips
+  // them from standalone /wiki URLs, but the tool-result payload arrives from
+  // the server/agent and can't assume that upstream filter.
+  const currentSlugReactive = computed<string | null>(() => {
+    const raw =
+      route.name === deps.pageWikiRoute && route.params.section === WIKI_ROUTE_SECTION.pages && typeof route.params.slug === "string"
+        ? route.params.slug
+        : deps.pageNameFromResult();
+    return isSafeWikiSlug(raw) ? raw : null;
+  });
+
+  // Imperative accessor for the same value, for call sites that read the slug
+  // at a specific moment (fetch endpoint, mid-flight save guard).
+  const currentSlug = (): string | null => currentSlugReactive.value;
+
+  const isStandaloneWikiRoute = computed(() => route.name === deps.pageWikiRoute);
+
+  function pushWiki(target: WikiTarget): void {
+    router.push({ name: deps.pageWikiRoute, params: buildWikiRouteParams(target) }).catch((err: unknown) => {
+      if (!isNavigationFailure(err)) console.error("[wiki] navigation failed:", err);
+    });
+  }
+
+  function navigate(newAction: typeof WIKI_ACTION.index | WikiTabView): void {
+    pushWiki(newAction === WIKI_ACTION.index ? { kind: "index" } : { kind: newAction });
+  }
+
+  function navigatePage(pageName: string): void {
+    pushWiki({ kind: "page", slug: pageName });
+  }
+
+  return { currentSlugReactive, currentSlug, isStandaloneWikiRoute, pushWiki, navigate, navigatePage };
+}

--- a/src/plugins/wiki/composables/useWikiPageEdit.ts
+++ b/src/plugins/wiki/composables/useWikiPageEdit.ts
@@ -1,0 +1,54 @@
+import { ref, type Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { loadPageEdit } from "../pageEditLoader";
+
+interface WikiPageEditDeps {
+  content: Ref<string>;
+}
+
+export interface WikiPageEditState {
+  // Snapshot's own timestamp (header subtitle); null once reset / not a snapshot.
+  pageEditTs: Ref<string | null>;
+  // Shown only when the snapshot was gc'd and we fell back to the live page.
+  pageEditBanner: Ref<string | null>;
+  // Flips on when neither the snapshot nor the live page survives.
+  pageEditDeleted: Ref<boolean>;
+  loadPageEditData: (slug: string, stamp: string) => Promise<void>;
+  resetPageEdit: () => void;
+}
+
+// `page-edit` action state (Stage 3a, #963). Populated when an LLM Write/Edit
+// toolResult is mounted: the body comes from the snapshot endpoint, not the
+// live-page /api/wiki fetch.
+export function useWikiPageEdit(deps: WikiPageEditDeps): WikiPageEditState {
+  const { t } = useI18n();
+  const pageEditTs = ref<string | null>(null);
+  const pageEditBanner = ref<string | null>(null);
+  const pageEditDeleted = ref(false);
+
+  function resetPageEdit(): void {
+    pageEditTs.value = null;
+    pageEditBanner.value = null;
+    pageEditDeleted.value = false;
+  }
+
+  async function loadPageEditData(slug: string, stamp: string): Promise<void> {
+    resetPageEdit();
+    deps.content.value = "";
+
+    const result = await loadPageEdit(slug, stamp);
+    if (result.kind === "snapshot") {
+      pageEditTs.value = result.ts;
+      deps.content.value = result.content;
+      return;
+    }
+    if (result.kind === "current") {
+      pageEditBanner.value = t("pluginWiki.snapshotExpired");
+      deps.content.value = result.content;
+      return;
+    }
+    pageEditDeleted.value = true;
+  }
+
+  return { pageEditTs, pageEditBanner, pageEditDeleted, loadPageEditData, resetPageEdit };
+}

--- a/src/plugins/wiki/composables/useWikiPageSave.ts
+++ b/src/plugins/wiki/composables/useWikiPageSave.ts
@@ -1,0 +1,96 @@
+import type { Ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { WIKI_ACTION } from "@mulmoclaude/core/wiki";
+import { apiPost } from "../../../utils/api";
+import { computeToggledContent } from "../helpers";
+
+interface WikiPageSaveDeps {
+  action: Ref<string>;
+  content: Ref<string>;
+  navError: Ref<string | null>;
+  currentSlug: () => string | null;
+  endpointBase: string;
+  refresh: () => Promise<boolean>;
+}
+
+export interface WikiPageSave {
+  onTaskCheckboxClick: (event: MouseEvent, target: HTMLInputElement) => void;
+}
+
+function revert(target: HTMLInputElement): void {
+  target.checked = !target.checked;
+}
+
+// Serialised POST chain for rapid task-checkbox clicks (#775): each click queues
+// onto the previous so a slower network can't reorder writes.
+// `saveQueueGeneration` invalidates older queued saves after a failure-triggered
+// refresh — their captured snapshots were computed against the now-discarded
+// optimistic state, so writing them would overwrite canonical server content.
+export function useWikiPageSave(deps: WikiPageSaveDeps): WikiPageSave {
+  const { t } = useI18n();
+  let taskPersistChain: Promise<unknown> = Promise.resolve();
+  let saveQueueGeneration = 0;
+
+  async function persistWikiPage(pageName: string, newContent: string, generation: number): Promise<void> {
+    // Stale queued save (a previous save failed + refresh discarded the
+    // optimistic state this snapshot was based on).
+    if (generation !== saveQueueGeneration) return;
+    // Navigation changed mid-flight — saving this snapshot to a different page
+    // would clobber unrelated state; the route/result watchers already load it.
+    if (deps.currentSlug() !== pageName) return;
+
+    const response = await apiPost<{ data?: { content?: string } }>(deps.endpointBase, {
+      action: WIKI_ACTION.save,
+      pageName,
+      content: newContent,
+    });
+
+    if (generation !== saveQueueGeneration) return;
+    if (deps.currentSlug() !== pageName) return;
+
+    if (!response.ok) {
+      deps.navError.value = response.status === 0 ? response.error : `Wiki save failed (${response.status}): ${response.error}`;
+      // The generation bump must come AFTER refresh: clicks arriving WHILE
+      // refresh is in flight capture the pre-bump generation, so bumping
+      // post-refresh invalidates them too.
+      await deps.refresh();
+      saveQueueGeneration += 1;
+      return;
+    }
+    deps.navError.value = null;
+  }
+
+  // `.catch` keeps the chain self-healing: an uncaught rejection would leave the
+  // chain permanently rejected and silently drop every later click. The error
+  // is already surfaced via navError inside persistWikiPage.
+  function queueSave(pageName: string, newContent: string): void {
+    const generation = saveQueueGeneration;
+    taskPersistChain = taskPersistChain.then(() => persistWikiPage(pageName, newContent, generation)).catch(() => undefined);
+  }
+
+  function onTaskCheckboxClick(event: MouseEvent, target: HTMLInputElement): void {
+    const root = event.currentTarget;
+    const pageName = deps.currentSlug();
+    // Only the live page view persists toggles; everything else is read-only.
+    if (deps.action.value !== WIKI_ACTION.page || !pageName || !(root instanceof HTMLElement)) {
+      revert(target);
+      return;
+    }
+
+    const result = computeToggledContent(target, root, deps.content.value);
+    if (result.status !== "toggled") {
+      // `mismatch` = source/DOM task-count drift; surface it. `skip` reverts
+      // silently (target not among the tasks, or an out-of-range toggle).
+      if (result.status === "mismatch") deps.navError.value = t("pluginWiki.taskCountMismatch");
+      revert(target);
+      return;
+    }
+
+    // Optimistic local update — re-render is driven by content's watcher.
+    deps.content.value = result.content;
+    deps.navError.value = null;
+    queueSave(pageName, result.content);
+  }
+
+  return { onTaskCheckboxClick };
+}

--- a/src/plugins/wiki/helpers.ts
+++ b/src/plugins/wiki/helpers.ts
@@ -4,7 +4,7 @@
 // wrapping (image-ref rewrite + marked + interactive task lists).
 
 import { marked } from "marked";
-import { renderWikiLinks } from "@mulmoclaude/core/wiki";
+import { renderWikiLinks, WIKI_ACTION } from "@mulmoclaude/core/wiki";
 import { rewriteMarkdownImageRefs } from "@mulmoclaude/markdown-utils/image/rewriteMarkdownImageRefs";
 import { findTaskLines, makeTasksInteractive, toggleTaskAt } from "@mulmoclaude/markdown-utils/markdown/taskList";
 import { splitFrontmatter } from "@mulmoclaude/markdown-utils/markdown/frontmatter";
@@ -87,6 +87,15 @@ export function computeTagChips(entries: readonly { tags?: readonly string[] }[]
   if (meaningful.length <= target) return meaningful;
   const [, cutoff] = meaningful[target - 1];
   return meaningful.filter(([, count]) => count >= cutoff);
+}
+
+/** Whether a page view should lazily fetch the global link graph to populate
+ *  its "Linked references" panel. The graph is global, so one fetch serves
+ *  every page — only fetch on a page that exists and only when the graph hasn't
+ *  already loaded. A wrong condition here fails silently (backlinks never
+ *  appear), so it is unit-tested. */
+export function shouldLazyLoadGraph(action: string, pageExists: boolean, hasGraph: boolean): boolean {
+  return action === WIKI_ACTION.page && pageExists && !hasGraph;
 }
 
 /** Outcome of a task-checkbox click, computed purely from the clicked

--- a/test/plugins/wiki/test_helpers.ts
+++ b/test/plugins/wiki/test_helpers.ts
@@ -9,6 +9,7 @@ import {
   computeTagCounts,
   computeTagChips,
   computeToggledContent,
+  shouldLazyLoadGraph,
 } from "../../../src/plugins/wiki/helpers.js";
 
 // Pin the timezone so `formatUpdated`'s local-time output is
@@ -248,6 +249,28 @@ describe("computeTagChips", () => {
 
   it("returns an empty array when every tag is a singleton", () => {
     assert.deepEqual(computeTagChips([{ tags: ["a", "b"] }, { tags: ["c"] }], 20), []);
+  });
+});
+
+describe("shouldLazyLoadGraph", () => {
+  it("loads on an existing page view when the graph is not yet loaded", () => {
+    assert.equal(shouldLazyLoadGraph("page", true, false), true);
+  });
+
+  it("does not load when the graph is already loaded", () => {
+    assert.equal(shouldLazyLoadGraph("page", true, true), false);
+  });
+
+  it("does not load when the page does not exist", () => {
+    assert.equal(shouldLazyLoadGraph("page", false, false), false);
+  });
+
+  it("does not load on non-page actions", () => {
+    assert.equal(shouldLazyLoadGraph("index", true, false), false);
+    assert.equal(shouldLazyLoadGraph("log", true, false), false);
+    assert.equal(shouldLazyLoadGraph("lint_report", true, false), false);
+    assert.equal(shouldLazyLoadGraph("graph", true, false), false);
+    assert.equal(shouldLazyLoadGraph("page-edit", true, false), false);
   });
 });
 


### PR DESCRIPTION
## Summary

Advances #2300 (the next step after the safe-layer PR #2382, which extracted pure
helpers only). Breaks the 1029-line `src/plugins/wiki/View.vue` into child
components and composables so the parent becomes an orchestrator.

**Before / after:** `View.vue` **1029 → 681 lines** (−348, −34%).

**Slices:**

Composables (script only — zero DOM impact) under `src/plugins/wiki/composables/`:
| Composable | Owns |
|---|---|
| `useWikiNavigation.ts` | `pushWiki` / `navigate` / `navigatePage` / `currentSlug()` / `currentSlugReactive` / `isStandaloneWikiRoute` |
| `useTagFilter.ts` | `selectedTag` / `tagCounts` / `allTags` / `visibleEntries` / `toggleTagFilter` / `setTagFilter` + clear-on-leave watcher |
| `useWikiGraph.ts` | `graphData` / `graphError` / `loadGraph` / `syncGraphFromResult` / `linkedReferences` |
| `useWikiPageSave.ts` | task-checkbox serialised save chain (`persistWikiPage` / `onTaskCheckboxClick`) |
| `useWikiPageEdit.ts` | `pageEditTs` / `pageEditBanner` / `pageEditDeleted` / `loadPageEditData` / `resetPageEdit` |

Child components (single-root, off the xpath path) under `src/plugins/wiki/components/`:
| Component | Region |
|---|---|
| `WikiHeader.vue` | header row (tabs, PDF/ZIP, lint-chat, back) — props in, `emit` out |
| `WikiMetadataBar.vue` | `created` / `updated` / `editor` / `tags` frontmatter bar |

Pure logic: added `shouldLazyLoadGraph(action, pageExists, hasGraph)` to `helpers.ts`
(the branch exposed by moving `syncGraphFromResult`) with unit tests. Also DRYed the
two identical `currentSlug()` / `currentSlugReactive` bodies into one.

## Items to Confirm / Review

- **DOM / testid / xpath unchanged (the load-bearing claim).** All **25 `data-testid`s**
  keep their exact string, DOM nesting, and layout classes (verified by diffing the
  testid set of the old file against the new `View.vue` + `WikiHeader.vue` +
  `WikiMetadataBar.vue` — identical). Composables move script only. The two child
  components are single-root, so their emitted DOM is byte-equivalent to the inlined
  markup.
- **xpath scroll test specifically.** The issue warned about
  `e2e/tests/wiki-navigation.spec.ts:216` (`wikiBody.locator("xpath=..")`), which
  depends on `wiki-page-body`'s **direct DOM parent** being the `ref="scrollRef"` div.
  That region and every `scrollRef`-bearing div were left **completely untouched** —
  no extraction wraps or relocates them. The mock e2e run confirms it: **26/26 passed**,
  including "clicking an in-content `[[wiki-link]]` resets scrollTop on the destination
  page".
- **Deliberately NOT split** (documented in `plans/refactor-2300-wiki-split.md`): the
  page content tab body, the index list, the page-edit / log bodies, the page-tab strip,
  and per-page empty states — all sit on or next to `scrollRef` / xpath-traversed DOM.
  Candidates for a follow-up only if the spec is first moved to a testid basis.
- **Scoped-style note:** `WikiMetadataBar.vue` carries its own copy of the
  `.entry-tag-chip` rule (scoped CSS can't cross the component boundary); `View.vue`
  keeps its copy for the index-list chips. Small, intentional duplication.

## User Prompt

> Advance issue #2300 — split `src/plugins/wiki/View.vue` into smaller
> components/composables — as the next step beyond the safe-layer PR (#2382), which
> extracted pure helpers only. This is part of pushing the #2298–#2301 splits past the
> safe layer. Respect the e2e constraints: the file has 25 `data-testid`s and the issue
> title warns "xpath 依存の e2e に注意" — rendered DOM must stay behavior-identical
> (never rename/remove/reorder a testid, never change DOM nesting the xpath e2e
> traverses). If further splitting is too risky for the xpath e2e, don't force it —
> ship the safe slice or recommend closing. Open a PR (do not merge).

## Approach

- **Composables first (safest):** they move only script, so they carry no xpath/testid
  risk and delivered the bulk of the reduction. Data-fetch orchestration
  (`callApi` / `applyWikiResult` / `useFreshPluginData` / the two watchers / `onMounted`)
  stays in the parent — it writes the shared view refs, emits `updateResult`, and wires
  the composables together. `navError` stays declared early (TDZ: the `immediate: true`
  URL watcher runs `callApi` synchronously during setup).
- **Only clearly-safe template extractions:** header and metadata bar — both single-root,
  off the xpath path, and free of `scrollRef`. The `v-if` guarding each region stays on
  the parent `<WikiHeader>` / `<WikiMetadataBar>` tag, so conditional rendering is
  identical. No function props (`emit` only); `$t()` for text in the new components.

## Verification

All green (no version bumps):
- `yarn format`, `yarn lint` (0 errors), `yarn typecheck` (full repo), `yarn build` — pass
- Unit tests — pass (adds `shouldLazyLoadGraph` cases; the existing pure-helper suite
  already covers `metaString` / `formatUpdated` / `computeTagChips` / `computeToggledContent`)
- `wiki-navigation` mock e2e (chromium) — **26/26 passed**, including the xpath scroll test

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refreshed wiki header navigation with page actions, tabs, downloads, and lint tools.
  * Added a metadata bar displaying timestamps, editor details, and clickable tags.
  * Improved wiki navigation, tag filtering, graph views, page editing, and task updates.
  * Added lazy loading for linked-reference graphs when needed.

* **Bug Fixes**
  * Improved page-edit refresh handling and prevented stale updates after failed saves.

* **Tests**
  * Added coverage for graph-loading behavior across wiki views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->