### PR TITLE
chore(dev): make LAN exposure of the dev server opt-in

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -55,6 +56,28 @@ function readDevToken(): string {
   }
 }
 
+// True for an IPv4/IPv6 loopback peer. Node reports an IPv4 peer on a
+// dual-stack socket as `::ffff:127.0.0.1`, so the mapped form is unwrapped
+// before comparing — matching only the bare literals would classify a real
+// loopback client as remote.
+function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false
+  const bare = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
+  return bare === '::1' || bare === '127.0.0.1' || bare.startsWith('127.')
+}
+
+// Carries "did this request arrive on the loopback interface?" from the
+// connect middleware (which can see the socket) down to
+// `transformIndexHtml` (which cannot — `IndexHtmlTransformContext` has no
+// `req`). AsyncLocalStorage rather than a module-level variable because
+// concurrent requests would otherwise read each other's value.
+const requestFromLoopback = new AsyncLocalStorage<boolean>()
+
+// Every path this dev server forwards to Express. Kept in sync with
+// `server.proxy` below — a prefix added there without being added here is
+// reachable from the LAN whenever MULMOCLAUDE_DEV_LAN is set.
+const PROXIED_BACKEND_PREFIXES = ['/api', '/artifacts'] as const
+
 function mulmoclaudeAuthTokenPlugin(): Plugin {
   return {
     name: 'mulmoclaude-auth-token',
@@ -65,8 +88,42 @@ function mulmoclaudeAuthTokenPlugin(): Plugin {
     // out to whatever value the builder happened to see — wrong for
     // every subsequent user.
     apply: 'serve',
+    // Registered from the `configureServer` body (not a returned function)
+    // so it runs BEFORE Vite's own html-serving middleware, and therefore
+    // before `transformIndexHtml` reads the store.
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const fromLoopback = isLoopbackAddress(req.socket.remoteAddress)
+        // Backend surface stays loopback-only even when the dev server is
+        // bound to every interface. These paths are PROXIED to Express, and
+        // some of them (`/api/files/*`, the `/artifacts/*` static mounts)
+        // are deliberately bearer-exempt because a browser `<img>` cannot
+        // send an Authorization header — their only protection was that
+        // Express binds to 127.0.0.1. The proxy defeats that: Express sees
+        // the proxy's own loopback socket, not the real client. Refusing
+        // here is the only layer that can still tell the two apart.
+        if (!fromLoopback && PROXIED_BACKEND_PREFIXES.some((prefix) => req.url?.startsWith(prefix))) {
+          res.statusCode = 403
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify({ error: 'Forbidden: backend access is loopback-only' }))
+          return
+        }
+        requestFromLoopback.run(fromLoopback, next)
+      })
+    },
     transformIndexHtml(html) {
-      return html.replace(TOKEN_PLACEHOLDER, readDevToken())
+      // The session token is a bearer credential for the whole API, so it
+      // is only ever handed to a caller on this machine. A non-loopback
+      // requester gets the empty string, which the Vue boot code already
+      // treats as "no auth" (every API call then 401s) — the same path as
+      // a missing token file.
+      //
+      // This matters because `/api` is PROXIED to Express: without the
+      // check, opting into `MULMOCLAUDE_DEV_LAN` would hand a full-API
+      // credential to anyone who can load the page, and Express would see
+      // every proxied call as loopback-sourced and trust it.
+      const fromLoopback = requestFromLoopback.getStore() ?? false
+      return html.replace(TOKEN_PLACEHOLDER, fromLoopback ? readDevToken() : '')
     },
   }
 }
