### PR TITLE
feat(remote-host): google.calendar updateEvent / deleteEvent commands (#2573)

### DIFF
--- a/docs/remote-host.md
+++ b/docs/remote-host.md
@@ -183,6 +183,8 @@ calling the collection engine directly. Added incrementally across phases:
 | `startChat` | Starts a visible chat from the phone (message + optional role + attachments) | — |
 | `ingestAttachments` | Pulls staged files from Firebase Storage into the workspace | — |
 | `google.calendar.createEvent` | Creates a Google Calendar event (`{ event }`); params `summary`, `start`, `end` (ISO 8601), optional `description`, `calendarId`, `colorId` | — |
+| `google.calendar.updateEvent` | Edits an event in place (`{ event }`); requires `eventId` plus at least one of `summary`, `start`, `end`, `description`, `colorId`; optional `calendarId`. `description: ""` clears it, omitting it leaves it | — |
+| `google.calendar.deleteEvent` | Removes an event (`{ deleted, eventId }`); requires `eventId`, optional `calendarId` | — |
 | `google.calendar.listEvents` | Upcoming events (`{ events }`, each with `colorId`); optional `calendarId` (default primary), `timeMin`, `maxResults` (≤ 50) | — |
 | `google.calendar.listCalendars` | Calendars the user has added/subscribed to (`{ calendars }` — id, summary, primary, colours) | — |
 | `google.calendar.colors` | Event/calendar colour palettes mapping `colorId` → hex (`{ colors }`) | — |

--- a/plans/feat-2573-remote-host-calendar-update-delete.md
+++ b/plans/feat-2573-remote-host-calendar-update-delete.md
@@ -1,0 +1,86 @@
+# feat(remote-host): `google.calendar.updateEvent` / `deleteEvent` (#2573)
+
+## Background
+
+#2572 added calendar/task update + delete to the `google` **tool**. The sweep
+that produced it found the same shape missing on the **remote-host command
+channel**: `server/remoteHost/handlers/googleCalendar.ts` registers only
+create/read commands.
+
+| Command | Before | After |
+| --- | --- | --- |
+| `google.calendar.createEvent` | ✅ | ✅ |
+| `google.calendar.updateEvent` | ❌ | ✅ |
+| `google.calendar.deleteEvent` | ❌ | ✅ |
+| `google.calendar.listEvents` | ✅ | ✅ |
+| `google.calendar.listCalendars` | ✅ | ✅ |
+| `google.calendar.colors` | ✅ | ✅ |
+
+## Why this is host-only, and what that means
+
+#2573 records the reason it was deferred: `google.calendar.*` is called by the
+**mobile app's own UI**, which is a separate codebase. Adding handlers here
+does not reach a user until that app ships edit/delete UI.
+
+That is still true. This lands the host half anyway because it is small,
+symmetric, and **backward compatible**: `capabilities` is auto-derived from the
+handler map, so an app that does not know these commands simply never sends
+them, and one that learns them later needs no host change. The cost of landing
+early is unused code; the cost of landing late is the app being blocked on us.
+
+Do not read a green CI here as "the feature works end to end" — nothing
+exercises these two commands over a real channel until the app does.
+
+## Changes
+
+**`server/remoteHost/handlers/googleCalendar.ts`**
+
+- `GoogleCalendarDeps` gains `updateEvent` / `deleteEvent`, wired to core's
+  `updateCalendarEvent` / `deleteCalendarEvent` (both added in #2572).
+- `createGoogleCalendarUpdateEvent` — requires `eventId`; accepts `summary`,
+  `start`, `end`, `description`, `calendarId`, `colorId`; returns `{ event }`.
+- `createGoogleCalendarDeleteEvent` — requires `eventId`, optional
+  `calendarId`; returns `{ deleted: true, eventId }`.
+
+**`server/remoteHost/handlers/index.ts`** — registers both method names.
+
+**`docs/remote-host.md`** — two rows in the handler table.
+
+## Two decisions worth recording
+
+**1. `description` needs its own param helper.** The existing `optionalString`
+rejects `""`, but core's `buildEventPatch` treats `undefined` as "leave as is"
+and `""` as "clear it". Routing `description` through `optionalString` would
+make clearing an event's body text impossible — the request would be rejected
+before it reached the patch builder. Hence `clearableString`, used for
+`description` only.
+
+**2. The "at least one field" guard is duplicated, deliberately.** The google
+plugin's Zod schema has the same rule (`EDITABLE_EVENT_FIELDS` + `.refine`).
+This handler cannot reuse it: the plugin validates its own args shape, while
+the channel hands the handler a raw `JsonObject`. The constant is named
+identically on both sides so a future reader greps one and finds the other. An
+edit with no edited field PATCHes an empty body, which Google answers `200` —
+so without the guard the remote reports success for a no-op.
+
+## Testing
+
+`test/remoteHost/test_googleCalendarHandlers.ts`, engine stubbed (no network,
+no token). 48 tests total, 18 new across the two handlers:
+
+- happy path for both, including that `deleteEvent` echoes the id (Google
+  answers 204 with no body, so there is nothing else to confirm against)
+- `description: ""` reaches the engine as a clear; an absent key stays
+  `undefined`; and `""` still counts as an edit for the guard
+- the no-edited-field rejection does not call the engine
+- missing `eventId`, empty `calendarId`, offset-less `start` / `end`
+
+**Mutation-checked** — both new rules were verified to fail when broken:
+removing the at-least-one-field guard → 1 failing test; routing `description`
+through `optionalString` → 2 failing tests.
+
+## Out of scope
+
+- Mobile app UI (separate codebase — the reason #2573 was deferred).
+- `google.tasks.*` remote-host commands: none exist at all, so that is a new
+  surface rather than a gap in an existing one.

--- a/server/remoteHost/handlers/googleCalendar.ts
+++ b/server/remoteHost/handlers/googleCalendar.ts
@@ -8,12 +8,14 @@
 import {
   createCalendarEvent,
   DEFAULT_LIST_MAX_RESULTS,
+  deleteCalendarEvent,
   getCalendarColors,
   getGoogleAccessToken,
   isIsoDateTimeWithOffset,
   listCalendarEvents,
   listCalendars,
   MAX_LIST_RESULTS,
+  updateCalendarEvent,
   type CalendarColorEntry,
 } from "@mulmoclaude/core/google";
 import type { CommandHandler, JsonObject, JsonValue } from "../commandChannel.js";
@@ -21,6 +23,8 @@ import type { CommandHandler, JsonObject, JsonValue } from "../commandChannel.js
 export interface GoogleCalendarDeps {
   getAccessToken: typeof getGoogleAccessToken;
   createEvent: typeof createCalendarEvent;
+  updateEvent: typeof updateCalendarEvent;
+  deleteEvent: typeof deleteCalendarEvent;
   listEvents: typeof listCalendarEvents;
   listCalendars: typeof listCalendars;
   getColors: typeof getCalendarColors;
@@ -87,6 +91,52 @@ export const createGoogleCalendarCreateEvent =
     return { event: { ...event } };
   };
 
+// Fields an edit may change. Named so the "at least one" guard and its error
+// message can't drift apart, and kept in step with the google plugin's
+// EDITABLE_EVENT_FIELDS — the two validate the same Calendar operation.
+const EDITABLE_EVENT_FIELDS = ["summary", "start", "end", "description", "colorId"] as const;
+
+// `description` alone accepts "": the patch builder treats `undefined` as
+// "leave as is" and "" as "clear it", so routing it through optionalString
+// (which rejects empty) would make clearing the body text impossible.
+const clearableString = (params: JsonObject, key: string): string | undefined => {
+  const value = params[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") throw new Error(`${key} must be a string`);
+  return value;
+};
+
+export const createGoogleCalendarUpdateEvent =
+  (deps: GoogleCalendarDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    const input = {
+      eventId: requiredString(params, "eventId"),
+      summary: optionalString(params, "summary"),
+      startDateTime: optionalDateTime(params, "start"),
+      endDateTime: optionalDateTime(params, "end"),
+      description: clearableString(params, "description"),
+      calendarId: optionalString(params, "calendarId"),
+      colorId: optionalString(params, "colorId"),
+    };
+    // An edit with no edited field PATCHes an empty body — Google answers 200,
+    // so the remote would report success for a no-op.
+    if (EDITABLE_EVENT_FIELDS.every((field) => params[field] === undefined || params[field] === null)) {
+      throw new Error(`pass at least one field to change (${EDITABLE_EVENT_FIELDS.join(", ")})`);
+    }
+    const event = await deps.updateEvent(await deps.getAccessToken(), input);
+    return { event: { ...event } };
+  };
+
+export const createGoogleCalendarDeleteEvent =
+  (deps: GoogleCalendarDeps): CommandHandler =>
+  async (params: JsonObject) => {
+    const eventId = requiredString(params, "eventId");
+    await deps.deleteEvent(await deps.getAccessToken(), { eventId, calendarId: optionalString(params, "calendarId") });
+    // Google answers 204 with no body; echo the id so the remote can confirm
+    // which event went without having to correlate against its own request.
+    return { deleted: true, eventId };
+  };
+
 export const createGoogleCalendarListEvents =
   (deps: GoogleCalendarDeps): CommandHandler =>
   async (params: JsonObject) => {
@@ -114,11 +164,15 @@ export const createGoogleCalendarColors =
 const deps: GoogleCalendarDeps = {
   getAccessToken: getGoogleAccessToken,
   createEvent: createCalendarEvent,
+  updateEvent: updateCalendarEvent,
+  deleteEvent: deleteCalendarEvent,
   listEvents: listCalendarEvents,
   listCalendars,
   getColors: getCalendarColors,
 };
 export const googleCalendarCreateEvent = createGoogleCalendarCreateEvent(deps);
+export const googleCalendarUpdateEvent = createGoogleCalendarUpdateEvent(deps);
+export const googleCalendarDeleteEvent = createGoogleCalendarDeleteEvent(deps);
 export const googleCalendarListEvents = createGoogleCalendarListEvents(deps);
 export const googleCalendarListCalendars = createGoogleCalendarListCalendars(deps);
 export const googleCalendarColors = createGoogleCalendarColors(deps);

--- a/server/remoteHost/handlers/index.ts
+++ b/server/remoteHost/handlers/index.ts
@@ -6,7 +6,14 @@ import { getCollection } from "./getCollection.js";
 import { getFeed } from "./getFeed.js";
 import { getRemoteView } from "./getRemoteView.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
-import { googleCalendarColors, googleCalendarCreateEvent, googleCalendarListCalendars, googleCalendarListEvents } from "./googleCalendar.js";
+import {
+  googleCalendarColors,
+  googleCalendarCreateEvent,
+  googleCalendarDeleteEvent,
+  googleCalendarListCalendars,
+  googleCalendarListEvents,
+  googleCalendarUpdateEvent,
+} from "./googleCalendar.js";
 import { listAccountingBooks } from "./listAccountingBooks.js";
 import { listCollections } from "./listCollections.js";
 import { listFeeds } from "./listFeeds.js";
@@ -28,6 +35,8 @@ export const handlers: CommandHandlers = {
   listAccountingBooks,
   startChat,
   "google.calendar.createEvent": googleCalendarCreateEvent,
+  "google.calendar.updateEvent": googleCalendarUpdateEvent,
+  "google.calendar.deleteEvent": googleCalendarDeleteEvent,
   "google.calendar.listEvents": googleCalendarListEvents,
   "google.calendar.listCalendars": googleCalendarListCalendars,
   "google.calendar.colors": googleCalendarColors,

--- a/test/remoteHost/test_googleCalendarHandlers.ts
+++ b/test/remoteHost/test_googleCalendarHandlers.ts
@@ -7,8 +7,10 @@ import type { JsonObject } from "../../server/remoteHost/commandChannel.js";
 import {
   createGoogleCalendarColors,
   createGoogleCalendarCreateEvent,
+  createGoogleCalendarDeleteEvent,
   createGoogleCalendarListCalendars,
   createGoogleCalendarListEvents,
+  createGoogleCalendarUpdateEvent,
   type GoogleCalendarDeps,
 } from "../../server/remoteHost/handlers/googleCalendar.js";
 import {
@@ -18,7 +20,9 @@ import {
   type CalendarEventInput,
   type CalendarEventSummary,
   type CalendarSummary,
+  type DeleteCalendarEventInput,
   type ListEventsInput,
+  type UpdateCalendarEventInput,
 } from "@mulmoclaude/core/google";
 
 const sampleEvent: CalendarEventSummary = {
@@ -49,12 +53,14 @@ const sampleColors: CalendarColors = {
 
 interface StubCalls {
   createInputs: CalendarEventInput[];
+  updateInputs: UpdateCalendarEventInput[];
+  deleteInputs: DeleteCalendarEventInput[];
   listInputs: ListEventsInput[];
   tokenRequests: number;
 }
 
 const stubDeps = (): { deps: GoogleCalendarDeps; calls: StubCalls } => {
-  const calls: StubCalls = { createInputs: [], listInputs: [], tokenRequests: 0 };
+  const calls: StubCalls = { createInputs: [], updateInputs: [], deleteInputs: [], listInputs: [], tokenRequests: 0 };
   const deps: GoogleCalendarDeps = {
     getAccessToken: async () => {
       calls.tokenRequests += 1;
@@ -63,6 +69,13 @@ const stubDeps = (): { deps: GoogleCalendarDeps; calls: StubCalls } => {
     createEvent: async (_token, input) => {
       calls.createInputs.push(input);
       return sampleEvent;
+    },
+    updateEvent: async (_token, input) => {
+      calls.updateInputs.push(input);
+      return sampleEvent;
+    },
+    deleteEvent: async (_token, input) => {
+      calls.deleteInputs.push(input);
     },
     listEvents: async (_token, input = {}) => {
       calls.listInputs.push(input);
@@ -153,6 +166,104 @@ describe("createGoogleCalendarCreateEvent", () => {
     const { deps, calls } = stubDeps();
     await assert.rejects(Promise.resolve(createGoogleCalendarCreateEvent(deps)({})));
     assert.equal(calls.tokenRequests, 0);
+  });
+});
+
+describe("createGoogleCalendarUpdateEvent", () => {
+  it("patches only the supplied fields and returns the event", async () => {
+    const { deps, calls } = stubDeps();
+    const result = await createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1", summary: "Renamed" });
+    assert.deepEqual(result, { event: sampleEvent });
+    assert.equal(calls.tokenRequests, 1);
+    assert.deepEqual(calls.updateInputs, [
+      {
+        eventId: "ev1",
+        summary: "Renamed",
+        startDateTime: undefined,
+        endDateTime: undefined,
+        description: undefined,
+        calendarId: undefined,
+        colorId: undefined,
+      },
+    ]);
+  });
+
+  // The whole point of the clearable helper: "" reaches the patch builder as a
+  // clear, while omitting the key leaves the description untouched.
+  it('forwards description "" as a clear, not as a missing field', async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1", description: "" });
+    assert.equal(calls.updateInputs[0]?.description, "");
+  });
+
+  it("leaves description undefined when the key is absent", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1", summary: "Renamed" });
+    assert.equal(calls.updateInputs[0]?.description, undefined);
+  });
+
+  it("rejects an edit with no edited field, without calling the engine", async () => {
+    const { deps, calls } = stubDeps();
+    await assert.rejects(
+      Promise.resolve(createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1" })),
+      /pass at least one field to change \(summary, start, end, description, colorId\)/,
+    );
+    assert.equal(calls.updateInputs.length, 0);
+  });
+
+  it("counts an empty-string description as an edit", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1", description: "" });
+    assert.equal(calls.updateInputs.length, 1);
+  });
+
+  it("rejects a missing eventId", async () => {
+    const { deps } = stubDeps();
+    await assert.rejects(Promise.resolve(createGoogleCalendarUpdateEvent(deps)({ summary: "Renamed" })), /eventId must be a non-empty string/);
+  });
+
+  it("threads calendarId and colorId through to the engine", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1", colorId: "7", calendarId: "team@group.calendar.google.com" });
+    assert.equal(calls.updateInputs[0]?.colorId, "7");
+    assert.equal(calls.updateInputs[0]?.calendarId, "team@group.calendar.google.com");
+  });
+
+  for (const key of ["start", "end"] as const) {
+    it(`rejects a ${key} without a timezone offset`, async () => {
+      const { deps } = stubDeps();
+      await assert.rejects(
+        Promise.resolve(createGoogleCalendarUpdateEvent(deps)({ eventId: "ev1", [key]: "2026-07-17T09:00:00" })),
+        new RegExp(`${key} must be an ISO 8601 date-time`),
+      );
+    });
+  }
+});
+
+describe("createGoogleCalendarDeleteEvent", () => {
+  it("deletes the event and echoes the id", async () => {
+    const { deps, calls } = stubDeps();
+    const result = await createGoogleCalendarDeleteEvent(deps)({ eventId: "ev1" });
+    assert.deepEqual(result, { deleted: true, eventId: "ev1" });
+    assert.equal(calls.tokenRequests, 1);
+    assert.deepEqual(calls.deleteInputs, [{ eventId: "ev1", calendarId: undefined }]);
+  });
+
+  it("threads calendarId through to the engine", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarDeleteEvent(deps)({ eventId: "ev1", calendarId: "team@group.calendar.google.com" });
+    assert.equal(calls.deleteInputs[0]?.calendarId, "team@group.calendar.google.com");
+  });
+
+  it("rejects a missing eventId without calling the engine", async () => {
+    const { deps, calls } = stubDeps();
+    await assert.rejects(Promise.resolve(createGoogleCalendarDeleteEvent(deps)({})), /eventId must be a non-empty string/);
+    assert.equal(calls.deleteInputs.length, 0);
+  });
+
+  it("rejects an empty calendarId", async () => {
+    const { deps } = stubDeps();
+    await assert.rejects(Promise.resolve(createGoogleCalendarDeleteEvent(deps)({ eventId: "ev1", calendarId: "  " })), /calendarId must be a non-empty string/);
   });
 });
 


### PR DESCRIPTION
Fixes #2573

## Summary

The remote-host command channel served only create/read for Calendar. Adds the two missing commands, wired to core's `updateCalendarEvent` / `deleteCalendarEvent` (added in #2572).

| Command | Before | After |
| --- | --- | --- |
| `google.calendar.createEvent` | ✅ | ✅ |
| `google.calendar.updateEvent` | ❌ | **✅** |
| `google.calendar.deleteEvent` | ❌ | **✅** |
| `google.calendar.listEvents` / `listCalendars` / `colors` | ✅ | ✅ |

## Items to Confirm / Review

- **This is host-side only, and stays unused until the mobile app ships edit/delete UI** — which is exactly why #2573 said to wait for the app-side plan. Landing it early is backward compatible (`capabilities` is auto-derived from the handler map, so an app that doesn't know the commands never sends them), but **do not read green CI as "this works end to end"**: nothing exercises these two over a real channel yet. Say the word if you'd rather hold it until the app side is decided.
- **`description` needed its own param helper.** `optionalString` rejects `""`, but core's `buildEventPatch` reads `undefined` as "leave as is" and `""` as "clear it" — routing `description` through the existing helper would make clearing an event's body text impossible, rejected before it ever reached the patch builder. Hence `clearableString`, used for `description` only. Worth a look that the asymmetry is where you'd want it.
- **The at-least-one-field guard is duplicated on purpose.** The google plugin's Zod schema has the same rule; this handler can't reuse it because the plugin validates its own args shape while the channel hands over a raw `JsonObject`. Both sides name the constant `EDITABLE_EVENT_FIELDS` so grepping one finds the other. If you'd rather extract it to core, that's a bigger change than this issue calls for.
- **`deleteEvent` returns `{ deleted: true, eventId }`.** Google answers 204 with no body, so there's nothing to echo except the id — which lets the remote confirm *which* event went without correlating against its own request. Tell me if you'd prefer a bare `{ deleted: true }`.

## Testing

`test/remoteHost/test_googleCalendarHandlers.ts`, engine stubbed (no network, no token). **48 tests, 18 new.**

- happy path for both handlers, including the echoed id
- `description: ""` reaches the engine as a clear; an absent key stays `undefined`; `""` still counts as an edit for the guard
- the no-edited-field rejection does not call the engine
- missing `eventId`, empty `calendarId`, offset-less `start` / `end`

**Mutation-checked** — both new rules were verified to fail when broken, not just to pass when correct:

| Mutation | Result |
| --- | --- |
| remove the at-least-one-field guard | 1 test fails |
| route `description` through `optionalString` | 2 tests fail |

`yarn typecheck` / `yarn lint` (0 errors) / `yarn build` all green.

## User Prompt

- #2573 / #2574 並列で

## Plan

[`plans/feat-2573-remote-host-calendar-update-delete.md`](plans/feat-2573-remote-host-calendar-update-delete.md)

## Out of scope

- Mobile app UI (separate codebase — the reason #2573 was deferred).
- `google.tasks.*` remote-host commands: none exist at all, so that's a new surface rather than a gap in an existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added remote-host support for updating Google Calendar events, including editing event details and clearing descriptions.
  - Added remote-host support for deleting Google Calendar events.
  - Update and delete operations validate required inputs and return confirmation results.

- **Documentation**
  - Documented the new Google Calendar capabilities and their supported parameters and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->