### PR TITLE
refactor: replace unvalidated `as` casts of external data with type guards (#2594)

### DIFF
--- a/packages/bridges/twilio-sms/src/index.ts
+++ b/packages/bridges/twilio-sms/src/index.ts
@@ -28,7 +28,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { parseCsvSet } from "@mulmoclaude/common";
+import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "twilio-sms";
 const MAX_SMS_LEN = 1_600; // Twilio concatenates segments up to 1600 chars
@@ -137,8 +137,8 @@ interface TwilioBody {
 }
 
 function parseTwilioBody(body: unknown): TwilioBody | null {
-  if (!body || typeof body !== "object") return null;
-  const record = body as Record<string, unknown>;
+  if (!isRecord(body)) return null;
+  const record = body;
   const from = typeof record.From === "string" ? record.From : "";
   const toField = typeof record.To === "string" ? record.To : "";
   const text = typeof record.Body === "string" ? record.Body : "";
@@ -147,7 +147,13 @@ function parseTwilioBody(body: unknown): TwilioBody | null {
   return { From: from, To: toField, Body: text, MessageSid: messageSid };
 }
 
-function stringifyParams(body: Record<string, unknown>): Record<string, string> {
+/** The string-valued subset of a form body, for signature computation.
+ *
+ *  Takes `unknown` because the caller has an Express `req.body`. A non-record
+ *  yields `{}`, which produces a signature that cannot match — fail closed,
+ *  the same outcome as an absent body. */
+function stringifyParams(body: unknown): Record<string, string> {
+  if (!isRecord(body)) return {};
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(body)) {
     if (typeof value === "string") out[key] = value;
@@ -164,7 +170,7 @@ app.post("/sms", async (req: Request, res: ExpressResponse) => {
 
   if (publicUrl) {
     const sig = typeof req.headers["x-twilio-signature"] === "string" ? req.headers["x-twilio-signature"] : "";
-    const params = stringifyParams(req.body as Record<string, unknown>);
+    const params = stringifyParams(req.body);
     // Twilio signs the *full* URL it POSTed to — including query string.
     // `req.originalUrl` keeps the querystring that Twilio saw, whereas
     // `req.path` is just "/sms". Without this, any webhook URL with a

--- a/packages/plugins/html-plugin/src/core/contract.ts
+++ b/packages/plugins/html-plugin/src/core/contract.ts
@@ -5,6 +5,8 @@
 // storage only through the GENERIC gui-chat-protocol `files.artifacts`
 // capability — no presentHtml-specific host method.
 
+import { isRecord } from "@mulmoclaude/common";
+
 /** Read the bytes of an existing HTML artifact (source editor + print). */
 export interface LoadHtmlArgs {
   kind: "loadHtml";
@@ -47,4 +49,31 @@ export interface PackHtmlResult {
 export interface HtmlDispatchResult {
   loadHtml: { html: string };
   saveHtml: { path: string };
+}
+
+// ── Runtime guards ──────────────────────────────────────────────────
+//
+// A dispatch payload arrives from the View over the host's HTTP surface, so
+// it is untyped data, not a value the compiler has seen. These live beside
+// the shapes they check — a guard in one host would leave every other host
+// asserting the same shape by hand.
+//
+// They take `unknown` rather than `Record<string, unknown>`: an interface
+// gets no implicit index signature, so a predicate narrowing FROM the record
+// type would not type-check. `unknown` accepts either caller.
+
+/** True when `value` is a well-formed `packHtml` payload. */
+export function isPackHtmlArgs(value: unknown): value is PackHtmlArgs {
+  return isRecord(value) && value.kind === "packHtml" && typeof value.path === "string";
+}
+
+/** True when `value` is a well-formed payload for the package router
+ *  (`loadHtml` / `saveHtml`).
+ *
+ *  `saveHtml` additionally requires `html` to be a string — without that,
+ *  `undefined` would reach `files.artifacts.write` and blank the artifact. */
+export function isHtmlDispatchArgs(value: unknown): value is HtmlDispatchArgs {
+  if (!isRecord(value) || typeof value.path !== "string") return false;
+  if (value.kind === "loadHtml") return true;
+  return value.kind === "saveHtml" && typeof value.html === "string";
 }

--- a/packages/plugins/html-plugin/src/core/index.ts
+++ b/packages/plugins/html-plugin/src/core/index.ts
@@ -3,4 +3,5 @@ export { TOOL_NAME, TOOL_DEFINITION } from "./definition";
 export { executeHtml, executeHtmlUpdate, pluginCore, type HtmlExecuteContext, type UpdateHtmlResult } from "./plugin";
 export { executeHtmlDispatch, type HtmlDispatchContext } from "./dispatch";
 export type { HtmlDispatchArgs, HtmlDispatchResult, LoadHtmlArgs, SaveHtmlArgs, PackHtmlArgs, PackHtmlResult } from "./contract";
+export { isHtmlDispatchArgs, isPackHtmlArgs } from "./contract";
 export { htmlArtifactPath, htmlArtifactPreviewUrl, isHtmlArtifactPath, toArtifactsRelative, slugify, type HtmlPath } from "./paths";

--- a/packages/plugins/html-plugin/test/test_dispatchGuards.ts
+++ b/packages/plugins/html-plugin/test/test_dispatchGuards.ts
@@ -1,0 +1,81 @@
+// Guards for the dispatch envelope.
+//
+// A dispatch payload arrives from the View over the host's HTTP surface, so it
+// is untyped data. Hosts used to assert it (`args as unknown as
+// HtmlDispatchArgs`) — these guards replace that, and they only earn their
+// keep if they actually reject the malformed shapes an assertion waved
+// through, which is what this file pins.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { isHtmlDispatchArgs, isPackHtmlArgs } from "../src/core/contract";
+
+describe("isPackHtmlArgs", () => {
+  it("accepts a well-formed packHtml payload", () => {
+    assert.equal(isPackHtmlArgs({ kind: "packHtml", path: "artifacts/html/a.html" }), true);
+  });
+
+  it("rejects a different kind", () => {
+    assert.equal(isPackHtmlArgs({ kind: "loadHtml", path: "artifacts/html/a.html" }), false);
+  });
+
+  it("rejects a missing or non-string path", () => {
+    assert.equal(isPackHtmlArgs({ kind: "packHtml" }), false);
+    assert.equal(isPackHtmlArgs({ kind: "packHtml", path: 42 }), false);
+    assert.equal(isPackHtmlArgs({ kind: "packHtml", path: null }), false);
+  });
+
+  it("rejects non-objects", () => {
+    for (const value of [null, undefined, "packHtml", 7, []]) {
+      assert.equal(isPackHtmlArgs(value), false, `expected ${JSON.stringify(value)} to be rejected`);
+    }
+  });
+});
+
+describe("isHtmlDispatchArgs", () => {
+  it("accepts loadHtml with a path", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "loadHtml", path: "artifacts/html/a.html" }), true);
+  });
+
+  it("accepts saveHtml with a path and html", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "saveHtml", path: "artifacts/html/a.html", html: "<p>hi</p>" }), true);
+  });
+
+  // The case with teeth: `html` absent would reach `files.artifacts.write` as
+  // `undefined` and blank the artifact. An empty string is a legitimate
+  // "clear the file", so only the TYPE is checked, not truthiness.
+  it("rejects saveHtml without html", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "saveHtml", path: "artifacts/html/a.html" }), false);
+  });
+
+  it("accepts saveHtml with an empty html string", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "saveHtml", path: "artifacts/html/a.html", html: "" }), true);
+  });
+
+  it("rejects a non-string html", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "saveHtml", path: "artifacts/html/a.html", html: 42 }), false);
+  });
+
+  it("rejects a missing or non-string path", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "loadHtml" }), false);
+    assert.equal(isHtmlDispatchArgs({ kind: "loadHtml", path: 42 }), false);
+  });
+
+  it("rejects an unknown kind", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "deleteHtml", path: "artifacts/html/a.html" }), false);
+  });
+
+  // `packHtml` is handled host-side, before the package router — it must not
+  // be admitted here or it would reach `executeHtmlDispatch`, which has no
+  // branch for it.
+  it("rejects packHtml (host intercepts it; the package router has no branch)", () => {
+    assert.equal(isHtmlDispatchArgs({ kind: "packHtml", path: "artifacts/html/a.html" }), false);
+  });
+
+  it("rejects non-objects", () => {
+    for (const value of [null, undefined, "loadHtml", 7, []]) {
+      assert.equal(isHtmlDispatchArgs(value), false, `expected ${JSON.stringify(value)} to be rejected`);
+    }
+  });
+});

