### PR TITLE
docs: add setup troubleshooting guide (#2558)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,6 +55,8 @@ yarn dev
 
 Öffnen Sie [http://localhost:5173](http://localhost:5173). Architektur und Skripte siehe [`docs/developer.md`](docs/developer.md).
 
+> **UI wirkt kaputt oder ungestylt?** Icons als Wörter, `dist/*` mit 404, `401` nach einem Neustart — siehe [`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 ## Was kann man tun?
 
 | Bitten Sie Claude um...                                   | Was Sie erhalten                                      |
@@ -664,6 +666,7 @@ Die vollständige Dokumentation befindet sich unter [`docs/`](docs/README.md). H
 | [Bridge-Protokoll](docs/bridge-protocol.md)                 | Wire-Level-Spezifikation zum Schreiben neuer Messaging-Bridges          |
 | [Sandbox-Anmeldeinformationen](docs/sandbox-credentials.md) | Docker-Sandbox-Weiterleitung von Anmeldeinformationen (SSH, GitHub CLI) |
 | [Logging](docs/logging.md)                                  | Log-Level, Formate, Dateirotation                                       |
+| [Troubleshooting](docs/troubleshooting.md)                  | Setup-Probleme — kaputt wirkende UI, `dist/*`-404s, Windows/OneDrive, `401` nach Neustart, Boot-Warnungen |
 | [CHANGELOG](docs/CHANGELOG.md)                              | Release-Historie                                                        |
 
 ## Lizenz

--- a/README.es.md
+++ b/README.es.md
@@ -55,6 +55,8 @@ yarn dev
 
 Abre [http://localhost:5173](http://localhost:5173). Consulta [`docs/developer.md`](docs/developer.md) para la arquitectura y los scripts.
 
+> **¿La interfaz se ve rota o sin estilos?** Iconos mostrados como palabras, `404` en `dist/*`, `401` tras reiniciar — consulta [`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 ## ¿Qué puedes hacer?
 
 | Pídele a Claude...                          | Lo que obtienes                                             |
@@ -662,6 +664,7 @@ La documentación completa vive en [`docs/`](docs/README.md). Aquí están los p
 | [Bridge Protocol](docs/bridge-protocol.md)         | Especificación a nivel de cable para escribir nuevos puentes de mensajería |
 | [Sandbox Credentials](docs/sandbox-credentials.md) | Reenvío de credenciales del sandbox de Docker (SSH, CLI de GitHub)         |
 | [Logging](docs/logging.md)                         | Niveles de log, formatos, rotación de archivos                             |
+| [Troubleshooting](docs/troubleshooting.md)         | Problemas de instalación — interfaz rota, `404` en `dist/*`, Windows/OneDrive, `401` tras reiniciar, avisos de arranque |
 | [CHANGELOG](docs/CHANGELOG.md)                     | Historial de versiones                                                     |
 
 ## Licencia

--- a/README.fr.md
+++ b/README.fr.md
@@ -55,6 +55,8 @@ yarn dev
 
 Ouvrez [http://localhost:5173](http://localhost:5173). Voir [`docs/developer.md`](docs/developer.md) pour l'architecture et les scripts.
 
+> **L'interface paraît cassée ou sans style ?** Icônes affichées en toutes lettres, `404` sur `dist/*`, `401` après un redémarrage — voir [`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 ## Que pouvez-vous faire ?
 
 | Demandez à Claude de...                              | Ce que vous obtenez                                            |
@@ -663,6 +665,7 @@ La documentation complète se trouve dans [`docs/`](docs/README.md). Voici les p
 | [Bridge Protocol](docs/bridge-protocol.md)         | Spécification au niveau du fil pour écrire de nouveaux ponts de messagerie |
 | [Sandbox Credentials](docs/sandbox-credentials.md) | Transfert d'identifiants du bac à sable Docker (SSH, GitHub CLI)           |
 | [Logging](docs/logging.md)                         | Niveaux de log, formats, rotation des fichiers                             |
+| [Troubleshooting](docs/troubleshooting.md)         | Problèmes d'installation — interface cassée, `404` sur `dist/*`, Windows/OneDrive, `401` après redémarrage, avertissements au démarrage |
 | [CHANGELOG](docs/CHANGELOG.md)                     | Historique des versions                                                    |
 
 ## Licence

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,6 +55,8 @@ yarn dev
 
 [http://localhost:5173](http://localhost:5173) を開いてください。アーキテクチャやスクリプトの詳細は [`docs/developer.md`](docs/developer.md) を参照してください。
 
+> **UI が崩れる・スタイルが当たらない場合**: アイコンが文字で表示される、`dist/*` が 404、再起動後に `401` — [`docs/troubleshooting.md`](docs/troubleshooting.md) を参照してください。
+
 ## 何ができるの?
 
 | Claude にこう頼むと...                           | 得られるもの                                         |
@@ -681,6 +683,7 @@ Claude はチャット会話からユーザーの永続的な事実を自動的�
 | [Bridge Protocol](docs/bridge-protocol.md)         | 新しいメッセージングブリッジを書くためのワイヤーレベル仕様        |
 | [Sandbox Credentials](docs/sandbox-credentials.md) | Docker サンドボックスの資格情報フォワーディング (SSH、GitHub CLI) |
 | [Logging](docs/logging.md)                         | ログレベル、フォーマット、ファイルローテーション                  |
+| [Troubleshooting](docs/troubleshooting.md)         | セットアップの問題 — UI が崩れる、`dist/*` の 404、Windows/OneDrive、再起動後の `401`、起動時の警告 |
 | [CHANGELOG](docs/CHANGELOG.md)                     | リリース履歴                                                      |
 
 ## ライセンス

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,6 +55,8 @@ yarn dev
 
 [http://localhost:5173](http://localhost:5173) 을 여세요. 아키텍처와 스크립트 자세한 내용은 [`docs/developer.md`](docs/developer.md) 를 참고하세요.
 
+> **UI가 깨지거나 스타일이 적용되지 않나요?** 아이콘이 글자로 표시됨, `dist/*` 404, 재시작 후 `401` — [`docs/troubleshooting.md`](docs/troubleshooting.md) 를 참고하세요.
+
 ## 무엇을 할 수 있나요?
 
 | Claude에게 요청해 보세요...       | 결과물                                             |
@@ -667,6 +669,7 @@ Claude는 채팅 대화에서 지속적인 사용자 사실을 자동으로 추�
 | [Bridge 프로토콜](docs/bridge-protocol.md)        | 새 메시징 브릿지 작성을 위한 와이어 레벨 스펙    |
 | [샌드박스 자격 증명](docs/sandbox-credentials.md) | Docker 샌드박스 자격 증명 전달 (SSH, GitHub CLI) |
 | [로깅](docs/logging.md)                           | 로그 레벨, 형식, 파일 회전                       |
+| [문제 해결](docs/troubleshooting.md)              | 설치 문제 — UI 깨짐, `dist/*` 404, Windows/OneDrive, 재시작 후 `401`, 부팅 경고 |
 | [CHANGELOG](docs/CHANGELOG.md)                    | 릴리스 이력                                      |
 
 ## 라이선스

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ yarn dev
 
 Open [http://localhost:5173](http://localhost:5173). See [`docs/developer.md`](docs/developer.md) for architecture and scripts.
 
+> **UI looks broken or unstyled?** Icons showing as words, `dist/*` 404s, `401` after a restart — see [`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 ## What can you do?
 
 | Ask Claude to...                | What you get                                    |
@@ -735,6 +737,7 @@ Full documentation lives in [`docs/`](docs/README.md). Here are the key entry po
 | [Bridge Protocol](docs/bridge-protocol.md)                                           | Wire-level spec for writing new messaging bridges                                                                                                    |
 | [Sandbox Credentials](docs/sandbox-credentials.md)                                   | Docker sandbox credential forwarding (SSH, GitHub CLI)                                                                                               |
 | [Logging](docs/logging.md)                                                           | Log levels, formats, file rotation                                                                                                                   |
+| [Troubleshooting](docs/troubleshooting.md)                                           | Setup problems — broken-looking UI, `dist/*` 404s, Windows/OneDrive, `401` after restart, boot warnings                                               |
 | [CHANGELOG](docs/CHANGELOG.md)                                                       | Release history                                                                                                                                      |
 
 ## License

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -55,6 +55,8 @@ yarn dev
 
 Abra [http://localhost:5173](http://localhost:5173). Consulte [`docs/developer.md`](docs/developer.md) para arquitetura e scripts.
 
+> **A interface parece quebrada ou sem estilo?** Ícones exibidos como palavras, `404` em `dist/*`, `401` após reiniciar — consulte [`docs/troubleshooting.md`](docs/troubleshooting.md).
+
 ## O que você pode fazer?
 
 | Peça ao Claude para...                              | O que você recebe                                          |
@@ -666,6 +668,7 @@ A documentação completa está em [`docs/`](docs/README.md). Aqui estão os pri
 | [Bridge Protocol](docs/bridge-protocol.md)         | Especificação em nível de protocolo para escrever novos bridges de mensagens |
 | [Sandbox Credentials](docs/sandbox-credentials.md) | Encaminhamento de credenciais do sandbox Docker (SSH, GitHub CLI)            |
 | [Logging](docs/logging.md)                         | Níveis de log, formatos, rotação de arquivos                                 |
+| [Troubleshooting](docs/troubleshooting.md)         | Problemas de instalação — interface quebrada, `404` em `dist/*`, Windows/OneDrive, `401` após reiniciar, avisos de inicialização |
 | [CHANGELOG](docs/CHANGELOG.md)                     | Histórico de releases                                                        |
 
 ## Licença

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,6 +55,8 @@ yarn dev
 
 打开 [http://localhost:5173](http://localhost:5173)。架构和脚本细节请参见 [`docs/developer.md`](docs/developer.md)。
 
+> **界面显示错乱或没有样式？** 图标显示为文字、`dist/*` 返回 404、重启后出现 `401` — 请参见 [`docs/troubleshooting.md`](docs/troubleshooting.md)。
+
 ## 你可以做什么？
 
 | 让 Claude 做...      | 你将得到                                 |
@@ -663,6 +665,7 @@ Claude 会自动从聊天对话中提取持久的用户事实，并将其追加�
 | [桥接协议](docs/bridge-protocol.md)     | 编写新消息桥接的线级规范               |
 | [沙盒凭据](docs/sandbox-credentials.md) | Docker 沙盒凭据转发（SSH、GitHub CLI） |
 | [日志](docs/logging.md)                 | 日志级别、格式、文件轮替               |
+| [故障排查](docs/troubleshooting.md)     | 安装问题 — 界面错乱、`dist/*` 404、Windows/OneDrive、重启后 `401`、启动警告 |
 | [CHANGELOG](docs/CHANGELOG.md)          | 发布历史                               |
 
 ## 许可证

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ Code structure, APIs, and build instructions for the host itself. Plugin authors
 | [Claude ↔ Docker boundary](claude-docker-boundary.md) | English  | What runs in the container vs. on the host when `claude -p` fires — Bash/Read/Write are in the sandbox, MCP tool implementations are on the host through a stdio proxy |
 | [Windows-host filesystem bugs in Linux containers on GHA](windows-docker-ci.md) | English  | How to reproduce Windows-FS-into-Linux-container bugs (dangling NTFS junctions, …) on GitHub Actions using WSL2 + native `dockerd` — the approach `docker_sandbox_windows.yaml` takes |
 | [Manual Testing](manual-testing.md)           | English  | Manual test items not covered by E2E                                                                                                |
+| [Troubleshooting](troubleshooting.md)         | English  | Setup problems between `git clone` and a working UI — broken-looking UI, `dist/*` 404s, Windows/OneDrive, `401` after restart, boot warnings |
 
 ## Project
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -150,6 +150,7 @@ You never set these by hand; the server constructs them when spawning Claude ins
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `yarn dev`                        | Server (`:3001`) + Vite client (`:5173`) concurrently. The default.                                                                                                                                     |
 | `yarn dev:debug`                  | Same as `dev` but spawns the server with `--debug` (Node inspector ready).                                                                                                                              |
+| `yarn dev:full-build`             | Same as `dev` but rebuilds every workspace package unconditionally first. Use when a plugin's `dist/` is stale or half-written — `dev`'s mtime gate treats a partial `dist/` as fresh and skips it.      |
 | `yarn dev:client`                 | Vite client only — useful when you've already started the server elsewhere.                                                                                                                             |
 | `yarn dev:server` / `yarn server` | Express server only.                                                                                                                                                                                    |
 | `yarn server:debug`               | Server with `--debug` flag.                                                                                                                                                                             |
@@ -757,6 +758,8 @@ Aggregator collisions don't throw — they're filtered and reported. `server/plu
 ---
 
 ## Common gotchas
+
+> Setup-time symptoms (unstyled UI, `dist/*` 404s, Windows/OneDrive, `401` after a restart) live in [`troubleshooting.md`](troubleshooting.md).
 
 - **Playwright uses its own port `:45173`** (`dev:client:e2e` in `package.json` + `webServer` in `e2e/playwright.config.ts`), so it doesn't collide with a running `yarn dev` on `:5173`. `reuseExistingServer: true` is still on for that port — if a stale `vite` process from a different working tree is already serving `:45173`, Playwright will happily talk to _that_ one. Symptom: tests fail because UI changes "haven't landed". Kill the stray process: `lsof -i :45173 | grep LISTEN`.
 - **CSRF guard is strict.** `requireSameOrigin` (`server/api/csrfGuard.ts`) rejects state-changing requests from non-localhost origins. Requests with no `Origin` header (CLI tools, server-to-server) are allowed because the listener is bound to `127.0.0.1`. If you ever expose the listener publicly, tighten this middleware first.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,116 @@
+# Troubleshooting
+
+Things that go wrong between `git clone` / `npx mulmoclaude` and a working UI.
+
+For failures the **agent** hits while running tools (sandbox auth, plugin install, build ordering),
+see [`packages/core/assets/helps/error-recovery.md`](../packages/core/assets/helps/error-recovery.md) —
+Claude reads that file itself before asking you about a tool failure.
+
+---
+
+## Icons render as words and the layout overlaps
+
+**Symptom** — the app loads, but icon-only buttons show text (`send`, `star`, or a translated
+`送信`, `星`), nav labels are drawn twice on top of each other, and every icon row is far too wide.
+Plain-text areas (chat bubbles, prompt suggestions) look fine.
+
+**Cause** — browser auto-translation, not CSS. Material Icons / Material Symbols draw glyphs via
+**ligatures**: the element's text content _is_ the icon name. Chrome's "Translate this page" (and the
+Google Translate extension) rewrites those text nodes, the ligature no longer matches, and the icon
+name renders as literal text — which also inflates the width of every icon-only control. The
+translator additionally overlays translated spans on the original text, producing the doubled nav.
+
+**Fix** — address-bar translate icon → **Show original** / **Never translate this site**, or open the
+app in a window with the extension disabled.
+
+MulmoClaude ships its own UI in 8 locales, so page translation is never needed: set `VITE_LOCALE=ja`
+(or `zh` / `ko` / `es` / `pt-BR` / `fr` / `de`) in `.env` and restart `yarn dev`.
+
+---
+
+## Console shows `404` for `dist/style.css` or `dist/vue.js`
+
+Two unrelated sources — check the request path first.
+
+**`/api/plugins/runtime/<pkg>/<version>/dist/...`** — a _runtime-loaded_ plugin installed into the
+workspace (`~/mulmoclaude/plugins/`) whose files are missing or half-installed. Non-fatal: the loader
+logs and skips that plugin, the rest of the app is unaffected. Reinstall the plugin. See
+[`plugin-runtime.md`](plugin-runtime.md).
+
+**A workspace plugin package (`@mulmoclaude/<name>-plugin`)** — the in-repo packages under
+`packages/plugins/` have not been built. `yarn dev` does build them on a cold clone
+(`scripts/dev-build-if-needed.mjs`), so this should not happen after a clean `yarn install && yarn dev`.
+
+It happens when a build was **interrupted or failed halfway**. The freshness gate is mtime-based: it
+compares the newest file under `<pkg>/src` against the newest under `<pkg>/dist`, and a _partial_
+`dist/` looks fresher than the source — so the rebuild is skipped and the missing files stay missing.
+(A completely absent `dist/` is handled correctly; only a partial one fools the gate.)
+
+```bash
+yarn dev:full-build                            # unconditional package build, then server + Vite
+node scripts/dev-build-if-needed.mjs --force   # rebuild only, without starting anything
+```
+
+---
+
+## Windows: `'concurrently' is not recognized` although `yarn install` says "Already up-to-date"
+
+**Cause** — the repository sits inside a OneDrive-synced folder (e.g.
+`...\OneDrive\Documents\GitHub\mulmoclaude`). OneDrive Files On-Demand dehydrates
+`node_modules\.bin`, so the executables are listed but their contents are not on disk — yarn sees the
+packages as installed while the shims fail to run.
+
+**Fix** — move the clone outside OneDrive, then reinstall:
+
+```powershell
+# close VS Code and any running yarn processes first
+Move-Item "$env:USERPROFILE\OneDrive\Documents\GitHub\mulmoclaude" "$env:USERPROFILE\GitHub\mulmoclaude"
+cd "$env:USERPROFILE\GitHub\mulmoclaude"
+Remove-Item -Recurse -Force node_modules
+yarn install
+yarn dev:full-build
+```
+
+Right-click → **Always keep on this device** rehydrates the folder as a stopgap, but OneDrive can
+evict it again.
+
+---
+
+## `Couldn't find a package.json file in ...`
+
+You are in the **workspace**, not the source clone. Two different directories share the name:
+
+| Directory                                                | Contents                                                     | `package.json` |
+| -------------------------------------------------------- | ------------------------------------------------------------ | -------------- |
+| `~/mulmoclaude` (override: `MULMOCLAUDE_WORKSPACE_PATH`) | Data MulmoClaude creates — `config/`, `data/`, `artifacts/`, … | no             |
+| wherever you cloned the repo                              | `src/`, `server/`, `packages/`                                | yes            |
+
+Run every `yarn` command in the clone. Workspace layout: [`developer.md`](developer.md#workspace-layout-mulmoclaude).
+
+---
+
+## `401` on `/api/*` right after (re)starting the server
+
+The server writes a **fresh bearer token on every start** to `<workspace>/.session-token`, and the
+page picks it up when the HTML is served. A tab left open across a restart still holds the previous
+token.
+
+**Fix** — reload the tab (`Ctrl+Shift+R` / `Cmd+Shift+R`) once the server logs `listening`. To keep one
+token across restarts (long-running bridges, docker-compose), set `MULMOCLAUDE_AUTH_TOKEN`. Details:
+[`developer.md`](developer.md#auth-bearer-token-on-api).
+
+A brief `ECONNREFUSED` from Vite in the first second is expected — the client starts before Express
+finishes booting, and the proxy recovers on its own.
+
+---
+
+## Boot warnings that are not errors
+
+| Log                                                              | Meaning                              | Action (optional)                                     |
+| ---------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `GEMINI_API_KEY not set — image / audio / video generation ...`  | Media generation disabled            | Add `GEMINI_API_KEY=...` to `.env` and restart        |
+| `optional dependency 'ffmpeg' unavailable — mulmocast degraded`  | MulmoScript video rendering disabled | Install ffmpeg and put it on `PATH`                   |
+| `Docker not found — claude will run unrestricted`                | Sandbox disabled                     | Install Docker Desktop to enable it                   |
+| `optional dependency 'whisper-server' unavailable — voiceInput degraded` | Local voice input disabled   | Only announced when voice input is enabled in Settings |
+
+Registry: `server/system/optionalDeps.ts`.

--- a/plans/docs-2558-setup-troubleshooting.md
+++ b/plans/docs-2558-setup-troubleshooting.md
@@ -1,0 +1,53 @@
+# docs: setup troubleshooting guide (#2558)
+
+## Request
+
+Issue #2558 (from an external contributor, ex-PR #2552) proposes a Japanese troubleshooting
+doc for "the UI at `:5173` is completely unstyled right after `git clone && yarn dev`"
+on Windows 11 / Node 24 / yarn 1.22. Their stated root cause: plugin packages unbuilt →
+`dist/style.css` / `dist/vue.js` 404 → fix with `yarn dev:full-build`.
+
+## What was verified before writing
+
+Reading the actual code / the reporter's screenshots changed the diagnosis:
+
+1. **The screenshot's brokenness is browser auto-translation, not the plugin build.**
+   The "broken" screenshot shows icon-only buttons rendering the words 「星」「電球」「送信」
+   and doubled nav text. Material Icons / Material Symbols draw via **ligatures** — the
+   element's text content *is* the icon name (`send`, `star`). Chrome / Google Translate
+   rewrites those text nodes, the ligature stops matching, and every icon-only control
+   inflates to a word of text. The centre column (plain text prompt pills) is styled
+   correctly in the same screenshot, which rules out "CSS never loaded".
+   `grep` confirms no `translate="no"` / `notranslate` anywhere in `src/` or `index.html`.
+
+2. **`yarn dev` already builds workspace packages on cold start.** `scripts/dev-build-if-needed.mjs`
+   rebuilds when `<pkg>/dist` is missing. So "you must run `dev:full-build` after a clone"
+   is not true as a general rule — but the gate is **mtime-based**, so a *partial* `dist/`
+   (interrupted or failed build) reads as fresh and the rebuild is silently skipped. That
+   is the real trap, and `yarn dev:full-build` is the right escape hatch. `dev:full-build`
+   is currently documented nowhere.
+
+3. The remaining pitfalls in the proposal check out: OneDrive dehydrating `node_modules\.bin`,
+   confusing the workspace (`~/mulmoclaude`, no `package.json`) with the source clone, and the
+   per-start bearer token causing a 401 in a stale tab (`docs/developer.md#auth`).
+
+4. Boot WARNs were re-checked against `server/system/announceOptionalDeps.ts` on latest `main`
+   — whisper is now gated behind `voiceInput.enabled` (#2555), so the proposal's table was
+   already stale on that row.
+
+## Plan
+
+- Add `docs/troubleshooting.md` (English, source of truth) covering: auto-translation breaking
+  icon ligatures, `dist/*` 404s (runtime-plugin vs workspace-package, and the mtime-gate trap),
+  OneDrive on Windows, workspace-vs-source confusion, 401 after restart, and the boot WARNs
+  that are not errors.
+- Link it from `docs/README.md` (Developers table).
+- Link it from all 8 `README*.md`: one line under "Run from source" + a row in the
+  documentation table, translated per locale (i18n lockstep).
+
+## Out of scope (follow-up)
+
+Making the UI translation-proof is a code change, not a doc change: icon spans need
+`translate="no"` (or a shared `<MaterialIcon>` component that sets it). Filed as **#2561**
+— the app already ships 8 locales, so page translation should never be needed, but users
+will still trigger it accidentally.


### PR DESCRIPTION
## Summary

Adds `docs/troubleshooting.md` — the missing home for "I cloned it and the UI looks wrong" problems — and links it from `docs/README.md`, `docs/developer.md`, and all 8 READMEs.

Closes #2558. Docs only, no code changes.

Two of the reported root causes turned out to be wrong, and the doc reflects the corrected diagnosis:

1. **The unstyled-looking UI in #2558 is browser auto-translation, not a missing plugin build.** Material Icons draw via **ligatures** — the element's text content *is* the icon name (`send`, `lightbulb`, `forum`, `schedule`). A translator rewrites those text nodes, the ligature stops matching, and every icon-only control renders its name as a word and inflates. Decisive evidence: in the same screenshot the centre column (plain-text prompt pills) is styled correctly, which rules out "CSS never loaded". Making the app translation-proof is a code change, filed separately as **#2561**.
2. **`yarn dev` *does* build workspace packages on a cold clone** (`scripts/dev-build-if-needed.mjs`), so "run `dev:full-build` after cloning" is not a general rule. What the gate misses is a **partial `dist/`**: it compares the newest mtime under `<pkg>/src` against the newest under `<pkg>/dist`, so an interrupted or failed build reads as fresh and the rebuild is silently skipped. `yarn dev:full-build` is the correct escape hatch — and it was documented nowhere until now.

## Items to Confirm / Review

- **Is `docs/troubleshooting.md` the right home?** The contributor proposed `docs/troubleshooting-ja.md`. This PR writes English as the source of truth (matching `developer.md`, `logging.md`, …) and links it from all 8 READMEs with a translated one-liner. If a `-ja` companion is wanted, say so and I'll add it.
- **The `dev:full-build` row added to `docs/developer.md`'s script table** describes the mtime-gate behaviour. Worth a second pair of eyes that the description of `scripts/dev-build-if-needed.mjs` matches intent — the gate skipping a half-written `dist/` may be considered a bug worth fixing rather than documenting.
- **The OneDrive section is not first-hand reproduced.** It is based on the reporter's environment (Windows 11 / Node 24 / yarn 1.22) plus the known Files On-Demand behaviour of dehydrating `node_modules\.bin`. Plausible and actionable, but nobody on the team has reproduced it.
- **Boot-warning table** was re-checked against `server/system/announceOptionalDeps.ts` on current `main` — whisper is gated behind `voiceInput.enabled` since #2555, so it only announces when voice input is on. The reporter's original table was already stale on that row.
- Translated one-liners in the 7 non-English READMEs are machine-quality; native-speaker corrections welcome.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2558 中身見て。必要であればREADME等、必要なところに情報を追加する。
>
> PRつくって

## What's in the doc

| Section | Cause | Fix |
|---|---|---|
| Icons render as words, layout overlaps | Browser auto-translation breaking Material Icons ligatures | Never translate this site; use `VITE_LOCALE` — the app ships 8 locales |
| `404` on `dist/style.css` / `dist/vue.js` | Runtime-plugin assets missing (non-fatal) **or** a partial workspace-package `dist/` that fools the mtime gate | `yarn dev:full-build` / `node scripts/dev-build-if-needed.mjs --force` |
| `'concurrently' is not recognized` while yarn says "up to date" | OneDrive dehydrating `node_modules\.bin` | Move the clone outside OneDrive, reinstall |
| `Couldn't find a package.json file in ...` | Running yarn in the workspace (`~/mulmoclaude`) instead of the clone | Table distinguishing the two directories |
| `401` on `/api/*` after a restart | Fresh bearer token per server start; the open tab holds the old one | Reload the tab; `MULMOCLAUDE_AUTH_TOKEN` to pin |
| Boot warnings | `GEMINI_API_KEY` / ffmpeg / docker / whisper optional deps | Table of what each disables |

## Files

- `docs/troubleshooting.md` — new
- `docs/developer.md` — `yarn dev:full-build` row in the script table + pointer from Common gotchas
- `docs/README.md` — row in the Developers table
- `README.md` + 7 locale READMEs — one line under "Run from source" + a row in the documentation table
- `plans/docs-2558-setup-troubleshooting.md` — verification record

## Credit

Original report, investigation log, and screenshots by @makoto-kazguitar (#2558, ex-PR #2552). The screenshots are what made the translation diagnosis possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
