### PR TITLE
fix: don't warn about missing whisper-server when voice input is disabled

### DIFF
--- a/plans/fix-whisper-optional-dep-announce-gate.md
+++ b/plans/fix-whisper-optional-dep-announce-gate.md
@@ -1,0 +1,29 @@
+# fix: gate the whisper optional-dep announcement on voice-input opt-in
+
+Issue: https://github.com/receptron/mulmoclaude/issues/2553
+
+## Problem
+
+`announceOptionalDeps` warns (log + bell) for every missing optional binary at boot,
+including `whisper-server`. Voice input ships OFF (`settings.voiceInput.enabled`
+defaults false), so users who never use it still get a "whisper-server unavailable —
+voiceInput degraded" warn + bell every start. No API key is involved (local whisper.cpp).
+
+## Fix
+
+Only announce a missing optional dep when its feature is wanted.
+
+- Add a pure `shouldAnnounceDep(depId, settings)` in `server/system/announceOptionalDeps.ts`:
+  opt-in deps (currently just `whisper` → `voiceInput.enabled`) are announced only when
+  enabled; everything else (`docker`, `ffmpeg`) always announces.
+- `announceOptionalDeps(settings)` takes settings and `continue`s past a gated-off dep,
+  suppressing BOTH the `log.warn` and the bell notification.
+- Caller `server/index.ts` passes `loadSettings()`.
+- Update the 2 existing degradation-test call sites to pass a settings object.
+
+## Tests
+
+- Unit: `shouldAnnounceDep` — whisper gated (enabled true→announce, false/undefined→skip);
+  docker/ffmpeg always true.
+- Integration: with whisper absent in the seed, `announceOptionalDeps` emits no `deps` warn
+  when voice input is disabled, and does emit one when enabled.

