### PR TITLE
docs(changelog): record the browser-translation icon fix in 1.5.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,10 @@ Pinned shortcuts on the launcher are draggable, with the order persisted. The re
 
 Dragging files onto a folder row in the File Explorer saves them directly into that workspace folder, instead of forcing a drop into the current directory and a follow-up move.
 
+#### Browser page translation no longer breaks the UI (#2558, #2561, #2563)
+
+Material Icons draw their glyphs from **ligatures**, so an icon element's text content _is_ the icon name (`<span class="material-icons">send</span>`). Chrome's page translation rewrites those text nodes, the ligature stops matching, and every icon-only control renders its name as a literal word — inflating each button to the width of that word. Combined with the translator's overlay spans on the nav, the result reads as "the CSS never loaded", which is exactly how it kept getting reported. The app chrome now carries `translate="no"` — it already ships in 8 locales, so translating it was never the wanted behaviour — and agent / user content opts back in with `translate="yes"`. Body teleports render outside `#app` and so carry their own attribute, with a guard test to stop the next one silently reintroducing the bug. Setup problems of this shape also gained a home: `docs/troubleshooting.md` (#2562, #2565).
+
 #### Collections — related-collections pulldown, agent-sized schema docs, and clean deletion (#2249, #2251, #2428, #2550)
 
 The view header gains a pulldown to jump between collections that reference each other (#2251). `schemaDocs` is now sectioned so it fits inside the agent's result limit instead of being truncated mid-schema (#2249). Deleting a collection now also clears the state that outlived it: the Google Calendar sync token (keyed by `calendarId`, so a collection recreated on the same calendar used to resume from the deleted one's token and receive only the delta) and the feeds ingest cursor at `data/ingest-state/<slug>.json` (which lives in a shared directory outside every per-collection location, so a recreated collection inherited `lastFetchedAt` and sat waiting for an interval instead of fetching). Both presented identically to the user: recreate a collection, it stays empty.


### PR DESCRIPTION
## Summary

Three PRs merged to `main` after the 1.5.0 CHANGELOG section was written, so they ship in this release but were missing from its record. One of them is user-visible enough to deserve a highlight rather than a Fixes-line mention.

- **#2563** — Chrome's page translation rewrites Material Icons ligature text, so every icon-only control renders its name as a literal word and inflates to that word's width. Combined with the translator's nav overlays, it reads as "the CSS never loaded" — which is exactly how it kept being reported (#2558, #2561). Added as a `####` highlight.
- **#2562 / #2565** — `docs/troubleshooting.md`, noted in the same paragraph.

## Items to Confirm / Review

- **Highlight vs Fixes line.** I promoted #2563 to a highlight because it explains a whole class of "the UI is broken" reports, which is worth more to a reader than one clause in the Fixes paragraph. Downgrade it if that reads as too much space.
- **This is CHANGELOG-only** — no version change. `1.5.0` is already on `main` in both `package.json` and `packages/mulmoclaude/package.json`; the `v1.5.0` tag will point at whatever `main` is after this merges, which still has root at `1.5.0`.

## Why it wasn't caught earlier

The 1.5.0 section was generated from the 211 PRs merged between the `v1.4.0` tag and the moment the release branch was cut. #2562, #2563 and #2565 landed in the window between cutting that branch and merging it — a gap the release flow doesn't currently check for. Worth folding a "re-check `git log <branch-point>..main` before tagging" step into `/publish-mulmoclaude` §9a if this recurs.

## User Prompt

- CHANGELOG は多いので、最初にサマリーを書こう。release も
- (merge of #2567) マージしたよ

## Test plan

- `docs/CHANGELOG.md` renders — the new `####` sits inside the `## [1.5.0]` section, above the Collections highlight
- No version fields touched: `git diff --stat` is CHANGELOG-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser page translation no longer disrupts the interface or replace icons with their text names.
  * User and agent content remains eligible for translation while application controls stay visually consistent.

* **Documentation**
  * Added changelog details and troubleshooting guidance for translation-related display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->