### PR TITLE
refactor(spreadsheet): fold duplicated engine helpers (#2482)

### DIFF
--- a/plans/refactor-2482-engine-folds.md
+++ b/plans/refactor-2482-engine-folds.md
@@ -1,0 +1,86 @@
+# refactor(spreadsheet): fold duplicated engine helpers (#2482)
+
+Behaviour-preserving de-duplication of the spreadsheet engine clones catalogued
+in #2482. The engine directory is excluded from the duplication scan, so these
+clones never surface in Code Scanning; #2482 records them so they don't get lost.
+
+Base: `origin/main` @ `bcd91c26b`. No open PR touches
+`src/plugins/spreadsheet/engine/` (checked `gh pr list --state open`), so no fold
+overlaps active parallel work. Matched every site by function name, not line
+number, against current main.
+
+## Per-candidate result
+
+| # | Candidate | Status | Helper | Sites folded |
+|---|-----------|--------|--------|--------------|
+| 1 | date-parser | DONE | `serialFromParts(year, month, day)` | 5 branches of `parseDate` (ISO, DD-MMM-YYYY, MMM D YYYY, D MMM YYYY, slash) |
+| 2 | formatter thousands grouping | ALREADY DONE | `groupThousands` (pre-existing, #2510) | both currency + comma branches already call it — nothing to do |
+| 3 | financial IPMT/PPMT handlers | DONE | `makePeriodicComponentHandler(compute)` factory | `ipmtHandler`, `ppmtHandler` in `functions/financial.ts` |
+| 4 | calculator cross-sheet resolve | DONE | `resolveSheetData(ref): ResolvedSheetRef \| null` | `getCellValue`, `collectRangeValues` |
+| 5 | text FIND/SEARCH | DONE | `locateSubstring(find, within, start, {caseInsensitive})` | `findHandler`, `searchHandler` in `functions/text.ts` |
+
+Nothing skipped for drift — all five sites still matched the issue's description on
+current main.
+
+### 1. date-parser — `serialFromParts`
+Every dated branch ended in the same `isValidDate -> Date.UTC(year, month-1, day)
+-> dateToSerial` tail (two clone shapes: bare, and month-name-guarded). Extracted
+`serialFromParts` returning `number | null`; the three month-name branches keep
+their own `parseMonthName` + `if (month === null) return null` (equivalent to the
+old `if (month && ...)` since month is 1-12, never 0).
+
+### 2. formatter — already folded
+`groupThousands` already exists (added by the TEXT-format PR #2510) and BOTH the
+`$` currency branch and the bare-comma branch already route through it. No second
+helper added.
+
+### 3. financial — `makePeriodicComponentHandler`
+`ipmtHandler` and `ppmtHandler` were byte-identical except the final
+`computeIpmt` / `computePpmt` call. A factory captures the shared six-operand
+parse (incl. the optional `fv` / `type` defaults) so the two can't drift.
+FV/PV/PMT/NPER/RATE left as-is (issue: don't over-abstract; the clear win is
+IPMT/PPMT).
+
+### 4. calculator — `resolveSheetData` (two-stage cache seed preserved EXACTLY)
+`getCellValue` and `collectRangeValues` shared: sheet-ref regex match -> cache
+check -> **two-stage cache seed (infinite-loop guard)** -> `calculateSheet`.
+`resolveSheetData` returns `{ sheetData, ref, isCurrentSheet } | null`; null means
+the named sheet doesn't exist, and each caller keeps its terminal action
+(`getCellValue` throws #REF!, `collectRangeValues` returns []). The two-stage seed
+(raw copy published to the cache BEFORE recursing, real result after) is copied
+verbatim. `.has()/.get()!` became `const cached = get(); if (cached)` — equivalent
+because cache values are always arrays (never falsy), and it drops the `!`
+non-null assertion. Kept as a closure (not a standalone pure fn) because it
+depends on `calculateSheet` recursion + the per-call cache; covered by the
+cross-sheet integration + cyclic tests.
+
+### 5. text — `locateSubstring`
+FIND (case-sensitive) and SEARCH (case-insensitive) shared start calc, #VALUE!
+miss, 1-based return; differed only in case folding. `locateSubstring` takes a
+`{caseInsensitive}` flag; each handler keeps its own arg resolution.
+
+## Not touched (見送り — intentionally kept duplicated, per #2482)
+- condition.ts / evaluator.ts / jsonCellLocator.ts quote scanners — 3 different
+  escape rules; a unified scanner hurts readability.
+- formatter <-> text.ts `$`/decimal branches — deliberately different output
+  (`TEXT(1000,"$")` -> `$1000.00` vs formatCell -> `$1000`).
+
+## Tests
+- Full engine suite: 829 -> 855 (+26), all pass after every fold.
+- New pure-helper tests: `test_serialFromParts.ts` (9), `test_locateSubstring.ts` (8).
+- New engine-level financial handler test: `test_financialPeriodicHandlers.ts` (4)
+  — drives IPMT/PPMT through the engine (the layer the factory lives in), since
+  the existing `test_financialMath.ts` only covers the pure math.
+- `test_crossSheetReference.ts` extended: 2- and 3-sheet cycles terminate with
+  `#ERROR!` (don't hang), valid cross-sheet still resolves `[10,30]`, missing-sheet
+  keeps per-caller terminal (#REF! for a cell, empty range for SUM).
+
+## Mutation checks (broke helper, saw red, restored)
+- calculator: `resolveSheetData` returning `ref: fullRef` -> 8/11 cross-sheet tests fail.
+- financial: factory ignoring `type` -> begin-of-period IPMT test fails (-1250 vs 0).
+- date-parser: wrong month offset -> 4 serialFromParts tests fail.
+- text: never case-fold -> 2 locateSubstring tests fail.
+
+## Verification
+- Cyclic cross-sheet baseline (before + after fold 4): `#ERROR!` in ~10ms, valid `[10,30]` — identical.
+- `npx tsc --noEmit` (src) clean; full `yarn typecheck` (incl. test/) clean.

--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -16,6 +16,11 @@ import { errorMessage } from "../../../utils/errors";
 import { classifyThrownError, invalidRefError } from "./formulaError";
 import { isSpreadsheetErrorValue, spreadsheetError } from "./spreadsheet-errors";
 
+// The grid a reference should read from, plus the sheet-name-stripped ref and
+// whether it points at the sheet currently being calculated (which decides
+// whether recursive formula evaluation is allowed for the cell it lands on).
+type ResolvedSheetRef = { sheetData: (SpreadsheetCell | CellValue)[][]; ref: string; isCurrentSheet: boolean };
+
 /**
  * Normalize malformed data structures
  * Some models generate flat arrays instead of 2D arrays - fix them
@@ -243,40 +248,42 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
     return isNaN(num) ? cell : num;
   };
 
+  // Resolve a possibly cross-sheet reference to the grid it reads from, plus the
+  // sheet-name-stripped ref. A same-sheet ref returns the current `calculated`
+  // grid; a cross-sheet ref computes and caches its target sheet. null means the
+  // named sheet does not exist — the caller picks the terminal action (#REF! for
+  // a single cell, [] for a range). The two-stage cache seed (raw copy published
+  // BEFORE recursing, real result after) is the cross-sheet infinite-loop guard.
+  const resolveSheetData = (fullRef: string): ResolvedSheetRef | null => {
+    const sheetMatch = fullRef.match(/^(?:'([^']+)'|([^!]+))!(.+)$/);
+    if (!sheetMatch) return { sheetData: calculated, ref: fullRef, isCurrentSheet: true };
+
+    const targetSheetName = sheetMatch[1] || sheetMatch[2]; // Quoted or unquoted sheet name
+    const innerRef = sheetMatch[3]; // Reference part after the sheet name
+
+    // Check cache first to prevent infinite loops
+    const cached = sheetsCache.get(targetSheetName);
+    if (cached) return { sheetData: cached, ref: innerRef, isCurrentSheet: false };
+
+    const targetSheet = processedAllSheets?.find((s) => s.name === targetSheetName);
+    if (!targetSheet || !targetSheet.data) return null;
+
+    // Seed the cache with a raw copy BEFORE recursing so a cyclic back-reference
+    // finds this sheet mid-flight, then overwrite it with the calculated result.
+    // Resolve cross-sheet values RAW (skip display formatting) so a date cell
+    // reads as its serial, not the presentation string "03/04/2025".
+    const targetCalculated = targetSheet.data.map((row) => [...row]);
+    sheetsCache.set(targetSheetName, targetCalculated);
+    const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY, skipFormatting: true });
+    sheetsCache.set(targetSheetName, targetResult.data);
+    return { sheetData: targetResult.data, ref: innerRef, isCurrentSheet: false };
+  };
+
   // Helper to get cell value by reference (e.g., "B2", "$B$2", or "'Sheet1'!B2")
   const getCellValue = (ref: string): CellValue => {
-    let sheetData: any[][] = calculated;
-    let cellRef = ref;
-    let isCurrentSheet = true;
-
-    // Check for cross-sheet reference (e.g., 'Sheet Name'!B2 or Sheet1!B2)
-    const sheetMatch = ref.match(/^(?:'([^']+)'|([^!]+))!(.+)$/);
-    if (sheetMatch) {
-      const targetSheetName = sheetMatch[1] || sheetMatch[2]; // Quoted or unquoted sheet name
-      cellRef = sheetMatch[3]; // Cell reference part
-      isCurrentSheet = false;
-
-      // Check cache first to prevent infinite loops
-      if (sheetsCache.has(targetSheetName)) {
-        sheetData = sheetsCache.get(targetSheetName)!;
-      } else {
-        // Find the sheet in all sheets
-        const targetSheet = processedAllSheets?.find((s) => s.name === targetSheetName);
-        if (targetSheet && targetSheet.data) {
-          // Calculate formulas for the target sheet with cache
-          const targetCalculated = targetSheet.data.map((row) => [...row]);
-          sheetsCache.set(targetSheetName, targetCalculated);
-
-          // Resolve cross-sheet values RAW (skip display formatting) so a date
-          // cell reads as its serial, not the presentation string "03/04/2025".
-          const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY, skipFormatting: true });
-          sheetsCache.set(targetSheetName, targetResult.data);
-          sheetData = targetResult.data as any[][];
-        } else {
-          throw invalidRefError(ref); // Sheet not found → #REF!
-        }
-      }
-    }
+    const resolved = resolveSheetData(ref);
+    if (!resolved) throw invalidRefError(ref); // Sheet not found → #REF!
+    const { sheetData, ref: cellRef, isCurrentSheet } = resolved;
 
     // Remove $ symbols for absolute references
     const cleanRef = cellRef.replace(/\$/g, "");
@@ -296,37 +303,9 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
   };
 
   const collectRangeValues = (range: string, options: { numericOnly: boolean }): CellValue[] => {
-    let sheetData: any[][] = calculated;
-    let rangeRef = range;
-    let isCurrentSheet = true;
-
-    // Check for cross-sheet reference
-    const sheetMatch = range.match(/^(?:'([^']+)'|([^!]+))!(.+)$/);
-    if (sheetMatch) {
-      const targetSheetName = sheetMatch[1] || sheetMatch[2];
-      rangeRef = sheetMatch[3];
-      isCurrentSheet = false;
-
-      // Check cache first
-      if (sheetsCache.has(targetSheetName)) {
-        sheetData = sheetsCache.get(targetSheetName)!;
-      } else {
-        // Find and calculate the target sheet
-        const targetSheet = processedAllSheets?.find((s) => s.name === targetSheetName);
-        if (targetSheet && targetSheet.data) {
-          const targetCalculated = targetSheet.data.map((row) => [...row]);
-          sheetsCache.set(targetSheetName, targetCalculated);
-
-          // Resolve cross-sheet values RAW (skip display formatting) so a date
-          // cell reads as its serial, not the presentation string "03/04/2025".
-          const targetResult = calculateSheet(targetSheet, processedAllSheets, { preferDDMMYYYY, skipFormatting: true });
-          sheetsCache.set(targetSheetName, targetResult.data);
-          sheetData = targetResult.data as any[][];
-        } else {
-          return [];
-        }
-      }
-    }
+    const resolved = resolveSheetData(range);
+    if (!resolved) return []; // Sheet not found → empty range
+    const { sheetData, ref: rangeRef, isCurrentSheet } = resolved;
 
     const coords = expandRangeOrCell(rangeRef);
     if (!coords) return [];

--- a/src/plugins/spreadsheet/engine/date-parser.ts
+++ b/src/plugins/spreadsheet/engine/date-parser.ts
@@ -42,6 +42,16 @@ export function isDateLike(str: string): boolean {
 }
 
 /**
+ * Build the Excel serial number for a year/month/day triple, or null when the
+ * triple is not a valid calendar date. Every dated branch of `parseDate` ends in
+ * this same validate → Date.UTC → dateToSerial step.
+ */
+export function serialFromParts(year: number, month: number, day: number): number | null {
+  if (!isValidDate(year, month, day)) return null;
+  return dateToSerial(new Date(Date.UTC(year, month - 1, day)));
+}
+
+/**
  * Parse a month name to month number (1-12)
  */
 function parseMonthName(monthStr: string): number | null {
@@ -84,11 +94,7 @@ export function parseDate(dateStr: string, preferDDMMYYYY: boolean = false): num
     const month = parseInt(isoMatch[2]);
     const day = parseInt(isoMatch[3]);
 
-    if (isValidDate(year, month, day)) {
-      const date = new Date(Date.UTC(year, month - 1, day));
-      return dateToSerial(date);
-    }
-    return null;
+    return serialFromParts(year, month, day);
   }
 
   // Try DD-MMM-YYYY or D-MMM-YYYY
@@ -104,11 +110,8 @@ export function parseDate(dateStr: string, preferDDMMYYYY: boolean = false): num
     }
 
     const month = parseMonthName(monthName);
-    if (month && isValidDate(year, month, day)) {
-      const date = new Date(Date.UTC(year, month - 1, day));
-      return dateToSerial(date);
-    }
-    return null;
+    if (month === null) return null;
+    return serialFromParts(year, month, day);
   }
 
   // Try MMM D, YYYY or MMMM D, YYYY
@@ -119,11 +122,8 @@ export function parseDate(dateStr: string, preferDDMMYYYY: boolean = false): num
     const year = parseInt(mmmMatch[3]);
 
     const month = parseMonthName(monthName);
-    if (month && isValidDate(year, month, day)) {
-      const date = new Date(Date.UTC(year, month - 1, day));
-      return dateToSerial(date);
-    }
-    return null;
+    if (month === null) return null;
+    return serialFromParts(year, month, day);
   }
 
   // Try D MMM YYYY
@@ -134,11 +134,8 @@ export function parseDate(dateStr: string, preferDDMMYYYY: boolean = false): num
     const year = parseInt(dMmmMatch[3]);
 
     const month = parseMonthName(monthName);
-    if (month && isValidDate(year, month, day)) {
-      const date = new Date(Date.UTC(year, month - 1, day));
-      return dateToSerial(date);
-    }
-    return null;
+    if (month === null) return null;
+    return serialFromParts(year, month, day);
   }
 
   // Try MM/DD/YYYY or DD/MM/YYYY
@@ -160,11 +157,7 @@ export function parseDate(dateStr: string, preferDDMMYYYY: boolean = false): num
     const month = isDayFirst ? second : first;
     const day = isDayFirst ? first : second;
 
-    if (isValidDate(year, month, day)) {
-      const date = new Date(Date.UTC(year, month - 1, day));
-      return dateToSerial(date);
-    }
-    return null;
+    return serialFromParts(year, month, day);
   }
 
   return null;

--- a/src/plugins/spreadsheet/engine/functions/financial.ts
+++ b/src/plugins/spreadsheet/engine/functions/financial.ts
@@ -87,37 +87,37 @@ const rateHandler: FunctionHandler = (args, context) => {
   return computeRate(nper, pmt, pv, fv, type, guess);
 };
 
+// IPMT and PPMT take the SAME six operands — (rate, per, nper, pv, [fv], [type])
+// — and differ only in which annuity component they compute. One factory parses
+// the shared shape so the two handlers can't drift in their optional-arg defaults.
+type PeriodicComponent = (rate: number, per: number, nper: number, pv: number, fv: number, type: number) => number;
+
+const makePeriodicComponentHandler =
+  (compute: PeriodicComponent): FunctionHandler =>
+  (args, context) => {
+    const rate = toNumber(context.evaluateFormula(args[0]));
+    const per = toNumber(context.evaluateFormula(args[1]));
+    const nper = toNumber(context.evaluateFormula(args[2]));
+    const pv = toNumber(context.evaluateFormula(args[3]));
+    const fv = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
+    const type = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0;
+
+    return compute(rate, per, nper, pv, fv, type);
+  };
+
 /**
  * IPMT - Interest Payment
  * Calculates the interest payment for a given period for an investment based on periodic, constant payments and a constant interest rate.
  * IPMT(rate, per, nper, pv, [fv], [type])
  */
-const ipmtHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
-  const per = toNumber(context.evaluateFormula(args[1]));
-  const nper = toNumber(context.evaluateFormula(args[2]));
-  const pv = toNumber(context.evaluateFormula(args[3]));
-  const fv = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
-  const type = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0;
-
-  return computeIpmt(rate, per, nper, pv, fv, type);
-};
+const ipmtHandler: FunctionHandler = makePeriodicComponentHandler(computeIpmt);
 
 /**
  * PPMT - Principal Payment
  * Calculates the payment on the principal for a given period for an investment based on periodic, constant payments and a constant interest rate.
  * PPMT(rate, per, nper, pv, [fv], [type])
  */
