### PR TITLE
fix(collections): clear a deleted collection's sync state (#2428, #2550)

### DIFF
--- a/packages/core/src/collection/server/delete.ts
+++ b/packages/core/src/collection/server/delete.ts
@@ -23,6 +23,7 @@ import path from "node:path";
 import { log, getWorkspaceRoot, isPresetSlug, skillsStagingDir, archiveDir as archiveRelDir } from "./host";
 import { isContainedInRoot } from "./paths";
 import { checkpointSqliteDatabase } from "./sqliteStore";
+import { ingestStatePath } from "../../feeds/paths";
 import type { LoadedCollection } from "./discoveredCollection";
 
 export type DeleteCollectionResult =
@@ -86,6 +87,7 @@ function deleteTargets(collection: LoadedCollection, workspaceRoot: string): str
     stagingSkillDir(workspaceRoot, collection.slug),
     collection.skillDir,
     collection.dataDir,
+    ingestStatePath(collection.slug, workspaceRoot),
     ...(collection.storageFile !== undefined ? [collection.storageFile] : []),
   ];
 }
@@ -209,6 +211,14 @@ async function removeLocations(collection: LoadedCollection, workspaceRoot: stri
   await rm(collection.skillDir, { recursive: true, force: true });
   await rm(collection.dataDir, { recursive: true, force: true });
   await rmdir(path.dirname(collection.dataDir)).catch(() => undefined);
+  // The retrieval cursor lives in a SHARED dir (`data/ingest-state/<slug>.json`),
+  // outside every per-collection location above, so nothing else would remove
+  // it. Left behind, a collection recreated under the same slug inherits the old
+  // `lastFetchedAt` and takes the "wait for the interval" branch in
+  // `isDailyAtHourDue` instead of fetching immediately — it just sits empty
+  // (#2550). Deliberately not archived: the archive restores user data, and
+  // restoring a stale cursor would reintroduce exactly this bug.
+  await rm(ingestStatePath(collection.slug, workspaceRoot), { force: true });
   // The archived copy above is the backup; remove the live db (+ sqlite
   // sidecars) so a deleted collection doesn't leave orphaned data behind.
   if (collection.storageFile !== undefined) {

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -212,6 +212,54 @@ export function groupByCalendar(collections: readonly LoadedCollection[]): Map<s
   return groups;
 }
 
+/** The minimum a value needs for the orphan check: just the calendar it reads.
+ *  Structural so the rule can be exercised without building a LoadedCollection. */
+export interface CalendarDeclaring {
+  googleCalendar?: { calendarId?: string };
+}
+
+/** The canonical calendar whose sync token nothing needs any more, or null.
+ *
+ *  Sync tokens are keyed by calendar, NOT by collection, so a deleted
+ *  collection's token outlives it. Recreating a collection on the same calendar
+ *  then resumes from that token and receives only the delta — the new
+ *  collection never gets the history (#2428).
+ *
+ *  Returns null while ANY remaining collection still reads that calendar:
+ *  clearing a live calendar's token costs a full re-walk on the next sync. The
+ *  comparison is on the CANONICAL id for the same reason `groupByCalendar` is —
+ *  an omitted `calendarId` and an explicit `"primary"` are one calendar. */
+export function orphanedCalendarId(deleted: CalendarDeclaring, remaining: readonly CalendarDeclaring[]): string | null {
+  if (!deleted.googleCalendar) return null;
+  const key = canonicalCalendarId(deleted.googleCalendar.calendarId);
+  const stillRead = remaining.some((other) => other.googleCalendar && canonicalCalendarId(other.googleCalendar.calendarId) === key);
+  return stillRead ? null : key;
+}
+
+/** Drop the sync token of a just-deleted collection's calendar, unless another
+ *  collection still reads it. Call AFTER the delete lands — the check reads the
+ *  collections that survive it.
+ *
+ *  Returns the cleared calendar id, or null when nothing was cleared. Never
+ *  throws: a failed cleanup must not fail the delete it follows. */
+export async function releaseOrphanedCalendarToken(deleted: CalendarDeclaring, workspaceRoot: string): Promise<string | null> {
+  try {
+    if (!deleted.googleCalendar) return null;
+    const remaining = await discoverCollections({ workspaceRoot });
+    const orphaned = orphanedCalendarId(
+      deleted,
+      remaining.map((collection) => collection.schema),
+    );
+    if (orphaned === null) return null;
+    await clearCalendarSyncToken(orphaned, workspaceRoot);
+    log.info("google", "cleared the sync token of a calendar no collection reads any more", { calendarId: orphaned });
+    return orphaned;
+  } catch (error) {
+    log.warn("google", "could not release the deleted collection's calendar sync token", { error: String(error) });
+    return null;
+  }
+}
+
 /** Sync every collection that declares `googleCalendar`. Failures are isolated
  *  per calendar — one unreachable calendar (or a revoked grant) must not stop
  *  the others. */

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -8,6 +8,7 @@
 // `googleCalendar` in its schema, exactly the way a feed opts in by declaring
 // `ingest`. There is no preset calendar collection (the standalone Calendar
 // view was removed in 0.7.0); the user asks for one and the agent authors it.
+import { stat } from "node:fs/promises";
 import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import type { SystemTaskDef } from "../scheduler/adapter.js";
 import { discoverCollections } from "../collection/server/discovery.js";
@@ -163,12 +164,55 @@ export async function syncCalendarGroup(
     log.warn("google", "skipping calendar events that can never be stored", { calendarId, unwritable });
   }
   const failed = results.flatMap((entry) => entry.errors);
-  if (result.nextSyncToken && failed.length === 0) {
-    await saveCalendarSyncToken(calendarId, result.nextSyncToken, workspaceRoot);
-  } else if (failed.length > 0) {
+  if (failed.length > 0) {
     log.warn("google", "holding back calendar sync token after failed writes", { calendarId, failed: failed.length });
+    return results;
   }
+  if (result.nextSyncToken) await advanceToken(calendarId, result.nextSyncToken, collections, workspaceRoot);
   return results;
+}
+
+/** Save the window's token unless every collection that consumed it was deleted
+ *  while the sync was in flight.
+ *
+ *  The sync opens with a `discoverCollections()` snapshot, so a delete landing
+ *  mid-run has already cleared this calendar's token by the time we get here
+ *  (`releaseOrphanedCalendarToken`). Saving anyway would resurrect exactly the
+ *  orphan the delete removed, and the next collection on this calendar would
+ *  resume from a token describing records it never received (#2428).
+ *
+ *  One survivor is enough: it still needs the incremental position. */
+async function advanceToken(
+  calendarId: string | undefined,
+  nextSyncToken: string,
+  collections: readonly LoadedCollection[],
+  workspaceRoot: string,
+): Promise<void> {
+  if (!(await anySyncedCollectionSurvives(collections))) {
+    log.info("google", "not advancing the sync token — every collection on this calendar was deleted mid-sync", { calendarId });
+    return;
+  }
+  await saveCalendarSyncToken(calendarId, nextSyncToken, workspaceRoot);
+}
+
+async function pathExists(absPath: string): Promise<boolean> {
+  try {
+    await stat(absPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Liveness of the collections a sync just wrote to, checked against the skill
+ *  dir `deleteCollection` removes. `exists` is injected so the rule is testable
+ *  without a filesystem. An empty group has no survivor by definition. */
+export async function anySyncedCollectionSurvives(
+  collections: readonly Pick<LoadedCollection, "skillDir">[],
+  exists: (absPath: string) => Promise<boolean> = pathExists,
+): Promise<boolean> {
+  const alive = await Promise.all(collections.map((collection) => exists(collection.skillDir)));
+  return alive.some(Boolean);
 }
 
 async function applyEventsToCollection(

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -55,11 +55,14 @@ export {
   classifyDelete,
   classifyWrite,
   groupByCalendar,
+  orphanedCalendarId,
+  releaseOrphanedCalendarToken,
   syncCalendarGroup,
   syncDueCalendarCollections,
   toCollectionRecord,
   GOOGLE_CALENDAR_SYNC_TASK_ID,
   type CalendarCollectionSyncResult,
+  type CalendarDeclaring,
 } from "./collectionSync.js";
 export {
   completeTask,

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -54,6 +54,7 @@ export {
   googleCalendarSyncTaskDef,
   classifyDelete,
   classifyWrite,
+  anySyncedCollectionSurvives,
   groupByCalendar,
   orphanedCalendarId,
   releaseOrphanedCalendarToken,

--- a/plans/fix-2428-orphaned-collection-state.md
+++ b/plans/fix-2428-orphaned-collection-state.md
@@ -1,0 +1,91 @@
+# fix(collections): deleting a collection leaves its sync state behind (#2428, #2550)
+
+## Symptom
+
+Both bugs look identical to the user: **recreate a collection and it stays empty.**
+
+- **#2428** — delete a `googleCalendar` collection, recreate it on the same
+  calendar, and only the delta since the delete arrives. The history never comes.
+- **#2550** — delete an `ingest` collection, recreate it under the same slug, and
+  the initial fetch is skipped; it sits empty until the next scheduled tick (for
+  `atHour` daily, up to ~24 h).
+
+## Root cause (one rule, two stores)
+
+Deleting a collection removes the collection. It does not remove the state that
+records **how far its syncing had got** — and that state is keyed by something
+other than the collection, so it survives and gets picked up by the replacement.
+
+Swept every store with that shape:
+
+| state | keyed by | cleared on delete? |
+|---|---|---|
+| `data/calendar/.sync-state.json` tokens | calendarId | ❌ **#2428** |
+| `data/ingest-state/<slug>.json` | slug | ❌ **#2550** |
+| `feeds/<slug>/_state.json` | slug | ✅ `removeFeed` removes `feeds/<slug>/` |
+| skillDir / dataDir / staging / sqlite | slug | ✅ `deleteTargets` |
+
+`deleteCollection` removes exactly what `deleteTargets()` lists — staging skill
+dir, `skillDir`, `dataDir`, `storageFile`. Both leaked stores live outside all
+four.
+
+For #2550 the mechanism is `engine.ts:152`: `if (!lastFetchedAt) return true`
+makes a genuinely new collection fetch immediately, so inheriting a stale
+`lastFetchedAt` sends it down the "wait for the interval" branch instead.
+
+## Changes
+
+**#2550** — `ingestStatePath(slug, workspaceRoot)` joins `deleteTargets()` (so it
+passes the same containment check as every other target) and is `rm`'d with
+`force: true` in `removeLocations`. Slug-exact, so there is no over-deletion
+surface, and a missing file is a no-op.
+
+Deliberately **not** archived: the archive exists to restore user data, and
+restoring a stale cursor would reintroduce the bug.
+
+**#2428** — the decision is a pure function, `orphanedCalendarId(deleted,
+remaining)`, returning the canonical calendar id only when no surviving
+collection reads it. `releaseOrphanedCalendarToken` wraps it with discovery + the
+existing `clearCalendarSyncToken` (already used on Google's 410) and is called
+from the delete route **after** the delete lands, so the check sees the
+collections that survive.
+
+Canonicalisation matters as much as the check: an omitted `calendarId` and an
+explicit `"primary"` are one calendar sharing one token, so comparing the raw
+values would clear a token still in use. Three tests pin that.
+
+## Why the route and not `deleteCollection`
+
+`collection/server/delete.ts` must not depend on the google module (uphill
+import). The ingest-state cleanup has no such constraint and lives inside
+`deleteCollection`, where it is safe against a future second delete path. There
+is exactly one delete path today (`collections.ts` → `deleteCollection`; the MCP
+`manageCollection` tool has `deleteItems`, not a collection delete).
+
+## Failure modes considered
+
+- `releaseOrphanedCalendarToken` never throws. The collection is already gone
+  when it runs; a failed cleanup must not turn into "the collection cannot be
+  deleted".
+- Worst case if the check is ever wrong in the clearing direction: one full
+  re-walk on the next sync. No data is lost either way — a sync token is a
+  bookmark, not content.
+
+## Known limitation (unfixed, deliberate)
+
+`syncDueCalendarCollections` opens with a `discoverCollections()` snapshot. A
+delete that lands *after* that snapshot but *before* the sync writes its token
+will have its cleanup overwritten by the in-flight run, leaving the token
+orphaned again. The window is narrow (syncs are hourly and short) and the
+existing 410 path recovers, so closing it would need locking that neither store
+has today. Recorded rather than papered over.
+
+## Verification
+
+- Mutation check on both fixes, **with `@mulmoclaude/core` rebuilt between runs**
+  — the tests import through the package name, so they resolve to `dist/` and a
+  source-only mutation reports a false green (this bit on the first attempt).
+  - dropping the `rm` → 1 test red
+  - forcing `stillRead = false` → 3 tests red, all three canonicalisation cases
+- `yarn format` / `lint` (0 errors, 45 pre-existing warnings) / `typecheck` /
+  `build` / `test` (7930 pass, 0 fail).

--- a/plans/fix-2428-orphaned-collection-state.md
+++ b/plans/fix-2428-orphaned-collection-state.md
@@ -71,14 +71,24 @@ is exactly one delete path today (`collections.ts` → `deleteCollection`; the M
   re-walk on the next sync. No data is lost either way — a sync token is a
   bookmark, not content.
 
-## Known limitation (unfixed, deliberate)
+## The mid-sync delete race (closed — CodeRabbit on PR #2551)
 
-`syncDueCalendarCollections` opens with a `discoverCollections()` snapshot. A
-delete that lands *after* that snapshot but *before* the sync writes its token
-will have its cleanup overwritten by the in-flight run, leaving the token
-orphaned again. The window is narrow (syncs are hourly and short) and the
-existing 410 path recovers, so closing it would need locking that neither store
-has today. Recorded rather than papered over.
+`syncDueCalendarCollections` opens with a `discoverCollections()` snapshot, so a
+delete landing after that snapshot has already cleared the calendar's token by
+the time the sync writes one. Saving it anyway resurrects exactly the orphan the
+delete removed.
+
+The first draft recorded this as a known limitation needing locking. That was too
+pessimistic: the token write can simply re-check liveness first.
+`anySyncedCollectionSurvives` tests the skill dirs `deleteCollection` removes,
+and `advanceToken` skips the save when every collection that consumed the window
+is gone. One survivor is enough — it still needs the incremental position.
+
+`exists` is injected so the rule is testable without a filesystem.
+
+Failure direction: a `stat` that fails for an unrelated reason reads as "gone",
+so the token is not advanced and the next run does a full re-walk. No data is
+lost either way.
 
 ## Verification
 

--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -68,6 +68,7 @@ import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
 import { workspacePath } from "../../workspace/workspace.js";
 import { refreshOne } from "@mulmoclaude/core/feeds/server";
+import { releaseOrphanedCalendarToken } from "@mulmoclaude/core/google";
 import { manageCollection } from "../../agent/mcp-tools/manageCollection.js";
 import { dispatchAgentAction, runningAgentActions } from "./collectionAgentActions.js";
 import { clampCapabilities, mintViewToken, requireViewToken } from "../auth/viewToken.js";
@@ -322,6 +323,11 @@ router.delete(API_ROUTES.collections.detail, async (req: Request<{ slug: string 
       forbidden(res, deleteCollectionRefusalMessage(result));
       return;
     }
+    // After the delete, so the "does anything still read this calendar?" check
+    // sees the collections that survive it. Best-effort by contract — the
+    // collection is already gone, and a stale token costs a delta-only sync,
+    // not data (#2428).
+    await releaseOrphanedCalendarToken(collection.schema, workspacePath);
     log.info("collections", "collection deleted", { slug: result.slug, archivePath: result.archivePath });
     res.json({ deleted: true, slug: result.slug, archivePath: result.archivePath });
   } catch (err) {

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -6,8 +6,8 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { classifyDelete, classifyWrite, groupByCalendar, toCollectionRecord } from "@mulmoclaude/core/google";
-import type { CalendarEventSummary } from "@mulmoclaude/core/google";
+import { classifyDelete, classifyWrite, groupByCalendar, orphanedCalendarId, toCollectionRecord } from "@mulmoclaude/core/google";
+import type { CalendarDeclaring, CalendarEventSummary } from "@mulmoclaude/core/google";
 import { parseIsoDateTime } from "@mulmoclaude/core/collection";
 import type { CollectionFieldSpec } from "@mulmoclaude/core/collection";
 import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
@@ -213,5 +213,52 @@ describe("apply-failure classification (#2184)", () => {
   it("names the event in every failure message so the log is actionable", () => {
     const outcome = classifyWrite("ev-42", "path-escape");
     assert.ok(outcome.kind === "error" && outcome.message.includes("ev-42"));
+  });
+});
+
+// #2428. Sync tokens are keyed by calendar, not by collection, so a deleted
+// collection's token outlives it — and a collection recreated on the same
+// calendar then resumes from it and receives only the delta, never the history.
+// This is the rule that decides whether the token may go.
+describe("orphanedCalendarId (#2428)", () => {
+  // Only the calendar matters here — `CalendarDeclaring` is deliberately the
+  // minimum the rule reads, so the field map a real schema carries is absent.
+  const reading = (calendarId?: string): CalendarDeclaring => ({ googleCalendar: { calendarId } });
+
+  it("names the calendar when nothing else reads it", () => {
+    assert.equal(orphanedCalendarId(reading("work"), []), "work");
+  });
+
+  // The expensive mistake in the other direction: clearing a token another
+  // collection is still using forces it into a full re-walk on the next sync.
+  it("holds the token while another collection still reads the calendar", () => {
+    assert.equal(orphanedCalendarId(reading("work"), [reading("work")]), null);
+  });
+
+  it("clears when the survivors read OTHER calendars", () => {
+    assert.equal(orphanedCalendarId(reading("work"), [reading("home"), reading("family")]), "work");
+  });
+
+  it("ignores survivors that declare no calendar at all", () => {
+    assert.equal(orphanedCalendarId(reading("work"), [{}, {}]), "work");
+  });
+
+  it("returns null for a collection that never read a calendar", () => {
+    assert.equal(orphanedCalendarId({}, []), null);
+  });
+
+  // Same canonicalisation as `groupByCalendar`: an omitted id and an explicit
+  // "primary" address ONE calendar and share ONE token, so treating them as
+  // different keys here would clear a token that is still in use.
+  it("treats an omitted calendarId as the primary calendar", () => {
+    assert.equal(orphanedCalendarId(reading(), []), "primary");
+  });
+
+  it("does not clear `primary` while a collection with an omitted id survives", () => {
+    assert.equal(orphanedCalendarId(reading("primary"), [reading()]), null);
+  });
+
+  it("does not clear an omitted id while an explicit `primary` survives", () => {
+    assert.equal(orphanedCalendarId(reading(), [reading("primary")]), null);
   });
 });

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -6,7 +6,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { classifyDelete, classifyWrite, groupByCalendar, orphanedCalendarId, toCollectionRecord } from "@mulmoclaude/core/google";
+import { anySyncedCollectionSurvives, classifyDelete, classifyWrite, groupByCalendar, orphanedCalendarId, toCollectionRecord } from "@mulmoclaude/core/google";
 import type { CalendarDeclaring, CalendarEventSummary } from "@mulmoclaude/core/google";
 import { parseIsoDateTime } from "@mulmoclaude/core/collection";
 import type { CollectionFieldSpec } from "@mulmoclaude/core/collection";
@@ -260,5 +260,43 @@ describe("orphanedCalendarId (#2428)", () => {
 
   it("does not clear an omitted id while an explicit `primary` survives", () => {
     assert.equal(orphanedCalendarId(reading(), [reading("primary")]), null);
+  });
+});
+
+// #2428 follow-up (CodeRabbit on PR #2551). The sync opens with a
+// `discoverCollections()` snapshot, so a delete landing mid-run has already
+// cleared this calendar's token by the time the token write happens. Saving
+// anyway resurrects exactly the orphan the delete removed.
+describe("anySyncedCollectionSurvives (#2428 mid-sync delete)", () => {
+  const collectionIn = (skillDir: string) => ({ skillDir });
+  const existing =
+    (...alive: string[]) =>
+    (absPath: string) =>
+      Promise.resolve(alive.includes(absPath));
+
+  it("lets the token advance while the collection still exists", async () => {
+    assert.equal(await anySyncedCollectionSurvives([collectionIn("/ws/.claude/skills/cal")], existing("/ws/.claude/skills/cal")), true);
+  });
+
+  it("holds the token back when the only collection was deleted mid-sync", async () => {
+    assert.equal(await anySyncedCollectionSurvives([collectionIn("/ws/.claude/skills/cal")], existing()), false);
+  });
+
+  // One survivor still needs the incremental position, so the token must
+  // advance even though a sibling on the same calendar was deleted.
+  it("advances when at least one of several survives", async () => {
+    const group = [collectionIn("/ws/.claude/skills/gone"), collectionIn("/ws/.claude/skills/kept")];
+    assert.equal(await anySyncedCollectionSurvives(group, existing("/ws/.claude/skills/kept")), true);
+  });
+
+  it("holds the token back when every collection in the group is gone", async () => {
+    const group = [collectionIn("/ws/.claude/skills/gone-a"), collectionIn("/ws/.claude/skills/gone-b")];
+    assert.equal(await anySyncedCollectionSurvives(group, existing()), false);
+  });
+
+  // Defensive: `groupByCalendar` never yields an empty group, but "nothing
+  // consumed the window" must never advance the token either.
+  it("treats an empty group as no survivor", async () => {
+    assert.equal(await anySyncedCollectionSurvives([], existing("/ws/.claude/skills/cal")), false);
   });
 });

--- a/test/workspace/collections/test_delete.ts
+++ b/test/workspace/collections/test_delete.ts
@@ -209,3 +209,57 @@ describe("deleteCollection — storage (sqlite) collections", () => {
     assert.ok(restore.includes("(storage)"), "summary line must mark the storage backend");
   });
 });
+
+// #2550. The retrieval cursor lives in a SHARED dir outside every
+// per-collection location, so nothing else would remove it. Left behind, a
+// collection recreated under the same slug inherits `lastFetchedAt` and skips
+// its initial fetch — it just sits empty until the next scheduled tick.
+describe("deleteCollection — ingest state", () => {
+  function seedIngestState(slug: string): string {
+    const stateDir = path.join(workdir, "data", "ingest-state");
+    mkdirSync(stateDir, { recursive: true });
+    const stateFile = path.join(stateDir, `${slug}.json`);
+    writeFileSync(stateFile, JSON.stringify({ slug, lastFetchedAt: "2026-07-01T00:00:00.000Z", cursor: { etag: "abc" }, consecutiveFailures: 3 }));
+    return stateFile;
+  }
+
+  it("removes the collection's ingest state", async () => {
+    const collection = seedCollection("daily-news", "project");
+    const stateFile = seedIngestState("daily-news");
+
+    const result = await deleteCollection(collection, { workspaceRoot: workdir, dateStamp: "2026-07-25" });
+
+    assert.equal(result.kind, "ok");
+    assert.equal(existsSync(stateFile), false, "ingest state survived the delete");
+  });
+
+  it("leaves another collection's ingest state alone", async () => {
+    const collection = seedCollection("daily-news", "project");
+    const otherState = seedIngestState("weekly-digest");
+
+    await deleteCollection(collection, { workspaceRoot: workdir, dateStamp: "2026-07-25" });
+
+    assert.equal(existsSync(otherState), true, "deleted the wrong collection's ingest state");
+  });
+
+  it("succeeds when there is no ingest state to remove", async () => {
+    const collection = seedCollection("restaurants", "project");
+
+    const result = await deleteCollection(collection, { workspaceRoot: workdir, dateStamp: "2026-07-25" });
+
+    assert.equal(result.kind, "ok");
+  });
+
+  // Deliberate: the archive exists to restore user data, and restoring a stale
+  // cursor would reintroduce the bug this delete is fixing.
+  it("does NOT archive the ingest state", async () => {
+    const collection = seedCollection("daily-news", "project");
+    seedIngestState("daily-news");
+
+    const result = await deleteCollection(collection, { workspaceRoot: workdir, dateStamp: "2026-07-25" });
+
+    assert.equal(result.kind, "ok");
+    if (result.kind !== "ok") return;
+    assert.equal(existsSync(path.join(workdir, result.archivePath, "daily-news.json")), false);
+  });
+});


### PR DESCRIPTION
Fixes #2428, fixes #2550

## Summary

Deleting a collection removes the collection — but not the state recording **how far its syncing had got**. That state is keyed by something other than the collection, so it survives and gets picked up by the replacement. Two stores had this shape, and both look identical to the user: **recreate a collection, it stays empty.**

- **#2428** — the calendar sync token is keyed by `calendarId`, so a collection recreated on the same calendar resumes from the deleted one's token and receives only the delta. The history never arrives.
- **#2550** — the ingest cursor lives in `data/ingest-state/<slug>.json`, a shared dir outside every per-collection location. A collection recreated under the same slug inherits `lastFetchedAt` and takes the "wait for the interval" branch in `isDailyAtHourDue` instead of fetching immediately.

#2550 was found while sweeping #2428's root cause; it was not previously reported.

## Items to Confirm / Review

- **The two fixes deliberately live in different places.** `collection/server/delete.ts` must not import the google module (uphill), so the calendar cleanup is a core `google` helper called from the delete route. The ingest-state cleanup has no such constraint and sits inside `deleteCollection`, where a future second delete path would still get it. There is exactly one delete path today (the MCP `manageCollection` tool has `deleteItems`, not a collection delete).
- **Canonicalisation is the subtle part of #2428.** An omitted `calendarId` and an explicit `"primary"` are one calendar sharing one token — comparing raw values would clear a token still in use. Three tests pin it.
- **`releaseOrphanedCalendarToken` never throws.** The collection is already gone when it runs; a failed cleanup must not become "the collection cannot be deleted". Worth confirming you agree that is the right trade.
- **Ingest state is deliberately NOT archived.** The archive restores user data; restoring a stale cursor would reintroduce the bug.

## Sweep

| state | keyed by | cleared on delete? |
|---|---|---|
| `data/calendar/.sync-state.json` tokens | calendarId | ❌ → fixed (#2428) |
| `data/ingest-state/<slug>.json` | slug | ❌ → fixed (#2550) |
| `feeds/<slug>/_state.json` | slug | ✅ already — `removeFeed` removes `feeds/<slug>/` |
| skillDir / dataDir / staging / sqlite | slug | ✅ already — `deleteTargets` |

## Blast radius

Both cleanups fire **only** on a successful collection delete. Neither can lose data — a sync token and a cursor are bookmarks, not content. Worst case in the clearing direction is one extra full re-walk on the next sync.

## Known limitation (deliberate, not fixed here)

`syncDueCalendarCollections` opens with a `discoverCollections()` snapshot. A delete landing after that snapshot but before the sync writes its token will have its cleanup overwritten, orphaning the token again. The window is narrow (hourly, short syncs) and Google's 410 path recovers; closing it properly needs locking neither store has today. Recorded in the plan rather than papered over.

## Verification

- **Mutation check on both fixes, with `@mulmoclaude/core` rebuilt between runs.** This matters: the tests import through the package name, so they resolve to `dist/` and a source-only mutation reports a **false green** — which is exactly what happened on my first attempt. With the rebuild: dropping the `rm` turns 1 test red; forcing `stillRead = false` turns 3 red, all three canonicalisation cases.
- `yarn format` / `lint` (0 errors, 45 pre-existing warnings) / `typecheck` / `build` / `test` (7930 pass, 0 fail).
- The pre-commit hook caught a `typecheck`-only failure that `yarn build` passed — a test-file type error invisible to the compile-only build.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues でopen2308以降で、副作用無く影響無く直せるのをおしえて。それだけ直したい
>
> （#2428 について）副作用とかなければ直したいんだけど、問題とか影響がわからない → 影響説明のうえ「両方直す」を選択

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting an ingest collection now removes its associated ingest state, preventing stale sync data from affecting recreated collections.
  - Deleting a Google Calendar collection now releases sync tokens when no remaining collection uses that calendar.
  - Calendar identifiers such as omitted values and `primary` are handled consistently.

- **Tests**
  - Added coverage for ingest-state cleanup, calendar token handling, shared calendars, and missing state files.

- **Documentation**
  - Documented cleanup behavior, edge cases, and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->