### PR TITLE
fix: forward next(err) from asyncHandler when headers are already sent (#2593)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -751,11 +751,25 @@ if (env.isProduction) {
   });
 }
 
-app.use((err: Error, _req: Request, res: Response, __next: NextFunction) => {
+app.use((err: Error, _req: Request, res: Response, next: NextFunction) => {
   log.error("express", "unhandled error", {
     error: err.message,
     stack: err.stack,
   });
+  // A partially-sent response can't take a status line. Without this guard
+  // `serverError` throws ERR_HTTP_HEADERS_SENT from inside the error handler:
+  // the socket still ends up destroyed (Express catches the secondary throw
+  // and falls through to finalhandler), but the logs then show the real error
+  // followed by a misleading second crash. Delegating instead reaches the same
+  // destroy via the intended path, logging only what actually happened.
+  //
+  // Reachable since asyncHandler started forwarding `next(err)` on the
+  // headersSent path (#2593) — before that, nothing routed a mid-response
+  // failure here.
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
   serverError(res, "Internal Server Error");
 });
 

--- a/server/utils/asyncHandler.ts
+++ b/server/utils/asyncHandler.ts
@@ -20,9 +20,14 @@
 //   - The inner handler stays in charge of 4xx mapping (validation,
 //     not-found, etc.) — those paths respond + `return` inside the
 //     handler before the wrapper's catch ever runs.
-//   - Skipped when the response has already been sent (`headersSent`)
-//     so a partial response that throws mid-stream doesn't try to
-//     write a second status.
+//   - When the response has already been sent (`headersSent`), a
+//     second status can't be written, so the error is forwarded to
+//     Express via `next(err)` instead. Measured against Express 5.2.1:
+//     returning without forwarding leaves the request hanging with no
+//     end to its body, while forwarding makes finalhandler destroy the
+//     socket in milliseconds. No route wrapped here streams today, so
+//     this branch is currently unreachable — it exists so the first
+//     streaming route added doesn't inherit a silent hang.
 //
 // Naming: `namespace` is the log tag (e.g. "accounting", "wiki") —
 // matches the existing `log.info("namespace", …)` convention across
@@ -31,7 +36,7 @@
 // load news items", "Failed to list tasks", …) so the client-facing
 // behaviour is unchanged.
 
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { log } from "../system/logger/index.js";
 import { errorMessage } from "./errors.js";
 import { serverError, type ErrorSendable } from "./httpError.js";
@@ -71,15 +76,23 @@ export function asyncHandler<TReq extends RoutePathBearing = Request, TRes exten
   namespace: string,
   fallbackMessage: string,
   handler: (req: TReq, res: TRes) => Promise<void>,
-): (req: TReq, res: TRes) => Promise<void> {
-  return async (req, res) => {
+): (req: TReq, res: TRes, next: NextFunction) => Promise<void> {
+  return async (req, res, next) => {
     try {
       await handler(req, res);
     } catch (err) {
       log.error(namespace, "handler threw", { route: req.path, error: errorMessage(err) });
-      if (!res.headersSent) {
-        serverError(res, fallbackMessage);
+      if (res.headersSent) {
+        // A partially-sent response can't take a clean 500, and simply
+        // returning here leaves the request open — measured against this
+        // repo's Express (5.2.1), the client waits indefinitely for a body
+        // that never ends. Handing the error to Express lets finalhandler
+        // destroy the socket instead, so the caller fails in milliseconds
+        // rather than hanging until some timeout upstream.
+        next(err);
+        return;
       }
+      serverError(res, fallbackMessage);
     }
   };
 }

--- a/server/utils/asyncHandler.ts
+++ b/server/utils/asyncHandler.ts
@@ -89,7 +89,17 @@ export function asyncHandler<TReq extends RoutePathBearing = Request, TRes exten
         // that never ends. Handing the error to Express lets finalhandler
         // destroy the socket instead, so the caller fails in milliseconds
         // rather than hanging until some timeout upstream.
-        next(err);
+        //
+        // The forwarded value must be TRUTHY. Express reads `next(<falsy>)`
+        // as plain `next()` — "keep routing", not "fail" — so forwarding a
+        // thrown `undefined` (a bare `Promise.reject()` produces exactly
+        // that) skips the error flow entirely and hangs, reintroducing the
+        // bug this branch exists to prevent. Measured: the request hung past
+        // 2.5s. A falsy throw carries no diagnostic value anyway, so
+        // substituting a real Error loses nothing.
+        // `||`, deliberately not `??`: `??` only substitutes for null/undefined,
+        // leaving `0` / `""` / `false` to be forwarded verbatim and swallowed.
+        next(err || new Error(`${namespace}: handler threw a falsy value`));
         return;
       }
       serverError(res, fallbackMessage);

--- a/test/utils/test_asyncHandler.ts
+++ b/test/utils/test_asyncHandler.ts
@@ -118,4 +118,43 @@ describe("asyncHandler — handler throws after the response started", () => {
     assert.equal(res.sent.status, undefined, "writing a status after headersSent would throw ERR_HTTP_HEADERS_SENT");
     assert.equal(res.sent.body, undefined);
   });
+
+  // Express reads `next(<falsy>)` as plain `next()` — "keep routing", not
+  // "fail" — so forwarding a falsy throw verbatim skips the error flow and
+  // hangs, which is the exact bug this branch exists to prevent. Measured at
+  // over 2.5s before the guard. `Promise.reject()` with no argument rejects
+  // with `undefined`, so this is reachable, not theoretical.
+  const falsyThrows: [string, unknown][] = [
+    ["undefined", undefined],
+    ["null", null],
+    ["zero", 0],
+    ["empty string", ""],
+    ["false", false],
+  ];
+  for (const [label, value] of falsyThrows) {
+    it(`forwards a truthy Error when the handler throws ${label}`, async () => {
+      const res = makeRes(true);
+      let forwarded: unknown = "not called";
+      await asyncHandler<FakeReq, FakeRes>("test-ns", "fallback", async () => {
+        throw value;
+      })(req, res, (err?: unknown) => {
+        forwarded = err;
+      });
+      assert.ok(forwarded, `next() must receive a truthy value, got ${String(forwarded)}`);
+      assert.ok(forwarded instanceof Error);
+      assert.match((forwarded as Error).message, /test-ns: handler threw a falsy value/);
+    });
+  }
+
+  it("forwards a truthy non-Error throw unchanged", async () => {
+    const res = makeRes(true);
+    const bare: unknown = "a bare string";
+    let forwarded: unknown = null;
+    await asyncHandler<FakeReq, FakeRes>("test", "fallback", async () => {
+      throw bare;
+    })(req, res, (err?: unknown) => {
+      forwarded = err;
+    });
+    assert.equal(forwarded, bare, "a truthy value already routes to Express's error flow — do not rewrite it");
+  });
 });

