### PR TITLE
fix: sanitise request-derived values reaching log.* (#2591)

### DIFF
--- a/server/api/routes/collections.ts
+++ b/server/api/routes/collections.ts
@@ -333,7 +333,7 @@ router.delete(API_ROUTES.collections.detail, async (req: Request<{ slug: string 
     log.info("collections", "collection deleted", { slug: result.slug, archivePath: result.archivePath });
     res.json({ deleted: true, slug: result.slug, archivePath: result.archivePath });
   } catch (err) {
-    log.warn("collections", "collection delete failed", { slug: req.params.slug, error: errorMessage(err) });
+    log.warn("collections", "collection delete failed", { slug: singleLineForLog(req.params.slug), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -407,7 +407,7 @@ router.put(API_ROUTES.collections.item, async (req: Request<{ slug: string; item
     log.info("collections", "item updated", { slug: collection.slug, itemId: result.itemId });
     res.json({ itemId: result.itemId, item: result.item });
   } catch (err) {
-    log.warn("collections", "item update failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+    log.warn("collections", "item update failed", { slug: collection.slug, itemId: singleLineForLog(req.params.itemId), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -429,7 +429,7 @@ router.delete(API_ROUTES.collections.item, async (req: Request<{ slug: string; i
     log.info("collections", "item deleted", { slug: collection.slug, itemId: result.itemId });
     res.json({ deleted: true, itemId: result.itemId });
   } catch (err) {
-    log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+    log.warn("collections", "item delete failed", { slug: collection.slug, itemId: singleLineForLog(req.params.itemId), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -635,7 +635,11 @@ router.post(API_ROUTES.collections.collectionAction, async (req: Request<{ slug:
     }
     await respondForActionKind(res, collection, action, seed);
   } catch (err) {
-    log.warn("collections", "collection action seed failed", { slug: collection.slug, actionId: req.params.actionId, error: errorMessage(err) });
+    log.warn("collections", "collection action seed failed", {
+      slug: collection.slug,
+      actionId: singleLineForLog(req.params.actionId),
+      error: errorMessage(err),
+    });
     serverError(res, errorMessage(err));
   }
 });
@@ -749,7 +753,7 @@ router.get(API_ROUTES.collections.viewFile, async (req: Request<{ slug: string }
     }
     res.type("text/html").send(html);
   } catch (err) {
-    log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });
+    log.warn("collections", "view-file read failed", { slug: singleLineForLog(req.params.slug), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -781,7 +785,7 @@ router.get(API_ROUTES.collections.remoteView, async (req: Request<{ slug: string
     }
     res.json({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
   } catch (err) {
-    log.warn("collections", "remote-view build failed", { slug: req.params.slug, error: errorMessage(err) });
+    log.warn("collections", "remote-view build failed", { slug: singleLineForLog(req.params.slug), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -817,10 +821,14 @@ router.post(API_ROUTES.collections.remoteViewMutate, async (req: Request<{ slug:
       sendMutateRemoteViewFailure(res, result, slug);
       return;
     }
-    log.info("collections", "remote-view mutate", { slug, viewId, op: result.op });
+    log.info("collections", "remote-view mutate", { slug: singleLineForLog(slug), viewId: singleLineForLog(viewId), op: result.op });
     res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
   } catch (err) {
-    log.warn("collections", "remote-view mutate failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
+    log.warn("collections", "remote-view mutate failed", {
+      slug: singleLineForLog(req.params.slug),
+      viewId: singleLineForLog(req.params.viewId),
+      error: errorMessage(err),
+    });
     serverError(res, errorMessage(err));
   }
 });
@@ -919,7 +927,7 @@ router.post(API_ROUTES.collections.viewToken, async (req: Request<{ slug: string
     }
     res.json({ token: minted.token, exp: minted.exp, dataUrl: API_ROUTES.collections.viewData.replace(":slug", slug), capabilities: granted });
   } catch (err) {
-    log.warn("collections", "view-token mint failed", { slug: req.params.slug, error: errorMessage(err) });
+    log.warn("collections", "view-token mint failed", { slug: singleLineForLog(req.params.slug), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -938,7 +946,7 @@ router.get(API_ROUTES.collections.viewData, viewDataCors, requireViewToken("read
     });
     sendToolResult(res, raw);
   } catch (err) {
-    log.warn("collections", "view-data read failed", { slug: req.params.slug, error: errorMessage(err) });
+    log.warn("collections", "view-data read failed", { slug: singleLineForLog(req.params.slug), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -1093,7 +1101,7 @@ router.put(API_ROUTES.collections.viewData, viewDataCors, requireViewToken("writ
     const raw = await manageCollection.handler({ action: "putItems", slug: req.params.slug, items: body.items, mode: body.mode });
     sendToolResult(res, raw);
   } catch (err) {
-    log.warn("collections", "view-data write failed", { slug: req.params.slug, error: errorMessage(err) });
+    log.warn("collections", "view-data write failed", { slug: singleLineForLog(req.params.slug), error: errorMessage(err) });
     serverError(res, errorMessage(err));
   }
 });
@@ -1190,7 +1198,11 @@ router.delete(API_ROUTES.collections.viewDelete, async (req: Request<{ slug: str
     log.info("collections", "custom view deleted", { slug: collection.slug, viewId: result.viewId });
     res.json({ deleted: true, viewId: result.viewId });
   } catch (err) {
-    log.warn("collections", "view delete failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
+    log.warn("collections", "view delete failed", {
+      slug: singleLineForLog(req.params.slug),
+      viewId: singleLineForLog(req.params.viewId),
+      error: errorMessage(err),
+    });
     serverError(res, errorMessage(err));
   }
 });

--- a/server/api/routes/runtime-plugin.ts
+++ b/server/api/routes/runtime-plugin.ts
@@ -42,6 +42,7 @@ import { isRecord } from "../../utils/types.js";
 import { resolveWithinRoot } from "../../utils/files/safe.js";
 import { readPluginAsset } from "../../utils/files/plugins-io.js";
 import { log } from "../../system/logger/index.js";
+import { singleLineForLog } from "../../utils/logPreview.js";
 
 const LOG_PREFIX = "api/plugins/runtime";
 
@@ -156,7 +157,7 @@ router.get(API_ROUTES.plugins.runtimeOauthCallback, async (req: Request<{ alias:
     const result = await plugin.execute({}, buildOauthCallbackArgs(req.query));
     sendOauthCallbackResult(res, result);
   } catch (err) {
-    log.error(LOG_PREFIX, "oauth callback dispatch threw", { alias, plugin: plugin.name, error: errorMessage(err) });
+    log.error(LOG_PREFIX, "oauth callback dispatch threw", { alias: singleLineForLog(alias), plugin: plugin.name, error: errorMessage(err) });
     res
       .status(500)
       .type("text/html")

--- a/server/api/routes/runtime-plugin.ts
+++ b/server/api/routes/runtime-plugin.ts
@@ -82,7 +82,7 @@ router.post(API_ROUTES.plugins.runtimeDispatch, async (req: Request<{ pkg: strin
     try {
       res.json(await builtin(args));
     } catch (err) {
-      log.error(LOG_PREFIX, "builtin execute failed", { pkg, error: errorMessage(err) });
+      log.error(LOG_PREFIX, "builtin execute failed", { pkg: singleLineForLog(pkg), error: errorMessage(err) });
       serverError(res, `plugin execute failed: ${errorMessage(err)}`);
     }
     return;
@@ -111,7 +111,7 @@ router.post(API_ROUTES.plugins.runtimeDispatch, async (req: Request<{ pkg: strin
     // spreads this into the toolResult event downstream.
     res.json(result);
   } catch (err) {
-    log.error(LOG_PREFIX, "execute failed", { pkg, error: errorMessage(err) });
+    log.error(LOG_PREFIX, "execute failed", { pkg: singleLineForLog(pkg), error: errorMessage(err) });
     serverError(res, `plugin execute failed: ${errorMessage(err)}`);
   }
 });
@@ -233,7 +233,12 @@ router.get(API_ROUTES.plugins.runtimeAsset, async (req: Request<{ pkg: string; v
     res.setHeader("Content-Type", contentType);
     res.send(data);
   } catch (err) {
-    log.error(LOG_PREFIX, "asset read failed", { pkg, version, subPath, error: errorMessage(err) });
+    log.error(LOG_PREFIX, "asset read failed", {
+      pkg: singleLineForLog(pkg),
+      version: singleLineForLog(version),
+      subPath: singleLineForLog(subPath),
+      error: errorMessage(err),
+    });
     serverError(res, "asset read failed");
   }
 });

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -18,6 +18,7 @@ import { readManifest, removeSessionFromIndex } from "../../workspace/chat-index
 import type { ChatIndexEntry } from "../../workspace/chat-index/types.js";
 import { markRead, getSession, evictSession, publishSessionsChanged } from "../../events/session-store/index.js";
 import { notFound, type ApiResponse, type ErrorBody } from "../../utils/httpError.js";
+import { singleLineForLog } from "../../utils/logPreview.js";
 import { createStampedCache } from "../../utils/stampedCache.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
@@ -358,23 +359,24 @@ async function parseSessionEntry(line: string): Promise<unknown> {
 
 router.get(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res: ApiResponse<unknown[]>) => {
   const { id: sessionId } = req.params;
+  const sessionIdForLog = singleLineForLog(sessionId);
   const chatDir = WORKSPACE_PATHS.chat;
-  log.info("sessions", "detail: start", { sessionId });
+  log.info("sessions", "detail: start", { sessionId: sessionIdForLog });
   try {
     const meta = await readSessionMeta(chatDir, sessionId);
     const content = await readSessionJsonl(sessionId);
     if (!content) {
-      log.warn("sessions", "detail: not found", { sessionId });
+      log.warn("sessions", "detail: not found", { sessionId: sessionIdForLog });
       notFound(res, `Session ${sessionId} not found`);
       return;
     }
     const entries = (await Promise.all(content.split("\n").filter(Boolean).map(parseSessionEntry))).filter(Boolean);
     // Prepend metadata as session_meta entry for the frontend
     const result = meta ? [{ type: EVENT_TYPES.sessionMeta, ...meta }, ...entries] : entries;
-    log.info("sessions", "detail: ok", { sessionId, entries: result.length });
+    log.info("sessions", "detail: ok", { sessionId: sessionIdForLog, entries: result.length });
     res.json(result);
   } catch (err) {
-    log.error("sessions", "detail: threw", { sessionId, error: errorMessage(err) });
+    log.error("sessions", "detail: threw", { sessionId: sessionIdForLog, error: errorMessage(err) });
     notFound(res, "Session not found");
   }
 });
@@ -383,9 +385,9 @@ router.get(API_ROUTES.sessions.detail, async (req: Request<SessionIdParams>, res
 // Awaits persistence so the response only arrives after the disk write
 // completes — prevents the client from refetching stale hasUnread values.
 router.post(API_ROUTES.sessions.markRead, async (req: Request<SessionIdParams>, res: Response<{ ok: boolean }>) => {
-  log.info("sessions", "mark-read: start", { sessionId: req.params.id });
+  log.info("sessions", "mark-read: start", { sessionId: singleLineForLog(req.params.id) });
   await markRead(req.params.id);
-  log.info("sessions", "mark-read: ok", { sessionId: req.params.id });
+  log.info("sessions", "mark-read: ok", { sessionId: singleLineForLog(req.params.id) });
   res.json({ ok: true });
 });
 
@@ -397,14 +399,15 @@ router.post(
     "Failed to update bookmark",
     async (req, res) => {
       const { id: sessionId } = req.params;
+      const sessionIdForLog = singleLineForLog(sessionId);
       const bookmarked = Boolean(req.body?.bookmarked);
-      log.info("sessions", "bookmark: start", { sessionId, bookmarked });
+      log.info("sessions", "bookmark: start", { sessionId: sessionIdForLog, bookmarked });
       await updateIsBookmarked(sessionId, bookmarked);
       // Meta-mtime bumps on the write — cursor diff will pick up the
       // change on the next refetch — but every other tab also needs
       // to know to refetch right now.
       publishSessionsChanged();
-      log.info("sessions", "bookmark: ok", { sessionId, bookmarked });
+      log.info("sessions", "bookmark: ok", { sessionId: sessionIdForLog, bookmarked });
       res.json({ ok: true });
     },
   ),
@@ -432,16 +435,17 @@ router.delete(
   API_ROUTES.sessions.detail,
   asyncHandler<Request<SessionIdParams>, ApiResponse<{ ok: boolean }>>("sessions", "Failed to delete session", async (req, res) => {
     const { id: sessionId } = req.params;
-    log.info("sessions", "delete: start", { sessionId });
+    const sessionIdForLog = singleLineForLog(sessionId);
+    log.info("sessions", "delete: start", { sessionId: sessionIdForLog });
     if (getSession(sessionId)?.isRunning) {
-      log.warn("sessions", "delete: refused — session running", { sessionId });
+      log.warn("sessions", "delete: refused — session running", { sessionId: sessionIdForLog });
       res.status(409).json({ error: "Session is running. Cancel the run before deleting." });
       return;
     }
     await deleteSessionFiles(sessionId);
     await removeSessionFromIndex(workspacePath, sessionId);
     evictSession(sessionId);
-    log.info("sessions", "delete: ok", { sessionId });
+    log.info("sessions", "delete: ok", { sessionId: sessionIdForLog });
     res.json({ ok: true });
   }),
 );

--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -33,6 +33,7 @@ import { workspacePath } from "../../workspace/workspace.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { bindRoute } from "../../utils/router.js";
 import { log } from "../../system/logger/index.js";
+import { singleLineForLog } from "../../utils/logPreview.js";
 import { refreshScheduledSkills } from "../../workspace/skills/scheduler.js";
 import { logBackgroundError } from "../../utils/logBackgroundError.js";
 import { badRequest, conflict, forbidden, notFound } from "../../utils/httpError.js";
@@ -254,7 +255,7 @@ bindRoute(
     }
     const result = await installExternalRepo({ url, subpath, ref });
     if (result.kind === "installed") {
-      log.info("skills", "external install: ok", { repoId: result.detail.repoId, skillCount: result.detail.skillCount });
+      log.info("skills", "external install: ok", { repoId: singleLineForLog(result.detail.repoId), skillCount: result.detail.skillCount });
       res.json({
         installed: true,
         repoId: result.detail.repoId,
@@ -265,7 +266,7 @@ bindRoute(
       return;
     }
     if (result.kind === "no-skills") {
-      log.warn("skills", "external install: no skills discovered", { repoId: result.repoId });
+      log.warn("skills", "external install: no skills discovered", { repoId: singleLineForLog(result.repoId) });
       res.status(422).json({ error: `no SKILL.md found in repo (${result.repoId})` });
       return;
     }
@@ -280,7 +281,7 @@ bindRoute(
       return;
     }
     if (result.kind === "id-collision") {
-      log.warn("skills", "external install: repoId collision", { repoId: result.repoId, existingUrl: result.existingUrl });
+      log.warn("skills", "external install: repoId collision", { repoId: singleLineForLog(result.repoId), existingUrl: result.existingUrl });
       conflict(res, `repo id "${result.repoId}" is already in use by ${result.existingUrl}. Uninstall it first if you intend to replace it.`);
       return;
     }
@@ -293,16 +294,16 @@ bindRoute(router, API_ROUTES.skills.externalReposRemove, async (req: Request<{ r
   const { repoId } = req.params;
   const result = await uninstallExternalRepo(repoId);
   if (result.kind === "uninstalled") {
-    log.info("skills", "external uninstall: ok", { repoId: result.repoId });
+    log.info("skills", "external uninstall: ok", { repoId: singleLineForLog(result.repoId) });
     res.json({ uninstalled: true, repoId: result.repoId });
     return;
   }
   if (result.kind === "not-found") {
-    log.warn("skills", "external uninstall: not found", { repoId: result.repoId });
+    log.warn("skills", "external uninstall: not found", { repoId: singleLineForLog(result.repoId) });
     notFound(res, `external repo not installed: ${result.repoId}`);
     return;
   }
-  log.warn("skills", "external uninstall: invalid repoId", { repoId: result.repoId });
+  log.warn("skills", "external uninstall: invalid repoId", { repoId: singleLineForLog(result.repoId) });
   badRequest(res, `invalid repoId: ${result.repoId}`);
 });
 

--- a/server/api/routes/skills.ts
+++ b/server/api/routes/skills.ts
@@ -129,11 +129,11 @@ function previewResponse(result: CatalogDetailResult, source: string, ident: str
     return;
   }
   if (result.kind === "not-found") {
-    log.warn("skills", "catalog preview: not found", { source, ident });
+    log.warn("skills", "catalog preview: not found", { source, ident: singleLineForLog(ident) });
     notFound(res, `catalog entry not found: ${result.source}/${result.slug}`);
     return;
   }
-  log.warn("skills", "catalog preview: invalid slug", { ident });
+  log.warn("skills", "catalog preview: invalid slug", { ident: singleLineForLog(ident) });
   badRequest(res, `invalid slug: ${result.slug}`);
 }
 
@@ -165,11 +165,11 @@ function starResponse(result: StarResult, source: string, ident: string, res: Re
     return;
   }
   if (result.kind === "not-found") {
-    log.warn("skills", "catalog star: not found", { source, ident });
+    log.warn("skills", "catalog star: not found", { source, ident: singleLineForLog(ident) });
     notFound(res, `catalog entry not found: ${result.source}/${result.slug}`);
     return;
   }
-  log.warn("skills", "catalog star: invalid slug", { ident });
+  log.warn("skills", "catalog star: invalid slug", { ident: singleLineForLog(ident) });
   badRequest(res, `invalid slug: ${result.slug}`);
 }
 
@@ -271,12 +271,12 @@ bindRoute(
       return;
     }
     if (result.kind === "invalid-url") {
-      log.warn("skills", "external install: invalid url", { url: result.url });
+      log.warn("skills", "external install: invalid url", { url: singleLineForLog(result.url) });
       badRequest(res, "url must be a github.com HTTPS URL: https://github.com/<owner>/<repo>");
       return;
     }
     if (result.kind === "invalid-subpath") {
-      log.warn("skills", "external install: invalid subpath", { subpath: result.subpath });
+      log.warn("skills", "external install: invalid subpath", { subpath: singleLineForLog(result.subpath) });
       badRequest(res, "subpath must be a relative path with no '..', leading '/', or backslash segments");
       return;
     }
@@ -308,11 +308,11 @@ bindRoute(router, API_ROUTES.skills.externalReposRemove, async (req: Request<{ r
 });
 
 bindRoute(router, API_ROUTES.skills.detail, async (req: Request<{ name: string }>, res: Response<SkillDetailResponse | ErrorResponse>) => {
-  log.info("skills", "detail: start", { name: req.params.name });
+  log.info("skills", "detail: start", { name: singleLineForLog(req.params.name) });
   const skills = await discoverSkills({ workspaceRoot: workspacePath });
   const skill = skills.find((candidate) => candidate.name === req.params.name);
   if (!skill) {
-    log.warn("skills", "detail: not found", { name: req.params.name });
+    log.warn("skills", "detail: not found", { name: singleLineForLog(req.params.name) });
     notFound(res, `skill not found: ${req.params.name}`);
     return;
   }
@@ -321,19 +321,19 @@ bindRoute(router, API_ROUTES.skills.detail, async (req: Request<{ name: string }
 
 bindRoute(router, API_ROUTES.skills.create, async (req: Request<object, unknown, SaveSkillBody>, res: Response<SaveSkillResponse | ErrorResponse>) => {
   const { name, description, body } = req.body ?? {};
-  log.info("skills", "create: start", { name: typeof name === "string" ? name : undefined });
+  log.info("skills", "create: start", { name: typeof name === "string" ? singleLineForLog(name) : undefined });
   if (typeof name !== "string") {
     log.warn("skills", "create: invalid name");
     badRequest(res, "name must be a string");
     return;
   }
   if (typeof description !== "string") {
-    log.warn("skills", "create: invalid description", { name });
+    log.warn("skills", "create: invalid description", { name: singleLineForLog(name) });
     badRequest(res, "description must be a string");
     return;
   }
   if (typeof body !== "string") {
-    log.warn("skills", "create: invalid body", { name });
+    log.warn("skills", "create: invalid body", { name: singleLineForLog(name) });
     badRequest(res, "body must be a string");
     return;
   }
@@ -344,7 +344,7 @@ bindRoute(router, API_ROUTES.skills.create, async (req: Request<object, unknown,
     body,
   });
   if (result.kind === "saved") {
-    log.info("skills", "saved", { name });
+    log.info("skills", "saved", { name: singleLineForLog(name) });
     refreshScheduledSkills().catch(logBackgroundError("skills"));
     res.json({ saved: true, path: result.path });
     return;
@@ -363,7 +363,7 @@ bindRoute(router, API_ROUTES.skills.create, async (req: Request<object, unknown,
     return;
   }
   if (result.kind === "exists") {
-    log.warn("skills", "create: already exists", { name: result.name });
+    log.warn("skills", "create: already exists", { name: singleLineForLog(result.name) });
     conflict(res, `skill already exists: ${result.name}. Choose a different name or delete the existing one first.`);
   }
 });
@@ -384,14 +384,14 @@ bindRoute(
   async (req: Request<{ name: string }, unknown, UpdateSkillBody>, res: Response<UpdateSkillResponse | ErrorResponse>) => {
     const { name } = req.params;
     const { description, body } = req.body ?? {};
-    log.info("skills", "update: start", { name });
+    log.info("skills", "update: start", { name: singleLineForLog(name) });
     if (typeof description !== "string") {
-      log.warn("skills", "update: invalid description", { name });
+      log.warn("skills", "update: invalid description", { name: singleLineForLog(name) });
       badRequest(res, "description must be a string");
       return;
     }
     if (typeof body !== "string") {
-      log.warn("skills", "update: invalid body", { name });
+      log.warn("skills", "update: invalid body", { name: singleLineForLog(name) });
       badRequest(res, "body must be a string");
       return;
     }
@@ -402,7 +402,7 @@ bindRoute(
       body,
     });
     if (result.kind === "updated") {
-      log.info("skills", "updated", { name });
+      log.info("skills", "updated", { name: singleLineForLog(name) });
       refreshScheduledSkills().catch(logBackgroundError("skills"));
       res.json({ updated: true, path: result.path });
       return;
@@ -413,30 +413,30 @@ bindRoute(
       return;
     }
     if (result.kind === "missing-field") {
-      log.warn("skills", "update: missing field", { name, field: result.field });
+      log.warn("skills", "update: missing field", { name: singleLineForLog(name), field: result.field });
       badRequest(res, `${result.field} must be a non-empty string`);
       return;
     }
     if (result.kind === "user-scope") {
-      log.warn("skills", "update: user scope refused", { name: result.name });
+      log.warn("skills", "update: user scope refused", { name: singleLineForLog(result.name) });
       forbidden(res, `cannot update user-scope skill "${result.name}" — only project-scope skills are writable.`);
       return;
     }
     if (result.kind === "not-found") {
-      log.warn("skills", "update: not found", { name: result.name });
+      log.warn("skills", "update: not found", { name: singleLineForLog(result.name) });
       notFound(res, `skill not found: ${result.name}`);
     }
   },
 );
 
 bindRoute(router, API_ROUTES.skills.remove, async (req: Request<{ name: string }>, res: Response<DeleteSkillResponse | ErrorResponse>) => {
-  log.info("skills", "delete: start", { name: req.params.name });
+  log.info("skills", "delete: start", { name: singleLineForLog(req.params.name) });
   const result = await deleteProjectSkill({
     workspaceRoot: workspacePath,
     name: req.params.name,
   });
   if (result.kind === "deleted") {
-    log.info("skills", "deleted", { name: result.name });
+    log.info("skills", "deleted", { name: singleLineForLog(result.name) });
     refreshScheduledSkills().catch(logBackgroundError("skills"));
     res.json({ deleted: true, name: result.name });
     return;
@@ -447,7 +447,7 @@ bindRoute(router, API_ROUTES.skills.remove, async (req: Request<{ name: string }
     return;
   }
   if (result.kind === "user-scope") {
-    log.warn("skills", "delete: user scope refused", { name: result.name });
+    log.warn("skills", "delete: user scope refused", { name: singleLineForLog(result.name) });
     forbidden(
       res,
       `cannot delete user-scope skill "${result.name}" — only project-scope skills under ~/mulmoclaude/.claude/skills/ are writable from MulmoClaude.`,
@@ -455,7 +455,7 @@ bindRoute(router, API_ROUTES.skills.remove, async (req: Request<{ name: string }
     return;
   }
   if (result.kind === "not-found") {
-    log.warn("skills", "delete: not found", { name: result.name });
+    log.warn("skills", "delete: not found", { name: singleLineForLog(result.name) });
     notFound(res, `skill not found: ${result.name}`);
   }
 });

--- a/server/api/routes/wiki/history.ts
+++ b/server/api/routes/wiki/history.ts
@@ -24,6 +24,7 @@ import { readTextOrNull } from "../../../utils/files/safe.js";
 import { workspacePath } from "../../../workspace/workspace.js";
 import { pushToolResult } from "../../../events/session-store/index.js";
 import { log } from "../../../system/logger/index.js";
+import { singleLineForLog } from "../../../utils/logPreview.js";
 import { errorMessage } from "../../../utils/errors.js";
 import { isSafeSlug } from "@mulmoclaude/core/wiki";
 
@@ -113,7 +114,7 @@ router.post("/pages/:slug/history/:stamp/restore", async (req: Request<{ slug: s
     reason: restoreReason(stamp),
     forceSnapshot: true,
   });
-  log.info("wiki", "history restore", { slug, stamp });
+  log.info("wiki", "history restore", { slug: singleLineForLog(slug), stamp: singleLineForLog(stamp) });
   res.json({ slug, restored: { fromStamp: stamp } });
 });
 
@@ -186,7 +187,7 @@ async function publishPageEditToolResult(sessionId: string, slug: string, stamp:
       },
     });
     if (outcome.kind === "skipped") {
-      log.warn("wiki", "page-edit toolResult publish skipped", { slug, reason: outcome.reason });
+      log.warn("wiki", "page-edit toolResult publish skipped", { slug: singleLineForLog(slug), reason: outcome.reason });
     }
   } catch (err) {
     log.warn("wiki", "page-edit toolResult publish failed", {
@@ -223,7 +224,7 @@ async function handleInternalSnapshot(req: Request<object, unknown, InternalSnap
   // `writeWikiPage` path; reusing it keeps both paths aligned.
   const previousContent = await loadPreviousSnapshotContent(slug);
   if (previousContent !== null && !hasMeaningfulChange(previousContent, content)) {
-    log.info("wiki", "internal snapshot skipped — no meaningful change since previous snapshot", { slug });
+    log.info("wiki", "internal snapshot skipped — no meaningful change since previous snapshot", { slug: singleLineForLog(slug) });
     res.json({ slug, ok: true, skipped: "no-meaningful-change" });
     return;
   }
@@ -242,7 +243,7 @@ async function handleInternalSnapshot(req: Request<object, unknown, InternalSnap
     },
     { workspaceRoot: workspacePath },
   );
-  log.info("wiki", "internal snapshot recorded", { slug });
+  log.info("wiki", "internal snapshot recorded", { slug: singleLineForLog(slug) });
 
   if (typeof sessionId === "string" && sessionId.length > 0) {
     await publishPageEditToolResult(sessionId, slug, stamp);


### PR DESCRIPTION
Closes #2591.

## Summary

Completes the log-injection sweep that #2590 started. Every request-derived value reaching `log.*` in the route layer now goes through `singleLineForLog`, so CR/LF in a crafted slug or id cannot terminate a log line and write attacker-chosen text that reads as its own legitimate entry.

Files: `collections.ts`, `sessions.ts`, `skills.ts`, `wiki/history.ts`, `runtime-plugin.ts`.

## Items to Confirm / Review

1. **This is a classification, not a find-and-replace — that is the main thing to check.** `collections.ts` has 28 log sites mentioning `slug`; only 9 are request-derived. I deliberately left 16 alone (see table below). If you disagree with where I drew that line, that is the review conversation worth having.
2. **`skills.ts` is the subtle one.** It logs `result.repoId`, which does not *look* request-derived — until you notice the `external uninstall: invalid repoId` branch logs a value that just **failed** validation, i.e. the raw request string. I sanitised all six `repoId` sites for consistency; the install-path ones (`result.detail.repoId`, derived from the request URL) are likely already constrained, so those three are the most arguable.
3. **Raw values are preserved everywhere they matter.** Verified no `singleLineForLog` call escaped into a non-log position: lookup, dispatch, HTTP responses, error messages and `manageCollection.handler` arguments all still receive the raw value.

## Classification

| Source | Sites | Action | Why |
|---|---|---|---|
| `req.params.*`, and vars destructured from it | 9 | **Sanitised** | Raw request input — the actual vector |
| `collection.slug` | 15 | **Left alone** | Comes off a collection already loaded from disk, so it is constrained by what can be a directory name, not by the request |
| `result.slug` | 1 | **Left alone** | Echoes the loaded collection's slug |

Wrapping the host-internal ones would add noise without removing risk — the failure mode `CLAUDE.md` calls out for exactly this kind of grep-driven sweep ("normalise everything the grep matched" trades one bug for another).

## Why this needed a sweep rather than three more patches

During #2590, CodeRabbit reported this same rule **three separate times** — `itemId`/`actionId`, then `taskId`, then `reason`/`error` — because each round fixed the reported line instead of the rule. The counts in #2591 were taken up front so this round could be done once, in full.

The recurring trap is **derived fields**: sanitising the obvious identifier is not enough when a sibling field is *built from* the same untrusted input. `errorMessage(err)` where the error was constructed as `` `task not found: ${taskId}` `` leaks the identical CR/LF through a field that does not look request-derived at all.

## Testing

- `yarn format` / `lint` / `typecheck` / `build` / `test` all exit 0.
- `test/utils/test_logPreview.ts` (added in #2590) covers the helper itself, including the lone-`\r` case and a forged-entry payload; it was mutation-verified there.
- No behaviour change beyond log output. HTTP responses are byte-identical.

## User Prompt

> 他に似た問題ない？
>
> issue化して全部やろう

Filed as #2591–#2594 and being worked in priority order; this PR is #2591 (security, highest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden route-layer logging by ensuring all request-derived values passed to log.* in collections, sessions, skills, wiki history, and runtime plugin handlers are normalised to single-line strings to mitigate log injection risks without changing HTTP behaviour.

Bug Fixes:
- Sanitise request-derived identifiers and parameters before logging to prevent log injection via crafted input.

Enhancements:
- Standardise use of singleLineForLog across collections, sessions, skills, wiki history, and runtime plugin routes for any log fields sourced from HTTP requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved diagnostic logging across collections, sessions, skills, wiki history, and runtime plugin workflows.
  * Log entries now consistently format user-provided identifiers as clean, single-line values, improving readability and reducing malformed or unsafe log output.
* **Bug Fixes**
  * Prevented unexpected line breaks and potentially confusing content from appearing in operational logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->