### PR TITLE
fix(env): report shadowing from the server's own .env load too (#2610)

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -127,7 +127,7 @@ Set by `npx mulmoclaude` on the server it spawns. Auto-computed like the contain
 
 | Variable | Set by | Purpose |
 | -------- | ------ | ------- |
-| `MULMOCLAUDE_SHADOWED_ENV_KEYS` | launcher | CSV of launch-dir `.env` key NAMES the shell had already defined, so the file's values lost (#2604). Read once at boot by `server/system/shadowedEnv.ts`, which raises a bell notification — otherwise a user editing `.env` against a stale `export` gets no hint why nothing changes. Names only, never values; the server drops any token that isn't an env var name. Absent when there is no conflict, and absent entirely outside `npx mulmoclaude` (see #2610). |
+| `MULMOCLAUDE_SHADOWED_ENV_KEYS` | launcher | CSV of launch-dir `.env` key NAMES the shell had already defined, so the file's values lost (#2604). Read once at boot by `server/system/shadowedEnv.ts`, which raises a bell notification — otherwise a user editing `.env` against a stale `export` gets no hint why nothing changes. Names only, never values; the server drops any token that isn't an env var name. Absent when there is no conflict. Outside `npx mulmoclaude` the same notification still fires, from the server's own `.env` load instead (`server/system/loadEnv.ts`, #2610) — that path is where `yarn dev` lands. |
 
 ### Container-only env (auto-set)
 

--- a/e2e-live/tests/docker.spec.ts
+++ b/e2e-live/tests/docker.spec.ts
@@ -67,8 +67,11 @@ const SYMLINK_UNSUPPORTED_CODES = new Set(["EPERM", "EACCES", "ENOTSUP", "EROFS"
 
 // Mirror the host server's dotenv load so the spec process can read
 // the same `X_BEARER_TOKEN` (and any future docker-relevant env) the
-// server saw at boot. `server/index.ts:1` calls `import "dotenv/config"`
-// from the repo root cwd; yarn / node don't auto-load .env, so the
+// server saw at boot. `server/index.ts:1` imports
+// `server/system/loadEnv.ts`, which reads `<cwd>/.env` — the repo root
+// here — with the same shell-wins rule `dotenv/config` used to apply
+// (#2610 replaced the import to make the shadowed keys reportable, not
+// to change what gets loaded); yarn / node don't auto-load .env, so the
 // spec runner would otherwise read `process.env` without the .env
 // overlay and L-23's precondition would mis-skip on hosts that do
 // have the credential. Sourcery review on PR #1462 surfaced this:

--- a/e2e-live/tests/docker.spec.ts
+++ b/e2e-live/tests/docker.spec.ts
@@ -67,9 +67,9 @@ const SYMLINK_UNSUPPORTED_CODES = new Set(["EPERM", "EACCES", "ENOTSUP", "EROFS"
 
 // Mirror the host server's dotenv load so the spec process can read
 // the same `X_BEARER_TOKEN` (and any future docker-relevant env) the
-// server saw at boot. `server/index.ts:1` imports
-// `server/system/loadEnv.ts`, which reads `<cwd>/.env` — the repo root
-// here — with the same shell-wins rule `dotenv/config` used to apply
+// server saw at boot. `server/index.ts` imports
+// `server/system/loadEnv.ts` first, which reads `<cwd>/.env` — the repo
+// root here — with the same shell-wins rule `dotenv/config` used to apply
 // (#2610 replaced the import to make the shadowed keys reportable, not
 // to change what gets loaded); yarn / node don't auto-load .env, so the
 // spec runner would otherwise read `process.env` without the .env

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -623,3 +623,46 @@ queue of paths, with one short-delay retry on 429. See the throttled-resolver
 example in `custom-view.md` ("Displaying images"). Do NOT widen the server
 cap, switch to base64-embedding images in the HTML, or treat the 429'd paths
 as bad values.
+
+## An API key in `.env` has no effect — the shell is shadowing it
+
+### Symptoms
+
+- The user says they put a key (`GEMINI_API_KEY`, `OPENAI_API_KEY`, …) in
+  `.env` and restarted, but generation still fails with an auth / 401 /
+  "API key not valid" error from the provider.
+- They may have edited `.env` several times, each time with no change.
+- The bell may show **"Shell env is overriding .env"**, and the server log
+  a `[shadowed-env]` warning naming the keys.
+
+### Cause
+
+An exported shell variable beats the file. `.env` is loaded with
+no-override semantics, so if `~/.zshrc` (or the current shell) still holds
+`export GEMINI_API_KEY=<old value>`, the file's value is read and
+discarded. Editing `.env` cannot fix it, which is why the loop repeats.
+
+An **empty** export shadows just as hard: `export GEMINI_API_KEY=` counts
+as set, so the provider receives an empty key while a perfectly good one
+sits in `.env`.
+
+Two files can be shadowed this way — the directory the user launched from
+(`npx mulmoclaude`) and the server's own working directory (`yarn dev`).
+
+### Fix
+
+Have the user check the shell, not the file:
+
+```bash
+echo "$GEMINI_API_KEY"        # empty output ⇒ nothing is shadowing
+```
+
+If it prints anything, that value is what the app is using. Either update
+the export to the correct value, or remove it (from the shell AND from
+`~/.zshrc` / `~/.bashrc`, or the next terminal brings it back) so the
+`.env` value takes effect. Restart the app afterwards — the load happens
+once at boot.
+
+Do NOT tell the user to re-check the spelling in `.env`, add the key
+again, or move it elsewhere; the file is already correct, and it is being
+read. The conflict is the whole problem.

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -651,17 +651,20 @@ Two files can be shadowed this way — the directory the user launched from
 
 ### Fix
 
-Have the user check the shell, not the file:
+Have the user check the shell, not the file. Test whether the variable
+is **set**, not whether it prints something — `export GEMINI_API_KEY=`
+prints nothing and still shadows, which is the case `echo` cannot see:
 
 ```bash
-echo "$GEMINI_API_KEY"        # empty output ⇒ nothing is shadowing
+[ -n "${GEMINI_API_KEY+x}" ] && echo "set in the shell — this is what the app uses" \
+                             || echo "not set — the shell is not the problem"
 ```
 
-If it prints anything, that value is what the app is using. Either update
-the export to the correct value, or remove it (from the shell AND from
-`~/.zshrc` / `~/.bashrc`, or the next terminal brings it back) so the
-`.env` value takes effect. Restart the app afterwards — the load happens
-once at boot.
+If it reports "set", that shell value is what the app is using, whatever
+`.env` says. Either correct the export, or remove it — from the current
+shell AND from `~/.zshrc` / `~/.bashrc`, or the next terminal brings it
+straight back — so the `.env` value takes effect. Restart the app
+afterwards; the load happens once at boot.
 
 Do NOT tell the user to re-check the spelling in `.env`, add the key
 again, or move it elsewhere; the file is already correct, and it is being

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude",
   "version": "1.7.1",
-  "description": "MulmoClaude \u2014 GUI-chat with Claude Code + long-term memory. One command to start.",
+  "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {
     "mulmoclaude": "bin/mulmoclaude.js"
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^1.0.3",
     "@mulmoclaude/collection-plugin": "^1.2.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.7.0",
+    "@mulmoclaude/core": "^1.7.1",
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.0",
     "@mulmoclaude/html-plugin": "^1.1.0",

--- a/plans/fix-2610-server-dotenv-shadowing.md
+++ b/plans/fix-2610-server-dotenv-shadowing.md
@@ -1,0 +1,97 @@
+# Make the server's own `.env` load report shadowing too
+
+Issue: #2610 · follows #2604
+
+## What's left unsignalled
+
+#2604 gave the launcher path an in-app notification when the shell shadows a launch-dir
+`.env`. The server reaches a `.env` by a second route that got nothing:
+
+| launch | server cwd | `.env` `dotenv/config` reads | signal today |
+| --- | --- | --- | --- |
+| `npx mulmoclaude` | `packages/mulmoclaude/` | none exists — a no-op | launcher detects it (#2604) |
+| `yarn dev` / `tsx server/index.ts` | repo root | **the repo's own `.env`** | **none** |
+
+Same shell-wins rule, same "I edited `.env` and nothing changed" dead end, and in the dev
+case not even the launcher's log line. So this is effectively a dev-path fix.
+
+## The trap in the obvious implementation
+
+`import "dotenv/config"` cannot simply become a function call. ESM evaluates **every**
+import before the first statement of the module body, so a `loadServerEnv()` on line 1 of
+the body would run *after* every imported module has already been evaluated —
+`server/workspace/paths.ts:81` reads `process.env` at its own module scope and would see
+an unpopulated environment.
+
+The load therefore stays a **side-effecting import**, listed first, exactly where
+`dotenv/config` was. Only the module behind it changes.
+
+## Change
+
+### 1. `server/system/loadEnv.ts` (new)
+
+Replaces `import "dotenv/config"` at `server/index.ts:1`.
+
+Reuses the launcher's existing pieces rather than a second parser: `parseEnvFile` +
+`mergeLaunchEnv` (`server/utils/launch-env.mjs`) already implement dotenv's no-override
+semantics and already return `skippedKeys`. Parsing stays byte-identical because
+`parseEnvFile` calls `dotenv.parse`.
+
+Split so the logic is testable without a module-load side effect:
+
+- `applyEnvFile(cwd, target)` — applies the file's non-shadowed keys to `target`, returns
+  the shadowed names. Takes both as arguments, so a test drives a temp dir and a plain
+  object.
+- the module body calls it once for `process.cwd()` / `process.env` and freezes the
+  result behind `shadowedByServerLoad()`.
+
+Nothing is lost in the swap: `DOTENV_CONFIG_*` is unused anywhere in the repo.
+
+### 2. Feed it into the existing announce
+
+`announceShadowedEnv` gains a second parameter for keys the server itself skipped, unioned
+with the launcher's. `server/index.ts` passes `shadowedByServerLoad()`.
+
+Both sources deliberately produce **one** notification with the union of key names, not
+one per source. Per the issue decision, the text does not name the `.env` path: only one
+of the two files is ever in play (the launcher's cwd has no `.env`, and `yarn dev` has no
+launcher), so a path would add an 8-locale change for a distinction the user cannot
+currently hit.
+
+`shadowedEnv.ts` deliberately does **not** import `loadEnv.ts` — that would make merely
+importing the diagnostic read the repo's real `.env`, which is exactly the side effect the
+tests must not have.
+
+### 3. `error-recovery.md` — the gap #2604 left
+
+CLAUDE.md requires a new runtime diagnostic to land in
+`packages/core/assets/helps/error-recovery.md`, and #2604 did not do it. The omission has
+teeth: the existing "media generation failed" section already tells the agent to *"add the
+missing key to `.env` (restart the server)"* — which is precisely the advice that silently
+fails when the shell holds a stale value. The agent reads that file before asking the user
+a clarifying question, so the know-how was invisible where it mattered most.
+
+Adding it means bumping `@mulmoclaude/core` (assets ship to npm) and the launcher's range
+for it in the same PR, per the launcher-sync gate.
+
+### 4. Documentation touch-ups
+
+- `docs/developer.md` — the `MULMOCLAUDE_SHADOWED_ENV_KEYS` row says the signal is "absent
+  entirely outside `npx mulmoclaude` (see #2610)". No longer true.
+- `e2e-live/tests/docker.spec.ts` — its comment names `server/index.ts:1` as
+  `import "dotenv/config"`. The spec's own behaviour is unaffected (it loads dotenv
+  itself), but the reference goes stale.
+
+## Verification
+
+- `applyEnvFile` unit-tested against a temp dir: file applied, shell value wins, shadowed
+  names returned, missing file a no-op.
+- The union in `announceShadowedEnv` tested at both layers, as in #2604.
+- Manual, as in #2604 but for the dev path: `export GEMINI_API_KEY=…` plus the same key in
+  the repo `.env`, then `yarn dev` → the bell shows it; unset one → it clears.
+
+## Out of scope
+
+The bridges (`packages/bridges/*/src/index.ts`) each carry their own `import
+"dotenv/config"`. They are separate processes with their own cwd and no bell to publish
+to; nothing here applies to them.

--- a/plans/fix-2610-server-dotenv-shadowing.md
+++ b/plans/fix-2610-server-dotenv-shadowing.md
@@ -28,24 +28,29 @@ The load therefore stays a **side-effecting import**, listed first, exactly wher
 
 ## Change
 
-### 1. `server/system/loadEnv.ts` (new)
+### 1. `server/system/envFile.ts` + `server/system/loadEnv.ts` (new)
 
-Replaces `import "dotenv/config"` at `server/index.ts:1`.
+Together they replace `import "dotenv/config"` at the top of `server/index.ts`.
 
 Reuses the launcher's existing pieces rather than a second parser: `parseEnvFile` +
 `mergeLaunchEnv` (`server/utils/launch-env.mjs`) already implement dotenv's no-override
 semantics and already return `skippedKeys`. Parsing stays byte-identical because
 `parseEnvFile` calls `dotenv.parse`.
 
-Split so the logic is testable without a module-load side effect:
+Two modules, because a single one cannot be both:
 
-- `applyEnvFile(cwd, target)` — applies the file's non-shadowed keys to `target`, returns
-  the shadowed names. Takes both as arguments, so a test drives a temp dir and a plain
-  object.
-- the module body calls it once for `process.cwd()` / `process.env` and freezes the
-  result behind `shadowedByServerLoad()`.
+- `envFile.ts` — `applyEnvFile(cwd, target)`, pure, **no load-time side effect**. Takes
+  both as arguments, so a test drives a temp dir and a plain object without ever reading
+  the repository's real `.env`.
+- `loadEnv.ts` — the side-effect entrypoint. Calls it once for `process.cwd()` /
+  `process.env` and freezes the result behind `shadowedByServerLoad()`. Nothing but
+  `server/index.ts` imports it.
 
-Nothing is lost in the swap: `DOTENV_CONFIG_*` is unused anywhere in the repo.
+`DOTENV_CONFIG_*` is deliberately **not** honoured. `dotenv/config` read
+`DOTENV_CONFIG_PATH` / `_OVERRIDE` / `_ENCODING` / `_DEBUG` / `_QUIET`; nothing in this
+repo — code, scripts, CI, Docker — ever set one, and they were never documented as a way
+to configure the server. Rejecting them explicitly (in a comment at the load site) beats
+carrying a config surface no caller uses.
 
 ### 2. Feed it into the existing announce
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,9 @@
-import "dotenv/config";
+// Must stay FIRST and stay an import: importing it populates
+// `process.env` from `<cwd>/.env` during the import phase, before any
+// module below reads env at its own scope. A call in the body would run
+// after every import had already been evaluated — too late. See
+// server/system/loadEnv.ts.
+import { shadowedByServerLoad } from "./system/loadEnv.js";
 // Wire @mulmoclaude/core/collection/server to this host's workspace + logger
 // before any module that touches collection storage loads.
 import "./workspace/collections/configure.js";
@@ -66,7 +71,7 @@ import { capturePhotoLocation } from "./workspace/photo-locations/index.js";
 import { createJournalRouter } from "./api/routes/journal.js";
 import { createTranslationRouter } from "./api/routes/translation.js";
 import { announcePluginMetaDiagnostics } from "./plugins/diagnostics.js";
-import { announceShadowedEnv } from "./system/shadowedEnv.js";
+import { announceShadowedEnv, SHADOWED_ENV_KEYS_VAR } from "./system/shadowedEnv.js";
 import { announceOptionalDeps } from "./system/announceOptionalDeps.js";
 import { announceGeminiKey } from "./system/announceGeminiKey.js";
 import { migrateLegacyBillingPresets } from "./workspace/billing-migration.js";
@@ -915,10 +920,12 @@ async function initBootDiagnostics(): Promise<void> {
   // notification.
   await announcePluginMetaDiagnostics();
 
-  // --- Shell-shadows-`.env` diagnostic (#2604) ---
-  // The launcher reports which `.env` keys the shell had already defined;
-  // without this the user sees no reason why editing `.env` changes nothing.
-  await announceShadowedEnv();
+  // --- Shell-shadows-`.env` diagnostic (#2604, #2610) ---
+  // Two `.env` files can lose to the shell: the user's launch dir, which
+  // the launcher reports, and this process's own cwd, which `yarn dev`
+  // lands in. Without this the user sees no reason why editing `.env`
+  // changes nothing.
+  await announceShadowedEnv(process.env[SHADOWED_ENV_KEYS_VAR], shadowedByServerLoad());
 
   // One settings read shared by the dep announce (gates the whisper warning on
   // voice-input opt-in) and the sidecar warm-up below.

--- a/server/system/envFile.ts
+++ b/server/system/envFile.ts
@@ -1,0 +1,27 @@
+// Pure `.env` application, with no module-load side effect.
+//
+// Split out from `loadEnv.ts` so importing this — as the tests do — can
+// never read the repository's real `.env` or touch `process.env`. The
+// one-shot call against the real ones lives in `loadEnv.ts`, which is
+// the side-effect entrypoint and is imported for that effect alone.
+
+import path from "node:path";
+import { mergeLaunchEnv, parseEnvFile } from "../utils/launch-env.mjs";
+
+/** The shape `process.env` presents. Spelled out rather than using the
+ *  `NodeJS` global namespace, which this repo's eslint config does not
+ *  declare. */
+export type MutableEnv = Record<string, string | undefined>;
+
+/** Apply `<cwd>/.env` to `target`, leaving keys it already defines
+ *  alone, and return the names that lost.
+ *
+ *  Reuses the launcher's `parseEnvFile` + `mergeLaunchEnv`, so the
+ *  parse is `dotenv.parse` and the precedence is the same no-override
+ *  rule `dotenv/config` applied — only the reporting is new. */
+export function applyEnvFile(cwd: string, target: MutableEnv): string[] {
+  const { parsed } = parseEnvFile(path.join(cwd, ".env"));
+  const { loadedKeys, skippedKeys } = mergeLaunchEnv(target, parsed);
+  for (const key of loadedKeys) target[key] = parsed[key];
+  return skippedKeys;
+}

--- a/server/system/loadEnv.ts
+++ b/server/system/loadEnv.ts
@@ -1,0 +1,49 @@
+// The server's own `.env` load, replacing `import "dotenv/config"`.
+//
+// Same semantics as before — read `<cwd>/.env`, let an exported shell
+// variable win — but it now REPORTS which keys the shell shadowed, so
+// the boot diagnostic can say so (#2610). Under `dotenv/config` that
+// information was computed and discarded, leaving `yarn dev` with no
+// signal at all that an edited `.env` was being ignored.
+//
+// This stays a SIDE-EFFECTING IMPORT, first in `server/index.ts`, and
+// must not become a function call there. ESM evaluates every import
+// before the first statement of the module body, so a call on line 1 of
+// the body would run after every imported module had already been
+// evaluated — `server/workspace/paths.ts` reads `process.env` at its own
+// module scope and would see an empty environment.
+//
+// Parsing is byte-identical to before: `parseEnvFile` calls
+// `dotenv.parse`. Nothing else is lost — `DOTENV_CONFIG_*` (the only
+// behaviour `dotenv/config` adds over `dotenv.config()`) is unused
+// across the repo.
+
+import path from "node:path";
+import { mergeLaunchEnv, parseEnvFile } from "../utils/launch-env.mjs";
+
+/** The shape `process.env` presents. Spelled out rather than using the
+ *  `NodeJS` global namespace, which this repo's eslint config does not
+ *  declare. */
+export type MutableEnv = Record<string, string | undefined>;
+
+/** Apply `<cwd>/.env` to `target`, leaving keys it already defines
+ *  alone, and return the names that lost.
+ *
+ *  Both inputs are arguments rather than `process.cwd()` / `process.env`
+ *  so this is drivable from a test — the module-level call below is the
+ *  only place that touches the real ones. */
+export function applyEnvFile(cwd: string, target: MutableEnv): string[] {
+  const { parsed } = parseEnvFile(path.join(cwd, ".env"));
+  const { loadedKeys, skippedKeys } = mergeLaunchEnv(target, parsed);
+  for (const key of loadedKeys) target[key] = parsed[key];
+  return skippedKeys;
+}
+
+const shadowed: readonly string[] = Object.freeze(applyEnvFile(process.cwd(), process.env));
+
+/** Keys this process's own `.env` load lost to the shell. Empty under
+ *  `npx mulmoclaude`, whose cwd is the package directory — there the
+ *  launcher does the equivalent for the user's launch dir. */
+export function shadowedByServerLoad(): readonly string[] {
+  return shadowed;
+}

--- a/server/system/loadEnv.ts
+++ b/server/system/loadEnv.ts
@@ -6,38 +6,27 @@
 // information was computed and discarded, leaving `yarn dev` with no
 // signal at all that an edited `.env` was being ignored.
 //
-// This stays a SIDE-EFFECTING IMPORT, first in `server/index.ts`, and
-// must not become a function call there. ESM evaluates every import
-// before the first statement of the module body, so a call on line 1 of
-// the body would run after every imported module had already been
-// evaluated — `server/workspace/paths.ts` reads `process.env` at its own
-// module scope and would see an empty environment.
+// This module exists to be imported for its SIDE EFFECT, first in
+// `server/index.ts`, and that import must not become a function call
+// there. ESM evaluates every import before the first statement of the
+// module body, so a call on line 1 of the body would run after every
+// imported module had already been evaluated — `server/workspace/
+// paths.ts` reads `process.env` at its own module scope and would see an
+// unpopulated environment. That is measured, not assumed: moving the
+// load into the body makes `paths.ts` resolve `~/mulmoclaude` instead of
+// the `.env` value.
 //
-// Parsing is byte-identical to before: `parseEnvFile` calls
-// `dotenv.parse`. Nothing else is lost — `DOTENV_CONFIG_*` (the only
-// behaviour `dotenv/config` adds over `dotenv.config()`) is unused
-// across the repo.
+// The logic itself lives in `envFile.ts` precisely so a test can drive
+// it without triggering the load below.
+//
+// `DOTENV_CONFIG_*` is deliberately NOT honoured. `dotenv/config` read
+// `DOTENV_CONFIG_PATH` / `_OVERRIDE` / `_ENCODING` / `_DEBUG` /
+// `_QUIET`; nothing in this repo — code, scripts, CI, Docker — ever set
+// one, and they were never a documented way to configure the server. The
+// file is always `<cwd>/.env` and the shell always wins. Reintroduce an
+// option here only with a caller that needs it.
 
-import path from "node:path";
-import { mergeLaunchEnv, parseEnvFile } from "../utils/launch-env.mjs";
-
-/** The shape `process.env` presents. Spelled out rather than using the
- *  `NodeJS` global namespace, which this repo's eslint config does not
- *  declare. */
-export type MutableEnv = Record<string, string | undefined>;
-
-/** Apply `<cwd>/.env` to `target`, leaving keys it already defines
- *  alone, and return the names that lost.
- *
- *  Both inputs are arguments rather than `process.cwd()` / `process.env`
- *  so this is drivable from a test — the module-level call below is the
- *  only place that touches the real ones. */
-export function applyEnvFile(cwd: string, target: MutableEnv): string[] {
-  const { parsed } = parseEnvFile(path.join(cwd, ".env"));
-  const { loadedKeys, skippedKeys } = mergeLaunchEnv(target, parsed);
-  for (const key of loadedKeys) target[key] = parsed[key];
-  return skippedKeys;
-}
+import { applyEnvFile } from "./envFile.js";
 
 const shadowed: readonly string[] = Object.freeze(applyEnvFile(process.cwd(), process.env));
 

--- a/server/system/shadowedEnv.ts
+++ b/server/system/shadowedEnv.ts
@@ -64,12 +64,16 @@ const ENV_VAR_NAME = /^[A-Za-z_]\w*$/;
  *  into a log line and a bell entry. Filtering here makes "names only" a
  *  property of the code rather than a promise about the producer. */
 export function parseShadowedEnvKeys(raw: string | undefined): string[] {
-  if (!raw) return [];
-  const keys = raw
-    .split(",")
-    .map((key) => key.trim())
-    .filter((key) => ENV_VAR_NAME.test(key));
-  return [...new Set(keys)].sort();
+  return raw ? normalizeShadowedEnvKeys(raw.split(",")) : [];
+}
+
+/** The same trim / validate / de-dupe / sort rule applied to keys that
+ *  arrive as a list rather than a CSV — the server's own `.env` load
+ *  (#2610) hands them over directly. Shared so both sources produce one
+ *  identity for the same conflict. */
+export function normalizeShadowedEnvKeys(keys: readonly string[]): string[] {
+  const clean = keys.map((key) => key.trim()).filter((key) => ENV_VAR_NAME.test(key));
+  return [...new Set(clean)].sort();
 }
 
 /** Render the key list for humans, capped. */
@@ -143,9 +147,19 @@ async function clearStale(entryIds: readonly string[]): Promise<void> {
 }
 
 /** Run at boot, after the notifier engine is initialised. No-ops unless
- *  the launcher reported shadowed keys. */
-export async function announceShadowedEnv(raw: string | undefined = process.env[SHADOWED_ENV_KEYS_VAR]): Promise<ShadowedEnvDiagnostic | null> {
-  const diagnostic = shadowedEnvDiagnostic(parseShadowedEnvKeys(raw));
+ *  something reported shadowed keys.
+ *
+ *  Two sources, one notification. The launcher covers the user's launch
+ *  directory (#2604); `serverLoadKeys` covers the `.env` this process
+ *  read from its own cwd (#2610) — which is where `yarn dev` lands, and
+ *  had no signal at all before. Only one of the two is ever non-empty in
+ *  practice, but they union rather than compete so neither can mask the
+ *  other. */
+export async function announceShadowedEnv(
+  raw: string | undefined = process.env[SHADOWED_ENV_KEYS_VAR],
+  serverLoadKeys: readonly string[] = [],
+): Promise<ShadowedEnvDiagnostic | null> {
+  const diagnostic = shadowedEnvDiagnostic(normalizeShadowedEnvKeys([...parseShadowedEnvKeys(raw), ...serverLoadKeys]));
   // Nothing shadowed now, but a previous boot may have said otherwise —
   // leaving that entry up would keep pointing at a conflict the user has
   // already resolved.

--- a/server/system/shadowedEnv.ts
+++ b/server/system/shadowedEnv.ts
@@ -159,30 +159,34 @@ export async function announceShadowedEnv(
   raw: string | undefined = process.env[SHADOWED_ENV_KEYS_VAR],
   serverLoadKeys: readonly string[] = [],
 ): Promise<ShadowedEnvDiagnostic | null> {
-  const diagnostic = shadowedEnvDiagnostic(normalizeShadowedEnvKeys([...parseShadowedEnvKeys(raw), ...serverLoadKeys]));
-  // Nothing shadowed now, but a previous boot may have said otherwise —
-  // leaving that entry up would keep pointing at a conflict the user has
-  // already resolved.
-  if (!diagnostic) {
-    await clearStale((await inspectActive("")).staleEntryIds);
-    return null;
-  }
+  const keys = normalizeShadowedEnvKeys([...parseShadowedEnvKeys(raw), ...serverLoadKeys]);
+  const diagnostic = shadowedEnvDiagnostic(keys);
+  // `""` matches no id, so with nothing shadowed every existing entry
+  // counts as stale — a boot that finds the conflict resolved retracts
+  // the warning instead of leaving it pointing at a fixed problem.
+  const active = await inspectActive(diagnostic?.id ?? "");
+  await clearStale(active.staleEntryIds);
+  if (!diagnostic) return null;
 
   log.warn(LOG_PREFIX, diagnostic.message, { keys: diagnostic.keys });
-  const active = await inspectActive(diagnostic.id);
-  await clearStale(active.staleEntryIds);
   if (active.alreadyShowing) {
     log.debug(LOG_PREFIX, "already in active set; skipping republish", { id: diagnostic.id });
     return diagnostic;
   }
+  publishShadowedEnv(diagnostic);
+  return diagnostic;
+}
+
+function publishShadowedEnv(diagnostic: ShadowedEnvDiagnostic): void {
   publishNotification({
     id: diagnostic.id,
     kind: "system",
+    // English fallback for the log line and the macOS Reminder push,
+    // neither of which has vue-i18n; the UI reads `i18n` instead.
     title: "Shell env is overriding .env",
     body: diagnostic.message,
     action: { type: NOTIFICATION_ACTION_TYPES.none },
     priority: NOTIFICATION_PRIORITIES.high,
     i18n: diagnostic.i18n,
   });
-  return diagnostic;
 }

--- a/test/system/test_loadEnv.ts
+++ b/test/system/test_loadEnv.ts
@@ -1,0 +1,72 @@
+// The server's own `.env` load (#2610) — what `import "dotenv/config"`
+// used to do, plus the part it threw away.
+//
+// `applyEnvFile` takes its cwd and its target as arguments precisely so
+// this file never touches `process.cwd()` / `process.env`; the module's
+// own one-shot call against the real ones is the only place that does.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { applyEnvFile, type MutableEnv } from "../../server/system/loadEnv.js";
+
+let dir: string;
+const writeEnv = (contents: string) => writeFileSync(path.join(dir, ".env"), contents);
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "test-load-env-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("applyEnvFile", () => {
+  it("applies a key the target doesn't have", () => {
+    writeEnv("GEMINI_API_KEY=from-file\n");
+    const target: MutableEnv = {};
+    assert.deepEqual(applyEnvFile(dir, target), []);
+    assert.equal(target.GEMINI_API_KEY, "from-file");
+  });
+
+  it("leaves an existing value alone and reports it as shadowed", () => {
+    writeEnv("GEMINI_API_KEY=from-file\n");
+    const target: MutableEnv = { GEMINI_API_KEY: "from-shell" };
+    assert.deepEqual(applyEnvFile(dir, target), ["GEMINI_API_KEY"]);
+    assert.equal(target.GEMINI_API_KEY, "from-shell", "the shell value must win, as dotenv always did");
+  });
+
+  it("reports only the keys that actually lost", () => {
+    writeEnv("A=file\nB=file\nC=file\n");
+    const target: MutableEnv = { B: "shell" };
+    assert.deepEqual(applyEnvFile(dir, target), ["B"]);
+    assert.equal(target.A, "file");
+    assert.equal(target.B, "shell");
+    assert.equal(target.C, "file");
+  });
+
+  it("counts an empty shell value as set — that is the confusing case, not an exception to it", () => {
+    // `export GEMINI_API_KEY=` still shadows the file under dotenv, and
+    // an empty key that silently beats a real one is exactly the trap
+    // this diagnostic exists for.
+    writeEnv("GEMINI_API_KEY=from-file\n");
+    const target: MutableEnv = { GEMINI_API_KEY: "" };
+    assert.deepEqual(applyEnvFile(dir, target), ["GEMINI_API_KEY"]);
+    assert.equal(target.GEMINI_API_KEY, "");
+  });
+
+  it("is a no-op when there is no .env", () => {
+    const target: MutableEnv = { EXISTING: "kept" };
+    assert.deepEqual(applyEnvFile(dir, target), []);
+    assert.deepEqual(target, { EXISTING: "kept" });
+  });
+
+  it("is a no-op for an empty .env", () => {
+    writeEnv("");
+    const target: MutableEnv = {};
+    assert.deepEqual(applyEnvFile(dir, target), []);
+    assert.deepEqual(target, {});
+  });
+});

--- a/test/system/test_loadEnv.ts
+++ b/test/system/test_loadEnv.ts
@@ -1,16 +1,17 @@
 // The server's own `.env` load (#2610) — what `import "dotenv/config"`
 // used to do, plus the part it threw away.
 //
-// `applyEnvFile` takes its cwd and its target as arguments precisely so
-// this file never touches `process.cwd()` / `process.env`; the module's
-// own one-shot call against the real ones is the only place that does.
+// `applyEnvFile` lives in its own module with no load-time side effect,
+// so importing it here cannot read the repository's real `.env` or touch
+// `process.env`. The one-shot call against the real ones is in
+// `loadEnv.ts`, which nothing but `server/index.ts` imports.
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { applyEnvFile, type MutableEnv } from "../../server/system/loadEnv.js";
+import { applyEnvFile, type MutableEnv } from "../../server/system/envFile.js";
 
 let dir: string;
 const writeEnv = (contents: string) => writeFileSync(path.join(dir, ".env"), contents);

--- a/test/system/test_shadowedEnv.ts
+++ b/test/system/test_shadowedEnv.ts
@@ -13,7 +13,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseShadowedEnvKeys, shadowedEnvDiagnostic } from "../../server/system/shadowedEnv.js";
+import { normalizeShadowedEnvKeys, parseShadowedEnvKeys, shadowedEnvDiagnostic } from "../../server/system/shadowedEnv.js";
 
 describe("parseShadowedEnvKeys", () => {
   it("reads the launcher's CSV", () => {
@@ -42,6 +42,17 @@ describe("parseShadowedEnvKeys", () => {
   it("de-duplicates and sorts, so parse order can't change the identity", () => {
     assert.deepEqual(parseShadowedEnvKeys("B,A,B"), ["A", "B"]);
     assert.deepEqual(parseShadowedEnvKeys("A,B"), parseShadowedEnvKeys("B,A"));
+  });
+});
+
+describe("normalizeShadowedEnvKeys", () => {
+  // The server's own `.env` load hands keys over as a list, not a CSV
+  // (#2610). Both entry points must reduce to the same identity, or the
+  // two sources would produce two different ids for one conflict.
+  it("applies the same rule as the CSV path", () => {
+    assert.deepEqual(normalizeShadowedEnvKeys([" B ", "A", "B"]), parseShadowedEnvKeys("A,B"));
+    assert.deepEqual(normalizeShadowedEnvKeys(["GEMINI_API_KEY=would-leak"]), []);
+    assert.deepEqual(normalizeShadowedEnvKeys([]), []);
   });
 });
 

--- a/test/system/test_shadowedEnv_bell.ts
+++ b/test/system/test_shadowedEnv_bell.ts
@@ -81,6 +81,23 @@ describe("announceShadowedEnv", () => {
     assert.deepEqual(await listAll(), []);
   });
 
+  it("merges the launcher's keys with the server's own into ONE notification (#2610)", async () => {
+    // Launcher saw the launch-dir `.env` lose A; this process saw its own
+    // cwd `.env` lose B. Two sources, one conflict to describe.
+    await announceShadowedEnv("A", ["B"]);
+    const entries = await activeEntries(1);
+    assert.equal(entries.length, 1, "two sources must not produce two notifications");
+    assert.match(entries[0].body ?? "", /A/);
+    assert.match(entries[0].body ?? "", /B/);
+  });
+
+  it("raises the notification from the server's own load alone — the yarn dev case", async () => {
+    await announceShadowedEnv(undefined, ["GEMINI_API_KEY"]);
+    const [entry] = await activeEntries(1);
+    assert.ok(entry);
+    assert.match(entry.body ?? "", /GEMINI_API_KEY/);
+  });
+
   it("does not stack a duplicate when a reboot finds the same conflict", async () => {
     await announceShadowedEnv("A,B");
     await activeEntries(1);


### PR DESCRIPTION
## Summary

Closes #2610. Follows #2604.

#2604 gave the launcher path an in-app notification when the shell shadows a launch-dir `.env`. The server reaches a `.env` by a **second route** that got nothing: `import "dotenv/config"` read `<cwd>/.env` with the same shell-wins rule and threw away what it skipped.

| launch | server cwd | `.env` read | signal before |
| --- | --- | --- | --- |
| `npx mulmoclaude` | `packages/mulmoclaude/` | none exists — no-op | launcher detects it (#2604) |
| `yarn dev` / `tsx server/index.ts` | repo root | **the repo's own `.env`** | **none, not even a log line** |

So this is the dev path. Same dead end — edit `.env`, restart, nothing changes — with less to go on than the case #2604 fixed.

`server/system/loadEnv.ts` replaces the import and reports what it skipped; `announceShadowedEnv` unions those keys with the launcher's into one notification.

## Items to Confirm / Review

1. **The ESM ordering is the whole risk, and it was verified rather than reasoned about.** `import "dotenv/config"` cannot become a function call: every import is evaluated before the first statement of the body, and `server/workspace/paths.ts` reads `process.env` at its own module scope. A probe with the load moved into the body made `paths.ts` compute `~/mulmoclaude` instead of the `.env` value — confirmed, not assumed. The load therefore stays a side-effecting import at `server/index.ts:1`. **If a future change turns that line into a call, this breaks silently.** The comment there says so.

   Worth knowing how that check went: my first control experiment was **invalid** — it imported `applyEnvFile`, which already triggers `loadEnv.ts`'s module-scope call, so the body call was redundant and everything passed. The real control had to bypass the module entirely.

2. **`@mulmoclaude/core` bumps to 1.7.1** because `assets/helps/*` ships to npm, with the launcher's range moved in the same PR per the sync gate. No publish here. Other consumers stay at `^1.7.0`, which still matches npm's latest — they move on their own next release.

3. **A MUST that #2604 missed, fixed here.** `error-recovery.md` had no shadowing entry, and the omission had teeth: the section already in that file tells the agent to *"add the missing key to `.env` (restart the server)"* — exactly the advice that fails silently in this state. The agent reads that file before asking the user a clarifying question, so the know-how was absent where it mattered most.

4. **No manual check on the dev path.** #2604's launcher path was exercised for real; this one is covered by unit tests and the ordering probe, but nobody ran `yarn dev` with a conflicting `export` and looked at the bell.

5. **Deliberately no `.env` path in the notification text** (decided when scoping): only one of the two files is ever in play, so naming it would cost an 8-locale change for a distinction the user cannot currently hit.

## User Prompt

> #2600 以降の open な issue を順次、できるものは対応していく

Decisions made in that conversation, for #2610:

> - dev 経路: ベル通知まで（#2604 と同じ通知を出す）
> - 通知に `.env` のパスを含めるか: 含めない（現状維持）

## Implementation

### `server/system/loadEnv.ts` (new)

Reuses the launcher's `parseEnvFile` + `mergeLaunchEnv` rather than parsing again — those already implement dotenv's no-override semantics and already return `skippedKeys`. Loaded values stay byte-identical because `parseEnvFile` calls `dotenv.parse`. Nothing is lost in the swap: `DOTENV_CONFIG_*`, the only behaviour `dotenv/config` adds over `dotenv.config()`, is unused across the repo.

Split so the logic is testable without a module-load side effect:

- `applyEnvFile(cwd, target)` — takes both as arguments, so a test drives a temp dir and a plain object
- the module body calls it once against the real `process.cwd()` / `process.env` and freezes the result behind `shadowedByServerLoad()`

### The union

`announceShadowedEnv(raw, serverLoadKeys)` — both sources, **one** notification with the union of names. `parseShadowedEnvKeys` and the new `normalizeShadowedEnvKeys` share one trim / validate / de-dupe / sort rule, so a CSV and a list reduce to the same identity and cannot produce two ids for one conflict.

`shadowedEnv.ts` deliberately does **not** import `loadEnv.ts`: that would make merely importing the diagnostic read the repo's real `.env`, which is exactly the side effect its tests must not have. `server/index.ts` wires them together instead.

### Documentation

- `error-recovery.md` — new section (see item 3)
- `docs/developer.md` — the `MULMOCLAUDE_SHADOWED_ENV_KEYS` row claimed the signal was "absent entirely outside `npx mulmoclaude`". No longer true.
- `e2e-live/tests/docker.spec.ts` — its comment named `server/index.ts:1` as `import "dotenv/config"`. Behaviour unaffected (the spec loads dotenv itself); the reference would have gone stale.

## Out of scope

The bridges (`packages/bridges/*/src/index.ts`) each carry their own `import "dotenv/config"`. Separate processes, own cwd, no bell to publish to.

## Tests

`test/system/test_loadEnv.ts` (new) — `applyEnvFile` against a temp dir: file applied, shell value wins, only the losers reported, **an empty shell value counts as set** (`export FOO=` shadows just as hard, and a blank key silently beating a good one is the trap itself), missing / empty file a no-op.

`test_shadowedEnv.ts` / `test_shadowedEnv_bell.ts` — extended for the union: two sources produce one notification carrying both names, and the server-only case (the `yarn dev` shape) raises it on its own.

## Gates

| gate | result |
| --- | --- |
| `yarn format` / `yarn lint` | 0 errors (46 pre-existing warnings) |
| `yarn typecheck` / `yarn build` | exit 0 |
| `yarn test` | exit 0 — 8307 tests, 0 fail (11 new) |
| `check:launcher-sync` | OK |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment-shadowing diagnostics by including both launcher and server `.env`-loading conflicts in a single warning.
  * Ensures `.env` values no longer silently fail when overridden by pre-existing environment exports (including empty exports).
* **Documentation**
  * Added end-user troubleshooting help for “API key in `.env` has no effect” due to shell overrides.
  * Clarified server handoff behavior in developer docs.
* **Tests**
  * Added system tests for `.env` application and normalized shadowed-key merging/notification behavior.
* **Maintenance**
  * Version bumps for core and related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->