### PR TITLE
refactor(spreadsheet): fold the formatter thousand-separator wrapper (#2482)

### DIFF
--- a/plans/refactor-2482-formatter-addthousandseparators.md
+++ b/plans/refactor-2482-formatter-addthousandseparators.md
@@ -1,0 +1,42 @@
+# refactor(spreadsheet): fold the formatter thousand-separator wrapper (#2482)
+
+Follow-up to #2529, which folded the other four #2482 engine candidates
+(`serialFromParts`, `makePeriodicComponentHandler`, `resolveSheetData`,
+`locateSubstring`). #2529 recorded candidate 2 (formatter grouping) as "already
+done via `groupThousands` (#2510)" — but that only extracted the inner digit
+loop. The 3-line **wrapper** around it was still copied in two branches of
+`formatNumber`:
+
+```ts
+const parts = formatted.split(".");
+parts[0] = groupThousands(parts[0]);
+formatted = parts.join(".");
+```
+
+— once inside the `$`-with-comma branch and once in the plain-comma branch.
+`addThousandSeparators` is exactly the helper #2482 candidate 2 named.
+
+## Change
+
+- **formatter.ts** — add `addThousandSeparators(formatted)` (group the integer
+  part, leave the fraction alone) beside `groupThousands`. Both branches call
+  it; the surrounding `let formatted` reassignment chains become `const` (the
+  currency branch inlines its one-shot `hasComma`, the comma branch collapses to
+  one expression). Output is byte-identical:
+  - currency: `magnitude → (comma ? group : magnitude) → "$"+ → sign` unchanged.
+  - comma: `group(magnitude) → sign` unchanged.
+
+The engine is excluded from the duplication scan, so this clone never surfaced
+as an alert; the tests are the only safety net.
+
+## Tests
+
+`test_formatter.ts` gains an `addThousandSeparators` block (grouping, fraction
+preserved, short/empty pass-through). The existing currency / comma / plain
+`formatNumber` assertions pin the end-to-end output unchanged. Full engine suite
+green.
+
+## Not in this PR
+
+Candidates 1/3/4/5 and the intentionally-kept 見送り duplicates are already
+handled by #2529 (merged) — untouched here.

--- a/src/plugins/spreadsheet/engine/formatter.ts
+++ b/src/plugins/spreadsheet/engine/formatter.ts
@@ -91,6 +91,14 @@ export const groupThousands = (digits: string): string =>
     return needsSeparator ? `${grouped},${digit}` : `${grouped}${digit}`;
   }, "");
 