-const ppmtHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
-  const per = toNumber(context.evaluateFormula(args[1]));
-  const nper = toNumber(context.evaluateFormula(args[2]));
-  const pv = toNumber(context.evaluateFormula(args[3]));
-  const fv = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
-  const type = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0;
-
-  return computePpmt(rate, per, nper, pv, fv, type);
-};
+const ppmtHandler: FunctionHandler = makePeriodicComponentHandler(computePpmt);
 
 /**
  * NPV - Net Present Value

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -148,13 +148,21 @@ const replaceHandler: FunctionHandler = (args, context) => {
   return oldText.substring(0, startPos) + newText + oldText.substring(startPos + numChars);
 };
 
+// FIND and SEARCH share everything but case sensitivity: same 0-based start,
+// same #VALUE! on no match, same 1-based result. SEARCH folds case first.
+export const locateSubstring = (find: string, within: string, start: number, options: { caseInsensitive: boolean }): number | SpreadsheetError => {
+  const needle = options.caseInsensitive ? find.toLowerCase() : find;
+  const haystack = options.caseInsensitive ? within.toLowerCase() : within;
+  const index = haystack.indexOf(needle, start);
+  return index === -1 ? VALUE_ERROR : index + 1; // 1-indexed position
+};
+
 const findHandler: FunctionHandler = (args, context) => {
   const findText = toString(context.evaluateFormula(args[0]));
   const withinText = toString(context.evaluateFormula(args[1]));
   const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
 
-  const index = withinText.indexOf(findText, startPos);
-  return index === -1 ? VALUE_ERROR : index + 1; // Return 1-indexed position
+  return locateSubstring(findText, withinText, startPos, { caseInsensitive: false });
 };
 
 const searchHandler: FunctionHandler = (args, context) => {
@@ -162,12 +170,7 @@ const searchHandler: FunctionHandler = (args, context) => {
   const withinText = toString(context.evaluateFormula(args[1]));
   const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
 
-  // SEARCH is case-insensitive
-  const lowerFind = findText.toLowerCase();
-  const lowerWithin = withinText.toLowerCase();
-
-  const index = lowerWithin.indexOf(lowerFind, startPos);
-  return index === -1 ? VALUE_ERROR : index + 1; // Return 1-indexed position
+  return locateSubstring(findText, withinText, startPos, { caseInsensitive: true });
 };
 
 // A format code written as a literal still carries its quotes when it reaches

--- a/test/plugins/spreadsheet/engine/test_crossSheetReference.ts
+++ b/test/plugins/spreadsheet/engine/test_crossSheetReference.ts
@@ -62,3 +62,43 @@ describe("cross-sheet range aggregation stays numeric", () => {
     assert.deepEqual(calcRow(sum, [data, sum]), [60]);
   });
 });
+
+// resolveSheetData (#2482) folds the sheet-ref match -> cache check -> two-stage
+// cache seed -> calculateSheet block that getCellValue and collectRangeValues
+// shared. The two-stage seed is the cross-sheet infinite-loop guard: a cyclic
+// reference must terminate with an error, not hang. If it hung, these tests would
+// never return and the whole suite would time out.
+describe("cyclic cross-sheet references terminate instead of hanging", () => {
+  it("a 2-sheet cycle (A!A1=B!A1, B!A1=A!A1) resolves to an error", () => {
+    const sheetA: SheetData = { name: "A", data: [[{ v: "=B!A1" }]] };
+    const sheetB: SheetData = { name: "B", data: [[{ v: "=A!A1" }]] };
+    assert.equal(String(calcRow(sheetA, [sheetA, sheetB])[0]), "#ERROR!");
+  });
+
+  it("a 3-sheet cycle (A->B->C->A) also terminates with an error", () => {
+    const sheetA: SheetData = { name: "A", data: [[{ v: "=B!A1" }]] };
+    const sheetB: SheetData = { name: "B", data: [[{ v: "=C!A1" }]] };
+    const sheetC: SheetData = { name: "C", data: [[{ v: "=A!A1" }]] };
+    assert.equal(String(calcRow(sheetA, [sheetA, sheetB, sheetC])[0]), "#ERROR!");
+  });
+
+  it("a valid cross-sheet reference next to the cycle still resolves", () => {
+    const data: SheetData = { name: "D", data: [[{ v: 10 }, { v: 20 }]] };
+    const main: SheetData = { name: "S", data: [[{ v: "=D!A1" }, { v: "=SUM(D!A1:B1)" }]] };
+    assert.deepEqual(calcRow(main, [data, main]), [10, 30]);
+  });
+});
+
+// A reference to a sheet that does not exist keeps each caller's terminal action
+// after the fold: #REF! for a single cell, an empty range for an aggregate.
+describe("missing-sheet reference keeps its per-caller terminal behaviour", () => {
+  it("a single cross-sheet cell to a missing sheet is #REF!", () => {
+    const main: SheetData = { name: "S", data: [[{ v: "=Ghost!A1" }]] };
+    assert.equal(String(calcRow(main, [main])[0]), "#REF!");
+  });
+
+  it("SUM over a range on a missing sheet contributes nothing (empty range)", () => {
+    const main: SheetData = { name: "S", data: [[{ v: "=SUM(Ghost!A1:B1)" }]] };
+    assert.equal(calcRow(main, [main])[0], 0);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_financialPeriodicHandlers.ts
+++ b/test/plugins/spreadsheet/engine/test_financialPeriodicHandlers.ts
@@ -1,0 +1,33 @@
+// IPMT and PPMT now share one arg-parsing factory, makePeriodicComponentHandler
+// (#2482). These drive both THROUGH the engine — the layer the factory lives in —
+// so a swapped compute call or a mis-parsed optional arg (fv / type) is caught.
+// The pure computeIpmt / computePpmt tests exercise the math, not the handler.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+
+const evalA1 = (formula: string): unknown => {
+  const sheet: SheetData = { name: "S", data: [[{ v: formula }]] };
+  return new SpreadsheetEngine().calculate(sheet).data[0][0];
+};
+
+const closeTo = (actual: unknown, expected: number, eps = 0.01): boolean => typeof actual === "number" && Math.abs(actual - expected) <= eps;
+
+describe("IPMT / PPMT through the engine (shared handler factory)", () => {
+  it("IPMT(0.005, 1, 360, 250000) is the interest-only first payment (-1250)", () => {
+    assert.ok(closeTo(evalA1("=IPMT(0.005, 1, 360, 250000)"), -1250, 1e-6), `got ${String(evalA1("=IPMT(0.005, 1, 360, 250000)"))}`);
+  });
+
+  it("PPMT(0.005, 1, 360, 250000) is the principal-only first payment (~ -248.88)", () => {
+    assert.ok(closeTo(evalA1("=PPMT(0.005, 1, 360, 250000)"), -248.88), `got ${String(evalA1("=PPMT(0.005, 1, 360, 250000)"))}`);
+  });
+
+  it("IPMT and PPMT stay distinct — the factory did not collapse them onto one compute", () => {
+    assert.notEqual(evalA1("=IPMT(0.005, 2, 360, 250000)"), evalA1("=PPMT(0.005, 2, 360, 250000)"));
+  });
+
+  it("parses the optional type arg: IPMT at period 1, begin-of-period, is 0", () => {
+    assert.equal(evalA1("=IPMT(0.005, 1, 360, 250000, 0, 1)"), 0);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_locateSubstring.ts
+++ b/test/plugins/spreadsheet/engine/test_locateSubstring.ts
@@ -1,0 +1,52 @@
+// locateSubstring folds the shared body of FIND (case-sensitive) and SEARCH
+// (case-insensitive) (#2482): identical 0-based start, identical 1-based hit
+// index, identical #VALUE! miss. Case folding is the ONLY axis that may differ,
+// so these pin both the common rule and that one deliberate asymmetry.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { locateSubstring } from "../../../../src/plugins/spreadsheet/engine/functions/text.ts";
+import { isSpreadsheetErrorValue } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
+
+const CASE_SENSITIVE = { caseInsensitive: false };
+const CASE_INSENSITIVE = { caseInsensitive: true };
+
+const missed = (result: ReturnType<typeof locateSubstring>): boolean => isSpreadsheetErrorValue(result) && result.code === "#VALUE!";
+
+describe("locateSubstring — 1-based hit index", () => {
+  it("returns the 1-based position of the first match", () => {
+    assert.equal(locateSubstring("b", "abc", 0, CASE_SENSITIVE), 2);
+  });
+
+  it("finds a match at the very start", () => {
+    assert.equal(locateSubstring("a", "abc", 0, CASE_SENSITIVE), 1);
+  });
+
+  it("honours a non-zero start, skipping an earlier match", () => {
+    assert.equal(locateSubstring("a", "banana", 2, CASE_SENSITIVE), 4);
+  });
+});
+
+describe("locateSubstring — case sensitivity is the only difference", () => {
+  it("case-sensitive: a wrong-case needle misses with #VALUE!", () => {
+    assert.ok(missed(locateSubstring("O", "hello", 0, CASE_SENSITIVE)));
+  });
+
+  it("case-insensitive: the same wrong-case needle matches", () => {
+    assert.equal(locateSubstring("O", "hello", 0, CASE_INSENSITIVE), 5);
+  });
+
+  it("case-insensitive folds BOTH the needle and the haystack", () => {
+    assert.equal(locateSubstring("HELLO", "hello world", 0, CASE_INSENSITIVE), 1);
+  });
+});
+
+describe("locateSubstring — misses and edge cases", () => {
+  it("a needle absent from the haystack is #VALUE!", () => {
+    assert.ok(missed(locateSubstring("z", "abc", 0, CASE_SENSITIVE)));
+  });
+
+  it("an empty needle matches at position 1 (indexOf semantics preserved)", () => {
+    assert.equal(locateSubstring("", "abc", 0, CASE_SENSITIVE), 1);
+  });
+});

--- a/test/plugins/spreadsheet/engine/test_serialFromParts.ts
+++ b/test/plugins/spreadsheet/engine/test_serialFromParts.ts
@@ -1,0 +1,48 @@
+// serialFromParts folds the validate -> Date.UTC -> dateToSerial tail that every
+// dated branch of parseDate repeated (#2482). parseDate now delegates to it, so
+// pinning the rule directly here is the only place a wrong month offset or a
+// dropped validity check is caught independently of parseDate itself.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { serialFromParts } from "../../../../src/plugins/spreadsheet/engine/date-parser.ts";
+
+describe("serialFromParts — valid triples map to the Excel serial", () => {
+  it("March 4, 2025 is serial 45720", () => {
+    assert.equal(serialFromParts(2025, 3, 4), 45720);
+  });
+
+  it("Jan 1, 1900 is serial 2 (Excel's Dec-30-1899 base with the 1900 leap-year quirk)", () => {
+    assert.equal(serialFromParts(1900, 1, 1), 2);
+  });
+
+  it("accepts a real leap day (Feb 29, 2024)", () => {
+    assert.equal(serialFromParts(2024, 2, 29), 45351);
+  });
+
+  it("accepts the upper year boundary (Dec 31, 2100)", () => {
+    assert.equal(serialFromParts(2100, 12, 31), 73415);
+  });
+});
+
+describe("serialFromParts — invalid triples are null", () => {
+  it("rejects Feb 29 on a non-leap year", () => {
+    assert.equal(serialFromParts(2025, 2, 29), null);
+  });
+
+  it("rejects a day past the month length (Feb 30)", () => {
+    assert.equal(serialFromParts(2025, 2, 30), null);
+  });
+
+  it("rejects a month above 12", () => {
+    assert.equal(serialFromParts(2025, 13, 1), null);
+  });
+
+  it("rejects a year below the 1900 floor", () => {
+    assert.equal(serialFromParts(1800, 1, 1), null);
+  });
+
+  it("rejects a zero day", () => {
+    assert.equal(serialFromParts(2025, 1, 0), null);
+  });
+});


### PR DESCRIPTION
## Summary

Behaviour-preserving de-duplication of the spreadsheet engine clones catalogued in #2482. The engine dir is excluded from the duplication scan, so these clones never surface in Code Scanning — #2482 records them by hand. Every site was matched by **function name** against current `main` (the engine is under active parallel refactoring); no open PR touches `src/plugins/spreadsheet/engine/`.

| # | Candidate | Status | Helper | Sites |
|---|-----------|--------|--------|-------|
| 1 | date-parser | ✅ folded | `serialFromParts(year, month, day)` | 5 dated branches of `parseDate` |
| 2 | formatter grouping | ⏭️ already done | `groupThousands` (pre-existing, #2510) | both branches already use it |
| 3 | financial IPMT/PPMT | ✅ folded | `makePeriodicComponentHandler(compute)` | `ipmtHandler`, `ppmtHandler` |
| 4 | calculator cross-sheet | ✅ folded | `resolveSheetData(ref): ResolvedSheetRef \| null` | `getCellValue`, `collectRangeValues` |
| 5 | text FIND/SEARCH | ✅ folded | `locateSubstring(find, within, start, {caseInsensitive})` | `findHandler`, `searchHandler` |

Nothing skipped for drift — all five sites still matched the issue on current `main`. The intentionally-kept 見送り duplicates (the three quote scanners; the formatter↔text `$`/decimal branches) were left untouched per the issue.

## Items to Confirm / Review

- **Behaviour unchanged** — this is a pure de-dup. Engine suite went 829 → 855 (added tests only), all pass; full `yarn test` green.
- **Two-stage cache seed preserved EXACTLY** (candidate 4): the raw-copy-before-recursion + real-result-after seed that guards cyclic cross-sheet refs is copied verbatim into `resolveSheetData`. Verified a 2- and 3-sheet cycle still terminates with `#ERROR!` in ~10ms (does **not** hang), and a valid cross-sheet ref still resolves — identical to the pre-fold baseline. `.has()/.get()!` became `const cached = get(); if (cached)` (equivalent — cache values are always non-falsy arrays — and drops the non-null assertion).
- **Missing-sheet terminal action** kept per-caller: `#REF!` for a single cell, empty range for an aggregate.
- **Mutation-checked** the calculator and financial folds (and the two pure helpers): broke each helper, confirmed a test went red, restored. Details below.
- `makePeriodicComponentHandler` deliberately folds **only** IPMT/PPMT; FV/PV/PMT/NPER/RATE left as-is (issue: don't over-abstract).

## User Prompt

issueを閉じれるようにして — the user asked to finish the remaining spreadsheet refactor issues so they can be closed; #2482 assigned here.

## Implementation

- **date-parser.ts** — `serialFromParts(year, month, day): number | null` = `isValidDate → Date.UTC(y, m-1, d) → dateToSerial`. Month-name branches keep `parseMonthName` + `if (month === null) return null` (equivalent to the old `if (month && …)`, since month is 1–12).
- **functions/financial.ts** — a factory captures the shared six-operand parse (incl. optional `fv`/`type` defaults); `ipmtHandler`/`ppmtHandler` become one-liners.
- **calculator.ts** — `resolveSheetData` closure returns the grid + sheet-stripped ref + `isCurrentSheet`, or `null` when the named sheet is absent. Kept as a closure (depends on `calculateSheet` recursion + the per-call cache); covered by the cross-sheet integration + cyclic tests.
- **functions/text.ts** — `locateSubstring` folds case first, then shares the 0-based start / `#VALUE!` miss / 1-based return.

**Tests added:** `test_serialFromParts.ts` (9), `test_locateSubstring.ts` (8), `test_financialPeriodicHandlers.ts` (4, engine-level — the existing `test_financialMath.ts` only covers the pure math, not the handler); `test_crossSheetReference.ts` extended with cyclic + missing-sheet cases.

**Mutation checks (broke helper → saw red → restored):**
- calculator: `resolveSheetData` returning `ref: fullRef` → 8/11 cross-sheet tests fail.
- financial: factory ignoring `type` → begin-of-period IPMT test fails (−1250 vs 0).
- date-parser: wrong month offset → 4 serialFromParts tests fail.
- text: never case-fold → 2 locateSubstring tests fail.

**Gates:** `yarn format --check`, `yarn lint` (0 errors), `yarn typecheck` (incl. test/), `yarn build`, `yarn test` — all green (also enforced by the pre-commit hook).

Fixes #2482