### PR TITLE
refactor(wiki): extract the task save queue into a pure, tested module

### DIFF
--- a/plans/refactor-plugin-pure-sweep.md
+++ b/plans/refactor-plugin-pure-sweep.md
@@ -80,8 +80,9 @@ These are verified or plausible but out of scope for a mechanical fix-plus-test 
   snapshot failure rendered as "page deleted"~~ **(shipped, fix/wiki-stale-response)**;
   ~~renderer vs `WIKI_LINK_PATTERN` divergence (core)~~ **(shipped, #2515)**;
   ~~save-queue extraction (`taskSaveQueue`)~~ **(shipped,
-  refactor/wiki-save-queue — pure `createTaskSaveQueue`, 8 node:test cases
-  incl. the #775 generation-invalidation invariant)**.
+  refactor/wiki-save-queue — pure `createTaskSaveQueue`, 9 node:test cases
+  incl. the #775 generation-invalidation invariant and a rejected-persist
+  regression)**.
 - ~~**textResponse / StackView**: speaker labels hardcoded English (×8);
   StackView duplicate capture-phase link handler (opens 2 tabs); StackView
   edit panel emits to nothing (silent edit loss); copy button copies rewritten

--- a/plans/refactor-plugin-pure-sweep.md
+++ b/plans/refactor-plugin-pure-sweep.md
@@ -76,8 +76,10 @@ These are verified or plausible but out of scope for a mechanical fix-plus-test 
   imported without re-coupling).
 - **wiki**: ~~stale-response tokens for `callApi`/`loadPageEditData`; non-404
   snapshot failure rendered as "page deleted"~~ **(shipped, fix/wiki-stale-response)**;
