### PR TITLE
fix(collection-plugin): remove unused activatePathLink import (main lint_test regression)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -548,7 +548,6 @@ import {
 import { collectionUi } from "../uiContext";
 import { useClickOutside } from "../composables/useClickOutside";
 import { useTableSort } from "../composables/useTableSort";
-import { activatePathLink } from "../refLink";
 import {
   dateOf,
   itemMatchesQuery,


### PR DESCRIPTION
## Summary

**Un-breaks `main`.** After two parallel #2528 slices merged, `lint_test` (ubuntu 22.x/24.x) and `yarn4_smoke` went red on main:

```
CollectionView.vue:551  'activatePathLink' is defined but never used.
```

### Root cause (semantic merge conflict — no textual conflict)

- PR #2533 (CollectionTable + CollectionCell) kept the `activatePathLink` import because its only remaining use in `CollectionView.vue` was the header's dataSource-route link (`@click="activatePathLink($event, dataSourceRoute …)"`).
- The parallel **CollectionHeader** extraction (#2528) moved that header — and thus the last `activatePathLink` call site — into `CollectionHeader.vue` (which imports and uses it there).
- Both branches were based on an older main and merged cleanly line-by-line, but the **combined** `CollectionView.vue` imports `activatePathLink` with no remaining use → lint error → `lint_test` + `yarn4_smoke` fail.

### Fix

Remove the now-unused `import { activatePathLink } from "../refLink";` from `CollectionView.vue`. One line. No behaviour change — the call site lives in `CollectionHeader.vue`, which keeps its own import.

## Verification (against current `origin/main`, fresh `yarn build:packages`)

- `eslint` on CollectionView / CollectionTable / CollectionCell / CollectionHeader → **0 errors**.
- `vue-tsc --noEmit` on `@mulmoclaude/collection-plugin` → **clean**.

## Items to Confirm / Review

- The removal is safe because `activatePathLink`'s only surviving caller is `CollectionHeader.vue` (verified: it imports it at line 205 and uses it at line 40). `CollectionView.vue` has no other reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Resolve eslint lint_test failures in the collection plugin by deleting the now-unused activatePathLink import from CollectionView.vue.