### PR TITLE
fix(manageSkills): repo-list load failure gets its own error channel

### DIFF
--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -485,6 +485,30 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     await expect(page.getByTestId("skill-catalog-add-repo")).toBeVisible();
   });
 
+  // Regression: the installed-repo LIST load and the catalog load run
+  // concurrently. A repo-list failure used to write the shared
+  // `catalogError`, which the sibling catalog SUCCESS then nulled — the
+  // error vanished and the repo groups silently disappeared. The repo-list
+  // failure now has its own channel that the catalog success can't clobber.
+  test("a repo-list load failure surfaces its own error, not clobbered by catalog success", async ({ page }) => {
+    const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
+    await setupExternalCatalog(page, calls);
+    // Override the repo-list GET to fail; catalog GET still succeeds.
+    await page.route(urlEndsWith("/api/skills/external/repos"), (route) => {
+      if (route.request().method() === "POST") return route.fallback();
+      return route.fulfill({ status: 500, json: { error: "repo registry corrupt" } });
+    });
+    await page.goto("/chat/skills-session");
+    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await page.getByText("2 skills").first().click();
+
+    // The catalog load resolving (presets render) is the very event that
+    // used to null the shared error — assert it happened, then that the
+    // repo-list error survived it in its own channel.
+    await expect(page.getByTestId("skill-catalog-item-mc-foo")).toBeVisible();
+    await expect(page.getByTestId("skill-catalog-repo-list-error")).toBeVisible();
+  });
+
   test("selecting an external entry loads detail and Star sends external params", async ({ page }) => {
     const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
     await setupExternalCatalog(page, calls);

--- a/plans/refactor-plugin-pure-sweep.md
+++ b/plans/refactor-plugin-pure-sweep.md
@@ -56,9 +56,11 @@ These are verified or plausible but out of scope for a mechanical fix-plus-test 
   mutation (scroll/expand reset); unconfirmed one-click delete; hardcoded English
   frequency-hint labels (8-locale change).~~ **Shipped (fix/scheduler-tasks-robustness).**
 - **manageSkills**: ~~same-repo update/uninstall overlap~~ **(shipped)**;
-  four loaders sharing one `catalogError` channel (still open — needs a UX call
-  on where the repo-list error surfaces); post-delete selection clobber;
-  ~~`actionLock` extraction (release-if-owner)~~ **(shipped, fix/manageskills-loader-races)**.
+  ~~repo-list load failure sharing the `catalogError` channel (clobbered by a
+  concurrent catalog success)~~ **(shipped, fix/manageskills-repo-error-channel
+  — own `repoListError` ref, live e2e + mutation verified)**; post-delete
+  selection clobber; ~~`actionLock` extraction (release-if-owner)~~ **(shipped,
+  fix/manageskills-loader-races)**.
 - **manageRoles** ~~IME-Enter commits half-typed names; no re-entrancy guard
   on Enter; unconfirmed delete; refresh-failure swallowed~~ **(shipped,
   fix/manageroles-form-robustness — applied to BOTH the plugin View and the

--- a/src/plugins/manageSkills/View.vue
+++ b/src/plugins/manageSkills/View.vue
@@ -146,6 +146,11 @@
             </p>
             <div v-if="catalogError" class="px-4 py-2 text-xs text-red-600">{{ catalogError }}</div>
 
+            <!-- Installed-repo LIST load failure — surfaced here next to the
+                 repo groups, not in the shared catalogError (which a
+                 concurrent catalog load would clobber). -->
+            <div v-if="repoListError" class="px-4 py-2 text-xs text-red-600" data-testid="skill-catalog-repo-list-error">{{ repoListError }}</div>
+
             <!-- External repos (#1383 PR-C2): one collapsible subgroup
                  per installed repo. Rows behave exactly like preset
                  rows (select → right pane with ★ Star / ▶ Run once). -->
@@ -519,6 +524,7 @@ const repos = useExternalRepos({
 });
 const {
   externalGroups,
+  repoListError,
   isRepoOpen,
   toggleRepo,
   addRepoOpen,

--- a/src/plugins/manageSkills/useExternalRepos.ts
+++ b/src/plugins/manageSkills/useExternalRepos.ts
@@ -59,6 +59,13 @@ export interface ExternalReposGroup {
 // (#2481) instead of being mirrored into two lists that can drift apart.
 interface ReposRefs {
   catalogRepos: Ref<ExternalRepo[]>;
+  /** Failure of the installed-repo LIST load. Kept separate from the
+   *  shared `catalogError` (which carries per-action install/uninstall/
+   *  update failures): the two loaders run concurrently via `Promise.all`,
+   *  so routing a repo-list failure into `catalogError` let a sibling
+   *  `loadCatalog` success null it out — the repo groups vanished with no
+   *  error shown. This channel surfaces next to the repo list instead. */
+  repoListError: Ref<string | null>;
   /** Per-repo collapse set (repoId ∈ set ⇒ collapsed). */
   repoCollapsed: Ref<Set<string>>;
   addRepoOpen: Ref<boolean>;
@@ -106,9 +113,11 @@ function toggleRepo(state: ReposState, repoId: string): void {
 async function loadExternalRepos(state: ReposState): Promise<void> {
   const response = await apiGet<{ repos: ExternalRepo[] }>(state.endpoints.externalReposList.url);
   if (!response.ok) {
-    state.deps.catalogError.value = state.t("pluginManageSkills.errCatalogRepoListFailed", { error: response.error });
+    state.repoListError.value = state.t("pluginManageSkills.errCatalogRepoListFailed", { error: response.error });
     return;
   }
+  // Clear on success so a recovered load drops a stale error banner.
+  state.repoListError.value = null;
   if (Array.isArray(response.data.repos)) state.catalogRepos.value = response.data.repos;
 }
 
@@ -213,6 +222,7 @@ function resetModalState(state: ReposState): void {
 function createReposRefs(): ReposRefs {
   return {
     catalogRepos: ref<ExternalRepo[]>([]),
+    repoListError: ref<string | null>(null),
     // shallowRef: the Set is replaced wholesale on toggle, so the deep
     // proxy ref() would build is wasted.
     repoCollapsed: shallowRef<Set<string>>(loadRepoCollapsed()),


### PR DESCRIPTION
## Summary

Follow-up to #2471's deferred list. The installed-repo **list** load and the **catalog** load run concurrently (`Promise.all` on mount and after every repo mutation). A repo-list failure wrote the **shared `catalogError`**, which the sibling catalog **success** then nulled — so the error banner vanished and the repo groups silently disappeared, with nothing shown. Whether the user ever saw the failure was nondeterministic (depended on response arrival order).

- Added a dedicated `repoListError` ref (owned by `useExternalRepos`, next to `catalogRepos`), cleared on a recovered load, surfaced in its own banner beside the repo groups (`data-testid="skill-catalog-repo-list-error"`).
- `loadExternalRepos` now writes `repoListError`, not the shared `catalogError` — which keeps carrying per-action install/uninstall/update failures (those legitimately belong on the catalog action surface).

## Live verification

New e2e (`skills.spec.ts`): repo-list GET `500` + catalog GET `200` → the repo-list error **shows and stays** after the catalog resolves (presets render). All 5 external-catalog tests pass.

**Mutation-checked:** routing the failure back to `catalogError` turns the new test red (`1 failed`). vue-tsc / eslint clean.

## Items to Confirm / Review

- This resolves the "four loaders sharing one `catalogError`" item from the deferred list — specifically the repo-**list** loader. The install/uninstall/update **action** errors intentionally stay on `catalogError` (co-located with where those actions live). Confirm that split matches the intended UX.
- The error banner sits directly above the repo groups in the catalog section.

## User Prompt

> manageSkills catalogError 分離を進めて

🤖 Generated with [Claude Code](https://claude.com/claude-code)