### PR TITLE
fix(wiki): stale-response tokens + honest snapshot-load failure

### DIFF
--- a/plans/refactor-plugin-pure-sweep.md
+++ b/plans/refactor-plugin-pure-sweep.md
@@ -62,9 +62,10 @@ These are verified or plausible but out of scope for a mechanical fix-plus-test 
   no re-entrancy guard on Enter; unconfirmed delete (needs new i18n key ×8);
   `alwaysActive` MCP tools shown as toggleable; refresh-failure swallowed;
   `RolesView.vue` is a ~561-line near-verbatim fork (every fix lands twice).
-- **wiki**: stale-response tokens for `callApi`/`loadPageEditData`; non-404
-  snapshot failure rendered as "page deleted"; renderer vs `WIKI_LINK_PATTERN`
-  divergence (core); save-queue extraction (`taskSaveQueue`).
+- **wiki**: ~~stale-response tokens for `callApi`/`loadPageEditData`; non-404
+  snapshot failure rendered as "page deleted"~~ **(shipped, fix/wiki-stale-response)**;
+  renderer vs `WIKI_LINK_PATTERN` divergence (core); save-queue extraction
+  (`taskSaveQueue`).
 - **textResponse / StackView**: speaker labels hardcoded English (×8);
   StackView duplicate capture-phase link handler (opens 2 tabs); StackView
   edit panel emits to nothing (silent edit loss); copy button copies rewritten

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -816,6 +816,7 @@ const deMessages = {
     metadataEditor: "Bearbeiter",
     pageEditHeader: "Wiki-Bearbeitung",
     snapshotExpired: "Snapshot abgelaufen — aktuelle Seite wird angezeigt",
+    snapshotLoadError: "Snapshot konnte nicht geladen werden — die Seite existiert möglicherweise noch. Bitte aktualisieren.",
     pageDeleted: "Seite gelöscht",
     history: {
       tabContent: "Inhalt",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -825,6 +825,7 @@ const enMessages = {
     metadataEditor: "Editor",
     pageEditHeader: "Wiki edit",
     snapshotExpired: "Snapshot expired — showing current page",
+    snapshotLoadError: "Couldn't load the snapshot — the page may still exist. Try refreshing.",
     pageDeleted: "Page deleted",
     history: {
       tabContent: "Content",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -811,6 +811,7 @@ const esMessages = {
     metadataEditor: "Editor",
     pageEditHeader: "Edición de wiki",
     snapshotExpired: "Instantánea expirada — mostrando la página actual",
+    snapshotLoadError: "No se pudo cargar la instantánea — es posible que la página aún exista. Actualiza la página.",
     pageDeleted: "Página eliminada",
     history: {
       tabContent: "Contenido",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -805,6 +805,7 @@ const frMessages = {
     metadataEditor: "Éditeur",
     pageEditHeader: "Édition du wiki",
     snapshotExpired: "Instantané expiré — affichage de la page actuelle",
+    snapshotLoadError: "Impossible de charger l'instantané — la page existe peut-être encore. Actualisez la page.",
     pageDeleted: "Page supprimée",
     history: {
       tabContent: "Contenu",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -799,6 +799,7 @@ const jaMessages = {
     metadataEditor: "編集者",
     pageEditHeader: "Wiki編集",
     snapshotExpired: "スナップショットが期限切れ — 現在のページを表示中",
+    snapshotLoadError: "スナップショットを読み込めませんでした — ページは存在する可能性があります。再読み込みしてください。",
     pageDeleted: "ページが削除されました",
     history: {
       tabContent: "本文",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -797,6 +797,7 @@ const koMessages = {
     metadataEditor: "편집자",
     pageEditHeader: "Wiki 편집",
     snapshotExpired: "스냅샷 만료됨 — 현재 페이지 표시 중",
+    snapshotLoadError: "스냅샷을 불러오지 못했습니다 — 페이지가 여전히 존재할 수 있습니다. 새로고침해 보세요.",
     pageDeleted: "페이지가 삭제되었습니다",
     history: {
       tabContent: "본문",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -802,6 +802,7 @@ const ptBRMessages = {
     metadataEditor: "Editor",
     pageEditHeader: "Edição do wiki",
     snapshotExpired: "Snapshot expirado — exibindo a página atual",
+    snapshotLoadError: "Não foi possível carregar o snapshot — a página pode ainda existir. Tente atualizar.",
     pageDeleted: "Página excluída",
     history: {
       tabContent: "Conteúdo",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -785,6 +785,7 @@ const zhMessages = {
     metadataEditor: "编辑者",
     pageEditHeader: "Wiki 编辑",
     snapshotExpired: "快照已过期 — 显示当前页面",
+    snapshotLoadError: "无法加载快照 — 页面可能仍然存在。请尝试刷新。",
     pageDeleted: "页面已删除",
     history: {
       tabContent: "正文",

--- a/src/plugins/wiki/View.vue
+++ b/src/plugins/wiki/View.vue
@@ -242,7 +242,13 @@
         >
           {{ pageEditBanner }}
         </div>
-        <div v-if="pageEditDeleted" class="flex items-center justify-center text-gray-400 text-sm py-12" data-testid="wiki-page-edit-deleted">
+        <div v-if="pageEditError" class="flex items-center justify-center text-gray-400 text-sm py-12" data-testid="wiki-page-edit-error">
+          <div class="text-center space-y-2">
+            <span class="material-icons text-4xl text-gray-300">cloud_off</span>
+            <p>{{ pageEditError }}</p>
+          </div>
+        </div>
+        <div v-else-if="pageEditDeleted" class="flex items-center justify-center text-gray-400 text-sm py-12" data-testid="wiki-page-edit-deleted">
           <div class="text-center space-y-2">
             <span class="material-icons text-4xl text-gray-300">delete</span>
             <p>{{ t("pluginWiki.pageDeleted") }}</p>
@@ -397,7 +403,7 @@ const { graphData, graphError, loadGraph, syncGraphFromResult, linkedReferences 
   endpointBase: wikiEndpoints.base,
 });
 
-const { pageEditTs, pageEditBanner, pageEditDeleted, loadPageEditData, resetPageEdit } = useWikiPageEdit({ content });
+const { pageEditTs, pageEditBanner, pageEditDeleted, pageEditError, loadPageEditData, resetPageEdit } = useWikiPageEdit({ content });
 
 watch(currentSlugReactive, (next, prev) => {
   if (next === prev) return;
@@ -473,9 +479,17 @@ function applyWikiResult(data: Partial<WikiData> | undefined): void {
   syncGraphFromResult(data);
 }
 
+// Monotonic token so a slow POST for one navigation can't apply after the
+// user has already navigated somewhere else (rapid page ↔ tab switching):
+// the older response would otherwise render a body that disagrees with the
+// URL until the next navigation.
+let callApiSeq = 0;
+
 async function callApi(body: Record<string, unknown>) {
+  const seq = ++callApiSeq;
   navError.value = null;
   const response = await apiPost<{ data?: Partial<WikiData> }>(wikiEndpoints.base, body);
+  if (seq !== callApiSeq) return;
   if (!response.ok) {
     navError.value = response.status === 0 ? response.error : `Wiki API error ${response.status}: ${response.error}`;
     return;

--- a/src/plugins/wiki/composables/useWikiPageEdit.ts
+++ b/src/plugins/wiki/composables/useWikiPageEdit.ts
@@ -11,8 +11,10 @@ export interface WikiPageEditState {
   pageEditTs: Ref<string | null>;
   // Shown only when the snapshot was gc'd and we fell back to the live page.
   pageEditBanner: Ref<string | null>;
-  // Flips on when neither the snapshot nor the live page survives.
+  // Flips on when neither the snapshot nor the live page survives (genuine deletion).
   pageEditDeleted: Ref<boolean>;
+  // Set on a transient load failure (network / 5xx) — the page may still exist.
+  pageEditError: Ref<string | null>;
   loadPageEditData: (slug: string, stamp: string) => Promise<void>;
   resetPageEdit: () => void;
 }
@@ -25,18 +27,26 @@ export function useWikiPageEdit(deps: WikiPageEditDeps): WikiPageEditState {
   const pageEditTs = ref<string | null>(null);
   const pageEditBanner = ref<string | null>(null);
   const pageEditDeleted = ref(false);
+  const pageEditError = ref<string | null>(null);
 
   function resetPageEdit(): void {
     pageEditTs.value = null;
     pageEditBanner.value = null;
     pageEditDeleted.value = false;
+    pageEditError.value = null;
   }
 
+  // Monotonic token so a slow load for one toolResult can't overwrite the
+  // state of a different one the user selected while it was in flight.
+  let loadToken = 0;
+
   async function loadPageEditData(slug: string, stamp: string): Promise<void> {
+    const token = ++loadToken;
     resetPageEdit();
     deps.content.value = "";
 
     const result = await loadPageEdit(slug, stamp);
+    if (token !== loadToken) return;
     if (result.kind === "snapshot") {
       pageEditTs.value = result.ts;
       deps.content.value = result.content;
@@ -47,8 +57,12 @@ export function useWikiPageEdit(deps: WikiPageEditDeps): WikiPageEditState {
       deps.content.value = result.content;
       return;
     }
+    if (result.kind === "error") {
+      pageEditError.value = t("pluginWiki.snapshotLoadError");
+      return;
+    }
     pageEditDeleted.value = true;
   }
 
-  return { pageEditTs, pageEditBanner, pageEditDeleted, loadPageEditData, resetPageEdit };
+  return { pageEditTs, pageEditBanner, pageEditDeleted, pageEditError, loadPageEditData, resetPageEdit };
 }

--- a/src/plugins/wiki/pageEditLoader.ts
+++ b/src/plugins/wiki/pageEditLoader.ts
@@ -9,7 +9,22 @@ import { pluginEndpoints } from "../api";
 import type { WikiEndpoints } from "./index";
 import { serializeWithFrontmatter } from "@mulmoclaude/markdown-utils/markdown/frontmatter";
 
-export type PageEditLoadResult = { kind: "snapshot"; content: string; ts: string } | { kind: "current"; content: string } | { kind: "deleted" };
+export type PageEditLoadResult =
+  { kind: "snapshot"; content: string; ts: string } | { kind: "current"; content: string } | { kind: "deleted" } | { kind: "error" };
+
+// A network failure (status 0) or a 5xx is transient — the page may well
+// exist. Reporting it as "deleted" is a factual lie the user can't recover
+// from without a manual reload.
+export const isTransientStatus = (status: number): boolean => status === 0 || status >= 500;
+
+// When neither the snapshot nor the live page yielded content, decide whether
+// that's a transient outage (report "error", recoverable) or a genuine
+// deletion (404 / exists:false). `current` is the failed live-page fetch.
+export const classifyLoadFailure = (snapStatus: number, current: { ok: boolean; status: number }): "error" | "deleted" => {
+  if (isTransientStatus(snapStatus)) return "error";
+  if (!current.ok && isTransientStatus(current.status)) return "error";
+  return "deleted";
+};
 
 interface SnapshotResponse {
   snapshot: {
@@ -37,17 +52,16 @@ export async function loadPageEdit(slug: string, stamp: string): Promise<PageEdi
     const { body, meta, ts } = snap.data.snapshot;
     return { kind: "snapshot", content: serializeWithFrontmatter(meta, body), ts };
   }
-  if (snap.status !== 404) {
-    // Network / 5xx: surface as deleted-equivalent for now. The
-    // banner stays neutral ("page deleted") rather than leaking
-    // transient errors into the UI; refresh recovers when the
-    // server is healthy again.
-    return { kind: "deleted" };
-  }
 
+  // Snapshot missing (gc'd → 404) or unreachable (transient) — try the live
+  // page. If it has content, show that; otherwise distinguish a transient
+  // outage from a genuine deletion.
   const current = await apiGet<CurrentPageResponse>(`${wikiEndpoints.base}?slug=${encodeURIComponent(slug)}`);
-  if (current.ok && current.data.data.pageExists && typeof current.data.data.content === "string") {
+  if (current.ok && current.data.data.pageExists === true && typeof current.data.data.content === "string") {
     return { kind: "current", content: current.data.data.content };
   }
-  return { kind: "deleted" };
+  // `status` only exists on the ApiResult failure branch; a successful-but-
+  // empty response (page exists:false) is a genuine deletion, not transient.
+  const currentStatus = current.ok ? 200 : current.status;
+  return { kind: classifyLoadFailure(snap.status, { ok: current.ok, status: currentStatus }) };
 }

--- a/test/plugins/wiki/test_pageEditClassify.ts
+++ b/test/plugins/wiki/test_pageEditClassify.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isTransientStatus, classifyLoadFailure } from "../../../src/plugins/wiki/pageEditLoader.js";
+
+describe("isTransientStatus", () => {
+  it("treats a network failure (status 0) as transient", () => {
+    assert.equal(isTransientStatus(0), true);
+  });
+
+  it("treats 5xx as transient", () => {
+    assert.equal(isTransientStatus(500), true);
+    assert.equal(isTransientStatus(503), true);
+  });
+
+  it("does not treat 404 / 4xx as transient", () => {
+    assert.equal(isTransientStatus(404), false);
+    assert.equal(isTransientStatus(400), false);
+  });
+});
+
+describe("classifyLoadFailure", () => {
+  // Regression: a snapshot 5xx used to be reported as "page deleted" for a
+  // page that exists.
+  it("reports error when the snapshot failed transiently", () => {
+    assert.equal(classifyLoadFailure(500, { ok: false, status: 404 }), "error");
+    assert.equal(classifyLoadFailure(0, { ok: false, status: 0 }), "error");
+  });
+
+  it("reports error when the live-page fallback failed transiently", () => {
+    assert.equal(classifyLoadFailure(404, { ok: false, status: 503 }), "error");
+    assert.equal(classifyLoadFailure(404, { ok: false, status: 0 }), "error");
+  });
+
+  // Snapshot gc'd (404) and the live page genuinely doesn't exist (200 ok but
+  // no content, or a 404) → the page really is gone.
+  it("reports deleted when both are genuine not-found", () => {
+    assert.equal(classifyLoadFailure(404, { ok: true, status: 200 }), "deleted");
+    assert.equal(classifyLoadFailure(404, { ok: false, status: 404 }), "deleted");
+  });
+});

--- a/test/plugins/wiki/test_pageEditLoader.ts
+++ b/test/plugins/wiki/test_pageEditLoader.ts
@@ -102,9 +102,23 @@ describe("loadPageEdit — snapshot gc'd", () => {
 });
 
 describe("loadPageEdit — transient failure", () => {
-  it("treats snapshot 5xx as deleted (no flicker, no exception)", async () => {
+  // A 5xx on both the snapshot and the live-page fallback is a transient
+  // outage, not a deletion — reporting "deleted" for a page that exists is a
+  // factual lie the user can't recover from. Now surfaced as "error".
+  it("treats a transient snapshot + live-page failure as error, not deleted", async () => {
     stubFetch(async () => jsonResponse(500, { error: "server exploded" }));
     const result = await loadPageEdit("topic", "stamp");
-    assert.equal(result.kind, "deleted");
+    assert.equal(result.kind, "error");
+  });
+
+  it("still recovers via the live page when only the snapshot 5xx's", async () => {
+    stubFetch(async (url) => {
+      if (typeof url === "string" && url.includes("/history/")) {
+        return jsonResponse(503, { error: "snapshot store down" });
+      }
+      return jsonResponse(200, { data: { action: "page", title: "T", content: "# live", pageExists: true } });
+    });
+    const result = await loadPageEdit("topic", "stamp");
+    assert.equal(result.kind, "current");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2471's deferred list, verified against the post-split wiki composables.

1. **`callApi` had no stale-response guard.** Rapid page ↔ tab navigation could resolve an older POST *after* a newer one and render a body that disagrees with the URL until the next navigation. Added a monotonic `callApiSeq`; only the latest response applies.
2. **`loadPageEditData` had no load token.** Selecting a different page-edit toolResult while a snapshot fetch was in flight could stamp the new selection with the old one's content/timestamp. Added a `loadToken` guard mirroring the history components' pattern.
3. **Every non-404 snapshot failure was reported as "page deleted".** During a backend restart / 5xx, a page that exists showed the "deleted" placeholder with no recovery path. Now `loadPageEdit` falls through to the live page on *any* snapshot failure, and distinguishes a transient outage (new `error` kind → neutral "couldn't load snapshot" banner) from a genuine deletion. The `isTransientStatus` / `classifyLoadFailure` rules are extracted as pure functions with unit tests (mutation-checked).

Adds `pluginWiki.snapshotLoadError` across all **8 locales**. Updated the existing `test_pageEditLoader` expectation (snapshot 5xx → `error`, not `deleted`).

## Items to Confirm / Review

- **New `error` kind vs `deleted`:** a snapshot 5xx now falls through to the live page; only if *both* fail transiently do we show the neutral error banner (icon `cloud_off`). Genuine 404 / `pageExists:false` still shows "page deleted". Confirm the copy and the fall-through behavior.
- Control-flow token guards (callApi / loadPageEditData) are verified by reading; the extracted classifier rules carry the tests.
- i18n `snapshotLoadError` wording is machine-assisted for the 7 non-English locales.

## User Prompt

> （#2471 マージ後）plan に残した見送り項目を順次やって

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated wiki responses from replacing content after rapid navigation.
  * Improved handling of temporary snapshot and network failures, distinguishing them from deleted pages.
  * Added a clear error state with guidance to refresh when a snapshot cannot be loaded.

* **Localization**
  * Added translated snapshot-loading error messages across supported languages.

* **Tests**
  * Expanded coverage for transient failures, missing pages, and live-page fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->