### PR TITLE
refactor: replace 8 hand-rolled JsonObject casts in remoteHost handlers (#2592)

### DIFF
--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -31,7 +31,20 @@ export type JsonObject = Record<string, JsonValue>;
  *  Recursive on purpose: a top-level-only map would still leave nested
  *  interfaces (`{ shortcuts: Shortcut[] }`) unassignable, which is the case
  *  every handler here actually has. */
-export type Jsonify<T> = T extends JsonValue ? T : T extends (infer U)[] ? Jsonify<U>[] : T extends object ? { [K in keyof T]: Jsonify<T[K]> } : never;
+// The function branch must come BEFORE the object branch: a function IS an
+// object to TypeScript, so without it a function maps to `{}` and sails
+// through — the helper would accept a payload that serialises to nothing.
+// Verified: `toJsonObject({ callback: () => undefined })` compiled clean until
+// this branch existed (CodeRabbit, #2596).
+export type Jsonify<T> = T extends JsonValue
+  ? T
+  : T extends (...args: never[]) => unknown
+    ? never
+    : T extends (infer U)[]
+      ? Jsonify<U>[]
+      : T extends object
+        ? { [K in keyof T]: Jsonify<T[K]> }
+        : never;
 
 /** Widen a JSON-shaped handler payload to the channel's `JsonObject`.
  *

--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -20,6 +20,27 @@ import { CollectionReference, DocumentData, DocumentReference, Firestore, collec
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 export type JsonObject = Record<string, JsonValue>;
 
+/** Structural JSON view of `T`, recursively.
+ *
+ *  TypeScript gives an implicit index signature to type aliases and mapped
+ *  types but NOT to interfaces, so a payload assembled from domain interfaces
+ *  (`Shortcut`, `FeedSummary`, …) cannot satisfy `Record<string, JsonValue>`
+ *  structurally — even though it is plain JSON at runtime. Mapping over `T`
+ *  reconstructs it as an anonymous type, which does get that index signature.
+ *
+ *  Recursive on purpose: a top-level-only map would still leave nested
+ *  interfaces (`{ shortcuts: Shortcut[] }`) unassignable, which is the case
+ *  every handler here actually has. */
+export type Jsonify<T> = T extends JsonValue ? T : T extends (infer U)[] ? Jsonify<U>[] : T extends object ? { [K in keyof T]: Jsonify<T[K]> } : never;
+
+/** Widen a JSON-shaped handler payload to the channel's `JsonObject`.
+ *
+ *  Exists so the `Jsonify` reasoning above lives in ONE place. Before this,
+ *  eight remote-host handlers each carried their own `as unknown as JsonObject`
+ *  with the justification re-argued in eight slightly different comments —
+ *  which is how a rule stops being reviewable. */
+export const toJsonObject = <T extends object>(payload: Jsonify<T>): JsonObject => payload as JsonObject;
+
 // A channel routes commands to one specific host. Both sides agree on a
 // hardcoded hostId per use case (e.g. "mulmoclaude", "mulmoterminal"); there is
 // no discovery — the remote and host just share the id.

--- a/server/remoteHost/handlers/collectionPage.ts
+++ b/server/remoteHost/handlers/collectionPage.ts
@@ -20,8 +20,25 @@ export { clampLimit, clampOffset, readIdParam };
 export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec> }, items: unknown[]): DerivableRecord[] =>
   items.map((item) => deriveAll({ fields: schema.fields ?? {} }, item as DerivableRecord, {}));
 
-// Build the paginated result. `detail` (a CollectionDetail) and `items`
-// (CollectionItem[]) are plain JSON, but their interfaces lack an index
-// signature so they don't structurally match JsonValue — the cast is safe.
+/** Build the paginated result.
+ *
+ *  The one place in this directory that still asserts. `toJsonObject` cannot
+ *  serve it, and that is the honest answer rather than a gap in the helper:
+ *  `CollectionDetail` reaches `schema.spawn.set`, typed `Record<string,
+ *  unknown>`, so the payload genuinely CANNOT be proven JSON by the type
+ *  system. It is JSON at runtime because the schema loader only ever puts
+ *  JSON there — a fact about the loader, not something these types record.
+ *
+ *  So this assertion buys something real, unlike the seven it replaced (those
+ *  only worked around interfaces lacking an implicit index signature, which
+ *  `toJsonObject` handles). Tightening it further means giving `spawn.set` a
+ *  JSON-valued type at the schema layer; until then, the unchecked step is
+ *  confined here rather than spread across eight handlers. */
 export const pageResult = (detail: unknown, items: unknown[], offset: number, limit: number): JsonObject =>
