### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.7.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ---
 
+## [1.7.2] - 2026-07-27
+
+**A `.env` you edit that has no effect, and no way to tell why.**
+
+### Highlights
+
+#### The app says when your shell is overriding `.env` (#2604, PR #2612 — and #2610, PR #2614)
+
+`.env` loses to an exported shell variable. That is dotenv's documented rule and it was working correctly — the problem was that losing was invisible. With a stale `export GEMINI_API_KEY=…` left in `~/.zshrc`, you can correct `.env` as many times as you like, restart every time, and nothing changes, with nothing anywhere pointing at the shell. The report that started this came out of exactly that loop.
+
+A single definition is unambiguous and fine. The failure needs two definitions and no visible precedence.
+
+The launcher already knew which keys had lost — `mergeLaunchEnv` returns them — and turned the fact into one terminal log line that is easy to scroll past. It now hands the key **names** (never values) to the server, which raises a notification in the bell naming them and saying which side won. The entry is de-duplicated by a stable id, so restarting with the conflict unfixed does not stack a second one; fixing one of two keys **replaces** the entry rather than leaving one that still names the key you just fixed; and a boot with nothing shadowed **retracts** the warning entirely.
+
+`yarn dev` reached a `.env` by a second route that got none of this (#2610): the server's own `import "dotenv/config"` read `<cwd>/.env` with the same shell-wins rule and discarded what it skipped — the same dead end with even less to go on, since the launcher's log line is not there either. That import is now a reporting loader, and both routes feed one notification.
+
+Along the way, `error-recovery.md` — the file the agent reads before asking you a clarifying question about a tool failure — gained a section for this state. It needed one: the section already there told the agent to *"add the missing key to `.env` (restart the server)"*, which is precisely the advice that fails silently here. It also corrects two things the obvious guidance gets wrong: an **empty** export (`export GEMINI_API_KEY=`) shadows just as hard, and `echo "$VAR"` cannot detect that case because unset and set-but-empty both print blank.
+
+Ships the same scoped package versions as 1.7.1, except `@mulmoclaude/core@1.7.1` (the `error-recovery.md` addition).
+
+---
+
 ## [1.7.1] - 2026-07-27
 
 **Icons that rendered as their own names instead of glyphs.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -123,7 +123,7 @@ Recommended: ≥ 32 characters of random data (shorter values trigger a startup 
 
 ## Optional features
 
-- **Gemini API key** (`GEMINI_API_KEY` in environment or `.env`) — enables AI image generation (`generateImage`), audio / video. Free tier suffices for everyday use; get one from [Google AI Studio](https://aistudio.google.com/).
+- **Gemini API key** (`GEMINI_API_KEY` in environment or `.env`) — enables AI image generation (`generateImage`), audio / video. Free tier suffices for everyday use; get one from [Google AI Studio](https://aistudio.google.com/). Set it in both places and the exported shell value wins, `.env` is ignored — the app now says so in the notification bell instead of leaving you editing a file that has no effect.
 - **Local voice input** (macOS only, opt-in) — `whisper.cpp` for dictating chat messages without sending audio to a cloud API.
 - **Marp slides** — `marp: true` frontmatter on any markdown file renders a slide deck in the canvas with PDF export. Custom themes via `config/marp-themes/<name>.css`.
 - **Auto memory** — the agent maintains a typed memory layout (`conversations/memory/<type>/<topic>.md`) and reads it ambient-style.

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release PR for `mulmoclaude@1.7.2`. **Already published to npm** — this PR carries the version bumps, README line and CHANGELOG entry that the publish flow requires to land on `main`.

`mulmoclaude@1.7.1` predates #2604 and #2610: both the launcher's own `bin/mulmoclaude.js` and the `server/` source it bundles changed after that publish, so npx users had none of this session's `.env` work.

## Published

| package | version | note |
| --- | --- | --- |
| `@mulmoclaude/core` | 1.7.1 | published **first** — the launcher declares `^1.7.1` and a fresh install would otherwise ETARGET. Only change since 1.7.0 is the `error-recovery.md` section |
| `mulmoclaude` | 1.7.2 | the launcher |

## Pre-publish checks (all green)

| check | result |
| --- | --- |
| §1 dependency audit (`deps.mjs`) | OK — no missing dependencies |
| §2 workspace drift (`drift.mjs`) | OK — all 4 `@mulmobridge/*` match their published dist |
| §3.5 README | flags match `bin` + `cli-flags.mjs` exactly; 156 lines, in the target range |
| §4 tarball smoke (`tarball.mjs`) | OK — HTTP 200, 5 runtime plugins loaded |
| §4 CI go/no-go | `MulmoClaude publish smoke` green on `b7ee42810` (main HEAD) |
| §6 internal dep resolution | every `@mulmoclaude/*` / `@mulmobridge/*` dep resolves on the public registry |
| §6 npx verify | `npx mulmoclaude@1.7.2 --version` → `mulmoclaude 1.7.2` from a clean install |
| launcher-sync | OK |

Tarball confirmed to contain `README.md` and the three new modules (`server/system/{envFile,loadEnv,shadowedEnv}.ts`), 1013 files.

## Items to Confirm / Review

1. **`@mulmoclaude/core@1.7.1` is a docs-only release.** `dist/` is byte-identical to 1.7.0; the sole change is the `error-recovery.md` section. It needed publishing because `assets/` ships to npm and the agent reads that file at runtime.

2. **Root and launcher versions are in lockstep** (both 1.7.2), per §5.5 — so the `v1.7.2` app tag will match what is on npm.

3. **The `v1.7.2` app release + `--latest` tag is still to come** (§9b), after this merges.

## Next

- `v1.7.2` GitHub release marked `--latest`, tagged at the merge commit

## Summary by Sourcery

Document the 1.7.2 release and bump the root monorepo and launcher package versions to 1.7.2.

Documentation:
- Add CHANGELOG entry describing the 1.7.2 release and its .env shadowing behavior.
- Clarify README guidance for GEMINI_API_KEY precedence between shell environment and .env.