### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.7.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [1.7.1] - 2026-07-27
+
+**Icons that rendered as their own names instead of glyphs.**
+
+### Highlights
+
+#### Action, custom-view and spinner icons draw with the font their names belong to (#2605, #2606, PR #2608)
+
+Both icon fonts resolve a glyph from the element's **text**, via a ligature. A name the font does not carry forms no ligature, so the browser typesets the letters instead — invisible as an icon, but still taking the width. Eleven sites moved from `.material-icons` to `material-symbols-outlined`: six spinners hardcoding `progress_activity` (#2605), and five icons whose name comes from a collection's `schema.json` (#2606), where the docs already told the LLM to write Material Symbols names and the code was the side that disagreed. A static guard pins the regression so it cannot return silently. Nothing is added to the bundle — `material-symbols/outlined.css` was already imported.
+
+**This fix is the whole reason 1.7.1 exists.** It merged while the 1.7.0 release PR was in review, twenty minutes after `mulmoclaude@1.7.0` had already gone to npm, so **1.7.0 on npm does not contain it**. Rather than tag a `v1.7.0` whose tree differs from its own published tarball, the fix ships as 1.7.1 and both versions keep a tag matching exactly what was published.
+
+Ships the same scoped package versions as 1.7.0, except `@mulmoclaude/collection-plugin@1.2.1` (five of the eleven icon sites live there).
+
+---
+
 ## [1.7.0] - 2026-07-27
 
 **Google Calendar sync stops being one-way, and a cycle of hardening closes the gaps where external data was trusted without checking.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude",
-  "version": "1.7.0",
-  "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
+  "version": "1.7.1",
+  "description": "MulmoClaude \u2014 GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {
     "mulmoclaude": "bin/mulmoclaude.js"
@@ -37,7 +37,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^1.1.0",
     "@mulmoclaude/chart-plugin": "^1.0.3",
-    "@mulmoclaude/collection-plugin": "^1.2.0",
+    "@mulmoclaude/collection-plugin": "^1.2.1",
     "@mulmoclaude/common": "^1.1.1",
     "@mulmoclaude/core": "^1.7.0",
     "@mulmoclaude/form-plugin": "^1.0.2",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "1.2.0",
-  "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
+  "version": "1.2.1",
+  "description": "Schema-driven Collections plugin (presentCollection) \u2014 the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/receptron/mulmoclaude.git",


### PR DESCRIPTION
## Summary

`mulmoclaude@1.7.1` and `@mulmoclaude/collection-plugin@1.2.1` are **already on npm** — this PR lands the version bumps and changelog, per `/publish-mulmoclaude` §8.

**1.7.1 exists because of a release-window gap that §9a-bis caught before tagging.** #2608 (icon fonts) merged twenty minutes *after* `mulmoclaude@1.7.0` had gone to npm, while the 1.7.0 release PR was still in review:

```
67074f730 ──┬── [publish: mulmoclaude@1.7.0 → npm]
            ├── 1b053b921  #2608 icon fix        ← NOT in the 1.7.0 tarball
            └── 15b56cdfb  #2609 version commit  ← main
```

Tagging `v1.7.0` at current `main` would have pointed the tag at a tree that differs from its own published tarball — precisely the "which one am I running?" drift §5.5 exists to prevent. Shipping the fix as 1.7.1 keeps every tag matching what was actually published, and gets the fix out now rather than at the next feature release.

#2608 is worth not deferring: both icon fonts resolve a glyph from the element's **text** via a ligature, so a name the font does not carry forms no ligature and the browser typesets the letters instead — invisible as an icon, but still taking the width. Six spinners and five schema-driven icons were affected.

## Items to Confirm / Review

1. **`v1.7.0` will be tagged retroactively at `b0bd7c6fc`**, the commit whose tree is exactly what `mulmoclaude@1.7.0` was packed from — so the npm version keeps a tag, per the "no untagged releases" rule, without claiming to contain #2608. `v1.7.1` then tags this PR's merge commit and carries `--latest`. Say if you would rather leave 1.7.0 untagged.
2. **CHANGELOG framing.** The 1.7.1 entry states plainly that 1.7.0 on npm lacks the fix. That is the honest record, but check the wording is what you want users reading.
3. Still open from 1.7.0: the calendar push has **never run against a live Google calendar** (#2602).

## Release gates (all green before publish)

| Gate | Result |
| --- | --- |
| §1 deps audit | OK |
| §2 workspace drift | OK — all four `@mulmobridge/*` match published dist |
| §6 internal deps resolve on npm | OK — no `⚠` lines |
| §4 tarball boot | **HTTP 200** from a clean install of the packed tarball |
| §6 npx verify | `mulmoclaude 1.7.1` via the public registry |
| typecheck / lint / build / unit | green |

## Published

| package | version |
| --- | --- |
| `@mulmoclaude/collection-plugin` | 1.2.1 |
| `mulmoclaude` | 1.7.1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the mulmoclaude monorepo and collection plugin to a 1.7.1 patch release that documents and ships the icon-font ligature fix already published to npm.

Bug Fixes:
- Ensure action, custom-view, and spinner icons render using the correct Material Symbols font instead of showing their raw names as text.

Enhancements:
- Clarify changelog history for 1.7.1, explicitly documenting the icon-font fix and its relationship to the previously published 1.7.0 release.

Build:
- Update root, mulmoclaude, and @mulmoclaude/collection-plugin package versions and metadata to 1.7.1 / 1.2.1 to match the published artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Material icon ligature rendering for action, custom-view, and spinner icons.
  * Added safeguards to prevent the rendering regression from returning unnoticed.

* **Documentation**
  * Added release notes for version 1.7.1, including clarification about the previous 1.7.0 release.

* **Release**
  * Published version 1.7.1 with the corrected icon behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->