### PR TITLE
refactor(collection-plugin): CollectionView → CollectionTable + CollectionCell (byte-equivalent) (#2528)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCell.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCell.vue
@@ -1,0 +1,233 @@
+<template>
+  <td class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
+    <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
+    <template v-if="fieldVisible(field, item)">
+      <!-- Toggle → inline checkbox projecting an enum field.
+           Stores nothing itself; toggling writes onValue/
+           offValue to the projected field via the same PUT. -->
+      <input
+        v-if="field.type === 'toggle'"
+        type="checkbox"
+        :checked="toggleChecked(item, field)"
+        :disabled="isReadOnly || rowInlineSaving"
+        class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle disabled:opacity-50 disabled:cursor-not-allowed"
+        :data-testid="`collections-inline-toggle-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        :aria-label="field.label"
+        @click.stop
+        @change="$emit('commitToggle', item, field)"
+      />
+
+      <!-- Boolean → inline checkbox. Tap toggles + saves
+           immediately; `@click.stop` so it doesn't open the
+           row's detail panel. Unset (undefined) and explicit
+           false both render unchecked. -->
+      <input
+        v-else-if="field.type === 'boolean'"
+        type="checkbox"
+        :checked="item[fieldKey] === true"
+        :disabled="isReadOnly || rowInlineSaving"
+        class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle disabled:opacity-50 disabled:cursor-not-allowed"
+        :data-testid="`collections-inline-bool-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        :aria-label="field.label"
+        @click.stop
+        @change="onBoolChange"
+      />
+
+      <!-- Flag (computed boolean predicate) → read-only check.
+           Never stored; recomputed by deriveAll, so there is
+           nothing to edit inline. -->
+      <span
+        v-else-if="field.type === 'flag'"
+        class="material-icons text-lg align-middle"
+        :class="flagValueOf(String(fieldKey), item) ? 'text-emerald-600' : 'text-slate-300'"
+        :data-testid="`collections-flag-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        :aria-label="`${field.label}: ${t(flagValueOf(String(fieldKey), item) ? 'common.yes' : 'common.no')}`"
+        role="img"
+        >{{ flagValueOf(String(fieldKey), item) ? "check_circle" : "radio_button_unchecked" }}</span
+      >
+
+      <!-- Ref link badge (binding-driven nav, router-optional) -->
+      <span v-else-if="field.type === 'ref' && field.to && typeof item[fieldKey] === 'string' && item[fieldKey]" class="block truncate">
+        <a
+          :href="cui.recordHref?.(field.to, String(item[fieldKey]))"
+          :tabindex="cui.recordHref?.(field.to, String(item[fieldKey])) ? undefined : 0"
+          role="link"
+          class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
+          :data-testid="`collections-ref-link-${fieldKey}-${item[fieldKey]}`"
+          @click="activateRefLink($event, field.to, String(item[fieldKey]), true)"
+          @keydown.enter="activateRefLink($event, field.to, String(item[fieldKey]), true)"
+          @keydown.space="activateRefLink($event, field.to, String(item[fieldKey]), true)"
+          >{{ render.refDisplay(field.to, String(item[fieldKey])) }}</a
+        >
+      </span>
+
+      <!-- Enum → inline dropdown. Selecting writes + saves
+           immediately; the empty placeholder clears the field.
+           `@click.stop` keeps the row's detail panel closed. -->
+      <select
+        v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
+        :value="item[fieldKey] == null ? '' : String(item[fieldKey])"
+        :disabled="isReadOnly || rowInlineSaving"
+        class="rounded-lg border px-2 py-0.5 text-[11px] font-semibold focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        :class="enumControlClass(String(fieldKey), item[fieldKey])"
+        :data-testid="`collections-inline-enum-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        :aria-label="field.label"
+        @click.stop
+        @change="onEnumChange"
+      >
+        <option v-if="showEnumPlaceholder(item, String(fieldKey))" value="">{{ t("collectionsView.selectPlaceholder") }}</option>
+        <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
+      </select>
+
+      <!-- Money -->
+      <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
+        render.formatMoney(item[fieldKey], render.resolveCurrency(field, item), locale)
+      }}</span>
+
+      <!-- Table summary counter -->
+      <span
+        v-else-if="field.type === 'table'"
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-[10px] font-bold bg-slate-100 text-slate-600 border border-slate-200/40"
+      >
+        <span class="material-icons text-[11px]">list</span>
+        <span>{{ tableSummary(item[fieldKey]) }}</span>
+      </span>
+
+      <!-- Derived formula fields -->
+      <span
+        v-else-if="field.type === 'derived'"
+        class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
+        >{{ render.derivedDisplay(field, render.evaluateDerivedAgainstItem(field, String(fieldKey), item), item) }}</span
+      >
+
+      <!-- Rollup aggregates (cross-collection, host/client-computed) -->
+      <span
+        v-else-if="field.type === 'rollup'"
+        class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
+        :data-testid="`collections-rollup-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        >{{ render.rollupDisplay(field, item) }}</span
+      >
+
+      <!-- URL string → external link (new tab). `@click.stop` so
+       clicking the link doesn't also open the row's detail. -->
+      <a
+        v-else-if="field.type !== 'file' && render.isExternalUrl(item[fieldKey])"
+        :href="String(item[fieldKey])"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+        :data-testid="`collections-url-link-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        @click.stop
+        >{{ String(item[fieldKey]) }}</a
+      >
+
+      <!-- File: served HTML/SVG artifact → open the rendered
+           app in a new tab. `@click.stop` keeps the row's
+           detail panel from also opening. -->
+      <a
+        v-else-if="field.type === 'file' && render.artifactUrl(item[fieldKey])"
+        :href="render.artifactUrl(item[fieldKey]) ?? undefined"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+        :data-testid="`collections-file-link-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        @click.stop
+        >{{ String(item[fieldKey]) }}</a
+      >
+
+      <!-- File: any other workspace path → open in File Explorer. -->
+      <a
+        v-else-if="field.type === 'file' && render.fileRoutePath(item[fieldKey])"
+        :href="render.fileRoutePath(item[fieldKey]) ?? undefined"
+        class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
+        :data-testid="`collections-file-link-${fieldKey}-${item[collection.schema.primaryKey]}`"
+        @click="activatePathLink($event, render.fileRoutePath(item[fieldKey]) ?? '', true)"
+        >{{ String(item[fieldKey]) }}</a
+      >
+
+      <span v-else class="block truncate text-slate-600">{{ render.formatCell(item[fieldKey], field.type) }}</span>
+    </template>
+  </td>
+</template>
+
+<script setup lang="ts">
+import { collectionUi } from "../uiContext";
+import { useCollectionI18n } from "../lang";
+import { activateRefLink, activatePathLink } from "../refLink";
+import type { CollectionRendering } from "../useCollectionRendering";
+import {
+  cellKey,
+  fieldVisible,
+  flagFieldValue,
+  resolveEnumColor,
+  rowIdOf,
+  toggleChecked,
+  type CollectionDetail,
+  type CollectionItem,
+  type CollectionFieldSpec as FieldSpec,
+} from "@mulmoclaude/core/collection";
+
+const props = defineProps<{
+  field: FieldSpec;
+  item: CollectionItem;
+  /** The column's field key (was `key` in the parent's `v-for`). */
+  fieldKey: string;
+  collection: CollectionDetail;
+  /** Shared rendering/derivation helpers + ref/embed caches. */
+  render: CollectionRendering;
+  isReadOnly: boolean;
+  /** This row has an inline cell save in flight (controls render disabled). */
+  rowInlineSaving: boolean;
+  /** Cells (keyed `<rowId>:<fieldKey>`) that had no value at load time —
+   *  only these offer the enum dropdown's empty placeholder option. */
+  enumOriginallyEmpty: Set<string>;
+}>();
+
+const emit = defineEmits<{
+  commitToggle: [item: CollectionItem, field: FieldSpec];
+  commitInlineEdit: [item: CollectionItem, key: string, field: FieldSpec, raw: boolean | string];
+}>();
+
+const cui = collectionUi();
+const { t, locale } = useCollectionI18n();
+
+/** A flag FIELD's computed boolean for one row: reads the enriched record so a
+ *  flag over derived/rollup inputs is correct. */
+function flagValueOf(key: string, item: CollectionItem): boolean {
+  return flagFieldValue(props.render.deriveRecord(item), key);
+}
+
+/** Whether an inline enum dropdown should render its empty placeholder
+ *  option: only for cells with no value at load time. */
+function showEnumPlaceholder(item: CollectionItem, key: string): boolean {
+  return props.enumOriginallyEmpty.has(cellKey(rowIdOf(props.collection.schema.primaryKey, item), key));
+}
+
+/** Tailwind fill/text/border classes tinting an inline enum `<select>` by its
+ *  current value's colour. */
+function enumControlClass(key: string, value: unknown): string {
+  const cls = resolveEnumColor(props.collection.schema, key, value);
+  return `${cls.badge} ${cls.border}`;
+}
+
+/** Short summary for a `table`-typed cell: row count, em-dash when empty. */
+function tableSummary(value: unknown): string {
+  if (!Array.isArray(value)) return "—";
+  if (value.length === 0) return "—";
+  return t("collectionsView.tableSummary", { count: value.length });
+}
+
+function onBoolChange(event: Event): void {
+  const { target } = event;
+  if (target instanceof HTMLInputElement) {
+    emit("commitInlineEdit", props.item, String(props.fieldKey), props.field, target.checked);
+  }
+}
+
+function onEnumChange(event: Event): void {
+  const { target } = event;
+  if (target instanceof HTMLSelectElement) {
+    emit("commitInlineEdit", props.item, String(props.fieldKey), props.field, target.value);
+  }
+}
+</script>

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionTable.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionTable.vue
@@ -1,0 +1,135 @@
+<template>
+  <table class="min-w-full text-xs">
+    <thead>
+      <tr class="bg-slate-50 border-b border-slate-200">
+        <th
+          v-for="[key, field] in listColumnFields"
+          :key="key"
+          :aria-sort="isSortableField(field) ? sortAriaValue(key) : undefined"
+          class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider whitespace-nowrap"
+        >
+          <div class="flex items-center gap-1">
+            <span class="truncate max-w-[14rem]" :title="field.label">{{ field.label }}</span>
+            <button
+              v-if="isSortableField(field)"
+              type="button"
+              class="inline-flex items-center justify-center rounded p-0.5 -my-1 leading-none transition-colors"
+              :class="sortButtonClass(key)"
+              :data-testid="`collections-sort-${key}`"
+              :aria-label="t('collectionsView.sortBy', { field: field.label })"
+              @click.stop="$emit('cycleSort', key)"
+              @pointerenter="$emit('update:hoveredSortKey', key)"
+              @pointerleave="$emit('update:hoveredSortKey', null)"
+            >
+              <span class="material-icons text-base align-middle">{{ sortIconName(key) }}</span>
+            </button>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-100 bg-white">
+      <template v-for="item in sortedItems" :key="String(item[collection.schema.primaryKey] ?? '')">
+        <tr
+          class="hover:bg-slate-50/70 cursor-pointer transition-colors focus:outline-none focus:bg-indigo-50/30"
+          :class="rowHighlighted(item) ? 'bg-indigo-50/40' : ''"
+          role="button"
+          tabindex="0"
+          :aria-label="t('collectionsView.openItem', { id: String(item[collection.schema.primaryKey] ?? '') })"
+          :data-testid="`collections-row-${item[collection.schema.primaryKey]}`"
+          @click="$emit('openView', item)"
+          @keydown.enter.self="$emit('openView', item)"
+          @keydown.space.self.prevent="$emit('openView', item)"
+        >
+          <CollectionCell
+            v-for="[key, field] in listColumnFields"
+            :key="key"
+            :field="field"
+            :field-key="key"
+            :item="item"
+            :collection="collection"
+            :render="render"
+            :is-read-only="isReadOnly"
+            :row-inline-saving="rowInlineSaving(item)"
+            :enum-originally-empty="enumOriginallyEmpty"
+            @commit-toggle="onCommitToggle"
+            @commit-inline-edit="onCommitInlineEdit"
+          />
+        </tr>
+      </template>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import CollectionCell from "./CollectionCell.vue";
+import { useCollectionI18n } from "../lang";
+import type { CollectionRendering } from "../useCollectionRendering";
+import { previewSortDir, sortAriaTokenForDir, sortButtonClassForDir, sortIconNameForDir, type SortDir } from "../tableSortDisplay";
+import {
+  isSortableField,
+  rowIdOf,
+  type CollectionDetail,
+  type CollectionItem,
+  type CollectionFieldSpec as FieldSpec,
+  type SortState,
+} from "@mulmoclaude/core/collection";
+
+const props = defineProps<{
+  collection: CollectionDetail;
+  listColumnFields: [string, FieldSpec][];
+  sortedItems: CollectionItem[];
+  render: CollectionRendering;
+  isReadOnly: boolean;
+  enumOriginallyEmpty: Set<string>;
+  /** Rows with an inline cell save in flight (by `rowId`). */
+  inlineSavingRows: Set<string>;
+  sortState: SortState | null;
+  /** The column whose sort button is hovered (drives the next-click preview). */
+  hoveredSortKey: string | null;
+  /** rowId of the record open in read-only detail, or null. */
+  openRowId: string | null;
+  /** rowId of the record being edited (non-create), or null. */
+  editingRowId: string | null;
+}>();
+
+const emit = defineEmits<{
+  openView: [item: CollectionItem];
+  cycleSort: [key: string];
+  commitToggle: [item: CollectionItem, field: FieldSpec];
+  commitInlineEdit: [item: CollectionItem, key: string, field: FieldSpec, raw: boolean | string];
+  "update:hoveredSortKey": [key: string | null];
+}>();
+
+const { t } = useCollectionI18n();
+
+function sortDirectionFor(key: string): SortDir {
+  return props.sortState?.field === key ? props.sortState.direction : null;
+}
+
+function effectiveSortDir(key: string): SortDir {
+  return previewSortDir(sortDirectionFor(key), props.hoveredSortKey === key);
+}
+
+const sortIconName = (key: string): string => sortIconNameForDir(effectiveSortDir(key));
+const sortButtonClass = (key: string): string => sortButtonClassForDir(effectiveSortDir(key));
+const sortAriaValue = (key: string): "ascending" | "descending" | "none" => sortAriaTokenForDir(sortDirectionFor(key));
+
+/** This row has an inline cell save in flight (its inline controls disabled). */
+function rowInlineSaving(item: CollectionItem): boolean {
+  return props.inlineSavingRows.has(rowIdOf(props.collection.schema.primaryKey, item));
+}
+
+/** This row is the one open in read-only detail OR the one being edited. */
+function rowHighlighted(item: CollectionItem): boolean {
+  const rowKey = rowIdOf(props.collection.schema.primaryKey, item);
+  return rowKey === props.openRowId || rowKey === props.editingRowId;
+}
+
+function onCommitToggle(item: CollectionItem, field: FieldSpec): void {
+  emit("commitToggle", item, field);
+}
+
+function onCommitInlineEdit(item: CollectionItem, key: string, field: FieldSpec, raw: boolean | string): void {
+  emit("commitInlineEdit", item, key, field, raw);
+}
+</script>

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -600,200 +600,23 @@
             <span class="material-icons text-base">close</span>
           </button>
         </div>
