### PR TITLE
fix(scheduler): harden TasksTab refetch, remount, delete, and i18n

### DIFF
--- a/plans/refactor-plugin-pure-sweep.md
+++ b/plans/refactor-plugin-pure-sweep.md
@@ -52,9 +52,9 @@ These are verified or plausible but out of scope for a mechanical fix-plus-test 
   The `coalescingSaver` extraction (E2) falls out of the C6/C9 fix.
 - **photoLocations**: declared `locations-changed` pubsub channel wired nowhere
   (stale list until remount).
-- **scheduler TasksTab**: unsequenced refetch races; full-list remount on every
+- ~~**scheduler TasksTab**: unsequenced refetch races; full-list remount on every
   mutation (scroll/expand reset); unconfirmed one-click delete; hardcoded English
-  frequency-hint labels (8-locale change).
+  frequency-hint labels (8-locale change).~~ **Shipped (fix/scheduler-tasks-robustness).**
 - **manageSkills**: same-repo update/uninstall overlap; four loaders sharing one
   `catalogError` channel; post-delete selection clobber; `actionLock` extraction
   (release-if-owner).

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -780,6 +780,12 @@ const deMessages = {
     detailsToggle: "Details anzeigen",
     promptLabel: "Prompt",
     roleLabel: "Rolle",
+    confirmDelete: "Aufgabe {name} löschen? Dies kann nicht rückgängig gemacht werden.",
+    hintNewsRss: "News- / RSS-Abruf",
+    hintJournal: "Täglicher Journallauf",
+    hintWiki: "Wiki-Wartung",
+    hintMemory: "Speicherextraktion",
+    hintCalendar: "Kalender- / Kontaktsynchronisierung",
   },
   pluginCanvas: {
     undo: "Rückgängig",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -790,6 +790,12 @@ const enMessages = {
     detailsToggle: "Show details",
     promptLabel: "Prompt",
     roleLabel: "Role",
+    confirmDelete: 'Delete the task "{name}"? This cannot be undone.',
+    hintNewsRss: "News / RSS fetch",
+    hintJournal: "Journal daily pass",
+    hintWiki: "Wiki maintenance",
+    hintMemory: "Memory extraction",
+    hintCalendar: "Calendar / contact sync",
   },
   pluginCanvas: {
     undo: "Undo",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -776,6 +776,12 @@ const esMessages = {
     detailsToggle: "Mostrar detalles",
     promptLabel: "Prompt",
     roleLabel: "Rol",
+    confirmDelete: "¿Eliminar la tarea « {name} »? Esta acción no se puede deshacer.",
+    hintNewsRss: "Obtención de noticias / RSS",
+    hintJournal: "Pase diario del diario",
+    hintWiki: "Mantenimiento del wiki",
+    hintMemory: "Extracción de memoria",
+    hintCalendar: "Sincronización de calendario / contactos",
   },
   pluginCanvas: {
     undo: "Deshacer",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -770,6 +770,12 @@ const frMessages = {
     detailsToggle: "Afficher les détails",
     promptLabel: "Prompt",
     roleLabel: "Rôle",
+    confirmDelete: "Supprimer la tâche « {name} » ? Cette action est irréversible.",
+    hintNewsRss: "Récupération actualités / RSS",
+    hintJournal: "Passage quotidien du journal",
+    hintWiki: "Maintenance du wiki",
+    hintMemory: "Extraction de mémoire",
+    hintCalendar: "Synchronisation agenda / contacts",
   },
   pluginCanvas: {
     undo: "Annuler",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -764,6 +764,12 @@ const jaMessages = {
     detailsToggle: "詳細を表示",
     promptLabel: "プロンプト",
     roleLabel: "ロール",
+    confirmDelete: "タスク「{name}」を削除しますか？この操作は取り消せません。",
+    hintNewsRss: "ニュース / RSS 取得",
+    hintJournal: "日次ジャーナル処理",
+    hintWiki: "Wiki メンテナンス",
+    hintMemory: "メモリー抽出",
+    hintCalendar: "カレンダー / 連絡先の同期",
   },
   pluginCanvas: {
     undo: "元に戻す",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -762,6 +762,12 @@ const koMessages = {
     detailsToggle: "상세 보기",
     promptLabel: "프롬프트",
     roleLabel: "역할",
+    confirmDelete: "작업 「{name}」을(를) 삭제하시겠습니까? 되돌릴 수 없습니다.",
+    hintNewsRss: "뉴스 / RSS 가져오기",
+    hintJournal: "일일 저널 처리",
+    hintWiki: "위키 유지 관리",
+    hintMemory: "메모리 추출",
+    hintCalendar: "캘린더 / 연락처 동기화",
   },
   pluginCanvas: {
     undo: "실행 취소",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -767,6 +767,12 @@ const ptBRMessages = {
     detailsToggle: "Mostrar detalhes",
     promptLabel: "Prompt",
     roleLabel: "Função",
+    confirmDelete: "Excluir a tarefa « {name} »? Esta ação não pode ser desfeita.",
+    hintNewsRss: "Busca de notícias / RSS",
+    hintJournal: "Passagem diária do diário",
+    hintWiki: "Manutenção do wiki",
+    hintMemory: "Extração de memória",
+    hintCalendar: "Sincronização de calendário / contatos",
   },
   pluginCanvas: {
     undo: "Desfazer",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -750,6 +750,12 @@ const zhMessages = {
     detailsToggle: "显示详情",
     promptLabel: "提示词",
     roleLabel: "角色",
+    confirmDelete: "删除任务「{name}」？此操作无法撤销。",
+    hintNewsRss: "新闻 / RSS 抓取",
+    hintJournal: "每日日志处理",
+    hintWiki: "Wiki 维护",
+    hintMemory: "记忆提取",
+    hintCalendar: "日历 / 联系人同步",
   },
   pluginCanvas: {
     undo: "撤销",

--- a/src/plugins/scheduler/TasksTab.vue
+++ b/src/plugins/scheduler/TasksTab.vue
@@ -23,8 +23,8 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="hint in FREQUENCY_HINTS" :key="hint.label" class="border-b border-gray-50 last:border-0">
-              <td class="px-3 py-1">{{ hint.label }}</td>
+            <tr v-for="hint in FREQUENCY_HINTS" :key="hint.labelKey" class="border-b border-gray-50 last:border-0">
+              <td class="px-3 py-1">{{ t(hint.labelKey) }}</td>
               <td class="px-3 py-1 font-mono text-gray-700">{{ formatSchedule(hint.schedule) }}</td>
             </tr>
           </tbody>
@@ -136,6 +136,7 @@ import { formatShortTime } from "../../utils/format/date";
 import { formatSchedule as formatTaskSchedule, type TaskSchedule as FormatterTaskSchedule } from "./formatSchedule";
 import { originKind, resultDotKind, nextEnabledState, type TaskOriginKind, type ResultDotKind } from "./taskDisplay";
 import { scrollIntoViewByTestId } from "../../utils/dom/scrollIntoViewByTestId";
+import { confirmItemDelete } from "../../utils/confirmDelete";
 
 const { t } = useI18n();
 
@@ -165,13 +166,13 @@ interface SchedulerTask {
   missedRunPolicy?: string;
 }
 
-// Structured (not pre-rendered) so daily rows route through formatTaskSchedule and pick up the viewer's local timezone.
-const FREQUENCY_HINTS: { label: string; schedule: FormatterTaskSchedule }[] = [
-  { label: "News / RSS fetch", schedule: { type: "interval", intervalMs: 3_600_000 } },
-  { label: "Journal daily pass", schedule: { type: "daily", time: "23:00" } },
-  { label: "Wiki maintenance", schedule: { type: "daily", time: "02:00" } },
-  { label: "Memory extraction", schedule: { type: "daily", time: "00:00" } },
-  { label: "Calendar / contact sync", schedule: { type: "interval", intervalMs: 14_400_000 } },
+// Structured (not pre-rendered) so daily rows route through formatTaskSchedule and pick up the viewer's local timezone. Labels are i18n keys (8-locale lockstep).
+const FREQUENCY_HINTS: { labelKey: string; schedule: FormatterTaskSchedule }[] = [
+  { labelKey: "pluginSchedulerTasks.hintNewsRss", schedule: { type: "interval", intervalMs: 3_600_000 } },
+  { labelKey: "pluginSchedulerTasks.hintJournal", schedule: { type: "daily", time: "23:00" } },
+  { labelKey: "pluginSchedulerTasks.hintWiki", schedule: { type: "daily", time: "02:00" } },
+  { labelKey: "pluginSchedulerTasks.hintMemory", schedule: { type: "daily", time: "00:00" } },
+  { labelKey: "pluginSchedulerTasks.hintCalendar", schedule: { type: "interval", intervalMs: 14_400_000 } },
 ];
 
 const tasks = ref<SchedulerTask[]>([]);
@@ -181,10 +182,19 @@ const mutationError = ref("");
 
 const endpoints = pluginEndpoints<SchedulerEndpoints>("scheduler");
 
+// Monotonic id so a slow list GET issued before a mutation can't land after
+// a newer one and overwrite the fresh snapshot with a stale row set.
+let fetchSeq = 0;
+
 async function fetchTasks(): Promise<void> {
-  loading.value = true;
+  const seq = ++fetchSeq;
+  // Full-screen loader only on the initial load. A refetch after a mutation
+  // keeps the list mounted, or the whole list would unmount and reset scroll
+  // position + every expanded <details> on each toggle/run/delete.
+  if (tasks.value.length === 0) loading.value = true;
   error.value = "";
   const result = await apiGet<{ tasks: SchedulerTask[] }>(endpoints.tasksList.url);
+  if (seq !== fetchSeq) return;
   loading.value = false;
   if (!result.ok) {
     error.value = result.error;
@@ -250,6 +260,8 @@ async function toggleEnabled(task: SchedulerTask): Promise<void> {
 }
 
 async function deleteTask(taskId: string): Promise<void> {
+  const name = tasks.value.find((task) => task.id === taskId)?.name ?? taskId;
+  if (!confirmItemDelete(t("pluginSchedulerTasks.confirmDelete", { name }))) return;
   mutationError.value = "";
   const url = buildRouteUrl(endpoints.taskDelete, { id: taskId });
   const result = await apiDelete(url);


### PR DESCRIPTION
## Summary

Follow-up to #2471's deferred list. Four verified bugs in `scheduler/TasksTab.vue`, all confirmed on current `main`:

1. **Unsequenced refetch race** — a slow list GET issued before a mutation could resolve *after* a newer one and overwrite the fresh snapshot with stale rows. Added a monotonic `fetchSeq`; only the latest response applies.
2. **Full-list remount on every mutation** — `fetchTasks` always set `loading=true`, so the whole list unmounted (scroll position + every expanded `<details>` reset) on each run/toggle/delete. The full-screen loader now shows only on the initial load.
3. **One-click unconfirmed permanent delete** — the trash button deleted immediately with no undo. Added the `confirmItemDelete` gate, matching the manageSkills / accounting delete-confirmation convention.
4. **Hardcoded English `FREQUENCY_HINTS` labels** in an otherwise localized table → moved to i18n keys across all **8 locales** (`hintNewsRss/Journal/Wiki/Memory/Calendar` + `confirmDelete`).

## Items to Confirm / Review

- **Delete confirmation UX**: now gated behind `window.confirm` (via `confirmItemDelete`). Consistent with manageSkills; confirm this is the desired behavior for user tasks.
- **i18n translations**: machine-assisted for the 7 non-English locales. `de` avoids typographic quotes per `.claude/rules/i18n-de.md`; `zh`/`ko` use corner brackets `「」`, `fr`/`es`/`pt-BR` use guillemets `« »`. A native check on wording is welcome.
- These are control-flow fixes (race guard, loader gating) — verified by reading; the plugin's pure units (`taskDisplay`, `formatSchedule`) already have tests and remain green. `dumpi18n` lockstep passes.

## User Prompt

> （#2471 マージ後）plan に残した見送り項目を順次やって

🤖 Generated with [Claude Code](https://claude.com/claude-code)