-  renderer vs `WIKI_LINK_PATTERN` divergence (core); save-queue extraction
-  (`taskSaveQueue`).
+  ~~renderer vs `WIKI_LINK_PATTERN` divergence (core)~~ **(shipped, #2515)**;
+  ~~save-queue extraction (`taskSaveQueue`)~~ **(shipped,
+  refactor/wiki-save-queue — pure `createTaskSaveQueue`, 8 node:test cases
+  incl. the #775 generation-invalidation invariant)**.
 - ~~**textResponse / StackView**: speaker labels hardcoded English (×8);
   StackView duplicate capture-phase link handler (opens 2 tabs); StackView
   edit panel emits to nothing (silent edit loss); copy button copies rewritten

--- a/src/plugins/wiki/composables/useWikiPageSave.ts
+++ b/src/plugins/wiki/composables/useWikiPageSave.ts
@@ -3,6 +3,7 @@ import { useI18n } from "vue-i18n";
 import { WIKI_ACTION } from "@mulmoclaude/core/wiki";
 import { apiPost } from "../../../utils/api";
 import { computeToggledContent } from "../helpers";
+import { createTaskSaveQueue, type SaveResult } from "../taskSaveQueue";
 
 interface WikiPageSaveDeps {
   action: Ref<string>;
@@ -21,52 +22,31 @@ function revert(target: HTMLInputElement): void {
   target.checked = !target.checked;
 }
 
-// Serialised POST chain for rapid task-checkbox clicks (#775): each click queues
-// onto the previous so a slower network can't reorder writes.
-// `saveQueueGeneration` invalidates older queued saves after a failure-triggered
-// refresh — their captured snapshots were computed against the now-discarded
-// optimistic state, so writing them would overwrite canonical server content.
+// Thin DOM/optimistic-update glue over the pure `createTaskSaveQueue`, which
+// owns the serialisation + generation-invalidation + page-switch rules
+// (#775). This composable only wires the wiki API, i18n, and the checkbox
+// event into that queue.
 export function useWikiPageSave(deps: WikiPageSaveDeps): WikiPageSave {
   const { t } = useI18n();
-  let taskPersistChain: Promise<unknown> = Promise.resolve();
-  let saveQueueGeneration = 0;
 
-  async function persistWikiPage(pageName: string, newContent: string, generation: number): Promise<void> {
-    // Stale queued save (a previous save failed + refresh discarded the
-    // optimistic state this snapshot was based on).
-    if (generation !== saveQueueGeneration) return;
-    // Navigation changed mid-flight — saving this snapshot to a different page
-    // would clobber unrelated state; the route/result watchers already load it.
-    if (deps.currentSlug() !== pageName) return;
-
-    const response = await apiPost<{ data?: { content?: string } }>(deps.endpointBase, {
-      action: WIKI_ACTION.save,
-      pageName,
-      content: newContent,
-    });
-
-    if (generation !== saveQueueGeneration) return;
-    if (deps.currentSlug() !== pageName) return;
-
-    if (!response.ok) {
-      deps.navError.value = response.status === 0 ? response.error : `Wiki save failed (${response.status}): ${response.error}`;
-      // The generation bump must come AFTER refresh: clicks arriving WHILE
-      // refresh is in flight capture the pre-bump generation, so bumping
-      // post-refresh invalidates them too.
-      await deps.refresh();
-      saveQueueGeneration += 1;
-      return;
-    }
-    deps.navError.value = null;
-  }
-
-  // `.catch` keeps the chain self-healing: an uncaught rejection would leave the
-  // chain permanently rejected and silently drop every later click. The error
-  // is already surfaced via navError inside persistWikiPage.
-  function queueSave(pageName: string, newContent: string): void {
-    const generation = saveQueueGeneration;
-    taskPersistChain = taskPersistChain.then(() => persistWikiPage(pageName, newContent, generation)).catch(() => undefined);
-  }
+  const queue = createTaskSaveQueue({
+    persist: async (pageName, content): Promise<SaveResult> => {
+      const response = await apiPost<{ data?: { content?: string } }>(deps.endpointBase, {
+        action: WIKI_ACTION.save,
+        pageName,
+        content,
+      });
+      return { ok: response.ok, status: response.ok ? 200 : response.status, error: response.ok ? "" : response.error };
+    },
+    refresh: () => deps.refresh(),
+    getCurrentSlug: deps.currentSlug,
+    onError: (message) => {
+      deps.navError.value = message;
+    },
+    onSuccess: () => {
+      deps.navError.value = null;
+    },
+  });
 
   function onTaskCheckboxClick(event: MouseEvent, target: HTMLInputElement): void {
     const root = event.currentTarget;
@@ -89,7 +69,7 @@ export function useWikiPageSave(deps: WikiPageSaveDeps): WikiPageSave {
     // Optimistic local update — re-render is driven by content's watcher.
     deps.content.value = result.content;
     deps.navError.value = null;
-    queueSave(pageName, result.content);
+    queue.queueSave(pageName, result.content);
   }
 
   return { onTaskCheckboxClick };

--- a/src/plugins/wiki/composables/useWikiPageSave.ts
+++ b/src/plugins/wiki/composables/useWikiPageSave.ts
@@ -2,6 +2,7 @@ import type { Ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { WIKI_ACTION } from "@mulmoclaude/core/wiki";
 import { apiPost } from "../../../utils/api";
+import { errorMessage } from "../../../utils/errors";
 import { computeToggledContent } from "../helpers";
 import { createTaskSaveQueue, type SaveResult } from "../taskSaveQueue";
 
@@ -31,12 +32,18 @@ export function useWikiPageSave(deps: WikiPageSaveDeps): WikiPageSave {
 
   const queue = createTaskSaveQueue({
     persist: async (pageName, content): Promise<SaveResult> => {
-      const response = await apiPost<{ data?: { content?: string } }>(deps.endpointBase, {
-        action: WIKI_ACTION.save,
-        pageName,
-        content,
-      });
-      return { ok: response.ok, status: response.ok ? 200 : response.status, error: response.ok ? "" : response.error };
+      // apiPost already encodes network failures as { ok:false, status:0 },
+      // but guard the fetch call anyway (repo rule: handle throws too).
+      try {
+        const response = await apiPost<{ data?: { content?: string } }>(deps.endpointBase, {
+          action: WIKI_ACTION.save,
+          pageName,
+          content,
+        });
+        return { ok: response.ok, status: response.ok ? 200 : response.status, error: response.ok ? "" : response.error };
+      } catch (err) {
+        return { ok: false, status: 0, error: errorMessage(err) };
+      }
     },
     refresh: () => deps.refresh(),
     getCurrentSlug: deps.currentSlug,

--- a/src/plugins/wiki/taskSaveQueue.ts
+++ b/src/plugins/wiki/taskSaveQueue.ts
@@ -19,6 +19,11 @@
 //   - The chain is self-healing: a rejected persist must not leave the
 //     chain permanently rejected (which would silently drop every later
 //     click).
+//   - A persist that THROWS (rather than returning `{ ok: false }`) is
+//     converted to a network-level failure so it still reaches onError,
+//     instead of being swallowed silently by the self-healing `.catch`.
+
+import { errorMessage } from "../../utils/errors";
 
 export interface SaveResult {
   ok: boolean;
@@ -57,7 +62,7 @@ export function createTaskSaveQueue(deps: TaskSaveQueueDeps): TaskSaveQueue {
     // already load the right page; saving this snapshot would clobber it.
     if (deps.getCurrentSlug() !== pageName) return;
 
-    const result = await deps.persist(pageName, content);
+    const result = await runPersist(pageName, content);
 
     // Re-check both invariants after the await: either could have changed
     // while the request was in flight.
@@ -74,6 +79,16 @@ export function createTaskSaveQueue(deps: TaskSaveQueueDeps): TaskSaveQueue {
       return;
     }
     deps.onSuccess();
+  }
+
+  // Never rejects: a throw from the injected persist becomes a status-0
+  // failure so persistOne's failure path (onError + refresh) handles it.
+  async function runPersist(pageName: string, content: string): Promise<SaveResult> {
+    try {
+      return await deps.persist(pageName, content);
+    } catch (err) {
+      return { ok: false, status: 0, error: errorMessage(err) };
+    }
   }
 
   function queueSave(pageName: string, content: string): void {

--- a/src/plugins/wiki/taskSaveQueue.ts
+++ b/src/plugins/wiki/taskSaveQueue.ts
@@ -1,0 +1,88 @@
+// The serialised save queue behind wiki task-checkbox toggles (#775),
+// extracted from useWikiPageSave so its intricate ordering rules can be
+// unit-tested without a Vue runtime. The composable keeps only the DOM /
+// optimistic-update glue; every decision below is pure control flow over
+// injected dependencies.
+//
+// The rules, in one place:
+//   - Each click queues onto the previous save (a slow network can't
+//     reorder writes).
+//   - A `generation` counter invalidates saves whose captured snapshot was
+//     computed against optimistic state that a failure-triggered refresh
+//     has since discarded.
+//   - A page switch mid-flight (checked before AND after the request)
+//     abandons the save — writing this page's snapshot onto a different
+//     page would clobber unrelated state.
+//   - On failure the generation bump happens AFTER refresh completes, so
+//     clicks that arrived WHILE the refresh was in flight (they captured
+//     the pre-bump generation) are invalidated too.
+//   - The chain is self-healing: a rejected persist must not leave the
+//     chain permanently rejected (which would silently drop every later
+//     click).
+
+export interface SaveResult {
+  ok: boolean;
+  /** 0 for a network-level failure, else the HTTP status. */
+  status: number;
+  error: string;
+}
+
+export interface TaskSaveQueueDeps {
+  /** Perform the actual save. Returns a discriminated ok/err result. */
+  persist: (pageName: string, content: string) => Promise<SaveResult>;
+  /** Reload canonical page state after a failed save. */
+  refresh: () => Promise<unknown>;
+  /** The slug the view is currently showing — read at each checkpoint. */
+  getCurrentSlug: () => string | null;
+  /** Surface a save failure to the user. */
+  onError: (message: string) => void;
+  /** Clear any prior error after a successful save. */
+  onSuccess: () => void;
+}
+
+export interface TaskSaveQueue {
+  /** Queue a save of `content` for `pageName` onto the serialised chain. */
+  queueSave: (pageName: string, content: string) => void;
+}
+
+export function createTaskSaveQueue(deps: TaskSaveQueueDeps): TaskSaveQueue {
+  let chain: Promise<unknown> = Promise.resolve();
+  let generation = 0;
+
+  async function persistOne(pageName: string, content: string, capturedGeneration: number): Promise<void> {
+    // Stale queued save (a previous save failed + refresh discarded the
+    // optimistic state this snapshot was based on).
+    if (capturedGeneration !== generation) return;
+    // Navigation changed before we even started — the route/result watchers
+    // already load the right page; saving this snapshot would clobber it.
+    if (deps.getCurrentSlug() !== pageName) return;
+
+    const result = await deps.persist(pageName, content);
+
+    // Re-check both invariants after the await: either could have changed
+    // while the request was in flight.
+    if (capturedGeneration !== generation) return;
+    if (deps.getCurrentSlug() !== pageName) return;
+
+    if (!result.ok) {
+      deps.onError(result.status === 0 ? result.error : `Wiki save failed (${result.status}): ${result.error}`);
+      // Bump AFTER refresh: clicks arriving WHILE refresh is in flight
+      // captured the pre-bump generation, so bumping post-refresh
+      // invalidates them too.
+      await deps.refresh();
+      generation += 1;
+      return;
+    }
+    deps.onSuccess();
+  }
+
+  function queueSave(pageName: string, content: string): void {
+    const capturedGeneration = generation;
+    // `.catch` keeps the chain self-healing: an uncaught rejection would
+    // leave the chain permanently rejected and silently drop every later
+    // click. The error is already surfaced via onError inside persistOne.
+    chain = chain.then(() => persistOne(pageName, content, capturedGeneration)).catch(() => undefined);
+  }
+
+  return { queueSave };
+}

--- a/test/plugins/wiki/test_taskSaveQueue.ts
+++ b/test/plugins/wiki/test_taskSaveQueue.ts
@@ -1,0 +1,190 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createTaskSaveQueue, type SaveResult } from "../../../src/plugins/wiki/taskSaveQueue.js";
+
+// A controllable persist: each call parks on a promise the test resolves by
+// hand, so ordering and mid-flight state changes are deterministic.
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const ok: SaveResult = { ok: true, status: 200, error: "" };
+const httpFail: SaveResult = { ok: false, status: 500, error: "boom" };
+const netFail: SaveResult = { ok: false, status: 0, error: "offline" };
+
+interface Harness {
+  slug: string;
+  persistCalls: { pageName: string; content: string }[];
+  refreshCalls: number;
+  errors: string[];
+  successes: number;
+}
+
+// Build a queue whose persist resolves immediately with a scripted sequence
+// of results. Returns the harness so tests can assert side effects.
+function immediateHarness(results: SaveResult[]): { queue: ReturnType<typeof createTaskSaveQueue>; harness: Harness } {
+  const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
+  let index = 0;
+  const queue = createTaskSaveQueue({
+    persist: async (pageName, content) => {
+      harness.persistCalls.push({ pageName, content });
+      return results[index++] ?? ok;
+    },
+    refresh: async () => {
+      harness.refreshCalls += 1;
+    },
+    getCurrentSlug: () => harness.slug,
+    onError: (msg) => harness.errors.push(msg),
+    onSuccess: () => {
+      harness.successes += 1;
+    },
+  });
+  return { queue, harness };
+}
+
+// Let the microtask chain drain.
+const flush = () => new Promise((resolveFn) => setTimeout(resolveFn, 0));
+
+const contents = (harness: Harness): string[] => harness.persistCalls.map((rec) => rec.content);
+
+describe("createTaskSaveQueue — happy path", () => {
+  it("persists a queued save and clears the error", async () => {
+    const { queue, harness } = immediateHarness([ok]);
+    queue.queueSave("page-a", "c1");
+    await flush();
+    assert.deepEqual(harness.persistCalls, [{ pageName: "page-a", content: "c1" }]);
+    assert.equal(harness.successes, 1);
+    assert.equal(harness.errors.length, 0);
+  });
+
+  it("serialises multiple clicks in order", async () => {
+    const { queue, harness } = immediateHarness([ok, ok, ok]);
+    queue.queueSave("page-a", "c1");
+    queue.queueSave("page-a", "c2");
+    queue.queueSave("page-a", "c3");
+    await flush();
+    assert.deepEqual(contents(harness), ["c1", "c2", "c3"]);
+  });
+});
+
+describe("createTaskSaveQueue — page switch", () => {
+  it("drops a save whose page is no longer current before the request", async () => {
+    const { queue, harness } = immediateHarness([ok]);
+    harness.slug = "page-b"; // user navigated away before the queued save ran
+    queue.queueSave("page-a", "c1");
+    await flush();
+    assert.equal(harness.persistCalls.length, 0, "must not persist page-a's snapshot while on page-b");
+  });
+
+  it("drops the result when the page changes DURING the request", async () => {
+    const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
+    const gate = deferred<SaveResult>();
+    const queue = createTaskSaveQueue({
+      persist: async (pageName, content) => {
+        harness.persistCalls.push({ pageName, content });
+        return gate.promise;
+      },
+      refresh: async () => {
+        harness.refreshCalls += 1;
+      },
+      getCurrentSlug: () => harness.slug,
+      onError: (msg) => harness.errors.push(msg),
+      onSuccess: () => {
+        harness.successes += 1;
+      },
+    });
+    queue.queueSave("page-a", "c1");
+    await flush();
+    assert.equal(harness.persistCalls.length, 1);
+    harness.slug = "page-b"; // navigated away while the request is in flight
+    gate.resolve(ok);
+    await flush();
+    // The success callback must NOT fire — the result is for a page we left.
+    assert.equal(harness.successes, 0);
+  });
+});
+
+describe("createTaskSaveQueue — failure + generation invalidation", () => {
+  it("surfaces an HTTP failure, refreshes, and clears success", async () => {
+    const { queue, harness } = immediateHarness([httpFail]);
+    queue.queueSave("page-a", "c1");
+    await flush();
+    assert.equal(harness.errors.length, 1);
+    assert.match(harness.errors[0], /Wiki save failed \(500\)/);
+    assert.equal(harness.refreshCalls, 1);
+    assert.equal(harness.successes, 0);
+  });
+
+  it("formats a network failure (status 0) without an HTTP code", async () => {
+    const { queue, harness } = immediateHarness([netFail]);
+    queue.queueSave("page-a", "c1");
+    await flush();
+    assert.equal(harness.errors[0], "offline");
+  });
+
+  // The core #775 invariant: a save that FAILED invalidates saves queued
+  // before its generation bump (their snapshots were built on now-discarded
+  // optimistic state), so they must not reach the server.
+  it("invalidates saves queued before a failure's generation bump", async () => {
+    const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
+    const firstGate = deferred<SaveResult>();
+    let callCount = 0;
+    const queue = createTaskSaveQueue({
+      persist: async (pageName, content) => {
+        harness.persistCalls.push({ pageName, content });
+        callCount += 1;
+        return callCount === 1 ? firstGate.promise : ok;
+      },
+      refresh: async () => {
+        harness.refreshCalls += 1;
+      },
+      getCurrentSlug: () => harness.slug,
+      onError: (msg) => harness.errors.push(msg),
+      onSuccess: () => {
+        harness.successes += 1;
+      },
+    });
+    // Two clicks captured while generation is 0.
+    queue.queueSave("page-a", "c1");
+    queue.queueSave("page-a", "c2");
+    await flush();
+    assert.equal(harness.persistCalls.length, 1, "second save waits behind the first");
+    firstGate.resolve(httpFail); // first fails → refresh → generation bumps to 1
+    await flush();
+    // c2 captured generation 0, now stale → must be skipped, never persisted.
+    assert.deepEqual(contents(harness), ["c1"], "the stale c2 save must not reach the server");
+  });
+});
+
+describe("createTaskSaveQueue — self-healing chain", () => {
+  it("keeps accepting clicks after a persist throws", async () => {
+    const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
+    let callCount = 0;
+    const queue = createTaskSaveQueue({
+      persist: async (pageName, content) => {
+        harness.persistCalls.push({ pageName, content });
+        callCount += 1;
+        if (callCount === 1) throw new Error("network exploded");
+        return ok;
+      },
+      refresh: async () => {
+        harness.refreshCalls += 1;
+      },
+      getCurrentSlug: () => harness.slug,
+      onError: (msg) => harness.errors.push(msg),
+      onSuccess: () => {
+        harness.successes += 1;
+      },
+    });
+    queue.queueSave("page-a", "c1"); // throws
+    await flush();
+    queue.queueSave("page-a", "c2"); // must still run despite the prior rejection
+    await flush();
+    assert.deepEqual(contents(harness), ["c1", "c2"]);
+    assert.equal(harness.successes, 1);
+  });
+});

--- a/test/plugins/wiki/test_taskSaveQueue.ts
+++ b/test/plugins/wiki/test_taskSaveQueue.ts
@@ -24,15 +24,20 @@ interface Harness {
   successes: number;
 }
 
-// Build a queue whose persist resolves immediately with a scripted sequence
-// of results. Returns the harness so tests can assert side effects.
-function immediateHarness(results: SaveResult[]): { queue: ReturnType<typeof createTaskSaveQueue>; harness: Harness } {
+/** Decide each persist call's outcome by its 0-based call index. May return a
+ *  pending promise (to hold a save mid-flight) or throw (to simulate a reject). */
+type PersistScript = (pageName: string, content: string, callIndex: number) => SaveResult | Promise<SaveResult>;
+
+// Build a queue wired to a fresh harness. The harness records every side
+// effect (persist calls, refreshes, errors, successes) so tests can assert on
+// them; only the persist OUTCOME differs per test, supplied via `script`.
+function makeQueueHarness(script: PersistScript): { queue: ReturnType<typeof createTaskSaveQueue>; harness: Harness } {
   const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
-  let index = 0;
+  let callIndex = 0;
   const queue = createTaskSaveQueue({
     persist: async (pageName, content) => {
       harness.persistCalls.push({ pageName, content });
-      return results[index++] ?? ok;
+      return script(pageName, content, callIndex++);
     },
     refresh: async () => {
       harness.refreshCalls += 1;
@@ -45,6 +50,10 @@ function immediateHarness(results: SaveResult[]): { queue: ReturnType<typeof cre
   });
   return { queue, harness };
 }
+
+// Convenience over makeQueueHarness: persist resolves immediately with a
+// scripted sequence of results (falling back to `ok` once exhausted).
+const immediateHarness = (results: SaveResult[]): ReturnType<typeof makeQueueHarness> => makeQueueHarness((_pageName, _content, index) => results[index] ?? ok);
 
 // Let the microtask chain drain.
 const flush = () => new Promise((resolveFn) => setTimeout(resolveFn, 0));
@@ -81,22 +90,8 @@ describe("createTaskSaveQueue — page switch", () => {
   });
 
   it("drops the result when the page changes DURING the request", async () => {
-    const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
     const gate = deferred<SaveResult>();
-    const queue = createTaskSaveQueue({
-      persist: async (pageName, content) => {
-        harness.persistCalls.push({ pageName, content });
-        return gate.promise;
-      },
-      refresh: async () => {
-        harness.refreshCalls += 1;
-      },
-      getCurrentSlug: () => harness.slug,
-      onError: (msg) => harness.errors.push(msg),
-      onSuccess: () => {
-        harness.successes += 1;
-      },
-    });
+    const { queue, harness } = makeQueueHarness(() => gate.promise);
     queue.queueSave("page-a", "c1");
     await flush();
     assert.equal(harness.persistCalls.length, 1);
@@ -130,24 +125,8 @@ describe("createTaskSaveQueue — failure + generation invalidation", () => {
   // before its generation bump (their snapshots were built on now-discarded
   // optimistic state), so they must not reach the server.
   it("invalidates saves queued before a failure's generation bump", async () => {
-    const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
     const firstGate = deferred<SaveResult>();
-    let callCount = 0;
-    const queue = createTaskSaveQueue({
-      persist: async (pageName, content) => {
-        harness.persistCalls.push({ pageName, content });
-        callCount += 1;
-        return callCount === 1 ? firstGate.promise : ok;
-      },
-      refresh: async () => {
-        harness.refreshCalls += 1;
-      },
-      getCurrentSlug: () => harness.slug,
-      onError: (msg) => harness.errors.push(msg),
-      onSuccess: () => {
-        harness.successes += 1;
-      },
-    });
+    const { queue, harness } = makeQueueHarness((_pageName, _content, index) => (index === 0 ? firstGate.promise : ok));
     // Two clicks captured while generation is 0.
     queue.queueSave("page-a", "c1");
     queue.queueSave("page-a", "c2");
@@ -162,27 +141,32 @@ describe("createTaskSaveQueue — failure + generation invalidation", () => {
 
 describe("createTaskSaveQueue — self-healing chain", () => {
   it("keeps accepting clicks after a persist throws", async () => {
-    const harness: Harness = { slug: "page-a", persistCalls: [], refreshCalls: 0, errors: [], successes: 0 };
-    let callCount = 0;
-    const queue = createTaskSaveQueue({
-      persist: async (pageName, content) => {
-        harness.persistCalls.push({ pageName, content });
-        callCount += 1;
-        if (callCount === 1) throw new Error("network exploded");
-        return ok;
-      },
-      refresh: async () => {
-        harness.refreshCalls += 1;
-      },
-      getCurrentSlug: () => harness.slug,
-      onError: (msg) => harness.errors.push(msg),
-      onSuccess: () => {
-        harness.successes += 1;
-      },
+    const { queue, harness } = makeQueueHarness((_pageName, _content, index) => {
+      if (index === 0) throw new Error("network exploded");
+      return ok;
     });
     queue.queueSave("page-a", "c1"); // throws
     await flush();
     queue.queueSave("page-a", "c2"); // must still run despite the prior rejection
+    await flush();
+    assert.deepEqual(contents(harness), ["c1", "c2"]);
+    assert.equal(harness.successes, 1);
+  });
+
+  // Regression (CodeRabbit): a persist that REJECTS (throws) must be reported
+  // via onError + refresh — like an HTTP failure — not swallowed silently.
+  it("reports a rejected persist as a failure instead of dropping it", async () => {
+    const { queue, harness } = makeQueueHarness((_pageName, _content, index) => {
+      if (index === 0) return Promise.reject(new Error("network exploded"));
+      return ok;
+    });
+    queue.queueSave("page-a", "c1"); // rejects
+    await flush();
+    assert.equal(harness.errors.length, 1, "the rejection must surface via onError, not be swallowed");
+    assert.equal(harness.errors[0], "network exploded");
+    assert.equal(harness.refreshCalls, 1, "a rejected save refreshes canonical state like any failure");
+    assert.equal(harness.successes, 0);
+    queue.queueSave("page-a", "c2"); // later save still runs (chain not poisoned)
     await flush();
     assert.deepEqual(contents(harness), ["c1", "c2"]);
     assert.equal(harness.successes, 1);


### PR DESCRIPTION
## Summary

The serialised save queue behind wiki task-checkbox toggles (#775) lived inline in `useWikiPageSave`, unreachable without a Vue runtime. This PR extracts its control flow into a pure `createTaskSaveQueue(deps)` module so the intricate ordering rules can be unit-tested directly, and adds 8 `node:test` cases. Behaviour is unchanged — the composable now delegates to the queue and keeps only the DOM / optimistic-update / i18n glue.

## Items to Confirm / Review

- **Behaviour parity**: the extraction is intended to be behaviour-preserving. Please sanity-check that `useWikiPageSave.ts` maps `apiPost` responses to `SaveResult` faithfully (`{ ok, status: ok ? 200 : status, error: ok ? "" : error }`) and that no failure path was dropped.
- **The #775 core invariant** (generation invalidation): a save that FAILED bumps `generation` **after** `refresh()` completes, so clicks that arrived *while* the refresh was in flight (they captured the pre-bump generation) are also invalidated. Test `invalidates saves queued before a failure's generation bump` pins this. Mutation-checked: removing the post-await re-check turns exactly one test red.
- **Page-switch checks** are done both **before** and **after** the `persist` await — confirm both are warranted (a mid-flight navigation must not clobber the newly-loaded page).

## User Prompt

Continuation of the `src/plugins/*` bug-hunt + pure-function-extraction sweep (`plans/refactor-plugin-pure-sweep.md`). The user asked to proceed with "wiki save-queue 抽出 か manageSkills post-delete selection clobber" — both; the manageSkills half already shipped as #2523, this is the wiki save-queue half.

## Implementation

`src/plugins/wiki/taskSaveQueue.ts` (new) — pure queue over injected deps (`persist` / `refresh` / `getCurrentSlug` / `onError` / `onSuccess`):

- serialise each click onto the previous save so a slow network can't reorder writes
- a `generation` counter invalidates saves whose optimistic snapshot a failure-triggered `refresh()` has since discarded
- drop a save whose page is no longer current, checked **before** and **after** the request
- bump `generation` **after** refresh so clicks arriving during the refresh are invalidated too
- keep the chain self-healing (`.catch`) so a rejected persist doesn't leave the chain permanently rejected and silently drop every later click

`src/plugins/wiki/composables/useWikiPageSave.ts` (rewritten) — delegates to `createTaskSaveQueue`, keeps `onTaskCheckboxClick` / `computeToggledContent` / optimistic revert / i18n.

`test/plugins/wiki/test_taskSaveQueue.ts` (new) — 8 cases: happy path, ordering, page-switch before/during, HTTP vs network (status 0) failure formatting, the generation-invalidation invariant, self-healing after a throw.

### Verification

- `yarn format` clean, `eslint` clean, `vue-tsc` clean
- taskSaveQueue suite 8/8, full wiki suite 89/89
- mutation-check: removing the post-await invalidation → 1 test red (restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wiki task saving to prevent stale or out-of-order updates.
  - Prevented saves from applying after navigating to a different wiki page.
  - Added recovery handling for failed or interrupted saves, including page refreshes and continued saving afterward.

- **Tests**
  - Added coverage for queued saves, navigation changes, failures, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->