### PR TITLE
refactor(collection-plugin): extract CollectionHeader.vue (#2528)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionHeader.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionHeader.vue
@@ -1,0 +1,257 @@
+<template>
+  <header v-if="!hideHeader" class="flex items-center gap-3 px-6 py-2 border-b border-slate-200 bg-white">
+    <button
+      v-if="!embedded"
+      type="button"
+      class="h-8 w-8 flex items-center justify-center rounded text-slate-500 hover:bg-slate-50 hover:text-slate-800 transition-colors"
+      :title="t('collectionsView.backToIndex')"
+      :aria-label="t('collectionsView.backToIndex')"
+      data-testid="collections-back"
+      @click="$emit('back')"
+    >
+      <span class="material-icons text-lg">arrow_back</span>
+    </button>
+
+    <div v-if="collection" class="h-9 w-9 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100">
+      <span class="material-symbols-outlined text-xl">{{ collection.icon }}</span>
+    </div>
+
+    <div class="flex-1 min-w-0">
+      <h1 class="text-base font-bold text-slate-800 truncate">
+        {{ collection?.title ?? t("collectionsView.title") }}
+      </h1>
+      <span v-if="collection" class="block text-[10px] text-slate-400 font-bold uppercase tracking-wider truncate">
+        {{ collection.slug }}
+        <!-- dataSource chip: sets the read-only expectation up front and
+             links to the file that IS the data (the one editable thing). -->
+        <template v-if="isReadOnly">
+          <span
+            class="inline-flex items-center gap-0.5 ml-1.5 px-1.5 py-px rounded bg-amber-50 text-amber-700 border border-amber-200 normal-case tracking-normal"
+            data-testid="collections-readonly-chip"
+          >
+            <span class="material-icons text-[11px]">lock</span>
+            {{ t("collectionsView.readonlyChip") }}
+          </span>
+          <a
+            v-if="dataSourceRoute"
+            :href="dataSourceRoute ?? undefined"
+            class="ml-1 normal-case tracking-normal font-mono font-normal text-slate-500 hover:text-indigo-700 hover:underline"
+            data-testid="collections-readonly-source"
+            @click="activatePathLink($event, dataSourceRoute ?? '', true)"
+            >{{ collection.schema.dataSource?.path }}</a
+          >
+        </template>
+      </span>
+    </div>
+
+    <component
+      :is="pinToggle"
+      v-if="collection && !embedded"
+      :kind="isFeedRoute ? 'feed' : 'collection'"
+      :slug="collection.slug"
+      :title="collection.title"
+      :icon="collection.icon"
+    />
+
+    <button
+      v-if="collection?.schema.ingest"
+      type="button"
+      class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors disabled:opacity-50"
+      :disabled="refreshing"
+      data-testid="collections-refresh-feed"
+      @click="$emit('refreshFeed')"
+    >
+      <span class="material-icons text-sm">{{ refreshing ? "hourglass_empty" : "refresh" }}</span>
+      <span>{{ t("collectionsView.refreshFeed") }}</span>
+    </button>
+
+    <button
+      v-if="collection"
+      type="button"
+      class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors"
+      data-testid="collections-chat"
+      @click="$emit('openChat')"
+    >
+      <span class="material-icons text-sm">forum</span>
+      <span>{{ t("collectionsView.chat") }}</span>
+    </button>
+
+    <!-- Related-collections pulldown: one click to hop to a collection this
+         one links to (its refs) or that links back (their refs/backlinks).
+         Standalone only, and only when the host exposes `fetchOntology` — a
+         host without that capability (MulmoTerminal) simply omits the
+         control, the same additive pattern as the index Map tab. Neighbors
+         are derived lazily on first open (the ontology scan is expensive and
+         most view opens never touch this menu). -->
+    <div v-if="showRelatedMenu" ref="relatedMenuRef" class="relative">
+      <button
+        type="button"
+        class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors"
+        :aria-expanded="relatedMenuOpen"
+        data-testid="collections-related-menu"
+        @click="toggleRelatedMenu"
+      >
+        <span class="material-icons text-sm">hub</span>
+        <span>{{ t("collectionsView.related") }}</span>
+      </button>
+      <div
+        v-if="relatedMenuOpen"
+        class="absolute right-0 top-full mt-1 z-20 min-w-max rounded border border-slate-200 bg-white shadow-lg py-1"
+        data-testid="collections-related-menu-panel"
+      >
+        <!-- In-flight: the ontology fetch backing this open. -->
+        <div v-if="relatedLoading" class="w-full h-8 px-3 flex items-center gap-2 text-xs text-slate-400" data-testid="collections-related-loading">
+          <span class="material-icons text-sm animate-spin">hourglass_empty</span>
+          <span>{{ t("common.loading") }}</span>
+        </div>
+        <!-- Fail-soft: a failed fetch or a collection with no relations both
+             land on the same disabled empty-state row (no error toast). -->
+        <div v-else-if="relatedItems.length === 0" class="w-full h-8 px-3 flex items-center text-xs text-slate-400" data-testid="collections-related-empty">
+          {{ t("collectionsView.relatedEmpty") }}
+        </div>
+        <button
+          v-for="related in relatedItems"
+          :key="related.slug"
+          type="button"
+          class="w-full h-8 px-3 flex items-center gap-2 text-xs text-slate-600 hover:bg-slate-50 transition-colors"
+          :data-testid="`collections-related-item-${related.slug}`"
+          @click="gotoRelated(related.slug)"
+        >
+          <span class="material-symbols-outlined text-base">{{ related.icon }}</span>
+          <span class="flex-1 text-left">{{ related.title }}</span>
+          <span
+            class="material-icons text-sm text-slate-400"
+            :title="relatedDirectionLabel(related.direction)"
+            :aria-label="relatedDirectionLabel(related.direction)"
+            role="img"
+            >{{ relatedDirectionIcon(related.direction) }}</span
+          >
+        </button>
+      </div>
+    </div>
+
+    <!-- Collection-level actions (schema `collectionActions`). No record
+         context: each seeds a chat with a progress summary of all items. -->
+    <button
+      v-for="action in collectionActions"
+      :key="action.id"
+      type="button"
+      class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors disabled:opacity-50"
+      :disabled="collectionActionPending || isActionRunning(action.id)"
+      :data-testid="`collections-action-${action.id}`"
+      @click="$emit('runCollectionAction', action)"
+    >
+      <!-- A running `kind:"agent"` worker replaces the icon with a spinner
+           until the completion ping's refetch clears its run key. -->
+      <span v-if="isActionRunning(action.id)" class="material-icons text-sm animate-spin">progress_activity</span>
+      <span v-else-if="action.icon" class="material-icons text-sm">{{ action.icon }}</span>
+      <span>{{ action.label }}</span>
+    </button>
+
+    <!-- Hidden in calendar view: there, creation happens via the day view's
+         + button, which opens the new-item form in the popup's right pane. -->
+    <button
+      v-if="canCreate && !calendarActive"
+      type="button"
+      class="h-8 px-2.5 flex items-center gap-1 rounded bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs transition-colors shadow-sm"
+      data-testid="collections-add-item"
+      @click="$emit('openCreate')"
+    >
+      <span class="material-icons text-sm">add</span>
+      <span>{{ t("common.add") }}</span>
+    </button>
+
+    <button
+      v-if="canDeleteCollection && !embedded"
+      type="button"
+      class="h-8 w-8 flex items-center justify-center rounded border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 transition-colors"
+      :title="t('collectionsView.deleteCollection')"
+      :aria-label="t('collectionsView.deleteCollection')"
+      data-testid="collections-delete"
+      @click="$emit('confirmCollectionDelete')"
+    >
+      <span class="material-icons text-sm">delete_forever</span>
+    </button>
+
+    <button
+      v-if="canDeleteFeed && !embedded"
+      type="button"
+      class="h-8 w-8 flex items-center justify-center rounded border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 transition-colors"
+      :title="t('collectionsView.deleteFeed')"
+      :aria-label="t('collectionsView.deleteFeed')"
+      data-testid="feeds-delete"
+      @click="$emit('confirmFeedDelete')"
+    >
+      <span class="material-icons text-sm">delete_forever</span>
+    </button>
+  </header>
+</template>
+
+<script setup lang="ts">
+// The collection view's top header (back / title + dataSource chip / pin /
+// refresh-feed / chat / related-menu / collection actions / add / delete),
+// extracted from CollectionView so that file stays an orchestrator (#2528).
+//
+// The related-collections pulldown lives ENTIRELY inside this header, so its
+// `useRelatedMenu` (open-state + click-outside ref + lazy ontology fetch) moves
+// here too — the wrapper ref, trigger and panel then sit in one component and
+// the document-level outside-click listener resolves against a ref this
+// component owns, exactly as before. The parent drives the per-slug reset
+// through the exposed `resetForSlugChange`, keeping its original timing.
+import { toRef } from "vue";
+import { useCollectionI18n } from "../lang";
+import { collectionUi } from "../uiContext";
+import { useRelatedMenu } from "../composables/useRelatedMenu";
+import { activatePathLink } from "../refLink";
+import { agentActionRunKey, type CollectionAction, type CollectionDetail } from "@mulmoclaude/core/collection";
+
+const props = defineProps<{
+  collection: CollectionDetail | null;
+  embedded: boolean;
+  hideHeader: boolean;
+  isReadOnly: boolean;
+  dataSourceRoute: string | null;
+  isFeedRoute: boolean;
+  refreshing: boolean;
+  collectionActions: CollectionAction[];
+  collectionActionPending: boolean;
+  runningActionIds: Set<string>;
+  canCreate: boolean;
+  calendarActive: boolean;
+  canDeleteCollection: boolean;
+  canDeleteFeed: boolean;
+}>();
+
+defineEmits<{
+  back: [];
+  refreshFeed: [];
+  openChat: [];
+  runCollectionAction: [action: CollectionAction];
+  openCreate: [];
+  confirmCollectionDelete: [];
+  confirmFeedDelete: [];
+}>();
+
+const { t } = useCollectionI18n();
+const cui = collectionUi();
+const { pinToggle } = cui;
+
+const {
+  relatedMenuOpen,
+  relatedMenuRef,
+  relatedLoading,
+  showRelatedMenu,
+  relatedItems,
+  toggleRelatedMenu,
+  gotoRelated,
+  relatedDirectionIcon,
+  relatedDirectionLabel,
+  resetForSlugChange,
+} = useRelatedMenu({ collection: toRef(props, "collection"), embedded: toRef(props, "embedded"), cui, t });
+
+/** Header buttons only ever check the collection-level run key (no itemId),
+ *  so this mirrors the parent's `isActionRunning(id)` via the same key builder. */
+const isActionRunning = (actionId: string): boolean => props.runningActionIds.has(agentActionRunKey(actionId));
+
+defineExpose({ resetForSlugChange });
+</script>

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1,191 +1,29 @@
 <template>
   <div class="h-full flex flex-col bg-slate-50/30">
-    <header v-if="!hideHeader" class="flex items-center gap-3 px-6 py-2 border-b border-slate-200 bg-white">
-      <button
-        v-if="!embedded"
-        type="button"
-        class="h-8 w-8 flex items-center justify-center rounded text-slate-500 hover:bg-slate-50 hover:text-slate-800 transition-colors"
-        :title="t('collectionsView.backToIndex')"
-        :aria-label="t('collectionsView.backToIndex')"
-        data-testid="collections-back"
-        @click="goBack"
-      >
-        <span class="material-icons text-lg">arrow_back</span>
-      </button>
-
-      <div v-if="collection" class="h-9 w-9 flex items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 border border-indigo-100">
-        <span class="material-symbols-outlined text-xl">{{ collection.icon }}</span>
-      </div>
-
-      <div class="flex-1 min-w-0">
-        <h1 class="text-base font-bold text-slate-800 truncate">
-          {{ collection?.title ?? t("collectionsView.title") }}
-        </h1>
-        <span v-if="collection" class="block text-[10px] text-slate-400 font-bold uppercase tracking-wider truncate">
-          {{ collection.slug }}
-          <!-- dataSource chip: sets the read-only expectation up front and
-               links to the file that IS the data (the one editable thing). -->
-          <template v-if="isReadOnly">
-            <span
-              class="inline-flex items-center gap-0.5 ml-1.5 px-1.5 py-px rounded bg-amber-50 text-amber-700 border border-amber-200 normal-case tracking-normal"
-              data-testid="collections-readonly-chip"
-            >
-              <span class="material-icons text-[11px]">lock</span>
-              {{ t("collectionsView.readonlyChip") }}
-            </span>
-            <a
-              v-if="dataSourceRoute"
-              :href="dataSourceRoute ?? undefined"
-              class="ml-1 normal-case tracking-normal font-mono font-normal text-slate-500 hover:text-indigo-700 hover:underline"
-              data-testid="collections-readonly-source"
-              @click="activatePathLink($event, dataSourceRoute ?? '', true)"
-              >{{ collection.schema.dataSource?.path }}</a
-            >
-          </template>
-        </span>
-      </div>
-
-      <component
-        :is="pinToggle"
-        v-if="collection && !embedded"
-        :kind="isFeedRoute ? 'feed' : 'collection'"
-        :slug="collection.slug"
-        :title="collection.title"
-        :icon="collection.icon"
-      />
-
-      <button
-        v-if="collection?.schema.ingest"
-        type="button"
-        class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors disabled:opacity-50"
-        :disabled="refreshing"
-        data-testid="collections-refresh-feed"
-        @click="refreshFeed"
-      >
-        <span class="material-icons text-sm">{{ refreshing ? "hourglass_empty" : "refresh" }}</span>
-        <span>{{ t("collectionsView.refreshFeed") }}</span>
-      </button>
-
-      <button
-        v-if="collection"
-        type="button"
-        class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors"
-        data-testid="collections-chat"
-        @click="openChat"
-      >
-        <span class="material-icons text-sm">forum</span>
-        <span>{{ t("collectionsView.chat") }}</span>
-      </button>
-
-      <!-- Related-collections pulldown: one click to hop to a collection this
-           one links to (its refs) or that links back (their refs/backlinks).
-           Standalone only, and only when the host exposes `fetchOntology` — a
-           host without that capability (MulmoTerminal) simply omits the
-           control, the same additive pattern as the index Map tab. Neighbors
-           are derived lazily on first open (the ontology scan is expensive and
-           most view opens never touch this menu). -->
-      <div v-if="showRelatedMenu" ref="relatedMenuRef" class="relative">
-        <button
-          type="button"
-          class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors"
-          :aria-expanded="relatedMenuOpen"
-          data-testid="collections-related-menu"
-          @click="toggleRelatedMenu"
-        >
-          <span class="material-icons text-sm">hub</span>
-          <span>{{ t("collectionsView.related") }}</span>
-        </button>
-        <div
-          v-if="relatedMenuOpen"
-          class="absolute right-0 top-full mt-1 z-20 min-w-max rounded border border-slate-200 bg-white shadow-lg py-1"
-          data-testid="collections-related-menu-panel"
-        >
-          <!-- In-flight: the ontology fetch backing this open. -->
-          <div v-if="relatedLoading" class="w-full h-8 px-3 flex items-center gap-2 text-xs text-slate-400" data-testid="collections-related-loading">
-            <span class="material-icons text-sm animate-spin">hourglass_empty</span>
-            <span>{{ t("common.loading") }}</span>
-          </div>
-          <!-- Fail-soft: a failed fetch or a collection with no relations both
-               land on the same disabled empty-state row (no error toast). -->
-          <div v-else-if="relatedItems.length === 0" class="w-full h-8 px-3 flex items-center text-xs text-slate-400" data-testid="collections-related-empty">
-            {{ t("collectionsView.relatedEmpty") }}
-          </div>
-          <button
-            v-for="related in relatedItems"
-            :key="related.slug"
-            type="button"
-            class="w-full h-8 px-3 flex items-center gap-2 text-xs text-slate-600 hover:bg-slate-50 transition-colors"
-            :data-testid="`collections-related-item-${related.slug}`"
-            @click="gotoRelated(related.slug)"
-          >
-            <span class="material-symbols-outlined text-base">{{ related.icon }}</span>
-            <span class="flex-1 text-left">{{ related.title }}</span>
-            <span
-              class="material-icons text-sm text-slate-400"
-              :title="relatedDirectionLabel(related.direction)"
-              :aria-label="relatedDirectionLabel(related.direction)"
-              role="img"
-              >{{ relatedDirectionIcon(related.direction) }}</span
-            >
-          </button>
-        </div>
-      </div>
-
-      <!-- Collection-level actions (schema `collectionActions`). No record
-           context: each seeds a chat with a progress summary of all items. -->
-      <button
-        v-for="action in collectionActions"
-        :key="action.id"
-        type="button"
-        class="h-8 px-2.5 flex items-center gap-1 rounded border border-indigo-200 bg-white hover:bg-indigo-50 text-indigo-600 font-bold text-xs transition-colors disabled:opacity-50"
-        :disabled="collectionActionPending || isActionRunning(action.id)"
-        :data-testid="`collections-action-${action.id}`"
-        @click="runCollectionAction(action)"
-      >
-        <!-- A running `kind:"agent"` worker replaces the icon with a spinner
-             until the completion ping's refetch clears its run key. -->
-        <span v-if="isActionRunning(action.id)" class="material-icons text-sm animate-spin">progress_activity</span>
-        <span v-else-if="action.icon" class="material-icons text-sm">{{ action.icon }}</span>
-        <span>{{ action.label }}</span>
-      </button>
-
-      <!-- Hidden in calendar view: there, creation happens via the day view's
-           + button, which opens the new-item form in the popup's right pane. -->
-      <button
-        v-if="canCreate && !calendarActive"
-        type="button"
-        class="h-8 px-2.5 flex items-center gap-1 rounded bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs transition-colors shadow-sm"
-        data-testid="collections-add-item"
-        @click="openCreate"
-      >
-        <span class="material-icons text-sm">add</span>
-        <span>{{ t("common.add") }}</span>
-      </button>
-
-      <button
-        v-if="canDeleteCollection && !embedded"
-        type="button"
-        class="h-8 w-8 flex items-center justify-center rounded border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 transition-colors"
-        :title="t('collectionsView.deleteCollection')"
-        :aria-label="t('collectionsView.deleteCollection')"
-        data-testid="collections-delete"
-        @click="confirmCollectionDelete"
-      >
-        <span class="material-icons text-sm">delete_forever</span>
-      </button>
-
-      <button
-        v-if="canDeleteFeed && !embedded"
-        type="button"
-        class="h-8 w-8 flex items-center justify-center rounded border border-rose-200 bg-white text-rose-600 hover:bg-rose-50 transition-colors"
-        :title="t('collectionsView.deleteFeed')"
-        :aria-label="t('collectionsView.deleteFeed')"
-        data-testid="feeds-delete"
-        @click="confirmFeedDelete"
-      >
-        <span class="material-icons text-sm">delete_forever</span>
-      </button>
-    </header>
+    <CollectionHeader
+      ref="collectionHeaderRef"
+      :collection="collection"
+      :embedded="embedded"
+      :hide-header="hideHeader"
+      :is-read-only="isReadOnly"
+      :data-source-route="dataSourceRoute"
+      :is-feed-route="isFeedRoute"
+      :refreshing="refreshing"
+      :collection-actions="collectionActions"
+      :collection-action-pending="collectionActionPending"
+      :running-action-ids="runningActions"
+      :can-create="canCreate"
+      :calendar-active="calendarActive"
+      :can-delete-collection="canDeleteCollection"
+      :can-delete-feed="canDeleteFeed"
+      @back="goBack"
+      @refresh-feed="refreshFeed"
+      @open-chat="openChat"
+      @run-collection-action="runCollectionAction"
+      @open-create="openCreate"
+      @confirm-collection-delete="confirmCollectionDelete"
+      @confirm-feed-delete="confirmFeedDelete"
+    />
 
     <!-- Transient note for an agent-ingest Refresh: the worker runs in the
          background, so records don't update synchronously — tell the user the
@@ -858,6 +696,7 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from "vue";
 import { useCollectionI18n } from "../lang";
+import CollectionHeader from "./CollectionHeader.vue";
 import CollectionMutateParamsModal from "./CollectionMutateParamsModal.vue";
 import CollectionRecordModal from "./CollectionRecordModal.vue";
 import CollectionChatModal from "./CollectionChatModal.vue";
@@ -884,7 +723,6 @@ import {
 } from "../collectionViewMode";
 import { collectionUi } from "../uiContext";
 import { useClickOutside } from "../composables/useClickOutside";
-import { useRelatedMenu } from "../composables/useRelatedMenu";
 import { useTableSort } from "../composables/useTableSort";
 import { activateRefLink, activatePathLink } from "../refLink";
 import {
@@ -981,7 +819,7 @@ const { t, locale } = useCollectionI18n();
 // the pin toggle) come through the injected CollectionUi binding. The aliases
 // keep the body's call sites unchanged where the host shape matched 1:1.
 const cui = collectionUi();
-const { confirm: openConfirm, unpin, pinToggle, startChat } = cui;
+const { confirm: openConfirm, unpin, startChat } = cui;
 const appApi = { startNewChat: startChat };
 
 /** Embedded when a `slug` prop is supplied; standalone (route-driven)
@@ -1527,27 +1365,14 @@ function closeChat(): void {
   chatOpen.value = false;
 }
 
-// ── Related-collections pulldown (same menu pattern as the filter / "+"
-// menus) ─────────────────────────────────────────────────────────────
-// Offered on the standalone page when the host can fetch the workspace
-// ontology; the derived neighbor list is cached per slug for the
-// component's lifetime and (re)built lazily on the menu's first open, so a
-// view open that never touches the pulldown never pays for the ontology
-// scan.
-// Reactive shell in the composable (open state, lazy per-slug ontology fetch,
-// direction glyph/label); the reset on collection switch is wired below.
-const {
-  relatedMenuOpen,
-  relatedMenuRef,
-  relatedLoading,
-  showRelatedMenu,
-  relatedItems,
-  toggleRelatedMenu,
-  gotoRelated,
-  relatedDirectionIcon,
-  relatedDirectionLabel,
-  resetForSlugChange: resetRelatedMenu,
-} = useRelatedMenu({ collection, embedded, cui, t });
+// ── Related-collections pulldown ──────────────────────────────────────
+// Its whole markup AND its `useRelatedMenu` (open-state, click-outside ref,
+// lazy per-slug ontology fetch) live in CollectionHeader — the menu sits
+// entirely inside the header, so the ref and the document listener belong in
+// one component. The parent still drives the per-slug reset (in the activeSlug
+// watcher below) through the child's exposed `resetForSlugChange`, at the same
+// point it always did.
+const collectionHeaderRef = ref<InstanceType<typeof CollectionHeader> | null>(null);
 
 /** Build the chat seed text for the current view.
  *
@@ -2491,7 +2316,7 @@ watch(
       filterMenuOpen.value = false;
       // Drop the previous collection's cached neighbors so the next open
       // re-derives them for the new slug (also clears any in-flight spinner).
-      resetRelatedMenu();
+      collectionHeaderRef.value?.resetForSlugChange();
       // A sort belongs to a collection's own schema, so don't carry it across —
       // restore the new collection's stored (shared) sort instead. Same for
       // the flag filter chips.

--- a/plans/refactor-2528-collection-header.md
+++ b/plans/refactor-2528-collection-header.md
@@ -1,0 +1,90 @@
+# refactor(collection-plugin): extract CollectionHeader.vue (#2528)
+
+Split from #2298. Extract the header region (template lines 3–188, the
+`<header v-if="!hideHeader">…</header>` element) of
+`packages/plugins/collection-plugin/src/vue/components/CollectionView.vue`
+into a child `CollectionHeader.vue`. One focused PR, proven DOM-byte-equivalent.
+
+## Named traps (from #2528 / #2298)
+
+1. **Some header branches are referenced by NO e2e spec** — a regression there
+   is unprovable by e2e alone, so for those branches safety is proven
+   **structurally** (byte-identical markup + testid inventory diff vs
+   origin/main).
+2. **It drags `useRelatedMenu` across a component boundary.** A
+   `useClickOutside` menu ref does NOT cross a boundary via props. Because the
+   related-menu markup (wrapper `<div ref="relatedMenuRef">`, trigger, panel) is
+   **entirely inside the header**, the fix is to move `useRelatedMenu` INTO
+   `CollectionHeader.vue` — the ref, open-state and document listener then live
+   in one component, exactly as before. This *eliminates* the cross-boundary
+   risk rather than introducing it.
+
+Favorable: the SFC has **no `<style scoped>`** — no scope-hash breakage.
+
+## Design
+
+- `CollectionHeader.vue` renders the `<header v-if="!hideHeader">` block
+  verbatim. The `v-if="!hideHeader"` stays INSIDE the child so the child is
+  always mounted (parent can always reach its exposed reset).
+- Host couplings the child obtains itself (module singletons, callable in any
+  component): `t` via `useCollectionI18n()`, `cui`/`pinToggle` via
+  `collectionUi()`. Pure import `activatePathLink` from `../refLink`.
+  `agentActionRunKey` from `@mulmoclaude/core/collection`.
+- `useRelatedMenu` is instantiated INSIDE the child with
+  `toRef(props,'collection')` / `toRef(props,'embedded')` + its own `cui`/`t`.
+  `resetForSlugChange` is exposed via `defineExpose`; the parent calls it at the
+  SAME `activeSlug`-watcher line it does today — **exact timing preserved**.
+- `isActionRunning(action.id)` is re-derived locally in the child from a
+  `runningActionIds: Set<string>` prop via the same pure `agentActionRunKey`
+  (header only ever calls it with one arg → key `collection/<id>`).
+
+### Props (read-only display state)
+
+`collection`, `embedded`, `hideHeader`, `isReadOnly`, `dataSourceRoute`,
+`isFeedRoute`, `refreshing`, `collectionActions`, `collectionActionPending`,
+`runningActionIds`, `canCreate`, `calendarActive`, `canDeleteCollection`,
+`canDeleteFeed`.
+
+### Emits (props-in / emit-out, no function props)
+
+`back`, `refreshFeed`, `openChat`, `runCollectionAction` (payload: action),
+`openCreate`, `confirmCollectionDelete`, `confirmFeedDelete`.
+
+## Per-branch verification table
+
+Every top-level conditional branch in the header, its testid(s), and how it is
+verified. "structural" = byte-identical markup + testid-inventory diff vs
+origin/main (the only safety net for no-e2e-coverage branches).
+
+| # | Branch (v-if / v-for) | testid(s) | e2e spec | Verification |
+|---|---|---|---|---|
+| 1 | `header v-if="!hideHeader"` | — | — | structural |
+| 2 | back `button v-if="!embedded"` | `collections-back` | none | structural |
+| 3 | icon `div v-if="collection"` | — | none | structural |
+| 4 | title/slug block; `readonly` sub-branch `template v-if="isReadOnly"` | `collections-readonly-chip`, `collections-readonly-source` (`a v-if="dataSourceRoute"`) | none | structural |
+| 5 | pin `component v-if="collection && !embedded"` | — | shortcut-bar (indirect) | structural |
+| 6 | refresh-feed `button v-if="collection?.schema.ingest"` | `collections-refresh-feed` | none | structural |
+| 7 | chat `button v-if="collection"` | `collections-chat` | collection-chat-button.spec.ts | e2e + structural |
+| 8 | related-menu `div v-if="showRelatedMenu"` + panel + loading/empty/items | `collections-related-menu`, `-panel`, `-loading`, `-empty`, `-item-<slug>` | collection-related-menu.spec.ts | e2e + structural + sensitivity |
+| 9 | collection actions `button v-for` | `collections-action-<id>` (computed) | none | structural |
+| 10 | add `button v-if="canCreate && !calendarActive"` | `collections-add-item` | none | structural |
+| 11 | delete-collection `button v-if="canDeleteCollection && !embedded"` | `collections-delete` | present-collection.spec.ts, collection-calendar.spec.ts | e2e + structural |
+| 12 | delete-feed `button v-if="canDeleteFeed && !embedded"` | `feeds-delete` | none | structural |
+
+## Proofs required before merge
+
+- **Structural**: `data-testid` inventory of (CollectionView + CollectionHeader)
+  on this branch == inventory of origin/main's CollectionView → empty diff.
+  Header markup (lines 3–188) byte-identical after normalizing renamed
+  handlers/state.
+- **e2e**: collection mock e2e — `collection-related-menu.spec.ts` plus the
+  covered header specs — on a PRIVATE port with `reuseExistingServer: false`,
+  AFTER `yarn workspace @mulmoclaude/collection-plugin run build` (host serves
+  plugin `dist/`, not `src/`). Pass.
+- **Sensitivity**: break the related-menu wiring, rebuild the plugin, confirm
+  `collection-related-menu.spec.ts` goes RED, restore.
+
+## Gates
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, collection unit
+tests, the three proofs above. No version bumps (extraction only).


### PR DESCRIPTION
## Summary

Extracts the header region (template lines 3–188, the `<header v-if="!hideHeader">…</header>` element) of `CollectionView.vue` into a child **`CollectionHeader.vue`** (#2528, split from #2298). One focused, DOM-byte-equivalent slice.

- `CollectionView.vue`: **2629 → 2454** lines (−175 net).
- `CollectionHeader.vue`: **257** new lines.
- Props-in / emit-out (no function props); Composition API; relative imports; `$t()` for text; no `v-html`; no `any`; no `as` casts.
- **No `<style scoped>`** in the SFC → no scope-hash breakage.

### How `useRelatedMenu` crosses the boundary

The related-collections pulldown (wrapper `<div ref="relatedMenuRef">`, trigger, panel) lives **entirely inside the header**, so `useRelatedMenu` (open-state + `useClickOutside` ref + lazy per-slug ontology fetch) **moves into `CollectionHeader.vue`** — the ref and the document `mousedown` listener now sit in one component, exactly as before. This *eliminates* the cross-boundary ref problem rather than plumbing a ref through props. The parent still drives the per-slug reset from its `activeSlug` watcher, at the **same line and timing** as today, via the child's `defineExpose`d `resetForSlugChange` (called through a template ref) — so switching collections still drops stale neighbors / clears any in-flight spinner identically.

`t` and `cui`/`pinToggle` are module-level singletons (`useCollectionI18n()` / `collectionUi()`), callable in any component, so the child obtains them directly. `activatePathLink` and `agentActionRunKey` are pure imports. `isActionRunning(id)` is re-derived in the child from a `runningActionIds: Set<string>` prop via the same pure key builder (header only ever calls the collection-level, itemId-less form).

## Items to Confirm / Review

- **The boundary decision for `useRelatedMenu`.** Moving it into the child (vs. keeping it in the parent and passing state down) — confirm you agree this is the right call given the menu markup is wholly inside the header.
- **`resetForSlugChange` via `defineExpose` + template ref.** This is the one imperative parent→child coupling. It was chosen to preserve the *exact* reset timing of the original `activeSlug` watcher. Confirm this over a child-side `watch(collection)` (which would reset slightly later, after the async load).
- **No-e2e-coverage branches rely on structural proof only.** `collections-back`, `collections-refresh-feed`, `collections-add-item`, `feeds-delete`, `collections-action-<id>`, `collections-readonly-chip/source` have no e2e spec; their safety is the byte-identical markup + testid-inventory diff below. Please sanity-check the per-branch table.

## Proofs

**Structural** (vs `origin/main`'s `CollectionView.vue`):
- `data-testid` inventory of (CollectionView + CollectionHeader) == origin's inventory → **empty diff** (43 == 43, static + computed).
- Header markup (lines 3–188), normalizing only renamed handlers (→ emits) and the one-level indent shift → **byte-identical** (every `v-if`/`v-else-if`/`v-for` arm preserved).

**e2e** (collection mock, on a **private port 45911 with `reuseExistingServer: false`**, after `yarn workspace @mulmoclaude/collection-plugin run build` so the host serves the fresh plugin `dist/`):
- `collection-related-menu.spec.ts` (both tests: open/list/navigate-close, empty-state) — **pass**
- `collection-chat-button.spec.ts`, `present-collection.spec.ts`, `collection-calendar.spec.ts` — **pass** (26 tests total green).

**Sensitivity**: broke the related-menu toggle wiring (`@click="toggleRelatedMenu"` → no-op), rebuilt the plugin dist → `collection-related-menu.spec.ts` went **RED** (2 failed, panel never opens); restored + rebuilt → **GREEN** (2 passed). Confirms the spec genuinely exercises the child's `useRelatedMenu`.

**Gates**: `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, collection unit tests (`test/utils/collections/*`, 309/309) — all pass.

### Per-branch verification table

Every top-level header branch, its testid(s), and how each is verified.

| # | Branch | testid(s) | e2e spec | Verification |
|---|---|---|---|---|
| 1 | `header v-if="!hideHeader"` | — | — | structural |
| 2 | back `v-if="!embedded"` | `collections-back` | none | structural |
| 3 | icon `v-if="collection"` | — | none | structural |
| 4 | title/slug; readonly `v-if="isReadOnly"` + source `v-if="dataSourceRoute"` | `collections-readonly-chip`, `collections-readonly-source` | none | structural |
| 5 | pin `v-if="collection && !embedded"` | — | shortcut-bar (indirect) | structural |
| 6 | refresh-feed `v-if="collection?.schema.ingest"` | `collections-refresh-feed` | none | structural |
| 7 | chat `v-if="collection"` | `collections-chat` | collection-chat-button.spec.ts | e2e + structural |
| 8 | related-menu `v-if="showRelatedMenu"` (+ panel / loading / empty / items) | `collections-related-menu`, `-panel`, `-loading`, `-empty`, `-item-<slug>` | collection-related-menu.spec.ts | e2e + structural + sensitivity |
| 9 | actions `v-for` | `collections-action-<id>` (computed) | none | structural |
| 10 | add `v-if="canCreate && !calendarActive"` | `collections-add-item` | collection-calendar (hides-in-calendar) | e2e + structural |
| 11 | delete-collection `v-if="canDeleteCollection && !embedded"` | `collections-delete` | present-collection, collection-calendar | e2e + structural |
| 12 | delete-feed `v-if="canDeleteFeed && !embedded"` | `feeds-delete` | none | structural |

## User Prompt

Advance #2528 by extracting `CollectionHeader.vue` (header region, ~lines 3–188) out of `CollectionView.vue` as one focused PR, then take it to merge — or report why it can't be done safely. Two named traps: (1) some header branches are referenced by no e2e spec, so their safety must be proven structurally (byte-identical markup + testid inventory vs origin/main, every conditional arm and every static/computed testid preserved); (2) it drags `useRelatedMenu` across a component boundary — the click-outside menu ref must live where its elements live. Prove DOM byte-equivalence, keep e2e green (`collection-related-menu.spec.ts` on a private port with `reuseExistingServer: false` after a real plugin `dist` rebuild), and add a sensitivity check (break the wiring → spec RED → restore). Be conservative: this is a core production feature — if any no-coverage branch can't be proven byte-equivalent, or the related menu can't cross the boundary safely, do not force it. Do not close #2528 (parallel slices land separately).

## Plan

`plans/refactor-2528-collection-header.md` (committed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated collection header with navigation, pinning, refresh, chat, related collections, and collection action controls.
  * Added permission-aware create and delete actions.
  * Added loading states for refreshes, related collections, and running actions.

* **Refactor**
  * Improved collection view organization by extracting header functionality into a reusable component.

* **Documentation**
  * Added a refactor plan covering component behavior and verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->