--- a/test/utils/test_asyncHandler.ts
+++ b/test/utils/test_asyncHandler.ts
@@ -1,0 +1,121 @@
+// Unit tests for the route-handler error wrapper.
+//
+// The module had no tests at all. The branch this file exists for —
+// "the handler throws AFTER the response has started" — is currently
+// unreachable through the real routes (none of the 14 `asyncHandler` call
+// sites stream), so nothing else in the suite would notice if it regressed.
+//
+// Why the branch matters despite being unreachable: measured against this
+// repo's Express (5.2.1), returning without forwarding leaves the request
+// hanging — the client waits indefinitely for a body that never ends.
+// Forwarding to `next(err)` lets finalhandler destroy the socket in
+// milliseconds. The first streaming route added here would otherwise inherit
+// a silent hang.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { asyncHandler } from "../../server/utils/asyncHandler.js";
+
+/** Minimal stand-ins. The wrapper only touches `req.path`, `res.headersSent`
+ *  and `res.status().json()`, and its generics are bounded to exactly that —
+ *  so a fake carrying those members is a faithful double, not a shortcut.
+ *
+ *  These are passed as explicit type arguments below. That is the point, not a
+ *  workaround: the bounds accept any shape satisfying what the wrapper
+ *  dereferences, so a test can drive it without constructing a real Express
+ *  `Request` / `Response`. Omitting the arguments falls back to the Express
+ *  defaults and correctly rejects these fakes. */
+function makeRes(headersSent: boolean) {
+  const sent: { status?: number; body?: { error: string } } = {};
+  return {
+    headersSent,
+    sent,
+    status(code: number) {
+      sent.status = code;
+      return {
+        json(body: { error: string }) {
+          sent.body = body;
+          return undefined;
+        },
+      };
+    },
+  };
+}
+
+interface FakeReq {
+  path: string;
+}
+type FakeRes = ReturnType<typeof makeRes>;
+
+const req: FakeReq = { path: "/api/thing" };
+
+describe("asyncHandler — handler resolves", () => {
+  it("does not touch the response", async () => {
+    const res = makeRes(false);
+    let ran = false;
+    await asyncHandler<FakeReq, FakeRes>("test", "fallback", async () => {
+      ran = true;
+    })(req, res, () => assert.fail("next must not be called on success"));
+    assert.equal(ran, true);
+    assert.equal(res.sent.status, undefined);
+  });
+});
+
+describe("asyncHandler — handler throws before the response starts", () => {
+  it("sends a 500 carrying the fallback message", async () => {
+    const res = makeRes(false);
+    await asyncHandler<FakeReq, FakeRes>("test", "fallback message", async () => {
+      throw new Error("boom");
+    })(req, res, () => assert.fail("next must not be called when headers are unsent"));
+    assert.equal(res.sent.status, 500);
+    assert.deepEqual(res.sent.body, { error: "fallback message" });
+  });
+
+  // The wrapper logs the raw error server-side but must never put it on the
+  // wire — raw text leaks stack shape, file paths and library internals.
+  it("never leaks the thrown error's message to the client", async () => {
+    const res = makeRes(false);
+    await asyncHandler<FakeReq, FakeRes>("test", "safe fallback", async () => {
+      throw new Error("ENOENT: /Users/secret/path/db.sqlite");
+    })(req, res, () => {});
+    assert.deepEqual(res.sent.body, { error: "safe fallback" });
+    assert.ok(!JSON.stringify(res.sent).includes("secret"));
+  });
+
+  // `errorMessage(err)` has to cope with a non-Error rejection — a library
+  // can reject with a string. Thrown via a variable rather than a literal so
+  // `no-throw-literal` stays on for real code.
+  it("handles a non-Error throw without crashing", async () => {
+    const res = makeRes(false);
+    const bare: unknown = "a bare string";
+    await asyncHandler<FakeReq, FakeRes>("test", "fallback", async () => {
+      throw bare;
+    })(req, res, () => {});
+    assert.equal(res.sent.status, 500);
+  });
+});
+
+describe("asyncHandler — handler throws after the response started", () => {
+  // The regression this change is for. Returning here instead of forwarding
+  // is what left the request hanging.
+  it("forwards the error to next() instead of returning", async () => {
+    const res = makeRes(true);
+    const thrown = new Error("mid-stream failure");
+    let forwarded: unknown = null;
+    await asyncHandler<FakeReq, FakeRes>("test", "fallback", async () => {
+      throw thrown;
+    })(req, res, (err?: unknown) => {
+      forwarded = err;
+    });
+    assert.equal(forwarded, thrown, "the original error must reach Express, not a substitute");
+  });
+
+  it("does not attempt a second status write", async () => {
+    const res = makeRes(true);
+    await asyncHandler<FakeReq, FakeRes>("test", "fallback", async () => {
+      throw new Error("boom");
+    })(req, res, () => {});
+    assert.equal(res.sent.status, undefined, "writing a status after headersSent would throw ERR_HTTP_HEADERS_SENT");
+    assert.equal(res.sent.body, undefined);
+  });
+});


