### PR TITLE
docs: release checklist + tag-every-publish rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,3 +156,11 @@ npm view <pkg> version --registry https://registry.npmjs.org/
 ```
 
 A range update reaches users only through that consumer's own next release, so it does not force an immediate republish of all 50 packages — but it MUST be in the tree before the consumer is published next.
+
+### Tag every publish — no untagged releases
+
+Every `npm publish` of a workspace package MUST be accompanied by a git tag `@scope/name@X.Y.Z` (no `v` prefix) on the published commit, plus a GH release (`--latest=false`). The `/publish` skill does this — do NOT publish by hand and skip the tag.
+
+Rationale: the tag is the ONLY reliable marker of "what commit this npm version was cut from". Answering *"which packages changed since their last release and need republishing?"* is a `git diff <name>@<version> HEAD -- <dir>` — which is impossible when the tag is missing. This is not hypothetical: the `1.0.0` plugins (`@mulmoclaude/*-plugin`) were published to npm without `@…@1.0.0` tags (a bulk `0.x → 1.0.0` re-version), so release-drift detection for them had to fall back to guessing the version-bump commit. `version` in `package.json` == npm's latest tells you it was published, but NOT whether the current source differs from what shipped — only the tag does.
+
+When you discover a past publish that was never tagged, create the tag retroactively on the commit that bumped `version` to the published value (best effort), so future drift detection works.

--- a/plans/release-shared-packages-2026-07.md
+++ b/plans/release-shared-packages-2026-07.md
@@ -1,0 +1,121 @@
+# Release shared workspace packages — 2026-07
+
+After ~3 days of heavy refactoring, many shared workspace packages have **source
+changes that were never published** — their `version` still equals npm's latest,
+so nothing is version-ahead, but their source differs from what shipped. This is
+the checklist to release them, in dependency-safe order.
+
+Excludes the launcher `mulmoclaude` (published separately via `/publish-mulmoclaude`).
+
+## How the candidates were found (reproducible)
+
+For every non-private package under `packages/**` (except the launcher):
+
+1. `local == npm`? (all are — nothing is version-ahead) — `npm view <name> version`.
+2. **Changed since its last publish?**
+   - Tagged at current version → `git diff <name>@<version> HEAD -- <dir>` (excl. `dist/`).
+   - No tag for current version (the bulk `0.x → 1.0.0` plugins) → diff from the commit
+     that set the current version. (Reliable only because `local == npm` there.)
+3. Classify: **src/assets changed → needs release**; README/`package.json`-only → meta;
+   no change → clean.
+
+> Lesson baked into CLAUDE.md ("Tag every publish"): the untagged `1.0.0` plugins made
+> step 2 fall back to guessing the bump commit. Every publish MUST create the
+> `@scope/name@X.Y.Z` tag so this is a clean `git diff` next time.
+
+## Per-package release procedure
+
+Use the `/publish` skill (it bumps, builds, tests, publishes, **tags**, and cuts a GH
+release `--latest=false`). For each package:
+
+1. Decide the bump: **patch** for a bugfix/refactor, **minor** for a new/changed API.
+2. Sweep this package's internal dep ranges to each dep's latest published version
+   (CLAUDE.md "Internal dep ranges"). After publishing a dependency below, sweep its
+   consumers' ranges to the new version as those consumers are released.
+3. `yarn build` + `yarn test` green.
+4. `/publish` → `npm publish` + tag `@scope/name@X.Y.Z` + GH release.
+5. `chore(release)` commit bumps only this package's `version` (+ the launcher's dep
+   RANGE for it, to keep `launcherSync.mjs` green) — never the launcher's own version.
+
+**Ripple note:** a `0.x` caret does not float across minor (`^0.1.4` = `>=0.1.4 <0.2.0`).
+So a **patch** bump of a foundation (protocol/core/…) is auto-picked up by `^0.1.x`
+consumers; a **minor** bump requires updating every consumer's range (and republishing
+them) — which is exactly why the order below matters.
+
+---
+
+## Wave 1 — foundations (publish first)
+
+- [ ] `@mulmobridge/protocol` @0.1.4 — +3 src (attachment/events/socket). Root of all bridges + chat-service.
+- [ ] `@mulmobridge/webhook-runtime` @1.0.0 — +1 src. Root of the webhook bridges.
+- [ ] `@receptron/task-scheduler` @0.1.0 — +6 src. Dep of `@mulmoclaude/core`.
+- [ ] `@mulmoclaude/core` @1.2.0 — +8 src (**includes the remote-host hostRunner work, #2535**). After task-scheduler. Root of all `@mulmoclaude/*-plugin`.
+
+## Wave 2 — bridges (after protocol / webhook-runtime)
+
+- [ ] `@mulmobridge/chat-service` @0.1.7 — +4 src (after protocol)
+- [ ] `@mulmobridge/relay` @0.2.1 — +9 src (deps client/common are clean → effectively independent)
+- [ ] `@mulmobridge/irc` @0.1.1 — +2 src
+- [ ] `@mulmobridge/line` @0.1.1 — +2 src (after protocol + webhook-runtime)
+- [ ] `@mulmobridge/teams` @0.1.1 — +2 src
+- [ ] `@mulmobridge/bluesky` @0.1.1 — +1 src
+- [ ] `@mulmobridge/chatwork` @0.1.1 — +1 src
+- [ ] `@mulmobridge/discord` @0.1.2 — +1 src
+- [ ] `@mulmobridge/email` @0.1.1 — +1 src
+- [ ] `@mulmobridge/matrix` @0.1.1 — +1 src
+- [ ] `@mulmobridge/mattermost` @0.1.2 — +1 src
+- [ ] `@mulmobridge/nostr` @0.1.2 — +1 src
+- [ ] `@mulmobridge/rocketchat` @0.1.1 — +1 src
+- [ ] `@mulmobridge/signal` @0.1.1 — +1 src
+- [ ] `@mulmobridge/slack` @0.4.2 — +1 src
+- [ ] `@mulmobridge/twilio-sms` @0.1.1 — +1 src
+- [ ] `@mulmobridge/webhook` @0.1.1 — +1 src
+- [ ] `@mulmobridge/xmpp` @0.1.2 — +1 src
+- [ ] `@mulmobridge/zulip` @0.1.1 — +1 src
+- [ ] `@mulmobridge/google-chat` @0.1.1 — +1 src (after protocol + webhook-runtime)
+- [ ] `@mulmobridge/line-works` @0.1.1 — +1 src (after protocol + webhook-runtime)
+- [ ] `@mulmobridge/messenger` @0.1.1 — +1 src (after protocol + webhook-runtime)
+- [ ] `@mulmobridge/viber` @0.1.1 — +1 src (after protocol + webhook-runtime)
+- [ ] `@mulmobridge/whatsapp` @0.1.1 — +1 src (after protocol + webhook-runtime)
+
+## Wave 3 — core-dependent plugins (after `@mulmoclaude/core`)
+
+- [ ] `@mulmoclaude/collection-plugin` @1.0.0 — +31 src (the #2528 refactor)
+- [ ] `@mulmoclaude/accounting-plugin` @1.0.0 — +21 src
+- [ ] `@mulmoclaude/markdown-plugin` @1.0.0 — +7 src
+- [ ] `@mulmoclaude/html-plugin` @1.0.0 — +4 src
+- [ ] `@mulmoclaude/chart-plugin` @1.0.0 — +3 src
+- [ ] `@mulmoclaude/google-plugin` @1.0.0 — +1 src
+
+## Independent (no internal dep needing release — publish any time)
+
+- [ ] `@mulmoclaude/spotify-plugin` @1.0.0 — +8 src (dep common is clean)
+- [ ] `@mulmoclaude/x-plugin` @0.1.2 — +4 src (dep common is clean)
+- [ ] `create-mulmoclaude-plugin` @0.1.0 — +4 src (**not on npm — first publish; confirm intent**)
+- [ ] `@mulmoclaude/bookmarks-plugin` @1.0.0 — +1 src
+- [ ] `@mulmoclaude/edgar-plugin` @1.0.0 — +1 src
+- [ ] `@mulmoclaude/email-plugin` @1.0.0 — +1 src
+- [ ] `@mulmoclaude/form-plugin` @1.0.0 — +1 src
+- [ ] `@mulmoclaude/recipe-book-plugin` @1.0.0 — +1 src
+
+---
+
+## Meta-only changes (README / package.json only — optional, batch)
+
+Not source; release only if the README/dep-range update should ship now.
+
+- [ ] `@mulmobridge/cli` @0.1.3 — README + package.json
+- [ ] `@mulmobridge/mastodon` @0.1.2 — package.json only
+- [ ] `@mulmobridge/telegram` @0.1.3 — README + package.json
+- [ ] `@mulmobridge/mock-server` @0.1.1 — README + package.json + a test file
+
+## Clean — no action (published == current source)
+
+`@mulmobridge/client`, `@mulmoclaude/common`, `@mulmoclaude/markdown-utils`,
+`@mulmobridge/web-push`, `@mulmoclaude/debug-plugin`, `@mulmoclaude/mulmoscript-plugin`
+(published at 1.1.0 via #2543).
+
+## After all shared packages
+
+To actually deliver everything to npm-installed users, the launcher `mulmoclaude`
+must be released last via `/publish-mulmoclaude` (out of scope for this checklist).


### PR DESCRIPTION
## Summary

Two docs artifacts ahead of the shared-package release wave:

1. **CLAUDE.md — "Tag every publish — no untagged releases"** (under *Internal dep ranges*). Every `npm publish` of a workspace package MUST create the `@scope/name@X.Y.Z` git tag + a GH release, because the tag is the only reliable marker of "what commit this npm version was cut from" — release-drift detection is `git diff <name>@<version> HEAD -- <dir>`, which is impossible without the tag. Motivated by the `1.0.0` plugins that were published untagged (bulk `0.x → 1.0.0`), forcing drift detection to guess the bump commit. Also: retroactively tag past untagged publishes.

2. **plans/release-shared-packages-2026-07.md** — a dependency-ordered checklist of the **42** shared workspace packages (launcher excluded) whose *source changed since their last publish* after the recent refactoring. Nothing is version-ahead (all `local == npm`); the changes simply were never released. Includes the detection method (reproducible), the per-package release procedure, the patch-vs-minor range-ripple note, and the clean/meta-only sets.

## Items to Confirm / Review

- The tag-every-publish rule wording and placement.
- The release ordering (foundations → bridges / core-plugins). Key roots: `@mulmobridge/protocol`, `@mulmobridge/webhook-runtime`, `@receptron/task-scheduler`, `@mulmoclaude/core` (which carries the just-merged remote-host hostRunner work #2535).
- `create-mulmoclaude-plugin` is not on npm — listed as a first-publish **pending intent confirmation**.

## User Prompt

> mulmoclaude 本体以外で publish が必要なもの（変更があるもの）で、まだ publish していないものを順次 publish していきたい。まず探して候補を出して、依存がある場合は順番も考慮して。多いので plan にして publish していこう。あと、タグを付けることも CLAUDE.md に書いておいて。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the new requirement to tag every workspace package publish and add a dependency-ordered checklist for releasing all shared workspace packages whose source has changed since their last publish.

Documentation:
- Clarify that every workspace package publish must create a versioned git tag and GitHub release to support reliable release-drift detection.
- Add a dated release plan outlining how to identify and sequentially publish shared workspace packages with unpublished source changes, including waves, dependency ordering, and meta-only vs. clean classifications.

Chores:
- Record a release checklist for shared packages, including notes on version bump types, internal dependency range updates, and launcher release sequencing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release guidance requiring every published package to include a matching version tag and GitHub release.
  * Documented the recommended publishing workflow, including version updates, validation, dependency coordination, and release ordering.
  * Added a July 2026 checklist for identifying and releasing packages with unpublished source changes.
  * Included guidance for handling already up-to-date packages and releasing the launcher last.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->