### PR TITLE
fix(spreadsheet): COUNTIF/SUMIF criteria match case-insensitively, with wildcards (#2360)

### DIFF
--- a/plans/fix-2360-countif-criteria.md
+++ b/plans/fix-2360-countif-criteria.md
@@ -1,0 +1,49 @@
+# fix(spreadsheet): COUNTIF/SUMIF criteria match case-insensitively, with wildcards (#2360)
+
+Two more "静かに間違う" cases from #2360 — both **undercount** without any error.
+
+| criteria                | cell   | before                      | Excel / now |
+| ----------------------- | ------ | --------------------------- | ----------- |
+| `COUNTIF(range, "yes")` | `Yes`  | 0 (no match)                | 1           |
+| `COUNTIF(range, "A*")`  | `Axle` | 0 (`A*` compared literally) | 1           |
+
+## Root cause
+
+`parseCriteria` (engine/registry.ts) finished with `String(v) === trimmedCriteria`:
+a case-sensitive, literal comparison. Excel matches criteria text
+case-insensitively and treats `*` / `?` as wildcards (`~` escapes them). The
+`=` / `<>` operator branches had the same literal comparison.
+
+## Fix
+
+Build the text test once per criteria with `textMatcher`:
+
+- `*` → any run of characters, `?` → exactly one, `~X` → literal `X`.
+- every other character is regex-escaped, so `a.c` matches only `a.c`.
+- the regex is anchored and case-insensitive (`iu`).
+
+`matchesTextOrNumber` combines it with the existing numeric equality, and both
+the bare-criteria path and `=` / `<>` use it (`<>` is its exact negation), so
+one rule covers every criteria form.
+
+## Behaviour changes to note
+
+- **VLOOKUP/HLOOKUP exact-match lookups also go through `parseCriteria`**
+  (`functions/lookup.ts`), so they are now case-insensitive and wildcard-aware —
+  which is also Excel's behaviour for an exact-match lookup.
+- Two tests in `test_registry.ts` pinned the OLD behaviour as a documented
+  limitation ("treats a wildcard as a literal character", "matching is
+  case-sensitive"); both are updated to the Excel behaviour.
+
+## Tests
+
+`test_criteria.ts` (new): case-insensitive match, non-match, `*` / `?` / `~`
+escape, regex metacharacters staying literal, numeric criteria, the comparison
+operators, `=` / `<>` case-insensitivity, and COUNTIF end-to-end through
+`SpreadsheetEngine`. Verified 7 of the 11 go red against a case-sensitive,
+literal matcher. Full engine suite green (672).
+
+## Still open in #2360
+
+`MID` negative length, `SUM` over multiple ranges, `TEXT` digit grouping,
+`VLOOKUP` out-of-range column, `VALUE("12abc")`.

--- a/src/plugins/spreadsheet/engine/registry.ts
+++ b/src/plugins/spreadsheet/engine/registry.ts
@@ -84,6 +84,35 @@ export function toString(value: CellValue): string {
   return String(value);
 }
 
+const REGEXP_METACHARACTERS = /[.*+?^${}()|[\]\\]/;
+
+const escapeRegExpChar = (char: string): string => (REGEXP_METACHARACTERS.test(char) ? `\\${char}` : char);
+
+/**
+ * Match text the way a spreadsheet criteria does: case-insensitively, with `*`
+ * standing for any run of characters, `?` for exactly one, and `~` escaping the
+ * next character. A plain `String(v) === criteria` missed both — `COUNTIF(range,
+ * "yes")` skipped a cell holding `Yes`, and `"A*"` was compared literally.
+ */
+function textMatcher(pattern: string): (text: string) => boolean {
+  const source: string[] = [];
+  for (let index = 0; index < pattern.length; index++) {
+    const char = pattern[index];
+    if (char === "~" && index + 1 < pattern.length) {
+      source.push(escapeRegExpChar(pattern[index + 1]));
+      index++;
+    } else if (char === "*") {
+      source.push(".*");
+    } else if (char === "?") {
+      source.push(".");
+    } else {
+      source.push(escapeRegExpChar(char));
+    }
+  }
+  const regex = new RegExp(`^${source.join("")}$`, "iu");
+  return (text) => regex.test(text);
+}
+
 /**
  * Helper to parse criteria for conditional functions like COUNTIF, SUMIF
  * Returns a comparison function that tests if a value matches the criteria
@@ -99,6 +128,9 @@ export function parseCriteria(criteria: string): (value: CellValue) => boolean {
     const [, op, value] = opMatch;
     const numValue = parseFloat(value);
 
+    // `=` / `<>` compare like the bare criteria does — case-insensitive text
+    // with wildcards, or the number. `<>` is exactly its negation.
+    const equals = matchesTextOrNumber(value);
     switch (op) {
       case ">":
         return (v) => toNumber(v) > numValue;
@@ -110,20 +142,23 @@ export function parseCriteria(criteria: string): (value: CellValue) => boolean {
         return (v) => toNumber(v) <= numValue;
       case "=":
       case "==":
-        return (v) => String(v) === value || toNumber(v) === numValue;
+        return equals;
       case "!=":
       case "<>":
-        return (v) => String(v) !== value && toNumber(v) !== numValue;
+        return (v) => !equals(v);
       default:
         return () => false;
     }
   }
 
-  // Exact match (string or number)
-  return (v) => {
-    const strMatch = String(v) === trimmedCriteria;
-    const numCriteria = parseFloat(trimmedCriteria);
-    const numMatch = !isNaN(numCriteria) && toNumber(v) === numCriteria;
-    return strMatch || numMatch;
-  };
+  return matchesTextOrNumber(trimmedCriteria);
+}
+
+/** A value matches when its text matches the criteria (case-insensitively, with
+ *  wildcards) or, for a numeric criteria, when its number is equal. */
+function matchesTextOrNumber(criteria: string): (value: CellValue) => boolean {
+  const matchesText = textMatcher(criteria);
+  const numCriteria = parseFloat(criteria);
+  const hasNumber = !isNaN(numCriteria);
+  return (value) => matchesText(String(value)) || (hasNumber && toNumber(value) === numCriteria);
 }

--- a/test/plugins/spreadsheet/engine/test_criteria.ts
+++ b/test/plugins/spreadsheet/engine/test_criteria.ts
@@ -1,0 +1,89 @@
+// Criteria matching for COUNTIF / SUMIF / AVERAGEIF. Both bugs undercounted
+// silently: text was compared with `===`, so `"yes"` skipped a cell holding
+// `Yes`, and `"A*"` was matched literally instead of as a wildcard (#2360).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseCriteria } from "../../../../src/plugins/spreadsheet/engine/registry.ts";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+describe("parseCriteria — text is matched case-insensitively", () => {
+  it("matches regardless of case", () => {
+    const matches = parseCriteria("yes");
+    assert.equal(matches("Yes"), true);
+    assert.equal(matches("YES"), true);
+    assert.equal(matches("yes"), true);
+  });
+
+  it("still rejects different text", () => {
+    const matches = parseCriteria("yes");
+    assert.equal(matches("no"), false);
+    assert.equal(matches("yesterday"), false, "an exact match, not a prefix");
+  });
+});
+
+describe("parseCriteria — wildcards", () => {
+  it("treats * as any run of characters", () => {
+    const matches = parseCriteria("A*");
+    assert.equal(matches("Axle"), true);
+    assert.equal(matches("A"), true, "* may match nothing");
+    assert.equal(matches("Bar"), false);
+  });
+
+  it("treats ? as exactly one character", () => {
+    const matches = parseCriteria("b?t");
+    assert.equal(matches("bat"), true);
+    assert.equal(matches("bt"), false);
+    assert.equal(matches("beat"), false);
+  });
+
+  it("escapes a wildcard with ~", () => {
+    const matches = parseCriteria("A~*");
+    assert.equal(matches("A*"), true);
+    assert.equal(matches("Axle"), false);
+  });
+
+  it("does not let regex metacharacters act as a pattern", () => {
+    const matches = parseCriteria("a.c");
+    assert.equal(matches("a.c"), true);
+    assert.equal(matches("abc"), false, "the dot is literal, not any-char");
+  });
+});
+
+describe("parseCriteria — numbers and operators", () => {
+  it("matches a numeric criteria against a number", () => {
+    const matches = parseCriteria("5");
+    assert.equal(matches(5), true);
+    assert.equal(matches("5"), true);
+    assert.equal(matches(6), false);
+  });
+
+  it("keeps the comparison operators working", () => {
+    assert.equal(parseCriteria(">3")(5), true);
+    assert.equal(parseCriteria(">3")(2), false);
+    assert.equal(parseCriteria("<=3")(3), true);
+  });
+
+  it("applies case-insensitive text to = and <>", () => {
+    assert.equal(parseCriteria("=yes")("Yes"), true);
+    assert.equal(parseCriteria("<>yes")("Yes"), false);
+    assert.equal(parseCriteria("<>yes")("no"), true);
+  });
+});
+
+describe("COUNTIF through the engine", () => {
+  const countif = (values: string[], criteria: string): unknown => {
+    const rows = values.map((value) => [{ v: value }]);
+    rows.push([{ v: `=COUNTIF(A1:A${values.length}, "${criteria}")` }]);
+    const sheet: SheetData = { name: "S", data: rows };
+    return new SpreadsheetEngine().calculate(sheet).data[values.length][0];
+  };
+
+  it("counts a case-differing match", () => {
+    assert.equal(countif(["Yes", "no"], "yes"), 1);
+  });
+
+  it("counts a wildcard match", () => {
+    assert.equal(countif(["Axle", "Bar"], "A*"), 1);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_registry.ts
+++ b/test/plugins/spreadsheet/engine/test_registry.ts
@@ -173,12 +173,14 @@ describe("parseCriteria — the ways it silently matches nothing", () => {
     assert.equal(gtText("abc"), false);
   });
 
-  // Excel supports `*` and `?` wildcards here; this implementation does not,
-  // so the criteria degrades to an exact string match.
-  it("treats a wildcard as a literal character, not a pattern", () => {
+  // `*` and `?` are Excel wildcards; `~` escapes them back to literals.
+  it("treats a wildcard as a pattern, and ~ escapes it", () => {
     const wildcard = parseCriteria("app*");
-    assert.equal(wildcard("apple"), false);
-    assert.equal(wildcard("app*"), true, "only the literal string matches");
+    assert.equal(wildcard("apple"), true);
+    assert.equal(wildcard("app"), true, "* may match nothing");
+    assert.equal(wildcard("axe"), false);
+    assert.equal(parseCriteria("app~*")("app*"), true, "escaped, so only the literal matches");
+    assert.equal(parseCriteria("app~*")("apple"), false);
   });
 });
 
@@ -186,7 +188,7 @@ describe("parseCriteria — exact match", () => {
   it("matches a plain string exactly", () => {
     const apple = parseCriteria("apple");
     assert.equal(apple("apple"), true);
-    assert.equal(apple("Apple"), false, "matching is case-sensitive");
+    assert.equal(apple("Apple"), true, "matching is case-insensitive, as in Excel");
     assert.equal(apple("apples"), false);
   });
 


### PR DESCRIPTION
## Summary
Two more "静かに間違う" (silently wrong) cases from #2360 — both **undercount with no error**, measured on current `main`:

| criteria | cell | before | Excel / now |
|---|---|---|---|
| `COUNTIF(range, "yes")` | `Yes` | 0 | 1 |
| `COUNTIF(range, "A*")` | `Axle` | 0 (`A*` compared literally) | 1 |

`parseCriteria` finished with `String(v) === criteria` — a case-sensitive, literal comparison. Excel matches criteria text case-insensitively and treats `*` / `?` as wildcards (`~` escapes them).

## Items to Confirm / Review
- **VLOOKUP/HLOOKUP exact-match lookups share `parseCriteria`** (`functions/lookup.ts:37`), so they become case-insensitive and wildcard-aware too — that is also Excel's behaviour for an exact-match lookup, but it is a behaviour change worth a look.
- **Two pinned tests updated**: `test_registry.ts` documented the old behaviour as a known limitation ("treats a wildcard as a literal character", "matching is case-sensitive"). Both now assert the Excel behaviour — please confirm that's the intent (it is what #2360 asks for).
- Regex metacharacters in a criteria stay literal (`a.c` matches only `a.c`), and the pattern is anchored, so no criteria can act as a partial-match regex.
- `<>` is implemented as the exact negation of `=`, so the two can't drift.

## User Prompt
スプシ、のこっている / どんどんすすめて — the user asked to keep working through the remaining spreadsheet issues.

## Implementation
- `engine/registry.ts`: `textMatcher(pattern)` compiles the criteria once (`*`→`.*`, `?`→`.`, `~X`→literal `X`, everything else escaped, flags `iu`); `matchesTextOrNumber` combines it with the existing numeric equality; the bare path and `=` / `<>` all use it.
- Tests: `test_criteria.ts` (new, 11 cases incl. COUNTIF end-to-end) — verified 7 go red against a case-sensitive literal matcher. Full engine suite green (672).
- Plan: `plans/fix-2360-countif-criteria.md`.

Refs #2360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * COUNTIF and SUMIF criteria now match text without regard to capitalization.
  * Added Excel-style wildcard support using `*` and `?`.
  * Use `~` to treat wildcard characters as literal text.
  * Improved criteria handling for exact matches, numeric values, and comparison operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->