--- a/packages/plugins/markdown-plugin/src/core/index.ts
+++ b/packages/plugins/markdown-plugin/src/core/index.ts
@@ -5,6 +5,7 @@ export { pluginCore, executeDocument } from "./plugin";
 export { executeMarkdown } from "../plugins/markdown/core";
 export type { MarkdownExecuteContext } from "../plugins/markdown/core";
 export type { MarkdownHostApp, MarkdownDispatchArgs, MarkdownDispatchResult, ExportPdfOptions, MarpThemeEntry } from "../plugins/markdown/contract";
+export { isMarkdownDispatchArgs } from "../plugins/markdown/contract";
 // Hosts whose workspace file server is not `/api/files/raw` call this.
 export { setFilesRawUrl } from "@mulmoclaude/markdown-utils/image/resolve";
 // Shared Marp render core — both hosts' PDF export + the MarpView preview.

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/contract.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/contract.ts
@@ -11,9 +11,12 @@
 //                    Gemini image-fill, artifacts/documents store).
 //   - MulmoTerminal → its `server/backends/*` (next session).
 //
-// This file is pure types + the dispatch envelope; it imports nothing
-// host-specific so it lifts verbatim into `@mulmoclaude/markdown-plugin`
-// at extraction (Phase 3).
+// This file is the dispatch envelope: its types, plus the runtime guard
+// that decides whether an incoming payload IS one of them. It imports
+// nothing host-specific, so it lifts verbatim into
+// `@mulmoclaude/markdown-plugin` at extraction (Phase 3).
+
+import { isRecord } from "@mulmoclaude/common";
 
 /** A workspace Marp theme: the slug authors reference via frontmatter
  *  `theme: <name>` and the CSS to register on the Marp themeSet. */