--- a/plans/fix-whisper-optional-dep-announce-gate.md
+++ b/plans/fix-whisper-optional-dep-announce-gate.md
@@ -6,8 +6,8 @@ Issue: https://github.com/receptron/mulmoclaude/issues/2553
 
 `announceOptionalDeps` warns (log + bell) for every missing optional binary at boot,
 including `whisper-server`. Voice input ships OFF (`settings.voiceInput.enabled`
-defaults false), so users who never use it still get a "whisper-server unavailable —
-voiceInput degraded" warn + bell every start. No API key is involved (local whisper.cpp).
+defaults to false), so users who never use it still get a "whisper-server unavailable —
+voiceInput degraded" warn + bell on every start. No API key is involved (local whisper.cpp).
 
 ## Fix
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -881,11 +881,15 @@ async function initBootDiagnostics(): Promise<void> {
   // notification.
   await announcePluginMetaDiagnostics();
 
+  // One settings read shared by the dep announce (gates the whisper warning on
+  // voice-input opt-in) and the sidecar warm-up below.
+  const bootSettings = loadSettings();
+
   // --- Optional host-dependency probe (#1385) ---
   // Probes docker / ffmpeg / … once, warns (log + bell) for any
   // missing one so a feature degrading is visible instead of a
   // later opaque crash. Never throws.
-  await announceOptionalDeps(loadSettings());
+  await announceOptionalDeps(bootSettings);
 
   // --- Gemini key presence (#2081) ---
   announceGeminiKey();
@@ -895,7 +899,7 @@ async function initBootDiagnostics(): Promise<void> {
   // pre-spawn the whisper-server sidecar now (deps were just probed) so
   // the user's first dictation doesn't pay the ~10s+ model-load cost
   // inside the request. No-op when voice input is off / not ready.
-  warmupVoiceInput(loadSettings());
+  warmupVoiceInput(bootSettings);
 
   // --- Billing-suite migration ---
   // The invoicing collections moved from bundled `mc-*` presets to

--- a/server/index.ts
+++ b/server/index.ts
@@ -885,7 +885,7 @@ async function initBootDiagnostics(): Promise<void> {
   // Probes docker / ffmpeg / … once, warns (log + bell) for any
   // missing one so a feature degrading is visible instead of a
   // later opaque crash. Never throws.
-  await announceOptionalDeps();
+  await announceOptionalDeps(loadSettings());
 
   // --- Gemini key presence (#2081) ---
   announceGeminiKey();

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -27,7 +27,8 @@ const ANNOUNCE_GATE: Record<string, (settings: AppSettings) => boolean> = {
 
 /** Whether a missing optional dep should be surfaced at boot. Pure — the gate for
  *  an opt-in dep reads the settings flag for its feature; non-gated deps always
- *  announce. */
+ *  announce. The single gate entry is guarded by a unit test, so a typo'd key
+ *  can't silently slip in. */
 export function shouldAnnounceDep(depId: string, settings: AppSettings): boolean {
   const gate = ANNOUNCE_GATE[depId];
   return gate ? gate(settings) : true;

--- a/server/system/announceOptionalDeps.ts
+++ b/server/system/announceOptionalDeps.ts
@@ -8,12 +8,29 @@ import { BUILT_IN_PLUGIN_METAS } from "../../src/plugins/metas.js";
 import type { PluginMeta } from "../../src/plugins/meta-types.js";
 import { NOTIFICATION_KINDS, NOTIFICATION_PRIORITIES } from "../../src/types/notification.js";
 import { log } from "./logger/index.js";
+import type { AppSettings } from "./config.js";
 import { publishNotification, type PublishNotificationOpts } from "../events/notifications.js";
 import { probeOptionalDeps, optionalDeps, type OptionalDep, type DepStatus } from "./optionalDeps.js";
 
 function pluginsRequiring(depId: string): string[] {
   const metas: readonly PluginMeta[] = Object.values(BUILT_IN_PLUGIN_METAS);
   return metas.filter((meta) => meta.requires?.includes(depId)).map((meta) => meta.toolName);
+}
+
+// Opt-in optional deps: announced only when the user has turned their feature on.
+// Voice input ships OFF, so a missing whisper-server binary is expected and must
+// not warn/notify unless voice input is actually enabled. docker (sandbox) and
+// ffmpeg (mulmocast) are not listed here, so they always announce when missing.
+const ANNOUNCE_GATE: Record<string, (settings: AppSettings) => boolean> = {
+  whisper: (settings) => settings.voiceInput?.enabled === true,
+};
+
+/** Whether a missing optional dep should be surfaced at boot. Pure — the gate for
+ *  an opt-in dep reads the settings flag for its feature; non-gated deps always
+ *  announce. */
+export function shouldAnnounceDep(depId: string, settings: AppSettings): boolean {
+  const gate = ANNOUNCE_GATE[depId];
+  return gate ? gate(settings) : true;
 }
 
 // Pure payload builder, exposed for unit tests. `not-on-path` →
@@ -41,11 +58,12 @@ export function buildOptionalDepNotification(dep: OptionalDep, status: DepStatus
   };
 }
 
-export async function announceOptionalDeps(): Promise<void> {
+export async function announceOptionalDeps(settings: AppSettings): Promise<void> {
   const statuses = await probeOptionalDeps();
   for (const dep of optionalDeps()) {
     const status = statuses[dep.id];
     if (!status || status.available) continue;
+    if (!shouldAnnounceDep(dep.id, settings)) continue;
     const affectedPlugins = pluginsRequiring(dep.id);
     log.warn("deps", `optional dependency '${dep.command}' unavailable — ${dep.enables} degraded`, {
       depId: dep.id,

--- a/server/system/optionalDeps.ts
+++ b/server/system/optionalDeps.ts
@@ -12,7 +12,9 @@ import { isDockerLive } from "./docker.js";
 
 /** A single optional host dependency the app can run without. */
 export interface OptionalDep {
-  /** Stable id used by `depStatus()` lookups and notification ids. */
+  /** Stable id used by `depStatus()` lookups and notification ids. Kept a plain
+   *  string — `probeOne` is a generic probe exercised with synthetic ids in the
+   *  unit tests, so narrowing this to the registry union would over-constrain it. */
   readonly id: string;
   /** Binary name passed to `which` for the default presence probe. */
   readonly command: string;

--- a/test/system/test_optionalDeps_degradation.ts
+++ b/test/system/test_optionalDeps_degradation.ts
@@ -21,11 +21,18 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Request, Response, Router } from "express";
 import mulmoScriptRouter from "../../server/api/routes/mulmo-script.js";
-import { announceOptionalDeps, buildOptionalDepNotification } from "../../server/system/announceOptionalDeps.js";
+import { announceOptionalDeps, buildOptionalDepNotification, shouldAnnounceDep } from "../../server/system/announceOptionalDeps.js";
 import { _resetOptionalDepsCacheForTest, _setOptionalDepsCacheForTest, type DepStatus, type OptionalDep } from "../../server/system/optionalDeps.js";
+import type { AppSettings } from "../../server/system/config.js";
 import { initNotifier, _setFilePathsForTesting } from "../../server/notifier/engine.js";
 import { log } from "../../server/system/logger/index.js";
 import { API_ROUTES } from "../../src/config/apiRoutes.js";
+
+const VOICE_OFF: AppSettings = { extraAllowedTools: [] };
+const VOICE_ON: AppSettings = { extraAllowedTools: [], voiceInput: { enabled: true } };
+const WHISPER_ABSENT: Record<string, DepStatus> = {
+  whisper: { id: "whisper", available: false, reason: "not-on-path" },
+};
 
 interface RouterInternals {
   stack: { route?: { path: string; stack: { handle: (req: Request, res: Response) => unknown }[] } }[];
@@ -141,7 +148,7 @@ describe("optional-deps: boot announcement", () => {
 
   it("warns under the 'deps' namespace and attributes presentMulmoScript when ffmpeg is absent", async () => {
     _setOptionalDepsCacheForTest(FFMPEG_ABSENT);
-    await announceOptionalDeps();
+    await announceOptionalDeps(VOICE_OFF);
     const depWarn = captured.find((entry) => entry.namespace === "deps");
     assert.ok(depWarn, "a 'deps' warn must be emitted for the missing dependency");
     const data = depWarn.data as { depId?: string; affectedPlugins?: string[] };
@@ -151,12 +158,43 @@ describe("optional-deps: boot announcement", () => {
 
   it("does not warn for ffmpeg when it is present", async () => {
     _setOptionalDepsCacheForTest(FFMPEG_PRESENT);
-    await announceOptionalDeps();
+    await announceOptionalDeps(VOICE_OFF);
     assert.equal(
       captured.find((entry) => entry.namespace === "deps"),
       undefined,
       "no 'deps' warn when the dependency is available",
     );
+  });
+
+  it("does NOT warn for a missing whisper-server when voice input is disabled", async () => {
+    _setOptionalDepsCacheForTest(WHISPER_ABSENT);
+    await announceOptionalDeps(VOICE_OFF);
+    assert.equal(
+      captured.find((entry) => entry.namespace === "deps"),
+      undefined,
+      "whisper is opt-in and off — a missing binary must stay silent",
+    );
+  });
+
+  it("DOES warn for a missing whisper-server once voice input is enabled", async () => {
+    _setOptionalDepsCacheForTest(WHISPER_ABSENT);
+    await announceOptionalDeps(VOICE_ON);
+    const depWarn = captured.find((entry) => entry.namespace === "deps");
+    assert.ok(depWarn, "with voice input on, a missing whisper-server must warn");
+    assert.equal((depWarn.data as { depId?: string }).depId, "whisper");
+  });
+});
+
+describe("shouldAnnounceDep (opt-in gate)", () => {
+  it("gates whisper on voiceInput.enabled", () => {
+    assert.equal(shouldAnnounceDep("whisper", VOICE_ON), true);
+    assert.equal(shouldAnnounceDep("whisper", VOICE_OFF), false);
+    assert.equal(shouldAnnounceDep("whisper", { extraAllowedTools: [], voiceInput: { enabled: false } }), false);
+  });
+
+  it("always announces non-opt-in deps (docker, ffmpeg)", () => {
+    assert.equal(shouldAnnounceDep("docker", VOICE_OFF), true);
+    assert.equal(shouldAnnounceDep("ffmpeg", VOICE_OFF), true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #2553. Voice input ships **off** (`settings.voiceInput.enabled` defaults false), but `announceOptionalDeps` warned (`log.warn` + a bell notification) for every missing optional binary at boot — including `whisper-server`. So a user who never uses voice input got, on every start:

```
[deps] optional dependency 'whisper-server' unavailable — voiceInput degraded
```

plus a "whisper-server not installed" bell notification. (No API key involved — it's the local whisper.cpp binary.)

## Fix

Only surface a missing optional dep when the feature it enables is actually wanted.

- New pure `shouldAnnounceDep(depId, settings)`: opt-in deps (currently just `whisper` → `voiceInput.enabled`) announce only when enabled; `docker` (sandbox) and `ffmpeg` (mulmocast) always announce.
- `announceOptionalDeps(settings)` now takes settings and `continue`s past a gated-off dep, suppressing **both** the log warn and the bell notification.
- Caller `server/index.ts` passes `loadSettings()`.

## Items to Confirm

- `docker` / `ffmpeg` still warn when missing (they back on-by-default features) — only `whisper` is gated. Confirm that's the desired scope (easy to add more opt-in gates later via `ANNOUNCE_GATE`).

## Tests

- Unit: `shouldAnnounceDep` — whisper gated on `voiceInput.enabled`; docker/ffmpeg always announce.
- Integration: with `whisper` absent in the probe seed, no `deps` warn when voice input is off; a `depId: "whisper"` warn once it's on.
- `yarn lint` (0 errors) / `typecheck` / `build` / test file (12 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate optional dependency warnings on user settings so whisper-server is only reported missing when voice input is enabled.

Bug Fixes:
- Suppress whisper-server missing dependency warnings and notifications when voice input is disabled.

Enhancements:
- Introduce a settings-aware shouldAnnounceDep helper to control which optional dependencies are announced.
- Pass application settings into announceOptionalDeps and its callers to support opt-in gating of dependency announcements.

Documentation:
- Add a planning note documenting the whisper optional dependency announcement gate change and its rationale.

Tests:
- Extend system tests to cover whisper-server announcement behavior based on voice input settings and the shouldAnnounceDep gating logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optional `whisper-server` warnings and notifications are now shown only when voice input is enabled.
  * Other relevant optional dependency warnings, such as `ffmpeg`, continue to be reported normally.
  * Startup diagnostics now consistently use the same settings when checking dependencies and preparing voice input.

* **Tests**
  * Added coverage for voice-input-enabled and disabled dependency announcement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->