### PR TITLE
refactor(collection-plugin): CollectionView script → composables, slice 1 (#2528)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -874,36 +874,29 @@ import {
   readCollectionViewMode,
   writeCollectionViewMode,
   writeCollectionSort,
-  readCollectionFlagFilters,
   writeCollectionFlagFilters,
   customViewKey,
   type CollectionViewMode,
   type BuiltInViewMode,
-  type FlagFilterMode,
-  type FlagFilterState,
 } from "../collectionViewMode";
 import { collectionUi } from "../uiContext";
 import { useClickOutside } from "../composables/useClickOutside";
 import { useRelatedMenu } from "../composables/useRelatedMenu";
 import { useTableSort } from "../composables/useTableSort";
+import { useCollectionActions } from "../composables/useCollectionActions";
+import { useFlagFilters } from "../composables/useFlagFilters";
+import { useCollectionChat } from "../composables/useCollectionChat";
 import { activateRefLink, activatePathLink } from "../refLink";
 import {
   dateOf,
   isSortableField,
   itemMatchesQuery,
-  completionCoveredByFieldChip,
   snapshotEmptyEnums,
   cellKey,
   rowIdOf,
-  flagFieldValue,
   toggleChecked,
-  chipMatches,
   nextUniqueItemId,
-  skillCommandSeed,
   shortHexId,
-  defangForPrompt,
-  actionVisible,
-  agentActionRunKey,
   COMPUTED_TYPES,
   fieldVisible,
   resolveEnumColor,
@@ -913,10 +906,7 @@ import {
   firstMissingRequiredField,
   rowFromItem,
   type Ymd,
-  type FlagChip,
   type SortValueDeps,
-  type CollectionAction,
-  type CollectionMutateAction,
   type CollectionCustomView as CustomViewSpec,
   type CollectionDetail,
   type CollectionItem,
@@ -1058,37 +1048,6 @@ const enumOriginallyEmpty = ref<Set<string>>(new Set());
  *  otherwise clobber the newer field on disk while the UI shows the
  *  newer optimistic value (Codex PR #1599 P2). */
 const inlineSavingRows = ref<Set<string>>(new Set());
-const actionPending = ref(false);
-const actionError = ref<string | null>(null);
-const collectionActionPending = ref(false);
-
-// In-flight `kind: "agent"` action run keys. The server's detail response
-// is the source of truth (its dispatch guard); a dispatch adds the key
-// optimistically BEFORE the POST, and the worker's completion ping
-// (publishCollectionChange) triggers the refetch that reconciles it.
-const runningActions = ref<Set<string>>(new Set());
-
-// Generation guard: bumped on every LOCAL runningActions mutation so a
-// detail response that started BEFORE the mutation can't clobber it — a
-// pre-dispatch snapshot would erase the optimistic key and strand the
-// button enabled while the worker runs (Codex + CodeRabbit on PR #2104).
-let runningActionsGen = 0;
-
-function mutateRunningActions(mutate: (next: Set<string>) => void): void {
-  runningActionsGen += 1;
-  const next = new Set(runningActions.value);
-  mutate(next);
-  runningActions.value = next;
-}
-
-/** Adopt a detail response's `runningActions` — only when no local
- *  mutation happened while the response was in flight (stale snapshots
- *  are dropped; the completion ping's refetch reconciles soon after). */
-function applyServerRunningActions(keys: string[] | undefined, genAtFetch: number): void {
-  if (runningActionsGen !== genAtFetch) return;
-  runningActions.value = new Set(keys ?? []);
-}
-const chatOpen = ref(false);
 
 // Shared rendering + linked-data layer: owns the ref/embed caches and
 // every value-formatting helper, reused by the extracted record panel
@@ -1107,129 +1066,27 @@ const filteredItems = computed<CollectionItem[]>(() => {
 });
 
 // ── Flag filter chips (table view only) ───────────────────────────
-// One tri-state chip per `flag` field (all → hide → only), ANDed with the
-// text search. Schemas with only the legacy completion pair (no flag) get
-// a synthesized "done" chip driven by the shared `itemIsDone`, so #2174's
-// hide-completed works without a schema edit. Calendar / kanban / custom
-// views deliberately see the UNfiltered list (plan scope —
-// plans/done/feat-collection-flag-fields.md). Chip state is a SHARED
-// per-collection localStorage preference, exactly like the table sort.
-
-/** Chip key (state/testid/localStorage) for the synthesized
- *  legacy-completion chip. Field names are unrestricted strings, so a
- *  schema COULD declare a field with this exact name — the chip list
- *  below skips synthesizing in that case, and the predicate dispatch
- *  keys off the structural `synthetic` marker, never this string. */
-const COMPLETION_CHIP_KEY = "__completion";
-
-function storedFlagFiltersFor(slug: string | undefined): FlagFilterState {
-  return slug ? readCollectionFlagFilters(slug) : {};
-}
-const flagFilters = ref<FlagFilterState>(storedFlagFiltersFor(activeSlug.value));
-
-/** The field types that earn a filter-menu entry: declared predicates
- *  (`flag`) plus the fields that ARE a predicate already — a stored
- *  `boolean` and a `toggle`'s projected on/off state. Enums stay out:
- *  they need a value picker, and kanban already slices by enum. */
-const CHIP_FIELD_TYPES = new Set(["flag", "boolean", "toggle"]);
-
-const flagChips = computed<FlagChip[]>(() => {
-  const schema = collection.value?.schema;
-  if (!schema) return [];
-  const chips: FlagChip[] = Object.entries(schema.fields)
-    .filter(([, field]) => CHIP_FIELD_TYPES.has(field.type))
-    .map(([key, field]) => ({ key, label: field.label ?? key }));
-  // Legacy completion pair (completionField NOT naming a flag) → one
-  // synthesized done chip; a flag-form completion is already covered by
-  // that flag's own chip, and a pair a boolean/toggle chip expresses
-  // exactly is covered by THAT chip (else e.g. the todos schema shows
-  // two "Done" filters). Skipped when a field happens to be named
-  // `__completion`, so the chip key (filter state / testid / Vue :key)
-  // can never collide with a real field's.
-  if (
-    schema.completionField &&
-    schema.completionDoneValues &&
-    schema.fields[schema.completionField]?.type !== "flag" &&
-    !completionCoveredByFieldChip(schema) &&
-    schema.fields[COMPLETION_CHIP_KEY] === undefined
-  ) {
-    chips.push({ key: COMPLETION_CHIP_KEY, label: t("collectionsView.flagDoneChip"), synthetic: true });
-  }
-  return chips;
-});
-
-/** Own-property read of a chip's active mode. Field names may shadow
- *  `Object.prototype` members (`toString`, `valueOf`, …) — a plain
- *  `filters[key]` on such a key reads the inherited function, which
- *  renders as an "active" chip that can never cycle (Codex review on
- *  PR #2176). Every chip-state read goes through here. */
-function flagFilterMode(key: string): FlagFilterMode | undefined {
-  const filters = flagFilters.value;
-  return Object.hasOwn(filters, key) ? filters[key] : undefined;
-}
-
-/** A flag FIELD's computed boolean for one row (list cells + sort): reads the
- *  enriched record so a flag over derived/rollup inputs is correct. */
-function flagValueOf(key: string, item: CollectionItem): boolean {
-  return flagFieldValue(render.deriveRecord(item), key);
-}
-
-/** `filteredItems` further narrowed by every ACTIVE chip (AND). Consumed
- *  only by the table (sortedItems / count summary / empty state). */
-const tableFilteredItems = computed<CollectionItem[]>(() => {
-  const schema = collection.value?.schema;
-  const active = flagChips.value.filter((chip) => flagFilterMode(chip.key) !== undefined);
-  if (!schema || active.length === 0) return filteredItems.value;
-  return filteredItems.value.filter((item) =>
-    active.every((chip) => chipMatches(chip, schema, item, render.deriveRecord) === (flagFilterMode(chip.key) === "only")),
-  );
-});
-
-/** Cycle a chip all → hide → only → all. */
-function cycleFlagFilter(key: string): void {
-  const current = flagFilterMode(key);
-  const next: FlagFilterMode | undefined = current === undefined ? "hide" : current === "hide" ? "only" : undefined;
-  const rest = Object.fromEntries(Object.entries(flagFilters.value).filter(([entry]) => entry !== key));
-  flagFilters.value = next ? { ...rest, [key]: next } : rest;
-}
-
-// Checkbox metaphor for the tri-state: checked = only the ON rows,
-// unchecked = only the OFF rows, faint unchecked = not filtering. The
-// icon glyph alone can't show the third state (Material Icons has no
-// dotted box), so `flagChipIconClass` greys it out instead.
-function flagChipIcon(key: string): string {
-  return flagFilterMode(key) === "only" ? "check_box" : "check_box_outline_blank";
-}
-
-function flagChipIconClass(key: string): string {
-  const mode = flagFilterMode(key);
-  if (mode === "hide") return "text-slate-600";
-  if (mode === "only") return "text-indigo-600";
-  return "text-slate-300";
-}
-
-// Menu-entry state tints (the distinct-from-view-toggle treatment lives
-// on the trigger pill): slate for "hide" (rows removed), indigo for
-// "only" (rows isolated), neutral when inactive.
-function flagChipClass(key: string): string {
-  const mode = flagFilterMode(key);
-  if (mode === "hide") return "bg-slate-100 text-slate-700";
-  if (mode === "only") return "bg-indigo-50 text-indigo-700";
-  return "text-slate-500";
-}
-
-/** How many chips currently filter (badge on the menu trigger). */
-const activeFlagFilterCount = computed<number>(() => flagChips.value.filter((chip) => flagFilterMode(chip.key) !== undefined).length);
-
-// ── Filter dropdown open/close (same pattern as the "+" add-view menu) ──
-const { open: filterMenuOpen, menuRef: filterMenuRef } = useClickOutside();
-
-function flagChipTitle(chip: FlagChip): string {
-  const mode = flagFilterMode(chip.key);
-  if (mode === "hide") return t("collectionsView.flagFilterHide", { label: chip.label });
-  if (mode === "only") return t("collectionsView.flagFilterOnly", { label: chip.label });
-  return t("collectionsView.flagFilterAll", { label: chip.label });
-}
+// One tri-state chip per predicate-shaped field (all → hide → only), ANDed with
+// the text search. The reactive shell + per-collection localStorage state live
+// in `useFlagFilters`; the tri-state transition / own-property read / colour
+// mappings in `../flagFilterDisplay`. `tableFilteredItems` + `flagValueOf` feed
+// the sort below.
+const {
+  flagFilters,
+  flagChips,
+  tableFilteredItems,
+  activeFlagFilterCount,
+  filterMenuOpen,
+  filterMenuRef,
+  flagValueOf,
+  flagFilterMode,
+  cycleFlagFilter,
+  flagChipIcon,
+  flagChipIconClass,
+  flagChipClass,
+  flagChipTitle,
+  resetForSlug: resetFlagFiltersForSlug,
+} = useFlagFilters({ collection, filteredItems, activeSlug, deriveRecord: render.deriveRecord, t });
 
 // ── List-table sort (single active column, header toggle) ─────────
 // Row readers the pure `sortValueOf` can't get from the raw cell: toggle /
@@ -1345,187 +1202,33 @@ function showRefreshNote(message: string): void {
   }, 6000);
 }
 
-/** Collection-level header actions. No `when` predicate (no record). */
-const collectionActions = computed<CollectionAction[]>(() => collection.value?.schema.collectionActions ?? []);
+// ── Schema-declared actions (collection-level, per-record, mutate) ──
+// The reactive shell + the `runningActions` generation guard live in
+// `useCollectionActions`; the load path (`loadCollection` / `refreshItemsInPlace`)
+// drives the guard through `clearRunningActions` / `beginRunningActionsReconcile`.
+const {
+  actionPending,
+  actionError,
+  collectionActionPending,
+  mutateModal,
+  mutatePending,
+  mutateError,
+  collectionActions,
+  visibleActions,
+  viewingRunningActionIds,
+  isActionRunning,
+  runCollectionAction,
+  runAction,
+  submitMutateParams,
+  repairCollection,
+  clearRunningActions,
+  beginRunningActionsReconcile,
+} = useCollectionActions({ collection, viewing, dataIssues, inlineError, cui, props, t });
 
-/** True when a `kind: "agent"` action's hidden worker is in flight —
- *  drives the button spinner + disable. Keys mirror the server's
- *  dispatch guard via `agentActionRunKey`. */
-function isActionRunning(actionId: string, itemId?: string): boolean {
-  return runningActions.value.has(agentActionRunKey(actionId, itemId));
-}
-
-/** Run a collection-level action: ask the server to assemble the seed
- *  prompt (a progress summary of all records + the template). `kind:
- *  "chat"` gets the seed back and starts a new chat; `kind: "agent"` is
- *  dispatched server-side as a hidden worker — mark it running and let
- *  the completion ping's refetch reconcile. Generic — no domain knowledge. */
-async function runCollectionAction(action: CollectionAction): Promise<void> {
-  const current = collection.value;
-  if (!current || collectionActionPending.value || isActionRunning(action.id)) return;
-  // Optimistic key BEFORE the POST: a fast worker's completion ping can
-  // beat the POST's resolution, and adding the key afterwards would
-  // strand the spinner past the only refetch that could clear it.
-  const runKey = action.kind === "agent" ? agentActionRunKey(action.id) : null;
-  if (runKey) mutateRunningActions((next) => next.add(runKey));
-  collectionActionPending.value = true;
-  inlineError.value = null;
-  const result = await cui.runCollectionAction(current.slug, action.id);
-  collectionActionPending.value = false;
-  if (!result.ok) {
-    // 409 = the server's dispatch guard CONFIRMED a worker is in flight
-    // (e.g. dispatched from another tab) — keep the key so the button
-    // stays disabled; drop it only for real launch failures.
-    if (runKey && result.status !== 409) mutateRunningActions((next) => next.delete(runKey));
-    inlineError.value = result.error;
-    return;
-  }
-  if (result.data.dispatched) return; // key already set; the completion ping's refetch reconciles
-  if (result.data.written) return; // mutate never reaches this handler branch; narrows the union
-  if (props.sendTextMessage) {
-    props.sendTextMessage(result.data.prompt);
-    return;
-  }
-  appApi.startNewChat(result.data.prompt, result.data.role);
-}
-
-/** Report the server-detected record data problems back to the LLM so it
- *  fixes the offending files. Mirrors the `presentCollection` validation
- *  path (`dispatchPresentCollection`), but user-initiated via the Repair
- *  button instead of fired automatically after a write. Dispatches into
- *  the current chat when embedded, else seeds a new General chat. */
-function repairCollection(): void {
-  const current = collection.value;
-  if (!current || dataIssues.value.length === 0) return;
-  // Issue text carries record-controlled values (ids, enum values), so defang
-  // structural injection vectors before it rides into the LLM prompt. Shared
-  // with the server's presentCollection path via `defangForPrompt` so the two
-  // can't drift (it also collapses whitespace, closing a newline-injection gap).
-  const lines = dataIssues.value.map((issue) => `- ${defangForPrompt(issue.file)}: ${defangForPrompt(issue.problem)}`).join("\n");
-  const prompt = t("collectionsView.repairPrompt", { title: current.title, count: dataIssues.value.length, issues: lines });
-  if (props.sendTextMessage) {
-    props.sendTextMessage(prompt);
-    return;
-  }
-  appApi.startNewChat(prompt, cui.generalRoleId);
-}
-
-/** Actions whose optional `when` predicate matches the open record.
- *  Status-driven buttons (e.g. invoice "Record payment") stay hidden
- *  until the record reaches the matching state. */
-const visibleActions = computed<CollectionAction[]>(() => {
-  const record = viewing.value;
-  if (!record) return [];
-  return (collection.value?.schema.actions ?? []).filter((action) => actionVisible(action, record));
-});
-
-// `kind: "mutate"` mini-form state: the open modal (which action, which
-// record), its in-flight flag, and the server's `problem` text on a
-// rejected write (rendered inline so the user fixes and retries).
-const mutateModal = ref<{ action: CollectionMutateAction; itemId: string } | null>(null);
-const mutatePending = ref(false);
-const mutateError = ref<string | null>(null);
-
-/** POST one mutate action and, on success, adopt the written record for
- *  the open panel (the write's change ping refreshes the table rows).
- *  Errors land in the modal when one is open, else on the panel. */
-async function executeMutate(action: CollectionMutateAction, itemId: string, params: Record<string, unknown>): Promise<boolean> {
-  // Re-entrancy guard: Enter-key repeats / double-clicks can outrun the
-  // buttons' :disabled state — one write in flight at a time.
-  if (!collection.value || mutatePending.value) return false;
-  mutatePending.value = true;
-  const result = await cui.runItemAction(collection.value.slug, itemId, action.id, params);
-  mutatePending.value = false;
-  if (!result.ok) {
-    if (mutateModal.value) mutateError.value = result.error;
-    else actionError.value = result.error;
-    return false;
-  }
-  if (result.data.written && viewing.value && String(viewing.value[collection.value.schema.primaryKey] ?? "") === itemId) {
-    viewing.value = result.data.item;
-  }
-  return true;
-}
-
-async function submitMutateParams(params: Record<string, unknown>): Promise<void> {
-  const open = mutateModal.value;
-  if (!open) return;
-  mutateError.value = null;
-  if (await executeMutate(open.action, open.itemId, params)) mutateModal.value = null;
-}
-
-/** Mutate kind: open the params mini-form when the action declares one,
- *  else apply the declarative write immediately. */
-async function runMutateAction(action: CollectionMutateAction, itemId: string): Promise<void> {
-  actionError.value = null;
-  if (action.params && Object.keys(action.params).length > 0) {
-    mutateError.value = null;
-    mutateModal.value = { action, itemId };
-    return;
-  }
-  await executeMutate(action, itemId, {});
-}
-
-/** Run a schema-declared action on the open record. `kind: "mutate"`
- *  never leaves the host: with `params` it opens the mini-form, else it
- *  applies immediately. `kind: "chat"` gets the seed back and starts a
- *  new chat; `kind: "agent"` is dispatched server-side as a hidden
- *  worker — mark it running and let the completion ping's refetch
- *  reconcile. Generic — no knowledge of what the action does. */
-async function runAction(action: CollectionAction): Promise<void> {
-  if (!collection.value || !viewing.value) return;
-  const itemId = String(viewing.value[collection.value.schema.primaryKey] ?? "");
-  if (!itemId || isActionRunning(action.id, itemId)) return;
-  if (action.kind === "mutate") {
-    await runMutateAction(action, itemId);
-    return;
-  }
-  // Optimistic key BEFORE the POST — see runCollectionAction.
-  const runKey = action.kind === "agent" ? agentActionRunKey(action.id, itemId) : null;
-  if (runKey) mutateRunningActions((next) => next.add(runKey));
-  actionPending.value = true;
-  actionError.value = null;
-  const result = await cui.runItemAction(collection.value.slug, itemId, action.id);
-  actionPending.value = false;
-  if (!result.ok) {
-    // 409 = already running server-side — keep the key; see runCollectionAction.
-    if (runKey && result.status !== 409) mutateRunningActions((next) => next.delete(runKey));
-    actionError.value = result.error;
-    return;
-  }
-  if (result.data.dispatched) return; // key already set; the completion ping's refetch reconciles
-  if (result.data.written) return; // mutate never reaches this handler branch; narrows the union
-  // In a chat card we have a channel into the current session — send
-  // the seed prompt there rather than spawning a new chat. Standalone
-  // route mode has no such channel, so start a fresh chat in the
-  // action's role (which carries the tools the action needs).
-  if (props.sendTextMessage) {
-    props.sendTextMessage(result.data.prompt);
-    return;
-  }
-  appApi.startNewChat(result.data.prompt, result.data.role);
-}
-
-/** Ids of the open record's actions whose hidden worker is running — the
- *  record panel renders those buttons with a spinner, disabled. */
-const viewingRunningActionIds = computed<string[]>(() => {
-  const current = collection.value;
-  const record = viewing.value;
-  if (!current || !record) return [];
-  const itemId = String(record[current.schema.primaryKey] ?? "");
-  if (!itemId) return [];
-  return (current.schema.actions ?? []).filter((action) => isActionRunning(action.id, itemId)).map((action) => action.id);
-});
-
-/** Open the chat modal. The modal owns its draft + focus: it remounts on
- *  every open (parent `v-if`), so it starts blank and self-focuses. */
-function openChat(): void {
-  chatOpen.value = true;
-}
-
-function closeChat(): void {
-  chatOpen.value = false;
-}
+// ── Chat entry points (header "chat about collection" + per-record chat box) ──
+// The modal open/close + the skill/feed chat-seed builder live in
+// `useCollectionChat`; the seed shape is core's `skillCommandSeed`.
+const { chatOpen, openChat, closeChat, submitChat, onItemChat } = useCollectionChat({ collection, viewing, cui, props, t });
 
 // ── Related-collections pulldown (same menu pattern as the filter / "+"
 // menus) ─────────────────────────────────────────────────────────────
@@ -1549,64 +1252,6 @@ const {
   resetForSlugChange: resetRelatedMenu,
 } = useRelatedMenu({ collection, embedded, cui, t });
 
-/** Build the chat seed text for the current view.
- *
- *  A collection IS a skill, so its slug doubles as a slash command:
- *  "I want to create an item" on `mc_worklog` becomes
- *  `/mc_worklog I want to create an item`.
- *
- *  A feed is data-only — it has NO skill, so `/<slug>` would resolve to
- *  nothing. Instead, point the agent at the feed's schema + records
- *  (`feeds/<slug>/schema.json` and `<dataPath>/`) and let it act on the
- *  request directly. */
-function buildChatSeed(slug: string, message: string, itemId?: string): string {
-  const current = collection.value;
-  // Only an actual Feed (source `feed`) is skill-less + data-only. A
-  // skill-backed collection — even one carrying an agent-ingest block — DOES
-  // have a `/<slug>` skill command, so seed that. (Checked via `source`
-  // directly, not the `isFeed` computed defined further down, to keep this
-  // helper self-contained and avoid a use-before-define.)
-  if (current?.source !== "feed") return skillCommandSeed(slug, message, itemId);
-  const dataPath = current.schema.dataPath ?? `data/feeds/${slug}`;
-  // A feed has no skill command — point the agent at a specific record by id
-  // inside the same schema-driven seed.
-  const scoped = itemId ? `(for record \`${itemId}\`) ${message}` : message;
-  return t("collectionsView.feedChatSeed", { slug, dataPath, message: scoped });
-}
-
-/** Start a new general-role chat seeded from the current view. `raw` is
- *  the modal's untrimmed textarea text. */
-function submitChat(raw: string): void {
-  if (!collection.value) return;
-  const message = raw.trim();
-  if (!message) return;
-  closeChat();
-  const text = buildChatSeed(collection.value.slug, message);
-  // Chat card → send into the current session; standalone → new chat.
-  if (props.sendTextMessage) {
-    props.sendTextMessage(text);
-    return;
-  }
-  appApi.startNewChat(text, cui.generalRoleId);
-}
-
-/** The open record's chat box: start a chat scoped to that one record. Seeds
- *  the collection's skill command with an `id=<itemId>` selector
- *  (`/<slug> id=<itemId> <message>`) so the agent acts on this record. */
-function onItemChat(message: string): void {
-  if (!collection.value || !viewing.value) return;
-  const text = message.trim();
-  if (!text) return;
-  const itemId = String(viewing.value[collection.value.schema.primaryKey] ?? "");
-  const seed = buildChatSeed(collection.value.slug, text, itemId || undefined);
-  // Chat card → send into the current session; standalone → new chat.
-  if (props.sendTextMessage) {
-    props.sendTextMessage(seed);
-    return;
-  }
-  appApi.startNewChat(seed, cui.generalRoleId);
-}
-
 async function loadCollection(slug: string): Promise<void> {
   // Snapshot the shortcut kind BEFORE the await — if the user navigates
   // between /feeds/:slug and /collections/:slug while the fetch is in
@@ -1618,7 +1263,7 @@ async function loadCollection(slug: string): Promise<void> {
   collection.value = null;
   items.value = [];
   dataIssues.value = []; // never carry a previous collection's issues over
-  mutateRunningActions((next) => next.clear()); // ditto for another collection's spinners
+  clearRunningActions(); // ditto for another collection's spinners
   searchQuery.value = ""; // Reset search query on collection load
   // NOTE: the active column sort is NOT reset here — it's part of the view
   // state, so it must survive a refresh / edit reload and an embedded card
@@ -1626,7 +1271,7 @@ async function loadCollection(slug: string): Promise<void> {
   render.resetLinkedCaches();
   viewing.value = null;
   openDay.value = null; // never carry a previous collection's open day over
-  const runningGen = runningActionsGen;
+  const reconcileRunningActions = beginRunningActionsReconcile();
   const result = await cui.fetchCollectionDetail(slug);
   loading.value = false;
   if (!result.ok) {
@@ -1644,7 +1289,7 @@ async function loadCollection(slug: string): Promise<void> {
   collection.value = result.data.collection;
   items.value = result.data.items;
   dataIssues.value = result.data.issues ?? [];
-  applyServerRunningActions(result.data.runningActions, runningGen);
+  reconcileRunningActions(result.data.runningActions);
   enumOriginallyEmpty.value = snapshotEmptyEnums(result.data.collection.schema, result.data.items);
   // Fan out to fetch each unique target collection so the table can
   // render ref values as display names (not slugs) and the form
@@ -1679,14 +1324,14 @@ async function loadCollection(slug: string): Promise<void> {
  *  fetch is a no-op (keep the current data) — a transient blip shouldn't blank a
  *  view the user is reading. */
 async function refreshItemsInPlace(slug: string): Promise<void> {
-  const runningGen = runningActionsGen;
+  const reconcileRunningActions = beginRunningActionsReconcile();
   const result = await cui.fetchCollectionDetail(slug);
   // Bail if the fetch failed or the user switched collections mid-flight.
   if (!result.ok || activeSlug.value !== slug) return;
   collection.value = result.data.collection;
   items.value = result.data.items;
   dataIssues.value = result.data.issues ?? [];
-  applyServerRunningActions(result.data.runningActions, runningGen);
+  reconcileRunningActions(result.data.runningActions);
   enumOriginallyEmpty.value = snapshotEmptyEnums(result.data.collection.schema, result.data.items);
   await render.loadLinkedCollections(result.data.collection.schema, slug);
   if (activeSlug.value !== slug) return; // re-check after the await
@@ -2496,7 +2141,7 @@ watch(
       // restore the new collection's stored (shared) sort instead. Same for
       // the flag filter chips.
       resetSortForSlug(slug);
-      flagFilters.value = storedFlagFiltersFor(slug);
+      resetFlagFiltersForSlug(slug);
     }
     if (slug) {
       loadCollection(slug);

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1045,6 +1045,7 @@ function showRefreshNote(message: string): void {
 // `useCollectionActions`; the load path (`loadCollection` / `refreshItemsInPlace`)
 // drives the guard through `clearRunningActions` / `beginRunningActionsReconcile`.
 const {
+  runningActions,
   actionPending,
   actionError,
   collectionActionPending,

--- a/packages/plugins/collection-plugin/src/vue/composables/collectionActionRunners.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/collectionActionRunners.ts
@@ -22,17 +22,23 @@ import type { useCollectionI18n } from "../lang";
 
 type Translate = ReturnType<typeof useCollectionI18n>["t"];
 
-export interface CollectionActionContext {
-  collection: Ref<CollectionDetail | null>;
-  viewing: Ref<CollectionItem | null>;
-  dataIssues: Readonly<Ref<CollectionRecordIssue[]>>;
-  inlineError: Ref<string | null>;
+/** The action UI-state refs the composable owns and the runners mutate — shared
+ *  between the run context (below) and the composable's public surface, so the
+ *  field set is declared once. */
+export interface CollectionActionState {
   actionPending: Ref<boolean>;
   actionError: Ref<string | null>;
   collectionActionPending: Ref<boolean>;
   mutateModal: Ref<{ action: CollectionMutateAction; itemId: string } | null>;
   mutatePending: Ref<boolean>;
   mutateError: Ref<string | null>;
+}
+
+export interface CollectionActionContext extends CollectionActionState {
+  collection: Ref<CollectionDetail | null>;
+  viewing: Ref<CollectionItem | null>;
+  dataIssues: Readonly<Ref<CollectionRecordIssue[]>>;
+  inlineError: Ref<string | null>;
   guard: RunningActionsGuard;
   cui: CollectionUi;
   props: { sendTextMessage?: (text?: string) => void };

--- a/packages/plugins/collection-plugin/src/vue/composables/collectionActionRunners.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/collectionActionRunners.ts
@@ -1,0 +1,179 @@
+// The action-run logic behind `useCollectionActions`, as module-level functions
+// over an explicit context object. Kept out of the composable's setup body so
+// each stays a small, independently-readable unit (and the composable stays a
+// thin reactive shell). Every write goes through the injected `cui`; the
+// optimistic run keys go through the injected `guard`.
+
+import type { Ref } from "vue";
+import {
+  actionVisible,
+  agentActionRunKey,
+  defangForPrompt,
+  rowIdOf,
+  type CollectionAction,
+  type CollectionMutateAction,
+  type CollectionDetail,
+  type CollectionItem,
+  type CollectionRecordIssue,
+} from "@mulmoclaude/core/collection";
+import type { RunningActionsGuard } from "./runningActionsGuard";
+import type { CollectionUi } from "../uiContext";
+import type { useCollectionI18n } from "../lang";
+
+type Translate = ReturnType<typeof useCollectionI18n>["t"];
+
+export interface CollectionActionContext {
+  collection: Ref<CollectionDetail | null>;
+  viewing: Ref<CollectionItem | null>;
+  dataIssues: Readonly<Ref<CollectionRecordIssue[]>>;
+  inlineError: Ref<string | null>;
+  actionPending: Ref<boolean>;
+  actionError: Ref<string | null>;
+  collectionActionPending: Ref<boolean>;
+  mutateModal: Ref<{ action: CollectionMutateAction; itemId: string } | null>;
+  mutatePending: Ref<boolean>;
+  mutateError: Ref<string | null>;
+  guard: RunningActionsGuard;
+  cui: CollectionUi;
+  props: { sendTextMessage?: (text?: string) => void };
+  t: Translate;
+}
+
+/** Dispatch a seed prompt into the current session (embedded chat card) or a new
+ *  chat in `role` (standalone page). */
+function dispatchPrompt(ctx: CollectionActionContext, text: string, role: string): void {
+  if (ctx.props.sendTextMessage) {
+    ctx.props.sendTextMessage(text);
+    return;
+  }
+  ctx.cui.startChat(text, role);
+}
+
+/** True when a `kind: "agent"` action's hidden worker is in flight. Keys mirror
+ *  the server's dispatch guard via `agentActionRunKey`. */
+export function isActionRunning(guard: RunningActionsGuard, actionId: string, itemId?: string): boolean {
+  return guard.isRunning(agentActionRunKey(actionId, itemId));
+}
+
+/** Actions whose optional `when` predicate matches the open record. */
+export function visibleActionsOf(collection: CollectionDetail | null, viewing: CollectionItem | null): CollectionAction[] {
+  if (!viewing) return [];
+  return (collection?.schema.actions ?? []).filter((action) => actionVisible(action, viewing));
+}
+
+/** Ids of the open record's actions whose hidden worker is running. */
+export function runningActionIdsOf(collection: CollectionDetail | null, viewing: CollectionItem | null, guard: RunningActionsGuard): string[] {
+  if (!collection || !viewing) return [];
+  const itemId = rowIdOf(collection.schema.primaryKey, viewing);
+  if (!itemId) return [];
+  return (collection.schema.actions ?? []).filter((action) => isActionRunning(guard, action.id, itemId)).map((action) => action.id);
+}
+
+/** Run a collection-level action: the server assembles the seed prompt. `kind:
+ *  "chat"` starts a new chat; `kind: "agent"` is dispatched server-side as a
+ *  hidden worker — mark it running and let the completion ping's refetch
+ *  reconcile. */
+export async function runCollectionAction(ctx: CollectionActionContext, action: CollectionAction): Promise<void> {
+  const current = ctx.collection.value;
+  if (!current || ctx.collectionActionPending.value || isActionRunning(ctx.guard, action.id)) return;
+  // Optimistic key BEFORE the POST: a fast worker's completion ping can beat the
+  // POST's resolution, and adding the key afterwards would strand the spinner.
+  const runKey = action.kind === "agent" ? agentActionRunKey(action.id) : null;
+  if (runKey) ctx.guard.mutate((next) => next.add(runKey));
+  ctx.collectionActionPending.value = true;
+  ctx.inlineError.value = null;
+  const result = await ctx.cui.runCollectionAction(current.slug, action.id);
+  ctx.collectionActionPending.value = false;
+  if (!result.ok) {
+    // 409 = the server's dispatch guard CONFIRMED a worker in flight — keep the
+    // key so the button stays disabled; drop it only for real launch failures.
+    if (runKey && result.status !== 409) ctx.guard.mutate((next) => next.delete(runKey));
+    ctx.inlineError.value = result.error;
+    return;
+  }
+  if (result.data.dispatched) return; // key already set; the completion ping's refetch reconciles
+  if (result.data.written) return; // mutate never reaches this branch; narrows the union
+  dispatchPrompt(ctx, result.data.prompt, result.data.role);
+}
+
+/** Report the server-detected record data problems back to the LLM so it fixes
+ *  the offending files. Dispatches into the current chat when embedded, else a
+ *  new General chat. */
+export function repairCollection(ctx: CollectionActionContext): void {
+  const current = ctx.collection.value;
+  if (!current || ctx.dataIssues.value.length === 0) return;
+  // Issue text carries record-controlled values, so defang structural injection
+  // vectors (shared with the server's presentCollection path via `defangForPrompt`).
+  const lines = ctx.dataIssues.value.map((issue) => `- ${defangForPrompt(issue.file)}: ${defangForPrompt(issue.problem)}`).join("\n");
+  const prompt = ctx.t("collectionsView.repairPrompt", { title: current.title, count: ctx.dataIssues.value.length, issues: lines });
+  dispatchPrompt(ctx, prompt, ctx.cui.generalRoleId);
+}
+
+/** POST one mutate action and, on success, adopt the written record for the open
+ *  panel. Errors land in the modal when one is open, else on the panel. */
+async function executeMutate(ctx: CollectionActionContext, action: CollectionMutateAction, itemId: string, params: Record<string, unknown>): Promise<boolean> {
+  // Snapshot before the await (route changes can null `collection`); the
+  // re-entrancy guard keeps one write in flight at a time.
+  const current = ctx.collection.value;
+  if (!current || ctx.mutatePending.value) return false;
+  ctx.mutatePending.value = true;
+  const result = await ctx.cui.runItemAction(current.slug, itemId, action.id, params);
+  ctx.mutatePending.value = false;
+  if (!result.ok) {
+    if (ctx.mutateModal.value) ctx.mutateError.value = result.error;
+    else ctx.actionError.value = result.error;
+    return false;
+  }
+  if (result.data.written && ctx.viewing.value && rowIdOf(current.schema.primaryKey, ctx.viewing.value) === itemId) {
+    ctx.viewing.value = result.data.item;
+  }
+  return true;
+}
+
+export async function submitMutateParams(ctx: CollectionActionContext, params: Record<string, unknown>): Promise<void> {
+  const open = ctx.mutateModal.value;
+  if (!open) return;
+  ctx.mutateError.value = null;
+  if (await executeMutate(ctx, open.action, open.itemId, params)) ctx.mutateModal.value = null;
+}
+
+/** Mutate kind: open the params mini-form when the action declares one, else
+ *  apply the declarative write immediately. */
+async function runMutateAction(ctx: CollectionActionContext, action: CollectionMutateAction, itemId: string): Promise<void> {
+  ctx.actionError.value = null;
+  if (action.params && Object.keys(action.params).length > 0) {
+    ctx.mutateError.value = null;
+    ctx.mutateModal.value = { action, itemId };
+    return;
+  }
+  await executeMutate(ctx, action, itemId, {});
+}
+
+/** Run a schema-declared action on the open record. `kind: "mutate"` never leaves
+ *  the host; `kind: "chat"` starts a new chat; `kind: "agent"` is dispatched
+ *  server-side as a hidden worker. */
+export async function runAction(ctx: CollectionActionContext, action: CollectionAction): Promise<void> {
+  const current = ctx.collection.value;
+  if (!current || !ctx.viewing.value) return;
+  const itemId = rowIdOf(current.schema.primaryKey, ctx.viewing.value);
+  if (!itemId || isActionRunning(ctx.guard, action.id, itemId)) return;
+  if (action.kind === "mutate") {
+    await runMutateAction(ctx, action, itemId);
+    return;
+  }
+  // Optimistic key BEFORE the POST — see runCollectionAction.
+  const runKey = action.kind === "agent" ? agentActionRunKey(action.id, itemId) : null;
+  if (runKey) ctx.guard.mutate((next) => next.add(runKey));
+  ctx.actionPending.value = true;
+  ctx.actionError.value = null;
+  const result = await ctx.cui.runItemAction(current.slug, itemId, action.id);
+  ctx.actionPending.value = false;
+  if (!result.ok) {
+    if (runKey && result.status !== 409) ctx.guard.mutate((next) => next.delete(runKey));
+    ctx.actionError.value = result.error;
+    return;
+  }
+  if (result.data.dispatched) return; // key already set; the completion ping's refetch reconciles
+  if (result.data.written) return; // mutate never reaches this branch; narrows the union
+  dispatchPrompt(ctx, result.data.prompt, result.data.role);
+}

--- a/packages/plugins/collection-plugin/src/vue/composables/runningActionsGuard.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/runningActionsGuard.ts
@@ -1,0 +1,52 @@
+// In-flight `kind: "agent"` action run keys, with the generation guard that
+// keeps a slow detail response from clobbering a newer local dispatch.
+//
+// The server's detail response is the source of truth for which agent actions
+// are running, but a dispatch adds its key OPTIMISTICALLY before the POST. A
+// detail fetch that started BEFORE that optimistic add would, on resolving,
+// carry a snapshot without the key and strand the button enabled while the
+// worker runs (Codex + CodeRabbit on PR #2104). The generation counter, bumped
+// on every local mutation, lets `beginReconcile` drop such a stale snapshot;
+// the worker's completion ping triggers a fresh refetch that reconciles soon
+// after. Extracted from CollectionView so the stale-drop rule is unit-testable.
+
+import { ref, type Ref } from "vue";
+
+export interface RunningActionsGuard {
+  /** Reactive set of in-flight agent-action run keys (drives button spinners). */
+  runningActions: Ref<Set<string>>;
+  /** Whether a run key is currently in flight. */
+  isRunning: (runKey: string) => boolean;
+  /** Apply a local mutation to a fresh copy of the set AND bump the generation,
+   *  so any server snapshot taken before this mutation is dropped by a
+   *  `beginReconcile` applier that is still pending. */
+  mutate: (apply: (next: Set<string>) => void) => void;
+  /** Snapshot the current generation before a detail fetch; the returned applier
+   *  adopts the server's keys ONLY if no local `mutate` happened while the fetch
+   *  was in flight (a stale snapshot is dropped). */
+  beginReconcile: () => (serverKeys: string[] | undefined) => void;
+}
+
+export function createRunningActionsGuard(): RunningActionsGuard {
+  const runningActions = ref<Set<string>>(new Set());
+  let generation = 0;
+
+  const isRunning = (runKey: string): boolean => runningActions.value.has(runKey);
+
+  const mutate = (apply: (next: Set<string>) => void): void => {
+    generation += 1;
+    const next = new Set(runningActions.value);
+    apply(next);
+    runningActions.value = next;
+  };
+
+  const beginReconcile = (): ((serverKeys: string[] | undefined) => void) => {
+    const generationAtFetch = generation;
+    return (serverKeys: string[] | undefined): void => {
+      if (generation !== generationAtFetch) return;
+      runningActions.value = new Set(serverKeys ?? []);
+    };
+  };
+
+  return { runningActions, isRunning, mutate, beginReconcile };
+}

--- a/packages/plugins/collection-plugin/src/vue/composables/useCollectionActions.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useCollectionActions.ts
@@ -1,0 +1,116 @@
+// Schema-declared actions on a collection: the collection-level header buttons,
+// the open record's action buttons, and the `kind: "mutate"` mini-form. Owns the
+// `runningActions` generation guard (see `runningActionsGuard.ts`) that keeps a
+// slow detail response from clobbering a newer optimistic dispatch key.
+//
+// A thin reactive shell: the run logic lives in `collectionActionRunners.ts`
+// (module-level functions over an explicit context), the guard's stale-drop rule
+// in `runningActionsGuard.ts`. The two load-path call sites (`loadCollection` /
+// `refreshItemsInPlace`) stay in the component and drive the guard through the
+// re-exposed `clearRunningActions` + `beginRunningActionsReconcile`.
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import type { CollectionAction, CollectionMutateAction, CollectionDetail, CollectionItem, CollectionRecordIssue } from "@mulmoclaude/core/collection";
+import { createRunningActionsGuard } from "./runningActionsGuard";
+import {
+  isActionRunning as isActionRunningOf,
+  runCollectionAction as runCollectionActionOf,
+  runAction as runActionOf,
+  submitMutateParams as submitMutateParamsOf,
+  repairCollection as repairCollectionOf,
+  visibleActionsOf,
+  runningActionIdsOf,
+  type CollectionActionContext,
+} from "./collectionActionRunners";
+import type { CollectionUi } from "../uiContext";
+import type { useCollectionI18n } from "../lang";
+
+type Translate = ReturnType<typeof useCollectionI18n>["t"];
+
+interface UseCollectionActionsParams {
+  collection: Ref<CollectionDetail | null>;
+  viewing: Ref<CollectionItem | null>;
+  /** Server-detected record data problems, reported back to the LLM by the
+   *  Repair button. Owned by the component's load path. */
+  dataIssues: Readonly<Ref<CollectionRecordIssue[]>>;
+  /** Table-level error banner, shared with the inline-edit / refresh paths;
+   *  a failed collection action surfaces here. */
+  inlineError: Ref<string | null>;
+  cui: CollectionUi;
+  /** The chat card's channel into the current session (embedded mode only). */
+  props: { sendTextMessage?: (text?: string) => void };
+  t: Translate;
+}
+
+export interface UseCollectionActions {
+  actionPending: Ref<boolean>;
+  actionError: Ref<string | null>;
+  collectionActionPending: Ref<boolean>;
+  mutateModal: Ref<{ action: CollectionMutateAction; itemId: string } | null>;
+  mutatePending: Ref<boolean>;
+  mutateError: Ref<string | null>;
+  collectionActions: ComputedRef<CollectionAction[]>;
+  visibleActions: ComputedRef<CollectionAction[]>;
+  viewingRunningActionIds: ComputedRef<string[]>;
+  isActionRunning: (actionId: string, itemId?: string) => boolean;
+  runCollectionAction: (action: CollectionAction) => Promise<void>;
+  runAction: (action: CollectionAction) => Promise<void>;
+  submitMutateParams: (params: Record<string, unknown>) => Promise<void>;
+  repairCollection: () => void;
+  /** Clear the running-action spinners on a collection switch (bumps the guard
+   *  generation, so an in-flight reconcile is dropped). */
+  clearRunningActions: () => void;
+  /** Snapshot the guard generation before a detail fetch; the returned applier
+   *  adopts the server's keys only if no local mutation raced the fetch. */
+  beginRunningActionsReconcile: () => (serverKeys: string[] | undefined) => void;
+}
+
+export function useCollectionActions({ collection, viewing, dataIssues, inlineError, cui, props, t }: UseCollectionActionsParams): UseCollectionActions {
+  const actionPending = ref(false);
+  const actionError = ref<string | null>(null);
+  const collectionActionPending = ref(false);
+  const mutateModal = ref<{ action: CollectionMutateAction; itemId: string } | null>(null);
+  const mutatePending = ref(false);
+  const mutateError = ref<string | null>(null);
+  const guard = createRunningActionsGuard();
+
+  const ctx: CollectionActionContext = {
+    collection,
+    viewing,
+    dataIssues,
+    inlineError,
+    actionPending,
+    actionError,
+    collectionActionPending,
+    mutateModal,
+    mutatePending,
+    mutateError,
+    guard,
+    cui,
+    props,
+    t,
+  };
+
+  const collectionActions = computed<CollectionAction[]>(() => collection.value?.schema.collectionActions ?? []);
+  const visibleActions = computed<CollectionAction[]>(() => visibleActionsOf(collection.value, viewing.value));
+  const viewingRunningActionIds = computed<string[]>(() => runningActionIdsOf(collection.value, viewing.value, guard));
+
+  return {
+    actionPending,
+    actionError,
+    collectionActionPending,
+    mutateModal,
+    mutatePending,
+    mutateError,
+    collectionActions,
+    visibleActions,
+    viewingRunningActionIds,
+    isActionRunning: (actionId, itemId) => isActionRunningOf(guard, actionId, itemId),
+    runCollectionAction: (action) => runCollectionActionOf(ctx, action),
+    runAction: (action) => runActionOf(ctx, action),
+    submitMutateParams: (params) => submitMutateParamsOf(ctx, params),
+    repairCollection: () => repairCollectionOf(ctx),
+    clearRunningActions: () => guard.mutate((next) => next.clear()),
+    beginRunningActionsReconcile: () => guard.beginReconcile(),
+  };
+}

--- a/packages/plugins/collection-plugin/src/vue/composables/useCollectionActions.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useCollectionActions.ts
@@ -21,6 +21,7 @@ import {
   visibleActionsOf,
   runningActionIdsOf,
   type CollectionActionContext,
+  type CollectionActionState,
 } from "./collectionActionRunners";
 import type { CollectionUi } from "../uiContext";
 import type { useCollectionI18n } from "../lang";
@@ -42,13 +43,11 @@ interface UseCollectionActionsParams {
   t: Translate;
 }
 
-export interface UseCollectionActions {
-  actionPending: Ref<boolean>;
-  actionError: Ref<string | null>;
-  collectionActionPending: Ref<boolean>;
-  mutateModal: Ref<{ action: CollectionMutateAction; itemId: string } | null>;
-  mutatePending: Ref<boolean>;
-  mutateError: Ref<string | null>;
+export interface UseCollectionActions extends CollectionActionState {
+  /** The in-flight agent-action run keys — passed to CollectionHeader (and the
+   *  record panel) so they can render the matching buttons with a spinner. The
+   *  same reactive Set the generation guard mutates. */
+  runningActions: Ref<Set<string>>;
   collectionActions: ComputedRef<CollectionAction[]>;
   visibleActions: ComputedRef<CollectionAction[]>;
   viewingRunningActionIds: ComputedRef<string[]>;
@@ -96,6 +95,7 @@ export function useCollectionActions({ collection, viewing, dataIssues, inlineEr
   const viewingRunningActionIds = computed<string[]>(() => runningActionIdsOf(collection.value, viewing.value, guard));
 
   return {
+    runningActions: guard.runningActions,
     actionPending,
     actionError,
     collectionActionPending,

--- a/packages/plugins/collection-plugin/src/vue/composables/useCollectionChat.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useCollectionChat.ts
@@ -1,0 +1,92 @@
+// The collection's chat entry points: the header "chat about this collection"
+// modal and the open record's "chat about this record" box. Both build a chat
+// seed from the current view — a skill-backed collection seeds its `/<slug>`
+// command, a data-only feed points the agent at its schema + records — and
+// dispatch it into the current session (embedded chat card) or a new General
+// chat (standalone page).
+//
+// Extracted from CollectionView as a reactive shell; the skill-seed shape lives
+// in core (`skillCommandSeed`).
+
+import { ref, type Ref } from "vue";
+import { rowIdOf, skillCommandSeed, type CollectionDetail, type CollectionItem } from "@mulmoclaude/core/collection";
+import type { CollectionUi } from "../uiContext";
+import type { useCollectionI18n } from "../lang";
+
+type Translate = ReturnType<typeof useCollectionI18n>["t"];
+
+interface UseCollectionChatParams {
+  collection: Ref<CollectionDetail | null>;
+  viewing: Ref<CollectionItem | null>;
+  cui: CollectionUi;
+  /** The chat card's channel into the current session (embedded mode only). */
+  props: { sendTextMessage?: (text?: string) => void };
+  t: Translate;
+}
+
+export interface UseCollectionChat {
+  chatOpen: Ref<boolean>;
+  openChat: () => void;
+  closeChat: () => void;
+  submitChat: (raw: string) => void;
+  onItemChat: (message: string) => void;
+}
+
+export function useCollectionChat({ collection, viewing, cui, props, t }: UseCollectionChatParams): UseCollectionChat {
+  const chatOpen = ref(false);
+
+  /** Open the chat modal. The modal owns its draft + focus: it remounts on every
+   *  open (parent `v-if`), so it starts blank and self-focuses. */
+  function openChat(): void {
+    chatOpen.value = true;
+  }
+
+  function closeChat(): void {
+    chatOpen.value = false;
+  }
+
+  /** Build the chat seed text for the current view. A collection IS a skill, so
+   *  its slug doubles as a slash command (`/<slug> <message>`). A feed is
+   *  data-only — no skill — so point the agent at the feed's schema + records
+   *  instead. Checked via `source` directly (not the `isFeed` computed) to keep
+   *  this self-contained. */
+  function buildChatSeed(slug: string, message: string, itemId?: string): string {
+    const current = collection.value;
+    if (current?.source !== "feed") return skillCommandSeed(slug, message, itemId);
+    const dataPath = current.schema.dataPath ?? `data/feeds/${slug}`;
+    const scoped = itemId ? `(for record \`${itemId}\`) ${message}` : message;
+    return t("collectionsView.feedChatSeed", { slug, dataPath, message: scoped });
+  }
+
+  /** Dispatch a seed: into the current session when embedded, else a new chat. */
+  function dispatchSeed(text: string): void {
+    if (props.sendTextMessage) {
+      props.sendTextMessage(text);
+      return;
+    }
+    cui.startChat(text, cui.generalRoleId);
+  }
+
+  /** Start a chat seeded from the current view. `raw` is the modal's untrimmed
+   *  textarea text. */
+  function submitChat(raw: string): void {
+    if (!collection.value) return;
+    const message = raw.trim();
+    if (!message) return;
+    closeChat();
+    dispatchSeed(buildChatSeed(collection.value.slug, message));
+  }
+
+  /** The open record's chat box: start a chat scoped to that one record. Seeds
+   *  the collection's skill command with an `id=<itemId>` selector so the agent
+   *  acts on this record. */
+  function onItemChat(message: string): void {
+    if (!collection.value || !viewing.value) return;
+    const text = message.trim();
+    if (!text) return;
+    const itemId = rowIdOf(collection.value.schema.primaryKey, viewing.value);
+    dispatchSeed(buildChatSeed(collection.value.slug, text, itemId || undefined));
+  }
+
+  return { chatOpen, openChat, closeChat, submitChat, onItemChat };
+}

--- a/packages/plugins/collection-plugin/src/vue/composables/useFlagFilters.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useFlagFilters.ts
@@ -1,0 +1,124 @@
+// Flag-filter chips (table view only): one tri-state chip per predicate-shaped
+// field (all → hide → only), ANDed with the text search. Schemas with only the
+// legacy completion pair (no flag) get a synthesized "done" chip. Chip state is a
+// SHARED per-collection localStorage preference (like the table sort) — read here
+// and reset on collection switch; the write lives in the parent's persist watch.
+//
+// The reactive shell, extracted from CollectionView; the tri-state transition,
+// own-property read, and icon/colour mappings live in `../flagFilterDisplay`, and
+// the per-row predicate (`chipMatches` / `flagFieldValue`) in core.
+
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import { chipMatches, flagFieldValue, type FlagChip, type CollectionDetail, type CollectionItem } from "@mulmoclaude/core/collection";
+import { readCollectionFlagFilters, type FlagFilterMode, type FlagFilterState } from "../collectionViewMode";
+import {
+  buildFlagChips,
+  cycleFlagFilterState,
+  flagChipClassForMode,
+  flagChipIconClassForMode,
+  flagChipIconForMode,
+  flagFilterModeOf,
+} from "../flagFilterDisplay";
+import { useClickOutside } from "./useClickOutside";
+import type { useCollectionI18n } from "../lang";
+
+type Translate = ReturnType<typeof useCollectionI18n>["t"];
+
+interface UseFlagFiltersParams {
+  collection: Ref<CollectionDetail | null>;
+  /** The text-search-filtered rows; the chips narrow these further (AND). */
+  filteredItems: Readonly<Ref<CollectionItem[]>>;
+  activeSlug: Readonly<Ref<string | undefined>>;
+  /** Enriches a record so a flag over derived/rollup inputs reads correctly. */
+  deriveRecord: (item: CollectionItem) => CollectionItem;
+  t: Translate;
+}
+
+export interface UseFlagFilters {
+  flagFilters: Ref<FlagFilterState>;
+  flagChips: ComputedRef<FlagChip[]>;
+  tableFilteredItems: ComputedRef<CollectionItem[]>;
+  activeFlagFilterCount: ComputedRef<number>;
+  filterMenuOpen: Ref<boolean>;
+  filterMenuRef: Ref<HTMLElement | null>;
+  /** A flag FIELD's computed boolean for one row (list cells + sort). */
+  flagValueOf: (key: string, item: CollectionItem) => boolean;
+  flagFilterMode: (key: string) => FlagFilterMode | undefined;
+  cycleFlagFilter: (key: string) => void;
+  flagChipIcon: (key: string) => string;
+  flagChipIconClass: (key: string) => string;
+  flagChipClass: (key: string) => string;
+  flagChipTitle: (chip: FlagChip) => string;
+  /** Restore the given collection's stored (shared) chip states — the
+   *  switch-collection reset; chip state belongs to a schema, never carried across. */
+  resetForSlug: (slug: string | undefined) => void;
+}
+
+function storedFlagFiltersFor(slug: string | undefined): FlagFilterState {
+  return slug ? readCollectionFlagFilters(slug) : {};
+}
+
+export function useFlagFilters({ collection, filteredItems, activeSlug, deriveRecord, t }: UseFlagFiltersParams): UseFlagFilters {
+  const flagFilters = ref<FlagFilterState>(storedFlagFiltersFor(activeSlug.value));
+  const { open: filterMenuOpen, menuRef: filterMenuRef } = useClickOutside();
+
+  const flagChips = computed<FlagChip[]>(() => {
+    const schema = collection.value?.schema;
+    return schema ? buildFlagChips(schema, t("collectionsView.flagDoneChip")) : [];
+  });
+
+  const flagFilterMode = (key: string): FlagFilterMode | undefined => flagFilterModeOf(flagFilters.value, key);
+
+  const flagValueOf = (key: string, item: CollectionItem): boolean => flagFieldValue(deriveRecord(item), key);
+
+  /** `filteredItems` further narrowed by every ACTIVE chip (AND). Consumed only
+   *  by the table (sortedItems / count summary / empty state). */
+  const tableFilteredItems = computed<CollectionItem[]>(() => {
+    const schema = collection.value?.schema;
+    const active = flagChips.value.filter((chip) => flagFilterMode(chip.key) !== undefined);
+    if (!schema || active.length === 0) return filteredItems.value;
+    return filteredItems.value.filter((item) =>
+      active.every((chip) => chipMatches(chip, schema, item, deriveRecord) === (flagFilterMode(chip.key) === "only")),
+    );
+  });
+
+  /** Cycle a chip all → hide → only → all. */
+  function cycleFlagFilter(key: string): void {
+    flagFilters.value = cycleFlagFilterState(flagFilters.value, key);
+  }
+
+  const flagChipIcon = (key: string): string => flagChipIconForMode(flagFilterMode(key));
+  const flagChipIconClass = (key: string): string => flagChipIconClassForMode(flagFilterMode(key));
+  const flagChipClass = (key: string): string => flagChipClassForMode(flagFilterMode(key));
+
+  /** How many chips currently filter (badge on the menu trigger). */
+  const activeFlagFilterCount = computed<number>(() => flagChips.value.filter((chip) => flagFilterMode(chip.key) !== undefined).length);
+
+  function flagChipTitle(chip: FlagChip): string {
+    const mode = flagFilterMode(chip.key);
+    if (mode === "hide") return t("collectionsView.flagFilterHide", { label: chip.label });
+    if (mode === "only") return t("collectionsView.flagFilterOnly", { label: chip.label });
+    return t("collectionsView.flagFilterAll", { label: chip.label });
+  }
+
+  function resetForSlug(slug: string | undefined): void {
+    flagFilters.value = storedFlagFiltersFor(slug);
+  }
+
+  return {
+    flagFilters,
+    flagChips,
+    tableFilteredItems,
+    activeFlagFilterCount,
+    filterMenuOpen,
+    filterMenuRef,
+    flagValueOf,
+    flagFilterMode,
+    cycleFlagFilter,
+    flagChipIcon,
+    flagChipIconClass,
+    flagChipClass,
+    flagChipTitle,
+    resetForSlug,
+  };
+}

--- a/packages/plugins/collection-plugin/src/vue/flagFilterDisplay.ts
+++ b/packages/plugins/collection-plugin/src/vue/flagFilterDisplay.ts
@@ -1,0 +1,99 @@
+// Pure decision + presentation logic for the list-table flag-filter chips:
+// the tri-state transition (all → hide → only → all), the own-property mode
+// read, the state rebuild on a cycle, and the icon / colour mappings. Split out
+// of the component (mirroring `tableSortDisplay.ts`) so the state machine and
+// the prototype-shadow guard are unit-testable and the composable stays a thin
+// reactive shell.
+
+import { completionCoveredByFieldChip, type FlagChip } from "@mulmoclaude/core/collection";
+import type { FlagFilterMode, FlagFilterState } from "./collectionViewMode";
+
+/** The minimal schema slice `buildFlagChips` reads — the full `CollectionSchema`
+ *  satisfies it structurally, and it stays small enough to build in a test. */
+export interface FlagChipSchemaView {
+  fields: Record<string, { type: string; label?: string; field?: string; onValue?: string }>;
+  completionField?: string;
+  completionDoneValues?: readonly string[];
+}
+
+/** Chip key (state/testid/localStorage) for the synthesized legacy-completion
+ *  chip. Field names are unrestricted, so a schema COULD declare a field with
+ *  this exact name — `buildFlagChips` skips synthesizing in that case, and the
+ *  predicate dispatch keys off the structural `synthetic` marker, never this
+ *  string. */
+const COMPLETION_CHIP_KEY = "__completion";
+
+/** The field types that earn a filter-menu entry: declared predicates (`flag`)
+ *  plus the fields that ARE a predicate already — a stored `boolean` and a
+ *  `toggle`'s projected on/off state. Enums stay out (kanban slices by enum). */
+const CHIP_FIELD_TYPES = new Set(["flag", "boolean", "toggle"]);
+
+/** The filter chips for a schema: one per predicate-shaped field, plus a
+ *  synthesized "done" chip for a legacy completion pair (no flag field). The
+ *  done chip's label is passed in already-translated so this stays i18n-free and
+ *  testable. */
+export function buildFlagChips(schema: FlagChipSchemaView, doneChipLabel: string): FlagChip[] {
+  const chips: FlagChip[] = Object.entries(schema.fields)
+    .filter(([, field]) => CHIP_FIELD_TYPES.has(field.type))
+    .map(([key, field]) => ({ key, label: field.label ?? key }));
+  // A flag-form completion is already covered by that flag's own chip, and a pair
+  // a boolean/toggle chip expresses exactly is covered by THAT chip. Skipped when
+  // a field is named `__completion`, so the chip key can never collide.
+  if (
+    schema.completionField &&
+    schema.completionDoneValues &&
+    schema.fields[schema.completionField]?.type !== "flag" &&
+    !completionCoveredByFieldChip(schema) &&
+    schema.fields[COMPLETION_CHIP_KEY] === undefined
+  ) {
+    chips.push({ key: COMPLETION_CHIP_KEY, label: doneChipLabel, synthetic: true });
+  }
+  return chips;
+}
+
+/** The next mode a chip cycles to: all (undefined) → hide → only → all. */
+export function nextFlagFilterMode(current: FlagFilterMode | undefined): FlagFilterMode | undefined {
+  if (current === undefined) return "hide";
+  if (current === "hide") return "only";
+  return undefined;
+}
+
+/** Own-property read of a chip's active mode. Field names may shadow
+ *  `Object.prototype` members (`toString`, `valueOf`, …) — a plain
+ *  `filters[key]` on such a key reads the inherited function, which renders as
+ *  an "active" chip that can never cycle (Codex review on PR #2176). Every
+ *  chip-state read goes through here. */
+export function flagFilterModeOf(filters: FlagFilterState, key: string): FlagFilterMode | undefined {
+  return Object.hasOwn(filters, key) ? filters[key] : undefined;
+}
+
+/** The filter state after cycling one chip's mode. Rebuilds without the key
+ *  (avoiding a dynamic `delete`) then re-adds it only when the next mode is
+ *  active, so clearing a chip leaves no stale key behind. */
+export function cycleFlagFilterState(filters: FlagFilterState, key: string): FlagFilterState {
+  const next = nextFlagFilterMode(flagFilterModeOf(filters, key));
+  const rest = Object.fromEntries(Object.entries(filters).filter(([entry]) => entry !== key));
+  return next ? { ...rest, [key]: next } : rest;
+}
+
+// Checkbox metaphor for the tri-state: checked = only the ON rows, unchecked =
+// only the OFF rows, faint unchecked = not filtering. The glyph alone can't show
+// the third state (Material Icons has no dotted box), so the icon COLOUR greys
+// it out instead.
+export function flagChipIconForMode(mode: FlagFilterMode | undefined): string {
+  return mode === "only" ? "check_box" : "check_box_outline_blank";
+}
+
+export function flagChipIconClassForMode(mode: FlagFilterMode | undefined): string {
+  if (mode === "hide") return "text-slate-600";
+  if (mode === "only") return "text-indigo-600";
+  return "text-slate-300";
+}
+
+// Menu-entry state tints: slate for "hide" (rows removed), indigo for "only"
+// (rows isolated), neutral when inactive.
+export function flagChipClassForMode(mode: FlagFilterMode | undefined): string {
+  if (mode === "hide") return "bg-slate-100 text-slate-700";
+  if (mode === "only") return "bg-indigo-50 text-indigo-700";
+  return "text-slate-500";
+}

--- a/plans/refactor-2528-collectionview-composables.md
+++ b/plans/refactor-2528-collectionview-composables.md
@@ -1,0 +1,62 @@
+# refactor(#2528): CollectionView.vue script → composables (slice 1)
+
+Issue #2528 (split from #2298) covers the remaining `CollectionView.vue` extraction: the
+template → child-component splits (`CollectionTable`/`CollectionCell`, `CollectionToolbar`,
+`CollectionHeader`) **and** the heavier stateful composables. This PR does the **script →
+composables** half, and only a coherent, individually-verifiable subset of it — one PR, the
+rest deferred with reasons below.
+
+## Why the script half is the safe half
+
+Composables are **script-only**. The template + every `data-testid` + the rendered DOM stay
+**byte-identical**: `<script setup>` logic moves into `useXxx.ts` files and the same names are
+destructured back into top-level scope, so the template's bindings are unchanged. The extraction
+is verified by an **empty template diff** (`git diff` restricted to lines 1–856) plus the
+collection unit + mock-e2e suites.
+
+`CollectionView.vue` has **no `<style scoped>`** (verified), so there is no CSS surface to move.
+
+## This PR extracts (3 composables + 2 pure-logic units)
+
+- **`useCollectionActions`** — the agent/mutate/collection action cluster, owning the
+  `runningActions` **generation guard**. The guard's stale-drop semantics (a detail response that
+  started before a local mutation must not clobber the optimistic key — Codex/CodeRabbit on #2104)
+  are preserved exactly and extracted into a standalone, unit-tested factory
+  `runningActionsGuard.ts` (`createRunningActionsGuard`). The composable re-exposes just
+  `clearRunningActions()` + `beginRunningActionsReconcile()` for the two load-path call sites
+  (`loadCollection` / `refreshItemsInPlace`) that stay in the component.
+- **`useFlagFilters`** — the tri-state flag-filter chips (all → hide → only), their per-collection
+  localStorage state, and the filter-menu click-outside. The pure decision logic — the tri-state
+  transition, the **own-property** mode read (a field named `toString` must not read the inherited
+  function — Codex #2176), the state-rebuild-on-cycle, and the icon/class mappings — moves into
+  `flagFilterDisplay.ts` (mirroring the existing `tableSortDisplay.ts`) and is unit-tested.
+- **`useCollectionChat`** — the chat modal open/close + the skill/feed chat-seed builder
+  (`submitChat` / `onItemChat`). The seed's skill-vs-feed decision already lives in core
+  (`skillCommandSeed`), so no new pure file is warranted here.
+
+## Deferred (with reasons)
+
+- **`useViewMode`** (view mode + calendar/kanban axis fields + custom views) — the largest cluster
+  and the most entangled with the switch-collection reset watch (`view`/`anchorOverride`/
+  `kanbanOverride`) and the persist watch (`activeView`/`calendarAnchorField`/`kanbanGroupField`).
+  Worth its own focused PR.
+- **`useLiveCollectionRefresh`** (debounce + edit-in-progress defer) — self-contained but timer-
+  based; deserves a dedicated PR with fake-timer tests for the debounce-collapse + defer-past-edit
+  rules.
+- **`useRecordPanelState`** (viewing/editing/openDay + open/edit/save/delete flows) — the biggest
+  and most load-path-coupled cluster (`loadCollection`, `emit("select")`, deep-link sync). Highest
+  review cost; last.
+- All **template → child-component** splits from #2528 (`CollectionTable`/`CollectionCell`,
+  `CollectionToolbar`, `CollectionHeader`) — each carries a DOM byte-equivalence trap and belongs
+  in its own PR.
+
+## Gates
+
+`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`; the collection unit tests
+(`test/utils/collections/*`, `test/plugins/collection/*`, `test/plugins/test_applicableViewModes.ts`)
+including the two new pure-logic tests, **red-verified**; and the collection mock e2e
+(`e2e/tests/collection-*.spec.ts`) on a **private port** with `reuseExistingServer: false` **after a
+real plugin `dist` rebuild** — with a sensitivity check that breaking the flag-filter wiring turns
+`collection-flag-filter.spec.ts` red.
+
+No version bumps (deferred to the next publish, per repo convention).

--- a/test/plugins/collection/test_flagFilterDisplay.ts
+++ b/test/plugins/collection/test_flagFilterDisplay.ts
@@ -1,0 +1,156 @@
+// Unit tests for the pure flag-filter decision + presentation logic
+// (packages/plugins/collection-plugin/src/vue/flagFilterDisplay.ts) — the
+// tri-state transition, the own-property mode read (guarding against a field
+// named after an Object.prototype member — Codex #2176), the state rebuild on a
+// cycle, and the icon / colour mappings. Pinned here so the composable stays a
+// thin reactive shell.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildFlagChips,
+  nextFlagFilterMode,
+  flagFilterModeOf,
+  cycleFlagFilterState,
+  flagChipIconForMode,
+  flagChipIconClassForMode,
+  flagChipClassForMode,
+  type FlagChipSchemaView,
+} from "../../../packages/plugins/collection-plugin/src/vue/flagFilterDisplay";
+import type { FlagFilterState } from "../../../packages/plugins/collection-plugin/src/vue/collectionViewMode";
+
+describe("nextFlagFilterMode", () => {
+  it("cycles all → hide → only → all", () => {
+    assert.equal(nextFlagFilterMode(undefined), "hide");
+    assert.equal(nextFlagFilterMode("hide"), "only");
+    assert.equal(nextFlagFilterMode("only"), undefined);
+  });
+});
+
+describe("flagFilterModeOf", () => {
+  it("reads an own property's mode", () => {
+    assert.equal(flagFilterModeOf({ done: "hide" }, "done"), "hide");
+    assert.equal(flagFilterModeOf({ done: "only" }, "done"), "only");
+  });
+
+  it("returns undefined for an absent key", () => {
+    assert.equal(flagFilterModeOf({}, "done"), undefined);
+  });
+
+  // Regression (Codex #2176): a field named after an Object.prototype member must
+  // read as ABSENT, not the inherited function — else the chip renders "active"
+  // and can never cycle.
+  it("does not read through the prototype chain for a shadowing key", () => {
+    assert.equal(flagFilterModeOf({}, "toString"), undefined);
+    assert.equal(flagFilterModeOf({}, "valueOf"), undefined);
+    assert.equal(flagFilterModeOf({}, "hasOwnProperty"), undefined);
+  });
+});
+
+describe("cycleFlagFilterState", () => {
+  it("adds, advances, then clears a chip's key across a full cycle", () => {
+    const empty: FlagFilterState = {};
+    const hidden = cycleFlagFilterState(empty, "done");
+    assert.deepEqual(hidden, { done: "hide" });
+    const only = cycleFlagFilterState(hidden, "done");
+    assert.deepEqual(only, { done: "only" });
+    const cleared = cycleFlagFilterState(only, "done");
+    assert.deepEqual(cleared, {}, "clearing removes the key entirely (no stale entry)");
+  });
+
+  it("does not disturb other chips' states", () => {
+    assert.deepEqual(cycleFlagFilterState({ a: "only", b: "hide" }, "a"), { b: "hide" });
+  });
+
+  it("cycles a prototype-shadowing key as an own property", () => {
+    const next = cycleFlagFilterState({}, "toString");
+    assert.deepEqual(next, { toString: "hide" });
+    assert.equal(flagFilterModeOf(next, "toString"), "hide");
+  });
+
+  it("returns a new object, leaving the input untouched", () => {
+    const input: FlagFilterState = { a: "hide" };
+    const out = cycleFlagFilterState(input, "a");
+    assert.notEqual(out, input);
+    assert.deepEqual(input, { a: "hide" });
+  });
+});
+
+describe("buildFlagChips", () => {
+  const DONE_LABEL = "Done";
+
+  it("emits one chip per predicate-shaped field (flag / boolean / toggle), labelled", () => {
+    const schema: FlagChipSchemaView = {
+      fields: {
+        id: { type: "string", label: "ID" },
+        status: { type: "enum", label: "Status" },
+        urgent: { type: "boolean", label: "Urgent" },
+        finished: { type: "toggle", label: "Finished", field: "status", onValue: "done" },
+        isOpen: { type: "flag", label: "Open" },
+      },
+    };
+    assert.deepEqual(buildFlagChips(schema, DONE_LABEL), [
+      { key: "urgent", label: "Urgent" },
+      { key: "finished", label: "Finished" },
+      { key: "isOpen", label: "Open" },
+    ]);
+  });
+
+  it("excludes non-predicate fields (string, enum) entirely", () => {
+    const schema: FlagChipSchemaView = { fields: { id: { type: "string" }, status: { type: "enum" } } };
+    assert.deepEqual(buildFlagChips(schema, DONE_LABEL), []);
+  });
+
+  it("falls back to the field key when a predicate field has no label", () => {
+    const schema: FlagChipSchemaView = { fields: { pinned: { type: "boolean" } } };
+    assert.deepEqual(buildFlagChips(schema, DONE_LABEL), [{ key: "pinned", label: "pinned" }]);
+  });
+
+  it("synthesizes a done chip for a legacy completion pair with no covering predicate", () => {
+    const schema: FlagChipSchemaView = {
+      fields: { status: { type: "enum", label: "Status" } },
+      completionField: "status",
+      completionDoneValues: ["done"],
+    };
+    assert.deepEqual(buildFlagChips(schema, DONE_LABEL), [{ key: "__completion", label: DONE_LABEL, synthetic: true }]);
+  });
+
+  it("does NOT synthesize a done chip when completionField names a flag (its own chip covers it)", () => {
+    const schema: FlagChipSchemaView = {
+      fields: { done: { type: "flag", label: "Done" } },
+      completionField: "done",
+    };
+    assert.deepEqual(buildFlagChips(schema, DONE_LABEL), [{ key: "done", label: "Done" }]);
+  });
+
+  it("does NOT synthesize when a real field is already named __completion (no key collision)", () => {
+    const schema: FlagChipSchemaView = {
+      fields: { __completion: { type: "boolean", label: "Complete" }, status: { type: "enum" } },
+      completionField: "status",
+      completionDoneValues: ["done"],
+    };
+    // The boolean __completion field produces its own chip; the synthesized one is skipped.
+    assert.deepEqual(buildFlagChips(schema, DONE_LABEL), [{ key: "__completion", label: "Complete" }]);
+  });
+});
+
+describe("flag chip icon / colour mappings", () => {
+  it("icon glyph is a filled box only for the only state", () => {
+    assert.equal(flagChipIconForMode("only"), "check_box");
+    assert.equal(flagChipIconForMode("hide"), "check_box_outline_blank");
+    assert.equal(flagChipIconForMode(undefined), "check_box_outline_blank");
+  });
+
+  it("icon colour distinguishes hide / only / inactive", () => {
+    assert.equal(flagChipIconClassForMode("hide"), "text-slate-600");
+    assert.equal(flagChipIconClassForMode("only"), "text-indigo-600");
+    assert.equal(flagChipIconClassForMode(undefined), "text-slate-300");
+  });
+
+  it("entry tint distinguishes hide / only / inactive", () => {
+    assert.equal(flagChipClassForMode("hide"), "bg-slate-100 text-slate-700");
+    assert.equal(flagChipClassForMode("only"), "bg-indigo-50 text-indigo-700");
+    assert.equal(flagChipClassForMode(undefined), "text-slate-500");
+  });
+});

--- a/test/plugins/collection/test_runningActionsGuard.ts
+++ b/test/plugins/collection/test_runningActionsGuard.ts
@@ -1,0 +1,78 @@
+// Unit tests for the running-actions generation guard
+// (packages/plugins/collection-plugin/src/vue/composables/runningActionsGuard.ts) —
+// the stale-drop rule that keeps a slow collection-detail response from clobbering
+// a newer optimistic dispatch key (Codex + CodeRabbit on PR #2104). Pinned here so
+// the composable can stay a thin reactive shell.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createRunningActionsGuard } from "../../../packages/plugins/collection-plugin/src/vue/composables/runningActionsGuard";
+
+describe("createRunningActionsGuard", () => {
+  it("reflects keys added / removed through mutate", () => {
+    const guard = createRunningActionsGuard();
+    assert.equal(guard.isRunning("a"), false);
+    guard.mutate((next) => next.add("a"));
+    assert.equal(guard.isRunning("a"), true);
+    guard.mutate((next) => next.delete("a"));
+    assert.equal(guard.isRunning("a"), false);
+  });
+
+  it("swaps in a fresh Set on mutate (never mutates the exposed one in place)", () => {
+    const guard = createRunningActionsGuard();
+    const before = guard.runningActions.value;
+    guard.mutate((next) => next.add("a"));
+    assert.notEqual(guard.runningActions.value, before, "ref holds a new Set");
+    assert.equal(before.has("a"), false, "the old Set is untouched");
+  });
+
+  it("adopts the server's keys when no local mutation raced the fetch", () => {
+    const guard = createRunningActionsGuard();
+    const reconcile = guard.beginReconcile();
+    reconcile(["x", "y"]);
+    assert.equal(guard.isRunning("x"), true);
+    assert.equal(guard.isRunning("y"), true);
+  });
+
+  it("treats an undefined server list as no running actions", () => {
+    const guard = createRunningActionsGuard();
+    guard.mutate((next) => next.add("stale"));
+    const reconcile = guard.beginReconcile();
+    reconcile(undefined);
+    assert.equal(guard.isRunning("stale"), false);
+    assert.equal(guard.runningActions.value.size, 0);
+  });
+
+  // The flagship rule: a reconcile whose generation snapshot predates a local
+  // mutation is DROPPED, so an optimistic key added mid-fetch survives.
+  it("drops a stale server snapshot when a local mutation happened after the fetch began", () => {
+    const guard = createRunningActionsGuard();
+    const reconcile = guard.beginReconcile(); // snapshot BEFORE the optimistic add
+    guard.mutate((next) => next.add("optimistic")); // dispatch races the in-flight fetch
+    reconcile([]); // server response predates the dispatch — must NOT clear the key
+    assert.equal(guard.isRunning("optimistic"), true, "optimistic key survives the stale reconcile");
+  });
+
+  it("applies a reconcile snapshotted AFTER the mutation (fresh, not stale)", () => {
+    const guard = createRunningActionsGuard();
+    guard.mutate((next) => next.add("optimistic"));
+    const reconcile = guard.beginReconcile(); // snapshot AFTER the add
+    reconcile(["server-key"]); // authoritative — replaces the optimistic set
+    assert.equal(guard.isRunning("optimistic"), false);
+    assert.equal(guard.isRunning("server-key"), true);
+  });
+
+  it("keeps concurrent reconciles independent — only the pre-mutation one is dropped", () => {
+    const guard = createRunningActionsGuard();
+    const stale = guard.beginReconcile();
+    guard.mutate((next) => next.add("k"));
+    const fresh = guard.beginReconcile();
+    stale(["from-stale"]); // dropped
+    assert.equal(guard.isRunning("k"), true);
+    assert.equal(guard.isRunning("from-stale"), false);
+    fresh(["from-fresh"]); // applied
+    assert.equal(guard.isRunning("from-fresh"), true);
+    assert.equal(guard.isRunning("k"), false);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts three heavier stateful clusters from `CollectionView.vue`'s `<script setup>` into composables. This is **script-only** — the template + all `data-testid`s + rendered DOM stay **byte-identical**; logic moves into `useXxx.ts` files and the same names are destructured back. First slice of the SCRIPT→COMPOSABLES half of #2528.

- **`useCollectionActions`** — the agent / mutate / collection action cluster. The `runningActions` **generation guard** is preserved exactly and extracted to `runningActionsGuard.ts` (`createRunningActionsGuard`), unit-tested + red-verified. The run logic lives in `collectionActionRunners.ts` (module-level functions over an explicit context) so every function stays under the 50-line budget; the composable re-exposes `clearRunningActions()` / `beginRunningActionsReconcile()` for the load path that stays in the component.
- **`useFlagFilters`** — the tri-state flag-filter chips + per-collection localStorage + the filter-menu click-outside. Pure decision logic (tri-state transition, own-property mode read, cycle rebuild, chip derivation, icon/colour maps) → `flagFilterDisplay.ts`, unit-tested + red-verified.
- **`useCollectionChat`** — the chat modal open/close + the skill/feed chat-seed builder.

`CollectionView.vue`: **2629 → 2274 lines**. Template diff **empty** (verified). `CollectionView` has no `<style scoped>`.

Deferred to follow-up PRs (recorded in `plans/refactor-2528-collectionview-composables.md`): `useViewMode`, `useLiveCollectionRefresh`, `useRecordPanelState`, and all template → child-component splits (`CollectionTable`/`CollectionCell`, `CollectionToolbar`, `CollectionHeader`).

## Items to Confirm / Review

1. **Generation-guard fidelity.** `runningActionsGuard.ts` reproduces the stale-drop rule (a detail response snapshotted *before* a local dispatch must not clobber the optimistic key — #2104). The old module-level `let runningActionsGen` becomes the guard's closed-over generation; the load path (`loadCollection` / `refreshItemsInPlace`) drives it via `clearRunningActions()` and `beginRunningActionsReconcile()` (snapshot-before-fetch → applier-after-fetch). Please sanity-check the snapshot-timing equivalence — it is covered by `test_runningActionsGuard.ts` (concurrent-reconcile + stale-drop cases).
2. **`String(item[pk] ?? "")` → `rowIdOf(pk, item)`** in the moved action / chat code. The `.ts` composables get type-aware `no-base-to-string` linting the `.vue <script>` did not; `rowIdOf` / `fieldText` is the codebase's canonical scalar-key stringify and is behavior-equivalent for scalar primary keys. Related: `executeMutate` now snapshots `collection.value` *before* its await (matching the existing `saveEditor` pattern) instead of re-reading it after — a micro-improvement in the switch-collection-mid-write race.
3. **Filter-menu click-outside.** `useFlagFilters` now owns the filter menu's `useClickOutside()` instance; `filterMenuRef` / `filterMenuOpen` bind to the exact same DOM. Verified via the collection mock e2e below, including a red sensitivity check.

## Verification

- `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` — all green.
- **Collection unit tests: 420 pass**, including 24 new tests in `test_runningActionsGuard.ts` + `test_flagFilterDisplay.ts`, each **red-verified**: inverting the guard's stale-drop, the own-property mode read, or the chip filter turns the covering test red; restore → green.
- **Template byte-identical**: a `diff` of lines 1–856 (`<template>…</template>`) between `origin/main` and this branch is empty.
- **Collection mock e2e** (all 17 `collection-*.spec.ts`, **69 tests**): green on a **private port (45983) with `reuseExistingServer:false`, after a real plugin `dist` rebuild**. Sensitivity check: breaking `cycleFlagFilter` to a no-op + rebuild turned 5/6 `collection-flag-filter.spec.ts` cases RED; restore + rebuild → green — proving the run exercises the rebuilt dist and the wiring is load-bearing.

## User Prompt

Advance issue #2528 — the SCRIPT→COMPOSABLES half — for `CollectionView.vue`. Extract the heavier stateful clusters into composables as a coherent, reviewable subset (2–4 composables) in one PR, deferring the rest with a note. Composition API, `ref` over `reactive`, relative imports, `emit` not function props, no `v-html`, `$t()` for text, functions under 20 lines, no `any`, no `as` casts. The template + all `data-testid`s + DOM must stay byte-identical (script-only moves; destructure the same names back — verify the template diff is empty). Extract any pure decision logic (tri-state filter transitions, the runningActions generation guard, localStorage/debounce rules) into its own file with red-verified unit tests. Respect dependency direction. Gate on `format`/`lint`/`typecheck`/`build`, the collection unit tests, and the collection mock e2e on a PRIVATE port (`reuseExistingServer:false`) after a rebuilt plugin `dist`. Extra caution — collection is a core production feature: prove the flag-filter menu's click-outside + wiring survive (sensitivity check: break the wiring → the spec goes red after rebuild → restore), or ship less with certainty.

## Notes

Follows the `useTableSort` / `useRelatedMenu` deps-object composable pattern established in #2298. No version bumps (deferred to the next publish, per repo convention). Does **not** close #2528 — more slices remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
