### PR TITLE
fix(icons): draw action / custom-view / spinner icons with the font their names belong to (#2605, #2606)

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/components/CollectionHeader.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionHeader.vue
@@ -155,8 +155,8 @@
     >
       <!-- A running `kind:"agent"` worker replaces the icon with a spinner
            until the completion ping's refetch clears its run key. -->
-      <span v-if="isActionRunning(action.id)" class="material-icons text-sm animate-spin">progress_activity</span>
-      <span v-else-if="action.icon" class="material-icons text-sm">{{ action.icon }}</span>
+      <span v-if="isActionRunning(action.id)" class="material-symbols-outlined text-sm animate-spin">progress_activity</span>
+      <span v-else-if="action.icon" class="material-symbols-outlined text-sm">{{ action.icon }}</span>
       <span>{{ action.label }}</span>
     </button>
 

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionMutateParamsModal.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionMutateParamsModal.vue
@@ -9,7 +9,7 @@
     <form class="flex flex-col overflow-y-auto" data-testid="collections-mutate-modal" @submit.prevent="submit">
       <div class="flex items-center justify-between px-6 pt-5 pb-3">
         <h2 class="text-sm font-bold text-slate-800 flex items-center gap-1.5">
-          <span v-if="action.icon" class="material-icons text-base text-indigo-600">{{ action.icon }}</span>
+          <span v-if="action.icon" class="material-symbols-outlined text-base text-indigo-600">{{ action.icon }}</span>
           <span>{{ action.label }}</span>
         </h2>
         <button
@@ -99,7 +99,7 @@
           :disabled="pending"
           data-testid="collections-mutate-submit"
         >
-          <span v-if="pending" class="material-icons text-sm animate-spin">progress_activity</span>
+          <span v-if="pending" class="material-symbols-outlined text-sm animate-spin">progress_activity</span>
           <span>{{ action.label }}</span>
         </button>
       </div>

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
@@ -51,8 +51,8 @@
         >
           <!-- A running `kind:"agent"` worker replaces the icon with a spinner
                until the completion ping's refetch clears its run key. -->
-          <span v-if="runningActionIds.includes(action.id)" class="material-icons text-sm animate-spin">progress_activity</span>
-          <span v-else-if="action.icon" class="material-icons text-sm">{{ action.icon }}</span>
+          <span v-if="runningActionIds.includes(action.id)" class="material-symbols-outlined text-sm animate-spin">progress_activity</span>
+          <span v-else-if="action.icon" class="material-symbols-outlined text-sm">{{ action.icon }}</span>
           <span>{{ action.label }}</span>
         </button>
 

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionToolbar.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionToolbar.vue
@@ -131,7 +131,7 @@
           :data-testid="`collection-view-custom-${cv.id}`"
           @click="emit('setCustomView', cv.id)"
         >
-          <span class="material-icons text-sm">{{ cv.icon || (cv.target === "mobile" ? "smartphone" : "dashboard_customize") }}</span>
+          <span class="material-symbols-outlined text-sm">{{ cv.icon || (cv.target === "mobile" ? "smartphone" : "dashboard_customize") }}</span>
           <span>{{ cv.label }}</span>
         </button>
         <!-- "+" — ask Claude to author a new custom view for this collection.

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionViewConfigModal.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionViewConfigModal.vue
@@ -31,7 +31,7 @@
 
         <ul v-if="views.length > 0" class="flex flex-col gap-1">
           <li v-for="view in views" :key="view.id" class="flex items-center gap-2 rounded border border-slate-200 bg-white px-3 py-2">
-            <span class="material-icons text-base text-slate-400">{{ view.icon || "dashboard_customize" }}</span>
+            <span class="material-symbols-outlined text-base text-slate-400">{{ view.icon || "dashboard_customize" }}</span>
             <span class="flex-1 truncate text-sm font-semibold text-slate-700">{{ view.label }}</span>
             <button
               type="button"

--- a/plans/fix-2605-material-symbols-icons.md
+++ b/plans/fix-2605-material-symbols-icons.md
@@ -1,0 +1,99 @@
+# Draw action / custom-view / spinner icons with the font their names belong to
+
+Issues: #2605 (visible breakage), #2606 (same cause, latent)
+
+## The bug
+
+Material Icons and Material Symbols both resolve an icon from the element's **text** via
+a ligature. When the name isn't in the font, the ligature doesn't form and the browser
+typesets the literal characters instead. The glyphs are invisible (the font has no
+outlines for plain letters at those codepoints) but the **width stays**, and the name is
+one unbreakable word — so it cannot shrink no matter how little room is left.
+
+`progress_activity` in a `.material-icons` element measures **408px** instead of 24px.
+In the record-detail header that pushes the title to width 0, wraps the button label,
+and shoves the close button outside the popup. #2605 has the full measurement table.
+
+#2606 is the same defect reached through data instead of code: action and custom-view
+icon names come from `schema.json`, the docs tell the LLM to write **Material Symbols**
+names there, and those two sites render with `.material-icons`.
+
+## Verification done before writing any code
+
+The issues' claims were re-measured in a real browser (Chromium, both stylesheets loaded
+over HTTP, `document.fonts.ready` awaited, `getBoundingClientRect().width` at
+`font-size: 24px` — a resolved ligature is exactly one em):
+
+| name | Symbols | classic |
+| --- | --- | --- |
+| `progress_activity` | 24px | **408px** |
+| `partly_cloudy_day` | 24px | 312px |
+| `weather_snowy` | 24px | 312px |
+| `rainy` | 24px | 120px |
+| `smartphone` | 24px | 24px |
+| `dashboard_customize` | 24px | 24px |
+| `refresh` / `settings` / `delete` | 24px | 24px |
+
+This reproduces #2605's 408px and #2606's three Symbols-only names exactly, so the
+method and the diagnosis both hold.
+
+**Do not trust either package's shipped name list.** #2605 already warned that
+`material-icons`'s `_data/versions.json` disagrees with its font. The same is true on the
+other side: `material-symbols/index.d.ts` omits `smartphone`, which the font resolves
+fine. Both lists produce false results in *both* directions; only rendering settles it.
+That is why the guard below measures nothing and asserts no name table.
+
+## Change
+
+Switch `.material-icons` → `material-symbols-outlined` at the 11 sites where the name
+being rendered is a Symbols name. `material-symbols/outlined.css` is already imported
+(`src/main.ts:24`) and `CollectionHeader.vue` already uses the class for the collection's
+own icon, so this adds nothing to the bundle and follows existing precedent in the file.
+
+Spinners — the name is `progress_activity`, hardcoded (#2605):
+
+- `packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue`
+- `packages/plugins/collection-plugin/src/vue/components/CollectionHeader.vue`
+- `packages/plugins/collection-plugin/src/vue/components/CollectionMutateParamsModal.vue`
+- `src/plugins/wiki/history/HistoryDetail.vue`
+- `src/plugins/wiki/history/HistoryTab.vue`
+- `src/plugins/wiki/history/RestoreConfirm.vue`
+
+Schema-driven icons — the name comes from `schema.json` (#2606):
+
+- `CollectionRecordPanel.vue` (action icon)
+- `CollectionHeader.vue` (collection-level action icon)
+- `CollectionMutateParamsModal.vue` (action icon in the params form)
+- `CollectionToolbar.vue` (custom-view icon, falls back to `smartphone` / `dashboard_customize`)
+- `CollectionViewConfigModal.vue` (custom-view icon, falls back to `dashboard_customize`)
+
+Both fallback names resolve in Symbols (measured above), so no default changes appearance.
+#2606 measured the 31 icon names in real schemas and found none that resolve only in
+classic, so no existing collection regresses either.
+
+### Not doing
+
+- **Migrating the whole app to Symbols.** `.material-icons` has 278 occurrences across
+  100 files against 11 for Symbols — classic is the house convention. Moving it would
+  mean verifying 278 names, which is a different piece of work from either issue.
+- **`CollectionHeader.vue`'s `hourglass_empty` loading indicator.** #2605 notes it as a
+  style inconsistency, not a defect: the name resolves in classic, so nothing is broken.
+  Changing it would alter a working icon outside both issues' scope.
+- **Clamping icon width defensively** (#2606 approach 2). Deferred deliberately — it
+  hides the symptom of a bad name rather than surfacing it, and the guard below plus the
+  docs already point the right way.
+
+## Guard against recurrence
+
+`test/components/test_icon_font_guard.ts` — a static scan in the same shape as
+`test_translate_guard.ts` (#2563), parsing each SFC with `vue/compiler-sfc` rather than
+grepping, so the class/text pairing is what's actually asserted.
+
+The invariant: **no element carrying `material-icons` may have Symbols-only text.**
+Seeded with `progress_activity`, the one name both issues trace back to.
+
+Scope, stated plainly so nobody reads it as more than it is: this catches the exact
+regression that produced #2605 and nothing else. A general guard would need to know every
+name in each font, and the measurement above shows neither package's list can supply
+that. The honest broad check is rendering width in a browser (#2605 approach 3), which
+belongs in `yarn test:e2e` and is not part of this change.

--- a/src/plugins/wiki/history/HistoryDetail.vue
+++ b/src/plugins/wiki/history/HistoryDetail.vue
@@ -279,7 +279,7 @@ async function performRestore(): Promise<void> {
     <!-- Body: loading / fetch error / no-previous / no-changes / diff -->
     <div class="flex-1 overflow-y-auto px-4 py-3 font-mono text-xs">
       <div v-if="loading" class="flex items-center justify-center py-8 text-gray-400">
-        <span class="material-icons animate-spin text-base mr-2">progress_activity</span>
+        <span class="material-symbols-outlined animate-spin text-base mr-2">progress_activity</span>
         {{ t("pluginWiki.history.loading") }}
       </div>
       <div v-else-if="fetchError" class="text-red-600">{{ fetchError }}</div>

--- a/src/plugins/wiki/history/HistoryTab.vue
+++ b/src/plugins/wiki/history/HistoryTab.vue
@@ -114,7 +114,7 @@ function onRestored(): void {
   <div class="flex-1 flex flex-col min-h-0" data-testid="wiki-history-tab">
     <!-- Loading -->
     <div v-if="loading" class="flex-1 flex items-center justify-center text-gray-400 text-sm">
-      <span class="material-icons animate-spin text-base mr-2">progress_activity</span>
+      <span class="material-symbols-outlined animate-spin text-base mr-2">progress_activity</span>
       {{ t("pluginWiki.history.loading") }}
     </div>
 

--- a/src/plugins/wiki/history/RestoreConfirm.vue
+++ b/src/plugins/wiki/history/RestoreConfirm.vue
@@ -54,7 +54,7 @@ function editorLabel(editor: SnapshotSummary["editor"]): string {
           data-testid="wiki-history-restore-confirm-action"
           @click="emit('confirm')"
         >
-          <span v-if="restoring" class="material-icons text-base animate-spin">progress_activity</span>
+          <span v-if="restoring" class="material-symbols-outlined text-base animate-spin">progress_activity</span>
           {{ t("pluginWiki.history.restoreConfirmAction") }}
         </button>
       </div>

--- a/test/components/test_icon_font_guard.ts
+++ b/test/components/test_icon_font_guard.ts
@@ -1,0 +1,63 @@
+// Regression guard for #2605 — an icon name must be drawn with the font
+// that actually has it.
+//
+// Both icon fonts resolve a glyph from the element's text via a ligature.
+// A name the font doesn't know forms no ligature, so the letters are
+// typeset instead: invisible, but full width, and one unbreakable word.
+// `progress_activity` in a `.material-icons` element measures 408px
+// rather than 24px, which is what flattened the record-detail header.
+//
+// SCOPE, so nobody reads this as more than it is: this pins the exact
+// regression #2605 traced, not the general problem. A general check would
+// need every name in each font, and neither package ships a list that
+// matches its own font — `material-icons`'s `_data/versions.json` omits
+// names that render (`sunny`), and `material-symbols`'s `index.d.ts` omits
+// `smartphone`, which renders fine. Both lists fail in both directions;
+// only rendering settles it, and rendering belongs in `yarn test:e2e`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { findIconElements } from "../helpers/iconFontProbe.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+const SCANNED_ROOTS = ["src", "packages/plugins"];
+const SKIPPED_DIRS = new Set(["node_modules", "dist", ".git"]);
+
+// Names verified in a browser to resolve ONLY in Material Symbols — each
+// one measured far wider than a single em under `.material-icons`. Add to
+// this list when another turns up; do not add a name without measuring it.
+const SYMBOLS_ONLY_ICON_NAMES = new Set(["progress_activity"]);
+
+function vueFilesUnder(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRS.has(entry.name)) vueFilesUnder(full, found);
+    } else if (entry.name.endsWith(".vue")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+test("no .material-icons element renders a Symbols-only name", () => {
+  const files = SCANNED_ROOTS.flatMap((rel) => vueFilesUnder(path.join(REPO_ROOT, rel)));
+  assert.ok(files.length > 0, "found no .vue files to scan — the scan roots are wrong");
+
+  const offenders = files.flatMap((file) =>
+    findIconElements(readFileSync(file, "utf-8"))
+      .filter((icon) => icon.fontClass === "material-icons" && icon.name !== null && SYMBOLS_ONLY_ICON_NAMES.has(icon.name))
+      .map((icon) => `${path.relative(REPO_ROOT, file)} → "${icon.name}"`),
+  );
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `These names exist only in Material Symbols, so \`.material-icons\` typesets them as text instead of drawing a glyph — an invisible element hundreds of pixels wide that flattens whatever shares its row (#2605). Use \`material-symbols-outlined\` here:\n  ${offenders.join("\n  ")}`,
+  );
+});

--- a/test/helpers/iconFontProbe.ts
+++ b/test/helpers/iconFontProbe.ts
@@ -1,0 +1,74 @@
+// Test helper — reports every icon-font element in a Vue SFC: which font
+// class it carries, and the literal text the ligature has to resolve from.
+//
+// Material Icons and Material Symbols pick a glyph from the element's own
+// text. A name the font doesn't know never forms a ligature, so the
+// browser typesets the letters instead — invisible, but full width, and a
+// single unbreakable word that no amount of missing room can shrink
+// (#2605: `progress_activity` measured 408px instead of 24px).
+//
+// Parsing with Vue's own compiler keeps the class/text PAIRING under test.
+// A source grep would see the class and the name on separate lines and
+// have no way to tell whether they belong to the same element.
+
+import { parse } from "vue/compiler-sfc";
+
+const NODE_TYPE_ELEMENT = 1;
+const NODE_TYPE_TEXT = 2;
+const NODE_TYPE_ATTRIBUTE = 6;
+
+type SfcTemplateAst = NonNullable<NonNullable<ReturnType<typeof parse>["descriptor"]["template"]>["ast"]>;
+type TemplateChild = SfcTemplateAst["children"][number];
+type ElementNode = Extract<TemplateChild, { type: typeof NODE_TYPE_ELEMENT }>;
+type ElementProp = ElementNode["props"][number];
+type AttributeNode = Extract<ElementProp, { type: typeof NODE_TYPE_ATTRIBUTE }>;
+
+/** The two icon fonts the app loads (`src/main.ts`). */
+export const ICON_FONT_CLASSES = ["material-icons", "material-symbols-outlined"] as const;
+
+export type IconFontClass = (typeof ICON_FONT_CLASSES)[number];
+
+export interface IconElement {
+  fontClass: IconFontClass;
+  /** The literal icon name, or `null` when the text is interpolated —
+   *  `{{ action.icon }}` comes from schema data and is not knowable here. */
+  name: string | null;
+}
+
+const isAttribute = (prop: ElementProp): prop is AttributeNode => prop.type === NODE_TYPE_ATTRIBUTE;
+const isElement = (node: TemplateChild): node is ElementNode => node.type === NODE_TYPE_ELEMENT;
+
+const staticClasses = (element: ElementNode): string[] => {
+  const attr = element.props.filter(isAttribute).find((prop) => prop.name === "class");
+  return attr?.value?.content.split(/\s+/) ?? [];
+};
+
+// Only a lone text child can be an icon name. Anything else — an
+// interpolation, several children, an element — is either data-driven or
+// not an icon at all, and reports as "no static name".
+const staticText = (element: ElementNode): string | null => {
+  const [only] = element.children;
+  if (element.children.length !== 1 || only === undefined) return null;
+  return only.type === NODE_TYPE_TEXT ? only.content.trim() : null;
+};
+
+const collect = (node: TemplateChild, found: IconElement[]): void => {
+  if (!isElement(node)) return;
+  const classes = staticClasses(node);
+  const fontClass = ICON_FONT_CLASSES.find((candidate) => classes.includes(candidate));
+  if (fontClass !== undefined) found.push({ fontClass, name: staticText(node) });
+  node.children.forEach((child) => collect(child, found));
+};
+
+/** Every icon-font element in the SFC, in template order. */
+export function findIconElements(sfcSource: string): IconElement[] {
+  const { descriptor, errors } = parse(sfcSource);
+  if (errors.length > 0) {
+    throw new Error(`SFC parse failed: ${errors.map((error) => error.message).join("; ")}`);
+  }
+  const ast = descriptor.template?.ast;
+  if (ast === undefined) return [];
+  const found: IconElement[] = [];
+  ast.children.forEach((child) => collect(child, found));
+  return found;
+}

--- a/test/helpers/test_iconFontProbe.ts
+++ b/test/helpers/test_iconFontProbe.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { findIconElements } from "./iconFontProbe.js";
+
+const sfc = (template: string) => `<template>\n${template}\n</template>\n`;
+
+describe("findIconElements", () => {
+  it("pairs the font class with the name on the SAME element", () => {
+    // The whole point of parsing: a grep would see "material-icons" and
+    // "progress_activity" in this template and could not tell they belong
+    // to different elements.
+    const found = findIconElements(
+      sfc(`<div>
+        <span class="material-icons text-sm">refresh</span>
+        <span class="material-symbols-outlined text-sm animate-spin">progress_activity</span>
+      </div>`),
+    );
+    assert.deepEqual(found, [
+      { fontClass: "material-icons", name: "refresh" },
+      { fontClass: "material-symbols-outlined", name: "progress_activity" },
+    ]);
+  });
+
+  it("reports an interpolated name as null — schema data is not knowable from source", () => {
+    const found = findIconElements(sfc(`<span class="material-icons text-sm">{{ action.icon }}</span>`));
+    assert.deepEqual(found, [{ fontClass: "material-icons", name: null }]);
+  });
+
+  it("finds icons nested at any depth, and ignores elements without a font class", () => {
+    const found = findIconElements(
+      sfc(`<div class="wrapper">
+        <button><span class="text-sm">not an icon</span></button>
+        <ul><li><span class="material-icons">delete</span></li></ul>
+      </div>`),
+    );
+    assert.deepEqual(found, [{ fontClass: "material-icons", name: "delete" }]);
+  });
+
+  it("is not fooled by a class that merely contains the font name", () => {
+    const found = findIconElements(sfc(`<span class="not-material-icons-really">refresh</span>`));
+    assert.deepEqual(found, []);
+  });
+
+  it("returns nothing for an SFC with no template", () => {
+    assert.deepEqual(findIconElements(`<script setup lang="ts">const a = 1;</script>\n`), []);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2605, closes #2606.

Both icon fonts resolve a glyph from the element's **text** via a ligature. A name the font doesn't have forms no ligature, so the browser typesets the letters instead — invisible, but full width, and one unbreakable word that cannot shrink however little room is left. `progress_activity` in a `.material-icons` element measures **408px** instead of 24px, which is what flattened the record-detail header (title to width 0, button label wrapped, close button pushed outside the popup).

Eleven sites switch from `.material-icons` to `material-symbols-outlined`:

- **6 spinners** with the hardcoded name `progress_activity` (#2605)
- **5 icons whose name comes from `schema.json`** (#2606) — where the docs already instruct the LLM to write Material Symbols names, so the code was the side that disagreed

Plus a static guard so the exact regression can't return silently.

`material-symbols/outlined.css` is already imported (`src/main.ts:24`) and `CollectionHeader.vue` already uses the class for the collection's own icon, so nothing is added to the bundle.

## Items to Confirm / Review

1. **No visual check on a running app.** `progress_activity` was measured resolving at 24px in Symbols in a real browser, but nobody ran an actual `kind: "agent"` action and looked at the popup from #2605's screenshots. That is the one thing this PR asserts and did not observe end-to-end.

2. **The fallback names were the risky part, and the shipped name list lied about them.** `CollectionToolbar.vue` falls back to `smartphone` / `dashboard_customize`, `CollectionViewConfigModal.vue` to `dashboard_customize`. `material-symbols/index.d.ts` does **not** list `smartphone` — but the font resolves it at 24px. Trusting that list would have caused an unnecessary icon change based on a false negative. Both fallbacks were confirmed by rendering. Worth a second opinion that measuring, not listing, is the right basis here.

3. **The guard's scope is narrow on purpose** — it knows one name (`progress_activity`). A general check needs every name in each font, and neither package can supply that (see #2 and the reverse case #2605 found: `material-icons`'s `_data/versions.json` omits `sunny`, which renders). The honest broad check is rendering width in a browser, which belongs in `yarn test:e2e` and is not in this PR. Say so if you want it here instead.

4. **Deliberately untouched** — please confirm these are the right calls:
   - Migrating the app to Symbols. `.material-icons` has 278 occurrences across 100 files against 11 for Symbols; classic is the house convention and moving it means verifying 278 names.
   - `CollectionHeader.vue`'s `hourglass_empty` loading icon. #2605 notes it as a style inconsistency, not a defect — it resolves in classic, so nothing is broken and changing it would alter a working icon.
   - Defensive width clamping (#2606 approach 2). It hides a bad name rather than surfacing it.

5. **One pre-existing e2e flake, confirmed unrelated.** `stack-sticky-bottom-scroll.spec.ts` › "a streamed result does not move the viewport while the reader is scrolled up" fails in a full parallel run and passes alone. Verified by reverting all 8 changed files to `main` and re-running the same full suite: **the same test failed identically** (441 passed / 1 failed both ways). Load-dependent timing on a 2500ms delayed stream. Not touched here; worth its own issue.

## User Prompt

> #2600 以降の open な issue を順次、できるものは対応していく

Decisions made in that conversation, for #2605 / #2606:

> - 直し方: 案1 — `material-symbols-outlined` に寄せる
> - 再発防止: 狭い静的ガードのみ
> - #2606: 同じ PR に含める

## What was measured before writing code

The issues' claims were re-measured in Chromium with both stylesheets served over HTTP, `document.fonts.ready` awaited, `getBoundingClientRect().width` at `font-size: 24px` (a resolved ligature is exactly one em):

| name | Symbols | classic | why it was checked |
| --- | --- | --- | --- |
| `progress_activity` | 24px | **408px** | the spinner in both issues |
| `partly_cloudy_day` | 24px | 312px | #2606's control group |
| `weather_snowy` | 24px | 312px | #2606's control group |
| `rainy` | 24px | 120px | #2606's control group |
| `smartphone` | 24px | 24px | `CollectionToolbar` mobile fallback |
| `dashboard_customize` | 24px | 24px | custom-view fallback |
| `refresh` / `settings` / `delete` | 24px | 24px | sanity — must resolve in both |

This reproduces #2605's 408px and #2606's three Symbols-only names exactly, so the method and the diagnosis both hold.

## Changed sites

Spinners, hardcoded `progress_activity` (#2605):

- `packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue`
- `packages/plugins/collection-plugin/src/vue/components/CollectionHeader.vue`
- `packages/plugins/collection-plugin/src/vue/components/CollectionMutateParamsModal.vue`
- `src/plugins/wiki/history/HistoryDetail.vue`
- `src/plugins/wiki/history/HistoryTab.vue`
- `src/plugins/wiki/history/RestoreConfirm.vue`

Schema-driven names (#2606):

- `CollectionRecordPanel.vue` / `CollectionHeader.vue` / `CollectionMutateParamsModal.vue` (action icon)
- `CollectionToolbar.vue` / `CollectionViewConfigModal.vue` (custom-view icon)

#2606 measured the 31 icon names in real schemas and found none that resolve only in classic, so no existing collection regresses.

## Guard

`test/components/test_icon_font_guard.ts` — same shape as `test_translate_guard.ts` (#2563), asserting no `.material-icons` element carries a Symbols-only name.

It parses each SFC with `vue/compiler-sfc` via a new `test/helpers/iconFontProbe.ts` rather than grepping, because the defect is a class and a name on the **same element** — a source grep sees both anywhere in the file and cannot tell. The probe has its own unit tests, including the case that separates it from a grep.

Verified to actually fail: reintroducing the bug at one site made it fail and name that file; reverting made it pass.

## Gates

| gate | result |
| --- | --- |
| `yarn format` / `yarn lint` | 0 errors (46 pre-existing warnings, none in new files) |
| `yarn typecheck` / `yarn build` | exit 0 |
| `yarn test` | exit 0 — 8280 tests, 0 fail (6 new) |
| `yarn test:e2e` | 441 passed / 1 failed — same failure on unmodified `main`, see item 5 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected icon rendering across collection actions, custom views, view configuration, and record panels.
  - Updated loading and restoring indicators in collection and wiki history views for proper display and sizing.
  - Prevented symbol-only icons from appearing as oversized or invisible text, improving layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->