@@ -178,7 +235,19 @@ export default defineConfig({
     },
   },
   server: {
-    host: true,
+    // Loopback by default. `host: true` (0.0.0.0) used to be
+    // unconditional, which put the dev server on every interface — and
+    // since `/api` is proxied to Express, that made a
+    // deliberately-127.0.0.1-bound backend reachable from the LAN through
+    // the proxy. Express saw those calls arriving from loopback, so the
+    // "we only bind to 127.0.0.1, therefore remote traffic can't reach
+    // us" assumption in `server/api/csrfGuard.ts` no longer held.
+    //
+    // Set MULMOCLAUDE_DEV_LAN=1 to bind every interface. Note that a LAN
+    // client still receives an EMPTY auth token (see
+    // `mulmoclaudeAuthTokenPlugin`), so opting in exposes the page, not
+    // the API. Only do it on a network you trust.
+    host: process.env.MULMOCLAUDE_DEV_LAN === '1' ? true : '127.0.0.1',
     // Disable Vite's dev CORS middleware. The app itself is same-origin in dev
     // (the page and the proxied `/api` both live on :5173), so it needs no CORS
     // headers from Vite. The one cross-origin consumer is a custom collection

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,7 +76,16 @@ const requestFromLoopback = new AsyncLocalStorage<boolean>()
 // Every path this dev server forwards to Express. Kept in sync with
 // `server.proxy` below — a prefix added there without being added here is
 // reachable from the LAN whenever MULMOCLAUDE_DEV_LAN is set.
-const PROXIED_BACKEND_PREFIXES = ['/api', '/artifacts'] as const
+//
+// `/ws` is the backend pub/sub socket. It needs BOTH guards below: the
+// connect middleware never sees a WebSocket handshake (those arrive on the
+// http server's `upgrade` event, not the request pipeline), so the prefix
+// alone would not stop it.
+const PROXIED_BACKEND_PREFIXES = ['/api', '/artifacts', '/ws'] as const
+
+function startsWithProxiedPrefix(url: string | undefined): boolean {
+  return PROXIED_BACKEND_PREFIXES.some((prefix) => url?.startsWith(prefix) ?? false)
+}
 
 function mulmoclaudeAuthTokenPlugin(): Plugin {
   return {
@@ -102,13 +111,28 @@ function mulmoclaudeAuthTokenPlugin(): Plugin {
         // Express binds to 127.0.0.1. The proxy defeats that: Express sees
         // the proxy's own loopback socket, not the real client. Refusing
         // here is the only layer that can still tell the two apart.
-        if (!fromLoopback && PROXIED_BACKEND_PREFIXES.some((prefix) => req.url?.startsWith(prefix))) {
+        if (!fromLoopback && startsWithProxiedPrefix(req.url)) {
           res.statusCode = 403
           res.setHeader('Content-Type', 'application/json')
           res.end(JSON.stringify({ error: 'Forbidden: backend access is loopback-only' }))
           return
         }
         requestFromLoopback.run(fromLoopback, next)
+      })
+
+      // WebSocket handshakes never reach the middleware above — Node routes
+      // them to the http server's `upgrade` event instead. Without this the
+      // `/ws` proxy would still carry backend pub/sub to a LAN client even
+      // though every HTTP path is refused.
+      //
+      // `prependListener` so this runs before the proxy's own upgrade
+      // handler, and only backend prefixes are destroyed — Vite's HMR socket
+      // is left alone, otherwise enabling LAN mode would break the very page
+      // it is meant to serve.
+      server.httpServer?.prependListener('upgrade', (req, socket) => {
+        if (isLoopbackAddress(socket.remoteAddress)) return
+        if (!startsWithProxiedPrefix(req.url)) return
+        socket.destroy()
       })
     },
     transformIndexHtml(html) {


### PR DESCRIPTION
## Summary

`vite dev` bound every interface unconditionally (`host: true`). That supports the "open the app on an iPad" workflow, but it applied to everyone whether they wanted it or not — including on networks where it isn't appropriate. This makes it a choice.

- Dev server binds `127.0.0.1` unless **`MULMOCLAUDE_DEV_LAN=1`** is set.
- With LAN enabled, the session token is injected into `index.html` only for loopback callers. A LAN caller gets an empty token, which the Vue boot code already treats as "no auth".
- With LAN enabled, the proxied backend prefixes (`/api`, `/artifacts`) are refused for non-loopback callers.

One switch: **off (default) exposes nothing; on exposes the page while keeping the backend loopback-only.**

## Why the backend needs its own check

`/api` and `/artifacts` are proxied to Express, and some of those paths are deliberately bearer-exempt (a browser `<img>` cannot send an `Authorization` header). Express only ever sees the proxy's own socket, so it cannot distinguish a local caller from a forwarded one — the proxy layer is the only place that still has the real client address.

## Implementation note

`transformIndexHtml` cannot see the request: `IndexHtmlTransformContext` has no `req`. The loopback flag is therefore carried from the connect middleware via `AsyncLocalStorage`. A module-level variable would be read across concurrent requests.

## Testing

Ran the dev server both ways and requested over loopback and over the host's LAN address:

| | Result |
|---|---|
| default | listener on `127.0.0.1` only; LAN connect refused |
| LAN on, from loopback | token present, `/api` 200 |
| LAN on, from LAN | token empty, `/api` + `/artifacts` 403 |

Also confirmed Vite's `fs.allow` still confines `/@fs/` to the repo root (a file outside it returns 403), so this change doesn't need to cover that surface.

`yarn format` / `lint` / `typecheck` / `build` / `test` all exit 0.

**e2e**: `stack-sticky-bottom-scroll.spec.ts` fails (2 cases) — pre-existing, **not caused by this change**. Verified by stashing the diff and re-running on clean `main`: the same 2 cases fail identically. The other 437 pass.

## Follow-up

`server/api/csrfGuard.ts` carries a comment asserting that missing-`Origin` requests are trustworthy "because the server binds to 127.0.0.1". The code never verifies the peer address, so that reasoning is an assumption rather than a check. Not changed here — worth revisiting separately so a future change to the bind address can't silently invalidate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make LAN exposure of the Vite dev server opt-in while keeping backend access restricted to loopback clients.

Enhancements:
- Default the dev server host to 127.0.0.1 and add an environment-controlled option (MULMOCLAUDE_DEV_LAN=1) to bind to all interfaces.
- Gate injection of the dev session token in index.html on whether the request originates from loopback, withholding credentials from LAN callers.
- Introduce request-scoped tracking of loopback status and enforce 403 responses for proxied backend routes (/api, /artifacts) when accessed from non-loopback addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted development backend and proxied routes to local (loopback) requests by default, returning `403` for non-local access attempts.
  * Ensured dev auth tokens are only injected for local requests, not for non-local connections.
  * Blocked non-local WebSocket upgrade attempts to proxied backend channels.
* **Configuration**
  * Updated the dev server to bind to `127.0.0.1` by default.
  * Added an opt-in switch (`MULMOCLAUDE_DEV_LAN === '1'`) to allow LAN access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->