### PR TITLE
refactor(spreadsheet): represent formula errors as a distinct value type (#2451)

### DIFF
--- a/plans/refactor-2451-error-value-type.md
+++ b/plans/refactor-2451-error-value-type.md
@@ -1,0 +1,157 @@
+# refactor(spreadsheet): formula errors as a distinct value type (#2451)
+
+## Problem
+
+Formula errors were plain strings. At the value level a real error and text that
+merely spells one were the same thing:
+
+| formula                           | before          | after        |
+| --------------------------------- | --------------- | ------------ |
+| `IFERROR(SQRT(-1), 42)`           | `42` ✅         | `42`         |
+| `IFERROR("#NUM!", 42)`            | `"#NUM!"` ✅ \* | `"#NUM!"`    |
+| `IFERROR(CONCAT("#N","UM!"), 42)` | `42` ❌         | `"#NUM!"` ✅ |
+
+\* only because `iferrorHandler` exempted a _syntactically_ quoted argument
+(`isQuotedLiteral`, #2432). A COMPUTED string carried no such signal, so it was
+swallowed. That is the case this refactor fixes.
+
+## Shape chosen
+
+A small class in `src/plugins/spreadsheet/engine/spreadsheet-errors.ts`:
+
+```ts
+export class SpreadsheetError {
+  constructor(readonly code: SpreadsheetErrorCode) {}
+  toString(): string {
+    return this.code;
+  }
+  toJSON(): string {
+    return this.code;
+  }
+}
+```
+
+Why a class rather than a branded object literal (`{ __spreadsheetError: … }`):
+
+- `instanceof` gives a one-line guard with no property-name convention to keep
+  in sync, and no chance a decoded JSON object accidentally satisfies it.
+- `toString()` means every place the engine already coerces a cell value to text
+  (`toString(value)`, `String(value)`, template literals) keeps producing
+  `#NUM!` with no extra branch.
+- `toJSON()` means an error that somehow reached a serializer becomes `"#NUM!"`
+  rather than `{}`.
+
+**Interning**: one instance per code (`spreadsheetError(code)` + the named
+`NUM_ERROR` / `DIV_ZERO_ERROR` / … exports). Two errors of the same kind
+therefore compare `===`, exactly as the strings did — which the condition
+comparison path (`applyOperator`'s `left === right`) and the existing pure-helper
+tests rely on.
+
+`#ERROR!` (the engine's own catch-all, previously listed only in
+`formulaError.ts`) is folded into `SPREADSHEET_ERRORS`, so there is now ONE
+taxonomy. `formulaError.ts`'s duplicate `RECOGNIZED_ERROR_VALUES` /
+`isErrorValue` are gone.
+
+### Types
+
+`types.ts` now distinguishes the two:
+
+```ts
+export type StoredCellValue = number | string | boolean; // serialized to JSON
+export type CellValue = StoredCellValue | SpreadsheetError; // computed
+export interface SpreadsheetCell {
+  v: StoredCellValue;
+  f?: string;
+}
+```
+
+An error is a COMPUTED value only. `SpreadsheetCell.v` stays `StoredCellValue`,
+so nothing can write an error into the workbook JSON.
+
+## Every function switched
+
+| File                            | Switched to the error value                                                                                                                  |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `math-ops.ts`                   | `floorToSignificance`, `ceilingToSignificance`, `modulo`, `power`, `safeLog`, `logWithBase`, `safeLog10`, `safeSqrt`                         |
+| `datedif.ts`                    | `computeDatedif` (start after end, unknown unit)                                                                                             |
+| `numericCoercion.ts`            | `toScalarNumber` (`#VALUE!`); its `VALUE_ERROR` moved to `spreadsheet-errors.ts`                                                             |
+| `functions/statistical-math.ts` | `computeMode`, `sampleVariance`, `sampleStdev`; its `NA_ERROR` / `DIV_ZERO_ERROR` moved                                                      |
+| `functions/statistical.ts`      | `AVERAGEIF` with no match → `#DIV/0!`                                                                                                        |
+| `functions/text.ts`             | `normalizeCharCount`, `takeLeft`, `takeRight`, `substituteText`, `FIND`, `SEARCH`, `VALUE`                                                   |
+| `functions/lookup.ts`           | `VLOOKUP` / `HLOOKUP` / `MATCH` no-match → `#N/A`, `INDEX` out of range → `#REF!`, `XLOOKUP` default `if_not_found` and fallthrough → `#N/A` |
+| `functions/logical.ts`          | `IFS` with no matching branch → `#N/A`                                                                                                       |
+| `functions/mathematical.ts`     | `ABS` / `SIGN` pass the error value through instead of a string                                                                              |
+| `calculator.ts`                 | a thrown `FormulaError` stores the error VALUE in the cell (so a cell reading it sees an error)                                              |
+
+Adjacent guards that had to learn the new variant (behaviour pinned, not
+changed): `coerce-boolean.ts` (an error is truthy, as the string was),
+`functions/lookup-math.ts` (`isApproximateMatch` reads an error as FALSE),
+`condition.ts` / `evaluator.ts` renderers (quote the code).
+
+## Display / serialization touch points
+
+- `cellFormatting.formatCellForDisplay` — renders an error value to its code
+  first; its return type is now `StoredCellValue`, making it the explicit
+  boundary where a computed value becomes what the cell shows and the workbook
+  serializes.
+- `calculator.calculateSheet` — the final display pass (skipped for cross-sheet
+  resolution, which must keep the raw error so it can propagate).
+- `SpreadsheetError.toJSON()` — belt and braces for any other serializer.
+- `evaluator.renderOperand` / `condition.renderConditionOperand` — an error
+  substituted into an expression/condition renders as its QUOTED code.
+- `engine/index.ts` re-exports `spreadsheet-errors` so UI consumers can render
+  the variant.
+
+## Provenance-aware checks
+
+- `isErrorResult` (what IFERROR catches) → the error VALUE, NaN/∞, null. **Not**
+  a look-alike string.
+- `ifnaHandler` → `isSpreadsheetErrorValue(result) && result.code === NA_ERROR.code`.
+- Nested-call substitution in `evaluator` → propagates only for the error VALUE,
+  so `CONCAT("#N","UM!") & "!"` stays ordinary text.
+- Cell-reference substitution in `evaluator` → uses `errorCodeOf`, which accepts
+  the error value OR a cell whose STORED TEXT spells a code. Deliberate: #2359
+  made a literal `#REF!` in a cell poison the arithmetic that reads it, and
+  arithmetic over such text is never meaningful. Provenance matters for
+  IFERROR/IFNA, not for "can I add 1 to this".
+
+## `isQuotedLiteral` removed
+
+Yes. `IFERROR("#NUM!", 42)` now returns `"#NUM!"` because a string literal is
+simply not an error value — no syntactic exemption needed. The workaround was
+also wrong in a way nobody had noticed: it matched anything starting and ending
+with a quote, so `IFERROR("#N" & "UM!", 42)` was exempted by accident, and
+`IFERROR("x" & SQRT(-1), 42)` would have been exempted for a real error.
+
+## Headline case (observed)
+
+```
+before:  =IFERROR(CONCAT("#N","UM!"), 42)  →  42        ← wrong
+after:   =IFERROR(CONCAT("#N","UM!"), 42)  →  "#NUM!"   ← correct
+```
+
+Pinned in `test/plugins/spreadsheet/engine/test_errorValue.ts`
+("does not catch COMPUTED text that spells an error"). Verified load-bearing by
+mutation: restoring the string check to `isErrorResult` turns 4 tests red.
+
+## Other behaviour changes (improvements, not preservation)
+
+Both were garbage before and are now the Excel answer:
+
+```
+=SQRT(-1)+1     before: "\"#NUM!\"+1"   after: #NUM!
+=SQRT(-1)&"x"   before: "#NUM!x"        after: #NUM!
+```
+
+`isSpreadsheetError("#ERROR!")` is now `true` (the two taxonomies were merged).
+
+## Tests
+
+- New `test/plugins/spreadsheet/engine/test_errorValue.ts` (25 tests): the guard,
+  interning, `isErrorResult` value-vs-string, the display pass, functions
+  returning the value, IFERROR provenance incl. the headline case, IFNA by code.
+- Updated in place: `test_spreadsheetErrors`, `test_formulaError`,
+  `test_mathematicalFunctions`, `test_datedif`, `test_statisticalMath`,
+  `test_numericCoercion`, `test_textFunctions` — pure helpers now compare against
+  the error VALUE, end-to-end assertions still compare against the code STRING.
+- Full engine suite: 688 pass (was 661).

--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -14,6 +14,7 @@ import { isObj } from "../../../utils/types";
 import { isEmptyCell } from "./cellEmpty";
 import { errorMessage } from "../../../utils/errors";
 import { classifyThrownError, invalidRefError } from "./formulaError";
+import { isSpreadsheetErrorValue, spreadsheetError } from "./spreadsheet-errors";
 
 /**
  * Normalize malformed data structures
@@ -166,8 +167,11 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
     } catch (error) {
       const { type, display } = classifyThrownError(error);
       errors.push({ cell: { row, col }, formula: formulaText, error: errorMessage(error), type });
-      calculated[row][col] = display;
-      return display;
+      // The error VALUE, not its text: a cell that reads this one must see a
+      // real error, and the display pass renders it back to `#DIV/0!`.
+      const errorValue = spreadsheetError(display);
+      calculated[row][col] = errorValue;
+      return errorValue;
     } finally {
       calculating.delete(cellKey);
       evaluated.add(cellKey);
@@ -178,6 +182,9 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
   const getRawValue = (cell: any, row?: number, col?: number): CellValue => {
     // Handle null/undefined cells - treat as 0
     if (cell === null || cell === undefined) return 0;
+
+    // An already-calculated cell can hold a formula error; it stays an error.
+    if (isSpreadsheetErrorValue(cell)) return cell;
 
     if (typeof cell === "number") return cell;
 

--- a/src/plugins/spreadsheet/engine/cellFormatting.ts
+++ b/src/plugins/spreadsheet/engine/cellFormatting.ts
@@ -9,7 +9,8 @@
 
 import { formatNumber } from "./formatter";
 import { isRecord } from "../../../utils/types";
-import type { CellValue, SpreadsheetCell } from "./types";
+import { isSpreadsheetErrorValue } from "./spreadsheet-errors";
+import type { CellValue, SpreadsheetCell, StoredCellValue } from "./types";
 
 // Integer serials the engine is willing to auto-format as dates without an
 // explicit format code: ~Jul 1998 (36000) through ~Dec 2073 (63499). Narrow on
@@ -28,11 +29,18 @@ export const isLikelyDateSerial = (value: CellValue): boolean =>
  * Resolve the display value of one cell from its original definition and its
  * calculated value.
  *
+ * - A formula error renders as its code, so the cell still reads `#NUM!`.
  * - Explicit format code wins (currency, percentage, date, ...).
  * - A formula that produced a date serial auto-formats as a date.
  * - Everything else (text, plain numbers, empty) passes through unchanged.
+ *
+ * The result is always a STORED value: this is the boundary where a computed
+ * error becomes the text a cell shows and a workbook serializes.
  */
-export const formatCellForDisplay = (originalCell: unknown, calculatedValue: CellValue, preferDDMMYYYY: boolean): CellValue => {
+export const formatCellForDisplay = (originalCell: unknown, calculatedValue: CellValue, preferDDMMYYYY: boolean): StoredCellValue => {
+  if (isSpreadsheetErrorValue(calculatedValue)) {
+    return calculatedValue.code;
+  }
   if (!isSpreadsheetCell(originalCell) || typeof calculatedValue !== "number") {
     return calculatedValue;
   }

--- a/src/plugins/spreadsheet/engine/coerce-boolean.ts
+++ b/src/plugins/spreadsheet/engine/coerce-boolean.ts
@@ -1,4 +1,5 @@
 import type { CellValue } from "./types";
+import { isSpreadsheetErrorValue } from "./spreadsheet-errors";
 
 /** Excel-style truthiness, shared by IF and AND/OR/NOT so the same value cannot
  *  read as true in one function and false in another. A number is false only
@@ -9,6 +10,9 @@ export function coerceToBoolean(value: CellValue | null | undefined): boolean {
   if (typeof value === "boolean") return value;
   if (value === null || value === undefined) return false;
   if (typeof value === "number") return value !== 0;
+  // Pinned: an error reads as non-empty text, i.e. true — the same answer the
+  // error strings gave before they became values.
+  if (isSpreadsheetErrorValue(value)) return true;
 
   const text = value.trim();
   if (text === "") return false;

--- a/src/plugins/spreadsheet/engine/condition.ts
+++ b/src/plugins/spreadsheet/engine/condition.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CellValue } from "./types";
+import { isSpreadsheetErrorValue } from "./spreadsheet-errors";
 
 export type ComparisonOperator = ">=" | "<=" | "<>" | "!=" | "==" | "=" | ">" | "<";
 
@@ -173,6 +174,9 @@ export function evaluateConditionValues(condition: string, evaluate: (operand: s
  *  render as themselves. */
 export function renderConditionOperand(value: CellValue | null | undefined): string {
   if (value === null || value === undefined) return '""';
-  if (typeof value === "string") return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-  return value.toString();
+  // A formula error renders as its quoted code, so a condition compares it as
+  // the text a cell shows rather than as a bare `#NUM!` token.
+  const text = isSpreadsheetErrorValue(value) ? value.code : value;
+  if (typeof text === "string") return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return text.toString();
 }

--- a/src/plugins/spreadsheet/engine/datedif.ts
+++ b/src/plugins/spreadsheet/engine/datedif.ts
@@ -1,13 +1,14 @@
 /**
  * DATEDIF — complete elapsed time between two dates, in a chosen unit.
  *
- * Pure: two Excel serials and a unit in, a number (or an Excel error string)
+ * Pure: two Excel serials and a unit in, a number (or a formula error value)
  * out. The unit branches each have their own boundary handling (month-end
  * borrowing, year wraparound), which is exactly what makes them worth testing
  * apart from the handler that reads the arguments.
  */
 
 import { serialToDate } from "./date-utils";
+import { NUM_ERROR, type SpreadsheetError } from "./spreadsheet-errors";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const MONTHS_PER_YEAR = 12;
@@ -24,11 +25,11 @@ function addMonthsClamped(date: Date, months: number): Date {
   return new Date(Date.UTC(year, month, day));
 }
 
-/** Complete `unit`s between two dates, or `"#NUM!"` when start is after end or
+/** Complete `unit`s between two dates, or `#NUM!` when start is after end or
  *  the unit is not one of Y / M / D / MD / YM / YD. `unit` is matched
  *  case-insensitively. */
-export function computeDatedif(startSerial: number, endSerial: number, unit: string): number | string {
-  if (startSerial > endSerial) return "#NUM!";
+export function computeDatedif(startSerial: number, endSerial: number, unit: string): number | SpreadsheetError {
+  if (startSerial > endSerial) return NUM_ERROR;
 
   const startDate = serialToDate(startSerial);
   const endDate = serialToDate(endSerial);
@@ -87,6 +88,6 @@ export function computeDatedif(startSerial: number, endSerial: number, unit: str
     }
 
     default:
-      return "#NUM!";
+      return NUM_ERROR;
   }
 }

--- a/src/plugins/spreadsheet/engine/evaluator.ts
+++ b/src/plugins/spreadsheet/engine/evaluator.ts
@@ -8,7 +8,8 @@ import { functionRegistry } from "./registry";
 import type { CellValue } from "./types";
 import { parseDate } from "./date-parser";
 import { caretToPow, replaceConcatOperator, rewriteComparisonEq, isSafeArithmetic, isSafeComparison } from "./translateFormula";
-import { divZeroError, unknownError, nameError, isErrorValue, propagatedError } from "./formulaError";
+import { divZeroError, unknownError, nameError, propagatedError } from "./formulaError";
+import { errorCodeOf, isSpreadsheetErrorValue } from "./spreadsheet-errors";
 
 /**
  * Evaluation context for formulas
@@ -29,8 +30,9 @@ export interface EvaluatorContext {
  *  treated everywhere else in the engine. */
 export function renderOperand(value: CellValue | null | undefined): string {
   if (value === null || value === undefined) return "0";
-  if (typeof value === "string") return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-  return value.toString();
+  const text = isSpreadsheetErrorValue(value) ? value.code : value;
+  if (typeof text === "string") return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return text.toString();
 }
 
 /** Replace every quoted string literal with an empty pair of quotes, honouring
@@ -375,6 +377,11 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
     if (depth === 0) {
       const fullMatch = expr.substring(funcStartIndex, argsEndIndex);
       const result = context.evaluateFormula(fullMatch);
+      // A nested call that errored poisons the expression the same way an
+      // errored reference does — substituting it produced `"#NUM!"+1` text.
+      // Only the error VALUE counts: text that merely spells an error (CONCAT)
+      // is an ordinary operand.
+      if (isSpreadsheetErrorValue(result)) throw propagatedError(result.code);
       // For string results, wrap in quotes; for numbers, wrap in parentheses
       const replacement = typeof result === "string" ? `"${result}"` : `(${result})`;
       expr = expr.substring(0, funcStartIndex) + replacement + expr.substring(argsEndIndex);
@@ -411,10 +418,13 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
   for (let index = cellRefs.length - 1; index >= 0; index--) {
     const { ref, start } = cellRefs[index];
     const value = context.getCellValue(ref);
-    // A referenced cell holding an error value poisons the whole expression:
+    // A referenced cell holding an error poisons the whole expression:
     // rendering it would produce `"#DIV/0!"+1` garbage, so propagate the error
-    // instead of substituting it (#2359, Excel behaviour).
-    if (isErrorValue(value)) throw propagatedError(value);
+    // instead of substituting it (#2359, Excel behaviour). A cell whose stored
+    // TEXT spells an error counts here too — Excel stores a typed error literal
+    // as an error, and arithmetic over it is never meaningful.
+    const referencedErrorCode = errorCodeOf(value);
+    if (referencedErrorCode !== null) throw propagatedError(referencedErrorCode);
     expr = expr.slice(0, start) + renderOperand(value) + expr.slice(start + ref.length);
   }
 

--- a/src/plugins/spreadsheet/engine/formulaError.ts
+++ b/src/plugins/spreadsheet/engine/formulaError.ts
@@ -9,37 +9,33 @@
  */
 
 import type { CalculationError } from "./types";
+import type { SpreadsheetErrorCode } from "./spreadsheet-errors";
 
 /** The evaluator-facing error kinds: every `CalculationError["type"]` except
  *  `circular`, which the calculator raises directly (not via a thrown error). */
 export type FormulaErrorType = Exclude<CalculationError["type"], "circular">;
 
-/** The cell value shown for each kind, matching Excel's error literals. */
-export const FORMULA_ERROR_VALUES: Record<FormulaErrorType, string> = {
+/** The error code shown for each kind, matching Excel's error literals. */
+export const FORMULA_ERROR_VALUES: Record<FormulaErrorType, SpreadsheetErrorCode> = {
   div_zero: "#DIV/0!",
   invalid_ref: "#REF!",
   syntax: "#NAME?",
   unknown: "#ERROR!",
 };
 
-/** Every string the engine treats as an error value, including the ones existing
- *  functions already return (`#N/A` from lookups, `#NUM!` from DATEDIF, …). Used
- *  to decide whether a referenced cell's value should propagate as an error. */
-const RECOGNIZED_ERROR_VALUES = new Set<string>([...Object.values(FORMULA_ERROR_VALUES), "#N/A", "#NUM!", "#VALUE!", "#NULL!"]);
-
-/** Reverse map for propagation: an error VALUE back to the kind it represents.
- *  Values without a dedicated kind (`#N/A`, `#NUM!`, …) propagate as `unknown`. */
+/** Reverse map for propagation: an error code back to the kind it represents.
+ *  Codes without a dedicated kind (`#N/A`, `#NUM!`, …) propagate as `unknown`. */
 const ERROR_VALUE_TO_TYPE: Record<string, FormulaErrorType> = {
   [FORMULA_ERROR_VALUES.div_zero]: "div_zero",
   [FORMULA_ERROR_VALUES.invalid_ref]: "invalid_ref",
   [FORMULA_ERROR_VALUES.syntax]: "syntax",
 };
 
-/** A recoverable formula failure carrying the kind and the cell value to show. */
+/** A recoverable formula failure carrying the kind and the code to show. */
 export class FormulaError extends Error {
   constructor(
     readonly errorType: FormulaErrorType,
-    readonly display: string,
+    readonly display: SpreadsheetErrorCode,
     message?: string,
   ) {
     super(message ?? display);
@@ -57,16 +53,15 @@ export const nameError = (funcName: string): FormulaError => new FormulaError("s
 
 export const unknownError = (message?: string): FormulaError => new FormulaError("unknown", FORMULA_ERROR_VALUES.unknown, message);
 
-/** Whether a value is one of the recognized Excel error literals. */
-export const isErrorValue = (value: unknown): value is string => typeof value === "string" && RECOGNIZED_ERROR_VALUES.has(value);
-
-/** The FormulaError that re-raises an error value read from a referenced cell,
- *  so `=A1+1` inherits A1's error instead of corrupting into `"#DIV/0!"+1`. */
-export const propagatedError = (value: string): FormulaError => new FormulaError(ERROR_VALUE_TO_TYPE[value] ?? "unknown", value, `Propagated error: ${value}`);
+/** The FormulaError that re-raises an error read from a referenced cell or a
+ *  nested call, so `=A1+1` inherits A1's error instead of corrupting into
+ *  `"#DIV/0!"+1`. */
+export const propagatedError = (value: SpreadsheetErrorCode): FormulaError =>
+  new FormulaError(ERROR_VALUE_TO_TYPE[value] ?? "unknown", value, `Propagated error: ${value}`);
 
 /** Map any thrown value onto the typed entry the calculator records. A
  *  `FormulaError` keeps its own kind and display; anything else is `unknown`. */
-export const classifyThrownError = (error: unknown): { type: FormulaErrorType; display: string } => {
+export const classifyThrownError = (error: unknown): { type: FormulaErrorType; display: SpreadsheetErrorCode } => {
   if (isFormulaError(error)) return { type: error.errorType, display: error.display };
   return { type: "unknown", display: FORMULA_ERROR_VALUES.unknown };
 };

--- a/src/plugins/spreadsheet/engine/functions/logical.ts
+++ b/src/plugins/spreadsheet/engine/functions/logical.ts
@@ -5,7 +5,7 @@
 import { evaluateConditionValues, readOperand, renderConditionOperand } from "../condition";
 import { findCellRefs } from "../evaluator";
 import { functionRegistry, type FunctionHandler } from "../registry";
-import { isErrorResult } from "../spreadsheet-errors";
+import { isErrorResult, isSpreadsheetErrorValue, NA_ERROR } from "../spreadsheet-errors";
 import { coerceToBoolean } from "../coerce-boolean";
 import type { CellValue } from "../types";
 
@@ -56,21 +56,16 @@ const notHandler: FunctionHandler = (args, context) => {
   return !coerceToBoolean(context.evaluateFormula(args[0]));
 };
 
-/** Whether `source` is a single quoted string literal. Its value is text even
- *  when that text looks like an error code, so IFERROR must not swallow it. */
-const isQuotedLiteral = (source: string): boolean => {
-  const trimmed = source.trim();
-  return trimmed.length >= 2 && ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'")));
-};
-
 const iferrorHandler: FunctionHandler = (args, context) => {
   try {
     const result = context.evaluateFormula(args[0]);
-    // Catches NaN/∞ AND the Excel error strings functions now return (a math
-    // domain miss like SQRT(-1) → "#NUM!"), so IFERROR(SQRT(-1), 0) is 0. A
-    // quoted literal that merely looks like an error (IFERROR("#NUM!", 42)) is
-    // real text, not an error value, so it passes through (Codex review).
-    if (!isQuotedLiteral(args[0]) && isErrorResult(result)) {
+    // Catches NaN/∞ and the formula error VALUES functions return (a math domain
+    // miss like SQRT(-1) → #NUM!), so IFERROR(SQRT(-1), 0) is 0. Text that
+    // merely spells an error is not an error value, so it passes through
+    // whether it was written as a literal (IFERROR("#NUM!", 42)) or computed
+    // (IFERROR(CONCAT("#N","UM!"), 42)) — the computed case is why errors carry
+    // provenance at all (#2451).
+    if (isErrorResult(result)) {
       return context.evaluateFormula(args[1]);
     }
     return result;
@@ -82,8 +77,8 @@ const iferrorHandler: FunctionHandler = (args, context) => {
 
 const ifnaHandler: FunctionHandler = (args, context) => {
   const result = context.evaluateFormula(args[0]);
-  // Check if result is N/A (could be represented as specific error value)
-  if (result === null || result === undefined || result === "#N/A") {
+  const isNotAvailable = isSpreadsheetErrorValue(result) && result.code === NA_ERROR.code;
+  if (result === null || result === undefined || isNotAvailable) {
     return context.evaluateFormula(args[1]);
   }
   return result;
@@ -136,7 +131,7 @@ const ifsHandler: FunctionHandler = (args, context) => {
   }
 
   // If no conditions match, return error
-  return "#N/A";
+  return NA_ERROR;
 };
 
 const trueHandler: FunctionHandler = () => true;

--- a/src/plugins/spreadsheet/engine/functions/lookup-math.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup-math.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CellValue } from "../types";
+import { isSpreadsheetErrorValue } from "../spreadsheet-errors";
 
 /**
  * Interpret VLOOKUP/HLOOKUP's 4th argument (range_lookup): TRUE (or omitted) =
@@ -15,11 +16,13 @@ import type { CellValue } from "../types";
  * (#2360). Read it the way Excel coerces a logical instead: a boolean as-is, a
  * non-zero number as TRUE, and the words `TRUE` / `FALSE` (case-insensitive)
  * and `"1"` / `"0"` as their logical value. Anything else (blank, stray text)
- * is treated as FALSE, matching Excel's coercion of a blank range_lookup.
+ * is treated as FALSE, matching Excel's coercion of a blank range_lookup — and
+ * so is a formula error, which is neither of the two logicals.
  */
 export function isApproximateMatch(rangeLookup: CellValue): boolean {
   if (typeof rangeLookup === "boolean") return rangeLookup;
   if (typeof rangeLookup === "number") return rangeLookup !== 0;
+  if (isSpreadsheetErrorValue(rangeLookup)) return false;
   const normalized = rangeLookup.trim().toUpperCase();
   return normalized === "TRUE" || normalized === "1";
 }

--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -7,6 +7,7 @@ import { indexToColumn } from "../parser";
 import { parseRangeBounds, resolveIndexTarget } from "../formulaRefs";
 import { isApproximateMatch } from "./lookup-math";
 import type { CellValue } from "../types";
+import { NA_ERROR, REF_ERROR } from "../spreadsheet-errors";
 
 const inclusiveRange = (start: number, end: number): number[] => Array.from({ length: Math.max(0, end - start + 1) }, (_, i) => start + i);
 
@@ -104,7 +105,7 @@ const vlookupHandler: FunctionHandler = (args, context) => {
   const startColStr = indexToColumn(bounds.startCol);
   const lookupArray = columnValues(context, bounds.sheetPrefix, startColStr, bounds.startRow, bounds.endRow);
   const matchIdx = findMatchIndex(lookupValue, lookupArray, matchType);
-  if (matchIdx === -1) return "#N/A";
+  if (matchIdx === -1) return NA_ERROR;
 
   const resultColStr = indexToColumn(bounds.startCol + colIndexNum - 1);
   const resultRow = bounds.startRow + matchIdx;
@@ -121,7 +122,7 @@ const hlookupHandler: FunctionHandler = (args, context) => {
 
   const lookupArray = rowValues(context, bounds.sheetPrefix, bounds.startRow, bounds.startCol, bounds.endCol);
   const matchIdx = findMatchIndex(lookupValue, lookupArray, matchType);
-  if (matchIdx === -1) return "#N/A";
+  if (matchIdx === -1) return NA_ERROR;
 
   const resultColStr = indexToColumn(bounds.startCol + matchIdx);
   const resultRow = bounds.startRow + rowIndexNum - 1;
@@ -137,7 +138,7 @@ const matchHandler: FunctionHandler = (args, context) => {
 
   const index = findMatchIndex(lookupValue, lookupArray, matchType);
 
-  return index === -1 ? "#N/A" : index + 1; // 1-based index
+  return index === -1 ? NA_ERROR : index + 1; // 1-based index
 };
 
 const indexHandler: FunctionHandler = (args, context) => {
@@ -147,7 +148,7 @@ const indexHandler: FunctionHandler = (args, context) => {
   const colNum = args.length >= 3 ? toNumber(context.evaluateFormula(args[2])) : 1; // Default to 1 if omitted (for 1D arrays)
 
   const target = resolveIndexTarget(bounds, rowNum, colNum);
-  if (!target) return "#REF!";
+  if (!target) return REF_ERROR;
   return context.getCellValue(`${bounds.sheetPrefix}${indexToColumn(target.colIndex)}${target.row}`);
 };
 
@@ -155,7 +156,7 @@ const xlookupHandler: FunctionHandler = (args, context) => {
   const lookupValue = context.evaluateFormula(args[0]);
   const lookupArrayRange = args[1];
   const returnArrayRange = args[2];
-  const ifNotFound = args.length >= 4 ? context.evaluateFormula(args[3]) : "#N/A";
+  const ifNotFound = args.length >= 4 ? context.evaluateFormula(args[3]) : NA_ERROR;
   const matchMode = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
   const searchMode = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 1;
 
@@ -213,7 +214,7 @@ const xlookupHandler: FunctionHandler = (args, context) => {
     return returnArray[matchIdx];
   }
 
-  return "#N/A";
+  return NA_ERROR;
 };
 
 // Register functions

--- a/src/plugins/spreadsheet/engine/functions/mathematical.ts
+++ b/src/plugins/spreadsheet/engine/functions/mathematical.ts
@@ -17,6 +17,7 @@ import {
   logWithBase,
 } from "../math-ops";
 import { toScalarNumber } from "../numericCoercion";
+import { isSpreadsheetErrorValue } from "../spreadsheet-errors";
 
 const roundHandler: FunctionHandler = (args, context) => {
   const number = toNumber(context.evaluateFormula(args[0]));
@@ -50,7 +51,7 @@ const ceilingHandler: FunctionHandler = (args, context) => {
 
 const absHandler: FunctionHandler = (args, context) => {
   const number = toScalarNumber(context.evaluateFormula(args[0]));
-  return typeof number === "string" ? number : Math.abs(number);
+  return isSpreadsheetErrorValue(number) ? number : Math.abs(number);
 };
 
 const powerHandler: FunctionHandler = (args, context) => {
@@ -84,7 +85,7 @@ const truncHandler: FunctionHandler = (args, context) => {
 
 const signHandler: FunctionHandler = (args, context) => {
   const number = toScalarNumber(context.evaluateFormula(args[0]));
-  return typeof number === "string" ? number : Math.sign(number);
+  return isSpreadsheetErrorValue(number) ? number : Math.sign(number);
 };
 
 const piHandler: FunctionHandler = () => Math.PI;

--- a/src/plugins/spreadsheet/engine/functions/statistical-math.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical-math.ts
@@ -3,10 +3,7 @@
  * be unit-tested directly.
  */
 
-/** Returned when a statistic has no defined value (MODE with no repeat). */
-export const NA_ERROR = "#N/A";
-/** Returned when an average would divide by zero (AVERAGEIF with no match). */
-export const DIV_ZERO_ERROR = "#DIV/0!";
+import { DIV_ZERO_ERROR, NA_ERROR, type SpreadsheetError } from "../spreadsheet-errors";
 
 /**
  * The most frequently occurring value, or `#N/A` when no value repeats.
@@ -16,14 +13,14 @@ export const DIV_ZERO_ERROR = "#DIV/0!";
  * is a silent wrong answer. Ties resolve to the value that appears first, which
  * Map insertion order preserves.
  */
-export function computeMode(values: number[]): number | string {
+export function computeMode(values: number[]): number | SpreadsheetError {
   const frequency = new Map<number, number>();
   for (const value of values) {
     frequency.set(value, (frequency.get(value) ?? 0) + 1);
   }
 
   let topFrequency = 0;
-  let mode: number | string = NA_ERROR;
+  let mode: number | SpreadsheetError = NA_ERROR;
   for (const [value, count] of frequency.entries()) {
     if (count > topFrequency) {
       topFrequency = count;
@@ -46,7 +43,7 @@ const arithmeticMean = (values: number[]): number => values.reduce((sum, value) 
  * for VAR understates the spread. Fewer than two values leave no `n - 1` to
  * divide by, so Excel reports `#DIV/0!` rather than a silent 0.
  */
-export function sampleVariance(values: number[]): number | string {
+export function sampleVariance(values: number[]): number | SpreadsheetError {
   if (values.length < MIN_SAMPLE_SIZE) return DIV_ZERO_ERROR;
   const mean = arithmeticMean(values);
   const sumSquaredDiffs = values.reduce((sum, value) => sum + (value - mean) ** 2, 0);
@@ -55,7 +52,7 @@ export function sampleVariance(values: number[]): number | string {
 
 /** Sample standard deviation (Excel STDEV): the square root of the sample
  *  variance, and `#DIV/0!` on the same fewer-than-two-values boundary. */
-export function sampleStdev(values: number[]): number | string {
+export function sampleStdev(values: number[]): number | SpreadsheetError {
   const variance = sampleVariance(values);
   return typeof variance === "number" ? Math.sqrt(variance) : variance;
 }

--- a/src/plugins/spreadsheet/engine/functions/statistical.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical.ts
@@ -3,7 +3,8 @@
  */
 
 import { functionRegistry, toNumber, parseCriteria, type FunctionContext, type FunctionHandler } from "../registry";
-import { computeMode, sampleStdev, sampleVariance, DIV_ZERO_ERROR } from "./statistical-math";
+import { computeMode, sampleStdev, sampleVariance } from "./statistical-math";
+import { DIV_ZERO_ERROR } from "../spreadsheet-errors";
 
 const isLetter = (char: string): boolean => /[A-Z]/i.test(char);
 

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -3,8 +3,7 @@
  */
 
 import { functionRegistry, toString, type FunctionHandler } from "../registry";
-
-const VALUE_ERROR = "#VALUE!";
+import { VALUE_ERROR, isSpreadsheetErrorValue, type SpreadsheetError } from "../spreadsheet-errors";
 
 // A letter or a combining mark. A decomposed accented letter (e + U+0301) is two
 // code points; counting the mark as part of the word stops PROPER from treating
@@ -25,20 +24,20 @@ export const toProperCase = (text: string): string => {
 // Excel truncates a fractional count toward zero and rejects a non-finite or
 // negative one with #VALUE! (LEFT/RIGHT with "x" or -1). Normalising once keeps
 // LEFT and RIGHT consistent instead of each feeding a raw Number() to substring.
-const normalizeCharCount = (count: number): number | string => {
+const normalizeCharCount = (count: number): number | SpreadsheetError => {
   // Test the sign before truncating: Math.trunc(-0.5) is -0, which is not < 0.
   if (!Number.isFinite(count) || count < 0) return VALUE_ERROR;
   return Math.trunc(count);
 };
 
-export const takeLeft = (text: string, count: number): string => {
+export const takeLeft = (text: string, count: number): string | SpreadsheetError => {
   const chars = normalizeCharCount(count);
-  return typeof chars === "string" ? chars : text.substring(0, chars);
+  return isSpreadsheetErrorValue(chars) ? chars : text.substring(0, chars);
 };
 
-export const takeRight = (text: string, count: number): string => {
+export const takeRight = (text: string, count: number): string | SpreadsheetError => {
   const chars = normalizeCharCount(count);
-  return typeof chars === "string" ? chars : text.substring(text.length - chars);
+  return isSpreadsheetErrorValue(chars) ? chars : text.substring(text.length - chars);
 };
 
 // Replace the nth (1-based) occurrence; split/join keeps matches non-overlapping,
@@ -51,7 +50,7 @@ const replaceNthOccurrence = (text: string, oldText: string, newText: string, nt
 
 // Excel SUBSTITUTE: empty old_text returns the text unchanged (never inserts
 // between characters); a supplied instance ≤ 0 or non-finite is a #VALUE! error.
-export const substituteText = (text: string, oldText: string, newText: string, instance?: number): string => {
+export const substituteText = (text: string, oldText: string, newText: string, instance?: number): string | SpreadsheetError => {
   if (oldText === "") return text;
   if (instance === undefined) return text.split(oldText).join(newText);
   const nth = Math.trunc(instance);
@@ -142,7 +141,7 @@ const findHandler: FunctionHandler = (args, context) => {
   const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
 
   const index = withinText.indexOf(findText, startPos);
-  return index === -1 ? "#VALUE!" : index + 1; // Return 1-indexed position
+  return index === -1 ? VALUE_ERROR : index + 1; // Return 1-indexed position
 };
 
 const searchHandler: FunctionHandler = (args, context) => {
@@ -155,7 +154,7 @@ const searchHandler: FunctionHandler = (args, context) => {
   const lowerWithin = withinText.toLowerCase();
 
   const index = lowerWithin.indexOf(lowerFind, startPos);
-  return index === -1 ? "#VALUE!" : index + 1; // Return 1-indexed position
+  return index === -1 ? VALUE_ERROR : index + 1; // Return 1-indexed position
 };
 
 const textHandler: FunctionHandler = (args, context) => {
@@ -195,11 +194,11 @@ const valueHandler: FunctionHandler = (args, context) => {
   // Handle percentages
   if (cleaned.includes("%")) {
     const num = parseFloat(cleaned.replace("%", ""));
-    return isNaN(num) ? "#VALUE!" : num / 100;
+    return isNaN(num) ? VALUE_ERROR : num / 100;
   }
 
   const num = parseFloat(cleaned);
-  return isNaN(num) ? "#VALUE!" : num;
+  return isNaN(num) ? VALUE_ERROR : num;
 };
 
 const exactHandler: FunctionHandler = (args, context) => {

--- a/src/plugins/spreadsheet/engine/index.ts
+++ b/src/plugins/spreadsheet/engine/index.ts
@@ -16,6 +16,7 @@ export * from "./datedif";
 export * from "./formatter";
 export * from "./translateFormula";
 export * from "./formulaError";
+export * from "./spreadsheet-errors";
 export * from "./evaluator";
 export * from "./calculator";
 export * from "./formulaRefs";

--- a/src/plugins/spreadsheet/engine/math-ops.ts
+++ b/src/plugins/spreadsheet/engine/math-ops.ts
@@ -1,15 +1,15 @@
 /**
  * Rounding, modulo and significance math for the mathematical functions.
  *
- * Pure number-in / (number | Excel-error-string)-out helpers. The rounding
+ * Pure number-in / (number | formula-error-value)-out helpers. The rounding
  * direction and the domain rules are exactly where the engine diverged from
  * Excel (rounding toward +∞ instead of away from zero, modulo taking the
  * dividend's sign, negative bases and domains slipping through as NaN/∞), so
  * they are worth testing apart from the argument-reading handlers.
  */
 
-const NUM_ERROR = "#NUM!";
-const DIV_ZERO_ERROR = "#DIV/0!";
+import { DIV_ZERO_ERROR, NUM_ERROR, isSpreadsheetErrorValue, type SpreadsheetError } from "./spreadsheet-errors";
+
 const DECIMAL_BASE = 10;
 
 const scale = (digits: number): number => Math.pow(DECIMAL_BASE, digits);
@@ -39,7 +39,7 @@ const sameSign = (value: number, significance: number): boolean => value === 0 |
 
 /** Excel FLOOR: nearest multiple of `significance` toward zero; opposite signs
  *  are #NUM!, and a zero significance is 0. */
-export function floorToSignificance(value: number, significance: number): number | string {
+export function floorToSignificance(value: number, significance: number): number | SpreadsheetError {
   if (significance === 0) return 0;
   if (!sameSign(value, significance)) return NUM_ERROR;
   return Math.floor(value / significance) * significance;
@@ -47,7 +47,7 @@ export function floorToSignificance(value: number, significance: number): number
 
 /** Excel CEILING: nearest multiple of `significance` away from zero; opposite
  *  signs are #NUM!, and a zero significance is 0. */
-export function ceilingToSignificance(value: number, significance: number): number | string {
+export function ceilingToSignificance(value: number, significance: number): number | SpreadsheetError {
   if (significance === 0) return 0;
   if (!sameSign(value, significance)) return NUM_ERROR;
   return Math.ceil(value / significance) * significance;
@@ -55,42 +55,42 @@ export function ceilingToSignificance(value: number, significance: number): numb
 
 /** Excel MOD: result takes the divisor's sign (`MOD(-3, 2) === 1`); dividing by
  *  zero is #DIV/0!, not a silent 0. */
-export function modulo(value: number, divisor: number): number | string {
+export function modulo(value: number, divisor: number): number | SpreadsheetError {
   if (divisor === 0) return DIV_ZERO_ERROR;
   return value - divisor * Math.floor(value / divisor);
 }
 
 /** Excel POWER: a negative base with a non-integer exponent has no real root, so
  *  it is #NUM! rather than JS's NaN. */
-export function power(base: number, exponent: number): number | string {
+export function power(base: number, exponent: number): number | SpreadsheetError {
   if (base < 0 && !Number.isInteger(exponent)) return NUM_ERROR;
   return Math.pow(base, exponent);
 }
 
 /** Natural log guarded to its domain: `LN(x)` for `x <= 0` is #NUM!, not
  *  -∞ / NaN. Reused by LN and LOG. */
-export function safeLog(value: number): number | string {
+export function safeLog(value: number): number | SpreadsheetError {
   if (value <= 0) return NUM_ERROR;
   return Math.log(value);
 }
 
 /** Excel LOG(value, base): the base must also be positive and not 1, or the
  *  result is #NUM! rather than the ∞ / NaN a bare division would give. */
-export function logWithBase(value: number, base: number): number | string {
+export function logWithBase(value: number, base: number): number | SpreadsheetError {
   const lnValue = safeLog(value);
-  if (typeof lnValue === "string") return lnValue;
+  if (isSpreadsheetErrorValue(lnValue)) return lnValue;
   if (base <= 0 || base === 1) return NUM_ERROR;
   return lnValue / Math.log(base);
 }
 
 /** Base-10 log guarded to its domain (`LOG10(x)` for `x <= 0` is #NUM!). */
-export function safeLog10(value: number): number | string {
+export function safeLog10(value: number): number | SpreadsheetError {
   if (value <= 0) return NUM_ERROR;
   return Math.log10(value);
 }
 
 /** Square root guarded to its domain (`SQRT(x)` for `x < 0` is #NUM!, not NaN). */
-export function safeSqrt(value: number): number | string {
+export function safeSqrt(value: number): number | SpreadsheetError {
   if (value < 0) return NUM_ERROR;
   return Math.sqrt(value);
 }

--- a/src/plugins/spreadsheet/engine/numericCoercion.ts
+++ b/src/plugins/spreadsheet/engine/numericCoercion.ts
@@ -9,10 +9,7 @@
  */
 
 import type { CellValue } from "./types";
-
-/** Returned (as a cell value) when a scalar coercion cannot read a number,
- *  matching how the rest of the engine surfaces errors (functions/text.ts). */
-export const VALUE_ERROR = "#VALUE!";
+import { VALUE_ERROR, type SpreadsheetError } from "./spreadsheet-errors";
 
 const numberOrNull = (num: number): number | null => (isNaN(num) ? null : num);
 
@@ -40,8 +37,9 @@ export function parseNumericString(value: string): number | null {
  * `#VALUE!` rather than a silent 0. A partly-numeric string still yields its
  * leading number, matching the engine's other numeric reads.
  */
-export function toScalarNumber(value: CellValue): number | string {
+export function toScalarNumber(value: CellValue): number | SpreadsheetError {
   if (typeof value === "number") return value;
   if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value !== "string") return value;
   return parseNumericString(value) ?? VALUE_ERROR;
 }

--- a/src/plugins/spreadsheet/engine/spreadsheet-errors.ts
+++ b/src/plugins/spreadsheet/engine/spreadsheet-errors.ts
@@ -1,24 +1,82 @@
 /**
- * The Excel error values the engine emits as strings (e.g. `#NUM!` from an
- * out-of-domain math function, `#DIV/0!` from MOD by zero). Centralised so
- * IFERROR and any future error-aware code can recognise them without each
- * hard-coding the list.
+ * Formula errors as a distinct VALUE type.
+ *
+ * A `#NUM!` produced by `SQRT(-1)` and the text `"#NUM!"` produced by
+ * `CONCAT("#N","UM!")` used to be the same string, so IFERROR could not tell a
+ * real error from text that merely spells one (#2451). An error is now its own
+ * value carrying the code, which is what the error-aware functions check; the
+ * display pass renders it back to `#NUM!` so cells look unchanged.
  */
 
-export const SPREADSHEET_ERRORS = ["#NULL!", "#DIV/0!", "#VALUE!", "#REF!", "#NAME?", "#NUM!", "#N/A"] as const;
+export const SPREADSHEET_ERRORS = ["#NULL!", "#DIV/0!", "#VALUE!", "#REF!", "#NAME?", "#NUM!", "#N/A", "#ERROR!"] as const;
+
+export type SpreadsheetErrorCode = (typeof SPREADSHEET_ERRORS)[number];
+
+/** A formula error, distinct from any string. `toString` yields the code so the
+ *  value renders as `#NUM!` wherever the engine coerces a cell value to text. */
+export class SpreadsheetError {
+  constructor(readonly code: SpreadsheetErrorCode) {}
+
+  toString(): string {
+    return this.code;
+  }
+
+  toJSON(): string {
+    return this.code;
+  }
+}
+
+export const NULL_ERROR = new SpreadsheetError("#NULL!");
+export const DIV_ZERO_ERROR = new SpreadsheetError("#DIV/0!");
+export const VALUE_ERROR = new SpreadsheetError("#VALUE!");
+export const REF_ERROR = new SpreadsheetError("#REF!");
+export const NAME_ERROR = new SpreadsheetError("#NAME?");
+export const NUM_ERROR = new SpreadsheetError("#NUM!");
+export const NA_ERROR = new SpreadsheetError("#N/A");
+export const UNKNOWN_ERROR = new SpreadsheetError("#ERROR!");
+
+// One instance per code: two errors of the same kind compare equal, which is how
+// error strings behaved and what the condition/comparison paths still rely on.
+const ERROR_VALUES: Record<SpreadsheetErrorCode, SpreadsheetError> = {
+  "#NULL!": NULL_ERROR,
+  "#DIV/0!": DIV_ZERO_ERROR,
+  "#VALUE!": VALUE_ERROR,
+  "#REF!": REF_ERROR,
+  "#NAME?": NAME_ERROR,
+  "#NUM!": NUM_ERROR,
+  "#N/A": NA_ERROR,
+  "#ERROR!": UNKNOWN_ERROR,
+};
+
+/** The error value for a code. */
+export const spreadsheetError = (code: SpreadsheetErrorCode): SpreadsheetError => ERROR_VALUES[code];
 
 const errorSet: ReadonlySet<string> = new Set(SPREADSHEET_ERRORS);
 
-/** Whether a value is one of the spreadsheet error strings. */
-export function isSpreadsheetError(value: unknown): boolean {
+/** Whether a value is one of the error CODES as a plain string. Text that spells
+ *  an error is not an error value — see `isSpreadsheetErrorValue`. */
+export function isSpreadsheetError(value: unknown): value is SpreadsheetErrorCode {
   return typeof value === "string" && errorSet.has(value);
 }
 
-/** Whether an evaluated result should be treated as an error: a spreadsheet
- *  error string, a NaN / infinite number, or a missing value. This is what
- *  IFERROR catches. */
+/** Whether a value IS a formula error, as opposed to text that spells one. */
+export function isSpreadsheetErrorValue(value: unknown): value is SpreadsheetError {
+  return value instanceof SpreadsheetError;
+}
+
+/** The code behind a value: an error value's own code, or the code a plain
+ *  string spells. Used where a literal `#REF!` written into a cell must still
+ *  poison the arithmetic that reads it, provenance aside. */
+export function errorCodeOf(value: unknown): SpreadsheetErrorCode | null {
+  if (isSpreadsheetErrorValue(value)) return value.code;
+  return isSpreadsheetError(value) ? value : null;
+}
+
+/** Whether an evaluated result should be treated as an error: a formula error
+ *  VALUE, a NaN / infinite number, or a missing value. This is what IFERROR
+ *  catches — deliberately NOT a look-alike string, which is ordinary text. */
 export function isErrorResult(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   if (typeof value === "number") return Number.isNaN(value) || !Number.isFinite(value);
-  return isSpreadsheetError(value);
+  return isSpreadsheetErrorValue(value);
 }

--- a/src/plugins/spreadsheet/engine/types.ts
+++ b/src/plugins/spreadsheet/engine/types.ts
@@ -2,10 +2,17 @@
  * Spreadsheet Engine Type Definitions
  */
 
-export type CellValue = number | string | boolean;
+import type { SpreadsheetError } from "./spreadsheet-errors";
+
+/** A value as it is STORED in a cell and serialized to the workbook JSON. A
+ *  formula error is never stored — it only exists as a computed result. */
+export type StoredCellValue = number | string | boolean;
+
+/** A value as the engine COMPUTES it: a stored value, or a formula error. */
+export type CellValue = StoredCellValue | SpreadsheetError;
 
 export interface SpreadsheetCell {
-  v: CellValue; // Value or formula (formulas start with "=")
+  v: StoredCellValue; // Value or formula (formulas start with "=")
   f?: string; // Format code (e.g., "$#,##0.00")
 }
 

--- a/test/plugins/spreadsheet/engine/test_datedif.ts
+++ b/test/plugins/spreadsheet/engine/test_datedif.ts
@@ -12,6 +12,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { computeDatedif } from "../../../../src/plugins/spreadsheet/engine/datedif.ts";
 import { dateToSerial } from "../../../../src/plugins/spreadsheet/engine/date-utils.ts";
+import { NUM_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 
 const serial = (year: number, month: number, day: number) => dateToSerial(new Date(Date.UTC(year, month - 1, day)));
 const diff = (start: [number, number, number], end: [number, number, number], unit: string) => computeDatedif(serial(...start), serial(...end), unit);
@@ -111,12 +112,12 @@ describe("computeDatedif — YD (day diff, years ignored)", () => {
 
 describe("computeDatedif — errors", () => {
   it("returns #NUM! when start is after end", () => {
-    assert.equal(diff([2023, 6, 15], [2023, 6, 10], "D"), "#NUM!");
+    assert.equal(diff([2023, 6, 15], [2023, 6, 10], "D"), NUM_ERROR);
   });
 
   it("returns #NUM! for an unknown unit", () => {
-    assert.equal(diff([2020, 1, 1], [2023, 1, 1], "Q"), "#NUM!");
-    assert.equal(diff([2020, 1, 1], [2023, 1, 1], ""), "#NUM!");
+    assert.equal(diff([2020, 1, 1], [2023, 1, 1], "Q"), NUM_ERROR);
+    assert.equal(diff([2020, 1, 1], [2023, 1, 1], ""), NUM_ERROR);
   });
 
   it("matches the unit case-insensitively", () => {

--- a/test/plugins/spreadsheet/engine/test_errorValue.ts
+++ b/test/plugins/spreadsheet/engine/test_errorValue.ts
@@ -1,0 +1,178 @@
+// Formula errors as a distinct VALUE (#2451).
+//
+// While errors were plain strings, `SQRT(-1)` and `CONCAT("#N","UM!")` both
+// produced "#NUM!", so IFERROR could not tell a real error from text that
+// merely spells one — the computed case was caught as an error and silently
+// replaced by the fallback. An error is now its own value carrying the code;
+// text stays text. The display pass renders the value back to `#NUM!`, so the
+// cells look exactly as they did.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { evaluateFormula } from "../../../../src/plugins/spreadsheet/engine/evaluator.ts";
+import { formatCellForDisplay } from "../../../../src/plugins/spreadsheet/engine/cellFormatting.ts";
+import {
+  DIV_ZERO_ERROR,
+  NA_ERROR,
+  NUM_ERROR,
+  SpreadsheetError,
+  isSpreadsheetErrorValue,
+  isErrorResult,
+  spreadsheetError,
+} from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
+import type { CellValue } from "../../../../src/plugins/spreadsheet/engine/types.ts";
+
+/** The raw computed value of a formula, before the display pass turns an error
+ *  back into its code — this is where provenance is observable. */
+const evaluateRaw: (formula: string) => CellValue = (formula) =>
+  evaluateFormula(formula, {
+    getCellValue: () => 0,
+    getRangeValues: () => [],
+    evaluateFormula: evaluateRaw,
+  });
+
+/** What a single-formula sheet DISPLAYS, through the public engine API. */
+const displayed = (formula: string): CellValue => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
+
+describe("the error value and its guard", () => {
+  it("recognises an error value and rejects a string that spells the same code", () => {
+    assert.equal(isSpreadsheetErrorValue(NUM_ERROR), true);
+    assert.equal(isSpreadsheetErrorValue("#NUM!"), false);
+    assert.equal(isSpreadsheetErrorValue(0), false);
+    assert.equal(isSpreadsheetErrorValue(null), false);
+  });
+
+  it("carries the code and renders as it when coerced to text", () => {
+    assert.equal(NUM_ERROR.code, "#NUM!");
+    assert.equal(String(NUM_ERROR), "#NUM!");
+    assert.equal(`${DIV_ZERO_ERROR}`, "#DIV/0!");
+  });
+
+  it("hands out one instance per code, so two errors of a kind compare equal", () => {
+    const fromLookup = spreadsheetError("#N/A");
+    const fromLookupAgain = spreadsheetError("#N/A");
+    assert.equal(fromLookup, NA_ERROR);
+    assert.equal(fromLookup === fromLookupAgain, true);
+    assert.equal(NA_ERROR instanceof SpreadsheetError, true);
+  });
+
+  it("serializes to its code rather than to an empty object", () => {
+    assert.equal(JSON.stringify({ cell: NUM_ERROR }), '{"cell":"#NUM!"}');
+  });
+});
+
+describe("isErrorResult keys off the value, not the text", () => {
+  it("catches an error value", () => {
+    assert.equal(isErrorResult(NUM_ERROR), true);
+    assert.equal(isErrorResult(DIV_ZERO_ERROR), true);
+  });
+
+  it("still catches NaN / infinity / missing", () => {
+    assert.equal(isErrorResult(NaN), true);
+    assert.equal(isErrorResult(Infinity), true);
+    assert.equal(isErrorResult(null), true);
+  });
+
+  it("does NOT catch a look-alike string — the whole point of #2451", () => {
+    assert.equal(isErrorResult("#NUM!"), false);
+    assert.equal(isErrorResult("#N/A"), false);
+  });
+});
+
+describe("the display pass renders an error value to its code", () => {
+  it("returns the code for a formula cell", () => {
+    assert.equal(formatCellForDisplay({ v: "=SQRT(-1)" }, NUM_ERROR, false), "#NUM!");
+  });
+
+  it("returns the code regardless of the cell's format code", () => {
+    assert.equal(formatCellForDisplay({ v: "=A1/A2", f: "$#,##0.00" }, DIV_ZERO_ERROR, false), "#DIV/0!");
+  });
+
+  it("leaves ordinary values alone", () => {
+    assert.equal(formatCellForDisplay({ v: "=1+1" }, 2, false), 2);
+    assert.equal(formatCellForDisplay({ v: "text" }, "text", false), "text");
+  });
+});
+
+describe("functions return an error VALUE, and the cell still shows its code", () => {
+  it("SQRT(-1) computes to the #NUM! value", () => {
+    const value = evaluateRaw("SQRT(-1)");
+    assert.equal(isSpreadsheetErrorValue(value), true);
+    assert.equal(value, NUM_ERROR);
+  });
+
+  it("MOD(5, 0) computes to the #DIV/0! value", () => {
+    assert.equal(evaluateRaw("MOD(5, 0)"), DIV_ZERO_ERROR);
+  });
+
+  it("computed text that spells an error stays a plain string", () => {
+    const value = evaluateRaw('CONCAT("#N","UM!")');
+    assert.equal(isSpreadsheetErrorValue(value), false);
+    assert.equal(value, "#NUM!");
+  });
+
+  it("displays the same codes end-to-end as before the refactor", () => {
+    assert.equal(displayed("=SQRT(-1)"), "#NUM!");
+    assert.equal(displayed("=MOD(5, 0)"), "#DIV/0!");
+    assert.equal(displayed("=1/0"), "#DIV/0!");
+    assert.equal(displayed('=DATEDIF(45000, 44000, "D")'), "#NUM!");
+    assert.equal(displayed('=VALUE("abc")'), "#VALUE!");
+  });
+
+  it("propagates an error VALUE through a reference and shows the code", () => {
+    const sheet: SheetData = { name: "S", data: [[{ v: "=SQRT(-1)" }, { v: "=A1+1" }]] };
+    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "#NUM!");
+  });
+});
+
+describe("IFERROR keys off provenance", () => {
+  it("catches a real error", () => {
+    assert.equal(displayed("=IFERROR(SQRT(-1), 42)"), 42);
+    assert.equal(displayed("=IFERROR(MOD(5, 0), -1)"), -1);
+  });
+
+  it("passes a non-error through untouched", () => {
+    assert.equal(displayed("=IFERROR(SQRT(4), 42)"), 2);
+    assert.equal(displayed('=IFERROR("hello", 42)'), "hello");
+  });
+
+  it("does not catch a quoted literal that only looks like an error", () => {
+    assert.equal(displayed('=IFERROR("#NUM!", 42)'), "#NUM!");
+  });
+
+  // THE headline case. Before #2451 this returned 42: the computed text was
+  // indistinguishable from a real #NUM!, so IFERROR swallowed it.
+  it("does not catch COMPUTED text that spells an error", () => {
+    assert.equal(displayed('=IFERROR(CONCAT("#N","UM!"), 42)'), "#NUM!");
+    assert.equal(displayed('=IFERROR(CONCATENATE("#DIV/", "0!"), 42)'), "#DIV/0!");
+  });
+
+  it("does not catch an error-looking string built with the & operator", () => {
+    assert.equal(displayed('=IFERROR("#N" & "UM!", 42)'), "#NUM!");
+  });
+
+  it("still catches an error that reaches it through arithmetic", () => {
+    assert.equal(displayed("=IFERROR(SQRT(-1) + 1, 42)"), 42);
+  });
+});
+
+describe("IFNA keys off the error value's code", () => {
+  it("substitutes the fallback for a real #N/A", () => {
+    const sheet: SheetData = { name: "S", data: [[{ v: 1 }, { v: '=IFNA(MATCH(99, A1:A1, 0), "missing")' }]] };
+    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "missing");
+  });
+
+  it("leaves a different error alone", () => {
+    assert.equal(displayed('=IFNA(SQRT(-1), "missing")'), "#NUM!");
+  });
+
+  it("does not substitute for text that merely spells #N/A", () => {
+    assert.equal(displayed('=IFNA("#N/A", "missing")'), "#N/A");
+    assert.equal(displayed('=IFNA(CONCAT("#N", "/A"), "missing")'), "#N/A");
+  });
+
+  it("passes an ordinary value through", () => {
+    assert.equal(displayed('=IFNA(7, "missing")'), 7);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_formulaError.ts
+++ b/test/plugins/spreadsheet/engine/test_formulaError.ts
@@ -12,7 +12,6 @@ import {
   invalidRefError,
   nameError,
   unknownError,
-  isErrorValue,
   propagatedError,
   classifyThrownError,
 } from "../../../../src/plugins/spreadsheet/engine/formulaError.ts";
@@ -63,23 +62,6 @@ describe("isFormulaError", () => {
     assert.equal(isFormulaError(new Error("plain")), false);
     assert.equal(isFormulaError("#DIV/0!"), false);
     assert.equal(isFormulaError(null), false);
-  });
-});
-
-describe("isErrorValue", () => {
-  it("recognizes every engine error literal, including function-returned ones", () => {
-    for (const value of ["#DIV/0!", "#REF!", "#NAME?", "#ERROR!", "#N/A", "#NUM!", "#VALUE!", "#NULL!"]) {
-      assert.equal(isErrorValue(value), true, value);
-    }
-  });
-
-  it("rejects ordinary values and near-misses", () => {
-    assert.equal(isErrorValue("hello"), false);
-    assert.equal(isErrorValue("#OOPS!"), false);
-    assert.equal(isErrorValue("100"), false);
-    assert.equal(isErrorValue(0), false);
-    assert.equal(isErrorValue(true), false);
-    assert.equal(isErrorValue(undefined), false);
   });
 });
 

--- a/test/plugins/spreadsheet/engine/test_mathematicalFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_mathematicalFunctions.ts
@@ -2,7 +2,7 @@
 // plausible NUMBER (FLOOR(-2.5,2) = -4, ROUND(-2.5,0) = -2, MOD(-3,2) = -1) or a
 // silent NaN/∞ instead of an Excel error (#2389). The rounding direction, the
 // modulo sign and the domain guards are checked directly on the pure helpers,
-// with a few end-to-end checks that the handlers surface the error strings.
+// with a few end-to-end checks that the handlers surface the error values.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -20,6 +20,7 @@ import {
   logWithBase,
 } from "../../../../src/plugins/spreadsheet/engine/math-ops.ts";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { DIV_ZERO_ERROR, NUM_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 
 const closeTo = (actual: number, expected: number, eps = 1e-9): boolean => Math.abs(actual - expected) <= eps;
 
@@ -42,9 +43,9 @@ describe("roundTo / roundUpTo / roundDownTo — direction", () => {
 });
 
 describe("floorToSignificance / ceilingToSignificance — sign domain", () => {
-  it("is #NUM! when number and significance disagree in sign", () => {
-    assert.equal(floorToSignificance(-2.5, 2), "#NUM!");
-    assert.equal(ceilingToSignificance(2.5, -2), "#NUM!");
+  it("is a #NUM! error value when number and significance disagree in sign", () => {
+    assert.equal(floorToSignificance(-2.5, 2), NUM_ERROR);
+    assert.equal(ceilingToSignificance(2.5, -2), NUM_ERROR);
   });
 
   it("rounds to the multiple when the signs match", () => {
@@ -69,14 +70,14 @@ describe("modulo — divisor sign and division by zero", () => {
   });
 
   it("is #DIV/0! when the divisor is zero", () => {
-    assert.equal(modulo(5, 0), "#DIV/0!");
+    assert.equal(modulo(5, 0), DIV_ZERO_ERROR);
   });
 });
 
 describe("power — negative base domain", () => {
   it("is #NUM! for a negative base with a non-integer exponent", () => {
-    assert.equal(power(-8, 1 / 3), "#NUM!");
-    assert.equal(power(-2, 0.5), "#NUM!");
+    assert.equal(power(-8, 1 / 3), NUM_ERROR);
+    assert.equal(power(-2, 0.5), NUM_ERROR);
   });
 
   it("computes when the exponent is an integer or the base is non-negative", () => {
@@ -88,10 +89,10 @@ describe("power — negative base domain", () => {
 
 describe("safeSqrt / safeLog / safeLog10 — domain", () => {
   it("is #NUM! outside the domain", () => {
-    assert.equal(safeSqrt(-1), "#NUM!");
-    assert.equal(safeLog(0), "#NUM!");
-    assert.equal(safeLog(-1), "#NUM!");
-    assert.equal(safeLog10(0), "#NUM!");
+    assert.equal(safeSqrt(-1), NUM_ERROR);
+    assert.equal(safeLog(0), NUM_ERROR);
+    assert.equal(safeLog(-1), NUM_ERROR);
+    assert.equal(safeLog10(0), NUM_ERROR);
   });
 
   it("computes inside the domain", () => {
@@ -108,21 +109,21 @@ describe("logWithBase — number and base domain", () => {
   });
 
   it("is #NUM! for a non-positive number", () => {
-    assert.equal(logWithBase(0, 10), "#NUM!");
-    assert.equal(logWithBase(-1, 10), "#NUM!");
+    assert.equal(logWithBase(0, 10), NUM_ERROR);
+    assert.equal(logWithBase(-1, 10), NUM_ERROR);
   });
 
   it("is #NUM! for a base that is non-positive or exactly 1", () => {
-    assert.equal(logWithBase(8, 1), "#NUM!");
-    assert.equal(logWithBase(8, -2), "#NUM!");
-    assert.equal(logWithBase(8, 0), "#NUM!");
+    assert.equal(logWithBase(8, 1), NUM_ERROR);
+    assert.equal(logWithBase(8, -2), NUM_ERROR);
+    assert.equal(logWithBase(8, 0), NUM_ERROR);
   });
 });
 
 describe("the handlers surface the errors end-to-end", () => {
   const evalFormula = (formula: string): unknown => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
 
-  it("returns the Excel error strings through the engine", () => {
+  it("displays the Excel error codes through the engine", () => {
     assert.equal(evalFormula("=FLOOR(-2.5, 2)"), "#NUM!");
     assert.equal(evalFormula("=SQRT(-1)"), "#NUM!");
     assert.equal(evalFormula("=MOD(5, 0)"), "#DIV/0!");
@@ -133,16 +134,16 @@ describe("the handlers surface the errors end-to-end", () => {
     assert.equal(evalFormula("=LOG(8, 2)"), 3);
   });
 
-  // Now that domain misses are error strings (not NaN/∞), IFERROR must still
-  // catch them or nested formulas would surface the raw error (#2389 review).
-  it("lets IFERROR catch the new error strings", () => {
+  // Domain misses are error VALUES (not NaN/∞), so IFERROR must still catch
+  // them or nested formulas would surface the raw error (#2389 review).
+  it("lets IFERROR catch the domain errors", () => {
     assert.equal(evalFormula("=IFERROR(SQRT(-1), 42)"), 42);
     assert.equal(evalFormula("=IFERROR(MOD(5, 0), -1)"), -1);
     assert.equal(evalFormula("=IFERROR(SQRT(4), 42)"), 2, "a non-error passes through");
   });
 
-  // A quoted literal that only looks like an error is real text, not an error
-  // value, so IFERROR returns it rather than the fallback (Codex review).
+  // Text that only looks like an error is real text, not an error value, so
+  // IFERROR returns it rather than the fallback.
   it("does not treat quoted error-looking text as an error", () => {
     assert.equal(evalFormula('=IFERROR("#NUM!", 42)'), "#NUM!");
     assert.equal(evalFormula('=IFERROR("hello", 42)'), "hello");

--- a/test/plugins/spreadsheet/engine/test_numericCoercion.ts
+++ b/test/plugins/spreadsheet/engine/test_numericCoercion.ts
@@ -6,7 +6,8 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseNumericString, toScalarNumber, VALUE_ERROR } from "../../../../src/plugins/spreadsheet/engine/numericCoercion.ts";
+import { parseNumericString, toScalarNumber } from "../../../../src/plugins/spreadsheet/engine/numericCoercion.ts";
+import { VALUE_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 import { toNumber } from "../../../../src/plugins/spreadsheet/engine/registry.ts";
 
 describe("parseNumericString — reads the formats the engine has always read", () => {

--- a/test/plugins/spreadsheet/engine/test_spreadsheetErrors.ts
+++ b/test/plugins/spreadsheet/engine/test_spreadsheetErrors.ts
@@ -1,16 +1,31 @@
-// Recognising the engine's error values. IFERROR relies on this: once math
-// functions return "#NUM!" / "#DIV/0!" strings instead of NaN, the old
-// NaN-only check would let those errors slip through (#2389).
+// The error taxonomy: which CODES the engine knows, and which values count as
+// an error RESULT. Since #2451 an error is its own value, so `isErrorResult`
+// deliberately rejects a look-alike string — that is what lets IFERROR tell
+// SQRT(-1) apart from CONCAT("#N","UM!"). The provenance behaviour itself is
+// covered in test_errorValue.ts.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isSpreadsheetError, isErrorResult } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
+import {
+  isSpreadsheetError,
+  isErrorResult,
+  errorCodeOf,
+  spreadsheetError,
+  SPREADSHEET_ERRORS,
+} from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 
 describe("isSpreadsheetError", () => {
   it("recognises the Excel error strings", () => {
     assert.equal(isSpreadsheetError("#NUM!"), true);
     assert.equal(isSpreadsheetError("#DIV/0!"), true);
     assert.equal(isSpreadsheetError("#N/A"), true);
+  });
+
+  it("recognises every code in the taxonomy, including the engine's own #ERROR!", () => {
+    assert.deepEqual(
+      SPREADSHEET_ERRORS.filter((code) => !isSpreadsheetError(code)),
+      [],
+    );
   });
 
   it("rejects ordinary text and non-strings", () => {
@@ -21,9 +36,22 @@ describe("isSpreadsheetError", () => {
   });
 });
 
+describe("errorCodeOf", () => {
+  it("reads the code off an error value and off a string that spells one", () => {
+    assert.equal(errorCodeOf(spreadsheetError("#REF!")), "#REF!");
+    assert.equal(errorCodeOf("#REF!"), "#REF!");
+  });
+
+  it("is null for anything else", () => {
+    assert.equal(errorCodeOf("#OOPS!"), null);
+    assert.equal(errorCodeOf(7), null);
+    assert.equal(errorCodeOf(undefined), null);
+  });
+});
+
 describe("isErrorResult", () => {
-  it("treats error strings, NaN/∞ and missing values as errors", () => {
-    assert.equal(isErrorResult("#DIV/0!"), true);
+  it("treats error values, NaN/∞ and missing values as errors", () => {
+    assert.equal(isErrorResult(spreadsheetError("#DIV/0!")), true);
     assert.equal(isErrorResult(NaN), true);
     assert.equal(isErrorResult(Infinity), true);
     assert.equal(isErrorResult(null), true);
@@ -34,5 +62,10 @@ describe("isErrorResult", () => {
     assert.equal(isErrorResult(0), false);
     assert.equal(isErrorResult(42), false);
     assert.equal(isErrorResult("text"), false);
+  });
+
+  it("does NOT treat a string that merely spells an error as one (#2451)", () => {
+    assert.equal(isErrorResult("#DIV/0!"), false);
+    assert.equal(isErrorResult("#NUM!"), false);
   });
 });

--- a/test/plugins/spreadsheet/engine/test_statisticalMath.ts
+++ b/test/plugins/spreadsheet/engine/test_statisticalMath.ts
@@ -4,7 +4,8 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { computeMode, sampleVariance, sampleStdev, NA_ERROR, DIV_ZERO_ERROR } from "../../../../src/plugins/spreadsheet/engine/functions/statistical-math.ts";
+import { computeMode, sampleVariance, sampleStdev } from "../../../../src/plugins/spreadsheet/engine/functions/statistical-math.ts";
+import { NA_ERROR, DIV_ZERO_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 
 describe("computeMode", () => {
   it("returns the single most frequent value", () => {

--- a/test/plugins/spreadsheet/engine/test_textFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_textFunctions.ts
@@ -13,8 +13,11 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { substituteText, takeLeft, takeRight, toProperCase } from "../../../../src/plugins/spreadsheet/engine/functions/text.ts";
 import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { VALUE_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 
-const VALUE_ERROR = "#VALUE!";
+// The engine's display pass renders an error VALUE back to its code, so the
+// end-to-end assertions compare against the string a cell shows.
+const VALUE_ERROR_TEXT = VALUE_ERROR.code;
 
 const engine = new SpreadsheetEngine();
 const evalFormula = (formula: string): unknown => engine.calculate(engine.createSheet("S", [[`=${formula}`]])).data[0][0];
@@ -166,17 +169,17 @@ describe("toProperCase — word boundaries include punctuation", () => {
 describe("SpreadsheetEngine — text edge cases end to end", () => {
   it("evaluates SUBSTITUTE with empty old_text and bad instance", () => {
     assert.equal(evalFormula('SUBSTITUTE("abc","","-")'), "abc");
-    assert.equal(evalFormula('SUBSTITUTE("aa","a","b",0)'), VALUE_ERROR);
+    assert.equal(evalFormula('SUBSTITUTE("aa","a","b",0)'), VALUE_ERROR_TEXT);
   });
 
   it("evaluates RIGHT / LEFT with a negative count as an error", () => {
-    assert.equal(evalFormula('RIGHT("Hello",-1)'), VALUE_ERROR);
-    assert.equal(evalFormula('LEFT("Hello",-1)'), VALUE_ERROR);
+    assert.equal(evalFormula('RIGHT("Hello",-1)'), VALUE_ERROR_TEXT);
+    assert.equal(evalFormula('LEFT("Hello",-1)'), VALUE_ERROR_TEXT);
   });
 
   it("errors on a non-numeric count and truncates a fractional one", () => {
-    assert.equal(evalFormula('LEFT("Hello","x")'), VALUE_ERROR);
-    assert.equal(evalFormula('RIGHT("Hello","x")'), VALUE_ERROR);
+    assert.equal(evalFormula('LEFT("Hello","x")'), VALUE_ERROR_TEXT);
+    assert.equal(evalFormula('RIGHT("Hello","x")'), VALUE_ERROR_TEXT);
     assert.equal(evalFormula('RIGHT("Hello",2.5)'), "lo");
   });
 


### PR DESCRIPTION
## Summary

Formula errors were plain strings, so a **real** error and a **string that spells one** were the same value. `IFERROR` therefore could not tell them apart, and the computed case was silently wrong:

| formula | before | after |
|---|---|---|
| `IFERROR(SQRT(-1), 42)` | `42` ✅ | `42` |
| `IFERROR("#NUM!", 42)` | `"#NUM!"` ✅ (via a syntactic workaround) | `"#NUM!"` |
| `IFERROR(CONCAT("#N","UM!"), 42)` | `42` ❌ | `"#NUM!"` ✅ |

An error is now its own value — a small `class SpreadsheetError` with a readonly `code`, `toString()`/`toJSON()` yielding that code, and one interned instance per code so two errors of a kind still compare `===` (as the strings did). `isSpreadsheetErrorValue(v)` is the `instanceof` guard.

- `CellValue` gains the variant; a new `StoredCellValue` keeps the SERIALIZED form (`SpreadsheetCell.v`) free of it, so an error can never be written into the workbook JSON.
- Every function that returned an error string now returns the value.
- The display pass renders it back to `#NUM!` / `#DIV/0!` / `#N/A`, so cells look exactly as before.
- `IFERROR` uses `isErrorResult` (value / NaN / ∞ / null — **not** a look-alike string); `IFNA` keys off the value's `code`.

Full design record: `plans/refactor-2451-error-value-type.md`.

## Items to Confirm / Review

1. **Display is unchanged.** Every `#…` a cell showed before it still shows. `formatCellForDisplay` renders the error value to its code and its return type is now `StoredCellValue`, making it the explicit boundary where a computed value becomes what the cell shows and the workbook serializes. All pre-existing end-to-end assertions (`test_errorReporting`, `test_mathematicalFunctions`, `test_numericFunctions2391`, `test_textFunctions`) pass untouched in their expected values.
2. **The computed-string case is now correct** — the headline. Observed before: `=IFERROR(CONCAT("#N","UM!"), 42)` → `42`. After: `"#NUM!"`. Pinned as a regression test and verified load-bearing by mutation (restoring the string check to `isErrorResult` turns 4 tests red).
3. **`isQuotedLiteral` removed.** It is no longer needed — a string literal simply is not an error value. Worth a look: the workaround was also silently wrong, matching anything that starts and ends with a quote, so `IFERROR("#N" & "UM!", 42)` was exempted by accident and `IFERROR("x" & SQRT(-1), 42)` would have been exempted for a *real* error.
4. **The `CellValue` change + UI consumers.** The only consumer outside the engine is `src/plugins/spreadsheet/View.vue`, which feeds `engine.calculate(...).data` to `XLSX.utils.aoa_to_sheet`. That data is post-display-pass, so it holds only strings/numbers/booleans; `vue-tsc` is clean. Adjacent engine guards that had to learn the variant keep their old answers deliberately: an error is truthy in `coerceToBoolean` (as the string was), and `isApproximateMatch` reads it as FALSE.
5. **Serialization.** `SpreadsheetCell.v: StoredCellValue` is the real guarantee; `toJSON()` returning the code is belt-and-braces so an error reaching any other serializer becomes `"#NUM!"` rather than `{}`.
6. **Two behaviour changes that are NOT preservation** (both were garbage before, both are now the Excel answer) — please sanity-check you agree:
   - `=SQRT(-1)+1` → was the literal text `"#NUM!"+1`, now `#NUM!`
   - `=SQRT(-1)&"x"` → was `#NUM!x`, now `#NUM!`

   These come from the evaluator now propagating a nested call's error VALUE, the same way it already propagated an errored cell reference (#2359).
7. **Deliberate asymmetry, please confirm.** Cell-reference substitution uses `errorCodeOf`, which accepts the error value **or** a cell whose stored TEXT spells a code — preserving #2359, where a literal `#REF!` typed into a cell poisons the arithmetic that reads it. Provenance is enforced where it decides an outcome (IFERROR / IFNA / nested-call results), not for "can I add 1 to this".
8. **Taxonomy merge.** `#ERROR!` (the engine's own catch-all, previously listed only in `formulaError.ts`) is folded into `SPREADSHEET_ERRORS`, and `formulaError.ts`'s duplicate `RECOGNIZED_ERROR_VALUES` / `isErrorValue` are deleted. Side effect: `isSpreadsheetError("#ERROR!")` is now `true`.

## User Prompt

> スプシ、のこっている / どんどんすすめて — the user asked to work through the remaining spreadsheet issues; #2451 assigned to this agent.

## Implementation

**New shape** (`engine/spreadsheet-errors.ts`, now the single source of the error taxonomy):

```ts
export class SpreadsheetError {
  constructor(readonly code: SpreadsheetErrorCode) {}
  toString(): string { return this.code; }
  toJSON(): string { return this.code; }
}
export const spreadsheetError = (code: SpreadsheetErrorCode): SpreadsheetError => ERROR_VALUES[code];
export const isSpreadsheetErrorValue = (value: unknown): value is SpreadsheetError => value instanceof SpreadsheetError;
```

A class rather than a branded object literal: `instanceof` needs no property-name convention kept in sync, no decoded JSON object can accidentally satisfy it, and `toString()` makes every existing text coercion in the engine keep producing `#NUM!` with no extra branch.

**Functions switched to the error value**

| File | What |
|---|---|
| `math-ops.ts` | `floorToSignificance`, `ceilingToSignificance`, `modulo`, `power`, `safeLog`, `logWithBase`, `safeLog10`, `safeSqrt` |
| `datedif.ts` | `computeDatedif` (start after end, unknown unit) |
| `numericCoercion.ts` | `toScalarNumber`; its `VALUE_ERROR` moved to `spreadsheet-errors.ts` |
| `functions/statistical-math.ts` | `computeMode`, `sampleVariance`, `sampleStdev`; its `NA_ERROR` / `DIV_ZERO_ERROR` moved |
| `functions/statistical.ts` | `AVERAGEIF` with no match |
| `functions/text.ts` | `normalizeCharCount`, `takeLeft`, `takeRight`, `substituteText`, `FIND`, `SEARCH`, `VALUE` |
| `functions/lookup.ts` | `VLOOKUP` / `HLOOKUP` / `MATCH` no-match, `INDEX` out of range, `XLOOKUP` default `if_not_found` |
| `functions/logical.ts` | `IFS` with no matching branch |
| `functions/mathematical.ts` | `ABS` / `SIGN` pass the error value through |
| `calculator.ts` | a thrown `FormulaError` stores the error VALUE in the cell, so a cell reading it sees a real error |

**Display / serialization touch points**: `cellFormatting.formatCellForDisplay` (error → code, return type `StoredCellValue`), the final display pass in `calculator.calculateSheet` (deliberately skipped for cross-sheet resolution, which must keep the raw error so it can propagate), `types.SpreadsheetCell.v`, `SpreadsheetError.toJSON`, and the two operand renderers (`evaluator.renderOperand`, `condition.renderConditionOperand`) which quote the code.

**Tests**: new `test/plugins/spreadsheet/engine/test_errorValue.ts` (25 tests) covering the guard, interning, `isErrorResult` value-vs-string, the display pass, functions returning the value, IFERROR provenance including the headline computed-string case, and IFNA by code. Seven existing test files updated so pure helpers compare against the error VALUE while end-to-end assertions still compare against the code STRING.

**Checks**: `npx tsc --noEmit` (root), `vue-tsc --noEmit`, `tsc -p test/tsconfig.json --noEmit`, `eslint src server test` (0 errors), `vite build`, and the full engine suite — **688 tests, 688 pass** (661 before).

Fixes #2451
