### PR TITLE
docs(packages): give the published packages a README and npm links

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,49 @@
+# @mulmoclaude/core
+
+Shared server-side core for **MulmoClaude** and **MulmoTerminal** — the
+subsystems the two hosts always ship together, consolidated behind subpath
+exports so they cannot drift apart.
+
+Not a general-purpose library: it exists so one implementation of collections,
+wiki, feeds, Google integration, scheduling and the rest serves both hosts.
+Every host specific (paths, logging, notification transport, …) is injected
+rather than imported, which is what lets the same code run under either.
+
+## Subpath exports
+
+| Area | Entries |
+| --- | --- |
+| Collections | `./collection`, `./collection/server`, `./collection/paths`, `./collection/registry`, `./collection/registry/server`, `./collection-watchers` |
+| Knowledge | `./wiki`, `./wiki/server`, `./wiki/paths`, `./feeds`, `./feeds/server`, `./feeds/paths` |
+| Google | `./google` — OAuth (loopback + PKCE), token store, Calendar / Tasks / Drive REST |
+| Runtime | `./scheduler`, `./notifier`, `./skill-bridge`, `./file-change`, `./workspace-setup`, `./artifacts` |
+| Remote | `./remote-host`, `./remote-host/server`, `./remote-view` |
+| Voice | `./whisper`, `./whisper/client` |
+| Plugin support | `./plugin-vue`, `./plugin-vue/i18n` |
+| Utilities | `./utils`, `./files`, `./fetch` |
+
+**Server-only**, except the browser-safe entries: `./artifacts`,
+`./whisper/client`, `./workspace-setup/slug`, `./translation/client`,
+`./remote-view`, `./remote-host` and `./plugin-vue`.
+
+The package also ships `assets/helps/*` — the help documents the agent reads at
+runtime — which is why a change there alone still warrants a release.
+
+## About MulmoClaude and MulmoTerminal
+
+- **[MulmoClaude](https://github.com/receptron/mulmoclaude)** — an AI-native
+  application platform built on Claude Code. Chat summons the right GUI for each
+  task (documents, charts, forms, wikis, spreadsheets, 3D scenes), and
+  everything your assistant accumulates stays as plain files in your own
+  workspace, on your own machine.
+- **[MulmoTerminal](https://github.com/receptron/mulmoterminal)** — run a whole
+  team of coding agents from your browser. Many Claude Code / Codex sessions at
+  once in a grid, colour-coded so you see which are working, which need you and
+  which are done, plus git worktrees, one-click PRs and cost readouts. One `npx`
+  command, no Electron, no config.
+
+📖 **User guide**: <https://receptron.github.io/mulmoterminal/> (日本語 / English)
+
+## License
+
+MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,15 @@
   "name": "@mulmoclaude/core",
   "version": "1.4.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/mulmoclaude.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://receptron.github.io/mulmoterminal/",
+  "bugs": {
+    "url": "https://github.com/receptron/mulmoclaude/issues"
+  },
   "type": "module",
   "exports": {
     "./utils": {

--- a/packages/plugins/collection-plugin/README.md
+++ b/packages/plugins/collection-plugin/README.md
@@ -1,0 +1,48 @@
+# @mulmoclaude/collection-plugin
+
+The **Collections** plugin (`presentCollection`) for **MulmoClaude** and
+**MulmoTerminal** — the Vue surfaces for schema-driven data apps: the chat
+View / Preview, page embeds, table / kanban / calendar / day / backlinks views,
+the record modal, and i18n in 8 locales.
+
+A collection is an application described by a `schema.json`: fields, relations,
+computed values, action buttons and which views to offer. The agent authors that
+schema when you describe what you want — a restaurant list, an invoice tracker,
+a vocabulary deck — and the records are plain files in your workspace.
+
+The isomorphic engine and the node storage engine live in
+[`@mulmoclaude/core/collection`](https://www.npmjs.com/package/@mulmoclaude/core)
+and `@mulmoclaude/core/collection/server`; this package is the UI half.
+
+## Google Calendar sync
+
+A collection can declare a `googleCalendar` block and mirror one of the user's
+calendars. The host syncs on creation, hourly in the background, and on demand
+from the Sync button in the collection header — with no tool call and no tokens
+spent per refresh.
+
+## About MulmoClaude and MulmoTerminal
+
+- **[MulmoClaude](https://github.com/receptron/mulmoclaude)** — an AI-native
+  application platform built on Claude Code. Chat summons the right GUI for each
+  task (documents, charts, forms, wikis, spreadsheets, 3D scenes), and
+  everything your assistant accumulates stays as plain files in your own
+  workspace, on your own machine.
+- **[MulmoTerminal](https://github.com/receptron/mulmoterminal)** — run a whole
+  team of coding agents from your browser. Many Claude Code / Codex sessions at
+  once in a grid, colour-coded so you see which are working, which need you and
+  which are done, plus git worktrees, one-click PRs and cost readouts. One `npx`
+  command, no Electron, no config.
+
+📖 **User guide**: <https://receptron.github.io/mulmoterminal/> (日本語 / English)
+
+## Dev loop
+
+```bash
+yarn workspace @mulmoclaude/collection-plugin run build
+yarn workspace @mulmoclaude/collection-plugin run test
+```
+
+## License
+
+MIT

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -2,6 +2,15 @@
   "name": "@mulmoclaude/collection-plugin",
   "version": "1.0.2",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/mulmoclaude.git",
+    "directory": "packages/plugins/collection-plugin"
+  },
+  "homepage": "https://receptron.github.io/mulmoterminal/",
+  "bugs": {
+    "url": "https://github.com/receptron/mulmoclaude/issues"
+  },
   "type": "module",
   "main": "./dist/vue.js",
   "module": "./dist/vue.js",

--- a/packages/plugins/google-plugin/README.md
+++ b/packages/plugins/google-plugin/README.md
@@ -12,9 +12,17 @@ dispatch). Server-only — no Vue View.
   OAuth client secret Google requires and stores nothing; tokens stay on the
   user's machine. A `~/.secrets/client_secret_*.json` (advanced) keeps the
   whole flow local instead.
-- Kinds: `status`; Calendar (`calendarListEvents`, `calendarCreateEvent`);
-  Tasks (`taskListsList`, `tasksList`, `tasksCreate`, `tasksComplete`);
+- Kinds: `status`; Calendar (`calendarListCalendars`, `calendarColors`,
+  `calendarListEvents`, `calendarSync`, `calendarCreateEvent`,
+  `calendarUpdateEvent`, `calendarDeleteEvent`); Tasks (`taskListsList`,
+  `tasksList`, `tasksCreate`, `tasksUpdate`, `tasksComplete`, `tasksDelete`);
   Drive (`driveList`, `driveCreate`, `driveRead`).
+- Editing is a **patch**: omitted fields keep their value, and `""` clears a
+  description / notes. Deletes are irreversible, so the tool tells the agent to
+  confirm with the user first.
+- Date-times must carry a **timezone offset** (`2026-07-17T09:00:00+09:00`);
+  Calendar rejects date-only and offset-less values with an opaque 400, so the
+  schema rejects them first with an actionable message.
 - **Drive is `drive.file`-scoped** — the app only ever sees files it created,
   never the user's wider Drive. That's what keeps the scope non-sensitive.
 - Not linked yet? The tool's errors tell the LLM to guide the user to this
@@ -22,9 +30,28 @@ dispatch). Server-only — no Vue View.
   per host (MulmoClaude: Settings → Plugins → Google or `yarn google:auth`;
   MulmoTerminal: Settings → Google account or `npx mulmoterminal google login`).
 
+## About MulmoClaude and MulmoTerminal
+
+- **[MulmoClaude](https://github.com/receptron/mulmoclaude)** — an AI-native
+  application platform built on Claude Code. Chat summons the right GUI for each
+  task (documents, charts, forms, wikis, spreadsheets, 3D scenes), and
+  everything your assistant accumulates stays as plain files in your own
+  workspace, on your own machine.
+- **[MulmoTerminal](https://github.com/receptron/mulmoterminal)** — run a whole
+  team of coding agents from your browser. Many Claude Code / Codex sessions at
+  once in a grid, colour-coded so you see which are working, which need you and
+  which are done, plus git worktrees, one-click PRs and cost readouts. One `npx`
+  command, no Electron, no config.
+
+📖 **User guide**: <https://receptron.github.io/mulmoterminal/> (日本語 / English)
+
 ## Dev loop
 
 ```bash
 yarn workspace @mulmoclaude/google-plugin run build
 yarn workspace @mulmoclaude/google-plugin run test
 ```
+
+## License
+
+MIT

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@mulmoclaude/google-plugin",
   "version": "1.0.2",
-  "description": "Google integration tool for MulmoClaude — operates the user's locally linked Google account (Calendar now; Tasks / Drive ride the same grant later). Server-only; no Vue View.",
+  "description": "Google integration tool for MulmoClaude and MulmoTerminal — operates the user's locally linked Google account: Calendar (list, sync, create, update, delete), Tasks and Drive, as one kind-discriminated `google` tool. Server-only; no Vue View.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/mulmoclaude.git",
+    "directory": "packages/plugins/google-plugin"
+  },
+  "homepage": "https://receptron.github.io/mulmoterminal/",
+  "bugs": {
+    "url": "https://github.com/receptron/mulmoclaude/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "exports": {


### PR DESCRIPTION
## Summary

Prep for publishing `@mulmoclaude/core`, `@mulmoclaude/google-plugin` and `@mulmoclaude/collection-plugin`. Right now they land on npm with **no way back to the project**:

- `core` and `collection-plugin` have **no README at all**
- none of the three declares `repository`, `homepage` or `bugs`, so the npm sidebar shows no GitHub link and no pointer to the guide

Each README now says what the package is and links both hosts — [MulmoClaude](https://github.com/receptron/mulmoclaude) and [MulmoTerminal](https://github.com/receptron/mulmoterminal) — plus the user guide at <https://receptron.github.io/mulmoterminal/>. `repository` carries the monorepo `directory` so npm resolves to the right subtree.

## Staleness found while writing them

- **google-plugin's README listed 9 kinds.** There are 17 since #2572 — the whole update/delete half was missing. Also added the patch semantics and the timezone-offset requirement, since those are the two things a reader gets wrong first.
- **google-plugin's npm description** still said *"Calendar now; Tasks / Drive ride the same grant later"*. Both shipped a while ago.

## Items to Confirm / Review

- **Prose is the deliverable here** — these are the npm landing pages. Worth a read for tone and for anything overstated. The MulmoTerminal blurb is condensed from its own README.
- **Only these 3 of 53 packages get `repository` / `homepage` / `bugs`** (previously only the `mulmoclaude` launcher had `repository`). Scoped to what's being published now; a sweep across the rest is a reasonable follow-up if you want consistency.
- **`homepage` points at the MulmoTerminal guide** for all three, since that is the user-facing manual. If you'd rather it point at the mulmoclaude repo for the MulmoClaude-side packages, say so.
- **Verified the READMEs reach the tarball**: `files` is `["dist"]` / `["dist","assets"]`, which does *not* list README — but npm's default rules include it regardless. Confirmed per package with `npm pack --dry-run --json`, and `scripts/packages/check-readme-translations.mjs` is clean.

## User Prompt

> その公開するパッケージ、全部mulmoclaude, mulmoterminalのgithubへのリンク、紹介を追加と https://receptron.github.io/mulmoterminal/ のマニュアルへのリンクを追加して。

## Next

Once this merges, the publish itself follows: `core` 1.4.0 (already bumped), `google-plugin` 1.1.0, `collection-plugin` 1.1.0, each with a tag + GH release, then a sweep of consumer dep ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the shared core package, including available modules, browser-safe exports, help assets, usage guides, and licensing.
  * Added documentation for the Collections plugin, including supported views, calendar synchronization, development guidance, and licensing.
  * Expanded Google plugin documentation with supported Calendar, Tasks, and Drive tools, request rules, date-time requirements, and deletion safeguards.
* **Package Information**
  * Added repository, homepage, issue-reporting, and licensing metadata across published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->