@@ -91,4 +94,41 @@ export interface MarkdownDispatchResult {
   marpThemes: { themes: MarpThemeEntry[] };
   exportPdf: { pdfBase64: string };
   fillImages: { markdown: string };
+}
+
+// ── Runtime guard ───────────────────────────────────────────────────
+//
+// A dispatch payload arrives from the View over the host's HTTP surface, so
+// it is untyped data. `executeMarkdown` switches on `kind` and passes the
+// other fields straight to the host app without checking them, so an absent
+// `path` / `markdown` would reach a backend as `undefined` rather than being
+// refused here. The guard lives beside the shapes it checks so every host
+// narrows the same way instead of asserting by hand.
+//
+// Takes `unknown`: an interface gets no implicit index signature, so a
+// predicate narrowing FROM `Record<string, unknown>` would not type-check.
+
+const isString = (value: unknown): value is string => typeof value === "string";
+const isOptional = (value: unknown, check: (candidate: unknown) => boolean): boolean => value === undefined || check(value);
+
+/** Per-kind required-field check. `marpThemes` carries no payload. */
+const DISPATCH_SHAPE_CHECKS: Record<string, (args: Record<string, unknown>) => boolean> = {
+  loadDoc: (args) => isString(args.path),
+  saveDoc: (args) => isString(args.path) && isString(args.markdown),
+  marpThemes: () => true,
+  fillImages: (args) => isString(args.markdown),
+  exportPdf: (args) =>
+    isString(args.markdown) &&
+    isString(args.filename) &&
+    isOptional(args.marp, (value) => typeof value === "boolean") &&
+    isOptional(args.baseDir, isString) &&
+    isOptional(args.format, (value) => value === "Letter" || value === "A4") &&
+    isOptional(args.stripFrontmatter, (value) => typeof value === "boolean"),
+};
+
+/** True when `value` is a well-formed dispatch payload for some known kind. */
+export function isMarkdownDispatchArgs(value: unknown): value is MarkdownDispatchArgs {
+  if (!isRecord(value) || typeof value.kind !== "string") return false;
+  const check = DISPATCH_SHAPE_CHECKS[value.kind];
+  return check !== undefined && check(value);
 }

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/contract.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/contract.ts
@@ -111,24 +111,35 @@ export interface MarkdownDispatchResult {
 const isString = (value: unknown): value is string => typeof value === "string";
 const isOptional = (value: unknown, check: (candidate: unknown) => boolean): boolean => value === undefined || check(value);
 
-/** Per-kind required-field check. `marpThemes` carries no payload. */
-const DISPATCH_SHAPE_CHECKS: Record<string, (args: Record<string, unknown>) => boolean> = {
-  loadDoc: (args) => isString(args.path),
-  saveDoc: (args) => isString(args.path) && isString(args.markdown),
-  marpThemes: () => true,
-  fillImages: (args) => isString(args.markdown),
-  exportPdf: (args) =>
-    isString(args.markdown) &&
-    isString(args.filename) &&
-    isOptional(args.marp, (value) => typeof value === "boolean") &&
-    isOptional(args.baseDir, isString) &&
-    isOptional(args.format, (value) => value === "Letter" || value === "A4") &&
-    isOptional(args.stripFrontmatter, (value) => typeof value === "boolean"),
-};
+/** Per-kind required-field check. `marpThemes` carries no payload.
+ *
+ *  A `Map`, not an object literal, because `kind` is attacker-supplied and an
+ *  object index reads through the prototype chain. Measured with a literal:
+ *  `kind: "constructor"` returned `Object`, whose call yields a truthy object,
+ *  so the guard reported VALID; `kind: "toString"` likewise; and
+ *  `"__proto__"` / `"hasOwnProperty"` made the guard THROW instead of
+ *  returning false, so the caller's `if (!isMarkdownDispatchArgs(…))` never
+ *  ran. Same reasoning as the `Map` in `@mulmoclaude/common`. */
+const DISPATCH_SHAPE_CHECKS = new Map<string, (args: Record<string, unknown>) => boolean>([
+  ["loadDoc", (args) => isString(args.path)],
+  ["saveDoc", (args) => isString(args.path) && isString(args.markdown)],
+  ["marpThemes", () => true],
+  ["fillImages", (args) => isString(args.markdown)],
+  [
+    "exportPdf",
+    (args) =>
+      isString(args.markdown) &&
+      isString(args.filename) &&
+      isOptional(args.marp, (value) => typeof value === "boolean") &&
+      isOptional(args.baseDir, isString) &&
+      isOptional(args.format, (value) => value === "Letter" || value === "A4") &&
+      isOptional(args.stripFrontmatter, (value) => typeof value === "boolean"),
+  ],
+]);
 
 /** True when `value` is a well-formed dispatch payload for some known kind. */
 export function isMarkdownDispatchArgs(value: unknown): value is MarkdownDispatchArgs {
   if (!isRecord(value) || typeof value.kind !== "string") return false;
-  const check = DISPATCH_SHAPE_CHECKS[value.kind];
+  const check = DISPATCH_SHAPE_CHECKS.get(value.kind);
   return check !== undefined && check(value);
 }

--- a/server/api/routes/translation.ts
+++ b/server/api/routes/translation.ts
@@ -6,7 +6,7 @@ import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { createTranslationService, TranslationInputError } from "../../services/translation/index.js";
 import { defaultTranslateBatch } from "../../services/translation/llm.js";
 import { log } from "../../system/logger/index.js";
-import type { TranslateBatchFn, TranslateRequest, TranslateResponse } from "../../services/translation/types.js";
+import type { TranslateBatchFn, TranslateResponse } from "../../services/translation/types.js";
 
 export interface TranslationRouteDeps {
   /** Override for tests — defaults to the live workspace root. */
@@ -28,7 +28,9 @@ export function createTranslationRouter(deps: TranslationRouteDeps = {}): Router
 
   router.post(API_ROUTES.translation.translate, async (req: Request, res: Response<TranslateResponse | TranslateErrorBody>) => {
     try {
-      const result = await service.translate(req.body as TranslateRequest);
+      // `req.body` is unvalidated input; the service validates and narrows it
+      // (`validateRequest`), so no assertion is needed at the boundary.
+      const result = await service.translate(req.body);
       res.json(result);
     } catch (err) {
       if (err instanceof TranslationInputError) {

--- a/server/plugins/builtin-dispatch.ts
+++ b/server/plugins/builtin-dispatch.ts
@@ -15,6 +15,23 @@ export type BuiltinDispatchHandler = (args: Record<string, unknown>) => Promise<
 
 const registry = new Map<string, BuiltinDispatchHandler>();
 
+/** Render a rejected payload's `kind` for an error message, without
+ *  dereferencing it.
+ *
+ *  A handler reaches this only after its guard said no, so the value is by
+ *  definition malformed — and `payload.kind` on a `null` or a primitive throws
+ *  a TypeError, replacing the diagnostic the caller was about to get with a
+ *  crash. A rejection path that throws is not a rejection path.
+ *
+ *  The declared parameter is `Record<string, unknown>` and the HTTP route
+ *  already coerces (`isRecord(req.body) ? req.body : {}`), so this is
+ *  belt-and-braces for a direct caller — a test, or another host wiring the
+ *  registry up itself. */
+export function describeKind(payload: unknown): string {
+  if (payload === null || typeof payload !== "object") return JSON.stringify(payload) ?? String(payload);
+  return JSON.stringify((payload as { kind?: unknown }).kind) ?? "undefined";
+}
+
 /** Register a built-in plugin's dispatch handler under its scope name.
  *  Last registration wins (modules are imported once at boot). */
 export function registerBuiltinDispatch(scope: string, handler: BuiltinDispatchHandler): void {

--- a/server/plugins/html-builtin.ts
+++ b/server/plugins/html-builtin.ts
@@ -6,8 +6,8 @@
 // publishes a file-change event after a save so subscribed View tabs refresh.
 // Imported for side effect at boot (server/index.ts) so the dispatch resolves.
 
-import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
-import type { HtmlDispatchArgs, PackHtmlArgs, PackHtmlResult } from "@mulmoclaude/html-plugin";
+import { executeHtmlDispatch, isHtmlDispatchArgs, isPackHtmlArgs } from "@mulmoclaude/html-plugin";
+import type { PackHtmlArgs, PackHtmlResult } from "@mulmoclaude/html-plugin";
 import { makeArtifactsFileOps } from "./runtime.js";
 import { publishFileChange } from "../events/file-change.js";
 import { registerBuiltinDispatch } from "./builtin-dispatch.js";
@@ -28,11 +28,17 @@ async function packHtmlForDownload(args: PackHtmlArgs): Promise<PackHtmlResult> 
   return { filename, zipBase64: zip.toString("base64") };
 }
 
+// `args` is whatever the View put on the wire — untyped data, not a value the
+// compiler has vouched for. The package exports guards for its own shapes, so
+// the boundary narrows instead of asserting.
 registerBuiltinDispatch(HTML_SCOPE, async (args) => {
-  if ((args as { kind?: string }).kind === "packHtml") {
-    return packHtmlForDownload(args as unknown as PackHtmlArgs);
+  if (isPackHtmlArgs(args)) {
+    return packHtmlForDownload(args);
   }
-  const dispatchArgs = args as unknown as HtmlDispatchArgs;
+  if (!isHtmlDispatchArgs(args)) {
+    throw new Error(`html plugin: unrecognised dispatch payload (kind=${JSON.stringify(args.kind)})`);
+  }
+  const dispatchArgs = args;
   const result = await executeHtmlDispatch({ files: { artifacts: makeArtifactsFileOps() } }, dispatchArgs);
   // saveHtml changed bytes on disk → nudge subscribed View tabs (load is read-only).
   if (dispatchArgs.kind === "saveHtml") {

--- a/server/plugins/html-builtin.ts
+++ b/server/plugins/html-builtin.ts
@@ -10,7 +10,7 @@ import { executeHtmlDispatch, isHtmlDispatchArgs, isPackHtmlArgs } from "@mulmoc
 import type { PackHtmlArgs, PackHtmlResult } from "@mulmoclaude/html-plugin";
 import { makeArtifactsFileOps } from "./runtime.js";
 import { publishFileChange } from "../events/file-change.js";
-import { registerBuiltinDispatch } from "./builtin-dispatch.js";
+import { describeKind, registerBuiltinDispatch } from "./builtin-dispatch.js";
 import { packHtmlZip } from "../utils/share/packHtml.js";
 import { isHtmlPath } from "../utils/files/html-store.js";
 
@@ -36,7 +36,7 @@ registerBuiltinDispatch(HTML_SCOPE, async (args) => {
     return packHtmlForDownload(args);
   }
   if (!isHtmlDispatchArgs(args)) {
-    throw new Error(`html plugin: unrecognised dispatch payload (kind=${JSON.stringify(args.kind)})`);
+    throw new Error(`html plugin: unrecognised dispatch payload (kind=${describeKind(args)})`);
   }
   const dispatchArgs = args;
   const result = await executeHtmlDispatch({ files: { artifacts: makeArtifactsFileOps() } }, dispatchArgs);

--- a/server/plugins/markdown-builtin.ts
+++ b/server/plugins/markdown-builtin.ts
@@ -19,7 +19,7 @@ import { publishFileChange } from "../events/file-change.js";
 import { listMarpThemes } from "../workspace/marp-themes.js";
 import { renderMarkdownPdf } from "../api/routes/pdf.js";
 import { fillMarkdownImagePlaceholders } from "../utils/files/markdown-image-fill.js";
-import { registerBuiltinDispatch } from "./builtin-dispatch.js";
+import { describeKind, registerBuiltinDispatch } from "./builtin-dispatch.js";
 
 /** Scope name — matches `wrapWithScope("markdown", …)` in
  *  `src/plugins/markdown/index.ts`, which is what the View's
@@ -72,7 +72,7 @@ const markdownHostApp: MarkdownHostApp = {
 // what keeps a malformed payload from reaching a backend as `undefined`.
 registerBuiltinDispatch(MARKDOWN_SCOPE, (args) => {
   if (!isMarkdownDispatchArgs(args)) {
-    throw new Error(`markdown plugin: unrecognised dispatch payload (kind=${JSON.stringify(args.kind)})`);
+    throw new Error(`markdown plugin: unrecognised dispatch payload (kind=${describeKind(args)})`);
   }
   return executeMarkdown({ app: markdownHostApp }, args);
 });

--- a/server/plugins/markdown-builtin.ts
+++ b/server/plugins/markdown-builtin.ts
@@ -12,8 +12,8 @@
 // `@mulmoclaude/markdown-plugin` and this file stays behind as
 // MulmoClaude's host adapter.
 
-import { executeMarkdown } from "@mulmoclaude/markdown-plugin";
-import type { MarkdownDispatchArgs, MarkdownHostApp } from "@mulmoclaude/markdown-plugin";
+import { executeMarkdown, isMarkdownDispatchArgs } from "@mulmoclaude/markdown-plugin";
+import type { MarkdownHostApp } from "@mulmoclaude/markdown-plugin";
 import { isMarkdownPath, loadMarkdown, overwriteMarkdown, saveMarkdown } from "../utils/files/markdown-store.js";
 import { publishFileChange } from "../events/file-change.js";
 import { listMarpThemes } from "../workspace/marp-themes.js";
@@ -67,4 +67,12 @@ const markdownHostApp: MarkdownHostApp = {
   },
 };
 
-registerBuiltinDispatch(MARKDOWN_SCOPE, (args) => executeMarkdown({ app: markdownHostApp }, args as unknown as MarkdownDispatchArgs));
+// `args` is whatever the View put on the wire. `executeMarkdown` switches on
+// `kind` and forwards the rest to the host app unchecked, so narrowing here is
+// what keeps a malformed payload from reaching a backend as `undefined`.
+registerBuiltinDispatch(MARKDOWN_SCOPE, (args) => {
+  if (!isMarkdownDispatchArgs(args)) {
+    throw new Error(`markdown plugin: unrecognised dispatch payload (kind=${JSON.stringify(args.kind)})`);
+  }
+  return executeMarkdown({ app: markdownHostApp }, args);
+});

--- a/server/services/translation/index.ts
+++ b/server/services/translation/index.ts
@@ -7,6 +7,7 @@
 // `defaultTranslateBatch` from `./llm.ts` (which spawns the
 // `claude` CLI), unit tests pass a deterministic fake.
 
+import { isRecord } from "../../utils/types.js";
 import { loadDictionary, saveDictionary } from "../../utils/files/translation-io.js";
 import { assembleResult, mergeTranslations, splitHitMiss } from "./cache.js";
 import type { TranslateRequest, TranslateResponse, TranslationService, TranslationServiceDeps } from "./types.js";
@@ -31,7 +32,19 @@ export class TranslationInputError extends Error {
   }
 }
 
-function validateRequest(req: TranslateRequest): void {
+/** Validate an unvalidated payload, narrowing it on success.
+ *
+ *  Takes `unknown` because that is what actually arrives: the HTTP route hands
+ *  over `req.body`. The checks below were always written for untyped input
+ *  (`typeof req.namespace !== "string"` only means something if the value
+ *  might not be one) — the parameter type just said otherwise, so the route
+ *  had to assert `req.body as TranslateRequest` to call in. Declaring the
+ *  narrowing makes the caller's cast unnecessary rather than merely
+ *  unnecessary-looking. */
+function validateRequest(req: unknown): asserts req is TranslateRequest {
+  if (!isRecord(req)) {
+    throw new TranslationInputError("request body must be an object");
+  }
   if (typeof req.namespace !== "string" || !NAMESPACE_RE.test(req.namespace)) {
     throw new TranslationInputError(`invalid namespace: ${JSON.stringify(req.namespace)}`);
   }
@@ -101,7 +114,7 @@ export function createTranslationService(deps: TranslationServiceDeps): Translat
     return next;
   }
 
-  async function translate(req: TranslateRequest): Promise<TranslateResponse> {
+  async function translate(req: unknown): Promise<TranslateResponse> {
     validateRequest(req);
     if (req.targetLanguage === "en") {
       return { translations: [...req.sentences] };

--- a/server/services/translation/types.ts
+++ b/server/services/translation/types.ts
@@ -31,5 +31,7 @@ export interface TranslationServiceDeps {
 }
 
 export interface TranslationService {
-  readonly translate: (req: TranslateRequest) => Promise<TranslateResponse>;
+  /** Accepts an unvalidated payload — `validateRequest` narrows it. The HTTP
+   *  route can therefore pass `req.body` straight through. */
+  readonly translate: (req: unknown) => Promise<TranslateResponse>;
 }

--- a/test/plugins/markdown/test_dispatchGuard.ts
+++ b/test/plugins/markdown/test_dispatchGuard.ts
@@ -85,4 +85,22 @@ describe("isMarkdownDispatchArgs — rejects what the assertion used to admit", 
       assert.equal(isMarkdownDispatchArgs(value), false, `expected ${JSON.stringify(value)} to be rejected`);
     }
   });
+
+  // `kind` is attacker-supplied, so looking it up must not read through the
+  // prototype chain. Measured against the object-literal version this guard
+  // first shipped with: `"constructor"` and `"toString"` returned truthy (the
+  // guard reported VALID), and `"__proto__"` / `"hasOwnProperty"` made it
+  // THROW — so the caller's `if (!isMarkdownDispatchArgs(…))` never ran at
+  // all. A `Map` has no such keys.
+  it("rejects Object.prototype key names as kinds", () => {
+    for (const kind of ["constructor", "__proto__", "toString", "hasOwnProperty", "valueOf", "isPrototypeOf"]) {
+      assert.equal(isMarkdownDispatchArgs({ kind, path: "a.md", markdown: "# hi", filename: "a.pdf" }), false, `expected kind="${kind}" to be rejected`);
+    }
+  });
+
+  it("does not throw on a prototype key name (a guard that throws is not a guard)", () => {
+    for (const kind of ["__proto__", "hasOwnProperty"]) {
+      assert.doesNotThrow(() => isMarkdownDispatchArgs({ kind }), `kind="${kind}" must return false, not throw`);
+    }
+  });
 });

--- a/test/plugins/markdown/test_dispatchGuard.ts
+++ b/test/plugins/markdown/test_dispatchGuard.ts
@@ -1,0 +1,88 @@
+// Guard for the markdown dispatch envelope.
+//
+// A dispatch payload arrives from the View over the host's HTTP surface, so it
+// is untyped data. The host used to assert it (`args as unknown as
+// MarkdownDispatchArgs`), and `executeMarkdown` switches on `kind` and hands
+// the remaining fields straight to the host app WITHOUT checking them — so an
+// absent `path` reached a backend as `undefined` rather than being refused.
+//
+// (Lives here rather than in the package: markdown-plugin has no in-package
+// test runner — `test/plugins/markdown/` is where its host-side tests already
+// live.)
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isMarkdownDispatchArgs } from "@mulmoclaude/markdown-plugin";
+
+describe("isMarkdownDispatchArgs — accepts well-formed payloads", () => {
+  it("accepts loadDoc with a path", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "loadDoc", path: "artifacts/documents/a.md" }), true);
+  });
+
+  it("accepts saveDoc with a path and markdown", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "saveDoc", path: "artifacts/documents/a.md", markdown: "# hi" }), true);
+  });
+
+  // The only kind with no payload — it must not require fields it never has.
+  it("accepts marpThemes with no other fields", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "marpThemes" }), true);
+  });
+
+  it("accepts fillImages with markdown", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "fillImages", markdown: "# hi" }), true);
+  });
+
+  it("accepts exportPdf with only its required fields", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "exportPdf", markdown: "# hi", filename: "a.pdf" }), true);
+  });
+
+  it("accepts exportPdf with every optional field supplied", () => {
+    const args = { kind: "exportPdf", markdown: "# hi", filename: "a.pdf", marp: true, baseDir: "artifacts", format: "A4", stripFrontmatter: false };
+    assert.equal(isMarkdownDispatchArgs(args), true);
+  });
+});
+
+describe("isMarkdownDispatchArgs — rejects what the assertion used to admit", () => {
+  it("rejects a missing required field", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "loadDoc" }), false);
+    assert.equal(isMarkdownDispatchArgs({ kind: "saveDoc", path: "a.md" }), false);
+    assert.equal(isMarkdownDispatchArgs({ kind: "fillImages" }), false);
+    assert.equal(isMarkdownDispatchArgs({ kind: "exportPdf", markdown: "# hi" }), false);
+  });
+
+  it("rejects a wrongly-typed required field", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "loadDoc", path: 42 }), false);
+    assert.equal(isMarkdownDispatchArgs({ kind: "saveDoc", path: "a.md", markdown: null }), false);
+  });
+
+  // An optional field that IS present must still be the right type — otherwise
+  // the guard would pass junk straight through to the PDF pipeline.
+  it("rejects a wrongly-typed optional field", () => {
+    const base = { kind: "exportPdf", markdown: "# hi", filename: "a.pdf" };
+    assert.equal(isMarkdownDispatchArgs({ ...base, marp: "yes" }), false);
+    assert.equal(isMarkdownDispatchArgs({ ...base, baseDir: 1 }), false);
+    assert.equal(isMarkdownDispatchArgs({ ...base, stripFrontmatter: "no" }), false);
+  });
+
+  it("rejects a format outside the supported set", () => {
+    const base = { kind: "exportPdf", markdown: "# hi", filename: "a.pdf" };
+    assert.equal(isMarkdownDispatchArgs({ ...base, format: "A4" }), true);
+    assert.equal(isMarkdownDispatchArgs({ ...base, format: "Letter" }), true);
+    assert.equal(isMarkdownDispatchArgs({ ...base, format: "A3" }), false);
+  });
+
+  it("rejects an unknown kind", () => {
+    assert.equal(isMarkdownDispatchArgs({ kind: "deleteDoc", path: "a.md" }), false);
+  });
+
+  it("rejects a missing or non-string kind", () => {
+    assert.equal(isMarkdownDispatchArgs({ path: "a.md" }), false);
+    assert.equal(isMarkdownDispatchArgs({ kind: 7 }), false);
+  });
+
+  it("rejects non-objects", () => {
+    for (const value of [null, undefined, "loadDoc", 7, []]) {
+      assert.equal(isMarkdownDispatchArgs(value), false, `expected ${JSON.stringify(value)} to be rejected`);
+    }
+  });
+});

