### PR TITLE
test(diagnostics): pin the two shortenHome boundary asymmetries (#2571)

### DIFF
--- a/test/server/utils/test_diagnostics_report.ts
+++ b/test/server/utils/test_diagnostics_report.ts
@@ -117,6 +117,31 @@ describe("shortenHome", () => {
     assert.equal(shortenHome("Workspace: /home/alice/ws", "/home/alice"), "Workspace: ~/ws");
   });
 
+  it("treats a separator as an end boundary but never as a start one", () => {
+    // The asymmetry is deliberate and easy to undo: `/home/alice` + `/ws` is
+    // the home directory, but `x/` + `/home/alice` is not — a separator before
+    // the match means the home path is the tail of a longer one. Adding a
+    // separator to PATH_START_RE would look symmetrical and be wrong.
+    assert.equal(shortenHome("/home/alice/ws", "/home/alice"), "~/ws");
+    assert.equal(shortenHome("x//home/alice", "/home/alice"), "x//home/alice");
+  });
+
+  it("treats a closing bracket as an end boundary but never an opening one", () => {
+    // The mirror asymmetry, and the one a future "make the two lists match"
+    // cleanup would break: prose wraps a path as `(/home/alice)`, so an opener
+    // may START a path — but a directory can genuinely be named `alice(x)`, so
+    // an opener may never END one.
+    assert.equal(shortenHome("(/home/alice)", "/home/alice"), "(~)");
+    assert.equal(shortenHome("/home/alice(x)/ws", "/home/alice"), "/home/alice(x)/ws");
+  });
+
+  it("reads both boundaries from the input, not from its own partial output", () => {
+    // Once the first match becomes `~`, the characters around a later match no
+    // longer describe the input. `~/home/alice` is the right answer here: a
+    // directory literally named `home/alice` beneath the user's home.
+    assert.equal(shortenHome("/home/alice/home/alice", "/home/alice"), "~/home/alice");
+  });
+
   it("does not shorten siblings using punctuation that is legal in a directory name", () => {
     // The first fix classified path characters as `[\w.-]`, which mangled every
     // sibling built with anything else. Almost any byte is legal in a directory


### PR DESCRIPTION
## Summary

**Tests only — no source change.** The implementation merged in #2579 is correct; this stops a plausible cleanup from undoing it.

`shortenHome` uses deliberately *different* character sets for the two ends of a match, and the comments say why. But nothing failed if someone unified them, and both asymmetries look like oversights to a reader tidying up:

| | ends a path | starts a path |
|---|---|---|
| separator `/` `\` | ✅ `/home/alice` + `/ws` | ❌ `x/` + `/home/alice` is a different directory |
| `)` `]` `}` | ✅ | — |
| `(` `[` `{` | ❌ a directory may be named `alice(backup)` | ✅ prose wraps a path as `(/home/alice)` |

Three cases added:

1. **separator asymmetry** — `x//home/alice` stays put
2. **bracket asymmetry** — `(/home/alice)` → `(~)`, but `/home/alice(x)/ws` stays put
3. **boundaries come from the input, not the partial output** — `/home/alice/home/alice` → `~/home/alice`

## Items to Confirm / Review

- **Case 2 is the one I'd most want to exist.** "The left list has `([{` and the right list doesn't — surely that's a typo" is an easy conclusion to reach, and acting on it silently mangles any directory whose name contains a bracket. That is the failure mode this PR is for.
- **Case 3 is about the scan, not the character sets.** Reading boundaries from the rewritten output would classify a later match by the `~` that replaced an earlier one. The current code already reads from `text`; this pins it.
- **No implementation change is intended.** If any of these three fail on your branch, the implementation moved — not the tests.

## Mutation check

Each mutation is the edit a tidy-up would actually make, not an artificial break:

| Mutation | Result |
| --- | --- |
| add `isSeparator` to `startsHomePath` | 1 test fails |
| switch `endsHomePath` to `PATH_START_RE` | 3 tests fail |
| read `before` from the accumulated output instead of `text` | 4 tests fail |

Restored source verified clean (`git status` empty for `report.ts`) before committing.

## Background

Came out of running `/gh-review-loop` on #2579. Codex had flagged the missing left boundary; by the time I had a fix, the author had already landed the same one (`df4bd81f2`, iter-3) and the PR merged. I verified the merged implementation independently against 15 boundary cases — all correct, including ones I expected to find gaps in. These three were the only ones the suite didn't already pin.

## User Prompt

- (on the three unpinned edge cases) hai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tests to pin the intended boundary behavior of shortenHome around home path matches.

Tests:
- Add tests verifying separator is treated as an end boundary but not a start boundary in shortenHome.
- Add tests verifying closing brackets are valid end boundaries while opening brackets can start but not end paths.
- Add a test ensuring boundary detection in shortenHome is based on the original input text rather than its partially rewritten output.