### PR TITLE
fix(spreadsheet): RATE/IRR report #NUM! on non-convergence (#2360)

### DIFF
--- a/plans/fix-2360-rate-irr-convergence.md
+++ b/plans/fix-2360-rate-irr-convergence.md
@@ -1,0 +1,57 @@
+# fix(spreadsheet): RATE / IRR report #NUM! on non-convergence — #2360 (final)
+
+## Problem
+
+`computeRate` and `computeIrr` (`engine/financial-math.ts`) solve their equations
+with Newton-Raphson. On a series with no real solution the iteration never
+converges — but the code fell out of the loop and returned the **last iterate**:
+a divergent finite number or `NaN`, handed back as if it were a valid rate. Excel
+reports `#NUM!` there. `computeIrr` additionally `throw`w `new Error("IRR cannot
+converge")` on a flat derivative, which after #2492 (errors are values) is
+inconsistent with the rest of the engine.
+
+This is the last unfixed row of the #2360 mismatch table.
+
+## Fix
+
+Both functions now return `number | SpreadsheetError` and yield `NUM_ERROR`
+(`#NUM!`) when:
+- the loop exhausts `NEWTON_MAX_ITERATIONS`, or
+- a converged step is non-finite, or
+- (IRR) the derivative collapses — replacing the `throw`.
+
+The two handlers in `functions/financial.ts` already return the helper's result
+directly, so the error value propagates as a cell value like every other
+function's `#NUM!`/`#DIV/0!`.
+
+## Tests
+
+`test_financialMath.ts` — two pre-existing tests **deliberately pinned the old
+Excel-divergent behaviour** (their comments said "pinned so a future change is a
+conscious decision"); this is that conscious change, so they were rewritten to
+assert `#NUM!`:
+- RATE with no root → `NUM_ERROR`
+- IRR on same-sign flows → `NUM_ERROR`
+
+The convergent cases are unchanged (a `converged()` type-guard narrows the union
+for the numeric assertions — no `as` cast).
+
+**Mutation-verified**: reverting both non-convergence returns to the old
+`return rate` / `throw` turns exactly those two tests red (`pass 24 / fail 2`),
+green after restore.
+
+## #2360 coverage (all rows now addressed)
+
+| Row | PR |
+|---|---|
+| IF nested function | #2474 |
+| IFERROR | #2492 (error value type) |
+| HLOOKUP/VLOOKUP 4th arg, out-of-range | #2453, #2506 |
+| STDEV/VAR sample | #2453 |
+| MOD, ROUND(UP/DOWN), ROUND negative | #2432, #2501 |
+| NPV period offset | #2441 |
+| RATE/IRR non-convergence | **this PR** |
+| IFS eval | #2362 |
+| MID bounds, VALUE | #2503 |
+| COUNTIF/SUMIF criteria, coercion | #2485, #2502 |
+| TEXT digit grouping | #2510 |

--- a/src/plugins/spreadsheet/engine/financial-math.ts
+++ b/src/plugins/spreadsheet/engine/financial-math.ts
@@ -8,6 +8,8 @@
  * arguments back through the formula evaluator.
  */
 
+import { NUM_ERROR, type SpreadsheetError } from "./spreadsheet-errors";
+
 /** Future value after `nper` periods. `type` is 0 (end of period) or 1 (begin). */
 export function computeFv(rate: number, nper: number, pmt: number, pv: number, type: number): number {
   if (rate === 0) return -(pv + pmt * nper);
@@ -55,13 +57,14 @@ export function computeNper(rate: number, pmt: number, pv: number, fv: number, t
 }
 
 // Newton-Raphson is iterative; a valid annuity / cash-flow series converges well
-// inside these bounds. On non-convergence RATE and IRR return the last iterate (a
-// divergent value or NaN) rather than Excel's #NUM!, preserving prior behaviour.
+// inside these bounds. A series with no real solution never does, so exhausting
+// the loop means "no answer" — Excel reports #NUM! there, and returning the last
+// iterate instead would hand back a divergent value or NaN as if it were a rate.
 const NEWTON_MAX_ITERATIONS = 100;
 const NEWTON_TOLERANCE = 1e-7;
 
 /** Interest rate per period solving the annuity equation, via Newton-Raphson. */
-export function computeRate(nper: number, pmt: number, pv: number, fv: number, type: number, guess: number): number {
+export function computeRate(nper: number, pmt: number, pv: number, fv: number, type: number, guess: number): number | SpreadsheetError {
   let rate = guess;
   for (let i = 0; i < NEWTON_MAX_ITERATIONS; i++) {
     if (Math.abs(rate) < NEWTON_TOLERANCE) rate = NEWTON_TOLERANCE; // avoid division by zero
@@ -72,10 +75,10 @@ export function computeRate(nper: number, pmt: number, pv: number, fv: number, t
       (pmt * (1 + rate * type) * (nper * Math.pow(1 + rate, nper - 1) * rate - (growth - 1))) / (rate * rate) +
       pmt * type * ((growth - 1) / rate);
     const newRate = rate - f / df;
-    if (Math.abs(newRate - rate) < NEWTON_TOLERANCE) return newRate;
+    if (Math.abs(newRate - rate) < NEWTON_TOLERANCE) return Number.isFinite(newRate) ? newRate : NUM_ERROR;
     rate = newRate;
   }
-  return rate;
+  return NUM_ERROR;
 }
 
 /** Net present value of `cashflows`, each discounted one period further into the future. */
@@ -84,7 +87,7 @@ export function computeNpv(rate: number, cashflows: number[]): number {
 }
 
 /** Internal rate of return of `values` (element 0 at period 0), via Newton-Raphson. */
-export function computeIrr(values: number[], guess: number): number {
+export function computeIrr(values: number[], guess: number): number | SpreadsheetError {
   let rate = guess;
   for (let i = 0; i < NEWTON_MAX_ITERATIONS; i++) {
     let npv = 0;
@@ -95,10 +98,11 @@ export function computeIrr(values: number[], guess: number): number {
       dnpv -= (j * values[j]) / (factor * (1 + rate));
     }
     if (Math.abs(npv) < NEWTON_TOLERANCE) return rate;
-    if (Math.abs(dnpv) < NEWTON_TOLERANCE) throw new Error("IRR cannot converge");
+    // A flat derivative leaves nowhere to step: the series has no root here.
+    if (Math.abs(dnpv) < NEWTON_TOLERANCE) return NUM_ERROR;
     const newRate = rate - npv / dnpv;
-    if (Math.abs(newRate - rate) < NEWTON_TOLERANCE) return newRate;
+    if (Math.abs(newRate - rate) < NEWTON_TOLERANCE) return Number.isFinite(newRate) ? newRate : NUM_ERROR;
     rate = newRate;
   }
-  return rate;
+  return NUM_ERROR;
 }

--- a/test/plugins/spreadsheet/engine/test_financialMath.ts
+++ b/test/plugins/spreadsheet/engine/test_financialMath.ts
@@ -16,8 +16,15 @@ import {
   computeNpv,
   computeIrr,
 } from "../../../../src/plugins/spreadsheet/engine/financial-math.ts";
+import { NUM_ERROR, type SpreadsheetError } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 
 const closeTo = (actual: number, expected: number, eps = 0.01): boolean => Math.abs(actual - expected) <= eps;
+
+/** RATE / IRR may answer `#NUM!`; the convergent cases assert on the number. */
+const converged = (result: number | SpreadsheetError): number => {
+  if (typeof result !== "number") throw new Error(`expected a rate, got ${String(result)}`);
+  return result;
+};
 
 // A 250,000 loan at 0.5%/period over 360 periods — the issue's worked example.
 const RATE = 0.005;
@@ -138,15 +145,11 @@ describe("computeNper", () => {
 describe("computeRate", () => {
   it("recovers the rate implied by a known payment via Newton-Raphson", () => {
     const payment = computePmt(0.05, 12, 1000, 0, 0);
-    assert.ok(closeTo(computeRate(12, payment, 1000, 0, 0, 0.1), 0.05, 1e-6), "RATE recovers 0.05");
+    assert.ok(closeTo(converged(computeRate(12, payment, 1000, 0, 0, 0.1)), 0.05, 1e-6), "RATE recovers 0.05");
   });
 
-  // Deliberate known limitation: with no real root the iteration diverges to a
-  // finite nonsense value; Excel reports #NUM!. Pinned so a future change to the
-  // convergence handling is a conscious decision, not a silent regression.
-  it("returns a divergent finite value instead of Excel's #NUM! when no root exists", () => {
-    const diverged = computeRate(10, 100, 100, 100, 0, 0.1);
-    assert.ok(closeTo(diverged, -2.5804947624929158, 1e-9), "divergent finite rate is preserved");
+  it("reports #NUM! instead of a divergent rate when no root exists", () => {
+    assert.equal(computeRate(10, 100, 100, 100, 0, 0.1), NUM_ERROR);
   });
 });
 
@@ -168,18 +171,18 @@ describe("computeNpv", () => {
 
 describe("computeIrr", () => {
   it("finds the rate that zeroes the NPV (Excel IRR)", () => {
-    assert.ok(closeTo(computeIrr([-100, 60, 60], 0.1), 0.130662, 1e-5), "IRR ≈ 0.130662");
+    assert.ok(closeTo(converged(computeIrr([-100, 60, 60], 0.1)), 0.130662, 1e-5), "IRR ≈ 0.130662");
   });
 
   it("drives the period-0 discounted cash flows to zero at the returned rate", () => {
-    const irr = computeIrr([-1000, 500, 400, 300, 100], 0.1);
+    const irr = converged(computeIrr([-1000, 500, 400, 300, 100], 0.1));
     const npvFromPeriodZero = [-1000, 500, 400, 300, 100].reduce((sum, value, index) => sum + value / (1 + irr) ** index, 0);
     assert.ok(closeTo(npvFromPeriodZero, 0, 1e-6), "NPV at IRR ≈ 0");
   });
 
-  // Same-sign cash flows have no internal rate of return; the derivative collapses
-  // and the current code throws rather than returning Excel's #NUM!. Pinned.
-  it("throws when the cash flows never change sign", () => {
-    assert.throws(() => computeIrr([100, 200, 300], 0.1), /IRR cannot converge/);
+  // Same-sign cash flows have no internal rate of return: the derivative collapses
+  // and there is nowhere to step, which Excel reports as #NUM!.
+  it("reports #NUM! when the cash flows never change sign", () => {
+    assert.equal(computeIrr([100, 200, 300], 0.1), NUM_ERROR);
   });
 });


### PR DESCRIPTION
## Summary

The last unfixed row of #2360. `computeRate` / `computeIrr` solve their equations with Newton-Raphson; on a series with **no real solution** the loop just returned its last iterate — a divergent number or `NaN` — as if it were a valid rate. Excel returns `#NUM!` there.

Both now return `number | SpreadsheetError` and yield `NUM_ERROR` (`#NUM!`) when the loop exhausts its iterations, when a converged step is non-finite, or (IRR) when the derivative collapses — the last of which **replaces IRR's old `throw`**, aligning it with #2492's error-value model (errors are values, not exceptions/strings). The two handlers already return the helper's result directly, so `#NUM!` propagates as a cell value like every other function's.

## Items to Confirm / Review

- **Two pre-existing tests deliberately pinned the old divergent behaviour** — their own comments said "pinned so a future change is a conscious decision, not a silent regression." This is that conscious change, so they were rewritten to assert `#NUM!`. The convergent cases are untouched; a `converged()` type-guard narrows the union for the numeric assertions (no `as` cast).
- **Mutation-verified**: reverting both non-convergence returns to `return rate` / `throw` turns exactly those two tests red (`pass 24 / fail 2`), green after restore.

## #2360 — every row now addressed

| Row | PR |
|---|---|
| IF nested function | #2474 |
| IFERROR | #2492 |
| HLOOKUP/VLOOKUP 4th arg, out-of-range | #2453, #2506 |
| STDEV/VAR sample | #2453 |
| MOD, ROUNDUP/DOWN, ROUND negative | #2432, #2501 |
| NPV period offset | #2441 |
| RATE/IRR non-convergence | **this PR** |
| IFS eval | #2362 |
| MID bounds, VALUE | #2503 |
| COUNTIF/SUMIF criteria, coercion | #2485, #2502 |
| TEXT digit grouping | #2510 |

## Verification

`yarn format`/`yarn lint`/`yarn typecheck` clean; full spreadsheet engine suite **829 pass / 0 fail** (financial-math 26/26). No version bumps.

Closes #2360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)