### PR TITLE
chore(ci): exclude generated plugin barrels from the jscpd duplication scan (#2464)

### DIFF
--- a/.github/workflows/duplication-scan.yaml
+++ b/.github/workflows/duplication-scan.yaml
@@ -94,6 +94,10 @@ jobs:
       # duplicate by nature, and the 528 extra findings they bring would
       # drown the ~186 that are actually worth reading.
       #
+      # `**/_generated/**` is excluded: codegen output (the plugin barrels
+      # from scripts/codegen-plugin-barrels.ts) duplicates by nature and
+      # is regenerated, never hand-refactored.
+      #
       # The test globs are written `**/test/**` rather than `test/**` to
       # say "any test dir, at any depth" out loud — packages/*/test/ has
       # to be excluded too. jscpd's --ignore globs are unanchored, so the
@@ -104,7 +108,7 @@ jobs:
           set -euo pipefail
           jscpd . \
             --format typescript \
-            --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/test/**,**/e2e/**,**/e2e-live/**,**/spreadsheet/engine/**" \
+            --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/test/**,**/e2e/**,**/e2e-live/**,**/spreadsheet/engine/**,**/_generated/**" \
             --reporters console,sarif \
             --output report
 


### PR DESCRIPTION
## Summary

`.github/workflows/duplication-scan.yaml` の jscpd `--ignore` グロブに `**/_generated/**` を追加。`src/plugins/_generated/metas.ts` ↔ `server-bindings.ts` は `scripts/codegen-plugin-barrels.ts` による AUTO-GENERATED ファイルで、import 行の重複は codegen の性質上不可避のため、スキャン対象から除外する(Code Scanning alert #313 対応)。あわせてワークフロー内の除外理由コメントに 1 行追記。

## Items to Confirm / Review

- alert #313 はマージ後の次回 main 解析で自動クローズされる想定(このワークフローは report-only、alert は base branch との差分で管理されるため)。クローズを確認してください。
- `**/_generated/**` が手書きコードを隠さないことの確認: リポジトリ全体(node_modules 除く)を `find -type d -name '_generated'` で走査し、該当は `src/plugins/_generated/` の 1 箇所のみ。中身は `metas.ts` / `registrations.ts` / `server-bindings.ts` の 3 ファイルで、全て先頭に `// AUTO-GENERATED by scripts/codegen-plugin-barrels.ts. DO NOT EDIT.` ヘッダーを持つ codegen 出力であることを確認済み。
- `yarn lint` は `.github/` を対象にしないためスキップ(ワークフローのみの変更)。代わりにローカルで `actionlint` を実行し、パスを確認済み。

## User Prompt

- "https://github.com/receptron/mulmoclaude/security/code-scanning コードの重複、消せるものをissue化して消していきたい"
- "調査終わったら並列で進めて"

## 実装アプローチ

- `**/spreadsheet/engine/**` を `--ignore` で除外した既存の前例に倣い、`**/_generated/**` をグロブ末尾に追加。generator 側での共通化は、`metas.ts`(META のみ import)と `server-bindings.ts`(definition + meta + mcpEndpoint を import)で必要な import 集合が正当に異なるため見送り(issue 参照)。
- 検証: ワークフローと同一の jscpd 5.0.12 バイナリでリポジトリルートから新旧の `--ignore` 文字列で各 1 回スキャンし、JSON レポートを diff。
  - 旧: **40 clones** → 新: **39 clones**
  - 消えたのは `src/plugins/_generated/metas.ts` (10–20) ↔ `server-bindings.ts` (22–32) の 1 件のみで、他の clone リストは完全一致(新規追加なし)。

Closes #2464

🤖 Generated with [Claude Code](https://claude.com/claude-code)