### PR TITLE
update

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "eslint-plugin-security": "^4.0.1",
     "eslint-plugin-sonarjs": "^4.2.0",
     "eslint-plugin-vue": "^10.10.0",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "jsdom": "^29.1.1",
     "jsonc-eslint-parser": "^3.1.0",
     "knip": "^6.29.0",

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -28,7 +28,7 @@
     "@mulmoclaude/common": "^1.1.1",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -28,7 +28,7 @@
     "@mulmoclaude/common": "^1.1.1",
     "dotenv": "^17.0.0",
     "express": "^5.0.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -27,7 +27,7 @@
     "@mulmobridge/webhook-runtime": "^1.0.2",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -28,7 +28,7 @@
     "@mulmoclaude/common": "^1.1.1",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -28,7 +28,7 @@
     "@mulmoclaude/common": "^1.1.1",
     "dotenv": "^17.0.0",
     "express": "^5.0.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -28,7 +28,7 @@
     "@mulmoclaude/common": "^1.1.1",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -52,7 +52,7 @@
     "echarts": "^6.1.0",
     "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "gui-chat-protocol": "^1.2.0",
     "tailwindcss": "^4.3.3",
     "typescript": "~6.0.2",

--- a/packages/plugins/form-plugin/package.json
+++ b/packages/plugins/form-plugin/package.json
@@ -47,7 +47,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "gui-chat-protocol": "^1.2.0",
     "tailwindcss": "^4.3.3",
     "typescript": "~6.0.2",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -54,7 +54,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "gui-chat-protocol": "^1.2.0",
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.1",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -57,7 +57,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "gui-chat-protocol": "^1.2.0",
     "tailwindcss": "^4.3.3",
     "typescript": "~6.0.2",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -61,7 +61,7 @@
     "@vitejs/plugin-vue": "^6.0.8",
     "eslint": "^10.8.0",
     "eslint-plugin-vue": "^10.10.0",
-    "globals": "^17.7.0",
+    "globals": "^17.8.0",
     "tailwindcss": "^4.3.2",
     "tsx": "^4.23.1",
     "typescript": "^6.0.3",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint src test"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^5.20260724.1",
+    "@cloudflare/workers-types": "^5.20260727.1",
     "typescript": "^6.0.3",
     "wrangler": "^4.114.0"
   },

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -28,7 +28,7 @@
   "author": "Receptron Team",
   "dependencies": {
     "express": "^5.1.0",
-    "express-rate-limit": "^8.6.0"
+    "express-rate-limit": "^8.6.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,10 +298,10 @@
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz#d2378b95fad122c574a97e25fe03aea3425aec92"
   integrity sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==
 
-"@cloudflare/workers-types@^5.20260724.1":
-  version "5.20260724.1"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-5.20260724.1.tgz#46fa4060e3273d43d82b70e5ef66ca4341b536d7"
-  integrity sha512-gl0brZ60JhkZU3INgr1jsxaFEiWf3AB9RsCjLTMwT5RKspWRUpsFd0wxwbys7gb8Ywkfq9tORhw0y9G+7bDUYw==
+"@cloudflare/workers-types@^5.20260727.1":
+  version "5.20260727.1"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-5.20260727.1.tgz#032e6feb658fd337c9fce96eed17ca35192c0bdb"
+  integrity sha512-b/wT+LMZz0oELzxibww0ujFz5BD8NRz9WJ+xd+JNZJUMXgh8IHjpibKdGDvtkbotmihWUknP5tBPUU8KluLxxA==
 
 "@codemirror/autocomplete@^6.0.0":
   version "6.20.2"
@@ -1888,13 +1888,6 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
-
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -4393,11 +4386,6 @@ chokidar@^5.0.0:
   dependencies:
     readdirp "^5.0.0"
 
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
-
 chromium-bidi@16.0.1:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-16.0.1.tgz#0c6b0e55065468fc777d62032b63b73f614b1d88"
@@ -5852,10 +5840,18 @@ exifr@^7.1.3:
   resolved "https://registry.yarnpkg.com/exifr/-/exifr-7.1.3.tgz#f6218012c36dbb7d843222011b27f065fddbab6f"
   integrity sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==
 
-express-rate-limit@^8.2.1, express-rate-limit@^8.6.0:
+express-rate-limit@^8.2.1:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.6.0.tgz#2e64ab10361da35881519ea92b426a43f8aa8c79"
   integrity sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==
+  dependencies:
+    debug "^4.4.3"
+    ip-address "^10.2.0"
+
+express-rate-limit@^8.6.1:
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.6.1.tgz#e0977ec8075346e207d788383362ada7c08324ae"
+  integrity sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==
   dependencies:
     debug "^4.4.3"
     ip-address "^10.2.0"
@@ -6355,6 +6351,11 @@ globals@^17.0.0, globals@^17.7.0:
   version "17.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.7.0.tgz#553d55090b4dde8209ec2da42580d6e7e7d8b10d"
   integrity sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==
+
+globals@^17.8.0:
+  version "17.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-17.8.0.tgz#a1f213a06adcd0eec38004c5cd39fef7af7e0830"
+  integrity sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -7892,17 +7893,10 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
-
-minizlib@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
-  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
-  dependencies:
-    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -9806,17 +9800,6 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.22:
-  version "7.5.22"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
-  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -10119,10 +10102,15 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.28.0, undici@^6.27.0, undici@^7.0.0, undici@^7.25.0:
+undici@7.28.0, undici@^7.0.0, undici@^7.25.0:
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+
+undici@^6.27.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unenv@2.0.0-rc.24:
   version "2.0.0-rc.24"
@@ -10250,10 +10238,20 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, uuid@14.0.1, uuid@^10.0.0, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1, uuid@^8.3.0:
+uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -10679,11 +10677,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION


## Summary by Sourcery

Bump dependency versions across bridges, plugins, and relay packages to keep third-party libraries up to date.

Enhancements:
- Update express-rate-limit to ^8.6.1 across bridge and webhook-runtime packages.
- Update globals to ^17.8.0 in root and plugin packages.
- Update @cloudflare/workers-types to ^5.20260727.1 in the relay package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rate-limiting components to the latest patch release.
  * Refreshed development tooling and environment type definitions across the project.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->