### PR TITLE
docs: mark the translation workaround as superseded by the fix

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,11 +20,13 @@ Google Translate extension) rewrites those text nodes, the ligature no longer ma
 name renders as literal text — which also inflates the width of every icon-only control. The
 translator additionally overlays translated spans on the original text, producing the doubled nav.
 
-**Fix** — address-bar translate icon → **Show original** / **Never translate this site**, or open the
-app in a window with the extension disabled.
+**Fix** — update. The app chrome now carries `translate="no"` (#2561), so translation leaves the
+icons alone; only agent / user content (chat replies, wiki pages, skill bodies) stays translatable.
+On an older build, turn translation off instead: address-bar translate icon → **Show original** /
+**Never translate this site**, or open the app in a window with the extension disabled.
 
-MulmoClaude ships its own UI in 8 locales, so page translation is never needed: set `VITE_LOCALE=ja`
-(or `zh` / `ko` / `es` / `pt-BR` / `fr` / `de`) in `.env` and restart `yarn dev`.
+MulmoClaude ships its own UI in 8 locales, so page translation is never needed for the chrome: set
+`VITE_LOCALE=ja` (or `zh` / `ko` / `es` / `pt-BR` / `fr` / `de`) in `.env` and restart `yarn dev`.
 
 ---
 

--- a/plans/fix-2561-icon-ligature-translate.md
+++ b/plans/fix-2561-icon-ligature-translate.md
@@ -67,8 +67,9 @@ subtree. Browser translation can't be driven from Playwright, so it's recorded i
 `docs/manual-testing.md` §9. If content stops being translatable, option B is the
 fallback.
 
-## Follow-up
+## Release drift
 
-`docs/troubleshooting.md` (PR #2562, not yet merged) tells users to turn
-translation off. Once both land, that entry should note the fix shipped and keep
-the workaround only for older versions.
+`packages/plugins/collection-plugin` was published as `1.0.2` in #2560, and this
+PR edits its source afterwards — so the package now differs from what shipped.
+Left for the next `/publish` run rather than bumped here, since the launcher's
+own release workflow owns that version.


### PR DESCRIPTION
## Summary

Docs-only reconciliation after #2562 and #2563 landed separately.

`docs/troubleshooting.md` (from #2562) tells users the fix for icons-rendered-as-words is "turn browser translation off". #2563 then made the chrome carry `translate="no"`, so that instruction is now only true for older builds. This updates the entry to say the fix shipped and keeps the workaround scoped to pre-fix versions.

Also records in the plan file the release drift #2563 created: `@mulmoclaude/collection-plugin` was published as `1.0.2` in #2560, and #2563 edited its source afterwards — so the package differs from what shipped and wants picking up on the next `/publish`.

## Items to Confirm / Review

- **The release-drift note is a note, not an action.** No version bump here — the `/publish` workflow owns that. Worth a look that this is the right call rather than bumping `collection-plugin` now.
- Wording only; no behaviour change.

## User Prompt

> PRで残っているの確認してマージしていって。

(#2562 and #2563 were both already merged by the time I checked; this is the leftover inconsistency between them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
