### PR TITLE
chore: add a "lint" script to every publishable workspace package (#2521)

### DIFF
--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/email/package.json
+++ b/packages/bridges/email/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmobridge/google-chat",
   "version": "0.1.1",
-  "description": "Google Chat bridge for MulmoBridge \u2014 connect Google Chat to MulmoClaude",
+  "description": "Google Chat bridge for MulmoBridge — connect Google Chat to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmobridge/line-works",
   "version": "0.1.1",
-  "description": "LINE Works bridge for MulmoBridge \u2014 enterprise LINE (separate API from the consumer product)",
+  "description": "LINE Works bridge for MulmoBridge — enterprise LINE (separate API from the consumer product)",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmobridge/line",
   "version": "0.1.1",
-  "description": "LINE bridge for MulmoBridge \u2014 connect a LINE bot to MulmoClaude",
+  "description": "LINE bridge for MulmoBridge — connect a LINE bot to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmobridge/messenger",
   "version": "0.1.1",
-  "description": "Facebook Messenger bridge for MulmoBridge \u2014 connect Messenger to MulmoClaude",
+  "description": "Facebook Messenger bridge for MulmoBridge — connect Messenger to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -17,7 +17,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmobridge/viber",
   "version": "0.1.1",
-  "description": "Viber bridge for MulmoBridge \u2014 Public Account chatbot via webhook + REST",
+  "description": "Viber bridge for MulmoBridge — Public Account chatbot via webhook + REST",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmobridge/whatsapp",
   "version": "0.1.1",
-  "description": "WhatsApp bridge for MulmoBridge \u2014 connect WhatsApp Business to MulmoClaude",
+  "description": "WhatsApp bridge for MulmoBridge — connect WhatsApp Business to MulmoClaude",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -16,7 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet"
+    "test": "echo no tests yet",
+    "lint": "eslint src"
   },
   "license": "MIT",
   "author": "Receptron Team",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -199,7 +199,8 @@
   "scripts": {
     "build": "vite build && vite build -c vite.esm.config.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/**/test_*.ts"
+    "test": "tsx --test test/**/test_*.ts",
+    "lint": "eslint src test"
   },
   "dependencies": {
     "@duckdb/node-api": "^1.5.5-r.1",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "build": "vite build && vue-tsc -p tsconfig.build.json --emitDeclarationOnly",
     "typecheck": "vue-tsc --noEmit",
-    "test": "tsx --test test/test_*.ts test/accounting/test_*.ts"
+    "test": "tsx --test test/test_*.ts test/accounting/test_*.ts",
+    "lint": "eslint src test"
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.0",

--- a/packages/plugins/bookmarks-plugin/package.json
+++ b/packages/plugins/bookmarks-plugin/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_bookmarks_integration.ts'"
+    "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_bookmarks_integration.ts'",
+    "lint": "eslint src"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "vite build && vue-tsc -p tsconfig.build.json --emitDeclarationOnly",
     "typecheck": "vue-tsc --noEmit",
-    "test": "echo 'no in-package tests; collection logic is covered by host tests test/utils/collections/*'"
+    "test": "echo 'no in-package tests; collection logic is covered by host tests test/utils/collections/*'",
+    "lint": "eslint src"
   },
   "dependencies": {
     "vuedraggable": "^4.1.0",

--- a/packages/plugins/debug-plugin/package.json
+++ b/packages/plugins/debug-plugin/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no in-package tests; debug plugin is exercised manually via /debug'"
+    "test": "echo 'no in-package tests; debug plugin is exercised manually via /debug'",
+    "lint": "eslint src"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/edgar-plugin/package.json
+++ b/packages/plugins/edgar-plugin/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/email-plugin/package.json
+++ b/packages/plugins/email-plugin/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "dependencies": {
     "@mulmoclaude/core": "^1.2.0"

--- a/packages/plugins/recipe-book-plugin/package.json
+++ b/packages/plugins/recipe-book-plugin/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_recipe_book_integration.ts'"
+    "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_recipe_book_integration.ts'",
+    "lint": "eslint src"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/spotify-plugin/package.json
+++ b/packages/plugins/spotify-plugin/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'no in-package tests; covered by host tests under test/plugins/spotify/'"
+    "test": "echo 'no in-package tests; covered by host tests under test/plugins/spotify/'",
+    "lint": "eslint src"
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.0"

--- a/packages/plugins/x-plugin/package.json
+++ b/packages/plugins/x-plugin/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.0"

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -20,7 +20,8 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/test_*.ts"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260723.1",


### PR DESCRIPTION
## Summary

Adds a per-package `lint` script to all 35 publishable workspaces that lacked one, so `yarn lint` works from inside any package and the `/publish` flow stops erroring with `Command "lint" not found`. Before this, only 5 of 42 packages (`common`, `client`, `markdown-utils`, `chat-service`, `protocol`) had it.

The script matches each package's layout:
- **`eslint src test`** where a `test/` directory exists (core, mastodon, relay, x-plugin, edgar/email/google/accounting plugins, line/slack/teams/xmpp bridges)
- **`eslint src`** otherwise — eslint errors on a missing `test` path, so packages without tests must not name it

Two commits:
1. core + mastodon (the two that surfaced during today's npm publishes)
2. the remaining 33 bridges/plugins/relay

## Items to Confirm / Review

- **Config only — no source or behavior changes.** All these sources were *already* linted by root `yarn lint` (`eslint … packages …`, run by CI's `lint_test`); this only adds per-package entry points. This is a consistency/ergonomics fix, not a lint-coverage fix.
- **Verified**: `yarn lint` runs green in all 35 packages individually, and root `yarn lint` is unchanged (still green).
- **Launcher excluded on purpose**: `packages/mulmoclaude`'s `src`/`server`/`client` subtrees are ignored by the root flat config (`eslint.config.mjs`), so a per-package eslint invocation there would match no files and error. Left without a `lint` script.

## User Prompt

- >lint スクリプトが core には存在しないだけでした これってあったほうがよくない？どこかでlintされてる？
- で、もしほかでも抜けがあったら追加してね。確認だけして必要ならissue化
- mastodon publish , lintの追加もすぐに
- 残りもまとめてやって！

## 実装アプローチ

Confirmed root `eslint.config.mjs` already lints `packages/**/src`, so no package was unlinted. Enumerated every publishable, non-private workspace missing a `lint` script, chose `eslint src test` vs `eslint src` by whether `test/` exists, applied, ran `yarn lint` in each to confirm green, and re-ran root `yarn lint` to confirm no regression. Excluded the launcher because its subtrees are deliberately root-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)