+/** Group the integer part of a formatted number ("1234567.89" → "1,234,567.89"),
+ *  leaving any fractional part after the decimal point untouched. */
+export const addThousandSeparators = (formatted: string): string => {
+  const parts = formatted.split(".");
+  parts[0] = groupThousands(parts[0]);
+  return parts.join(".");
+};
+
 /**
  * Format a number according to Excel format code
  *
@@ -117,17 +125,10 @@ export function formatNumber(value: number, format: string): string {
     // Handle currency formats
     if (format.includes("$")) {
       const decimals = (format.match(/\.0+/) || [""])[0].length - 1;
-      const hasComma = format.includes(",");
-
-      let formatted = Math.abs(value).toFixed(decimals >= 0 ? decimals : 0);
-      if (hasComma) {
-        const parts = formatted.split(".");
-        parts[0] = groupThousands(parts[0]);
-        formatted = parts.join(".");
-      }
-      formatted = "$" + formatted;
-      if (value < 0) formatted = "-" + formatted;
-      return formatted;
+      const magnitude = Math.abs(value).toFixed(decimals >= 0 ? decimals : 0);
+      const grouped = format.includes(",") ? addThousandSeparators(magnitude) : magnitude;
+      const withSymbol = "$" + grouped;
+      return value < 0 ? "-" + withSymbol : withSymbol;
     }
 
     // Handle percentage
@@ -139,12 +140,8 @@ export function formatNumber(value: number, format: string): string {
     // Handle comma separator
     if (format.includes(",")) {
       const decimals = (format.match(/\.0+/) || [""])[0].length - 1;
-      let formatted = Math.abs(value).toFixed(decimals >= 0 ? decimals : 0);
-      const parts = formatted.split(".");
-      parts[0] = groupThousands(parts[0]);
-      formatted = parts.join(".");
-      if (value < 0) formatted = "-" + formatted;
-      return formatted;
+      const grouped = addThousandSeparators(Math.abs(value).toFixed(decimals >= 0 ? decimals : 0));
+      return value < 0 ? "-" + grouped : grouped;
     }
 
     // Handle decimal places

--- a/test/plugins/spreadsheet/engine/test_formatter.ts
+++ b/test/plugins/spreadsheet/engine/test_formatter.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { formatNumber } from "../../../../src/plugins/spreadsheet/engine/formatter.ts";
+import { addThousandSeparators, formatNumber } from "../../../../src/plugins/spreadsheet/engine/formatter.ts";
 import { dateToSerial } from "../../../../src/plugins/spreadsheet/engine/date-utils.ts";
 
 const serialOf = (year: number, month: number, day: number, hour = 0, minute = 0, second = 0) =>
@@ -132,5 +132,26 @@ describe("formatNumber — plain numbers", () => {
 
   it("reads the decimal count from the leading .0 run of a mixed format", () => {
     assert.equal(formatNumber(0.5, "0.0#"), "0.5");
+  });
+});
+
+// The split/group/join wrapper the currency and plain-comma branches of
+// formatNumber both share: group the integer part, leave any fraction alone.
+describe("addThousandSeparators", () => {
+  it("groups the integer part in threes", () => {
+    assert.equal(addThousandSeparators("1000"), "1,000");
+    assert.equal(addThousandSeparators("1234567"), "1,234,567");
+  });
+
+  it("leaves the fractional part untouched", () => {
+    assert.equal(addThousandSeparators("1234567.89"), "1,234,567.89");
+    assert.equal(addThousandSeparators("12.5"), "12.5");
+    assert.equal(addThousandSeparators("0.50"), "0.50");
+  });
+
+  it("passes short and empty integer parts through unchanged", () => {
+    assert.equal(addThousandSeparators("100"), "100");
+    assert.equal(addThousandSeparators("999"), "999");
+    assert.equal(addThousandSeparators(""), "");
   });
 });


### PR DESCRIPTION
## Summary

Folds the **one remaining** `#2482` engine clone: the thousand-separator wrapper in `formatter.ts`.

`#2482` catalogued five fold candidates in the (jscpd-excluded) spreadsheet engine. While this task was in flight, **PR #2529 landed candidates 1, 3, 4, 5 and closed the issue**, so those are already on `main` and are NOT touched here:

| # | Candidate | Where |
|---|-----------|-------|
| 1 | `serialFromParts` (date-parser) | ✅ on main (#2529) |
| 2 | **`addThousandSeparators` (formatter)** | **this PR** |
| 3 | `makePeriodicComponentHandler` (financial) | ✅ on main (#2529) |
| 4 | `resolveSheetData` (calculator) | ✅ on main (#2529) |
| 5 | `locateSubstring` (text) | ✅ on main (#2529) |

#2529 recorded candidate 2 as *"already done via `groupThousands` (#2510)"*, but #2510 only extracted the inner digit loop. The 3-line split/group/join **wrapper** around it is still copied byte-for-byte in two branches of `formatNumber`:

```ts
const parts = formatted.split(".");
parts[0] = groupThousands(parts[0]);
formatted = parts.join(".");
```

— once in the `$`-with-comma branch, once in the plain-comma branch. This PR extracts `addThousandSeparators(formatted)` (the helper #2482 candidate 2 named) and routes both branches through it. Output is byte-identical; the surrounding `let formatted` chains collapse to `const`.

Nothing else is re-done — candidates 1/3/4/5 already merged via #2529, and the intentionally-kept 見送り duplicates stay untouched.

## Items to Confirm / Review

- **Behaviour is unchanged** — pure de-dup. Currency: `magnitude → (comma ? group : magnitude) → "$"+ → sign` is the same order as before; comma: `group(magnitude) → sign` is the same. The existing `formatNumber` currency/comma/plain assertions pin this end-to-end.
- **The engine is excluded from the duplication scan**, so this clone never surfaced as a Code Scanning alert and jscpd will not verify the fold — **the tests are the only safety net**. `test_formatter.ts` gains a direct `addThousandSeparators` block; I mutation-checked it (dropped the grouping call → 6 tests went red → restored).
- **Collision note for the reviewer:** this overlaps issue #2482, which #2529 already closed. If you consider the remaining wrapper not worth folding (i.e. `groupThousands` reuse was "enough"), this PR is safe to close — it changes no behaviour either way.
- Deliberately scoped to the wrapper only; `groupThousands` (and its own tests in `test_textFormat.ts`) are unchanged and still used by `textFormat.ts`.

## User Prompt

> https://github.com/receptron/mulmoclaude/security/code-scanning コードの重複、消せるものをissue化して消していきたい

> https://github.com/receptron/mulmoclaude/issues/2482 対応 or close　これだけみればよい。他は見ないで。

## 実装アプローチ

- **formatter.ts** — add `addThousandSeparators(formatted)` beside `groupThousands`: split on `.`, group the integer part with `groupThousands`, re-join so any fractional part is preserved. Both `formatNumber` branches call it:
  - currency branch: inline the one-shot `hasComma`, compute `grouped = includes(",") ? addThousandSeparators(magnitude) : magnitude`, prepend `$`, then the sign — no `let`.
  - comma branch: one expression `addThousandSeparators(|value|.toFixed(...))` + sign.
- **test_formatter.ts** — new `addThousandSeparators` describe: grouping in threes, fraction left untouched, short/empty integer pass-through. Existing suite pins `formatNumber` output.
- Ran `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn build`, `yarn test` — all green (engine suite 855 → 858).

Closes #2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spreadsheet number formatting by consistently adding thousand separators to integer values.
  - Preserved decimal portions exactly as entered, including currency values and numbers using comma separators.
  - Maintained existing formatting output for negative and short values.

- **Tests**
  - Added coverage for grouped integers, decimal preservation, short values, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->