### PR TITLE
fix(launcher): the icon launch could never load a .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npx mulmoclaude@latest create-shortcut
 
 This writes `MulmoClaude.app` to `/Applications` (or `~/Applications` if that is not writable — pass `--dir <path>` to choose, `--yes` to skip the prompt). Double-clicking it checks the prerequisites, shows a progress page while the server starts, and opens the app when it is ready. If the server is already running it just opens the browser rather than starting a second one.
 
-When something is missing — Node.js, npm, or Claude Code — it says which one and what to run, in your system language. Its log is at `~/Library/Logs/MulmoClaude/launcher.log`.
+When something is missing — Node.js, `npx`, or Claude Code — it says which one and what to run, in your system language. Its log is at `~/Library/Logs/MulmoClaude/launcher.log`.
 
 > **Where `.env` goes**: a terminal launch reads `.env` from the directory you launched in. An icon has no such directory (macOS starts apps in `/`), so the icon launch reads `~/.env` — your home directory.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This writes `MulmoClaude.app` to `/Applications` (or `~/Applications` if that is
 
 When something is missing — Node.js, npm, or Claude Code — it says which one and what to run, in your system language. Its log is at `~/Library/Logs/MulmoClaude/launcher.log`.
 
+> **Where `.env` goes**: a terminal launch reads `.env` from the directory you launched in. An icon has no such directory (macOS starts apps in `/`), so the icon launch reads `~/.env` — your home directory.
+
 Re-run the command after upgrading: the bundle carries its own copy of the launcher.
 
 ### Prerequisites

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -62,7 +62,7 @@ npx mulmoclaude create-shortcut --yes        # Skip the confirmation prompt
 Creates a real app bundle (no Electron — an `Info.plist` and a shell stub) in `/Applications`, or `~/Applications` when that is not writable. Double-clicking it:
 
 1. reuses an already-running MulmoClaude by just opening the browser,
-2. checks Node.js, npm, and Claude Code, and explains in your system language what to do when one is missing,
+2. checks Node.js, `npx` and Claude Code, and explains in your system language what to do when one is missing,
 3. shows a progress page while `npx mulmoclaude@latest` starts, then switches to the app.
 
 A GUI launch gets none of your shell's `PATH`, so the bundle asks your login shell for it before looking for anything — this is why a version manager (nodebrew / nvm / asdf / Volta) still works from the icon.

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -67,6 +67,8 @@ Creates a real app bundle (no Electron — an `Info.plist` and a shell stub) in 
 
 A GUI launch gets none of your shell's `PATH`, so the bundle asks your login shell for it before looking for anything — this is why a version manager (nodebrew / nvm / asdf / Volta) still works from the icon.
 
+It also starts the server from your home directory rather than the `/` macOS hands a GUI app, so the `.env` it loads is `~/.env`.
+
 The launcher writes `~/Library/Logs/MulmoClaude/launcher.log`. The bundle carries its own copy of the launcher code, so re-run the command after upgrading. Windows is not supported yet.
 
 ## How it works

--- a/server/utils/launcher/start.d.mts
+++ b/server/utils/launcher/start.d.mts
@@ -4,6 +4,8 @@ export function launcherLogPath(home?: string): string;
 
 export function detectLocale(options?: { env?: Record<string, string | undefined>; run?: () => string }): string;
 
+export function serverSpawnPlan(options: { port: number; home?: string }): { command: string; args: string[]; cwd: string };
+
 export interface StartLauncherOptions {
   env?: Record<string, string | undefined>;
   tmpDir?: string;

--- a/server/utils/launcher/start.d.mts
+++ b/server/utils/launcher/start.d.mts
@@ -1,6 +1,6 @@
 // Type declarations for start.mjs.
 
-export function launcherLogPath(home?: string): string;
+export function launcherLogPath(home?: string, platform?: string): string;
 
 export function detectLocale(options?: { env?: Record<string, string | undefined>; run?: () => string; platform?: string; intl?: () => string }): string;
 

--- a/server/utils/launcher/start.mjs
+++ b/server/utils/launcher/start.mjs
@@ -105,12 +105,35 @@ function toPageFailure(messages, { key, values }) {
 // holding the read ends — the process never exits, which is the exact
 // opposite of detaching — and killing it would then break the server's
 // stdout mid-write.
+/**
+ * What to spawn, and from where.
+ *
+ * The working directory is set explicitly because a GUI launch runs with
+ * cwd `/` (measured), and the CLI loads `<cwd>/.env` to pick up keys like
+ * `GEMINI_API_KEY`. Left alone, an icon user's `.env` could only ever be
+ * `/.env` — a path they cannot write — so the documented way to supply a
+ * key would silently do nothing for exactly the people who never open a
+ * terminal. Home is the one directory that is theirs and always exists.
+ *
+ * @param {{ port: number, home?: string }} options
+ * @returns {{ command: string, args: string[], cwd: string }}
+ */
+export function serverSpawnPlan({ port, home = homedir() }) {
+  return {
+    command: "npx",
+    args: ["mulmoclaude@latest", "--port", String(port), "--no-open"],
+    cwd: home,
+  };
+}
+
 function spawnServer({ port, logPath, env }) {
   mkdirSync(dirname(logPath), { recursive: true });
   const logFd = openSync(logPath, "a");
+  const { command, args, cwd } = serverSpawnPlan({ port });
   try {
-    const child = spawn("npx", ["mulmoclaude@latest", "--port", String(port), "--no-open"], {
+    const child = spawn(command, args, {
       env,
+      cwd,
       detached: true,
       stdio: ["ignore", logFd, logFd],
     });

--- a/server/utils/launcher/start.mjs
+++ b/server/utils/launcher/start.mjs
@@ -23,8 +23,8 @@ const DEFAULT_PORT = 3001;
 const LOG_SIZE_CAP_BYTES = 1_000_000;
 
 /** macOS keeps per-app logs here, which is also where Console.app looks. */
-export function launcherLogPath(home = homedir()) {
-  return launcherPaths({ home }).logPath;
+export function launcherLogPath(home = homedir(), platform = process.platform) {
+  return launcherPaths({ home, platform }).logPath;
 }
 
 function log(logPath, message) {

--- a/test/utils/launcher/test_start.ts
+++ b/test/utils/launcher/test_start.ts
@@ -1,0 +1,36 @@
+// Tests for the decisions in `server/utils/launcher/start.mjs` that can
+// be checked without actually launching anything.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { launcherLogPath, serverSpawnPlan } from "../../../server/utils/launcher/start.mjs";
+
+describe("serverSpawnPlan", () => {
+  it("asks npx for the latest release on the chosen port, without opening a browser", () => {
+    const { command, args } = serverSpawnPlan({ port: 3005 });
+    assert.equal(command, "npx");
+    assert.deepEqual(args, ["mulmoclaude@latest", "--port", "3005", "--no-open"]);
+  });
+
+  it("passes --no-open — the progress page does the navigating, so the CLI must not open a second tab", () => {
+    assert.ok(serverSpawnPlan({ port: 3001 }).args.includes("--no-open"));
+  });
+
+  it("runs from home, never the `/` a GUI launch inherits", () => {
+    // The CLI reads `<cwd>/.env`. With the inherited cwd that is `/.env`,
+    // which the user cannot write — the documented way to supply
+    // GEMINI_API_KEY would quietly do nothing from the icon.
+    assert.equal(serverSpawnPlan({ port: 3001, home: "/Users/example" }).cwd, "/Users/example");
+    assert.equal(serverSpawnPlan({ port: 3001 }).cwd, homedir());
+    assert.notEqual(serverSpawnPlan({ port: 3001 }).cwd, "/");
+  });
+});
+
+describe("launcherLogPath", () => {
+  it("uses the per-app location Console.app also looks at", () => {
+    assert.equal(launcherLogPath("/Users/example"), join("/Users/example", "Library", "Logs", "MulmoClaude", "launcher.log"));
+  });
+});

--- a/test/utils/launcher/test_start.ts
+++ b/test/utils/launcher/test_start.ts
@@ -37,6 +37,15 @@ describe("serverSpawnPlan", () => {
 
 describe("launcherLogPath", () => {
   it("uses the per-app location Console.app also looks at", () => {
-    assert.equal(launcherLogPath("/Users/example"), join("/Users/example", "Library", "Logs", "MulmoClaude", "launcher.log"));
+    // Platform passed explicitly: the answer is per-OS since #2623, so
+    // leaving it to the host would assert macOS behaviour on the Windows
+    // runner and fail for a reason the code is not responsible for.
+    assert.equal(launcherLogPath("/Users/example", "darwin"), join("/Users/example", "Library", "Logs", "MulmoClaude", "launcher.log"));
+  });
+
+  it("uses LOCALAPPDATA on Windows, not a Library folder that means nothing there", () => {
+    const windowsLog = launcherLogPath(String.raw`C:\Users\example`, "win32");
+    assert.match(windowsLog, /MulmoClaude/);
+    assert.doesNotMatch(windowsLog, /Library/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #2615, which merged while this was being reviewed.

**From the icon, a `.env` could never be loaded.** A GUI-launched `.app` runs with cwd `/` — measured with a probe bundle, not assumed — and the CLI reads `<cwd>/.env` to pick up keys like `GEMINI_API_KEY`. So the only `.env` the icon launch could ever have read was `/.env`, a path the user cannot write. The documented way to supply a key did nothing for exactly the people who never open a terminal.

The server is now spawned from the home directory, which makes `~/.env` the answer and is what both READMEs now say.

Also corrects both READMEs to name `npx` rather than `npm` as the prerequisite preflight actually probes — the changelog was fixed in #2615 iter-4, the READMEs were missed.

## Items to Confirm / Review

1. **Is `~/.env` the right location?** It is the only directory that is the user's and always exists, and it matches the existing rule ("`.env` sits where you launch") for a launch that has no directory. The alternative was to leave cwd at `/` and document that `.env` is simply unavailable from the icon — worse for a beginner following the README's Gemini-key instructions.

2. **A pre-existing `~/.env` will now be read** when launching from the icon. Shell-exported variables still win (`mergeLaunchEnv` does not override), so the blast radius is limited to keys the user only defined in that file.

3. The cwd is no longer implicit: `serverSpawnPlan` is extracted so the argv **and** the working directory are asserted rather than assumed.

## User Prompt

> ランチャーか。問題ないならマージ。指摘あるなら直す

自分でも差分を通しでレビューし、ボットが挙げていない問題を 1 件見つけたので直しています。

## Verification

- Probe bundle launched through LaunchServices under the GUI environment reports `pwd=[/]` — this is measured, not inferred.
- `serverSpawnPlan` unit-tested for the argv (including `--no-open`, so the CLI never opens a second tab on top of the progress page's redirect) and for the cwd never being `/`.
- Gates green: format / lint / typecheck / build, 90 launcher tests.

Found during my own read of the merged diff; no bot flagged it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix launcher server startup so GUI icon launches correctly respect `.env` from the user's home directory, and update documentation and tests to match the clarified spawn behavior and prerequisites.

Bug Fixes:
- Ensure icon-launched server processes run from the user home directory so `~/.env` is correctly loaded instead of the unwritable `/.env`.

Enhancements:
- Extract a `serverSpawnPlan` helper to centralize server spawn command, arguments, and working directory.

Documentation:
- Document that GUI launches read `~/.env` while terminal launches read `.env` from the current directory, and clarify that `npx` (not `npm`) is the prerequisite being checked in the launcher READMEs.

Tests:
- Add unit tests for `serverSpawnPlan` and `launcherLogPath` to verify spawn arguments, working directory selection, and log path resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS/Windows icon-launch guidance to clarify where environment variables are loaded (icon launches use `~/.env`) and that the server starts from the home directory.
* **Bug Fixes**
  * Fixed launcher startup to run the server with the correct working directory so `.env` discovery works reliably.
  * Prevented an extra browser tab from opening during launcher startup.
* **Tests**
  * Added coverage to ensure launcher command construction, platform-specific behavior, working directory selection, and per-app log path generation are correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->