-        <table class="min-w-full text-xs">
-          <thead>
-            <tr class="bg-slate-50 border-b border-slate-200">
-              <th
-                v-for="[key, field] in listColumnFields"
-                :key="key"
-                :aria-sort="isSortableField(field) ? sortAriaValue(key) : undefined"
-                class="px-5 py-3 font-bold text-slate-500 text-left uppercase tracking-wider whitespace-nowrap"
-              >
-                <div class="flex items-center gap-1">
-                  <span class="truncate max-w-[14rem]" :title="field.label">{{ field.label }}</span>
-                  <button
-                    v-if="isSortableField(field)"
-                    type="button"
-                    class="inline-flex items-center justify-center rounded p-0.5 -my-1 leading-none transition-colors"
-                    :class="sortButtonClass(key)"
-                    :data-testid="`collections-sort-${key}`"
-                    :aria-label="t('collectionsView.sortBy', { field: field.label })"
-                    @click.stop="cycleSort(key)"
-                    @pointerenter="hoveredSortKey = key"
-                    @pointerleave="hoveredSortKey = null"
-                  >
-                    <span class="material-icons text-base align-middle">{{ sortIconName(key) }}</span>
-                  </button>
-                </div>
-              </th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-slate-100 bg-white">
-            <template v-for="item in sortedItems" :key="String(item[collection.schema.primaryKey] ?? '')">
-              <tr
-                class="hover:bg-slate-50/70 cursor-pointer transition-colors focus:outline-none focus:bg-indigo-50/30"
-                :class="isRowOpen(item) || isEditingRow(item) ? 'bg-indigo-50/40' : ''"
-                role="button"
-                tabindex="0"
-                :aria-label="t('collectionsView.openItem', { id: String(item[collection.schema.primaryKey] ?? '') })"
-                :data-testid="`collections-row-${item[collection.schema.primaryKey]}`"
-                @click="openView(item)"
-                @keydown.enter.self="openView(item)"
-                @keydown.space.self.prevent="openView(item)"
-              >
-                <td v-for="[key, field] in listColumnFields" :key="key" class="px-5 py-2 text-slate-700 align-middle max-w-xs font-medium">
-                  <!-- Conditionally hidden field (`when` predicate) → blank cell. -->
-                  <template v-if="fieldVisible(field, item)">
-                    <!-- Toggle → inline checkbox projecting an enum field.
-                         Stores nothing itself; toggling writes onValue/
-                         offValue to the projected field via the same PUT. -->
-                    <input
-                      v-if="field.type === 'toggle'"
-                      type="checkbox"
-                      :checked="toggleChecked(item, field)"
-                      :disabled="isReadOnly || isRowInlineSaving(item)"
-                      class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle disabled:opacity-50 disabled:cursor-not-allowed"
-                      :data-testid="`collections-inline-toggle-${key}-${item[collection.schema.primaryKey]}`"
-                      :aria-label="field.label"
-                      @click.stop
-                      @change="commitToggle(item, field)"
-                    />
-
-                    <!-- Boolean → inline checkbox. Tap toggles + saves
-                         immediately; `@click.stop` so it doesn't open the
-                         row's detail panel. Unset (undefined) and explicit
-                         false both render unchecked. -->
-                    <input
-                      v-else-if="field.type === 'boolean'"
-                      type="checkbox"
-                      :checked="item[key] === true"
-                      :disabled="isReadOnly || isRowInlineSaving(item)"
-                      class="h-5 w-5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500/20 cursor-pointer align-middle disabled:opacity-50 disabled:cursor-not-allowed"
-                      :data-testid="`collections-inline-bool-${key}-${item[collection.schema.primaryKey]}`"
-                      :aria-label="field.label"
-                      @click.stop
-                      @change="commitInlineEdit(item, String(key), field, ($event.target as HTMLInputElement).checked)"
-                    />
-
-                    <!-- Flag (computed boolean predicate) → read-only check.
-                         Never stored; recomputed by deriveAll, so there is
-                         nothing to edit inline. -->
-                    <span
-                      v-else-if="field.type === 'flag'"
-                      class="material-icons text-lg align-middle"
-                      :class="flagValueOf(String(key), item) ? 'text-emerald-600' : 'text-slate-300'"
-                      :data-testid="`collections-flag-${key}-${item[collection.schema.primaryKey]}`"
-                      :aria-label="`${field.label}: ${t(flagValueOf(String(key), item) ? 'common.yes' : 'common.no')}`"
-                      role="img"
-                      >{{ flagValueOf(String(key), item) ? "check_circle" : "radio_button_unchecked" }}</span
-                    >
-
-                    <!-- Ref link badge (binding-driven nav, router-optional) -->
-                    <span v-else-if="field.type === 'ref' && field.to && typeof item[key] === 'string' && item[key]" class="block truncate">
-                      <a
-                        :href="cui.recordHref?.(field.to, String(item[key]))"
-                        :tabindex="cui.recordHref?.(field.to, String(item[key])) ? undefined : 0"
-                        role="link"
-                        class="text-indigo-600 hover:text-indigo-800 hover:underline font-semibold"
-                        :data-testid="`collections-ref-link-${key}-${item[key]}`"
-                        @click="activateRefLink($event, field.to, String(item[key]), true)"
-                        @keydown.enter="activateRefLink($event, field.to, String(item[key]), true)"
-                        @keydown.space="activateRefLink($event, field.to, String(item[key]), true)"
-                        >{{ refDisplay(field.to, String(item[key])) }}</a
-                      >
-                    </span>
-
-                    <!-- Enum → inline dropdown. Selecting writes + saves
-                         immediately; the empty placeholder clears the field.
-                         `@click.stop` keeps the row's detail panel closed. -->
-                    <select
-                      v-else-if="field.type === 'enum' && Array.isArray(field.values) && field.values.length > 0"
-                      :value="item[key] == null ? '' : String(item[key])"
-                      :disabled="isReadOnly || isRowInlineSaving(item)"
-                      class="rounded-lg border px-2 py-0.5 text-[11px] font-semibold focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                      :class="enumControlClass(String(key), item[key])"
-                      :data-testid="`collections-inline-enum-${key}-${item[collection.schema.primaryKey]}`"
-                      :aria-label="field.label"
-                      @click.stop
-                      @change="commitInlineEdit(item, String(key), field, ($event.target as HTMLSelectElement).value)"
-                    >
-                      <option v-if="showEnumPlaceholder(item, String(key))" value="">{{ t("collectionsView.selectPlaceholder") }}</option>
-                      <option v-for="value in field.values" :key="value" :value="value">{{ value }}</option>
-                    </select>
-
-                    <!-- Money -->
-                    <span v-else-if="field.type === 'money'" class="block truncate tabular-nums font-semibold text-slate-900">{{
-                      formatMoney(item[key], resolveCurrency(field, item), locale)
-                    }}</span>
-
-                    <!-- Table summary counter -->
-                    <span
-                      v-else-if="field.type === 'table'"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-[10px] font-bold bg-slate-100 text-slate-600 border border-slate-200/40"
-                    >
-                      <span class="material-icons text-[11px]">list</span>
-                      <span>{{ tableSummary(item[key]) }}</span>
-                    </span>
-
-                    <!-- Derived formula fields -->
-                    <span
-                      v-else-if="field.type === 'derived'"
-                      class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
-                      >{{ derivedDisplay(field, evaluateDerivedAgainstItem(field, String(key), item), item) }}</span
-                    >
-
-                    <!-- Rollup aggregates (cross-collection, host/client-computed) -->
-                    <span
-                      v-else-if="field.type === 'rollup'"
-                      class="inline-block truncate tabular-nums font-bold text-indigo-900 bg-indigo-50/50 px-1.5 py-0.5 rounded border border-indigo-100/50"
-                      :data-testid="`collections-rollup-${key}-${item[collection.schema.primaryKey]}`"
-                      >{{ render.rollupDisplay(field, item) }}</span
-                    >
-
-                    <!-- URL string → external link (new tab). `@click.stop` so
-                     clicking the link doesn't also open the row's detail. -->
-                    <a
-                      v-else-if="field.type !== 'file' && isExternalUrl(item[key])"
-                      :href="String(item[key])"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
-                      :data-testid="`collections-url-link-${key}-${item[collection.schema.primaryKey]}`"
-                      @click.stop
-                      >{{ String(item[key]) }}</a
-                    >
-
-                    <!-- File: served HTML/SVG artifact → open the rendered
-                         app in a new tab. `@click.stop` keeps the row's
-                         detail panel from also opening. -->
-                    <a
-                      v-else-if="field.type === 'file' && artifactUrl(item[key])"
-                      :href="artifactUrl(item[key]) ?? undefined"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
-                      :data-testid="`collections-file-link-${key}-${item[collection.schema.primaryKey]}`"
-                      @click.stop
-                      >{{ String(item[key]) }}</a
-                    >
-
-                    <!-- File: any other workspace path → open in File Explorer. -->
-                    <a
-                      v-else-if="field.type === 'file' && fileRoutePath(item[key])"
-                      :href="fileRoutePath(item[key]) ?? undefined"
-                      class="block truncate text-blue-600 hover:text-blue-800 hover:underline font-semibold"
-                      :data-testid="`collections-file-link-${key}-${item[collection.schema.primaryKey]}`"
-                      @click="activatePathLink($event, fileRoutePath(item[key]) ?? '', true)"
-                      >{{ String(item[key]) }}</a
-                    >
-
-                    <span v-else class="block truncate text-slate-600">{{ formatCell(item[key], field.type) }}</span>
-                  </template>
-                </td>
-              </tr>
-            </template>
-          </tbody>
-        </table>
+        <CollectionTable
+          v-model:hovered-sort-key="hoveredSortKey"
+          :collection="collection"
+          :list-column-fields="listColumnFields"
+          :sorted-items="sortedItems"
+          :render="render"
+          :is-read-only="isReadOnly"
+          :enum-originally-empty="enumOriginallyEmpty"
+          :inline-saving-rows="inlineSavingRows"
+          :sort-state="sortState"
+          :open-row-id="openRowId"
+          :editing-row-id="editingRowId"
+          @open-view="openView"
+          @cycle-sort="cycleSort"
+          @commit-toggle="commitToggle"
+          @commit-inline-edit="commitInlineEdit"
+        />
       </div>
     </div>
 
