### PR TITLE
fix(canvas): per-instance id, honest Clear, off-canvas save, failure UI

### DIFF
--- a/e2e/tests/canvas-plugin.spec.ts
+++ b/e2e/tests/canvas-plugin.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// A 1x1 transparent PNG — the placeholder the server writes for a fresh
+// openCanvas. Served for the canvas background fetch.
+const TINY_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+interface CanvasResult {
+  uuid: string;
+  imageData: string;
+}
+
+async function setupCanvasSession(page: Page, results: CanvasResult[]): Promise<void> {
+  await mockAllApis(page, {
+    sessions: [{ id: "canvas-session", title: "Canvas Session", roleId: "general", startedAt: "2026-04-14T10:00:00Z", updatedAt: "2026-04-14T10:05:00Z" }],
+  });
+
+  await page.route(
+    (url) => url.pathname.startsWith("/api/sessions/") && url.pathname !== "/api/sessions",
+    (route) =>
+      route.fulfill({
+        json: [
+          { type: "session_meta", roleId: "general", sessionId: "canvas-session" },
+          { type: "text", source: "user", message: "I want to draw" },
+          ...results.map((res) => ({
+            type: "tool_result",
+            source: "tool",
+            result: {
+              uuid: res.uuid,
+              toolName: "openCanvas",
+              message: "Drawing Canvas",
+              title: "Drawing Canvas",
+              data: { imageData: res.imageData, prompt: "" },
+            },
+          })),
+        ],
+      }),
+  );
+
+  // Background image fetch for the canvas.
+  await page.route(
+    (url) => url.pathname === "/api/files/raw",
+    (route) => route.fulfill({ contentType: "image/png", body: Buffer.from(TINY_PNG, "base64") }),
+  );
+}
+
+// Land in stack layout so every openCanvas result mounts a live canvas.
+async function useStackLayout(page: Page): Promise<void> {
+  await page.addInitScript(() => window.localStorage.setItem("canvas_layout_mode", "stack"));
+}
+
+test.describe("canvas plugin", () => {
+  test("two canvas results get DISTINCT element ids (no cross-contamination)", async ({ page }) => {
+    await useStackLayout(page);
+    await setupCanvasSession(page, [
+      { uuid: "canvas-a", imageData: "images/canvas-a.png" },
+      { uuid: "canvas-b", imageData: "images/canvas-b.png" },
+    ]);
+    await page.goto("/chat/canvas-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const canvases = page.locator("canvas[id^='vdc-']");
+    await expect(canvases).toHaveCount(2);
+    const ids = await canvases.evaluateAll((els) => els.map((node) => node.id));
+    // Both are per-instance ids, and they differ — the library's
+    // `querySelector('#'+id)` can no longer resolve one canvas for both.
+    expect(new Set(ids).size).toBe(2);
+    expect(ids.every((elementId) => elementId.startsWith("vdc-"))).toBe(true);
+  });
+
+  test("a failed save surfaces the 'not saved' indicator", async ({ page }) => {
+    await useStackLayout(page);
+    await setupCanvasSession(page, [{ uuid: "canvas-a", imageData: "images/canvas-a.png" }]);
+    // Make every image-store PUT fail.
+    await page.route(
+      (url) => url.pathname === "/api/images/update",
+      (route) => route.fulfill({ status: 500, json: { error: "disk full" } }),
+    );
+    await page.goto("/chat/canvas-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const canvas = page.locator("canvas[id^='vdc-']").first();
+    await expect(canvas).toBeVisible();
+    // A stroke end triggers a save; the PUT fails → indicator shows.
+    await canvas.dispatchEvent("mouseup");
+    await expect(page.getByTestId("canvas-save-failed")).toBeVisible();
+  });
+
+  test("Clear PUTs a blank image and remounts the canvas", async ({ page }) => {
+    await useStackLayout(page);
+    await setupCanvasSession(page, [{ uuid: "canvas-a", imageData: "images/canvas-a.png" }]);
+    const puts: string[] = [];
+    await page.route(
+      (url) => url.pathname === "/api/images/update",
+      async (route) => {
+        puts.push(route.request().postData() ?? "");
+        await route.fulfill({ json: { path: "images/canvas-a.png" } });
+      },
+    );
+    await page.goto("/chat/canvas-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+
+    const idBefore = await page.locator("canvas[id^='vdc-']").first().getAttribute("id");
+    // Clear is the red delete-icon button in the toolbar.
+    await page.getByTitle("Clear", { exact: true }).click();
+
+    // A PUT (the blank image) must have fired…
+    await expect.poll(() => puts.length).toBeGreaterThan(0);
+    // …and the canvas must have remounted with a fresh id (renderKey++),
+    // so it re-fetches the now-blank file instead of the stale drawing.
+    await expect.poll(async () => page.locator("canvas[id^='vdc-']").first().getAttribute("id")).not.toBe(idBefore);
+  });
+});

--- a/plans/refactor-plugin-pure-sweep.md
+++ b/plans/refactor-plugin-pure-sweep.md
@@ -44,12 +44,17 @@ Every regression test was mutation-checked (reverting the fix turns it red).
 
 These are verified or plausible but out of scope for a mechanical fix-plus-test PR:
 
-- **canvas** (leans on unmaintained `vue-drawing-canvas@1.0.14`): shared default
-  `canvas-id` cross-contaminates two mounted instances (C1); Clear round-trips
-  cleared content back to disk after remount (C2); white-snapshot race on slow
-  background load (C3); stroke lost on off-canvas release (C4); silent save
-  failures (C6); ResizeObserver + debounced remount; height clamp in stack layout.
-  The `coalescingSaver` extraction (E2) falls out of the C6/C9 fix.
+- **canvas** (leans on unmaintained `vue-drawing-canvas@1.0.14`):
+  ~~shared default `canvas-id` cross-contaminates two mounted instances (C1)~~
+  **(shipped, fix/canvas-save-pipeline — per-instance `canvasElementId`, live
+  e2e verified)**; ~~Clear round-trips cleared content back to disk after
+  remount (C2)~~ **(shipped — blank-PNG PUT + remount, live e2e verified)**;
+  ~~stroke lost on off-canvas release (C4)~~ **(shipped — `@mouseleave` /
+  `@touchcancel` save triggers)**; ~~silent save failures (C6)~~ **(shipped —
+  visible "Not saved" indicator, live e2e verified)**. Still open: white-snapshot
+  race on slow background load (C3 — needs the background-preload gate; narrow
+  window, only when drawing during the initial load of an EXISTING drawing);
+  ResizeObserver + debounced remount; height clamp in stack layout.
 - **photoLocations**: declared `locations-changed` pubsub channel wired nowhere
   (stale list until remount).
 - ~~**scheduler TasksTab**: unsequenced refetch races; full-list remount on every

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -794,6 +794,7 @@ const deMessages = {
     styleLabel: "Stil:",
     stylePromptWithPath: "Wandle das Bild unter `{path}` in ein Bild im {style}-Stil um.",
     stylePromptNoPath: "Wandle meine Zeichnung auf dem Canvas in ein Bild im {style}-Stil um.",
+    saveFailed: "Nicht gespeichert",
   },
   pluginWiki: {
     backToIndex: "Zurück zum Index",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -804,6 +804,7 @@ const enMessages = {
     styleLabel: "Style:",
     stylePromptWithPath: "Turn the image at `{path}` into a {style} style image.",
     stylePromptNoPath: "Turn my drawing on the canvas into a {style} style image.",
+    saveFailed: "Not saved",
   },
   pluginWiki: {
     backToIndex: "Back to index",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -790,6 +790,7 @@ const esMessages = {
     styleLabel: "Estilo:",
     stylePromptWithPath: "Convierte la imagen en `{path}` en una imagen de estilo {style}.",
     stylePromptNoPath: "Convierte mi dibujo en el lienzo en una imagen de estilo {style}.",
+    saveFailed: "Sin guardar",
   },
   pluginWiki: {
     backToIndex: "Volver al índice",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -784,6 +784,7 @@ const frMessages = {
     styleLabel: "Style :",
     stylePromptWithPath: "Transforme l'image en `{path}` en une image de style {style}.",
     stylePromptNoPath: "Transforme mon dessin sur le canevas en une image de style {style}.",
+    saveFailed: "Non enregistré",
   },
   pluginWiki: {
     backToIndex: "Retour à l'index",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -778,6 +778,7 @@ const jaMessages = {
     styleLabel: "スタイル:",
     stylePromptWithPath: "`{path}` の画像を {style} スタイルの画像に変換してください。",
     stylePromptNoPath: "キャンバスに描いた絵を {style} スタイルの画像に変換してください。",
+    saveFailed: "未保存",
   },
   pluginWiki: {
     backToIndex: "インデックスに戻る",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -776,6 +776,7 @@ const koMessages = {
     styleLabel: "스타일:",
     stylePromptWithPath: "`{path}`의 이미지를 {style} 스타일 이미지로 변환해 주세요.",
     stylePromptNoPath: "캔버스에 그린 그림을 {style} 스타일 이미지로 변환해 주세요.",
+    saveFailed: "저장 안 됨",
   },
   pluginWiki: {
     backToIndex: "목차로 돌아가기",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -781,6 +781,7 @@ const ptBRMessages = {
     styleLabel: "Estilo:",
     stylePromptWithPath: "Transforme a imagem em `{path}` em uma imagem no estilo {style}.",
     stylePromptNoPath: "Transforme meu desenho na tela em uma imagem no estilo {style}.",
+    saveFailed: "Não salvo",
   },
   pluginWiki: {
     backToIndex: "Voltar ao índice",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -764,6 +764,7 @@ const zhMessages = {
     styleLabel: "样式:",
     stylePromptWithPath: "将 `{path}` 处的图像转换为 {style} 风格的图像。",
     stylePromptNoPath: "将我在画布上的绘图转换为 {style} 风格的图像。",
+    saveFailed: "未保存",
   },
   pluginWiki: {
     backToIndex: "返回目录",

--- a/src/plugins/canvas/View.vue
+++ b/src/plugins/canvas/View.vue
@@ -31,6 +31,14 @@
         </div>
 
         <div class="flex items-center gap-1">
+          <span
+            v-if="saveFailed"
+            class="text-xs text-red-600 bg-red-50 border border-red-200 rounded px-2 py-1 mr-1"
+            role="alert"
+            data-testid="canvas-save-failed"
+          >
+            {{ t("pluginCanvas.saveFailed") }}
+          </span>
           <button
             class="w-8 h-8 flex items-center justify-center rounded border-2 border-gray-300 bg-white hover:bg-gray-50"
             :title="t('pluginCanvas.undo')"
@@ -61,6 +69,7 @@
         v-if="canvasWidth > 0"
         ref="canvasRef"
         :key="`${selectedResult?.uuid || 'default'}-${canvasRenderKey}`"
+        :canvas-id="canvasDomId"
         :width="canvasWidth"
         :height="canvasHeight"
         stroke-type="dash"
@@ -80,7 +89,9 @@
         }"
         :lock="false"
         @mouseup="saveDrawing"
+        @mouseleave="saveDrawing"
         @touchend="saveDrawing"
+        @touchcancel="saveDrawing"
       />
       <div class="flex items-center gap-2 flex-wrap mt-3">
         <span class="text-xs text-gray-500 mr-1">{{ t("pluginCanvas.styleLabel") }}</span>
@@ -108,6 +119,7 @@ import { pluginEndpoints } from "../api";
 import { resolveImageSrc } from "@mulmoclaude/markdown-utils/image/resolve";
 import { bumpImage } from "@mulmoclaude/markdown-utils/image/cacheBust";
 import { computeCanvasSize } from "./canvasSize";
+import { canvasElementId } from "./canvasElementId";
 
 const imageStoreEndpoints = pluginEndpoints<{ update: string }>("imageStore");
 
@@ -146,6 +158,15 @@ const brushColor = ref("#000000");
 const canvasWidth = ref(0);
 const canvasHeight = ref(0);
 const canvasRenderKey = ref(0);
+
+// Per-instance DOM id so two canvases mounted at once (two openCanvas
+// results in stack layout) don't collide on the library's default
+// `#VueDrawingCanvas` selector and cross-contaminate each other's saves.
+const canvasDomId = computed(() => canvasElementId(props.selectedResult?.uuid, canvasRenderKey.value));
+
+// Set when a stroke's PUT fails so the user sees their work isn't
+// persisting, instead of the failure vanishing into console.error.
+const saveFailed = ref(false);
 
 // The PNG on disk is the source of truth. The path is baked into
 // the tool result at openCanvas time (server-allocated), so reload
@@ -186,11 +207,23 @@ const backgroundImage = computed(() => {
 let uploadInFlight = false;
 let pendingSave = false;
 
-// Snapshot the current bitmap and PUT it back to the pre-allocated
-// file. No result mutation — the path is fixed from canvas creation,
-// so nothing upstream needs to know about saves. `function` (not
-// `const`) so the undo/redo/clear handlers below can reference it
-// without TDZ ordering problems.
+// PUT a data-URI back to the pre-allocated file. No result mutation —
+// the path is fixed from canvas creation, so nothing upstream needs to
+// know about saves. Surfaces failures via `saveFailed` instead of
+// letting them vanish into console.error.
+async function putImage(imageDataUri: string): Promise<void> {
+  const result = await apiPut<{ path: string }>(imageStoreEndpoints.update, {
+    relativePath: imagePath.value,
+    imageData: imageDataUri,
+  });
+  if (!result.ok) throw new Error(`PUT failed: ${result.error}`);
+  bumpImage(imagePath.value);
+}
+
+// Snapshot the current bitmap and PUT it. Coalesces concurrent calls so
+// a burst of stroke-ends collapses to one in-flight upload plus at most
+// one trailing re-run. `function` (not `const`) so undo/redo can
+// reference it without TDZ ordering problems.
 async function saveDrawing(): Promise<void> {
   if (!canvasRef.value || !imagePath.value) return;
   if (uploadInFlight) {
@@ -200,14 +233,11 @@ async function saveDrawing(): Promise<void> {
   uploadInFlight = true;
   try {
     const imageDataUri: string = await canvasRef.value.save();
-    const result = await apiPut<{ path: string }>(imageStoreEndpoints.update, {
-      relativePath: imagePath.value,
-      imageData: imageDataUri,
-    });
-    if (!result.ok) throw new Error(`PUT failed: ${result.error}`);
-    bumpImage(imagePath.value);
+    await putImage(imageDataUri);
+    saveFailed.value = false;
   } catch (error) {
     console.error("Failed to save drawing:", error);
+    saveFailed.value = true;
   } finally {
     uploadInFlight = false;
     if (pendingSave) {
@@ -227,9 +257,30 @@ const redo = () => {
   canvasRef.value?.redo();
   setTimeout(saveDrawing, 50);
 };
-const clear = () => {
+
+// Clear can't just reset the library's strokes: the saved PNG IS the
+// canvas background, so `reset()` re-composites the old drawing and the
+// library's snapshot-during-redraw races back to disk. Instead PUT a
+// blank white PNG directly, then remount so the child drops its stale
+// cached `loadedImage` and re-fetches the now-blank file as background.
+const clear = async () => {
   canvasRef.value?.reset();
-  saveDrawing();
+  if (!imagePath.value) return;
+  const blank = document.createElement("canvas");
+  blank.width = canvasWidth.value;
+  blank.height = canvasHeight.value;
+  const ctx = blank.getContext("2d");
+  if (!ctx) return;
+  ctx.fillStyle = "#FFFFFF";
+  ctx.fillRect(0, 0, blank.width, blank.height);
+  try {
+    await putImage(blank.toDataURL("image/png"));
+    saveFailed.value = false;
+    canvasRenderKey.value++;
+  } catch (error) {
+    console.error("Failed to clear drawing:", error);
+    saveFailed.value = true;
+  }
 };
 
 const updateCanvasSize = () => {

--- a/src/plugins/canvas/canvasElementId.ts
+++ b/src/plugins/canvas/canvasElementId.ts
@@ -1,0 +1,15 @@
+// The vue-drawing-canvas library locates its <canvas> with
+// `document.querySelector('#' + canvasId)`, and its `canvasId` prop
+// defaults to the SAME literal `"VueDrawingCanvas"` for every instance.
+// Two canvases mounted at once (e.g. two openCanvas results in stack
+// layout) then collide: the second instance's setContext / save operate
+// on the FIRST instance's element, cross-contaminating both saved PNGs.
+//
+// A per-instance id keyed on the result uuid (plus the remount counter,
+// so a resize-driven remount gets a fresh element) keeps them distinct.
+// The id must be a valid CSS selector target, so any character outside
+// [A-Za-z0-9_-] is replaced.
+export const canvasElementId = (uuid: string | null | undefined, renderKey: number): string => {
+  const safeUuid = (uuid ?? "default").replace(/[^A-Za-z0-9_-]/g, "-");
+  return `vdc-${safeUuid}-${renderKey}`;
+};

--- a/test/plugins/canvas/test_canvasElementId.ts
+++ b/test/plugins/canvas/test_canvasElementId.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { canvasElementId } from "../../../src/plugins/canvas/canvasElementId.js";
+
+describe("canvasElementId", () => {
+  it("builds a per-uuid id", () => {
+    assert.equal(canvasElementId("result-canvas-1", 0), "vdc-result-canvas-1-0");
+  });
+
+  // Regression: two instances must get DISTINCT ids so the library's
+  // `querySelector('#'+canvasId)` can't resolve one canvas for both.
+  it("gives two different uuids different ids", () => {
+    assert.notEqual(canvasElementId("a", 0), canvasElementId("b", 0));
+  });
+
+  it("changes with the remount counter so a resize gets a fresh element", () => {
+    assert.notEqual(canvasElementId("a", 0), canvasElementId("a", 1));
+  });
+
+  it("falls back to 'default' for null/undefined uuid", () => {
+    assert.equal(canvasElementId(null, 0), "vdc-default-0");
+    assert.equal(canvasElementId(undefined, 2), "vdc-default-2");
+  });
+
+  // The id feeds `querySelector('#'+id)`, so it must stay a valid
+  // selector target — characters outside [A-Za-z0-9_-] are replaced.
+  it("sanitises characters that would break a CSS selector", () => {
+    const elementId = canvasElementId("a/b.c:d 1", 0);
+    assert.equal(elementId, "vdc-a-b-c-d-1-0");
+    assert.ok(/^[A-Za-z0-9_-]+$/.test(elementId));
+  });
+
+  it("is stable for the same inputs", () => {
+    assert.equal(canvasElementId("x", 3), canvasElementId("x", 3));
+  });
+});


### PR DESCRIPTION
## Summary

Batch 7 of #2471's deferred list — the canvas plugin's `vue-drawing-canvas` interaction bugs. **Verified live in the browser** via a new e2e spec (`e2e/tests/canvas-plugin.spec.ts`, 3 tests driven against the real component in chromium), not just unit tests.

- **C1 — data corruption (highest impact).** The library defaults every instance's `canvasId` to the same literal `"VueDrawingCanvas"` and locates its element with `document.querySelector('#'+canvasId)`. Two canvases mounted at once (two `openCanvas` results in stack layout) collide — the second instance's `setContext`/`save` operate on the **first** instance's element, cross-contaminating both saved PNGs. Now each instance gets a per-uuid id via the pure `canvasElementId` (extracted, unit-tested, mutation-checked). **E2e asserts two mounted canvases have DISTINCT ids** — and with the fix reverted, that test fails (`1 failed`).
- **C2 — Clear did nothing.** The saved PNG *is* the canvas background, so `reset()` re-composited the old drawing and the library's snapshot-during-redraw raced it back to disk. Now Clear PUTs a blank white PNG directly, then remounts so the child drops its stale cached background and re-fetches the blank file. **E2e asserts a PUT fires and the canvas remounts with a fresh id.**
- **C4 — lost stroke.** A stroke released off-canvas fired the library's own `mouseleave`/`touchcancel` → `stopDraw`, but the parent only saved on `mouseup`/`touchend`. Added `@mouseleave` / `@touchcancel` save triggers.
- **C6 — silent save failure.** A failed PUT vanished into `console.error`. Added a visible "Not saved" indicator (i18n ×8). **E2e asserts it appears when the PUT 500s.**

## Live verification

```
✓ two canvas results get DISTINCT element ids (no cross-contamination)
✓ a failed save surfaces the 'not saved' indicator
✓ Clear PUTs a blank image and remounts the canvas
  3 passed
```
Plus: `canvasElementId` unit suite 6/6, C1 mutation-checked (fails with shared id), vue-tsc / eslint / prettier / vite build all clean.

## Items to Confirm / Review

- **C3 deferred (noted in the plan):** the white-snapshot race on a *slow* background load needs a background-preload gate; its window is narrow (only when drawing during the initial load of an EXISTING drawing) and it's the subtlest of the set, so it's left for a focused follow-up rather than risking a fragile partial fix here.
- The e2e spec drives real pointer/DOM events against the library canvas in the existing mock harness (no backend). Worth a glance that the assertions match the intended UX.
- i18n `saveFailed` wording is machine-assisted for the 7 non-English locales.

## User Prompt

> Batch 7 canvasを実ブラウザ検証つきで着手して

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas instances now maintain independent drawings when multiple canvases are displayed.
  * Clearing a canvas reliably refreshes it with a blank image.
  * Canvas save failures now display a localized “Not saved” alert.
  * Saving is triggered across additional pointer and touch interactions.
  * Added translations for the save-failure message across supported languages.

* **Tests**
  * Added end-to-end coverage for multiple canvases, failed saves, and clearing behavior.
  * Added validation for unique canvas identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->