--- a/test/plugins/test_builtinDispatch.ts
+++ b/test/plugins/test_builtinDispatch.ts
@@ -1,0 +1,49 @@
+// `describeKind` renders a rejected dispatch payload's `kind` for an error
+// message. Its one hard requirement is that it NEVER throws: it runs only
+// after a guard has already refused the payload, so the value is malformed by
+// definition, and `payload.kind` on a `null` or a primitive would replace the
+// caller's diagnostic with a TypeError.
+//
+// The declared handler parameter is `Record<string, unknown>` and the HTTP
+// route coerces (`isRecord(req.body) ? req.body : {}`), so the non-object
+// cases are unreachable through that path — they are covered because a direct
+// caller (a test, another host wiring the registry itself) has no such
+// guarantee.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { describeKind } from "../../server/plugins/builtin-dispatch.js";
+
+describe("describeKind", () => {
+  it("renders a present kind", () => {
+    assert.equal(describeKind({ kind: "loadDoc" }), '"loadDoc"');
+  });
+
+  it("renders a missing kind without throwing", () => {
+    assert.equal(describeKind({}), "undefined");
+  });
+
+  it("renders a non-string kind", () => {
+    assert.equal(describeKind({ kind: 7 }), "7");
+    assert.equal(describeKind({ kind: null }), "null");
+  });
+
+  // The cases that used to throw when the message interpolated `args.kind`
+  // directly. A rejection path that throws is not a rejection path.
+  it("never throws on null, undefined, or a primitive", () => {
+    for (const value of [null, undefined, 7, "loadDoc", true]) {
+      assert.doesNotThrow(() => describeKind(value), `describeKind(${JSON.stringify(value)}) must not throw`);
+    }
+  });
+
+  it("returns something printable for each of those", () => {
+    assert.equal(describeKind(null), "null");
+    assert.equal(describeKind(undefined), "undefined");
+    assert.equal(describeKind(7), "7");
+    assert.equal(describeKind("loadDoc"), '"loadDoc"');
+  });
+
+  it("does not throw on an array", () => {
+    assert.doesNotThrow(() => describeKind([]));
+  });
+});


