### PR TITLE
fix(launcher): the generated .app died at module resolution (#2625)

### DIFF
--- a/server/utils/launcher/macos/create-app.mjs
+++ b/server/utils/launcher/macos/create-app.mjs
@@ -32,6 +32,7 @@ const BUNDLED_FILES = [
   "launcher/detect-server.mjs",
   "launcher/launcher-page.mjs",
   "launcher/messages.mjs",
+  "launcher/platform.mjs",
   "launcher/preflight.mjs",
   "launcher/macos/resolve-path.sh",
   "launcher/macos/message-file.sh",

--- a/server/utils/launcher/run.mjs
+++ b/server/utils/launcher/run.mjs
@@ -1,16 +1,29 @@
-// Executable entry the .app hands control to once node is reachable.
-// Kept separate from start.mjs so the logic stays importable by tests
-// without launching anything.
+// Executable entry the generated launcher hands control to once node is
+// reachable. Kept separate from start.mjs so the logic stays importable
+// by tests without launching anything.
 
 import { execFileSync } from "node:child_process";
 
-import { launcherLogPath, startLauncher } from "./start.mjs";
-
 // Absolute last resort. Everything expected has a browser page; this
 // only fires if the launcher itself broke, and even then the user gets
-// a sentence and a path instead of an icon that blinks and does nothing.
+// a sentence instead of an icon that blinks and does nothing.
 function alertNatively(title, body) {
   try {
+    if (process.platform === "win32") {
+      // No osascript here, and the stub that got us this far is already
+      // gone — PowerShell is the one dialog every install can show.
+      execFileSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          "Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($env:MC_BODY, $env:MC_TITLE)",
+        ],
+        { stdio: "ignore", env: { ...process.env, MC_TITLE: title, MC_BODY: body } },
+      );
+      return;
+    }
     execFileSync("/usr/bin/osascript", ["-e", "on run {t, m}", "-e", "display alert t message m as critical", "-e", "end run", title, body], {
       stdio: "ignore",
     });
@@ -19,10 +32,34 @@ function alertNatively(title, body) {
   }
 }
 
-try {
-  await startLauncher();
-} catch (error) {
+// A module missing from the generated launcher is not a bug the user can
+// act on except in one way, and it is the one that works: generate it
+// again. Said plainly, because the raw ERR_MODULE_NOT_FOUND names an
+// absolute path inside a bundle they never opened.
+function describeFailure(error) {
   const detail = error instanceof Error ? error.message : String(error);
-  alertNatively("MulmoClaude", `${detail}\n\n${launcherLogPath()}`);
+  if (error?.code === "ERR_MODULE_NOT_FOUND") {
+    return `This launcher is missing part of itself, so it cannot start.\n\nRe-create it:\n  npx mulmoclaude@latest create-shortcut\n\n${detail}`;
+  }
+  return detail;
+}
+
+// The import is INSIDE the try on purpose. As a static import it was
+// resolved before this body ran, so a module missing from the bundle
+// skipped the whole safety net and the icon simply blinked and vanished
+// — the exact outcome the comment above claims to prevent (#2625).
+try {
+  const { launcherLogPath, startLauncher } = await import("./start.mjs");
+  try {
+    await startLauncher();
+  } catch (error) {
+    alertNatively("MulmoClaude", `${describeFailure(error)}\n\n${launcherLogPath()}`);
+    process.exit(1);
+  }
+} catch (error) {
+  // Reached only when start.mjs itself could not be loaded, so there is
+  // no launcherLogPath() to call and no log to point at: nothing ever
+  // ran to write one.
+  alertNatively("MulmoClaude", describeFailure(error));
   process.exit(1);
 }

--- a/test/utils/launcher/test_bundleImports.ts
+++ b/test/utils/launcher/test_bundleImports.ts
@@ -13,17 +13,20 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 import { createAppBundle } from "../../../server/utils/launcher/macos/create-app.mjs";
 import { createWindowsShortcut } from "../../../server/utils/launcher/windows/create-launcher.mjs";
 
-// Matches the specifier of a static import or a top-level `await
-// import(...)`. Only relative ones matter: bare specifiers are node
-// built-ins here, and the launcher deliberately has no dependencies.
-const IMPORT_PATTERN = /(?:from\s*|import\s*\(\s*)["'](\.[^"']+)["']/g;
+// Every syntax that can pull in another file: `from "./x"` (covering
+// re-exports too), `import("./x")`, and the bare side-effect form
+// `import "./x"`. Missing that last one would make this whole check
+// quietly weaker than it claims to be — a launcher module switching to
+// it would go unnoticed again. Only relative specifiers matter: bare
+// ones are node built-ins, the launcher having no dependencies.
+const IMPORT_PATTERN = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)["'](\.[^"']+)["']/g;
 
 // `{import("./x.d.mts").Foo}` in a JSDoc type annotation is erased before
 // anything runs, and the sibling `.d.mts` files are deliberately NOT
@@ -67,6 +70,39 @@ const withTempDir = async (body: (dir: string) => Promise<void>) => {
 };
 
 const report = (missing: MissingImport[]) => missing.map(({ from, specifier }) => `${from} imports ${specifier}`).join("\n");
+
+describe("unresolvedImports — the matcher itself", () => {
+  // Written because the first version of this matcher only understood
+  // `from "..."` and `import("...")`, so a side-effect import could have
+  // hidden a missing module from the very check meant to catch it.
+  const eachSyntax: [string, string][] = [
+    ["static default", 'import thing from "./missing-a.mjs";'],
+    ["static named", 'import { thing } from "./missing-b.mjs";'],
+    ["side-effect", 'import "./missing-c.mjs";'],
+    ["dynamic", 'const mod = await import("./missing-d.mjs");'],
+    ["re-export", 'export { thing } from "./missing-e.mjs";'],
+  ];
+
+  eachSyntax.forEach(([label, source]) => {
+    it(`sees a missing module imported by ${label}`, async () => {
+      await withTempDir(async (dir) => {
+        const entry = join(dir, "entry.mjs");
+        writeFileSync(entry, `${source}\n`);
+        const missing = unresolvedImports(entry);
+        assert.equal(missing.length, 1, `${label} was not detected: ${report(missing)}`);
+      });
+    });
+  });
+
+  it("does not chase a specifier that resolves", async () => {
+    await withTempDir(async (dir) => {
+      writeFileSync(join(dir, "present.mjs"), "export const ok = true;\n");
+      const entry = join(dir, "entry.mjs");
+      writeFileSync(entry, 'import "./present.mjs";\n');
+      assert.deepEqual(unresolvedImports(entry), []);
+    });
+  });
+});
 
 describe("generated bundle import graph", () => {
   it("macOS: every module run.mjs reaches is present in the .app", async () => {

--- a/test/utils/launcher/test_bundleImports.ts
+++ b/test/utils/launcher/test_bundleImports.ts
@@ -1,0 +1,111 @@
+// Every module the generated launcher imports must actually be in it.
+//
+// `BUNDLED_FILES` is a hand-written list in each generator, and #2625 is
+// what that costs: `platform.mjs` was added to the Windows list and
+// forgotten in the macOS one, so a freshly generated `.app` died at
+// module resolution — before `run.mjs` could show its native alert, so
+// the icon just blinked and vanished with no log and no dialog.
+//
+// The existing test asserted a hard-coded list of expected paths, which
+// is the same hand-written list a second time: it agreed with the bug.
+// This walks the real import graph instead, so a module added tomorrow
+// fails here rather than on a user's machine.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import { createAppBundle } from "../../../server/utils/launcher/macos/create-app.mjs";
+import { createWindowsShortcut } from "../../../server/utils/launcher/windows/create-launcher.mjs";
+
+// Matches the specifier of a static import or a top-level `await
+// import(...)`. Only relative ones matter: bare specifiers are node
+// built-ins here, and the launcher deliberately has no dependencies.
+const IMPORT_PATTERN = /(?:from\s*|import\s*\(\s*)["'](\.[^"']+)["']/g;
+
+// `{import("./x.d.mts").Foo}` in a JSDoc type annotation is erased before
+// anything runs, and the sibling `.d.mts` files are deliberately NOT
+// bundled — they describe the modules, they are not part of them.
+const isTypeOnly = (specifier: string): boolean => /\.d\.m?ts$/.test(specifier);
+
+interface MissingImport {
+  from: string;
+  specifier: string;
+}
+
+// Walks outward from an entry module, collecting relative imports that
+// do not exist on disk. Static analysis rather than a real `import()`:
+// importing `run.mjs` would launch the thing.
+const unresolvedImports = (entry: string): MissingImport[] => {
+  const missing: MissingImport[] = [];
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.shift() as string;
+    if (seen.has(file) || !existsSync(file)) continue;
+    seen.add(file);
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(IMPORT_PATTERN)) {
+      if (isTypeOnly(match[1])) continue;
+      const target = resolve(dirname(file), match[1]);
+      if (existsSync(target)) queue.push(target);
+      else missing.push({ from: file, specifier: match[1] });
+    }
+  }
+  return missing;
+};
+
+const withTempDir = async (body: (dir: string) => Promise<void>) => {
+  const dir = mkdtempSync(join(tmpdir(), "mulmoclaude-graph-"));
+  try {
+    await body(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const report = (missing: MissingImport[]) => missing.map(({ from, specifier }) => `${from} imports ${specifier}`).join("\n");
+
+describe("generated bundle import graph", () => {
+  it("macOS: every module run.mjs reaches is present in the .app", async () => {
+    await withTempDir(async (dir) => {
+      const bundlePath = join(dir, "MulmoClaude.app");
+      await createAppBundle({ bundlePath, name: "MulmoClaude", version: "9.9.9" });
+      const entry = join(bundlePath, "Contents", "Resources", "utils", "launcher", "run.mjs");
+      assert.ok(existsSync(entry), "run.mjs is the entry the stub execs — it must be bundled");
+      const missing = unresolvedImports(entry);
+      assert.deepEqual(missing, [], `the bundle cannot resolve its own imports:\n${report(missing)}`);
+    });
+  });
+
+  it("Windows: every module run.mjs reaches is present in the install dir", async () => {
+    await withTempDir(async (dir) => {
+      const rootDir = join(dir, "launcher");
+      // The .lnk needs Windows to write it; the file tree does not, and
+      // the tree is what this asserts.
+      await createWindowsShortcut({ rootDir, shortcutPath: join(dir, "MulmoClaude.lnk") }).catch(() => undefined);
+      const entry = join(rootDir, "utils", "launcher", "run.mjs");
+      assert.ok(existsSync(entry), "run.mjs is what the .vbs stub hands node — it must be copied");
+      const missing = unresolvedImports(entry);
+      assert.deepEqual(missing, [], `the launcher cannot resolve its own imports:\n${report(missing)}`);
+    });
+  });
+
+  it("catches a module that was left out — the check itself must not be vacuous", async () => {
+    await withTempDir(async (dir) => {
+      const bundlePath = join(dir, "MulmoClaude.app");
+      await createAppBundle({ bundlePath, name: "MulmoClaude", version: "9.9.9" });
+      const launcherDir = join(bundlePath, "Contents", "Resources", "utils", "launcher");
+      // Delete exactly the file #2625 was missing and confirm it is seen.
+      rmSync(join(launcherDir, "platform.mjs"));
+      const missing = unresolvedImports(join(launcherDir, "run.mjs"));
+      assert.ok(missing.length > 0, "removing a bundled module must fail this check");
+      assert.ok(
+        missing.some(({ specifier }) => specifier.includes("platform.mjs")),
+        report(missing),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`platform.mjs` (new in #2623) was added to the **Windows** `BUNDLED_FILES` and left out of the **macOS** one, while `start.mjs` and `launcher-page.mjs` both import it. A freshly generated `.app` therefore died at module resolution: the icon bounced once and vanished, with no page, no alert and no log.

Reproduced exactly as reported, fixed, and verified against a regenerated bundle.

Fixes #2625. Reported by **michiof**, whose diagnosis was precise down to the one-line diff — this PR is that line plus the two things the report was right to say were worth fixing alongside it.

## Items to Confirm / Review

1. **The failure was invisible, and that is the more serious half.** `run.mjs` wraps the launcher in try/catch to guarantee "a sentence instead of an icon that blinks and does nothing" — its own words. But the import was static, so ESM resolved it *before* the try block, and the net was skipped entirely. The import is now inside the try. A missing module reports **"This launcher is missing part of itself"** plus the `create-shortcut` command, because re-generating is the only action a user can take and it is the one that works — a raw `ERR_MODULE_NOT_FOUND` naming a path inside a bundle they never opened is not.

2. **The alert was macOS-only.** #2623 made `run.mjs` run on Windows too, but `alertNatively` shells straight to `/usr/bin/osascript`; on Windows the last-resort dialog was silently a no-op. It now uses PowerShell's MessageBox there.

3. **The existing test agreed with the bug.** `test_createApp.ts` asserted a hard-coded list of expected paths — which is the hand-written `BUNDLED_FILES` written a second time, so it passed happily while the bundle was broken. Replaced by a check that walks the **actual import graph** of the generated artifact (both platforms), with a negative control that deletes `platform.mjs` and requires the check to fail. This is the part that stops #2625 recurring; the one-line fix on its own does not.

4. Static analysis rather than a real `import()` — importing `run.mjs` would launch the app. Type-only specifiers (`import("./x.d.mts")` inside JSDoc) are excluded: the `.d.mts` files describe the modules and are deliberately not bundled.

## User Prompt

> 2625, 2626 をみて、改善していって！！

## Verification

- Before: generating a bundle from `main` (`0b666e6cb`) and resolving it reproduces `ERR_MODULE_NOT_FOUND … platform.mjs imported from … launcher-page.mjs`.
- After: `platform.mjs` is present, and importing the bundle's `start.mjs` / `launcher-page.mjs` / `preflight.mjs` / `detect-server.mjs` resolves the whole graph.
- The new test fails when `platform.mjs` is removed from a generated bundle, so it is not vacuous.

Gates: `yarn format` / `lint` (0 errors) / `typecheck` / `build` / `test` green — 10282 tests, 0 failures.

## Not verified

The native alert itself. The macOS dialog was already manual-only (`docs/manual-testing.md` §11), and the new Windows MessageBox path is in §12 territory — no harness can assert what a modal looks like, and firing one in CI would hang the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure generated launchers include all required modules and fail with visible, actionable errors when module resolution breaks.

Bug Fixes:
- Add platform.mjs to the macOS launcher bundle so generated .app launchers no longer fail at module resolution.
- Make the launcher entry point handle module-load and runtime failures inside its safety net, surfacing clear error messages instead of silently exiting.

Enhancements:
- Add native Windows alert support for launcher failures using a PowerShell MessageBox fallback when osascript is unavailable.
- Improve launcher failure messaging to explain missing-module issues and instruct users to regenerate the launcher.

Tests:
- Replace hard-coded bundled file assertions with tests that walk the generated launcher import graph for macOS and Windows, and verify the check fails when a module like platform.mjs is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher behavior when required bundle modules are missing, with clearer guidance to recreate the launcher.
  * Added native error notifications on Windows and macOS to surface missing-module issues instead of failing silently.
  * Ensured generated macOS application bundles include all required launcher components.
* **Tests**
  * Added automated coverage to detect missing relative launcher imports across macOS and Windows bundle/install layouts, including an anti-vacuity check for omitted components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->