### PR DESCRIPTION
Closes #2593.

## Summary

The host `asyncHandler` logged and returned when a handler threw after the response had started. The accounting plugin's copy already forwarded to `next(err)`. This converges the host on the plugin's behaviour.

Raised by CodeRabbit on #2590 and deferred there on purpose — it changes runtime behaviour, which did not belong in a types-only PR.

## The measurement

#2593 said Express's behaviour here "should be confirmed, not assumed". Measured against this repo's actual Express **5.2.1**, with a route that writes a partial body then throws:

| | Result |
|---|---|
| `return` (before) | **request still hanging at 3000ms** — no end to the body |
| `next(err)` (after) | **socket aborted after 3ms** — client sees the failure |

The previous behaviour left the caller waiting indefinitely for a response that would never complete. Forwarding lets `finalhandler` destroy the socket.

## Items to Confirm / Review

1. **This is behaviourally a no-op today, and that is the argument for doing it now.** All 14 `asyncHandler` call sites end in `res.json()` and none stream, so `headersSent` is never true when the catch runs. `res.json` also serialises *before* sending, so even a `JSON.stringify` failure still lands on the unsent path. The change exists so the first streaming route added here doesn't silently inherit the hang — please confirm you agree the branch is genuinely unreachable today, since that is what makes this low-risk.
2. **Arity change.** The returned middleware goes from 2 params to 3. Express treats 4-param functions as error middleware; 3 params stays normal middleware, so the classification is unchanged. `bindRoute` already casts to `RequestHandler`, and Express was always passing `next` — it was simply ignored.
3. **The test fakes use explicit type arguments deliberately.** That exercises the structural bounds added in #2590: a test can drive the wrapper without constructing a real Express `Request`/`Response`, while *omitting* the arguments correctly falls back to the Express defaults and rejects the fakes. I hit that rejection while writing this and kept the explicit form rather than widening the bounds.

## Testing

- **New file `test/utils/test_asyncHandler.ts`** — the module had no tests at all, and this branch is unreachable through the real routes, so nothing else in the suite would have noticed a regression.
- **Mutation-verified**: restoring the old `if (!res.headersSent)` turns `forwards the error to next() instead of returning` red (1 fail / 5 pass); the fix turns it green (6 pass).
- Covers: success path, throw-before-send (500 + fallback message), **no leak of the raw error text to the client**, non-`Error` throws, throw-after-send forwarding the *original* error object, and no second status write.
- `yarn format` / `lint` / `typecheck` / `build` / `test` all exit 0.

## User Prompt

> #2593は詳しく教えて
>
> はい

Detail was requested before deciding; the measurement above is what the decision was made on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of errors that occur after a response has started by forwarding them to Express’s final error handler instead of attempting a second response.
  * Kept fallback messaging consistent for errors before any response is sent.
  * Added safer behavior for unexpected thrown values (including falsy and non-`Error` cases).
* **Tests**
  * Expanded `asyncHandler` regression coverage for both pre- and post-response error scenarios, including falsy throws and non-`Error` throws.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->