### PR DESCRIPTION
Closes #2594.

## Summary

Six sites asserted a concrete type onto data that arrived from outside the process. `CLAUDE.md`: *"NEVER use `as` type casts; MUST use type guards instead."*

| Site | Replaced with |
|---|---|
| `html-plugin` (3 casts, in `server/plugins/html-builtin.ts`) | `isPackHtmlArgs`, `isHtmlDispatchArgs` — exported from the package |
| `markdown-plugin` (1) | `isMarkdownDispatchArgs` — exported from the package |
| `server/api/routes/translation.ts` (1) | `validateRequest` now `asserts req is TranslateRequest` |
| `packages/bridges/twilio-sms` (2 — one more than the issue listed) | `isRecord` from `@mulmoclaude/common` |

Guards live with the shapes they check, not at the call site: a guard written in one host would leave every other host asserting the same shape by hand. They take `unknown` rather than `Record<string, unknown>`, because an interface gets no implicit index signature and a predicate narrowing *from* the record type does not type-check.

## Items to Confirm / Review

1. **Only one of these was an actual hole.** `executeMarkdown` switches on `kind` and forwards the remaining fields to the host app **without checking them**, so a payload missing `path` reached a backend as `undefined`. html and translation already validated internally — there the cast was a lie the compiler could not see, not an open door. Worth confirming you read the severity the same way.
2. **`TranslationService.translate` widened to `unknown`.** The validation was always written for untyped input (`typeof req.namespace !== "string"` only means something if the value might not be one); only the parameter type claimed otherwise. All existing callers pass object literals, so nothing else changes.
3. **`twilio-sms` had a second cast the issue did not list** — `body as Record<…>` inside `parseTwilioBody`. Both are gone. `stringifyParams` now takes `unknown` and returns `{}` for a non-record, which yields a signature that cannot match — fail closed.
4. **`markdown-plugin` has no in-package test runner**, so its guard test went to `test/plugins/markdown/`, where that package's host-side tests already live. Say the word if you would rather stand up a runner in the package instead.

## Testing

- **26 cases** across the two new guards: every kind, missing required fields, wrongly-typed required fields, optional fields that are present but wrong (`format: "A3"`, `marp: "yes"`), and non-object inputs.
- **Mutation-verified**: neutering `isMarkdownDispatchArgs` to `return true` — exactly the old cast's behaviour — turns 5 of them red.
- That check initially reported a **false pass**, worth flagging: the suite reads the built `dist`, and `yarn build:packages` had not rebuilt this workspace, so it was testing stale output and reported 13/13 green against a guard that did nothing. Rebuilding the package directly is what made the mutation visible. Anyone repeating this should build the specific workspace, not the aggregate.
- `yarn format` / `lint` / `typecheck` / `build` / `test` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twilio SMS webhook handling by tightening request-body validation during signature verification.
  * Strengthened translation handling by accepting untrusted payloads and narrowing safely before processing.
  * Added runtime validation for HTML and Markdown dispatch payloads, improving early rejection and error messages.
  * Added a safer payload `kind` description helper for clearer failures.
* **Tests**
  * Added/updated dispatch-guard tests for HTML and Markdown, including prototype-key safety cases.
  * Added tests for the `kind` description helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->