-  ({ collection: detail, items: items.slice(offset, offset + limit), total: items.length, offset, limit }) as unknown as JsonObject;
+  ({
+    collection: detail,
+    items: items.slice(offset, offset + limit),
+    total: items.length,
+    offset,
+    limit,
+  }) as JsonObject;

--- a/server/remoteHost/handlers/collectionPage.ts
+++ b/server/remoteHost/handlers/collectionPage.ts
@@ -22,18 +22,14 @@ export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec
 
 /** Build the paginated result.
  *
- *  The one place in this directory that still asserts. `toJsonObject` cannot
- *  serve it, and that is the honest answer rather than a gap in the helper:
- *  `CollectionDetail` reaches `schema.spawn.set`, typed `Record<string,
- *  unknown>`, so the payload genuinely CANNOT be proven JSON by the type
- *  system. It is JSON at runtime because the schema loader only ever puts
- *  JSON there — a fact about the loader, not something these types record.
+ *  `toJsonObject` cannot serve this one. `CollectionDetail` reaches
+ *  `schema.spawn.set`, typed `Record<string, unknown>`, so the payload
+ *  genuinely CANNOT be proven JSON by the type system — it is JSON at runtime
+ *  because the schema loader only ever puts JSON there, a fact about the
+ *  loader that these types do not record.
  *
- *  So this assertion buys something real, unlike the seven it replaced (those
- *  only worked around interfaces lacking an implicit index signature, which
- *  `toJsonObject` handles). Tightening it further means giving `spawn.set` a
- *  JSON-valued type at the schema layer; until then, the unchecked step is
- *  confined here rather than spread across eight handlers. */
+ *  Removing this assertion means giving `spawn.set` a JSON-valued type at the
+ *  schema layer, not adjusting anything here. */
 export const pageResult = (detail: unknown, items: unknown[], offset: number, limit: number): JsonObject =>
   ({
     collection: detail,

--- a/server/remoteHost/handlers/getRemoteView.ts
+++ b/server/remoteHost/handlers/getRemoteView.ts
@@ -12,6 +12,7 @@
 import { readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { buildRemoteView, remoteViewFailureMessage } from "../../workspace/collections/remoteView.js";
+import { toJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface GetRemoteViewDeps {
@@ -30,9 +31,7 @@ export const createGetRemoteView =
     const result = await deps.buildRemoteView(collection, viewId, locale);
     if (result.kind !== "ok") throw new Error(remoteViewFailureMessage(result, slug));
     const { view, srcdoc, bytes } = result;
-    // Plain JSON, but the interface lacks an index signature — cast like the
-    // phase-2 handlers.
-    return { view, srcdoc, bytes } as unknown as JsonObject;
+    return toJsonObject({ view, srcdoc, bytes });
   };
 
 export const getRemoteView = createGetRemoteView({ loadCollection, buildRemoteView });

--- a/server/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/remoteHost/handlers/getRemoteViewItems.ts
@@ -30,8 +30,10 @@ export const createGetRemoteViewItems =
     if (!collection) throw new Error(`collection '${slug}' not found`);
     const result = await deps.remoteViewItems(collection, viewId, request);
     if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
-    // Plain JSON, but the interface lacks an index signature — cast like the
-    // phase-2/3 handlers.
+    // Not `toJsonObject`: `RemoteViewPage.items` is `RemoteViewItem[]`, whose
+    // values are `unknown`, so the payload cannot be PROVEN JSON — same
+    // irreducible gap as `pageResult` in collectionPage.ts, and for the same
+    // reason (record values are JSON by loader invariant, not by type).
     return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
   };
 

--- a/server/remoteHost/handlers/listAccountingBooks.ts
+++ b/server/remoteHost/handlers/listAccountingBooks.ts
@@ -22,10 +22,11 @@ export const createListAccountingBooks =
   // Takes no params (the `__` prefix marks it intentionally unused per lint).
   async (__params: JsonObject) => {
     const { books } = await deps.listBooks();
-    // { id, name } are always present on a BookSummary. The cast only satisfies
-    // the channel's structural JsonValue type, which the BookSummary interface
-    // (no index signature) can't match directly.
-    return { books: books.map((book) => ({ id: book.id, name: book.name })) } as unknown as JsonObject;
+    // No `toJsonObject` needed here, unlike the sibling handlers: the `.map`
+    // rebuilds each entry as an anonymous object literal, and those DO get
+    // TypeScript's implicit index signature. `BookSummary`'s own lack of one
+    // never reaches the return type.
+    return { books: books.map((book) => ({ id: book.id, name: book.name })) };
   };
 
 export const listAccountingBooks = createListAccountingBooks({ listBooks });

--- a/server/remoteHost/handlers/listCollections.ts
+++ b/server/remoteHost/handlers/listCollections.ts
@@ -12,6 +12,7 @@
 // Exposed as a factory (createListCollections) so the mapping is unit-testable
 // with discovery stubbed; the default export wires the real engine functions.
 import { discoverCollections, toSummary } from "../../workspace/collections/index.js";
+import { toJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface ListCollectionsDeps {
@@ -25,10 +26,7 @@ export const createListCollections =
   // `__` prefix marks it intentionally unused per the lint config).
   async (__params: JsonObject) => {
     const collections = (await deps.discover()).filter((collection) => collection.source !== "feed").map(deps.toSummary);
-    // CollectionSummary is plain JSON (slug/title/icon/source strings), so this
-    // is safe — the cast only satisfies the channel's structural JsonValue type,
-    // which an interface without an index signature can't match directly.
-    return { collections } as unknown as JsonObject;
+    return toJsonObject({ collections });
   };
 
 export const listCollections = createListCollections({ discover: discoverCollections, toSummary });

--- a/server/remoteHost/handlers/listFeeds.ts
+++ b/server/remoteHost/handlers/listFeeds.ts
@@ -6,6 +6,7 @@
 import { listFeeds as listFeedsRegistry, readFeedState } from "@mulmoclaude/core/feeds/server";
 import { buildFeedSummaries } from "../../workspace/feeds/summaries.js";
 import { workspacePath } from "../../workspace/workspace.js";
+import { toJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface ListFeedsDeps {
@@ -20,10 +21,7 @@ export const createListFeeds =
   async (__params: JsonObject) => {
     const feeds = await deps.listFeeds(deps.workspaceRoot);
     const summaries = await buildFeedSummaries(feeds, deps.readFeedState, deps.workspaceRoot);
-    // FeedSummary is plain JSON (strings + a nullable string), so this is safe —
-    // the cast only satisfies the channel's structural JsonValue type, which an
-    // interface without an index signature can't match directly.
-    return { feeds: summaries } as unknown as JsonObject;
+    return toJsonObject({ feeds: summaries });
   };
 
 export const listFeeds = createListFeeds({ listFeeds: listFeedsRegistry, readFeedState, workspaceRoot: workspacePath });

--- a/server/remoteHost/handlers/listShortcuts.ts
+++ b/server/remoteHost/handlers/listShortcuts.ts
@@ -4,6 +4,7 @@
 // GET /api/shortcuts → { shortcuts: Shortcut[] }. Read-only: editing the pin
 // list stays desktop-only.
 import { readShortcuts } from "../../utils/files/shortcuts-io.js";
+import { toJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface ListShortcutsDeps {
@@ -16,9 +17,7 @@ export const createListShortcuts =
   // prefix marks it intentionally unused per the lint config).
   async (__params: JsonObject) => {
     const shortcuts = await deps.read();
-    // Shortcut is plain JSON (string fields) but the interface lacks an index
-    // signature, so it doesn't structurally match JsonValue — cast is safe.
-    return { shortcuts } as unknown as JsonObject;
+    return toJsonObject({ shortcuts });
   };
 
 export const listShortcuts = createListShortcuts({ read: readShortcuts });

--- a/server/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/remoteHost/handlers/mutateRemoteView.ts
@@ -14,6 +14,7 @@
 import { normalizeMutate, readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../workspace/collections/remoteView.js";
+import { toJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface MutateRemoteViewHandlerDeps {
@@ -32,9 +33,13 @@ export const createMutateRemoteViewHandler =
     if (!collection) throw new Error(`collection '${slug}' not found`);
     const result = await deps.mutateRemoteView(collection, viewId, request);
     if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
-    // Plain JSON, but the interface lacks an index signature — cast like the
-    // other phase-2/3 handlers.
-    return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
+    // The delete branch is all strings, so it type-checks. The update branch
+    // carries a `CollectionItem`, whose values are `unknown` — JSON by the
+    // record loader's invariant, but not provably so. Same irreducible gap as
+    // `pageResult` / `getRemoteViewItems`, kept visible per branch rather than
+    // blanketing both.
+    if (result.op === "delete") return toJsonObject({ op: "delete", id: result.id });
+    return { op: "update", item: result.item } as unknown as JsonObject;
   };
 
 export const mutateRemoteViewItem = createMutateRemoteViewHandler({ loadCollection, mutateRemoteView });


### PR DESCRIPTION
Closes #2592.

## Summary

Eight remote-host handlers each carried their own `as unknown as JsonObject`, with the justification re-argued in eight slightly different comments.

**Typechecking each one showed they were not all the same problem — that is the actual finding**, and it is why this PR does three different things rather than one blanket fix.

Adds `Jsonify<T>` + `toJsonObject` to `@mulmoclaude/core/remote-host`. `Jsonify` is a **recursive** mapped type: TypeScript gives an implicit index signature to type aliases and mapped types but not to interfaces, and a top-level-only map would still leave nested interfaces (`{ shortcuts: Shortcut[] }`) unassignable — which is what every handler here actually has.

## Outcome per handler

| Handler | Result |
|---|---|
| `listShortcuts`, `listFeeds`, `listCollections`, `getRemoteView`, delete branch of `mutateRemoteView` | → `toJsonObject`. **Genuinely type-checked; no assertion at all.** |
| `listAccountingBooks` | → **cast deleted outright**, no helper. Its `.map` rebuilds entries as anonymous object literals, which *do* get the implicit index signature. The comment claiming the cast was necessary was simply wrong. |
| `collectionPage`, `getRemoteViewItems`, update branch of `mutateRemoteView` | → **assertion kept**, with an accurate reason. |

So the eight-way duplication hid a real distinction: **five** were a TypeScript quirk with a clean fix, **one** was dead, **three** are a genuine gap in the schema types.

## Items to Confirm / Review

1. **The issue's acceptance criterion is not met, deliberately.** #2592 said "zero `as unknown as JsonObject`". The honest answer is three survive. Those payloads reach `Record<string, unknown>` (`schema.spawn.set`, `RemoteViewItem`, `CollectionItem`), so they **cannot be proven JSON** — they are JSON by the record loader's invariant, not by their types. `Jsonify` rejects them, correctly. I would rather leave three assertions that say what they are than weaken the helper until it accepts everything.
2. **`pageResult` keeps `unknown` parameters.** I tried tightening them to `Jsonify<T>` and reverted it: the compiler correctly rejected `CollectionDetail`. That failure is recorded in the code comment, since it tells the next person what would actually fix it (giving `spawn.set` a JSON-valued type at the schema layer) rather than inviting them to retry the same dead end.
3. **`toJsonObject` still contains one internal assertion.** It is confined to a single audited function rather than spread across eight handlers, and its parameter type `Jsonify<T>` does real work — verify you agree it is not merely a dressed-up `any`. Evidence it constrains: it rejected `CollectionDetail`, `RemoteViewItem` and `CollectionItem` above, which is exactly why three call sites could not adopt it.

## Testing

- `yarn format` / `lint` / `typecheck` / `build` / `test` all exit 0.
- Types only — no runtime behaviour change. The emitted JavaScript for the five converted handlers is the same object literal it always was.

## User Prompt

> 他に似た問題ない？
>
> issue化して全部やろう

Filed as #2591–#2594. This is #2592; #2591 is PR #2595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a reusable JSON typing and conversion layer for remote-host protocol payloads.
  * Updated remote-host handlers (collections, feeds, shortcuts, accounting books, and remote views) to use consistent JSON serialization.
  * Reduced unsafe type coercions in responses while preserving the same runtime payload shapes and existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->