### PR TITLE
feat(mulmoscript): show beat numbers, hide Generate on beat-reference beats

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^1.0.0",
     "@mulmoclaude/markdown-plugin": "^1.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.0",
-    "@mulmoclaude/mulmoscript-plugin": "^1.0.0",
+    "@mulmoclaude/mulmoscript-plugin": "^1.1.0",
     "@mulmoclaude/spotify-plugin": "^1.0.0",
     "@mulmoclaude/x-plugin": "^0.1.2",
     "@receptron/task-scheduler": "^0.1.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -99,6 +99,15 @@
             @dragleave="onBeatDragLeave(index)"
             @drop="onBeatDrop($event, index)"
           >
+            <!-- Beat number badge (1-based). Sits above the drop-hint
+                 overlay and the inline video player so the index stays
+                 readable in every beat state. -->
+            <div
+              class="absolute top-1.5 left-1.5 z-10 px-1.5 py-0.5 rounded bg-black/55 text-white text-xs font-medium leading-none pointer-events-none"
+              :data-testid="`mulmo-script-beat-number-${index}`"
+            >
+              {{ index + 1 }}
+            </div>
             <!-- Inline player for the beat's generated video clip.
                  Replaces the thumbnail while open; the close button
                  returns to the still image. -->
@@ -183,7 +192,7 @@
                  text-only beats fall back to a prompt derived from
                  the narration text (mulmocast prompt.js). -->
             <button
-              v-if="!renderedImages[index] && renderState[index] !== 'rendering' && !movieGenerating"
+              v-if="!renderedImages[index] && renderState[index] !== 'rendering' && !movieGenerating && !isBeatImageReference(effectiveBeat(index))"
               class="absolute top-1.5 right-1.5 flex items-center gap-1 px-2 py-0.5 text-xs rounded border border-blue-400 text-blue-600 bg-white hover:bg-blue-50"
               @click="renderBeat(index)"
             >
@@ -342,6 +351,7 @@ import {
   beatMayHaveMovie,
   shouldAutoRenderBeat,
   effectiveBeat as effectiveBeatOf,
+  isBeatImageReference,
   isValidBeat as isValidBeatOf,
   staleSince as staleSinceOf,
   scriptSourceText as toScriptSourceText,

--- a/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
@@ -78,6 +78,17 @@ export function beatMayHaveMovie(beat: { moviePrompt?: string; image?: { type?: 
   return beat.image?.type === "html_tailwind" && Boolean(beat.image.animation);
 }
 
+/**
+ * True for a beat whose image merely REFERENCES another beat's image
+ * (`image: { type: "beat", id }` — mulmoBeatReferenceMediaSchema). Such a
+ * beat owns no asset of its own, so there is nothing to generate for it:
+ * the View hides the Generate button (offering it produced a render that
+ * could never succeed on its own terms).
+ */
+export function isBeatImageReference(beat: { image?: { type?: string; [key: string]: unknown } }): boolean {
+  return beat.image?.type === "beat";
+}
+
 /** Pure check: is every beat in the script a `slide`-typed beat?
  *  When true, the View mounts `@mulmocast/deck-web`'s
  *  `MulmoScriptDeckEditor` instead of the per-beat list UI (#1575).

--- a/test/plugins/mulmoscript/test_helpers.ts
+++ b/test/plugins/mulmoscript/test_helpers.ts
@@ -14,6 +14,7 @@ import {
   effectiveBeat,
   getMissingCharacterKeys,
   isAllSlideDeck,
+  isBeatImageReference,
   isSameScript,
   isValidBeat,
   scriptSourceText,
@@ -171,6 +172,21 @@ describe("beatMayHaveMovie", () => {
   it("refuses an empty beat and an empty moviePrompt", () => {
     assert.equal(beatMayHaveMovie({}), false);
     assert.equal(beatMayHaveMovie({ moviePrompt: "" }), false);
+  });
+});
+
+describe("isBeatImageReference", () => {
+  it("accepts a beat whose image references another beat", () => {
+    assert.equal(isBeatImageReference({ image: { type: "beat", id: "intro" } }), true);
+  });
+
+  it("refuses beats that own their image", () => {
+    assert.equal(isBeatImageReference({ image: { type: "slide" } }), false);
+    assert.equal(isBeatImageReference({ image: { type: "imagePrompt" } }), false);
+  });
+
+  it("refuses a beat with no image", () => {
+    assert.equal(isBeatImageReference({}), false);
   });
 });
 


### PR DESCRIPTION
## What

Two small fixes to the `presentMulmoScript` beat list.

### 1. Beat numbers

The beat list gave no way to tell which beat a row was — every row is a thumbnail + narration with no index, so matching a row against `beats[n]` in the source editor meant counting from the top.

Each thumbnail now carries a 1-based number badge (top-left, `bg-black/55`), stacked above the drop-hint overlay and the inline clip player so it stays readable in every beat state (rendered, rendering, error, dragging, playing a clip). testid: `mulmo-script-beat-number-<index>`.

### 2. Generate button on `image.type === "beat"` beats

A beat whose image is `{ type: "beat", id }` (`mulmoBeatReferenceMediaSchema`) merely REFERENCES another beat's image and owns no asset of its own — there is nothing to generate for it, but the Generate button was offered anyway, promising a render that could never succeed on its own terms.

New pure helper `isBeatImageReference()` in `vue/helpers.ts` gates the button, with unit tests alongside the existing `beatMayHaveMovie` ones.

The regenerate (↺) button is unaffected — it only appears once a rendered image exists. The "or drop image" hint is left in place for reference beats: dropping a file there is still a valid override.

## Version

Bumps `@mulmoclaude/mulmoscript-plugin` 1.0.0 → 1.1.0 and the launcher's dep range to `^1.1.0` in lockstep (`yarn check:launcher-sync` green).

## Test plan

- `yarn build:packages && yarn format --check && yarn lint && yarn typecheck && yarn build && yarn test` — all green locally.
- New unit tests in `test/plugins/mulmoscript/test_helpers.ts` cover the reference beat, image-owning beats, and a beat with no image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)