### PR TITLE
fix: settle a pending confirm before replacing state in shared confirm.ts (#2463)

### DIFF
--- a/packages/plugins/shared/components/confirm.ts
+++ b/packages/plugins/shared/components/confirm.ts
@@ -1,3 +1,7 @@
+// Promise-based confirm dialog state, plugin-side mirror of
+// `src/composables/useConfirm.ts` — see the header note there for
+// why the two files stay separate (useRuntime vs vue-i18n locale).
+
 import { ref } from "vue";
 
 export interface ConfirmOptions {
@@ -33,6 +37,12 @@ export function useConfirm() {
     const opts = typeof options === "string" ? { message: options } : options;
 
     return new Promise<boolean>((resolve) => {
+      // If a previous confirm is still pending, settle it as
+      // "cancelled" before replacing the state. Without this the
+      // earlier `Promise<boolean>` would hang forever and any
+      // caller `await`ing it would deadlock.
+      const previous = confirmState.value.resolve;
+      if (previous) previous(false);
       confirmState.value = {
         isOpen: true,
         title: opts.title || "",

--- a/plans/fix-2463-confirm-pending-promise.md
+++ b/plans/fix-2463-confirm-pending-promise.md
@@ -1,0 +1,36 @@
+# fix: settle a pending confirm before replacing state in the plugin-side confirm mirror (#2463)
+
+## Problem
+
+`packages/plugins/shared/components/confirm.ts` is the plugin-side mirror of
+`src/composables/useConfirm.ts` (the two stay separate on purpose: the plugin
+side pulls locale from `useRuntime`, the host side from vue-i18n — see the
+header note in `useConfirm.ts`). The host copy settles a still-pending confirm
+as `false` before `openConfirm` replaces the state; the plugin copy does not,
+so opening a second confirm while one is pending leaves the first
+`Promise<boolean>` unresolved forever and the caller `await`ing it hangs.
+
+## Fix
+
+- Port the host's settle-previous block (comment included, verbatim) into the
+  plugin copy's `openConfirm`.
+- Add a reciprocal mirror-note header to the plugin copy pointing at
+  `src/composables/useConfirm.ts`, so future edits to either file know to keep
+  them in sync (the missing note is how this drift happened).
+- Consumer check: `packages/plugins/recipe-book-plugin/src/View.vue` only does
+  `!(await openConfirm(...))` for delete confirmation — a superseded confirm
+  now resolves `false` → early return, no delete. Nothing relied on the old
+  hanging behavior.
+
+## Test
+
+`test/plugins/shared/test_confirm.ts` (node:test, vue `ref` runs headless under
+`tsx --test` like the other `test/composables`/`test/plugins` suites): open →
+open again → first promise resolves `false` (checked via `Promise.race` so a
+regression fails red instead of hanging), plus the plain resolve/clear path.
+Mutation-checked by removing the ported lines.
+
+## Out of scope
+
+Merging the two files — blocked on the host/plugin runtime split; jscpd alerts
+#257/#258 for this pair remain KEEP.

--- a/test/plugins/shared/test_confirm.ts
+++ b/test/plugins/shared/test_confirm.ts
@@ -1,0 +1,50 @@
+// The plugin-side confirm mirror must settle a still-pending confirm
+// as "cancelled" before replacing state (same rule as the host mirror
+// `src/composables/useConfirm.ts`) — otherwise the earlier caller's
+// `await` hangs forever.
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { confirmState, useConfirm } from "../../../packages/plugins/shared/components/confirm";
+
+const settleProbe = async (promise: Promise<boolean>): Promise<{ pending: boolean; value: boolean | null }> => {
+  const probe: { pending: boolean; value: boolean | null } = { pending: true, value: null };
+  void promise.then((value) => {
+    probe.pending = false;
+    probe.value = value;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  return probe;
+};
+
+describe("plugins/shared confirm", () => {
+  const { openConfirm, handleConfirm } = useConfirm();
+
+  afterEach(() => {
+    if (confirmState.value.resolve) {
+      handleConfirm(false);
+    }
+  });
+
+  it("resolves via handleConfirm and clears state", async () => {
+    const pending = openConfirm("delete?");
+    assert.equal(confirmState.value.isOpen, true);
+    assert.equal(confirmState.value.message, "delete?");
+    handleConfirm(true);
+    assert.equal(await pending, true);
+    assert.equal(confirmState.value.isOpen, false);
+    assert.equal(confirmState.value.resolve, null);
+  });
+
+  it("settles a still-pending confirm as false when a new confirm replaces it", async () => {
+    const first = openConfirm({ title: "First", message: "first?" });
+    const second = openConfirm({ title: "Second", message: "second?" });
+
+    assert.deepEqual(await settleProbe(first), { pending: false, value: false });
+    assert.equal(confirmState.value.message, "second?");
+
+    handleConfirm(true);
+    assert.equal(await second, true);
+  });
+});


### PR DESCRIPTION
## Summary

`packages/plugins/shared/components/confirm.ts` (the plugin-side mirror of `src/composables/useConfirm.ts`) was missing the host-side fix that settles a still-pending confirm before `openConfirm` replaces the state. Opening a second confirm while one was pending left the first `Promise<boolean>` unresolved forever, hanging any caller `await`ing it. This PR ports the host's settle-previous block verbatim into the plugin copy, adds a reciprocal mirror-note header, and pins the behavior with a node:test regression test.

## Items to Confirm / Review

- This makes the plugin copy a **true mirror** of the host copy again: the ported block (comment included) is byte-identical to `src/composables/useConfirm.ts`. Pre-existing cosmetic differences outside the ported code (blank line after `const opts`, `handleConfirm` return-type annotation, multi-line return object) were deliberately left untouched to keep the diff minimal.
- The two files intentionally stay **separate** (documented i18n split: plugin side pulls locale via `useRuntime`, host side via vue-i18n — see the header note in `useConfirm.ts`), so the jscpd alerts #257/#258 for this pair remain **KEEP**.
- A reciprocal mirror-note header was added to the plugin copy pointing at `src/composables/useConfirm.ts` — the missing note on the plugin side is how this drift went unnoticed. Please confirm this addition is wanted.
- Consumer check: `packages/plugins/recipe-book-plugin/src/View.vue` only does `!(await openConfirm(...))` for delete confirmation. A superseded confirm now resolves `false` → early return, no delete. Nothing relied on the old hanging behavior.
- The new test (`test/plugins/shared/test_confirm.ts`) was mutation-checked: with the ported lines removed it fails red (via a settle-probe + `setImmediate` flush, so a regression fails fast instead of hanging the runner); with them present it passes.

## User Prompt

- "https://github.com/receptron/mulmoclaude/security/code-scanning コードの重複、消せるものをissue化して消していきたい"
- "調査終わったら並列で進めて"

## 実装アプローチ

1. **修正の移植**: host 側 `useConfirm.ts` の settle-previous ブロック(コメント含む)を plugin 側 `confirm.ts` の `openConfirm` にそのまま移植。pending 中の confirm は state 置き換え前に `false`(cancelled)で解決される。
2. **ミラー注記**: plugin 側にも host 側を指す相互参照ヘッダコメントを追加(drift の再発防止。統合できない理由は host 側ヘッダに記載済みのためそちらを参照する形)。
3. **テスト**: `test/plugins/shared/test_confirm.ts` を追加(node:test + tsx、vue の `ref` は headless で動作 — 既存の `test/composables/` / `test/plugins/` と同じレイアウト)。「open → open again → 先行 promise が `false` で解決」を settle-probe(`setImmediate` flush)で検証し、壊れたコードではハングではなく即 red になるようにした。移植行を削除して red になることを確認済み(mutation check)。
4. **plan**: `plans/fix-2463-confirm-pending-promise.md` を追加。
5. **ゲート**: `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` すべて green(fresh worktree のため `yarn build:packages` で workspace dist を先にブートストラップ)。

Closes #2463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