@@ -869,6 +692,7 @@ import CollectionRecordPanel from "./CollectionRecordPanel.vue";
 import CollectionViewConfigModal from "./CollectionViewConfigModal.vue";
 import CollectionCustomView from "./CollectionCustomView.vue";
 import CollectionRemoteViewPreview from "./CollectionRemoteViewPreview.vue";
+import CollectionTable from "./CollectionTable.vue";
 import { useCollectionRendering } from "../useCollectionRendering";
 import {
   readCollectionViewMode,
@@ -886,14 +710,12 @@ import { collectionUi } from "../uiContext";
 import { useClickOutside } from "../composables/useClickOutside";
 import { useRelatedMenu } from "../composables/useRelatedMenu";
 import { useTableSort } from "../composables/useTableSort";
-import { activateRefLink, activatePathLink } from "../refLink";
+import { activatePathLink } from "../refLink";
 import {
   dateOf,
-  isSortableField,
   itemMatchesQuery,
   completionCoveredByFieldChip,
   snapshotEmptyEnums,
-  cellKey,
   rowIdOf,
   flagFieldValue,
   toggleChecked,
@@ -905,8 +727,6 @@ import {
   actionVisible,
   agentActionRunKey,
   COMPUTED_TYPES,
-  fieldVisible,
-  resolveEnumColor,
   buildUpdatedRecord,
   coerceInlineValue,
   draftToRecord,
@@ -1091,12 +911,12 @@ function applyServerRunningActions(keys: string[] | undefined, genAtFetch: numbe
 const chatOpen = ref(false);
 
 // Shared rendering + linked-data layer: owns the ref/embed caches and
-// every value-formatting helper, reused by the extracted record panel
-// (table + calendar) so there's one implementation. Destructure the
-// helpers the list table renders with; pass the whole object to the
-// panel as its `render` prop.
+// every value-formatting helper, reused by the extracted table / cell / record
+// panel so there's one implementation. The whole object is passed down as the
+// `render` prop; only the few helpers this component still calls directly
+// (sort deps, dataSource route) are destructured here.
 const render = useCollectionRendering(collection, locale);
-const { refDisplay, formatMoney, resolveCurrency, derivedDisplay, evaluateDerivedAgainstItem, formatCell, isExternalUrl, artifactUrl, fileRoutePath } = render;
+const { refDisplay, evaluateDerivedAgainstItem, fileRoutePath } = render;
 
 const searchQuery = ref("");
 
@@ -1253,9 +1073,6 @@ const {
   hoveredSortKey,
   sortedItems,
   cycleSort,
-  sortIconName,
-  sortButtonClass,
-  sortAriaValue,
   resetForSlug: resetSortForSlug,
 } = useTableSort({
   collection,
@@ -1277,34 +1094,22 @@ function rowId(item: CollectionItem): string {
   return rowIdOf(collection.value?.schema.primaryKey, item);
 }
 
-/** Whether an inline enum dropdown should render its empty placeholder
- *  option: only for cells with no value at load time. */
-function showEnumPlaceholder(item: CollectionItem, fieldKey: string): boolean {
-  return enumOriginallyEmpty.value.has(cellKey(rowId(item), fieldKey));
-}
-
-/** Tailwind fill/text/border classes tinting an inline enum `<select>` by its
- *  current value's colour (palette, or notification red/amber/grey when the
- *  field is the schema's notifyWhen target). */
-function enumControlClass(fieldKey: string, value: unknown): string {
-  const schema = collection.value?.schema;
-  if (!schema) return "";
-  const cls = resolveEnumColor(schema, fieldKey, value);
-  return `${cls.badge} ${cls.border}`;
-}
-
 /** This row is the one open in read-only detail. */
 function isRowOpen(item: CollectionItem): boolean {
   return viewing.value !== null && rowId(viewing.value) === rowId(item);
 }
 
-/** This row is the one being edited (highlights it in the list while the
- *  edit modal is open). Create mode has no backing row, so nothing matches. */
-function isEditingRow(item: CollectionItem): boolean {
+/** rowId of the record open in read-only detail (drives the table's row
+ *  highlight), or null when nothing is open. */
+const openRowId = computed<string | null>(() => (viewing.value ? rowId(viewing.value) : null));
+
+/** rowId of the record being edited (highlights it in the list while the edit
+ *  modal is open), or null. Create mode has no backing row, so nothing matches. */
+const editingRowId = computed<string | null>(() => {
   const draft = editing.value;
-  if (!draft || draft.mode === "create") return false;
-  return draft.originalId === rowId(item);
-}
+  if (!draft || draft.mode === "create") return null;
+  return draft.originalId;
+});
 
 /** Re-run a feed collection's retrieval now, then reload its records.
  *  Only reachable when `schema.ingest` is present (button is gated). */
@@ -2202,15 +2007,6 @@ const liveDerived = computed<CollectionItem | null>(() => {
   return render.deriveRecord(liveRecord.value);
 });
 
-/** Short summary for a `table`-typed cell in the main collection
- *  table. Counts rows; nothing fancier yet (per-row preview is
- *  hard to fit in a single cell). */
-function tableSummary(value: unknown): string {
-  if (!Array.isArray(value)) return "—";
-  if (value.length === 0) return "—";
-  return t("collectionsView.tableSummary", { count: value.length });
-}
-
 async function saveEditor(): Promise<void> {
   if (!collection.value || !editing.value) return;
   // Snapshot mutable refs before any await — route changes during
@@ -2250,12 +2046,6 @@ async function saveEditor(): Promise<void> {
  *  option; the PUT body omits the key via `buildUpdatedRecord`. */
 function applyInlineValue(item: CollectionItem, key: string, value: unknown): void {
   item[key] = value;
-}
-
-/** True while this row has an inline cell save in flight — its inline
- *  controls render disabled to serialize edits (one PUT per row). */
-function isRowInlineSaving(item: CollectionItem): boolean {
-  return inlineSavingRows.value.has(rowId(item));
 }
 
 /** Inline table-cell edit (boolean checkbox / enum dropdown): optimistic

--- a/plans/refactor-2528-collection-table.md
+++ b/plans/refactor-2528-collection-table.md
@@ -1,0 +1,93 @@
+# refactor(#2528): extract CollectionTable.vue + CollectionCell.vue from CollectionView.vue
+
+## Goal
+
+Split the list-table markup out of `CollectionView.vue` (~2629 lines) into two
+child components, proving the rendered DOM is **byte-equivalent**. This is the
+highest-risk slice of #2528 / #2298 because:
+
+1. `collections-row-<id>` (6 e2e specs) MUST stay on the root `<tr>`.
+2. `collection-image-field.spec.ts:71` traverses `thead th` — the
+   `<table><thead>…<th></thead><tbody>…</tbody></table>` shape must not gain or
+   lose a node.
+3. All `data-testid`s across the region must stay identical.
+
+Favourable: the SFC has **no `<style scoped>`**, so no scope-hash breakage.
+
+## Decomposition
+
+- **`CollectionCell.vue`** — template root IS the `<td class="px-5 py-2 …">`.
+  Contains every field-type branch (toggle/bool/flag/ref/enum/money/table/derived/
+  rollup/url/file/plain). No wrapper node.
+- **`CollectionTable.vue`** — template root IS the `<table class="min-w-full text-xs">`.
+  Contains `<thead>` (th + sort), `<tbody>` with the `<template v-for>`/`<tr>` loop;
+  each `<td>` becomes `<CollectionCell>`. No wrapper node.
+
+Single-root-element children ⇒ Vue emits no wrapper ⇒ `<tr>`/`<td>`/`<table>`
+nesting is preserved.
+
+## Prop / emit contracts (props in, emit out — no function props)
+
+Established pattern (mirrors `CollectionRecordPanel.vue`): child receives the
+`render: CollectionRendering` service as a prop, calls `collectionUi()` and
+`useCollectionI18n()` itself, and imports pure helpers directly
+(`fieldVisible`, `toggleChecked`, `isSortableField`, `rowIdOf`, `cellKey`,
+`resolveEnumColor`, `flagFieldValue` from core; `activateRefLink`/`activatePathLink`
+from `../refLink`; `previewSortDir`/`sort*ForDir` from `../tableSortDisplay`).
+
+### CollectionCell.vue
+- props: `field`, `item`, `fieldKey`, `collection`, `render`, `isReadOnly`,
+  `rowInlineSaving`, `enumOriginallyEmpty`
+- emits: `commitToggle(item, field)`, `commitInlineEdit(item, key, field, raw)`
+- local (identical logic): `flagValueOf`, `showEnumPlaceholder`, `enumControlClass`,
+  `tableSummary`
+- `($event.target as HTMLInputElement)` casts → `instanceof` type-guard methods
+  (no-`as` rule; DOM output unchanged)
+
+### CollectionTable.vue
+- props: `collection`, `listColumnFields`, `sortedItems`, `render`, `isReadOnly`,
+  `enumOriginallyEmpty`, `inlineSavingRows`, `sortState`, `openRowId`, `editingRowId`
+- `v-model:hoveredSortKey`
+- emits: `openView(item)`, `cycleSort(key)`, `commitToggle`, `commitInlineEdit`,
+  `update:hoveredSortKey`
+- re-derives per-column sort display from `sortState` + `hoveredSortKey` via the
+  pure `../tableSortDisplay` fns (same output as `useTableSort`).
+
+## Parent changes (CollectionView.vue)
+
+- Replace `<table>…</table>` (603–796) with `<CollectionTable …>`.
+- Remove now-unused: fns `showEnumPlaceholder`, `enumControlClass`, `isEditingRow`,
+  `tableSummary`, `isRowInlineSaving`; imports `fieldVisible`, `cellKey`,
+  `resolveEnumColor`, `activateRefLink`; useTableSort destructure entries
+  `sortIconName`, `sortButtonClass`, `sortAriaValue`.
+- Add computeds `openRowId` (= rowId(viewing)) and `editingRowId`
+  (= non-create draft.originalId), replacing the `isRowOpen||isEditingRow` row class.
+- Keep everything still referenced elsewhere: `isRowOpen` (openView), `flagValueOf`
+  (sortValueDeps), `toggleChecked`/`refDisplay`/`evaluateDerivedAgainstItem`
+  (sortValueDeps), `cycleSort`/`hoveredSortKey`/`sortState`/`sortedItems` (props),
+  `activatePathLink` (dataSource route, line 41).
+
+## Staged commits (ship the proven subset)
+
+1. `docs(plan)` — this file.
+2. Extract `CollectionCell.vue`; prove testid diff + build + collection unit +
+   e2e subset + sensitivity.
+3. Extract `CollectionTable.vue`; prove full `<table>` byte-diff + e2e + sensitivity.
+
+If the Table proof is not rock-solid, DROP commit 3 and PR Cell-only (Table
+deferred with evidence) — the `<table>/<thead>/<tr>` stay untouched in the parent,
+so traps 1 & 2 hold by non-modification.
+
+## Three proofs (all required before merge)
+
+1. **Structural** — sort+diff every `data-testid` template string:
+   `origin/main` CollectionView vs (View + CollectionTable + CollectionCell),
+   normalizing `${fieldKey}`→`${key}`. Empty diff. Plus a normalized
+   `<table>…</table>` markup diff (nesting identical).
+2. **e2e** — collection mock e2e on a PRIVATE port (`reuseExistingServer:false`)
+   AFTER `yarn workspace @mulmoclaude/collection-plugin run build`. Must include
+   `collection-image-field.spec.ts` + the 6 `collections-row-<id>` specs. All green.
+3. **Sensitivity** — move `collections-row-<id>` onto a wrapper (or drop a `<th>`),
+   rebuild, confirm the relevant spec goes RED, restore.
+
+Do NOT merge unless all three are rock-solid.


### PR DESCRIPTION
## Summary

Extracts the list-table markup out of the ~2629-line `CollectionView.vue` into two **single-root-element** child components, proving the rendered DOM is **byte-equivalent**. This is the highest-risk slice of #2528 / #2298 (6 e2e specs depend on `collections-row-<id>` on the `<tr>`; `collection-image-field.spec.ts:71` traverses `thead th`).

- **`CollectionCell.vue`** — template root **is** the `<td>`; every field-type branch (toggle/bool/flag/ref/enum/money/table/derived/rollup/url/file/plain). Receives the `render: CollectionRendering` service + data as props, calls `collectionUi()`/`useCollectionI18n()` itself, imports pure helpers directly; emits `commitToggle` / `commitInlineEdit`.
- **`CollectionTable.vue`** — template root **is** the `<table>`; `<thead>` (sort) + `<tbody>`/`<tr>` loop, each cell a `<CollectionCell>`. Re-derives per-column sort display from the pure `tableSortDisplay` fns; emits `openView` / `cycleSort` / `commit*`; `v-model:hoveredSortKey`.

`CollectionView.vue`: **2629 → 2419 lines** (−210).

Single-root-element children ⇒ Vue emits **no wrapper node** ⇒ `<tr>` / `<td>` / `<table>` nesting is preserved. `collections-row-<id>` stays on the root `<tr>`; the `<table>/<thead>/<th>` shape is unchanged.

## Items to Confirm / Review

- **`collections-row-<id>` on the `<tr>`**: it is a `:data-testid` on `CollectionTable`'s `<tr>` (the row id passed through as `item[collection.schema.primaryKey]`, never a wrapper). 6 specs depend on it.
- **`thead th` shape**: the `<thead><tr><th>` markup is reproduced verbatim in `CollectionTable`; no element added/dropped.
- **Props-in / emit-out**: no function props. `render` is passed as a prop (same pattern as `CollectionRecordPanel.vue`); interactive handlers are emits. Pure display helpers are imported or re-derived, not passed.
- **`as`-cast removal**: the two `($event.target as HTMLInputElement/SelectElement)` casts became `instanceof` type-guard methods (`onBoolChange` / `onEnumChange`) — same DOM behaviour, repo no-`as` rule honoured.
- **Sort display duplication**: `CollectionTable` re-derives `sortIconName/Class/AriaValue` from `sortState` + `hoveredSortKey` via the pure `../tableSortDisplay` fns (the same functions `useTableSort` uses) — logic reused, not copied.

## Three proofs (all rock-solid)

1. **Structural (testids)** — extracted + sorted every `data-testid` template string from `origin/main`'s `CollectionView` vs the merged tree (View + Table + Cell), normalizing only the `fieldKey`↔`key` rename → **empty diff, all 43 identical**.
2. **Structural (table markup)** — element-nesting skeleton (tag names only) of the origin `<table>…</table>` vs `CollectionTable` with `CollectionCell`'s `<td>` inlined → **60 tags, IDENTICAL** (`table>thead>tr>th…` + `tbody>template>tr>td…`).
3. **e2e + sensitivity** — full collection mock e2e on a **private port (47531, `reuseExistingServer:false`)** after `yarn workspace @mulmoclaude/collection-plugin run build` (host serves plugin `dist/`): **73/73 green**, including `collection-image-field.spec.ts` + the 6 `collections-row-<id>` specs. **Sensitivity**: breaking `collections-row-<id>` on the `<tr>` → rebuild → **7 specs RED** → restore → **38 green** again, proving the e2e actually guards the trap.

## Gates

`yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` all green; collection host unit tests pass (0 failures).

## User Prompt

Advance issue #2528 by extracting `CollectionTable.vue` + `CollectionCell.vue` out of `CollectionView.vue` — the highest-risk slice — as one focused, byte-equivalence PR that proves the rendered DOM is identical, keeping `collections-row-<id>` on the root `<tr>` and the `<table>/<thead>/<th>` structure byte-for-byte intact, with all `data-testid`s unchanged. Prove it three ways (testid diff, table-markup diff, collection e2e on a private port after a real plugin `dist` rebuild, plus a sensitivity check that the specs go red when the trap is broken). Collection is a core production feature — be conservative: merge only if every proof is rock-solid, else ship only the provably-safe sub-part or report CANNOT-SAFELY-EXTRACT. Do not close #2528 (other slices in flight); post a progress comment.

## Related

#2528, #2298 (closed), #2384, #2455, #2476, #2527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)